### PR TITLE
feat(shipping,prestashop): branch-1 (OMP-fulfilled) shipment status read-back (#834)

### DIFF
--- a/apps/api/src/migrations/1799000000007-add-branch-one-shipments-uq-index.ts
+++ b/apps/api/src/migrations/1799000000007-add-branch-one-shipments-uq-index.ts
@@ -1,0 +1,44 @@
+/**
+ * Add Branch-1 Shipments Unique Index Migration
+ *
+ * Adds the partial-unique index `UQ_shipments_branch_one_per_order_conn`
+ * on `shipments(orderId, connectionId) WHERE providerShipmentId IS NULL` —
+ * the DB-side dedup gate for branch-1 (OMP-fulfilled) shipment projection
+ * rows (#834, ADR-012).
+ *
+ * Branch-1 rows carry `providerShipmentId IS NULL`; branches 2/3 carry a
+ * non-null provider id and are already guarded by
+ * `UQ_shipments_providerShipmentId`. The two indexes are disjoint by
+ * construction — every row matches exactly one (or neither, during the
+ * tiny draft window of branch-2/3 dispatch).
+ *
+ * @see {@link FulfillmentStatusSyncService} for the find-then-create gate
+ *   this index backstops against concurrent ticks.
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddBranchOneShipmentsUqIndex1799000000007 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // `IF NOT EXISTS` makes the migration idempotent — re-running it on a
+    // database that already has the index (e.g. after the integration-test
+    // synchronize path has run, or after a manual hot-fix) is a no-op.
+    // Trade-off: if a pre-existing index with the same NAME but a
+    // different `WHERE` clause exists, Postgres silently keeps the
+    // existing one instead of replacing it (a different name would surface
+    // the drift loudly via a duplicate-name error). Acceptable for
+    // OpenLinker's deploy model where prod schema is always migration-driven
+    // — the only way the shadowing risk materialises is a manual `psql`
+    // edit, which would be a process issue independent of this migration.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_shipments_branch_one_per_order_conn"
+        ON "shipments" ("orderId", "connectionId")
+        WHERE "providerShipmentId" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "UQ_shipments_branch_one_per_order_conn"
+    `);
+  }
+}

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -85,6 +85,7 @@ describe('ShipmentController', () => {
       persistIncomingSnapshot: jest.fn(),
       // Default: order/customer unknown → customerId resolves to null.
       getOrderRecord: jest.fn().mockResolvedValue(null),
+      findMany: jest.fn(),
     };
     controller = new ShipmentController(query, dispatch, cancellation, orders);
   });

--- a/apps/worker/src/sync/handlers/__tests__/marketplace-fulfillment-status-sync.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/marketplace-fulfillment-status-sync.handler.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Marketplace Fulfillment Status Sync Handler Tests (#834)
+ *
+ * Mirrors `marketplace-shipment-status-sync.handler.spec.ts`: scan-offset
+ * cursor read/parse/advance, default cursor key + limit, ok outcome, and
+ * error wrapping. Doesn't re-cover the projection-only orchestration —
+ * that's tested on the core service.
+ *
+ * @module apps/worker/src/sync/handlers/__tests__
+ */
+import type { ConnectionCursorRepositoryPort } from '@openlinker/core/sync';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import type { SyncJob } from '@openlinker/core/sync';
+import type { FulfillmentStatusSyncResult } from '@openlinker/core/shipping';
+
+import { MarketplaceFulfillmentStatusSyncHandler } from '../marketplace-fulfillment-status-sync.handler';
+
+describe('MarketplaceFulfillmentStatusSyncHandler', () => {
+  let handler: MarketplaceFulfillmentStatusSyncHandler;
+  type FulfillmentStatusSyncServiceLike = { sync: jest.Mock };
+  let fulfillmentStatusSync: FulfillmentStatusSyncServiceLike;
+  let cursorRepository: jest.Mocked<ConnectionCursorRepositoryPort>;
+
+  const baseResult: FulfillmentStatusSyncResult = {
+    scanned: 1,
+    created: 1,
+    updated: 0,
+    skipped: 0,
+    failed: 0,
+    total: 50,
+    nextOffset: 10,
+  };
+
+  beforeEach(() => {
+    fulfillmentStatusSync = { sync: jest.fn().mockResolvedValue(baseResult) };
+    cursorRepository = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<ConnectionCursorRepositoryPort>;
+
+    handler = new MarketplaceFulfillmentStatusSyncHandler(
+      fulfillmentStatusSync as never,
+      cursorRepository,
+    );
+  });
+
+  const createJob = (payload: Record<string, unknown>): SyncJob => ({
+    id: 'job-id',
+    jobType: 'marketplace.fulfillment.statusSync' as unknown as SyncJob['jobType'],
+    connectionId: 'connection-1',
+    payload,
+    idempotencyKey: 'key',
+    status: 'queued',
+    attempts: 0,
+    maxAttempts: 10,
+    nextRunAt: new Date(),
+    lockedAt: null,
+    lockedBy: null,
+    lastError: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  it('starts at offset 0 with the default cursor key when no cursor is stored', async () => {
+    const job = createJob({ schemaVersion: 1, limit: 25 });
+
+    const result = await handler.execute(job);
+
+    expect(cursorRepository.get).toHaveBeenCalledWith(
+      'connection-1',
+      'prestashop.fulfillmentStatus.scanOffset',
+    );
+    expect(fulfillmentStatusSync.sync).toHaveBeenCalledWith('connection-1', {
+      limit: 25,
+      offset: 0,
+      updatedSinceDays: undefined,
+    });
+    expect(cursorRepository.set).toHaveBeenCalledWith(
+      'connection-1',
+      'prestashop.fulfillmentStatus.scanOffset',
+      '10',
+    );
+    expect(result).toEqual({ outcome: 'ok' });
+  });
+
+  it('honours the payload cursorKey + updatedSinceDays + limit', async () => {
+    const job = createJob({
+      schemaVersion: 1,
+      limit: 50,
+      cursorKey: 'custom.cursor.key',
+      updatedSinceDays: 45,
+    });
+
+    await handler.execute(job);
+
+    expect(cursorRepository.get).toHaveBeenCalledWith('connection-1', 'custom.cursor.key');
+    expect(fulfillmentStatusSync.sync).toHaveBeenCalledWith('connection-1', {
+      limit: 50,
+      offset: 0,
+      updatedSinceDays: 45,
+    });
+    expect(cursorRepository.set).toHaveBeenCalledWith(
+      'connection-1',
+      'custom.cursor.key',
+      '10',
+    );
+  });
+
+  it('parses the stored offset string into a number', async () => {
+    cursorRepository.get.mockResolvedValue('42');
+    const job = createJob({ schemaVersion: 1, limit: 10 });
+
+    await handler.execute(job);
+
+    expect(fulfillmentStatusSync.sync).toHaveBeenCalledWith('connection-1', {
+      limit: 10,
+      offset: 42,
+      updatedSinceDays: undefined,
+    });
+  });
+
+  it('falls back to default limit when payload limit is missing/invalid', async () => {
+    const job = createJob({ schemaVersion: 1, limit: 'bogus' as unknown as number });
+
+    await handler.execute(job);
+
+    expect(fulfillmentStatusSync.sync).toHaveBeenCalledWith('connection-1', {
+      limit: 100,
+      offset: 0,
+      updatedSinceDays: undefined,
+    });
+  });
+
+  it('wraps service errors in SyncJobExecutionError', async () => {
+    fulfillmentStatusSync.sync.mockRejectedValue(new Error('downstream'));
+    const job = createJob({ schemaVersion: 1, limit: 10 });
+
+    await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+  });
+
+  it('throws when the payload is missing', async () => {
+    const job = createJob(null as unknown as Record<string, unknown>);
+
+    await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+  });
+});

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -19,6 +19,7 @@ import { MarketplaceOfferPollCreationStatusHandler } from './marketplace-offer-p
 import { MarketplaceOffersSyncHandler } from './marketplace-offers-sync.handler';
 import { MarketplaceOfferStatusSyncHandler } from './marketplace-offer-status-sync.handler';
 import { MarketplaceShipmentStatusSyncHandler } from './marketplace-shipment-status-sync.handler';
+import { MarketplaceFulfillmentStatusSyncHandler } from './marketplace-fulfillment-status-sync.handler';
 import { MasterProductSyncHandler } from './master-product-sync.handler';
 import { MasterInventorySyncHandler } from './master-inventory-sync.handler';
 import { AutoMatchVariantsHandler } from './auto-match-variants.handler';
@@ -39,6 +40,7 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly marketplaceOffersSyncHandler: MarketplaceOffersSyncHandler,
     private readonly marketplaceOfferStatusSyncHandler: MarketplaceOfferStatusSyncHandler,
     private readonly marketplaceShipmentStatusSyncHandler: MarketplaceShipmentStatusSyncHandler,
+    private readonly marketplaceFulfillmentStatusSyncHandler: MarketplaceFulfillmentStatusSyncHandler,
     private readonly masterProductSyncHandler: MasterProductSyncHandler,
     private readonly masterInventorySyncHandler: MasterInventorySyncHandler,
     private readonly autoMatchVariantsHandler: AutoMatchVariantsHandler,
@@ -71,6 +73,10 @@ export class HandlerRegistrationService implements OnModuleInit {
     this.handlerRegistry.register(
       'marketplace.shipment.statusSync',
       this.marketplaceShipmentStatusSyncHandler
+    );
+    this.handlerRegistry.register(
+      'marketplace.fulfillment.statusSync',
+      this.marketplaceFulfillmentStatusSyncHandler
     );
 
     // Register generic master handlers (Option B)

--- a/apps/worker/src/sync/handlers/marketplace-fulfillment-status-sync.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-fulfillment-status-sync.handler.ts
@@ -1,0 +1,127 @@
+/**
+ * Marketplace Fulfillment Status Sync Handler (#834)
+ *
+ * Thin delegate for jobs of type `marketplace.fulfillment.statusSync`.
+ * Drives one page of branch-1 (OMP-fulfilled) shipment status read-back
+ * via the core `FulfillmentStatusSyncService` and persists the rolling
+ * scan offset on the connection cursor so the next run continues where
+ * this one stopped.
+ *
+ * Mirrors `MarketplaceShipmentStatusSyncHandler` (#871) — the
+ * cursor-advance pattern is identical because both wrap a core service
+ * that returns the `nextOffset` the caller should persist. Disjoint by
+ * branch: this handler projects branch-1 rows; the sibling handler
+ * refreshes branch-2/3 rows. The two never write the same Shipment.
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import type {
+  MarketplaceFulfillmentStatusSyncPayloadV1,
+  SyncJobHandler,
+  SyncJobHandlerResult,
+  SyncJob as SyncJobEntity,
+} from '@openlinker/core/sync';
+import {
+  CONNECTION_CURSOR_REPOSITORY_TOKEN,
+  ConnectionCursorRepositoryPort,
+  SyncJobExecutionError,
+} from '@openlinker/core/sync';
+import {
+  IFulfillmentStatusSyncService,
+  FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,
+} from '@openlinker/core/shipping';
+import { Logger } from '@openlinker/shared/logging';
+
+type SyncJob = SyncJobEntity;
+
+const DEFAULT_LIMIT = 100;
+/**
+ * Default for the unlikely case a job lands without an explicit
+ * `cursorKey` in its payload (the PrestaShop scheduler task always
+ * supplies one; this default fires only for hand-enqueued jobs). Mirrors
+ * `MarketplaceShipmentStatusSyncHandler`'s default — the handler is
+ * OMP-generic, but the only OMP supporting branch-1 today is PrestaShop.
+ * When a second OMP adopts `FulfillmentStatusReader`, parameterize the
+ * default by reading `connection.platformType` rather than hard-coding here.
+ */
+const DEFAULT_CURSOR_KEY = 'prestashop.fulfillmentStatus.scanOffset';
+
+@Injectable()
+export class MarketplaceFulfillmentStatusSyncHandler implements SyncJobHandler {
+  private readonly logger = new Logger(MarketplaceFulfillmentStatusSyncHandler.name);
+
+  constructor(
+    @Inject(FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN)
+    private readonly fulfillmentStatusSync: IFulfillmentStatusSyncService,
+    @Inject(CONNECTION_CURSOR_REPOSITORY_TOKEN)
+    private readonly cursorRepository: ConnectionCursorRepositoryPort,
+  ) {}
+
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
+    const payload = this.getPayload(job);
+    const cursorKey = payload.cursorKey ?? DEFAULT_CURSOR_KEY;
+    const storedOffset = await this.cursorRepository.get(job.connectionId, cursorKey);
+    const offset = this.parseOffset(storedOffset);
+
+    this.logger.log(
+      `Executing marketplace.fulfillment.statusSync job ${job.id} for connection ${job.connectionId} (limit=${payload.limit}, offset=${offset})`,
+    );
+
+    try {
+      const result = await this.fulfillmentStatusSync.sync(job.connectionId, {
+        limit: payload.limit,
+        offset,
+        updatedSinceDays: payload.updatedSinceDays,
+      });
+
+      this.logger.log(
+        `marketplace.fulfillment.statusSync completed (connection=${job.connectionId}): scanned=${result.scanned}, created=${result.created}, updated=${result.updated}, skipped=${result.skipped}, failed=${result.failed}, nextOffset=${result.nextOffset}/${result.total}`,
+      );
+
+      await this.cursorRepository.set(job.connectionId, cursorKey, String(result.nextOffset));
+
+      return { outcome: 'ok' };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SyncJobExecutionError(
+        `Marketplace fulfillment status sync failed: ${message}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  private getPayload(job: SyncJob): MarketplaceFulfillmentStatusSyncPayloadV1 {
+    const payload = job.payload as unknown as Partial<MarketplaceFulfillmentStatusSyncPayloadV1>;
+    if (!payload || typeof payload !== 'object') {
+      throw new SyncJobExecutionError(
+        `Missing payload for job: ${job.id}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+    const limit =
+      typeof payload.limit === 'number' && payload.limit > 0 ? payload.limit : DEFAULT_LIMIT;
+    return {
+      schemaVersion: 1,
+      limit,
+      cursorKey: typeof payload.cursorKey === 'string' ? payload.cursorKey : undefined,
+      updatedSinceDays:
+        typeof payload.updatedSinceDays === 'number' && payload.updatedSinceDays > 0
+          ? payload.updatedSinceDays
+          : undefined,
+    };
+  }
+
+  private parseOffset(stored: string | null): number {
+    if (stored === null) {
+      return 0;
+    }
+    const parsed = Number.parseInt(stored, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  }
+}

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -29,6 +29,7 @@ import { MarketplaceOfferPollCreationStatusHandler } from './handlers/marketplac
 import { MarketplaceOffersSyncHandler } from './handlers/marketplace-offers-sync.handler';
 import { MarketplaceOfferStatusSyncHandler } from './handlers/marketplace-offer-status-sync.handler';
 import { MarketplaceShipmentStatusSyncHandler } from './handlers/marketplace-shipment-status-sync.handler';
+import { MarketplaceFulfillmentStatusSyncHandler } from './handlers/marketplace-fulfillment-status-sync.handler';
 import { MasterProductSyncHandler } from './handlers/master-product-sync.handler';
 import { MasterInventorySyncHandler } from './handlers/master-inventory-sync.handler';
 import { AutoMatchVariantsHandler } from './handlers/auto-match-variants.handler';
@@ -62,6 +63,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     MarketplaceOffersSyncHandler,
     MarketplaceOfferStatusSyncHandler,
     MarketplaceShipmentStatusSyncHandler,
+    MarketplaceFulfillmentStatusSyncHandler,
     MasterProductSyncHandler,
     MasterInventorySyncHandler,
     AutoMatchVariantsHandler,

--- a/docs/plans/implementation-plan-834-prestashop-branch1-status-readback.md
+++ b/docs/plans/implementation-plan-834-prestashop-branch1-status-readback.md
@@ -1,0 +1,313 @@
+# Implementation Plan — #834 Branch-1 (PS-fulfilled) shipment status read-back
+
+**Issue:** #834 · **ADR:** [ADR-012](../architecture/adrs/012-branch-1-fulfillment-modeling.md) (branch-1 modeling — delegate-to-OMP + status-reader capability)
+**Layer:** Core (shipping) + Integration (prestashop) · **Branch:** `834-prestashop-branch1-shipment-readback`
+**Effort:** S–M (1–3 days) · **Migration:** 1 (partial-unique index on `shipments`)
+
+> Makes OL the single status pane for branch-1 (PS-fulfilled) shipments. **Backend-only PR** — the existing `/shipments` page (#770/#848) picks up new branch-1 rows for free via the existing read API (#846/#847); no FE work in #834.
+
+## 1. Direction — projection-only
+
+The architecturally-grounded model for branch-1: **`Shipment` is a projection of PS's reality, not a commitment OL writes proactively.** PS is the system of record. A branch-1 Shipment row exists when, and only when, **PS has acted** on the order (state transitions to a shipping-related state, or `shipping_number` is set).
+
+This mirrors how OL already models other downstream truths — `OfferStatusSnapshot` (ADR-009) is a persisted projection of marketplace offer state, never written speculatively. Branch-1 Shipments follow the same primitive.
+
+**Concrete consequences of "projection-only":**
+
+| | Effect |
+|---|---|
+| **Single lifecycle owner** | The new sync service is the **only** creator + updater of branch-1 Shipments. No cross-context coupling between `orders` and `shipping`. `OrderSyncService` is untouched. |
+| **No phantom rows** | Every persisted branch-1 Shipment 1:1 with a real PS fulfillment event. No "OL says dispatched, PS says awaiting payment" mismatch windows. |
+| **No `ShipmentDispatchService` changes** | Dispatch is operator-triggered (`POST /shipments/dispatch`) and shapes around `GenerateLabelCommand`. Branch-1 never invokes it. The plan's prior "extend dispatch" was the wrong hook. |
+| **Reporting integrity** | Branch-1 Shipment count = real branch-1 shipment count. Finance / SLA queries don't need defensive filters against phantom rows. |
+| **FE consequence — explicit gap** | `/shipments` shows branch-1 rows once PS acts, **not before**. Pre-fulfillment branch-1 orders are visible in `/orders` only. A "pending fulfillment count" hint banner on `/shipments` is a deferred follow-up FE issue — out of scope for #834. |
+
+## 2. Goal & non-goals
+
+**Goal.** Branch-1 (`processorKind === 'omp_fulfilled'`) orders show up in OL's `/shipments` view as the fulfilling party (PS) acts on them, with status + tracking read back from PS via a new `FulfillmentStatusReader` capability.
+
+**Non-goals (explicit per issue):**
+
+- Changing how PS fulfils (stays external — OL generates no label).
+- Operator-set workflow statuses → PD #827.
+- FE changes — `/shipments` page already exists and reads via the existing API. The "pending PS fulfillment" hint banner on `/shipments` is a *deferred* FE follow-up.
+- Shipment column schema changes (the nullable fields branch-1 needs — `providerShipmentId`, `paczkomatId`, `trackingNumber`, `labelPdfRef` — already exist). **One small migration** ships: a partial-unique index `(orderId, connectionId) WHERE providerShipmentId IS NULL` to guard branch-1 dedup at the DB.
+- Proactive Shipment creation at order-mirror time. Pre-fulfillment branch-1 orders are not represented in `Shipment` (per §1 architectural decision).
+
+## 3. Design
+
+### 3.1 New capability — `FulfillmentStatusReader`
+
+Sub-capability of `OrderProcessorManagerPort`, parallel in shape to `OrderFulfillmentUpdater` (#858). Lives under `libs/core/src/shipping/domain/ports/capabilities/` (the OrderProcessorManager sub-capabilities map cleanly to shipping concerns and live in the shipping context; same convention as `OrderFulfillmentUpdater` did).
+
+```ts
+// fulfillment-status-reader.capability.ts
+export interface FulfillmentStatusReader {
+  /**
+   * Read the destination OMP's view of an order's fulfillment status.
+   *
+   * Returns a snapshot whose `status` is `null` when the OMP has not yet acted
+   * (pre-fulfillment: awaiting payment, processing, picking, …). The sync
+   * service treats `null` as "no shipment to project — skip this order this
+   * pass." When non-null, the value is the canonical OL `ShipmentStatus`
+   * reflecting the OMP's current fulfillment state.
+   */
+  getFulfillmentStatus(input: { externalOrderId: string }): Promise<FulfillmentStatusSnapshot>;
+}
+
+export function isFulfillmentStatusReader(adapter: unknown): adapter is FulfillmentStatusReader {
+  return typeof (adapter as FulfillmentStatusReader)?.getFulfillmentStatus === 'function';
+}
+```
+
+```ts
+// fulfillment-status-snapshot.types.ts
+export interface FulfillmentStatusSnapshot {
+  /**
+   * `null` ⇒ OMP has not yet acted on the order (pre-fulfillment). The sync
+   * service skips creation/update in that case — projection-only semantics.
+   * Non-null ⇒ OMP has acted; this is the OL-canonical status to project.
+   */
+  status: ShipmentStatus | null;
+  trackingNumber: string | null;
+  deliveredAt: Date | null;
+}
+```
+
+### 3.2 PS adapter implementation
+
+The existing `PrestashopOrderProcessorAdapter` (or its decomposed equivalent) declares `implements FulfillmentStatusReader`. **No `supportedCapabilities` manifest change** — sub-capability discovery is via the `isFulfillmentStatusReader` type guard at the call site, mirroring how `isOrderFulfillmentUpdater` (#858) works against the same `OrderProcessorManager` capability declaration. Reads PS order + the matching `order_state` row, then maps via the boolean columns PS itself uses to describe a state — **not** by name regex, which is brittle under multi-language configs and operator-renamed states.
+
+**Source data:**
+
+- `GET /api/orders/{id}` returns `PrestashopOrder` carrying `current_state` (id), `date_upd`, and `shipping_number` (legacy direct-on-order tracking field, accessed via the existing `[key:string]: unknown` index).
+- `GET /api/order_states?deleted=0` (already loaded once per scan via the existing `listOrderStatuses()` pattern) returns the canonical state rows. The `PrestashopOrderState` type is widened to expose the three boolean discriminator columns PS ships:
+  - `delivered` — `'1'` ⇔ the state means "the customer has the package."
+  - `shipped` — `'1'` ⇔ the state means "handed off to carrier."
+  - `paid` — `'1'` ⇔ the state means "payment captured" (not used by the mapper today; documenting for future).
+
+  **Verification gate:** the PrestaShop Webservice allowlist on `order_states` must surface these columns on the wire. Confirm against [developer.prestashop.com](https://devdocs.prestashop-project.org/) (or a sandbox probe) at impl-start. If the WS strips them, the mapper falls back to v1 name-match (less correct but still ships) and we file a follow-up to add them via WS schema config.
+
+**Mapping (conservative v1):**
+
+- `delivered === '1'` → `SHIPMENT_STATUS.Delivered` (+ `deliveredAt = order.date_upd`).
+- `shipped === '1' && delivered !== '1'` → `SHIPMENT_STATUS.Dispatched` (+ `dispatchedAt = order.date_upd`). PS has handed off to carrier.
+- **Cancellation — explicit fallback:** PS has no canonical cancellation boolean (operators define cancel states by convention). v1 falls back to `state.name` matching `/cancel|annul|anul|storno|reject|abge/i` ⇒ `SHIPMENT_STATUS.Cancelled` (+ `cancelledAt = order.date_upd`). Coverage: EN `cancel/cancelled`, FR `annulé`, ES `anulado`, PL `anulowano`/`anulowane` (single `n`), CS/SK `storno`, EN `rejected`, DE `abgebrochen`. Documented as the regex-fallback gap; the proper fix is operator-configurable PS→OL state mapping under **#862** — once that ships, this mapper consumes the same config table.
+- Otherwise → `status: null` (PS has not yet acted on this order — pre-fulfillment).
+
+**Tracking number** — read `order.shipping_number` through `PrestashopOrder`'s `[key:string]: unknown` index, narrow with `typeof === 'string' && length > 0` before use (engineering-standards.md § Type Safety), else fall back to the first non-empty `order_carriers[].tracking_number` (`writeTracking` in the same adapter already proves this resource access pattern); `null` if neither.
+
+The mapper extracts to a pure unit `prestashop-fulfillment-status.mapper.ts`:
+
+```ts
+mapToFulfillmentStatusSnapshot(
+  order: PrestashopOrder,
+  state: PrestashopOrderState | null,    // null ⇒ orphaned current_state, treat as 'not acted'
+  orderCarriers: readonly PrestashopOrderCarrier[],
+): FulfillmentStatusSnapshot
+```
+
+The adapter is a thin shell: fetch the order, look up the state, fetch the carriers, delegate to the mapper. The PS `order_states` map is cached **inside the adapter** as a lazy-init `Map<id, PrestashopOrderState>`. Lifetime = the adapter instance.
+
+**Why the lazy-init cache is correctly bounded** (verified against `libs/core/src/integrations/application/services/integrations.service.ts:94-132`): `IntegrationsService.getCapabilityAdapter` constructs a **fresh adapter via the factory resolver on every call** — there is no instance cache. The sync service in §3.4 resolves the adapter **once per page** (single `const adapter = await ...` before the loop) and reuses it across all records in that page. So: adapter constructed at page start → state map loaded lazily on the first record → reused for every subsequent record in the page → discarded when `sync()` returns and the adapter goes out of scope. One PS `order_states` WS call per scan tick; no stale-state hazard across ticks. Document this contract in the adapter's file header so future refactors of `getCapabilityAdapter` (any pathway that introduces adapter-instance caching) surface this assumption explicitly.
+
+### 3.3 Type widenings (all additive — existing call sites unchanged)
+
+- **`ShippingMethod`** gains `'omp'` (the persisted `shippingMethod` value for branch-1 Shipments). Forward-compatible per its docstring (which already documents the type as discriminating *what kind of shipment OL persists*, not strictly what `ShippingProviderManagerPort` produces — update the docstring to reflect this honestly).
+- **`ShipmentFilters`** gains `hasProviderShipmentId?: boolean`. When `false`, the query adds `providerShipmentId IS NULL` (the branch-1 selector). Used by both the find-existing-branch-1-shipment lookup in the sync service and any future read API that wants to filter by branch.
+- **`CreateShipmentInput`** gains `initialStatus?: ShipmentStatus` (default `'draft'` — preserves existing call-site behaviour) plus `trackingNumber?: string`, `dispatchedAt?: Date`, `deliveredAt?: Date`, `cancelledAt?: Date`. The sync service writes the snapshot's status + terminal-timestamp at create time so the row is born at its correct status (no `draft → terminal` two-write cycle, no transient pre-projection state that would trip the partial-unique index). `ShipmentDispatchService` keeps its existing two-step `create(draft) → update(generated)` flow — the draft row is observable as `failed` on `generateLabel` errors, which is the intended UX there.
+- **`OrderRecordFilters`** (on `OrderRecordRepositoryPort.findMany`) gains `destinationConnectionId?: string` (JSONB `@>` containment on `syncStatus`, mirroring the existing `syncStatus` enum filter at `order-record.repository.ts:85-88`) and `updatedSince?: Date` (column predicate on `rec.updatedAt`, mirroring the existing `createdFrom`). `recordStatus?: OrderRecordStatus` already exists (`order-record.types.ts:40`) — no widening, just reused. Without a GIN index the JSONB containment is a seqscan; acceptable at v1 scale (~30k rows in the 30-day window), file as a follow-up if scan time creeps.
+
+### 3.4 The new sync service — `FulfillmentStatusSyncService`
+
+```ts
+// libs/core/src/shipping/application/services/fulfillment-status-sync.service.ts
+
+@Injectable()
+export class FulfillmentStatusSyncService implements IFulfillmentStatusSyncService {
+  constructor(
+    @Inject(SHIPMENT_REPOSITORY_TOKEN) private readonly shipments: ShipmentRepositoryPort,
+    // Cross-context callers go through I*Service per
+    // architecture-overview.md § "Cross-context dependencies in core" —
+    // repository ports are explicitly forbidden across context boundaries.
+    // Same precedent as the sibling ShipmentStatusSyncService (#871).
+    @Inject(ORDER_RECORD_SERVICE_TOKEN) private readonly orderRecords: IOrderRecordService,
+    @Inject(FULFILLMENT_ROUTING_SERVICE_TOKEN) private readonly routing: IFulfillmentRoutingService,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN) private readonly integrations: IIntegrationsService,
+  ) {}
+
+  async sync(
+    connectionId: string,
+    options: FulfillmentStatusSyncOptions,
+  ): Promise<FulfillmentStatusSyncResult> {
+    // 1. Page candidate OL Order Records: those mirrored to this PS connection,
+    //    bounded by recent activity (default: updated_at within last 30 days).
+    //    `findMany` is added to IOrderRecordService as part of this PR (Step 8b),
+    //    delegating to the existing OrderRecordRepositoryPort.findMany inside
+    //    the orders context — repository stays intra-context.
+    const page = await this.orderRecords.findMany(
+      { destinationConnectionId: connectionId, recordStatus: 'ready', updatedSince: thirtyDaysAgo() },
+      { offset: options.offset ?? 0, limit: options.limit },
+    );
+
+    // 2. Resolve the PS OrderProcessor adapter once; bail if it doesn't
+    //    declare FulfillmentStatusReader.
+    const adapter = await this.integrations.getCapabilityAdapter<OrderProcessorManagerPort>(
+      connectionId, 'OrderProcessorManager',
+    );
+    if (!isFulfillmentStatusReader(adapter)) {
+      this.logger.warn(`Connection ${connectionId} doesn't declare FulfillmentStatusReader — skipping scan`);
+      return zeroResult(page);
+    }
+
+    let created = 0, updated = 0, skipped = 0, failed = 0;
+
+    // Per-invocation routing cache: `(sourceConnectionId, sourceDeliveryMethodId)`
+    // is a hot key with low cardinality per page (≤ #distinct delivery methods,
+    // typically <10). Lifetime is one sync() call — stale-cache risk is bounded
+    // to one page; next tick re-reads. Don't push this into the routing service
+    // (would couple lifetimes across all callers and need invalidation on rule
+    // edit). See #834 deep-analysis Q F.
+    const routingCache = new Map<string, FulfillmentRoutingResolution>();
+    const resolveCached = async (
+      sourceConnectionId: string,
+      methodId: string | null,
+    ): Promise<FulfillmentRoutingResolution> => {
+      const key = `${sourceConnectionId}::${methodId ?? '__null__'}`;
+      const hit = routingCache.get(key);
+      if (hit) return hit;
+      const resolution = await this.routing.resolve({
+        sourceConnectionId,
+        sourceDeliveryMethodId: methodId,
+      });
+      routingCache.set(key, resolution);
+      return resolution;
+    };
+
+    for (const record of page.items) {
+      try {
+        // 3. Routing check: only branch-1 rows where this connection is the omp processor.
+        const resolution = await resolveCached(
+          record.sourceConnectionId,
+          record.sourceDeliveryMethodId ?? null,
+        );
+        if (resolution.processorKind !== FULFILLMENT_PROCESSOR_KIND.OmpFulfilled
+            || (resolution.processorConnectionId !== null && resolution.processorConnectionId !== connectionId)) {
+          skipped += 1;
+          continue;
+        }
+
+        // 4. External order id lookup from the record's syncStatus.
+        const externalOrderId = findExternalOrderId(record, connectionId);
+        if (!externalOrderId) { skipped += 1; continue; }
+
+        // 5. Read PS state.
+        const snapshot = await adapter.getFulfillmentStatus({ externalOrderId });
+
+        // 6. Projection: status === null ⇒ PS hasn't acted ⇒ no-op.
+        if (snapshot.status === null) { skipped += 1; continue; }
+
+        // 7. Find existing branch-1 Shipment for (orderId, this PS connection, providerShipmentId IS NULL).
+        const existing = await this.shipments.findBranchOneByOrderAndConnection(record.internalOrderId, connectionId);
+
+        if (!existing) {
+          await this.shipments.create({
+            orderId: record.internalOrderId,
+            connectionId,
+            shippingMethod: SHIPPING_METHOD.Omp,
+            sourceDeliveryMethodId: record.sourceDeliveryMethodId ?? undefined,
+            initialStatus: snapshot.status,
+            // dispatchedAt / deliveredAt / cancelledAt / trackingNumber from snapshot
+            // (terminal timestamps set per status; trackingNumber threaded directly).
+          });
+          created += 1;
+        } else {
+          const patch = diffPatch(existing, snapshot);
+          if (Object.keys(patch).length > 0) {
+            await this.shipments.update(existing.id, patch);
+            updated += 1;
+          }
+        }
+      } catch (error) {
+        failed += 1;
+        this.logger.warn(`Branch-1 status sync failed for record ${record.internalOrderId}: ${msg(error)}`);
+      }
+    }
+
+    const offset = options.offset ?? 0;
+    const consumed = offset + page.items.length;
+    const nextOffset = consumed >= page.total ? 0 : consumed;
+
+    return {
+      scanned: page.items.length,
+      created, updated, skipped, failed,
+      total: page.total, nextOffset,
+    };
+  }
+}
+```
+
+**Key shape notes:**
+
+- The sync service iterates **OL Order Records**, not OL Shipments (because pre-fulfillment branch-1 orders have no Shipment yet). The page filter (`destinationConnectionId` + recent activity) bounds the work.
+- The single per-page adapter resolution mirrors #871's pattern.
+- **Idempotency**: `findBranchOneByOrderAndConnection` is the dedup gate. Two concurrent syncs for the same connection could in principle both pass it and double-create — but per-connection scans are serialised by the scheduler (one job per connection per tick), so the race window is closed in practice. Worst case: a second create attempts to insert; rely on a partial-unique index `(orderId, connectionId) WHERE providerShipmentId IS NULL` as the DB-side guard (cheap addition).
+- **No OMP push-back** (unlike #871's branches-2/3 sync). Branch-1's OMP IS the source of truth — there's nothing to push.
+
+### 3.5 Scheduler + worker
+
+- **Scheduler task** in PS plugin: `prestashop-fulfillment-status-sync`. Default `0 */15 * * * *` (15 min). Cursor key `prestashop.fulfillmentStatus.scanOffset`.
+- **Worker handler** at `marketplace.fulfillment.statusSync`. Thin shell: parse `connectionId` + `{ offset, limit }`, call service, persist `nextOffset` to `connection_cursors`. Mirrors #871's `marketplace.shipment.statusSync` handler.
+
+## 4. Step-by-step
+
+| # | File | Change |
+|---|---|---|
+| 1 | `libs/core/src/shipping/domain/ports/capabilities/fulfillment-status-reader.capability.ts` (NEW) | `FulfillmentStatusReader` port + `isFulfillmentStatusReader` guard |
+| 2 | `libs/core/src/shipping/domain/types/fulfillment-status-snapshot.types.ts` (NEW) | `FulfillmentStatusSnapshot` type with `status: ShipmentStatus \| null` semantics documented |
+| 3 | `libs/core/src/shipping/domain/types/shipping-method.types.ts` | Add `'omp'` to `ShippingMethodValues`; update docstring |
+| 4 | `libs/core/src/shipping/domain/types/shipment.types.ts` | Add `hasProviderShipmentId?: boolean` to `ShipmentFilters`; add `initialStatus?` (and terminal timestamps + `trackingNumber`) to `CreateShipmentInput` |
+| 5 | `libs/core/src/shipping/domain/ports/shipment-repository.port.ts` | Add `findBranchOneByOrderAndConnection(orderId, connectionId): Promise<Shipment \| null>` |
+| 6 | `libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts` | Implement filter widenings + new find method; honour `initialStatus` (and terminal-timestamp fields) in create |
+| 7a | `libs/core/src/shipping/infrastructure/persistence/entities/shipment.orm-entity.ts` | Decorate the ORM entity with `@Index('UQ_shipments_branch_one_per_order_conn', ['orderId','connectionId'], { unique: true, where: '"providerShipmentId" IS NULL' })` (matches the existing `UQ_shipments_providerShipmentId` decorator pattern so integration-test synchronize stays consistent). |
+| 7b | `apps/api/src/migrations/1799000000007-add-branch-one-shipments-uq-index.ts` (NEW) | Production migration creating the partial-unique index — `CREATE UNIQUE INDEX … WHERE "providerShipmentId" IS NULL` in `up`, `DROP INDEX` in `down`. Mirrors the partial-unique-index pattern at `1790000000000-add-prompt-templates-table.ts:43-65`. Class name **must** end in the same 13-digit suffix as the filename — `AddBranchOneShipmentsUqIndex1799000000007` — per `docs/migrations.md § Timestamp uniqueness invariant` (lint-enforced by `scripts/check-migration-timestamps.mjs`). |
+| 8a | `libs/core/src/orders/domain/ports/order-record-repository.port.ts` + types | Widen `OrderRecordFilters` with `destinationConnectionId?` + `updatedSince?` (intra-context — repository surface stays inside `orders`) |
+| 8b | `libs/core/src/orders/application/interfaces/order-record.service.interface.ts` + service impl | Widen `IOrderRecordService` with `findMany(filters, pagination): Promise<PaginatedOrderRecords>`; `OrderRecordService` delegates to `OrderRecordRepositoryPort.findMany`. This is the **cross-context contract surface** the shipping sync service consumes — `*RepositoryPort` is forbidden across context boundaries per architecture-overview.md § "Cross-context dependencies in core". |
+| 9 | `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts` | Implement the new filter (JSONB `@>` for `destinationConnectionId`; `rec.updatedAt >= :updatedSince` column predicate). |
+| 10 | `libs/core/src/shipping/index.ts` | Re-export new capability + snapshot type |
+| 11 | `libs/core/src/shipping/application/services/fulfillment-status-sync.service.ts` (NEW) + sibling `*.service.interface.ts` + `*.types.ts` | The sync service implementing §3.4 |
+| 12 | `libs/core/src/shipping/shipping.module.ts` + `shipping.tokens.ts` | Bind the new service with `FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN` |
+| 13a | `libs/integrations/prestashop/src/domain/types/prestashop-options.types.ts` | Widen `PrestashopOrderState` with `delivered?: string \| number`, `shipped?: string \| number`, `paid?: string \| number` (the boolean discriminator cols the mapper consumes) — gated on the §3.2 WS-exposure verification |
+| 13b | `libs/integrations/prestashop/src/.../mappers/prestashop-fulfillment-status.mapper.ts` (NEW) | Pure mapper PS order + state + carriers → `FulfillmentStatusSnapshot` per §3.2 |
+| 14 | `libs/integrations/prestashop/src/.../adapters/prestashop-order-processor.adapter.ts` | `implements FulfillmentStatusReader`; `getFulfillmentStatus` reads PS order, looks up state via lazy-initialised per-instance `Map<id, PrestashopOrderState>`, fetches order_carriers, delegates to the mapper |
+| 15 | `libs/integrations/prestashop/src/infrastructure/scheduler/prestashop-scheduler-tasks.ts` (NEW or extend) | Register `prestashop-fulfillment-status-sync` scheduler task |
+| 16 | `libs/integrations/prestashop/src/prestashop-plugin.ts` `register(host)` | Wire the new task |
+| 17 | `apps/worker/src/.../handlers/marketplace-fulfillment-status-sync.handler.ts` (NEW) + registration | Worker handler |
+| 18 | Unit specs for every new/touched file | **Mapper** (5 cases: `delivered=1` → Delivered+deliveredAt; `shipped=1 && delivered≠1` → Dispatched+dispatchedAt; state name matches cancel-regex → Cancelled+cancelledAt; orphaned `current_state` / null state row → `status: null`; tracking precedence — `shipping_number` wins over `order_carriers[].tracking_number`). **Adapter** (state-map cache hit on the 2nd call; WS list-resources call shape against `order_states` + `order_carriers`). **Sync service** (routing-cache: two records with the same `(source, method)` issue exactly one `routing.resolve` call; branch-2/3 routing → `skipped++`, no Shipment write; `snapshot.status === null` → `skipped++`, no Shipment write; find-or-create branching; partial-unique-index conflict on concurrent create → caught, counted as `failed` not throw). **Repository** (`findBranchOneByOrderAndConnection` returns null when no row, null when only a non-null-`providerShipmentId` row exists, the row when a `providerShipmentId IS NULL` row exists). |
+| 19 | `apps/api/test/integration/prestashop-branch1-status.int-spec.ts` (NEW) | End-to-end: seed PS order → routing rule omp_fulfilled → sync runs → Shipment row appears with correct status / tracking; second sync no-ops; PS-state advance projects to the row. |
+
+## 5. Validation
+
+- **Architecture:** ADR-012 honoured — branch-1 stays on `OrderProcessorManagerPort + CarrierMapping`; new sub-capability sits on `OrderProcessorManager` in the same shape as `OrderFulfillmentUpdater` (#858). The sync service is the sole branch-1 Shipment lifecycle owner — no cross-context coupling between `orders` and `shipping` is introduced. The PS adapter lives in `libs/integrations/prestashop`; no core→plugin value imports.
+- **Naming:** `*.capability.ts` + co-located guard (per engineering-standards §"Port sub-capabilities"); `*.service.ts` + sibling `*.service.interface.ts`; `*.types.ts` for types; `*.mapper.ts` for the mapper.
+- **Symbol DI tokens:** `FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN` in `libs/core/src/shipping/shipping.tokens.ts` (#595 convention).
+- **Type strictness:** no `any`; the snapshot's `status: ShipmentStatus | null` cleanly encodes the "PS hasn't acted" case in the type system.
+- **Tests:** unit specs for mapper, adapter, sync service, scheduler-task builder, worker handler, repository extensions. Int-spec verifies the projection vertical-slice through real Postgres.
+- **Quality gate:** `pnpm lint && pnpm type-check && pnpm test`; `pnpm --filter @openlinker/api migration:show` → one new migration (`1799000000007-add-branch-one-shipments-uq-index.ts`) listed as pending, runs cleanly forward + reverts cleanly.
+
+## 6. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Iterating Order Records is unbounded over time.** | `OrderRecordFilters.updatedSince` bounds the scan. Default 30 days, exposed via `FulfillmentStatusSyncOptions.updatedSinceDays?: number` so the scheduler-task config can override per-operator without code change. **30 days is a v1 guess** — covers normal B2C cadence, misses operators who ship 6-week-old B2B-with-approval orders. Two follow-up options if v1 signal demands it: (i) drop the bound entirely and page across all destination-matching records like `OfferStatusSyncService` (#816), accepting slower scans for completeness; (ii) double-watermark — time window + a periodic "scan latest N un-projected" sweep so the long tail isn't perpetually missed. Both are over-engineering for v1; ship the 30-day single bound and re-decide once operator data arrives. |
+| **Race-creates if scheduler fires the same connection twice.** | Per-connection serialisation in the scheduler today (one job per connection per tick) + partial-unique index `(orderId, connectionId) WHERE providerShipmentId IS NULL` as DB-side guard. |
+| **Conservative PS-state mapping leaves shipments forever `dispatched`.** | Acceptable v1 trade-off — `delivered`/`cancelled` are explicit; further-grained transitions (`in-transit`, etc.) are a documented follow-up once we have operator feedback on which PS states should map to what. |
+| **Pre-fulfillment branch-1 orders aren't visible on `/shipments`.** | Documented intentional UX consequence of projection-only. Follow-up FE issue (deferred): aggregate "pending PS fulfillment" count + link on `/shipments`. Not in #834. |
+| **Routing rules with `processorConnectionId === null` (fan-out default).** | The sync service's "destination match" check (§3.4 step 3) handles this: when `processorConnectionId === null`, any destination matches; when non-null, only that specific connection. Both shapes work. |
+
+## 7. Out-of-scope follow-ups (file when appropriate)
+
+- **FE:** `/shipments` "pending PS fulfillment" hint banner + link to `/orders` filter. Restores the "single pane" UX intent without polluting the data model.
+- **Richer PS-state → `ShipmentStatus` mapping** (e.g. forward transitions to `in-transit` on PS `shipped` once we have signal data).
+- **Order-state mapping configurability** (#862 — `feat(prestashop,mappings): operator-configurable OL→PrestaShop order-state mapping`) is the inverse direction; this PR's read-back mapping could later consume that config table once it ships.
+- **Watch-list-style invalidation**: if PS state changes are bursty, a webhook-driven invalidation could eventually replace polling. Not v1.

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -10,6 +10,11 @@
 import type { Order } from '../../domain/types/order.types';
 import type { OrderRecord, OrderSyncStatus } from '../../domain/entities/order-record.entity';
 import type { IncomingOrder } from '../../domain/types/incoming-order.types';
+import type {
+  OrderRecordFilters,
+  OrderRecordPagination,
+  PaginatedOrderRecords,
+} from '../../domain/types/order-record.types';
 
 export interface IOrderRecordService {
   /**
@@ -73,4 +78,17 @@ export interface IOrderRecordService {
    * @returns Order record or null if not found
    */
   getOrderRecord(internalOrderId: string): Promise<OrderRecord | null>;
+
+  /**
+   * Filtered, paginated list of order records (#834). The cross-context
+   * surface the shipping branch-1 sync service uses to enumerate
+   * destination-matched records — repository ports are forbidden across
+   * context boundaries per architecture-overview.md § "Cross-context
+   * dependencies in core", so callers go through this service method
+   * instead. Delegates to `OrderRecordRepositoryPort.findMany`.
+   */
+  findMany(
+    filters: OrderRecordFilters,
+    pagination: OrderRecordPagination
+  ): Promise<PaginatedOrderRecords>;
 }

--- a/libs/core/src/orders/application/services/__tests__/order-destination-retry.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-destination-retry.service.spec.ts
@@ -63,6 +63,7 @@ describe('OrderDestinationRetryService', () => {
       updateSyncStatus: jest.fn().mockResolvedValue(undefined),
       persistIncomingSnapshot: jest.fn(),
       getOrderRecord: jest.fn(),
+      findMany: jest.fn(),
     } as unknown as jest.Mocked<IOrderRecordService>;
 
     identifierMapping = {

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -95,6 +95,7 @@ describe('OrderIngestionService', () => {
       persistIncomingSnapshot: jest.fn().mockResolvedValue({}),
       updateSyncStatus: jest.fn().mockResolvedValue(undefined),
       getOrderRecord: jest.fn(),
+      findMany: jest.fn(),
     } as unknown as jest.Mocked<IOrderRecordService>;
 
     customerIdentityResolver = {

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -15,6 +15,11 @@ import { OrderRecord } from '../../domain/entities/order-record.entity';
 import type { OrderSyncStatus, SyncAttempt } from '../../domain/types/order-sync.types';
 import type { IOrderRecordService } from '../interfaces/order-record.service.interface';
 import type { IncomingOrder } from '../../domain/types/incoming-order.types';
+import type {
+  OrderRecordFilters,
+  OrderRecordPagination,
+  PaginatedOrderRecords,
+} from '../../domain/types/order-record.types';
 import { getPiiConfig } from '@openlinker/shared/config';
 import { ORDER_RECORD_REPOSITORY_TOKEN } from '../../orders.tokens';
 
@@ -191,6 +196,13 @@ export class OrderRecordService implements IOrderRecordService {
    */
   async getOrderRecord(internalOrderId: string): Promise<OrderRecord | null> {
     return this.repository.findById(internalOrderId);
+  }
+
+  async findMany(
+    filters: OrderRecordFilters,
+    pagination: OrderRecordPagination
+  ): Promise<PaginatedOrderRecords> {
+    return this.repository.findMany(filters, pagination);
   }
 
   /**

--- a/libs/core/src/orders/domain/ports/capabilities/fulfillment-status-reader.capability.ts
+++ b/libs/core/src/orders/domain/ports/capabilities/fulfillment-status-reader.capability.ts
@@ -1,0 +1,52 @@
+/**
+ * Fulfillment Status Reader Capability
+ *
+ * Optional sub-capability of `OrderProcessorManagerPort` (#834) — order
+ * *destinations* (OMPs) that can report back their view of an order's
+ * fulfillment progress declare `implements FulfillmentStatusReader`.
+ * Counterpart to `OrderFulfillmentUpdater` (#858): that capability writes
+ * status/tracking from OL into the OMP; this one reads the OMP's view of
+ * the same axis back out.
+ *
+ * **Scope** — branch-1 of the fulfillment-routing model (#732, ADR-012):
+ * the destination OMP ships externally and OL projects the resulting
+ * `Shipment` row from the OMP's state transitions. Branches 2/3 use
+ * `ShippingProviderManagerPort.getTracking` instead, keyed on the
+ * provider-issued shipment id — different code path, different cursor,
+ * never racing.
+ *
+ * Call sites resolve the destination adapter via
+ * `getCapabilityAdapter<OrderProcessorManagerPort>(destConnectionId,
+ * 'OrderProcessorManager')` then narrow with `isFulfillmentStatusReader`,
+ * degrading gracefully (skip) when a destination doesn't implement it.
+ *
+ * @module libs/core/src/orders/domain/ports/capabilities
+ * @see {@link OrderProcessorManagerPort} for the base port
+ * @see {@link FulfillmentStatusSnapshot} for the returned shape
+ */
+
+import type { FulfillmentStatusSnapshot } from '../../types/fulfillment-status-snapshot.types';
+import type { OrderProcessorManagerPort } from '../order-processor-manager.port';
+
+export interface FulfillmentStatusReader {
+  /**
+   * Read the destination OMP's view of an order's fulfillment status.
+   *
+   * Returns a snapshot whose `status` is `null` when the OMP has not yet
+   * acted on the order (pre-fulfillment: awaiting payment, processing,
+   * picking, …). The sync service treats `null` as "no shipment to
+   * project — skip this order this pass." When non-null, the value is
+   * the OMP's report of the order's current fulfillment state, mapped
+   * onto OL's `ShipmentStatus` by the sync service.
+   *
+   * `externalOrderId` is the source-platform-native order id (PrestaShop:
+   * the numeric `id_order`).
+   */
+  getFulfillmentStatus(input: { externalOrderId: string }): Promise<FulfillmentStatusSnapshot>;
+}
+
+export function isFulfillmentStatusReader(
+  adapter: OrderProcessorManagerPort,
+): adapter is OrderProcessorManagerPort & FulfillmentStatusReader {
+  return typeof (adapter as Partial<FulfillmentStatusReader>).getFulfillmentStatus === 'function';
+}

--- a/libs/core/src/orders/domain/types/fulfillment-status-snapshot.types.ts
+++ b/libs/core/src/orders/domain/types/fulfillment-status-snapshot.types.ts
@@ -1,0 +1,56 @@
+/**
+ * Fulfillment Status Snapshot Types
+ *
+ * Neutral DTO returned by `FulfillmentStatusReader.getFulfillmentStatus` —
+ * the destination OMP's view of an order's fulfillment progress (#834).
+ *
+ * **Why a dedicated `FulfillmentStatus` union and not `ShipmentStatus`**:
+ * `ShipmentStatus` is the *shipping context's* persistence vocabulary for
+ * the OL-side `Shipment` row. `FulfillmentStatus` is the *OMP's view* of
+ * the order — a contract-surface concept. Keeping them distinct means
+ * adding a non-fulfillment value to `ShipmentStatus` (e.g. `in-transit`,
+ * already there for carrier reads) doesn't ripple into the
+ * `OrderProcessorManagerPort` contract. The branch-1 sync service maps
+ * `FulfillmentStatus → ShipmentStatus` at projection time — that's the
+ * single source of truth for the mapping.
+ *
+ * The `null` status case is the projection-only semantics' load-bearing
+ * signal: the OMP has not yet acted on the order (awaiting payment,
+ * processing, picking, …) and there is nothing to project. The branch-1
+ * sync service treats `null` as "skip this record this pass" — no
+ * Shipment row is written, the order will be re-checked on the next tick.
+ *
+ * `deliveredAt` is populated only on the `delivered` transition.
+ *
+ * @module libs/core/src/orders/domain/types
+ * @see {@link FulfillmentStatusReader} for the port consuming this type
+ */
+
+/**
+ * Fulfillment status values the OMP reports back. The values intentionally
+ * overlap with the shipping-context `ShipmentStatus` literal strings for
+ * the three transitions an OMP can describe today, but the contract is
+ * independent — shipping is free to add states (e.g. `in-transit`,
+ * `failed`) without touching this union.
+ */
+export const FulfillmentStatusValues = ['delivered', 'dispatched', 'cancelled'] as const;
+export type FulfillmentStatus = (typeof FulfillmentStatusValues)[number];
+
+export const FULFILLMENT_STATUS = {
+  Delivered: 'delivered',
+  Dispatched: 'dispatched',
+  Cancelled: 'cancelled',
+} as const satisfies Record<'Delivered' | 'Dispatched' | 'Cancelled', FulfillmentStatus>;
+
+export interface FulfillmentStatusSnapshot {
+  /**
+   * `null` ⇒ OMP has not yet acted on the order (pre-fulfillment). The
+   * sync service skips creation/update in that case — projection-only
+   * semantics. Non-null ⇒ OMP has acted; the value is the OMP's report
+   * of the order's current fulfillment state, mapped onto OL's persisted
+   * shipment status by the sync service.
+   */
+  status: FulfillmentStatus | null;
+  trackingNumber: string | null;
+  deliveredAt: Date | null;
+}

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -38,6 +38,21 @@ export interface OrderRecordFilters {
   createdFrom?: Date;
   createdTo?: Date;
   recordStatus?: OrderRecordStatus;
+  /**
+   * Match records whose `syncStatus[]` contains an entry for this destination
+   * connection (#834). JSONB containment — same idiom as the existing
+   * `syncStatus` enum filter. Consumed by the shipping context's branch-1
+   * status-sync service to enumerate "OL Orders mirrored to this destination".
+   */
+  destinationConnectionId?: string;
+  /**
+   * Inclusive lower bound on `updatedAt` (#834). Bounds the branch-1 scan
+   * window — records that haven't been re-touched in `updatedSince` aren't
+   * worth re-checking the destination OMP for. Note: `updatedAt` shifts on
+   * every `updateSyncStatus` call, so a record that re-syncs stays in the
+   * window even if it's been around for months.
+   */
+  updatedSince?: Date;
 }
 
 /**

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -24,6 +24,18 @@ export type { OrderDispatchNotifier } from './domain/ports/capabilities/order-di
 export { isOrderDispatchNotifier } from './domain/ports/capabilities/order-dispatch-notifier.capability';
 export type { OrderFulfillmentUpdater } from './domain/ports/capabilities/order-fulfillment-updater.capability';
 export { isOrderFulfillmentUpdater } from './domain/ports/capabilities/order-fulfillment-updater.capability';
+// Read-back counterpart to OrderFulfillmentUpdater (#834): branch-1
+// shipment-status projection from the OMP's view.
+export type { FulfillmentStatusReader } from './domain/ports/capabilities/fulfillment-status-reader.capability';
+export { isFulfillmentStatusReader } from './domain/ports/capabilities/fulfillment-status-reader.capability';
+export type {
+  FulfillmentStatus,
+  FulfillmentStatusSnapshot,
+} from './domain/types/fulfillment-status-snapshot.types';
+export {
+  FulfillmentStatusValues,
+  FULFILLMENT_STATUS,
+} from './domain/types/fulfillment-status-snapshot.types';
 export type { DispatchCarrierHint } from './domain/types/dispatch-carrier-hint.types';
 export type { MappingOption, MappingOptionKind } from './domain/types/mapping-option.types';
 export { MappingOptionKindValues } from './domain/types/mapping-option.types';

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -91,6 +91,23 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       qb.andWhere('rec.recordStatus = :recordStatus', { recordStatus: filters.recordStatus });
     }
 
+    if (filters.destinationConnectionId) {
+      // JSONB containment — match records whose `syncStatus[]` contains an
+      // entry with this destinationConnectionId (#834). Same idiom as the
+      // `syncStatus` enum filter above. No GIN index today — acceptable at
+      // v1 scale (≤30k rows in the typical 30-day window), file a follow-up
+      // if scan time creeps.
+      qb.andWhere(`rec."syncStatus" @> :destFilter::jsonb`, {
+        destFilter: JSON.stringify([
+          { destinationConnectionId: filters.destinationConnectionId },
+        ]),
+      });
+    }
+
+    if (filters.updatedSince) {
+      qb.andWhere('rec.updatedAt >= :updatedSince', { updatedSince: filters.updatedSince });
+    }
+
     const [entities, total] = await qb.getManyAndCount();
 
     return {

--- a/libs/core/src/shipping/application/interfaces/fulfillment-status-sync.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/fulfillment-status-sync.service.interface.ts
@@ -1,0 +1,25 @@
+/**
+ * Fulfillment Status Sync Service Interface
+ *
+ * Application-layer contract for the branch-1 (OMP-fulfilled) shipment
+ * status read-back service (#834). Injected via
+ * `FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN`. The worker handler at
+ * `apps/worker/src/.../handlers/marketplace-fulfillment-status-sync.handler.ts`
+ * drives one `sync(connectionId, options)` call per tick, persists
+ * `nextOffset` to `connection_cursors`, and reports the stats back to the
+ * scheduler.
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+
+import type {
+  FulfillmentStatusSyncOptions,
+  FulfillmentStatusSyncResult,
+} from '../types/fulfillment-status-sync.types';
+
+export interface IFulfillmentStatusSyncService {
+  sync(
+    connectionId: string,
+    options: FulfillmentStatusSyncOptions,
+  ): Promise<FulfillmentStatusSyncResult>;
+}

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -1,0 +1,506 @@
+/**
+ * FulfillmentStatusSyncService — unit tests (#834)
+ *
+ * Covers the orchestration: routing-cache amortisation, branch-1
+ * disambiguation against branches 2/3, the projection-only null skip, and
+ * find-or-create with diff-patching against existing branch-1 rows.
+ */
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import type { IFulfillmentRoutingService } from '@openlinker/core/mappings';
+import { FULFILLMENT_PROCESSOR_KIND } from '@openlinker/core/mappings';
+import type {
+  FulfillmentStatusReader,
+  IOrderRecordService,
+  OrderRecord,
+} from '@openlinker/core/orders';
+import { FULFILLMENT_STATUS } from '@openlinker/core/orders';
+
+import { Shipment } from '../../domain/entities/shipment.entity';
+import type { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import { SHIPMENT_STATUS } from '../../domain/types/shipment-status.types';
+import { FulfillmentStatusSyncService } from './fulfillment-status-sync.service';
+
+const PS = 'conn-ps-1';
+const ALLEGRO = 'conn-allegro-1';
+
+function makeOrderRecord(overrides: {
+  internalOrderId?: string;
+  sourceConnectionId?: string;
+  methodId?: string | null;
+  syncedTo?: Array<{ destinationConnectionId: string; externalOrderId?: string }>;
+} = {}): OrderRecord {
+  const shipping = overrides.methodId === null
+    ? {}
+    : { shipping: { methodId: overrides.methodId ?? 'allegro-courier' } };
+  return {
+    internalOrderId: overrides.internalOrderId ?? 'ol_order_1',
+    sourceConnectionId: overrides.sourceConnectionId ?? ALLEGRO,
+    syncStatus: overrides.syncedTo ?? [
+      { destinationConnectionId: PS, status: 'synced', externalOrderId: 'ps-100' },
+    ],
+    orderSnapshot: shipping as Record<string, unknown>,
+  } as unknown as OrderRecord;
+}
+
+function makeBranchOneShipment(overrides: Partial<Shipment> = {}): Shipment {
+  return new Shipment(
+    overrides.id ?? 'ol_shipment_1',
+    overrides.orderId ?? 'ol_order_1',
+    overrides.connectionId ?? PS,
+    overrides.shippingMethod ?? 'omp',
+    overrides.status ?? 'dispatched',
+    null,                                  // providerShipmentId — branch-1 invariant
+    overrides.paczkomatId ?? null,
+    overrides.trackingNumber ?? null,
+    overrides.labelPdfRef ?? null,
+    overrides.dispatchedAt ?? null,
+    overrides.deliveredAt ?? null,
+    overrides.cancelledAt ?? null,
+    overrides.failedAt ?? null,
+    overrides.errorMessage ?? null,
+    overrides.createdAt ?? new Date('2026-05-27T09:00:00.000Z'),
+    overrides.updatedAt ?? new Date('2026-05-27T10:00:00.000Z'),
+    overrides.sourceDeliveryMethodId ?? null,
+  );
+}
+
+describe('FulfillmentStatusSyncService', () => {
+  let shipments: jest.Mocked<ShipmentRepositoryPort>;
+  let orderRecords: jest.Mocked<IOrderRecordService>;
+  let routing: jest.Mocked<IFulfillmentRoutingService>;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let getFulfillmentStatus: jest.Mock;
+  let service: FulfillmentStatusSyncService;
+
+  beforeEach(() => {
+    shipments = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findById: jest.fn(),
+      findByOrderId: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findByProviderShipmentId: jest.fn(),
+      findBranchOneByOrderAndConnection: jest.fn().mockResolvedValue(null),
+      update: jest.fn(),
+    };
+
+    orderRecords = {
+      persistOrder: jest.fn(),
+      updateSyncStatus: jest.fn(),
+      persistIncomingSnapshot: jest.fn(),
+      getOrderRecord: jest.fn(),
+      findMany: jest.fn(),
+    };
+
+    routing = {
+      resolve: jest.fn().mockResolvedValue({
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+        processorConnectionId: null,
+        source: 'default',
+      }),
+      // The other IFulfillmentRoutingService methods aren't called by the
+      // sync service; stub them so the Mocked<…> shape is satisfied.
+      getCandidateProcessors: jest.fn(),
+      replaceRules: jest.fn(),
+      listRules: jest.fn(),
+    } as unknown as jest.Mocked<IFulfillmentRoutingService>;
+
+    getFulfillmentStatus = jest.fn();
+    const ompAdapter: FulfillmentStatusReader = { getFulfillmentStatus };
+    integrations = {
+      getCapabilityAdapter: jest.fn().mockResolvedValue(ompAdapter),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    service = new FulfillmentStatusSyncService(
+      shipments,
+      orderRecords,
+      routing,
+      integrations,
+    );
+  });
+
+  describe('happy path — branch-1, OMP has acted, no existing shipment', () => {
+    it('should create a branch-1 Shipment born at the snapshot status', async () => {
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Dispatched,
+        trackingNumber: 'PS-TRK-1',
+        deliveredAt: null,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(shipments.create).toHaveBeenCalledTimes(1);
+      const createInput = shipments.create.mock.calls[0][0];
+      expect(createInput.connectionId).toBe(PS);
+      expect(createInput.orderId).toBe('ol_order_1');
+      expect(createInput.shippingMethod).toBe('omp');
+      expect(createInput.initialStatus).toBe(SHIPMENT_STATUS.Dispatched);
+      expect(createInput.trackingNumber).toBe('PS-TRK-1');
+      expect(createInput.dispatchedAt).toBeInstanceOf(Date);
+      expect(createInput.deliveredAt).toBeUndefined();
+      expect(createInput.sourceDeliveryMethodId).toBe('allegro-courier');
+      expect(result).toMatchObject({
+        scanned: 1,
+        created: 1,
+        updated: 0,
+        skipped: 0,
+        failed: 0,
+      });
+    });
+
+    it('should set deliveredAt on Delivered transitions', async () => {
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+      const deliveredAt = new Date('2026-05-28T08:00:00.000Z');
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Delivered,
+        trackingNumber: 'PS-TRK-1',
+        deliveredAt,
+      });
+
+      await service.sync(PS, { limit: 100 });
+
+      const createInput = shipments.create.mock.calls[0][0];
+      expect(createInput.initialStatus).toBe(SHIPMENT_STATUS.Delivered);
+      expect(createInput.deliveredAt).toEqual(deliveredAt);
+    });
+  });
+
+  describe('routing-cache amortisation', () => {
+    it('should call routing.resolve once per distinct (sourceConn, methodId) — even with many records', async () => {
+      const records = [
+        makeOrderRecord({ internalOrderId: 'ol_order_1', methodId: 'm1' }),
+        makeOrderRecord({ internalOrderId: 'ol_order_2', methodId: 'm1' }),
+        makeOrderRecord({ internalOrderId: 'ol_order_3', methodId: 'm1' }),
+      ];
+      orderRecords.findMany.mockResolvedValue({ items: records, total: 3 });
+      getFulfillmentStatus.mockResolvedValue({
+        status: null,
+        trackingNumber: null,
+        deliveredAt: null,
+      });
+
+      await service.sync(PS, { limit: 100 });
+
+      expect(routing.resolve).toHaveBeenCalledTimes(1);
+      expect(routing.resolve).toHaveBeenCalledWith({
+        sourceConnectionId: ALLEGRO,
+        sourceDeliveryMethodId: 'm1',
+      });
+    });
+
+    it('should call routing.resolve once per distinct method even within one page', async () => {
+      const records = [
+        makeOrderRecord({ internalOrderId: 'ol_order_1', methodId: 'm1' }),
+        makeOrderRecord({ internalOrderId: 'ol_order_2', methodId: 'm2' }),
+        makeOrderRecord({ internalOrderId: 'ol_order_3', methodId: 'm1' }),
+      ];
+      orderRecords.findMany.mockResolvedValue({ items: records, total: 3 });
+      getFulfillmentStatus.mockResolvedValue({
+        status: null,
+        trackingNumber: null,
+        deliveredAt: null,
+      });
+
+      await service.sync(PS, { limit: 100 });
+
+      expect(routing.resolve).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('branch-2/3 disambiguation', () => {
+    it('should skip records whose routing resolves to OlManagedCarrier', async () => {
+      routing.resolve.mockResolvedValue({
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: 'conn-inpost',
+        source: 'rule',
+      });
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(shipments.create).not.toHaveBeenCalled();
+      expect(getFulfillmentStatus).not.toHaveBeenCalled();
+      expect(result.skipped).toBe(1);
+      expect(result.created).toBe(0);
+    });
+
+    it('should skip records whose routing resolves to a different OMP connection', async () => {
+      routing.resolve.mockResolvedValue({
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+        processorConnectionId: 'conn-different-ps',
+        source: 'rule',
+      });
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(shipments.create).not.toHaveBeenCalled();
+      expect(result.skipped).toBe(1);
+    });
+
+    it('should NOT skip records when the rule pins processorConnectionId to this connection', async () => {
+      routing.resolve.mockResolvedValue({
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+        processorConnectionId: PS,
+        source: 'rule',
+      });
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Dispatched,
+        trackingNumber: null,
+        deliveredAt: null,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(result.created).toBe(1);
+    });
+  });
+
+  describe('projection-only null skip', () => {
+    it('should skip when snapshot.status is null (OMP has not acted)', async () => {
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+      getFulfillmentStatus.mockResolvedValue({
+        status: null,
+        trackingNumber: null,
+        deliveredAt: null,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(shipments.create).not.toHaveBeenCalled();
+      expect(shipments.update).not.toHaveBeenCalled();
+      expect(result.skipped).toBe(1);
+      expect(result.created).toBe(0);
+    });
+  });
+
+  describe('externalOrderId resolution', () => {
+    it('should skip when the record has no synced destination for this connection', async () => {
+      orderRecords.findMany.mockResolvedValue({
+        items: [
+          makeOrderRecord({
+            syncedTo: [
+              { destinationConnectionId: 'conn-other', externalOrderId: 'other-1' },
+            ],
+          }),
+        ],
+        total: 1,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(getFulfillmentStatus).not.toHaveBeenCalled();
+      expect(result.skipped).toBe(1);
+    });
+  });
+
+  describe('find-or-create + diff-patching', () => {
+    it('should patch status when an existing branch-1 row advances', async () => {
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+      shipments.findBranchOneByOrderAndConnection.mockResolvedValue(
+        makeBranchOneShipment({ status: 'dispatched' }),
+      );
+      const deliveredAt = new Date('2026-05-28T09:00:00.000Z');
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Delivered,
+        trackingNumber: null,
+        deliveredAt,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(shipments.update).toHaveBeenCalledTimes(1);
+      const [updateId, patch] = shipments.update.mock.calls[0];
+      expect(updateId).toBe('ol_shipment_1');
+      expect(patch.status).toBe(SHIPMENT_STATUS.Delivered);
+      expect(patch.deliveredAt).toEqual(deliveredAt);
+      expect(result.updated).toBe(1);
+      expect(result.created).toBe(0);
+    });
+
+    it('should backfill trackingNumber when present and not already set', async () => {
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+      shipments.findBranchOneByOrderAndConnection.mockResolvedValue(
+        makeBranchOneShipment({ status: 'dispatched', trackingNumber: null }),
+      );
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Dispatched,
+        trackingNumber: 'PS-TRK-NEW',
+        deliveredAt: null,
+      });
+
+      await service.sync(PS, { limit: 100 });
+
+      const [, patch] = shipments.update.mock.calls[0];
+      expect(patch.trackingNumber).toBe('PS-TRK-NEW');
+      expect(patch.status).toBeUndefined();
+    });
+
+    it('should no-op (no update) when the snapshot matches the existing row', async () => {
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+      shipments.findBranchOneByOrderAndConnection.mockResolvedValue(
+        makeBranchOneShipment({ status: 'dispatched', trackingNumber: 'PS-TRK-1' }),
+      );
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Dispatched,
+        trackingNumber: 'PS-TRK-1',
+        deliveredAt: null,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(shipments.update).not.toHaveBeenCalled();
+      expect(result.updated).toBe(0);
+    });
+  });
+
+  describe('error containment', () => {
+    it('should count per-record throws as `failed` and continue', async () => {
+      orderRecords.findMany.mockResolvedValue({
+        items: [
+          makeOrderRecord({ internalOrderId: 'ol_order_1' }),
+          makeOrderRecord({ internalOrderId: 'ol_order_2' }),
+        ],
+        total: 2,
+      });
+      getFulfillmentStatus
+        .mockRejectedValueOnce(new Error('PS WS 500'))
+        .mockResolvedValueOnce({
+          status: FULFILLMENT_STATUS.Dispatched,
+          trackingNumber: null,
+          deliveredAt: null,
+        });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(result.failed).toBe(1);
+      expect(result.created).toBe(1);
+    });
+
+    it('should count partial-unique-index conflict on concurrent create as `failed`, not throw', async () => {
+      // Two ticks racing on the same order: this tick's `findBranchOneByOrderAndConnection`
+      // returns null, but by the time `create` fires, the sibling tick has
+      // already inserted the branch-1 row and the partial-unique index
+      // `UQ_shipments_branch_one_per_order_conn` rejects this INSERT.
+      // The sync service must catch the duplicate-key error, increment
+      // `failed`, and NOT propagate the throw out — otherwise the worker
+      // handler retries the whole page and the cursor never advances.
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Dispatched,
+        trackingNumber: null,
+        deliveredAt: null,
+      });
+      shipments.create.mockRejectedValueOnce(
+        new Error(
+          'duplicate key value violates unique constraint "UQ_shipments_branch_one_per_order_conn"',
+        ),
+      );
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(shipments.create).toHaveBeenCalledTimes(1);
+      expect(result.failed).toBe(1);
+      expect(result.created).toBe(0);
+      expect(result.skipped).toBe(0);
+    });
+
+    it('should mark the page as `failed` when adapter resolution throws (integration error, not platform-shape limitation)', async () => {
+      (integrations.getCapabilityAdapter as jest.Mock).mockRejectedValue(
+        new Error('Connection 999 not found'),
+      );
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord(), makeOrderRecord({ internalOrderId: 'ol_order_2' })],
+        total: 2,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(result.failed).toBe(2);
+      expect(result.skipped).toBe(0);
+      expect(result.created).toBe(0);
+      expect(shipments.create).not.toHaveBeenCalled();
+    });
+
+    it('should return zeroResult when the adapter does not declare FulfillmentStatusReader', async () => {
+      // Resolve a bare port without the sub-capability method.
+      (integrations.getCapabilityAdapter as jest.Mock).mockResolvedValue({});
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(shipments.create).not.toHaveBeenCalled();
+      expect(result.created).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+  });
+
+  describe('cursor advancement', () => {
+    it('should wrap nextOffset to 0 when the page reaches `total`', async () => {
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 1,
+      });
+      getFulfillmentStatus.mockResolvedValue({
+        status: null,
+        trackingNumber: null,
+        deliveredAt: null,
+      });
+
+      const result = await service.sync(PS, { limit: 100, offset: 0 });
+
+      expect(result.nextOffset).toBe(0);
+    });
+
+    it('should advance nextOffset by page size when more rows remain', async () => {
+      orderRecords.findMany.mockResolvedValue({
+        items: [makeOrderRecord()],
+        total: 100,
+      });
+      getFulfillmentStatus.mockResolvedValue({
+        status: null,
+        trackingNumber: null,
+        deliveredAt: null,
+      });
+
+      const result = await service.sync(PS, { limit: 1, offset: 5 });
+
+      expect(result.nextOffset).toBe(6);
+    });
+  });
+});

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.ts
@@ -1,0 +1,417 @@
+/**
+ * Fulfillment Status Sync Service
+ *
+ * Branch-1 (OMP-fulfilled) shipment status read-back (#834, ADR-012). The
+ * service is the **sole creator and updater** of branch-1 `Shipment` rows
+ * — projection-only semantics: a row exists when, and only when, the
+ * destination OMP has acted on the order.
+ *
+ * Pages OL Order Records mirrored to this OMP connection, bounded by a
+ * 30-day-default activity window. For each record (in order):
+ *
+ *  1. Resolve the fulfillment routing for `(sourceConnectionId,
+ *     sourceDeliveryMethodId)`. Cache the resolution within this
+ *     `sync()` invocation — typical pages have ≤10 distinct delivery
+ *     methods, so 100 records collapse to ≤10 routing-service calls.
+ *  2. Skip non-branch-1 routings (`ol_managed_carrier` /
+ *     `source_brokered`) — those go through `ShipmentStatusSyncService`
+ *     (#871), keyed on `providerShipmentId`. Disjoint code paths.
+ *  3. Read the OMP's view via `FulfillmentStatusReader.getFulfillmentStatus`.
+ *  4. If the snapshot's `status` is `null`, the OMP hasn't acted yet —
+ *     skip; the next tick re-checks.
+ *  5. Otherwise find-or-create the branch-1 Shipment row (`providerShipmentId
+ *     IS NULL`). New rows are written atomic-terminal — born at the
+ *     snapshot's status + matching terminal timestamp + tracking number.
+ *     The partial-unique index
+ *     `UQ_shipments_branch_one_per_order_conn` is the DB-side backstop
+ *     against concurrent ticks racing on the same order.
+ *
+ * Mirrors `ShipmentStatusSyncService` (#871) in shape: the service
+ * returns scan stats; the caller (worker handler) advances the persisted
+ * `connection_cursors` offset.
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IFulfillmentStatusSyncService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+
+import { Logger } from '@openlinker/shared/logging';
+import {
+  type IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+} from '@openlinker/core/integrations';
+import {
+  type IFulfillmentRoutingService,
+  type FulfillmentRoutingResolution,
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+} from '@openlinker/core/mappings';
+import {
+  type FulfillmentStatus,
+  type FulfillmentStatusSnapshot,
+  type IOrderRecordService,
+  type OrderProcessorManagerPort,
+  type OrderRecord,
+  FULFILLMENT_STATUS,
+  isFulfillmentStatusReader,
+  ORDER_RECORD_SERVICE_TOKEN,
+} from '@openlinker/core/orders';
+
+import type { IFulfillmentStatusSyncService } from '../interfaces/fulfillment-status-sync.service.interface';
+import type {
+  FulfillmentStatusSyncOptions,
+  FulfillmentStatusSyncResult,
+} from '../types/fulfillment-status-sync.types';
+import { DEFAULT_UPDATED_SINCE_DAYS } from '../types/fulfillment-status-sync.types';
+import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import {
+  SHIPMENT_STATUS,
+  type ShipmentStatus,
+} from '../../domain/types/shipment-status.types';
+import { SHIPPING_METHOD } from '../../domain/types/shipping-method.types';
+import type { Shipment } from '../../domain/entities/shipment.entity';
+import type { UpdateShipmentInput } from '../../domain/types/shipment.types';
+import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+
+/**
+ * Project the OMP's neutral `FulfillmentStatus` onto the shipping
+ * context's `ShipmentStatus`. The mapping is intentionally identity for
+ * the three values — but the seam exists so that shipping can add states
+ * (e.g. `in-transit`, `failed`) without those states leaking into the
+ * `OrderProcessorManagerPort` contract.
+ */
+function projectStatus(status: FulfillmentStatus): ShipmentStatus {
+  switch (status) {
+    case FULFILLMENT_STATUS.Delivered:
+      return SHIPMENT_STATUS.Delivered;
+    case FULFILLMENT_STATUS.Dispatched:
+      return SHIPMENT_STATUS.Dispatched;
+    case FULFILLMENT_STATUS.Cancelled:
+      return SHIPMENT_STATUS.Cancelled;
+    default: {
+      // Exhaustiveness guard — a new FulfillmentStatus value added without a
+      // matching projection must fail loud, not silently map onto draft.
+      const exhaustive: never = status;
+      throw new Error(`unknown FulfillmentStatus value: ${String(exhaustive)}`);
+    }
+  }
+}
+
+const ORDER_PROCESSOR_MANAGER_CAPABILITY = 'OrderProcessorManager';
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class FulfillmentStatusSyncService implements IFulfillmentStatusSyncService {
+  private readonly logger = new Logger(FulfillmentStatusSyncService.name);
+
+  constructor(
+    @Inject(SHIPMENT_REPOSITORY_TOKEN)
+    private readonly shipments: ShipmentRepositoryPort,
+    // Cross-context callers go through I*Service per architecture-overview.md
+    // § "Cross-context dependencies in core" — repository ports are explicitly
+    // forbidden across context boundaries. Same precedent as the sibling
+    // ShipmentStatusSyncService (#871).
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecords: IOrderRecordService,
+    @Inject(FULFILLMENT_ROUTING_SERVICE_TOKEN)
+    private readonly routing: IFulfillmentRoutingService,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+  ) {}
+
+  async sync(
+    connectionId: string,
+    options: FulfillmentStatusSyncOptions,
+  ): Promise<FulfillmentStatusSyncResult> {
+    const offset = options.offset ?? 0;
+    const { limit } = options;
+    const updatedSinceDays = options.updatedSinceDays ?? DEFAULT_UPDATED_SINCE_DAYS;
+    const updatedSince = new Date(Date.now() - updatedSinceDays * MS_PER_DAY);
+
+    // 1. Page candidate OL Order Records: mirrored to this OMP connection,
+    //    fully resolved (recordStatus='ready'), and recently active.
+    const page = await this.orderRecords.findMany(
+      {
+        destinationConnectionId: connectionId,
+        recordStatus: 'ready',
+        updatedSince,
+      },
+      { offset, limit },
+    );
+
+    // 2. Resolve the OMP OrderProcessor adapter once for this page; bail
+    //    early if it doesn't declare FulfillmentStatusReader (the operator
+    //    enabled the scheduler task on a platform that doesn't support
+    //    branch-1 read-back). Same pattern as ShipmentStatusSyncService.
+    let omp: OrderProcessorManagerPort | null = null;
+    try {
+      omp = await this.integrations.getCapabilityAdapter<OrderProcessorManagerPort>(
+        connectionId,
+        ORDER_PROCESSOR_MANAGER_CAPABILITY,
+      );
+    } catch (error) {
+      // Adapter resolution threw — this is an integration error, not a
+      // platform-shape limitation. Surface it as `failed` so it appears in
+      // /sync/jobs as a job-level failure rather than being silently
+      // counted as "skipped because the platform doesn't support it".
+      this.logger.error(
+        `Could not resolve OrderProcessorManager adapter for connection ${connectionId}: ${this.message(error)}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+      return this.failedResult(page.items.length, page.total, offset);
+    }
+    if (!isFulfillmentStatusReader(omp)) {
+      // Adapter is fine; it just doesn't declare the sub-capability. This
+      // is a platform-shape decision (not every OMP supports branch-1
+      // read-back). Skipped — operator can disable the scheduler task.
+      this.logger.debug(
+        `Connection ${connectionId} adapter does not declare FulfillmentStatusReader — skipping scan`,
+      );
+      return this.zeroResult(page.items.length, page.total, offset);
+    }
+    const reader = omp;
+
+    // 3. Per-invocation routing-resolution cache. `(sourceConnectionId,
+    //    sourceDeliveryMethodId)` is a hot key with low cardinality per page
+    //    (typically <10 distinct methods). Lifetime is one sync() call — the
+    //    next tick re-reads, so a routing-rule edit becomes visible on the
+    //    next page boundary. See plan §3.4 / deep-analysis Q F.
+    const routingCache = new Map<string, FulfillmentRoutingResolution>();
+    const resolveCached = async (
+      sourceConnectionId: string,
+      methodId: string | null,
+    ): Promise<FulfillmentRoutingResolution> => {
+      const key = `${sourceConnectionId}::${methodId ?? '__null__'}`;
+      const hit = routingCache.get(key);
+      if (hit) return hit;
+      const resolution = await this.routing.resolve({
+        sourceConnectionId,
+        sourceDeliveryMethodId: methodId,
+      });
+      routingCache.set(key, resolution);
+      return resolution;
+    };
+
+    let created = 0;
+    let updated = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    for (const record of page.items) {
+      try {
+        const sourceDeliveryMethodId = this.extractSourceDeliveryMethodId(record);
+
+        const resolution = await resolveCached(
+          record.sourceConnectionId,
+          sourceDeliveryMethodId,
+        );
+
+        // 4. Only branch-1 rows where this connection is the OMP processor.
+        //    `processorConnectionId === null` is the fan-out default — every
+        //    destination is a branch-1 OMP; non-null means a specific OMP rule.
+        const branchOneForThisConn =
+          resolution.processorKind === FULFILLMENT_PROCESSOR_KIND.OmpFulfilled &&
+          (resolution.processorConnectionId === null ||
+            resolution.processorConnectionId === connectionId);
+        if (!branchOneForThisConn) {
+          skipped += 1;
+          continue;
+        }
+
+        const externalOrderId = this.findExternalOrderId(record, connectionId);
+        if (!externalOrderId) {
+          // Record is mirrored to this connection but hasn't reached
+          // 'synced' state yet (or the destination didn't surface an id).
+          // Skip — next tick re-checks.
+          skipped += 1;
+          continue;
+        }
+
+        const snapshot = await reader.getFulfillmentStatus({ externalOrderId });
+
+        // 5. Projection-only: status === null ⇒ OMP hasn't acted ⇒ no-op.
+        if (snapshot.status === null) {
+          skipped += 1;
+          continue;
+        }
+
+        const existing = await this.shipments.findBranchOneByOrderAndConnection(
+          record.internalOrderId,
+          connectionId,
+        );
+
+        if (!existing) {
+          await this.createBranchOneShipment(
+            record.internalOrderId,
+            connectionId,
+            sourceDeliveryMethodId,
+            snapshot,
+          );
+          created += 1;
+        } else {
+          const patch = this.diffPatch(existing, snapshot);
+          if (Object.keys(patch).length > 0) {
+            await this.shipments.update(existing.id, patch);
+            updated += 1;
+          }
+        }
+      } catch (error) {
+        failed += 1;
+        this.logger.warn(
+          `Branch-1 status sync failed for record ${record.internalOrderId} ` +
+            `(connection ${connectionId}): ${this.message(error)}`,
+        );
+      }
+    }
+
+    const consumed = offset + page.items.length;
+    const nextOffset = consumed >= page.total ? 0 : consumed;
+
+    return {
+      scanned: page.items.length,
+      created,
+      updated,
+      skipped,
+      failed,
+      total: page.total,
+      nextOffset,
+    };
+  }
+
+  /**
+   * Pull `Order.shipping.methodId` out of the persisted `orderSnapshot`. The
+   * snapshot is typed as `Record<string, unknown>` so the path is narrowed
+   * defensively — `OrderRecord` was authored before this field had a typed
+   * accessor.
+   *
+   * **Implicit contract** — the `shipping.methodId` path here mirrors:
+   *   - `Order.shipping?.methodId` in `libs/core/src/orders/domain/types/order.types.ts`
+   *     (the source-of-truth contract), and
+   *   - the persistence shape `OrderRecordService.persistOrder` writes into
+   *     `orderSnapshot.shipping` (`libs/core/src/orders/application/services/order-record.service.ts`).
+   * If either of those moves the field, this path silently returns `null`
+   * for every record and routing falls through to the OMP-fulfilled default.
+   * Worth a typed accessor on `OrderRecord` once a second consumer needs it.
+   */
+  private extractSourceDeliveryMethodId(record: OrderRecord): string | null {
+    const shipping = record.orderSnapshot['shipping'];
+    if (!shipping || typeof shipping !== 'object') return null;
+    const methodId = (shipping as Record<string, unknown>)['methodId'];
+    return typeof methodId === 'string' && methodId.length > 0 ? methodId : null;
+  }
+
+  /**
+   * Locate the destination's `externalOrderId` for this connection from the
+   * record's per-destination sync-status entries.
+   */
+  private findExternalOrderId(record: OrderRecord, connectionId: string): string | null {
+    const entry = record.syncStatus.find((s) => s.destinationConnectionId === connectionId);
+    return entry?.externalOrderId ?? null;
+  }
+
+  private async createBranchOneShipment(
+    orderId: string,
+    connectionId: string,
+    sourceDeliveryMethodId: string | null,
+    snapshot: FulfillmentStatusSnapshot,
+  ): Promise<void> {
+    // `status === null` is filtered upstream; the non-null assertion here
+    // is documentation, not optimism.
+    const fulfillmentStatus = snapshot.status;
+    if (fulfillmentStatus === null) return;
+    const shipmentStatus = projectStatus(fulfillmentStatus);
+    await this.shipments.create({
+      orderId,
+      connectionId,
+      shippingMethod: SHIPPING_METHOD.Omp,
+      sourceDeliveryMethodId: sourceDeliveryMethodId ?? undefined,
+      initialStatus: shipmentStatus,
+      trackingNumber: snapshot.trackingNumber ?? undefined,
+      dispatchedAt:
+        fulfillmentStatus === FULFILLMENT_STATUS.Dispatched ? new Date() : undefined,
+      deliveredAt:
+        fulfillmentStatus === FULFILLMENT_STATUS.Delivered
+          ? snapshot.deliveredAt ?? new Date()
+          : undefined,
+      cancelledAt:
+        fulfillmentStatus === FULFILLMENT_STATUS.Cancelled ? new Date() : undefined,
+    });
+  }
+
+  /**
+   * Build the minimum patch from `(existing, snapshot)` that reflects the
+   * OMP's current truth. Only fields that actually changed are included so
+   * `update()` returns a true "no-op" when nothing diffed.
+   */
+  private diffPatch(existing: Shipment, snapshot: FulfillmentStatusSnapshot): UpdateShipmentInput {
+    const patch: UpdateShipmentInput = {};
+    if (snapshot.status !== null) {
+      const projectedStatus = projectStatus(snapshot.status);
+      if (projectedStatus !== existing.status) {
+        patch.status = projectedStatus;
+        if (snapshot.status === FULFILLMENT_STATUS.Dispatched && !existing.dispatchedAt) {
+          patch.dispatchedAt = new Date();
+        }
+        if (snapshot.status === FULFILLMENT_STATUS.Delivered && !existing.deliveredAt) {
+          patch.deliveredAt = snapshot.deliveredAt ?? new Date();
+        }
+        if (snapshot.status === FULFILLMENT_STATUS.Cancelled && !existing.cancelledAt) {
+          patch.cancelledAt = new Date();
+        }
+      }
+    }
+    if (
+      snapshot.trackingNumber !== null &&
+      snapshot.trackingNumber !== existing.trackingNumber
+    ) {
+      patch.trackingNumber = snapshot.trackingNumber;
+    }
+    return patch;
+  }
+
+  private zeroResult(
+    scanned: number,
+    total: number,
+    offset: number,
+  ): FulfillmentStatusSyncResult {
+    const consumed = offset + scanned;
+    return {
+      scanned,
+      created: 0,
+      updated: 0,
+      skipped: scanned,
+      failed: 0,
+      total,
+      nextOffset: consumed >= total ? 0 : consumed,
+    };
+  }
+
+  /**
+   * Page-level failure shape — adapter resolution threw, no per-record
+   * processing happened. Counts the whole page as `failed` so the worker
+   * job surfaces in `/sync/jobs` as a failure rather than a successful
+   * no-op. Cursor still advances to avoid replaying the same page on
+   * every tick of a broken connection.
+   */
+  private failedResult(
+    scanned: number,
+    total: number,
+    offset: number,
+  ): FulfillmentStatusSyncResult {
+    const consumed = offset + scanned;
+    return {
+      scanned,
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      failed: scanned,
+      total,
+      nextOffset: consumed >= total ? 0 : consumed,
+    };
+  }
+
+  private message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/libs/core/src/shipping/application/services/shipment-cancellation.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-cancellation.service.spec.ts
@@ -60,6 +60,7 @@ describe('ShipmentCancellationService', () => {
       findByOrderId: jest.fn(),
       findActiveByOrderId: jest.fn(),
       findByProviderShipmentId: jest.fn(),
+      findBranchOneByOrderAndConnection: jest.fn(),
       update: jest.fn(),
     };
     cancellerAdapter = {

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -65,6 +65,7 @@ describe('ShipmentDispatchNotificationService', () => {
       findByOrderId: jest.fn(),
       findActiveByOrderId: jest.fn(),
       findByProviderShipmentId: jest.fn(),
+      findBranchOneByOrderAndConnection: jest.fn(),
       update: jest.fn(),
     };
     orderRecords = {
@@ -72,6 +73,7 @@ describe('ShipmentDispatchNotificationService', () => {
       updateSyncStatus: jest.fn(),
       persistIncomingSnapshot: jest.fn(),
       getOrderRecord: jest.fn().mockResolvedValue(makeRecord()),
+      findMany: jest.fn(),
     };
     identifierMapping = {
       getInternalId: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -96,6 +96,7 @@ describe('ShipmentDispatchService', () => {
       findByOrderId: jest.fn(),
       findActiveByOrderId: jest.fn(),
       findByProviderShipmentId: jest.fn(),
+      findBranchOneByOrderAndConnection: jest.fn(),
       update: jest.fn(),
     };
     routing = {

--- a/libs/core/src/shipping/application/services/shipment-query.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-query.service.spec.ts
@@ -50,6 +50,7 @@ describe('ShipmentQueryService', () => {
       findByOrderId: jest.fn(),
       findActiveByOrderId: jest.fn(),
       findByProviderShipmentId: jest.fn(),
+      findBranchOneByOrderAndConnection: jest.fn(),
       update: jest.fn(),
     };
     service = new ShipmentQueryService(repository);

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
@@ -76,6 +76,7 @@ describe('ShipmentStatusSyncService', () => {
       findByOrderId: jest.fn(),
       findActiveByOrderId: jest.fn(),
       findByProviderShipmentId: jest.fn(),
+      findBranchOneByOrderAndConnection: jest.fn(),
       update: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<ShipmentRepositoryPort>;
 
@@ -84,6 +85,7 @@ describe('ShipmentStatusSyncService', () => {
       updateSyncStatus: jest.fn(),
       persistIncomingSnapshot: jest.fn(),
       getOrderRecord: jest.fn().mockResolvedValue(makeRecord()),
+      findMany: jest.fn(),
     } as unknown as jest.Mocked<IOrderRecordService>;
 
     getTracking = jest.fn();

--- a/libs/core/src/shipping/application/types/fulfillment-status-sync.types.ts
+++ b/libs/core/src/shipping/application/types/fulfillment-status-sync.types.ts
@@ -1,0 +1,50 @@
+/**
+ * Fulfillment Status Sync Types
+ *
+ * Options + result types for the branch-1 (OMP-fulfilled) shipment status
+ * read-back sync service (#834). The shape mirrors the sibling
+ * `ShipmentStatusSyncService` (#871) so both worker handlers — the
+ * branch-1 and branch-2/3 polls — share a uniform contract.
+ *
+ * @module libs/core/src/shipping/application/types
+ */
+
+export interface FulfillmentStatusSyncOptions {
+  /** Page size for the OrderRecord scan. */
+  limit: number;
+  /** Cursor — the row offset advanced across ticks. Persisted by the worker
+   * handler in `connection_cursors`. */
+  offset?: number;
+  /**
+   * Iteration-window bound — only OrderRecords whose `updatedAt` is within
+   * this many days from now are scanned. Defaults to
+   * `DEFAULT_UPDATED_SINCE_DAYS` (30) when omitted. Operators with longer
+   * fulfillment cadences (B2B-with-approval) can widen via the
+   * scheduler-task config; in v2 this becomes a per-connection setting.
+   */
+  updatedSinceDays?: number;
+}
+
+/**
+ * Default iteration-window bound (days). 30 covers normal B2C cadence;
+ * orders untouched for longer are excluded from the scan. Documented as
+ * the weakest v1 design call — see plan §6 risks.
+ */
+export const DEFAULT_UPDATED_SINCE_DAYS = 30;
+
+export interface FulfillmentStatusSyncResult {
+  /** Records visited this tick. */
+  scanned: number;
+  /** New branch-1 Shipment rows created. */
+  created: number;
+  /** Existing branch-1 Shipment rows patched. */
+  updated: number;
+  /** Records skipped (routing not branch-1, OMP not yet acted, no externalOrderId, …). */
+  skipped: number;
+  /** Records where the per-record processing threw — logged at warn, counted here. */
+  failed: number;
+  /** Total OrderRecords matching the filters (unpaginated). */
+  total: number;
+  /** Next offset to persist for the cursor. `0` when the scan has wrapped. */
+  nextOffset: number;
+}

--- a/libs/core/src/shipping/domain/ports/shipment-repository.port.ts
+++ b/libs/core/src/shipping/domain/ports/shipment-repository.port.ts
@@ -60,6 +60,25 @@ export interface ShipmentRepositoryPort {
   findByProviderShipmentId(providerShipmentId: string): Promise<Shipment | null>;
 
   /**
+   * Branch-1 (#834) idempotency gate. Returns the existing branch-1
+   * Shipment for `(orderId, connectionId)` if one is already projected,
+   * or `null` to greenlight `create()`. Matches the persisted-shape
+   * predicate `orderId = ? AND connectionId = ? AND providerShipmentId
+   * IS NULL` — the same predicate the partial-unique index
+   * `UQ_shipments_branch_one_per_order_conn` enforces at the DB.
+   *
+   * Returns `null` when the order has only non-null-`providerShipmentId`
+   * rows (branches 2/3 — the order is being shipped by InPost / Allegro
+   * Delivery, not the OMP), so the sync service can skip branch-1
+   * projection for non-branch-1 orders even before checking the routing
+   * resolution.
+   */
+  findBranchOneByOrderAndConnection(
+    orderId: string,
+    connectionId: string,
+  ): Promise<Shipment | null>;
+
+  /**
    * Apply a partial patch. Throws `ShipmentNotFoundException` when no
    * row matches `id`. Only fields present on the patch are written;
    * unspecified fields stay untouched.

--- a/libs/core/src/shipping/domain/types/shipment-query.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment-query.types.ts
@@ -30,6 +30,13 @@ export interface ShipmentFilters {
   shippingMethod?: ShippingMethod;
   /** `true` → only shipments with a tracking number; `false` → only those without. */
   hasTracking?: boolean;
+  /**
+   * Branch discriminator at the row level (#834). `true` → only rows with a
+   * provider-issued id (branches 2/3); `false` → only branch-1 projection
+   * rows (no provider id). Used by the branch-1 sync service's find-existing
+   * lookup and by any future read API that wants to filter by branch.
+   */
+  hasProviderShipmentId?: boolean;
   /** Inclusive lower bound on `createdAt`. */
   createdFrom?: Date;
   /** Inclusive upper bound on `createdAt`. */

--- a/libs/core/src/shipping/domain/types/shipment.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment.types.ts
@@ -6,8 +6,19 @@
  * `OfferCreationRecord` discipline — entity-shape changes (added fields,
  * derived behavior) don't silently affect repository callers.
  *
- * Shipments always start at `'draft'`; the repository applies that
- * invariant at write time so the input type captures it.
+ * **Two creation modes** on `CreateShipmentInput`:
+ *
+ * - **Draft mode (default)**: omit `initialStatus`. The repository writes
+ *   the row at `'draft'`. The dispatch path (`ShipmentDispatchService`,
+ *   #835) uses this so a `generateLabel` failure leaves an observable
+ *   `failed` row in `/shipments`. Branches 2/3 follow this path.
+ * - **Atomic-terminal mode (#834)**: pass `initialStatus` (typically a
+ *   non-draft value) + the matching terminal-timestamp field +
+ *   optionally `trackingNumber`. The branch-1 projection path
+ *   (`FulfillmentStatusSyncService`) uses this so the row is born at its
+ *   correct status — no transient draft state to trip the partial-unique
+ *   `(orderId, connectionId) WHERE providerShipmentId IS NULL` index, no
+ *   `draft → terminal` two-write cycle.
  *
  * @module libs/core/src/shipping/domain/types
  */
@@ -18,7 +29,8 @@ import type { ShippingMethod } from './shipping-method.types';
 export interface CreateShipmentInput {
   /** Internal order id (`ol_order_*`). */
   orderId: string;
-  /** Shipping-provider connection that will issue the label. */
+  /** Shipping-provider connection that will issue the label, or the OMP
+   * connection for branch-1 projection rows. */
   connectionId: string;
   /** Which shipping shape this attempt produces. */
   shippingMethod: ShippingMethod;
@@ -29,6 +41,19 @@ export interface CreateShipmentInput {
    * produced the shipment) — distinct from the resolved provider
    * `deliveryMethodId` the adapter sends. */
   sourceDeliveryMethodId?: string;
+  /** Atomic-terminal mode (#834). Defaults to `'draft'` (the dispatch
+   * path's existing behaviour). Branch-1 projection sets this to the
+   * snapshot's status at create-time so the row is born correct. */
+  initialStatus?: ShipmentStatus;
+  /** Atomic-terminal mode (#834). Backfill the row's tracking number at
+   * create-time. */
+  trackingNumber?: string;
+  /** Atomic-terminal mode (#834). Set when `initialStatus === 'dispatched'`. */
+  dispatchedAt?: Date;
+  /** Atomic-terminal mode (#834). Set when `initialStatus === 'delivered'`. */
+  deliveredAt?: Date;
+  /** Atomic-terminal mode (#834). Set when `initialStatus === 'cancelled'`. */
+  cancelledAt?: Date;
 }
 
 /**

--- a/libs/core/src/shipping/domain/types/shipping-method.types.ts
+++ b/libs/core/src/shipping/domain/types/shipping-method.types.ts
@@ -1,24 +1,35 @@
 /**
  * Shipping Method Types
  *
- * Discriminates the kind of shipment a `ShippingProviderManagerPort`
- * adapter can produce. Each value corresponds to a different ShipX (or
- * equivalent) endpoint shape on the provider side. The runtime-discoverable
- * answer to "what shipment kinds does this adapter support?" is
- * `ShippingProviderManagerPort.getSupportedMethods()`, which returns a
- * `readonly ShippingMethod[]`.
+ * Discriminates the kind of shipment OL persists on a `Shipment` row. The
+ * runtime-discoverable answer to "what shipment kinds does a given
+ * `ShippingProviderManagerPort` adapter support?" is
+ * `getSupportedMethods()`, which returns a `readonly ShippingMethod[]`.
  *
- * Future adapters (e.g. #732 Allegro Delivery) may add new values here as
- * new shipping models surface. Removing a value requires a coordinated
- * migration; adding one is a forward-compatible change.
+ * Two flavours of value live in the same union:
+ *
+ * - **Provider-issued methods** — `paczkomat`, `kurier` (and future ones
+ *   for #732 Allegro Delivery): each maps to a different ShipX endpoint
+ *   shape on the provider side, and a label-issuing
+ *   `ShippingProviderManagerPort` adapter is the row's authoritative
+ *   writer.
+ * - **Projection-only methods** — `omp` (#834, ADR-012): branch-1
+ *   shipments where the destination OMP ships externally and OL holds no
+ *   provider id, no `labelPdfRef`. The row exists as a *projection* of
+ *   the OMP's state, populated by `FulfillmentStatusSyncService`. No
+ *   `ShippingProviderManagerPort` ever advertises `omp`.
+ *
+ * Adding a new provider-issued value is a forward-compatible change;
+ * removing any value requires a coordinated migration.
  *
  * @module libs/core/src/shipping/domain/types
  */
 
-export const ShippingMethodValues = ['paczkomat', 'kurier'] as const;
+export const ShippingMethodValues = ['paczkomat', 'kurier', 'omp'] as const;
 export type ShippingMethod = (typeof ShippingMethodValues)[number];
 
 export const SHIPPING_METHOD = {
   Paczkomat: 'paczkomat',
   Kurier: 'kurier',
-} as const satisfies Record<'Paczkomat' | 'Kurier', ShippingMethod>;
+  Omp: 'omp',
+} as const satisfies Record<'Paczkomat' | 'Kurier' | 'Omp', ShippingMethod>;

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -86,6 +86,12 @@ export { isShipmentCanceller } from './domain/ports/capabilities/shipment-cancel
 export type { PickupPointFinder } from './domain/ports/capabilities/pickup-point-finder.capability';
 export { isPickupPointFinder } from './domain/ports/capabilities/pickup-point-finder.capability';
 
+// `FulfillmentStatusReader` (#834) lives in `@openlinker/core/orders`
+// alongside `OrderFulfillmentUpdater` (#858) — both are sub-capabilities of
+// `OrderProcessorManagerPort` and follow the same placement convention.
+// The shipping context's `FulfillmentStatusSyncService` consumes it and
+// projects the OMP's view onto the shipping-owned `ShipmentStatus`.
+
 // Domain exceptions
 export { ShipmentNotFoundException } from './domain/exceptions/shipment-not-found.exception';
 export { UndispatchableResolutionException } from './domain/exceptions/undispatchable-resolution.exception';
@@ -127,3 +133,14 @@ export type {
   ShipmentStatusSyncOptions,
   ShipmentStatusSyncResult,
 } from './application/types/shipment-status-sync.types';
+
+// Application — branch-1 fulfillment-status-sync seam (#834). Interface +
+// result types only; the service is injected via
+// FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN. Sister-service to
+// ShipmentStatusSyncService; disjoint by branch (branch-1 vs branches 2/3).
+export type { IFulfillmentStatusSyncService } from './application/interfaces/fulfillment-status-sync.service.interface';
+export type {
+  FulfillmentStatusSyncOptions,
+  FulfillmentStatusSyncResult,
+} from './application/types/fulfillment-status-sync.types';
+export { DEFAULT_UPDATED_SINCE_DAYS } from './application/types/fulfillment-status-sync.types';

--- a/libs/core/src/shipping/infrastructure/persistence/entities/shipment.orm-entity.ts
+++ b/libs/core/src/shipping/infrastructure/persistence/entities/shipment.orm-entity.ts
@@ -36,6 +36,17 @@ import { ShippingMethod } from '../../../domain/types/shipping-method.types';
   unique: true,
   where: '"providerShipmentId" IS NOT NULL',
 })
+// Branch-1 (#834) dedup guard. At most one branch-1 Shipment per
+// `(orderId, connectionId)` — `providerShipmentId IS NULL` selects the
+// branch-1 set; branches 2/3 carry a non-null provider id and are
+// disambiguated by the sibling `UQ_shipments_providerShipmentId` above.
+// The `FulfillmentStatusSyncService` find-then-create gate is not
+// atomic; this index is the DB-side backstop against concurrent ticks
+// racing on the same order.
+@Index('UQ_shipments_branch_one_per_order_conn', ['orderId', 'connectionId'], {
+  unique: true,
+  where: '"providerShipmentId" IS NULL',
+})
 export class ShipmentOrmEntity {
   @PrimaryColumn({ type: 'text' })
   id!: string;

--- a/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.spec.ts
+++ b/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.spec.ts
@@ -112,6 +112,29 @@ describe('ShipmentRepository', () => {
       expect(result.shippingMethod).toBe('kurier');
       expect(result.paczkomatId).toBeNull();
     });
+
+    it('should support the branch-1 atomic-terminal mode (#834) — initialStatus + terminal timestamps + trackingNumber at create time', async () => {
+      ormRepository.save.mockImplementation((entity) =>
+        Promise.resolve(entity as ShipmentOrmEntity),
+      );
+      const deliveredAt = new Date('2026-05-28T12:00:00.000Z');
+
+      const result = await repository.create({
+        orderId: 'ol_order_b1',
+        connectionId: '00000000-0000-0000-0000-000000000001',
+        shippingMethod: 'omp',
+        initialStatus: 'delivered',
+        trackingNumber: 'PS-TRK-9',
+        deliveredAt,
+      });
+
+      expect(result.status).toBe('delivered');
+      expect(result.providerShipmentId).toBeNull();
+      expect(result.trackingNumber).toBe('PS-TRK-9');
+      expect(result.deliveredAt).toEqual(deliveredAt);
+      expect(result.dispatchedAt).toBeNull();
+      expect(result.cancelledAt).toBeNull();
+    });
   });
 
   describe('findById', () => {
@@ -228,6 +251,41 @@ describe('ShipmentRepository', () => {
       ormRepository.findOne.mockResolvedValue(null);
 
       const result = await repository.findByProviderShipmentId('UNKNOWN');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findBranchOneByOrderAndConnection (#834)', () => {
+    it('should match the partial-unique-index predicate', async () => {
+      ormRepository.findOne.mockResolvedValue(
+        buildOrm({ providerShipmentId: null, shippingMethod: 'omp', status: 'dispatched' }),
+      );
+
+      const result = await repository.findBranchOneByOrderAndConnection(
+        'ol_order_b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1',
+        '00000000-0000-0000-0000-000000000001',
+      );
+
+      expect(result?.providerShipmentId).toBeNull();
+      const args = ormRepository.findOne.mock.calls[0][0];
+      expect(args.where).toMatchObject({
+        orderId: 'ol_order_b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1',
+        connectionId: '00000000-0000-0000-0000-000000000001',
+      });
+      // providerShipmentId is filtered via TypeORM's IsNull() — verify the
+      // type-of marker rather than asserting the raw shape.
+      const where = args.where as { providerShipmentId: unknown };
+      expect(where.providerShipmentId).toBeDefined();
+    });
+
+    it('should return null when no branch-1 row exists', async () => {
+      ormRepository.findOne.mockResolvedValue(null);
+
+      const result = await repository.findBranchOneByOrderAndConnection(
+        'ol_order_none',
+        '00000000-0000-0000-0000-000000000001',
+      );
 
       expect(result).toBeNull();
     });

--- a/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts
+++ b/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts
@@ -98,6 +98,23 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
     return entity ? this.toDomain(entity) : null;
   }
 
+  async findBranchOneByOrderAndConnection(
+    orderId: string,
+    connectionId: string,
+  ): Promise<Shipment | null> {
+    // Matches the partial-unique-index predicate
+    // `UQ_shipments_branch_one_per_order_conn` so the lookup hits exactly
+    // the row the index protects against — at most one row by construction.
+    const entity = await this.repository.findOne({
+      where: {
+        orderId,
+        connectionId,
+        providerShipmentId: IsNull(),
+      },
+    });
+    return entity ? this.toDomain(entity) : null;
+  }
+
   async update(id: string, patch: UpdateShipmentInput): Promise<Shipment> {
     const result = await this.repository.update({ id }, this.buildUpdatePayload(patch));
     if (result.affected === 0) {
@@ -118,15 +135,19 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
     entity.orderId = input.orderId;
     entity.connectionId = input.connectionId;
     entity.shippingMethod = input.shippingMethod;
-    entity.status = 'draft';
+    // Atomic-terminal mode (#834): when `initialStatus` is supplied (the
+    // branch-1 projection path), the row is born at its correct status +
+    // terminal timestamps + tracking number. Default `'draft'` preserves
+    // the dispatch path's two-step `create(draft) → update(generated)` flow.
+    entity.status = input.initialStatus ?? 'draft';
     entity.providerShipmentId = null;
     entity.paczkomatId = input.paczkomatId ?? null;
     entity.sourceDeliveryMethodId = input.sourceDeliveryMethodId ?? null;
-    entity.trackingNumber = null;
+    entity.trackingNumber = input.trackingNumber ?? null;
     entity.labelPdfRef = null;
-    entity.dispatchedAt = null;
-    entity.deliveredAt = null;
-    entity.cancelledAt = null;
+    entity.dispatchedAt = input.dispatchedAt ?? null;
+    entity.deliveredAt = input.deliveredAt ?? null;
+    entity.cancelledAt = input.cancelledAt ?? null;
     entity.failedAt = null;
     entity.errorMessage = null;
     return entity;
@@ -146,6 +167,9 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
     if (filters.shippingMethod !== undefined) where.shippingMethod = filters.shippingMethod;
     if (filters.hasTracking !== undefined) {
       where.trackingNumber = filters.hasTracking ? Not(IsNull()) : IsNull();
+    }
+    if (filters.hasProviderShipmentId !== undefined) {
+      where.providerShipmentId = filters.hasProviderShipmentId ? Not(IsNull()) : IsNull();
     }
     const { createdFrom, createdTo } = filters;
     if (createdFrom !== undefined && createdTo !== undefined) {

--- a/libs/core/src/shipping/shipping.module.ts
+++ b/libs/core/src/shipping/shipping.module.ts
@@ -36,7 +36,9 @@ import { ShipmentCancellationService } from './application/services/shipment-can
 import { PickupPointLookupService } from './application/services/pickup-point-lookup.service';
 import { ShipmentDispatchNotificationService } from './application/services/shipment-dispatch-notification.service';
 import { ShipmentStatusSyncService } from './application/services/shipment-status-sync.service';
+import { FulfillmentStatusSyncService } from './application/services/fulfillment-status-sync.service';
 import {
+  FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,
   PICKUP_POINT_CACHE_TOKEN,
   PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
   SHIPMENT_CANCELLATION_SERVICE_TOKEN,
@@ -103,6 +105,13 @@ import {
       provide: SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
       useExisting: ShipmentStatusSyncService,
     },
+    // #834 branch-1 (OMP-fulfilled) shipment status read-back. Sole creator
+    // + updater of branch-1 Shipment rows (projection-only semantics).
+    FulfillmentStatusSyncService,
+    {
+      provide: FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,
+      useExisting: FulfillmentStatusSyncService,
+    },
   ],
   exports: [
     SHIPMENT_REPOSITORY_TOKEN,
@@ -113,6 +122,7 @@ import {
     PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
     SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
     SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
+    FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,
   ],
 })
 export class ShippingModule {}

--- a/libs/core/src/shipping/shipping.tokens.ts
+++ b/libs/core/src/shipping/shipping.tokens.ts
@@ -20,3 +20,4 @@ export const SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN = Symbol(
   'IShipmentDispatchNotificationService',
 );
 export const SHIPMENT_STATUS_SYNC_SERVICE_TOKEN = Symbol('IShipmentStatusSyncService');
+export const FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN = Symbol('IFulfillmentStatusSyncService');

--- a/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
@@ -231,3 +231,34 @@ export interface MarketplaceShipmentStatusSyncPayloadV1 {
    */
   cursorKey?: string;
 }
+
+/**
+ * marketplace.fulfillment.statusSync (#834)
+ *
+ * Branch-1 (OMP-fulfilled) shipment status read-back. The handler pages OL
+ * Order Records mirrored to this OMP connection, reads each one's
+ * PrestaShop state via the `FulfillmentStatusReader` capability, and
+ * projects branch-1 `Shipment` rows. Mirrors
+ * `MarketplaceShipmentStatusSyncPayloadV1` in shape — both are rolling
+ * scan-offset polls — but disjoint in scope (branch-1 vs branches 2/3).
+ *
+ * Cursor key default (when omitted) is
+ * `prestashop.fulfillmentStatus.scanOffset`.
+ */
+export interface MarketplaceFulfillmentStatusSyncPayloadV1 {
+  schemaVersion: 1;
+  /** Page size: number of OrderRecords to scan per run. */
+  limit: number;
+  /**
+   * Connection-cursor key under which the rolling numeric scan offset is
+   * persisted. Omitted → the handler falls back to
+   * `prestashop.fulfillmentStatus.scanOffset`.
+   */
+  cursorKey?: string;
+  /**
+   * Iteration-window bound (days). Records whose `updatedAt` is older than
+   * this many days are skipped. Defaults to `DEFAULT_UPDATED_SINCE_DAYS` (30)
+   * inside the service when omitted.
+   */
+  updatedSinceDays?: number;
+}

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -24,6 +24,7 @@ export const JobTypeValues = [
   'marketplace.offer.pollCreationStatus',
   'marketplace.offer.statusSync',
   'marketplace.shipment.statusSync',
+  'marketplace.fulfillment.statusSync',
   'master.product.syncByExternalId',
   'master.product.syncAll',
   'master.inventory.syncByExternalId',

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -69,6 +69,7 @@ export {
   MarketplaceOfferPollCreationStatusPayloadV1,
   MarketplaceOfferStatusSyncPayloadV1,
   MarketplaceShipmentStatusSyncPayloadV1,
+  MarketplaceFulfillmentStatusSyncPayloadV1,
   OfferDescriptionTone,
 } from './domain/types/marketplace-job-payloads.types';
 export { OfferDescriptionToneValues } from './domain/types/marketplace-job-payloads.types';

--- a/libs/integrations/prestashop/src/__tests__/prestashop-plugin.spec.ts
+++ b/libs/integrations/prestashop/src/__tests__/prestashop-plugin.spec.ts
@@ -161,10 +161,20 @@ describe('createPrestashopPlugin → register(host)', () => {
       identifierMapping: {} as IdentifierMappingPort,
       credentialsResolver: {} as CredentialsResolverPort,
       cache: undefined,
+      // Minimal logger stub — `register()` may emit a `debug` line on the
+      // no-ConfigService path (#834). Return an object with the four
+      // LogLevel methods so any of them are safely callable.
+      logger: jest.fn().mockReturnValue({
+        log: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      }),
       connectionTesterRegistry: { register: jest.fn() },
       webhookProvisioningRegistry: { register: jest.fn() },
       connectionConfigShapeValidatorRegistry: configRegistry,
       connectionCredentialsShapeValidatorRegistry: credentialsRegistry,
+      schedulerTaskRegistry: { register: jest.fn() },
     } as unknown as HostServices;
     return { host, configRegistry, credentialsRegistry };
   }

--- a/libs/integrations/prestashop/src/domain/types/prestashop-options.types.ts
+++ b/libs/integrations/prestashop/src/domain/types/prestashop-options.types.ts
@@ -50,10 +50,26 @@ export interface PrestashopCarrier {
 /**
  * `GET /order_states` row. `name` may be a flat string (single-lang PS
  * config) or the multi-lang shape (`{ language: [{ '#text': … }] }`).
+ *
+ * The three boolean discriminator columns (`delivered`, `shipped`, `paid`)
+ * are PS's own canonical "what does this state mean" flags — PrestaShop
+ * uses them internally to decide whether to render a tracking link, send
+ * a shipped-email, etc. The branch-1 fulfillment-status mapper (#834)
+ * reads them as the primary discriminator instead of name-matching the
+ * `name` field (which is brittle under multi-language configs and
+ * operator-renamed states). PS Webservice returns them as `'0'`/`'1'`
+ * string values.
  */
 export interface PrestashopOrderState {
   id: string;
   name: PrestashopLanguageField;
   deleted: string | number;
+  /** `'1'` ⇔ the state means "the customer has the package" (#834). */
+  delivered?: string | number;
+  /** `'1'` ⇔ the state means "handed off to carrier" (#834). */
+  shipped?: string | number;
+  /** `'1'` ⇔ the state means "payment captured" — informational; not used
+   * by the v1 fulfillment-status mapper (#834). */
+  paid?: string | number;
 }
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
@@ -11,7 +11,10 @@ import { PrestashopOrderProcessorManagerAdapter } from '../prestashop-order-proc
 import { createMockHttpClient } from '../../../__tests__/mocks/mock-http-client.factory';
 import { createMockIdentifierMapping } from '../../../__tests__/mocks/mock-identifier-mapping.factory';
 import { createTestConnection } from '../../../__tests__/fixtures/connection.fixture';
-import { PrestashopApiException } from '@openlinker/integrations-prestashop';
+import {
+  PrestashopApiException,
+  PrestashopResourceNotFoundException,
+} from '@openlinker/integrations-prestashop';
 import type { IPrestashopWebserviceClient } from '../../http/prestashop-webservice.client.interface';
 import type { IPrestashopOpenLinkerModuleClient } from '../../http/prestashop-openlinker-module.client.interface';
 import { PrestashopOlModuleException } from '../../../domain/exceptions/prestashop-ol-module.exception';
@@ -1798,6 +1801,147 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       await expect(
         adapter.updateFulfillment({ externalOrderId: PS_ORDER_ID, status: 'shipped' })
       ).rejects.toBeInstanceOf(PrestashopApiException);
+    });
+  });
+
+  describe('getFulfillmentStatus (#834 — FulfillmentStatusReader)', () => {
+    const PS_ORDER_ID = '5001';
+
+    /**
+     * Stub PS `getResource`/`listResources` paths needed by the
+     * fulfillment-status read. The state map is loaded lazily on the first
+     * `getFulfillmentStatus` call; subsequent calls reuse the cache, so the
+     * `order_states` listResources call should fire exactly **once** per
+     * adapter instance. Verified explicitly in the dedicated cache test.
+     */
+    beforeEach(() => {
+      mockHttpClient.getResource = jest.fn().mockImplementation(
+        (resource: string, _id: string | number) => {
+          if (resource === 'orders') {
+            return Promise.resolve({
+              id: PS_ORDER_ID,
+              current_state: '5',
+              date_upd: '2026-05-28 14:00:00',
+              shipping_number: 'PS-TRK-1',
+            } as PrestashopOrder);
+          }
+          return Promise.resolve(null);
+        }
+      );
+      // Keep the carrier-mapping path from the parent beforeEach intact,
+      // add the order_states + order_carriers branches.
+      mockHttpClient.listResources = jest
+        .fn()
+        .mockImplementation((resource: string, params?: { custom?: Record<string, unknown> }) => {
+          if (resource === 'carriers' && params?.custom?.external_module_name === 'openlinker') {
+            return Promise.resolve([{ id: OL_DYNAMIC_CARRIER_ID, active: '1', deleted: '0' }]);
+          }
+          if (resource === 'order_states') {
+            return Promise.resolve([
+              { id: '4', name: 'Awaiting payment', deleted: '0' },
+              { id: '5', name: 'Shipped', deleted: '0', shipped: '1' },
+              { id: '6', name: 'Delivered', deleted: '0', delivered: '1', shipped: '1' },
+              { id: '7', name: 'Cancelled', deleted: '0' },
+            ]);
+          }
+          if (resource === 'order_carriers') {
+            return Promise.resolve([]);
+          }
+          return Promise.resolve([]);
+        });
+    });
+
+    it('should project PS state.shipped=1 onto FulfillmentStatus.Dispatched with tracking', async () => {
+      const snapshot = await adapter.getFulfillmentStatus({ externalOrderId: PS_ORDER_ID });
+
+      expect(snapshot.status).toBe('dispatched');
+      expect(snapshot.trackingNumber).toBe('PS-TRK-1');
+      expect(snapshot.deliveredAt).toBeNull();
+    });
+
+    it('should cache the order_states map across calls (one listResources(order_states) per adapter instance)', async () => {
+      await adapter.getFulfillmentStatus({ externalOrderId: PS_ORDER_ID });
+      await adapter.getFulfillmentStatus({ externalOrderId: PS_ORDER_ID });
+      await adapter.getFulfillmentStatus({ externalOrderId: PS_ORDER_ID });
+
+      const orderStatesCalls = (mockHttpClient.listResources as jest.Mock).mock.calls.filter(
+        (call: unknown[]) => call[0] === 'order_states'
+      );
+      expect(orderStatesCalls).toHaveLength(1);
+    });
+
+    it('should NOT fetch order_carriers when order.shipping_number is set (lazy WS optimisation)', async () => {
+      // The default `beforeEach` returns an order with `shipping_number: 'PS-TRK-1'`,
+      // so the carriers fetch should be skipped entirely.
+      await adapter.getFulfillmentStatus({ externalOrderId: PS_ORDER_ID });
+      await adapter.getFulfillmentStatus({ externalOrderId: PS_ORDER_ID });
+
+      const orderCarriersCalls = (mockHttpClient.listResources as jest.Mock).mock.calls.filter(
+        (call: unknown[]) => call[0] === 'order_carriers'
+      );
+      expect(orderCarriersCalls).toHaveLength(0);
+    });
+
+    it('should fetch order_carriers as fallback when shipping_number is empty', async () => {
+      // Re-stub `getResource` so the order has NO shipping_number.
+      mockHttpClient.getResource = jest.fn().mockResolvedValue({
+        id: PS_ORDER_ID,
+        current_state: '5',
+        date_upd: '2026-05-28 14:00:00',
+        // no shipping_number
+      } as PrestashopOrder);
+      // Carriers row with tracking — the mapper should pick it up.
+      (mockHttpClient.listResources as jest.Mock).mockImplementation(
+        (resource: string, params?: { custom?: Record<string, unknown> }) => {
+          if (resource === 'carriers' && params?.custom?.external_module_name === 'openlinker') {
+            return Promise.resolve([{ id: OL_DYNAMIC_CARRIER_ID, active: '1', deleted: '0' }]);
+          }
+          if (resource === 'order_states') {
+            return Promise.resolve([
+              { id: '5', name: 'Shipped', deleted: '0', shipped: '1' },
+            ]);
+          }
+          if (resource === 'order_carriers') {
+            return Promise.resolve([
+              { id: '10', id_order: PS_ORDER_ID, id_carrier: '1', tracking_number: 'CARR-TRK-9' },
+            ]);
+          }
+          return Promise.resolve([]);
+        },
+      );
+
+      const snapshot = await adapter.getFulfillmentStatus({ externalOrderId: PS_ORDER_ID });
+
+      expect(snapshot.trackingNumber).toBe('CARR-TRK-9');
+      const orderCarriersCalls = (mockHttpClient.listResources as jest.Mock).mock.calls.filter(
+        (call: unknown[]) => call[0] === 'order_carriers'
+      );
+      expect(orderCarriersCalls).toHaveLength(1);
+    });
+
+    it('should issue WS calls with the documented resource shapes', async () => {
+      await adapter.getFulfillmentStatus({ externalOrderId: PS_ORDER_ID });
+
+      expect(mockHttpClient.getResource).toHaveBeenCalledWith('orders', PS_ORDER_ID);
+      expect(mockHttpClient.listResources).toHaveBeenCalledWith(
+        'order_states',
+        { custom: { deleted: '0' } },
+        1000,
+        0
+      );
+      // order_carriers is NOT called here — shipping_number was set on the order.
+    });
+
+    it('should swallow PrestashopResourceNotFoundException as `{status: null}` (order deleted in PS)', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockRejectedValue(new PrestashopResourceNotFoundException('orders', PS_ORDER_ID));
+
+      const snapshot = await adapter.getFulfillmentStatus({ externalOrderId: PS_ORDER_ID });
+
+      expect(snapshot.status).toBeNull();
+      expect(snapshot.trackingNumber).toBeNull();
+      expect(snapshot.deliveredAt).toBeNull();
     });
   });
 });

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -20,6 +20,15 @@ import type {
   OrderStatus,
   MappingOption,
 } from '@openlinker/core/orders';
+import type {
+  FulfillmentStatusReader,
+  FulfillmentStatusSnapshot,
+} from '@openlinker/core/orders';
+import {
+  extractTrackingFromCarriers,
+  extractTrackingFromOrder,
+  mapToFulfillmentStatusSnapshot,
+} from '../mappers/prestashop-fulfillment-status.mapper';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { MappingAlreadyExistsError, DuplicateIdentifierMappingError, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { IMappingConfigService } from '@openlinker/core/mappings';
@@ -66,9 +75,33 @@ interface PrestashopCarrierRow {
  * Handles order creation in PrestaShop via WebService API.
  */
 export class PrestashopOrderProcessorManagerAdapter
-  implements OrderProcessorManagerPort, DestinationOptionsReader, OrderFulfillmentUpdater
+  implements
+    OrderProcessorManagerPort,
+    DestinationOptionsReader,
+    OrderFulfillmentUpdater,
+    FulfillmentStatusReader
 {
   private readonly logger = new Logger(PrestashopOrderProcessorManagerAdapter.name);
+
+  /**
+   * Per-instance lazy cache of `GET /api/order_states` rows keyed by id —
+   * used by `getFulfillmentStatus` to look up the order's current state
+   * row by `current_state` (#834). One PS WS list call per adapter
+   * instance.
+   *
+   * Lifetime contract (verified against
+   * `libs/core/src/integrations/application/services/integrations.service.ts`):
+   * `IntegrationsService.getCapabilityAdapter` constructs a fresh adapter
+   * via the factory resolver on every call — no instance cache. The
+   * branch-1 sync service (#834) resolves this adapter once per page and
+   * reuses it for every record in the page, so this cache amortises one
+   * `order_states` WS call across the whole page and is discarded when
+   * the sync invocation returns. If a future refactor of
+   * `getCapabilityAdapter` introduces adapter-instance caching across
+   * ticks, revisit this cache — operator-added PS states would persist
+   * stale here.
+   */
+  private orderStatesById: Map<string, PrestashopOrderState> | null = null;
 
   constructor(
     private readonly httpClient: IPrestashopWebserviceClient,
@@ -661,6 +694,81 @@ export class PrestashopOrderProcessorManagerAdapter
         this.connection.id
       );
     }
+  }
+
+  /**
+   * Branch-1 (#834) `FulfillmentStatusReader` implementation. Reads the PS
+   * order, looks up the matching `order_state` row via a per-instance lazy
+   * cache (one WS list call per adapter instance), reads the order's
+   * `order_carriers` for tracking fallback, and delegates to the pure
+   * mapper.
+   *
+   * Returns `{ status: null, ... }` when PS hasn't reached a shipping-
+   * related state (the projection-only "skip this record this pass"
+   * signal). Returns `{ status: 'delivered' | 'dispatched' | 'cancelled', ... }`
+   * once PS has acted, with tracking number and (for delivered) the
+   * `date_upd` timestamp threaded through.
+   */
+  async getFulfillmentStatus(input: {
+    externalOrderId: string;
+  }): Promise<FulfillmentStatusSnapshot> {
+    const { externalOrderId } = input;
+    try {
+      const order = await this.httpClient.getResource<PrestashopOrder>(
+        'orders',
+        externalOrderId,
+      );
+      const stateId = order.current_state !== undefined ? String(order.current_state) : null;
+      const state = stateId !== null ? await this.lookupOrderState(stateId) : null;
+      // Lazy carriers fetch: most PS configurations populate `shipping_number`
+      // directly on the order when the operator prints the label, so the
+      // carriers WS call is unnecessary for the majority of records. Skip
+      // it whenever we already have a value — halves PS API pressure at
+      // scale without changing observable behaviour.
+      const trackingFromOrder = extractTrackingFromOrder(order);
+      const trackingNumber =
+        trackingFromOrder ?? extractTrackingFromCarriers(
+          await this.httpClient.listResources<PrestashopOrderCarrier>('order_carriers', {
+            custom: { id_order: externalOrderId },
+          }),
+        );
+      return mapToFulfillmentStatusSnapshot(order, state, trackingNumber);
+    } catch (error) {
+      if (error instanceof PrestashopResourceNotFoundException) {
+        // Order was deleted PS-side after OL mirrored it. Treat as
+        // "OMP hasn't acted" — the sync service skips, the row stays
+        // visible in /orders, and operator action surfaces the missing
+        // order through the dispatch-notify failure path (#871) if any
+        // branch-2/3 sibling exists.
+        this.logger.warn(
+          `PrestaShop order ${externalOrderId} not found during fulfillment-status read (connection: ${this.connection.id})`,
+        );
+        return { status: null, trackingNumber: null, deliveredAt: null };
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Look up an `order_state` row by id, lazy-loading the full map on first
+   * call. Returns `null` for unknown ids (orphaned `current_state` — treat
+   * as "not yet acted" per the mapper's `state === null` branch).
+   */
+  private async lookupOrderState(stateId: string): Promise<PrestashopOrderState | null> {
+    if (this.orderStatesById === null) {
+      const rows = await this.httpClient.listResources<PrestashopOrderState>(
+        'order_states',
+        { custom: { deleted: '0' } },
+        1000,
+        0,
+      );
+      const map = new Map<string, PrestashopOrderState>();
+      for (const row of rows) {
+        map.set(String(row.id), row);
+      }
+      this.orderStatesById = map;
+    }
+    return this.orderStatesById.get(stateId) ?? null;
   }
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-fulfillment-status.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-fulfillment-status.mapper.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit specs for the PrestaShop fulfillment-status mapper (#834).
+ *
+ * Two layers:
+ *   1. `mapToFulfillmentStatusSnapshot(order, state, trackingNumber)` —
+ *      status projection + delivered-timestamp threading.
+ *   2. `extractTrackingFromOrder` / `extractTrackingFromCarriers` — the
+ *      tracking-resolution helpers the adapter chains lazily.
+ */
+import { FULFILLMENT_STATUS } from '@openlinker/core/orders';
+
+import {
+  extractTrackingFromCarriers,
+  extractTrackingFromOrder,
+  mapToFulfillmentStatusSnapshot,
+} from './prestashop-fulfillment-status.mapper';
+import type {
+  PrestashopOrder,
+  PrestashopOrderCarrier,
+} from './prestashop.mapper.interface';
+import type { PrestashopOrderState } from '../../domain/types/prestashop-options.types';
+
+function makeOrder(overrides: Partial<PrestashopOrder> = {}): PrestashopOrder {
+  return {
+    id: '1',
+    reference: 'REF',
+    current_state: '2',
+    date_upd: '2026-05-28 12:00:00',
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<PrestashopOrderState> = {}): PrestashopOrderState {
+  return {
+    id: '2',
+    name: 'Awaiting payment',
+    deleted: '0',
+    ...overrides,
+  };
+}
+
+function makeOrderCarrier(
+  overrides: Partial<PrestashopOrderCarrier> = {},
+): PrestashopOrderCarrier {
+  return {
+    id: '1',
+    id_order: '1',
+    id_carrier: '1',
+    ...overrides,
+  };
+}
+
+describe('mapToFulfillmentStatusSnapshot', () => {
+  describe('delivered branch', () => {
+    it('should return Delivered with deliveredAt = date_upd when state.delivered = 1', () => {
+      const order = makeOrder({ date_upd: '2026-05-28 14:00:00' });
+      const state = makeState({ delivered: '1' });
+
+      const snapshot = mapToFulfillmentStatusSnapshot(order, state, null);
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Delivered);
+      expect(snapshot.deliveredAt).toEqual(new Date('2026-05-28 14:00:00'));
+    });
+
+    it('should prefer delivered over shipped when both flags are set', () => {
+      const state = makeState({ delivered: '1', shipped: '1' });
+
+      const snapshot = mapToFulfillmentStatusSnapshot(makeOrder(), state, null);
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Delivered);
+    });
+  });
+
+  describe('dispatched branch', () => {
+    it('should return Dispatched when shipped = 1 and delivered != 1', () => {
+      const state = makeState({ shipped: '1' });
+
+      const snapshot = mapToFulfillmentStatusSnapshot(makeOrder(), state, null);
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Dispatched);
+      // dispatchedAt threading is the sync service's job — the snapshot
+      // carries only deliveredAt for delivered transitions.
+      expect(snapshot.deliveredAt).toBeNull();
+    });
+  });
+
+  describe('cancelled branch (regex fallback)', () => {
+    it.each([
+      ['Cancelled', 'Cancelled'],
+      ['English cancel state', 'Cancel pending'],
+      ['French annulé', 'Annulé'],
+      ['Spanish anulado', 'Anulado'],
+      ['Italian annullato', 'Annullato'],
+      ['Portuguese cancelado', 'Cancelado'],
+      ['Romanian anulat', 'Anulat'],
+      ['Polish anulowano', 'Anulowano'],
+      ['Czech storno', 'Storno'],
+      ['German abgebrochen', 'Abgebrochen'],
+      ['English rejected', 'Rejected'],
+    ])('should match cancel-regex for %s ("%s")', (_label, name) => {
+      const state = makeState({ name });
+
+      const snapshot = mapToFulfillmentStatusSnapshot(makeOrder(), state, null);
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Cancelled);
+    });
+
+    it.each([
+      ['Hungarian törölt', 'Törölt'],
+      ['Russian Cyrillic отменён', 'Отменён'],
+    ])(
+      'should NOT match cancel for %s ("%s") — documented gap pending #862',
+      (_label, name) => {
+        const state = makeState({ name });
+
+        const snapshot = mapToFulfillmentStatusSnapshot(makeOrder(), state, null);
+
+        // Non-Latin-script cancellation labels miss the regex by design.
+        // This test documents the gap so a future change to the cancel
+        // regex is deliberate, not accidental.
+        expect(snapshot.status).toBeNull();
+      },
+    );
+
+    it('should match cancel against multilingual-shape `name`', () => {
+      const state = makeState({
+        name: {
+          language: [
+            { '#text': 'Awaiting payment' },
+            { '#text': 'Anulowano' },
+          ],
+        } as unknown as PrestashopOrderState['name'],
+      });
+
+      const snapshot = mapToFulfillmentStatusSnapshot(makeOrder(), state, null);
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Cancelled);
+    });
+  });
+
+  describe('null branch — OMP has not acted', () => {
+    it('should return status null when no flags are set and name does not match cancel', () => {
+      const state = makeState({ name: 'Awaiting payment' });
+
+      const snapshot = mapToFulfillmentStatusSnapshot(makeOrder(), state, null);
+
+      expect(snapshot.status).toBeNull();
+      expect(snapshot.deliveredAt).toBeNull();
+    });
+
+    it('should return status null when state is null (orphaned current_state)', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot(makeOrder(), null, null);
+
+      expect(snapshot.status).toBeNull();
+    });
+  });
+
+  describe('tracking-number passthrough', () => {
+    it('should thread the pre-resolved trackingNumber onto the snapshot verbatim', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot(
+        makeOrder(),
+        makeState({ delivered: '1' }),
+        'PS-TRK-1',
+      );
+
+      expect(snapshot.trackingNumber).toBe('PS-TRK-1');
+    });
+
+    it('should pass null through when no tracking was resolved upstream', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot(
+        makeOrder(),
+        makeState({ shipped: '1' }),
+        null,
+      );
+
+      expect(snapshot.trackingNumber).toBeNull();
+    });
+  });
+
+  describe('boolean-flag parsing', () => {
+    it.each(['1', 1, 'true'])(
+      'should treat value %p as truthy on delivered',
+      (truthyValue) => {
+        const state = makeState({ delivered: truthyValue });
+
+        const snapshot = mapToFulfillmentStatusSnapshot(makeOrder(), state, null);
+
+        expect(snapshot.status).toBe(FULFILLMENT_STATUS.Delivered);
+      },
+    );
+
+    it.each(['0', 0, ''])('should treat value %p as falsy on shipped', (falsyValue) => {
+      const state = makeState({ shipped: falsyValue });
+
+      const snapshot = mapToFulfillmentStatusSnapshot(makeOrder(), state, null);
+
+      expect(snapshot.status).toBeNull();
+    });
+  });
+});
+
+describe('extractTrackingFromOrder', () => {
+  it('should return shipping_number when present and non-empty', () => {
+    expect(extractTrackingFromOrder(makeOrder({ shipping_number: 'PS-TRK-1' }))).toBe('PS-TRK-1');
+  });
+
+  it('should return null when shipping_number is absent', () => {
+    expect(extractTrackingFromOrder(makeOrder())).toBeNull();
+  });
+
+  it('should return null when shipping_number is empty string', () => {
+    expect(extractTrackingFromOrder(makeOrder({ shipping_number: '' }))).toBeNull();
+  });
+
+  it('should return null for non-string shipping_number (defensive narrowing)', () => {
+    expect(
+      extractTrackingFromOrder(makeOrder({ shipping_number: 42 as unknown as string })),
+    ).toBeNull();
+  });
+});
+
+describe('extractTrackingFromCarriers', () => {
+  it('should return the first non-empty tracking_number across rows', () => {
+    const carriers = [
+      makeOrderCarrier({ id: '1', tracking_number: undefined }),
+      makeOrderCarrier({ id: '2', tracking_number: 'CARRIER-TRK-2' }),
+      makeOrderCarrier({ id: '3', tracking_number: 'CARRIER-TRK-3' }),
+    ];
+
+    expect(extractTrackingFromCarriers(carriers)).toBe('CARRIER-TRK-2');
+  });
+
+  it('should return null when no row has a tracking_number', () => {
+    expect(extractTrackingFromCarriers([makeOrderCarrier(), makeOrderCarrier()])).toBeNull();
+  });
+
+  it('should return null for an empty rows array', () => {
+    expect(extractTrackingFromCarriers([])).toBeNull();
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-fulfillment-status.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-fulfillment-status.mapper.ts
@@ -1,0 +1,171 @@
+/**
+ * PrestaShop Fulfillment Status Mapper
+ *
+ * Pure mappers from PrestaShop's order + state model to the neutral
+ * `FulfillmentStatusSnapshot` (#834). Three exported helpers, all sync +
+ * side-effect-free:
+ *
+ *   - `mapToFulfillmentStatusSnapshot(order, state, trackingNumber)` —
+ *     the projection mapping; takes a pre-resolved `trackingNumber` so the
+ *     caller controls whether the carriers WS fetch was needed.
+ *   - `extractTrackingFromOrder(order)` — read the legacy on-order
+ *     `shipping_number` field (`null` if absent/empty).
+ *   - `extractTrackingFromCarriers(orderCarriers)` — first non-empty
+ *     `tracking_number` across the supplied carrier rows.
+ *
+ * The split lets `PrestashopOrderProcessorManagerAdapter.getFulfillmentStatus`
+ * lazy-fetch `order_carriers` only when `shipping_number` is empty —
+ * halving WS round-trips at scale, since most operators populate
+ * `shipping_number` directly when they print the label.
+ *
+ * **Status mapping rules** (conservative v1):
+ *
+ * - `state.delivered === '1'` → `'delivered'` (+ `deliveredAt = order.date_upd`).
+ * - `state.shipped === '1' && state.delivered !== '1'` → `'dispatched'`
+ *   (PS has handed off to carrier).
+ * - `state.name` matches cancel-regex → `'cancelled'` (the regex-fallback
+ *   gap, pending operator-configurable mapping under #862).
+ *   - **Latin-script coverage**: EN (`cancel/cancelled/rejected`),
+ *     FR (`annulé`), ES (`anulado`), IT (`annullato`), PT (`cancelado`),
+ *     PL (`anulowano`/`anulowane`), CS/SK (`storno`), DE (`abgebrochen`),
+ *     RO (`anulat`).
+ *   - **Known gap — non-Latin scripts**: HU (`törölt`), RU (`отменён`),
+ *     UA, BG. Storefronts in those languages will MISS cancellation
+ *     detection in v1 and the row will stay in `dispatched`. Closed by
+ *     #862's operator-configurable PS→OL state mapping table.
+ * - Otherwise → `status: null` (PS has not yet acted on the order —
+ *   projection-only skip).
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/mappers
+ */
+
+import type {
+  FulfillmentStatus,
+  FulfillmentStatusSnapshot,
+} from '@openlinker/core/orders';
+import { FULFILLMENT_STATUS } from '@openlinker/core/orders';
+
+import type {
+  PrestashopOrder,
+  PrestashopOrderCarrier,
+} from './prestashop.mapper.interface';
+import type { PrestashopOrderState } from '../../domain/types/prestashop-options.types';
+
+const TRUE_VALUES: ReadonlySet<string> = new Set(['1', 'true']);
+const CANCEL_REGEX = /cancel|annul|anul|storno|reject|abge/i;
+
+export function mapToFulfillmentStatusSnapshot(
+  order: PrestashopOrder,
+  state: PrestashopOrderState | null,
+  trackingNumber: string | null,
+): FulfillmentStatusSnapshot {
+  const status = mapStatus(state);
+  const dateUpd = parseDate(order.date_upd);
+  const deliveredAt = status === FULFILLMENT_STATUS.Delivered ? dateUpd : null;
+
+  return {
+    status,
+    trackingNumber,
+    deliveredAt,
+  };
+}
+
+/**
+ * Read the legacy `shipping_number` field directly off the PS order.
+ * Returns `null` when absent / non-string / empty so the caller can fall
+ * back to the carriers fetch without re-narrowing.
+ *
+ * `shipping_number` is not in the typed `PrestashopOrder` surface; it's a
+ * direct-on-order field accessed via the index signature. Narrow `unknown`
+ * per engineering-standards §"Type Safety".
+ */
+export function extractTrackingFromOrder(order: PrestashopOrder): string | null {
+  const shippingNumber = (order as Record<string, unknown>)['shipping_number'];
+  if (typeof shippingNumber === 'string' && shippingNumber.length > 0) {
+    return shippingNumber;
+  }
+  return null;
+}
+
+/**
+ * First non-empty `tracking_number` across the supplied carrier rows, or
+ * `null` if none.
+ */
+export function extractTrackingFromCarriers(
+  orderCarriers: readonly PrestashopOrderCarrier[],
+): string | null {
+  for (const row of orderCarriers) {
+    const tracking = row.tracking_number;
+    if (typeof tracking === 'string' && tracking.length > 0) {
+      return tracking;
+    }
+  }
+  return null;
+}
+
+function mapStatus(state: PrestashopOrderState | null): FulfillmentStatus | null {
+  if (!state) return null;
+  if (isTruthyFlag(state.delivered)) {
+    return FULFILLMENT_STATUS.Delivered;
+  }
+  if (isTruthyFlag(state.shipped)) {
+    return FULFILLMENT_STATUS.Dispatched;
+  }
+  if (matchesCancel(state.name)) {
+    return FULFILLMENT_STATUS.Cancelled;
+  }
+  return null;
+}
+
+function isTruthyFlag(value: string | number | undefined): boolean {
+  if (value === undefined) return false;
+  return TRUE_VALUES.has(String(value));
+}
+
+/**
+ * `PrestashopOrderState.name` is either a flat string (single-language PS
+ * install) or the multi-language shape `{ language: [{ '#text': … }] }` /
+ * `{ language: { '#text': … } }`. Walk the shape and match on any
+ * available label so multilingual stores get correct cancellation
+ * detection without needing the operator to set a specific lang.
+ */
+function matchesCancel(name: PrestashopOrderState['name']): boolean {
+  for (const label of extractAllLabels(name)) {
+    if (CANCEL_REGEX.test(label)) return true;
+  }
+  return false;
+}
+
+function extractAllLabels(name: PrestashopOrderState['name']): readonly string[] {
+  if (typeof name === 'string') return [name];
+  if (name === null || name === undefined) return [];
+  if (typeof name !== 'object') return [];
+  const obj = name as Record<string, unknown>;
+  const language = obj['language'];
+  const labels: string[] = [];
+  if (Array.isArray(language)) {
+    for (const entry of language) {
+      const label = extractTextLabel(entry);
+      if (label) labels.push(label);
+    }
+  } else if (language && typeof language === 'object') {
+    const label = extractTextLabel(language);
+    if (label) labels.push(label);
+  }
+  return labels;
+}
+
+function extractTextLabel(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object') {
+    const text = (value as Record<string, unknown>)['#text'];
+    if (typeof text === 'string') return text;
+  }
+  return null;
+}
+
+function parseDate(value: string | undefined): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}

--- a/libs/integrations/prestashop/src/infrastructure/scheduler/prestashop-scheduler-tasks.ts
+++ b/libs/integrations/prestashop/src/infrastructure/scheduler/prestashop-scheduler-tasks.ts
@@ -1,0 +1,73 @@
+/**
+ * PrestaShop Scheduler Tasks
+ *
+ * Builds the `SchedulerTaskConfig` instances PrestaShop contributes to the
+ * core `SchedulerTaskRegistryService` (#584). One task today:
+ *
+ *   - `prestashop-fulfillment-status-sync` (#834) — branch-1 (OMP-fulfilled)
+ *     shipment status read-back. Reads each mirrored order's PrestaShop
+ *     state via `FulfillmentStatusReader.getFulfillmentStatus` and projects
+ *     branch-1 `Shipment` rows. Default every 15 minutes. Rolling
+ *     scan-offset cursor key `prestashop.fulfillmentStatus.scanOffset`.
+ *
+ * Env-var gating mirrors the Allegro scheduler-tasks shape. The scheduler
+ * also re-checks the gate at each cron tick, so toggling without restart
+ * works for tasks that *did* register at boot.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/scheduler
+ * @see {@link SchedulerTaskConfig} in `@openlinker/core/sync`.
+ */
+import type { ConfigService } from '@nestjs/config';
+import type { SchedulerTaskConfig } from '@openlinker/core/sync';
+
+const isEnabled = (configService: ConfigService, key: string): boolean =>
+  configService.get<string>(key, 'true') !== 'false';
+
+/**
+ * Build the PrestaShop scheduler-task list. Returns 0–1 tasks depending on
+ * the `OL_PRESTASHOP_*_SCHEDULER_ENABLED` env-var gates.
+ */
+export function buildPrestashopSchedulerTasks(
+  configService: ConfigService,
+): SchedulerTaskConfig[] {
+  const tasks: SchedulerTaskConfig[] = [];
+
+  if (
+    isEnabled(configService, 'OL_PRESTASHOP_FULFILLMENT_STATUS_SYNC_SCHEDULER_ENABLED')
+  ) {
+    const cronExpression = configService.get<string>(
+      'OL_PRESTASHOP_FULFILLMENT_STATUS_SYNC_INTERVAL_CRON',
+      '0 */15 * * * *',
+    );
+    const pageLimitRaw = Number(
+      configService.get<string>('OL_PRESTASHOP_FULFILLMENT_STATUS_SYNC_PAGE_LIMIT', '100'),
+    );
+    const pageLimit = Number.isFinite(pageLimitRaw) && pageLimitRaw > 0 ? pageLimitRaw : 100;
+    const updatedSinceDaysRaw = Number(
+      configService.get<string>(
+        'OL_PRESTASHOP_FULFILLMENT_STATUS_SYNC_UPDATED_SINCE_DAYS',
+        '30',
+      ),
+    );
+    const updatedSinceDays =
+      Number.isFinite(updatedSinceDaysRaw) && updatedSinceDaysRaw > 0 ? updatedSinceDaysRaw : 30;
+
+    tasks.push({
+      taskId: 'prestashop-fulfillment-status-sync',
+      platformType: 'prestashop',
+      jobType: 'marketplace.fulfillment.statusSync',
+      cronExpression,
+      enabledEnvVar: 'OL_PRESTASHOP_FULFILLMENT_STATUS_SYNC_SCHEDULER_ENABLED',
+      generatePayload: () => ({
+        schemaVersion: 1,
+        limit: pageLimit,
+        cursorKey: 'prestashop.fulfillmentStatus.scanOffset',
+        updatedSinceDays,
+      }),
+      generateIdempotencyKey: (connection, timestamp) =>
+        `marketplace:${connection.id}:fulfillment:status:sync:${timestamp}`,
+    });
+  }
+
+  return tasks;
+}

--- a/libs/integrations/prestashop/src/prestashop-integration.module.ts
+++ b/libs/integrations/prestashop/src/prestashop-integration.module.ts
@@ -15,6 +15,7 @@
  */
 import type { OnModuleInit } from '@nestjs/common';
 import { Module, Inject } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import {
   IdentifierMappingModule,
   IDENTIFIER_MAPPING_PORT_TOKEN,
@@ -129,6 +130,7 @@ export class PrestashopIntegrationModule implements OnModuleInit {
     private readonly mappingConfigService: IMappingConfigService,
     @Inject(WEBHOOK_SECRET_PROVIDER_TOKEN)
     private readonly webhookSecretProvider: WebhookSecretProviderPort,
+    private readonly configService: ConfigService,
     @Inject(CACHE_PORT_TOKEN)
     private readonly cache?: CachePort
   ) {}
@@ -144,6 +146,7 @@ export class PrestashopIntegrationModule implements OnModuleInit {
       mappingConfigService: this.mappingConfigService,
       webhookSecretProvider: this.webhookSecretProvider,
       webhookProvisioningAdapter: this.webhookProvisioningAdapter,
+      configService: this.configService,
     });
 
     // Build the HostServices bag from injected host fields.

--- a/libs/integrations/prestashop/src/prestashop-plugin.ts
+++ b/libs/integrations/prestashop/src/prestashop-plugin.ts
@@ -21,6 +21,7 @@
  *
  * @module libs/integrations/prestashop/src
  */
+import type { ConfigService } from '@nestjs/config';
 import { dispatchCapability, type AdapterPlugin, type HostServices } from '@openlinker/plugin-sdk';
 import type { AdapterMetadata } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
@@ -31,6 +32,7 @@ import { PrestashopAdapterFactory } from './application/prestashop-adapter.facto
 import { PrestashopConnectionTesterAdapter } from './infrastructure/adapters/prestashop-connection-tester.adapter';
 import { PrestashopConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/prestashop-connection-config-shape-validator.adapter';
 import { PrestashopConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/prestashop-connection-credentials-shape-validator.adapter';
+import { buildPrestashopSchedulerTasks } from './infrastructure/scheduler/prestashop-scheduler-tasks';
 import type { PrestashopCustomerProvisioner } from './infrastructure/provisioners/prestashop-customer-provisioner';
 import type { PrestashopAddressProvisioner } from './infrastructure/provisioners/prestashop-address-provisioner';
 import type { PrestashopWebhookProvisioningAdapter } from './infrastructure/adapters/prestashop-webhook-provisioning.adapter';
@@ -42,6 +44,12 @@ export interface CreatePrestashopPluginDeps {
   readonly mappingConfigService: IMappingConfigService;
   readonly webhookSecretProvider: WebhookSecretProviderPort;
   readonly webhookProvisioningAdapter: PrestashopWebhookProvisioningAdapter;
+  /**
+   * NestJS ConfigService — used to build scheduler tasks
+   * (`buildPrestashopSchedulerTasks`, #834). When absent (unit-test
+   * bootstraps), the plugin skips scheduler-task registration.
+   */
+  readonly configService?: ConfigService;
 }
 
 /**
@@ -100,6 +108,20 @@ export function createPrestashopPlugin(deps: CreatePrestashopPluginDeps): Adapte
         'prestashop.webservice.v1',
         new PrestashopConnectionCredentialsShapeValidatorAdapter(PRESTASHOP_BRAND),
       );
+      if (deps.configService) {
+        for (const task of buildPrestashopSchedulerTasks(deps.configService)) {
+          host.schedulerTaskRegistry.register(task);
+        }
+      } else {
+        // Unit-test bootstrap (no ConfigService). Production wiring always
+        // passes one; if a runtime path ever lands here, the scheduler
+        // task simply doesn't fire and the operator sees the gap via
+        // missing cursor advancement. This log line makes the gap
+        // greppable when triaging "why isn't branch-1 status-sync running?"
+        host.logger(`${PRESTASHOP_BRAND}IntegrationModule`).debug(
+          'Skipping scheduler-task registration: no ConfigService provided to createPrestashopPlugin (expected in unit-test bootstraps only).',
+        );
+      }
     },
 
     async createCapabilityAdapter<T>(

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -243,6 +243,14 @@ const ALLOW_LIST = new Map([
     'apps/worker/src/sync/handlers/__tests__/marketplace-shipment-status-sync.handler.spec.ts',
     new Set(['ConnectionCursorRepositoryPort']),
   ],
+  [
+    'apps/worker/src/sync/handlers/marketplace-fulfillment-status-sync.handler.ts',
+    new Set(['ConnectionCursorRepositoryPort']),
+  ],
+  [
+    'apps/worker/src/sync/handlers/__tests__/marketplace-fulfillment-status-sync.handler.spec.ts',
+    new Set(['ConnectionCursorRepositoryPort']),
+  ],
 
   // worker → sync.{SyncJobRepositoryPort + ConnectionCursorRepositoryPort} — rewire via ISyncJobsService + ISyncCursorsService
   [


### PR DESCRIPTION
## Summary

Branch-1 of the fulfillment-routing model ([#732](https://github.com/openlinker-project/openlinker/issues/732), [ADR-012](docs/architecture/adrs/012-branch-1-fulfillment-modeling.md)): destinations that ship via their own carrier setup now project a `Shipment` row into OL as the OMP acts on the order. **Projection-only** — a row exists when and only when the OMP has acted (mirrors the [ADR-009](docs/architecture/adrs/009-persisted-offer-status-snapshots.md) `OfferStatusSnapshot` precedent).

Closes #834.

## Design

`FulfillmentStatusReader` is a new sub-capability of `OrderProcessorManagerPort`, counterpart to `OrderFulfillmentUpdater` (#858). The PrestaShop adapter declares it; the new `FulfillmentStatusSyncService` is the **sole creator + updater** of branch-1 `Shipment` rows.

```
                        FulfillmentStatusSyncService (#834)
                                       │
                                       │ per OMP connection, every 15min
                                       ▼
                        ┌──────────────────────────────┐
                        │ page OL OrderRecords         │
                        │ mirrored to this OMP         │
                        │ (30-day updatedSince window) │
                        └──────────────┬───────────────┘
                                       │
                        per record:    ▼
                  ┌────────────────────────────────────┐
                  │ routing.resolve  ◄─ per-page cache │
                  │ branch == omp_fulfilled & this conn│
                  └──────────────────┬─────────────────┘
                                     │ branch-1 only
                                     ▼
                  ┌────────────────────────────────────┐
                  │ adapter.getFulfillmentStatus(extId)│
                  │ → FulfillmentStatusSnapshot        │
                  │   {status, trackingNumber, …}      │
                  └──────────────────┬─────────────────┘
                                     │
                            null ────┴──── non-null
                            │             │
                          skip            ▼
                                ┌─────────────────────────┐
                                │ findBranchOne…(order,   │
                                │   connection)           │
                                └──┬───────────────┬──────┘
                              null │               │ existing
                                   ▼               ▼
                            create(atomic    diff-patch update
                            terminal mode)
```

**Two failure modes intentionally distinct:**
- Adapter resolution throws → `failed` (integration error, surfaces in `/sync/jobs`).
- Adapter doesn't declare `FulfillmentStatusReader` → `skipped` (platform-shape decision).

## What changed

| Layer | Highlights |
|---|---|
| `libs/core/src/orders` | New `FulfillmentStatusReader` sub-capability + `FulfillmentStatusSnapshot` type with its own `FulfillmentStatus` union (decoupled from `ShipmentStatus` so the OMP contract stays stable). `IOrderRecordService` widens with `findMany()` so the shipping context can paginate destination-matched records without reaching into the repository port. |
| `libs/core/src/shipping` | `FulfillmentStatusSyncService` + interface + types + token. `ShipmentRepositoryPort.findBranchOneByOrderAndConnection` (DB-side dedup gate). `CreateShipmentInput` gains atomic-terminal mode (`initialStatus` + terminal timestamps + `trackingNumber`). `ShippingMethod` widens with `'omp'`. Per-invocation `routing.resolve` cache (`(srcConn, methodId)` → resolution, ~10 calls → 1 typical). |
| `libs/core/src/sync` | New `JobType` `marketplace.fulfillment.statusSync` + `MarketplaceFulfillmentStatusSyncPayloadV1`. |
| `libs/integrations/prestashop` | `PrestashopOrderProcessorManagerAdapter.getFulfillmentStatus` — maps via PS `order_state` boolean columns (`delivered`/`shipped`/`paid`), name-regex fallback for cancellation (Latin-script multilingual; non-Latin scripts intentionally fall through pending #862). **Lazy `order_carriers` fetch** — skipped when `order.shipping_number` is set (halves WS round-trips at scale). Per-adapter-instance lazy cache for the `order_states` map. New scheduler task `prestashop-fulfillment-status-sync` (`0 */15 * * * *`, cursor key `prestashop.fulfillmentStatus.scanOffset`). |
| `apps/worker` | `MarketplaceFulfillmentStatusSyncHandler` — thin delegate mirroring [#871](https://github.com/openlinker-project/openlinker/pull/871). |
| `apps/api/migrations` | `1799000000007-add-branch-one-shipments-uq-index.ts` — partial-unique index `(orderId, connectionId) WHERE providerShipmentId IS NULL`. |

## Migration

One migration. Adds the partial-unique index `UQ_shipments_branch_one_per_order_conn`. `up()` is `CREATE UNIQUE INDEX IF NOT EXISTS … WHERE "providerShipmentId" IS NULL`; `down()` is the matching `DROP INDEX IF EXISTS`. Mirrors the partial-unique-index pattern in `1790000000000-add-prompt-templates-table.ts`.

## Operator-facing config (all optional)

| Env var | Default | Effect |
|---|---|---|
| `OL_PRESTASHOP_FULFILLMENT_STATUS_SYNC_SCHEDULER_ENABLED` | `true` | Toggle the branch-1 scheduler task. |
| `OL_PRESTASHOP_FULFILLMENT_STATUS_SYNC_INTERVAL_CRON` | `0 */15 * * * *` | Cron expression. |
| `OL_PRESTASHOP_FULFILLMENT_STATUS_SYNC_PAGE_LIMIT` | `100` | Records per tick. |
| `OL_PRESTASHOP_FULFILLMENT_STATUS_SYNC_UPDATED_SINCE_DAYS` | `30` | Iteration-window bound (#834 plan §6 risk row). |

## How to test

1. **Dev**: bring up the stack, run a fresh migration:
   ```bash
   pnpm dev:stack:up
   pnpm --filter @openlinker/api migration:run
   pnpm start:dev:api && pnpm start:dev:worker
   ```
2. **Confirm wiring**: `migration:show` lists `AddBranchOneShipmentsUqIndex1799000000007` as applied; the scheduler emits `marketplace.fulfillment.statusSync` jobs every 15 min per PS connection.
3. **Vertical slice**: mirror an Allegro order to PS, set PS state to "Shipped" (or any state with `shipped=1`), wait one tick, then check `/shipments` — the branch-1 row should appear with `shippingMethod=omp`, `status=dispatched`, `providerShipmentId=NULL`.

## Quality gate

- ✅ `pnpm lint` (incl. `check:invariants`)
- ✅ `pnpm type-check`
- ✅ `pnpm test` — **3,682 / 3,682** across 11 workspaces (≈80 new tests covering mapper / sync service / adapter / handler / repository)
- ✅ `pnpm --filter @openlinker/api migration:show` — one new pending migration, class-suffix matches filename

## Out of scope (deferred follow-ups)

- **Integration spec** end-to-end through PS Testcontainer. Skipped because the existing harness's OL-module-install path has a documented CI flake; #834 doesn't need that path. File as a follow-up so the int-spec can use the right harness shape.
- **FE hint banner** on `/shipments` for pre-fulfillment branch-1 orders (visible in `/orders` only today).
- **Operator-configurable PS→OL state mapping** (#862) — closes the cancel-regex limitation, including non-Latin scripts (HU/RU/UA/BG).
- **GIN index on `order_records.syncStatus`** — JSONB containment is a seqscan today; acceptable at v1 scale (~30k rows in the 30-day window), file when scan time creeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)