### PR TITLE
feat(webhooks): WebhookEventTranslator capability + core InboundRoutingPolicy; delete provider switches

### DIFF
--- a/apps/api/src/webhooks/application/handlers/__tests__/webhook-to-job.handler.spec.ts
+++ b/apps/api/src/webhooks/application/handlers/__tests__/webhook-to-job.handler.spec.ts
@@ -1,64 +1,98 @@
 /**
  * Webhook-to-Job Handler Unit Tests
  *
- * Tests the mapping logic for converting webhook events to sync jobs,
- * including provider-specific objectType mappings (e.g., PrestaShop 'stock' → 'inventory').
+ * Tests the thin dispatcher flow (ADR-015 / #903): resolve connection →
+ * resolve plugin translator → translate → core routing policy → enqueue or
+ * dead-letter. No platform string-matching lives in the handler anymore.
  *
  * @module apps/api/src/webhooks/application/handlers/__tests__
  */
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { WebhookToJobHandler } from '../webhook-to-job.handler';
-import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
-import type { InboundWebhookEvent } from '@openlinker/core/events';
-import type { SyncJobRequest } from '@openlinker/core/sync';
-import { JobTypeValues } from '@openlinker/core/sync';
+import {
+  INTEGRATIONS_SERVICE_TOKEN,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  type CanonicalInboundEvent,
+  type AdapterMetadata,
+} from '@openlinker/core/integrations';
+import { INBOUND_ROUTING_POLICY_TOKEN } from '@openlinker/core/sync';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { ConnectionDisabledException } from '@openlinker/core/identifier-mapping';
 import { WEBHOOK_DELIVERY_REPOSITORY_TOKEN } from '@openlinker/core/webhooks';
 import { REDIS_CLIENT_BLOCKING_TOKEN } from '../../../webhooks.tokens';
 
-describe('WebhookToJobHandler', () => {
+const STREAM = 'events.inbound.webhooks';
+const DLQ = 'events.inbound.webhooks.dead';
+const GROUP = 'webhook-handler';
+
+describe('WebhookToJobHandler (dispatcher)', () => {
   let handler: WebhookToJobHandler;
-  let mockRedisClient: {
+  let redis: {
     xGroupCreate: jest.Mock;
     xReadGroup: jest.Mock;
     xAck: jest.Mock;
     xAdd: jest.Mock;
     quit: jest.Mock;
   };
+  let getAdapter: jest.Mock;
+  let translate: jest.Mock;
+  let registryGet: jest.Mock;
+  let route: jest.Mock;
+  let upsert: jest.Mock;
+
+  const metadata: AdapterMetadata = {
+    adapterKey: 'prestashop.webservice.v1',
+    platformType: 'prestashop',
+    supportedCapabilities: ['OrderSource'],
+  };
+  const connection = { id: 'conn-1', platformType: 'prestashop' } as unknown as Connection;
+  const canonicalOrder: CanonicalInboundEvent = {
+    domain: 'order',
+    externalId: '42',
+    eventType: 'created',
+  };
+
+  const fields = (overrides: Record<string, string> = {}): Record<string, string> => ({
+    eventId: 'evt-1',
+    eventType: 'inbound.webhook.order.created',
+    payloadJson: JSON.stringify({ objectType: 'order', externalId: '42', payload: {} }),
+    metadataJson: JSON.stringify({ provider: 'prestashop', connectionId: 'conn-1' }),
+    occurredAt: '2026-01-01T00:00:00.000Z',
+    publishedAt: '2026-01-01T00:00:01.000Z',
+    ...overrides,
+  });
+
+  const process = (id: string, f: Record<string, string>): Promise<void> =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- test: invoke private processMessage
+    (handler as any).processMessage(id, f);
 
   beforeEach(async () => {
-    mockRedisClient = {
+    redis = {
       xGroupCreate: jest.fn(),
       xReadGroup: jest.fn(),
       xAck: jest.fn(),
       xAdd: jest.fn(),
       quit: jest.fn().mockResolvedValue(undefined),
     };
-
-    const mockJobEnqueue = {
-      enqueueJob: jest.fn().mockResolvedValue({ jobId: 'job-1', isExisting: false }),
-    };
-
-    const mockDeliveryRepo = {
-      upsert: jest.fn().mockResolvedValue(undefined),
-      findById: jest.fn(),
-      findMany: jest.fn(),
-    };
+    getAdapter = jest.fn().mockResolvedValue({ connection, metadata });
+    translate = jest.fn().mockReturnValue(canonicalOrder);
+    registryGet = jest.fn().mockReturnValue({ translate });
+    route = jest
+      .fn()
+      .mockResolvedValue({ status: 'enqueued', jobId: 'job-1', jobType: 'marketplace.order.sync' });
+    upsert = jest.fn().mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WebhookToJobHandler,
-        {
-          provide: REDIS_CLIENT_BLOCKING_TOKEN,
-          useValue: mockRedisClient,
-        },
-        {
-          provide: JOB_ENQUEUE_TOKEN,
-          useValue: mockJobEnqueue,
-        },
+        { provide: REDIS_CLIENT_BLOCKING_TOKEN, useValue: redis },
+        { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: { getAdapter } },
+        { provide: WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN, useValue: { get: registryGet } },
+        { provide: INBOUND_ROUTING_POLICY_TOKEN, useValue: { route } },
         {
           provide: WEBHOOK_DELIVERY_REPOSITORY_TOKEN,
-          useValue: mockDeliveryRepo,
+          useValue: { upsert, findById: jest.fn(), findMany: jest.fn() },
         },
       ],
     }).compile();
@@ -66,430 +100,122 @@ describe('WebhookToJobHandler', () => {
     handler = module.get<WebhookToJobHandler>(WebhookToJobHandler);
   });
 
+  it('should dispatch an order webhook through translator + policy and ACK', async () => {
+    await process('msg-1', fields());
+
+    expect(getAdapter).toHaveBeenCalledWith('conn-1');
+    expect(registryGet).toHaveBeenCalledWith('prestashop.webservice.v1');
+    expect(route).toHaveBeenCalledWith(canonicalOrder, connection, ['OrderSource'], 'evt-1');
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'job_enqueued',
+        downstreamJobType: 'marketplace.order.sync',
+        downstreamJobId: 'job-1',
+      })
+    );
+    expect(redis.xAck).toHaveBeenCalledWith(STREAM, GROUP, 'msg-1');
+    expect(redis.xAdd).not.toHaveBeenCalled();
+  });
+
+  it('should skip test.* events without resolving the connection', async () => {
+    await process('msg-1', fields({ eventType: 'inbound.webhook.test.ping' }));
+
+    expect(getAdapter).not.toHaveBeenCalled();
+    expect(route).not.toHaveBeenCalled();
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({ status: 'received' }));
+    expect(redis.xAck).toHaveBeenCalledWith(STREAM, GROUP, 'msg-1');
+  });
+
+  it('should dead-letter when no translator is registered for the adapter', async () => {
+    registryGet.mockReturnValue(undefined);
+
+    await process('msg-1', fields());
+
+    expect(route).not.toHaveBeenCalled();
+    expect(redis.xAdd).toHaveBeenCalledWith(DLQ, '*', expect.objectContaining({ eventId: 'evt-1' }));
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'deadlettered',
+        dlqReason: expect.stringContaining('no-translator'),
+      })
+    );
+    expect(redis.xAck).toHaveBeenCalledWith(STREAM, GROUP, 'msg-1');
+  });
+
+  it('should dead-letter when the translator cannot decode the event', async () => {
+    translate.mockReturnValue(null);
+
+    await process(
+      'msg-1',
+      fields({ payloadJson: JSON.stringify({ objectType: 'category', externalId: '1' }) })
+    );
+
+    expect(route).not.toHaveBeenCalled();
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'deadlettered',
+        dlqReason: expect.stringContaining('undecodable'),
+      })
+    );
+    expect(redis.xAck).toHaveBeenCalledWith(STREAM, GROUP, 'msg-1');
+  });
+
+  it('should dead-letter when the routing policy gates the event out', async () => {
+    route.mockResolvedValue({ status: 'ungated', domain: 'order', requiredCapability: 'OrderSource' });
+
+    await process('msg-1', fields());
+
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'deadlettered',
+        dlqReason: expect.stringContaining('ungated'),
+      })
+    );
+    expect(redis.xAck).toHaveBeenCalledWith(STREAM, GROUP, 'msg-1');
+  });
+
+  it('should dead-letter when the connection is permanently unroutable (disabled/not-found)', async () => {
+    getAdapter.mockRejectedValue(new ConnectionDisabledException('conn-1'));
+
+    await process('msg-1', fields());
+
+    expect(registryGet).not.toHaveBeenCalled();
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'deadlettered',
+        dlqReason: expect.stringContaining('connection-unavailable'),
+      })
+    );
+    expect(redis.xAck).toHaveBeenCalledWith(STREAM, GROUP, 'msg-1');
+  });
+
+  it('should NOT dead-letter on a TRANSIENT connection-resolution error — rethrow for redelivery', async () => {
+    // A non-domain error (e.g. DB blip) must not silently drop the webhook.
+    getAdapter.mockRejectedValue(new Error('db connection lost'));
+
+    await expect(process('msg-1', fields())).rejects.toThrow('db connection lost');
+    expect(redis.xAdd).not.toHaveBeenCalled();
+    expect(redis.xAck).not.toHaveBeenCalled();
+  });
+
+  it('should NOT ack (rethrow for redelivery) on a transient routing error', async () => {
+    route.mockRejectedValue(new Error('redis down'));
+
+    await expect(process('msg-1', fields())).rejects.toThrow('redis down');
+    expect(redis.xAck).not.toHaveBeenCalled();
+  });
+
   describe('onModuleDestroy', () => {
-    it('should call redisClient.quit() on module destroy', async () => {
+    it('should quit the redis client', async () => {
       jest.useFakeTimers();
-
       try {
-        const onModuleDestroyPromise = handler.onModuleDestroy();
+        const p = handler.onModuleDestroy();
         await jest.advanceTimersByTimeAsync(2000);
-        await onModuleDestroyPromise;
-
-        expect(mockRedisClient.quit).toHaveBeenCalledTimes(1);
+        await p;
+        expect(redis.quit).toHaveBeenCalledTimes(1);
       } finally {
         jest.useRealTimers();
       }
-    });
-  });
-
-  describe('mapObjectType (via mapToSyncJob)', () => {
-    const createInboundEvent = (provider: string, objectType: string): InboundWebhookEvent => ({
-      eventId: 'test-event-123',
-      provider,
-      connectionId: '59f4129e-a827-4650-b69b-fc2302b9ecb7',
-      eventType: 'stock.changed',
-      occurredAt: '2025-01-01T12:00:00.000Z',
-      receivedAt: '2025-01-01T12:00:01.000Z',
-      objectType,
-      externalId: '23',
-      payload: {},
-    });
-
-    it('should map PrestaShop "stock" to "inventory" for job type', () => {
-      const event = createInboundEvent('prestashop', 'stock');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const job = (handler as any).mapToSyncJob(event);
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.jobType).toBe('master.inventory.syncByExternalId');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.payload.objectType).toBe('Inventory'); // Normalized canonical type
-    });
-
-    it('should map PrestaShop "stock" (uppercase) to "inventory"', () => {
-      const event = createInboundEvent('prestashop', 'STOCK');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const job = (handler as any).mapToSyncJob(event);
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.jobType).toBe('master.inventory.syncByExternalId');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.payload.objectType).toBe('Inventory');
-    });
-
-    it('should pass through PrestaShop "product" unchanged', () => {
-      const event = createInboundEvent('prestashop', 'product');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const job = (handler as any).mapToSyncJob(event);
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.jobType).toBe('master.product.syncByExternalId');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.payload.objectType).toBe('Product');
-    });
-
-    it('should throw error for unmapped objectType that results in invalid job type', () => {
-      const event = createInboundEvent('prestashop', 'unknown_type');
-
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-        (handler as any).mapToSyncJob(event);
-      }).toThrow(/Unsupported master objectType: unknown_type/i);
-    });
-
-    it('should throw error for unknown provider that results in invalid job type', () => {
-      const event = createInboundEvent('shopify', 'inventory_level');
-
-      // No mapping defined for shopify yet, and job type is invalid
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-        (handler as any).mapToSyncJob(event);
-      }).toThrow(/Invalid job type: shopify\.inventory_level\.syncByExternalId/);
-    });
-
-    it('should handle case-insensitive provider matching', () => {
-      const event = createInboundEvent('PRESTASHOP', 'stock');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const job = (handler as any).mapToSyncJob(event);
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.jobType).toBe('master.inventory.syncByExternalId');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.payload.objectType).toBe('Inventory');
-    });
-  });
-
-  describe('order routing to marketplace.order.sync (#902)', () => {
-    const createOrderEvent = (eventType: string): InboundWebhookEvent => ({
-      eventId: 'evt-order-1',
-      provider: 'prestashop',
-      connectionId: '59f4129e-a827-4650-b69b-fc2302b9ecb7',
-      eventType,
-      occurredAt: '2025-01-01T12:00:00.000Z',
-      receivedAt: '2025-01-01T12:00:01.000Z',
-      objectType: 'order',
-      externalId: '4242',
-      payload: {},
-    });
-
-    const mapToJob = (event: InboundWebhookEvent): SyncJobRequest =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test: invoke private mapToSyncJob
-      (handler as any).mapToSyncJob(event) as SyncJobRequest;
-
-    it('should route order.created to marketplace.order.sync with the externalOrderId payload shape', () => {
-      const job = mapToJob(createOrderEvent('order.created'));
-
-      expect(job).toMatchObject({
-        jobType: 'marketplace.order.sync',
-        connectionId: '59f4129e-a827-4650-b69b-fc2302b9ecb7',
-        payload: {
-          schemaVersion: 1,
-          externalOrderId: '4242',
-          sourceEventId: 'evt-order-1',
-          eventType: 'created',
-        },
-        // idempotency key shape pinned so a future payload refactor can't drift it
-        idempotencyKey: 'prestashop:59f4129e-a827-4650-b69b-fc2302b9ecb7:evt-order-1',
-      });
-      expect(JobTypeValues).toContain(job.jobType);
-    });
-
-    it('should map order.status_changed to the "updated" feed event type', () => {
-      const job = mapToJob(createOrderEvent('order.status_changed'));
-
-      expect(job.jobType).toBe('marketplace.order.sync');
-      expect(job.payload.eventType).toBe('updated');
-    });
-
-    it('should default an unrecognized order event type to "updated"', () => {
-      const job = mapToJob(createOrderEvent('order.refunded'));
-
-      expect(job.payload.eventType).toBe('updated');
-    });
-
-    it('should not emit the generic master payload shape (externalId/objectType) for orders', () => {
-      const job = mapToJob(createOrderEvent('order.created'));
-
-      expect(job.payload.externalOrderId).toBe('4242');
-      expect(job.payload.externalId).toBeUndefined();
-      expect(job.payload.objectType).toBeUndefined();
-    });
-
-    it('should route orders provider-agnostically (objectType=order regardless of provider)', () => {
-      const event = createOrderEvent('order.created');
-      event.provider = 'shopify';
-      const job = mapToJob(event);
-
-      expect(job.jobType).toBe('marketplace.order.sync');
-      expect(job.idempotencyKey).toBe(
-        'shopify:59f4129e-a827-4650-b69b-fc2302b9ecb7:evt-order-1'
-      );
-    });
-  });
-
-  describe('mapToSyncJob', () => {
-    const createInboundEvent = (provider: string, objectType: string): InboundWebhookEvent => ({
-      eventId: 'test-event-123',
-      provider,
-      connectionId: '59f4129e-a827-4650-b69b-fc2302b9ecb7',
-      eventType: 'stock.changed',
-      occurredAt: '2025-01-01T12:00:00.000Z',
-      receivedAt: '2025-01-01T12:01:00.000Z',
-      objectType,
-      externalId: '23',
-      payload: { quantity: 100 },
-    });
-
-    it('should create valid job request for PrestaShop inventory event', () => {
-      const event = createInboundEvent('prestashop', 'stock');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const job = (handler as any).mapToSyncJob(event);
-
-      expect(job).toMatchObject({
-        jobType: 'master.inventory.syncByExternalId',
-        connectionId: '59f4129e-a827-4650-b69b-fc2302b9ecb7',
-        payload: {
-          externalId: '23',
-          objectType: 'Inventory', // Mapped and normalized
-          eventType: 'stock.changed',
-        },
-        idempotencyKey: 'prestashop:59f4129e-a827-4650-b69b-fc2302b9ecb7:test-event-123',
-      });
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(JobTypeValues).toContain(job.jobType);
-    });
-
-    it('should create valid job request for PrestaShop product event', () => {
-      const event = createInboundEvent('prestashop', 'product');
-      event.eventType = 'product.saved';
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const job = (handler as any).mapToSyncJob(event);
-
-      expect(job).toMatchObject({
-        jobType: 'master.product.syncByExternalId',
-        payload: {
-          objectType: 'Product',
-          eventType: 'product.saved',
-        },
-      });
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(JobTypeValues).toContain(job.jobType);
-    });
-
-    it('should throw error for invalid job type', () => {
-      const event = createInboundEvent('prestashop', 'invalid_type');
-      event.eventType = 'invalid.event';
-
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-        (handler as any).mapToSyncJob(event);
-      }).toThrow(/Unsupported master objectType: invalid_type/i);
-    });
-
-    it('should throw error for invalid job type even if normalization works', () => {
-      const event = createInboundEvent('prestashop', 'product_variant');
-
-      // The normalization would work, but the job type is invalid
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-        (handler as any).mapToSyncJob(event);
-      }).toThrow(/Unsupported master objectType: product_variant/i);
-    });
-
-    it('should preserve event payload in job payload', () => {
-      const event = createInboundEvent('prestashop', 'stock');
-      event.payload = { quantity: 100, location: 'warehouse-1' };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const job = (handler as any).mapToSyncJob(event);
-
-      // Note: The current implementation doesn't preserve the full payload,
-      // but we test what's actually included
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.payload.externalId).toBe('23');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.payload.eventType).toBe('stock.changed');
-    });
-  });
-
-  describe('normalizeObjectType', () => {
-    it('should convert lowercase to PascalCase', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const result = (handler as any).normalizeObjectType('product');
-      expect(result).toBe('Product');
-    });
-
-    it('should convert snake_case to PascalCase', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const result = (handler as any).normalizeObjectType('product_variant');
-      expect(result).toBe('ProductVariant');
-    });
-
-    it('should handle already PascalCase', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const result = (handler as any).normalizeObjectType('Product');
-      expect(result).toBe('Product');
-    });
-
-    it('should handle uppercase', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const result = (handler as any).normalizeObjectType('PRODUCT');
-      expect(result).toBe('Product');
-    });
-
-    it('should handle mixed case', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const result = (handler as any).normalizeObjectType('PrOdUcT');
-      expect(result).toBe('Product');
-    });
-
-    it('should handle empty string', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const result = (handler as any).normalizeObjectType('');
-      expect(result).toBe('');
-    });
-
-    it('should handle multiple underscores', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const result = (handler as any).normalizeObjectType('product_variant_attribute');
-      expect(result).toBe('ProductVariantAttribute');
-    });
-  });
-
-  describe('validateJobType', () => {
-    it('should return valid job type', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const result = (handler as any).validateJobType('master.product.syncByExternalId');
-      expect(result).toBe('master.product.syncByExternalId');
-      expect(JobTypeValues).toContain(result);
-    });
-
-    it('should return valid inventory job type', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const result = (handler as any).validateJobType('master.inventory.syncByExternalId');
-      expect(result).toBe('master.inventory.syncByExternalId');
-      expect(JobTypeValues).toContain(result);
-    });
-
-    it('should throw error for invalid job type', () => {
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-        (handler as any).validateJobType('prestashop.stock.syncByExternalId');
-      }).toThrow(/Invalid job type: prestashop\.stock\.syncByExternalId/);
-    });
-
-    it('should throw error with list of valid types', () => {
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-        (handler as any).validateJobType('invalid.job.type');
-      }).toThrow(/Valid types: .*master\.product\.syncByExternalId/);
-    });
-  });
-
-  describe('Integration: Full mapping flow', () => {
-    it('should correctly map PrestaShop stock event end-to-end', () => {
-      const event: InboundWebhookEvent = {
-        eventId: 'prestashop-stock-123',
-        provider: 'prestashop',
-        connectionId: '59f4129e-a827-4650-b69b-fc2302b9ecb7',
-        eventType: 'stock.changed',
-        occurredAt: '2025-01-01T12:00:00.000Z',
-        receivedAt: '2025-01-01T12:00:01.000Z',
-        objectType: 'stock', // PrestaShop terminology
-        externalId: '23',
-        payload: { quantity: 100 },
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const job = (handler as any).mapToSyncJob(event);
-
-      // Verify job type uses canonical terminology
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.jobType).toBe('master.inventory.syncByExternalId');
-
-      // Verify payload uses normalized canonical terminology
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.payload.objectType).toBe('Inventory');
-
-      // Verify job is valid
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(JobTypeValues).toContain(job.jobType);
-
-      // Verify idempotency key format
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.idempotencyKey).toBe(
-        'prestashop:59f4129e-a827-4650-b69b-fc2302b9ecb7:prestashop-stock-123'
-      );
-    });
-
-    it('should correctly map PrestaShop product event (no mapping needed)', () => {
-      const event: InboundWebhookEvent = {
-        eventId: 'prestashop-product-456',
-        provider: 'prestashop',
-        connectionId: '59f4129e-a827-4650-b69b-fc2302b9ecb7',
-        eventType: 'product.saved',
-        occurredAt: '2025-01-01T12:00:00.000Z',
-        receivedAt: '2025-01-01T12:00:01.000Z',
-        objectType: 'product',
-        externalId: '456',
-        payload: { name: 'Test Product' },
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-      const job = (handler as any).mapToSyncJob(event);
-
-      // Verify job type (no mapping needed for product)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.jobType).toBe('master.product.syncByExternalId');
-
-      // Verify payload uses normalized objectType
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(job.payload.objectType).toBe('Product');
-
-      // Verify job is valid
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
-      expect(JobTypeValues).toContain(job.jobType);
-    });
-  });
-
-  describe('Edge cases', () => {
-    it('should throw error for objectType with special characters that results in invalid job type', () => {
-      const event: InboundWebhookEvent = {
-        eventId: 'test-123',
-        provider: 'prestashop',
-        connectionId: 'conn-123',
-        eventType: 'test.event',
-        occurredAt: '2025-01-01T12:00:00.000Z',
-        receivedAt: '2025-01-01T12:00:01.000Z',
-        objectType: 'product_variant_attribute',
-        externalId: '123',
-        payload: {},
-      };
-
-      // The normalization would work, but the job type is invalid
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-        (handler as any).mapToSyncJob(event);
-      }).toThrow(/Unsupported master objectType: product_variant_attribute/i);
-    });
-
-    it('should handle empty objectType', () => {
-      const event: InboundWebhookEvent = {
-        eventId: 'test-123',
-        provider: 'prestashop',
-        connectionId: 'conn-123',
-        eventType: 'test.event',
-        occurredAt: '2025-01-01T12:00:00.000Z',
-        receivedAt: '2025-01-01T12:00:01.000Z',
-        objectType: '',
-        externalId: '123',
-        payload: {},
-      };
-
-      // Empty objectType will result in invalid job type, should throw
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- test mock: explicit any narrows the dynamic spy / fixture shape
-        (handler as any).mapToSyncJob(event);
-      }).toThrow();
     });
   });
 });

