### PR TITLE
refactor(web): replace platformType literal-equality with pickupPointResolvesAsync trait (#893)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -515,6 +515,22 @@ module.exports = {
             message:
               "Literal-equality dispatch on platformType is forbidden outside apps/web/src/plugins/. Use usePlatform()/usePlatforms() from shared/plugins, or capability checks (supportedCapabilities.includes('…')). See #578/#579.",
           },
+          {
+            // Optional-chained member access (`conn?.platformType === '…'`) parses
+            // as a ChainExpression wrapping the MemberExpression, so the property
+            // lives one level deeper at `left.expression.property`. Without these
+            // two branches the rule misses the optional-chained form (#893).
+            selector:
+              "BinaryExpression[operator=/^(===|!==)$/][left.expression.property.name='platformType'][right.type='Literal']",
+            message:
+              "Literal-equality dispatch on platformType is forbidden outside apps/web/src/plugins/. Use usePlatform()/usePlatforms() from shared/plugins, or capability checks (supportedCapabilities.includes('…')). See #578/#579.",
+          },
+          {
+            selector:
+              "BinaryExpression[operator=/^(===|!==)$/][right.expression.property.name='platformType'][left.type='Literal']",
+            message:
+              "Literal-equality dispatch on platformType is forbidden outside apps/web/src/plugins/. Use usePlatform()/usePlatforms() from shared/plugins, or capability checks (supportedCapabilities.includes('…')). See #578/#579.",
+          },
         ],
       },
     },

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -217,6 +217,9 @@ describe('GenerateLabelForm — AC-3 pickup-point retry hint (#839)', () => {
     ).toBeInTheDocument();
   });
 
