### PR TITLE
refactor(allegro): converge OAuth + REST host resolution onto a single resolver (#892)

### DIFF
--- a/docs/plans/implementation-plan-allegro-shared-host-resolver.md
+++ b/docs/plans/implementation-plan-allegro-shared-host-resolver.md
@@ -1,0 +1,159 @@
+# Implementation Plan — Allegro shared host resolver (#892)
+
+## 1. Understand the task
+
+**Goal.** Remove the duplicated OAuth-host / REST-API-host string-resolution scattered across the
+Allegro plugin by extracting a single pure resolver module, then migrating every runtime call site
+onto it. This kills the drift class that produced the #889 bug (one copy used the wrong host).
+
+**Classification.** Integration (Allegro plugin) · Infrastructure layer. No CORE port, domain, or
+schema change. No migration.
+
+**Explicit non-goals (from the issue).**
+- Do **not** hoist the resolver into a cross-plugin shared package — Allegro-specific, no second consumer.
+- Do **not** touch the `upload.allegro.pl` image-upload subdomain (genuinely separate host).
+- Do **not** touch webhook host (n/a here).
+- Do **not** touch `https://developer.allegro.pl` doc-portal links (unrelated documentation URLs).
+
+## 2. Research findings (codebase reality vs. the issue body)
+
+The issue lists **three** call sites. Grep of the plugin (`https://(api\.)?allegro\.pl`, excluding
+tests / `upload.` / `developer.`) found **runtime host resolution in five places**, not three:
+
+| File | Helper | Host kind | In issue? |
+|---|---|---|---|
+| `application/allegro-adapter.factory.ts:153` | `getDefaultApiBaseUrl` | REST (`api.allegro.pl`) | ✅ yes |
+| `application/allegro-adapter.factory.ts:170` | `getDefaultStorefrontBaseUrl` | site (`allegro.pl`) | ⚠️ no |
+| `infrastructure/adapters/allegro-connection-tester.adapter.ts:25` | `DEFAULT_API_BASE_URLS` map | REST | ✅ yes |
+| `infrastructure/adapters/allegro-oauth-completion.adapter.ts:43-51` | `getOAuthBaseUrl` / `getRestApiBaseUrl` | OAuth + REST | ✅ yes |
+| `infrastructure/token-refresh/allegro-token-refresh.service.ts:319` | `getApiBaseUrl` | OAuth/site (`allegro.pl`) **misnamed** | ❌ no |
+
+Two findings beyond the issue's inventory:
+
+- **`allegro-token-refresh.service.ts` `getApiBaseUrl` is a misnamed OAuth-host duplicate.** It returns
+  the `allegro.pl` site host and is consumed at line 209 to build `/auth/oauth/token` (the refresh-grant
+  token endpoint). This is the *exact* misnaming pattern #889 fixed in the OAuth-completion adapter
+  ("the pre-#889 state had four... misnamed `*_API_BASE_URL` constants"). Leaving it would mean the
+  issue's own AC — "one module owns the OAuth-host... resolution; no other file contains the literal
+  strings" — is **not met**. → **Migrate it.** (rename local `apiBaseUrl` → `oauthBaseUrl` for clarity.)
+
+- **The factory's storefront host (`allegro.pl`) equals the OAuth/site host.** Allegro serves the OAuth
+  authorize UI, the `/auth/oauth/token` endpoint, and the public storefront all on the same `allegro.pl`
+  web host (as distinct from the `api.allegro.pl` REST host). The storefront helper therefore contains
+  the literal `https://allegro.pl`, which the AC forbids in "any other file". → **Migrate it onto
+  `getAllegroOAuthBaseUrl`** (the value is identical; documented as "the Allegro web/site host").
+
+Supporting facts:
+- Existing type: `AllegroEnvironment = 'sandbox' | 'production'` + `AllegroEnvironmentValues` in
+  `domain/types/allegro-config.types.ts` (re-exported from the package barrel).
+- All four migrated helpers currently **`logger.warn` on unknown env** and default to sandbox. The new
+  resolver must preserve that observable behaviour (AC: "existing behaviour is preserved").
+- Call sites pass un-narrowed `string` (e.g. `getDefaultApiBaseUrl(environment: string)`) — the defensive
+  `default` branch only makes sense for `string`, so the resolver's param is `string`, not the narrow
+  `AllegroEnvironment` (a narrow type makes `default` unreachable). Minor, deliberate deviation from the
+  issue's `env: AllegroEnvironment` signature.
+- The OAuth-completion spec (`...adapter.spec.ts:50-208`) already asserts the host values through the
+  public port — it stays green and guards the delegation against behaviour change.
+- `allegro-token-refresh.service.ts` and the connection-tester have **no** existing specs.
+- The factory lives in `application/` but is a wiring factory that already imports heavily from
+  `infrastructure/` (`AllegroHttpClient`, adapters) — importing the resolver from `infrastructure/http`
+  is consistent with the file's existing role.
+
+## 3. Design
+
+New pure module `libs/integrations/allegro/src/infrastructure/http/allegro-hosts.ts`:
+
+```ts
+// private module constants (the single source of truth for Allegro hosts)
+const SANDBOX_WEB_BASE_URL = 'https://allegro.pl.allegrosandbox.pl';     // OAuth authorize + token + storefront
+const PRODUCTION_WEB_BASE_URL = 'https://allegro.pl';
+const SANDBOX_REST_API_BASE_URL = 'https://api.allegro.pl.allegrosandbox.pl';
+const PRODUCTION_REST_API_BASE_URL = 'https://api.allegro.pl';
+
+// only public surface:
+export function getAllegroWebBaseUrl(environment: string): string     // /auth/oauth/* + token-refresh + storefront links
+export function getAllegroRestApiBaseUrl(environment: string): string // /me, /sale/*, /order/*, ...
+```
+
+**Naming decision (tech-review IMPORTANT).** The web-host helper is named `getAllegroWebBaseUrl`, not
+the issue's prescribed `getAllegroOAuthBaseUrl`. The `allegro.pl` host serves OAuth authorize, the
+`/auth/oauth/token` endpoint, **and** the public storefront link — naming it "OAuth" would reintroduce
+the name/purpose mismatch this issue exists to remove (a storefront link calling an "OAuth" function).
+The AC mandates convergence/behaviour, not the identifier, so this is a safe deviation — recorded on the PR.
+
+- Both: `sandbox → sandbox host`, `production → production host`, `default → warn + sandbox`.
+- Preserve the warn via a module-scoped neutral `Logger` from `@openlinker/shared/logging`
+  (plugin-safe, zero-config console default). Keeps the existing observable behaviour.
+- Relocate the alignment-constraint JSDoc (currently on `getRestApiBaseUrl` in the OAuth adapter)
+  to sit next to both helpers — one-place-enforceable instead of duplicated-by-convention.
+
+Data flow is unchanged — same strings resolved, just from one module.
+
+## 4. Step-by-step implementation
+
+**Step 1 — create the resolver.**
+`libs/integrations/allegro/src/infrastructure/http/allegro-hosts.ts`
+- File header; four private consts; two exported functions; module `Logger`.
+- AC: pure module, no NestJS/DI; only the two functions are exported.
+
+**Step 2 — create the spec.**
+`libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-hosts.spec.ts`
+- Assert the four host strings explicitly (OAuth prod/sandbox, REST prod/sandbox).
+- Assert both default to sandbox on an unknown env string.
+- AC: a typo in any host value fails at lint/test time.
+
+**Step 3 — migrate `allegro-adapter.factory.ts`.**
+- Line 71 `getDefaultApiBaseUrl(config.environment)` → `getAllegroRestApiBaseUrl(config.environment)`.
+- Line 75 `getDefaultStorefrontBaseUrl(config.environment)` → `getAllegroWebBaseUrl(config.environment)`.
+- Delete the private `getDefaultApiBaseUrl` + `getDefaultStorefrontBaseUrl` methods.
+- **Leave `getDefaultUploadBaseUrl` untouched.**
+- Add `import { getAllegroWebBaseUrl, getAllegroRestApiBaseUrl } from '../infrastructure/http/allegro-hosts';`
+
+**Step 4 — migrate `allegro-connection-tester.adapter.ts`.**
+- Delete `DEFAULT_API_BASE_URLS` map (25-28).
+- Line 40 → `config.apiBaseUrl ?? getAllegroRestApiBaseUrl(environment)`.
+- Add `import { getAllegroRestApiBaseUrl } from '../http/allegro-hosts';`
+
+**Step 5 — migrate `allegro-oauth-completion.adapter.ts`.**
+- Delete the four module consts (43-51) and the two private methods `getOAuthBaseUrl` / `getRestApiBaseUrl`.
+- Replace internal calls `this.getOAuthBaseUrl(env)` → `getAllegroWebBaseUrl(env)` (lines 59, 70) and
+  `this.getRestApiBaseUrl(env)` → `getAllegroRestApiBaseUrl(env)` (line 148).
+- Add `import { getAllegroWebBaseUrl, getAllegroRestApiBaseUrl } from '../http/allegro-hosts';`
+
+**Step 6 — migrate `allegro-token-refresh.service.ts`.**
+- Line 137 `this.getApiBaseUrl(environment)` → `getAllegroWebBaseUrl(environment)`; rename local
+  `apiBaseUrl` → `webBaseUrl` (used at 209 for `/auth/oauth/token`).
+- Delete the private `getApiBaseUrl` method (319-329).
+- Add `import { getAllegroWebBaseUrl } from '../http/allegro-hosts';`
+
+**Step 7 — doc comments (tech-review SUGGESTION: keep clarifying docs intact).**
+- `allegro-offer-manager.adapter.ts:267-268` — reword the storefront comment to reference the resolver
+  without embedding the literal host strings (cheap).
+- `domain/types/allegro-config.types.ts:37-38` — **keep intact.** It documents the `apiBaseUrl`
+  config-field default; the example URLs are genuine documentation. The AC's intent ("caught at lint
+  time", "value drift") is about *executable* host resolution, not doc comments — recorded on the PR.
+
+**Step 8 — quality gate.**
+`pnpm --filter @openlinker/integrations-allegro test`, then `pnpm lint && pnpm type-check && pnpm test`.
+
+## 5. Validation
+
+- **Architecture**: resolver is pure infra; no CORE↔Integration boundary crossing; factory→infra import
+  matches the file's existing wiring role. ✅
+- **Naming**: `*.ts` pure module, co-located `__tests__/*.spec.ts`. ✅
+- **Behaviour preserved**: same four strings; warn-on-unknown retained via neutral Logger; OAuth-completion
+  spec re-verifies host behaviour unchanged. ✅
+- **Security**: no secrets, no input-trust change. ✅
+- **AC closure**: after Steps 3-7, grep for `https://(api\.)?allegro\.pl` (excluding tests / `upload.` /
+  `developer.`) returns only `allegro-hosts.ts`. ✅
+
+## Decisions (resolved after tech-review)
+
+1. **5-site convergence** (factory REST + storefront, oauth-completion OAuth + REST, connection-tester
+   REST, token-refresh OAuth) — not the issue's literal 3. Required by the AC; fixes the same misnaming
+   bug class. **Approved.**
+2. **Function naming** → `getAllegroWebBaseUrl` + `getAllegroRestApiBaseUrl`. Deviates from the issue's
+   `getAllegroOAuthBaseUrl` because the web host also serves storefront + token-refresh; an "OAuth"-named
+   function for a storefront link would reintroduce name/purpose drift. **Approved; noted on PR.**
+3. **Preserve warn-on-unknown** via a module-scoped neutral `Logger` (AC: behaviour preserved).
+4. **`allegro-config.types.ts` doc comment** kept intact (documentation ≠ executable drift). **Noted on PR.**

--- a/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
+++ b/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
@@ -20,6 +20,10 @@ import type { AllegroCredentials } from '../domain/types/allegro-credentials.typ
 import { AllegroConfigException } from '../domain/exceptions/allegro-config.exception';
 import { AllegroHttpClient } from '../infrastructure/http/allegro-http-client';
 import { AllegroConnectionTokenState } from '../infrastructure/http/allegro-connection-token-state';
+import {
+  getAllegroWebBaseUrl,
+  getAllegroRestApiBaseUrl,
+} from '../infrastructure/http/allegro-hosts';
 import type { QuantityPollConfig } from '../infrastructure/adapters/allegro-offer-manager.adapter';
 import { AllegroOfferManagerAdapter } from '../infrastructure/adapters/allegro-offer-manager.adapter';
 import { AllegroOrderSourceAdapter } from '../infrastructure/adapters/allegro-order-source.adapter';
@@ -68,11 +72,12 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
     const credentials = await this.resolveCredentials(connection, credentialsResolver);
 
     // Determine API + upload base URLs
-    const apiBaseUrl = config.apiBaseUrl || this.getDefaultApiBaseUrl(config.environment);
+    const apiBaseUrl = config.apiBaseUrl || getAllegroRestApiBaseUrl(config.environment);
     const uploadBaseUrl = config.uploadBaseUrl || this.getDefaultUploadBaseUrl(config.environment);
     // #464 — public buyer-facing storefront, used by `OfferReader.getOffer` to
-    // synthesise a marketplace-side URL the operator can open in a new tab.
-    const storefrontBaseUrl = this.getDefaultStorefrontBaseUrl(config.environment);
+    // synthesise a marketplace-side URL the operator can open in a new tab. The
+    // storefront lives on the same `allegro.pl` web host as the OAuth surface.
+    const storefrontBaseUrl = getAllegroWebBaseUrl(config.environment);
 
     // Create token refresh callback if token refresh service is available.
     // We forward both accessToken and expiresAt so the HTTP client can update
@@ -145,38 +150,6 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
       orderSource: orderSourceAdapter,
       shippingManager: shippingAdapter,
     };
