### PR TITLE
feat(webhooks): ingest PrestaShop order webhooks via marketplace.order.sync

### DIFF
--- a/apps/api/src/webhooks/application/handlers/__tests__/webhook-to-job.handler.spec.ts
+++ b/apps/api/src/webhooks/application/handlers/__tests__/webhook-to-job.handler.spec.ts
@@ -11,6 +11,7 @@ import { Test } from '@nestjs/testing';
 import { WebhookToJobHandler } from '../webhook-to-job.handler';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import type { InboundWebhookEvent } from '@openlinker/core/events';
+import type { SyncJobRequest } from '@openlinker/core/sync';
 import { JobTypeValues } from '@openlinker/core/sync';
 import { WEBHOOK_DELIVERY_REPOSITORY_TOKEN } from '@openlinker/core/webhooks';
 import { REDIS_CLIENT_BLOCKING_TOKEN } from '../../../webhooks.tokens';
@@ -127,16 +128,6 @@ describe('WebhookToJobHandler', () => {
       expect(job.payload.objectType).toBe('Product');
     });
 
-    it('should throw error for unsupported PrestaShop "order" master objectType', () => {
-      const event = createInboundEvent('prestashop', 'order');
-      event.eventType = 'order.created';
-
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-        (handler as any).mapToSyncJob(event);
-      }).toThrow(/Unsupported master objectType: order/i);
-    });
-
     it('should throw error for unmapped objectType that results in invalid job type', () => {
       const event = createInboundEvent('prestashop', 'unknown_type');
 
@@ -165,6 +156,74 @@ describe('WebhookToJobHandler', () => {
       expect(job.jobType).toBe('master.inventory.syncByExternalId');
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
       expect(job.payload.objectType).toBe('Inventory');
+    });
+  });
+
+  describe('order routing to marketplace.order.sync (#902)', () => {
+    const createOrderEvent = (eventType: string): InboundWebhookEvent => ({
+      eventId: 'evt-order-1',
+      provider: 'prestashop',
+      connectionId: '59f4129e-a827-4650-b69b-fc2302b9ecb7',
+      eventType,
+      occurredAt: '2025-01-01T12:00:00.000Z',
+      receivedAt: '2025-01-01T12:00:01.000Z',
+      objectType: 'order',
+      externalId: '4242',
+      payload: {},
+    });
+
+    const mapToJob = (event: InboundWebhookEvent): SyncJobRequest =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test: invoke private mapToSyncJob
+      (handler as any).mapToSyncJob(event) as SyncJobRequest;
+
+    it('should route order.created to marketplace.order.sync with the externalOrderId payload shape', () => {
+      const job = mapToJob(createOrderEvent('order.created'));
+
+      expect(job).toMatchObject({
+        jobType: 'marketplace.order.sync',
+        connectionId: '59f4129e-a827-4650-b69b-fc2302b9ecb7',
+        payload: {
+          schemaVersion: 1,
+          externalOrderId: '4242',
+          sourceEventId: 'evt-order-1',
+          eventType: 'created',
+        },
+        // idempotency key shape pinned so a future payload refactor can't drift it
+        idempotencyKey: 'prestashop:59f4129e-a827-4650-b69b-fc2302b9ecb7:evt-order-1',
+      });
+      expect(JobTypeValues).toContain(job.jobType);
+    });
+
+    it('should map order.status_changed to the "updated" feed event type', () => {
+      const job = mapToJob(createOrderEvent('order.status_changed'));
+
+      expect(job.jobType).toBe('marketplace.order.sync');
+      expect(job.payload.eventType).toBe('updated');
+    });
+
+    it('should default an unrecognized order event type to "updated"', () => {
+      const job = mapToJob(createOrderEvent('order.refunded'));
+
+      expect(job.payload.eventType).toBe('updated');
+    });
+
+    it('should not emit the generic master payload shape (externalId/objectType) for orders', () => {
+      const job = mapToJob(createOrderEvent('order.created'));
+
+      expect(job.payload.externalOrderId).toBe('4242');
+      expect(job.payload.externalId).toBeUndefined();
+      expect(job.payload.objectType).toBeUndefined();
+    });
+
+    it('should route orders provider-agnostically (objectType=order regardless of provider)', () => {
+      const event = createOrderEvent('order.created');
+      event.provider = 'shopify';
+      const job = mapToJob(event);
+
+      expect(job.jobType).toBe('marketplace.order.sync');
+      expect(job.idempotencyKey).toBe(
+        'shopify:59f4129e-a827-4650-b69b-fc2302b9ecb7:evt-order-1'
+      );
     });
   });
 

