### PR TITLE
feat(orders): server-side sortable columns on the /orders list (#944)

### DIFF
--- a/apps/api/src/migrations/1800000000000-add-order-sort-indexes.ts
+++ b/apps/api/src/migrations/1800000000000-add-order-sort-indexes.ts
@@ -1,0 +1,36 @@
+/**
+ * Add Order Sort Indexes
+ *
+ * Expression indexes backing the server-side sortable columns on the /orders
+ * list (#944): total (numeric), item count, and customer last name are derived
+ * from the `orderSnapshot` JSONB, so a plain column index can't cover them.
+ * The `status` sort uses a bounded health `CASE` (cheap, no index). `createdAt`
+ * / `dispatchByAt` already have B-tree indexes from earlier migrations.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderSortIndexes1800000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_order_records_snapshot_total" ON "order_records" ` +
+        `((("orderSnapshot"#>>'{totals,total}')::numeric))`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_order_records_snapshot_customer" ON "order_records" ` +
+        `((lower("orderSnapshot"#>>'{shippingAddress,lastName}')))`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_order_records_snapshot_items" ON "order_records" ` +
+        `((CASE WHEN jsonb_typeof("orderSnapshot"->'items') = 'array' ` +
+        `THEN jsonb_array_length("orderSnapshot"->'items') END))`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_order_records_snapshot_items"`);
+    await queryRunner.query(`DROP INDEX "IDX_order_records_snapshot_customer"`);
+    await queryRunner.query(`DROP INDEX "IDX_order_records_snapshot_total"`);
+  }
+}

--- a/apps/api/src/migrations/1800000000000-add-order-sort-indexes.ts
+++ b/apps/api/src/migrations/1800000000000-add-order-sort-indexes.ts
@@ -15,7 +15,8 @@ export class AddOrderSortIndexes1800000000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `CREATE INDEX "IDX_order_records_snapshot_total" ON "order_records" ` +
-        `((("orderSnapshot"#>>'{totals,total}')::numeric))`
+        `((CASE WHEN jsonb_typeof("orderSnapshot"#>'{totals,total}') = 'number' ` +
+        `THEN ("orderSnapshot"#>>'{totals,total}')::numeric END))`
     );
     await queryRunner.query(
       `CREATE INDEX "IDX_order_records_snapshot_customer" ON "order_records" ` +
@@ -29,8 +30,8 @@ export class AddOrderSortIndexes1800000000000 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX "IDX_order_records_snapshot_items"`);
-    await queryRunner.query(`DROP INDEX "IDX_order_records_snapshot_customer"`);
-    await queryRunner.query(`DROP INDEX "IDX_order_records_snapshot_total"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_records_snapshot_items"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_records_snapshot_customer"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_records_snapshot_total"`);
   }
 }

--- a/apps/api/src/orders/http/dto/list-orders-query.dto.ts
+++ b/apps/api/src/orders/http/dto/list-orders-query.dto.ts
@@ -22,12 +22,14 @@ import {
   OrderRecordStatusValues,
   OrderHealthValues,
   OrderRecordSortValues,
+  OrderRecordSortDirectionValues,
 } from '@openlinker/core/orders';
 import {
   OrderSyncStatusFilter,
   OrderRecordStatus,
   OrderHealth,
   OrderRecordSort,
+  OrderRecordSortDirection,
 } from '@openlinker/core/orders';
 
 export class ListOrdersQueryDto {
@@ -88,11 +90,20 @@ export class ListOrdersQueryDto {
   @ApiPropertyOptional({
     enum: OrderRecordSortValues,
     description:
-      'Result ordering (#927). "createdAt" (default) = newest first; "dispatchBy" = ship-by deadline ascending (soonest first, NULLs last) — the triage default on the orders list.',
+      'Result ordering (#927/#944). "dispatchBy" = ship-by deadline (triage default, NULLs last); "createdAt" = ingestion time; "customer"/"items"/"status"/"total" back the sortable table columns (derived from the order snapshot + health). Pair with `dir`.',
   })
   @IsOptional()
   @IsEnum(OrderRecordSortValues)
   sort?: OrderRecordSort;
+
+  @ApiPropertyOptional({
+    enum: OrderRecordSortDirectionValues,
+    description:
+      'Sort direction for `sort` (#944). Defaults per-column server-side when omitted; the UI sends an explicit direction once a header is clicked.',
+  })
+  @IsOptional()
+  @IsEnum(OrderRecordSortDirectionValues)
+  dir?: OrderRecordSortDirection;
 
   @ApiPropertyOptional({
     description:

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -119,6 +119,17 @@ describe('OrdersController', () => {
       );
     });
 
+    it('passes the sort key and direction through to the repository (#944)', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.listOrders({ sort: 'total', dir: 'desc', limit: 20, offset: 0 });
+
+      expect(repository.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: 'total', dir: 'desc' }),
+        { limit: 20, offset: 0 }
+      );
+    });
+
     it('should return empty list when no orders match', async () => {
       repository.findMany.mockResolvedValue({ items: [], total: 0 });
 

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -77,6 +77,7 @@ export class OrdersController {
       recordStatus,
       health,
       sort,
+      dir,
       dueBefore,
       limit = 20,
       offset = 0,
@@ -92,6 +93,7 @@ export class OrdersController {
         recordStatus,
         health,
         sort,
+        dir,
         dueBefore: dueBefore ? new Date(dueBefore) : undefined,
       },
       { limit, offset }

--- a/apps/api/test/integration/order-column-sort.int-spec.ts
+++ b/apps/api/test/integration/order-column-sort.int-spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Order Column-Sort Integration Test (#944)
+ *
+ * Exercises the real `OrderRecordRepository.findMany` against Testcontainers
+ * Postgres for the server-side sortable columns: `total` / `items` / `customer`
+ * (JSONB-derived from `orderSnapshot`) and `status` (the health ordinal),
+ * including the `dir` direction override. Mirrors the dispatch-SLA spec's
+ * harness + seed-then-assert-order pattern.
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+import { createTestOrderRecord } from './fixtures/order.fixtures';
+import {
+  ORDER_RECORD_REPOSITORY_TOKEN,
+  OrderRecordRepositoryPort,
+} from '@openlinker/core/orders';
+
+const SOURCE = '11111111-1111-4111-8111-111111111111';
+const PAGE = { limit: 50, offset: 0 };
+
+describe('Order column sort (integration)', () => {
+  let harness: IntegrationTestHarness;
+  let repository: OrderRecordRepositoryPort;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    repository = harness.getApp().get<OrderRecordRepositoryPort>(ORDER_RECORD_REPOSITORY_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('sorts by total descending (default direction), NULLs last', async () => {
+    const ds = harness.getDataSource();
+    const cheap = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [], totals: { total: 10.5, currency: 'PLN' } },
+    });
+    const pricey = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [], totals: { total: 199.99, currency: 'PLN' } },
+    });
+    const noTotal = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [] },
+    });
+
+    const { items } = await repository.findMany({ sort: 'total', dir: 'desc' }, PAGE);
+
+    expect(items.map((o) => o.internalOrderId)).toEqual([
+      pricey.internalOrderId,
+      cheap.internalOrderId,
+      noTotal.internalOrderId, // NULLs last
+    ]);
+  });
+
+  it('sorts by total ascending when dir=asc', async () => {
+    const ds = harness.getDataSource();
+    const cheap = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [], totals: { total: 10.5, currency: 'PLN' } },
+    });
+    const pricey = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [], totals: { total: 199.99, currency: 'PLN' } },
+    });
+
+    const { items } = await repository.findMany({ sort: 'total', dir: 'asc' }, PAGE);
+
+    expect(items.map((o) => o.internalOrderId)).toEqual([
+      cheap.internalOrderId,
+      pricey.internalOrderId,
+    ]);
+  });
+
+  it('sorts by item count descending', async () => {
+    const ds = harness.getDataSource();
+    const one = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [{ id: 'a', quantity: 1, price: 1 }] },
+    });
+    const three = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: {
+        items: [
+          { id: 'a', quantity: 1, price: 1 },
+          { id: 'b', quantity: 1, price: 1 },
+          { id: 'c', quantity: 1, price: 1 },
+        ],
+      },
+    });
+
+    const { items } = await repository.findMany({ sort: 'items', dir: 'desc' }, PAGE);
+
+    expect(items.map((o) => o.internalOrderId)).toEqual([
+      three.internalOrderId,
+      one.internalOrderId,
+    ]);
+  });
+
+  it('sorts by customer last name ascending (case-insensitive), NULLs last', async () => {
+    const ds = harness.getDataSource();
+    const nowak = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [], shippingAddress: { lastName: 'nowak' } },
+    });
+    const kowalski = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [], shippingAddress: { lastName: 'Kowalski' } },
+    });
+    const noName = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [] },
+    });
+
+    const { items } = await repository.findMany({ sort: 'customer', dir: 'asc' }, PAGE);
+
+    expect(items.map((o) => o.internalOrderId)).toEqual([
+      kowalski.internalOrderId, // 'kowalski' < 'nowak' (lowercased)
+      nowak.internalOrderId,
+      noName.internalOrderId, // NULLs last
+    ]);
+  });
+
+  it('sorts by status ascending using the triage-urgency ordinal (needs_attention first)', async () => {
+    const ds = harness.getDataSource();
+    const synced = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      recordStatus: 'ready',
+      syncStatus: [{ destinationConnectionId: SOURCE, status: 'synced' }],
+    });
+    const needsAttention = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      recordStatus: 'ready',
+      syncStatus: [{ destinationConnectionId: SOURCE, status: 'failed' }],
+    });
+    const awaitingMapping = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      recordStatus: 'awaiting_mapping',
+      syncStatus: [],
+    });
+    const awaitingDispatch = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      recordStatus: 'ready',
+      syncStatus: [{ destinationConnectionId: SOURCE, status: 'pending' }],
+    });
+
+    const { items } = await repository.findMany({ sort: 'status', dir: 'asc' }, PAGE);
+
+    expect(items.map((o) => o.internalOrderId)).toEqual([
+      needsAttention.internalOrderId, // 0
+      awaitingMapping.internalOrderId, // 1
+      awaitingDispatch.internalOrderId, // 2
+      synced.internalOrderId, // 3
+    ]);
+  });
+});

--- a/apps/api/test/integration/order-column-sort.int-spec.ts
+++ b/apps/api/test/integration/order-column-sort.int-spec.ts
@@ -65,6 +65,27 @@ describe('Order column sort (integration)', () => {
     ]);
   });
 
+  it('does not throw on a non-numeric total — guarded cast sorts it NULLs-last (#944)', async () => {
+    const ds = harness.getDataSource();
+    const valid = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [], totals: { total: 42, currency: 'PLN' } },
+    });
+    // Malformed snapshot — a non-numeric total would throw on a bare ::numeric
+    // cast; the jsonb_typeof guard must treat it as NULL instead.
+    const malformed = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [], totals: { total: 'not-a-number', currency: 'PLN' } },
+    });
+
+    const { items } = await repository.findMany({ sort: 'total', dir: 'desc' }, PAGE);
+
+    expect(items.map((o) => o.internalOrderId)).toEqual([
+      valid.internalOrderId,
+      malformed.internalOrderId, // non-numeric → NULL → last
+    ]);
+  });
+
   it('sorts by total ascending when dir=asc', async () => {
     const ds = harness.getDataSource();
     const cheap = await createTestOrderRecord(ds, {

--- a/apps/web/src/features/orders/api/orders.api.ts
+++ b/apps/web/src/features/orders/api/orders.api.ts
@@ -40,6 +40,7 @@ function buildQuery(filters?: OrderFilters, pagination?: OrderPagination): strin
   if (filters?.recordStatus) params.set('recordStatus', filters.recordStatus);
   if (filters?.health) params.set('health', filters.health);
   if (filters?.sort) params.set('sort', filters.sort);
+  if (filters?.dir) params.set('dir', filters.dir);
   if (filters?.dueBefore) params.set('dueBefore', filters.dueBefore);
   if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
   if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -69,10 +69,23 @@ export interface OrderRecord {
   dispatchByAt?: string | null;
 }
 
-// Result ordering for the orders list (#927). Mirrors `OrderRecordSortValues`
-// in `@openlinker/core/orders`. `dispatchBy` = ship-by ascending (triage default).
-export const OrderSortValues = ['createdAt', 'dispatchBy'] as const;
+// Result ordering for the orders list (#927, extended #944). Mirrors
+// `OrderRecordSortValues` in `@openlinker/core/orders`. `dispatchBy` = ship-by
+// ascending (triage default); `customer`/`items`/`status`/`total` back the
+// sortable table columns (server-side).
+export const OrderSortValues = [
+  'createdAt',
+  'dispatchBy',
+  'customer',
+  'items',
+  'status',
+  'total',
+] as const;
 export type OrderSortValue = (typeof OrderSortValues)[number];
+
+// Sort direction (#944). Mirrors `OrderRecordSortDirectionValues` in core.
+export const OrderSortDirectionValues = ['asc', 'desc'] as const;
+export type OrderSortDirection = (typeof OrderSortDirectionValues)[number];
 
 // Derived order-health buckets (#929). Hand-mirrored from `OrderHealthValues`
 // in `@openlinker/core/orders` per the FE-001 contract strategy — keep in sync.
@@ -108,8 +121,10 @@ export interface OrderFilters {
   recordStatus?: OrderRecordStatusValue;
   /** Filter to a single derived health bucket (#929). */
   health?: OrderHealthValue;
-  /** Result ordering (#927); `dispatchBy` = ship-by ascending (triage default). */
+  /** Result ordering (#927/#944); `dispatchBy` = ship-by ascending (triage default). */
   sort?: OrderSortValue;
+  /** Sort direction for `sort` (#944); defaults per-column server-side when omitted. */
+  dir?: OrderSortDirection;
   /** SLA "breaching / overdue" filter (#927): ISO instant; keeps orders with a ship-by deadline ≤ this. */
   dueBefore?: string;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7241,10 +7241,6 @@ a.kpi-card:focus-visible {
   gap: var(--space-3);
   margin-bottom: var(--space-3);
 }
-/* Push the sort control to the trailing edge — filters lead, sort trails. */
-.orders-toolbar__sort {
-  margin-left: auto;
-}
 /* Inline date field: small mono-caps label sitting left of the native input. */
 .orders-toolbar__field {
   display: inline-flex;

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -371,7 +371,8 @@ describe('OrdersListPage', () => {
     renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
 
     await screen.findByText('ALG-882414');
-    await user.click(screen.getByRole('button', { name: /Ship-by/i }));
+    // Exact name targets the chip, not the sortable "Ship-by" column header (#944).
+    await user.click(screen.getByRole('button', { name: 'Ship-by ≤ 24h / overdue' }));
 
     await vi.waitFor(() => {
       const calledWithDue = list.mock.calls.some(
@@ -404,22 +405,65 @@ describe('OrdersListPage', () => {
     });
   });
 
-  it('should change the sort order when the sort select changes (#939)', async () => {
+  it('should server-sort by a column (with its default direction) when its header is clicked (#944)', async () => {
     const user = userEvent.setup();
     const list = vi.fn().mockResolvedValue(paginated([syncedOrder]));
-    const mockApi = createMockApiClient({ orders: { list } });
+    const mockApi = createMockApiClient({
+      orders: { list },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
 
     renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
 
     await screen.findByText('ALG-882414');
-    await user.selectOptions(screen.getByLabelText('Sort orders'), 'createdAt');
+    // Total's first-click default direction is descending (biggest first).
+    await user.click(screen.getByRole('button', { name: 'Total' }));
 
     await vi.waitFor(() => {
-      const called = list.mock.calls.some(
-        ([filters]) => (filters as { sort?: string } | undefined)?.sort === 'createdAt',
-      );
+      const called = list.mock.calls.some(([filters]) => {
+        const f = filters as { sort?: string; dir?: string } | undefined;
+        return f?.sort === 'total' && f?.dir === 'desc';
+      });
       expect(called).toBe(true);
     });
+  });
+
+  it('should flip direction when the already-active sort header is re-clicked (#944)', async () => {
+    const user = userEvent.setup();
+    const list = vi.fn().mockResolvedValue(paginated([syncedOrder]));
+    const mockApi = createMockApiClient({
+      orders: { list },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    // Start on the default Ship-by ascending sort; re-clicking flips to desc.
+    renderWithProviders(<OrdersListPage />, {
+      apiClient: mockApi,
+      route: '/orders?sort=dispatchBy&dir=asc',
+    });
+
+    await screen.findByText('ALG-882414');
+    await user.click(screen.getByRole('button', { name: 'Ship-by' }));
+
+    await vi.waitFor(() => {
+      const called = list.mock.calls.some(([filters]) => {
+        const f = filters as { sort?: string; dir?: string } | undefined;
+        return f?.sort === 'dispatchBy' && f?.dir === 'desc';
+      });
+      expect(called).toBe(true);
+    });
+  });
+
+  it('should no longer render the standalone sort dropdown — headers own sort now (#944)', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    expect(screen.queryByLabelText('Sort orders')).not.toBeInTheDocument();
   });
 
   it('should widen the created-from date to a start-of-day ISO instant (#939)', async () => {

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -52,8 +52,13 @@ import type {
   OrderHealthValue,
   OrderHealthSummary,
   OrderSortValue,
+  OrderSortDirection,
 } from '../../features/orders/api/orders.types';
-import { OrderHealthValues, OrderSortValues } from '../../features/orders/api/orders.types';
+import {
+  OrderHealthValues,
+  OrderSortValues,
+  OrderSortDirectionValues,
+} from '../../features/orders/api/orders.types';
 import { useConnectionsQuery } from '../../features/connections';
 
 const PAGE_SIZE = 20;
@@ -100,10 +105,45 @@ function isOrderSort(value: string | null): value is OrderSortValue {
   return value !== null && (OrderSortValues as readonly string[]).includes(value);
 }
 
-/** Operator-facing labels for the sort control (#939). */
-const SORT_LABELS: Record<OrderSortValue, string> = {
-  dispatchBy: 'Ship-by (soonest)',
-  createdAt: 'Created (newest)',
+/** Type-guard for the `dir` URL param (#944). */
+function isOrderDir(value: string | null): value is OrderSortDirection {
+  return value !== null && (OrderSortDirectionValues as readonly string[]).includes(value);
+}
+
+/**
+ * Sortable-column wiring (#944). The table column `id` and the server sort key
+ * diverge only for ship-by (`shipBy` column ↔ `dispatchBy` key); the rest match.
+ * Columns not in these maps (Order / Channel / Payment / actions) aren't sortable.
+ */
+const SORT_KEY_TO_COLUMN: Record<OrderSortValue, string> = {
+  dispatchBy: 'shipBy',
+  createdAt: 'createdAt',
+  customer: 'customer',
+  items: 'items',
+  status: 'status',
+  total: 'total',
+};
+const COLUMN_TO_SORT_KEY: Record<string, OrderSortValue> = {
+  shipBy: 'dispatchBy',
+  createdAt: 'createdAt',
+  customer: 'customer',
+  items: 'items',
+  status: 'status',
+  total: 'total',
+};
+
+/**
+ * First-click direction per sort key (#944): the operator-intuitive default
+ * when a column is newly selected. Re-clicking the active column flips it.
+ * Ship-by asc (soonest first) is the list's default sort state.
+ */
+const DEFAULT_DIR: Record<OrderSortValue, OrderSortDirection> = {
+  dispatchBy: 'asc',
+  createdAt: 'desc',
+  customer: 'asc',
+  items: 'desc',
+  status: 'asc',
+  total: 'desc',
 };
 
 /**
@@ -183,6 +223,10 @@ export function OrdersListPage(): ReactElement {
   const sourceConnectionId = searchParams.get('sourceConnectionId') ?? undefined;
   const rawSort = searchParams.get('sort');
   const sort = isOrderSort(rawSort) ? rawSort : DEFAULT_SORT;
+  const rawDir = searchParams.get('dir');
+  // Direction defaults to the active key's first-click default until a header
+  // click pins an explicit one (#944).
+  const dir: OrderSortDirection = isOrderDir(rawDir) ? rawDir : DEFAULT_DIR[sort];
   // Date filters stay calendar-date (YYYY-MM-DD) in the URL so the native date
   // input round-trips; they're widened to start-/end-of-day UTC instants only
   // when building the query, so the `createdTo` bound is inclusive of that day.
@@ -203,10 +247,10 @@ export function OrdersListPage(): ReactElement {
   const filters: OrderFilters = {
     health,
     sourceConnectionId: sourceConnectionId || undefined,
-    // Operator-selectable ordering (#939); defaults to the triage sort
-    // (soonest ship-by first, NULLs last). Column-header sort stays a non-goal
-    // (JSONB-derived columns the server can't ORDER BY without indexes).
+    // Server-side ordering driven by clickable column headers (#944); defaults
+    // to the triage sort (soonest ship-by first, NULLs last).
     sort,
+    dir,
     createdFrom: createdFromIso,
     createdTo: createdToIso,
     dueBefore,
@@ -263,6 +307,7 @@ export function OrdersListPage(): ReactElement {
       {
         id: 'customer',
         header: 'Customer',
+        sortable: true,
         cell: (order) => {
           const parsed = parseOrderSnapshot(order.orderSnapshot);
           const name = customerName(parsed);
@@ -280,6 +325,7 @@ export function OrdersListPage(): ReactElement {
       {
         id: 'items',
         header: 'Items',
+        sortable: true,
         cell: (order) => {
           const parsed = parseOrderSnapshot(order.orderSnapshot);
           const count = parsed.items.length;
@@ -320,6 +366,7 @@ export function OrdersListPage(): ReactElement {
       {
         id: 'status',
         header: 'Status',
+        sortable: true,
         cell: (order) => {
           const h = deriveOrderHealth(order);
           return (
@@ -339,6 +386,7 @@ export function OrdersListPage(): ReactElement {
       {
         id: 'shipBy',
         header: 'Ship-by',
+        sortable: true,
         cell: (order) => {
           const due = order.dispatchByAt ?? null;
           const view = formatShipBy(due);
@@ -359,6 +407,7 @@ export function OrdersListPage(): ReactElement {
       {
         id: 'createdAt',
         header: 'Created',
+        sortable: true,
         cell: (order) => <TimeDisplay iso={order.createdAt} format="relative" />,
       },
       {
@@ -371,6 +420,7 @@ export function OrdersListPage(): ReactElement {
         id: 'total',
         header: 'Total',
         align: 'right',
+        sortable: true,
         cell: (order) => {
           const parsed = parseOrderSnapshot(order.orderSnapshot);
           if (!parsed.totals) return <span className="text-muted">—</span>;
@@ -486,6 +536,11 @@ export function OrdersListPage(): ReactElement {
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
 
+  // Controlled (server-side) sort state for the DataTable (#944): the active
+  // sort key → its table column id, plus direction. Structurally a
+  // `SortingState` ({ id, desc }[]) without importing the react-table type.
+  const sortingState = [{ id: SORT_KEY_TO_COLUMN[sort], desc: dir === 'desc' }];
+
   const freshness = useMemo(
     () => formatFreshness(query.data?.items ?? [], locale),
     [query.data?.items, locale],
@@ -562,8 +617,9 @@ export function OrdersListPage(): ReactElement {
         ))}
       </div>
 
-      {/* Filter + sort bar (#939) — source/date/sort controls in URL state.
-          Mirrors the connections-list toolbar pattern. */}
+      {/* Filter bar (#939) — source + created-date controls in URL state
+          (mirrors the connections-list toolbar). Sorting moved to clickable
+          column headers (#944). */}
       <div className="toolbar orders-toolbar">
         <div className="toolbar__group">
           <Select
@@ -598,19 +654,6 @@ export function OrdersListPage(): ReactElement {
               onChange={(e) => { setFilterParam('createdTo', e.target.value); }}
             />
           </label>
-        </div>
-        <div className="toolbar__group orders-toolbar__sort">
-          <Select
-            aria-label="Sort orders"
-            value={sort}
-            onChange={(e) => { setFilterParam('sort', e.target.value); }}
-          >
-            {OrderSortValues.map((value) => (
-              <option key={value} value={value}>
-                {SORT_LABELS[value]}
-              </option>
-            ))}
-          </Select>
         </div>
       </div>
 
@@ -671,6 +714,29 @@ export function OrdersListPage(): ReactElement {
             rows={query.data?.items ?? []}
             rowKey={(order) => order.internalOrderId}
             rowHref={(order) => order.internalOrderId}
+            manualSorting
+            sort={sortingState}
+            onSortChange={(updater) => {
+              // Server-side sort (#944): take the column the user interacted
+              // with (the new state's column, or the active one when react-table
+              // cleared on a third click), then apply our own asc⇄desc toggle —
+              // same column flips, a new column starts at its default direction.
+              const next =
+                typeof updater === 'function' ? updater(sortingState) : updater;
+              const clickedColumnId =
+                next.length > 0 ? next[0].id : SORT_KEY_TO_COLUMN[sort];
+              const key = COLUMN_TO_SORT_KEY[clickedColumnId];
+              if (!key) return;
+              const nextDir: OrderSortDirection =
+                key === sort ? (dir === 'asc' ? 'desc' : 'asc') : DEFAULT_DIR[key];
+              setSearchParams((prev) => {
+                const p = new URLSearchParams(prev);
+                p.set('sort', key);
+                p.set('dir', nextDir);
+                p.delete('offset');
+                return p;
+              });
+            }}
             cardView={{
               title: (order) => {
                 const parsed = parseOrderSnapshot(order.orderSnapshot);

--- a/apps/web/src/shared/ui/data-table.test.tsx
+++ b/apps/web/src/shared/ui/data-table.test.tsx
@@ -323,6 +323,51 @@ describe('DataTable', () => {
     expect(onSortChange).toHaveBeenCalledTimes(1);
   });
 
+  it('does not reorder rows in manualSorting mode (server already sorted) (#944)', () => {
+    // Ascending sort state on `name`, but the table must render ROWS in the
+    // given order (Bravo, Alpha) because the server owns ordering.
+    renderWithRouter(
+      <DataTable<TestRow>
+        columns={[
+          { id: 'name', header: 'Name', cell: (row): string => row.name, sortable: true },
+        ]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        manualSorting
+        sort={[{ id: 'name', desc: false }]}
+        onSortChange={vi.fn()}
+      />,
+    );
+
+    const cells = screen.getAllByRole('cell').map((c) => c.textContent);
+    expect(cells).toEqual(['Bravo', 'Alpha']);
+    // The active column still reflects the controlled sort state in the header.
+    expect(screen.getByRole('columnheader', { name: /Name/ })).toHaveAttribute(
+      'aria-sort',
+      'ascending',
+    );
+  });
+
+  it('fires onSortChange for a sortable column that has no accessor (server-sorted) (#944)', () => {
+    const onSortChange = vi.fn();
+    renderWithRouter(
+      <DataTable<TestRow>
+        columns={[
+          // No `accessor` — server-sorted column. Must still be clickable.
+          { id: 'name', header: 'Name', cell: (row): string => row.name, sortable: true },
+        ]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        manualSorting
+        sort={[]}
+        onSortChange={onSortChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Name/ }));
+    expect(onSortChange).toHaveBeenCalledTimes(1);
+  });
+
   it('mounts a fixed-height scroll container and keeps rendered rows far below the row count when virtualize=true', () => {
     const manyRows: TestRow[] = Array.from({ length: 1000 }, (_, i) => ({
       id: `row-${i}`,

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -56,6 +56,15 @@ interface DataTableProps<Row> {
   emptyState?: ReactNode;
   /** Per-row height estimate used by the virtualizer. Default 36. */
   estimateRowHeight?: number;
+  /**
+   * Server-controlled sorting (#944). When true, the table does not reorder
+   * rows itself — it renders `rows` as-given and only tracks the active sort
+   * column/direction for the header affordance, firing `onSortChange` on click.
+   * Use when the backend already applied the sort (e.g. a paginated list where
+   * client sort would only reorder the visible page). Default false (client
+   * sort, unchanged for existing consumers).
+   */
+  manualSorting?: boolean;
   onSortChange?: OnChangeFn<SortingState>;
   rowHref?: (row: Row) => string;
   rowKey: (row: Row) => Key;
@@ -90,6 +99,7 @@ export function DataTable<Row>({
   containerHeight = 560,
   emptyState,
   estimateRowHeight = 36,
+  manualSorting = false,
   onSortChange,
   rowHref,
   rowKey,
@@ -117,8 +127,11 @@ export function DataTable<Row>({
     columns: defs,
     state: { sorting: effectiveSort },
     onSortingChange: effectiveOnSortChange,
+    manualSorting,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
+    // Skip the client sorted-row model in server-sort mode so the table renders
+    // `rows` in the order the backend returned them (#944).
+    ...(manualSorting ? {} : { getSortedRowModel: getSortedRowModel() }),
   });
 
   const tableRows = table.getRowModel().rows;
@@ -364,7 +377,15 @@ function buildColumnDefs<Row>(columns: DataTableColumn<Row>[]): ColumnDef<Row>[]
       header: () => column.header,
       cell: (info) => column.cell(info.row.original),
       enableSorting: column.sortable ?? false,
-      accessorFn: accessor ? (row) => accessor(row) ?? '' : undefined,
+      // react-table only treats a column as sortable when it has an accessorFn,
+      // so a `sortable` column with no `accessor` (server-sorted columns under
+      // `manualSorting` — #944) still needs one. Fall back to a constant: it's
+      // unused for ordering in manual mode and a no-op for client sort.
+      accessorFn: accessor
+        ? (row) => accessor(row) ?? ''
+        : column.sortable
+          ? () => ''
+          : undefined,
     };
   });
 }

--- a/docs/plans/implementation-plan-orders-server-side-column-sort.md
+++ b/docs/plans/implementation-plan-orders-server-side-column-sort.md
@@ -1,0 +1,66 @@
+# Implementation Plan — server-side sortable columns on /orders (#944)
+
+> Supersedes the #939 standalone Sort dropdown and the column-sort non-goal deferred in #929.
+> Layers: CORE (domain types + repository SQL), Interface (DTO/controller), migration, Frontend (DataTable prop + page wiring).
+
+## 1. Goal
+Clickable column headers with an up/down arrow that sort the `/orders` list **server-side** (global across the paginated set, not just the visible 20 rows).
+
+## 2. Sortable columns
+- **Sortable:** Customer, Items, Status, Ship-by, Created, Total.
+- **Plain:** Order (opaque id), Channel (categorical, resolved client-side from connectionId), Payment (ghost #928).
+
+## 3. Design decisions (confirmed)
+- **Status order** — triage-urgency ordinal: `needs_attention(0) → awaiting_mapping(1) → awaiting_dispatch(2) → synced(3)`; asc = most urgent first. Reuses the existing health `IS_MAPPING`/`HAS_FAILED`/`HAS_SYNCED` SQL expressions in a `CASE`.
+- **Total** — sort by raw numeric `(orderSnapshot->'totals'->>'total')::numeric` regardless of currency (no FX normalization available). Documented caveat: mixed-currency sort is approximate.
+- **Direction** — new `dir: 'asc' | 'desc'`. Default state = Ship-by `asc` (the triage default; replaces the dropdown). Per-column first-click default: Total `desc`, Customer `asc`, Items `desc`, Status `asc`, Created `desc`, Ship-by `asc`. Re-click flips.
+- **Dropdown** — the #939 standalone Sort `Select` is removed (headers own sort now).
+
+## 4. Backend steps
+### 4.1 `libs/core/src/orders/domain/types/order-record.types.ts`
+- Extend `OrderRecordSortValues` → `['createdAt','dispatchBy','customer','items','status','total']`.
+- Add `OrderRecordSortDirectionValues = ['asc','desc'] as const` + `OrderRecordSortDirection`.
+- Add `dir?: OrderRecordSortDirection` to `OrderRecordFilters`.
+
+### 4.2 `.../repositories/order-record.repository.ts`
+- Replace the `findMany` ORDER BY block with a `applySort(qb, sort, dir)` helper mapping each key → column/expression + direction, with stable `createdAt DESC` tiebreaker. JSONB expressions:
+  - `total` → `(rec."orderSnapshot"#>>'{totals,total}')::numeric` (NULLS LAST)
+  - `items` → `jsonb_array_length(rec."orderSnapshot"->'items')`
+  - `customer` → `lower(rec."orderSnapshot"#>>'{shippingAddress,lastName}')` (NULLS LAST)
+  - `status` → `CASE` over `IS_MAPPING`/`HAS_FAILED`/`HAS_SYNCED` (urgency ordinal)
+  - `dispatchBy` → `dispatchByAt` ASC/DESC NULLS LAST
+  - `createdAt` → `createdAt`
+- Default (no sort) unchanged: `dispatchBy` asc semantics.
+
+### 4.3 Migration `apps/api/src/migrations/{ts}-add-order-sort-indexes.ts`
+- Expression indexes: total numeric cast, items length, lower(customer lastName). (Status CASE is cheap/bounded — index optional; skip to keep the migration lean, note it.)
+- `up` + `down`. 13-digit unique timestamp; class suffix matches.
+
+### 4.4 `apps/api/src/orders/http/dto/list-orders-query.dto.ts` + controller
+- `sort` enum already validated against `OrderRecordSortValues` (auto-extends). Add `dir` (`@IsEnum(OrderRecordSortDirectionValues)`, optional). Controller passes `dir` through to `findMany`.
+
+## 5. Frontend steps
+### 5.1 `apps/web/src/shared/ui/data-table.tsx`
+- Add `manualSorting?: boolean` → `useReactTable({ manualSorting })` and skip the client sorted-row model when true. Additive; default false = unchanged for all consumers. Add a `data-table.test.tsx` case.
+
+### 5.2 `features/orders/api/orders.types.ts` + `orders.api.ts`
+- Mirror `OrderSortValues` extension + `OrderSortDirection`; add `dir` to `OrderFilters`; `buildQuery` serializes `dir`.
+
+### 5.3 `pages/orders/orders-list-page.tsx`
+- Read `sort` (default `dispatchBy`) + `dir` (default per active column) from URL; build `SortingState` for DataTable; mark the 6 columns `sortable` with `accessor` no-ops (server-sorted); pass `manualSorting`, `sort`, `onSortChange` (→ setSearchParams sort+dir, clear offset). Remove the Sort `Select`. Map column id ↔ sort key.
+- Per-column default direction on first click.
+
+### 5.4 `index.css`
+- Header sort-arrow styling already exists for DataTable sortable headers (verify); add only if missing, bounded `#944` section.
+
+## 6. Testing
+- Repo int-spec: one ordering assertion per new key (asc + desc; NULLS-last where relevant), reusing the `order-dispatch-sla.int-spec.ts` pattern.
+- Controller spec: `dir` validated/passed.
+- DataTable test: `manualSorting` disables client reordering.
+- Orders page test: header click sets `?sort`+`?dir`; arrow on active column; dropdown gone.
+- Full `pnpm test` + `pnpm test:integration` (orders repo).
+
+## 7. Risks
+- **DataTable shared primitive**: additive `manualSorting` only — assert existing consumers (connections client sort) unaffected via the existing DataTable tests.
+- **JSONB sort performance**: expression indexes cover total/items/customer; status CASE is bounded. Note if scan time creeps.
+- **#945 overlap fix** lands in `index.css`/toolbar too — trivial merge (different sections); this branch also removes the Sort dropdown from the toolbar.

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -128,18 +128,41 @@ export interface OrderRecordFilters {
    */
   dueBefore?: Date;
   /**
-   * Result ordering (#927). Default (`createdAt`) is newest-first. `dispatchBy`
-   * orders by the ship-by deadline ascending with NULLs last — the triage
-   * default on the orders list (soonest deadline first).
+   * Result ordering (#927/#944). Maps to a SQL `ORDER BY` by
+   * `OrderRecordRepository.applySort`. `dispatchBy` (ship-by deadline, NULLs
+   * last) is the list's triage default; the JSONB-derived keys (`customer`,
+   * `items`, `status`, `total`) back the clickable sortable columns (#944).
    */
   sort?: OrderRecordSort;
+  /**
+   * Sort direction for `sort` (#944). Defaults per-key in `applySort` when
+   * absent (the FE supplies an explicit direction once a header is clicked).
+   */
+  dir?: OrderRecordSortDirection;
 }
 
 /**
- * Sort fields for order-record list queries (#927).
+ * Sort fields for order-record list queries (#927, extended #944).
+ *
+ * - `createdAt` / `dispatchBy` — top-level timestamp columns.
+ * - `customer` / `items` / `status` / `total` — derived from `orderSnapshot`
+ *   JSONB (and the health `CASE` for `status`); back the sortable table columns.
  */
-export const OrderRecordSortValues = ['createdAt', 'dispatchBy'] as const;
+export const OrderRecordSortValues = [
+  'createdAt',
+  'dispatchBy',
+  'customer',
+  'items',
+  'status',
+  'total',
+] as const;
 export type OrderRecordSort = (typeof OrderRecordSortValues)[number];
+
+/**
+ * Sort direction for order-record list queries (#944).
+ */
+export const OrderRecordSortDirectionValues = ['asc', 'desc'] as const;
+export type OrderRecordSortDirection = (typeof OrderRecordSortDirectionValues)[number];
 
 /**
  * Pagination parameters for order record queries.

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -86,6 +86,8 @@ export {
   OrderHealthSummaryFilters,
   OrderRecordSort,
   OrderRecordSortValues,
+  OrderRecordSortDirection,
+  OrderRecordSortDirectionValues,
 } from './domain/types/order-record.types';
 
 // Services

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -225,7 +225,13 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     `WHEN ${OrderRecordRepository.HAS_SYNCED} THEN 3 ELSE 2 END`;
 
   /** JSONB ORDER-BY expressions for the derived sortable columns (#944). */
-  private static readonly TOTAL_EXPR = `(rec."orderSnapshot"#>>'{totals,total}')::numeric`;
+  // Guarded with `jsonb_typeof(...) = 'number'` (mirrors ITEMS_EXPR) so a
+  // malformed / non-numeric `totals.total` sorts as NULL rather than throwing on
+  // the `::numeric` cast and failing the whole list query. The migration's
+  // expression index uses the identical form so the planner can still use it.
+  private static readonly TOTAL_EXPR =
+    `CASE WHEN jsonb_typeof(rec."orderSnapshot"#>'{totals,total}') = 'number' ` +
+    `THEN (rec."orderSnapshot"#>>'{totals,total}')::numeric END`;
   private static readonly CUSTOMER_EXPR = `lower(rec."orderSnapshot"#>>'{shippingAddress,lastName}')`;
   // Guarded so a malformed (non-array) `items` value sorts as NULL rather than
   // erroring the whole list query.

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -27,6 +27,8 @@ import type {
   OrderHealth,
   OrderHealthSummary,
   OrderHealthSummaryFilters,
+  OrderRecordSort,
+  OrderRecordSortDirection,
 } from '../../../domain/types/order-record.types';
 
 @Injectable()
@@ -122,13 +124,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       this.applyHealthFilter(qb, filters.health);
     }
 
-    // Ordering (#927). `dispatchBy` is the triage default on the list: soonest
-    // ship-by first, NULLs last, with createdAt as a stable tiebreaker.
-    if (filters.sort === 'dispatchBy') {
-      qb.orderBy('rec.dispatchByAt', 'ASC', 'NULLS LAST').addOrderBy('rec.createdAt', 'DESC');
-    } else {
-      qb.orderBy('rec.createdAt', 'DESC');
-    }
+    this.applySort(qb, filters.sort, filters.dir);
 
     const [entities, total] = await qb.getManyAndCount();
 
@@ -216,6 +212,76 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
   private static readonly IS_MAPPING = `rec."recordStatus" = 'awaiting_mapping'`;
   private static readonly HAS_FAILED = `rec."syncStatus" @> '[{"status":"failed"}]'::jsonb`;
   private static readonly HAS_SYNCED = `rec."syncStatus" @> '[{"status":"synced"}]'::jsonb`;
+
+  /**
+   * Triage-urgency ordinal for the `status` sort (#944): most-urgent first when
+   * ascending. Mirrors the health precedence (mapping → failed → synced → else)
+   * in WHEN order, but assigns the ordinal by urgency:
+   * needs_attention(0) < awaiting_mapping(1) < awaiting_dispatch(2) < synced(3).
+   */
+  private static readonly HEALTH_ORDINAL =
+    `CASE WHEN ${OrderRecordRepository.IS_MAPPING} THEN 1 ` +
+    `WHEN ${OrderRecordRepository.HAS_FAILED} THEN 0 ` +
+    `WHEN ${OrderRecordRepository.HAS_SYNCED} THEN 3 ELSE 2 END`;
+
+  /** JSONB ORDER-BY expressions for the derived sortable columns (#944). */
+  private static readonly TOTAL_EXPR = `(rec."orderSnapshot"#>>'{totals,total}')::numeric`;
+  private static readonly CUSTOMER_EXPR = `lower(rec."orderSnapshot"#>>'{shippingAddress,lastName}')`;
+  // Guarded so a malformed (non-array) `items` value sorts as NULL rather than
+  // erroring the whole list query.
+  private static readonly ITEMS_EXPR =
+    `CASE WHEN jsonb_typeof(rec."orderSnapshot"->'items') = 'array' ` +
+    `THEN jsonb_array_length(rec."orderSnapshot"->'items') END`;
+
+  /**
+   * Apply result ordering (#927/#944). `dispatchBy` is the list's triage
+   * default (soonest ship-by first, NULLs last); the JSONB-derived keys back the
+   * sortable table columns. `dir` overrides the per-key default direction when
+   * the FE supplies one (a header click). Every branch adds a stable
+   * `createdAt DESC` tiebreaker so equal sort keys keep a deterministic order.
+   */
+  private applySort(
+    qb: SelectQueryBuilder<OrderRecordOrmEntity>,
+    sort: OrderRecordSort | undefined,
+    dir: OrderRecordSortDirection | undefined
+  ): void {
+    const d = (fallback: 'ASC' | 'DESC'): 'ASC' | 'DESC' =>
+      dir === 'asc' ? 'ASC' : dir === 'desc' ? 'DESC' : fallback;
+    switch (sort) {
+      case 'dispatchBy':
+        qb.orderBy('rec.dispatchByAt', d('ASC'), 'NULLS LAST').addOrderBy('rec.createdAt', 'DESC');
+        return;
+      case 'total':
+        qb.orderBy(OrderRecordRepository.TOTAL_EXPR, d('DESC'), 'NULLS LAST').addOrderBy(
+          'rec.createdAt',
+          'DESC'
+        );
+        return;
+      case 'items':
+        qb.orderBy(OrderRecordRepository.ITEMS_EXPR, d('DESC'), 'NULLS LAST').addOrderBy(
+          'rec.createdAt',
+          'DESC'
+        );
+        return;
+      case 'customer':
+        qb.orderBy(OrderRecordRepository.CUSTOMER_EXPR, d('ASC'), 'NULLS LAST').addOrderBy(
+          'rec.createdAt',
+          'DESC'
+        );
+        return;
+      case 'status':
+        qb.orderBy(OrderRecordRepository.HEALTH_ORDINAL, d('ASC')).addOrderBy(
+          'rec.createdAt',
+          'DESC'
+        );
+        return;
+      case 'createdAt':
+      default:
+        // No-sort default stays createdAt DESC (unchanged for non-list callers).
+        qb.orderBy('rec.createdAt', d('DESC'));
+        return;
+    }
+  }
 
   /**
    * Narrow a `findMany` query to a single derived-health bucket (#929).

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -345,6 +345,10 @@ const ALLOW_LIST = new Map([
     'apps/api/test/integration/order-dispatch-sla.int-spec.ts',
     new Set(['OrderRecordRepositoryPort']),
   ],
+  [
+    'apps/api/test/integration/order-column-sort.int-spec.ts',
+    new Set(['OrderRecordRepositoryPort']),
+  ],
 
   // apps → products.{ProductRepositoryPort, ProductVariantRepositoryPort} — rewire via IProductsService
   ['apps/api/test/integration/products-read.int-spec.ts', new Set(['ProductRepositoryPort'])],


### PR DESCRIPTION
## What & why

Closes #944. Replaces the #939 standalone Sort dropdown with **clickable, server-sorted column headers** (up/down arrow), so sorting is global across the paginated set — not just the visible 20 rows. Supersedes the column-sort non-goal deferred in #929.

**Sortable:** Customer, Items, Status, Ship-by, Created, Total.
**Plain:** Order (opaque id), Channel (categorical), Payment (ghost #928).

## How it works

**Backend (CORE + Interface + migration)**
- `OrderRecordSortValues` extended with `customer | items | status | total`; new `OrderRecordSortDirection` (`asc|desc`).
- `findMany` gains `applySort` mapping each key → SQL `ORDER BY`:
  - `total` → `(orderSnapshot#>>'{totals,total}')::numeric` (NULLS LAST)
  - `items` → `jsonb_array_length(...)` (guarded against non-array)
  - `customer` → `lower(orderSnapshot#>>'{shippingAddress,lastName}')` (NULLS LAST)
  - `status` → triage-urgency `CASE` reusing the existing health expressions (needs_attention < awaiting_mapping < awaiting_dispatch < synced)
  - each with a stable `createdAt DESC` tiebreaker. No-sort default stays `createdAt DESC` (non-list callers unchanged); `dispatchBy` keeps NULLS LAST.
- Migration: expression indexes for the total/items/customer paths (status `CASE` is bounded — no index).
- `ListOrdersQueryDto` gains `dir`; controller passes it through. SQL uses only static expressions + an enum-validated key + a mapped direction — no interpolated user input.

**Frontend**
- `DataTable`: additive **`manualSorting`** prop — server-sort mode renders rows as-given and only tracks the active column for the header arrow. Backward-compatible (default off; existing client-sort consumers untouched). A sortable column with no `accessor` now still toggles.
- Orders page: header clicks drive `?sort` + `?dir` URL state; per-column first-click direction (Total desc, Customer asc, Status asc, …), re-click flips. Default state = Ship-by asc. Standalone Sort dropdown removed.

## Design decisions (confirmed)
- **Status order** = triage urgency (most urgent first when asc).
- **Total across currencies** = raw numeric, no FX normalization (mixed-currency sort is approximate — documented).
- **Direction** = per-column default on first click, flip on re-click.

## Known limitation
- The mobile **card view** has no header sort control (headers are table-only); the default triage sort applies. Re-adding a mobile sort affordance is a follow-up.

## Tests
- Repo int-spec (`order-column-sort.int-spec.ts`): each sort key + direction + NULLs-last, against real Postgres.
- Controller spec: `dir` passthrough.
- `DataTable`: `manualSorting` doesn't reorder rows; no-accessor sortable column still fires `onSortChange`.
- Page: header-click sorts (key + default dir), re-click flips, dropdown gone.
- Full gate green: `pnpm lint` (incl. cross-context, migration-timestamp, token-drift invariants), `pnpm type-check`, web + api unit suites, and the orders integration suites.

## Notes
- Adds one `(file, symbol)` entry to the cross-context allow-list for the new int-spec's `OrderRecordRepositoryPort` import — consistent with the sibling order int-specs (#722).
- Independent of the open #945 (KPI/toolbar overlap fix); trivial `index.css` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)