### PR TITLE
chore(test): guard jest-integration moduleNameMapper drift (#917)

### DIFF
--- a/apps/api/test/jest-integration.cjs
+++ b/apps/api/test/jest-integration.cjs
@@ -19,6 +19,8 @@ module.exports = {
     '^@openlinker/core/(.*)$': path.resolve(__dirname, '../../../libs/core/src/$1'),
     '^@openlinker/shared$': path.resolve(__dirname, '../../../libs/shared/src/index.ts'),
     '^@openlinker/shared/(.*)$': path.resolve(__dirname, '../../../libs/shared/src/$1'),
+    '^@openlinker/plugin-sdk$': path.resolve(__dirname, '../../../libs/plugin-sdk/src/index.ts'),
+    '^@openlinker/plugin-sdk/(.*)$': path.resolve(__dirname, '../../../libs/plugin-sdk/src/$1'),
     '^@openlinker/integrations-allegro$': path.resolve(
       __dirname,
       '../../../libs/integrations/allegro/src/index.ts',

--- a/docs/plans/implementation-plan-917-jest-mapper-drift-guard.md
+++ b/docs/plans/implementation-plan-917-jest-mapper-drift-guard.md
@@ -1,0 +1,87 @@
+# Implementation Plan — Guard jest-integration moduleNameMapper drift (#917)
+
+## 1. Understand the task
+
+**Goal:** Add a durable invariant so a plugin wired into `apps/<app>/src/plugins.ts` cannot be
+shipped without a matching `@openlinker/integrations-*` `moduleNameMapper` entry in that app's
+`apps/<app>/test/jest-integration.cjs`. The mapper source-maps each integration package to its
+`src/`; when it drifts, **every** integration test in a fresh (un-built) worktree fails with
+`Cannot find module '@openlinker/integrations-…' from 'src/plugins.ts'` — invisible in CI (which
+builds `dist`, so the package resolves via its `main`).
+
+**Layer:** DX / repo tooling. No application code, no schema.
+
+**Why now:** Surfaced twice — #916 (`@openlinker/integrations-inpost` missing from the **API**
+config) and #786 (`@openlinker/integrations-ai` missing from the **worker** config). Both were
+one-off fixes; this is the durable guard.
+
+**Scope extension (justified):** #917 names only `apps/api`, but the identical drift exists for
+`apps/worker` (that's what bit #786). The guard covers **both** apps via a single `APPS` list —
+adding a future app is a one-line edit.
+
+**Scope refinement (post tech-review):** the guard ALSO pins a small `REQUIRED_BASE` set —
+`@openlinker/core` / `@openlinker/shared` / `@openlinker/plugin-sdk` — that every plugin-loading
+app must source-map (AppModule + every plugin pull them in transitively, none ships committed
+`dist`). This closes the *other* half of #786 (the worker `plugin-sdk` miss) for ~5 lines. It
+surfaced a real latent gap: **`apps/api` did not map `@openlinker/plugin-sdk`** (only worker did,
+from #786) — so a fresh api worktree would also break. The fix adds that mapper to the api config
+(in scope: same #786 class).
+
+**Non-goals:**
+- Not auto-discovering transitive workspace deps beyond `REQUIRED_BASE` (would need full
+  import-graph walking) — `REQUIRED_BASE` pins the universally-required foundation; the
+  `plugins.ts` scan covers the integration packages that actually drift.
+- Not the *reverse* check (extra mappers with no plugin) — extra mappers are harmless.
+- Source of truth is `plugins.ts`, NOT `package.json`: apps under-declare their `@openlinker/*`
+  deps (worker imports `integrations-allegro`+`integrations-ai` but lists neither), so a
+  package.json-based check would miss the exact drift this guard targets.
+
+## 2. Research (findings)
+
+- **Precedent:** `scripts/check-service-interfaces.mjs` and `scripts/check-migration-timestamps.mjs`
+  — ESM `.mjs`, header docblock, a **pure** classifier + a filesystem `main()`, a `--self-check`
+  mode exercising the pure logic against synthetic inputs, `✓/✗` output, exit 0/1.
+- **Wiring:** `package.json` `check:invariants` runs each guard as `node scripts/<x>.mjs
+  --self-check && node scripts/<x>.mjs`, and `check:invariants` is chained into `pnpm lint`.
+- **Current state (guard must pass on main):**
+  - `apps/api/src/plugins.ts` → `prestashop, allegro, ai, inpost`; api jest config maps all four
+    (+ `core`, `shared`, `test-kit`). ✓
+  - `apps/worker/src/plugins.ts` → `prestashop, allegro, ai`; worker jest config maps all three
+    (+ `core`, `shared`, `plugin-sdk`). ✓
+
+## 3. Design
+
+New `scripts/check-jest-integration-mappers.mjs`, pure functions + `main()` + `--self-check`:
+
+- `parsePluginPackages(pluginsTs)` → Set of `@openlinker/integrations-<name>` specifiers from
+  `from '…'` clauses (regex; type-only `@openlinker/core/integrations` excluded since it's not
+  `integrations-*`).
+- `parseMapperPackages(jestCjs)` → Set of `@openlinker/integrations-<name>` packages that have
+  **both** a `^<pkg>$` and a `^<pkg>/(.*)$` key (a partial mapping still breaks subpath imports,
+  so both are required).
+- `findMissing(pluginPkgs, mappedPkgs)` → plugin packages not fully mapped.
+- `main()` iterates a top-level `APPS = [{ name, pluginsTs, jestConfig }]` for `api` + `worker`,
+  collects `{ app, missingPkg }`, and on any miss prints an actionable message (app + package +
+  the exact two mapper lines to add) and exits 1.
+- `--self-check` exercises the three pure functions against synthetic strings (no filesystem).
+
+## 4. Step-by-step
+
+1. `scripts/check-jest-integration-mappers.mjs` — new guard (pure fns + `main` + `--self-check`).
+2. `package.json` — add `node scripts/check-jest-integration-mappers.mjs --self-check && node
+   scripts/check-jest-integration-mappers.mjs` to the `check:invariants` chain.
+3. `docs/testing-guide.md` — short note under the integration-jest/harness section documenting the
+   guard and how to satisfy it (add both mapper lines when adding a plugin to `plugins.ts`).
+
+**Acceptance criteria** (from #917):
+- Forgetting a mapper entry for a plugin in `plugins.ts` fails `pnpm lint` with a message naming
+  the missing package (verified by temporarily deleting an entry).
+- The guard passes on `main` as-is (api + worker both complete today).
+- Documented in `docs/testing-guide.md`.
+
+## 5. Validate
+
+- **Architecture:** tooling-only; no boundary impact.
+- **Testing:** `--self-check` covers the parser/diff logic in the unit-gate; a manual
+  delete-an-entry run proves the failure path + message; `pnpm lint` proves the green path.
+- **Security:** none.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -538,6 +538,32 @@ apps/api/
 - ✅ **Resource isolation**: Requires Docker, slower execution
 - ✅ **Clear separation**: Different purposes, different execution models
 
+### jest-integration `moduleNameMapper` guard (#917)
+
+Each host app's `test/jest-integration.cjs` hand-maintains a `moduleNameMapper`
+that **source-maps** every `@openlinker/*` workspace package its Nest module
+graph imports — so a *fresh, un-built* worktree resolves them via `src/` instead
+of a missing `dist/`. This list silently drifts: adding a plugin to
+`apps/<app>/src/plugins.ts` without the matching mapper entry breaks **every**
+integration test in a fresh worktree with `Cannot find module
+'@openlinker/integrations-…' from 'src/plugins.ts'` (CI masks it because the
+integration job builds `dist` first). This bit #916 (api missing `inpost`) and
+#786 (worker missing `integrations-ai`).
+
+`scripts/check-jest-integration-mappers.mjs` (run from `pnpm lint` via
+`pnpm check:invariants`) guards it: for `apps/api` and `apps/worker`, every
+`@openlinker/integrations-*` package imported in `plugins.ts` — plus the base set
+`@openlinker/core` / `@openlinker/shared` / `@openlinker/plugin-sdk` — must have
+**both** a `^<pkg>$` and a `^<pkg>/(.*)$` entry in that app's
+`jest-integration.cjs`, and the bare entry's target file must exist (catches a
+typo'd `src` path). A failure names the app, the package, and the fix (the exact
+two lines to paste for a missing entry).
+
+**When you add a plugin to `plugins.ts`**, add its two mapper lines to the same
+app's `test/jest-integration.cjs` (the guard prints them for you). Source of
+truth is `plugins.ts`, not the app's `package.json` — in this pnpm monorepo apps
+under-declare their `@openlinker/*` deps.
+
 ---
 
 ## Best Practices

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:integration": "pnpm --filter @openlinker/api test:integration",
     "test:php": "cd apps/prestashop-module/openlinker && composer install --no-interaction --quiet && vendor/bin/phpunit",
     "lint": "pnpm -r lint && pnpm check:invariants",
-    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-libs-build-scripts.mjs && node scripts/check-plugin-guide-quotes.mjs && node scripts/check-repo-urls.mjs && node scripts/check-cross-context-imports.mjs && node scripts/check-service-interfaces.mjs --self-check && node scripts/check-service-interfaces.mjs",
+    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-libs-build-scripts.mjs && node scripts/check-plugin-guide-quotes.mjs && node scripts/check-repo-urls.mjs && node scripts/check-cross-context-imports.mjs && node scripts/check-service-interfaces.mjs --self-check && node scripts/check-service-interfaces.mjs && node scripts/check-jest-integration-mappers.mjs --self-check && node scripts/check-jest-integration-mappers.mjs",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
     "create-adapter": "node scripts/create-adapter.mjs",

--- a/scripts/check-jest-integration-mappers.mjs
+++ b/scripts/check-jest-integration-mappers.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * check-jest-integration-mappers.mjs
+ *
+ * Lint-time invariant guarding against jest-integration `moduleNameMapper`
+ * drift (#917). Each host app's `test/jest-integration.cjs` hand-maintains a
+ * `moduleNameMapper` that source-maps every `@openlinker/*` workspace package
+ * the app's module graph pulls in (so a *fresh, un-built* worktree can resolve
+ * them via `src/` instead of a missing `dist/`).
+ *
+ * The list silently drifts: a plugin can be wired into `apps/<app>/src/plugins.ts`
+ * (and thus into the Nest module graph) WITHOUT a matching mapper entry. CI masks
+ * it because the integration job builds `dist` first, but a fresh worktree then
+ * fails EVERY integration test with `Cannot find module '@openlinker/integrations-…'
+ * from 'src/plugins.ts'`. This bit #916 (api missing `inpost`) and #786 (worker
+ * missing `integrations-ai`).
+ *
+ * Rule. For each app in `APPS`, every package in
+ *   `REQUIRED_BASE` ∪ { `@openlinker/integrations-*` imported by its plugins.ts }
+ * MUST have BOTH a `^<pkg>$` and a `^<pkg>/(.*)$` entry in that app's
+ * `jest-integration.cjs` `moduleNameMapper` (a partial mapping still breaks
+ * subpath imports), AND the bare entry's target file must exist (catches a
+ * typo'd `src` path). Failures name the app, the package, and the fix.
+ *
+ * Source of truth = `plugins.ts`, NOT the app's `package.json` `dependencies`:
+ * in this pnpm monorepo apps under-declare their `@openlinker/*` deps (e.g.
+ * `apps/worker` imports `integrations-allegro` + `integrations-ai` in plugins.ts
+ * but lists neither), so a package.json-based check would miss the very drift
+ * this guard targets.
+ *
+ * Limitation. Transitive workspace deps beyond `REQUIRED_BASE` are not
+ * auto-discovered — `REQUIRED_BASE` pins the universally-required foundation
+ * (`core` / `shared` / `plugin-sdk`, pulled in by AppModule + every plugin);
+ * the plugins.ts scan covers the integration packages that actually drift.
+ *
+ * Run with `--self-check` to exercise the pure parsers against synthetic inputs
+ * (no filesystem) — mirrors `check-service-interfaces.mjs --self-check`.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = join(__dirname, '..');
+const require = createRequire(import.meta.url);
+
+/** Host apps that boot a Nest module graph in their integration harness. */
+const APPS = [
+  {
+    name: 'api',
+    pluginsTs: 'apps/api/src/plugins.ts',
+    jestConfig: 'apps/api/test/jest-integration.cjs',
+  },
+  {
+    name: 'worker',
+    pluginsTs: 'apps/worker/src/plugins.ts',
+    jestConfig: 'apps/worker/test/jest-integration.cjs',
+  },
+];
+
+/**
+ * Workspace packages every plugin-loading app must source-map regardless of
+ * plugins.ts: AppModule + every integration plugin pull these in transitively,
+ * and none ships a committed `dist` for a fresh worktree.
+ */
+const REQUIRED_BASE = ['@openlinker/core', '@openlinker/shared', '@openlinker/plugin-sdk'];
+
+const DOCS_REF = 'docs/testing-guide.md § jest-integration moduleNameMapper guard (#917)';
+
+/** `@openlinker/integrations-ai` → `libs/integrations/ai/src`; `@openlinker/plugin-sdk` → `libs/plugin-sdk/src`. */
+function pkgToLibSrcDir(pkg) {
+  const name = pkg.replace('@openlinker/', '');
+  return name.startsWith('integrations-')
+    ? `libs/integrations/${name.slice('integrations-'.length)}/src`
+    : `libs/${name}/src`;
+}
+
+/**
+ * Extract `@openlinker/integrations-*` package specifiers imported by a
+ * plugins.ts file. Assumes plugins.ts imports the package ROOT (the Nest
+ * module), never a subpath — `[a-z0-9-]+` stops at `/`, so a hypothetical
+ * `…/integrations-ai/foo` import would not be detected.
+ */
+function parsePluginPackages(content) {
+  const re = /from\s+['"](@openlinker\/integrations-[a-z0-9-]+)['"]/g;
+  const pkgs = new Set();
+  let m;
+  while ((m = re.exec(content)) !== null) pkgs.add(m[1]);
+  return pkgs;
+}
+
+/**
+ * Parse a Jest `moduleNameMapper` into `Map<pkg, { bareTarget, hasSub }>` for
+ * every `@openlinker/*` package: `bareTarget` is the `^pkg$` mapping's resolved
+ * target (string) or `undefined`; `hasSub` is whether a `^pkg/(.*)$` entry exists.
+ */
+function parseMapper(moduleNameMapper) {
+  const map = new Map();
+  for (const [key, value] of Object.entries(moduleNameMapper ?? {})) {
+    let body = key;
+    if (body.startsWith('^')) body = body.slice(1);
+    if (body.endsWith('$')) body = body.slice(0, -1);
+    if (!body.startsWith('@openlinker/')) continue;
+    const isSub = body.endsWith('/(.*)');
+    const pkg = isSub ? body.slice(0, -'/(.*)'.length) : body;
+    const entry = map.get(pkg) ?? { bareTarget: undefined, hasSub: false };
+    if (isSub) entry.hasSub = true;
+    else entry.bareTarget = typeof value === 'string' ? value : undefined;
+    map.set(pkg, entry);
+  }
+  return map;
+}
+
+/**
+ * Pure classifier (no fs — `targetExists` is injected). For each required
+ * package, returns `{ missing, broken }`: `missing` = not fully mapped (lacks a
+ * bare or subpath entry); `broken` = fully mapped but the bare target file is
+ * absent (typo'd path).
+ */
+function classifyRequired(requiredPkgs, mapper, targetExists) {
+  const missing = [];
+  const broken = [];
+  for (const pkg of [...requiredPkgs].sort()) {
+    const entry = mapper.get(pkg);
+    if (!entry || entry.bareTarget === undefined || !entry.hasSub) {
+      missing.push(pkg);
+    } else if (!targetExists(entry.bareTarget)) {
+      broken.push({ pkg, target: entry.bareTarget });
+    }
+  }
+  return { missing, broken };
+}
+
+/** The two `moduleNameMapper` lines a maintainer should paste for `pkg`. */
+function suggestedMapperLines(pkg) {
+  const dir = pkgToLibSrcDir(pkg);
+  return [
+    `'^${pkg}$': path.resolve(__dirname, '../../../${dir}/index.ts'),`,
+    `'^${pkg}/(.*)$': path.resolve(__dirname, '../../../${dir}/$1'),`,
+  ];
+}
+
+async function main() {
+  const violations = [];
+
+  for (const app of APPS) {
+    const pluginsContent = await readFile(join(repoRoot, app.pluginsTs), 'utf8');
+    const required = new Set([...REQUIRED_BASE, ...parsePluginPackages(pluginsContent)]);
+
+    const cfgPath = join(repoRoot, app.jestConfig);
+    delete require.cache[cfgPath];
+    const cfg = require(cfgPath);
+    const mapper = parseMapper(cfg.moduleNameMapper);
+    const { missing, broken } = classifyRequired(required, mapper, existsSync);
+
+    for (const pkg of missing) violations.push({ app, kind: 'missing', pkg });
+    for (const b of broken) violations.push({ app, kind: 'broken', pkg: b.pkg, target: b.target });
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `✓ check-jest-integration-mappers: ${APPS.length} app(s) checked. ` +
+        `All plugins.ts integrations + base deps are source-mapped.`
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    `✗ check-jest-integration-mappers: ${violations.length} moduleNameMapper problem(s).\n`
+  );
+  for (const v of violations) {
+    if (v.kind === 'missing') {
+      console.error(
+        `  ${v.app.name}: ${v.pkg} is in the app's plugin graph but not source-mapped in ${v.app.jestConfig}`
+      );
+      console.error('    add inside moduleNameMapper:');
+      for (const line of suggestedMapperLines(v.pkg)) console.error(`      ${line}`);
+    } else {
+      console.error(
+        `  ${v.app.name}: ${v.pkg} is mapped in ${v.app.jestConfig} but its target does not exist:`
+      );
+      console.error(`      ${v.target}`);
+      console.error('    fix the path in moduleNameMapper.');
+    }
+    console.error('');
+  }
+  console.error(`  docs: ${DOCS_REF}`);
+  process.exit(1);
+}
+
+/** Self-test the pure parsers against synthetic inputs — no filesystem. */
+function selfCheck() {
+  const plugins = parsePluginPackages(
+    [
+      `import type { PluginEntry } from '@openlinker/core/integrations';`,
+      `import { A } from '@openlinker/integrations-allegro';`,
+      `import { B } from "@openlinker/integrations-ai";`,
+    ].join('\n')
+  );
+
+  const mapper = parseMapper({
+    '^@openlinker/integrations-ai$': '/abs/libs/integrations/ai/src/index.ts',
+    '^@openlinker/integrations-ai/(.*)$': '/abs/libs/integrations/ai/src/$1',
+    '^@openlinker/integrations-allegro$': '/abs/x', // bare only — partial
+    '^@openlinker/integrations-prestashop$': '/abs/typo/index.ts', // both forms, bad target
+    '^@openlinker/integrations-prestashop/(.*)$': '/abs/typo/$1',
+    '^@openlinker/core$': '/abs/libs/core/src/index.ts',
+    '^@openlinker/core/(.*)$': '/abs/libs/core/src/$1',
+  });
+
+  const allExist = () => true;
+  const existsExceptTypo = (p) => !p.includes('/typo/');
+
+  const c1 = classifyRequired(
+    new Set(['@openlinker/integrations-ai', '@openlinker/integrations-allegro', '@openlinker/core']),
+    mapper,
+    allExist
+  );
+  const c2 = classifyRequired(new Set(['@openlinker/integrations-prestashop']), mapper, existsExceptTypo);
+
+  const cases = [
+    ['parse: finds integrations-*, excludes @openlinker/core/integrations', plugins.size === 2],
+    ['parse: includes allegro + ai', plugins.has('@openlinker/integrations-allegro') && plugins.has('@openlinker/integrations-ai')],
+    ['mapper: both forms recorded', mapper.get('@openlinker/integrations-ai')?.hasSub === true && typeof mapper.get('@openlinker/integrations-ai')?.bareTarget === 'string'],
+    ['classify: bare-only → missing', c1.missing.includes('@openlinker/integrations-allegro')],
+    ['classify: fully-mapped + target exists → clean', !c1.missing.includes('@openlinker/core') && c1.broken.length === 0],
+    ['classify: fully-mapped + missing target → broken', c2.broken.length === 1 && c2.broken[0].pkg === '@openlinker/integrations-prestashop'],
+    ['libSrcDir: integrations', pkgToLibSrcDir('@openlinker/integrations-ai') === 'libs/integrations/ai/src'],
+    ['libSrcDir: base pkg', pkgToLibSrcDir('@openlinker/plugin-sdk') === 'libs/plugin-sdk/src'],
+  ];
+
+  const failures = cases.filter(([, ok]) => !ok).map(([name]) => `  ✗ ${name}`);
+  if (failures.length === 0) {
+    console.log(`✓ check-jest-integration-mappers --self-check: ${cases.length} case(s) passed.`);
+    process.exit(0);
+  }
+  console.error('✗ check-jest-integration-mappers --self-check failed:\n');
+  console.error(failures.join('\n'));
+  process.exit(1);
+}
+
+const run = process.argv.includes('--self-check') ? selfCheck : main;
+Promise.resolve(run()).catch((err) => {
+  console.error('check-jest-integration-mappers: fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What & why

Each host app's `test/jest-integration.cjs` hand-maintains a `moduleNameMapper` that source-maps every `@openlinker/*` workspace package its Nest module graph imports — so a *fresh, un-built* worktree resolves them via `src/` instead of a missing `dist/`. The list silently drifts: a plugin wired into `apps/<app>/src/plugins.ts` without the matching mapper entry breaks **every** integration test in a fresh worktree (`Cannot find module '@openlinker/integrations-…' from 'src/plugins.ts'`). CI masks it (the integration job builds `dist` first). This bit **#916** (api missing `inpost`) and **#786** (worker missing `integrations-ai`).

## Changes (tooling + docs only — no app/lib code)

- **`scripts/check-jest-integration-mappers.mjs`** — new guard, wired into `check:invariants` (→ `pnpm lint`), mirroring the `check-migration-timestamps` / `check-service-interfaces` precedent (pure parsers + `--self-check`). For `apps/api` and `apps/worker`, every `@openlinker/integrations-*` imported in `plugins.ts` — **plus the base set `core` / `shared` / `plugin-sdk`** — must have **both** a `^pkg$` and `^pkg/(.*)$` entry, **and** the bare entry's target file must exist (catches a typo'd `src` path). Failures name the app, the package, and the exact fix.
- **Source of truth is `plugins.ts`, not `package.json`:** in this pnpm monorepo apps under-declare their `@openlinker/*` deps (`apps/worker` imports `integrations-allegro` + `integrations-ai` but lists neither), so a package.json-based check would miss the very drift this guards.
- **Latent gap fixed:** `apps/api` never mapped `@openlinker/plugin-sdk` (only the worker did, from #786) — a fresh api worktree would also break. Added the mapper (same #786 class).
- **Docs:** documented the guard in `docs/testing-guide.md`.

## How to test

```bash
node scripts/check-jest-integration-mappers.mjs --self-check
node scripts/check-jest-integration-mappers.mjs
# or just: pnpm lint
```

To see it fire: delete an `integrations-*` mapper entry from a `jest-integration.cjs` and re-run — it names the missing package + prints the two lines to add.

## Verification

- `--self-check`: 8 cases pass (parse, both-forms, missing, broken-target).
- Green on `main` as-is (api + worker complete after the `plugin-sdk` fix).
- Failure path demonstrated on the real api/`plugin-sdk` gap before it was fixed (rc=1, named the package + fix lines).
- `pnpm lint` + `type-check` + `test` all pass.

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)