### PR TITLE
fix(orders): persist customerEmail in the order snapshot (#948)

### DIFF
--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -519,8 +519,9 @@ function buildGenerateLabelInput(args: {
       // recipient contract.
       firstName: a?.firstName ?? undefined,
       lastName: a?.lastName ?? undefined,
-      // Gate guarantees customerEmail is present; the `??` only fires under
-      // the (impossible-by-invariant) "gate bypassed" branch.
+      // `detectMissingFields` blocks submit when customerEmail is absent, so the
+      // `??` only fires defensively (e.g. snapshots predating #948, or hash-only
+      // PII mode where the email isn't persisted).
       email: snapshot.customerEmail ?? '',
       phone: a?.phone ?? '',
       address,

--- a/docs/plans/implementation-plan-persist-customer-email-snapshot.md
+++ b/docs/plans/implementation-plan-persist-customer-email-snapshot.md
@@ -1,0 +1,65 @@
+# Implementation Plan — persist `customerEmail` in the order snapshot (#948)
+
+## 1. Goal & layer
+Stop dropping the buyer email captured on `IncomingOrder` so `order_records.orderSnapshot.customerEmail` is populated and the Generate-Label form (#769) no longer rejects every order with "Buyer email is missing from the order snapshot."
+
+- **Layer: CORE / orders** — Domain type (`Order`) + Application services (`OrderIngestionService`, `OrderRecordService`).
+- **No migration** (snapshot is JSONB). **No FE change** (the FE `ParsedOrderSnapshot.customerEmail` already exists and `detectMissingFields` already reads it).
+
+## 2. Root cause (verified)
+`IncomingOrder.customerEmail` is set by adapters but:
+1. `Order` (order.types.ts:82-135) has no `customerEmail` field.
+2. `buildUnifiedOrder` (order-ingestion.service.ts:361-385) doesn't map it onto `Order` (uses it only for customer-identity resolution).
+3. `persistOrder` (order-record.service.ts:53-94) and `persistIncomingSnapshot` (:126-153) both omit it.
+
+DB: 0/40 snapshots carry `customerEmail`.
+
+## 3. Steps
+
+### 3.1 `libs/core/src/orders/domain/types/order.types.ts`
+Add to the `Order` interface, near `customerId`:
+```ts
+/** Buyer email from the source platform (#948), carried through from
+ *  `IncomingOrder.customerEmail`. Persisted into the order snapshot (PII-gated)
+ *  so the Generate-Label recipient can be built. Absent when the source didn't
+ *  expose one. */
+customerEmail?: string;
+```
+
+### 3.2 `order-ingestion.service.ts` — `buildUnifiedOrder`
+Map it onto the returned `Order`: `customerEmail: incoming.customerEmail,`.
+
+### 3.3 `order-record.service.ts` — `persistOrder` snapshot
+Add a **PII-gated, present-only** key (email is PII — under hash-only mode `OL_STORE_PII=false` raw email must not be stored; the projection keeps `emailHash`):
+```ts
+...(piiConfig.storePii && order.customerEmail !== undefined && {
+  customerEmail: order.customerEmail,
+}),
+```
+Rationale doc-comment referencing the address PII precedent already in this method.
+
+### 3.4 `order-record.service.ts` — `persistIncomingSnapshot` snapshot
+Same, from `incoming.customerEmail`.
+
+### 3.5 Tests — `order-record.service.spec.ts`
+- `persistOrder`: with `OL_STORE_PII=true` (or mocked `getPiiConfig`) and `order.customerEmail` set → snapshot has `customerEmail`; with PII off → key absent; with email undefined → key absent.
+- `persistIncomingSnapshot`: same three cases from `incoming.customerEmail`.
+- Mirror however the existing suite controls `getPiiConfig` (check whether it mocks the module or sets `OL_STORE_PII`).
+
+### 3.6 (optional polish) `apps/web/.../generate-label-form.tsx`
+Fix the now-stale comment in `buildGenerateLabelInput` ("Gate guarantees customerEmail is present") — there's no such guarantee; `detectMissingFields` is the gate and the `?? ''` is the real fallback. One-line comment correction; no behavior change.
+
+## 4. Non-goals (per #948)
+- Thin PrestaShop **seed** orders missing address/items — dev-fixture data, not code.
+- Masked Allegro email deliverability — separate downstream concern.
+- Backfilling existing rows — value lands on next re-ingest (snapshot rebuilt each `syncOrderFromSource`).
+- Button-level recipient gate on `ShipmentActionButtons` — reasonable follow-up, not here.
+
+## 5. Validation
+- `pnpm lint` + `pnpm type-check` + `pnpm test` green.
+- `check:invariants` (service-interface, cross-context) unaffected — additive field, same context.
+- Manual/int confidence: a freshly-ingested Allegro order with a buyer email now carries `customerEmail` in the snapshot (covered by the unit tests; the existing order-ingestion int-specs exercise the persist path).
+
+## 6. Risks
+- **PII semantics**: gating behind `storePii` keeps hash-only mode honest. The in-memory `Order.customerEmail` carries the raw value regardless (transient), exactly like `Order.shippingAddress`; only persistence is gated.
+- Low blast radius: additive optional field; no consumer breaks if absent.

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -292,6 +292,29 @@ describe('OrderIngestionService', () => {
       expect(order.placedAt).toBeUndefined();
     });
 
+    it('should carry incoming.customerEmail onto the unified Order (#948)', async () => {
+      orderSource.getOrder.mockResolvedValueOnce({
+        ...baseIncoming,
+        customerEmail: 'buyer@example.com',
+      });
+      orderSyncService.syncOrder.mockResolvedValue([]);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      const order = orderRecordService.persistOrder.mock.calls[0][0];
+      expect(order.customerEmail).toBe('buyer@example.com');
+    });
+
+    it('should leave Order.customerEmail undefined when the incoming order omits it (#948)', async () => {
+      // baseIncoming carries no customerEmail.
+      orderSyncService.syncOrder.mockResolvedValue([]);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      const order = orderRecordService.persistOrder.mock.calls[0][0];
+      expect(order.customerEmail).toBeUndefined();
+    });
+
     it('should call updateSyncStatus with synced when syncOrder succeeds', async () => {
       orderSyncService.syncOrder.mockResolvedValue([
         {

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -260,6 +260,30 @@ describe('OrderRecordService', () => {
       const callArg = repository.upsert.mock.calls[0][0];
       expect(callArg.orderSnapshot).not.toHaveProperty('placedAt');
     });
+
+    it('should serialise Order.customerEmail into the snapshot when present (#948)', async () => {
+      const order = createMockOrder();
+      order.customerEmail = 'buyer@example.com';
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot['customerEmail']).toBe('buyer@example.com');
+    });
+
+    it('should omit customerEmail from the snapshot when the Order does not carry it (#948)', async () => {
+      const order = createMockOrder();
+      expect(order.customerEmail).toBeUndefined();
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot).not.toHaveProperty('customerEmail');
+    });
   });
 
   describe('persistOrder - PII disabled', () => {
@@ -339,6 +363,18 @@ describe('OrderRecordService', () => {
       const callArg = repository.upsert.mock.calls[0][0];
       expect(callArg.orderSnapshot.shippingAddress).toBeUndefined();
       expect(callArg.orderSnapshot.billingAddress).toBeUndefined();
+    });
+
+    it('should omit customerEmail under hash-only PII mode even when present (#948)', async () => {
+      const order = createMockOrder();
+      order.customerEmail = 'buyer@example.com';
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot).not.toHaveProperty('customerEmail');
     });
   });
 
@@ -458,6 +494,41 @@ describe('OrderRecordService', () => {
 
       const callArg = repository.upsert.mock.calls[0][0];
       expect(callArg.orderSnapshot).not.toHaveProperty('deliverySmart');
+    });
+
+    it('should serialise IncomingOrder.customerEmail into the snapshot when present (#948)', async () => {
+      const incoming = createMockIncomingOrder(); // carries customerEmail
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot['customerEmail']).toBe('buyer@example.com');
+    });
+
+    it('should omit customerEmail from the snapshot when IncomingOrder does not carry it (#948)', async () => {
+      const incoming = { ...createMockIncomingOrder(), customerEmail: undefined };
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot).not.toHaveProperty('customerEmail');
+    });
+
+    it('should omit customerEmail from the snapshot under hash-only PII mode (#948)', async () => {
+      process.env.OL_STORE_PII = 'false';
+      service = new OrderRecordService(repository);
+
+      const incoming = createMockIncomingOrder();
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot).not.toHaveProperty('customerEmail');
     });
   });
 

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -369,6 +369,10 @@ export class OrderIngestionService implements IOrderIngestionService {
       orderNumber: incoming.orderNumber,
       status: incoming.status,
       customerId: internalCustomerId,
+      // Carry the buyer email through (#948) — used only for customer-identity
+      // resolution before this point; the snapshot needs it for the label
+      // recipient. PII gating happens at persistence (`persistOrder`).
+      customerEmail: incoming.customerEmail,
       items: resolvedItems,
       totals: incoming.totals,
       shippingAddress: incoming.shippingAddress,

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -76,6 +76,13 @@ export class OrderRecordService implements IOrderRecordService {
       billingAddress: piiConfig.storePii
         ? order.billingAddress
         : this.sanitizeAddress(order.billingAddress),
+      // Buyer email (#948) — PII-gated + present-only. Unlike addresses (which
+      // get a `[REDACTED]` placeholder via sanitizeAddress), email is omitted
+      // entirely under hash-only mode: there's no meaningful redaction of an
+      // atomic identifier, and the privacy model keeps only `emailHash` on the
+      // customer projection. Needed for the Generate-Label recipient.
+      ...(piiConfig.storePii &&
+        order.customerEmail !== undefined && { customerEmail: order.customerEmail }),
       // Conditional spread matches the items-level precedent above: keep the
       // snapshot key absent (not `undefined` and not `false`) when the source
       // did not supply the flag, so consumers can distinguish "Smart not
@@ -141,6 +148,14 @@ export class OrderRecordService implements IOrderRecordService {
       billingAddress: piiConfig.storePii
         ? incoming.billingAddress
         : this.sanitizeAddress(incoming.billingAddress),
+      // Buyer email (#948) — PII-gated + present-only; see persistOrder for the
+      // omit-vs-redact rationale. For "ready" orders this awaiting_mapping
+      // snapshot is overwritten by persistOrder, so this write is for
+      // consistency/debugging of records still awaiting item mapping (which
+      // can't generate a label yet anyway) — persistOrder is the load-bearing
+      // write for the label flow.
+      ...(piiConfig.storePii &&
+        incoming.customerEmail !== undefined && { customerEmail: incoming.customerEmail }),
       createdAt: incoming.createdAt,
       updatedAt: incoming.updatedAt,
       metadata: incoming.metadata,

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -84,6 +84,13 @@ export interface Order {
   orderNumber?: string;
   status: string;
   customerId?: string;
+  /**
+   * Buyer email from the source platform (#948), carried through from
+   * `IncomingOrder.customerEmail`. Persisted into the order snapshot (PII-gated)
+   * so the Generate-Label recipient can be built without re-fetching the source.
+   * Absent when the source didn't expose one.
+   */
+  customerEmail?: string;
   items: OrderItem[];
   totals: OrderTotals;
   shippingAddress?: Address;


### PR DESCRIPTION
## What changed and why

The buyer email captured on `IncomingOrder` was dropped at every layer, so `order_records.orderSnapshot.customerEmail` was **always absent** — making the Generate-Label form (#769) reject every order with *"Buyer email is missing from the order snapshot"*, even fully-addressed ones. DB-verified: `customerEmail` present in 0/40 snapshots before this fix.

Root cause spanned three layers:
1. `Order` domain type had no `customerEmail` field (`IncomingOrder` did).
2. `OrderIngestionService.buildUnifiedOrder` used `incoming.customerEmail` only for customer-identity resolution and never mapped it onto the `Order`.
3. Both `OrderRecordService.persistOrder` and `persistIncomingSnapshot` omitted it.

### The fix (CORE-only, no migration — JSONB snapshot)
- **`order.types.ts`** — add `customerEmail?: string` to the `Order` domain type.
- **`order-ingestion.service.ts`** — `buildUnifiedOrder` maps `incoming.customerEmail` onto the unified `Order`.
- **`order-record.service.ts`** — write `customerEmail` into **both** snapshots (`persistOrder` + `persistIncomingSnapshot`), **PII-gated** behind `getPiiConfig().storePii` and present-only. Unlike addresses (which get a `[REDACTED]` placeholder), email is **omitted entirely** under hash-only mode — there's no meaningful redaction of an atomic identifier, and the projection keeps only `emailHash`.
- **`generate-label-form.tsx`** — correct the stale *"Gate guarantees customerEmail is present"* comment (no behavior change).

### Out of scope (per #948)
- Thin PrestaShop seed orders lacking address/items (dev-fixture data, not a code bug).
- Masked Allegro email (`+txid@allegromail`) deliverability — separate downstream concern.
- Backfilling existing rows — value lands on next re-ingest (snapshot rebuilt each `syncOrderFromSource`).
- Button-level recipient gate on `ShipmentActionButtons` — reasonable follow-up, not here.

## How to test
- `pnpm test` — covers the full path:
  - `order-ingestion.service.spec.ts` — `buildUnifiedOrder` carries the email (present/absent).
  - `order-record.service.spec.ts` — both snapshots persist it (present / absent / hash-only-omitted).
- Manually: re-ingest an Allegro order with a buyer email → `orderSnapshot.customerEmail` is populated → Generate-Label form no longer reports the email missing.

## Quality gate
- `pnpm lint` ✅ (zero errors) · `pnpm type-check` ✅ · `pnpm test` ✅ (core 1001 + web suites)
- No migration needed (JSONB snapshot); `check:invariants` unaffected (additive optional field, same context).

## Related
#769 (generate label) · #928 (payment gate) · #939 (snapshot `.nullish()` fix) · #925 (data-capture epic)

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)