### PR TITLE
feat(web): orders list filter/sort bar + identity-cell fixes (#939)

### DIFF
--- a/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
@@ -190,4 +190,41 @@ describe('parseOrderSnapshot', () => {
     expect(parsed.items).toEqual([]);
     expect(parsed.parseWarnings.some((w) => w.field === 'items')).toBe(true);
   });
+
+  it('keeps the address when optional fields are JSON null, not just absent (#939)', () => {
+    // The persisted snapshot serialises absent optional fields as `null`
+    // (e.g. the Allegro adapter emits `company: null`). A bare `.optional()`
+    // would reject `null` and drop the whole address, blanking the customer
+    // cell. `.nullish()` must tolerate it.
+    const parsed = parseOrderSnapshot({
+      shippingAddress: {
+        firstName: 'Piotr',
+        lastName: 'Swierzy',
+        company: null,
+        address1: 'Biadaczowa 14',
+        address2: null,
+        city: 'Strzelce Opolskie',
+        state: null,
+        postalCode: '47-100',
+        country: 'PL',
+        phone: '+48500500500',
+      },
+    });
+
+    expect(parsed.shippingAddress).toBeDefined();
+    expect(parsed.shippingAddress?.firstName).toBe('Piotr');
+    expect(parsed.shippingAddress?.lastName).toBe('Swierzy');
+    expect(parsed.shippingAddress?.city).toBe('Strzelce Opolskie');
+    expect(parsed.parseWarnings.some((w) => w.field === 'shippingAddress')).toBe(false);
+  });
+
+  it('keeps an item when its optional fields are JSON null (#939)', () => {
+    const parsed = parseOrderSnapshot({
+      items: [{ id: 'i1', quantity: 1, price: 10, sku: null, name: null, imageUrl: null }],
+    });
+
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0]?.id).toBe('i1');
+    expect(parsed.parseWarnings).toHaveLength(0);
+  });
 });

--- a/apps/web/src/features/orders/api/order-snapshot.schema.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.ts
@@ -12,28 +12,34 @@
  */
 import { z } from 'zod/v4';
 
+// Optional string fields use `.nullish()` (string | null | undefined), not
+// `.optional()` (string | undefined): the persisted snapshot serialises absent
+// values as JSON `null` (e.g. the Allegro adapter emits `company: null`), and a
+// bare `.optional()` rejects `null` — failing the whole sub-tree's `safeParse`
+// and blanking the entire address from one empty field. `.nullish()` tolerates
+// both shapes so a single null never drops the section.
 const addressSchema = z.object({
-  firstName: z.string().optional(),
-  lastName: z.string().optional(),
-  company: z.string().optional(),
+  firstName: z.string().nullish(),
+  lastName: z.string().nullish(),
+  company: z.string().nullish(),
   address1: z.string(),
-  address2: z.string().optional(),
+  address2: z.string().nullish(),
   city: z.string(),
-  state: z.string().optional(),
+  state: z.string().nullish(),
   postalCode: z.string(),
   country: z.string(),
-  phone: z.string().optional(),
+  phone: z.string().nullish(),
 });
 
 const orderItemSchema = z.object({
   id: z.string(),
-  productId: z.string().optional(),
-  variantId: z.string().optional(),
+  productId: z.string().nullish(),
+  variantId: z.string().nullish(),
   quantity: z.number(),
   price: z.number(),
-  sku: z.string().optional(),
-  name: z.string().optional(),
-  imageUrl: z.string().optional(),
+  sku: z.string().nullish(),
+  name: z.string().nullish(),
+  imageUrl: z.string().nullish(),
 });
 
 /**
@@ -60,17 +66,17 @@ const orderTotalsSchema = z.object({
 const orderShippingSchema = z.object({
   /** Source-side delivery-method id (routing-rule lookup key). */
   methodId: z.string(),
