### PR TITLE
fix(allegro): route OAuth completion `/me` to REST API host (#889)

### DIFF
--- a/docs/plans/implementation-plan-889-allegro-oauth-me-rest-host.md
+++ b/docs/plans/implementation-plan-889-allegro-oauth-me-rest-host.md
@@ -1,0 +1,123 @@
+# Implementation Plan — #889 Allegro OAuth `/me` REST API host fix
+
+**Branch:** `889-fix-allegro-oauth-me-rest-host`
+**Issue:** [#889](https://github.com/openlinker-project/openlinker/issues/889)
+**Classification:** Integration / Infrastructure / Bug
+
+---
+
+## 1. Goal
+
+Stop calling `GET /me` against the Allegro OAuth/site host (returns 403 on sandbox). Use the REST API host instead — `https://api.allegro.pl.allegrosandbox.pl/me` on sandbox, `https://api.allegro.pl/me` on production.
+
+Token exchange continues to use the OAuth/site host (the existing — and correct — behaviour for `/auth/oauth/authorize` and `/auth/oauth/token`).
+
+## 2. Non-goals
+
+- Hoisting URL constants into the shared factory (`allegro-adapter.factory.ts`) — flagged as follow-up in the issue. The same OAuth-host / REST-API-host pair is currently duplicated across three files; convergence is a separate refactor.
+- Changing the `OAuthCompletionPort` contract or the neutral `OAuthCredentialBlob` shape.
+- Adding new env vars / runtime config / Allegro API features.
+- Touching credentials persistence or the per-connection `AllegroHttpClient`.
+- Production OAuth verification — that's an AC for the PR reviewer / shipper, not a code change.
+
+## 3. Root cause (recap)
+
+`allegro-oauth-completion.adapter.ts:39-40` defines two constants named `*_API_BASE_URL` whose **values** are the OAuth/site hosts (`allegro.pl` / `allegro.pl.allegrosandbox.pl`). The single `getApiBaseUrl()` helper feeds those values into three call sites:
+
+- `buildAuthorizationUrl` → `/auth/oauth/authorize` — ✅ correct (OAuth UI host)
+- `exchangeCode` → `/auth/oauth/token` — ✅ correct (Allegro hosts the token endpoint on the OAuth host)
+- `fetchAccountIdentity` → `AllegroAccountReader.fetchSellerIdentity(baseUrl, ...)` → `GET /me` — ❌ wrong (`/me` is a REST API call; it lives on the `api.` subdomain)
+
+Other code in the package already uses the correct REST API host:
+- `allegro-adapter.factory.ts:154-162` (per-connection `AllegroHttpClient`)
+- `allegro-connection-tester.adapter.ts:25-28`
+
+Two existing tests lock in the bug:
+- `allegro-oauth-completion.adapter.spec.ts:173` asserts the wrong URL is passed to `fetchSellerIdentity`
+- `allegro-account-reader.spec.ts:12` declares `BASE_URL` as the OAuth host (opaque mocked value, so the test passes regardless)
+
+## 4. Files
+
+| File | Change |
+|---|---|
+| `libs/integrations/allegro/src/infrastructure/adapters/allegro-oauth-completion.adapter.ts` | Split URL constants into OAuth-host pair + REST-API-host pair; add `getRestApiBaseUrl()` helper; wire `fetchAccountIdentity` to the REST host |
+| `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-oauth-completion.adapter.spec.ts` | Flip the assertion at line ~173 that locks in the wrong URL; add a sandbox case asserting the sandbox REST API host |
+| `libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-account-reader.spec.ts` | Fix the misleading `BASE_URL` constant so future readers don't copy the wrong pattern |
+
+No domain entity changes, no migrations, no port-shape changes, no module wiring changes.
+
+## 5. Steps
+
+### Step 1 — Adapter constants + helpers
+
+In `libs/integrations/allegro/src/infrastructure/adapters/allegro-oauth-completion.adapter.ts`:
+
+1. Rename existing `SANDBOX_API_BASE_URL` / `PRODUCTION_API_BASE_URL` → `SANDBOX_OAUTH_BASE_URL` / `PRODUCTION_OAUTH_BASE_URL` (values unchanged — they were always the OAuth host).
+2. Add new constants:
+   ```ts
+   const SANDBOX_REST_API_BASE_URL = 'https://api.allegro.pl.allegrosandbox.pl';
+   const PRODUCTION_REST_API_BASE_URL = 'https://api.allegro.pl';
+   ```
+3. Rename `getApiBaseUrl()` → `getOAuthBaseUrl()`; switch on `environment` exactly as before, but return the renamed OAuth constants.
+4. Add `getRestApiBaseUrl()` — identical structure, returns the REST API constants. The default-on-unknown-environment branch matches `getOAuthBaseUrl`'s posture (defaults to sandbox + warns).
+5. Wire call sites:
+   - `buildAuthorizationUrl` (line ~48) → `getOAuthBaseUrl(...)`
+   - `exchangeCode` (line ~59) → `getOAuthBaseUrl(...)`
+   - `fetchAccountIdentity` (line ~137) → `getRestApiBaseUrl(...)`
+6. Update the file header comment if it mentions the now-renamed helper.
+
+**Acceptance:** `pnpm --filter @openlinker/integrations-allegro build` passes.
+
+### Step 2 — Adapter spec
+
+In `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-oauth-completion.adapter.spec.ts`:
+
+1. Find the assertion at ~line 173 that does `expect(reader.fetchSellerIdentity).toHaveBeenCalledWith('https://allegro.pl', 'at-1');`. Flip the URL to `'https://api.allegro.pl'`.
+2. Add (or extend) a sandbox case asserting `fetchSellerIdentity` is called with `'https://api.allegro.pl.allegrosandbox.pl'` when `environment: 'sandbox'`.
+3. Confirm existing `buildAuthorizationUrl` + `exchangeCode` tests continue to assert the OAuth host — those paths' behaviour is unchanged and the assertions should still pass without edits.
+
+**Acceptance:** `pnpm --filter @openlinker/integrations-allegro test -- allegro-oauth-completion.adapter.spec` green.
+
+### Step 3 — Account-reader spec
+
+In `libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-account-reader.spec.ts`:
+
+1. Change `const BASE_URL = 'https://allegro.pl.allegrosandbox.pl';` → `const BASE_URL = 'https://api.allegro.pl.allegrosandbox.pl';`.
+
+Pure documentation fix — the mock matches any URL the adapter constructs, so the test passes either way. The purpose is to stop future readers from copy-pasting the wrong pattern.
+
+**Acceptance:** `pnpm --filter @openlinker/integrations-allegro test -- allegro-account-reader.spec` green.
+
+### Step 4 — Quality gate
+
+```bash
+pnpm --filter @openlinker/integrations-allegro build
+pnpm --filter @openlinker/integrations-allegro test
+```
+
+Then the full pre-commit hook (lint + check:invariants + type-check + full test suite) runs on `git commit`.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Renaming the existing constants/helpers breaks something else in the file | Scope is one file; ctrl-F confirms no external imports of the renamed symbols. Verified: both old constants and `getApiBaseUrl` are private to the adapter. |
+| `buildAuthorizationUrl` / `exchangeCode` tests start failing because something inadvertently changed | Only the constant *name* and the helper *name* changed for those paths; values are identical. Test assertions check URL strings, not symbol names. |
+| Production was actually relying on the OAuth-host-for-/me quirk | Extremely unlikely — that would mean Allegro proxies `allegro.pl/me` → `api.allegro.pl/me`. The acceptance criteria require a live production OAuth re-verification by the shipper; the AC is in the issue body and surfaces this gap. Either way the fix is the same. |
+
+No domain risk, no migration risk, no consumer-API-breaking risk.
+
+## 7. Architecture compliance
+
+- No CORE ↔ Integration boundary crossings (change is purely inside the Allegro plugin).
+- No domain-layer changes.
+- No NestJS-framework imports added.
+- No `any` types introduced.
+- No `console.log` introduced.
+- No new ESLint disable comments.
+- Naming follows existing conventions (`{SCOPE}_{NAME}_BASE_URL`, camelCase methods).
+- No new ports / capability changes.
+
+## 8. Effort
+
+S — ~1 hour code + tests. Full pre-commit hook adds ~5 min wall time.

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-oauth-completion.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-oauth-completion.adapter.spec.ts
@@ -155,6 +155,24 @@ describe('AllegroOAuthCompletionAdapter', () => {
 
       await expect(adapter.exchangeCode(input)).rejects.toBeInstanceOf(AllegroNetworkException);
     });
+
+    it('uses the OAuth host (not the REST api. host) for the token endpoint', async () => {
+      // Negative regression guard for the symmetrical inverse of the /me
+      // host bug: the token endpoint must never inherit the `api.` REST
+      // host. Token exchange lives on Allegro's OAuth/site origin.
+      const fetchMock = mockFetchResolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ access_token: 'at', refresh_token: 'rt', token_type: 'bearer' }),
+      });
+      const adapter = new AllegroOAuthCompletionAdapter();
+
+      await adapter.exchangeCode(input);
+
+      const [url] = fetchMock.mock.calls[0] as [string];
+      expect(url).not.toMatch(/^https:\/\/api\./);
+    });
   });
 
   describe('fetchAccountIdentity', () => {
@@ -170,7 +188,26 @@ describe('AllegroOAuthCompletionAdapter', () => {
       });
 
       expect(identity).toEqual({ accountId: '12345', label: 'my_shop' });
-      expect(reader.fetchSellerIdentity).toHaveBeenCalledWith('https://allegro.pl', 'at-1');
+      // `/me` lives on Allegro's REST API host (`api.` subdomain), not the
+      // OAuth/site host the authorize + token endpoints use.
+      expect(reader.fetchSellerIdentity).toHaveBeenCalledWith('https://api.allegro.pl', 'at-1');
+    });
+
+    it('passes the sandbox REST API host (api. subdomain) when environment is sandbox', async () => {
+      const reader = {
+        fetchSellerIdentity: jest.fn().mockResolvedValue({ sellerId: '999', login: 'sb_shop' }),
+      } as unknown as AllegroAccountReader;
+      const adapter = new AllegroOAuthCompletionAdapter(reader);
+
+      await adapter.fetchAccountIdentity({
+        credentials: { accessToken: 'at-2' },
+        config: { environment: 'sandbox' },
+      });
+
+      expect(reader.fetchSellerIdentity).toHaveBeenCalledWith(
+        'https://api.allegro.pl.allegrosandbox.pl',
+        'at-2',
+      );
     });
 
     it('propagates the reader failure (host treats it as fatal to completion)', async () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-oauth-completion.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-oauth-completion.adapter.ts
@@ -36,8 +36,19 @@ import { AllegroAccountReader } from '../http/allegro-account-reader';
 import type { AllegroOAuthTokenResponse } from '../../domain/types/allegro-oauth.types';
 
 const ALLEGRO_OAUTH_TIMEOUT_MS = 10_000;
-const SANDBOX_API_BASE_URL = 'https://allegro.pl.allegrosandbox.pl';
-const PRODUCTION_API_BASE_URL = 'https://allegro.pl';
+
+// OAuth / authorize site host — serves both the /auth/oauth/authorize
+// browser-facing UI and the /auth/oauth/token endpoint. Allegro hosts both
+// on the same origin.
+const SANDBOX_OAUTH_BASE_URL = 'https://allegro.pl.allegrosandbox.pl';
+const PRODUCTION_OAUTH_BASE_URL = 'https://allegro.pl';
+
+// REST API host — serves /me and every other REST call. Distinct `api.`
+// subdomain from the OAuth/site host above. Mirrors the values that
+// `allegro-adapter.factory.ts` and `allegro-connection-tester.adapter.ts`
+// use for their own REST clients.
+const SANDBOX_REST_API_BASE_URL = 'https://api.allegro.pl.allegrosandbox.pl';
+const PRODUCTION_REST_API_BASE_URL = 'https://api.allegro.pl';
 
 export class AllegroOAuthCompletionAdapter implements OAuthCompletionPort {
   private readonly logger = new Logger(AllegroOAuthCompletionAdapter.name);
@@ -45,8 +56,8 @@ export class AllegroOAuthCompletionAdapter implements OAuthCompletionPort {
   constructor(private readonly accountReader: AllegroAccountReader = new AllegroAccountReader()) {}
 
   buildAuthorizationUrl(input: BuildAuthorizationUrlInput): string {
-    const apiBaseUrl = this.getApiBaseUrl(this.readEnvironment(input.config));
-    const authorizationUrl = new URL('/auth/oauth/authorize', apiBaseUrl);
+    const oauthBaseUrl = this.getOAuthBaseUrl(this.readEnvironment(input.config));
+    const authorizationUrl = new URL('/auth/oauth/authorize', oauthBaseUrl);
     authorizationUrl.searchParams.set('client_id', input.clientId);
     authorizationUrl.searchParams.set('response_type', 'code');
     authorizationUrl.searchParams.set('redirect_uri', input.redirectUri);
@@ -56,7 +67,7 @@ export class AllegroOAuthCompletionAdapter implements OAuthCompletionPort {
 
   async exchangeCode(input: ExchangeCodeInput): Promise<OAuthCredentialBlob> {
     const environment = this.readEnvironment(input.config);
-    const tokenUrl = new URL('/auth/oauth/token', this.getApiBaseUrl(environment)).toString();
+    const tokenUrl = new URL('/auth/oauth/token', this.getOAuthBaseUrl(environment)).toString();
     const basic = Buffer.from(`${input.clientId}:${input.clientSecret}`).toString('base64');
 
     let response: Response;
@@ -134,8 +145,8 @@ export class AllegroOAuthCompletionAdapter implements OAuthCompletionPort {
         '/me'
       );
     }
-    const baseUrl = this.getApiBaseUrl(this.readEnvironment(input.config));
-    const identity = await this.accountReader.fetchSellerIdentity(baseUrl, accessToken);
+    const restApiBaseUrl = this.getRestApiBaseUrl(this.readEnvironment(input.config));
+    const identity = await this.accountReader.fetchSellerIdentity(restApiBaseUrl, accessToken);
     return { accountId: identity.sellerId, label: identity.login };
   }
 
@@ -144,15 +155,37 @@ export class AllegroOAuthCompletionAdapter implements OAuthCompletionPort {
     return typeof environment === 'string' && environment.length > 0 ? environment : 'sandbox';
   }
 
-  private getApiBaseUrl(environment: string): string {
+  private getOAuthBaseUrl(environment: string): string {
     switch (environment) {
       case 'sandbox':
-        return SANDBOX_API_BASE_URL;
+        return SANDBOX_OAUTH_BASE_URL;
       case 'production':
-        return PRODUCTION_API_BASE_URL;
+        return PRODUCTION_OAUTH_BASE_URL;
       default:
         this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
-        return SANDBOX_API_BASE_URL;
+        return SANDBOX_OAUTH_BASE_URL;
+    }
+  }
+
+  /**
+   * REST API host for `/me` and any other REST call we need at OAuth
+   * completion. The unknown-environment default MUST match
+   * `getOAuthBaseUrl`'s default — if the two helpers diverge on the
+   * fallback environment, a connection would exchange its authorization
+   * code on one Allegro environment but try to verify the resulting
+   * token's identity against a different one, and the identity check
+   * would 401/403 in a way that looks like a credentials bug. Keep the
+   * two switch tables aligned.
+   */
+  private getRestApiBaseUrl(environment: string): string {
+    switch (environment) {
+      case 'sandbox':
+        return SANDBOX_REST_API_BASE_URL;
+      case 'production':
+        return PRODUCTION_REST_API_BASE_URL;
+      default:
+        this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
+        return SANDBOX_REST_API_BASE_URL;
     }
   }
 

--- a/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-account-reader.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-account-reader.spec.ts
@@ -9,7 +9,10 @@ import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exce
 import { AllegroAuthenticationException } from '../../../domain/exceptions/allegro-authentication.exception';
 import { AllegroNetworkException } from '../../../domain/exceptions/allegro-network.exception';
 
-const BASE_URL = 'https://allegro.pl.allegrosandbox.pl';
+// REST API host — `/me` and other REST calls live on the `api.` subdomain;
+// the OAuth/site host (`allegro.pl.allegrosandbox.pl`) used to land here
+// historically and returned 403 because it doesn't serve the REST API.
+const BASE_URL = 'https://api.allegro.pl.allegrosandbox.pl';
 const TOKEN = 'access-tok';
 
 describe('AllegroAccountReader', () => {


### PR DESCRIPTION
## Summary

- Unblocks all new sandbox Allegro OAuth connections — the `AllegroOAuthCompletionAdapter` routed `GET /me` to the OAuth/site host (`allegro.pl.allegrosandbox.pl`) instead of the REST API host (`api.allegro.pl.allegrosandbox.pl`), which returned 403 because that host doesn't serve the REST API. Token exchange (which legitimately lives on the OAuth host) worked, masking the bug behind a "credentials seem to be OK but identity check fails" symptom.
- See #889 for the full root-cause analysis. Introduced by #820.
- One-file change in the adapter, plus two spec files where one test had locked in the wrong URL.

## Root cause (short)

A single `getApiBaseUrl` helper whose constants were the OAuth host values fed all three port methods: `buildAuthorizationUrl` (correct, OAuth host), `exchangeCode` (correct, OAuth host), and `fetchAccountIdentity` → `GET /me` (wrong, needed the REST API host). Production likely worked by Allegro-side coincidence — most plausibly an implicit redirect from `allegro.pl/me` to `api.allegro.pl/me`.

## What changed

- `allegro-oauth-completion.adapter.ts` — split into two clearly-named constant pairs (`*_OAUTH_BASE_URL` for the authorize + token endpoints, `*_REST_API_BASE_URL` for `/me`). Two helper methods, `getOAuthBaseUrl` + `getRestApiBaseUrl`. The new helper carries an inline JSDoc constraint that its unknown-environment default must stay aligned with `getOAuthBaseUrl`'s — drifting them would route token exchange and identity verification to different Allegro environments.
- `allegro-oauth-completion.adapter.spec.ts` — flipped the assertion that locked the wrong URL (`'https://allegro.pl'` → `'https://api.allegro.pl'`); added a sandbox case asserting `'https://api.allegro.pl.allegrosandbox.pl'`; added a negative-assertion regression guard that `exchangeCode`'s URL never inherits the `api.` host (symmetric inverse of the `/me` bug).
- `allegro-account-reader.spec.ts` — fixed the misleading `BASE_URL` constant value so future readers don't copy the wrong host into new specs.
- `docs/plans/implementation-plan-889-allegro-oauth-me-rest-host.md` — the plan that produced this PR.

## Test plan

- [x] `pnpm --filter @openlinker/integrations-allegro build` passes locally.
- [x] `pnpm --filter @openlinker/integrations-allegro test --testPathPattern='(allegro-oauth-completion|allegro-account-reader)'` — all 18 tests pass (the flipped assertion, the new sandbox case, the new negative-assertion guard, plus existing coverage).
- [x] Full pre-commit hook ran green: lint + `pnpm check:invariants` + type-check + full Jest suite across every package.
- [ ] **CI on this branch passes.**
- [ ] **Live sandbox verification** — connect a real Allegro sandbox account end-to-end, confirm no 403 at OAuth completion, confirm seller identity lands on the connection.
- [ ] **Live production re-verification** — production may have been silently broken since #820 too (if `allegro.pl/me` proxies/redirects to `api.allegro.pl/me`, the wrong code path was working by coincidence). Confirm by completing a fresh production OAuth flow.

## Follow-up (not in this PR)

The same OAuth-host / REST-API-host pair is duplicated across three files (`allegro-adapter.factory.ts`, `allegro-connection-tester.adapter.ts`, this adapter). Filing a separate follow-up issue to converge them onto a shared resolver — three duplicates is exactly how this bug shipped in the first place.

Closes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)
