### PR TITLE
feat(shipping,dpd): DPD Pickup points — PickupPointFinder + ship-to-point

### DIFF
--- a/apps/api/src/shipping/http/dto/generate-label.dto.ts
+++ b/apps/api/src/shipping/http/dto/generate-label.dto.ts
@@ -142,7 +142,10 @@ export class GenerateLabelDto {
   @IsEnum(ShippingMethodValues)
   shippingMethod!: ShippingMethod;
 
-  @ApiPropertyOptional({ description: 'Required when shippingMethod === paczkomat' })
+  @ApiPropertyOptional({
+    description:
+      'Pickup-point id — required for point-delivery methods (paczkomat = locker, pickup = parcel-shop/PUDO); absent for kurier',
+  })
   @IsOptional()
   @IsString()
   paczkomatId?: string;

--- a/docs/plans/implementation-plan-963-dpd-pickup-points.md
+++ b/docs/plans/implementation-plan-963-dpd-pickup-points.md
@@ -1,0 +1,181 @@
+# Implementation Plan: DPD Pickup points — PickupPointFinder + ship-to-point
+
+**Date**: 2026-06-03
+**Status**: Draft — pending Gate (Phase 3 review)
+**Issue**: #963 (Part of #961)
+**Spec**: [`docs/specs/product-spec-961-dpd-polska-shipping.md`](../specs/product-spec-961-dpd-polska-shipping.md) §4.3 (US-4 / AC-4)
+**Builds on**: #962 (DPD adapter package + REST transport, merged via #971)
+**Implementation branch**: `963-dpd-pickup-points`
+**Estimated Effort**: S–M (~2–4 days)
+
+> **Scope correction from research (2026-06-03).** Two facts reshape this issue
+> from the issue-body framing:
+> 1. **The dispatch path is already carrier-agnostic.** `GenerateLabelCommand.paczkomatId`
+>    carries *any* pickup-point id; the Allegro adapter reads `delivery.pickupPoint.id`
+>    carrier-blind into `IncomingOrder.pickupPoint` → order snapshot, and the operator
+>    generate-label flow supplies it. A DPD point id (`PL11033`) **already flows through
+>    with zero core / Allegro changes** — the "Allegro auto-fill" AC is satisfied by
+>    existing plumbing once the DPD adapter consumes `paczkomatId`.
+> 2. **The FE pickup picker modal does not exist yet** (deferred; the form is manual
+>    text entry today) and the DPD FE connection plugin is **#966's** scope. So #963's
+>    "thin FE wiring to reuse the picker" is effectively nil.
+>
+> **#963 is therefore a backend-only Integration slice.** Net-new = the DPD adapter's
+> `PickupPointFinder` + the ship-to-point (`pudoReceiver` / `DPD_PICKUP`) mapping.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Add DPD Pickup (parcel-shop / PUDO) delivery to `@openlinker/integrations-dpd-polska`: the adapter implements `PickupPointFinder` (searches the DPD point directory) and the mapper ships a parcel to a chosen point (`pudoReceiver` + `DPD_PICKUP` service) when `shippingMethod === 'paczkomat'`.
+
+**Classification**: **CORE (one additive line) + Integration.** A dedicated `'pickup'` `ShippingMethod` value is added to the closed core union (`shipping_method` is a `text` column → **no migration**); the rest is the DPD integration. No FE change in this issue (FE mirror + form affordances = #966).
+
+**Context**: Mirrors the InPost pickup vertical slice (#764/#766) — DPD plugs into the already-carrier-agnostic `PickupPointLookupService` → `GET /pickup-points` → `isPickupPointFinder` → `findPickupPoints` machinery and the operator generate-label flow.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+**CORE (`libs/core/src/shipping/`) — one additive edit:**
+- Add `'pickup'` to `ShippingMethodValues` + `SHIPPING_METHOD` in `domain/types/shipping-method.types.ts` (the dedicated carrier-neutral "ship to a parcel-shop / PUDO point" method, distinct from `paczkomat` = locker). `shipping_method` is a `text` column → no migration; `@IsEnum(ShippingMethodValues)` DTOs auto-accept it; no exhaustive `never`-switch to update.
+
+**Integration (`libs/integrations/dpd-polska/`):**
+- `DpdShippingAdapter implements …, PickupPointFinder` — `findPickupPoints(query)` against the DPD point directory; `getSupportedMethods()` gains `'pickup'` (→ `['kurier','pickup']`).
+- Mapper **pickup branch**: `shippingMethod === 'pickup'` → one `SinglePackage` with `pudoReceiver` (the point id from `cmd.paczkomatId`) + the `DPD_PICKUP` `TransportService`, instead of the courier `receiver`.
+- Point-directory mapping: DPD point → neutral `PickupPoint`; neutral `FindPickupPointsQuery` → DPD point-search request.
+- Types: `pudoReceiver` on `DpdSinglePackage`, `DPD_PICKUP` service code, point-search request/response shapes.
+- `FakeDpdShippingAdapter` gains `findPickupPoints` (seeded points) + pickup-branch validation.
+- Unit tests for all of the above.
+
+### Out of Scope
+- **Allegro / order-ingestion changes** — the pickup-point id already flows (research §2 below). Zero changes.
+- **FE** — the FE `ShippingMethodValues` mirror (`apps/web/src/features/shipments/api/shipments.types.ts`) gaining `'pickup'`, the generate-label form offering it, picker modal (doesn't exist; deferred), DPD connection form + COD/pickup panel = **#966**. Until #966, DPD pickup is backend-capable but not operator-reachable via the FE (mirrors #962: COD backend shipped, operator entry = #966).
+- **Renaming `GenerateLabelCommand.paczkomatId`** — the point id keeps riding the existing (carrier-neutral despite the name) `paczkomatId` command field; renaming it is a separate, larger core change, out of scope.
+- **PrestaShop pickup-point read** — PS order source doesn't expose a point today; manual fallback. Out of scope (re-evaluate if a PS DPD module surfaces it).
+- Courier-to-door + COD (#962, shipped); bulk + protocol (#964); tracking (#965).
+
+### Constraints
+- No new runtime dep. No migration (`text` column). The dedicated `'pickup'` value is additive to the closed core union (forward-compatible per `shipping-method.types.ts`'s own doc).
+
+---
+
+## 3. Architecture Mapping
+
+**Layer**: Integration only. Implements the existing `PickupPointFinder` sub-capability (`@openlinker/core/shipping`) — no new core surface.
+
+**Reused unchanged**:
+- `PickupPointLookupService.search(connectionId, query)` → `getCapabilityAdapter<ShippingProviderManagerPort>` → `isPickupPointFinder(adapter)` → `findPickupPoints` → write-through `PickupPointCachePort`. Carrier-agnostic.
+- `GET /pickup-points?connectionId&searchText&city&postalCode&limit` (`apps/api/src/shipping/http/pickup-point.controller.ts`) — works for any connection whose adapter implements the capability.
+- `FindPickupPointsQuery` / `PickupPoint` / `PickupPointAddress` types.
+- The whole #962 DPD stack: `DpdHttpClient`, factory, plugin, config validator.
+
+**InPost reference slice to mirror**: `inpost-shipping.adapter.ts` (`findPickupPoints`), `inpost-shipx.mapper.ts` (`buildPointsQuery` / `toPickupPoint`), `pickup-point-finder.capability.ts` (guard — reuse as-is).
+
+---
+
+## 4. External Research — DPD point directory (OQ-1, the one spike item)
+
+DPD Polska exposes a **ParcelShopFinder / DPD Pickup point directory** (parcel shops + lockers) — confirmed it exists; the exact placement + shape is the spike item, same gated-Swagger situation as #962's live round-trip:
+
+- **OQ-1 (primary):** the exact point-search endpoint — is it in the REST `DPDServices` API (e.g. an `appservices` / `findPoints` / postal-code group at `dpdservices.dpd.com.pl`, reusing the same Basic auth + `DpdHttpClient`), or a **separate** DPD Pickup finder service (different base URL / auth → would need a second small client)? Confirm method (GET-with-query vs POST-body), request fields (city / postcode / street / limit), and response fields (point id, name, address, lat/lon, type=shop|locker, opening hours). **Resolve via the live Swagger (chrome-devtools-mcp, as in #962).**
+- **OQ-2:** the ship-to-point wire shape — does the point id ride on `SinglePackage.pudoReceiver` (e.g. `{ pudoId, name?, phone?, email? }`), as a `DPD_PICKUP` `TransportService` attribute, or both? Confirm against `generatePackagesNumbers` in the Swagger.
+- **OQ-3:** does a pickup shipment still require `receiver` contact (for SMS/notification) alongside `pudoReceiver`? InPost sends a receiver peer without an address for lockers — DPD likely similar.
+
+**Design guard:** the entire DPD-point wire shape lives in `dpd-rest.types.ts` + a new `dpd-pickup.mapper.ts` (or an extension of `dpd-shipment.mapper.ts`). Confirming OQ-1/OQ-2 later touches only those files + (if OQ-1 = separate service) the factory's client wiring. Unit tests run against canned fixtures of the expected shape; the **live point-search + ship-to-point round-trip is a pre-merge manual AC** (needs the #962 test-server creds).
+
+---
+
+## 5. Questions & Assumptions
+
+### Assumptions (confirm in Phase 0 spike)
+- The point directory is reachable via the same `DPDServices` host + Basic auth → reuse `DpdHttpClient` (add a `query?` option for a GET search, mirroring InPost). If OQ-1 shows a separate service, add a small `DpdPointDirectoryClient` behind the same factory.
+- `cmd.paczkomatId` = the DPD point id (e.g. `PL11033`); `cmd.parcel.weightGrams` required (DPD parcels always carry weight; no locker-size `template` like InPost).
+- A pickup shipment sends `pudoReceiver` (point id + buyer contact) and **omits** the courier street `receiver.address`.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 0 — Spike (confirm OQ-1/OQ-2 against the live Swagger; needs #962 creds for the live call)
+1. Via chrome-devtools-mcp on `dpdservices.dpd.com.pl` Swagger (the #962 path): confirm (a) the point-search endpoint path/method/auth/fields, (b) the `pudoReceiver` / `DPD_PICKUP` shape on `generatePackagesNumbers`. Capture canned request/response fixtures. Spike code NOT merged. (If creds are still gated, build Phases 1–3 against the documented/expected shape and leave the live finder + ship-to-point round-trip as the pre-merge AC.)
+
+### Phase 1 — CORE: dedicated `'pickup'` method (additive)
+2. `libs/core/src/shipping/domain/types/shipping-method.types.ts`: add `'pickup'` to `ShippingMethodValues` and `SHIPPING_METHOD` (+ JSDoc: parcel-shop/PUDO point delivery, distinct from `paczkomat` locker). Update the file's "two flavours" note to list `pickup` alongside `paczkomat`/`kurier`.
+   - **Acceptance**: type-check green repo-wide (no exhaustive switch breaks); `@IsEnum` DTOs accept `'pickup'`; InPost/Allegro adapters unaffected (they don't advertise it).
+
+### Phase 2 — DPD types
+3. `domain/types/dpd-rest.types.ts`: add `DpdPudoReceiver` (point id + optional contact), `pudoReceiver?` on `DpdSinglePackage`, `DPD_SERVICE_CODE_DPD_PICKUP = 'DPD_PICKUP'`, and point-search request/response interfaces (`DpdPointSearchRequest`/`Query`, `DpdPoint`, `DpdPointSearchResponse`).
+   - **Acceptance**: type-check green; existing #962 types unchanged.
+
+### Phase 3 — Mapper (pickup branch + point mapping)
+4. `infrastructure/mappers/dpd-shipment.mapper.ts`: split `buildCreatePackagesRequest` into method branches — keep the courier branch (#962), add a **pickup branch** for `shippingMethod === 'pickup'`: require `cmd.paczkomatId` (the point id; else `preflight.missing-paczkomat-id`) + `weightGrams`; build `pudoReceiver` from the point id + `cmd.recipient` contact; add the `DPD_PICKUP` service; COD still allowed (attach as #962). Throw `preflight.unsupported-method` for anything other than `kurier`/`pickup`.
+5. Point mapping helpers: `buildPointSearchRequest(query: FindPickupPointsQuery)` and `toPickupPoint(dpdPoint): PickupPoint` (map id/name/address/lat/lon/status).
+   - **Acceptance**: mapper unit tests — pickup-branch body (pudoReceiver + DPD_PICKUP), missing-point-id throw, COD-on-pickup, point query/response mapping.
+
+### Phase 4 — Adapter + fake
+6. `infrastructure/adapters/dpd-shipping.adapter.ts`: `implements … , PickupPointFinder`; add `findPickupPoints(query)` → `client.request` (GET-with-query or POST per OQ-1, `idempotent: true`) → `toPickupPoint[]`; `getSupportedMethods()` → `['kurier', 'pickup']`. `generateLabel` already routes through the mapper (now method-aware).
+7. `testing/fake-dpd-shipping.adapter.ts`: `implements PickupPointFinder`; `findPickupPoints` returns seeded points; `generateLabel` validates the pickup branch (missing point id → rejection); add `seedPickupPoints`.
+   - **Acceptance**: adapter unit tests — `findPickupPoints` happy path + capability presence (`isPickupPointFinder(adapter) === true`), `'pickup'`-method `generateLabel`, `getSupportedMethods` = `['kurier','pickup']`; fake spec updated.
+
+### Phase 5 — HTTP client (only if OQ-1 needs it)
+8. If the point search is a GET with query params, add a `query?: Record<string, string|number|undefined>` option to `DpdRequestOptions` + build it in `dpd-http-client.ts` (mirror InPost's `buildUrl`). If it's a separate service (OQ-1), add `DpdPointDirectoryClient` + wire it in `dpd-adapter.factory.ts`.
+   - **Acceptance**: http-client unit test for query serialization (if added).
+
+### Config / Migrations / Events
+- None. No env vars, no migration, no events.
+
+---
+
+## 7. Alternatives Considered
+- **Reuse `paczkomat` as the generic pickup method** — rejected (maintainer decision). `paczkomat` is InPost-locker terminology; conflating DPD parcel-shops onto it muddies the vocabulary. A dedicated `'pickup'` value is clean because the `text` column needs no migration, `@IsEnum` DTOs auto-accept it, and no exhaustive `never`-switch exists — so the only cost is one additive core line + the FE mirror update (deferred to #966).
+- **Carrier-prefixed value (`'dpd_pickup'`)** — rejected; `ShippingMethod` values are carrier-neutral (`paczkomat`/`kurier`/`omp`). `'pickup'` lets future carriers' parcel-shop delivery reuse it.
+- **Auto-deriving `paczkomatId` from the order snapshot in core dispatch** — rejected; the operator-supplied seam (caller-owns-payload, #962/#769) is intentional and already carries the point id. No core change.
+- **Building Allegro/PS pickup-point read in this issue** — unnecessary; Allegro already reads it carrier-blind (#458). PS doesn't expose it (separate future issue).
+
+---
+
+## 8. Validation & Risks
+- **OQ-1 (point-directory endpoint)** is the highest-uncertainty item — mitigated by isolating the wire shape (types + mapper) and the spike. Worst case (separate service) adds one small client behind the factory, not a redesign.
+- **R1 — `'pickup'` not operator-reachable until #966 (confirmed safe)**: the FE keeps a *standalone* `SHIPPING_METHOD_VALUES` + `SHIPPING_METHOD_LABEL: Record<ShippingMethod,string>` mirror (`apps/web/src/features/shipments/api/shipments.types.ts`), NOT imported from core — so adding `'pickup'` to the core union does **not** break `apps/web` type-check, and no BE↔FE parity test exists. **#966 owns** widening the FE mirror + label + offering `'pickup'` in the generate-label form. Until then DPD pickup is backend-capable but FE-dormant; no `'pickup'` shipment can reach the `/shipments` label map, so the missing FE label is harmless (hand-off note for #966).
+- **R2 — point id rides `paczkomatId`**: the dedicated method is `'pickup'` but the point id reuses the generic `cmd.paczkomatId` field (renaming it is out of scope). Slight name/field mismatch, documented.
+- **R3 — pickup still needs weight/dims**: DPD parcels carry weight regardless of pickup vs courier; the pickup branch requires `weightGrams` (unlike InPost lockers which use a size `template`).
+- **Live round-trip** (finder + ship-to-point) gated on #962 test-server creds → pre-merge manual AC, not a build/unit blocker.
+- Backward compatible — additive to the #962 adapter; courier + COD paths unchanged.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests (extend the #962 suites)
+- `dpd-shipment.mapper.spec.ts` — pickup branch (pudoReceiver + DPD_PICKUP), missing-point-id throw, COD-on-pickup, point query + response mapping.
+- `dpd-shipping.adapter.spec.ts` — `findPickupPoints` happy path, `isPickupPointFinder` true, `'pickup'` `generateLabel`, `getSupportedMethods` = `['kurier','pickup']`.
+- `fake-dpd-shipping.adapter.spec.ts` — `findPickupPoints` seeded, pickup validation.
+
+### Acceptance Criteria (#963)
+- [ ] `'pickup'` added to core `ShippingMethodValues`; repo type-check green.
+- [ ] `DpdShippingAdapter` implements `PickupPointFinder`; `GET /pickup-points?connectionId=<dpd>` returns DPD points (unit-proven; live in the AC below).
+- [ ] A label with `shippingMethod='pickup'` + `paczkomatId=<point>` builds a `pudoReceiver` + `DPD_PICKUP` request (unit-proven).
+- [ ] A DPD point id (`PL11033`) passes through `paczkomatId` → pickup mapping unchanged (carrier-agnostic plumbing; mapper/adapter test). Operator selection of `'pickup'` in the FE = #966.
+- [ ] `pnpm lint` / `type-check` / unit tests green; `check-create-adapter` + jest-integration invariants satisfied.
+- [ ] **Manual (pre-merge):** live DPD point search + a real label shipped to a DPD Pickup point (needs #962 test-server creds + OQ-1/OQ-2 confirmation).
+
+---
+
+## 10. Alignment Checklist
+- [x] Hexagonal — integration implements an existing core sub-capability; one additive core enum value
+- [x] CORE vs Integration boundary respected (dispatch plumbing already carrier-agnostic; the `'pickup'` value is a neutral core vocabulary addition)
+- [x] Reuses existing patterns (InPost pickup slice, #962 DPD stack, `PickupPointFinder` guard)
+- [x] Idempotency — `findPickupPoints` is an idempotent read; ship-to-point inherits #962's create guard
+- [x] Error handling — `ShippingProviderRejectionException` (`preflight.*`) + #962 HTTP mapping
+- [x] Testing strategy complete (3 unit suites extended)
+- [x] Naming + file structure per standards (mirrors #962 / InPost)
+- [x] Execution-ready (OQ-1/OQ-2 + live round-trip scoped to the spike / pre-merge AC)
+
+---
+
+## Related Documentation
+- Spec: [`product-spec-961-dpd-polska-shipping.md`](../specs/product-spec-961-dpd-polska-shipping.md)
+- #962 plan: [`implementation-plan-962-dpd-adapter-rest.md`](./implementation-plan-962-dpd-adapter-rest.md) · ADR-018
+- Reference: `libs/integrations/inpost/` (pickup slice), `libs/integrations/dpd-polska/` (#962)

--- a/libs/core/src/shipping/domain/types/generate-label.types.ts
+++ b/libs/core/src/shipping/domain/types/generate-label.types.ts
@@ -40,8 +40,11 @@ export interface GenerateLabelCommand {
    * own-contract adapters (InPost) ignore it. Source-brokered adapters that
    * require it MUST throw a readable error when it is absent. */
   deliveryMethodId?: string;
-  /** Required when `shippingMethod === 'paczkomat'`. Provider-issued
-   * locker id (e.g. `'POZ08A'`). */
+  /** Pickup-point id the parcel ships to. Required for the point-delivery
+   * methods — `'paczkomat'` (locker id, e.g. InPost `'POZ08A'`) and `'pickup'`
+   * (parcel-shop / PUDO id, e.g. DPD `'PL11033'`, #963). The field name is
+   * historical (InPost locker); it carries any provider's pickup-point id.
+   * Absent for `'kurier'`. */
   paczkomatId?: string;
   /** Recipient (buyer) — name, contact, optional postal address. The caller
    * resolves it from the order. Adapters require `recipient.address` for

--- a/libs/core/src/shipping/domain/types/shipment.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment.types.ts
@@ -34,7 +34,8 @@ export interface CreateShipmentInput {
   connectionId: string;
   /** Which shipping shape this attempt produces. */
   shippingMethod: ShippingMethod;
-  /** Required when `shippingMethod === 'paczkomat'`; absent for kurier. */
+  /** Pickup-point id — required for point-delivery methods (`'paczkomat'`
+   * locker, `'pickup'` parcel-shop/PUDO #963); absent for `'kurier'`. */
   paczkomatId?: string;
   /** Source-side delivery-method id (`OrderShipping.methodId`) this shipment
    * was routed from. Persisted for audit/forensics (which marketplace method

--- a/libs/core/src/shipping/domain/types/shipping-method.types.ts
+++ b/libs/core/src/shipping/domain/types/shipping-method.types.ts
@@ -8,11 +8,12 @@
  *
  * Two flavours of value live in the same union:
  *
- * - **Provider-issued methods** — `paczkomat`, `kurier` (and future ones
- *   for #732 Allegro Delivery): each maps to a different ShipX endpoint
- *   shape on the provider side, and a label-issuing
- *   `ShippingProviderManagerPort` adapter is the row's authoritative
- *   writer.
+ * - **Provider-issued methods** — `paczkomat` (locker), `pickup` (parcel-shop /
+ *   PUDO point — DPD Pickup #963; carrier-neutral, distinct from the
+ *   `paczkomat` locker), `kurier` (and future ones for #732 Allegro Delivery):
+ *   each maps to a different endpoint shape on the provider side, and a
+ *   label-issuing `ShippingProviderManagerPort` adapter is the row's
+ *   authoritative writer.
  * - **Projection-only methods** — `omp` (#834, ADR-012): branch-1
  *   shipments where the destination OMP ships externally and OL holds no
  *   provider id, no `labelPdfRef`. The row exists as a *projection* of
@@ -25,11 +26,12 @@
  * @module libs/core/src/shipping/domain/types
  */
 
-export const ShippingMethodValues = ['paczkomat', 'kurier', 'omp'] as const;
+export const ShippingMethodValues = ['paczkomat', 'pickup', 'kurier', 'omp'] as const;
 export type ShippingMethod = (typeof ShippingMethodValues)[number];
 
 export const SHIPPING_METHOD = {
   Paczkomat: 'paczkomat',
+  Pickup: 'pickup',
   Kurier: 'kurier',
   Omp: 'omp',
-} as const satisfies Record<'Paczkomat' | 'Kurier' | 'Omp', ShippingMethod>;
+} as const satisfies Record<'Paczkomat' | 'Pickup' | 'Kurier' | 'Omp', ShippingMethod>;

--- a/libs/integrations/dpd-polska/src/domain/types/dpd-rest.types.ts
+++ b/libs/integrations/dpd-polska/src/domain/types/dpd-rest.types.ts
@@ -28,8 +28,10 @@ export type DpdGenerationPolicy = (typeof DpdGenerationPolicyValues)[number];
 /** Status string that means success at every level of the body. */
 export const DPD_STATUS_OK = 'OK';
 
-/** ServiceCode values this adapter emits today (COD); the full enum is larger. */
+/** ServiceCode values this adapter emits today (COD, DPD_PICKUP); the full enum is larger. */
 export const DPD_SERVICE_CODE_COD = 'COD';
+/** Ship-to-point service for a DPD Pickup (parcel-shop / PUDO) delivery (#963). */
+export const DPD_SERVICE_CODE_DPD_PICKUP = 'DPD_PICKUP';
 
 /** COD/declared-value attribute keys (generic `code`/`value` attribute bag). */
 export const DPD_COD_ATTRIBUTE = {
@@ -79,10 +81,32 @@ export interface DpdParcel {
   customerData3?: string;
 }
 
+/**
+ * Receiver for a DPD Pickup (parcel-shop / PUDO) shipment (#963). The parcel is
+ * delivered to the chosen point (`pudoId`); the buyer contact is carried for
+ * pickup notifications. No street address — the point's own address applies.
+ *
+ * ⚠ OQ-2 (#963 plan): the exact field name (`pudoId` vs an id on `pudoReceiver`
+ * vs a `DPD_PICKUP` service attribute) is confirmed against the live
+ * `generatePackagesNumbers` Swagger during the Phase-0 spike; this is the
+ * documented/expected shape and is isolated here + in the mapper.
+ */
+export interface DpdPudoReceiver {
+  /** DPD Pickup point id (e.g. `PL11033`). */
+  pudoId: string;
+  company?: string;
+  name?: string;
+  phone?: string;
+  email?: string;
+}
+
 export interface DpdSinglePackage {
   reference?: string;
   sender: DpdSenderOrReceiver;
+  /** Courier-to-door receiver (street address). Mutually exclusive with `pudoReceiver`. */
   receiver?: DpdSenderOrReceiver;
+  /** Ship-to-point receiver for a DPD Pickup shipment (#963). */
+  pudoReceiver?: DpdPudoReceiver;
   /** Payer FID sub-number (numkat/fid). */
   payerFID: number;
   ref1?: string;
@@ -205,4 +229,50 @@ export interface DpdErrors {
 /** `401` body. */
 export interface DpdError401 {
   status?: string;
+}
+
+// --- pickup-point directory (#963) -------------------------------------------
+
+/**
+ * DPD Pickup point directory search (#963).
+ *
+ * ⚠ OQ-1 (#963 plan): whether the point directory lives in this REST
+ * `DPDServices` API (reuse `DpdHttpClient` + Basic auth) or a separate DPD
+ * Pickup finder service, plus the exact request/response field names and
+ * GET-vs-POST, is confirmed against the live Swagger in the Phase-0 spike.
+ * This is the documented/expected shape, isolated here + in the mapper so a
+ * later correction touches only these two files.
+ */
+export interface DpdPointSearchQuery {
+  city?: string;
+  postalCode?: string;
+  /** Free-text (street / name). */
+  searchText?: string;
+  countryCode?: string;
+  limit?: number;
+}
+
+export interface DpdPointAddress {
+  street?: string;
+  city?: string;
+  postalCode?: string;
+  countryCode?: string;
+}
+
+export interface DpdPoint {
+  /** Point id (e.g. `PL11033`) — the value sent back as `pudoReceiver.pudoId`. */
+  id: string;
+  name?: string;
+  address?: DpdPointAddress;
+  latitude?: number;
+  longitude?: number;
+  /** Provider-native point type (parcel shop vs locker), for diagnostics. */
+  type?: string;
+}
+
+export interface DpdPointSearchResponse {
+  /** Non-`'OK'` ⇒ search failed. */
+  status?: string;
+  points?: DpdPoint[];
+  traceId?: string;
 }

--- a/libs/integrations/dpd-polska/src/domain/types/dpd-rest.types.ts
+++ b/libs/integrations/dpd-polska/src/domain/types/dpd-rest.types.ts
@@ -248,7 +248,6 @@ export interface DpdPointSearchQuery {
   postalCode?: string;
   /** Free-text (street / name). */
   searchText?: string;
-  countryCode?: string;
   limit?: number;
 }
 

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-shipping.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-shipping.adapter.spec.ts
@@ -8,7 +8,11 @@
  *
  * @module libs/integrations/dpd-polska/src/infrastructure/adapters
  */
-import { ShippingProviderRejectionException, type GenerateLabelCommand } from '@openlinker/core/shipping';
+import {
+  isPickupPointFinder,
+  ShippingProviderRejectionException,
+  type GenerateLabelCommand,
+} from '@openlinker/core/shipping';
 import type { DpdConnectionConfig } from '../../../domain/types/dpd-config.types';
 import type { IDpdHttpClient } from '../../http/dpd-http-client.interface';
 import { DpdShippingAdapter } from '../dpd-shipping.adapter';
@@ -54,8 +58,12 @@ describe('DpdShippingAdapter', () => {
     adapter = new DpdShippingAdapter(http, makeConfig());
   });
 
-  it('should declare kurier as the only supported method', () => {
-    expect(adapter.getSupportedMethods()).toEqual(['kurier']);
+  it('should declare kurier and pickup as supported methods', () => {
+    expect(adapter.getSupportedMethods()).toEqual(['kurier', 'pickup']);
+  });
+
+  it('should declare the PickupPointFinder capability', () => {
+    expect(isPickupPointFinder(adapter)).toBe(true);
   });
 
   it('should create a shipment and return the waybill as provider id + tracking + label ref', async () => {
@@ -128,5 +136,44 @@ describe('DpdShippingAdapter', () => {
       providerName: 'dpd',
       providerCode: 'tracking.unavailable',
     });
+  });
+
+  it('should create a pickup shipment to a DPD point (pudoReceiver + DPD_PICKUP)', async () => {
+    http.request.mockResolvedValueOnce({
+      status: 'OK',
+      packages: [{ status: 'OK', parcels: [{ status: 'OK', waybill: 'WB-PUDO' }] }],
+    });
+
+    const result = await adapter.generateLabel(makeCmd({ shippingMethod: 'pickup', paczkomatId: 'PL11033' }));
+
+    expect(result.providerShipmentId).toBe('WB-PUDO');
+    const body = http.request.mock.calls[0][0].body as {
+      packages: Array<{ pudoReceiver?: { pudoId: string }; receiver?: unknown; services?: Array<{ code: string }> }>;
+    };
+    expect(body.packages[0].pudoReceiver).toMatchObject({ pudoId: 'PL11033' });
+    expect(body.packages[0].receiver).toBeUndefined();
+    expect((body.packages[0].services ?? []).map((s) => s.code)).toContain('DPD_PICKUP');
+  });
+
+  it('should search the DPD point directory via findPickupPoints', async () => {
+    http.request.mockResolvedValueOnce({
+      status: 'OK',
+      points: [
+        { id: 'PL11033', name: 'Żabka', address: { street: 'Krakowska 12', city: 'Poznań', postalCode: '60-001', countryCode: 'PL' } },
+      ],
+    });
+
+    const points = await adapter.findPickupPoints({ city: 'Poznań' });
+
+    expect(points).toHaveLength(1);
+    expect(points[0]).toMatchObject({ providerId: 'PL11033', name: 'Żabka', status: 'active' });
+    expect(http.request).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'POST', path: '/public/appservices/v1/findPoints', idempotent: true }),
+    );
+  });
+
+  it('should return an empty list when the directory has no points', async () => {
+    http.request.mockResolvedValueOnce({ status: 'OK' });
+    await expect(adapter.findPickupPoints({ city: 'Nowhere' })).resolves.toEqual([]);
   });
 });

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts
@@ -2,9 +2,10 @@
  * DPD Polska Shipping Adapter
  *
  * Implements the core `ShippingProviderManagerPort` plus the
- * `LabelDocumentReader` sub-capability against the DPDServices REST API. Thin
- * orchestration only: it delegates wire translation to `dpd-shipment.mapper`
- * and HTTP/retry/error-mapping to `IDpdHttpClient`.
+ * `LabelDocumentReader` and `PickupPointFinder` (#963 — DPD Pickup) sub-
+ * capabilities against the DPDServices REST API. Thin orchestration only: it
+ * delegates wire translation to `dpd-shipment.mapper` and HTTP/retry/error-
+ * mapping to `IDpdHttpClient`.
  *
  * Two-call flow: `generatePackagesNumbers` (create → waybill) then
  * `generateSpedLabels` (render → PDF) on demand. Business validation failures
@@ -19,10 +20,13 @@
  */
 import {
   ShippingProviderRejectionException,
+  type FindPickupPointsQuery,
   type GenerateLabelCommand,
   type GenerateLabelResult,
   type LabelDocument,
   type LabelDocumentReader,
+  type PickupPoint,
+  type PickupPointFinder,
   type ShippingMethod,
   type ShippingProviderManagerPort,
   type TrackingSnapshot,
@@ -31,22 +35,31 @@ import type { DpdConnectionConfig } from '../../domain/types/dpd-config.types';
 import type {
   DpdGeneratePackagesNumbersResponse,
   DpdGenerateSpedLabelsResponse,
+  DpdPointSearchResponse,
 } from '../../domain/types/dpd-rest.types';
 import type { IDpdHttpClient } from '../http/dpd-http-client.interface';
 import {
   assertCreateSucceededAndExtractWaybill,
   buildCreatePackagesRequest,
   buildGenerateLabelRequest,
+  buildPointSearchQuery,
   decodeLabelDocument,
   toGenerateLabelResult,
+  toPickupPoint,
 } from '../mappers/dpd-shipment.mapper';
 
-const SUPPORTED_METHODS: readonly ShippingMethod[] = ['kurier'];
+const SUPPORTED_METHODS: readonly ShippingMethod[] = ['kurier', 'pickup'];
 
 const CREATE_PATH = '/public/shipment/v1/generatePackagesNumbers';
 const LABEL_PATH = '/public/shipment/v1/generateSpedLabels';
+// OQ-1 (#963 plan): exact point-directory path/method/auth confirmed against the
+// live Swagger in the Phase-0 spike. DPDServices is POST-heavy (findPostalCode-
+// style), so v1 POSTs the query body; isolated here + in the mapper.
+const POINT_SEARCH_PATH = '/public/appservices/v1/findPoints';
 
-export class DpdShippingAdapter implements ShippingProviderManagerPort, LabelDocumentReader {
+export class DpdShippingAdapter
+  implements ShippingProviderManagerPort, LabelDocumentReader, PickupPointFinder
+{
   constructor(
     private readonly http: IDpdHttpClient,
     private readonly config: DpdConnectionConfig,
@@ -80,6 +93,17 @@ export class DpdShippingAdapter implements ShippingProviderManagerPort, LabelDoc
       idempotent: true,
     });
     return decodeLabelDocument(response);
+  }
+
+  async findPickupPoints(query: FindPickupPointsQuery): Promise<PickupPoint[]> {
+    // Idempotent read of the DPD Pickup point directory (#963).
+    const response = await this.http.request<DpdPointSearchResponse>({
+      method: 'POST',
+      path: POINT_SEARCH_PATH,
+      body: buildPointSearchQuery(query),
+      idempotent: true,
+    });
+    return (response.points ?? []).map(toPickupPoint);
   }
 
   getTracking(_input: { providerShipmentId: string }): Promise<TrackingSnapshot> {

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
@@ -14,12 +14,15 @@ import type {
   DpdGeneratePackagesNumbersResponse,
   DpdGenerateSpedLabelsResponse,
 } from '../../../domain/types/dpd-rest.types';
+import type { DpdPoint } from '../../../domain/types/dpd-rest.types';
 import {
   assertCreateSucceededAndExtractWaybill,
   buildCreatePackagesRequest,
   buildGenerateLabelRequest,
+  buildPointSearchQuery,
   decodeLabelDocument,
   toGenerateLabelResult,
+  toPickupPoint,
 } from '../dpd-shipment.mapper';
 
 function makeConfig(overrides: Partial<DpdConnectionConfig> = {}): DpdConnectionConfig {
@@ -178,8 +181,8 @@ describe('buildCreatePackagesRequest', () => {
   });
 
   it('should reject an unsupported shipping method', () => {
-    expect(() => buildCreatePackagesRequest(makeCmd({ shippingMethod: 'paczkomat' }), makeConfig())).toThrow(
-      /supports 'kurier' only/,
+    expect(() => buildCreatePackagesRequest(makeCmd({ shippingMethod: 'omp' }), makeConfig())).toThrow(
+      /'kurier' and 'pickup' only/,
     );
   });
 
@@ -193,6 +196,90 @@ describe('buildCreatePackagesRequest', () => {
     expect(() => buildCreatePackagesRequest(makeCmd({ parcel: {} }), makeConfig())).toThrow(
       /weightGrams is required/,
     );
+  });
+});
+
+describe('buildCreatePackagesRequest — DPD Pickup (#963)', () => {
+  function makePickupCmd(overrides: Partial<GenerateLabelCommand> = {}): GenerateLabelCommand {
+    return makeCmd({ shippingMethod: 'pickup', paczkomatId: 'PL11033', ...overrides });
+  }
+
+  it('should build a pudoReceiver + DPD_PICKUP service for a pickup shipment (no courier receiver)', () => {
+    const req = buildCreatePackagesRequest(makePickupCmd(), makeConfig());
+    const pkg = req.packages[0];
+
+    expect(pkg.receiver).toBeUndefined();
+    expect(pkg.pudoReceiver).toMatchObject({
+      pudoId: 'PL11033',
+      name: 'Jan Kowalski',
+      phone: '+48500600700',
+      email: 'buyer@example.com',
+    });
+    expect(pkg.services).toEqual([{ code: 'DPD_PICKUP' }]);
+    // Still a real parcel with weight.
+    expect(pkg.parcels[0].weight).toBe(1.5);
+  });
+
+  it('should reject a pickup shipment with no point id (paczkomatId)', () => {
+    const cmd = makePickupCmd({ paczkomatId: undefined });
+    const error = run(() => buildCreatePackagesRequest(cmd, makeConfig()));
+    expect(error).toMatchObject({ providerCode: 'preflight.missing-paczkomat-id' });
+  });
+
+  it('should NOT require a recipient street address for a pickup shipment', () => {
+    const cmd = makePickupCmd();
+    const noAddr = { ...cmd, recipient: { ...cmd.recipient, address: undefined } };
+    expect(() => buildCreatePackagesRequest(noAddr, makeConfig())).not.toThrow();
+  });
+
+  it('should still attach COD on a pickup shipment (DPD_PICKUP + COD)', () => {
+    const req = buildCreatePackagesRequest(
+      makePickupCmd({ cod: { amount: '39.99', currency: 'PLN' } }),
+      makeConfig(),
+    );
+    const codes = (req.packages[0].services ?? []).map((s) => s.code);
+    expect(codes).toEqual(['DPD_PICKUP', 'COD']);
+  });
+
+  it('should reject an unsupported method with a kurier/pickup message', () => {
+    expect(() => buildCreatePackagesRequest(makeCmd({ shippingMethod: 'omp' }), makeConfig())).toThrow(
+      /'kurier' and 'pickup' only/,
+    );
+  });
+});
+
+describe('point directory mapping (#963)', () => {
+  it('should map a neutral query to the DPD point-search shape', () => {
+    expect(
+      buildPointSearchQuery({ city: 'Poznań', postalCode: '60-001', searchText: 'Krakowska', limit: 20 }),
+    ).toEqual({ city: 'Poznań', postalCode: '60-001', searchText: 'Krakowska', limit: 20 });
+  });
+
+  it('should map a DPD point to the neutral PickupPoint', () => {
+    const point: DpdPoint = {
+      id: 'PL11033',
+      name: 'DPD Pickup Żabka',
+      address: { street: 'Krakowska 12', city: 'Poznań', postalCode: '60-001', countryCode: 'PL' },
+      latitude: 52.4,
+      longitude: 16.9,
+      type: 'shop',
+    };
+
+    expect(toPickupPoint(point)).toEqual({
+      providerId: 'PL11033',
+      name: 'DPD Pickup Żabka',
+      address: { line1: 'Krakowska 12', city: 'Poznań', postalCode: '60-001', country: 'PL' },
+      status: 'active',
+      lat: 52.4,
+      lon: 16.9,
+    });
+  });
+
+  it('should fall back to the point id for the name and PL for the country when absent', () => {
+    const point: DpdPoint = { id: 'PL999' };
+    const mapped = toPickupPoint(point);
+    expect(mapped.name).toBe('PL999');
+    expect(mapped.address.country).toBe('PL');
   });
 });
 

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
@@ -86,6 +86,9 @@ describe('buildCreatePackagesRequest', () => {
     expect(pkg.payerFID).toBe(1495); // numeric, parsed from the '1495' string
     expect(pkg.sender).toMatchObject({ name: 'Sklep ACME', address: 'Magazynowa 1', city: 'Warszawa' });
     expect(pkg.services).toBeUndefined();
+    // Courier ships to a street receiver — never a pudoReceiver (mutual exclusivity).
+    expect(pkg.pudoReceiver).toBeUndefined();
+    expect(pkg.receiver).toBeDefined();
     expect(pkg.parcels).toHaveLength(1);
   });
 

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
@@ -14,14 +14,17 @@
  * @module libs/integrations/dpd-polska/src/infrastructure/mappers
  */
 import type {
+  FindPickupPointsQuery,
   GenerateLabelCommand,
   GenerateLabelResult,
   LabelDocument,
+  PickupPoint,
+  PickupPointAddress,
   ShipmentAddress,
   ShipmentCod,
   ShipmentRecipient,
 } from '@openlinker/core/shipping';
-import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
+import { PICKUP_POINT_STATUS, ShippingProviderRejectionException } from '@openlinker/core/shipping';
 import type { DpdConnectionConfig, DpdSenderContact } from '../../domain/types/dpd-config.types';
 import type {
   DpdGeneratePackagesNumbersRequest,
@@ -29,61 +32,104 @@ import type {
   DpdGenerateSpedLabelsRequest,
   DpdGenerateSpedLabelsResponse,
   DpdParcel,
+  DpdPoint,
+  DpdPointSearchQuery,
+  DpdPudoReceiver,
   DpdSenderOrReceiver,
+  DpdSinglePackage,
   DpdTransportService,
   DpdValidationInfo,
 } from '../../domain/types/dpd-rest.types';
 import {
   DPD_COD_ATTRIBUTE,
   DPD_SERVICE_CODE_COD,
+  DPD_SERVICE_CODE_DPD_PICKUP,
   DPD_STATUS_OK,
   DpdCodCurrencyValues,
 } from '../../domain/types/dpd-rest.types';
 
 const DPD_BRAND = 'dpd';
 
-/** Build the create-packages request for the command (v1: one package, one parcel). */
+/**
+ * Build the create-packages request for the command (v1: one package, one
+ * parcel). Branches on shipping method: `kurier` → courier `receiver` (street
+ * address); `pickup` → `pudoReceiver` + the `DPD_PICKUP` service (ship to a DPD
+ * Pickup parcel-shop / PUDO point, #963). COD applies to either.
+ */
 export function buildCreatePackagesRequest(
   cmd: GenerateLabelCommand,
   config: DpdConnectionConfig,
 ): DpdGeneratePackagesNumbersRequest {
-  if (cmd.shippingMethod !== 'kurier') {
+  if (cmd.shippingMethod !== 'kurier' && cmd.shippingMethod !== 'pickup') {
     throw new ShippingProviderRejectionException(
       DPD_BRAND,
       'preflight.unsupported-method',
-      `DPD Polska supports 'kurier' only; got '${String(cmd.shippingMethod)}'`,
+      `DPD Polska supports 'kurier' and 'pickup' only; got '${String(cmd.shippingMethod)}'`,
     );
   }
-  if (!cmd.recipient.address) {
-    throw new ShippingProviderRejectionException(
-      DPD_BRAND,
-      'preflight.missing-recipient-address',
-      'recipient.address is required for a DPD courier shipment',
-    );
-  }
+  // Both methods carry a physical parcel → weight is always required.
   if (cmd.parcel.weightGrams === undefined) {
     throw new ShippingProviderRejectionException(
       DPD_BRAND,
       'preflight.missing-dimensions-or-weight',
-      'parcel.weightGrams is required for a DPD courier shipment',
+      'parcel.weightGrams is required for a DPD shipment',
     );
   }
 
-  const services = cmd.cod ? [buildCodService(cmd.cod)] : undefined;
+  const isPickup = cmd.shippingMethod === 'pickup';
 
+  const services: DpdTransportService[] = [];
+  if (isPickup) {
+    services.push({ code: DPD_SERVICE_CODE_DPD_PICKUP });
+  }
+  if (cmd.cod) {
+    services.push(buildCodService(cmd.cod));
+  }
+
+  const pkg: DpdSinglePackage = {
+    reference: cmd.shipmentId,
+    ref1: cmd.orderId,
+    sender: toSenderPeer(config.senderAddress),
+    payerFID: Number(config.payerFid),
+    services: services.length > 0 ? services : undefined,
+    parcels: [toParcel(cmd)],
+  };
+
+  if (isPickup) {
+    pkg.pudoReceiver = toPudoReceiver(cmd);
+  } else {
+    if (!cmd.recipient.address) {
+      throw new ShippingProviderRejectionException(
+        DPD_BRAND,
+        'preflight.missing-recipient-address',
+        'recipient.address is required for a DPD courier shipment',
+      );
+    }
+    pkg.receiver = toReceiverPeer(cmd.recipient, cmd.recipient.address);
+  }
+
+  return { generationPolicy: 'ALL_OR_NOTHING', packages: [pkg] };
+}
+
+/** Map a neutral pickup-point query to the DPD point-directory search shape. */
+export function buildPointSearchQuery(query: FindPickupPointsQuery): DpdPointSearchQuery {
   return {
-    generationPolicy: 'ALL_OR_NOTHING',
-    packages: [
-      {
-        reference: cmd.shipmentId,
-        ref1: cmd.orderId,
-        sender: toSenderPeer(config.senderAddress),
-        receiver: toReceiverPeer(cmd.recipient, cmd.recipient.address),
-        payerFID: Number(config.payerFid),
-        services,
-        parcels: [toParcel(cmd)],
-      },
-    ],
+    city: query.city,
+    postalCode: query.postalCode,
+    searchText: query.searchText,
+    limit: query.limit,
+  };
+}
+
+/** Map a DPD Pickup point to the neutral `PickupPoint`. */
+export function toPickupPoint(point: DpdPoint): PickupPoint {
+  return {
+    providerId: point.id,
+    name: point.name ?? point.id,
+    address: toPickupPointAddress(point),
+    status: PICKUP_POINT_STATUS.Active,
+    lat: point.latitude,
+    lon: point.longitude,
   };
 }
 
@@ -194,6 +240,36 @@ function toParcel(cmd: GenerateLabelCommand): DpdParcel {
     parcel.sizeZ = height / 10;
   }
   return parcel;
+}
+
+/**
+ * Build the DPD Pickup `pudoReceiver` from the command — the point id (carried
+ * on the generic `paczkomatId` field) + the buyer contact for pickup
+ * notifications. No street address (the point's own address applies).
+ */
+function toPudoReceiver(cmd: GenerateLabelCommand): DpdPudoReceiver {
+  if (!cmd.paczkomatId) {
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      'preflight.missing-paczkomat-id',
+      'paczkomatId (the DPD Pickup point id) is required for a pickup shipment',
+    );
+  }
+  return {
+    pudoId: cmd.paczkomatId,
+    name: resolveRecipientName(cmd.recipient),
+    phone: cmd.recipient.phone,
+    email: cmd.recipient.email,
+  };
+}
+
+function toPickupPointAddress(point: DpdPoint): PickupPointAddress {
+  return {
+    line1: point.address?.street ?? '',
+    city: point.address?.city ?? '',
+    postalCode: point.address?.postalCode ?? '',
+    country: point.address?.countryCode ?? 'PL',
+  };
 }
 
 function toSenderPeer(sender: DpdSenderContact): DpdSenderOrReceiver {

--- a/libs/integrations/dpd-polska/src/testing/__tests__/fake-dpd-shipping.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/testing/__tests__/fake-dpd-shipping.adapter.spec.ts
@@ -33,8 +33,8 @@ describe('FakeDpdShippingAdapter', () => {
     adapter = new FakeDpdShippingAdapter();
   });
 
-  it('should support only kurier', () => {
-    expect(adapter.getSupportedMethods()).toEqual(['kurier']);
+  it('should support kurier and pickup', () => {
+    expect(adapter.getSupportedMethods()).toEqual(['kurier', 'pickup']);
   });
 
   it('should generate a deterministic, incrementing waybill', async () => {
@@ -58,6 +58,27 @@ describe('FakeDpdShippingAdapter', () => {
     await expect(
       adapter.generateLabel({ ...cmd, recipient: { ...cmd.recipient, address: undefined } }),
     ).rejects.toMatchObject({ providerCode: 'preflight.missing-recipient-address' });
+  });
+
+  it('should generate a pickup shipment when a point id is supplied', async () => {
+    const result = await adapter.generateLabel(makeCmd({ shippingMethod: 'pickup', paczkomatId: 'PL11033' }));
+    expect(result.providerShipmentId).toBe('fake-dpd-1');
+  });
+
+  it('should reject a pickup shipment with no point id', async () => {
+    await expect(adapter.generateLabel(makeCmd({ shippingMethod: 'pickup' }))).rejects.toMatchObject({
+      providerCode: 'preflight.missing-paczkomat-id',
+    });
+  });
+
+  it('should return seeded pickup points and clear them on reset', async () => {
+    adapter.seedPickupPoints([
+      { providerId: 'PL11033', name: 'Żabka', address: { line1: 'Krakowska 12', city: 'Poznań', postalCode: '60-001', country: 'PL' }, status: 'active' },
+    ]);
+    await expect(adapter.findPickupPoints({ city: 'Poznań' })).resolves.toHaveLength(1);
+
+    adapter.clear();
+    await expect(adapter.findPickupPoints({ city: 'Poznań' })).resolves.toEqual([]);
   });
 
   it('should return a PDF label document', async () => {

--- a/libs/integrations/dpd-polska/src/testing/fake-dpd-shipping.adapter.ts
+++ b/libs/integrations/dpd-polska/src/testing/fake-dpd-shipping.adapter.ts
@@ -1,12 +1,12 @@
 /**
  * Fake DPD Polska Shipping Adapter
  *
- * In-memory `ShippingProviderManagerPort` (+ `LabelDocumentReader`) for
- * plugin-author / consumer unit tests that need deterministic shipping
- * behaviour without hitting DPDServices. Mirrors the real adapter's observable
- * contract — including the courier pre-submit validation and the
- * `getTracking` throw — and adds `seed*` / `clear` helpers for arranging test
- * state.
+ * In-memory `ShippingProviderManagerPort` (+ `LabelDocumentReader`,
+ * `PickupPointFinder`) for plugin-author / consumer unit tests that need
+ * deterministic shipping behaviour without hitting DPDServices. Mirrors the
+ * real adapter's observable contract — courier + pickup pre-submit validation,
+ * seeded pickup points, and the `getTracking` throw — and adds `seed*` /
+ * `clear` helpers for arranging test state.
  *
  * Consumed only from `*.spec.ts` via `@openlinker/integrations-dpd-polska/testing`,
  * never from runtime code.
@@ -15,20 +15,26 @@
  */
 import {
   ShippingProviderRejectionException,
+  type FindPickupPointsQuery,
   type GenerateLabelCommand,
   type GenerateLabelResult,
   type LabelDocument,
   type LabelDocumentReader,
+  type PickupPoint,
+  type PickupPointFinder,
   type ShippingMethod,
   type ShippingProviderManagerPort,
   type TrackingSnapshot,
 } from '@openlinker/core/shipping';
 
-const SUPPORTED_METHODS: readonly ShippingMethod[] = ['kurier'];
+const SUPPORTED_METHODS: readonly ShippingMethod[] = ['kurier', 'pickup'];
 
-export class FakeDpdShippingAdapter implements ShippingProviderManagerPort, LabelDocumentReader {
+export class FakeDpdShippingAdapter
+  implements ShippingProviderManagerPort, LabelDocumentReader, PickupPointFinder
+{
   private counter = 0;
   private seededFailure: Error | null = null;
+  private seededPoints: PickupPoint[] = [];
 
   getSupportedMethods(): readonly ShippingMethod[] {
     return SUPPORTED_METHODS;
@@ -38,16 +44,25 @@ export class FakeDpdShippingAdapter implements ShippingProviderManagerPort, Labe
     if (this.seededFailure) {
       return Promise.reject(this.seededFailure);
     }
-    if (cmd.shippingMethod !== 'kurier') {
+    if (cmd.shippingMethod !== 'kurier' && cmd.shippingMethod !== 'pickup') {
       return Promise.reject(
         new ShippingProviderRejectionException(
           'dpd',
           'preflight.unsupported-method',
-          `DPD Polska supports 'kurier' only; got '${String(cmd.shippingMethod)}'`,
+          `DPD Polska supports 'kurier' and 'pickup' only; got '${String(cmd.shippingMethod)}'`,
         ),
       );
     }
-    if (!cmd.recipient.address) {
+    if (cmd.shippingMethod === 'pickup' && !cmd.paczkomatId) {
+      return Promise.reject(
+        new ShippingProviderRejectionException(
+          'dpd',
+          'preflight.missing-paczkomat-id',
+          'paczkomatId (the DPD Pickup point id) is required for a pickup shipment',
+        ),
+      );
+    }
+    if (cmd.shippingMethod === 'kurier' && !cmd.recipient.address) {
       return Promise.reject(
         new ShippingProviderRejectionException(
           'dpd',
@@ -58,6 +73,10 @@ export class FakeDpdShippingAdapter implements ShippingProviderManagerPort, Labe
     }
     const waybill = `fake-dpd-${(this.counter += 1)}`;
     return Promise.resolve({ providerShipmentId: waybill, trackingNumber: waybill, labelPdfRef: waybill });
+  }
+
+  findPickupPoints(_query: FindPickupPointsQuery): Promise<PickupPoint[]> {
+    return Promise.resolve([...this.seededPoints]);
   }
 
   fetchLabel(_input: { providerShipmentId: string }): Promise<LabelDocument> {
@@ -87,9 +106,15 @@ export class FakeDpdShippingAdapter implements ShippingProviderManagerPort, Labe
     this.seededFailure = error;
   }
 
+  /** Set the points returned by `findPickupPoints`. */
+  seedPickupPoints(points: readonly PickupPoint[]): void {
+    this.seededPoints = [...points];
+  }
+
   /** Reset all in-memory state between tests. */
   clear(): void {
     this.counter = 0;
     this.seededFailure = null;
+    this.seededPoints = [];
   }
 }


### PR DESCRIPTION
## What & why

Adds DPD Pickup (parcel-shop / PUDO) delivery to `@openlinker/integrations-dpd-polska` — the third DPD child after the #962 adapter foundation. Part of #961.

## Changes

**CORE (one additive value, no migration):**
- New `'pickup'` `ShippingMethod` value — the carrier-neutral "ship to a parcel-shop / PUDO point" method, distinct from `'paczkomat'` (locker). `shipping_method` is a `text` column → no migration; `@IsEnum(ShippingMethodValues)` DTOs auto-accept it; no exhaustive `never`-switch to update (verified by a full build across all 13 projects).
- Fixed the `paczkomatId` contract docs (command + create-input + generate-label DTO) — it now carries the pickup-point id for **both** `'paczkomat'` and `'pickup'`.

**Integration (`libs/integrations/dpd-polska/`):**
- `DpdShippingAdapter` now implements `PickupPointFinder` — `findPickupPoints` against the DPD point directory; `getSupportedMethods()` = `['kurier','pickup']`.
- Mapper **pickup branch**: `shippingMethod==='pickup'` builds a `pudoReceiver` (point id from `cmd.paczkomatId`) + the `DPD_PICKUP` `TransportService` instead of the courier `receiver`; COD still applies; weight still required.
- Point-directory mapping (`buildPointSearchQuery` / `toPickupPoint`), types (`DpdPudoReceiver`, `DPD_SERVICE_CODE_DPD_PICKUP`, point-search shapes), and `FakeDpdShippingAdapter` gains `findPickupPoints`.

## Architecture notes

- **No core/Allegro/order changes needed** — the dispatch path is already carrier-agnostic: Allegro reads `delivery.pickupPoint.id` carrier-blind into the order snapshot, and the point id rides the generic `paczkomatId` command field. A DPD point (`PL11033`) flows through unchanged.
- **Manifest unchanged** — `PickupPointFinder` is a sub-capability discovered via the `isPickupPointFinder` guard (matches the InPost pattern); the manifest still declares only `ShippingProviderManager`.
- **FE is #966** — the FE `ShippingMethodValues` mirror is standalone (not core-imported), so `apps/web` is unaffected; widening it + offering `'pickup'` in the generate-label form + the picker modal are #966's scope. Until then DPD pickup is backend-capable but FE-dormant (mirrors #962: COD backend shipped, operator entry = #966).

## Testing

- 68 unit tests across 5 suites (pickup-branch mapping, point-directory mapping, `isPickupPointFinder` capability presence, `findPickupPoints`, fake). Full repo `type-check` + `lint` + invariants green; **backend unit tests 2725 green**.

## Remaining (pre-merge AC)

- [ ] **Confirm OQ-1/OQ-2 against the live DPDServices Swagger + manual round-trip**: the point-directory endpoint (`POINT_SEARCH_PATH`) and the `pudoReceiver`/`DPD_PICKUP` wire shape are the documented/expected forms, isolated in the types + mapper + a single constant. Confirming them is the Phase-0 spike + the live finder/ship-to-point round-trip — gated on the #962 test-server creds, same pattern as #962.

Plan: `docs/plans/implementation-plan-963-dpd-pickup-points.md`

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)