### PR TITLE
feat(shipping): bulk label dispatch + DPD handover protocol (#964)

### DIFF
--- a/apps/api/src/shipping/http/dto/bulk-dispatch-result-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/bulk-dispatch-result-response.dto.ts
@@ -1,0 +1,55 @@
+/**
+ * Bulk Dispatch Result Response DTO
+ *
+ * Response for POST /shipments/bulk/generate-labels (#964). Mirrors the core
+ * `BulkShipmentDispatchResult` — a per-order outcome list. Each entry carries
+ * its `orderId` and `kind`: `dispatched` includes the created shipment;
+ * `omp_fulfilled` includes none (OMP ships externally); `failed` includes the
+ * error message (the partial-failure case — successful siblings are untouched).
+ *
+ * The handover protocol is NOT in this response (it streams as binary from the
+ * separate protocol endpoint); the FE collects the dispatched shipment ids from
+ * `results` and requests the protocol over them.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { BulkShipmentDispatchResult, PerOrderDispatchResult } from '@openlinker/core/shipping';
+import { ShipmentResponseDto } from './shipment-response.dto';
+
+export class PerOrderDispatchResultDto {
+  @ApiProperty({ enum: ['dispatched', 'omp_fulfilled', 'failed'] })
+  kind!: 'dispatched' | 'omp_fulfilled' | 'failed';
+
+  @ApiProperty({ description: 'Internal order id (ol_order_*) this result is for' })
+  orderId!: string;
+
+  @ApiPropertyOptional({ type: ShipmentResponseDto, description: 'Present only when kind=dispatched' })
+  shipment?: ShipmentResponseDto;
+
+  @ApiPropertyOptional({ description: 'Present only when kind=failed — the rejection message' })
+  error?: string;
+
+  static fromResult(result: PerOrderDispatchResult): PerOrderDispatchResultDto {
+    const dto = new PerOrderDispatchResultDto();
+    dto.kind = result.kind;
+    dto.orderId = result.orderId;
+    if (result.kind === 'dispatched') {
+      dto.shipment = ShipmentResponseDto.fromDomain(result.shipment);
+    } else if (result.kind === 'failed') {
+      dto.error = result.error;
+    }
+    return dto;
+  }
+}
+
+export class BulkDispatchResultResponseDto {
+  @ApiProperty({ type: [PerOrderDispatchResultDto] })
+  results!: PerOrderDispatchResultDto[];
+
+  static fromResult(result: BulkShipmentDispatchResult): BulkDispatchResultResponseDto {
+    const dto = new BulkDispatchResultResponseDto();
+    dto.results = result.results.map((r) => PerOrderDispatchResultDto.fromResult(r));
+    return dto;
+  }
+}

--- a/apps/api/src/shipping/http/dto/bulk-generate-labels.dto.ts
+++ b/apps/api/src/shipping/http/dto/bulk-generate-labels.dto.ts
@@ -1,0 +1,46 @@
+/**
+ * Bulk Generate Labels DTO
+ *
+ * Request body for POST /shipments/bulk/generate-labels (#964). One shared
+ * `sourceConnectionId` (the bulk scope) plus N per-order payloads. Each item is
+ * the single-dispatch `GenerateLabelDto` minus `sourceConnectionId` (via
+ * `OmitType`, which carries every nested validation rule), so the bulk and
+ * single surfaces can't drift.
+ *
+ * Capped at 25 items (ADR-019): v1 dispatches synchronously by looping the
+ * per-order seam — N sequential outbound calls in one request — so the cap
+ * bounds request wall-clock. NOT the bulk-offer 100 cap (that surface fans out
+ * to async workers). The cap is removable once the prepare/execute split or a
+ * durable batch lands.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsUUID, ValidateNested } from 'class-validator';
+import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { GenerateLabelDto } from './generate-label.dto';
+
+/** A single order's dispatch payload within a bulk request (sans the shared connection). */
+export class BulkDispatchItemDto extends OmitType(GenerateLabelDto, ['sourceConnectionId'] as const) {}
+
+/** Max items per synchronous bulk dispatch (ADR-019 §"Synchronous-cap bound"). */
+export const BULK_DISPATCH_MAX_ITEMS = 25;
+
+export class BulkGenerateLabelsDto {
+  @ApiProperty({ description: 'Order-source connection id shared by every item (the bulk scope)' })
+  @IsUUID()
+  sourceConnectionId!: string;
+
+  @ApiProperty({
+    type: [BulkDispatchItemDto],
+    minItems: 1,
+    maxItems: BULK_DISPATCH_MAX_ITEMS,
+    description: `Per-order dispatch payloads (1..${BULK_DISPATCH_MAX_ITEMS}).`,
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(BULK_DISPATCH_MAX_ITEMS)
+  @ValidateNested({ each: true })
+  @Type(() => BulkDispatchItemDto)
+  items!: BulkDispatchItemDto[];
+}

--- a/apps/api/src/shipping/http/dto/generate-protocol.dto.ts
+++ b/apps/api/src/shipping/http/dto/generate-protocol.dto.ts
@@ -1,0 +1,31 @@
+/**
+ * Generate Protocol DTO
+ *
+ * Request body for POST /shipments/bulk/protocol (#964). The OL shipment ids
+ * (typically the dispatched ids from a prior bulk dispatch) to cover with one
+ * carrier handover protocol. The service derives the carrier connection +
+ * provider waybills from the persisted rows and asserts a single connection, so
+ * the client never supplies a connection id or waybills directly.
+ *
+ * Capped at the same 25 as the dispatch (ADR-019): one protocol per bulk action.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { BULK_DISPATCH_MAX_ITEMS } from './bulk-generate-labels.dto';
+
+export class GenerateProtocolDto {
+  @ApiProperty({
+    type: [String],
+    minItems: 1,
+    maxItems: BULK_DISPATCH_MAX_ITEMS,
+    description: `OL shipment ids (ol_shipment_*) to cover with one handover protocol (1..${BULK_DISPATCH_MAX_ITEMS}).`,
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(BULK_DISPATCH_MAX_ITEMS)
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  shipmentIds!: string[];
+}

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -16,12 +16,15 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import {
+  type IBulkShipmentDispatchService,
   type IShipmentCancellationService,
   type IShipmentDispatchNotificationService,
   type IShipmentDispatchService,
   type IShipmentLabelService,
   type IShipmentQueryService,
   type LabelDocument,
+  DispatchProtocolNotSupportedException,
+  InvalidProtocolBatchException,
   LabelDocumentNotSupportedException,
   LabelNotAvailableException,
   Shipment,
@@ -37,6 +40,7 @@ import type { IOrderRecordService, OrderRecord } from '@openlinker/core/orders';
 import type { Response } from 'express';
 
 import { ShipmentController, extensionForContentType } from './shipment.controller';
+import type { BulkGenerateLabelsDto } from './dto/bulk-generate-labels.dto';
 import type { GenerateLabelDto } from './dto/generate-label.dto';
 import type { ListShipmentsQueryDto } from './dto/list-shipments-query.dto';
 
@@ -77,6 +81,7 @@ function makeGenerateLabelDto(overrides: Partial<GenerateLabelDto> = {}): Genera
 describe('ShipmentController', () => {
   let query: jest.Mocked<IShipmentQueryService>;
   let dispatch: jest.Mocked<IShipmentDispatchService>;
+  let bulkDispatch: jest.Mocked<IBulkShipmentDispatchService>;
   let cancellation: jest.Mocked<IShipmentCancellationService>;
   let notification: jest.Mocked<IShipmentDispatchNotificationService>;
   let labelService: jest.Mocked<IShipmentLabelService>;
@@ -90,6 +95,7 @@ describe('ShipmentController', () => {
       getActiveByOrderId: jest.fn(),
     };
     dispatch = { dispatch: jest.fn() };
+    bulkDispatch = { dispatchBulk: jest.fn(), generateProtocol: jest.fn() };
     cancellation = { cancel: jest.fn() };
     notification = { notifyDispatched: jest.fn() };
     labelService = { fetchLabel: jest.fn() };
@@ -104,6 +110,7 @@ describe('ShipmentController', () => {
     controller = new ShipmentController(
       query,
       dispatch,
+      bulkDispatch,
       cancellation,
       notification,
       labelService,
@@ -273,6 +280,106 @@ describe('ShipmentController', () => {
       dispatch.dispatch.mockRejectedValue(new Error('something broke'));
       await expect(controller.generateLabel(makeGenerateLabelDto())).rejects.toBeInstanceOf(
         InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('bulkGenerateLabels (#964)', () => {
+    function makeBulkDto(): BulkGenerateLabelsDto {
+      return {
+        sourceConnectionId: 'a1b2c3d4-0000-4000-8000-000000000002',
+        items: [
+          {
+            orderId: 'ol_order_1',
+            shippingMethod: 'kurier',
+            recipient: { email: 'a@example.com', phone: '+48500600700' },
+            parcel: { weightGrams: 1000 },
+          },
+          {
+            orderId: 'ol_order_2',
+            sourceDeliveryMethodId: 'dm-9',
+            shippingMethod: 'kurier',
+            recipient: { email: 'b@example.com', phone: '+48500600701' },
+            parcel: { weightGrams: 1500 },
+          },
+        ],
+      } as BulkGenerateLabelsDto;
+    }
+
+    it('should map each item (defaulting source method to null) and return the per-order results', async () => {
+      bulkDispatch.dispatchBulk.mockResolvedValue({
+        results: [
+          { kind: 'dispatched', orderId: 'ol_order_1', shipment: makeShipment({ orderId: 'ol_order_1' }) },
+          { kind: 'failed', orderId: 'ol_order_2', error: 'carrier rejected' },
+        ],
+      });
+
+      const result = await controller.bulkGenerateLabels(makeBulkDto());
+
+      const call = bulkDispatch.dispatchBulk.mock.calls[0][0];
+      expect(call.sourceConnectionId).toBe('a1b2c3d4-0000-4000-8000-000000000002');
+      expect(call.items[0]).toMatchObject({ orderId: 'ol_order_1', sourceDeliveryMethodId: null });
+      expect(call.items[1]).toMatchObject({ orderId: 'ol_order_2', sourceDeliveryMethodId: 'dm-9' });
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0]).toMatchObject({ kind: 'dispatched', orderId: 'ol_order_1' });
+      expect(result.results[1]).toMatchObject({ kind: 'failed', orderId: 'ol_order_2', error: 'carrier rejected' });
+    });
+  });
+
+  describe('downloadProtocol (#964)', () => {
+    function makeRes(): { res: Response; setHeader: jest.Mock; send: jest.Mock } {
+      const setHeader = jest.fn();
+      const send = jest.fn();
+      const res = { setHeader, send } as unknown as Response;
+      return { res, setHeader, send };
+    }
+
+    it('should stream the protocol PDF with attachment disposition', async () => {
+      bulkDispatch.generateProtocol.mockResolvedValue({
+        contentType: 'application/pdf',
+        body: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+      });
+      const { res, setHeader, send } = makeRes();
+
+      await controller.downloadProtocol({ shipmentIds: ['ol_shipment_1', 'ol_shipment_2'] }, res);
+
+      expect(bulkDispatch.generateProtocol).toHaveBeenCalledWith({
+        shipmentIds: ['ol_shipment_1', 'ol_shipment_2'],
+      });
+      expect(setHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+      expect(setHeader).toHaveBeenCalledWith(
+        'Content-Disposition',
+        'attachment; filename="ol-handover-protocol.pdf"',
+      );
+      expect(send).toHaveBeenCalled();
+    });
+
+    it('should map InvalidProtocolBatchException to 400', async () => {
+      bulkDispatch.generateProtocol.mockRejectedValue(new InvalidProtocolBatchException('mixed carriers'));
+      const { res } = makeRes();
+
+      await expect(controller.downloadProtocol({ shipmentIds: ['x'] }, res)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('should map DispatchProtocolNotSupportedException to 422', async () => {
+      bulkDispatch.generateProtocol.mockRejectedValue(new DispatchProtocolNotSupportedException('conn-x'));
+      const { res } = makeRes();
+
+      await expect(controller.downloadProtocol({ shipmentIds: ['x'] }, res)).rejects.toBeInstanceOf(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('should map ShippingProviderRejectionException to 502', async () => {
+      bulkDispatch.generateProtocol.mockRejectedValue(
+        new ShippingProviderRejectionException('dpd', 'PROTOCOL_ERROR', 'boom'),
+      );
+      const { res } = makeRes();
+
+      await expect(controller.downloadProtocol({ shipmentIds: ['x'] }, res)).rejects.toBeInstanceOf(
+        BadGatewayException,
       );
     });
   });

--- a/apps/api/src/shipping/http/shipment.controller.ts
+++ b/apps/api/src/shipping/http/shipment.controller.ts
@@ -40,18 +40,23 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import {
+  type IBulkShipmentDispatchService,
   type IShipmentCancellationService,
   type IShipmentDispatchNotificationService,
   type IShipmentDispatchService,
   type IShipmentLabelService,
   type IShipmentQueryService,
+  type BulkShipmentDispatchItem,
   type ShipmentDispatchInput,
   type ShipmentFilters,
+  BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN,
   SHIPMENT_CANCELLATION_SERVICE_TOKEN,
   SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
   SHIPMENT_DISPATCH_SERVICE_TOKEN,
   SHIPMENT_LABEL_SERVICE_TOKEN,
   SHIPMENT_QUERY_SERVICE_TOKEN,
+  DispatchProtocolNotSupportedException,
+  InvalidProtocolBatchException,
   LabelDocumentNotSupportedException,
   LabelNotAvailableException,
   ShipmentCancellationNotSupportedException,
@@ -64,8 +69,11 @@ import {
 import { type IOrderRecordService, ORDER_RECORD_SERVICE_TOKEN } from '@openlinker/core/orders';
 import { Logger } from '@openlinker/shared/logging';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { BulkDispatchResultResponseDto } from './dto/bulk-dispatch-result-response.dto';
+import { BulkGenerateLabelsDto } from './dto/bulk-generate-labels.dto';
 import { DispatchResultResponseDto } from './dto/dispatch-result-response.dto';
 import { GenerateLabelDto } from './dto/generate-label.dto';
+import { GenerateProtocolDto } from './dto/generate-protocol.dto';
 import { ListShipmentsQueryDto } from './dto/list-shipments-query.dto';
 import { NotifyDispatchedResponseDto } from './dto/notify-dispatched-response.dto';
 import { PaginatedShipmentsResponseDto } from './dto/paginated-shipments-response.dto';
@@ -83,6 +91,8 @@ export class ShipmentController {
     private readonly query: IShipmentQueryService,
     @Inject(SHIPMENT_DISPATCH_SERVICE_TOKEN)
     private readonly dispatch: IShipmentDispatchService,
+    @Inject(BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN)
+    private readonly bulkDispatch: IBulkShipmentDispatchService,
     @Inject(SHIPMENT_CANCELLATION_SERVICE_TOKEN)
     private readonly cancellation: IShipmentCancellationService,
     @Inject(SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN)
@@ -209,6 +219,68 @@ export class ShipmentController {
     }
   }
 
+  @Post('bulk/generate-labels')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Dispatch labels for up to 25 orders in one action (#964)',
+    description:
+      'Synchronous bulk dispatch: loops the per-order dispatch seam, isolating ' +
+      'each order so a partial failure keeps the successful labels. Returns a ' +
+      'per-order outcome list (200 even on partial failure). Fetch the handover ' +
+      'protocol over the dispatched shipments via POST /shipments/bulk/protocol.',
+  })
+  @ApiResponse({ status: 200, type: BulkDispatchResultResponseDto })
+  async bulkGenerateLabels(
+    @Body() dto: BulkGenerateLabelsDto,
+  ): Promise<BulkDispatchResultResponseDto> {
+    const items: BulkShipmentDispatchItem[] = dto.items.map((item) => ({
+      sourceDeliveryMethodId: item.sourceDeliveryMethodId ?? null,
+      orderId: item.orderId,
+      shippingMethod: item.shippingMethod,
+      paczkomatId: item.paczkomatId,
+      recipient: item.recipient,
+      parcel: item.parcel,
+    }));
+    // No try/catch around the whole batch: per-order failures are isolated INSIDE
+    // the service (caught into `failed` results), so this resolves 200 with the
+    // outcome list. An exception here would be a true infrastructure failure.
+    const result = await this.bulkDispatch.dispatchBulk({
+      sourceConnectionId: dto.sourceConnectionId,
+      items,
+    });
+    return BulkDispatchResultResponseDto.fromResult(result);
+  }
+
+  @Post('bulk/protocol')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Download the carrier handover protocol over a set of dispatched shipments (#964)',
+  })
+  @ApiProduces('application/pdf')
+  @ApiResponse({ status: 200, description: 'Handover protocol bytes (Content-Type per provider)' })
+  @ApiResponse({
+    status: 400,
+    description: 'No generated labels in the set, or shipments span multiple carrier connections',
+  })
+  @ApiResponse({ status: 422, description: 'Carrier does not support handover protocols' })
+  @ApiResponse({ status: 502, description: 'Shipping provider rejected protocol generation' })
+  async downloadProtocol(@Body() dto: GenerateProtocolDto, @Res() res: Response): Promise<void> {
+    // `@Res()` disables Nest's serializer (binary, not JSON). The service runs
+    // FIRST so a thrown domain exception still routes through Nest's exception
+    // layer before any byte is written; `res.*` only runs on success.
+    try {
+      const { contentType, body } = await this.bulkDispatch.generateProtocol({
+        shipmentIds: dto.shipmentIds,
+      });
+      const ext = extensionForContentType(contentType);
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Disposition', `attachment; filename="ol-handover-protocol.${ext}"`);
+      res.send(Buffer.from(body));
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
+  }
+
   @Post(':id/cancel')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Cancel a not-yet-dispatched shipment' })
@@ -307,12 +379,17 @@ export class ShipmentController {
     if (error instanceof ShipmentNotCancellableException) {
       return new ConflictException(error.message);
     }
+    if (error instanceof InvalidProtocolBatchException) {
+      // Client-input problem (empty set / no labels / mixed carriers) → 400.
+      return new BadRequestException(error.message);
+    }
     if (
       error instanceof ShipmentCancellationNotSupportedException ||
       error instanceof UndispatchableResolutionException ||
       error instanceof OrderNotDispatchablePaymentStatusException ||
       error instanceof LabelDocumentNotSupportedException ||
-      error instanceof LabelNotAvailableException
+      error instanceof LabelNotAvailableException ||
+      error instanceof DispatchProtocolNotSupportedException
     ) {
       return new UnprocessableEntityException(error.message);
     }

--- a/apps/api/test/integration/helpers/inpost-test-shipping-stub.helper.ts
+++ b/apps/api/test/integration/helpers/inpost-test-shipping-stub.helper.ts
@@ -23,7 +23,9 @@ import {
   AdapterFactoryResolverService,
   AdapterRegistryPort,
 } from '@openlinker/core/integrations';
+import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
 import type {
+  DispatchProtocolReader,
   GenerateLabelCommand,
   GenerateLabelResult,
   LabelDocument,
@@ -41,27 +43,55 @@ export const INPOST_TEST_PLATFORM_TYPE = 'inpost';
 /** Canned label bytes the stub returns from `fetchLabel` (`%PDF` magic). */
 export const STUB_LABEL_BYTES = Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x2d]);
 
-export function installInpostTestShippingStub(harness: IntegrationTestHarness): {
+/** Canned handover-protocol bytes the stub returns from `generateProtocol`. */
+export const STUB_PROTOCOL_BYTES = Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x50]);
+
+/**
+ * Control handle returned by {@link installInpostTestShippingStub} — lets a spec
+ * arrange per-order behaviour after the suite-scoped stub is installed.
+ */
+export interface InpostTestShippingStubHandle {
   readonly adapterKey: string;
   readonly platformType: string;
-} {
+  /** Make `generateLabel` reject for this order id only (siblings still succeed). */
+  failOrder(orderId: string): void;
+  /** Clear all per-order failure arrangements (call between tests). */
+  resetFailures(): void;
+}
+
+export function installInpostTestShippingStub(
+  harness: IntegrationTestHarness,
+): InpostTestShippingStubHandle {
   const adapterRegistry = harness.getApp().get<AdapterRegistryPort>(ADAPTER_REGISTRY_TOKEN);
   const factoryResolver = harness
     .getApp()
     .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
 
   let counter = 0;
-  // Implements ShipmentCanceller + LabelDocumentReader too (#846 / #884): the
-  // cancel + label endpoints resolve this adapter and narrow via the
-  // co-located guards. #835's dispatch spec ignores the extra methods, so
-  // adding them is backward-compatible.
+  const failingOrderIds = new Set<string>();
+  // Implements ShipmentCanceller + LabelDocumentReader + DispatchProtocolReader
+  // too (#846 / #884 / #964): the cancel / label / bulk-protocol endpoints
+  // resolve this adapter and narrow via the co-located guards. #835's dispatch
+  // spec ignores the extra methods, so adding them is backward-compatible.
   const shippingStub: ShippingProviderManagerPort &
     ShipmentCanceller &
-    LabelDocumentReader = {
+    LabelDocumentReader &
+    DispatchProtocolReader = {
     getSupportedMethods(): readonly ShippingMethod[] {
       return ['paczkomat', 'kurier'];
     },
     generateLabel(cmd: GenerateLabelCommand): Promise<GenerateLabelResult> {
+      // Per-order failure hook for the #964 bulk partial-failure spec —
+      // arranged via the returned handle's `failOrder(orderId)`.
+      if (failingOrderIds.has(cmd.orderId)) {
+        return Promise.reject(
+          new ShippingProviderRejectionException(
+            'inpost',
+            'stub.forced-failure',
+            `forced failure for ${cmd.orderId}`,
+          ),
+        );
+      }
       counter += 1;
       return Promise.resolve({
         providerShipmentId: `stub-${counter}`,
@@ -78,6 +108,9 @@ export function installInpostTestShippingStub(harness: IntegrationTestHarness): 
     fetchLabel(_input: { providerShipmentId: string }): Promise<LabelDocument> {
       return Promise.resolve({ contentType: 'application/pdf', body: STUB_LABEL_BYTES });
     },
+    generateProtocol(_input: { providerShipmentIds: string[] }): Promise<LabelDocument> {
+      return Promise.resolve({ contentType: 'application/pdf', body: STUB_PROTOCOL_BYTES });
+    },
   };
 
   adapterRegistry.register({
@@ -93,5 +126,14 @@ export function installInpostTestShippingStub(harness: IntegrationTestHarness): 
     createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(shippingStub as unknown as T),
   });
 
-  return { adapterKey: INPOST_TEST_ADAPTER_KEY, platformType: INPOST_TEST_PLATFORM_TYPE };
+  return {
+    adapterKey: INPOST_TEST_ADAPTER_KEY,
+    platformType: INPOST_TEST_PLATFORM_TYPE,
+    failOrder: (orderId: string): void => {
+      failingOrderIds.add(orderId);
+    },
+    resetFailures: (): void => {
+      failingOrderIds.clear();
+    },
+  };
 }

--- a/apps/api/test/integration/shipments-bulk-dispatch.int-spec.ts
+++ b/apps/api/test/integration/shipments-bulk-dispatch.int-spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Bulk Shipment Dispatch Integration Test (#964)
+ *
+ * Exercises the synchronous bulk surface (ADR-019) end-to-end against real
+ * Postgres: a routing rule is configured via the real #832
+ * `FulfillmentRoutingService`, then `BulkShipmentDispatchService.dispatchBulk`
+ * loops the per-order dispatch seam (creating one `Shipment` row per order via
+ * the in-memory InPost stub), and `generateProtocol` resolves the dispatched
+ * shipments' single carrier connection and narrows `DispatchProtocolReader`.
+ *
+ * Covers: all-success bulk → N persisted `generated` shipments + a protocol;
+ * partial-failure survival (one order forced to fail, siblings still dispatch);
+ * protocol over the succeeded shipments only.
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import {
+  IBulkShipmentDispatchService,
+  IShipmentQueryService,
+  BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN,
+  SHIPMENT_QUERY_SERVICE_TOKEN,
+} from '@openlinker/core/shipping';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+import {
+  INPOST_TEST_ADAPTER_KEY,
+  STUB_PROTOCOL_BYTES,
+  installInpostTestShippingStub,
+  type InpostTestShippingStubHandle,
+} from './helpers/inpost-test-shipping-stub.helper';
+
+const RECIPIENT = {
+  email: 'buyer@example.com',
+  phone: '+48500600700',
+  address: {
+    street: 'Krakowska',
+    buildingNumber: '12',
+    city: 'Poznań',
+    postCode: '60-001',
+    countryCode: 'PL',
+  },
+};
+const PARCEL = { dimensions: { length: 200, width: 150, height: 100 }, weightGrams: 1200 };
+const METHOD = 'allegro-courier';
+
+describe('Bulk Shipment Dispatch Integration (#964)', () => {
+  let harness: IntegrationTestHarness;
+  let shippingStub: InpostTestShippingStubHandle;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    shippingStub = installInpostTestShippingStub(harness);
+  });
+
+  afterEach(async () => {
+    shippingStub.resetFailures();
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  const bulkService = (): IBulkShipmentDispatchService =>
+    harness.getApp().get<IBulkShipmentDispatchService>(BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN);
+  const queryService = (): IShipmentQueryService =>
+    harness.getApp().get<IShipmentQueryService>(SHIPMENT_QUERY_SERVICE_TOKEN);
+  const routingService = (): IFulfillmentRoutingService =>
+    harness.getApp().get<IFulfillmentRoutingService>(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+
+  async function seedRoutedConnections(): Promise<{ sourceId: string; carrierId: string }> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.publicapi.v1',
+      enabledCapabilities: ['OrderSource'],
+    });
+    const carrier = await createTestConnection(dataSource, {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: INPOST_TEST_ADAPTER_KEY,
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    await routingService().replaceRules(source.id, [
+      {
+        sourceDeliveryMethodId: METHOD,
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: carrier.id,
+      },
+    ]);
+    return { sourceId: source.id, carrierId: carrier.id };
+  }
+
+  function item(orderId: string) {
+    return {
+      sourceDeliveryMethodId: METHOD,
+      orderId,
+      shippingMethod: 'kurier' as const,
+      recipient: RECIPIENT,
+      parcel: PARCEL,
+    };
+  }
+
+  it('should dispatch every order to a persisted shipment and produce one handover protocol', async () => {
+    const { sourceId, carrierId } = await seedRoutedConnections();
+
+    const result = await bulkService().dispatchBulk({
+      sourceConnectionId: sourceId,
+      items: [item('ol_order_bulk_1'), item('ol_order_bulk_2')],
+    });
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results.every((r) => r.kind === 'dispatched')).toBe(true);
+
+    const shipmentIds = result.results.flatMap((r) => (r.kind === 'dispatched' ? [r.shipment.id] : []));
+    expect(shipmentIds).toHaveLength(2);
+
+    // Each shipment really persisted on the carrier connection.
+    for (const id of shipmentIds) {
+      const persisted = await queryService().getById(id);
+      expect(persisted).toMatchObject({ connectionId: carrierId, status: 'generated' });
+    }
+
+    // The protocol resolves the single carrier connection + DispatchProtocolReader.
+    const protocol = await bulkService().generateProtocol({ shipmentIds });
+    expect(protocol.contentType).toBe('application/pdf');
+    expect(Buffer.from(protocol.body)).toEqual(Buffer.from(STUB_PROTOCOL_BYTES));
+  });
+
+  it('should isolate a per-order failure and still protocol the succeeded shipments (AC-6)', async () => {
+    const { sourceId } = await seedRoutedConnections();
+    // Arrange the middle order to fail at the carrier; siblings should survive.
+    shippingStub.failOrder('ol_order_boom');
+
+    const result = await bulkService().dispatchBulk({
+      sourceConnectionId: sourceId,
+      items: [item('ol_order_ok_1'), item('ol_order_boom'), item('ol_order_ok_2')],
+    });
+
+    expect(result.results).toHaveLength(3);
+    expect(result.results[0].kind).toBe('dispatched');
+    expect(result.results[1]).toMatchObject({ kind: 'failed', orderId: 'ol_order_boom' });
+    expect(result.results[2].kind).toBe('dispatched');
+
+    // A protocol over the two successes still works (the failure didn't sink them).
+    const shipmentIds = result.results.flatMap((r) => (r.kind === 'dispatched' ? [r.shipment.id] : []));
+    expect(shipmentIds).toHaveLength(2);
+    const protocol = await bulkService().generateProtocol({ shipmentIds });
+    expect(protocol.contentType).toBe('application/pdf');
+  });
+});

--- a/docs/architecture/adrs/019-synchronous-bulk-shipment-dispatch.md
+++ b/docs/architecture/adrs/019-synchronous-bulk-shipment-dispatch.md
@@ -1,0 +1,50 @@
+# ADR-019: Synchronous bulk shipment dispatch (loop the per-order seam)
+
+- **Status**: Accepted
+- **Date**: 2026-06-03
+- **Authors**: @pjswierzy
+
+## Context
+
+Shipping dispatch is per-order today: `ShipmentDispatchService.dispatch(input)` produces one `Shipment` and already owns routing resolution (#832), the payment-status gate (#938), per-order idempotency (`findActiveByOrderId`), and `Shipment`-row creation. #964 (DPD Polska) needs a bulk surface — dispatch N orders' labels in one action and produce one DPD handover protocol (the courier hand-off manifest), with per-order success/failure and partial-failure survival.
+
+The issue flagged the orchestration shape as undecided. The tempting precedent is the listings bulk-offer aggregate (#726/#734): a parent batch row, a `bulk_*_advancements` at-most-once gate, submit/progress/retry services, a worker fan-out job, and an FE progress-polling page. That machinery exists because offer creation is **N slow, independent, rate-limited Allegro calls** that run for minutes, must survive worker restarts, and need durable progress + retry. DPD bulk is a different workload: a handful of fast HTTP calls, and the protocol is a single batch-native call.
+
+The decision must also hold for the next consumer of this seam: #831 (Allegro Delivery dispatch manifest + courier pickup), whose dispatch half **is** the slow, source-brokered workload.
+
+## Decision
+
+Build a **synchronous** core `BulkShipmentDispatchService` that loops the existing per-order `ShipmentDispatchService.dispatch()` (inheriting all four per-order guarantees with zero duplication), isolates per-order failures with a `try/catch` per item, then issues one carrier-neutral `DispatchProtocolReader.generateProtocol()` over the dispatched waybills. No async executor, no durable batch record, no migration. The bulk API caps N at **25**.
+
+The fork is treated as three *separate* deferral decisions, not one binary:
+
+- **(a) Async executor — rejected.** Justified only by slow/rate-limited/restart-surviving per-item calls. DPD bulk isn't that.
+- **(b) Durable batch record — deferred on its own terms.** #964's partial-failure AC is met by per-order `Shipment` rows; a batch row would add navigate-away + batch-subset retry, which #964 doesn't require.
+- **(c) Per-order-prepare / batched-execute split — named, not built.** v1 loops `dispatch()` (N sequential outbound calls); the long-term shape separates per-order prepare (routing + gate + `Shipment` row) from one batched adapter call (e.g. DPD `generatePackagesNumbers` with N packages).
+
+## Alternatives considered
+
+- **Async `BulkShipmentDispatchBatch` aggregate (bulk-offer clone)**: durable batch + worker fan-out + advancement gate + progress polling. Rejected — large, mostly-idle scaffold for a fast workload; it is the wrapper #831 adds later, around this seam.
+- **Adapter-local batch (no core seam)**: rejected — duplicates routing/payment-gate/idempotency/`Shipment`-row logic in the adapter, and the protocol capability must be core anyway (carrier-neutral, #831 reuses it).
+- **Batch-native single `generatePackagesNumbers` for v1**: deferred (decision (c)) — bypasses the per-order dispatch seam; the loop preserves all guarantees and the N≤25 cap bounds the cost.
+
+## Consequences
+
+**Pros:**
+- Reuses every per-order guarantee with zero duplication; partial-failure isolation is a `try/catch`.
+- No migration, no worker, no FE polling — M–L instead of L–XL.
+- The synchronous service is the exact seam an async wrapper (#831) later calls — sync-now forecloses nothing.
+
+**Cons / trade-offs:**
+- v1 issues N sequential outbound calls in one request → a real request-timeout ceiling. Mitigated by the **N≤25** cap (vs bulk-offer's 100, which is safe only because it fans out to async workers).
+- Trades DPD-native batch-create efficiency for per-order-seam reuse; the cap is removable once decision (b) or (c) lands.
+
+**Migration path (if applicable):**
+- (b)/(c) are additive: add `bulk_shipment_dispatch_batch` + `Shipment.bulkBatchId`, then move execution into a worker. The capability + service signatures stay; #831 is expected to drive this.
+
+## References
+
+- Related issues: #964, #831, #832, #938
+- Related ADRs: [ADR-002](./002-capability-ports-with-sub-capabilities.md), [ADR-018](./018-dpd-polska-rest-api-over-soap.md)
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md)
+- Plan: [implementation-plan-964-dpd-bulk-protocol.md](../../plans/implementation-plan-964-dpd-bulk-protocol.md)

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -107,5 +107,6 @@ One pointer per section, identical format every time.
 | [ADR-015](./015-inbound-event-routing-capability-translated.md) | Capability-driven, plugin-translated inbound webhook event routing | Accepted | 2026-05-30 |
 | [ADR-017](./017-cross-origin-order-reingestion-guard.md) | Skip re-ingestion of orders re-read from a destination connection | Accepted | 2026-06-01 |
 | [ADR-018](./018-dpd-polska-rest-api-over-soap.md) | DPD Polska transport: native REST DPDServices API over legacy SOAP | Proposed | 2026-06-02 |
+| [ADR-019](./019-synchronous-bulk-shipment-dispatch.md) | Synchronous bulk shipment dispatch (loop the per-order seam) | Accepted | 2026-06-03 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/docs/plans/analysis/ANALYSIS-964-dpd-bulk-protocol.md
+++ b/docs/plans/analysis/ANALYSIS-964-dpd-bulk-protocol.md
@@ -1,0 +1,47 @@
+# Pre-implement gate: #964 DPD bulk label generation + handover protocol
+
+**Plan**: [`../implementation-plan-964-dpd-bulk-protocol.md`](../implementation-plan-964-dpd-bulk-protocol.md)
+**Date**: 2026-06-03
+**Verdict**: ✅ **READY**
+
+Purely additive plan. Every artifact the plan calls "new" is confirmed absent; every reuse target exists with the exact shape the plan assumes. No contract-surface breaks. One naming/wiring clarification (W-1) to honour during implementation, and the dispatch-input item type can be made precise (W-2) — neither blocks.
+
+---
+
+## Reuse findings
+
+| Plan artifact | Verdict | Evidence |
+|---|---|---|
+| `DispatchProtocolReader` capability (`shipping/domain/ports/capabilities/dispatch-protocol-reader.capability.ts`) | **NEW (absent)** — name pre-reserved | `label-document-reader.capability.ts:15-17` reserves it verbatim: *"a sibling sub-capability (`DispatchProtocolReader`) when it ships"* |
+| `isDispatchProtocolReader` guard | **NEW** | Matches existing guard convention (`isLabelDocumentReader`, `isShipmentCanceller`, `isPickupPointFinder`) |
+| `LabelDocument` reuse (`{contentType:string; body:Uint8Array}`) | **EXISTS → reuse** | `shipping/domain/types/label-document.types.ts:22-28`; exported from `@openlinker/core/shipping` |
+| `BulkShipmentDispatchService` + `I*Service` interface | **NEW (absent)** | No `bulk-shipment-dispatch*` under `shipping/application/services/` |
+| `bulk-shipment-dispatch.types.ts` | **NEW (absent)** | confirmed absent under `application/types/` |
+| `BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN` | **NEW** | `shipping.tokens.ts` pattern `Symbol('I…Service')`; `SHIPMENT_DISPATCH_SERVICE_TOKEN` already exists for the per-order service the bulk loop injects |
+| Per-order `ShipmentDispatchService.dispatch()` loop target | **EXISTS → reuse** | `shipment-dispatch.service.ts:73` `dispatch(input: ShipmentDispatchInput): Promise<ShipmentDispatchResult>`; injects routing(#832)+payment-gate(#938)+`findActiveByOrderId` idempotency |
+| DPD `generateProtocol` on `DpdShippingAdapter` | **NEW (absent)** | adapter implements `ShippingProviderManagerPort, LabelDocumentReader, PickupPointFinder`; no protocol code anywhere in package |
+| `decodeProtocolDocument` (base64→bytes) | **PARTIAL → reuse `decodeLabelDocument`** | `dpd-shipment.mapper.ts:189-207` decodes base64 `documentData`→`Uint8Array`; same shape for protocol |
+| `FakeDpdShippingAdapter` gains `generateProtocol` | **EXISTS → extend** | `testing/fake-dpd-shipping.adapter.ts:32` |
+| `POST /shipments/bulk/generate-labels` + protocol download | **NEW (absent)** | no `/shipments/bulk*` route in `shipment.controller.ts`; binary-stream pattern to mirror at `:id/label` (`res.setHeader` + `res.send(Buffer.from(body))`) |
+| Bulk request DTO (`@ArrayMaxSize(25)`) | **NEW** | pattern established in `listings/http/dto/bulk-offer-create.dto.ts` (`@IsArray/@ArrayMinSize/@ArrayMaxSize`); bulk-offer cap **= 100** confirmed (plan's claim correct) |
+
+## Backward-compat findings
+
+No Critical items. Everything is additive — no exported symbol removed/renamed, no port signature changed, no DTO retyped, no ORM/migration touched (`check:invariants` unaffected; no cross-context or deep-barrel imports introduced).
+
+**Warnings / clarifications to honour during implementation:**
+
+- **W-1 (sub-capability is NOT a manifest capability).** One audit suggested adding `'DispatchProtocolReader'` to the DPD manifest `supportedCapabilities` + the `dispatchCapability` map. **Do not.** The existing sub-capabilities `LabelDocumentReader` and `PickupPointFinder` are **not** in `supportedCapabilities` (`dpd-plugin.ts:31` lists only `'ShippingProviderManager'`) and **not** in the `dispatchCapability` map — they're discovered by resolving the `ShippingProviderManager` adapter and narrowing with the `is*` guard (exactly what `ShipmentLabelService` does for `LabelDocumentReader`). The bulk service must resolve `getCapabilityAdapter<ShippingProviderManagerPort>(processorConnectionId, 'ShippingProviderManager')` then `isDispatchProtocolReader(adapter)`. No manifest change. The plan already models it as a sub-capability; this note just blocks the wrong wiring.
+
+- **W-2 (make the per-order item type precise).** The plan describes the bulk item as "the per-order payload minus the shared routing keys." Concretely that is `Omit<ShipmentDispatchInput, 'sourceConnectionId' | 'sourceDeliveryMethodId'>`, and `BulkShipmentDispatchInput = { sourceConnectionId; sourceDeliveryMethodId: string | null } & { items: <thatOmit>[] }`. Derive from the existing `ShipmentDispatchInput` (`application/types/shipment-dispatch.types.ts:23`) rather than re-declaring fields, so the two can't drift.
+
+- **W-3 (result-union mapping).** `ShipmentDispatchResult` has **no** `failed` variant — a label failure is **thrown** (shipment persisted `failed` first). So the bulk per-order `failed{orderId,error}` entry is produced by the bulk loop's `try/catch`, and the protocol is generated only over waybills from `kind:'dispatched'` results (`omp_fulfilled` carries no shipment). Plan §3/§8 already say this; flagging so the implementation maps the union correctly.
+
+## Open questions (unchanged from plan, none blocking)
+
+- **OQ-1** DPD `generateProtocol` exact path/request/response (waybills vs sessionId) — gated on #962 creds; isolated in DPD types+mapper; live round-trip = pre-merge AC. Build against documented shape.
+- **OQ-2** Protocol delivery to FE (inline bytes vs retrievable ref) — decided with #966; v1 returns a streamable `LabelDocument`.
+
+## Idempotency note
+
+`findActiveByOrderId` is best-effort (find→create not atomic). The bulk loop is **sequential synchronous**, so no intra-batch concurrent double-create — consistent with the existing per-order serialization expectation. The N≤25 cap (ADR-019) bounds the sequential-call wall-clock.

--- a/docs/plans/implementation-plan-964-dpd-bulk-protocol.md
+++ b/docs/plans/implementation-plan-964-dpd-bulk-protocol.md
@@ -1,0 +1,186 @@
+# Implementation Plan: DPD bulk label generation + handover protocol
+
+**Date**: 2026-06-03
+**Status**: Draft — pending Gate (Phase 3 review); one architecture fork to settle
+**Issue**: #964 (Part of #961)
+**Spec**: [`docs/specs/product-spec-961-dpd-polska-shipping.md`](../specs/product-spec-961-dpd-polska-shipping.md) §4.4 (US-6 / AC-6)
+**Builds on**: #962 (DPD adapter, merged #971), #963 (DPD Pickup, merged #973)
+**Implementation branch**: `964-dpd-bulk-protocol`
+**Estimated Effort**: M–L (~1 week for the recommended shape; L–XL for the async-aggregate alternative)
+
+> **The architecture fork the issue flagged is settled in §3 below**: a *synchronous* core
+> bulk-dispatch orchestrator (NOT the async `BulkOfferCreationBatch`-style aggregate).
+> §3 keeps three deferred decisions explicitly separate — (a) the **async executor**
+> (worker + advancement gate + progress polling), rejected because DPD bulk is not a
+> slow/rate-limited/restart-surviving workload; (b) the **durable batch record**, deferred
+> because #964's partial-failure AC is already met by per-order `Shipment` rows; and (c) the
+> **per-order-prepare / batched-execute split**, named as the intended long-term shape that a
+> batch-native or slow carrier (#831) evolves into. Synchronous-now forecloses none of them —
+> `BulkShipmentDispatchService` is the exact seam an async wrapper later calls. See §3 + ADR-019.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Let an operator dispatch **N orders' DPD labels in one action** and get a **single DPD handover protocol** (the courier hand-off manifest), with **per-order success/failure** and partial-failure survival.
+
+**Classification**: **CORE (new bulk-dispatch orchestrator + new `DispatchProtocolReader` sub-capability) + Integration (DPD `generateProtocol` impl) + API.** FE bulk-selection UX is deferred (see Non-Goals). No DB migration (recommended shape).
+
+**Context**: Today shipping dispatch is strictly per-order (`ShipmentDispatchService.dispatch(input)` → one `Shipment`). #964 adds the bulk surface. The handover-manifest capability name is **pre-reserved** by the codebase: `label-document-reader.capability.ts` says the dispatch protocol "is a DIFFERENT document (per-batch, not per-parcel)… it will be a sibling sub-capability (`DispatchProtocolReader`) when it ships." This is also the seam Allegro Delivery #831 will reuse.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+**CORE (`libs/core/src/shipping/`):**
+- `DispatchProtocolReader` sub-capability (`domain/ports/capabilities/dispatch-protocol-reader.capability.ts`) — `generateProtocol(input: { providerShipmentIds: string[] }): Promise<LabelDocument>` + `isDispatchProtocolReader` guard. Carrier-neutral (the name + intent are pre-reserved; #831 reuses it).
+- `BulkShipmentDispatchService` (`application/services/bulk-shipment-dispatch.service.ts` + interface) — **synchronous** orchestrator: for each item, delegate to the existing `ShipmentDispatchService.dispatch()` (so routing + payment-gate + idempotency + `Shipment` rows are reused per order), isolate per-order failures, then call the connection's `DispatchProtocolReader.generateProtocol()` over the dispatched waybills. Returns per-order results + the protocol document.
+- Types: `BulkShipmentDispatchInput` / `BulkShipmentDispatchResult` (per-order outcome union + optional protocol).
+
+**Integration (`libs/integrations/dpd-polska/`):**
+- `DpdShippingAdapter implements … , DispatchProtocolReader` — `generateProtocol` via DPD `generateProtocolV1` (handover document, base64 → bytes; reuses `DpdHttpClient`).
+- Mapper + types for the protocol request/response.
+
+**API (`apps/api/src/shipping/http/`):**
+- `POST /shipments/bulk/generate-labels` → `BulkShipmentDispatchService`; returns `{ results: [{ orderId, status, shipmentId?, error? }], protocol?: { contentType, ... } }`.
+- Protocol document download (`GET /shipments/bulk/protocol?...` or a follow-the-link ref) — exact shape decided with the FE issue; v1 may return the protocol bytes inline / via a one-shot ref.
+
+### Out of Scope (Non-Goals)
+- **FE bulk-selection UX** (multi-select on `/orders` → bulk-dispatch action + per-order result panel). Deferred to the DPD FE issue (#966) / a FE follow-up — mirrors #962/#963 which shipped backend-first. The `BulkActionBar` primitive already exists (used by bulk-offer-creation) for that work.
+- **Async executor** (worker fan-out + `bulk_*_advancements` gate + progress-polling) — rejected for this workload (§3 (a)). #831's slow dispatch half is the consumer that adds it; the synchronous service is the seam it wraps.
+- **Durable batch record** (`bulk_shipment_dispatch_batch` row + `Shipment.bulkBatchId` FK) — deferred (§3 (b)): #964's partial-failure AC is met by per-order `Shipment` rows. Adds batch retry / navigate-away later; no migration in v1.
+- **Per-order-prepare / batched-execute split** + **DPD batch-native single create call** (`generatePackagesNumbers` with N packages in one HTTP call) — named as the intended long-term shape (§3 (c)) but not built. v1 reuses per-order `dispatch()` (N sequential create calls) to inherit routing/payment-gate/idempotency/`Shipment`-row guarantees; the N≤25 cap bounds the timeout cost. The **protocol** is the genuinely-batch call even in v1.
+- **Multi-parcel single order** (1 order → N parcels) — spec §7, separate.
+- Courier / COD / pickup base flows (#962 + #963).
+
+### Constraints
+- No CORE change beyond the additive capability + new service. No migration (no persistent batch in the recommended shape). Reuse #962 `DpdHttpClient` + #963 patterns.
+
+---
+
+## 3. Architecture decision — synchronous orchestrator vs async batch aggregate (THE FORK)
+
+The issue says: *"possible new core bulk-dispatch seam (shipping is per-order today) — run /plan to settle core-vs-adapter-local."* Settled:
+
+**Chosen: a synchronous core `BulkShipmentDispatchService` that loops the existing per-order `ShipmentDispatchService.dispatch()`, then issues one `generateProtocol`.**
+
+The fork is not one binary choice — it's **three independent deferral decisions** that the bulk-offer aggregate happens to bundle together. Keeping them separate is what makes "synchronous now" honest rather than a guess:
+
+**(a) Async executor — REJECTED.** The `BulkOfferCreationBatch` machinery (parent batch row + `bulk_*_advancements` at-most-once gate + submit/progress/retry services + `marketplace.*.create` worker job + FE progress-polling page; listings #726/#734) exists because **offer creation is N slow, independent, rate-limited Allegro calls with per-offer classification read-back** — minutes-long, must survive worker restarts, needs durable progress + retry. DPD bulk is not that workload, so this whole scaffold would be large and mostly idle for zero latency benefit. Rejected.
+
+**(b) Durable batch record — DEFERRED (on its own terms, not as a side-effect of (a)).** A `bulk_shipment_dispatch_batch` row + `Shipment.bulkBatchId` FK would buy durability (navigate-away/come-back), batch-level retry of the *failed subset*, and a home for protocol-regeneration state — **without** any of the (a) async machinery. #964's AC ("partial failure doesn't lose successful labels") does **not** require it: the per-order `Shipment` rows already persist each outcome, and the synchronous response carries the per-order result list. So we defer it — but we reject it *because the AC is already met*, not because "no persistence is ever needed." It is the natural first thing #831 adds.
+
+**(c) Per-order-prepare / batched-execute split — NAMED as the intended evolution, not built now.** This v1 reuses `ShipmentDispatchService.dispatch()` wholesale, which means a bulk of N is **N sequential `dispatch()` calls** (each: routing resolution #832 + payment-status read #938 + `Shipment` insert + one outbound DPD create) **plus** one protocol call — all in one request. That reuses every per-order guarantee for free (zero duplication, per-order failure isolation is a `try/catch` per item → a failed order becomes a `failed` `Shipment` row + a failure entry; successful siblings untouched). The cost is real: it is **not** "~3 fast calls" — it is ~N sequential outbound round-trips, with a hard request-timeout ceiling. The clean long-term shape splits **"prepare per order"** (routing + payment-gate + `Shipment` row, looped — cheap, DB-local) from **"execute"** (one *batched* adapter call, e.g. DPD `generatePackagesNumbers` with N packages). That split is what lets a batch-native carrier stay efficient *without* bypassing the per-order guarantees, and what a slow source-brokered carrier (#831's Allegro Delivery dispatch-command half) wraps in the (a) executor. We don't build the split now (the loop is simpler and correct at a bounded cap), but the cap below exists precisely because we haven't.
+
+**Synchronous-cap bound (mitigation for (c)).** Because v1 issues N sequential outbound calls in one request, the API DTO caps N at **25** (not the bulk-offer 100) — worst case ~25 DPD creates + 1 protocol stays comfortably under a 30 s gateway timeout. The cap is documented as a deliberate consequence of the per-order loop, removable once the prepare/execute split (c) or the durable record (b) lands. (Bulk-offer's 100 cap is fine there because it fans out to async workers, not a synchronous loop.)
+
+**Known second consumer.** #831 (Allegro Delivery — dispatch manifest + courier pickup) reuses `DispatchProtocolReader` (capability is pre-reserved for it) **and** is the slow, source-brokered dispatch workload that triggers (a)+(b)+(c). So we are not pre-paying hypothetical complexity: #831 is a filed issue, and `BulkShipmentDispatchService` is the exact synchronous seam it wraps. That's the whole reason sync-now is safe.
+
+**Net:** recommended shape = **1 new capability + 1 new core service + DPD protocol impl + API endpoints + tests**, M–L, N≤25. The async alternative would push this to L–XL. Decision recorded in **ADR-019**.
+
+---
+
+## 4. External Research — DPD `generateProtocol` (verified shape pending spike)
+
+- DPD `DPDServices` REST exposes **`generateProtocolV1`** (handover protocol / "protokół odbioru") over a set of waybills — returns a document (PDF) analogous to `generateSpedLabels`' `documentData` (base64). Same Basic-auth + `DpdHttpClient`. (#962 grounding note + the customer doc list `generateProtocol` alongside the shipment ops.)
+- **OQ-1 (spike, gated on #962 creds):** exact path (`/public/shipment/v1/generateProtocol`?), request shape (session/waybills array, like `generateSpedLabels`), response (`documentData` base64 + status), and whether a protocol is keyed by waybills or by the create `sessionId`. Isolated in DPD types + mapper; the live round-trip is a pre-merge AC (the #962 pattern).
+
+### Internal patterns to mirror
+- **`LabelDocumentReader`** (`fetchLabel` → `LabelDocument`) — `DispatchProtocolReader.generateProtocol` is its per-batch sibling, same `LabelDocument` return (contentType + bytes).
+- **`ShipmentLabelService` + `GET /shipments/:id/label`** — the binary-download controller pattern (content-type, `Content-Disposition`, extension-from-MIME) to mirror for the protocol download.
+- **`ShipmentDispatchService.dispatch()`** — looped per item by the new bulk service.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+- **OQ-1 (DPD protocol endpoint/shape)** — confirmed in the Phase-0 spike against the live Swagger (gated on #962 creds); isolated in types + mapper. Live bulk + protocol round-trip = pre-merge AC.
+- **OQ-2 (protocol document delivery to FE)** — return protocol bytes inline in the bulk response vs a retrievable ref (`labelPdfRef`-style). Decided with the FE issue; v1 backend returns a `LabelDocument` the API can stream. Recommend a `GET /shipments/bulk/protocol` taking the waybill set (stateless) to match the stateless DPD call.
+
+### Assumptions
+- Bulk is operator-triggered, synchronous, bounded at **N≤25** (NOT the bulk-offer 100 — see §3 cap rationale: v1 issues N sequential outbound calls in one request, so the cap bounds the timeout cost; bulk-offer's 100 is fine there because it fans out to async workers). Documented in the API DTO with a comment pointing at §3.
+- All orders in one bulk call target the **same** source connection / carrier (the protocol is per-DPD-account); the service asserts a single resolved processor connection across items and errors clearly otherwise.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 0 — Spike (confirm OQ-1; gated on #962 creds)
+1. Against the live DPDServices Swagger (#962 chrome-devtools path): confirm `generateProtocol` path/method/request/response + whether it keys on waybills or sessionId. Capture canned fixtures. Not merged; if creds unavailable, build Phases 1–4 against the documented shape + leave the live round-trip as the pre-merge AC.
+
+### Phase 1 — CORE: `DispatchProtocolReader` capability
+2. `domain/ports/capabilities/dispatch-protocol-reader.capability.ts` — interface (`generateProtocol(input: { providerShipmentIds: string[] }): Promise<LabelDocument>`) + `isDispatchProtocolReader` guard. Export both from the shipping barrel. (Reuses `LabelDocument`.)
+   - **Acceptance**: type-check green; guard unit-tested; no other adapter forced to implement it (optional sub-capability).
+
+### Phase 2 — CORE: `BulkShipmentDispatchService`
+3. Types `application/types/bulk-shipment-dispatch.types.ts`: `BulkShipmentDispatchInput { sourceConnectionId; sourceDeliveryMethodId; items: ShipmentDispatchItem[] }` (item = the per-order payload minus the shared routing keys) + `BulkShipmentDispatchResult { results: PerOrderDispatchResult[]; protocol?: LabelDocument }` where `PerOrderDispatchResult` is a per-order discriminated union (`dispatched{shipment}` | `omp_fulfilled` | `failed{orderId, error}`).
+4. `application/services/bulk-shipment-dispatch.service.ts` (+ `I*Service` interface): inject `IShipmentDispatchService` + `IIntegrationsService`. For each item: `try { dispatch() } catch → failed entry` (failure isolation). Then resolve the processor connection's adapter, `isDispatchProtocolReader` → `generateProtocol(dispatchedWaybills)`; if unsupported, return results without a protocol (don't fail the batch). Assert single resolved connection across items.
+   - **Acceptance**: unit tests — all-success + protocol; partial-failure (one order throws, others survive, protocol covers only succeeded); adapter without `DispatchProtocolReader` → results, no protocol; mixed connections → throws.
+
+### Phase 3 — Integration: DPD `generateProtocol`
+5. `dpd-rest.types.ts`: protocol request/response shapes (isolated, OQ-1). `dpd-shipment.mapper.ts`: `buildGenerateProtocolRequest(waybills)` + `decodeProtocolDocument(res)` (base64 → bytes, status assert — reuse the #962 helpers).
+6. `dpd-shipping.adapter.ts`: `implements … , DispatchProtocolReader`; `generateProtocol` → `POST` the protocol endpoint (`idempotent: true` read-style) → `decodeProtocolDocument`. `FakeDpdShippingAdapter` gains it.
+   - **Acceptance**: mapper + adapter unit tests (protocol build + decode + capability presence).
+
+### Phase 4 — API
+7. `POST /shipments/bulk/generate-labels` (DTO with `items[]`, `@ArrayMaxSize(25)` + a comment pointing at §3's cap rationale) → `BulkShipmentDispatchService`; map per-order failures into the response (200 with per-order statuses; never 500 for a partial failure). Protocol retrieval endpoint (binary stream, mirroring `GET /shipments/:id/label`).
+   - **Acceptance**: controller unit test; integration test (bulk happy-path + partial-failure) reusing the shipping int-spec harness.
+
+### Config / Migrations / Events
+- No migration, no env vars, no events (synchronous; per-order persistence already exists).
+
+---
+
+## 7. Alternatives Considered
+- **Async executor (BulkOfferCreationBatch clone — worker + advancement gate + progress/retry services + FE polling)** — rejected (§3 (a)): justified only by slow/rate-limited/restart-surviving per-item calls; DPD bulk isn't that. #831's slow dispatch half is the consumer that adds it, wrapping this synchronous seam.
+- **Durable batch record (`bulk_shipment_dispatch_batch` + `Shipment.bulkBatchId`, no async machinery)** — deferred (§3 (b)) on its own terms: #964's partial-failure AC is met by per-order `Shipment` rows. The first thing #831 adds for batch retry / navigate-away; no migration in v1.
+- **Per-order-prepare / batched-execute split + DPD batch-native single `generatePackagesNumbers` (N packages, 1 call)** — named as the long-term shape (§3 (c)) but deferred: v1 loops per-order `dispatch()` to preserve all guarantees with zero duplication; the N≤25 cap bounds the sequential-call timeout cost. This is the lever that lifts the cap, not just a latency nicety.
+- **Adapter-local batch (no core seam)** — rejected: would duplicate routing/payment-gate/idempotency/`Shipment`-row logic inside the adapter, and the protocol capability has to be core anyway (carrier-neutral, #831 reuses it).
+
+---
+
+## 8. Validation & Risks
+- **Per-order failure isolation** is the core AC — covered by the try/catch-per-item loop + a dedicated partial-failure test. A failed order persists as a `failed` `Shipment`; successes are untouched.
+- **Protocol-over-succeeded-only**: the protocol is generated over the waybills that actually dispatched, so a partial failure still yields a valid protocol for the successes.
+- **Single-connection assumption**: bulk asserts one resolved processor connection (the protocol is per-DPD-account); mixed-connection input errors clearly rather than producing a wrong manifest.
+- **`DispatchProtocolReader` optional**: adapters that don't support it (InPost today) just yield no protocol — the capability guard prevents a hard dependency.
+- **Live round-trip** (bulk + protocol) gated on #962 creds → pre-merge AC.
+- **FE-dormant until #966**: backend bulk is API-reachable but the operator multi-select UX is the FE issue. Consistent with #962/#963.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `dispatch-protocol-reader.capability.spec.ts` — guard true/false.
+- `bulk-shipment-dispatch.service.spec.ts` — all-success+protocol, partial-failure survival, no-protocol-capability, mixed-connection throw, payment-gate-per-order (one blocked, others proceed).
+- DPD `dpd-shipment.mapper.spec.ts` + `dpd-shipping.adapter.spec.ts` — protocol build/decode + `isDispatchProtocolReader` true.
+
+### Integration Tests
+- `shipments-bulk-dispatch.int-spec.ts` — bulk happy-path + partial-failure via the existing harness (stubbed shipping adapter). Live DPD bulk+protocol = manual pre-merge AC (needs #962 creds).
+
+### Acceptance Criteria (#964)
+- [ ] Operator (API) submits N orders → N labels generated + one DPD handover protocol (unit + int-proven; live in the AC below).
+- [ ] Per-order success/failure surfaced; a partial failure keeps successful labels + still yields a protocol for the successes.
+- [ ] `pnpm lint` / `type-check` / unit tests green; invariants satisfied.
+- [ ] **Manual (pre-merge):** live DPD bulk + protocol round-trip (needs #962 creds + OQ-1).
+
+---
+
+## 10. Alignment Checklist
+- [x] Hexagonal — additive core capability + service; integration implements it; API delegates
+- [x] CORE vs Integration settled (§3) — synchronous core orchestrator, carrier-neutral protocol capability
+- [x] Reuses existing patterns (`ShipmentDispatchService` loop, `LabelDocumentReader` sibling, #962 DPD stack, `BulkActionBar` for the deferred FE)
+- [x] Idempotency — per-order `findActiveByOrderId` reused; protocol is an idempotent read
+- [x] Error handling — per-order failure isolation; `ShippingProviderRejectionException`
+- [x] Testing strategy complete (unit + int, partial-failure focus)
+- [x] No migration; no async machinery (justified §3)
+- [x] Execution-ready pending the architecture-fork sign-off + OQ-1 spike
+
+---
+
+## Related Documentation
+- Spec: [`product-spec-961-dpd-polska-shipping.md`](../specs/product-spec-961-dpd-polska-shipping.md) · #962/#963 plans · [ADR-019](../architecture/adrs/019-synchronous-bulk-shipment-dispatch.md) (this decision) · [ADR-018](../architecture/adrs/018-dpd-polska-rest-api-over-soap.md) (DPD REST)
+- Reference: `libs/integrations/dpd-polska/` (#962/#963), `libs/core/src/listings/**` bulk-offer (#726/#734), `libs/core/src/shipping/application/services/shipment-dispatch.service.ts`

--- a/libs/core/src/shipping/application/interfaces/bulk-shipment-dispatch.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/bulk-shipment-dispatch.service.interface.ts
@@ -1,0 +1,50 @@
+/**
+ * Bulk Shipment Dispatch Service Interface
+ *
+ * The bulk surface over the per-order dispatch seam (#964): dispatch N orders'
+ * labels in one action, then produce one carrier handover protocol over the
+ * dispatched shipments. SYNCHRONOUS by design (ADR-019) — it loops the existing
+ * `IShipmentDispatchService.dispatch()`, inheriting routing / payment-gate /
+ * idempotency / `Shipment`-row creation for free, rather than cloning the async
+ * bulk-offer aggregate. The protocol is a distinct method so the dispatch
+ * response stays JSON and the protocol streams as binary.
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+
+import type {
+  BulkShipmentDispatchInput,
+  BulkShipmentDispatchResult,
+} from '../types/bulk-shipment-dispatch.types';
+import type { LabelDocument } from '../../domain/types/label-document.types';
+
+export interface IBulkShipmentDispatchService {
+  /**
+   * Dispatch each item by looping the per-order seam. Per-order failures are
+   * isolated (caught into a `failed` result) so a partial failure never loses
+   * the successful siblings' labels. Returns the per-order outcome list; the
+   * handover protocol is produced separately via {@link generateProtocol}.
+   *
+   * **Precondition (ADR-019):** this is a SYNCHRONOUS loop — it issues N
+   * sequential outbound calls in one execution. Callers MUST bound `items`
+   * (the HTTP surface caps it at 25). The service does not re-impose the cap;
+   * an unbounded caller would run an unbounded sequential loop. A future async
+   * wrapper (#831) is the seam that lifts this constraint by moving execution
+   * onto a worker.
+   */
+  dispatchBulk(input: BulkShipmentDispatchInput): Promise<BulkShipmentDispatchResult>;
+
+  /**
+   * Produce the carrier handover protocol over the given OL shipment ids. Loads
+   * the shipments, keeps only those with a provider shipment id (a manifest can
+   * only cover generated labels), asserts they belong to a single carrier
+   * connection (the protocol is per-carrier-account), resolves that connection's
+   * `ShippingProviderManagerPort`, and narrows the `DispatchProtocolReader`
+   * sub-capability.
+   *
+   * Throws `InvalidProtocolBatchException` (empty / no-labels / mixed
+   * connections), `DispatchProtocolNotSupportedException` (carrier has no
+   * protocol concept), or a provider rejection.
+   */
+  generateProtocol(input: { shipmentIds: string[] }): Promise<LabelDocument>;
+}

--- a/libs/core/src/shipping/application/services/bulk-shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/bulk-shipment-dispatch.service.spec.ts
@@ -1,0 +1,245 @@
+/**
+ * Bulk Shipment Dispatch Service unit tests (#964).
+ *
+ * Mocks `IShipmentDispatchService` (the looped per-order seam),
+ * `ShipmentRepositoryPort`, and `IIntegrationsService` (→ a fake
+ * `ShippingProviderManager` adapter that may or may not implement
+ * `DispatchProtocolReader`).
+ *
+ * Covers:
+ *  - dispatchBulk: all-success, partial-failure survival, omp_fulfilled passthrough
+ *  - generateProtocol: happy path, no-capability, mixed-connection throw,
+ *    no-labels / empty throw, label-less ids dropped, provider error rethrow
+ */
+
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+
+import { BulkShipmentDispatchService } from './bulk-shipment-dispatch.service';
+import type { IShipmentDispatchService } from '../interfaces/shipment-dispatch.service.interface';
+import type { BulkShipmentDispatchItem } from '../types/bulk-shipment-dispatch.types';
+import { Shipment } from '../../domain/entities/shipment.entity';
+import { DispatchProtocolNotSupportedException } from '../../domain/exceptions/dispatch-protocol-not-supported.exception';
+import { InvalidProtocolBatchException } from '../../domain/exceptions/invalid-protocol-batch.exception';
+import type { DispatchProtocolReader } from '../../domain/ports/capabilities/dispatch-protocol-reader.capability';
+import type { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+
+const SOURCE_CONNECTION = 'conn-source';
+const DPD_CONNECTION = 'conn-dpd';
+
+function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
+  return new Shipment(
+    overrides.id ?? 'ol_shipment_1',
+    overrides.orderId ?? 'ol_order_1',
+    overrides.connectionId ?? DPD_CONNECTION,
+    overrides.shippingMethod ?? 'kurier',
+    overrides.status ?? 'generated',
+    overrides.providerShipmentId !== undefined ? overrides.providerShipmentId : 'waybill-1',
+    overrides.paczkomatId ?? null,
+    overrides.trackingNumber ?? null,
+    overrides.labelPdfRef ?? 'waybill-1',
+    null,
+    null,
+    null,
+    null,
+    null,
+    new Date(),
+    new Date(),
+    overrides.sourceDeliveryMethodId ?? null,
+    overrides.carrier ?? null,
+  );
+}
+
+function makeItem(orderId: string, overrides: Partial<BulkShipmentDispatchItem> = {}): BulkShipmentDispatchItem {
+  return {
+    sourceDeliveryMethodId: overrides.sourceDeliveryMethodId ?? 'dm-1',
+    orderId,
+    shippingMethod: overrides.shippingMethod ?? 'kurier',
+    paczkomatId: overrides.paczkomatId,
+    recipient: overrides.recipient ?? {
+      email: 'buyer@example.com',
+      phone: '600100200',
+      address: {
+        street: 'Main',
+        buildingNumber: '1',
+        city: 'Warsaw',
+        postCode: '00-001',
+        countryCode: 'PL',
+      },
+    },
+    parcel: overrides.parcel ?? { weightGrams: 1000 },
+  };
+}
+
+describe('BulkShipmentDispatchService', () => {
+  let dispatch: jest.Mocked<IShipmentDispatchService>;
+  let repository: jest.Mocked<ShipmentRepositoryPort>;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let protocolAdapter: jest.Mocked<ShippingProviderManagerPort & DispatchProtocolReader>;
+  let service: BulkShipmentDispatchService;
+
+  beforeEach(() => {
+    dispatch = { dispatch: jest.fn() };
+    repository = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findById: jest.fn(),
+      findByOrderId: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findByProviderShipmentId: jest.fn(),
+      findBranchOneByOrderAndConnection: jest.fn(),
+      update: jest.fn(),
+    };
+    protocolAdapter = {
+      generateLabel: jest.fn(),
+      getTracking: jest.fn(),
+      getSupportedMethods: jest.fn(),
+      generateProtocol: jest.fn().mockResolvedValue({
+        contentType: 'application/pdf',
+        body: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+      }),
+    };
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn().mockResolvedValue(protocolAdapter),
+      resolveAdapterMetadata: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+    };
+    service = new BulkShipmentDispatchService(dispatch, repository, integrations);
+  });
+
+  describe('dispatchBulk', () => {
+    it('should dispatch every item and return a dispatched result per order when all succeed', async () => {
+      dispatch.dispatch
+        .mockResolvedValueOnce({ kind: 'dispatched', shipment: makeShipment({ id: 'ol_shipment_1', orderId: 'ol_order_1' }) })
+        .mockResolvedValueOnce({ kind: 'dispatched', shipment: makeShipment({ id: 'ol_shipment_2', orderId: 'ol_order_2' }) });
+
+      const result = await service.dispatchBulk({
+        sourceConnectionId: SOURCE_CONNECTION,
+        items: [makeItem('ol_order_1'), makeItem('ol_order_2')],
+      });
+
+      expect(dispatch.dispatch).toHaveBeenCalledTimes(2);
+      // The shared sourceConnectionId is re-attached to each per-order call.
+      expect(dispatch.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceConnectionId: SOURCE_CONNECTION, orderId: 'ol_order_1' }),
+      );
+      expect(result.results).toHaveLength(2);
+      expect(result.results.every((r) => r.kind === 'dispatched')).toBe(true);
+    });
+
+    it('should isolate a per-order failure so successful siblings still dispatch (AC-6)', async () => {
+      dispatch.dispatch
+        .mockResolvedValueOnce({ kind: 'dispatched', shipment: makeShipment({ orderId: 'ol_order_1' }) })
+        .mockRejectedValueOnce(new Error('carrier rejected order 2'))
+        .mockResolvedValueOnce({ kind: 'dispatched', shipment: makeShipment({ orderId: 'ol_order_3' }) });
+
+      const result = await service.dispatchBulk({
+        sourceConnectionId: SOURCE_CONNECTION,
+        items: [makeItem('ol_order_1'), makeItem('ol_order_2'), makeItem('ol_order_3')],
+      });
+
+      expect(result.results).toHaveLength(3);
+      expect(result.results[0]).toMatchObject({ kind: 'dispatched', orderId: 'ol_order_1' });
+      expect(result.results[1]).toMatchObject({
+        kind: 'failed',
+        orderId: 'ol_order_2',
+        error: 'carrier rejected order 2',
+      });
+      expect(result.results[2]).toMatchObject({ kind: 'dispatched', orderId: 'ol_order_3' });
+    });
+
+    it('should map an omp_fulfilled dispatch to an omp_fulfilled per-order result', async () => {
+      dispatch.dispatch.mockResolvedValueOnce({ kind: 'omp_fulfilled' });
+
+      const result = await service.dispatchBulk({
+        sourceConnectionId: SOURCE_CONNECTION,
+        items: [makeItem('ol_order_1')],
+      });
+
+      expect(result.results[0]).toEqual({ kind: 'omp_fulfilled', orderId: 'ol_order_1' });
+    });
+  });
+
+  describe('generateProtocol', () => {
+    it('should resolve the single carrier connection and return the protocol document', async () => {
+      repository.findById
+        .mockResolvedValueOnce(makeShipment({ id: 'ol_shipment_1', providerShipmentId: 'waybill-1' }))
+        .mockResolvedValueOnce(makeShipment({ id: 'ol_shipment_2', providerShipmentId: 'waybill-2' }));
+
+      const doc = await service.generateProtocol({ shipmentIds: ['ol_shipment_1', 'ol_shipment_2'] });
+
+      expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(
+        DPD_CONNECTION,
+        'ShippingProviderManager',
+      );
+      expect(protocolAdapter.generateProtocol).toHaveBeenCalledWith({
+        providerShipmentIds: ['waybill-1', 'waybill-2'],
+      });
+      expect(doc.contentType).toBe('application/pdf');
+    });
+
+    it('should throw InvalidProtocolBatchException for an empty shipment set', async () => {
+      await expect(service.generateProtocol({ shipmentIds: [] })).rejects.toBeInstanceOf(
+        InvalidProtocolBatchException,
+      );
+      expect(repository.findById).not.toHaveBeenCalled();
+    });
+
+    it('should drop label-less / unknown ids and throw when none have a provider id', async () => {
+      repository.findById
+        .mockResolvedValueOnce(makeShipment({ id: 'ol_shipment_1', providerShipmentId: null }))
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        service.generateProtocol({ shipmentIds: ['ol_shipment_1', 'missing'] }),
+      ).rejects.toBeInstanceOf(InvalidProtocolBatchException);
+      expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('should cover only the labelled shipments, dropping label-less ones from the manifest', async () => {
+      repository.findById
+        .mockResolvedValueOnce(makeShipment({ id: 'ol_shipment_1', providerShipmentId: 'waybill-1' }))
+        .mockResolvedValueOnce(makeShipment({ id: 'ol_shipment_2', providerShipmentId: null }));
+
+      await service.generateProtocol({ shipmentIds: ['ol_shipment_1', 'ol_shipment_2'] });
+
+      expect(protocolAdapter.generateProtocol).toHaveBeenCalledWith({
+        providerShipmentIds: ['waybill-1'],
+      });
+    });
+
+    it('should throw InvalidProtocolBatchException when shipments span multiple carrier connections', async () => {
+      repository.findById
+        .mockResolvedValueOnce(makeShipment({ id: 'ol_shipment_1', connectionId: 'conn-a', providerShipmentId: 'w1' }))
+        .mockResolvedValueOnce(makeShipment({ id: 'ol_shipment_2', connectionId: 'conn-b', providerShipmentId: 'w2' }));
+
+      await expect(
+        service.generateProtocol({ shipmentIds: ['ol_shipment_1', 'ol_shipment_2'] }),
+      ).rejects.toBeInstanceOf(InvalidProtocolBatchException);
+      expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('should throw DispatchProtocolNotSupportedException when the carrier lacks the capability', async () => {
+      repository.findById.mockResolvedValueOnce(makeShipment({ providerShipmentId: 'waybill-1' }));
+      const nonReader: ShippingProviderManagerPort = {
+        generateLabel: jest.fn(),
+        getTracking: jest.fn(),
+        getSupportedMethods: jest.fn(),
+      };
+      integrations.getCapabilityAdapter.mockResolvedValue(nonReader);
+
+      await expect(
+        service.generateProtocol({ shipmentIds: ['ol_shipment_1'] }),
+      ).rejects.toBeInstanceOf(DispatchProtocolNotSupportedException);
+    });
+
+    it('should rethrow when the provider generateProtocol rejects', async () => {
+      repository.findById.mockResolvedValueOnce(makeShipment({ providerShipmentId: 'waybill-1' }));
+      const boom = new Error('provider protocol rejected');
+      protocolAdapter.generateProtocol.mockRejectedValue(boom);
+
+      await expect(service.generateProtocol({ shipmentIds: ['ol_shipment_1'] })).rejects.toBe(boom);
+    });
+  });
+});

--- a/libs/core/src/shipping/application/services/bulk-shipment-dispatch.service.ts
+++ b/libs/core/src/shipping/application/services/bulk-shipment-dispatch.service.ts
@@ -1,0 +1,136 @@
+/**
+ * Bulk Shipment Dispatch Service
+ *
+ * Synchronous bulk surface over the per-order dispatch seam (#964, ADR-019):
+ *
+ *  - `dispatchBulk` loops `IShipmentDispatchService.dispatch()` once per item,
+ *    isolating each order's failure so a partial failure keeps the successful
+ *    siblings' labels (AC-6). It owns NO routing / payment-gate / idempotency /
+ *    persistence of its own — every per-order guarantee is inherited from the
+ *    seam it loops, with zero duplication.
+ *  - `generateProtocol` resolves the dispatched shipments' single carrier
+ *    connection and narrows the `DispatchProtocolReader` sub-capability to
+ *    produce the handover manifest (the per-batch sibling of the #884 per-parcel
+ *    label fetch).
+ *
+ * Deliberately NOT an async batch aggregate (no batch table, worker, or
+ * advancement gate) — DPD bulk is a handful of fast calls, not the slow,
+ * rate-limited, restart-surviving workload that justifies the bulk-offer
+ * machinery. This service is the seam a future async wrapper (#831) would call.
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IBulkShipmentDispatchService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+
+import type { IBulkShipmentDispatchService } from '../interfaces/bulk-shipment-dispatch.service.interface';
+import { IShipmentDispatchService } from '../interfaces/shipment-dispatch.service.interface';
+import type {
+  BulkShipmentDispatchInput,
+  BulkShipmentDispatchResult,
+  PerOrderDispatchResult,
+} from '../types/bulk-shipment-dispatch.types';
+import type { LabelDocument } from '../../domain/types/label-document.types';
+import type { Shipment } from '../../domain/entities/shipment.entity';
+import { DispatchProtocolNotSupportedException } from '../../domain/exceptions/dispatch-protocol-not-supported.exception';
+import { InvalidProtocolBatchException } from '../../domain/exceptions/invalid-protocol-batch.exception';
+import { isDispatchProtocolReader } from '../../domain/ports/capabilities/dispatch-protocol-reader.capability';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import { SHIPMENT_DISPATCH_SERVICE_TOKEN, SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+
+/** Capability the resolved carrier connection must declare to resolve a provider adapter. */
+const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
+
+@Injectable()
+export class BulkShipmentDispatchService implements IBulkShipmentDispatchService {
+  private readonly logger = new Logger(BulkShipmentDispatchService.name);
+
+  constructor(
+    @Inject(SHIPMENT_DISPATCH_SERVICE_TOKEN)
+    private readonly dispatch: IShipmentDispatchService,
+    @Inject(SHIPMENT_REPOSITORY_TOKEN)
+    private readonly shipments: ShipmentRepositoryPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+  ) {}
+
+  async dispatchBulk(input: BulkShipmentDispatchInput): Promise<BulkShipmentDispatchResult> {
+    const results: PerOrderDispatchResult[] = [];
+
+    // Sequential, NOT Promise.all: the per-order idempotency check
+    // (findActiveByOrderId) is best-effort, not concurrency-safe, and the N≤25
+    // cap keeps sequential wall-clock acceptable (ADR-019). Distinct orders also
+    // avoid any shared-row contention by construction.
+    for (const item of input.items) {
+      try {
+        const result = await this.dispatch.dispatch({
+          sourceConnectionId: input.sourceConnectionId,
+          ...item,
+        });
+        results.push(
+          result.kind === 'dispatched'
+            ? { kind: 'dispatched', orderId: item.orderId, shipment: result.shipment }
+            : { kind: 'omp_fulfilled', orderId: item.orderId },
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.warn(`Bulk dispatch failed for order ${item.orderId}: ${message}`);
+        results.push({ kind: 'failed', orderId: item.orderId, error: message });
+      }
+    }
+
+    return { results };
+  }
+
+  async generateProtocol(input: { shipmentIds: string[] }): Promise<LabelDocument> {
+    if (input.shipmentIds.length === 0) {
+      throw new InvalidProtocolBatchException('no shipments provided');
+    }
+
+    const loaded = await Promise.all(input.shipmentIds.map((id) => this.shipments.findById(id)));
+    // Only shipments with a provider id were actually generated — a manifest can
+    // only cover real waybills. Silently drop unknown / label-less ids; if none
+    // remain the batch is invalid.
+    const dispatched = loaded.filter(
+      (s): s is Shipment => s !== null && s.providerShipmentId !== null,
+    );
+    if (dispatched.length === 0) {
+      throw new InvalidProtocolBatchException(
+        'none of the shipments have a generated label (no provider shipment id)',
+      );
+    }
+    // Observability: in the designed flow the caller passes dispatched ids so
+    // nothing drops. A mismatch means an unknown / label-less id slipped in —
+    // surface it so a wrong manifest count is diagnosable rather than silent.
+    if (dispatched.length < input.shipmentIds.length) {
+      this.logger.warn(
+        `Protocol covers ${dispatched.length}/${input.shipmentIds.length} requested shipments; ` +
+          `the rest are unknown or have no generated label`,
+      );
+    }
+
+    const connectionIds = new Set(dispatched.map((s) => s.connectionId));
+    if (connectionIds.size > 1) {
+      throw new InvalidProtocolBatchException(
+        `shipments span ${connectionIds.size} carrier connections; a handover protocol is per-carrier-account`,
+      );
+    }
+    const connectionId = dispatched[0].connectionId;
+
+    const adapter = await this.integrations.getCapabilityAdapter<ShippingProviderManagerPort>(
+      connectionId,
+      SHIPPING_PROVIDER_MANAGER_CAPABILITY,
+    );
+    if (!isDispatchProtocolReader(adapter)) {
+      throw new DispatchProtocolNotSupportedException(connectionId);
+    }
+
+    // Non-null asserted: the filter above kept only providerShipmentId !== null.
+    const providerShipmentIds = dispatched.map((s) => s.providerShipmentId as string);
+    return adapter.generateProtocol({ providerShipmentIds });
+  }
+}

--- a/libs/core/src/shipping/application/types/bulk-shipment-dispatch.types.ts
+++ b/libs/core/src/shipping/application/types/bulk-shipment-dispatch.types.ts
@@ -1,0 +1,57 @@
+/**
+ * Bulk Shipment Dispatch Types
+ *
+ * Contracts for `IBulkShipmentDispatchService` (#964) — dispatch N orders'
+ * labels in one operator action, then produce one carrier handover protocol
+ * over the dispatched shipments.
+ *
+ * Each item is a per-order dispatch payload minus the bulk-shared
+ * `sourceConnectionId` — derived from the shipped `ShipmentDispatchInput`
+ * (#835) via `Omit` so the two can't drift (the per-order seam stays the single
+ * source of truth for the label payload shape). The synchronous orchestrator
+ * reconstructs a full `ShipmentDispatchInput` per item by re-attaching the
+ * shared connection id and looping the existing `dispatch()` — see
+ * [ADR-019](../../../../../docs/architecture/adrs/019-synchronous-bulk-shipment-dispatch.md).
+ *
+ * @module libs/core/src/shipping/application/types
+ */
+
+import type { Shipment } from '../../domain/entities/shipment.entity';
+import type { ShipmentDispatchInput } from './shipment-dispatch.types';
+
+/** A single order's dispatch payload within a bulk request (sans the shared connection). */
+export type BulkShipmentDispatchItem = Omit<ShipmentDispatchInput, 'sourceConnectionId'>;
+
+export type BulkShipmentDispatchInput = {
+  /** The bulk scope: every item dispatches from this order-source connection. */
+  sourceConnectionId: string;
+  /**
+   * Per-order payloads. Bounded by the API (N≤25, ADR-019) — the synchronous
+   * loop issues N sequential outbound calls, so the cap bounds request
+   * wall-clock; the core service itself does not re-impose the cap.
+   */
+  items: BulkShipmentDispatchItem[];
+};
+
+/**
+ * Per-order outcome. Mirrors `ShipmentDispatchResult` but adds `orderId` (so the
+ * operator can correlate each result to its order) and a third `failed` variant:
+ * the per-order seam surfaces a label failure as a THROW (the row is persisted
+ * `failed` first), and the bulk loop catches it into this variant so one bad
+ * order never sinks its successful siblings (AC-6).
+ */
+export type PerOrderDispatchResult =
+  | { readonly kind: 'dispatched'; readonly orderId: string; readonly shipment: Shipment }
+  | { readonly kind: 'omp_fulfilled'; readonly orderId: string }
+  | { readonly kind: 'failed'; readonly orderId: string; readonly error: string };
+
+/**
+ * Result of a bulk dispatch — the per-order outcome list. The handover protocol
+ * is produced by a SEPARATE call (`generateProtocol`) so this stays pure JSON
+ * and the protocol can stream as binary (ADR-019 / the #884 label-download
+ * pattern). The FE collects the dispatched shipment ids from `results`, then
+ * requests the protocol over them.
+ */
+export type BulkShipmentDispatchResult = {
+  readonly results: PerOrderDispatchResult[];
+};

--- a/libs/core/src/shipping/domain/exceptions/dispatch-protocol-not-supported.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/dispatch-protocol-not-supported.exception.ts
@@ -1,0 +1,22 @@
+/**
+ * Dispatch Protocol Not Supported Exception
+ *
+ * Thrown by `BulkShipmentDispatchService.generateProtocol` when the resolved
+ * shipping-provider adapter for the batch's carrier connection does not
+ * implement the `DispatchProtocolReader` sub-capability — i.e. the carrier has
+ * no handover-manifest concept (e.g. InPost). The API maps it to 422 with an
+ * operator-actionable message. Distinct from a provider rejection (502): the
+ * carrier integration simply offers no protocol, it didn't reject a request.
+ *
+ * @module libs/core/src/shipping/domain/exceptions
+ */
+export class DispatchProtocolNotSupportedException extends Error {
+  constructor(public readonly connectionId: string) {
+    super(
+      `Cannot generate a handover protocol: connection ${connectionId} does not ` +
+        `support dispatch protocols`,
+    );
+    this.name = 'DispatchProtocolNotSupportedException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/shipping/domain/exceptions/invalid-protocol-batch.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/invalid-protocol-batch.exception.ts
@@ -1,0 +1,19 @@
+/**
+ * Invalid Protocol Batch Exception
+ *
+ * Thrown by `BulkShipmentDispatchService.generateProtocol` when the requested
+ * shipment set cannot yield a valid handover protocol: no shipment carries a
+ * provider shipment id (no labels generated yet), or the shipments span more
+ * than one carrier connection (the protocol is per-carrier-account, so a mixed
+ * set would produce a wrong manifest). A client-input problem → the API maps it
+ * to 400.
+ *
+ * @module libs/core/src/shipping/domain/exceptions
+ */
+export class InvalidProtocolBatchException extends Error {
+  constructor(public readonly reason: string) {
+    super(`Cannot generate a handover protocol: ${reason}`);
+    this.name = 'InvalidProtocolBatchException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/shipping/domain/ports/capabilities/dispatch-protocol-reader.capability.spec.ts
+++ b/libs/core/src/shipping/domain/ports/capabilities/dispatch-protocol-reader.capability.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * DispatchProtocolReader type-guard unit tests (#964).
+ */
+
+import { isDispatchProtocolReader } from './dispatch-protocol-reader.capability';
+import type { DispatchProtocolReader } from './dispatch-protocol-reader.capability';
+import type { ShippingProviderManagerPort } from '../shipping-provider-manager.port';
+
+const base: ShippingProviderManagerPort = {
+  generateLabel: jest.fn(),
+  getTracking: jest.fn(),
+  getSupportedMethods: jest.fn(),
+};
+
+describe('isDispatchProtocolReader', () => {
+  it('should return true when the adapter implements generateProtocol', () => {
+    const adapter: ShippingProviderManagerPort & DispatchProtocolReader = {
+      ...base,
+      generateProtocol: jest.fn(),
+    };
+    expect(isDispatchProtocolReader(adapter)).toBe(true);
+  });
+
+  it('should return false when the adapter does not implement generateProtocol', () => {
+    expect(isDispatchProtocolReader(base)).toBe(false);
+  });
+});

--- a/libs/core/src/shipping/domain/ports/capabilities/dispatch-protocol-reader.capability.ts
+++ b/libs/core/src/shipping/domain/ports/capabilities/dispatch-protocol-reader.capability.ts
@@ -1,0 +1,47 @@
+/**
+ * Dispatch Protocol Reader Capability
+ *
+ * Optional sub-capability of `ShippingProviderManagerPort` — adapters that can
+ * produce the carrier handover protocol (the "protokół odbioru" / courier
+ * hand-off manifest covering a batch of already-generated shipments) declare
+ * `implements DispatchProtocolReader`. Call sites narrow via
+ * `isDispatchProtocolReader(adapter)` before invoking `generateProtocol`; after
+ * the guard TypeScript knows the method is present.
+ *
+ * This is the sibling reserved by `label-document-reader.capability.ts`: the
+ * label is a per-PARCEL document (one shipment → one label), the protocol is a
+ * per-BATCH document (N shipments → one manifest the courier signs on pickup).
+ * Like `LabelDocumentReader`, the capability names the business verb, not the
+ * wire format — the returned `LabelDocument.contentType` carries the real
+ * format (PDF today; provider-dependent). It reuses `LabelDocument` rather than
+ * inventing a near-identical "ProtocolDocument" type.
+ *
+ * Carrier-neutral and OPTIONAL: carriers with no handover-manifest concept
+ * (e.g. InPost) simply don't implement it, and the bulk-dispatch protocol
+ * endpoint reports the gap rather than failing. Allegro Delivery (#831) reuses
+ * this exact capability for its dispatch manifest.
+ *
+ * @module libs/core/src/shipping/domain/ports/capabilities
+ */
+
+import type { ShippingProviderManagerPort } from '../shipping-provider-manager.port';
+import type { LabelDocument } from '../../types/label-document.types';
+
+export interface DispatchProtocolReader {
+  /**
+   * Produce the handover protocol covering the given provider shipments. The
+   * caller resolves each `providerShipmentId` from the persisted `Shipment`
+   * rows (only shipments with a provider id can appear on a manifest) and
+   * asserts they all belong to one carrier connection — the protocol is
+   * per-carrier-account. Throws (provider error) when the provider rejects the
+   * request; the application service maps that to a
+   * `ShippingProviderRejectionException`.
+   */
+  generateProtocol(input: { providerShipmentIds: string[] }): Promise<LabelDocument>;
+}
+
+export function isDispatchProtocolReader(
+  adapter: ShippingProviderManagerPort,
+): adapter is ShippingProviderManagerPort & DispatchProtocolReader {
+  return typeof (adapter as Partial<DispatchProtocolReader>).generateProtocol === 'function';
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -91,6 +91,8 @@ export type { PickupPointFinder } from './domain/ports/capabilities/pickup-point
 export { isPickupPointFinder } from './domain/ports/capabilities/pickup-point-finder.capability';
 export type { LabelDocumentReader } from './domain/ports/capabilities/label-document-reader.capability';
 export { isLabelDocumentReader } from './domain/ports/capabilities/label-document-reader.capability';
+export type { DispatchProtocolReader } from './domain/ports/capabilities/dispatch-protocol-reader.capability';
+export { isDispatchProtocolReader } from './domain/ports/capabilities/dispatch-protocol-reader.capability';
 export type { LabelDocument } from './domain/types/label-document.types';
 
 // `FulfillmentStatusReader` (#834) lives in `@openlinker/core/orders`
@@ -109,6 +111,8 @@ export { PickupPointFinderNotSupportedException } from './domain/exceptions/pick
 export { ShippingProviderRejectionException } from './domain/exceptions/shipping-provider-rejection.exception';
 export { LabelDocumentNotSupportedException } from './domain/exceptions/label-document-not-supported.exception';
 export { LabelNotAvailableException } from './domain/exceptions/label-not-available.exception';
+export { DispatchProtocolNotSupportedException } from './domain/exceptions/dispatch-protocol-not-supported.exception';
+export { InvalidProtocolBatchException } from './domain/exceptions/invalid-protocol-batch.exception';
 
 // Application — dispatch seam (#835). Interface + types only; the service
 // class is injected via SHIPMENT_DISPATCH_SERVICE_TOKEN (exported above via
@@ -118,6 +122,17 @@ export type {
   ShipmentDispatchInput,
   ShipmentDispatchResult,
 } from './application/types/shipment-dispatch.types';
+
+// Application — bulk-dispatch + handover-protocol seam (#964, ADR-019).
+// Interface + types only; the service is injected via
+// BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN.
+export type { IBulkShipmentDispatchService } from './application/interfaces/bulk-shipment-dispatch.service.interface';
+export type {
+  BulkShipmentDispatchInput,
+  BulkShipmentDispatchItem,
+  BulkShipmentDispatchResult,
+  PerOrderDispatchResult,
+} from './application/types/bulk-shipment-dispatch.types';
 
 // Application — read + cancel seams (#846). Interfaces only; services are
 // injected via SHIPMENT_QUERY_SERVICE_TOKEN / SHIPMENT_CANCELLATION_SERVICE_TOKEN.

--- a/libs/core/src/shipping/shipping.module.ts
+++ b/libs/core/src/shipping/shipping.module.ts
@@ -31,6 +31,7 @@ import { ShipmentOrmEntity } from './infrastructure/persistence/entities/shipmen
 import { ShipmentRepository } from './infrastructure/persistence/repositories/shipment.repository';
 import { RedisPickupPointCacheAdapter } from './infrastructure/adapters/redis-pickup-point-cache.adapter';
 import { ShipmentDispatchService } from './application/services/shipment-dispatch.service';
+import { BulkShipmentDispatchService } from './application/services/bulk-shipment-dispatch.service';
 import { ShipmentQueryService } from './application/services/shipment-query.service';
 import { ShipmentCancellationService } from './application/services/shipment-cancellation.service';
 import { PickupPointLookupService } from './application/services/pickup-point-lookup.service';
@@ -39,6 +40,7 @@ import { ShipmentStatusSyncService } from './application/services/shipment-statu
 import { FulfillmentStatusSyncService } from './application/services/fulfillment-status-sync.service';
 import { ShipmentLabelService } from './application/services/shipment-label.service';
 import {
+  BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN,
   FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,
   PICKUP_POINT_CACHE_TOKEN,
   PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
@@ -76,6 +78,13 @@ import {
     {
       provide: SHIPMENT_DISPATCH_SERVICE_TOKEN,
       useExisting: ShipmentDispatchService,
+    },
+    // #964 bulk surface: loops the per-order dispatch seam (synchronous,
+    // ADR-019) + resolves the DispatchProtocolReader sub-capability.
+    BulkShipmentDispatchService,
+    {
+      provide: BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN,
+      useExisting: BulkShipmentDispatchService,
     },
     ShipmentQueryService,
     {
@@ -125,6 +134,7 @@ import {
   exports: [
     SHIPMENT_REPOSITORY_TOKEN,
     SHIPMENT_DISPATCH_SERVICE_TOKEN,
+    BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN,
     SHIPMENT_QUERY_SERVICE_TOKEN,
     SHIPMENT_CANCELLATION_SERVICE_TOKEN,
     PICKUP_POINT_CACHE_TOKEN,

--- a/libs/core/src/shipping/shipping.tokens.ts
+++ b/libs/core/src/shipping/shipping.tokens.ts
@@ -13,6 +13,7 @@
 export const SHIPMENT_REPOSITORY_TOKEN = Symbol('ShipmentRepositoryPort');
 export const PICKUP_POINT_CACHE_TOKEN = Symbol('PickupPointCachePort');
 export const SHIPMENT_DISPATCH_SERVICE_TOKEN = Symbol('IShipmentDispatchService');
+export const BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN = Symbol('IBulkShipmentDispatchService');
 export const SHIPMENT_QUERY_SERVICE_TOKEN = Symbol('IShipmentQueryService');
 export const SHIPMENT_CANCELLATION_SERVICE_TOKEN = Symbol('IShipmentCancellationService');
 export const PICKUP_POINT_LOOKUP_SERVICE_TOKEN = Symbol('IPickupPointLookupService');

--- a/libs/integrations/dpd-polska/src/domain/types/dpd-rest.types.ts
+++ b/libs/integrations/dpd-polska/src/domain/types/dpd-rest.types.ts
@@ -210,6 +210,33 @@ export interface DpdGenerateSpedLabelsResponse {
   traceId?: string;
 }
 
+// --- protocol (handover manifest, #964) --------------------------------------
+
+/**
+ * Handover-protocol ("protokół odbioru") request — the courier hand-off manifest
+ * over a batch of already-generated waybills. Modelled on the label request: a
+ * waybill `session` + an output format, returning a base64 document.
+ *
+ * ⚠ OQ-1 (#964 plan): the exact path (`/public/shipment/v1/generateProtocol`?),
+ * whether it keys on a waybill list vs the create `sessionId`, and the precise
+ * field names are confirmed against the live `DPDServices` Swagger in the
+ * Phase-0 spike. This is the documented/expected shape, isolated here + in the
+ * mapper so a later correction touches only these two files.
+ */
+export interface DpdGenerateProtocolRequest {
+  session: DpdLabelSession;
+  outputDocFormat: DpdOutputDocFormat;
+}
+
+export interface DpdGenerateProtocolResponse {
+  /** Non-`'OK'` ⇒ protocol generation failed. */
+  status: string;
+  /** Base64-encoded document bytes (PDF for `outputDocFormat: 'PDF'`). */
+  documentData?: string;
+  documentId?: string;
+  traceId?: string;
+}
+
 // --- error envelopes ---------------------------------------------------------
 
 export interface DpdErrorItem {

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-shipping.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-shipping.adapter.spec.ts
@@ -9,6 +9,7 @@
  * @module libs/integrations/dpd-polska/src/infrastructure/adapters
  */
 import {
+  isDispatchProtocolReader,
   isPickupPointFinder,
   ShippingProviderRejectionException,
   type GenerateLabelCommand,
@@ -64,6 +65,35 @@ describe('DpdShippingAdapter', () => {
 
   it('should declare the PickupPointFinder capability', () => {
     expect(isPickupPointFinder(adapter)).toBe(true);
+  });
+
+  it('should declare the DispatchProtocolReader capability', () => {
+    expect(isDispatchProtocolReader(adapter)).toBe(true);
+  });
+
+  it('should generate a handover protocol PDF over a batch of waybills (idempotent)', async () => {
+    const pdf = Buffer.from('%PDF-protocol', 'utf8').toString('base64');
+    http.request.mockResolvedValueOnce({ status: 'OK', documentData: pdf });
+
+    const doc = await adapter.generateProtocol({ providerShipmentIds: ['WB1', 'WB2'] });
+
+    expect(doc.contentType).toBe('application/pdf');
+    expect(Buffer.from(doc.body).toString('utf8')).toBe('%PDF-protocol');
+    expect(http.request).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'POST', path: '/public/shipment/v1/generateProtocol', idempotent: true }),
+    );
+    const body = http.request.mock.calls[0][0].body as {
+      session: { type: string; packages: Array<{ parcels: Array<{ waybill: string }> }> };
+    };
+    expect(body.session.type).toBe('DOMESTIC');
+    expect(body.session.packages.map((p) => p.parcels[0].waybill)).toEqual(['WB1', 'WB2']);
+  });
+
+  it('should reject when protocol generation returns a non-OK status', async () => {
+    http.request.mockResolvedValueOnce({ status: 'PROTOCOL_ERROR' });
+    await expect(
+      adapter.generateProtocol({ providerShipmentIds: ['WB1'] }),
+    ).rejects.toBeInstanceOf(ShippingProviderRejectionException);
   });
 
   it('should create a shipment and return the waybill as provider id + tracking + label ref', async () => {

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts
@@ -20,6 +20,7 @@
  */
 import {
   ShippingProviderRejectionException,
+  type DispatchProtocolReader,
   type FindPickupPointsQuery,
   type GenerateLabelCommand,
   type GenerateLabelResult,
@@ -34,6 +35,7 @@ import {
 import type { DpdConnectionConfig } from '../../domain/types/dpd-config.types';
 import type {
   DpdGeneratePackagesNumbersResponse,
+  DpdGenerateProtocolResponse,
   DpdGenerateSpedLabelsResponse,
   DpdPointSearchResponse,
 } from '../../domain/types/dpd-rest.types';
@@ -42,8 +44,10 @@ import {
   assertCreateSucceededAndExtractWaybill,
   buildCreatePackagesRequest,
   buildGenerateLabelRequest,
+  buildGenerateProtocolRequest,
   buildPointSearchQuery,
   decodeLabelDocument,
+  decodeProtocolDocument,
   toGenerateLabelResult,
   toPickupPoint,
 } from '../mappers/dpd-shipment.mapper';
@@ -52,13 +56,20 @@ const SUPPORTED_METHODS: readonly ShippingMethod[] = ['kurier', 'pickup'];
 
 const CREATE_PATH = '/public/shipment/v1/generatePackagesNumbers';
 const LABEL_PATH = '/public/shipment/v1/generateSpedLabels';
+// OQ-1 (#964 plan): exact protocol path/request/response confirmed against the
+// live Swagger in the Phase-0 spike; isolated here + in the mapper/types.
+const PROTOCOL_PATH = '/public/shipment/v1/generateProtocol';
 // OQ-1 (#963 plan): exact point-directory path/method/auth confirmed against the
 // live Swagger in the Phase-0 spike. DPDServices is POST-heavy (findPostalCode-
 // style), so v1 POSTs the query body; isolated here + in the mapper.
 const POINT_SEARCH_PATH = '/public/appservices/v1/findPoints';
 
 export class DpdShippingAdapter
-  implements ShippingProviderManagerPort, LabelDocumentReader, PickupPointFinder
+  implements
+    ShippingProviderManagerPort,
+    LabelDocumentReader,
+    PickupPointFinder,
+    DispatchProtocolReader
 {
   constructor(
     private readonly http: IDpdHttpClient,
@@ -93,6 +104,19 @@ export class DpdShippingAdapter
       idempotent: true,
     });
     return decodeLabelDocument(response);
+  }
+
+  async generateProtocol(input: { providerShipmentIds: string[] }): Promise<LabelDocument> {
+    const body = buildGenerateProtocolRequest(input.providerShipmentIds);
+    // Idempotent render of the handover manifest over existing waybills — safe
+    // to retry on network/timeout (no side effect at the carrier).
+    const response = await this.http.request<DpdGenerateProtocolResponse>({
+      method: 'POST',
+      path: PROTOCOL_PATH,
+      body,
+      idempotent: true,
+    });
+    return decodeProtocolDocument(response);
   }
 
   async findPickupPoints(query: FindPickupPointsQuery): Promise<PickupPoint[]> {

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
@@ -12,6 +12,7 @@ import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
 import type { DpdConnectionConfig } from '../../../domain/types/dpd-config.types';
 import type {
   DpdGeneratePackagesNumbersResponse,
+  DpdGenerateProtocolResponse,
   DpdGenerateSpedLabelsResponse,
 } from '../../../domain/types/dpd-rest.types';
 import type { DpdPoint } from '../../../domain/types/dpd-rest.types';
@@ -19,8 +20,10 @@ import {
   assertCreateSucceededAndExtractWaybill,
   buildCreatePackagesRequest,
   buildGenerateLabelRequest,
+  buildGenerateProtocolRequest,
   buildPointSearchQuery,
   decodeLabelDocument,
+  decodeProtocolDocument,
   toGenerateLabelResult,
   toPickupPoint,
 } from '../dpd-shipment.mapper';
@@ -381,6 +384,33 @@ describe('decodeLabelDocument', () => {
   it('should throw command.empty-label when OK but no documentData', () => {
     const error = run(() => decodeLabelDocument({ status: 'OK' }));
     expect(error).toMatchObject({ providerCode: 'command.empty-label' });
+  });
+});
+
+describe('buildGenerateProtocolRequest', () => {
+  it('should build a DOMESTIC PDF session listing every waybill as its own package', () => {
+    const req = buildGenerateProtocolRequest(['WB1', 'WB2', 'WB3']);
+    expect(req.outputDocFormat).toBe('PDF');
+    expect(req.session.type).toBe('DOMESTIC');
+    expect(req.session.packages?.map((p) => p.parcels[0].waybill)).toEqual(['WB1', 'WB2', 'WB3']);
+  });
+});
+
+describe('decodeProtocolDocument', () => {
+  it('should decode the base64 protocol PDF to bytes', () => {
+    const pdf = Buffer.from('%PDF-protocol', 'utf8').toString('base64');
+    const doc = decodeProtocolDocument({ status: 'OK', documentData: pdf } as DpdGenerateProtocolResponse);
+    expect(doc.contentType).toBe('application/pdf');
+    expect(Buffer.from(doc.body).toString('utf8')).toBe('%PDF-protocol');
+  });
+
+  it('should throw when the protocol status is not OK', () => {
+    expect(() => decodeProtocolDocument({ status: 'ERROR' })).toThrow(ShippingProviderRejectionException);
+  });
+
+  it('should throw command.empty-protocol when OK but no documentData', () => {
+    const error = run(() => decodeProtocolDocument({ status: 'OK' }));
+    expect(error).toMatchObject({ providerCode: 'command.empty-protocol' });
   });
 });
 

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
@@ -29,8 +29,11 @@ import type { DpdConnectionConfig, DpdSenderContact } from '../../domain/types/d
 import type {
   DpdGeneratePackagesNumbersRequest,
   DpdGeneratePackagesNumbersResponse,
+  DpdGenerateProtocolRequest,
+  DpdGenerateProtocolResponse,
   DpdGenerateSpedLabelsRequest,
   DpdGenerateSpedLabelsResponse,
+  DpdLabelSessionPackage,
   DpdParcel,
   DpdPoint,
   DpdPointSearchQuery,
@@ -199,6 +202,42 @@ export function decodeLabelDocument(res: DpdGenerateSpedLabelsResponse): LabelDo
       DPD_BRAND,
       'command.empty-label',
       'DPD reported OK but returned no label document',
+    );
+  }
+  return {
+    contentType: 'application/pdf',
+    body: new Uint8Array(Buffer.from(res.documentData, 'base64')),
+  };
+}
+
+/**
+ * Build the handover-protocol request over a batch of waybills (#964). One
+ * domestic session listing every waybill as its own package/parcel, PDF output.
+ */
+export function buildGenerateProtocolRequest(waybills: string[]): DpdGenerateProtocolRequest {
+  const packages: DpdLabelSessionPackage[] = waybills.map((waybill) => ({
+    parcels: [{ waybill }],
+  }));
+  return {
+    session: { type: 'DOMESTIC', packages },
+    outputDocFormat: 'PDF',
+  };
+}
+
+/** Assert the protocol response succeeded and decode the base64 PDF to bytes. */
+export function decodeProtocolDocument(res: DpdGenerateProtocolResponse): LabelDocument {
+  if (res.status !== DPD_STATUS_OK) {
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      res.status,
+      `DPD protocol generation rejected (status: ${res.status})`,
+    );
+  }
+  if (!res.documentData) {
+    throw new ShippingProviderRejectionException(
+      DPD_BRAND,
+      'command.empty-protocol',
+      'DPD reported OK but returned no protocol document',
     );
   }
   return {

--- a/libs/integrations/dpd-polska/src/testing/__tests__/fake-dpd-shipping.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/testing/__tests__/fake-dpd-shipping.adapter.spec.ts
@@ -87,6 +87,19 @@ describe('FakeDpdShippingAdapter', () => {
     expect(doc.body.length).toBeGreaterThan(0);
   });
 
+  it('should return a PDF handover protocol document', async () => {
+    const doc = await adapter.generateProtocol({ providerShipmentIds: ['fake-dpd-1', 'fake-dpd-2'] });
+    expect(doc.contentType).toBe('application/pdf');
+    expect(doc.body.length).toBeGreaterThan(0);
+  });
+
+  it('should surface a seeded failure from generateProtocol', async () => {
+    adapter.seedFailure(new Error('protocol boom'));
+    await expect(adapter.generateProtocol({ providerShipmentIds: ['fake-dpd-1'] })).rejects.toThrow(
+      'protocol boom',
+    );
+  });
+
   it('should throw tracking.unavailable from getTracking', async () => {
     await expect(adapter.getTracking({ providerShipmentId: 'fake-dpd-1' })).rejects.toMatchObject({
       providerCode: 'tracking.unavailable',

--- a/libs/integrations/dpd-polska/src/testing/fake-dpd-shipping.adapter.ts
+++ b/libs/integrations/dpd-polska/src/testing/fake-dpd-shipping.adapter.ts
@@ -15,6 +15,7 @@
  */
 import {
   ShippingProviderRejectionException,
+  type DispatchProtocolReader,
   type FindPickupPointsQuery,
   type GenerateLabelCommand,
   type GenerateLabelResult,
@@ -30,7 +31,11 @@ import {
 const SUPPORTED_METHODS: readonly ShippingMethod[] = ['kurier', 'pickup'];
 
 export class FakeDpdShippingAdapter
-  implements ShippingProviderManagerPort, LabelDocumentReader, PickupPointFinder
+  implements
+    ShippingProviderManagerPort,
+    LabelDocumentReader,
+    PickupPointFinder,
+    DispatchProtocolReader
 {
   private counter = 0;
   private seededFailure: Error | null = null;
@@ -99,9 +104,19 @@ export class FakeDpdShippingAdapter
     );
   }
 
+  generateProtocol(_input: { providerShipmentIds: string[] }): Promise<LabelDocument> {
+    if (this.seededFailure) {
+      return Promise.reject(this.seededFailure);
+    }
+    return Promise.resolve({
+      contentType: 'application/pdf',
+      body: new Uint8Array([0x25, 0x50, 0x44, 0x46]), // %PDF
+    });
+  }
+
   // --- test helpers ----------------------------------------------------------
 
-  /** Make the next `generateLabel` / `fetchLabel` throw the given error. */
+  /** Make the next `generateLabel` / `fetchLabel` / `generateProtocol` throw the given error. */
   seedFailure(error: Error): void {
     this.seededFailure = error;
   }


### PR DESCRIPTION
## What & why

Closes #964. Lets an operator dispatch **N orders' DPD labels in one action** and download **one DPD handover protocol** (the courier hand-off manifest), with **per-order success/failure** and partial-failure survival.

Synchronous-orchestrator design, recorded in **ADR-019**. The async executor (worker + advancement gate) and a durable batch record are deliberately **deferred** — DPD bulk is a handful of fast calls, not the slow, rate-limited, restart-surviving workload that justifies the bulk-offer aggregate. This service is the seam a future async wrapper (#831, Allegro Delivery — the slow workload) would call.

## Changes

**Core (`libs/core/src/shipping/`)**
- `DispatchProtocolReader` sub-capability + `isDispatchProtocolReader` guard — the per-batch sibling pre-reserved by `label-document-reader.capability.ts`. Optional + carrier-neutral.
- `BulkShipmentDispatchService` (synchronous, `IBulkShipmentDispatchService`):
  - `dispatchBulk` loops the existing per-order `ShipmentDispatchService.dispatch()` — inheriting routing (#832), the payment-status gate (#938), per-order idempotency, and `Shipment`-row creation — and isolates each order's failure into a `failed` result so a partial failure keeps the successful siblings' labels.
  - `generateProtocol` loads the shipments, asserts a single carrier connection (the protocol is per-carrier-account), and narrows `DispatchProtocolReader`.
- New token (`BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN`), two domain exceptions (`InvalidProtocolBatchException`, `DispatchProtocolNotSupportedException`), barrel exports, module wiring.

**DPD (`libs/integrations/dpd-polska/`)** — adapter + fake implement `generateProtocol` via the `generateProtocol` endpoint; wire types + mapper (`buildGenerateProtocolRequest` / `decodeProtocolDocument`). **Manifest unchanged** — sub-capabilities are discovered via the `is*` guard, matching `LabelDocumentReader`/`PickupPointFinder`.

**API (`apps/api/src/shipping/`)**
- `POST /shipments/bulk/generate-labels` — items capped at **25** (ADR-019: the synchronous loop issues N sequential outbound calls; not the bulk-offer 100, which fans out to async workers). Returns a per-order outcome list (200 even on partial failure).
- `POST /shipments/bulk/protocol` — streams the handover manifest as binary (mirrors `GET /shipments/:id/label`).

## Two decisions to note

1. **Protocol endpoint keys by OL shipment id, not waybill.** The plan floated a stateless GET-by-waybill; this implements `POST …/protocol` taking shipment ids and deriving the carrier connection + waybills from the persisted rows — so the client can't supply (or spoof) a connection id, and the single-connection assertion runs on real rows. Resolves OQ-2 to the OL-native, safer option.
2. **OQ-1 (live DPD `generateProtocol` shape) is a pre-merge / post-creds AC.** The exact path/request/response is unverified against the sandbox (gated on #962 REST test creds) — isolated in the DPD types + mapper, exactly as #962/#963 shipped. **Do not merge before the live bulk + protocol round-trip is confirmed.**

## Testing

- Unit: bulk service (all-success / partial-failure survival / omp_fulfilled passthrough / no-capability / mixed-connection / empty / label-less drop / provider-error), capability guard, DPD mapper + adapter + fake, controller (both endpoints + exception mapping).
- Integration: `shipments-bulk-dispatch.int-spec.ts` — bulk happy-path (N persisted shipments + protocol) and partial-failure survival, via the existing shipping harness.
- `pnpm lint` / `type-check` / `check:invariants` / unit / shipping int-specs all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)