### PR TITLE
fix(web): reserve KPI card height so the orders filter bar can't overlap it (#943)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7187,7 +7187,13 @@ a.kpi-card:focus-visible {
 /* ── Orders list redesign (#929) ───────────────────────────────────── */
 /* Status segments double as clickable health filters: a reset button wraps a
    MetricCard; the active segment mirrors the chip-active accent treatment. */
-.orders-segments { margin-bottom: var(--space-4); }
+/* `grid-auto-rows: minmax(5.5rem, auto)` reserves the real card height on the
+   track (#943): `.orders-segment` is a `<button>` and its `.metric-card` child
+   uses `height: 100%`, so a percentage height against the auto-height button
+   collapses during track sizing — the track shrank to ~32px while the cards
+   render 88px and overflowed downward, colliding with the filter bar below.
+   5.5rem matches `.metric-card`'s own `min-height`. */
+.orders-segments { margin-bottom: var(--space-4); grid-auto-rows: minmax(5.5rem, auto); }
 .orders-segment {
   display: block;
   width: 100%;


### PR DESCRIPTION
## What & why

Closes #943. On `/orders` the #939 filter/sort bar rendered **on top of the KPI segment cards** — values clipped, colored card backgrounds running behind the selects.

**Root cause (measured):** `.orders-segment` is a `<button>` (auto height) whose `.metric-card` child uses `height: 100%`. The percentage height collapses against the auto-height button during grid track sizing, so `.orders-segments` reserved only **32px** while the cards render **88px** and overflow downward into the toolbar below. Pre-dates #939 (the old chip row overlapped too, just invisibly); the taller bordered toolbar exposed it.

**Fix:** one line —
```css
.orders-segments { grid-auto-rows: minmax(5.5rem, auto); }
```
`5.5rem` matches `.metric-card`'s own `min-height`, so the track reserves the real card height.

## Verification

Measured the injected segments+toolbar markup against the compiled stylesheet:

| | grid track | card | toolbar vs card |
|---|---|---|---|
| before | 32px | 88px | −12px (overlap) |
| after | 88px | 88px | +16px gap |

(No unit test — this is pure layout, which jsdom doesn't compute. Verified via DevTools measurement instead.)

## Gate
`pnpm lint` (incl. design-token drift), type-check, and the full web suite (1356) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)