### PR TITLE
feat(shipping): paczkomat cache v2 — background refresh + query-result caching (#849)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -88,6 +88,16 @@ OL_PRODUCT_SYNC_CRON=*/20 * * * *
 OL_INVENTORY_SYNC_ENABLED=true
 OL_INVENTORY_SYNC_CRON=*/15 * * * *
 
+# --- Schedulers: paczkomat cache re-warm (#849, capability-based, ShippingProviderManager)
+# Daily re-runs the top-N most-frequently-queried pickup-point searches to
+# refresh their cached points + result lists. Set ENABLED=false to disable.
+OL_PICKUP_POINT_REFRESH_ENABLED=true
+OL_PICKUP_POINT_REFRESH_CRON=0 3 * * *
+# Number of top-frequent queries to re-warm per connection (default 50, clamped 1..500)
+# OL_PICKUP_POINT_REFRESH_TOP_N=50
+# Result-cache TTL in seconds (default 3600 = 1h, clamped 60..86400; shorter than the 24h per-point entry)
+# OL_PICKUP_POINT_SEARCH_CACHE_TTL_SECONDS=3600
+
 # --- Schedulers: Allegro offers sync ------------------------------------------
 ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED=true
 ALLEGRO_OFFERS_SYNC_INTERVAL_CRON=*/1 * * * *

--- a/apps/api/src/shipping/http/pickup-point.controller.spec.ts
+++ b/apps/api/src/shipping/http/pickup-point.controller.spec.ts
@@ -39,7 +39,7 @@ describe('PickupPointController', () => {
   let controller: PickupPointController;
 
   beforeEach(() => {
-    lookup = { search: jest.fn(), getCachedPoint: jest.fn() };
+    lookup = { search: jest.fn(), refreshSearch: jest.fn(), getCachedPoint: jest.fn() };
     controller = new PickupPointController(lookup);
   });
 

--- a/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
+++ b/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
@@ -93,7 +93,11 @@ describe('SchedulerService', () => {
 
   describe('onApplicationBootstrap', () => {
     const defaultConfigGet = (key: string, defaultValue?: unknown): unknown => {
-      const cronKeys = ['OL_INVENTORY_SYNC_CRON', 'OL_PRODUCT_SYNC_CRON'];
+      const cronKeys = [
+        'OL_INVENTORY_SYNC_CRON',
+        'OL_PRODUCT_SYNC_CRON',
+        'OL_PICKUP_POINT_REFRESH_CRON',
+      ];
       if (cronKeys.includes(key)) return defaultValue ?? '*/15 * * * *';
       return 'true';
     };
@@ -156,7 +160,7 @@ describe('SchedulerService', () => {
 
     it('should not carry any allegro-specific task knowledge in core', () => {
       // Regression guard for #584: with an empty registry the scheduler must
-      // register *only* the two capability-based core tasks. The previous
+      // register *only* the capability-based core tasks. The previous
       // implementation hardcoded `allegro-orders-poll` and `allegro-offers-sync`
       // here; both must now be contributed by AllegroIntegrationModule.
       configService.get.mockImplementation(defaultConfigGet);
@@ -164,7 +168,11 @@ describe('SchedulerService', () => {
       service.onApplicationBootstrap();
 
       const registeredJobs = schedulerRegistry.addCronJob.mock.calls.map((c) => c[0]);
-      expect(registeredJobs.sort()).toEqual(['master-inventory-sync', 'master-product-sync']);
+      expect(registeredJobs.sort()).toEqual([
+        'master-inventory-sync',
+        'master-product-sync',
+        'pickup-point-refresh',
+      ]);
     });
 
     it('should skip a registry-contributed task whose enabledEnvVar resolves to false', () => {

--- a/apps/api/src/sync/application/services/scheduler.service.ts
+++ b/apps/api/src/sync/application/services/scheduler.service.ts
@@ -53,6 +53,7 @@ export class SchedulerService implements OnApplicationBootstrap, OnModuleDestroy
     // core-side; only platform-specific *triggers* move to integrations.
     this.registerInventorySyncTask();
     this.registerProductSyncTask();
+    this.registerPickupPointRefreshTask();
 
     // Drain plugin-contributed tasks. Integration modules have already
     // populated the registry at `onModuleInit`; NestJS guarantees every
@@ -314,6 +315,42 @@ export class SchedulerService implements OnApplicationBootstrap, OnModuleDestroy
       }),
       generateIdempotencyKey: (connection, timestamp) =>
         `master:${connection.id}:product:syncAll:${timestamp}`,
+    });
+  }
+
+  /**
+   * Register the periodic paczkomat-cache re-warm task (#849).
+   *
+   * Enqueues `shipping.pickupPoint.refreshFrequent` for every active connection
+   * that supports the ShippingProviderManager capability (capability-scoped —
+   * covers InPost and DPD alike). The worker handler delegates to the core
+   * `PickupPointRefreshService`, which re-runs the top-N most-frequent searches;
+   * connections without a pickup-point finder no-op cleanly. Daily by default.
+   */
+  private registerPickupPointRefreshTask(): void {
+    const enabled = this.configService.get<string>('OL_PICKUP_POINT_REFRESH_ENABLED', 'true');
+    if (enabled === 'false') {
+      return;
+    }
+
+    const cron = this.configService.get<string>('OL_PICKUP_POINT_REFRESH_CRON', '0 3 * * *');
+
+    this.tasks.push({
+      taskId: 'pickup-point-refresh',
+      jobType: 'shipping.pickupPoint.refreshFrequent',
+      cronExpression: cron,
+      enabledEnvVar: 'OL_PICKUP_POINT_REFRESH_ENABLED',
+      connectionFilter: async () => {
+        const adapters = await this.integrationsService.listCapabilityAdapters({
+          capability: 'ShippingProviderManager',
+        });
+        return (adapters ?? []).map((a) => a.connection);
+      },
+      generatePayload: () => ({
+        schemaVersion: 1,
+      }),
+      generateIdempotencyKey: (connection, timestamp) =>
+        `shipping:${connection.id}:pickupPoints:refresh:${timestamp}`,
     });
   }
 }

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -25,6 +25,7 @@ import { MasterInventorySyncHandler } from './master-inventory-sync.handler';
 import { AutoMatchVariantsHandler } from './auto-match-variants.handler';
 import { MasterInventorySyncAllHandler } from './master-inventory-sync-all.handler';
 import { MasterProductSyncAllHandler } from './master-product-sync-all.handler';
+import { PickupPointRefreshHandler } from './pickup-point-refresh.handler';
 
 @Injectable()
 export class HandlerRegistrationService implements OnModuleInit {
@@ -45,7 +46,8 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly masterInventorySyncHandler: MasterInventorySyncHandler,
     private readonly autoMatchVariantsHandler: AutoMatchVariantsHandler,
     private readonly masterInventorySyncAllHandler: MasterInventorySyncAllHandler,
-    private readonly masterProductSyncAllHandler: MasterProductSyncAllHandler
+    private readonly masterProductSyncAllHandler: MasterProductSyncAllHandler,
+    private readonly pickupPointRefreshHandler: PickupPointRefreshHandler
   ) {}
 
   onModuleInit(): void {
@@ -94,6 +96,12 @@ export class HandlerRegistrationService implements OnModuleInit {
 
     // Register master product sync all handler (catalog discovery / periodic full sync)
     this.handlerRegistry.register('master.product.syncAll', this.masterProductSyncAllHandler);
+
+    // Register pickup-point background-refresh handler (#849, daily re-warm)
+    this.handlerRegistry.register(
+      'shipping.pickupPoint.refreshFrequent',
+      this.pickupPointRefreshHandler
+    );
 
     // Register inventory propagate to marketplaces handler
     this.handlerRegistry.register(

--- a/apps/worker/src/sync/handlers/pickup-point-refresh.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/pickup-point-refresh.handler.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Pickup-point refresh handler unit tests (#849).
+ */
+import type { IPickupPointRefreshService } from '@openlinker/core/shipping';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import type { SyncJob } from '@openlinker/core/sync';
+import { PickupPointRefreshHandler } from './pickup-point-refresh.handler';
+
+function makeJob(): SyncJob {
+  return {
+    id: 'job-1',
+    jobType: 'shipping.pickupPoint.refreshFrequent',
+    connectionId: 'conn-1',
+    payload: { schemaVersion: 1 },
+    idempotencyKey: 'shipping:conn-1:pickupPoints:refresh:2026-06-05-03-00',
+    status: 'running',
+    attempts: 1,
+    maxAttempts: 10,
+    nextRunAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as SyncJob;
+}
+
+describe('PickupPointRefreshHandler', () => {
+  let refreshService: jest.Mocked<IPickupPointRefreshService>;
+  let handler: PickupPointRefreshHandler;
+
+  beforeEach(() => {
+    refreshService = { refreshFrequentForConnection: jest.fn() };
+    handler = new PickupPointRefreshHandler(refreshService);
+  });
+
+  it('delegates to the refresh service and returns ok', async () => {
+    refreshService.refreshFrequentForConnection.mockResolvedValue({ refreshed: 3, failed: 0 });
+
+    const result = await handler.execute(makeJob());
+
+    expect(refreshService.refreshFrequentForConnection).toHaveBeenCalledWith('conn-1');
+    expect(result).toEqual({ outcome: 'ok' });
+  });
+
+  it('wraps a service failure in SyncJobExecutionError', async () => {
+    refreshService.refreshFrequentForConnection.mockRejectedValue(new Error('redis down'));
+
+    await expect(handler.execute(makeJob())).rejects.toBeInstanceOf(SyncJobExecutionError);
+  });
+});

--- a/apps/worker/src/sync/handlers/pickup-point-refresh.handler.ts
+++ b/apps/worker/src/sync/handlers/pickup-point-refresh.handler.ts
@@ -1,0 +1,63 @@
+/**
+ * Pickup-Point Refresh Handler (#849)
+ *
+ * Thin delegate for jobs of type `shipping.pickupPoint.refreshFrequent`.
+ * Re-warms the most-frequently-queried pickup-point searches for one
+ * connection via the core `PickupPointRefreshService` (which reads the top-N
+ * queries and re-runs each, refreshing the per-point + result caches). The
+ * scheduler fans this out daily, one job per ShippingProviderManager
+ * connection; connections without a pickup-point finder no-op in the service.
+ *
+ * Mirrors the other shipping-backed worker handlers (e.g.
+ * `MarketplaceShipmentStatusSyncHandler`, #838): thin, delegates to a core
+ * service, wraps failures in `SyncJobExecutionError`.
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import type {
+  SyncJobHandler,
+  SyncJobHandlerResult,
+  SyncJob as SyncJobEntity,
+} from '@openlinker/core/sync';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import {
+  IPickupPointRefreshService,
+  PICKUP_POINT_REFRESH_SERVICE_TOKEN,
+} from '@openlinker/core/shipping';
+import { Logger } from '@openlinker/shared/logging';
+
+type SyncJob = SyncJobEntity;
+
+@Injectable()
+export class PickupPointRefreshHandler implements SyncJobHandler {
+  private readonly logger = new Logger(PickupPointRefreshHandler.name);
+
+  constructor(
+    @Inject(PICKUP_POINT_REFRESH_SERVICE_TOKEN)
+    private readonly refreshService: IPickupPointRefreshService,
+  ) {}
+
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
+    this.logger.log(
+      `Executing shipping.pickupPoint.refreshFrequent job ${job.id} for connection ${job.connectionId}`,
+    );
+
+    try {
+      const result = await this.refreshService.refreshFrequentForConnection(job.connectionId);
+      this.logger.log(
+        `shipping.pickupPoint.refreshFrequent completed (connection=${job.connectionId}): refreshed=${result.refreshed}, failed=${result.failed}`,
+      );
+      return { outcome: 'ok' };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SyncJobExecutionError(
+        `Pickup-point refresh failed: ${message}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+}

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -35,6 +35,7 @@ import { MasterInventorySyncHandler } from './handlers/master-inventory-sync.han
 import { AutoMatchVariantsHandler } from './handlers/auto-match-variants.handler';
 import { MasterInventorySyncAllHandler } from './handlers/master-inventory-sync-all.handler';
 import { MasterProductSyncAllHandler } from './handlers/master-product-sync-all.handler';
+import { PickupPointRefreshHandler } from './handlers/pickup-point-refresh.handler';
 import { HandlerRegistrationService } from './handlers/handler-registration.service';
 
 @Module({
@@ -69,6 +70,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     AutoMatchVariantsHandler,
     MasterInventorySyncAllHandler,
     MasterProductSyncAllHandler,
+    PickupPointRefreshHandler,
     HandlerRegistrationService,
   ],
 })

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-849-paczkomat-cache-v2.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-849-paczkomat-cache-v2.md
@@ -1,0 +1,44 @@
+# Pre-implement gate — #849 Paczkomat cache v2
+
+**Plan:** `docs/plans/implementation-plan-849-paczkomat-cache-v2.md`
+**Gate run:** read-only, against the live worktree @ `13001fd1`.
+
+## Verdict: `READY`
+
+No reuse collisions, no contract-surface breaks. The change is purely additive (new ports/adapters/service/tokens/job-type + an additive method on one in-context interface). No DB/migration. The one feasibility risk flagged in `/tech-review` (raw `'REDIS_CLIENT'` injectable from the shipping context) was verified resolved before this gate — `RedisConfigModule` is `@Global()` + `exports: ['REDIS_CLIENT']`, already injected across `libs/core`.
+
+## Reuse findings
+
+| Plan artifact | Status | Evidence |
+|---|---|---|
+| `PickupPointSearchCachePort` (port) | **NEW** | tree-wide grep: absent |
+| `PickupPointQueryStatsPort` (port) | **NEW** | absent |
+| `pickup-point-query.ts` (normalizer) | **NEW** | absent |
+| `RedisPickupPointSearchCacheAdapter` | **NEW** | absent |
+| `RedisPickupPointQueryStatsAdapter` | **NEW** | absent |
+| `PickupPointRefreshService` / `IPickupPointRefreshService` | **NEW** | absent |
+| `PickupPointRefreshHandler` (worker) | **NEW** | absent |
+| `registerPickupPointRefreshTask` (scheduler) | **NEW** | absent |
+| 3 tokens (`PICKUP_POINT_SEARCH_CACHE_TOKEN`, `…_QUERY_STATS_TOKEN`, `…_REFRESH_SERVICE_TOKEN`) | **NEW** | `shipping.tokens.ts` holds 10 tokens, none of these |
+| job type `shipping.pickupPoint.refreshFrequent` | **NEW** | `JobTypeValues` (16 entries) has no `shipping.*` |
+| **Reused (not recreated):** shared `CachePort` + `CACHE_PORT_TOKEN` (`@Global`), `'REDIS_CLIENT'` (`@Global` export), `SchedulerTaskConfig` registry + `SchedulerService`, `JobTypeValues` + `SyncJobHandlerRegistry`, `IIntegrationsService.listCapabilityAdapters({capability:'ShippingProviderManager'})`, `PickupPointLookupService` / `isPickupPointFinder` / `FindPickupPointsQuery` / `PickupPoint`, `ShippingModule` (already worker-imported) | **EXISTS → reuse** | confirmed in research + barrel |
+
+No reinvention. The by-id `PickupPointCachePort` is correctly left untouched (sibling ports instead).
+
+## Backward-compat findings
+
+| Surface | Finding | Severity |
+|---|---|---|
+| `shipping.tokens.ts` + barrel | 3 tokens added; barrel re-exports via `export * from './shipping.tokens'` (line 15) → auto-exposed. Additive. New port-types + `IPickupPointRefreshService` need **explicit** named exports in `shipping/index.ts` (the barrel lists ports/interfaces explicitly) — additive, no removals. | OK (additive) |
+| `IPickupPointLookupService` | Plan adds a `refreshSearch` method (and the impl gains 2 injected deps). Additive to an exported interface; the **only** implementer is the in-context service, and the sole external caller (`PickupPointController`) is unaffected. The existing `pickup-point-lookup.service.spec.ts` mock must add the method — expected test work, not a consumer break. | Warning (intended) |
+| `JobTypeValues` | New union member `shipping.pickupPoint.refreshFrequent` — additive; introduces a `shipping.*` namespace (new but consistent with the context name). | OK (additive) |
+| ORM schema / migration | None — Redis-only. | — |
+| `check:invariants` | **cross-context-imports:** worker handler imports the `@openlinker/core/shipping` barrel + scheduler uses the already-injected `IIntegrationsService` — no deny-pattern (no cross-context `*RepositoryPort` / ORM-entity / adapter). **service-interfaces:** `PickupPointRefreshService` implements `IPickupPointRefreshService`; adapters implement their `*Port` — satisfied. **tokens-file rule:** only Symbols added to `shipping.tokens.ts`. **jest-integration-mappers:** no new package → no mapper change. | OK |
+
+## Open questions
+
+- None blocking. Implementation notes already captured in the plan: (1) `topQueries` must persist enough to reconstruct a `FindPickupPointsQuery` from the ZSET member (store `{city,postalCode,searchText}` as a stable-JSON member); (2) two normalizer derivations (freq excludes `limit`, search-cache includes it); (3) refresh service guards `isPickupPointFinder` up front; (4) add explicit barrel exports for the two new port types + the refresh-service interface.
+
+## Bottom line
+
+Plan is internally consistent, reuses the right seams, and breaks nothing. The ZSET-adapter feasibility (the one real risk) is confirmed. Proceed to implementation; build libs before the quality gate (cross-package `dist` resolution).

--- a/docs/plans/implementation-plan-849-paczkomat-cache-v2.md
+++ b/docs/plans/implementation-plan-849-paczkomat-cache-v2.md
@@ -1,0 +1,99 @@
+# Implementation Plan — #849 Paczkomat cache v2 (background refresh + query-result caching)
+
+## 1. Understand the task
+
+Deferred from #766. Two acceptance criteria from the #766 spec were carved out because they didn't fit the deliberately-narrow by-id `PickupPointCachePort` that shipped:
+
+1. **Background refresh** — a scheduled job that daily re-warms the **most-frequently-queried** pickup-point searches (configurable cron).
+2. **Per-search-query result caching** — cache whole `query → PickupPoint[]` results (shorter TTL than the 24h per-point entry), so repeated identical searches don't always hit the provider (ShipX / DPD).
+
+**Layer:** CORE (shipping context) + Interface (API scheduler) + a worker handler. **Capability-scoped, not InPost-specific** — `PickupPointFinder` is now implemented by both InPost **and** DPD (#973), so the feature keys off the `ShippingProviderManager` + `PickupPointFinder` capability, never a `platformType` string.
+
+**Non-goals (unchanged from #766):** full ~15k-locker PL snapshot; geo-radius / map search; cache invalidation on provider update; widening the by-id `PickupPointCachePort` (it stays as-is).
+
+## 2. Research (findings)
+
+- **By-id cache (shipped, #766):** `PickupPointCachePort` (get/put by `providerId`) → `RedisPickupPointCacheAdapter` over the shared `CachePort`, key `paczkomat:point:{id}`, 24h TTL. `PickupPointLookupService.search()` runs a live provider search and write-throughs each point. Token `PICKUP_POINT_CACHE_TOKEN`.
+- **Shared `CachePort`** (`libs/shared/src/cache/cache.port.ts`): **KV only** — `get<T>`, `set<T>(…, ttlSec)`, `delete`. No sorted-set / increment / SCAN. ⇒ frequency *ranking* cannot go through it; needs a dedicated port. The Redis adapter injects the raw `'REDIS_CLIENT'` token.
+- **Scheduler pattern:** `SchedulerTaskConfig` (`libs/core/src/sync/domain/types/scheduler-task.types.ts`): `{ taskId, jobType, cronExpression, enabledEnvVar?, connectionFilter?, generatePayload, generateIdempotencyKey }`. Core tasks are registered inline in `apps/api/src/sync/application/services/scheduler.service.ts` (`registerInventorySyncTask()` is the template — capability filter via `integrationsService.listCapabilityAdapters({ capability })` → `Connection[]`, enqueues one job per connection). Plugin tasks come from `schedulerTaskRegistry`.
+- **Job types:** `JobTypeValues` union in `libs/core/src/sync/domain/types/sync-job.types.ts`; worker handler registered in `apps/worker/src/sync/handlers/handler-registration.service.ts` (`handlerRegistry.register(jobType, handler)`); a handler implements `SyncJobHandler.execute(job): SyncJobHandlerResult`.
+- **Worker wiring:** `ShippingModule` is already imported by `apps/worker/src/sync/sync-worker.module.ts` (for the status-sync service, #838); it exports the pickup-point tokens — so a worker handler can inject a new shipping service token.
+- **Orchestration belongs in core** (architecture §Sync Manager): the worker handler stays thin and delegates to a core application service.
+- **No DB / migration** — everything is Redis-backed.
+
+## 3. Design
+
+Two new single-purpose **sibling ports** (the by-id `PickupPointCachePort` stays untouched, per its own "add when a real consumer surfaces" note), one new core service, one worker handler, one core scheduler task.
+
+### New domain ports (`libs/core/src/shipping/domain/ports/`)
+- **`PickupPointSearchCachePort`** — `get(connectionId, query): Promise<PickupPoint[] | null>`, `put(connectionId, query, points): Promise<void>`. Caches the whole result list.
+- **`PickupPointQueryStatsPort`** — `record(connectionId, query): Promise<void>`, `topQueries(connectionId, limit): Promise<FindPickupPointsQuery[]>`. Frequency tracking + top-N ranking.
+
+### New normalizer (`libs/core/src/shipping/domain/pickup-point-query.ts`, pure)
+**Two derivations** (tech-review IMPORTANT — `limit` must be handled differently for the two keyspaces; do NOT share one key):
+- `pickupPointFrequencyKey(query): string` — lowercase/trim `city`/`postalCode`/`searchText`, **excludes `limit`** (popularity of a locality query must not fragment by page size).
+- `pickupPointSearchCacheKey(query): string` — same normalization but **includes `limit`** (simplest correct option). Excluding it would let a `limit=5` cache entry wrongly satisfy a later `limit=50` query with a truncated list. (Alternative considered: cache the full list and slice on read — more code; deferred. `limit` values are a small fixed set in practice, so key fragmentation is negligible.)
+
+Both are pure functions, domain-safe (runtime code → a `pickup-point-query.ts`, not a `*.types.ts`).
+
+### New adapters (`libs/core/src/shipping/infrastructure/adapters/`)
+- **`RedisPickupPointSearchCacheAdapter`** (over shared `CachePort`): key `paczkomat:search:{connectionId}:{pickupPointSearchCacheKey(query)}` (limit-inclusive), TTL `OL_PICKUP_POINT_SEARCH_CACHE_TTL_SECONDS` (default 3600 = 1h; shorter than the 24h per-point entry because lists go stale faster). Token `PICKUP_POINT_SEARCH_CACHE_TOKEN`.
+- **`RedisPickupPointQueryStatsAdapter`** — **option A confirmed feasible** (tech-review IMPORTANT resolved): `RedisConfigModule` is `@Global()` and `exports: ['REDIS_CLIENT']`, and the raw client is already injected across `libs/core` (`RedisSyncLockService`, the Redis-Streams job-enqueue + event-publisher adapters) for exactly the ops the KV `CachePort` can't express. This adapter follows that established precedent — `@Inject('REDIS_CLIENT')`, `ZINCRBY` on `paczkomat:freq:{connectionId}` keyed by `pickupPointFrequencyKey(query)`, `EXPIRE` for a rolling ~7-day window, `ZREVRANGE 0 N-1` for `topQueries`, optional `ZREMRANGEBYRANK` to cap cardinality. File header must state the rationale (atomic top-N; KV port can't rank) and cite the `RedisSyncLockService` precedent so it isn't "fixed" back to `CachePort`. Token `PICKUP_POINT_QUERY_STATS_TOKEN`. The port stays adapter-agnostic, so a `CounterCachePort` promotion to `@openlinker/shared/cache` remains the future path if a second ranking consumer appears.
+
+  **`topQueries` returns `FindPickupPointsQuery[]`** — since the ZSET member is the normalized frequency key (limit-excluded), the adapter must store enough to reconstruct a `FindPickupPointsQuery` (store the original `{city,postalCode,searchText}` as the member via a stable JSON encoding, or a `paczkomat:freq:meta` hash mapping key→query). The refresh re-search runs without an explicit `limit` (provider default), so the limit-exclusion on the frequency key is consistent with how the warm re-runs the search.
+
+### Changed: `PickupPointLookupService`
+- `search(connectionId, query)` (operator path, controller-facing): **(1)** `stats.record(connectionId, query)`; **(2)** `searchCache.get` → on hit, return cached list (skip provider call); **(3)** on miss, live provider search → `searchCache.put` + per-point `cache.put` write-through (existing). Frequency is recorded for *operator* searches only.
+- New `refreshSearch(connectionId, query)`: live search → write-through both caches, **bypassing** the result-cache read and **not** recording frequency (so the daily re-warm doesn't self-reinforce its own counts). Shares a private `runLiveSearchAndCache`.
+
+### New core service: `PickupPointRefreshService` (`IPickupPointRefreshService`, token `PICKUP_POINT_REFRESH_SERVICE_TOKEN`)
+`refreshFrequentForConnection(connectionId): Promise<{ refreshed; failed }>` — **guards `isPickupPointFinder` up front** (tech-review SUGGESTION): resolves the connection's `ShippingProviderManager` adapter, early-returns `{refreshed:0,failed:0}` if it isn't a `PickupPointFinder` (so a stray recorded query can't trigger `PickupPointFinderNotSupportedException` mid-loop, and non-finder SPM connections no-op cleanly). Then reads `stats.topQueries(connectionId, N)` (`N` = `OL_PICKUP_POINT_REFRESH_TOP_N`, default 50, clamped), calls `lookup.refreshSearch` per query, isolates per-query failure (a dead query must not abort the batch), returns counts. Registered + exported from `ShippingModule`.
+
+### New job type + worker handler
+- Add `'shipping.pickupPoint.refreshFrequent'` to `JobTypeValues`.
+- `PickupPointRefreshHandler` (`apps/worker/src/sync/handlers/`): thin — reads `job.connectionId`, calls `PickupPointRefreshService.refreshFrequentForConnection`, returns `{ outcome: 'ok' }`. Registered in `handler-registration.service.ts`.
+
+### New core scheduler task (`SchedulerService.registerPickupPointRefreshTask`)
+Mirrors `registerInventorySyncTask`: env-gated `OL_PICKUP_POINT_REFRESH_ENABLED` (default on), `cronExpression` = `OL_PICKUP_POINT_REFRESH_CRON` (default `0 3 * * *`, daily 03:00), `connectionFilter` = `listCapabilityAdapters({ capability: 'ShippingProviderManager' })` → `Connection[]`, one `shipping.pickupPoint.refreshFrequent` job per connection. Idempotency key `shipping:{connectionId}:pickupPoints:refresh:{timestamp}`. (Connections that are SPM but not `PickupPointFinder` → the handler/service no-ops with `topQueries` empty; harmless.)
+
+### Data flow
+```
+operator → GET /pickup-points → PickupPointLookupService.search
+    → stats.record  → searchCache.get (hit? return) → live search → searchCache.put + point cache.put
+
+daily cron (SchedulerService) → enqueue shipping.pickupPoint.refreshFrequent per SPM connection
+    → PickupPointRefreshHandler → PickupPointRefreshService.refreshFrequentForConnection
+        → stats.topQueries(N) → per query: lookup.refreshSearch (fresh) → re-warm both caches
+```
+
+## 4. Step-by-step
+
+1. **Ports + normalizer** — create `pickup-point-search-cache.port.ts`, `pickup-point-query-stats.port.ts`, `pickup-point-query.ts` (normalizer + unit spec). AC: domain-only, no framework imports; normalizer excludes `limit`, stable across key reorder.
+2. **Tokens** — add `PICKUP_POINT_SEARCH_CACHE_TOKEN`, `PICKUP_POINT_QUERY_STATS_TOKEN`, `PICKUP_POINT_REFRESH_SERVICE_TOKEN` to `shipping.tokens.ts`. AC: token-only file rule preserved.
+3. **Search-cache adapter** + spec (over shared `CachePort`, env TTL with default+clamp). AC: round-trips a `PickupPoint[]`; key uses normalized query; TTL honored (mocked CachePort assertion).
+4. **Query-stats adapter** + spec — per OQ-1 decision. AC: `record` increments; `topQueries(n)` returns the n most-frequent normalized queries as `FindPickupPointsQuery[]`, most-frequent first; bounded.
+5. **`PickupPointLookupService`** — inject the 2 new ports; implement record→cache-first→write-through in `search`; add `refreshSearch`; update interface + spec. AC: cache-hit skips provider; refresh path neither reads result-cache nor records frequency; existing tests still green.
+6. **`PickupPointRefreshService`** + interface + spec. AC: reads top-N, per-query isolation (one throwing query doesn't abort), returns counts; N clamped.
+7. **Job type** — add `'shipping.pickupPoint.refreshFrequent'` to `JobTypeValues`. AC: union updated; downstream `JobType` checks compile.
+8. **Worker handler** `PickupPointRefreshHandler` + spec; register in `handler-registration.service.ts`. AC: delegates to core service, returns `ok`; registered for the job type.
+9. **Scheduler task** `registerPickupPointRefreshTask` in `SchedulerService` + spec coverage. AC: env-gated; capability-filtered connection fan-out; one job per connection; idempotency key shape.
+10. **Module wiring + barrel** — `ShippingModule` providers/exports for the 3 new tokens; export the refresh-service token (+ any types the worker needs) from `@openlinker/core/shipping`. AC: worker resolves `PICKUP_POINT_REFRESH_SERVICE_TOKEN`.
+11. **Docs/env** — document the 4 new `OL_PICKUP_POINT_*` env vars (`.env.example` + a line in the shipping/testing or dev-environment doc); one-line note in `architecture-overview.md` §Listings/Shipping if warranted.
+12. **Quality gate** — build libs first (`pnpm -r --filter "./libs/**" build`), then `pnpm lint && pnpm type-check && pnpm test`; `migration:show` = no pending (no schema change, sanity only).
+
+## 5. Validation
+
+- **Architecture:** new ports in `domain/ports/`, adapters in `infrastructure/adapters/`, orchestration in a core service; worker handler stays thin (delegates to core, per §Sync Manager). Capability-scoped (no `platformType` literal). Tokens follow the Symbol convention. No `any`; `Logger` from `@openlinker/shared/logging`.
+- **Testing:** unit specs for normalizer, both adapters (mock `CachePort` / Redis client), lookup-service new paths, refresh service (isolation), worker handler, scheduler task. No integration test strictly required (Redis-only, no DB vertical slice) — mirror #766's unit-level coverage.
+- **Security:** no secrets; pickup-point data is non-sensitive; the controller path is unchanged (already `@Roles('admin')`).
+- **Migrations:** none (Redis only).
+
+## Resolved decisions (from user + tech-review)
+
+- **OQ-1 (frequency-tracking adapter) → (A) Redis ZSET, confirmed feasible.** Long-term-correct: top-N ranking is intrinsically a sorted-set problem (atomic `ZINCRBY`, server-side `ZREVRANGE`, bounded via `ZREMRANGEBYRANK`); the JSON-map alternative loses increments under concurrency and needs manual capping. Feasibility verified: `RedisConfigModule` is `@Global()` + `exports: ['REDIS_CLIENT']`, already injected in `libs/core` (`RedisSyncLockService`, Redis-Streams adapters) — established precedent, not a novel coupling. Future path if a 2nd ranking consumer appears: promote a `CounterCachePort` to `@openlinker/shared/cache` (YAGNI now).
+- **`limit` keying (tech-review IMPORTANT).** Frequency key excludes `limit`; search-cache key includes it. Two normalizer helpers, not one shared key.
+- **OQ-2 (result-cache-hit semantics):** a hit returns the cached list and **skips the live provider call** within the short TTL — the point of the feature. Trades a little freshness for latency/rate-limit relief; 1h default TTL bounds staleness (issue framing: "lists go stale faster… shorter TTL"). `search()` thus shifts from always-live to cache-first — intended.
+- **OQ-3 (env knob count):** 4 new `OL_PICKUP_POINT_*` knobs (enabled, cron, top-N, search-TTL), sensible defaults, numeric ones clamped — matches #766's operability posture.
+
+## Remaining open questions
+- None blocking. Optional: a single `*.int-spec.ts` exercising the ZSET stats adapter against the Testcontainer Redis (mocking `ZINCRBY`/`ZREVRANGE` is low-value). Will add if the unit-level coverage feels thin after implementation.

--- a/libs/core/src/shipping/application/interfaces/pickup-point-lookup.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/pickup-point-lookup.service.interface.ts
@@ -13,11 +13,21 @@ import type { FindPickupPointsQuery, PickupPoint } from '../../domain/types/pick
 
 export interface IPickupPointLookupService {
   /**
-   * Live provider search; write-throughs each returned point to the cache.
+   * Operator-facing search. Records query frequency (#849), then serves from
+   * the result cache when warm (skipping the provider call); on a miss runs a
+   * live provider search and write-throughs the result list + each point.
    * Throws `PickupPointFinderNotSupportedException` when the connection's
    * adapter has no pickup-point network (e.g. a courier-only carrier).
    */
   search(connectionId: string, query: FindPickupPointsQuery): Promise<PickupPoint[]>;
+
+  /**
+   * Background re-warm path (#849): always runs a live provider search and
+   * write-throughs both caches, **bypassing** the result-cache read and
+   * **without** recording frequency (so the daily re-warm doesn't reinforce
+   * its own counts). Used by `IPickupPointRefreshService`.
+   */
+  refreshSearch(connectionId: string, query: FindPickupPointsQuery): Promise<void>;
 
   /**
    * Fast by-id read from cache. `null` on miss — there is no live by-id

--- a/libs/core/src/shipping/application/interfaces/pickup-point-refresh.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/pickup-point-refresh.service.interface.ts
@@ -1,0 +1,23 @@
+/**
+ * Pickup-Point Refresh Service Interface
+ *
+ * Background re-warm of the most-frequently-queried pickup-point searches for
+ * a connection (#849). Driven per-connection by the `shipping.pickupPoint.refreshFrequent`
+ * worker handler (fanned out daily by the core scheduler). Reads the top-N
+ * queries from `PickupPointQueryStatsPort` and re-runs each via
+ * `IPickupPointLookupService.refreshSearch`, re-warming both the per-point and
+ * result caches.
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+import type { PickupPointRefreshResult } from '../types/pickup-point-refresh.types';
+
+export interface IPickupPointRefreshService {
+  /**
+   * Re-warm the top-N most-frequent searches for `connectionId`. No-ops
+   * (returns zero counts) when the connection's adapter isn't a
+   * `PickupPointFinder`. Per-query failures are isolated — one dead query does
+   * not abort the batch.
+   */
+  refreshFrequentForConnection(connectionId: string): Promise<PickupPointRefreshResult>;
+}

--- a/libs/core/src/shipping/application/services/pickup-point-lookup.service.spec.ts
+++ b/libs/core/src/shipping/application/services/pickup-point-lookup.service.spec.ts
@@ -8,6 +8,8 @@
 import type { IIntegrationsService } from '@openlinker/core/integrations';
 import { PickupPointLookupService } from './pickup-point-lookup.service';
 import type { PickupPointCachePort } from '../../domain/ports/pickup-point-cache.port';
+import type { PickupPointSearchCachePort } from '../../domain/ports/pickup-point-search-cache.port';
+import type { PickupPointQueryStatsPort } from '../../domain/ports/pickup-point-query-stats.port';
 import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
 import type { PickupPointFinder } from '../../domain/ports/capabilities/pickup-point-finder.capability';
 import type { PickupPoint } from '../../domain/types/pickup-point.types';
@@ -44,14 +46,25 @@ function courierOnlyAdapter(): ShippingProviderManagerPort {
 
 describe('PickupPointLookupService', () => {
   let cache: jest.Mocked<PickupPointCachePort>;
+  let searchCache: jest.Mocked<PickupPointSearchCachePort>;
+  let stats: jest.Mocked<PickupPointQueryStatsPort>;
   let getCapabilityAdapter: jest.Mock;
   let service: PickupPointLookupService;
 
   beforeEach(() => {
     cache = { get: jest.fn(), put: jest.fn().mockResolvedValue(undefined) };
+    // Default: result-cache miss, so existing tests exercise the live path.
+    searchCache = {
+      get: jest.fn().mockResolvedValue(null),
+      put: jest.fn().mockResolvedValue(undefined),
+    };
+    stats = {
+      record: jest.fn().mockResolvedValue(undefined),
+      topQueries: jest.fn().mockResolvedValue([]),
+    };
     getCapabilityAdapter = jest.fn();
     const integrations = { getCapabilityAdapter } as unknown as IIntegrationsService;
-    service = new PickupPointLookupService(integrations, cache);
+    service = new PickupPointLookupService(integrations, cache, searchCache, stats);
   });
 
   describe('search', () => {
@@ -91,6 +104,65 @@ describe('PickupPointLookupService', () => {
       cache.put.mockRejectedValueOnce(new Error('redis down'));
 
       await expect(service.search(CONN, {})).resolves.toEqual(points);
+    });
+
+    it('should record query frequency (#849)', async () => {
+      getCapabilityAdapter.mockResolvedValue(finderAdapter([makePoint()]));
+
+      await service.search(CONN, { city: 'Poznań' });
+
+      expect(stats.record).toHaveBeenCalledWith(CONN, { city: 'Poznań' });
+    });
+
+    it('should serve from the result cache and skip the provider on a hit (#849)', async () => {
+      const cached = [makePoint(), makePoint({ providerId: 'WAW01A' })];
+      searchCache.get.mockResolvedValue(cached);
+
+      const result = await service.search(CONN, { city: 'Poznań' });
+
+      expect(result).toEqual(cached);
+      expect(stats.record).toHaveBeenCalledWith(CONN, { city: 'Poznań' });
+      expect(getCapabilityAdapter).not.toHaveBeenCalled(); // provider not hit
+      expect(cache.put).not.toHaveBeenCalled(); // no per-point warm on hit
+    });
+
+    it('should write the result list through to the search cache on a miss (#849)', async () => {
+      const points = [makePoint()];
+      getCapabilityAdapter.mockResolvedValue(finderAdapter(points));
+
+      await service.search(CONN, { city: 'Poznań' });
+
+      expect(searchCache.put).toHaveBeenCalledWith(CONN, { city: 'Poznań' }, points);
+    });
+
+    it('should still serve live when the search-cache read fails (#849)', async () => {
+      const points = [makePoint()];
+      searchCache.get.mockRejectedValueOnce(new Error('redis down'));
+      getCapabilityAdapter.mockResolvedValue(finderAdapter(points));
+
+      await expect(service.search(CONN, {})).resolves.toEqual(points);
+    });
+  });
+
+  describe('refreshSearch (#849)', () => {
+    it('should run a live search and warm both caches without recording frequency or reading the result cache', async () => {
+      const points = [makePoint(), makePoint({ providerId: 'WAW01A' })];
+      getCapabilityAdapter.mockResolvedValue(finderAdapter(points));
+
+      await service.refreshSearch(CONN, { city: 'Poznań' });
+
+      expect(stats.record).not.toHaveBeenCalled();
+      expect(searchCache.get).not.toHaveBeenCalled();
+      expect(cache.put).toHaveBeenCalledTimes(2);
+      expect(searchCache.put).toHaveBeenCalledWith(CONN, { city: 'Poznań' }, points);
+    });
+
+    it('should throw PickupPointFinderNotSupportedException when the adapter has no finder', async () => {
+      getCapabilityAdapter.mockResolvedValue(courierOnlyAdapter());
+
+      await expect(service.refreshSearch(CONN, {})).rejects.toBeInstanceOf(
+        PickupPointFinderNotSupportedException,
+      );
     });
   });
 

--- a/libs/core/src/shipping/application/services/pickup-point-lookup.service.ts
+++ b/libs/core/src/shipping/application/services/pickup-point-lookup.service.ts
@@ -1,14 +1,19 @@
 /**
  * Pickup-Point Lookup Service
  *
- * Read-through orchestration the manual paczkomat picker (#769) consumes:
- * resolves the connection's `ShippingProviderManagerPort`, narrows to the
- * `PickupPointFinder` sub-capability, runs a live provider search, and
- * write-throughs each returned point to `PickupPointCachePort` so a later
- * by-id read is a sub-10ms cache hit. Search stays live because lists must be
- * fresh; only individual points are cached (the #727.1 port is by-id only).
+ * Read-through orchestration the manual paczkomat picker (#769) consumes, plus
+ * the query-result caching + frequency tracking added in #849:
  *
- * Cache write-through failures are swallowed (warn-logged) — a degraded cache
+ * - `search` (operator path): records query frequency, then serves from the
+ *   result cache when warm (skipping the live provider call within the short
+ *   TTL); on a miss runs a live `PickupPointFinder` search and write-throughs
+ *   the whole result list (`PickupPointSearchCachePort`) **and** each point by
+ *   id (`PickupPointCachePort`, #766).
+ * - `refreshSearch` (background re-warm, #849): always live, write-throughs
+ *   both caches, but bypasses the result-cache read and does NOT record
+ *   frequency — so the daily re-warm can't reinforce its own counts.
+ *
+ * Cache + frequency side effects are swallowed (warn-logged): a degraded cache
  * must never fail a live search.
  *
  * @module libs/core/src/shipping/application/services
@@ -20,11 +25,17 @@ import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/co
 
 import type { IPickupPointLookupService } from '../interfaces/pickup-point-lookup.service.interface';
 import { PickupPointCachePort } from '../../domain/ports/pickup-point-cache.port';
+import { PickupPointSearchCachePort } from '../../domain/ports/pickup-point-search-cache.port';
+import { PickupPointQueryStatsPort } from '../../domain/ports/pickup-point-query-stats.port';
 import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
 import { isPickupPointFinder } from '../../domain/ports/capabilities/pickup-point-finder.capability';
 import type { FindPickupPointsQuery, PickupPoint } from '../../domain/types/pickup-point.types';
 import { PickupPointFinderNotSupportedException } from '../../domain/exceptions/pickup-point-finder-not-supported.exception';
-import { PICKUP_POINT_CACHE_TOKEN } from '../../shipping.tokens';
+import {
+  PICKUP_POINT_CACHE_TOKEN,
+  PICKUP_POINT_QUERY_STATS_TOKEN,
+  PICKUP_POINT_SEARCH_CACHE_TOKEN,
+} from '../../shipping.tokens';
 
 /** Capability the connection must declare to host a pickup-point network. */
 const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
@@ -38,9 +49,37 @@ export class PickupPointLookupService implements IPickupPointLookupService {
     private readonly integrations: IIntegrationsService,
     @Inject(PICKUP_POINT_CACHE_TOKEN)
     private readonly cache: PickupPointCachePort,
+    @Inject(PICKUP_POINT_SEARCH_CACHE_TOKEN)
+    private readonly searchCache: PickupPointSearchCachePort,
+    @Inject(PICKUP_POINT_QUERY_STATS_TOKEN)
+    private readonly stats: PickupPointQueryStatsPort,
   ) {}
 
   async search(connectionId: string, query: FindPickupPointsQuery): Promise<PickupPoint[]> {
+    await this.recordFrequencySafe(connectionId, query);
+
+    const cached = await this.readSearchCacheSafe(connectionId, query);
+    if (cached !== null) {
+      return cached;
+    }
+
+    return this.runLiveSearchAndCache(connectionId, query);
+  }
+
+  async refreshSearch(connectionId: string, query: FindPickupPointsQuery): Promise<void> {
+    // No frequency record, no result-cache read — always fetch fresh and re-warm.
+    await this.runLiveSearchAndCache(connectionId, query);
+  }
+
+  getCachedPoint(providerId: string): Promise<PickupPoint | null> {
+    return this.cache.get(providerId);
+  }
+
+  /** Live provider search + write-through to both the result and per-point caches. */
+  private async runLiveSearchAndCache(
+    connectionId: string,
+    query: FindPickupPointsQuery,
+  ): Promise<PickupPoint[]> {
     const adapter = await this.integrations.getCapabilityAdapter<ShippingProviderManagerPort>(
       connectionId,
       SHIPPING_PROVIDER_MANAGER_CAPABILITY,
@@ -50,24 +89,59 @@ export class PickupPointLookupService implements IPickupPointLookupService {
     }
 
     const points = await adapter.findPickupPoints(query);
-    await this.warmCache(points);
+    await this.warmPointCache(points);
+    await this.warmSearchCache(connectionId, query, points);
     return points;
   }
 
-  getCachedPoint(providerId: string): Promise<PickupPoint | null> {
-    return this.cache.get(providerId);
+  private async recordFrequencySafe(
+    connectionId: string,
+    query: FindPickupPointsQuery,
+  ): Promise<void> {
+    try {
+      await this.stats.record(connectionId, query);
+    } catch (error) {
+      this.logger.warn(`Failed to record pickup-point query frequency: ${messageOf(error)}`);
+    }
   }
 
-  private async warmCache(points: readonly PickupPoint[]): Promise<void> {
+  private async readSearchCacheSafe(
+    connectionId: string,
+    query: FindPickupPointsQuery,
+  ): Promise<PickupPoint[] | null> {
+    try {
+      return await this.searchCache.get(connectionId, query);
+    } catch (error) {
+      this.logger.warn(`Failed to read pickup-point search cache: ${messageOf(error)}`);
+      return null;
+    }
+  }
+
+  private async warmSearchCache(
+    connectionId: string,
+    query: FindPickupPointsQuery,
+    points: readonly PickupPoint[],
+  ): Promise<void> {
+    try {
+      await this.searchCache.put(connectionId, query, points);
+    } catch (error) {
+      this.logger.warn(`Failed to cache pickup-point search result: ${messageOf(error)}`);
+    }
+  }
+
+  private async warmPointCache(points: readonly PickupPoint[]): Promise<void> {
     await Promise.all(
       points.map(async (point) => {
         try {
           await this.cache.put(point);
         } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          this.logger.warn(`Failed to cache pickup point ${point.providerId}: ${message}`);
+          this.logger.warn(`Failed to cache pickup point ${point.providerId}: ${messageOf(error)}`);
         }
       }),
     );
   }
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/libs/core/src/shipping/application/services/pickup-point-refresh.service.spec.ts
+++ b/libs/core/src/shipping/application/services/pickup-point-refresh.service.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Pickup-point refresh service unit tests (#849).
+ *
+ * Mocks IIntegrationsService (→ finder / courier-only adapter), the
+ * query-stats port, and the lookup service. Covers the finder guard, the
+ * top-N re-warm loop, per-query failure isolation, and the empty case.
+ */
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import { PickupPointRefreshService } from './pickup-point-refresh.service';
+import type { IPickupPointLookupService } from '../interfaces/pickup-point-lookup.service.interface';
+import type { PickupPointQueryStatsPort } from '../../domain/ports/pickup-point-query-stats.port';
+
+const CONN = 'conn-inpost';
+
+function finderAdapter(): unknown {
+  return { generateLabel: jest.fn(), getTracking: jest.fn(), findPickupPoints: jest.fn() };
+}
+
+function courierOnlyAdapter(): unknown {
+  return { generateLabel: jest.fn(), getTracking: jest.fn() };
+}
+
+describe('PickupPointRefreshService', () => {
+  let getCapabilityAdapter: jest.Mock;
+  let stats: jest.Mocked<PickupPointQueryStatsPort>;
+  let lookup: jest.Mocked<IPickupPointLookupService>;
+  let service: PickupPointRefreshService;
+
+  beforeEach(() => {
+    getCapabilityAdapter = jest.fn().mockResolvedValue(finderAdapter());
+    stats = { record: jest.fn(), topQueries: jest.fn().mockResolvedValue([]) };
+    lookup = {
+      search: jest.fn(),
+      refreshSearch: jest.fn().mockResolvedValue(undefined),
+      getCachedPoint: jest.fn(),
+    };
+    const integrations = { getCapabilityAdapter } as unknown as IIntegrationsService;
+    service = new PickupPointRefreshService(integrations, stats, lookup);
+  });
+
+  it('no-ops when the connection adapter is not a pickup-point finder', async () => {
+    getCapabilityAdapter.mockResolvedValue(courierOnlyAdapter());
+
+    const result = await service.refreshFrequentForConnection(CONN);
+
+    expect(result).toEqual({ refreshed: 0, failed: 0 });
+    expect(stats.topQueries).not.toHaveBeenCalled();
+    expect(lookup.refreshSearch).not.toHaveBeenCalled();
+  });
+
+  it('re-runs each top-N query and reports the refreshed count', async () => {
+    stats.topQueries.mockResolvedValue([{ city: 'poznań' }, { postalCode: '00-001' }]);
+
+    const result = await service.refreshFrequentForConnection(CONN);
+
+    expect(result).toEqual({ refreshed: 2, failed: 0 });
+    expect(lookup.refreshSearch).toHaveBeenCalledWith(CONN, { city: 'poznań' });
+    expect(lookup.refreshSearch).toHaveBeenCalledWith(CONN, { postalCode: '00-001' });
+  });
+
+  it('isolates a per-query failure without aborting the batch', async () => {
+    stats.topQueries.mockResolvedValue([{ city: 'a' }, { city: 'b' }, { city: 'c' }]);
+    lookup.refreshSearch
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('ShipX 500'))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await service.refreshFrequentForConnection(CONN);
+
+    expect(result).toEqual({ refreshed: 2, failed: 1 });
+    expect(lookup.refreshSearch).toHaveBeenCalledTimes(3);
+  });
+
+  it('defensively skips an unfiltered query without calling the provider', async () => {
+    stats.topQueries.mockResolvedValue([{}, { city: 'poznań' }]);
+
+    const result = await service.refreshFrequentForConnection(CONN);
+
+    expect(result).toEqual({ refreshed: 1, failed: 0 });
+    expect(lookup.refreshSearch).toHaveBeenCalledTimes(1);
+    expect(lookup.refreshSearch).toHaveBeenCalledWith(CONN, { city: 'poznań' });
+  });
+
+  it('returns zero counts when there are no recorded queries', async () => {
+    stats.topQueries.mockResolvedValue([]);
+
+    const result = await service.refreshFrequentForConnection(CONN);
+
+    expect(result).toEqual({ refreshed: 0, failed: 0 });
+    expect(lookup.refreshSearch).not.toHaveBeenCalled();
+  });
+});

--- a/libs/core/src/shipping/application/services/pickup-point-refresh.service.ts
+++ b/libs/core/src/shipping/application/services/pickup-point-refresh.service.ts
@@ -1,0 +1,106 @@
+/**
+ * Pickup-Point Refresh Service
+ *
+ * Background re-warm orchestration (#849): for a connection, reads the top-N
+ * most-frequently-queried pickup-point searches from `PickupPointQueryStatsPort`
+ * and re-runs each via `IPickupPointLookupService.refreshSearch` (which fetches
+ * fresh provider results and re-warms the per-point + result caches WITHOUT
+ * recording frequency — so the re-warm doesn't reinforce its own counts).
+ *
+ * Capability-scoped: guards `isPickupPointFinder` up front so a connection that
+ * is a `ShippingProviderManager` but has no locker network (e.g. courier-only)
+ * is a clean no-op, and a stray recorded query can't surface
+ * `PickupPointFinderNotSupportedException` mid-loop. Per-query failures are
+ * isolated — a single dead query must not abort the batch.
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IPickupPointRefreshService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+
+import type { IPickupPointRefreshService } from '../interfaces/pickup-point-refresh.service.interface';
+import { IPickupPointLookupService } from '../interfaces/pickup-point-lookup.service.interface';
+import type { PickupPointRefreshResult } from '../types/pickup-point-refresh.types';
+import { PickupPointQueryStatsPort } from '../../domain/ports/pickup-point-query-stats.port';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+import { isPickupPointFinder } from '../../domain/ports/capabilities/pickup-point-finder.capability';
+import {
+  PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
+  PICKUP_POINT_QUERY_STATS_TOKEN,
+} from '../../shipping.tokens';
+
+/** Capability the connection must declare to host a pickup-point network. */
+const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
+
+const DEFAULT_REFRESH_TOP_N = 50;
+const MIN_REFRESH_TOP_N = 1;
+const MAX_REFRESH_TOP_N = 500;
+
+function resolveTopN(): number {
+  const raw = process.env.OL_PICKUP_POINT_REFRESH_TOP_N;
+  const parsed = raw !== undefined && raw !== '' ? Number(raw) : Number.NaN;
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_REFRESH_TOP_N;
+  }
+  return Math.min(MAX_REFRESH_TOP_N, Math.max(MIN_REFRESH_TOP_N, Math.trunc(parsed)));
+}
+
+@Injectable()
+export class PickupPointRefreshService implements IPickupPointRefreshService {
+  private readonly logger = new Logger(PickupPointRefreshService.name);
+  private readonly topN = resolveTopN();
+
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+    @Inject(PICKUP_POINT_QUERY_STATS_TOKEN)
+    private readonly stats: PickupPointQueryStatsPort,
+    @Inject(PICKUP_POINT_LOOKUP_SERVICE_TOKEN)
+    private readonly lookup: IPickupPointLookupService,
+  ) {}
+
+  async refreshFrequentForConnection(connectionId: string): Promise<PickupPointRefreshResult> {
+    const adapter = await this.integrations.getCapabilityAdapter<ShippingProviderManagerPort>(
+      connectionId,
+      SHIPPING_PROVIDER_MANAGER_CAPABILITY,
+    );
+    if (!isPickupPointFinder(adapter)) {
+      this.logger.debug(
+        `Pickup-point refresh skipped for connection ${connectionId}: adapter has no pickup-point finder`,
+      );
+      return { refreshed: 0, failed: 0 };
+    }
+
+    const queries = await this.stats.topQueries(connectionId, this.topN);
+    if (queries.length === 0) {
+      return { refreshed: 0, failed: 0 };
+    }
+
+    let refreshed = 0;
+    let failed = 0;
+    for (const query of queries) {
+      // Defensive: never re-warm an unfiltered query (the stats adapter already
+      // declines to track it, but historical entries could still surface).
+      if (!query.city && !query.postalCode && !query.searchText) {
+        continue;
+      }
+      try {
+        await this.lookup.refreshSearch(connectionId, query);
+        refreshed += 1;
+      } catch (error) {
+        failed += 1;
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          `Pickup-point refresh failed for connection ${connectionId}, query ${JSON.stringify(query)}: ${message}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Pickup-point refresh for connection ${connectionId}: ${refreshed} refreshed, ${failed} failed (of ${queries.length} top queries)`,
+    );
+    return { refreshed, failed };
+  }
+}

--- a/libs/core/src/shipping/application/types/pickup-point-refresh.types.ts
+++ b/libs/core/src/shipping/application/types/pickup-point-refresh.types.ts
@@ -1,0 +1,14 @@
+/**
+ * Pickup-Point Refresh Types
+ *
+ * Result shape for the background re-warm (#849).
+ *
+ * @module libs/core/src/shipping/application/types
+ */
+
+export interface PickupPointRefreshResult {
+  /** Number of top-N queries successfully re-searched + re-cached. */
+  refreshed: number;
+  /** Number of top-N queries whose re-search failed (isolated; batch continues). */
+  failed: number;
+}

--- a/libs/core/src/shipping/domain/pickup-point-query.spec.ts
+++ b/libs/core/src/shipping/domain/pickup-point-query.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Pickup-point query normalization unit tests (#849).
+ */
+import {
+  pickupPointFrequencyMember,
+  parsePickupPointFrequencyMember,
+  pickupPointSearchCacheKey,
+} from './pickup-point-query';
+
+describe('pickup-point-query', () => {
+  describe('pickupPointFrequencyMember', () => {
+    it('excludes limit so page size does not fragment the key', () => {
+      expect(pickupPointFrequencyMember({ city: 'Poznań', limit: 5 })).toBe(
+        pickupPointFrequencyMember({ city: 'Poznań', limit: 50 }),
+      );
+    });
+
+    it('trims, collapses whitespace, and lowercases', () => {
+      expect(pickupPointFrequencyMember({ city: '  PoZNAŃ  ' })).toBe(
+        pickupPointFrequencyMember({ city: 'poznań' }),
+      );
+      expect(pickupPointFrequencyMember({ searchText: 'al.   Solidarności' })).toBe(
+        pickupPointFrequencyMember({ searchText: 'al. solidarności' }),
+      );
+    });
+
+    it('omits empty/whitespace-only fields', () => {
+      expect(pickupPointFrequencyMember({ city: '   ', postalCode: '60-001' })).toBe(
+        pickupPointFrequencyMember({ postalCode: '60-001' }),
+      );
+    });
+
+    it('produces a stable key regardless of input field order', () => {
+      const a = pickupPointFrequencyMember({ city: 'poznań', postalCode: '60-001' });
+      const b = pickupPointFrequencyMember({ postalCode: '60-001', city: 'poznań' });
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('parsePickupPointFrequencyMember', () => {
+    it('round-trips a member back into a query', () => {
+      const member = pickupPointFrequencyMember({ city: 'Poznań', postalCode: '60-001' });
+      expect(parsePickupPointFrequencyMember(member)).toEqual({
+        city: 'poznań',
+        postalCode: '60-001',
+        searchText: undefined,
+      });
+    });
+
+    it('degrades to an empty query on a corrupt member', () => {
+      expect(parsePickupPointFrequencyMember('not-json')).toEqual({});
+    });
+  });
+
+  describe('pickupPointSearchCacheKey', () => {
+    it('includes limit so a narrower entry cannot satisfy a wider request', () => {
+      expect(pickupPointSearchCacheKey({ city: 'poznań', limit: 5 })).not.toBe(
+        pickupPointSearchCacheKey({ city: 'poznań', limit: 50 }),
+      );
+    });
+
+    it('treats absent/zero limit as the same "none" bucket', () => {
+      expect(pickupPointSearchCacheKey({ city: 'poznań' })).toBe(
+        pickupPointSearchCacheKey({ city: 'poznań', limit: 0 }),
+      );
+    });
+  });
+});

--- a/libs/core/src/shipping/domain/pickup-point-query.ts
+++ b/libs/core/src/shipping/domain/pickup-point-query.ts
@@ -1,0 +1,87 @@
+/**
+ * Pickup-Point Query Normalization
+ *
+ * Pure helpers that derive stable cache/frequency keys from a
+ * `FindPickupPointsQuery` (#849). Two derivations, deliberately distinct:
+ *
+ * - `pickupPointFrequencyMember` — the ZSET member for query-frequency
+ *   tracking. **Excludes `limit`** (popularity of a locality query must not
+ *   fragment by page size) and is a stable JSON encoding so the stats adapter
+ *   can reconstruct the original query for the daily re-warm
+ *   (`parsePickupPointFrequencyMember`).
+ * - `pickupPointSearchCacheKey` — the result-cache key. **Includes `limit`**:
+ *   a `limit=5` cache entry must not satisfy a later `limit=50` query with a
+ *   truncated list.
+ *
+ * Domain-only — zero framework imports.
+ *
+ * @module libs/core/src/shipping/domain
+ */
+import type { FindPickupPointsQuery } from './types/pickup-point.types';
+
+/** The query dimensions that identify a search, sans `limit`. */
+interface NormalizedQueryParts {
+  city?: string;
+  postalCode?: string;
+  searchText?: string;
+}
+
+function normalizeField(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const collapsed = value.trim().replace(/\s+/g, ' ').toLowerCase();
+  return collapsed.length > 0 ? collapsed : undefined;
+}
+
+/**
+ * Normalize the identity dimensions of a query. Empty/whitespace-only fields
+ * collapse to `undefined` so they don't fragment the key. Keys are emitted in
+ * a fixed order for a stable JSON encoding.
+ */
+function normalizeParts(query: FindPickupPointsQuery): NormalizedQueryParts {
+  const parts: NormalizedQueryParts = {};
+  const city = normalizeField(query.city);
+  const postalCode = normalizeField(query.postalCode);
+  const searchText = normalizeField(query.searchText);
+  if (city !== undefined) parts.city = city;
+  if (postalCode !== undefined) parts.postalCode = postalCode;
+  if (searchText !== undefined) parts.searchText = searchText;
+  return parts;
+}
+
+/**
+ * Stable frequency-tracking member for a query — limit-excluded. Used as the
+ * ZSET member and round-tripped back to a `FindPickupPointsQuery` by the
+ * daily re-warm via {@link parsePickupPointFrequencyMember}.
+ */
+export function pickupPointFrequencyMember(query: FindPickupPointsQuery): string {
+  return JSON.stringify(normalizeParts(query));
+}
+
+/**
+ * Reconstruct a `FindPickupPointsQuery` from a frequency member. Returns an
+ * empty query (`{}`) if the member is not parseable, so a corrupt entry
+ * degrades to a broad re-warm rather than throwing.
+ */
+export function parsePickupPointFrequencyMember(member: string): FindPickupPointsQuery {
+  try {
+    const parsed: unknown = JSON.parse(member);
+    if (parsed === null || typeof parsed !== 'object') {
+      return {};
+    }
+    const { city, postalCode, searchText } = parsed as NormalizedQueryParts;
+    return { city, postalCode, searchText };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Result-cache key for a query — limit-inclusive. `limit` is appended so a
+ * narrower cached list can't wrongly satisfy a wider request.
+ */
+export function pickupPointSearchCacheKey(query: FindPickupPointsQuery): string {
+  const limit = typeof query.limit === 'number' && query.limit > 0 ? query.limit : 'none';
+  return `${pickupPointFrequencyMember(query)}::limit=${limit}`;
+}

--- a/libs/core/src/shipping/domain/ports/pickup-point-query-stats.port.ts
+++ b/libs/core/src/shipping/domain/ports/pickup-point-query-stats.port.ts
@@ -1,0 +1,27 @@
+/**
+ * Pickup-Point Query-Stats Port
+ *
+ * Tracks how often each pickup-point search query is run per connection and
+ * returns the most-frequent queries (#849). Feeds the daily background re-warm
+ * (`PickupPointRefreshService`), which re-runs the top-N searches to refresh
+ * their cached points + result lists.
+ *
+ * `record` is limit-agnostic (popularity is about the locality, not page
+ * size); `topQueries` returns reconstructed `FindPickupPointsQuery` objects,
+ * most-frequent first. Top-N ranking is intrinsically a sorted-set operation,
+ * which the KV `CachePort` can't express — hence a dedicated port (the Redis
+ * adapter uses ZSET ops on the raw client).
+ *
+ * Domain-only — zero framework imports.
+ *
+ * @module libs/core/src/shipping/domain/ports
+ */
+import type { FindPickupPointsQuery } from '../types/pickup-point.types';
+
+export interface PickupPointQueryStatsPort {
+  /** Increment the frequency count for `query` on `connectionId`. Best-effort. */
+  record(connectionId: string, query: FindPickupPointsQuery): Promise<void>;
+
+  /** The `limit` most-frequently-recorded queries for `connectionId`, most-frequent first. */
+  topQueries(connectionId: string, limit: number): Promise<FindPickupPointsQuery[]>;
+}

--- a/libs/core/src/shipping/domain/ports/pickup-point-search-cache.port.ts
+++ b/libs/core/src/shipping/domain/ports/pickup-point-search-cache.port.ts
@@ -1,0 +1,30 @@
+/**
+ * Pickup-Point Search-Cache Port
+ *
+ * Caches whole `query → PickupPoint[]` search results (#849), distinct from
+ * the by-id `PickupPointCachePort` (#766) which caches individual points.
+ * Sibling port rather than a widening of the by-id port: the two have
+ * different keyspaces, TTLs, and freshness semantics (lists go stale faster
+ * than a single locker's metadata, so the implementation uses a shorter TTL).
+ *
+ * A cache hit lets `PickupPointLookupService.search` skip the live provider
+ * call within the (short) TTL — the latency / rate-limit win this port exists
+ * for. The key is limit-inclusive (see `pickupPointSearchCacheKey`).
+ *
+ * Domain-only — zero framework imports.
+ *
+ * @module libs/core/src/shipping/domain/ports
+ */
+import type { FindPickupPointsQuery, PickupPoint } from '../types/pickup-point.types';
+
+export interface PickupPointSearchCachePort {
+  /** Cached result list for `(connectionId, query)`, or `null` on miss/expiry. */
+  get(connectionId: string, query: FindPickupPointsQuery): Promise<PickupPoint[] | null>;
+
+  /** Cache the result list for `(connectionId, query)`. TTL handled by the implementation. */
+  put(
+    connectionId: string,
+    query: FindPickupPointsQuery,
+    points: readonly PickupPoint[],
+  ): Promise<void>;
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -82,6 +82,8 @@ export { Shipment } from './domain/entities/shipment.entity';
 export type { ShippingProviderManagerPort } from './domain/ports/shipping-provider-manager.port';
 export type { ShipmentRepositoryPort } from './domain/ports/shipment-repository.port';
 export type { PickupPointCachePort } from './domain/ports/pickup-point-cache.port';
+export type { PickupPointSearchCachePort } from './domain/ports/pickup-point-search-cache.port';
+export type { PickupPointQueryStatsPort } from './domain/ports/pickup-point-query-stats.port';
 
 // Sub-capabilities (#763 — sub-port + co-located type guard pattern per
 // engineering-standards §"Port sub-capabilities").
@@ -146,6 +148,11 @@ export type { IShipmentLabelService } from './application/interfaces/shipment-la
 // Application — pickup-point lookup seam (#766). Interface only; the service is
 // injected via PICKUP_POINT_LOOKUP_SERVICE_TOKEN.
 export type { IPickupPointLookupService } from './application/interfaces/pickup-point-lookup.service.interface';
+
+// Application — pickup-point background-refresh seam (#849). Interface + result
+// type only; the service is injected via PICKUP_POINT_REFRESH_SERVICE_TOKEN.
+export type { IPickupPointRefreshService } from './application/interfaces/pickup-point-refresh.service.interface';
+export type { PickupPointRefreshResult } from './application/types/pickup-point-refresh.types';
 
 // Application — dispatch-notify seam (#837). Interface + result types only; the
 // service is injected via SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN.

--- a/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-query-stats.adapter.spec.ts
+++ b/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-query-stats.adapter.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Redis pickup-point query-stats adapter unit tests (#849).
+ *
+ * Mocks the raw Redis client's ZSET ops. Asserts record (ZINCRBY + rolling
+ * EXPIRE + cardinality cap) and topQueries (reverse ZRANGE → reconstructed
+ * queries, most-frequent first).
+ */
+import type { RedisClientType } from 'redis';
+import { RedisPickupPointQueryStatsAdapter } from './redis-pickup-point-query-stats.adapter';
+
+interface MockRedis {
+  zIncrBy: jest.Mock;
+  expire: jest.Mock;
+  zRemRangeByRank: jest.Mock;
+  zRange: jest.Mock;
+}
+
+describe('RedisPickupPointQueryStatsAdapter', () => {
+  let redis: MockRedis;
+  let adapter: RedisPickupPointQueryStatsAdapter;
+
+  beforeEach(() => {
+    redis = {
+      zIncrBy: jest.fn().mockResolvedValue(1),
+      expire: jest.fn().mockResolvedValue(true),
+      zRemRangeByRank: jest.fn().mockResolvedValue(0),
+      zRange: jest.fn().mockResolvedValue([]),
+    };
+    adapter = new RedisPickupPointQueryStatsAdapter(redis as unknown as RedisClientType);
+  });
+
+  describe('record', () => {
+    it('increments the connection ZSET, refreshes the rolling window, and caps cardinality', async () => {
+      await adapter.record('conn-1', { city: 'Poznań', limit: 5 });
+
+      expect(redis.zIncrBy).toHaveBeenCalledTimes(1);
+      const [key, increment, member] = redis.zIncrBy.mock.calls[0];
+      expect(key).toBe('paczkomat:freq:conn-1');
+      expect(increment).toBe(1);
+      // limit excluded from the member
+      expect(member).toBe(JSON.stringify({ city: 'poznań' }));
+
+      expect(redis.expire).toHaveBeenCalledWith('paczkomat:freq:conn-1', 7 * 86_400);
+      // keep only the top 500 (rank 0 = lowest score)
+      expect(redis.zRemRangeByRank).toHaveBeenCalledWith('paczkomat:freq:conn-1', 0, -501);
+    });
+
+    it('does not track the empty/unfiltered query', async () => {
+      await adapter.record('conn-1', {});
+      await adapter.record('conn-1', { city: '   ', limit: 10 });
+
+      expect(redis.zIncrBy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('topQueries', () => {
+    it('reads the top-N descending and reconstructs queries', async () => {
+      redis.zRange.mockResolvedValue([
+        JSON.stringify({ city: 'poznań' }),
+        JSON.stringify({ postalCode: '00-001' }),
+      ]);
+
+      const result = await adapter.topQueries('conn-1', 2);
+
+      expect(redis.zRange).toHaveBeenCalledWith('paczkomat:freq:conn-1', 0, 1, { REV: true });
+      expect(result).toEqual([
+        { city: 'poznań', postalCode: undefined, searchText: undefined },
+        { city: undefined, postalCode: '00-001', searchText: undefined },
+      ]);
+    });
+
+    it('returns [] for a non-positive limit without hitting Redis', async () => {
+      await expect(adapter.topQueries('conn-1', 0)).resolves.toEqual([]);
+      expect(redis.zRange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-query-stats.adapter.ts
+++ b/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-query-stats.adapter.ts
@@ -1,0 +1,79 @@
+/**
+ * Redis Pickup-Point Query-Stats Adapter
+ *
+ * Redis-ZSET-backed `PickupPointQueryStatsPort` (#849). Per-connection sorted
+ * set scored by query frequency: `ZINCRBY` on record, `ZRANGE … REV` for the
+ * top-N re-warm read, `EXPIRE` for a rolling window, `ZREMRANGEBYRANK` to cap
+ * cardinality.
+ *
+ * Why the raw `'REDIS_CLIENT'` (not the shared `CachePort`): top-N ranking is
+ * intrinsically a sorted-set operation, which the KV `CachePort`
+ * (`get`/`set`/`delete`) cannot express. Reaching for the raw client here
+ * follows the established `libs/core` precedent (`RedisSyncLockService`, the
+ * Redis-Streams enqueue + event-publisher adapters) — `'REDIS_CLIENT'` is a
+ * `@Global` export of `RedisConfigModule`. If a second ranking consumer ever
+ * appears, the right move is to promote a `CounterCachePort` into
+ * `@openlinker/shared/cache` — do NOT "fix" this back to `CachePort`.
+ *
+ * @module libs/core/src/shipping/infrastructure/adapters
+ * @see {@link PickupPointQueryStatsPort} for the port contract
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { RedisClientType } from 'redis';
+
+import type { PickupPointQueryStatsPort } from '../../domain/ports/pickup-point-query-stats.port';
+import type { FindPickupPointsQuery } from '../../domain/types/pickup-point.types';
+import {
+  pickupPointFrequencyMember,
+  parsePickupPointFrequencyMember,
+} from '../../domain/pickup-point-query';
+
+const KEY_PREFIX = 'paczkomat:freq:';
+/** `pickupPointFrequencyMember` for a query with no identity fields. */
+const EMPTY_QUERY_MEMBER = '{}';
+/** Rolling window: a query unqueried for 7 days ages out of the ranking. */
+const WINDOW_SECONDS = 7 * 86_400;
+/** Cap distinct tracked queries per connection so the ZSET can't grow unbounded. */
+const MAX_TRACKED_QUERIES = 500;
+
+@Injectable()
+export class RedisPickupPointQueryStatsAdapter implements PickupPointQueryStatsPort {
+  constructor(
+    @Inject('REDIS_CLIENT')
+    private readonly redisClient: RedisClientType,
+  ) {}
+
+  async record(connectionId: string, query: FindPickupPointsQuery): Promise<void> {
+    const member = pickupPointFrequencyMember(query);
+    // Don't track the empty/unfiltered query: re-warming `findPickupPoints({})`
+    // is the heaviest possible provider call and not a meaningful locality
+    // search. The member is `{}` only when every identity field is empty.
+    if (member === EMPTY_QUERY_MEMBER) {
+      return;
+    }
+    const key = keyFor(connectionId);
+    // Issued together so node-redis pipelines them into a single round-trip.
+    // `expire` refreshes the rolling window; `zRemRangeByRank` drops everything
+    // below the top MAX_TRACKED_QUERIES (rank 0 = lowest score). Order between
+    // them is irrelevant — neither depends on the increment's result.
+    await Promise.all([
+      this.redisClient.zIncrBy(key, 1, member),
+      this.redisClient.expire(key, WINDOW_SECONDS),
+      this.redisClient.zRemRangeByRank(key, 0, -(MAX_TRACKED_QUERIES + 1)),
+    ]);
+  }
+
+  async topQueries(connectionId: string, limit: number): Promise<FindPickupPointsQuery[]> {
+    if (!Number.isFinite(limit) || limit <= 0) {
+      return [];
+    }
+    const members = await this.redisClient.zRange(keyFor(connectionId), 0, limit - 1, {
+      REV: true,
+    });
+    return members.map((member) => parsePickupPointFrequencyMember(member));
+  }
+}
+
+function keyFor(connectionId: string): string {
+  return `${KEY_PREFIX}${connectionId}`;
+}

--- a/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-search-cache.adapter.spec.ts
+++ b/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-search-cache.adapter.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Redis pickup-point search-cache adapter unit tests (#849).
+ *
+ * Mocks the shared CachePort. Asserts the limit-inclusive key shape, the
+ * 1h-default TTL on write, and round-trip read.
+ */
+import type { CachePort } from '@openlinker/shared/cache';
+import { RedisPickupPointSearchCacheAdapter } from './redis-pickup-point-search-cache.adapter';
+import type { PickupPoint } from '../../domain/types/pickup-point.types';
+
+function makePoint(providerId = 'POZ08A'): PickupPoint {
+  return {
+    providerId,
+    name: `Paczkomat ${providerId}`,
+    address: { line1: 'Krakowska 12', city: 'Poznań', postalCode: '60-001', country: 'PL' },
+    status: 'active',
+  };
+}
+
+describe('RedisPickupPointSearchCacheAdapter', () => {
+  let cache: jest.Mocked<CachePort>;
+  let adapter: RedisPickupPointSearchCacheAdapter;
+
+  beforeEach(() => {
+    cache = { get: jest.fn(), set: jest.fn().mockResolvedValue(undefined), delete: jest.fn() };
+    adapter = new RedisPickupPointSearchCacheAdapter(cache);
+  });
+
+  it('writes the list under a connection- and limit-scoped key with the default 1h TTL', async () => {
+    const points = [makePoint(), makePoint('WAW01A')];
+
+    await adapter.put('conn-1', { city: 'Poznań', limit: 5 }, points);
+
+    expect(cache.set).toHaveBeenCalledTimes(1);
+    const [key, value, ttl] = cache.set.mock.calls[0];
+    expect(key).toContain('paczkomat:search:conn-1:');
+    expect(key).toContain('limit=5');
+    expect(value).toEqual(points);
+    expect(ttl).toBe(3_600);
+  });
+
+  it('reads from the same key it writes', async () => {
+    const points = [makePoint()];
+    cache.get.mockResolvedValue(points);
+
+    await expect(adapter.get('conn-1', { city: 'Poznań' })).resolves.toEqual(points);
+    const getKey = cache.get.mock.calls[0][0];
+    expect(getKey).toContain('paczkomat:search:conn-1:');
+    expect(getKey).toContain('limit=none');
+  });
+
+  it('uses distinct keys for different limits', async () => {
+    await adapter.put('conn-1', { city: 'Poznań', limit: 5 }, []);
+    await adapter.put('conn-1', { city: 'Poznań', limit: 50 }, []);
+    expect(cache.set.mock.calls[0][0]).not.toBe(cache.set.mock.calls[1][0]);
+  });
+
+  it('returns null on a miss', async () => {
+    cache.get.mockResolvedValue(null);
+    await expect(adapter.get('conn-1', {})).resolves.toBeNull();
+  });
+});

--- a/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-search-cache.adapter.ts
+++ b/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-search-cache.adapter.ts
@@ -1,0 +1,60 @@
+/**
+ * Redis Pickup-Point Search-Cache Adapter
+ *
+ * Redis-backed `PickupPointSearchCachePort` (#849) over the shared `CachePort`
+ * (values JSON-serialized at that boundary). Caches whole `query → PickupPoint[]`
+ * result lists keyed by connection + the limit-inclusive
+ * `pickupPointSearchCacheKey`, with a TTL shorter than the 24h per-point entry
+ * (#766) because lists go stale faster than a single locker's metadata.
+ *
+ * @module libs/core/src/shipping/infrastructure/adapters
+ * @see {@link PickupPointSearchCachePort} for the port contract
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { CACHE_PORT_TOKEN, type CachePort } from '@openlinker/shared/cache';
+
+import type { PickupPointSearchCachePort } from '../../domain/ports/pickup-point-search-cache.port';
+import type { FindPickupPointsQuery, PickupPoint } from '../../domain/types/pickup-point.types';
+import { pickupPointSearchCacheKey } from '../../domain/pickup-point-query';
+
+/** Default search-list TTL (1h). Shorter than the 24h per-point entry — lists go stale faster. */
+const DEFAULT_SEARCH_CACHE_TTL_SECONDS = 3_600;
+const MIN_SEARCH_CACHE_TTL_SECONDS = 60;
+const MAX_SEARCH_CACHE_TTL_SECONDS = 86_400;
+
+const KEY_PREFIX = 'paczkomat:search:';
+
+function resolveTtlSeconds(): number {
+  const raw = process.env.OL_PICKUP_POINT_SEARCH_CACHE_TTL_SECONDS;
+  const parsed = raw !== undefined && raw !== '' ? Number(raw) : Number.NaN;
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_SEARCH_CACHE_TTL_SECONDS;
+  }
+  return Math.min(MAX_SEARCH_CACHE_TTL_SECONDS, Math.max(MIN_SEARCH_CACHE_TTL_SECONDS, parsed));
+}
+
+@Injectable()
+export class RedisPickupPointSearchCacheAdapter implements PickupPointSearchCachePort {
+  private readonly ttlSeconds = resolveTtlSeconds();
+
+  constructor(
+    @Inject(CACHE_PORT_TOKEN)
+    private readonly cache: CachePort,
+  ) {}
+
+  get(connectionId: string, query: FindPickupPointsQuery): Promise<PickupPoint[] | null> {
+    return this.cache.get<PickupPoint[]>(keyFor(connectionId, query));
+  }
+
+  async put(
+    connectionId: string,
+    query: FindPickupPointsQuery,
+    points: readonly PickupPoint[],
+  ): Promise<void> {
+    await this.cache.set(keyFor(connectionId, query), [...points], this.ttlSeconds);
+  }
+}
+
+function keyFor(connectionId: string, query: FindPickupPointsQuery): string {
+  return `${KEY_PREFIX}${connectionId}:${pickupPointSearchCacheKey(query)}`;
+}

--- a/libs/core/src/shipping/shipping.module.ts
+++ b/libs/core/src/shipping/shipping.module.ts
@@ -30,11 +30,14 @@ import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { ShipmentOrmEntity } from './infrastructure/persistence/entities/shipment.orm-entity';
 import { ShipmentRepository } from './infrastructure/persistence/repositories/shipment.repository';
 import { RedisPickupPointCacheAdapter } from './infrastructure/adapters/redis-pickup-point-cache.adapter';
+import { RedisPickupPointSearchCacheAdapter } from './infrastructure/adapters/redis-pickup-point-search-cache.adapter';
+import { RedisPickupPointQueryStatsAdapter } from './infrastructure/adapters/redis-pickup-point-query-stats.adapter';
 import { ShipmentDispatchService } from './application/services/shipment-dispatch.service';
 import { BulkShipmentDispatchService } from './application/services/bulk-shipment-dispatch.service';
 import { ShipmentQueryService } from './application/services/shipment-query.service';
 import { ShipmentCancellationService } from './application/services/shipment-cancellation.service';
 import { PickupPointLookupService } from './application/services/pickup-point-lookup.service';
+import { PickupPointRefreshService } from './application/services/pickup-point-refresh.service';
 import { ShipmentDispatchNotificationService } from './application/services/shipment-dispatch-notification.service';
 import { ShipmentStatusSyncService } from './application/services/shipment-status-sync.service';
 import { FulfillmentStatusSyncService } from './application/services/fulfillment-status-sync.service';
@@ -44,6 +47,9 @@ import {
   FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,
   PICKUP_POINT_CACHE_TOKEN,
   PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
+  PICKUP_POINT_SEARCH_CACHE_TOKEN,
+  PICKUP_POINT_QUERY_STATS_TOKEN,
+  PICKUP_POINT_REFRESH_SERVICE_TOKEN,
   SHIPMENT_CANCELLATION_SERVICE_TOKEN,
   SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
   SHIPMENT_DISPATCH_SERVICE_TOKEN,
@@ -101,10 +107,27 @@ import {
       provide: PICKUP_POINT_CACHE_TOKEN,
       useExisting: RedisPickupPointCacheAdapter,
     },
+    RedisPickupPointSearchCacheAdapter,
+    {
+      provide: PICKUP_POINT_SEARCH_CACHE_TOKEN,
+      useExisting: RedisPickupPointSearchCacheAdapter,
+    },
+    RedisPickupPointQueryStatsAdapter,
+    {
+      provide: PICKUP_POINT_QUERY_STATS_TOKEN,
+      useExisting: RedisPickupPointQueryStatsAdapter,
+    },
     PickupPointLookupService,
     {
       provide: PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
       useExisting: PickupPointLookupService,
+    },
+    // #849 background re-warm orchestration — re-runs the top-N most-frequent
+    // searches per connection (driven by the worker's pickup-point-refresh handler).
+    PickupPointRefreshService,
+    {
+      provide: PICKUP_POINT_REFRESH_SERVICE_TOKEN,
+      useExisting: PickupPointRefreshService,
     },
     ShipmentDispatchNotificationService,
     {
@@ -139,6 +162,9 @@ import {
     SHIPMENT_CANCELLATION_SERVICE_TOKEN,
     PICKUP_POINT_CACHE_TOKEN,
     PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
+    PICKUP_POINT_SEARCH_CACHE_TOKEN,
+    PICKUP_POINT_QUERY_STATS_TOKEN,
+    PICKUP_POINT_REFRESH_SERVICE_TOKEN,
     SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
     SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
     FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,

--- a/libs/core/src/shipping/shipping.tokens.ts
+++ b/libs/core/src/shipping/shipping.tokens.ts
@@ -17,6 +17,9 @@ export const BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN = Symbol('IBulkShipmentDispatc
 export const SHIPMENT_QUERY_SERVICE_TOKEN = Symbol('IShipmentQueryService');
 export const SHIPMENT_CANCELLATION_SERVICE_TOKEN = Symbol('IShipmentCancellationService');
 export const PICKUP_POINT_LOOKUP_SERVICE_TOKEN = Symbol('IPickupPointLookupService');
+export const PICKUP_POINT_SEARCH_CACHE_TOKEN = Symbol('PickupPointSearchCachePort');
+export const PICKUP_POINT_QUERY_STATS_TOKEN = Symbol('PickupPointQueryStatsPort');
+export const PICKUP_POINT_REFRESH_SERVICE_TOKEN = Symbol('IPickupPointRefreshService');
 export const SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN = Symbol(
   'IShipmentDispatchNotificationService',
 );

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -32,6 +32,9 @@ export const JobTypeValues = [
 
   'master.variants.autoMatch',
 
+  // Shipping (core-owned; capability-scoped, executed by worker)
+  'shipping.pickupPoint.refreshFrequent',
+
   // Internal orchestration (core-owned policies; executed by worker)
   'inventory.propagateToMarketplaces',
 ] as const;


### PR DESCRIPTION
## What & why

Closes #849. Delivers the two acceptance criteria #766 deferred. **Capability-scoped** — keys off `ShippingProviderManager` + the `PickupPointFinder` sub-capability, so it covers **InPost and DPD (#973)** alike, never a `platformType` literal. **Redis-only; no DB/migration.**

### 1. Per-search-query result caching
New **sibling** `PickupPointSearchCachePort` (over the shared `CachePort`) caches whole `query → PickupPoint[]` lists — key is **limit-inclusive**, TTL `OL_PICKUP_POINT_SEARCH_CACHE_TTL_SECONDS` (default 1h, shorter than the 24h per-point entry). The by-id `PickupPointCachePort` (#766) is **untouched**. `PickupPointLookupService.search` now: record frequency → **cache-first** (skip the provider on a hit within TTL) → live search + write-through both caches on a miss.

### 2. Background re-warm
A daily, env-gated **core scheduler task** fans out one `shipping.pickupPoint.refreshFrequent` job per `ShippingProviderManager` connection. A thin worker handler delegates to the core `PickupPointRefreshService`, which reads the **top-N most-frequent** searches and re-runs each via a new `refreshSearch` path (always live, **no** frequency record, **no** cache-read — so the re-warm can't reinforce its own counts; guarded by `isPickupPointFinder` so non-finder connections no-op).

### Frequency tracking
New `PickupPointQueryStatsPort` backed by a Redis **ZSET** adapter (`ZINCRBY` / `ZREVRANGE` / rolling `EXPIRE` / `ZREMRANGEBYRANK` cap), following the established `libs/core` raw-`'REDIS_CLIENT'` precedent (`RedisSyncLockService`, the Redis-Streams adapters) for ranking — an operation the KV `CachePort` can't express. Long-term escalation path (a shared `CounterCachePort`) is documented in the adapter header; YAGNI today.

## Architecture
Ports in `domain/ports`, adapters in `infrastructure/adapters`, orchestration in a core service, thin worker handler (per the Sync-Manager rule). Two normalizer key-derivations: frequency key **excludes** `limit`; search-cache key **includes** it (a `limit=5` entry must not satisfy a later `limit=50` query).

## Tech-review fixes folded in
- The **empty/unfiltered query** (`{}`) is neither tracked nor re-warmed — avoids a nightly unfiltered provider call; refresh guards defensively too.
- The frequency-record ops are **pipelined** into a single Redis round-trip.

## Env knobs (apps/api/.env.example)
`OL_PICKUP_POINT_REFRESH_ENABLED` / `_CRON` (default `0 3 * * *`) / `_TOP_N` (50), `OL_PICKUP_POINT_SEARCH_CACHE_TTL_SECONDS` (3600).

## Testing
- `pnpm lint` (ESLint + all `check:invariants`) ✓, `pnpm type-check` ✓, full `pnpm test` ✓.
- New unit specs: normalizer, both Redis adapters, lookup-service paths (record / cache-first / refresh), refresh service (finder guard, isolation, empty-skip), worker handler; existing lookup + scheduler + controller specs updated.
- No int-spec added (Redis-only, additive — mirrors #766's unit-level coverage); the scheduler→worker→service wiring boots in the existing api/worker integration harnesses on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)