--- a/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
+++ b/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
@@ -11,16 +11,20 @@
 import type { OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { Injectable, Inject } from '@nestjs/common';
 import { RedisClientType } from 'redis';
-import { JobEnqueuePort } from '@openlinker/core/sync';
-import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import type { EventEnvelope, InboundWebhookEvent } from '@openlinker/core/events';
-import type {
-  SyncJobRequest,
-  JobType,
-  MarketplaceOrderSyncPayloadV1,
-} from '@openlinker/core/sync';
-import { JobTypeValues } from '@openlinker/core/sync';
-import type { OrderFeedEventType } from '@openlinker/core/orders';
+import {
+  INTEGRATIONS_SERVICE_TOKEN,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  WebhookEventTranslatorRegistryService,
+ IIntegrationsService} from '@openlinker/core/integrations';
+import type { AdapterMetadata } from '@openlinker/core/integrations';
+import { INBOUND_ROUTING_POLICY_TOKEN } from '@openlinker/core/sync';
+import { IInboundRoutingPolicyService } from '@openlinker/core/sync';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import {
+  ConnectionNotFoundException,
+  ConnectionDisabledException,
+} from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
 import type { WebhookDeliveryUpsertInput } from '@openlinker/core/webhooks';
 import {
@@ -46,8 +50,12 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
   constructor(
     @Inject(REDIS_CLIENT_BLOCKING_TOKEN)
     private readonly redisClient: RedisClientType,
-    @Inject(JOB_ENQUEUE_TOKEN)
-    private readonly jobEnqueue: JobEnqueuePort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+    @Inject(WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN)
+    private readonly translatorRegistry: WebhookEventTranslatorRegistryService,
+    @Inject(INBOUND_ROUTING_POLICY_TOKEN)
+    private readonly routingPolicy: IInboundRoutingPolicyService,
     @Inject(WEBHOOK_DELIVERY_REPOSITORY_TOKEN)
     private readonly deliveryRepository: WebhookDeliveryRepositoryPort
   ) {}
@@ -240,46 +248,84 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
         return;
       }
 
-      // Map to sync job (may throw if unmappable)
-      let job: SyncJobRequest;
+      // Resolve the connection + its adapter metadata. A *permanent* config
+      // fault (connection not found / disabled) dead-letters; any other
+      // (transient) error rethrows to the outer catch (no ACK → redelivery), so
+      // a brief DB/infra blip never silently drops a webhook (ADR-015 invariant 3).
+      let connection: Connection;
+      let metadata: AdapterMetadata;
       try {
-        job = this.mapToSyncJob(event);
-      } catch (mappingError) {
-        // Mapping failed (invalid job type, unmappable objectType, etc.)
-        // ACK the webhook message and send to DLQ to prevent infinite retries
-        const errorMessage =
-          mappingError instanceof Error ? mappingError.message : String(mappingError);
-        this.logger.warn(
-          `Failed to map webhook event to job: eventId=${event.eventId}, provider=${event.provider}, objectType=${event.objectType}, error=${errorMessage}`
-        );
-        await this.sendToDeadLetterQueue(event, errorMessage, fields);
-        await this.recordDelivery({
-          eventId: event.eventId,
-          provider: event.provider,
-          connectionId: event.connectionId,
-          status: 'deadlettered',
-          dlqReason: errorMessage.slice(0, 500),
-        });
-        await this.redisClient.xAck(this.STREAM_NAME, this.CONSUMER_GROUP, messageId);
+        ({ connection, metadata } = await this.integrationsService.getAdapter(event.connectionId));
+      } catch (resolveError) {
+        if (
+          resolveError instanceof ConnectionNotFoundException ||
+          resolveError instanceof ConnectionDisabledException
+        ) {
+          await this.deadLetter(
+            messageId,
+            event,
+            fields,
+            `connection-unavailable: ${resolveError.message}`
+          );
+          return;
+        }
+        throw resolveError;
+      }
+
+      // Resolve the plugin's webhook-event translator by adapterKey. No
+      // translator → this plugin doesn't decode webhooks (poll-only) → DLQ.
+      const translator = this.translatorRegistry.get(metadata.adapterKey);
+      if (!translator) {
+        await this.deadLetter(messageId, event, fields, `no-translator: ${metadata.adapterKey}`);
         return;
       }
 
-      // Enqueue job (idempotency enforced at JobEnqueuePort level)
-      const { jobId } = await this.jobEnqueue.enqueueJob(job);
+      // Decode the native event into a neutral canonical event (null = undecodable).
+      const canonical = translator.translate(event);
+      if (!canonical) {
+        await this.deadLetter(
+          messageId,
+          event,
+          fields,
+          `undecodable: objectType=${event.objectType}, eventType=${event.eventType}`
+        );
+        return;
+      }
+
+      // Route via the core policy (capability-gated; enqueues on a passed gate).
+      // Pass the already-resolved supportedCapabilities so the policy stays a
+      // pure function (no second metadata resolve).
+      const outcome = await this.routingPolicy.route(
+        canonical,
+        connection,
+        metadata.supportedCapabilities,
+        event.eventId
+      );
+      if (outcome.status === 'ungated') {
+        await this.deadLetter(
+          messageId,
+          event,
+          fields,
+          `ungated: ${canonical.domain} requires ${outcome.requiredCapability}`
+        );
+        return;
+      }
 
       await this.recordDelivery({
         eventId: event.eventId,
         provider: event.provider,
         connectionId: event.connectionId,
         status: 'job_enqueued',
-        downstreamJobId: jobId,
-        downstreamJobType: job.jobType,
+        downstreamJobId: outcome.jobId,
+        downstreamJobType: outcome.jobType,
       });
 
       // ACK message only after successful enqueue
       await this.redisClient.xAck(this.STREAM_NAME, this.CONSUMER_GROUP, messageId);
 
-      this.logger.debug(`Processed webhook event ${event.eventId} and enqueued job ${job.jobType}`);
+      this.logger.debug(
+        `Processed webhook event ${event.eventId} and enqueued job ${outcome.jobType}`
+      );
     } catch (error) {
       // Unexpected error (network, Redis, etc.) - don't ACK, allow retry
       this.logger.error(
@@ -337,191 +383,29 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Map inbound webhook event to sync job
-   *
-   * Maps webhook events to sync job requests based on event type and provider.
-   * Acts as a translation layer: provider-specific terminology → canonical job types.
-   * Normalizes objectType to PascalCase to match the well-known core entity types.
-   *
-   * @throws Error if job type cannot be constructed or validated
+   * Dead-letter an unroutable webhook event: publish to the DLQ stream, record
+   * the delivery as `deadlettered`, and ACK so it isn't redelivered. Reasons
+   * are tagged (`connection-unavailable` / `no-translator` / `undecodable` /
+   * `ungated`) to distinguish expected poll-only noise from misconfiguration.
    */
-  private mapToSyncJob(event: InboundWebhookEvent): SyncJobRequest {
-    // Map provider-specific objectType to canonical objectType for job type construction
-    // Example: PrestaShop uses "stock" but OpenLinker uses "inventory" in job types
-    const canonicalObjectType = this.mapObjectType(event.provider, event.objectType);
-
-    // Normalize canonical objectType to PascalCase for payload
-    // This ensures payload uses canonical terminology (e.g., "inventory" -> "Inventory")
-    // rather than provider-specific terminology (e.g., "stock" -> "Stock")
-    const normalizedCanonicalObjectType = this.normalizeObjectType(canonicalObjectType);
-
-    // Order events route onto the same `marketplace.order.sync` job the poller
-    // uses — push and poll converge on one pull path (idempotent on the internal
-    // order id; concurrent triggers are serialized by the per-order create lock).
-    //
-    // Provider-agnostic by design: keyed on objectType, not provider, so any
-    // marketplace emitting an `order` webhook routes here (today only PrestaShop
-    // does). The payload intentionally uses the poller's `externalOrderId` shape
-    // (MarketplaceOrderSyncPayloadV1), not the generic `externalId` master shape.
-    if (canonicalObjectType.toLowerCase() === 'order') {
-      return {
-        jobType: this.validateJobType('marketplace.order.sync'),
-        connectionId: event.connectionId,
-        // Inline literal (not a typed const) so it stays assignable to the
-        // payload's `Record<string, unknown>`; `satisfies` still shape-checks it.
-        payload: {
-          schemaVersion: 1,
-          externalOrderId: event.externalId,
-          sourceEventId: event.eventId,
-          eventType: this.mapOrderFeedEventType(event.eventType),
-          occurredAt: event.occurredAt,
-        } satisfies MarketplaceOrderSyncPayloadV1,
-        idempotencyKey: `${event.provider}:${event.connectionId}:${event.eventId}`,
-      };
-    }
-
-    // Build job type: master.{canonicalObjectType}.syncByExternalId for master systems (e.g., PrestaShop)
-    // (Option B: job taxonomy is integration-agnostic.)
-    const normalizedProvider = event.provider.toLowerCase();
-    const isMasterProvider = normalizedProvider === 'prestashop';
-
-    if (isMasterProvider) {
-      const supported = ['product', 'inventory'];
-      if (!supported.includes(canonicalObjectType.toLowerCase())) {
-        throw new Error(
-          `Unsupported master objectType: ${canonicalObjectType}. Supported: ${supported.join(', ')}`
-        );
-      }
-    }
-
-    const jobTypeString = isMasterProvider
-      ? `master.${canonicalObjectType.toLowerCase()}.syncByExternalId`
-      : `${normalizedProvider}.${canonicalObjectType.toLowerCase()}.syncByExternalId`;
-
-    // Validate that the constructed job type is a valid JobType
-    // Type assertion is safe here because we validate against JobTypeValues
-    const jobType = this.validateJobType(jobTypeString);
-
-    // Build idempotency key: {provider}:{connectionId}:{eventId}
-    const idempotencyKey = `${event.provider}:${event.connectionId}:${event.eventId}`;
-
-    return {
-      jobType,
+  private async deadLetter(
+    messageId: string,
+    event: InboundWebhookEvent,
+    fields: Record<string, string>,
+    reason: string
+  ): Promise<void> {
+    this.logger.warn(
+      `Dead-lettering webhook event: eventId=${event.eventId}, provider=${event.provider}, objectType=${event.objectType}, reason=${reason}`
+    );
+    await this.sendToDeadLetterQueue(event, reason, fields);
+    await this.recordDelivery({
+      eventId: event.eventId,
+      provider: event.provider,
       connectionId: event.connectionId,
-      payload: {
-        schemaVersion: 1,
-        externalId: event.externalId,
-        objectType: normalizedCanonicalObjectType, // Use normalized canonical objectType (PascalCase) in payload
-        eventType: event.eventType,
-      },
-      idempotencyKey,
-    };
-  }
-
-  /**
-   * Map an inbound webhook event type to the poller's `OrderFeedEventType`
-   * vocabulary, so push and poll express order events in one language.
-   *
-   * Webhook event types arrive in dotted form (e.g. PrestaShop emits
-   * `order.created` / `order.status_changed`). `OrderFeedEventType` has no
-   * `status_changed` token, so a status change maps to `updated`. Any
-   * unrecognized order event falls back to `updated` — a safe re-pull; the
-   * field is an advisory hint, not a routing key (every order event routes to
-   * the same `marketplace.order.sync` job).
-   */
-  private mapOrderFeedEventType(webhookEventType: string): OrderFeedEventType {
-    switch (webhookEventType) {
-      case 'order.created':
-        return 'created';
-      case 'order.status_changed':
-        return 'updated';
-      default:
-        return 'updated';
-    }
-  }
-
-  /**
-   * Map provider-specific objectType to canonical objectType
-   *
-   * Acts as a translation layer between provider terminology and OpenLinker's canonical terminology.
-   * This allows providers to use their own terminology (e.g., PrestaShop uses "stock") while
-   * OpenLinker uses canonical terms in job types (e.g., "inventory").
-   *
-   * Structure is designed to be extensible: can be extracted to provider-specific mappers later.
-   *
-   * @param provider - Provider identifier (e.g., 'prestashop', 'shopify')
-   * @param objectType - Provider-specific object type (e.g., 'stock', 'product')
-   * @returns Canonical object type for job type construction (e.g., 'inventory', 'product')
-   */
-  private mapObjectType(provider: string, objectType: string): string {
-    const p = provider.toLowerCase();
-    const o = objectType.toLowerCase();
-
-    // Provider-specific objectType mappings
-    // Structure: { provider: { providerObjectType: canonicalObjectType } }
-    const mapping: Record<string, Record<string, string>> = {
-      prestashop: {
-        stock: 'inventory', // PrestaShop uses "stock", OpenLinker uses "inventory"
-        // product: 'product', // No mapping needed (pass-through)
-        // order: 'order', // No mapping needed (pass-through)
-      },
-      // Future providers can be added here:
-      // shopify: {
-      //   inventory_level: 'inventory',
-      //   product: 'product',
-      // },
-    };
-
-    // Return mapped value if exists, otherwise pass through unchanged
-    return mapping[p]?.[o] ?? o;
-  }
-
-  /**
-   * Normalize objectType to PascalCase
-   *
-   * Converts lowercase/snake_case object types to PascalCase to match the well-known core entity types.
-   * Examples:
-   * - "product" -> "Product"
-   * - "product_variant" -> "ProductVariant"
-   * - "Product" -> "Product" (already normalized)
-   * - "PRODUCT" -> "Product"
-   *
-   * @param objectType - Raw object type from webhook (any case)
-   * @returns Normalized object type in PascalCase
-   */
-  private normalizeObjectType(objectType: string): string {
-    if (!objectType) {
-      return objectType;
-    }
-
-    // Convert to lowercase first, then split by underscore
-    const parts = objectType.toLowerCase().split('_');
-
-    // Capitalize first letter of each part and join
-    return parts.map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join('');
-  }
-
-  /**
-   * Validate and return a JobType
-   *
-   * Ensures the job type string is a valid JobType value.
-   * Throws an error if the job type is not recognized.
-   *
-   * @throws Error if job type is not in JobTypeValues
-   */
-  private validateJobType(jobTypeString: string): JobType {
-    // Type guard: check if jobTypeString is in the JobTypeValues array
-    const isValidJobType = (value: string): value is JobType => {
-      return (JobTypeValues as readonly string[]).includes(value);
-    };
-
-    if (isValidJobType(jobTypeString)) {
-      return jobTypeString;
-    }
-
-    const errorMessage = `Invalid job type: ${jobTypeString}. Valid types: ${JobTypeValues.join(', ')}`;
-    this.logger.error(errorMessage);
-    throw new Error(errorMessage);
+      status: 'deadlettered',
+      dlqReason: reason.slice(0, 500),
+    });
+    await this.redisClient.xAck(this.STREAM_NAME, this.CONSUMER_GROUP, messageId);
   }
 
   /**

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -14,7 +14,11 @@ import { createClient } from 'redis';
 import { EventsModule } from '@openlinker/core/events';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
-import { SyncModule } from '@openlinker/core/sync';
+import {
+  SyncModule,
+  InboundRoutingPolicyService,
+  INBOUND_ROUTING_POLICY_TOKEN,
+} from '@openlinker/core/sync';
 import { WebhooksCoreModule } from '@openlinker/core/webhooks';
 import { WebhookController } from './http/webhook.controller';
 import { WebhookDeliveryController } from './http/webhook-delivery.controller';
@@ -50,6 +54,10 @@ import { REDIS_CLIENT_BLOCKING_TOKEN } from './webhooks.tokens';
     WebhookEventPublisher,
     WebhookDeliveryQueryService,
     { provide: WEBHOOK_DELIVERY_QUERY_SERVICE_TOKEN, useExisting: WebhookDeliveryQueryService },
+    // Inbound routing policy (ADR-015 / #903) — core class bound here, where its
+    // deps (IIntegrationsService, JobEnqueuePort) are already imported.
+    InboundRoutingPolicyService,
+    { provide: INBOUND_ROUTING_POLICY_TOKEN, useExisting: InboundRoutingPolicyService },
     WebhookToJobHandler,
     {
       // Dedicated client for blocking xReadGroup loop — must not share with health check client

--- a/docs/plans/implementation-plan-903-webhook-translator-routing-policy.md
+++ b/docs/plans/implementation-plan-903-webhook-translator-routing-policy.md
@@ -1,0 +1,171 @@
+# Implementation Plan: WebhookEventTranslator capability + core InboundRoutingPolicy; delete provider switches (#903)
+
+**Date**: 2026-05-30
+**Status**: Ready for Review
+**Estimated Effort**: ~1.5–2 days
+**Issue**: #903 (Phase 2 of epic #900). Depends on #901 (ADR-015) + #902 (Phase 1, merged). Authoritative design: **ADR-015**.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Move webhook-event *translation* into the plugin (a new per-plugin `WebhookEventTranslator` capability) and *routing policy* into core (`InboundRoutingPolicy`), then **delete** the hardcoded `isMasterProvider = provider === 'prestashop'` switch + `mapObjectType` allow-list from `WebhookToJobHandler`, turning it into a thin dispatcher.
+
+**Why**: Per ADR-015 — "is this a source we pull from?" is a **capability** question (`OrderSource`), not a platform-name one; routing orchestration belongs in core, not an `apps/api` handler; and adding a new platform's webhooks must need **no** host PR.
+
+**Classification**: CORE (new domain port + types + core application service) + Integration (PrestaShop translator adapter) + plugin-sdk (HostServices handle) + Interface (handler refactor). No schema, no migration.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope (ADR-015 Phase 2)
+1. New per-plugin capability **`WebhookEventTranslatorPort`** + **`WebhookEventTranslatorRegistryService`** (mirrors the `WebhookProvisioning` registry mechanics; semantics match the pure shape-validators).
+2. New neutral type **`CanonicalInboundEvent`** (transient, no `schemaVersion`).
+3. New core **`InboundRoutingPolicy`** application service: deterministic `domain → required capability → jobType` table, capability-gated via a **metadata read** (not exception-as-control-flow), enqueues the resulting `SyncJobRequest`.
+4. **PrestaShop translator adapter** mapping `order.created`/`order.status_changed`/`stock.changed`/`product.saved` → canonical events; registered in `createPrestashopPlugin().register(host)`.
+5. **Refactor `WebhookToJobHandler`** to a thin dispatcher (resolve connection → translator → policy). **Delete** `isMasterProvider`, `mapObjectType`, `validateJobType`, `mapToSyncJob`, and the #902 `mapOrderFeedEventType` helper (relocated into the translator/policy).
+
+### Out of Scope
+- Poll backstop → **#904** (Phase 3).
+- Destination idempotency → already shipped (#906); #909 is the full-A′ follow-up.
+- Unified webhook/poll dedup-key derivation (ADR-015 invariant 2) — an optimization; **invariant 1 (idempotency, done in #906) is the correctness guarantee**. Tracked separately if pursued.
+- DLQ metric/alert surface (ADR-015 invariant 4) — the DLQ stream already has no consumer; this PR preserves the existing DLQ behavior and does not add observability tooling. Note as a follow-up.
+- Allegro translator — Allegro is **poll-only** (no inbound webhook); per ADR orthogonality table it ships `OrderSource` without a translator. No translator registered.
+
+### §4a — Master payload contract (verified before delete)
+
+`libs/core/src/sync/domain/types/master-job-payloads.types.ts` + the worker handlers (`master-inventory-sync.handler.ts:71-102`, `master-product-sync.handler.ts`):
+- `MasterProductSyncByExternalIdPayloadV1 = { schemaVersion:1; externalId; objectType: 'Product' }`
+- `MasterInventorySyncByExternalIdPayloadV1 = { schemaVersion:1; externalId; objectType: 'Inventory' | 'Product' }`
+- Handlers **require** `externalId` + `objectType` (throw if missing), validate `objectType` ∈ {inventory,product} case-insensitively, and **ignore `eventType`** (`getPayload` drops it). → The policy reproduces these exactly via `satisfies`; it must emit PascalCase `objectType` and need not emit `eventType`.
+
+### Constraints
+- **Acceptance**: no platform-name string-matching or objectType map left in `WebhookToJobHandler`; PS order/stock/product all route through translator + policy; source/destination decision is capability-driven; a new plugin's webhooks need no core/interface edit; **full `pnpm test:integration` green**.
+- No regression to product/stock routing (they become routing-table rows).
+
+---
+
+## 3. Architecture & Placement Decisions
+
+Layer dependencies introduced (all **type/interface/token-only** → cycle-safe per the documented rule, since none of the targets import back at value level):
+- `integrations → events` (translator port references `InboundWebhookEvent`). Acyclic (`events` doesn't import `integrations`).
+- `sync → integrations` (policy references `CanonicalInboundEvent`, `IIntegrationsService`, `Connection`). Acyclic (`integrations` doesn't import `sync`).
+- `sync → orders` already exists (policy validates `OrderFeedEventType`).
+
+### New components
+
+| Component | Location | Notes |
+|---|---|---|
+| `CanonicalInboundEvent` (+ `InboundEventDomainValues`/`InboundEventDomain`) | `libs/core/src/integrations/domain/types/canonical-inbound-event.types.ts` | Lives with the port (its return type). `domain: 'order'\|'inventory'\|'product'` (closed, additive — the routing key). `eventType: string` **advisory** (see §4 A1). `externalId: string`; `occurredAt?`, `payload?`. |
+| `WebhookEventTranslatorPort` | `libs/core/src/integrations/domain/ports/webhook-event-translator.port.ts` | `translate(event: InboundWebhookEvent): CanonicalInboundEvent \| null` — pure, no I/O; `null` = undecodable (ADR invariant 5: return, don't throw unbounded). |
+| `WebhookEventTranslatorRegistryService` | `libs/core/src/integrations/infrastructure/adapters/webhook-event-translator-registry.service.ts` | Exact clone of `WebhookProvisioningRegistryService`: `Map<adapterKey, port>`, `register/get/has`. |
+| `WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN` | `libs/core/src/integrations/integrations.tokens.ts` | + provide/bind/export in `integrations.module.ts`. |
+| `webhookEventTranslatorRegistry` handle | `libs/plugin-sdk/src/host-services.ts` | 9th well-known registry on `HostServices`. |
+| `InboundRoutingPolicy` (+ `IInboundRoutingPolicy` interface) | `libs/core/src/sync/application/services/inbound-routing-policy.service.ts` (+ `application/interfaces/inbound-routing-policy.service.interface.ts`) | Sync-orchestration policy (ADR: "orchestration in core"). Deps: `IIntegrationsService` (gate) + `JobEnqueuePort` (enqueue) — exactly the two ADR-015 §Decision names. |
+| `INBOUND_ROUTING_POLICY_TOKEN` + `RoutingOutcome` type | `libs/core/src/sync/sync.tokens.ts` + `.../inbound-routing-policy.types.ts` | |
+| `PrestashopWebhookEventTranslatorAdapter` | `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-webhook-event-translator.adapter.ts` | No-dep class; registered via `new`. |
+
+### Routing table (in `InboundRoutingPolicy`)
+
+Payloads are **verified against the worker handlers** (§4a) and typed via `satisfies` against the existing payload interfaces:
+
+| `domain` | gate capability | `jobType` (typed `JobType`) | payload built (`satisfies` the existing type) |
+|---|---|---|---|
+| `order` | `OrderSource` | `marketplace.order.sync` | `MarketplaceOrderSyncPayloadV1` — `{ schemaVersion:1, externalOrderId, sourceEventId, eventType: OrderFeedEventType, occurredAt }` |
+| `inventory` | `InventoryMaster` | `master.inventory.syncByExternalId` | `MasterInventorySyncByExternalIdPayloadV1` — `{ schemaVersion:1, externalId, objectType: 'Inventory' }` |
+| `product` | `ProductMaster` | `master.product.syncByExternalId` | `MasterProductSyncByExternalIdPayloadV1` — `{ schemaVersion:1, externalId, objectType: 'Product' }` |
+
+`domain` is the routing key; capability is only the **gate**. **Gate = `metadata.supportedCapabilities.includes(cap) && connection.enabledCapabilities.includes(cap)`** (decision below) — both reads, no exception-as-control-flow. The canonical `eventType` feeds **only** the order payload (master payloads carry no `eventType` — §4a). Job-type strings are compile-time `JobType` literals (no runtime `validateJobType`). Idempotency key: `${connection.platformType}:${connection.id}:${sourceEventId}` — `sourceEventId` (= source `eventId`) is passed by the dispatcher (§4 A3), not carried on `CanonicalInboundEvent`.
+
+---
+
+## 4. Questions & Assumptions
+
+- **A1 — `CanonicalInboundEvent.eventType` is an advisory `string`, not a per-domain union.** ADR-015 says "order → `OrderFeedEventType`", but typing the canonical event as a discriminated union would force `integrations → orders` (a type-only cycle; documented-safe but avoidable). Decision: keep `eventType: string` on the neutral type (translator emits `'created'`/`'updated'` for orders, `'stock.changed'`/`'product.saved'` passthrough otherwise); the **policy** validates/coerces it to `OrderFeedEventType` (default `'updated'`) when building the order payload (it's in `sync`, which already imports `orders`). Keeps `integrations` free of an `orders` import. *(Alternative — discriminated union with order→`OrderFeedEventType` — is viable if we accept the type-only cycle; flagged for review.)*
+- **A2 — `InboundRoutingPolicy` enqueues** (owns `JobEnqueuePort`), returning a `RoutingOutcome` (`{ status: 'enqueued', jobId, jobType }` | `{ status: 'ungated', domain, requiredCapability }`). The dispatcher DLQs on `ungated`. This matches ADR-015 §Decision ("depends on IIntegrationsService **and** JobEnqueuePort") and keeps the dispatcher thin (no enqueue in the interface layer).
+- **A3 — `eventId` for the idempotency key**: not part of `CanonicalInboundEvent` (which is domain-routing data). The dispatcher passes the source `eventId` + the resolved `connection` into `route(canonical, connection, sourceEventId)`. Idempotency key derivation stays `${platformType}:${connectionId}:${eventId}` (unchanged from #902/existing).
+- **A4 — Policy wiring**: `InboundRoutingPolicy` (core class) is **provided in the `apps/api` webhooks module**, where `INTEGRATIONS_SERVICE_TOKEN` + `JOB_ENQUEUE_TOKEN` are already available — precedent: `ContentSuggestionService` is bound in `apps/api/.../content.module.ts`. Avoids a core `SyncModule ↔ IntegrationsModule` import cycle. *(Verify no cycle at impl; fall back to wiring in `SyncModule` with token-only imports if cleaner.)*
+- **A5 — Translator input** is the existing `InboundWebhookEvent` (already carries provider `objectType`/`eventType`/`externalId`/`payload`). Envelope parsing (`mapToInboundWebhookEvent`) stays in the handler — that's transport decode, not domain translation. The translator maps provider vocabulary → canonical domain.
+- **A6 — `getAdapter` throws** (connection not found / disabled) → DLQ (config fault, not transient). Genuinely transient infra errors (Redis) keep the existing "don't ACK, rethrow, redeliver" path. The gate uses capability **reads**, never exception-as-control-flow (ADR invariant 3). **Behavior change (intentional)**: the old `mapToSyncJob` had no connection-status check; the new dispatcher DLQs webhooks for **disabled** connections (the `WebhookController` validates "active" at receipt, so this only bites a disable between receipt and processing — DLQ, not silent drop, is acceptable). DLQ reason strings distinguish `connection-unavailable` / `no-translator` / `ungated:<capability>` for future invariant-4 observability.
+- **A7 — Gate decision: `supportedCapabilities && enabledCapabilities`.** The downstream `IntegrationsService.getCapabilityAdapter` (called by `OrderIngestionService`/master syncs) enforces **both** adapter-level `supportedCapabilities` and connection-level `enabledCapabilities`. So the routing gate checks both too — a connection that *supports* but has *disabled* a capability must **not** enqueue a job that's guaranteed to fail downstream with `CapabilityNotEnabledException`. The policy holds the `connection` (so `enabledCapabilities` is in hand) and resolves `metadata` for `supportedCapabilities`. *(ADR-015 invariant 3 says "supportedCapabilities"; this is a stricter, connection-scoped superset — worth a one-line ADR clarification in a follow-up, non-blocking.)*
+- **A8 — Master payloads carry no `eventType`.** Verified (§4a): the master worker handlers read only `externalId` + `objectType` and **require** `objectType` (PascalCase literal `'Inventory'`/`'Product'`). The canonical `eventType` is dropped for the master domains and used only to derive the order payload's `OrderFeedEventType`.
+
+---
+
+## 5. Implementation Plan
+
+### Phase A — core `integrations`: capability + registry + type
+1. `canonical-inbound-event.types.ts` — `InboundEventDomainValues = ['order','inventory','product'] as const`; `InboundEventDomain`; `CanonicalInboundEvent` interface.
+2. `webhook-event-translator.port.ts` — `WebhookEventTranslatorPort.translate(event: InboundWebhookEvent): CanonicalInboundEvent | null`.
+3. `webhook-event-translator-registry.service.ts` — clone `WebhookProvisioningRegistryService`.
+4. `integrations.tokens.ts` — `WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN`. `integrations.module.ts` — provide + `useExisting` bind + export. Barrel already `export * from tokens`; add type/port exports to `integrations/index.ts`.
+5. Unit test: registry `register/get/has`.
+
+### Phase B — plugin-sdk
+6. `host-services.ts` — add `webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService` to `HostServices` (import type from `@openlinker/core/integrations`).
+
+### Phase C — core `sync`: routing policy
+7. `inbound-routing-policy.types.ts` — `RoutingOutcome` union.
+8. `inbound-routing-policy.service.interface.ts` — `IInboundRoutingPolicy.route(event, connection, sourceEventId): Promise<RoutingOutcome>`.
+9. `inbound-routing-policy.service.ts` — table + gate (`resolveAdapterMetadata().supportedCapabilities.includes(required)`) + per-domain payload build + `jobEnqueue.enqueueJob`. Implements the interface; injected via tokens.
+10. `sync.tokens.ts` — `INBOUND_ROUTING_POLICY_TOKEN`. Barrel exports service + interface + types + token.
+11. Unit test: each domain → correct jobType+payload+idempotencyKey; gate-pass enqueues; gate-fail → `ungated`; order eventType coercion (`created`/unknown→`updated`).
+
+### Phase D — PrestaShop translator
+12. `prestashop-webhook-event-translator.adapter.ts` — `implements WebhookEventTranslatorPort`. Map by `objectType` (case-insensitive): `order`→domain `order` (eventType `order.created`→`created`, `order.status_changed`→`updated`, else `updated`); `stock`→domain `inventory` (eventType passthrough); `product`→domain `product`; else `null`. (`test.*` never reaches here — handler short-circuits.)
+13. Register in `createPrestashopPlugin().register(host)`: `host.webhookEventTranslatorRegistry.register('prestashop.webservice.v1', new PrestashopWebhookEventTranslatorAdapter())`. Add the registry to the `HostServices` bag built in `PrestashopIntegrationModule.onModuleInit` (inject the new token).
+14. Unit test: order/stock/product/unknown→null mappings.
+
+### Phase E — refactor the dispatcher (apps/api)
+15. `webhook-to-job.handler.ts`:
+    - Inject `INTEGRATIONS_SERVICE_TOKEN` (`IIntegrationsService`), `WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN` (registry), `INBOUND_ROUTING_POLICY_TOKEN` (policy). Drop `JOB_ENQUEUE_TOKEN` (policy enqueues).
+    - New `processMessage` body after the `test.*` skip: `getAdapter(connectionId)` → `{connection, metadata}`; `translator = registry.get(metadata.adapterKey)` (null → DLQ "no translator"); `canonical = translator.translate(event)` (null → DLQ "undecodable"); `outcome = policy.route(canonical, connection, event.eventId)`; `ungated` → DLQ (`no <capability> capability`); `enqueued` → `recordDelivery(job_enqueued, downstreamJobId/Type)` + ACK. `getAdapter` throw → DLQ.
+    - **Delete**: `mapToSyncJob`, `mapObjectType`, `normalizeObjectType` (verify no other caller), `validateJobType`, `mapOrderFeedEventType`, `isMasterProvider`. Drop now-unused imports (`JobTypeValues`, `MarketplaceOrderSyncPayloadV1`, `OrderFeedEventType`, `JobEnqueuePort`).
+16. apps/api webhooks module — provide `InboundRoutingPolicy` bound to `INBOUND_ROUTING_POLICY_TOKEN` (deps resolve from already-imported Integrations + sync tokens); ensure `WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN` + `INTEGRATIONS_SERVICE_TOKEN` are importable.
+17. Rewrite `webhook-to-job.handler.spec.ts` to the dispatch flow (mock `getAdapter`, registry, policy): order/stock/product route; no-translator→DLQ; undecodable→DLQ; ungated→DLQ; `test.*` skip unchanged; idempotency-key shape preserved.
+
+### Phase F — quality gate
+18. `pnpm lint && pnpm type-check && pnpm test`, then **full `pnpm test:integration`** (acceptance; per the manifest-capability→routing-int-spec ripple lesson, run the whole suite, not just webhook specs).
+
+---
+
+## 6. Alternatives Considered
+- **`CanonicalInboundEvent.eventType` as a discriminated union** (order→`OrderFeedEventType`): more type-safe but forces a type-only `integrations→orders` cycle. Deferred to `string` + policy-side coercion (A1).
+- **Policy returns a `SyncJobRequest`, dispatcher enqueues**: leaves enqueue orchestration in the interface layer; rejected per ADR ("orchestration in core") — policy enqueues (A2).
+- **Translator as a method on `OrderSourcePort`**: rejected by ADR-015 (inbound webhooks are multi-domain per connection; translation is api-side/pure vs OrderSource's worker-side I/O).
+- **Wire policy in core `SyncModule`**: risks a `SyncModule↔IntegrationsModule` cycle; binding in `apps/api` (ContentSuggestionService precedent) is safer (A4).
+
+---
+
+## 7. Risks
+- **Module cycle** when wiring the policy (`sync` service needing `IIntegrationsService`). Mitigated by binding in `apps/api` (A4) + token/interface-only cross-context imports.
+- **Spec churn**: the existing `webhook-to-job.handler.spec.ts` is built around `mapToSyncJob`/`mapObjectType` — it's substantially rewritten. The #902 order-routing tests are relocated into the translator + policy specs. Risk of losing a behavior assertion → mitigate by mapping each deleted test to its new home.
+- **Int-spec ripple**: webhook-ingestion / routing int-specs may assert the old DLQ-for-order or master-routing behavior. Run the **full** integration suite; update any that encode the pre-refactor routing.
+- **`normalizeObjectType` / `validateJobType` external callers**: confirm nothing else imports them before deleting (grep).
+- **DLQ semantics change**: previously `order` → DLQ ("unsupported"); now `order` with no `OrderSource` → DLQ ("ungated"), and `order` with `OrderSource` → enqueued. Net-better, but the DLQ *reason strings* change — update any test asserting them.
+
+---
+
+## 8. Acceptance Criteria (from #903)
+- [ ] No `provider === '...'` / objectType map in `WebhookToJobHandler` (it only resolves connection → translator → policy).
+- [ ] PS order/stock/product webhooks route through the plugin translator + core policy.
+- [ ] Source/destination is capability-driven (`OrderSource` gate) — one PS connection can be both without contradiction.
+- [ ] A new plugin's webhook events need **no** core/interface edit — only `register(host)` + a translator class.
+- [ ] `pnpm lint && type-check && test` green; **full `pnpm test:integration` green**.
+
+---
+
+## 9. Alignment Checklist
+- [x] Hexagonal: port in domain, registry in infrastructure, policy in application; adapter in plugin.
+- [x] Capability registered via `HostServices` (mirrors #583/#586/#587); keyed by `adapterKey`.
+- [x] Routing orchestration in **core**, not `apps/api`.
+- [x] Capability gate is a metadata read, not exception-as-control-flow (ADR invariant 3).
+- [x] Translator total (returns `null`, never unbounded throw — invariant 5).
+- [x] No new job type / schema / migration; reuses #902's `marketplace.order.sync` + master jobs.
+- [x] Cross-context edges are type/interface/token-only (cycle-safe).
+
+---
+
+## Related
+- ADR-015 (authoritative design). Epic #900. Phase 1 #902 (merged), Phase 3 #904. Idempotency prerequisite #906 (merged).

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -440,7 +440,7 @@ authoring your plugin). Its four fields:
 
 The `HostServices` bag passed into `register` and `createCapabilityAdapter`
 is defined at
-[`libs/plugin-sdk/src/host-services.ts:52-142`](../libs/plugin-sdk/src/host-services.ts#L52-L142).
+[`libs/plugin-sdk/src/host-services.ts:53-152`](../libs/plugin-sdk/src/host-services.ts#L53-L152).
 It splits into two blocks:
 
 - **Read inputs** (use): `logger`, `identifierMapping`,
@@ -1022,7 +1022,7 @@ If you're proposing a new "bulk" capability on a port, that's almost certainly a
   vertical-slice patterns, the PrestaShop opt-in helper.
 - [`libs/plugin-sdk/src/adapter-plugin.ts:42-110`](../libs/plugin-sdk/src/adapter-plugin.ts#L42-L110)
   — the `AdapterPlugin` contract spec, header-comment form.
-- [`libs/plugin-sdk/src/host-services.ts:52-142`](../libs/plugin-sdk/src/host-services.ts#L52-L142)
+- [`libs/plugin-sdk/src/host-services.ts:53-152`](../libs/plugin-sdk/src/host-services.ts#L53-L152)
   — the `HostServices` bag, fields split into read-inputs vs side
   registries.
 

--- a/libs/core/src/integrations/domain/ports/webhook-event-translator.port.ts
+++ b/libs/core/src/integrations/domain/ports/webhook-event-translator.port.ts
@@ -1,0 +1,32 @@
+/**
+ * Webhook Event Translator Port
+ *
+ * Per-plugin capability that decodes a provider's inbound webhook event into
+ * a neutral `CanonicalInboundEvent` (ADR-015). It is a **pure, payload-in
+ * transform** — no I/O, no connection state — so it joins the shape-validator
+ * / OAuth-completion family of host-bag registries, registered in each
+ * plugin's `register(host)` keyed by `adapterKey`
+ * (`WebhookEventTranslatorRegistryService`). The registry *mechanics* mirror
+ * `WebhookProvisioning`; the *semantics* match the pure validators.
+ *
+ * A plugin maps its **own** webhook vocabulary across **all** the domains it
+ * emits (a single connection may push product + stock + order). It knows
+ * nothing about job types — domain→job routing is the core routing policy's
+ * job. The translator must be **total**: it returns `null` for events it
+ * cannot decode (→ dead-letter) rather than throwing unbounded (only
+ * signature-verified payloads reach it).
+ *
+ * @module libs/core/src/integrations/domain/ports
+ * @see {@link CanonicalInboundEvent} for the neutral output contract
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+import type { CanonicalInboundEvent } from '../types/canonical-inbound-event.types';
+
+export interface WebhookEventTranslatorPort {
+  /**
+   * Decode a provider-native inbound webhook event into a neutral
+   * `CanonicalInboundEvent`, or `null` when the event is not decodable by
+   * this plugin (unknown object type / event type → dead-letter).
+   */
+  translate(event: InboundWebhookEvent): CanonicalInboundEvent | null;
+}

--- a/libs/core/src/integrations/domain/types/canonical-inbound-event.types.ts
+++ b/libs/core/src/integrations/domain/types/canonical-inbound-event.types.ts
@@ -1,0 +1,39 @@
+/**
+ * Canonical Inbound Event Types
+ *
+ * Neutral, plugin-agnostic representation of an inbound webhook event,
+ * produced by a `WebhookEventTranslatorPort` and consumed by the core
+ * inbound routing policy (ADR-015). It is a **transient, in-process value**
+ * passed between two co-located seams (api-side translate → core route);
+ * it is never persisted, so it carries **no `schemaVersion`** — the durable,
+ * versioned contract is the emitted `SyncJobRequest` payload.
+ *
+ * `domain` is the routing key (closed, additive core union). `eventType` is
+ * an **advisory** source-vocabulary string — for the `order` domain the
+ * routing policy coerces it to the poll-path `OrderFeedEventType`; the master
+ * domains ignore it. `payload` is a non-authoritative hint (never source of
+ * truth — the trigger fans out to an authoritative pull).
+ *
+ * @module libs/core/src/integrations/domain/types
+ */
+
+export const InboundEventDomainValues = ['order', 'inventory', 'product'] as const;
+
+export type InboundEventDomain = (typeof InboundEventDomainValues)[number];
+
+export interface CanonicalInboundEvent {
+  /** Routing key — which core domain this event concerns. */
+  domain: InboundEventDomain;
+  /** Source-native external identifier (order/product/stock id). */
+  externalId: string;
+  /**
+   * Advisory source-vocabulary event type (e.g. `created`, `updated`,
+   * `stock.changed`). Consumed only by the `order` domain (coerced to
+   * `OrderFeedEventType`); master domains ignore it.
+   */
+  eventType: string;
+  /** ISO 8601 occurrence time from the webhook (advisory). */
+  occurredAt?: string;
+  /** Non-authoritative payload hint; never source of truth. */
+  payload?: Record<string, unknown>;
+}

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -14,6 +14,7 @@ export { ICredentialsService } from './application/interfaces/credentials.servic
 export { AdapterFactoryResolverService } from './infrastructure/adapters/adapter-factory-resolver.service';
 export { ConnectionTesterRegistryService } from './infrastructure/adapters/connection-tester-registry.service';
 export { WebhookProvisioningRegistryService } from './infrastructure/adapters/webhook-provisioning-registry.service';
+export { WebhookEventTranslatorRegistryService } from './infrastructure/adapters/webhook-event-translator-registry.service';
 export { EmailNormalizerRegistryService } from './infrastructure/adapters/email-normalizer-registry.service';
 export { ConnectionConfigShapeValidatorRegistryService } from './infrastructure/adapters/connection-config-shape-validator-registry.service';
 export { ConnectionCredentialsShapeValidatorRegistryService } from './infrastructure/adapters/connection-credentials-shape-validator-registry.service';
@@ -25,6 +26,7 @@ export { CredentialsResolverPort } from './domain/ports/credentials-resolver.por
 export { AdapterFactoryPort } from './domain/ports/adapter-factory.port';
 export { ConnectionTesterPort } from './domain/ports/connection-tester.port';
 export { WebhookProvisioningPort } from './domain/ports/webhook-provisioning.port';
+export { WebhookEventTranslatorPort } from './domain/ports/webhook-event-translator.port';
 export { EmailNormalizerPort } from './domain/ports/email-normalizer.port';
 export { ConnectionConfigShapeValidatorPort } from './domain/ports/connection-config-shape-validator.port';
 export { ConnectionCredentialsShapeValidatorPort } from './domain/ports/connection-credentials-shape-validator.port';
@@ -48,6 +50,11 @@ export {
 } from './domain/types/adapter.types';
 export { ConnectionTestResult } from './domain/types/connection-test.types';
 export { WebhookProvisioningResult } from './domain/types/webhook-provisioning.types';
+export {
+  CanonicalInboundEvent,
+  InboundEventDomain,
+  InboundEventDomainValues,
+} from './domain/types/canonical-inbound-event.types';
 export {
   OAuthCredentialBlob,
   BuildAuthorizationUrlInput,

--- a/libs/core/src/integrations/infrastructure/adapters/__tests__/webhook-event-translator-registry.service.spec.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/__tests__/webhook-event-translator-registry.service.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Webhook Event Translator Registry Service Unit Tests
+ *
+ * @module libs/core/src/integrations/infrastructure/adapters/__tests__
+ */
+import { WebhookEventTranslatorRegistryService } from '../webhook-event-translator-registry.service';
+import type { WebhookEventTranslatorPort } from '../../../domain/ports/webhook-event-translator.port';
+
+describe('WebhookEventTranslatorRegistryService', () => {
+  let registry: WebhookEventTranslatorRegistryService;
+  const translator: WebhookEventTranslatorPort = { translate: () => null };
+
+  beforeEach(() => {
+    registry = new WebhookEventTranslatorRegistryService();
+  });
+
+  it('should return the registered translator by adapterKey', () => {
+    registry.register('prestashop.webservice.v1', translator);
+
+    expect(registry.get('prestashop.webservice.v1')).toBe(translator);
+    expect(registry.has('prestashop.webservice.v1')).toBe(true);
+  });
+
+  it('should return undefined for an unregistered adapterKey', () => {
+    expect(registry.get('unknown.adapter.v1')).toBeUndefined();
+    expect(registry.has('unknown.adapter.v1')).toBe(false);
+  });
+
+  it('should overwrite a duplicate adapterKey registration (last wins)', () => {
+    const second: WebhookEventTranslatorPort = { translate: () => null };
+    registry.register('prestashop.webservice.v1', translator);
+    registry.register('prestashop.webservice.v1', second);
+
+    expect(registry.get('prestashop.webservice.v1')).toBe(second);
+  });
+});

--- a/libs/core/src/integrations/infrastructure/adapters/webhook-event-translator-registry.service.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/webhook-event-translator-registry.service.ts
@@ -1,0 +1,36 @@
+/**
+ * Webhook Event Translator Registry Service
+ *
+ * Holds `WebhookEventTranslatorPort` implementations keyed by `adapterKey`.
+ * Integration plugins register their translator in `register(host)` at
+ * bootstrap, mirroring `WebhookProvisioningRegistryService` /
+ * `ConnectionTesterRegistryService` (ADR-015). Consumed by the inbound
+ * webhook dispatcher (`WebhookToJobHandler`) to decode a connection's native
+ * event into a neutral `CanonicalInboundEvent` before the core routing policy
+ * decides the job — so the dispatcher carries zero platform knowledge.
+ *
+ * Silent overwrite on duplicate `adapterKey` mirrors the sister registries;
+ * plugins register exactly once at boot.
+ *
+ * @module libs/core/src/integrations/infrastructure/adapters
+ * @see {@link WebhookEventTranslatorPort} for the port interface
+ */
+import { Injectable } from '@nestjs/common';
+import type { WebhookEventTranslatorPort } from '../../domain/ports/webhook-event-translator.port';
+
+@Injectable()
+export class WebhookEventTranslatorRegistryService {
+  private readonly translators: Map<string, WebhookEventTranslatorPort> = new Map();
+
+  register(adapterKey: string, translator: WebhookEventTranslatorPort): void {
+    this.translators.set(adapterKey, translator);
+  }
+
+  get(adapterKey: string): WebhookEventTranslatorPort | undefined {
+    return this.translators.get(adapterKey);
+  }
+
+  has(adapterKey: string): boolean {
+    return this.translators.has(adapterKey);
+  }
+}

--- a/libs/core/src/integrations/integrations.module.ts
+++ b/libs/core/src/integrations/integrations.module.ts
@@ -18,6 +18,7 @@ import { CredentialsResolverService } from './infrastructure/credentials/credent
 import { AdapterFactoryResolverService } from './infrastructure/adapters/adapter-factory-resolver.service';
 import { ConnectionTesterRegistryService } from './infrastructure/adapters/connection-tester-registry.service';
 import { WebhookProvisioningRegistryService } from './infrastructure/adapters/webhook-provisioning-registry.service';
+import { WebhookEventTranslatorRegistryService } from './infrastructure/adapters/webhook-event-translator-registry.service';
 import { EmailNormalizerRegistryService } from './infrastructure/adapters/email-normalizer-registry.service';
 import { ConnectionConfigShapeValidatorRegistryService } from './infrastructure/adapters/connection-config-shape-validator-registry.service';
 import { ConnectionCredentialsShapeValidatorRegistryService } from './infrastructure/adapters/connection-credentials-shape-validator-registry.service';
@@ -38,6 +39,7 @@ import {
   INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
   CONNECTION_TESTER_REGISTRY_TOKEN,
   WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
   EMAIL_NORMALIZER_REGISTRY_TOKEN,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -56,6 +58,7 @@ export {
   INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
   CONNECTION_TESTER_REGISTRY_TOKEN,
   WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
   EMAIL_NORMALIZER_REGISTRY_TOKEN,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -75,6 +78,7 @@ export {
     AdapterFactoryResolverService,
     ConnectionTesterRegistryService,
     WebhookProvisioningRegistryService,
+    WebhookEventTranslatorRegistryService,
     EmailNormalizerRegistryService,
     ConnectionConfigShapeValidatorRegistryService,
     ConnectionCredentialsShapeValidatorRegistryService,
@@ -107,6 +111,10 @@ export {
     {
       provide: WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
       useExisting: WebhookProvisioningRegistryService,
+    },
+    {
+      provide: WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+      useExisting: WebhookEventTranslatorRegistryService,
     },
     {
       provide: EMAIL_NORMALIZER_REGISTRY_TOKEN,
@@ -148,6 +156,7 @@ export {
     ADAPTER_FACTORY_RESOLVER_TOKEN,
     CONNECTION_TESTER_REGISTRY_TOKEN,
     WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
+    WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
     EMAIL_NORMALIZER_REGISTRY_TOKEN,
     CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
     CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -161,6 +170,7 @@ export {
     AdapterFactoryResolverService,
     ConnectionTesterRegistryService,
     WebhookProvisioningRegistryService,
+    WebhookEventTranslatorRegistryService,
     EmailNormalizerRegistryService,
     ConnectionConfigShapeValidatorRegistryService,
     ConnectionCredentialsShapeValidatorRegistryService,

--- a/libs/core/src/integrations/integrations.tokens.ts
+++ b/libs/core/src/integrations/integrations.tokens.ts
@@ -19,6 +19,9 @@ export const INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN = Symbol('IntegrationCreden
 export const CREDENTIALS_SERVICE_TOKEN = Symbol('ICredentialsService');
 export const CONNECTION_TESTER_REGISTRY_TOKEN = Symbol('ConnectionTesterRegistryService');
 export const WEBHOOK_PROVISIONING_REGISTRY_TOKEN = Symbol('WebhookProvisioningRegistryService');
+export const WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN = Symbol(
+  'WebhookEventTranslatorRegistryService',
+);
 export const PLUGIN_REGISTRY_OPTIONS_TOKEN = Symbol('PluginRegistryOptions');
 export const EMAIL_NORMALIZER_REGISTRY_TOKEN = Symbol('EmailNormalizerRegistryService');
 export const CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN = Symbol(

--- a/libs/core/src/sync/application/interfaces/inbound-routing-policy.service.interface.ts
+++ b/libs/core/src/sync/application/interfaces/inbound-routing-policy.service.interface.ts
@@ -1,0 +1,38 @@
+/**
+ * Inbound Routing Policy Service Interface
+ *
+ * Core sync-orchestration policy that maps a neutral `CanonicalInboundEvent`
+ * to a sync job, gated on the connection's resolved capabilities (ADR-015).
+ * Deterministic `domain → required capability → jobType` routing; enqueues the
+ * resulting job. The inbound webhook dispatcher delegates the "which job?"
+ * decision here so no platform knowledge lives in the interface layer.
+ *
+ * @module libs/core/src/sync/application/interfaces
+ */
+import type { CanonicalInboundEvent } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { RoutingOutcome } from '../types/inbound-routing-policy.types';
+
+export interface IInboundRoutingPolicyService {
+  /**
+   * Route a canonical inbound event to a sync job for the given connection.
+   *
+   * Gates on capability (the event's domain requires a specific capability to
+   * be both adapter-supported and connection-enabled); on a passed gate the
+   * job is enqueued and `{ status: 'enqueued' }` returned. On a failed gate no
+   * job is enqueued and `{ status: 'ungated' }` is returned so the caller can
+   * dead-letter.
+   *
+   * @param event - The neutral canonical inbound event (from a translator).
+   * @param connection - The resolved source connection.
+   * @param supportedCapabilities - The connection's adapter `supportedCapabilities`
+   *   (resolved by the caller), the adapter-level half of the capability gate.
+   * @param sourceEventId - The source webhook event id (idempotency + traceability).
+   */
+  route(
+    event: CanonicalInboundEvent,
+    connection: Connection,
+    supportedCapabilities: readonly string[],
+    sourceEventId: string
+  ): Promise<RoutingOutcome>;
+}

--- a/libs/core/src/sync/application/services/__tests__/inbound-routing-policy.service.spec.ts
+++ b/libs/core/src/sync/application/services/__tests__/inbound-routing-policy.service.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Inbound Routing Policy Service Unit Tests
+ *
+ * @module libs/core/src/sync/application/services/__tests__
+ */
+import type { CanonicalInboundEvent } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { InboundRoutingPolicyService } from '../inbound-routing-policy.service';
+import type { JobEnqueuePort } from '../../../domain/ports/job-enqueue.port';
+
+describe('InboundRoutingPolicyService', () => {
+  let service: InboundRoutingPolicyService;
+  let jobEnqueue: jest.Mocked<JobEnqueuePort>;
+
+  const connection = (enabled: string[]): Connection =>
+    ({
+      id: 'conn-1',
+      platformType: 'prestashop',
+      adapterKey: 'prestashop.webservice.v1',
+      enabledCapabilities: enabled,
+    }) as unknown as Connection;
+
+  const event = (overrides: Partial<CanonicalInboundEvent>): CanonicalInboundEvent => ({
+    domain: 'order',
+    externalId: '42',
+    eventType: 'created',
+    occurredAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jobEnqueue = { enqueueJob: jest.fn().mockResolvedValue({ jobId: 'job-1', isExisting: false }) };
+    service = new InboundRoutingPolicyService(jobEnqueue);
+  });
+
+  it('should route an order event to marketplace.order.sync when OrderSource is supported and enabled', async () => {
+    const outcome = await service.route(
+      event({ domain: 'order' }),
+      connection(['OrderSource']),
+      ['OrderSource'],
+      'evt-9'
+    );
+
+    expect(outcome).toEqual({ status: 'enqueued', jobId: 'job-1', jobType: 'marketplace.order.sync' });
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith({
+      jobType: 'marketplace.order.sync',
+      connectionId: 'conn-1',
+      payload: {
+        schemaVersion: 1,
+        externalOrderId: '42',
+        sourceEventId: 'evt-9',
+        eventType: 'created',
+        occurredAt: '2026-01-01T00:00:00.000Z',
+      },
+      idempotencyKey: 'prestashop:conn-1:evt-9',
+    });
+  });
+
+  it('should coerce an unknown order eventType to updated', async () => {
+    await service.route(
+      event({ domain: 'order', eventType: 'refunded' }),
+      connection(['OrderSource']),
+      ['OrderSource'],
+      'evt-9'
+    );
+
+    const enqueued = jobEnqueue.enqueueJob.mock.calls[0][0];
+    expect((enqueued.payload as { eventType: string }).eventType).toBe('updated');
+  });
+
+  it('should route an inventory event to master.inventory.syncByExternalId with objectType Inventory', async () => {
+    const outcome = await service.route(
+      event({ domain: 'inventory', eventType: 'stock.changed' }),
+      connection(['InventoryMaster']),
+      ['InventoryMaster'],
+      'evt-9'
+    );
+
+    expect(outcome.status).toBe('enqueued');
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobType: 'master.inventory.syncByExternalId',
+        payload: { schemaVersion: 1, externalId: '42', objectType: 'Inventory' },
+      })
+    );
+  });
+
+  it('should route a product event to master.product.syncByExternalId with objectType Product', async () => {
+    const outcome = await service.route(
+      event({ domain: 'product', eventType: 'product.saved' }),
+      connection(['ProductMaster']),
+      ['ProductMaster'],
+      'evt-9'
+    );
+
+    expect(outcome.status).toBe('enqueued');
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobType: 'master.product.syncByExternalId',
+        payload: { schemaVersion: 1, externalId: '42', objectType: 'Product' },
+      })
+    );
+  });
+
+  it('should not enqueue and return ungated when the capability is supported but not enabled', async () => {
+    const outcome = await service.route(
+      event({ domain: 'order' }),
+      connection([]),
+      ['OrderSource'],
+      'evt-9'
+    );
+
+    expect(outcome).toEqual({ status: 'ungated', domain: 'order', requiredCapability: 'OrderSource' });
+    expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+  });
+
+  it('should not enqueue and return ungated when the capability is enabled but not adapter-supported', async () => {
+    const outcome = await service.route(
+      event({ domain: 'order' }),
+      connection(['OrderSource']),
+      [],
+      'evt-9'
+    );
+
+    expect(outcome.status).toBe('ungated');
+    expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+  });
+});

--- a/libs/core/src/sync/application/services/inbound-routing-policy.service.ts
+++ b/libs/core/src/sync/application/services/inbound-routing-policy.service.ts
@@ -1,0 +1,149 @@
+/**
+ * Inbound Routing Policy Service
+ *
+ * Maps a neutral `CanonicalInboundEvent` to a sync job and enqueues it,
+ * gated on the connection's resolved capabilities (ADR-015). This is the
+ * single place that decides "which job does this inbound event become?" —
+ * a deterministic, platform-agnostic table keyed on the event's `domain`.
+ * The inbound webhook dispatcher (`WebhookToJobHandler`) carries zero
+ * platform knowledge and delegates here.
+ *
+ * Gate = the adapter's `supportedCapabilities` (passed in by the dispatcher,
+ * which already resolved the connection's metadata) **and**
+ * `connection.enabledCapabilities` (connection-level) — both pure reads, never
+ * exception-as-control-flow — so a connection that supports but has disabled
+ * the capability does not enqueue a job guaranteed to fail downstream. The
+ * policy is a pure function of its inputs (no I/O beyond the enqueue).
+ *
+ * @module libs/core/src/sync/application/services
+ * @implements {IInboundRoutingPolicyService}
+ */
+import { Injectable, Inject } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import type { CanonicalInboundEvent, CoreCapability } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { OrderFeedEventType } from '@openlinker/core/orders';
+import type { IInboundRoutingPolicyService } from '../interfaces/inbound-routing-policy.service.interface';
+import type { RoutingOutcome } from '../types/inbound-routing-policy.types';
+import { JobEnqueuePort } from '../../domain/ports/job-enqueue.port';
+import { JOB_ENQUEUE_TOKEN } from '../../sync.tokens';
+import type { JobType, SyncJobRequest } from '../../domain/types/sync-job.types';
+import type { MarketplaceOrderSyncPayloadV1 } from '../../domain/types/marketplace-job-payloads.types';
+import type {
+  MasterInventorySyncByExternalIdPayloadV1,
+  MasterProductSyncByExternalIdPayloadV1,
+} from '../../domain/types/master-job-payloads.types';
+
+/**
+ * Local mirror of the order-domain event vocabulary. `OrderFeedEventType` is
+ * imported **type-only** (no runtime `@openlinker/core/orders` barrel load) so
+ * the `sync` barrel doesn't gain a `sync → orders` value edge — the orders
+ * barrel re-exports `OrdersModule`, which imports `SyncModule`, so a value
+ * import here would close a runtime module cycle. `satisfies` guards drift:
+ * removing a token upstream breaks this at compile time.
+ */
+const ORDER_FEED_EVENT_TYPES = [
+  'created',
+  'updated',
+  'cancelled',
+  'paid',
+] as const satisfies readonly OrderFeedEventType[];
+
+@Injectable()
+export class InboundRoutingPolicyService implements IInboundRoutingPolicyService {
+  private readonly logger = new Logger(InboundRoutingPolicyService.name);
+
+  constructor(
+    @Inject(JOB_ENQUEUE_TOKEN)
+    private readonly jobEnqueue: JobEnqueuePort
+  ) {}
+
+  async route(
+    event: CanonicalInboundEvent,
+    connection: Connection,
+    supportedCapabilities: readonly string[],
+    sourceEventId: string
+  ): Promise<RoutingOutcome> {
+    const { jobType, requiredCapability, payload } = this.resolveRoute(event, sourceEventId);
+
+    const supported = supportedCapabilities.includes(requiredCapability);
+    const enabled = connection.enabledCapabilities.includes(requiredCapability);
+    if (!supported || !enabled) {
+      this.logger.warn(
+        `Inbound ${event.domain} event for connection ${connection.id} ungated: ` +
+          `requires ${requiredCapability} (supported=${supported}, enabled=${enabled})`
+      );
+      return { status: 'ungated', domain: event.domain, requiredCapability };
+    }
+
+    const job: SyncJobRequest = {
+      jobType,
+      connectionId: connection.id,
+      payload,
+      idempotencyKey: `${connection.platformType}:${connection.id}:${sourceEventId}`,
+    };
+    const { jobId } = await this.jobEnqueue.enqueueJob(job);
+    this.logger.log(
+      `Routed inbound ${event.domain} event (externalId=${event.externalId}) for connection ` +
+        `${connection.id} → ${jobType} (job ${jobId})`
+    );
+    return { status: 'enqueued', jobId, jobType };
+  }
+
+  /**
+   * Deterministic `domain → { capability, jobType, payload }` routing table.
+   * Payloads `satisfies` the existing job-payload contracts (verified against
+   * the worker handlers): master jobs carry no `eventType`; only the order
+   * payload consumes the (advisory) canonical `eventType`.
+   */
+  private resolveRoute(
+    event: CanonicalInboundEvent,
+    sourceEventId: string
+  ): { jobType: JobType; requiredCapability: CoreCapability; payload: SyncJobRequest['payload'] } {
+    switch (event.domain) {
+      case 'order':
+        return {
+          jobType: 'marketplace.order.sync',
+          requiredCapability: 'OrderSource',
+          payload: {
+            schemaVersion: 1,
+            externalOrderId: event.externalId,
+            sourceEventId,
+            eventType: this.toOrderFeedEventType(event.eventType),
+            occurredAt: event.occurredAt,
+          } satisfies MarketplaceOrderSyncPayloadV1,
+        };
+      case 'inventory':
+        return {
+          jobType: 'master.inventory.syncByExternalId',
+          requiredCapability: 'InventoryMaster',
+          payload: {
+            schemaVersion: 1,
+            externalId: event.externalId,
+            objectType: 'Inventory',
+          } satisfies MasterInventorySyncByExternalIdPayloadV1,
+        };
+      case 'product':
+        return {
+          jobType: 'master.product.syncByExternalId',
+          requiredCapability: 'ProductMaster',
+          payload: {
+            schemaVersion: 1,
+            externalId: event.externalId,
+            objectType: 'Product',
+          } satisfies MasterProductSyncByExternalIdPayloadV1,
+        };
+      default: {
+        // Exhaustive — `domain` is a closed union; this guards future additions.
+        const exhaustive: never = event.domain;
+        throw new Error(`Unhandled inbound event domain: ${String(exhaustive)}`);
+      }
+    }
+  }
+
+  private toOrderFeedEventType(eventType: string): OrderFeedEventType {
+    return (ORDER_FEED_EVENT_TYPES as readonly string[]).includes(eventType)
+      ? (eventType as OrderFeedEventType)
+      : 'updated';
+  }
+}

--- a/libs/core/src/sync/application/types/inbound-routing-policy.types.ts
+++ b/libs/core/src/sync/application/types/inbound-routing-policy.types.ts
@@ -1,0 +1,13 @@
+/**
+ * Inbound Routing Policy Types
+ *
+ * Result of routing a `CanonicalInboundEvent` to a sync job (ADR-015).
+ *
+ * @module libs/core/src/sync/application/types
+ */
+import type { CoreCapability, InboundEventDomain } from '@openlinker/core/integrations';
+import type { JobType } from '../../domain/types/sync-job.types';
+
+export type RoutingOutcome =
+  | { status: 'enqueued'; jobId: string; jobType: JobType }
+  | { status: 'ungated'; domain: InboundEventDomain; requiredCapability: CoreCapability };

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -101,6 +101,12 @@ export type { ISyncJobsService } from './application/services/sync-jobs.service.
 export type { ScheduleJobInput } from './application/services/sync-jobs.types';
 export type { ISyncCursorsService } from './application/services/sync-cursors.service.interface';
 
+// Inbound routing policy (ADR-015) — class is value-exported so the API webhooks
+// module can bind it; deps (IIntegrationsService, JobEnqueuePort) resolve there.
+export { InboundRoutingPolicyService } from './application/services/inbound-routing-policy.service';
+export type { IInboundRoutingPolicyService } from './application/interfaces/inbound-routing-policy.service.interface';
+export type { RoutingOutcome } from './application/types/inbound-routing-policy.types';
+
 // Module and tokens
 export { SyncModule } from './sync.module';
 export * from './sync.tokens';

--- a/libs/core/src/sync/sync.tokens.ts
+++ b/libs/core/src/sync/sync.tokens.ts
@@ -21,6 +21,7 @@ export const AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN = Symbol('AuthFailureClassif
 export const SCHEDULER_TASK_REGISTRY_TOKEN = Symbol('SchedulerTaskRegistryService');
 export const SYNC_JOBS_SERVICE_TOKEN = Symbol('ISyncJobsService');
 export const SYNC_CURSORS_SERVICE_TOKEN = Symbol('ISyncCursorsService');
+export const INBOUND_ROUTING_POLICY_TOKEN = Symbol('IInboundRoutingPolicyService');
 
 
 

--- a/libs/integrations/allegro/src/allegro-integration.module.ts
+++ b/libs/integrations/allegro/src/allegro-integration.module.ts
@@ -31,6 +31,8 @@ import {
   EmailNormalizerRegistryService,
   WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
   WebhookProvisioningRegistryService,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  WebhookEventTranslatorRegistryService,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionConfigShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -117,6 +119,8 @@ export class AllegroIntegrationModule implements OnModuleInit {
     private readonly emailNormalizerRegistry: EmailNormalizerRegistryService,
     @Inject(WEBHOOK_PROVISIONING_REGISTRY_TOKEN)
     private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
+    @Inject(WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN)
+    private readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService,
     @Inject(CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN)
     private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
     @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
@@ -180,6 +184,7 @@ export class AllegroIntegrationModule implements OnModuleInit {
       authFailureClassifierRegistry: this.authFailureClassifierRegistry,
       schedulerTaskRegistry: this.schedulerTaskRegistry,
       webhookProvisioningRegistry: this.webhookProvisioningRegistry,
+      webhookEventTranslatorRegistry: this.webhookEventTranslatorRegistry,
       connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
       connectionCredentialsShapeValidatorRegistry: this.connectionCredentialsShapeValidatorRegistry,
       oauthCompletionRegistry: this.oauthCompletionRegistry,

--- a/libs/integrations/prestashop/src/__tests__/prestashop-plugin.spec.ts
+++ b/libs/integrations/prestashop/src/__tests__/prestashop-plugin.spec.ts
@@ -172,6 +172,7 @@ describe('createPrestashopPlugin → register(host)', () => {
       }),
       connectionTesterRegistry: { register: jest.fn() },
       webhookProvisioningRegistry: { register: jest.fn() },
+      webhookEventTranslatorRegistry: { register: jest.fn() },
       connectionConfigShapeValidatorRegistry: configRegistry,
       connectionCredentialsShapeValidatorRegistry: credentialsRegistry,
       schedulerTaskRegistry: { register: jest.fn() },

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-webhook-event-translator.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-webhook-event-translator.adapter.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * PrestaShop Webhook Event Translator Adapter Unit Tests
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/adapters/__tests__
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+import { PrestashopWebhookEventTranslatorAdapter } from '../prestashop-webhook-event-translator.adapter';
+
+describe('PrestashopWebhookEventTranslatorAdapter', () => {
+  const translator = new PrestashopWebhookEventTranslatorAdapter();
+
+  const event = (overrides: Partial<InboundWebhookEvent>): InboundWebhookEvent => ({
+    eventId: 'evt-1',
+    provider: 'prestashop',
+    connectionId: 'conn-1',
+    eventType: 'order.created',
+    occurredAt: '2026-01-01T00:00:00.000Z',
+    receivedAt: '2026-01-01T00:00:01.000Z',
+    objectType: 'order',
+    externalId: '42',
+    payload: {},
+    ...overrides,
+  });
+
+  it('should translate order.created to the order domain with created', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'order.created' }));
+
+    expect(result).toEqual({
+      domain: 'order',
+      externalId: '42',
+      eventType: 'created',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      payload: {},
+    });
+  });
+
+  it('should map order.status_changed to updated', () => {
+    const result = translator.translate(
+      event({ objectType: 'order', eventType: 'order.status_changed' })
+    );
+
+    expect(result?.domain).toBe('order');
+    expect(result?.eventType).toBe('updated');
+  });
+
+  it('should default an unknown order event type to updated', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'order.weird' }));
+
+    expect(result?.eventType).toBe('updated');
+  });
+
+  it('should translate stock to the inventory domain', () => {
+    const result = translator.translate(
+      event({ objectType: 'stock', eventType: 'stock.changed', externalId: '7' })
+    );
+
+    expect(result?.domain).toBe('inventory');
+    expect(result?.externalId).toBe('7');
+  });
+
+  it('should translate product to the product domain', () => {
+    const result = translator.translate(
+      event({ objectType: 'product', eventType: 'product.saved', externalId: '99' })
+    );
+
+    expect(result?.domain).toBe('product');
+    expect(result?.externalId).toBe('99');
+  });
+
+  it('should be case-insensitive on objectType', () => {
+    const result = translator.translate(event({ objectType: 'ORDER', eventType: 'order.created' }));
+
+    expect(result?.domain).toBe('order');
+  });
+
+  it('should return null for an unknown object type (undecodable → dead-letter)', () => {
+    expect(translator.translate(event({ objectType: 'category' }))).toBeNull();
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-webhook-event-translator.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-webhook-event-translator.adapter.ts
@@ -1,0 +1,75 @@
+/**
+ * PrestaShop Webhook Event Translator Adapter (#903 / ADR-015)
+ *
+ * Decodes PrestaShop OL-module inbound webhook events into neutral
+ * `CanonicalInboundEvent`s. Pure transform — no I/O, no connection state.
+ * The PS module emits these `objectType`/`eventType` pairs:
+ *   - `order`   + `order.created` / `order.status_changed`
+ *   - `stock`   + `stock.changed`      → canonical domain `inventory`
+ *   - `product` + `product.saved`
+ * (`test.ping` is short-circuited by the dispatcher before translation.)
+ *
+ * This is the only place that holds PrestaShop's webhook vocabulary — the
+ * core routing policy maps `domain → job` with zero platform knowledge.
+ * Unknown object types return `null` (→ dead-letter), keeping the translator
+ * total (ADR-015 invariant 5).
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/adapters
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+import type {
+  CanonicalInboundEvent,
+  WebhookEventTranslatorPort,
+} from '@openlinker/core/integrations';
+
+export class PrestashopWebhookEventTranslatorAdapter implements WebhookEventTranslatorPort {
+  translate(event: InboundWebhookEvent): CanonicalInboundEvent | null {
+    const objectType = event.objectType.toLowerCase();
+
+    switch (objectType) {
+      case 'order':
+        return {
+          domain: 'order',
+          externalId: event.externalId,
+          eventType: this.orderEventType(event.eventType),
+          occurredAt: event.occurredAt,
+          payload: event.payload,
+        };
+      case 'stock':
+        return {
+          domain: 'inventory',
+          externalId: event.externalId,
+          eventType: event.eventType,
+          occurredAt: event.occurredAt,
+          payload: event.payload,
+        };
+      case 'product':
+        return {
+          domain: 'product',
+          externalId: event.externalId,
+          eventType: event.eventType,
+          occurredAt: event.occurredAt,
+          payload: event.payload,
+        };
+      default:
+        // Unknown object type — not decodable by this plugin → dead-letter.
+        return null;
+    }
+  }
+
+  /**
+   * Map the PS order event type into the order domain's advisory vocabulary.
+   * `OrderFeedEventType` has no `status_changed`, so a status change is an
+   * `updated`; unknown order events also fall back to `updated` (a safe re-pull).
+   */
+  private orderEventType(eventType: string): string {
+    switch (eventType) {
+      case 'order.created':
+        return 'created';
+      case 'order.status_changed':
+        return 'updated';
+      default:
+        return 'updated';
+    }
+  }
+}

--- a/libs/integrations/prestashop/src/prestashop-integration.module.ts
+++ b/libs/integrations/prestashop/src/prestashop-integration.module.ts
@@ -35,6 +35,8 @@ import {
   EmailNormalizerRegistryService,
   WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
   WebhookProvisioningRegistryService,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  WebhookEventTranslatorRegistryService,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionConfigShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -105,6 +107,8 @@ export class PrestashopIntegrationModule implements OnModuleInit {
     private readonly emailNormalizerRegistry: EmailNormalizerRegistryService,
     @Inject(WEBHOOK_PROVISIONING_REGISTRY_TOKEN)
     private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
+    @Inject(WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN)
+    private readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService,
     @Inject(CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN)
     private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
     @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
@@ -163,6 +167,7 @@ export class PrestashopIntegrationModule implements OnModuleInit {
       authFailureClassifierRegistry: this.authFailureClassifierRegistry,
       schedulerTaskRegistry: this.schedulerTaskRegistry,
       webhookProvisioningRegistry: this.webhookProvisioningRegistry,
+      webhookEventTranslatorRegistry: this.webhookEventTranslatorRegistry,
       connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
       connectionCredentialsShapeValidatorRegistry: this.connectionCredentialsShapeValidatorRegistry,
       oauthCompletionRegistry: this.oauthCompletionRegistry,

--- a/libs/integrations/prestashop/src/prestashop-plugin.ts
+++ b/libs/integrations/prestashop/src/prestashop-plugin.ts
@@ -31,6 +31,7 @@ import type { IMappingConfigService } from '@openlinker/core/mappings';
 import { PrestashopAdapterFactory } from './application/prestashop-adapter.factory';
 import { PrestashopConnectionTesterAdapter } from './infrastructure/adapters/prestashop-connection-tester.adapter';
 import { PrestashopConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/prestashop-connection-config-shape-validator.adapter';
+import { PrestashopWebhookEventTranslatorAdapter } from './infrastructure/adapters/prestashop-webhook-event-translator.adapter';
 import { PrestashopConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/prestashop-connection-credentials-shape-validator.adapter';
 import { buildPrestashopSchedulerTasks } from './infrastructure/scheduler/prestashop-scheduler-tasks';
 import type { PrestashopCustomerProvisioner } from './infrastructure/provisioners/prestashop-customer-provisioner';
@@ -99,6 +100,12 @@ export function createPrestashopPlugin(deps: CreatePrestashopPluginDeps): Adapte
       host.webhookProvisioningRegistry.register(
         'prestashop.webservice.v1',
         deps.webhookProvisioningAdapter,
+      );
+      // Inbound webhook-event translator (ADR-015 / #903) — decodes PS
+      // order/stock/product events into neutral CanonicalInboundEvents.
+      host.webhookEventTranslatorRegistry.register(
+        'prestashop.webservice.v1',
+        new PrestashopWebhookEventTranslatorAdapter(),
       );
       host.connectionConfigShapeValidatorRegistry.register(
         'prestashop.webservice.v1',

--- a/libs/plugin-sdk/src/create-nest-adapter-module.spec.ts
+++ b/libs/plugin-sdk/src/create-nest-adapter-module.spec.ts
@@ -22,6 +22,7 @@ import {
   CONNECTION_TESTER_REGISTRY_TOKEN,
   EMAIL_NORMALIZER_REGISTRY_TOKEN,
   WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
@@ -57,6 +58,7 @@ describe('createNestAdapterModule', () => {
     connectionTesterRegistry: object;
     emailNormalizerRegistry: object;
     webhookProvisioningRegistry: object;
+    webhookEventTranslatorRegistry: object;
     connectionConfigShapeValidatorRegistry: object;
     connectionCredentialsShapeValidatorRegistry: object;
     oauthCompletionRegistry: object;
@@ -72,6 +74,7 @@ describe('createNestAdapterModule', () => {
       connectionTesterRegistry: {},
       emailNormalizerRegistry: {},
       webhookProvisioningRegistry: {},
+      webhookEventTranslatorRegistry: {},
       connectionConfigShapeValidatorRegistry: {},
       connectionCredentialsShapeValidatorRegistry: {},
       oauthCompletionRegistry: {},
@@ -100,6 +103,10 @@ describe('createNestAdapterModule', () => {
         { provide: CONNECTION_TESTER_REGISTRY_TOKEN, useValue: registries.connectionTesterRegistry },
         { provide: EMAIL_NORMALIZER_REGISTRY_TOKEN, useValue: registries.emailNormalizerRegistry },
         { provide: WEBHOOK_PROVISIONING_REGISTRY_TOKEN, useValue: registries.webhookProvisioningRegistry },
+        {
+          provide: WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+          useValue: registries.webhookEventTranslatorRegistry,
+        },
         {
           provide: CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
           useValue: registries.connectionConfigShapeValidatorRegistry,

--- a/libs/plugin-sdk/src/create-nest-adapter-module.ts
+++ b/libs/plugin-sdk/src/create-nest-adapter-module.ts
@@ -42,6 +42,8 @@ import {
   EmailNormalizerRegistryService,
   WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
   WebhookProvisioningRegistryService,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  WebhookEventTranslatorRegistryService,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionConfigShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -106,6 +108,8 @@ export function createNestAdapterModule(options: CreateNestAdapterModuleOptions)
       private readonly emailNormalizerRegistry: EmailNormalizerRegistryService,
       @Inject(WEBHOOK_PROVISIONING_REGISTRY_TOKEN)
       private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
+      @Inject(WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN)
+      private readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService,
       @Inject(CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN)
       private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
       @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
@@ -145,6 +149,7 @@ export function createNestAdapterModule(options: CreateNestAdapterModuleOptions)
         authFailureClassifierRegistry: this.authFailureClassifierRegistry,
         schedulerTaskRegistry: this.schedulerTaskRegistry,
         webhookProvisioningRegistry: this.webhookProvisioningRegistry,
+        webhookEventTranslatorRegistry: this.webhookEventTranslatorRegistry,
         connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
         connectionCredentialsShapeValidatorRegistry:
           this.connectionCredentialsShapeValidatorRegistry,

--- a/libs/plugin-sdk/src/host-services.ts
+++ b/libs/plugin-sdk/src/host-services.ts
@@ -38,6 +38,7 @@ import type {
   ConnectionTesterRegistryService,
   EmailNormalizerRegistryService,
   WebhookProvisioningRegistryService,
+  WebhookEventTranslatorRegistryService,
   ConnectionConfigShapeValidatorRegistryService,
   ConnectionCredentialsShapeValidatorRegistryService,
   OAuthCompletionRegistryService,
@@ -111,6 +112,15 @@ export interface HostServices {
 
   /** Webhook-provisioning registry — adapter-installable webhook flows (#583). */
   readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService;
+
+  /**
+   * Webhook-event-translator registry (ADR-015 / #903). A plugin registers a
+   * `WebhookEventTranslatorPort` here to decode its native inbound webhook
+   * events into neutral `CanonicalInboundEvent`s. Pure, payload-in transform —
+   * the core routing policy then maps domain → job. Absence degrades to
+   * poll-only (a stray webhook dead-letters as "no translator").
+   */
+  readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService;
 
   /**
    * Per-plugin `Connection.config` shape-validator registry (#587). A plugin

--- a/scripts/check-plugin-guide-quotes.mjs
+++ b/scripts/check-plugin-guide-quotes.mjs
@@ -18,7 +18,7 @@
  *      110; the link still resolves but lands on the wrong content.
  *
  *   3. **Boundary check** for the `HostServices` interface at
- *      `libs/plugin-sdk/src/host-services.ts:52-142`. Same shape.
+ *      `libs/plugin-sdk/src/host-services.ts:53-152`. Same shape.
  *
  * Both checks are deliberately strict: when they fire on a benign
  * refactor (e.g., new import above the interface), the human updates
@@ -68,9 +68,9 @@ const BOUNDARY_REFS = [
   {
     label: 'HostServices',
     sourceFile: 'libs/plugin-sdk/src/host-services.ts',
-    sourceStart: 52,
-    sourceEnd: 142,
-    guideLinkSubstring: 'host-services.ts:52-142',
+    sourceStart: 53,
+    sourceEnd: 152,
+    guideLinkSubstring: 'host-services.ts:53-152',
     expectedStart: /^export interface HostServices \{$/,
     expectedEnd: /^\}\s*$/,
   },


### PR DESCRIPTION
## What & why

ADR-015 **Phase 2** (#903) — the architectural payoff of the inbound-routing epic (#900). Webhook-event **translation** moves into the plugin (a new per-plugin capability) and **routing policy** into core, so the interface-layer handler stops string-matching platform names. This **deletes** `isMasterProvider = provider === 'prestashop'`, the `mapObjectType` allow-list, and the `master.*`-vs-`marketplace.*` order-job split that #902 deliberately left in place.

Now: source-vs-destination is a **capability** decision (one PrestaShop connection can be both), and adding a new platform's webhooks needs **no core/interface PR** — only a translator class + one `register(host)` line.

## How it works

- **`WebhookEventTranslatorPort` + `WebhookEventTranslatorRegistryService`** (core `integrations`) — pure `translate(InboundWebhookEvent) → CanonicalInboundEvent | null` (`null` = undecodable → DLQ; total, never throws unbounded — ADR invariant 5). Registry mechanics mirror `WebhookProvisioning`; registered per-plugin via `HostServices` (the 9th well-known registry), keyed by `adapterKey`.
- **`CanonicalInboundEvent`** (core `integrations`) — neutral, transient (no `schemaVersion`): `{ domain: 'order'|'inventory'|'product', externalId, eventType (advisory), occurredAt?, payload? }`.
- **`InboundRoutingPolicyService`** (core `sync`) — deterministic `domain → required-capability → jobType` table. **Pure function**: the dispatcher passes the connection's already-resolved `supportedCapabilities`; the gate is `supportedCapabilities ∋ cap && connection.enabledCapabilities ∋ cap` (both reads, never exception-as-control-flow). Enqueues the `SyncJobRequest`. Bound in the `apps/api` webhooks module (deps already imported) to avoid a `SyncModule↔IntegrationsModule` cycle.
- **`PrestashopWebhookEventTranslatorAdapter`** maps `order` / `stock`→inventory / `product`; registered in `createPrestashopPlugin().register(host)`. Allegro stays poll-only (no translator — ADR orthogonality table).
- **`WebhookToJobHandler` → thin dispatcher**: resolve connection → translator → policy → enqueue or dead-letter (tagged reasons: `connection-unavailable` / `no-translator` / `undecodable` / `ungated`). Deleted `isMasterProvider`, `mapObjectType`, `normalizeObjectType`, `validateJobType`, `mapToSyncJob`, and #902's `mapOrderFeedEventType`.

## Acceptance (ADR-015 / #903) — all met
- No platform-name string-matching or objectType map left in `WebhookToJobHandler`.
- PS order/stock/product all route via the plugin translator + core policy.
- Source/destination is capability-driven (`OrderSource` gate) — one connection can be both.
- A new plugin's webhook events need no core/interface edit.
- **Full `pnpm test:integration` green** (API suite: 43 suites / 237 passed / 1 CI-skip).

## Review fixes applied (tech-review)
- **Narrowed connection-resolution catch** to `ConnectionNotFoundException` / `ConnectionDisabledException` → DLQ; **any other (transient) error rethrows → redelivery**, so a brief DB blip never silently drops a webhook (ADR-015 invariant 3). New unit test asserts the transient-rethrow path.
- **Policy is now a pure function** — takes `supportedCapabilities` from the dispatcher (which already resolved metadata) instead of re-resolving; this also drops the policy's only value-dependency on `integrations`.

## Notes / cross-cutting
- New cross-context edges (`integrations→events`, `sync→integrations`, `sync→orders`) are **type/interface/token-only** (cycle-safe). The `sync→orders` value cycle (caught at app-boot) is broken by importing `OrderFeedEventType` type-only + a `satisfies`-guarded local vocabulary mirror; root-cause cleanup (orders barrel re-exporting `OrdersModule` alongside types) is a noted follow-up.
- Adding the required `HostServices` field rippled into the 4 bag-builders, 2 specs, and the plugin-guide-quote invariant (all updated).
- Tests: registry, PS translator, routing-policy (gate pass/fail + per-domain payloads + eventType coercion), and a rewritten dispatcher spec (translate→policy→enqueue + 4 DLQ branches + transient rethrow). `pnpm lint` + `type-check` + full unit suites green.

## Epic
Closes #903 · builds on #901 (ADR-015), #902 (Phase 1), #906 (idempotency). Next: #904 (poll backstop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)