### PR TITLE
docs(adr): ADR-023/024 — cross-platform listing + shop ProductPublisher

### DIFF
--- a/docs/architecture/adrs/023-cross-platform-category-and-attribute-projection.md
+++ b/docs/architecture/adrs/023-cross-platform-category-and-attribute-projection.md
@@ -1,0 +1,216 @@
+# ADR-023: Cross-platform category placement and attribute projection for listing master products
+
+- **Status**: Accepted
+- **Date**: 2026-06-13
+- **Authors**: @piotrswierzy
+
+> Supersedes the design in the unmerged `adr-015-product-sync-mapping` branch (#1005 / PR #1007), which generalised the category-mapping *table* but (a) modelled attribute values as plain neutral strings that cannot produce a valid Allegro parameter payload, (b) keyed platform-pair defaults on store-local category ids, and (c) scoped mappings by a single ambiguous `connection_id`.
+>
+> **Pairs with [ADR-024](./024-destination-listing-capabilities.md)** (destination listing capabilities — marketplace `OfferManager` vs shop `ProductPublisher`). ADR-023 owns the *shared brain* (where a product is placed + how its attributes are projected); ADR-024 owns *how each destination shape consumes it*. The two were designed together.
+
+## Context
+
+A product/inventory **master** (today PrestaShop; WooCommerce also implements `ProductMaster`) is listed for sale on a **destination** channel. "Listed with correct categories" is a four-stage pipeline whose rules differ per destination:
+
+1. **Placement** — put the product into the right destination category.
+2. **Requirement discovery** — what does that category demand (required parameters, leaf-only)?
+3. **Attribute projection** — turn the product's descriptive attributes into the destination's parameter shape.
+4. **Publish gate** — publishable vs. needs-operator-input vs. infra-error.
+
+### The asymmetry that drives the design: marketplace vs. shop
+
+| | Marketplace (Allegro, ERLI) | Shop (WooCommerce, Shopify) |
+|---|---|---|
+| Taxonomy | Closed, global, rigid, **leaf required** | Open, seller-owned, free-form, **multi-category** |
+| Action on it | **Resolve into** an existing category | **Provision** — mirror / create the category |
+| Category drives parameters? | **Yes** — category-scoped, dictionary-constrained, required-gated, offer/product section | No — attributes free-form, optional |
+| "Listing" capability | `OfferManager.createOffer` (offer ≠ product) — ADR-024 | `ProductPublisher.publishProduct` (owned record) — ADR-024 |
+| Barcode→category lookup | Yes (GTIN → catalog → category) | None |
+
+This ADR settles the **stages 1–4 brain** that both destination shapes share. The capability shapes themselves live in ADR-024.
+
+### Taxonomy provenance — the third mode (ERLI-driven)
+
+Research into the in-flight ERLI integration (spec PR #999, #984/#985) surfaced a mode the prior draft missed. A destination relates to "its" taxonomy in one of three ways:
+
+- **Owns** it (Allegro): has its own category tree + per-category parameter schema (`CategoryParametersReader`). Resolve attribute values against *its* live dictionary.
+- **Borrows** another connection's taxonomy (ERLI accepts Allegro category/parameter ids verbatim via `source:"allegro"`; it ships **no** `CategoryBrowser`/`CategoryParametersReader`). Pass the source-provenance ids through; do **not** attempt per-destination dictionary resolution.
+- **Open** taxonomy (shop): no fixed tree, no required-parameter gate; placement is *provisioning* (mirror/create), realized by ADR-024's `CategoryProvisioner`.
+
+Provenance is the axis that lets one neutral brain serve all three. It also yields a concrete win: because ERLI *borrows* Allegro's taxonomy, **an existing PrestaShop→Allegro category mapping is reusable for ERLI at zero extra mapping cost** — the mapping store must be keyed so an Allegro-provenance row resolves for any destination that consumes Allegro ids.
+
+### What already ships (the seams we build on)
+
+- **Placement orchestration**: `CategoryResolutionService` (`libs/core/src/listings/`) — a 3-step chain (barcode → configured mapping → manual), already platform-agnostic in shape; its types still leak Allegro names (`CategoryResolutionResult.allegroCategoryId`, `IMappingConfigService.resolveAllegroCategory`).
+- **Storage**: `category_mappings` + `CategoryMapping` entity + `CategoryMappingRepositoryPort` (`libs/core/src/mappings/`). Columns hard-named `prestashop_category_id`/`allegro_category_id`; unique key `(connection_id, prestashop_category_id)` where `connection_id` is the **destination** connection and there is **no source-connection identity**.
+- **Capabilities (the generic destination surface, sub-capabilities of `OfferManagerPort`)**: `CategoryBrowser.fetchCategories`, `CategoryBarcodeMatcher`/`EanCategoryMatcher`, `CategoryParametersReader.fetchCategoryParameters({categoryId}) → CategoryParameter[]` (each parameter carries `required`, `section: 'offer'|'product'`, `type`, a `dictionary` of `{id, value}`).
+- **Source data**: `ProductVariant.attributes: Record<string,string> | null` (variant-level; `Product` carries none).
+- **Failure plumbing**: a `null` category already becomes `business_failure` (`OfferBuilderService` → `OfferBuilderValidationException` → `OfferCreationExecutionService.recordToOutcome → 'business_failure'`, ADR-007).
+
+### Two confirmed gaps
+
+- **Attribute → parameter projection does not exist.**
+- **Source categories are read at sync but thrown away** — `MasterProductSyncService` strips them; `ProductOrmEntity` has no category column. So per-source-category mapping has **no input today**. This is the load-bearing prerequisite (Phase 0 below).
+
+### Industry validation
+
+A competitor/market scan (BaseLinker, ChannelEngine, Linnworks, Sellbrite, M2E Pro, ChannelAdvisor, GoDataFeed) corroborates the core decisions: per-source-category mapping configured once and reused with a per-product override is the **near-universal** pattern; dictionary values are mapped by name and **resolved to native ids at publish-time** (no tool stores raw Allegro/eBay value ids); **pairwise** source→destination mapping dominates — **no** surveyed tool uses a canonical/pivot taxonomy; required-parameter **completeness worklists** (mapped/unmapped per category) are the scale UX; AI category/param suggestion is now standard but manual override stays authoritative.
+
+## Decision
+
+**Keep all platform specifics in the destination adapter behind existing capabilities; core stays neutral, capability-driven, and provenance-aware. Generalise the placement stack in place; add a neutral attribute-projection stack that resolves to native ids at publish-time from the live category schema — never by storing the destination's id space in core.**
+
+### 0. Phase 0 — persist source categories (prerequisite, ships first)
+
+Add a `categories` JSONB column to `Product` (source-provenance category ids/paths); stop stripping them in `MasterProductSyncService`. Nothing downstream works without this — `CategoryResolutionService` already accepts `sourceCategoryIds` but the product cannot supply them post-sync.
+
+### 1. Placement = a capability-gated, provenance-aware resolution chain → a neutral destination category
+
+`CategoryResolutionService` generalised (names neutralised — see §Contract surface). Resolution order, each step gated on a declared capability:
+
+1. **Provision** (open provenance) — if the destination implements `CategoryProvisioner` (ADR-024), mirror the source path / create-if-missing.
+2. **Barcode** — `CategoryBarcodeMatcher`/`EanCategoryMatcher` (GTIN → catalog → category). Auto, highest-leverage where the GTIN is in the destination/borrowed catalog.
+3. **Per-source-category mapping** — a configured `(source category) → (destination category)` row (§2). The scalable manual lever: map once per source category.
+4. **Manual pick** — operator chooses; resolution returns `null` until they do.
+
+Output is a neutral `{ destinationCategoryId, provenance, method }`. The chain is identical for Allegro (owns), ERLI (borrows — barcode/mapping resolve to Allegro ids passed through), and a future shop (open — provision). Which steps are *available* is decided by capability presence, never `platformType` string-matching.
+
+### 2. Scope mappings by **source connection + destination connection** (and provenance), not a single ambiguous id
+
+Category ids are **store-local** — PrestaShop category `15` differs across stores. So:
+
+- Key: `(source_connection_id, destination_connection_id, source_category_id) → (destination_category_id, …)`.
+- Add `destination_taxonomy_provenance` (e.g. `'allegro'`) so a *borrowed-taxonomy* destination (ERLI) resolves against the owner's (Allegro's) mappings without re-authoring.
+- **Drop platform-pair defaults for categories** — a pair-default keyed on a store-local id is unsound. (§4 explains why attributes are different.)
+
+### 3. Attribute projection lives in **core**, provenance-aware, over the neutral `CategoryParameter` output
+
+Once the category is resolved, core projects attributes generically — no new capability, no destination ids in core tables:
+
+- **Owns provenance**: read `CategoryParametersReader.fetchCategoryParameters({categoryId})`; for each parameter, find the mapped source attribute + value; resolve `type:'dictionary'` to `{id, valuesIds:[entry.id]}` by matching the mapped value against `parameter.dictionary[].value` (exact, case-insensitive), free-text to `{id, values:[mapped]}`; take `section` from the parameter (never stored in the mapping).
+- **Borrows provenance** (ERLI): emit the source-provenance parameter ids/values directly (the owner's schema already validated them); no per-destination dictionary lookup.
+- **Open provenance** (shop): emit attributes as free-form destination attributes (no required gate); ADR-024 maps these to Woo global/custom attributes / Shopify category metafields.
+
+The destination's own schema is the source of truth for ids/sections/dictionaries, fetched at publish-time — so core stores only neutral, human-meaningful intent and works unchanged for any destination.
+
+### 4. Mapping units, and where a "default" is legitimate
+
+- **Category mappings**: per `(source_connection, destination_connection, source_category)`. No connection-wide default (ids are store-local).
+- **Attribute key mappings**: per `(source_connection, source_attribute_key)` with an **optional** destination-category scope. A category-NULL row is a legitimate connection-wide default *because attribute keys are stable across categories* (`color`/`size`/`brand`) — the asymmetry that makes pair-defaults wrong for categories but right for attributes. Category-scoped rows override.
+- **Attribute value mappings**: child rows `source_value → destination_value` (human strings). Category-specific dictionary-id resolution happens at projection-time (§3), so stored values stay neutral and portable.
+
+### 5. Publish gate — three outcomes, never one `catch`
+
+- **Required category unmapped, or a `required` parameter has no resolvable value** → `business_failure` (ADR-007) with an actionable payload (unmapped source category / attribute keys). Never fabricate `uncategorized` or a placeholder value.
+- **Optional attribute unmapped or value not in dictionary** → omit + warn (`unmappedSourceKeys`); the listing still publishes.
+- **Infra error** → throw and let the job retry.
+
+### 6. `CategoryParameter` extensions for marketplace-generality
+
+The neutral shape represents Allegro + eBay cleanly; to avoid getting stuck on a 3rd marketplace, add now (harmless for Allegro/ERLI/shops):
+
+- `multiValue: boolean` (eBay `itemToAspectCardinality: MULTI`, Allegro `variantsAllowed`).
+- `dictionary[].id?` — Allegro uses value **ids**; eBay/Amazon use **labels**. Carry both.
+- **Documented limit**: Amazon's Product-Type JSON-Schema conditional/nested requirements don't fit a flat list — the abstraction captures Amazon's *flattened top-level* required attributes only.
+
+## Flow
+
+Placement (provenance-aware chain) → projection (over the live category schema) → publish gate. The same brain serves any destination shape; `business_failure` is raised at two points (unresolved required category, unresolved required parameter).
+
+```mermaid
+sequenceDiagram
+    participant Builder as Listing builder (offer/product)
+    participant Res as CategoryResolutionService
+    participant Cap as Destination adapter (capabilities)
+    participant Map as Mapping store
+    participant Proj as AttributeProjectionService
+
+    Builder->>Res: resolveCategory(source product, dest connection)
+    Note over Res: provenance: owns | borrows | open
+    alt open (shop)
+        Res->>Cap: CategoryProvisioner.provisionCategory(source path)
+        Cap-->>Res: destinationCategoryId (created / mirrored)
+    else barcode available
+        Res->>Cap: CategoryBarcodeMatcher.match(GTIN)
+        Cap-->>Res: destinationCategoryId | null
+    end
+    opt still unresolved
+        Res->>Map: findBySourceCategory(srcConn, destConn, srcCat)
+        Map-->>Res: destinationCategoryId | null
+    end
+    Res-->>Builder: {destinationCategoryId, provenance, method} | null
+    alt category null
+        Builder-->>Builder: business_failure (needs operator mapping)
+    end
+
+    Builder->>Proj: project(attributes, destCategoryId, provenance)
+    alt owns (Allegro)
+        Proj->>Cap: CategoryParametersReader.fetch(destCategoryId)
+        Cap-->>Proj: CategoryParameter[] (required, section, dictionary)
+        Note over Proj: map source attr→param; resolve value→valueId at publish-time
+    else borrows (ERLI)
+        Note over Proj: pass source-provenance ids/values through verbatim
+    else open (shop)
+        Note over Proj: emit free-form destination attributes
+    end
+    Proj-->>Builder: ResolvedParameter[] + unmappedSourceKeys
+    alt required parameter unresolved
+        Builder-->>Builder: business_failure
+    end
+```
+
+## Contract surface to neutralise (not just the table)
+
+The Allegro naming is welded through the vertical; neutralisation must cover all of it:
+
+- Entity `CategoryMapping`: `prestashopCategoryId`/`allegroCategory*` → `sourceCategoryId`/`destinationCategory*`; add `sourceConnectionId`, `destinationConnectionId`, `destinationTaxonomyProvenance`.
+- `CategoryMappingRepositoryPort.findByPrestashopCategoryId` → `findBySourceCategory(...)`.
+- `IMappingConfigService.resolveAllegroCategory` / `deleteCategoryMapping(…, prestashopCategoryId)` → neutral names; `CategoryMappingInput` fields.
+- `CategoryResolutionResult.allegroCategoryId` → `destinationCategoryId` (+ `provenance`).
+- API DTOs + the FE mapping editor and create-offer wizard.
+
+## Storage
+
+**Category — evolve + migrate (real production rows exist):**
+
+- Rename `prestashop_category_id` → `source_category_id`; `allegro_category_id/name/path` → `destination_category_id/name/path`.
+- Add `source_connection_id`, `destination_connection_id` (existing `connection_id` becomes `destination_connection_id`), `destination_taxonomy_provenance`.
+- **Backfill**: `destination_connection_id` from existing `connection_id`; `destination_taxonomy_provenance='allegro'`; `source_connection_id` to the single PrestaShop `ProductMaster` connection **iff exactly one exists**, else `NULL` + flag in the editor as "needs source store" (we cannot invent which store a historical row came from).
+- Unique index `(source_connection_id, destination_connection_id, source_category_id)`.
+
+**Attribute — new tables:**
+
+- `attribute_mappings` (`source_connection_id`, `destination_connection_id`, `source_attribute_key`, `destination_parameter_name`, **nullable** `destination_category_id`). **Two partial unique indexes** for Postgres NULL-distinct semantics (precedent: `product_content_field`, `prompt_templates`): `… WHERE destination_category_id IS NULL` (default) and `… WHERE destination_category_id IS NOT NULL` (override).
+- `attribute_value_mappings` (`attribute_mapping_id` FK, `source_value`, `destination_value`), unique `(attribute_mapping_id, source_value)`.
+
+No `destination_section` column (from `CategoryParameter.section`). No destination parameter/value **ids** stored (resolved at publish-time).
+
+## Alternatives considered
+
+- **Store destination-native ids in core (parameter id + value id), category-scoped.** Rejected: leaks the destination id space, forces a row per attribute per category, isn't portable. Publish-time resolution gives the same payload with neutral storage. (Industry scan: no tool stores native ids.)
+- **A per-platform `AttributeProjector` capability adapter.** Rejected: projection is generic over the neutral `CategoryParameter` contract; adapters would hold no platform code.
+- **One `connection_id`, no source scoping (status quo + prior draft).** Rejected: store-local ids collide across multi-store (§2).
+- **Platform-pair defaults for categories.** Rejected (§2); kept for attributes only (§4).
+- **Canonical/pivot taxonomy.** Rejected for now — no surveyed tool uses one; the marketplaces don't share a standard tree (Google/GPC only partially inter-map). The row schema (with `destination_taxonomy_provenance`) leaves room to add a pivot column if a 3rd distinct marketplace ever forces it.
+- **Fuzzy / AI auto-categorisation.** Deferred by decision (scope = barcode + manual per-category). The chain has room for a suggest-and-approve step later (OL already ships an AI subsystem).
+
+## Consequences
+
+**Pros:** one neutral, provenance-aware, capability-driven mechanism for any destination; no platform strings/ids in core; reuses four shipped capabilities + the existing chain; multi-store-correct; ERLI reuses Allegro mappings for free; attribute defaults where sound and per-category where required; clean three-way failure; honest migration. Aligns with the dominant industry pattern.
+
+**Cons / trade-offs:**
+- **Publish-time schema fetch** per offer (mitigated by the adapter's existing 24h category-parameter cache).
+- **Exact-string value/name matching** (no fuzzy, by decision) — a non-matching value counts unmapped (operator fixes it).
+- **Parameter matched by name across categories** — Allegro names vary per category; the editor should let operators pick from discovered names.
+- **Migration touches a populated table** and cannot reconstruct historical source-connection identity beyond one source store (flagged, not guessed).
+- **Manual mapping maintenance** beyond barcode.
+
+**Deferred (not designed here):** AI category/param suggestion; mapping-editor completeness-worklist UX (the competitor pattern); caching of projection results; soft-delete/audit on mapping rows; a pivot taxonomy.
+
+## Related
+
+- Supersedes the `adr-015-product-sync-mapping` draft (#1005 / PR #1007).
+- **[ADR-024](./024-destination-listing-capabilities.md)** — the listing-capability shapes that consume this brain.
+- [ADR-002](./002-capability-ports-with-sub-capabilities.md), [ADR-007](./007-syncjob-status-vs-outcome-split.md), [ADR-004](./004-identifier-mapping-service.md).
+- Issues: #1005; #824 (variant offers / barcode self-link); ERLI (#978 family, spec PR #999).
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md) § Products, Listings.

--- a/docs/architecture/adrs/024-destination-listing-capabilities.md
+++ b/docs/architecture/adrs/024-destination-listing-capabilities.md
@@ -1,0 +1,169 @@
+# ADR-024: Destination listing capabilities — marketplace `OfferManager` vs shop `ProductPublisher`
+
+- **Status**: Accepted
+- **Date**: 2026-06-13
+- **Authors**: @piotrswierzy
+
+> **Pairs with [ADR-023](./023-cross-platform-category-and-attribute-projection.md).** ADR-023 owns the *shared brain* (category placement + attribute projection + provenance). This ADR owns *how each destination shape is listed to* and how a new **shop** listing capability is introduced without forking the offer pipeline. They were designed together.
+
+## Context
+
+OpenLinker lists a master catalog product onto destinations of two structurally different kinds. "List a product" is **not one capability**:
+
+- **Marketplace** (Allegro, ERLI): listing creates an **offer** — a thin sell-record over a (catalog) product, into a **closed** taxonomy, gated by required category parameters. Today: `OfferManagerPort.createOffer` + sub-capabilities. ERLI (spec PR #999) is a marketplace whose backend is *product-shaped* (single seller-keyed resource), yet the team deliberately maps it onto `OfferManager` — confirming the verb-based capability ports already stretch across offer-backed and product-backed marketplaces.
+- **Shop** (WooCommerce, Shopify): listing creates/owns the **product record itself** (content, images, SEO, price/stock as product fields), into an **open** taxonomy you can create into, with a separate **visibility/publication** axis and no required-parameter gate.
+
+The research (WooCommerce REST `POST /products` + `POST /products/categories`; Shopify GraphQL `productSet` + `publishablePublish`; how BaseLinker/Codisto publish to shops) shows the shop case **shares** a core with marketplace offer-create but **diverges** on three axes too substantial to collapse into `createOffer`:
+
+| | Marketplace `createOffer` | Shop publish |
+|---|---|---|
+| Object created | Offer over a catalog card | **The owned product record** (content/images/SEO) |
+| Taxonomy | Map-only into a fixed tree | **Create/mirror** (hierarchical, `POST products/categories`) |
+| Cardinality | Single category | **Multiple categories** (Woo) |
+| Required-param gate | Hard gate | None |
+| Visibility | ≈ offer activation | **Separate channel-publish** (Shopify `publishablePublish`) + draft/`status` |
+| Price/stock | On the offer | **On the product/variant** |
+
+**Shared with `OfferManager`:** category resolution + attribute projection (ADR-023), variant expansion (#824 analog), stock/price sync, idempotent upsert + identifier mapping.
+
+The current pipeline is offer-named end-to-end (`OfferCreationRecord`, `BulkOfferCreationBatch`, `marketplace.offer.create`, `OfferBuilderService`). An audit shows it is **~60% destination-neutral orchestration** (batch state machine, at-most-once advancement gate, variant expansion, idempotency, enqueue/execute/retry) and **~40% offer-welded** (entity *names*, the job-type string, and the genuinely-divergent builder).
+
+## Decision
+
+**Introduce a sibling shop-listing capability rather than overloading `createOffer`; share the cross-cutting brain (ADR-023) and extract the destination-neutral orchestration so both paths reuse it; keep the builders separate.**
+
+### 1. New capability: `ProductPublisher` (shop-side), sibling to `OfferCreator` (marketplace-side)
+
+A new optional capability with its own port + `is*` type guard, following the `OfferCreator` precedent:
+
+```
+publishProduct(cmd: PublishProductCommand): Promise<PublishProductResult>
+```
+
+`PublishProductCommand` expresses what `createOffer` cannot: **multi-category placement, draft/published status, full owned-record fields (content/images/SEO), price/stock as product fields**. It does **not** carry the offer-only concepts (catalog-card link, required-param gate).
+
+Rejected: folding shop publish into `OfferCreator` (ERLI-style). ERLI is a *marketplace* whose backend happens to be product-shaped, so wearing `OfferManager` is conceptually honest there. A shop is a different domain (own-catalog projection), and the three divergences above would leak offer-isms into a "createOffer" that no longer means "create an offer."
+
+### 2. New capability: `CategoryProvisioner` (the "open" provenance from ADR-023, now real)
+
+```
+provisionCategory(cmd: ProvisionCategoryCommand): Promise<CategoryProvisionResult>
+```
+
+Mirrors a source category path on the destination, creating missing nodes (`POST products/categories` with `parent`), returning the destination category id. It is ADR-023's placement step #1 — only shops implement it; marketplaces never can (you cannot create an Allegro/eBay category). Today no capability *creates* categories — `assignCategories` only attaches to existing ones — so this is net-new.
+
+### 3. Visibility is a first-class axis, not "active = visible"
+
+The command/result model a publication state distinct from record existence and from data sync: Woo `status` (draft→publish), Shopify `status` (ACTIVE/DRAFT) **plus** per-channel `publishablePublish`. Marketplace offers collapse this into activation; shops do not. The shop path must not assume create ⇒ visible.
+
+### 4. Extract destination-neutral orchestration; keep builders separate
+
+Rather than copy-paste a parallel bulk pipeline, **lift the ~60% generic scaffolding** — `BulkOfferCreationBatch` → a neutral `BulkListingBatch` (operation-typed), the at-most-once `bulk_batch_advancements` gate, variant expansion, the enqueue/execute/progress/retry services — into destination-neutral primitives that both `marketplace.offer.create` and the new `shop.product.publish` use. The **builders stay separate** (`OfferBuilderService` vs a new `ProductPublishBuilderService`) because that is the genuinely-divergent 40% (offer payload + required-param gate vs owned-record + provisioning).
+
+This extraction is justified now (not premature) because there are **two real consumers** plus ERLI as a third on the offer side — the rule-of-three threshold is met. It is the medium-effort path; a full parallel copy is the fallback if the extraction proves riskier than the duplication on this hot subsystem.
+
+### 5. `ProductMaster.createProduct` is not reused as the publish seam
+
+WooCommerce already implements `ProductMaster.createProduct` (write methods exist, never called), but `ProductMaster` is semantically *master/source* (read the catalog of truth). Using it as a destination-publish seam blurs source vs. destination. `ProductPublisher` is a distinct capability; an adapter may implement both (a WC connection can be a source master *and* a publish destination) without conflating them.
+
+## Flow
+
+Both listing paths share the neutral enqueue/batch orchestration and the ADR-023 brain; they branch only on the resolved capability and the final adapter call.
+
+```mermaid
+sequenceDiagram
+    actor Op as Operator
+    participant API
+    participant Enq as Neutral enqueue / batch (shared §4)
+    participant Job as Worker handler
+    participant Exec as Execution service
+    participant Brain as ADR-023 brain (resolve + project)
+    participant Dest as Destination adapter
+
+    Op->>API: list product(s) on connection
+    API->>API: resolve capability (OfferCreator? ProductPublisher?)
+    API->>Enq: enqueue (marketplace.offer.create | shop.product.publish)
+    Enq-->>Job: one job per product / variant
+    Job->>Exec: execute
+    Exec->>Brain: resolve category + project attributes
+    Brain-->>Exec: destCategory + ResolvedParameter[] (or business_failure)
+    alt marketplace (OfferCreator)
+        Exec->>Dest: createOffer(cmd)
+        Dest-->>Exec: externalOfferId
+    else shop (ProductPublisher)
+        Exec->>Dest: provisionCategory(...) then publishProduct(cmd)
+        Dest-->>Exec: externalProductId + visibility/publication
+    end
+    Exec-->>Job: record + outcome (ok | business_failure)
+```
+
+### Shop publish path (`ProductPublisher`), in detail
+
+The branch above collapses the shop path to one line; it differs from `createOffer` enough to warrant its own flow — category *provisioning* (not just resolution), owned-record fields, and a visibility step decoupled from record creation.
+
+```mermaid
+sequenceDiagram
+    participant Exec as ProductPublishExecutionService
+    participant Brain as ADR-023 brain
+    participant Prov as CategoryProvisioner (shop adapter)
+    participant Pub as ProductPublisher (shop adapter)
+    participant Map as IdentifierMapping
+
+    Note over Exec: shop.product.publish job (per product / variant)
+    Exec->>Brain: resolveCategory (provenance = open)
+    Brain->>Prov: provisionCategory(source category path)
+    Prov-->>Brain: destCategoryId[] (mirror / create-if-missing, hierarchical, multi)
+    Brain->>Brain: project attributes → free-form destination attributes
+    Brain-->>Exec: destCategoryId[] + attributes + unmappedSourceKeys
+
+    Exec->>Map: getExternalId(product, destConnection)
+    Map-->>Exec: externalProductId | none
+    alt new product
+        Exec->>Pub: publishProduct(create: content/images/SEO,\nmulti-category, price+stock as fields, status=draft)
+        Pub-->>Exec: externalProductId
+        Exec->>Map: createMapping(product → externalProductId)
+    else already published
+        Exec->>Pub: publishProduct(upsert by externalProductId)
+        Pub-->>Exec: externalProductId
+    end
+
+    Exec->>Pub: setVisibility(status→publish /\npublishablePublish → sales channel)
+    Pub-->>Exec: visible
+    Exec-->>Exec: record + outcome (ok | business_failure)
+```
+
+## Impact surface (audited)
+
+A new shop-listing capability touches, end-to-end (~13 new files, ~15 edits):
+
+- **Capability**: add `'ProductPublisher'` (+ `'CategoryProvisioner'`) to `CoreCapabilityValues` (`integrations/domain/types/adapter.types.ts`); add to the WooCommerce manifest `supportedCapabilities`; `enabledCapabilities` on `Connection` already accepts open strings.
+- **Ports**: new `product-publisher.capability.ts` + `category-provisioner.capability.ts` (+ `is*` guards) under `listings/domain/ports/capabilities/`; barrel exports.
+- **Types/exceptions**: `PublishProductCommand/Result`, `ProvisionCategoryCommand/Result`, `ProductPublishRejectedException`.
+- **Jobs**: add `'shop.product.publish'` to `JobTypeValues` (`sync/domain/types/sync-job.types.ts`) + payload type; the generic Redis-Streams enqueue is reused unchanged.
+- **Worker**: new `shop-product-publish.handler.ts` + registration in `handler-registration.service.ts`.
+- **Services**: `ProductPublishExecutionService` (+ interface, tokens) consuming the ADR-023 resolution/projection services + `CategoryProvisioner`; reuse the extracted neutral enqueue/batch/progress/retry.
+- **Persistence**: `listing_creation_records` (generalised from `offer_creation_records`) or a sibling table; ORM entity + repo port + impl + migration.
+- **API**: single + bulk publish controllers under `apps/api/src/listings/http/` + DTOs.
+- **FE**: a `shopProductPublishWizard` plugin contribution + a "Publish to shop" CTA gated on `enabledCapabilities.includes('ProductPublisher')`; the existing wizard-resolver pattern is reused.
+
+## Alternatives considered
+
+- **Overload `OfferManager.createOffer` for shops (ERLI-style).** Rejected (§1): leaks the three divergences into an offer capability; shops are a different domain.
+- **Reuse `ProductMaster.createProduct`.** Rejected (§5): conflates source and destination roles.
+- **Copy-paste a parallel bulk pipeline.** Rejected as default (§4): two+ consumers justify extraction; copy is the fallback only if extraction is riskier than duplication.
+- **One unified `createListing` capability over a `listingMode` flag.** Rejected: the verb-based ports + sub-capabilities already give per-destination variation without a god-method; a mode flag re-centralises divergence the capability model is designed to keep at the edge. (Market evidence: BaseLinker — the closest competitor — keeps marketplace-listing and shop-publishing as separate flows.)
+
+## Consequences
+
+**Pros:** honest modelling of two genuinely different destination shapes; shops get category *provisioning* + multi-category + draft/visibility that offers never had; the shared brain (ADR-023) and the neutral orchestration are reused, not duplicated; ERLI stays on `OfferManager` (validated); capability-presence routing means no `platformType` branching.
+
+**Cons / trade-offs:** the orchestration extraction is a refactor of the hottest subsystem (#726/#824 just landed) — sequence it carefully behind tests; two builder code-paths to maintain; the visibility axis adds state the offer model didn't have; WooCommerce global-attribute-on-variation writes are documented as REST-friction-prone (prefer per-product custom attributes initially); Shopify is GraphQL-forward (REST product endpoints legacy as of Oct 2024) — the adapter targets `productSet` + `publishablePublish`.
+
+**Deferred:** Shopify collections (orthogonal to categories); scheduled publication; per-channel publication fan-out beyond Online Store; bulk publish UX depth.
+
+## Related
+
+- **[ADR-023](./023-cross-platform-category-and-attribute-projection.md)** — the shared placement/projection brain (provenance: owns/borrows/**open** ← this ADR's `CategoryProvisioner`).
+- [ADR-002](./002-capability-ports-with-sub-capabilities.md) (sub-capability pattern reused), [ADR-007](./007-syncjob-status-vs-outcome-split.md) (`business_failure`), [ADR-004](./004-identifier-mapping-service.md).
+- ERLI (#978 family, spec PR #999) — the marketplace-on-`OfferManager` precedent.
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md) § Listings, Products.

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -111,5 +111,7 @@ One pointer per section, identical format every time.
 | [ADR-020](./020-neutral-delivery-intent-shipping-dispatch.md) | Neutral delivery intent as the shipping-dispatch caller contract | Accepted | 2026-06-05 |
 | [ADR-021](./021-third-party-native-inbound-webhook-ingestion.md) | Third-party-native inbound webhook ingestion via a per-provider decoder | Proposed | 2026-06-08 |
 | [ADR-022](./022-dpd-tracking-soap-dpdinfoservices.md) | DPD Polska tracking transport: SOAP DPDInfoServices (dual-transport plugin) | Proposed | 2026-06-11 |
+| [ADR-023](./023-cross-platform-category-and-attribute-projection.md) | Cross-platform category placement and attribute projection | Accepted | 2026-06-13 |
+| [ADR-024](./024-destination-listing-capabilities.md) | Destination listing capabilities — marketplace OfferManager vs shop ProductPublisher | Accepted | 2026-06-13 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*


### PR DESCRIPTION
## Summary

Two interlocking, **Accepted** ADRs for listing a master-catalog product onto any destination with correct categories:

- **ADR-023 — Cross-platform category placement and attribute projection.** The neutral, capability-driven *brain* shared by every destination. Provenance-aware (**owns** = Allegro / **borrows** = ERLI reuses Allegro ids / **open** = shop). Dictionary value-ids are resolved at publish-time from the destination's live category schema — core stores only neutral intent, never a platform's id space.
- **ADR-024 — Destination listing capabilities.** "List a product" is not one capability: marketplace `OfferManager.createOffer` (Allegro offer / ERLI product-backed) vs a new shop `ProductPublisher` + `CategoryProvisioner`. Shared neutral orchestration; separate builders.

Both carry Mermaid sequence diagrams (ADR-024 includes a dedicated `ProductPublisher` shop-publish flow) and are indexed in `adrs/README.md`.

## Supersedes

Supersedes the design in the unmerged `adr-015-product-sync-mapping` branch / **#1007** (kept the table-rename idea, but modelled attribute values as plain strings that can't produce a valid Allegro payload, keyed pair-defaults on store-local category ids, and scoped by a single ambiguous `connection_id`). Builds on that groundwork — thanks @norbert-kulus-blockydevs. PR #1007 will be closed as superseded.

## Grounding

Decisions are validated against the live code (offer pipeline coupling, `CategoryParametersReader`/`ProductVariant.attributes`, the source-category-stripped-at-sync gap), the in-flight ERLI spec (PR #999), and an industry scan (BaseLinker, ChannelEngine, Linnworks, M2E Pro, et al.).

## Scope

Docs only — no code. Implementation is tracked as the epic **#1005** and its child issues.

Part of #1005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)