### PR TITLE
fix(orders): skip re-ingestion of orders re-read from a destination connection

### DIFF
--- a/apps/api/test/integration/orders/order-reingestion-echo-guard.int-spec.ts
+++ b/apps/api/test/integration/orders/order-reingestion-echo-guard.int-spec.ts
@@ -1,0 +1,216 @@
+/**
+ * Order Re-ingestion Echo-Guard Int-Spec (#940 / ADR-017)
+ *
+ * Reproduces the destination-echo regression end-to-end against the real
+ * Postgres harness: an order that originated on Allegro is pushed into
+ * PrestaShop as a sync destination, then the PrestaShop reconciliation poll
+ * re-reads that PrestaShop order. Before the guard, `syncOrderFromSource`
+ * resolved the existing internal order (via the destination identifier
+ * mapping) and overwrote its `sourceConnectionId`/`sourceEventId`/snapshot
+ * while resetting `syncStatus` — flipping the order's channel to PrestaShop
+ * and dropping it out of fulfillment reconciliation.
+ *
+ * This slice exercises the REAL identifier-mapping resolution and REAL
+ * OrderRecord persistence — the layers the unit spec mocks, and exactly
+ * where the bug lived. Only the `OrderSource` adapter is stubbed, via the
+ * public `AdapterRegistryService` + `AdapterFactoryResolverService` seam
+ * (#570/#574), so no PrestaShop container is required. The guard's other
+ * branches (no existing record; same-source reconcile) are covered
+ * deterministically by the unit spec.
+ *
+ * @module apps/api/test/integration/orders
+ */
+import {
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterFactoryResolverService,
+  AdapterRegistryPort,
+} from '@openlinker/core/integrations';
+import {
+  CORE_ENTITY_TYPE,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  IIdentifierMappingService,
+} from '@openlinker/core/identifier-mapping';
+import {
+  IOrderIngestionService,
+  ORDER_INGESTION_SERVICE_TOKEN,
+  type IncomingOrder,
+  type OrderSourcePort,
+} from '@openlinker/core/orders';
+import { OrderRecordOrmEntity } from '@openlinker/core/orders/orm-entities';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from '../setup';
+import { createTestConnection } from '../helpers/test-connection.helper';
+import { createTestOrderRecord } from '../fixtures/order.fixtures';
+
+const PS_SOURCE_STUB_KEY = 'prestashop.test.echo.v1';
+
+function makeIncoming(externalOrderId: string, status: string): IncomingOrder {
+  return {
+    externalOrderId,
+    orderNumber: externalOrderId,
+    status,
+    items: [],
+    totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'PLN' },
+    createdAt: '2026-06-01T00:19:00.000Z',
+    updatedAt: '2026-06-01T05:20:00.000Z',
+  } as IncomingOrder;
+}
+
+describe('Order re-ingestion echo guard (#940)', () => {
+  let harness: IntegrationTestHarness;
+  let ingestion: IOrderIngestionService;
+  let identifierMapping: IIdentifierMappingService;
+  // Per-test programmable PrestaShop `OrderSource.getOrder` responses, keyed by external id.
+  const psSourceResponses = new Map<string, IncomingOrder>();
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    ingestion = harness.getApp().get<IOrderIngestionService>(ORDER_INGESTION_SERVICE_TOKEN);
+    identifierMapping = harness
+      .getApp()
+      .get<IIdentifierMappingService>(IDENTIFIER_MAPPING_SERVICE_TOKEN);
+
+    // Register a synthetic PrestaShop OrderSource adapter via the same public
+    // seam real plugins use. Process-lifetime, intentionally not unregistered
+    // (the registry throws on duplicate adapterKey) — mirrors the Allegro source
+    // stub precedent. Survives resetTestHarness (which only truncates the DB).
+    // `isDefault: false` keeps the real prestashop default adapter intact. The
+    // connection sets this adapterKey explicitly.
+    const registry = harness.getApp().get<AdapterRegistryPort>(ADAPTER_REGISTRY_TOKEN);
+    const factoryResolver = harness
+      .getApp()
+      .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
+
+    const psSourceStub: OrderSourcePort = {
+      listOrderFeed: () => Promise.resolve({ items: [], nextCursor: null }),
+      getOrder: ({ externalOrderId }) => {
+        const incoming = psSourceResponses.get(externalOrderId);
+        return incoming
+          ? Promise.resolve(incoming)
+          : Promise.reject(
+              new Error(`PS echo stub: no IncomingOrder registered for ${externalOrderId}`)
+            );
+      },
+    };
+
+    registry.register({
+      adapterKey: PS_SOURCE_STUB_KEY,
+      platformType: 'prestashop',
+      supportedCapabilities: ['OrderSource'],
+      displayName: 'PrestaShop OrderSource (echo-guard test stub)',
+      version: '0.0.0-test',
+      isDefault: false,
+    });
+    factoryResolver.registerFactory(PS_SOURCE_STUB_KEY, {
+      createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(psSourceStub as unknown as T),
+    });
+  });
+
+  afterEach(async () => {
+    psSourceResponses.clear();
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('skips re-ingestion and preserves source attribution + sync history when re-reading an order it created as a destination', async () => {
+    const dataSource = harness.getDataSource();
+
+    // An Allegro source connection and a PrestaShop connection that doubles as
+    // an OrderSource (the destination shop the poll re-reads).
+    const allegroConnection = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.test.unused',
+    });
+    const prestashopConnection = await createTestConnection(dataSource, {
+      platformType: 'prestashop',
+      name: 'PrestaShop destination',
+      adapterKey: PS_SOURCE_STUB_KEY,
+      enabledCapabilities: ['OrderSource'],
+    });
+
+    const allegroOrderId = 'allegro-checkout-abc';
+    const prestashopOrderId = '7';
+    const internalOrderId = 'ol_order_echo_guard_test';
+
+    // Mimic the post-sync identity state: the Allegro source mapping (created at
+    // ingest) and the PrestaShop destination mapping (created by OrderSyncService
+    // when the order was pushed into PrestaShop) both point at one internal order.
+    // The guard reads `record.sourceConnectionId`, not these mappings — the
+    // Allegro mapping is seeded for scenario realism; the PS destination mapping
+    // is what makes `getOrCreateInternalId(Order, '7', PS)` resolve to the
+    // existing order rather than minting a new one.
+    await identifierMapping.createMapping(
+      CORE_ENTITY_TYPE.Order,
+      allegroOrderId,
+      allegroConnection.id,
+      internalOrderId
+    );
+    await identifierMapping.createMapping(
+      CORE_ENTITY_TYPE.Order,
+      prestashopOrderId,
+      prestashopConnection.id,
+      internalOrderId
+    );
+
+    // The OrderRecord as it stands after a successful Allegro → PrestaShop sync:
+    // source = Allegro, synced to the PrestaShop destination.
+    await createTestOrderRecord(dataSource, {
+      internalOrderId,
+      sourceConnectionId: allegroConnection.id,
+      sourceEventId: 'allegro-evt-1',
+      orderSnapshot: { status: 'BOUGHT', orderNumber: allegroOrderId, items: [] },
+      recordStatus: 'ready',
+      syncStatus: [
+        {
+          destinationConnectionId: prestashopConnection.id,
+          status: 'synced',
+          syncedAt: '2026-06-01T00:19:52.000Z',
+          externalOrderId: prestashopOrderId,
+          externalOrderNumber: prestashopOrderId,
+        },
+      ],
+    });
+
+    // PrestaShop's projected view of the same order (a different status — what
+    // an overwrite would have written onto the record).
+    psSourceResponses.set(prestashopOrderId, makeIncoming(prestashopOrderId, 'PS_SHIPPED'));
+
+    // Act: the PrestaShop poll re-ingests its own (OL-created) order.
+    const result = await ingestion.syncOrderFromSource(
+      prestashopConnection.id,
+      prestashopOrderId
+    );
+
+    // The echo is a no-op.
+    expect(result).toEqual([]);
+
+    const recordRepo = dataSource.getRepository(OrderRecordOrmEntity);
+    const found = await recordRepo.findOne({ where: { internalOrderId } });
+
+    expect(found).not.toBeNull();
+    // Source attribution is untouched — still Allegro, not PrestaShop.
+    expect(found!.sourceConnectionId).toBe(allegroConnection.id);
+    expect(found!.sourceEventId).toBe('allegro-evt-1');
+    // Snapshot not overwritten with PrestaShop's projected status.
+    expect(found!.orderSnapshot.status).toBe('BOUGHT');
+    // Sync history preserved (a reset to [] would also break fulfillment sync).
+    expect(found!.syncStatus).toHaveLength(1);
+    expect(found!.syncStatus[0].destinationConnectionId).toBe(prestashopConnection.id);
+    expect(found!.syncStatus[0].status).toBe('synced');
+
+    // No duplicate internal order was minted; the PS external id still resolves
+    // to the original internal order.
+    expect(await recordRepo.count()).toBe(1);
+    expect(
+      await identifierMapping.getInternalId(
+        CORE_ENTITY_TYPE.Order,
+        prestashopOrderId,
+        prestashopConnection.id
+      )
+    ).toBe(internalOrderId);
+  });
+});

