### PR TITLE
ci(worker): run worker integration tests in CI (#786)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
 
   test-integration:
     name: Integration Tests
-    timeout-minutes: 30
+    # Budget covers two sequential suites (API + worker) plus install + libs build.
+    timeout-minutes: 45
     # runs-on: ubuntu-latest
     runs-on: self-hosted
     # Run on push to main (after merge) and on PRs to catch issues early
@@ -100,6 +101,12 @@ jobs:
         run: pnpm --filter @openlinker/api test:integration
         timeout-minutes: 15 # Integration tests can take longer due to container startup
         # Note: Docker is pre-installed on GitHub Actions runners, required for Testcontainers
+      - name: Run worker integration tests
+        # Runs even if the API suite failed (!cancelled) so a worker-specific
+        # AppModule DI regression is reported independently — the point of #786.
+        if: ${{ !cancelled() }}
+        run: pnpm --filter @openlinker/worker test:integration
+        timeout-minutes: 10 # Worker suite runs ~80s locally; cap guards a hung container boot
 
   test-php:
     name: PHP Unit Tests

--- a/apps/worker/test/jest-integration.cjs
+++ b/apps/worker/test/jest-integration.cjs
@@ -10,6 +10,16 @@ module.exports = {
   },
   maxWorkers: 1,
   testTimeout: 120000,
+  // Mirrors apps/api: the worker AppModule boots long-lived handles (scheduler
+  // crons, JobIntake consumption loops) that onModuleDestroy stops but may not
+  // fully drain; forceExit is the safety net against a CI hang after tests pass.
+  forceExit: true,
+  // Start/stop the Postgres + Redis Testcontainers once for the whole run and
+  // export their connection env BEFORE any suite boots AppModule. Without these
+  // the harness never runs, so AppModule falls back to localhost defaults —
+  // green locally (dev stack on :5432/:6379) but ECONNREFUSED in CI (#786).
+  globalSetup: '<rootDir>/test/integration/setup-global.ts',
+  globalTeardown: '<rootDir>/test/integration/teardown.ts',
   moduleNameMapper: {
     '^@openlinker/core$': path.resolve(__dirname, '../../../libs/core/src/index.ts'),
     '^@openlinker/core/(.*)$': path.resolve(__dirname, '../../../libs/core/src/$1'),

--- a/docs/plans/implementation-plan-786-worker-int-tests-ci.md
+++ b/docs/plans/implementation-plan-786-worker-int-tests-ci.md
@@ -76,3 +76,35 @@ the existing job.
 - **Testing:** local re-run of the worker int suite is the pre-merge proxy; the authoritative
   check is the PR's own CI run.
 - **Security:** none. No secrets added (`OL_PII_HASH_SALT` already set at job level).
+
+## 6. CI-run finding — worker harness never started its Testcontainers
+
+The first CI run (the authoritative check) surfaced a **real, deterministic** failure — exactly
+what #786 exists to catch:
+
+```
+ERROR [ExceptionHandler] connect ECONNREFUSED 127.0.0.1:6379
+  at WorkerIntegrationTestHarness.setup (test/integration/setup.ts:39) → NestFactory.createApplicationContext(AppModule)
+```
+
+**Root cause:** `apps/worker/test/jest-integration.cjs` was missing `globalSetup` /
+`globalTeardown`. The worker harness is designed around them — `setup-global.ts` (globalSetup)
+calls `startHarness()` in `harness.ts`, which starts the Postgres + Redis Testcontainers and
+exports `DB_*` / `REDIS_*` env; `setup.ts` then boots `AppModule` against that env. With the
+hooks unregistered, `startHarness()` never ran, so `AppModule` fell back to localhost defaults
+(`127.0.0.1:6379` / `:5432`). That is **green locally** (the dev stack listens there) but
+`ECONNREFUSED` in CI — the classic "passes on my machine" masking. The suite had therefore never
+actually exercised its own Testcontainers.
+
+**Fix (`apps/worker/test/jest-integration.cjs`):**
+- Register `globalSetup: '<rootDir>/test/integration/setup-global.ts'` +
+  `globalTeardown: '<rootDir>/test/integration/teardown.ts'` so the containers start once per run
+  and the env is set before any suite boots `AppModule`.
+- Add `forceExit: true` (mirrors `apps/api`) — the worker `AppModule` holds long-lived handles
+  (scheduler crons, JobIntake consumption loops) that could otherwise hang the CI step until its
+  timeout after tests pass.
+
+**Verification:** ran the suite with bogus defaults
+`DB_HOST=10.255.255.1 DB_PORT=6399 REDIS_HOST=10.255.255.1 REDIS_PORT=6399` — removing the
+dev-stack fallback so only a working `globalSetup` (which overwrites the env to the container)
+can pass. Result: **9/9 suites, 23/23 tests green**, proving the containers are now actually used.

--- a/docs/plans/implementation-plan-786-worker-int-tests-ci.md
+++ b/docs/plans/implementation-plan-786-worker-int-tests-ci.md
@@ -1,0 +1,78 @@
+# Implementation Plan — Run worker integration tests in CI (#786)
+
+## 1. Understand the task
+
+**Goal:** Extend the CI `test-integration` job so it also runs the worker Testcontainers
+integration suite (`pnpm --filter @openlinker/worker test:integration`), closing the gap that
+let worker `AppModule` DI regressions ship twice (#737, #744) — CI only ran the API suite.
+
+**Layer:** DX / CI infrastructure. No application code.
+
+**Why now:** The worker integration suite was uncompilable on `main` until #913 (last session)
+restored it to green (9/9 suites, 23/23 tests). With the suite passing, #786 is unblocked.
+
+**Non-goals:**
+- No change to the worker harness, specs, or any app/lib code.
+- Not chasing CI-specific flakes inline — per AC, if the first CI run flakes, file a separate
+  stabilization issue rather than blocking the PR.
+- Not touching the self-hosted-runner debate (#557/#662) — orthogonal.
+
+## 2. Research (findings)
+
+`.github/workflows/ci.yml` `test-integration` job (lines 69–101):
+- `runs-on: self-hosted`, `needs: [test]`, `timeout-minutes: 30`, job-level
+  `env.OL_PII_HASH_SALT`.
+- Steps: checkout → pnpm/action-setup@v2 (v9) → setup-node@20 (pnpm cache) →
+  `pnpm install --frozen-lockfile` → `pnpm -r --filter "./libs/**" build` → verify core dist →
+  `pnpm --filter @openlinker/api test:integration` (`timeout-minutes: 15`).
+
+The worker suite (`apps/worker/test/jest-integration.cjs`) resolves workspace deps via
+`moduleNameMapper` to source (ts-jest), uses its own ephemeral Testcontainers (Postgres + Redis,
+random ports), and inherits the job-level `OL_PII_HASH_SALT`. Docker is available on the runner
+(the API suite already uses it). Running both suites sequentially in one job is safe (separate,
+torn-down containers).
+
+## 3. Design
+
+Add **one step** to the existing `test-integration` job, immediately after the API integration
+step. It reuses the same `pnpm install`; the libs build is already present for the API step —
+the worker suite itself resolves workspace deps via `moduleNameMapper`→source (ts-jest), so it
+does **not** depend on the dist build. The step is a real gate that fails the build on a worker
+DI regression.
+
+```yaml
+- name: Run worker integration tests
+  if: ${{ !cancelled() }}          # report worker regressions independently of the API suite
+  run: pnpm --filter @openlinker/worker test:integration
+  timeout-minutes: 10              # ~80s locally; cap guards a hung container boot
+```
+
+Budget: the job-level `timeout-minutes` is raised `30 → 45` so two sequential suites (API 15 +
+worker 10, both run under `!cancelled`) plus install + libs build can't trip an opaque job-level
+timeout.
+
+`if: ${{ !cancelled() }}` makes the worker suite run even when the API suite fails — #786 is
+specifically about catching *worker* `AppModule` DI regressions, so the two suites must report
+independently rather than the worker step being skipped behind an API failure.
+
+Rejected alternative: a separate parallel job — it would duplicate install + libs build
+(expensive on the self-hosted runner) for no real gain; the issue explicitly proposes a step in
+the existing job.
+
+## 4. Step-by-step
+
+1. `.github/workflows/ci.yml` — append the worker integration step to `test-integration` after
+   the API step (line ~101).
+
+**Acceptance criteria** (from #786):
+- `ci.yml` runs `pnpm --filter @openlinker/worker test:integration` in `test-integration`.
+- First green CI run on the PR branch confirms the worker harness boots in the runner.
+- (Local proxy for the above, since GH Actions can't run locally) `pnpm --filter
+  @openlinker/worker test:integration` passes on this branch.
+
+## 5. Validate
+
+- **Architecture:** CI-only; no boundary impact.
+- **Testing:** local re-run of the worker int suite is the pre-merge proxy; the authoritative
+  check is the PR's own CI run.
+- **Security:** none. No secrets added (`OL_PII_HASH_SALT` already set at job level).


### PR DESCRIPTION
## What & why

The CI `test-integration` job ran only `pnpm --filter @openlinker/api test:integration`, so worker `AppModule` DI regressions slipped through twice (#737, #744). The worker Testcontainers harness was uncompilable on `main` until **#913** (last PR) restored it to green (9/9 suites, 23/23 tests). With the suite passing, this wires it into CI.

## Changes (CI-config only — no application code)

- Add a **`Run worker integration tests`** step to the existing `test-integration` job, reusing the same `pnpm install` + libs build. (The worker suite resolves workspace deps via `moduleNameMapper`→source, so it doesn't depend on the dist build — the build is already there for the API step.)
- `if: ${{ !cancelled() }}` so a worker-specific DI regression is reported **independently** of the API suite rather than skipped behind an API failure — which is the entire point of #786.
- Worker step `timeout-minutes: 10` (suite runs ~80s locally; cap guards a hung Testcontainers boot). Raise the job `timeout-minutes` `30 → 45` so two sequential suites (API 15 + worker 10, both running under `!cancelled`) plus install + build can't trip an opaque job-level timeout.

A single step in the existing job (not a separate parallel job) avoids duplicating the expensive `pnpm install` + libs build on the self-hosted runner.

## How to test

```bash
pnpm --filter @openlinker/worker test:integration
```

## Verification

- `ci.yml` is valid YAML; the new step mirrors the existing API step's shape.
- Local run on this branch: **9/9 suites, 23/23 tests pass** (slowest single suite 52s cold — comfortably under the 10-min step cap).
- Authoritative check: this PR's own `test-integration` CI run is the first time the worker harness boots in the GitHub Actions runner (per AC). Per AC-3, if it reveals CI-specific flakes, I'll open a separate stabilization issue rather than block here.

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)