-  /** Operator-facing label (e.g. "InPost Paczkomaty"). */
-  methodName: z.string().optional(),
+  /** Operator-facing label (e.g. "InPost Paczkomaty"). `.nullish()` — see addressSchema. */
+  methodName: z.string().nullish(),
 });
 
 const orderPickupPointSchema = z.object({
   /** Bare locker code (e.g. `POZ08A`). */
   id: z.string(),
-  /** Operator-facing label (e.g. `Paczkomat POZ08A`). */
-  name: z.string().optional(),
-  /** Locker-side description (e.g. `Stacja paliw BP`). */
-  description: z.string().optional(),
+  /** Operator-facing label (e.g. `Paczkomat POZ08A`). `.nullish()` — see addressSchema. */
+  name: z.string().nullish(),
+  /** Locker-side description (e.g. `Stacja paliw BP`). `.nullish()` — see addressSchema. */
+  description: z.string().nullish(),
 });
 
 export type ParsedOrderItem = z.infer<typeof orderItemSchema>;

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -514,8 +514,11 @@ function buildGenerateLabelInput(args: {
     shippingMethod,
     paczkomatId: values.paczkomatId && values.paczkomatId.length > 0 ? values.paczkomatId : undefined,
     recipient: {
-      firstName: a?.firstName,
-      lastName: a?.lastName,
+      // Address optionals are `string | null | undefined` (#939 — snapshot
+      // serialises absent fields as null); coalesce null → undefined for the
+      // recipient contract.
+      firstName: a?.firstName ?? undefined,
+      lastName: a?.lastName ?? undefined,
       // Gate guarantees customerEmail is present; the `??` only fires under
       // the (impossible-by-invariant) "gate bypassed" branch.
       email: snapshot.customerEmail ?? '',

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7235,6 +7235,30 @@ a.kpi-card:focus-visible {
   padding: 1px 7px;
 }
 
+/* ── Orders list filter/sort bar (#939) ─────────────────────────────── */
+.orders-toolbar {
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+/* Push the sort control to the trailing edge — filters lead, sort trails. */
+.orders-toolbar__sort {
+  margin-left: auto;
+}
+/* Inline date field: small mono-caps label sitting left of the native input. */
+.orders-toolbar__field {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.orders-toolbar__label {
+  font-size: 0.6875rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
 /* ── Surface card used for grouping demos ────────────────────────── */
 .ds-surface {
   background: var(--bg-surface);

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -8,7 +8,7 @@
  * snapshot, the all-clear empty state, and the inline per-row Retry. Preserves
  * the canonical async states (loading / error / empty / data).
  */
-import { cleanup, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
@@ -379,5 +379,115 @@ describe('OrdersListPage', () => {
       );
       expect(calledWithDue).toBe(true);
     });
+  });
+
+  it('should filter the list by source connection when the source select changes (#939)', async () => {
+    const user = userEvent.setup();
+    const list = vi.fn().mockResolvedValue(paginated([syncedOrder]));
+    const mockApi = createMockApiClient({
+      orders: { list },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    await user.selectOptions(screen.getByLabelText('Filter by source'), 'conn_allegro_1');
+
+    await vi.waitFor(() => {
+      const called = list.mock.calls.some(
+        ([filters]) =>
+          (filters as { sourceConnectionId?: string } | undefined)?.sourceConnectionId ===
+          'conn_allegro_1',
+      );
+      expect(called).toBe(true);
+    });
+  });
+
+  it('should change the sort order when the sort select changes (#939)', async () => {
+    const user = userEvent.setup();
+    const list = vi.fn().mockResolvedValue(paginated([syncedOrder]));
+    const mockApi = createMockApiClient({ orders: { list } });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    await user.selectOptions(screen.getByLabelText('Sort orders'), 'createdAt');
+
+    await vi.waitFor(() => {
+      const called = list.mock.calls.some(
+        ([filters]) => (filters as { sort?: string } | undefined)?.sort === 'createdAt',
+      );
+      expect(called).toBe(true);
+    });
+  });
+
+  it('should widen the created-from date to a start-of-day ISO instant (#939)', async () => {
+    const list = vi.fn().mockResolvedValue(paginated([syncedOrder]));
+    const mockApi = createMockApiClient({ orders: { list } });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    fireEvent.change(screen.getByLabelText('Created from'), { target: { value: '2026-05-01' } });
+
+    await vi.waitFor(() => {
+      const called = list.mock.calls.some(
+        ([filters]) =>
+          (filters as { createdFrom?: string } | undefined)?.createdFrom ===
+          '2026-05-01T00:00:00.000Z',
+      );
+      expect(called).toBe(true);
+    });
+  });
+
+  it('should shorten a UUID-shaped order number so it reads as a reference (#939)', async () => {
+    const uuidOrder: OrderRecord = {
+      ...syncedOrder,
+      internalOrderId: 'ol_order_uuid',
+      orderSnapshot: {
+        ...syncedOrder.orderSnapshot,
+        orderNumber: '186d7a20-5b82-11f1-979b-098d4666d4ec',
+      },
+    };
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([uuidOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('186d7a20…66d4ec')).toBeInTheDocument();
+    expect(screen.queryByText('186d7a20-5b82-11f1-979b-098d4666d4ec')).not.toBeInTheDocument();
+  });
+
+  it('should fall back to the buyer email in the customer cell when the address has no name (#939)', async () => {
+    const noNameOrder: OrderRecord = {
+      ...syncedOrder,
+      internalOrderId: 'ol_order_noname',
+      orderSnapshot: {
+        orderNumber: 'ALG-NONAME',
+        customerEmail: 'buyer@allegromail.pl',
+        items: [{ id: 'i1', quantity: 1, price: 10, name: 'Thing' }],
+        // shippingAddress has geography but no first/last name (locker/guest order)
+        shippingAddress: {
+          company: null,
+          address1: 'Locker POZ08A',
+          city: 'Poznań',
+          postalCode: '60-001',
+          country: 'PL',
+        },
+      },
+    };
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([noNameOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-NONAME');
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+    expect(within(row).getByText('buyer@allegromail.pl')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -1,16 +1,20 @@
 /**
  * Orders List Page
  *
- * Operator triage queue for the orders backbone (#778, redesigned #929).
- * Composes:
+ * Operator triage queue for the orders backbone (#778, redesigned #929;
+ * filter/sort bar + identity-cell fixes #939). Composes:
  * — status segments (5 clickable `MetricCard`s backed by the single
  *   `/orders/status-summary` count endpoint) that **partition** the order set,
  *   so the counts sum to the total and double as the `health` URL-state filter;
- * — a dense `DataTable` whose rows lead with human identity (`EntityLabel`),
- *   surface customer + contents (parsed from `orderSnapshot`), the source→
- *   destination channel, one reconciled health `StatusBadge` (`deriveOrderHealth`,
- *   replacing the per-destination list and the blank "—"), a "Created" time, a
- *   **Ship-by** SLA countdown (#927; server-sorted soonest-first, with a
+ * — a filter/sort bar (#939) — source-connection, created-date range, and sort
+ *   controls, all URL-state-backed (mirrors the connections-list toolbar);
+ * — a dense `DataTable` whose rows lead with human identity (`EntityLabel`,
+ *   showing a shortened channel order reference — #939), surface customer +
+ *   contents (parsed from `orderSnapshot`, with an email fallback when the
+ *   source omits a buyer name — #939), the source→destination channel, one
+ *   reconciled health `StatusBadge` (`deriveOrderHealth`, replacing the
+ *   per-destination list and the blank "—"), a "Created" time, a **Ship-by**
+ *   SLA countdown (#927; server-sorted soonest-first, with a
  *   "breaching ≤24h / overdue" filter chip), a ghost Payment column (#928), and
  *   an inline Retry for failed rows;
  * — loading / error / empty (incl. all-clear) states via shared feedback prims.
@@ -28,6 +32,7 @@ import { ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { DataTableSkeleton } from '../../shared/ui/data-table-skeleton';
 import { Button } from '../../shared/ui/button';
 import { Chip } from '../../shared/ui/chip';
+import { Select } from '../../shared/ui/select';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { MetricCard, type MetricCardTone } from '../../shared/ui/metric-card';
@@ -46,8 +51,9 @@ import type {
   OrderFilters,
   OrderHealthValue,
   OrderHealthSummary,
+  OrderSortValue,
 } from '../../features/orders/api/orders.types';
-import { OrderHealthValues } from '../../features/orders/api/orders.types';
+import { OrderHealthValues, OrderSortValues } from '../../features/orders/api/orders.types';
 import { useConnectionsQuery } from '../../features/connections';
 
 const PAGE_SIZE = 20;
@@ -86,6 +92,35 @@ function isOrderHealth(value: string | null): value is OrderHealthValue {
   return value !== null && (OrderHealthValues as readonly string[]).includes(value);
 }
 
+/** Triage default ordering — soonest ship-by first (NULLs last), server-backed. */
+const DEFAULT_SORT: OrderSortValue = 'dispatchBy';
+
+/** Type-guard for the `sort` URL param (#939). Same widen-then-narrow shape as `isOrderHealth`. */
+function isOrderSort(value: string | null): value is OrderSortValue {
+  return value !== null && (OrderSortValues as readonly string[]).includes(value);
+}
+
+/** Operator-facing labels for the sort control (#939). */
+const SORT_LABELS: Record<OrderSortValue, string> = {
+  dispatchBy: 'Ship-by (soonest)',
+  createdAt: 'Created (newest)',
+};
+
+/**
+ * Order-column primary label (#939). The source marketplace often has no
+ * human-friendly order number — Allegro's `orderNumber` is its `checkoutFormId`,
+ * a 36-char UUID that reads as noise when rendered verbatim. Shorten long ids to
+ * a `head…tail` form so the cell reads as a reference; short numbers (most
+ * shops) pass through untouched. Returns `''` when no order number is present so
+ * the caller can fall back to the internal id. The marketplace itself is already
+ * conveyed by the dedicated Channel column, so no channel prefix is added here.
+ */
+function formatOrderRef(orderNumber: string | undefined): string {
+  if (!orderNumber) return '';
+  if (orderNumber.length <= 18) return orderNumber;
+  return `${orderNumber.slice(0, 8)}…${orderNumber.slice(-6)}`;
+}
+
 /** Map the neutral ship-by urgency level (#927) to a StatusBadge tone. */
 const SHIP_BY_TONE: Record<ShipByLevel, StatusBadgeTone> = {
   ok: 'info',
@@ -106,12 +141,16 @@ function formatCurrency(amount: number, currency: string, locale: LocaleCode): s
   );
 }
 
-/** Buyer name from the snapshot's shipping address — null when absent. */
+/**
+ * Buyer identity for the customer cell (#939). Prefers the shipping-address
+ * name; falls back to the buyer email when the source omits a name (so the cell
+ * stays useful instead of blanking). `null` only when neither is present.
+ */
 function customerName(parsed: ReturnType<typeof parseOrderSnapshot>): string | null {
   const a = parsed.shippingAddress;
-  if (!a) return null;
-  const name = [a.firstName, a.lastName].filter(Boolean).join(' ').trim();
-  return name.length > 0 ? name : null;
+  const name = [a?.firstName, a?.lastName].filter(Boolean).join(' ').trim();
+  if (name.length > 0) return name;
+  return parsed.customerEmail ?? null;
 }
 
 /**
@@ -142,6 +181,15 @@ export function OrdersListPage(): ReactElement {
   const rawHealth = searchParams.get('health');
   const health = isOrderHealth(rawHealth) ? rawHealth : undefined;
   const sourceConnectionId = searchParams.get('sourceConnectionId') ?? undefined;
+  const rawSort = searchParams.get('sort');
+  const sort = isOrderSort(rawSort) ? rawSort : DEFAULT_SORT;
+  // Date filters stay calendar-date (YYYY-MM-DD) in the URL so the native date
+  // input round-trips; they're widened to start-/end-of-day UTC instants only
+  // when building the query, so the `createdTo` bound is inclusive of that day.
+  const createdFrom = searchParams.get('createdFrom') || undefined;
+  const createdTo = searchParams.get('createdTo') || undefined;
+  const createdFromIso = createdFrom ? `${createdFrom}T00:00:00.000Z` : undefined;
+  const createdToIso = createdTo ? `${createdTo}T23:59:59.999Z` : undefined;
   const breaching = searchParams.get('due') === 'breaching';
   const offset = Number(searchParams.get('offset') ?? '0');
 
@@ -155,9 +203,12 @@ export function OrdersListPage(): ReactElement {
   const filters: OrderFilters = {
     health,
     sourceConnectionId: sourceConnectionId || undefined,
-    // Server-backed triage default: soonest ship-by first (NULLs last). The
-    // only sort on this list — kept coherent (no client-page-sorted columns).
-    sort: 'dispatchBy',
+    // Operator-selectable ordering (#939); defaults to the triage sort
+    // (soonest ship-by first, NULLs last). Column-header sort stays a non-goal
+    // (JSONB-derived columns the server can't ORDER BY without indexes).
+    sort,
+    createdFrom: createdFromIso,
+    createdTo: createdToIso,
     dueBefore,
   };
   const pagination = { limit: PAGE_SIZE, offset };
@@ -165,11 +216,16 @@ export function OrdersListPage(): ReactElement {
   const query = useOrdersQuery(filters, pagination);
 
   // Single count endpoint — partitions the set, so segment counts sum to total.
-  // Scoped by source only (the table's other axis); `health` is intentionally
-  // never part of the summary scope.
+  // Scoped by the same source + date axes as the table (NOT `health`, so the
+  // aggregate can't be self-filtered) — keeps the segment counts coherent with
+  // an active source/date filter.
   const summaryScope = useMemo(
-    () => ({ sourceConnectionId: sourceConnectionId || undefined }),
-    [sourceConnectionId],
+    () => ({
+      sourceConnectionId: sourceConnectionId || undefined,
+      createdFrom: createdFromIso,
+      createdTo: createdToIso,
+    }),
+    [sourceConnectionId, createdFromIso, createdToIso],
   );
   const summaryQuery = useOrderStatusSummaryQuery(summaryScope);
   const summary = summaryQuery.data;
@@ -199,7 +255,7 @@ export function OrdersListPage(): ReactElement {
           return (
             <EntityLabel
               id={order.internalOrderId}
-              name={parsed.orderNumber ?? order.internalOrderId}
+              name={formatOrderRef(parsed.orderNumber) || order.internalOrderId}
             />
           );
         },
@@ -382,6 +438,25 @@ export function OrdersListPage(): ReactElement {
     });
   }
 
+  /**
+   * Set/clear a single filter URL param (#939) and reset paging. Empty string
+   * removes the param (e.g. the "All sources" / default-sort option). Mirrors
+   * the connections-list filter pattern; `offset` is dropped so a new filter
+   * always lands on page 1.
+   */
+  function setFilterParam(key: string, value: string): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (value) {
+        p.set(key, value);
+      } else {
+        p.delete(key);
+      }
+      p.delete('offset');
+      return p;
+    });
+  }
+
   function toggleBreaching(): void {
     setSearchParams((prev) => {
       const p = new URLSearchParams(prev);
@@ -429,6 +504,7 @@ export function OrdersListPage(): ReactElement {
       if (
         target?.tagName === 'INPUT' ||
         target?.tagName === 'TEXTAREA' ||
+        target?.tagName === 'SELECT' ||
         target?.isContentEditable
       ) {
         return;
@@ -484,6 +560,58 @@ export function OrdersListPage(): ReactElement {
             <MetricCard label={segment.label} tone={segment.tone} value={segmentCount(segment)} />
           </button>
         ))}
+      </div>
+
+      {/* Filter + sort bar (#939) — source/date/sort controls in URL state.
+          Mirrors the connections-list toolbar pattern. */}
+      <div className="toolbar orders-toolbar">
+        <div className="toolbar__group">
+          <Select
+            aria-label="Filter by source"
+            value={sourceConnectionId ?? ''}
+            onChange={(e) => { setFilterParam('sourceConnectionId', e.target.value); }}
+          >
+            <option value="">All sources</option>
+            {(connectionsQuery.data ?? []).map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </Select>
+          <label className="orders-toolbar__field">
+            <span className="orders-toolbar__label">From</span>
+            <input
+              type="date"
+              className="control"
+              aria-label="Created from"
+              value={createdFrom ?? ''}
+              onChange={(e) => { setFilterParam('createdFrom', e.target.value); }}
+            />
+          </label>
+          <label className="orders-toolbar__field">
+            <span className="orders-toolbar__label">To</span>
+            <input
+              type="date"
+              className="control"
+              aria-label="Created to"
+              value={createdTo ?? ''}
+              onChange={(e) => { setFilterParam('createdTo', e.target.value); }}
+            />
+          </label>
+        </div>
+        <div className="toolbar__group orders-toolbar__sort">
+          <Select
+            aria-label="Sort orders"
+            value={sort}
+            onChange={(e) => { setFilterParam('sort', e.target.value); }}
+          >
+            {OrderSortValues.map((value) => (
+              <option key={value} value={value}>
+                {SORT_LABELS[value]}
+              </option>
+            ))}
+          </Select>
+        </div>
       </div>
 
       <div className="ds-row" style={{ gap: 'var(--space-2)', flexWrap: 'wrap' }}>
@@ -549,7 +677,7 @@ export function OrdersListPage(): ReactElement {
                 return (
                   <EntityLabel
                     id={order.internalOrderId}
-                    name={parsed.orderNumber ?? order.internalOrderId}
+                    name={formatOrderRef(parsed.orderNumber) || order.internalOrderId}
                   />
                 );
               },

--- a/docs/plans/implementation-plan-orders-list-filter-sort.md
+++ b/docs/plans/implementation-plan-orders-list-filter-sort.md
@@ -1,0 +1,64 @@
+# Implementation Plan — Orders list filter/sort bar + identity-cell robustness (#939)
+
+> Sibling redesign: #929 (orders list). Spec mockup: `docs/plans/orders-list-redesign-mockup.html`.
+> Page under change: `apps/web/src/pages/orders/orders-list-page.tsx`.
+
+## 1. Goal & layer classification
+
+Two bundled gaps against the #929 mockup, both felt on `/orders`:
+
+- **A — Filter + sort bar.** The mockup specs a filter row (Status / Source / Destination / Placed / Sort) that was never built; today only the health tiles + breaching chip filter. Surface the controls the backend query already supports.
+- **C — Identity cells read poorly.** Order column renders a bare Allegro `checkoutFormId` UUID; Customer column shows `—` on every row.
+
+**Layer: Frontend only.** No backend/CORE/migration touch. This is the key finding from research (see §2) — the original issue hypothesized a backend mapping/PII bug; the trace disproves that.
+
+## 2. Research findings (root cause of C)
+
+Traced the order-snapshot data path (Allegro adapter → IncomingOrder → Order → snapshot → FE):
+
+- The Allegro adapter **does** populate `orderNumber` and `shippingAddress` (incl. `firstName`/`lastName`) correctly — `allegro-order-source.adapter.ts:265,335-390`.
+- `orderNumber` = the Allegro **`checkoutFormId`**, which is genuinely a UUID (`212fbcf0-39d5-11f1-…`). Allegro exposes no friendly order number. So the Order column showing a UUID is **not a bug** — it's the real identifier, rendered verbatim by `EntityLabel`'s `name` prop (no shortening on `name`).
+- Customer `—`: **confirmed root cause via dev-DB inspection (PII=true).** The persisted `shippingAddress` is complete and correct (`firstName: "Piotr"`, `lastName`, `address1`, `city`, `postalCode`, `country` all present) — but it also carries `company: null`. The FE `addressSchema` (`order-snapshot.schema.ts:15-26`) declares `company: z.string().optional()`, which accepts `string | undefined` but **rejects `null`**. So `addressSchema.safeParse` fails on the whole object, `parsed.shippingAddress` is dropped, and `customerName()` returns `null` → `—`. (32/39 dev rows carry `company:null`; 7 have a genuinely null `shippingAddress` and correctly show `—`.)
+
+**Conclusion:** C is a **frontend** fix. The primary bug is the zod schema's intolerance of `null` on optional fields. No change to adapters, core, or persistence. Verified: `OL_STORE_PII=true`, `orderNumber` = Allegro `checkoutFormId` UUID (real identifier).
+
+## 3. Scope
+
+### A — Filter + sort bar (mirror `connections-list-page.tsx` precedent)
+- **Source filter** — `Select` from `useConnectionsQuery()` (already loaded), wired to existing `?sourceConnectionId` URL param (already read at `:144`, already scopes both list + summary).
+- **Sort control** — `Select` over `OrderSortValues` (`'createdAt' | 'dispatchBy'`), replacing the hardcoded `sort: 'dispatchBy'` (`:160`), persisted to `?sort=`. Labels: "Ship-by (soonest)" = `dispatchBy`, "Created (newest)" = `createdAt`.
+- **Placed/Created date range** — two `<input type="date">` wired to `?createdFrom` / `?createdTo` (already in `buildQuery`). Convert to ISO instant on set.
+- All state in URL search params; each change clears `offset` (mirror `setHealthFilter`). Render in the existing chip row (`:489-501`), left of the results count. Reuse `handleFilterChange` shape from connections page.
+
+### C — Identity cells
+- **C0 (primary bug) Address schema tolerates `null`** — in `order-snapshot.schema.ts`, optional string fields (`company`, `phone`, `address2`, `firstName`, `lastName`, `state`) must accept `null` (persisted as `null`, not absent). Switch `.optional()` → `.nullish()` (or a `null → undefined` preprocess) on the nullable optionals so one `null` field no longer fails the whole `safeParse`. This single fix restores Customer name + city on the 32 affected rows. Add a regression test with a `company:null` snapshot.
+- **C1 Order column** — shorten a long (UUID-shaped) `orderNumber` to a `head…tail` form via `formatOrderRef(orderNumber)` so it reads as a reference instead of a 36-char hash; short numbers pass through untouched. No channel prefix (the dedicated Channel column already conveys the marketplace, and prefixing would churn the existing exact-text test anchors). Full `internalOrderId` stays in the `EntityLabel` chip + Copy; absent `orderNumber` keeps the `internalOrderId` fallback.
+- **C2 Customer column (defense-in-depth)** — make `customerName()` resilient: name (`firstName`/`lastName`) → fall back to `parsed.customerEmail` → then `—`. Keep the city subline when a name resolved. Secondary to C0.
+
+### Out of scope (deferred from #929, keep)
+- Clickable column-header sort (server can't `ORDER BY` JSONB derivations without indexes).
+- Status filter chip (overlaps health tiles).
+- Destination filter, Save view, bulk selection.
+- Any backend / adapter / PII change.
+
+## 4. Steps
+
+| # | File | Change | Acceptance |
+|---|---|---|---|
+| 4.1 | `features/orders/api/orders.types.ts` | (verify only) `OrderSortValues` exported | no change expected |
+| 4.2 | `pages/orders/orders-list-page.tsx` | Read `sort`/`createdFrom`/`createdTo` from URL; type-guard `sort` vs `OrderSortValues`; drop hardcoded sort | filters object built from URL |
+| 4.3 | `pages/orders/orders-list-page.tsx` | `handleFilterChange(key,value)` setter (clears `offset`) | mirrors connections page |
+| 4.4 | `pages/orders/orders-list-page.tsx` | Render Source `Select`, Sort `Select`, two date inputs in the filter row | a11y labels; tabular/mono per style |
+| 4.5 | `pages/orders/orders-list-page.tsx` | `formatOrderRef()` helper + use in Order column cell + cardView title | UUID no longer shown raw; channel-prefixed + shortened |
+| 4.6 | `pages/orders/orders-list-page.tsx` | Harden `customerName()` with email fallback | cell never blank when email/city present |
+| 4.7 | `index.css` (+ `tokens.ts` if new var) | `/* ── Orders list filters (#939) ── */` bounded section for the filter row layout | reuse existing tokens; drift check passes |
+| 4.8 | `pages/orders/orders-list-page.test.tsx` | Tests: source filter sets `sourceConnectionId`; sort `Select` sets `sort`; date sets `createdFrom`; Order ref shows channel+short; Customer falls back to email | all green |
+
+## 5. Testing
+- FE unit/component (`orders-list-page.test.tsx`) — extend with the 4.8 cases, mirroring the existing segment-click URL-param assertions.
+- Full `pnpm lint` + `pnpm type-check` + `pnpm test`. No integration tests (FE-only, no API contract change).
+
+## 6. Risks
+- **Date-input UX** — native `<input type=date>` is the MVP-appropriate control (no date-picker primitive exists). Acceptable; note as follow-up if richer range UI wanted.
+- **Sort label honesty** — `dispatchBy` default must stay the initial sort so the triage ordering is unchanged when no `?sort` is set.
+- **C2 email is PII** — surfacing `customerEmail` as a fallback is consistent with it already being in the snapshot + on the detail page; if PII-hardening later hashes email, the fallback simply yields `—` again (no regression).


### PR DESCRIPTION
## What changed and why

Closes #939. Follow-up to the #929 orders-list redesign. Adds the filter/sort bar the spec mockup (`docs/plans/orders-list-redesign-mockup.html`) specced but never shipped, and fixes the two identity-cell defects on `/orders`. **Frontend-only** — no backend, adapter, or migration change.

### A — Filter + sort bar
The shipped page only had the health tiles + breaching chip; there was no way to filter by source or date, and `sort` was hardcoded. Added (mirroring the `connections-list-page` toolbar pattern, all URL-state per FE-001 § URL State):
- **Source** `Select` → existing `?sourceConnectionId`
- **Created date range** → `?createdFrom` / `?createdTo`. The inputs stay calendar-date (`YYYY-MM-DD`) in the URL so the native date control round-trips, and widen to start-/end-of-day UTC instants when building the query so the `To` bound is inclusive.
- **Sort** `Select` over the two server-supported orders (`dispatchBy` / `createdAt`), replacing the hardcoded value (`dispatchBy` stays the default).

The status-summary scope now also carries the date axis so segment counts stay coherent with an active date filter (`health` is still excluded so the aggregate can't self-filter).

### C — Identity cells

**Customer column showed `—` on every row — root cause found.** The persisted order snapshot serialises absent optional address fields as JSON `null` (e.g. the Allegro adapter emits `company: null`), but the FE `addressSchema` used `.optional()` (`string | undefined`), which **rejects `null`** and failed the whole-address `safeParse` — dropping the address and blanking the cell. Switched the optional string fields to `.nullish()` so one null field no longer drops the section. Also hardened `customerName` to fall back to the buyer email when the source omits a name.

**Order column showed a raw 36-char UUID.** That UUID is Allegro's real `checkoutFormId` (it has no friendly order number) — not a bug, just unreadable. Now shortened to a `head…tail` reference; short shop numbers pass through untouched. No channel prefix (the Channel column already conveys the marketplace).

Verified against the dev DB: `OL_STORE_PII=true`, addresses carry real names — confirming the `—` was the schema `null`-intolerance, not missing data or PII redaction.

One downstream fix: `generate-label-form.tsx` coalesces the now-nullable address name fields for the recipient contract.

## How to test
1. `/orders` — Customer column now shows buyer name + city (was `—`); Order column shows a shortened ref (was a full UUID).
2. Pick a source / set a created-date range / change sort — each reflects in the URL and is shareable; counts stay coherent.

## Scope notes
Deferred (consistent with #929 non-goals): clickable column-header sort (JSONB-derived columns the server can't `ORDER BY` without indexes), a status filter (overlaps the health tiles), destination filter, saved views, bulk selection. Native `<input type=date>` is the MVP control (no date-picker primitive exists yet).

## Tests
`pnpm lint` (0 errors), `pnpm type-check`, and the full web suite (1356) pass. Added: schema `null`-tolerance regressions; page tests for source/sort/date filters, UUID shortening, and the email fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)