### PR TITLE
test(orders): #909 follow-ups — cover both swallow arms, hoist int-spec helper

### DIFF
--- a/apps/api/test/integration/helpers/order-ref.helper.ts
+++ b/apps/api/test/integration/helpers/order-ref.helper.ts
@@ -1,0 +1,24 @@
+/**
+ * Order-ref test helpers (integration suite).
+ *
+ * Single home for the #909 `OrderRef` contract assertion: `OrderRef.orderId`
+ * carries the destination-native external order id (e.g. the PrestaShop numeric
+ * order id), not an internal OpenLinker id — idempotency and the
+ * external↔internal mapping write are owned by `OrderSyncService`. Kept here so
+ * the contract is encoded once instead of duplicated per int-spec.
+ *
+ * @module apps/api/test/integration/helpers
+ */
+import type { OrderRef } from '@openlinker/core/orders';
+
+/**
+ * Parse the destination-native PrestaShop numeric `id_order` from an `OrderRef`
+ * (#909). Throws if the id is not a positive integer.
+ */
+export function destinationOrderIdFromRef(orderRef: Pick<OrderRef, 'orderId'>): number {
+  const parsed = Number(orderRef.orderId);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`PS-side order id not a positive integer: '${orderRef.orderId}'`);
+  }
+  return parsed;
+}

--- a/apps/api/test/integration/orders/allegro-prestashop-carrier-mapping.int-spec.ts
+++ b/apps/api/test/integration/orders/allegro-prestashop-carrier-mapping.int-spec.ts
@@ -49,6 +49,7 @@ import {
 } from '@openlinker/core/identifier-mapping';
 import { ORDER_INGESTION_SERVICE_TOKEN, IOrderIngestionService } from '@openlinker/core/orders';
 import { ProductOrmEntity, ProductVariantOrmEntity } from '@openlinker/core/products/orm-entities';
