### PR TITLE
feat(shipping): server-side payment-status gate on dispatch

### DIFF
--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -30,6 +30,7 @@ import {
   ShipmentNotFoundException,
   ShippingProviderRejectionException,
   UndispatchableResolutionException,
+  OrderNotDispatchablePaymentStatusException,
 } from '@openlinker/core/shipping';
 
 import type { IOrderRecordService, OrderRecord } from '@openlinker/core/orders';
@@ -241,6 +242,15 @@ describe('ShipmentController', () => {
 
     it('should map UndispatchableResolutionException to 422', async () => {
       dispatch.dispatch.mockRejectedValue(new UndispatchableResolutionException('no connection'));
+      await expect(controller.generateLabel(makeGenerateLabelDto())).rejects.toBeInstanceOf(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('should map OrderNotDispatchablePaymentStatusException to 422', async () => {
+      dispatch.dispatch.mockRejectedValue(
+        new OrderNotDispatchablePaymentStatusException('ol_order_1', 'awaiting'),
+      );
       await expect(controller.generateLabel(makeGenerateLabelDto())).rejects.toBeInstanceOf(
         UnprocessableEntityException,
       );

--- a/apps/api/src/shipping/http/shipment.controller.ts
+++ b/apps/api/src/shipping/http/shipment.controller.ts
@@ -59,6 +59,7 @@ import {
   ShipmentNotFoundException,
   ShippingProviderRejectionException,
   UndispatchableResolutionException,
+  OrderNotDispatchablePaymentStatusException,
 } from '@openlinker/core/shipping';
 import { type IOrderRecordService, ORDER_RECORD_SERVICE_TOKEN } from '@openlinker/core/orders';
 import { Logger } from '@openlinker/shared/logging';
@@ -185,7 +186,10 @@ export class ShipmentController {
     summary: 'Generate a shipping label for an order via the resolved fulfillment processor',
   })
   @ApiResponse({ status: 200, type: DispatchResultResponseDto })
-  @ApiResponse({ status: 422, description: 'Routing resolution cannot be dispatched' })
+  @ApiResponse({
+    status: 422,
+    description: 'Order not dispatchable (routing unresolvable, or payment status blocks dispatch)',
+  })
   @ApiResponse({ status: 502, description: 'Shipping provider rejected label generation' })
   async generateLabel(@Body() dto: GenerateLabelDto): Promise<DispatchResultResponseDto> {
     const input: ShipmentDispatchInput = {
@@ -306,6 +310,7 @@ export class ShipmentController {
     if (
       error instanceof ShipmentCancellationNotSupportedException ||
       error instanceof UndispatchableResolutionException ||
+      error instanceof OrderNotDispatchablePaymentStatusException ||
       error instanceof LabelDocumentNotSupportedException ||
       error instanceof LabelNotAvailableException
     ) {

--- a/docs/plans/implementation-plan-shipping-payment-status-dispatch-gate.md
+++ b/docs/plans/implementation-plan-shipping-payment-status-dispatch-gate.md
@@ -1,0 +1,72 @@
+# Implementation Plan — Server-side payment-status gate on dispatch (#938)
+
+## 1. Understand the task
+
+**Goal.** The FE-only Generate-label gate from #928 is a UX affordance, not enforcement — an authenticated operator can still POST the dispatch endpoint for an `awaiting`/`refunded` order. Add the durable server-side guard in `ShipmentDispatchService.dispatch()`: block dispatch when the order's payment status is in the block set, returning HTTP 422.
+
+**Layer.** CORE (application-service precondition + new domain exception) + Interface (HTTP 422 mapping). No schema change, no migration.
+
+**Non-goals.**
+- Wiring the live dispatch call-site (#769/#771) — out of scope; this guards the path it will trigger.
+- Changing the FE gate (#928 already shipped it).
+- Any new persisted state.
+
+## 2. Research (findings)
+
+- `ShipmentDispatchService.dispatch(input: ShipmentDispatchInput)` (`libs/core/src/shipping/application/services/shipment-dispatch.service.ts`): calls `routing.resolve(...)` then `switch`es on the processor kind (`omp_fulfilled` → no-op; `ol_managed_carrier` / `source_brokered` → `dispatchViaShippingProvider` → `generateLabel`; default → `UndispatchableResolutionException`). **`input.orderId` is available** (ShipmentDispatchInput carries the internal order id).
+- `IOrderRecordService` + `ORDER_RECORD_SERVICE_TOKEN` are exported from `@openlinker/core/orders`. `getOrderRecord(internalOrderId): Promise<OrderRecord | null>`; `OrderRecord.orderSnapshot` is `Record<string, unknown>` (payment status is a loose JSON key: `orderSnapshot.paymentStatus`).
+- `PaymentStatus` (`'paid' | 'cod' | 'awaiting' | 'refunded'`), `PaymentStatusValues`, `PAYMENT_STATUS` — `libs/core/src/orders/domain/types/payment-status.types.ts`, exported from `@openlinker/core/orders`.
+- **FE block polarity** (`apps/web/.../shipment-action-buttons.tsx`): `PAYMENT_BLOCKS_DISPATCH = new Set(['awaiting','refunded'])`; `paid`/`cod`/`undefined`/unknown all **permit**. Mirror exactly.
+- HTTP mapping: `shipment.controller.ts` `toHttpException()` maps `UndispatchableResolutionException` (+ peers) → `UnprocessableEntityException` (422). Add the new exception to that group.
+- **`ShippingModule` already imports `OrdersModule`** (#837) → `ORDER_RECORD_SERVICE_TOKEN` is injectable into `ShipmentDispatchService` with no module change.
+- Spec (`shipment-dispatch.service.spec.ts`) constructs the SUT directly with `jest.Mocked` ports; add a `getOrderRecord` mock + 4th constructor arg.
+
+## 3. Design
+
+**Gate placement.** Immediately after `routing.resolve(...)` returns, **before the `switch`** — the literal reading of the issue ("in `dispatch()`, after the routing resolve, before `generateLabel`") and the faithful mirror of the FE gate, which is processor-kind-agnostic (gates on status + payment only). Routing errors still surface first (resolve precedes the payment check).
+
+```ts
+const order = await this.orders.getOrderRecord(input.orderId);
+const paymentStatus = order?.orderSnapshot?.paymentStatus;
+if (typeof paymentStatus === 'string' && BLOCKED_PAYMENT_STATUSES.has(paymentStatus as PaymentStatus)) {
+  throw new OrderNotDispatchablePaymentStatusException(input.orderId, paymentStatus);
+}
+```
+
+- `BLOCKED_PAYMENT_STATUSES: ReadonlySet<PaymentStatus> = new Set([PAYMENT_STATUS.Awaiting, PAYMENT_STATUS.Refunded])` — module const, mirrors FE.
+- `order === null` or `paymentStatus` absent/non-string → permit (graceful degradation for PrestaShop / legacy orders), matching the FE's `undefined`-permits polarity.
+- New domain exception `OrderNotDispatchablePaymentStatusException(orderId, paymentStatus)` under `libs/core/src/shipping/domain/exceptions/`, mirroring `UndispatchableResolutionException`'s shape.
+
+**Cross-context edge.** `shipping → orders` strictly via the `IOrderRecordService` barrel contract + Symbol token + `PaymentStatus` type/const — all allowed cross-context shapes (no repository port, no ORM entity). Documented edge already exists at the module layer (#837).
+
+## 4. Implementation steps
+
+1. **`libs/core/src/shipping/domain/exceptions/order-not-dispatchable-payment-status.exception.ts`** (new) — `OrderNotDispatchablePaymentStatusException extends Error`, carrying `orderId` + `paymentStatus`, clear message. AC: file header, `Error.captureStackTrace`.
+2. **`shipment-dispatch.service.ts`** — inject `@Inject(ORDER_RECORD_SERVICE_TOKEN) IOrderRecordService`; add module-const block set; insert the gate after `routing.resolve`. AC: blocked statuses throw before any `generateLabel`; permitted statuses unaffected.
+3. **`apps/api/src/shipping/http/shipment.controller.ts`** — import + add the new exception to the 422 branch of `toHttpException()`; add `@ApiResponse(422)` note if useful. AC: blocked dispatch → 422.
+4. **`shipment-dispatch.service.spec.ts`** — add `orderRecordService` mock + 4th ctor arg; tests: blocked for `awaiting`/`refunded` (throws, `generateLabel` not called), permitted for `paid`/`cod`/`undefined`/null order. AC: all green; existing tests unaffected (default `getOrderRecord` → undefined → permit).
+5. **(maybe) controller spec** — if `shipment.controller.spec.ts` exists and tests `toHttpException`, add a 422 case for the new exception.
+
+## 5. Validation
+
+- Architecture: precondition is application-layer orchestration in core; new exception in `domain/exceptions/`; cross-context via `I*Service` + token only. ✅
+- Naming: `*.exception.ts`, `{Reason}Exception`. ✅
+- Types: reuse existing `PaymentStatus`; no inline type defs; no `any` (narrow `unknown` via `typeof`). ✅
+- Testing: unit tests mock ports; run `pnpm test` + full `pnpm test:integration` (the issue's AC asks for green integration — routing/dispatch int-specs exercise this service). ✅
+- Security: defense-in-depth enforcement moved server-side; no secrets. No migration.
+
+## Tech-review resolutions (applied)
+
+- **Typed accessor, not a snapshot-key read.** Added a pure read-only getter `OrderRecord.paymentStatus: PaymentStatus | undefined` (ADR-011-compliant) in the orders context; the gate reads `order?.paymentStatus`, so shipping binds to a typed contract and the `orderSnapshot.paymentStatus` key + narrowing live in the owning context.
+- **Fails closed.** `getOrderRecord` is awaited with no permit-on-error catch — a read failure propagates (→ 500), never silently permits. Covered by a "fail closed (propagate) when the read throws" test.
+- **422 mapping tested.** Added the controller-spec case asserting `OrderNotDispatchablePaymentStatusException → UnprocessableEntityException` (the explicit AC).
+- **Named block-set.** `DISPATCH_BLOCKING_PAYMENT_STATUSES` lives in `shipping/application/types/dispatch-payment-policy.types.ts` (application layer — it's a shipping *policy* needing a sibling-context value, kept out of the domain layer) with a comment pointing at the FE counterpart (drift note, both directions); the service builds a `Set` from it once.
+- **Audit log on block.** The gate emits a `logger.warn` before throwing — a bypassed-FE dispatch attempt on a payment-blocked order is a notable signal (the 422 itself isn't logged by the controller).
+- **Idempotency edge** documented in the gate comment: a `paid→dispatched→refunded` order is refused (422) on repeat rather than returning the existing shipment — intended.
+- **Constructor arity:** only DI (class provider) + the unit spec construct `ShipmentDispatchService`; spec updated. No other `new` sites.
+
+## Risks / open questions
+
+- **Gate covers the OMP-fulfilled branch too** (it's before the switch). That's intended — it mirrors the processor-kind-agnostic FE gate and the issue's "in `dispatch()`" placement. Net effect: an `awaiting`/`refunded` OMP-fulfilled order is also refused, which is the correct defense-in-depth posture. Calls out in the plan in case reviewers prefer scoping it to the shipping-provider branch only.
+- **One extra `getOrderRecord` read per dispatch** — dispatch is low-frequency; acceptable.
+- Dispatch call-site not yet live (#771) — guard protects a not-yet-triggered path (issue acknowledges; still correct to land).

--- a/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * OrderRecord entity unit tests — payment-status getter (#928/#938).
+ *
+ * The getter is the typed contract cross-context consumers (the #938 shipping
+ * dispatch gate) bind to instead of reaching into the loose snapshot JSON.
+ */
+
+import { OrderRecord } from './order-record.entity';
+import { PAYMENT_STATUS } from '../types/payment-status.types';
+
+function makeRecord(snapshot: Record<string, unknown>): OrderRecord {
+  return new OrderRecord(
+    'ol_order_1',
+    'ol_customer_1',
+    'conn-1',
+    null,
+    snapshot,
+    [],
+    'ready',
+    new Date(),
+    new Date(),
+  );
+}
+
+describe('OrderRecord.paymentStatus', () => {
+  it.each([PAYMENT_STATUS.Paid, PAYMENT_STATUS.Cod, PAYMENT_STATUS.Awaiting, PAYMENT_STATUS.Refunded])(
+    'returns the recognised payment status %s from the snapshot',
+    (status) => {
+      expect(makeRecord({ paymentStatus: status }).paymentStatus).toBe(status);
+    },
+  );
+
+  it('returns undefined when the snapshot has no paymentStatus key', () => {
+    expect(makeRecord({}).paymentStatus).toBeUndefined();
+  });
+
+  it('returns undefined when paymentStatus is an unrecognised string', () => {
+    expect(makeRecord({ paymentStatus: 'partially-refunded' }).paymentStatus).toBeUndefined();
+  });
+
+  it('returns undefined when paymentStatus is a non-string value', () => {
+    expect(makeRecord({ paymentStatus: 42 }).paymentStatus).toBeUndefined();
+    expect(makeRecord({ paymentStatus: null }).paymentStatus).toBeUndefined();
+  });
+});

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -9,6 +9,8 @@
  */
 import type { OrderRecordStatus } from '../types/order-record.types';
 import type { OrderSyncStatus, SyncAttempt } from '../types/order-sync.types';
+import { PaymentStatusValues } from '../types/payment-status.types';
+import type { PaymentStatus } from '../types/payment-status.types';
 
 export type { OrderSyncStatus, SyncAttempt } from '../types/order-sync.types';
 
@@ -46,4 +48,21 @@ export class OrderRecord {
      */
     public readonly dispatchByAt: Date | null = null,
   ) {}
+
+  /**
+   * Typed, fail-safe read of the order's neutral payment status (#928) from the
+   * snapshot. Pure derivation of an already-loaded field (ADR-011): no I/O, no
+   * mutation. Centralises the `orderSnapshot.paymentStatus` key + narrowing in
+   * the owning context so cross-context consumers (e.g. the #938 shipping
+   * dispatch gate) bind to a typed contract rather than the snapshot's internal
+   * JSON layout. Returns `undefined` when the source didn't populate payment
+   * (graceful degradation — PrestaShop / legacy orders) or the stored value
+   * isn't a recognised status.
+   */
+  get paymentStatus(): PaymentStatus | undefined {
+    const value = this.orderSnapshot.paymentStatus;
+    return typeof value === 'string' && (PaymentStatusValues as readonly string[]).includes(value)
+      ? (value as PaymentStatus)
+      : undefined;
+  }
 }

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -15,12 +15,29 @@ import {
   type FulfillmentRoutingResolution,
   type IFulfillmentRoutingService,
 } from '@openlinker/core/mappings';
+import { type IOrderRecordService, OrderRecord, type PaymentStatus } from '@openlinker/core/orders';
 import { ShipmentDispatchService } from './shipment-dispatch.service';
 import type { ShipmentDispatchInput } from '../types/shipment-dispatch.types';
 import { Shipment } from '../../domain/entities/shipment.entity';
 import type { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
 import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
 import { UndispatchableResolutionException } from '../../domain/exceptions/undispatchable-resolution.exception';
+import { OrderNotDispatchablePaymentStatusException } from '../../domain/exceptions/order-not-dispatchable-payment-status.exception';
+
+/** Build an OrderRecord whose snapshot carries the given payment status (or none). */
+function makeOrderRecord(paymentStatus?: PaymentStatus): OrderRecord {
+  return new OrderRecord(
+    'ol_order_1',
+    'ol_customer_1',
+    SOURCE,
+    null,
+    paymentStatus === undefined ? {} : { paymentStatus },
+    [],
+    'ready',
+    new Date(),
+    new Date(),
+  );
+}
 
 const SOURCE = 'conn-allegro';
 const INPOST = 'conn-inpost';
@@ -87,6 +104,7 @@ describe('ShipmentDispatchService', () => {
   let routing: jest.Mocked<IFulfillmentRoutingService>;
   let integrations: jest.Mocked<IIntegrationsService>;
   let adapter: jest.Mocked<ShippingProviderManagerPort>;
+  let orders: jest.Mocked<IOrderRecordService>;
   let service: ShipmentDispatchService;
 
   beforeEach(() => {
@@ -117,7 +135,87 @@ describe('ShipmentDispatchService', () => {
       resolveAdapterMetadata: jest.fn(),
       listCapabilityAdapters: jest.fn(),
     };
-    service = new ShipmentDispatchService(repository, routing, integrations);
+    orders = {
+      persistOrder: jest.fn(),
+      persistIncomingSnapshot: jest.fn(),
+      updateSyncStatus: jest.fn(),
+      getOrderRecord: jest.fn().mockResolvedValue(null),
+      findMany: jest.fn(),
+    };
+    service = new ShipmentDispatchService(repository, routing, integrations, orders);
+  });
+
+  describe('payment-status dispatch gate (#938)', () => {
+    /** Arrange the ol_managed_carrier happy path so a permitted status dispatches. */
+    function arrangeHappyPath(): void {
+      routing.resolve.mockResolvedValue(
+        resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier, processorConnectionId: INPOST }),
+      );
+      repository.findActiveByOrderId.mockResolvedValue(null);
+      repository.create.mockResolvedValue(makeShipment({ status: 'draft' }));
+      adapter.generateLabel.mockResolvedValue({
+        providerShipmentId: 'shipx-1',
+        trackingNumber: null,
+        labelPdfRef: 'shipx:label:shipx-1',
+      });
+      repository.update.mockResolvedValue(makeShipment({ status: 'generated', providerShipmentId: 'shipx-1' }));
+    }
+
+    it.each(['awaiting', 'refunded'] as const)(
+      'should reject dispatch with OrderNotDispatchablePaymentStatusException when payment status is %s',
+      async (paymentStatus) => {
+        routing.resolve.mockResolvedValue(resolution());
+        orders.getOrderRecord.mockResolvedValue(makeOrderRecord(paymentStatus));
+
+        await expect(service.dispatch(makeInput())).rejects.toBeInstanceOf(
+          OrderNotDispatchablePaymentStatusException,
+        );
+
+        // No shipment work happens once the gate blocks.
+        expect(repository.findActiveByOrderId).not.toHaveBeenCalled();
+        expect(repository.create).not.toHaveBeenCalled();
+        expect(adapter.generateLabel).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(['paid', 'cod'] as const)(
+      'should permit dispatch when payment status is %s',
+      async (paymentStatus) => {
+        arrangeHappyPath();
+        orders.getOrderRecord.mockResolvedValue(makeOrderRecord(paymentStatus));
+
+        const result = await service.dispatch(makeInput());
+
+        expect(result.kind).toBe('dispatched');
+        expect(adapter.generateLabel).toHaveBeenCalled();
+      },
+    );
+
+    it('should permit dispatch when the order has no payment status (graceful degradation)', async () => {
+      arrangeHappyPath();
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord(undefined));
+
+      const result = await service.dispatch(makeInput());
+
+      expect(result.kind).toBe('dispatched');
+    });
+
+    it('should permit dispatch when no order record is found', async () => {
+      arrangeHappyPath();
+      orders.getOrderRecord.mockResolvedValue(null);
+
+      const result = await service.dispatch(makeInput());
+
+      expect(result.kind).toBe('dispatched');
+    });
+
+    it('should fail closed (propagate) when the order record read throws', async () => {
+      routing.resolve.mockResolvedValue(resolution());
+      orders.getOrderRecord.mockRejectedValue(new Error('db down'));
+
+      await expect(service.dispatch(makeInput())).rejects.toThrow('db down');
+      expect(adapter.generateLabel).not.toHaveBeenCalled();
+    });
   });
 
   describe('omp_fulfilled (branch-1, no OL label)', () => {

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
@@ -29,6 +29,11 @@ import {
   FULFILLMENT_PROCESSOR_KIND,
   FULFILLMENT_ROUTING_SERVICE_TOKEN,
 } from '@openlinker/core/mappings';
+import {
+  type IOrderRecordService,
+  type PaymentStatus,
+  ORDER_RECORD_SERVICE_TOKEN,
+} from '@openlinker/core/orders';
 
 import type { IShipmentDispatchService } from '../interfaces/shipment-dispatch.service.interface';
 import type {
@@ -37,13 +42,18 @@ import type {
 } from '../types/shipment-dispatch.types';
 import type { Shipment } from '../../domain/entities/shipment.entity';
 import { UndispatchableResolutionException } from '../../domain/exceptions/undispatchable-resolution.exception';
+import { OrderNotDispatchablePaymentStatusException } from '../../domain/exceptions/order-not-dispatchable-payment-status.exception';
 import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
 import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
 import { SHIPMENT_STATUS } from '../../domain/types/shipment-status.types';
+import { DISPATCH_BLOCKING_PAYMENT_STATUSES } from '../types/dispatch-payment-policy.types';
 import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
 
 /** Capability the resolved processor connection must declare to issue a label. */
 const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
+
+/** Payment statuses that block dispatch (#938). Built once from the domain policy. */
+const DISPATCH_BLOCKING: ReadonlySet<PaymentStatus> = new Set(DISPATCH_BLOCKING_PAYMENT_STATUSES);
 
 @Injectable()
 export class ShipmentDispatchService implements IShipmentDispatchService {
@@ -56,6 +66,8 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
     private readonly routing: IFulfillmentRoutingService,
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrations: IIntegrationsService,
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orders: IOrderRecordService,
   ) {}
 
   async dispatch(input: ShipmentDispatchInput): Promise<ShipmentDispatchResult> {
@@ -63,6 +75,28 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
       sourceConnectionId: input.sourceConnectionId,
       sourceDeliveryMethodId: input.sourceDeliveryMethodId,
     });
+
+    // Payment-status gate (#938): server-side enforcement of the FE Generate-label
+    // gate (#928) — the FE affordance is not authorization (frontend-architecture
+    // § App Boundary), so the durable guarantee lives here. Runs after routing
+    // resolve (routing errors take precedence) and before any processor branch,
+    // mirroring the processor-kind-agnostic FE gate. A read failure here PROPAGATES
+    // (fails closed) — it must never silently permit dispatch of an unpaid order.
+    // Only an absent/unknown payment status permits (graceful degradation for
+    // PrestaShop / legacy orders). NOTE: this precedes the per-order idempotency
+    // check, so an order that was dispatched while `paid` and later goes
+    // `refunded` is refused (422) on a repeat call rather than returning the
+    // existing shipment — intended.
+    const order = await this.orders.getOrderRecord(input.orderId);
+    const paymentStatus = order?.paymentStatus;
+    if (paymentStatus !== undefined && DISPATCH_BLOCKING.has(paymentStatus)) {
+      // Audit signal: the FE already disables dispatch for blocked payment, so
+      // reaching here means a direct API call (or a bug) bypassed that gate.
+      this.logger.warn(
+        `Blocked dispatch of order ${input.orderId}: payment status '${paymentStatus}'`,
+      );
+      throw new OrderNotDispatchablePaymentStatusException(input.orderId, paymentStatus);
+    }
 
     switch (resolution.processorKind) {
       case FULFILLMENT_PROCESSOR_KIND.OmpFulfilled:

--- a/libs/core/src/shipping/application/types/dispatch-payment-policy.types.ts
+++ b/libs/core/src/shipping/application/types/dispatch-payment-policy.types.ts
@@ -1,0 +1,30 @@
+/**
+ * Dispatch Payment-Status Policy
+ *
+ * The set of neutral payment statuses (#928) that BLOCK dispatch, enforced
+ * server-side by `ShipmentDispatchService` (#938). Block-list polarity, not
+ * allow-list: only these explicitly block; `paid`, `cod`, `undefined`
+ * (payment unknown — PrestaShop / legacy orders), and any future union member
+ * not listed here all PERMIT dispatch, so a new payment value never silently
+ * blocks shipping until consciously added here.
+ *
+ * Lives in the application layer (not domain) because "which payment statuses
+ * block dispatch" is a shipping *policy* decision that depends on a sibling
+ * context's value (`PAYMENT_STATUS`); keeping it here leaves the shipping
+ * domain free of runtime cross-context coupling.
+ *
+ * MIRRORS the FE gate `PAYMENT_BLOCKS_DISPATCH` in
+ * `apps/web/src/features/orders/components/shipment-action-buttons.tsx` —
+ * keep the two in sync (they can't share a const across the apps/web ↔
+ * libs/core boundary). This is the authoritative server-side copy.
+ *
+ * @module libs/core/src/shipping/application/types
+ */
+
+import type { PaymentStatus } from '@openlinker/core/orders';
+import { PAYMENT_STATUS } from '@openlinker/core/orders';
+
+export const DISPATCH_BLOCKING_PAYMENT_STATUSES = [
+  PAYMENT_STATUS.Awaiting,
+  PAYMENT_STATUS.Refunded,
+] as const satisfies readonly PaymentStatus[];

--- a/libs/core/src/shipping/domain/exceptions/order-not-dispatchable-payment-status.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/order-not-dispatchable-payment-status.exception.ts
@@ -1,0 +1,25 @@
+/**
+ * Order Not Dispatchable (Payment Status) Exception
+ *
+ * Thrown by `ShipmentDispatchService` when an order's neutral payment status
+ * (#928) is in the dispatch block set (`awaiting` | `refunded`). This is the
+ * server-side enforcement of the gate the FE renders as a disabled
+ * Generate-label CTA (#938) — the durable guarantee that belongs server-side
+ * per `docs/frontend-architecture.md` (the FE must not be the source of truth
+ * for business/authorization rules). Mapped to HTTP 422 at the controller.
+ *
+ * @module libs/core/src/shipping/domain/exceptions
+ */
+
+export class OrderNotDispatchablePaymentStatusException extends Error {
+  constructor(
+    public readonly orderId: string,
+    public readonly paymentStatus: string,
+  ) {
+    super(
+      `Order ${orderId} cannot be dispatched: payment status is '${paymentStatus}'`,
+    );
+    this.name = 'OrderNotDispatchablePaymentStatusException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -101,6 +101,7 @@ export type { LabelDocument } from './domain/types/label-document.types';
 // Domain exceptions
 export { ShipmentNotFoundException } from './domain/exceptions/shipment-not-found.exception';
 export { UndispatchableResolutionException } from './domain/exceptions/undispatchable-resolution.exception';
+export { OrderNotDispatchablePaymentStatusException } from './domain/exceptions/order-not-dispatchable-payment-status.exception';
 export { ShipmentNotCancellableException } from './domain/exceptions/shipment-not-cancellable.exception';
 export { ShipmentCancellationNotSupportedException } from './domain/exceptions/shipment-cancellation-not-supported.exception';
 export { PickupPointFinderNotSupportedException } from './domain/exceptions/pickup-point-finder-not-supported.exception';


### PR DESCRIPTION
## What & why

The FE Generate-label gate from #928 is a UX affordance, not enforcement — an authenticated operator can still POST the dispatch endpoint for an `awaiting`/`refunded` order. Per `docs/frontend-architecture.md` (App Boundary), the durable authorization guarantee belongs server-side. This enforces it in `ShipmentDispatchService`.

## Change

After routing resolves and **before any processor branch**, load the order via the `IOrderRecordService` cross-context contract and reject dispatch (HTTP **422**, `OrderNotDispatchablePaymentStatusException`) when payment status is in the block set.

Mirrors the FE block-list polarity exactly: **`awaiting` / `refunded` block**; `paid` / `cod` / unknown / missing-order all **permit** (graceful degradation for PrestaShop / legacy orders). Placed before the switch so it's processor-kind-agnostic, like the FE gate.

Key design points:
- **Typed accessor:** new `OrderRecord.paymentStatus` getter (ADR-011 pure read-only derivation) — shipping binds to a typed contract, not the snapshot's internal JSON layout.
- **Fails closed:** an order-record read error propagates (never silently permits dispatch); only a successfully-read absent/unknown status permits.
- **Block-set** lives in `shipping/application/types/dispatch-payment-policy.types.ts` (authoritative server copy; mirrors the FE const, kept out of the domain layer since it needs a sibling-context value).
- **Audit log:** `logger.warn` before throwing — a bypassed-FE attempt is a notable signal (the 422 isn't logged by the controller).
- **`shipping → orders`** edge via the `I*Service` barrel + Symbol token only (no repository port, no ORM entity); `ShippingModule` already imports `OrdersModule`.

No schema change, no migration.

## How to test

- `pnpm --filter @openlinker/core exec jest shipment-dispatch.service.spec` — gate: blocked (`awaiting`/`refunded`), permitted (`paid`/`cod`/undefined/no-record), fail-closed on read throw.
- `pnpm --filter @openlinker/core exec jest order-record.entity.spec` — the `paymentStatus` getter (recognised / absent / unrecognised / non-string).
- `pnpm --filter @openlinker/api exec jest shipment.controller.spec` — `OrderNotDispatchablePaymentStatusException → 422` mapping.
- Full `pnpm test:integration` — **47 suites green** (the issue AC).

## Notes / sequencing

- The live dispatch call-site (#769/#771) isn't wired yet; this guards the path it will trigger (the issue acknowledges this; the guard is correct to land now).
- The gate precedes the per-order idempotency check, so a `paid → dispatched → refunded` order is refused (422) on a repeat call rather than returning the existing shipment — intended; documented in the gate comment.

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)