### PR TITLE
docs(dx): add pnpm build step - getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,9 +71,10 @@ cp apps/api/.env.example apps/api/.env.local
 cp apps/worker/.env.example apps/worker/.env.local
 ```
 
-Run migrations, then start the API and the web app (in separate terminals):
+Build the workspace, run migrations, then start the API and the web app (in separate terminals):
 
 ```bash
+pnpm build
 pnpm --filter @openlinker/api migration:run
 pnpm start:dev:api       # http://localhost:3000
 pnpm start:dev:web       # http://localhost:4173


### PR DESCRIPTION
<!--
Thank you for contributing to OpenLinker!

Title: use Conventional Commits format — `feat(scope): subject`,
`fix(scope): subject`, `docs:`, `refactor:`, `test:`, `chore:`.
See CONTRIBUTING.md → Commits for the full type list.
-->

## Summary

<!-- 1–3 bullets: what changed and why. Focus on the why. -->

- Add `pnpm build` to the §2 setup sequence in `docs/getting-started.md`, before migrations and `start:dev:*` commands.
- Update the lead-in sentence so developers know to build the workspace first on a clean clone.
- Workspace packages (`libs/*`) expose runtime entry points under `dist/`; without an initial build, `pnpm start:dev:api` and `pnpm start:dev:worker` fail with missing-module errors for `@openlinker/*`.


## Related issues

<!-- One `Closes #N` per issue this PR resolves. Issues are closed
     automatically when the PR merges — do not close them manually. -->

Closes #869

## Test plan

<!-- How a reviewer verifies the change. Commands to run, paths to
     click through, edge cases to confirm. -->

- [x] Follow `docs/getting-started.md` §2 from a clean clone (or after removing `libs/*/dist` and `apps/*/dist`).
- [x] Confirm `pnpm build` completes successfully.
- [x] Confirm `pnpm start:dev:api` and `pnpm start:dev:worker` start without `Cannot find module '@openlinker/...'` errors.

## Quality gate

- [x] `pnpm lint` passes (zero errors)
- [x] `pnpm type-check` passes (zero errors)
- [x] `pnpm test` passes (all unit tests green)
- [x] *Optional, Docker required:* `pnpm test:integration` passes — needed
      only if you touched `apps/api/test/integration/**` or any plugin's
      `infrastructure/adapters/`.

## Migrations

- [x] No schema changes; migration box trivially satisfied.

## ADR

- [x] No architectural decision; ADR box trivially satisfied.

## DCO sign-off

> Sign off with `git commit -s`. 

---

<sub>By submitting this pull request, I confirm that my contributions
are made under the terms of the [Apache License 2.0](../LICENSE), and I
certify the [Developer Certificate of Origin](https://developercertificate.org/)
by signing off my commits.</sub>
