### PR TITLE
feat(shipping): schedule InPost shipment-status poll (webhook fallback) (#772)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -98,6 +98,16 @@ OL_PICKUP_POINT_REFRESH_CRON=0 3 * * *
 # Result-cache TTL in seconds (default 3600 = 1h, clamped 60..86400; shorter than the 24h per-point entry)
 # OL_PICKUP_POINT_SEARCH_CACHE_TTL_SECONDS=3600
 
+# --- Schedulers: InPost shipment-status poll (#772, platform-scoped, inpost) --
+# Webhook fallback for InPost tracking: drives the carrier-generic
+# marketplace.shipment.statusSync poll (#838) for InPost connections. Default
+# every 30 min (deliberately slower than Allegro's 15 — this is a fallback, not
+# the primary path). Set ENABLED=false to disable.
+OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED=true
+OL_INPOST_SHIPMENT_STATUS_SYNC_INTERVAL_CRON=0 */30 * * * *
+# Shipments scanned per tick (default 50)
+# OL_INPOST_SHIPMENT_STATUS_SYNC_PAGE_LIMIT=50
+
 # --- Schedulers: Allegro offers sync ------------------------------------------
 ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED=true
 ALLEGRO_OFFERS_SYNC_INTERVAL_CRON=*/1 * * * *

--- a/apps/worker/src/plugins.ts
+++ b/apps/worker/src/plugins.ts
@@ -16,6 +16,12 @@
  * per-job AI description generation. Without this, `AI_COMPLETION_PORT_TOKEN`
  * is unresolved in the worker's DI scope.
  *
+ * `InpostIntegrationModule` is registered here (#772) so the worker can resolve
+ * the InPost `ShippingProviderManager` adapter when executing the
+ * `marketplace.shipment.statusSync` job for InPost connections. (The worker runs
+ * no SchedulerService, so InPost's scheduler task registers but never fires
+ * here — it is drained only by the api.)
+ *
  * See `docs/architecture-overview.md` § *Adapter Registry (Code-Level)* for
  * the conceptual model.
  *
@@ -25,9 +31,11 @@ import type { PluginEntry } from '@openlinker/core/integrations';
 import { PrestashopIntegrationModule } from '@openlinker/integrations-prestashop';
 import { AllegroIntegrationModule } from '@openlinker/integrations-allegro';
 import { AiIntegrationModule } from '@openlinker/integrations-ai';
+import { InpostIntegrationModule } from '@openlinker/integrations-inpost';
 
 export const workerPlugins: PluginEntry[] = [
   PrestashopIntegrationModule,
   AllegroIntegrationModule,
   AiIntegrationModule.register(),
+  InpostIntegrationModule,
 ];

--- a/apps/worker/test/jest-integration.cjs
+++ b/apps/worker/test/jest-integration.cjs
@@ -51,5 +51,13 @@ module.exports = {
       __dirname,
       '../../../libs/integrations/ai/src/$1',
     ),
+    '^@openlinker/integrations-inpost$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/inpost/src/index.ts',
+    ),
+    '^@openlinker/integrations-inpost/(.*)$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/inpost/src/$1',
+    ),
   },
 };

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-772-inpost-shipment-status-poll.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-772-inpost-shipment-status-poll.md
@@ -1,0 +1,39 @@
+# Pre-implement analysis — #772 InPost shipment-status polling
+
+**Verdict: READY** (no Critical contract breaks; no reuse collision; purely additive)
+
+Gated against `docs/plans/implementation-plan-772-inpost-shipment-status-poll.md` on a fresh worktree at `origin/main` (dbc791b1).
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `inpost-scheduler-tasks.ts` / `buildInpostSchedulerTasks()` | **NEW** | `find libs/integrations/inpost -iname '*scheduler*'` → none |
+| `marketplace.shipment.statusSync` job type | **EXISTS → reuse (no change)** | `libs/core/src/sync/domain/types/sync-job.types.ts:26` |
+| `ShipmentStatusSyncService` + `MarketplaceShipmentStatusSyncHandler` | **EXISTS → reuse (no change)** | `libs/core/src/shipping/application/services/shipment-status-sync.service.ts`; `apps/worker/src/sync/handlers/marketplace-shipment-status-sync.handler.ts` (reads `payload.cursorKey`) |
+| `SchedulerTaskConfig` (`platformType` scoping) | **EXISTS → reuse** | `libs/core/src/sync/domain/types/scheduler-task.types.ts` (exactly-one-of `platformType`/`connectionFilter`) |
+| `host.schedulerTaskRegistry` register seam | **EXISTS → reuse** | `createNestAdapterModule` injects `SCHEDULER_TASK_REGISTRY_TOKEN`; Allegro's `register(host)` already uses it |
+| `OL_INPOST_SHIPMENT_STATUS_SYNC_*` env vars | **NEW** | grep across `libs`/`apps` → no prior use |
+| `InpostIntegrationModule` in `apps/worker/src/plugins.ts` | **NEW edit** | worker plugins list has Prestashop/Allegro/AI only |
+| InPost worker `jest-integration.cjs` mapper pair | **NEW edit** | `grep -c integrations-inpost apps/worker/test/jest-integration.cjs` → **0** |
+| InPost api `jest-integration.cjs` mapper pair | **ALREADY PRESENT (no edit)** | api file → 2 hits (InPost is already an api plugin) |
+
+## Backward-compatibility findings
+
+| Surface | Result |
+|---|---|
+| Top-level barrels | No symbol removed/renamed — additive only. |
+| Port signatures | None changed (`ShippingProviderManagerPort`, handler, service all untouched). |
+| DTO shapes | None. |
+| Symbol tokens | None added/removed (task uses the existing job type + cursor mechanism). |
+| ORM schema | **No change → no migration.** |
+| `check:invariants` | `check-jest-integration-mappers` **requires** the worker mapper pair when InPost is added to `apps/worker/src/plugins.ts` — the plan includes it (step 4), so the guard stays green. No cross-context-import or service-interface rule is touched (plugin imports `SchedulerTaskConfig` as a type from the `@openlinker/core/sync` top-level barrel). |
+
+## Open questions (carry into implementation — non-blocking for the gate)
+
+1. **Load-bearing (from tech-review):** verify InPost `Shipment` rows are persisted with `connectionId = <the InPost ShippingProviderManager connection>` the scheduler enqueues for. `ShipmentStatusSyncService.sync` does `shipments.findMany({ connectionId, statuses })`; if InPost shipments are stored under a different connection, the poll silently scans zero rows. Trace the `#765/#812` InPost label/dispatch persistence path before trusting `platformType:'inpost'` scoping.
+2. **Cadence:** plan defaults to 30 min (SC-4 "conservative") vs Allegro's 15 — operator's call, already surfaced.
+
+## Summary
+
+Purely additive, integration-layer only; reuses the #838 engine + job + handler verbatim and mirrors the Allegro sibling task. No contract surface changes, no migration. The one worker-mapper edit is mandatory (guard-enforced) and already in the plan. The only real risk is behavioral, not structural — the `Shipment.connectionId` assumption (Open Question 1) — which is a verification step, not a plan defect. **READY to implement.**

