### PR TITLE
feat(shipping,dpd): DPD tracking via SOAP DPDInfoServices + worker registration (#965)

### DIFF
--- a/apps/api/test/integration/dpd-tracking.int-spec.ts
+++ b/apps/api/test/integration/dpd-tracking.int-spec.ts
@@ -1,0 +1,131 @@
+/**
+ * DPD Tracking Integration Test (#965, ADR-022)
+ *
+ * Proves the DPD tracking chain wired through real DI: a seeded DPD connection
+ * resolves the real `DpdShippingAdapter` via `IntegrationsService`
+ * (factory → credentials → SOAP client → mapper), and `getTracking` decodes a
+ * (mocked) DPD InfoServices `getEventsForWaybillV1` SOAP response into a neutral
+ * `TrackingSnapshot`. Only the outbound SOAP HTTP call is stubbed (global
+ * `fetch`); the resolution chain + envelope build + XML parse + status mapping
+ * are all real.
+ *
+ * @module apps/api/test/integration
+ */
+import { encryptWithKey, loadEncryptionKey } from '@openlinker/shared';
+import { IntegrationCredentialOrmEntity } from '@openlinker/core/integrations/orm-entities';
+import {
+  INTEGRATIONS_SERVICE_TOKEN,
+  type IIntegrationsService,
+} from '@openlinker/core/integrations';
+import type { ShippingProviderManagerPort } from '@openlinker/core/shipping';
+import { createTestConnection } from './helpers/test-connection.helper';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+
+const CRED_REF = 'dpd-tracking-cred';
+
+function soapResponse(body: string): Response {
+  return { ok: true, status: 200, text: () => Promise.resolve(body) } as unknown as Response;
+}
+
+function eventsEnvelope(rows: string): string {
+  return `<?xml version="1.0"?>
+<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+  <S:Body>
+    <ns2:getEventsForWaybillV1Response xmlns:ns2="http://events.dpdinfoservices.dpd.com.pl/">
+      <return><confirmId>abc=</confirmId>${rows}</return>
+    </ns2:getEventsForWaybillV1Response>
+  </S:Body>
+</S:Envelope>`;
+}
+
+describe('DPD Tracking Integration (#965)', () => {
+  let harness: IntegrationTestHarness;
+  const originalFetch = global.fetch;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    global.fetch = originalFetch;
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function seedDpdConnection(): Promise<string> {
+    const dataSource = harness.getDataSource();
+    const { key } = loadEncryptionKey(process.env);
+    await dataSource.getRepository(IntegrationCredentialOrmEntity).save(
+      dataSource.getRepository(IntegrationCredentialOrmEntity).create({
+        ref: CRED_REF,
+        platformType: 'dpd',
+        credentialsCiphertext: encryptWithKey(key, JSON.stringify({ login: 'test', password: 'secret' })),
+      }),
+    );
+    const connection = await createTestConnection(dataSource, {
+      platformType: 'dpd',
+      name: 'DPD Polska',
+      adapterKey: 'dpd.polska.rest.v1',
+      enabledCapabilities: ['ShippingProviderManager'],
+      credentialsRef: `db:${CRED_REF}`,
+      config: {
+        environment: 'sandbox',
+        payerFid: '1495',
+        senderAddress: {
+          name: 'Sklep ACME',
+          address: 'Magazynowa 1',
+          city: 'Warszawa',
+          postalCode: '00-001',
+          countryCode: 'PL',
+        },
+      },
+    });
+    return connection.id;
+  }
+
+  const resolveAdapter = (connectionId: string): Promise<ShippingProviderManagerPort> =>
+    harness
+      .getApp()
+      .get<IIntegrationsService>(INTEGRATIONS_SERVICE_TOKEN)
+      .getCapabilityAdapter<ShippingProviderManagerPort>(connectionId, 'ShippingProviderManager');
+
+  it('resolves the real DPD adapter and maps a delivered SOAP history to a snapshot', async () => {
+    const connectionId = await seedDpdConnection();
+    const fetchMock = jest.fn().mockResolvedValue(
+      soapResponse(
+        eventsEnvelope(
+          `<eventsList><businessCode>040101</businessCode><eventTime>2026-06-10T08:00:00</eventTime><waybill>WB1</waybill></eventsList>` +
+            `<eventsList><businessCode>190101</businessCode><eventTime>2026-06-11T14:30:00</eventTime><waybill>WB1</waybill></eventsList>`,
+        ),
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const adapter = await resolveAdapter(connectionId);
+    const snapshot = await adapter.getTracking({ providerShipmentId: 'WB1' });
+
+    expect(snapshot.status).toBe('delivered');
+    expect(snapshot.providerStatus).toBe('190101');
+    expect(snapshot.deliveredAt?.toISOString()).toBe('2026-06-11T12:30:00.000Z');
+
+    // The SOAP call hit the InfoServices host (not the REST shipment host).
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('dpdinfoservices');
+    expect(url).toContain('/DPDInfoServicesObjEventsService/DPDInfoServicesObjEvents');
+    expect(init.method).toBe('POST');
+    expect(init.body as string).toContain('<waybill>WB1</waybill>');
+  });
+
+  it('maps an empty event history to a generated snapshot', async () => {
+    const connectionId = await seedDpdConnection();
+    global.fetch = jest.fn().mockResolvedValue(soapResponse(eventsEnvelope(''))) as unknown as typeof fetch;
+
+    const adapter = await resolveAdapter(connectionId);
+    await expect(adapter.getTracking({ providerShipmentId: 'WB-NONE' })).resolves.toEqual({
+      status: 'generated',
+    });
+  });
+});

--- a/apps/worker/src/plugins.ts
+++ b/apps/worker/src/plugins.ts
@@ -33,6 +33,7 @@ import { AllegroIntegrationModule } from '@openlinker/integrations-allegro';
 import { AiIntegrationModule } from '@openlinker/integrations-ai';
 import { InpostIntegrationModule } from '@openlinker/integrations-inpost';
 import { WooCommerceIntegrationModule } from '@openlinker/integrations-woocommerce';
+import { DpdIntegrationModule } from '@openlinker/integrations-dpd-polska';
 
 export const workerPlugins: PluginEntry[] = [
   PrestashopIntegrationModule,
@@ -40,4 +41,8 @@ export const workerPlugins: PluginEntry[] = [
   AiIntegrationModule.register(),
   InpostIntegrationModule,
   WooCommerceIntegrationModule,
+  // #965: resolve the DPD `ShippingProviderManager` adapter when the worker
+  // runs `marketplace.shipment.statusSync` for DPD connections (tracking via
+  // SOAP DPDInfoServices, ADR-022). Scheduler runs api-side; worker only drains.
+  DpdIntegrationModule,
 ];

--- a/apps/worker/test/jest-integration.cjs
+++ b/apps/worker/test/jest-integration.cjs
@@ -67,5 +67,13 @@ module.exports = {
       __dirname,
       '../../../libs/integrations/inpost/src/$1',
     ),
+    '^@openlinker/integrations-dpd-polska$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/dpd-polska/src/index.ts',
+    ),
+    '^@openlinker/integrations-dpd-polska/(.*)$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/dpd-polska/src/$1',
+    ),
   },
 };

--- a/docs/architecture/adrs/018-dpd-polska-rest-api-over-soap.md
+++ b/docs/architecture/adrs/018-dpd-polska-rest-api-over-soap.md
@@ -34,7 +34,7 @@ Build the DPD Polska adapter against the **native REST `DPDServices` API** — J
 
 **Cons / trade-offs:**
 - REST **test-server credentials** live in the gated Swagger/redoc doc — needed for the Phase-0 spike (the public-internet OpenAPI JSON returns 403).