+import { destinationOrderIdFromRef } from '../helpers/order-ref.helper';
 import { getTestHarness, IntegrationTestHarness } from '../setup';
 import {
   PRESTASHOP_IMAGE,
@@ -118,22 +119,6 @@ const fetchPsOrder = (ps: PrestashopTestContainer, idOrder: number): Promise<PsO
 
 const fetchPsCart = (ps: PrestashopTestContainer, idCart: number): Promise<PsCartRow> =>
   fetchPsResource<PsCartRow>(ps, `/api/carts/${idCart}`, 'cart');
-
-/**
- * Parse the destination-native PrestaShop `id_order` from an `OrderRef` (#909).
- *
- * `OrderRef.orderId` now carries the destination-native external order id (the
- * PS numeric id), not an OL-internal id — idempotency and the external↔internal
- * mapping write moved into `OrderSyncService`. The PS WS accepts that numeric id
- * directly on `/api/orders/{id}`.
- */
-function destinationOrderIdFromRef(orderRef: { orderId: string }): number {
-  const parsed = Number(orderRef.orderId);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error(`PS-side order id not a positive integer: '${orderRef.orderId}'`);
-  }
-  return parsed;
-}
 
 /**
  * Surface PS PHP error logs into the test stderr when an order-create fails.

--- a/apps/api/test/integration/prestashop/prestashop-order-fulfillment-update.int-spec.ts
+++ b/apps/api/test/integration/prestashop/prestashop-order-fulfillment-update.int-spec.ts
@@ -41,6 +41,7 @@ import {
   isOrderFulfillmentUpdater,
 } from '@openlinker/core/orders';
 import { ProductOrmEntity, ProductVariantOrmEntity } from '@openlinker/core/products/orm-entities';
+import { destinationOrderIdFromRef } from '../helpers/order-ref.helper';
 import { getTestHarness, IntegrationTestHarness } from '../setup';
 import {
   PrestashopTestContainer,
@@ -116,15 +117,6 @@ async function fetchPsListByOrder<T>(
   const data = json[resource];
   if (Array.isArray(data)) return data as T[];
   return data ? [data as T] : [];
-}
-
-/** Parse the destination-native PS order id from an `OrderRef` (#909). */
-function destinationOrderIdFromRef(orderRef: { orderId: string }): number {
-  const parsed = Number(orderRef.orderId);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error(`PS-side order id not a positive integer: '${orderRef.orderId}'`);
-  }
-  return parsed;
 }
 
 /**

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -17,7 +17,10 @@ import { NoOrderDestinationsAvailableException } from '../../../domain/exception
 import { OrderCreateContendedException } from '../../../domain/exceptions/order-create-contended.exception';
 import type { SyncLockPort } from '@openlinker/core/sync';
 import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
-import { DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
+import {
+  DuplicateIdentifierMappingError,
+  MappingAlreadyExistsError,
+} from '@openlinker/core/identifier-mapping';
 
 describe('OrderSyncService', () => {
   let service: OrderSyncService;
@@ -508,13 +511,18 @@ describe('OrderSyncService', () => {
       );
     });
 
-    it('should swallow DuplicateIdentifierMappingError from createMapping (concurrent create resolved)', async () => {
+    // Both arms of persistDestinationMapping's catch are exercised: the
+    // unique-constraint race (DuplicateIdentifierMappingError) and the
+    // read-before-write race (MappingAlreadyExistsError). Either resolves to an
+    // idempotent success returning the adapter's external id.
+    it.each([
+      ['DuplicateIdentifierMappingError', new DuplicateIdentifierMappingError('Order', 'PS-555', 'prestashop', 'dest-a')],
+      ['MappingAlreadyExistsError', new MappingAlreadyExistsError('Order', 'PS-555', 'dest-a', 'ol_order_123')],
+    ])('should swallow %s from createMapping (concurrent create resolved)', async (_label, error) => {
       const adapter = makeAdapter({ orderId: 'PS-555' });
       registerDestinations([{ connectionId: 'dest-a', adapter }]);
       identifierMapping.getExternalIds.mockResolvedValue([]);
-      identifierMapping.createMapping.mockRejectedValue(
-        new DuplicateIdentifierMappingError('Order', 'PS-555', 'prestashop', 'dest-a')
-      );
+      identifierMapping.createMapping.mockRejectedValue(error);
 
       const results = await service.syncOrder({
         order: createOrder(),

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -214,6 +214,13 @@ export class OrderSyncService implements IOrderSyncService {
         return { orderId: existing };
       }
 
+      // Create-then-record is non-atomic: if createOrder succeeds but
+      // persistDestinationMapping throws a non-duplicate (transient) error, the
+      // destination order exists with no mapping. On the next retry this method
+      // re-enters createOrder (the mapping read finds nothing); the adapter's
+      // own platform-side duplicate recovery is what prevents a second
+      // destination order in that window — hence the port contract asks adapters
+      // to keep it as defense-in-depth.
       const orderRef = await adapter.createOrder(orderCreate);
       await this.persistDestinationMapping(
         internalOrderId,


### PR DESCRIPTION
## What & why

Test-hygiene follow-ups from the tech-review of #909 (merged in #919). No production behavior change.

1. **Cover both `persistDestinationMapping` catch arms.** `OrderSyncService.persistDestinationMapping` swallows *both* `DuplicateIdentifierMappingError` (unique-constraint race) and `MappingAlreadyExistsError` (read-before-write race), but the unit spec only exercised the former. Converted the swallow test to `it.each` over both error types — the second arm was previously untested.

2. **Hoist the duplicated `destinationOrderIdFromRef` helper.** Both PrestaShop int-specs (`allegro-prestashop-carrier-mapping`, `prestashop-order-fulfillment-update`) carried a verbatim copy of the helper that encodes the #909 contract ("`OrderRef.orderId` is the destination-native external id"). Moved it to `apps/api/test/integration/helpers/order-ref.helper.ts` so the contract is encoded once instead of drifting across two files.

3. **Document the create-then-record window.** Added a code comment in `OrderSyncService.createOrderIdempotently` making explicit that the non-atomic create→persist-mapping sequence relies on the adapter's platform-side duplicate recovery for the create-succeeded/map-failed window — the reason the port contract asks adapters to keep it.

## Testing

- `pnpm lint` — 0 errors
- `pnpm type-check` — 0 errors
- `order-sync.service.spec` — green (both swallow-error arms now asserted)
- `pnpm --filter @openlinker/api test:integration` target suites — green:
  - `prestashop-order-fulfillment-update.int-spec` — 1/1
  - `allegro-prestashop-carrier-mapping.int-spec` — 3/3

Refs #909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)