--- a/docs/plans/implementation-plan-772-inpost-shipment-status-poll.md
+++ b/docs/plans/implementation-plan-772-inpost-shipment-status-poll.md
@@ -1,0 +1,51 @@
+# Implementation Plan — #772 InPost shipment-status polling (re-scoped)
+
+## 1. Understand the task
+
+**Goal:** Make InPost shipment tracking update end-to-end **without** a provisioned webhook, by scheduling the *existing* #838 `marketplace.shipment.statusSync` poll for InPost connections.
+
+**Layer:** Integration (InPost plugin) + host wiring (worker plugin list). **No CORE change** — the poll engine, job, handler, and propagation path all shipped in #838 and are carrier-generic.
+
+**Re-scope context:** #772's original body ("build a poller + extract a shared propagation service") is obsolete — #838 did it. Investigation (Phase 1.5) found the poll is scheduled **only for Allegro** (`allegro-scheduler-tasks.ts`, `platformType:'allegro'`); InPost registers no scheduler tasks and is absent from `apps/worker/src/plugins.ts`. The issue body was updated on claim.
+
+**Non-goals:**
+- Any change to `ShipmentStatusSyncService` / `MarketplaceShipmentStatusSyncHandler` / the OMP propagation path (all #838).
+- Per-connection "polling fallback enabled" DB toggle — env-gate + always-on poll suffices for v1 (deferred).
+- Customer-visible tracking pages; time-since-dispatch cadence optimization (v2).
+
+## 2. Research findings (live repo)
+
+- **`MarketplaceShipmentStatusSyncHandler`** (`apps/worker`) is carrier-generic: reads `payload.cursorKey ?? DEFAULT_CURSOR_KEY` and resolves the carrier via `getCapabilityAdapter(connectionId, 'ShippingProviderManager')`. **No handler change needed.**
+- **`ShipmentStatusSyncService`** (#838, core) polls non-terminal shipments, advances to terminal, backfills tracking, propagates to OMP. Carrier-agnostic.
+- **Allegro task** (`allegro-scheduler-tasks.ts`): `taskId:'allegro-shipment-status-sync'`, `platformType:'allegro'`, `jobType:'marketplace.shipment.statusSync'`, `cursorKey:'allegro.shipmentStatus.scanOffset'`, env-gated. **This is the exact template.**
+- **`SchedulerTaskConfig`** requires exactly one of `platformType` | `connectionFilter`; `platformType:'inpost'` is correct.
+- **`createNestAdapterModule`** (InPost's module) injects `host.schedulerTaskRegistry` and calls `plugin.register(host)` → the InPost `register()` can register tasks. The plugin is constructed eagerly (no DI), so the task helper reads **`process.env`** (precedent: #849 pickup-refresh reads `process.env` directly).
+- **`apps/worker/src/plugins.ts`** lacks `InpostIntegrationModule`. The worker has **no SchedulerService**, so: (a) the worker needs InPost added so the poll handler can resolve the InPost adapter; (b) registering the task in the worker is a harmless no-op (only the api drains tasks — same as Allegro today).
+- **`check-jest-integration-mappers`** (#917) requires every `plugins.ts` integration to have two `moduleNameMapper` entries in that app's `test/jest-integration.cjs`. Adding InPost to `apps/worker/plugins.ts` ⇒ must add its two worker mapper lines.
+
+## 3. Design / steps
+
+| # | File | Change | Acceptance |
+|---|---|---|---|
+| 0 | *(verification — no code)* | **Confirm the load-bearing assumption** (tech-review IMPORTANT-1): trace the InPost label/dispatch persistence path (`#765/#812`) and confirm InPost `Shipment` rows are written with `connectionId = <the InPost ShippingProviderManager connection>` that this task enqueues for. `ShipmentStatusSyncService.sync` does `shipments.findMany({ connectionId, statuses })` + resolves the carrier via `getCapabilityAdapter(connectionId, 'ShippingProviderManager')`, so a mismatch makes the poll a silent zero-row no-op. **If the assumption does not hold, STOP and resurface** — the scheduler task is pointless until shipment persistence keys to the carrier connection. | Documented confirmation (file + line where `Shipment.connectionId` is set for InPost) before any task code is written. |
+| 1 | `libs/integrations/inpost/src/infrastructure/scheduler/inpost-scheduler-tasks.ts` *(new)* | `buildInpostSchedulerTasks(): SchedulerTaskConfig[]` reading `process.env` (the plugin is constructed eagerly by `createNestAdapterModule` — no DI — and `register(host)` runs at `onModuleInit`, after dotenv has populated `process.env`; #849 precedent. **The file header must state this** so a future reader doesn't "fix" it toward `ConfigService` and reopen the eager-construction problem). Returns the `inpost-shipment-status-sync` task; omits it when `OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED === 'false'`. Mirrors the Allegro task: `platformType:'inpost'`, `jobType:'marketplace.shipment.statusSync'`, `cursorKey:'inpost.shipmentStatus.scanOffset'`, `enabledEnvVar:'OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED'`, cron default `'0 */30 * * * *'` (**6-field, seconds-leading — parity with Allegro's `'0 */15 * * * *'`; keep 6-field**), page-limit default 50, idempotency `marketplace:${connection.id}:shipment:status:sync:${timestamp}`. | Returns 1 task when enabled, 0 when disabled; payload carries `schemaVersion:1`, `limit`, `cursorKey:'inpost.shipmentStatus.scanOffset'`. |
+| 2 | `libs/integrations/inpost/src/inpost-plugin.ts` | In `register(host)`: `for (const task of buildInpostSchedulerTasks()) host.schedulerTaskRegistry.register(task);` | Registration loop present; existing config-validator registration untouched. |
+| 3 | `apps/worker/src/plugins.ts` | Import + append `InpostIntegrationModule` to `workerPlugins`. | Worker can resolve the InPost `ShippingProviderManager` adapter when running `marketplace.shipment.statusSync`. |
+| 4 | `apps/worker/test/jest-integration.cjs` | Add `^@openlinker/integrations-inpost$` + `^@openlinker/integrations-inpost/(.*)$` mapper entries. | `pnpm lint` (`check-jest-integration-mappers`) green; fresh-worktree worker int-tests resolve InPost via `src/`. |
+| 5 | `apps/api/.env.example` | Document `OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED` / `_INTERVAL_CRON` / `_PAGE_LIMIT`. | Knobs documented next to the Allegro shipment-sync block. |
+| 6 | `libs/integrations/inpost/src/infrastructure/scheduler/inpost-scheduler-tasks.spec.ts` *(new)* | Unit specs: enabled→1 task w/ correct fields+payload; `=false`→0 tasks; cron default + override; page-limit default + override. | All assertions pass. |
+
+## 4. Validation
+
+- **Architecture:** integration-layer only; no CORE edit; matches the Allegro sibling exactly. Additive — no signature/DTO/token/ORM change → no contract break, no migration.
+- **Naming:** `inpost-scheduler-tasks.ts` mirrors `allegro-scheduler-tasks.ts`; env vars mirror `OL_ALLEGRO_SHIPMENT_STATUS_SYNC_*`.
+- **Testing:** unit spec on the task builder (the only new logic). End-to-end poll is already covered by #838's specs; the worker→adapter resolution is exercised by existing worker integration boot.
+- **jest-integration mappers (#917):** `apps/api/test/jest-integration.cjs` already maps `@openlinker/integrations-inpost` (InPost is already an api plugin — verified, 2 hits), so **only the worker file needs the pair added** (verified absent — 0 hits). `check-jest-integration-mappers` enforces this once InPost lands in `apps/worker/src/plugins.ts`.
+- **Cadence decision:** default `'0 */30 * * * *'` (every 30 min) per SC-4's "conservative" guidance — deliberately slower than Allegro's 15 min because the InPost poll is a webhook *fallback*, not the primary path. Operator-overridable via `OL_INPOST_SHIPMENT_STATUS_SYNC_INTERVAL_CRON`. (Surfaced to the maintainer; 30 min chosen.)
+- **Risk:** structural risk very low. Double-scheduling is impossible (worker runs no SchedulerService). Cursor key + idempotency key are disjoint from Allegro's. The only real risk is behavioral — the step-0 `Shipment.connectionId` assumption — which is verified before any code.
+
+## 5. Pre-implement gate
+
+Ran `/pre-implement` → **READY**. Verdict at `docs/plans/analysis/ANALYSIS-implementation-plan-772-inpost-shipment-status-poll.md`. Confirmed against a fresh worktree at `origin/main` (dbc791b1): no reuse collision (`inpost-scheduler-tasks*` absent; job type / service / handler / register-seam reused verbatim; env names unused); no contract-surface break; no migration. The mandatory worker `jest-integration.cjs` mapper edit is included (guard-enforced; worker file confirmed at 0 hits, api file already at 2). One open question carried forward as step 0 above — the `Shipment.connectionId` assumption — behavioral, not structural.
+
+A deep `/tech-review` of this plan also ran → 🔄 Approve with changes: the step-0 verification is the folded IMPORTANT item; SUGGESTIONs (process.env rationale, 6-field cron, api-mapper-already-present) are reflected in steps 1 + §4.

--- a/libs/integrations/inpost/src/infrastructure/scheduler/__tests__/inpost-scheduler-tasks.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/scheduler/__tests__/inpost-scheduler-tasks.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * InPost Scheduler Tasks — Unit Spec
+ *
+ * Covers `buildInpostSchedulerTasks`: the enable gate, task identity/scoping,
+ * payload shape (incl. the disjoint cursor key), cron + page-limit defaults and
+ * overrides, and the idempotency-key shape. Reads from `process.env`, so each
+ * test mutates a restored copy.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/scheduler/__tests__
+ */
+import { Connection } from '@openlinker/core/identifier-mapping';
+import { buildInpostSchedulerTasks } from '../inpost-scheduler-tasks';
+
+const ENV_KEYS = [
+  'OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED',
+  'OL_INPOST_SHIPMENT_STATUS_SYNC_INTERVAL_CRON',
+  'OL_INPOST_SHIPMENT_STATUS_SYNC_PAGE_LIMIT',
+] as const;
+
+const makeConnection = (): Connection =>
+  new Connection(
+    'conn-inpost-1',
+    'inpost',
+    'Test InPost',
+    'active',
+    {},
+    'cred-ref',
+    new Date(),
+    new Date(),
+    undefined,
+    ['ShippingProviderManager'],
+  );
+
+describe('buildInpostSchedulerTasks', () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  describe('enable gate', () => {
+    it('should register the shipment-status poll by default (env unset)', () => {
+      const tasks = buildInpostSchedulerTasks();
+      expect(tasks.map((t) => t.taskId)).toEqual(['inpost-shipment-status-sync']);
+    });
+
+    it('should omit the task when OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED=false', () => {
+      process.env.OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED = 'false';
+      expect(buildInpostSchedulerTasks()).toEqual([]);
+    });
+
+    it('should register the task for any non-"false" value', () => {
+      process.env.OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED = 'true';
+      expect(buildInpostSchedulerTasks()).toHaveLength(1);
+    });
+  });
+
+  describe('task shape', () => {
+    it('should be platform-scoped to inpost on the shared shipment-status job', () => {
+      const [task] = buildInpostSchedulerTasks();
+      expect(task.platformType).toBe('inpost');
+      expect(task.jobType).toBe('marketplace.shipment.statusSync');
+      expect(task.enabledEnvVar).toBe('OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED');
+    });
+
+    it('should default to a 30-minute (6-field) cron', () => {
+      const [task] = buildInpostSchedulerTasks();
+      expect(task.cronExpression).toBe('0 */30 * * * *');
+    });
+
+    it('should honour an interval-cron override', () => {
+      process.env.OL_INPOST_SHIPMENT_STATUS_SYNC_INTERVAL_CRON = '0 */5 * * * *';
+      const [task] = buildInpostSchedulerTasks();
+      expect(task.cronExpression).toBe('0 */5 * * * *');
+    });
+  });
+
+  describe('payload', () => {
+    it('should carry schemaVersion, default limit, and the disjoint cursor key', () => {
+      const [task] = buildInpostSchedulerTasks();
+      expect(task.generatePayload(makeConnection())).toEqual({
+        schemaVersion: 1,
+        limit: 50,
+        cursorKey: 'inpost.shipmentStatus.scanOffset',
+      });
+    });
+
+    it('should honour a page-limit override', () => {
+      process.env.OL_INPOST_SHIPMENT_STATUS_SYNC_PAGE_LIMIT = '120';
+      const [task] = buildInpostSchedulerTasks();
+      expect(task.generatePayload(makeConnection())).toMatchObject({ limit: 120 });
+    });
+
+    it('should fall back to the default limit on a non-positive override', () => {
+      process.env.OL_INPOST_SHIPMENT_STATUS_SYNC_PAGE_LIMIT = '0';
+      const [task] = buildInpostSchedulerTasks();
+      expect(task.generatePayload(makeConnection())).toMatchObject({ limit: 50 });
+    });
+  });
+
+  describe('idempotency key', () => {
+    it('should key per connection + timestamp', () => {
+      const [task] = buildInpostSchedulerTasks();
+      expect(task.generateIdempotencyKey(makeConnection(), '2026-06-05T03:00')).toBe(
+        'marketplace:conn-inpost-1:shipment:status:sync:2026-06-05T03:00',
+      );
+    });
+  });
+});

--- a/libs/integrations/inpost/src/infrastructure/scheduler/inpost-scheduler-tasks.ts
+++ b/libs/integrations/inpost/src/infrastructure/scheduler/inpost-scheduler-tasks.ts
@@ -1,0 +1,80 @@
+/**
+ * InPost Scheduler Tasks
+ *
+ * Builds the `SchedulerTaskConfig` instances InPost contributes to the core
+ * `SchedulerTaskRegistryService`. One task today:
+ *
+ *   - `inpost-shipment-status-sync` (#772) — the webhook **fallback** for InPost
+ *     tracking. Drives the existing carrier-generic `marketplace.shipment.statusSync`
+ *     job (#838) for InPost connections: the worker handler re-reads each
+ *     non-terminal InPost `Shipment` via `getTracking`, advances OL's row toward
+ *     carrier reality, and projects the tracking number to the destination OMP.
+ *     This package adds **only the scheduling** — the poll engine, job, handler,
+ *     and propagation path are all #838. Rolling scan-offset cursor key
+ *     `inpost.shipmentStatus.scanOffset` (disjoint from Allegro's). Default every
+ *     30 minutes — deliberately slower than Allegro's 15 because this is a
+ *     fallback for when the InPost webhook (#768) isn't provisioned, not the
+ *     primary path.
+ *
+ * **Why `process.env` (not `ConfigService`):** the InPost plugin is constructed
+ * eagerly by `createNestAdapterModule` (no DI container at construction), and
+ * this builder is invoked from the descriptor's `register(host)` at
+ * `onModuleInit` — after the host bootstrap has populated `process.env` (incl.
+ * dotenv). Reading `process.env` here is correct and intentional; do NOT "fix"
+ * it toward `ConfigService` (that would require converting InPost off the
+ * easy-path module). Mirrors the #849 pickup-refresh precedent. The core
+ * scheduler re-reads `enabledEnvVar` at each tick for runtime on/off toggling.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/scheduler
+ * @see {@link SchedulerTaskConfig} in `@openlinker/core/sync`.
+ */
+import type { SchedulerTaskConfig } from '@openlinker/core/sync';
+
+const SCHEDULER_ENABLED_ENV = 'OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED';
+const INTERVAL_CRON_ENV = 'OL_INPOST_SHIPMENT_STATUS_SYNC_INTERVAL_CRON';
+const PAGE_LIMIT_ENV = 'OL_INPOST_SHIPMENT_STATUS_SYNC_PAGE_LIMIT';
+
+/** Every 30 min (6-field, seconds-leading — parity with Allegro's task). */
+const DEFAULT_INTERVAL_CRON = '0 */30 * * * *';
+const DEFAULT_PAGE_LIMIT = 50;
+
+/** Disjoint from Allegro's `allegro.shipmentStatus.scanOffset`. */
+const CURSOR_KEY = 'inpost.shipmentStatus.scanOffset';
+
+const isEnabled = (key: string): boolean => (process.env[key] ?? 'true') !== 'false';
+
+function resolvePageLimit(): number {
+  const raw = process.env[PAGE_LIMIT_ENV];
+  const parsed = raw !== undefined && raw !== '' ? Number(raw) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : DEFAULT_PAGE_LIMIT;
+}
+
+/**
+ * Build the InPost scheduler-task list. Returns 0–1 tasks depending on the
+ * `OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED` gate.
+ */
+export function buildInpostSchedulerTasks(): SchedulerTaskConfig[] {
+  const tasks: SchedulerTaskConfig[] = [];
+
+  if (isEnabled(SCHEDULER_ENABLED_ENV)) {
+    const cronExpression = process.env[INTERVAL_CRON_ENV] || DEFAULT_INTERVAL_CRON;
+    const pageLimit = resolvePageLimit();
+
+    tasks.push({
+      taskId: 'inpost-shipment-status-sync',
+      platformType: 'inpost',
+      jobType: 'marketplace.shipment.statusSync',
+      cronExpression,
+      enabledEnvVar: SCHEDULER_ENABLED_ENV,
+      generatePayload: () => ({
+        schemaVersion: 1,
+        limit: pageLimit,
+        cursorKey: CURSOR_KEY,
+      }),
+      generateIdempotencyKey: (connection, timestamp) =>
+        `marketplace:${connection.id}:shipment:status:sync:${timestamp}`,
+    });
+  }
+
+  return tasks;
+}

--- a/libs/integrations/inpost/src/infrastructure/scheduler/inpost-scheduler-tasks.ts
+++ b/libs/integrations/inpost/src/infrastructure/scheduler/inpost-scheduler-tasks.ts
@@ -28,7 +28,10 @@
  * @module libs/integrations/inpost/src/infrastructure/scheduler
  * @see {@link SchedulerTaskConfig} in `@openlinker/core/sync`.
  */
-import type { SchedulerTaskConfig } from '@openlinker/core/sync';
+import type {
+  MarketplaceShipmentStatusSyncPayloadV1,
+  SchedulerTaskConfig,
+} from '@openlinker/core/sync';
 
 const SCHEDULER_ENABLED_ENV = 'OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED';
 const INTERVAL_CRON_ENV = 'OL_INPOST_SHIPMENT_STATUS_SYNC_INTERVAL_CRON';
@@ -66,11 +69,16 @@ export function buildInpostSchedulerTasks(): SchedulerTaskConfig[] {
       jobType: 'marketplace.shipment.statusSync',
       cronExpression,
       enabledEnvVar: SCHEDULER_ENABLED_ENV,
-      generatePayload: () => ({
-        schemaVersion: 1,
-        limit: pageLimit,
-        cursorKey: CURSOR_KEY,
-      }),
+      // `satisfies` (not a return annotation): validates the literal against the
+      // handler's payload contract at compile time while keeping the inferred type
+      // assignable to SchedulerTaskConfig.generatePayload's `Record<string, unknown>`
+      // (a named interface lacks the index signature that return type requires).
+      generatePayload: () =>
+        ({
+          schemaVersion: 1,
+          limit: pageLimit,
+          cursorKey: CURSOR_KEY,
+        }) satisfies MarketplaceShipmentStatusSyncPayloadV1,
       generateIdempotencyKey: (connection, timestamp) =>
         `marketplace:${connection.id}:shipment:status:sync:${timestamp}`,
     });

--- a/libs/integrations/inpost/src/inpost-plugin.ts
+++ b/libs/integrations/inpost/src/inpost-plugin.ts
@@ -17,6 +17,7 @@ import type { AdapterMetadata } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { createInpostShippingAdapter } from './application/inpost-adapter.factory';
 import { InpostConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/inpost-connection-config-shape-validator.adapter';
+import { buildInpostSchedulerTasks } from './infrastructure/scheduler/inpost-scheduler-tasks';
 
 /**
  * Static plugin manifest (#575). Exported as a top-level `const` so host-side
@@ -47,6 +48,14 @@ export function createInpostPlugin(): AdapterPlugin {
       );
       // No credentials-shape validator: the `{ apiToken }` shape is enforced
       // at adapter construction time by the factory (deeper than this boundary).
+
+      // #772 — schedule the carrier-generic shipment-status poll (#838) for
+      // InPost connections (webhook fallback). Drained only by the api's
+      // SchedulerService; the worker registers it too (no SchedulerService
+      // there) but never fires it.
+      for (const task of buildInpostSchedulerTasks()) {
+        host.schedulerTaskRegistry.register(task);
+      }
     },
 
     async createCapabilityAdapter<T>(


### PR DESCRIPTION
## What & why

Closes #772. **Re-scoped on claim** (see the issue thread): #772 originally asked to *build* an InPost tracking poller + a shared status-propagation service — but #838 already shipped both as the **carrier-generic** `marketplace.shipment.statusSync` poll + handler + OMP propagation. Investigation found that poll is scheduled **only for Allegro** (`allegro-scheduler-tasks.ts`, `platformType:'allegro'`), and InPost was absent from `apps/worker/src/plugins.ts` entirely. So the genuine remaining gap is just the **InPost scheduling** — this PR adds it. **No CORE change, no migration.**

## Changes

- **`libs/integrations/inpost/.../scheduler/inpost-scheduler-tasks.ts`** *(new)* — `buildInpostSchedulerTasks()` returns the `inpost-shipment-status-sync` task: `platformType:'inpost'`, the shared `marketplace.shipment.statusSync` job, cursor key `inpost.shipmentStatus.scanOffset` (disjoint from Allegro's), env-gated, **30-min default** (deliberately slower than Allegro's 15 — this is the *fallback* for when the InPost webhook (#768) isn't provisioned, not the primary path). Reads `process.env` because the plugin is constructed eagerly by `createNestAdapterModule` (rationale in the file header; #849 precedent).
- **`inpost-plugin.ts`** — `register(host)` loops the tasks into `host.schedulerTaskRegistry`.
- **`apps/worker/src/plugins.ts`** — register `InpostIntegrationModule` so the worker can resolve the InPost `ShippingProviderManager` adapter when executing the poll. (The worker runs no SchedulerService, so the task registers there but never fires — drained only by the api.)
- **`apps/worker/test/jest-integration.cjs`** — add the InPost `moduleNameMapper` pair (required by `check-jest-integration-mappers` once InPost is a worker plugin).
- **`apps/api/.env.example`** — document `OL_INPOST_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED` / `_INTERVAL_CRON` / `_PAGE_LIMIT`.

## Verified load-bearing assumption

`ShipmentStatusSyncService.sync(connectionId, …)` scans `shipments.findMany({ connectionId, statuses })`, so the poll only works if InPost shipments are keyed to the InPost connection the task enqueues for. Confirmed in `shipment-dispatch.service.ts`: the shipment is created with `connectionId = the resolved ShippingProviderManager (carrier) connection` — for InPost that's the InPost connection. Symmetric with Allegro Delivery. ✅

## Testing

- `pnpm lint` (incl. all `check:invariants` — `check-jest-integration-mappers` validates the new worker mapper), `pnpm type-check`, full `pnpm test` — all green. 10 new unit tests for the task builder (gate / scoping / payload+cursor / cron default+override / page-limit / idempotency key).
- **Integration (Docker):** `apps/worker` `job-intake-execution.int-spec` (7/7) — worker boots with InPost in the plugin graph; `apps/api` `app-boot.int-spec` (4/4) — api boots with the SchedulerService draining the new task (cron valid, registers cleanly).

## Out of scope (deferred)

Per-connection "polling fallback enabled" DB toggle (env-gate suffices for v1); any change to the #838 engine/handler/propagation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)