### PR TITLE
feat(orders): lock-guarded concurrency-safe destination order creation

### DIFF
--- a/docs/plans/implementation-plan-906-destination-order-idempotency.md
+++ b/docs/plans/implementation-plan-906-destination-order-idempotency.md
@@ -1,0 +1,152 @@
+# Implementation Plan: Lock-guarded idempotent destination order creation (#906)
+
+**Date**: 2026-05-30
+**Status**: Ready for Review (revised after deep review + research)
+**Estimated Effort**: ~0.5–1 day
+**Issue**: #906 (blocks #902; part of epic #900) — ADR-015 § Required invariants 1 & 2
+
+---
+
+## 1. Task Summary
+
+**Objective**: Make creating an order in a destination safe under concurrency — a per-`(order, destination)` distributed **lock in core `OrderSyncService`** so converging triggers (webhook + poll, or a job retry) cannot produce a duplicate destination order, even across multiple worker processes.
+
+**Context & premise correction**: Deep review + codebase research established that destination idempotency is **not** absent today — `PrestashopOrderProcessorManagerAdapter.createOrder` already does a check-then-act guard (Step 0 `getExternalIds` skip + Step 6 `createMapping`). The real gaps are: (a) that guard is **check-then-act → racy under multi-worker** (`sync-job.runner.ts` locks per-*job*, not per-*order*; two workers can run a webhook job and a poll job for the same order concurrently); and (b) it lives per-adapter. This issue closes (a) — the correctness gap — by adding the missing serialization lock in core. Closing (b) fully (platform-agnostic idempotency) is **deferred** (see §7) because it requires a rippling `OrderRef` contract change.
+
+**Classification**: CORE application service + Testing. (No adapter behavior change in this issue.)
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- A per-`(internalOrderId, destinationConnectionId)` lock in `OrderSyncService` around each `adapter.createOrder`.
+- Lock-not-acquired handling: re-read mapping → already-created ⇒ success; else **rethrow a retryable contention error** so the worker job retries (matches the `MissingOrderItemMappingError` pattern).
+- A port-contract note on `OrderProcessorManagerPort.createOrder` documenting the idempotency expectation.
+- Unit + integration tests.
+
+### Out of Scope (deferred — see §7)
+- **Full A′**: lifting the adapter's Step 0/6 into core, changing `OrderRef.orderId` to carry the destination external id, core-owned `createMapping`, and the `syncStatus.externalOrderId`-records-internal-id fix. (Tracked as a follow-up issue; rippling contract change.)
+- Unified webhook/poll job dedup key (optional optimization; the lock is the guarantee).
+- Any `OrderRef` shape change, DB migration, new job type, or API surface change.
+
+### Constraints
+- No `OrderRef` contract change (keeps blast radius small).
+- Must land **before** #902 routes order webhooks onto `marketplace.order.sync`.
+
+---
+
+## 3. Architecture Mapping
+
+**Target layer**: CORE application — `libs/core/src/orders/application/services/order-sync.service.ts` (+ a port-doc note on `domain/ports/order-processor-manager.port.ts`, + lock-key/TTL constants in a `*.types.ts`).
+
+**Ports involved** (all already in `OrdersModule` scope — research-confirmed, **zero module edits**):
+- `SyncLockPort` (`SYNC_LOCK_TOKEN`, `@openlinker/core/sync`) — `acquire(key, ttlMs) → token|null` (single-shot `SET NX PX`), `release(key, token)` (compare-and-delete Lua). `OrderIngestionService` (same module) already injects it for the poll lock — proves resolution in both apps; `REDIS_CLIENT` is `@Global`.
+- `IIdentifierMappingService` (`IDENTIFIER_MAPPING_SERVICE_TOKEN`) — `getExternalIds('Order', internalId)` for the contention re-read. Already injected by sibling services.
+
+**Core vs Integration**: serialization of "create exactly once per (order, destination)" is platform-agnostic orchestration → core. The adapter's create + its own native dedup/recovery stay in the adapter.
+
+---
+
+## 4. External / Domain Research (grounded, file:line)
+
+- `OrderSyncService.syncOrder` builds one `OrderCreate` (stamps `metadata.internalOrderId = order.id`, `order-sync.service.ts:91`) and dispatches `adapter.createOrder` per destination via `Promise.allSettled` (lines 96-100); rejections → `{status:'failed'}` results (123-127); **never rethrows**.
+- `OrderIngestionService.syncOrderFromSource` swallows failed destinations — only `updateSyncStatus(...,'failed')` (`order-ingestion.service.ts:279-310`), `return results` (312), **no throw**. So a failed destination ⇒ worker job `markSucceeded`, **not** retried (`sync-job.runner.ts:274-280`). The retry-on-throw path (`handleJobFailure`, 296-342) only fires on a *thrown* error; the precedent for "make the job retry" is the `MissingOrderItemMappingError` throw (`order-ingestion.service.ts:235-243`).
+- `OrderDestinationRetryService` (`order-destination-retry.service.ts:48-137`) is **operator-driven** (`POST /orders/:id/destinations/:cid/retry`), only for `failed` rows, **no scheduler** — not an automatic safety net.
+- PrestaShop `createOrder` returns `{ orderId: internalOrderId, … }` on **both** success (adapter:635) and skip (170-173) paths — `OrderRef.orderId` is the **internal** id, not the destination external id. (This is why full A′ needs a contract change — deferred.)
+- `RedisSyncLockService.acquire` is single-shot (`redis-sync-lock.service.ts:33-38`); no heartbeat/extension → TTL must exceed worst-case `createOrder`.
+- Wiring: `OrdersModule` imports `SyncModule` + `IdentifierMappingModule` and provides `OrderSyncService`; `OrderIngestionService` already uses `SYNC_LOCK_TOKEN` (`order-ingestion.service.ts:66-67,86-87,163`).
+
+---
+
+## 5. Questions & Assumptions
+
+- **A1 (lock key)**: `order:create:{destinationConnectionId}:{internalOrderId}`; constant builder + TTL in `order-sync.types.ts` (no inline literals — engineering-standards § Constants).
+- **A2 (TTL)**: `ORDER_CREATE_LOCK_TTL_MS` generous (default **120 000 ms**) because PS `createOrder` (customer + cart + pin + POST) is multi-second. Documented bound below.
+- **A3 (contention → retry)**: on `acquire → null`, re-read `getExternalIds`; mapped ⇒ return `success` synthesized from the mapping; unmapped ⇒ throw `OrderCreateContendedError` (retryable). After `allSettled`, contention rejections are **rethrown** to trigger a whole-job retry; genuine per-destination failures stay isolated `failed` results (preserves existing behavior).
+- **A4**: the adapter keeps Step 0/6, so on the retry the other worker has finished and the adapter skips. Core's lock + the adapter's check-then-act compose: the lock removes the concurrency window, the adapter remains the create/skip authority.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1 — Port contract note
+1. `order-processor-manager.port.ts` — JSDoc: `createOrder` SHOULD be idempotent w.r.t. `(metadata.internalOrderId, destination connection)`; core serializes concurrent creates per `(order, destination)` via a lock. Doc-only.
+
+### Phase 2 — Lock constants + contention error
+2. `application/types/order-sync.types.ts` (or existing types file) — `ORDER_CREATE_LOCK_TTL_MS` and `orderCreateLockKey(destinationConnectionId, internalOrderId)`.
+3. `domain/exceptions/order-create-contended.exception.ts` — `OrderCreateContendedError extends Error` (retryable; thrown when a concurrent create holds the lock and no mapping exists yet).
+
+### Phase 3 — Lock guard in `OrderSyncService`
+4. Inject `@Inject(SYNC_LOCK_TOKEN) syncLock: SyncLockPort` and `@Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN) identifierMapping: IIdentifierMappingService` (no module change).
+5. Replace the per-destination `adapter.createOrder(orderCreate)` (line 98) with `createOrderIdempotently(adapter, destinationConnectionId, order.id, orderCreate)`:
+   - `acquire(orderCreateLockKey(dest, order.id), ORDER_CREATE_LOCK_TTL_MS)`;
+   - **acquired** → `adapter.createOrder(...)` in `try`, `release` in `finally`; return its `OrderRef`;
+   - **not acquired** → `getExternalIds('Order', order.id)` filtered to `dest`; mapped ⇒ return synthesized `OrderRef { orderId: existing.externalId }`; unmapped ⇒ `throw new OrderCreateContendedError(...)`.
+6. After `Promise.allSettled`, if any settlement rejected with `OrderCreateContendedError`, **rethrow** an aggregate retryable error so the worker job retries (whole-job retry is safe given idempotency). Non-contention rejections remain `status:'failed'` results (unchanged isolation).
+
+### Phase 4 — Tests
+7. Unit `order-sync.service.spec.ts`: (a) lock acquired → `createOrder` called once, released; (b) **lock not acquired + mapping present** → `createOrder` NOT called, success synthesized from mapping; (c) **lock not acquired + no mapping** → throws (job will retry); (d) genuine `createOrder` failure → isolated `failed` result, lock released; (e) two sequential calls (adapter Step-0 simulated) → one create. Mock `SyncLockPort` (`acquire` returns token / null) + identifier mapping.
+8. Integration — extend `allegro-order-sync-e2e.int-spec.ts`: two sequential `marketplace.order.sync` jobs for the same order → exactly one `createOrder` (exercises the lock-release + adapter skip; see caveat §8).
+
+### Phase 5 — Quality gate
+9. `pnpm lint && pnpm type-check && pnpm test`, then full `pnpm test:integration`.
+
+---
+
+## 7. Deferred follow-up — "Full A′" (separate issue)
+
+Lift idempotency fully into core so **any** destination adapter is safe with no per-adapter code:
+- Change `OrderProcessorManagerPort.createOrder` to return the **destination external id** in `OrderRef.orderId` (today it returns the internal id).
+- Move the `getExternalIds` skip + `createMapping` write into `OrderSyncService` (under the lock from this issue); remove PrestaShop Step 0/6.
+- Fix `syncStatus.externalOrderId` to record the destination external id (today records the internal id).
+- Audit consumers of `OrderRef.orderId` / `syncStatus.externalOrderId` (fulfillment + shipment sync) for the contract change.
+
+Deferred because the `OrderRef` contract change has wide blast radius; this issue delivers the correctness (concurrency) fix without it. **File as a follow-up of #900.**
+
+---
+
+## 8. Validation & Risks
+
+- **Architecture**: ✅ lock (orchestration) in core; adapter unchanged. Cross-context imports interface/token-only; zero module edits (research-confirmed).
+- **Risks**:
+  - **TTL-expiry window**: single-shot lock, no heartbeat. If `createOrder` exceeds `ORDER_CREATE_LOCK_TTL_MS`, the lock expires and a concurrent create can slip through. Mitigation: generous TTL (120 s) **and** PrestaShop's own duplicate-key recovery remains the backstop (kept, since Step 0/6 stay). **Honest bound**: the lock guarantees exactly-once *up to TTL*; beyond it, correctness falls back to adapter-native dedup. For a future adapter without native recovery, full A′ + a sufficient TTL is the answer.
+  - **Whole-job retry on contention** re-dispatches all destinations — safe because the adapter create is idempotent (the property this issue + Step 0 provide).
+- **Backward compatibility**: ✅ no `OrderRef`/persistence/contract change.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+- **Unit**: `order-sync.service.spec.ts` branches (a)–(e) in Phase 4, mocking `SyncLockPort` (incl. `acquire → null` to simulate contention).
+- **Integration**: none added — and deliberately so:
+  - The lock's actual property (prevents *simultaneous* double-create) is unobservable in the integration harness, which runs a **single worker sequentially**. Pre-holding the exact lock key to fake contention requires the runtime-derived `internalOrderId` + the destination connection id (from `listCapabilityAdapters`, not the harness's mocked `getCapabilityAdapter`) — a brittle, low-value test of a property the unit specs already cover via `acquire → null`.
+  - A mock-adapter "two sequential jobs → one create" assertion would be *misleading*: sequential jobs release the lock between runs, so dedup there comes from the **adapter's** Step-0 mapping (a mock has none) — not from this change.
+  - The existing `apps/worker/test/integration/allegro-order-sync-e2e.int-spec.ts` is **pre-broken on `main`** (calls `markSucceeded(id)` one-arg vs the #400 two-arg `markSucceeded(id, outcome)` contract) — unrelated to #906; flagged for separate cleanup. It therefore can't validate this change either.
+  - Validation rests on: `pnpm type-check` (all src), `pnpm check:invariants`, core ESLint (0 errors), and 963 core unit tests including the 4 new lock-branch specs.
+- **`OrderSyncResult` note**: there is no `skipped` variant; a skip surfaces as `status:'success'`. On the adapter Step-0 skip `orderRef.orderId` is the internal id (existing behavior); on the core contention re-read it's the destination external id. Minor inconsistency, documented; fully reconciled by full A′ (§7).
+- **Acceptance**:
+  - [ ] Concurrent creates for the same `(order, destination)` are serialized by the lock; a contended job retries rather than silently dropping.
+  - [ ] Two converging same-order syncs → exactly one `createOrder`.
+  - [ ] Lock always released (success + failure paths).
+  - [ ] No `OrderRef`/module changes; `pnpm lint && type-check && test` green. (The worker order-sync e2e int-spec is pre-broken on `main` — `markSucceeded` arity, unrelated to #906 — and is out of scope; flagged for separate cleanup.)
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Hexagonal (lock orchestration in core; adapter untouched)
+- [x] CORE vs Integration boundaries (interface/token imports; zero module edits)
+- [x] Reuses existing seams (`SyncLockPort`, identifier mapping)
+- [x] Idempotency + multi-worker concurrency addressed (the point)
+- [x] Retry-safe (contention → rethrow → runner retry, matching `MissingOrderItemMappingError`)
+- [x] Error handling (retryable contention error; isolated genuine failures)
+- [x] Testing strategy complete + harness caveat documented
+- [x] Constants in `*.types.ts`; no inline literals
+- [x] Plan saved as markdown
+
+---
+
+## Related Documentation
+- ADR-015 § Required invariants (1 & 2)
+- Epic #900; blocks #902; full-A′ follow-up to be filed.

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -14,11 +14,16 @@ import type { Order } from '../../../domain/types/order.types';
 import type { OrderRef } from '../../../domain/types/order-processor.types';
 import type { IMappingConfigService } from '@openlinker/core/mappings';
 import { NoOrderDestinationsAvailableException } from '../../../domain/exceptions/no-order-destinations-available.exception';
+import { OrderCreateContendedException } from '../../../domain/exceptions/order-create-contended.exception';
+import type { SyncLockPort } from '@openlinker/core/sync';
+import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
 
 describe('OrderSyncService', () => {
   let service: OrderSyncService;
   let integrationsService: jest.Mocked<IIntegrationsService>;
   let mappingConfigService: jest.Mocked<IMappingConfigService>;
+  let syncLock: jest.Mocked<SyncLockPort>;
+  let identifierMapping: jest.Mocked<IIdentifierMappingService>;
 
   const makeAdapter = (orderRef: OrderRef = { orderId: 'dest_order' }) =>
     ({
@@ -86,7 +91,25 @@ describe('OrderSyncService', () => {
       resolveAllegroCategory: jest.fn(),
     } as jest.Mocked<IMappingConfigService>;
 
-    service = new OrderSyncService(integrationsService, mappingConfigService);
+    syncLock = {
+      acquire: jest.fn().mockResolvedValue('lock-token'),
+      release: jest.fn().mockResolvedValue(true),
+    } as jest.Mocked<SyncLockPort>;
+
+    identifierMapping = {
+      getOrCreateInternalId: jest.fn(),
+      getInternalId: jest.fn(),
+      getExternalIds: jest.fn().mockResolvedValue([]),
+      createMapping: jest.fn(),
+      batchGetOrCreateInternalIds: jest.fn(),
+    } as unknown as jest.Mocked<IIdentifierMappingService>;
+
+    service = new OrderSyncService(
+      integrationsService,
+      mappingConfigService,
+      syncLock,
+      identifierMapping
+    );
   });
 
   afterEach(() => {
@@ -309,6 +332,117 @@ describe('OrderSyncService', () => {
       await expect(
         service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' })
       ).rejects.toThrow('Mapping service unavailable');
+    });
+  });
+
+  describe('createOrder idempotency (lock)', () => {
+    it('should acquire the per-(order, destination) lock and release it after create', async () => {
+      const adapter = makeAdapter({ orderId: 'dest-1' });
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
+
+      await service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' });
+
+      expect(syncLock.acquire).toHaveBeenCalledWith('order:create:dest-a:ol_order_123', 120000);
+      expect(adapter.createOrder).toHaveBeenCalledTimes(1);
+      expect(syncLock.release).toHaveBeenCalledWith(
+        'order:create:dest-a:ol_order_123',
+        'lock-token'
+      );
+    });
+
+    it('should skip create and synthesize the ref from the mapping when the lock is held but the order already exists', async () => {
+      const adapter = makeAdapter({ orderId: 'should-not-be-used' });
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
+      syncLock.acquire.mockResolvedValue(null);
+      identifierMapping.getExternalIds.mockResolvedValue([
+        {
+          externalId: 'PS-EXISTING-42',
+          connectionId: 'dest-a',
+          platformType: 'prestashop',
+          entityType: 'Order',
+        },
+      ]);
+
+      const results = await service.syncOrder({
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
+      });
+
+      expect(adapter.createOrder).not.toHaveBeenCalled();
+      expect(results).toEqual([
+        {
+          destinationConnectionId: 'dest-a',
+          status: 'success',
+          orderRef: { orderId: 'PS-EXISTING-42' },
+        },
+      ]);
+    });
+
+    it('should throw OrderCreateContendedException (retryable) when the lock is held and no mapping exists yet', async () => {
+      const adapter = makeAdapter();
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
+      syncLock.acquire.mockResolvedValue(null);
+      identifierMapping.getExternalIds.mockResolvedValue([]);
+
+      await expect(
+        service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' })
+      ).rejects.toBeInstanceOf(OrderCreateContendedException);
+      expect(adapter.createOrder).not.toHaveBeenCalled();
+    });
+
+    it('should not mask a successful create when releasing the lock fails', async () => {
+      const adapter = makeAdapter({ orderId: 'dest-1' });
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
+      syncLock.release.mockRejectedValue(new Error('redis down'));
+
+      const results = await service.syncOrder({
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
+      });
+
+      expect(results).toEqual([
+        { destinationConnectionId: 'dest-a', status: 'success', orderRef: { orderId: 'dest-1' } },
+      ]);
+    });
+
+    it('should rethrow contention (aborting the whole job) even when another destination succeeds', async () => {
+      const ok = makeAdapter({ orderId: 'ok-1' });
+      const contended = makeAdapter({ orderId: 'never' });
+      registerDestinations([
+        { connectionId: 'dest-ok', adapter: ok },
+        { connectionId: 'dest-contended', adapter: contended },
+      ]);
+      // dest-contended cannot acquire the lock and no mapping exists yet → contended
+      syncLock.acquire.mockImplementation((key: string) =>
+        Promise.resolve(key.includes('dest-contended') ? null : 'lock-token')
+      );
+      identifierMapping.getExternalIds.mockResolvedValue([]);
+
+      await expect(
+        service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' })
+      ).rejects.toBeInstanceOf(OrderCreateContendedException);
+      // the uncontended destination still attempted its create under its own lock
+      expect(ok.createOrder).toHaveBeenCalledTimes(1);
+      expect(contended.createOrder).not.toHaveBeenCalled();
+    });
+
+    it('should rethrow contention rather than a sibling genuine failure', async () => {
+      const failing = {
+        createOrder: jest.fn().mockRejectedValue(new Error('destination down')),
+      } as unknown as jest.Mocked<OrderProcessorManagerPort>;
+      const contended = makeAdapter({ orderId: 'never' });
+      registerDestinations([
+        { connectionId: 'dest-fail', adapter: failing },
+        { connectionId: 'dest-contended', adapter: contended },
+      ]);
+      syncLock.acquire.mockImplementation((key: string) =>
+        Promise.resolve(key.includes('dest-contended') ? null : 'lock-token')
+      );
+      identifierMapping.getExternalIds.mockResolvedValue([]);
+
+      await expect(
+        service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' })
+      ).rejects.toBeInstanceOf(OrderCreateContendedException);
     });
   });
 });

--- a/libs/core/src/orders/application/services/order-create-lock.ts
+++ b/libs/core/src/orders/application/services/order-create-lock.ts
@@ -1,0 +1,47 @@
+/**
+ * Order Create Lock helpers
+ *
+ * Lock key + TTL for serializing destination order creation per
+ * (internalOrderId, destinationConnectionId). The lock (SyncLockPort) removes
+ * the multi-worker race window in the adapter's check-then-act create-or-skip:
+ * `sync-job.runner` locks per-job, not per-order, so a webhook job and a poll
+ * job for the same order can otherwise run concurrently on two workers and both
+ * create the destination order.
+ *
+ * @module libs/core/src/orders/application/services
+ */
+
+/**
+ * Lock TTL (ms). Must comfortably exceed the worst-case `createOrder` duration
+ * (PrestaShop: customer provisioning + cart + price-pin + POST /orders is
+ * multi-second). The lock is single-shot (no heartbeat), so it guarantees
+ * exactly-once only up to this TTL; beyond it, correctness falls back to the
+ * adapter's own duplicate-key recovery (PrestaShop keeps one).
+ *
+ * Operator-tunable via `OL_ORDER_CREATE_LOCK_TTL_MS` (clamped to [10s, 600s]),
+ * mirroring `OL_WEBHOOK_SKEW_WINDOW_MS`. Tune up for slow destinations.
+ */
+const DEFAULT_ORDER_CREATE_LOCK_TTL_MS = 120_000;
+const MIN_ORDER_CREATE_LOCK_TTL_MS = 10_000;
+const MAX_ORDER_CREATE_LOCK_TTL_MS = 600_000;
+
+function resolveOrderCreateLockTtlMs(): number {
+  const raw = process.env.OL_ORDER_CREATE_LOCK_TTL_MS;
+  const parsed = raw !== undefined && raw !== '' ? Number(raw) : Number.NaN;
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_ORDER_CREATE_LOCK_TTL_MS;
+  }
+  return Math.min(MAX_ORDER_CREATE_LOCK_TTL_MS, Math.max(MIN_ORDER_CREATE_LOCK_TTL_MS, parsed));
+}
+
+export const ORDER_CREATE_LOCK_TTL_MS = resolveOrderCreateLockTtlMs();
+
+/**
+ * Build the lock key for creating one order at one destination.
+ */
+export function orderCreateLockKey(
+  destinationConnectionId: string,
+  internalOrderId: string,
+): string {
+  return `order:create:${destinationConnectionId}:${internalOrderId}`;
+}

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -18,13 +18,21 @@ import type {
   OrderSyncResult,
 } from '../interfaces/order-sync.service.interface';
 import type { OrderProcessorManagerPort } from '../../domain/ports/order-processor-manager.port';
-import type { OrderCreate } from '../../domain/types/order-processor.types';
+import type { OrderCreate, OrderRef } from '../../domain/types/order-processor.types';
 import { OrderStatusValues } from '../../domain/types/order.types';
 import { IIntegrationsService } from '@openlinker/core/integrations';
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { IMappingConfigService, MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
+import { SyncLockPort, SYNC_LOCK_TOKEN } from '@openlinker/core/sync';
+import {
+  IIdentifierMappingService,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  CORE_ENTITY_TYPE,
+} from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
 import { NoOrderDestinationsAvailableException } from '../../domain/exceptions/no-order-destinations-available.exception';
+import { OrderCreateContendedException } from '../../domain/exceptions/order-create-contended.exception';
+import { ORDER_CREATE_LOCK_TTL_MS, orderCreateLockKey } from './order-create-lock';
 
 @Injectable()
 export class OrderSyncService implements IOrderSyncService {
@@ -34,7 +42,11 @@ export class OrderSyncService implements IOrderSyncService {
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrationsService: IIntegrationsService,
     @Inject(MAPPING_CONFIG_SERVICE_TOKEN)
-    private readonly mappingConfigService: IMappingConfigService
+    private readonly mappingConfigService: IMappingConfigService,
+    @Inject(SYNC_LOCK_TOKEN)
+    private readonly syncLock: SyncLockPort,
+    @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
+    private readonly identifierMapping: IIdentifierMappingService
   ) {}
 
   async syncOrder(request: OrderSyncRequest): Promise<OrderSyncResult[]> {
@@ -92,12 +104,36 @@ export class OrderSyncService implements IOrderSyncService {
       },
     };
 
-    // Dispatch in parallel with per-destination error isolation
+    // Dispatch in parallel with per-destination error isolation. Each create is
+    // serialized per (order, destination) by a lock so converging triggers
+    // (webhook + poll, or a job retry) on multiple workers can't double-create.
     const settled = await Promise.allSettled(
       destinations.map(({ connectionId, adapter }) =>
-        adapter.createOrder(orderCreate).then((orderRef) => ({ connectionId, orderRef }))
+        this.createOrderIdempotently(adapter, connectionId, order.id, orderCreate).then(
+          (orderRef) => ({ connectionId, orderRef })
+        )
       )
     );
+
+    // Lock contention (a concurrent create is in-flight for the same order) is a
+    // retryable condition, not a per-destination failure: rethrow so the sync
+    // job retries (mirrors MissingOrderItemMappingError). By the retry the peer
+    // worker has finished and the create is skipped.
+    //
+    // Note: the whole-job retry re-dispatches every destination, including ones
+    // that already succeeded this run (they hit the adapter's skip path) and a
+    // sibling that genuinely failed (re-attempted as a side effect). Both are
+    // safe because create is idempotent; the already-succeeded skip currently
+    // returns the internal id in the OrderRef — fixed when the mapping write +
+    // OrderRef external-id contract move into core (#909).
+    const contended = settled.find(
+      (outcome): outcome is PromiseRejectedResult =>
+        outcome.status === 'rejected' && outcome.reason instanceof OrderCreateContendedException
+    );
+    if (contended) {
+      this.logger.warn(`Order ${order.id} create contended on a destination; retrying sync job`);
+      throw contended.reason;
+    }
 
     return settled.map((outcome, index): OrderSyncResult => {
       const destinationConnectionId = destinations[index].connectionId;
@@ -126,6 +162,56 @@ export class OrderSyncService implements IOrderSyncService {
         error: { message },
       };
     });
+  }
+
+  /**
+   * Create one order at one destination under a per-(order, destination) lock.
+   *
+   * The lock removes the multi-worker race in the adapter's own check-then-act
+   * create-or-skip (`sync-job.runner` locks per-job, not per-order). On
+   * contention (lock held by a concurrent worker) we re-read the destination
+   * mapping: if the peer already created the order we skip and synthesize the
+   * ref from the mapping; otherwise we throw a retryable
+   * `OrderCreateContendedException` so the sync job retries.
+   */
+  private async createOrderIdempotently(
+    adapter: OrderProcessorManagerPort,
+    destinationConnectionId: string,
+    internalOrderId: string,
+    orderCreate: OrderCreate
+  ): Promise<OrderRef> {
+    const lockKey = orderCreateLockKey(destinationConnectionId, internalOrderId);
+    const token = await this.syncLock.acquire(lockKey, ORDER_CREATE_LOCK_TTL_MS);
+
+    if (!token) {
+      const mappings = await this.identifierMapping.getExternalIds(
+        CORE_ENTITY_TYPE.Order,
+        internalOrderId
+      );
+      const existing = mappings.find((m) => m.connectionId === destinationConnectionId);
+      if (existing) {
+        this.logger.log(
+          `Order ${internalOrderId} already present at destination ${destinationConnectionId} ` +
+            `(concurrent create resolved); skipping create`
+        );
+        return { orderId: existing.externalId };
+      }
+      throw new OrderCreateContendedException(internalOrderId, destinationConnectionId);
+    }
+
+    try {
+      return await adapter.createOrder(orderCreate);
+    } finally {
+      // Best-effort release — never let a release failure mask the create result.
+      try {
+        await this.syncLock.release(lockKey, token);
+      } catch (releaseError) {
+        this.logger.warn(
+          `Failed to release order-create lock ${lockKey}: ` +
+            `${releaseError instanceof Error ? releaseError.message : String(releaseError)}`
+        );
+      }
+    }
   }
 
   private async resolveDestinations(

--- a/libs/core/src/orders/domain/exceptions/order-create-contended.exception.ts
+++ b/libs/core/src/orders/domain/exceptions/order-create-contended.exception.ts
@@ -1,0 +1,27 @@
+/**
+ * Order Create Contended Exception
+ *
+ * Thrown by OrderSyncService when a per-(order, destination) create lock is held
+ * by a concurrent worker AND no destination mapping exists yet — i.e. another
+ * worker is mid-create for the same order. It is a **retryable** signal: callers
+ * let it propagate so the sync job is retried (by which point the other worker
+ * has finished and the create is skipped). Distinct from a genuine destination
+ * failure, which is surfaced as a per-destination `OrderSyncResult` (status
+ * 'failed') without aborting sibling destinations.
+ *
+ * @module libs/core/src/orders/domain/exceptions
+ */
+export class OrderCreateContendedException extends Error {
+  constructor(
+    public readonly internalOrderId: string,
+    public readonly destinationConnectionId: string,
+  ) {
+    super(
+      `Order create is contended for order ${internalOrderId} (destinationConnectionId=${destinationConnectionId}); a concurrent create holds the lock — retry`,
+    );
+    this.name = 'OrderCreateContendedException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, OrderCreateContendedException);
+    }
+  }
+}

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -109,6 +109,7 @@ export { MissingOrderItemMappingError } from './domain/exceptions/missing-order-
 export { OrderDestinationNotFoundException } from './domain/exceptions/order-destination-not-found.exception';
 export { OrderDestinationNotRetryableException } from './domain/exceptions/order-destination-not-retryable.exception';
 export { MissingSourceExternalIdException } from './domain/exceptions/missing-source-external-id.exception';
+export { OrderCreateContendedException } from './domain/exceptions/order-create-contended.exception';
 
 // Ports
 export { OrderRecordRepositoryPort } from './domain/ports/order-record-repository.port';


### PR DESCRIPTION
## What & why

`OrderSyncService` now serializes each destination `createOrder` under a per-`(internalOrderId, destinationConnectionId)` distributed lock (`SyncLockPort`), closing the multi-worker race in the adapter's check-then-act create-or-skip: `sync-job.runner` locks **per-job, not per-order**, so a webhook job and a poll job for the same order could otherwise run on two workers and both create the destination order. This is the concurrency-safety foundation the webhook epic (#900) needs before #902 routes order webhooks.

Premise was corrected during review: destination idempotency already exists *inside the PrestaShop adapter* (Step-0 `getExternalIds` skip + Step-6 `createMapping`) — the real gap is that it's check-then-act (racy under multi-worker) and per-adapter. This PR adds the missing serialization lock in core; **lifting the guard fully into core** (the `OrderRef` external-id contract change) is deferred to #909.

## How it works

- **Lock acquired** → `adapter.createOrder` runs under the lock (the adapter writes its mapping before returning, so create + mapping are covered); released in `finally` (best-effort, compare-and-delete — a TTL-expired holder can't delete a successor's lock).
- **Lock not acquired** (peer mid-create) → re-read the destination mapping; if present, skip and synthesize the ref; else throw a retryable `OrderCreateContendedException` so the sync job retries (mirrors the `MissingOrderItemMappingError` precedent — `syncOrderFromSource` swallows failed destinations, so a *thrown* error is the only thing that retries). Contention is detected before the result-mapping and rethrown, so it aborts the whole job while genuine per-destination failures stay isolated `failed` results.
- Lock key + TTL in `order-create-lock.ts`; TTL is operator-tunable via `OL_ORDER_CREATE_LOCK_TTL_MS` (clamped [10s, 600s], default 120s). **Honest bound:** exactly-once *up to TTL*; beyond it, PrestaShop's duplicate-key recovery is the backstop.

## Scope

- **No** `OrderRef` contract change, **no** adapter behavior change, **no** module edits (`OrdersModule` already imports `SyncModule` + `IdentifierMappingModule`; `OrderIngestionService` already uses the lock token).
- New `OrderCreateContendedException` (domain/exceptions, barrel-exported).

## Tests

18 unit specs (6 new lock-branch cases), incl. lock acquire+release, contention→skip, contention→retryable-throw, release-failure-doesn't-mask, and **multi-destination contention propagation** (`[success + contended] → rejects`, `[failure + contended] → rejects with contention`).

`pnpm lint && type-check && test` green (full pre-commit gate). Integration note: the lock's true *concurrency* property isn't exercisable in the single-worker test harness (covered by unit `acquire→null` specs); separately, the worker order-sync e2e int-spec is pre-broken on `main` (#910) — unrelated to this PR.

## Follow-ups
- #909 — lift idempotency fully into core (`OrderRef` external-id contract; fixes the skip-path internal-id quirk a whole-job retry can surface).
- #910 — fix the stale worker order-sync e2e int-spec.

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)