--- a/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
+++ b/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
@@ -14,8 +14,13 @@ import { RedisClientType } from 'redis';
 import { JobEnqueuePort } from '@openlinker/core/sync';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import type { EventEnvelope, InboundWebhookEvent } from '@openlinker/core/events';
-import type { SyncJobRequest, JobType } from '@openlinker/core/sync';
+import type {
+  SyncJobRequest,
+  JobType,
+  MarketplaceOrderSyncPayloadV1,
+} from '@openlinker/core/sync';
 import { JobTypeValues } from '@openlinker/core/sync';
+import type { OrderFeedEventType } from '@openlinker/core/orders';
 import { Logger } from '@openlinker/shared/logging';
 import type { WebhookDeliveryUpsertInput } from '@openlinker/core/webhooks';
 import {
@@ -350,6 +355,31 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
     // rather than provider-specific terminology (e.g., "stock" -> "Stock")
     const normalizedCanonicalObjectType = this.normalizeObjectType(canonicalObjectType);
 
+    // Order events route onto the same `marketplace.order.sync` job the poller
+    // uses — push and poll converge on one pull path (idempotent on the internal
+    // order id; concurrent triggers are serialized by the per-order create lock).
+    //
+    // Provider-agnostic by design: keyed on objectType, not provider, so any
+    // marketplace emitting an `order` webhook routes here (today only PrestaShop
+    // does). The payload intentionally uses the poller's `externalOrderId` shape
+    // (MarketplaceOrderSyncPayloadV1), not the generic `externalId` master shape.
+    if (canonicalObjectType.toLowerCase() === 'order') {
+      return {
+        jobType: this.validateJobType('marketplace.order.sync'),
+        connectionId: event.connectionId,
+        // Inline literal (not a typed const) so it stays assignable to the
+        // payload's `Record<string, unknown>`; `satisfies` still shape-checks it.
+        payload: {
+          schemaVersion: 1,
+          externalOrderId: event.externalId,
+          sourceEventId: event.eventId,
+          eventType: this.mapOrderFeedEventType(event.eventType),
+          occurredAt: event.occurredAt,
+        } satisfies MarketplaceOrderSyncPayloadV1,
+        idempotencyKey: `${event.provider}:${event.connectionId}:${event.eventId}`,
+      };
+    }
+
     // Build job type: master.{canonicalObjectType}.syncByExternalId for master systems (e.g., PrestaShop)
     // (Option B: job taxonomy is integration-agnostic.)
     const normalizedProvider = event.provider.toLowerCase();
@@ -386,6 +416,28 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
       },
       idempotencyKey,
     };
