### PR TITLE
feat(shipping,web): shipment label-document download endpoint + panel CTA (#884)

### DIFF
--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -19,7 +19,11 @@ import {
   type IShipmentCancellationService,
   type IShipmentDispatchNotificationService,
   type IShipmentDispatchService,
+  type IShipmentLabelService,
   type IShipmentQueryService,
+  type LabelDocument,
+  LabelDocumentNotSupportedException,
+  LabelNotAvailableException,
   Shipment,
   ShipmentCancellationNotSupportedException,
   ShipmentNotCancellableException,
@@ -29,8 +33,9 @@ import {
 } from '@openlinker/core/shipping';
 
 import type { IOrderRecordService, OrderRecord } from '@openlinker/core/orders';
+import type { Response } from 'express';
 
-import { ShipmentController } from './shipment.controller';
+import { ShipmentController, extensionForContentType } from './shipment.controller';
 import type { GenerateLabelDto } from './dto/generate-label.dto';
 import type { ListShipmentsQueryDto } from './dto/list-shipments-query.dto';
 
@@ -73,6 +78,7 @@ describe('ShipmentController', () => {
   let dispatch: jest.Mocked<IShipmentDispatchService>;
   let cancellation: jest.Mocked<IShipmentCancellationService>;
   let notification: jest.Mocked<IShipmentDispatchNotificationService>;
+  let labelService: jest.Mocked<IShipmentLabelService>;
   let orders: jest.Mocked<IOrderRecordService>;
   let controller: ShipmentController;
 
@@ -85,6 +91,7 @@ describe('ShipmentController', () => {
     dispatch = { dispatch: jest.fn() };
     cancellation = { cancel: jest.fn() };
     notification = { notifyDispatched: jest.fn() };
+    labelService = { fetchLabel: jest.fn() };
     orders = {
       persistOrder: jest.fn(),
       updateSyncStatus: jest.fn(),
@@ -93,7 +100,14 @@ describe('ShipmentController', () => {
       getOrderRecord: jest.fn().mockResolvedValue(null),
       findMany: jest.fn(),
     };
-    controller = new ShipmentController(query, dispatch, cancellation, notification, orders);
+    controller = new ShipmentController(
+      query,
+      dispatch,
+      cancellation,
+      notification,
+      labelService,
+      orders,
+    );
   });
 
   describe('list', () => {
@@ -332,6 +346,108 @@ describe('ShipmentController', () => {
       await expect(controller.notifyDispatched('missing')).rejects.toBeInstanceOf(
         NotFoundException,
       );
+    });
+  });
+
+  describe('downloadLabel', () => {
+    function makeRes(): {
+      res: Response;
+      setHeader: jest.Mock;
+      send: jest.Mock;
+    } {
+      const setHeader = jest.fn();
+      const send = jest.fn();
+      const res = { setHeader, send } as unknown as Response;
+      return { res, setHeader, send };
+    }
+
+    it('should stream the bytes with content-type + attachment disposition', async () => {
+      const doc: LabelDocument = {
+        contentType: 'application/pdf',
+        body: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+      };
+      labelService.fetchLabel.mockResolvedValue(doc);
+      const { res, setHeader, send } = makeRes();
+
+      await controller.downloadLabel('ol_shipment_1', res);
+
+      expect(labelService.fetchLabel).toHaveBeenCalledWith('ol_shipment_1');
+      expect(setHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+      expect(setHeader).toHaveBeenCalledWith(
+        'Content-Disposition',
+        'attachment; filename="ol-shipment-ol_shipment_1.pdf"',
+      );
+      expect(send).toHaveBeenCalledWith(Buffer.from(doc.body));
+    });
+
+    it('should use the content-type-derived extension for a non-PDF document', async () => {
+      labelService.fetchLabel.mockResolvedValue({
+        contentType: 'application/zpl',
+        body: new Uint8Array([0x5e, 0x58, 0x41]),
+      });
+      const { res, setHeader } = makeRes();
+
+      await controller.downloadLabel('ol_shipment_1', res);
+
+      expect(setHeader).toHaveBeenCalledWith(
+        'Content-Disposition',
+        'attachment; filename="ol-shipment-ol_shipment_1.zpl"',
+      );
+    });
+
+    it('should map ShipmentNotFoundException to 404', async () => {
+      labelService.fetchLabel.mockRejectedValue(new ShipmentNotFoundException('missing'));
+      const { res } = makeRes();
+
+      await expect(controller.downloadLabel('missing', res)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('should map LabelNotAvailableException to 422', async () => {
+      labelService.fetchLabel.mockRejectedValue(new LabelNotAvailableException('ol_shipment_1'));
+      const { res } = makeRes();
+
+      await expect(controller.downloadLabel('ol_shipment_1', res)).rejects.toBeInstanceOf(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('should map LabelDocumentNotSupportedException to 422', async () => {
+      labelService.fetchLabel.mockRejectedValue(
+        new LabelDocumentNotSupportedException('ol_shipment_1', 'conn-1'),
+      );
+      const { res } = makeRes();
+
+      await expect(controller.downloadLabel('ol_shipment_1', res)).rejects.toBeInstanceOf(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('should map ShippingProviderRejectionException to 502', async () => {
+      labelService.fetchLabel.mockRejectedValue(
+        new ShippingProviderRejectionException('inpost', 'api.http-500', 'boom'),
+      );
+      const { res } = makeRes();
+
+      await expect(controller.downloadLabel('ol_shipment_1', res)).rejects.toBeInstanceOf(
+        BadGatewayException,
+      );
+    });
+  });
+
+  describe('extensionForContentType', () => {
+    it.each([
+      ['application/pdf', 'pdf'],
+      ['application/pdf; charset=binary', 'pdf'],
+      ['image/png', 'png'],
+      ['application/zpl', 'zpl'],
+      ['application/x-zpl', 'zpl'],
+      ['application/epl', 'epl'],
+      ['', 'bin'],
+      ['application/octet-stream', 'bin'],
+    ])('maps %s → %s', (ct, ext) => {
+      expect(extensionForContentType(ct)).toBe(ext);
     });
   });
 });

--- a/apps/api/src/shipping/http/shipment.controller.ts
+++ b/apps/api/src/shipping/http/shipment.controller.ts
@@ -27,20 +27,33 @@ import {
   Param,
   Post,
   Query,
+  Res,
   UnprocessableEntityException,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiProduces,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import {
   type IShipmentCancellationService,
   type IShipmentDispatchNotificationService,
   type IShipmentDispatchService,
+  type IShipmentLabelService,
   type IShipmentQueryService,
   type ShipmentDispatchInput,
   type ShipmentFilters,
   SHIPMENT_CANCELLATION_SERVICE_TOKEN,
   SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
   SHIPMENT_DISPATCH_SERVICE_TOKEN,
+  SHIPMENT_LABEL_SERVICE_TOKEN,
   SHIPMENT_QUERY_SERVICE_TOKEN,
+  LabelDocumentNotSupportedException,
+  LabelNotAvailableException,
   ShipmentCancellationNotSupportedException,
   ShipmentNotCancellableException,
   ShipmentNotFoundException,
@@ -73,6 +86,8 @@ export class ShipmentController {
     private readonly cancellation: IShipmentCancellationService,
     @Inject(SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN)
     private readonly notification: IShipmentDispatchNotificationService,
+    @Inject(SHIPMENT_LABEL_SERVICE_TOKEN)
+    private readonly label: IShipmentLabelService,
     @Inject(ORDER_RECORD_SERVICE_TOKEN)
     private readonly orders: IOrderRecordService,
   ) {}
@@ -134,6 +149,34 @@ export class ShipmentController {
       throw new NotFoundException(`Shipment not found: ${id}`);
     }
     return ShipmentResponseDto.fromDomain(shipment, await this.resolveCustomerId(shipment.orderId));
+  }
+
+  @Get(':id/label')
+  @ApiOperation({
+    summary: "Download a shipment's label document (PDF/ZPL/PNG, provider-dependent)",
+  })
+  @ApiProduces('application/pdf')
+  @ApiResponse({ status: 200, description: 'Label document bytes (Content-Type per provider)' })
+  @ApiResponse({ status: 404, description: 'Shipment not found' })
+  @ApiResponse({
+    status: 422,
+    description: 'No label generated yet, or provider cannot return label documents',
+  })
+  @ApiResponse({ status: 502, description: 'Shipping provider rejected the label fetch' })
+  async downloadLabel(@Param('id') id: string, @Res() res: Response): Promise<void> {
+    // `@Res()` disables Nest's global serializer for this handler — intended,
+    // since the response is binary, not JSON. The service call runs FIRST so a
+    // thrown domain exception still routes through Nest's exception layer
+    // before any header/byte is written; `res.*` only ever runs on success.
+    try {
+      const { contentType, body } = await this.label.fetchLabel(id);
+      const ext = extensionForContentType(contentType);
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Disposition', `attachment; filename="ol-shipment-${id}.${ext}"`);
+      res.send(Buffer.from(body));
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
   }
 
   @Post('generate-label')
@@ -262,7 +305,9 @@ export class ShipmentController {
     }
     if (
       error instanceof ShipmentCancellationNotSupportedException ||
-      error instanceof UndispatchableResolutionException
+      error instanceof UndispatchableResolutionException ||
+      error instanceof LabelDocumentNotSupportedException ||
+      error instanceof LabelNotAvailableException
     ) {
       return new UnprocessableEntityException(error.message);
     }
@@ -277,5 +322,32 @@ export class ShipmentController {
       return new InternalServerErrorException(error.message);
     }
     return new InternalServerErrorException(String(error));
+  }
+}
+
+/**
+ * Map a label document's MIME type to a download-filename extension. The label
+ * bytes are NOT always PDF — Allegro returns ZPL/EPL per the seller's "Ship
+ * with Allegro" setting and InPost ShipX can return PNG — so the saved file
+ * must be labelled by its actual content type, never hardcoded to `.pdf`.
+ * Falls back to `bin` for anything unrecognised so the download never claims a
+ * format it isn't.
+ */
+export function extensionForContentType(contentType: string): string {
+  const ct = contentType.toLowerCase().split(';', 1)[0].trim();
+  switch (ct) {
+    case 'application/pdf':
+      return 'pdf';
+    case 'image/png':
+      return 'png';
+    case 'application/zpl':
+    case 'application/x-zpl':
+    case 'text/zpl':
+      return 'zpl';
+    case 'application/epl':
+    case 'application/x-epl':
+      return 'epl';
+    default:
+      return 'bin';
   }
 }

--- a/apps/api/test/integration/helpers/inpost-test-shipping-stub.helper.ts
+++ b/apps/api/test/integration/helpers/inpost-test-shipping-stub.helper.ts
@@ -26,6 +26,8 @@ import {
 import type {
   GenerateLabelCommand,
   GenerateLabelResult,
+  LabelDocument,
+  LabelDocumentReader,
   ShipmentCanceller,
   ShippingMethod,
   ShippingProviderManagerPort,
@@ -35,6 +37,9 @@ import type { IntegrationTestHarness } from '../setup';
 
 export const INPOST_TEST_ADAPTER_KEY = 'inpost.test.v1';
 export const INPOST_TEST_PLATFORM_TYPE = 'inpost';
+
+/** Canned label bytes the stub returns from `fetchLabel` (`%PDF` magic). */
+export const STUB_LABEL_BYTES = Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x2d]);
 
 export function installInpostTestShippingStub(harness: IntegrationTestHarness): {
   readonly adapterKey: string;
@@ -46,10 +51,13 @@ export function installInpostTestShippingStub(harness: IntegrationTestHarness): 
     .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
 
   let counter = 0;
-  // Implements ShipmentCanceller too (#846): the cancel command resolves this
-  // adapter and narrows via `isShipmentCanceller`. #835's dispatch spec ignores
-  // the extra method, so adding it is backward-compatible.
-  const shippingStub: ShippingProviderManagerPort & ShipmentCanceller = {
+  // Implements ShipmentCanceller + LabelDocumentReader too (#846 / #884): the
+  // cancel + label endpoints resolve this adapter and narrow via the
+  // co-located guards. #835's dispatch spec ignores the extra methods, so
+  // adding them is backward-compatible.
+  const shippingStub: ShippingProviderManagerPort &
+    ShipmentCanceller &
+    LabelDocumentReader = {
     getSupportedMethods(): readonly ShippingMethod[] {
       return ['paczkomat', 'kurier'];
     },
@@ -66,6 +74,9 @@ export function installInpostTestShippingStub(harness: IntegrationTestHarness): 
     },
     cancelShipment(_input: { providerShipmentId: string }): Promise<void> {
       return Promise.resolve();
+    },
+    fetchLabel(_input: { providerShipmentId: string }): Promise<LabelDocument> {
+      return Promise.resolve({ contentType: 'application/pdf', body: STUB_LABEL_BYTES });
     },
   };
 

--- a/apps/api/test/integration/shipment-label-download.int-spec.ts
+++ b/apps/api/test/integration/shipment-label-download.int-spec.ts
@@ -10,7 +10,6 @@
  *
  * @module apps/api/test/integration
  */
-import request from 'supertest';
 import {
   FULFILLMENT_PROCESSOR_KIND,
   FULFILLMENT_ROUTING_SERVICE_TOKEN,

--- a/apps/api/test/integration/shipment-label-download.int-spec.ts
+++ b/apps/api/test/integration/shipment-label-download.int-spec.ts
@@ -22,7 +22,6 @@ import {
   teardownTestHarness,
 } from './setup';
 import { loginAsAdmin } from './helpers/test-auth.helper';
-import type { TestHttpClient } from './helpers/http-client';
 import { createTestConnection } from './helpers/test-connection.helper';
 import {
   INPOST_TEST_ADAPTER_KEY,
@@ -91,7 +90,7 @@ describe('Shipment Label Download API Integration', () => {
   // `loginAsAdmin` does a plain INSERT of a fixed admin user (no upsert), so a
   // second login in the same test would violate the users unique constraint.
   async function seedShipment(
-    http: TestHttpClient,
+    http: ReturnType<IntegrationTestHarness['getHttp']>,
     token: string,
     orderId: string,
   ): Promise<string> {
@@ -115,7 +114,7 @@ describe('Shipment Label Download API Integration', () => {
     it('should stream the label bytes with content-type + attachment disposition', async () => {
       const http = harness.getHttp();
       const token = await loginAsAdmin(http, harness.getDataSource());
-      const id = await seedShipment('ol_order_label_1');
+      const id = await seedShipment(http, token, 'ol_order_label_1');
 
       const res = await http
         .get(`/shipments/${id}/label`)

--- a/apps/api/test/integration/shipment-label-download.int-spec.ts
+++ b/apps/api/test/integration/shipment-label-download.int-spec.ts
@@ -22,6 +22,7 @@ import {
   teardownTestHarness,
 } from './setup';
 import { loginAsAdmin } from './helpers/test-auth.helper';
+import type { TestHttpClient } from './helpers/http-client';
 import { createTestConnection } from './helpers/test-connection.helper';
 import {
   INPOST_TEST_ADAPTER_KEY,
@@ -86,9 +87,14 @@ describe('Shipment Label Download API Integration', () => {
     return { sourceId: source.id, carrierId: carrier.id };
   }
 
-  async function seedShipment(orderId: string): Promise<string> {
-    const http = harness.getHttp();
-    const token = await loginAsAdmin(http, harness.getDataSource());
+  // Takes the caller's token + http rather than logging in itself —
+  // `loginAsAdmin` does a plain INSERT of a fixed admin user (no upsert), so a
+  // second login in the same test would violate the users unique constraint.
+  async function seedShipment(
+    http: TestHttpClient,
+    token: string,
+    orderId: string,
+  ): Promise<string> {
     const { sourceId } = await seedRoute();
     const created = await http
       .post('/shipments/generate-label')

--- a/apps/api/test/integration/shipment-label-download.int-spec.ts
+++ b/apps/api/test/integration/shipment-label-download.int-spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Shipment Label Download API Integration Test (#884)
+ *
+ * Exercises `GET /shipments/:id/label` end-to-end against real Postgres + Nest
+ * wiring. A shipment is seeded through the generate-label endpoint (the #835
+ * dispatch seam → in-memory stub adapter that also implements
+ * `LabelDocumentReader`), then its label is fetched. Asserts the byte payload
+ * + `Content-Type` + `Content-Disposition` round-trip, and the 404 / 422
+ * branches.
+ *
+ * @module apps/api/test/integration
+ */
+import request from 'supertest';
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+import { createTestConnection } from './helpers/test-connection.helper';
+import {
+  INPOST_TEST_ADAPTER_KEY,
+  STUB_LABEL_BYTES,
+  installInpostTestShippingStub,
+} from './helpers/inpost-test-shipping-stub.helper';
+
+const RECIPIENT = {
+  email: 'buyer@example.com',
+  phone: '+48500600700',
+  address: {
+    street: 'Krakowska',
+    buildingNumber: '12',
+    city: 'Poznań',
+    postCode: '60-001',
+    countryCode: 'PL',
+  },
+};
+const PARCEL = { dimensions: { length: 200, width: 150, height: 100 }, weightGrams: 1200 };
+const METHOD = 'allegro-courier';
+
+describe('Shipment Label Download API Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    installInpostTestShippingStub(harness);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  const routingService = (): IFulfillmentRoutingService =>
+    harness.getApp().get<IFulfillmentRoutingService>(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+
+  async function seedRoute(): Promise<{ sourceId: string; carrierId: string }> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.publicapi.v1',
+      enabledCapabilities: ['OrderSource'],
+    });
+    const carrier = await createTestConnection(dataSource, {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: INPOST_TEST_ADAPTER_KEY,
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    await routingService().replaceRules(source.id, [
+      {
+        sourceDeliveryMethodId: METHOD,
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: carrier.id,
+      },
+    ]);
+    return { sourceId: source.id, carrierId: carrier.id };
+  }
+
+  async function seedShipment(orderId: string): Promise<string> {
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+    const { sourceId } = await seedRoute();
+    const created = await http
+      .post('/shipments/generate-label')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        sourceConnectionId: sourceId,
+        sourceDeliveryMethodId: METHOD,
+        orderId,
+        shippingMethod: 'kurier',
+        recipient: RECIPIENT,
+        parcel: PARCEL,
+      })
+      .expect(200);
+    return created.body.shipment.id as string;
+  }
+
+  describe('GET /shipments/:id/label', () => {
+    it('should stream the label bytes with content-type + attachment disposition', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+      const id = await seedShipment('ol_order_label_1');
+
+      const res = await http
+        .get(`/shipments/${id}/label`)
+        .set('Authorization', `Bearer ${token}`)
+        .buffer(true)
+        .parse((response, cb) => {
+          const chunks: Buffer[] = [];
+          response.on('data', (c: Buffer) => chunks.push(c));
+          response.on('end', () => cb(null, Buffer.concat(chunks)));
+        })
+        .expect(200);
+
+      expect(res.headers['content-type']).toContain('application/pdf');
+      expect(res.headers['content-disposition']).toBe(
+        `attachment; filename="ol-shipment-${id}.pdf"`,
+      );
+      expect(Buffer.compare(res.body as Buffer, Buffer.from(STUB_LABEL_BYTES))).toBe(0);
+    });
+
+    it('should 404 when the shipment does not exist', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+
+      await http
+        .get('/shipments/ol_shipment_missing/label')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+    });
+
+    it('should 401 without auth', async () => {
+      await harness.getHttp().get('/shipments/ol_shipment_x/label').expect(401);
+    });
+  });
+});

--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -68,6 +68,14 @@ interface ApiClientConfig {
 export type ApiRequest = <T>(path: string, init?: RequestInit) => Promise<T>;
 
 /**
+ * Binary-response variant of {@link ApiRequest}. Reuses the same auth-header
+ * injection + 401-refresh + timeout machinery as `request`, but reads the
+ * success response as a `Blob` (e.g. a label PDF) instead of JSON/text. Errors
+ * still normalize to `ApiError`.
+ */
+export type ApiBlobRequest = (path: string, init?: RequestInit) => Promise<Blob>;
+
+/**
  * Plugin-augmentable surface. Empty by default; each plugin extends it
  * via `declare module '../../app/api/api-client'` (see the allegro plugin
  * for the canonical pattern). The empty form is the documented TS shape
@@ -94,6 +102,7 @@ export interface CoreApiClient {
   promptTemplates: PromptTemplatesApi;
   mappings: MappingsApi;
   request: ApiRequest;
+  requestBlob: ApiBlobRequest;
   shipments: ShipmentsApi;
   syncJobs: SyncJobsApi;
   webhookDeliveries: WebhookDeliveriesApi;
@@ -204,6 +213,52 @@ export function createApiClient({
     }
   };
 
+  const requestBlob: ApiBlobRequest = async (path: string, init: RequestInit = {}): Promise<Blob> => {
+    const accessToken = await sessionAdapter.getAccessToken();
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, requestTimeoutMs);
+    const signal = init.signal
+      ? AbortSignal.any([controller.signal, init.signal])
+      : controller.signal;
+
+    try {
+      let response = await fetchWith(path, init, accessToken, signal);
+
+      if (response.status === 401 && sessionAdapter.refresh) {
+        const fresh = await sessionAdapter.refresh();
+        if (fresh) {
+          response = await fetchWith(path, init, fresh, signal);
+        }
+      }
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        // Error bodies are JSON/text — reuse the shared normaliser so the
+        // caller sees the same `ApiError` shape as every other request.
+        const payload = await readResponseBody(response);
+        throw ApiError.fromResponse(response, payload);
+      }
+
+      return await response.blob();
+    } catch (error) {
+      clearTimeout(timeoutId);
+
+      if (error instanceof ApiError) {
+        throw error;
+      }
+
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw ApiError.fromTimeout(path);
+      }
+
+      throw ApiError.fromNetworkFailure(error);
+    }
+  };
+
   const core: CoreApiClient = {
     adapters: createAdaptersApi(request),
     aiProviderSettings: createAiProviderSettingsApi(request),
@@ -220,7 +275,8 @@ export function createApiClient({
     products: createProductsApi(request),
     promptTemplates: createPromptTemplatesApi(request),
     request,
-    shipments: createShipmentsApi(request),
+    requestBlob,
+    shipments: createShipmentsApi(request, requestBlob),
     syncJobs: createSyncJobsApi(request),
     webhookDeliveries: createWebhookDeliveriesApi(request),
   };

--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -164,7 +164,14 @@ export function createApiClient({
     });
   }
 
-  const request: ApiRequest = async <T>(path: string, init: RequestInit = {}): Promise<T> => {
+  /**
+   * Shared transport: token fetch → fetch → timeout → single 401-refresh-retry
+   * → error normalisation. Returns the raw OK `Response` for the caller to read
+   * however it needs (JSON/text vs blob). `request` and `requestBlob` differ
+   * ONLY in how they consume that body — all auth/refresh/timeout/error
+   * machinery lives here so the two paths can't drift.
+   */
+  async function execute(path: string, init: RequestInit): Promise<Response> {
     const accessToken = await sessionAdapter.getAccessToken();
 
     const controller = new AbortController();
@@ -191,59 +198,15 @@ export function createApiClient({
 
       clearTimeout(timeoutId);
 
-      const payload = await readResponseBody(response);
-
       if (!response.ok) {
-        throw ApiError.fromResponse(response, payload);
-      }
-
-      return payload as T;
-    } catch (error) {
-      clearTimeout(timeoutId);
-
-      if (error instanceof ApiError) {
-        throw error;
-      }
-
-      if (error instanceof DOMException && error.name === 'AbortError') {
-        throw ApiError.fromTimeout(path);
-      }
-
-      throw ApiError.fromNetworkFailure(error);
-    }
-  };
-
-  const requestBlob: ApiBlobRequest = async (path: string, init: RequestInit = {}): Promise<Blob> => {
-    const accessToken = await sessionAdapter.getAccessToken();
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort();
-    }, requestTimeoutMs);
-    const signal = init.signal
-      ? AbortSignal.any([controller.signal, init.signal])
-      : controller.signal;
-
-    try {
-      let response = await fetchWith(path, init, accessToken, signal);
-
-      if (response.status === 401 && sessionAdapter.refresh) {
-        const fresh = await sessionAdapter.refresh();
-        if (fresh) {
-          response = await fetchWith(path, init, fresh, signal);
-        }
-      }
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        // Error bodies are JSON/text — reuse the shared normaliser so the
-        // caller sees the same `ApiError` shape as every other request.
+        // Error bodies are JSON/text on every endpoint (even binary ones) —
+        // normalise to the shared `ApiError` shape before the caller reads
+        // the success body.
         const payload = await readResponseBody(response);
         throw ApiError.fromResponse(response, payload);
       }
 
-      return await response.blob();
+      return response;
     } catch (error) {
       clearTimeout(timeoutId);
 
@@ -257,6 +220,16 @@ export function createApiClient({
 
       throw ApiError.fromNetworkFailure(error);
     }
+  }
+
+  const request: ApiRequest = async <T>(path: string, init: RequestInit = {}): Promise<T> => {
+    const response = await execute(path, init);
+    return (await readResponseBody(response)) as T;
+  };
+
+  const requestBlob: ApiBlobRequest = async (path: string, init: RequestInit = {}): Promise<Blob> => {
+    const response = await execute(path, init);
+    return response.blob();
   };
 
   const core: CoreApiClient = {

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -6,7 +6,7 @@
  * Plus the happy-path render: with a complete snapshot, the form mounts
  * focused on the first input and the submit is enabled.
  */
-import { cleanup, screen, fireEvent } from '@testing-library/react';
+import { cleanup, screen, fireEvent, waitFor } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 
 import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
@@ -160,6 +160,63 @@ describe('GenerateLabelForm — happy path', () => {
 
     // Resolve the mutation so the test doesn't leak the unresolved promise.
     resolveRef.current?.({ kind: 'dispatched', shipment: null });
+  });
+
+  it('should auto-download the label after a successful dispatched generation (#884)', async () => {
+    const downloadLabel = vi.fn().mockResolvedValue(new Blob([new Uint8Array([0x25, 0x50])]));
+    const apiClient = createMockApiClient({
+      shipments: {
+        generateLabel: vi.fn().mockResolvedValue({
+          kind: 'dispatched',
+          shipment: { id: 'ol_shipment_99', labelPdfRef: 'shipx:label:99' },
+        }),
+        downloadLabel,
+      },
+    });
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() => expect(downloadLabel).toHaveBeenCalledWith('ol_shipment_99'));
+    expect(downloadLabel).toHaveBeenCalledTimes(1);
+    vi.restoreAllMocks();
+  });
+
+  it('should NOT auto-download when generation resolves omp_fulfilled (no label)', async () => {
+    const downloadLabel = vi.fn();
+    const apiClient = createMockApiClient({
+      shipments: {
+        generateLabel: vi.fn().mockResolvedValue({ kind: 'omp_fulfilled' }),
+        downloadLabel,
+      },
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    // Wait for the success toast path to settle, then assert no download fired.
+    await waitFor(() => expect(apiClient.shipments.generateLabel).toHaveBeenCalled());
+    expect(downloadLabel).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -42,7 +42,11 @@ import {
   type ParsedOrderSnapshot,
 } from '../api/order-snapshot.schema';
 import { ordersQueryKeys } from '../api/orders.query-keys';
-import { useGenerateLabelMutation, type GenerateLabelInput } from '../../shipments';
+import {
+  useGenerateLabelMutation,
+  useLabelPdfDownload,
+  type GenerateLabelInput,
+} from '../../shipments';
 import {
   generateLabelSchema,
   type GenerateLabelFormSubmission,
@@ -92,6 +96,7 @@ export function GenerateLabelForm({
   );
 
   const mutation = useGenerateLabelMutation();
+  const labelDownload = useLabelPdfDownload();
   const { showToast } = useToast();
 
   // AC-3 retry hint (#839) — when the order is Allegro-sourced + the
@@ -170,12 +175,21 @@ export function GenerateLabelForm({
   const onSubmit: SubmitHandler<GenerateLabelFormSubmission> = async (values) => {
     const input = buildGenerateLabelInput({ order, snapshot, values, shippingMethod });
     try {
-      await mutation.mutateAsync(input);
+      const result = await mutation.mutateAsync(input);
       showToast({
         tone: 'success',
         title: 'Label generated',
         description: 'Tracking number will appear within ~5 minutes.',
       });
+      // Auto-download the freshly-issued label (AC: "download triggered
+      // immediately after successful generation"). Imperative + guarded on the
+      // returned result so it fires exactly once per issuance — NOT a reactive
+      // effect, which would re-fire on the post-success query invalidation.
+      // Only the OL-managed-dispatch branch issues a label; the omp_fulfilled
+      // branch carries no shipment.
+      if (result.kind === 'dispatched' && result.shipment?.labelPdfRef) {
+        void labelDownload.download(result.shipment.id);
+      }
       form.reset();
       onSuccess();
     } catch {

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -44,7 +44,7 @@ import {
 import { ordersQueryKeys } from '../api/orders.query-keys';
 import {
   useGenerateLabelMutation,
-  useLabelPdfDownload,
+  useLabelDownload,
   type GenerateLabelInput,
 } from '../../shipments';
 import {
@@ -96,7 +96,7 @@ export function GenerateLabelForm({
   );
 
   const mutation = useGenerateLabelMutation();
-  const labelDownload = useLabelPdfDownload();
+  const labelDownload = useLabelDownload();
   const { showToast } = useToast();
 
   // AC-3 retry hint (#839) — when the order is Allegro-sourced + the

--- a/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
@@ -5,7 +5,7 @@
  * status matrix, empty-state CTA, tracking link, paczkomat caption keyed on
  * shipping connection's platformType.
  */
-import { cleanup, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
 import { OrderShipmentPanel } from './order-shipment-panel';
@@ -222,20 +222,25 @@ describe('OrderShipmentPanel — action button matrix (§3.4)', () => {
   it.each([
     // Plan §3.4 status-matrix coverage.
     // `draft` → generate-as-retry per the spec ("enabled (retry)").
-    ['draft', { generate: true, cancel: false, notify: false }],
-    ['generated', { generate: false, cancel: true, notify: true }],
-    ['dispatched', { generate: false, cancel: false, notify: false }],
-    ['in-transit', { generate: false, cancel: false, notify: false }],
-    ['delivered', { generate: true, cancel: false, notify: false }],
-    ['failed', { generate: true, cancel: false, notify: false }],
-    ['cancelled', { generate: true, cancel: false, notify: false }],
+    // `download` column assumes a non-null labelPdfRef (set below) so it
+    // isolates the lifecycle-state gate; the ref-absent case is covered separately.
+    ['draft', { generate: true, cancel: false, notify: false, download: false }],
+    ['generated', { generate: false, cancel: true, notify: true, download: true }],
+    ['dispatched', { generate: false, cancel: false, notify: false, download: true }],
+    ['in-transit', { generate: false, cancel: false, notify: false, download: true }],
+    ['delivered', { generate: true, cancel: false, notify: false, download: true }],
+    ['failed', { generate: true, cancel: false, notify: false, download: false }],
+    ['cancelled', { generate: true, cancel: false, notify: false, download: false }],
   ] as const)('should compute enablement for status %s', async (status, expected) => {
     const apiClient = createMockApiClient({
       connections: { list: vi.fn().mockResolvedValue([makeConnection()]) },
       shipments: {
-        list: vi
-          .fn()
-          .mockResolvedValue({ items: [makeShipment({ status })], total: 1, limit: 20, offset: 0 }),
+        list: vi.fn().mockResolvedValue({
+          items: [makeShipment({ status, labelPdfRef: 'shipx:label:1' })],
+          total: 1,
+          limit: 20,
+          offset: 0,
+        }),
       },
     });
 
@@ -249,10 +254,33 @@ describe('OrderShipmentPanel — action button matrix (§3.4)', () => {
     const generate = screen.getByRole('button', { name: /Generate label|Generate shipping label/i });
     const cancel = screen.getByRole('button', { name: /^Cancel$/i });
     const notify = screen.getByRole('button', { name: /Mark dispatched/i });
+    const download = screen.getByRole('button', { name: /Download label|Download shipping label/i });
 
     expect((generate as HTMLButtonElement).disabled).toBe(!expected.generate);
     expect((cancel as HTMLButtonElement).disabled).toBe(!expected.cancel);
     expect((notify as HTMLButtonElement).disabled).toBe(!expected.notify);
+    expect((download as HTMLButtonElement).disabled).toBe(!expected.download);
+  });
+
+  it('should disable Download label when the shipment has no labelPdfRef even if dispatched', async () => {
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([makeConnection()]) },
+      shipments: {
+        list: vi.fn().mockResolvedValue({
+          items: [makeShipment({ status: 'dispatched', labelPdfRef: null })],
+          total: 1,
+          limit: 20,
+          offset: 0,
+        }),
+      },
+    });
+
+    renderWithProviders(<OrderShipmentPanel order={makeOrder()} />, { apiClient });
+
+    const download = await screen.findByRole('button', {
+      name: /Download label|Download shipping label/i,
+    });
+    expect((download as HTMLButtonElement).disabled).toBe(true);
   });
 
   // ── #839 — branch-1 (shippingMethod='omp') awareness ─────────────────
@@ -289,5 +317,45 @@ describe('OrderShipmentPanel — action button matrix (§3.4)', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Cancel$/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Mark dispatched/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Download label|Download shipping label/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should call the download API + name the file by the blob content type when clicked', async () => {
+    const downloadLabel = vi
+      .fn()
+      .mockResolvedValue(new Blob([new Uint8Array([0x25, 0x50])], { type: 'application/pdf' }));
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([makeConnection()]) },
+      shipments: {
+        list: vi.fn().mockResolvedValue({
+          items: [makeShipment({ status: 'dispatched', labelPdfRef: 'shipx:label:1' })],
+          total: 1,
+          limit: 20,
+          offset: 0,
+        }),
+        downloadLabel,
+      },
+    });
+    // jsdom lacks createObjectURL/revokeObjectURL — stub so the hook runs.
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    // Capture the click target's download attribute (filename + extension).
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+
+    renderWithProviders(<OrderShipmentPanel order={makeOrder()} />, { apiClient });
+
+    const button = await screen.findByRole('button', {
+      name: /Download label|Download shipping label/i,
+    });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(downloadLabel).toHaveBeenCalledWith('ol_shipment_1'));
+    const anchor = clickSpy.mock.instances[0] as HTMLAnchorElement;
+    expect(anchor.download).toBe('ol-shipment-ol_shipment_1.pdf');
+    vi.restoreAllMocks();
   });
 });

--- a/apps/web/src/features/orders/components/shipment-action-buttons.tsx
+++ b/apps/web/src/features/orders/components/shipment-action-buttons.tsx
@@ -13,11 +13,13 @@ import { useState, type ReactElement } from 'react';
 import {
   useCancelShipmentMutation,
   useNotifyDispatchedMutation,
+  useLabelPdfDownload,
   type Shipment,
   type ShipmentStatus,
 } from '../../shipments';
 import { Button } from '../../../shared/ui/button';
 import { ConfirmDialog } from '../../../shared/ui/confirm-dialog';
+import { useToast } from '../../../shared/ui/toast-provider';
 import { getCarrierDisplayName } from '../../shipments';
 
 interface ShipmentActionButtonsProps {
@@ -38,6 +40,14 @@ const CAN_GENERATE: ReadonlySet<ShipmentStatus | 'none'> = new Set([
 
 const CAN_CANCEL: ReadonlySet<ShipmentStatus> = new Set(['generated']);
 const CAN_NOTIFY_DISPATCHED: ReadonlySet<ShipmentStatus> = new Set(['generated']);
+// A label document exists once the shipment is generated and stays retrievable
+// through the carrier-tracked lifecycle; cancelled/failed/draft have none.
+const CAN_DOWNLOAD_LABEL: ReadonlySet<ShipmentStatus> = new Set([
+  'generated',
+  'dispatched',
+  'in-transit',
+  'delivered',
+]);
 
 export function ShipmentActionButtons({
   shipment,
@@ -45,6 +55,8 @@ export function ShipmentActionButtons({
 }: ShipmentActionButtonsProps): ReactElement {
   const cancelMutation = useCancelShipmentMutation();
   const notifyMutation = useNotifyDispatchedMutation();
+  const labelDownload = useLabelPdfDownload();
+  const { showToast } = useToast();
 
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [notifyDialogOpen, setNotifyDialogOpen] = useState(false);
@@ -69,6 +81,21 @@ export function ShipmentActionButtons({
   const canGenerate = CAN_GENERATE.has(status);
   const canCancel = shipment !== null && CAN_CANCEL.has(shipment.status);
   const canNotify = shipment !== null && CAN_NOTIFY_DISPATCHED.has(shipment.status);
+  // Label download needs both a retrievable lifecycle state AND a persisted
+  // label ref (the "a label was generated" marker).
+  const canDownloadLabel =
+    shipment !== null &&
+    shipment.labelPdfRef !== null &&
+    CAN_DOWNLOAD_LABEL.has(shipment.status);
+
+  const handleDownloadLabel = (): void => {
+    if (!shipment) return;
+    void labelDownload.download(shipment.id).then((ok) => {
+      if (!ok) {
+        showToast({ tone: 'error', description: 'Could not download the label. Try again.' });
+      }
+    });
+  };
 
   const carrierName = getCarrierDisplayName(shipment?.carrier ?? null) ?? 'the carrier';
 
@@ -101,6 +128,19 @@ export function ShipmentActionButtons({
           disabled={!canNotify || notifyMutation.isPending}
         >
           Mark dispatched
+        </Button>
+        <Button
+          tone="secondary"
+          className="button--sm"
+          onClick={handleDownloadLabel}
+          disabled={!canDownloadLabel || labelDownload.isDownloading}
+          aria-label={
+            canDownloadLabel
+              ? 'Download shipping label'
+              : 'Download label not available in this state'
+          }
+        >
+          {labelDownload.isDownloading ? 'Downloading…' : 'Download label'}
         </Button>
       </div>
 

--- a/apps/web/src/features/orders/components/shipment-action-buttons.tsx
+++ b/apps/web/src/features/orders/components/shipment-action-buttons.tsx
@@ -13,7 +13,7 @@ import { useState, type ReactElement } from 'react';
 import {
   useCancelShipmentMutation,
   useNotifyDispatchedMutation,
-  useLabelPdfDownload,
+  useLabelDownload,
   type Shipment,
   type ShipmentStatus,
 } from '../../shipments';
@@ -55,7 +55,7 @@ export function ShipmentActionButtons({
 }: ShipmentActionButtonsProps): ReactElement {
   const cancelMutation = useCancelShipmentMutation();
   const notifyMutation = useNotifyDispatchedMutation();
-  const labelDownload = useLabelPdfDownload();
+  const labelDownload = useLabelDownload();
   const { showToast } = useToast();
 
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);

--- a/apps/web/src/features/shipments/api/shipments.api.ts
+++ b/apps/web/src/features/shipments/api/shipments.api.ts
@@ -39,10 +39,19 @@ export interface ShipmentsApi {
    *  notify + destination OMP projection. Idempotent: re-firing on an
    *  already-dispatched shipment returns `outcome: 'skipped-not-generated'`. */
   notifyDispatched: (id: string) => Promise<NotifyDispatchedResult>;
+
+  /** `GET /shipments/:id/label` (#884) — fetch the label document bytes as a
+   *  Blob. Content type is provider-dependent (PDF / ZPL / PNG); the browser
+   *  filename comes from the server's `Content-Disposition` header. */
+  downloadLabel: (id: string) => Promise<Blob>;
 }
 
 interface ApiRequest {
   <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+interface ApiBlobRequest {
+  (path: string, init?: RequestInit): Promise<Blob>;
 }
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
@@ -64,7 +73,10 @@ function buildQuery(filters?: ShipmentFilters, pagination?: ShipmentPagination):
   return qs.length > 0 ? `?${qs}` : '';
 }
 
-export function createShipmentsApi(request: ApiRequest): ShipmentsApi {
+export function createShipmentsApi(
+  request: ApiRequest,
+  requestBlob: ApiBlobRequest,
+): ShipmentsApi {
   return {
     list(filters, pagination): Promise<PaginatedShipments> {
       return request<PaginatedShipments>(`/shipments${buildQuery(filters, pagination)}`);
@@ -90,6 +102,9 @@ export function createShipmentsApi(request: ApiRequest): ShipmentsApi {
           headers: JSON_HEADERS,
         },
       );
+    },
+    downloadLabel(id): Promise<Blob> {
+      return requestBlob(`/shipments/${encodeURIComponent(id)}/label`);
     },
   };
 }

--- a/apps/web/src/features/shipments/hooks/use-label-download.ts
+++ b/apps/web/src/features/shipments/hooks/use-label-download.ts
@@ -1,5 +1,5 @@
 /**
- * useLabelPdfDownload
+ * useLabelDownload
  *
  * One-shot action (NOT a TanStack mutation) that fetches a shipment's label
  * document via `apiClient.shipments.downloadLabel(id)` and triggers a browser
@@ -39,7 +39,7 @@ function extensionForBlob(blob: Blob): string {
   return EXTENSION_BY_MIME[mime] ?? 'bin';
 }
 
-interface UseLabelPdfDownload {
+interface UseLabelDownload {
   /** Fetch + trigger the browser download. Resolves `true` on success, `false`
    *  when the fetch failed (the error is also exposed via `error`). */
   download: (shipmentId: string) => Promise<boolean>;
@@ -47,7 +47,7 @@ interface UseLabelPdfDownload {
   error: Error | null;
 }
 
-export function useLabelPdfDownload(): UseLabelPdfDownload {
+export function useLabelDownload(): UseLabelDownload {
   const apiClient = useApiClient();
   const [isDownloading, setIsDownloading] = useState(false);
   const [error, setError] = useState<Error | null>(null);

--- a/apps/web/src/features/shipments/hooks/use-label-pdf-download.ts
+++ b/apps/web/src/features/shipments/hooks/use-label-pdf-download.ts
@@ -1,0 +1,93 @@
+/**
+ * useLabelPdfDownload
+ *
+ * One-shot action (NOT a TanStack mutation) that fetches a shipment's label
+ * document via `apiClient.shipments.downloadLabel(id)` and triggers a browser
+ * download through an in-memory object URL + programmatic `<a download>` click.
+ *
+ * Filename: a blob-URL download cannot read the server's `Content-Disposition`
+ * header (the object URL carries no HTTP headers), so the extension is derived
+ * from `blob.type` — which `Response.blob()` populates from the response
+ * `Content-Type`. This mirrors the backend's content-type → extension mapping
+ * so a PDF/ZPL/PNG label saves with the right extension.
+ *
+ * Exposes local `{ download, isDownloading, error }` state — there's nothing to
+ * cache, so this is deliberately not a query/mutation hook.
+ *
+ * @module apps/web/src/features/shipments/hooks
+ */
+import { useCallback, useState } from 'react';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+/**
+ * Map a label blob's MIME type to a download-filename extension. Mirrors the
+ * backend `extensionForContentType` (apps/api shipment.controller) — the two
+ * can't share code across the FE/BE boundary, so the small map is duplicated.
+ */
+const EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
+  'application/pdf': 'pdf',
+  'image/png': 'png',
+  'application/zpl': 'zpl',
+  'application/x-zpl': 'zpl',
+  'text/zpl': 'zpl',
+  'application/epl': 'epl',
+  'application/x-epl': 'epl',
+};
+
+function extensionForBlob(blob: Blob): string {
+  const mime = blob.type.toLowerCase().split(';', 1)[0]?.trim() ?? '';
+  return EXTENSION_BY_MIME[mime] ?? 'bin';
+}
+
+interface UseLabelPdfDownload {
+  /** Fetch + trigger the browser download. Resolves `true` on success, `false`
+   *  when the fetch failed (the error is also exposed via `error`). */
+  download: (shipmentId: string) => Promise<boolean>;
+  isDownloading: boolean;
+  error: Error | null;
+}
+
+export function useLabelPdfDownload(): UseLabelPdfDownload {
+  const apiClient = useApiClient();
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const download = useCallback(
+    async (shipmentId: string): Promise<boolean> => {
+      setIsDownloading(true);
+      setError(null);
+      let objectUrl: string | null = null;
+      try {
+        const blob = await apiClient.shipments.downloadLabel(shipmentId);
+        objectUrl = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = objectUrl;
+        anchor.download = `ol-shipment-${shipmentId}.${extensionForBlob(blob)}`;
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        // Defer revoke past the current tick: some engines cancel the in-flight
+        // download if the object URL is revoked synchronously after click().
+        if (objectUrl) {
+          const toRevoke = objectUrl;
+          setTimeout(() => URL.revokeObjectURL(toRevoke), 0);
+          objectUrl = null;
+        }
+        return true;
+      } catch (caught) {
+        setError(caught instanceof Error ? caught : new Error(String(caught)));
+        return false;
+      } finally {
+        // Only fires on the error path (success nulls `objectUrl` after
+        // scheduling the deferred revoke above).
+        if (objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+        }
+        setIsDownloading(false);
+      }
+    },
+    [apiClient],
+  );
+
+  return { download, isDownloading, error };
+}

--- a/apps/web/src/features/shipments/index.ts
+++ b/apps/web/src/features/shipments/index.ts
@@ -39,5 +39,6 @@ export { useOrderShipmentsQuery } from './hooks/use-order-shipments-query';
 export { useGenerateLabelMutation } from './hooks/use-generate-label-mutation';
 export { useCancelShipmentMutation } from './hooks/use-cancel-shipment-mutation';
 export { useNotifyDispatchedMutation } from './hooks/use-notify-dispatched-mutation';
+export { useLabelPdfDownload } from './hooks/use-label-pdf-download';
 export { ShipmentStatusBadge } from './components/shipment-status-badge';
 export { buildCarrierTrackingUrl, getCarrierDisplayName } from './lib/carrier-tracking-url';

--- a/apps/web/src/features/shipments/index.ts
+++ b/apps/web/src/features/shipments/index.ts
@@ -39,6 +39,6 @@ export { useOrderShipmentsQuery } from './hooks/use-order-shipments-query';
 export { useGenerateLabelMutation } from './hooks/use-generate-label-mutation';
 export { useCancelShipmentMutation } from './hooks/use-cancel-shipment-mutation';
 export { useNotifyDispatchedMutation } from './hooks/use-notify-dispatched-mutation';
-export { useLabelPdfDownload } from './hooks/use-label-pdf-download';
+export { useLabelDownload } from './hooks/use-label-download';
 export { ShipmentStatusBadge } from './components/shipment-status-badge';
 export { buildCarrierTrackingUrl, getCarrierDisplayName } from './lib/carrier-tracking-url';

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -87,6 +87,7 @@ export function createMockApiClient(
 ): ApiClient {
   const core: CoreApiClient = {
     request: overrides.request ?? vi.fn(),
+    requestBlob: overrides.requestBlob ?? vi.fn(),
     adapters: {
       list: vi.fn().mockResolvedValue([]),
       ...overrides.adapters,
@@ -339,6 +340,7 @@ export function createMockApiClient(
         source: 'ok',
         destinations: [],
       }),
+      downloadLabel: vi.fn().mockResolvedValue(new Blob([new Uint8Array([0x25, 0x50])])),
       ...overrides.shipments,
     } as ApiClient['shipments'],
     syncJobs: {

--- a/docs/plans/implementation-plan-884-shipment-label-pdf-download.md
+++ b/docs/plans/implementation-plan-884-shipment-label-pdf-download.md
@@ -1,0 +1,165 @@
+# Implementation Plan — #884 Shipment label-document download endpoint + panel CTA
+
+> Status: reviewed (2× tech-review applied) · Branch `884-shipping-label-pdf-download` · Author: OpenLinker Senior Engineer
+
+## 0. Resolved decisions (post tech-review)
+
+- **O1 — capability name:** `LabelDocumentReader` (capability), `fetchLabel` (method), `LabelDocument` (type), `isLabelDocumentReader` (guard). The capability names the **business verb**, never the wire format — the bytes can be PDF *or* ZPL/EPL (Allegro per seller "Ship with Allegro" setting) *or* PNG (InPost), and `LabelDocument.contentType` carries the actual format dynamically. A `*Pdf` name would be a lying contract on a published, plugin-facing port. Matches the in-repo #833 forward-reference (`allegro-shipment.mapper.ts`) and the agent-noun sibling style (`ShipmentCanceller`, `PickupPointFinder`). NOT the issue's `OrderFulfillmentLabelPdfReader` (wrong port family + wrong format-in-name).
+- **Scope boundary (no `documentType` discriminator):** deliberately NOT generalized to `ShipmentDocumentReader` + `documentType: 'label' | 'protocol'`. The dispatch **protocol** (handover manifest, #831) is per-batch not per-parcel, has a different input shape, and #831 is an uncommitted spike — YAGNI. When it ships it's a sibling sub-capability `DispatchProtocolReader`, composed via `implements LabelDocumentReader, DispatchProtocolReader`.
+- **O2 — FE transport:** extend the shared api-client with a `requestBlob` path (keeps auth-header + 401-refresh + timeout). Raw `fetch` in a hook is banned by `no-restricted-globals` in `features/`.
+- **O3 — Allegro response framing:** pass the response `Content-Type` through unchanged; default to `application/pdf` ONLY when the header is entirely absent (never overwrite a real header). Adapter specs must exercise the uncertainty (pdf / non-pdf / JSON-error). Still flagged as the one residual external unknown — see §6.
+- **Filename extension (review IMPORTANT):** the controller download filename's extension derives from `contentType` (`application/pdf→pdf`, `image/png→png`, `application/zpl`/`x-zpl→zpl`, else `bin`) — NOT a hardcoded `.pdf`. A `.pdf` file containing ZPL is worse than no download.
+- **Error-body ordering (both HTTP clients):** check `response.ok` FIRST; on failure stay on the existing `.text()` → error-envelope path; read `.arrayBuffer()` ONLY on the success branch. Binary mode must never feed bytes to the error parser.
+- **Auto-download trigger:** imperative, inside the `mutateAsync()` success block in `onSubmit` — guarded on `result.kind === 'dispatched' && result.shipment?.labelPdfRef`. NOT a `useEffect` watching query state (would re-fire on every panel refetch after the `onSuccess` invalidation).
+- **`@Res()` contract:** service call first, `res.setHeader`/`res.send` last (so a thrown error still routes through Nest before any byte is written); annotate `@ApiProduces('application/pdf')` + `@ApiResponse({ status: 200 })` so Swagger doesn't advertise a JSON body.
+- **Exception messages:** `LabelDocumentNotSupportedException` ("this shipping provider can't return labels") and `LabelNotAvailableException` ("generate the label first") carry distinct, operator-actionable messages — both map to 422.
+
+## 1. Understand the task
+
+**Goal.** Give operators a UI path to retrieve the shipping-label document for a shipment. PR #881 shipped the order-detail Shipment panel and `Shipment.labelPdfRef` is already persisted by the dispatch seam (#835/#843), but there is no endpoint or button to actually fetch the bytes.
+
+> Note on the `labelPdfRef` field name: it is the existing persisted column (#835) and is out of scope to rename here. It's an opaque "a label exists" marker; the new capability is format-neutral regardless of the field's legacy name.
+
+**Layers touched:** CORE (new sub-capability port), Integration (Allegro + InPost adapter impls + binary HTTP transport), Interface (new controller endpoint + binary response), Frontend (download hook + button + auto-download on first issuance).
+
+**Non-goals (explicit, from the issue):**
+- Bulk-label download (PDF stitching across N shipments).
+- Carrier-specific re-print metadata (ShipX "first print" flag).
+- Re-issuing a label without cancel+re-create (governed by the existing AC-7 flow).
+- The dispatch protocol / handover manifest (#831 — separate future `DispatchProtocolReader`).
+
+## 2. Research findings (corrections to the issue body)
+
+1. **Allegro endpoint is NOT `GET /shipment-management/shipments/{id}/protocol`.** That path is the *protocol* (courier handover manifest) — #831 v2 scope — and the verb is wrong. The **label** download is **`POST /shipment-management/label`** with body `{ shipmentIds: string[], pageSize: 'A4' | 'A6' }`, returning the label bytes. Corroborated by developer.allegro.pl docs and the in-repo `allegro-shipment.mapper.ts` comment written during #833 (which says "a future label-download endpoint resolves it via `POST /shipment-management/label`" and anticipates capability name `LabelDocumentReader`).
+   - `pageSize` is page **geometry**, NOT a format selector — the returned format (PDF vs ZPL/EPL) is governed by the seller's "Ship with Allegro" account setting. This is exactly why the design reads format from the response `Content-Type` rather than assuming it from the request.
+   - Residual risk: exact response framing (raw bytes vs JSON wrapper) is best confirmed by a sandbox probe (§6). The adapter reads the response `Content-Type` and passes it through (default `application/pdf` only if absent), so a non-PDF format still flows correctly to the browser.
+2. **InPost label:** `GET /v1/shipments/{id}/label?format=pdf` → PDF bytes (ShipX). The shipment must be `confirmed` first; pre-confirmation ShipX returns a retryable/202 — out of scope here (operator triggers download once the label exists, i.e. status ≥ `generated`).
+3. **Both HTTP clients are JSON-only on the response side.** `AllegroHttpClient.executeRequest` always does `response.text()` → `JSON.parse`; `IInpostHttpClient.request<T>` parses JSON. A binary-**response** transport method must be added to each (Allegro already has `postBinary`/`postMultipart` for binary request *bodies* only — not the same thing).
+4. **`labelPdfRef` is an opaque, provider-prefixed ref** (`allegro-delivery:label:{shipmentId}`, `shipx:label:{id}`). The adapter does NOT need to parse it — `fetchLabel` receives `providerShipmentId` directly from the controller (same shape as `cancelShipment`/`getTracking`). `labelPdfRef`'s presence is just the "a label exists" signal for the FE button.
+
+## 3. Design
+
+### 3.1 CORE — new sub-capability `LabelDocumentReader`
+
+`libs/core/src/shipping/domain/ports/capabilities/label-document-reader.capability.ts`
+```ts
+export interface LabelDocumentReader {
+  fetchLabel(input: { providerShipmentId: string }): Promise<LabelDocument>;
+}
+export function isLabelDocumentReader(
+  adapter: ShippingProviderManagerPort,
+): adapter is ShippingProviderManagerPort & LabelDocumentReader { ... }
+```
+- `LabelDocument { contentType: string; body: Uint8Array }` type lives in `domain/types/label-document.types.ts`. **Doc-comment `contentType` as the canonical, provider-reported format signal** — consumers (controller filename, FE) must read it, never assume PDF. Keeps the capability file interface+guard only (mirrors how `PickupPointFinder` keeps `FindPickupPointsQuery` in `pickup-point.types.ts`).
+- `Uint8Array` not Node `Buffer` in the port — domain stays framework/runtime-neutral (Allegro client already speaks `Uint8Array`). Controller wraps to `Buffer` at the boundary.
+- **Naming (O1 resolved):** capability names the verb, not the format — see §0. `fetchLabel` reads cleanly since the return type already says `LabelDocument`.
+- Barrel: export type+guard from `libs/core/src/shipping/index.ts` (sub-capabilities block).
+
+### 3.2 CORE — application service `ShipmentLabelService`
+
+`application/services/shipment-label.service.ts` + `application/interfaces/shipment-label.service.interface.ts`, token `SHIPMENT_LABEL_SERVICE_TOKEN`.
+```ts
+interface IShipmentLabelService { fetchLabel(shipmentId: string): Promise<LabelDocument>; }
+```
+- Mirrors `ShipmentCancellationService` exactly: load shipment via `ShipmentRepositoryPort.findById` → 404 `ShipmentNotFoundException`; resolve adapter via `IIntegrationsService.getCapabilityAdapter<ShippingProviderManagerPort>(connectionId, 'ShippingProviderManager')`; narrow `isLabelDocumentReader` → else new `LabelDocumentNotSupportedException`; guard `providerShipmentId` present → else `LabelNotAvailableException` (no provider shipment ⇒ no label); call `adapter.fetchLabel({providerShipmentId})`; provider errors propagate as `ShippingProviderRejectionException` (→ 502).
+- New domain exceptions: `LabelDocumentNotSupportedException`, `LabelNotAvailableException` (in `domain/exceptions/`, exported from barrel). **Distinct operator-actionable messages** (both → 422): not-supported = "this shipping provider can't return labels"; not-available = "no label has been generated for this shipment yet — generate the label first".
+- Why a service (not controller-direct): apps/** is banned from `ShipmentRepositoryPort` (cross-context); the read+resolve+narrow belongs behind an `I*Service` seam, consistent with every other shipment command.
+
+### 3.3 Integration — binary transport + adapter impls
+
+**Allegro** — add to `IAllegroHttpClient` + `AllegroHttpClient`:
+```ts
+postExpectingBinary(path, body, options?): Promise<{ data: Uint8Array; contentType: string; status: number; headers }>
+```
+Refactor `executeRequest` to branch on an `expectBinary` flag. **Ordering is load-bearing:** check `response.ok` FIRST. On `!response.ok` keep the existing `await response.text()` → `handleError(status, body, …)` path verbatim (so `parseAllegroErrorBody` still gets the JSON error envelope + `userMessage`). ONLY on the success branch read `response.arrayBuffer()`, skip `JSON.parse`, and surface the lowercased `content-type`. Never feed bytes to the error parser.
+`AllegroDeliveryShippingAdapter implements … LabelDocumentReader`:
+```ts
+fetchLabel({providerShipmentId}) =>
+  postExpectingBinary('/shipment-management/label',
+    { shipmentIds: [providerShipmentId], pageSize: 'A6' }) // A6 = thermal-label page geometry (NOT a format selector)
+  // O3: pass the REAL content-type through; default to application/pdf only when
+  // the header is entirely absent — never overwrite a present non-pdf header.
+  → { contentType: res.contentType || 'application/pdf', body: res.data }
+  (wrap failures via this.toRejected → ShippingProviderRejectionException)
+```
+
+**InPost** — add to `IInpostHttpClient`:
+```ts
+requestBinary(options): Promise<{ body: Uint8Array; contentType: string }>
+```
+Implement in `InpostHttpClient` reusing the retry loop. Same ordering rule: the existing `safeParseError`/`RetryableHttpError` path stays on the text branch for non-ok; read `arrayBuffer()` + content-type ONLY on `response.ok`. `InpostShippingAdapter implements … LabelDocumentReader`:
+```ts
+fetchLabel({providerShipmentId}) =>
+  requestBinary({ method:'GET', path:`/v1/shipments/${providerShipmentId}/label`, query:{ format:'pdf' } })
+```
+Update `fake-inpost-shipping.adapter.ts` (testing barrel) to implement the new method (returns canned bytes).
+
+### 3.4 Interface — `GET /shipments/:id/label`
+
+In `ShipmentController`: inject `SHIPMENT_LABEL_SERVICE_TOKEN`. New endpoint streams bytes:
+```ts
+@Get(':id/label')
+@ApiProduces('application/pdf')
+@ApiResponse({ status: 200, description: 'Label document bytes' })
+@ApiResponse({ status: 404, description: 'Shipment not found' })
+@ApiResponse({ status: 422, description: 'Provider has no label / cannot return one' })
+@ApiResponse({ status: 502, description: 'Shipping provider rejected the label fetch' })
+async downloadLabel(@Param('id') id, @Res() res): Promise<void> {
+  // Service call FIRST — a thrown error routes through Nest before any
+  // byte/header is written; res.* only ever runs on the happy path.
+  try {
+    const { contentType, body } = await this.label.fetchLabel(id);
+    const ext = extensionForContentType(contentType); // pdf | png | zpl | bin
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Disposition', `attachment; filename="ol-shipment-${id}.${ext}"`);
+    res.send(Buffer.from(body));
+  } catch (e) { throw this.toHttpException(e); }
+}
+```
+- `extensionForContentType(ct: string): string` — tiny pure helper co-located with the controller, unit-tested (`application/pdf→pdf`, `image/png→png`, `application/zpl`|`application/x-zpl`→`zpl`, else `bin`). The download's only filename — it must not hardcode `.pdf` when the design allows non-PDF bytes through.
+- Extend `toHttpException`: `LabelDocumentNotSupportedException` / `LabelNotAvailableException` → 422 (`UnprocessableEntityException`); 404 + 502 already covered.
+- `@Res()` disables the global serializer for this handler — intended for a binary endpoint. `@ApiProduces('application/pdf')` keeps Swagger from advertising a JSON body. Document the `@Res()` choice inline.
+- Route ordering: `:id/label` is a distinct sub-path, no conflict with the `active` literal guard.
+
+### 3.5 Frontend
+
+- **api-client `requestBlob` (O2 resolved):** add a `requestBlob(path): Promise<Blob>` path to `createApiClient` that reuses the existing `request` wrapper (auth-header injection + 401-refresh + timeout) but reads `response.blob()` on success instead of `readResponseBody`'s JSON/text branch. Raw `fetch` in a hook is banned by `no-restricted-globals` in `features/` and would skip the refresh-retry.
+- `features/shipments/api/shipments.api.ts`: `downloadLabelBlob(id): Promise<Blob>` → `requestBlob('/shipments/{id}/label')`.
+- `features/shipments/hooks/use-label-pdf-download.ts` — one-shot action (NOT a TanStack mutation). Calls `apiClient.shipments.downloadLabelBlob(id)`, then `URL.createObjectURL` → programmatic `<a download>` click → `URL.revokeObjectURL` (in a `finally`). Exposes `{ download(shipmentId), isDownloading, error }` via local `useState`. (Browser infers the saved filename from the `Content-Disposition` header the controller sets.)
+- `ShipmentActionButtons`: add **Download label** button (placed AFTER the existing `shippingMethod === 'omp'` early-return, so projection-only rows never show it). Enabled when `status ∈ {generated, dispatched, in-transit, delivered}` AND `shipment.labelPdfRef !== null`. Disabled while downloading; surfaces error via the existing toast.
+- `GenerateLabelForm` auto-download (imperative, not effect-based): inside `onSubmit`, capture `const result = await mutation.mutateAsync(input)` and, on the existing success block, trigger the download iff `result.kind === 'dispatched' && result.shipment?.labelPdfRef`, passing `result.shipment.id`. Do NOT watch `labelPdfRef` in a `useEffect` — `useGenerateLabelMutation.onSuccess` invalidates `shipmentsQueryKeys.all`, so an effect would re-fire on every refetch.
+- Mobile/tablet parity: button inherits the existing `button--sm` action-row styling (no new layout). Tap-target ≥ 44 px on touch is already handled by the shared `.button--sm` touch rule.
+
+## 4. Step-by-step (each step → files + acceptance)
+
+| # | Step | Files | Acceptance |
+|---|------|-------|-----------|
+| 1 | `LabelDocument` type + `LabelDocumentReader` capability + guard | `domain/types/label-document.types.ts`, `domain/ports/capabilities/label-document-reader.capability.ts` (+ `__tests__`) | guard returns true only when `fetchLabel` present; barrel exports type+guard; `contentType` doc-commented as format source-of-truth |
+| 2 | Domain exceptions | `domain/exceptions/label-document-not-supported.exception.ts`, `label-not-available.exception.ts` | exported from barrel; distinct operator-actionable messages |
+| 3 | Service + interface + token | `application/services/shipment-label.service.ts` (+ `.spec.ts`), `application/interfaces/shipment-label.service.interface.ts`, `shipping.tokens.ts` | unit spec: 404 / not-supported / not-available / happy / provider-rejection paths |
+| 4 | Wire service in `ShippingModule` | `shipping.module.ts` | provider bound to token, exported |
+| 5 | Allegro binary transport + adapter impl | `allegro-http-client.interface.ts`, `allegro-http-client.ts`, `allegro-delivery-shipping.adapter.ts` (+ specs) | adapter spec asserts `POST /shipment-management/label` body shape; **ok-before-arrayBuffer ordering**; O3 cases: pdf passthrough / non-pdf content-type passthrough / JSON-error → `ShippingProviderRejectionException` |
+| 6 | InPost binary transport + adapter impl + fake | `inpost-http-client.interface.ts`, `inpost-http-client.ts`, `inpost-shipping.adapter.ts`, `testing/fake-inpost-shipping.adapter.ts` (+ specs) | adapter spec asserts `GET /v1/shipments/{id}/label?format=pdf`; ok-before-arrayBuffer ordering; error stays on text path |
+| 7 | Controller endpoint + `extensionForContentType` + exception mapping | `apps/api/src/shipping/http/shipment.controller.ts` (+ `.spec.ts`) | unit: content-type + disposition headers, extension-per-content-type, 404/422/502 mapping; `@ApiProduces` set |
+| 8 | Controller int-spec against stubbed provider | `apps/api/test/integration/...shipment-label...int-spec.ts` | canned bytes round-trip end-to-end |
+| 9 | FE api-client `requestBlob` + api method + hook | `app/api/api-client.ts`, `features/shipments/api/shipments.api.ts`, `features/shipments/hooks/use-label-pdf-download.ts`, barrel | `requestBlob` reuses auth/refresh wrapper; hook triggers `<a download>`; error surfaces; `revokeObjectURL` in `finally` |
+| 10 | FE button + auto-download | `shipment-action-buttons.tsx` (+ test), `generate-label-form.tsx` (+ test) | button enablement matrix; **`omp` row shows NO Download button** (test asserts); imperative auto-download fires once per fresh ref, gated on `kind==='dispatched'` |
+
+## 5. Validation
+
+- **Architecture:** capability in CORE domain; adapters in integrations implement it; controller depends on `I*Service` seam not the repo. No CORE→integration leak. ✔
+- **Naming:** `*.capability.ts`, `*.service.ts`+`.interface.ts`, `*.types.ts`, Symbol token `SHIPMENT_LABEL_SERVICE_TOKEN`. Capability names the verb (`LabelDocumentReader`), not the format. ✔
+- **No migration** — no schema change (reads existing `labelPdfRef`/`providerShipmentId`). ✔
+- **Security:** endpoint inherits class-level `@Roles('admin')` + JWT; no secrets in bytes; filename derived from internal id. ✔
+- **Testing:** adapter unit specs (request shape), service unit spec (branch matrix), controller spec + one int-spec, FE component tests. ✔
+- **Quality gate:** `pnpm lint && pnpm type-check && pnpm test`; `LabelDocumentReader` is a sub-capability discovered by duck-typing guard, NOT registered in adapter-manifest `supportedCapabilities`, so it does not ripple into the capability-routing int-specs — run the shipping int-specs (and the full integration suite before shipping per standing practice).
+
+## 6. Residual risk (the one open external unknown)
+
+**Allegro `POST /shipment-management/label` response framing (O3).** Create+poll for create/cancel is confirmed; the label endpoint's exact success-response framing is corroborated by docs + the in-repo #833 comment but not yet sandbox-verified. The two shapes that would change the adapter:
+- **(a) raw bytes** (assumed) — design works as drafted.
+- **(b) JSON wrapper** (e.g. `{ contents: "<base64>" }` or a resource href requiring a second GET) — would need a small adapter parse/second-fetch step.
+
+**Mitigations already in the design:** content-type passthrough (never assume PDF), ok-before-arrayBuffer ordering (error envelopes still parse), and adapter specs that exercise pdf / non-pdf / JSON-error. If the sandbox probe reveals shape (b), the change is localized to `AllegroDeliveryShippingAdapter.fetchLabel` + its spec — no contract, controller, or FE change. **Not a blocker to start**: InPost (`GET …/label?format=pdf` → bytes) is unambiguous, the CORE/Interface/FE layers are provider-agnostic, and the Allegro adapter is the last/most-isolated step.
+
+All open questions are resolved in §0; no decisions remain open for the user.

--- a/libs/core/src/shipping/application/interfaces/shipment-label.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/shipment-label.service.interface.ts
@@ -1,0 +1,25 @@
+/**
+ * Shipment Label Service Interface
+ *
+ * Query seam for fetching the printable label document of a generated
+ * shipment (#884). Resolves the shipment's shipping-provider adapter, narrows
+ * the `LabelDocumentReader` sub-capability, and returns the raw bytes +
+ * provider-reported content type. The HTTP layer streams them as an
+ * attachment.
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+
+import type { LabelDocument } from '../../domain/types/label-document.types';
+
+export interface IShipmentLabelService {
+  /**
+   * Fetch the label document for a shipment. Throws
+   * `ShipmentNotFoundException` when absent, `LabelNotAvailableException` when
+   * no label has been generated (no `providerShipmentId`),
+   * `LabelDocumentNotSupportedException` when the provider adapter lacks
+   * `LabelDocumentReader`, and `ShippingProviderRejectionException` when the
+   * provider rejects the fetch.
+   */
+  fetchLabel(shipmentId: string): Promise<LabelDocument>;
+}

--- a/libs/core/src/shipping/application/services/shipment-label.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-label.service.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Shipment Label Service unit tests (#884).
+ *
+ * Mocks `ShipmentRepositoryPort` + `IIntegrationsService` (→ a fake
+ * `ShippingProviderManager` adapter that may or may not implement
+ * `LabelDocumentReader`). Covers: happy path (bytes passed through), not-found,
+ * no-provider-shipment (label not available), provider-lacks-reader, and
+ * provider error rethrow.
+ */
+
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+
+import { ShipmentLabelService } from './shipment-label.service';
+import { Shipment } from '../../domain/entities/shipment.entity';
+import { LabelDocumentNotSupportedException } from '../../domain/exceptions/label-document-not-supported.exception';
+import { LabelNotAvailableException } from '../../domain/exceptions/label-not-available.exception';
+import { ShipmentNotFoundException } from '../../domain/exceptions/shipment-not-found.exception';
+import type { LabelDocumentReader } from '../../domain/ports/capabilities/label-document-reader.capability';
+import type { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+
+const CONNECTION = 'conn-inpost';
+
+function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
+  return new Shipment(
+    overrides.id ?? 'ol_shipment_1',
+    overrides.orderId ?? 'ol_order_1',
+    overrides.connectionId ?? CONNECTION,
+    overrides.shippingMethod ?? 'paczkomat',
+    overrides.status ?? 'generated',
+    // Honour an explicit `null` (the no-provider-shipment case) — `??` would
+    // wrongly fall through to the default.
+    overrides.providerShipmentId !== undefined ? overrides.providerShipmentId : 'shipx-1',
+    overrides.paczkomatId ?? 'POZ08A',
+    overrides.trackingNumber ?? null,
+    overrides.labelPdfRef ?? 'shipx:label:1',
+    null,
+    null,
+    overrides.cancelledAt ?? null,
+    null,
+    null,
+    new Date(),
+    new Date(),
+    overrides.sourceDeliveryMethodId ?? null,
+    overrides.carrier ?? null,
+  );
+}
+
+describe('ShipmentLabelService', () => {
+  let repository: jest.Mocked<ShipmentRepositoryPort>;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let readerAdapter: jest.Mocked<ShippingProviderManagerPort & LabelDocumentReader>;
+  let service: ShipmentLabelService;
+
+  beforeEach(() => {
+    repository = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findById: jest.fn(),
+      findByOrderId: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findByProviderShipmentId: jest.fn(),
+      findBranchOneByOrderAndConnection: jest.fn(),
+      update: jest.fn(),
+    };
+    readerAdapter = {
+      generateLabel: jest.fn(),
+      getTracking: jest.fn(),
+      getSupportedMethods: jest.fn(),
+      fetchLabel: jest.fn().mockResolvedValue({
+        contentType: 'application/pdf',
+        body: new Uint8Array([1, 2, 3]),
+      }),
+    };
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn().mockResolvedValue(readerAdapter),
+      resolveAdapterMetadata: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+    };
+    service = new ShipmentLabelService(repository, integrations);
+  });
+
+  it('should resolve the provider adapter and return the label bytes for a generated shipment', async () => {
+    repository.findById.mockResolvedValue(
+      makeShipment({ status: 'generated', providerShipmentId: 'shipx-1' }),
+    );
+
+    const result = await service.fetchLabel('ol_shipment_1');
+
+    expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(
+      CONNECTION,
+      'ShippingProviderManager',
+    );
+    expect(readerAdapter.fetchLabel).toHaveBeenCalledWith({ providerShipmentId: 'shipx-1' });
+    expect(result).toEqual({ contentType: 'application/pdf', body: new Uint8Array([1, 2, 3]) });
+  });
+
+  it('should pass through a non-PDF content type unchanged', async () => {
+    repository.findById.mockResolvedValue(makeShipment({ status: 'generated' }));
+    readerAdapter.fetchLabel.mockResolvedValue({
+      contentType: 'application/zpl',
+      body: new Uint8Array([9]),
+    });
+
+    const result = await service.fetchLabel('ol_shipment_1');
+
+    expect(result.contentType).toBe('application/zpl');
+  });
+
+  it('should throw ShipmentNotFoundException when the shipment does not exist', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    await expect(service.fetchLabel('missing')).rejects.toBeInstanceOf(ShipmentNotFoundException);
+    expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+  });
+
+  it('should throw LabelNotAvailableException when the shipment has no provider shipment id', async () => {
+    repository.findById.mockResolvedValue(
+      makeShipment({ status: 'draft', providerShipmentId: null }),
+    );
+
+    await expect(service.fetchLabel('ol_shipment_1')).rejects.toBeInstanceOf(
+      LabelNotAvailableException,
+    );
+    expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+  });
+
+  it('should throw LabelDocumentNotSupportedException when the adapter lacks LabelDocumentReader', async () => {
+    repository.findById.mockResolvedValue(makeShipment({ status: 'generated' }));
+    const nonReader: ShippingProviderManagerPort = {
+      generateLabel: jest.fn(),
+      getTracking: jest.fn(),
+      getSupportedMethods: jest.fn(),
+    };
+    integrations.getCapabilityAdapter.mockResolvedValue(nonReader);
+
+    await expect(service.fetchLabel('ol_shipment_1')).rejects.toBeInstanceOf(
+      LabelDocumentNotSupportedException,
+    );
+  });
+
+  it('should rethrow when the provider fetchLabel rejects', async () => {
+    repository.findById.mockResolvedValue(makeShipment({ status: 'generated' }));
+    const boom = new Error('provider label fetch rejected');
+    readerAdapter.fetchLabel.mockRejectedValue(boom);
+
+    await expect(service.fetchLabel('ol_shipment_1')).rejects.toBe(boom);
+  });
+});

--- a/libs/core/src/shipping/application/services/shipment-label.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-label.service.ts
@@ -1,0 +1,64 @@
+/**
+ * Shipment Label Service
+ *
+ * Fetches the printable label document for a generated shipment (#884).
+ * Resolves the shipment's shipping-provider adapter via the integrations
+ * registry, narrows the `LabelDocumentReader` sub-capability, and returns the
+ * raw bytes + provider-reported content type for the HTTP layer to stream.
+ *
+ * Read-only: never mutates the `Shipment` row. Mirrors the resolve+narrow
+ * shape of `ShipmentCancellationService`.
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IShipmentLabelService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+
+import type { IShipmentLabelService } from '../interfaces/shipment-label.service.interface';
+import type { LabelDocument } from '../../domain/types/label-document.types';
+import { LabelDocumentNotSupportedException } from '../../domain/exceptions/label-document-not-supported.exception';
+import { LabelNotAvailableException } from '../../domain/exceptions/label-not-available.exception';
+import { ShipmentNotFoundException } from '../../domain/exceptions/shipment-not-found.exception';
+import { isLabelDocumentReader } from '../../domain/ports/capabilities/label-document-reader.capability';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+
+/** Capability the shipment's connection must declare to resolve a provider adapter. */
+const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
+
+@Injectable()
+export class ShipmentLabelService implements IShipmentLabelService {
+  constructor(
+    @Inject(SHIPMENT_REPOSITORY_TOKEN)
+    private readonly shipments: ShipmentRepositoryPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+  ) {}
+
+  async fetchLabel(shipmentId: string): Promise<LabelDocument> {
+    const shipment = await this.shipments.findById(shipmentId);
+    if (!shipment) {
+      throw new ShipmentNotFoundException(shipmentId);
+    }
+
+    // No provider shipment ⇒ no label was ever generated. Distinct from the
+    // capability gap below so the operator gets a "generate the label first"
+    // message rather than "this carrier can't return labels".
+    if (!shipment.providerShipmentId) {
+      throw new LabelNotAvailableException(shipmentId);
+    }
+
+    const adapter = await this.integrations.getCapabilityAdapter<ShippingProviderManagerPort>(
+      shipment.connectionId,
+      SHIPPING_PROVIDER_MANAGER_CAPABILITY,
+    );
+    if (!isLabelDocumentReader(adapter)) {
+      throw new LabelDocumentNotSupportedException(shipmentId, shipment.connectionId);
+    }
+
+    return adapter.fetchLabel({ providerShipmentId: shipment.providerShipmentId });
+  }
+}

--- a/libs/core/src/shipping/domain/exceptions/label-document-not-supported.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/label-document-not-supported.exception.ts
@@ -1,0 +1,25 @@
+/**
+ * Label Document Not Supported Exception
+ *
+ * Thrown by `ShipmentLabelService` when the resolved shipping-provider adapter
+ * for the shipment's connection does not implement the `LabelDocumentReader`
+ * sub-capability — i.e. the carrier integration cannot return a label
+ * document. Distinct from `LabelNotAvailableException` (label not yet
+ * generated) so the API surface maps both to 422 with operator-actionable
+ * messages that point at different fixes.
+ *
+ * @module libs/core/src/shipping/domain/exceptions
+ */
+export class LabelDocumentNotSupportedException extends Error {
+  constructor(
+    public readonly shipmentId: string,
+    public readonly connectionId: string,
+  ) {
+    super(
+      `Cannot fetch label for shipment ${shipmentId}: connection ${connectionId} ` +
+        `does not support returning label documents`,
+    );
+    this.name = 'LabelDocumentNotSupportedException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/shipping/domain/exceptions/label-not-available.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/label-not-available.exception.ts
@@ -1,0 +1,21 @@
+/**
+ * Label Not Available Exception
+ *
+ * Thrown by `ShipmentLabelService` when a shipment has no provider shipment id
+ * yet (`providerShipmentId === null`) — i.e. no label has been generated, so
+ * there is nothing to fetch. Distinct from `LabelDocumentNotSupportedException`
+ * (the provider can't return labels at all): the operator fix here is "generate
+ * the label first", not "use a different carrier". Both map to 422.
+ *
+ * @module libs/core/src/shipping/domain/exceptions
+ */
+export class LabelNotAvailableException extends Error {
+  constructor(public readonly shipmentId: string) {
+    super(
+      `No label has been generated for shipment ${shipmentId} yet — ` +
+        `generate the label first`,
+    );
+    this.name = 'LabelNotAvailableException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/shipping/domain/ports/capabilities/__tests__/label-document-reader.capability.spec.ts
+++ b/libs/core/src/shipping/domain/ports/capabilities/__tests__/label-document-reader.capability.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Label Document Reader Capability — Type-Guard Tests
+ *
+ * Verifies the `isLabelDocumentReader` runtime narrowing matches its
+ * compile-time signature on both branches. Mirrors the sibling
+ * `shipment-canceller.capability.spec.ts` shape.
+ *
+ * @module libs/core/src/shipping/domain/ports/capabilities/__tests__
+ */
+import type { ShippingProviderManagerPort } from '../../shipping-provider-manager.port';
+import {
+  type LabelDocumentReader,
+  isLabelDocumentReader,
+} from '../label-document-reader.capability';
+
+describe('isLabelDocumentReader', () => {
+  it('should narrow to ShippingProviderManagerPort & LabelDocumentReader when the adapter implements fetchLabel', () => {
+    const adapter: ShippingProviderManagerPort & LabelDocumentReader = {
+      generateLabel: jest.fn(),
+      getTracking: jest.fn(),
+      getSupportedMethods: () => ['paczkomat'],
+      fetchLabel: jest.fn(),
+    };
+
+    expect(isLabelDocumentReader(adapter)).toBe(true);
+
+    if (isLabelDocumentReader(adapter)) {
+      // Compile-time narrowing check: TS knows `fetchLabel` exists.
+      expect(typeof adapter.fetchLabel).toBe('function');
+    }
+  });
+
+  it('should return false when the adapter does not implement fetchLabel', () => {
+    const adapter: ShippingProviderManagerPort = {
+      generateLabel: jest.fn(),
+      getTracking: jest.fn(),
+      getSupportedMethods: () => ['paczkomat'],
+    };
+
+    expect(isLabelDocumentReader(adapter)).toBe(false);
+  });
+
+  it('should return false when fetchLabel is present but not a function', () => {
+    const adapter = {
+      generateLabel: jest.fn(),
+      getTracking: jest.fn(),
+      getSupportedMethods: () => ['paczkomat'],
+      fetchLabel: 'not a function',
+    } as unknown as ShippingProviderManagerPort;
+
+    expect(isLabelDocumentReader(adapter)).toBe(false);
+  });
+});

--- a/libs/core/src/shipping/domain/ports/capabilities/label-document-reader.capability.ts
+++ b/libs/core/src/shipping/domain/ports/capabilities/label-document-reader.capability.ts
@@ -1,0 +1,43 @@
+/**
+ * Label Document Reader Capability
+ *
+ * Optional sub-capability of `ShippingProviderManagerPort` — adapters that can
+ * return the printable label document for an already-generated shipment
+ * declare `implements LabelDocumentReader`. Call sites narrow via
+ * `isLabelDocumentReader(adapter)` before invoking `fetchLabel`; after the
+ * guard TypeScript knows the method is present.
+ *
+ * The capability names the business verb (fetch the label), NOT the wire
+ * format: the returned `LabelDocument.contentType` carries the real format
+ * (PDF / ZPL / EPL / PNG, provider- and seller-config-dependent). A `*Pdf`
+ * name would be a lying contract on this published, plugin-facing port.
+ *
+ * The dispatch protocol / handover manifest (#831) is a DIFFERENT document
+ * (per-batch, not per-parcel) and is intentionally NOT modelled here — it will
+ * be a sibling sub-capability (`DispatchProtocolReader`) when it ships.
+ *
+ * Mirrors the listings sub-capability pattern (e.g. `OfferCanceller`) per
+ * engineering-standards §"Port sub-capabilities".
+ *
+ * @module libs/core/src/shipping/domain/ports/capabilities
+ */
+
+import type { ShippingProviderManagerPort } from '../shipping-provider-manager.port';
+import type { LabelDocument } from '../../types/label-document.types';
+
+export interface LabelDocumentReader {
+  /**
+   * Fetch the printable label document for an already-generated shipment.
+   * The caller resolves `providerShipmentId` from the persisted `Shipment`
+   * (same shape as `cancelShipment` / `getTracking`). Throws (provider error)
+   * when the provider rejects the fetch; the application service maps that to
+   * a `ShippingProviderRejectionException`.
+   */
+  fetchLabel(input: { providerShipmentId: string }): Promise<LabelDocument>;
+}
+
+export function isLabelDocumentReader(
+  adapter: ShippingProviderManagerPort,
+): adapter is ShippingProviderManagerPort & LabelDocumentReader {
+  return typeof (adapter as Partial<LabelDocumentReader>).fetchLabel === 'function';
+}

--- a/libs/core/src/shipping/domain/types/label-document.types.ts
+++ b/libs/core/src/shipping/domain/types/label-document.types.ts
@@ -1,0 +1,28 @@
+/**
+ * Label Document Types
+ *
+ * Return type for the `LabelDocumentReader` sub-capability
+ * (`ShippingProviderManagerPort.fetchLabel`). Carries the raw label bytes
+ * plus the provider-reported MIME type.
+ *
+ * `contentType` is the canonical, provider-reported format signal — it is NOT
+ * always `application/pdf`. Allegro Delivery returns PDF / ZPL / EPL depending
+ * on the seller's "Ship with Allegro" account setting; InPost ShipX can return
+ * PDF or PNG. Consumers (the controller's download-filename extension, the FE
+ * download) MUST read `contentType` and never assume PDF — that's exactly why
+ * the capability is named `LabelDocumentReader`, not `LabelPdfReader`.
+ *
+ * `body` is a `Uint8Array` (not Node `Buffer`) so the domain stays
+ * framework/runtime-neutral; the HTTP boundary wraps it to `Buffer` when it
+ * needs Node specifics.
+ *
+ * @module libs/core/src/shipping/domain/types
+ */
+
+export interface LabelDocument {
+  /** Provider-reported MIME type of `body` (e.g. `application/pdf`,
+   * `image/png`, `application/zpl`). Source of truth for the document format. */
+  contentType: string;
+  /** Raw label bytes, passed through unmodified from the provider. */
+  body: Uint8Array;
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -88,6 +88,9 @@ export type { ShipmentCanceller } from './domain/ports/capabilities/shipment-can
 export { isShipmentCanceller } from './domain/ports/capabilities/shipment-canceller.capability';
 export type { PickupPointFinder } from './domain/ports/capabilities/pickup-point-finder.capability';
 export { isPickupPointFinder } from './domain/ports/capabilities/pickup-point-finder.capability';
+export type { LabelDocumentReader } from './domain/ports/capabilities/label-document-reader.capability';
+export { isLabelDocumentReader } from './domain/ports/capabilities/label-document-reader.capability';
+export type { LabelDocument } from './domain/types/label-document.types';
 
 // `FulfillmentStatusReader` (#834) lives in `@openlinker/core/orders`
 // alongside `OrderFulfillmentUpdater` (#858) — both are sub-capabilities of
@@ -102,6 +105,8 @@ export { ShipmentNotCancellableException } from './domain/exceptions/shipment-no
 export { ShipmentCancellationNotSupportedException } from './domain/exceptions/shipment-cancellation-not-supported.exception';
 export { PickupPointFinderNotSupportedException } from './domain/exceptions/pickup-point-finder-not-supported.exception';
 export { ShippingProviderRejectionException } from './domain/exceptions/shipping-provider-rejection.exception';
+export { LabelDocumentNotSupportedException } from './domain/exceptions/label-document-not-supported.exception';
+export { LabelNotAvailableException } from './domain/exceptions/label-not-available.exception';
 
 // Application — dispatch seam (#835). Interface + types only; the service
 // class is injected via SHIPMENT_DISPATCH_SERVICE_TOKEN (exported above via
@@ -116,6 +121,10 @@ export type {
 // injected via SHIPMENT_QUERY_SERVICE_TOKEN / SHIPMENT_CANCELLATION_SERVICE_TOKEN.
 export type { IShipmentQueryService } from './application/interfaces/shipment-query.service.interface';
 export type { IShipmentCancellationService } from './application/interfaces/shipment-cancellation.service.interface';
+
+// Application — label-document fetch seam (#884). Interface only; the service
+// is injected via SHIPMENT_LABEL_SERVICE_TOKEN.
+export type { IShipmentLabelService } from './application/interfaces/shipment-label.service.interface';
 
 // Application — pickup-point lookup seam (#766). Interface only; the service is
 // injected via PICKUP_POINT_LOOKUP_SERVICE_TOKEN.

--- a/libs/core/src/shipping/shipping.module.ts
+++ b/libs/core/src/shipping/shipping.module.ts
@@ -37,6 +37,7 @@ import { PickupPointLookupService } from './application/services/pickup-point-lo
 import { ShipmentDispatchNotificationService } from './application/services/shipment-dispatch-notification.service';
 import { ShipmentStatusSyncService } from './application/services/shipment-status-sync.service';
 import { FulfillmentStatusSyncService } from './application/services/fulfillment-status-sync.service';
+import { ShipmentLabelService } from './application/services/shipment-label.service';
 import {
   FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,
   PICKUP_POINT_CACHE_TOKEN,
@@ -44,6 +45,7 @@ import {
   SHIPMENT_CANCELLATION_SERVICE_TOKEN,
   SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
   SHIPMENT_DISPATCH_SERVICE_TOKEN,
+  SHIPMENT_LABEL_SERVICE_TOKEN,
   SHIPMENT_QUERY_SERVICE_TOKEN,
   SHIPMENT_REPOSITORY_TOKEN,
   SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
@@ -112,6 +114,13 @@ import {
       provide: FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,
       useExisting: FulfillmentStatusSyncService,
     },
+    // #884 label-document fetch seam: resolves the shipment's provider adapter
+    // and narrows the LabelDocumentReader sub-capability. Read-only.
+    ShipmentLabelService,
+    {
+      provide: SHIPMENT_LABEL_SERVICE_TOKEN,
+      useExisting: ShipmentLabelService,
+    },
   ],
   exports: [
     SHIPMENT_REPOSITORY_TOKEN,
@@ -123,6 +132,7 @@ import {
     SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
     SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
     FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,
+    SHIPMENT_LABEL_SERVICE_TOKEN,
   ],
 })
 export class ShippingModule {}

--- a/libs/core/src/shipping/shipping.tokens.ts
+++ b/libs/core/src/shipping/shipping.tokens.ts
@@ -21,3 +21,4 @@ export const SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN = Symbol(
 );
 export const SHIPMENT_STATUS_SYNC_SERVICE_TOKEN = Symbol('IShipmentStatusSyncService');
 export const FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN = Symbol('IFulfillmentStatusSyncService');
+export const SHIPMENT_LABEL_SERVICE_TOKEN = Symbol('IShipmentLabelService');

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-delivery-shipping.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-delivery-shipping.adapter.spec.ts
@@ -36,6 +36,7 @@ function makeHttp(): jest.Mocked<IAllegroHttpClient> {
     patch: jest.fn(),
     postBinary: jest.fn(),
     postMultipart: jest.fn(),
+    postExpectingBinary: jest.fn(),
   } as unknown as jest.Mocked<IAllegroHttpClient>;
 }
 
@@ -310,6 +311,66 @@ describe('AllegroDeliveryShippingAdapter', () => {
         name: 'ShippingProviderRejectionException',
         providerName: 'allegro',
         providerCode: 'SHIPMENT_ALREADY_DISPATCHED',
+      });
+    });
+  });
+
+  describe('fetchLabel', () => {
+    it('POSTs the label request with the shipment id + page size and returns the bytes', async () => {
+      const bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+      http.postExpectingBinary.mockResolvedValue({
+        data: bytes,
+        contentType: 'application/pdf',
+        status: 200,
+        headers: { 'content-type': 'application/pdf' },
+      });
+
+      const result = await adapter.fetchLabel({ providerShipmentId: 'allegro-ship-1' });
+
+      expect(http.postExpectingBinary).toHaveBeenCalledWith('/shipment-management/label', {
+        shipmentIds: ['allegro-ship-1'],
+        pageSize: 'A6',
+      });
+      expect(result).toEqual({ contentType: 'application/pdf', body: bytes });
+    });
+
+    it('passes a non-PDF content type through unchanged (ZPL per seller setting)', async () => {
+      http.postExpectingBinary.mockResolvedValue({
+        data: new Uint8Array([0x5e, 0x58, 0x41]), // ^XA (ZPL)
+        contentType: 'application/zpl',
+        status: 200,
+        headers: { 'content-type': 'application/zpl' },
+      });
+
+      const result = await adapter.fetchLabel({ providerShipmentId: 'allegro-ship-1' });
+
+      expect(result.contentType).toBe('application/zpl');
+    });
+
+    it('defaults to application/pdf only when the response carries no content type', async () => {
+      http.postExpectingBinary.mockResolvedValue({
+        data: new Uint8Array([1, 2]),
+        contentType: '',
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.fetchLabel({ providerShipmentId: 'allegro-ship-1' });
+
+      expect(result.contentType).toBe('application/pdf');
+    });
+
+    it('wraps an Allegro API failure into a typed ShippingProviderRejectionException', async () => {
+      http.postExpectingBinary.mockRejectedValue(
+        new AllegroApiException('Label not found', 404, 'body', 'url'),
+      );
+
+      await expect(
+        adapter.fetchLabel({ providerShipmentId: 'allegro-ship-1' }),
+      ).rejects.toMatchObject({
+        name: 'ShippingProviderRejectionException',
+        providerName: 'allegro',
+        providerCode: 'api.http-404',
       });
     });
   });

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-delivery-shipping.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-delivery-shipping.adapter.ts
@@ -25,6 +25,8 @@ import {
   ShippingProviderRejectionException,
   type GenerateLabelCommand,
   type GenerateLabelResult,
+  type LabelDocument,
+  type LabelDocumentReader,
   type ShipmentCanceller,
   type ShippingMethod,
   type ShippingProviderManagerPort,
@@ -60,9 +62,19 @@ const SUPPORTED_METHODS: readonly ShippingMethod[] = ['paczkomat', 'kurier'];
 const CREATE_COMMANDS_PATH = '/shipment-management/shipments/create-commands';
 const CANCEL_COMMANDS_PATH = '/shipment-management/shipments/cancel-commands';
 const SHIPMENTS_PATH = '/shipment-management/shipments';
+const LABEL_PATH = '/shipment-management/label';
+
+/**
+ * Page geometry for the label request. NOT a format selector — the returned
+ * document format (PDF / ZPL / EPL) is governed by the seller's "Ship with
+ * Allegro" account setting, so the adapter reads the actual format from the
+ * response `Content-Type` rather than assuming it here. `A6` is the
+ * thermal-label default.
+ */
+const LABEL_PAGE_SIZE = 'A6';
 
 export class AllegroDeliveryShippingAdapter
-  implements ShippingProviderManagerPort, ShipmentCanceller
+  implements ShippingProviderManagerPort, ShipmentCanceller, LabelDocumentReader
 {
   private readonly logger = new Logger(AllegroDeliveryShippingAdapter.name);
   private readonly pollConfig: AllegroShipmentPollConfig;
@@ -160,6 +172,26 @@ export class AllegroDeliveryShippingAdapter
     }
 
     await this.pollUntilTerminal(CANCEL_COMMANDS_PATH, commandId);
+  }
+
+  async fetchLabel(input: { providerShipmentId: string }): Promise<LabelDocument> {
+    // `POST /shipment-management/label` returns the label document bytes
+    // directly. `pageSize` is page geometry, not a format selector — the
+    // format (PDF/ZPL/EPL) follows the seller's account setting, so we forward
+    // whatever `Content-Type` Allegro reports and default to PDF only when the
+    // header is absent (never overwrite a real one).
+    try {
+      const response = await this.httpClient.postExpectingBinary(LABEL_PATH, {
+        shipmentIds: [input.providerShipmentId],
+        pageSize: LABEL_PAGE_SIZE,
+      });
+      return {
+        contentType: response.contentType || 'application/pdf',
+        body: response.data,
+      };
+    } catch (error) {
+      throw this.toRejected(error, `fetch label for ${input.providerShipmentId}`);
+    }
   }
 
   /**

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.interface.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.interface.ts
@@ -28,6 +28,19 @@ export interface AllegroHttpResponse<T = unknown> {
 }
 
 /**
+ * Binary HTTP response — raw bytes plus the provider-reported content type.
+ * Used for endpoints that return a document (e.g. a label PDF/ZPL) rather than
+ * a JSON envelope. `contentType` is the lowercased `content-type` response
+ * header; the caller decides the default when it's absent.
+ */
+export interface AllegroBinaryResponse {
+  data: Uint8Array;
+  contentType: string;
+  status: number;
+  headers: Record<string, string>;
+}
+
+/**
  * Allegro HTTP Client Interface
  *
  * Interface for making HTTP requests to Allegro Public API.
@@ -127,6 +140,28 @@ export interface IAllegroHttpClient {
     parts: AllegroMultipartPart[],
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
   ): Promise<AllegroHttpResponse<T>>;
+
+  /**
+   * POST a JSON body but read the **response** as raw bytes (not JSON).
+   *
+   * For endpoints that return a binary document — e.g.
+   * `POST /shipment-management/label` returns the label PDF/ZPL bytes. The
+   * request body is still JSON-serialized; only the response handling differs:
+   * success bodies are read via `arrayBuffer()` and the `content-type` header
+   * is surfaced so the caller can label/forward the document correctly.
+   * Error responses (`!ok`) are still parsed as the JSON Allegro error
+   * envelope through the same `handleError` path as every other call.
+   *
+   * @param path - API path (e.g. '/shipment-management/label')
+   * @param body - JSON request body
+   * @param options - Request options (headers, query params)
+   * @returns Raw bytes + content type
+   */
+  postExpectingBinary(
+    path: string,
+    body?: Record<string, unknown> | string,
+    options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
+  ): Promise<AllegroBinaryResponse>;
 }
 
 /**

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
@@ -41,6 +41,20 @@ interface RetryConfig {
 }
 
 /**
+ * How the request body / response body deviate from the JSON default.
+ * Replaces trailing positional flags on the private request path so adding a
+ * mode is a named field, not another positional boolean.
+ */
+interface RequestMode {
+  /** MIME type for a raw-bytes request body (e.g. image upload). When set, the
+   *  body is sent as `Uint8Array` with this `Content-Type` instead of JSON. */
+  requestContentType?: string;
+  /** Read the SUCCESS response as raw bytes (`arrayBuffer`) instead of JSON.
+   *  Error responses are still parsed as the JSON Allegro error envelope. */
+  expectBinaryResponse?: boolean;
+}
+
+/**
  * Default retry configuration
  */
 const DEFAULT_RETRY_CONFIG: RetryConfig = {
@@ -92,7 +106,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     path: string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>
   ): Promise<AllegroHttpResponse<T>> {
-    return this.request<T>('GET', path, undefined, undefined, options);
+    return this.request<T>('GET', path, undefined, options);
   }
 
   async post<T = unknown>(
@@ -100,7 +114,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     body?: Record<string, unknown> | string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>
   ): Promise<AllegroHttpResponse<T>> {
-    return this.request<T>('POST', path, body, undefined, options);
+    return this.request<T>('POST', path, body, options);
   }
 
   async put<T = unknown>(
@@ -108,7 +122,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     body?: Record<string, unknown> | string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>
   ): Promise<AllegroHttpResponse<T>> {
-    return this.request<T>('PUT', path, body, undefined, options);
+    return this.request<T>('PUT', path, body, options);
   }
 
   async patch<T = unknown>(
@@ -116,7 +130,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     body?: Record<string, unknown> | string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>
   ): Promise<AllegroHttpResponse<T>> {
-    return this.request<T>('PATCH', path, body, undefined, options);
+    return this.request<T>('PATCH', path, body, options);
   }
 
   async postBinary<T = unknown>(
@@ -125,7 +139,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     body: Uint8Array,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>
   ): Promise<AllegroHttpResponse<T>> {
-    return this.request<T>('POST', path, body, contentType, options);
+    return this.request<T>('POST', path, body, options, { requestContentType: contentType });
   }
 
   async postMultipart<T = unknown>(
@@ -136,7 +150,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     const boundary = `----OpenLinkerFormBoundary${randomUUID().replace(/-/g, '')}`;
     const body = buildMultipartBody(parts, boundary);
     const contentType = `multipart/form-data; boundary=${boundary}`;
-    return this.request<T>('POST', path, body, contentType, options);
+    return this.request<T>('POST', path, body, options, { requestContentType: contentType });
   }
 
   async postExpectingBinary(
@@ -147,14 +161,9 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     // Reuse the full retry + token-refresh machinery; only the success-branch
     // body reading differs (arrayBuffer, not JSON). The response carries the
     // bytes as `data` and the content-type in `headers['content-type']`.
-    const response = await this.request<Uint8Array>(
-      'POST',
-      path,
-      body,
-      undefined,
-      options,
-      true
-    );
+    const response = await this.request<Uint8Array>('POST', path, body, options, {
+      expectBinaryResponse: true,
+    });
     return {
       data: response.data,
       contentType: response.headers['content-type'] ?? '',
@@ -168,27 +177,26 @@ export class AllegroHttpClient implements IAllegroHttpClient {
    *
    * @param method - HTTP method
    * @param path - API path
-   * @param body - Request body (optional). When `Uint8Array`, the request is
-   *   binary and `binaryContentType` must be supplied.
-   * @param binaryContentType - When body is binary, the MIME type to send.
-   *   When undefined the request takes the JSON default.
+   * @param body - Request body (optional). When `mode.requestContentType` is
+   *   set the body is treated as raw `Uint8Array` bytes.
    * @param options - Request options
+   * @param mode - Deviations from the JSON-in/JSON-out default (raw request
+   *   body content-type, binary response). Defaults to JSON both ways.
    * @returns Response data
    */
   private async request<T = unknown>(
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
     path: string,
     body?: Record<string, unknown> | string | Uint8Array,
-    binaryContentType?: string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
-    expectBinary = false
+    mode: RequestMode = {}
   ): Promise<AllegroHttpResponse<T>> {
     let lastError: Error | null = null;
     let delay = this.retryConfig.initialDelayMs;
 
     for (let attempt = 0; attempt <= this.retryConfig.maxRetries; attempt++) {
       try {
-        return await this.executeRequest<T>(method, path, body, binaryContentType, options, expectBinary);
+        return await this.executeRequest<T>(method, path, body, options, mode);
       } catch (error: unknown) {
         lastError = error instanceof Error ? error : new Error(String(error));
 
@@ -254,18 +262,18 @@ export class AllegroHttpClient implements IAllegroHttpClient {
    * @param method - HTTP method
    * @param path - API path
    * @param body - Request body (optional)
-   * @param binaryContentType - MIME for raw binary body; undefined for JSON
    * @param options - Request options
+   * @param mode - JSON-default deviations (raw request content-type, binary response)
    * @returns Response data
    */
   private async executeRequest<T = unknown>(
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
     path: string,
     body?: Record<string, unknown> | string | Uint8Array,
-    binaryContentType?: string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
-    expectBinary = false
+    mode: RequestMode = {}
   ): Promise<AllegroHttpResponse<T>> {
+    const { requestContentType, expectBinaryResponse } = mode;
     const startTime = Date.now();
     const traceId = randomUUID();
 
@@ -287,8 +295,8 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     // Structural headers land last because Authorization is owned by the token-refresh
     // flow and X-Trace-Id must match the log correlation ID — neither is a caller concern.
     const headers = new Headers();
-    if (binaryContentType !== undefined) {
-      headers.set('Content-Type', binaryContentType);
+    if (requestContentType !== undefined) {
+      headers.set('Content-Type', requestContentType);
     } else {
       headers.set('Content-Type', 'application/vnd.allegro.public.v1+json');
     }
@@ -320,7 +328,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     // unchanged; the JSON path stringifies plain objects.
     let requestBody: string | Uint8Array | undefined;
     if (body !== undefined) {
-      if (binaryContentType !== undefined) {
+      if (requestContentType !== undefined) {
         // Caller supplied a Content-Type — body must be raw bytes.
         requestBody = body as Uint8Array;
       } else {
@@ -376,7 +384,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
       }
 
       // Success + binary expected: read raw bytes, skip JSON parsing entirely.
-      if (expectBinary) {
+      if (expectBinaryResponse) {
         const bytes = new Uint8Array(await response.arrayBuffer());
         return {
           data: bytes as unknown as T,

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
@@ -16,6 +16,7 @@
  */
 import type {
   IAllegroHttpClient,
+  AllegroBinaryResponse,
   AllegroHttpRequestOptions,
   AllegroHttpResponse,
   AllegroMultipartPart,
@@ -138,6 +139,30 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     return this.request<T>('POST', path, body, contentType, options);
   }
 
+  async postExpectingBinary(
+    path: string,
+    body?: Record<string, unknown> | string,
+    options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>
+  ): Promise<AllegroBinaryResponse> {
+    // Reuse the full retry + token-refresh machinery; only the success-branch
+    // body reading differs (arrayBuffer, not JSON). The response carries the
+    // bytes as `data` and the content-type in `headers['content-type']`.
+    const response = await this.request<Uint8Array>(
+      'POST',
+      path,
+      body,
+      undefined,
+      options,
+      true
+    );
+    return {
+      data: response.data,
+      contentType: response.headers['content-type'] ?? '',
+      status: response.status,
+      headers: response.headers,
+    };
+  }
+
   /**
    * Make HTTP request with retry logic
    *
@@ -155,14 +180,15 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     path: string,
     body?: Record<string, unknown> | string | Uint8Array,
     binaryContentType?: string,
-    options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>
+    options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
+    expectBinary = false
   ): Promise<AllegroHttpResponse<T>> {
     let lastError: Error | null = null;
     let delay = this.retryConfig.initialDelayMs;
 
     for (let attempt = 0; attempt <= this.retryConfig.maxRetries; attempt++) {
       try {
-        return await this.executeRequest<T>(method, path, body, binaryContentType, options);
+        return await this.executeRequest<T>(method, path, body, binaryContentType, options, expectBinary);
       } catch (error: unknown) {
         lastError = error instanceof Error ? error : new Error(String(error));
 
@@ -237,7 +263,8 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     path: string,
     body?: Record<string, unknown> | string | Uint8Array,
     binaryContentType?: string,
-    options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>
+    options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
+    expectBinary = false
   ): Promise<AllegroHttpResponse<T>> {
     const startTime = Date.now();
     const traceId = randomUUID();
@@ -332,18 +359,33 @@ export class AllegroHttpClient implements IAllegroHttpClient {
         `[${traceId}] Response: ${response.status} (${duration}ms) - ${method} ${url.pathname}`
       );
 
-      const responseBody = await response.text();
-
-      // Handle errors
+      // Error handling runs FIRST and always reads the body as text, so the
+      // Allegro JSON error envelope (`userMessage`, structured `errors[]`) is
+      // parsed by `handleError` on every failed call — including binary ones.
+      // Only a SUCCESS response is read as bytes. Never feed error bytes to a
+      // binary consumer or success JSON to the error parser.
       if (!response.ok) {
+        const errorBody = await response.text();
         await this.handleError(
           response.status,
-          responseBody,
+          errorBody,
           url.toString(),
           responseHeaders,
           traceId
         );
       }
+
+      // Success + binary expected: read raw bytes, skip JSON parsing entirely.
+      if (expectBinary) {
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        return {
+          data: bytes as unknown as T,
+          status: response.status,
+          headers: responseHeaders,
+        };
+      }
+
+      const responseBody = await response.text();
 
       // Parse JSON response
       let data: T;

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-shipping.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-shipping.adapter.spec.ts
@@ -64,10 +64,15 @@ const courierCmd: GenerateLabelCommand = {
   parcel: { dimensions: { length: 80, width: 360, height: 640 }, weightGrams: 2500 },
 };
 
-function makeAdapter(): { adapter: InpostShippingAdapter; request: jest.Mock } {
+function makeAdapter(): {
+  adapter: InpostShippingAdapter;
+  request: jest.Mock;
+  requestBinary: jest.Mock;
+} {
   const request = jest.fn();
-  const http = { request } as unknown as IInpostHttpClient;
-  return { adapter: new InpostShippingAdapter(http, config), request };
+  const requestBinary = jest.fn();
+  const http = { request, requestBinary } as unknown as IInpostHttpClient;
+  return { adapter: new InpostShippingAdapter(http, config), request, requestBinary };
 }
 
 describe('InpostShippingAdapter', () => {
@@ -204,6 +209,44 @@ describe('InpostShippingAdapter', () => {
       );
       expect(points).toHaveLength(1);
       expect(points[0].providerId).toBe('POZ08A');
+    });
+  });
+
+  describe('fetchLabel', () => {
+    it('should GET the label endpoint with format=pdf and return the bytes', async () => {
+      const { adapter, requestBinary } = makeAdapter();
+      const bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+      requestBinary.mockResolvedValueOnce({ body: bytes, contentType: 'application/pdf' });
+
+      const result = await adapter.fetchLabel({ providerShipmentId: '1234' });
+
+      expect(requestBinary).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v1/shipments/1234/label',
+        query: { format: 'pdf' },
+      });
+      expect(result).toEqual({ contentType: 'application/pdf', body: bytes });
+    });
+
+    it('should pass a non-PDF content type (e.g. PNG) through unchanged', async () => {
+      const { adapter, requestBinary } = makeAdapter();
+      requestBinary.mockResolvedValueOnce({
+        body: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+        contentType: 'image/png',
+      });
+
+      const result = await adapter.fetchLabel({ providerShipmentId: '1234' });
+
+      expect(result.contentType).toBe('image/png');
+    });
+
+    it('should default to application/pdf when the response carries no content type', async () => {
+      const { adapter, requestBinary } = makeAdapter();
+      requestBinary.mockResolvedValueOnce({ body: new Uint8Array([1]), contentType: '' });
+
+      const result = await adapter.fetchLabel({ providerShipmentId: '1234' });
+
+      expect(result.contentType).toBe('application/pdf');
     });
   });
 });

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-shipping.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-shipping.adapter.ts
@@ -19,8 +19,10 @@ import {
   type ShippingProviderManagerPort,
   type ShipmentCanceller,
   type PickupPointFinder,
+  type LabelDocumentReader,
   type GenerateLabelCommand,
   type GenerateLabelResult,
+  type LabelDocument,
   type TrackingSnapshot,
   type ShippingMethod,
   type PickupPoint,
@@ -41,7 +43,7 @@ import {
 const SUPPORTED_METHODS: readonly ShippingMethod[] = ['paczkomat', 'kurier'];
 
 export class InpostShippingAdapter
-  implements ShippingProviderManagerPort, ShipmentCanceller, PickupPointFinder
+  implements ShippingProviderManagerPort, ShipmentCanceller, PickupPointFinder, LabelDocumentReader
 {
   private readonly logger = new Logger(InpostShippingAdapter.name);
 
@@ -120,6 +122,18 @@ export class InpostShippingAdapter
       query: buildPointsQuery(query),
     });
     return (response.items ?? []).map(toPickupPoint);
+  }
+
+  async fetchLabel(input: { providerShipmentId: string }): Promise<LabelDocument> {
+    // ShipX returns the label document bytes directly. We request PDF; the
+    // adapter forwards whatever `Content-Type` ShipX reports (it can answer
+    // PNG for some carriers) and defaults to PDF only when the header is absent.
+    const { body, contentType } = await this.http.requestBinary({
+      method: 'GET',
+      path: `/v1/shipments/${input.providerShipmentId}/label`,
+      query: { format: 'pdf' },
+    });
+    return { contentType: contentType || 'application/pdf', body };
   }
 }
 

--- a/libs/integrations/inpost/src/infrastructure/http/__tests__/inpost-http-client.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/http/__tests__/inpost-http-client.spec.ts
@@ -17,6 +17,8 @@ interface FakeResponseInit {
   status: number;
   body?: string;
   retryAfter?: string;
+  contentType?: string;
+  bytes?: Uint8Array;
 }
 
 function fakeResponse(init: FakeResponseInit): Response {
@@ -24,10 +26,21 @@ function fakeResponse(init: FakeResponseInit): Response {
     ok: init.ok,
     status: init.status,
     headers: {
-      get: (name: string): string | null =>
-        name.toLowerCase() === 'retry-after' ? (init.retryAfter ?? null) : null,
+      get: (name: string): string | null => {
+        const n = name.toLowerCase();
+        if (n === 'retry-after') return init.retryAfter ?? null;
+        if (n === 'content-type') return init.contentType ?? null;
+        return null;
+      },
     },
     text: (): Promise<string> => Promise.resolve(init.body ?? ''),
+    arrayBuffer: (): Promise<ArrayBuffer> => {
+      const bytes = init.bytes ?? new Uint8Array();
+      // Return a standalone ArrayBuffer copy (the Uint8Array's buffer may be a
+      // shared/pooled SharedArrayBuffer slice in some runtimes).
+      const copy = new Uint8Array(bytes);
+      return Promise.resolve(copy.buffer);
+    },
   } as unknown as Response;
 }
 
@@ -144,5 +157,44 @@ describe('InpostHttpClient', () => {
       InpostNetworkException,
     );
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  describe('requestBinary', () => {
+    it('should read a 2xx response as raw bytes and surface the content type', async () => {
+      const bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+      fetchMock.mockResolvedValueOnce(
+        fakeResponse({ ok: true, status: 200, contentType: 'application/pdf', bytes }),
+      );
+
+      const result = await client.requestBinary({ method: 'GET', path: '/v1/shipments/1/label' });
+
+      expect(result.contentType).toBe('application/pdf');
+      expect(Array.from(result.body)).toEqual([0x25, 0x50, 0x44, 0x46]);
+    });
+
+    it('should parse the JSON error envelope (NOT bytes) on a non-ok response', async () => {
+      // The error body must still go through the text/JSON error path — never
+      // read as bytes. A 4xx maps to ShippingProviderRejectionException.
+      fetchMock.mockResolvedValueOnce(
+        fakeResponse({
+          ok: false,
+          status: 400,
+          body: '{"message":"bad label request","details":{"shipment":["invalid"]}}',
+        }),
+      );
+
+      await expect(
+        client.requestBinary({ method: 'GET', path: '/v1/shipments/1/label' }),
+      ).rejects.toBeInstanceOf(ShippingProviderRejectionException);
+    });
+
+    it('should retry binary requests on 5xx and eventually surface InpostNetworkException', async () => {
+      fetchMock.mockResolvedValue(fakeResponse({ ok: false, status: 503 }));
+
+      await expect(
+        client.requestBinary({ method: 'GET', path: '/v1/shipments/1/label' }),
+      ).rejects.toBeInstanceOf(InpostNetworkException);
+      expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+    });
   });
 });

--- a/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.interface.ts
+++ b/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.interface.ts
@@ -21,6 +21,13 @@ export interface InpostRequestOptions {
   body?: unknown;
 }
 
+/** Raw-bytes response — the document bytes plus the reported content type. */
+export interface InpostBinaryResponse {
+  body: Uint8Array;
+  /** Lowercased `content-type` response header; '' when absent. */
+  contentType: string;
+}
+
 export interface IInpostHttpClient {
   /**
    * Issue a ShipX request. Resolves with the parsed JSON body (or `undefined`
@@ -29,4 +36,14 @@ export interface IInpostHttpClient {
    * `InpostNetworkException`).
    */
   request<T>(options: InpostRequestOptions): Promise<T>;
+
+  /**
+   * Issue a ShipX request and read the **response** as raw bytes (not JSON) —
+   * for document endpoints like `GET /v1/shipments/{id}/label?format=pdf`.
+   * Shares the same retry + error-mapping machinery as `request`: error
+   * responses are still parsed as the JSON ShipX error envelope; only a
+   * SUCCESS body is read via `arrayBuffer()`. Returns the bytes + the
+   * `content-type` header so the caller can label the document correctly.
+   */
+  requestBinary(options: InpostRequestOptions): Promise<InpostBinaryResponse>;
 }

--- a/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.ts
+++ b/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.ts
@@ -17,7 +17,11 @@ import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
 import type { ShipXErrorBody } from '../../domain/types/inpost-shipx.types';
 import { InpostUnauthorizedException } from '../../domain/exceptions/inpost-unauthorized.exception';
 import { InpostNetworkException } from '../../domain/exceptions/inpost-network.exception';
-import type { IInpostHttpClient, InpostRequestOptions } from './inpost-http-client.interface';
+import type {
+  IInpostHttpClient,
+  InpostBinaryResponse,
+  InpostRequestOptions,
+} from './inpost-http-client.interface';
 
 interface RetryConfig {
   maxRetries: number;
@@ -64,12 +68,28 @@ export class InpostHttpClient implements IInpostHttpClient {
   }
 
   async request<T>(options: InpostRequestOptions): Promise<T> {
+    return this.withRetry(options, (opts) => this.executeOnce<T>(opts));
+  }
+
+  async requestBinary(options: InpostRequestOptions): Promise<InpostBinaryResponse> {
+    return this.withRetry(options, (opts) => this.executeBinaryOnce(opts));
+  }
+
+  /**
+   * Shared retry loop: runs `exec` up to `maxRetries + 1` times, retrying only
+   * on the internal `RetryableHttpError` marker (429 / 5xx / network), honoring
+   * `Retry-After`, and converting an exhausted budget to `InpostNetworkException`.
+   */
+  private async withRetry<R>(
+    options: InpostRequestOptions,
+    exec: (options: InpostRequestOptions) => Promise<R>,
+  ): Promise<R> {
     const requestId = randomUUID();
     let delay = this.retryConfig.initialDelayMs;
 
     for (let attempt = 0; attempt <= this.retryConfig.maxRetries; attempt++) {
       try {
-        return await this.executeOnce<T>(options);
+        return await exec(options);
       } catch (error) {
         if (!(error instanceof RetryableHttpError)) {
           throw error;
@@ -91,13 +111,45 @@ export class InpostHttpClient implements IInpostHttpClient {
   }
 
   private async executeOnce<T>(options: InpostRequestOptions): Promise<T> {
+    const response = await this.fetchOnce(options);
+
+    // Error handling runs FIRST (throws on !ok) so a binary call never feeds
+    // bytes to the error parser and a JSON call never parses an error body as data.
+    await this.throwIfNotOk(response, options);
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    const text = await response.text();
+    if (!text) {
+      return undefined as T;
+    }
+    try {
+      const data: unknown = JSON.parse(text);
+      return data as T;
+    } catch (error) {
+      throw new InpostNetworkException('ShipX returned an unparseable response body', error);
+    }
+  }
+
+  private async executeBinaryOnce(options: InpostRequestOptions): Promise<InpostBinaryResponse> {
+    const response = await this.fetchOnce(options);
+    await this.throwIfNotOk(response, options);
+
+    const body = new Uint8Array(await response.arrayBuffer());
+    return {
+      body,
+      contentType: response.headers.get('content-type')?.toLowerCase() ?? '',
+    };
+  }
+
+  private async fetchOnce(options: InpostRequestOptions): Promise<Response> {
     const url = this.buildUrl(options.path, options.query);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
-    let response: Response;
     try {
-      response = await fetch(url, {
+      return await fetch(url, {
         method: options.method,
         headers: {
           Authorization: `Bearer ${this.apiToken}`,
@@ -112,21 +164,12 @@ export class InpostHttpClient implements IInpostHttpClient {
     } finally {
       clearTimeout(timeout);
     }
+  }
 
+  /** Map a non-ok ShipX response to the right domain exception. No-op on ok. */
+  private async throwIfNotOk(response: Response, options: InpostRequestOptions): Promise<void> {
     if (response.ok) {
-      if (response.status === 204) {
-        return undefined as T;
-      }
-      const text = await response.text();
-      if (!text) {
-        return undefined as T;
-      }
-      try {
-        const data: unknown = JSON.parse(text);
-        return data as T;
-      } catch (error) {
-        throw new InpostNetworkException('ShipX returned an unparseable response body', error);
-      }
+      return;
     }
 
     const errorBody = await this.safeParseError(response);

--- a/libs/integrations/inpost/src/testing/fake-inpost-shipping.adapter.ts
+++ b/libs/integrations/inpost/src/testing/fake-inpost-shipping.adapter.ts
@@ -16,8 +16,10 @@ import type {
   ShippingProviderManagerPort,
   ShipmentCanceller,
   PickupPointFinder,
+  LabelDocumentReader,
   GenerateLabelCommand,
   GenerateLabelResult,
+  LabelDocument,
   TrackingSnapshot,
   ShipmentStatus,
   ShippingMethod,
@@ -29,7 +31,11 @@ import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
 const SUPPORTED_METHODS: readonly ShippingMethod[] = ['paczkomat', 'kurier'];
 
 export class FakeInpostShippingAdapter
-  implements ShippingProviderManagerPort, ShipmentCanceller, PickupPointFinder
+  implements
+    ShippingProviderManagerPort,
+    ShipmentCanceller,
+    PickupPointFinder,
+    LabelDocumentReader
 {
   private counter = 0;
   private seededFailure: Error | null = null;
@@ -92,6 +98,16 @@ export class FakeInpostShippingAdapter
 
   findPickupPoints(_query: FindPickupPointsQuery): Promise<PickupPoint[]> {
     return Promise.resolve([...this.seededPoints]);
+  }
+
+  fetchLabel(_input: { providerShipmentId: string }): Promise<LabelDocument> {
+    if (this.seededFailure) {
+      return Promise.reject(this.seededFailure);
+    }
+    return Promise.resolve({
+      contentType: 'application/pdf',
+      body: new Uint8Array([0x25, 0x50, 0x44, 0x46]), // %PDF
+    });
   }
 
   // --- test helpers ----------------------------------------------------------


### PR DESCRIPTION
## What & why

Gives operators a UI path to retrieve a shipment's printable label. PR #881 shipped the order-detail Shipment panel and the dispatch seam (#835) already persists `labelPdfRef`, but there was no endpoint or button to fetch the bytes. This closes that gap.

The capability is named for the **business verb, not the format**: the bytes can be PDF / ZPL / EPL / PNG depending on provider + seller config, carried dynamically by `LabelDocument.contentType`.

## Changes

**CORE**
- New `LabelDocumentReader` sub-capability of `ShippingProviderManagerPort` (`fetchLabel({providerShipmentId}) → LabelDocument`) + co-located `isLabelDocumentReader` guard.
- `ShipmentLabelService` (behind `SHIPMENT_LABEL_SERVICE_TOKEN`) — resolves the shipment's provider adapter, narrows the capability, returns the bytes. Read-only; mirrors `ShipmentCancellationService`.
- Domain exceptions `LabelDocumentNotSupportedException` / `LabelNotAvailableException` (both → 422, distinct operator-actionable messages).

**Integration**
- Binary-response transport added to both HTTP clients (`postExpectingBinary` on Allegro via a named `RequestMode`, `requestBinary` on InPost via a shared `withRetry`/`throwIfNotOk`). Ordering is load-bearing: `response.ok` is checked **first**, so error envelopes still parse as JSON and only success bodies are read as bytes.
- `AllegroDeliveryShippingAdapter.fetchLabel` → `POST /shipment-management/label`; `InpostShippingAdapter.fetchLabel` → `GET /v1/shipments/{id}/label?format=pdf`. Content-type is passed through (default `application/pdf` only when absent).

**Interface**
- `GET /shipments/:id/label` streams the bytes with a content-type-derived filename extension (`extensionForContentType`); 404 / 422 / 502 mapping via the existing `toHttpException` helper. Admin + JWT inherited.

**Frontend**
- Shared api-client `requestBlob` path (reuses the same `execute()` auth/refresh/timeout machinery as `request`).
- One-shot `useLabelDownload` hook, a status-gated **Download label** button, and auto-download on first issuance. Filename extension derived from the blob content type; object URL revoke deferred past the click tick.

## How to test

- Unit: `pnpm test` — core shipping (incl. `shipment-label.service`, `label-document-reader.capability`), allegro (`allegro-http-client`, `allegro-delivery-shipping`), inpost (`inpost-http-client`, `inpost-shipping`), api `shipment.controller`, web `order-shipment-panel` / `generate-label-form`.
- Integration: `apps/api/test/integration/shipment-label-download.int-spec.ts` (round-trips canned bytes end-to-end through a stubbed provider). **Not run in the authoring session — Docker unavailable; please run `pnpm test:integration` in CI / locally.**

## Notes / follow-ups

- The exact Allegro `POST /shipment-management/label` **response framing** (raw bytes vs JSON wrapper) is documented-but-unverified (plan §6). The design is robust to it (content-type passthrough, JSON-error path intact) and any correction is localized to `AllegroDeliveryShippingAdapter.fetchLabel`. Worth a sandbox probe before relying on it in production.
- The paczkomat picker (#883) and dispatch protocol / handover manifest (#831) remain out of scope; `DispatchProtocolReader` will be a sibling sub-capability when #831 ships.

No migration (reads the existing `labelPdfRef` / `providerShipmentId` columns).

Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)