-- Tracking is a **separate service** (`DPD InfoServices`) regardless of transport — unchanged (#965).
+- Tracking is a **separate service** (`DPD InfoServices`) regardless of transport — unchanged (#965). **Resolved by [ADR-022](./022-dpd-tracking-soap-dpdinfoservices.md): tracking is SOAP `DPDInfoServices`; the DPD plugin is now dual-transport.**
 
 **Migration path:** none — this is a pre-implementation reversal of the draft; no code shipped against SOAP.
 

--- a/docs/architecture/adrs/022-dpd-tracking-soap-dpdinfoservices.md
+++ b/docs/architecture/adrs/022-dpd-tracking-soap-dpdinfoservices.md
@@ -1,0 +1,45 @@
+# ADR-022: DPD Polska tracking transport — SOAP DPDInfoServices (dual-transport plugin)
+
+- **Status**: Proposed
+- **Date**: 2026-06-11
+- **Authors**: @piotrswierzy
+
+> Completes the tracking-transport thread that [ADR-018](./018-dpd-polska-rest-api-over-soap.md) explicitly deferred ("Tracking is a separate service (DPD InfoServices) *regardless of transport* — unchanged (#965)"). This does **not** supersede ADR-018 — it leaves the REST shipment/label decision intact and only settles how tracking is read.
+
+## Context
+
+ADR-018 chose the native **REST `DPDServices`** API for DPD shipment creation + labels, and deliberately left tracking out of scope: DPD Polska has **no tracking operation in the shipment API**. Tracking lives in a **separate web service, `DPDInfoServices`**, confirmed from DPD's own `INFO_Services_v2` spec (obtained 2026-06-11, #965):
+
+- It is a **SOAP** service on its **own host** — `dpdinfoservices.dpd.com.pl` (PROD), distinct from the `dpdservices` shipment host and from the `gryf` documentation portal.
+- It exposes two interfaces: **`DPDInfoServicesObjEvents`** (parameters passed/returned uncoded) and **`DPDInfoServicesXmlEvents`** (same data base64-encoded, optionally ZIP-compressed).
+- The per-parcel operation is **`getEventsForWaybillV1(waybill, langCode, ALL|ONLY_LAST, authDataV1)`** — channel-less (§1.3) and idempotent on re-read.
+- Auth is `authDataV1 { login, password, channel }` carried **in the SOAP body** (not the `X-DPD-FID` header the REST shipment API uses); `channel` is empty for the waybill method.
+
+So the DPD plugin — REST-only after #962/#971 — must gain a second, SOAP transport to satisfy `ShippingProviderManagerPort.getTracking` (the #838 status-sync engine calls it per-shipment).
+
+## Decision
+
+1. **The DPD plugin becomes dual-transport**: REST `DPDServices` for shipment/labels/pickup (unchanged) + a minimal SOAP `DPDInfoServices` client for tracking. One adapter (`DpdShippingAdapter`), one connection, one credential set — two internal transports.
+2. **Use the `DPDInfoServicesObjEvents` interface** (uncoded), not `XmlEvents`. We read one waybill at a time, so the base64/ZIP codec `XmlEvents` adds buys nothing and costs complexity.
+3. **No SOAP library** — hand-build the `getEventsForWaybillV1` envelope as a template string and parse the response with **`fast-xml-parser`** (already a repo dependency; the PrestaShop plugin sets the precedent). It is a single operation; `node-soap`/`strong-soap` bring WSDL parsing we don't need plus a larger dependency/CVE surface.
+4. **Auth reuses the connection's existing `login`/`password`** (the factory already resolves them); `masterFid` is irrelevant to InfoServices. `channel` is sent empty for the waybill method.
+5. **Read-only / no `markEventsAsProcessed`.** That confirmation step exists only for the channel-based `getEventsForCustomer` *account-bulk pull*; a per-waybill query is an idempotent read (re-querying returns the same events — exactly what status polling wants).
+
+## Alternatives considered
+
+- **A SOAP library (`node-soap` / `strong-soap`).** Rejected: heavyweight WSDL machinery for one operation; larger dependency + security surface; we already ship `fast-xml-parser`.
+- **The `XmlEvents` interface.** Rejected: base64 + optional ZIP coding adds a codec layer with no benefit for single-waybill reads.
+- **A separate DPD-InfoServices connection / adapter.** Rejected: it's the same DPD account and the same `ShippingProviderManager.getTracking` capability — one adapter with two transports is the correct shape; a second connection would fork credentials + capability resolution for no gain.
+- **The `getEventsForCustomerV4` + `markEventsAsProcessedV1` account-pull** (DPD's "recommended scenario"). Deferred: it's an account-level bulk feed that doesn't map to the per-shipment `getTracking({ providerShipmentId })` contract. It's the natural **future batch optimization** if per-waybill fan-out becomes a throughput problem, but would need a core change to drive.
+
+## Consequences
+
+- One extra transport (SOAP/XML) to maintain inside a single plugin; isolated behind a `IDpdInfoSoapClient` port so the REST path is untouched.
+- **Per-waybill poll fan-out**: the #838 poll iterates a connection's DPD shipments and calls `getTracking` once each ⇒ N SOAP round-trips per batch. Mitigated by a conservative default cadence (~30 min) + a modest page limit; the batch op above is the escape hatch if needed.
+- **XML-decoding robustness burden**: single-element array coercion (`fast-xml-parser` collapses one `<eventsList>` to an object), offset-less `eventTime` (Europe/Warsaw wall-clock), and SOAP-Fault-on-HTTP-200 must all be handled in the client/mapper.
+- **Redirect/return stall**: on a `230402` redirect the parcel gets a *new* waybill; OL keeps polling the original `providerShipmentId`, so a redirected shipment's status stalls at `in-transit` (logged). Auto-following the new waybill is a documented follow-up, out of scope for #965.
+- The **demo InfoServices host** (`dpdinfoservicesdemo.dpd.com.pl`) is inferred from the demo-host naming pattern and carries a `// TODO confirm` until validated against the demo WSDL; PROD is confirmed.
+
+## Related
+
+- [ADR-018](./018-dpd-polska-rest-api-over-soap.md) — DPD shipment transport (REST). This ADR resolves the tracking-transport thread ADR-018 deferred; ADR-018's status is unchanged.

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -110,5 +110,6 @@ One pointer per section, identical format every time.
 | [ADR-019](./019-synchronous-bulk-shipment-dispatch.md) | Synchronous bulk shipment dispatch (loop the per-order seam) | Accepted | 2026-06-03 |
 | [ADR-020](./020-neutral-delivery-intent-shipping-dispatch.md) | Neutral delivery intent as the shipping-dispatch caller contract | Accepted | 2026-06-05 |
 | [ADR-021](./021-third-party-native-inbound-webhook-ingestion.md) | Third-party-native inbound webhook ingestion via a per-provider decoder | Proposed | 2026-06-08 |
+| [ADR-022](./022-dpd-tracking-soap-dpdinfoservices.md) | DPD Polska tracking transport: SOAP DPDInfoServices (dual-transport plugin) | Proposed | 2026-06-11 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-965-dpd-tracking.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-965-dpd-tracking.md
@@ -1,0 +1,53 @@
+# Pre-implement gate — #965 DPD tracking (DPDInfoServices SOAP + worker registration)
+
+**Plan:** `docs/plans/implementation-plan-965-dpd-tracking.md` · **Gate run:** 2026-06-11 · **Verdict: ✅ READY**
+
+No Critical contract breaks; no reuse collisions. One Warning (declare a direct dep) and four external-API open questions that are already flagged in the plan and rendered non-blocking by the unknown→`in-transit` fallback. The plan is correctly scoped to plugin-local additions over an existing, unchanged core/worker contract.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `ShippingProviderManagerPort.getTracking` | **EXISTS → implement (fill stub)** | `libs/core/src/shipping/domain/ports/shipping-provider-manager.port.ts:58`; current `dpd-shipping.adapter.ts` rejects with a `#965`-tagged stub. Signature unchanged. |
+| `TrackingSnapshot`, `ShipmentStatus` | **EXISTS → reuse** | `libs/core/src/shipping/domain/types/{tracking-snapshot,shipment-status}.types.ts` (exported via `@openlinker/core/shipping`). |
+| `ShipmentStatusSyncService` (+ `sync`, `syncOneByProviderShipmentId`) | **EXISTS → reuse unchanged** | `libs/core/src/shipping/application/services/shipment-status-sync.service.ts` (#838/#768). |
+| `marketplace.shipment.statusSync` job + poll handler + `syncByExternalId` handler | **EXISTS → reuse** | `apps/worker/src/sync/handlers/*` already registered in `sync-worker.module.ts`. **No new core/worker handler.** |
+| `SchedulerTaskConfig` + `host.schedulerTaskRegistry` | **EXISTS → reuse** | `@openlinker/core/sync`; InPost precedent `libs/integrations/inpost/src/infrastructure/scheduler/inpost-scheduler-tasks.ts`. |
+| `fast-xml-parser` | **EXISTS (repo dep) → reuse** | root `package.json` + **`libs/integrations/prestashop/package.json`** already uses it for XML (precedent + config reference). |
+| DPD SOAP client (`dpd-info-soap-client.{interface,}.ts`) | **NEW** | no SOAP client in `dpd-polska`; `DpdHttpClient` is REST/JSON-only (not reusable). |
+| `dpd-tracking.mapper.ts`, `dpd-tracking.types.ts`, `DPD_EVENT_CODE_STATUS` | **NEW** | none present. |
+| `DpdTrackingException` | **NEW** | existing exceptions are Config/Network/Unauthorized only. |
+| `dpd-scheduler-tasks.ts` + DPD scheduler registration | **NEW** | DPD registers no scheduler task today. |
+| DPD in `apps/worker/src/plugins.ts` + worker jest mapper | **NEW (additive)** | worker mapper DPD count = **0** (confirmed); plan adds both lines. |
+
+## Backward-compatibility findings
+
+- **No Critical.** No barrel symbol removed/renamed; `getTracking` port signature unchanged (stub→impl); no DTO change; no Symbol-token change.
+- **No migration.** The plan touches no `*.orm-entity.ts` — the `shipments` table + #838 entity already exist; tracking only reads + patches via the existing repo. ✅
+- **Warning — under-declared direct dependency.** The plan uses `fast-xml-parser` from inside `libs/integrations/dpd-polska`, but that package's `package.json` does **not** declare it (only root + prestashop do). It resolves today via hoisting, but per the monorepo under-declaration trap it should be added to `libs/integrations/dpd-polska/package.json` `dependencies` in this PR. **Migration path:** add `"fast-xml-parser": "^5.3.3"` (match the root pin).
+- **`check:invariants` — clean / addressed.** `check-jest-integration-mappers`: api side already has DPD (plugins.ts + 2 mapper lines); the plan adds the matching 2 worker lines (guard satisfied). `check-cross-context-imports`: plugin imports from `@openlinker/core/shipping` + `@openlinker/core/sync` top-level barrels only (types, capability const, `SchedulerTaskConfig`) — allowed shapes. No deep-barrel or service-interface violations.
+- **ADR number:** plan now targets **ADR-022** — confirmed the next free number (019/020/021 are taken: bulk-dispatch / delivery-intent / inbound-webhook). ✅
+
+## Open questions (external-API — flagged in plan, non-blocking to start)
+
+1. **Event-code catalogue** — exact DPD codes for `DPD_EVENT_CODE_STATUS` (from the gryf `/Documentation/DPD-InfoServices` spec). Mapper's unknown→`in-transit`+warn fallback makes the feature shippable; table must be verified before merge.
+2. **Operation version + response XML shape** — `getEventsForWaybillV1` vs `V3`; element names for the parser.
+3. **Service endpoint URL** — real DPDInfoServices SOAP host/path (NOT the gryf doc portal) for demo + prod.
+4. **Auth placement** — confirm `authDataV1` in the SOAP body vs HTTP Basic.
+
+> These shape the SOAP client's envelope + the mapper table but not the plan's structure. Recommended: implementation can scaffold all files now; fill (1)-(4) from the spec/WSDL before the PR merges. The mapper's fallback + the int-spec (mocked SOAP) keep the unverified table from being a correctness risk in the interim.
+
+**Bottom line:** READY to implement. Add `fast-xml-parser` to the DPD package's deps as part of the work, and treat the four API unknowns as fill-before-merge (not start-blockers).
+
+---
+
+## Re-gate — 2026-06-11 (plan v2, after DPD spec obtained) → ✅ STILL READY
+
+The plan was revised after the DPD `INFO_Services_v2` spec + event xlsx were obtained: all four open questions resolved, ADR renumbered **019 → 022** (confirmed next-free), auth refined to `authDataV1 { login, password, channel }` (not `masterFid`), endpoint pinned to the separate host `dpdinfoservices.dpd.com.pl` (ObjEvents / `getEventsForWaybillV1`). Re-verified the v2 assumptions against the live tree:
+
+- **No new contract surface.** `getTracking(input:{providerShipmentId}): Promise<TrackingSnapshot>` signature **unchanged** (still implementing, not altering) — `shipping-provider-manager.port.ts:58`. Factory `resolveCredentials` already returns `{ login, password }` (the SOAP client needs exactly these + a constant empty `channel`; `masterFid` is irrelevant) — no credential-shape change.
+- **No new `ShipmentStatus` value.** Mapping targets `generated|dispatched|in-transit|delivered|failed` all exist in `ShipmentStatusValues`. ✅
+- **New reuse opportunity:** core already defines `TerminalShipmentStatusValues = ['delivered','failed','cancelled']` (`shipment-status.types.ts`). The mapper's terminal-precedence concept overlaps; **prefer reusing it** for the OL-side terminal check rather than hardcoding (note: the *DPD-side* terminal set still comes from `Ending statuses.xlsx` — the two are distinct axes, OL-status-terminality vs DPD-event-terminality).
+- **Warning unchanged:** `fast-xml-parser` still absent from `libs/integrations/dpd-polska/package.json` (count = 0) — declare it during the work.
+
+Verdict unchanged: **READY**. Plan v2 is strictly more precise than v1 (resolved its own open questions); no Critical, the one Warning persists, demo-host URL is the only residual unknown (provisional + `// TODO confirm`, non-blocking).

--- a/docs/plans/implementation-plan-965-dpd-tracking.md
+++ b/docs/plans/implementation-plan-965-dpd-tracking.md
@@ -1,0 +1,114 @@
+# Implementation Plan — #965 DPD tracking via DPDInfoServices (SOAP) + worker registration
+
+**Issue:** #965 · **Parent spec:** `docs/specs/product-spec-961-dpd-polska-shipping.md` (§4.9 OQ-B4, US-7 / AC-7) · **Branch:** `965-dpd-tracking`
+
+---
+
+## Phase 1 — Understand the task
+
+**Goal.** Replace the coarse `getTracking` stub (shipped in #962, which rejects) with **real DPD tracking**, register the DPD plugin in the worker so status-sync runs, and propagate status + tracking to Allegro + PrestaShop (via the existing #838 sync pipeline).
+
+**Layer.** **Integration** (DPD plugin) + **DX/Worker** (plugin registration + scheduled poll). No core changes — the #838 `ShipmentStatusSyncService`, the `marketplace.shipment.statusSync` poll handler, and the `marketplace.shipment.syncByExternalId` webhook-trigger handler all already exist (the latter two landed via #838 + #768).
+
+**Transport decision (resolved — the crux of this issue).** The issue body assumes a SOAP `DPDInfoServices` WSDL; the shipped DPD adapter is **REST `DPDServices`** (ADR-018). Verified against ADR-018 (line 37: *"Tracking is a separate service (DPD InfoServices) regardless of transport — unchanged (#965)"*), the public DPD PHP wrapper (shipment-only — no tracking op), and DPD's own structure: **tracking lives only in the SOAP `DPDInfoServices` service (`getEventsForWaybillV*`); the REST API has no tracking op.** → The DPD plugin becomes **dual-transport**: REST `DPDServices` for shipment/labels (unchanged) + a **minimal SOAP `DPDInfoServices` client** for tracking.
+
+**Non-goals.** Courier/COD/pickup/bulk (shipped in #962/#964/#966/#971). No new core ports/types. No webhook ingestion for DPD (DPD has no tracking webhook — poll-only, unlike InPost #768). No COD settlement/reconciliation.
+
+---
+
+## Phase 2 — Research (reuse map)
+
+| Reuse | Path | Note |
+|---|---|---|
+| `getTracking` stub to replace | `libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts` (rejects today) | implement here |
+| Plugin descriptor / register(host) | `libs/integrations/dpd-polska/src/dpd-plugin.ts` | add scheduler-task registration |
+| Factory + cred resolution (`login`/`password`/`masterFid`) | `libs/integrations/dpd-polska/src/application/dpd-adapter.factory.ts` | construct + inject the SOAP client |
+| REST client (NOT reusable for SOAP) | `infrastructure/http/dpd-http-client.ts` | JSON/fetch only → new SOAP client needed |
+| `getTracking` port + `TrackingSnapshot` + `ShipmentStatus` | `libs/core/src/shipping/domain/{ports,types}` | unchanged — adapter returns `TrackingSnapshot` |
+| Status-sync engine (poll + webhook-trigger) | `libs/core/src/shipping/application/services/shipment-status-sync.service.ts` | unchanged — calls `getTracking` |
+| Worker poll + webhook-trigger handlers | `apps/worker/src/sync/handlers/marketplace-shipment-status-sync.handler.ts`, `…-sync-by-external-id.handler.ts` | already registered (#838/#768) |
+| Worker plugin list (DPD **absent**) | `apps/worker/src/plugins.ts` | add `DpdIntegrationModule` |
+| Worker jest mapper (#917) | `apps/worker/test/jest-integration.cjs` | add 2 lines for `@openlinker/integrations-dpd-polska` |
+| Scheduler-task pattern | `libs/integrations/inpost/src/infrastructure/scheduler/inpost-scheduler-tasks.ts` → registered via `host.schedulerTaskRegistry` | mirror for DPD |
+| XML parsing | `fast-xml-parser@^5.3.3` (already a dep) | **no SOAP lib** — hand-build the envelope, parse with fast-xml-parser |
+
+---
+
+## Phase 3 — Design
+
+**SOAP, no heavyweight lib.** DPDInfoServices is a single operation (`getEventsForWaybillV1`). Adding `soap`/`node-soap` (WSDL parsing, CVE history, large surface) is overkill. **Decision: hand-build the SOAP envelope as a template string and parse the response with the already-present `fast-xml-parser`** — MVP-appropriate, lean dependency surface. Captured as **ADR-022** (see § ADR below — it *completes* the tracking-transport thread ADR-018 deferred; it does not supersede ADR-018).
+
+**Auth.** DPDInfoServices `getEventsForWaybillV1` carries auth in the SOAP body (`authDataV1 { login, password, masterFid }`) — the **same** credentials the factory already resolves (`login`/`password` from `credentialsRef`, `masterFid` from config). No new credential shape.
+
+**Data flow (unchanged core; new adapter internals):**
+```
+worker poll (marketplace.shipment.statusSync, DPD cursor)  ─┐
+worker webhook-trigger (marketplace.shipment.syncByExternalId) ─┤ (no DPD webhook; poll-only)
+                                                            ▼
+ShipmentStatusSyncService → carrierAdapter.getTracking({ providerShipmentId })   [#838, unchanged]
+                                                            ▼
+DpdShippingAdapter.getTracking  →  DpdInfoSoapClient.getEventsForWaybill(waybill)
+                                 →  DpdTrackingMapper.toSnapshot(events)  →  TrackingSnapshot
+                                                            ▼
+                          #838 buildPatchAndMaybePush → propagate to Allegro + PrestaShop
+```
+
+**Event-code mapping.** `getEventsForWaybill` returns an event list (status code + timestamp). The mapper picks the latest event, maps its DPD code → `ShipmentStatus` (`generated | dispatched | in-transit | delivered | failed`), sets `deliveredAt`/`dispatchedAt` from event timestamps, records the raw code in `providerStatus`, and **degrades unknown codes to `in-transit` with a `logger.warn`** (AC-3). ⚠️ The exact DPD event-code catalogue lives in the gated `DPDInfoServices` spec (gryf portal `/Documentation/DPD-InfoServices`) — see Open Questions; the table is seeded conservatively and the unknown→`in-transit` fallback keeps the mapper correct-by-construction until verified.
+
+---
+
+## Phase 4 — Step-by-step plan
+
+1. **ADR-022** `docs/architecture/adrs/022-dpd-tracking-soap-dpdinfoservices.md` (+ README row): scoped to **transport mechanics**, NOT REST-vs-SOAP (ADR-018 owns that). **Context** = ADR-018 deferred tracking transport; #965 finds it's SOAP-only → the DPD plugin is now dual-transport. **Decision** = (a) dual-transport DPD plugin (REST shipment + SOAP tracking); (b) the **ObjEvents** interface (uncoded) over **XmlEvents** (base64 + optional ZIP); (c) hand-built SOAP envelope + `fast-xml-parser` (no `soap` lib); (d) auth reuses the connection's `login`/`password` (channel-less waybill method). **Alternatives rejected** = `node-soap`/`strong-soap` (heavy, WSDL parsing we don't need, CVE surface); the **XmlEvents** interface (smaller payloads but adds base64/zip codec complexity for no real gain on per-waybill reads); a *separate* DPD-InfoServices connection/adapter (same account + same `ShippingProviderManager.getTracking` capability ⇒ one adapter, two transports is correct). **Consequences** = one extra transport to maintain in a single plugin; per-waybill poll fan-out (no batch on the per-shipment contract); XML-decoding robustness burden (single-element array coercion, offset-less timestamps); the redirect-stall limitation (Step 4). Status **Proposed**, **Related to ADR-018** (not superseding — add a one-line "tracking transport resolved by ADR-022" note to ADR-018's line 37). **AC:** ADR present + README index row; ADR-018 unchanged in status.
+
+2. **Tracking types** `libs/integrations/dpd-polska/src/domain/types/dpd-tracking.types.ts`: `DpdWaybillEvent { code: string; description?: string; occurredAt?: string }`, the `DPD_EVENT_CODE_STATUS` map (`as const`, seeded + `// VERIFY against DPDInfoServices spec`), and `eventsSelectType` constant. **AC:** `as const` union pattern; no `any`; file header.
+
+3. **SOAP client port + impl**
+   - `infrastructure/http/dpd-info-soap-client.interface.ts` — `getEventsForWaybill(input: { waybill: string }): Promise<DpdWaybillEvent[]>`.
+   - `infrastructure/http/dpd-info-soap-client.ts` — `fetch` POST `text/xml; charset=utf-8` to the **DPDInfoServicesObjEvents** endpoint, hand-built `getEventsForWaybillV1` envelope (namespace `http://events.dpdinfoservices.dpd.com.pl/`) embedding `waybill` + `langCode='EN'` + `eventsSelectType='ALL'` + `authDataV1 { login, password, channel: '' }` (**not** masterFid — channel is empty for the waybill method); parse with `fast-xml-parser` configured `removeNSPrefix: true` (response is `ns2:`-namespaced; don't depend on the server's prefix) **and `isArray: (name) => name === 'eventsList'`** — fast-xml-parser collapses a **single** `<eventsList>` to an object (not a 1-element array), so without this a one-event waybill breaks the mapper; belt-and-braces, the client also coerces `Array.isArray(x) ? x : [x]`. Extract `<eventsList>` items → `{ businessCode, eventTime, description, newWaybill: eventDataList/value }`.
+     - **Never log the request body** — the SOAP envelope carries `login`/`password` in the body (unlike the REST client's header). Log only endpoint + waybill + HTTP status + latency. Reuse the REST client's retry/timeout shape (read-only → retryable on transient).
+     - **SOAP Fault arrives as HTTP 200** (not 4xx/5xx): the client MUST inspect the parsed body for a `Fault` element regardless of HTTP status. Auth faults → `DpdUnauthorizedException`; other faults → a new `domain/exceptions/dpd-tracking.exception.ts` (`DpdTrackingException`); transport/timeout → `DpdNetworkException`. Relying on HTTP status alone would treat faults as success.
+     - **XML-escape every interpolated value** (waybill + creds) via a small `escapeXml()` helper — the envelope is a hand-built template string, so the waybill (external input) is an injection vector. Helper gets its own unit test.
+     **AC:** interface/impl split; no secrets logged; Fault-on-200 mapped to a domain exception; unknown-shape responses raise a domain exception, never `any`; `escapeXml` unit-tested.
+
+4. **Tracking mapper** `infrastructure/mappers/dpd-tracking.mapper.ts` — `toSnapshot(events: DpdWaybillEvent[]): TrackingSnapshot`. **Event-selection semantics (define explicitly — this is the mapper's core contract + its test spec):** sort events by `eventTime` ascending; the **status** derives from the most-recent event, BUT a **terminal state wins if present anywhere in the history** — i.e. if any event maps to a terminal OL status (reuse core `TerminalShipmentStatusValues` = `delivered`/`failed`/`cancelled`), that is the snapshot status even if a later non-terminal event exists (DPD histories can be non-monotonic; a parcel doesn't "un-deliver"). Among multiple terminal events, the latest by timestamp wins (`failed` after `delivered` ⇒ `failed`). Missing/equal timestamps fall back to array order. Set `deliveredAt`/`dispatchedAt` from the matching events' timestamps; `providerStatus` = raw code of the selected event; empty list → `generated`; unknown code (not terminal) → `in-transit` + `logger.warn`.
+   - **Timezone:** DPD `eventTime` is offset-less (`2021-01-08T11:18:52.122` = `Europe/Warsaw` wall-clock). Parse deliberately as Warsaw-local → UTC `Date` (don't pass the bare string to `new Date()`, which parses offset-less ISO as UTC in V8 → a 1–2 h error on `dispatchedAt`/`deliveredAt`). A small `parseDpdEventTime()` helper + a unit test asserting the resolved instant.
+   - **Redirect/return limitation (`230402`):** map → `in-transit` + capture `newWaybill` from `eventDataList/value`, and `logger.warn` (`DPD redirected {old}→{new}; OL keeps polling {old} — auto-follow out of scope for #965`). The shipment's `providerShipmentId` stays the original waybill, so a redirected parcel's status **stalls at in-transit** (the old number stops getting events). Accepted v1 limitation — auto-follow (rewrite `providerShipmentId` to the new waybill) is a documented follow-up, not silent.
+   **AC:** pure; covers delivered / in-transit / unknown / empty / `delivered-then-failed` / unordered-input / single-event / redirect-with-new-waybill / timezone-correct instant.
+
+5. **Implement `getTracking`** in `dpd-shipping.adapter.ts` — replace the stub: call the SOAP client, map, return `TrackingSnapshot`. Adapter constructor now also takes the SOAP client. **AC:** stub + `ShippingProviderRejectionException` removed; no behaviour change to shipment/label methods.
+
+6. **Factory wiring** `application/dpd-adapter.factory.ts` — construct `DpdInfoSoapClient` with the connection's `login`/`password` (channel `''`; **not** masterFid) + endpoint from a new `DPD_INFO_BASE_URLS[environment]` constant: prod `https://dpdinfoservices.dpd.com.pl/DPDInfoServicesObjEventsService/DPDInfoServicesObjEvents`, demo `https://dpdinfoservicesdemo.dpd.com.pl/DPDInfoServicesObjEventsService/DPDInfoServicesObjEvents`. Inject into the adapter. ⚠️ InfoServices is its **own host** (`dpdinfoservices.dpd.com.pl`) — distinct from the `dpdservices` shipment host AND the `gryf` doc portal. **AC:** demo vs prod resolved from `config.environment`; auth = `login`/`password` (no masterFid); demo host carries a `// TODO confirm demo WSDL` note (the one residual unknown).
+
+7. **Scheduler poll** `infrastructure/scheduler/dpd-scheduler-tasks.ts` (mirror InPost) — `buildDpdSchedulerTasks(): SchedulerTaskConfig[]` → `taskId: 'dpd-shipment-status-sync'`, `platformType: 'dpd'`, `jobType: 'marketplace.shipment.statusSync'`, env-gated cron (default conservative, e.g. every 30 min), cursor `dpd.shipmentStatus.scanOffset`. Register in `dpd-plugin.ts` `register(host)` via `host.schedulerTaskRegistry.register(task)`.
+   - **Fan-out is per-waybill** (a chosen trade-off, not a surprise): `getEventsForWaybillV1` is single-waybill, and `ShipmentStatusSyncService.sync(connectionId, {limit, offset})` iterates OL's DPD shipments calling `getTracking` once each → **N SOAP round-trips per poll batch**. Keep the default cron conservative + the page `limit` modest to stay under DPD rate limits. Check the WSDL for a **multi-waybill/batch op** — if one exists, note it as a **future optimization** (the core `getTracking({providerShipmentId})` contract is single-shipment, so a batch op can't be wired without a core change — out of scope for #965; record it, don't silently ignore it).
+   **AC:** env-gated (off unless enabled); idempotency key per InPost precedent; conservative default cadence documented.
+
+8. **Worker registration** — `apps/worker/src/plugins.ts`: add `DpdIntegrationModule`. `apps/worker/test/jest-integration.cjs`: add the two `@openlinker/integrations-dpd-polska` mapper lines (#917). **AC:** `pnpm --filter @openlinker/worker … check-jest-integration-mappers` passes; worker boots with DPD.
+
+9. **Tests** — `dpd-info-soap-client.spec.ts` (envelope build + parse + fault/401 mapping, mocked fetch), `dpd-tracking.mapper.spec.ts` (each status + unknown fallback + empty), `dpd-shipping.adapter.spec.ts` (getTracking happy + SOAP-fault paths), `dpd-scheduler-tasks.spec.ts` (env-gate on/off). Update `testing/fake-dpd-shipping.adapter.ts` `getTracking` (currently throws) to return a seeded snapshot + `seedTracking()` helper. **AC:** ports mocked, not `fetch`; adapter coverage ≥70%.
+
+10. **DPD tracking int-spec** (promoted from optional) — mirror the InPost #768 int-spec: seed a DPD shipment + connection → run the `marketplace.shipment.statusSync` poll path → mocked SOAP response → assert the shipment status is patched. De-risks the worker-registration + cursor wiring (adding a worker plugin ripples into worker int-specs — the manifest-capability lesson). **AC:** SOAP transport mocked (not real DPD); status patch asserted against the DB.
+
+11. **Quality gate** — `pnpm lint && pnpm type-check && pnpm test`; full `pnpm test:integration` before PR.
+
+---
+
+## Phase 5 — Validate
+
+- **Architecture:** Integration-only + worker wiring; no CORE↔Integration boundary crossing; SOAP client behind a port (interface/impl split); adapter implements the existing `ShippingProviderManagerPort.getTracking` contract unchanged.
+- **Naming:** `*.interface.ts` / `*.ts` / `*.mapper.ts` / `*.types.ts` / `*.spec.ts`; `as const` unions; `UPPER_SNAKE_CASE` constants.
+- **Security:** creds resolved via `CredentialsResolverPort` (never hardcoded); auth fields never logged; SOAP body built with explicit XML-escaping of the waybill (the only external input) to avoid envelope injection.
+- **Testing:** unit-mock the SOAP transport; mapper + fallback fully covered.
+
+### Resolved API facts (from DPD `INFO_Services_v2` spec + `Events`/`Ending statuses` xlsx, obtained 2026-06-11)
+
+All four pre-implement open questions are now **RESOLVED**:
+
+1. **Event-code catalogue** ✅ — full `businessCode → group/description` list (`DPD Infoservices Events_22-05-2026.xlsx`) + the 20 **terminal** codes (`Ending statuses.xlsx`). Mapping rule for `DPD_EVENT_CODE_STATUS`:
+   - **Terminal-precedence** (any event `businessCode` ∈ ending-statuses): `1901xx`/`1902xx` (*Doręczona / delivered*) → **delivered**; `230403`/`230408` (*Zwrot / return to sender*) → **failed**; `230402` (*Przekierowana / redirect*) → **in-transit** + capture the new waybill from `eventDataList/value`; any other terminal code → **failed**.
+   - **Non-terminal by group/prefix**: `030103` (registered) → **generated**; `040101/040102`, `500500` (collected by courier) → **dispatched**; `170xxx` (out for delivery), `0501xx/120xxx/160xxx/230101/320xxx/330xxx/450xxx` (hub/depot/customs/sort), `5001xx/5002xx` (transit abroad) → **in-transit**; `040200-040605` (failed pickup/reception) → **generated** (pre-dispatch); `200xxx` (undelivered *attempt*, non-terminal) → **in-transit**; unknown → **in-transit** + `logger.warn`.
+2. **Operation + request** ✅ — `getEventsForWaybillV1` on the **DPDInfoServicesObjEvents** interface (object/uncoded — not the base64/zip XmlEvents). Params: `waybill`, two-letter `langCode` (`'EN'`), `eventsSelectType` = **`ALL`** (full history — needed for terminal-precedence + dispatched/delivered timestamps), `authDataV1`. Channel-less (§1.3) + idempotent on re-read ⇒ **no `markEventsAsProcessed`** (that's only the channel-based `getEventsForCustomer` pull — the future batch path). Response: `getEventsForWaybillV1Response` → `<return>` → repeated `<eventsList>` with `businessCode`, `eventTime`, `description`, `eventDataList/value`, `waybill`.
+3. **Endpoint** ✅ — separate host `dpdinfoservices.dpd.com.pl` (NOT gryf — the doc portal — and NOT the `dpdservices` shipment host). **PROD**: `https://dpdinfoservices.dpd.com.pl/DPDInfoServicesObjEventsService/DPDInfoServicesObjEvents`. **Demo**: `https://dpdinfoservicesdemo.dpd.com.pl/…` (by the demo-host naming pattern — *the one residual unknown*; confirm against the demo WSDL before relying on the demo path). SOAP namespace `http://events.dpdinfoservices.dpd.com.pl/`.
+4. **Auth** ✅ — `authDataV1 { login, password, channel }` in the SOAP body (NOT `masterFid`/`X-DPD-FID`; channel **empty** for the waybill method). The factory already resolves `login`/`password`; `masterFid` is irrelevant to InfoServices.
+   - **Residual note (non-blocking):** InfoServices auth is LDAP-scoped and *may* be a distinct DPD account from the shipment creds. Default to reusing the connection's `login`/`password`; if DPD issues separate InfoServices creds, that's a future config addition. The `DeniedAccessWSException` SOAP Fault surfaces a mismatch clearly at runtime.

--- a/libs/integrations/dpd-polska/package.json
+++ b/libs/integrations/dpd-polska/package.json
@@ -34,7 +34,8 @@
     "@openlinker/plugin-sdk": "workspace:*",
     "@openlinker/shared": "workspace:*",
     "class-transformer": "0.5.1",
-    "class-validator": "0.14.1"
+    "class-validator": "0.14.1",
+    "fast-xml-parser": "^5.3.3"
   },
   "peerDependencies": {
     "@nestjs/common": "^10.0.0"

--- a/libs/integrations/dpd-polska/src/application/dpd-adapter.factory.ts
+++ b/libs/integrations/dpd-polska/src/application/dpd-adapter.factory.ts
@@ -19,6 +19,7 @@ import { DpdEnvironmentValues } from '../domain/types/dpd-config.types';
 import type { DpdCredentials } from '../domain/types/dpd-credentials.types';
 import { DpdShippingAdapter } from '../infrastructure/adapters/dpd-shipping.adapter';
 import { DpdHttpClient } from '../infrastructure/http/dpd-http-client';
+import { DpdInfoSoapClient } from '../infrastructure/http/dpd-info-soap-client';
 
 // OQ-3 (#962): test is credentials-gated, not host-gated — both environments
 // resolve to the same DPDServices host today. Split here if a sandbox host
@@ -26,6 +27,15 @@ import { DpdHttpClient } from '../infrastructure/http/dpd-http-client';
 const BASE_URLS: Readonly<Record<DpdEnvironment, string>> = {
   sandbox: 'https://dpdservices.dpd.com.pl',
   production: 'https://dpdservices.dpd.com.pl',
+};
+
+// DPD InfoServices SOAP tracking endpoint (#965 / ADR-022). A SEPARATE host
+// from the REST shipment API above — `dpdinfoservices.dpd.com.pl` (PROD,
+// confirmed from INFO_Services_v2 §1.4), ObjEvents interface. The demo host
+// follows the `…demo…` naming pattern; // TODO confirm against the demo WSDL.
+const INFO_BASE_URLS: Readonly<Record<DpdEnvironment, string>> = {
+  sandbox: 'https://dpdinfoservicesdemo.dpd.com.pl/DPDInfoServicesObjEventsService/DPDInfoServicesObjEvents',
+  production: 'https://dpdinfoservices.dpd.com.pl/DPDInfoServicesObjEventsService/DPDInfoServicesObjEvents',
 };
 
 export async function createDpdShippingAdapter(
@@ -39,7 +49,13 @@ export async function createDpdShippingAdapter(
     password: credentials.password,
     masterFid: config.masterFid,
   });
-  return new DpdShippingAdapter(client, config);
+  // InfoServices tracking auth is `login`/`password` in the SOAP body (channel
+  // empty for the waybill method) — masterFid is shipment-only (ADR-022).
+  const infoClient = new DpdInfoSoapClient(INFO_BASE_URLS[config.environment], {
+    login: credentials.login,
+    password: credentials.password,
+  });
+  return new DpdShippingAdapter(client, config, infoClient);
 }
 
 function extractConfig(connection: Connection): DpdConnectionConfig {

--- a/libs/integrations/dpd-polska/src/domain/exceptions/dpd-tracking.exception.ts
+++ b/libs/integrations/dpd-polska/src/domain/exceptions/dpd-tracking.exception.ts
@@ -1,0 +1,20 @@
+/**
+ * DPD Tracking Exception
+ *
+ * Thrown for DPD InfoServices SOAP failures that aren't auth (`401`/SOAP
+ * `DeniedAccessWSException` → `DpdUnauthorizedException`) or transient transport
+ * (`DpdNetworkException`): a SOAP `<Fault>` business error, or a structurally
+ * unparseable / unexpected response body. Keeps tracking failures distinct from
+ * the shipment-side rejection vocabulary.
+ *
+ * @module libs/integrations/dpd-polska/src/domain/exceptions
+ */
+export class DpdTrackingException extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, { cause });
+    this.name = 'DpdTrackingException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DpdTrackingException);
+    }
+  }
+}

--- a/libs/integrations/dpd-polska/src/domain/types/dpd-tracking.types.ts
+++ b/libs/integrations/dpd-polska/src/domain/types/dpd-tracking.types.ts
@@ -1,0 +1,42 @@
+/**
+ * DPD Polska Tracking Types
+ *
+ * Neutral shapes for the DPD InfoServices `getEventsForWaybillV1` flow (#965,
+ * ADR-022). `DpdWaybillEvent` is the post-parse representation of one
+ * `<eventsList>` entry; the SOAP client maps the raw XML to it and the
+ * tracking mapper folds a list of them into a `TrackingSnapshot`.
+ *
+ * @module libs/integrations/dpd-polska/src/domain/types
+ */
+
+/**
+ * One DPD waybill event (a parsed `<eventsList>` entry).
+ *
+ * `eventTime` is the DPD wire value — an **offset-less** ISO string in
+ * `Europe/Warsaw` wall-clock (e.g. `2014-11-26T11:39:39`); the mapper converts
+ * it to a proper instant, never `new Date(raw)` directly.
+ */
+export interface DpdWaybillEvent {
+  /** DPD 6-digit `businessCode` (the status code the mapper classifies). */
+  businessCode: string;
+  /** Offset-less `Europe/Warsaw` timestamp string, when present. */
+  eventTime?: string;
+  /** Human description, when the response carries one (diagnostics only). */
+  description?: string;
+  /**
+   * Raw `eventDataList/value` strings for this event. For redirect/return codes
+   * (`230402` / `230403` / `230408`) the first value is the **new tracking
+   * number**; for other events it's incidental (signatory name, etc.). The
+   * mapper interprets it per business code — the transport just passes it
+   * through. OL keeps polling the original waybill (auto-follow is out of scope
+   * for #965 — see ADR-022).
+   */
+  eventData?: string[];
+}
+
+/** `EventsSelectTypeEnum` — full history (vs `ONLY_LAST`). We need history for
+ * terminal-precedence + dispatched/delivered timestamps. */
+export const DPD_EVENTS_SELECT_ALL = 'ALL';
+
+/** Two-letter description language requested from DPD. */
+export const DPD_EVENT_LANGUAGE = 'EN';

--- a/libs/integrations/dpd-polska/src/dpd-plugin.ts
+++ b/libs/integrations/dpd-polska/src/dpd-plugin.ts
@@ -18,6 +18,7 @@ import type { AdapterMetadata } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { createDpdShippingAdapter } from './application/dpd-adapter.factory';
 import { DpdConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/dpd-connection-config-shape-validator.adapter';
+import { buildDpdSchedulerTasks } from './infrastructure/scheduler/dpd-scheduler-tasks';
 
 /**
  * Static plugin manifest (#575). Exported as a top-level `const` so host-side
@@ -48,6 +49,12 @@ export function createDpdPlugin(): AdapterPlugin {
       );
       // No credentials-shape validator: the `{ login, password }` shape is
       // enforced at adapter construction time by the factory.
+
+      // Shipment-status poll (#965, ADR-022) — the only DPD tracking path
+      // (no DPD webhook). Env-gated; takes effect worker-side via the scheduler.
+      for (const task of buildDpdSchedulerTasks()) {
+        host.schedulerTaskRegistry.register(task);
+      }
     },
 
     async createCapabilityAdapter<T>(

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-shipping.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-shipping.adapter.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '@openlinker/core/shipping';
 import type { DpdConnectionConfig } from '../../../domain/types/dpd-config.types';
 import type { IDpdHttpClient } from '../../http/dpd-http-client.interface';
+import type { IDpdInfoSoapClient } from '../../http/dpd-info-soap-client.interface';
 import { DpdShippingAdapter } from '../dpd-shipping.adapter';
 
 function makeConfig(): DpdConnectionConfig {
@@ -52,11 +53,13 @@ function makeCmd(overrides: Partial<GenerateLabelCommand> = {}): GenerateLabelCo
 
 describe('DpdShippingAdapter', () => {
   let http: jest.Mocked<IDpdHttpClient>;
+  let infoClient: jest.Mocked<IDpdInfoSoapClient>;
   let adapter: DpdShippingAdapter;
 
   beforeEach(() => {
     http = { request: jest.fn() };
-    adapter = new DpdShippingAdapter(http, makeConfig());
+    infoClient = { getEventsForWaybill: jest.fn() };
+    adapter = new DpdShippingAdapter(http, makeConfig(), infoClient);
   });
 
   it('should declare kurier and pickup as supported methods', () => {
@@ -161,11 +164,23 @@ describe('DpdShippingAdapter', () => {
     );
   });
 
-  it('should throw a typed tracking.unavailable rejection from getTracking', async () => {
-    await expect(adapter.getTracking({ providerShipmentId: 'WB1' })).rejects.toMatchObject({
-      providerName: 'dpd',
-      providerCode: 'tracking.unavailable',
-    });
+  it('should read the waybill events via InfoServices and map them to a snapshot', async () => {
+    infoClient.getEventsForWaybill.mockResolvedValueOnce([
+      { businessCode: '040101', eventTime: '2026-06-10T09:00:00' },
+      { businessCode: '190101', eventTime: '2026-06-11T14:30:00' },
+    ]);
+
+    const snapshot = await adapter.getTracking({ providerShipmentId: 'WB1' });
+
+    expect(infoClient.getEventsForWaybill).toHaveBeenCalledWith({ waybill: 'WB1' });
+    expect(snapshot.status).toBe('delivered');
+    expect(snapshot.providerStatus).toBe('190101');
+  });
+
+  it('should propagate an InfoServices failure from getTracking', async () => {
+    const boom = new Error('soap down');
+    infoClient.getEventsForWaybill.mockRejectedValueOnce(boom);
+    await expect(adapter.getTracking({ providerShipmentId: 'WB1' })).rejects.toBe(boom);
   });
 
   it('should create a pickup shipment to a DPD point (pudoReceiver + DPD_PICKUP)', async () => {

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-shipping.adapter.ts
@@ -18,19 +18,18 @@
  *
  * @module libs/integrations/dpd-polska/src/infrastructure/adapters
  */
-import {
-  ShippingProviderRejectionException,
-  type DispatchProtocolReader,
-  type FindPickupPointsQuery,
-  type GenerateLabelCommand,
-  type GenerateLabelResult,
-  type LabelDocument,
-  type LabelDocumentReader,
-  type PickupPoint,
-  type PickupPointFinder,
-  type ShippingMethod,
-  type ShippingProviderManagerPort,
-  type TrackingSnapshot,
+import type {
+  DispatchProtocolReader,
+  FindPickupPointsQuery,
+  GenerateLabelCommand,
+  GenerateLabelResult,
+  LabelDocument,
+  LabelDocumentReader,
+  PickupPoint,
+  PickupPointFinder,
+  ShippingMethod,
+  ShippingProviderManagerPort,
+  TrackingSnapshot,
 } from '@openlinker/core/shipping';
 import type { DpdConnectionConfig } from '../../domain/types/dpd-config.types';
 import type {
@@ -40,6 +39,7 @@ import type {
   DpdPointSearchResponse,
 } from '../../domain/types/dpd-rest.types';
 import type { IDpdHttpClient } from '../http/dpd-http-client.interface';
+import type { IDpdInfoSoapClient } from '../http/dpd-info-soap-client.interface';
 import {
   assertCreateSucceededAndExtractWaybill,
   buildCreatePackagesRequest,
@@ -51,6 +51,7 @@ import {
   toGenerateLabelResult,
   toPickupPoint,
 } from '../mappers/dpd-shipment.mapper';
+import { toTrackingSnapshot } from '../mappers/dpd-tracking.mapper';
 
 const SUPPORTED_METHODS: readonly ShippingMethod[] = ['kurier', 'pickup'];
 
@@ -74,6 +75,7 @@ export class DpdShippingAdapter
   constructor(
     private readonly http: IDpdHttpClient,
     private readonly config: DpdConnectionConfig,
+    private readonly infoClient: IDpdInfoSoapClient,
   ) {}
 
   getSupportedMethods(): readonly ShippingMethod[] {
@@ -130,18 +132,14 @@ export class DpdShippingAdapter
     return (response.points ?? []).map(toPickupPoint);
   }
 
-  getTracking(_input: { providerShipmentId: string }): Promise<TrackingSnapshot> {
-    // DPD tracking is a separate service (DPD InfoServices, #965). Until then
-    // we throw rather than fabricate a status — the adapter receives only the
-    // waybill, so any returned status would be a lie. The #838 status-sync
-    // poller catches this and logs a warn (no crash); DPD should stay out of
-    // that scan until #965 wires real tracking.
-    return Promise.reject(
-      new ShippingProviderRejectionException(
-        'dpd',
-        'tracking.unavailable',
-        'DPD tracking is not available until DPD InfoServices is wired (#965)',
-      ),
-    );
+  async getTracking(input: { providerShipmentId: string }): Promise<TrackingSnapshot> {
+    // DPD tracking lives in the separate SOAP DPDInfoServices service (#965 /
+    // ADR-022): read the waybill's full event history, then fold it into the
+    // neutral snapshot (terminal-precedence + offset-less-timestamp handling in
+    // the mapper). `providerShipmentId` is the DPD waybill.
+    const events = await this.infoClient.getEventsForWaybill({
+      waybill: input.providerShipmentId,
+    });
+    return toTrackingSnapshot(events);
   }
 }

--- a/libs/integrations/dpd-polska/src/infrastructure/http/__tests__/dpd-info-soap-client.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/__tests__/dpd-info-soap-client.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * DPD InfoServices SOAP Client — unit tests
+ *
+ * Mocks global `fetch` to verify envelope construction, response parsing
+ * (multi- and single-event, the array-collapse guard), SOAP-fault mapping
+ * (auth vs generic, fault-on-HTTP-200), and transient-retry behaviour (#965).
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/http
+ */
+import { DpdUnauthorizedException } from '../../../domain/exceptions/dpd-unauthorized.exception';
+import { DpdTrackingException } from '../../../domain/exceptions/dpd-tracking.exception';
+import { DpdNetworkException } from '../../../domain/exceptions/dpd-network.exception';
+import { DpdInfoSoapClient } from '../dpd-info-soap-client';
+
+const ENDPOINT = 'https://dpdinfoservicesdemo.dpd.com.pl/DPDInfoServicesObjEventsService/DPDInfoServicesObjEvents';
+const AUTH = { login: 'test', password: 'secret&<pw>' };
+
+const fetchMock = jest.fn();
+
+function soapResponse(body: string, ok = true, status = 200): Response {
+  return { ok, status, text: () => Promise.resolve(body) } as unknown as Response;
+}
+
+function eventsEnvelope(rows: string): string {
+  return `<?xml version="1.0"?>
+<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+  <S:Body>
+    <ns2:getEventsForWaybillV1Response xmlns:ns2="http://events.dpdinfoservices.dpd.com.pl/">
+      <return><confirmId>abc=</confirmId>${rows}</return>
+    </ns2:getEventsForWaybillV1Response>
+  </S:Body>
+</S:Envelope>`;
+}
+
+const ROW_COLLECTED = `<eventsList><businessCode>040101</businessCode><eventTime>2026-06-10T08:00:00</eventTime><waybill>WB1</waybill></eventsList>`;
+const ROW_DELIVERED = `<eventsList><businessCode>190101</businessCode><eventTime>2026-06-11T14:30:00</eventTime><waybill>WB1</waybill></eventsList>`;
+
+const FAULT_AUTH = `<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><S:Fault><faultcode>S:Server</faultcode><faultstring>Access denied to secured webserwis method</faultstring></S:Fault></S:Body></S:Envelope>`;
+const FAULT_OTHER = `<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><S:Fault><faultcode>S:Server</faultcode><faultstring>Invalid waybill format</faultstring></S:Fault></S:Body></S:Envelope>`;
+
+describe('DpdInfoSoapClient', () => {
+  let client: DpdInfoSoapClient;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    // Tiny backoff so the retry test doesn't wait real seconds.
+    client = new DpdInfoSoapClient(ENDPOINT, AUTH, { initialDelayMs: 1, maxRetries: 2 });
+  });
+
+  it('POSTs a SOAP envelope carrying the waybill + escaped auth and parses events', async () => {
+    fetchMock.mockResolvedValueOnce(soapResponse(eventsEnvelope(ROW_COLLECTED + ROW_DELIVERED)));
+
+    const events = await client.getEventsForWaybill({ waybill: 'WB1' });
+
+    expect(events).toEqual([
+      { businessCode: '040101', eventTime: '2026-06-10T08:00:00' },
+      { businessCode: '190101', eventTime: '2026-06-11T14:30:00' },
+    ]);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(ENDPOINT);
+    expect(init.method).toBe('POST');
+    const body = init.body as string;
+    expect(body).toContain('<waybill>WB1</waybill>');
+    expect(body).toContain('<eventsSelectType>ALL</eventsSelectType>');
+    expect(body).toContain('<login>test</login>');
+    // Password XML-escaped, never raw.
+    expect(body).toContain('<password>secret&amp;&lt;pw&gt;</password>');
+  });
+
+  it('parses a single event (array-collapse guard)', async () => {
+    fetchMock.mockResolvedValueOnce(soapResponse(eventsEnvelope(ROW_DELIVERED)));
+    const events = await client.getEventsForWaybill({ waybill: 'WB1' });
+    expect(events).toHaveLength(1);
+    expect(events[0].businessCode).toBe('190101');
+  });
+
+  it('returns [] when the waybill has no events', async () => {
+    fetchMock.mockResolvedValueOnce(soapResponse(eventsEnvelope('')));
+    await expect(client.getEventsForWaybill({ waybill: 'WB1' })).resolves.toEqual([]);
+  });
+
+  it('maps an auth SOAP fault (on HTTP 200) to DpdUnauthorizedException', async () => {
+    fetchMock.mockResolvedValueOnce(soapResponse(FAULT_AUTH, true, 200));
+    await expect(client.getEventsForWaybill({ waybill: 'WB1' })).rejects.toBeInstanceOf(
+      DpdUnauthorizedException,
+    );
+  });
+
+  it('maps a non-auth SOAP fault to DpdTrackingException', async () => {
+    fetchMock.mockResolvedValueOnce(soapResponse(FAULT_OTHER, false, 500));
+    await expect(client.getEventsForWaybill({ waybill: 'WB1' })).rejects.toBeInstanceOf(
+      DpdTrackingException,
+    );
+  });
+
+  it('retries a transient network error then succeeds', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(soapResponse(eventsEnvelope(ROW_DELIVERED)));
+    const events = await client.getEventsForWaybill({ waybill: 'WB1' });
+    expect(events).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('exhausts retries and throws DpdNetworkException', async () => {
+    fetchMock.mockRejectedValue(new Error('ETIMEDOUT'));
+    await expect(client.getEventsForWaybill({ waybill: 'WB1' })).rejects.toBeInstanceOf(
+      DpdNetworkException,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+});

--- a/libs/integrations/dpd-polska/src/infrastructure/http/dpd-info-soap-client.interface.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/dpd-info-soap-client.interface.ts
@@ -1,0 +1,22 @@
+/**
+ * DPD InfoServices SOAP Client Port
+ *
+ * Narrow transport contract for the DPD InfoServices `getEventsForWaybillV1`
+ * SOAP operation (#965, ADR-022). Keeping it an interface (not the concrete
+ * client) lets the adapter + its unit specs mock tracking without a real
+ * `fetch`/SOAP round-trip, per engineering-standards §"Interface and
+ * Implementation Separation".
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/http
+ */
+import type { DpdWaybillEvent } from '../../domain/types/dpd-tracking.types';
+
+export interface IDpdInfoSoapClient {
+  /**
+   * Fetch the full event history for one waybill (`eventsSelectType=ALL`).
+   * Returns the parsed events (possibly empty); throws `DpdUnauthorizedException`
+   * on auth failure, `DpdTrackingException` on a SOAP fault / unparseable body,
+   * `DpdNetworkException` on exhausted transient retries.
+   */
+  getEventsForWaybill(input: { waybill: string }): Promise<DpdWaybillEvent[]>;
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/http/dpd-info-soap-client.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/dpd-info-soap-client.ts
@@ -89,8 +89,8 @@ export class DpdInfoSoapClient implements IDpdInfoSoapClient {
 
     for (let attempt = 0; attempt <= this.retryConfig.maxRetries; attempt++) {
       try {
-        const body = await this.fetchOnce(envelope, input.waybill);
-        return this.parseEvents(body);
+        const parsed = await this.fetchOnce(envelope, input.waybill);
+        return this.parseEvents(parsed);
       } catch (error) {
         if (!(error instanceof RetryableSoapError)) {
           throw error; // auth / fault / parse failures are terminal
@@ -110,8 +110,12 @@ export class DpdInfoSoapClient implements IDpdInfoSoapClient {
     throw new DpdNetworkException('DPD InfoServices request exhausted its retry budget');
   }
 
-  /** One round-trip → raw response text. Throws on transport/auth; never logs the body. */
-  private async fetchOnce(envelope: string, waybill: string): Promise<string> {
+  /**
+   * One round-trip → the parsed SOAP body. Parses exactly once and routes:
+   * SOAP `<Fault>` (on HTTP 200 *or* 5xx) → auth/tracking exception; non-ok
+   * status → retryable/unauthorized/tracking. Never logs the body.
+   */
+  private async fetchOnce(envelope: string, waybill: string): Promise<SoapParsed> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
     let response: Response;
@@ -130,13 +134,23 @@ export class DpdInfoSoapClient implements IDpdInfoSoapClient {
     }
 
     const text = await response.text();
-    // A SOAP fault can arrive on HTTP 200 OR 500 — inspect the body first.
-    const fault = this.extractFault(text);
+    let parsed: SoapParsed | null = null;
+    try {
+      parsed = this.parser.parse(text) as SoapParsed;
+    } catch {
+      parsed = null; // resolved below: non-ok → status path; ok → unparseable
+    }
+
+    // A SOAP fault can arrive on HTTP 200 OR 5xx — inspect the parsed body first.
+    const fault = parsed?.Envelope?.Body?.Fault;
     if (fault) {
-      if (/denied|authoriz|authentic/i.test(fault)) {
-        throw new DpdUnauthorizedException(`DPD InfoServices auth failed for waybill ${waybill}: ${fault}`);
+      const faultstring = fault.faultstring ?? 'unknown SOAP fault';
+      if (/denied|authoriz|authentic/i.test(faultstring)) {
+        throw new DpdUnauthorizedException(
+          `DPD InfoServices auth failed for waybill ${waybill}: ${faultstring}`,
+        );
       }
-      throw new DpdTrackingException(`DPD InfoServices fault for waybill ${waybill}: ${fault}`);
+      throw new DpdTrackingException(`DPD InfoServices fault for waybill ${waybill}: ${faultstring}`);
     }
 
     if (!response.ok) {
@@ -148,31 +162,13 @@ export class DpdInfoSoapClient implements IDpdInfoSoapClient {
       }
       throw new DpdTrackingException(`DPD InfoServices returned ${response.status} for waybill ${waybill}`);
     }
-    return text;
+    if (!parsed) {
+      throw new DpdTrackingException('DPD InfoServices returned an unparseable response body');
+    }
+    return parsed;
   }
 
-  /** Return the SOAP `<faultstring>` text if the body is a fault, else null. */
-  private extractFault(text: string): string | null {
-    let parsed: SoapParsed;
-    try {
-      parsed = this.parser.parse(text) as SoapParsed;
-    } catch {
-      return null; // unparseable → handled by parseEvents (terminal) on the ok path
-    }
-    const fault = parsed?.Envelope?.Body?.Fault;
-    if (!fault) {
-      return null;
-    }
-    return fault.faultstring ?? 'unknown SOAP fault';
-  }
-
-  private parseEvents(text: string): DpdWaybillEvent[] {
-    let parsed: SoapParsed;
-    try {
-      parsed = this.parser.parse(text) as SoapParsed;
-    } catch (error) {
-      throw new DpdTrackingException('DPD InfoServices returned an unparseable response body', error);
-    }
+  private parseEvents(parsed: SoapParsed): DpdWaybillEvent[] {
     const ret = parsed?.Envelope?.Body?.getEventsForWaybillV1Response?.return;
     if (!ret) {
       throw new DpdTrackingException('DPD InfoServices response missing getEventsForWaybillV1Response/return');

--- a/libs/integrations/dpd-polska/src/infrastructure/http/dpd-info-soap-client.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/dpd-info-soap-client.ts
@@ -1,0 +1,253 @@
+/**
+ * DPD InfoServices SOAP Client
+ *
+ * Native-`fetch` SOAP transport for DPD InfoServices `getEventsForWaybillV1`
+ * (#965, ADR-022) — the tracking half of the dual-transport DPD plugin. Builds
+ * the envelope by hand (one operation; no `soap` lib) and parses the reply with
+ * `fast-xml-parser` (the PrestaShop-plugin precedent). Read-only + idempotent,
+ * so every transient failure (network / `429` / `5xx` without a fault) is
+ * retried with jittered backoff.
+ *
+ * Decoding guards (ADR-022 consequences):
+ *  - `parseTagValue: false` — DPD `businessCode`s have leading zeros (`030103`)
+ *    and waybills are digit strings; numeric coercion would corrupt them.
+ *  - `isArray` for `eventsList` / `eventDataList` — `fast-xml-parser` collapses a
+ *    single occurrence to an object, which would break list handling.
+ *  - **SOAP `<Fault>` can arrive on HTTP 200 *or* 500** — the body is parsed and
+ *    inspected for a fault before trusting the HTTP status.
+ *  - The request body carries `login`/`password` (SOAP `authDataV1`), so it is
+ *    **never logged** — only endpoint + waybill + status + latency.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/http
+ */
+import { randomUUID } from 'node:crypto';
+import { XMLParser } from 'fast-xml-parser';
+import { Logger } from '@openlinker/shared/logging';
+import {
+  DPD_EVENTS_SELECT_ALL,
+  DPD_EVENT_LANGUAGE,
+  type DpdWaybillEvent,
+} from '../../domain/types/dpd-tracking.types';
+import { DpdNetworkException } from '../../domain/exceptions/dpd-network.exception';
+import { DpdUnauthorizedException } from '../../domain/exceptions/dpd-unauthorized.exception';
+import { DpdTrackingException } from '../../domain/exceptions/dpd-tracking.exception';
+import type { IDpdInfoSoapClient } from './dpd-info-soap-client.interface';
+
+interface SoapAuth {
+  login: string;
+  password: string;
+}
+
+interface RetryConfig {
+  maxRetries: number;
+  initialDelayMs: number;
+  backoffMultiplier: number;
+  maxDelayMs: number;
+}
+
+const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRetries: 3,
+  initialDelayMs: 500,
+  backoffMultiplier: 2,
+  maxDelayMs: 8000,
+};
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const SOAP_NS = 'http://events.dpdinfoservices.dpd.com.pl/';
+
+/** Internal marker for a retryable transient failure (network / 429 / 5xx-no-fault). */
+class RetryableSoapError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RetryableSoapError';
+  }
+}
+
+export class DpdInfoSoapClient implements IDpdInfoSoapClient {
+  private readonly logger = new Logger(DpdInfoSoapClient.name);
+  private readonly retryConfig: RetryConfig;
+  private readonly parser = new XMLParser({
+    removeNSPrefix: true,
+    ignoreAttributes: true,
+    parseTagValue: false,
+    trimValues: true,
+    isArray: (name) => name === 'eventsList' || name === 'eventDataList',
+  });
+
+  constructor(
+    private readonly endpoint: string,
+    private readonly auth: SoapAuth,
+    retryConfig?: Partial<RetryConfig>,
+  ) {
+    this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+  }
+
+  async getEventsForWaybill(input: { waybill: string }): Promise<DpdWaybillEvent[]> {
+    const requestId = randomUUID();
+    const envelope = buildEnvelope(input.waybill, this.auth);
+    let delay = this.retryConfig.initialDelayMs;
+
+    for (let attempt = 0; attempt <= this.retryConfig.maxRetries; attempt++) {
+      try {
+        const body = await this.fetchOnce(envelope, input.waybill);
+        return this.parseEvents(body);
+      } catch (error) {
+        if (!(error instanceof RetryableSoapError)) {
+          throw error; // auth / fault / parse failures are terminal
+        }
+        if (attempt === this.retryConfig.maxRetries) {
+          throw new DpdNetworkException(error.message, error);
+        }
+        const waitMs = this.jitter(delay);
+        this.logger.warn(
+          `DPD InfoServices getEventsForWaybill failed (attempt ${attempt + 1}/${this.retryConfig.maxRetries + 1}); retrying in ${waitMs}ms [requestId=${requestId}]`,
+        );
+        await this.sleep(waitMs);
+        delay = Math.min(delay * this.retryConfig.backoffMultiplier, this.retryConfig.maxDelayMs);
+      }
+    }
+    // Unreachable: the final attempt returns or throws above.
+    throw new DpdNetworkException('DPD InfoServices request exhausted its retry budget');
+  }
+
+  /** One round-trip → raw response text. Throws on transport/auth; never logs the body. */
+  private async fetchOnce(envelope: string, waybill: string): Promise<string> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await fetch(this.endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/xml; charset=utf-8', SOAPAction: '' },
+        body: envelope,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      // Network/timeout — retryable for this read-only call.
+      throw new RetryableSoapError(`DPD InfoServices network error: ${(error as Error).message}`);
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const text = await response.text();
+    // A SOAP fault can arrive on HTTP 200 OR 500 — inspect the body first.
+    const fault = this.extractFault(text);
+    if (fault) {
+      if (/denied|authoriz|authentic/i.test(fault)) {
+        throw new DpdUnauthorizedException(`DPD InfoServices auth failed for waybill ${waybill}: ${fault}`);
+      }
+      throw new DpdTrackingException(`DPD InfoServices fault for waybill ${waybill}: ${fault}`);
+    }
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        throw new DpdUnauthorizedException(`DPD InfoServices returned ${response.status} for waybill ${waybill}`);
+      }
+      if (response.status === 429 || response.status >= 500) {
+        throw new RetryableSoapError(`DPD InfoServices returned ${response.status}`);
+      }
+      throw new DpdTrackingException(`DPD InfoServices returned ${response.status} for waybill ${waybill}`);
+    }
+    return text;
+  }
+
+  /** Return the SOAP `<faultstring>` text if the body is a fault, else null. */
+  private extractFault(text: string): string | null {
+    let parsed: SoapParsed;
+    try {
+      parsed = this.parser.parse(text) as SoapParsed;
+    } catch {
+      return null; // unparseable → handled by parseEvents (terminal) on the ok path
+    }
+    const fault = parsed?.Envelope?.Body?.Fault;
+    if (!fault) {
+      return null;
+    }
+    return fault.faultstring ?? 'unknown SOAP fault';
+  }
+
+  private parseEvents(text: string): DpdWaybillEvent[] {
+    let parsed: SoapParsed;
+    try {
+      parsed = this.parser.parse(text) as SoapParsed;
+    } catch (error) {
+      throw new DpdTrackingException('DPD InfoServices returned an unparseable response body', error);
+    }
+    const ret = parsed?.Envelope?.Body?.getEventsForWaybillV1Response?.return;
+    if (!ret) {
+      throw new DpdTrackingException('DPD InfoServices response missing getEventsForWaybillV1Response/return');
+    }
+    const rows = ret.eventsList ?? [];
+    return rows
+      .filter((row) => typeof row.businessCode === 'string' && row.businessCode.length > 0)
+      .map((row) => toEvent(row));
+  }
+
+  private jitter(delayMs: number): number {
+    return Math.round(delayMs * (0.5 + Math.random() * 0.5));
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+// ── parsed-XML shapes (post removeNSPrefix) ──────────────────────────────────
+interface RawEventData {
+  code?: string;
+  value?: string;
+}
+interface RawEvent {
+  businessCode?: string;
+  eventTime?: string;
+  description?: string;
+  eventDataList?: RawEventData[];
+}
+interface SoapParsed {
+  Envelope?: {
+    Body?: {
+      Fault?: { faultstring?: string };
+      getEventsForWaybillV1Response?: { return?: { eventsList?: RawEvent[] } };
+    };
+  };
+}
+
+function toEvent(row: RawEvent): DpdWaybillEvent {
+  const eventData = (row.eventDataList ?? [])
+    .map((d) => d.value)
+    .filter((v): v is string => typeof v === 'string' && v.length > 0);
+  return {
+    businessCode: row.businessCode as string,
+    eventTime: typeof row.eventTime === 'string' ? row.eventTime : undefined,
+    description: typeof row.description === 'string' ? row.description : undefined,
+    eventData: eventData.length > 0 ? eventData : undefined,
+  };
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildEnvelope(waybill: string, auth: SoapAuth): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:even="${SOAP_NS}">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <even:getEventsForWaybillV1>
+      <waybill>${escapeXml(waybill)}</waybill>
+      <eventsSelectType>${DPD_EVENTS_SELECT_ALL}</eventsSelectType>
+      <language>${DPD_EVENT_LANGUAGE}</language>
+      <authDataV1>
+        <channel></channel>
+        <login>${escapeXml(auth.login)}</login>
+        <password>${escapeXml(auth.password)}</password>
+      </authDataV1>
+    </even:getEventsForWaybillV1>
+  </soapenv:Body>
+</soapenv:Envelope>`;
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-tracking.mapper.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-tracking.mapper.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * DPD Tracking Mapper — unit tests
+ *
+ * Covers event-code classification, the offset-less Europe/Warsaw timestamp
+ * parse, and the terminal-precedence snapshot fold (#965).
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/mappers
+ */
+import type { DpdWaybillEvent } from '../../../domain/types/dpd-tracking.types';
+import {
+  classifyDpdEventCode,
+  parseDpdEventTime,
+  toTrackingSnapshot,
+} from '../dpd-tracking.mapper';
+
+describe('classifyDpdEventCode', () => {
+  it.each([
+    ['030103', 'generated'],
+    ['040101', 'dispatched'],
+    ['500500', 'dispatched'],
+    ['040200', 'generated'], // failed pickup / reception → pre-dispatch
+    ['050101', 'in-transit'],
+    ['170101', 'in-transit'],
+    ['200201', 'in-transit'], // undelivered attempt (non-terminal)
+    ['190101', 'delivered'],
+    ['190204', 'delivered'],
+    ['230403', 'failed'], // return to sender
+    ['230408', 'failed'],
+    ['230402', 'in-transit'], // redirect
+  ])('maps %s → %s (recognized)', (code, expected) => {
+    const result = classifyDpdEventCode(code);
+    expect(result.status).toBe(expected);
+    expect(result.recognized).toBe(true);
+  });
+
+  it('degrades a genuinely unknown code to in-transit (unrecognized)', () => {
+    expect(classifyDpdEventCode('999999')).toEqual({ status: 'in-transit', recognized: false });
+  });
+});
+
+describe('parseDpdEventTime', () => {
+  it('parses an offset-less timestamp as Europe/Warsaw summer time (CEST, +02:00)', () => {
+    // 2026-06-11 14:30 Warsaw (CEST) = 12:30 UTC.
+    expect(parseDpdEventTime('2026-06-11T14:30:00')?.toISOString()).toBe('2026-06-11T12:30:00.000Z');
+  });
+
+  it('parses winter time as CET (+01:00)', () => {
+    // 2026-01-08 11:18:52 Warsaw (CET) = 10:18:52 UTC.
+    expect(parseDpdEventTime('2026-01-08T11:18:52.122')?.toISOString()).toBe('2026-01-08T10:18:52.000Z');
+  });
+
+  it('returns undefined for missing/malformed input', () => {
+    expect(parseDpdEventTime(undefined)).toBeUndefined();
+    expect(parseDpdEventTime('not-a-date')).toBeUndefined();
+  });
+});
+
+describe('toTrackingSnapshot', () => {
+  it('returns generated for an empty history', () => {
+    expect(toTrackingSnapshot([])).toEqual({ status: 'generated' });
+  });
+
+  it('takes the latest non-terminal event by time, regardless of input order', () => {
+    const events: DpdWaybillEvent[] = [
+      { businessCode: '170101', eventTime: '2026-06-11T10:00:00' }, // out for delivery
+      { businessCode: '040101', eventTime: '2026-06-10T08:00:00' }, // collected (earlier)
+    ];
+    const snap = toTrackingSnapshot(events);
+    expect(snap.status).toBe('in-transit');
+    expect(snap.providerStatus).toBe('170101');
+    expect(snap.dispatchedAt?.toISOString()).toBe('2026-06-10T06:00:00.000Z');
+  });
+
+  it('lets a terminal delivered win even when a later non-terminal event exists', () => {
+    const events: DpdWaybillEvent[] = [
+      { businessCode: '190101', eventTime: '2026-06-11T14:30:00' }, // delivered
+      { businessCode: '170304', eventTime: '2026-06-11T15:00:00' }, // later notification
+    ];
+    const snap = toTrackingSnapshot(events);
+    expect(snap.status).toBe('delivered');
+    expect(snap.deliveredAt?.toISOString()).toBe('2026-06-11T12:30:00.000Z');
+  });
+
+  it('prefers the latest terminal when both delivered and failed are present (failed-after-delivered)', () => {
+    const events: DpdWaybillEvent[] = [
+      { businessCode: '190101', eventTime: '2026-06-11T09:00:00' },
+      { businessCode: '230403', eventTime: '2026-06-12T09:00:00' }, // return — later terminal
+    ];
+    expect(toTrackingSnapshot(events).status).toBe('failed');
+  });
+
+  it('handles a single event (no array collapse assumptions)', () => {
+    expect(toTrackingSnapshot([{ businessCode: '190101', eventTime: '2026-06-11T14:30:00' }]).status).toBe(
+      'delivered',
+    );
+  });
+
+  it('maps a redirect to in-transit (new waybill is captured in eventData)', () => {
+    const snap = toTrackingSnapshot([
+      { businessCode: '230402', eventTime: '2026-06-11T10:00:00', eventData: ['0000010923567L'] },
+    ]);
+    expect(snap.status).toBe('in-transit');
+    expect(snap.providerStatus).toBe('230402');
+  });
+});

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-tracking.mapper.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-tracking.mapper.ts
@@ -1,0 +1,186 @@
+/**
+ * DPD Tracking Mapper
+ *
+ * Folds a DPD InfoServices waybill-event history (`DpdWaybillEvent[]`) into a
+ * neutral `TrackingSnapshot` (#965, ADR-022). Pure — no I/O.
+ *
+ * Status derivation (see the plan + `Events`/`Ending statuses` xlsx):
+ *  - **Terminal-precedence**: if any event maps to a terminal OL status (core
+ *    `TerminalShipmentStatusValues` = delivered/failed/cancelled), the latest
+ *    terminal event wins — a parcel doesn't "un-deliver" if a stray later event
+ *    arrives, and `failed` after `delivered` ⇒ `failed`.
+ *  - Otherwise the latest event (by `eventTime`) decides.
+ *  - DPD `businessCode` → OL status by group/prefix; unrecognized codes degrade
+ *    to `in-transit` with a `logger.warn`.
+ *  - `eventTime` is offset-less `Europe/Warsaw` wall-clock — converted to a true
+ *    UTC instant via `parseDpdEventTime`, never `new Date(raw)`.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/mappers
+ */
+import { Logger } from '@openlinker/shared/logging';
+import {
+  TerminalShipmentStatusValues,
+  type ShipmentStatus,
+  type TrackingSnapshot,
+} from '@openlinker/core/shipping';
+import type { DpdWaybillEvent } from '../../domain/types/dpd-tracking.types';
+
+const logger = new Logger('DpdTrackingMapper');
+
+const DPD_TIMEZONE = 'Europe/Warsaw';
+const REDIRECT_CODE = '230402';
+const RETURN_CODES = new Set(['230403', '230408']);
+const REGISTERED_CODE = '030103';
+const COLLECTED_ABROAD_CODE = '500500';
+
+/** DPD event-group 2-digit prefixes that are legitimately mid-transit (hub,
+ * depot, sort, customs, out-for-delivery, undelivered-attempt, notifications,
+ * pickup-point). Used to distinguish a known in-transit code from a genuinely
+ * unknown one (which warns). */
+const IN_TRANSIT_PREFIXES = [
+  '05', '11', '12', '15', '16', '17', '20', '21', '23', '25', '26', '32', '33', '37', '41', '45', '50',
+];
+
+const TERMINAL = new Set<ShipmentStatus>(TerminalShipmentStatusValues);
+
+interface ClassifiedEvent {
+  event: DpdWaybillEvent;
+  status: ShipmentStatus;
+  instant: number | undefined; // epoch ms, or undefined when eventTime is absent/unparseable
+}
+
+/**
+ * Classify a single DPD `businessCode` → OL `ShipmentStatus`. `recognized` is
+ * false only for codes that match no known rule/group (the caller warns).
+ */
+export function classifyDpdEventCode(code: string): { status: ShipmentStatus; recognized: boolean } {
+  if (code.startsWith('1901') || code.startsWith('1902')) {
+    return { status: 'delivered', recognized: true };
+  }
+  if (RETURN_CODES.has(code)) {
+    return { status: 'failed', recognized: true };
+  }
+  if (code === REDIRECT_CODE) {
+    return { status: 'in-transit', recognized: true };
+  }
+  if (code === REGISTERED_CODE) {
+    return { status: 'generated', recognized: true };
+  }
+  if (code.startsWith('0401') || code === COLLECTED_ABROAD_CODE) {
+    return { status: 'dispatched', recognized: true };
+  }
+  // Failed pickup / reception (parcel never collected) — still pre-dispatch.
+  if (code.startsWith('0402') || code.startsWith('0405') || code.startsWith('0406')) {
+    return { status: 'generated', recognized: true };
+  }
+  if (IN_TRANSIT_PREFIXES.includes(code.slice(0, 2))) {
+    return { status: 'in-transit', recognized: true };
+  }
+  return { status: 'in-transit', recognized: false };
+}
+
+/**
+ * Parse a DPD offset-less `eventTime` (`YYYY-MM-DDTHH:mm:ss(.SSS)?`, interpreted
+ * as `Europe/Warsaw` wall-clock) into a UTC `Date`. Returns undefined for a
+ * missing/malformed value.
+ */
+export function parseDpdEventTime(raw: string | undefined): Date | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/.exec(raw);
+  if (!m) {
+    return undefined;
+  }
+  const [, y, mo, d, h, mi, s] = m;
+  const asUtc = Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s));
+  // Offset the zone applies around this instant (handles CET/CEST DST).
+  const offsetMs = warsawOffsetMs(asUtc);
+  return new Date(asUtc - offsetMs);
+}
+
+/** Europe/Warsaw UTC offset (ms) at the given instant, via Intl (no tz lib). */
+function warsawOffsetMs(utcMs: number): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: DPD_TIMEZONE,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const parts = dtf.formatToParts(new Date(utcMs));
+  const get = (type: string): number => Number(parts.find((p) => p.type === type)?.value ?? '0');
+  const asIfUtc = Date.UTC(
+    get('year'),
+    get('month') - 1,
+    get('day'),
+    get('hour') === 24 ? 0 : get('hour'),
+    get('minute'),
+    get('second'),
+  );
+  return asIfUtc - utcMs;
+}
+
+/**
+ * Fold an event history into a `TrackingSnapshot`. Empty history → `generated`.
+ */
+export function toTrackingSnapshot(events: DpdWaybillEvent[]): TrackingSnapshot {
+  if (events.length === 0) {
+    return { status: 'generated' };
+  }
+
+  const classified: ClassifiedEvent[] = events.map((event) => {
+    const { status, recognized } = classifyDpdEventCode(event.businessCode);
+    if (!recognized) {
+      logger.warn(
+        `DPD InfoServices: unrecognized businessCode ${event.businessCode} — defaulting to in-transit`,
+      );
+    }
+    return { event, status, instant: parseDpdEventTime(event.eventTime)?.getTime() };
+  });
+
+  // Stable chronological order (events without a parsable time keep input order).
+  const ordered = classified
+    .map((c, index) => ({ c, index }))
+    .sort((a, b) => {
+      if (a.c.instant !== undefined && b.c.instant !== undefined) {
+        return a.c.instant - b.c.instant || a.index - b.index;
+      }
+      if (a.c.instant === undefined && b.c.instant === undefined) {
+        return a.index - b.index;
+      }
+      return a.c.instant === undefined ? -1 : 1; // undefined-time events sort earliest
+    })
+    .map((x) => x.c);
+
+  const terminalEvents = ordered.filter((c) => TERMINAL.has(c.status));
+  const selected = terminalEvents.length > 0 ? terminalEvents[terminalEvents.length - 1] : ordered[ordered.length - 1];
+
+  const deliveredEvent = [...ordered].reverse().find((c) => c.status === 'delivered');
+  const dispatchedEvent = ordered.find((c) => c.status === 'dispatched');
+
+  // Redirect: parcel moved to a new waybill; OL keeps polling the old one (stall).
+  if (selected.event.businessCode === REDIRECT_CODE) {
+    const newWaybill = selected.event.eventData?.[0];
+    logger.warn(
+      `DPD redirected waybill → ${newWaybill ?? 'unknown'}; OL keeps polling the original — auto-follow is out of scope (#965/ADR-022)`,
+    );
+  }
+
+  const snapshot: TrackingSnapshot = {
+    status: selected.status,
+    providerStatus: selected.event.businessCode,
+  };
+  const deliveredAt = deliveredEvent && parseDpdEventTime(deliveredEvent.event.eventTime);
+  if (deliveredAt) {
+    snapshot.deliveredAt = deliveredAt;
+  }
+  const dispatchedAt = dispatchedEvent && parseDpdEventTime(dispatchedEvent.event.eventTime);
+  if (dispatchedAt) {
+    snapshot.dispatchedAt = dispatchedAt;
+  }
+  return snapshot;
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-tracking.mapper.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-tracking.mapper.ts
@@ -132,15 +132,20 @@ export function toTrackingSnapshot(events: DpdWaybillEvent[]): TrackingSnapshot 
     return { status: 'generated' };
   }
 
+  const unrecognized = new Set<string>();
   const classified: ClassifiedEvent[] = events.map((event) => {
     const { status, recognized } = classifyDpdEventCode(event.businessCode);
     if (!recognized) {
-      logger.warn(
-        `DPD InfoServices: unrecognized businessCode ${event.businessCode} — defaulting to in-transit`,
-      );
+      unrecognized.add(event.businessCode);
     }
     return { event, status, instant: parseDpdEventTime(event.eventTime)?.getTime() };
   });
+  // Warn once per distinct unknown code (not per event) to avoid per-poll spam.
+  if (unrecognized.size > 0) {
+    logger.warn(
+      `DPD InfoServices: unrecognized businessCode(s) [${[...unrecognized].join(', ')}] — defaulting to in-transit`,
+    );
+  }
 
   // Stable chronological order (events without a parsable time keep input order).
   const ordered = classified
@@ -159,7 +164,6 @@ export function toTrackingSnapshot(events: DpdWaybillEvent[]): TrackingSnapshot 
   const terminalEvents = ordered.filter((c) => TERMINAL.has(c.status));
   const selected = terminalEvents.length > 0 ? terminalEvents[terminalEvents.length - 1] : ordered[ordered.length - 1];
 
-  const deliveredEvent = [...ordered].reverse().find((c) => c.status === 'delivered');
   const dispatchedEvent = ordered.find((c) => c.status === 'dispatched');
 
   // Redirect: parcel moved to a new waybill; OL keeps polling the old one (stall).
@@ -174,10 +178,16 @@ export function toTrackingSnapshot(events: DpdWaybillEvent[]): TrackingSnapshot 
     status: selected.status,
     providerStatus: selected.event.businessCode,
   };
-  const deliveredAt = deliveredEvent && parseDpdEventTime(deliveredEvent.event.eventTime);
-  if (deliveredAt) {
-    snapshot.deliveredAt = deliveredAt;
+  // deliveredAt only when the snapshot is actually delivered — `selected` is the
+  // delivered terminal in that case. A return-after-delivery resolves to
+  // `failed`, where a deliveredAt would be semantically muddy for #838.
+  if (selected.status === 'delivered') {
+    const deliveredAt = parseDpdEventTime(selected.event.eventTime);
+    if (deliveredAt) {
+      snapshot.deliveredAt = deliveredAt;
+    }
   }
+  // dispatchedAt reflects pickup regardless of final status (it was dispatched).
   const dispatchedAt = dispatchedEvent && parseDpdEventTime(dispatchedEvent.event.eventTime);
   if (dispatchedAt) {
     snapshot.dispatchedAt = dispatchedAt;

--- a/libs/integrations/dpd-polska/src/infrastructure/scheduler/__tests__/dpd-scheduler-tasks.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/scheduler/__tests__/dpd-scheduler-tasks.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * DPD Scheduler Tasks — unit tests
+ *
+ * Verifies the env gate, the default task shape, and the cron/page-limit
+ * overrides (#965).
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/scheduler
+ */
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { buildDpdSchedulerTasks } from '../dpd-scheduler-tasks';
+
+// generatePayload ignores the connection (it builds a static payload), so a
+// minimal stub is sufficient for the contract call.
+const CONN = { id: 'conn-dpd', platformType: 'dpd' } as unknown as Connection;
+
+const ENV_KEYS = [
+  'OL_DPD_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED',
+  'OL_DPD_SHIPMENT_STATUS_SYNC_INTERVAL_CRON',
+  'OL_DPD_SHIPMENT_STATUS_SYNC_PAGE_LIMIT',
+];
+
+describe('buildDpdSchedulerTasks', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = saved[k];
+      }
+    }
+  });
+
+  it('emits one task with the DPD defaults when unset (enabled by default)', () => {
+    const tasks = buildDpdSchedulerTasks();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      taskId: 'dpd-shipment-status-sync',
+      platformType: 'dpd',
+      jobType: 'marketplace.shipment.statusSync',
+      cronExpression: '0 */30 * * * *',
+      enabledEnvVar: 'OL_DPD_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED',
+    });
+    expect(tasks[0].generatePayload(CONN)).toEqual({
+      schemaVersion: 1,
+      limit: 50,
+      cursorKey: 'dpd.shipmentStatus.scanOffset',
+    });
+  });
+
+  it('emits no task when explicitly disabled', () => {
+    process.env.OL_DPD_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED = 'false';
+    expect(buildDpdSchedulerTasks()).toHaveLength(0);
+  });
+
+  it('honours cron + page-limit overrides', () => {
+    process.env.OL_DPD_SHIPMENT_STATUS_SYNC_INTERVAL_CRON = '0 0 */2 * * *';
+    process.env.OL_DPD_SHIPMENT_STATUS_SYNC_PAGE_LIMIT = '25';
+    const [task] = buildDpdSchedulerTasks();
+    expect(task.cronExpression).toBe('0 0 */2 * * *');
+    expect(task.generatePayload(CONN)).toMatchObject({ limit: 25 });
+  });
+});

--- a/libs/integrations/dpd-polska/src/infrastructure/scheduler/dpd-scheduler-tasks.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/scheduler/dpd-scheduler-tasks.ts
@@ -1,0 +1,79 @@
+/**
+ * DPD Polska Scheduler Tasks
+ *
+ * Builds the `SchedulerTaskConfig` instances the DPD plugin contributes to the
+ * core `SchedulerTaskRegistryService`. One task (#965):
+ *
+ *   - `dpd-shipment-status-sync` — drives the carrier-generic
+ *     `marketplace.shipment.statusSync` job (#838) for DPD connections. The
+ *     worker handler re-reads each non-terminal DPD `Shipment` via `getTracking`
+ *     (SOAP DPDInfoServices, ADR-022), advances OL's row toward carrier reality,
+ *     and propagates status + tracking to the destination OMP. DPD has **no
+ *     tracking webhook**, so this poll is the *only* tracking path (not a
+ *     fallback). Per-waybill fan-out → keep the cadence conservative (default
+ *     30 min) and the page limit modest. Rolling scan-offset cursor key
+ *     `dpd.shipmentStatus.scanOffset` (disjoint from Allegro/InPost).
+ *
+ * **Why `process.env` (not `ConfigService`):** identical rationale to the InPost
+ * tasks — the plugin is constructed eagerly by `createNestAdapterModule` and
+ * this builder runs from the descriptor's `register(host)` at `onModuleInit`,
+ * after the host has populated `process.env`. The core scheduler re-reads
+ * `enabledEnvVar` each tick for runtime on/off toggling.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/scheduler
+ * @see {@link SchedulerTaskConfig} in `@openlinker/core/sync`.
+ */
+import type {
+  MarketplaceShipmentStatusSyncPayloadV1,
+  SchedulerTaskConfig,
+} from '@openlinker/core/sync';
+
+const SCHEDULER_ENABLED_ENV = 'OL_DPD_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED';
+const INTERVAL_CRON_ENV = 'OL_DPD_SHIPMENT_STATUS_SYNC_INTERVAL_CRON';
+const PAGE_LIMIT_ENV = 'OL_DPD_SHIPMENT_STATUS_SYNC_PAGE_LIMIT';
+
+/** Every 30 min (6-field, seconds-leading — parity with InPost/Allegro tasks). */
+const DEFAULT_INTERVAL_CRON = '0 */30 * * * *';
+const DEFAULT_PAGE_LIMIT = 50;
+
+/** Disjoint from Allegro's / InPost's shipment-status cursors. */
+const CURSOR_KEY = 'dpd.shipmentStatus.scanOffset';
+
+const isEnabled = (key: string): boolean => (process.env[key] ?? 'true') !== 'false';
+
+function resolvePageLimit(): number {
+  const raw = process.env[PAGE_LIMIT_ENV];
+  const parsed = raw !== undefined && raw !== '' ? Number(raw) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : DEFAULT_PAGE_LIMIT;
+}
+
+/**
+ * Build the DPD scheduler-task list. Returns 0–1 tasks depending on the
+ * `OL_DPD_SHIPMENT_STATUS_SYNC_SCHEDULER_ENABLED` gate.
+ */
+export function buildDpdSchedulerTasks(): SchedulerTaskConfig[] {
+  const tasks: SchedulerTaskConfig[] = [];
+
+  if (isEnabled(SCHEDULER_ENABLED_ENV)) {
+    const cronExpression = process.env[INTERVAL_CRON_ENV] || DEFAULT_INTERVAL_CRON;
+    const pageLimit = resolvePageLimit();
+
+    tasks.push({
+      taskId: 'dpd-shipment-status-sync',
+      platformType: 'dpd',
+      jobType: 'marketplace.shipment.statusSync',
+      cronExpression,
+      enabledEnvVar: SCHEDULER_ENABLED_ENV,
+      generatePayload: () =>
+        ({
+          schemaVersion: 1,
+          limit: pageLimit,
+          cursorKey: CURSOR_KEY,
+        }) satisfies MarketplaceShipmentStatusSyncPayloadV1,
+      generateIdempotencyKey: (connection, timestamp) =>
+        `marketplace:${connection.id}:shipment:status:sync:${timestamp}`,
+    });
+  }
+
+  return tasks;
+}

--- a/libs/integrations/dpd-polska/src/testing/__tests__/fake-dpd-shipping.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/testing/__tests__/fake-dpd-shipping.adapter.spec.ts
@@ -100,9 +100,20 @@ describe('FakeDpdShippingAdapter', () => {
     );
   });
 
-  it('should throw tracking.unavailable from getTracking', async () => {
-    await expect(adapter.getTracking({ providerShipmentId: 'fake-dpd-1' })).rejects.toMatchObject({
-      providerCode: 'tracking.unavailable',
+  it('should return the seeded tracking snapshot (default in-transit)', async () => {
+    await expect(adapter.getTracking({ providerShipmentId: 'fake-dpd-1' })).resolves.toEqual({
+      status: 'in-transit',
+    });
+
+    adapter.seedTracking({ status: 'delivered', providerStatus: '190101' });
+    await expect(adapter.getTracking({ providerShipmentId: 'fake-dpd-1' })).resolves.toEqual({
+      status: 'delivered',
+      providerStatus: '190101',
+    });
+
+    adapter.clear();
+    await expect(adapter.getTracking({ providerShipmentId: 'fake-dpd-1' })).resolves.toEqual({
+      status: 'in-transit',
     });
   });
 

--- a/libs/integrations/dpd-polska/src/testing/fake-dpd-shipping.adapter.ts
+++ b/libs/integrations/dpd-polska/src/testing/fake-dpd-shipping.adapter.ts
@@ -40,6 +40,7 @@ export class FakeDpdShippingAdapter
   private counter = 0;
   private seededFailure: Error | null = null;
   private seededPoints: PickupPoint[] = [];
+  private seededTracking: TrackingSnapshot = { status: 'in-transit' };
 
   getSupportedMethods(): readonly ShippingMethod[] {
     return SUPPORTED_METHODS;
@@ -95,13 +96,10 @@ export class FakeDpdShippingAdapter
   }
 
   getTracking(_input: { providerShipmentId: string }): Promise<TrackingSnapshot> {
-    return Promise.reject(
-      new ShippingProviderRejectionException(
-        'dpd',
-        'tracking.unavailable',
-        'DPD tracking is not available until DPD InfoServices is wired (#965)',
-      ),
-    );
+    if (this.seededFailure) {
+      return Promise.reject(this.seededFailure);
+    }
+    return Promise.resolve(this.seededTracking);
   }
 
   generateProtocol(_input: { providerShipmentIds: string[] }): Promise<LabelDocument> {
@@ -126,10 +124,16 @@ export class FakeDpdShippingAdapter
     this.seededPoints = [...points];
   }
 
+  /** Set the snapshot returned by `getTracking`. */
+  seedTracking(snapshot: TrackingSnapshot): void {
+    this.seededTracking = snapshot;
+  }
+
   /** Reset all in-memory state between tests. */
   clear(): void {
     this.counter = 0;
     this.seededFailure = null;
     this.seededPoints = [];
+    this.seededTracking = { status: 'in-transit' };
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,6 +573,9 @@ importers:
       class-validator:
         specifier: 0.14.1
         version: 0.14.1
+      fast-xml-parser:
+        specifier: ^5.3.3
+        version: 5.3.3
     devDependencies:
       '@types/jest':
         specifier: 29.5.12


### PR DESCRIPTION
Closes #965.

## What & why
The last DPD backend slice — real shipment tracking, replacing the #962 `getTracking` stub. DPD Polska has **no tracking op in the REST DPDServices shipment API**; tracking lives in a separate **SOAP `DPDInfoServices`** service (`getEventsForWaybillV1`), confirmed against DPD's own `INFO_Services_v2` spec + event-code catalogue. So the DPD plugin becomes **dual-transport** — REST for shipment/labels (unchanged) + a minimal SOAP client for tracking. Recorded in **ADR-022** (completes the tracking-transport thread ADR-018 explicitly deferred; does not supersede it).

End-to-end: scheduled poll → `marketplace.shipment.statusSync` (#838) → `DpdShippingAdapter.getTracking` → SOAP `getEventsForWaybillV1` → event-code mapper → `TrackingSnapshot` → propagation to Allegro + PrestaShop via the **unchanged #838 pipeline**.

## Design (ADR-022)
- **SOAP, no library** — one operation, so a hand-built envelope + `fast-xml-parser` (already a dep; PrestaShop precedent) over `node-soap` (WSDL machinery + CVE surface we don't need). **ObjEvents** interface (uncoded) over XmlEvents (base64/zip).
- **Auth** reuses the connection's `login`/`password` in the SOAP body (`authDataV1`, channel-less waybill method) — not `masterFid` (shipment-only). Separate host `dpdinfoservices.dpd.com.pl`.
- **Idempotent read** → no `markEventsAsProcessed` (that's the account-bulk pull — the documented future batch optimization).

## Decoding guards (the SOAP traps, all unit-covered)
- `parseTagValue:false` — preserves leading-zero `businessCode`s (`030103`) + digit waybills.
- `isArray` for `eventsList` — survives `fast-xml-parser`'s single-element→object collapse.
- **SOAP `<Fault>` on HTTP 200 *or* 5xx** — body inspected (parsed once) before trusting status; auth-fault → `DpdUnauthorizedException`, else `DpdTrackingException`.
- **Europe/Warsaw** offset-aware `eventTime` parse (Intl-based, no tz lib) — DPD timestamps are offset-less wall-clock.
- Waybill + creds XML-escaped; request body **never logged**.

## Status mapping
`businessCode` → `ShipmentStatus` by group/prefix (delivered `1901xx/1902xx`; return `230403/230408`→failed; redirect `230402`→in-transit + logged stall; collected→dispatched; registered→generated; undelivered-attempt→in-transit; unknown→in-transit + one warn per distinct code). **Terminal-precedence** (reuses core `TerminalShipmentStatusValues`): a delivered/failed anywhere in history wins, latest terminal breaks ties (`failed`-after-`delivered` ⇒ `failed`).

## Worker + scheduling
- `DpdIntegrationModule` registered in `apps/worker/src/plugins.ts` + the `#917` jest-integration mapper lines; `fast-xml-parser` declared on the plugin package.
- Conservative env-gated poll (`dpd-shipment-status-sync`, default 30 min) — the **only** DPD tracking path (no DPD webhook). Per-waybill fan-out is a documented trade-off; batch op is the escape hatch.

## How tested
`pnpm type-check` (repo) ✓, `pnpm lint` + `check:invariants` ✓, full `pnpm test` ✓ (dpd-polska **110**, all packages). Integration: the new **`dpd-tracking.int-spec`** (real adapter resolved via DI decoding a mocked SOAP response — delivered history + empty history) ✓, and worker boot with DPD registered ✓. New unit specs: SOAP client (fault/retry/single-event), mapper (classify / Warsaw-timezone / terminal-precedence / redirect), adapter delegation, scheduler env-gate.

## Deferred (documented, non-blocking)
- **Redirect auto-follow** (`230402` → new waybill): OL keeps polling the original (status stalls at in-transit, logged) — rewriting `providerShipmentId` is a follow-up.
- **Demo InfoServices host** (`dpdinfoservicesdemo…`) is inferred from the naming pattern (`// TODO confirm` against the demo WSDL); PROD is confirmed.
- **Account-bulk `getEventsForCustomerV4` + `markEventsAsProcessed`** — the future throughput optimization if per-waybill fan-out becomes a problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)