### PR TITLE
feat(orders,allegro,web): dispatch SLA / ship-by deadline + countdown (#927)

### DIFF
--- a/apps/api/src/migrations/1799000000009-add-order-dispatch-by-at.ts
+++ b/apps/api/src/migrations/1799000000009-add-order-dispatch-by-at.ts
@@ -1,0 +1,32 @@
+/**
+ * Add order_records.dispatchByAt + index (#927)
+ *
+ * Persists the derived marketplace dispatch (ship-by) deadline — the `.to` of
+ * the source dispatch window (Allegro `delivery.time.dispatch`) — denormalized
+ * from the JSONB snapshot to a top-level, indexed column so the orders list can
+ * sort by SLA and filter "breaching / overdue" without parsing JSONB per row.
+ *
+ * Additive + nullable → backward-compatible: existing rows get NULL (no
+ * dispatch SLA known) and degrade gracefully (no countdown). Re-derived on
+ * every persist, so a re-pulled order with a changed window updates it.
+ * `down()` drops the index then the column.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderDispatchByAt1799000000009 implements MigrationInterface {
+  name = 'AddOrderDispatchByAt1799000000009';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "order_records" ADD "dispatchByAt" TIMESTAMP WITH TIME ZONE`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_order_records_dispatchByAt" ON "order_records" ("dispatchByAt")`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_order_records_dispatchByAt"`);
+    await queryRunner.query(`ALTER TABLE "order_records" DROP COLUMN "dispatchByAt"`);
+  }
+}

--- a/apps/api/src/orders/http/dto/list-orders-query.dto.ts
+++ b/apps/api/src/orders/http/dto/list-orders-query.dto.ts
@@ -21,8 +21,14 @@ import {
   OrderSyncStatusFilterValues,
   OrderRecordStatusValues,
   OrderHealthValues,
+  OrderRecordSortValues,
 } from '@openlinker/core/orders';
-import { OrderSyncStatusFilter, OrderRecordStatus, OrderHealth } from '@openlinker/core/orders';
+import {
+  OrderSyncStatusFilter,
+  OrderRecordStatus,
+  OrderHealth,
+  OrderRecordSort,
+} from '@openlinker/core/orders';
 
 export class ListOrdersQueryDto {
   @ApiPropertyOptional({ description: 'Filter by source connection ID (UUID)' })
@@ -78,6 +84,23 @@ export class ListOrdersQueryDto {
   @IsOptional()
   @IsEnum(OrderHealthValues)
   health?: OrderHealth;
+
+  @ApiPropertyOptional({
+    enum: OrderRecordSortValues,
+    description:
+      'Result ordering (#927). "createdAt" (default) = newest first; "dispatchBy" = ship-by deadline ascending (soonest first, NULLs last) — the triage default on the orders list.',
+  })
+  @IsOptional()
+  @IsEnum(OrderRecordSortValues)
+  sort?: OrderRecordSort;
+
+  @ApiPropertyOptional({
+    description:
+      'Dispatch-SLA filter (#927): keep only orders with a known ship-by deadline at or before this instant (ISO 8601). Pass `now` for overdue, `now + window` for "breaching soon".',
+  })
+  @IsOptional()
+  @IsDateString()
+  dueBefore?: string;
 
   @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
   @IsOptional()

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -56,4 +56,13 @@ export class OrderRecordResponseDto {
 
   @ApiProperty({ description: 'Order last-update timestamp (ISO 8601)' })
   updatedAt!: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'Marketplace dispatch (ship-by) deadline (ISO 8601), derived from the source dispatch window (#927). ' +
+      'null when the source exposes no dispatch SLA. Surfaced top-level so the list SLA column / sort / filter ' +
+      'and the detail countdown read it without parsing the snapshot.',
+  })
+  dispatchByAt!: string | null;
 }

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -220,6 +220,47 @@ describe('OrdersController', () => {
         { limit: 20, offset: 0 }
       );
     });
+
+    it('should pass the dispatch-SLA sort and dueBefore filter through to the repository (#927)', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.listOrders({
+        sort: 'dispatchBy',
+        dueBefore: '2026-06-01T12:00:00Z',
+        limit: 20,
+        offset: 0,
+      });
+
+      expect(repository.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sort: 'dispatchBy',
+          dueBefore: new Date('2026-06-01T12:00:00Z'),
+        }),
+        { limit: 20, offset: 0 }
+      );
+    });
+
+    it('should serialize dispatchByAt as an ISO string, or null when absent (#927)', async () => {
+      const orderWithDeadline = new OrderRecord(
+        'ol_order_sla',
+        null,
+        'conn-source-001',
+        null,
+        {},
+        [],
+        'ready',
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-04-01T00:00:00Z'),
+        [],
+        new Date('2026-04-02T16:00:00Z')
+      );
+      repository.findMany.mockResolvedValue({ items: [orderWithDeadline, mockOrder], total: 2 });
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(result.items[0].dispatchByAt).toBe('2026-04-02T16:00:00.000Z');
+      expect(result.items[1].dispatchByAt).toBeNull();
+    });
   });
 
   describe('statusSummary', () => {

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -76,6 +76,8 @@ export class OrdersController {
       createdTo,
       recordStatus,
       health,
+      sort,
+      dueBefore,
       limit = 20,
       offset = 0,
     } = query;
@@ -89,6 +91,8 @@ export class OrdersController {
         createdTo: createdTo ? new Date(createdTo) : undefined,
         recordStatus,
         health,
+        sort,
+        dueBefore: dueBefore ? new Date(dueBefore) : undefined,
       },
       { limit, offset }
     );
@@ -201,6 +205,7 @@ export class OrdersController {
       recordStatus: order.recordStatus,
       createdAt: order.createdAt instanceof Date ? order.createdAt.toISOString() : order.createdAt,
       updatedAt: order.updatedAt instanceof Date ? order.updatedAt.toISOString() : order.updatedAt,
+      dispatchByAt: order.dispatchByAt ? order.dispatchByAt.toISOString() : null,
     };
   }
 

--- a/apps/api/test/integration/order-dispatch-sla.int-spec.ts
+++ b/apps/api/test/integration/order-dispatch-sla.int-spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Order Dispatch-SLA Integration Test (#927)
+ *
+ * Exercises the real `OrderRecordRepository` against Testcontainers Postgres for
+ * the ship-by deadline column: the `dispatchBy` sort (ascending, NULLs last),
+ * the `dueBefore` "breaching / overdue" filter, and recompute-on-re-pull (an
+ * upsert with a changed deadline updates the indexed column — the #904/#906/#909
+ * reconcile path stays fresh).
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+import { createTestOrderRecord } from './fixtures/order.fixtures';
+import {
+  ORDER_RECORD_REPOSITORY_TOKEN,
+  OrderRecord,
+  OrderRecordRepositoryPort,
+} from '@openlinker/core/orders';
+
+const SOURCE = '11111111-1111-4111-8111-111111111111';
+const PAGE = { limit: 50, offset: 0 };
+
+describe('Order dispatch SLA (integration)', () => {
+  let harness: IntegrationTestHarness;
+  let repository: OrderRecordRepositoryPort;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    repository = harness.getApp().get<OrderRecordRepositoryPort>(ORDER_RECORD_REPOSITORY_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('sorts by dispatchBy ascending with NULL deadlines last', async () => {
+    const ds = harness.getDataSource();
+    const late = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      dispatchByAt: new Date('2026-06-03T12:00:00Z'),
+    });
+    const noDeadline = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      dispatchByAt: null,
+    });
+    const soon = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      dispatchByAt: new Date('2026-06-01T12:00:00Z'),
+    });
+
+    const { items } = await repository.findMany({ sort: 'dispatchBy' }, PAGE);
+
+    expect(items.map((o) => o.internalOrderId)).toEqual([
+      soon.internalOrderId, // earliest deadline first
+      late.internalOrderId,
+      noDeadline.internalOrderId, // NULLs last
+    ]);
+  });
+
+  it('filters by dueBefore — only known deadlines at or before the cutoff', async () => {
+    const ds = harness.getDataSource();
+    const overdue = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      dispatchByAt: new Date('2026-06-01T08:00:00Z'),
+    });
+    await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      dispatchByAt: new Date('2026-06-05T08:00:00Z'), // after cutoff — excluded
+    });
+    await createTestOrderRecord(ds, { sourceConnectionId: SOURCE, dispatchByAt: null }); // excluded
+
+    const { items, total } = await repository.findMany(
+      { dueBefore: new Date('2026-06-02T00:00:00Z') },
+      PAGE
+    );
+
+    expect(total).toBe(1);
+    expect(items[0].internalOrderId).toBe(overdue.internalOrderId);
+  });
+
+  it('updates dispatchByAt on re-pull (upsert with a changed deadline)', async () => {
+    const seeded = await createTestOrderRecord(harness.getDataSource(), {
+      sourceConnectionId: SOURCE,
+      dispatchByAt: new Date('2026-06-01T12:00:00Z'),
+    });
+
+    // Re-pull: same PK, new deadline (the source moved the dispatch window).
+    const rePulled = new OrderRecord(
+      seeded.internalOrderId,
+      null,
+      SOURCE,
+      null,
+      { dispatchTime: { to: '2026-06-02T18:00:00Z' } },
+      [],
+      'ready',
+      new Date(),
+      new Date(),
+      [],
+      new Date('2026-06-02T18:00:00Z')
+    );
+    await repository.upsert(rePulled);
+
+    const found = await repository.findById(seeded.internalOrderId);
+    expect(found?.dispatchByAt?.toISOString()).toBe('2026-06-02T18:00:00.000Z');
+  });
+});

--- a/apps/web/src/features/orders/api/orders.api.ts
+++ b/apps/web/src/features/orders/api/orders.api.ts
@@ -39,6 +39,8 @@ function buildQuery(filters?: OrderFilters, pagination?: OrderPagination): strin
   if (filters?.createdTo) params.set('createdTo', filters.createdTo);
   if (filters?.recordStatus) params.set('recordStatus', filters.recordStatus);
   if (filters?.health) params.set('health', filters.health);
+  if (filters?.sort) params.set('sort', filters.sort);
+  if (filters?.dueBefore) params.set('dueBefore', filters.dueBefore);
   if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
   if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
   const qs = params.toString();

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -59,7 +59,20 @@ export interface OrderRecord {
   recordStatus: OrderRecordStatusValue;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Marketplace dispatch (ship-by) deadline (ISO 8601) or null (#927). Surfaced
+   * top-level by the BE (derived from the source dispatch window) so the list
+   * SLA column / sort / filter and the detail countdown read it without parsing
+   * the snapshot. Optional on the FE contract (mirrors the BE
+   * `@ApiPropertyOptional`) so older/absent payloads degrade gracefully.
+   */
+  dispatchByAt?: string | null;
 }
