### PR TITLE
fix(api): declare dotenv dependency

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -48,6 +48,7 @@
     "class-transformer": "0.5.1",
     "class-validator": "0.14.1",
     "cookie-parser": "^1.4.7",
+    "dotenv": "16.6.1",
     "passport": "0.7.0",
     "passport-jwt": "4.0.1",
     "pg": "8.11.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       cookie-parser:
         specifier: ^1.4.7
         version: 1.4.7
+      dotenv:
+        specifier: 16.6.1
+        version: 16.6.1
       passport:
         specifier: 0.7.0
         version: 0.7.0


### PR DESCRIPTION
## Summary
- declare `dotenv` as a direct runtime dependency of `@openlinker/api`
- update the API importer in `pnpm-lock.yaml` so TypeORM CLI migration scripts can load `.env.local` / `.env` consistently

## Why
`apps/api/src/database/data-source.ts` directly calls `require('dotenv')` for migration CLI usage. With pnpm's strict workspace dependency resolution, `@openlinker/api` should declare that runtime dependency itself instead of relying on another package to provide it transitively.

Fixes #868.

## Verification
- `corepack pnpm@9.15.9 install --frozen-lockfile --ignore-scripts`
- `corepack --% pnpm@9.15.9 --filter @openlinker/api exec node -p "require.resolve('dotenv/package.json')"`
- `git diff --check`

Note: `corepack pnpm@9.15.9 --filter @openlinker/api type-check` currently fails on existing workspace resolution errors for `@openlinker/integrations-prestashop` and `@openlinker/plugin-sdk`; those errors are unrelated to this dependency declaration.