--- a/docs/architecture/adrs/017-cross-origin-order-reingestion-guard.md
+++ b/docs/architecture/adrs/017-cross-origin-order-reingestion-guard.md
@@ -1,0 +1,60 @@
+# ADR-017: Skip re-ingestion of orders re-read from a destination connection
+
+- **Status**: Accepted
+- **Date**: 2026-06-01
+- **Authors**: @piotrswierzy
+
+## Context
+
+OpenLinker ingests orders through a single core choke point, `OrderIngestionService.syncOrderFromSource(connectionId, externalOrderId)`, shared by both the webhook path and the poll path (#904/#906/#909). It hydrates the order from the connection's `OrderSourcePort`, resolves an internal order id via `IdentifierMappingService.getOrCreateInternalId(Order, externalOrderId, connectionId)`, and **upserts** the `OrderRecord` (snapshot + `sourceConnectionId` + `sourceEventId`, with `syncStatus`/`syncAttempts` reset).
+
+PrestaShop is both an `OrderSource` *and* an `OrderProcessorManager` destination. When an order that originated on Allegro is synced into PrestaShop, OpenLinker creates a PrestaShop order (id e.g. `7`) and records a destination identifier mapping `(Order, "7", PS-conn) → ol_order_X`. The `prestashop-orders-poll` reconciliation backstop (#904) then re-reads PrestaShop order `7`. Because the destination mapping already exists, `getOrCreateInternalId` resolves to the *same* `ol_order_X`, and the upsert **overwrites the order's source attribution** (Allegro → PrestaShop), `sourceEventId`, and snapshot, and resets `syncStatus`/`syncAttempts` to empty.
+
+Confirmed in #940 against live data: the affected order carried two mappings — its Allegro identity and the PS destination identity — to one internal id, with `sourceConnectionId` flipped to PrestaShop and `syncStatus = []`. The UI then shows Channel = PrestaShop (with an Allegro buyer email), "No sync destinations configured", and only an "Order received" activity event. Every Allegro→PrestaShop order loses its provenance on the next poll cycle.
+
+Resetting `syncStatus` to `[]` is a second, quieter failure: `marketplace.fulfillment.statusSync` locates destination orders by `syncStatus[].destinationConnectionId` (`fulfillment-status-sync.service.ts`), so a cleared `syncStatus` also drops the order out of destination-side fulfillment reconciliation.
+
+## Decision
+
+In `OrderIngestionService.syncOrderFromSource`, after the internal order id is resolved and **before** any persist, load the existing record and **skip re-ingestion (return no sync results) when the order already exists and originated from a *different* connection**:
+
+```ts
+const existing = await this.orderRecordService.getOrderRecord(internalOrderId);
+if (existing && existing.sourceConnectionId !== connectionId) {
+  // Destination echo: this external id on `connectionId` maps to an order that
+  // originated elsewhere and was pushed here as a sync destination. Re-ingesting
+  // would clobber its true source/event id/snapshot and reset sync history.
+  return [];
+}
+```
+
+The guard lives in the **core application orchestrator** — orchestration policy belongs in core application services, not handlers or adapters (architecture-overview § Sync Manager). It reuses the existing `IOrderRecordService.getOrderRecord` port method: **no new port, type, DTO, entity, or migration.**
+
+## Why a blanket skip (not a scoped reconcile) is correct
+
+- `OrderRecord` has no `status` column; order status lives only inside the JSONB `orderSnapshot`. For an Allegro-origin order, **Allegro is authoritative** for content and status, and its own source path (`syncOrderFromSource(allegroConn, …)`) reconciles the snapshot normally because `source === connectionId` (the guard does not fire).
+- Destination-side fulfillment/shipment changes reach OpenLinker through dedicated jobs — `marketplace.fulfillment.statusSync` (reads PrestaShop → writes the `Shipment` table) and `marketplace.shipment.statusSync` (carrier → `Shipment`). Both key on `destinationConnectionId` and are independent of `sourceConnectionId`; neither writes `OrderRecord` status. The guard does not affect them — and by preserving `syncStatus` it *restores* fulfillment sync's ability to find the order.
+- The PrestaShop poll echo is the only writer of PrestaShop's *projected* view onto the record. That view is non-authoritative for a marketplace-origin order, so writing it is wrong, not a feature being lost.
+
+## Alternatives considered
+
+- **Scoped reconcile (update fulfillment/status only, keep source):** rejected — there is no `OrderRecord` status field to update, and destination fulfillment is already owned by the status-sync jobs. A scoped reconcile would add machinery for data nothing consumes from this path.
+- **Feed-level filter / origin marker on destination create** (issue option 2): stamp OL-created PrestaShop orders and exclude them from `listOrderFeed`. Cleaner long-term (also avoids the wasted `getOrder` hydration) but platform-specific and larger. Deferred; the core guard is platform-agnostic and sufficient for correctness.
+- **Make `persistOrder` refuse to change `sourceConnectionId`** (issue option 3): a defensive backstop in the persistence service. The guard short-circuits before persist, so this is redundant for the echo; retained as a possible future hardening.
+- **Reverse identifier-mapping lookup** (`getExternalIds` → any mapping under a different connection) as the discriminator: more robust (immune to an already-clobbered `source` field, would also flag corrupted rows) but heavier. The record-field comparison is correct for all *new* orders, which is the prevention scope here.
+
+## Consequences
+
+**Pros**
+- Marketplace-origin orders keep their true `sourceConnectionId`, `sourceEventId`, snapshot, and `syncStatus` across PrestaShop poll cycles.
+- Repairs a second latent bug: fulfillment status sync no longer loses cross-origin orders to a wiped `syncStatus`.
+- Converts a previously-throwing path (`NoOrderDestinationsAvailableException`, source filtered out → zero destinations) into a clean no-op (`[]`), removing dead/retried jobs for these orders.
+- No schema/contract change; confined to one core service.
+
+**Cons / trade-offs**
+- **Directional assumption.** Encodes today's topology (marketplace → shop; only shops are `OrderProcessorManager` destinations). If shop→marketplace order push is ever added, this guard would skip legitimate updates — a future implementer must revisit it (this ADR is the breadcrumb).
+- **Preventive, not curative.** Already-corrupted rows (whose `sourceConnectionId` is already the PrestaShop connection) won't trip the guard; their repair is a separate #940 follow-up.
+- **One wasted source hydration per echo.** The guard sits after `getOrder()`, so an echo still costs one PrestaShop API round-trip before skipping (bounded by the `date_upd` watermark window). Option 2 would remove it.
+- **One extra record read per ingestion.** The `getOrderRecord` lookup runs on *every* ingestion (webhook and poll, every order), not just echoes — a wasted indexed PK read on the common new-order / same-source path. Negligible, but it's a per-order cost, not echo-only. Option 2 would remove it too.
+
+The `marketplace.order.sync` handler returns `{ outcome: 'ok' }` on any non-throwing `syncOrderFromSource` return, so the `[]` skip is recorded as a succeeded job (verified in `marketplace-order-sync.handler.ts`) — replacing the prior `NoOrderDestinationsAvailableException` → failed/retried job for these echoes.

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -105,5 +105,6 @@ One pointer per section, identical format every time.
 | [ADR-013](./013-neutral-oauth-completion-port.md) | Neutral OAuth-completion port — relocate Allegro OAuth into the plugin | Accepted | 2026-05-28 |
 | [ADR-014](./014-source-authoritative-order-pricing.md) | Source-authoritative order pricing | Proposed | 2026-05-30 |
 | [ADR-015](./015-inbound-event-routing-capability-translated.md) | Capability-driven, plugin-translated inbound webhook event routing | Accepted | 2026-05-30 |
+| [ADR-017](./017-cross-origin-order-reingestion-guard.md) | Skip re-ingestion of orders re-read from a destination connection | Accepted | 2026-06-01 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/docs/plans/implementation-plan-orders-echo-source-overwrite-guard.md
+++ b/docs/plans/implementation-plan-orders-echo-source-overwrite-guard.md
@@ -1,0 +1,81 @@
+# Implementation Plan — Echo guard: stop the PrestaShop poll from overwriting Allegro order provenance (#940)
+
+## 1. Understand the task
+
+**Goal.** When the PrestaShop reconciliation poll (`prestashop-orders-poll`, #904) re-reads an order that OpenLinker itself created in PrestaShop as a *sync destination* (originating on Allegro), it must **not** re-ingest it as a PrestaShop-sourced order. Today re-ingestion resolves to the same internal order (via the destination identifier mapping) and then **overwrites** its `sourceConnectionId`, `sourceEventId`, and snapshot, and **resets** `syncStatus` / `syncAttempts` to empty — destroying the order's Allegro provenance and sync history.
+
+**Layer.** CORE — application-layer orchestration policy (`OrderIngestionService`). No new ports, no schema change.
+
+**Non-goals (deferred).**
+- Feed-level filtering of OL-created PS orders / origin marker on destination create (issue option 2) — platform-specific; not needed for correctness.
+- Making `persistOrder` defensively source-preserving (issue option 3) — superseded by short-circuiting before persist; can be a later backstop.
+- Data repair of already-corrupted rows — tracked as a separate follow-up in #940.
+
+## 2. Research (findings)
+
+- `OrderIngestionService.syncOrderFromSource(connectionId, externalOrderId, sourceEventId?)` is the single choke point for both webhook and poll ingestion (`libs/core/src/orders/application/services/order-ingestion.service.ts:178`). It:
+  1. `getOrder()` hydrates the incoming order,
+  2. `getOrCreateInternalId(Order, incoming.externalOrderId, connectionId)` — for an echo this **resolves the existing** destination mapping (no new mapping),
+  3. `persistIncomingSnapshot(...)` then `persistOrder(...)` **upsert** the record, overwriting source + resetting `syncStatus`/`syncAttempts` (`order-record.service.ts:99-113,155-169`).
+- `IOrderRecordService.getOrderRecord(internalOrderId): Promise<OrderRecord | null>` already exists (`order-record.service.interface.ts:80`); `OrderRecord` carries `sourceConnectionId`. → cheap PK lookup, no new method.
+- `syncOrderFromSource` returns `OrderSyncResult[]` (`syncOrder` return). An empty array `[]` is a valid no-op result.
+- Existing unit spec (`__tests__/order-ingestion.service.spec.ts`) already mocks `getOrderRecord` returning `undefined` → guard is inert for all current tests (backward compatible).
+
+## 3. Design
+
+Add an **echo guard** in `syncOrderFromSource`, after `internalOrderId` is resolved and **before** `persistIncomingSnapshot` / customer resolution:
+
+```ts
+const existing = await this.orderRecordService.getOrderRecord(internalOrderId);
+if (existing && existing.sourceConnectionId !== connectionId) {
+  // Destination echo: this external id on `connectionId` maps to an order that
+  // originated elsewhere and was pushed here as a sync destination. Re-ingesting
+  // would clobber its true source + sync history. Skip; the real source stays
+  // authoritative, and destination status flows via the status-sync jobs.
+  this.logger.debug(`Skipping destination echo for ${internalOrderId} …`);
+  return [];
+}
+```
+
+**Correctness across scenarios:**
+| Scenario | `getOrderRecord` | guard fires? | outcome |
+|---|---|---|---|
+| New order (any source), 1st ingest | `null` | no | normal create |
+| Genuine PS-direct order re-polled | record, `source==PS==conn` | no | normal reconcile |
+| Allegro order re-ingested from Allegro | record, `source==Allegro==conn` | no | normal reconcile (authoritative) |
+| **Allegro order re-read by PS poll (echo)** | record, `source==Allegro≠PS` | **yes** | **skip — provenance preserved** |
+
+Idempotent: on a skip the record keeps its original source, so subsequent echoes are detected identically.
+
+## 4. Implementation steps
+
+1. **`libs/core/src/orders/application/services/order-ingestion.service.ts`** — insert the guard between `getOrCreateInternalId` (~line 195) and `resolveCustomerId` (~line 197). Acceptance: echo input returns `[]`; `persistIncomingSnapshot`/`persistOrder`/`syncOrder` not called.
+2. **`__tests__/order-ingestion.service.spec.ts`** — add a `describe('destination echo guard (#940)')` block:
+   - skips (returns `[]`, no persist/sync) when existing record's `sourceConnectionId !== connectionId`;
+   - proceeds normally when `getOrderRecord` returns `null`;
+   - proceeds normally when existing record's `sourceConnectionId === connectionId` (genuine same-source reconcile).
+
+## 5. Validation
+
+- Architecture: orchestration policy stays in the core application service; no boundary crossed; no new dependency. ✅
+- Naming/standards: no new types; reuses existing port method. ✅
+- Testing: unit-level (mock ports). Quality gate `pnpm lint && pnpm type-check && pnpm test`. ✅
+- Security: none. No schema change → no migration.
+
+## Tech-review resolution (item 1 — "is the skip safe?")
+
+Verified against the code. **The blanket skip is safe and strictly more correct:**
+
+- `OrderRecord` has **no `status` column** (`order-record.orm-entity.ts`) — order status lives only inside the JSONB `orderSnapshot`. The authoritative source for an Allegro-origin order's content/status is **Allegro**; its own source path (`syncOrderFromSource(allegroConn, …)`) reconciles the snapshot normally because `source === connectionId` (guard doesn't fire).
+- Destination-side fulfillment/shipment changes flow via dedicated jobs — `marketplace.fulfillment.statusSync` (reads PrestaShop → writes the **Shipment** table; `fulfillment-status-sync.service.ts`) and `marketplace.shipment.statusSync` (carrier → Shipment). Both key on `destinationConnectionId` and are **independent of `sourceConnectionId`**, so the guard doesn't affect them. Neither writes `OrderRecord` status today.
+- The PS poll echo is the *only* writer of PrestaShop's projected view onto the record — and it writes non-authoritative data while resetting `syncStatus`/`syncAttempts` to `[]`. That reset additionally **breaks fulfillment sync**, which locates the order by its `syncStatus[].destinationConnectionId`. Skipping the echo therefore *repairs* a second latent bug.
+
+**Decision:** keep the simple `return []`; no scoped reconcile is warranted. Captured in [ADR-017](../architecture/adrs/017-cross-origin-order-reingestion-guard.md).
+
+## Risks / open questions
+
+- **Wasted `getOrder()` hydration per echo.** The guard sits after `getOrder()`, so an echo still costs one source API round-trip before skipping. Bounded (an OL-created order only re-enters the feed while inside the `date_upd` watermark window), acceptable for the core fix; option-2 feed filtering would eliminate it later.
+- **One extra `getOrderRecord` read per ingestion.** The guard's record lookup runs on every ingestion (webhook and poll, every order), not just echoes — an indexed PK read wasted on the common new-order / same-source path. Negligible but per-order; option-2 would remove it.
+- Placing the guard after `getOrder` (not before) avoids assuming the `externalOrderId` param equals `incoming.externalOrderId`; correctness over micro-optimization.
+- **Directional assumption.** The guard encodes today's topology (marketplace → shop; only shops are `OrderProcessorManager` destinations). If a shop→marketplace order push is ever added, this guard would skip legitimate updates — documented in ADR-017 so a future implementer finds it.
+- **Preventive, not curative.** The field comparison won't fire for already-corrupted rows (their `source` is already the PS connection). Data repair of existing rows is a separate #940 follow-up.

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -23,6 +23,7 @@ import type { IOrderSyncService } from '../../interfaces/order-sync.service.inte
 import type { IOrderRecordService } from '../../interfaces/order-record.service.interface';
 import type { IOrderItemRefResolverService } from '../../interfaces/order-item-ref-resolver.service.interface';
 import { MissingOrderItemMappingError } from '../../../domain/exceptions/missing-order-item-mapping.error';
+import type { OrderRecord } from '../../../domain/entities/order-record.entity';
 
 describe('OrderIngestionService', () => {
   let service: OrderIngestionService;
@@ -424,6 +425,65 @@ describe('OrderIngestionService', () => {
       await service.syncOrderFromSource(connectionId, externalOrderId);
 
       expect(customerProjectionUpdater.updateProjectionsForOrder).not.toHaveBeenCalled();
+      expect(orderSyncService.syncOrder).toHaveBeenCalled();
+    });
+  });
+
+  describe('syncOrderFromSource – destination-echo guard (#940)', () => {
+    const externalOrderId = 'ps-order-7';
+
+    const baseIncoming = {
+      externalOrderId,
+      orderNumber: externalOrderId,
+      status: 'BOUGHT',
+      items: [],
+      totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'PLN' },
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    };
+
+    beforeEach(() => {
+      identifierMapping.getOrCreateInternalId.mockResolvedValue('ol_order_echo');
+      orderSource.getOrder.mockResolvedValue(baseIncoming);
+      integrationsService.getCapabilityAdapter.mockResolvedValue(orderSource);
+    });
+
+    it('should skip re-ingestion and return [] when the resolved order originated from a different connection', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        sourceConnectionId: 'allegro-connection',
+      } as unknown as OrderRecord);
+
+      const result = await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(result).toEqual([]);
+      // Source attribution, snapshot and sync history must be left untouched.
+      expect(orderRecordService.persistIncomingSnapshot).not.toHaveBeenCalled();
+      expect(orderRecordService.persistOrder).not.toHaveBeenCalled();
+      expect(orderSyncService.syncOrder).not.toHaveBeenCalled();
+      expect(orderItemRefResolver.tryResolve).not.toHaveBeenCalled();
+    });
+
+    it('should proceed with ingestion when no existing order record is found (genuinely new order)', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(null);
+      orderSyncService.syncOrder.mockResolvedValue([]);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(orderRecordService.persistIncomingSnapshot).toHaveBeenCalled();
+      expect(orderRecordService.persistOrder).toHaveBeenCalled();
+      expect(orderSyncService.syncOrder).toHaveBeenCalled();
+    });
+
+    it('should proceed with ingestion when the existing order shares the same source connection (genuine same-source reconcile)', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        sourceConnectionId: connectionId,
+      } as unknown as OrderRecord);
+      orderSyncService.syncOrder.mockResolvedValue([]);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(orderRecordService.persistIncomingSnapshot).toHaveBeenCalled();
+      expect(orderRecordService.persistOrder).toHaveBeenCalled();
       expect(orderSyncService.syncOrder).toHaveBeenCalled();
     });
   });

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -194,6 +194,28 @@ export class OrderIngestionService implements IOrderIngestionService {
       connectionId
     );
 
