### PR TITLE
feat(webhooks,shipping): InPost shipment-status webhook ingestion — trigger-based (ADR-021) (#768)

### DIFF
--- a/apps/api/src/webhooks/application/decoders/default-webhook-decoder.spec.ts
+++ b/apps/api/src/webhooks/application/decoders/default-webhook-decoder.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for DefaultWebhookDecoder (#768, ADR-021).
+ *
+ * Pins the OL-module default decoder's behaviour: OL-HMAC verify + the
+ * WebhookRequestDto envelope validation that preserves the pre-ADR-021
+ * controller contract (202 valid / 401 bad-sig / 400 malformed surfaces).
+ */
+import { createHmac } from 'node:crypto';
+import { DefaultWebhookDecoder } from './default-webhook-decoder';
+
+const SECRET = 'ol-shared-secret';
+const TS = '1780000000000';
+
+function olSign(rawBody: Buffer, timestamp: string, secret: string): string {
+  const signed = Buffer.concat([Buffer.from(timestamp), Buffer.from('.'), rawBody]);
+  return `sha256=${createHmac('sha256', secret).update(signed).digest('hex')}`;
+}
+
+const validEnvelope = {
+  schemaVersion: 1,
+  eventId: 'evt-123',
+  eventType: 'order.created',
+  occurredAt: '2026-06-08T10:00:00.000Z',
+  object: { type: 'order', externalId: 'ps-42' },
+  payload: { hint: true },
+};
+
+describe('DefaultWebhookDecoder', () => {
+  let decoder: DefaultWebhookDecoder;
+
+  beforeEach(() => {
+    decoder = new DefaultWebhookDecoder();
+  });
+
+  describe('verify', () => {
+    it('accepts a correctly OL-signed payload and returns the numeric timestamp', () => {
+      const rawBody = Buffer.from(JSON.stringify(validEnvelope));
+      const result = decoder.verify({
+        rawBody,
+        secret: SECRET,
+        headers: {
+          'x-openlinker-timestamp': TS,
+          'x-openlinker-signature': olSign(rawBody, TS, SECRET),
+        },
+      });
+      expect(result.ok).toBe(true);
+      expect(result.timestampMs).toBe(Number(TS));
+    });
+
+    it('rejects a tampered signature', () => {
+      const rawBody = Buffer.from(JSON.stringify(validEnvelope));
+      const result = decoder.verify({
+        rawBody,
+        secret: SECRET,
+        headers: {
+          'x-openlinker-timestamp': TS,
+          'x-openlinker-signature': olSign(Buffer.from('other'), TS, SECRET),
+        },
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects a non-sha256= signature format', () => {
+      const rawBody = Buffer.from('{}');
+      const result = decoder.verify({
+        rawBody,
+        secret: SECRET,
+        headers: { 'x-openlinker-timestamp': TS, 'x-openlinker-signature': 'deadbeef' },
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects when headers are missing', () => {
+      expect(decoder.verify({ rawBody: Buffer.from('{}'), secret: SECRET, headers: {} }).ok).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('extractEnvelope', () => {
+    it('routes a valid OL envelope into the neutral shape', () => {
+      const result = decoder.extractEnvelope(Buffer.from(JSON.stringify(validEnvelope)), {});
+      expect(result.action).toBe('route');
+      if (result.action === 'route') {
+        expect(result.envelope).toEqual({
+          eventId: 'evt-123',
+          eventType: 'order.created',
+          occurredAt: '2026-06-08T10:00:00.000Z',
+          objectType: 'order',
+          externalId: 'ps-42',
+          payload: { hint: true },
+        });
+      }
+    });
+
+    it('rejects malformed JSON', () => {
+      expect(decoder.extractEnvelope(Buffer.from('not json'), {}).action).toBe('reject');
+    });
+
+    it('rejects an envelope failing DTO validation (missing object)', () => {
+      const bad = { schemaVersion: 1, eventId: 'e', eventType: 'order.created', occurredAt: '2026-06-08T10:00:00.000Z' };
+      expect(decoder.extractEnvelope(Buffer.from(JSON.stringify(bad)), {}).action).toBe('reject');
+    });
+
+    it('rejects an envelope with a malformed eventType', () => {
+      const bad = { ...validEnvelope, eventType: 'NOT VALID FORMAT' };
+      expect(decoder.extractEnvelope(Buffer.from(JSON.stringify(bad)), {}).action).toBe('reject');
+    });
+  });
+});

--- a/apps/api/src/webhooks/application/decoders/default-webhook-decoder.ts
+++ b/apps/api/src/webhooks/application/decoders/default-webhook-decoder.ts
@@ -14,6 +14,7 @@
  *
  * @module apps/api/src/webhooks/application/decoders
  */
+import { Injectable } from '@nestjs/common';
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { plainToInstance } from 'class-transformer';
 import { validateSync } from 'class-validator';
@@ -28,6 +29,7 @@ const TIMESTAMP_HEADER = 'x-openlinker-timestamp';
 const SIGNATURE_HEADER = 'x-openlinker-signature';
 const SIGNATURE_PREFIX = 'sha256=';
 
+@Injectable()
 export class DefaultWebhookDecoder implements InboundWebhookDecoderPort {
   verify(input: {
     rawBody: Buffer;

--- a/apps/api/src/webhooks/application/decoders/default-webhook-decoder.ts
+++ b/apps/api/src/webhooks/application/decoders/default-webhook-decoder.ts
@@ -59,8 +59,14 @@ export class DefaultWebhookDecoder implements InboundWebhookDecoderPort {
       return { ok: false };
     }
 
+    // OL timestamps are always epoch-ms numeric. A non-numeric (but
+    // validly-signed) timestamp is malformed — fail closed rather than return
+    // ok without a timestamp, which would silently skip the replay-window check.
     const timestampMs = Number.parseInt(timestamp, 10);
-    return { ok: true, timestampMs: Number.isNaN(timestampMs) ? undefined : timestampMs };
+    if (Number.isNaN(timestampMs)) {
+      return { ok: false };
+    }
+    return { ok: true, timestampMs };
   }
 
   extractEnvelope(rawBody: Buffer, _headers: Record<string, string>): DecodeResult {

--- a/apps/api/src/webhooks/application/decoders/default-webhook-decoder.ts
+++ b/apps/api/src/webhooks/application/decoders/default-webhook-decoder.ts
@@ -1,0 +1,102 @@
+/**
+ * Default Webhook Decoder (#768, ADR-021)
+ *
+ * The host's fallback `InboundWebhookDecoderPort` for providers that register
+ * no decoder of their own — i.e. OpenLinker's own modules (PrestaShop) that
+ * post the OL-enveloped, OL-HMAC-signed webhook shape. It preserves the
+ * pre-ADR-021 behaviour exactly: `verify` is the OL HMAC scheme
+ * (`sha256=<hex>` over `{X-OpenLinker-Timestamp}.{rawBody}`); `extractEnvelope`
+ * validates the body as `WebhookRequestDto` (same `class-validator` rules the
+ * controller's `ValidationPipe` applied) and maps it to the neutral envelope.
+ *
+ * Registered by the webhooks module as the provider-agnostic default; a plugin
+ * that registers a per-`provider` decoder (e.g. InPost) overrides it.
+ *
+ * @module apps/api/src/webhooks/application/decoders
+ */
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import type {
+  DecodeResult,
+  InboundWebhookDecoderPort,
+  WebhookVerifyResult,
+} from '@openlinker/core/integrations';
+import { WebhookRequestDto } from '../../http/dto/webhook-request.dto';
+
+const TIMESTAMP_HEADER = 'x-openlinker-timestamp';
+const SIGNATURE_HEADER = 'x-openlinker-signature';
+const SIGNATURE_PREFIX = 'sha256=';
+
+export class DefaultWebhookDecoder implements InboundWebhookDecoderPort {
+  verify(input: {
+    rawBody: Buffer;
+    headers: Record<string, string>;
+    secret: string;
+  }): WebhookVerifyResult {
+    const timestamp = this.header(input.headers, TIMESTAMP_HEADER);
+    const signature = this.header(input.headers, SIGNATURE_HEADER);
+    if (!timestamp || !signature || !signature.startsWith(SIGNATURE_PREFIX)) {
+      return { ok: false };
+    }
+    const providedHex = signature.slice(SIGNATURE_PREFIX.length);
+    if (!/^[0-9a-f]{64}$/i.test(providedHex)) {
+      return { ok: false };
+    }
+
+    const signedPayload = Buffer.concat([
+      Buffer.from(timestamp),
+      Buffer.from('.'),
+      input.rawBody,
+    ]);
+    const expectedHex = createHmac('sha256', input.secret).update(signedPayload).digest('hex');
+
+    const provided = Buffer.from(providedHex, 'hex');
+    const expected = Buffer.from(expectedHex, 'hex');
+    if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+      return { ok: false };
+    }
+
+    const timestampMs = Number.parseInt(timestamp, 10);
+    return { ok: true, timestampMs: Number.isNaN(timestampMs) ? undefined : timestampMs };
+  }
+
+  extractEnvelope(rawBody: Buffer, _headers: Record<string, string>): DecodeResult {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawBody.toString('utf8'));
+    } catch {
+      return { action: 'reject', reason: 'body is not valid JSON' };
+    }
+
+    const dto = plainToInstance(WebhookRequestDto, parsed);
+    const errors = validateSync(dto as object, {
+      whitelist: true,
+      forbidNonWhitelisted: false,
+    });
+    if (errors.length > 0) {
+      return {
+        action: 'reject',
+        reason: `webhook envelope failed validation: ${errors
+          .map((e) => e.property)
+          .join(', ')}`,
+      };
+    }
+
+    return {
+      action: 'route',
+      envelope: {
+        eventId: dto.eventId,
+        eventType: dto.eventType,
+        occurredAt: dto.occurredAt,
+        objectType: dto.object.type,
+        externalId: dto.object.externalId,
+        payload: dto.payload,
+      },
+    };
+  }
+
+  private header(headers: Record<string, string>, name: string): string | null {
+    return headers[name] ?? headers[name.toLowerCase()] ?? null;
+  }
+}

--- a/apps/api/src/webhooks/application/errors/webhook-decode.exception.ts
+++ b/apps/api/src/webhooks/application/errors/webhook-decode.exception.ts
@@ -1,0 +1,23 @@
+/**
+ * Webhook Decode Exception
+ *
+ * Domain exception thrown when a (signature-verified) inbound webhook body
+ * cannot be decoded into the neutral envelope — i.e. the per-provider decoder
+ * returned `reject` (malformed body / missing required fields). The controller
+ * maps it to HTTP 400. Distinct from `WebhookAuthenticationException` (401):
+ * the request was authentic but its body is unusable. A well-formed-but-not-ours
+ * event (`ignore`) is NOT an error — it returns 202 with no publish.
+ *
+ * @module apps/api/src/webhooks/application/errors
+ */
+export class WebhookDecodeException extends Error {
+  constructor(
+    message: string,
+    public readonly provider?: string,
+    public readonly connectionId?: string,
+  ) {
+    super(message);
+    this.name = 'WebhookDecodeException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/apps/api/src/webhooks/application/interfaces/webhook-auth.service.interface.ts
+++ b/apps/api/src/webhooks/application/interfaces/webhook-auth.service.interface.ts
@@ -11,37 +11,26 @@
 
 export interface IWebhookAuthService {
   /**
-   * Verify webhook signature
+   * Provider-agnostic connection gate (ADR-021): the connection must exist, be
+   * active, and its `platformType` must match the URL `provider`. The host runs
+   * this for every provider before handing off to that provider's decoder.
    *
-   * Validates the HMAC SHA256 signature of the webhook request.
-   * Signature scheme: HMAC_SHA256(secret, timestamp + '.' + rawBody)
-   *
-   * @param provider - Provider identifier (e.g., 'prestashop')
-   * @param connectionId - Connection identifier (UUID)
-   * @param timestamp - Unix timestamp in milliseconds (from X-OpenLinker-Timestamp header)
-   * @param rawBody - Raw request body bytes
-   * @param signature - Signature from X-OpenLinker-Signature header (format: sha256=<hex>)
-   * @returns Promise resolving to true if signature is valid, false otherwise
-   * @throws WebhookAuthenticationException if signature format is invalid or verification fails
+   * @throws WebhookAuthenticationException if the connection is missing/inactive
+   *   or the provider doesn't match
    */
-  verifySignature(
-    provider: string,
-    connectionId: string,
-    timestamp: string,
-    rawBody: Buffer,
-    signature: string,
-  ): Promise<boolean>;
+  assertConnectionUsable(provider: string, connectionId: string): Promise<void>;
+
+  /** Resolve the per-connection webhook shared secret (handed to the decoder). */
+  getSecret(provider: string, connectionId: string): Promise<string>;
 
   /**
-   * Validate timestamp for replay protection
+   * Replay-window check on an already-normalized epoch-ms timestamp (ADR-021).
+   * The per-provider decoder owns the provider's timestamp header/format and
+   * returns the normalized value from `verify`; the host applies the shared
+   * window here.
    *
-   * Checks if the timestamp is within the allowed skew window (default ±5 minutes).
-   *
-   * @param timestamp - Unix timestamp in milliseconds (string)
-   * @param skewWindowMs - Allowed skew window in milliseconds (default: 300000 = 5 minutes)
-   * @returns true if timestamp is valid, false otherwise
-   * @throws WebhookReplayException if timestamp is outside the allowed window
+   * @throws WebhookReplayException if the timestamp is outside the allowed window
    */
-  validateTimestamp(timestamp: string, skewWindowMs?: number): boolean;
+  validateTimestampMs(timestampMs: number, skewWindowMs?: number): void;
 }
 

--- a/apps/api/src/webhooks/application/interfaces/webhook.service.interface.ts
+++ b/apps/api/src/webhooks/application/interfaces/webhook.service.interface.ts
@@ -8,33 +8,28 @@
  * @module apps/api/src/webhooks/application/interfaces
  * @see {@link WebhookService} for the implementation
  */
-import type { WebhookRequestDto } from '../../http/dto/webhook-request.dto';
-
 export interface IWebhookService {
   /**
-   * Process an inbound webhook request
+   * Process an inbound webhook request (ADR-021)
    *
    * Orchestrates the complete webhook processing flow:
-   * 1. Validate connection exists and is active
-   * 2. Verify signature (via IWebhookAuthService)
-   * 3. Validate timestamp (replay protection)
-   * 4. Check deduplication (via IWebhookDedupService)
-   * 5. Publish event (via IWebhookEventPublisher)
-   * 6. Mark as done (via IWebhookDedupService)
+   * 1. Resolve the per-provider decoder (default = OL-HMAC + WebhookRequestDto)
+   * 2. Connection gate (exists, active, platformType matches)
+   * 3. Verify signature via the decoder; replay-check the normalized timestamp
+   * 4. Decode the body → route | ignore (202, no publish) | reject (400)
+   * 5. Dedup gate → publish event → record delivery
    *
-   * @param provider - Provider identifier (e.g., 'prestashop')
+   * @param provider - Provider identifier (e.g., 'prestashop', 'inpost')
    * @param connectionId - Connection identifier (UUID)
-   * @param request - Webhook request DTO
-   * @param rawBody - Raw request body bytes for signature verification
-   * @param headers - Request headers (including X-OpenLinker-Timestamp and X-OpenLinker-Signature)
-   * @throws WebhookAuthenticationException if signature is invalid
-   * @throws WebhookReplayException if timestamp is out of window
-   * @throws Error if connection not found or processing fails
+   * @param rawBody - Raw request body bytes (the decoder verifies + parses these)
+   * @param headers - Request headers (provider-specific signature/timestamp/topic)
+   * @throws WebhookAuthenticationException if signature/connection is invalid (401)
+   * @throws WebhookReplayException if timestamp is out of window (401)
+   * @throws WebhookDecodeException if the body can't be decoded (400)
    */
   processWebhook(
     provider: string,
     connectionId: string,
-    request: WebhookRequestDto,
     rawBody: Buffer,
     headers: Record<string, string>
   ): Promise<void>;

--- a/apps/api/src/webhooks/application/services/webhook-auth.service.spec.ts
+++ b/apps/api/src/webhooks/application/services/webhook-auth.service.spec.ts
@@ -13,7 +13,6 @@ import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
 import { CONNECTION_PORT_TOKEN, Connection } from '@openlinker/core/identifier-mapping';
 import { WebhookAuthenticationException } from '../errors/webhook-authentication.exception';
 import { WebhookReplayException } from '../errors/webhook-replay.exception';
-import * as crypto from 'crypto';
 
 describe('WebhookAuthService', () => {
   let service: WebhookAuthService;
@@ -70,73 +69,15 @@ describe('WebhookAuthService', () => {
     connectionPort.get.mockResolvedValue(mockConnection);
   });
 
-  describe('verifySignature', () => {
-    it('should verify valid signature', async () => {
-      const provider = 'prestashop';
-      const connectionId = mockConnection.id;
-      const timestamp = Date.now().toString();
-      const rawBody = Buffer.from('{"test": "data"}');
-      const signedPayload = timestamp + '.' + rawBody.toString();
-      const signature = crypto.createHmac('sha256', mockSecret).update(signedPayload).digest('hex');
-
-      const result = await service.verifySignature(
-        provider,
-        connectionId,
-        timestamp,
-        rawBody,
-        `sha256=${signature}`
-      );
-
-      expect(result).toBe(true);
-      expect(connectionPort.get).toHaveBeenCalledWith(connectionId);
-      expect(secretProvider.getSecret).toHaveBeenCalledWith(provider, connectionId);
-    });
-
-    it('should reject invalid signature', async () => {
-      const provider = 'prestashop';
-      const connectionId = mockConnection.id;
-      const timestamp = Date.now().toString();
-      const rawBody = Buffer.from('{"test": "data"}');
-      // Use a properly formatted hex string (64 chars) but wrong value
-      const invalidSignature = 'sha256=' + '0'.repeat(64);
-
-      const result = await service.verifySignature(
-        provider,
-        connectionId,
-        timestamp,
-        rawBody,
-        invalidSignature
-      );
-
-      expect(result).toBe(false);
-    });
-
-    it('should reject signature with wrong format', async () => {
-      const provider = 'prestashop';
-      const connectionId = mockConnection.id;
-      const timestamp = Date.now().toString();
-      const rawBody = Buffer.from('{"test": "data"}');
-
+  describe('assertConnectionUsable', () => {
+    it('resolves when the connection is active and the provider matches', async () => {
       await expect(
-        service.verifySignature(provider, connectionId, timestamp, rawBody, 'invalid-format')
-      ).rejects.toThrow(WebhookAuthenticationException);
+        service.assertConnectionUsable('prestashop', mockConnection.id),
+      ).resolves.toBeUndefined();
+      expect(connectionPort.get).toHaveBeenCalledWith(mockConnection.id);
     });
 
-    it('should reject if connection not found', async () => {
-      connectionPort.get.mockRejectedValue(new Error('Connection not found'));
-
-      const provider = 'prestashop';
-      const connectionId = 'non-existent';
-      const timestamp = Date.now().toString();
-      const rawBody = Buffer.from('{"test": "data"}');
-      const signature = 'sha256=test';
-
-      await expect(
-        service.verifySignature(provider, connectionId, timestamp, rawBody, signature)
-      ).rejects.toThrow();
-    });
-
-    it('should reject if connection is not active', async () => {
+    it('throws when the connection is not active', async () => {
       const disabledConnection = new Connection(
         mockConnection.id,
         mockConnection.platformType,
@@ -151,54 +92,62 @@ describe('WebhookAuthService', () => {
       );
       connectionPort.get.mockResolvedValue(disabledConnection);
 
-      const provider = 'prestashop';
-      const connectionId = mockConnection.id;
-      const timestamp = Date.now().toString();
-      const rawBody = Buffer.from('{"test": "data"}');
-      const signature = 'sha256=test';
-
       await expect(
-        service.verifySignature(provider, connectionId, timestamp, rawBody, signature)
+        service.assertConnectionUsable('prestashop', mockConnection.id),
       ).rejects.toThrow(WebhookAuthenticationException);
+    });
+
+    it('throws on provider / platformType mismatch', async () => {
+      await expect(
+        service.assertConnectionUsable('inpost', mockConnection.id),
+      ).rejects.toThrow(WebhookAuthenticationException);
+    });
+
+    it('propagates when the connection does not exist', async () => {
+      connectionPort.get.mockRejectedValue(new Error('Connection not found'));
+      await expect(
+        service.assertConnectionUsable('prestashop', 'non-existent'),
+      ).rejects.toThrow();
     });
   });
 
-  describe('validateTimestamp', () => {
-    it('should accept valid timestamp within window', () => {
-      const timestamp = Date.now().toString();
-      const result = service.validateTimestamp(timestamp);
-      expect(result).toBe(true);
+  describe('getSecret', () => {
+    it('resolves the per-connection secret from the provider', async () => {
+      await expect(service.getSecret('prestashop', mockConnection.id)).resolves.toBe(mockSecret);
+      expect(secretProvider.getSecret).toHaveBeenCalledWith('prestashop', mockConnection.id);
+    });
+  });
+
+  describe('validateTimestampMs', () => {
+    it('accepts a timestamp within the window', () => {
+      expect(() => service.validateTimestampMs(Date.now())).not.toThrow();
     });
 
-    it('should reject timestamp outside window', () => {
-      const oldTimestamp = (Date.now() - 10 * 60 * 1000).toString(); // 10 minutes ago
-      expect(() => service.validateTimestamp(oldTimestamp)).toThrow(WebhookReplayException);
+    it('rejects a timestamp outside the window', () => {
+      expect(() => service.validateTimestampMs(Date.now() - 10 * 60 * 1000)).toThrow(
+        WebhookReplayException,
+      );
     });
 
-    it('should reject invalid timestamp format', () => {
-      expect(() => service.validateTimestamp('invalid')).toThrow(WebhookReplayException);
-      expect(() => service.validateTimestamp('')).toThrow(WebhookReplayException);
-      expect(() => service.validateTimestamp('abc123')).toThrow(WebhookReplayException);
+    it('rejects a non-finite or non-positive timestamp', () => {
+      expect(() => service.validateTimestampMs(Number.NaN)).toThrow(WebhookReplayException);
+      expect(() => service.validateTimestampMs(0)).toThrow(WebhookReplayException);
+      expect(() => service.validateTimestampMs(-1)).toThrow(WebhookReplayException);
     });
 
-    it('should accept custom skew window', () => {
-      const timestamp = (Date.now() - 2 * 60 * 1000).toString(); // 2 minutes ago
-      const result = service.validateTimestamp(timestamp, 5 * 60 * 1000); // 5 minute window
-      expect(result).toBe(true);
+    it('accepts a custom skew window', () => {
+      expect(() => service.validateTimestampMs(Date.now() - 2 * 60 * 1000, 5 * 60 * 1000)).not.toThrow();
     });
 
-    // #711 — proves the default window tightened from 5 min → 120 s.
-    // A 4-minute-old timestamp would have been accepted under the old default
-    // and is rejected under the new one.
-    it('should reject a 4-minute-old timestamp under the new 120s default window (#711)', () => {
-      const oldTimestamp = (Date.now() - 4 * 60 * 1000).toString();
-      expect(() => service.validateTimestamp(oldTimestamp)).toThrow(WebhookReplayException);
+    // #711 — the default window tightened from 5 min → 120 s.
+    it('rejects a 4-minute-old timestamp under the new 120s default window (#711)', () => {
+      expect(() => service.validateTimestampMs(Date.now() - 4 * 60 * 1000)).toThrow(
+        WebhookReplayException,
+      );
     });
 
-    it('should accept a 60-second-old timestamp within the new default window (#711)', () => {
-      const recentTimestamp = (Date.now() - 60 * 1000).toString();
-      const result = service.validateTimestamp(recentTimestamp);
-      expect(result).toBe(true);
+    it('accepts a 60-second-old timestamp within the new default window (#711)', () => {
+      expect(() => service.validateTimestampMs(Date.now() - 60 * 1000)).not.toThrow();
     });
   });
 });

--- a/apps/api/src/webhooks/application/services/webhook-auth.service.ts
+++ b/apps/api/src/webhooks/application/services/webhook-auth.service.ts
@@ -1,15 +1,17 @@
 /**
  * Webhook Authentication Service
  *
- * Implements webhook signature verification and replay protection. Validates
- * HMAC SHA256 signatures and enforces timestamp-based replay protection to
- * prevent replay attacks.
+ * The host-side auth helpers for inbound webhook ingestion (ADR-021): the
+ * provider-agnostic connection gate (`assertConnectionUsable`), per-connection
+ * secret resolution (`getSecret`), and the shared replay-window check
+ * (`validateTimestampMs`). Signature verification itself lives in each
+ * provider's `InboundWebhookDecoderPort` (the OL-HMAC default in
+ * `DefaultWebhookDecoder`), which this service feeds the secret.
  *
  * @module apps/api/src/webhooks/application/services
  * @implements {IWebhookAuthService}
  */
 import { Injectable, Inject } from '@nestjs/common';
-import { createHmac, timingSafeEqual } from 'crypto';
 import { WebhookSecretProviderPort } from '@openlinker/core/integrations';
 import { WEBHOOK_SECRET_PROVIDER_TOKEN } from '@openlinker/core/integrations';
 import { ConnectionPort } from '@openlinker/core/identifier-mapping';
@@ -75,9 +77,9 @@ export class WebhookAuthService implements IWebhookAuthService {
 
   /**
    * Provider-agnostic connection gate (ADR-021): the connection must exist, be
-   * active, and its `platformType` must match the URL `provider`. Extracted out
-   * of `verifySignature` so the host runs it for every provider before handing
-   * off to that provider's decoder. Throws `WebhookAuthenticationException`.
+   * active, and its `platformType` must match the URL `provider`. The host runs
+   * it for every provider before handing off to that provider's decoder
+   * (which owns signature verification). Throws `WebhookAuthenticationException`.
    */
   async assertConnectionUsable(provider: string, connectionId: string): Promise<void> {
     const connection = await this.connectionPort.get(connectionId);
@@ -100,102 +102,6 @@ export class WebhookAuthService implements IWebhookAuthService {
   /** Resolve the per-connection webhook shared secret (handed to the decoder). */
   async getSecret(provider: string, connectionId: string): Promise<string> {
     return this.secretProvider.getSecret(provider, connectionId);
-  }
-
-  async verifySignature(
-    provider: string,
-    connectionId: string,
-    timestamp: string,
-    rawBody: Buffer,
-    signature: string
-  ): Promise<boolean> {
-    try {
-      // Validate signature format: sha256=<hex>
-      if (!signature.startsWith('sha256=')) {
-        throw new WebhookAuthenticationException(
-          `Invalid signature format. Expected 'sha256=<hex>', got: ${signature.substring(0, 20)}...`,
-          provider,
-          connectionId
-        );
-      }
-
-      const signatureHex = signature.substring(7); // Remove 'sha256=' prefix
-
-      // Validate hex format
-      if (!/^[0-9a-f]{64}$/i.test(signatureHex)) {
-        throw new WebhookAuthenticationException(
-          'Invalid signature format. Expected 64-character hex string',
-          provider,
-          connectionId
-        );
-      }
-
-      // Validate connection exists, is active, and matches the provider.
-      await this.assertConnectionUsable(provider, connectionId);
-
-      // Get webhook secret
-      const secret = await this.secretProvider.getSecret(provider, connectionId);
-
-      // Build signed payload: timestamp + '.' + rawBody
-      const signedPayload = Buffer.concat([Buffer.from(timestamp), Buffer.from('.'), rawBody]);
-
-      // Compute expected signature
-      const hmac = createHmac('sha256', secret);
-      hmac.update(signedPayload);
-      const expectedSignature = hmac.digest('hex');
-
-      // Constant-time comparison to prevent timing attacks
-      const providedSignatureBuffer = Buffer.from(signatureHex, 'hex');
-      const expectedSignatureBuffer = Buffer.from(expectedSignature, 'hex');
-
-      // Ensure buffers are same length (should always be 32 bytes for SHA256)
-      if (providedSignatureBuffer.length !== expectedSignatureBuffer.length) {
-        this.logger.warn(`Signature length mismatch for ${provider}:${connectionId}`);
-        return false;
-      }
-
-      const isValid = timingSafeEqual(providedSignatureBuffer, expectedSignatureBuffer);
-
-      if (!isValid) {
-        this.logger.warn(`Invalid signature for webhook ${provider}:${connectionId}`);
-      }
-
-      return isValid;
-    } catch (error) {
-      if (error instanceof WebhookAuthenticationException) {
-        throw error;
-      }
-
-      this.logger.error(
-        `Signature verification error for ${provider}:${connectionId}`,
-        error instanceof Error ? error.stack : String(error)
-      );
-
-      throw new WebhookAuthenticationException(
-        `Signature verification failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        provider,
-        connectionId
-      );
-    }
-  }
-
-  validateTimestamp(
-    timestamp: string,
-    skewWindowMs: number = this.DEFAULT_SKEW_WINDOW_MS
-  ): boolean {
-    // Validate timestamp format (should be numeric string), then delegate the
-    // window check to the normalized-ms path so both the OL-string and the
-    // per-provider epoch-ms callers share one replay rule (ADR-021).
-    const timestampNum = Number.parseInt(timestamp, 10);
-    if (Number.isNaN(timestampNum) || timestampNum <= 0) {
-      throw new WebhookReplayException(
-        `Invalid timestamp format: ${timestamp}`,
-        timestamp,
-        skewWindowMs
-      );
-    }
-    this.validateTimestampMs(timestampNum, skewWindowMs);
-    return true;
   }
 
   /**

--- a/apps/api/src/webhooks/application/services/webhook-auth.service.ts
+++ b/apps/api/src/webhooks/application/services/webhook-auth.service.ts
@@ -73,6 +73,35 @@ export class WebhookAuthService implements IWebhookAuthService {
     );
   }
 
+  /**
+   * Provider-agnostic connection gate (ADR-021): the connection must exist, be
+   * active, and its `platformType` must match the URL `provider`. Extracted out
+   * of `verifySignature` so the host runs it for every provider before handing
+   * off to that provider's decoder. Throws `WebhookAuthenticationException`.
+   */
+  async assertConnectionUsable(provider: string, connectionId: string): Promise<void> {
+    const connection = await this.connectionPort.get(connectionId);
+    if (connection.status !== 'active') {
+      throw new WebhookAuthenticationException(
+        `Connection ${connectionId} is not active (status: ${connection.status})`,
+        provider,
+        connectionId
+      );
+    }
+    if (connection.platformType !== provider) {
+      throw new WebhookAuthenticationException(
+        `Provider mismatch: expected ${connection.platformType}, got ${provider}`,
+        provider,
+        connectionId
+      );
+    }
+  }
+
+  /** Resolve the per-connection webhook shared secret (handed to the decoder). */
+  async getSecret(provider: string, connectionId: string): Promise<string> {
+    return this.secretProvider.getSecret(provider, connectionId);
+  }
+
   async verifySignature(
     provider: string,
     connectionId: string,
@@ -101,24 +130,8 @@ export class WebhookAuthService implements IWebhookAuthService {
         );
       }
 
-      // Validate connection exists and is active (fail fast before HMAC)
-      const connection = await this.connectionPort.get(connectionId);
-      if (connection.status !== 'active') {
-        throw new WebhookAuthenticationException(
-          `Connection ${connectionId} is not active (status: ${connection.status})`,
-          provider,
-          connectionId
-        );
-      }
-
-      // Validate provider matches connection platformType
-      if (connection.platformType !== provider) {
-        throw new WebhookAuthenticationException(
-          `Provider mismatch: expected ${connection.platformType}, got ${provider}`,
-          provider,
-          connectionId
-        );
-      }
+      // Validate connection exists, is active, and matches the provider.
+      await this.assertConnectionUsable(provider, connectionId);
 
       // Get webhook secret
       const secret = await this.secretProvider.getSecret(provider, connectionId);
@@ -170,42 +183,43 @@ export class WebhookAuthService implements IWebhookAuthService {
     timestamp: string,
     skewWindowMs: number = this.DEFAULT_SKEW_WINDOW_MS
   ): boolean {
-    try {
-      // Validate timestamp format (should be numeric string)
-      const timestampNum = Number.parseInt(timestamp, 10);
-      if (Number.isNaN(timestampNum) || timestampNum <= 0) {
-        throw new WebhookReplayException(
-          `Invalid timestamp format: ${timestamp}`,
-          timestamp,
-          skewWindowMs
-        );
-      }
-
-      // Get current time
-      const now = Date.now();
-      const timestampMs = timestampNum;
-
-      // Calculate time difference
-      const timeDiff = Math.abs(now - timestampMs);
-
-      // Check if within skew window
-      if (timeDiff > skewWindowMs) {
-        throw new WebhookReplayException(
-          `Timestamp outside allowed window. Difference: ${timeDiff}ms, allowed: ±${skewWindowMs}ms`,
-          timestamp,
-          skewWindowMs
-        );
-      }
-
-      return true;
-    } catch (error) {
-      if (error instanceof WebhookReplayException) {
-        throw error;
-      }
-
+    // Validate timestamp format (should be numeric string), then delegate the
+    // window check to the normalized-ms path so both the OL-string and the
+    // per-provider epoch-ms callers share one replay rule (ADR-021).
+    const timestampNum = Number.parseInt(timestamp, 10);
+    if (Number.isNaN(timestampNum) || timestampNum <= 0) {
       throw new WebhookReplayException(
-        `Timestamp validation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `Invalid timestamp format: ${timestamp}`,
         timestamp,
+        skewWindowMs
+      );
+    }
+    this.validateTimestampMs(timestampNum, skewWindowMs);
+    return true;
+  }
+
+  /**
+   * Replay-window check on an already-normalized epoch-ms timestamp (ADR-021).
+   * The per-provider decoder returns this from `verify` (it owns the provider's
+   * timestamp header/format); the host applies the shared window here. Throws
+   * `WebhookReplayException` when outside the window.
+   */
+  validateTimestampMs(
+    timestampMs: number,
+    skewWindowMs: number = this.DEFAULT_SKEW_WINDOW_MS
+  ): void {
+    if (!Number.isFinite(timestampMs) || timestampMs <= 0) {
+      throw new WebhookReplayException(
+        `Invalid timestamp: ${timestampMs}`,
+        String(timestampMs),
+        skewWindowMs
+      );
+    }
+    const timeDiff = Math.abs(Date.now() - timestampMs);
+    if (timeDiff > skewWindowMs) {
+      throw new WebhookReplayException(
+        `Timestamp outside allowed window. Difference: ${timeDiff}ms, allowed: ±${skewWindowMs}ms`,
+        String(timestampMs),
         skewWindowMs
       );
     }

--- a/apps/api/src/webhooks/application/services/webhook.service.spec.ts
+++ b/apps/api/src/webhooks/application/services/webhook.service.spec.ts
@@ -1,36 +1,48 @@
 /**
  * Webhook Service Unit Tests
  *
- * Focused coverage for the dedup-gate + failure-recovery branches added in
- * #711. Integration coverage of the full happy path lives in
- * `apps/api/test/integration/webhook-ingestion.int-spec.ts`.
+ * Covers the ADR-021 decoder-dispatch flow (verify → replay → extract →
+ * dedup/publish), the three-state decode (route / ignore / reject), and the
+ * #711 dedup-gate + failure-recovery branches. Integration coverage of the
+ * full happy path lives in `apps/api/test/integration/webhook-ingestion.int-spec.ts`.
  *
  * @module apps/api/src/webhooks/application/services
  */
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { WebhookService } from './webhook.service';
-import { WebhookAuthService } from './webhook-auth.service';
-import { WebhookDedupService } from './webhook-dedup.service';
-import { WebhookEventPublisher } from './webhook-event-publisher.service';
+import type {
+  DecodeResult,
+  InboundWebhookDecoderPort,
+  InboundWebhookDecoderRegistryService,
+} from '@openlinker/core/integrations';
+import { INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN } from '@openlinker/core/integrations';
 import type {
   WebhookDeliveryRepositoryPort,
   WebhookDelivery,
   WebhookDeliveryUpsertInput,
 } from '@openlinker/core/webhooks';
 import { WEBHOOK_DELIVERY_REPOSITORY_TOKEN } from '@openlinker/core/webhooks';
-import type { WebhookRequestDto } from '../../http/dto/webhook-request.dto';
+import { WebhookService } from './webhook.service';
+import { WebhookAuthService } from './webhook-auth.service';
+import { WebhookDedupService } from './webhook-dedup.service';
+import { WebhookEventPublisher } from './webhook-event-publisher.service';
+import { DefaultWebhookDecoder } from '../decoders/default-webhook-decoder';
 import { WebhookReplayException } from '../errors/webhook-replay.exception';
+import { WebhookAuthenticationException } from '../errors/webhook-authentication.exception';
+import { WebhookDecodeException } from '../errors/webhook-decode.exception';
 
-function makeRequest(eventId: string): WebhookRequestDto {
+function routeResult(eventId: string): DecodeResult {
   return {
-    schemaVersion: 1,
-    eventId,
-    eventType: 'product.saved',
-    occurredAt: new Date().toISOString(),
-    object: { type: 'product', externalId: '12345' },
-    payload: { name: 'Test' },
-  } as WebhookRequestDto;
+    action: 'route',
+    envelope: {
+      eventId,
+      eventType: 'product.saved',
+      occurredAt: '2026-06-08T10:00:00.000Z',
+      objectType: 'product',
+      externalId: '12345',
+      payload: { name: 'Test' },
+    },
+  };
 }
 
 function makeDelivery(input: WebhookDeliveryUpsertInput): WebhookDelivery {
@@ -57,9 +69,13 @@ function makeDelivery(input: WebhookDeliveryUpsertInput): WebhookDelivery {
   } as WebhookDelivery;
 }
 
-describe('WebhookService (#711 dedup + failure-recovery branches)', () => {
+describe('WebhookService (ADR-021 decoder dispatch + #711 dedup/recovery)', () => {
   let service: WebhookService;
-  let authService: jest.Mocked<Pick<WebhookAuthService, 'validateTimestamp' | 'verifySignature'>>;
+  let authService: jest.Mocked<
+    Pick<WebhookAuthService, 'assertConnectionUsable' | 'getSecret' | 'validateTimestampMs'>
+  >;
+  let decoder: jest.Mocked<InboundWebhookDecoderPort>;
+  let decoderRegistry: jest.Mocked<Pick<InboundWebhookDecoderRegistryService, 'get'>>;
   let dedupService: jest.Mocked<
     Pick<WebhookDedupService, 'markProcessing' | 'markDone' | 'clearProcessing'>
   >;
@@ -76,21 +92,28 @@ describe('WebhookService (#711 dedup + failure-recovery branches)', () => {
 
   beforeEach(async () => {
     authService = {
-      validateTimestamp: jest.fn().mockReturnValue(true),
-      verifySignature: jest.fn().mockResolvedValue(true),
+      assertConnectionUsable: jest.fn().mockResolvedValue(undefined),
+      getSecret: jest.fn().mockResolvedValue('secret'),
+      validateTimestampMs: jest.fn(),
     };
+    decoder = {
+      verify: jest.fn().mockReturnValue({ ok: true, timestampMs: Date.now() }),
+      extractEnvelope: jest.fn().mockReturnValue(routeResult('e1')),
+    };
+    // Registry returns undefined → the host falls back to the default decoder.
+    decoderRegistry = { get: jest.fn().mockReturnValue(undefined) };
     dedupService = {
       markProcessing: jest.fn().mockResolvedValue(true),
       markDone: jest.fn().mockResolvedValue(undefined),
       clearProcessing: jest.fn().mockResolvedValue(undefined),
     };
-    eventPublisher = {
-      publishInboundWebhook: jest.fn().mockResolvedValue('msg_1'),
-    };
+    eventPublisher = { publishInboundWebhook: jest.fn().mockResolvedValue('msg_1') };
     deliveryRepository = {
-      upsert: jest.fn().mockImplementation((input: WebhookDeliveryUpsertInput) =>
-        Promise.resolve(makeDelivery(input))
-      ),
+      upsert: jest
+        .fn()
+        .mockImplementation((input: WebhookDeliveryUpsertInput) =>
+          Promise.resolve(makeDelivery(input)),
+        ),
       insertIfNew: jest.fn(),
       deleteByEventKey: jest.fn().mockResolvedValue(undefined),
       findById: jest.fn(),
@@ -101,6 +124,8 @@ describe('WebhookService (#711 dedup + failure-recovery branches)', () => {
       providers: [
         WebhookService,
         { provide: WebhookAuthService, useValue: authService },
+        { provide: DefaultWebhookDecoder, useValue: decoder },
+        { provide: INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN, useValue: decoderRegistry },
         { provide: WebhookDedupService, useValue: dedupService },
         { provide: WebhookEventPublisher, useValue: eventPublisher },
         { provide: WEBHOOK_DELIVERY_REPOSITORY_TOKEN, useValue: deliveryRepository },
@@ -109,28 +134,51 @@ describe('WebhookService (#711 dedup + failure-recovery branches)', () => {
     service = module.get(WebhookService);
   });
 
-  describe('Postgres dedup gate', () => {
-    it('publishes the event when insertIfNew reports isNew=true', async () => {
+  describe('decoder dispatch + three-state decode', () => {
+    it('publishes a routed event when the decoder verifies + routes and the row is new', async () => {
       deliveryRepository.insertIfNew.mockResolvedValue({
         isNew: true,
         delivery: makeDelivery({ eventId: 'e1', provider, connectionId }),
       });
 
-      await service.processWebhook(provider, connectionId, makeRequest('e1'), rawBody, headers);
+      await service.processWebhook(provider, connectionId, rawBody, headers);
 
+      expect(authService.assertConnectionUsable).toHaveBeenCalledWith(provider, connectionId);
+      expect(decoder.verify).toHaveBeenCalled();
       expect(eventPublisher.publishInboundWebhook).toHaveBeenCalledTimes(1);
       expect(deliveryRepository.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({ status: 'published' })
+        expect.objectContaining({ status: 'published', externalId: '12345' }),
       );
     });
 
+    it('ignores (202, no publish, no row) when the decoder returns ignore', async () => {
+      decoder.extractEnvelope.mockReturnValue({ action: 'ignore', reason: 'unhandled topic' });
+
+      await service.processWebhook(provider, connectionId, rawBody, headers);
+
+      expect(deliveryRepository.insertIfNew).not.toHaveBeenCalled();
+      expect(eventPublisher.publishInboundWebhook).not.toHaveBeenCalled();
+    });
+
+    it('throws WebhookDecodeException (→400) and inserts no row when the decoder rejects', async () => {
+      decoder.extractEnvelope.mockReturnValue({ action: 'reject', reason: 'malformed' });
+
+      await expect(
+        service.processWebhook(provider, connectionId, rawBody, headers),
+      ).rejects.toThrow(WebhookDecodeException);
+
+      expect(deliveryRepository.insertIfNew).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Postgres dedup gate', () => {
     it('short-circuits with no publish when insertIfNew reports isNew=false (replay)', async () => {
       deliveryRepository.insertIfNew.mockResolvedValue({
         isNew: false,
-        existing: makeDelivery({ eventId: 'e2', provider, connectionId }),
+        existing: makeDelivery({ eventId: 'e1', provider, connectionId }),
       });
 
-      await service.processWebhook(provider, connectionId, makeRequest('e2'), rawBody, headers);
+      await service.processWebhook(provider, connectionId, rawBody, headers);
 
       expect(eventPublisher.publishInboundWebhook).not.toHaveBeenCalled();
       expect(dedupService.markProcessing).not.toHaveBeenCalled();
@@ -142,43 +190,42 @@ describe('WebhookService (#711 dedup + failure-recovery branches)', () => {
     it('DELETEs the webhook_deliveries row when publish fails, so source can retry', async () => {
       deliveryRepository.insertIfNew.mockResolvedValue({
         isNew: true,
-        delivery: makeDelivery({ eventId: 'e3', provider, connectionId }),
+        delivery: makeDelivery({ eventId: 'e1', provider, connectionId }),
       });
       eventPublisher.publishInboundWebhook.mockRejectedValueOnce(new Error('stream down'));
 
       await expect(
-        service.processWebhook(provider, connectionId, makeRequest('e3'), rawBody, headers)
+        service.processWebhook(provider, connectionId, rawBody, headers),
       ).rejects.toThrow('stream down');
 
-      // The failure-recovery semantics: row deleted, Redis cleared, error rethrown.
-      expect(deliveryRepository.deleteByEventKey).toHaveBeenCalledWith(provider, connectionId, 'e3');
-      expect(dedupService.clearProcessing).toHaveBeenCalledWith(provider, connectionId, 'e3');
+      expect(deliveryRepository.deleteByEventKey).toHaveBeenCalledWith(provider, connectionId, 'e1');
+      expect(dedupService.clearProcessing).toHaveBeenCalledWith(provider, connectionId, 'e1');
     });
   });
 
-  describe('validation rejection (no row inserted)', () => {
-    it('does not insert a row when timestamp is stale', async () => {
-      authService.validateTimestamp.mockImplementation(() => {
-        throw new WebhookReplayException('stale', headers['x-openlinker-timestamp'], 120_000);
+  describe('verify/replay rejection (no row inserted)', () => {
+    it('does not insert a row when the signature fails to verify (401)', async () => {
+      decoder.verify.mockReturnValue({ ok: false });
+
+      await expect(
+        service.processWebhook(provider, connectionId, rawBody, headers),
+      ).rejects.toThrow(WebhookAuthenticationException);
+
+      expect(decoder.extractEnvelope).not.toHaveBeenCalled();
+      expect(deliveryRepository.insertIfNew).not.toHaveBeenCalled();
+    });
+
+    it('does not insert a row when the timestamp is outside the replay window', async () => {
+      authService.validateTimestampMs.mockImplementation(() => {
+        throw new WebhookReplayException('stale', '0', 120_000);
       });
 
       await expect(
-        service.processWebhook(provider, connectionId, makeRequest('e4'), rawBody, headers)
+        service.processWebhook(provider, connectionId, rawBody, headers),
       ).rejects.toThrow(WebhookReplayException);
 
+      expect(decoder.extractEnvelope).not.toHaveBeenCalled();
       expect(deliveryRepository.insertIfNew).not.toHaveBeenCalled();
-      expect(deliveryRepository.upsert).not.toHaveBeenCalled();
-    });
-
-    it('does not insert a row when signature is invalid', async () => {
-      authService.verifySignature.mockResolvedValue(false);
-
-      await expect(
-        service.processWebhook(provider, connectionId, makeRequest('e5'), rawBody, headers)
-      ).rejects.toThrow('Invalid webhook signature');
-
-      expect(deliveryRepository.insertIfNew).not.toHaveBeenCalled();
-      expect(deliveryRepository.upsert).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/webhooks/application/services/webhook.service.ts
+++ b/apps/api/src/webhooks/application/services/webhook.service.ts
@@ -13,8 +13,14 @@ import type { IWebhookService } from '../interfaces/webhook.service.interface';
 import { WebhookAuthService } from './webhook-auth.service';
 import { WebhookDedupService } from './webhook-dedup.service';
 import { WebhookEventPublisher } from './webhook-event-publisher.service';
+import { DefaultWebhookDecoder } from '../decoders/default-webhook-decoder';
+import { WebhookAuthenticationException } from '../errors/webhook-authentication.exception';
+import { WebhookDecodeException } from '../errors/webhook-decode.exception';
 import type { InboundWebhookEvent } from '@openlinker/core/events';
-import type { WebhookRequestDto } from '../../http/dto/webhook-request.dto';
+import {
+  InboundWebhookDecoderRegistryService,
+  INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
+} from '@openlinker/core/integrations';
 import { Logger } from '@openlinker/shared/logging';
 import type { WebhookDeliveryUpsertInput } from '@openlinker/core/webhooks';
 import {
@@ -30,6 +36,9 @@ export class WebhookService implements IWebhookService {
     private readonly authService: WebhookAuthService,
     private readonly dedupService: WebhookDedupService,
     private readonly eventPublisher: WebhookEventPublisher,
+    private readonly defaultDecoder: DefaultWebhookDecoder,
+    @Inject(INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN)
+    private readonly decoderRegistry: InboundWebhookDecoderRegistryService,
     @Inject(WEBHOOK_DELIVERY_REPOSITORY_TOKEN)
     private readonly deliveryRepository: WebhookDeliveryRepositoryPort
   ) {}
@@ -47,77 +56,73 @@ export class WebhookService implements IWebhookService {
   async processWebhook(
     provider: string,
     connectionId: string,
-    request: WebhookRequestDto,
     rawBody: Buffer,
     headers: Record<string, string>
   ): Promise<void> {
-    const correlationId = request.eventId; // Use eventId as correlation ID
+    // Resolve the provider's decoder (ADR-021); fall back to the host's
+    // OL-HMAC + WebhookRequestDto default for OL-module providers.
+    const decoder = this.decoderRegistry.get(provider) ?? this.defaultDecoder;
+
+    // Connection gate (provider-agnostic): exists, active, platformType matches.
+    await this.authService.assertConnectionUsable(provider, connectionId);
+
+    // Verify the signature via the decoder (host supplies the per-connection
+    // secret). Then replay-check the decoder-normalized timestamp. Order is
+    // verify → replay because a third-party timestamp is only trusted once the
+    // signature over it is verified. Both failures short-circuit BEFORE any row
+    // is inserted (a `status='rejected'` row would block legitimate retries via
+    // the unique constraint, #711).
+    const secret = await this.authService.getSecret(provider, connectionId);
+    const verifyResult = decoder.verify({ rawBody, headers, secret });
+    if (!verifyResult.ok) {
+      this.logger.warn(
+        `Invalid webhook signature: provider=${provider}, connectionId=${connectionId}`
+      );
+      throw new WebhookAuthenticationException('Invalid webhook signature', provider, connectionId);
+    }
+    if (verifyResult.timestampMs !== undefined) {
+      // Throws WebhookReplayException which the controller maps to 401.
+      this.authService.validateTimestampMs(verifyResult.timestampMs);
+    }
+
+    // Decode the (verified) body into the neutral envelope.
+    const decoded = decoder.extractEnvelope(rawBody, headers);
+    if (decoded.action === 'reject') {
+      this.logger.warn(
+        `Webhook body rejected: provider=${provider}, connectionId=${connectionId}: ${decoded.reason}`
+      );
+      throw new WebhookDecodeException(decoded.reason, provider, connectionId);
+    }
+    if (decoded.action === 'ignore') {
+      // Well-formed but not ours (unhandled topic / setup ping) — 202, no
+      // publish. Distinct from reject so benign third-party noise doesn't
+      // trigger source-side retry storms (ADR-021).
+      this.logger.debug(
+        `Webhook ignored (no publish): provider=${provider}, connectionId=${connectionId}: ${decoded.reason}`
+      );
+      return;
+    }
+
+    const envelope = decoded.envelope;
+    const correlationId = envelope.eventId;
 
     this.logger.log(
-      `Processing webhook: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}, eventType=${request.eventType}`
+      `Processing webhook: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}, eventType=${envelope.eventType}`
     );
 
-    const timestamp = headers['x-openlinker-timestamp'] || headers['X-OpenLinker-Timestamp'];
-    const signature = headers['x-openlinker-signature'] || headers['X-OpenLinker-Signature'];
-
-    // Validation steps below short-circuit BEFORE any row is inserted. Failed
-    // validation lives in logs (Logger.warn) — see plan §4.4 for why we don't
-    // record `status='rejected'` rows: under the new Postgres-authoritative
-    // dedup model (#711), such rows would block legitimate source-side retries
-    // of the same eventId via the unique constraint.
-
-    if (!timestamp) {
-      this.logger.warn(
-        `Missing X-OpenLinker-Timestamp header: provider=${provider}, connectionId=${connectionId}`
-      );
-      throw new Error('Missing X-OpenLinker-Timestamp header');
-    }
-
-    if (!signature) {
-      this.logger.warn(
-        `Missing X-OpenLinker-Signature header: provider=${provider}, connectionId=${connectionId}`
-      );
-      throw new Error('Missing X-OpenLinker-Signature header');
-    }
-
-    // Step 1: Validate timestamp (replay protection) - fail fast before HMAC.
-    // Throws WebhookReplayException which the controller maps to 401.
-    this.authService.validateTimestamp(timestamp);
-
-    // Step 2: Verify signature.
-    const isValid = await this.authService.verifySignature(
-      provider,
-      connectionId,
-      timestamp,
-      rawBody,
-      signature
-    );
-
-    if (!isValid) {
-      this.logger.error(
-        `Invalid webhook signature: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}`
-      );
-      throw new Error('Invalid webhook signature');
-    }
-
-    this.logger.debug(
-      `Signature verified: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}`
-    );
-
-    // Step 3: Authoritative dedup gate (#711). INSERT ... ON CONFLICT DO
-    // NOTHING against `webhook_deliveries`'s unique constraint on
-    // `(provider, connectionId, eventId)`. A replay finds the existing row
-    // and short-circuits to a 202 idempotent ack — durable, survives Redis
-    // outages, the durable counterpart to Redis-only dedup.
+    // Authoritative dedup gate (#711). INSERT ... ON CONFLICT DO NOTHING against
+    // `webhook_deliveries`'s unique constraint on `(provider, connectionId,
+    // eventId)`. A replay finds the existing row and short-circuits to a 202
+    // idempotent ack — durable, survives Redis outages.
     const baseDelivery: WebhookDeliveryUpsertInput = {
-      eventId: request.eventId,
+      eventId: envelope.eventId,
       provider,
       connectionId,
-      eventType: request.eventType ?? null,
-      objectType: request.object?.type ?? null,
-      externalId: request.object?.externalId ?? null,
+      eventType: envelope.eventType ?? null,
+      objectType: envelope.objectType ?? null,
+      externalId: envelope.externalId ?? null,
       receivedAt: new Date(),
-      payload: request.payload as Record<string, unknown>,
+      payload: envelope.payload as Record<string, unknown>,
       signatureValid: true,
       status: 'received',
     };
@@ -136,7 +141,7 @@ export class WebhookService implements IWebhookService {
     const isNewInRedis = await this.dedupService.markProcessing(
       provider,
       connectionId,
-      request.eventId
+      envelope.eventId
     );
 
     if (!isNewInRedis) {
@@ -150,17 +155,18 @@ export class WebhookService implements IWebhookService {
     }
 
     try {
-      // Step 5: Build and publish the inbound webhook event.
+      // Build and publish the inbound webhook event from the neutral envelope;
+      // the host owns provider / connectionId / receivedAt.
       const event: InboundWebhookEvent = {
-        eventId: request.eventId,
+        eventId: envelope.eventId,
         provider,
         connectionId,
-        eventType: request.eventType,
-        occurredAt: request.occurredAt,
+        eventType: envelope.eventType,
+        occurredAt: envelope.occurredAt,
         receivedAt: new Date().toISOString(),
-        objectType: request.object.type,
-        externalId: request.object.externalId,
-        payload: request.payload,
+        objectType: envelope.objectType,
+        externalId: envelope.externalId,
+        payload: envelope.payload,
       };
 
       const messageId = await this.eventPublisher.publishInboundWebhook(event);
@@ -178,7 +184,7 @@ export class WebhookService implements IWebhookService {
       // Step 6: Mark Redis-side dedup as done (non-fatal if it fails — the
       // Postgres row's status='published' is the durable signal).
       try {
-        await this.dedupService.markDone(provider, connectionId, request.eventId);
+        await this.dedupService.markDone(provider, connectionId, envelope.eventId);
       } catch (markDoneError) {
         this.logger.warn(
           `Failed to mark webhook as done (non-fatal): provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}`,
@@ -191,7 +197,7 @@ export class WebhookService implements IWebhookService {
       // drafts of this PR got wrong: leaving the row in place would block all
       // future retries via the unique constraint.
       try {
-        await this.deliveryRepository.deleteByEventKey(provider, connectionId, request.eventId);
+        await this.deliveryRepository.deleteByEventKey(provider, connectionId, envelope.eventId);
       } catch (deleteError) {
         this.logger.error(
           `Failed to delete webhook_deliveries row after publish failure: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}`,
@@ -199,7 +205,7 @@ export class WebhookService implements IWebhookService {
         );
       }
       try {
-        await this.dedupService.clearProcessing(provider, connectionId, request.eventId);
+        await this.dedupService.clearProcessing(provider, connectionId, envelope.eventId);
       } catch (clearError) {
         this.logger.error(
           `Failed to clear Redis processing marker: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}`,

--- a/apps/api/src/webhooks/http/webhook.controller.ts
+++ b/apps/api/src/webhooks/http/webhook.controller.ts
@@ -45,8 +45,18 @@ export class WebhookController {
   @ApiOperation({ summary: 'Receive inbound webhook from external system' })
   @ApiParam({ name: 'provider', description: 'Provider identifier (e.g., "prestashop")', example: 'prestashop' })
   @ApiParam({ name: 'connectionId', description: 'Connection identifier (UUID)', example: '123e4567-e89b-12d3-a456-426614174000' })
-  @ApiHeader({ name: 'X-OpenLinker-Timestamp', description: 'Unix timestamp in milliseconds', required: true })
-  @ApiHeader({ name: 'X-OpenLinker-Signature', description: 'HMAC SHA256 signature (format: sha256=<hex>)', required: true })
+  @ApiHeader({
+    name: 'X-OpenLinker-Timestamp',
+    description:
+      'Provider-specific signature timestamp. OL-module providers (e.g. PrestaShop) send Unix ms here; third-party providers use their own header (e.g. InPost `x-inpost-timestamp`). The connection\'s registered decoder reads the right one (ADR-021).',
+    required: false,
+  })
+  @ApiHeader({
+    name: 'X-OpenLinker-Signature',
+    description:
+      'Provider-specific webhook signature. OL-module providers send `sha256=<hex>`; third-party providers use their own scheme + header (e.g. InPost `x-inpost-signature`, base64 HMAC). Resolved per-provider by the registered decoder.',
+    required: false,
+  })
   @ApiResponse({ status: 202, description: 'Webhook accepted and queued for processing' })
   @ApiResponse({ status: 400, description: 'Invalid request payload or malformed data' })
   @ApiResponse({ status: 401, description: 'Invalid signature or timestamp out of window' })

--- a/apps/api/src/webhooks/http/webhook.controller.ts
+++ b/apps/api/src/webhooks/http/webhook.controller.ts
@@ -11,7 +11,6 @@ import {
   Controller,
   Post,
   Param,
-  Body,
   Headers,
   Req,
   HttpCode,
@@ -23,11 +22,11 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiHeader } from '@nestjs/swagger';
 import { Public } from '../../auth/decorators/public.decorator';
-import { WebhookRequestDto } from './dto/webhook-request.dto';
 import { WebhookService } from '../application/services/webhook.service';
 import { RequestWithRawBody } from './middleware/raw-body.middleware';
 import { WebhookAuthenticationException } from '../application/errors/webhook-authentication.exception';
 import { WebhookReplayException } from '../application/errors/webhook-replay.exception';
+import { WebhookDecodeException } from '../application/errors/webhook-decode.exception';
 import { Logger } from '@openlinker/shared/logging';
 
 @Public()
@@ -56,10 +55,13 @@ export class WebhookController {
   async receiveWebhook(
     @Param('provider') provider: string,
     @Param('connectionId') connectionId: string,
-    @Body() request: WebhookRequestDto,
     @Headers() headers: Record<string, string>,
     @Req() req: RequestWithRawBody,
   ): Promise<void> {
+    // No `@Body() WebhookRequestDto` — the body shape is the provider's, not
+    // OL's (ADR-021). The per-provider decoder (resolved in WebhookService)
+    // verifies + parses the raw bytes; the host OL-module default decoder still
+    // validates the WebhookRequestDto envelope for OL-enveloped providers.
     // Get raw body from request (set by express.json() verify hook in main.ts)
     const rawBody = req.rawBody;
 
@@ -88,15 +90,18 @@ export class WebhookController {
     }
 
     try {
-      await this.webhookService.processWebhook(
-        provider,
-        connectionId,
-        request,
-        rawBody,
-        headers,
-      );
+      await this.webhookService.processWebhook(provider, connectionId, rawBody, headers);
     } catch (error) {
       // Map domain exceptions to HTTP exceptions
+      if (error instanceof WebhookDecodeException) {
+        // Authentic request, unusable body (decoder `reject`) → 400.
+        this.logger.warn(
+          `Webhook body decode failed: provider=${provider}, connectionId=${connectionId}`,
+          error.message,
+        );
+        throw new BadRequestException(error.message);
+      }
+
       if (error instanceof WebhookAuthenticationException) {
         this.logger.warn(
           `Webhook authentication failed: provider=${provider}, connectionId=${connectionId}`,

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -24,6 +24,7 @@ import { WebhookController } from './http/webhook.controller';
 import { WebhookDeliveryController } from './http/webhook-delivery.controller';
 import { WebhookService } from './application/services/webhook.service';
 import { WebhookAuthService } from './application/services/webhook-auth.service';
+import { DefaultWebhookDecoder } from './application/decoders/default-webhook-decoder';
 import { WebhookDedupService } from './application/services/webhook-dedup.service';
 import { WebhookEventPublisher } from './application/services/webhook-event-publisher.service';
 import { WebhookDeliveryQueryService } from './application/services/webhook-delivery-query.service';
@@ -50,6 +51,7 @@ import { REDIS_CLIENT_BLOCKING_TOKEN } from './webhooks.tokens';
   providers: [
     WebhookService,
     WebhookAuthService,
+    DefaultWebhookDecoder,
     WebhookDedupService,
     WebhookEventPublisher,
     WebhookDeliveryQueryService,

--- a/apps/api/test/integration/inpost-webhook-ingestion.int-spec.ts
+++ b/apps/api/test/integration/inpost-webhook-ingestion.int-spec.ts
@@ -1,0 +1,145 @@
+/**
+ * InPost Webhook Ingestion Integration Tests (#768, ADR-021)
+ *
+ * End-to-end proof of the third-party-native ingress: an InPost-HMAC-signed
+ * `Shipment.Tracking` webhook → per-provider decoder (verify + extract) →
+ * publish → translate → routing policy (`shipment` domain, gated on
+ * ShippingProviderManager) → `marketplace.shipment.syncByExternalId` job.
+ * Complements `webhook-ingestion.int-spec.ts` (the OL-enveloped/default-decoder
+ * path) by exercising a registered per-provider decoder.
+ *
+ * @module apps/api/test/integration
+ */
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { IntegrationTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+import * as crypto from 'crypto';
+
+function inpostSign(rawBody: Buffer, timestamp: string, secret: string): string {
+  return crypto
+    .createHmac('sha256', secret)
+    .update(Buffer.concat([Buffer.from(timestamp), Buffer.from('.'), rawBody]))
+    .digest('base64');
+}
+
+describe('InPost Webhook Ingestion Integration (#768)', () => {
+  let harness: IntegrationTestHarness;
+  const webhookSecret = 'inpost-test-secret-67890';
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    process.env.OPENLINKER_WEBHOOK_SECRET__INPOST = webhookSecret;
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function createInpostConnection(): Promise<{ id: string }> {
+    return createTestConnection(harness.getDataSource(), {
+      platformType: 'inpost',
+      status: 'active',
+      adapterKey: 'inpost.shipx.v1',
+      config: {},
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+  }
+
+  it('verifies an InPost-signed Shipment.Tracking webhook and routes it to a shipment-sync job', async () => {
+    const connection = await createInpostConnection();
+
+    const body = { tracking_number: '6200000000001' };
+    const rawBody = Buffer.from(JSON.stringify(body));
+    const timestamp = new Date().toISOString();
+    const signature = inpostSign(rawBody, timestamp, webhookSecret);
+
+    await harness
+      .getHttp()
+      .post(`/webhooks/inpost/${connection.id}`)
+      .set('x-inpost-timestamp', timestamp)
+      .set('x-inpost-signature', signature)
+      .set('x-inpost-topic', 'Shipment.Tracking')
+      .send(body)
+      .expect(202);
+
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    const redisClient = harness.getRedisClient();
+    if (!redisClient) throw new Error('Redis client not available');
+
+    // Inbound event published with the neutral shipment shape. The publisher
+    // packs objectType + externalId into the `payloadJson` stream field.
+    const events = await redisClient.xRead(
+      [{ key: 'events.inbound.webhooks', id: '0' }],
+      { COUNT: 50 },
+    );
+    const shipmentEvent = events?.[0]?.messages.find((msg) => {
+      try {
+        const p = JSON.parse(msg.message.payloadJson as string) as {
+          objectType?: string;
+          externalId?: string;
+        };
+        return p.objectType === 'shipment' && p.externalId === '6200000000001';
+      } catch {
+        return false;
+      }
+    });
+    expect(shipmentEvent).toBeDefined();
+
+    // Routed to the parcel-targeted shipment-sync job.
+    const jobs = await redisClient.xRead([{ key: 'jobs.sync', id: '0' }], { COUNT: 50 });
+    const shipmentJob = jobs?.[0]?.messages.find(
+      (msg) =>
+        msg.message.jobType === 'marketplace.shipment.syncByExternalId' &&
+        msg.message.connectionId === connection.id,
+    );
+    expect(shipmentJob).toBeDefined();
+  });
+
+  it('rejects an InPost webhook with an invalid signature (401)', async () => {
+    const connection = await createInpostConnection();
+
+    await harness
+      .getHttp()
+      .post(`/webhooks/inpost/${connection.id}`)
+      .set('x-inpost-timestamp', new Date().toISOString())
+      .set('x-inpost-signature', Buffer.from('not-the-real-signature').toString('base64'))
+      .set('x-inpost-topic', 'Shipment.Tracking')
+      .send({ tracking_number: '6200000000002' })
+      .expect(401);
+  });
+
+  it('ignores a non-tracking topic (202, no job enqueued)', async () => {
+    const connection = await createInpostConnection();
+    const body = { tracking_number: '6200000000003' };
+    const rawBody = Buffer.from(JSON.stringify(body));
+    const timestamp = new Date().toISOString();
+    const signature = inpostSign(rawBody, timestamp, webhookSecret);
+
+    await harness
+      .getHttp()
+      .post(`/webhooks/inpost/${connection.id}`)
+      .set('x-inpost-timestamp', timestamp)
+      .set('x-inpost-signature', signature)
+      .set('x-inpost-topic', 'Shipment.SomethingElse')
+      .send(body)
+      .expect(202);
+
+    await new Promise((resolve) => setTimeout(resolve, 750));
+
+    const redisClient = harness.getRedisClient();
+    if (!redisClient) throw new Error('Redis client not available');
+    const jobs = await redisClient.xRead([{ key: 'jobs.sync', id: '0' }], { COUNT: 50 });
+    const shipmentJobs =
+      jobs?.[0]?.messages.filter(
+        (msg) =>
+          msg.message.jobType === 'marketplace.shipment.syncByExternalId' &&
+          msg.message.connectionId === connection.id,
+      ) ?? [];
+    expect(shipmentJobs).toHaveLength(0);
+  });
+});

--- a/apps/web/src/plugins/index.ts
+++ b/apps/web/src/plugins/index.ts
@@ -43,8 +43,14 @@ import type { OpenLinkerPlugin } from '../shared/plugins';
 import { allegroPlugin } from './allegro';
 import { assertUniquePluginInvariants } from './assert-unique-plugin-invariants';
 import { dpdPlugin } from './dpd';
+import { inpostPlugin } from './inpost';
 import { prestashopPlugin } from './prestashop';
 
-export const plugins: readonly OpenLinkerPlugin[] = [prestashopPlugin, allegroPlugin, dpdPlugin];
+export const plugins: readonly OpenLinkerPlugin[] = [
+  prestashopPlugin,
+  allegroPlugin,
+  dpdPlugin,
+  inpostPlugin,
+];
 
 assertUniquePluginInvariants(plugins);

--- a/apps/web/src/plugins/inpost/components/inpost-webhook-runbook.test.tsx
+++ b/apps/web/src/plugins/inpost/components/inpost-webhook-runbook.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * InpostWebhookRunbook — component tests (#768)
+ *
+ * Covers the per-connection webhook URL rendering and the copy-email-template
+ * affordance.
+ */
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../test/test-utils';
+import type { Connection } from '../../../features/connections';
+import { InpostWebhookRunbook } from './inpost-webhook-runbook';
+
+afterEach(cleanup);
+
+function makeConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn-inpost-1',
+    platformType: 'inpost',
+    name: 'InPost',
+    status: 'active',
+    config: {},
+    credentialsBacked: true,
+    adapterKey: 'inpost.shipx.v1',
+    supportedCapabilities: ['ShippingProviderManager'],
+    enabledCapabilities: ['ShippingProviderManager'],
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('InpostWebhookRunbook', () => {
+  it('renders the per-connection webhook endpoint URL', () => {
+    renderWithProviders(<InpostWebhookRunbook connection={makeConnection()} />);
+    expect(
+      screen.getByText(`${window.location.origin}/webhooks/inpost/conn-inpost-1`),
+    ).toBeInTheDocument();
+    expect(screen.getByText('integration@inpost.pl')).toBeInTheDocument();
+  });
+
+  it('copies an email template containing the endpoint URL on click', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    renderWithProviders(<InpostWebhookRunbook connection={makeConnection()} />);
+    fireEvent.click(screen.getByText('Copy email template'));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain(`${window.location.origin}/webhooks/inpost/conn-inpost-1`);
+    expect(copied).toContain('Shipment.Tracking');
+  });
+});

--- a/apps/web/src/plugins/inpost/components/inpost-webhook-runbook.tsx
+++ b/apps/web/src/plugins/inpost/components/inpost-webhook-runbook.tsx
@@ -1,0 +1,83 @@
+/**
+ * InPost Webhook Runbook
+ *
+ * Plugin-owned `ConnectionActions` row for InPost connections (#768). InPost
+ * provisions shipment-tracking webhooks **manually** via its integration team
+ * (no self-service API), so this is a runbook — not a "configure" button: it
+ * surfaces the OL webhook endpoint for this connection + a copy-paste email
+ * template the operator sends to InPost. OL authenticates each delivery by HMAC
+ * (ADR-021) and refreshes the shipment on every event.
+ *
+ * @module plugins/inpost/components
+ */
+import { useMemo, type ReactElement } from 'react';
+import { Button } from '../../../shared/ui/button';
+import { CopyableId } from '../../../shared/ui/copyable-id';
+import { useToast } from '../../../shared/ui/toast-provider';
+import type { Connection } from '../../../features/connections';
+
+const INPOST_INTEGRATION_EMAIL = 'integration@inpost.pl';
+
+interface InpostWebhookRunbookProps {
+  connection: Connection;
+}
+
+export function InpostWebhookRunbook({ connection }: InpostWebhookRunbookProps): ReactElement {
+  const { showToast } = useToast();
+
+  const webhookUrl = useMemo(
+    () => `${window.location.origin}/webhooks/inpost/${connection.id}`,
+    [connection.id],
+  );
+
+  const emailTemplate = useMemo(
+    () =>
+      [
+        'Hello InPost Integration Team,',
+        '',
+        'Please enable shipment-tracking webhooks for our account, delivered to:',
+        '',
+        webhookUrl,
+        '',
+        'Topic: Shipment.Tracking',
+        '',
+        'Thank you.',
+      ].join('\n'),
+    [webhookUrl],
+  );
+
+  async function handleCopyEmail(): Promise<void> {
+    try {
+      await navigator.clipboard?.writeText(emailTemplate);
+      showToast({
+        tone: 'success',
+        title: 'Email template copied',
+        description: `Send it to ${INPOST_INTEGRATION_EMAIL} to request webhook provisioning.`,
+      });
+    } catch (error) {
+      showToast({
+        tone: 'error',
+        title: 'Copy failed',
+        description: (error as Error).message,
+      });
+    }
+  }
+
+  return (
+    <div className="action-list__item">
+      <div>
+        <strong>Webhook setup (manual)</strong>
+        <p className="muted-text">
+          InPost provisions shipment-tracking webhooks manually. Email{' '}
+          <code className="mono-text">{INPOST_INTEGRATION_EMAIL}</code> with the endpoint below;
+          OpenLinker verifies each delivery by HMAC and refreshes the shipment on every event.
+          Self-service provisioning is not offered by InPost today.
+        </p>
+        <CopyableId id={webhookUrl} />
+      </div>
+      <Button tone="secondary" onClick={() => void handleCopyEmail()}>
+        Copy email template
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/plugins/inpost/index.ts
+++ b/apps/web/src/plugins/inpost/index.ts
@@ -1,0 +1,24 @@
+/**
+ * InPost plugin (FE)
+ *
+ * Carrier (shipping-only) FE plugin. v1 scope here (#768) is the webhook
+ * runbook affordance on the connection-detail page — the manual webhook-setup
+ * runbook that complements the backend shipment-status webhook ingestion. The
+ * fuller InPost connection-settings surface (setup card, structured config,
+ * credentials panel, trigger config) is owned by #771; this plugin grows those
+ * slots there.
+ *
+ * @module plugins/inpost
+ */
+import type { OpenLinkerPlugin } from '../../shared/plugins';
+import { definePlugin } from '../define-plugin';
+import { InpostWebhookRunbook } from './components/inpost-webhook-runbook';
+
+export const inpostPlugin: OpenLinkerPlugin = definePlugin({
+  id: 'inpost',
+  platformType: 'inpost',
+  platform: {
+    displayName: 'InPost',
+    ConnectionActions: InpostWebhookRunbook,
+  },
+});

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -19,6 +19,7 @@ import { MarketplaceOfferPollCreationStatusHandler } from './marketplace-offer-p
 import { MarketplaceOffersSyncHandler } from './marketplace-offers-sync.handler';
 import { MarketplaceOfferStatusSyncHandler } from './marketplace-offer-status-sync.handler';
 import { MarketplaceShipmentStatusSyncHandler } from './marketplace-shipment-status-sync.handler';
+import { MarketplaceShipmentSyncByExternalIdHandler } from './marketplace-shipment-sync-by-external-id.handler';
 import { MarketplaceFulfillmentStatusSyncHandler } from './marketplace-fulfillment-status-sync.handler';
 import { MasterProductSyncHandler } from './master-product-sync.handler';
 import { MasterInventorySyncHandler } from './master-inventory-sync.handler';
@@ -41,6 +42,7 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly marketplaceOffersSyncHandler: MarketplaceOffersSyncHandler,
     private readonly marketplaceOfferStatusSyncHandler: MarketplaceOfferStatusSyncHandler,
     private readonly marketplaceShipmentStatusSyncHandler: MarketplaceShipmentStatusSyncHandler,
+    private readonly marketplaceShipmentSyncByExternalIdHandler: MarketplaceShipmentSyncByExternalIdHandler,
     private readonly marketplaceFulfillmentStatusSyncHandler: MarketplaceFulfillmentStatusSyncHandler,
     private readonly masterProductSyncHandler: MasterProductSyncHandler,
     private readonly masterInventorySyncHandler: MasterInventorySyncHandler,
@@ -75,6 +77,10 @@ export class HandlerRegistrationService implements OnModuleInit {
     this.handlerRegistry.register(
       'marketplace.shipment.statusSync',
       this.marketplaceShipmentStatusSyncHandler
+    );
+    this.handlerRegistry.register(
+      'marketplace.shipment.syncByExternalId',
+      this.marketplaceShipmentSyncByExternalIdHandler
     );
     this.handlerRegistry.register(
       'marketplace.fulfillment.statusSync',

--- a/apps/worker/src/sync/handlers/marketplace-shipment-sync-by-external-id.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-shipment-sync-by-external-id.handler.ts
@@ -1,0 +1,75 @@
+/**
+ * Marketplace Shipment Sync-By-External-Id Handler (#768, ADR-021)
+ *
+ * Thin delegate for jobs of type `marketplace.shipment.syncByExternalId` — the
+ * trigger half of the InPost webhook flow. An inbound `Shipment.Tracking`
+ * webhook routes here carrying the carrier's own parcel id; the handler asks
+ * the core `ShipmentStatusSyncService` to refresh that one shipment
+ * (connection-scoped, authoritative re-read via `getTracking`). The webhook
+ * payload's own status is never trusted — the re-read is the source of truth.
+ *
+ * Mirrors the per-shipment primitive the paged `marketplace.shipment.statusSync`
+ * poll (#838) drives; this is the single-parcel, no-cursor sibling.
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import type {
+  MarketplaceShipmentSyncByExternalIdPayloadV1,
+  SyncJobHandler,
+  SyncJobHandlerResult,
+  SyncJob as SyncJobEntity,
+} from '@openlinker/core/sync';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import {
+  IShipmentStatusSyncService,
+  SHIPMENT_STATUS_SYNC_SERVICE_TOKEN,
+} from '@openlinker/core/shipping';
+import { Logger } from '@openlinker/shared/logging';
+
+type SyncJob = SyncJobEntity;
+
+@Injectable()
+export class MarketplaceShipmentSyncByExternalIdHandler implements SyncJobHandler {
+  private readonly logger = new Logger(MarketplaceShipmentSyncByExternalIdHandler.name);
+
+  constructor(
+    @Inject(SHIPMENT_STATUS_SYNC_SERVICE_TOKEN)
+    private readonly shipmentStatusSync: IShipmentStatusSyncService,
+  ) {}
+
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
+    const { externalId } = this.getPayload(job);
+
+    this.logger.log(
+      `Executing marketplace.shipment.syncByExternalId job ${job.id} for connection ${job.connectionId} (providerShipmentId=${externalId})`,
+    );
+
+    try {
+      await this.shipmentStatusSync.syncOneByProviderShipmentId(job.connectionId, externalId);
+      return { outcome: 'ok' };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SyncJobExecutionError(
+        `Marketplace shipment sync-by-external-id failed: ${message}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  private getPayload(job: SyncJob): MarketplaceShipmentSyncByExternalIdPayloadV1 {
+    const payload = job.payload as unknown as Partial<MarketplaceShipmentSyncByExternalIdPayloadV1>;
+    if (!payload || typeof payload !== 'object' || typeof payload.externalId !== 'string') {
+      throw new SyncJobExecutionError(
+        `Missing or invalid payload (externalId) for job: ${job.id}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+    return { schemaVersion: 1, externalId: payload.externalId };
+  }
+}

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -29,6 +29,7 @@ import { MarketplaceOfferPollCreationStatusHandler } from './handlers/marketplac
 import { MarketplaceOffersSyncHandler } from './handlers/marketplace-offers-sync.handler';
 import { MarketplaceOfferStatusSyncHandler } from './handlers/marketplace-offer-status-sync.handler';
 import { MarketplaceShipmentStatusSyncHandler } from './handlers/marketplace-shipment-status-sync.handler';
+import { MarketplaceShipmentSyncByExternalIdHandler } from './handlers/marketplace-shipment-sync-by-external-id.handler';
 import { MarketplaceFulfillmentStatusSyncHandler } from './handlers/marketplace-fulfillment-status-sync.handler';
 import { MasterProductSyncHandler } from './handlers/master-product-sync.handler';
 import { MasterInventorySyncHandler } from './handlers/master-inventory-sync.handler';
@@ -64,6 +65,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     MarketplaceOffersSyncHandler,
     MarketplaceOfferStatusSyncHandler,
     MarketplaceShipmentStatusSyncHandler,
+    MarketplaceShipmentSyncByExternalIdHandler,
     MarketplaceFulfillmentStatusSyncHandler,
     MasterProductSyncHandler,
     MasterInventorySyncHandler,

--- a/docs/architecture/adrs/021-third-party-native-inbound-webhook-ingestion.md
+++ b/docs/architecture/adrs/021-third-party-native-inbound-webhook-ingestion.md
@@ -1,0 +1,68 @@
+# ADR-021: Third-party-native inbound webhook ingestion via a per-provider decoder
+
+- **Status**: Proposed
+- **Date**: 2026-06-08
+- **Authors**: @piotrswierzy
+
+## Context
+
+[ADR-015](./015-inbound-event-routing-capability-translated.md) made inbound webhook *routing* provider-agnostic (native event → `CanonicalInboundEvent` → capability-gated `InboundRoutingPolicy`). But the step *before* that — getting in the door — is still hard-coded to OpenLinker's own conventions in two ways:
+
+1. **Signature scheme.** `WebhookAuthService` verifies OL's HMAC only: `HMAC-SHA256(secret, "{ts}.{rawBody}") → sha256=<hex>`, headers `X-OpenLinker-Timestamp/Signature`.
+2. **Body envelope.** The controller validates `@Body() WebhookRequestDto` (required `eventId`, `eventType` `^[a-z]+\.[a-z_]+$`, `object.{type,externalId}`, `occurredAt`) — so the NestJS `ValidationPipe` rejects any non-OL body **before** the handler runs. The `eventId` it extracts is the Postgres dedup key, so it must be derived *before* publish.
+
+This held because the controller's only client is **OL's own PrestaShop module** — first-party code emitting OL-enveloped, OL-signed events. **InPost (#768) is the first third-party-native inbound webhook:** it signs with `x-inpost-signature`/`x-inpost-timestamp` (base64 HMAC-SHA256) and posts its *own* body shape, satisfying neither axis. DPD (#965) and future carriers are next. The translator (ADR-015) runs too late and too narrow to help — it's a pure transform on the worker side, post-publish, with no access to the raw bytes or the per-connection secret.
+
+## Decision
+
+Introduce one combined **`InboundWebhookDecoderPort`** — a per-provider host-bag capability resolved by **`provider`** (the `/webhooks/:provider/:connectionId` path segment), mirroring the `WebhookEventTranslator` registry mechanics:
+
+```
+verify(input: { rawBody: Buffer; headers; secret: string }): { ok: boolean; timestampMs?: number }
+extractEnvelope(rawBody: Buffer, headers): DecodeResult
+
+type DecodeResult =
+  | { action: 'route';  envelope: InboundWebhookEnvelope }   // → publish + 202
+  | { action: 'ignore'; reason: string }                     // well-formed, not ours → 202, no publish
+  | { action: 'reject'; reason: string }                     // malformed / untrusted shape → 400
+```
+
+`InboundWebhookEnvelope` = `Omit<InboundWebhookEvent, 'provider' | 'connectionId' | 'receivedAt'>` (the host completes those). OL's HMAC + `WebhookRequestDto` become the **registered default decoder** for providers with no explicit registration — not hard-coded.
+
+**Key design points (from the design session, [DESIGN-021](../../plans/analysis/DESIGN-021-third-party-native-webhook-ingestion.md)):**
+
+- **Keyed by `provider`, not `adapterKey`.** Signature + secret already resolve by `(provider, connectionId)`; `adapterKey` resolves only *downstream* in `WebhookToJobHandler`. Keying the decoder by `adapterKey` would drag connection-metadata resolution into the hot pre-dedup path for no benefit.
+- **Pipeline order: `verify → replay → extractEnvelope → dedup → publish`.** A native provider's trusted timestamp comes *from* `verify` (InPost signs `{x-inpost-timestamp}.{body}`), so replay can't precede it — hence `verify` returns a normalized `timestampMs`, and the shared replay-window check runs on it. The OL default returns its header timestamp; replay logic stays provider-agnostic (and now runs on a signature-covered timestamp).
+- **Three-state decode.** A third party emits a broader stream than OL's own module (unhandled topics, setup pings, future event types). `ignore` (→ 202, no bus entry) vs `reject` (→ 400) prevents retry-storms and log noise on benign unhandled events — a semantic the OL-enveloped path never needed.
+- **Fail-closed.** No registered decoder → the strict OL-HMAC default; a provider cannot weaken verification by *not* registering. Only signature-verified payloads reach `extractEnvelope`.
+- **`eventId` is a best-effort efficiency key, not a correctness primitive.** It seeds Postgres dedup, but routing terminates in an idempotent `getTracking` pull keyed by `(connectionId, externalId)` (ADR-015 invariant 6), so an imperfect `eventId` degrades to a redundant re-read, never wrong state. Decoders derive it from immutable event-identifying fields (provider event id if present, else a hash of parcel-id + the event's own timestamp).
+
+## Alternatives considered
+
+- **Two single-purpose registries** (signature-verifier + envelope-extractor). Rejected: both are keyed by the same `provider`, run at the same pipeline point, and are always co-registered (a provider needing custom verification needs custom decoding) — two lookups make a half-configured provider *representable* and grow the host bag by two handles for one concern.
+- **Dual-route (A2)** — leave the existing `@Body() WebhookRequestDto` route untouched for OL-module providers; add a *second* raw-body route running the decoder pipeline for native providers. Pro: the OL path is literally unchanged (zero regression risk). Rejected as the primary: the URL space bifurcates (operators paste a different URL per provider type) and it bakes in a permanent "OL-legacy vs native" split — arbitrary, since OL's own module isn't conceptually privileged. **Retained as the de-risk fallback** if preserving the default path's status contract proves fragile in implementation.
+- **Dedicated InPost webhook controller** in the InPost API surface. Rejected: reintroduces per-platform host ingress — the exact coupling ADR-015 / #900 removed — and still must expose a shared post-verify ingest entrypoint for dedup/replay/DLQ; the N-th carrier becomes the N-th controller.
+- **Fold decode into the existing `WebhookEventTranslator`.** Rejected: the translator is a pure transform that runs post-publish on the worker side; signature verification needs the secret + raw bytes at the controller, and `eventId` is needed pre-dedup (before publish) — wrong layer and wrong time.
+- **Per-provider body seam only, keep OL-HMAC hard-coded.** Rejected: InPost differs on *both* axes — half a seam leaves it 401-ing.
+
+## Consequences
+
+**Pros:**
+- A new carrier's webhooks need no host PR — one decoder + one `register(host)` line; DPD #965 reuses it. Aligns with ADR-015, open-world capability (#576), and the plugin trust model ([ADR-003](./003-plugin-sdk-trust-model.md)).
+- Single ingress = one security, dedup, and DLQ surface; atomic per-provider registration (no half-configured state).
+- The ADR-015 invariants (trigger-not-truth, unified dedup, DLQ observability, signature-verified-before-translate) carry over unchanged — this ADR only changes *who authenticates and decodes the body*.
+
+**Cons / trade-offs:**
+- One more host-bag registry capability to maintain.
+- The default decoder must reproduce the current `ValidationPipe` behaviour. The preserved contract is the **HTTP status** (202 valid / 401 bad-signature-or-replay / 400 malformed), **not** the exact error-JSON body — nothing is known to depend on the body shape (the PrestaShop module only needs non-2xx to retry). Reusing `class-validator` in the default decoder keeps messages equivalent. Still a security-sensitive shared path — pinned by an int-spec, not assumed.
+- `verify(input: { secret })` fits InPost's **HMAC-shared-secret** option (OL-generated, handed to InPost — reuses `WebhookSecretProviderPort`). InPost also documents `SHA256withRSA` (its public cert, no shared secret); v1 uses HMAC, and the port deliberately doesn't over-fit — a future cert-based decoder resolves its own material from connection config rather than the `secret` param.
+
+**Migration path:**
+- OL-HMAC + `WebhookRequestDto` ship as the registered default decoder; PrestaShop/Allegro stay unchanged on the **status contract**, pinned by the existing webhook integration spec asserting 202/401/400 before and after the refactor.
+- InPost registers its decoder for the `inpost` provider. No schema change — dedup reuses `webhook_deliveries`; the secret reuses `WebhookSecretProviderPort` (OL-generated, handed to InPost). **Open:** confirm InPost sandbox offers the HMAC option (OQ-B3-adjacent).
+
+## References
+
+- Related issues: #768, #727 (parent spec), #965 (DPD — next consumer)
+- Related ADRs: [ADR-015](./015-inbound-event-routing-capability-translated.md) (downstream complement), [ADR-005](./005-postgres-authoritative-job-dedup.md) (dedup), [ADR-003](./003-plugin-sdk-trust-model.md), [ADR-013](./013-neutral-oauth-completion-port.md) (host-bag registry sibling)
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md) § Webhook Ingestion Flow

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -109,5 +109,6 @@ One pointer per section, identical format every time.
 | [ADR-018](./018-dpd-polska-rest-api-over-soap.md) | DPD Polska transport: native REST DPDServices API over legacy SOAP | Proposed | 2026-06-02 |
 | [ADR-019](./019-synchronous-bulk-shipment-dispatch.md) | Synchronous bulk shipment dispatch (loop the per-order seam) | Accepted | 2026-06-03 |
 | [ADR-020](./020-neutral-delivery-intent-shipping-dispatch.md) | Neutral delivery intent as the shipping-dispatch caller contract | Accepted | 2026-06-05 |
+| [ADR-021](./021-third-party-native-inbound-webhook-ingestion.md) | Third-party-native inbound webhook ingestion via a per-provider decoder | Proposed | 2026-06-08 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-768-inpost-shipment-status-webhook.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-768-inpost-shipment-status-webhook.md
@@ -1,0 +1,50 @@
+# Pre-implement analysis — #768 InPost shipment-status webhook ingestion (trigger-based)
+
+> **Re-gate (revised single-PR plan, approach (a)) → ✅ READY.** The revision adds the **inbound envelope/eventId extractor seam (Phase A2)** alongside the signature-verifier seam (A1) — directly closing the only blocker (the controller's rigid OL-envelope `WebhookRequestDto` couldn't ingest InPost's native body). Both seams fall back to an **OL-module default strategy** (current OL-HMAC + `WebhookRequestDto`), so prestashop/allegro stay byte-for-byte unchanged → additive, no contract break. Reuse picture unchanged from below (`findByProviderShipmentId`, translator/secret/dedup/routing all reused). Remaining items are **implementation risks/open-questions, not blockers**: (1) the host ingress refactor is security-sensitive — preserve the default path + keep A1–A3 a cohesive, independently-reviewable module (peelable to a precursor PR only if review/diff demands); (2) InPost `eventId` determinism for dedup (sandbox — deterministic fallback hash); (3) sandbox-gated payload isolated to the parcel-id field (status re-read via `getTracking` is authoritative). Proceed.
+>
+> The original verdict below is retained for the record.
+
+---
+
+**Original verdict (pre-revision): NEEDS-REVISION** — no reuse collision and no removed/renamed contract symbol, but the plan **under-scopes the host webhook ingress**: the existing `/webhooks/:provider/:connectionId` path assumes an **OL-shaped inbound envelope** (rigid `WebhookRequestDto`) in addition to OL's HMAC scheme. InPost is the first *third-party-native* inbound webhook; its native body + signature can't traverse the current controller. The plan addresses the signature seam (Phase A) but not the envelope/eventId seam. Revise before coding.
+
+Gated on a fresh worktree at `origin/main` (1112ed5c), reusing two Explore architecture maps from planning.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `WebhookSignatureVerifierPort` + registry (Phase A1/A2) | **NEW** | no `WebhookSignatureVerifier*` anywhere; `WebhookAuthService` is hard-coded to OL HMAC |
+| `ShipmentRepositoryPort.findByProviderShipmentId` (B4) | **ALREADY EXISTS → reuse** | `shipment-repository.port.ts:60` (plan said "verify/add" — it exists; takes `providerShipmentId` only, no connectionId arg) |
+| `'shipment'` in `InboundEventDomainValues` (B1) | **PARTIAL (widen closed union)** | `canonical-inbound-event.types.ts` = `['order','inventory','product']` |
+| `marketplace.shipment.syncByExternalId` job + `…PayloadV1` (B2) | **NEW** | grep → none; mirrors `master.product.syncByExternalId` |
+| `InboundRoutingPolicy` `shipment` case (B3) | **PARTIAL (extend switch)** | `inbound-routing-policy.service.ts` `resolveRoute` has `default: never` — the case is required for exhaustiveness |
+| `ShipmentStatusSyncService.syncOneByProviderShipmentId` (B4) | **PARTIAL (extract from `sync()`)** | per-shipment body exists inside the paged loop |
+| worker handler for the new job (B5) | **NEW** | mirrors `MarketplaceShipmentStatusSyncHandler` |
+| `WebhookEventTranslatorPort` + registry (C2/C3) | **EXISTS → reuse** | `webhook-event-translator.port.ts`; PrestaShop reference adapter + `register(host)` |
+| Per-connection webhook secret + rotation (verifier secret source) | **EXISTS → reuse** | `WebhookSecretProviderPort` / `WebhookSecretService` (ref `webhook-secret:<connectionId>`) |
+| Postgres dedup / replay-window | **EXISTS → reuse** | `webhook_deliveries` unique `(provider,connectionId,eventId)`; `OL_WEBHOOK_SKEW_WINDOW_MS` |
+| `ShippingProviderManager` capability gate (B3) | **EXISTS → reuse** | already InPost's declared capability — **do not invent a `tracking-webhooks` CoreCapability** (it's a spec label, not in `CoreCapabilityValues`) |
+| InPost translator + signature-verifier adapters (C1/C2) | **NEW (plugin)** | none today |
+| FE connection-settings runbook (D1) | **NEW (plugin platform contribution)** | — |
+
+## Backward-compat findings
+
+| Surface | Severity | Finding / migration path |
+|---|---|---|
+| **Webhook ingress envelope (`WebhookRequestDto`)** | **Critical (gap)** | The controller validates a rigid OL envelope (`eventId`, `eventType` `^[a-z]+\.[a-z_]+$`, `object.{type,externalId}`, `occurredAt`) **before** translation. InPost's native body fails this → 400 before verify/translate. The plan's per-provider **signature** seam is insufficient; a per-provider **raw-body + eventId-derivation** path is also required. This is the load-bearing revision. |
+| `WebhookAuthService` provider-dispatch (Phase A) | Warning | Additive if the OL-HMAC default stays the fallback; must preserve PrestaShop/Allegro byte-for-byte. Security-sensitive shared path. |
+| `InboundEventDomainValues` widen | Warning | Additive to a published `@openlinker/core/integrations` barrel type; the only exhaustive consumer is the routing-policy switch (B3 supplies the case); `RoutingOutcome` union widens safely. |
+| New `JobType` + payload | Warning | Additive to `JobTypeValues`; the worker handler-registration must register it (B5) or an enqueued job has no handler at runtime. |
+| ORM schema | None | No new column — dedup reuses `webhook_deliveries`. No migration. |
+| `check:invariants` | None expected | New core service method keeps `IShipmentStatusSyncService` in sync (service-interface check); plugin imports the new port via the top-level barrel; no new `plugins.ts` entry (InPost already present) → no jest-mapper change. |
+
+## Open questions (must resolve in the revised plan)
+
+1. **Third-party-native ingress (the big one).** Decide the approach: **(a)** generalize the shared controller — per-provider signature verifier **+** per-provider envelope/eventId extraction (translate the *raw* body; derive `eventId` per provider), likely meriting a short ADR ("third-party-native inbound webhook ingestion"); or **(b)** a dedicated InPost webhook controller in the InPost API surface that verifies + derives eventId + publishes to the same `events.inbound.webhooks` bus, leaving the OL-module controller untouched. (a) is more reusable for future carriers (DPD #965); (b) is lower-blast-radius now.
+2. **eventId for dedup** from InPost's native body — which field is stable/unique? (sandbox-gated, OQ-B3). Needs a deterministic fallback (e.g. hash of parcel-id + status + timestamp).
+3. **Scope/split.** This is M+ across 5 layers. Recommend splitting: **(1)** host third-party-native ingress seam (signature verifier + envelope/eventId) — own PR + ADR; **(2)** core `shipment` inbound-routing + targeted `syncByExternalId` job; **(3)** InPost translator/verifier + FE runbook.
+4. **Sandbox-gated payload** — translator reads only the parcel id (avoids the status-enum blocker); isolate that one field access behind a documented best-guess fixture.
+
+## Summary
+The trigger-based design is architecturally right and most of it reuses existing seams (translator registry, secret provider, dedup, `findByProviderShipmentId`, `ShipmentStatusSyncService`). But the gate surfaced one thing the plan missed: the shared webhook controller is built for **OL-enveloped** events from OL's own modules, so InPost — the first **third-party-native** inbound webhook — can't traverse it on **either** the signature **or** the body-envelope/eventId axis. Phase A must grow to a full third-party-native ingress seam (or a dedicated InPost controller), ideally with an ADR, and the work should be split into ~3 PRs. **NEEDS-REVISION.**

--- a/docs/plans/analysis/DESIGN-021-third-party-native-webhook-ingestion.md
+++ b/docs/plans/analysis/DESIGN-021-third-party-native-webhook-ingestion.md
@@ -1,0 +1,63 @@
+# Design session — ADR-021 third-party-native inbound webhook ingestion
+
+Pressure-test of the ADR-021 decision against the *actual* ingress pipeline (`apps/api/src/webhooks/application/services/webhook.service.ts:47-209`, `webhook.controller.ts:56-97`, `webhook-auth.service.ts`). Eleven findings; several amend the ADR as first drafted.
+
+## Grounding facts (current pipeline)
+
+`processWebhook(provider, connectionId, request: WebhookRequestDto, rawBody, headers)`:
+1. reads OL headers `x-openlinker-timestamp/signature` (hard-coded names);
+2. **`validateTimestamp` (replay) runs BEFORE signature**, on the *untrusted* header timestamp;
+3. `verifySignature(provider, connectionId, timestamp, rawBody, signature)` — keyed by **`(provider, connectionId)`**, resolves secret via `getSecret(provider, connectionId)`. **`adapterKey` is never used here** — it resolves downstream in `WebhookToJobHandler`;
+4. dedup `insertIfNew` on `(provider, connectionId, eventId)`, `eventId` from the DTO;
+5. builds `InboundWebhookEvent` from DTO fields + publishes.
+The controller binds `@Body() WebhookRequestDto`, so the `ValidationPipe` rejects a non-OL body with **400 before the handler runs**.
+
+## Findings & decisions
+
+### F1 — Registry key: `provider`, not `adapterKey` (amends ADR)
+The ADR said "keyed by `adapterKey`, mirroring the translator registry." But the decoder runs at the controller/service layer where **only `provider` + `connectionId` are known** — `adapterKey` requires connection-metadata resolution that today happens *downstream*. Signature + secret already key by `(provider, connectionId)`. **Decision: key the decoder registry by `provider`** (the URL path segment). Keying by `adapterKey` would drag connection-metadata resolution into the hot pre-dedup path for no benefit. (Caveat: if one provider ever ships two incompatible webhook formats across adapter versions, revisit — not a v1 concern.)
+
+### F2 — Pipeline ordering: verify → replay → extract → dedup (amends ordering)
+For a native provider the trusted timestamp comes *from* signature verification (InPost signs `{x-inpost-timestamp}.{body}`), so replay can't run first. Unify on: **`decoder.verify()` → replay-check(decoder-returned timestamp) → `decoder.extractEnvelope()` → dedup → publish.** `verify` returns a **normalized** timestamp: `{ ok: boolean; timestampMs?: number }`. The OL default decoder returns its header timestamp; replay logic stays shared and provider-agnostic. Bonus: replay now runs on a signature-covered timestamp (slightly stronger than today's replay-on-untrusted-header).
+
+### F3 — The real refactor + risk is removing `@Body() WebhookRequestDto`
+The service is built around the pre-validated DTO. Supporting native providers means the controller stops binding/validating it; the **default decoder reproduces** the validation. This is the single security-sensitive change. **Right-size the earlier "byte-for-byte" claim:** preserve the **400/401/202 status contract** (not necessarily the exact error-JSON body — nothing is known to depend on the body shape; PrestaShop's module only needs non-2xx to retry). Reuse `class-validator` in the default decoder so messages stay equivalent. **Guard: the existing PrestaShop webhook int-spec must assert 202-on-valid / 401-on-bad-sig / 400-on-malformed before and after the refactor.**
+
+### F4 — Decode must be three-state: route / ignore / reject (new — important)
+OL's own module only emits events OL handles, so today "unparseable" → 400 is fine. A third party emits a **broader stream**: unhandled topics (`x-inpost-topic !== 'Shipment.Tracking'`), setup test-pings, future event types. Returning 400 on those makes InPost **retry-storm** and pollutes logs. **Decision:** `extractEnvelope` returns a discriminated result —
+```
+{ action: 'route'; envelope: InboundWebhookEnvelope }
+| { action: 'ignore'; reason: string }   // well-formed, not for us → 202, no publish, debug log
+| { action: 'reject'; reason: string }    // malformed/unauthenticated-shape → 400
+```
+Controller maps route→publish+202, ignore→202 (no bus entry), reject→400. This is a genuine semantic the OL-enveloped path never needed.
+
+### F5 — eventId determinism is de-risked by the idempotent pull (lowers stakes)
+Dedup keys on `eventId` derived from the body. **But** routing terminates in an authoritative `getTracking` pull keyed by `(connectionId, externalId)` that is idempotent and tolerates duplicate/out-of-order delivery (ADR-015 invariant 6). So an imperfect `eventId` degrades to a **redundant re-read**, never incorrect state. **Decision:** derive `eventId` from immutable event-identifying fields (InPost event id if present; else `hash(parcelId + event-timestamp[+status])` using the event's *own* timestamp so retries collide and distinct events don't). Treat it as a best-effort efficiency key, not a correctness primitive.
+
+### F6 — Secret injection assumes HMAC-shared-secret; RSA is a future divergence
+`verify(input:{secret})` fits InPost's HMAC-shared-secret option (OL generates, hands to InPost — reuses `WebhookSecretProviderPort`). InPost *also* documents `SHA256withRSA` (its cert), which has **no shared secret**. **Decision (v1):** use HMAC-shared-secret; keep `secret` in the contract but document that a cert-based decoder would resolve its own material from connection config rather than the `secret` param (don't over-fit the port). **Open question:** confirm InPost sandbox offers the HMAC option (OQ-B3-adjacent).
+
+### F7 — Fail-closed default (confirmed safe)
+No registered decoder → the OL-HMAC default (strict). A provider cannot weaken verification by *not* registering — it falls to OL-HMAC and 401s (it didn't sign OL-style). The default is always present. No "unverified" path exists.
+
+### F8 — Layering (confirmed)
+Port + registry + `InboundWebhookEnvelope` type live in `libs/core/src/integrations` (plugins implement without an `apps/api` dependency; `InboundWebhookEvent` is already core). The **default decoder** uses `WebhookRequestDto` + OL-HMAC (both `apps/api`), so it lives in `apps/api/src/webhooks` and self-registers as the fallback. `InboundWebhookEnvelope = Omit<InboundWebhookEvent,'provider'|'connectionId'|'receivedAt'>`.
+
+### F9 — Alternative weighed: dual-route vs unified default decoder
+**Option A2 (dual-route):** keep `@Body() WebhookRequestDto` on the existing route untouched (zero PS risk); add a *second* raw-body route for native providers that runs the decoder pipeline. Pro: OL path literally unchanged. Con: URL space bifurcates (operators paste a different URL per provider type) and a permanent "OL-legacy vs native" split — arbitrary, since OL's module isn't conceptually special. **Recommendation: keep the unified default-decoder (ADR as written)** — it's the principled end state ("OL's module is just a provider whose decoder is the built-in default") and F3 right-sizes its only real risk. A2 stays the documented **fallback** if 400-preservation proves fragile in implementation.
+
+### F10 — HostServices growth
+One new registry handle (the combined port keeps it to one, vs two — the reason the ADR chose combined). Ninth well-known registry; additive, documented in the host bag.
+
+### F11 — Observability (extends ADR-015 invariant 4)
+New signals: `ignore`-count by reason (unhandled topic / ping) — expected noise, must be distinguishable from `reject`/401 (misconfiguration / attack). Surface a counter; don't let benign ignores look like failures.
+
+## Net amendments to ADR-021
+1. Decoder keyed by **`provider`**, not `adapterKey` (F1).
+2. `verify` returns **`{ ok; timestampMs? }`**; pipeline order **verify → replay → extract → dedup** (F2).
+3. `extractEnvelope` returns a **three-state result** (route/ignore/reject), not `Envelope | null` (F4).
+4. Preserve the **status contract** (not byte-for-byte body); pin via the PS int-spec (F3).
+5. eventId framed as a **best-effort efficiency key** given the idempotent pull (F5).
+6. Note HMAC-shared-secret for v1; **RSA/cert is a future divergence** the port shouldn't over-fit (F6).
+7. Record **dual-route (A2)** as the considered alternative + de-risk fallback (F9).

--- a/docs/plans/implementation-plan-768-inpost-shipment-status-webhook.md
+++ b/docs/plans/implementation-plan-768-inpost-shipment-status-webhook.md
@@ -1,0 +1,63 @@
+# Implementation Plan — #768 InPost shipment-status webhook ingestion (trigger-based, single PR)
+
+**Issue:** #768 · **Parent:** #727 (spec §3.2, AC-8/AC-9) · **Branch:** `768-inpost-shipment-status-webhook`
+**Layers:** Interface (third-party-native webhook ingress seam) + CORE (inbound `shipment` domain + targeted refresh) + Integration (InPost) + Worker + FE (runbook) + ADR.
+**Shape:** **one PR** (one coherent vertical slice, `Closes #768`, end-to-end int-test). The ingress seam is a clean internal module so it *could* be peeled into a precursor PR **only if** review or diff size demands — not pre-split on spec.
+
+## 1. Goal
+
+InPost pushes shipment-tracking webhooks; OL ingests them as a **low-latency trigger** (OL's webhook=trigger doctrine, #900/#904): verify InPost's signature → confirm `Shipment.Tracking` topic → enqueue a **parcel-targeted** shipment refresh that re-reads authoritative status via the InPost adapter's `getTracking` and propagates via #838 `ShipmentStatusSyncService`. **No payload-status parsing** (sandbox-gated catalogue, OQ-B3 — deferred; the re-read is authoritative).
+
+**Re-scoped** off the issue's 2026-05-17 "bespoke handler parses status + propagates directly" wording (predated #838 + #900/ADR-015). **Decisions this session:** trigger-based; host ingress generalized via per-provider registries (approach **(a)**), not a dedicated InPost controller (b); single PR.
+
+**Non-goals:** payload-of-record fast-path; self-service webhook provisioning (manual InPost-team contact — runbook only).
+
+## 2. Research findings (live contracts)
+
+- **The shared `/webhooks/:provider/:connectionId` controller is an OL-first-party-envelope ingress, not truly generic.** It hard-codes *both*: (i) OL-HMAC (`WebhookAuthService`: `HMAC-SHA256(secret,"{ts}.{rawBody}")→sha256=<hex>`, headers `X-OpenLinker-*`), and (ii) an OL body envelope — `@Body() WebhookRequestDto` (`webhook.controller.ts:59`) with **required** `eventId`, `eventType` `^[a-z]+\.[a-z_]+$`, `object.{type,externalId}`, `occurredAt`. NestJS ValidationPipe ⇒ a non-OL body (InPost native) **400s before the handler runs**. Its only client today is OL's own PS module. **InPost is the first third-party-native inbound webhook** → needs per-provider seams on *both* axes. `req.rawBody` is already available (`webhook.controller.ts:64`).
+- **Reuse confirmed:** `ShipmentRepositoryPort.findByProviderShipmentId` exists (`shipment-repository.port.ts:60`); `WebhookEventTranslatorPort`+registry, `WebhookSecretProviderPort`+`WebhookSecretService` (per-connection secret `webhook-secret:<connectionId>`, rotatable), `webhook_deliveries` dedup + `OL_WEBHOOK_SKEW_WINDOW_MS` replay, `events.inbound.webhooks` bus + `WebhookToJobHandler`, `InboundRoutingPolicy` + capability gating, `ShipmentStatusSyncService` per-shipment logic — all reusable.
+- **Genuinely new:** per-provider signature verifier + envelope/eventId extractor seams; `shipment` inbound domain; `marketplace.shipment.syncByExternalId` job; InPost adapters; FE runbook. `WebhookSignatureVerifier*` absent; `marketplace.shipment.syncByExternalId` absent.
+- `InboundEventDomainValues` is closed `order|inventory|product`; the only exhaustive consumer is `InboundRoutingPolicy.resolveRoute`'s `default: never`. Gate uses `ShippingProviderManager` (exists) — **do not invent a `tracking-webhooks` CoreCapability** (spec label only).
+
+## 3. Steps (one PR; internal modules A→F)
+
+### ADR-021 — third-party-native inbound webhook ingestion
+`docs/architecture/adrs/021-third-party-native-inbound-webhook-ingestion.md`: records that the webhook controller becomes provider-agnostic via a per-provider decoder registry; OL-HMAC + the `WebhookRequestDto` envelope become the **OL-module provider's registered default strategy**, not hard-coded; third parties (InPost now, DPD #965 next) register their own. **Decision: one combined `InboundWebhookDecoderPort` (`verify()` + `extractEnvelope()`)** over two single-purpose registries — cohesion, atomic registration (no half-configured provider), one `HostServices` handle. Upstream complement to **ADR-015** (which covers native-event → `CanonicalInboundEvent` → routing *after* ingest); cross-reference it.
+
+### A — host ingress seam (the load-bearing module; keep cohesive/peelable)
+| # | File | Change | AC |
+|---|---|---|---|
+| A1 | `libs/core/src/integrations/domain/ports/inbound-webhook-decoder.port.ts` *(new)* + `*.types.ts` + registry + token | **One combined port** (ADR-021), **keyed by `provider`**: `verify(input:{rawBody:Buffer;headers;secret:string}):{ok:boolean;timestampMs?:number}` + `extractEnvelope(rawBody:Buffer, headers): DecodeResult`. `DecodeResult` = discriminated union `{action:'route';envelope} \| {action:'ignore';reason} \| {action:'reject';reason}` (plain union on `action`, mirroring `RoutingOutcome.status` — not the `as const`+Values pattern; it's an internal control-flow discriminant). `InboundWebhookEnvelope` = `Omit<InboundWebhookEvent,'provider'|'connectionId'|'receivedAt'>` — in a `*.types.ts`, not inline. Registry mirrors `WebhookEventTranslatorRegistryService`. **Export `InboundWebhookDecoderPort` / `InboundWebhookEnvelope` / `DecodeResult` from the `@openlinker/core/integrations` top-level barrel and the registry token from `integrations.tokens.ts`** (Symbol DI Re-export Convention) so the plugin imports them via the barrel. Add the registry handle to `HostServices` in `@openlinker/plugin-sdk` (mirrors the translator-registry handle). | additive; atomic registration |
+| A2 | `WebhookService.processWebhook` / `webhook.controller.ts` + `apps/api/.../default-webhook-decoder.ts` *(new host default)* | controller takes the **raw body** (drop eager `@Body() WebhookRequestDto` validation on the generic route); resolve the per-**`provider`** decoder; **fall back to a host `DefaultWebhookDecoder`** (verify = current OL-HMAC; extract = construct+`validate()` `WebhookRequestDto`, same pipe options) — a host class registered in the `apps/api` webhooks module as the fallback, **not** via a plugin `register(host)`. Pipeline order **verify → replay(decoder `timestampMs`) → extract → dedup → publish**; the controller (interface layer) maps `route`→publish+202, `ignore`→202 no-publish, `reject`→400. Preserve the **status contract** (202/401/400), not the exact 400 body. | OL default status contract identical; per-provider path used when registered; bad sig → 401 |
+| A3 | specs + **pin existing PS webhook int-spec** | add/confirm a PrestaShop-webhook int-spec asserting the current 202/401/400 **status** contract **before** refactor, green after — **incl. reordered-path regressions: stale-but-correctly-signed OL timestamp → 401 (replay), missing timestamp → 401**; new InPost-style path verifies + extracts; bad sig/replay → 401, malformed → 400, unhandled topic → 202 ignore. | green; PS contract unchanged |
+| A4 | observability | structured log/counter on the `ignore` (benign: unhandled topic / setup ping) vs `reject`/401 (malformed / misconfig / attack) branches — benign third-party noise must be distinguishable from real failure (ADR-015 invariant 4). | both branches observable |
+
+### B — core: `shipment` inbound domain + targeted refresh job
+| # | File | Change |
+|---|---|---|
+| B1 | `canonical-inbound-event.types.ts` | add `'shipment'` to `InboundEventDomainValues`. |
+| B2 | `marketplace-job-payloads.types.ts` + `sync-job.types.ts` | `marketplace.shipment.syncByExternalId` + `MarketplaceShipmentSyncByExternalIdPayloadV1 {schemaVersion:1; externalId:string}` (parcel/providerShipmentId). |
+| B3 | `inbound-routing-policy.service.ts` | `case 'shipment'` → `{jobType, requiredCapability:'ShippingProviderManager', payload:{schemaVersion:1, externalId}}` (capability-gated like siblings). |
+| B4 | `ShipmentStatusSyncService` (+interface) | extract per-shipment body of `sync()` into `syncOneByProviderShipmentId(connectionId, providerShipmentId)` (reuse `findByProviderShipmentId` → `getTracking` → patch → propagate); paged `sync()` calls it per row (no behavior change). **Connection-scope:** assert the resolved shipment's `connectionId` matches the job's (job carries connectionId at `SyncJobRequest` level; payload carries `externalId`) — guards cross-connection refresh under multi-account (#727 v2). |
+| B5 | worker `marketplace-shipment-sync-by-external-id.handler.ts` *(new)* + registration + `sync-worker.module.ts` | thin delegate → `syncOneByProviderShipmentId`; wrap in `SyncJobExecutionError`. |
+
+### C — InPost plugin
+| # | File | Change |
+|---|---|---|
+| C1 | `inpost-inbound-webhook-decoder.adapter.ts` *(new)* → `InpostInboundWebhookDecoderAdapter` | implements the combined `InboundWebhookDecoderPort`: **verify** = base64 HMAC-SHA256 over `"{x-inpost-timestamp}.{rawBody}"`, header `x-inpost-signature`, `timingSafeEqual`, returns the parsed `x-inpost-timestamp` as `timestampMs`; **extractEnvelope** = `x-inpost-topic==='Shipment.Tracking'` → `{action:'route', envelope:{eventId (stable from body; fallback hash parcel-id+event-ts), objectType:'shipment', externalId:<parcel id>}}`; setup ping / other known topic → `{action:'ignore'}`; malformed → `{action:'reject'}`. Reads **only the parcel-id field** — no status enum (sandbox-gated). |
+| C2 | `inpost-webhook-event-translator.adapter.ts` *(new)* | `objectType 'shipment'` → `{domain:'shipment', externalId}`; else `null`. |
+| C3 | `inpost-plugin.ts` `register(host)` | register **decoder by provider `inpost`** + **translator by adapterKey `inpost.shipx.v1`** (translator resolves downstream where adapterKey is known). |
+
+### D — FE connection-settings runbook
+InPost platform contribution: webhook URL `{origin}/webhooks/inpost/{connectionId}` + copy affordance + InPost email template + rotate-secret action.
+
+### E — tests + gate
+Unit: verifier (valid/invalid/replay), extractor (topic gate, eventId, parcel id, null), routing `shipment` case (+ungated), `syncOneByProviderShipmentId`. **Integration: HMAC-signed InPost fixture → `POST /webhooks/inpost/:id` → dedup → bus → translate → route → job (mock `getTracking`) → shipment updated + propagated** (the end-to-end correctness signal — the reason this is one PR). `pnpm lint`/`type-check`/`test` + affected `test:integration`.
+
+## 4. Risks
+- **Host ingress refactor is the principal risk** (security-sensitive, shared). Mitigation: OL-module default strategy preserves prestashop/allegro byte-for-byte; keep A1–A3 a cohesive module behind the registries so it's independently reviewable (and peelable to a precursor PR **only if** the diff/review demands). ADR records the decision.
+- `InboundEventDomainValues` widen — additive published-barrel change; sole exhaustive consumer (routing switch) updated in B3.
+- New job type — additive; handler registration (B5) required or enqueue has no handler.
+- **No ORM/migration** — reuses `webhook_deliveries`.
+- **Sandbox-gated payload** — extractor depends only on the parcel-id field + topic; isolate that access + cover with a documented best-guess fixture; the status re-read via `getTracking` is authoritative regardless.
+- **eventId determinism** for dedup from InPost's native body — confirm the field; deterministic fallback hash if absent.

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -440,7 +440,7 @@ authoring your plugin). Its four fields:
 
 The `HostServices` bag passed into `register` and `createCapabilityAdapter`
 is defined at
-[`libs/plugin-sdk/src/host-services.ts:53-152`](../libs/plugin-sdk/src/host-services.ts#L53-L152).
+[`libs/plugin-sdk/src/host-services.ts:54-163`](../libs/plugin-sdk/src/host-services.ts#L54-L163).
 It splits into two blocks:
 
 - **Read inputs** (use): `logger`, `identifierMapping`,
@@ -1022,7 +1022,7 @@ If you're proposing a new "bulk" capability on a port, that's almost certainly a
   vertical-slice patterns, the PrestaShop opt-in helper.
 - [`libs/plugin-sdk/src/adapter-plugin.ts:42-110`](../libs/plugin-sdk/src/adapter-plugin.ts#L42-L110)
   — the `AdapterPlugin` contract spec, header-comment form.
-- [`libs/plugin-sdk/src/host-services.ts:53-152`](../libs/plugin-sdk/src/host-services.ts#L53-L152)
+- [`libs/plugin-sdk/src/host-services.ts:54-163`](../libs/plugin-sdk/src/host-services.ts#L54-L163)
   — the `HostServices` bag, fields split into read-inputs vs side
   registries.
 

--- a/libs/core/src/integrations/domain/ports/inbound-webhook-decoder.port.ts
+++ b/libs/core/src/integrations/domain/ports/inbound-webhook-decoder.port.ts
@@ -1,0 +1,45 @@
+/**
+ * Inbound Webhook Decoder Port
+ *
+ * Per-provider capability that authenticates a third-party-native inbound
+ * webhook and decodes its raw body into the host's neutral inbound envelope
+ * (ADR-021). It is the upstream complement to `WebhookEventTranslatorPort`
+ * (ADR-015): the decoder runs **at the controller, before dedup/publish** (it
+ * needs the raw bytes, the per-connection secret, and must derive the dedup
+ * `eventId` pre-publish); the translator runs after publish on the neutral
+ * event.
+ *
+ * Registered per `provider` (the `/webhooks/:provider/:connectionId` path
+ * segment) in `InboundWebhookDecoderRegistryService`. OpenLinker's own HMAC +
+ * `WebhookRequestDto` envelope is the registered host default decoder — third
+ * parties (InPost, DPD) register their own scheme. Only signature-verified
+ * payloads reach `extractEnvelope`.
+ *
+ * @module libs/core/src/integrations/domain/ports
+ * @see {@link DecodeResult} for the three-state extract outcome
+ */
+import type {
+  DecodeResult,
+  WebhookVerifyResult,
+} from '../types/inbound-webhook-decoder.types';
+
+export interface InboundWebhookDecoderPort {
+  /**
+   * Verify the request's signature over the raw body, using the per-connection
+   * shared secret. Returns `ok` plus the normalized (epoch-ms) timestamp the
+   * host feeds to the shared replay-window check. A scheme without a shared
+   * secret (e.g. cert-based) resolves its own material and may ignore `secret`.
+   */
+  verify(input: {
+    rawBody: Buffer;
+    headers: Record<string, string>;
+    secret: string;
+  }): WebhookVerifyResult;
+
+  /**
+   * Decode the (already signature-verified) raw body into the neutral
+   * envelope, or signal `ignore` (well-formed, not ours) / `reject`
+   * (malformed). Must be total — never throw unbounded.
+   */
+  extractEnvelope(rawBody: Buffer, headers: Record<string, string>): DecodeResult;
+}

--- a/libs/core/src/integrations/domain/types/canonical-inbound-event.types.ts
+++ b/libs/core/src/integrations/domain/types/canonical-inbound-event.types.ts
@@ -17,7 +17,7 @@
  * @module libs/core/src/integrations/domain/types
  */
 
-export const InboundEventDomainValues = ['order', 'inventory', 'product'] as const;
+export const InboundEventDomainValues = ['order', 'inventory', 'product', 'shipment'] as const;
 
 export type InboundEventDomain = (typeof InboundEventDomainValues)[number];
 

--- a/libs/core/src/integrations/domain/types/inbound-webhook-decoder.types.ts
+++ b/libs/core/src/integrations/domain/types/inbound-webhook-decoder.types.ts
@@ -1,0 +1,56 @@
+/**
+ * Inbound Webhook Decoder Types
+ *
+ * Neutral types for the per-provider inbound-webhook decode seam (ADR-021).
+ * A `InboundWebhookDecoderPort` authenticates a third-party-native webhook and
+ * decodes its raw body into the host's neutral inbound envelope — the upstream
+ * complement to the `WebhookEventTranslatorPort` (ADR-015), which runs after
+ * publish to map the decoded event onto a `CanonicalInboundEvent`.
+ *
+ * `InboundWebhookEnvelope` is the subset of `InboundWebhookEvent` a decoder
+ * derives from the raw body + headers; the host completes the `provider`,
+ * `connectionId`, and `receivedAt` fields it owns.
+ *
+ * @module libs/core/src/integrations/domain/types
+ * @see {@link InboundWebhookDecoderPort} for the port interface
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+
+/**
+ * The decoder-derived portion of an inbound webhook event. The host owns and
+ * fills `provider` (route param), `connectionId` (route param), and
+ * `receivedAt` (ingest clock); the decoder supplies everything else from the
+ * provider-native body — including `eventId` (the Postgres dedup key, derived
+ * pre-dedup).
+ */
+export type InboundWebhookEnvelope = Omit<
+  InboundWebhookEvent,
+  'provider' | 'connectionId' | 'receivedAt'
+>;
+
+/**
+ * Outcome of `extractEnvelope`. A discriminated union (plain `action`
+ * discriminant, mirroring `RoutingOutcome.status`) — three states a
+ * third-party-native stream needs that the OL-enveloped path never did:
+ *
+ * - `route`  — a well-formed event this connection should ingest → publish + 202.
+ * - `ignore` — well-formed but not ours (unhandled topic, setup ping) → 202,
+ *   no publish. Distinct from `reject` so benign third-party noise does not
+ *   trigger source-side retry storms.
+ * - `reject` — malformed / untrusted shape → 400.
+ */
+export type DecodeResult =
+  | { action: 'route'; envelope: InboundWebhookEnvelope }
+  | { action: 'ignore'; reason: string }
+  | { action: 'reject'; reason: string };
+
+/**
+ * Outcome of `verify`. `timestampMs` is the normalized (epoch-ms) timestamp the
+ * decoder extracted from the signed request, fed to the shared replay-window
+ * check — so replay logic stays provider-agnostic regardless of the provider's
+ * timestamp header name/format.
+ */
+export interface WebhookVerifyResult {
+  ok: boolean;
+  timestampMs?: number;
+}

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -15,6 +15,7 @@ export { AdapterFactoryResolverService } from './infrastructure/adapters/adapter
 export { ConnectionTesterRegistryService } from './infrastructure/adapters/connection-tester-registry.service';
 export { WebhookProvisioningRegistryService } from './infrastructure/adapters/webhook-provisioning-registry.service';
 export { WebhookEventTranslatorRegistryService } from './infrastructure/adapters/webhook-event-translator-registry.service';
+export { InboundWebhookDecoderRegistryService } from './infrastructure/adapters/inbound-webhook-decoder-registry.service';
 export { EmailNormalizerRegistryService } from './infrastructure/adapters/email-normalizer-registry.service';
 export { ConnectionConfigShapeValidatorRegistryService } from './infrastructure/adapters/connection-config-shape-validator-registry.service';
 export { ConnectionCredentialsShapeValidatorRegistryService } from './infrastructure/adapters/connection-credentials-shape-validator-registry.service';
@@ -27,6 +28,7 @@ export { AdapterFactoryPort } from './domain/ports/adapter-factory.port';
 export { ConnectionTesterPort } from './domain/ports/connection-tester.port';
 export { WebhookProvisioningPort } from './domain/ports/webhook-provisioning.port';
 export { WebhookEventTranslatorPort } from './domain/ports/webhook-event-translator.port';
+export { InboundWebhookDecoderPort } from './domain/ports/inbound-webhook-decoder.port';
 export { EmailNormalizerPort } from './domain/ports/email-normalizer.port';
 export { ConnectionConfigShapeValidatorPort } from './domain/ports/connection-config-shape-validator.port';
 export { ConnectionCredentialsShapeValidatorPort } from './domain/ports/connection-credentials-shape-validator.port';
@@ -55,6 +57,11 @@ export {
   InboundEventDomain,
   InboundEventDomainValues,
 } from './domain/types/canonical-inbound-event.types';
+export {
+  InboundWebhookEnvelope,
+  DecodeResult,
+  WebhookVerifyResult,
+} from './domain/types/inbound-webhook-decoder.types';
 export {
   OAuthCredentialBlob,
   BuildAuthorizationUrlInput,

--- a/libs/core/src/integrations/infrastructure/adapters/inbound-webhook-decoder-registry.service.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/inbound-webhook-decoder-registry.service.ts
@@ -1,0 +1,38 @@
+/**
+ * Inbound Webhook Decoder Registry Service
+ *
+ * Holds `InboundWebhookDecoderPort` implementations keyed by `provider` (the
+ * `/webhooks/:provider/:connectionId` path segment) — ADR-021. The host
+ * webhook service resolves a connection's decoder by provider before dedup,
+ * falling back to the registered OpenLinker default decoder when none is
+ * registered (so PrestaShop/Allegro stay on the OL-HMAC + `WebhookRequestDto`
+ * path unchanged).
+ *
+ * Keyed by `provider`, not `adapterKey`, because signature + secret already
+ * resolve by `(provider, connectionId)` at the controller layer and
+ * `adapterKey` resolves only downstream — see ADR-021 / DESIGN-021 F1. Silent
+ * overwrite on duplicate key mirrors the sister registries; the host registers
+ * its default and plugins register exactly once at boot.
+ *
+ * @module libs/core/src/integrations/infrastructure/adapters
+ * @see {@link InboundWebhookDecoderPort} for the port interface
+ */
+import { Injectable } from '@nestjs/common';
+import type { InboundWebhookDecoderPort } from '../../domain/ports/inbound-webhook-decoder.port';
+
+@Injectable()
+export class InboundWebhookDecoderRegistryService {
+  private readonly decoders: Map<string, InboundWebhookDecoderPort> = new Map();
+
+  register(provider: string, decoder: InboundWebhookDecoderPort): void {
+    this.decoders.set(provider, decoder);
+  }
+
+  get(provider: string): InboundWebhookDecoderPort | undefined {
+    return this.decoders.get(provider);
+  }
+
+  has(provider: string): boolean {
+    return this.decoders.has(provider);
+  }
+}

--- a/libs/core/src/integrations/integrations.module.ts
+++ b/libs/core/src/integrations/integrations.module.ts
@@ -19,6 +19,7 @@ import { AdapterFactoryResolverService } from './infrastructure/adapters/adapter
 import { ConnectionTesterRegistryService } from './infrastructure/adapters/connection-tester-registry.service';
 import { WebhookProvisioningRegistryService } from './infrastructure/adapters/webhook-provisioning-registry.service';
 import { WebhookEventTranslatorRegistryService } from './infrastructure/adapters/webhook-event-translator-registry.service';
+import { InboundWebhookDecoderRegistryService } from './infrastructure/adapters/inbound-webhook-decoder-registry.service';
 import { EmailNormalizerRegistryService } from './infrastructure/adapters/email-normalizer-registry.service';
 import { ConnectionConfigShapeValidatorRegistryService } from './infrastructure/adapters/connection-config-shape-validator-registry.service';
 import { ConnectionCredentialsShapeValidatorRegistryService } from './infrastructure/adapters/connection-credentials-shape-validator-registry.service';
@@ -40,6 +41,7 @@ import {
   CONNECTION_TESTER_REGISTRY_TOKEN,
   WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
   WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
   EMAIL_NORMALIZER_REGISTRY_TOKEN,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -59,6 +61,7 @@ export {
   CONNECTION_TESTER_REGISTRY_TOKEN,
   WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
   WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
   EMAIL_NORMALIZER_REGISTRY_TOKEN,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -79,6 +82,7 @@ export {
     ConnectionTesterRegistryService,
     WebhookProvisioningRegistryService,
     WebhookEventTranslatorRegistryService,
+    InboundWebhookDecoderRegistryService,
     EmailNormalizerRegistryService,
     ConnectionConfigShapeValidatorRegistryService,
     ConnectionCredentialsShapeValidatorRegistryService,
@@ -115,6 +119,10 @@ export {
     {
       provide: WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
       useExisting: WebhookEventTranslatorRegistryService,
+    },
+    {
+      provide: INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
+      useExisting: InboundWebhookDecoderRegistryService,
     },
     {
       provide: EMAIL_NORMALIZER_REGISTRY_TOKEN,
@@ -157,6 +165,7 @@ export {
     CONNECTION_TESTER_REGISTRY_TOKEN,
     WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
     WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+    INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
     EMAIL_NORMALIZER_REGISTRY_TOKEN,
     CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
     CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -171,6 +180,7 @@ export {
     ConnectionTesterRegistryService,
     WebhookProvisioningRegistryService,
     WebhookEventTranslatorRegistryService,
+    InboundWebhookDecoderRegistryService,
     EmailNormalizerRegistryService,
     ConnectionConfigShapeValidatorRegistryService,
     ConnectionCredentialsShapeValidatorRegistryService,

--- a/libs/core/src/integrations/integrations.tokens.ts
+++ b/libs/core/src/integrations/integrations.tokens.ts
@@ -22,6 +22,9 @@ export const WEBHOOK_PROVISIONING_REGISTRY_TOKEN = Symbol('WebhookProvisioningRe
 export const WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN = Symbol(
   'WebhookEventTranslatorRegistryService',
 );
+export const INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN = Symbol(
+  'InboundWebhookDecoderRegistryService',
+);
 export const PLUGIN_REGISTRY_OPTIONS_TOKEN = Symbol('PluginRegistryOptions');
 export const EMAIL_NORMALIZER_REGISTRY_TOKEN = Symbol('EmailNormalizerRegistryService');
 export const CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN = Symbol(

--- a/libs/core/src/shipping/application/interfaces/shipment-status-sync.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/shipment-status-sync.service.interface.ts
@@ -20,4 +20,18 @@ export interface IShipmentStatusSyncService {
     connectionId: string,
     options: ShipmentStatusSyncOptions,
   ): Promise<ShipmentStatusSyncResult>;
+
+  /**
+   * Parcel-targeted refresh — the trigger half of the InPost webhook flow
+   * (#768, ADR-021). Resolves the shipment by carrier `providerShipmentId`
+   * (connection-scoped — a webhook on one connection must not refresh
+   * another's), re-reads authoritative status via `getTracking`, and applies
+   * the same per-shipment patch + OMP propagation the paged `sync()` does.
+   * No-op (logged) when the parcel id resolves to no shipment or a shipment on
+   * a different connection.
+   */
+  syncOneByProviderShipmentId(
+    connectionId: string,
+    providerShipmentId: string,
+  ): Promise<void>;
 }

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
@@ -390,4 +390,41 @@ describe('ShipmentStatusSyncService', () => {
       );
     });
   });
+
+  describe('syncOneByProviderShipmentId (#768 webhook-triggered refresh)', () => {
+    it('resolves the shipment by provider id and applies the re-read patch', async () => {
+      const s = makeShipment({ status: 'dispatched', trackingNumber: null });
+      shipments.findByProviderShipmentId.mockResolvedValue(s);
+      getTracking.mockResolvedValue(
+        snapshot({ status: 'delivered', deliveredAt: new Date('2026-05-28') }),
+      );
+
+      await service.syncOneByProviderShipmentId(CARRIER, 'prov-abc');
+
+      expect(getTracking).toHaveBeenCalledWith({ providerShipmentId: 'prov-abc' });
+      expect(shipments.update).toHaveBeenCalledWith(
+        s.id,
+        expect.objectContaining({ status: 'delivered' }),
+      );
+    });
+
+    it('is a no-op when no shipment resolves for the provider id', async () => {
+      shipments.findByProviderShipmentId.mockResolvedValue(null);
+
+      await service.syncOneByProviderShipmentId(CARRIER, 'prov-missing');
+
+      expect(getTracking).not.toHaveBeenCalled();
+      expect(shipments.update).not.toHaveBeenCalled();
+    });
+
+    it('skips (cross-connection guard) when the resolved shipment belongs to another connection', async () => {
+      const s = makeShipment({ connectionId: 'conn-other' });
+      shipments.findByProviderShipmentId.mockResolvedValue(s);
+
+      await service.syncOneByProviderShipmentId(CARRIER, 'prov-abc');
+
+      expect(getTracking).not.toHaveBeenCalled();
+      expect(shipments.update).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.ts
@@ -166,6 +166,40 @@ export class ShipmentStatusSyncService implements IShipmentStatusSyncService {
     };
   }
 
+  async syncOneByProviderShipmentId(
+    connectionId: string,
+    providerShipmentId: string,
+  ): Promise<void> {
+    const shipment = await this.shipments.findByProviderShipmentId(providerShipmentId);
+    if (!shipment) {
+      this.logger.warn(
+        `Webhook-triggered shipment refresh: no shipment for providerShipmentId=${providerShipmentId} (connection ${connectionId}) — ignoring.`,
+      );
+      return;
+    }
+    // Cross-connection guard (ADR-021): a webhook delivered for connection A
+    // must never refresh a shipment owned by connection B, even if provider
+    // shipment ids collide across multi-account connections (#727 v2).
+    if (shipment.connectionId !== connectionId) {
+      this.logger.warn(
+        `Webhook-triggered shipment refresh: providerShipmentId=${providerShipmentId} resolved to shipment ${shipment.id} on connection ${shipment.connectionId}, not the webhook's connection ${connectionId} — skipping.`,
+      );
+      return;
+    }
+
+    const carrierAdapter =
+      await this.integrations.getCapabilityAdapter<ShippingProviderManagerPort>(
+        connectionId,
+        SHIPPING_PROVIDER_MANAGER_CAPABILITY,
+      );
+    const snapshot = await carrierAdapter.getTracking({ providerShipmentId });
+
+    const { patch } = await this.buildPatchAndMaybePush(shipment, snapshot);
+    if (Object.keys(patch).length > 0) {
+      await this.shipments.update(shipment.id, patch);
+    }
+  }
+
   /**
    * Diff the snapshot against the shipment, attempt the OMP push under the
    * dispatched-gate (workaround #2), and return the patch. On push failure

--- a/libs/core/src/sync/application/services/__tests__/inbound-routing-policy.service.spec.ts
+++ b/libs/core/src/sync/application/services/__tests__/inbound-routing-policy.service.spec.ts
@@ -102,6 +102,39 @@ describe('InboundRoutingPolicyService', () => {
     );
   });
 
+  it('should route a shipment event to marketplace.shipment.syncByExternalId gated on ShippingProviderManager', async () => {
+    const outcome = await service.route(
+      event({ domain: 'shipment', eventType: 'tracking' }),
+      connection(['ShippingProviderManager']),
+      ['ShippingProviderManager'],
+      'evt-9'
+    );
+
+    expect(outcome.status).toBe('enqueued');
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobType: 'marketplace.shipment.syncByExternalId',
+        payload: { schemaVersion: 1, externalId: '42' },
+      })
+    );
+  });
+
+  it('should not enqueue a shipment event when ShippingProviderManager is not enabled', async () => {
+    const outcome = await service.route(
+      event({ domain: 'shipment', eventType: 'tracking' }),
+      connection([]),
+      ['ShippingProviderManager'],
+      'evt-9'
+    );
+
+    expect(outcome).toEqual({
+      status: 'ungated',
+      domain: 'shipment',
+      requiredCapability: 'ShippingProviderManager',
+    });
+    expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+  });
+
   it('should not enqueue and return ungated when the capability is supported but not enabled', async () => {
     const outcome = await service.route(
       event({ domain: 'order' }),

--- a/libs/core/src/sync/application/services/inbound-routing-policy.service.ts
+++ b/libs/core/src/sync/application/services/inbound-routing-policy.service.ts
@@ -20,7 +20,7 @@
  */
 import { Injectable, Inject } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
-import type { CanonicalInboundEvent, CoreCapability } from '@openlinker/core/integrations';
+import type { CanonicalInboundEvent } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import type { OrderFeedEventType } from '@openlinker/core/orders';
 import type { IInboundRoutingPolicyService } from '../interfaces/inbound-routing-policy.service.interface';
@@ -28,7 +28,13 @@ import type { RoutingOutcome } from '../types/inbound-routing-policy.types';
 import { JobEnqueuePort } from '../../domain/ports/job-enqueue.port';
 import { JOB_ENQUEUE_TOKEN } from '../../sync.tokens';
 import type { JobType, SyncJobRequest } from '../../domain/types/sync-job.types';
-import type { MarketplaceOrderSyncPayloadV1 } from '../../domain/types/marketplace-job-payloads.types';
+import type {
+  MarketplaceOrderSyncPayloadV1,
+  MarketplaceShipmentSyncByExternalIdPayloadV1,
+} from '../../domain/types/marketplace-job-payloads.types';
+
+/** Open-world shipping capability (#576) — the `shipment` domain's gate (#768). */
+const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
 import type {
   MasterInventorySyncByExternalIdPayloadV1,
   MasterProductSyncByExternalIdPayloadV1,
@@ -99,7 +105,11 @@ export class InboundRoutingPolicyService implements IInboundRoutingPolicyService
   private resolveRoute(
     event: CanonicalInboundEvent,
     sourceEventId: string
-  ): { jobType: JobType; requiredCapability: CoreCapability; payload: SyncJobRequest['payload'] } {
+  ): {
+    jobType: JobType;
+    requiredCapability: string;
+    payload: SyncJobRequest['payload'];
+  } {
     switch (event.domain) {
       case 'order':
         return {
@@ -132,6 +142,15 @@ export class InboundRoutingPolicyService implements IInboundRoutingPolicyService
             externalId: event.externalId,
             objectType: 'Product',
           } satisfies MasterProductSyncByExternalIdPayloadV1,
+        };
+      case 'shipment':
+        return {
+          jobType: 'marketplace.shipment.syncByExternalId',
+          requiredCapability: SHIPPING_PROVIDER_MANAGER_CAPABILITY,
+          payload: {
+            schemaVersion: 1,
+            externalId: event.externalId,
+          } satisfies MarketplaceShipmentSyncByExternalIdPayloadV1,
         };
       default: {
         // Exhaustive — `domain` is a closed union; this guards future additions.

--- a/libs/core/src/sync/application/types/inbound-routing-policy.types.ts
+++ b/libs/core/src/sync/application/types/inbound-routing-policy.types.ts
@@ -5,9 +5,18 @@
  *
  * @module libs/core/src/sync/application/types
  */
-import type { CoreCapability, InboundEventDomain } from '@openlinker/core/integrations';
+import type { InboundEventDomain } from '@openlinker/core/integrations';
 import type { JobType } from '../../domain/types/sync-job.types';
 
 export type RoutingOutcome =
   | { status: 'enqueued'; jobId: string; jobType: JobType }
-  | { status: 'ungated'; domain: InboundEventDomain; requiredCapability: CoreCapability };
+  | {
+      status: 'ungated';
+      domain: InboundEventDomain;
+      // Open-world capability (#576): the well-known `CoreCapability` set plus
+      // plugin-registered names like `ShippingProviderManager` (the `shipment`
+      // domain's gate, #768), which lives as a string constant across the
+      // shipping context rather than in `CoreCapabilityValues`. Typed `string`
+      // to match `AdapterMetadata.supportedCapabilities` (also `string[]`).
+      requiredCapability: string;
+    };

--- a/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
@@ -233,6 +233,26 @@ export interface MarketplaceShipmentStatusSyncPayloadV1 {
 }
 
 /**
+ * marketplace.shipment.syncByExternalId (#768, ADR-021)
+ *
+ * Parcel-targeted shipment refresh — the **trigger** half of the InPost
+ * webhook flow. An inbound `Shipment.Tracking` webhook routes here (via the
+ * `shipment` inbound domain) carrying the carrier's own parcel id; the handler
+ * re-reads authoritative status via the connection's `getTracking` and
+ * propagates terminal status + waybill to the destination OMP — the same
+ * per-shipment primitive the paged `marketplace.shipment.statusSync` poll
+ * (#838) uses, just keyed to one parcel instead of a rolling scan. The webhook
+ * payload's own status is never trusted (sandbox-gated catalogue); the re-read
+ * is the source of truth. `externalId` is the carrier `providerShipmentId`; the
+ * job's connection scope resolves the shipment (cross-connection-guarded).
+ */
+export interface MarketplaceShipmentSyncByExternalIdPayloadV1 {
+  schemaVersion: 1;
+  /** Carrier-native parcel id (`providerShipmentId`) to refresh. */
+  externalId: string;
+}
+
+/**
  * marketplace.fulfillment.statusSync (#834)
  *
  * Branch-1 (OMP-fulfilled) shipment status read-back. The handler pages OL

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -24,6 +24,7 @@ export const JobTypeValues = [
   'marketplace.offer.pollCreationStatus',
   'marketplace.offer.statusSync',
   'marketplace.shipment.statusSync',
+  'marketplace.shipment.syncByExternalId',
   'marketplace.fulfillment.statusSync',
   'master.product.syncByExternalId',
   'master.product.syncAll',

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -69,6 +69,7 @@ export {
   MarketplaceOfferPollCreationStatusPayloadV1,
   MarketplaceOfferStatusSyncPayloadV1,
   MarketplaceShipmentStatusSyncPayloadV1,
+  MarketplaceShipmentSyncByExternalIdPayloadV1,
   MarketplaceFulfillmentStatusSyncPayloadV1,
   OfferDescriptionTone,
 } from './domain/types/marketplace-job-payloads.types';

--- a/libs/integrations/allegro/src/allegro-integration.module.ts
+++ b/libs/integrations/allegro/src/allegro-integration.module.ts
@@ -33,6 +33,8 @@ import {
   WebhookProvisioningRegistryService,
   WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
   WebhookEventTranslatorRegistryService,
+  INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
+  InboundWebhookDecoderRegistryService,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionConfigShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -121,6 +123,8 @@ export class AllegroIntegrationModule implements OnModuleInit {
     private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
     @Inject(WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN)
     private readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService,
+    @Inject(INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN)
+    private readonly inboundWebhookDecoderRegistry: InboundWebhookDecoderRegistryService,
     @Inject(CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN)
     private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
     @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
@@ -185,6 +189,7 @@ export class AllegroIntegrationModule implements OnModuleInit {
       schedulerTaskRegistry: this.schedulerTaskRegistry,
       webhookProvisioningRegistry: this.webhookProvisioningRegistry,
       webhookEventTranslatorRegistry: this.webhookEventTranslatorRegistry,
+      inboundWebhookDecoderRegistry: this.inboundWebhookDecoderRegistry,
       connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
       connectionCredentialsShapeValidatorRegistry: this.connectionCredentialsShapeValidatorRegistry,
       oauthCompletionRegistry: this.oauthCompletionRegistry,

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for InpostInboundWebhookDecoderAdapter (#768, ADR-021).
+ */
+import { createHmac } from 'node:crypto';
+import { InpostInboundWebhookDecoderAdapter } from '../inpost-inbound-webhook-decoder.adapter';
+
+const SECRET = 'fdXbfU27DBNG6LuoHu@ThKl3';
+const TIMESTAMP = '2025-01-08T14:03:55.387Z';
+
+function sign(rawBody: Buffer, timestamp: string, secret: string): string {
+  const signed = Buffer.concat([Buffer.from(timestamp), Buffer.from('.'), rawBody]);
+  return createHmac('sha256', secret).update(signed).digest('base64');
+}
+
+describe('InpostInboundWebhookDecoderAdapter', () => {
+  let decoder: InpostInboundWebhookDecoderAdapter;
+
+  beforeEach(() => {
+    decoder = new InpostInboundWebhookDecoderAdapter();
+  });
+
+  describe('verify', () => {
+    it('should accept a correctly-signed payload and return the normalized timestamp', () => {
+      const rawBody = Buffer.from(JSON.stringify({ tracking_number: '6200000000001' }));
+      const result = decoder.verify({
+        rawBody,
+        secret: SECRET,
+        headers: {
+          'x-inpost-signature': sign(rawBody, TIMESTAMP, SECRET),
+          'x-inpost-timestamp': TIMESTAMP,
+        },
+      });
+      expect(result.ok).toBe(true);
+      expect(result.timestampMs).toBe(Date.parse(TIMESTAMP));
+    });
+
+    it('should reject a tampered signature', () => {
+      const rawBody = Buffer.from(JSON.stringify({ tracking_number: '6200000000001' }));
+      const result = decoder.verify({
+        rawBody,
+        secret: SECRET,
+        headers: {
+          'x-inpost-signature': sign(Buffer.from('different'), TIMESTAMP, SECRET),
+          'x-inpost-timestamp': TIMESTAMP,
+        },
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('should reject when signature or timestamp header is missing', () => {
+      const rawBody = Buffer.from('{}');
+      expect(decoder.verify({ rawBody, secret: SECRET, headers: {} }).ok).toBe(false);
+    });
+  });
+
+  describe('extractEnvelope', () => {
+    it('should route a Shipment.Tracking event with the parcel id as externalId', () => {
+      const rawBody = Buffer.from(JSON.stringify({ tracking_number: '6200000000001' }));
+      const result = decoder.extractEnvelope(rawBody, {
+        'x-inpost-topic': 'Shipment.Tracking',
+        'x-inpost-timestamp': TIMESTAMP,
+      });
+      expect(result.action).toBe('route');
+      if (result.action === 'route') {
+        expect(result.envelope.externalId).toBe('6200000000001');
+        expect(result.envelope.objectType).toBe('shipment');
+        expect(result.envelope.eventId).toBeTruthy();
+      }
+    });
+
+    it('should derive a deterministic eventId for the same parcel + timestamp', () => {
+      const rawBody = Buffer.from(JSON.stringify({ tracking_number: '6200000000001' }));
+      const headers = { 'x-inpost-topic': 'Shipment.Tracking', 'x-inpost-timestamp': TIMESTAMP };
+      const a = decoder.extractEnvelope(rawBody, headers);
+      const b = decoder.extractEnvelope(rawBody, headers);
+      if (a.action === 'route' && b.action === 'route') {
+        expect(a.envelope.eventId).toBe(b.envelope.eventId);
+      } else {
+        throw new Error('expected both to route');
+      }
+    });
+
+    it('should prefer an explicit event id when present', () => {
+      const rawBody = Buffer.from(
+        JSON.stringify({ id: 'evt_abc123', tracking_number: '6200000000001' }),
+      );
+      const result = decoder.extractEnvelope(rawBody, {
+        'x-inpost-topic': 'Shipment.Tracking',
+        'x-inpost-timestamp': TIMESTAMP,
+      });
+      if (result.action === 'route') {
+        expect(result.envelope.eventId).toBe('evt_abc123');
+      } else {
+        throw new Error('expected route');
+      }
+    });
+
+    it('should ignore (not reject) a non-tracking topic', () => {
+      const result = decoder.extractEnvelope(Buffer.from('{}'), {
+        'x-inpost-topic': 'Shipment.Something',
+      });
+      expect(result.action).toBe('ignore');
+    });
+
+    it('should reject malformed JSON', () => {
+      const result = decoder.extractEnvelope(Buffer.from('not json'), {
+        'x-inpost-topic': 'Shipment.Tracking',
+      });
+      expect(result.action).toBe('reject');
+    });
+
+    it('should reject a tracking event with no parcel identifier', () => {
+      const result = decoder.extractEnvelope(Buffer.from(JSON.stringify({ foo: 'bar' })), {
+        'x-inpost-topic': 'Shipment.Tracking',
+      });
+      expect(result.action).toBe('reject');
+    });
+  });
+});

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts
@@ -115,5 +115,13 @@ describe('InpostInboundWebhookDecoderAdapter', () => {
       });
       expect(result.action).toBe('reject');
     });
+
+    it('should reject a tracking event missing the timestamp header', () => {
+      const result = decoder.extractEnvelope(
+        Buffer.from(JSON.stringify({ tracking_number: '6200000000001' })),
+        { 'x-inpost-topic': 'Shipment.Tracking' },
+      );
+      expect(result.action).toBe('reject');
+    });
   });
 });

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts
@@ -100,8 +100,13 @@ export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoder
     }
 
     // A verified request always carries `x-inpost-timestamp` (it's inside the
-    // signed payload); fall back to now only for the type system's benefit.
-    const occurredAt = this.header(headers, TIMESTAMP_HEADER) ?? new Date().toISOString();
+    // signed payload), so its absence here means the body reached extract
+    // without passing verify — reject rather than fabricate a timestamp, keeping
+    // this a pure transform.
+    const occurredAt = this.header(headers, TIMESTAMP_HEADER);
+    if (!occurredAt) {
+      return { action: 'reject', reason: 'missing x-inpost-timestamp' };
+    }
     return {
       action: 'route',
       envelope: {

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts
@@ -1,0 +1,157 @@
+/**
+ * InPost Inbound Webhook Decoder Adapter (#768, ADR-021)
+ *
+ * Authenticates + decodes InPost ShipX `Shipment.Tracking` webhooks at the host
+ * ingress, keyed by `provider = 'inpost'`. The verify half uses InPost's HMAC
+ * scheme (base64 HMAC-SHA256 over `{x-inpost-timestamp}.{rawBody}`, header
+ * `x-inpost-signature`) — the shared secret OL generates and hands InPost,
+ * resolved by the host via `WebhookSecretProviderPort`. The extract half is a
+ * pure transform into the host's neutral envelope.
+ *
+ * Trigger model (ADR-021): the webhook is a low-latency nudge, never the source
+ * of truth. We read ONLY the parcel identifier from the body — never InPost's
+ * status enum (sandbox-gated catalogue, OQ-B3) — and route a parcel-targeted
+ * refresh that re-reads authoritative status via `getTracking`. So an imperfect
+ * payload degrades to a redundant re-read, never wrong state.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/adapters
+ */
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import type {
+  DecodeResult,
+  InboundWebhookDecoderPort,
+  WebhookVerifyResult,
+} from '@openlinker/core/integrations';
+
+const SIGNATURE_HEADER = 'x-inpost-signature';
+const TIMESTAMP_HEADER = 'x-inpost-timestamp';
+const TOPIC_HEADER = 'x-inpost-topic';
+const TRACKING_TOPIC = 'Shipment.Tracking';
+
+/**
+ * Candidate body fields carrying the parcel identifier, tried in order. InPost's
+ * exact `Shipment.Tracking` payload shape is not public (OQ-B3) — these are the
+ * documented-best-guess keys; the live field is confirmed during sandbox
+ * onboarding. Isolated here so confirming it is a one-line change, and because
+ * the re-read (not the payload) is authoritative the blast radius is a redundant
+ * `getTracking`, not incorrect state.
+ */
+const PARCEL_ID_CANDIDATE_PATHS: readonly string[][] = [
+  ['tracking_number'],
+  ['trackingNumber'],
+  ['shipment', 'tracking_number'],
+  ['payload', 'tracking_number'],
+];
+
+export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoderPort {
+  verify(input: {
+    rawBody: Buffer;
+    headers: Record<string, string>;
+    secret: string;
+  }): WebhookVerifyResult {
+    const signature = this.header(input.headers, SIGNATURE_HEADER);
+    const timestamp = this.header(input.headers, TIMESTAMP_HEADER);
+    if (!signature || !timestamp) {
+      return { ok: false };
+    }
+
+    const signedPayload = Buffer.concat([
+      Buffer.from(timestamp),
+      Buffer.from('.'),
+      input.rawBody,
+    ]);
+    const expected = createHmac('sha256', input.secret).update(signedPayload).digest('base64');
+
+    const provided = Buffer.from(signature);
+    const expectedBuf = Buffer.from(expected);
+    if (provided.length !== expectedBuf.length || !timingSafeEqual(provided, expectedBuf)) {
+      return { ok: false };
+    }
+
+    // InPost stamps an ISO-8601 timestamp (e.g. "2025-01-08T14:03:55.387Z"); the
+    // host replay-window check runs on the normalized epoch-ms we return.
+    const timestampMs = Date.parse(timestamp);
+    return { ok: true, timestampMs: Number.isNaN(timestampMs) ? undefined : timestampMs };
+  }
+
+  extractEnvelope(rawBody: Buffer, headers: Record<string, string>): DecodeResult {
+    const topic = this.header(headers, TOPIC_HEADER);
+    if (topic !== TRACKING_TOPIC) {
+      // Well-formed but not a tracking event (other topic / setup ping) —
+      // ack-and-ignore, don't 400 (avoids InPost retry storms on topics we
+      // don't route).
+      return { action: 'ignore', reason: `unhandled topic: ${topic ?? '(none)'}` };
+    }
+
+    let body: unknown;
+    try {
+      body = JSON.parse(rawBody.toString('utf8'));
+    } catch {
+      return { action: 'reject', reason: 'body is not valid JSON' };
+    }
+    if (typeof body !== 'object' || body === null) {
+      return { action: 'reject', reason: 'body is not a JSON object' };
+    }
+
+    const record = body as Record<string, unknown>;
+    const parcelId = this.firstString(record, PARCEL_ID_CANDIDATE_PATHS);
+    if (!parcelId) {
+      return { action: 'reject', reason: 'no parcel identifier in payload' };
+    }
+
+    // A verified request always carries `x-inpost-timestamp` (it's inside the
+    // signed payload); fall back to now only for the type system's benefit.
+    const occurredAt = this.header(headers, TIMESTAMP_HEADER) ?? new Date().toISOString();
+    return {
+      action: 'route',
+      envelope: {
+        // Dedup key — use a provider event id if present, else a deterministic
+        // hash of the parcel id + event timestamp so retries collapse and
+        // distinct events don't. Best-effort (the idempotent re-read is the
+        // correctness guarantee), so the eventId need only suppress obvious dupes.
+        eventId: this.deriveEventId(record, parcelId, occurredAt),
+        eventType: 'tracking',
+        occurredAt,
+        objectType: 'shipment',
+        externalId: parcelId,
+      },
+    };
+  }
+
+  private deriveEventId(
+    record: Record<string, unknown>,
+    parcelId: string,
+    occurredAt: string | undefined,
+  ): string {
+    const explicit = this.firstString(record, [['event_id'], ['eventId'], ['id']]);
+    if (explicit) {
+      return explicit;
+    }
+    const basis = `${parcelId}:${occurredAt ?? ''}`;
+    return `inpost-${createHash('sha256').update(basis).digest('hex').slice(0, 32)}`;
+  }
+
+  private header(headers: Record<string, string>, name: string): string | null {
+    return headers[name] ?? headers[name.toLowerCase()] ?? null;
+  }
+
+  private firstString(
+    record: Record<string, unknown>,
+    paths: readonly string[][],
+  ): string | null {
+    for (const path of paths) {
+      let cursor: unknown = record;
+      for (const key of path) {
+        if (typeof cursor !== 'object' || cursor === null) {
+          cursor = undefined;
+          break;
+        }
+        cursor = (cursor as Record<string, unknown>)[key];
+      }
+      if (typeof cursor === 'string' && cursor.length > 0) {
+        return cursor;
+      }
+    }
+    return null;
+  }
+}

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-webhook-event-translator.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-webhook-event-translator.adapter.ts
@@ -1,0 +1,34 @@
+/**
+ * InPost Webhook Event Translator Adapter (#768, ADR-015 / ADR-021)
+ *
+ * Downstream complement to the decoder: maps the host's neutral
+ * `InboundWebhookEvent` (already authenticated + enveloped by the decoder, then
+ * published to the bus) into a `CanonicalInboundEvent` the core
+ * `InboundRoutingPolicy` routes. InPost emits only the `shipment` domain; the
+ * routing policy turns that into `marketplace.shipment.syncByExternalId`.
+ *
+ * Total transform — returns `null` for object types it doesn't decode
+ * (→ dead-letter), never throws.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/adapters
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+import type {
+  CanonicalInboundEvent,
+  WebhookEventTranslatorPort,
+} from '@openlinker/core/integrations';
+
+export class InpostWebhookEventTranslatorAdapter implements WebhookEventTranslatorPort {
+  translate(event: InboundWebhookEvent): CanonicalInboundEvent | null {
+    if (event.objectType !== 'shipment') {
+      return null;
+    }
+    return {
+      domain: 'shipment',
+      externalId: event.externalId,
+      eventType: event.eventType,
+      occurredAt: event.occurredAt,
+      payload: event.payload,
+    };
+  }
+}

--- a/libs/integrations/inpost/src/inpost-plugin.ts
+++ b/libs/integrations/inpost/src/inpost-plugin.ts
@@ -17,6 +17,8 @@ import type { AdapterMetadata } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { createInpostShippingAdapter } from './application/inpost-adapter.factory';
 import { InpostConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/inpost-connection-config-shape-validator.adapter';
+import { InpostInboundWebhookDecoderAdapter } from './infrastructure/adapters/inpost-inbound-webhook-decoder.adapter';
+import { InpostWebhookEventTranslatorAdapter } from './infrastructure/adapters/inpost-webhook-event-translator.adapter';
 import { buildInpostSchedulerTasks } from './infrastructure/scheduler/inpost-scheduler-tasks';
 
 /**
@@ -48,6 +50,19 @@ export function createInpostPlugin(): AdapterPlugin {
       );
       // No credentials-shape validator: the `{ apiToken }` shape is enforced
       // at adapter construction time by the factory (deeper than this boundary).
+
+      // #768 / ADR-021 — third-party-native webhook ingress. The decoder
+      // (provider-keyed) authenticates + decodes InPost's `Shipment.Tracking`
+      // webhook at the host ingress; the translator (adapterKey-keyed) maps the
+      // decoded event onto the `shipment` inbound domain downstream.
+      host.inboundWebhookDecoderRegistry.register(
+        inpostAdapterManifest.platformType,
+        new InpostInboundWebhookDecoderAdapter(),
+      );
+      host.webhookEventTranslatorRegistry.register(
+        inpostAdapterManifest.adapterKey,
+        new InpostWebhookEventTranslatorAdapter(),
+      );
 
       // #772 — schedule the carrier-generic shipment-status poll (#838) for
       // InPost connections (webhook fallback). Drained only by the api's

--- a/libs/integrations/prestashop/src/prestashop-integration.module.ts
+++ b/libs/integrations/prestashop/src/prestashop-integration.module.ts
@@ -37,6 +37,8 @@ import {
   WebhookProvisioningRegistryService,
   WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
   WebhookEventTranslatorRegistryService,
+  INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
+  InboundWebhookDecoderRegistryService,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionConfigShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -109,6 +111,8 @@ export class PrestashopIntegrationModule implements OnModuleInit {
     private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
     @Inject(WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN)
     private readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService,
+    @Inject(INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN)
+    private readonly inboundWebhookDecoderRegistry: InboundWebhookDecoderRegistryService,
     @Inject(CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN)
     private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
     @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
@@ -168,6 +172,7 @@ export class PrestashopIntegrationModule implements OnModuleInit {
       schedulerTaskRegistry: this.schedulerTaskRegistry,
       webhookProvisioningRegistry: this.webhookProvisioningRegistry,
       webhookEventTranslatorRegistry: this.webhookEventTranslatorRegistry,
+      inboundWebhookDecoderRegistry: this.inboundWebhookDecoderRegistry,
       connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
       connectionCredentialsShapeValidatorRegistry: this.connectionCredentialsShapeValidatorRegistry,
       oauthCompletionRegistry: this.oauthCompletionRegistry,

--- a/libs/plugin-sdk/src/create-nest-adapter-module.spec.ts
+++ b/libs/plugin-sdk/src/create-nest-adapter-module.spec.ts
@@ -23,6 +23,7 @@ import {
   EMAIL_NORMALIZER_REGISTRY_TOKEN,
   WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
   WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
@@ -59,6 +60,7 @@ describe('createNestAdapterModule', () => {
     emailNormalizerRegistry: object;
     webhookProvisioningRegistry: object;
     webhookEventTranslatorRegistry: object;
+    inboundWebhookDecoderRegistry: object;
     connectionConfigShapeValidatorRegistry: object;
     connectionCredentialsShapeValidatorRegistry: object;
     oauthCompletionRegistry: object;
@@ -75,6 +77,7 @@ describe('createNestAdapterModule', () => {
       emailNormalizerRegistry: {},
       webhookProvisioningRegistry: {},
       webhookEventTranslatorRegistry: {},
+      inboundWebhookDecoderRegistry: {},
       connectionConfigShapeValidatorRegistry: {},
       connectionCredentialsShapeValidatorRegistry: {},
       oauthCompletionRegistry: {},
@@ -106,6 +109,10 @@ describe('createNestAdapterModule', () => {
         {
           provide: WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
           useValue: registries.webhookEventTranslatorRegistry,
+        },
+        {
+          provide: INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
+          useValue: registries.inboundWebhookDecoderRegistry,
         },
         {
           provide: CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,

--- a/libs/plugin-sdk/src/create-nest-adapter-module.ts
+++ b/libs/plugin-sdk/src/create-nest-adapter-module.ts
@@ -44,6 +44,8 @@ import {
   WebhookProvisioningRegistryService,
   WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
   WebhookEventTranslatorRegistryService,
+  INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
+  InboundWebhookDecoderRegistryService,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionConfigShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
@@ -110,6 +112,8 @@ export function createNestAdapterModule(options: CreateNestAdapterModuleOptions)
       private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
       @Inject(WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN)
       private readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService,
+      @Inject(INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN)
+      private readonly inboundWebhookDecoderRegistry: InboundWebhookDecoderRegistryService,
       @Inject(CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN)
       private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
       @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
@@ -150,6 +154,7 @@ export function createNestAdapterModule(options: CreateNestAdapterModuleOptions)
         schedulerTaskRegistry: this.schedulerTaskRegistry,
         webhookProvisioningRegistry: this.webhookProvisioningRegistry,
         webhookEventTranslatorRegistry: this.webhookEventTranslatorRegistry,
+        inboundWebhookDecoderRegistry: this.inboundWebhookDecoderRegistry,
         connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
         connectionCredentialsShapeValidatorRegistry:
           this.connectionCredentialsShapeValidatorRegistry,

--- a/libs/plugin-sdk/src/host-services.ts
+++ b/libs/plugin-sdk/src/host-services.ts
@@ -39,6 +39,7 @@ import type {
   EmailNormalizerRegistryService,
   WebhookProvisioningRegistryService,
   WebhookEventTranslatorRegistryService,
+  InboundWebhookDecoderRegistryService,
   ConnectionConfigShapeValidatorRegistryService,
   ConnectionCredentialsShapeValidatorRegistryService,
   OAuthCompletionRegistryService,
@@ -121,6 +122,16 @@ export interface HostServices {
    * poll-only (a stray webhook dead-letters as "no translator").
    */
   readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService;
+
+  /**
+   * Inbound-webhook-decoder registry (ADR-021). A plugin registers an
+   * `InboundWebhookDecoderPort` here, keyed by `provider`, to authenticate and
+   * decode its third-party-native webhook body (signature scheme + envelope +
+   * dedup `eventId`) before the host's shared dedup/publish pipeline. Absence
+   * means the connection's webhooks fall to the host default OL-HMAC +
+   * `WebhookRequestDto` decoder.
+   */
+  readonly inboundWebhookDecoderRegistry: InboundWebhookDecoderRegistryService;
 
   /**
    * Per-plugin `Connection.config` shape-validator registry (#587). A plugin

--- a/scripts/check-plugin-guide-quotes.mjs
+++ b/scripts/check-plugin-guide-quotes.mjs
@@ -18,7 +18,7 @@
  *      110; the link still resolves but lands on the wrong content.
  *
  *   3. **Boundary check** for the `HostServices` interface at
- *      `libs/plugin-sdk/src/host-services.ts:53-152`. Same shape.
+ *      `libs/plugin-sdk/src/host-services.ts:54-163`. Same shape.
  *
  * Both checks are deliberately strict: when they fire on a benign
  * refactor (e.g., new import above the interface), the human updates
@@ -68,9 +68,9 @@ const BOUNDARY_REFS = [
   {
     label: 'HostServices',
     sourceFile: 'libs/plugin-sdk/src/host-services.ts',
-    sourceStart: 53,
-    sourceEnd: 152,
-    guideLinkSubstring: 'host-services.ts:53-152',
+    sourceStart: 54,
+    sourceEnd: 163,
+    guideLinkSubstring: 'host-services.ts:54-163',
     expectedStart: /^export interface HostServices \{$/,
     expectedEnd: /^\}\s*$/,
   },


### PR DESCRIPTION
Closes #768.

## What & why
Real-time InPost shipment-status tracking via inbound webhooks — the low-latency **primary path** complementing the #772 poll backstop. Re-scoped off the issue's 2026-05-17 "bespoke handler parses status + propagates directly" wording onto OpenLinker's current architecture (#838 `ShipmentStatusSyncService`, #900/ADR-015 translate→route), and designed **trigger-based** per OL's webhook doctrine: the webhook is a nudge, never the source of truth.

End-to-end: `POST /webhooks/inpost/:connectionId` → InPost decoder (HMAC verify + parcel-id extract) → dedup/publish → translator → `InboundRoutingPolicy` (`shipment` domain) → `marketplace.shipment.syncByExternalId` → `ShipmentStatusSyncService.syncOneByProviderShipmentId` → re-reads authoritative status via `getTracking` and propagates terminal status + waybill to the destination OMP (#838). **InPost's status enum is never parsed** — sidesteps the sandbox-gated payload catalogue (OQ-B3); the re-read is authoritative.

## Design — ADR-021 (third-party-native inbound webhook ingestion)
The shared `/webhooks/:provider/:connectionId` controller was built for **OL-enveloped** events from OL's own modules (OL-HMAC + a rigid `WebhookRequestDto`). InPost is the first **third-party-native** webhook, so the controller becomes provider-agnostic via a per-provider **`InboundWebhookDecoderPort`** (combined `verify` + `extractEnvelope`, keyed by `provider`). OL-HMAC + `WebhookRequestDto` become the **registered default decoder** — so PrestaShop/Allegro are unchanged. Three-state decode (`route` / `ignore`→202 / `reject`→400) handles a third party's broader stream without retry-storms. See `docs/architecture/adrs/021-…` (+ `DESIGN-021` for the pressure-test).

## Commits (incremental, each green)
- A1 contract foundation + B core `shipment` routing (`be1f6569`)
- C InPost decoder + translator (`b93aa297`)
- review fixes — routing/service tests + decoder purity (`7da7b571`)
- DefaultWebhookDecoder (`8111cff4`)
- A2 host decoder-dispatch switch-over — feature live (`bb8b831a`)
- D FE webhook-setup runbook (`46794fd6`)

## How tested
`pnpm type-check`, full `pnpm test` (all packages), and full `pnpm test:integration` (48 suites / 254 tests / 1 known-skip) — **all green**. New unit coverage: InPost decoder (verify/extract/3-state), `shipment` routing-policy case, `syncOneByProviderShipmentId` (incl. cross-connection guard), `DefaultWebhookDecoder`, FE runbook. The `webhook-ingestion` int-spec (OL/PrestaShop path: signature-reject, dedup, replay, stale-timestamp) confirms the shared-path refactor preserves existing behavior.

## Deferred (intentional, documented)
- **Payload-of-record fast-path** (trust a signed terminal event to skip the re-read) — until InPost sandbox confirms the payload/status catalogue. The decoder's parcel-id field set is isolated + documented-best-guess for that confirmation.
- **Dedicated InPost HMAC int-spec** end-to-end — the unit decoder spec + OL int-spec + routing/service unit specs cover the mechanics; a follow-up int-spec would add end-to-end confidence.
- **Fuller InPost FE connection settings** (setup card, structured config, credentials, trigger config) — owned by #771; this PR ships only the webhook runbook affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)