### PR TITLE
test(worker): restore worker integration suite to green (#910)

### DIFF
--- a/apps/worker/test/integration/allegro-cursor-persistence.int-spec.ts
+++ b/apps/worker/test/integration/allegro-cursor-persistence.int-spec.ts
@@ -98,7 +98,7 @@ describe('Allegro Cursor Persistence Integration', () => {
       const { OrdersPollHandler } = require('../../src/sync/handlers/orders-poll.handler');
       const pollHandler = harness.get(OrdersPollHandler);
       await pollHandler.execute(persistedJob);
-      await jobRepository.markSucceeded(persistedJob.id);
+      await jobRepository.markSucceeded(persistedJob.id, 'ok');
 
       // Verify cursor was set
       const firstCursor = await cursorRepository.get(connection.id, cursorKey);
@@ -126,7 +126,7 @@ describe('Allegro Cursor Persistence Integration', () => {
       });
 
       await pollHandler.execute(persistedJob2);
-      await jobRepository.markSucceeded(persistedJob2.id);
+      await jobRepository.markSucceeded(persistedJob2.id, 'ok');
 
       // Verify cursor advanced
       const secondCursor = await cursorRepository.get(connection.id, cursorKey);
@@ -190,7 +190,7 @@ describe('Allegro Cursor Persistence Integration', () => {
       const { OrdersPollHandler } = require('../../src/sync/handlers/orders-poll.handler');
       const pollHandler = harness.get(OrdersPollHandler);
       await pollHandler.execute(persistedJob1);
-      await jobRepository.markSucceeded(persistedJob1.id);
+      await jobRepository.markSucceeded(persistedJob1.id, 'ok');
 
       const cursor1 = await cursorRepository.get(connection1.id, cursorKey);
 
@@ -203,7 +203,7 @@ describe('Allegro Cursor Persistence Integration', () => {
       });
 
       await pollHandler.execute(persistedJob2);
-      await jobRepository.markSucceeded(persistedJob2.id);
+      await jobRepository.markSucceeded(persistedJob2.id, 'ok');
 
       const cursor2 = await cursorRepository.get(connection2.id, cursorKey);
 

--- a/apps/worker/test/integration/allegro-offer-quantity-update-e2e.int-spec.ts
+++ b/apps/worker/test/integration/allegro-offer-quantity-update-e2e.int-spec.ts
@@ -109,7 +109,7 @@ describe('Allegro Offer Quantity Update End-to-End Integration', () => {
       await handler.execute(persistedJob);
 
       // Mark job as succeeded
-      await jobRepository.markSucceeded(persistedJob.id);
+      await jobRepository.markSucceeded(persistedJob.id, 'ok');
 
       // 5. Verify command was called on adapter
       expect(mockMarketplaceAdapter.updateOfferQuantity).toHaveBeenCalledWith({

--- a/apps/worker/test/integration/allegro-order-sync-e2e.int-spec.ts
+++ b/apps/worker/test/integration/allegro-order-sync-e2e.int-spec.ts
@@ -32,6 +32,7 @@ import {
   IIdentifierMappingService,
   IDENTIFIER_MAPPING_SERVICE_TOKEN,
 } from '@openlinker/core/identifier-mapping';
+import { ProductOrmEntity, ProductVariantOrmEntity } from '@openlinker/core/products/orm-entities';
 import { DataSource } from 'typeorm';
 import { randomUUID } from 'crypto';
 
@@ -90,6 +91,24 @@ describe('Allegro Order Sync End-to-End Integration', () => {
         }
         throw new Error(`Unsupported capability: ${capability}`);
       });
+
+    // Order routing resolves destinations via listCapabilityAdapters (one
+    // OrderProcessorManager destination, distinct from the Allegro source).
+    jest
+      .spyOn(integrationsService, 'listCapabilityAdapters')
+      .mockImplementation(async (filters: { capability: string }) => {
+        if (filters.capability === 'OrderProcessorManager') {
+          return [
+            {
+              connectionId: 'dest-prestashop-1',
+              connection: {} as any,
+              adapter: mockOrderProcessor as any,
+              metadata: {} as any,
+            },
+          ];
+        }
+        return [];
+      });
   });
 
   afterEach(async () => {
@@ -110,8 +129,20 @@ describe('Allegro Order Sync End-to-End Integration', () => {
         adapterKey: 'allegro.publicapi.v1',
       });
 
-      // Seed offer mapping required by IncomingOrderItemRef(type='offer') resolution
-      await identifierMapping.createMapping('Offer', 'offer-1', connection.id, 'ol_product_test_1');
+      // Seed a product + variant and the offer→variant mapping required by
+      // IncomingOrderItemRef(type='offer') resolution. OrderItemRefResolver maps
+      // the offer external id to an internal *variant* id, then loads that variant.
+      const product = new ProductOrmEntity();
+      product.id = 'ol_product_test_1';
+      product.name = 'Test Product';
+      await dataSource.getRepository(ProductOrmEntity).save(product);
+
+      const variant = new ProductVariantOrmEntity();
+      variant.id = 'ol_variant_test_1';
+      variant.productId = product.id;
+      await dataSource.getRepository(ProductVariantOrmEntity).save(variant);
+
+      await identifierMapping.createMapping('Offer', 'offer-1', connection.id, variant.id);
 
       // 2. Enqueue poll job to Redis Stream
       const pollJobRequest: SyncJobRequest = {
@@ -147,7 +178,7 @@ describe('Allegro Order Sync End-to-End Integration', () => {
       await pollHandler.execute(persistedPollJob);
 
       // Mark poll job as succeeded
-      await jobRepository.markSucceeded(persistedPollJob.id);
+      await jobRepository.markSucceeded(persistedPollJob.id, 'ok');
 
       // 5. Verify order sync jobs were enqueued to the queue (published)
       // Note: the poll handler enqueues via SyncJobQueueService -> JobEnqueuePort.
@@ -180,7 +211,7 @@ describe('Allegro Order Sync End-to-End Integration', () => {
       await orderSyncHandler.execute(orderSyncPersisted);
 
       // Mark order sync job as succeeded
-      await jobRepository.markSucceeded(orderSyncPersisted.id);
+      await jobRepository.markSucceeded(orderSyncPersisted.id, 'ok');
 
       // 7. Verify order was routed to OrderProcessorManager
       expect(mockOrderProcessor.createOrder).toHaveBeenCalled();
@@ -225,7 +256,7 @@ describe('Allegro Order Sync End-to-End Integration', () => {
       const { OrdersPollHandler } = require('../../src/sync/handlers/orders-poll.handler');
       const pollHandler = harness.get(OrdersPollHandler);
       await pollHandler.execute(persistedPollJob);
-      await jobRepository.markSucceeded(persistedPollJob.id);
+      await jobRepository.markSucceeded(persistedPollJob.id, 'ok');
 
       // Get first cursor
       const firstCursor = await cursorRepository.get(connection.id, 'allegro.orders.lastEventId');
@@ -252,7 +283,7 @@ describe('Allegro Order Sync End-to-End Integration', () => {
       });
 
       await pollHandler.execute(persistedPollJob2);
-      await jobRepository.markSucceeded(persistedPollJob2.id);
+      await jobRepository.markSucceeded(persistedPollJob2.id, 'ok');
 
       // Verify cursor advanced
       const secondCursor = await cursorRepository.get(connection.id, 'allegro.orders.lastEventId');

--- a/apps/worker/test/integration/connection-reauth-flagging.int-spec.ts
+++ b/apps/worker/test/integration/connection-reauth-flagging.int-spec.ts
@@ -15,7 +15,7 @@ import { WorkerIntegrationTestHarness } from './setup';
 import { createTestConnection } from './helpers/test-connection.helper';
 import { createTestSyncJob, getSyncJobById } from './helpers/test-sync-job.helper';
 import { SyncJobRunner } from '../../src/sync/sync-job.runner';
-import { SyncJobEntity as SyncJob, SyncJobExecutionError } from '@openlinker/core/sync';
+import { SyncJobEntity as SyncJob, SyncJobExecutionError, type JobType } from '@openlinker/core/sync';
 import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
 import { CONNECTION_PORT_TOKEN } from '@openlinker/core/identifier-mapping';
 import {
@@ -42,7 +42,7 @@ describe('Connection Re-auth Flagging Integration (#819)', () => {
     await teardownTestHarness();
   });
 
-  async function runFailure(connectionId: string, cause: unknown): Promise<string> {
+  async function runFailure(connectionId: string, cause: Error): Promise<string> {
     const ormJob = await createTestSyncJob(harness.getDataSource(), {
       jobType: 'marketplace.orders.poll',
       connectionId,
@@ -52,7 +52,7 @@ describe('Connection Re-auth Flagging Integration (#819)', () => {
     });
     const job = new SyncJob(
       ormJob.id,
-      ormJob.jobType,
+      ormJob.jobType as JobType,
       connectionId,
       ormJob.payloadJson,
       'running',

--- a/apps/worker/test/integration/helpers/mock-adapters.helper.ts
+++ b/apps/worker/test/integration/helpers/mock-adapters.helper.ts
@@ -24,6 +24,7 @@ export function createMockPrestashopProductAdapter(): ProductMasterPort {
         name: 'Test Product',
         sku: 'TEST-SKU-001',
         price: 19.99,
+        currency: null,
         description: 'Test Product Description',
         images: ['http://example.com/image1.jpg', 'http://example.com/image2.jpg'],
         createdAt: new Date(),

--- a/apps/worker/test/integration/job-intake-execution.int-spec.ts
+++ b/apps/worker/test/integration/job-intake-execution.int-spec.ts
@@ -221,7 +221,7 @@ describe('Job Intake → Execution Integration', () => {
         status: 'running',
       });
 
-      await jobRepository.markSucceeded(job.id);
+      await jobRepository.markSucceeded(job.id, 'ok');
 
       const updatedJob = await getSyncJobById(harness.getDataSource(), job.id);
       expect(updatedJob?.status).toBe('succeeded');
@@ -282,7 +282,7 @@ describe('Job Intake → Execution Integration', () => {
 // Helper function to get all sync jobs (for assertions)
 async function getAllSyncJobs(dataSource: any): Promise<any[]> {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- dynamic require() needed: path computed at runtime
-  const { SyncJobOrmEntity } = require('@openlinker/core/sync');
+  const { SyncJobOrmEntity } = require('@openlinker/core/sync/orm-entities');
   return dataSource.getRepository(SyncJobOrmEntity).find({
     order: { createdAt: 'DESC' },
   });

--- a/apps/worker/test/integration/master-inventory-sync-all-e2e.int-spec.ts
+++ b/apps/worker/test/integration/master-inventory-sync-all-e2e.int-spec.ts
@@ -144,7 +144,7 @@ describe('Master Inventory Sync All End-to-End Integration', () => {
     } = require('../../src/sync/handlers/master-inventory-sync-all.handler');
     const handler = harness.get(MasterInventorySyncAllHandler);
 
-    await expect(handler.execute(outerJob)).resolves.toBeUndefined();
+    await expect(handler.execute(outerJob)).resolves.toEqual({ outcome: 'ok' });
 
     const subJobCalls = enqueueSpy.mock.calls.filter(
       ([req]) => req.jobType === 'master.inventory.syncByExternalId'

--- a/apps/worker/test/integration/product-sync-e2e.int-spec.ts
+++ b/apps/worker/test/integration/product-sync-e2e.int-spec.ts
@@ -112,7 +112,7 @@ describe('Product Sync End-to-End Integration', () => {
       await handler.execute(persistedJob);
 
       // 5. Manually mark job as succeeded (handler doesn't update status, runner does)
-      await jobRepository.markSucceeded(persistedJob.id);
+      await jobRepository.markSucceeded(persistedJob.id, 'ok');
 
       // Verify job status updated to succeeded
       const updatedJob = await getSyncJobById(dataSource, persistedJob.id);
@@ -275,7 +275,7 @@ describe('Product Sync End-to-End Integration', () => {
       await handler.execute(persistedJob);
 
       // Manually mark job as succeeded (handler doesn't update status, runner does)
-      await jobRepository.markSucceeded(persistedJob.id);
+      await jobRepository.markSucceeded(persistedJob.id, 'ok');
 
       // Verify all fields are preserved
       const productRepository = dataSource.getRepository(ProductOrmEntity);

--- a/apps/worker/test/jest-integration.cjs
+++ b/apps/worker/test/jest-integration.cjs
@@ -15,6 +15,8 @@ module.exports = {
     '^@openlinker/core/(.*)$': path.resolve(__dirname, '../../../libs/core/src/$1'),
     '^@openlinker/shared$': path.resolve(__dirname, '../../../libs/shared/src/index.ts'),
     '^@openlinker/shared/(.*)$': path.resolve(__dirname, '../../../libs/shared/src/$1'),
+    '^@openlinker/plugin-sdk$': path.resolve(__dirname, '../../../libs/plugin-sdk/src/index.ts'),
+    '^@openlinker/plugin-sdk/(.*)$': path.resolve(__dirname, '../../../libs/plugin-sdk/src/$1'),
     '^@openlinker/integrations-allegro$': path.resolve(
       __dirname,
       '../../../libs/integrations/allegro/src/index.ts',
@@ -30,6 +32,14 @@ module.exports = {
     '^@openlinker/integrations-prestashop/(.*)$': path.resolve(
       __dirname,
       '../../../libs/integrations/prestashop/src/$1',
+    ),
+    '^@openlinker/integrations-ai$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/ai/src/index.ts',
+    ),
+    '^@openlinker/integrations-ai/(.*)$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/ai/src/$1',
     ),
   },
 };

--- a/docs/plans/implementation-plan-worker-marksucceeded-two-arg.md
+++ b/docs/plans/implementation-plan-worker-marksucceeded-two-arg.md
@@ -1,0 +1,63 @@
+# Implementation Plan — Restore the worker integration suite to green (#910)
+
+## 1. Goal & scope
+
+**Issue #910** reported that `allegro-order-sync-e2e.int-spec.ts` fails to compile because it
+calls `SyncJobRepositoryPort.markSucceeded(id)` one-arg, against the two-arg
+`markSucceeded(id, outcome)` contract from the #400 status/outcome split. The issue's "Notes"
+asked for an audit of other stale callers.
+
+The audit revealed the breakage was broader: the entire worker integration suite had not been
+run for some time (it is not yet in CI — see **#786**) and had accumulated several independent
+forms of rot. Scope was expanded (with sign-off) to **restore the full worker integration suite
+to green**.
+
+**Layer:** DX / Testing. Test files + the worker integration jest config only. No production
+code, no schema, no migration, no CORE/Integration boundary changes.
+
+## 2. What was fixed
+
+**A. `markSucceeded` two-arg contract (the #910 core)** — appended `'ok'` (`JobOutcome`) to all
+**12** one-arg call sites across 5 specs (`allegro-order-sync-e2e`, `allegro-cursor-persistence`,
+`product-sync-e2e`, `allegro-offer-quantity-update-e2e`, `job-intake-execution`). All are
+success-path completions; `'ok'` matches the existing repo unit-test usage.
+
+**B. Compile blockers**
+- `helpers/mock-adapters.helper.ts` — `Product` literal missing the required `currency` field
+  (added `currency: null`), fallout from #895. Blocked `product-sync-e2e` compile.
+- `connection-reauth-flagging.int-spec.ts` — `runFailure`'s `cause` typed `unknown` but passed to
+  `SyncJobExecutionError(cause?: Error)` (both call sites pass Allegro exception instances →
+  `cause: Error`); and `ormJob.jobType` (`string`) passed to `SyncJob(jobType: JobType)` →
+  `ormJob.jobType as JobType`.
+
+**C. Boot/module-resolution blockers** — `test/jest-integration.cjs` `moduleNameMapper` was
+missing two workspace packages reached through the worker module graph (every other workspace
+lib is mapped to its `src`; these were simply omitted). Added `@openlinker/plugin-sdk` (#593) and
+`@openlinker/integrations-ai` (#737).
+
+**D. Behavioral fixture drift** (specs predated contract evolution)
+- `allegro-order-sync-e2e` — `OrderItemRefResolver` now maps an `offer` ref to an internal
+  *variant* id then loads that variant; the spec seeded only an identifier mapping. Now seeds a
+  real `Product` + `ProductVariant` and maps `offer-1 → variant.id`. Also: order routing resolves
+  destinations via `IntegrationsService.listCapabilityAdapters` (not `getCapabilityAdapter`), so
+  the spec now stubs `listCapabilityAdapters` to return one `OrderProcessorManager` destination
+  distinct from the Allegro source.
+- `master-inventory-sync-all-e2e` — handler now returns a `SyncJobHandlerResult` (#400); assertion
+  changed from `.resolves.toBeUndefined()` to `.resolves.toEqual({ outcome: 'ok' })`.
+- `job-intake-execution` — `getAllSyncJobs` required `SyncJobOrmEntity` from the main `@openlinker/core/sync`
+  barrel (undefined → `EntityMetadataNotFoundError`); ORM entities live on the
+  `@openlinker/core/sync/orm-entities` host-only sub-barrel (#594) — corrected the `require`.
+
+## 3. Verification
+
+- `pnpm lint` + `check:invariants` — clean (cross-context walker covers `apps/worker/test`).
+- `pnpm type-check` — clean across all packages; a throwaway `src + test` tsconfig confirms every
+  worker int-spec type-checks.
+- `pnpm test` — all unit suites pass (core 965, api 445, worker 154, allegro 497, …).
+- `pnpm --filter @openlinker/worker test:integration` — **9/9 suites, 23/23 tests pass** (was
+  uncompilable on `main`).
+
+## 4. Out of scope
+
+Wiring the worker integration suite into CI (**#786**) — this PR makes it green locally; running
+it in CI is that issue's job.


### PR DESCRIPTION
## What & why

#910 reported that `allegro-order-sync-e2e.int-spec.ts` fails to **compile** on `main` — it calls `SyncJobRepositoryPort.markSucceeded(id)` one-arg, against the two-arg `markSucceeded(id, outcome)` contract from the #400 status/outcome split. The issue's "Notes" asked for an audit of other stale callers.

**Scope note (expanded with sign-off).** The audit showed the breakage was broader: the worker integration suite is not yet wired into CI (**#786**) and hadn't been run for some time, so it had accumulated several *independent* forms of rot. This PR restores the **whole worker integration suite to green** rather than just the one named call.

## Changes (test-only — no production code, schema, or boundary changes)

**A. `markSucceeded` two-arg contract (the #910 core)** — appended `'ok'` (`JobOutcome`) to all **12** one-arg call sites across 5 specs (`allegro-order-sync-e2e`, `allegro-cursor-persistence`, `product-sync-e2e`, `allegro-offer-quantity-update-e2e`, `job-intake-execution`). All are success-path completions; `'ok'` matches the existing repo unit-test usage.

**B. Compile blockers**
- `helpers/mock-adapters.helper.ts` — `Product` literal missing required `currency` (added `currency: null`; #895 fallout). Blocked `product-sync-e2e`.
- `connection-reauth-flagging.int-spec.ts` — `runFailure(cause)` typed `unknown` but passed to `SyncJobExecutionError(cause?: Error)` (both call sites pass Allegro exception instances → `cause: Error`); `ormJob.jobType` (`string`) passed to `SyncJob(jobType: JobType)` → `ormJob.jobType as JobType`.

**C. Boot / module-resolution blockers** — `test/jest-integration.cjs` `moduleNameMapper` was missing two workspace packages reached through the worker module graph (every other workspace lib is mapped to `src`; these were simply omitted): added `@openlinker/plugin-sdk` (#593) and `@openlinker/integrations-ai` (#737).

**D. Behavioral fixture drift** (specs predated contract evolution)
- `allegro-order-sync-e2e` — `OrderItemRefResolver` now maps an `offer` ref to an internal *variant* id then loads that variant, so the spec seeds a real `Product` + `ProductVariant` and maps `offer-1 → variant.id`. Order routing resolves destinations via `IntegrationsService.listCapabilityAdapters` (not `getCapabilityAdapter`), so the spec now stubs `listCapabilityAdapters` to return one `OrderProcessorManager` destination distinct from the Allegro source.
- `master-inventory-sync-all-e2e` — handler returns a `SyncJobHandlerResult` (#400); assertion changed from `.resolves.toBeUndefined()` to `.resolves.toEqual({ outcome: 'ok' })`.
- `job-intake-execution` — `getAllSyncJobs` required `SyncJobOrmEntity` from the main barrel (→ `undefined` → `EntityMetadataNotFoundError`); ORM entities live on the `@openlinker/core/sync/orm-entities` host-only sub-barrel (#594) — corrected the `require`.

## How to test

```bash
pnpm --filter @openlinker/worker test:integration
```

## Verification
- `pnpm lint` + `check:invariants` — clean (cross-context walker covers `apps/worker/test`).
- `pnpm type-check` — clean across all packages (a throwaway `src + test` tsconfig confirms every worker int-spec type-checks).
- `pnpm test` — all unit suites pass (core 965, api 445, worker 154, allegro 497, …).
- **`pnpm --filter @openlinker/worker test:integration` — 9/9 suites, 23/23 tests pass** (was uncompilable on `main`).

## Out of scope / follow-up
Wiring the worker integration suite into CI is tracked by **#786** — this PR makes it green locally; running it in CI is that issue's job.

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)