### PR TITLE
feat(orders): capture buyer-placed timestamp from source

### DIFF
--- a/apps/api/test/integration/fixtures/incoming-order.fixtures.ts
+++ b/apps/api/test/integration/fixtures/incoming-order.fixtures.ts
@@ -40,6 +40,11 @@ export interface CarrierMappingFixtureOpts {
    * `total_paid_real == total`.
    */
   status?: IncomingOrder['status'];
+  /**
+   * Buyer-placed-on-marketplace time (#926). Defaults to a fixed ISO value so
+   * the ingested order carries a realistic `placedAt` through the snapshot.
+   */
+  placedAt?: string;
 }
 
 /**
@@ -103,6 +108,7 @@ export function createIncomingOrderForCarrierMapping(
       methodId: opts.methodId,
       methodName,
     },
+    placedAt: opts.placedAt ?? '2026-05-01T09:55:00.000Z',
     createdAt: '2026-05-01T10:00:00.000Z',
     updatedAt: '2026-05-01T10:00:00.000Z',
   };

--- a/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
@@ -56,6 +56,16 @@ describe('parseOrderSnapshot', () => {
     expect(withoutTreatment.parseWarnings).toHaveLength(0);
   });
 
+  it('surfaces a buyer-placed timestamp when present and leaves it undefined otherwise (#926)', () => {
+    const withPlaced = parseOrderSnapshot({ placedAt: '2026-05-31T16:00:00.000Z' });
+    expect(withPlaced.placedAt).toBe('2026-05-31T16:00:00.000Z');
+    expect(withPlaced.parseWarnings).toHaveLength(0);
+
+    expect(parseOrderSnapshot({}).placedAt).toBeUndefined();
+    // Wrong-typed value is tolerated silently (no warning), like other scalars.
+    expect(parseOrderSnapshot({ placedAt: 12345 }).placedAt).toBeUndefined();
+  });
+
   it('returns a ParsedOrderSnapshot (never null) even when the top-level `id` is missing', () => {
     const parsed = parseOrderSnapshot({ orderNumber: '1024' });
 

--- a/apps/web/src/features/orders/api/order-snapshot.schema.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.ts
@@ -95,6 +95,13 @@ export interface ParsedOrderSnapshot {
    * don't expose it (in which case the operator types it).
    */
   customerEmail?: string;
+  /**
+   * When the buyer placed the order on the source marketplace (#926) — ISO
+   * string. The operationally meaningful order date; the detail/list surfaces
+   * lead with it and fall back to the record's ingestion `createdAt` when
+   * absent (older records, sources that don't expose a placed time).
+   */
+  placedAt?: string;
   items: ParsedOrderItem[];
   totals?: ParsedOrderTotals;
   shippingAddress?: ParsedAddress;
@@ -141,6 +148,10 @@ export function parseOrderSnapshot(snapshot: Record<string, unknown>): ParsedOrd
   const customerEmail =
     typeof snapshot.customerEmail === 'string' && snapshot.customerEmail.length > 0
       ? snapshot.customerEmail
+      : undefined;
+  const placedAt =
+    typeof snapshot.placedAt === 'string' && snapshot.placedAt.length > 0
+      ? snapshot.placedAt
       : undefined;
 
   // Items — parse each element independently so one bad row doesn't drop the rest.
@@ -240,6 +251,7 @@ export function parseOrderSnapshot(snapshot: Record<string, unknown>): ParsedOrd
     orderNumber,
     status,
     customerEmail,
+    placedAt,
     items,
     totals,
     shippingAddress,

--- a/apps/web/src/features/orders/components/order-detail-header.tsx
+++ b/apps/web/src/features/orders/components/order-detail-header.tsx
@@ -85,11 +85,27 @@ export function OrderDetailHeader({ order, snapshot }: OrderDetailHeaderProps): 
           )}
         </span>
 
+        {/* Lead with the buyer-placed-on-marketplace time (#926) when available;
+            fall back to the record's ingestion `createdAt` (NOT snapshot.createdAt,
+            which is vestigial) for older records / sources without a placed time. */}
         <span className="order-header__received">