+
+// Result ordering for the orders list (#927). Mirrors `OrderRecordSortValues`
+// in `@openlinker/core/orders`. `dispatchBy` = ship-by ascending (triage default).
+export const OrderSortValues = ['createdAt', 'dispatchBy'] as const;
+export type OrderSortValue = (typeof OrderSortValues)[number];
 
 // Derived order-health buckets (#929). Hand-mirrored from `OrderHealthValues`
 // in `@openlinker/core/orders` per the FE-001 contract strategy — keep in sync.
@@ -95,6 +108,10 @@ export interface OrderFilters {
   recordStatus?: OrderRecordStatusValue;
   /** Filter to a single derived health bucket (#929). */
   health?: OrderHealthValue;
+  /** Result ordering (#927); `dispatchBy` = ship-by ascending (triage default). */
+  sort?: OrderSortValue;
+  /** SLA "breaching / overdue" filter (#927): ISO instant; keeps orders with a ship-by deadline ≤ this. */
+  dueBefore?: string;
 }
 
 /**

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -21,6 +21,7 @@ import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useToast } from '../../shared/ui/toast-provider';
+import { formatShipBy, type ShipByLevel } from '../../shared/format/format-ship-by';
 import { useOrderQuery } from '../../features/orders/hooks/use-order-query';
 import { useRetryOrderDestinationMutation } from '../../features/orders/hooks/use-retry-order-destination-mutation';
 import type { OrderSyncStatusValue } from '../../features/orders/api/orders.types';
@@ -45,6 +46,13 @@ const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
   syncing: 'warning',
   synced: 'success',
   failed: 'error',
+};
+
+/** Ship-by urgency level (#927) → StatusBadge tone. */
+const SHIP_BY_TONE: Record<ShipByLevel, StatusBadgeTone> = {
+  ok: 'info',
+  soon: 'warning',
+  overdue: 'error',
 };
 
 export function OrderDetailPage(): ReactElement {
@@ -121,6 +129,7 @@ export function OrderDetailPage(): ReactElement {
     connections.find((c) => c.id === order.sourceConnectionId)?.platformType ?? null;
 
   // Internal ID is the header copy-chip; not duplicated here.
+  const shipByView = formatShipBy(order.dispatchByAt ?? null);
   const summaryItems: KeyValueItem[] = [
     ...(snapshot.orderNumber
       ? [{ id: 'orderNumber', label: 'Order #', value: snapshot.orderNumber, mono: true }]
@@ -141,6 +150,23 @@ export function OrderDetailPage(): ReactElement {
       : []),
     { id: 'createdAt', label: 'Received (OL)', value: <TimeDisplay iso={order.createdAt} format="datetime" /> },
     { id: 'updatedAt', label: 'Updated (OL)', value: <TimeDisplay iso={order.updatedAt} format="datetime" /> },
+    // Dispatch SLA countdown (#927) — the ship-by deadline + urgency badge.
+    ...(order.dispatchByAt && shipByView
+      ? [
+          {
+            id: 'shipBy',
+            label: 'Ship by',
+            value: (
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+                <TimeDisplay iso={order.dispatchByAt} format="datetime" />
+                <StatusBadge tone={SHIP_BY_TONE[shipByView.level]} withDot compact>
+                  {shipByView.remaining}
+                </StatusBadge>
+              </span>
+            ),
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -330,4 +330,54 @@ describe('OrdersListPage', () => {
       expect(statusSummary.mock.calls.length).toBeGreaterThan(summaryBaseline);
     });
   });
+
+  it('should default the list query to the dispatchBy (ship-by) sort (#927)', async () => {
+    const list = vi.fn().mockResolvedValue(paginated([syncedOrder]));
+    const mockApi = createMockApiClient({ orders: { list } });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: 'dispatchBy' }),
+      expect.anything(),
+    );
+  });
+
+  it('should render a Ship-by countdown for an order with a deadline, and "—" without (#927)', async () => {
+    const withDeadline: OrderRecord = {
+      ...syncedOrder,
+      internalOrderId: 'ol_order_sla',
+      orderSnapshot: { ...syncedOrder.orderSnapshot, orderNumber: 'ALG-SLA' },
+      dispatchByAt: '2030-01-01T00:00:00.000Z', // far future → deterministic "Nd left"
+    };
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([withDeadline])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-SLA');
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+    expect(within(row).getByText(/left$/)).toBeInTheDocument();
+  });
+
+  it('should set the dueBefore filter when the breaching/overdue chip is clicked (#927)', async () => {
+    const user = userEvent.setup();
+    const list = vi.fn().mockResolvedValue(paginated([syncedOrder]));
+    const mockApi = createMockApiClient({ orders: { list } });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    await user.click(screen.getByRole('button', { name: /Ship-by/i }));
+
+    await vi.waitFor(() => {
+      const calledWithDue = list.mock.calls.some(
+        ([filters]) => typeof (filters as { dueBefore?: string } | undefined)?.dueBefore === 'string',
+      );
+      expect(calledWithDue).toBe(true);
+    });
+  });
 });

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -9,9 +9,10 @@
  * — a dense `DataTable` whose rows lead with human identity (`EntityLabel`),
  *   surface customer + contents (parsed from `orderSnapshot`), the source→
  *   destination channel, one reconciled health `StatusBadge` (`deriveOrderHealth`,
- *   replacing the per-destination list and the blank "—"), an honest "Created"
- *   time, ghost Ship-by / Payment columns (capture-gap epic #925), and an inline
- *   Retry for failed rows;
+ *   replacing the per-destination list and the blank "—"), a "Created" time, a
+ *   **Ship-by** SLA countdown (#927; server-sorted soonest-first, with a
+ *   "breaching ≤24h / overdue" filter chip), a ghost Payment column (#928), and
+ *   an inline Retry for failed rows;
  * — loading / error / empty (incl. all-clear) states via shared feedback prims.
  *
  * Pure presentation — all data flows through feature query hooks; no transport
@@ -23,15 +24,16 @@ import { useEffect, useMemo, type ReactElement } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
-import { useTableSort } from '../../shared/ui/use-table-sort';
 import { ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { DataTableSkeleton } from '../../shared/ui/data-table-skeleton';
 import { Button } from '../../shared/ui/button';
+import { Chip } from '../../shared/ui/chip';
 import { TimeDisplay } from '../../shared/ui/time-display';
-import { StatusBadge } from '../../shared/ui/status-badge';
+import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { MetricCard, type MetricCardTone } from '../../shared/ui/metric-card';
 import { EntityLabel } from '../../shared/ui/entity-label';
 import { useToast } from '../../shared/ui/toast-provider';
+import { formatShipBy, type ShipByLevel } from '../../shared/format/format-ship-by';
 import { useTranslation, getBcp47Locale } from '../../shared/i18n';
 import type { LocaleCode } from '../../shared/i18n';
 import { useOrdersQuery } from '../../features/orders/hooks/use-orders-query';
@@ -84,6 +86,16 @@ function isOrderHealth(value: string | null): value is OrderHealthValue {
   return value !== null && (OrderHealthValues as readonly string[]).includes(value);
 }
 
+/** Map the neutral ship-by urgency level (#927) to a StatusBadge tone. */
+const SHIP_BY_TONE: Record<ShipByLevel, StatusBadgeTone> = {
+  ok: 'info',
+  soon: 'warning',
+  overdue: 'error',
+};
+
+/** "Breaching soon" window — surface orders due within this horizon (or overdue). */
+const BREACHING_WINDOW_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Resolve the per-row total via the i18n seam (#612). Currency varies per row
  * so we instantiate per call; locale comes from the LocaleProvider.
@@ -124,18 +136,29 @@ function formatFreshness(items: readonly OrderRecord[], locale: LocaleCode): str
 
 export function OrdersListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { sort, setSort } = useTableSort([{ id: 'createdAt', desc: true }]);
   const { locale } = useTranslation();
   const { showToast } = useToast();
 
   const rawHealth = searchParams.get('health');
   const health = isOrderHealth(rawHealth) ? rawHealth : undefined;
   const sourceConnectionId = searchParams.get('sourceConnectionId') ?? undefined;
+  const breaching = searchParams.get('due') === 'breaching';
   const offset = Number(searchParams.get('offset') ?? '0');
+
+  // "Breaching soon / overdue" cutoff — stable per toggle (not recomputed each
+  // render) so the query key doesn't churn. `now + 24h` catches overdue too.
+  const dueBefore = useMemo(
+    () => (breaching ? new Date(Date.now() + BREACHING_WINDOW_MS).toISOString() : undefined),
+    [breaching],
+  );
 
   const filters: OrderFilters = {
     health,
     sourceConnectionId: sourceConnectionId || undefined,
+    // Server-backed triage default: soonest ship-by first (NULLs last). The
+    // only sort on this list — kept coherent (no client-page-sorted columns).
+    sort: 'dispatchBy',
+    dueBefore,
   };
   const pagination = { limit: PAGE_SIZE, offset };
 
@@ -260,15 +283,27 @@ export function OrdersListPage(): ReactElement {
       {
         id: 'shipBy',
         header: 'Ship-by',
-        cell: () => <span className="orders-ghost" title="Dispatch SLA — arrives with #927">soon</span>,
-        hideBelow: 1024,
+        cell: (order) => {
+          const due = order.dispatchByAt ?? null;
+          const view = formatShipBy(due);
+          if (!due || !view) return <span className="text-muted">—</span>;
+          return (
+            <span className="orders-cell-stack">
+              <StatusBadge tone={SHIP_BY_TONE[view.level]} withDot compact>
+                {view.remaining}
+              </StatusBadge>
+              <span className="text-muted orders-cell-sub">
+                <TimeDisplay iso={due} format="date" />
+              </span>
+            </span>
+          );
+        },
+        hideBelow: 768,
       },
       {
         id: 'createdAt',
         header: 'Created',
         cell: (order) => <TimeDisplay iso={order.createdAt} format="relative" />,
-        accessor: (order) => order.createdAt,
-        sortable: true,
       },
       {
         id: 'payment',
@@ -341,6 +376,19 @@ export function OrdersListPage(): ReactElement {
         p.set('health', next);
       } else {
         p.delete('health');
+      }
+      p.delete('offset');
+      return p;
+    });
+  }
+
+  function toggleBreaching(): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (breaching) {
+        p.delete('due');
+      } else {
+        p.set('due', 'breaching');
       }
       p.delete('offset');
       return p;
@@ -439,6 +487,9 @@ export function OrdersListPage(): ReactElement {
       </div>
 
       <div className="ds-row" style={{ gap: 'var(--space-2)', flexWrap: 'wrap' }}>
+        <Chip tone="warning" active={breaching} onClick={toggleBreaching}>
+          Ship-by ≤ 24h / overdue
+        </Chip>
         {query.data && (
           <span
             className="text-muted mono tabular"
@@ -492,8 +543,6 @@ export function OrdersListPage(): ReactElement {
             rows={query.data?.items ?? []}
             rowKey={(order) => order.internalOrderId}
             rowHref={(order) => order.internalOrderId}
-            sort={sort}
-            onSortChange={setSort}
             cardView={{
               title: (order) => {
                 const parsed = parseOrderSnapshot(order.orderSnapshot);
@@ -508,6 +557,7 @@ export function OrdersListPage(): ReactElement {
               meta: (order) => {
                 const h = deriveOrderHealth(order);
                 const source = channelLabel(platformByConnection.get(order.sourceConnectionId));
+                const shipBy = formatShipBy(order.dispatchByAt ?? null);
                 const failed = order.syncStatus.find((s) => s.status === 'failed');
                 const isRetrying =
                   retryMutation.isPending &&
@@ -525,6 +575,11 @@ export function OrdersListPage(): ReactElement {
                     <StatusBadge tone={h.tone} withDot compact>
                       {h.label}
                     </StatusBadge>
+                    {shipBy && (
+                      <StatusBadge tone={SHIP_BY_TONE[shipBy.level]} withDot compact>
+                        {shipBy.remaining}
+                      </StatusBadge>
+                    )}
                     {failed && order.recordStatus !== 'awaiting_mapping' ? (
                       <Button
                         tone="ghost"

--- a/apps/web/src/shared/format/format-ship-by.test.ts
+++ b/apps/web/src/shared/format/format-ship-by.test.ts
@@ -1,0 +1,53 @@
+/**
+ * formatShipBy tests (#927) — deterministic against an explicit `now`.
+ */
+import { describe, expect, it } from 'vitest';
+import { formatShipBy } from './format-ship-by';
+
+const NOW = new Date('2026-06-01T12:00:00.000Z');
+
+describe('formatShipBy', () => {
+  it('returns null for a missing or unparseable deadline', () => {
+    expect(formatShipBy(null, NOW)).toBeNull();
+    expect(formatShipBy('not-a-date', NOW)).toBeNull();
+  });
+
+  it('is "ok" with days remaining when the deadline is far out', () => {
+    const result = formatShipBy('2026-06-03T12:00:00.000Z', NOW);
+    expect(result).toEqual({ level: 'ok', remaining: '2d left' });
+  });
+
+  it('is "soon" within the 24h threshold (hours)', () => {
+    const result = formatShipBy('2026-06-01T15:00:00.000Z', NOW);
+    expect(result).toEqual({ level: 'soon', remaining: '3h left' });
+  });
+
+  it('treats exactly 24h out as "soon"', () => {
+    expect(formatShipBy('2026-06-02T12:00:00.000Z', NOW)?.level).toBe('soon');
+  });
+
+  it('treats just over 24h out as "ok"', () => {
+    expect(formatShipBy('2026-06-02T12:00:00.001Z', NOW)?.level).toBe('ok');
+  });
+
+  it('reports minutes when under an hour', () => {
+    expect(formatShipBy('2026-06-01T12:45:00.000Z', NOW)).toEqual({
+      level: 'soon',
+      remaining: '45m left',
+    });
+  });
+
+  it('is "overdue" with magnitude when past the deadline', () => {
+    expect(formatShipBy('2026-06-01T08:00:00.000Z', NOW)).toEqual({
+      level: 'overdue',
+      remaining: 'Overdue 4h',
+    });
+  });
+
+  it('says "due now" at the exact deadline', () => {
+    expect(formatShipBy('2026-06-01T12:00:00.000Z', NOW)).toEqual({
+      level: 'overdue',
+      remaining: 'due now',
+    });
+  });
+});

--- a/apps/web/src/shared/format/format-ship-by.ts
+++ b/apps/web/src/shared/format/format-ship-by.ts
@@ -1,0 +1,55 @@
+/**
+ * Ship-by (dispatch SLA) formatting (#927)
+ *
+ * Pure, deterministic countdown for the marketplace dispatch deadline. Returns
+ * a neutral urgency `level` (the page maps it to a StatusBadge tone, so this
+ * stays free of any `shared/ui` dependency) plus a short `remaining` phrase.
+ * Returns `null` when there is no (or an unparseable) deadline — callers render
+ * nothing, never a false countdown.
+ *
+ * @module shared/format
+ */
+
+/** Urgency buckets for the ship-by deadline. `soon` is the warning threshold. */
+export const ShipByLevelValues = ['ok', 'soon', 'overdue'] as const;
+export type ShipByLevel = (typeof ShipByLevelValues)[number];
+
+export interface ShipByView {
+  level: ShipByLevel;
+  /** Short phrase: e.g. "1d left", "3h left", "Overdue 4h", "due now". */
+  remaining: string;
+}
+
+/** Hours within which the deadline is considered "breaching soon" (warning). */
+const SOON_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+/** Largest-unit magnitude of a non-negative duration: "2d" / "5h" / "12m". */
+function humanizeDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60_000);
+  const days = Math.floor(totalMinutes / (60 * 24));
+  if (days >= 1) return `${days}d`;
+  const hours = Math.floor(totalMinutes / 60);
+  if (hours >= 1) return `${hours}h`;
+  return `${totalMinutes}m`;
+}
+
+/**
+ * Format the ship-by deadline relative to `now`. `dueAtIso` null/invalid → null.
+ */
+export function formatShipBy(dueAtIso: string | null, now: Date = new Date()): ShipByView | null {
+  if (!dueAtIso) return null;
+  const dueMs = new Date(dueAtIso).getTime();
+  if (Number.isNaN(dueMs)) return null;
+
+  const diff = dueMs - now.getTime();
+  if (diff <= 0) {
+    return {
+      level: 'overdue',
+      remaining: diff === 0 ? 'due now' : `Overdue ${humanizeDuration(-diff)}`,
+    };
+  }
+  return {
+    level: diff <= SOON_THRESHOLD_MS ? 'soon' : 'ok',
+    remaining: `${humanizeDuration(diff)} left`,
+  };
+}

--- a/docs/plans/implementation-plan-dispatch-sla-ship-by.md
+++ b/docs/plans/implementation-plan-dispatch-sla-ship-by.md
@@ -1,0 +1,68 @@
+# Implementation Plan — Dispatch SLA / ship-by deadline + countdown (#927)
+
+Part of the #925 capture-gap epic. **P0.** Lights up the ghost **Ship-by** column shipped on the #929 orders list and adds a countdown to the order detail.
+
+## 1. Goal & layer
+
+Give operators the single highest-value number in a marketplace ops console: **when an order must ship**. Capture the marketplace dispatch deadline, persist it, expose it on the order contract, and surface it as a countdown (detail) + an SLA sort and a "breaching / overdue" filter (list).
+
+- **Layers:** Integration (Allegro adapter) → CORE (IncomingOrder, snapshot, order-record column + migration, repository sort/filter) → Interface (controller query params + DTO) → Frontend (countdown chip, list column + server sort + filter chip).
+
+## 2. Key research finding (drives the design)
+
+The issue assumed `ship-by = buyer-placed-at + handling-time` (hence "depends on #926"). **Verified against developer.allegro.pl: Allegro's order checkout-form exposes the dispatch window directly** as `delivery.time.dispatch.{from,to}` — absolute ISO-8601 timestamps, populated for **all** delivery methods. (Refs: developer.allegro.pl news "wprowadzimy czas dostawy i wysyłki" and "gwarantowany czas dostawy w sekcji delivery".)
+
+**Decisions that follow:**
+- The ship-by deadline = **`delivery.time.dispatch.to`** — a source-authoritative absolute timestamp. We capture it directly; we do **not** derive it from placedAt + handlingTime.
+- **#927 is therefore independent of #926** — no cross-dependency on the buyer-placed timestamp. (#926 still improves the "Placed" column separately.)
+- No ISO-8601 duration parser needed.
+- Graceful: if `delivery.time.dispatch` is absent (older records, non-Allegro sources) → no deadline → no countdown, no false SLA. (Satisfies the AC.)
+
+## 3. Persist vs compute (decision: **persist** an indexed column)
+
+The deadline is an absolute timestamp independent of "now", and the issue's payoff is **list-level sort + filter**. Persisting a top-level `dispatch_by_at timestamptz null` column (indexed) enables server-side `ORDER BY` and "due before / overdue" `WHERE` without per-row JSONB parsing. Compute-on-read can't be indexed for a global sort. → **Persist** + keep the full dispatch window in the snapshot for fidelity.
+
+## 4. Steps
+
+### Integration — Allegro
+- `allegro-api.types.ts`: extend `AllegroCheckoutForm.delivery` with `time?: { from?; to?; dispatch?: { from?; to? }; guaranteed?: {...} }` (only what we read).
+- `allegro-order-source.adapter.ts` `getOrder()`: map `checkoutForm.delivery.time.dispatch` → `IncomingOrder.dispatchTime` (window). Unit-test the mapping with a fixture carrying the dispatch window.
+
+### CORE — contract + persistence
+- `incoming-order.types.ts`: add `dispatchTime?: { from?: string; to?: string }` (ISO timestamps; the SLA deadline is `.to`).
+- `order.types.ts`: carry `dispatchTime?` through the resolved `Order` if needed for snapshot rebuild.
+- `order-record.service.ts`: include `dispatchTime` in the snapshot; compute the scalar `dispatchByAt = dispatchTime?.to` for the column.
+- `order-record.orm-entity.ts`: add `@Column({ type: 'timestamptz', nullable: true }) @Index() dispatchByAt!: Date | null`. **Migration** (`apps/api/src/migrations/`, follow docs/migrations.md; run `migration:show`).
+- `order-record.types.ts` (`OrderRecordFilters`): add `dueBefore?: Date` and `overdue?: boolean`; add a sort option. `order-record-repository.port.ts` + repository: support `ORDER BY dispatchByAt` (nulls last) and the due/overdue predicate; populate `dispatchByAt` in `upsert`/`persist` mapping + `toDomain`.
+
+### Interface
+- `list-orders-query.dto.ts`: add `sort` (allow `dispatchBy`) + `dueBefore` / `overdue` (validated). Controller maps to filters.
+- `OrderRecordResponseDto`: expose `dispatchByAt: string | null` (top-level, alongside createdAt) so the FE doesn't parse the snapshot for the hot path.
+
+### Frontend
+- `orders.types.ts`: add `dispatchByAt: string | null` to `OrderRecord`.
+- New `shared/format/format-countdown.ts` (+ test): `formatShipBy(dueAtIso, now)` → `{ label: "Ship by 02 Jun · 1d left" | "Overdue 4h", tone: 'success'|'warning'|'error' }`. Thresholds via status tokens (e.g. ≤24h → warning, past due → error).
+- Order **detail**: a ship-by summary chip (countdown), tone-shifting.
+- Orders **list** (#929 page): populate the **Ship-by** column (replace the ghost) with the countdown; wire **server-side default sort by `dispatchBy`** and a "Breaching soon / Overdue" filter chip (URL-state). This is the first server-sorted column on the list — the prior columns are client-page-sorted; `dispatchBy` sorts via the new query param so it orders the whole set.
+
+## 4a. Review adjustments applied (tech-review, before Phase 4)
+- **Boundary held:** Allegro `delivery.time` typing stays in the allegro package; CORE gains only the neutral `dispatchTime` / `dispatchByAt`. No `platformType` branching anywhere; neutral names only.
+- **Coherent sort model:** `dispatchBy` is the **server-backed default sort** (asc = soonest first, nulls last). To avoid a silent client-page-sort vs server-global-sort split, **`dispatchBy` is the only sortable column** in this PR — `Created` loses its client sort caret. The sortable header maps to a `sort` URL param that drives the query (the column carries no client accessor, so the server order governs).
+- **Recompute-on-re-pull:** `dispatchByAt` is written in the same snapshot mapping on **both** insert and update, so the #904/#906/#909 re-pull path keeps it fresh. Integration test asserts a changed dispatch window updates the column.
+- **`dispatch` not `guaranteed`:** read `delivery.time.dispatch.to` (all methods); ignore the deprecated Kurier-X-press-only `delivery.time.guaranteed`. Fixture-backed mapping test.
+- **Window captured, scalar derived once:** `IncomingOrder.dispatchTime = { from, to }`; `dispatchByAt = .to` derived a single time in the core service; FE/DTO hot path uses the top-level scalar (no snapshot parse).
+- **Strict typing:** type the extended `AllegroCheckoutForm.delivery.time` (no `any`); expose `dispatchByAt` top-level on `OrderRecordResponseDto`.
+
+## 5. Tests
+- Unit: Allegro `getOrder` dispatch-window mapping; `format-countdown` thresholds (future / <24h / overdue / unknown→none); FE list (Ship-by renders, SLA sort sets the query param, overdue filter).
+- Integration (`*.int-spec.ts`): repository `dispatchByAt` sort (nulls last) + due/overdue filter against real Postgres; full `pnpm test:integration` (order-ingestion + carrier-mapping + fulfillment) green.
+
+## 6. Non-goals
+- Buyer-placed timestamp (#926, parallel) — not redefined here.
+- Non-Allegro dispatch sources (PrestaShop has no marketplace SLA) — graceful-absent.
+- Notifications/alerts on breach — future.
+
+## 7. Risks
+- **Overlap with #926 (parallel):** both touch the Allegro `getOrder` mapping, `IncomingOrder`, the snapshot build in `order-record.service`, `OrderRecordResponseDto`, FE `OrderRecord`/snapshot schema, and the orders list/detail pages. Additive fields + a bounded merge (like #929/#930). Keep changes localized; coordinate the snapshot key names.
+- **Migration** adds a column — first schema change in this area; verify `migration:show` and that integration harness picks it up.
+- **Server-side list sort** is new on the redesigned list; scope it to the `dispatchBy` column only (others stay client-page-sort) to limit blast radius.

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -355,6 +355,7 @@ export class OrderIngestionService implements IOrderIngestionService {
       pickupPoint: incoming.pickupPoint,
       deliverySmart: incoming.deliverySmart,
       paymentStatus: incoming.paymentStatus,
+      dispatchTime: incoming.dispatchTime,
       placedAt: incoming.placedAt ? new Date(incoming.placedAt) : undefined,
       createdAt: new Date(incoming.createdAt),
       updatedAt: new Date(incoming.updatedAt),

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -9,7 +9,7 @@
  * @implements {IOrderRecordService}
  */
 import { Injectable, Inject } from '@nestjs/common';
-import type { Order } from '../../domain/types/order.types';
+import type { Order, OrderDispatchWindow } from '../../domain/types/order.types';
 import { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
 import { OrderRecord } from '../../domain/entities/order-record.entity';
 import type { OrderSyncStatus, SyncAttempt } from '../../domain/types/order-sync.types';
@@ -82,6 +82,9 @@ export class OrderRecordService implements IOrderRecordService {
       // reported" from "Smart explicitly false".
       ...(order.deliverySmart !== undefined && { deliverySmart: order.deliverySmart }),
       ...(order.paymentStatus !== undefined && { paymentStatus: order.paymentStatus }),
+      // Dispatch (ship-by) window carried through for fidelity; the scalar
+      // deadline is denormalized to the `dispatchByAt` column below (#927).
+      ...(order.dispatchTime !== undefined && { dispatchTime: order.dispatchTime }),
       // Buyer-placed-on-marketplace time (#926) — absent when the source didn't
       // expose one. Conditional spread keeps the key off the snapshot rather
       // than emitting `undefined`.
@@ -102,7 +105,9 @@ export class OrderRecordService implements IOrderRecordService {
       syncStatus,
       'ready',
       now,
-      now
+      now,
+      [],
+      this.deriveDispatchByAt(order.dispatchTime)
     );
 
     return this.repository.upsert(orderRecord);
@@ -142,6 +147,7 @@ export class OrderRecordService implements IOrderRecordService {
       // See `persistOrder` above for the absent-vs-false rationale.
       ...(incoming.deliverySmart !== undefined && { deliverySmart: incoming.deliverySmart }),
       ...(incoming.paymentStatus !== undefined && { paymentStatus: incoming.paymentStatus }),
+      ...(incoming.dispatchTime !== undefined && { dispatchTime: incoming.dispatchTime }),
       // Buyer-placed-on-marketplace time (#926) — ISO string passed through verbatim.
       ...(incoming.placedAt !== undefined && { placedAt: incoming.placedAt }),
     };
@@ -155,10 +161,28 @@ export class OrderRecordService implements IOrderRecordService {
       [],
       'awaiting_mapping',
       now,
-      now
+      now,
+      [],
+      this.deriveDispatchByAt(incoming.dispatchTime)
     );
 
     return this.repository.upsert(orderRecord);
+  }
+
+  /**
+   * Derive the scalar ship-by deadline (`dispatchByAt`) from a dispatch window
+   * (#927) — the `.to` bound. Returns `null` when absent or unparseable, so the
+   * column and SLA surfaces degrade gracefully. Re-run on every persist (both
+   * the `awaiting_mapping` and `ready` paths) so a re-pulled order with a
+   * changed window updates the column.
+   */
+  private deriveDispatchByAt(window: OrderDispatchWindow | undefined): Date | null {
+    const to = window?.to;
+    if (!to) {
+      return null;
+    }
+    const parsed = new Date(to);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
   }
 
   /**

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -37,5 +37,13 @@ export class OrderRecord {
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
     public readonly syncAttempts: SyncAttempt[] = [],
+    /**
+     * Derived marketplace dispatch (ship-by) deadline (#927) — the `.to` of the
+     * source dispatch window, denormalized to a top-level column so the orders
+     * list can sort/filter on the SLA without parsing the snapshot. `null` when
+     * the source exposes no dispatch SLA. Re-derived on every persist so a
+     * re-pulled order with a changed window stays fresh.
+     */
+    public readonly dispatchByAt: Date | null = null,
   ) {}
 }

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -10,7 +10,12 @@
  * @module libs/core/src/orders/domain/types
  */
 
-import type { OrderShipping, OrderPickupPoint, PriceTaxTreatment } from './order.types';
+import type {
+  OrderShipping,
+  OrderPickupPoint,
+  OrderDispatchWindow,
+  PriceTaxTreatment,
+} from './order.types';
 import type { PaymentStatus } from './payment-status.types';
 
 export interface IncomingOrder {
@@ -75,6 +80,13 @@ export interface IncomingOrder {
   deliverySmart?: boolean;
   /** Source-reported payment status (#928); absent when the source did not report it. */
   paymentStatus?: PaymentStatus;
+
+  /**
+   * Marketplace dispatch (ship-by) commitment window (#927). The SLA deadline
+   * is `dispatchTime.to`. Neutral concept — the Allegro adapter maps
+   * `delivery.time.dispatch` here; absent for sources without a dispatch SLA.
+   */
+  dispatchTime?: OrderDispatchWindow;
 
   /**
    * When the buyer placed the order on the source marketplace, as an ISO string

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -120,10 +120,29 @@ export interface OrderRecordFilters {
    * window even if it's been around for months.
    */
   updatedSince?: Date;
+  /**
+   * Dispatch-SLA "breaching / overdue" filter (#927): keep only records with a
+   * known ship-by deadline at or before this instant (`dispatchByAt IS NOT NULL
+   * AND dispatchByAt <= dueBefore`). The list passes `now` (overdue) or
+   * `now + window` (breaching soon); records without a deadline are excluded.
+   */
+  dueBefore?: Date;
+  /**
+   * Result ordering (#927). Default (`createdAt`) is newest-first. `dispatchBy`
+   * orders by the ship-by deadline ascending with NULLs last — the triage
+   * default on the orders list (soonest deadline first).
+   */
+  sort?: OrderRecordSort;
 }
 
 /**
- * Pagination parameters for order record queries
+ * Sort fields for order-record list queries (#927).
+ */
+export const OrderRecordSortValues = ['createdAt', 'dispatchBy'] as const;
+export type OrderRecordSort = (typeof OrderRecordSortValues)[number];
+
+/**
+ * Pagination parameters for order record queries.
  */
 export interface OrderRecordPagination {
   limit: number;

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -122,6 +122,14 @@ export interface Order {
    * for records ingested before this field existed.
    */
   placedAt?: Date;
+  /**
+   * Marketplace dispatch (ship-by) commitment window, carried through from the
+   * source `IncomingOrder` (#927). The SLA deadline is `dispatchTime.to`. A
+   * platform-agnostic concept — Allegro maps its `delivery.time.dispatch` here,
+   * future sources map their own handling-time/ship-by. Absent for sources that
+   * don't express a dispatch SLA (e.g. PrestaShop shop orders).
+   */
+  dispatchTime?: OrderDispatchWindow;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -135,6 +143,19 @@ export interface Order {
 export interface OrderShipping {
   methodId: string;
   methodName?: string;
+}
+
+/**
+ * Marketplace dispatch (ship-by) commitment window (#927). Both bounds are ISO
+ * 8601 timestamp strings. `from` is when dispatch may begin; `to` is the
+ * **ship-by deadline** the SLA surfaces (the latest acceptable dispatch). A
+ * neutral concept: every order-source maps its platform-native dispatch
+ * commitment onto this shape (Allegro `delivery.time.dispatch`). Either bound
+ * may be absent.
+ */
+export interface OrderDispatchWindow {
+  from?: string;
+  to?: string;
 }
 
 /**

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -53,6 +53,7 @@ export {
   Address,
   OrderShipping,
   OrderPickupPoint,
+  OrderDispatchWindow,
 } from './domain/types/order.types';
 export { PaymentStatusValues, PAYMENT_STATUS } from './domain/types/payment-status.types';
 export type { PaymentStatus } from './domain/types/payment-status.types';
@@ -83,6 +84,8 @@ export {
   OrderHealthValues,
   OrderHealthSummary,
   OrderHealthSummaryFilters,
+  OrderRecordSort,
+  OrderRecordSortValues,
 } from './domain/types/order-record.types';
 
 // Services

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -77,6 +77,16 @@ export class OrderRecordOrmEntity {
   @Index()
   recordStatus!: string;
 
+  /**
+   * Derived marketplace dispatch (ship-by) deadline (#927) — the `.to` of the
+   * source dispatch window, denormalized from the snapshot so the orders list
+   * can sort/filter on the SLA via an index without parsing JSONB. `null` when
+   * the source exposes no dispatch SLA (non-marketplace orders, older records).
+   */
+  @Column({ type: 'timestamptz', nullable: true })
+  @Index()
+  dispatchByAt!: Date | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -54,7 +54,6 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
   ): Promise<PaginatedOrderRecords> {
     const qb: SelectQueryBuilder<OrderRecordOrmEntity> = this.repository
       .createQueryBuilder('rec')
-      .orderBy('rec.createdAt', 'DESC')
       .take(pagination.limit)
       .skip(pagination.offset);
 
@@ -111,8 +110,24 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       qb.andWhere('rec.updatedAt >= :updatedSince', { updatedSince: filters.updatedSince });
     }
 
+    if (filters.dueBefore) {
+      // SLA "breaching / overdue" filter (#927) — only records with a known
+      // ship-by deadline at or before the cutoff. NULL deadlines are excluded.
+      qb.andWhere('rec.dispatchByAt IS NOT NULL AND rec.dispatchByAt <= :dueBefore', {
+        dueBefore: filters.dueBefore,
+      });
+    }
+
     if (filters.health) {
       this.applyHealthFilter(qb, filters.health);
+    }
+
+    // Ordering (#927). `dispatchBy` is the triage default on the list: soonest
+    // ship-by first, NULLs last, with createdAt as a stable tiebreaker.
+    if (filters.sort === 'dispatchBy') {
+      qb.orderBy('rec.dispatchByAt', 'ASC', 'NULLS LAST').addOrderBy('rec.createdAt', 'DESC');
+    } else {
+      qb.orderBy('rec.createdAt', 'DESC');
     }
 
     const [entities, total] = await qb.getManyAndCount();
@@ -359,7 +374,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       (entity.recordStatus as OrderRecordStatus) ?? 'ready',
       entity.createdAt,
       entity.updatedAt,
-      syncAttempts
+      syncAttempts,
+      entity.dispatchByAt
     );
   }
 
@@ -390,6 +406,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       externalOrderNumber: a.externalOrderNumber,
     }));
     entity.recordStatus = orderRecord.recordStatus;
+    entity.dispatchByAt = orderRecord.dispatchByAt;
     entity.createdAt = orderRecord.createdAt;
     entity.updatedAt = orderRecord.updatedAt;
     return entity;

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -98,6 +98,19 @@ export interface AllegroCheckoutForm {
     };
     /** Allegro Smart! free-delivery flag. Ignored today. */
     smart?: boolean;
+    /**
+     * #927 — delivery/dispatch time windows. `dispatch.{from,to}` (the
+     * shipment window, populated for all delivery methods) is the ship-by SLA
+     * source; `dispatch.to` is the deadline. `time.{from,to}` is the delivery
+     * window and `time.guaranteed` (deprecated, Kurier-X-press-only) is NOT
+     * consumed. All bounds are ISO 8601 timestamps.
+     */
+    time?: {
+      from?: string;
+      to?: string;
+      dispatch?: { from?: string; to?: string };
+      guaranteed?: { from?: string; to?: string };
+    };
   };
   /**
    * Last-revision timestamp of the checkout form (the only order-level date

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -331,6 +331,69 @@ describe('AllegroOrderSourceAdapter', () => {
       expect(incoming.paymentStatus).toBe('cod');
     });
 
+    describe('dispatch time / ship-by (#927)', () => {
+      const formWithDelivery = (
+        delivery: NonNullable<AllegroCheckoutForm['delivery']>
+      ): AllegroCheckoutForm => ({
+        id: 'cf',
+        updatedAt: '2024-01-01T00:00:00Z',
+        buyer: { id: 'b', email: 'b@e.com', login: 'b' },
+        lineItems: [
+          { id: 'l1', offer: { id: 'o1', name: 'O1' }, quantity: 1, price: { amount: '10.00', currency: 'PLN' } },
+        ],
+        summary: { totalToPay: { amount: '10.00', currency: 'PLN' } },
+        payment: { type: 'ONLINE', finishedAt: '2024-01-01T01:00:00Z' },
+        delivery,
+      });
+
+      it('maps delivery.time.dispatch to the neutral dispatchTime window', async () => {
+        httpClient.get.mockResolvedValueOnce({
+          data: formWithDelivery({
+            time: {
+              from: '2024-01-03T10:00:00Z',
+              to: '2024-01-03T12:00:00Z',
+              dispatch: { from: '2024-01-02T08:00:00Z', to: '2024-01-02T16:00:00Z' },
+            },
+          }),
+          status: 200,
+          headers: {},
+        });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.dispatchTime).toEqual({
+          from: '2024-01-02T08:00:00Z',
+          to: '2024-01-02T16:00:00Z',
+        });
+      });
+
+      it('ignores the deprecated guaranteed window and leaves dispatchTime undefined when no dispatch', async () => {
+        httpClient.get.mockResolvedValueOnce({
+          data: formWithDelivery({
+            time: { guaranteed: { from: '2024-01-03T10:00:00Z', to: '2024-01-03T12:00:00Z' } },
+          }),
+          status: 200,
+          headers: {},
+        });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.dispatchTime).toBeUndefined();
+      });
+
+      it('leaves dispatchTime undefined when the delivery block has no time', async () => {
+        httpClient.get.mockResolvedValueOnce({
+          data: formWithDelivery({ method: { id: 'm1', name: 'Courier' } }),
+          status: 200,
+          headers: {},
+        });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.dispatchTime).toBeUndefined();
+      });
+    });
+
     describe('totals — shipping cost (#454)', () => {
       const baseForm = (): AllegroCheckoutForm => ({
         id: 'cf',

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -25,6 +25,7 @@ import type {
   IncomingOrderAddress,
   OrderShipping,
   OrderPickupPoint,
+  OrderDispatchWindow,
 } from '@openlinker/core/orders';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
@@ -294,6 +295,7 @@ export class AllegroOrderSourceAdapter
         pickupPoint: this.resolvePickupPoint(checkoutForm),
         deliverySmart: checkoutForm.delivery?.smart,
         paymentStatus: deriveAllegroPaymentStatus(checkoutForm.payment),
+        dispatchTime: this.resolveDispatchTime(checkoutForm),
         placedAt,
         createdAt,
         updatedAt,
@@ -444,6 +446,23 @@ export class AllegroOrderSourceAdapter
       return undefined;
     }
     return { id: pp.id, name: pp.name, description: pp.description };
+  }
+
+  /**
+   * Resolve the marketplace dispatch (ship-by) window (#927).
+   *
+   * Reads `delivery.time.dispatch.{from,to}` — the shipment window Allegro
+   * populates for all delivery methods. `dispatch.to` is the ship-by deadline
+   * the SLA surfaces. The deprecated, Kurier-X-press-only `delivery.time.guaranteed`
+   * is intentionally NOT consumed. Returns `undefined` when neither bound is
+   * present (older orders / sources without a dispatch SLA → graceful no-deadline).
+   */
+  private resolveDispatchTime(checkoutForm: AllegroCheckoutForm): OrderDispatchWindow | undefined {
+    const dispatch = checkoutForm.delivery?.time?.dispatch;
+    if (!dispatch?.from && !dispatch?.to) {
+      return undefined;
+    }
+    return { from: dispatch.from, to: dispatch.to };
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -341,6 +341,10 @@ const ALLOW_LIST = new Map([
     'apps/api/test/integration/order-health-summary.int-spec.ts',
     new Set(['OrderRecordRepositoryPort']),
   ],
+  [
+    'apps/api/test/integration/order-dispatch-sla.int-spec.ts',
+    new Set(['OrderRecordRepositoryPort']),
+  ],
 
   // apps → products.{ProductRepositoryPort, ProductVariantRepositoryPort} — rewire via IProductsService
   ['apps/api/test/integration/products-read.int-spec.ts', new Set(['ProductRepositoryPort'])],


### PR DESCRIPTION
## What & why

Captures the marketplace **dispatch (ship-by) deadline** and surfaces it as an SLA countdown across the orders list and detail.

**Key finding (verified against developer.allegro.pl):** the Allegro checkout-form exposes the dispatch window directly — `delivery.time.dispatch.{from,to}` (all delivery methods) — so the ship-by deadline is the **source-authoritative `dispatch.to` timestamp**, not derived from placed-at + handling-time. This decoupled #927 from #926 and needs no ISO-8601 duration parser. The deprecated, Kurier-X-press-only `delivery.time.guaranteed` is intentionally not consumed.

## How

- **Allegro plugin** → maps `delivery.time.dispatch` to the neutral `IncomingOrder.dispatchTime`; `undefined` when absent.
- **CORE** → carries `dispatchTime` through the order snapshot; derives the scalar `dispatchByAt` (= `dispatch.to`) once and persists it to a new **indexed** `order_records.dispatchByAt` column (migration `1799000000008`), **re-derived on every upsert** so re-pulls (the #904/#906/#909 reconcile path) stay fresh.
- **Repository / API** → `dispatchBy` sort (ascending, NULLs last) + `dueBefore` breaching/overdue filter; controller/DTO expose `dispatchByAt` + the `sort`/`dueBefore` query.
- **Web** → Ship-by **countdown column** (server-sorted soonest-first — the list default) with a "ship-by ≤24h / overdue" filter chip, plus a countdown row on the order detail. `formatShipBy` returns a neutral urgency level (no `shared/ui` dependency).

## Boundary

Only neutral concepts cross into CORE (`OrderDispatchWindow` / `dispatchTime` / `dispatchByAt`); the Allegro `delivery.time` shape stays in the plugin; no `platformType` branching. The neutral type is the seam any future order-source maps onto.

## Relationship to #926

Built on top of #926 (buyer-placed timestamp, already merged to `main`). Both features add fields along the same `getOrder → IncomingOrder → Order → snapshot → order-detail` chain. Rebased cleanly onto post-#926 `main`; the order-detail time block now reads **Placed → Received (OL) → Updated (OL) → Ship by**. One semantic integration point: #926 removed the fictional `AllegroCheckoutForm.createdAt`, so the Allegro spec fixture no longer sets it.

## Review adjustments applied

Tech-review suggestions folded in before ship: restored the `OrderRecordPagination` JSDoc (the sort const no longer hijacks it) and dropped a redundant `?? null` in the repository `toDomain`.

## Tests / quality gate

Green on the rebased state: `type-check`, `lint` + all invariants (migration timestamp unique among 54, design-tokens, cross-context, service-interfaces, jest-integration-mappers), unit — **allegro 505 / core 985 / apps/web 1341** — and the order int-specs (dispatch-SLA 3/3, with the migration applying in the Testcontainers harness).

New tests: `formatShipBy` (8), Allegro dispatch-mapping incl. the `guaranteed`-window trap (3), controller passthrough + serialization (2), repository sort/filter/recompute integration (3), FE list SLA column + breaching chip + default-sort (3).

Closes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)