+    // Destination-echo guard (#940 / ADR-017): if an internal order already
+    // exists for this external id and it originated from a DIFFERENT connection,
+    // this is a re-read of an order OpenLinker itself created here as a sync
+    // destination (e.g. the PrestaShop reconciliation poll re-reading an
+    // Allegro-origin order it pushed in). Re-ingesting would overwrite the
+    // order's true source, source event id and snapshot, and reset its sync
+    // history — so skip. The real source stays authoritative; destination-side
+    // fulfillment flows through the dedicated *.statusSync jobs (which key on
+    // destinationConnectionId, not the source) and is unaffected.
+    const existing = await this.orderRecordService.getOrderRecord(internalOrderId);
+    if (existing && existing.sourceConnectionId !== connectionId) {
+      // `debug` not `log`: this is an expected, per-order steady-state skip that
+      // fires for every cross-origin order on each poll within the watermark
+      // window — emitting it at info level would be production noise.
+      this.logger.debug(
+        `Skipping destination-echo re-ingestion of order ${internalOrderId}: ` +
+          `external id ${incoming.externalOrderId} on connection ${connectionId} ` +
+          `maps to an order originating from ${existing.sourceConnectionId}`
+      );
+      return [];
+    }
+
     const internalCustomerId = await this.resolveCustomerId(
       incoming,
       connectionId,


### PR DESCRIPTION
## What & why

An order that originates on Allegro is pushed into PrestaShop as a sync destination. The PrestaShop reconciliation poll (#904) then re-reads that PrestaShop order, and because the destination identifier mapping already exists, `OrderIngestionService.syncOrderFromSource` resolved the **same** internal order and overwrote its `sourceConnectionId` / `sourceEventId` / snapshot while resetting `syncStatus` / `syncAttempts`.

Effect (confirmed against live data in #940): an Allegro-origin order flips to **Channel = PrestaShop** (with an Allegro buyer email), loses its sync history, and shows "No sync destinations configured". The cleared `syncStatus` additionally drops the order out of `marketplace.fulfillment.statusSync` (which locates destination orders by `syncStatus[].destinationConnectionId`).

## Fix

Add a **destination-echo guard** in `syncOrderFromSource`: after resolving the internal order id and before any persist, skip (return no sync results) when an existing record originated from a *different* connection.

```ts
const existing = await this.orderRecordService.getOrderRecord(internalOrderId);
if (existing && existing.sourceConnectionId !== connectionId) {
  return []; // destination echo — leave source + sync history untouched
}
```

**Why a blanket skip is safe and strictly more correct** (see ADR-017 for the full analysis):
- `OrderRecord` has no `status` column — order content/status lives in the snapshot, for which **Allegro is authoritative**; its own source path reconciles normally (guard doesn't fire).
- Destination fulfillment/shipment flows through the dedicated `marketplace.fulfillment.statusSync` / `marketplace.shipment.statusSync` jobs, which key on `destinationConnectionId` and are independent of `sourceConnectionId`.
- The skip preserves `syncStatus`, *repairing* the latent fulfillment-sync drop.
- `marketplace.order.sync` returns `{ outcome: 'ok' }` on any non-throwing return, so the `[]` skip is a succeeded job (replacing the prior `NoOrderDestinationsAvailableException` → failed/retried job for these echoes).

Confined to one core application service — **no port, type, DTO, entity, or migration change.**

## How to test

- `pnpm --filter @openlinker/core exec jest order-ingestion.service.spec` — guard unit tests (echo skip / new-order passthrough / same-source reconcile).
- `pnpm --filter @openlinker/api exec jest --config test/jest-integration.cjs --testPathPattern=order-reingestion-echo-guard` — vertical slice over the real Postgres harness (real identifier-mapping + OrderRecord persistence; `OrderSource` stubbed via the public registry seam, no PrestaShop container). Asserts source stays Allegro, `syncStatus` preserved, no duplicate order minted.

## Notes / follow-ups

- **Directional assumption** (ADR-017): encodes today's marketplace → shop topology; a future shop→marketplace order push must revisit the guard.
- **Preventive, not curative**: already-corrupted rows aren't healed by this guard — data repair is a separate #940 follow-up.
- Deferred: option-2 feed-level filter / origin marker (would also remove the per-echo `getOrder` hydration and the per-ingestion `getOrderRecord` read).

Closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)