### PR TITLE
fix(orders): persist delivery method + pickup point in the order snapshot (#952)

### DIFF
--- a/docs/plans/implementation-plan-persist-delivery-method-pickup-point.md
+++ b/docs/plans/implementation-plan-persist-delivery-method-pickup-point.md
@@ -1,0 +1,52 @@
+# Implementation Plan — persist delivery method + pickup point in the order snapshot (#952)
+
+## 1. Goal & layer
+Stop dropping the buyer's delivery method (`Order.shipping`) and pickup point (`Order.pickupPoint`) at the persistence boundary so they reach `order_records.orderSnapshot`. This makes the order-detail Delivery panel render the method/locker, restores the paczkomat pre-fill on Generate-Label, and — critically — gives fulfillment routing the `shipping.methodId` it keys on (today every Allegro order falls through to the `omp_fulfilled` default because the field is null; see #952 comment).
+
+- **Layer: CORE / orders** — Application service only (`OrderRecordService`).
+- **No migration** (JSONB snapshot). **No FE change** (the FE schema + parse + `ParsedOrderSnapshot` already handle `shipping`/`pickupPoint`).
+- **Symmetric to #948** (same persist-boundary omission, same present-only conditional-spread fix).
+
+## 2. Root cause (verified in this worktree)
+- `Order` carries `shipping?: OrderShipping` + `pickupPoint?: OrderPickupPoint` (order.types.ts). ✅
+- Allegro adapter populates them: `shipping: this.resolveShipping(lForm)` (from `delivery.method`), `pickupPoint: this.resolvePickupPoint(lForm)` (from `delivery.pickupPoint`) in `allegro-order-source.adapter.ts`. ✅
+- `buildUnifiedOrder` maps `shipping: incoming.shipping` / `pickupPoint: incoming.pickupPoint` onto `Order` (order-ingestion.service.ts:380-381). ✅
+- **`OrderRecordService.persistOrder` and `persistIncomingSnapshot` reference only `shippingAddress` — they omit `shipping` and `pickupPoint`.** ❌ ← the bug. DB-verified: `orderSnapshot->'shipping'` and `->'pickupPoint'` are null on a re-ingested Allegro order.
+
+## 3. Steps
+
+### 3.1 `order-record.service.ts` — `persistOrder` snapshot
+Add two **present-only, NON-PII** spreads (these are a carrier method id/name and a public locker code — not PII; persist unconditionally like `deliverySmart`/`dispatchTime`, NOT gated on `storePii`). Place beside `deliverySmart`/`dispatchTime`:
+```ts
+// Source-side delivery method + pickup point (#952) — non-PII; present-only
+// like deliverySmart/dispatchTime. Needed by the Delivery panel, the
+// Generate-Label paczkomat pre-fill, and fulfillment routing (methodId is the
+// carrier-mapping key — without it routing always resolves omp_fulfilled).
+...(order.shipping !== undefined && { shipping: order.shipping }),
+...(order.pickupPoint !== undefined && { pickupPoint: order.pickupPoint }),
+```
+Nested optional fields (`methodName`, `name`, `description`) drop out via JSON serialization when undefined — matches the present-only wire shape.
+
+### 3.2 `order-record.service.ts` — `persistIncomingSnapshot` snapshot
+Same two spreads from `incoming.shipping` / `incoming.pickupPoint`.
+
+### 3.3 Tests — `order-record.service.spec.ts`
+- `persistOrder`: with `order.shipping = { methodId, methodName }` and `order.pickupPoint = { id, name }` set → snapshot carries both verbatim; unset (the `createMockOrder` default) → keys absent.
+- `persistIncomingSnapshot`: same from `incoming.shipping` / `incoming.pickupPoint` (present + absent).
+
+### 3.4 FE — none
+Verified: `apps/web/src/features/orders/api/order-snapshot.schema.ts` already defines `orderShippingSchema`/`orderPickupPointSchema`, parses `snapshot.shipping`/`snapshot.pickupPoint`, and exposes them on `ParsedOrderSnapshot`. `methodName` is `.nullish()`. No change beyond the existing wiring.
+
+## 4. Non-goals (per #952)
+- Backfilling existing snapshots — value lands on next re-ingest (snapshot rebuilt each `syncOrderFromSource`).
+- `methodName` human-name enrichment when the source only carries `methodId` (FE treats it as nullish).
+- Carrier-of-record display (resolved only at dispatch onto `Shipment`).
+- Seeding `fulfillment_routing_rules` (config, not code) and the FE pickup-point gating fix (#954) — separate.
+
+## 5. Validation
+- `pnpm lint` + `pnpm type-check` + `pnpm test` green.
+- `check:invariants` unaffected (additive snapshot keys, same context).
+- Confidence: a re-ingested Allegro order now carries `shipping.methodId` (+ `pickupPoint` for locker orders) — covered by the new unit tests; existing order-ingestion int-specs exercise the persist path.
+
+## 6. Risks
+- Minimal — additive optional snapshot keys, present-only, no consumer breaks when absent. Non-PII so no `storePii` interaction.

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -315,6 +315,21 @@ describe('OrderIngestionService', () => {
       expect(order.customerEmail).toBeUndefined();
     });
 
+    it('should carry incoming.shipping and pickupPoint onto the unified Order (#952)', async () => {
+      orderSource.getOrder.mockResolvedValueOnce({
+        ...baseIncoming,
+        shipping: { methodId: 'allegro-courier-1', methodName: 'Kurier DPD' },
+        pickupPoint: { id: 'POZ08A', name: 'Paczkomat POZ08A' },
+      });
+      orderSyncService.syncOrder.mockResolvedValue([]);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      const order = orderRecordService.persistOrder.mock.calls[0][0];
+      expect(order.shipping).toEqual({ methodId: 'allegro-courier-1', methodName: 'Kurier DPD' });
+      expect(order.pickupPoint).toEqual({ id: 'POZ08A', name: 'Paczkomat POZ08A' });
+    });
+
     it('should call updateSyncStatus with synced when syncOrder succeeds', async () => {
       orderSyncService.syncOrder.mockResolvedValue([
         {

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -284,6 +284,40 @@ describe('OrderRecordService', () => {
       const callArg = repository.upsert.mock.calls[0][0];
       expect(callArg.orderSnapshot).not.toHaveProperty('customerEmail');
     });
+
+    it('should serialise Order.shipping and pickupPoint into the snapshot when present (#952)', async () => {
+      const order = createMockOrder();
+      order.shipping = { methodId: 'allegro-courier-1', methodName: 'Kurier DPD' };
+      order.pickupPoint = { id: 'POZ08A', name: 'Paczkomat POZ08A' };
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot['shipping']).toEqual({
+        methodId: 'allegro-courier-1',
+        methodName: 'Kurier DPD',
+      });
+      expect(callArg.orderSnapshot['pickupPoint']).toEqual({
+        id: 'POZ08A',
+        name: 'Paczkomat POZ08A',
+      });
+    });
+
+    it('should omit shipping and pickupPoint from the snapshot when the Order does not carry them (#952)', async () => {
+      const order = createMockOrder();
+      expect(order.shipping).toBeUndefined();
+      expect(order.pickupPoint).toBeUndefined();
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot).not.toHaveProperty('shipping');
+      expect(callArg.orderSnapshot).not.toHaveProperty('pickupPoint');
+    });
   });
 
   describe('persistOrder - PII disabled', () => {
@@ -529,6 +563,42 @@ describe('OrderRecordService', () => {
 
       const callArg = repository.upsert.mock.calls[0][0];
       expect(callArg.orderSnapshot).not.toHaveProperty('customerEmail');
+    });
+
+    it('should serialise IncomingOrder.shipping and pickupPoint into the snapshot when present (#952)', async () => {
+      const incoming = {
+        ...createMockIncomingOrder(),
+        shipping: { methodId: 'allegro-courier-1', methodName: 'Kurier DPD' },
+        pickupPoint: { id: 'POZ08A', name: 'Paczkomat POZ08A' },
+      };
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot['shipping']).toEqual({
+        methodId: 'allegro-courier-1',
+        methodName: 'Kurier DPD',
+      });
+      expect(callArg.orderSnapshot['pickupPoint']).toEqual({
+        id: 'POZ08A',
+        name: 'Paczkomat POZ08A',
+      });
+    });
+
+    it('should omit shipping and pickupPoint from the snapshot when IncomingOrder does not carry them (#952)', async () => {
+      const incoming = createMockIncomingOrder();
+      expect(incoming.shipping).toBeUndefined();
+      expect(incoming.pickupPoint).toBeUndefined();
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot).not.toHaveProperty('shipping');
+      expect(callArg.orderSnapshot).not.toHaveProperty('pickupPoint');
     });
   });
 

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -96,6 +96,15 @@ export class OrderRecordService implements IOrderRecordService {
       // expose one. Conditional spread keeps the key off the snapshot rather
       // than emitting `undefined`.
       ...(order.placedAt !== undefined && { placedAt: order.placedAt.toISOString() }),
+      // Source-side delivery method + pickup point (#952) — present-only, like
+      // deliverySmart/dispatchTime. NOT PII-gated: a carrier method id/name and a
+      // public locker code aren't personal data (the locker's address is folded
+      // into the PII-gated shippingAddress). Needed by the order-detail Delivery
+      // panel, the Generate-Label paczkomat pre-fill, and — critically —
+      // fulfillment routing, which keys on `shipping.methodId` (absent it, routing
+      // always resolves to the omp_fulfilled default).
+      ...(order.shipping !== undefined && { shipping: order.shipping }),
+      ...(order.pickupPoint !== undefined && { pickupPoint: order.pickupPoint }),
       createdAt: order.createdAt.toISOString(),
       updatedAt: order.updatedAt.toISOString(),
     };
@@ -165,6 +174,10 @@ export class OrderRecordService implements IOrderRecordService {
       ...(incoming.dispatchTime !== undefined && { dispatchTime: incoming.dispatchTime }),
       // Buyer-placed-on-marketplace time (#926) — ISO string passed through verbatim.
       ...(incoming.placedAt !== undefined && { placedAt: incoming.placedAt }),
+      // Source-side delivery method + pickup point (#952) — see persistOrder for
+      // the present-only + non-PII rationale. Same fields, same placement.
+      ...(incoming.shipping !== undefined && { shipping: incoming.shipping }),
+      ...(incoming.pickupPoint !== undefined && { pickupPoint: incoming.pickupPoint }),
     };
 
     const orderRecord = new OrderRecord(


### PR DESCRIPTION
## What changed and why

The buyer's delivery method (`Order.shipping`) and pickup point (`Order.pickupPoint`) were captured by the Allegro adapter (`resolveShipping` / `resolvePickupPoint`) and mapped onto the unified `Order` by `buildUnifiedOrder` — but `OrderRecordService` dropped them at the persistence boundary, so `order_records.orderSnapshot` never carried them. DB-verified: `shipping` / `pickupPoint` null on every snapshot.

### Consequences fixed
- **Order-detail Delivery panel** can render the method / locker (the FE already parses `snapshot.shipping` / `snapshot.pickupPoint`).
- **Generate-Label paczkomat pre-fill** works (reads `snapshot.pickupPoint`).
- **Fulfillment routing** can finally match a rule — it keys on `shipping.methodId`, and absent it every order resolved to the `omp_fulfilled` default, making the Generate-Label flow inert for Allegro orders (see #952 discussion).

### The fix (CORE-only, no migration — JSONB)
Write `shipping` + `pickupPoint` into **both** `persistOrder` and `persistIncomingSnapshot` snapshots, present-only (conditional spread, same idiom as `deliverySmart` / `dispatchTime`), placed symmetrically in both builders.

**NOT PII-gated** (unlike #948's `customerEmail`): a carrier method id/name and a public locker code aren't personal data; the locker's address is folded into the already-PII-gated `shippingAddress`. Rationale documented inline.

The data is captured upstream and mapped already — this is purely a persistence-boundary fix, so no adapter or `buildUnifiedOrder` change is needed.

## How to test
- `pnpm test` — covers the full path:
  - `order-ingestion.service.spec.ts` — `buildUnifiedOrder` carries `shipping`/`pickupPoint` (present/absent).
  - `order-record.service.spec.ts` — both snapshots persist them (present/absent).
- Manually: re-ingest an Allegro order → `orderSnapshot.shipping.methodId` (+ `pickupPoint` for locker orders) now present → Delivery panel renders the method; routing can key a rule.

## Quality gate
- `pnpm lint` ✅ · `pnpm type-check` ✅ · `pnpm test` ✅ (core 1020) · pre-commit ✅
- No migration (JSONB snapshot); no FE change (`order-snapshot.schema.ts` already parses both; `methodName` is `.nullish()`).

## Out of scope (per #952)
- Backfilling existing snapshots — value lands on next re-ingest.
- `methodName` human-name enrichment when the source carries only `methodId`.
- Carrier-of-record display (resolved at dispatch onto `Shipment`).
- Seeding `fulfillment_routing_rules` (config) and the FE pickup-point gating fix (#954).

## Related
#769 (generate label) · #948 (customerEmail snapshot, same persist-boundary class of bug) · #953 / #954 (FE follow-ups downstream of this fix)

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)