+  // PrestaShop omits the `pickupPointResolvesAsync` trait, so `usePlatform`
+  // resolves it falsy and the hint stays hidden — pins the trait path (#893),
+  // not the old literal `platformType === 'allegro'` compare.
   it('should NOT render the retry hint when the order source is not Allegro', async () => {
     const order = makeOrderWithoutPickupPoint({
       sourceConnectionId: 'conn-ps-1',

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -27,6 +27,7 @@ import { useForm, type SubmitHandler } from 'react-hook-form';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { useConnectionsQuery } from '../../connections';
+import { usePlatform } from '../../../shared/plugins';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { FieldError } from '../../../shared/ui/field-error';
@@ -105,9 +106,14 @@ export function GenerateLabelForm({
   const sourceConnection = (connectionsQuery.data ?? []).find(
     (c) => c.id === order.sourceConnectionId,
   );
+  // Trait-driven, not a literal `platformType === 'allegro'` compare (#893):
+  // any platform whose pickup-point resolves asynchronously opts in via the
+  // `pickupPointResolvesAsync` PlatformContribution slot. `usePlatform` is a
+  // hook — keep this call unconditional at the top of the component.
+  const sourcePlatform = usePlatform(sourceConnection?.platformType);
   const showPickupRetryHint =
     !hasPickupPoint &&
-    sourceConnection?.platformType === 'allegro' &&
+    sourcePlatform?.pickupPointResolvesAsync === true &&
     isWithinPickupPointRetryWindow(order.createdAt);
   const [pickupRetryInFlight, setPickupRetryInFlight] = useState(false);
   const handlePickupRetry = async (): Promise<void> => {

--- a/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
@@ -198,6 +198,10 @@ describe('OrderShipmentPanel — populated state', () => {
 
     renderWithProviders(<OrderShipmentPanel order={makeOrder()} />, { apiClient });
 
+    // Driven by the Allegro plugin's `pickupPointResolvesAsync` trait (#893),
+    // resolved via `usePlatform` against the real registry — not a literal
+    // `platformType === 'allegro'` compare. The "via Allegro" suffix is the
+    // platform's `displayName`.
     expect(await screen.findByText(/buyer-selected via Allegro/i)).toBeInTheDocument();
   });
 

--- a/apps/web/src/features/orders/components/order-shipment-panel.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.tsx
@@ -18,6 +18,7 @@ import {
   useOrderShipmentsQuery,
   type Shipment,
 } from '../../shipments';
+import { usePlatform, type Platform } from '../../../shared/plugins';
 import { Alert } from '../../../shared/ui/alert';
 import { LoadingState, ErrorState, EmptyState } from '../../../shared/ui/feedback-state';
 import { KeyValueList, type KeyValueItem } from '../../../shared/ui/key-value-list';
@@ -144,7 +145,11 @@ function OrderShipmentPanelBody({
   shippingPlatformType: string | null;
   mutationError: string | null;
 }): ReactElement {
-  const items = buildShipmentFieldItems(shipment, shippingPlatformType);
+  // Resolve the shipping platform's contribution here (a component) rather than
+  // in the parent, which has early returns above its `shippingConnection`
+  // computation — a `usePlatform` call there would be conditional (#893).
+  const shippingPlatform = usePlatform(shippingPlatformType ?? undefined);
+  const items = buildShipmentFieldItems(shipment, shippingPlatform);
   return (
     <div className="order-shipment-panel__body">
       <KeyValueList items={items} />
@@ -159,7 +164,7 @@ function OrderShipmentPanelBody({
 
 function buildShipmentFieldItems(
   shipment: Shipment,
-  shippingPlatformType: string | null,
+  shippingPlatform: Platform | undefined,
 ): KeyValueItem[] {
   const items: KeyValueItem[] = [];
 
@@ -184,13 +189,15 @@ function buildShipmentFieldItems(
     value: carrierName ?? <span className="text-muted">— (awaiting)</span>,
   });
 
-  // Paczkomat row — caption keyed on shipping-connection platformType, NOT
-  // the shipment's `paczkomatId === null` (a null is "kurier shipment", a
-  // value is "paczkomat shipment"; caption tells operator who selected it).
+  // Paczkomat row — caption keyed on the shipping platform's
+  // `pickupPointResolvesAsync` trait (#893), NOT the shipment's
+  // `paczkomatId === null` (a null is "kurier shipment", a value is "paczkomat
+  // shipment"; caption tells operator who selected it). Platforms whose locker
+  // is buyer-selected on-platform set the trait; everything else is operator-set.
   if (shipment.paczkomatId !== null) {
     const caption =
-      shippingPlatformType === 'allegro'
-        ? '(buyer-selected via Allegro)'
+      shippingPlatform?.pickupPointResolvesAsync === true
+        ? `(buyer-selected via ${shippingPlatform.displayName})`
         : '(operator-selected)';
     items.push({
       id: 'paczkomat',

--- a/apps/web/src/plugins/allegro/index.ts
+++ b/apps/web/src/plugins/allegro/index.ts
@@ -49,6 +49,9 @@ export const allegroPlugin: OpenLinkerPlugin = definePlugin({
     requiresExternalAuthRedirect: true,
     ExtraConfigSection: AllegroExtraSection,
     supportsListingEdit: true,
+    // Allegro Delivery resolves the buyer's locker asynchronously — the order
+    // arrives before the pickup-point payload (#839 AC-3, #893).
+    pickupPointResolvesAsync: true,
     extractContentPublishErrors: extractAllegroContentPublishErrors,
   },
 });

--- a/apps/web/src/shared/plugins/plugin.types.ts
+++ b/apps/web/src/shared/plugins/plugin.types.ts
@@ -214,6 +214,18 @@ export interface PlatformContribution {
   /** Listing-detail: gate the "Edit offer" button on `ListingDetailPage`. */
   supportsListingEdit?: boolean;
   /**
+   * `true` when the platform's order pickup-point payload resolves
+   * asynchronously after the order is received — the buyer selects the
+   * locker on the platform, but it arrives on a later platform poll.
+   * Drives:
+   *   - `OrderShipmentPanel`'s paczkomat-row caption ("buyer-selected via
+   *     {displayName}" vs. "operator-selected")
+   *   - `GenerateLabelForm`'s pickup-point retry hint (#839 AC-3)
+   * Omit for platforms where the pickup-point arrives synchronously with the
+   * order payload.
+   */
+  pickupPointResolvesAsync?: boolean;
+  /**
    * Content feature: optional platform-specific structured-error extractor
    * for content-publish failures (#613). Given an unknown error thrown by
    * the publish mutation, return a `StructuredError[]` for inline rendering

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -501,6 +501,7 @@ Every slot is optional. A plugin contributes only the affordances its platform a
 | `CredentialsPanel` | `ComponentType<{ connection }>` | `EditConnectionForm` | Full credentials panel including the rotate-key UI shape that fits the platform's credential model. When absent, the form renders a read-only "Stored securely (managed by integration)" / "Environment variable" affordance. |
 | `ConnectionActions` | `ComponentType<{ connection }>` | `ConnectionActionsPanel` | Extra platform-specific actions on the connection-detail page (PS: "Configure webhooks"). |
 | `supportsListingEdit` | `boolean` | `ListingDetailPage` | Gates the "Edit offer" button on the listing-detail page. |
+| `pickupPointResolvesAsync` | `boolean` | `OrderShipmentPanel`, `GenerateLabelForm` | `true` when the platform's order pickup-point (locker) resolves asynchronously after the order is received — the buyer selects it on-platform and it arrives on a later poll. Drives the paczkomat-row caption ("buyer-selected via {displayName}" vs "operator-selected") and the pickup-point retry hint (#839 AC-3 / #893). |
 | `extractContentPublishErrors` | `(err: unknown) => StructuredError[] \| null` | `extractPlatformErrors` | Optional platform-specific structured-error extractor for content-publish failures (#613). |
 
 Module-load validation in `apps/web/src/plugins/index.ts` rejects duplicate plugin `id`s and duplicate `platformType`s before any provider mounts. `PluginRegistryProvider` re-runs the same check at mount time as belt-and-suspenders for test fixtures.

--- a/docs/plans/implementation-plan-fe-pickup-resolves-async-trait.md
+++ b/docs/plans/implementation-plan-fe-pickup-resolves-async-trait.md
@@ -1,0 +1,143 @@
+# Implementation Plan — FE `pickupPointResolvesAsync` platform trait (#893)
+
+## 1. Understand the task
+
+**Goal.** Replace two `platformType === 'allegro'` literal compares in `features/orders/` with a
+declarative `PlatformContribution` trait, so the orders feature stays platform-agnostic and any future
+platform with async pickup-point semantics opts in by declaring the trait. Tighten the ESLint selector
+that should have caught the optional-chained form.
+
+**Classification.** Frontend (`apps/web`). No backend change, no migration.
+
+**Explicit non-goals (from the issue).**
+- The broader Modularity Thread H / FE plugin-contract redesign (#554) — this is a narrow doc-vs-code
+  reconciliation on the *existing* `PlatformContribution` surface.
+- Migrating other `platformType` literal compares — the widened ESLint rule surfaces them; address
+  opportunistically (and the sweep below shows there are none left to migrate anyway).
+
+## 2. Research findings
+
+**The two call sites (both genuinely Allegro-specific async-pickup UX):**
+
+1. `features/orders/components/generate-label-form.tsx:108-111` — AC-3 retry hint gated on
+   `sourceConnection?.platformType === 'allegro'` (**optional-chained** — this is the form the current
+   ESLint rule misses).
+2. `features/orders/components/order-shipment-panel.tsx:191-194` — paczkomat-row caption
+   (`buildShipmentFieldItems` helper) gated on a standalone `shippingPlatformType === 'allegro'`
+   variable (the panel passes `shippingConnection?.platformType ?? null` down through
+   `OrderShipmentPanelBody`).
+
+**Existing trait surface** (`shared/plugins/plugin.types.ts:182`): `PlatformContribution` already holds
+~11 optional slots (`setupCard`, `supportsListingEdit`, `extractContentPublishErrors`, …). Adding one
+more optional boolean is the established extension shape. `usePlatform(platformType)` (`shared/plugins/
+use-platform.ts`) returns the flattened `Platform = { platformType } & PlatformContribution` or
+`undefined` for unknown platforms.
+
+**Allegro plugin** (`plugins/allegro/index.ts:40`): `platform.displayName === 'Allegro'`. So a generalized
+caption `(buyer-selected via ${displayName})` renders byte-identical to today's `(buyer-selected via Allegro)`.
+
+**Tests** (`renderWithProviders` defaults `plugins = inTreePlugins`, the real registry — so `usePlatform`
+resolves the real Allegro/PrestaShop plugins in tests):
+- `order-shipment-panel.test.tsx` — asserts `operator-selected` for an **InPost** shipping connection
+  (no FE plugin → `usePlatform` undefined → falsy ✓) and `buyer-selected via Allegro` for Allegro ✓.
+- `generate-label-form.test.tsx` — Allegro-source ⇒ hint shown ✓; **PrestaShop-source ⇒ no hint**
+  (line 220, the AC's required negative test **already exists**); old Allegro order outside window ⇒
+  no hint ✓.
+
+**ESLint sweep** (`platformType [=!]== <literal>` under `apps/web/src` excl. `plugins/` and tests):
+the only optional-chained member-access-vs-literal compare is `generate-label-form.tsx:110` — which this
+migration deletes. The other matches compare against **identifiers/sentinels** (`MASTER_CHANNEL_SENTINEL`,
+a `platformType` variable), not string literals, so the widened `[…type='Literal']`-guarded selector
+won't newly fire on them. `allegro-seller-panel-url.ts:29` is a standalone-variable compare the rule
+intentionally exempts.
+
+## 3. Design
+
+**New trait slot** (`shared/plugins/plugin.types.ts`, on `PlatformContribution`):
+
+```ts
+/**
+ * `true` when the platform's order pickup-point payload resolves asynchronously
+ * after the order is received (the buyer selects the locker on the platform, but
+ * it arrives on a later poll). Drives the OrderShipmentPanel paczkomat caption
+ * and the GenerateLabelForm pickup-point retry hint. Omit for platforms whose
+ * pickup-point arrives synchronously with the order payload.
+ */
+pickupPointResolvesAsync?: boolean;
+```
+
+Allegro plugin sets `pickupPointResolvesAsync: true`. PrestaShop/others omit it (falsy).
+
+**Migration — generate-label-form.tsx:** the component already calls `useConnectionsQuery` and computes
+`sourceConnection`. Add `const sourcePlatform = usePlatform(sourceConnection?.platformType);` and gate on
+`sourcePlatform?.pickupPointResolvesAsync === true`. (Hook call is unconditional, top-level of the
+component — safe.)
+
+**Migration — order-shipment-panel.tsx:** call `usePlatform` inside `OrderShipmentPanelBody` (a component
+rendered unconditionally in the active-shipment branch — no early returns before it, so the hook is
+safe). Pass the resolved `Platform | undefined` into `buildShipmentFieldItems`, which derives:
+```ts
+const caption = shippingPlatform?.pickupPointResolvesAsync
+  ? `(buyer-selected via ${shippingPlatform.displayName})`
+  : '(operator-selected)';
+```
+`buildShipmentFieldItems` stays a pure function (takes `Platform | undefined`, no hook). The parent keeps
+passing `shippingConnection?.platformType ?? null` to Body; Body resolves it. Caption is byte-identical
+for Allegro (`displayName: 'Allegro'`).
+
+**ESLint widening** (`.eslintrc.js`, the `no-restricted-syntax` block ~503-518): keep the two existing
+general selectors and **add two optional-chain branches**, preserving generality (any Literal, `===`/`!==`,
+either side) rather than the issue's narrower `right.value='allegro'`/`===`-only proposal:
+```
+BinaryExpression[operator=/^(===|!==)$/][left.expression.property.name='platformType'][right.type='Literal']
+BinaryExpression[operator=/^(===|!==)$/][right.expression.property.name='platformType'][left.type='Literal']
+```
+(`left.expression` reaches through the `ChainExpression` wrapper that optional chaining produces.)
+
+## 4. Step-by-step implementation
+
+1. **`shared/plugins/plugin.types.ts`** — add `pickupPointResolvesAsync?: boolean` + JSDoc to
+   `PlatformContribution`. AC: slot added with JSDoc.
+2. **`plugins/allegro/index.ts`** — set `pickupPointResolvesAsync: true` in the `platform` bag.
+   AC: Allegro sets the trait.
+3. **`features/orders/components/generate-label-form.tsx`** — import `usePlatform`; replace the
+   `sourceConnection?.platformType === 'allegro'` gate with the trait lookup. AC: site migrated.
+4. **`features/orders/components/order-shipment-panel.tsx`** — `usePlatform` in `OrderShipmentPanelBody`;
+   change `buildShipmentFieldItems` to take `Platform | undefined`; caption uses the trait + `displayName`.
+   AC: site migrated.
+5. **`.eslintrc.js`** — add the two optional-chain selector branches. AC: selector tightened.
+6. **Tests** — the AC's PS-negative test already exists (`generate-label-form.test.tsx:220`) and the panel
+   has the InPost `operator-selected` negative. Verify both green unchanged; add an explicit
+   `pickupPointResolvesAsync` assertion only if coverage is thin (decide during impl — likely no new test
+   needed beyond confirming existing ones pin the trait behaviour).
+7. **Quality gate** — `pnpm lint && pnpm type-check && pnpm test` (run `pnpm build` first so workspace
+   `dist` artifacts exist — the dist-resolution gotcha hit last session, tracked by #869).
+
+## 5. Validation
+
+- **Architecture / dependency direction**: `features → shared` (`usePlatform` from `shared/plugins`) — legal;
+  `plugins/allegro` declaring the trait — legal. No `shared → features` edge introduced. ✅
+- **Naming/state**: no new files; trait is an optional boolean on an existing interface. ✅
+- **Behaviour preserved**: Allegro caption + hint identical (`displayName: 'Allegro'`); InPost/PS fall to
+  the generic/no-hint path exactly as today. ✅
+- **Lint regression risk**: swept — the widened selector fires only on the deleted line; no pre-existing
+  literal-vs-`platformType` member compares remain. ✅
+- **Security**: none (pure FE display logic). ✅
+
+## Resolved after tech-review
+
+- **Doc-table update (IMPORTANT):** added a `pickupPointResolvesAsync` row to the `PlatformContribution`
+  slot-reference table in `docs/frontend-architecture.md` — the doc enumerates every slot and #893
+  anchors on it, so a new slot must be listed.
+- **ESLint selector:** kept general (any Literal, `===`/`!==`, both sides) + added the two optional-chain
+  branches (`{left,right}.expression.property.name`). Verified disjoint from the existing branches.
+- **Tests:** no new test required (AC's PS-negative + the InPost panel negative already exist); added
+  intent comments documenting that both now pin the trait path, not the literal compare.
+
+## Open question (minor)
+
+- The issue's proposed ESLint selector hardcodes `right.value='allegro'` and only `===`. I'm keeping the
+  rule **general** (any literal, both operators, both sides) and only adding optional-chain reach — a
+  strict improvement over the issue text. Flagging in case the issue author specifically wanted the
+  narrower form (I don't think so — the existing rule is general and #893 is about closing the
+  optional-chain gap, not narrowing scope).


### PR DESCRIPTION
## What & why

Closes #893.

Two sites in `features/orders/` branched UX on `connection.platformType === 'allegro'` — forbidden outside `plugins/` per `docs/frontend-architecture.md` § Platform Plugins. The **optional-chained** form (`conn?.platformType === '…'`) slipped past the `no-restricted-syntax` guard, which is how these shipped in #881 / #890.

This replaces the literal compares with a declarative trait on the existing `PlatformContribution` bag, keeping the orders feature platform-agnostic — any future platform with async pickup-point semantics opts in by declaring the trait.

## Changes

- **`shared/plugins/plugin.types.ts`** — new optional `pickupPointResolvesAsync?: boolean` slot on `PlatformContribution` (matches the `supportsListingEdit` precedent), with JSDoc.
- **`plugins/allegro/index.ts`** — Allegro sets `pickupPointResolvesAsync: true` (Allegro Delivery resolves the buyer's locker asynchronously, #839 AC-3).
- **`features/orders/components/generate-label-form.tsx`** — AC-3 retry-hint gate → `usePlatform(sourceConnection?.platformType)?.pickupPointResolvesAsync === true`.
- **`features/orders/components/order-shipment-panel.tsx`** — paczkomat caption resolved via `usePlatform` inside `OrderShipmentPanelBody` (not the early-returning parent), generalized to `(buyer-selected via {displayName})`.
- **`.eslintrc.js`** — `no-restricted-syntax` selector widened to also catch the optional-chained member form (`{left,right}.expression.property.name`). Kept general (any literal, both operators) rather than narrowing to `'allegro'`.
- **`docs/frontend-architecture.md`** — `PlatformContribution` slot-reference table row for the new slot.

## Behaviour

Unchanged — Allegro keeps the retry hint + "buyer-selected via Allegro" caption (`displayName: 'Allegro'` ⇒ byte-identical); PrestaShop/InPost fall to the no-hint / "operator-selected" path. The existing PS-source and InPost negatives already pin both sites, and `renderWithProviders` uses the real plugin registry so they now exercise the trait path; intent comments added.

## How to test

```bash
pnpm --filter @openlinker/web test          # 1288 pass
pnpm --filter @openlinker/web lint           # 0 errors (widened selector fires nowhere)
pnpm --filter @openlinker/web type-check
```

## Deviations from the issue (intentional)

- ESLint selector kept **general** (any literal, `===`/`!==`, both sides) rather than the issue's `'allegro'`/`===`-only proposal — strictly broader coverage.
- No new test added: the AC's requested PrestaShop-negative already exists (`generate-label-form.test.tsx`), as does the InPost "operator-selected" negative for the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)