### PR TITLE
feat(shipping): DPD Polska adapter (REST) + courier labels + COD

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -41,6 +41,7 @@
     "@openlinker/core": "workspace:*",
     "@openlinker/integrations-ai": "workspace:*",
     "@openlinker/integrations-allegro": "workspace:*",
+    "@openlinker/integrations-dpd-polska": "workspace:*",
     "@openlinker/integrations-inpost": "workspace:*",
     "@openlinker/integrations-prestashop": "workspace:*",
     "bcryptjs": "^3.0.3",

--- a/apps/api/src/plugins.ts
+++ b/apps/api/src/plugins.ts
@@ -31,10 +31,12 @@ import { PrestashopIntegrationModule } from '@openlinker/integrations-prestashop
 import { AllegroIntegrationModule } from '@openlinker/integrations-allegro';
 import { AiIntegrationModule } from '@openlinker/integrations-ai';
 import { InpostIntegrationModule } from '@openlinker/integrations-inpost';
+import { DpdIntegrationModule } from '@openlinker/integrations-dpd-polska';
 
 export const apiPlugins: PluginEntry[] = [
   PrestashopIntegrationModule,
   AllegroIntegrationModule,
   AiIntegrationModule.register(),
   InpostIntegrationModule,
+  DpdIntegrationModule,
 ];

--- a/apps/api/test/jest-integration.cjs
+++ b/apps/api/test/jest-integration.cjs
@@ -53,6 +53,14 @@ module.exports = {
       __dirname,
       '../../../libs/integrations/inpost/src/$1',
     ),
+    '^@openlinker/integrations-dpd-polska$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/dpd-polska/src/index.ts',
+    ),
+    '^@openlinker/integrations-dpd-polska/(.*)$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/dpd-polska/src/$1',
+    ),
     '^@openlinker/test-kit$': path.resolve(__dirname, '../../../libs/test-kit/src/index.ts'),
     '^@openlinker/test-kit/(.*)$': path.resolve(__dirname, '../../../libs/test-kit/src/$1'),
   },

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -22,6 +22,8 @@
       "@openlinker/integrations-ai/*": ["../../libs/integrations/ai/src/*"],
       "@openlinker/integrations-inpost": ["../../libs/integrations/inpost/src/index.ts"],
       "@openlinker/integrations-inpost/*": ["../../libs/integrations/inpost/src/*"],
+      "@openlinker/integrations-dpd-polska": ["../../libs/integrations/dpd-polska/src/index.ts"],
+      "@openlinker/integrations-dpd-polska/*": ["../../libs/integrations/dpd-polska/src/*"],
       "@openlinker/test-kit": ["../../libs/test-kit/src/index.ts"],
       "@openlinker/test-kit/*": ["../../libs/test-kit/src/*"]
     }

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -301,6 +301,43 @@ describe('ShipmentDispatchService', () => {
       expect(result).toEqual({ kind: 'dispatched', shipment: generated });
     });
 
+    it('should forward caller-supplied COD verbatim to generateLabel (#962)', async () => {
+      routing.resolve.mockResolvedValue(
+        resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier, processorConnectionId: INPOST }),
+      );
+      repository.findActiveByOrderId.mockResolvedValue(null);
+      repository.create.mockResolvedValue(makeShipment({ status: 'draft' }));
+      adapter.generateLabel.mockResolvedValue({
+        providerShipmentId: 'dpd-1',
+        trackingNumber: 'dpd-1',
+        labelPdfRef: 'dpd-1',
+      });
+      repository.update.mockResolvedValue(makeShipment({ status: 'generated' }));
+
+      const cod = { amount: '39.99', currency: 'PLN' };
+      await service.dispatch(makeInput({ cod }));
+
+      expect(adapter.generateLabel).toHaveBeenCalledWith(expect.objectContaining({ cod }));
+    });
+
+    it('should forward cod as undefined when the caller omits it', async () => {
+      routing.resolve.mockResolvedValue(
+        resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier, processorConnectionId: INPOST }),
+      );
+      repository.findActiveByOrderId.mockResolvedValue(null);
+      repository.create.mockResolvedValue(makeShipment({ status: 'draft' }));
+      adapter.generateLabel.mockResolvedValue({
+        providerShipmentId: 'shipx-1',
+        trackingNumber: null,
+        labelPdfRef: 'shipx:label:shipx-1',
+      });
+      repository.update.mockResolvedValue(makeShipment({ status: 'generated' }));
+
+      await service.dispatch(makeInput());
+
+      expect(adapter.generateLabel).toHaveBeenCalledWith(expect.objectContaining({ cod: undefined }));
+    });
+
     it('should dispatch source_brokered through the identical path (no rework for #833)', async () => {
       routing.resolve.mockResolvedValue(
         resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.SourceBrokered, processorConnectionId: SOURCE }),

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
@@ -193,6 +193,9 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
         deliveryMethodId: this.resolveProviderDeliveryMethodId(input),
         recipient: input.recipient,
         parcel: input.parcel,
+        // Caller-supplied COD (#962) — pass through verbatim; COD-incapable
+        // adapters ignore it, COD-capable ones translate it to their wire shape.
+        cod: input.cod,
       });
 
       return await this.shipments.update(shipment.id, {

--- a/libs/core/src/shipping/domain/types/generate-label.types.ts
+++ b/libs/core/src/shipping/domain/types/generate-label.types.ts
@@ -22,6 +22,7 @@
 import type { ShippingMethod } from './shipping-method.types';
 import type { ShipmentRecipient } from './shipment-recipient.types';
 import type { ShipmentParcel } from './shipment-parcel.types';
+import type { ShipmentCod } from './shipment-cod.types';
 
 export interface GenerateLabelCommand {
   /** Internal Shipment id (`ol_shipment_*`). */
@@ -50,6 +51,11 @@ export interface GenerateLabelCommand {
    * `dimensions` + `weightGrams` (courier). The adapter validates the right
    * combination per method. */
   parcel: ShipmentParcel;
+  /** Cash-on-delivery to collect on delivery. Carrier-neutral and
+   * **caller-supplied** (operator input / #966), not order-sourced — adapters
+   * that don't support COD ignore it; COD-capable adapters (DPD Polska #962)
+   * translate it to their provider's wire format. */
+  cod?: ShipmentCod;
 }
 
 export interface GenerateLabelResult {

--- a/libs/core/src/shipping/domain/types/shipment-cod.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment-cod.types.ts
@@ -1,0 +1,29 @@
+/**
+ * Shipment COD (Cash-on-Delivery) Types
+ *
+ * Carrier-neutral cash-on-delivery descriptor for a label-generation command.
+ * Lives in core/shipping so every shipping adapter that supports COD (DPD
+ * Polska #962, future couriers) maps from one canonical shape; the adapter
+ * translates to its provider's wire format (e.g. DPD's COD `TransportService`
+ * with `AMOUNT` / `CURRENCY` attributes).
+ *
+ * Like `ShipmentRecipient` / `ShipmentParcel`, this is its own one-shape-per-
+ * file type (engineering-standards §"Type Definitions in Separate Files"); it
+ * is referenced as the optional `GenerateLabelCommand.cod` field.
+ *
+ * **Caller-supplied, not order-sourced.** COD is part of the label payload the
+ * dispatch caller owns (operator input / #966), exactly like `recipient` /
+ * `parcel` — it is NOT derived from a persisted `Order` in the dispatch seam.
+ *
+ * `amount` is a decimal **string** (not a number) so the value crosses the
+ * adapter boundary without binary float rounding (`'39.99'`, not `39.99`).
+ *
+ * @module libs/core/src/shipping/domain/types
+ */
+
+export interface ShipmentCod {
+  /** COD amount to collect, as a decimal string (e.g. `'39.99'`). */
+  amount: string;
+  /** ISO 4217 currency code (e.g. `'PLN'`). Adapter validates carrier support. */
+  currency: string;
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -57,6 +57,7 @@ export type {
   ShipmentParcel,
   ShipmentDimensions,
 } from './domain/types/shipment-parcel.types';
+export type { ShipmentCod } from './domain/types/shipment-cod.types';
 
 export type { TrackingSnapshot, KnownCarrier } from './domain/types/tracking-snapshot.types';
 export { KnownCarrierValues } from './domain/types/tracking-snapshot.types';

--- a/libs/integrations/dpd-polska/jest.config.mjs
+++ b/libs/integrations/dpd-polska/jest.config.mjs
@@ -1,0 +1,35 @@
+export default {
+  testEnvironment: 'node',
+  rootDir: '.',
+
+  // IMPORTANT: avoid running fixtures/mocks as "tests"
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+
+  // ESM + TS support for Node16 module resolution
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
+  },
+
+  // Helps when TS/Node16 emits/assumes .js in import paths
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@openlinker/integrations-dpd-polska$': '<rootDir>/src/index.ts',
+    '^@openlinker/integrations-dpd-polska/(.*)$': '<rootDir>/src/$1',
+    '^@openlinker/core/(.*)$': '<rootDir>/../../core/src/$1',
+    '^@openlinker/shared/(.*)$': '<rootDir>/../../shared/src/$1',
+    '^@openlinker/plugin-sdk$': '<rootDir>/../../plugin-sdk/src/index.ts',
+  },
+
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '<rootDir>/coverage',
+  clearMocks: true,
+  testTimeout: 30000,
+};

--- a/libs/integrations/dpd-polska/package.json
+++ b/libs/integrations/dpd-polska/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@openlinker/integrations-dpd-polska",
+  "version": "0.1.0",
+  "description": "DPD Polska (DPDServices REST) shipping adapter for OpenLinker",
+  "license": "Apache-2.0",
+  "author": "OpenLinker",
+  "private": true,
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "require": "./dist/testing.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "jest --config ./jest.config.mjs",
+    "test:watch": "jest --watch --config ./jest.config.mjs",
+    "test:cov": "jest --coverage --config ./jest.config.mjs",
+    "lint": "eslint \"src/**/*.ts\" --fix",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@openlinker/core": "workspace:*",
+    "@openlinker/plugin-sdk": "workspace:*",
+    "@openlinker/shared": "workspace:*",
+    "class-transformer": "0.5.1",
+    "class-validator": "0.14.1"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^10.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "20.11.30",
+    "@typescript-eslint/eslint-plugin": "7.3.1",
+    "@typescript-eslint/parser": "7.3.1",
+    "eslint": "8.57.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.2",
+    "typescript": "5.4.3"
+  }
+}

--- a/libs/integrations/dpd-polska/src/application/dpd-adapter.factory.ts
+++ b/libs/integrations/dpd-polska/src/application/dpd-adapter.factory.ts
@@ -1,0 +1,103 @@
+/**
+ * DPD Polska Adapter Factory
+ *
+ * Builds a per-connection `DpdShippingAdapter`: reads + defensively validates
+ * the connection config, resolves the DPDServices Basic-auth pair via the host
+ * `CredentialsResolverPort`, selects the environment base URL, and wires the
+ * HTTP client. Invoked from the plugin's `createCapabilityAdapter`. Config
+ * *shape* is enforced earlier by the connection-config validator at
+ * create/update time; this factory's checks are a runtime safety net that
+ * raises `DpdConfigException` on a malformed/under-provisioned connection.
+ *
+ * @module libs/integrations/dpd-polska/src/application
+ */
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import { DpdConfigException } from '../domain/exceptions/dpd-config.exception';
+import type { DpdConnectionConfig, DpdEnvironment } from '../domain/types/dpd-config.types';
+import { DpdEnvironmentValues } from '../domain/types/dpd-config.types';
+import type { DpdCredentials } from '../domain/types/dpd-credentials.types';
+import { DpdShippingAdapter } from '../infrastructure/adapters/dpd-shipping.adapter';
+import { DpdHttpClient } from '../infrastructure/http/dpd-http-client';
+
+// OQ-3 (#962): test is credentials-gated, not host-gated — both environments
+// resolve to the same DPDServices host today. Split here if a sandbox host
+// surfaces; nothing else changes.
+const BASE_URLS: Readonly<Record<DpdEnvironment, string>> = {
+  sandbox: 'https://dpdservices.dpd.com.pl',
+  production: 'https://dpdservices.dpd.com.pl',
+};
+
+export async function createDpdShippingAdapter(
+  connection: Connection,
+  credentialsResolver: CredentialsResolverPort,
+): Promise<DpdShippingAdapter> {
+  const config = extractConfig(connection);
+  const credentials = await resolveCredentials(connection, credentialsResolver);
+  const client = new DpdHttpClient(BASE_URLS[config.environment], {
+    login: credentials.login,
+    password: credentials.password,
+    masterFid: config.masterFid,
+  });
+  return new DpdShippingAdapter(client, config);
+}
+
+function extractConfig(connection: Connection): DpdConnectionConfig {
+  const raw = (connection.config ?? {}) as Record<string, unknown>;
+
+  const environment = raw.environment;
+  if (typeof environment !== 'string' || !DpdEnvironmentValues.includes(environment as DpdEnvironment)) {
+    throw new DpdConfigException(
+      `Connection ${connection.id} has invalid or missing DPD environment`,
+      connection.id,
+    );
+  }
+
+  const payerFid = raw.payerFid;
+  if (typeof payerFid !== 'string' || !/^\d+$/.test(payerFid)) {
+    throw new DpdConfigException(
+      `Connection ${connection.id} has invalid or missing payerFid (numeric string required)`,
+      connection.id,
+    );
+  }
+
+  const masterFid = raw.masterFid;
+  if (masterFid !== undefined && (typeof masterFid !== 'string' || !/^\d+$/.test(masterFid))) {
+    throw new DpdConfigException(
+      `Connection ${connection.id} has an invalid masterFid (numeric string required when present)`,
+      connection.id,
+    );
+  }
+
+  const senderAddress = raw.senderAddress;
+  if (typeof senderAddress !== 'object' || senderAddress === null) {
+    throw new DpdConfigException(
+      `Connection ${connection.id} is missing senderAddress`,
+      connection.id,
+    );
+  }
+
+  return {
+    environment: environment as DpdEnvironment,
+    payerFid,
+    masterFid: masterFid,
+    senderAddress: senderAddress as DpdConnectionConfig['senderAddress'],
+  };
+}
+
+async function resolveCredentials(
+  connection: Connection,
+  credentialsResolver: CredentialsResolverPort,
+): Promise<DpdCredentials> {
+  if (!connection.credentialsRef) {
+    throw new DpdConfigException(`Connection ${connection.id} has no credentialsRef`, connection.id);
+  }
+  const credentials = await credentialsResolver.get<DpdCredentials>(connection.credentialsRef);
+  if (!credentials?.login || !credentials?.password) {
+    throw new DpdConfigException(
+      `Connection ${connection.id} credentials are missing login/password`,
+      connection.id,
+    );
+  }
+  return { login: credentials.login, password: credentials.password };
+}

--- a/libs/integrations/dpd-polska/src/application/dto/dpd-connection-config.dto.ts
+++ b/libs/integrations/dpd-polska/src/application/dto/dpd-connection-config.dto.ts
@@ -1,0 +1,87 @@
+/**
+ * DPD Polska Connection Config DTO
+ *
+ * Application-layer `class-validator` schema for the DPD `Connection.config`
+ * blob. Plugin-private — only `DpdConnectionConfigShapeValidatorAdapter`
+ * (registered with the host at boot) reaches into it; the API-layer
+ * `ConnectionService` invokes the validator via the registry and never touches
+ * this DTO directly. Sibling-context value (`DpdEnvironmentValues`) imported
+ * relatively to avoid a self-package `dist/` cycle (mirrors the InPost DTO).
+ *
+ * Field length caps mirror the DPD `SenderOrReceiver` OpenAPI constraints.
+ * `login` / `password` are the secret half and are validated at adapter
+ * construction (the factory), not here.
+ *
+ * @module libs/integrations/dpd-polska/src/application/dto
+ */
+import {
+  IsEmail,
+  IsIn,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { DpdEnvironmentValues } from '../../domain/types/dpd-config.types';
+
+export class DpdSenderContactDto {
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  company?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  name?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  address!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  city!: string;
+
+  @IsString()
+  @Matches(/^\d{2}-\d{3}$/, { message: 'postalCode must match the PL format NN-NNN' })
+  postalCode!: string;
+
+  @IsString()
+  @Matches(/^[A-Z]{2}$/, { message: 'countryCode must be an ISO 3166-1 alpha-2 code' })
+  countryCode!: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  phone?: string;
+
+  @IsEmail()
+  @IsOptional()
+  email?: string;
+}
+
+export class DpdConnectionConfigDto {
+  @IsIn(DpdEnvironmentValues as readonly string[])
+  environment!: (typeof DpdEnvironmentValues)[number];
+
+  @IsString()
+  @Matches(/^\d+$/, { message: 'payerFid must be a numeric string' })
+  payerFid!: string;
+
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d+$/, { message: 'masterFid must be a numeric string' })
+  masterFid?: string;
+
+  @ValidateNested()
+  @Type(() => DpdSenderContactDto)
+  @IsObject()
+  senderAddress!: DpdSenderContactDto;
+}

--- a/libs/integrations/dpd-polska/src/domain/exceptions/dpd-config.exception.ts
+++ b/libs/integrations/dpd-polska/src/domain/exceptions/dpd-config.exception.ts
@@ -1,0 +1,22 @@
+/**
+ * DPD Config Exception
+ *
+ * Thrown when a connection's config or credentials are invalid or missing
+ * required fields (no `login`/`password`, non-numeric `payerFid`, …). Distinct
+ * from the shared `ShippingProviderRejectionException` (#885), which covers
+ * per-shipment/command validation surfaced by DPD.
+ *
+ * @module libs/integrations/dpd-polska/src/domain/exceptions
+ */
+export class DpdConfigException extends Error {
+  constructor(
+    message: string,
+    public readonly connectionId?: string,
+  ) {
+    super(message);
+    this.name = 'DpdConfigException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DpdConfigException);
+    }
+  }
+}

