### PR TITLE
fix(orders,prestashop): source-authoritative order pricing (#895)

### DIFF
--- a/apps/api/test/integration/helpers/prestashop-fixture.helper.ts
+++ b/apps/api/test/integration/helpers/prestashop-fixture.helper.ts
@@ -63,6 +63,14 @@ const WS_RESOURCES = [
   'languages',
   'countries',
   'states',
+  // #895: source-authoritative line pricing. The order processor writes
+  // cart-scoped `specific_prices` to pin the buyer-paid price, and
+  // `PrestashopTaxRateResolver` reads `tax_rules` + `taxes` to convert
+  // gross→net. Without these grants the WS key is rejected on those
+  // resources and order creation fails (the fail-loud pricing invariant).
+  'specific_prices',
+  'tax_rules',
+  'taxes',
   // Used by PrestashopWebhookProvisioningAdapter to write OPENLINKER_*
   // rows (#168 / #541). Carrier-mapping smoke spec doesn't touch this
   // resource, so adding it here is purely additive.

--- a/docs/architecture/adrs/014-source-authoritative-order-pricing.md
+++ b/docs/architecture/adrs/014-source-authoritative-order-pricing.md
@@ -1,0 +1,75 @@
+# ADR-014: Source-authoritative order pricing
+
+- **Status**: Proposed
+- **Date**: 2026-05-30
+- **Authors**: @piotrswierzy
+
+## Context
+
+When a marketplace order (Allegro) is created into a destination shop (PrestaShop), the
+destination order must reflect the **buyer-paid source price**, not the destination's own catalog
+price. Today PrestaShop orders land in `Payment error` (issue #895, repro order #6 `RPRRSFSUW`):
+the `order_detail` lines are priced from the PS catalog while only `total_paid` carries the
+marketplace amount, so PS flags "X paid instead of Y". Root cause: the PS adapter creates the
+order from a cart (`id_cart`), and PS prices `order_detail` from the cart's catalog price,
+ignoring the `order_rows[].product_price` we send.
+
+The order-creation contract (`OrderProcessorManagerPort.createOrder`, `OrderCreate`/`OrderTotals`)
+carries a bare `price: number` with no tax semantics — it under-specifies money. WooCommerce
+(#877) and Shopify are future destinations, so the contract must stay platform-neutral.
+
+## Decision
+
+Model source-authoritative pricing as a **core invariant**, implemented natively per integration:
+
+1. **Invariant, not capability.** `createOrder` MUST price lines at `OrderCreate.items[].price`
+   and MUST NOT substitute the destination catalog price; a destination that cannot must fail
+   loudly. This is a behavioural constraint on an existing method, not an opt-in sub-capability.
+2. **Neutral tax semantics in core.** Add `taxTreatment?: 'inclusive' | 'exclusive'` (order-level)
+   and make `tax?: number` optional on `OrderTotals` — two orthogonal axes (gross/net vs.
+   amount-known/unknown). The destination's tax **rate** stays destination-side (bounded context).
+3. **PrestaShop implements via native cart-scoped `specific_price`** (tax-excluded), created before
+   `POST /orders`; gross→net inversion uses PS's own rate for the order's **delivery country**.
+4. **Rounding** anchors on the buyer-paid total via a neutral largest-remainder penny-allocation
+   helper (`@openlinker/shared/money`, minor units); PS stays the tax/rounding authority.
+5. Override rows have a **saga lifecycle** (create → order → delete, compensate on failure,
+   self-healing reconciliation for crashes, short `to`-expiry as fail-safe).
+
+## Alternatives considered
+
+- **Opt-in `is…` capability** for price-pinning. Rejected: pinning is universal (every real
+  destination supports it) and mis-pricing money is a correctness bug, not a degraded-but-OK
+  outcome — capability-absence would license silent catalog fallback (the bug itself).
+- **Extend the OL PrestaShop module sidecar** (like shipping). Rejected: it bypasses PS's tax
+  engine, making OpenLinker a second, drift-prone tax authority and producing fiscally-wrong VAT
+  on invoices. The shipping sidecar was a workaround for a *missing* native PS mechanism; line
+  pricing has a native one (`specific_price`).
+- **Per-line tax-inclusivity / tax rate on `OrderItem`.** Rejected: tax inclusivity is
+  source-uniform; tax rate is destination-catalog knowledge that must not leak into the source
+  order model.
+- **Mirror PS's rounding engine in the adapter.** Rejected: re-implements platform-internal
+  accounting; couples to PS internals and drifts across versions.
+
+## Consequences
+
+**Pros:**
+- Orders are fiscally correct (PS-native VAT decomposition, invoices, accounting).
+- Contract is platform-neutral; WC/Shopify implement the same invariant natively.
+- Tax-rate and rounding authority stay in the destination system of record.
+
+**Cons / trade-offs:**
+- PS adapter must resolve per-country tax rates and manage `specific_price` lifecycle.
+- `tax?: number` becoming optional ripples to all `OrderTotals.tax` consumers (compiler-guided).
+- Float `number` money representation remains; a `Money` value object is the deferred end-state.
+
+**Migration path:**
+- No DB migration — `order_records.totals` is `jsonb`; new fields are optional/back-compatible.
+
+## References
+
+- Related issues: #895; future consumers #877 (WooCommerce `OrderProcessorManager`)
+- Related ADRs: [ADR-002](./002-capability-ports-with-sub-capabilities.md) (capability vs.
+  invariant distinction), [ADR-012](./012-branch-1-fulfillment-modeling.md) (order destination
+  modeling)
+- Plan: [implementation-plan-source-authoritative-order-pricing.md](../../plans/implementation-plan-source-authoritative-order-pricing.md)
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md) § Orders

--- a/docs/plans/implementation-plan-source-authoritative-order-pricing.md
+++ b/docs/plans/implementation-plan-source-authoritative-order-pricing.md
@@ -203,6 +203,15 @@ compute net unit prices + penny-allocate + `POST /specific_prices` (cart-scoped)
 
 ## 5. Open risks (tracked, not blocking)
 
+0a. **New PrestaShop WS-key permission requirement (operator-facing).** The order
+    processor now writes `specific_prices` and the tax resolver reads `tax_rules` /
+    `taxes`. An existing PS connection whose WS key lacks these permissions will now
+    **fail order creation loudly** (by design — the alternative is silent
+    mis-pricing). Surfaced in the int-test fixture grant; **operators must grant
+    `specific_prices` (CRUD) + `tax_rules` / `taxes` (read)** on the PS WebService key.
+    Follow-up: have the PrestaShop connection-tester verify these grants and/or
+    document them in the connection setup guide.
+
 0. **Shipping reconciliation is out of scope (scope boundary).** This fix pins the
    **line** price. `Payment error` also fires on shipping mismatch: for a **static**
    (non-OL-Dynamic) carrier PS computes shipping from its own zone tables, which may

--- a/docs/plans/implementation-plan-source-authoritative-order-pricing.md
+++ b/docs/plans/implementation-plan-source-authoritative-order-pricing.md
@@ -1,0 +1,214 @@
+# Implementation Plan — Source-Authoritative Order Pricing (#895)
+
+> **Status:** v3 (post tech-review) — in implementation
+> **Issue:** [#895](https://github.com/openlinker-project/openlinker/issues/895)
+> **ADR:** [ADR-014](../architecture/adrs/014-source-authoritative-order-pricing.md)
+> **Branch:** `895-source-authoritative-order-pricing`
+
+---
+
+## 1. Goal & framing
+
+When a marketplace order (Allegro) is created into a destination shop (PrestaShop), the destination
+order **must be priced at the buyer-paid source price**, not the destination catalog price. Today PS
+orders land in `Payment error` (repro #6 `RPRRSFSUW`: catalog 1,499×2 on the lines, 30.95 paid).
+
+**CORE owns the scenario; integrations implement it natively.** The seven design decisions below
+were resolved in a design grill and are captured in ADR-014.
+
+### Resolved decisions
+
+| # | Decision | Resolution |
+|---|---|---|
+| Q1 | Contract shape | **Invariant** on `createOrder` (not opt-in capability); fail-fast if unhonorable |
+| Q2 | Core tax signal | `taxTreatment?: 'inclusive'\|'exclusive'` union on `OrderTotals`, order-level; tax **rate stays destination-side** |
+| Q3 | PS mechanism | Native cart-scoped **`specific_price`** (fiscal correctness; PS stays its own tax authority) |
+| Q4 | Tax + rounding | **Delivery-country** rate from PS; **buyer-paid-total-anchored largest-remainder** allocation; don't mirror PS rounding |
+| Q5 | Override lifecycle | **Short-`to` expiry + create→order→best-effort-delete** this PR; durable self-healing reconciliation = follow-up (avoids a new entity + migration) |
+| Q6 | Source tax model | `taxTreatment` (gross/net) union now; **`tax?` optional deferred to a follow-up** (highest blast radius, marginal present value) |
+| Q7 | Enforcement/placement | Layered tests + PS int-spec lock (no OL module); `@openlinker/shared/money` (minor units, wired in `exports`); ADR-014 |
+
+### Tech-review adjustments (applied)
+
+- **No migration in this PR.** `OrderTotals` gains only `taxTreatment?` (jsonb-stored, optional). The durable saga-state reconciliation (which *would* need a new entity + migration) is deferred; override cleanup this PR is short-`to` expiry + best-effort delete.
+- **`tax?` optional deferred.** Ship `taxTreatment` + the PS fix (closes #895) now; `tax` stays a required `number`. The gross + genuinely-tax-exempt case (the only thing `tax?` unlocks) has no source today.
+- **`@openlinker/shared/money`** requires a `libs/shared/package.json` `exports` subpath entry (mirrors `logging`/`cache`) — explicit step, else `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+- **PS tax "based-on" config** (delivery vs invoice vs store address) must match rate resolution — the int-spec asserts against the real PS response, not the delivery-country assumption.
+- **Int-spec runs without the OL module** (`installOlModule: false`), isolating line pricing from shipping so it runs in CI.
+
+### Layer map
+
+| Layer | Change |
+|---|---|
+| **CORE — orders** | `OrderTotals.taxTreatment?`, `tax?` optional; `createOrder` invariant doc; propagation |
+| **CORE — shared** | `@openlinker/shared/money` largest-remainder allocation (minor units), pure |
+| **Integration — Allegro** | emit `taxTreatment: 'inclusive'`, omit `tax` |
+| **Integration — PrestaShop** | `specific_price` pin + delivery-country rate inversion + penny allocation + saga lifecycle; fix `total_paid_tax_excl` derivation |
+| **Docs** | ADR-014; architecture-overview Orders note |
+
+### Non-goals (deferred, with rationale)
+
+- **Per-line `subtotal`/`total`/`currency`/`taxAmount` on `OrderItem`** — Allegro reports
+  order-level gross with no per-line tax; speculative until WC #877 needs it.
+- **`Money` value object / minor-unit migration of the contract** — the float `number`
+  representation is the deeper latent issue; the allocation helper works in minor units internally,
+  but a full VO refactor is its own effort. Flagged as the correct end-state.
+- **WooCommerce / Shopify adapters** — out of scope; contract validated as neutral against #877 +
+  Shopify draft-order model.
+- **Editing the OL PrestaShop PHP module** — `specific_price` is native; no module change.
+- **Reconciling historical `Payment error` orders** — forward-fix only.
+
+---
+
+## 2. Design detail
+
+### 2.1 CORE — `OrderTotals` tax semantics (two orthogonal axes)
+
+`libs/core/src/orders/domain/types/order.types.ts` + `incoming-order.types.ts`:
+
+```ts
+export const PriceTaxTreatmentValues = ['inclusive', 'exclusive'] as const;
+export type PriceTaxTreatment = (typeof PriceTaxTreatmentValues)[number];
+
+export interface OrderTotals {
+  subtotal: number;
+  tax: number;
+  shipping: number;
+  total: number;
+  currency: string;
+  taxTreatment?: PriceTaxTreatment;  // absent = unknown; 'inclusive' = gross, 'exclusive' = net
+}
+```
+
+Mirror `taxTreatment?` on `IncomingOrderTotals`. Optional → backward-compatible, **no migration**
+(`order_records.totals` is `jsonb`).
+
+**Why:** `taxTreatment` (gross/net) is source-uniform and source-domain. Tax **rate** is
+deliberately absent — it's destination-catalog knowledge. **`tax?` optional is deferred** (see
+tech-review adjustments): `tax` stays a required `number` this PR; the only scenario it unlocks
+(gross + genuinely-tax-exempt source) has no source today, and the change has the largest consumer
+blast radius.
+
+### 2.2 CORE — `createOrder` invariant
+
+Doc-contract on `OrderProcessorManagerPort.createOrder`: MUST price lines at `items[].price`
+honouring `totals.taxTreatment`; MUST NOT substitute catalog price; MUST fail loudly if it cannot.
+**Not** a sub-capability (it's a universal behavioural constraint — see ADR-014).
+
+### 2.3 CORE — `@openlinker/shared/money` allocation helper
+
+New pure module `libs/shared/src/money/allocate-by-largest-remainder.ts`:
+
+```ts
+/** Distribute `totalMinor` across `weightsMinor` so the parts sum EXACTLY to
+ *  totalMinor, assigning rounding residual by largest fractional remainder. */
+export function allocateByLargestRemainder(totalMinor: number, weightsMinor: number[]): number[];
+```
+
+Operates on **integer minor units** (exact sums; no float drift). Pure, dependency-free, reusable
+by every destination adapter. Unit-tested on the sum-preservation property + deterministic residual
+placement. (Seed for a future `Money` VO.)
+
+**Exports wiring:** add a `./money` subpath to `libs/shared/package.json` `exports` (+ a barrel
+`libs/shared/src/money/index.ts`), mirroring `@openlinker/shared/logging` / `cache` — otherwise the
+import fails at Node runtime with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+
+**Multi-rate note:** with mixed per-line tax rates there is no single net total. The helper preserves
+each line's **gross** (`net_line = gross_line / (1 + rate_line)`, summing to the authoritative gross
+total because source lines already sum to it) and distributes only the **sub-cent rounding residual**
+across lines, independent of per-line rate.
+
+### 2.4 Integration — Allegro source
+
+`allegro-order-source.adapter.ts` totals (~line 274): set `taxTreatment: 'inclusive'`, **omit
+`tax`** (Allegro doesn't decompose). Buyer prices (`lineItem.price.amount`, `summary.totalToPay`)
+are gross.
+
+### 2.5 Integration — PrestaShop destination
+
+Sequence in `createOrder` becomes: resolve → `POST /carts` → **resolve delivery-country tax rate +
+compute net unit prices + penny-allocate + `POST /specific_prices` (cart-scoped) per line** →
+`POST /orders` → **delete overrides** → map identifiers.
+
+- **Rate resolution:** product → `id_tax_rules_group` → rate for the order's **delivery country**
+  (state where configured), read from PS, memoized per `(connection, group, country)`. Inversion
+  `net = gross / (1 + rate)`; PS re-grosses with the same rate → exact line total. Rate `0`/unknown
+  → `net = gross`.
+- **Penny allocation:** anchor on buyer-paid `totals.total`; allocate net line amounts (minor
+  units) via `allocateByLargestRemainder` so PS's re-grossed sum equals buyer-paid exactly;
+  irreducible sub-cent residual logged as tolerance.
+- **`specific_price` payload:** cart-scoped (`id_cart`), `from_quantity: 1`, `price` = net,
+  `reduction: 0`, `reduction_type: 'amount'`, `reduction_tax: 0`, broad-match `0` ids, `from` now,
+  **`to` = short near-future expiry** (fail-safe deactivation).
+- **Lifecycle (this PR):** create overrides before `POST /orders`; **best-effort delete** the
+  created ids after success (and on failure). Short-`to` expiry bounds the harm of any orphan from a
+  crash. *Durable coordinator-side reconciliation* (which needs a new persisted entity + migration)
+  is a tracked follow-up — out of scope here.
+- **PS tax "based-on" caveat:** rate resolution assumes PS taxes on the **delivery** address; PS can
+  be configured for invoice/store address. The int-spec asserts against the **actual** PS-computed
+  `order_detail` rather than trusting the assumption.
+- **Mapper fix:** `total_paid_tax_excl` derived as `subtotal / (1 + rate)` when
+  `taxTreatment: 'inclusive'`, not equated to the gross `subtotal`. Keep `order_rows.product_price`
+  with a comment that `specific_price` is the effective mechanism.
+- **WS client:** add `deleteResource(resource, id)` (none today).
+
+---
+
+## 3. Step-by-step
+
+### CORE
+1. `order.types.ts` / `incoming-order.types.ts` — `PriceTaxTreatment` union + `taxTreatment?`
+   (no `tax?` change). *AC:* type-check; documented; no migration.
+2. `order-sync.service.ts` / `order-ingestion.service.ts` — propagate `taxTreatment`.
+   *AC:* unit test asserts it reaches the `OrderCreate` handed to `createOrder`.
+3. `order-processor-manager.port.ts` — invariant doc.
+4. `libs/shared/src/money/` — `allocateByLargestRemainder` + barrel + `package.json` `exports`
+   subpath. *AC:* pure unit tests (sum-exact; residual determinism; n=1, zeros, negatives guarded);
+   import resolves at runtime.
+
+### Integration — Allegro
+6. `allegro-order-source.adapter.ts` — `taxTreatment: 'inclusive'`, omit `tax`. *AC:* adapter spec.
+
+### Integration — PrestaShop
+5. WS client interface+impl — `deleteResource`. *AC:* client spec (URL/verb).
+6. Delivery-country tax-rate resolver (memoized), extracted as a private helper/collaborator with a
+   file header. *AC:* unit: 23%→0.23, country-specific, unknown→0.
+7. `prestashop-order-processor-manager.adapter.ts` — specific_price pin (net + allocation) +
+   best-effort cleanup, behind extracted helpers to keep `createOrder` readable. *AC:* unit (mocked
+   WS): one `specific_prices` POST/line, correct net, `id_cart`, ordered before `orders`, delete
+   after.
+8. `prestashop-order.mapper.ts` — `total_paid_tax_excl` derivation; comment that `specific_price` is
+   authoritative (keep the no-op `order_rows.product_price`). *AC:* mapper spec.
+
+### Tests + Docs
+9. **Int-spec (regression lock)** — `installOlModule: false`, shipping isolated (standard carrier /
+   zero shipping): order with buyer price ≠ catalog price → assert PS-computed
+   `order_detail.product_price == buyer-paid` (within tolerance) AND status ≠ payment-error. Runs in
+   CI (no OL module).
+10. ADR-014 (done); architecture-overview Orders note referencing it. New files carry headers per
+    engineering-standards § File Headers.
+
+---
+
+## 4. Validation
+
+- **Architecture:** core neutral (no PS/WC leakage); PS specifics in the adapter; CORE→Integration
+  direction preserved; `shared/money` dependency-free.
+- **Standards:** `as const` union; types in `*.types.ts`; invariant on the port; Symbol tokens
+  unaffected; barrel exports for the new union + helper.
+- **Security:** no secrets; `specific_price` writes via the authenticated WS client.
+- **Testing:** unit on every branch + the vertical int-spec lock.
+
+---
+
+## 5. Open risks (tracked, not blocking)
+
+1. **PS rounding modes** (`PS_ROUND_TYPE`/precision) can still leave a logged sub-cent tolerance —
+   int-spec asserts within tolerance, not bit-exact.
+2. **Cross-border / OSS rates** — delivery-country resolution covers the common case; exotic
+   per-state configs may need follow-up.
+3. **Reconciliation sweep** — durable saga-state cleanup is the correct model; if the persistence
+   for sync-attempt override-state is heavier than wanted, the short-`to`-expiry fail-safe bounds
+   the harm and a follow-up can add the sweep. Call this out at review.
+4. **PR size** — core + shared + Allegro + PS + ADR is one cohesive bug-fix PR (the bug isn't fixed
+   without all parts). Split only if review prefers a core-contract-first PR.

--- a/docs/plans/implementation-plan-source-authoritative-order-pricing.md
+++ b/docs/plans/implementation-plan-source-authoritative-order-pricing.md
@@ -203,6 +203,13 @@ compute net unit prices + penny-allocate + `POST /specific_prices` (cart-scoped)
 
 ## 5. Open risks (tracked, not blocking)
 
+0. **Shipping reconciliation is out of scope (scope boundary).** This fix pins the
+   **line** price. `Payment error` also fires on shipping mismatch: for a **static**
+   (non-OL-Dynamic) carrier PS computes shipping from its own zone tables, which may
+   differ from `totals.shipping`. So `Payment error` is fully resolved only when
+   shipping also reconciles (the OL Dynamic carrier sidecar path, #516). Not a
+   regression — separate concern.
+
 1. **PS rounding modes** (`PS_ROUND_TYPE`/precision) can still leave a logged sub-cent tolerance —
    int-spec asserts within tolerance, not bit-exact.
 2. **Cross-border / OSS rates** — delivery-country resolution covers the common case; exotic

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -77,6 +77,7 @@ export class OrderSyncService implements IOrderSyncService {
         shipping: order.totals.shipping,
         total: order.totals.total,
         currency: order.totals.currency,
+        taxTreatment: order.totals.taxTreatment,
       },
       shippingAddress: order.shippingAddress,
       billingAddress: order.billingAddress,

--- a/libs/core/src/orders/domain/ports/order-processor-manager.port.ts
+++ b/libs/core/src/orders/domain/ports/order-processor-manager.port.ts
@@ -29,6 +29,15 @@ export interface OrderProcessorManagerPort {
    * OpenLinker IDs; the adapter must map these to external IDs before
    * submitting to the destination platform.
    *
+   * **Source-authoritative pricing invariant (#895, ADR-014):** implementations
+   * MUST create destination order lines priced at the supplied
+   * `order.items[].price` (the buyer-paid source price), honouring
+   * `order.totals.taxTreatment`. Implementations MUST NOT substitute the
+   * destination's own catalog price. An implementation that cannot pin the
+   * buyer-paid price MUST fail (throw) rather than silently fall back to the
+   * catalog. This is a base-contract invariant of every destination order
+   * processor, not an optional capability.
+   *
    * @param order - Order creation request with internal IDs
    * @returns Order reference (orderId and optional orderNumber)
    * @throws Error if order creation fails

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -10,7 +10,7 @@
  * @module libs/core/src/orders/domain/types
  */
 
-import type { OrderShipping, OrderPickupPoint } from './order.types';
+import type { OrderShipping, OrderPickupPoint, PriceTaxTreatment } from './order.types';
 
 export interface IncomingOrder {
   /**
@@ -138,6 +138,13 @@ export interface IncomingOrderTotals {
   shipping: number;
   total: number;
   currency: string;
+
+  /**
+   * How the source expresses tax on its amounts (gross vs net). See
+   * {@link OrderTotals.taxTreatment}. Optional — absent when the source does
+   * not assert it.
+   */
+  taxTreatment?: PriceTaxTreatment;
 }
 
 export interface IncomingOrderAddress {

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -159,12 +159,33 @@ export interface OrderItem {
   imageUrl?: string;
 }
 
+/**
+ * How monetary amounts express tax.
+ *
+ * `inclusive` (gross) — `OrderItem.price`, `subtotal`, and `total` INCLUDE tax;
+ * marketplaces (e.g. Allegro) report buyer-paid gross prices this way.
+ * `exclusive` (net) — those amounts EXCLUDE tax.
+ */
+export const PriceTaxTreatmentValues = ['inclusive', 'exclusive'] as const;
+export type PriceTaxTreatment = (typeof PriceTaxTreatmentValues)[number];
+
 export interface OrderTotals {
   subtotal: number;
   tax: number;
   shipping: number;
   total: number;
   currency: string;
+
+  /**
+   * Whether `subtotal` / `total` and the per-line `OrderItem.price` include tax
+   * (`inclusive`/gross) or exclude it (`exclusive`/net). Optional and
+   * source-uniform: absent means "not asserted by the source", and a
+   * destination falls back to its prior assumption. Destinations that price
+   * net (e.g. PrestaShop `specific_price`) use this to decide whether the
+   * buyer-paid amount must be converted to net before pinning — the tax *rate*
+   * itself stays destination-side, never on the order contract.
+   */
+  taxTreatment?: PriceTaxTreatment;
 }
 
 export interface Address {

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -48,6 +48,8 @@ export {
   Order,
   OrderItem,
   OrderTotals,
+  PriceTaxTreatment,
+  PriceTaxTreatmentValues,
   Address,
   OrderShipping,
   OrderPickupPoint,

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -299,6 +299,7 @@ describe('AllegroOrderSourceAdapter', () => {
         shipping: 0,
         total: 39.98,
         currency: 'PLN',
+        taxTreatment: 'inclusive',
       });
       expect(incoming.shippingAddress?.city).toBe('Warsaw');
     });
@@ -358,6 +359,7 @@ describe('AllegroOrderSourceAdapter', () => {
           shipping: 12.49,
           total: 22.49,
           currency: 'PLN',
+          taxTreatment: 'inclusive',
         });
       });
 
@@ -409,6 +411,7 @@ describe('AllegroOrderSourceAdapter', () => {
           shipping: 0,
           total: 10,
           currency: 'PLN',
+          taxTreatment: 'inclusive',
         });
       });
     });

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -277,6 +277,11 @@ export class AllegroOrderSourceAdapter
           shipping: roundCurrency(shipping),
           total: roundCurrency(total),
           currency: checkoutForm.summary.totalToPay.currency,
+          // Allegro reports buyer-paid GROSS prices (line `price.amount` and
+          // `summary.totalToPay` include tax); it does not decompose tax.
+          // Destinations that price net use this to convert before pinning
+          // (#895 / ADR-014).
+          taxTreatment: 'inclusive',
         },
         shippingAddress: this.resolveShippingAddress(checkoutForm),
         billingAddress: undefined,

--- a/libs/integrations/prestashop/src/__tests__/mocks/mock-http-client.factory.ts
+++ b/libs/integrations/prestashop/src/__tests__/mocks/mock-http-client.factory.ts
@@ -16,6 +16,7 @@ export function createMockHttpClient(
     listResources: jest.fn(),
     createResource: jest.fn(),
     updateResource: jest.fn(),
+    deleteResource: jest.fn(),
     ...overrides,
   } as jest.Mocked<IPrestashopWebserviceClient>;
 }

--- a/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
+++ b/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
@@ -33,6 +33,7 @@ import type { PrestashopCustomerProvisioner } from '../infrastructure/provisione
 import { PrestashopAddressProvisioner } from '../infrastructure/provisioners/prestashop-address-provisioner';
 import { PrestashopCountryResolver } from '../infrastructure/provisioners/prestashop-country-resolver';
 import { PrestashopCurrencyResolver } from '../infrastructure/provisioners/prestashop-currency-resolver';
+import { PrestashopTaxRateResolver } from '../infrastructure/provisioners/prestashop-tax-rate.resolver';
 import type { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
 import { Logger } from '@openlinker/shared/logging';
 
@@ -119,6 +120,7 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
       // Create provisioners (if not provided, create new instances)
       const countryResolver = new PrestashopCountryResolver();
       const currencyResolver = new PrestashopCurrencyResolver();
+      const taxRateResolver = new PrestashopTaxRateResolver(countryResolver);
       const addressProvisioner =
         this.addressProvisioner || new PrestashopAddressProvisioner(null, countryResolver);
 
@@ -144,6 +146,7 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
         currencyResolver,
         this.customerProjectionRepository,
         openlinkerModuleClient,
+        taxRateResolver,
         this.mappingConfigService
       );
     } else {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
@@ -520,6 +520,10 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         if (resource === 'carts') {
           return Promise.resolve(createdCart);
         }
+        if (resource === 'specific_prices') {
+          // Pins succeed; this test exercises the order-POST failure path.
+          return Promise.resolve({ id: 'sp_test' });
+        }
         if (resource === 'orders') {
           return Promise.reject(apiError);
         }
@@ -873,6 +877,39 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         // Net source → no rate lookup, price pinned verbatim.
         expect(mockTaxRateResolver.resolveProductTaxRate).not.toHaveBeenCalled();
         expect(specificPriceFor('100')?.price).toBe((29.99).toFixed(6));
+      });
+
+      it('fails loudly (does not create the order) when a line price cannot be pinned', async () => {
+        arrange();
+        // PS rejects the specific_price write → must abort before POST /orders
+        // rather than silently create a catalog-priced order (ADR-014 invariant).
+        mockHttpClient.createResource = jest.fn().mockImplementation((resource: string) => {
+          if (resource === 'specific_prices') {
+            return Promise.reject(new Error('PS rejected specific_price'));
+          }
+          if (resource === 'orders') {
+            return Promise.resolve({ id: '999', reference: 'TEST-ORDER-001' } as PrestashopOrder);
+          }
+          return Promise.resolve({ id: '123' });
+        });
+
+        await expect(
+          adapter.createOrder(
+            createTestOrder({
+              totals: {
+                subtotal: 109.97,
+                tax: 0,
+                shipping: 5.0,
+                total: 114.97,
+                currency: 'EUR',
+                taxTreatment: 'inclusive',
+              },
+            })
+          )
+        ).rejects.toThrow(/pin source-authoritative price/);
+
+        // The order POST must NOT have happened.
+        expect(createCalls().map((c) => c[0])).not.toContain('orders');
       });
     });
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
@@ -27,6 +27,7 @@ import { DuplicateIdentifierMappingError } from '@openlinker/core/identifier-map
 import type { OrderCreate } from '@openlinker/core/orders';
 import type { IMappingConfigService } from '@openlinker/core/mappings';
 import type { PrestashopCurrencyResolver } from '../../provisioners/prestashop-currency-resolver';
+import type { PrestashopTaxRateResolver } from '../../provisioners/prestashop-tax-rate.resolver';
 import type { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
 import type { PrestashopCustomerProvisioner } from '../../provisioners/prestashop-customer-provisioner';
 import type { PrestashopAddressProvisioner } from '../../provisioners/prestashop-address-provisioner';
@@ -46,6 +47,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
   let mockIdentifierMapping: jest.Mocked<IdentifierMappingPort>;
   let mockOrderMapper: jest.Mocked<IPrestashopOrderMapper>;
   let mockCurrencyResolver: jest.Mocked<PrestashopCurrencyResolver>;
+  let mockTaxRateResolver: PrestashopTaxRateResolver;
   let mockCustomerProjectionRepository: jest.Mocked<CustomerProjectionRepositoryPort>;
   let mockCustomerProvisioner: jest.Mocked<PrestashopCustomerProvisioner>;
   let mockAddressProvisioner: jest.Mocked<PrestashopAddressProvisioner>;
@@ -110,6 +112,11 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       clearCache: jest.fn(),
     } as unknown as jest.Mocked<PrestashopCurrencyResolver>;
 
+    mockTaxRateResolver = {
+      // Default: untaxed (net == gross) so existing assertions are unaffected.
+      resolveProductTaxRate: jest.fn().mockResolvedValue(0),
+    } as unknown as PrestashopTaxRateResolver;
+
     mockCustomerProjectionRepository = {
       findById: jest.fn(),
       findByEmailHash: jest.fn(),
@@ -153,9 +160,28 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       mockAddressProvisioner,
       mockCurrencyResolver,
       mockCustomerProjectionRepository,
-      mockOpenLinkerModuleClient
+      mockOpenLinkerModuleClient,
+      mockTaxRateResolver
     );
   });
+
+  /**
+   * Dispatch `createResource` by resource name so the order-creation flow's
+   * intermediate `specific_prices` pins (#895) don't consume the cart/order
+   * slots the way sequential `mockResolvedValueOnce` did.
+   */
+  function setCreateResourceDispatch(cart: unknown, order: unknown): void {
+    mockHttpClient.createResource = jest.fn().mockImplementation((resource: string) => {
+      if (resource === 'orders') {
+        return Promise.resolve(order);
+      }
+      if (resource === 'specific_prices') {
+        return Promise.resolve({ id: 'sp_test' });
+      }
+      // 'carts' (and any other resource hit during create) → cart payload.
+      return Promise.resolve(cart);
+    });
+  }
 
   describe('createOrder', () => {
     it('should create order successfully with all IDs resolved', async () => {
@@ -227,10 +253,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         id: '999',
         reference: order.orderNumber,
       };
-      mockHttpClient.createResource = jest
-        .fn()
-        .mockResolvedValueOnce(createdCart) // First call: cart creation
-        .mockResolvedValueOnce(createdOrder); // Second call: order creation
+      setCreateResourceDispatch(createdCart, createdOrder);
 
       // Mock identifier mapping creation
       mockIdentifierMapping.createMapping = jest.fn().mockResolvedValue(undefined);
@@ -732,14 +755,13 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
 
       const createdCart = { id: '123' };
       const createdOrder: PrestashopOrder = { id: externalPsOrderId, reference: order.orderNumber };
-      mockHttpClient.createResource = jest
-        .fn()
-        .mockResolvedValueOnce(createdCart)
-        .mockResolvedValueOnce(createdOrder);
+      setCreateResourceDispatch(createdCart, createdOrder);
       mockIdentifierMapping.createMapping = jest.fn().mockResolvedValue(undefined);
 
       await adapter.createOrder(order);
-      expect(mockHttpClient.createResource).toHaveBeenCalledTimes(2); // cart + order
+      // PS create happened on the first call (cart + specific_price pins + order).
+      expect(mockHttpClient.createResource).toHaveBeenCalledWith('carts', expect.anything());
+      expect(mockHttpClient.createResource).toHaveBeenCalledWith('orders', expect.anything());
 
       // Second call: Step 0 finds the mapping → early-return.
       mockIdentifierMapping.getExternalIds = jest.fn().mockImplementation(resolveExternalIds);
@@ -751,6 +773,106 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       expect(result).toEqual({
         orderId: METADATA_INTERNAL_ORDER_ID,
         orderNumber: expect.any(String),
+      });
+    });
+
+    describe('source-authoritative line pricing (#895)', () => {
+      type CreateCall = [string, Record<string, unknown>];
+      const createCalls = (): CreateCall[] =>
+        (mockHttpClient.createResource as jest.Mock).mock.calls as CreateCall[];
+      const specificPriceFor = (productId: string): Record<string, unknown> | undefined =>
+        createCalls()
+          .filter((c) => c[0] === 'specific_prices')
+          .find((c) => c[1].id_product === productId)?.[1];
+
+      const resolveIds = (
+        entityType: string,
+        internalId: string
+      ): Promise<Array<{ connectionId: string; externalId: string; entityType: string }>> => {
+        const map: Record<string, Record<string, string>> = {
+          Customer: { 'internal-customer-123': '42' },
+          Product: { 'internal-product-456': '100', 'internal-product-789': '200' },
+          ProductVariant: { 'internal-variant-789': '300' },
+        };
+        const externalId = map[entityType]?.[internalId];
+        return Promise.resolve(
+          externalId ? [{ connectionId: connection.id, externalId, entityType }] : []
+        );
+      };
+
+      const arrange = (): void => {
+        mockIdentifierMapping.getExternalIds = jest
+          .fn()
+          .mockImplementation((entityType: string, internalId: string) =>
+            entityType === 'Order' ? Promise.resolve([]) : resolveIds(entityType, internalId)
+          );
+        mockOrderMapper.mapOrderCreate.mockReturnValue({
+          id_customer: '42',
+          current_state: 1,
+          associations: { order_rows: { order_row: [] } },
+        });
+        setCreateResourceDispatch(
+          { id: '123' },
+          { id: '999', reference: 'TEST-ORDER-001' } as PrestashopOrder
+        );
+        mockIdentifierMapping.createMapping = jest.fn().mockResolvedValue(undefined);
+      };
+
+      it('pins each line net via cart-scoped specific_prices before POST /orders, then cleans up', async () => {
+        arrange();
+        (mockTaxRateResolver.resolveProductTaxRate as jest.Mock).mockResolvedValue(0.23);
+
+        await adapter.createOrder(
+          createTestOrder({
+            totals: {
+              subtotal: 109.97,
+              tax: 0,
+              shipping: 5.0,
+              total: 114.97,
+              currency: 'EUR',
+              taxTreatment: 'inclusive',
+            },
+          })
+        );
+
+        const calls = createCalls();
+        expect(calls.filter((c) => c[0] === 'specific_prices')).toHaveLength(2);
+
+        // Line 1: gross 29.99 → net 29.99 / 1.23.
+        const line1 = specificPriceFor('100');
+        expect(line1?.price).toBe((29.99 / 1.23).toFixed(6));
+        expect(line1?.id_cart).toBe('123');
+        expect(line1?.id_customer).toBe('42');
+        expect(line1?.from_quantity).toBe(1);
+
+        // specific_prices must be written BEFORE the order POST.
+        const firstOrderIdx = calls.findIndex((c) => c[0] === 'orders');
+        const lastSpecificIdx = calls.map((c) => c[0]).lastIndexOf('specific_prices');
+        expect(lastSpecificIdx).toBeLessThan(firstOrderIdx);
+
+        // Pins are cleaned up after the order is created.
+        expect(mockHttpClient.deleteResource).toHaveBeenCalledWith('specific_prices', 'sp_test');
+      });
+
+      it('pins the price as-is (no tax conversion) when the source reports net prices', async () => {
+        arrange();
+
+        await adapter.createOrder(
+          createTestOrder({
+            totals: {
+              subtotal: 109.97,
+              tax: 0,
+              shipping: 5.0,
+              total: 114.97,
+              currency: 'EUR',
+              taxTreatment: 'exclusive',
+            },
+          })
+        );
+
+        // Net source → no rate lookup, price pinned verbatim.
+        expect(mockTaxRateResolver.resolveProductTaxRate).not.toHaveBeenCalled();
+        expect(specificPriceFor('100')?.price).toBe((29.99).toFixed(6));
       });
     });
 
@@ -809,10 +931,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
 
       const createdCart = { id: '123' };
       const createdOrder: PrestashopOrder = { id: '999', reference: order.orderNumber };
-      mockHttpClient.createResource = jest
-        .fn()
-        .mockResolvedValueOnce(createdCart)
-        .mockResolvedValueOnce(createdOrder);
+      setCreateResourceDispatch(createdCart, createdOrder);
 
       // Simulate concurrent-insert race: createMapping throws DuplicateIdentifierMappingError
       mockIdentifierMapping.createMapping = jest
@@ -902,10 +1021,10 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         associations: { order_rows: { order_row: [] } },
       });
 
-      mockHttpClient.createResource = jest
-        .fn()
-        .mockResolvedValueOnce({ id: '123' })
-        .mockResolvedValueOnce({ id: '999', reference: 'TEST-ORDER-001' } as PrestashopOrder);
+      setCreateResourceDispatch({ id: '123' }, {
+        id: '999',
+        reference: 'TEST-ORDER-001',
+      } as PrestashopOrder);
 
       mockIdentifierMapping.createMapping = jest.fn().mockResolvedValue(undefined);
     };
@@ -924,6 +1043,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
         mockOpenLinkerModuleClient,
+        mockTaxRateResolver,
         mockMappingConfig
       );
 
@@ -976,6 +1096,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
         mockOpenLinkerModuleClient,
+        mockTaxRateResolver,
         mockMappingConfig
       );
 
@@ -1017,6 +1138,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
         mockOpenLinkerModuleClient,
+        mockTaxRateResolver,
         mockMappingConfig
       );
 
@@ -1061,6 +1183,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
         mockOpenLinkerModuleClient,
+        mockTaxRateResolver,
         mockMappingConfig
       );
 
@@ -1124,10 +1247,10 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         associations: { order_rows: { order_row: [] } },
       });
 
-      mockHttpClient.createResource = jest
-        .fn()
-        .mockResolvedValueOnce({ id: '123' }) // cart
-        .mockResolvedValueOnce({ id: '999', reference: 'TEST-ORDER-001' } as PrestashopOrder);
+      setCreateResourceDispatch({ id: '123' }, {
+        id: '999',
+        reference: 'TEST-ORDER-001',
+      } as PrestashopOrder);
 
       mockIdentifierMapping.createMapping = jest.fn().mockResolvedValue(undefined);
     };
@@ -1148,6 +1271,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
         mockOpenLinkerModuleClient,
+        mockTaxRateResolver,
         mockMappingConfig
       );
 
@@ -1179,6 +1303,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
         mockOpenLinkerModuleClient,
+        mockTaxRateResolver,
         mockMappingConfig
       );
 
@@ -1205,6 +1330,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
         mockOpenLinkerModuleClient,
+        mockTaxRateResolver,
         mockMappingConfig
       );
 
@@ -1379,10 +1505,10 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         current_state: 1,
         associations: { order_rows: { order_row: [] } },
       });
-      mockHttpClient.createResource = jest
-        .fn()
-        .mockResolvedValueOnce({ id: '123' })
-        .mockResolvedValueOnce({ id: '999', reference: 'TEST-ORDER-001' } as PrestashopOrder);
+      setCreateResourceDispatch({ id: '123' }, {
+        id: '999',
+        reference: 'TEST-ORDER-001',
+      } as PrestashopOrder);
       mockIdentifierMapping.createMapping = jest.fn().mockResolvedValue(undefined);
 
       await adapter.createOrder(order);
@@ -1545,7 +1671,8 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
           mockAddressProvisioner,
           mockCurrencyResolver,
           mockCustomerProjectionRepository,
-          mockOpenLinkerModuleClient
+          mockOpenLinkerModuleClient,
+          mockTaxRateResolver
         );
       }
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -53,6 +53,8 @@ import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
 import type { PrestashopCustomerProvisioner } from '../provisioners/prestashop-customer-provisioner';
 import type { PrestashopAddressProvisioner } from '../provisioners/prestashop-address-provisioner';
 import type { PrestashopCurrencyResolver } from '../provisioners/prestashop-currency-resolver';
+import type { PrestashopTaxRateResolver } from '../provisioners/prestashop-tax-rate.resolver';
+import { allocateByLargestRemainder } from '@openlinker/shared/money';
 import type { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
 import type { PrestashopConnectionConfig } from '../../domain/types/prestashop-config.types';
 import { PrestashopOlCarrierMissingException } from '../../domain/exceptions/prestashop-ol-module.exception';
@@ -68,6 +70,14 @@ interface PrestashopCarrierRow {
   active?: string | number;
   deleted?: string | number;
 }
+
+/**
+ * Active-window length for a pinned `specific_prices` row's `to` field — a
+ * crash fail-safe so an un-deleted pin self-expires rather than lingering. A
+ * full day is generous against shop-timezone skew (the order is created seconds
+ * after the pin) while still bounding any orphan's active life (#895).
+ */
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
  * PrestaShop Order Processor Manager Adapter
@@ -114,6 +124,9 @@ export class PrestashopOrderProcessorManagerAdapter
     private readonly customerProjectionRepository: CustomerProjectionRepositoryPort,
     // OL PrestaShop module client for HMAC-signed sidecar writes (#516).
     private readonly openlinkerModuleClient: IPrestashopOpenLinkerModuleClient,
+    // Resolves the destination product's tax rate so buyer-paid gross line
+    // prices can be pinned net via `specific_prices` (#895 / ADR-014).
+    private readonly taxRateResolver: PrestashopTaxRateResolver,
     private readonly mappingConfigService?: IMappingConfigService
   ) {}
 
@@ -124,6 +137,13 @@ export class PrestashopOrderProcessorManagerAdapter
     );
 
     this.logger.debug(`order: ${JSON.stringify(order)}`);
+
+    // Cart-scoped `specific_prices` rows created to pin line prices (#895).
+    // Declared outside the try so the success path and the catch can both
+    // best-effort clean them up. They're transient (the price is materialised
+    // into `order_detail` at POST /orders); cart-scoped so they never affect
+    // another cart, and carry a short `to`-expiry as a crash fail-safe.
+    const pinnedPriceIds: Array<string | number> = [];
 
     try {
       // Step 0: Check if order already exists (idempotency check)
@@ -409,6 +429,23 @@ export class PrestashopOrderProcessorManagerAdapter
         );
       }
 
+      // Step 6.6: Pin line prices to the buyer-paid (source-authoritative)
+      // amount via cart-scoped `specific_prices` BEFORE POST /orders (#895 /
+      // ADR-014). PS prices the order's `order_detail` from the cart; without
+      // this it would use the catalog price and land the order in
+      // `Payment error`. Best-effort failures are swallowed inside the helper —
+      // a missing pin must not abort an otherwise-valid order (the int-spec is
+      // the correctness lock).
+      const created = await this.pinLinePrices(
+        order,
+        externalCartId,
+        externalCustomerId,
+        externalCurrencyId,
+        externalProductIds,
+        externalVariantIds
+      );
+      pinnedPriceIds.push(...created);
+
       // Step 7: Map OrderCreate to PrestaShop format (including cart ID, currency ID, language ID, carrier ID)
       const prestashopOrderData = this.orderMapper.mapOrderCreate(
         order,
@@ -588,12 +625,19 @@ export class PrestashopOrderProcessorManagerAdapter
       // its sidecar row at Step 6.5; static carriers price from PS's own
       // zone tables.
 
+      // The line prices are now materialised into `order_detail`; the pin rows
+      // have served their purpose. Best-effort cleanup (never throws).
+      await this.cleanupPinnedPrices(pinnedPriceIds);
+
       // Step 7: Return order reference
       return {
         orderId: internalOrderId,
         orderNumber: createdOrder.reference || order.orderNumber || externalOrderId,
       };
     } catch (error) {
+      // Best-effort cleanup on the failure path too — the short `to`-expiry
+      // bounds the harm of any pin row we can't delete here.
+      await this.cleanupPinnedPrices(pinnedPriceIds);
       if (
         error instanceof PrestashopResourceNotFoundException ||
         error instanceof PrestashopApiException ||
@@ -610,6 +654,141 @@ export class PrestashopOrderProcessorManagerAdapter
         undefined
       );
     }
+  }
+
+  /**
+   * Pin each order line to its buyer-paid (source-authoritative) price via a
+   * cart-scoped `specific_prices` row, so PrestaShop values the order's
+   * `order_detail` at the marketplace price instead of the catalog price
+   * (#895 / ADR-014).
+   *
+   * `specific_prices.price` is tax-EXCLUDED. When the source reports GROSS
+   * prices (`taxTreatment` `inclusive`, or unset — the marketplace default) the
+   * gross is converted to net using the destination product's own tax rate, so
+   * PS re-grosses it back to the buyer-paid amount. When the source reports NET
+   * (`exclusive`) the price is pinned as-is. The buyer-paid product subtotal is
+   * apportioned across lines with a largest-remainder allocation so the pinned
+   * lines sum exactly to the authoritative total under rounding.
+   *
+   * Returns the created `specific_prices` ids for cleanup. Best-effort: a
+   * failure to pin a line is logged and skipped rather than aborting the order.
+   */
+  private async pinLinePrices(
+    order: OrderCreate,
+    externalCartId: string | number,
+    externalCustomerId: string | number,
+    externalCurrencyId: number | undefined,
+    externalProductIds: Map<string, string | number>,
+    externalVariantIds: Map<string, string | number>
+  ): Promise<Array<string | number>> {
+    const createdIds: Array<string | number> = [];
+    if (order.items.length === 0) {
+      return createdIds;
+    }
+
+    // `exclusive` → already net; everything else (`inclusive`/unset) → gross,
+    // convert to net. Marketplace orders are gross, so unset defaults to gross.
+    const convertGrossToNet = order.totals.taxTreatment !== 'exclusive';
+    const deliveryCountryIso = order.shippingAddress?.country;
+    const toExpiry = this.formatPsDateTime(new Date(Date.now() + ONE_DAY_MS));
+
+    // Apportion the gross product subtotal across lines (minor units) so the
+    // pinned lines sum exactly to the authoritative total.
+    const subtotalMinor = Math.round(order.totals.subtotal * 100);
+    const weightsMinor = order.items.map((item) => Math.round(item.price * item.quantity * 100));
+    const lineGrossMinor = allocateByLargestRemainder(subtotalMinor, weightsMinor);
+
+    for (let index = 0; index < order.items.length; index++) {
+      const item = order.items[index];
+      if (item.quantity <= 0) {
+        continue;
+      }
+      const externalProductId = externalProductIds.get(item.productId);
+      if (externalProductId === undefined) {
+        continue; // resolution already guaranteed this in Step 2
+      }
+      const externalVariantId = item.variantId
+        ? (externalVariantIds.get(item.variantId) ?? 0)
+        : 0;
+
+      const grossUnit = lineGrossMinor[index] / 100 / item.quantity;
+      let rate = 0;
+      if (convertGrossToNet) {
+        rate = await this.taxRateResolver.resolveProductTaxRate(
+          externalProductId,
+          deliveryCountryIso,
+          this.connection.id,
+          this.httpClient
+        );
+      }
+      const netUnit = grossUnit / (1 + rate);
+
+      try {
+        const createdPrice = await this.httpClient.createResource<{ id: string | number }>(
+          'specific_prices',
+          {
+            id_product: externalProductId,
+            id_product_attribute: externalVariantId,
+            id_shop: 0,
+            id_shop_group: 0,
+            id_cart: externalCartId,
+            id_currency: externalCurrencyId ?? 0,
+            id_country: 0,
+            id_group: 0,
+            id_customer: externalCustomerId,
+            from_quantity: 1,
+            price: netUnit.toFixed(6),
+            reduction: '0',
+            reduction_type: 'amount',
+            reduction_tax: '0',
+            from: '0000-00-00 00:00:00',
+            to: toExpiry,
+          }
+        );
+        if (createdPrice?.id !== undefined) {
+          createdIds.push(createdPrice.id);
+        }
+        this.logger.debug(
+          `Pinned line price: product=${externalProductId} variant=${externalVariantId} ` +
+            `grossUnit=${grossUnit.toFixed(4)} rate=${rate} netUnit=${netUnit.toFixed(6)}`
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to pin specific_price for product ${externalProductId}: ` +
+            `${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+
+    return createdIds;
+  }
+
+  /**
+   * Best-effort deletion of the cart-scoped `specific_prices` rows created by
+   * {@link pinLinePrices}. Never throws — the rows are cart-scoped (harmless to
+   * other carts) and carry a short `to`-expiry, so a failed delete degrades to
+   * a short-lived orphan, not a correctness problem.
+   */
+  private async cleanupPinnedPrices(ids: Array<string | number>): Promise<void> {
+    for (const id of ids) {
+      try {
+        await this.httpClient.deleteResource('specific_prices', id);
+      } catch (error) {
+        this.logger.warn(
+          `Failed to delete pinned specific_price ${id} (will self-expire): ` +
+            `${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  }
+
+  /** Format a `Date` as PrestaShop's `YYYY-MM-DD HH:MM:SS` (UTC). */
+  private formatPsDateTime(date: Date): string {
+    const pad = (n: number): string => String(n).padStart(2, '0');
+    return (
+      `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ` +
+      `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`
+    );
   }
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -433,18 +433,19 @@ export class PrestashopOrderProcessorManagerAdapter
       // amount via cart-scoped `specific_prices` BEFORE POST /orders (#895 /
       // ADR-014). PS prices the order's `order_detail` from the cart; without
       // this it would use the catalog price and land the order in
-      // `Payment error`. Best-effort failures are swallowed inside the helper —
-      // a missing pin must not abort an otherwise-valid order (the int-spec is
-      // the correctness lock).
-      const created = await this.pinLinePrices(
+      // `Payment error`. Per the createOrder invariant, a line we cannot pin
+      // MUST fail (throw) rather than silently mis-price — `pinLinePrices`
+      // records created ids into `pinnedPriceIds` as it goes, so the outer
+      // catch cleans up any partial pins before the error propagates.
+      await this.pinLinePrices(
         order,
         externalCartId,
         externalCustomerId,
         externalCurrencyId,
         externalProductIds,
-        externalVariantIds
+        externalVariantIds,
+        pinnedPriceIds
       );
-      pinnedPriceIds.push(...created);
 
       // Step 7: Map OrderCreate to PrestaShop format (including cart ID, currency ID, language ID, carrier ID)
       const prestashopOrderData = this.orderMapper.mapOrderCreate(
@@ -670,8 +671,10 @@ export class PrestashopOrderProcessorManagerAdapter
    * apportioned across lines with a largest-remainder allocation so the pinned
    * lines sum exactly to the authoritative total under rounding.
    *
-   * Returns the created `specific_prices` ids for cleanup. Best-effort: a
-   * failure to pin a line is logged and skipped rather than aborting the order.
+   * Records created `specific_prices` ids into `createdIds` (for caller-side
+   * cleanup). Per the createOrder invariant (ADR-014), a line that cannot be
+   * pinned throws — a silently-unpinned line would be priced from the catalog
+   * and land the order in `Payment error`, which is the bug this fixes.
    */
   private async pinLinePrices(
     order: OrderCreate,
@@ -679,21 +682,27 @@ export class PrestashopOrderProcessorManagerAdapter
     externalCustomerId: string | number,
     externalCurrencyId: number | undefined,
     externalProductIds: Map<string, string | number>,
-    externalVariantIds: Map<string, string | number>
-  ): Promise<Array<string | number>> {
-    const createdIds: Array<string | number> = [];
+    externalVariantIds: Map<string, string | number>,
+    createdIds: Array<string | number>
+  ): Promise<void> {
     if (order.items.length === 0) {
-      return createdIds;
+      return;
     }
 
     // `exclusive` → already net; everything else (`inclusive`/unset) → gross,
     // convert to net. Marketplace orders are gross, so unset defaults to gross.
+    // A future NET source that omits `taxTreatment` would be mis-converted —
+    // tracked as the deferred `tax?`/treatment hardening in ADR-014.
     const convertGrossToNet = order.totals.taxTreatment !== 'exclusive';
     const deliveryCountryIso = order.shippingAddress?.country;
     const toExpiry = this.formatPsDateTime(new Date(Date.now() + ONE_DAY_MS));
 
     // Apportion the gross product subtotal across lines (minor units) so the
-    // pinned lines sum exactly to the authoritative total.
+    // pinned lines sum exactly to the authoritative total. NOTE: the pinned
+    // price is per-UNIT, so for a multi-quantity line a 1-cent line residual
+    // becomes sub-cent per unit and PS may round it away when it re-grosses
+    // unit × qty — the order total can still differ by a per-line rounding cent
+    // (asserted within tolerance by the int-spec, not bit-exact).
     const subtotalMinor = Math.round(order.totals.subtotal * 100);
     const weightsMinor = order.items.map((item) => Math.round(item.price * item.quantity * 100));
     const lineGrossMinor = allocateByLargestRemainder(subtotalMinor, weightsMinor);
@@ -753,14 +762,17 @@ export class PrestashopOrderProcessorManagerAdapter
             `grossUnit=${grossUnit.toFixed(4)} rate=${rate} netUnit=${netUnit.toFixed(6)}`
         );
       } catch (error) {
-        this.logger.warn(
-          `Failed to pin specific_price for product ${externalProductId}: ` +
-            `${error instanceof Error ? error.message : String(error)}`
+        // Fail loudly (createOrder invariant, ADR-014): do NOT let the order be
+        // created at the catalog price. Throw so the idempotency-guarded retry
+        // re-attempts; the caller's catch cleans up any pins created so far.
+        throw new PrestashopApiException(
+          `Failed to pin source-authoritative price for product ${externalProductId}: ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+          undefined,
+          undefined
         );
       }
     }
-
-    return createdIds;
   }
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.interface.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.interface.ts
@@ -112,6 +112,21 @@ export interface IPrestashopWebserviceClient {
     data: Record<string, unknown>,
     options?: PrestashopWriteOptions,
   ): Promise<T>;
+
+  /**
+   * Delete a resource by ID (DELETE).
+   *
+   * Used for transient resources OpenLinker creates as a means to an end and
+   * cleans up afterwards (e.g. cart-scoped `specific_prices` used to pin a
+   * marketplace order's line price — #895 / ADR-014).
+   *
+   * @param resource - Resource name (e.g., 'specific_prices')
+   * @param id - Resource ID to delete
+   * @throws PrestashopResourceNotFoundException if resource not found
+   * @throws PrestashopAuthenticationException if authentication fails
+   * @throws PrestashopApiException for other API errors
+   */
+  deleteResource(resource: string, id: string | number): Promise<void>;
 }
 
 

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts
@@ -213,6 +213,13 @@ export class PrestashopWebserviceClient implements IPrestashopWebserviceClient {
     return this.writeResource<T>(resource, id, data, options);
   }
 
+  async deleteResource(resource: string, id: string | number): Promise<void> {
+    const path = PrestashopQueryBuilder.buildResourcePath(resource, id);
+    const url = `${this.baseUrl}${path}`;
+    this.logger.debug(`Deleting resource: ${resource}/${id}`);
+    await this.requestWithRetry(url, { method: 'DELETE' });
+  }
+
   /**
    * Shared POST/PUT writer.
    *

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -215,6 +215,11 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
         product_id: externalProductId,
         product_attribute_id: externalVariantId,
         product_quantity: item.quantity,
+        // NOTE: PrestaShop derives `order_detail` line prices from the cart
+        // (the order is created with `id_cart`), so this `product_price` is NOT
+        // authoritative — the cart-scoped `specific_prices` the order processor
+        // writes before POST /orders pin the buyer-paid price (#895 / ADR-014).
+        // Kept for parity with the PS order body shape.
         product_price: item.price.toFixed(6), // PrestaShop expects string with 6 decimals
         product_reference: item.sku || '',
       };

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-tax-rate.resolver.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-tax-rate.resolver.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the PrestaShop tax-rate resolver (#895 / ADR-014).
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/provisioners
+ */
+import { PrestashopTaxRateResolver } from '../prestashop-tax-rate.resolver';
+import type { PrestashopCountryResolver } from '../prestashop-country-resolver';
+import { createMockHttpClient } from '../../../__tests__/mocks/mock-http-client.factory';
+
+describe('PrestashopTaxRateResolver', () => {
+  let httpClient: ReturnType<typeof createMockHttpClient>;
+  let countryResolver: jest.Mocked<PrestashopCountryResolver>;
+  let resolver: PrestashopTaxRateResolver;
+
+  beforeEach(() => {
+    httpClient = createMockHttpClient();
+    countryResolver = {
+      resolveCountryId: jest.fn(),
+    } as unknown as jest.Mocked<PrestashopCountryResolver>;
+    resolver = new PrestashopTaxRateResolver(countryResolver);
+  });
+
+  it('should return 0 when the product has no tax-rule group', async () => {
+    httpClient.getResource.mockResolvedValueOnce({ id_tax_rules_group: '0' });
+
+    const rate = await resolver.resolveProductTaxRate('100', undefined, 'conn-1', httpClient);
+
+    expect(rate).toBe(0);
+    expect(httpClient.listResources).not.toHaveBeenCalled();
+  });
+
+  it('should resolve the delivery-country rule and return its rate as a fraction', async () => {
+    httpClient.getResource
+      .mockResolvedValueOnce({ id_tax_rules_group: '2' }) // products/100
+      .mockResolvedValueOnce({ rate: '23.000' }); // taxes/7
+    countryResolver.resolveCountryId.mockResolvedValueOnce(6); // PL → id 6
+    httpClient.listResources.mockResolvedValueOnce([
+      { id_tax: '9', id_country: '0', id_state: '0' }, // catch-all
+      { id_tax: '7', id_country: '6', id_state: '0' }, // PL
+    ]);
+
+    const rate = await resolver.resolveProductTaxRate('100', 'PL', 'conn-1', httpClient);
+
+    expect(rate).toBeCloseTo(0.23, 5);
+    expect(httpClient.getResource).toHaveBeenCalledWith('taxes', '7');
+  });
+
+  it('should fall back to the catch-all rule when the delivery country does not resolve', async () => {
+    httpClient.getResource
+      .mockResolvedValueOnce({ id_tax_rules_group: '2' })
+      .mockResolvedValueOnce({ rate: '5.000' });
+    countryResolver.resolveCountryId.mockRejectedValueOnce(new Error('country not found'));
+    httpClient.listResources.mockResolvedValueOnce([
+      { id_tax: '9', id_country: '0', id_state: '0' },
+      { id_tax: '7', id_country: '6', id_state: '0' },
+    ]);
+
+    const rate = await resolver.resolveProductTaxRate('100', 'ZZ', 'conn-1', httpClient);
+
+    expect(rate).toBeCloseTo(0.05, 5);
+    expect(httpClient.getResource).toHaveBeenCalledWith('taxes', '9');
+  });
+
+  it('should return 0 when the product read fails', async () => {
+    httpClient.getResource.mockRejectedValueOnce(new Error('boom'));
+
+    const rate = await resolver.resolveProductTaxRate('100', 'PL', 'conn-1', httpClient);
+
+    expect(rate).toBe(0);
+  });
+
+  it('should return 0 when the tax-rule group has no usable rules', async () => {
+    httpClient.getResource.mockResolvedValueOnce({ id_tax_rules_group: '2' });
+    countryResolver.resolveCountryId.mockResolvedValueOnce(6);
+    httpClient.listResources.mockResolvedValueOnce([]);
+
+    const rate = await resolver.resolveProductTaxRate('100', 'PL', 'conn-1', httpClient);
+
+    expect(rate).toBe(0);
+  });
+
+  it('should cache the resolved rate per product/country', async () => {
+    httpClient.getResource
+      .mockResolvedValueOnce({ id_tax_rules_group: '2' })
+      .mockResolvedValueOnce({ rate: '23.000' });
+    countryResolver.resolveCountryId.mockResolvedValue(6);
+    httpClient.listResources.mockResolvedValueOnce([{ id_tax: '7', id_country: '6', id_state: '0' }]);
+
+    await resolver.resolveProductTaxRate('100', 'PL', 'conn-1', httpClient);
+    await resolver.resolveProductTaxRate('100', 'PL', 'conn-1', httpClient);
+
+    // products + taxes read once each (second call served from cache).
+    expect(httpClient.getResource).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-tax-rate.resolver.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-tax-rate.resolver.spec.ts
@@ -61,6 +61,22 @@ describe('PrestashopTaxRateResolver', () => {
     expect(httpClient.getResource).toHaveBeenCalledWith('taxes', '9');
   });
 
+  it('should prefer the country-level (id_state=0) rule over a state-specific row', async () => {
+    httpClient.getResource
+      .mockResolvedValueOnce({ id_tax_rules_group: '2' })
+      .mockResolvedValueOnce({ rate: '23.000' }); // taxes/7 (the id_state=0 row)
+    countryResolver.resolveCountryId.mockResolvedValueOnce(6);
+    httpClient.listResources.mockResolvedValueOnce([
+      { id_tax: '8', id_country: '6', id_state: '12' }, // state-specific row first
+      { id_tax: '7', id_country: '6', id_state: '0' }, // country-level row
+    ]);
+
+    const rate = await resolver.resolveProductTaxRate('100', 'PL', 'conn-1', httpClient);
+
+    expect(rate).toBeCloseTo(0.23, 5);
+    expect(httpClient.getResource).toHaveBeenCalledWith('taxes', '7');
+  });
+
   it('should return 0 when the product read fails', async () => {
     httpClient.getResource.mockRejectedValueOnce(new Error('boom'));
 

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-tax-rate.resolver.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-tax-rate.resolver.ts
@@ -1,0 +1,174 @@
+/**
+ * PrestaShop Tax-Rate Resolver
+ *
+ * Resolves the effective tax rate PrestaShop applies to a product, so the order
+ * processor can convert a buyer-paid GROSS line price into the tax-EXCLUDED
+ * `specific_prices.price` PrestaShop expects, and rely on PS to re-apply the
+ * same rate and reproduce the buyer-paid gross on the order line
+ * (#895 / ADR-014).
+ *
+ * The rate is destination-catalog knowledge resolved entirely here — it never
+ * leaks onto the core order contract. Resolution walks
+ * product → `id_tax_rules_group` → `tax_rules` → `taxes`, selecting the rule for
+ * the order's delivery country when resolvable (PS taxes on the delivery address
+ * by default), else the catch-all (`id_country = 0`) rule, else the first rule.
+ * A product with no tax-rule group (or an unresolvable rate) yields `0`.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/provisioners
+ */
+import { Logger } from '@openlinker/shared/logging';
+import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
+import type { PrestashopCountryResolver } from './prestashop-country-resolver';
+
+interface PrestashopProductTaxRow {
+  id_tax_rules_group?: string | number;
+}
+
+interface PrestashopTaxRuleRow {
+  id_tax?: string | number;
+  id_country?: string | number;
+  id_state?: string | number;
+}
+
+interface PrestashopTaxRow {
+  rate?: string | number;
+}
+
+const CACHE_TTL_MS = 5 * 60_000;
+
+interface CacheEntry {
+  rate: number;
+  timestamp: number;
+}
+
+export class PrestashopTaxRateResolver {
+  private readonly logger = new Logger(PrestashopTaxRateResolver.name);
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(private readonly countryResolver: PrestashopCountryResolver) {}
+
+  /**
+   * Resolve the effective tax rate (as a fraction, e.g. `0.23` for 23%) PS
+   * applies to `externalProductId` for an order delivered to
+   * `deliveryCountryIso`. Returns `0` when the product is untaxed or the rate
+   * cannot be resolved.
+   */
+  async resolveProductTaxRate(
+    externalProductId: string | number,
+    deliveryCountryIso: string | undefined,
+    connectionId: string,
+    webserviceClient: IPrestashopWebserviceClient
+  ): Promise<number> {
+    const countryId = await this.resolveCountryIdSafe(
+      deliveryCountryIso,
+      connectionId,
+      webserviceClient
+    );
+
+    const cacheKey = `${connectionId}:${externalProductId}:${countryId ?? 'none'}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+      return cached.rate;
+    }
+
+    const rate = await this.computeRate(externalProductId, countryId, webserviceClient);
+    this.cache.set(cacheKey, { rate, timestamp: Date.now() });
+    return rate;
+  }
+
+  private async computeRate(
+    externalProductId: string | number,
+    countryId: number | undefined,
+    webserviceClient: IPrestashopWebserviceClient
+  ): Promise<number> {
+    let groupId: number;
+    try {
+      const product = await webserviceClient.getResource<PrestashopProductTaxRow>(
+        'products',
+        externalProductId
+      );
+      groupId = this.toInt(product?.id_tax_rules_group);
+    } catch (error) {
+      this.logger.warn(
+        `Could not read tax-rule group for product ${externalProductId}; treating as untaxed. ` +
+          `${error instanceof Error ? error.message : String(error)}`
+      );
+      return 0;
+    }
+
+    if (!groupId) {
+      // 0 / missing → product carries no tax rule.
+      return 0;
+    }
+
+    const rules = await webserviceClient.listResources<PrestashopTaxRuleRow>('tax_rules', {
+      custom: { id_tax_rules_group: groupId },
+    });
+    const rule = this.selectRule(rules, countryId);
+    if (!rule || !rule.id_tax) {
+      this.logger.warn(
+        `No usable tax rule for group ${groupId} (product ${externalProductId}); treating as untaxed.`
+      );
+      return 0;
+    }
+
+    const tax = await webserviceClient.getResource<PrestashopTaxRow>('taxes', rule.id_tax);
+    const ratePercent = Number.parseFloat(String(tax?.rate ?? '0'));
+    if (!Number.isFinite(ratePercent) || ratePercent < 0) {
+      return 0;
+    }
+    return ratePercent / 100;
+  }
+
+  /**
+   * Pick the tax rule for the delivery country, falling back to the catch-all
+   * (`id_country = 0`) rule and finally the first rule.
+   */
+  private selectRule(
+    rules: PrestashopTaxRuleRow[],
+    countryId: number | undefined
+  ): PrestashopTaxRuleRow | undefined {
+    if (!rules || rules.length === 0) {
+      return undefined;
+    }
+    if (countryId !== undefined) {
+      const countryMatch = rules.find((r) => this.toInt(r.id_country) === countryId);
+      if (countryMatch) {
+        return countryMatch;
+      }
+    }
+    const catchAll = rules.find((r) => this.toInt(r.id_country) === 0);
+    return catchAll ?? rules[0];
+  }
+
+  private async resolveCountryIdSafe(
+    deliveryCountryIso: string | undefined,
+    connectionId: string,
+    webserviceClient: IPrestashopWebserviceClient
+  ): Promise<number | undefined> {
+    if (!deliveryCountryIso) {
+      return undefined;
+    }
+    try {
+      return await this.countryResolver.resolveCountryId(
+        deliveryCountryIso,
+        connectionId,
+        webserviceClient
+      );
+    } catch (error) {
+      this.logger.debug(
+        `Could not resolve delivery country '${deliveryCountryIso}'; using catch-all tax rule. ` +
+          `${error instanceof Error ? error.message : String(error)}`
+      );
+      return undefined;
+    }
+  }
+
+  private toInt(value: string | number | undefined): number {
+    if (value === undefined || value === null) {
+      return 0;
+    }
+    const n = Number.parseInt(String(value), 10);
+    return Number.isNaN(n) ? 0 : n;
+  }
+}

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-tax-rate.resolver.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-tax-rate.resolver.ts
@@ -122,7 +122,9 @@ export class PrestashopTaxRateResolver {
 
   /**
    * Pick the tax rule for the delivery country, falling back to the catch-all
-   * (`id_country = 0`) rule and finally the first rule.
+   * (`id_country = 0`) rule and finally the first rule. Among rows matching the
+   * country, prefer the country-level rule (`id_state = 0`) over state-specific
+   * rows so a multi-state group (e.g. US) doesn't return an arbitrary state rate.
    */
   private selectRule(
     rules: PrestashopTaxRuleRow[],
@@ -132,9 +134,9 @@ export class PrestashopTaxRateResolver {
       return undefined;
     }
     if (countryId !== undefined) {
-      const countryMatch = rules.find((r) => this.toInt(r.id_country) === countryId);
-      if (countryMatch) {
-        return countryMatch;
+      const countryMatches = rules.filter((r) => this.toInt(r.id_country) === countryId);
+      if (countryMatches.length > 0) {
+        return countryMatches.find((r) => this.toInt(r.id_state) === 0) ?? countryMatches[0];
       }
     }
     const catchAll = rules.find((r) => this.toInt(r.id_country) === 0);

--- a/libs/shared/package.json
+++ b/libs/shared/package.json
@@ -48,6 +48,10 @@
     "./cache/testing": {
       "types": "./dist/cache/testing/index.d.ts",
       "require": "./dist/cache/testing/index.js"
+    },
+    "./money": {
+      "types": "./dist/money/index.d.ts",
+      "require": "./dist/money/index.js"
     }
   },
   "files": [

--- a/libs/shared/src/money/__tests__/allocate-by-largest-remainder.spec.ts
+++ b/libs/shared/src/money/__tests__/allocate-by-largest-remainder.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for largest-remainder allocation.
+ *
+ * @module money
+ */
+import { allocateByLargestRemainder } from '../allocate-by-largest-remainder';
+
+describe('allocateByLargestRemainder', () => {
+  it('should return an empty array when there are no weights', () => {
+    expect(allocateByLargestRemainder(0, [])).toEqual([]);
+    expect(allocateByLargestRemainder(100, [])).toEqual([]);
+  });
+
+  it('should preserve the total exactly for an even split', () => {
+    const parts = allocateByLargestRemainder(100, [1, 1]);
+    expect(parts).toEqual([50, 50]);
+    expect(sum(parts)).toBe(100);
+  });
+
+  it('should hand the leftover unit to the largest fractional remainder', () => {
+    // 100 / 3 = 33.33 each → floors [33,33,33], remainder 1 → lowest index wins on the tie
+    const parts = allocateByLargestRemainder(100, [1, 1, 1]);
+    expect(parts).toEqual([34, 33, 33]);
+    expect(sum(parts)).toBe(100);
+  });
+
+  it('should allocate proportionally to weights and sum exactly', () => {
+    // total 1000 across weights 1:2:7 → 100 : 200 : 700
+    const parts = allocateByLargestRemainder(1000, [1, 2, 7]);
+    expect(parts).toEqual([100, 200, 700]);
+    expect(sum(parts)).toBe(1000);
+  });
+
+  it('should distribute the residual by largest remainder for uneven proportions', () => {
+    // exact shares: 10*1/6=1.666, 10*2/6=3.333, 10*3/6=5.0
+    // floors [1,3,5] sum 9, remainder 1 → largest frac is index 0 (0.666)
+    const parts = allocateByLargestRemainder(10, [1, 2, 3]);
+    expect(parts).toEqual([2, 3, 5]);
+    expect(sum(parts)).toBe(10);
+  });
+
+  it('should spread evenly when every weight is zero', () => {
+    const parts = allocateByLargestRemainder(10, [0, 0, 0]);
+    expect(parts).toEqual([4, 3, 3]);
+    expect(sum(parts)).toBe(10);
+  });
+
+  it('should handle a single part by giving it the whole total', () => {
+    expect(allocateByLargestRemainder(999, [5])).toEqual([999]);
+  });
+
+  it('should handle a zero total', () => {
+    const parts = allocateByLargestRemainder(0, [3, 7]);
+    expect(parts).toEqual([0, 0]);
+    expect(sum(parts)).toBe(0);
+  });
+
+  it('should be deterministic across runs for tied remainders', () => {
+    const a = allocateByLargestRemainder(100, [1, 1, 1]);
+    const b = allocateByLargestRemainder(100, [1, 1, 1]);
+    expect(a).toEqual(b);
+  });
+
+  it('should throw when the total is negative', () => {
+    expect(() => allocateByLargestRemainder(-1, [1])).toThrow(RangeError);
+  });
+
+  it('should throw when the total is not an integer', () => {
+    expect(() => allocateByLargestRemainder(1.5, [1])).toThrow(RangeError);
+  });
+
+  it('should throw when a weight is negative', () => {
+    expect(() => allocateByLargestRemainder(100, [1, -1])).toThrow(RangeError);
+  });
+
+  it('should throw when a weight is not an integer', () => {
+    expect(() => allocateByLargestRemainder(100, [1, 2.5])).toThrow(RangeError);
+  });
+});
+
+function sum(values: number[]): number {
+  return values.reduce((acc, v) => acc + v, 0);
+}

--- a/libs/shared/src/money/allocate-by-largest-remainder.ts
+++ b/libs/shared/src/money/allocate-by-largest-remainder.ts
@@ -1,0 +1,88 @@
+/**
+ * Largest-Remainder Allocation (Hamilton apportionment)
+ *
+ * Distributes an authoritative integer total across N parts so the parts sum
+ * EXACTLY to the total, proportionally to a set of weights. Each part gets its
+ * floored proportional share; the leftover units are handed out one-by-one to
+ * the parts with the largest fractional remainder (ties broken by lowest index
+ * for determinism).
+ *
+ * Pure and dependency-free. Operates in integer minor units (e.g. cents) to
+ * avoid floating-point drift — callers convert to/from minor units at the
+ * boundary. Reused by destination adapters that must decompose a buyer-paid
+ * order total across lines under rounding (#895 / ADR-014).
+ *
+ * @module money
+ */
+
+/**
+ * Allocate `totalMinor` across `weightsMinor` proportionally, returning integer
+ * minor-unit parts that sum to exactly `totalMinor`.
+ *
+ * When every weight is zero, the total is spread as evenly as possible (the
+ * remainder going to the lowest indices), so the result is still exact.
+ *
+ * @param totalMinor - authoritative total in integer minor units (>= 0)
+ * @param weightsMinor - non-negative relative weights, one per part
+ * @returns integer minor-unit parts, `parts.length === weightsMinor.length`,
+ *          `sum(parts) === totalMinor`
+ * @throws RangeError if `totalMinor` is negative/non-integer or any weight is
+ *         negative/non-integer
+ */
+export function allocateByLargestRemainder(totalMinor: number, weightsMinor: number[]): number[] {
+  if (!Number.isInteger(totalMinor) || totalMinor < 0) {
+    throw new RangeError(`totalMinor must be a non-negative integer, got ${totalMinor}`);
+  }
+  for (const w of weightsMinor) {
+    if (!Number.isInteger(w) || w < 0) {
+      throw new RangeError(`weights must be non-negative integers, got ${w}`);
+    }
+  }
+
+  const n = weightsMinor.length;
+  if (n === 0) {
+    return [];
+  }
+
+  const weightSum = weightsMinor.reduce((acc, w) => acc + w, 0);
+  if (weightSum === 0) {
+    return distributeEvenly(totalMinor, n);
+  }
+
+  const floors: number[] = new Array<number>(n);
+  const fractions: Array<{ index: number; fraction: number }> = new Array<{
+    index: number;
+    fraction: number;
+  }>(n);
+  let allocated = 0;
+  for (let i = 0; i < n; i++) {
+    const exact = (totalMinor * weightsMinor[i]) / weightSum;
+    const floor = Math.floor(exact);
+    floors[i] = floor;
+    fractions[i] = { index: i, fraction: exact - floor };
+    allocated += floor;
+  }
+
+  let remainder = totalMinor - allocated;
+  // Largest fractional remainder first; ties resolved by lowest index.
+  fractions.sort((a, b) => b.fraction - a.fraction || a.index - b.index);
+  for (let k = 0; remainder > 0; k++, remainder--) {
+    floors[fractions[k].index] += 1;
+  }
+
+  return floors;
+}
+
+/**
+ * Spread `totalMinor` across `n` parts as evenly as possible; leftover units go
+ * to the lowest indices. Sum is exact.
+ */
+function distributeEvenly(totalMinor: number, n: number): number[] {
+  const base = Math.floor(totalMinor / n);
+  let remainder = totalMinor - base * n;
+  const parts = new Array<number>(n).fill(base);
+  for (let i = 0; remainder > 0; i++, remainder--) {
+    parts[i] += 1;
+  }
+  return parts;
+}

--- a/libs/shared/src/money/index.ts
+++ b/libs/shared/src/money/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Money utilities barrel.
+ *
+ * Pure, dependency-free monetary helpers operating in integer minor units.
+ *
+ * @module money
+ */
+export { allocateByLargestRemainder } from './allocate-by-largest-remainder';


### PR DESCRIPTION
## What & why

Marketplace orders created into PrestaShop landed in **`Payment error`** (repro #6 `RPRRSFSUW`: Canon SX740 priced 1,499×2 = 2,998 on the lines, 30.95 actually paid). Root cause: PS prices `order_detail` from the cart (via `id_cart`) using the **catalog** price, while only `total_paid` carried the marketplace amount.

This models the scenario in **CORE** and implements it **per integration** ([ADR-014](https://github.com/openlinker-project/openlinker/blob/895-source-authoritative-order-pricing/docs/architecture/adrs/014-source-authoritative-order-pricing.md)).

### CORE
- `OrderTotals` / `IncomingOrderTotals` gain an optional `taxTreatment: 'inclusive' | 'exclusive'` union (gross vs net). **No migration** — `order_records.totals` is `jsonb`. The tax *rate* stays destination-side (bounded context).
- `OrderProcessorManagerPort.createOrder` carries a **source-authoritative pricing invariant**: destinations MUST price lines at `items[].price`, never the catalog, and MUST fail loudly if they can't. It's a base-contract invariant, **not** an opt-in capability.
- New `@openlinker/shared/money` — pure largest-remainder allocation in integer minor units.

### Allegro (source)
- Emits `taxTreatment: 'inclusive'` (buyer prices are gross).

### PrestaShop (destination)
- `createOrder` pins each line via cart-scoped **`specific_prices`** (tax-excluded) **before** `POST /orders`, converting gross→net with the **delivery-country** tax rate (resolved from PS). Pins are best-effort-cleaned-up after, with a short `to`-expiry fail-safe.
- A line that can't be pinned **throws** (honours the invariant; the idempotency guard makes the retry safe).
- New `PrestashopTaxRateResolver`; `deleteResource` added to the WS client.

## How to test
- `pnpm lint && pnpm type-check && pnpm test` — all green (incl. +23 new unit tests: allocation helper, tax resolver, pinning behaviour, fail-loud abort).
- ⚠️ **Integration tests must be run before merge** (`pnpm test:integration`, Docker): the existing `allegro-prestashop-carrier-mapping.int-spec.ts` now exercises the pinning path against real PrestaShop.

## Scope / deferred (tracked in ADR-014 + plan)
- Dedicated PS-Testcontainer **regression-lock int-spec** (`installOlModule:false`; asserts `order_detail.product_price == buyer-paid` & status ≠ payment-error).
- `tax?` optional (gross + genuinely-tax-exempt case); durable saga-state reconciliation (short-`to` expiry covers crashes for now).
- **Shipping** reconciliation is out of scope — `Payment error` is fully resolved only when shipping also reconciles (OL Dynamic carrier path, #516).

Closes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)