### PR TITLE
feat(products): persist source categories on Product (#1034)

### DIFF
--- a/apps/api/src/migrations/1803000000000-add-product-categories.ts
+++ b/apps/api/src/migrations/1803000000000-add-product-categories.ts
@@ -1,0 +1,26 @@
+/**
+ * Add Product Categories (#1034 / ADR-023 §0)
+ *
+ * Adds a nullable `categories` JSONB column to `products` — the source-platform
+ * external category ids carried on `Product.categories`. Phase 0 of the
+ * cross-platform-listing epic (#1005): until now the master product sync
+ * dropped these ids on persist (no column), leaving per-source-category mapping
+ * with no input. Existing rows get `NULL`; the column repopulates on the next
+ * product sync, so no backfill is needed.
+ *
+ * Mirrors the existing nullable `images` JSONB column. `IF NOT EXISTS` /
+ * `IF EXISTS` guards keep up/down idempotent.
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductCategories1803000000000 implements MigrationInterface {
+  name = 'AddProductCategories1803000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "products" ADD COLUMN IF NOT EXISTS "categories" jsonb`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "products" DROP COLUMN IF EXISTS "categories"`);
+  }
+}

--- a/apps/api/test/integration/products-read.int-spec.ts
+++ b/apps/api/test/integration/products-read.int-spec.ts
@@ -202,4 +202,50 @@ describe('Products Read API Integration — currency persistence', () => {
     expect(item).toBeDefined();
     expect(item.currency).toBe('PLN');
   });
+
+  // #1034 — source category ids persist + survive reload. Asserted via the
+  // repository (not GET /products): the response DTO does not expose
+  // `categories` yet (that surface is #1044). The AC is the persistence
+  // round-trip against real Postgres.
+  describe('source categories persistence (#1034)', () => {
+    const baseProduct = (id: string): Product => ({
+      id,
+      name: 'Categories Roundtrip',
+      sku: null,
+      price: null,
+      currency: null,
+      description: null,
+      images: null,
+    });
+
+    const getRepo = (): ProductRepositoryPort =>
+      harness.getApp().get<ProductRepositoryPort>(PRODUCT_REPOSITORY_TOKEN);
+
+    it('round-trips populated source category ids', async () => {
+      const repo = getRepo();
+      const id = `ol_product_cats_${Date.now()}`;
+      await repo.upsert({ ...baseProduct(id), categories: ['10', '25', '100'] });
+
+      const reloaded = await repo.findById(id);
+      expect(reloaded?.categories).toEqual(['10', '25', '100']);
+    });
+
+    it('preserves an empty categories array (not coerced to absent)', async () => {
+      const repo = getRepo();
+      const id = `ol_product_cats_empty_${Date.now()}`;
+      await repo.upsert({ ...baseProduct(id), categories: [] });
+
+      const reloaded = await repo.findById(id);
+      expect(reloaded?.categories).toEqual([]);
+    });
+
+    it('returns absent categories when unset (DB null → undefined)', async () => {
+      const repo = getRepo();
+      const id = `ol_product_cats_none_${Date.now()}`;
+      await repo.upsert(baseProduct(id));
+
+      const reloaded = await repo.findById(id);
+      expect(reloaded?.categories).toBeUndefined();
+    });
+  });
 });

--- a/docs/plans/implementation-plan-1034-persist-source-categories.md
+++ b/docs/plans/implementation-plan-1034-persist-source-categories.md
@@ -1,0 +1,67 @@
+# Implementation Plan — #1034 Phase 0: persist source categories on Product
+
+**Issue:** #1034 · **Epic:** #1005 · **ADR-023 §0** (prerequisite — blocks the epic) · **Branch:** `1034-persist-source-categories-on-product`
+
+---
+
+## Phase 1 — Understand the task
+
+**Goal.** Stop silently dropping `Product.categories` (the source-platform external category ids) on persist, so per-source-category mapping (#1036+) has an input. Persist + round-trip the existing `Product.categories: string[]` field.
+
+**Layer.** **CORE** (products context) — ORM schema + repository mapping + migration. No new ports/services/tokens.
+
+**Precise diagnosis (from research).**
+- `Product` (interface) already has `categories?: string[]` — `libs/core/src/products/domain/entities/product.entity.ts:38` (commented *"not persisted on the products table"*).
+- `MasterProductSyncService.toDomainProduct` already spreads `categories` through (`...product`) — it does **not** strip; its comment ("silently dropped on persist") points at the repository.
+- The drop is in **`ProductRepository`**: `toOrmEntity` / `toDomain` map every field **except** `categories`, and `ProductOrmEntity` has **no `categories` column**.
+
+**Non-goals (Phase 0 is deliberately minimal).** No category-mapping resolution / provenance scoping (that's #1036/#1037). No change to the `categories` *shape* — keep `string[]` (the PS/Woo mappers already produce external id strings); richer `{id,path}` provenance is a later epic phase. **No API/response-DTO surface** — the product GET endpoint will not expose `categories` here; that's #1044's surface work. The entire AC is the persistence round-trip ("persisted but not yet exposed" is intentional, not an omission).
+
+---
+
+## Phase 2 — Research (reuse map)
+
+| Reuse / touch | Path |
+|---|---|
+| Domain field (exists, unchanged) | `products/domain/entities/product.entity.ts` — `categories?: string[]` |
+| ORM entity (add column) | `products/infrastructure/persistence/entities/product.orm-entity.ts` — has `images jsonb`; mirror for `categories` |
+| Repository mapping (add round-trip) | `products/infrastructure/persistence/repositories/product.repository.ts` — `toOrmEntity` (l.106) + `toDomain` (l.86) |
+| Sync service (doc-only) | `products/application/services/master-product-sync.service.ts` — `toDomainProduct` already passes `categories`; fix the stale comment |
+| Migration home | `apps/api/src/migrations/` (core schema) — see `docs/migrations.md` |
+| Pattern reference | the existing `images: string[] | null` jsonb column is the exact precedent (column + both mappings) |
+
+---
+
+## Phase 3 — Design
+
+`categories` follows the **`images`** precedent verbatim — a nullable `jsonb` `string[]` column with symmetric repository mapping. No domain/contract change (the interface field already exists); this is purely "make the existing field durable".
+
+- **ORM**: `@Column({ type: 'jsonb', nullable: true }) categories!: string[] | null;` (after `images`).
+- **toOrmEntity**: `entity.categories = product.categories ?? null;`
+- **toDomain**: `categories: entity.categories ?? undefined,` (interface field is optional; DB `null` → omit, matching how adapters/drafts leave it absent).
+- **Migration**: `ALTER TABLE "products" ADD "categories" jsonb` (up) / `DROP COLUMN "categories"` (down).
+
+---
+
+## Phase 4 — Step-by-step plan
+
+1. **ORM column** — add `categories!: string[] | null` (`jsonb`, nullable) to `ProductOrmEntity`, directly after `images`. **AC:** column present; file header unchanged-style.
+2. **Repository round-trip** — `toOrmEntity`: write `entity.categories = product.categories ?? null`; `toDomain`: read `categories: entity.categories ?? undefined`. **AC:** a domain `Product` with `categories` upserted then re-read via `findById` returns the same ids.
+3. **Migration** `apps/api/src/migrations/{ts}-add-product-categories.ts` — **hand-authored** (NOT `migration:generate`, which would diff all entities against the dev DB and risk pulling unrelated drift into this surgical change). `up`: `ALTER TABLE "products" ADD "categories" jsonb`; `down`: `ALTER TABLE "products" DROP COLUMN "categories"`. 13-digit unique timestamp (greater than the latest existing migration) + matching class suffix (timestamp invariant). **AC:** `migration:run` + `migration:revert` both clean; `migration:show` shows no pending after run.
+4. **Sync-service comment** — update `toDomainProduct`'s stale "silently dropped on persist" note: `categories` is now persisted (#1034); **`weight` remains intentionally transient** (no column — still master-derived only). **AC:** comment accurate; no logic change.
+5. **Tests**
+   - Repository round-trip: unit-test `upsert` → `toDomain` preserves `categories` (mock `Repository<ProductOrmEntity>` echoing the saved entity). **Assert all three cases**: a populated array survives, `[]` survives as `[]` (not coerced away), and `null`/absent returns absent — locking the null↔undefined bridge.
+   - **Int-spec (AC)**: in `apps/api/test/integration` — upsert a product carrying `categories` through the real `IProductsService`, reload, assert `categories` survives (persisted round-trip against real Postgres). **First confirm an existing products-persistence int-spec to mirror**; if none, add a thin self-contained one (the unit round-trip + `migration:show` still cover the core).
+6. **Quality gate** — `pnpm lint && pnpm type-check && pnpm test`; for the schema change run `pnpm --filter @openlinker/api migration:show` (no pending) + `pnpm test:integration` (the new int-spec + product-sync regression) before PR.
+
+---
+
+## Phase 5 — Validate
+
+- **Architecture:** CORE-only; mapping stays private in the repository (ORM↔domain rule); no port/DTO/token change; domain interface untouched.
+- **Naming/standards:** migration timestamp invariant; `as const` n/a; no `any`.
+- **Migration:** required (ORM entity schema change) — follow `docs/migrations.md`; both `up`/`down` implemented.
+- **Risk:** very low — additive nullable column mirroring `images`; existing rows get `null`; no backfill needed (categories populate on next product sync).
+
+### Open questions
+- **Category shape** — Phase 0 persists `string[]` (current field). If ADR-023 later needs structured provenance (`{ id, path, sourcePlatform }`), that's a typed follow-up in a later epic phase, not here. Confirm Phase 0 stays `string[]`.

--- a/libs/core/src/products/application/services/master-product-sync.service.ts
+++ b/libs/core/src/products/application/services/master-product-sync.service.ts
@@ -81,8 +81,9 @@ export class MasterProductSyncService implements IMasterProductSyncService {
    *
    * Adapters may omit createdAt/updatedAt — the repository populates them on
    * save via TypeORM's @CreateDateColumn/@UpdateDateColumn. Master-derived
-   * fields (currency/weight/categories) spread through untouched; the ORM
-   * has no columns for them, so they're silently dropped on persist.
+   * fields spread through untouched; `currency` and `categories` (#1034) are
+   * persisted by the repository, while `weight` remains intentionally transient
+   * (no column — master-derived only).
    */
   private toDomainProduct(product: Product): Product {
     return {

--- a/libs/core/src/products/infrastructure/persistence/entities/product.orm-entity.ts
+++ b/libs/core/src/products/infrastructure/persistence/entities/product.orm-entity.ts
@@ -32,6 +32,13 @@ export class ProductOrmEntity {
   @Column({ type: 'jsonb', nullable: true })
   images!: string[] | null;
 
+  /**
+   * Source-platform external category ids (#1034 / ADR-023 §0) — the input for
+   * per-source-category mapping. Null until a product sync populates it.
+   */
+  @Column({ type: 'jsonb', nullable: true })
+  categories!: string[] | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
@@ -92,6 +92,9 @@ export class ProductRepository implements ProductRepositoryPort {
       currency: entity.currency,
       description: entity.description,
       images: entity.images,
+      // Source-platform category ids (#1034). DB `null` → omit (the field is
+      // optional + non-null on the domain interface); `[]` is preserved.
+      categories: entity.categories ?? undefined,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
     };
@@ -112,6 +115,7 @@ export class ProductRepository implements ProductRepositoryPort {
     entity.currency = product.currency;
     entity.description = product.description;
     entity.images = product.images;
+    entity.categories = product.categories ?? null;
     if (product.createdAt) entity.createdAt = product.createdAt;
     if (product.updatedAt) entity.updatedAt = product.updatedAt;
     return entity;


### PR DESCRIPTION
Closes #1034.

## What & why
**Phase 0 of the cross-platform-listing epic (#1005 / ADR-023 §0)** — the prerequisite that unblocks the chain. The PrestaShop/WooCommerce product mappers already set source-platform external category ids on `Product.categories`, and `MasterProductSyncService` passes them through — but the **repository dropped them on persist** (`ProductOrmEntity` had no column), so per-source-category mapping (#1036+) had no input.

## Change (mirrors the existing `images` jsonb column exactly)
- **ORM**: add nullable `categories jsonb` to `ProductOrmEntity`.
- **Repository round-trip**: `toOrmEntity` writes (`?? null`); `toDomain` reads (`?? undefined` — DB `null` → absent, `[]` preserved).
- **Migration** `1803000000000-add-product-categories` — hand-authored `ADD`/`DROP COLUMN IF [NOT] EXISTS` (not generated, to stay surgical). Existing rows get `null`; the column repopulates on the next product sync — no backfill.
- **Comment fix**: `MasterProductSyncService.toDomainProduct` no longer claims categories are dropped; notes `weight` stays intentionally transient.

## Scope
Persistence-only. **No API/response-DTO surface** — the product GET endpoint does not expose `categories` here; that's #1044. "Persisted but not yet exposed" is intentional (the entire AC is the round-trip).

## Verification (AC: "persisted, survives reload")
- New **products-read int-spec** cases (real Postgres) — `categories` round-trips **populated / empty `[]` / absent**; the harness applies the migration on a fresh DB, so `up` is verified end-to-end. **8/8** in that spec.
- Confirmed the input side: PS (`prestashop-product.mapper.ts:52`) + Woo (`woocommerce-product.mapper.ts:42`) both populate `Product.categories`, so the chain holds mapper → sync → persist.
- Full gate green: `type-check`, `lint` + `check:invariants` (migration-timestamp ordering verified), full unit suite (core 1078 / api 451 / worker 156 / all packages), `migration:show` (recognized, ordered last).

## Notes / follow-ups (not in scope)
- A GIN index on `categories` belongs with the consumer that queries it (#1036/#1037), not Phase-0 persistence.
- `down` is the trivial symmetric `DROP COLUMN IF EXISTS` (verified by inspection; the int harness runs migrations `up` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)