+  }
+
+  /**
+   * Map an inbound webhook event type to the poller's `OrderFeedEventType`
+   * vocabulary, so push and poll express order events in one language.
+   *
+   * Webhook event types arrive in dotted form (e.g. PrestaShop emits
+   * `order.created` / `order.status_changed`). `OrderFeedEventType` has no
+   * `status_changed` token, so a status change maps to `updated`. Any
+   * unrecognized order event falls back to `updated` — a safe re-pull; the
+   * field is an advisory hint, not a routing key (every order event routes to
+   * the same `marketplace.order.sync` job).
+   */
+  private mapOrderFeedEventType(webhookEventType: string): OrderFeedEventType {
+    switch (webhookEventType) {
+      case 'order.created':
+        return 'created';
+      case 'order.status_changed':
+        return 'updated';
+      default:
+        return 'updated';
+    }
   }
 
   /**

--- a/docs/plans/implementation-plan-902-webhook-order-ingestion.md
+++ b/docs/plans/implementation-plan-902-webhook-order-ingestion.md
@@ -1,0 +1,151 @@
+# Implementation Plan: Ingest PrestaShop order webhooks via the unified `marketplace.order.sync` job (#902)
+
+**Date**: 2026-05-30
+**Status**: Ready for Review
+**Estimated Effort**: ~half day
+**Issue**: #902 (Phase 1 of epic #900). Prerequisite #906 (lock-guarded idempotent create) is **merged**.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Stop dead-lettering PrestaShop order webhooks. Route `order.created` / `order.status_changed` onto the **existing** `marketplace.order.sync` job so they ingest via the same pull path the poller uses.
+
+**Context**: The PrestaShop OL module already emits order webhooks (enabled by default); they reach `events.inbound.webhooks` and then `WebhookToJobHandler.mapToSyncJob`, which only allows `['product', 'inventory']` for `prestashop` and throws `Unsupported master objectType: order` → DLQ. `OrderIngestionService.syncOrderFromSource` (called by the `marketplace.order.sync` worker handler) already does the full hydrate→resolve→persist→route, and #906 made the destination create concurrency-safe — so webhook+poll convergence is now safe.
+
+**Classification**: Interface (the `apps/api` webhook→job translation layer). No CORE/domain change, no new job type, no schema, no module edits.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- Accept `order` from `prestashop` in `WebhookToJobHandler` and route it to the **existing** `marketplace.order.sync` job (NOT a new `master.order.*`).
+- Build the order job payload in the shape `MarketplaceOrderSyncHandler` consumes (`externalOrderId`, `sourceEventId`, `eventType`, `occurredAt`) — not the generic `externalId` shape.
+- Normalize the webhook event type into the poller's `OrderFeedEventType` vocabulary so push and poll speak one language.
+- Unit tests on the new mapping branch + regression on the untouched `stock`/`product` paths.
+
+### Out of Scope (later phases of #900)
+- Removing `isMasterProvider` / `mapObjectType` and the dispatcher refactor → **#903** (Phase 2).
+- PS order-poll reconciliation cron → **#904** (Phase 3).
+- Any new job type, `OrderRef`/contract change, schema, or PS-module change.
+
+### Constraints
+- Reuse `marketplace.order.sync` — do **not** introduce `master.order.syncByExternalId` (keeps the taxonomy unified so #903 has nothing to undo, per the epic's key constraint).
+- No regression to the existing `stock`/`product` routing.
+
+---
+
+## 3. Architecture Mapping
+
+**Target layer**: Interface — `apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts` (one new branch + one private helper). Downstream worker handler + core service are unchanged.
+
+**Reused (unchanged)**:
+- `MarketplaceOrderSyncHandler` (`apps/worker`) — reads `payload.externalOrderId`, calls `OrderIngestionService.syncOrderFromSource(connectionId, externalOrderId, sourceEventId)`.
+- `MarketplaceOrderSyncPayloadV1` (`@openlinker/core/sync`) — `{ schemaVersion, externalOrderId, sourceEventId?, eventKey?, occurredAt?, eventType?: OrderFeedEventType }`.
+- `OrderFeedEventTypeValues = ['created','updated','cancelled','paid']` (`@openlinker/core/orders`).
+- `marketplace.order.sync` is already in `JobTypeValues` — no edit.
+
+**Grounded current state** (`webhook-to-job.handler.ts:343-389`): the master branch builds `master.{type}.syncByExternalId` with `payload.externalId`; `order` hits the `['product','inventory']` guard (line 359) and throws → DLQ (the bug). `InboundWebhookEvent` carries `eventType` (`'order.created'` post-prefix-strip), `objectType` (`'order'`), `externalId`, `eventId`, `occurredAt`, `connectionId`.
+
+---
+
+## 4. Questions & Assumptions
+
+- **A1** *(confirmed — see §4a)*: `event.eventType` arrives as the **dotted** form `order.created` / `order.status_changed`; map → `created` / `updated`. Unknown/missing → default `updated` (safe: a re-pull). `OrderFeedEventType` has no `status_changed`, so `updated` is the correct existing token. The helper matches the dotted literals exactly.
+- **A2**: Both order event types map to the **same** `marketplace.order.sync` job (both re-pull current state; idempotent on internal order id + #906 lock). No special handling for status changes in this phase.
+- **A3**: `sourceEventId = event.eventId` (traceability; poller uses `eventKey` — both opaque source-event ids). Idempotency key stays the handler's existing `${provider}:${connectionId}:${eventId}`.
+- **A4**: The order branch returns **before** the master-objectType guard, so `mapObjectType` / the guard / the generic master path stay untouched.
+
+---
+
+## 4a. Source Verification (completed 2026-05-30)
+
+All four assumptions verified against `main` (with #906) before implementation — no surprises:
+
+| Assumption | Confirmed from source |
+|---|---|
+| Payload shape | `MarketplaceOrderSyncPayloadV1` = `{ schemaVersion: 1; externalOrderId: string; sourceEventId?; eventKey?; occurredAt?; eventType?: OrderFeedEventType }` — `libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts:19`. The `satisfies` will compile. |
+| Worker reads `externalOrderId` | `marketplace-order-sync.handler.ts:69` hard-fails if `externalOrderId` is missing/non-string; passes `payload.externalOrderId` + `payload.sourceEventId` to `syncOrderFromSource` (`:40-44`). |
+| `marketplace.order.sync` ∈ `JobTypeValues` | `libs/core/src/sync/domain/types/sync-job.types.ts:19`. |
+| `OrderFeedEventType` tokens | `['created','updated','cancelled','paid']` — `libs/core/src/orders/domain/types/order-feed.types.ts:20`. No `status_changed`. |
+| `eventType` literal + `objectType` | PS module emits `eventType: 'order.created'` (`openlinker.php:1277`) / `'order.status_changed'` (`:1372`), `objectType: 'order'` (`:1278`), `externalId: orderId` (`:1279`). `webhook.service.ts:117` sets `objectType` from `request.object.type` (not split from eventType), so the branch keys cleanly on `objectType === 'order'`. |
+
+---
+
+## 5. Proposed Implementation Plan
+
+### Phase 1 — order routing branch
+1. **`mapOrderFeedEventType(webhookEventType: string): OrderFeedEventType`** (private helper) — `'order.created' → 'created'`, `'order.status_changed' → 'updated'`, default `'updated'`. Import `type OrderFeedEventType` (+ `OrderFeedEventTypeValues` if a guard is wanted) from `@openlinker/core/orders` and `type MarketplaceOrderSyncPayloadV1` from `@openlinker/core/sync`.
+2. **Early branch in `mapToSyncJob`** (before the `isMasterProvider` guard): when `canonicalObjectType.toLowerCase() === 'order'`, return
+   ```ts
+   {
+     jobType: this.validateJobType('marketplace.order.sync'),
+     connectionId: event.connectionId,
+     payload: {
+       schemaVersion: 1,
+       externalOrderId: event.externalId,
+       sourceEventId: event.eventId,
+       eventType: this.mapOrderFeedEventType(event.eventType),
+       occurredAt: event.occurredAt,
+     } satisfies MarketplaceOrderSyncPayloadV1,
+     idempotencyKey: `${event.provider}:${event.connectionId}:${event.eventId}`,
+   }
+   ```
+   **Two code comments** to add: (a) the order job intentionally uses the poller's `externalOrderId` shape (vs the generic `externalId` master branch); (b) the branch is **provider-agnostic by design** — keyed on `objectType === 'order'`, not `provider`, so any future marketplace emitting an `order` webhook routes to the neutral `marketplace.order.sync` job (today only PrestaShop emits one). This is intentional, aligning with the neutral job name + ADR-015 direction — not an accidentally-broad match.
+
+### Phase 2 — tests
+3. `webhook-to-job.handler.spec.ts`:
+   - order.created → `marketplace.order.sync`, `payload.externalOrderId === event.externalId`, `eventType === 'created'`, **and assert the idempotency key equals `${provider}:${connectionId}:${eventId}`** (so a future order-payload refactor can't silently drift the key).
+   - order.status_changed → `eventType === 'updated'`.
+   - regression: stock.changed → `master.inventory.syncByExternalId` with `payload.externalId` (untouched).
+   - regression: an unsupported `prestashop` objectType (e.g. `category`) still throws (master guard intact).
+
+### Phase 3 — quality gate
+4. `pnpm lint && pnpm type-check && pnpm test`.
+
+### Integration note
+No int-spec added: the dead-letter→ingest path is covered at the mapping layer by unit tests; an end-to-end webhook→job→ingest int-spec would mostly exercise the (already-tested) downstream `marketplace.order.sync` path. (The webhook-ingestion int-spec harness exists if a vertical slice is later wanted.) **PR-body note**: state plainly that "no DLQ" / "order webhook ingests" is proven at the **unit-mapping** level this phase, not end-to-end — so reviewers don't read it as a full E2E guarantee.
+
+---
+
+## 6. Alternatives Considered
+
+- **`master.order.syncByExternalId` + add `order` to the master allow-list** — rejected: a third order-job taxonomy the poller doesn't use; #903 would migrate off it. Reusing `marketplace.order.sync` keeps the quick win and the long-term target pointing the same way (epic key constraint).
+- **Wait for #903's translator** — rejected: delays closing the live dead-letter bug; the branch is a clean delete during #903.
+
+---
+
+## 7. Validation & Risks
+
+- **Field-name mismatch** (the main trap): the generic branch emits `externalId`; `MarketplaceOrderSyncHandler` needs `externalOrderId`. Mitigated by the dedicated order branch typed as `MarketplaceOrderSyncPayloadV1`; unit-asserted. **Verified resolved** (§4a): worker hard-fails on missing `externalOrderId` (`marketplace-order-sync.handler.ts:69`); the typed branch supplies it.
+- **Vocabulary gap**: `OrderFeedEventType` has no `status_changed` → map to `updated`; documented + tested. **Verified** (§4a): eventType arrives dotted (`order.status_changed`), so the helper's literal match is correct.
+- **Idempotency / double-ingest**: webhook + poll convergence is safe — #906 lock + PrestaShop adapter create-or-skip. (Webhook dedup gate + job idempotency key still apply per-trigger.)
+- **Backward compatibility**: additive branch; product/inventory routing, payload shapes, job types, schema all unchanged.
+
+---
+
+## 8. Testing Strategy & Acceptance Criteria
+
+- **Unit**: the four cases in §5.3 (mock `REDIS_CLIENT`, `JOB_ENQUEUE_TOKEN`, `WEBHOOK_DELIVERY_REPOSITORY_TOKEN` per the existing spec).
+- **Acceptance**:
+  - [ ] PrestaShop `order.created` / `order.status_changed` → enqueued `marketplace.order.sync` (no DLQ).
+  - [ ] Payload uses `externalOrderId` + a valid `OrderFeedEventType`.
+  - [ ] No new order job type; poller + webhook share `marketplace.order.sync`.
+  - [ ] `stock`/`product` routing unchanged (regression green).
+  - [ ] `pnpm lint && type-check && test` green.
+
+---
+
+## 9. Alignment Checklist
+- [x] Interface-layer only; no CORE/domain/module change
+- [x] Reuses existing job + payload type (no new taxonomy)
+- [x] Idempotency considered (#906 lock + dedup)
+- [x] Error handling (genuinely unmappable events still DLQ)
+- [x] Tests + regression guards
+- [x] Plan saved as markdown
+
+---
+
+## Related
+- Epic #900; ADR-015 § Migration path (Phase 1). Unblocked by #906. Next: #903 (translator/policy), #904 (poll backstop).


### PR DESCRIPTION
## What & why

PrestaShop order webhooks were being **dead-lettered**: the PS OL module emits `order.created` / `order.status_changed` (enabled by default), they reach `events.inbound.webhooks`, but `WebhookToJobHandler.mapToSyncJob` only allowed `['product','inventory']` for `prestashop` and threw `Unsupported master objectType: order` → DLQ. This PR routes them onto the **existing** `marketplace.order.sync` job, so order webhooks ingest via the same pull path the poller uses.

Phase 1 of epic #900 ([ADR-015](https://github.com/openlinker-project/openlinker/blob/main/docs/architecture/adrs/015-inbound-event-routing-capability-translated.md)). Unblocked by #906 (merged).

## How it works

A new branch in `mapToSyncJob`, placed **before** the master-objectType guard:

- **Keyed on `objectType === 'order'`, provider-agnostic** — any marketplace emitting an `order` webhook routes here (today only PrestaShop), aligning with the neutral job name + ADR-015 direction.
- Builds the poller's **`MarketplaceOrderSyncPayloadV1`** shape (`externalOrderId`, `sourceEventId`, `occurredAt`, `eventType`) — *not* the generic `externalId` master shape the worker handler can't read. Typed via `satisfies` so the contract is compile-checked.
- `mapOrderFeedEventType` maps the dotted webhook event type into the `OrderFeedEventType` vocabulary: `order.created → created`, `order.status_changed → updated` (no `status_changed` token exists), unknown → `updated` (safe re-pull; the field is an advisory hint, not a routing key).

Push and poll converge on one idempotent pull path. Concurrent webhook+poll triggers for the same order are serialized by the per-order create lock from #906 — the webhook `eventId` and poll `eventKey` differ, so the job idempotency key alone does **not** dedupe across triggers; #906's lock is the load-bearing guard (by design).

## Scope

Interface-layer only — **no** new job type, **no** payload/contract change, **no** module/schema/PS-module edits. All four pre-coding assumptions were verified against source (payload shape, worker field read, `JobTypeValues` membership, the literal `eventType`/`objectType` strings) — see the plan doc §4a.

## Tests

`webhook-to-job.handler.spec.ts` — 5 new order-routing cases (created / status_changed→updated / unknown→updated default / payload-shape-not-master / provider-agnostic incl. idempotency-key shape). The obsolete "order throws" test (asserted the old DLQ behavior) is replaced. product/inventory routing regression intact. **32 suite tests + 449 API unit tests green; `pnpm lint` + `type-check` + `check:invariants` clean.**

**Verification scope note:** "order webhooks ingest / no DLQ" is proven this phase at the **unit-mapping** level. The downstream `marketplace.order.sync` → `OrderIngestionService` path is already separately tested; no new end-to-end webhook→job→ingest int-spec was added (the mapping is the only new logic).

## Follow-ups (epic #900)
- #903 — Phase 2: per-plugin `WebhookEventTranslator` + core routing policy; deletes the `provider === 'prestashop'` switch this PR extends.
- #904 — Phase 3: PS order-poll reconciliation backstop.

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)