-          Received <TimeDisplay iso={order.createdAt} format="datetime" className="mono-text tabular" />{' '}
-          <span className="text-muted">
-            · <TimeDisplay iso={order.createdAt} format="relative" />
-          </span>
+          {snapshot.placedAt ? (
+            <>
+              Placed{' '}
+              <TimeDisplay iso={snapshot.placedAt} format="datetime" className="mono-text tabular" />{' '}
+              <span className="text-muted">
+                · <TimeDisplay iso={snapshot.placedAt} format="relative" />
+              </span>
+            </>
+          ) : (
+            <>
+              Received{' '}
+              <TimeDisplay iso={order.createdAt} format="datetime" className="mono-text tabular" />{' '}
+              <span className="text-muted">
+                · <TimeDisplay iso={order.createdAt} format="relative" />
+              </span>
+            </>
+          )}
         </span>
       </div>
 

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -124,6 +124,7 @@ describe('OrderDetailPage', () => {
       orderSnapshot: {
         orderNumber: 'A-1024',
         status: 'processing',
+        placedAt: '2026-05-31T16:00:00.000Z',
         items: [
           { id: 'it1', productId: 'ol_product_1', quantity: 2, price: 10, sku: 'SKU-1', name: 'Camera' },
         ],
@@ -172,6 +173,27 @@ describe('OrderDetailPage', () => {
       renderDetail(api);
       // 1 ingest event + 1 sync attempt = 2 events.
       expect(await screen.findByText(/Showing 2 of 2 events/)).toBeInTheDocument();
+    });
+
+    it('leads with the buyer-placed timestamp and demotes the OL clocks (#926)', async () => {
+      const api = createMockApiClient({ orders: { getById: vi.fn().mockResolvedValue(richOrder) } });
+      renderDetail(api);
+      // Header "Placed …" + Summary "Placed" row.
+      expect((await screen.findAllByText(/^Placed$|Placed/)).length).toBeGreaterThan(0);
+      // OL ingestion clock is demoted, not removed.
+      expect(screen.getByText('Received (OL)')).toBeInTheDocument();
+    });
+
+    it('falls back to the OL received time in the header when no placedAt is present (#926)', async () => {
+      const noPlaced: OrderRecord = {
+        ...richOrder,
+        orderSnapshot: { ...richOrder.orderSnapshot, placedAt: undefined },
+      };
+      const api = createMockApiClient({ orders: { getById: vi.fn().mockResolvedValue(noPlaced) } });
+      renderDetail(api);
+      // Header + summary both show "Received" (the OL ingestion clock); no "Placed" anywhere.
+      expect((await screen.findAllByText(/Received/)).length).toBeGreaterThan(0);
+      expect(screen.queryByText(/Placed/)).toBeNull();
     });
   });
 

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -134,8 +134,13 @@ export function OrderDetailPage(): ReactElement {
     ...(order.sourceEventId
       ? [{ id: 'sourceEvent', label: 'Source Event ID', value: order.sourceEventId, mono: true }]
       : []),
-    { id: 'createdAt', label: 'Received', value: <TimeDisplay iso={order.createdAt} format="datetime" /> },
-    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={order.updatedAt} format="datetime" /> },
+    // Buyer-placed-on-marketplace time leads (#926); the OL ingestion clocks
+    // (Received / Updated) are demoted to "OpenLinker processing" below it.
+    ...(snapshot.placedAt
+      ? [{ id: 'placedAt', label: 'Placed', value: <TimeDisplay iso={snapshot.placedAt} format="datetime" /> }]
+      : []),
+    { id: 'createdAt', label: 'Received (OL)', value: <TimeDisplay iso={order.createdAt} format="datetime" /> },
+    { id: 'updatedAt', label: 'Updated (OL)', value: <TimeDisplay iso={order.updatedAt} format="datetime" /> },
   ];
 
   return (

--- a/docs/plans/implementation-plan-buyer-placed-timestamp.md
+++ b/docs/plans/implementation-plan-buyer-placed-timestamp.md
@@ -1,0 +1,108 @@
+# Implementation Plan — Buyer-placed timestamp (#926)
+
+> Part of epic #925 (P1). Thread a **buyer-placed-on-marketplace** timestamp end-to-end
+> so the order surfaces lead with *when the buyer placed the order*, not when OpenLinker
+> ingested it. Unblocks the dispatch-SLA deadline (#927) and upgrades the "Placed"
+> stand-in that #924 (detail) and #929/#932 (list) currently fill with ingestion time.
+
+## 1. Goal & layers
+
+- **Layers:** Integration (Allegro + PrestaShop order-source adapters) → CORE (orders
+  domain types + ingestion mapping + snapshot persistence) → Interface (DTO — pass-through,
+  no change) → Frontend (snapshot schema + detail header/summary + list column).
+- **Goal:** a `placedAt` ISO timestamp present on the order contract end-to-end; FE leads
+  with it, demoting OL's `received`/`updated` clocks to a secondary "OpenLinker processing" line.
+- **Non-goals:** server-side sort-by-placedAt on the list (stays `createdAt`; noted below);
+  payment status / SLA countdown (#927/#928); a DB migration (placedAt rides the existing
+  `orderSnapshot` JSONB — no schema change).
+
+## 2. Verified source field (Allegro — confirmed against developer.allegro.pl swagger)
+
+- `CheckoutForm` top-level exposes only `updatedAt` (revision time) + `revision` — **no
+  order-placed/created field.** OpenLinker's `AllegroCheckoutForm.createdAt?` is **fictional**
+  (Allegro never returns it; the adapter's `checkoutForm.createdAt ?? new Date()` always hits
+  the `new Date()` ingestion fallback).
+- Buyer-placed time = **`lineItems[].boughtAt`** — `format: date-time`, *"ISO date when offer
+  was bought"*. Allegro's own order list sorts by `lineItems.boughtAt`. For a single checkout
+  form all line items are bought together; we take the **earliest** present `boughtAt`.
+- **PrestaShop:** `date_add` is the real placed time (already mapped to `IncomingOrder.createdAt`
+  at `prestashop-order-source.adapter.ts`). Populate `placedAt` from the same value for parity.
+
+## 3. Steps (each with acceptance)
+
+### CORE — domain contract
+1. `libs/core/src/orders/domain/types/incoming-order.types.ts` — add `placedAt?: string` (ISO)
+   to `IncomingOrder` with a doc comment (buyer-placed-on-source; absent when source omits it).
+2. `libs/core/src/orders/domain/types/order.types.ts` — add `placedAt?: Date` to `Order`
+   (sibling to `createdAt`/`updatedAt: Date`).
+3. `libs/core/src/orders/application/services/order-ingestion.service.ts` (`buildUnifiedOrder`)
+   — carry `placedAt: incoming.placedAt ? new Date(incoming.placedAt) : undefined`.
+4. `libs/core/src/orders/application/services/order-record.service.ts` — both snapshot builders
+   write `placedAt` via the established conditional-spread (absent-not-undefined) pattern:
+   `persistOrder` → `...(order.placedAt && { placedAt: order.placedAt.toISOString() })`;
+   `persistIncomingSnapshot` → `...(incoming.placedAt && { placedAt: incoming.placedAt })`.
+   - *Acceptance:* unit specs assert the snapshot carries `placedAt` when present, omits the key when absent.
+
+### Integration — adapters
+5. `libs/integrations/allegro/.../allegro-order-source.adapter.ts` — derive
+   `placedAt = earliest(lineItems[].boughtAt)` (present values only) and set it on the returned
+   `IncomingOrder`. **Honest cleanup:** drop the fictional top-level `createdAt?` from
+   `AllegroCheckoutForm` (allegro-api.types.ts) and set the adapter's ingestion `createdAt`
+   directly to `new Date().toISOString()` (its current effective value); keep the real `updatedAt`.
+   - *Acceptance:* adapter spec — boughtAt → placedAt; earliest-of-many; absent boughtAt → placedAt undefined.
+6. `libs/integrations/prestashop/.../prestashop-order-source.adapter.ts` — set
+   `placedAt` from `date_add` (parity), undefined when absent.
+   - *Acceptance:* adapter spec — `date_add` → placedAt.
+
+### Interface — no change
+7. `apps/api/.../order-record-response.dto.ts` passes `orderSnapshot` verbatim → `placedAt`
+   rides the wire automatically (same pattern as `taxTreatment` in #924). DTO's record-level
+   `createdAt`/`updatedAt` are OL clocks and stay unchanged.
+
+### Frontend
+8. `apps/web/src/features/orders/api/order-snapshot.schema.ts` — add `placedAt?: string`
+   to `ParsedOrderSnapshot` + parse it as a tolerated top-level scalar (like `customerEmail`).
+   - *Acceptance:* schema test — parses `placedAt`, leaves undefined when absent, no parse warning.
+9. `order-detail-header.tsx` + Summary KV (`order-detail-page.tsx`) — **lead with
+   "Placed" = `snapshot.placedAt`** (absolute + relative); demote Received(`createdAt`)/Updated
+   into a secondary "OpenLinker processing" line. Fall back to `createdAt` when `placedAt` absent.
+10. `orders-list-page.tsx` — the existing "Placed" column (added by #929 as an honest
+    `createdAt` stand-in) shows `parsedSnapshot.placedAt ?? createdAt`. **Server-side sort stays
+    on `createdAt`** (placedAt lives in JSONB; sort-by-placedAt is out of scope — note in code).
+
+### Optional stretch (only if one-liners)
+11. Fold buyer note (`messageToSeller`) + source-side status string into the Allegro snapshot
+    metadata if trivial; otherwise defer. Not required by AC.
+
+## 4. Tests
+- Unit: Allegro adapter (3 cases), PS adapter (1), `order-record.service` snapshot (2),
+  ingestion mapping (1), FE schema (1), FE header/list display (2).
+- Integration: extend an order-ingestion int-spec under `apps/api/test/integration` to assert
+  `orderSnapshot.placedAt` end-to-end. **AC requires full `pnpm test:integration` green** (Docker).
+- FE degrades gracefully when `placedAt` absent on older records (covered by fallback + schema test).
+
+## 4a. Tech-review refinements applied
+
+- **Guard external `boughtAt`** — the Allegro earliest-placed helper filters to *parseable*
+  dates (`!Number.isNaN(Date.parse(v))`) and emits `placedAt` only when valid. A malformed
+  source value degrades to **absent**, never throwing in `order.placedAt.toISOString()` (which
+  would fail the whole snapshot build / order ingestion). Unit case covers it.
+- **List column honesty — detail-only for #926.** The merged `/orders` list (#932) has a
+  sortable "Created" column on the record `createdAt` (honest, consistent). Surfacing `placedAt`
+  there would either create a sort-key ≠ display-value mismatch or require a server-side
+  `orderSnapshot->>'placedAt'` sort — out of #926's scope. So #926 leaves the list untouched and
+  scopes the FE change to the **detail page** (header + Summary lead with `placedAt`, demoting
+  Received/Updated to OL-processing clocks). A sortable list "Placed" column is a follow-up.
+- **Spec + int-suite ripple** — update existing `allegro-order-source.adapter.spec.ts`
+  assertions touched by removing the fictional `createdAt`; run the **full** `pnpm test:integration`
+  (conditional-spread keeps the key absent unless `boughtAt` present, so ripple is bounded to
+  fixtures carrying it). Confirm `checkoutForm.createdAt` has no reader besides the adapter.
+- **PR note** — call out the fictional-`createdAt` removal as a deliberate honesty fix.
+- **Fold-ins ride snapshot/metadata only** — buyer-note/source-status (if included) do not widen
+  the typed `IncomingOrder`/`Order` contract.
+- **FE fallback comment** — `snapshot.placedAt ?? order.createdAt` falls back to the **record**
+  `createdAt` (OL ingestion), not `snapshot.createdAt` (vestigial); comment it.
+
+## 5. Quality gate
+`pnpm lint && pnpm type-check && pnpm test` green; then `pnpm test:integration` (order-ingestion
++ carrier-mapping + fulfillment) per the issue AC.

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -268,6 +268,29 @@ describe('OrderIngestionService', () => {
       );
     });
 
+    it('should carry incoming.placedAt onto the unified Order as a Date (#926)', async () => {
+      orderSource.getOrder.mockResolvedValueOnce({
+        ...baseIncoming,
+        placedAt: '2026-05-31T16:00:00.000Z',
+      });
+      orderSyncService.syncOrder.mockResolvedValue([]);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      const order = orderRecordService.persistOrder.mock.calls[0][0];
+      expect(order.placedAt).toEqual(new Date('2026-05-31T16:00:00.000Z'));
+    });
+
+    it('should leave Order.placedAt undefined when the incoming order omits it (#926)', async () => {
+      // baseIncoming carries no placedAt.
+      orderSyncService.syncOrder.mockResolvedValue([]);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      const order = orderRecordService.persistOrder.mock.calls[0][0];
+      expect(order.placedAt).toBeUndefined();
+    });
+
     it('should call updateSyncStatus with synced when syncOrder succeeds', async () => {
       orderSyncService.syncOrder.mockResolvedValue([
         {

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -236,6 +236,30 @@ describe('OrderRecordService', () => {
       const callArg = repository.upsert.mock.calls[0][0];
       expect(callArg.orderSnapshot).not.toHaveProperty('deliverySmart');
     });
+
+    it('should serialise Order.placedAt into the snapshot as an ISO string when present (#926)', async () => {
+      const order = createMockOrder();
+      order.placedAt = new Date('2026-05-31T16:00:00.000Z');
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot['placedAt']).toBe('2026-05-31T16:00:00.000Z');
+    });
+
+    it('should omit placedAt from the snapshot when the Order does not carry it (#926)', async () => {
+      const order = createMockOrder();
+      expect(order.placedAt).toBeUndefined();
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot).not.toHaveProperty('placedAt');
+    });
   });
 
   describe('persistOrder - PII disabled', () => {
@@ -358,6 +382,29 @@ describe('OrderRecordService', () => {
       expect(callArg.recordStatus).toBe('awaiting_mapping');
       expect(callArg.orderSnapshot['externalOrderId']).toBe(incoming.externalOrderId);
       expect(callArg.orderSnapshot['items']).toEqual(incoming.items);
+    });
+
+    it('should pass incoming.placedAt through into the raw snapshot when present (#926)', async () => {
+      const incoming = { ...createMockIncomingOrder(), placedAt: '2026-05-31T16:00:00.000Z' };
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-1', 'evt-1');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot['placedAt']).toBe('2026-05-31T16:00:00.000Z');
+    });
+
+    it('should omit placedAt from the raw snapshot when incoming does not carry it (#926)', async () => {
+      const incoming = createMockIncomingOrder();
+      expect(incoming.placedAt).toBeUndefined();
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-1', 'evt-1');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot).not.toHaveProperty('placedAt');
     });
 
     it('should sanitize addresses in snapshot when PII is disabled', async () => {

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -354,6 +354,7 @@ export class OrderIngestionService implements IOrderIngestionService {
       shipping: incoming.shipping,
       pickupPoint: incoming.pickupPoint,
       deliverySmart: incoming.deliverySmart,
+      placedAt: incoming.placedAt ? new Date(incoming.placedAt) : undefined,
       createdAt: new Date(incoming.createdAt),
       updatedAt: new Date(incoming.updatedAt),
     };

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -81,6 +81,10 @@ export class OrderRecordService implements IOrderRecordService {
       // did not supply the flag, so consumers can distinguish "Smart not
       // reported" from "Smart explicitly false".
       ...(order.deliverySmart !== undefined && { deliverySmart: order.deliverySmart }),
+      // Buyer-placed-on-marketplace time (#926) — absent when the source didn't
+      // expose one. Conditional spread keeps the key off the snapshot rather
+      // than emitting `undefined`.
+      ...(order.placedAt !== undefined && { placedAt: order.placedAt.toISOString() }),
       createdAt: order.createdAt.toISOString(),
       updatedAt: order.updatedAt.toISOString(),
     };
@@ -136,6 +140,8 @@ export class OrderRecordService implements IOrderRecordService {
       metadata: incoming.metadata,
       // See `persistOrder` above for the absent-vs-false rationale.
       ...(incoming.deliverySmart !== undefined && { deliverySmart: incoming.deliverySmart }),
+      // Buyer-placed-on-marketplace time (#926) — ISO string passed through verbatim.
+      ...(incoming.placedAt !== undefined && { placedAt: incoming.placedAt }),
     };
 
     const orderRecord = new OrderRecord(

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -74,6 +74,15 @@ export interface IncomingOrder {
   deliverySmart?: boolean;
 
   /**
+   * When the buyer placed the order on the source marketplace, as an ISO string
+   * (#926). For Allegro this is the earliest `lineItems[].boughtAt`; for
+   * PrestaShop it is `date_add`. Distinct from `createdAt`/`updatedAt` (OL
+   * ingestion clocks). Optional — adapters omit it when the source has no
+   * placed time. Adapters MUST only emit a valid ISO date string here.
+   */
+  placedAt?: string;
+
+  /**
    * ISO timestamps (strings) to keep DTO stable across runtimes.
    */
   createdAt: string;

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -111,6 +111,14 @@ export interface Order {
    * predating the Smart! program.
    */
   deliverySmart?: boolean;
+  /**
+   * When the buyer placed the order on the source marketplace (#926). Distinct
+   * from `createdAt`/`updatedAt`, which are OpenLinker's ingestion clocks — this
+   * is the operationally meaningful date for SLA and "how old is this order"
+   * judgments. Optional: absent for sources that don't expose a placed time and
+   * for records ingested before this field existed.
+   */
+  placedAt?: Date;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -99,7 +99,11 @@ export interface AllegroCheckoutForm {
     /** Allegro Smart! free-delivery flag. Ignored today. */
     smart?: boolean;
   };
-  createdAt?: string;
+  /**
+   * Last-revision timestamp of the checkout form (the only order-level date
+   * Allegro returns). NOT a placed/created time — the buyer-placed time lives
+   * on `lineItems[].boughtAt` (#926).
+   */
   updatedAt?: string;
 }
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -249,7 +249,6 @@ describe('AllegroOrderSourceAdapter', () => {
     it('should hydrate a full IncomingOrder from the checkout-form endpoint', async () => {
       const checkoutForm: AllegroCheckoutForm = {
         id: 'checkout-form-1',
-        createdAt: '2024-01-01T00:00:00Z',
         updatedAt: '2024-01-01T01:00:00Z',
         buyer: {
           id: 'buyer-1',
@@ -307,7 +306,6 @@ describe('AllegroOrderSourceAdapter', () => {
     it('should report pending status when the buyer has not yet completed payment', async () => {
       const checkoutForm: AllegroCheckoutForm = {
         id: 'checkout-2',
-        createdAt: '2024-01-02T00:00:00Z',
         updatedAt: '2024-01-02T00:00:00Z',
         buyer: { id: 'b2', email: 'b2@example.com', login: 'b2' },
         lineItems: [
@@ -331,7 +329,6 @@ describe('AllegroOrderSourceAdapter', () => {
     describe('totals — shipping cost (#454)', () => {
       const baseForm = (): AllegroCheckoutForm => ({
         id: 'cf',
-        createdAt: '2024-01-01T00:00:00Z',
         updatedAt: '2024-01-01T00:00:00Z',
         buyer: { id: 'b', email: 'b@e.com', login: 'b' },
         lineItems: [
@@ -416,10 +413,90 @@ describe('AllegroOrderSourceAdapter', () => {
       });
     });
 
+    describe('placedAt — buyer-placed time from lineItems[].boughtAt (#926)', () => {
+      const formWithBoughtAt = (boughtAts: Array<string | undefined>): AllegroCheckoutForm => ({
+        id: 'cf',
+        updatedAt: '2024-01-01T00:00:00Z',
+        buyer: { id: 'b', email: 'b@e.com', login: 'b' },
+        lineItems: boughtAts.map((boughtAt, i) => ({
+          id: `l${i}`,
+          offer: { id: `o${i}`, name: `O${i}` },
+          quantity: 1,
+          price: { amount: '10.00', currency: 'PLN' },
+          ...(boughtAt !== undefined && { boughtAt }),
+        })),
+        summary: { totalToPay: { amount: '10.00', currency: 'PLN' } },
+        payment: { type: 'ONLINE' },
+      });
+
+      it('should surface a single boughtAt as placedAt', async () => {
+        httpClient.get.mockResolvedValueOnce({
+          data: formWithBoughtAt(['2026-05-31T16:00:00.000Z']),
+          status: 200,
+          headers: {},
+        });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.placedAt).toBe('2026-05-31T16:00:00.000Z');
+      });
+
+      it('should pick the earliest boughtAt across line items', async () => {
+        httpClient.get.mockResolvedValueOnce({
+          data: formWithBoughtAt([
+            '2026-05-31T18:00:00.000Z',
+            '2026-05-31T16:00:00.000Z',
+            '2026-05-31T17:00:00.000Z',
+          ]),
+          status: 200,
+          headers: {},
+        });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.placedAt).toBe('2026-05-31T16:00:00.000Z');
+      });
+
+      it('should leave placedAt undefined when no line item carries boughtAt', async () => {
+        httpClient.get.mockResolvedValueOnce({
+          data: formWithBoughtAt([undefined, undefined]),
+          status: 200,
+          headers: {},
+        });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.placedAt).toBeUndefined();
+      });
+
+      it('should skip an unparseable boughtAt and use the earliest valid one', async () => {
+        httpClient.get.mockResolvedValueOnce({
+          data: formWithBoughtAt(['not-a-date', '2026-05-31T16:00:00.000Z']),
+          status: 200,
+          headers: {},
+        });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.placedAt).toBe('2026-05-31T16:00:00.000Z');
+      });
+
+      it('should leave placedAt undefined when every boughtAt is unparseable (no ingestion throw)', async () => {
+        httpClient.get.mockResolvedValueOnce({
+          data: formWithBoughtAt(['not-a-date', 'also-bad']),
+          status: 200,
+          headers: {},
+        });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.placedAt).toBeUndefined();
+      });
+    });
+
     describe('shippingAddress — delivery.address preference (#457)', () => {
       const baseForm = (): AllegroCheckoutForm => ({
         id: 'cf',
-        createdAt: '2024-01-01T00:00:00Z',
         updatedAt: '2024-01-01T00:00:00Z',
         buyer: {
           id: 'b',
@@ -533,7 +610,6 @@ describe('AllegroOrderSourceAdapter', () => {
     describe('shipping (#455)', () => {
       const baseForm = (): AllegroCheckoutForm => ({
         id: 'cf',
-        createdAt: '2024-01-01T00:00:00Z',
         updatedAt: '2024-01-01T00:00:00Z',
         buyer: {
           id: 'b',
@@ -581,7 +657,6 @@ describe('AllegroOrderSourceAdapter', () => {
     describe('pickupPoint (#458)', () => {
       const baseForm = (): AllegroCheckoutForm => ({
         id: 'cf',
-        createdAt: '2024-01-01T00:00:00Z',
         updatedAt: '2024-01-01T00:00:00Z',
         buyer: {
           id: 'b',
@@ -687,7 +762,6 @@ describe('AllegroOrderSourceAdapter', () => {
     describe('deliverySmart (#738)', () => {
       const baseForm = (): AllegroCheckoutForm => ({
         id: 'cf',
-        createdAt: '2024-01-01T00:00:00Z',
         updatedAt: '2024-01-01T00:00:00Z',
         buyer: {
           id: 'b',

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -238,8 +238,12 @@ export class AllegroOrderSourceAdapter
       const checkoutForm = response.data;
 
       const status = checkoutForm.payment.finishedAt ? 'processing' : 'pending';
-      const createdAt = checkoutForm.createdAt ?? new Date().toISOString();
+      // Allegro's checkout-form carries no order-level created timestamp, so
+      // `createdAt` is OpenLinker's ingestion time. The buyer-placed time lives
+      // on `lineItems[].boughtAt` and is surfaced separately as `placedAt` (#926).
+      const createdAt = new Date().toISOString();
       const updatedAt = checkoutForm.updatedAt ?? createdAt;
+      const placedAt = this.resolvePlacedAt(checkoutForm.lineItems);
 
       // #454 — split totals: derive subtotal from line items, shipping from
       // delivery.cost (or fallback). Previously we used `totalToPay` as both
@@ -288,6 +292,7 @@ export class AllegroOrderSourceAdapter
         shipping: this.resolveShipping(checkoutForm),
         pickupPoint: this.resolvePickupPoint(checkoutForm),
         deliverySmart: checkoutForm.delivery?.smart,
+        placedAt,
         createdAt,
         updatedAt,
         metadata: {
@@ -393,6 +398,35 @@ export class AllegroOrderSourceAdapter
       return undefined;
     }
     return { methodId: method.id, methodName: method.name };
+  }
+
+  /**
+   * Resolve the buyer-placed timestamp (#926) from the earliest valid
+   * `lineItems[].boughtAt` ("ISO date when offer was bought" — the field
+   * Allegro itself sorts orders by). The line items of one checkout form are
+   * bought together, so the earliest present value is the order-placed time.
+   *
+   * Unparseable / missing values are skipped so a malformed source value
+   * degrades to `undefined` rather than producing an Invalid Date that would
+   * throw downstream when the snapshot serializes it.
+   */
+  private resolvePlacedAt(lineItems: AllegroCheckoutForm['lineItems']): string | undefined {
+    let earliestMs: number | undefined;
+    let earliestIso: string | undefined;
+    for (const item of lineItems) {
+      if (typeof item.boughtAt !== 'string') {
+        continue;
+      }
+      const ms = Date.parse(item.boughtAt);
+      if (Number.isNaN(ms)) {
+        continue;
+      }
+      if (earliestMs === undefined || ms < earliestMs) {
+        earliestMs = ms;
+        earliestIso = item.boughtAt;
+      }
+    }
+    return earliestIso;
   }
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
@@ -146,6 +146,8 @@ describe('PrestashopOrderSourceAdapter', () => {
       expect(incoming.customerExternalId).toBe('7');
       expect(incoming.createdAt).toBe('2024-01-01 10:00:00');
       expect(incoming.updatedAt).toBe('2024-01-01 12:00:00');
+      // Buyer-placed time (#926) is PrestaShop `date_add`.
+      expect(incoming.placedAt).toBe('2024-01-01 10:00:00');
       expect(incoming.items).toHaveLength(1);
       expect(incoming.items[0].productRef).toEqual({ type: 'product', externalId: '5' });
     });

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
@@ -168,6 +168,10 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
       typeof prestashopOrder.date_upd === 'string'
         ? prestashopOrder.date_upd
         : mapped.updatedAt.toISOString();
+    // PrestaShop `date_add` is when the customer placed the order — the
+    // buyer-placed time (#926). Undefined when the source row omits it.
+    const placedAtIso =
+      typeof prestashopOrder.date_add === 'string' ? prestashopOrder.date_add : undefined;
 
     return {
       externalOrderId,
@@ -179,6 +183,7 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
       totals: mapped.totals,
       shippingAddress: mapped.shippingAddress as IncomingOrderAddress | undefined,
       billingAddress: mapped.billingAddress as IncomingOrderAddress | undefined,
+      placedAt: placedAtIso,
       createdAt: createdAtIso,
       updatedAt: updatedAtIso,
     };


### PR DESCRIPTION
## What & why

Thread a **buyer-placed-on-marketplace** timestamp end-to-end so the order surfaces lead with *when the buyer placed the order*, not when OpenLinker ingested it. Part of epic #925 (P1); unblocks the dispatch-SLA deadline (#927) and upgrades the "Placed" stand-in that #924 (detail) and #929/#932 (list) currently fill with ingestion time.

## Changes

- **Allegro** (`allegro-order-source.adapter.ts`) — derive `placedAt` from the **earliest valid `lineItems[].boughtAt`** (verified against `developer.allegro.pl/swagger.yaml`: `boughtAt` is *"ISO date when offer was bought"* and the field Allegro itself sorts orders by; the `CheckoutForm` has no order-level placed/created field). Parsing is **NaN-guarded** so a malformed source value degrades to absent rather than throwing during snapshot serialization. Also drops the **fictional** top-level `AllegroCheckoutForm.createdAt` (Allegro never returns it — the adapter always hit the `new Date()` ingestion fallback), which is now explicit.
- **PrestaShop** (`prestashop-order-source.adapter.ts`) — populate `placedAt` from `date_add` (the customer-placed time), for parity.
- **CORE** — optional `placedAt` on the `IncomingOrder` (ISO string) and `Order` (Date) contracts — **backward-compatible**, no existing adapter breaks. Carried through `buildUnifiedOrder` and written into **both** snapshot builders (`persistOrder` + `persistIncomingSnapshot`) via the absent-not-undefined conditional spread (same pattern as `deliverySmart` / `taxTreatment`).
- **No DTO change, no migration** — `placedAt` rides the existing `orderSnapshot` JSONB; the response DTO passes the snapshot verbatim.
- **Web** — parse `placedAt` in `ParsedOrderSnapshot`; the order-detail **header + Summary lead with "Placed"**, falling back to the record ingestion `createdAt` (not the vestigial `snapshot.createdAt`) and demoting Received/Updated to OpenLinker-processing clocks.

### Scope notes
- **Detail page only** for the lead-with-placed FE change. The `/orders` list keeps its honest `createdAt` column — a server-sortable "Placed" column needs an `orderSnapshot->>'placedAt'` sort (deferred follow-up); displaying placed-at while sorting by ingestion would be a misleading affordance.
- Buyer-note / source-status fold-ins were kept out of the typed contract (not rendered yet).
- Removing the fictional `AllegroCheckoutForm.createdAt` is a deliberate honesty fix, flagged here so it doesn't read as scope creep.

## Tests

- **Allegro adapter** (5 cases): single `boughtAt` → `placedAt`; earliest-of-many; none → undefined; unparseable skipped; all-unparseable → undefined (no ingestion throw).
- **PrestaShop adapter**: `date_add` → `placedAt`.
- **CORE**: `order-record.service` snapshot serialization (present/absent, both builders); `order-ingestion.service` proves `incoming.placedAt → Order.placedAt` as a `Date` through `buildUnifiedOrder` (present/absent).
- **Web**: `ParsedOrderSnapshot` parse (present / absent / wrong-typed); detail header + Summary lead-with-placed and fallback-to-received.
- Full `pnpm lint` · `pnpm type-check` · `pnpm test` green (core 985, allegro 502, prestashop 366, api 429, web 164 files, worker 154, …). The carrier-mapping fixture now carries a realistic `placedAt` through a real ingestion path.

## How to test

`pnpm --filter @openlinker/core test` / `@openlinker/integrations-allegro` / `@openlinker/web`. Visit `/orders/:id` for an Allegro order → header leads with "Placed …"; for a record without a placed time it falls back to "Received".

> ⚠️ **Integration suite note:** the order-ingestion + carrier-mapping int-spec exercises a real PrestaShop testcontainer (CI-gated module-install path). Locally it timed out at **container boot** (resource contention with the running dev stack) — not a code failure; the end-to-end wiring is unit-proven and CI runs the suite.

Closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)