### PR TITLE
feat(dx): adopt open-mercato AI dev workflows (#949)

### DIFF
--- a/.claude/commands/pre-implement.md
+++ b/.claude/commands/pre-implement.md
@@ -1,0 +1,65 @@
+@docs/architecture-overview.md
+@docs/engineering-standards.md
+
+You are the **OpenLinker Tech Lead** running a **read-only readiness gate** on an implementation plan *before* any code is written.
+
+Your job: catch the two classes of mistake that are expensive to unwind once code exists —
+1. **Reinventing what already exists** (a port, service, DI token, ORM entity, or capability the plan assumes is new but isn't), and
+2. **Breaking a published contract surface** (a barrel export, port signature, DTO shape, Symbol token, or ORM schema other code depends on).
+
+Run against: **$ARGUMENTS** — a plan path (`docs/plans/implementation-plan-*.md`) and/or an issue number. If neither is given, ask for one.
+
+---
+
+## How this differs from `/plan` and `/tech-review`
+
+- `/plan` **Phase 4** validates the plan *in the abstract* — internal consistency, naming, architecture fit.
+- `/tech-review` reviews a *diff that already exists*.
+- `/pre-implement` is the missing middle: it greps the **live repository** to confirm the plan's assumptions against reality, and flags contract-surface breaks **before** a line is written. It produces no code and edits nothing — including the plan.
+
+If you find yourself rewriting the plan or editing source, stop: that is out of scope for this gate.
+
+---
+
+## Phase A — Load context
+
+1. Read the plan file end to end. If only an issue number was given, locate the matching `docs/plans/implementation-plan-*.md`; if none exists, read the issue (`issue_read`) and gate against its proposed solution instead.
+2. From the plan, extract the concrete artifacts it proposes to **create** or **change**: ports, services, repositories, adapters, DI tokens, ORM entities, controllers, DTOs, events, capabilities, barrel exports.
+
+## Phase B — Reuse audit (does it already exist?)
+
+Fan out parallel `Explore` agents — one per artifact class — to grep the real tree:
+
+- **Ports / capabilities** — search `libs/core/src/**/domain/ports/**` for an existing `*Port` or `*.capability.ts` that already covers the intent.
+- **Services** — search `libs/**/application/services/**` for an existing `*Service` doing this.
+- **DI tokens** — search `libs/core/src/**/*.tokens.ts` for a token the plan reinvents.
+- **ORM entities / schema** — search `**/*.orm-entity.ts` for an existing table/column the plan re-adds.
+- **Capabilities** — check `CoreCapabilityValues` and adapter `supportedCapabilities`.
+
+For each plan artifact, classify: **NEW (confirmed absent)** / **ALREADY EXISTS → reuse** / **PARTIAL (extend existing)**. Cite the file path for every "exists" hit.
+
+## Phase C — Backward-compatibility checklist
+
+For everything the plan **changes** (not just adds), check each contract surface and assign a severity:
+
+| Surface | What to check | Break = |
+|---|---|---|
+| Top-level barrels (`@openlinker/core/<ctx>`) | Is an exported symbol removed/renamed? | Critical |
+| Port method signatures | Signature changed on an implemented `*Port`? | Critical |
+| DTO shapes | Field removed / made required / retyped on a request/response DTO? | Critical |
+| Symbol tokens (`*.tokens.ts`) | Token removed/renamed? | Critical |
+| ORM schema | Entity field/table change ⇒ migration required (`docs/migrations.md`)? | Warning |
+| `check:invariants` rules | Will the plan trip `check-cross-context-imports`, `check-service-interfaces`, deep-barrel imports, or the repo-URL guard? | Warning |
+
+## Phase D — Verdict
+
+Write `docs/plans/analysis/ANALYSIS-{plan-name}.md` containing:
+
+- **Verdict**: `READY` / `NEEDS-REVISION` / `NEEDS-MAJOR-REVISION`.
+- **Reuse findings**: table of plan artifact → NEW / EXISTS / PARTIAL + file path.
+- **Backward-compat findings**: Critical and Warning items with the affected surface and a suggested migration path.
+- **Open questions**: anything the plan leaves unresolved that blocks a clean implementation.
+
+Verdict rule: any **Critical** ⇒ at least `NEEDS-REVISION`; an unaddressed contract break or a major reuse collision ⇒ `NEEDS-MAJOR-REVISION`. Otherwise `READY`.
+
+Then print a one-paragraph summary to the user and stop. Do not edit the plan or any source — the report is the deliverable; revising the plan is the human's (or `/plan`'s) next step.

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -9,7 +9,7 @@ Follow each phase below in sequence. **Pause for user input** at the decision po
 
 ## Phase 1 — Discover
 
-1. Fetch open GitHub issues using the MCP GitHub tools (`list_issues` for `SilkSoftwareHouse/openlinker`, state `OPEN`)
+1. Fetch open GitHub issues using the MCP GitHub tools (`list_issues` for `openlinker-project/openlinker`, state `OPEN`)
 2. Review recent git history (`git log --oneline -20`) to understand what was recently merged
 3. Identify which issues are ready to work on — consider:
    - Dependencies (does this issue depend on another that isn't done yet?)
@@ -17,6 +17,29 @@ Follow each phase below in sequence. **Pause for user input** at the decision po
    - Priority (unblocks other work, completes a vertical slice, reduces tech debt)
 
 ⏸️ **Present your recommendations** — suggest 2-3 issues (or issue pairs) ranked by priority with a one-line reason each. Ask the user which to work on.
+
+---
+
+## Phase 1.5 — Claim & Verify
+
+After the user picks the issue(s), **before** creating the worktree, run a lightweight claim-lock so parallel sessions don't collide. All GitHub operations use the MCP GitHub tools (`gh` CLI is not installed).
+
+1. **Verify the issue is still actionable** — for each picked issue:
+   - `issue_read` — confirm it is still `OPEN` (skip if closed).
+   - Confirm it isn't already fixed: search merged PRs (`list_pull_requests` / `search_pull_requests`) and `git log origin/main --grep "#<n>"` for work that already landed. If it looks fixed, surface that and stop rather than duplicating it.
+
+2. **Check for an existing claim** — note that parallel OpenLinker sessions all authenticate as the **same** GitHub account, so the GitHub *actor* cannot tell two sessions apart. The lock therefore keys on the **branch name**, not the assignee:
+   - Read the issue's comments for a marker of the form
+     `🤖 claimed for work by branch \`<branch>\` at <ISO-timestamp>`.
+   - If a marker exists whose `<branch>` **differs** from the branch this session is about to create AND its timestamp is within the **2-hour** freshness window → another live session likely holds it. Stop and ask the user before proceeding (override allowed).
+   - A marker from this session's **own** branch is a re-entry (resume), not a collision.
+   - A marker older than 2 hours is **stale** — reclaim it.
+
+3. **Post the claim** via the MCP GitHub tools:
+   - `add_issue_comment` with `🤖 claimed for work by branch \`<issue>-<slug>\` at <ISO-timestamp>`.
+   - If the repo has an `in-progress` label (verify once with `get_label`; if it doesn't exist, ask the user to create it or fall back to comment-only locking), add it via `issue_write`.
+
+> The claim is advisory — it prevents accidental double-work, not malicious races. Never block on it silently; always tell the user what you found.
 
 ---
 
@@ -70,6 +93,7 @@ docs/plans/implementation-plan-{feature-name}.md
 
 ## Phase 4 — Implement
 
+0. **Re-touch the claim** (keeps long-but-active sessions from being treated as stale): post a fresh `🤖 claimed for work by branch …` comment so the 2-hour window resets before the implementation phase, which can run long.
 1. **Implement every step** from the plan:
    - Follow all architecture rules (hexagonal boundaries, ports, naming conventions)
    - No `any` types, no `console.log`, no hardcoded secrets
@@ -99,6 +123,7 @@ docs/plans/implementation-plan-{feature-name}.md
 If the user says to ship it:
 5. Push the branch and create a PR with `Closes #N` in the body
 6. Output the PR URL
+7. **Release the claim**: remove the `in-progress` label (if it was applied) via `issue_write`. The PR's `Closes #N` handles closure on merge — never close the issue manually. If work is **abandoned** instead of shipped, also release the label so another session can pick the issue up.
 
 ---
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,35 +11,13 @@ pnpm lint || exit 1
 echo "🔎 Running type check for all packages..."
 pnpm type-check || exit 1
 
-# Tests are scoped to the packages whose files are staged. A libs/** touch
-# still fans out to all tests because shared libs can break any consumer.
-# Docs/config-only changes skip tests entirely. CI runs the full suite
-# regardless — this only speeds up the local loop.
-changed=$(git diff --cached --name-only)
-
-# Keep in sync with the CI job so nothing silently diverges.
-# Unit tests only here; `pnpm test:integration` stays out of the hook.
-if [ -z "$changed" ]; then
-  echo "🧪 Running unit tests for all packages (no staged paths)..."
-  pnpm test || exit 1
-elif printf '%s\n' "$changed" | grep -Eq '^libs/'; then
-  echo "🧪 Running unit tests for all packages (libs/ touched)..."
-  pnpm test || exit 1
-elif ! printf '%s\n' "$changed" | grep -Eqv '^(docs/|\.claude/|\.github/|\.vscode/|README\.md$|\.gitignore$|\.prettierignore$|\.prettierrc|\.editorconfig$)'; then
-  echo "🧪 Skipping tests (docs/config-only change)."
-else
-  filters=""
-  printf '%s\n' "$changed" | grep -q '^apps/web/'    && filters="$filters --filter @openlinker/web"
-  printf '%s\n' "$changed" | grep -q '^apps/api/'    && filters="$filters --filter @openlinker/api"
-  printf '%s\n' "$changed" | grep -q '^apps/worker/' && filters="$filters --filter @openlinker/worker"
-
-  if [ -z "$filters" ]; then
-    echo "🧪 Running unit tests for all packages (unknown path staged)..."
-    pnpm test || exit 1
-  else
-    echo "🧪 Running scoped unit tests:$filters"
-    pnpm $filters test || exit 1
-  fi
-fi
+# Diff-driven unit-test selection (scripts/smart-test.mjs). Replaces the
+# hand-rolled per-package scoping that previously ran the FULL suite on any
+# libs/ touch — a libs/core change now runs only @openlinker/core's related
+# specs (jest --findRelatedTests), not the flaky apps/web suite. The
+# integration tier stays out of the hook (--no-integration); CI runs the full
+# suite regardless. See scripts/smart-test.mjs for the classification rules.
+echo "🧪 Running affected unit tests (smart-test)..."
+pnpm smart-test --no-integration || exit 1
 
 echo "✅ Pre-commit checks passed!"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,11 @@ Before writing or modifying code, read the relevant doc(s):
 | Frontend technical architecture and state rules | `docs/frontend-architecture.md` |
 | Frontend visual and interaction style | `docs/frontend-ui-style-guide.md` |
 | Implementation plan process | `docs/implementation-plan-generator-guide.md` |
+| Recurring gotchas / regression ledger | `docs/lessons.md` |
 
 Architecture docs define **intent and direction**, not every implementation detail. You may infer missing layers or patterns if they clearly align — but always justify them explicitly.
+
+**Review `docs/lessons.md` at the start of a work session** — it's the empirical regression ledger of mistakes already made (not architectural rules; those live in the docs above). After a correction that would prevent a repeat mistake, add an entry following the format documented at the top of that file.
 
 ---
 

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1,0 +1,72 @@
+# Lessons
+
+Recurring patterns and mistakes to avoid. **Review at the start of a work session.**
+
+## What belongs here (and what doesn't)
+
+This file is a **regression ledger** — empirical gotchas discovered while doing the work, written forward so the same mistake isn't repeated. It is **not** the place for architectural rules. Those stay canonical in:
+
+- `docs/engineering-standards.md` — coding standards, naming, layering
+- `docs/architecture-overview.md` — bounded contexts, ports, data flow
+- `docs/architecture/adrs/` — decisions and their rationale
+- `.claude/rules/*` — agent-facing rule sheets
+
+When a lesson hardens into a rule, **graduate it** to the canonical doc and leave the lesson pointing at it. Keep entries empirical, dated by the PR/ADR that established them, and scoped with **Applies to** so they're easy to match against the file you're touching.
+
+**Entry format** — one `##` heading per lesson (the heading *is* the rule, imperative), then:
+
+- `**Context**:` the situation it came up in
+- `**Problem**:` what went wrong
+- `**Rule**:` the preventive measure
+- `**Applies to**:` files / modules / scope
+- `**Source**:` PR / ADR reference
+
+---
+
+## Create destination PrestaShop orders via `validateOrder`, never the raw webservice `POST /orders`
+
+**Context**: Creating marketplace orders on a destination PrestaShop shop.
+**Problem**: `POST /orders` over the PrestaShop webservice bypasses `PaymentModule::validateOrder` — it drops the posted carrier and re-resolves shipping to the cheapest *available* option (a free click-&-collect can win), corrupting the order's carrier and totals.
+**Rule**: Create destination orders through PrestaShop's canonical `PaymentModule::validateOrder`, invoked via the OpenLinker module's HMAC-authed `importorder` endpoint. This requires the OL PrestaShop module to be installed on the destination shop. Do not "fix up" the carrier with a post-create `PUT` — it is rejected.
+**Applies to**: PrestaShop order-processor adapter; destination order creation in `libs/integrations/prestashop`.
+**Source**: ADR-016 (`docs/architecture/adrs/016-prestashop-order-create-via-validateorder.md`), PR #916.
+
+## Rebuild `libs` dist after pulling/merging main, before type-check or commit
+
+**Context**: Cross-package TypeScript resolves `@openlinker/*` against each library's built `dist`, not its source.
+**Problem**: After pulling or merging `main`, stale `dist` output makes `pnpm type-check` (and the pre-commit hook) fail in ways that look like a merge defect but are just stale artifacts.
+**Rule**: After pulling/merging `main`, rebuild the libraries before type-checking or committing: `pnpm -r --filter "./libs/**" build` (this is exactly what the root `type-check` and `test:ci` scripts do first).
+**Applies to**: any session that pulls main mid-work; pre-commit hook failures referencing `@openlinker/*` types.
+**Source**: root `package.json` `type-check` / `test:ci` scripts.
+
+## FE Zod schemas over OL snapshots must use `.nullish()`, not `.optional()`
+
+**Context**: OpenLinker serialises absent optional fields in persisted snapshots as JSON `null` (not omitted).
+**Problem**: A frontend Zod schema using `.optional()` rejects an explicit `null`, so one null sub-field fails validation for the whole section and the cell/section renders blank.
+**Rule**: When a FE Zod schema models an OL snapshot, use `.nullish()` (accepts `null` and `undefined`) for every optional field, not `.optional()`.
+**Applies to**: `apps/web/src` Zod schemas that parse backend snapshot payloads.
+**Source**: PR #941.
+
+## Worker integration specs are not covered by the lint / type-check gate
+
+**Context**: `apps/worker/tsconfig.build.json` excludes `test` (and `**/*.spec.ts` / `**/*.test.ts`); the root `type-check` and `lint` don't compile `apps/worker/test`.
+**Problem**: Worker `*.int-spec.ts` files are only compile-checked by ts-jest at integration-test runtime, so a broken worker int-spec slips past `pnpm lint` + `pnpm type-check` and isn't caught until the integration suite runs (and may not run in CI).
+**Rule**: After changing worker integration specs, run them explicitly with the integration suite — do not assume the standard quality gate covers them.
+**Applies to**: `apps/worker/test/**/*.int-spec.ts`.
+**Source**: `apps/worker/tsconfig.build.json`.
+
+## Allegro shipping label PDF is `POST /shipment-management/label` — not the protocol/handover endpoint
+
+**Context**: Generating Allegro shipping artifacts.
+**Problem**: A label is not the same as a handover protocol / manifest; using the protocol endpoint returns the wrong document, and the shipping HTTP clients lacked a binary-response path.
+**Rule**: Download the label PDF via `POST /shipment-management/label`; keep label and protocol/handover-manifest endpoints distinct, and ensure the HTTP client supports binary responses.
+**Applies to**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-delivery-shipping.adapter.ts` and the Allegro HTTP client interface.
+**Source**: Allegro shipping adapter implementation.
+
+## Allegro buyer-placed time is `lineItems[].boughtAt`, not a top-level checkout-form field
+
+**Context**: Capturing the buyer-placed timestamp from an Allegro order.
+**Problem**: There is no top-level checkout-form `placed`/`created` timestamp; an `AllegroCheckoutForm.createdAt` field would be fictional.
+**Rule**: Read the buyer-placed time from `lineItems[].boughtAt`. The PrestaShop equivalent is `date_add`.
+**Applies to**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts`; `libs/core/src/orders/domain/types/incoming-order.types.ts`.
+**Source**: Allegro order-source adapter.

--- a/docs/plans/analysis/.gitkeep
+++ b/docs/plans/analysis/.gitkeep
@@ -1,0 +1,4 @@
+# Pre-implement readiness reports
+
+`/pre-implement` writes its readiness verdict here as `ANALYSIS-{plan-name}.md`.
+This file keeps the directory tracked when no reports are present.

--- a/docs/plans/implementation-plan-949-adopt-open-mercato-ai-workflows.md
+++ b/docs/plans/implementation-plan-949-adopt-open-mercato-ai-workflows.md
@@ -1,0 +1,88 @@
+# Implementation Plan — Adopt open-mercato AI dev workflows (#949)
+
+## TL;DR
+
+Port four lightweight DX workflows from [`open-mercato/open-mercato`](https://github.com/open-mercato/open-mercato)'s MIT-licensed `.ai/` tooling into OpenLinker's Claude Code flow:
+
+1. `/pre-implement` — a read-only readiness gate between `/plan` and `/work`.
+2. A GitHub claim-lock protocol added to `/work` startup (parallel-session safety).
+3. `scripts/smart-test.mjs` — diff-driven `pnpm --filter` test selection + integration-tier gating.
+4. `docs/lessons.md` — a committed, shared project-lessons ledger, referenced from `CLAUDE.md`.
+
+This is a **DX / tooling** change only. No runtime code in `libs/` or `apps/`, no migrations, no change to the `pnpm check:invariants` contract.
+
+## Classification
+
+- **Type**: DX (process / tooling)
+- **Layer**: none (repo-level `.claude/`, `scripts/`, `docs/`)
+- **Non-goals**: porting open-mercato's `tiers.json` / `install-skills` dual-runtime distribution; a plugin-scaffold skill; `sync-merged-pr-issues`; an architecture-guardian score; `/merge-buddy`. All explicitly deferred per #949.
+
+## Research notes (existing patterns reused)
+
+- **Commands** live as tracked markdown in `.claude/commands/*.md` (`plan.md`, `work.md`, …). They open with `@docs/...` includes and a role line, use `$ARGUMENTS`, and mark human pauses with ⏸️. New command mirrors this.
+- **Invariant scripts** in `scripts/check-*.mjs` use a pure classifier + a `--self-check` mode exercising synthetic cases (canonical example: `check-service-interfaces.mjs`). `smart-test.mjs` reuses that exact shape so its classifier is testable without a root jest spec.
+- **`check-repo-urls.mjs`** scans `docs/` and `scripts/` (skips `.claude/`) and forbids the old `SilkSoftwareHouse` org slug — new files use the canonical `openlinker-project/openlinker`.
+- **Contract surfaces** the pre-implement gate checks are already named in `docs/engineering-standards.md`: top-level barrels (`@openlinker/core/<ctx>`), `*.tokens.ts` Symbol tokens, capability `*Port`s, ORM entities, plus the `check:invariants` rules (`check-cross-context-imports.mjs`, `check-service-interfaces.mjs`).
+
+## Design & steps
+
+### Item 1 — `/pre-implement` gate · `.claude/commands/pre-implement.md` (new)
+Read-only command. Input via `$ARGUMENTS`: a plan path (`docs/plans/implementation-plan-*.md`) and/or an issue number.
+- Phase A — load the plan + issue (`issue_read`).
+- Phase B — **reuse audit**: fan out `Explore` agents to grep the real repo for each port / service / DI token / ORM entity / capability the plan treats as *new*, flagging anything that already exists as a reuse candidate.
+- Phase C — **backward-compat checklist** over contract surfaces: barrel exports, port method signatures, DTO shapes, `*.tokens.ts` symbols, ORM schema (migration needed?), and the `check:invariants` rules the plan might trip.
+- Phase D — emit a verdict **READY / NEEDS-REVISION / NEEDS-MAJOR-REVISION** with Critical/Warning findings, written to `docs/plans/analysis/ANALYSIS-{plan-name}.md`. No code or plan edits.
+- **Seam note (I2)**: the command must open with a short "How this differs from `/plan` and `/tech-review`" section — `/plan` Phase 4 validates the plan *in the abstract*; `/tech-review` reviews a *diff*; `/pre-implement`'s unique job is grepping the **live repo** for collisions (does this token/port/entity already exist?) and contract-surface breaks *before* code exists. Without this, it bitrots as a duplicate of `/plan`'s checklist.
+- Create `docs/plans/analysis/.gitkeep` (S2) so the output directory exists and is tracked.
+- **AC**: command exists, is read-only, carries the seam note, names the contract-surface checklist, writes to `docs/plans/analysis/`.
+
+### Item 2 — claim-lock · `.claude/commands/work.md` (edit)
+Insert a **"Phase 1.5 — Claim & verify"** between issue selection and worktree setup:
+- Verify the issue is still **open and unfixed**: `issue_read` state + search merged PRs (`list_pull_requests` / `search_pull_requests`) + `git log origin/main --grep "#N"`.
+- **Lock identity (B2)**: parallel OpenLinker sessions all run as the **same** GitHub account, so the GitHub *actor* cannot distinguish two sessions. The claim therefore keys on the **session's branch/worktree name**, not the assignee. The claim comment is `🤖 claimed for work by branch \`{issue}-{slug}\` at {ISO-ts}`; the gate reads existing `🤖 claimed for work by branch …` comments and only blocks when the holder branch **differs** from this session's branch. A claim from this session's own branch is a no-op re-entry, not a collision.
+- **Existing-claim handling**: if an `in-progress` label is present AND a live foreign-branch claim comment exists within the freshness window → stop unless the user overrides. Outside the window → treat as stale and reclaim.
+- **Freshness window (I3)**: `/work` sessions routinely exceed an hour, so a 60-min steal window is too short. Use a **2-hour** window, and re-touch the claim (new timestamped comment) at the start of Phase 4 (Implement) so long but active sessions aren't stolen.
+- **Label precondition (I3)**: before relying on the `in-progress` label, confirm it exists in the repo (`get_label`); if absent, the command instructs the operator to create it once (or falls back to comment-only locking) rather than assuming `issue_write` auto-creates it.
+- Post the claim via GitHub MCP: `issue_write` (add `in-progress` label, if present) + `add_issue_comment` (branch-scoped `🤖` marker).
+- Add a release note to Phase 5: on ship/abandon, remove `in-progress` (never close the issue — existing rule).
+- Drive-by: fix the stale `SilkSoftwareHouse` org slug already in `work.md` line 12 → `openlinker-project/openlinker`.
+- **AC**: `/work` startup verifies open/unfixed, claims via a **branch-scoped** marker (no false collision for same-user sessions), recovers stale locks on a 2-hour window, re-touches on Phase 4, releases on finish.
+
+### Item 3 — `scripts/smart-test.mjs` (new) + `package.json` (edit)
+Pure classifier `classify(changedFiles) → { scope, packages, runIntegration, reason }`:
+- **Granularity (B1)**: pnpm's finest test unit is the **workspace package**, not the bounded context — `libs/core` is a *single* package (`@openlinker/core`) with subpath exports, so a change under `libs/core/src/orders/` can only select the whole `@openlinker/core` Jest project via `pnpm --filter`. The classifier therefore maps changed paths → **workspace package names** (`@openlinker/core`, `@openlinker/api`, `@openlinker/worker`, each `libs/integrations/*` package, `@openlinker/web`). Intra-package narrowing (run only the specs touching the changed files) is delegated to **`jest --findRelatedTests <files>`** within the selected package — *not* `pnpm --filter`, which can't reach below package level.
+- **WIDE** (run everything) when any changed path is under `libs/shared/`, a core top-level barrel (`libs/core/src/<ctx>/index.ts` / `*.tokens.ts`), or root config (`package.json`, `tsconfig*.json`, `pnpm-workspace.yaml`, jest config).
+- **Layer gating**: pure `apps/web/**` → skip backend packages + skip integration tier; backend-only → skip `@openlinker/web`; integration (`pnpm test:integration`) runs only when backend/core/integration code or `*.int-spec.ts` changed.
+- Driver: resolve base ref (`SMART_TEST_BASE_REF` env or `origin/main`), `git diff --name-only <base>...HEAD` + uncommitted + untracked, classify, print the plan; exec the `pnpm --filter <pkg> exec jest --findRelatedTests …` (and `pnpm test:integration` when gated in) unless `--dry-run`.
+- **No cache (S1)**: drop the commit-pinned `.smart-test-cache.json` for v1 — the classifier + `--dry-run` is the valuable core; cache invalidation is a foot-gun deferred until there's evidence it's needed.
+- `--self-check`: exercise the pure classifier on synthetic diffs incl. the AC cases (backend-only skips `@openlinker/web`; `libs/shared` → WIDE; pure `apps/web` skips the integration tier), mirroring `check-service-interfaces.mjs --self-check`.
+- Wire `"smart-test": "node scripts/smart-test.mjs"` in `package.json`. **Not** added to `check:invariants` (respects the AC) and CI keeps running the full suite.
+- **Wired into the pre-commit hook (revised — replaces I1's "follow-up")**: smart-test replaces the hand-rolled test-scoping block in `.husky/pre-commit`, unit-only via a new `--no-integration` flag. The old hook ran the **full** suite on any `libs/` touch, so a `libs/core` backend change dragged in the flaky `apps/web` suite; now it runs only `@openlinker/core`'s related specs (`jest --findRelatedTests`). It is **not** added to `check:invariants`; `/work` Phase 4 and CI still run the full suite — the hook is the fast local path, the full suite the safety net. The real exec path was validated end-to-end before wiring.
+- **AC**: maps a backend-only diff to `@openlinker/*` backend packages + skips `@openlinker/web`; treats `libs/shared` as WIDE; uses `jest --findRelatedTests` for intra-package selection; `--no-integration` skips the Testcontainers tier; wired into `.husky/pre-commit`; `--self-check` passes.
+
+### Item 4 — `docs/lessons.md` (new) + `CLAUDE.md` (edit)
+- Create `docs/lessons.md`: preamble + topical `## <imperative rule>` entries, each with `**Context** / **Problem** / **Rule** / **Applies to**` (open-mercato `.ai/lessons.md` shape).
+- **Seam definition (I4)**: the preamble must state that `docs/lessons.md` holds **empirical regression gotchas** discovered during work — *not* architectural rules (those stay canonical in `docs/engineering-standards.md`, `docs/architecture-overview.md`, `.claude/rules/*`). When a lesson hardens into a rule, it graduates to the canonical doc and the lesson links to it. This prevents the five-rule-homes drift.
+- **Seed-verification step (I4)**: each candidate lesson is sourced from accumulated memory that reflects *state when written*; before writing each entry, **verify it against the current repo** (the named file/flag/command still exists) and cite the PR/ADR. Drop or correct any that no longer hold.
+- Seed with durable, **verified, project-level** lessons (not personal workflow prefs): PrestaShop WS carrier→`validateOrder` (ADR-016 / #916); rebuild `libs` dist after pulling main before type-check; FE zod `.nullish()` over snapshot nulls (#941); worker int-specs escape the quality gate; Allegro label vs protocol endpoint; Allegro `boughtAt` placed-time. Personal-workflow items (e.g. the single-int-spec invocation form) stay in agent memory unless they prove to be team-wide.
+- Reference `docs/lessons.md` from `CLAUDE.md` (Reference Documentation table + a "read at session start" note).
+- **AC**: file exists in the prescribed format with the seam definition, seeded with verified lessons, referenced from `CLAUDE.md`.
+
+## Risks & validation
+
+- **Quality gate**: changes are non-TS-source; `pnpm lint` / `type-check` / `test` should be unaffected. Risk is `check-repo-urls` (mitigated: canonical slug in `docs/` + `scripts/`) — run the full gate before commit.
+- **smart-test correctness**: under-testing a boundary-crossing change. Mitigation: `libs/shared` + core-barrel + root-config ⇒ WIDE; CI still runs everything; `--self-check` locks the classifier; it's opt-in (I1) so a misclassification can't silently weaken the default gate.
+- **Testability reality (S3)**: 3 of 4 deliverables are markdown (commands, docs) with no automated test by nature; only `smart-test.mjs` carries logic and is covered by `--self-check`. The Phase 5 self-review should treat "tests added" as satisfied by the self-check + N/A for the prose artifacts, not a gap.
+- **No migration**, no ORM entity, no barrel change ⇒ no `migration:show` step.
+
+## Final checklist
+
+- [ ] Four deliverables implemented as scoped above
+- [ ] Item 1 carries the seam note vs `/plan` + `/tech-review`; `docs/plans/analysis/.gitkeep` added
+- [ ] Item 2 lock keys on branch identity (no same-user false collision), 2-hour window + Phase-4 re-touch, label-existence precondition
+- [ ] Item 3 maps to workspace packages + `jest --findRelatedTests`, no cache, `--no-integration` flag, wired into `.husky/pre-commit` (not `check:invariants`); exec path validated
+- [ ] Item 4 has the seam definition; every seeded lesson verified against the current repo
+- [ ] `pnpm smart-test --self-check` passes
+- [ ] `pnpm lint && pnpm type-check && pnpm test` green
+- [ ] No change to `check:invariants` chain; CI full suite intact
+- [ ] `CLAUDE.md` references the new command + lessons ledger

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:cov": "pnpm -r test:cov",
     "test:integration": "pnpm --filter @openlinker/api test:integration",
     "test:php": "cd apps/prestashop-module/openlinker && composer install --no-interaction --quiet && vendor/bin/phpunit",
+    "smart-test": "node scripts/smart-test.mjs",
     "lint": "pnpm -r lint && pnpm check:invariants",
     "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-libs-build-scripts.mjs && node scripts/check-plugin-guide-quotes.mjs && node scripts/check-repo-urls.mjs && node scripts/check-cross-context-imports.mjs && node scripts/check-service-interfaces.mjs --self-check && node scripts/check-service-interfaces.mjs && node scripts/check-jest-integration-mappers.mjs --self-check && node scripts/check-jest-integration-mappers.mjs",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",

--- a/scripts/smart-test.mjs
+++ b/scripts/smart-test.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+/**
+ * smart-test.mjs (#949)
+ *
+ * Diff-driven test selector for the pnpm workspace. Maps the files changed
+ * vs a base ref to the *workspace packages* they belong to, then runs only
+ * those packages' tests — narrowing within each package via
+ * `jest --findRelatedTests`. Backend-only changes skip the flaky
+ * `@openlinker/web` suite; pure frontend changes skip the slow Testcontainers
+ * integration tier.
+ *
+ * Granularity note (#949 review B1). pnpm's finest test unit is the workspace
+ * PACKAGE, not the bounded context — `libs/core` is a single package
+ * (`@openlinker/core`) with subpath exports, so a change under
+ * `libs/core/src/orders/` can only select the whole `@openlinker/core` Jest
+ * project via `pnpm --filter`. Sub-package narrowing is delegated to
+ * `jest --findRelatedTests <files>`, which `pnpm --filter` cannot do.
+ *
+ * Wired into `.husky/pre-commit` (unit-only, via `--no-integration`) so the
+ * per-commit loop runs only the affected packages' tests. It is NOT added to
+ * `check:invariants`, and `/work` Phase 4 + CI still run the full suite — the
+ * hook is the fast local path, the full suite stays the safety net.
+ *
+ * Usage:
+ *   pnpm smart-test                   # classify changes vs origin/main and run
+ *   pnpm smart-test --dry-run         # print the plan, run nothing
+ *   pnpm smart-test --no-integration  # skip the Testcontainers tier (used by the hook)
+ *   pnpm smart-test --self-check      # exercise the pure classifier (no git, no fs)
+ *   SMART_TEST_BASE_REF=<ref> pnpm smart-test   # override the base ref
+ *
+ * @module scripts
+ */
+
+import { spawnSync } from 'node:child_process';
+
+const DEFAULT_BASE_REF = 'origin/main';
+
+// Changes anywhere under these roots, or to a top-level config file, force a
+// full run — they can affect any package transitively.
+const WIDE_PREFIXES = ['libs/shared/', 'libs/test-kit/'];
+const WIDE_BASENAMES = new Set([
+  'package.json',
+  'pnpm-workspace.yaml',
+  'pnpm-lock.yaml',
+  'turbo.json',
+  'tsconfig.base.json',
+  'tsconfig.json',
+  'jest.config.cjs',
+  'jest.config.js',
+  'jest.setup.ts',
+  '.eslintrc.js',
+]);
+// A change to a core top-level barrel or a context's Symbol-token file is a
+// published-contract change → treat as wide.
+const CORE_BARREL_RE = /^libs\/core\/src\/[^/]+\/index\.ts$/;
+const CORE_TOKENS_RE = /^libs\/core\/src\/[^/]+\/[^/]+\.tokens\.ts$/;
+
+// The single frontend package; everything else selected is "backend".
+const FRONTEND_PACKAGE = 'apps/web';
+const INT_SPEC_RE = /\.int-spec\.ts$/;
+
+/** Map one repo-relative path to its workspace package root dir, or null. */
+function packageRootFor(file) {
+  // libs/integrations/<name>/... → libs/integrations/<name>
+  const integ = file.match(/^(libs\/integrations\/[^/]+)\//);
+  if (integ) return integ[1];
+  // libs/<name>/... → libs/<name>  (core, plugin-sdk, …; shared/test-kit handled as wide)
+  const lib = file.match(/^(libs\/[^/]+)\//);
+  if (lib) return lib[1];
+  // apps/<name>/... → apps/<name>
+  const app = file.match(/^(apps\/[^/]+)\//);
+  if (app) return app[1];
+  return null;
+}
+
+function basename(file) {
+  const i = file.lastIndexOf('/');
+  return i === -1 ? file : file.slice(i + 1);
+}
+
+function isWideTrigger(file) {
+  if (WIDE_PREFIXES.some((p) => file.startsWith(p))) return true;
+  if (CORE_BARREL_RE.test(file) || CORE_TOKENS_RE.test(file)) return true;
+  // Top-level config file (no directory component).
+  if (!file.includes('/') && WIDE_BASENAMES.has(basename(file))) return true;
+  return false;
+}
+
+/**
+ * Pure classifier — no git, no filesystem. Given the list of changed
+ * repo-relative paths, decide what to run. Returns:
+ *   { scope: 'none'|'scoped'|'wide', packages: string[], runIntegration: boolean, reason }
+ */
+export function classify(changedFiles) {
+  const files = changedFiles.filter(Boolean);
+  if (files.length === 0) {
+    return { scope: 'none', packages: [], runIntegration: false, reason: 'no changed files' };
+  }
+
+  const wideHit = files.find((f) => isWideTrigger(f));
+  if (wideHit) {
+    return {
+      scope: 'wide',
+      packages: [],
+      runIntegration: true,
+      reason: `wide trigger: ${wideHit} affects all packages`,
+    };
+  }
+
+  const packages = new Set();
+  for (const f of files) {
+    const root = packageRootFor(f);
+    if (root) packages.add(root);
+  }
+
+  if (packages.size === 0) {
+    return {
+      scope: 'none',
+      packages: [],
+      runIntegration: false,
+      reason: 'changes touch no workspace package (e.g. docs / .claude only)',
+    };
+  }
+
+  const selected = [...packages].sort();
+  const backendSelected = selected.filter((p) => p !== FRONTEND_PACKAGE);
+  // Integration tier runs when backend code is in scope, or any int-spec changed.
+  const runIntegration = backendSelected.length > 0 || files.some((f) => INT_SPEC_RE.test(f));
+
+  const skipped = selected.includes(FRONTEND_PACKAGE) && backendSelected.length === 0
+    ? 'frontend-only — integration tier skipped'
+    : backendSelected.length > 0 && !selected.includes(FRONTEND_PACKAGE)
+      ? 'backend-only — apps/web suite skipped'
+      : 'mixed frontend + backend';
+
+  return {
+    scope: 'scoped',
+    packages: selected,
+    runIntegration,
+    reason: skipped,
+  };
+}
+
+/** Collect changed repo-relative paths from git (committed vs base + working tree). */
+function collectChangedFiles(baseRef) {
+  const runs = [
+    ['git', ['diff', '--name-only', `${baseRef}...HEAD`]],
+    ['git', ['diff', '--name-only', 'HEAD']],
+    ['git', ['diff', '--name-only', '--cached']],
+    ['git', ['ls-files', '--others', '--exclude-standard']],
+  ];
+  const set = new Set();
+  for (const [cmd, args] of runs) {
+    const out = spawnSync(cmd, args, { encoding: 'utf8' });
+    if (out.status !== 0) continue; // base ref may not exist locally; skip that source
+    for (const line of out.stdout.split('\n')) {
+      const f = line.trim();
+      if (f) set.add(f);
+    }
+  }
+  return [...set];
+}
+
+function relWithin(root, files) {
+  return files
+    .filter((f) => f.startsWith(`${root}/`))
+    .map((f) => f.slice(root.length + 1));
+}
+
+function exec(cmd, args) {
+  process.stdout.write(`\n$ ${cmd} ${args.join(' ')}\n`);
+  const res = spawnSync(cmd, args, { stdio: 'inherit', encoding: 'utf8' });
+  return res.status ?? 1;
+}
+
+function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const noIntegration = process.argv.includes('--no-integration');
+  const baseRef = process.env.SMART_TEST_BASE_REF || DEFAULT_BASE_REF;
+  const files = collectChangedFiles(baseRef);
+  const plan = classify(files);
+  const willRunIntegration = plan.runIntegration && !noIntegration;
+
+  process.stdout.write(`smart-test: base ref ${baseRef}, ${files.length} changed file(s)\n`);
+  process.stdout.write(`  scope: ${plan.scope} — ${plan.reason}\n`);
+  if (plan.scope === 'scoped') {
+    process.stdout.write(`  packages: ${plan.packages.join(', ')}\n`);
+  }
+  process.stdout.write(
+    `  integration tier: ${
+      willRunIntegration ? 'run' : plan.runIntegration ? 'skip (--no-integration)' : 'skip'
+    }\n`,
+  );
+
+  if (dryRun) {
+    process.stdout.write('\n(--dry-run: nothing executed)\n');
+    return 0;
+  }
+
+  if (plan.scope === 'none') return 0;
+
+  let failures = 0;
+
+  if (plan.scope === 'wide') {
+    failures += exec('pnpm', ['test']) === 0 ? 0 : 1;
+  } else {
+    for (const root of plan.packages) {
+      const rel = relWithin(root, files);
+      if (rel.length === 0) continue;
+      // Narrow within the package to specs related to the changed files.
+      const code = exec('pnpm', [
+        '--filter',
+        `./${root}`,
+        'exec',
+        'jest',
+        '--findRelatedTests',
+        ...rel,
+        '--passWithNoTests',
+      ]);
+      if (code !== 0) failures += 1;
+    }
+  }
+
+  if (willRunIntegration) {
+    const code = exec('pnpm', ['test:integration']);
+    if (code !== 0) failures += 1;
+  }
+
+  if (failures > 0) {
+    process.stderr.write(`\nsmart-test: ${failures} test command(s) failed.\n`);
+    return 1;
+  }
+  process.stdout.write('\nsmart-test: all selected tests passed.\n');
+  return 0;
+}
+
+/** Self-test the pure classifier against synthetic diffs (no git, no fs). */
+function selfCheck() {
+  const cases = [
+    {
+      name: 'backend-only (core) → core package, skip web, integration on',
+      files: ['libs/core/src/orders/application/services/order-ingestion.service.ts'],
+      expect: (r) =>
+        r.scope === 'scoped' &&
+        r.packages.includes('libs/core') &&
+        !r.packages.includes('apps/web') &&
+        r.runIntegration === true,
+    },
+    {
+      name: 'pure apps/web → web package, integration skipped',
+      files: ['apps/web/src/features/orders/components/orders-table.tsx'],
+      expect: (r) =>
+        r.scope === 'scoped' &&
+        r.packages.length === 1 &&
+        r.packages[0] === 'apps/web' &&
+        r.runIntegration === false,
+    },
+    {
+      name: 'libs/shared change → wide',
+      files: ['libs/shared/src/logging/logger.ts'],
+      expect: (r) => r.scope === 'wide' && r.runIntegration === true,
+    },
+    {
+      name: 'core top-level barrel → wide (published contract)',
+      files: ['libs/core/src/inventory/index.ts'],
+      expect: (r) => r.scope === 'wide',
+    },
+    {
+      name: 'core tokens file → wide (published contract)',
+      files: ['libs/core/src/inventory/inventory.tokens.ts'],
+      expect: (r) => r.scope === 'wide',
+    },
+    {
+      name: 'root package.json → wide',
+      files: ['package.json'],
+      expect: (r) => r.scope === 'wide',
+    },
+    {
+      name: 'integration plugin change → its package, backend, integration on',
+      files: ['libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts'],
+      expect: (r) =>
+        r.scope === 'scoped' &&
+        r.packages.includes('libs/integrations/allegro') &&
+        r.runIntegration === true,
+    },
+    {
+      name: 'int-spec change alone → integration on',
+      files: ['apps/api/test/integration/orders.int-spec.ts'],
+      expect: (r) => r.scope === 'scoped' && r.runIntegration === true,
+    },
+    {
+      name: 'mixed web + core → both packages, integration on (backend present)',
+      files: [
+        'apps/web/src/features/orders/index.ts',
+        'libs/core/src/orders/domain/entities/order.entity.ts',
+      ],
+      expect: (r) =>
+        r.scope === 'scoped' &&
+        r.packages.includes('apps/web') &&
+        r.packages.includes('libs/core') &&
+        r.runIntegration === true,
+    },
+    {
+      name: 'docs-only / .claude-only → none',
+      files: ['docs/lessons.md', '.claude/commands/work.md'],
+      expect: (r) => r.scope === 'none' && r.runIntegration === false,
+    },
+    {
+      name: 'empty diff → none',
+      files: [],
+      expect: (r) => r.scope === 'none',
+    },
+  ];
+
+  const failures = [];
+  for (const c of cases) {
+    let ok = false;
+    try {
+      ok = c.expect(classify(c.files));
+    } catch {
+      ok = false;
+    }
+    if (!ok) failures.push(`  ✗ ${c.name}`);
+  }
+
+  if (failures.length === 0) {
+    process.stdout.write(`✓ smart-test --self-check: ${cases.length} classifier case(s) passed.\n`);
+    return 0;
+  }
+  process.stderr.write('✗ smart-test --self-check failed:\n');
+  process.stderr.write(`${failures.join('\n')}\n`);
+  return 1;
+}
+
+const code = process.argv.includes('--self-check') ? selfCheck() : main();
+process.exit(code);


### PR DESCRIPTION
Closes #949.

Ports/adapts four DX workflows from [`open-mercato/open-mercato`](https://github.com/open-mercato/open-mercato)'s MIT-licensed `.ai/` tooling, adapted to our stack (pnpm, GitHub MCP, `.claude/commands/*.md`, TypeORM). **Tooling/docs only — no runtime code, no migration, no `check:invariants` change.**

## What's included

1. **`/pre-implement`** (`.claude/commands/pre-implement.md`) — a read-only readiness gate between `/plan` and `/work`. Fans out `Explore` agents to grep the live repo for collisions (does this port / `*.tokens.ts` symbol / ORM entity / capability already exist?) and runs a backward-compat checklist over our contract surfaces, writing a `READY / NEEDS-REVISION / NEEDS-MAJOR-REVISION` verdict to `docs/plans/analysis/`. Opens with an explicit "how this differs from `/plan` Phase 4 and `/tech-review`" seam note.

2. **`/work` claim-lock** (`.claude/commands/work.md`) — a new *Phase 1.5* that verifies an issue is still open + unfixed (merged-PR + `origin/main` search) and posts a **branch-scoped** claim marker. Keyed on branch identity rather than GitHub actor, because parallel OpenLinker sessions all authenticate as the same account; 2-hour freshness window with a Phase-4 re-touch and release on ship/abandon. Also fixes a stale org slug in the file.

3. **`scripts/smart-test.mjs`** — diff-driven test selection. Maps changed paths to **workspace packages** (`pnpm`'s finest unit; `libs/core` is one package) and narrows within each via `jest --findRelatedTests`; `libs/shared` / core barrels / `*.tokens.ts` / root config ⇒ run everything. **Wired into `.husky/pre-commit`** (unit-only via `--no-integration`), replacing the hand-rolled block that ran the *full* suite on any `libs/` touch — so a `libs/core` change no longer drags in the flaky `apps/web` suite. Pure classifier covered by `--self-check` (11 cases). Not added to `check:invariants`; CI + `/work` Phase 4 still run the full suite.

4. **`docs/lessons.md`** — a committed regression-ledger (`Context / Problem / Rule / Applies to`), referenced from `CLAUDE.md` and read at session start. Seeded only with durable, repo-verified project lessons; preamble defines the seam vs the canonical rule docs so it doesn't become a dumping ground.

## Notes for review

- Plan + adversarial self-review captured in `docs/plans/implementation-plan-949-adopt-open-mercato-ai-workflows.md` (every BLOCKING/IMPORTANT/SUGGESTION finding applied before coding).
- **Behavior change to a shared hook:** per-package runs now use `jest --findRelatedTests` (import-graph–related specs) instead of whole-package suites — finer/faster locally, with CI's full suite as the backstop. The real exec path was validated end-to-end before wiring.
- Deferred (noted in #949, not in scope): plugin-scaffold skill, `sync-merged-pr-issues`, architecture-guardian scoring, `/merge-buddy`, and the `tiers.json`/`install-skills` distribution model.

## Verification

- `pnpm lint` ✅ (0 errors, `check-repo-urls` OK) · `pnpm type-check` ✅ · `pnpm test` ✅
- `pnpm smart-test --self-check` ✅ (11/11); real `jest --findRelatedTests` exec path validated
- pre-commit hook (now lint → type-check → `smart-test --no-integration`) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)