### PR TITLE
feat(orders,web): triage-queue redesign of the /orders list (#929)

### DIFF
--- a/apps/api/src/orders/http/dto/list-orders-query.dto.ts
+++ b/apps/api/src/orders/http/dto/list-orders-query.dto.ts
@@ -17,8 +17,12 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { OrderSyncStatusFilterValues, OrderRecordStatusValues } from '@openlinker/core/orders';
-import { OrderSyncStatusFilter, OrderRecordStatus } from '@openlinker/core/orders';
+import {
+  OrderSyncStatusFilterValues,
+  OrderRecordStatusValues,
+  OrderHealthValues,
+} from '@openlinker/core/orders';
+import { OrderSyncStatusFilter, OrderRecordStatus, OrderHealth } from '@openlinker/core/orders';
 
 export class ListOrdersQueryDto {
   @ApiPropertyOptional({ description: 'Filter by source connection ID (UUID)' })
@@ -65,6 +69,15 @@ export class ListOrdersQueryDto {
   @IsOptional()
   @IsEnum(OrderRecordStatusValues)
   recordStatus?: OrderRecordStatus;
+
+  @ApiPropertyOptional({
+    enum: OrderHealthValues,
+    description:
+      'Filter by derived health bucket (#929) — partitions the set: awaiting_mapping | needs_attention | synced | awaiting_dispatch',
+  })
+  @IsOptional()
+  @IsEnum(OrderHealthValues)
+  health?: OrderHealth;
 
   @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
   @IsOptional()

--- a/apps/api/src/orders/http/dto/order-health-summary-query.dto.ts
+++ b/apps/api/src/orders/http/dto/order-health-summary-query.dto.ts
@@ -1,0 +1,35 @@
+/**
+ * Order Health Summary Query DTO
+ *
+ * Query parameters for GET /orders/status-summary (#929). Deliberately a
+ * narrow scope subset — source / customer / date only. It intentionally omits
+ * `health`, `syncStatus`, and pagination so the aggregate can't be
+ * self-filtered into a contradiction (counting all buckets while scoped to
+ * one). Mirrors `OrderHealthSummaryFilters` in `@openlinker/core/orders`.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { IsOptional, IsUUID, IsString, IsDateString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class OrderHealthSummaryQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by source connection ID (UUID)' })
+  @IsOptional()
+  @IsUUID()
+  sourceConnectionId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by internal customer ID' })
+  @IsOptional()
+  @IsString()
+  customerId?: string;
+
+  @ApiPropertyOptional({ description: 'Count orders created on or after this date (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  createdFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Count orders created on or before this date (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  createdTo?: string;
+}

--- a/apps/api/src/orders/http/dto/order-health-summary-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-health-summary-response.dto.ts
@@ -1,0 +1,28 @@
+/**
+ * Order Health Summary Response DTO
+ *
+ * Response shape for GET /orders/status-summary (#929). Carries the count of
+ * order records per derived-health bucket for the current filter scope. The
+ * four buckets partition the set, so `total` equals their sum — the list-page
+ * status segments rely on this to render counts that add up.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OrderHealthSummaryResponseDto {
+  @ApiProperty({ description: 'Total order records in scope (sum of the four buckets)' })
+  total!: number;
+
+  @ApiProperty({ description: 'recordStatus = awaiting_mapping (item refs unresolved)' })
+  awaitingMapping!: number;
+
+  @ApiProperty({ description: 'ready AND at least one destination failed' })
+  needsAttention!: number;
+
+  @ApiProperty({ description: 'ready, no failed, at least one destination synced' })
+  synced!: number;
+
+  @ApiProperty({ description: 'ready, no failed, no synced (empty / pending / syncing)' })
+  awaitingDispatch!: number;
+}

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -52,6 +52,7 @@ describe('OrdersController', () => {
       upsert: jest.fn(),
       updateSyncStatus: jest.fn(),
       findMany: jest.fn(),
+      countByHealth: jest.fn(),
     };
 
     const mockRetryService: jest.Mocked<IOrderDestinationRetryService> = {
@@ -207,6 +208,57 @@ describe('OrdersController', () => {
       const result = await controller.listOrders({ limit: 20, offset: 0 });
 
       expect(result.items[0].syncAttempts).toEqual([]);
+    });
+
+    it('should pass the health filter through to the repository (#929)', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.listOrders({ health: 'needs_attention', limit: 20, offset: 0 });
+
+      expect(repository.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ health: 'needs_attention' }),
+        { limit: 20, offset: 0 }
+      );
+    });
+  });
+
+  describe('statusSummary', () => {
+    it('should return per-health-bucket counts from the repository (#929)', async () => {
+      repository.countByHealth.mockResolvedValue({
+        total: 11,
+        awaitingMapping: 0,
+        needsAttention: 1,
+        synced: 1,
+        awaitingDispatch: 9,
+      });
+
+      const result = await controller.statusSummary({});
+
+      expect(result.total).toBe(11);
+      expect(result.needsAttention).toBe(1);
+      expect(result.awaitingDispatch).toBe(9);
+    });
+
+    it('should forward only the scope subset (source/date) to the repository (#929)', async () => {
+      repository.countByHealth.mockResolvedValue({
+        total: 0,
+        awaitingMapping: 0,
+        needsAttention: 0,
+        synced: 0,
+        awaitingDispatch: 0,
+      });
+
+      await controller.statusSummary({
+        sourceConnectionId: 'conn-001',
+        createdFrom: '2026-01-01T00:00:00Z',
+      });
+
+      expect(repository.countByHealth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceConnectionId: 'conn-001',
+          createdFrom: new Date('2026-01-01T00:00:00Z'),
+        })
+      );
     });
   });
 

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -34,6 +34,8 @@ import {
 } from '@openlinker/core/orders';
 import type { OrderRecord, OrderSyncStatus, SyncAttempt } from '@openlinker/core/orders';
 import { ListOrdersQueryDto } from './dto/list-orders-query.dto';
+import { OrderHealthSummaryQueryDto } from './dto/order-health-summary-query.dto';
+import { OrderHealthSummaryResponseDto } from './dto/order-health-summary-response.dto';
 import { OrderRecordResponseDto } from './dto/order-record-response.dto';
 import type { OrderSyncStatusResponseDto } from './dto/order-sync-status-response.dto';
 import type { SyncAttemptResponseDto } from './dto/sync-attempt-response.dto';
@@ -73,6 +75,7 @@ export class OrdersController {
       createdFrom,
       createdTo,
       recordStatus,
+      health,
       limit = 20,
       offset = 0,
     } = query;
@@ -85,6 +88,7 @@ export class OrdersController {
         createdFrom: createdFrom ? new Date(createdFrom) : undefined,
         createdTo: createdTo ? new Date(createdTo) : undefined,
         recordStatus,
+        health,
       },
       { limit, offset }
     );
@@ -95,6 +99,31 @@ export class OrdersController {
       limit,
       offset,
     };
+  }
+
+  @Get('status-summary')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Order health summary counts',
+    description:
+      'Returns the count of order records per derived-health bucket (awaiting_mapping | needs_attention | synced | awaiting_dispatch) for the given source/customer/date scope. The four buckets partition the set, so `total` equals their sum — backs the list-page status segments.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Per-health-bucket counts',
+    type: OrderHealthSummaryResponseDto,
+  })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async statusSummary(
+    @Query() query: OrderHealthSummaryQueryDto
+  ): Promise<OrderHealthSummaryResponseDto> {
+    const { sourceConnectionId, customerId, createdFrom, createdTo } = query;
+    return this.orderRecordRepository.countByHealth({
+      sourceConnectionId,
+      customerId,
+      createdFrom: createdFrom ? new Date(createdFrom) : undefined,
+      createdTo: createdTo ? new Date(createdTo) : undefined,
+    });
   }
 
   @Get(':internalOrderId')

--- a/apps/api/test/integration/order-health-summary.int-spec.ts
+++ b/apps/api/test/integration/order-health-summary.int-spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Order Health Summary Integration Test (#929)
+ *
+ * Exercises the real `OrderRecordRepository.countByHealth` and the `health`
+ * filter on `findMany` against Testcontainers Postgres — the only reliable
+ * cover for the JSONB `@>` containment + `CASE`/`FILTER` SQL that derives the
+ * health buckets. Asserts the canonical precedence (notably failed+synced →
+ * needs_attention and awaiting_mapping over a failed sync), the partition
+ * invariant (buckets sum to total), and the source-scope filter.
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+import { createTestOrderRecord } from './fixtures/order.fixtures';
+import {
+  ORDER_RECORD_REPOSITORY_TOKEN,
+  OrderRecordRepositoryPort,
+} from '@openlinker/core/orders';
+
+const SOURCE_A = '11111111-1111-4111-8111-111111111111';
+const SOURCE_B = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const DEST = '22222222-2222-4222-8222-222222222222';
+const DEST2 = '33333333-3333-4333-8333-333333333333';
+
+describe('Order health summary (integration)', () => {
+  let harness: IntegrationTestHarness;
+  let repository: OrderRecordRepositoryPort;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    repository = harness.getApp().get<OrderRecordRepositoryPort>(ORDER_RECORD_REPOSITORY_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  /** Seed the seven canonical SOURCE_A records covering every bucket + precedence. */
+  async function seedCanonicalSet(): Promise<void> {
+    const ds = harness.getDataSource();
+    // awaiting_mapping — wins even with a failed sync (precedence rule 1).
+    await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE_A,
+      recordStatus: 'awaiting_mapping',
+      syncStatus: [{ destinationConnectionId: DEST, status: 'failed', error: 'x' }],
+    });
+    // needs_attention — ready + failed (×2).
+    await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE_A,
+      recordStatus: 'ready',
+      syncStatus: [{ destinationConnectionId: DEST, status: 'failed', error: 'x' }],
+    });
+    await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE_A,
+      recordStatus: 'ready',
+      syncStatus: [{ destinationConnectionId: DEST, status: 'failed', error: 'x' }],
+    });
+    // needs_attention — failed wins over synced (precedence rule 2 over 3).
+    await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE_A,
+      recordStatus: 'ready',
+      syncStatus: [
+        { destinationConnectionId: DEST, status: 'synced' },
+        { destinationConnectionId: DEST2, status: 'failed', error: 'x' },
+      ],
+    });
+    // synced — ready, no failed, a destination synced.
+    await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE_A,
+      recordStatus: 'ready',
+      syncStatus: [{ destinationConnectionId: DEST, status: 'synced' }],
+    });
+    // awaiting_dispatch — empty syncStatus.
+    await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE_A,
+      recordStatus: 'ready',
+      syncStatus: [],
+    });
+    // awaiting_dispatch — only pending.
+    await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE_A,
+      recordStatus: 'ready',
+      syncStatus: [{ destinationConnectionId: DEST, status: 'pending' }],
+    });
+  }
+
+  it('partitions records into health buckets that sum to the total', async () => {
+    await seedCanonicalSet();
+
+    const summary = await repository.countByHealth({});
+
+    expect(summary.awaitingMapping).toBe(1);
+    expect(summary.needsAttention).toBe(3); // 2 failed + 1 failed-beats-synced
+    expect(summary.synced).toBe(1);
+    expect(summary.awaitingDispatch).toBe(2); // empty + pending
+    expect(summary.total).toBe(7);
+    expect(
+      summary.awaitingMapping +
+        summary.needsAttention +
+        summary.synced +
+        summary.awaitingDispatch,
+    ).toBe(summary.total);
+  });
+
+  it('scopes the counts to a single source connection', async () => {
+    await seedCanonicalSet(); // 7 under SOURCE_A
+    await createTestOrderRecord(harness.getDataSource(), {
+      sourceConnectionId: SOURCE_B,
+      recordStatus: 'ready',
+      syncStatus: [{ destinationConnectionId: DEST, status: 'failed', error: 'x' }],
+    });
+
+    const all = await repository.countByHealth({});
+    expect(all.total).toBe(8);
+    expect(all.needsAttention).toBe(4);
+
+    const scoped = await repository.countByHealth({ sourceConnectionId: SOURCE_A });
+    expect(scoped.total).toBe(7);
+    expect(scoped.needsAttention).toBe(3);
+  });
+
+  it('findMany filters to a single health bucket', async () => {
+    await seedCanonicalSet();
+
+    const needsAttention = await repository.findMany(
+      { health: 'needs_attention' },
+      { limit: 50, offset: 0 },
+    );
+    expect(needsAttention.total).toBe(3);
+
+    const awaitingDispatch = await repository.findMany(
+      { health: 'awaiting_dispatch' },
+      { limit: 50, offset: 0 },
+    );
+    expect(awaitingDispatch.total).toBe(2);
+
+    const awaitingMapping = await repository.findMany(
+      { health: 'awaiting_mapping' },
+      { limit: 50, offset: 0 },
+    );
+    expect(awaitingMapping.total).toBe(1);
+    expect(awaitingMapping.items[0].recordStatus).toBe('awaiting_mapping');
+  });
+});

--- a/apps/api/test/integration/order-health-summary.int-spec.ts
+++ b/apps/api/test/integration/order-health-summary.int-spec.ts
@@ -128,6 +128,35 @@ describe('Order health summary (integration)', () => {
     expect(scoped.needsAttention).toBe(3);
   });
 