--- a/libs/integrations/dpd-polska/src/domain/exceptions/dpd-network.exception.ts
+++ b/libs/integrations/dpd-polska/src/domain/exceptions/dpd-network.exception.ts
@@ -1,0 +1,21 @@
+/**
+ * DPD Network Exception
+ *
+ * Thrown for transient DPDServices failures — `5xx`, timeouts, connection
+ * errors, and rate-limit (`429`) exhaustion after the HTTP client's retry
+ * budget. Also thrown for an indeterminate **create** outcome: a network/
+ * timeout on `generatePackagesNumbers` is NOT auto-retried (no DPD-side
+ * idempotency key → a retry could double-create a waybill and double-charge
+ * COD), so it surfaces here for the caller to reconcile rather than re-POST.
+ *
+ * @module libs/integrations/dpd-polska/src/domain/exceptions
+ */
+export class DpdNetworkException extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, { cause });
+    this.name = 'DpdNetworkException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DpdNetworkException);
+    }
+  }
+}

--- a/libs/integrations/dpd-polska/src/domain/exceptions/dpd-unauthorized.exception.ts
+++ b/libs/integrations/dpd-polska/src/domain/exceptions/dpd-unauthorized.exception.ts
@@ -1,0 +1,20 @@
+/**
+ * DPD Unauthorized Exception
+ *
+ * Thrown when DPDServices rejects the request with `401` (bad Basic-auth
+ * pair / `MISSING_PERMISSION`) or `403`. Not retryable.
+ *
+ * @module libs/integrations/dpd-polska/src/domain/exceptions
+ */
+export class DpdUnauthorizedException extends Error {
+  constructor(
+    message: string,
+    public readonly connectionId?: string,
+  ) {
+    super(message);
+    this.name = 'DpdUnauthorizedException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DpdUnauthorizedException);
+    }
+  }
+}

--- a/libs/integrations/dpd-polska/src/domain/types/dpd-config.types.ts
+++ b/libs/integrations/dpd-polska/src/domain/types/dpd-config.types.ts
@@ -1,0 +1,47 @@
+/**
+ * DPD Polska Connection Config Types
+ *
+ * Non-secret per-connection configuration: the DPDServices environment, the
+ * payer FID (the customer's account sub-number sent in every request body —
+ * non-secret, analogous to InPost's `organizationId`), the optional
+ * `masterFid` (provisional, for the `X-DPD-FID` header pending OQ-2 in the
+ * #962 plan), and the sender block used as the DPD shipment `sender`.
+ *
+ * The sender `address` is a single line here to match DPD's flat
+ * `SenderOrReceiver.address` field; the recipient's split `ShipmentAddress`
+ * (`street` + `buildingNumber`) is concatenated in the mapper.
+ *
+ * Validated at the boundary by the connection-config shape validator
+ * (`class-validator` DTO). `login` / `password` are the secret half and live
+ * in credentials, not here.
+ *
+ * @module libs/integrations/dpd-polska/src/domain/types
+ */
+
+export const DpdEnvironmentValues = ['sandbox', 'production'] as const;
+export type DpdEnvironment = (typeof DpdEnvironmentValues)[number];
+
+/** Sender block — maps to a DPD `sender` SenderOrReceiver. */
+export interface DpdSenderContact {
+  company?: string;
+  name?: string;
+  /** Single-line street address (DPD `address`, ≤100). */
+  address: string;
+  city: string;
+  /** PL postal code `NN-NNN`. */
+  postalCode: string;
+  /** ISO 3166-1 alpha-2. */
+  countryCode: string;
+  phone?: string;
+  email?: string;
+}
+
+export interface DpdConnectionConfig {
+  environment: DpdEnvironment;
+  /** Payer FID sub-number (numkat/fid) — numeric string, sent as `payerFID`. */
+  payerFid: string;
+  /** Provisional master FID for the `X-DPD-FID` header (OQ-2). Numeric string. */
+  masterFid?: string;
+  /** Sender — populates the DPD `sender` on every shipment. */
+  senderAddress: DpdSenderContact;
+}

--- a/libs/integrations/dpd-polska/src/domain/types/dpd-credentials.types.ts
+++ b/libs/integrations/dpd-polska/src/domain/types/dpd-credentials.types.ts
@@ -1,0 +1,20 @@
+/**
+ * DPD Polska Credentials Types
+ *
+ * The secret half of a DPD connection — the HTTP Basic-auth pair for the
+ * DPDServices REST API (`Authorization: Basic base64(login:password)`).
+ * Resolved via the host `CredentialsResolverPort` from
+ * `connection.credentialsRef`; never logged or returned in responses.
+ *
+ * The payer/master FID account identifiers live in `DpdConnectionConfig`
+ * (non-secret, sent in the request body / `X-DPD-FID` header).
+ *
+ * @module libs/integrations/dpd-polska/src/domain/types
+ */
+
+export interface DpdCredentials {
+  /** DPDServices Basic-auth login. */
+  login: string;
+  /** DPDServices Basic-auth password. */
+  password: string;
+}

--- a/libs/integrations/dpd-polska/src/domain/types/dpd-rest.types.ts
+++ b/libs/integrations/dpd-polska/src/domain/types/dpd-rest.types.ts
@@ -1,0 +1,208 @@
+/**
+ * DPD Polska `DPDServices` REST Wire Types
+ *
+ * Request/response shapes for the two endpoints this adapter uses, transcribed
+ * from the live `DPDServices` OpenAPI (verified 2026-06-02):
+ *   - `POST /public/shipment/v1/generatePackagesNumbers` (create → waybills)
+ *   - `POST /public/shipment/v1/generateSpedLabels` (render → base64 PDF)
+ *
+ * Values WE emit (generation policy, service/attribute codes, label output
+ * options, session type) are modelled as closed `as const` unions. Response
+ * **status** fields are typed `string`, not unions: DPD's status enums are
+ * open-ended and the adapter's correctness rule is "treat anything that is not
+ * `'OK'` as a failure" — a `string` makes an unrecognised status fail safe
+ * rather than mistype-pass.
+ *
+ * @module libs/integrations/dpd-polska/src/domain/types
+ */
+
+// --- shared value vocabularies (we emit these) -------------------------------
+
+export const DpdGenerationPolicyValues = [
+  'STOP_ON_FIRST_ERROR',
+  'IGNORE_ERRORS',
+  'ALL_OR_NOTHING',
+] as const;
+export type DpdGenerationPolicy = (typeof DpdGenerationPolicyValues)[number];
+
+/** Status string that means success at every level of the body. */
+export const DPD_STATUS_OK = 'OK';
+
+/** ServiceCode values this adapter emits today (COD); the full enum is larger. */
+export const DPD_SERVICE_CODE_COD = 'COD';
+
+/** COD/declared-value attribute keys (generic `code`/`value` attribute bag). */
+export const DPD_COD_ATTRIBUTE = {
+  Amount: 'AMOUNT',
+  Currency: 'CURRENCY',
+} as const;
+
+/** COD currencies DPD accepts. COD is mutually exclusive with INTERNATIONAL/PALETTE. */
+export const DpdCodCurrencyValues = ['PLN', 'EUR', 'RON', 'CZK'] as const;
+export type DpdCodCurrency = (typeof DpdCodCurrencyValues)[number];
+
+// --- create: request ---------------------------------------------------------
+
+export interface DpdAttribute {
+  code: string;
+  value: string;
+}
+
+export interface DpdTransportService {
+  code: string;
+  attributes?: DpdAttribute[];
+}
+
+export interface DpdSenderOrReceiver {
+  company?: string;
+  name?: string;
+  address: string;
+  city: string;
+  /** ISO 3166-1 alpha-2. */
+  countryCode: string;
+  postalCode: string;
+  phone?: string;
+  email?: string;
+}
+
+export interface DpdParcel {
+  reference?: string;
+  /** Kilograms. */
+  weight: number;
+  /** Centimetres. */
+  sizeX?: number;
+  sizeY?: number;
+  sizeZ?: number;
+  content?: string;
+  customerData1?: string;
+  customerData2?: string;
+  customerData3?: string;
+}
+
+export interface DpdSinglePackage {
+  reference?: string;
+  sender: DpdSenderOrReceiver;
+  receiver?: DpdSenderOrReceiver;
+  /** Payer FID sub-number (numkat/fid). */
+  payerFID: number;
+  ref1?: string;
+  ref2?: string;
+  ref3?: string;
+  services?: DpdTransportService[];
+  parcels: DpdParcel[];
+}
+
+export interface DpdGeneratePackagesNumbersRequest {
+  generationPolicy: DpdGenerationPolicy;
+  packages: DpdSinglePackage[];
+}
+
+// --- create: response --------------------------------------------------------
+
+export interface DpdValidationInfo {
+  errorCode?: string;
+  info?: string;
+}
+
+export interface DpdParcelResult {
+  /** Non-`'OK'` ⇒ this parcel failed. */
+  status: string;
+  reference?: string;
+  waybill?: string;
+  validationInfo?: DpdValidationInfo[];
+}
+
+export interface DpdPackageResult {
+  /** Non-`'OK'` ⇒ this package failed. */
+  status: string;
+  reference?: string;
+  validationInfo?: DpdValidationInfo[];
+  parcels?: DpdParcelResult[];
+}
+
+export interface DpdGeneratePackagesNumbersResponse {
+  /** Top-level multi-package status; non-`'OK'` ⇒ the batch failed. */
+  status: string;
+  sessionId?: number;
+  packages?: DpdPackageResult[];
+  traceId?: string;
+}
+
+// --- label: request ----------------------------------------------------------
+
+export const DpdLabelSessionTypeValues = ['DOMESTIC', 'INTERNATIONAL'] as const;
+export type DpdLabelSessionType = (typeof DpdLabelSessionTypeValues)[number];
+
+export const DpdLabelPolicyValues = ['STOP_ON_FIRST_ERROR', 'IGNORE_ERRORS'] as const;
+export type DpdLabelPolicy = (typeof DpdLabelPolicyValues)[number];
+
+export const DpdOutputDocFormatValues = ['PDF', 'EPL', 'ZPL', 'XML'] as const;
+export type DpdOutputDocFormat = (typeof DpdOutputDocFormatValues)[number];
+
+export const DpdLabelFormatValues = ['A4', 'LBL_PRINTER'] as const;
+export type DpdLabelFormat = (typeof DpdLabelFormatValues)[number];
+
+export const DpdLabelOutputTypeValues = ['BIC3', 'EXTENDED', 'RETURN'] as const;
+export type DpdLabelOutputType = (typeof DpdLabelOutputTypeValues)[number];
+
+export interface DpdLabelSessionParcel {
+  reference?: string;
+  waybill: string;
+}
+
+export interface DpdLabelSessionPackage {
+  reference?: string;
+  parcels: DpdLabelSessionParcel[];
+}
+
+export interface DpdLabelSession {
+  type: DpdLabelSessionType;
+  sessionId?: number;
+  packages?: DpdLabelSessionPackage[];
+}
+
+export interface DpdLabelSearchParams {
+  policy: DpdLabelPolicy;
+  session: DpdLabelSession;
+  documentId?: string;
+}
+
+export interface DpdGenerateSpedLabelsRequest {
+  labelSearchParams: DpdLabelSearchParams;
+  outputDocFormat: DpdOutputDocFormat;
+  format: DpdLabelFormat;
+  outputType: DpdLabelOutputType;
+  variant?: string;
+}
+
+// --- label: response ---------------------------------------------------------
+
+export interface DpdGenerateSpedLabelsResponse {
+  /** Non-`'OK'` ⇒ label render failed. */
+  status: string;
+  /** Base64-encoded document bytes (PDF for `outputDocFormat: 'PDF'`). */
+  documentData?: string;
+  documentId?: string;
+  traceId?: string;
+}
+
+// --- error envelopes ---------------------------------------------------------
+
+export interface DpdErrorItem {
+  code?: string;
+  subCode?: string;
+  userMessage?: string;
+  rejectedValue?: string;
+  field?: string;
+}
+
+/** `400`-style body. */
+export interface DpdErrors {
+  errors?: DpdErrorItem[];
+  traceId?: string;
+}
+
+/** `401` body. */
+export interface DpdError401 {
+  status?: string;
+}

