### PR TITLE
ci: run integration tests in parallel with unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,13 @@ jobs:
     runs-on: self-hosted
     # Run on push to main (after merge) and on PRs to catch issues early
     if: github.event_name == 'push' || github.event_name == 'pull_request'
-    needs: [test] # Only run if unit tests pass
+    # No `needs:` — this job re-installs deps + rebuilds libs itself, so it has
+    # no artifact dependency on `test`. Gating on `test` previously serialized
+    # the two longest jobs (unit ~6min, then integration ~10min), so integration
+    # only started after unit finished. Running them in parallel cuts the
+    # critical path by ~6min. Trade-off: integration spends compute even when
+    # unit tests fail on a PR — acceptable for the wall-clock win; both still
+    # gate the merge via branch protection.
     env:
       OL_PII_HASH_SALT: ${{ vars.OL_PII_HASH_SALT }}
     steps:


### PR DESCRIPTION
## What & why

The `test-integration` job gated on `needs: [test]`, which serialized the two longest CI jobs: unit **Test** (~6 min) then **Integration Tests** (~10 min). Because integration only started *after* unit finished, the critical path was ~19 min wall-clock even though the slowest single job is only ~10 min.

The integration job **re-installs deps and rebuilds libs itself** (`pnpm install` + `pnpm -r --filter "./libs/**" build` in its own steps) — it has no artifact dependency on the `test` job. The `needs: [test]` gate was a *policy* ("don't bother running integration if units fail"), not a technical necessity.

Removing it lets the two jobs run **concurrently**, cutting the critical path by ~6 min (down to roughly `max(unit, integration)`).

## Change

One job-level change in `.github/workflows/ci.yml`: drop `needs: [test]` from `test-integration` (replaced with an explanatory comment). The `if:` event guard and all steps are unchanged.

## Trade-off

Integration tests now spend runner compute even when unit tests fail on a PR. That's an acceptable cost for the wall-clock win — and both checks still gate the merge via branch protection, so the merge gate is unchanged.

## Measurement (run [26693753749](https://github.com/openlinker-project/openlinker/actions/runs/26693753749))

| Job | Run time | Started @ | Ended @ |
|---|---|---|---|
| Integration Tests | 10.4 min | 8.5 min | **18.9 min** |
| Test (unit) | 5.7 min | 2.8 min | 8.5 min |
| Lint / Type Check / Build / PHP | ≤ 1.9 min each | — | done by ~3 min |

Expected after this change: critical path ≈ `max(Test, Integration)` ≈ **11–12 min** (the two run in parallel; integration starts at ~t=0 instead of t=8.5min).

## Follow-ups (not in this PR)

- `maxWorkers: 1` → `2` in `apps/api/test/jest-integration.cjs` could roughly halve the ~9.5-min serial spec phase (per-process `globalThis` container singletons make this correctness-safe; the risk is purely runner RAM/Docker headroom on the self-hosted runner — needs a measured trial).
- Splitting the 4 PrestaShop specs (~4 min of the 9.5) into their own parallel lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)