+  it('treats an unknown recordStatus as the residual awaiting_dispatch bucket (structural partition)', async () => {
+    const ds = harness.getDataSource();
+    // A hypothetical future recordStatus the bucket SQL doesn't name. The
+    // residual `NOT awaiting_mapping` gating must still place it (and keep the
+    // partition summing to total) — guards against #929's catch-all regressing.
+    await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE_A,
+      recordStatus: 'archived',
+      syncStatus: [],
+    });
+    await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE_A,
+      recordStatus: 'archived',
+      syncStatus: [{ destinationConnectionId: DEST, status: 'failed', error: 'x' }],
+    });
+
+    const summary = await repository.countByHealth({});
+
+    expect(summary.total).toBe(2);
+    expect(summary.awaitingDispatch).toBe(1); // archived + empty → residual
+    expect(summary.needsAttention).toBe(1); // archived + failed → not-mapping AND failed
+    expect(
+      summary.awaitingMapping +
+        summary.needsAttention +
+        summary.synced +
+        summary.awaitingDispatch,
+    ).toBe(summary.total);
+  });
+
   it('findMany filters to a single health bucket', async () => {
     await seedCanonicalSet();
 

--- a/apps/web/src/features/orders/api/orders.api.ts
+++ b/apps/web/src/features/orders/api/orders.api.ts
@@ -12,10 +12,13 @@ import type {
   PaginatedOrders,
   OrderRecord,
   RetryOrderDestinationResult,
+  OrderHealthSummary,
+  OrderHealthSummaryFilters,
 } from './orders.types';
 
 export interface OrdersApi {
   list: (filters?: OrderFilters, pagination?: OrderPagination) => Promise<PaginatedOrders>;
+  statusSummary: (filters?: OrderHealthSummaryFilters) => Promise<OrderHealthSummary>;
   getById: (internalOrderId: string) => Promise<OrderRecord>;
   retryDestination: (
     internalOrderId: string,
@@ -35,8 +38,19 @@ function buildQuery(filters?: OrderFilters, pagination?: OrderPagination): strin
   if (filters?.createdFrom) params.set('createdFrom', filters.createdFrom);
   if (filters?.createdTo) params.set('createdTo', filters.createdTo);
   if (filters?.recordStatus) params.set('recordStatus', filters.recordStatus);
+  if (filters?.health) params.set('health', filters.health);
   if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
   if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : '';
+}
+
+function buildSummaryQuery(filters?: OrderHealthSummaryFilters): string {
+  const params = new URLSearchParams();
+  if (filters?.sourceConnectionId) params.set('sourceConnectionId', filters.sourceConnectionId);
+  if (filters?.customerId) params.set('customerId', filters.customerId);
+  if (filters?.createdFrom) params.set('createdFrom', filters.createdFrom);
+  if (filters?.createdTo) params.set('createdTo', filters.createdTo);
   const qs = params.toString();
   return qs.length > 0 ? `?${qs}` : '';
 }
@@ -45,6 +59,9 @@ export function createOrdersApi(request: ApiRequest): OrdersApi {
   return {
     list(filters, pagination): Promise<PaginatedOrders> {
       return request<PaginatedOrders>(`/orders${buildQuery(filters, pagination)}`);
+    },
+    statusSummary(filters): Promise<OrderHealthSummary> {
+      return request<OrderHealthSummary>(`/orders/status-summary${buildSummaryQuery(filters)}`);
     },
     getById(internalOrderId): Promise<OrderRecord> {
       return request<OrderRecord>(`/orders/${internalOrderId}`);

--- a/apps/web/src/features/orders/api/orders.query-keys.ts
+++ b/apps/web/src/features/orders/api/orders.query-keys.ts
@@ -1,8 +1,10 @@
-import type { OrderFilters, OrderPagination } from './orders.types';
+import type { OrderFilters, OrderPagination, OrderHealthSummaryFilters } from './orders.types';
 
 export const ordersQueryKeys = {
   all: ['orders'] as const,
   list: (filters?: OrderFilters, pagination?: OrderPagination) =>
     ['orders', 'list', filters ?? {}, pagination ?? {}] as const,
+  statusSummary: (filters?: OrderHealthSummaryFilters) =>
+    ['orders', 'status-summary', filters ?? {}] as const,
   detail: (internalOrderId: string) => ['orders', 'detail', internalOrderId] as const,
 };

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -61,6 +61,31 @@ export interface OrderRecord {
   updatedAt: string;
 }
 
+// Derived order-health buckets (#929). Hand-mirrored from `OrderHealthValues`
+// in `@openlinker/core/orders` per the FE-001 contract strategy — keep in sync.
+// Partition the order set: every record maps to exactly one bucket, so the KPI
+// segment counts sum to the total. Canonical precedence (highest wins) lives in
+// `deriveOrderHealth` (lib/order-health.ts), the single FE source of truth.
+export const OrderHealthValues = [
+  'awaiting_mapping',
+  'needs_attention',
+  'synced',
+  'awaiting_dispatch',
+] as const;
+export type OrderHealthValue = (typeof OrderHealthValues)[number];
+
+/**
+ * Per-health-bucket counts from `GET /orders/status-summary` (#929). Mirrors
+ * `OrderHealthSummaryResponseDto` (BE). `total` equals the sum of the buckets.
+ */
+export interface OrderHealthSummary {
+  total: number;
+  awaitingMapping: number;
+  needsAttention: number;
+  synced: number;
+  awaitingDispatch: number;
+}
+
 export interface OrderFilters {
   sourceConnectionId?: string;
   syncStatus?: OrderSyncStatusValue;
@@ -68,6 +93,20 @@ export interface OrderFilters {
   createdFrom?: string;
   createdTo?: string;
   recordStatus?: OrderRecordStatusValue;
+  /** Filter to a single derived health bucket (#929). */
+  health?: OrderHealthValue;
+}
+
+/**
+ * Scope filters for the health-summary count (#929) — source/customer/date
+ * subset only. Intentionally excludes `health` so the aggregate can't be
+ * self-filtered. Mirrors `OrderHealthSummaryQueryDto` (BE).
+ */
+export interface OrderHealthSummaryFilters {
+  sourceConnectionId?: string;
+  customerId?: string;
+  createdFrom?: string;
+  createdTo?: string;
 }
 
 export interface OrderPagination {

--- a/apps/web/src/features/orders/hooks/use-order-status-summary-query.ts
+++ b/apps/web/src/features/orders/hooks/use-order-status-summary-query.ts
@@ -18,6 +18,11 @@ export function useOrderStatusSummaryQuery(
 ): UseQueryResult<OrderHealthSummary> {
   const apiClient = useApiClient();
 
+  // No bespoke staleTime: the segment counts and the table are eventually
+  // consistent by design. The retry mutation invalidates the whole orders
+  // domain (`ordersQueryKeys.all`), so the counts and rows re-sync together on
+  // the mutation path; any transient drift between background refetches is
+  // cosmetic and acceptable for a triage summary.
   return useQuery({
     queryKey: ordersQueryKeys.statusSummary(filters),
     queryFn: () => apiClient.orders.statusSummary(filters),

--- a/apps/web/src/features/orders/hooks/use-order-status-summary-query.ts
+++ b/apps/web/src/features/orders/hooks/use-order-status-summary-query.ts
@@ -1,0 +1,25 @@
+/**
+ * Order Status Summary Query Hook
+ *
+ * Fetches the per-derived-health-bucket counts from GET /orders/status-summary
+ * (#929). Backs the orders-list status segments, whose counts partition the set
+ * and therefore sum to the total — replacing the prior four overlapping
+ * count-only list queries that left ingested/awaiting-mapping orders uncounted.
+ *
+ * @module apps/web/src/features/orders/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { ordersQueryKeys } from '../api/orders.query-keys';
+import type { OrderHealthSummary, OrderHealthSummaryFilters } from '../api/orders.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useOrderStatusSummaryQuery(
+  filters?: OrderHealthSummaryFilters,
+): UseQueryResult<OrderHealthSummary> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: ordersQueryKeys.statusSummary(filters),
+    queryFn: () => apiClient.orders.statusSummary(filters),
+  });
+}

--- a/apps/web/src/features/orders/hooks/use-retry-order-destination-mutation.ts
+++ b/apps/web/src/features/orders/hooks/use-retry-order-destination-mutation.ts
@@ -1,9 +1,10 @@
 /**
  * Retry Order Destination Mutation Hook
  *
- * Provides a mutation for retrying a failed destination sync from the order
- * detail page. Invalidates the order detail query on success so the row
- * reflects its new `pending` status without a manual refresh.
+ * Provides a mutation for retrying a failed destination sync. Invalidates the
+ * whole orders domain on success so both the detail view and the list (row
+ * badge + status-summary counts) reflect the new `pending` status without a
+ * manual refresh — the list page added an inline per-row Retry in #929.
  *
  * @module apps/web/src/features/orders/hooks
  */
@@ -28,8 +29,8 @@ export function useRetryOrderDestinationMutation(): UseMutationResult<
   return useMutation({
     mutationFn: ({ internalOrderId, destinationConnectionId }) =>
       apiClient.orders.retryDestination(internalOrderId, destinationConnectionId),
-    onSuccess: async (_, { internalOrderId }) => {
-      await queryClient.invalidateQueries({ queryKey: ordersQueryKeys.detail(internalOrderId) });
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ordersQueryKeys.all });
     },
   });
 }

--- a/apps/web/src/features/orders/lib/order-health.test.ts
+++ b/apps/web/src/features/orders/lib/order-health.test.ts
@@ -1,0 +1,97 @@
+/**
+ * deriveOrderHealth tests (#929)
+ *
+ * Asserts the canonical four-way precedence — the FE twin of the SQL `CASE` in
+ * `OrderRecordRepository`. The failed+synced → needs_attention case is the key
+ * precedence assertion shared with the backend integration test.
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveOrderHealth } from './order-health';
+import type { OrderRecord, OrderSyncStatus } from '../api/orders.types';
+
+function syncEntry(overrides: Partial<OrderSyncStatus>): OrderSyncStatus {
+  return {
+    destinationConnectionId: 'conn_ps_1',
+    status: 'pending',
+    syncedAt: null,
+    externalOrderId: null,
+    externalOrderNumber: null,
+    error: null,
+    ...overrides,
+  };
+}
+
+function order(overrides: Partial<OrderRecord>): OrderRecord {
+  return {
+    internalOrderId: 'ol_order_1',
+    customerId: null,
+    sourceConnectionId: 'conn_allegro_1',
+    sourceEventId: null,
+    orderSnapshot: {},
+    syncStatus: [],
+    syncAttempts: [],
+    recordStatus: 'ready',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('deriveOrderHealth', () => {
+  it('should return awaiting_mapping when recordStatus is awaiting_mapping (highest precedence)', () => {
+    const result = deriveOrderHealth(
+      order({ recordStatus: 'awaiting_mapping', syncStatus: [syncEntry({ status: 'failed' })] }),
+    );
+    expect(result.key).toBe('awaiting_mapping');
+    expect(result.tone).toBe('warning');
+  });
+
+  it('should return needs_attention with the failed reason when a destination failed', () => {
+    const result = deriveOrderHealth(
+      order({ syncStatus: [syncEntry({ status: 'failed', error: 'Carrier not mapped' })] }),
+    );
+    expect(result.key).toBe('needs_attention');
+    expect(result.tone).toBe('error');
+    expect(result.reason).toBe('Carrier not mapped');
+  });
+
+  it('should prefer needs_attention over synced when both a failed and a synced destination exist', () => {
+    const result = deriveOrderHealth(
+      order({
+        syncStatus: [
+          syncEntry({ destinationConnectionId: 'a', status: 'synced' }),
+          syncEntry({ destinationConnectionId: 'b', status: 'failed' }),
+        ],
+      }),
+    );
+    expect(result.key).toBe('needs_attention');
+  });
+
+  it('should return synced when ready, no failed, and a destination is synced', () => {
+    const result = deriveOrderHealth(order({ syncStatus: [syncEntry({ status: 'synced' })] }));
+    expect(result.key).toBe('synced');
+    expect(result.tone).toBe('success');
+  });
+
+  it('should return awaiting_dispatch for an empty syncStatus', () => {
+    const result = deriveOrderHealth(order({ syncStatus: [] }));
+    expect(result.key).toBe('awaiting_dispatch');
+    expect(result.tone).toBe('info');
+  });
+
+  it('should return awaiting_dispatch when destinations are only pending/syncing', () => {
+    const result = deriveOrderHealth(
+      order({
+        syncStatus: [
+          syncEntry({ destinationConnectionId: 'a', status: 'pending' }),
+          syncEntry({ destinationConnectionId: 'b', status: 'syncing' }),
+        ],
+      }),
+    );
+    expect(result.key).toBe('awaiting_dispatch');
+  });
+
+  it('should not set a reason for non-failed buckets', () => {
+    expect(deriveOrderHealth(order({ syncStatus: [syncEntry({ status: 'synced' })] })).reason).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/orders/lib/order-health.ts
+++ b/apps/web/src/features/orders/lib/order-health.ts
@@ -1,0 +1,63 @@
+/**
+ * Order Health View-Model
+ *
+ * Derives a single operator-facing health classification for an order row by
+ * reconciling `recordStatus` with the per-destination `syncStatus[]` (#929).
+ * Replaces the old per-destination badge list (and the blank "—" for orders
+ * with an empty `syncStatus[]`) with one reconciled `StatusBadge`.
+ *
+ * CANONICAL PRECEDENCE (highest wins) — this is the single FE source of truth
+ * and the twin of the SQL `CASE` in `OrderRecordRepository` (#929); keep both
+ * in lockstep:
+ *   1. awaiting_mapping  — recordStatus = 'awaiting_mapping' (can't sync yet)
+ *   2. needs_attention   — ready AND any destination failed
+ *   3. synced            — ready, no failed, AND any destination synced
+ *   4. awaiting_dispatch — everything else (ready, no failed, no synced)
+ *
+ * @module apps/web/src/features/orders/lib
+ */
+import type { OrderRecord, OrderHealthValue } from '../api/orders.types';
+import type { StatusBadgeTone } from '../../../shared/ui/status-badge';
+
+export interface OrderHealthView {
+  key: OrderHealthValue;
+  tone: StatusBadgeTone;
+  /** Row-badge label. */
+  label: string;
+  /** Plain-language cause, present only for `needs_attention`. */
+  reason?: string;
+}
+
+/** Static label + tone per bucket. Shared by the row badge and the KPI segments. */
+export const ORDER_HEALTH_META: Record<OrderHealthValue, { label: string; tone: StatusBadgeTone }> =
+  {
+    awaiting_mapping: { label: 'Awaiting mapping', tone: 'warning' },
+    needs_attention: { label: 'Sync failed', tone: 'error' },
+    synced: { label: 'Synced', tone: 'success' },
+    awaiting_dispatch: { label: 'Awaiting dispatch', tone: 'info' },
+  };
+
+/**
+ * Classify an order into exactly one health bucket. Pure function of the
+ * record's own already-loaded fields — no I/O.
+ */
+export function deriveOrderHealth(order: OrderRecord): OrderHealthView {
+  if (order.recordStatus === 'awaiting_mapping') {
+    return { key: 'awaiting_mapping', ...ORDER_HEALTH_META.awaiting_mapping };
+  }
+
+  const failed = order.syncStatus.find((s) => s.status === 'failed');
+  if (failed) {
+    return {
+      key: 'needs_attention',
+      ...ORDER_HEALTH_META.needs_attention,
+      reason: failed.error ?? undefined,
+    };
+  }
+
+  if (order.syncStatus.some((s) => s.status === 'synced')) {
+    return { key: 'synced', ...ORDER_HEALTH_META.synced };
+  }
+
+  return { key: 'awaiting_dispatch', ...ORDER_HEALTH_META.awaiting_dispatch };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7226,9 +7226,54 @@ a.kpi-card:focus-visible {
 .ds-grid--2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .ds-grid--3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 .ds-grid--4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.ds-grid--5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
 .ds-grid--6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
 @media (max-width: 960px) {
-  .ds-grid--3, .ds-grid--4, .ds-grid--6 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ds-grid--3, .ds-grid--4, .ds-grid--5, .ds-grid--6 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+/* ── Orders list redesign (#929) ───────────────────────────────────── */
+/* Status segments double as clickable health filters: a reset button wraps a
+   MetricCard; the active segment mirrors the chip-active accent treatment. */
+.orders-segments { margin-bottom: var(--space-4); }
+.orders-segment {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--radius-lg);
+}
+.orders-segment > .metric-card { height: 100%; }
+.orders-segment:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+.orders-segment--active .metric-card {
+  border-color: var(--accent-primary-border);
+  box-shadow: var(--shadow-focus);
+}
+
+/* Two-line table cells (customer / items / channel). */
+.orders-cell-stack { display: flex; flex-direction: column; gap: 2px; align-items: flex-start; }
+.orders-cell-sub { font-size: 0.75rem; }
+.orders-status-reason { font-size: 0.6875rem; color: var(--status-error-strong); }
+
+/* Ghost (capture-gap) columns — Ship-by (#927), Payment (#928): the layout
+   reserves their space so they drop in with zero rework once captured. */
+.orders-ghost {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-disabled);
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 1px 7px;
 }
 
 /* ── Surface card used for grouping demos ────────────────────────── */
@@ -7667,6 +7712,7 @@ html[data-density='compact'] .status-badge {
   .ds-grid--2,
   .ds-grid--3,
   .ds-grid--4,
+  .ds-grid--5,
   .ds-grid--6 {
     grid-template-columns: 1fr;
   }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7259,7 +7259,14 @@ a.kpi-card:focus-visible {
 /* Two-line table cells (customer / items / channel). */
 .orders-cell-stack { display: flex; flex-direction: column; gap: 2px; align-items: flex-start; }
 .orders-cell-sub { font-size: 0.75rem; }
-.orders-status-reason { font-size: 0.6875rem; color: var(--status-error-strong); }
+.orders-status-reason {
+  font-size: 0.6875rem;
+  color: var(--status-error-strong);
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* Ghost (capture-gap) columns — Ship-by (#927), Payment (#928): the layout
    reserves their space so they drop in with zero rework once captured. */

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -1,18 +1,23 @@
 /**
  * OrdersListPage tests
  *
- * Covers the cockpit redesign (#778): KPI strip wiring, filter-chip
- * behaviour, channel-pill resolution via `useConnectionsQuery`,
- * EntityLabel rendering on the Order column, pulse-on-syncing badge
- * state. Preserves the four canonical async states
- * (loading / error / empty / data) from the original page.
+ * Covers the triage-queue redesign (#929): status segments backed by the
+ * partitioning `/orders/status-summary` count endpoint, the `health` URL
+ * filter, the single reconciled health badge (`deriveOrderHealth`) replacing
+ * the per-destination list, customer + contents columns parsed from the
+ * snapshot, the all-clear empty state, and the inline per-row Retry. Preserves
+ * the canonical async states (loading / error / empty / data).
  */
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { OrdersListPage } from './orders-list-page';
-import type { PaginatedOrders, OrderRecord } from '../../features/orders/api/orders.types';
+import type {
+  PaginatedOrders,
+  OrderRecord,
+  OrderHealthSummary,
+} from '../../features/orders/api/orders.types';
 import type { Connection } from '../../features/connections';
 
 const sampleConnection: Connection = {
@@ -28,14 +33,23 @@ const sampleConnection: Connection = {
   updatedAt: '2026-01-01T00:00:00.000Z',
 };
 
-const sampleOrder: OrderRecord = {
-  internalOrderId: 'ol_order_abc123',
+const syncedOrder: OrderRecord = {
+  internalOrderId: 'ol_order_synced',
   customerId: 'ol_customer_xyz',
   sourceConnectionId: 'conn_allegro_1',
   sourceEventId: null,
   orderSnapshot: {
     orderNumber: 'ALG-882414',
+    items: [{ id: 'i1', quantity: 1, price: 84.2, name: 'Filtr kubełkowy AquaPro' }],
     totals: { subtotal: 80, tax: 4.2, shipping: 0, total: 84.2, currency: 'EUR' },
+    shippingAddress: {
+      firstName: 'Anna',
+      lastName: 'Kowalska',
+      address1: 'ul. Testowa 1',
+      city: 'Warszawa',
+      postalCode: '00-001',
+      country: 'PL',
+    },
   },
   syncStatus: [
     {
@@ -53,11 +67,32 @@ const sampleOrder: OrderRecord = {
   updatedAt: '2026-01-15T10:00:00.000Z',
 };
 
-const sampleOrders: PaginatedOrders = {
-  items: [sampleOrder],
-  total: 1,
-  limit: 20,
-  offset: 0,
+const failedOrder: OrderRecord = {
+  ...syncedOrder,
+  internalOrderId: 'ol_order_failed',
+  orderSnapshot: { ...syncedOrder.orderSnapshot, orderNumber: 'ALG-FAIL' },
+  syncStatus: [
+    {
+      destinationConnectionId: 'conn_ps_1',
+      status: 'failed',
+      syncedAt: null,
+      externalOrderId: null,
+      externalOrderNumber: null,
+      error: 'Carrier not mapped in OMP',
+    },
+  ],
+};
+
+function paginated(items: OrderRecord[]): PaginatedOrders {
+  return { items, total: items.length, limit: 20, offset: 0 };
+}
+
+const emptySummary: OrderHealthSummary = {
+  total: 0,
+  awaitingMapping: 0,
+  needsAttention: 0,
+  synced: 0,
+  awaitingDispatch: 0,
 };
 
 describe('OrdersListPage', () => {
@@ -84,179 +119,215 @@ describe('OrdersListPage', () => {
     expect(screen.getByText('Network error')).toBeInTheDocument();
   });
 
-  it('should show empty state with a Manage connections CTA when no orders exist and no filters are active', async () => {
+  it('should show empty state with a Manage connections CTA when no orders exist and no filter is active', async () => {
     const mockApi = createMockApiClient({
-      orders: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
+      orders: { list: vi.fn().mockResolvedValue(paginated([])) },
     });
 
     renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
 
     expect(await screen.findByText('No orders found')).toBeInTheDocument();
-    const cta = screen.getByRole('link', { name: 'Manage connections' });
-    expect(cta).toHaveAttribute('href', '/connections');
+    expect(screen.getByRole('link', { name: 'Manage connections' })).toHaveAttribute(
+      'href',
+      '/connections',
+    );
   });
 
-  it('should show a Clear filters button that clears syncStatus from the URL when a filter is active', async () => {
-    const user = userEvent.setup();
+  it('should show the all-clear empty state when the needs-attention filter is empty', async () => {
     const mockApi = createMockApiClient({
-      orders: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
+      orders: { list: vi.fn().mockResolvedValue(paginated([])) },
     });
 
     renderWithProviders(<OrdersListPage />, {
       apiClient: mockApi,
-      route: '/orders?syncStatus=failed',
+      route: '/orders?health=needs_attention',
     });
 
-    expect(await screen.findByText('No orders match the current filters.')).toBeInTheDocument();
-    // Two "Clear filters" affordances now exist: the chip-row button
-    // and the empty-state CTA. Either path clears the URL filter; pick
-    // the empty-state CTA (last) so the test mirrors the operator flow
-    // when the filter strips the result set.
-    const clearButtons = screen.getAllByRole('button', { name: 'Clear filters' });
-    await user.click(clearButtons[clearButtons.length - 1]);
-
-    expect(await screen.findByRole('link', { name: 'Manage connections' })).toBeInTheDocument();
+    expect(
+      await screen.findByText('All clear — nothing needs your attention'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'View all orders' })).toBeInTheDocument();
   });
 
-  it('should render the KPI strip with four status counts wired to the orders query (#778)', async () => {
-    // Each MetricCard reads `.total` from its own filtered useOrdersQuery
-    // call (limit:1). Mocking `orders.list` so the count varies by filter
-    // arg exercises the four wires independently.
-    const list = vi.fn().mockImplementation(async (filters?: { syncStatus?: string }) => {
-      if (filters?.syncStatus === 'synced') return { items: [], total: 7, limit: 1, offset: 0 };
-      if (filters?.syncStatus === 'pending') return { items: [], total: 3, limit: 1, offset: 0 };
-      if (filters?.syncStatus === 'failed') return { items: [], total: 1, limit: 1, offset: 0 };
-      return sampleOrders;
-    });
-    const mockApi = createMockApiClient({ orders: { list } });
-
-    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
-
-    // Labels are rendered by MetricCard.
-    expect(await screen.findByText('All orders')).toBeInTheDocument();
-    expect(screen.getByText('Synced')).toBeInTheDocument();
-    expect(screen.getByText('Pending')).toBeInTheDocument();
-    expect(screen.getByText('Failed')).toBeInTheDocument();
-
-    // Values flow through once each query resolves. Scope to the
-    // MetricCard value slot — bare digit text would collide with the
-    // paginator's "Showing 1–1 of 1" line.
-    await screen.findByText('All orders');
-    const values = Array.from(container.querySelectorAll('.metric-card__value')).map(
-      (el) => el.textContent,
-    );
-    expect(values).toContain('7'); // Synced
-    expect(values).toContain('3'); // Pending
-    expect(values).toContain('1'); // Failed
-  });
-
-  it('should render a channel-pill resolved from the connection platformType (#778)', async () => {
+  it('should render status segments with counts from the summary endpoint (#929)', async () => {
+    const statusSummary = vi.fn().mockResolvedValue({
+      total: 11,
+      needsAttention: 1,
+      awaitingMapping: 0,
+      awaitingDispatch: 9,
+      synced: 1,
+    } satisfies OrderHealthSummary);
     const mockApi = createMockApiClient({
-      orders: { list: vi.fn().mockResolvedValue(sampleOrders) },
+      orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])), statusSummary },
       connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
     });
 
     const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
 
-    // Wait for the data row to mount.
-    await screen.findByText('ALG-882414');
+    expect(await screen.findByText('All orders')).toBeInTheDocument();
+    expect(screen.getByText('Needs attention')).toBeInTheDocument();
+    expect(screen.getByText('Awaiting mapping')).toBeInTheDocument();
+    expect(screen.getByText('Awaiting dispatch')).toBeInTheDocument();
 
+    await vi.waitFor(() => {
+      const values = Array.from(container.querySelectorAll('.metric-card__value')).map(
+        (el) => el.textContent,
+      );
+      expect(values).toContain('11'); // total
+      expect(values).toContain('9'); // awaiting dispatch
+    });
+  });
+
+  it('should filter the list by health when a status segment is clicked (#929)', async () => {
+    const user = userEvent.setup();
+    const list = vi.fn().mockResolvedValue(paginated([syncedOrder]));
+    const mockApi = createMockApiClient({
+      orders: { list },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    await user.click(screen.getByRole('button', { name: /Needs attention/ }));
+
+    await vi.waitFor(() => {
+      const calledWithHealth = list.mock.calls.some(
+        ([filters]) => (filters as { health?: string } | undefined)?.health === 'needs_attention',
+      );
+      expect(calledWithHealth).toBe(true);
+    });
+  });
+
+  it('should render one reconciled health badge with a plain-language reason for a failed order (#929)', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([failedOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-FAIL');
+    const row = container.querySelector('.data-table__row');
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText('Sync failed')).toBeInTheDocument();
+    expect(within(row as HTMLElement).getByText('Carrier not mapped in OMP')).toBeInTheDocument();
+  });
+
+  it('should render Awaiting dispatch for an order with an empty syncStatus (#929)', async () => {
+    const dispatchOrder: OrderRecord = {
+      ...syncedOrder,
+      internalOrderId: 'ol_order_dispatch',
+      orderSnapshot: { ...syncedOrder.orderSnapshot, orderNumber: 'ALG-DISPATCH' },
+      syncStatus: [],
+    };
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([dispatchOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-DISPATCH');
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+    expect(within(row).getByText('Awaiting dispatch')).toBeInTheDocument();
+  });
+
+  it('should render customer and item-count columns parsed from the snapshot (#929)', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+    expect(within(row).getByText('Anna Kowalska')).toBeInTheDocument();
+    expect(within(row).getByText('Warszawa')).toBeInTheDocument();
+    expect(within(row).getByText('1 item')).toBeInTheDocument();
+  });
+
+  it('should render a channel-pill resolved from the connection platformType', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
     const pill = container.querySelector('.channel-pill[data-channel="allegro"]');
-    expect(pill).not.toBeNull();
     expect(pill?.textContent).toBe('Allegro');
   });
 
-  it('should render the EntityLabel name from the parsed orderNumber, falling back to the internalOrderId when absent (#778)', async () => {
+  it('should fall back to the internalOrderId when the snapshot has no orderNumber', async () => {
     const orderWithoutNumber: OrderRecord = {
-      ...sampleOrder,
+      ...syncedOrder,
       internalOrderId: 'ol_order_no_number',
-      orderSnapshot: {}, // No orderNumber.
+      orderSnapshot: {},
     };
     const mockApi = createMockApiClient({
-      orders: {
-        list: vi.fn().mockResolvedValue({
-          items: [sampleOrder, orderWithoutNumber],
-          total: 2,
-          limit: 20,
-          offset: 0,
-        }),
-      },
+      orders: { list: vi.fn().mockResolvedValue(paginated([orderWithoutNumber])) },
       connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
     });
 
     renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
 
-    // Parsed orderNumber wins as the human-facing label.
-    expect(await screen.findByText('ALG-882414')).toBeInTheDocument();
-    // Fallback: when no orderNumber, the EntityLabel renders the
-    // internalOrderId.
     expect(await screen.findByText('ol_order_no_number')).toBeInTheDocument();
   });
 
-  it('should render a temporal "Synced HH:MM" eyebrow derived from the freshest updatedAt (#778)', async () => {
+  it('should call retryDestination with the failed destination when the row Retry is clicked (#929)', async () => {
+    const user = userEvent.setup();
+    const retryDestination = vi.fn().mockResolvedValue({
+      internalOrderId: 'ol_order_failed',
+      destinationConnectionId: 'conn_ps_1',
+      jobId: 'job_1',
+      jobType: 'marketplace.order.sync',
+    });
     const mockApi = createMockApiClient({
-      orders: { list: vi.fn().mockResolvedValue(sampleOrders) },
+      orders: { list: vi.fn().mockResolvedValue(paginated([failedOrder])), retryDestination },
       connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
     });
 
     renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
 
-    // Eyebrow is locale-formatted (HH:MM) — assert the "Synced …" prefix
-    // and the digits without pinning the exact time zone the test runner
-    // happens to be in.
-    const eyebrow = await screen.findByText(/^Synced \d{1,2}:\d{2}/);
-    expect(eyebrow).toBeInTheDocument();
+    await screen.findByText('ALG-FAIL');
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await vi.waitFor(() => {
+      expect(retryDestination).toHaveBeenCalledWith('ol_order_failed', 'conn_ps_1');
+    });
   });
 
-  it('should refetch all queries when the R keyboard shortcut fires (#778)', async () => {
-    const user = userEvent.setup();
-    const list = vi.fn().mockResolvedValue(sampleOrders);
-    const mockApi = createMockApiClient({ orders: { list } });
+  it('should render a temporal "Synced HH:MM" eyebrow derived from the freshest updatedAt', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
 
     renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
 
-    // Wait for the page to settle — main + 4 KPI queries each fire once.
-    await screen.findByText('ALG-882414');
-    const baselineCalls = list.mock.calls.length;
+    expect(await screen.findByText(/^Synced \d{1,2}:\d{2}/)).toBeInTheDocument();
+  });
 
-    // Press R outside any focused input.
+  it('should refetch the list and summary when the R shortcut fires', async () => {
+    const user = userEvent.setup();
+    const list = vi.fn().mockResolvedValue(paginated([syncedOrder]));
+    const statusSummary = vi.fn().mockResolvedValue(emptySummary);
+    const mockApi = createMockApiClient({ orders: { list, statusSummary } });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    const listBaseline = list.mock.calls.length;
+    const summaryBaseline = statusSummary.mock.calls.length;
+
     await user.keyboard('r');
 
-    // R should refetch the main query at minimum. The KPI queries also
-    // refetch via the same handler — assert the main one strictly and
-    // the total grows by at least 1.
     await vi.waitFor(() => {
-      expect(list.mock.calls.length).toBeGreaterThan(baselineCalls);
+      expect(list.mock.calls.length).toBeGreaterThan(listBaseline);
+      expect(statusSummary.mock.calls.length).toBeGreaterThan(summaryBaseline);
     });
-  });
-
-  it('should add the pulse class to the StatusBadge when a destination is syncing (#778)', async () => {
-    const orderSyncing: OrderRecord = {
-      ...sampleOrder,
-      syncStatus: [
-        {
-          destinationConnectionId: 'conn_ps_1',
-          status: 'syncing',
-          syncedAt: null,
-          externalOrderId: null,
-          externalOrderNumber: null,
-          error: null,
-        },
-      ],
-    };
-    const mockApi = createMockApiClient({
-      orders: { list: vi.fn().mockResolvedValue({ items: [orderSyncing], total: 1, limit: 20, offset: 0 }) },
-      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
-    });
-
-    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
-
-    await screen.findByText('syncing');
-
-    // StatusBadge applies `status-badge--pulse` when pulse=true. Pinning the
-    // exact class (vs `[class*="pulse"]`) keeps the assertion contracted to
-    // the StatusBadge primitive's actual API.
-    const pulsed = container.querySelector('.status-badge--pulse');
-    expect(pulsed).not.toBeNull();
   });
 });

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -249,7 +249,9 @@ export function OrdersListPage(): ReactElement {
                 {h.label}
               </StatusBadge>
               {h.reason ? (
-                <span className="orders-status-reason">{h.reason}</span>
+                <span className="orders-status-reason" title={h.reason}>
+                  {h.reason}
+                </span>
               ) : null}
             </span>
           );

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -1,16 +1,21 @@
 /**
  * Orders List Page
  *
- * Cockpit-style operator surface for the orders backbone (#778). Composes:
- * — KPI strip (4 MetricCards backed by cheap count-only `useOrdersQuery`
- *   calls; cached per filter via TanStack query keys),
- * — chip-based status filter (`Chip` + `DropdownMenu`, URL-state),
- * — dense `DataTable` with `EntityLabel` identity, channel-pill (resolved
- *   via `useConnectionsQuery`), pulse-on-syncing `StatusBadge`, and
- *   mono+tabular totals formatted through the i18n seam (#612).
+ * Operator triage queue for the orders backbone (#778, redesigned #929).
+ * Composes:
+ * — status segments (5 clickable `MetricCard`s backed by the single
+ *   `/orders/status-summary` count endpoint) that **partition** the order set,
+ *   so the counts sum to the total and double as the `health` URL-state filter;
+ * — a dense `DataTable` whose rows lead with human identity (`EntityLabel`),
+ *   surface customer + contents (parsed from `orderSnapshot`), the source→
+ *   destination channel, one reconciled health `StatusBadge` (`deriveOrderHealth`,
+ *   replacing the per-destination list and the blank "—"), an honest "Created"
+ *   time, ghost Ship-by / Payment columns (capture-gap epic #925), and an inline
+ *   Retry for failed rows;
+ * — loading / error / empty (incl. all-clear) states via shared feedback prims.
  *
- * Pure presentation — all data flows through feature query hooks; no
- * transport logic at this layer.
+ * Pure presentation — all data flows through feature query hooks; no transport
+ * logic at this layer.
  *
  * @module pages/orders
  */
@@ -22,44 +27,28 @@ import { useTableSort } from '../../shared/ui/use-table-sort';
 import { ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { DataTableSkeleton } from '../../shared/ui/data-table-skeleton';
 import { Button } from '../../shared/ui/button';
-import { Chip } from '../../shared/ui/chip';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '../../shared/ui/dropdown-menu';
 import { TimeDisplay } from '../../shared/ui/time-display';
-import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
-import { MetricCard } from '../../shared/ui/metric-card';
+import { StatusBadge } from '../../shared/ui/status-badge';
+import { MetricCard, type MetricCardTone } from '../../shared/ui/metric-card';
 import { EntityLabel } from '../../shared/ui/entity-label';
+import { useToast } from '../../shared/ui/toast-provider';
 import { useTranslation, getBcp47Locale } from '../../shared/i18n';
 import type { LocaleCode } from '../../shared/i18n';
 import { useOrdersQuery } from '../../features/orders/hooks/use-orders-query';
+import { useOrderStatusSummaryQuery } from '../../features/orders/hooks/use-order-status-summary-query';
+import { useRetryOrderDestinationMutation } from '../../features/orders/hooks/use-retry-order-destination-mutation';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
+import { deriveOrderHealth } from '../../features/orders/lib/order-health';
 import type {
   OrderRecord,
   OrderFilters,
-  OrderSyncStatusValue,
+  OrderHealthValue,
+  OrderHealthSummary,
 } from '../../features/orders/api/orders.types';
-import { OrderSyncStatusValues } from '../../features/orders/api/orders.types';
+import { OrderHealthValues } from '../../features/orders/api/orders.types';
 import { useConnectionsQuery } from '../../features/connections';
 
 const PAGE_SIZE = 20;
-
-const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
-  pending: 'info',
-  syncing: 'warning',
-  synced: 'success',
-  failed: 'error',
-};
-
-const STATUS_FILTER_LABELS: Record<OrderSyncStatusValue, string> = {
-  pending: 'Pending',
-  syncing: 'Syncing',
-  synced: 'Synced',
-  failed: 'Failed',
-};
 
 const CHANNEL_LABELS: Record<string, string> = {
   allegro: 'Allegro',
@@ -69,19 +58,35 @@ const CHANNEL_LABELS: Record<string, string> = {
 };
 
 /**
- * Type-guard for the syncStatus URL param. `OrderSyncStatusValues.includes`
- * widens the haystack to `readonly string[]` so the predicate accepts any
- * string and narrows cleanly to `OrderSyncStatusValue` without a cast.
+ * Status segments — partition the order set (#929). The "All" card carries the
+ * total; the four health cards map 1:1 to the `health` URL filter and their
+ * counts sum to that total. Tone communicates operational alarm at a glance.
  */
-function isOrderSyncStatus(value: string | null): value is OrderSyncStatusValue {
-  return value !== null && (OrderSyncStatusValues as readonly string[]).includes(value);
+interface HealthSegment {
+  key: OrderHealthValue;
+  label: string;
+  tone: MetricCardTone;
+  countKey: keyof Omit<OrderHealthSummary, 'total'>;
+}
+
+const HEALTH_SEGMENTS: readonly HealthSegment[] = [
+  { key: 'needs_attention', label: 'Needs attention', tone: 'error', countKey: 'needsAttention' },
+  { key: 'awaiting_mapping', label: 'Awaiting mapping', tone: 'warning', countKey: 'awaitingMapping' },
+  { key: 'awaiting_dispatch', label: 'Awaiting dispatch', tone: 'info', countKey: 'awaitingDispatch' },
+  { key: 'synced', label: 'Synced', tone: 'success', countKey: 'synced' },
+];
+
+/**
+ * Type-guard for the `health` URL param. `includes` widens the haystack to
+ * `readonly string[]` so the predicate narrows cleanly without a cast.
+ */
+function isOrderHealth(value: string | null): value is OrderHealthValue {
+  return value !== null && (OrderHealthValues as readonly string[]).includes(value);
 }
 
 /**
  * Resolve the per-row total via the i18n seam (#612). Currency varies per row
- * so we instantiate per call — locale comes from the LocaleProvider rather
- * than being pinned to en-US. Locale resolution goes through the shared
- * `getBcp47Locale` helper so the seam stays single-source-of-truth (#783).
+ * so we instantiate per call; locale comes from the LocaleProvider.
  */
 function formatCurrency(amount: number, currency: string, locale: LocaleCode): string {
   return new Intl.NumberFormat(getBcp47Locale(locale), { style: 'currency', currency }).format(
@@ -89,11 +94,18 @@ function formatCurrency(amount: number, currency: string, locale: LocaleCode): s
   );
 }
 
+/** Buyer name from the snapshot's shipping address — null when absent. */
+function customerName(parsed: ReturnType<typeof parseOrderSnapshot>): string | null {
+  const a = parsed.shippingAddress;
+  if (!a) return null;
+  const name = [a.firstName, a.lastName].filter(Boolean).join(' ').trim();
+  return name.length > 0 ? name : null;
+}
+
 /**
- * Cockpit-style "data freshness" line — the freshest `updatedAt` across
- * visible rows, rendered as a locale-aware HH:MM. The temporal eyebrow is
- * the operator's "how stale is this view" signal; same locale-resolution
- * path as `formatCurrency` so the i18n seam stays single-source-of-truth.
+ * Cockpit "data freshness" line — freshest `updatedAt` across visible rows,
+ * rendered as a locale-aware HH:MM. Same locale-resolution path as
+ * `formatCurrency` so the i18n seam stays single-source-of-truth.
  */
 function formatFreshness(items: readonly OrderRecord[], locale: LocaleCode): string | null {
   if (items.length === 0) return null;
@@ -114,30 +126,34 @@ export function OrdersListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const { sort, setSort } = useTableSort([{ id: 'createdAt', desc: true }]);
   const { locale } = useTranslation();
+  const { showToast } = useToast();
 
-  const rawSyncStatus = searchParams.get('syncStatus');
-  const syncStatus = isOrderSyncStatus(rawSyncStatus) ? rawSyncStatus : undefined;
+  const rawHealth = searchParams.get('health');
+  const health = isOrderHealth(rawHealth) ? rawHealth : undefined;
   const sourceConnectionId = searchParams.get('sourceConnectionId') ?? undefined;
   const offset = Number(searchParams.get('offset') ?? '0');
 
   const filters: OrderFilters = {
-    syncStatus,
+    health,
     sourceConnectionId: sourceConnectionId || undefined,
   };
   const pagination = { limit: PAGE_SIZE, offset };
 
   const query = useOrdersQuery(filters, pagination);
 
-  // KPI strip — four cheap count-only queries. limit:1 ships ~empty results;
-  // we only read `.total`. Each call has its own queryKey so TanStack caches
-  // them independently across the app session.
-  const allOrdersKpi = useOrdersQuery(undefined, { limit: 1 });
-  const syncedKpi = useOrdersQuery({ syncStatus: 'synced' }, { limit: 1 });
-  const pendingKpi = useOrdersQuery({ syncStatus: 'pending' }, { limit: 1 });
-  const failedKpi = useOrdersQuery({ syncStatus: 'failed' }, { limit: 1 });
+  // Single count endpoint — partitions the set, so segment counts sum to total.
+  // Scoped by source only (the table's other axis); `health` is intentionally
+  // never part of the summary scope.
+  const summaryScope = useMemo(
+    () => ({ sourceConnectionId: sourceConnectionId || undefined }),
+    [sourceConnectionId],
+  );
+  const summaryQuery = useOrderStatusSummaryQuery(summaryScope);
+  const summary = summaryQuery.data;
 
-  // Channel lookup: build connectionId → platformType once per
-  // connections-query data change. Already cached app-wide via TanStack.
+  const retryMutation = useRetryOrderDestinationMutation();
+
+  // Channel lookup: connectionId → platformType, cached app-wide via TanStack.
   const connectionsQuery = useConnectionsQuery();
   const platformByConnection = useMemo(() => {
     const map = new Map<string, string>();
@@ -147,15 +163,11 @@ export function OrdersListPage(): ReactElement {
     return map;
   }, [connectionsQuery.data]);
 
+  const channelLabel = (platform: string | undefined): string | undefined =>
+    platform ? (CHANNEL_LABELS[platform] ?? platform) : undefined;
+
   const columns: DataTableColumn<OrderRecord>[] = useMemo(
     () => [
-      {
-        id: 'createdAt',
-        header: 'Created',
-        cell: (order) => <TimeDisplay iso={order.createdAt} format="date" />,
-        accessor: (order) => order.createdAt,
-        sortable: true,
-      },
       {
         id: 'order',
         header: 'Order',
@@ -170,44 +182,97 @@ export function OrdersListPage(): ReactElement {
         },
       },
       {
-        id: 'channel',
-        header: 'Channel',
+        id: 'customer',
+        header: 'Customer',
         cell: (order) => {
-          const platform = platformByConnection.get(order.sourceConnectionId);
-          if (!platform) {
-            return <span className="text-muted">—</span>;
-          }
+          const parsed = parseOrderSnapshot(order.orderSnapshot);
+          const name = customerName(parsed);
+          if (!name) return <span className="text-muted">—</span>;
+          const city = parsed.shippingAddress?.city;
           return (
-            <span className="channel-pill" data-channel={platform}>
-              {CHANNEL_LABELS[platform] ?? platform}
+            <span className="orders-cell-stack">
+              <span>{name}</span>
+              {city ? <span className="text-muted orders-cell-sub">{city}</span> : null}
             </span>
           );
         },
         hideBelow: 768,
       },
       {
-        id: 'syncStatus',
-        header: 'Sync Status',
+        id: 'items',
+        header: 'Items',
         cell: (order) => {
-          if (order.syncStatus.length === 0) {
-            return <span className="text-muted">—</span>;
-          }
+          const parsed = parseOrderSnapshot(order.orderSnapshot);
+          const count = parsed.items.length;
+          if (count === 0) return <span className="text-muted">—</span>;
+          const first = parsed.items[0]?.name;
           return (
-            <span className="data-table__badge-row">
-              {order.syncStatus.map((s) => (
-                <StatusBadge
-                  key={s.destinationConnectionId}
-                  tone={SYNC_STATUS_TONES[s.status]}
-                  pulse={s.status === 'syncing'}
-                  withDot={s.status !== 'syncing'}
-                  compact
-                >
-                  {s.status}
-                </StatusBadge>
-              ))}
+            <span className="orders-cell-stack">
+              <span>
+                {count} {count === 1 ? 'item' : 'items'}
+              </span>
+              {first ? <span className="text-muted orders-cell-sub">{first}</span> : null}
             </span>
           );
         },
+        hideBelow: 1024,
+      },
+      {
+        id: 'channel',
+        header: 'Channel',
+        cell: (order) => {
+          const source = channelLabel(platformByConnection.get(order.sourceConnectionId));
+          const destPlatform = order.syncStatus[0]
+            ? platformByConnection.get(order.syncStatus[0].destinationConnectionId)
+            : undefined;
+          const dest = channelLabel(destPlatform);
+          if (!source) return <span className="text-muted">—</span>;
+          return (
+            <span className="orders-cell-stack">
+              <span className="channel-pill" data-channel={platformByConnection.get(order.sourceConnectionId)}>
+                {source}
+              </span>
+              {dest ? <span className="text-muted orders-cell-sub">→ {dest}</span> : null}
+            </span>
+          );
+        },
+        hideBelow: 768,
+      },
+      {
+        id: 'status',
+        header: 'Status',
+        cell: (order) => {
+          const h = deriveOrderHealth(order);
+          return (
+            <span className="orders-cell-stack">
+              <StatusBadge tone={h.tone} withDot compact>
+                {h.label}
+              </StatusBadge>
+              {h.reason ? (
+                <span className="orders-status-reason">{h.reason}</span>
+              ) : null}
+            </span>
+          );
+        },
+      },
+      {
+        id: 'shipBy',
+        header: 'Ship-by',
+        cell: () => <span className="orders-ghost" title="Dispatch SLA — arrives with #927">soon</span>,
+        hideBelow: 1024,
+      },
+      {
+        id: 'createdAt',
+        header: 'Created',
+        cell: (order) => <TimeDisplay iso={order.createdAt} format="relative" />,
+        accessor: (order) => order.createdAt,
+        sortable: true,
+      },
+      {
+        id: 'payment',
+        header: 'Payment',
+        cell: () => <span className="orders-ghost" title="Payment status — arrives with #928">soon</span>,
+        hideBelow: 1024,
       },
       {
         id: 'total',
@@ -215,9 +280,7 @@ export function OrdersListPage(): ReactElement {
         align: 'right',
         cell: (order) => {
           const parsed = parseOrderSnapshot(order.orderSnapshot);
-          if (!parsed.totals) {
-            return <span className="text-muted">—</span>;
-          }
+          if (!parsed.totals) return <span className="text-muted">—</span>;
           return (
             <span className="mono tabular">
               {formatCurrency(parsed.totals.total, parsed.totals.currency, locale)}
@@ -225,17 +288,57 @@ export function OrdersListPage(): ReactElement {
           );
         },
       },
+      {
+        id: 'actions',
+        header: '',
+        align: 'right',
+        cell: (order) => {
+          const failed = order.syncStatus.find((s) => s.status === 'failed');
+          if (order.recordStatus === 'awaiting_mapping' || !failed) return null;
+          const isRetrying =
+            retryMutation.isPending &&
+            retryMutation.variables?.internalOrderId === order.internalOrderId;
+          return (
+            <Button
+              tone="ghost"
+              className="button--sm"
+              disabled={isRetrying}
+              onClick={() => { handleRetry(order.internalOrderId, failed.destinationConnectionId); }}
+            >
+              {isRetrying ? 'Retrying…' : 'Retry'}
+            </Button>
+          );
+        },
+      },
     ],
-    [locale, platformByConnection],
+    // Deps: columns rebuild when locale, the channel lookup, or the retry
+    // mutation's pending/variables change — the last two so the inline Retry
+    // reflects its in-flight state. `handleRetry` closes over the stable
+    // `mutate` handle, so it doesn't need to be a dep.
+    [locale, platformByConnection, retryMutation.isPending, retryMutation.variables],
   );
 
-  function handleStatusFilterChange(next: OrderSyncStatusValue | ''): void {
+  function handleRetry(internalOrderId: string, destinationConnectionId: string): void {
+    retryMutation.mutate(
+      { internalOrderId, destinationConnectionId },
+      {
+        onSuccess: () => {
+          showToast({ tone: 'success', title: 'Retry queued', description: 'Sync re-enqueued.' });
+        },
+        onError: (error) => {
+          showToast({ tone: 'error', title: 'Retry failed', description: error.message });
+        },
+      },
+    );
+  }
+
+  function setHealthFilter(next: OrderHealthValue | null): void {
     setSearchParams((prev) => {
       const p = new URLSearchParams(prev);
       if (next) {
-        p.set('syncStatus', next);
+        p.set('health', next);
       } else {
-        p.delete('syncStatus');
+        p.delete('health');
       }
       p.delete('offset');
       return p;
@@ -254,40 +357,21 @@ export function OrdersListPage(): ReactElement {
     });
   }
 
-  function clearFilters(): void {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      next.delete('syncStatus');
-      next.delete('sourceConnectionId');
-      next.delete('offset');
-      return next;
-    });
-  }
-
-  const filtersActive = Boolean(syncStatus || sourceConnectionId);
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
 
-  // Temporal eyebrow — freshest `updatedAt` across the visible page. Falls
-  // back to the static "Operations" label when nothing has loaded yet, so the
-  // header layout is stable on first paint.
   const freshness = useMemo(
     () => formatFreshness(query.data?.items ?? [], locale),
     [query.data?.items, locale],
   );
 
-  // `R` keyboard shortcut — operator-cockpit affordance for "refresh
-  // everything visible." Skips when modifier keys are pressed (Cmd+R is
-  // browser reload) and when a text input has focus.
   function refreshAll(): void {
     void query.refetch();
-    void allOrdersKpi.refetch();
-    void syncedKpi.refetch();
-    void pendingKpi.refetch();
-    void failedKpi.refetch();
+    void summaryQuery.refetch();
   }
 
+  // `R` keyboard shortcut — operator-cockpit "refresh everything visible".
   useEffect(() => {
     function onKeydown(e: KeyboardEvent): void {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
@@ -306,89 +390,53 @@ export function OrdersListPage(): ReactElement {
     }
     document.addEventListener('keydown', onKeydown);
     return () => { document.removeEventListener('keydown', onKeydown); };
-    // Empty deps: `refreshAll` closes over the five React-Query refetch
-    // handles, whose identities are stable per query instance — the
-    // listener doesn't need to rebind on every render. The handler will
-    // see fresh refetch handles at fire-time via the closure.
+    // Empty deps: the listener fires `refreshAll`, which closes over the two
+    // React-Query refetch handles (stable per query instance) — no rebind
+    // needed; the handler reads fresh state at fire-time via the closure.
   }, []);
+
+  const segmentCount = (segment: HealthSegment): string =>
+    summary ? String(summary[segment.countKey]) : '—';
 
   return (
     <PageLayout
       eyebrow={freshness ?? 'Operations'}
       title="Orders"
       actions={
-        <>
-          <Button tone="ghost" className="button--sm" onClick={refreshAll}>
-            Refresh
-            <span className="button__shortcut">R</span>
-          </Button>
-          <Link to="/orders/failed" className="button button--ghost">
-            Failed Orders
-          </Link>
-        </>
+        <Button tone="ghost" className="button--sm" onClick={refreshAll}>
+          Refresh
+          <span className="button__shortcut">R</span>
+        </Button>
       }
     >
-      {/* KPI strip — counts by sync status. Tone-tinted; '—' placeholders
-          while queries resolve so the layout stays stable. */}
-      <div className="ds-grid ds-grid--4">
-        <MetricCard
-          label="All orders"
-          value={allOrdersKpi.data ? allOrdersKpi.data.total : '—'}
-        />
-        <MetricCard
-          label="Synced"
-          tone="success"
-          value={syncedKpi.data ? syncedKpi.data.total : '—'}
-        />
-        <MetricCard
-          label="Pending"
-          tone="warning"
-          value={pendingKpi.data ? pendingKpi.data.total : '—'}
-        />
-        <MetricCard
-          label="Failed"
-          tone="error"
-          value={failedKpi.data ? failedKpi.data.total : '—'}
-        />
+      {/* Status segments — partition the set; click to filter by `health`. */}
+      <div className="ds-grid ds-grid--5 orders-segments">
+        <button
+          type="button"
+          className={['orders-segment', health === undefined ? 'orders-segment--active' : '']
+            .filter(Boolean)
+            .join(' ')}
+          aria-pressed={health === undefined}
+          onClick={() => { setHealthFilter(null); }}
+        >
+          <MetricCard label="All orders" value={summary ? String(summary.total) : '—'} />
+        </button>
+        {HEALTH_SEGMENTS.map((segment) => (
+          <button
+            key={segment.key}
+            type="button"
+            className={['orders-segment', health === segment.key ? 'orders-segment--active' : '']
+              .filter(Boolean)
+              .join(' ')}
+            aria-pressed={health === segment.key}
+            onClick={() => { setHealthFilter(segment.key); }}
+          >
+            <MetricCard label={segment.label} tone={segment.tone} value={segmentCount(segment)} />
+          </button>
+        ))}
       </div>
 
-      {/* Chip filter row — Status filter (active when set). Status chip
-          serves as both indicator and trigger via DropdownMenu. */}
       <div className="ds-row" style={{ gap: 'var(--space-2)', flexWrap: 'wrap' }}>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Chip active={Boolean(syncStatus)} aria-label="Filter by sync status">
-              Status: {syncStatus ? STATUS_FILTER_LABELS[syncStatus] : 'All'}
-            </Chip>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            <DropdownMenuItem onSelect={() => { handleStatusFilterChange(''); }}>
-              All
-            </DropdownMenuItem>
-            {OrderSyncStatusValues.map((status) => (
-              <DropdownMenuItem
-                key={status}
-                onSelect={() => { handleStatusFilterChange(status); }}
-              >
-                {STATUS_FILTER_LABELS[status]}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        {filtersActive && (
-          <Button
-            tone="ghost"
-            className="button--sm"
-            onClick={clearFilters}
-          >
-            Clear filters
-          </Button>
-        )}
-
-        {/* Right-aligned results-count signal. Surfaces the total above
-            the table — operators don't need to scan to the paginator to
-            tell whether the filter is doing anything. */}
         {query.data && (
           <span
             className="text-muted mono tabular"
@@ -405,29 +453,35 @@ export function OrdersListPage(): ReactElement {
         <ErrorState
           title="Unable to load orders"
           message={query.error.message}
-          action={
-            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
-          }
+          action={<Button onClick={() => { void query.refetch(); }}>Retry</Button>}
         />
       ) : (query.data?.items.length ?? 0) === 0 ? (
-        <EmptyState
-          liveRegion="off"
-          title="No orders found"
-          message={
-            filtersActive
-              ? 'No orders match the current filters.'
-              : 'No order records have been synced yet.'
-          }
-          action={
-            filtersActive ? (
-              <Button onClick={clearFilters}>Clear filters</Button>
-            ) : (
+        health === 'needs_attention' ? (
+          <EmptyState
+            liveRegion="off"
+            title="All clear — nothing needs your attention"
+            message="No failed syncs or unmapped orders right now. New issues surface here the moment they happen."
+            action={<Button onClick={() => { setHealthFilter(null); }}>View all orders</Button>}
+          />
+        ) : health !== undefined ? (
+          <EmptyState
+            liveRegion="off"
+            title="No orders in this view"
+            message="No orders match the current filter."
+            action={<Button onClick={() => { setHealthFilter(null); }}>View all orders</Button>}
+          />
+        ) : (
+          <EmptyState
+            liveRegion="off"
+            title="No orders found"
+            message="No order records have been synced yet."
+            action={
               <Link className="button button--primary" to="/connections">
                 Manage connections
               </Link>
-            )
-          }
-        />
+            }
+          />
+        )
       ) : (
         <>
           <DataTable
@@ -448,27 +502,37 @@ export function OrdersListPage(): ReactElement {
                   />
                 );
               },
-              subtitle: (order) => <TimeDisplay iso={order.createdAt} format="date" />,
+              subtitle: (order) => <TimeDisplay iso={order.createdAt} format="relative" />,
               meta: (order) => {
-                const platform = platformByConnection.get(order.sourceConnectionId);
-                const primary = order.syncStatus[0];
+                const h = deriveOrderHealth(order);
+                const source = channelLabel(platformByConnection.get(order.sourceConnectionId));
+                const failed = order.syncStatus.find((s) => s.status === 'failed');
+                const isRetrying =
+                  retryMutation.isPending &&
+                  retryMutation.variables?.internalOrderId === order.internalOrderId;
                 return (
                   <span className="data-table__badge-row">
-                    {platform && (
-                      <span className="channel-pill" data-channel={platform}>
-                        {CHANNEL_LABELS[platform] ?? platform}
+                    {source && (
+                      <span
+                        className="channel-pill"
+                        data-channel={platformByConnection.get(order.sourceConnectionId)}
+                      >
+                        {source}
                       </span>
                     )}
-                    {primary && (
-                      <StatusBadge
-                        tone={SYNC_STATUS_TONES[primary.status]}
-                        pulse={primary.status === 'syncing'}
-                        withDot={primary.status !== 'syncing'}
-                        compact
+                    <StatusBadge tone={h.tone} withDot compact>
+                      {h.label}
+                    </StatusBadge>
+                    {failed && order.recordStatus !== 'awaiting_mapping' ? (
+                      <Button
+                        tone="ghost"
+                        className="button--sm"
+                        disabled={isRetrying}
+                        onClick={() => { handleRetry(order.internalOrderId, failed.destinationConnectionId); }}
                       >
-                        {primary.status}
-                      </StatusBadge>
-                    )}
+                        {isRetrying ? 'Retrying…' : 'Retry'}
+                      </Button>
+                    ) : null}
                   </span>
                 );
               },
@@ -480,16 +544,10 @@ export function OrdersListPage(): ReactElement {
               Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
             </span>
             <div className="pagination__actions">
-              <Button
-                disabled={!hasPrev}
-                onClick={() => { setOffset(offset - PAGE_SIZE); }}
-              >
+              <Button disabled={!hasPrev} onClick={() => { setOffset(offset - PAGE_SIZE); }}>
                 Previous
               </Button>
-              <Button
-                disabled={!hasNext}
-                onClick={() => { setOffset(offset + PAGE_SIZE); }}
-              >
+              <Button disabled={!hasNext} onClick={() => { setOffset(offset + PAGE_SIZE); }}>
                 Next
               </Button>
             </div>

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -231,7 +231,20 @@ export function createMockApiClient(
         limit: 20,
         offset: 0,
       }),
+      statusSummary: vi.fn().mockResolvedValue({
+        total: 0,
+        awaitingMapping: 0,
+        needsAttention: 0,
+        synced: 0,
+        awaitingDispatch: 0,
+      }),
       getById: vi.fn().mockResolvedValue(null),
+      retryDestination: vi.fn().mockResolvedValue({
+        internalOrderId: '',
+        destinationConnectionId: '',
+        jobId: '',
+        jobType: '',
+      }),
       ...overrides.orders,
     } as ApiClient['orders'],
     listings: {

--- a/docs/plans/implementation-plan-orders-list-redesign.md
+++ b/docs/plans/implementation-plan-orders-list-redesign.md
@@ -1,0 +1,109 @@
+# Implementation Plan — Orders list (`/orders`) UX redesign (#929)
+
+> Spec mockup: `docs/plans/orders-list-redesign-mockup.html` (standalone, verified light + dark).
+> Sibling FE redesign: #924 (order detail). Data-capture epic: #925 → #926/#927/#928.
+
+## 1. Goal & layer classification
+
+Reshape the existing `OrdersListPage` from a **sync log** into an operator **triage queue**, and fix the headline correctness bug where the KPI cards don't partition the order set (`32 ≠ 0+0+9`) and every row's status renders `—`.
+
+- **Primary layer: Frontend** (`apps/web/pages/orders`, `features/orders`).
+- **Secondary layer: CORE + Interface (backend)** — a small, contained addition to make the status buckets *partition correctly* (the bug): a derived **order-health** classification used for both a list filter and an aggregate count summary. This is the only backend touch.
+
+The current page already provides (reuse, don't rebuild): `DataTable` (client sort, mobile `cardView`, `rowHref`), `DataTableSkeleton` (loading), `ErrorState`/`EmptyState`, `MetricCard` KPI strip, `parseOrderSnapshot`, URL-state filters via `useSearchParams`, i18n currency/relative-time seam, the `R` refresh shortcut.
+
+## 2. The bug (root cause, confirmed in code)
+
+- `orders-list-page.tsx:134-137` issues 4 count queries; `pending`/`synced`/`failed` use the repository's JSONB-containment filter (`order-record.repository.ts:82-88`). An order with an **empty `syncStatus[]`** (ingested, not yet dispatched) matches none of them, and an `awaiting_mapping` order isn't represented at all → the cards don't sum to total.
+- `orders-list-page.tsx:192-193` renders `—` whenever `syncStatus.length === 0` — i.e. for every not-yet-dispatched order (the majority in the screenshot).
+
+The fix is a single **derived order-health** with mutually-exclusive precedence, computed identically on the row (FE) and in aggregate (SQL):
+
+| Health | Precedence | Definition |
+|---|---|---|
+| `awaiting_mapping` | 1 | `recordStatus = 'awaiting_mapping'` |
+| `needs_attention` | 2 | `recordStatus = 'ready'` AND any destination `syncStatus = 'failed'` |
+| `synced` | 3 | ready, no failed, AND any destination `synced` |
+| `awaiting_dispatch` | 4 | everything else (ready, no failed, no synced — empty / pending / syncing) |
+
+These four + `all` partition the set; counts sum to total.
+
+## 3. Scope decision (⏸️ confirm with user)
+
+### Review adjustments applied (tech-review, before Phase 4)
+- **Sort scope tightened.** Only `Placed`/`createdAt` is sortable in v1 (the column the server already orders by). Customer/Items/Total/Status are **not** marked sortable — they're `orderSnapshot` (JSONB) derivations the server can't sort without expression indexes; a client-only sort of the 20-row page would be a misleading affordance. Server `orderBy` for Total/Status is a follow-up.
+- **Inline Retry vs `rowHref`.** The row is a navigable link; a `<button>` nested in it is invalid/inaccessible. Retry renders in a dedicated action cell the row-link excludes (verify `DataTable`'s action-cell mechanism first; if absent, drop `rowHref` and make the identity cell the explicit link).
+- **`countByHealth` input narrowed.** Takes a `OrderHealthSummaryFilters` subset (source/customer/date) — never the `health` field — so the aggregate can't be self-filtered.
+- **"Placed" label kept honest.** The date column stays **Created / Ingested** (`createdAt`) until #926 lands; "Placed" is not asserted from data we don't have (consistent with the ghost-column rule).
+- **No migration.** `countByHealth` + `health` filter read existing columns (`recordStatus`, `syncStatus` JSONB) — no ORM schema change, so the `migration:show` gate is consciously skipped.
+- **Single-source health precedence.** The four-way precedence is written once as a doc comment referenced verbatim by both `deriveOrderHealth` (TS) and the SQL `CASE`; the int-spec asserts failed+synced → `needs_attention`.
+
+**Recommended — Option A (full vertical slice, one PR):** implement the derived-health classification end-to-end:
+- Backend: add `health` to `OrderRecordFilters` (translate → SQL `CASE`/jsonb predicate) and a `countByHealth()` repository method (single grouped query) surfaced via `GET /orders/status-summary`.
+- FE: per-row health badge (kills `—`), clickable segment cards that filter by `health`, counts that partition.
+- Satisfies the issue's acceptance ("buckets partition the full set; counts sum to total"). Contained; does **not** touch the orders detail files #924 is editing.
+
+**Fallback — Option B (FE-only this PR, defer counts):** ship the per-row health badge + all column/state work; leave the KPI cards on today's (imperfect) raw-status counts and file a follow-up backend issue for the partition. Faster, but leaves the headline bug partly unfixed and misses an AC.
+
+→ **Plan below assumes Option A.** If the user prefers B, drop steps 4.1–4.4 and keep the cards as-is.
+
+## 4. Backend steps (Option A)
+
+### 4.1 Domain types — `libs/core/src/orders/domain/types/order-record.types.ts`
+- Add `OrderHealthValues = ['awaiting_mapping','needs_attention','synced','awaiting_dispatch'] as const;` + `OrderHealth` union.
+- Add `OrderHealthSummary` type: `{ total; awaitingMapping; needsAttention; synced; awaitingDispatch }`.
+- Extend `OrderRecordFilters` with `health?: OrderHealth`.
+- **Acceptance:** `as const` + union per standards; no inline types.
+
+### 4.2 Repository port — `domain/ports/order-record-repository.port.ts`
+- Add `countByHealth(filters: OrderRecordFilters): Promise<OrderHealthSummary>`.
+
+### 4.3 Repository impl — `infrastructure/persistence/repositories/order-record.repository.ts`
+- Add a private `applyHealthFilter(qb, health)` that appends the precedence predicate (reuse in `findMany` when `filters.health` is set).
+- Implement `countByHealth` as one grouped query: a `CASE` expression mapping each row to a bucket, `GROUP BY` it, plus the source/customer/date filters. Map rows → `OrderHealthSummary` (zero-fill missing buckets).
+- **Acceptance:** single round-trip; respects existing `sourceConnectionId`/date filters; integration test (`*.int-spec.ts`) covering each bucket + precedence (e.g. failed+synced → needs_attention).
+
+### 4.4 Interface — `apps/api/src/orders/http/orders.controller.ts` (+ response DTO + query DTO)
+- `GET /orders/status-summary` → `OrderHealthSummaryResponseDto`; accepts the same source/date query params as the list.
+- Add `health` to the list query DTO (`ListOrdersQueryDto`) validated against `OrderHealthValues`.
+- **Acceptance:** `@UseGuards(JwtAuthGuard)`; controller spec; degrades to all-zero when empty.
+
+## 5. Frontend steps
+
+### 5.1 Health view-model — `features/orders/lib/order-health.ts` (+ `.test.ts`)
+- Pure `deriveOrderHealth(order: OrderRecord): { key: OrderHealth; tone: StatusBadgeTone; label: string; reason?: string }`. `reason` = first failed destination's `error` (plain-language) for `needs_attention`.
+- Mirrors the SQL precedence exactly (single source of truth for the rule, documented in both).
+- **Acceptance:** unit tests for all four buckets + precedence + empty-array case.
+
+### 5.2 Types/api/hook for the summary — `features/orders/api/orders.types.ts`, `orders.api.ts`, `orders.query-keys.ts`, `hooks/use-order-status-summary-query.ts`
+- Add `OrderHealth*` types (FE mirror), `statusSummary(filters?)` client method, query key, `useOrderStatusSummaryQuery(filters)` hook. Add `health` to `OrderFilters`.
+
+### 5.3 Reshape the table — `pages/orders/orders-list-page.tsx`
+Columns (left→right): **Order** (EntityLabel: human # + uuid — keep), **Customer** (NEW — `parsed.shippingAddress` name + city), **Items** (NEW — `parsed.items.length` + first item name), **Channel** (source pill + `→ OMP · PrestaShop` dest subline from `syncStatus[].destinationConnectionId`), **Status** (NEW — single `deriveOrderHealth` badge + `reason`, replaces the per-destination list and the `—`), **Ship-by** (ghost — disabled column, `#927`), **Placed** (relative `TimeDisplay` + abs subline; honest "ingested" tooltip until #926), **Payment** (ghost — `#928`), **Total** (keep). Sortable: Order, Customer, Items, Status, Placed, Total (client-side page sort, matching existing `useTableSort` behavior — server multi-sort is a noted non-goal).
+- Update `cardView` (mobile) to the new fields.
+- **Per-row inline Retry** for `needs_attention` via the existing `useRetryOrderDestinationMutation` — render inside the row with `e.stopPropagation()` so it doesn't trigger `rowHref` navigation.
+
+### 5.4 Segment cards as filters — same file
+- Replace the 4 static `MetricCard`s with 5 segment cards (`all`, `needs_attention`, `awaiting_mapping`, `awaiting_dispatch`, `synced`) backed by `useOrderStatusSummaryQuery`. Clicking sets the `health` URL param (reuse the `setSearchParams` pattern). Active card = current filter. `MetricCard` is presentational; wrap in a button/Link for the filter affordance (keep a11y — real `<button>`).
+
+### 5.5 Empty / all-clear — same file
+- When `health=needs_attention` (or any filter) yields zero rows, show the "all clear" `EmptyState` copy ("Nothing needs your attention…") instead of the generic empty message.
+
+### 5.6 Styles — `apps/web/src/index.css` (+ `shared/theme/tokens.ts` if new vars)
+- Ghost-column + channel-dest-subline styles in a bounded `/* ── Orders list redesign (#929) ── */` section. Reuse existing tokens; add to `tokens.ts` if any new var (drift checker).
+
+## 6. Testing
+- Unit: `order-health.test.ts` (precedence/buckets); extend `orders-list-page.test.tsx` (new columns render customer/items/channel; single health badge; segment-card click sets `health` param; all-clear empty; inline retry calls mutation without navigating).
+- Backend: `order-record.repository.int-spec.ts` for `countByHealth` + `health` filter; controller spec for `/orders/status-summary`.
+- Run full `pnpm test` (FE) + `pnpm test:integration` (orders repo) — manifest/contract-adjacent per project memory.
+
+## 7. Non-goals (explicit)
+- Bulk row selection/actions (`DataTable` has no selection model — would change a shared primitive). Inline per-row Retry only. **Follow-up.**
+- True server-side multi-column sort (keep current client page-sort). **Follow-up.**
+- Ship-by / Payment data (capture-gap epic #925) — ghost columns only.
+- Saved views / column picker. **Follow-up.**
+
+## 8. Risks
+- **Overlap with #924 (parallel):** both edit `apps/web` orders. I touch only `pages/orders/orders-list-page.tsx`, `features/orders/{api,hooks,lib}`, `index.css`. I will **not** touch order-detail files. Shared edits (`orders.types.ts` additive, `index.css` bounded section) are merge-friendly. `parseOrderSnapshot` is read-only.
+- **Partition correctness:** the FE `deriveOrderHealth` and the SQL `CASE` must stay in lockstep — documented as a single rule in both; integration test asserts the SQL side, unit test the FE side.
+- **Health filter has no index** (JSONB scan) — acceptable at v1 scale per the existing note in the repository; file a follow-up if scan time creeps.

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -12,6 +12,8 @@ import type {
   OrderRecordFilters,
   OrderRecordPagination,
   PaginatedOrderRecords,
+  OrderHealthSummary,
+  OrderHealthSummaryFilters,
 } from '../types/order-record.types';
 import type { SyncAttempt } from '../types/order-sync.types';
 
@@ -51,4 +53,14 @@ export interface OrderRecordRepositoryPort {
     filters: OrderRecordFilters,
     pagination: OrderRecordPagination
   ): Promise<PaginatedOrderRecords>;
+
+  /**
+   * Count order records per derived health bucket (#929).
+   *
+   * Single aggregate query partitioning every record in scope into exactly one
+   * bucket using the canonical precedence on `OrderHealthValues`. The returned
+   * `total` equals the sum of the four buckets. Scope is the source/customer/
+   * date subset only — `health` itself is intentionally not a valid input.
+   */
+  countByHealth(filters: OrderHealthSummaryFilters): Promise<OrderHealthSummary>;
 }

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -38,14 +38,18 @@ export type OrderRecordStatus = (typeof OrderRecordStatusValues)[number];
  * fell into no bucket.
  *
  * CANONICAL PRECEDENCE (highest wins) — this comment is the single source of
- * truth; the FE `deriveOrderHealth` helper and the SQL `CASE` in
+ * truth; the FE `deriveOrderHealth` helper and the SQL in
  * `OrderRecordRepository.countByHealth` / `applyHealthFilter` must both encode
  * exactly this order:
  *   1. `awaiting_mapping`  — `recordStatus = 'awaiting_mapping'` (can't sync yet)
- *   2. `needs_attention`   — ready AND any destination `syncStatus = 'failed'`
- *   3. `synced`            — ready, no failed, AND any destination `synced`
- *   4. `awaiting_dispatch` — everything else (ready, no failed, no synced:
- *                            empty `syncStatus[]` / pending / syncing)
+ *   2. `needs_attention`   — not awaiting_mapping AND any destination `failed`
+ *   3. `synced`            — not awaiting_mapping, no failed, AND any `synced`
+ *   4. `awaiting_dispatch` — the residual: everything else (no failed, no
+ *                            synced: empty `syncStatus[]` / pending / syncing)
+ *
+ * Buckets 2–4 gate on `NOT awaiting_mapping` (not `recordStatus = 'ready'`) so
+ * the four remain a complete partition for ANY `recordStatus` value — a future
+ * status can't silently leave rows uncounted and break the cards' sum-to-total.
  */
 export const OrderHealthValues = [
   'awaiting_mapping',

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -29,6 +29,62 @@ export const OrderRecordStatusValues = ['ready', 'awaiting_mapping'] as const;
 export type OrderRecordStatus = (typeof OrderRecordStatusValues)[number];
 
 /**
+ * Derived order-health buckets (#929).
+ *
+ * A single operator-facing classification reconciling `recordStatus` with the
+ * per-destination `syncStatus[]`. The four buckets **partition** the order set
+ * (every record maps to exactly one) so the list KPI cards sum to the total —
+ * fixing the prior bug where empty-`syncStatus[]` and `awaiting_mapping` orders
+ * fell into no bucket.
+ *
+ * CANONICAL PRECEDENCE (highest wins) — this comment is the single source of
+ * truth; the FE `deriveOrderHealth` helper and the SQL `CASE` in
+ * `OrderRecordRepository.countByHealth` / `applyHealthFilter` must both encode
+ * exactly this order:
+ *   1. `awaiting_mapping`  — `recordStatus = 'awaiting_mapping'` (can't sync yet)
+ *   2. `needs_attention`   — ready AND any destination `syncStatus = 'failed'`
+ *   3. `synced`            — ready, no failed, AND any destination `synced`
+ *   4. `awaiting_dispatch` — everything else (ready, no failed, no synced:
+ *                            empty `syncStatus[]` / pending / syncing)
+ */
+export const OrderHealthValues = [
+  'awaiting_mapping',
+  'needs_attention',
+  'synced',
+  'awaiting_dispatch',
+] as const;
+
+/**
+ * Derived order-health type
+ */
+export type OrderHealth = (typeof OrderHealthValues)[number];
+
+/**
+ * Aggregate count of order records per derived health bucket (#929).
+ * `total` equals the sum of the four buckets for the same filter scope.
+ */
+export interface OrderHealthSummary {
+  total: number;
+  awaitingMapping: number;
+  needsAttention: number;
+  synced: number;
+  awaitingDispatch: number;
+}
+
+/**
+ * Filter scope for the health-summary count (#929). A deliberate subset of
+ * `OrderRecordFilters` — it intentionally omits `health` (and the sync-status /
+ * destination JSONB filters) so the aggregate can't be self-filtered into a
+ * contradiction (counting all buckets while filtering to one).
+ */
+export interface OrderHealthSummaryFilters {
+  sourceConnectionId?: string;
+  customerId?: string;
+  createdFrom?: Date;
+  createdTo?: Date;
+}
+
+/**
  * Order record filters for list queries
  */
 export interface OrderRecordFilters {
@@ -38,6 +94,13 @@ export interface OrderRecordFilters {
   createdFrom?: Date;
   createdTo?: Date;
   recordStatus?: OrderRecordStatus;
+  /**
+   * Filter to a single derived health bucket (#929). Translated to a SQL
+   * predicate by `OrderRecordRepository.applyHealthFilter` using the canonical
+   * precedence documented on {@link OrderHealthValues}. Used by the list page's
+   * clickable status segments.
+   */
+  health?: OrderHealth;
   /**
    * Match records whose `syncStatus[]` contains an entry for this destination
    * connection (#834). JSONB containment — same idiom as the existing

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -77,6 +77,10 @@ export {
   OrderSyncStatusFilterValues,
   OrderRecordStatus,
   OrderRecordStatusValues,
+  OrderHealth,
+  OrderHealthValues,
+  OrderHealthSummary,
+  OrderHealthSummaryFilters,
 } from './domain/types/order-record.types';
 
 // Services

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -140,19 +140,19 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       .createQueryBuilder('rec')
       .select('COUNT(*)', 'total')
       .addSelect(
-        `COUNT(*) FILTER (WHERE rec."recordStatus" = 'awaiting_mapping')`,
+        `COUNT(*) FILTER (WHERE ${OrderRecordRepository.IS_MAPPING})`,
         'awaiting_mapping'
       )
       .addSelect(
-        `COUNT(*) FILTER (WHERE rec."recordStatus" = 'ready' AND ${OrderRecordRepository.HAS_FAILED})`,
+        `COUNT(*) FILTER (WHERE NOT (${OrderRecordRepository.IS_MAPPING}) AND ${OrderRecordRepository.HAS_FAILED})`,
         'needs_attention'
       )
       .addSelect(
-        `COUNT(*) FILTER (WHERE rec."recordStatus" = 'ready' AND NOT (${OrderRecordRepository.HAS_FAILED}) AND ${OrderRecordRepository.HAS_SYNCED})`,
+        `COUNT(*) FILTER (WHERE NOT (${OrderRecordRepository.IS_MAPPING}) AND NOT (${OrderRecordRepository.HAS_FAILED}) AND ${OrderRecordRepository.HAS_SYNCED})`,
         'synced'
       )
       .addSelect(
-        `COUNT(*) FILTER (WHERE rec."recordStatus" = 'ready' AND NOT (${OrderRecordRepository.HAS_FAILED}) AND NOT (${OrderRecordRepository.HAS_SYNCED}))`,
+        `COUNT(*) FILTER (WHERE NOT (${OrderRecordRepository.IS_MAPPING}) AND NOT (${OrderRecordRepository.HAS_FAILED}) AND NOT (${OrderRecordRepository.HAS_SYNCED}))`,
         'awaiting_dispatch'
       );
 
@@ -189,39 +189,44 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
   }
 
   /**
-   * JSONB-containment fragments shared by `applyHealthFilter` and
-   * `countByHealth`. Constant SQL (no user input) — `@>` matches when the
-   * `syncStatus[]` array contains an entry with the given status. Mirrors the
-   * idiom already used for the `syncStatus` enum filter in `findMany`.
+   * Constant SQL fragments shared by `applyHealthFilter` and `countByHealth`
+   * (no user input). `HAS_*` use `@>` containment — matches when `syncStatus[]`
+   * contains an entry with the given status; `IS_MAPPING` keys the highest-
+   * precedence bucket. The three non-mapping buckets gate on `NOT IS_MAPPING`
+   * (residual form) rather than `recordStatus = 'ready'`, so the four buckets
+   * remain a complete partition for ANY `recordStatus` value — adding a third
+   * status later can't silently leave rows uncounted. This mirrors the FE
+   * `deriveOrderHealth` precedence (mapping → failed → synced → else) exactly.
    */
+  private static readonly IS_MAPPING = `rec."recordStatus" = 'awaiting_mapping'`;
   private static readonly HAS_FAILED = `rec."syncStatus" @> '[{"status":"failed"}]'::jsonb`;
   private static readonly HAS_SYNCED = `rec."syncStatus" @> '[{"status":"synced"}]'::jsonb`;
 
   /**
    * Narrow a `findMany` query to a single derived-health bucket (#929).
-   * Encodes the canonical precedence from `OrderHealthValues` — the buckets are
-   * mutually exclusive because every non-`awaiting_mapping` bucket requires
-   * `recordStatus = 'ready'`, and `recordStatus` is a closed two-value set.
+   * Encodes the canonical precedence from `OrderHealthValues`; `awaiting_dispatch`
+   * is the residual (everything not mapping / failed / synced).
    */
   private applyHealthFilter(
     qb: SelectQueryBuilder<OrderRecordOrmEntity>,
     health: OrderHealth
   ): void {
+    const notMapping = `NOT (${OrderRecordRepository.IS_MAPPING})`;
     switch (health) {
       case 'awaiting_mapping':
-        qb.andWhere(`rec."recordStatus" = 'awaiting_mapping'`);
+        qb.andWhere(OrderRecordRepository.IS_MAPPING);
         break;
       case 'needs_attention':
-        qb.andWhere(`rec."recordStatus" = 'ready' AND ${OrderRecordRepository.HAS_FAILED}`);
+        qb.andWhere(`${notMapping} AND ${OrderRecordRepository.HAS_FAILED}`);
         break;
       case 'synced':
         qb.andWhere(
-          `rec."recordStatus" = 'ready' AND NOT (${OrderRecordRepository.HAS_FAILED}) AND ${OrderRecordRepository.HAS_SYNCED}`
+          `${notMapping} AND NOT (${OrderRecordRepository.HAS_FAILED}) AND ${OrderRecordRepository.HAS_SYNCED}`
         );
         break;
       case 'awaiting_dispatch':
         qb.andWhere(
-          `rec."recordStatus" = 'ready' AND NOT (${OrderRecordRepository.HAS_FAILED}) AND NOT (${OrderRecordRepository.HAS_SYNCED})`
+          `${notMapping} AND NOT (${OrderRecordRepository.HAS_FAILED}) AND NOT (${OrderRecordRepository.HAS_SYNCED})`
         );
         break;
     }

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -24,6 +24,9 @@ import type {
   OrderRecordPagination,
   PaginatedOrderRecords,
   OrderRecordStatus,
+  OrderHealth,
+  OrderHealthSummary,
+  OrderHealthSummaryFilters,
 } from '../../../domain/types/order-record.types';
 
 @Injectable()
@@ -108,12 +111,120 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       qb.andWhere('rec.updatedAt >= :updatedSince', { updatedSince: filters.updatedSince });
     }
 
+    if (filters.health) {
+      this.applyHealthFilter(qb, filters.health);
+    }
+
     const [entities, total] = await qb.getManyAndCount();
 
     return {
       items: entities.map((e) => this.toDomain(e)),
       total,
     };
+  }
+
+  /**
+   * Derived-health count summary (#929).
+   *
+   * One aggregate query partitioning every in-scope record into exactly one
+   * bucket via `COUNT(*) FILTER (...)`. The bucket predicates encode the
+   * canonical precedence documented on `OrderHealthValues` — and are the SQL
+   * twin of the FE `deriveOrderHealth` helper; keep both in lockstep.
+   *
+   * No GIN index on `syncStatus` today — full scan is acceptable at v1 scale
+   * (same trade-off noted on the `findMany` JSONB filters); revisit with an
+   * index if scan time creeps.
+   */
+  async countByHealth(filters: OrderHealthSummaryFilters): Promise<OrderHealthSummary> {
+    const qb = this.repository
+      .createQueryBuilder('rec')
+      .select('COUNT(*)', 'total')
+      .addSelect(
+        `COUNT(*) FILTER (WHERE rec."recordStatus" = 'awaiting_mapping')`,
+        'awaiting_mapping'
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE rec."recordStatus" = 'ready' AND ${OrderRecordRepository.HAS_FAILED})`,
+        'needs_attention'
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE rec."recordStatus" = 'ready' AND NOT (${OrderRecordRepository.HAS_FAILED}) AND ${OrderRecordRepository.HAS_SYNCED})`,
+        'synced'
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE rec."recordStatus" = 'ready' AND NOT (${OrderRecordRepository.HAS_FAILED}) AND NOT (${OrderRecordRepository.HAS_SYNCED}))`,
+        'awaiting_dispatch'
+      );
+
+    if (filters.sourceConnectionId) {
+      qb.andWhere('rec.sourceConnectionId = :sourceConnectionId', {
+        sourceConnectionId: filters.sourceConnectionId,
+      });
+    }
+    if (filters.customerId) {
+      qb.andWhere('rec.customerId = :customerId', { customerId: filters.customerId });
+    }
+    if (filters.createdFrom) {
+      qb.andWhere('rec.createdAt >= :createdFrom', { createdFrom: filters.createdFrom });
+    }
+    if (filters.createdTo) {
+      qb.andWhere('rec.createdAt <= :createdTo', { createdTo: filters.createdTo });
+    }
+
+    const raw = await qb.getRawOne<{
+      total: string;
+      awaiting_mapping: string;
+      needs_attention: string;
+      synced: string;
+      awaiting_dispatch: string;
+    }>();
+
+    return {
+      total: Number(raw?.total ?? 0),
+      awaitingMapping: Number(raw?.awaiting_mapping ?? 0),
+      needsAttention: Number(raw?.needs_attention ?? 0),
+      synced: Number(raw?.synced ?? 0),
+      awaitingDispatch: Number(raw?.awaiting_dispatch ?? 0),
+    };
+  }
+
+  /**
+   * JSONB-containment fragments shared by `applyHealthFilter` and
+   * `countByHealth`. Constant SQL (no user input) — `@>` matches when the
+   * `syncStatus[]` array contains an entry with the given status. Mirrors the
+   * idiom already used for the `syncStatus` enum filter in `findMany`.
+   */
+  private static readonly HAS_FAILED = `rec."syncStatus" @> '[{"status":"failed"}]'::jsonb`;
+  private static readonly HAS_SYNCED = `rec."syncStatus" @> '[{"status":"synced"}]'::jsonb`;
+
+  /**
+   * Narrow a `findMany` query to a single derived-health bucket (#929).
+   * Encodes the canonical precedence from `OrderHealthValues` — the buckets are
+   * mutually exclusive because every non-`awaiting_mapping` bucket requires
+   * `recordStatus = 'ready'`, and `recordStatus` is a closed two-value set.
+   */
+  private applyHealthFilter(
+    qb: SelectQueryBuilder<OrderRecordOrmEntity>,
+    health: OrderHealth
+  ): void {
+    switch (health) {
+      case 'awaiting_mapping':
+        qb.andWhere(`rec."recordStatus" = 'awaiting_mapping'`);
+        break;
+      case 'needs_attention':
+        qb.andWhere(`rec."recordStatus" = 'ready' AND ${OrderRecordRepository.HAS_FAILED}`);
+        break;
+      case 'synced':
+        qb.andWhere(
+          `rec."recordStatus" = 'ready' AND NOT (${OrderRecordRepository.HAS_FAILED}) AND ${OrderRecordRepository.HAS_SYNCED}`
+        );
+        break;
+      case 'awaiting_dispatch':
+        qb.andWhere(
+          `rec."recordStatus" = 'ready' AND NOT (${OrderRecordRepository.HAS_FAILED}) AND NOT (${OrderRecordRepository.HAS_SYNCED})`
+        );
+        break;
+    }
   }
 
   async upsert(orderRecord: OrderRecord): Promise<OrderRecord> {

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -337,6 +337,10 @@ const ALLOW_LIST = new Map([
     'apps/api/test/integration/order-record-attempts.int-spec.ts',
     new Set(['OrderRecordRepositoryPort']),
   ],
+  [
+    'apps/api/test/integration/order-health-summary.int-spec.ts',
+    new Set(['OrderRecordRepositoryPort']),
+  ],
 
   // apps → products.{ProductRepositoryPort, ProductVariantRepositoryPort} — rewire via IProductsService
   ['apps/api/test/integration/products-read.int-spec.ts', new Set(['ProductRepositoryPort'])],


### PR DESCRIPTION
## What & why

Reshapes the `/orders` list from a **sync log** into an operator **triage queue**, and fixes the headline bug where the KPI cards didn't partition the order set (orders with an empty `syncStatus[]` and `awaiting_mapping` orders fell into no bucket, and every row's status rendered a blank `—`).

Closes #929. Sibling to the order-detail redesign (#924); data-capture epic #925 (→ #926/#927/#928) supplies the ghosted Ship-by/Payment columns later.

## Changes

**Backend (core + api) — no migration (reads existing columns)**
- New derived **order-health** classification (`awaiting_mapping | needs_attention | synced | awaiting_dispatch`) with a single documented canonical precedence.
- `OrderRecordRepository.countByHealth` — one `COUNT(*) FILTER (...)` aggregate that **partitions** the set, behind `GET /orders/status-summary`. The three non-mapping buckets gate on `NOT awaiting_mapping` (residual form), so the partition stays complete for *any* `recordStatus` value.
- A `health` filter on `findMany` (drives the clickable segments). Validated via `@IsEnum(OrderHealthValues)`.

**Frontend (apps/web)**
- One reconciled health `StatusBadge` per row (`deriveOrderHealth`) replacing the per-destination list and the blank `—`, with a plain-language failure reason (clamped to one line + `title`).
- **Customer** + **Items** columns parsed from `orderSnapshot`; source→destination **Channel**; honest **Created** time; ghost **Ship-by/Payment** columns (epic #925); inline per-row **Retry**.
- Status segments back the `health` URL filter via the count endpoint (counts sum to total); all-clear empty state; loading / error / mobile states via existing primitives.

## How to test
- `pnpm lint && pnpm type-check && pnpm test` — green (1303 unit tests; the one `webhook-deliveries` flake passes in isolation, unrelated).
- Integration: `OL_PII_HASH_SALT=… pnpm --filter @openlinker/api exec jest --config test/jest-integration.cjs --testPathPattern=order-health-summary` — 4/4 against real Postgres (partition sum, source scope, `health` filter, and the failed+synced → needs_attention precedence + unknown-recordStatus residual).

## Notes
- Isolated from the in-flight #924 (order-detail) work — touches only `pages/orders/orders-list-page.tsx`, `features/orders/{api,hooks,lib}`, a bounded `index.css` section, and the orders backend.
- FE `deriveOrderHealth` and the SQL share one canonical precedence comment + an integration assertion to keep them in lockstep.
- Tech-reviewed twice (plan + implementation); all suggestions applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)