-  }
-
-  /**
-   * Get default API base URL for environment
-   */
-  private getDefaultApiBaseUrl(environment: string): string {
-    switch (environment) {
-      case 'sandbox':
-        return 'https://api.allegro.pl.allegrosandbox.pl';
-      case 'production':
-        return 'https://api.allegro.pl';
-      default:
-        this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
-        return 'https://api.allegro.pl.allegrosandbox.pl';
-    }
-  }
-
-  /**
-   * Public storefront base URL for the offer-detail link surfaced on the
-   * listing-detail page (#464). Same `*.allegrosandbox.pl` naming pattern as
-   * the api/upload hosts.
-   */
-  private getDefaultStorefrontBaseUrl(environment: string): string {
-    switch (environment) {
-      case 'sandbox':
-        return 'https://allegro.pl.allegrosandbox.pl';
-      case 'production':
-        return 'https://allegro.pl';
-      default:
-        this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox storefront`);
-        return 'https://allegro.pl.allegrosandbox.pl';
-    }
   }
 
   /**

--- a/libs/integrations/allegro/src/domain/types/allegro-config.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-config.types.ts
@@ -33,9 +33,9 @@ export interface AllegroConnectionConfig {
   environment: AllegroEnvironment;
 
   /**
-   * Allegro API base URL (optional, defaults based on environment)
-   * - Sandbox: https://api.allegro.pl.allegrosandbox.pl
-   * - Production: https://api.allegro.pl
+   * Allegro REST API base URL (optional). When omitted, the per-environment
+   * default is resolved by `getAllegroRestApiBaseUrl` (the `api.` host) in
+   * `infrastructure/http/allegro-hosts.ts`.
    */
   apiBaseUrl?: string;
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-connection-tester.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-connection-tester.adapter.ts
@@ -19,13 +19,9 @@ import type {
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { AllegroHttpClient } from '../http/allegro-http-client';
 import { AllegroConnectionTokenState } from '../http/allegro-connection-token-state';
+import { getAllegroRestApiBaseUrl } from '../http/allegro-hosts';
 import type { AllegroCredentials } from '../../domain/types/allegro-credentials.types';
 import type { AllegroConnectionConfig } from '../../domain/types/allegro-config.types';
-
-const DEFAULT_API_BASE_URLS: Record<string, string> = {
-  sandbox: 'https://api.allegro.pl.allegrosandbox.pl',
-  production: 'https://api.allegro.pl',
-};
 
 export class AllegroConnectionTesterAdapter implements ConnectionTesterPort {
   async test(
@@ -36,8 +32,7 @@ export class AllegroConnectionTesterAdapter implements ConnectionTesterPort {
     try {
       const config = (connection.config ?? {}) as Partial<AllegroConnectionConfig>;
       const environment = config.environment ?? 'sandbox';
-      const apiBaseUrl =
-        config.apiBaseUrl ?? DEFAULT_API_BASE_URLS[environment] ?? DEFAULT_API_BASE_URLS.sandbox;
+      const apiBaseUrl = config.apiBaseUrl ?? getAllegroRestApiBaseUrl(environment);
 
       const credentials = await credentialsResolver.get<AllegroCredentials>(
         connection.credentialsRef

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-oauth-completion.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-oauth-completion.adapter.ts
@@ -33,22 +33,10 @@ import type {
 import { OAuthCodeExchangeException } from '@openlinker/core/integrations';
 import { AllegroNetworkException } from '../../domain/exceptions/allegro-network.exception';
 import { AllegroAccountReader } from '../http/allegro-account-reader';
+import { getAllegroWebBaseUrl, getAllegroRestApiBaseUrl } from '../http/allegro-hosts';
 import type { AllegroOAuthTokenResponse } from '../../domain/types/allegro-oauth.types';
 
 const ALLEGRO_OAUTH_TIMEOUT_MS = 10_000;
-
-// OAuth / authorize site host — serves both the /auth/oauth/authorize
-// browser-facing UI and the /auth/oauth/token endpoint. Allegro hosts both
-// on the same origin.
-const SANDBOX_OAUTH_BASE_URL = 'https://allegro.pl.allegrosandbox.pl';
-const PRODUCTION_OAUTH_BASE_URL = 'https://allegro.pl';
-
-// REST API host — serves /me and every other REST call. Distinct `api.`
-// subdomain from the OAuth/site host above. Mirrors the values that
-// `allegro-adapter.factory.ts` and `allegro-connection-tester.adapter.ts`
-// use for their own REST clients.
-const SANDBOX_REST_API_BASE_URL = 'https://api.allegro.pl.allegrosandbox.pl';
-const PRODUCTION_REST_API_BASE_URL = 'https://api.allegro.pl';
 
 export class AllegroOAuthCompletionAdapter implements OAuthCompletionPort {
   private readonly logger = new Logger(AllegroOAuthCompletionAdapter.name);
@@ -56,7 +44,7 @@ export class AllegroOAuthCompletionAdapter implements OAuthCompletionPort {
   constructor(private readonly accountReader: AllegroAccountReader = new AllegroAccountReader()) {}
 
   buildAuthorizationUrl(input: BuildAuthorizationUrlInput): string {
-    const oauthBaseUrl = this.getOAuthBaseUrl(this.readEnvironment(input.config));
+    const oauthBaseUrl = getAllegroWebBaseUrl(this.readEnvironment(input.config));
     const authorizationUrl = new URL('/auth/oauth/authorize', oauthBaseUrl);
     authorizationUrl.searchParams.set('client_id', input.clientId);
     authorizationUrl.searchParams.set('response_type', 'code');
@@ -67,7 +55,7 @@ export class AllegroOAuthCompletionAdapter implements OAuthCompletionPort {
 
   async exchangeCode(input: ExchangeCodeInput): Promise<OAuthCredentialBlob> {
     const environment = this.readEnvironment(input.config);
-    const tokenUrl = new URL('/auth/oauth/token', this.getOAuthBaseUrl(environment)).toString();
+    const tokenUrl = new URL('/auth/oauth/token', getAllegroWebBaseUrl(environment)).toString();
     const basic = Buffer.from(`${input.clientId}:${input.clientSecret}`).toString('base64');
 
     let response: Response;
@@ -145,7 +133,7 @@ export class AllegroOAuthCompletionAdapter implements OAuthCompletionPort {
         '/me'
       );
     }
-    const restApiBaseUrl = this.getRestApiBaseUrl(this.readEnvironment(input.config));
+    const restApiBaseUrl = getAllegroRestApiBaseUrl(this.readEnvironment(input.config));
     const identity = await this.accountReader.fetchSellerIdentity(restApiBaseUrl, accessToken);
     return { accountId: identity.sellerId, label: identity.login };
   }
@@ -153,40 +141,6 @@ export class AllegroOAuthCompletionAdapter implements OAuthCompletionPort {
   private readEnvironment(config?: Record<string, unknown>): string {
     const environment = config?.environment;
     return typeof environment === 'string' && environment.length > 0 ? environment : 'sandbox';
-  }
-
-  private getOAuthBaseUrl(environment: string): string {
-    switch (environment) {
-      case 'sandbox':
-        return SANDBOX_OAUTH_BASE_URL;
-      case 'production':
-        return PRODUCTION_OAUTH_BASE_URL;
-      default:
-        this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
-        return SANDBOX_OAUTH_BASE_URL;
-    }
-  }
-
-  /**
-   * REST API host for `/me` and any other REST call we need at OAuth
-   * completion. The unknown-environment default MUST match
-   * `getOAuthBaseUrl`'s default — if the two helpers diverge on the
-   * fallback environment, a connection would exchange its authorization
-   * code on one Allegro environment but try to verify the resulting
-   * token's identity against a different one, and the identity check
-   * would 401/403 in a way that looks like a credentials bug. Keep the
-   * two switch tables aligned.
-   */
-  private getRestApiBaseUrl(environment: string): string {
-    switch (environment) {
-      case 'sandbox':
-        return SANDBOX_REST_API_BASE_URL;
-      case 'production':
-        return PRODUCTION_REST_API_BASE_URL;
-      default:
-        this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
-        return SANDBOX_REST_API_BASE_URL;
-    }
   }
 
   /**

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -264,9 +264,9 @@ export class AllegroOfferManagerAdapter
     private readonly sellerDefaults?: AllegroSellerDefaultsConfig,
     /**
      * Storefront base URL used to derive the public buyer-facing offer URL
-     * for `getOffer` (#464). Sandbox: `https://allegro.pl.allegrosandbox.pl`,
-     * production: `https://allegro.pl`. The factory passes the right value;
-     * when undefined, `getOffer` omits `marketplaceUrl` from its result.
+     * for `getOffer` (#464) — the Allegro web host, resolved per environment by
+     * `getAllegroWebBaseUrl` in the adapter factory. When undefined, `getOffer`
+     * omits `marketplaceUrl` from its result.
      */
     private readonly storefrontBaseUrl?: string
   ) {

--- a/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-hosts.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-hosts.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit spec for the Allegro host resolver (#892).
+ *
+ * Pins the four host strings explicitly so any future typo in a host value fails
+ * here rather than silently shipping to one environment, and asserts the
+ * unknown-environment defaults stay aligned between the two resolvers.
+ */
+import { getAllegroWebBaseUrl, getAllegroRestApiBaseUrl } from '../allegro-hosts';
+
+describe('allegro-hosts', () => {
+  describe('getAllegroWebBaseUrl', () => {
+    it('should resolve the production web host when environment is production', () => {
+      expect(getAllegroWebBaseUrl('production')).toBe('https://allegro.pl');
+    });
+
+    it('should resolve the sandbox web host when environment is sandbox', () => {
+      expect(getAllegroWebBaseUrl('sandbox')).toBe('https://allegro.pl.allegrosandbox.pl');
+    });
+
+    it('should default to the sandbox web host when environment is unknown', () => {
+      expect(getAllegroWebBaseUrl('staging')).toBe('https://allegro.pl.allegrosandbox.pl');
+    });
+  });
+
+  describe('getAllegroRestApiBaseUrl', () => {
+    it('should resolve the production REST host when environment is production', () => {
+      expect(getAllegroRestApiBaseUrl('production')).toBe('https://api.allegro.pl');
+    });
+
+    it('should resolve the sandbox REST host when environment is sandbox', () => {
+      expect(getAllegroRestApiBaseUrl('sandbox')).toBe('https://api.allegro.pl.allegrosandbox.pl');
+    });
+
+    it('should default to the sandbox REST host when environment is unknown', () => {
+      expect(getAllegroRestApiBaseUrl('staging')).toBe('https://api.allegro.pl.allegrosandbox.pl');
+    });
+  });
+
+  it('should keep web and REST resolvers on the same environment for the unknown-env default', () => {
+    // Both default to sandbox: a connection must never authorize on one Allegro
+    // environment while resolving REST calls against another.
+    expect(getAllegroWebBaseUrl('???')).toContain('allegrosandbox.pl');
+    expect(getAllegroRestApiBaseUrl('???')).toContain('allegrosandbox.pl');
+  });
+});

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-hosts.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-hosts.ts
@@ -1,0 +1,73 @@
+/**
+ * Allegro Host Resolver
+ *
+ * Single source of truth for Allegro's two base hosts, keyed by environment:
+ *
+ *   - Web host   (`allegro.pl`)     — serves the `/auth/oauth/authorize` browser UI,
+ *                                     the `/auth/oauth/token` grant endpoint, AND the
+ *                                     public buyer-facing storefront links.
+ *   - REST host  (`api.allegro.pl`) — serves `/me`, `/sale/*`, `/order/*`, and every
+ *                                     other REST call.
+ *
+ * Before #892 this `(environment) => host` lookup was duplicated across the adapter
+ * factory, the connection tester, the OAuth-completion adapter, and the token-refresh
+ * service. That duplication is exactly how #889 shipped — one copy held the web host
+ * where the REST host was correct. Both alignment constraints now live here, in one
+ * place, instead of being maintained-by-convention across files.
+ *
+ * Pure module: no NestJS, no DI. The only public surface is the two resolver functions.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/http
+ */
+import { Logger } from '@openlinker/shared/logging';
+
+const logger = new Logger('AllegroHosts');
+
+// Web/site host — OAuth authorize + token endpoints and public storefront links.
+const SANDBOX_WEB_BASE_URL = 'https://allegro.pl.allegrosandbox.pl';
+const PRODUCTION_WEB_BASE_URL = 'https://allegro.pl';
+
+// REST API host — distinct `api.` subdomain. The unknown-environment default MUST
+// match the web host's default below: if the two diverge on the fallback, a connection
+// could authorize on one Allegro environment but resolve REST calls against another,
+// surfacing as a confusing 401/403 that looks like a credentials bug.
+const SANDBOX_REST_API_BASE_URL = 'https://api.allegro.pl.allegrosandbox.pl';
+const PRODUCTION_REST_API_BASE_URL = 'https://api.allegro.pl';
+
+/**
+ * Resolve the Allegro web/site base URL for an environment.
+ *
+ * Used for `/auth/oauth/authorize`, `/auth/oauth/token`, and buyer-facing storefront
+ * links. Accepts an un-narrowed `string` (call sites operate on unvalidated config
+ * values) and defaults to sandbox on anything other than `'production'`.
+ */
+export function getAllegroWebBaseUrl(environment: string): string {
+  switch (environment) {
+    case 'sandbox':
+      return SANDBOX_WEB_BASE_URL;
+    case 'production':
+      return PRODUCTION_WEB_BASE_URL;
+    default:
+      logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
+      return SANDBOX_WEB_BASE_URL;
+  }
+}
+
+/**
+ * Resolve the Allegro REST API base URL for an environment.
+ *
+ * Used for `/me` and every other REST call. Accepts an un-narrowed `string` and
+ * defaults to sandbox on anything other than `'production'` — the default MUST stay
+ * aligned with {@link getAllegroWebBaseUrl}'s default (see the constant comment above).
+ */
+export function getAllegroRestApiBaseUrl(environment: string): string {
+  switch (environment) {
+    case 'sandbox':
+      return SANDBOX_REST_API_BASE_URL;
+    case 'production':
+      return PRODUCTION_REST_API_BASE_URL;
+    default:
+      logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
+      return SANDBOX_REST_API_BASE_URL;
+  }
+}

--- a/libs/integrations/allegro/src/infrastructure/token-refresh/allegro-token-refresh.service.ts
+++ b/libs/integrations/allegro/src/infrastructure/token-refresh/allegro-token-refresh.service.ts
@@ -20,6 +20,7 @@ import type { AllegroCredentials } from '../../domain/types/allegro-credentials.
 import { AllegroConfigException } from '../../domain/exceptions/allegro-config.exception';
 import { AllegroAuthenticationException } from '../../domain/exceptions/allegro-authentication.exception';
 import { AllegroNetworkException } from '../../domain/exceptions/allegro-network.exception';
+import { getAllegroWebBaseUrl } from '../http/allegro-hosts';
 import { RedisClientType } from 'redis';
 
 /**
@@ -134,14 +135,15 @@ export class AllegroTokenRefreshService {
       }
 
       const environment = config.environment || 'sandbox';
-      const apiBaseUrl = this.getApiBaseUrl(environment);
+      // `/auth/oauth/token` is served from the Allegro web host, not the REST host.
+      const webBaseUrl = getAllegroWebBaseUrl(environment);
 
       // Call Allegro token refresh endpoint
       const tokenResponse = await this.callRefreshEndpoint(
         credentials.refreshToken,
         credentials.clientId,
         credentials.clientSecret,
-        apiBaseUrl
+        webBaseUrl
       );
 
       // Prepare updated credentials
@@ -192,21 +194,21 @@ export class AllegroTokenRefreshService {
    * @param refreshToken - OAuth refresh token
    * @param clientId - OAuth client ID
    * @param clientSecret - OAuth client secret
-   * @param apiBaseUrl - Allegro API base URL
+   * @param webBaseUrl - Allegro web host (serves `/auth/oauth/token`)
    * @returns Token response from Allegro
    */
   private async callRefreshEndpoint(
     refreshToken: string,
     clientId: string,
     clientSecret: string,
-    apiBaseUrl: string
+    webBaseUrl: string
   ): Promise<{
     access_token: string;
     refresh_token?: string;
     expires_in?: number;
     token_type: string;
   }> {
-    const tokenUrl = new URL('/auth/oauth/token', apiBaseUrl);
+    const tokenUrl = new URL('/auth/oauth/token', webBaseUrl);
 
     // Prepare token refresh request
     const tokenRequest = {
@@ -310,21 +312,6 @@ export class AllegroTokenRefreshService {
     } catch (error) {
       this.logger.error(`Failed to release lock ${lockKey}: ${(error as Error).message}`, error);
       // Non-critical error, continue
-    }
-  }
-
-  /**
-   * Get API base URL for environment
-   */
-  private getApiBaseUrl(environment: string): string {
-    switch (environment) {
-      case 'sandbox':
-        return 'https://allegro.pl.allegrosandbox.pl';
-      case 'production':
-        return 'https://allegro.pl';
-      default:
-        this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
-        return 'https://allegro.pl.allegrosandbox.pl';
     }
   }
 


### PR DESCRIPTION
## What & why

Closes #892.

Allegro's two base hosts — the `allegro.pl` **web host** (OAuth authorize, `/auth/oauth/token`, storefront links) and the `api.allegro.pl` **REST host** (`/me`, `/sale/*`, `/order/*`) — were resolved by a duplicated `(environment) => host` switch in **five** runtime sites. That duplication is exactly how #889 shipped: one copy held the web host where the REST host was correct.

This extracts a single pure resolver and migrates every call site onto it, so the alignment constraint is enforced in one place instead of maintained-by-convention across files.

## Changes

- **New** `infrastructure/http/allegro-hosts.ts` — pure module (no NestJS/DI), two exports:
  - `getAllegroWebBaseUrl(env)` — OAuth authorize + `/auth/oauth/token` + storefront
  - `getAllegroRestApiBaseUrl(env)` — every REST call
  - Preserves the existing warn-on-unknown-env + sandbox-default posture via the neutral `@openlinker/shared/logging` logger.
- **New** `__tests__/allegro-hosts.spec.ts` — pins the four host strings explicitly so any future value typo fails at test time; asserts both resolvers share the sandbox default.
- **Migrated 5 sites**: adapter factory (REST + storefront), connection-tester (REST), oauth-completion (OAuth + REST), token-refresh (`/auth/oauth/token`).

## Deviations from the issue (intentional)

1. **Named `getAllegroWebBaseUrl`, not the issue's `getAllegroOAuthBaseUrl`.** The `allegro.pl` host also serves storefront + token-refresh, so an "OAuth"-named helper for a storefront link would reintroduce the very name/purpose drift this issue removes. The AC mandates convergence/behaviour, not the identifier.
2. **5 call sites, not the issue's 3.** The issue's inventory missed two runtime duplicates required by the AC ("no other file contains the literal host strings"):
   - `allegro-token-refresh.service.ts` `getApiBaseUrl` — a **misnamed** web-host duplicate (returned `allegro.pl`, fed `/auth/oauth/token`); the exact #889 misnaming pattern.
   - the factory's storefront helper — same `allegro.pl` web host.

After the migration, no file other than `allegro-hosts.ts` contains a REST/web host literal (`upload.allegro.pl` and `developer.allegro.pl` are out of scope and untouched).

## Behaviour

Unchanged — every migrated site resolves to byte-identical host strings. Verified.

## How to test

```bash
pnpm --filter @openlinker/integrations-allegro test   # 27 suites / 493 tests green
pnpm type-check && pnpm lint                           # clean (0 errors)
```

The existing `allegro-oauth-completion.adapter.spec.ts` continues to assert the OAuth/REST host behaviour through the port, guarding the delegation against any behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)