--- a/libs/integrations/dpd-polska/src/dpd-integration.module.ts
+++ b/libs/integrations/dpd-polska/src/dpd-integration.module.ts
@@ -1,0 +1,23 @@
+/**
+ * DPD Polska Integration Module
+ *
+ * Host wiring for the DPD Polska DPDServices REST plugin. DPD has no
+ * plugin-specific NestJS providers, so it uses the SDK's
+ * `createNestAdapterModule` directly: the helper imports the
+ * integrations/sync/identifier-mapping modules, builds the `HostServices` bag
+ * from DI, registers the manifest + factory, and calls `plugin.register(host)`
+ * for the config-shape validator.
+ *
+ * Added to `apps/api/src/plugins.ts` as the single edit point that enables the
+ * plugin in the host. Not registered worker-side in this PR (DPD tracking via
+ * DPD InfoServices is #965).
+ *
+ * @module libs/integrations/dpd-polska/src
+ */
+import type { DynamicModule } from '@nestjs/common';
+import { createNestAdapterModule } from '@openlinker/plugin-sdk';
+import { createDpdPlugin } from './dpd-plugin';
+
+export const DpdIntegrationModule: DynamicModule = createNestAdapterModule({
+  plugin: createDpdPlugin(),
+});

--- a/libs/integrations/dpd-polska/src/dpd-plugin.ts
+++ b/libs/integrations/dpd-polska/src/dpd-plugin.ts
@@ -1,0 +1,62 @@
+/**
+ * DPD Polska Plugin Descriptor (#593)
+ *
+ * Framework-neutral `AdapterPlugin` for the DPD Polska DPDServices REST
+ * integration. Holds the static manifest, the config-shape validator
+ * side-registration, and the per-connection `createCapabilityAdapter` factory
+ * (which resolves credentials + builds the shipping adapter, then dispatches by
+ * capability name).
+ *
+ * DPD needs no plugin-specific NestJS providers (no repository, no token
+ * refresh), so the host wires it via `createNestAdapterModule` — see
+ * `dpd-integration.module.ts`.
+ *
+ * @module libs/integrations/dpd-polska/src
+ */
+import { dispatchCapability, type AdapterPlugin, type HostServices } from '@openlinker/plugin-sdk';
+import type { AdapterMetadata } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { createDpdShippingAdapter } from './application/dpd-adapter.factory';
+import { DpdConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/dpd-connection-config-shape-validator.adapter';
+
+/**
+ * Static plugin manifest (#575). Exported as a top-level `const` so host-side
+ * tooling can read `adapterKey` / `supportedCapabilities` / `version` without
+ * instantiating the plugin. `createDpdPlugin().manifest` returns the same
+ * reference, so static and runtime views can't drift.
+ */
+export const dpdAdapterManifest: AdapterMetadata = {
+  adapterKey: 'dpd.polska.rest.v1',
+  platformType: 'dpd',
+  supportedCapabilities: ['ShippingProviderManager'],
+  displayName: 'DPD Polska REST v1',
+  version: '1.0.0',
+  isDefault: true,
+};
+
+/** Short brand label for the config-validator's error prefix. */
+const DPD_BRAND = 'DPD Polska';
+
+export function createDpdPlugin(): AdapterPlugin {
+  return {
+    manifest: dpdAdapterManifest,
+
+    register(host: HostServices): void {
+      host.connectionConfigShapeValidatorRegistry.register(
+        dpdAdapterManifest.adapterKey,
+        new DpdConnectionConfigShapeValidatorAdapter(DPD_BRAND),
+      );
+      // No credentials-shape validator: the `{ login, password }` shape is
+      // enforced at adapter construction time by the factory.
+    },
+
+    async createCapabilityAdapter<T>(
+      connection: Connection,
+      capability: string,
+      host: HostServices,
+    ): Promise<T> {
+      const adapter = await createDpdShippingAdapter(connection, host.credentialsResolver);
+      return dispatchCapability<T>(capability, { ShippingProviderManager: () => adapter }, DPD_BRAND);
+    },
+  };
+}

--- a/libs/integrations/dpd-polska/src/index.ts
+++ b/libs/integrations/dpd-polska/src/index.ts
@@ -1,0 +1,32 @@
+/**
+ * @openlinker/integrations-dpd-polska — Public Barrel
+ *
+ * DPD Polska DPDServices REST shipping adapter plugin. The runtime entry the
+ * host composes is `DpdIntegrationModule`; this barrel also exports the static
+ * `dpdAdapterManifest` and the domain exceptions for host-side error handling.
+ *
+ * @module libs/integrations/dpd-polska/src
+ */
+
+// Domain exceptions
+export { DpdConfigException } from './domain/exceptions/dpd-config.exception';
+export { DpdUnauthorizedException } from './domain/exceptions/dpd-unauthorized.exception';
+export { DpdNetworkException } from './domain/exceptions/dpd-network.exception';
+// Per-shipment / command validation rejections throw the shared
+// `ShippingProviderRejectionException` from `@openlinker/core/shipping`
+// (#885) — `providerName: 'dpd'`, `providerCode` carries the DPD `errorCode`
+// (or a `preflight.*` / `command.*` pseudo-code), structured details on
+// `providerDetails`.
+
+// Config + credentials types
+export { DpdEnvironmentValues } from './domain/types/dpd-config.types';
+export type {
+  DpdEnvironment,
+  DpdConnectionConfig,
+  DpdSenderContact,
+} from './domain/types/dpd-config.types';
+export type { DpdCredentials } from './domain/types/dpd-credentials.types';
+
+// Plugin descriptor + host wiring
+export { dpdAdapterManifest, createDpdPlugin } from './dpd-plugin';
+export { DpdIntegrationModule } from './dpd-integration.module';

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-connection-config-shape-validator.adapter.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * DPD Connection Config Shape Validator — unit tests
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/adapters
+ */
+import { InvalidConnectionConfigException } from '@openlinker/core/integrations';
+import { DpdConnectionConfigShapeValidatorAdapter } from '../dpd-connection-config-shape-validator.adapter';
+
+const validConfig: Record<string, unknown> = {
+  environment: 'sandbox',
+  payerFid: '1495',
+  senderAddress: {
+    name: 'Sklep ACME',
+    address: 'Magazynowa 1',
+    city: 'Warszawa',
+    postalCode: '00-001',
+    countryCode: 'PL',
+    phone: '+48111222333',
+    email: 'sklep@example.com',
+  },
+};
+
+describe('DpdConnectionConfigShapeValidatorAdapter', () => {
+  const validator = new DpdConnectionConfigShapeValidatorAdapter('DPD Polska');
+
+  it('should resolve for a well-formed config', async () => {
+    await expect(validator.validate(validConfig)).resolves.toBeUndefined();
+  });
+
+  it('should resolve when masterFid is present and numeric', async () => {
+    await expect(validator.validate({ ...validConfig, masterFid: '12345' })).resolves.toBeUndefined();
+  });
+
+  it('should throw when payerFid is non-numeric', async () => {
+    await expect(validator.validate({ ...validConfig, payerFid: 'abc' })).rejects.toBeInstanceOf(
+      InvalidConnectionConfigException,
+    );
+  });
+
+  it('should throw when payerFid is missing', async () => {
+    const config = { environment: validConfig.environment, senderAddress: validConfig.senderAddress };
+    await expect(validator.validate(config)).rejects.toBeInstanceOf(InvalidConnectionConfigException);
+  });
+
+  it('should throw for an invalid environment', async () => {
+    await expect(validator.validate({ ...validConfig, environment: 'staging' })).rejects.toBeInstanceOf(
+      InvalidConnectionConfigException,
+    );
+  });
+
+  it('should throw for a malformed sender postal code', async () => {
+    const config = {
+      ...validConfig,
+      senderAddress: {
+        ...(validConfig.senderAddress as Record<string, unknown>),
+        postalCode: '0001',
+      },
+    };
+    await expect(validator.validate(config)).rejects.toBeInstanceOf(InvalidConnectionConfigException);
+  });
+
+  it('should throw when masterFid is present but non-numeric', async () => {
+    await expect(validator.validate({ ...validConfig, masterFid: 'xx' })).rejects.toBeInstanceOf(
+      InvalidConnectionConfigException,
+    );
+  });
+});

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-shipping.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-shipping.adapter.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * DPD Shipping Adapter — unit tests
+ *
+ * Mocks `IDpdHttpClient` to verify the create/label orchestration: the
+ * non-idempotent create path, COD wiring, the three-level body-status guard
+ * (business failures arrive as HTTP 200), label decode, supported methods, and
+ * the dormant `getTracking` throw.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/adapters
+ */
+import { ShippingProviderRejectionException, type GenerateLabelCommand } from '@openlinker/core/shipping';
+import type { DpdConnectionConfig } from '../../../domain/types/dpd-config.types';
+import type { IDpdHttpClient } from '../../http/dpd-http-client.interface';
+import { DpdShippingAdapter } from '../dpd-shipping.adapter';
+
+function makeConfig(): DpdConnectionConfig {
+  return {
+    environment: 'sandbox',
+    payerFid: '1495',
+    senderAddress: {
+      name: 'Sklep ACME',
+      address: 'Magazynowa 1',
+      city: 'Warszawa',
+      postalCode: '00-001',
+      countryCode: 'PL',
+    },
+  };
+}
+
+function makeCmd(overrides: Partial<GenerateLabelCommand> = {}): GenerateLabelCommand {
+  return {
+    shipmentId: 'ol_shipment_1',
+    orderId: 'ol_order_1',
+    connectionId: 'conn-dpd',
+    shippingMethod: 'kurier',
+    recipient: {
+      firstName: 'Jan',
+      lastName: 'Kowalski',
+      email: 'buyer@example.com',
+      phone: '+48500600700',
+      address: { street: 'Krakowska', buildingNumber: '12', city: 'Poznań', postCode: '60-001', countryCode: 'PL' },
+    },
+    parcel: { dimensions: { length: 200, width: 150, height: 100 }, weightGrams: 1500 },
+    ...overrides,
+  };
+}
+
+describe('DpdShippingAdapter', () => {
+  let http: jest.Mocked<IDpdHttpClient>;
+  let adapter: DpdShippingAdapter;
+
+  beforeEach(() => {
+    http = { request: jest.fn() };
+    adapter = new DpdShippingAdapter(http, makeConfig());
+  });
+
+  it('should declare kurier as the only supported method', () => {
+    expect(adapter.getSupportedMethods()).toEqual(['kurier']);
+  });
+
+  it('should create a shipment and return the waybill as provider id + tracking + label ref', async () => {
+    http.request.mockResolvedValueOnce({
+      status: 'OK',
+      packages: [{ status: 'OK', parcels: [{ status: 'OK', waybill: 'WB123' }] }],
+    });
+
+    const result = await adapter.generateLabel(makeCmd());
+
+    expect(result).toEqual({ providerShipmentId: 'WB123', trackingNumber: 'WB123', labelPdfRef: 'WB123' });
+    expect(http.request).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'POST', path: '/public/shipment/v1/generatePackagesNumbers' }),
+    );
+    // The create must NOT opt into network-retry (double-COD guard).
+    expect(http.request).toHaveBeenCalledWith(
+      expect.not.objectContaining({ retryOnNetworkError: true }),
+    );
+  });
+
+  it('should thread COD into the create request body', async () => {
+    http.request.mockResolvedValueOnce({
+      status: 'OK',
+      packages: [{ status: 'OK', parcels: [{ status: 'OK', waybill: 'WB1' }] }],
+    });
+
+    await adapter.generateLabel(makeCmd({ cod: { amount: '39.99', currency: 'PLN' } }));
+
+    const body = http.request.mock.calls[0][0].body as { packages: Array<{ services?: unknown }> };
+    expect(body.packages[0].services).toEqual([
+      { code: 'COD', attributes: [{ code: 'AMOUNT', value: '39.99' }, { code: 'CURRENCY', value: 'PLN' }] },
+    ]);
+  });
+
+  it('should reject when a business failure arrives as HTTP 200 with a non-OK parcel status', async () => {
+    http.request.mockResolvedValueOnce({
+      status: 'OK',
+      packages: [
+        {
+          status: 'OK',
+          parcels: [{ status: 'COD_IS_NOT_AVAILABLE_FOR_POSTAL_CODE', validationInfo: [{ errorCode: 'COD_IS_NOT_AVAILABLE_FOR_POSTAL_CODE' }] }],
+        },
+      ],
+    });
+
+    await expect(adapter.generateLabel(makeCmd())).rejects.toBeInstanceOf(ShippingProviderRejectionException);
+  });
+
+  it('should propagate an HTTP-level rejection from the client', async () => {
+    http.request.mockRejectedValueOnce(
+      new ShippingProviderRejectionException('dpd', 'INCORRECT_PAYER_FID', 'bad fid'),
+    );
+
+    await expect(adapter.generateLabel(makeCmd())).rejects.toMatchObject({ providerCode: 'INCORRECT_PAYER_FID' });
+  });
+
+  it('should render a label PDF for an existing waybill (idempotent, retry-enabled)', async () => {
+    const pdf = Buffer.from('%PDF-1.4', 'utf8').toString('base64');
+    http.request.mockResolvedValueOnce({ status: 'OK', documentData: pdf });
+
+    const doc = await adapter.fetchLabel({ providerShipmentId: 'WB123' });
+
+    expect(doc.contentType).toBe('application/pdf');
+    expect(Buffer.from(doc.body).toString('utf8')).toBe('%PDF-1.4');
+    expect(http.request).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'POST', path: '/public/shipment/v1/generateSpedLabels', retryOnNetworkError: true }),
+    );
+  });
+
+  it('should throw a typed tracking.unavailable rejection from getTracking', async () => {
+    await expect(adapter.getTracking({ providerShipmentId: 'WB1' })).rejects.toMatchObject({
+      providerName: 'dpd',
+      providerCode: 'tracking.unavailable',
+    });
+  });
+});

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-shipping.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-shipping.adapter.spec.ts
@@ -70,10 +70,8 @@ describe('DpdShippingAdapter', () => {
     expect(http.request).toHaveBeenCalledWith(
       expect.objectContaining({ method: 'POST', path: '/public/shipment/v1/generatePackagesNumbers' }),
     );
-    // The create must NOT opt into network-retry (double-COD guard).
-    expect(http.request).toHaveBeenCalledWith(
-      expect.not.objectContaining({ retryOnNetworkError: true }),
-    );
+    // The create must NOT opt into idempotent retry (double-COD guard).
+    expect(http.request).toHaveBeenCalledWith(expect.not.objectContaining({ idempotent: true }));
   });
 
   it('should thread COD into the create request body', async () => {
@@ -121,7 +119,7 @@ describe('DpdShippingAdapter', () => {
     expect(doc.contentType).toBe('application/pdf');
     expect(Buffer.from(doc.body).toString('utf8')).toBe('%PDF-1.4');
     expect(http.request).toHaveBeenCalledWith(
-      expect.objectContaining({ method: 'POST', path: '/public/shipment/v1/generateSpedLabels', retryOnNetworkError: true }),
+      expect.objectContaining({ method: 'POST', path: '/public/shipment/v1/generateSpedLabels', idempotent: true }),
     );
   });
 

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-connection-config-shape-validator.adapter.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-connection-config-shape-validator.adapter.ts
@@ -1,0 +1,38 @@
+/**
+ * DPD Connection Config Shape Validator Adapter
+ *
+ * Implements `ConnectionConfigShapeValidatorPort` for the DPD adapter. Runs
+ * `class-validator` against `DpdConnectionConfigDto` and throws
+ * `InvalidConnectionConfigException` carrying the flattened error list on
+ * failure. The host's `ConnectionService` maps that to `BadRequestException`
+ * at the API boundary — the plugin never depends on `@nestjs/common`.
+ *
+ * Registered with `host.connectionConfigShapeValidatorRegistry` at boot via
+ * `createDpdPlugin().register(host)`.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/adapters
+ * @implements {ConnectionConfigShapeValidatorPort}
+ */
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import type { ConnectionConfigShapeValidatorPort } from '@openlinker/core/integrations';
+import {
+  InvalidConnectionConfigException,
+  flattenValidationErrors,
+} from '@openlinker/core/integrations';
+import { DpdConnectionConfigDto } from '../../application/dto/dpd-connection-config.dto';
+
+export class DpdConnectionConfigShapeValidatorAdapter implements ConnectionConfigShapeValidatorPort {
+  constructor(private readonly pluginName: string = 'DPD Polska') {}
+
+  async validate(config: Record<string, unknown>): Promise<void> {
+    const instance = plainToInstance(DpdConnectionConfigDto, config);
+    // `whitelist: false` — the persisted config may carry adjacent keys outside
+    // this DTO; validate shape on what the DTO describes, not exhaustive
+    // ownership of the blob.
+    const errors = await validate(instance, { whitelist: false, forbidNonWhitelisted: false });
+    if (errors.length > 0) {
+      throw new InvalidConnectionConfigException(this.pluginName, flattenValidationErrors(errors));
+    }
+  }
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts
@@ -1,0 +1,99 @@
+/**
+ * DPD Polska Shipping Adapter
+ *
+ * Implements the core `ShippingProviderManagerPort` plus the
+ * `LabelDocumentReader` sub-capability against the DPDServices REST API. Thin
+ * orchestration only: it delegates wire translation to `dpd-shipment.mapper`
+ * and HTTP/retry/error-mapping to `IDpdHttpClient`.
+ *
+ * Two-call flow: `generatePackagesNumbers` (create → waybill) then
+ * `generateSpedLabels` (render → PDF) on demand. Business validation failures
+ * arrive as HTTP 200 with a non-OK body status, so `generateLabel` asserts all
+ * three status levels before trusting the waybill.
+ *
+ * Class name is deliberately shortened from the `{Platform}{Capability}Adapter`
+ * rule's `DpdShippingProviderManagerAdapter` (matches the InPost #764 shipping
+ * vocabulary).
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/adapters
+ */
+import {
+  ShippingProviderRejectionException,
+  type GenerateLabelCommand,
+  type GenerateLabelResult,
+  type LabelDocument,
+  type LabelDocumentReader,
+  type ShippingMethod,
+  type ShippingProviderManagerPort,
+  type TrackingSnapshot,
+} from '@openlinker/core/shipping';
+import type { DpdConnectionConfig } from '../../domain/types/dpd-config.types';
+import type {
+  DpdGeneratePackagesNumbersResponse,
+  DpdGenerateSpedLabelsResponse,
+} from '../../domain/types/dpd-rest.types';
+import type { IDpdHttpClient } from '../http/dpd-http-client.interface';
+import {
+  assertCreateSucceededAndExtractWaybill,
+  buildCreatePackagesRequest,
+  buildGenerateLabelRequest,
+  decodeLabelDocument,
+  toGenerateLabelResult,
+} from '../mappers/dpd-shipment.mapper';
+
+const SUPPORTED_METHODS: readonly ShippingMethod[] = ['kurier'];
+
+const CREATE_PATH = '/public/shipment/v1/generatePackagesNumbers';
+const LABEL_PATH = '/public/shipment/v1/generateSpedLabels';
+
+export class DpdShippingAdapter implements ShippingProviderManagerPort, LabelDocumentReader {
+  constructor(
+    private readonly http: IDpdHttpClient,
+    private readonly config: DpdConnectionConfig,
+  ) {}
+
+  getSupportedMethods(): readonly ShippingMethod[] {
+    return SUPPORTED_METHODS;
+  }
+
+  async generateLabel(cmd: GenerateLabelCommand): Promise<GenerateLabelResult> {
+    const body = buildCreatePackagesRequest(cmd, this.config);
+    // Non-idempotent create: the client does NOT retry on network/timeout
+    // (no DPD idempotency key → double waybill + double COD).
+    const response = await this.http.request<DpdGeneratePackagesNumbersResponse>({
+      method: 'POST',
+      path: CREATE_PATH,
+      body,
+    });
+    const waybill = assertCreateSucceededAndExtractWaybill(response);
+    return toGenerateLabelResult(waybill);
+  }
+
+  async fetchLabel(input: { providerShipmentId: string }): Promise<LabelDocument> {
+    const body = buildGenerateLabelRequest(input.providerShipmentId);
+    // Idempotent render (returns the PDF for an existing waybill) — safe to
+    // retry on network/timeout.
+    const response = await this.http.request<DpdGenerateSpedLabelsResponse>({
+      method: 'POST',
+      path: LABEL_PATH,
+      body,
+      retryOnNetworkError: true,
+    });
+    return decodeLabelDocument(response);
+  }
+
+  getTracking(_input: { providerShipmentId: string }): Promise<TrackingSnapshot> {
+    // DPD tracking is a separate service (DPD InfoServices, #965). Until then
+    // we throw rather than fabricate a status — the adapter receives only the
+    // waybill, so any returned status would be a lie. The #838 status-sync
+    // poller catches this and logs a warn (no crash); DPD should stay out of
+    // that scan until #965 wires real tracking.
+    return Promise.reject(
+      new ShippingProviderRejectionException(
+        'dpd',
+        'tracking.unavailable',
+        'DPD tracking is not available until DPD InfoServices is wired (#965)',
+      ),
+    );
+  }
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts
@@ -77,7 +77,7 @@ export class DpdShippingAdapter implements ShippingProviderManagerPort, LabelDoc
       method: 'POST',
       path: LABEL_PATH,
       body,
-      retryOnNetworkError: true,
+      idempotent: true,
     });
     return decodeLabelDocument(response);
   }

--- a/libs/integrations/dpd-polska/src/infrastructure/http/__tests__/dpd-http-client.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/__tests__/dpd-http-client.spec.ts
@@ -155,11 +155,40 @@ describe('DpdHttpClient', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
   });
 
