### PR TITLE
feat(shipping,allegro): shipment-status poll for async carrier waybills (#838)

### DIFF
--- a/apps/api/test/integration/helpers/shipment-status-sync-test-stubs.helper.ts
+++ b/apps/api/test/integration/helpers/shipment-status-sync-test-stubs.helper.ts
@@ -30,8 +30,11 @@ import {
   AdapterRegistryPort,
 } from '@openlinker/core/integrations';
 import type {
+  OrderFeedInput,
+  OrderFeedOutput,
   OrderFulfillmentUpdater,
   OrderProcessorManagerPort,
+  OrderSourcePort,
   OrderStatus,
 } from '@openlinker/core/orders';
 import type {
@@ -47,12 +50,24 @@ export const STATUS_SYNC_CARRIER_ADAPTER_KEY = 'allegro.delivery.statussync.test
 export const STATUS_SYNC_CARRIER_PLATFORM_TYPE = 'allegro';
 export const STATUS_SYNC_DEST_ADAPTER_KEY = 'prestashop.fulfillmentupdate.statussync.test.v1';
 export const STATUS_SYNC_DEST_PLATFORM_TYPE = 'prestashop';
+/**
+ * No-op source adapter — declares `OrderSource` so the seed's source
+ * connection has a valid adapterKey, but its methods reject if invoked.
+ * #838 itself never touches the source, but the routing-rule + OrderRecord
+ * machinery requires a non-null source connection on the same `platformType`
+ * as the upstream marketplace; this stub lets us seed that without polluting
+ * the carrier or destination stubs with an unrelated capability.
+ */
+export const STATUS_SYNC_SOURCE_ADAPTER_KEY = 'allegro.source.statussync.test.v1';
+export const STATUS_SYNC_SOURCE_PLATFORM_TYPE = 'allegro';
 
 export interface DestFulfillmentCall {
   externalOrderId: string;
   status: OrderStatus;
   trackingNumber?: string;
 }
+
+export type DestFulfillmentOutcome = 'ok' | { throw: Error };
 
 export interface ShipmentStatusSyncTestStubs {
   readonly carrier: {
@@ -66,8 +81,13 @@ export interface ShipmentStatusSyncTestStubs {
   readonly dest: {
     readonly adapterKey: string;
     readonly platformType: string;
-    /** Override the next `updateFulfillment` call's behaviour (resolve / reject). */
-    setNextOutcome(outcome: 'ok' | { throw: Error }): void;
+    /**
+     * Push a FIFO queue of outcomes the next `updateFulfillment` calls will
+     * realise (oldest first). When the queue is drained the stub falls back to
+     * `'ok'`. Use `enqueueOutcomes(['ok', { throw: new Error('boom') }])` to
+     * stage multi-destination orderings.
+     */
+    enqueueOutcomes(outcomes: readonly DestFulfillmentOutcome[]): void;
     readonly calls: DestFulfillmentCall[];
   };
 }
@@ -105,9 +125,9 @@ export function installShipmentStatusSyncTestStubs(
     },
   };
 
-  // Destination — capability B (records calls + supports a one-shot throw).
+  // Destination — capability B (records calls + drains a FIFO outcome queue).
   const destCalls: DestFulfillmentCall[] = [];
-  let nextDestOutcome: 'ok' | { throw: Error } = 'ok';
+  const destOutcomeQueue: DestFulfillmentOutcome[] = [];
 
   const destStub: OrderProcessorManagerPort & OrderFulfillmentUpdater = {
     createOrder(): Promise<never> {
@@ -115,12 +135,23 @@ export function installShipmentStatusSyncTestStubs(
     },
     updateFulfillment(input): Promise<void> {
       destCalls.push({ ...input });
-      const outcome = nextDestOutcome;
-      nextDestOutcome = 'ok';
+      const outcome: DestFulfillmentOutcome = destOutcomeQueue.shift() ?? 'ok';
       if (typeof outcome === 'object' && outcome !== null && 'throw' in outcome) {
         return Promise.reject(outcome.throw);
       }
       return Promise.resolve();
+    },
+  };
+
+  // Source — declares OrderSource only so the seed's source connection has a
+  // valid adapterKey. The shipment-status-sync flow never reaches it; methods
+  // reject defensively in case they ever do.
+  const sourceStub: OrderSourcePort = {
+    listOrderFeed(_input: OrderFeedInput): Promise<OrderFeedOutput> {
+      return Promise.reject(new Error('status-sync stub: listOrderFeed is not exercised'));
+    },
+    getOrder(): Promise<never> {
+      return Promise.reject(new Error('status-sync stub: getOrder is not exercised'));
     },
   };
 
@@ -140,12 +171,23 @@ export function installShipmentStatusSyncTestStubs(
     version: '0.0.0-test',
     isDefault: false,
   });
+  adapterRegistry.register({
+    adapterKey: STATUS_SYNC_SOURCE_ADAPTER_KEY,
+    platformType: STATUS_SYNC_SOURCE_PLATFORM_TYPE,
+    supportedCapabilities: ['OrderSource'],
+    displayName: 'Allegro status-sync source (integration-test stub)',
+    version: '0.0.0-test',
+    isDefault: false,
+  });
 
   factoryResolver.registerFactory(STATUS_SYNC_CARRIER_ADAPTER_KEY, {
     createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(carrierStub as unknown as T),
   });
   factoryResolver.registerFactory(STATUS_SYNC_DEST_ADAPTER_KEY, {
     createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(destStub as unknown as T),
+  });
+  factoryResolver.registerFactory(STATUS_SYNC_SOURCE_ADAPTER_KEY, {
+    createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(sourceStub as unknown as T),
   });
 
   return {
@@ -160,8 +202,8 @@ export function installShipmentStatusSyncTestStubs(
     dest: {
       adapterKey: STATUS_SYNC_DEST_ADAPTER_KEY,
       platformType: STATUS_SYNC_DEST_PLATFORM_TYPE,
-      setNextOutcome(outcome: 'ok' | { throw: Error }): void {
-        nextDestOutcome = outcome;
+      enqueueOutcomes(outcomes: readonly DestFulfillmentOutcome[]): void {
+        destOutcomeQueue.push(...outcomes);
       },
       calls: destCalls,
     },

--- a/apps/api/test/integration/helpers/shipment-status-sync-test-stubs.helper.ts
+++ b/apps/api/test/integration/helpers/shipment-status-sync-test-stubs.helper.ts
@@ -1,0 +1,169 @@
+/**
+ * Shipment Status Sync Test Stubs Helper (#838)
+ *
+ * Registers two synthetic adapters with the running Nest app's
+ * `AdapterRegistryService` + `AdapterFactoryResolverService` (the same public
+ * plugin seam real integrations use, #570 / #574):
+ *
+ *   - a **carrier** adapter implementing `ShippingProviderManagerPort` with a
+ *     `generateLabel` that returns *no* synchronous tracking number — mirroring
+ *     Allegro Delivery, where the carrier waybill arrives asynchronously after
+ *     create — and a `getTracking` whose response is **configurable per test**
+ *     (`carrier.setNextSnapshot(snap)`), so the int-spec can drive the
+ *     `null → carrierWaybill` backfill transition the service projects.
+ *   - a **destination** adapter implementing `OrderProcessorManagerPort` +
+ *     `OrderFulfillmentUpdater`, recording its `updateFulfillment` calls so the
+ *     int-spec can assert that capability B's projection fires (push-first
+ *     ordering + `>= dispatched` push-gate).
+ *
+ * Mirrors `dispatch-notify-test-stubs.helper.ts` (#837) — same registration
+ * shape, same Symbol-token resolution, distinct adapter keys so both helpers
+ * can coexist in the same suite. Lifetime: suite-scoped (`AdapterRegistryService
+ * .register` throws on a second call for the same adapterKey).
+ *
+ * @module apps/api/test/integration/helpers
+ */
+import {
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterFactoryResolverService,
+  AdapterRegistryPort,
+} from '@openlinker/core/integrations';
+import type {
+  OrderFulfillmentUpdater,
+  OrderProcessorManagerPort,
+  OrderStatus,
+} from '@openlinker/core/orders';
+import type {
+  GenerateLabelCommand,
+  GenerateLabelResult,
+  ShippingMethod,
+  ShippingProviderManagerPort,
+  TrackingSnapshot,
+} from '@openlinker/core/shipping';
+import type { IntegrationTestHarness } from '../setup';
+
+export const STATUS_SYNC_CARRIER_ADAPTER_KEY = 'allegro.delivery.statussync.test.v1';
+export const STATUS_SYNC_CARRIER_PLATFORM_TYPE = 'allegro';
+export const STATUS_SYNC_DEST_ADAPTER_KEY = 'prestashop.fulfillmentupdate.statussync.test.v1';
+export const STATUS_SYNC_DEST_PLATFORM_TYPE = 'prestashop';
+
+export interface DestFulfillmentCall {
+  externalOrderId: string;
+  status: OrderStatus;
+  trackingNumber?: string;
+}
+
+export interface ShipmentStatusSyncTestStubs {
+  readonly carrier: {
+    readonly adapterKey: string;
+    readonly platformType: string;
+    /** Set the snapshot the next `getTracking` call will resolve with. */
+    setNextSnapshot(snapshot: TrackingSnapshot): void;
+    /** Provider shipment ids handed out by `generateLabel`, in call order. */
+    readonly providerShipmentIds: string[];
+  };
+  readonly dest: {
+    readonly adapterKey: string;
+    readonly platformType: string;
+    /** Override the next `updateFulfillment` call's behaviour (resolve / reject). */
+    setNextOutcome(outcome: 'ok' | { throw: Error }): void;
+    readonly calls: DestFulfillmentCall[];
+  };
+}
+
+export function installShipmentStatusSyncTestStubs(
+  harness: IntegrationTestHarness,
+): ShipmentStatusSyncTestStubs {
+  const adapterRegistry = harness.getApp().get<AdapterRegistryPort>(ADAPTER_REGISTRY_TOKEN);
+  const factoryResolver = harness
+    .getApp()
+    .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
+
+  // Carrier — async waybill shape (Allegro Delivery).
+  let carrierCounter = 0;
+  const providerShipmentIds: string[] = [];
+  let nextSnapshot: TrackingSnapshot = { status: 'generated', providerStatus: 'pending' };
+
+  const carrierStub: ShippingProviderManagerPort = {
+    getSupportedMethods(): readonly ShippingMethod[] {
+      return ['paczkomat', 'kurier'];
+    },
+    generateLabel(cmd: GenerateLabelCommand): Promise<GenerateLabelResult> {
+      carrierCounter += 1;
+      const providerShipmentId = `delivery-stub-${carrierCounter}`;
+      providerShipmentIds.push(providerShipmentId);
+      return Promise.resolve({
+        providerShipmentId,
+        // Async-waybill shape: tracking comes on a later poll.
+        trackingNumber: null,
+        labelPdfRef: `delivery-stub:label:${cmd.shipmentId}`,
+      });
+    },
+    getTracking(): Promise<TrackingSnapshot> {
+      return Promise.resolve(nextSnapshot);
+    },
+  };
+
+  // Destination — capability B (records calls + supports a one-shot throw).
+  const destCalls: DestFulfillmentCall[] = [];
+  let nextDestOutcome: 'ok' | { throw: Error } = 'ok';
+
+  const destStub: OrderProcessorManagerPort & OrderFulfillmentUpdater = {
+    createOrder(): Promise<never> {
+      return Promise.reject(new Error('status-sync stub: createOrder is not exercised'));
+    },
+    updateFulfillment(input): Promise<void> {
+      destCalls.push({ ...input });
+      const outcome = nextDestOutcome;
+      nextDestOutcome = 'ok';
+      if (typeof outcome === 'object' && outcome !== null && 'throw' in outcome) {
+        return Promise.reject(outcome.throw);
+      }
+      return Promise.resolve();
+    },
+  };
+
+  adapterRegistry.register({
+    adapterKey: STATUS_SYNC_CARRIER_ADAPTER_KEY,
+    platformType: STATUS_SYNC_CARRIER_PLATFORM_TYPE,
+    supportedCapabilities: ['ShippingProviderManager'],
+    displayName: 'Allegro Delivery status-sync carrier (integration-test stub)',
+    version: '0.0.0-test',
+    isDefault: false,
+  });
+  adapterRegistry.register({
+    adapterKey: STATUS_SYNC_DEST_ADAPTER_KEY,
+    platformType: STATUS_SYNC_DEST_PLATFORM_TYPE,
+    supportedCapabilities: ['OrderProcessorManager'],
+    displayName: 'PrestaShop status-sync destination (integration-test stub)',
+    version: '0.0.0-test',
+    isDefault: false,
+  });
+
+  factoryResolver.registerFactory(STATUS_SYNC_CARRIER_ADAPTER_KEY, {
+    createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(carrierStub as unknown as T),
+  });
+  factoryResolver.registerFactory(STATUS_SYNC_DEST_ADAPTER_KEY, {
+    createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(destStub as unknown as T),
+  });
+
+  return {
+    carrier: {
+      adapterKey: STATUS_SYNC_CARRIER_ADAPTER_KEY,
+      platformType: STATUS_SYNC_CARRIER_PLATFORM_TYPE,
+      setNextSnapshot(snapshot: TrackingSnapshot): void {
+        nextSnapshot = snapshot;
+      },
+      providerShipmentIds,
+    },
+    dest: {
+      adapterKey: STATUS_SYNC_DEST_ADAPTER_KEY,
+      platformType: STATUS_SYNC_DEST_PLATFORM_TYPE,
+      setNextOutcome(outcome: 'ok' | { throw: Error }): void {
+        nextDestOutcome = outcome;
+      },
+      calls: destCalls,
+    },
+  };
+}

--- a/apps/api/test/integration/shipment-status-sync.int-spec.ts
+++ b/apps/api/test/integration/shipment-status-sync.int-spec.ts
@@ -51,6 +51,7 @@ import {
   ShipmentStatusSyncTestStubs,
   STATUS_SYNC_CARRIER_ADAPTER_KEY,
   STATUS_SYNC_DEST_ADAPTER_KEY,
+  STATUS_SYNC_SOURCE_ADAPTER_KEY,
   installShipmentStatusSyncTestStubs,
 } from './helpers/shipment-status-sync-test-stubs.helper';
 import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
@@ -85,7 +86,7 @@ describe('Shipment Status Sync Integration (#838)', () => {
     stubs.dest.calls.length = 0;
     stubs.carrier.providerShipmentIds.length = 0;
     stubs.carrier.setNextSnapshot({ status: 'generated', providerStatus: 'pending' });
-    stubs.dest.setNextOutcome('ok');
+    // Outcome queue drains naturally; left empty here so each test stages what it needs.
   });
 
   afterEach(async () => {
@@ -120,16 +121,14 @@ describe('Shipment Status Sync Integration (#838)', () => {
     options: { advanceToDispatched?: boolean } = {},
   ): Promise<{ carrierConnectionId: string; destConnectionId: string; shipmentId: string }> {
     const dataSource = harness.getDataSource();
+    // Source connection — distinct adapter declaring `OrderSource` only.
+    // #838 never touches it, but the routing-rule + OrderRecord seam needs a
+    // source connection on the same platformType as the upstream marketplace.
     const source = await createTestConnection(dataSource, {
       platformType: 'allegro',
       name: 'Allegro source',
-      // The source isn't exercised by #838 — but the routing-rule keying needs
-      // a source connection to scope on. Reuse the carrier stub's allegro
-      // adapter-key here just to satisfy the adapter-registry lookup; this
-      // record never has #837 stubs attached, so any source-side resolution
-      // would surface clearly as a failure.
-      adapterKey: STATUS_SYNC_CARRIER_ADAPTER_KEY,
-      enabledCapabilities: ['ShippingProviderManager'],
+      adapterKey: STATUS_SYNC_SOURCE_ADAPTER_KEY,
+      enabledCapabilities: ['OrderSource'],
     });
     const dest = await createTestConnection(dataSource, {
       platformType: 'prestashop',
@@ -241,7 +240,7 @@ describe('Shipment Status Sync Integration (#838)', () => {
       providerStatus: 'waybill-assigned',
       trackingNumber: 'WOULD-LOSE-1',
     });
-    stubs.dest.setNextOutcome({ throw: new Error('PS unreachable') });
+    stubs.dest.enqueueOutcomes([{ throw: new Error('PS unreachable') }]);
 
     const result = await statusSyncService().sync(carrierConnectionId, { limit: 10 });
 

--- a/apps/api/test/integration/shipment-status-sync.int-spec.ts
+++ b/apps/api/test/integration/shipment-status-sync.int-spec.ts
@@ -1,0 +1,285 @@
+/**
+ * Shipment Status Sync Integration Test (#838)
+ *
+ * Exercises the carrier-tracking poll end-to-end against real Postgres.
+ * `ShipmentStatusSyncService.sync`:
+ *   - reads each non-terminal `Shipment`'s carrier state via the connection's
+ *     `ShippingProviderManagerPort.getTracking` (#833 / Allegro Delivery shape:
+ *     async `carrierWaybill`),
+ *   - builds a desired-state patch (terminal status + `null → trackingNumber`
+ *     backfill),
+ *   - projects the backfilled tracking number to each destination's
+ *     `OrderFulfillmentUpdater` (capability B, #858) under two v1 workarounds
+ *     (push-first + `>= dispatched` push-gate; both dissolve under #861),
+ *   - persists the patch via the `Shipment` repository,
+ *   - returns scan stats (`scanned / updated / propagated / failed / total /
+ *     nextOffset`) for the worker handler's cursor advance.
+ *
+ * Shipments are seeded through the real #835 dispatch seam (routed to the
+ * async-waybill carrier stub returning `trackingNumber: null`), then advanced
+ * to `dispatched` via #837's `notifyDispatched` so the OMP-push gate is open.
+ * The carrier + destination capability adapters are in-memory stubs, so the
+ * full resolution chain is real while the marketplace HTTP calls are not.
+ *
+ * Covers: (a) the `null → carrierWaybill` backfill with capability-B push to the
+ * synced destination; (b) push-first ordering — if the OMP push throws, the
+ * patch drops `trackingNumber` so the next poll retries; (c) the `>= dispatched`
+ * push-gate — at `generated` the service backfills `Shipment.trackingNumber`
+ * but does NOT fire the destination OMP (deferred to #837's `notifyDispatched`).
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import {
+  IShipmentDispatchNotificationService,
+  IShipmentDispatchService,
+  IShipmentQueryService,
+  IShipmentStatusSyncService,
+  SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
+  SHIPMENT_DISPATCH_SERVICE_TOKEN,
+  SHIPMENT_QUERY_SERVICE_TOKEN,
+  SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
+} from '@openlinker/core/shipping';
+
+import { createTestOrderRecord } from './fixtures/order.fixtures';
+import { createTestConnection } from './helpers/test-connection.helper';
+import {
+  ShipmentStatusSyncTestStubs,
+  STATUS_SYNC_CARRIER_ADAPTER_KEY,
+  STATUS_SYNC_DEST_ADAPTER_KEY,
+  installShipmentStatusSyncTestStubs,
+} from './helpers/shipment-status-sync-test-stubs.helper';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+
+const DEST_EXTERNAL_ID = 'ps-order-statussync';
+const SOURCE_DELIVERY_METHOD_ID = 'allegro-courier';
+const RECIPIENT = {
+  email: 'buyer@example.com',
+  phone: '+48500600700',
+  address: {
+    street: 'Krakowska',
+    buildingNumber: '12',
+    city: 'Poznań',
+    postCode: '60-001',
+    countryCode: 'PL',
+  },
+};
+const PARCEL = { dimensions: { length: 200, width: 150, height: 100 }, weightGrams: 1200 };
+
+describe('Shipment Status Sync Integration (#838)', () => {
+  let harness: IntegrationTestHarness;
+  let stubs: ShipmentStatusSyncTestStubs;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    stubs = installShipmentStatusSyncTestStubs(harness);
+  });
+
+  beforeEach(() => {
+    // Suite-scoped stubs — clear recorded state per test (resetTestHarness only
+    // truncates the database).
+    stubs.dest.calls.length = 0;
+    stubs.carrier.providerShipmentIds.length = 0;
+    stubs.carrier.setNextSnapshot({ status: 'generated', providerStatus: 'pending' });
+    stubs.dest.setNextOutcome('ok');
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  const statusSyncService = (): IShipmentStatusSyncService =>
+    harness.getApp().get<IShipmentStatusSyncService>(SHIPMENT_STATUS_SYNC_SERVICE_TOKEN);
+  const dispatchService = (): IShipmentDispatchService =>
+    harness.getApp().get<IShipmentDispatchService>(SHIPMENT_DISPATCH_SERVICE_TOKEN);
+  const notificationService = (): IShipmentDispatchNotificationService =>
+    harness
+      .getApp()
+      .get<IShipmentDispatchNotificationService>(SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN);
+  const queryService = (): IShipmentQueryService =>
+    harness.getApp().get<IShipmentQueryService>(SHIPMENT_QUERY_SERVICE_TOKEN);
+  const routingService = (): IFulfillmentRoutingService =>
+    harness.getApp().get<IFulfillmentRoutingService>(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+
+  /**
+   * Seed the resolution graph for a status-sync test: source + dest + carrier
+   * connections, the `ol_managed_carrier` routing rule, the `OrderRecord` with
+   * a synced destination, and (optionally) a `generated`-state shipment.
+   * Returns the carrier connection id + (optional) shipment id.
+   */
+  async function seedShipment(
+    orderId: string,
+    options: { advanceToDispatched?: boolean } = {},
+  ): Promise<{ carrierConnectionId: string; destConnectionId: string; shipmentId: string }> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      // The source isn't exercised by #838 — but the routing-rule keying needs
+      // a source connection to scope on. Reuse the carrier stub's allegro
+      // adapter-key here just to satisfy the adapter-registry lookup; this
+      // record never has #837 stubs attached, so any source-side resolution
+      // would surface clearly as a failure.
+      adapterKey: STATUS_SYNC_CARRIER_ADAPTER_KEY,
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    const dest = await createTestConnection(dataSource, {
+      platformType: 'prestashop',
+      name: 'PrestaShop destination',
+      adapterKey: STATUS_SYNC_DEST_ADAPTER_KEY,
+      enabledCapabilities: ['OrderProcessorManager'],
+    });
+    const carrier = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro Delivery carrier',
+      adapterKey: STATUS_SYNC_CARRIER_ADAPTER_KEY,
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+
+    await routingService().replaceRules(source.id, [
+      {
+        sourceDeliveryMethodId: SOURCE_DELIVERY_METHOD_ID,
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: carrier.id,
+      },
+    ]);
+
+    await createTestOrderRecord(dataSource, {
+      internalOrderId: orderId,
+      sourceConnectionId: source.id,
+      syncStatus: [
+        {
+          destinationConnectionId: dest.id,
+          status: 'synced',
+          externalOrderId: DEST_EXTERNAL_ID,
+        },
+      ],
+    });
+
+    const dispatched = await dispatchService().dispatch({
+      sourceConnectionId: source.id,
+      sourceDeliveryMethodId: SOURCE_DELIVERY_METHOD_ID,
+      orderId,
+      shippingMethod: 'kurier',
+      recipient: RECIPIENT,
+      parcel: PARCEL,
+    });
+    if (dispatched.kind !== 'dispatched') {
+      throw new Error(`expected a dispatched shipment, got ${dispatched.kind}`);
+    }
+    const shipmentId = dispatched.shipment.id;
+
+    if (options.advanceToDispatched) {
+      // Drive the real #837 transition so the push-gate is open. The source
+      // OrderDispatchNotifier isn't registered for this connection — the
+      // dest is — so the source half degrades to 'absent' / 'unsupported',
+      // which doesn't block the `generated → dispatched` Shipment transition.
+      // Hop SOURCE → DEST mapping out of #837's view: we just need the
+      // Shipment row in `dispatched` so #838 fires capability B.
+      await notificationService().notifyDispatched({ shipmentId });
+      // Reset the dest stub's recorded calls — the dispatch-notify wave that
+      // just ran would otherwise count toward our #838 assertions. (The
+      // notifyDispatched call will have invoked dest.updateFulfillment once
+      // because the destination implements capability B.)
+      stubs.dest.calls.length = 0;
+    }
+
+    return { carrierConnectionId: carrier.id, destConnectionId: dest.id, shipmentId };
+  }
+
+  it('backfills a freshly-arrived carrierWaybill on a dispatched shipment and pushes shipped+tracking to the destination', async () => {
+    const { carrierConnectionId, shipmentId } = await seedShipment('ol_order_statussync_1', {
+      advanceToDispatched: true,
+    });
+
+    // Carrier reports the waybill on the next poll.
+    stubs.carrier.setNextSnapshot({
+      status: 'dispatched',
+      providerStatus: 'waybill-assigned',
+      trackingNumber: 'NEW-WAYBILL',
+    });
+
+    const result = await statusSyncService().sync(carrierConnectionId, { limit: 10 });
+
+    expect(result.scanned).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(result.propagated).toBe(1);
+    expect(result.failed).toBe(0);
+
+    // Capability B was invoked with the backfilled tracking number.
+    expect(stubs.dest.calls).toEqual([
+      {
+        externalOrderId: DEST_EXTERNAL_ID,
+        status: 'shipped',
+        trackingNumber: 'NEW-WAYBILL',
+      },
+    ]);
+
+    // Patch landed on the Shipment row.
+    const persisted = await queryService().getById(shipmentId);
+    expect(persisted?.trackingNumber).toBe('NEW-WAYBILL');
+    // Status doesn't regress; `dispatched` carrier state ≠ terminal so the
+    // service leaves the existing `dispatched` row alone.
+    expect(persisted?.status).toBe('dispatched');
+  });
+
+  it('PUSH-FIRST: drops trackingNumber from the Shipment patch when the destination OMP push throws (v1 workaround #1, #861-dissolves)', async () => {
+    const { carrierConnectionId, shipmentId } = await seedShipment('ol_order_statussync_2', {
+      advanceToDispatched: true,
+    });
+
+    stubs.carrier.setNextSnapshot({
+      status: 'dispatched',
+      providerStatus: 'waybill-assigned',
+      trackingNumber: 'WOULD-LOSE-1',
+    });
+    stubs.dest.setNextOutcome({ throw: new Error('PS unreachable') });
+
+    const result = await statusSyncService().sync(carrierConnectionId, { limit: 10 });
+
+    // The push was attempted (call recorded) but no patch persisted — `updated`
+    // and `propagated` both 0 because the single patch-field (tracking) was
+    // dropped when the push failed.
+    expect(stubs.dest.calls).toHaveLength(1);
+    expect(stubs.dest.calls[0]?.trackingNumber).toBe('WOULD-LOSE-1');
+    expect(result.updated).toBe(0);
+    expect(result.propagated).toBe(0);
+    // Per-destination push failure is logged + masked at the push layer; it
+    // doesn't count as a top-level shipment failure (see service jsdoc).
+    expect(result.failed).toBe(0);
+
+    const persisted = await queryService().getById(shipmentId);
+    expect(persisted?.trackingNumber).toBeNull();
+  });
+
+  it('PUSH-GATE: at `generated` backfills Shipment.trackingNumber but does NOT fire capability B (deferred to #837, v1 workaround #2)', async () => {
+    const { carrierConnectionId, shipmentId } = await seedShipment('ol_order_statussync_3', {
+      advanceToDispatched: false,
+    });
+
+    stubs.carrier.setNextSnapshot({
+      status: 'generated',
+      providerStatus: 'waybill-assigned',
+      trackingNumber: 'BACKFILL-ONLY',
+    });
+
+    const result = await statusSyncService().sync(carrierConnectionId, { limit: 10 });
+
+    expect(result.scanned).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(result.propagated).toBe(0);
+    expect(stubs.dest.calls).toHaveLength(0);
+
+    const persisted = await queryService().getById(shipmentId);
+    expect(persisted?.trackingNumber).toBe('BACKFILL-ONLY');
+    expect(persisted?.status).toBe('generated');
+  });
+});

--- a/apps/worker/src/sync/handlers/__tests__/marketplace-shipment-status-sync.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/marketplace-shipment-status-sync.handler.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Marketplace Shipment Status Sync Handler Tests (#838)
+ *
+ * Mirrors `marketplace-offer-status-sync.handler.spec.ts` (#816): scan-offset
+ * cursor read/parse/advance, default cursor key + limit, ok outcome, and error
+ * wrapping. Doesn't re-cover the workaround logic — that's tested on the core
+ * service.
+ *
+ * @module apps/worker/src/sync/handlers/__tests__
+ */
+import type { ConnectionCursorRepositoryPort } from '@openlinker/core/sync';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import type { SyncJobEntity as SyncJob } from '@openlinker/core/sync';
+import type { ShipmentStatusSyncResult } from '@openlinker/core/shipping';
+
+import { MarketplaceShipmentStatusSyncHandler } from '../marketplace-shipment-status-sync.handler';
+
+describe('MarketplaceShipmentStatusSyncHandler', () => {
+  let handler: MarketplaceShipmentStatusSyncHandler;
+  type ShipmentStatusSyncServiceLike = { sync: jest.Mock };
+  let shipmentStatusSync: ShipmentStatusSyncServiceLike;
+  let cursorRepository: jest.Mocked<ConnectionCursorRepositoryPort>;
+
+  const baseResult: ShipmentStatusSyncResult = {
+    scanned: 1,
+    updated: 1,
+    propagated: 0,
+    failed: 0,
+    total: 50,
+    nextOffset: 10,
+  };
+
+  beforeEach(() => {
+    shipmentStatusSync = { sync: jest.fn().mockResolvedValue(baseResult) };
+    cursorRepository = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<ConnectionCursorRepositoryPort>;
+
+    handler = new MarketplaceShipmentStatusSyncHandler(
+      shipmentStatusSync as never,
+      cursorRepository,
+    );
+  });
+
+  const createJob = (payload: Record<string, unknown>): SyncJob => ({
+    id: 'job-id',
+    jobType: 'marketplace.shipment.statusSync' as unknown as SyncJob['jobType'],
+    connectionId: 'connection-1',
+    payload,
+    idempotencyKey: 'key',
+    status: 'queued',
+    attempts: 0,
+    maxAttempts: 10,
+    nextRunAt: new Date(),
+    lockedAt: null,
+    lockedBy: null,
+    lastError: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  it('starts at offset 0 with the default cursor key when no cursor is stored', async () => {
+    const job = createJob({ schemaVersion: 1, limit: 25 });
+
+    const result = await handler.execute(job);
+
+    expect(cursorRepository.get).toHaveBeenCalledWith(
+      'connection-1',
+      'allegro.shipmentStatus.scanOffset',
+    );
+    expect(shipmentStatusSync.sync).toHaveBeenCalledWith('connection-1', {
+      limit: 25,
+      offset: 0,
+    });
+    expect(cursorRepository.set).toHaveBeenCalledWith(
+      'connection-1',
+      'allegro.shipmentStatus.scanOffset',
+      '10',
+    );
+    expect(result).toEqual({ outcome: 'ok' });
+  });
+
+  it('parses the stored numeric offset and passes it to the service', async () => {
+    const job = createJob({
+      schemaVersion: 1,
+      limit: 25,
+      cursorKey: 'allegro.shipmentStatus.scanOffset',
+    });
+    cursorRepository.get.mockResolvedValue('30');
+
+    await handler.execute(job);
+
+    expect(shipmentStatusSync.sync).toHaveBeenCalledWith('connection-1', {
+      limit: 25,
+      offset: 30,
+    });
+  });
+
+  it('honours a custom cursor key from the payload', async () => {
+    const job = createJob({ schemaVersion: 1, limit: 10, cursorKey: 'custom.cursor' });
+
+    await handler.execute(job);
+
+    expect(cursorRepository.get).toHaveBeenCalledWith('connection-1', 'custom.cursor');
+    expect(cursorRepository.set).toHaveBeenCalledWith('connection-1', 'custom.cursor', '10');
+  });
+
+  it('defaults limit to 50 when the payload limit is missing or invalid', async () => {
+    const job = createJob({ schemaVersion: 1 });
+
+    await handler.execute(job);
+
+    expect(shipmentStatusSync.sync).toHaveBeenCalledWith('connection-1', {
+      limit: 50,
+      offset: 0,
+    });
+  });
+
+  it('treats a non-numeric stored cursor as offset 0', async () => {
+    const job = createJob({ schemaVersion: 1, limit: 10 });
+    cursorRepository.get.mockResolvedValue('not-a-number');
+
+    await handler.execute(job);
+
+    expect(shipmentStatusSync.sync).toHaveBeenCalledWith('connection-1', {
+      limit: 10,
+      offset: 0,
+    });
+  });
+
+  it('throws SyncJobExecutionError when the payload is not an object', async () => {
+    const job = createJob(null as unknown as Record<string, unknown>);
+
+    await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+  });
+
+  it('wraps service failures in SyncJobExecutionError without advancing the cursor', async () => {
+    const job = createJob({ schemaVersion: 1, limit: 10 });
+    shipmentStatusSync.sync.mockRejectedValue(new Error('boom'));
+
+    await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+    expect(cursorRepository.set).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -18,6 +18,7 @@ import { MarketplaceOfferCreateHandler } from './marketplace-offer-create.handle
 import { MarketplaceOfferPollCreationStatusHandler } from './marketplace-offer-poll-creation-status.handler';
 import { MarketplaceOffersSyncHandler } from './marketplace-offers-sync.handler';
 import { MarketplaceOfferStatusSyncHandler } from './marketplace-offer-status-sync.handler';
+import { MarketplaceShipmentStatusSyncHandler } from './marketplace-shipment-status-sync.handler';
 import { MasterProductSyncHandler } from './master-product-sync.handler';
 import { MasterInventorySyncHandler } from './master-inventory-sync.handler';
 import { AutoMatchVariantsHandler } from './auto-match-variants.handler';
@@ -37,6 +38,7 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly marketplaceOfferPollCreationStatusHandler: MarketplaceOfferPollCreationStatusHandler,
     private readonly marketplaceOffersSyncHandler: MarketplaceOffersSyncHandler,
     private readonly marketplaceOfferStatusSyncHandler: MarketplaceOfferStatusSyncHandler,
+    private readonly marketplaceShipmentStatusSyncHandler: MarketplaceShipmentStatusSyncHandler,
     private readonly masterProductSyncHandler: MasterProductSyncHandler,
     private readonly masterInventorySyncHandler: MasterInventorySyncHandler,
     private readonly autoMatchVariantsHandler: AutoMatchVariantsHandler,
@@ -65,6 +67,10 @@ export class HandlerRegistrationService implements OnModuleInit {
     this.handlerRegistry.register(
       'marketplace.offer.statusSync',
       this.marketplaceOfferStatusSyncHandler
+    );
+    this.handlerRegistry.register(
+      'marketplace.shipment.statusSync',
+      this.marketplaceShipmentStatusSyncHandler
     );
 
     // Register generic master handlers (Option B)

--- a/apps/worker/src/sync/handlers/marketplace-shipment-status-sync.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-shipment-status-sync.handler.ts
@@ -33,6 +33,15 @@ import { Logger } from '@openlinker/shared/logging';
 type SyncJob = SyncJobEntity;
 
 const DEFAULT_LIMIT = 50;
+/**
+ * Carrier-specific default for the unlikely case a job lands without an explicit
+ * `cursorKey` in its payload (the Allegro scheduler task always supplies one;
+ * this default fires only for hand-enqueued jobs). Mirrors `MarketplaceOfferStatusSync
+ * Handler`'s `allegro.offerStatus.scanOffset` default — the handler is
+ * carrier-generic, but the only carrier shipping today is Allegro Delivery.
+ * When a second carrier (e.g. InPost) adopts this job, parameterize the default
+ * by reading `connection.platformType` rather than hard-coding here.
+ */
 const DEFAULT_CURSOR_KEY = 'allegro.shipmentStatus.scanOffset';
 
 @Injectable()

--- a/apps/worker/src/sync/handlers/marketplace-shipment-status-sync.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-shipment-status-sync.handler.ts
@@ -1,0 +1,110 @@
+/**
+ * Marketplace Shipment Status Sync Handler (#838)
+ *
+ * Thin delegate for jobs of type `marketplace.shipment.statusSync`. Refreshes
+ * one page of a carrier connection's non-terminal `Shipment`s via the core
+ * `ShipmentStatusSyncService` and persists the rolling scan offset on the
+ * connection cursor so the next run continues where this one stopped.
+ *
+ * Mirrors `MarketplaceOfferStatusSyncHandler` (#816) — the cursor-advance
+ * pattern is identical because both wrap a core service that returns the
+ * `nextOffset` the caller should persist.
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import type {
+  MarketplaceShipmentStatusSyncPayloadV1,
+  SyncJobHandler,
+  SyncJobHandlerResult,
+  SyncJob as SyncJobEntity,
+} from '@openlinker/core/sync';
+import {
+  CONNECTION_CURSOR_REPOSITORY_TOKEN,
+  ConnectionCursorRepositoryPort,
+  SyncJobExecutionError,
+} from '@openlinker/core/sync';
+import {
+  IShipmentStatusSyncService,
+  SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
+} from '@openlinker/core/shipping';
+import { Logger } from '@openlinker/shared/logging';
+
+type SyncJob = SyncJobEntity;
+
+const DEFAULT_LIMIT = 50;
+const DEFAULT_CURSOR_KEY = 'allegro.shipmentStatus.scanOffset';
+
+@Injectable()
+export class MarketplaceShipmentStatusSyncHandler implements SyncJobHandler {
+  private readonly logger = new Logger(MarketplaceShipmentStatusSyncHandler.name);
+
+  constructor(
+    @Inject(SHIPMENT_STATUS_SYNC_SERVICE_TOKEN)
+    private readonly shipmentStatusSync: IShipmentStatusSyncService,
+    @Inject(CONNECTION_CURSOR_REPOSITORY_TOKEN)
+    private readonly cursorRepository: ConnectionCursorRepositoryPort,
+  ) {}
+
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
+    const payload = this.getPayload(job);
+    const cursorKey = payload.cursorKey ?? DEFAULT_CURSOR_KEY;
+    const storedOffset = await this.cursorRepository.get(job.connectionId, cursorKey);
+    const offset = this.parseOffset(storedOffset);
+
+    this.logger.log(
+      `Executing marketplace.shipment.statusSync job ${job.id} for connection ${job.connectionId} (limit=${payload.limit}, offset=${offset})`,
+    );
+
+    try {
+      const result = await this.shipmentStatusSync.sync(job.connectionId, {
+        limit: payload.limit,
+        offset,
+      });
+
+      this.logger.log(
+        `marketplace.shipment.statusSync completed (connection=${job.connectionId}): scanned=${result.scanned}, updated=${result.updated}, propagated=${result.propagated}, failed=${result.failed}, nextOffset=${result.nextOffset}/${result.total}`,
+      );
+
+      await this.cursorRepository.set(job.connectionId, cursorKey, String(result.nextOffset));
+
+      return { outcome: 'ok' };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SyncJobExecutionError(
+        `Marketplace shipment status sync failed: ${message}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  private getPayload(job: SyncJob): MarketplaceShipmentStatusSyncPayloadV1 {
+    const payload = job.payload as unknown as Partial<MarketplaceShipmentStatusSyncPayloadV1>;
+    if (!payload || typeof payload !== 'object') {
+      throw new SyncJobExecutionError(
+        `Missing payload for job: ${job.id}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+    const limit =
+      typeof payload.limit === 'number' && payload.limit > 0 ? payload.limit : DEFAULT_LIMIT;
+    return {
+      schemaVersion: 1,
+      limit,
+      cursorKey: typeof payload.cursorKey === 'string' ? payload.cursorKey : undefined,
+    };
+  }
+
+  private parseOffset(stored: string | null): number {
+    if (stored === null) {
+      return 0;
+    }
+    const parsed = Number.parseInt(stored, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  }
+}

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -14,6 +14,7 @@ import { ProductsModule } from '@openlinker/core/products';
 import { InventoryModule } from '@openlinker/core/inventory';
 import { OrdersModule } from '@openlinker/core/orders';
 import { ListingsModule } from '@openlinker/core/listings/services';
+import { ShippingModule } from '@openlinker/core/shipping';
 import { WorkerContentModule } from '../content/worker-content.module';
 import { JobIntakeConsumer } from './job-intake.consumer';
 import { SyncJobRunner } from './sync-job.runner';
@@ -27,6 +28,7 @@ import { MarketplaceOfferCreateHandler } from './handlers/marketplace-offer-crea
 import { MarketplaceOfferPollCreationStatusHandler } from './handlers/marketplace-offer-poll-creation-status.handler';
 import { MarketplaceOffersSyncHandler } from './handlers/marketplace-offers-sync.handler';
 import { MarketplaceOfferStatusSyncHandler } from './handlers/marketplace-offer-status-sync.handler';
+import { MarketplaceShipmentStatusSyncHandler } from './handlers/marketplace-shipment-status-sync.handler';
 import { MasterProductSyncHandler } from './handlers/master-product-sync.handler';
 import { MasterInventorySyncHandler } from './handlers/master-inventory-sync.handler';
 import { AutoMatchVariantsHandler } from './handlers/auto-match-variants.handler';
@@ -43,6 +45,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     InventoryModule, // Import InventoryModule to access INVENTORY_SERVICE_TOKEN
     OrdersModule, // Import OrdersModule to access ORDER_SYNC_SERVICE_TOKEN
     ListingsModule, // Import ListingsModule to access OFFER_MAPPING_SYNC_SERVICE_TOKEN
+    ShippingModule, // Import ShippingModule to access SHIPMENT_STATUS_SYNC_SERVICE_TOKEN (#838)
     WorkerContentModule, // Worker-side ContentModule for #737 — exposes CONTENT_SUGGESTION_SERVICE_TOKEN
   ],
   providers: [
@@ -58,6 +61,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     MarketplaceOfferPollCreationStatusHandler,
     MarketplaceOffersSyncHandler,
     MarketplaceOfferStatusSyncHandler,
+    MarketplaceShipmentStatusSyncHandler,
     MasterProductSyncHandler,
     MasterInventorySyncHandler,
     AutoMatchVariantsHandler,

--- a/docs/plans/implementation-plan-allegro-delivery-status-poll.md
+++ b/docs/plans/implementation-plan-allegro-delivery-status-poll.md
@@ -1,0 +1,213 @@
+# Implementation Plan — #838 Allegro Delivery shipment-status poll sync (cursor-based)
+
+**Issue:** [#838](https://github.com/openlinker-project/openlinker/issues/838) (branch-3 of #732)
+**Spec:** `docs/specs/product-spec-732-allegro-delivery-shipment.md` §3.6 (poll-not-webhook), §5 AC-7
+**Branch:** `838-allegro-delivery-status-poll`
+**Layer:** CORE (shipping orchestration + a small contract widening) + Integration (Allegro scheduler task + adapter delta) + Worker (job handler). **No migration.**
+
+> Builds on the merged trio: #832 routing model, #833 Allegro Delivery shipping adapter, #837 mark-sent orchestration + capability B port, **#858 PrestaShop capability B impl** (the reason this is unblocked — `OrderFulfillmentUpdater` now actually projects status+tracking onto PS, so #838 can re-push backfilled tracking and have something happen).
+
+---
+
+## 1. Goal & scope
+
+A **cursor-based worker job** that periodically polls Allegro Delivery for shipment status + tracking, advances OL's `Shipment` state, and propagates **backfilled tracking** + status to the destination OMP via capability B (`OrderFulfillmentUpdater`).
+
+The pattern mirrors the **#816 offer-status-sync** job: persisted scan-offset cursor on `connection_cursors` (key `allegro.shipmentStatus.scanOffset`), scheduler-enqueued per-connection job, per-page enumeration of OL's own rows (here: `Shipment`s for the Allegro carrier connection).
+
+**In scope**
+- New `IShipmentStatusSyncService` (core/shipping) that scans `Shipment`s for one connection, polls each via the carrier's `ShippingProviderManagerPort.getTracking`, updates `Shipment` on change, and pushes status+tracking to the OMP via capability B (resolved per-destination from `OrderRecord.syncStatus`).
+- One contract widening on `TrackingSnapshot`: add `trackingNumber?: string` (the adapter has it; `getTracking` just doesn't expose it today — without this, no backfill is possible).
+- One small repository widening on `ShipmentFilters`: add `statuses?: readonly ShipmentStatus[]` (multi-status IN) so the scan can exclude terminal rows at the DB layer rather than in-memory.
+- Allegro Delivery adapter delta: populate `trackingNumber` from `AllegroShipmentResource` in `getTracking`. No new port methods.
+- Allegro scheduler task `allegro-shipment-status-sync` (default cron `0 */15 * * * *` — every 15 min, env-overridable).
+- Worker handler `MarketplaceShipmentStatusSyncHandler` registered as `marketplace.shipment.statusSync`.
+
+**Out of scope / deferred**
+- Branch-1 (OMP-fulfilled) status read-back — **#834**.
+- Richer in-transit / delivered transitions via `GET /order/carriers/{carrierId}/tracking` (the spec's other poll target). v1 uses the existing `GET /shipment-management/shipments/{id}` shape (which only distinguishes generated / dispatched / cancelled). When richer pickup events are needed, extend the Allegro adapter — not the core contract.
+- Durable per-target notify-state — **#861**. v1 accepts re-driving capability B per poll; the #858 adapter is idempotent on both axes (state-skip-if-in-state, tracking-skip-if-unchanged), so re-pushes are safe.
+- Webhook ingestion — none exists for Allegro `/shipment-management`.
+
+---
+
+## 2. Research findings (verified against the branch)
+
+- **The mould — #816 offer-status-sync** (`apps/worker/src/sync/handlers/marketplace-offer-status-sync.handler.ts` + `libs/core/src/listings/application/services/offer-status-sync.service.ts`). Job reads cursor → calls service.sync(connectionId, {offset, limit}) → persists `nextOffset`. Cursor on `ConnectionCursorRepositoryPort` (`connection_cursors` table). Scheduler task in `allegro-scheduler-tasks.ts` registers cron + enqueue per active connection. Handler returns `{ outcome: 'ok' }` (status-vs-outcome split, #391/#400).
+- **Allegro Delivery adapter** (`libs/integrations/allegro/src/infrastructure/adapters/allegro-delivery-shipping.adapter.ts`) already implements `ShippingProviderManagerPort` + `ShipmentCanceller`. **`getTracking({providerShipmentId})` returns `TrackingSnapshot` with the canonical `status` already mapped** from `AllegroShipmentResource` (in `allegro-shipment.mapper.ts`: waybill-present → `dispatched`, `canceledDate` → `cancelled`, else `generated`). The waybill IS available in the resource (`packages[].transportingInfo[].carrierWaybill`) — but `TrackingSnapshot` carries no `trackingNumber` field today, so the adapter can't propagate it through the existing port shape. Adding it is a small generic improvement.
+- **`ShipmentRepositoryPort.findMany(filters, pagination)`** already accepts `connectionId` + `status` + paging; the impl uses TypeORM `where`. Adding `statuses?: readonly ShipmentStatus[]` as a multi-status IN is a one-method-body edit.
+- **`Shipment` lifecycle**: `draft → generated → dispatched → in-transit → delivered/failed/cancelled`. `TerminalShipmentStatusValues = ['delivered','failed','cancelled']`. `update(id, patch)` accepts `status`, `trackingNumber`, `dispatchedAt`, `deliveredAt`, etc.
+- **Capability B** (`OrderFulfillmentUpdater.updateFulfillment({externalOrderId, status, trackingNumber?})`) is what #837's `ShipmentDispatchNotificationService.updateDestinations` calls per-destination. **That service is NOT reusable for #838** — its at-most-once gate (`if (shipment.status !== 'generated') return skipped-not-generated`, line 96) blocks any later push. #838 invokes capability B directly via the same `getCapabilityAdapter('OrderProcessorManager')` + `isOrderFulfillmentUpdater` pattern.
+- **`ConnectionCursorRepositoryPort`** (`libs/core/src/sync/`) — `get/set` keyed on `(connectionId, cursorKey)`. Backed by `connection_cursors`. **No migration** — reusing the existing table.
+- **Status-vs-outcome (#391/#400)**: handler returns `{outcome:'ok'}` for clean polls; `'business_failure'` is not needed (per-item snapshot misses + OMP pushes are surfaced via per-call logging, not the outcome axis — same shape as offer-status-sync).
+- **Spec §3.6**: explicitly maps onto the "offer-status sync (#816)" pattern. AC-7 covers `/shipments` page surfacing — already addressed by #846/#770; no FE work in #838.
+
+---
+
+## 3. Design
+
+### 3.1 Contract widenings (small, generic, reusable)
+
+**`TrackingSnapshot`** — add the optional tracking number:
+```ts
+// libs/core/src/shipping/domain/types/tracking-snapshot.types.ts
+export interface TrackingSnapshot {
+  status: ShipmentStatus;
+  dispatchedAt?: Date;
+  deliveredAt?: Date;
+  trackingNumber?: string;        // NEW — carriers that have it return it here
+  providerStatus?: string;
+}
+```
+**Why generic, not Allegro-specific:** InPost already has tracking sync at create; #772 (InPost polling fallback) will populate this same field. So it's a base-port concern, not adapter-internal.
+
+**`ShipmentFilters`** — add multi-status IN:
+```ts
+// libs/core/src/shipping/domain/types/shipment-query.types.ts
+export interface ShipmentFilters {
+  // … existing
+  /** Combined with AND; takes precedence over `status` when both are set. */
+  statuses?: readonly ShipmentStatus[];
+}
+```
+Repo impl: `In([...filters.statuses])` when present.
+
+### 3.2 `ShipmentStatusSyncService` (core/shipping)
+```
+sync(connectionId, { offset, limit }): { scanned, updated, propagated, notFound, total, nextOffset }
+  shipments = shipmentRepo.findMany(
+    { connectionId, statuses: ['generated','dispatched','in-transit'] },  // exclude terminal
+    { offset, limit }
+  )
+
+  for shipment in shipments.items:                                         // per-item try/catch
+    if !shipment.providerShipmentId: continue                              // not yet generated by carrier
+    carrierAdapter = integrations.getCapabilityAdapter<ShippingProviderManagerPort>(shipment.connectionId, 'ShippingProviderManager')
+    snapshot = carrierAdapter.getTracking({ providerShipmentId: shipment.providerShipmentId })
+
+    // 0. Compute the *desired* patch from the snapshot (status, dates, trackingNumber).
+    patch = diff(shipment, snapshot)
+
+    // 1. OMP propagation gate — see §3.4 for the two v1 workarounds (→ #861 dissolves both).
+    //    (a) Push only when there's a NEW tracking number (was null, now set) and
+    //    (b) Shipment is already at `dispatched` or richer — so we don't fire 'shipped'
+    //        on the OMP before #837's notifyDispatched has had its turn.
+    let trackingForPatch = patch.trackingNumber
+    if (patch.trackingNumber !== undefined
+        AND shipment.trackingNumber == null
+        AND shipment.status IN ['dispatched','in-transit']):
+      record = orderRecords.getOrderRecord(shipment.orderId)
+      for entry in record.syncStatus where entry.externalOrderId:
+        adapter = integrations.getCapabilityAdapter<OrderProcessorManagerPort>(entry.destinationConnectionId, 'OrderProcessorManager')
+        if (isOrderFulfillmentUpdater(adapter)):
+          try:
+            adapter.updateFulfillment({ externalOrderId: entry.externalOrderId, status: 'shipped', trackingNumber: patch.trackingNumber })
+          catch e:
+            log.warn(per-destination push failed); trackingForPatch = undefined  // ← push-first: drop tracking from patch on push failure → next poll retries
+    // status/dates always persist; trackingNumber persists iff the push succeeded
+    // (or wasn't gated this round).
+    finalPatch = { ...patch, trackingNumber: trackingForPatch }
+    if finalPatch is non-empty:
+      shipmentRepo.update(shipment.id, finalPatch)
+
+  return stats (caller advances cursor)
+```
+
+- **Status mapping (Allegro-side semantics):** the adapter's mapper currently returns `'dispatched'` whenever a carrier waybill exists. This is empirically *close enough* for branch-3 because by the time #838 sees the shipment its OL status is already `dispatched` (from the #835 dispatch + #837 notify flow); the *new* fact #838 discovers is the **trackingNumber**, not the status. Status genuinely transitions only on `cancelled`. Richer in-transit/delivered events come from `GET /order/carriers/{carrierId}/tracking` — explicitly **deferred** to a follow-up adapter pass.
+- **Per-item isolation:** wrap each shipment's processing in `try/catch` so one carrier-side error doesn't tank the page; mirror #816's loop (tolerate per-item errors, log, continue, count). The handler re-throws only on unrecoverable infrastructure failures (so the cursor doesn't advance and the next scheduled run retries from the same offset).
+- **No identifier-mapping call** from this service — `externalOrderId` is resolved from `OrderRecord.syncStatus` (the same pattern as `ShipmentDispatchNotificationService`).
+
+### 3.3 Allegro Delivery adapter delta
+In `getTracking`, populate `trackingNumber` from `AllegroShipmentResource.packages[].transportingInfo[].carrierWaybill` (already available; the `mapShipmentStateToStatus` helper reads from the same field). Single-line semantic addition; no new methods, no Allegro plumbing.
+
+### 3.4 v1 workarounds — both dissolve when #861 lands
+
+The two locally-correct gates in §3.2 are symptoms of one missing core architecture: **per-destination notify-state** (a persisted "OL projected version X of status+tracking onto destination Y at T"). Without it, two services (#837, #838) push to the same OMP without coordination *and* without a durable convergence record. With it, both gates dissolve into a reconciler that's the single owner of capability-B calls and re-drives until notify-state matches `Shipment`.
+
+| Workaround | Why v1 needs it | What replaces it under #861 |
+|---|---|---|
+| **Push-first, then update `Shipment.trackingNumber`** — drop trackingNumber from the patch if the OMP call throws, so the next poll sees the diff and retries. | Without notify-state, the only thing distinguishing "already projected" from "not yet projected" is the Shipment row itself. A naïve "update then push" loses the backfill on transient OMP failures. | Update `Shipment` unconditionally; the reconciler reads notify-state vs Shipment and retries until they match. Shipment becomes carrier truth (always current); notify-state becomes projection truth. |
+| **Dispatched-status gate on OMP push** — fire `updateFulfillment(status:'shipped')` only when `Shipment.status >= dispatched`. | Two projectors (#837, #838) can't coordinate timing without a shared record. Without the gate, #838 could fire 'shipped' on the OMP before #837 has its turn — premature email, wrong ordering with the source notify. | Single reconciler owns all capability-B calls; #837 and #838 become *inputs that update `Shipment`*. Ordering is correct by construction (the reconciler fires when `Shipment` changes vs notify-state). |
+
+Both workarounds are **architecturally non-damaging** (local to this service, no schema implications, removable in one PR) — but tag them in the code with `// v1 workaround — removed when #861 lands` so a future reader knows they're staging, not the target shape.
+
+### 3.5 Worker handler — mirrors `MarketplaceOfferStatusSyncHandler`
+```ts
+@Injectable()
+export class MarketplaceShipmentStatusSyncHandler implements SyncJobHandler {
+  constructor(
+    @Inject(SHIPMENT_STATUS_SYNC_SERVICE_TOKEN) private readonly service: IShipmentStatusSyncService,
+    @Inject(CONNECTION_CURSOR_REPOSITORY_TOKEN) private readonly cursors: ConnectionCursorRepositoryPort,
+  ) {}
+
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
+    const cursorKey = job.payload?.cursorKey ?? 'allegro.shipmentStatus.scanOffset';
+    const offset = parseOffset(await this.cursors.get(job.connectionId, cursorKey));
+    const result = await this.service.sync(job.connectionId, { offset, limit: BATCH_SIZE });
+    await this.cursors.set(job.connectionId, cursorKey, String(result.nextOffset));
+    return { outcome: 'ok' };
+  }
+}
+```
+Registered as `marketplace.shipment.statusSync` in `handler-registration.service.ts`.
+
+### 3.6 Scheduler task (Allegro)
+In `buildAllegroSchedulerTasks` add a parallel task `'allegro-shipment-status-sync'` with default cron `'0 */15 * * * *'` (every 15 min — tracking is faster-moving than offers; env override `OL_ALLEGRO_SHIPMENT_STATUS_SYNC_INTERVAL_CRON`). Enqueues `marketplace.shipment.statusSync` per active **Allegro connection that declares `ShippingProviderManager`** (i.e., the Allegro Delivery carrier connection, not the order-source connection).
+
+### 3.7 Files
+```
+libs/core/src/shipping/
+  domain/types/tracking-snapshot.types.ts             (+ trackingNumber? on TrackingSnapshot)
+  domain/types/shipment-query.types.ts                (+ statuses?: readonly ShipmentStatus[] on ShipmentFilters)
+  infrastructure/persistence/repositories/shipment.repository.ts  (apply statuses IN filter)
+  application/interfaces/shipment-status-sync.service.interface.ts   NEW
+  application/services/shipment-status-sync.service.ts (+ .spec.ts)  NEW
+  application/types/shipment-status-sync.types.ts                    NEW
+  shipping.tokens.ts                                  (+ SHIPMENT_STATUS_SYNC_SERVICE_TOKEN)
+  shipping.module.ts                                  (+ wire service + token; import OrdersModule, IntegrationsModule already there)
+  index.ts                                            (+ export interface + result types)
+
+libs/integrations/allegro/src/
+  infrastructure/adapters/allegro-delivery-shipping.adapter.ts       (populate trackingNumber in getTracking)
+  infrastructure/mappers/allegro-shipment.mapper.ts                  (expose carrierWaybill via a small helper or extend snapshot construction)
+  infrastructure/adapters/__tests__/allegro-delivery-shipping.adapter.spec.ts  (+ trackingNumber case)
+  infrastructure/scheduler/allegro-scheduler-tasks.ts                (+ 'allegro-shipment-status-sync' task + ENV var)
+
+apps/worker/src/
+  sync/handlers/marketplace-shipment-status-sync.handler.ts (+ .spec.ts)   NEW
+  sync/sync-worker.module.ts                                (+ register handler)
+  sync/handler-registration.service.ts                      (+ register 'marketplace.shipment.statusSync')
+
+apps/api/test/integration/
+  shipment-status-sync.int-spec.ts                                   NEW (cursor advance + Shipment update + capability-B push, stub adapters)
+```
+**Migration: none.**
+
+---
+
+## 4. Step-by-step
+
+1. **Contract widenings** — `TrackingSnapshot.trackingNumber?`, `ShipmentFilters.statuses?` + repo impl. *AC:* existing specs stay green; the trackingNumber field is recognised by callers that ignore it (additive).
+2. **`ShipmentStatusSyncService`** — interface + impl + types + token + module wiring. Diff-based update logic, OMP push only on new-tracking or advanced-status. *AC:* unit spec covers happy + no-change + new-tracking-triggers-push + capability-B-unsupported + per-shipment isolation (one bad apple doesn't tank the page).
+3. **Allegro Delivery adapter delta** — populate `trackingNumber` in `getTracking`. Tiny mapper update. *AC:* adapter spec asserts the snapshot carries the waybill.
+4. **Allegro scheduler task** — register `allegro-shipment-status-sync` with default cron + env override + per-connection enqueue gated on `ShippingProviderManager` capability. *AC:* scheduler spec / int-spec sees the job enqueue.
+5. **Worker handler** — `MarketplaceShipmentStatusSyncHandler` + register in `sync-worker.module.ts` + `handler-registration.service.ts` for `marketplace.shipment.statusSync`. *AC:* handler spec mirrors `MarketplaceOfferStatusSyncHandler` (cursor read → service.sync → cursor write → `outcome:'ok'`).
+6. **Integration spec** — `shipment-status-sync.int-spec.ts` mirroring the offer-status-sync int-spec: seed an Allegro carrier connection + an OL `Shipment` (via the #835 dispatch seam routed to an in-memory carrier stub that returns a tracking number on `getTracking` only the *second* call — so the first scan sees null, the second backfills), a destination connection with the stub `OrderFulfillmentUpdater`, and an `OrderRecord` with a synced destination. Run the worker handler twice and assert: cursor advance, `Shipment.trackingNumber` updated, `OrderFulfillmentUpdater.updateFulfillment` called once (only on the poll that newly discovers tracking — idempotent re-push isn't observable).
+7. **Quality gate** — `pnpm lint && type-check && test`; `pnpm test:integration` (no manifest/routing change, but #833-lesson suite-wide green). `migration:show` (none).
+
+---
+
+## 5. Validation
+- **Architecture:** core ↔ integration boundary holds (the carrier adapter is resolved via `IIntegrationsService.getCapabilityAdapter`; capability B is invoked the same way). Status mapping stays in the carrier adapter (Allegro-WS knowledge), the projection mechanic stays in `OrderFulfillmentUpdater` (PS-WS knowledge), the orchestration sits in core. The two contract widenings are generic + additive (other carriers benefit too).
+- **Idempotency / safety:** `Shipment.update` is patch-based; OMP push is gated to "newly-relevant change" to avoid noisy re-drives; PS adapter is itself idempotent (skip-in-state / skip-tracking-unchanged) so any over-firing is benign. Cursor advances after `service.sync` returns successfully (#838 inherits #816's cursor-after-success pattern).
+- **No migration; no manifest change.** Sub-capability check: `OrderFulfillmentUpdater` is the existing sub-capability — invoked exactly as #837 does. `ShippingProviderManager.getTracking` is the base port (required), so adapter capability discovery is unchanged.
+- **CI:** the new int-spec is module-free (mirrors `#858`'s approach — Allegro adapter is stubbed, no PS container needed for the orchestration assertions). Worker int-spec gap (#786) is unrelated; this PR doesn't depend on it.
+
+---
+
+## 6. Open design notes — to surface at the ⏸️ pause
+
+- **Waybill-presence ≠ true dispatched.** The Allegro adapter's `mapShipmentStateToStatus` returns `'dispatched'` from waybill presence alone — which today is fine because #837 has already set OL `Shipment.status='dispatched'` by then. v1 #838 explicitly does **not** rely on the snapshot's status for the OL→OMP "this just shipped" decision; it only consumes the trackingNumber and any `cancelled` transition. Richer status from `GET /order/carriers/{carrierId}/tracking` is a deferred adapter pass.
+- **`status: 'shipped'` is hardcoded in the OMP push** — same as #837. Pushing `'delivered'` (or `'cancelled'`) onto capability B would land in PS via `mapStatusToPrestashopStateId` (`delivered → 5`, `cancelled → 6`), but it's outside #838's primary scope (tracking backfill). Wire it through if the snapshot reaches those statuses; skip otherwise. v1 leans conservative — push `'shipped'` only.
+- **Scan cadence:** default `0 */15 * * * *` (every 15 min). Allegro Delivery waybills typically appear within minutes of label creation; hourly (offer-status-sync's cadence) would feel laggy for buyer-visible tracking. Env-overridable.
+- **Per-target idempotency:** v1 leans on the PS adapter's idempotency (#858) plus a "new-tracking-only" push gate in this service. Long-term (#861), the durable per-destination notify-state would replace this gate entirely — the service would consult it before calling B, not re-derive from snapshot diffs. Designed-out scope of #838.

--- a/libs/core/src/shipping/application/interfaces/shipment-status-sync.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/shipment-status-sync.service.interface.ts
@@ -1,0 +1,23 @@
+/**
+ * Shipment Status Sync Service Interface
+ *
+ * Read seam for the cursor-based shipment-status poll (#838). Polls each
+ * non-terminal `Shipment` for one shipping-provider connection, advances the
+ * `Shipment` row to reflect carrier reality, and propagates backfilled
+ * tracking + status to the destination OMP via capability B
+ * (`OrderFulfillmentUpdater`). Mirrors `IOfferStatusSyncService` (#816) so
+ * the worker handler that drives it follows the same cursor-advance pattern.
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+import type {
+  ShipmentStatusSyncOptions,
+  ShipmentStatusSyncResult,
+} from '../types/shipment-status-sync.types';
+
+export interface IShipmentStatusSyncService {
+  sync(
+    connectionId: string,
+    options: ShipmentStatusSyncOptions,
+  ): Promise<ShipmentStatusSyncResult>;
+}

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
@@ -1,0 +1,326 @@
+/**
+ * ShipmentStatusSyncService — unit tests (#838)
+ *
+ * Covers the two v1 workarounds explicitly: push-first ordering (failed OMP
+ * push drops `trackingNumber` from the patch) and the `>= dispatched` push
+ * gate (generated shipments backfill `Shipment.trackingNumber` but don't fire
+ * the destination OMP).
+ *
+ * @module libs/core/src/shipping/application/services
+ */
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import type { IOrderRecordService, OrderRecord } from '@openlinker/core/orders';
+
+import { Shipment } from '../../domain/entities/shipment.entity';
+import type { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import type { TrackingSnapshot } from '../../domain/types/tracking-snapshot.types';
+import { ShipmentStatusSyncService } from './shipment-status-sync.service';
+
+const CARRIER = 'conn-allegro-delivery';
+const PS1 = 'conn-ps-1';
+const PS2 = 'conn-ps-2';
+
+function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
+  // `?? 'prov-abc'` would mask an explicit `null` (the null-providerId test
+  // case needs to set this exact value). Use `'key' in overrides` instead.
+  return new Shipment(
+    overrides.id ?? 'ol_shipment_1',
+    overrides.orderId ?? 'ol_order_1',
+    overrides.connectionId ?? CARRIER,
+    overrides.shippingMethod ?? 'paczkomat',
+    overrides.status ?? 'dispatched',
+    'providerShipmentId' in overrides ? overrides.providerShipmentId! : 'prov-abc',
+    overrides.paczkomatId ?? null,
+    overrides.trackingNumber ?? null,
+    overrides.labelPdfRef ?? null,
+    overrides.dispatchedAt ?? new Date('2026-05-27T10:00:00.000Z'),
+    overrides.deliveredAt ?? null,
+    overrides.cancelledAt ?? null,
+    overrides.failedAt ?? null,
+    overrides.errorMessage ?? null,
+    overrides.createdAt ?? new Date('2026-05-27T09:00:00.000Z'),
+    overrides.updatedAt ?? new Date('2026-05-27T10:00:00.000Z'),
+    overrides.sourceDeliveryMethodId ?? null,
+  );
+}
+
+function makeRecord(overrides: Partial<OrderRecord> = {}): OrderRecord {
+  return {
+    syncStatus: [
+      { destinationConnectionId: PS1, status: 'synced', externalOrderId: 'ps1-100' },
+    ],
+    ...overrides,
+  } as OrderRecord;
+}
+
+function snapshot(overrides: Partial<TrackingSnapshot> = {}): TrackingSnapshot {
+  return {
+    status: 'dispatched',
+    ...overrides,
+  };
+}
+
+describe('ShipmentStatusSyncService', () => {
+  let shipments: jest.Mocked<ShipmentRepositoryPort>;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let orderRecords: jest.Mocked<IOrderRecordService>;
+  let getTracking: jest.Mock;
+  let updateFulfillment: jest.Mock;
+  let service: ShipmentStatusSyncService;
+
+  beforeEach(() => {
+    shipments = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findById: jest.fn(),
+      findByOrderId: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findByProviderShipmentId: jest.fn(),
+      update: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<ShipmentRepositoryPort>;
+
+    orderRecords = {
+      persistOrder: jest.fn(),
+      updateSyncStatus: jest.fn(),
+      persistIncomingSnapshot: jest.fn(),
+      getOrderRecord: jest.fn().mockResolvedValue(makeRecord()),
+    } as unknown as jest.Mocked<IOrderRecordService>;
+
+    getTracking = jest.fn();
+    updateFulfillment = jest.fn().mockResolvedValue(undefined);
+
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+      resolveAdapterMetadata: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    (integrations.getCapabilityAdapter as jest.Mock).mockImplementation(
+      (_connId: string, cap: string) => {
+        if (cap === 'ShippingProviderManager') {
+          return Promise.resolve({ getTracking });
+        }
+        // OrderProcessorManager — return an adapter that implements
+        // OrderFulfillmentUpdater (the `updateFulfillment` presence is what
+        // `isOrderFulfillmentUpdater` checks).
+        return Promise.resolve({ createOrder: jest.fn(), updateFulfillment });
+      },
+    );
+
+    service = new ShipmentStatusSyncService(shipments, integrations, orderRecords);
+  });
+
+  describe('page mechanics', () => {
+    it('returns zero counters and wraps to 0 when the page is empty', async () => {
+      shipments.findMany.mockResolvedValue({ items: [], total: 0 });
+      const result = await service.sync(CARRIER, { limit: 50 });
+      expect(result).toEqual({
+        scanned: 0,
+        updated: 0,
+        propagated: 0,
+        failed: 0,
+        total: 0,
+        nextOffset: 0,
+      });
+      expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('keeps the offset stationary when the page is empty mid-scan (so the cursor can advance externally)', async () => {
+      // Empty page is a degenerate read; consumed = offset + 0 = offset. The
+      // caller's cursor advancer sees the same offset on the next tick — that's
+      // expected for the OfferStatusSync precedent too.
+      shipments.findMany.mockResolvedValue({ items: [], total: 100 });
+      const result = await service.sync(CARRIER, { offset: 50, limit: 50 });
+      expect(result.nextOffset).toBe(50);
+    });
+
+    it('wraps nextOffset to 0 when the scan reaches total', async () => {
+      const s = makeShipment({ trackingNumber: '6800000001', status: 'dispatched' });
+      getTracking.mockResolvedValue(snapshot({ status: 'delivered', trackingNumber: '6800000001', deliveredAt: new Date('2026-05-28') }));
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      const result = await service.sync(CARRIER, { offset: 0, limit: 50 });
+      expect(result.nextOffset).toBe(0);
+      expect(result.scanned).toBe(1);
+    });
+
+    it('skips shipments without a providerShipmentId without calling the carrier', async () => {
+      const s = makeShipment({ providerShipmentId: null });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      const result = await service.sync(CARRIER, { limit: 50 });
+      expect(getTracking).not.toHaveBeenCalled();
+      expect(shipments.update).not.toHaveBeenCalled();
+      expect(result.failed).toBe(0);
+    });
+
+    it('counts a failure when getTracking throws but continues the page', async () => {
+      const failing = makeShipment({ id: 'ol_shipment_a' });
+      const succeeding = makeShipment({ id: 'ol_shipment_b' });
+      shipments.findMany.mockResolvedValue({ items: [failing, succeeding], total: 2 });
+      getTracking
+        .mockRejectedValueOnce(new Error('carrier 500'))
+        .mockResolvedValueOnce(snapshot({ status: 'delivered', deliveredAt: new Date('2026-05-28') }));
+      const result = await service.sync(CARRIER, { limit: 50 });
+      expect(result).toMatchObject({ scanned: 2, failed: 1, updated: 1 });
+    });
+  });
+
+  describe('status transitions', () => {
+    it('advances into a terminal state (delivered) with deliveredAt set', async () => {
+      const s = makeShipment({ trackingNumber: '6800000001' });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      const deliveredAt = new Date('2026-05-28T12:00:00.000Z');
+      getTracking.mockResolvedValue(snapshot({ status: 'delivered', deliveredAt }));
+      await service.sync(CARRIER, { limit: 50 });
+      expect(shipments.update).toHaveBeenCalledWith(
+        s.id,
+        expect.objectContaining({ status: 'delivered', deliveredAt }),
+      );
+    });
+
+    it('advances into terminal cancelled with cancelledAt populated', async () => {
+      const s = makeShipment({ trackingNumber: '6800000001' });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      getTracking.mockResolvedValue(snapshot({ status: 'cancelled' }));
+      await service.sync(CARRIER, { limit: 50 });
+      const patch = shipments.update.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(patch.status).toBe('cancelled');
+      expect(patch.cancelledAt).toBeInstanceOf(Date);
+    });
+
+    it('does NOT advance generated → dispatched (left to #837 notifyDispatched)', async () => {
+      const s = makeShipment({ status: 'generated', trackingNumber: '6800000001' });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      getTracking.mockResolvedValue(snapshot({ status: 'dispatched' }));
+      await service.sync(CARRIER, { limit: 50 });
+      expect(shipments.update).not.toHaveBeenCalled();
+    });
+
+    it('does NOT advance dispatched → in-transit (non-terminal forward)', async () => {
+      const s = makeShipment({ status: 'dispatched', trackingNumber: '6800000001' });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      getTracking.mockResolvedValue(snapshot({ status: 'in-transit' }));
+      await service.sync(CARRIER, { limit: 50 });
+      expect(shipments.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tracking-number backfill', () => {
+    it('backfills tracking on generated shipment WITHOUT pushing to the destination OMP (workaround #2)', async () => {
+      const s = makeShipment({ status: 'generated', trackingNumber: null });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      getTracking.mockResolvedValue(snapshot({ status: 'generated', trackingNumber: 'NEW123' }));
+      const result = await service.sync(CARRIER, { limit: 50 });
+      expect(shipments.update).toHaveBeenCalledWith(
+        s.id,
+        expect.objectContaining({ trackingNumber: 'NEW123' }),
+      );
+      expect(updateFulfillment).not.toHaveBeenCalled();
+      expect(result.propagated).toBe(0);
+      expect(result.updated).toBe(1);
+    });
+
+    it('backfills tracking on dispatched shipment AND pushes shipped+tracking to every destination', async () => {
+      orderRecords.getOrderRecord.mockResolvedValue(
+        makeRecord({
+          syncStatus: [
+            { destinationConnectionId: PS1, status: 'synced', externalOrderId: 'ps1-100' },
+            { destinationConnectionId: PS2, status: 'synced', externalOrderId: 'ps2-200' },
+          ],
+        } as Partial<OrderRecord>),
+      );
+      const s = makeShipment({ status: 'dispatched', trackingNumber: null });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      getTracking.mockResolvedValue(snapshot({ status: 'dispatched', trackingNumber: 'NEW456' }));
+      const result = await service.sync(CARRIER, { limit: 50 });
+      expect(updateFulfillment).toHaveBeenCalledTimes(2);
+      expect(updateFulfillment).toHaveBeenCalledWith({
+        externalOrderId: 'ps1-100',
+        status: 'shipped',
+        trackingNumber: 'NEW456',
+      });
+      expect(updateFulfillment).toHaveBeenCalledWith({
+        externalOrderId: 'ps2-200',
+        status: 'shipped',
+        trackingNumber: 'NEW456',
+      });
+      expect(shipments.update).toHaveBeenCalledWith(
+        s.id,
+        expect.objectContaining({ trackingNumber: 'NEW456' }),
+      );
+      expect(result.propagated).toBe(1);
+    });
+
+    it('PUSH-FIRST: drops trackingNumber from the patch when ANY destination push throws (workaround #1)', async () => {
+      orderRecords.getOrderRecord.mockResolvedValue(
+        makeRecord({
+          syncStatus: [
+            { destinationConnectionId: PS1, status: 'synced', externalOrderId: 'ps1-100' },
+            { destinationConnectionId: PS2, status: 'synced', externalOrderId: 'ps2-200' },
+          ],
+        } as Partial<OrderRecord>),
+      );
+      // First push succeeds, second throws.
+      updateFulfillment
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('500 from PS2'));
+      const s = makeShipment({ status: 'dispatched', trackingNumber: null });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      getTracking.mockResolvedValue(snapshot({ status: 'dispatched', trackingNumber: 'NEW456' }));
+      const result = await service.sync(CARRIER, { limit: 50 });
+      // Push attempted on both, only second threw.
+      expect(updateFulfillment).toHaveBeenCalledTimes(2);
+      // No update call — patch was empty because the single field (tracking) was dropped.
+      expect(shipments.update).not.toHaveBeenCalled();
+      expect(result.propagated).toBe(0);
+      expect(result.updated).toBe(0);
+      // Per-item error was caught at the destination layer, not the outer try, so it's not "failed".
+      expect(result.failed).toBe(0);
+    });
+
+    it('pushes nothing when no destinations have an externalOrderId yet — still backfills tracking', async () => {
+      orderRecords.getOrderRecord.mockResolvedValue(
+        makeRecord({ syncStatus: [{ destinationConnectionId: PS1, status: 'pending' }] } as Partial<OrderRecord>),
+      );
+      const s = makeShipment({ status: 'dispatched', trackingNumber: null });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      getTracking.mockResolvedValue(snapshot({ status: 'dispatched', trackingNumber: 'NEW456' }));
+      const result = await service.sync(CARRIER, { limit: 50 });
+      expect(updateFulfillment).not.toHaveBeenCalled();
+      expect(shipments.update).toHaveBeenCalledWith(
+        s.id,
+        expect.objectContaining({ trackingNumber: 'NEW456' }),
+      );
+      expect(result.propagated).toBe(1); // vacuously: all-zero destinations all-ok
+    });
+
+    it('skips a destination that does not implement OrderFulfillmentUpdater (no failure)', async () => {
+      (integrations.getCapabilityAdapter as jest.Mock).mockImplementation(
+        (_connId: string, cap: string) => {
+          if (cap === 'ShippingProviderManager') return Promise.resolve({ getTracking });
+          // OrderProcessorManager that LACKS updateFulfillment.
+          return Promise.resolve({ createOrder: jest.fn() });
+        },
+      );
+      const s = makeShipment({ status: 'dispatched', trackingNumber: null });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      getTracking.mockResolvedValue(snapshot({ status: 'dispatched', trackingNumber: 'NEW456' }));
+      const result = await service.sync(CARRIER, { limit: 50 });
+      // Push not invoked, but the shipment is patched (treated as vacuously OK).
+      expect(shipments.update).toHaveBeenCalledWith(
+        s.id,
+        expect.objectContaining({ trackingNumber: 'NEW456' }),
+      );
+      expect(result.failed).toBe(0);
+    });
+
+    it('does not overwrite a previously-set tracking number', async () => {
+      const s = makeShipment({ status: 'dispatched', trackingNumber: 'EXISTING' });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      getTracking.mockResolvedValue(snapshot({ status: 'dispatched', trackingNumber: 'WOULD_OVERWRITE' }));
+      await service.sync(CARRIER, { limit: 50 });
+      expect(updateFulfillment).not.toHaveBeenCalled();
+      expect(shipments.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
@@ -21,15 +21,15 @@ const PS1 = 'conn-ps-1';
 const PS2 = 'conn-ps-2';
 
 function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
-  // `?? 'prov-abc'` would mask an explicit `null` (the null-providerId test
-  // case needs to set this exact value). Use `'key' in overrides` instead.
+  // `?? 'prov-abc'` would mask an explicit `null`, but `=== undefined` keeps
+  // null pass-through clean without a non-null assertion.
   return new Shipment(
     overrides.id ?? 'ol_shipment_1',
     overrides.orderId ?? 'ol_order_1',
     overrides.connectionId ?? CARRIER,
     overrides.shippingMethod ?? 'paczkomat',
     overrides.status ?? 'dispatched',
-    'providerShipmentId' in overrides ? overrides.providerShipmentId! : 'prov-abc',
+    overrides.providerShipmentId === undefined ? 'prov-abc' : overrides.providerShipmentId,
     overrides.paczkomatId ?? null,
     overrides.trackingNumber ?? null,
     overrides.labelPdfRef ?? null,

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.ts
@@ -35,7 +35,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
 import {
-  IIntegrationsService,
+  type IIntegrationsService,
   INTEGRATIONS_SERVICE_TOKEN,
 } from '@openlinker/core/integrations';
 import {
@@ -117,7 +117,7 @@ export class ShipmentStatusSyncService implements IShipmentStatusSyncService {
     let propagated = 0;
     let failed = 0;
 
-    let carrierAdapter: (ShippingProviderManagerPort & object) | null = null;
+    let carrierAdapter: ShippingProviderManagerPort | null = null;
 
     for (const shipment of page.items) {
       if (!shipment.providerShipmentId) {
@@ -270,9 +270,17 @@ export class ShipmentStatusSyncService implements IShipmentStatusSyncService {
           trackingNumber,
         });
       } catch (error) {
+        // Push-first workaround means we deliberately don't propagate this up
+        // to the worker — the poll job stays `succeeded` and the next tick
+        // retries the diff. Without that propagation, this log line is the
+        // only observable signal of an OMP outage, so log at `error` level
+        // (with stack) for triage visibility. Under #861, per-destination
+        // notify-state becomes the durable failure record and we can drop
+        // back to `warn` cadence here.
         allOk = false;
-        this.logger.warn(
+        this.logger.error(
           `OMP push failed for shipment ${shipment.id} dest ${entry.destinationConnectionId}: ${this.message(error)}`,
+          error instanceof Error ? error.stack : undefined,
         );
       }
     }

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.ts
@@ -1,0 +1,285 @@
+/**
+ * Shipment Status Sync Service
+ *
+ * Cursor-based poll over OL's own `Shipment`s for one shipping-provider
+ * connection (#838). For each non-terminal shipment it (1) reads the carrier's
+ * `TrackingSnapshot` via `ShippingProviderManagerPort.getTracking`, (2) builds
+ * a patch reflecting carrier reality (status into terminal states +
+ * trackingNumber backfill), and (3) propagates a newly-arrived tracking number
+ * to the destination OMP via capability B (`OrderFulfillmentUpdater`) — same
+ * resolution path `ShipmentDispatchNotificationService.updateDestinations`
+ * uses, but without that service's `'generated'`-status gate (which exists for
+ * #837's first-push semantics and isn't reusable here).
+ *
+ * Mirrors `OfferStatusSyncService` (#816): the service returns scan stats; the
+ * caller (worker handler) advances the persisted `connection_cursors` offset.
+ *
+ * Two locally-correct v1 workarounds (both dissolve under #861, see the
+ * implementation-plan §3.4):
+ *
+ * - **Push-first ordering** — if the OMP push throws for *any* destination,
+ *   `trackingNumber` is dropped from the patch so the next poll sees the diff
+ *   and retries. Without notify-state, `Shipment.trackingNumber` itself is the
+ *   only thing distinguishing "already projected" from "not yet projected";
+ *   updating it before a failed push would lose the backfill until manual
+ *   intervention.
+ * - **Dispatched-gate on the OMP push** — `updateFulfillment(status:'shipped')`
+ *   fires only when `Shipment.status` is `dispatched`-or-richer, so #838 never
+ *   marks a PS order shipped before #837's `notifyDispatched` has had its
+ *   turn. For `generated` shipments we still backfill `Shipment.trackingNumber`
+ *   so the next #837 invocation reads it and pushes once, correctly ordered.
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IShipmentStatusSyncService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+} from '@openlinker/core/integrations';
+import {
+  type IOrderRecordService,
+  type OrderProcessorManagerPort,
+  isOrderFulfillmentUpdater,
+  ORDER_RECORD_SERVICE_TOKEN,
+} from '@openlinker/core/orders';
+
+import type { IShipmentStatusSyncService } from '../interfaces/shipment-status-sync.service.interface';
+import type {
+  ShipmentStatusSyncOptions,
+  ShipmentStatusSyncResult,
+} from '../types/shipment-status-sync.types';
+import type { Shipment } from '../../domain/entities/shipment.entity';
+import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+import type { TrackingSnapshot } from '../../domain/types/tracking-snapshot.types';
+import type {
+  ShipmentStatus} from '../../domain/types/shipment-status.types';
+import {
+  SHIPMENT_STATUS,
+  TerminalShipmentStatusValues,
+} from '../../domain/types/shipment-status.types';
+import type { UpdateShipmentInput } from '../../domain/types/shipment.types';
+import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+
+const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
+const ORDER_PROCESSOR_MANAGER_CAPABILITY = 'OrderProcessorManager';
+
+/**
+ * Statuses the scan visits — non-terminal, in the order the lifecycle
+ * progresses. Excludes `draft` (no provider id yet) and the three terminals
+ * (no further changes expected).
+ */
+const SCAN_STATUSES: readonly ShipmentStatus[] = [
+  SHIPMENT_STATUS.Generated,
+  SHIPMENT_STATUS.Dispatched,
+  SHIPMENT_STATUS.InTransit,
+];
+
+/**
+ * Statuses from which the OMP push is allowed (#838 workaround #2). At
+ * `generated` we still backfill `Shipment.trackingNumber` but defer the OMP
+ * push to #837's `notifyDispatched` so the source + dest are notified once,
+ * in order.
+ */
+const PUSH_GATE_OPEN_FROM: readonly ShipmentStatus[] = [
+  SHIPMENT_STATUS.Dispatched,
+  SHIPMENT_STATUS.InTransit,
+];
+
+@Injectable()
+export class ShipmentStatusSyncService implements IShipmentStatusSyncService {
+  private readonly logger = new Logger(ShipmentStatusSyncService.name);
+
+  constructor(
+    @Inject(SHIPMENT_REPOSITORY_TOKEN)
+    private readonly shipments: ShipmentRepositoryPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecords: IOrderRecordService,
+  ) {}
+
+  async sync(
+    connectionId: string,
+    options: ShipmentStatusSyncOptions,
+  ): Promise<ShipmentStatusSyncResult> {
+    const offset = options.offset ?? 0;
+    const { limit } = options;
+
+    const page = await this.shipments.findMany(
+      { connectionId, statuses: SCAN_STATUSES },
+      { offset, limit },
+    );
+
+    let updated = 0;
+    let propagated = 0;
+    let failed = 0;
+
+    let carrierAdapter: (ShippingProviderManagerPort & object) | null = null;
+
+    for (const shipment of page.items) {
+      if (!shipment.providerShipmentId) {
+        // Edge case: a generated shipment without a provider id is a dispatch
+        // hole upstream; nothing to poll. Don't touch.
+        continue;
+      }
+      try {
+        if (!carrierAdapter) {
+          carrierAdapter = await this.integrations.getCapabilityAdapter<ShippingProviderManagerPort>(
+            connectionId,
+            SHIPPING_PROVIDER_MANAGER_CAPABILITY,
+          );
+        }
+        const snapshot = await carrierAdapter.getTracking({
+          providerShipmentId: shipment.providerShipmentId,
+        });
+
+        const { didPush, patch } = await this.buildPatchAndMaybePush(shipment, snapshot);
+
+        if (Object.keys(patch).length > 0) {
+          await this.shipments.update(shipment.id, patch);
+          updated += 1;
+        }
+        if (didPush) {
+          propagated += 1;
+        }
+      } catch (error) {
+        failed += 1;
+        this.logger.warn(
+          `Shipment-status sync failed for shipment ${shipment.id} (connection ${connectionId}): ${this.message(error)}`,
+        );
+      }
+    }
+
+    const consumed = offset + page.items.length;
+    const nextOffset = consumed >= page.total ? 0 : consumed;
+
+    return {
+      scanned: page.items.length,
+      updated,
+      propagated,
+      failed,
+      total: page.total,
+      nextOffset,
+    };
+  }
+
+  /**
+   * Diff the snapshot against the shipment, attempt the OMP push under the
+   * dispatched-gate (workaround #2), and return the patch. On push failure
+   * (any destination), `trackingNumber` is excluded from the patch so the
+   * next poll retries (workaround #1).
+   */
+  private async buildPatchAndMaybePush(
+    shipment: Shipment,
+    snapshot: TrackingSnapshot,
+  ): Promise<{ didPush: boolean; patch: UpdateShipmentInput }> {
+    const patch: UpdateShipmentInput = {};
+
+    // 1. Status — advance only into TERMINAL states. Forward transitions out
+    //    of `generated → dispatched` are #837's job (it pairs source + dest
+    //    notify with the transition); #838 must not race that pairing.
+    if (
+      snapshot.status !== shipment.status &&
+      TerminalShipmentStatusValues.includes(
+        snapshot.status as (typeof TerminalShipmentStatusValues)[number],
+      )
+    ) {
+      patch.status = snapshot.status;
+      if (snapshot.status === SHIPMENT_STATUS.Delivered && snapshot.deliveredAt) {
+        patch.deliveredAt = snapshot.deliveredAt;
+      }
+      if (snapshot.status === SHIPMENT_STATUS.Cancelled) {
+        patch.cancelledAt = new Date();
+      }
+      if (snapshot.status === SHIPMENT_STATUS.Failed) {
+        patch.failedAt = new Date();
+      }
+    }
+
+    // 2. Tracking number — backfill on null → value transition. Carriers that
+    //    deliver waybills asynchronously (Allegro Delivery #833) populate this
+    //    on a later poll.
+    const newTrackingNumber =
+      shipment.trackingNumber === null && typeof snapshot.trackingNumber === 'string'
+        ? snapshot.trackingNumber
+        : null;
+
+    if (newTrackingNumber === null) {
+      return { didPush: false, patch };
+    }
+
+    // 3. OMP push under the dispatched-gate (v1 workaround #2 — removed when
+    //    #861 lands). For `generated` shipments we still backfill the data
+    //    field on `Shipment` so #837's `notifyDispatched` reads it; we just
+    //    don't fire `updateFulfillment` ourselves.
+    if (!PUSH_GATE_OPEN_FROM.includes(shipment.status)) {
+      patch.trackingNumber = newTrackingNumber;
+      return { didPush: false, patch };
+    }
+
+    const allDestPushOk = await this.pushTrackingToOmps(shipment, newTrackingNumber);
+
+    // 4. Push-first (v1 workaround #1 — removed when #861 lands). Include
+    //    trackingNumber in the patch iff the push succeeded everywhere; on
+    //    failure, drop it so the next poll sees the diff and retries.
+    if (allDestPushOk) {
+      patch.trackingNumber = newTrackingNumber;
+    }
+
+    return { didPush: allDestPushOk, patch };
+  }
+
+  /**
+   * Push `{status:'shipped', trackingNumber}` to each synced destination's
+   * `OrderFulfillmentUpdater`. Returns `true` iff every eligible destination
+   * accepted the call (i.e., not unsupported and not throwing). Mirrors the
+   * resolution path in `ShipmentDispatchNotificationService.updateDestinations`.
+   */
+  private async pushTrackingToOmps(
+    shipment: Shipment,
+    trackingNumber: string,
+  ): Promise<boolean> {
+    const record = await this.orderRecords.getOrderRecord(shipment.orderId);
+    const targets = (record?.syncStatus ?? []).filter(
+      (s): s is typeof s & { externalOrderId: string } => Boolean(s.externalOrderId),
+    );
+    if (targets.length === 0) {
+      // No destination to push to — vacuously "all-ok"; trackingNumber lands
+      // on the Shipment without a downstream call.
+      return true;
+    }
+
+    let allOk = true;
+    for (const entry of targets) {
+      try {
+        const adapter = await this.integrations.getCapabilityAdapter<OrderProcessorManagerPort>(
+          entry.destinationConnectionId,
+          ORDER_PROCESSOR_MANAGER_CAPABILITY,
+        );
+        if (!isOrderFulfillmentUpdater(adapter)) {
+          // Destination doesn't implement capability B (yet). Same semantic
+          // as #837: skip, don't count as a failure — there's nothing to retry.
+          continue;
+        }
+        await adapter.updateFulfillment({
+          externalOrderId: entry.externalOrderId,
+          status: 'shipped',
+          trackingNumber,
+        });
+      } catch (error) {
+        allOk = false;
+        this.logger.warn(
+          `OMP push failed for shipment ${shipment.id} dest ${entry.destinationConnectionId}: ${this.message(error)}`,
+        );
+      }
+    }
+    return allOk;
+  }
+
+  private message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/libs/core/src/shipping/application/types/shipment-status-sync.types.ts
+++ b/libs/core/src/shipping/application/types/shipment-status-sync.types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shipment Status Sync Types
+ *
+ * Input/result contract for `IShipmentStatusSyncService.sync` (#838). Mirrors
+ * the offer-status-sync shape (#816) so the worker handler that drives it can
+ * follow the same cursor-advance pattern.
+ *
+ * @module libs/core/src/shipping/application/types
+ */
+
+export interface ShipmentStatusSyncOptions {
+  /** Persisted scan offset (default 0). */
+  offset?: number;
+  /** Page size. */
+  limit: number;
+}
+
+export interface ShipmentStatusSyncResult {
+  /** Number of shipments visited this run (== page items). */
+  scanned: number;
+  /** Number of shipments whose row was patched (status/dates/trackingNumber). */
+  updated: number;
+  /** Number of shipments where the OMP push (capability B) fired this run. */
+  propagated: number;
+  /**
+   * Number of shipments where per-item processing failed (carrier read, OMP
+   * push partial failure) — counted, logged, loop continues. Surfaces in the
+   * worker's job audit; not the same as a thrown error which stops the run.
+   */
+  failed: number;
+  /** Total rows matching the scan filter (for cursor wrap). */
+  total: number;
+  /** Caller's next cursor value (wraps to 0 when reaching `total`). */
+  nextOffset: number;
+}

--- a/libs/core/src/shipping/domain/types/shipment-query.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment-query.types.ts
@@ -18,6 +18,13 @@ export interface ShipmentFilters {
   /** Internal order id (`ol_order_*`). */
   orderId?: string;
   status?: ShipmentStatus;
+  /**
+   * Multi-status IN filter (#838). Takes precedence over `status` when both
+   * are set. Lets the status-sync scan exclude terminal rows at the DB layer
+   * (e.g. `['generated','dispatched','in-transit']`) — keep the explicit set,
+   * not "non-terminal", so a future status addition is a deliberate edit.
+   */
+  statuses?: readonly ShipmentStatus[];
   /** Shipping-provider connection id (UUID). */
   connectionId?: string;
   shippingMethod?: ShippingMethod;

--- a/libs/core/src/shipping/domain/types/tracking-snapshot.types.ts
+++ b/libs/core/src/shipping/domain/types/tracking-snapshot.types.ts
@@ -24,6 +24,15 @@ export interface TrackingSnapshot {
   dispatchedAt?: Date;
   /** Time the parcel was delivered, if known. */
   deliveredAt?: Date;
+  /**
+   * Carrier waybill / tracking number when the snapshot carries one (#838).
+   * Carriers that issue tracking asynchronously (Allegro Delivery: after the
+   * `/shipment-management` create-command completes) populate this on a later
+   * poll; carriers that issue it synchronously at `generateLabel` (InPost) may
+   * leave it `undefined` here — the status-sync service is the consumer that
+   * backfills `Shipment.trackingNumber` when a new value appears.
+   */
+  trackingNumber?: string;
   /** Provider-native status code, for diagnostics. Not used by core
    * branching logic. */
   providerStatus?: string;

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -118,3 +118,12 @@ export type {
   ShipmentDispatchNotificationInput,
   ShipmentDispatchNotificationResult,
 } from './application/types/shipment-dispatch-notification.types';
+
+// Application — shipment-status-sync seam (#838). Interface + result types only; the
+// service is injected via SHIPMENT_STATUS_SYNC_SERVICE_TOKEN. The cursor-based
+// worker handler drives it the same way OfferStatusSync (#816) drives its service.
+export type { IShipmentStatusSyncService } from './application/interfaces/shipment-status-sync.service.interface';
+export type {
+  ShipmentStatusSyncOptions,
+  ShipmentStatusSyncResult,
+} from './application/types/shipment-status-sync.types';

--- a/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts
+++ b/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts
@@ -135,7 +135,13 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
   private buildWhere(filters: ShipmentFilters): FindOptionsWhere<ShipmentOrmEntity> {
     const where: FindOptionsWhere<ShipmentOrmEntity> = {};
     if (filters.orderId !== undefined) where.orderId = filters.orderId;
-    if (filters.status !== undefined) where.status = filters.status;
+    // `statuses` (multi-status IN) takes precedence over `status` when both
+    // are set (#838 — see ShipmentFilters jsdoc).
+    if (filters.statuses !== undefined && filters.statuses.length > 0) {
+      where.status = In([...filters.statuses]);
+    } else if (filters.status !== undefined) {
+      where.status = filters.status;
+    }
     if (filters.connectionId !== undefined) where.connectionId = filters.connectionId;
     if (filters.shippingMethod !== undefined) where.shippingMethod = filters.shippingMethod;
     if (filters.hasTracking !== undefined) {

--- a/libs/core/src/shipping/shipping.module.ts
+++ b/libs/core/src/shipping/shipping.module.ts
@@ -35,6 +35,7 @@ import { ShipmentQueryService } from './application/services/shipment-query.serv
 import { ShipmentCancellationService } from './application/services/shipment-cancellation.service';
 import { PickupPointLookupService } from './application/services/pickup-point-lookup.service';
 import { ShipmentDispatchNotificationService } from './application/services/shipment-dispatch-notification.service';
+import { ShipmentStatusSyncService } from './application/services/shipment-status-sync.service';
 import {
   PICKUP_POINT_CACHE_TOKEN,
   PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
@@ -43,6 +44,7 @@ import {
   SHIPMENT_DISPATCH_SERVICE_TOKEN,
   SHIPMENT_QUERY_SERVICE_TOKEN,
   SHIPMENT_REPOSITORY_TOKEN,
+  SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
 } from './shipping.tokens';
 
 @Module({
@@ -96,6 +98,11 @@ import {
       provide: SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
       useExisting: ShipmentDispatchNotificationService,
     },
+    ShipmentStatusSyncService,
+    {
+      provide: SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
+      useExisting: ShipmentStatusSyncService,
+    },
   ],
   exports: [
     SHIPMENT_REPOSITORY_TOKEN,
@@ -105,6 +112,7 @@ import {
     PICKUP_POINT_CACHE_TOKEN,
     PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
     SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
+    SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
   ],
 })
 export class ShippingModule {}

--- a/libs/core/src/shipping/shipping.tokens.ts
+++ b/libs/core/src/shipping/shipping.tokens.ts
@@ -19,3 +19,4 @@ export const PICKUP_POINT_LOOKUP_SERVICE_TOKEN = Symbol('IPickupPointLookupServi
 export const SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN = Symbol(
   'IShipmentDispatchNotificationService',
 );
+export const SHIPMENT_STATUS_SYNC_SERVICE_TOKEN = Symbol('IShipmentStatusSyncService');

--- a/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
@@ -204,3 +204,30 @@ export interface MarketplaceOfferStatusSyncPayloadV1 {
    */
   cursorKey?: string;
 }
+
+/**
+ * Payload v1 — Marketplace Shipment Status Sync (#838)
+ *
+ * Cursor-paced refresh of non-terminal `Shipment` rows for one carrier
+ * (`ShippingProviderManager`) connection. The handler reads each shipment's
+ * current carrier state via the connection's `getTracking` and projects
+ * terminal status + carrier-waybill backfill onto OL's `Shipment` row,
+ * propagating any newly-arrived tracking number to the destination OMP via
+ * capability B (`OrderFulfillmentUpdater`).
+ *
+ * Mirrors `MarketplaceOfferStatusSyncPayloadV1` (#816): there's no carrier
+ * cursor, so the work-list is OL's own `Shipment` rows paged by a rolling
+ * scan offset persisted on `connection_cursors` (default
+ * `allegro.shipmentStatus.scanOffset`).
+ */
+export interface MarketplaceShipmentStatusSyncPayloadV1 {
+  schemaVersion: 1;
+  /** Page size: number of non-terminal shipments to refresh per run. */
+  limit: number;
+  /**
+   * Connection-cursor key under which the rolling numeric scan offset is
+   * persisted. Omitted → the handler falls back to
+   * `allegro.shipmentStatus.scanOffset`.
+   */
+  cursorKey?: string;
+}

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -23,6 +23,7 @@ export const JobTypeValues = [
   'marketplace.offer.create',
   'marketplace.offer.pollCreationStatus',
   'marketplace.offer.statusSync',
+  'marketplace.shipment.statusSync',
   'master.product.syncByExternalId',
   'master.product.syncAll',
   'master.inventory.syncByExternalId',

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -68,6 +68,7 @@ export {
   MarketplaceOfferCreatePayloadV2,
   MarketplaceOfferPollCreationStatusPayloadV1,
   MarketplaceOfferStatusSyncPayloadV1,
+  MarketplaceShipmentStatusSyncPayloadV1,
   OfferDescriptionTone,
 } from './domain/types/marketplace-job-payloads.types';
 export { OfferDescriptionToneValues } from './domain/types/marketplace-job-payloads.types';

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-delivery-shipping.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-delivery-shipping.adapter.spec.ts
@@ -190,7 +190,25 @@ describe('AllegroDeliveryShippingAdapter', () => {
       await expect(adapter.getTracking({ providerShipmentId: 'allegro-ship-1' })).resolves.toEqual({
         status: 'dispatched',
         providerStatus: 'waybill-assigned',
+        trackingNumber: '6800000001',
       });
+    });
+
+    it('populates trackingNumber from transportingInfo.carrierWaybill (#838)', async () => {
+      http.get.mockResolvedValue(
+        ok<AllegroShipmentResource>({
+          id: 'allegro-ship-2',
+          packages: [{ transportingInfo: [{ carrierId: 'INPOST', carrierWaybill: 'NEW-WAYBILL' }] }],
+        }),
+      );
+      const snapshot = await adapter.getTracking({ providerShipmentId: 'allegro-ship-2' });
+      expect(snapshot.trackingNumber).toBe('NEW-WAYBILL');
+    });
+
+    it('leaves trackingNumber undefined when no carrier waybill has been assigned yet', async () => {
+      http.get.mockResolvedValue(ok<AllegroShipmentResource>({ id: 'allegro-ship-3', packages: [{}] }));
+      const snapshot = await adapter.getTracking({ providerShipmentId: 'allegro-ship-3' });
+      expect(snapshot.trackingNumber).toBeUndefined();
     });
 
     it('maps a canceled shipment to cancelled', async () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-delivery-shipping.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-delivery-shipping.adapter.ts
@@ -47,6 +47,7 @@ import {
   buildCreateShipmentInput,
   deriveCommandId,
   describeShipmentState,
+  extractCarrierWaybill,
   formatCommandErrors,
   mapShipmentStateToStatus,
   toGenerateLabelResult,
@@ -122,9 +123,13 @@ export class AllegroDeliveryShippingAdapter
       `${SHIPMENTS_PATH}/${input.providerShipmentId}`,
     );
     const resource = response.data;
+    // Carrier waybill arrives asynchronously after `generateLabel` returns
+    // (#838); leaving `trackingNumber` undefined here is normal until the
+    // first poll that finds one in `transportingInfo[].carrierWaybill`.
     return {
       status: mapShipmentStateToStatus(resource),
       providerStatus: describeShipmentState(resource),
+      trackingNumber: extractCarrierWaybill(resource),
     };
   }
 

--- a/libs/integrations/allegro/src/infrastructure/mappers/__tests__/allegro-shipment.mapper.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/mappers/__tests__/allegro-shipment.mapper.spec.ts
@@ -11,6 +11,7 @@ import {
   buildCreateShipmentInput,
   deriveCommandId,
   describeShipmentState,
+  extractCarrierWaybill,
   formatCommandErrors,
   mapShipmentStateToStatus,
   toGenerateLabelResult,
@@ -145,6 +146,41 @@ describe('mapShipmentStateToStatus', () => {
     const resource: AllegroShipmentResource = { id: 's1', packages: [{}] };
     expect(mapShipmentStateToStatus(resource)).toBe('generated');
     expect(describeShipmentState(resource)).toBe('created');
+  });
+});
+
+describe('extractCarrierWaybill', () => {
+  it('returns undefined when there are no packages', () => {
+    expect(extractCarrierWaybill({ id: 's1' })).toBeUndefined();
+  });
+
+  it('returns undefined when no transportingInfo carries a waybill', () => {
+    const resource: AllegroShipmentResource = {
+      id: 's1',
+      packages: [{ transportingInfo: [{ carrierId: 'INPOST' }] }],
+    };
+    expect(extractCarrierWaybill(resource)).toBeUndefined();
+  });
+
+  it('returns the first non-empty carrierWaybill in document order', () => {
+    const resource: AllegroShipmentResource = {
+      id: 's1',
+      packages: [
+        { transportingInfo: [{ carrierId: 'INPOST', carrierWaybill: '6800000001' }] },
+        { transportingInfo: [{ carrierId: 'INPOST', carrierWaybill: '6800000002' }] },
+      ],
+    };
+    expect(extractCarrierWaybill(resource)).toBe('6800000001');
+  });
+
+  it('skips empty-string waybills and returns the next non-empty value', () => {
+    const resource: AllegroShipmentResource = {
+      id: 's1',
+      packages: [
+        { transportingInfo: [{ carrierWaybill: '' }, { carrierWaybill: '6800000003' }] },
+      ],
+    };
+    expect(extractCarrierWaybill(resource)).toBe('6800000003');
   });
 });
 

--- a/libs/integrations/allegro/src/infrastructure/mappers/allegro-shipment.mapper.ts
+++ b/libs/integrations/allegro/src/infrastructure/mappers/allegro-shipment.mapper.ts
@@ -144,9 +144,30 @@ export function toGenerateLabelResult(shipmentId: string): GenerateLabelResult {
 }
 
 function hasCarrierWaybill(resource: AllegroShipmentResource): boolean {
-  return (resource.packages ?? []).some((pkg) =>
-    (pkg.transportingInfo ?? []).some((t) => Boolean(t.carrierWaybill)),
-  );
+  return extractCarrierWaybill(resource) !== undefined;
+}
+
+/**
+ * Pick the first non-empty `transportingInfo[].carrierWaybill` across packages,
+ * in document order — Allegro doesn't promise multi-package determinism, but
+ * iterating in array order is stable across polls of the same shipment and
+ * matches `hasCarrierWaybill`'s scan. Falls back to `undefined` when none is
+ * assigned yet.
+ *
+ * Consumed by `getTracking` (#838) to populate
+ * `TrackingSnapshot.trackingNumber`, which the core status-sync service
+ * backfills onto `Shipment.trackingNumber` and projects to the destination
+ * OMP.
+ */
+export function extractCarrierWaybill(resource: AllegroShipmentResource): string | undefined {
+  for (const pkg of resource.packages ?? []) {
+    for (const t of pkg.transportingInfo ?? []) {
+      if (t.carrierWaybill && t.carrierWaybill.length > 0) {
+        return t.carrierWaybill;
+      }
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/libs/integrations/allegro/src/infrastructure/scheduler/__tests__/allegro-scheduler-tasks.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/scheduler/__tests__/allegro-scheduler-tasks.spec.ts
@@ -35,12 +35,13 @@ const makeConnection = (overrides: Partial<{ config: Record<string, unknown> }> 
 
 describe('buildAllegroSchedulerTasks', () => {
   describe('enable gates', () => {
-    it('should return all three tasks by default (env-vars unset)', () => {
+    it('should return all four tasks by default (env-vars unset)', () => {
       const tasks = buildAllegroSchedulerTasks(makeConfig());
       expect(tasks.map((t) => t.taskId)).toEqual([
         'allegro-orders-poll',
         'allegro-offers-sync',
         'allegro-offer-status-sync',
+        'allegro-shipment-status-sync',
       ]);
     });
 
@@ -51,6 +52,7 @@ describe('buildAllegroSchedulerTasks', () => {
       expect(tasks.map((t) => t.taskId)).toEqual([
         'allegro-offers-sync',
         'allegro-offer-status-sync',
+        'allegro-shipment-status-sync',
       ]);
     });
 
@@ -61,6 +63,7 @@ describe('buildAllegroSchedulerTasks', () => {
       expect(tasks.map((t) => t.taskId)).toEqual([
         'allegro-orders-poll',
         'allegro-offer-status-sync',
+        'allegro-shipment-status-sync',
       ]);
     });
 
@@ -68,7 +71,22 @@ describe('buildAllegroSchedulerTasks', () => {
       const tasks = buildAllegroSchedulerTasks(
         makeConfig({ OL_ALLEGRO_OFFER_STATUS_SYNC_SCHEDULER_ENABLED: 'false' })
       );
-      expect(tasks.map((t) => t.taskId)).toEqual(['allegro-orders-poll', 'allegro-offers-sync']);
+      expect(tasks.map((t) => t.taskId)).toEqual([
+        'allegro-orders-poll',
+        'allegro-offers-sync',
+        'allegro-shipment-status-sync',
+      ]);
+    });
+
+    it('should omit shipment-status-sync when OL_ALLEGRO_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED=false', () => {
+      const tasks = buildAllegroSchedulerTasks(
+        makeConfig({ OL_ALLEGRO_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED: 'false' })
+      );
+      expect(tasks.map((t) => t.taskId)).toEqual([
+        'allegro-orders-poll',
+        'allegro-offers-sync',
+        'allegro-offer-status-sync',
+      ]);
     });
 
     it('should return an empty array when all env-vars are false', () => {
@@ -77,6 +95,7 @@ describe('buildAllegroSchedulerTasks', () => {
           OL_ALLEGRO_POLL_SCHEDULER_ENABLED: 'false',
           OL_ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED: 'false',
           OL_ALLEGRO_OFFER_STATUS_SYNC_SCHEDULER_ENABLED: 'false',
+          OL_ALLEGRO_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED: 'false',
         })
       );
       expect(tasks).toEqual([]);
@@ -224,6 +243,50 @@ describe('buildAllegroSchedulerTasks', () => {
       const statusSync = tasks.find((t) => t.taskId === 'allegro-offer-status-sync');
       expect(statusSync?.generateIdempotencyKey(makeConnection(), '2026-05-11-12-34')).toBe(
         'marketplace:conn-allegro-1:offer:status:sync:2026-05-11-12-34'
+      );
+    });
+  });
+
+  describe('shipment-status-sync task (#838)', () => {
+    it('should target platformType=allegro and jobType=marketplace.shipment.statusSync', () => {
+      const tasks = buildAllegroSchedulerTasks(makeConfig());
+      const shipSync = tasks.find((t) => t.taskId === 'allegro-shipment-status-sync');
+      expect(shipSync?.platformType).toBe('allegro');
+      expect(shipSync?.jobType).toBe('marketplace.shipment.statusSync');
+    });
+
+    it('should default to every-15-minute cron and emit the scan-offset cursor key + limit 50', () => {
+      const tasks = buildAllegroSchedulerTasks(makeConfig());
+      const shipSync = tasks.find((t) => t.taskId === 'allegro-shipment-status-sync');
+      expect(shipSync?.cronExpression).toBe('0 */15 * * * *');
+      expect(shipSync?.generatePayload(makeConnection())).toEqual({
+        schemaVersion: 1,
+        limit: 50,
+        cursorKey: 'allegro.shipmentStatus.scanOffset',
+      });
+    });
+
+    it('should honour OL_ALLEGRO_SHIPMENT_STATUS_SYNC_INTERVAL_CRON override', () => {
+      const tasks = buildAllegroSchedulerTasks(
+        makeConfig({ OL_ALLEGRO_SHIPMENT_STATUS_SYNC_INTERVAL_CRON: '*/5 * * * *' })
+      );
+      const shipSync = tasks.find((t) => t.taskId === 'allegro-shipment-status-sync');
+      expect(shipSync?.cronExpression).toBe('*/5 * * * *');
+    });
+
+    it('should fall back to limit=50 when OL_ALLEGRO_SHIPMENT_STATUS_SYNC_PAGE_LIMIT is non-numeric', () => {
+      const tasks = buildAllegroSchedulerTasks(
+        makeConfig({ OL_ALLEGRO_SHIPMENT_STATUS_SYNC_PAGE_LIMIT: 'not-a-number' })
+      );
+      const shipSync = tasks.find((t) => t.taskId === 'allegro-shipment-status-sync');
+      expect(shipSync?.generatePayload(makeConnection())?.limit).toBe(50);
+    });
+
+    it('should generate a per-connection, per-minute idempotency key', () => {
+      const tasks = buildAllegroSchedulerTasks(makeConfig());
+      const shipSync = tasks.find((t) => t.taskId === 'allegro-shipment-status-sync');
+      expect(shipSync?.generateIdempotencyKey(makeConnection(), '2026-05-11-12-34')).toBe(
+        'marketplace:conn-allegro-1:shipment:status:sync:2026-05-11-12-34'
       );
     });
   });

--- a/libs/integrations/allegro/src/infrastructure/scheduler/allegro-scheduler-tasks.ts
+++ b/libs/integrations/allegro/src/infrastructure/scheduler/allegro-scheduler-tasks.ts
@@ -2,7 +2,7 @@
  * Allegro Scheduler Tasks
  *
  * Builds the `SchedulerTaskConfig` instances Allegro contributes to the core
- * `SchedulerTaskRegistryService` (#584). Three tasks today:
+ * `SchedulerTaskRegistryService` (#584). Four tasks today:
  *
  *   - `allegro-orders-poll` — incremental `/order/events` ingest, default
  *     every 5 minutes. Cursor key `allegro.orders.lastEventId`.
@@ -12,6 +12,14 @@
  *   - `allegro-offer-status-sync` (#816) — steady-state refresh of mapped
  *     offers' publication status into `offer_status_snapshots`, default
  *     hourly. Rolling scan-offset cursor key `allegro.offerStatus.scanOffset`.
+ *   - `allegro-shipment-status-sync` (#838) — steady-state refresh of
+ *     non-terminal `shipments` for Allegro Delivery shipments: re-reads each
+ *     shipment's `/shipment-management/shipments/{id}`, advances OL's
+ *     `Shipment` row toward carrier reality (terminal states + asynchronous
+ *     carrier-waybill backfill), and projects the backfilled tracking number
+ *     to the destination OMP (PrestaShop via capability B). Default every
+ *     15 minutes. Rolling scan-offset cursor key
+ *     `allegro.shipmentStatus.scanOffset`.
  *
  * Env-var gating is preserved verbatim from the previous core implementation
  * for deployer back-compat: when `OL_ALLEGRO_POLL_SCHEDULER_ENABLED=false`
@@ -135,6 +143,32 @@ export function buildAllegroSchedulerTasks(configService: ConfigService): Schedu
       }),
       generateIdempotencyKey: (connection, timestamp) =>
         `marketplace:${connection.id}:offer:status:sync:${timestamp}`,
+    });
+  }
+
+  if (isEnabled(configService, 'OL_ALLEGRO_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED')) {
+    const cronExpression = configService.get<string>(
+      'OL_ALLEGRO_SHIPMENT_STATUS_SYNC_INTERVAL_CRON',
+      '0 */15 * * * *'
+    );
+    const pageLimitRaw = Number(
+      configService.get<string>('OL_ALLEGRO_SHIPMENT_STATUS_SYNC_PAGE_LIMIT', '50')
+    );
+    const pageLimit = Number.isFinite(pageLimitRaw) && pageLimitRaw > 0 ? pageLimitRaw : 50;
+
+    tasks.push({
+      taskId: 'allegro-shipment-status-sync',
+      platformType: 'allegro',
+      jobType: 'marketplace.shipment.statusSync',
+      cronExpression,
+      enabledEnvVar: 'OL_ALLEGRO_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED',
+      generatePayload: () => ({
+        schemaVersion: 1,
+        limit: pageLimit,
+        cursorKey: 'allegro.shipmentStatus.scanOffset',
+      }),
+      generateIdempotencyKey: (connection, timestamp) =>
+        `marketplace:${connection.id}:shipment:status:sync:${timestamp}`,
     });
   }
 

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -235,6 +235,14 @@ const ALLOW_LIST = new Map([
     'apps/worker/src/sync/handlers/__tests__/marketplace-offer-status-sync.handler.spec.ts',
     new Set(['ConnectionCursorRepositoryPort']),
   ],
+  [
+    'apps/worker/src/sync/handlers/marketplace-shipment-status-sync.handler.ts',
+    new Set(['ConnectionCursorRepositoryPort']),
+  ],
+  [
+    'apps/worker/src/sync/handlers/__tests__/marketplace-shipment-status-sync.handler.spec.ts',
+    new Set(['ConnectionCursorRepositoryPort']),
+  ],
 
   // worker → sync.{SyncJobRepositoryPort + ConnectionCursorRepositoryPort} — rewire via ISyncJobsService + ISyncCursorsService
   [


### PR DESCRIPTION
## What

Adds the **steady-state counterpart** to #837 (`notifyDispatched`): a cursor-paced worker job that polls each non-terminal `Shipment` on a shipping-provider connection, advances OL's `Shipment` row toward carrier reality (terminal status transitions + asynchronous carrier-waybill backfill), and projects backfilled tracking numbers to the destination OMP via capability B (`OrderFulfillmentUpdater`, #858).

## Why

Allegro Delivery (#833) issues the carrier waybill **asynchronously** — `generateLabel` returns without one, and it appears in `transportingInfo[].carrierWaybill` on a later poll of `/shipment-management/shipments/{id}`. Without a poll, OL has no way to learn about the waybill or push it to the destination shop.

Mirrors the `OfferStatusSyncService` (#816) cursor-advance pattern — no marketplace cursor; the work-list is OL's own `Shipment` rows paged by a rolling scan offset.

## Architecture

```
SchedulerService (every 15 min, per Allegro connection)
   → enqueues 'marketplace.shipment.statusSync' job
   → MarketplaceShipmentStatusSyncHandler
       → ShipmentStatusSyncService.sync(connectionId, { offset, limit })
           ↳ for each non-terminal Shipment:
               · ShippingProviderManagerPort.getTracking()
               · build patch (terminal status, null→trackingNumber)
               · gate: if dispatched-or-richer AND tracking backfill
                       → OrderFulfillmentUpdater.updateFulfillment(shipped, tracking)
               · write patch (push-first: drop tracking on push failure)
       → persist next scan offset on `connection_cursors`
```

### What ships

- **Core** `ShipmentStatusSyncService` — port-only deps on `ShipmentRepositoryPort`, `IIntegrationsService`, `IOrderRecordService`; pure projector: diff snapshot → patch → push → write, per-item try/catch isolated.
- **Contract widenings (additive, non-breaking)**
  - `TrackingSnapshot.trackingNumber?: string` (carrier waybill propagation)
  - `ShipmentFilters.statuses?: readonly ShipmentStatus[]` (multi-status IN; takes precedence over `status`)
- **Allegro Delivery adapter** populates `trackingNumber` from `transportingInfo[].carrierWaybill` via the new `extractCarrierWaybill` mapper helper (first non-empty value in document order).
- **Allegro scheduler task** `allegro-shipment-status-sync` — default `OL_ALLEGRO_SHIPMENT_STATUS_SYNC_INTERVAL_CRON='0 */15 * * * *'`, page limit 50, cursor key `allegro.shipmentStatus.scanOffset`.
- **Worker handler** `marketplace.shipment.statusSync` + payload type `MarketplaceShipmentStatusSyncPayloadV1` + handler-registration wiring.
- **Tests** — service 15/15, mapper +4, adapter +2, scheduler-tasks +5, worker handler 7/7; integration spec (3 cases) exercising the full resolution chain against real Postgres.

## Two v1 workarounds (both dissolve under #861)

Both are named in code comments at the gate site with explicit `// v1 workaround — removed when #861 lands` tags.

### 1. Push-first ordering

If the OMP push throws for any destination, `trackingNumber` is dropped from the `Shipment` patch so the next poll re-attempts. Without per-destination notify-state, `Shipment.trackingNumber` is the only thing distinguishing "already projected" from "not yet projected"; updating it before a failed push would lose the backfill until manual intervention.

### 2. Dispatched-gate on the OMP push

`updateFulfillment(status:'shipped')` fires only when `Shipment.status` is `dispatched`-or-richer, so #838 never marks a PS order shipped before #837's `notifyDispatched` has had its turn. At `generated` the service still backfills `Shipment.trackingNumber` so the next #837 invocation reads it and pushes once, correctly ordered.

Both workarounds collapse into a single seam once #861 ships per-destination notify-state — see #861's body for the dissolution table.

## Quality gate

- ✅ `pnpm lint` (0 errors)
- ✅ `pnpm type-check` (0 errors)
- ✅ `pnpm test` — 2495 / 2495 unit tests
- ✅ `pnpm test:integration` — 231 / 231 (1 pre-existing skip)
- ✅ `pnpm --filter @openlinker/api migration:show` — no new migrations

## How to test

1. Configure an Allegro connection with `ShippingProviderManager` enabled.
2. Trigger a shipment via `/shipments/dispatch` routed to that Allegro Delivery carrier (will return `providerShipmentId`, no `trackingNumber`).
3. After Allegro assigns the carrier waybill (a few minutes in sandbox), wait for `allegro-shipment-status-sync` to tick, or manually enqueue a `marketplace.shipment.statusSync` job on the connection.
4. Verify the `Shipment` row's `trackingNumber` is populated and, if it was `dispatched`-or-richer when the poll ran, that the destination PS order shows `shipping` state + the same tracking number.

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)