### PR TITLE
feat(listings,allegro): neutral CategoryParameter.multiValue (#1035)

### DIFF
--- a/docs/architecture/adrs/023-cross-platform-category-and-attribute-projection.md
+++ b/docs/architecture/adrs/023-cross-platform-category-and-attribute-projection.md
@@ -109,8 +109,8 @@ The destination's own schema is the source of truth for ids/sections/dictionarie
 
 The neutral shape represents Allegro + eBay cleanly; to avoid getting stuck on a 3rd marketplace, add now (harmless for Allegro/ERLI/shops):
 
-- `multiValue: boolean` (eBay `itemToAspectCardinality: MULTI`, Allegro `variantsAllowed`).
-- `dictionary[].id?` — Allegro uses value **ids**; eBay/Amazon use **labels**. Carry both.
+- `multiValue` (eBay `itemToAspectCardinality: MULTI`; Allegro `restrictions.multipleChoices` or `allowedNumberOfValues > 1` — there is no single Allegro `variantsAllowed` field). Shipped in #1035 as **optional** (`multiValue?: boolean`, additive) — promote to required when a second producing adapter lands.
+- `dictionary[].id` already exists and is **required** on `CategoryParameterDictionaryEntry` (Allegro uses value **ids**); eBay/Amazon use **labels**, so a labels-only adapter synthesises an id at its boundary rather than the field being made optional (avoids a breaking change for current consumers).
 - **Documented limit**: Amazon's Product-Type JSON-Schema conditional/nested requirements don't fit a flat list — the abstraction captures Amazon's *flattened top-level* required attributes only.
 
 ## Flow

--- a/docs/plans/implementation-plan-category-parameter-multivalue.md
+++ b/docs/plans/implementation-plan-category-parameter-multivalue.md
@@ -1,0 +1,37 @@
+# Implementation Plan — CategoryParameter `multiValue` (#1035)
+
+**Issue:** #1035 (epic #1005, ADR-023 §6) · **Layer:** CORE contract + Integration (Allegro) mapper · **Size:** XS
+
+## 1. Understand
+
+Add the neutral multi-value cardinality signal to the `CategoryParameter` contract so cross-platform consumers (the attribute-projection brain, #1038) can tell a multi-value parameter from a single-value one without knowing each platform's encoding (eBay `itemToAspectCardinality: MULTI`, Allegro `restrictions.multipleChoices` / `allowedNumberOfValues`).
+
+**Non-goals:** building eBay/Amazon adapters; FE rendering changes; making `dictionary[].id` optional.
+
+## 2. Research findings (baseline / reuse check — substitutes for a formal pre-implement gate on this XS change)
+
+- `CategoryParameterDictionaryEntry` **already carries `id` + `value`** (both, `id` required) → the issue's "add `dictionary[].id`" half is **already satisfied**. We will **not** make `id` optional: it's required today, every consumer (Allegro mapper, FE `serialize-allegro-parameters`) relies on it, and there is no present adapter that lacks stable value ids. A future eBay adapter synthesises an id at its boundary. (Documented deviation from ADR-023 §6's `dictionary[].id?`.)
+- `multiValue` does **not** exist yet → the real work.
+- **Allegro has no `variantsAllowed` field** (ADR-023 §6's example was inaccurate). Allegro multi-value = `restrictions.multipleChoices === true || (allowedNumberOfValues ?? 1) > 1`.
+- FE reads `restrictions.multipleChoices` directly (`build-parameters-zod-schema.ts:88`) → additive `multiValue?` leaves FE untouched.
+- 7 object-literal construction sites set `section:` → making `multiValue` **required** would touch all 7 for zero present benefit. Use **optional** (`multiValue?: boolean`), per the issue's "additive" acceptance. Document the upgrade-to-required path for when a 2nd adapter lands.
+
+## 3. Design
+
+- Neutral contract: `CategoryParameter.multiValue?: boolean` — undefined ⇒ single-valued. Roll-up flag, not a replacement for `restrictions` (which keep the platform-precise counts).
+- Allegro adapter is the only producer; it emits an explicit boolean.
+
+## 4. Steps
+
+1. `libs/core/src/listings/domain/types/category-parameter.types.ts` — add `multiValue?: boolean` to `CategoryParameter` with a doc comment; add a one-line Amazon "flattened top-level only" note to the file header. **AC:** type-check green; field documented.
+2. `libs/integrations/allegro/src/infrastructure/mappers/allegro-category-parameter.mapper.ts` — populate `multiValue` from `multipleChoices`/`allowedNumberOfValues`. **AC:** dictionary multi-select → `true`; `allowedNumberOfValues > 1` → `true`; single → `false`.
+3. `…/__tests__/allegro-category-parameter.mapper.spec.ts` — add cases covering the three branches against the existing fixture. **AC:** specs pass.
+
+## 5. Validate
+
+- Architecture: contract lives in core, mapping in the adapter — no boundary crossing. Additive optional field — no breaking change. `as const`/types conventions respected. No `any`, no `console.log`.
+- Testing: unit only (pure mapper); no migration, no integration surface.
+
+## Follow-up (out of scope)
+
+ADR-023 §6 wording should be corrected when PR #1033 merges: drop the `variantsAllowed` example, and note `dictionary[].id` is required (not optional). Tracked in the #1035 PR description.

--- a/libs/core/src/listings/domain/types/category-parameter.types.ts
+++ b/libs/core/src/listings/domain/types/category-parameter.types.ts
@@ -18,6 +18,11 @@
  * Conflating them would mis-render both classes of category — see issue #410
  * for context.
  *
+ * Scope note (#1035, ADR-023 §6): this shape captures a destination's
+ * *flattened, top-level* required parameters. Amazon's Product-Type
+ * JSON-Schema conditional / nested requirements are out of scope — they don't
+ * fit a flat list and are intentionally not represented here.
+ *
  * @module libs/core/src/listings/domain/types
  */
 
@@ -99,6 +104,17 @@ export interface CategoryParameter {
   name: string;
   type: CategoryParameterType;
   required: boolean;
+  /**
+   * Neutral multi-value cardinality roll-up (#1035, ADR-023 §6): `true` when the
+   * parameter accepts more than one value — eBay `itemToAspectCardinality: MULTI`,
+   * Allegro `restrictions.multipleChoices` or `allowedNumberOfValues > 1`. A
+   * convenience flag so cross-platform consumers (e.g. attribute projection)
+   * needn't decode each platform's `restrictions` shape; `restrictions` still
+   * carries the platform-precise counts. `undefined` ⇒ single-valued. Optional
+   * for now (additive); adapters that can express it SHOULD set it explicitly —
+   * promote to required once a second producing adapter lands.
+   */
+  multiValue?: boolean;
   /** Optional unit label (e.g. "mm", "kg"). */
   unit?: string;
   /** Present when type === 'dictionary'. Entries may carry their own `dependsOnParameterValueIds`. */

--- a/libs/integrations/allegro/src/infrastructure/mappers/__tests__/allegro-category-parameter.mapper.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/mappers/__tests__/allegro-category-parameter.mapper.spec.ts
@@ -103,6 +103,24 @@ describe('toNeutralCategoryParameter', () => {
     });
   });
 
+  describe('multi-value cardinality (#1035)', () => {
+    it('sets multiValue=true for a multipleChoices dictionary parameter', () => {
+      const neutral = toNeutralCategoryParameter(findRaw(fixture, '14349')); // "Stabilizacja", multipleChoices
+      expect(neutral.multiValue).toBe(true);
+    });
+
+    it('sets multiValue=true when allowedNumberOfValues > 1', () => {
+      const neutral = toNeutralCategoryParameter(findRaw(fixture, '218145')); // "Model załączonego obiektywu", anv=5
+      expect(neutral.multiValue).toBe(true);
+    });
+
+    it('sets multiValue=false for single-value parameters', () => {
+      expect(toNeutralCategoryParameter(findRaw(fixture, '237206')).multiValue).toBe(false); // "Model", string, anv=1
+      expect(toNeutralCategoryParameter(findRaw(fixture, '38')).multiValue).toBe(false); // float, no value restriction
+      expect(toNeutralCategoryParameter(findRaw(fixture, '11323')).multiValue).toBe(false); // "Stan", single-select dictionary
+    });
+  });
+
   describe('parameter-level visibility (dependsOn)', () => {
     it('returns undefined when there is no parameter-level dependency', () => {
       const raw = findRaw(fixture, '11323'); // "Stan", no dependsOnParameterId

--- a/libs/integrations/allegro/src/infrastructure/mappers/allegro-category-parameter.mapper.ts
+++ b/libs/integrations/allegro/src/infrastructure/mappers/allegro-category-parameter.mapper.ts
@@ -37,6 +37,12 @@ export function toNeutralCategoryParameter(
     name: raw.name,
     type: raw.type,
     required: raw.required,
+    // #1035 — neutral multi-value roll-up. Allegro has no single `multiValue`
+    // flag; multi-value is expressed either as a dictionary multi-select
+    // (`multipleChoices`) or a capped value count (`allowedNumberOfValues > 1`).
+    multiValue:
+      raw.restrictions?.multipleChoices === true ||
+      (raw.restrictions?.allowedNumberOfValues ?? 1) > 1,
     unit: raw.unit,
     dictionary: raw.dictionary?.map(toNeutralEntry),
     restrictions: {


### PR DESCRIPTION
## What & why

Adds `multiValue?: boolean` to the neutral `CategoryParameter` contract — a cross-platform multi-value cardinality roll-up so consumers (the attribute-projection brain, #1038) read **one** neutral flag instead of decoding each platform's `restrictions` shape:

- eBay `itemToAspectCardinality: MULTI`
- Allegro `restrictions.multipleChoices` **or** `allowedNumberOfValues > 1`

The Allegro category-parameter mapper derives and emits it explicitly. The field is **optional/additive** — existing offer-wizard rendering is unaffected (FE reads `restrictions.multipleChoices` directly).

## Scope notes (ADR-023 §6)

The issue's premise narrowed after a baseline check:
- **`dictionary[].id` already existed** (required) on `CategoryParameterDictionaryEntry` — that half was already satisfied. Left required (making it optional would be a breaking change with no present consumer; a future eBay adapter synthesises an id at its boundary).
- **Allegro has no `variantsAllowed` field** — the ADR's example was inaccurate. Allegro multi-value is `multipleChoices`/`allowedNumberOfValues`.
- Documented the **Amazon flattened-top-level-only** limit in the type header.
- **ADR-023 §6 corrected in this PR** (now that #1033 has merged) — the `variantsAllowed` example and the `dictionary[].id?` characterisation are fixed. Factual correction only; the decision is unchanged.

## Design choice

`multiValue` is **optional** while `section` is required — deliberate: only one producer (Allegro) exists today and the issue calls for additive behaviour. The field doc flags the promote-to-required path for when a second producing adapter lands.

## Tests

3 mapper cases against the real sandbox fixture: `multipleChoices` dictionary → true; `allowedNumberOfValues > 1` → true; single-value (string anv=1, float, single-select dictionary) → false.

## Quality gate

`pnpm type-check`, `pnpm lint`, full `pnpm test` all green; pre-commit smart-test green on both commits.

Closes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)