+  it('should NOT retry an ambiguous 5xx (500) on the non-idempotent create (guards double-COD)', async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ ok: false, status: 500, body: '{}' }));
+
+    await expect(client.request({ method: 'POST', path: CREATE_PATH })).rejects.toBeInstanceOf(
+      DpdNetworkException,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry a 503 even on the non-idempotent create (DPD did not commit)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(fakeResponse({ ok: false, status: 503, body: '{}' }))
+      .mockResolvedValueOnce(fakeResponse({ ok: true, status: 200, body: '{"status":"OK"}' }));
+
+    await expect(client.request({ method: 'POST', path: CREATE_PATH })).resolves.toEqual({
+      status: 'OK',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should retry an ambiguous 5xx (500) on an idempotent read', async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ ok: false, status: 500, body: '{}' }));
+
+    await expect(
+      client.request({ method: 'POST', path: '/public/shipment/v1/generateSpedLabels', idempotent: true }),
+    ).rejects.toBeInstanceOf(DpdNetworkException);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
   it('should NOT retry a network/timeout on the create call (guards double-COD)', async () => {
     fetchMock.mockRejectedValue(new Error('ETIMEDOUT'));
 
     await expect(
-      // retryOnNetworkError omitted ⇒ false for the non-idempotent create.
+      // idempotent omitted ⇒ false for the non-idempotent create.
       client.request({ method: 'POST', path: CREATE_PATH }),
     ).rejects.toBeInstanceOf(DpdNetworkException);
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -169,7 +198,7 @@ describe('DpdHttpClient', () => {
     fetchMock.mockRejectedValue(new Error('ECONNRESET'));
 
     await expect(
-      client.request({ method: 'GET', path: '/public/shipment/v1/generateSpedLabels', retryOnNetworkError: true }),
+      client.request({ method: 'GET', path: '/public/shipment/v1/generateSpedLabels', idempotent: true }),
     ).rejects.toBeInstanceOf(DpdNetworkException);
     expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
   });

--- a/libs/integrations/dpd-polska/src/infrastructure/http/__tests__/dpd-http-client.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/__tests__/dpd-http-client.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * DPD DPDServices HTTP Client — unit tests
+ *
+ * Stubs `global.fetch` to verify Basic-auth (+ optional `X-DPD-FID`), the
+ * status → domain-exception classification, and the retry ASYMMETRY that
+ * guards double-COD: HTTP 429/5xx always retry; a network/timeout retries only
+ * when the caller opts in, so the non-idempotent create fails fast.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/http
+ */
+import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
+import { DpdUnauthorizedException } from '../../../domain/exceptions/dpd-unauthorized.exception';
+import { DpdNetworkException } from '../../../domain/exceptions/dpd-network.exception';
+import { DpdHttpClient } from '../dpd-http-client';
+
+interface FakeResponseInit {
+  ok: boolean;
+  status: number;
+  body?: string;
+  retryAfter?: string;
+}
+
+function fakeResponse(init: FakeResponseInit): Response {
+  return {
+    ok: init.ok,
+    status: init.status,
+    headers: {
+      get: (name: string): string | null =>
+        name.toLowerCase() === 'retry-after' ? init.retryAfter ?? null : null,
+    },
+    text: (): Promise<string> => Promise.resolve(init.body ?? ''),
+  } as unknown as Response;
+}
+
+const originalFetch = global.fetch;
+const BASE_URL = 'https://dpdservices.dpd.com.pl';
+const CREATE_PATH = '/public/shipment/v1/generatePackagesNumbers';
+
+describe('DpdHttpClient', () => {
+  let fetchMock: jest.Mock;
+  let client: DpdHttpClient;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    client = new DpdHttpClient(
+      BASE_URL,
+      { login: 'user', password: 'pass' },
+      { maxRetries: 2, initialDelayMs: 1, backoffMultiplier: 1, maxDelayMs: 1 },
+    );
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('should parse a 2xx JSON body and attach the Basic auth header', async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({ ok: true, status: 200, body: '{"status":"OK"}' }));
+
+    const result = await client.request<{ status: string }>({ method: 'POST', path: CREATE_PATH });
+
+    expect(result).toEqual({ status: 'OK' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}${CREATE_PATH}`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          // base64('user:pass') === 'dXNlcjpwYXNz'
+          Authorization: 'Basic dXNlcjpwYXNz',
+        }),
+      }),
+    );
+  });
+
+  it('should attach the X-DPD-FID header when masterFid is configured', async () => {
+    const fidClient = new DpdHttpClient(BASE_URL, {
+      login: 'user',
+      password: 'pass',
+      masterFid: '1495',
+    });
+    fetchMock.mockResolvedValueOnce(fakeResponse({ ok: true, status: 200, body: '{"status":"OK"}' }));
+
+    await fidClient.request({ method: 'POST', path: CREATE_PATH });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-DPD-FID': '1495' }),
+      }),
+    );
+  });
+
+  it('should map 401 to DpdUnauthorizedException without retrying', async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({ ok: false, status: 401, body: '{"status":"MISSING_PERMISSION"}' }),
+    );
+
+    await expect(client.request({ method: 'POST', path: CREATE_PATH })).rejects.toBeInstanceOf(
+      DpdUnauthorizedException,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should map a 400 DpdErrors body to ShippingProviderRejectionException (no retry)', async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: false,
+        status: 400,
+        body: '{"errors":[{"code":"INCORRECT_PAYER_FID","subCode":"X","userMessage":"bad fid","field":"payerFID"}],"traceId":"t1"}',
+      }),
+    );
+
+    const error = await client
+      .request({ method: 'POST', path: CREATE_PATH })
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ShippingProviderRejectionException);
+    expect(error).toMatchObject({
+      providerName: 'dpd',
+      providerCode: 'INCORRECT_PAYER_FID',
+      message: 'bad fid',
+      providerDetails: { field: 'payerFID', subCode: 'X' },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry a 429 and then succeed', async () => {
+    fetchMock
+      .mockResolvedValueOnce(fakeResponse({ ok: false, status: 429, retryAfter: '0', body: '{}' }))
+      .mockResolvedValueOnce(fakeResponse({ ok: true, status: 200, body: '{"status":"OK"}' }));
+
+    await expect(client.request({ method: 'POST', path: CREATE_PATH })).resolves.toEqual({
+      status: 'OK',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should retry a 5xx and then succeed', async () => {
+    fetchMock
+      .mockResolvedValueOnce(fakeResponse({ ok: false, status: 503, body: '{}' }))
+      .mockResolvedValueOnce(fakeResponse({ ok: true, status: 200, body: '{"status":"OK"}' }));
+
+    await expect(client.request({ method: 'POST', path: CREATE_PATH })).resolves.toEqual({
+      status: 'OK',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should surface DpdNetworkException after exhausting retries on persistent 429', async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ ok: false, status: 429, retryAfter: '0', body: '{}' }));
+
+    await expect(client.request({ method: 'POST', path: CREATE_PATH })).rejects.toBeInstanceOf(
+      DpdNetworkException,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it('should NOT retry a network/timeout on the create call (guards double-COD)', async () => {
+    fetchMock.mockRejectedValue(new Error('ETIMEDOUT'));
+
+    await expect(
+      // retryOnNetworkError omitted ⇒ false for the non-idempotent create.
+      client.request({ method: 'POST', path: CREATE_PATH }),
+    ).rejects.toBeInstanceOf(DpdNetworkException);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry a network/timeout when the caller opts in (idempotent read)', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNRESET'));
+
+    await expect(
+      client.request({ method: 'GET', path: '/public/shipment/v1/generateSpedLabels', retryOnNetworkError: true }),
+    ).rejects.toBeInstanceOf(DpdNetworkException);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+});

--- a/libs/integrations/dpd-polska/src/infrastructure/http/dpd-http-client.interface.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/dpd-http-client.interface.ts
@@ -1,0 +1,41 @@
+/**
+ * DPD HTTP Client Port
+ *
+ * Narrow transport contract the adapter codes against. Keeping it an interface
+ * (not the concrete client) lets adapter unit specs mock DPDServices HTTP
+ * without a real `fetch`, per engineering-standards §"Interface and
+ * Implementation Separation".
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/http
+ */
+
+export type DpdHttpMethod = 'GET' | 'POST';
+
+export interface DpdRequestOptions {
+  method: DpdHttpMethod;
+  /** Absolute path on the DPDServices host, e.g. `/public/shipment/v1/generatePackagesNumbers`. */
+  path: string;
+  /** JSON request body (serialised by the client). */
+  body?: unknown;
+  /**
+   * Whether a **network/timeout** failure may be auto-retried. `true` only for
+   * idempotent reads (label render). For the non-idempotent create
+   * (`generatePackagesNumbers`) leave it `false`/unset: DPD has no idempotency
+   * key, so a retry after the request already committed would double-create a
+   * waybill and double-charge COD — the network error surfaces as
+   * `DpdNetworkException` (reconcile, don't re-POST). HTTP `429`/`5xx` (which
+   * mean DPD did NOT commit) are always retryable regardless of this flag.
+   */
+  retryOnNetworkError?: boolean;
+}
+
+export interface IDpdHttpClient {
+  /**
+   * Issue a DPDServices request. Resolves with the parsed JSON body. Throws a
+   * mapped domain exception on HTTP failure (`DpdUnauthorizedException` /
+   * `ShippingProviderRejectionException` / `DpdNetworkException`). Business
+   * validation failures arrive as HTTP `200` with a non-OK body status and are
+   * the adapter's concern, not the client's.
+   */
+  request<T>(options: DpdRequestOptions): Promise<T>;
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/http/dpd-http-client.interface.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/dpd-http-client.interface.ts
@@ -11,6 +11,14 @@
 
 export type DpdHttpMethod = 'GET' | 'POST';
 
+/** Auth identifiers for the DPDServices client (HTTP Basic + optional X-DPD-FID). */
+export interface DpdHttpAuth {
+  login: string;
+  password: string;
+  /** Provisional `X-DPD-FID` header value (master FID), pending OQ-2. */
+  masterFid?: string;
+}
+
 export interface DpdRequestOptions {
   method: DpdHttpMethod;
   /** Absolute path on the DPDServices host, e.g. `/public/shipment/v1/generatePackagesNumbers`. */
@@ -18,15 +26,19 @@ export interface DpdRequestOptions {
   /** JSON request body (serialised by the client). */
   body?: unknown;
   /**
-   * Whether a **network/timeout** failure may be auto-retried. `true` only for
-   * idempotent reads (label render). For the non-idempotent create
-   * (`generatePackagesNumbers`) leave it `false`/unset: DPD has no idempotency
-   * key, so a retry after the request already committed would double-create a
-   * waybill and double-charge COD — the network error surfaces as
-   * `DpdNetworkException` (reconcile, don't re-POST). HTTP `429`/`5xx` (which
-   * mean DPD did NOT commit) are always retryable regardless of this flag.
+   * Whether the call is safe to auto-retry on an **ambiguous** failure — a
+   * network/timeout or an ambiguous `5xx` (`500`/`502`/`504`) that might have
+   * committed server-side. `true` only for idempotent reads (label render).
+   *
+   * For the non-idempotent create (`generatePackagesNumbers`) leave it
+   * `false`/unset: DPD has no idempotency key, so retrying a request that
+   * already committed would double-create a waybill and double-charge COD — the
+   * failure surfaces as `DpdNetworkException` (reconcile, don't re-POST).
+   *
+   * `429` and `503` are retryable regardless of this flag: both mean DPD did
+   * NOT process the request, so a retry can't double-create.
    */
-  retryOnNetworkError?: boolean;
+  idempotent?: boolean;
 }
 
 export interface IDpdHttpClient {

--- a/libs/integrations/dpd-polska/src/infrastructure/http/dpd-http-client.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/dpd-http-client.ts
@@ -1,0 +1,252 @@
+/**
+ * DPD Polska DPDServices HTTP Client
+ *
+ * Native-`fetch` transport for the DPDServices REST API (mirrors
+ * `InpostHttpClient` — the established shipping precedent; no axios). Attaches
+ * HTTP Basic auth (`Authorization: Basic base64(login:password)`) plus the
+ * optional `X-DPD-FID` header (provisional, OQ-2), applies a jittered retry
+ * loop, enforces a request timeout, and maps DPDServices error bodies to domain
+ * exceptions.
+ *
+ * **Retry asymmetry (guards double-COD).** HTTP `429` / `5xx` mean DPD did NOT
+ * commit, so they are always retried. A **network/timeout** is retried ONLY
+ * when the caller opts in (`retryOnNetworkError`) — true for the idempotent
+ * label render, false for the create (`generatePackagesNumbers`), where a
+ * blind retry after a committed-but-lost response would mint a second waybill
+ * and a second COD charge. Non-retryable failures (`401`/`403` → unauthorized,
+ * `4xx` → `ShippingProviderRejectionException`) throw immediately; a retryable
+ * failure that exhausts the budget surfaces as `DpdNetworkException`.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/http
+ */
+import { randomUUID } from 'node:crypto';
+import { Logger } from '@openlinker/shared/logging';
+import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
+import type { DpdError401, DpdErrorItem, DpdErrors } from '../../domain/types/dpd-rest.types';
+import { DpdUnauthorizedException } from '../../domain/exceptions/dpd-unauthorized.exception';
+import { DpdNetworkException } from '../../domain/exceptions/dpd-network.exception';
+import type { DpdRequestOptions, IDpdHttpClient } from './dpd-http-client.interface';
+
+interface RetryConfig {
+  maxRetries: number;
+  initialDelayMs: number;
+  backoffMultiplier: number;
+  maxDelayMs: number;
+}
+
+const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRetries: 3,
+  initialDelayMs: 500,
+  backoffMultiplier: 2,
+  maxDelayMs: 8000,
+};
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+const DPD_BRAND = 'dpd';
+
+/** Auth identifiers for the DPDServices client. */
+export interface DpdHttpAuth {
+  login: string;
+  password: string;
+  /** Provisional `X-DPD-FID` header value (master FID), pending OQ-2. */
+  masterFid?: string;
+}
+
+/**
+ * Internal marker for retryable transport failures (429 / 5xx, plus network
+ * errors when the caller opted in). Never escapes the client — the retry loop
+ * converts it to `DpdNetworkException` once the budget is exhausted.
+ */
+class RetryableHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly retryAfterMs?: number,
+  ) {
+    super(message);
+    this.name = 'RetryableHttpError';
+  }
+}
+
+export class DpdHttpClient implements IDpdHttpClient {
+  private readonly logger = new Logger(DpdHttpClient.name);
+  private readonly retryConfig: RetryConfig;
+  private readonly authorizationHeader: string;
+
+  constructor(
+    private readonly baseUrl: string,
+    private readonly auth: DpdHttpAuth,
+    retryConfig?: Partial<RetryConfig>,
+  ) {
+    this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+    const token = Buffer.from(`${auth.login}:${auth.password}`, 'utf8').toString('base64');
+    this.authorizationHeader = `Basic ${token}`;
+  }
+
+  async request<T>(options: DpdRequestOptions): Promise<T> {
+    const requestId = randomUUID();
+    let delay = this.retryConfig.initialDelayMs;
+
+    for (let attempt = 0; attempt <= this.retryConfig.maxRetries; attempt++) {
+      try {
+        return await this.executeOnce<T>(options);
+      } catch (error) {
+        if (!(error instanceof RetryableHttpError)) {
+          // Non-retryable (unauthorized / rejection) OR a network error on a
+          // non-idempotent call (already converted to DpdNetworkException in
+          // fetchOnce) — propagate without retry.
+          throw error;
+        }
+        if (attempt === this.retryConfig.maxRetries) {
+          throw new DpdNetworkException(error.message, error);
+        }
+        const waitMs = error.retryAfterMs ?? this.jitter(delay);
+        this.logger.warn(
+          `DPDServices ${options.method} ${options.path} failed (attempt ${attempt + 1}/${this.retryConfig.maxRetries + 1}); retrying in ${waitMs}ms [requestId=${requestId}]`,
+        );
+        await this.sleep(waitMs);
+        delay = Math.min(delay * this.retryConfig.backoffMultiplier, this.retryConfig.maxDelayMs);
+      }
+    }
+
+    // Unreachable: the final attempt either returns or throws above.
+    throw new DpdNetworkException('DPDServices request exhausted its retry budget');
+  }
+
+  private async executeOnce<T>(options: DpdRequestOptions): Promise<T> {
+    const response = await this.fetchOnce(options);
+
+    await this.throwIfNotOk(response, options);
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    const text = await response.text();
+    if (!text) {
+      return undefined as T;
+    }
+    try {
+      const data: unknown = JSON.parse(text);
+      return data as T;
+    } catch (error) {
+      throw new DpdNetworkException('DPDServices returned an unparseable response body', error);
+    }
+  }
+
+  private async fetchOnce(options: DpdRequestOptions): Promise<Response> {
+    const url = new URL(options.path, this.baseUrl).toString();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    const headers: Record<string, string> = {
+      Authorization: this.authorizationHeader,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+    if (this.auth.masterFid) {
+      headers['X-DPD-FID'] = this.auth.masterFid;
+    }
+
+    try {
+      return await fetch(url, {
+        method: options.method,
+        headers,
+        body: options.body === undefined ? undefined : JSON.stringify(options.body),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      const message = `DPDServices network error: ${(error as Error).message}`;
+      // Idempotent reads may retry; the non-idempotent create must NOT
+      // (double-waybill / double-COD), so it throws a terminal network error.
+      if (options.retryOnNetworkError) {
+        throw new RetryableHttpError(message);
+      }
+      throw new DpdNetworkException(message, error);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /** Map a non-ok DPDServices response to the right domain exception. No-op on ok. */
+  private async throwIfNotOk(response: Response, options: DpdRequestOptions): Promise<void> {
+    if (response.ok) {
+      return;
+    }
+
+    const errorBody = await this.safeParseError(response);
+    const message = errorMessage(errorBody, options, response.status);
+
+    if (response.status === 401 || response.status === 403) {
+      throw new DpdUnauthorizedException(message);
+    }
+    if (response.status === 429) {
+      throw new RetryableHttpError(
+        message,
+        response.status,
+        parseRetryAfterMs(response.headers.get('retry-after')),
+      );
+    }
+    if (response.status >= 500) {
+      throw new RetryableHttpError(message, response.status);
+    }
+    const first = firstErrorItem(errorBody);
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      first?.code ?? null,
+      message,
+      first ? { field: first.field, subCode: first.subCode } : undefined,
+    );
+  }
+
+  private async safeParseError(response: Response): Promise<DpdErrors | DpdError401 | undefined> {
+    try {
+      const text = await response.text();
+      if (!text) {
+        return undefined;
+      }
+      const data: unknown = JSON.parse(text);
+      return data as DpdErrors | DpdError401;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private jitter(delayMs: number): number {
+    return Math.round(delayMs * (0.5 + Math.random() * 0.5));
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) {
+    return undefined;
+  }
+  const seconds = Number(header);
+  return Number.isFinite(seconds) ? seconds * 1000 : undefined;
+}
+
+/** First structured error item from a `DpdErrors` body, if present. */
+function firstErrorItem(body: DpdErrors | DpdError401 | undefined): DpdErrorItem | undefined {
+  const errors = (body as DpdErrors | undefined)?.errors;
+  return errors && errors.length > 0 ? errors[0] : undefined;
+}
+
+function errorMessage(
+  body: DpdErrors | DpdError401 | undefined,
+  options: DpdRequestOptions,
+  status: number,
+): string {
+  const first = (body as DpdErrors | undefined)?.errors?.[0];
+  if (first?.userMessage) {
+    return first.userMessage;
+  }
+  const status401 = (body as DpdError401 | undefined)?.status;
+  if (status401) {
+    return status401;
+  }
+  return `DPDServices ${options.method} ${options.path} failed (${status})`;
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/http/dpd-http-client.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/dpd-http-client.ts
@@ -25,7 +25,7 @@ import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
 import type { DpdError401, DpdErrorItem, DpdErrors } from '../../domain/types/dpd-rest.types';
 import { DpdUnauthorizedException } from '../../domain/exceptions/dpd-unauthorized.exception';
 import { DpdNetworkException } from '../../domain/exceptions/dpd-network.exception';
-import type { DpdRequestOptions, IDpdHttpClient } from './dpd-http-client.interface';
+import type { DpdHttpAuth, DpdRequestOptions, IDpdHttpClient } from './dpd-http-client.interface';
 
 interface RetryConfig {
   maxRetries: number;
@@ -45,18 +45,10 @@ const REQUEST_TIMEOUT_MS = 30_000;
 
 const DPD_BRAND = 'dpd';
 
-/** Auth identifiers for the DPDServices client. */
-export interface DpdHttpAuth {
-  login: string;
-  password: string;
-  /** Provisional `X-DPD-FID` header value (master FID), pending OQ-2. */
-  masterFid?: string;
-}
-
 /**
- * Internal marker for retryable transport failures (429 / 5xx, plus network
- * errors when the caller opted in). Never escapes the client — the retry loop
- * converts it to `DpdNetworkException` once the budget is exhausted.
+ * Internal marker for retryable transport failures (429 / 503 always; ambiguous
+ * 5xx + network only for idempotent calls). Never escapes the client — the
+ * retry loop converts it to `DpdNetworkException` once the budget is exhausted.
  */
 class RetryableHttpError extends Error {
   constructor(
@@ -159,7 +151,7 @@ export class DpdHttpClient implements IDpdHttpClient {
       const message = `DPDServices network error: ${(error as Error).message}`;
       // Idempotent reads may retry; the non-idempotent create must NOT
       // (double-waybill / double-COD), so it throws a terminal network error.
-      if (options.retryOnNetworkError) {
+      if (options.idempotent) {
         throw new RetryableHttpError(message);
       }
       throw new DpdNetworkException(message, error);
@@ -180,7 +172,9 @@ export class DpdHttpClient implements IDpdHttpClient {
     if (response.status === 401 || response.status === 403) {
       throw new DpdUnauthorizedException(message);
     }
-    if (response.status === 429) {
+    if (response.status === 429 || response.status === 503) {
+      // Rate-limited / unavailable: DPD did NOT process the request, so a retry
+      // can't double-create — always retryable, regardless of idempotency.
       throw new RetryableHttpError(
         message,
         response.status,
@@ -188,7 +182,13 @@ export class DpdHttpClient implements IDpdHttpClient {
       );
     }
     if (response.status >= 500) {
-      throw new RetryableHttpError(message, response.status);
+      // Ambiguous 5xx (500/502/504): the request may have committed server-side.
+      // Retry only idempotent reads; a non-idempotent create treats it as an
+      // indeterminate outcome (reconcile, don't re-POST) to avoid double-COD.
+      if (options.idempotent) {
+        throw new RetryableHttpError(message, response.status);
+      }
+      throw new DpdNetworkException(message);
     }
     const first = firstErrorItem(errorBody);
     throw new ShippingProviderRejectionException(

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
@@ -1,0 +1,284 @@
+/**
+ * DPD Shipment Mapper — unit tests
+ *
+ * Pure-function coverage: request building (field flatten, grams→kg, mm→cm,
+ * COD attributes, payerFID parse), the three-level body-status assertion, and
+ * base64 label decode.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/mappers
+ */
+import type { GenerateLabelCommand } from '@openlinker/core/shipping';
+import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
+import type { DpdConnectionConfig } from '../../../domain/types/dpd-config.types';
+import type {
+  DpdGeneratePackagesNumbersResponse,
+  DpdGenerateSpedLabelsResponse,
+} from '../../../domain/types/dpd-rest.types';
+import {
+  assertCreateSucceededAndExtractWaybill,
+  buildCreatePackagesRequest,
+  buildGenerateLabelRequest,
+  decodeLabelDocument,
+  toGenerateLabelResult,
+} from '../dpd-shipment.mapper';
+
+function makeConfig(overrides: Partial<DpdConnectionConfig> = {}): DpdConnectionConfig {
+  return {
+    environment: 'sandbox',
+    payerFid: '1495',
+    senderAddress: {
+      name: 'Sklep ACME',
+      address: 'Magazynowa 1',
+      city: 'Warszawa',
+      postalCode: '00-001',
+      countryCode: 'PL',
+      phone: '+48111222333',
+      email: 'sklep@example.com',
+    },
+    ...overrides,
+  };
+}
+
+function makeCmd(overrides: Partial<GenerateLabelCommand> = {}): GenerateLabelCommand {
+  return {
+    shipmentId: 'ol_shipment_1',
+    orderId: 'ol_order_1',
+    connectionId: 'conn-dpd',
+    shippingMethod: 'kurier',
+    recipient: {
+      firstName: 'Jan',
+      lastName: 'Kowalski',
+      email: 'buyer@example.com',
+      phone: '+48500600700',
+      address: {
+        street: 'Krakowska',
+        buildingNumber: '12',
+        city: 'Poznań',
+        postCode: '60-001',
+        countryCode: 'PL',
+      },
+    },
+    parcel: { dimensions: { length: 200, width: 150, height: 100 }, weightGrams: 1500 },
+    ...overrides,
+  };
+}
+
+function okCreateResponse(waybill = 'WB123'): DpdGeneratePackagesNumbersResponse {
+  return {
+    status: 'OK',
+    sessionId: 1,
+    packages: [{ status: 'OK', parcels: [{ status: 'OK', waybill }] }],
+  };
+}
+
+describe('buildCreatePackagesRequest', () => {
+  it('should build a single-package, single-parcel courier request with the sender from config', () => {
+    const req = buildCreatePackagesRequest(makeCmd(), makeConfig());
+
+    expect(req.generationPolicy).toBe('ALL_OR_NOTHING');
+    expect(req.packages).toHaveLength(1);
+    const pkg = req.packages[0];
+    expect(pkg.reference).toBe('ol_shipment_1');
+    expect(pkg.ref1).toBe('ol_order_1');
+    expect(pkg.payerFID).toBe(1495); // numeric, parsed from the '1495' string
+    expect(pkg.sender).toMatchObject({ name: 'Sklep ACME', address: 'Magazynowa 1', city: 'Warszawa' });
+    expect(pkg.services).toBeUndefined();
+    expect(pkg.parcels).toHaveLength(1);
+  });
+
+  it('should flatten the split recipient address and name into DPD single fields', () => {
+    const req = buildCreatePackagesRequest(makeCmd(), makeConfig());
+    const receiver = req.packages[0].receiver;
+
+    expect(receiver).toMatchObject({
+      name: 'Jan Kowalski', // firstName + lastName
+      address: 'Krakowska 12', // street + buildingNumber
+      city: 'Poznań',
+      postalCode: '60-001',
+      countryCode: 'PL',
+    });
+  });
+
+  it('should prefer recipient.name over first/last when present', () => {
+    const req = buildCreatePackagesRequest(
+      makeCmd({
+        recipient: {
+          name: 'ACME Sp. z o.o.',
+          firstName: 'Jan',
+          lastName: 'Kowalski',
+          email: 'b@example.com',
+          phone: '+48500600700',
+          address: {
+            street: 'Krakowska',
+            buildingNumber: '12',
+            city: 'Poznań',
+            postCode: '60-001',
+            countryCode: 'PL',
+          },
+        },
+      }),
+      makeConfig(),
+    );
+
+    expect(req.packages[0].receiver?.name).toBe('ACME Sp. z o.o.');
+  });
+
+  it('should convert grams to kilograms and millimetres to centimetres', () => {
+    const req = buildCreatePackagesRequest(makeCmd(), makeConfig());
+    const parcel = req.packages[0].parcels[0];
+
+    expect(parcel.weight).toBe(1.5); // 1500 g → 1.5 kg
+    expect(parcel.sizeX).toBe(20); // 200 mm → 20 cm
+    expect(parcel.sizeY).toBe(15);
+    expect(parcel.sizeZ).toBe(10);
+  });
+
+  it('should emit a COD TransportService with AMOUNT and CURRENCY attributes', () => {
+    const req = buildCreatePackagesRequest(
+      makeCmd({ cod: { amount: '39.99', currency: 'PLN' } }),
+      makeConfig(),
+    );
+
+    expect(req.packages[0].services).toEqual([
+      {
+        code: 'COD',
+        attributes: [
+          { code: 'AMOUNT', value: '39.99' },
+          { code: 'CURRENCY', value: 'PLN' },
+        ],
+      },
+    ]);
+  });
+
+  it('should reject a COD currency outside the DPD allow-list', () => {
+    expect(() =>
+      buildCreatePackagesRequest(makeCmd({ cod: { amount: '10.00', currency: 'USD' } }), makeConfig()),
+    ).toThrow(ShippingProviderRejectionException);
+  });
+
+  it('should reject an unsupported shipping method', () => {
+    expect(() => buildCreatePackagesRequest(makeCmd({ shippingMethod: 'paczkomat' }), makeConfig())).toThrow(
+      /supports 'kurier' only/,
+    );
+  });
+
+  it('should reject a courier shipment with no recipient address', () => {
+    const cmd = makeCmd();
+    const noAddr = { ...cmd, recipient: { ...cmd.recipient, address: undefined } };
+    expect(() => buildCreatePackagesRequest(noAddr, makeConfig())).toThrow(/recipient.address is required/);
+  });
+
+  it('should reject a courier shipment with no weight', () => {
+    expect(() => buildCreatePackagesRequest(makeCmd({ parcel: {} }), makeConfig())).toThrow(
+      /weightGrams is required/,
+    );
+  });
+});
+
+describe('assertCreateSucceededAndExtractWaybill', () => {
+  it('should return the parcel waybill when every status level is OK', () => {
+    expect(assertCreateSucceededAndExtractWaybill(okCreateResponse('WB999'))).toBe('WB999');
+  });
+
+  it('should throw with the validation errorCode when the top-level status is not OK', () => {
+    const res: DpdGeneratePackagesNumbersResponse = {
+      status: 'INCORRECT_DATA',
+      packages: [
+        {
+          status: 'INCORRECT_DATA',
+          parcels: [{ status: 'INCORRECT_DATA', validationInfo: [{ errorCode: 'INCORRECT_PAYER_FID', info: 'bad fid' }] }],
+        },
+      ],
+    };
+
+    const error = run(() => assertCreateSucceededAndExtractWaybill(res));
+    expect(error).toBeInstanceOf(ShippingProviderRejectionException);
+    expect(error).toMatchObject({ providerName: 'dpd', providerCode: 'INCORRECT_PAYER_FID' });
+  });
+
+  it('should throw when the package status is not OK even if the top status is OK', () => {
+    const res: DpdGeneratePackagesNumbersResponse = {
+      status: 'OK',
+      packages: [{ status: 'INCORRECT_DATA', parcels: [{ status: 'OK', waybill: 'WB1' }] }],
+    };
+    expect(() => assertCreateSucceededAndExtractWaybill(res)).toThrow(ShippingProviderRejectionException);
+  });
+
+  it('should throw when the parcel status is not OK', () => {
+    const res: DpdGeneratePackagesNumbersResponse = {
+      status: 'OK',
+      packages: [
+        {
+          status: 'OK',
+          parcels: [{ status: 'COD_IS_NOT_AVAILABLE_FOR_POSTAL_CODE', validationInfo: [{ errorCode: 'COD_IS_NOT_AVAILABLE_FOR_POSTAL_CODE' }] }],
+        },
+      ],
+    };
+    const error = run(() => assertCreateSucceededAndExtractWaybill(res));
+    expect(error).toMatchObject({ providerCode: 'COD_IS_NOT_AVAILABLE_FOR_POSTAL_CODE' });
+  });
+
+  it('should throw command.success-without-shipment-id when OK but no waybill', () => {
+    const res: DpdGeneratePackagesNumbersResponse = {
+      status: 'OK',
+      packages: [{ status: 'OK', parcels: [{ status: 'OK' }] }],
+    };
+    const error = run(() => assertCreateSucceededAndExtractWaybill(res));
+    expect(error).toMatchObject({ providerCode: 'command.success-without-shipment-id' });
+  });
+});
+
+describe('toGenerateLabelResult', () => {
+  it('should map the waybill to provider id, tracking number and label ref', () => {
+    expect(toGenerateLabelResult('WB1')).toEqual({
+      providerShipmentId: 'WB1',
+      trackingNumber: 'WB1',
+      labelPdfRef: 'WB1',
+    });
+  });
+});
+
+describe('buildGenerateLabelRequest', () => {
+  it('should build a domestic PDF/A4/BIC3 request for the waybill', () => {
+    expect(buildGenerateLabelRequest('WB1')).toEqual({
+      labelSearchParams: {
+        policy: 'STOP_ON_FIRST_ERROR',
+        session: { type: 'DOMESTIC', packages: [{ parcels: [{ waybill: 'WB1' }] }] },
+      },
+      outputDocFormat: 'PDF',
+      format: 'A4',
+      outputType: 'BIC3',
+    });
+  });
+});
+
+describe('decodeLabelDocument', () => {
+  it('should decode the base64 documentData to PDF bytes', () => {
+    const pdf = Buffer.from('%PDF-1.4', 'utf8').toString('base64');
+    const res: DpdGenerateSpedLabelsResponse = { status: 'OK', documentData: pdf };
+
+    const doc = decodeLabelDocument(res);
+
+    expect(doc.contentType).toBe('application/pdf');
+    expect(Buffer.from(doc.body).toString('utf8')).toBe('%PDF-1.4');
+  });
+
+  it('should throw when the label status is not OK', () => {
+    expect(() => decodeLabelDocument({ status: 'NOT_FOUND' })).toThrow(ShippingProviderRejectionException);
+  });
+
+  it('should throw command.empty-label when OK but no documentData', () => {
+    const error = run(() => decodeLabelDocument({ status: 'OK' }));
+    expect(error).toMatchObject({ providerCode: 'command.empty-label' });
+  });
+});
+
+/** Run a throwing fn and return the thrown error (or null if it didn't throw). */
+function run(fn: () => unknown): unknown {
+  try {
+    fn();
+    return null;
+  } catch (e) {
+    return e;
+  }
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
@@ -123,6 +123,27 @@ describe('buildCreatePackagesRequest', () => {
     expect(req.packages[0].receiver?.name).toBe('ACME Sp. z o.o.');
   });
 
+  it('should omit the receiver name when the order carries no name parts', () => {
+    const req = buildCreatePackagesRequest(
+      makeCmd({
+        recipient: {
+          email: 'b@example.com',
+          phone: '+48500600700',
+          address: {
+            street: 'Krakowska',
+            buildingNumber: '12',
+            city: 'Poznań',
+            postCode: '60-001',
+            countryCode: 'PL',
+          },
+        },
+      }),
+      makeConfig(),
+    );
+
+    expect(req.packages[0].receiver?.name).toBeUndefined();
+  });
+
   it('should convert grams to kilograms and millimetres to centimetres', () => {
     const req = buildCreatePackagesRequest(makeCmd(), makeConfig());
     const parcel = req.packages[0].parcels[0];

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
@@ -1,0 +1,240 @@
+/**
+ * DPD Polska Shipment Mapper
+ *
+ * Pure translation between the carrier-neutral `@openlinker/core/shipping`
+ * types and the DPDServices REST wire shapes. The single seam where DPD field
+ * names, the COD `TransportService`, the field-flattening (split OL address →
+ * single DPD `address` line; first/last → single `name`), and the grams→kg /
+ * mm→cm unit conversions live — keeping the adapter free of wire-format detail.
+ *
+ * All functions are pure (no I/O, no logging). Command/response validation that
+ * must surface to the operator throws `ShippingProviderRejectionException`
+ * (same seam every shipping adapter uses, #885).
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/mappers
+ */
+import type {
+  GenerateLabelCommand,
+  GenerateLabelResult,
+  LabelDocument,
+  ShipmentAddress,
+  ShipmentCod,
+  ShipmentRecipient,
+} from '@openlinker/core/shipping';
+import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
+import type { DpdConnectionConfig, DpdSenderContact } from '../../domain/types/dpd-config.types';
+import type {
+  DpdGeneratePackagesNumbersRequest,
+  DpdGeneratePackagesNumbersResponse,
+  DpdGenerateSpedLabelsRequest,
+  DpdGenerateSpedLabelsResponse,
+  DpdParcel,
+  DpdSenderOrReceiver,
+  DpdTransportService,
+  DpdValidationInfo,
+} from '../../domain/types/dpd-rest.types';
+import {
+  DPD_COD_ATTRIBUTE,
+  DPD_SERVICE_CODE_COD,
+  DPD_STATUS_OK,
+  DpdCodCurrencyValues,
+} from '../../domain/types/dpd-rest.types';
+
+const DPD_BRAND = 'dpd';
+
+/** Build the create-packages request for the command (v1: one package, one parcel). */
+export function buildCreatePackagesRequest(
+  cmd: GenerateLabelCommand,
+  config: DpdConnectionConfig,
+): DpdGeneratePackagesNumbersRequest {
+  if (cmd.shippingMethod !== 'kurier') {
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      'preflight.unsupported-method',
+      `DPD Polska supports 'kurier' only; got '${String(cmd.shippingMethod)}'`,
+    );
+  }
+  if (!cmd.recipient.address) {
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      'preflight.missing-recipient-address',
+      'recipient.address is required for a DPD courier shipment',
+    );
+  }
+  if (cmd.parcel.weightGrams === undefined) {
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      'preflight.missing-dimensions-or-weight',
+      'parcel.weightGrams is required for a DPD courier shipment',
+    );
+  }
+
+  const services = cmd.cod ? [buildCodService(cmd.cod)] : undefined;
+
+  return {
+    generationPolicy: 'ALL_OR_NOTHING',
+    packages: [
+      {
+        reference: cmd.shipmentId,
+        ref1: cmd.orderId,
+        sender: toSenderPeer(config.senderAddress),
+        receiver: toReceiverPeer(cmd.recipient, cmd.recipient.address),
+        payerFID: Number(config.payerFid),
+        services,
+        parcels: [toParcel(cmd)],
+      },
+    ],
+  };
+}
+
+/**
+ * Assert the create response succeeded at ALL three status levels (top, package,
+ * parcel) — DPD returns business failures as HTTP 200 with a non-OK body status,
+ * so a green HTTP call is not a green shipment. Returns the parcel waybill.
+ */
+export function assertCreateSucceededAndExtractWaybill(
+  res: DpdGeneratePackagesNumbersResponse,
+): string {
+  const pkg = res.packages?.[0];
+  const parcel = pkg?.parcels?.[0];
+  const info = firstValidation(parcel?.validationInfo) ?? firstValidation(pkg?.validationInfo);
+
+  if (res.status !== DPD_STATUS_OK) {
+    throw reject(info, `DPD create rejected (batch status: ${res.status})`);
+  }
+  if (!pkg || pkg.status !== DPD_STATUS_OK) {
+    throw reject(info, `DPD create rejected (package status: ${pkg?.status ?? 'missing'})`);
+  }
+  if (!parcel || parcel.status !== DPD_STATUS_OK) {
+    throw reject(info, `DPD create rejected (parcel status: ${parcel?.status ?? 'missing'})`);
+  }
+  if (!parcel.waybill) {
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      'command.success-without-shipment-id',
+      'DPD reported OK but returned no waybill',
+    );
+  }
+  return parcel.waybill;
+}
+
+/** Map an extracted waybill to the port result (waybill is the tracking number + label locator). */
+export function toGenerateLabelResult(waybill: string): GenerateLabelResult {
+  return { providerShipmentId: waybill, trackingNumber: waybill, labelPdfRef: waybill };
+}
+
+/** Build the label-render request for a single waybill (domestic PDF, A4, BIC3). */
+export function buildGenerateLabelRequest(waybill: string): DpdGenerateSpedLabelsRequest {
+  return {
+    labelSearchParams: {
+      policy: 'STOP_ON_FIRST_ERROR',
+      session: {
+        type: 'DOMESTIC',
+        packages: [{ parcels: [{ waybill }] }],
+      },
+    },
+    outputDocFormat: 'PDF',
+    format: 'A4',
+    outputType: 'BIC3',
+  };
+}
+
+/** Assert the label response succeeded and decode the base64 PDF to bytes. */
+export function decodeLabelDocument(res: DpdGenerateSpedLabelsResponse): LabelDocument {
+  if (res.status !== DPD_STATUS_OK) {
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      res.status,
+      `DPD label render rejected (status: ${res.status})`,
+    );
+  }
+  if (!res.documentData) {
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      'command.empty-label',
+      'DPD reported OK but returned no label document',
+    );
+  }
+  return {
+    contentType: 'application/pdf',
+    body: new Uint8Array(Buffer.from(res.documentData, 'base64')),
+  };
+}
+
+// --- internals ---------------------------------------------------------------
+
+function buildCodService(cod: ShipmentCod): DpdTransportService {
+  if (!DpdCodCurrencyValues.includes(cod.currency as (typeof DpdCodCurrencyValues)[number])) {
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      'preflight.cod-currency-unsupported',
+      `DPD COD currency must be one of ${DpdCodCurrencyValues.join(', ')}; got '${cod.currency}'`,
+    );
+  }
+  return {
+    code: DPD_SERVICE_CODE_COD,
+    attributes: [
+      { code: DPD_COD_ATTRIBUTE.Amount, value: cod.amount },
+      { code: DPD_COD_ATTRIBUTE.Currency, value: cod.currency },
+    ],
+  };
+}
+
+function toParcel(cmd: GenerateLabelCommand): DpdParcel {
+  const parcel: DpdParcel = {
+    reference: cmd.shipmentId,
+    // grams → kg (e.g. 1500 → 1.5).
+    weight: (cmd.parcel.weightGrams as number) / 1000,
+  };
+  if (cmd.parcel.dimensions) {
+    const { length, width, height } = cmd.parcel.dimensions;
+    // OL dimensions are millimetres; DPD sizeX/Y/Z are centimetres.
+    parcel.sizeX = length / 10;
+    parcel.sizeY = width / 10;
+    parcel.sizeZ = height / 10;
+  }
+  return parcel;
+}
+
+function toSenderPeer(sender: DpdSenderContact): DpdSenderOrReceiver {
+  return {
+    company: sender.company,
+    name: sender.name,
+    address: sender.address,
+    city: sender.city,
+    countryCode: sender.countryCode,
+    postalCode: sender.postalCode,
+    phone: sender.phone,
+    email: sender.email,
+  };
+}
+
+function toReceiverPeer(recipient: ShipmentRecipient, address: ShipmentAddress): DpdSenderOrReceiver {
+  return {
+    name: resolveRecipientName(recipient),
+    // OL splits street + buildingNumber; DPD's `address` is a single ≤100 line.
+    address: `${address.street} ${address.buildingNumber}`.trim(),
+    city: address.city,
+    countryCode: address.countryCode,
+    postalCode: address.postCode,
+    phone: recipient.phone,
+    email: recipient.email,
+  };
+}
+
+function resolveRecipientName(recipient: ShipmentRecipient): string {
+  return recipient.name ?? `${recipient.firstName ?? ''} ${recipient.lastName ?? ''}`.trim();
+}
+
+function firstValidation(infos?: DpdValidationInfo[]): DpdValidationInfo | undefined {
+  return infos && infos.length > 0 ? infos[0] : undefined;
+}
+
+function reject(info: DpdValidationInfo | undefined, fallback: string): ShippingProviderRejectionException {
+  return new ShippingProviderRejectionException(
+    DPD_BRAND,
+    info?.errorCode ?? null,
+    info?.info ?? fallback,
+    info ? { errorCode: info.errorCode, info: info.info } : undefined,
+  );
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
@@ -210,7 +210,13 @@ function toSenderPeer(sender: DpdSenderContact): DpdSenderOrReceiver {
 }
 
 function toReceiverPeer(recipient: ShipmentRecipient, address: ShipmentAddress): DpdSenderOrReceiver {
+  // Recipient fields come from the order (not the DTO-validated sender config),
+  // so DPD's length caps (name/address ≤100, city ≤50, postalCode ≤10) are NOT
+  // pre-validated here — an over-cap or malformed value is rejected by DPD and
+  // surfaced verbatim as a `ShippingProviderRejectionException`.
   return {
+    // Omit `name` (optional on DPD) rather than send an empty string when the
+    // order carries no name parts.
     name: resolveRecipientName(recipient),
     // OL splits street + buildingNumber; DPD's `address` is a single ≤100 line.
     address: `${address.street} ${address.buildingNumber}`.trim(),
@@ -222,8 +228,12 @@ function toReceiverPeer(recipient: ShipmentRecipient, address: ShipmentAddress):
   };
 }
 
-function resolveRecipientName(recipient: ShipmentRecipient): string {
-  return recipient.name ?? `${recipient.firstName ?? ''} ${recipient.lastName ?? ''}`.trim();
+function resolveRecipientName(recipient: ShipmentRecipient): string | undefined {
+  if (recipient.name) {
+    return recipient.name;
+  }
+  const composed = `${recipient.firstName ?? ''} ${recipient.lastName ?? ''}`.trim();
+  return composed.length > 0 ? composed : undefined;
 }
 
 function firstValidation(infos?: DpdValidationInfo[]): DpdValidationInfo | undefined {

--- a/libs/integrations/dpd-polska/src/testing.ts
+++ b/libs/integrations/dpd-polska/src/testing.ts
@@ -1,0 +1,11 @@
+/**
+ * @openlinker/integrations-dpd-polska/testing — test-only sub-barrel
+ *
+ * Exposes `FakeDpdShippingAdapter` for plugin-author / consumer unit tests that
+ * need an in-memory `ShippingProviderManagerPort` (+ `LabelDocumentReader`)
+ * without hitting DPDServices. Consumed only from `*.spec.ts`, never from
+ * runtime code.
+ *
+ * @module libs/integrations/dpd-polska/src
+ */
+export { FakeDpdShippingAdapter } from './testing/fake-dpd-shipping.adapter';

--- a/libs/integrations/dpd-polska/src/testing/__tests__/fake-dpd-shipping.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/testing/__tests__/fake-dpd-shipping.adapter.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Fake DPD Shipping Adapter — unit tests
+ *
+ * Verifies the in-memory fake mirrors the real adapter's observable contract:
+ * supported methods, courier pre-submit validation, a seeded failure, and the
+ * dormant `getTracking` throw.
+ *
+ * @module libs/integrations/dpd-polska/src/testing
+ */
+import { ShippingProviderRejectionException, type GenerateLabelCommand } from '@openlinker/core/shipping';
+import { FakeDpdShippingAdapter } from '../fake-dpd-shipping.adapter';
+
+function makeCmd(overrides: Partial<GenerateLabelCommand> = {}): GenerateLabelCommand {
+  return {
+    shipmentId: 'ol_shipment_1',
+    orderId: 'ol_order_1',
+    connectionId: 'conn-dpd',
+    shippingMethod: 'kurier',
+    recipient: {
+      email: 'buyer@example.com',
+      phone: '+48500600700',
+      address: { street: 'Krakowska', buildingNumber: '12', city: 'Poznań', postCode: '60-001', countryCode: 'PL' },
+    },
+    parcel: { weightGrams: 1500 },
+    ...overrides,
+  };
+}
+
+describe('FakeDpdShippingAdapter', () => {
+  let adapter: FakeDpdShippingAdapter;
+
+  beforeEach(() => {
+    adapter = new FakeDpdShippingAdapter();
+  });
+
+  it('should support only kurier', () => {
+    expect(adapter.getSupportedMethods()).toEqual(['kurier']);
+  });
+
+  it('should generate a deterministic, incrementing waybill', async () => {
+    const a = await adapter.generateLabel(makeCmd());
+    const b = await adapter.generateLabel(makeCmd());
+
+    expect(a.providerShipmentId).toBe('fake-dpd-1');
+    expect(b.providerShipmentId).toBe('fake-dpd-2');
+    expect(a.trackingNumber).toBe('fake-dpd-1');
+    expect(a.labelPdfRef).toBe('fake-dpd-1');
+  });
+
+  it('should reject an unsupported method', async () => {
+    await expect(adapter.generateLabel(makeCmd({ shippingMethod: 'paczkomat' }))).rejects.toBeInstanceOf(
+      ShippingProviderRejectionException,
+    );
+  });
+
+  it('should reject a courier shipment with no recipient address', async () => {
+    const cmd = makeCmd();
+    await expect(
+      adapter.generateLabel({ ...cmd, recipient: { ...cmd.recipient, address: undefined } }),
+    ).rejects.toMatchObject({ providerCode: 'preflight.missing-recipient-address' });
+  });
+
+  it('should return a PDF label document', async () => {
+    const doc = await adapter.fetchLabel({ providerShipmentId: 'fake-dpd-1' });
+    expect(doc.contentType).toBe('application/pdf');
+    expect(doc.body.length).toBeGreaterThan(0);
+  });
+
+  it('should throw tracking.unavailable from getTracking', async () => {
+    await expect(adapter.getTracking({ providerShipmentId: 'fake-dpd-1' })).rejects.toMatchObject({
+      providerCode: 'tracking.unavailable',
+    });
+  });
+
+  it('should surface a seeded failure and reset it on clear', async () => {
+    adapter.seedFailure(new Error('boom'));
+    await expect(adapter.generateLabel(makeCmd())).rejects.toThrow('boom');
+
+    adapter.clear();
+    await expect(adapter.generateLabel(makeCmd())).resolves.toMatchObject({ providerShipmentId: 'fake-dpd-1' });
+  });
+});

--- a/libs/integrations/dpd-polska/src/testing/fake-dpd-shipping.adapter.ts
+++ b/libs/integrations/dpd-polska/src/testing/fake-dpd-shipping.adapter.ts
@@ -1,0 +1,95 @@
+/**
+ * Fake DPD Polska Shipping Adapter
+ *
+ * In-memory `ShippingProviderManagerPort` (+ `LabelDocumentReader`) for
+ * plugin-author / consumer unit tests that need deterministic shipping
+ * behaviour without hitting DPDServices. Mirrors the real adapter's observable
+ * contract — including the courier pre-submit validation and the
+ * `getTracking` throw — and adds `seed*` / `clear` helpers for arranging test
+ * state.
+ *
+ * Consumed only from `*.spec.ts` via `@openlinker/integrations-dpd-polska/testing`,
+ * never from runtime code.
+ *
+ * @module libs/integrations/dpd-polska/src/testing
+ */
+import {
+  ShippingProviderRejectionException,
+  type GenerateLabelCommand,
+  type GenerateLabelResult,
+  type LabelDocument,
+  type LabelDocumentReader,
+  type ShippingMethod,
+  type ShippingProviderManagerPort,
+  type TrackingSnapshot,
+} from '@openlinker/core/shipping';
+
+const SUPPORTED_METHODS: readonly ShippingMethod[] = ['kurier'];
+
+export class FakeDpdShippingAdapter implements ShippingProviderManagerPort, LabelDocumentReader {
+  private counter = 0;
+  private seededFailure: Error | null = null;
+
+  getSupportedMethods(): readonly ShippingMethod[] {
+    return SUPPORTED_METHODS;
+  }
+
+  generateLabel(cmd: GenerateLabelCommand): Promise<GenerateLabelResult> {
+    if (this.seededFailure) {
+      return Promise.reject(this.seededFailure);
+    }
+    if (cmd.shippingMethod !== 'kurier') {
+      return Promise.reject(
+        new ShippingProviderRejectionException(
+          'dpd',
+          'preflight.unsupported-method',
+          `DPD Polska supports 'kurier' only; got '${String(cmd.shippingMethod)}'`,
+        ),
+      );
+    }
+    if (!cmd.recipient.address) {
+      return Promise.reject(
+        new ShippingProviderRejectionException(
+          'dpd',
+          'preflight.missing-recipient-address',
+          'recipient.address is required for a DPD courier shipment',
+        ),
+      );
+    }
+    const waybill = `fake-dpd-${(this.counter += 1)}`;
+    return Promise.resolve({ providerShipmentId: waybill, trackingNumber: waybill, labelPdfRef: waybill });
+  }
+
+  fetchLabel(_input: { providerShipmentId: string }): Promise<LabelDocument> {
+    if (this.seededFailure) {
+      return Promise.reject(this.seededFailure);
+    }
+    return Promise.resolve({
+      contentType: 'application/pdf',
+      body: new Uint8Array([0x25, 0x50, 0x44, 0x46]), // %PDF
+    });
+  }
+
+  getTracking(_input: { providerShipmentId: string }): Promise<TrackingSnapshot> {
+    return Promise.reject(
+      new ShippingProviderRejectionException(
+        'dpd',
+        'tracking.unavailable',
+        'DPD tracking is not available until DPD InfoServices is wired (#965)',
+      ),
+    );
+  }
+
+  // --- test helpers ----------------------------------------------------------
+
+  /** Make the next `generateLabel` / `fetchLabel` throw the given error. */
+  seedFailure(error: Error): void {
+    this.seededFailure = error;
+  }
+
+  /** Reset all in-memory state between tests. */
+  clear(): void {
+    this.counter = 0;
+    this.seededFailure = null;
+  }
+}

--- a/libs/integrations/dpd-polska/tsconfig.json
+++ b/libs/integrations/dpd-polska/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    { "path": "../../core" },
+    { "path": "../../shared" },
+    { "path": "../../plugin-sdk" }
+  ]
+}

--- a/libs/integrations/dpd-polska/tsconfig.spec.json
+++ b/libs/integrations/dpd-polska/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/__tests__/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@openlinker/integrations-allegro':
         specifier: workspace:*
         version: link:../../libs/integrations/allegro
+      '@openlinker/integrations-dpd-polska':
+        specifier: workspace:*
+        version: link:../../libs/integrations/dpd-polska
       '@openlinker/integrations-inpost':
         specifier: workspace:*
         version: link:../../libs/integrations/inpost
@@ -518,6 +521,52 @@ importers:
       image-size:
         specifier: ^1.0.0
         version: 1.2.1
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.12
+        version: 29.5.12
+      '@types/node':
+        specifier: 20.11.30
+        version: 20.11.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: 7.3.1
+        version: 7.3.1(@typescript-eslint/parser@7.3.1(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/parser':
+        specifier: 7.3.1
+        version: 7.3.1(eslint@8.57.0)(typescript@5.4.3)
+      eslint:
+        specifier: 8.57.0
+        version: 8.57.0
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@20.11.30)(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3))
+      ts-jest:
+        specifier: 29.1.2
+        version: 29.1.2(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@20.11.30)(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3)))(typescript@5.4.3)
+      typescript:
+        specifier: 5.4.3
+        version: 5.4.3
+
+  libs/integrations/dpd-polska:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^10.0.0
+        version: 10.3.0(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.1)(rxjs@7.8.1)
+      '@openlinker/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@openlinker/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../plugin-sdk
+      '@openlinker/shared':
+        specifier: workspace:*
+        version: link:../../shared
+      class-transformer:
+        specifier: 0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: 0.14.1
+        version: 0.14.1
     devDependencies:
       '@types/jest':
         specifier: 29.5.12


### PR DESCRIPTION
## What & why

Adds `@openlinker/integrations-dpd-polska`, OpenLinker's **second OL-managed carrier** after InPost (#727), built on the native **DPDServices REST API** (HTTP Basic, JSON) behind `ShippingProviderManagerPort` + `LabelDocumentReader`. Customer-driven (#961). Transport decision (REST over the legacy SOAP `DPDPackageObjServices`) is recorded in ADR-018.

Two-call flow: `generatePackagesNumbers` (create → waybill) → `generateSpedLabels` (render → base64 PDF, on demand).

## Scope (#962)

Courier-to-door labels **+ Cash-on-Delivery**. Out of scope (sibling issues): DPD Pickup (#963), bulk + protocol (#964), real tracking via DPD InfoServices (#965), FE connection form + COD-amount input (#966).

## Changes

**CORE (additive, no migration):**
- New `ShipmentCod` type (`{ amount: string; currency: string }`) in its own `shipment-cod.types.ts`.
- Optional `GenerateLabelCommand.cod` (auto-flows into `ShipmentDispatchInput` via its `Omit<>`).
- One caller-supplied pass-through line in `ShipmentDispatchService` — COD is **caller-owned** (operator input / #966), not order-sourced.

**Integration (`libs/integrations/dpd-polska/`):**
- `DpdHttpClient` (native fetch, Basic auth + optional `X-DPD-FID` header) with a **retry asymmetry that guards double-COD**: `429`/`503` (DPD did-not-commit) always retry; ambiguous `5xx` + network/timeout retry **only for the idempotent label read** — the non-idempotent create surfaces a terminal `DpdNetworkException` (reconcile, never blind re-POST) because DPD has no idempotency key.
- `DpdShippingAdapter` asserts **all three body-status levels** (DPD returns business failures as HTTP 200) before trusting the waybill.
- Mapper flattens the split recipient address (`street`+`buildingNumber` → DPD single `address`) and name, converts grams→kg + mm→cm, emits COD as `TransportService{AMOUNT,CURRENCY}`.
- `getTracking` throws a typed `tracking.unavailable` (the adapter has only the waybill — any status would be fabricated). Confirmed dormant: the #838 `marketplace.shipment.statusSync` handler is job-driven per `connectionId` and no DPD scheduler enqueues those jobs until #965.
- Config-shape validator, factory, plugin descriptor + manifest `dpd.polska.rest.v1`, host wiring in `apps/api/src/plugins.ts` + jest-integration mappers (#917).

**Design note (OQ-2):** `payerFID`/`masterFid` are modelled as non-secret **config** (mirroring InPost's `organizationId`; the config-shape validator enforces numeric); only `login`/`password` are credentials.

## Testing

- 6 unit suites — core dispatch COD pass-through + 5 plugin suites (http-client, mapper, adapter, config-validator, fake). Full repo: **2710 unit tests green**, `type-check` + `lint` + all invariants pass.
- Full `pnpm test:integration` run: the DPD-relevant slices (`shipment-dispatch`, `shipment-label-download`, `connection-capabilities`, `connection-crud`) pass and the plugin registers cleanly (`Registered adapter: dpd.polska.rest.v1 (default for dpd)`). A late-run cohort of 5 unrelated suites flaked under Docker resource degradation; **all 5 pass on isolated re-run**.

## Remaining (pre-merge AC)

- [ ] **Manual live REST round-trip** against the DPD test server — gated on test-server credentials (OQ-1) + final auth-shape confirmation (OQ-2: whether `X-DPD-FID` is required alongside Basic). Build + unit tests do not need them; this is the one thing this session couldn't exercise.

Plan: `docs/plans/implementation-plan-962-dpd-adapter-rest.md` (#968) · ADR: `docs/architecture/adrs/018-dpd-polska-rest-api-over-soap.md`

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)