### PR TITLE
fix(orders): generate-label toast + pickup-point hint (#953, #954)

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -91,6 +91,21 @@ docs/plans/implementation-plan-{feature-name}.md
 
 ---
 
+## Phase 3.5 — Pre-implement gate
+
+Before writing any code, run the read-only `/pre-implement` gate on the plan:
+
+```
+/pre-implement docs/plans/implementation-plan-{feature-name}.md #{issue}
+```
+
+It greps the **live repo** for reuse collisions (a port / service / DI token / ORM entity / helper the plan assumes is new but already exists) and contract-surface breaks (top-level barrels, port signatures, DTOs, Symbol tokens, ORM schema, `check:invariants` rules), and writes a `READY / NEEDS-REVISION / NEEDS-MAJOR-REVISION` verdict to `docs/plans/analysis/`.
+
+- **NEEDS-REVISION** → fix the plan and re-gate before proceeding. The cheapest place to fix a collision is the plan, not a branch.
+- For a trivial, self-contained change you may note the gate is unnecessary and skip it — but say so explicitly.
+
+---
+
 ## Phase 4 — Implement
 
 0. **Re-touch the claim** (keeps long-but-active sessions from being treated as stale): post a fresh `🤖 claimed for work by branch …` comment so the 2-hour window resets before the implementation phase, which can run long.
@@ -104,7 +119,12 @@ docs/plans/implementation-plan-{feature-name}.md
    pnpm type-check  # must pass with zero errors
    pnpm test        # all unit tests must pass
    ```
-   Fix all errors before continuing.
+   Fix all errors before continuing. The pre-commit hook auto-runs `pnpm
+   smart-test --no-integration` (only the affected packages' related specs,
+   via each package's own runner), so the per-commit loop is fast; still run
+   the full `pnpm test` (and `pnpm test:integration` for backend changes)
+   before opening the PR — the hook is the fast path, the full suite is the
+   safety net.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,7 @@ See `docs/testing-guide.md` for the full guide.
 | Command | What it does |
 |---|---|
 | `/plan <task>` | Generate a full 5-phase implementation plan, saved to `docs/plans/` |
+| `/pre-implement <plan\|issue>` | Read-only readiness gate between `/plan` and `/work` — greps the live repo for reuse collisions + contract-surface breaks; verdict to `docs/plans/analysis/` |
 | `/tech-review <file\|diff>` | Quick tech lead review with BLOCKING/IMPORTANT/SUGGESTION ratings |
 | `/pr-review <PR number\|diff>` | Full systematic PR review using `code-review-guide.md` workflow |
 | `/migrate <description>` | Guide through creating, validating, and verifying a TypeORM migration |

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -9,7 +9,11 @@
 import { cleanup, screen, fireEvent, waitFor } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 
-import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
+import {
+  renderWithProviders,
+  createMockApiClient,
+  findToastTitle,
+} from '../../../test/test-utils';
 import { GenerateLabelForm } from './generate-label-form';
 import type { OrderRecord } from '../api/orders.types';
 
@@ -223,6 +227,11 @@ describe('GenerateLabelForm — happy path', () => {
 // ── #839 AC-3 — pickup-point retry hint ─────────────────────────────────
 
 describe('GenerateLabelForm — AC-3 pickup-point retry hint (#839)', () => {
+  // A genuine unresolved-locker order: a locker delivery method, but the
+  // pickup point hasn't arrived yet (#954 — the hint's legitimate case). The
+  // locker method is what makes it "expecting a pickup point" rather than a
+  // courier order; before #954 this helper kept the base courier method, which
+  // is exactly the false-positive #954 fixes.
   function makeOrderWithoutPickupPoint(
     overrides: Partial<OrderRecord> = {},
   ): OrderRecord {
@@ -233,12 +242,13 @@ describe('GenerateLabelForm — AC-3 pickup-point retry hint (#839)', () => {
       ...overrides,
       orderSnapshot: {
         ...baseSnapshot,
+        shipping: { methodId: 'allegro-one-box', methodName: 'Allegro One Box' },
         pickupPoint: undefined,
       },
     };
   }
 
-  it('should render the retry hint when the order is Allegro-sourced + no pickup-point + recent', async () => {
+  it('should render the retry hint for a locker-method Allegro order with no pickup-point yet + recent', async () => {
     const order = makeOrderWithoutPickupPoint({
       sourceConnectionId: 'conn-allegro-1',
       createdAt: new Date().toISOString(),
@@ -350,5 +360,137 @@ describe('GenerateLabelForm — AC-3 pickup-point retry hint (#839)', () => {
     // submit button, so findByText is ambiguous here.
     await screen.findByLabelText(/Length in millimetres/i);
     expect(screen.queryByText(/Pickup point not yet available/i)).not.toBeInTheDocument();
+  });
+});
+
+// ── #954 — hint must key on delivery method, not pickupPoint presence ─────
+
+describe('GenerateLabelForm — #954 courier-vs-locker hint gating', () => {
+  function allegroConnApi() {
+    return createMockApiClient({
+      connections: {
+        list: vi.fn().mockResolvedValue([
+          {
+            id: 'conn-allegro-1',
+            platformType: 'allegro',
+            name: 'Allegro Main',
+            status: 'active',
+            config: {},
+            credentialsBacked: true,
+            enabledCapabilities: [],
+            supportedCapabilities: ['OrderSource'],
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ]),
+      },
+    });
+  }
+
+  function recentAllegroOrder(snapshotOverrides: Record<string, unknown>): OrderRecord {
+    const base = makeOrder();
+    return {
+      ...base,
+      sourceConnectionId: 'conn-allegro-1',
+      createdAt: new Date().toISOString(),
+      orderSnapshot: {
+        ...(base.orderSnapshot as Record<string, unknown>),
+        ...snapshotOverrides,
+      },
+    };
+  }
+
+  it('should NOT render the retry hint for a courier-method Allegro order (the #954 false positive)', async () => {
+    const order = recentAllegroOrder({
+      shipping: { methodId: 'allegro-courier', methodName: 'Kurier Allegro' },
+      pickupPoint: undefined,
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={order} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient: allegroConnApi() },
+    );
+
+    await screen.findByLabelText(/Length in millimetres/i);
+    expect(screen.queryByText(/Pickup point not yet available/i)).not.toBeInTheDocument();
+  });
+
+  it('should NOT render the retry hint when the method is unknown but a full street address is present', async () => {
+    // Pre-#952 reality: the snapshot carries no delivery method, but the order
+    // has a full street address → courier heuristic suppresses the hint.
+    const order = recentAllegroOrder({ shipping: undefined, pickupPoint: undefined });
+
+    renderWithProviders(
+      <GenerateLabelForm order={order} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient: allegroConnApi() },
+    );
+
+    await screen.findByLabelText(/Length in millimetres/i);
+    expect(screen.queryByText(/Pickup point not yet available/i)).not.toBeInTheDocument();
+  });
+
+  it('should NOT render the retry hint once the locker pickup point is resolved', async () => {
+    const order = recentAllegroOrder({
+      shipping: { methodId: 'allegro-one-box', methodName: 'Allegro One Box' },
+      // base snapshot's pickupPoint is present (resolved)
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={order} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient: allegroConnApi() },
+    );
+
+    await screen.findByLabelText(/Length in millimetres/i);
+    expect(screen.queryByText(/Pickup point not yet available/i)).not.toBeInTheDocument();
+  });
+});
+
+// ── #953 — post-submit toast must reflect the dispatch outcome ────────────
+
+describe('GenerateLabelForm — #953 dispatch-outcome toast', () => {
+  function fillParcelAndSubmit(): void {
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+  }
+
+  it('should show the "Label generated" success toast on a dispatched result', async () => {
+    const apiClient = createMockApiClient({
+      shipments: {
+        generateLabel: vi.fn().mockResolvedValue({
+          kind: 'dispatched',
+          shipment: { id: 'ol_shipment_1', labelPdfRef: null },
+        }),
+        downloadLabel: vi.fn().mockResolvedValue(new Blob()),
+      },
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+    fillParcelAndSubmit();
+
+    expect(await findToastTitle(/Label generated/i)).toBeInTheDocument();
+  });
+
+  it('should show a neutral toast (not "Label generated") on an omp_fulfilled result', async () => {
+    const apiClient = createMockApiClient({
+      shipments: {
+        generateLabel: vi.fn().mockResolvedValue({ kind: 'omp_fulfilled' }),
+        downloadLabel: vi.fn(),
+      },
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+    fillParcelAndSubmit();
+
+    expect(await findToastTitle(/Fulfilled by destination store/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Label generated/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -82,6 +82,28 @@ function isWithinPickupPointRetryWindow(createdAtIso: string): boolean {
   return Date.now() - createdAt < PICKUP_POINT_RETRY_WINDOW_MS;
 }
 
+/**
+ * Locker-method keyword tokens (#954). A delivery method whose name/id matches
+ * resolves to a pickup point (paczkomat / parcel locker), not a courier
+ * doorstep delivery. Heuristic until the snapshot carries the method
+ * authoritatively (#952 populates `shipping.methodId`/`methodName`); a
+ * platform-provided locker flag is the longer-term replacement.
+ */
+const LOCKER_METHOD_RE = /paczkomat|locker|automat|punkt|pickup|one\s*box|one\s*punkt/i;
+
+/**
+ * Classify the buyer's source delivery method as a locker (pickup-point) or
+ * courier shipment. Returns `'unknown'` when the snapshot doesn't carry the
+ * method yet (pre-#952) — callers fall back to other signals.
+ */
+function classifyDeliveryMethod(
+  shipping: ParsedOrderSnapshot['shipping'],
+): 'locker' | 'courier' | 'unknown' {
+  if (!shipping) return 'unknown';
+  const haystack = `${shipping.methodName ?? ''} ${shipping.methodId}`;
+  return LOCKER_METHOD_RE.test(haystack) ? 'locker' : 'courier';
+}
+
 export function GenerateLabelForm({
   order,
   onSuccess,
@@ -90,7 +112,24 @@ export function GenerateLabelForm({
   const snapshot = parseOrderSnapshot(order.orderSnapshot);
   const recipient = buildRecipientPreview(snapshot);
   const hasPickupPoint = snapshot.pickupPoint !== undefined;
-  const shippingMethod: 'paczkomat' | 'kurier' = hasPickupPoint ? 'paczkomat' : 'kurier';
+  // Locker-vs-courier is driven by the actual delivery method (#954), not by
+  // `pickupPoint` presence alone (which was circular). A resolved pickup point
+  // or a locker-classified method ⇒ paczkomat flow.
+  const methodClass = classifyDeliveryMethod(snapshot.shipping);
+  const shippingMethod: 'paczkomat' | 'kurier' =
+    hasPickupPoint || methodClass === 'locker' ? 'paczkomat' : 'kurier';
+  // Clear courier signal: the method is known-courier, or — until the snapshot
+  // carries the method (#952) — the order has a full street address but no
+  // pickup point. Suppresses the locker retry hint on courier orders that will
+  // never have a pickup point, while preserving it for likely-locker orders
+  // (no street address yet) per #839/#893.
+  const hasFullStreetAddress = Boolean(
+    snapshot.shippingAddress?.address1 &&
+      snapshot.shippingAddress?.city &&
+      snapshot.shippingAddress?.postalCode,
+  );
+  const isLikelyCourier =
+    methodClass === 'courier' || (methodClass === 'unknown' && hasFullStreetAddress);
   const missingFields = useMemo(
     () => detectMissingFields(snapshot, shippingMethod),
     [snapshot, shippingMethod],
@@ -118,6 +157,7 @@ export function GenerateLabelForm({
   const sourcePlatform = usePlatform(sourceConnection?.platformType);
   const showPickupRetryHint =
     !hasPickupPoint &&
+    !isLikelyCourier &&
     sourcePlatform?.pickupPointResolvesAsync === true &&
     isWithinPickupPointRetryWindow(order.createdAt);
   const [pickupRetryInFlight, setPickupRetryInFlight] = useState(false);
@@ -182,19 +222,29 @@ export function GenerateLabelForm({
     const input = buildGenerateLabelInput({ order, snapshot, values, shippingMethod });
     try {
       const result = await mutation.mutateAsync(input);
-      showToast({
-        tone: 'success',
-        title: 'Label generated',
-        description: 'Tracking number will appear within ~5 minutes.',
-      });
-      // Auto-download the freshly-issued label (AC: "download triggered
-      // immediately after successful generation"). Imperative + guarded on the
-      // returned result so it fires exactly once per issuance — NOT a reactive
-      // effect, which would re-fire on the post-success query invalidation.
-      // Only the OL-managed-dispatch branch issues a label; the omp_fulfilled
-      // branch carries no shipment.
-      if (result.kind === 'dispatched' && result.shipment?.labelPdfRef) {
-        void labelDownload.download(result.shipment.id);
+      if (result.kind === 'dispatched') {
+        showToast({
+          tone: 'success',
+          title: 'Label generated',
+          description: 'Tracking number will appear within ~5 minutes.',
+        });
+        // Auto-download the freshly-issued label (AC: "download triggered
+        // immediately after successful generation"). Imperative + guarded on the
+        // returned result so it fires exactly once per issuance — NOT a reactive
+        // effect, which would re-fire on the post-success query invalidation.
+        if (result.shipment?.labelPdfRef) {
+          void labelDownload.download(result.shipment.id);
+        }
+      } else {
+        // omp_fulfilled (#953): the destination store fulfils this order — no OL
+        // shipment or label is created (also the default path when no
+        // fulfillment-routing rule matches). Don't claim a label was generated.
+        showToast({
+          tone: 'info',
+          title: 'Fulfilled by destination store',
+          description:
+            'This order is fulfilled by the destination store — no OpenLinker label is issued.',
+        });
       }
       form.reset();
       onSuccess();

--- a/docs/plans/analysis/ANALYSIS-953-954-label-form-toast-and-pickup-hint.md
+++ b/docs/plans/analysis/ANALYSIS-953-954-label-form-toast-and-pickup-hint.md
@@ -1,0 +1,40 @@
+# Pre-implement readiness — #953 / #954 (generate-label toast + pickup hint)
+
+**Plan:** `docs/plans/implementation-plan-953-954-label-form-toast-and-pickup-hint.md`
+**Run:** retroactive (implementation already in progress; run to dogfood the gate)
+
+## Verdict: READY
+
+A self-contained FE bug-fix pair confined to one component + its test. No new backend artifacts, no contract-surface changes.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `classifyDeliveryMethod()` + `LOCKER_METHOD_RE` (locker-vs-courier helper) | **NEW — confirmed absent** | No existing locker/paczkomat classifier anywhere in `apps/web/src` (grep for `classifyDelivery\|isLocker\|isPaczkomat\|lockerMethod\|LOCKER_` returned only unrelated `BLOCKER_CHIPS`). Genuinely new; nothing to reuse. |
+| `isLikelyCourier` gate on `showPickupRetryHint` | edit of existing local logic | `generate-label-form.tsx` only |
+| `result.kind` toast branch (#953) | edit of existing local logic | `DispatchResult.kind` already exists (`shipments.types.ts:151`) — consumed, not added |
+| Ports / services / DI tokens / ORM entities / DTOs / capabilities | **none created** | plan is FE-only |
+
+## Backward-compatibility findings
+
+| Surface | Result |
+|---|---|
+| Feature public barrel (`features/orders/index.ts`) | **No risk** — exports only `ordersQueryKeys` + order types; `GenerateLabelForm` is an internal component (not re-exported). Editing it can't break cross-feature/plugin consumers. |
+| Snapshot schema (`order-snapshot.schema.ts`) | **Unchanged** — `orderShippingSchema` (`methodId`/`methodName`) already exists; the fix reads it, doesn't alter it. |
+| `DispatchResult` shape | **Unchanged** — `kind` already on the type; only the consumer branches. |
+| Port signatures / Symbol tokens / ORM schema / migrations | **N/A** — none touched. |
+| `check:invariants` (cross-context, repo-URL, service-interface…) | **No risk** — FE-only, no `@openlinker/core` deep imports, no repo URLs. |
+
+## Open questions / sibling-bug sweep (apply-elsewhere)
+
+The fix touches trait-driven logic (`pickupPointResolvesAsync`). Swept the two sibling consumers for the same courier false-positive:
+
+- `order-delivery-panel.tsx:93` — pickup caption renders only `{pickupPoint ? … }` (gated on pickup-point presence). **No false-positive.**
+- `order-shipment-panel.tsx:207` — paczkomat row renders only when `shipment.paczkomatId !== null`. **No false-positive.**
+
+Neither sibling shows the affected affordance for courier orders, so **no follow-up is warranted** — #954 is correctly scoped to `generate-label-form.tsx` alone.
+
+## Notes
+
+- #954's interim full-street-address heuristic is documented in-code and converges with the parallel #952 work (which populates `snapshot.shipping.methodId`) — the classifier already prefers the method when present, so no rework when #952 lands.

--- a/docs/plans/implementation-plan-953-954-label-form-toast-and-pickup-hint.md
+++ b/docs/plans/implementation-plan-953-954-label-form-toast-and-pickup-hint.md
@@ -1,0 +1,62 @@
+# Implementation Plan — Generate-Label toast + pickup-hint fixes (#953, #954)
+
+## TL;DR
+
+Two FE-only bug fixes in one file, `apps/web/src/features/orders/components/generate-label-form.tsx`:
+
+- **#953** — the "Label generated" success toast fires unconditionally, even on the `omp_fulfilled` dispatch branch (no shipment, no label) — which is the *default* path for Allegro orders today. Branch the post-submit feedback on `result.kind`.
+- **#954** — the "Pickup point not yet available" retry hint fires on courier orders that will never have a locker, because locker-vs-courier is inferred from `pickupPoint` presence (circular) rather than the delivery method. Gate the hint (and the `shippingMethod` inference) on the order's actual delivery method, with an interim heuristic where the method is absent.
+
+**Classification:** Frontend / Interface (one feature component + its test). No backend, no migration, no API change.
+
+## Scope decision — #954 without #952
+
+#954 is "best done with #952" (which persists `shipping.methodId` into the snapshot). The user selected #953 + #954 **without** #952. Resolution, matching #954's own interim guidance:
+
+- `orderShippingSchema` (`methodId`, `methodName`) **already exists** in `order-snapshot.schema.ts` and the parsed `snapshot.shipping` is already consumed in this file — it's simply `undefined` at runtime until #952 lands.
+- So the fix keys on `snapshot.shipping` **when present** (authoritative), and falls back to a **full-street-address heuristic** when absent: a clear street address + no pickup point ⇒ courier ⇒ suppress the hint. This fixes the reported case (Allegro courier order, street-address ship-to, no pickup point) while **preserving** the #839 hint for likely-locker orders (no street address yet) — so we don't regress the feature #839/#893 added.
+- When #952 lands, the method becomes authoritative and the heuristic is dead code that can be dropped. Noted as a follow-up.
+
+## Research notes
+
+- `DispatchResult.kind: 'dispatched' | 'omp_fulfilled'` — `apps/web/src/features/shipments/api/shipments.types.ts:151`. The mutation already returns it; the `dispatched` branch already guards the auto-download (line 196). Only the toast is unconditional.
+- `showToast` tone is `AlertTone`; `'info'` is valid (and the default) — `shared/ui/toast-provider.tsx`.
+- `snapshot.shipping` (`ParsedOrderShipping`: `methodId`, `methodName?`) and `snapshot.pickupPoint` are already parsed by `order-snapshot.schema.ts`. The test fixture in `generate-label-form.test.tsx` already supplies `shipping.methodId`.
+- Existing hint gate: `!hasPickupPoint && sourcePlatform?.pickupPointResolvesAsync === true && isWithinPickupPointRetryWindow(order.createdAt)` (lines 119-122).
+
+## Design & steps
+
+### Step 1 — #953: branch post-submit feedback on `result.kind`
+`generate-label-form.tsx` `onSubmit` (~L181-204):
+- `result.kind === 'dispatched'` → keep the current success toast ("Label generated / tracking in ~5 min") + the existing auto-download guard. Unchanged.
+- `result.kind === 'omp_fulfilled'` → show a neutral `tone: 'info'` toast: title e.g. "Fulfilled by destination store", description "This order is fulfilled by the destination store — no OpenLinker label is issued." No download.
+- `form.reset()` + `onSuccess()` still run in both branches (the inline form collapses either way).
+- **AC**: omp_fulfilled shows no "Label generated" toast; dispatched unchanged.
+
+### Step 2 — #954: locker-method classifier + hint/`shippingMethod` gating
+- Add a pure helper `classifyDeliveryMethod(shipping: ParsedOrderShipping | undefined): 'locker' | 'courier' | 'unknown'` — keyword match on `methodName`/`methodId` (`paczkomat | locker | automat | punkt | pickup | one box | one punkt`) ⇒ `locker`; any other present method ⇒ `courier`; absent ⇒ `unknown`. Heuristic, documented, with a TODO to replace with a platform-provided classification post-#952.
+- Compute `hasFullStreetAddress = Boolean(a?.address1 && a?.city && a?.postalCode)`.
+- `isLikelyCourier = methodClass === 'courier' || (methodClass === 'unknown' && hasFullStreetAddress)`.
+- `shippingMethod`: `hasPickupPoint || methodClass === 'locker'` ⇒ `'paczkomat'`, else `'kurier'` (was: `hasPickupPoint ? paczkomat : kurier`). Drives `detectMissingFields` (locker skips the address requirement) and the paczkomat input.
+- `showPickupRetryHint`: add `&& !isLikelyCourier` to the existing gate.
+- **AC**: courier ⇒ no hint; locker-unresolved-within-window ⇒ hint shown; locker-resolved ⇒ no hint; `shippingMethod` consults the method.
+
+### Step 3 — tests (`generate-label-form.test.tsx`)
+Add cases (mirroring the existing `renderWithProviders` + `createMockApiClient` patterns):
+- **#953**: mock the generate-label mutation to resolve `{ kind: 'omp_fulfilled' }` → assert no "Label generated" toast, an info message present, no label download; and `{ kind: 'dispatched', shipment: { id, labelPdfRef } }` → success toast + download invoked.
+- **#954**: courier order (`shipping.methodId` courier, async platform, young, no pickup) → hint NOT shown; locker order (locker method, no pickup, async, young) → hint shown; locker order with pickup resolved → no hint; unknown-method + full street address → no hint (interim heuristic).
+
+## Risks & validation
+
+- **Heuristic misclassification** (#954): a locker method whose name lacks a known token would be treated as courier and suppress a genuine hint. Bounded: method-present courier classification only triggers on a real method string; the keyword list covers the Allegro/InPost locker vocabulary; #952 makes it authoritative later. Documented as heuristic.
+- **`shippingMethod` change downstream**: now an order can be `paczkomat` via method without a `pickupPoint` id — the paczkomat input renders empty (operator types it), matching the existing InPost-direct flow; `detectMissingFields` correctly drops the address requirement. Covered by tests.
+- **No backend/Schema/contract change** ⇒ no `check:invariants`, migration, or barrel impact.
+- Gate: `pnpm lint` / `type-check` / `test` (web suite via `jest`/vitest) green; the new pre-commit `smart-test` will scope to `@openlinker/web`.
+
+## Final checklist
+
+- [ ] #953 toast branches on `result.kind`; `omp_fulfilled` issues no label claim
+- [ ] #954 hint suppressed for courier (method or street-address heuristic); preserved for unresolved locker
+- [ ] `shippingMethod` consults the delivery method, not only `pickupPoint`
+- [ ] Component tests cover both bugs' branches
+- [ ] `pnpm lint && type-check && test` green

--- a/scripts/smart-test.mjs
+++ b/scripts/smart-test.mjs
@@ -4,10 +4,11 @@
  *
  * Diff-driven test selector for the pnpm workspace. Maps the files changed
  * vs a base ref to the *workspace packages* they belong to, then runs only
- * those packages' tests — narrowing within each package via
- * `jest --findRelatedTests`. Backend-only changes skip the flaky
- * `@openlinker/web` suite; pure frontend changes skip the slow Testcontainers
- * integration tier.
+ * those packages' tests — narrowing within each package via its own runner
+ * (`vitest related` for apps/web, `jest --findRelatedTests` elsewhere; the
+ * runner is read from each package's `test` script). Backend-only changes skip
+ * the flaky `@openlinker/web` suite; pure frontend changes skip the slow
+ * Testcontainers integration tier.
  *
  * Granularity note (#949 review B1). pnpm's finest test unit is the workspace
  * PACKAGE, not the bounded context — `libs/core` is a single package
@@ -32,7 +33,11 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const DEFAULT_BASE_REF = 'origin/main';
 
 // Changes anywhere under these roots, or to a top-level config file, force a
@@ -173,6 +178,33 @@ function exec(cmd, args) {
   return res.status ?? 1;
 }
 
+/**
+ * Pure: pick the related-tests runner from a package's `test` script. A vitest
+ * package (apps/web) must run `vitest related`, not `jest --findRelatedTests` —
+ * jest can't transform the vitest/TSX setup and fails the whole package.
+ */
+function testRunnerForScript(testScript) {
+  return /\bvitest\b/.test(testScript ?? '') ? 'vitest' : 'jest';
+}
+
+/** Read a package's `test` script to decide its runner; default to jest. */
+function testRunnerFor(root) {
+  try {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, root, 'package.json'), 'utf8'));
+    return testRunnerForScript(pkg.scripts?.test);
+  } catch {
+    return 'jest';
+  }
+}
+
+/** Build the `pnpm --filter` related-tests command for a package + changed files. */
+function relatedTestsArgs(root, rel) {
+  const base = ['--filter', `./${root}`, 'exec'];
+  return testRunnerFor(root) === 'vitest'
+    ? [...base, 'vitest', 'related', '--run', '--passWithNoTests', ...rel]
+    : [...base, 'jest', '--findRelatedTests', ...rel, '--passWithNoTests'];
+}
+
 function main() {
   const dryRun = process.argv.includes('--dry-run');
   const noIntegration = process.argv.includes('--no-integration');
@@ -207,16 +239,9 @@ function main() {
     for (const root of plan.packages) {
       const rel = relWithin(root, files);
       if (rel.length === 0) continue;
-      // Narrow within the package to specs related to the changed files.
-      const code = exec('pnpm', [
-        '--filter',
-        `./${root}`,
-        'exec',
-        'jest',
-        '--findRelatedTests',
-        ...rel,
-        '--passWithNoTests',
-      ]);
+      // Narrow within the package to specs related to the changed files, using
+      // the package's own runner (vitest for apps/web, jest elsewhere).
+      const code = exec('pnpm', relatedTestsArgs(root, rel));
       if (code !== 0) failures += 1;
     }
   }
@@ -323,8 +348,19 @@ function selfCheck() {
     if (!ok) failures.push(`  ✗ ${c.name}`);
   }
 
+  // Runner detection: a vitest package must not be run with jest.
+  const runnerCases = [
+    { name: 'vitest run script → vitest', script: 'vitest run', expect: 'vitest' },
+    { name: 'jest script → jest', script: 'jest', expect: 'jest' },
+    { name: 'absent test script → jest', script: undefined, expect: 'jest' },
+  ];
+  for (const c of runnerCases) {
+    if (testRunnerForScript(c.script) !== c.expect) failures.push(`  ✗ ${c.name}`);
+  }
+  const total = cases.length + runnerCases.length;
+
   if (failures.length === 0) {
-    process.stdout.write(`✓ smart-test --self-check: ${cases.length} classifier case(s) passed.\n`);
+    process.stdout.write(`✓ smart-test --self-check: ${total} case(s) passed.\n`);
     return 0;
   }
   process.stderr.write('✗ smart-test --self-check failed:\n');


### PR DESCRIPTION
Closes #953
Closes #954

Two FE bug fixes in `apps/web/src/features/orders/components/generate-label-form.tsx`, plus two bundled DX items (see "Bundled" below — flagged so reviewers can chunk the diff).

## #953 — "Label generated" toast fired on `omp_fulfilled`
The success toast + auto-download fired unconditionally, even on the `omp_fulfilled` dispatch branch (no shipment, no label) — which is the **default** path for Allegro orders today, so operators were routinely told a label was generated when none was.

Fix: branch the post-submit feedback on `DispatchResult.kind`. `dispatched` keeps the success toast + auto-download (unchanged); `omp_fulfilled` shows a neutral `info` toast ("Fulfilled by destination store — no OpenLinker label is issued") and no download.

## #954 — pickup-retry hint fired on courier orders
The "Pickup point not yet available" hint inferred locker-vs-courier from `pickupPoint` *presence* (circular), so courier orders that will never have a locker showed a "still arriving, retry" hint.

Fix: gate the hint (and the `shippingMethod` inference) on the order's **actual delivery method** via a keyword classifier over `snapshot.shipping`. Because #952 (which populates `shipping.methodId`) is being handled in parallel, an interim **full-street-address heuristic** suppresses the hint on courier orders until then, while preserving it for likely-locker orders (#839/#893). The classifier prefers the method when present, so it converges with #952 with **no rework**. The existing "hint shows" test encoded the bug (a courier method) — repointed it to a genuine locker order; added courier / unknown-method / resolved-locker + `dispatched` / `omp_fulfilled` toast cases.

## Bundled (per maintainer request)

- **`fix(dx)` — smart-test runner-aware** (`f668b11a`): the #949 `smart-test.mjs` hardcoded `jest --findRelatedTests`, but `apps/web` uses **vitest**, so the pre-commit hook (live since #955) **failed on every web-only commit repo-wide**. Now picks the runner from each package's `test` script (`vitest related` for `apps/web`, jest elsewhere) + self-check coverage. Surfaced by dogfooding smart-test on this very change.
- **`chore(dx)` — `/pre-implement` wired into `/work`** (`806dccf3`): adds Phase 3.5 (the readiness gate) to the `/work` flow so it's an explicit step, notes the scoped pre-commit smart-test loop, and lists `/pre-implement` in the CLAUDE.md skills table.

## Process notes (dogfooding the #949 flow)

- `/pre-implement` was run on the plan — verdict **READY**; its sibling-sweep confirmed `order-delivery-panel` / `order-shipment-panel` gate on pickup/paczkomat presence, so no sibling false-positive and no scope expansion. Analysis at `docs/plans/analysis/ANALYSIS-953-954-…`.
- Claim-lock was posted on #953/#954 as comment-only because the `in-progress` label didn't exist at claim time (now created).

## Verification

- `pnpm lint` ✅ (0 errors) · `pnpm type-check` ✅ · `pnpm --filter @openlinker/web test` ✅ (166 files / 1365 tests) · targeted suite 15 tests ✅
- `pnpm smart-test --self-check` ✅ (14 cases) — and the real runner-aware path drives `vitest related` on `apps/web` (validated)
- Pre-commit hook (lint → type-check → smart-test) passed on all three commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)