### PR TITLE
fix(shipping): pass Shipment.carrier arg in fulfillment-status-sync spec helper (#886)

### DIFF
--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -61,6 +61,7 @@ function makeBranchOneShipment(overrides: Partial<Shipment> = {}): Shipment {
     overrides.createdAt ?? new Date('2026-05-27T09:00:00.000Z'),
     overrides.updatedAt ?? new Date('2026-05-27T10:00:00.000Z'),
     overrides.sourceDeliveryMethodId ?? null,
+    overrides.carrier === undefined ? null : overrides.carrier,
   );
 }
 


### PR DESCRIPTION
## Summary

- Unbreaks CI on `main`. `pnpm build` was failing on every push with `TS2554: Expected 18 arguments, but got 17` at `libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts:46`.
- One-line fix in the `makeBranchOneShipment` test helper: pass the 18th `carrier` ctor arg using the same `=== undefined ? null : overrides.carrier` pattern used at `shipment-status-sync.service.spec.ts:43`.
- See #886 for full root-cause analysis (merge-order race between #881 — which added the `carrier` field to `Shipment` ctor — and #882 — which introduced this new spec in parallel and missed the new arg).

## Root cause (short)

PR #881 (commit `0ba022f`) added `Shipment.carrier: string | null` as the 18th ctor parameter and updated every then-existing sibling spec. PR #882 (commit `978476a`) introduced a **new** spec whose `makeBranchOneShipment` helper called `new Shipment(...)` with 17 args. Because the new file post-dated #881's API change, no git conflict surfaced — and `tsc -b` only runs at build time in CI, not on every PR's lint step.

## Test plan

- [x] `pnpm --filter @openlinker/core build` passes (the failure mode CI was hitting)
- [x] `pnpm --filter @openlinker/core test -- fulfillment-status-sync.service.spec` — all 18 tests in the spec pass
- [x] Full pre-commit hook ran green locally: lint + `pnpm check:invariants` + type-check + the full test suite (including the 154 worker tests that take the longest)
- [ ] CI on this branch passes
- [ ] After merge, `main` recovers and subsequent PRs unblock

## Follow-up suggestion

Consider adding `pnpm build` (or just `pnpm type-check`) to the per-PR CI surface so future arity drift between a new spec file and an existing API change fails pre-merge rather than after main lands. Out of scope for this fix.

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
