### PR TITLE
feat(web): order-detail redesign — health header, pricing/tax, shipping panel, audit trail, clickable items

### DIFF
--- a/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
@@ -42,6 +42,20 @@ describe('parseOrderSnapshot', () => {
     expect(parsed.parseWarnings).toHaveLength(0);
   });
 
+  it('surfaces totals.taxTreatment when present and leaves it undefined when absent', () => {
+    const withTreatment = parseOrderSnapshot({
+      totals: { subtotal: 10, tax: 2.3, shipping: 0, total: 12.3, currency: 'PLN', taxTreatment: 'inclusive' },
+    });
+    expect(withTreatment.totals?.taxTreatment).toBe('inclusive');
+    expect(withTreatment.parseWarnings).toHaveLength(0);
+
+    const withoutTreatment = parseOrderSnapshot({
+      totals: { subtotal: 10, tax: 2.3, shipping: 0, total: 12.3, currency: 'PLN' },
+    });
+    expect(withoutTreatment.totals?.taxTreatment).toBeUndefined();
+    expect(withoutTreatment.parseWarnings).toHaveLength(0);
+  });
+
   it('returns a ParsedOrderSnapshot (never null) even when the top-level `id` is missing', () => {
     const parsed = parseOrderSnapshot({ orderNumber: '1024' });
 

--- a/apps/web/src/features/orders/api/order-snapshot.schema.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.ts
@@ -36,12 +36,25 @@ const orderItemSchema = z.object({
   imageUrl: z.string().optional(),
 });
 
+/**
+ * Tax-treatment values — hand-mirrored from `PriceTaxTreatmentValues` in
+ * `libs/core/src/orders/domain/types/order.types.ts` per the FE-001 contract
+ * strategy. The backend already pins `totals.taxTreatment` into the persisted
+ * snapshot (#895/ADR-014); surfacing it here is a read-only extension, not a
+ * new field. Keep in sync with the core constant if the vocabulary changes.
+ */
+export const ParsedOrderTaxTreatmentValues = ['inclusive', 'exclusive'] as const;
+export type ParsedOrderTaxTreatment = (typeof ParsedOrderTaxTreatmentValues)[number];
+
 const orderTotalsSchema = z.object({
   subtotal: z.number(),
   tax: z.number(),
   shipping: z.number(),
   total: z.number(),
   currency: z.string(),
+  /** Whether `total` is tax-inclusive (gross) or tax-exclusive (net). Optional —
+   *  absent for sources that don't report it. */
+  taxTreatment: z.enum(ParsedOrderTaxTreatmentValues).optional(),
 });
 
 const orderShippingSchema = z.object({

--- a/apps/web/src/features/orders/components/order-activity-timeline.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.tsx
@@ -24,6 +24,8 @@ interface TimelineEvent {
   id: string;
   timestamp: string | null;
   title: ReactElement | string;
+  /** Actor eyebrow (e.g. "system · ingest", "system · attempt 2"). */
+  by?: string;
   description?: ReactElement | string;
   tone: 'default' | 'success' | 'error' | 'warning';
   /**
@@ -76,6 +78,7 @@ function buildEvents(
     id: 'ingested',
     timestamp: createdAt,
     title: 'Order received',
+    by: 'system · ingest',
     description:
       recordStatus === 'awaiting_mapping'
         ? 'Awaiting product mapping — some item references could not be resolved yet.'
@@ -109,15 +112,19 @@ function buildEvents(
     lastIndexByDestination.set(a.destinationConnectionId, i);
   });
 
+  const attemptNumberByDestination = new Map<string, number>();
   sortedAttempts.forEach((attempt, i) => {
     const verb = STATUS_PAST_TENSE[attempt.status] ?? attempt.status;
     const isLastForDestination = lastIndexByDestination.get(attempt.destinationConnectionId) === i;
     const showCapLink =
       isLastForDestination && cappedDestinations.has(attempt.destinationConnectionId);
+    const attemptNumber = (attemptNumberByDestination.get(attempt.destinationConnectionId) ?? 0) + 1;
+    attemptNumberByDestination.set(attempt.destinationConnectionId, attemptNumber);
 
     events.push({
       id: `attempt-${attempt.destinationConnectionId}-${i}`,
       timestamp: attempt.attemptedAt,
+      by: `system · attempt ${attemptNumber}`,
       title: (
         <>
           Order {verb}{' '}
@@ -181,12 +188,16 @@ export function OrderActivityTimeline({
   }
 
   return (
+    <>
     <ol className="order-activity" aria-label="Order activity timeline">
       {events.map((event) => (
         <li key={event.id} className="order-activity__item">
           <span className={`order-activity__dot ${TONE_CLASS[event.tone]}`} aria-hidden="true" />
           <div className="order-activity__body">
-            <p className="order-activity__title">{event.title}</p>
+            <p className="order-activity__title">
+              {event.title}
+              {event.by ? <span className="order-activity__by">{event.by}</span> : null}
+            </p>
             {event.description ? (
               <p className="order-activity__description">{event.description}</p>
             ) : null}
@@ -202,5 +213,10 @@ export function OrderActivityTimeline({
         </li>
       ))}
     </ol>
+    <p className="order-activity__caption">
+      Showing {events.length} of {events.length} event{events.length === 1 ? '' : 's'} · attempts capped at{' '}
+      {SYNC_ATTEMPTS_PER_DESTINATION_CAP} per destination.
+    </p>
+    </>
   );
 }

--- a/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../test/test-utils';
+import { OrderDeliveryPanel } from './order-delivery-panel';
+
+describe('OrderDeliveryPanel', () => {
+  it('renders nothing when there is no delivery data', () => {
+    renderWithProviders(<OrderDeliveryPanel />);
+    expect(screen.queryByRole('region', { name: 'Delivery' })).toBeNull();
+  });
+
+  it('renders the address, method and pickup code when present', () => {
+    renderWithProviders(
+      <OrderDeliveryPanel
+        shippingAddress={{ address1: 'ul. Testowa 1', city: 'Warszawa', postalCode: '00-001', country: 'PL' }}
+        shipping={{ methodId: 'm1', methodName: 'InPost Paczkomat' }}
+        pickupPoint={{ id: 'POP-WAW-04412' }}
+        sourcePlatformType="allegro"
+      />,
+    );
+    expect(screen.getByText('POP-WAW-04412')).toBeInTheDocument();
+    expect(screen.getByText('InPost Paczkomat')).toBeInTheDocument();
+    expect(screen.getByText(/operator-selected|buyer-selected/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/orders/components/order-delivery-panel.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.tsx
@@ -1,0 +1,105 @@
+/**
+ * Order Delivery Panel
+ *
+ * Snapshot-driven "where it's going" panel for the order-detail page (#924):
+ * ship-to address, delivery method, and buyer-selected pickup point. Always
+ * available (not capability-gated) — the dispatch lifecycle (label / tracking)
+ * stays in the capability-gated `OrderShipmentPanel`.
+ *
+ * The pickup caption keys on the SOURCE platform's `pickupPointResolvesAsync`
+ * trait (#893): the buyer selects the locker on the source marketplace, so the
+ * source connection — not the destination — owns the "buyer-selected" wording.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import type { ReactElement } from 'react';
+
+import { usePlatform } from '../../../shared/plugins';
+import { KeyValueList, type KeyValueItem } from '../../../shared/ui/key-value-list';
+import type {
+  ParsedAddress,
+  ParsedOrderPickupPoint,
+  ParsedOrderShipping,
+} from '../api/order-snapshot.schema';
+
+interface OrderDeliveryPanelProps {
+  shippingAddress?: ParsedAddress;
+  shipping?: ParsedOrderShipping;
+  pickupPoint?: ParsedOrderPickupPoint;
+  /** Source platform type — drives the buyer-selected vs operator-selected caption. */
+  sourcePlatformType?: string | null;
+}
+
+function addressLines(address: ParsedAddress): ReactElement {
+  const name = [address.firstName, address.lastName].filter(Boolean).join(' ').trim();
+  return (
+    <span className="order-delivery__addr">
+      {name ? (
+        <>
+          {name}
+          <br />
+        </>
+      ) : null}
+      {address.company ? (
+        <>
+          {address.company}
+          <br />
+        </>
+      ) : null}
+      {address.address1}
+      <br />
+      {address.address2 ? (
+        <>
+          {address.address2}
+          <br />
+        </>
+      ) : null}
+      {address.postalCode} {address.city}
+      <br />
+      {address.country}
+    </span>
+  );
+}
+
+export function OrderDeliveryPanel({
+  shippingAddress,
+  shipping,
+  pickupPoint,
+  sourcePlatformType,
+}: OrderDeliveryPanelProps): ReactElement | null {
+  // Resolved unconditionally (never inside a branch) — see #893.
+  const sourcePlatform = usePlatform(sourcePlatformType ?? undefined);
+
+  if (!shippingAddress && !shipping && !pickupPoint) return null;
+
+  const items: KeyValueItem[] = [];
+  if (shippingAddress) {
+    items.push({ id: 'ship-to', label: 'Ship to', value: addressLines(shippingAddress) });
+  }
+  if (shipping?.methodName ?? shipping?.methodId) {
+    items.push({ id: 'method', label: 'Method', value: shipping.methodName ?? shipping.methodId });
+  }
+
+  const pickupCaption =
+    sourcePlatform?.pickupPointResolvesAsync === true
+      ? `buyer-selected via ${sourcePlatform.displayName}`
+      : 'operator-selected';
+
+  return (
+    <section className="detail-section order-delivery" aria-label="Delivery">
+      <h3 className="detail-section__title">Delivery</h3>
+      <div className="order-delivery__card">
+        {items.length > 0 ? <KeyValueList items={items} /> : null}
+        {pickupPoint ? (
+          <div className="order-delivery__pickup">
+            <div className="order-delivery__pickup-code mono-text">{pickupPoint.id}</div>
+            <div className="order-delivery__pickup-caption text-muted">
+              {pickupPoint.description ? `${pickupPoint.description} · ` : ''}
+              {pickupCaption}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/orders/components/order-detail-header.tsx
+++ b/apps/web/src/features/orders/components/order-detail-header.tsx
@@ -1,0 +1,127 @@
+/**
+ * Order Detail Header
+ *
+ * Operator-cockpit header for the order-detail page (#924): title + derived
+ * health badge + lifecycle badge, an internal-id copy chip, the role-labelled
+ * source → destination route, received timestamp (absolute + relative), and a
+ * one-line order-contents summary with a clickable product link. All values
+ * come from data already on the `OrderRecord` / parsed snapshot — no new
+ * backend fields.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+
+import { ConnectionEntityLabel } from '../../connections';
+import { CopyableId } from '../../../shared/ui/copyable-id';
+import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
+import { TimeDisplay } from '../../../shared/ui/time-display';
+import { formatAmount } from '../../../shared/format/format-amount';
+import type { OrderRecord } from '../api/orders.types';
+import type { ParsedOrderSnapshot } from '../api/order-snapshot.schema';
+import { deriveHealthLevel, healthLabel, rollupSyncStatus, totalUnits, type OrderHealthLevel } from '../lib/order-health';
+
+interface OrderDetailHeaderProps {
+  order: OrderRecord;
+  snapshot: ParsedOrderSnapshot;
+}
+
+const HEALTH_TONE: Record<OrderHealthLevel, StatusBadgeTone> = {
+  attention: 'error',
+  pending: 'warning',
+  healthy: 'success',
+  unknown: 'neutral',
+};
+
+export function OrderDetailHeader({ order, snapshot }: OrderDetailHeaderProps): ReactElement {
+  const rollup = rollupSyncStatus(order.syncStatus);
+  const healthLevel = deriveHealthLevel(rollup);
+
+  const title = snapshot.orderNumber ? `Order ${snapshot.orderNumber}` : `Order ${order.internalOrderId}`;
+
+  const firstItem = snapshot.items[0];
+  const itemCount = snapshot.items.length;
+  const unitCount = totalUnits(snapshot.items);
+  const productName = firstItem?.name ?? firstItem?.sku ?? firstItem?.productId ?? null;
+
+  return (
+    <header className="order-header">
+      <div className="order-header__top">
+        <h1 className="order-header__title">{title}</h1>
+        <StatusBadge tone={HEALTH_TONE[healthLevel]} withDot pulse={healthLevel === 'pending'}>
+          {healthLabel(healthLevel)}
+        </StatusBadge>
+        {snapshot.status ? (
+          <StatusBadge tone="neutral" withDot>
+            {snapshot.status}
+          </StatusBadge>
+        ) : null}
+      </div>
+
+      <div className="order-header__sub">
+        <CopyableId id={order.internalOrderId} />
+
+        <span className="order-route">
+          <span className="order-route__node">
+            <span className="order-route__dot" aria-hidden="true" />
+            <ConnectionEntityLabel connectionId={order.sourceConnectionId} showId={false} />
+            <span className="order-route__role">source</span>
+          </span>
+          <span className="order-route__arrow" aria-hidden="true">
+            →
+          </span>
+          {order.syncStatus.length > 0 ? (
+            order.syncStatus.map((s) => (
+              <span className="order-route__node" key={s.destinationConnectionId}>
+                <span className="order-route__dot order-route__dot--accent" aria-hidden="true" />
+                <ConnectionEntityLabel connectionId={s.destinationConnectionId} showId={false} />
+                <span className="order-route__role">destination</span>
+              </span>
+            ))
+          ) : (
+            <span className="order-route__node text-muted">no destination</span>
+          )}
+        </span>
+
+        <span className="order-header__received">
+          Received <TimeDisplay iso={order.createdAt} format="datetime" className="mono-text tabular" />{' '}
+          <span className="text-muted">
+            · <TimeDisplay iso={order.createdAt} format="relative" />
+          </span>
+        </span>
+      </div>
+
+      {itemCount > 0 ? (
+        <div className="order-header__summary-line">
+          <ProductThumbnail name={productName ?? order.internalOrderId} src={firstItem?.imageUrl} size="sm" />
+          <strong>
+            {itemCount} item{itemCount > 1 ? 's' : ''} · {unitCount} unit{unitCount > 1 ? 's' : ''}
+          </strong>
+          {productName ? (
+            <>
+              <span className="order-header__summary-sep">—</span>
+              {firstItem?.productId ? (
+                <Link className="order-product-link" to={`/products/${firstItem.productId}`}>
+                  {productName}
+                </Link>
+              ) : (
+                <span className="order-product-link order-product-link--plain">{productName}</span>
+              )}
+              {itemCount > 1 ? <span className="text-muted">+{itemCount - 1} more</span> : null}
+            </>
+          ) : null}
+          {snapshot.totals ? (
+            <>
+              <span className="order-header__summary-sep">·</span>
+              <span className="mono-text tabular">
+                {formatAmount(snapshot.totals.total, snapshot.totals.currency)}
+              </span>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </header>
+  );
+}

--- a/apps/web/src/features/orders/components/order-health-summary.tsx
+++ b/apps/web/src/features/orders/components/order-health-summary.tsx
@@ -1,0 +1,85 @@
+/**
+ * Order Health Summary
+ *
+ * Derived three-cell health strip for the order-detail page (#924): Sync (from
+ * per-destination `syncStatus`), Fulfillment (from the shipments query +
+ * shipping capability), and Total (from the parsed snapshot totals). Pure
+ * presentation over values derived in `../lib/order-health`.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import type { ReactElement } from 'react';
+
+import { ConnectionEntityLabel } from '../../connections';
+import { formatAmount } from '../../../shared/format/format-amount';
+import type { OrderSyncStatus } from '../api/orders.types';
+import type { ParsedOrderTotals } from '../api/order-snapshot.schema';
+import {
+  fulfillmentLabel,
+  rollupSyncStatus,
+  syncCellLabel,
+  type FulfillmentState,
+} from '../lib/order-health';
+
+interface OrderHealthSummaryProps {
+  syncStatus: OrderSyncStatus[];
+  fulfillment: FulfillmentState;
+  totals?: ParsedOrderTotals;
+  itemCount: number;
+  /** First failed destination — rendered as the Sync cell hint. */
+  failedDestinationId?: string | null;
+}
+
+export function OrderHealthSummary({
+  syncStatus,
+  fulfillment,
+  totals,
+  itemCount,
+  failedDestinationId,
+}: OrderHealthSummaryProps): ReactElement {
+  const rollup = rollupSyncStatus(syncStatus);
+  const alarm = rollup.failed > 0;
+
+  const fulfillmentHint =
+    fulfillment === 'unavailable'
+      ? 'No shipping destination'
+      : alarm && fulfillment === 'not-shipped'
+        ? 'Blocked until sync succeeds'
+        : fulfillment === 'not-shipped'
+          ? 'Awaiting dispatch'
+          : null;
+
+  return (
+    <div className="order-health" role="group" aria-label="Order health">
+      <div className={`order-health__cell${alarm ? ' order-health__cell--alarm' : ''}`}>
+        <div className="order-health__k">Sync</div>
+        <div className={`order-health__v${alarm ? ' order-health__v--alarm' : ''}`}>{syncCellLabel(rollup)}</div>
+        <div className="order-health__hint">
+          {alarm && failedDestinationId ? (
+            <ConnectionEntityLabel connectionId={failedDestinationId} showId={false} />
+          ) : rollup.total === 0 ? (
+            'No destinations configured'
+          ) : (
+            'All destinations reconciled'
+          )}
+        </div>
+      </div>
+
+      <div className="order-health__cell">
+        <div className="order-health__k">Fulfillment</div>
+        <div className="order-health__v">{fulfillmentLabel(fulfillment)}</div>
+        {fulfillmentHint ? <div className="order-health__hint">{fulfillmentHint}</div> : null}
+      </div>
+
+      <div className="order-health__cell">
+        <div className="order-health__k">Total</div>
+        <div className="order-health__v mono-text tabular">
+          {totals ? formatAmount(totals.total, totals.currency) : '—'}
+        </div>
+        <div className="order-health__hint">
+          {itemCount > 0 ? `${itemCount} item${itemCount > 1 ? 's' : ''} · source-priced` : 'No line items'}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/orders/components/order-health-summary.tsx
+++ b/apps/web/src/features/orders/components/order-health-summary.tsx
@@ -28,6 +28,8 @@ interface OrderHealthSummaryProps {
   itemCount: number;
   /** First failed destination — rendered as the Sync cell hint. */
   failedDestinationId?: string | null;
+  /** Shipping capability / shipments still resolving — show a neutral placeholder. */
+  fulfillmentPending?: boolean;
 }
 
 export function OrderHealthSummary({
@@ -36,12 +38,14 @@ export function OrderHealthSummary({
   totals,
   itemCount,
   failedDestinationId,
+  fulfillmentPending = false,
 }: OrderHealthSummaryProps): ReactElement {
   const rollup = rollupSyncStatus(syncStatus);
   const alarm = rollup.failed > 0;
 
-  const fulfillmentHint =
-    fulfillment === 'unavailable'
+  const fulfillmentHint = fulfillmentPending
+    ? 'Checking…'
+    : fulfillment === 'unavailable'
       ? 'No shipping destination'
       : alarm && fulfillment === 'not-shipped'
         ? 'Blocked until sync succeeds'
@@ -67,7 +71,7 @@ export function OrderHealthSummary({
 
       <div className="order-health__cell">
         <div className="order-health__k">Fulfillment</div>
-        <div className="order-health__v">{fulfillmentLabel(fulfillment)}</div>
+        <div className="order-health__v">{fulfillmentPending ? '—' : fulfillmentLabel(fulfillment)}</div>
         {fulfillmentHint ? <div className="order-health__hint">{fulfillmentHint}</div> : null}
       </div>
 

--- a/apps/web/src/features/orders/components/order-pricing-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-pricing-panel.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { OrderPricingPanel } from './order-pricing-panel';
+
+describe('OrderPricingPanel', () => {
+  it('labels tax-exclusive totals as net and explains source-authoritative pricing', () => {
+    render(
+      <OrderPricingPanel
+        items={[]}
+        totals={{ subtotal: 10, tax: 2, shipping: 0, total: 12, currency: 'PLN', taxTreatment: 'exclusive' }}
+      />,
+    );
+    expect(screen.getByText(/net · source-authoritative/i)).toBeInTheDocument();
+    expect(screen.getByText(/buyer-paid \(net\) price/i)).toBeInTheDocument();
+  });
+
+  it('omits the treatment badge and note when taxTreatment is absent', () => {
+    render(
+      <OrderPricingPanel
+        items={[]}
+        totals={{ subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' }}
+      />,
+    );
+    expect(screen.queryByText(/source-authoritative/i)).toBeNull();
+  });
+});

--- a/apps/web/src/features/orders/components/order-pricing-panel.tsx
+++ b/apps/web/src/features/orders/components/order-pricing-panel.tsx
@@ -1,0 +1,51 @@
+/**
+ * Order Pricing Panel
+ *
+ * Pricing & tax breakdown for the order-detail page (#924). Composes the
+ * existing line-items + totals panels, then surfaces the source-authoritative
+ * tax treatment (`totals.taxTreatment`, already on the snapshot per #895/
+ * ADR-014). Wording is treatment-aware: tax-inclusive totals read "gross",
+ * tax-exclusive read "net" — never hardcoded.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import type { ReactElement } from 'react';
+
+import { StatusBadge } from '../../../shared/ui/status-badge';
+import type { ParsedOrderItem, ParsedOrderTotals } from '../api/order-snapshot.schema';
+import { OrderLineItemsPanel } from './order-line-items-panel';
+import { OrderTotalsPanel } from './order-totals-panel';
+
+interface OrderPricingPanelProps {
+  items: ParsedOrderItem[];
+  totals?: ParsedOrderTotals;
+}
+
+export function OrderPricingPanel({ items, totals }: OrderPricingPanelProps): ReactElement {
+  const treatment = totals?.taxTreatment;
+  const grossNet = treatment === 'inclusive' ? 'gross' : treatment === 'exclusive' ? 'net' : null;
+
+  return (
+    <div className="order-pricing">
+      {items.length > 0 ? <OrderLineItemsPanel items={items} totals={totals} /> : null}
+
+      {totals ? (
+        <div className="order-pricing__summary">
+          <OrderTotalsPanel totals={totals} />
+          {grossNet ? (
+            <StatusBadge tone="neutral" className="order-pricing__treatment">
+              {grossNet} · source-authoritative
+            </StatusBadge>
+          ) : null}
+        </div>
+      ) : null}
+
+      {grossNet ? (
+        <p className="order-pricing__note">
+          OpenLinker pins the <b>buyer-paid ({grossNet}) price</b> onto the destination — it does not use the
+          destination&rsquo;s catalog price.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/orders/lib/order-health.test.ts
+++ b/apps/web/src/features/orders/lib/order-health.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { OrderSyncStatus } from '../api/orders.types';
+import {
+  deriveFulfillment,
+  deriveHealthLevel,
+  fulfillmentLabel,
+  healthLabel,
+  rollupSyncStatus,
+  syncCellLabel,
+  totalUnits,
+} from './order-health';
+
+function status(over: Partial<OrderSyncStatus>): OrderSyncStatus {
+  return {
+    destinationConnectionId: 'conn-1',
+    status: 'synced',
+    syncedAt: null,
+    externalOrderId: null,
+    externalOrderNumber: null,
+    error: null,
+    ...over,
+  };
+}
+
+describe('rollupSyncStatus', () => {
+  it('counts failed, synced and pending (pending + syncing) buckets', () => {
+    const rollup = rollupSyncStatus([
+      status({ status: 'failed' }),
+      status({ status: 'synced' }),
+      status({ status: 'pending' }),
+      status({ status: 'syncing' }),
+    ]);
+    expect(rollup).toEqual({ total: 4, failed: 1, synced: 1, pending: 2 });
+  });
+});
+
+describe('deriveHealthLevel + healthLabel', () => {
+  it('returns unknown for no destinations', () => {
+    const level = deriveHealthLevel(rollupSyncStatus([]));
+    expect(level).toBe('unknown');
+    expect(healthLabel(level)).toBe('No destinations');
+  });
+
+  it('prioritises attention when any destination failed', () => {
+    const level = deriveHealthLevel(rollupSyncStatus([status({ status: 'failed' }), status({ status: 'synced' })]));
+    expect(level).toBe('attention');
+    expect(healthLabel(level)).toBe('Needs attention');
+  });
+
+  it('reports pending when nothing failed but some are in flight', () => {
+    expect(deriveHealthLevel(rollupSyncStatus([status({ status: 'syncing' })]))).toBe('pending');
+  });
+
+  it('reports healthy when all synced', () => {
+    const level = deriveHealthLevel(rollupSyncStatus([status({ status: 'synced' })]));
+    expect(level).toBe('healthy');
+    expect(healthLabel(level)).toBe('Synced');
+  });
+});
+
+describe('syncCellLabel', () => {
+  it('leads with failures when present', () => {
+    expect(syncCellLabel(rollupSyncStatus([status({ status: 'failed' })]))).toBe('1 of 1 failed');
+  });
+  it('reports synced count otherwise', () => {
+    expect(syncCellLabel(rollupSyncStatus([status({ status: 'synced' }), status({ status: 'syncing' })]))).toBe(
+      '1 of 2 synced',
+    );
+  });
+  it('handles no destinations', () => {
+    expect(syncCellLabel(rollupSyncStatus([]))).toBe('No destinations');
+  });
+});
+
+describe('deriveFulfillment + fulfillmentLabel', () => {
+  it('is unavailable without a shipping capability', () => {
+    expect(deriveFulfillment(['dispatched'], false)).toBe('unavailable');
+    expect(fulfillmentLabel('unavailable')).toBe('Not tracked');
+  });
+
+  it('is not-shipped when capable but no shipment exists', () => {
+    expect(deriveFulfillment(null, true)).toBe('not-shipped');
+    expect(deriveFulfillment([], true)).toBe('not-shipped');
+  });
+
+  it('prefers delivered over in-flight states', () => {
+    expect(deriveFulfillment(['dispatched', 'delivered'], true)).toBe('delivered');
+  });
+
+  it('reports dispatched for generated / dispatched / in-transit', () => {
+    expect(deriveFulfillment(['generated'], true)).toBe('dispatched');
+    expect(deriveFulfillment(['in-transit'], true)).toBe('dispatched');
+  });
+
+  it('reports failed only when every shipment is terminal-bad', () => {
+    expect(deriveFulfillment(['failed', 'cancelled'], true)).toBe('failed');
+    expect(fulfillmentLabel('failed')).toBe('Dispatch failed');
+  });
+});
+
+describe('totalUnits', () => {
+  it('sums item quantities', () => {
+    expect(totalUnits([{ quantity: 2 }, { quantity: 3 }])).toBe(5);
+    expect(totalUnits([])).toBe(0);
+  });
+});

--- a/apps/web/src/features/orders/lib/order-health.ts
+++ b/apps/web/src/features/orders/lib/order-health.ts
@@ -1,0 +1,110 @@
+/**
+ * Order Health Derivations
+ *
+ * Pure, framework-free view-model helpers that derive an order's operator-facing
+ * health from data already on the `OrderRecord` (per-destination `syncStatus`)
+ * and the shipments query. Kept out of the page/components so the rules are
+ * unit-testable in isolation (#924).
+ *
+ * @module apps/web/src/features/orders/lib
+ */
+import type { OrderSyncStatus } from '../api/orders.types';
+
+export interface SyncRollup {
+  total: number;
+  failed: number;
+  synced: number;
+  /** pending + syncing — anything not yet terminal. */
+  pending: number;
+}
+
+export function rollupSyncStatus(syncStatus: readonly OrderSyncStatus[]): SyncRollup {
+  let failed = 0;
+  let synced = 0;
+  let pending = 0;
+  for (const s of syncStatus) {
+    if (s.status === 'failed') failed += 1;
+    else if (s.status === 'synced') synced += 1;
+    else pending += 1;
+  }
+  return { total: syncStatus.length, failed, synced, pending };
+}
+
+export const OrderHealthLevelValues = ['attention', 'pending', 'healthy', 'unknown'] as const;
+export type OrderHealthLevel = (typeof OrderHealthLevelValues)[number];
+
+export function deriveHealthLevel(rollup: SyncRollup): OrderHealthLevel {
+  if (rollup.total === 0) return 'unknown';
+  if (rollup.failed > 0) return 'attention';
+  if (rollup.pending > 0) return 'pending';
+  return 'healthy';
+}
+
+export function healthLabel(level: OrderHealthLevel): string {
+  switch (level) {
+    case 'attention':
+      return 'Needs attention';
+    case 'pending':
+      return 'In progress';
+    case 'healthy':
+      return 'Synced';
+    case 'unknown':
+      return 'No destinations';
+  }
+}
+
+/** "1 of 1 failed" / "2 of 3 synced" — the headline for the Sync health cell. */
+export function syncCellLabel(rollup: SyncRollup): string {
+  if (rollup.total === 0) return 'No destinations';
+  if (rollup.failed > 0) return `${rollup.failed} of ${rollup.total} failed`;
+  return `${rollup.synced} of ${rollup.total} synced`;
+}
+
+export const FulfillmentStateValues = [
+  'not-shipped',
+  'dispatched',
+  'delivered',
+  'failed',
+  'unavailable',
+] as const;
+export type FulfillmentState = (typeof FulfillmentStateValues)[number];
+
+/**
+ * Derive the fulfillment state from the order's shipment statuses. `null` /
+ * empty means no shipment exists yet. When no connection declares the
+ * ShippingProviderManager capability the order can't be dispatched at all, so
+ * the state collapses to `unavailable` (the panel + cell hide the affordance).
+ */
+export function deriveFulfillment(
+  shipmentStatuses: readonly string[] | null,
+  hasShippingCapability: boolean,
+): FulfillmentState {
+  if (!hasShippingCapability) return 'unavailable';
+  if (!shipmentStatuses || shipmentStatuses.length === 0) return 'not-shipped';
+  if (shipmentStatuses.includes('delivered')) return 'delivered';
+  if (shipmentStatuses.some((s) => s === 'dispatched' || s === 'in-transit' || s === 'generated')) {
+    return 'dispatched';
+  }
+  if (shipmentStatuses.every((s) => s === 'failed' || s === 'cancelled')) return 'failed';
+  return 'not-shipped';
+}
+
+export function fulfillmentLabel(state: FulfillmentState): string {
+  switch (state) {
+    case 'not-shipped':
+      return 'Not shipped';
+    case 'dispatched':
+      return 'Dispatched';
+    case 'delivered':
+      return 'Delivered';
+    case 'failed':
+      return 'Dispatch failed';
+    case 'unavailable':
+      return 'Not tracked';
+  }
+}
+
+/** Sum of item quantities — the "M unit" half of the header summary line. */
+export function totalUnits(items: readonly { quantity: number }[]): number {
+  return items.reduce((sum, item) => sum + item.quantity, 0);
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6166,37 +6166,6 @@ a.kpi-card:focus-visible {
   }
 }
 
-/* Three-column variant (#382): summary | sync status | customer */
-@media (min-width: 768px) and (max-width: 1023px) {
-  .order-detail__primary-grid--three {
-    /* Tablet: fall back to two columns and let the customer card wrap underneath. */
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr);
-  }
-
-  .order-detail__primary-grid--three > :last-child {
-    grid-column: 1 / -1;
-  }
-}
-
-@media (min-width: 1024px) {
-  .order-detail__primary-grid--three {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr) minmax(0, 0.85fr);
-  }
-}
-
-/* Address grid: shipping + billing side-by-side (desktop) */
-.order-detail__address-grid {
-  display: grid;
-  gap: 1.25rem;
-}
-
-@media (min-width: 600px) {
-  .order-detail__address-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: start;
-  }
-}
-
 /* Line items */
 .order-line-items {
   display: grid;
@@ -6233,23 +6202,6 @@ a.kpi-card:focus-visible {
    scroll so the section heading clears the sticky topbar on jump. */
 #order-raw-snapshot {
   scroll-margin-top: 4rem;
-}
-
-/* Items + totals grid (#382): items on the left, totals panel on the right at >=1024px. */
-.order-detail__items-grid {
-  display: grid;
-  gap: 1.25rem;
-}
-
-@media (min-width: 1024px) {
-  .order-detail__items-grid {
-    grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.45fr);
-    align-items: start;
-  }
-}
-
-.order-detail__totals-section {
-  min-width: 0;
 }
 
 /* Standalone warning breadcrumb row — quiet, diagnostic, links to raw snapshot. */
@@ -8668,9 +8620,7 @@ html[data-density='compact'] .status-badge {
   font-family: var(--font-sans);
 }
 .order-pricing__note {
-  display: flex;
-  gap: var(--space-2);
-  align-items: flex-start;
+  display: block;
   margin: 0;
   font-size: 0.75rem;
   color: var(--text-secondary);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8486,3 +8486,313 @@ html[data-density='compact'] .status-badge {
     min-height: 44px;
   }
 }
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Order detail redesign (#924)
+   Operator cockpit: derived health header + strip, failure banner, pricing,
+   delivery rail, audit timeline. Tokens-only; mobile-first (768 / 1024).
+   ───────────────────────────────────────────────────────────────────────── */
+
+/* Header */
+.order-header {
+  display: grid;
+  gap: var(--space-2);
+  margin-bottom: var(--space-5);
+}
+.order-header__top {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+.order-header__title {
+  margin: 0;
+  font-size: 1.75rem;
+  line-height: 1.1;
+  font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+  color: var(--text-primary);
+}
+.order-header__sub {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+.order-header__received {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Route: source → destination, role-labelled */
+.order-route {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.order-route__node {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+.order-route__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-pill);
+  background: var(--text-disabled);
+}
+.order-route__dot--accent {
+  background: var(--accent-primary);
+}
+.order-route__arrow {
+  color: var(--text-disabled);
+}
+.order-route__role {
+  font-size: 0.625rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 600;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0 5px;
+  line-height: 1.5;
+  background: var(--bg-surface-muted);
+}
+
+/* One-line order-contents summary */
+.order-header__summary-line {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+.order-header__summary-sep {
+  color: var(--text-disabled);
+}
+.order-product-link {
+  color: var(--text-primary);
+  text-decoration: none;
+  font-weight: 500;
+  border-bottom: 1px solid var(--border-default);
+  transition: color var(--duration-fast) var(--ease-out);
+}
+.order-product-link:hover,
+.order-product-link:focus-visible {
+  color: var(--accent-primary);
+  border-bottom-color: var(--accent-primary);
+}
+.order-product-link--plain {
+  border-bottom: none;
+  cursor: default;
+}
+
+/* Derived health strip */
+.order-health {
+  display: grid;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+}
+@media (min-width: 768px) {
+  .order-health {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+.order-health__cell {
+  position: relative;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  box-shadow: var(--shadow-xs);
+}
+.order-health__cell--alarm::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  border-radius: 3px 0 0 3px;
+  background: var(--status-error);
+}
+.order-health__k {
+  font-size: 0.6875rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+.order-health__v {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-top: 4px;
+  letter-spacing: var(--tracking-tight);
+  color: var(--text-primary);
+}
+.order-health__v--alarm {
+  color: var(--status-error-fg);
+}
+.order-health__hint {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+/* Pricing & tax */
+.order-pricing {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+  overflow: hidden;
+}
+.order-pricing__summary {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  padding: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+}
+.order-pricing__treatment {
+  text-transform: none;
+  letter-spacing: 0;
+  font-family: var(--font-sans);
+}
+.order-pricing__note {
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-start;
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-surface-muted);
+  border-top: 1px solid var(--border-subtle);
+}
+.order-pricing__note b {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* Detail grid: summary/sync (left) + delivery/shipment/customer (right) */
+.order-detail__primary-grid--split {
+  display: grid;
+  gap: var(--space-5);
+}
+@media (min-width: 1024px) {
+  .order-detail__primary-grid--split {
+    grid-template-columns: minmax(0, 1.5fr) minmax(320px, 1fr);
+    align-items: start;
+  }
+}
+.order-detail__stack {
+  display: grid;
+  gap: var(--space-5);
+  align-content: start;
+}
+
+/* Failure banner rows */
+.order-detail__failed-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-1) 0;
+}
+.order-detail__failed-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.order-detail__failed-raw {
+  font-size: 0.6875rem;
+  color: var(--text-link);
+  text-decoration: none;
+}
+.order-detail__failed-raw:hover,
+.order-detail__failed-raw:focus-visible {
+  text-decoration: underline;
+}
+
+/* Sync status compact rows */
+.order-sync-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+.order-sync-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+.order-sync-row__ext {
+  margin-left: auto;
+  font-size: 0.75rem;
+}
+.order-sync-list__note {
+  margin: var(--space-2) 0 0;
+  font-size: 0.6875rem;
+  line-height: 1.5;
+}
+
+/* Delivery panel */
+.order-delivery__card {
+  display: grid;
+  gap: var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+  padding: var(--space-4);
+}
+.order-delivery__addr {
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: var(--text-primary);
+}
+.order-delivery__pickup {
+  display: grid;
+  gap: 2px;
+  background: var(--bg-surface-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+}
+.order-delivery__pickup-code {
+  font-size: 0.8125rem;
+}
+.order-delivery__pickup-caption {
+  font-size: 0.6875rem;
+}
+
+/* Activity: actor eyebrow + footer caption */
+.order-activity__by {
+  margin-left: var(--space-2);
+  font-size: 0.625rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+.order-activity__caption {
+  margin: var(--space-3) 0 0;
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+}

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -166,6 +166,13 @@ describe('OrderDetailPage', () => {
       renderDetail(api);
       expect(await screen.findByText(/1 item · 2 units/)).toBeInTheDocument();
     });
+
+    it('renders the activity audit caption derived from the event count', async () => {
+      const api = createMockApiClient({ orders: { getById: vi.fn().mockResolvedValue(richOrder) } });
+      renderDetail(api);
+      // 1 ingest event + 1 sync attempt = 2 events.
+      expect(await screen.findByText(/Showing 2 of 2 events/)).toBeInTheDocument();
+    });
   });
 
   describe('destination retry', () => {

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -56,8 +56,7 @@ describe('OrderDetailPage', () => {
 
     renderDetail(api);
 
-    expect(await screen.findByText('ol_order_abc123')).toBeInTheDocument();
-    expect(screen.getByText('ol_customer_xyz')).toBeInTheDocument();
+    expect((await screen.findAllByText('ol_order_abc123')).length).toBeGreaterThan(0);
     expect(screen.getByText('evt_42')).toBeInTheDocument();
 
     const links = await screen.findAllByRole('link', { name: sampleConnection.name });
@@ -117,6 +116,56 @@ describe('OrderDetailPage', () => {
       'href',
       `/orders/failed?connectionId=${sampleConnection.id}`,
     );
+  });
+
+  describe('redesigned sections', () => {
+    const richOrder: OrderRecord = {
+      ...sampleOrder,
+      orderSnapshot: {
+        orderNumber: 'A-1024',
+        status: 'processing',
+        items: [
+          { id: 'it1', productId: 'ol_product_1', quantity: 2, price: 10, sku: 'SKU-1', name: 'Camera' },
+        ],
+        totals: { subtotal: 20, tax: 3.92, shipping: 5, total: 28.92, currency: 'PLN', taxTreatment: 'inclusive' },
+        shippingAddress: {
+          firstName: 'Jan',
+          lastName: 'Kowalski',
+          address1: 'ul. Testowa 1',
+          city: 'Warszawa',
+          postalCode: '00-001',
+          country: 'PL',
+        },
+        pickupPoint: { id: 'POP-WAW-04412' },
+        shipping: { methodId: 'm1', methodName: 'InPost Paczkomat' },
+      },
+    };
+
+    it('derives the sync health cell from syncStatus', async () => {
+      const api = createMockApiClient({ orders: { getById: vi.fn().mockResolvedValue(richOrder) } });
+      renderDetail(api);
+      expect(await screen.findByText('1 of 1 synced')).toBeInTheDocument();
+    });
+
+    it('surfaces the tax treatment as gross for tax-inclusive totals', async () => {
+      const api = createMockApiClient({ orders: { getById: vi.fn().mockResolvedValue(richOrder) } });
+      renderDetail(api);
+      expect(await screen.findByText(/gross · source-authoritative/i)).toBeInTheDocument();
+      expect(screen.getAllByText('Camera').length).toBeGreaterThan(0);
+    });
+
+    it('renders the buyer-selected pickup point and delivery method', async () => {
+      const api = createMockApiClient({ orders: { getById: vi.fn().mockResolvedValue(richOrder) } });
+      renderDetail(api);
+      expect(await screen.findByText('POP-WAW-04412')).toBeInTheDocument();
+      expect(screen.getByText('InPost Paczkomat')).toBeInTheDocument();
+    });
+
+    it('summarises item and unit counts in the header', async () => {
+      const api = createMockApiClient({ orders: { getById: vi.fn().mockResolvedValue(richOrder) } });
+      renderDetail(api);
+      expect(await screen.findByText(/1 item · 2 units/)).toBeInTheDocument();
+    });
   });
 
   describe('destination retry', () => {

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -1,11 +1,21 @@
-import { useCallback, useMemo, type ReactElement } from 'react';
+/**
+ * Order Detail Page
+ *
+ * Operator cockpit for a single order (#924): derived health header + strip,
+ * plain-language failure banner with a scoped Retry, pricing/tax breakdown,
+ * delivery + shipment + customer rail, and an audit-trail activity timeline.
+ * Display-only — every value comes from the `OrderRecord` / parsed snapshot /
+ * shipments query that already exist; the page composes features and performs
+ * no raw API calls.
+ *
+ * @module apps/web/src/pages/orders
+ */
+import { useCallback, type ReactElement } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { Alert } from '../../shared/ui/alert';
-import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
-import { EmptyValue } from '../../shared/ui/empty-value';
 import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
@@ -13,18 +23,22 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { useToast } from '../../shared/ui/toast-provider';
 import { useOrderQuery } from '../../features/orders/hooks/use-order-query';
 import { useRetryOrderDestinationMutation } from '../../features/orders/hooks/use-retry-order-destination-mutation';
-import type { OrderSyncStatus, OrderSyncStatusValue } from '../../features/orders/api/orders.types';
+import type { OrderSyncStatusValue } from '../../features/orders/api/orders.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
-import { CustomerEntityLabel } from '../../features/customers/components/CustomerEntityLabel';
+import { useConnectionsQuery } from '../../features/connections';
+import { useOrderShipmentsQuery } from '../../features/shipments';
 import { OrderCustomerCard } from '../../features/orders/components/order-customer-card';
-import { OrderLineItemsPanel } from '../../features/orders/components/order-line-items-panel';
-import { OrderTotalsPanel } from '../../features/orders/components/order-totals-panel';
 import { OrderActivityTimeline } from '../../features/orders/components/order-activity-timeline';
 import { OrderShipmentPanel } from '../../features/orders/components/order-shipment-panel';
+import { OrderDetailHeader } from '../../features/orders/components/order-detail-header';
+import { OrderHealthSummary } from '../../features/orders/components/order-health-summary';
+import { OrderPricingPanel } from '../../features/orders/components/order-pricing-panel';
+import { OrderDeliveryPanel } from '../../features/orders/components/order-delivery-panel';
+import { deriveFulfillment } from '../../features/orders/lib/order-health';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
-import type { ParsedAddress } from '../../features/orders/api/order-snapshot.schema';
 
 const RAW_SNAPSHOT_ANCHOR_ID = 'order-raw-snapshot';
+const SHIPPING_CAPABILITY = 'ShippingProviderManager';
 
 const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
   pending: 'info',
@@ -33,103 +47,11 @@ const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
   failed: 'error',
 };
 
-function buildSyncColumns(
-  onRetry: (destinationConnectionId: string) => void,
-  isRetrying: (destinationConnectionId: string) => boolean,
-): DataTableColumn<OrderSyncStatus>[] {
-  return [
-    {
-      id: 'destinationConnectionId',
-      header: 'Destination',
-      cell: (s) => <ConnectionEntityLabel connectionId={s.destinationConnectionId} showId={false} />,
-    },
-    {
-      id: 'status',
-      header: 'Status',
-      cell: (s) => (
-        <StatusBadge tone={SYNC_STATUS_TONES[s.status]} compact>
-          {s.status}
-        </StatusBadge>
-      ),
-    },
-    {
-      id: 'externalOrderId',
-      header: 'External Order ID',
-      cell: (s) =>
-        s.externalOrderId ? (
-          <span className="mono-text">{s.externalOrderId}</span>
-        ) : (
-          <EmptyValue />
-        ),
-      hideBelow: 768,
-    },
-    {
-      id: 'externalOrderNumber',
-      header: 'External Order #',
-      cell: (s) =>
-        s.externalOrderNumber ? (
-          <span className="mono-text">{s.externalOrderNumber}</span>
-        ) : (
-          <EmptyValue />
-        ),
-    },
-    {
-      id: 'syncedAt',
-      header: 'Synced At',
-      cell: (s) => (s.syncedAt ? <TimeDisplay iso={s.syncedAt} /> : <EmptyValue />),
-      hideBelow: 768,
-    },
-    {
-      id: 'error',
-      header: 'Error',
-      cell: (s) =>
-        s.error ? (
-          <span className="text-muted" title={s.error}>
-            {s.error.length > 80 ? `${s.error.slice(0, 80)}…` : s.error}
-          </span>
-        ) : (
-          <EmptyValue />
-        ),
-      hideBelow: 1024,
-    },
-    {
-      id: 'actions',
-      header: 'Actions',
-      cell: (s) => {
-        if (s.status !== 'failed') {
-          return <EmptyValue />;
-        }
-        const pending = isRetrying(s.destinationConnectionId);
-        return (
-          <Button
-            tone="secondary"
-            onClick={() => onRetry(s.destinationConnectionId)}
-            disabled={pending}
-          >
-            {pending ? 'Retrying…' : 'Retry'}
-          </Button>
-        );
-      },
-    },
-  ];
-}
-
-function buildAddressItems(address: ParsedAddress, label: string): KeyValueItem[] {
-  const fullName = [address.firstName, address.lastName].filter(Boolean).join(' ');
-  return [
-    ...(fullName ? [{ id: 'name', label: 'Name', value: fullName }] : []),
-    ...(address.company ? [{ id: 'company', label: 'Company', value: address.company }] : []),
-    { id: 'address1', label: label, value: address.address1 },
-    ...(address.address2 ? [{ id: 'address2', label: '', value: address.address2 }] : []),
-    { id: 'city', label: 'City', value: `${address.city}, ${address.postalCode}` },
-    { id: 'country', label: 'Country', value: address.country },
-    ...(address.phone ? [{ id: 'phone', label: 'Phone', value: address.phone }] : []),
-  ];
-}
-
 export function OrderDetailPage(): ReactElement {
   const { internalOrderId = '' } = useParams<{ internalOrderId: string }>();
   const query = useOrderQuery(internalOrderId);
+  const connectionsQuery = useConnectionsQuery();
+  const shipmentsQuery = useOrderShipmentsQuery(internalOrderId);
   const retry = useRetryOrderDestinationMutation();
   const { showToast } = useToast();
 
@@ -155,15 +77,6 @@ export function OrderDetailPage(): ReactElement {
       );
     },
     [retry, internalOrderId, showToast],
-  );
-
-  const syncColumns = useMemo(
-    () =>
-      buildSyncColumns(
-        handleRetry,
-        (destinationConnectionId) => pendingDestinationId === destinationConnectionId,
-      ),
-    [handleRetry, pendingDestinationId],
   );
 
   if (query.isLoading) {
@@ -195,27 +108,20 @@ export function OrderDetailPage(): ReactElement {
   }
 
   const order = query.data;
-  const failedDestinations = order.syncStatus.filter((s) => s.status === 'failed');
   const snapshot = parseOrderSnapshot(order.orderSnapshot);
-  const hasAnyAddress = Boolean(snapshot.shippingAddress ?? snapshot.billingAddress);
+  const failedDestinations = order.syncStatus.filter((s) => s.status === 'failed');
 
-  const shippingLine = snapshot.shippingAddress
-    ? [
-        snapshot.shippingAddress.address1,
-        snapshot.shippingAddress.city,
-        snapshot.shippingAddress.country,
-      ]
-        .filter(Boolean)
-        .join(', ')
-    : null;
+  const connections = connectionsQuery.data ?? [];
+  const hasShippingCapability = connections.some((c) =>
+    c.supportedCapabilities.includes(SHIPPING_CAPABILITY),
+  );
+  const shipmentStatuses = shipmentsQuery.data?.items.map((s) => s.status) ?? null;
+  const fulfillment = deriveFulfillment(shipmentStatuses, hasShippingCapability);
+  const sourcePlatformType =
+    connections.find((c) => c.id === order.sourceConnectionId)?.platformType ?? null;
 
+  // Internal ID is the header copy-chip; not duplicated here.
   const summaryItems: KeyValueItem[] = [
-    {
-      id: 'orderId',
-      label: 'Internal ID',
-      value: order.internalOrderId,
-      mono: true,
-    },
     ...(snapshot.orderNumber
       ? [{ id: 'orderNumber', label: 'Order #', value: snapshot.orderNumber, mono: true }]
       : []),
@@ -225,35 +131,25 @@ export function OrderDetailPage(): ReactElement {
       label: 'Source',
       value: <ConnectionEntityLabel connectionId={order.sourceConnectionId} />,
     },
-    {
-      id: 'customer',
-      label: 'Customer',
-      value: order.customerId ? (
-        <CustomerEntityLabel customerId={order.customerId} />
-      ) : (
-        <EmptyValue />
-      ),
-    },
-    ...(shippingLine
-      ? [{ id: 'shippingTo', label: 'Shipping to', value: shippingLine }]
-      : []),
-    { id: 'createdAt', label: 'Received', value: <TimeDisplay iso={order.createdAt} format="datetime" /> },
-    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={order.updatedAt} format="datetime" /> },
     ...(order.sourceEventId
       ? [{ id: 'sourceEvent', label: 'Source Event ID', value: order.sourceEventId, mono: true }]
       : []),
+    { id: 'createdAt', label: 'Received', value: <TimeDisplay iso={order.createdAt} format="datetime" /> },
+    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={order.updatedAt} format="datetime" /> },
   ];
 
   return (
-    <PageLayout
-      backTo={{ to: '/orders', label: 'Orders' }}
-      eyebrow="Orders"
-      title={
-        snapshot.orderNumber
-          ? `Order #${snapshot.orderNumber}`
-          : `Order — ${order.internalOrderId}`
-      }
-    >
+    <PageLayout backTo={{ to: '/orders', label: 'Orders' }} eyebrow="Orders" title="Order detail">
+      <OrderDetailHeader order={order} snapshot={snapshot} />
+
+      <OrderHealthSummary
+        syncStatus={order.syncStatus}
+        fulfillment={fulfillment}
+        totals={snapshot.totals}
+        itemCount={snapshot.items.length}
+        failedDestinationId={failedDestinations[0]?.destinationConnectionId ?? null}
+      />
+
       {failedDestinations.length > 0 ? (
         <Alert
           tone="error"
@@ -263,7 +159,7 @@ export function OrderDetailPage(): ReactElement {
           action={
             <Link
               to={`/orders/failed?connectionId=${encodeURIComponent(order.sourceConnectionId)}`}
-              className="button button--primary button--compact"
+              className="button button--secondary button--sm"
             >
               View failed orders
             </Link>
@@ -271,56 +167,91 @@ export function OrderDetailPage(): ReactElement {
         >
           <ul className="order-detail__failed-list">
             {failedDestinations.map((status) => (
-              <li key={status.destinationConnectionId}>
-                <ConnectionEntityLabel
-                  connectionId={status.destinationConnectionId}
-                  showId={false}
-                />
-                {status.error ? (
-                  <span className="order-detail__failed-error">
-                    {status.error.length > 120
-                      ? `${status.error.slice(0, 120)}…`
-                      : status.error}
-                  </span>
-                ) : null}
+              <li key={status.destinationConnectionId} className="order-detail__failed-row">
+                <div className="order-detail__failed-main">
+                  <ConnectionEntityLabel connectionId={status.destinationConnectionId} showId={false} />
+                  {status.error ? (
+                    <span className="order-detail__failed-error mono-text">
+                      {status.error.length > 160 ? `${status.error.slice(0, 160)}…` : status.error}
+                    </span>
+                  ) : null}
+                  <a className="order-detail__failed-raw" href={`#${RAW_SNAPSHOT_ANCHOR_ID}`}>
+                    view raw ▸
+                  </a>
+                </div>
+                <Button
+                  tone="primary"
+                  className="button--sm"
+                  onClick={() => handleRetry(status.destinationConnectionId)}
+                  disabled={pendingDestinationId === status.destinationConnectionId}
+                >
+                  {pendingDestinationId === status.destinationConnectionId ? 'Retrying…' : 'Retry'}
+                </Button>
               </li>
             ))}
           </ul>
         </Alert>
       ) : null}
 
-      {/* Primary grid: Summary | Sync Status | Customer (three columns on wide viewports) */}
-      <div className="order-detail__primary-grid order-detail__primary-grid--three">
+      {snapshot.items.length > 0 || snapshot.totals ? (
         <section className="detail-section">
-          <h3 className="detail-section__title">Summary</h3>
-          <KeyValueList items={summaryItems} />
+          <h3 className="detail-section__title">Pricing &amp; tax</h3>
+          <OrderPricingPanel items={snapshot.items} totals={snapshot.totals} />
         </section>
+      ) : null}
 
-        <section className="detail-section">
-          <h3 className="detail-section__title">
-            Sync Status{order.syncStatus.length > 0 ? ` (${order.syncStatus.length})` : ''}
-          </h3>
-          {order.syncStatus.length > 0 ? (
-            <DataTable
-              caption="Order sync status"
-              columns={syncColumns}
-              rows={order.syncStatus}
-              rowKey={(s) => s.destinationConnectionId}
-            />
-          ) : (
-            <p className="text-muted">No sync destinations configured.</p>
-          )}
-        </section>
+      {/* Detail grid: left = summary + sync status, right = delivery + shipment + customer */}
+      <div className="order-detail__primary-grid order-detail__primary-grid--split">
+        <div className="order-detail__stack">
+          <section className="detail-section">
+            <h3 className="detail-section__title">Summary</h3>
+            <KeyValueList items={summaryItems} />
+          </section>
 
-        <OrderCustomerCard
-          customerId={order.customerId}
-          sourceConnectionId={order.sourceConnectionId}
-        />
+          <section className="detail-section">
+            <h3 className="detail-section__title">
+              Sync status{order.syncStatus.length > 0 ? ` (${order.syncStatus.length})` : ''}
+            </h3>
+            {order.syncStatus.length > 0 ? (
+              <ul className="order-sync-list">
+                {order.syncStatus.map((status) => (
+                  <li key={status.destinationConnectionId} className="order-sync-row">
+                    <ConnectionEntityLabel connectionId={status.destinationConnectionId} showId={false} />
+                    <StatusBadge tone={SYNC_STATUS_TONES[status.status]} compact>
+                      {status.status}
+                    </StatusBadge>
+                    <span className="order-sync-row__ext">
+                      {status.externalOrderId ? (
+                        <span className="mono-text">#{status.externalOrderId}</span>
+                      ) : (
+                        <span className="text-muted">no destination order id yet</span>
+                      )}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-muted">No sync destinations configured.</p>
+            )}
+            <p className="order-sync-list__note text-muted">
+              Idempotent create (#909) — a retry won&rsquo;t double-create; a synced row shows its destination
+              order id.
+            </p>
+          </section>
+        </div>
+
+        <div className="order-detail__stack">
+          <OrderDeliveryPanel
+            shippingAddress={snapshot.shippingAddress}
+            shipping={snapshot.shipping}
+            pickupPoint={snapshot.pickupPoint}
+            sourcePlatformType={sourcePlatformType}
+          />
+          <OrderShipmentPanel order={order} />
+          <OrderCustomerCard customerId={order.customerId} sourceConnectionId={order.sourceConnectionId} />
+        </div>
       </div>
 
-      {/* Parse-warnings breadcrumb — quiet, diagnostic, links to the raw snapshot.
-          Stays page-level so it remains visible even when every enriched section
-          below is empty because everything failed to parse. */}
       {snapshot.parseWarnings.length > 0 ? (
         <p className="order-detail__parse-warning-row">
           <a
@@ -334,50 +265,6 @@ export function OrderDetailPage(): ReactElement {
         </p>
       ) : null}
 
-      {/* Line items + totals — each renders independently so one failure doesn't blank both.
-          When items are empty but totals exist, skip the Line Items column entirely rather
-          than showing a "Line Items" heading over an explanatory paragraph. */}
-      {snapshot.items.length > 0 || snapshot.totals ? (
-        <div className="order-detail__items-grid">
-          {snapshot.items.length > 0 ? (
-            <section className="detail-section">
-              <h3 className="detail-section__title">Line Items ({snapshot.items.length})</h3>
-              <OrderLineItemsPanel items={snapshot.items} totals={snapshot.totals} />
-            </section>
-          ) : null}
-          {snapshot.totals ? (
-            <section className="detail-section order-detail__totals-section">
-              <h3 className="detail-section__title">Totals</h3>
-              <OrderTotalsPanel totals={snapshot.totals} />
-            </section>
-          ) : null}
-        </div>
-      ) : null}
-
-      {/* Addresses — render each independently whenever its own sub-tree parsed */}
-      {hasAnyAddress ? (
-        <div className="order-detail__address-grid">
-          {snapshot.shippingAddress ? (
-            <section className="detail-section">
-              <h3 className="detail-section__title">Shipping Address</h3>
-              <KeyValueList items={buildAddressItems(snapshot.shippingAddress, 'Address')} />
-            </section>
-          ) : null}
-          {snapshot.billingAddress ? (
-            <section className="detail-section">
-              <h3 className="detail-section__title">Billing Address</h3>
-              <KeyValueList items={buildAddressItems(snapshot.billingAddress, 'Address')} />
-            </section>
-          ) : null}
-        </div>
-      ) : null}
-
-      {/* Shipment panel (#769) — full-width Band-2 section, between Addresses
-          (where it's going) and Activity Timeline (what's happened). Renders
-          nothing when no ShippingProviderManager is configured. */}
-      <OrderShipmentPanel order={order} />
-
-      {/* Activity timeline */}
       <section className="detail-section">
         <h3 className="detail-section__title">Activity</h3>
         <OrderActivityTimeline
@@ -388,7 +275,6 @@ export function OrderDetailPage(): ReactElement {
         />
       </section>
 
-      {/* Raw snapshot — collapsed by default; warning chip above links here */}
       <section className="detail-section" id={RAW_SNAPSHOT_ANCHOR_ID}>
         <RawPayloadPanel title="Order Snapshot" payload={order.orderSnapshot} />
       </section>

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -148,6 +148,7 @@ export function OrderDetailPage(): ReactElement {
         totals={snapshot.totals}
         itemCount={snapshot.items.length}
         failedDestinationId={failedDestinations[0]?.destinationConnectionId ?? null}
+        fulfillmentPending={connectionsQuery.isLoading || shipmentsQuery.isLoading}
       />
 
       {failedDestinations.length > 0 ? (

--- a/docs/plans/implementation-plan-order-detail-redesign.md
+++ b/docs/plans/implementation-plan-order-detail-redesign.md
@@ -1,0 +1,122 @@
+# Implementation Plan — Order-detail redesign (#924)
+
+> Display-only redesign of `/orders/:internalOrderId`. Renders data **already on**
+> the `OrderRecord` DTO + parsed `orderSnapshot` + shipments query. **No backend
+> fields added** (those are the separate epics #925–#928). The approved visual
+> spec is `docs/plans/order-detail-redesign-mockup.html` — its layout, token
+> usage, and primitive vocabulary are the North Star.
+
+## 1. Goal & layer
+
+- **Layer:** Frontend only (`apps/web`). No CORE / Integration / API changes.
+- **Goal:** turn the order-detail page from an "ingestion record" into an
+  operator cockpit: derived health header, plain-language failure banner with a
+  scoped Retry, pricing/tax breakdown, a shipping/delivery panel (pre- and
+  post-dispatch), and a real audit-trail activity timeline — with clickable
+  product/identity links.
+- **Non-goals:** new backend fields, a reconciliation-timestamp, a real human
+  actor on the audit trail, an external-marketplace listing URL, a "Re-check"
+  reconcile action. All of these are out of scope and **degraded gracefully**
+  (the line is hidden, not faked) per the issue's own implementation notes.
+
+## 2. Data availability (confirmed by reading the source)
+
+| Mockup element | Field | Source | Verdict |
+|---|---|---|---|
+| Order number, internal id | `orderNumber`, `internalOrderId` | snapshot / record | ✅ render |
+| Source → destination route | `sourceConnectionId`, `syncStatus[].destinationConnectionId` | record | ✅ render (`ConnectionEntityLabel`) |
+| Lifecycle badge ("Processing") | `snapshot.status` | snapshot | ✅ render |
+| Derived health badge ("Needs attention") | derived from `syncStatus` | record | ✅ derive |
+| Received + relative | `createdAt` | record | ✅ render (`TimeDisplay relative`) |
+| Order-contents one-liner | `items[]`, `totals` | snapshot | ✅ render; product → `/products/{productId}` when present |
+| Health row: Sync / Fulfillment / Total | `syncStatus`, shipments query, `totals` | record + query | ✅ derive |
+| Failure banner cause | `syncStatus[].error` (raw string) | record | ✅ render raw; **no fabricated remedy prose** |
+| Scoped Retry | `useRetryOrderDestinationMutation` | existing | ✅ reuse |
+| Pricing & tax table | `items[]`, `totals.{subtotal,shipping,tax,total,currency}` | snapshot | ✅ render |
+| Tax treatment badge | `totals.taxTreatment` (`'inclusive'\|'exclusive'`) | snapshot | ✅ surface via schema extension (existing BE data) |
+| Ship-to / method / pickup | `shippingAddress`, `shipping.methodName`, `pickupPoint` | snapshot | ✅ render |
+| Dispatch lifecycle / label / tracking | shipments query | existing `OrderShipmentPanel` | ✅ reuse (capability-gated) |
+| Activity audit trail | `createdAt`, `syncAttempts[]` | record | ✅ reuse `OrderActivityTimeline` (restyled) |
+| External listing ↗ | — | — | ❌ no data → **omit** |
+| Reconciliation freshness + Re-check | — | — | ❌ no data + backend action → **omit** |
+| Audit-trail human actor | — | — | ❌ not tracked → **"system"-derived eyebrow only** |
+
+## 3. Design — composition
+
+Page IA (top → bottom), matching the mockup:
+
+1. **Header** (in-page markup): `h1` order title + derived-health `StatusBadge` +
+   lifecycle `StatusBadge`; sub-row = internal-id copy chip (`CopyableId`) +
+   role-labelled route + "Received … · Nm ago"; order-contents one-liner
+   (thumbnail + item/unit count + product link + total).
+2. **`OrderHealthSummary`** (NEW) — 3 derived cells (Sync / Fulfillment / Total),
+   alarm rule on the failed cell.
+3. **Failure banner** — `Alert tone="error"`, per failed destination: raw error
+   as cause + scoped `Retry` + "view raw ▸" anchor to the raw snapshot.
+4. **`OrderPricingPanel`** (NEW) — card composing `OrderLineItemsPanel` +
+   `OrderTotalsPanel` (both reused) + tax-treatment badge + static pricing note.
+5. **Detail grid** — left `stack`: Summary `KeyValueList` (Received **before**
+   Updated) + Sync-status rows; right `stack`: **`OrderDeliveryPanel`** (NEW,
+   snapshot-driven ship-to/method/pickup) + `OrderShipmentPanel` (reused) +
+   `OrderCustomerCard` (reused).
+6. **Activity** — `OrderActivityTimeline` (reused, restyled per mockup).
+7. **Raw snapshot** — `RawPayloadPanel` (unchanged).
+
+### New components (`features/orders/components/`)
+- `order-health-summary.tsx` (+ `.test.tsx`) — pure; props: `syncStatus`,
+  `shipmentSummary` (`'none'|'awaiting'|'dispatched'|'delivered'|'unavailable'`),
+  `totals`.
+- `order-pricing-panel.tsx` (+ `.test.tsx`) — props: `items`, `totals`.
+- `order-delivery-panel.tsx` (+ `.test.tsx`) — props: `shippingAddress?`,
+  `shipping?`, `pickupPoint?`, `shippingPlatformType?` (for the pickup caption).
+
+### Touched files
+- `pages/orders/order-detail-page.tsx` — layout rework + header markup.
+- `pages/orders/order-detail-page.test.tsx` — extend for the new sections;
+  update the failure-banner assertions to the redesigned banner (keep a
+  failed-destination signal + a Retry affordance).
+- `features/orders/components/order-activity-timeline.tsx` — restyle + "system"
+  eyebrow + "Showing N of N · capped at 20" caption.
+- `features/orders/api/order-snapshot.schema.ts` — add optional `taxTreatment`
+  to `orderTotalsSchema` (+ extend `order-snapshot.schema.test.ts`).
+- `index.css` — new bounded section `/* ── Order detail redesign (#924) ── */`
+  (tokens already match the mockup verbatim). Then mirror any new var into
+  `shared/theme/tokens.ts` (none expected — mockup reuses existing tokens).
+
+## 4. Standards & risks
+
+- Vanilla CSS + existing OKLCH tokens only; BEM-flat class names; `tone` props;
+  mono+tabular on ids/numerics; `aria-hidden` on dots; color never the only signal.
+- No raw API calls in the page; server state via existing query hooks.
+- Reuse-before-create honoured: 3 new components are genuinely novel
+  (health/pricing/delivery); everything else is reused.
+- Risk: existing failure-banner test couples to old copy — updated deliberately.
+- Risk: apps/web full-suite flakiness — retry, never `--no-verify`.
+
+## 5. Quality gate
+`pnpm lint && pnpm type-check && pnpm test` green (light + dark visually spot-checked).
+
+## 6. Tech-review refinements applied
+
+- **View-model derivations → `features/orders/lib/order-health.ts`** (pure, unit-tested):
+  `rollupSyncStatus`, `deriveHealthLevel` / `healthLabel`, `syncCellLabel`,
+  `deriveFulfillment` / `fulfillmentLabel`. The page stays composition-only; the
+  header derivations move into `order-detail-header.tsx`.
+- **Pickup caption keys on the SOURCE platform** (`usePlatform(sourcePlatformType)`,
+  called unconditionally) per #893 — the buyer-selects the locker on the source
+  marketplace, not the destination/shipping connection.
+- **Tax wording is treatment-aware**: `inclusive → gross`, `exclusive → net`;
+  the badge + note never hardcode "gross". Schema enum mirrors core
+  `PriceTaxTreatmentValues` with a keep-in-sync comment (FE-001 contract strategy).
+- **Mobile-first breakpoints** (768 / 1024 `min-width`), not the mockup's
+  desktop-first `max-width: 860`. Detail grid: single-column → 65/35 at ≥1024;
+  health strip: 1-col → 3-col at ≥768.
+- **Query degradation**: the Fulfillment cell consumes `useOrderShipmentsQuery` +
+  `useConnectionsQuery` via their barrels and degrades to `unavailable` on
+  loading/error; existing page tests pass against the mock client's default
+  shipments/connections namespaces.
+- Scoped **Retry lives only in the failure banner** (single source of truth) —
+  the sync-status rows are status-only, so there's no double Retry button.
+- File-header comments on every new file; neutral source/destination route
+  labels (no `platformType` literal-equality); activity caption derived from
+  real `events.length`.

--- a/docs/plans/order-detail-redesign-mockup.html
+++ b/docs/plans/order-detail-redesign-mockup.html
@@ -1,0 +1,801 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OpenLinker · Order detail redesign (mockup)</title>
+<!--
+  Standalone, framework-free mockup for the Order-detail redesign (route /orders/:id).
+  Tokens are copied verbatim from apps/web/src/index.css (#775 OKLCH system) so the
+  mockup reads exactly as the shipping product would. Fonts fall back to system if the
+  self-hosted IBM Plex woff2 aren't reachable offline — the proportions/weights match.
+
+  Covers: (1) revised header + derived order-health, (2) plain-language failure banner
+  with scoped Retry, (3) Shipping/Delivery panel in pre-dispatch AND post-dispatch states.
+  Use the toggles top-right to flip theme + dispatch state.
+-->
+<style>
+  /* ───────────────────────── tokens (verbatim from index.css) ───────────────────────── */
+  :root {
+    --font-sans: 'IBM Plex Sans', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+    --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+    --bg-canvas: oklch(99% 0.003 80);
+    --bg-shell: oklch(97.5% 0.004 80);
+    --bg-surface: #ffffff;
+    --bg-surface-elevated: oklch(99% 0.003 80);
+    --bg-muted: oklch(96% 0.005 80);
+    --bg-surface-muted: oklch(96% 0.005 80);
+    --bg-surface-hover: oklch(93% 0.006 80);
+    --bg-strong: oklch(93% 0.006 80);
+
+    --border-subtle: oklch(93.5% 0.006 80);
+    --border-default: oklch(88% 0.008 80);
+    --border-strong: oklch(78% 0.010 80);
+
+    --text-primary: oklch(20% 0.012 80);
+    --text-secondary: oklch(38% 0.010 80);
+    --text-muted: oklch(52% 0.008 80);
+    --text-disabled: oklch(70% 0.005 80);
+    --text-on-primary: oklch(18% 0.012 50);
+    --text-link: oklch(50% 0.14 250);
+
+    --accent-primary: oklch(68% 0.18 50);
+    --accent-primary-hover: oklch(62% 0.19 50);
+    --accent-primary-soft: oklch(96% 0.04 60);
+    --accent-primary-border: oklch(85% 0.10 55);
+    --accent-ring: oklch(68% 0.18 50 / 0.30);
+
+    --status-success: oklch(54% 0.14 150);
+    --status-success-soft: oklch(96% 0.04 150);
+    --status-success-border: oklch(85% 0.08 150);
+    --status-success-fg: oklch(36% 0.12 150);
+
+    --status-warning: oklch(72% 0.16 85);
+    --status-warning-soft: oklch(96% 0.05 85);
+    --status-warning-border: oklch(85% 0.10 85);
+    --status-warning-fg: oklch(42% 0.12 80);
+
+    --status-error: oklch(58% 0.20 25);
+    --status-error-soft: oklch(96% 0.04 25);
+    --status-error-border: oklch(85% 0.10 25);
+    --status-error-fg: oklch(42% 0.16 25);
+
+    --status-info: oklch(56% 0.14 245);
+    --status-info-soft: oklch(96% 0.03 245);
+    --status-info-border: oklch(85% 0.08 245);
+    --status-info-fg: oklch(40% 0.12 245);
+
+    --status-disabled: oklch(55% 0.008 80);
+    --status-disabled-soft: oklch(95% 0.005 80);
+    --status-disabled-border: oklch(85% 0.008 80);
+    --status-disabled-fg: oklch(38% 0.010 80);
+
+    --shadow-xs: 0 1px 2px rgb(15 18 26 / 0.04);
+    --shadow-sm: 0 1px 2px rgb(15 18 26 / 0.04), 0 1px 3px rgb(15 18 26 / 0.06);
+    --shadow-md: 0 2px 4px rgb(15 18 26 / 0.04), 0 6px 16px rgb(15 18 26 / 0.08);
+    --shadow-focus: 0 0 0 3px var(--accent-ring);
+
+    --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem;
+    --space-5: 1.5rem; --space-6: 2rem; --space-7: 3rem;
+
+    --radius-sm: 6px; --radius-md: 8px; --radius-lg: 10px; --radius-xl: 14px; --radius-pill: 9999px;
+
+    --tracking-tight: -0.012em; --tracking-caps: 0.08em;
+    --duration-fast: 120ms; --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+
+    color-scheme: light;
+    font-family: var(--font-sans);
+    color: var(--text-primary);
+    background: var(--bg-canvas);
+  }
+
+  html[data-theme='dark'] {
+    color-scheme: dark;
+    --bg-canvas: oklch(14% 0.005 270);
+    --bg-shell: oklch(16% 0.006 270);
+    --bg-surface: oklch(19% 0.007 270);
+    --bg-surface-elevated: oklch(22% 0.008 270);
+    --bg-muted: oklch(24% 0.009 270);
+    --bg-surface-muted: oklch(24% 0.009 270);
+    --bg-surface-hover: oklch(28% 0.010 270);
+    --bg-strong: oklch(28% 0.010 270);
+    --border-subtle: oklch(24% 0.010 270);
+    --border-default: oklch(30% 0.012 270);
+    --border-strong: oklch(42% 0.014 270);
+    --text-primary: oklch(96% 0.006 270);
+    --text-secondary: oklch(78% 0.010 270);
+    --text-muted: oklch(60% 0.012 270);
+    --text-disabled: oklch(42% 0.012 270);
+    --text-on-primary: oklch(16% 0.012 50);
+    --text-link: oklch(76% 0.14 245);
+    --accent-primary: oklch(72% 0.18 50);
+    --accent-primary-hover: oklch(78% 0.18 50);
+    --accent-primary-soft: oklch(28% 0.08 50);
+    --accent-primary-border: oklch(40% 0.14 55);
+    --accent-ring: oklch(72% 0.18 50 / 0.40);
+    --status-success: oklch(68% 0.16 150); --status-success-soft: oklch(26% 0.06 150);
+    --status-success-border: oklch(36% 0.10 150); --status-success-fg: oklch(86% 0.14 150);
+    --status-warning: oklch(78% 0.16 85); --status-warning-soft: oklch(28% 0.07 85);
+    --status-warning-border: oklch(38% 0.10 85); --status-warning-fg: oklch(88% 0.14 85);
+    --status-error: oklch(70% 0.18 25); --status-error-soft: oklch(28% 0.10 25);
+    --status-error-border: oklch(40% 0.14 25); --status-error-fg: oklch(86% 0.14 25);
+    --status-info: oklch(72% 0.14 245); --status-info-soft: oklch(26% 0.06 245);
+    --status-info-border: oklch(36% 0.10 245); --status-info-fg: oklch(86% 0.12 245);
+    --status-disabled: oklch(65% 0.010 270); --status-disabled-soft: oklch(24% 0.010 270);
+    --status-disabled-border: oklch(34% 0.012 270); --status-disabled-fg: oklch(82% 0.010 270);
+    --shadow-xs: 0 1px 2px rgb(0 0 0 / 0.40);
+    --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.40), 0 1px 3px rgb(0 0 0 / 0.32);
+    --shadow-md: 0 2px 4px rgb(0 0 0 / 0.40), 0 6px 16px rgb(0 0 0 / 0.36);
+  }
+
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg-canvas); -webkit-font-smoothing: antialiased; }
+  .mono { font-family: var(--font-mono); font-feature-settings: 'ss01'; }
+  .tabular { font-variant-numeric: tabular-nums; }
+
+  /* ───────────────────────── page scaffold ───────────────────────── */
+  .page { max-width: 1180px; margin: 0 auto; padding: var(--space-6) var(--space-6) var(--space-7); }
+
+  /* control bar (mockup-only, not part of the product) */
+  .controls {
+    position: sticky; top: 0; z-index: 50;
+    display: flex; gap: var(--space-2); align-items: center; justify-content: flex-end;
+    padding: var(--space-3) var(--space-6);
+    background: color-mix(in oklab, var(--bg-shell) 88%, transparent);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .controls__label { margin-right: auto; font-size: 11px; letter-spacing: var(--tracking-caps);
+    text-transform: uppercase; color: var(--text-muted); font-weight: 600; }
+
+  /* ───────────────────────── back link + header ───────────────────────── */
+  .backlink {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 0.8125rem; color: var(--text-muted); text-decoration: none;
+    margin-bottom: var(--space-4);
+  }
+  .backlink:hover { color: var(--text-primary); }
+  .backlink svg { width: 14px; height: 14px; }
+
+  .order-header { margin-bottom: var(--space-5); }
+  .order-header__top {
+    display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap;
+  }
+  .order-header h1 {
+    margin: 0; font-size: 1.75rem; line-height: 1.1; font-weight: 600;
+    letter-spacing: var(--tracking-tight); color: var(--text-primary);
+  }
+  .order-header__sub {
+    display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap;
+    margin-top: var(--space-2);
+    font-size: 0.8125rem; color: var(--text-muted);
+  }
+  .uuid-chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 0.75rem; color: var(--text-muted);
+  }
+  .copybtn {
+    border: 1px solid var(--border-subtle); background: var(--bg-surface-muted);
+    color: var(--text-muted); border-radius: var(--radius-sm);
+    padding: 1px 6px; font-size: 0.6875rem; cursor: pointer; line-height: 1.4;
+    font-family: var(--font-sans);
+  }
+  .copybtn:hover { color: var(--text-primary); border-color: var(--border-default); }
+
+  /* route: source → destination, role-labelled */
+  .route { display: inline-flex; align-items: center; gap: var(--space-2); }
+  .route__node { display: inline-flex; align-items: center; gap: 5px;
+    font-size: 0.75rem; color: var(--text-secondary); }
+  .route__dot { width: 6px; height: 6px; border-radius: 50%; background: var(--text-disabled); }
+  .route__arrow { color: var(--text-disabled); }
+  .dot--accent { background: var(--accent-primary); }
+  .route__role {
+    font-size: 0.625rem; letter-spacing: var(--tracking-caps); text-transform: uppercase;
+    color: var(--text-muted); font-weight: 600;
+    border: 1px solid var(--border-subtle); border-radius: var(--radius-sm);
+    padding: 0 5px; line-height: 1.5; background: var(--bg-surface-muted);
+  }
+
+  /* one-line order contents summary */
+  .order-summary-line {
+    display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap;
+    margin-top: var(--space-3); font-size: 0.8125rem; color: var(--text-secondary);
+  }
+  .order-summary-line b { color: var(--text-primary); font-weight: 600; }
+  .order-summary-line__sep { color: var(--text-disabled); }
+
+  /* clickable product → OpenLinker product; ↗ → external marketplace listing */
+  .product-link { color: var(--text-primary); text-decoration: none; font-weight: 500;
+    border-bottom: 1px solid var(--border-default); transition: color var(--duration-fast) var(--ease-out); }
+  .product-link:hover { color: var(--accent-primary); border-bottom-color: var(--accent-primary); }
+  .ext-link { color: var(--text-muted); text-decoration: none; font-size: 0.75rem; padding: 0 2px; }
+  .ext-link:hover { color: var(--accent-primary); }
+
+  /* reconciliation freshness line */
+  .recon {
+    display: inline-flex; align-items: center; gap: 6px; margin-top: var(--space-3);
+    font-size: 0.75rem; color: var(--text-muted);
+  }
+  .recon__dot { width: 6px; height: 6px; border-radius: 50%; background: var(--status-success); }
+
+  /* sync attempts + idempotency note */
+  .attempts { padding: var(--space-2) var(--space-4); }
+  .attempts__row { display: flex; align-items: center; gap: var(--space-2); padding: var(--space-1) 0; }
+  .attempts__when { font-size: 0.6875rem; color: var(--text-secondary); }
+  .badge--mini { padding: 1px 6px; font-size: 0.625rem; }
+  .idem-note {
+    display: flex; gap: var(--space-2); align-items: flex-start;
+    font-size: 0.6875rem; color: var(--text-muted); line-height: 1.5;
+    padding: var(--space-3) var(--space-4); border-top: 1px solid var(--border-subtle);
+    background: var(--bg-surface-muted);
+  }
+  .idem-note b { color: var(--text-secondary); font-weight: 600; }
+  .idem-note svg { width: 14px; height: 14px; flex: 0 0 auto; color: var(--status-success); margin-top: 1px; }
+
+  /* timeline (primitive) */
+  .timeline { list-style: none; margin: 0; padding: 0; }
+  .tl { display: grid; grid-template-columns: 16px 1fr auto; gap: var(--space-3); padding-bottom: var(--space-4); position: relative; }
+  .tl:not(:last-child)::before {
+    content: ''; position: absolute; left: 7px; top: 16px; bottom: 0; width: 1px; background: var(--border-default);
+  }
+  .tl__dot { width: 10px; height: 10px; border-radius: 50%; margin-top: 4px; margin-left: 1px; z-index: 1;
+    border: 2px solid var(--bg-surface); box-shadow: 0 0 0 1px currentColor; }
+  .tl__dot--info { color: var(--status-info); background: var(--status-info); }
+  .tl__dot--error { color: var(--status-error); background: var(--status-error); }
+  .tl__dot--neutral { color: var(--text-muted); background: var(--text-muted); }
+  .tl__head { display: flex; align-items: baseline; gap: var(--space-2); flex-wrap: wrap; }
+  .tl__head b { font-size: 0.8125rem; font-weight: 600; color: var(--text-primary); }
+  .tl__by {
+    font-size: 0.625rem; letter-spacing: var(--tracking-caps); text-transform: uppercase;
+    color: var(--text-muted); font-weight: 600;
+  }
+  .tl__detail { font-size: 0.75rem; color: var(--text-secondary); margin-top: 2px; line-height: 1.5; }
+  .tl__time { font-size: 0.6875rem; color: var(--text-muted); white-space: nowrap; }
+  .thumb {
+    width: 22px; height: 22px; flex: 0 0 auto; border-radius: var(--radius-sm);
+    background: var(--bg-surface-muted); border: 1px solid var(--border-subtle);
+    display: inline-flex; align-items: center; justify-content: center;
+    font-family: var(--font-mono); font-size: 0.6875rem; color: var(--text-muted);
+  }
+
+  /* ───────────────────────── status badge (primitive) ───────────────────────── */
+  .badge {
+    display: inline-flex; align-items: center; gap: 6px;
+    border-radius: var(--radius-sm); padding: 3px 9px;
+    font-size: 0.6875rem; font-weight: 600; letter-spacing: var(--tracking-caps);
+    text-transform: uppercase; font-family: var(--font-mono);
+    border: 1px solid transparent; white-space: nowrap;
+  }
+  .badge__dot { width: 6px; height: 6px; border-radius: 50%; }
+  .badge--error   { background: var(--status-error-soft);   color: var(--status-error-fg);   border-color: var(--status-error-border); }
+  .badge--error   .badge__dot { background: var(--status-error); }
+  .badge--warning { background: var(--status-warning-soft); color: var(--status-warning-fg); border-color: var(--status-warning-border); }
+  .badge--warning .badge__dot { background: var(--status-warning); }
+  .badge--success { background: var(--status-success-soft); color: var(--status-success-fg); border-color: var(--status-success-border); }
+  .badge--success .badge__dot { background: var(--status-success); }
+  .badge--info    { background: var(--status-info-soft);    color: var(--status-info-fg);    border-color: var(--status-info-border); }
+  .badge--info    .badge__dot { background: var(--status-info); }
+  .badge--neutral { background: var(--bg-surface-muted);    color: var(--text-secondary);    border-color: var(--border-default); }
+  .badge--neutral .badge__dot { background: var(--text-muted); }
+  .badge--lifecycle { background: transparent; color: var(--text-muted); border-color: var(--border-default); }
+  .badge--lifecycle .badge__dot { background: var(--text-disabled); }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
+  .badge__dot--pulse { animation: pulse 1.6s var(--ease-out) infinite; }
+
+  /* ───────────────────────── buttons (primitive) ───────────────────────── */
+  .btn {
+    display: inline-flex; align-items: center; gap: 6px; justify-content: center;
+    height: 32px; padding: 0 var(--space-3); border-radius: var(--radius-md);
+    font-size: 0.8125rem; font-weight: 500; font-family: var(--font-sans);
+    cursor: pointer; border: 1px solid transparent; white-space: nowrap;
+    transition: background var(--duration-fast) var(--ease-out), border-color var(--duration-fast);
+  }
+  .btn:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+  .btn--primary { background: var(--accent-primary); color: var(--text-on-primary); }
+  .btn--primary:hover { background: var(--accent-primary-hover); }
+  .btn--secondary { background: var(--bg-surface); color: var(--text-primary); border-color: var(--border-default); }
+  .btn--secondary:hover { background: var(--bg-surface-hover); }
+  .btn--ghost { background: transparent; color: var(--text-secondary); }
+  .btn--ghost:hover { background: var(--bg-surface-hover); color: var(--text-primary); }
+  .btn--sm { height: 28px; padding: 0 var(--space-2); font-size: 0.75rem; }
+  .btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+  .btn svg { width: 14px; height: 14px; }
+
+  /* ───────────────────────── alert (primitive) ───────────────────────── */
+  .alert {
+    border: 1px solid; border-radius: var(--radius-lg); padding: var(--space-4) var(--space-5);
+    margin-bottom: var(--space-5); position: relative; overflow: hidden;
+  }
+  .alert::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; }
+  .alert--error { background: var(--status-error-soft); border-color: var(--status-error-border); }
+  .alert--error::before { background: var(--status-error); }
+  .alert__head { display: flex; align-items: flex-start; gap: var(--space-3); }
+  .alert__icon { flex: 0 0 auto; width: 18px; height: 18px; color: var(--status-error); margin-top: 1px; }
+  .alert__body { flex: 1 1 auto; min-width: 0; }
+  .alert__title { font-size: 0.9375rem; font-weight: 600; color: var(--text-primary); margin: 0 0 4px; }
+  .alert__cause { font-size: 0.8125rem; color: var(--text-secondary); margin: 0 0 var(--space-2); line-height: 1.5; }
+  .alert__cause b { color: var(--text-primary); font-weight: 600; }
+  .alert__remedy {
+    font-size: 0.8125rem; color: var(--text-secondary); line-height: 1.5;
+    background: color-mix(in oklab, var(--bg-surface) 60%, transparent);
+    border: 1px solid var(--status-error-border); border-radius: var(--radius-md);
+    padding: var(--space-2) var(--space-3); margin: 0 0 var(--space-3);
+  }
+  .alert__remedy strong { color: var(--text-primary); }
+  .alert__meta {
+    display: flex; align-items: center; gap: var(--space-2);
+    font-size: 0.6875rem; color: var(--text-muted);
+  }
+  .alert__meta .mono { font-size: 0.6875rem; color: var(--status-error-fg); }
+  .alert__actions { display: flex; gap: var(--space-2); flex: 0 0 auto; margin-left: auto; }
+
+  /* ───────────────────────── panels / cards ───────────────────────── */
+  .grid { display: grid; gap: var(--space-5); }
+  .grid--detail { grid-template-columns: minmax(0, 1.35fr) minmax(320px, 1fr); align-items: start; }
+  .stack { display: grid; gap: var(--space-5); align-content: start; }
+  .section-title {
+    font-size: 0.6875rem; font-weight: 600; letter-spacing: var(--tracking-caps);
+    text-transform: uppercase; color: var(--text-muted); margin: 0 0 var(--space-3);
+  }
+  .card {
+    background: var(--bg-surface); border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg); box-shadow: var(--shadow-xs); overflow: hidden;
+  }
+  .card__head {
+    display: flex; align-items: center; justify-content: space-between; gap: var(--space-2);
+    padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle);
+  }
+  .card__head h2 { margin: 0; font-size: 0.9375rem; font-weight: 600; letter-spacing: var(--tracking-tight); }
+  .card__head .badge { margin-left: auto; }
+  .card__body { padding: var(--space-4); }
+  .card__foot {
+    display: flex; align-items: center; justify-content: space-between; gap: var(--space-3);
+    padding: var(--space-3) var(--space-4); border-top: 1px solid var(--border-subtle);
+    background: var(--bg-surface-muted);
+  }
+  .linklike { font-size: 0.75rem; color: var(--text-link); text-decoration: none; }
+  .linklike:hover { text-decoration: underline; }
+
+  /* health summary row */
+  .health {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-3);
+    margin-bottom: var(--space-5);
+  }
+  .health__cell {
+    background: var(--bg-surface); border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg); padding: var(--space-3) var(--space-4);
+    box-shadow: var(--shadow-xs); position: relative;
+  }
+  .health__cell--alarm::before {
+    content: ''; position: absolute; inset: 0 auto 0 0; width: 3px; border-radius: 3px 0 0 3px;
+    background: var(--status-error);
+  }
+  .health__k { font-size: 0.6875rem; letter-spacing: var(--tracking-caps); text-transform: uppercase; color: var(--text-muted); font-weight: 600; }
+  .health__v { font-size: 1.125rem; font-weight: 600; margin-top: 4px; letter-spacing: var(--tracking-tight); }
+  .health__hint { font-size: 0.6875rem; color: var(--text-muted); margin-top: 2px; }
+
+  /* KeyValueList (primitive) */
+  .kv { display: grid; grid-template-columns: 132px 1fr; gap: 0; }
+  .kv__k {
+    font-size: 0.6875rem; letter-spacing: var(--tracking-caps); text-transform: uppercase;
+    color: var(--text-muted); font-weight: 600; padding: var(--space-2) var(--space-3) var(--space-2) 0;
+    border-top: 1px solid var(--border-subtle);
+  }
+  .kv__v {
+    font-size: 0.8125rem; color: var(--text-primary); padding: var(--space-2) 0;
+    border-top: 1px solid var(--border-subtle); min-width: 0;
+  }
+  .kv > .kv__k:first-of-type, .kv > .kv__k:first-of-type + .kv__v { border-top: none; }
+
+  /* address block */
+  .addr { font-size: 0.8125rem; line-height: 1.55; color: var(--text-primary); }
+  .addr .muted { color: var(--text-muted); }
+  .flag { font-size: 0.95rem; }
+
+  /* method / pickup rows */
+  .meta-row { display: flex; align-items: baseline; gap: var(--space-2); flex-wrap: wrap; }
+  .caption { font-size: 0.6875rem; color: var(--text-muted); }
+  .pickup {
+    display: flex; gap: var(--space-2); align-items: center;
+    background: var(--bg-surface-muted); border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md); padding: var(--space-2) var(--space-3); margin-top: var(--space-2);
+  }
+  .pickup__code { font-size: 0.8125rem; }
+  .locker-ico { width: 18px; height: 18px; color: var(--text-muted); flex: 0 0 auto; }
+
+  /* tracking link */
+  .track { display: inline-flex; align-items: center; gap: 6px; color: var(--text-link); text-decoration: none; }
+  .track:hover { text-decoration: underline; }
+  .track svg { width: 12px; height: 12px; }
+
+  /* empty / gated dispatch */
+  .dispatch-gate {
+    display: flex; align-items: center; gap: var(--space-2);
+    font-size: 0.75rem; color: var(--status-warning-fg);
+    background: var(--status-warning-soft); border: 1px solid var(--status-warning-border);
+    border-radius: var(--radius-md); padding: var(--space-2) var(--space-3); margin-top: var(--space-3);
+  }
+  .dispatch-gate svg { width: 14px; height: 14px; flex: 0 0 auto; }
+
+  .divider { height: 1px; background: var(--border-subtle); margin: var(--space-4) 0; border: 0; }
+
+  /* pricing & tax table (#5) */
+  .price-table { width: 100%; border-collapse: collapse; font-size: 0.8125rem; }
+  .price-table th {
+    text-align: left; font-size: 0.625rem; font-weight: 600; letter-spacing: var(--tracking-caps);
+    text-transform: uppercase; color: var(--text-muted);
+    padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle);
+  }
+  .price-table td {
+    padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle);
+    color: var(--text-primary); vertical-align: top;
+  }
+  .price-table .num { text-align: right; }
+  .price-table th.num { text-align: right; }
+  .price-table tfoot td { border-bottom: none; padding-top: var(--space-2); padding-bottom: var(--space-2); color: var(--text-secondary); }
+  .price-table tfoot tr:first-child td { padding-top: var(--space-3); }
+  .price-table__total td { color: var(--text-primary); font-weight: 600; font-size: 0.9375rem;
+    border-top: 1px solid var(--border-default); padding-top: var(--space-3); }
+  .price-note {
+    display: flex; gap: var(--space-2); align-items: flex-start;
+    font-size: 0.75rem; color: var(--text-secondary); line-height: 1.5;
+    padding: var(--space-3) var(--space-4); background: var(--bg-surface-muted);
+    border-top: 1px solid var(--border-subtle);
+  }
+  .price-note b { color: var(--text-primary); font-weight: 600; }
+  .price-note svg { width: 15px; height: 15px; flex: 0 0 auto; color: var(--text-muted); margin-top: 1px; }
+
+  .state-label {
+    font-size: 0.6875rem; letter-spacing: var(--tracking-caps); text-transform: uppercase;
+    color: var(--text-muted); font-weight: 600; margin: var(--space-7) 0 var(--space-3);
+    padding-bottom: var(--space-2); border-bottom: 1px dashed var(--border-default);
+  }
+  .toggle-btn {
+    border: 1px solid var(--border-default); background: var(--bg-surface);
+    color: var(--text-secondary); border-radius: var(--radius-md);
+    padding: 5px 10px; font-size: 0.75rem; cursor: pointer; font-family: var(--font-sans);
+  }
+  .toggle-btn:hover { background: var(--bg-surface-hover); }
+
+  @media (max-width: 860px) {
+    .grid--detail { grid-template-columns: 1fr; }
+    .health { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<div class="controls">
+  <span class="controls__label">Order detail · redesign mockup</span>
+  <button class="toggle-btn" onclick="document.documentElement.dataset.theme = document.documentElement.dataset.theme==='dark'?'light':'dark'">Toggle theme</button>
+</div>
+
+<div class="page">
+
+  <a class="backlink" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg> Orders</a>
+
+  <!-- ░░░░░░░░░░░░░░░░░░░ (1) REVISED HEADER ░░░░░░░░░░░░░░░░░░░ -->
+  <header class="order-header">
+    <div class="order-header__top">
+      <h1>Allegro order <span class="mono">a41a-0710-979b</span></h1>
+      <span class="badge badge--error"><span class="badge__dot"></span>Needs attention</span>
+      <span class="badge badge--lifecycle"><span class="badge__dot"></span>Processing</span>
+    </div>
+    <div class="order-header__sub">
+      <span class="uuid-chip mono">ol_order_10d2abbf…64fc09c <button class="copybtn">⧉ copy</button></span>
+      <!-- role-labelled route (#2): platform name + the hat it wears in this flow -->
+      <span class="route">
+        <span class="route__node"><span class="route__dot"></span>Allegro sandbox <span class="route__role">marketplace</span></span>
+        <span class="route__arrow">→</span>
+        <span class="route__node"><span class="route__dot dot--accent"></span>PrestaShop <span class="route__role">fulfillment · OMP</span></span>
+      </span>
+      <span>·</span>
+      <span>Received <span class="mono tabular">31 May 16:00</span> · 2h ago</span>
+    </div>
+    <!-- one-line order-contents summary (#3): what is this order, without scrolling.
+         The product is clickable → OpenLinker product; ↗ opens the marketplace listing. -->
+    <div class="order-summary-line">
+      <span class="thumb" aria-hidden="true">A</span>
+      <b>1 item · 1 unit</b> —
+      <a class="product-link" href="#" title="Open product in OpenLinker">Aparat cyfrowy CANON PowerShot SX740 Lite Edition · srebrny</a>
+      <a class="ext-link" href="#" title="Open listing on Allegro" aria-label="Open listing on Allegro">↗</a>
+      <span class="order-summary-line__sep">·</span>
+      <span class="mono tabular">PLN 20.95</span>
+    </div>
+    <!-- reconciliation freshness (#1): OL is a mirror — say how fresh its view is -->
+    <div class="recon">
+      <span class="recon__dot"></span>
+      Reconciled with Allegro &amp; PrestaShop <span class="mono tabular">4m ago</span>
+      <button class="copybtn" style="margin-left:4px">↻ Re-check</button>
+    </div>
+  </header>
+
+  <!-- ░░░░░░░░░░░░░░░░░░░ derived ORDER-HEALTH summary row ░░░░░░░░░░░░░░░░░░░ -->
+  <div class="health">
+    <div class="health__cell health__cell--alarm">
+      <div class="health__k">Sync</div>
+      <div class="health__v" style="color: var(--status-error-fg)">1 of 1 failed</div>
+      <div class="health__hint">PrestaShop · pricing error</div>
+    </div>
+    <div class="health__cell">
+      <div class="health__k">Fulfillment</div>
+      <div class="health__v">Not shipped</div>
+      <div class="health__hint">Blocked until sync succeeds</div>
+    </div>
+    <div class="health__cell">
+      <div class="health__k">Total</div>
+      <div class="health__v mono tabular">PLN 20.95</div>
+      <div class="health__hint">1 item · source-priced</div>
+    </div>
+  </div>
+
+  <!-- ░░░░░░░░░░░░░░░░░░░ (2) FAILURE BANNER w/ remediation + scoped Retry ░░░░░░░░░░░░░░░░░░░ -->
+  <div class="alert alert--error" role="alert">
+    <div class="alert__head">
+      <svg class="alert__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v4m0 4h.01M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z"/></svg>
+      <div class="alert__body">
+        <p class="alert__title">Sync to PrestaShop failed</p>
+        <p class="alert__cause">Destination product <b>#25</b> has no catalog price in PrestaShop, so OpenLinker couldn’t pin the buyer-paid price (PLN&nbsp;10.00) onto the order.</p>
+        <p class="alert__remedy"><strong>What to do:</strong> set a base price on the PrestaShop product (or add a price mapping), then retry. This failure is retryable once the product is priced.</p>
+        <div class="alert__meta">
+          <span class="mono">PrestaShop API 400 · POST /api/specific_prices</span>
+          <button class="copybtn">⧉ copy</button>
+          <a class="linklike" href="#">view raw ▸</a>
+        </div>
+      </div>
+      <div class="alert__actions">
+        <button class="btn btn--secondary btn--sm">Open PS product ↗</button>
+        <button class="btn btn--primary btn--sm">Retry sync</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ░░░░░░░░░░░░░░░░░░░ (5) PRICING breakdown — source→destination + tax treatment ░░░░░░░░░░░░░░░░░░░ -->
+  <!-- Surfaces totals.tax + taxTreatment (already in the data, #895/ADR-014). Placed here
+       because the failure above is a pricing error: this is the context to debug it. -->
+  <section style="margin-bottom: var(--space-5)">
+    <h2 class="section-title">Pricing &amp; tax</h2>
+    <div class="card"><div class="card__body" style="padding: 0">
+      <table class="price-table">
+        <thead>
+          <tr><th>Line</th><th class="num">Qty</th><th class="num">Unit (buyer-paid)</th><th class="num">Line total</th><th>Tax treatment</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a class="product-link" href="#" title="Open product in OpenLinker">CANON PowerShot SX740</a>
+              <a class="ext-link" href="#" aria-label="Open listing on Allegro">↗</a>
+              <span class="mono caption">7781562863</span>
+            </td>
+            <td class="num mono tabular">1</td>
+            <td class="num mono tabular">PLN 10.00</td>
+            <td class="num mono tabular">PLN 10.00</td>
+            <td><span class="badge badge--neutral" style="text-transform:none; letter-spacing:0; font-family:var(--font-sans)">gross · source-authoritative</span></td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr><td colspan="3" class="num caption">Subtotal</td><td class="num mono tabular">PLN 10.00</td><td></td></tr>
+          <tr><td colspan="3" class="num caption">Shipping</td><td class="num mono tabular">PLN 10.95</td><td></td></tr>
+          <tr><td colspan="3" class="num caption">VAT incl. (23%)</td><td class="num mono tabular">PLN 3.92</td><td></td></tr>
+          <tr class="price-table__total"><td colspan="3" class="num">Total</td><td class="num mono tabular">PLN 20.95</td><td><span class="caption">PLN</span></td></tr>
+        </tfoot>
+      </table>
+      <div class="price-note">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v4h1"/></svg>
+        OpenLinker pins the <b>buyer-paid (gross) price</b> onto the destination — it does not use the PrestaShop catalog price. The sync failed because product #25 has no base price to pin against.
+      </div>
+    </div></div>
+  </section>
+
+  <!-- ░░░░░░░░░░░░░░░░░░░ detail grid (left = existing summary/sync, right = NEW shipping) ░░░░░░░░░░░░░░░░░░░ -->
+  <div class="grid grid--detail">
+
+    <!-- LEFT: condensed summary (existing) — shown for context only -->
+    <div class="stack">
+      <section>
+        <h2 class="section-title">Summary</h2>
+        <div class="card"><div class="card__body" style="padding-top: var(--space-2); padding-bottom: var(--space-2)">
+          <div class="kv">
+            <div class="kv__k">Order #</div><div class="kv__v mono">a41a0710-5cf8-11f1-979b-098d4666d4ec</div>
+            <div class="kv__k">Source</div><div class="kv__v">Allegro sandbox <span class="mono" style="color:var(--text-muted)">aacff639…ea2e</span></div>
+            <div class="kv__k">Source event</div><div class="kv__v mono tabular">1780235877036619</div>
+            <div class="kv__k">Received</div><div class="kv__v mono tabular">31 May 2026 16:00</div>
+            <div class="kv__k">Updated</div><div class="kv__v mono tabular">31 May 2026 16:07</div>
+          </div>
+        </div></div>
+      </section>
+
+      <section>
+        <h2 class="section-title">Sync status (1)</h2>
+        <div class="card"><div class="card__body" style="padding: 0">
+          <div style="display:flex; align-items:center; gap:var(--space-3); padding:var(--space-3) var(--space-4); border-bottom:1px solid var(--border-subtle)">
+            <span class="route__node"><span class="route__dot dot--accent"></span>PrestaShop <span class="route__role">OMP</span></span>
+            <span class="badge badge--error"><span class="badge__dot"></span>Failed</span>
+            <span class="caption" style="margin-left:auto">no destination order id yet</span>
+            <button class="btn btn--secondary btn--sm">Retry</button>
+          </div>
+          <!-- idempotency / external-id surfacing (#2 / #909): make the create-once contract visible.
+               Failed here, so no external id; the success variant is shown in the note below. -->
+          <div class="attempts">
+            <div class="attempts__row">
+              <span class="badge badge--error badge--mini"><span class="badge__dot"></span>Failed</span>
+              <span class="attempts__when mono tabular">attempt 1 · 31 May 16:00</span>
+              <span class="caption">price-pin error · no order created</span>
+            </div>
+          </div>
+          <div class="idem-note">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/><circle cx="12" cy="12" r="9"/></svg>
+            Idempotent create (#909): a retry won’t double-create. On success this row shows
+            <b>Created once · PS&nbsp;#888&nbsp;↗</b>; a deduped retry is labelled <b>already existed</b>.
+          </div>
+        </div></div>
+      </section>
+    </div>
+
+    <!-- RIGHT: NEW Shipping & Customer panel — PRE-DISPATCH -->
+    <div class="stack">
+      <section>
+        <h2 class="section-title">Shipping &amp; customer</h2>
+        <div class="card">
+          <div class="card__head">
+            <h2>Delivery</h2>
+            <span class="badge badge--neutral"><span class="badge__dot"></span>Awaiting dispatch</span>
+          </div>
+          <div class="card__body">
+            <!-- ship-to -->
+            <div class="kv">
+              <div class="kv__k">Ship to</div>
+              <div class="kv__v">
+                <div class="addr">
+                  <span class="muted">Guest buyer · unmapped</span><br>
+                  ul. Przykładowa 12 / 4<br>
+                  00-001 Warszawa<br>
+                  <span class="flag">🇵🇱</span> Poland
+                </div>
+              </div>
+              <div class="kv__k">Contact</div>
+              <div class="kv__v">
+                <span class="mono" style="font-size:0.75rem">pa315…310@user.allegrogroup.pl</span>
+                <button class="copybtn">⧉</button><br>
+                <span class="caption">☎ not provided · 31 previous orders</span>
+                <a class="linklike" href="#">View customer →</a>
+              </div>
+            </div>
+
+            <hr class="divider">
+
+            <!-- method + pickup -->
+            <div class="kv">
+              <div class="kv__k">Method</div>
+              <div class="kv__v">
+                <div class="meta-row"><strong>InPost Paczkomat</strong><span class="caption">pickup point</span></div>
+              </div>
+              <div class="kv__k">Carrier</div>
+              <div class="kv__v"><span class="muted">Not resolved yet</span></div>
+            </div>
+            <div class="pickup">
+              <svg class="locker-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
+              <div>
+                <div class="pickup__code mono">POP-WAW-04412</div>
+                <div class="caption">buyer-selected via Allegro</div>
+              </div>
+            </div>
+          </div>
+          <div class="card__foot" style="flex-direction:column; align-items:stretch; gap:var(--space-2)">
+            <div style="display:flex; align-items:center; justify-content:space-between; gap:var(--space-2)">
+              <span class="caption">No shipment yet — generate a label to dispatch.</span>
+              <button class="btn btn--primary btn--sm" disabled>Generate label</button>
+            </div>
+            <div class="dispatch-gate">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v4m0 4h.01M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z"/></svg>
+              Resolve the sync failure above before dispatching.
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <!-- ░░░░░░░░░░░░░░░░░░░ (3) ACTIVITY — real audit trail (actor + timestamp per event) ░░░░░░░░░░░░░░░░░░░ -->
+  <section style="margin-top: var(--space-5)">
+    <h2 class="section-title">Activity</h2>
+    <div class="card"><div class="card__body">
+      <ol class="timeline">
+        <li class="tl">
+          <span class="tl__dot tl__dot--info"></span>
+          <div class="tl__body">
+            <div class="tl__head"><b>Order received</b><span class="tl__by">system · Allegro poll</span></div>
+            <div class="tl__detail">Ingested from Allegro sandbox · ready for sync.</div>
+          </div>
+          <time class="tl__time mono tabular">31 May 16:00</time>
+        </li>
+        <li class="tl">
+          <span class="tl__dot tl__dot--error"></span>
+          <div class="tl__body">
+            <div class="tl__head"><b>Sync to PrestaShop failed</b><span class="tl__by">system · attempt 1</span></div>
+            <div class="tl__detail mono">PrestaShop API 400 · couldn’t pin price for product #25 (no base price).</div>
+          </div>
+          <time class="tl__time mono tabular">31 May 16:00</time>
+        </li>
+        <li class="tl">
+          <span class="tl__dot tl__dot--neutral"></span>
+          <div class="tl__body">
+            <div class="tl__head"><b>Retry requested</b><span class="tl__by">admin@openlinker</span></div>
+            <div class="tl__detail">Manual retry from order detail · re-queued sync job.</div>
+          </div>
+          <time class="tl__time mono tabular">31 May 16:05</time>
+        </li>
+        <li class="tl">
+          <span class="tl__dot tl__dot--error"></span>
+          <div class="tl__body">
+            <div class="tl__head"><b>Sync to PrestaShop failed</b><span class="tl__by">system · attempt 2</span></div>
+            <div class="tl__detail mono">Same price-pin error — product #25 still unpriced.</div>
+          </div>
+          <time class="tl__time mono tabular">31 May 16:05</time>
+        </li>
+        <li class="tl">
+          <span class="tl__dot tl__dot--info"></span>
+          <div class="tl__body">
+            <div class="tl__head"><b>Reconciled with source &amp; destination</b><span class="tl__by">system · poll backstop</span></div>
+            <div class="tl__detail">No drift — Allegro order still active, no PrestaShop order exists yet.</div>
+          </div>
+          <time class="tl__time mono tabular">31 May 16:07</time>
+        </li>
+      </ol>
+      <div class="caption" style="margin-top:var(--space-3)">Showing 5 of 5 events · attempts capped at 20 per destination.</div>
+    </div></div>
+  </section>
+
+  <!-- ░░░░░░░░░░░░░░░░░░░ (3b) Shipping panel — POST-DISPATCH state ░░░░░░░░░░░░░░░░░░░ -->
+  <div class="state-label">Shipping panel · post-dispatch state (after a successful sync + label)</div>
+  <div class="grid grid--detail">
+    <div></div>
+    <div class="stack">
+      <div class="card">
+        <div class="card__head">
+          <h2>Delivery</h2>
+          <span class="badge badge--success"><span class="badge__dot"></span>Dispatched</span>
+        </div>
+        <div class="card__body">
+          <div class="kv">
+            <div class="kv__k">Ship to</div>
+            <div class="kv__v">
+              <div class="addr">
+                Jan Kowalski<br>
+                ul. Przykładowa 12 / 4<br>
+                00-001 Warszawa · <span class="flag">🇵🇱</span> PL
+              </div>
+            </div>
+            <div class="kv__k">Method</div>
+            <div class="kv__v"><div class="meta-row"><strong>InPost Paczkomat</strong></div></div>
+            <div class="kv__k">Carrier</div>
+            <div class="kv__v">InPost</div>
+            <div class="kv__k">Tracking</div>
+            <div class="kv__v">
+              <a class="track mono" href="#">6200&nbsp;0000&nbsp;8841 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M7 17 17 7M7 7h10v10"/></svg></a>
+              <button class="copybtn">⧉</button>
+            </div>
+          </div>
+          <div class="pickup">
+            <svg class="locker-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
+            <div>
+              <div class="pickup__code mono">POP-WAW-04412</div>
+              <div class="caption">buyer-selected via Allegro · BP fuel station</div>
+            </div>
+          </div>
+        </div>
+        <div class="card__foot">
+          <span class="caption">Label generated <span class="mono tabular">31 May 16:42</span> · 2h ago</span>
+          <span style="display:flex; gap:var(--space-2)">
+            <button class="btn btn--ghost btn--sm">Reprint</button>
+            <button class="btn btn--secondary btn--sm">Download label</button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## What & why

Rebuilds `/orders/:id` from an "engineer's ingestion record" into an operator cockpit, matching the approved standalone mockup (`docs/plans/order-detail-redesign-mockup.html`, copied into the worktree). **Display-only**: every value comes from data already on the `OrderRecord` / parsed `orderSnapshot` / shipments query — **no new backend fields** (those remain epics #925–#928).

## Changes

- **Derived order health** — header verdict badge (`Needs attention` / `In progress` / `Synced`) + a 3-cell strip (Sync / Fulfillment / Total), all derived in a pure, unit-tested `features/orders/lib/order-health.ts`. The page stays composition-only.
- **Header** — title + health + lifecycle badges, internal-id copy chip, role-labelled `source → destination` route, received timestamp (absolute + relative), and a one-line order-contents summary with a clickable product link → OpenLinker product.
- **Failure banner** — plain-language, per-destination raw error + a **scoped Retry** (reuses the existing retry mutation) + a `view raw` anchor. Single retry source of truth (sync-status rows are status-only).
- **Pricing & tax panel** — surfaces `totals.taxTreatment` (already persisted per #895 / ADR-014) by extending the FE zod schema; wording is **treatment-aware** (`inclusive → gross`, `exclusive → net`), composed from the existing line-items + totals panels.
- **Delivery panel** — snapshot-driven ship-to / method / pickup; the pickup caption keys on the **source** platform's `pickupPointResolvesAsync` trait (#893), with `usePlatform` called unconditionally.
- **Activity timeline** — restyled with an actor eyebrow + a caption derived from the real event count.
- Vanilla CSS on existing #775 tokens (**zero new tokens** — drift check confirms); mobile-first breakpoints (768 / 1024).

### Honest degradations (hidden, not faked — per the issue's "degrade gracefully" note)
External marketplace listing link · reconciliation timestamp + re-check · synthesized failure-remedy prose · human audit-trail actor. Each is absent from the DTO, so the line is omitted rather than fabricated.

## How to test

- `pnpm --filter @openlinker/web test` — unit + component + page tests (lib derivations, schema `taxTreatment`, pricing net/gross, delivery render + null-render, health sync cell, activity caption, retry flow).
- Visit `/orders/:id` against a synced order, a failed-sync order, and a pre-/post-dispatch order; toggle light/dark.

## Quality gate

`pnpm lint` · `pnpm type-check` · `pnpm test` all green (1316 unit tests; apps/web 164 files). Two `/tech-review` passes folded in (derivations→`lib/`, source-platform pickup caption, treatment-aware tax wording, mobile-first breakpoints, query-degradation; then a pricing-note flex fix, orphaned-CSS cleanup, fulfillment loading state, added delivery/caption tests).

## Screenshots

⚠️ Per the style guide, after-shots at 360×812 / 768×1024 / 1440×900 should be attached — these need capturing against a running dev server (can't be produced headlessly in this change).

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)