### PR TITLE
refactor(listings): neutralise bulk-orchestration names → bulk-listing (Part of #1040)

### DIFF
--- a/apps/api/src/listings/http/bulk-listing.controller.spec.ts
+++ b/apps/api/src/listings/http/bulk-listing.controller.spec.ts
@@ -4,7 +4,7 @@
  * Verifies routing, status codes, DTO → service-input mapping, and
  * error → HTTP mapping for `POST /listings/bulk-create` and
  * `GET /listings/bulk-create/:batchId`. Mocks the
- * `IBulkOfferCreationSubmitService` token; per-product flow + Redis are
+ * `IBulkListingSubmitService` token; per-product flow + Redis are
  * covered by the int-spec.
  *
  * @module apps/api/src/listings/http
@@ -21,28 +21,28 @@ import { Test } from '@nestjs/testing';
 
 import {
   AdapterCapabilityNotSupportedException,
-  BULK_OFFER_CREATION_RETRY_SERVICE_TOKEN,
-  BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN,
-  BulkOfferCreationBatch,
-  BulkOfferCreationBatchNotFoundException,
+  BULK_LISTING_RETRY_SERVICE_TOKEN,
+  BULK_LISTING_SUBMIT_SERVICE_TOKEN,
+  BulkListingBatch,
+  BulkListingBatchNotFoundException,
   BulkRetryMissingSnapshotException,
   EmptyBulkSubmissionException,
   NoFailedChildrenToRetryException,
 } from '@openlinker/core/listings';
 import type {
-  IBulkOfferCreationRetryService,
-  IBulkOfferCreationSubmitService,
+  IBulkListingRetryService,
+  IBulkListingSubmitService,
   OfferCreationRecord,
 } from '@openlinker/core/listings';
 
-import { BulkOfferCreationController } from './bulk-offer-creation.controller';
+import { BulkListingController } from './bulk-listing.controller';
 import type { BulkOfferCreateRequestDto } from './dto/bulk-offer-create.dto';
 import type { AuthenticatedUser } from '../../auth/auth.types';
 
-describe('BulkOfferCreationController', () => {
-  let controller: BulkOfferCreationController;
-  let bulkSubmit: jest.Mocked<IBulkOfferCreationSubmitService>;
-  let bulkRetry: jest.Mocked<IBulkOfferCreationRetryService>;
+describe('BulkListingController', () => {
+  let controller: BulkListingController;
+  let bulkSubmit: jest.Mocked<IBulkListingSubmitService>;
+  let bulkRetry: jest.Mocked<IBulkListingRetryService>;
 
   const adminUser: AuthenticatedUser = {
     id: 'user-admin',
@@ -60,14 +60,14 @@ describe('BulkOfferCreationController', () => {
     };
 
     const module: TestingModule = await Test.createTestingModule({
-      controllers: [BulkOfferCreationController],
+      controllers: [BulkListingController],
       providers: [
-        { provide: BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN, useValue: bulkSubmit },
-        { provide: BULK_OFFER_CREATION_RETRY_SERVICE_TOKEN, useValue: bulkRetry },
+        { provide: BULK_LISTING_SUBMIT_SERVICE_TOKEN, useValue: bulkSubmit },
+        { provide: BULK_LISTING_RETRY_SERVICE_TOKEN, useValue: bulkRetry },
       ],
     }).compile();
 
-    controller = module.get<BulkOfferCreationController>(BulkOfferCreationController);
+    controller = module.get<BulkListingController>(BulkListingController);
   });
 
   describe('POST /listings/bulk-create', () => {
@@ -163,7 +163,7 @@ describe('BulkOfferCreationController', () => {
 
   describe('GET /listings/bulk-create/:batchId', () => {
     it('returns the serialised summary when the batch exists', async () => {
-      const batch = new BulkOfferCreationBatch(
+      const batch = new BulkListingBatch(
         'b-1',
         'conn-1',
         'user-1',
@@ -260,9 +260,9 @@ describe('BulkOfferCreationController', () => {
       expect(bulkRetry.retryFailed).toHaveBeenCalledWith(BATCH_ID);
     });
 
-    it('maps BulkOfferCreationBatchNotFoundException to NotFoundException (HTTP 404)', async () => {
+    it('maps BulkListingBatchNotFoundException to NotFoundException (HTTP 404)', async () => {
       bulkRetry.retryFailed.mockRejectedValue(
-        new BulkOfferCreationBatchNotFoundException(BATCH_ID)
+        new BulkListingBatchNotFoundException(BATCH_ID)
       );
 
       await expect(controller.retryFailed(BATCH_ID)).rejects.toBeInstanceOf(NotFoundException);

--- a/apps/api/src/listings/http/bulk-listing.controller.ts
+++ b/apps/api/src/listings/http/bulk-listing.controller.ts
@@ -2,7 +2,7 @@
  * Bulk Offer Creation Controller (#736)
  *
  * HTTP endpoints for operator-driven bulk offer creation. Thin wrapper
- * over `IBulkOfferCreationSubmitService`: validates the request DTO, maps
+ * over `IBulkListingSubmitService`: validates the request DTO, maps
  * to the service input (stamping `initiatedBy` from the authenticated
  * session), and serialises the typed result back through the response
  * DTOs.
@@ -32,18 +32,18 @@ import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@ne
 
 import {
   AdapterCapabilityNotSupportedException,
-  BULK_OFFER_CREATION_RETRY_SERVICE_TOKEN,
-  BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN,
-  BulkOfferCreationBatchNotFoundException,
+  BULK_LISTING_RETRY_SERVICE_TOKEN,
+  BULK_LISTING_SUBMIT_SERVICE_TOKEN,
+  BulkListingBatchNotFoundException,
   BulkRetryMissingSnapshotException,
   EmptyBulkSubmissionException,
-  IBulkOfferCreationRetryService,
-  IBulkOfferCreationSubmitService,
+  IBulkListingRetryService,
+  IBulkListingSubmitService,
   NoFailedChildrenToRetryException,
 } from '@openlinker/core/listings';
 import type {
   BulkBatchSummary,
-  BulkOfferCreationSubmitInput,
+  BulkListingSubmitInput,
 } from '@openlinker/core/listings';
 
 import { Roles } from '../../auth/decorators/roles.decorator';
@@ -56,18 +56,18 @@ import {
   BulkBatchSummaryDto,
   BulkOfferCreateResponseDto,
 } from './dto/bulk-offer-create-response.dto';
-import { BulkOfferCreationRetryResponseDto } from './dto/bulk-offer-creation-retry-response.dto';
+import { BulkListingRetryResponseDto } from './dto/bulk-listing-retry-response.dto';
 
 @Roles('admin')
 @ApiBearerAuth()
 @ApiTags('listings')
 @Controller('listings/bulk-create')
-export class BulkOfferCreationController {
+export class BulkListingController {
   constructor(
-    @Inject(BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN)
-    private readonly bulkSubmit: IBulkOfferCreationSubmitService,
-    @Inject(BULK_OFFER_CREATION_RETRY_SERVICE_TOKEN)
-    private readonly bulkRetry: IBulkOfferCreationRetryService
+    @Inject(BULK_LISTING_SUBMIT_SERVICE_TOKEN)
+    private readonly bulkSubmit: IBulkListingSubmitService,
+    @Inject(BULK_LISTING_RETRY_SERVICE_TOKEN)
+    private readonly bulkRetry: IBulkListingRetryService
   ) {}
 
   @Post()
@@ -75,7 +75,7 @@ export class BulkOfferCreationController {
   @ApiOperation({
     summary: 'Submit a bulk offer-creation batch (1..100 products)',
     description:
-      'Validates the connection + adapter capability, persists a BulkOfferCreationBatch, enqueues one marketplace.offer.create job per product, and returns the batchId + per-job message ids. The worker handler change consuming the V2 payload lands in #737; this endpoint is the submit + read seam for the wizard.',
+      'Validates the connection + adapter capability, persists a BulkListingBatch, enqueues one marketplace.offer.create job per product, and returns the batchId + per-job message ids. The worker handler change consuming the V2 payload lands in #737; this endpoint is the submit + read seam for the wizard.',
   })
   @ApiResponse({
     status: 202,
@@ -90,7 +90,7 @@ export class BulkOfferCreationController {
     @Body() dto: BulkOfferCreateRequestDto,
     @CurrentUser() user: AuthenticatedUser
   ): Promise<BulkOfferCreateResponseDto> {
-    const input: BulkOfferCreationSubmitInput = {
+    const input: BulkListingSubmitInput = {
       connectionId: dto.connectionId,
       initiatedBy: user.id,
       productIds: dto.productIds,
@@ -157,7 +157,7 @@ export class BulkOfferCreationController {
   @ApiResponse({
     status: 202,
     description: 'Retry wave dispatched',
-    type: BulkOfferCreationRetryResponseDto,
+    type: BulkListingRetryResponseDto,
   })
   @ApiResponse({ status: 404, description: 'Batch not found' })
   @ApiResponse({ status: 409, description: 'Batch has no failed children to retry' })
@@ -165,7 +165,7 @@ export class BulkOfferCreationController {
   @ApiResponse({ status: 500, description: 'Documented invariant violation (snapshot missing)' })
   async retryFailed(
     @Param('batchId', new ParseUUIDPipe()) batchId: string
-  ): Promise<BulkOfferCreationRetryResponseDto> {
+  ): Promise<BulkListingRetryResponseDto> {
     try {
       const result = await this.bulkRetry.retryFailed(batchId);
       return {
@@ -174,7 +174,7 @@ export class BulkOfferCreationController {
         batchStatus: result.batchStatus,
       };
     } catch (error) {
-      if (error instanceof BulkOfferCreationBatchNotFoundException) {
+      if (error instanceof BulkListingBatchNotFoundException) {
         throw new NotFoundException(error.message);
       }
       if (error instanceof NoFailedChildrenToRetryException) {

--- a/apps/api/src/listings/http/dto/bulk-listing-retry-response.dto.ts
+++ b/apps/api/src/listings/http/dto/bulk-listing-retry-response.dto.ts
@@ -17,7 +17,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { BulkBatchStatusValues, type BulkBatchStatus } from '@openlinker/core/listings';
 
-export class BulkOfferCreationRetryResponseDto {
+export class BulkListingRetryResponseDto {
   @ApiProperty({ description: 'Internal IDs of records re-enqueued, in original createdAt order.' })
   retriedRecordIds!: string[];
 

--- a/apps/api/src/listings/http/dto/bulk-offer-create.dto.ts
+++ b/apps/api/src/listings/http/dto/bulk-offer-create.dto.ts
@@ -2,7 +2,7 @@
  * Bulk Offer Create DTOs (#736)
  *
  * Request DTO for `POST /listings/bulk-create`. The controller maps this
- * validated shape into `BulkOfferCreationSubmitInput` and stamps
+ * validated shape into `BulkListingSubmitInput` and stamps
  * `initiatedBy` from the authenticated session before handing off to the
  * core service.
  *

--- a/apps/api/src/listings/listings.module.ts
+++ b/apps/api/src/listings/listings.module.ts
@@ -12,7 +12,7 @@ import { ListingsModule as CoreListingsModule } from '@openlinker/core/listings/
 import { ProductsModule as CoreProductsModule } from '@openlinker/core/products';
 import { SyncModule as CoreSyncModule } from '@openlinker/core/sync';
 import { ListingsController } from './http/listings.controller';
-import { BulkOfferCreationController } from './http/bulk-offer-creation.controller';
+import { BulkListingController } from './http/bulk-listing.controller';
 
 @Module({
   // CoreIntegrationsModule supplies INTEGRATIONS_SERVICE_TOKEN, which the
@@ -21,6 +21,6 @@ import { BulkOfferCreationController } from './http/bulk-offer-creation.controll
   // CoreProductsModule supplies PRODUCT_VARIANT_REPOSITORY_TOKEN, used by
   // GET /listings/:id to resolve the linked variant's productId (#485).
   imports: [CoreListingsModule, CoreSyncModule, CoreIntegrationsModule, CoreProductsModule],
-  controllers: [ListingsController, BulkOfferCreationController],
+  controllers: [ListingsController, BulkListingController],
 })
 export class ListingsApiModule {}

--- a/apps/api/test/integration/helpers/bulk-batch-drain.helper.ts
+++ b/apps/api/test/integration/helpers/bulk-batch-drain.helper.ts
@@ -1,10 +1,10 @@
 /**
  * Bulk Batch Drain Helper (#742)
  *
- * Synchronously drains pending children of a `BulkOfferCreationBatch` for
+ * Synchronously drains pending children of a `BulkListingBatch` for
  * int-spec end-to-end coverage. Stands in for the worker handler when the
  * worker process isn't booted: invokes `IOfferCreationExecutionService`
- * + `IBulkOfferCreationProgressService` directly per-record, mirroring the
+ * + `IBulkListingProgressService` directly per-record, mirroring the
  * `MarketplaceOfferCreateHandler.execute(job)` V2 path step-by-step.
  *
  * The fake adapter registered by `allegro-test-offer-manager-stub.helper.ts`
@@ -22,10 +22,10 @@
  * @module apps/api/test/integration/helpers
  */
 import {
-  BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
-  BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN,
-  IBulkOfferCreationProgressService,
-  IBulkOfferCreationSubmitService,
+  BULK_LISTING_PROGRESS_SERVICE_TOKEN,
+  BULK_LISTING_SUBMIT_SERVICE_TOKEN,
+  IBulkListingProgressService,
+  IBulkListingSubmitService,
   IOfferCreationExecutionService,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
 } from '@openlinker/core/listings';
@@ -54,11 +54,11 @@ export async function drainBulkBatch(
   const executeService = app.get<IOfferCreationExecutionService>(
     OFFER_CREATION_EXECUTION_SERVICE_TOKEN
   );
-  const progressService = app.get<IBulkOfferCreationProgressService>(
-    BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN
+  const progressService = app.get<IBulkListingProgressService>(
+    BULK_LISTING_PROGRESS_SERVICE_TOKEN
   );
-  const submitService = app.get<IBulkOfferCreationSubmitService>(
-    BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN
+  const submitService = app.get<IBulkListingSubmitService>(
+    BULK_LISTING_SUBMIT_SERVICE_TOKEN
   );
 
   const summary = await submitService.getBatch(batchId);

--- a/apps/api/test/integration/listings-bulk-offer-creation-retry-failed.int-spec.ts
+++ b/apps/api/test/integration/listings-bulk-offer-creation-retry-failed.int-spec.ts
@@ -9,7 +9,7 @@
  *
  * Direct seeding (skipping the submit service) keeps the spec focused on the
  * retry surface — the submit-side flow is covered by
- * `listings-bulk-offer-creation.int-spec.ts`.
+ * `listings-bulk-listing.int-spec.ts`.
  *
  * **Deferred — AC end-to-end happy path** (issue #742 AC: submit → drain →
  * retry → drain → final `partially-failed`): requires booting the
@@ -21,7 +21,7 @@
  * (Product + ProductVariant fixtures + a second connection with
  * `masterCatalogConnectionId`). The orchestration semantics (counter
  * reopen, wave-distinct idempotency key, per-record decrement) are fully
- * covered by `bulk-offer-creation-retry.service.spec.ts`'s 15 cases; the
+ * covered by `bulk-listing-retry.service.spec.ts`'s 15 cases; the
  * remaining gap is the worker-side drain wiring, which is exercised in
  * `apps/worker/src/sync/handlers/__tests__/marketplace-offer-create.handler.spec.ts`.
  *

--- a/apps/api/test/integration/listings-bulk-offer-creation.int-spec.ts
+++ b/apps/api/test/integration/listings-bulk-offer-creation.int-spec.ts
@@ -14,9 +14,9 @@
  * the bulk service requires a connection whose adapter supports the
  * `OfferCreator` capability (Allegro), which needs live OAuth
  * credentials. That orchestration is covered by:
- *  - `BulkOfferCreationSubmitService` unit spec (fan-out + status flips)
+ *  - `BulkListingSubmitService` unit spec (fan-out + status flips)
  *  - `OfferCreationEnqueueService` unit spec (V2 payload, bulk idempotency key)
- *  - `BulkOfferCreationController` unit spec (DTO mapping, error → HTTP)
+ *  - `BulkListingController` unit spec (DTO mapping, error → HTTP)
  *
  * This int-spec proves Nest wiring + DB plumbing for the operator-facing
  * read contract the FE wizard's progress page (#741) will call every few

--- a/apps/web/src/features/listings/api/bulk-listings.types.ts
+++ b/apps/web/src/features/listings/api/bulk-listings.types.ts
@@ -3,10 +3,10 @@
  *
  * FE transport types for the bulk offer-creation endpoints (#736 / #742).
  * Mirrors the BE DTOs in `apps/api/src/listings/http/dto/bulk-offer-create*.dto.ts`
- * and `bulk-offer-creation-retry-response.dto.ts`.
+ * and `bulk-listing-retry-response.dto.ts`.
  *
  * Note: the BE field `productIds` actually carries **variant IDs** (see
- * `libs/core/src/listings/application/services/bulk-offer-creation-submit.service.ts:182`
+ * `libs/core/src/listings/application/services/bulk-listing-submit.service.ts:182`
  * where `internalVariantId: productId`). The FE picks one canonical variant
  * per selected product before submit.
  *
@@ -103,7 +103,7 @@ export interface BulkBatchSummary {
   records: BulkBatchRecordSummary[];
 }
 
-export interface BulkOfferCreationRetryResponse {
+export interface BulkListingRetryResponse {
   retriedRecordIds: string[];
   retriedCount: number;
   batchStatus: BulkBatchStatus;

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -31,7 +31,7 @@ import type {
   BulkBatchSummary,
   BulkOfferCreateRequest,
   BulkOfferCreateResponse,
-  BulkOfferCreationRetryResponse,
+  BulkListingRetryResponse,
 } from './bulk-listings.types';
 
 export interface CreateOfferOptions {
@@ -103,7 +103,7 @@ export interface ListingsApi {
   /** Read a bulk batch + its per-record summary. Used for polling on #741. */
   getBulkBatch: (batchId: string) => Promise<BulkBatchSummary>;
   /** Re-enqueue failed children of a batch (#742). Batch-level retry only. */
-  retryBulkFailed: (batchId: string) => Promise<BulkOfferCreationRetryResponse>;
+  retryBulkFailed: (batchId: string) => Promise<BulkListingRetryResponse>;
 }
 
 interface ApiRequest {
@@ -218,8 +218,8 @@ export function createListingsApi(request: ApiRequest): ListingsApi {
         `/listings/bulk-create/${encodeURIComponent(batchId)}`,
       );
     },
-    retryBulkFailed(batchId): Promise<BulkOfferCreationRetryResponse> {
-      return request<BulkOfferCreationRetryResponse>(
+    retryBulkFailed(batchId): Promise<BulkListingRetryResponse> {
+      return request<BulkListingRetryResponse>(
         `/listings/bulk-create/${encodeURIComponent(batchId)}/retry-failed`,
         { method: 'POST' },
       );

--- a/apps/web/src/features/listings/hooks/use-bulk-retry-failed-mutation.ts
+++ b/apps/web/src/features/listings/hooks/use-bulk-retry-failed-mutation.ts
@@ -14,13 +14,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useApiClient } from '../../../app/api/api-client-provider';
 import { listingsQueryKeys } from '../api/listings.query-keys';
-import type { BulkOfferCreationRetryResponse } from '../api/bulk-listings.types';
+import type { BulkListingRetryResponse } from '../api/bulk-listings.types';
 
 export function useBulkRetryFailedMutation() {
   const apiClient = useApiClient();
   const queryClient = useQueryClient();
 
-  return useMutation<BulkOfferCreationRetryResponse, Error, string>({
+  return useMutation<BulkListingRetryResponse, Error, string>({
     mutationFn: (batchId: string) => apiClient.listings.retryBulkFailed(batchId),
     onSuccess: (_data, batchId) => {
       void queryClient.invalidateQueries({

--- a/apps/worker/src/sync/handlers/__tests__/marketplace-offer-create.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/marketplace-offer-create.handler.spec.ts
@@ -3,7 +3,7 @@
  *
  * Covers both V1 (single-offer) and V2 (bulk-aware) payload paths and the
  * two V2 side-effects the handler owns: AI description prep and
- * BulkOfferCreationProgressService counter advancement.
+ * BulkListingProgressService counter advancement.
  *
  * Smart classification readback was moved into OfferCreationExecutionService
  * (so the handler stays cross-context-clean — no repository-port imports).
@@ -18,7 +18,7 @@ import { SyncJobExecutionError } from '@openlinker/core/sync';
 import type { SyncJobEntity as SyncJob } from '@openlinker/core/sync';
 import {
   OfferCreationRecord,
-  type IBulkOfferCreationProgressService,
+  type IBulkListingProgressService,
   type IOfferCreationExecutionService,
 } from '@openlinker/core/listings';
 import type { IContentSuggestionService } from '@openlinker/core/content';
@@ -55,7 +55,7 @@ describe('MarketplaceOfferCreateHandler', () => {
   let offerCreation: jest.Mocked<IOfferCreationExecutionService>;
   let contentSuggestion: jest.Mocked<IContentSuggestionService>;
   let products: jest.Mocked<IProductsService>;
-  let bulkProgress: jest.Mocked<IBulkOfferCreationProgressService>;
+  let bulkProgress: jest.Mocked<IBulkListingProgressService>;
 
   beforeEach(() => {
     offerCreation = {
@@ -72,7 +72,7 @@ describe('MarketplaceOfferCreateHandler', () => {
 
     bulkProgress = {
       advanceBatchStatus: jest.fn().mockResolvedValue(null),
-    } as unknown as jest.Mocked<IBulkOfferCreationProgressService>;
+    } as unknown as jest.Mocked<IBulkListingProgressService>;
 
     handler = new MarketplaceOfferCreateHandler(
       offerCreation,

--- a/apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts
@@ -12,7 +12,7 @@
  *      and thread the result into `overrides.description`. AI failure falls
  *      through — operator override or builder default takes over (AC-9).
  *   2. **After** `executeCreation`, terminal outcome: advance the parent
- *      batch's counters via `BulkOfferCreationProgressService` — which
+ *      batch's counters via `BulkListingProgressService` — which
  *      gates on the `bulk_batch_advancements` table to give at-most-once
  *      counter semantics across retries + concurrent workers.
  *
@@ -33,10 +33,10 @@ import {
   type IContentSuggestionService,
 } from '@openlinker/core/content';
 import {
-  BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
+  BULK_LISTING_PROGRESS_SERVICE_TOKEN,
   type BulkChildOutcome,
   type CreateOfferOverrides,
-  type IBulkOfferCreationProgressService,
+  type IBulkListingProgressService,
   type IOfferCreationExecutionService,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
   OfferCreationInvariantException,
@@ -69,8 +69,8 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
     private readonly contentSuggestion: IContentSuggestionService,
     @Inject(PRODUCTS_SERVICE_TOKEN)
     private readonly products: IProductsService,
-    @Inject(BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN)
-    private readonly bulkProgress: IBulkOfferCreationProgressService
+    @Inject(BULK_LISTING_PROGRESS_SERVICE_TOKEN)
+    private readonly bulkProgress: IBulkListingProgressService
   ) {}
 
   async execute(job: SyncJob): Promise<SyncJobHandlerResult> {

--- a/docs/plans/implementation-plan-1040-neutral-listing-orchestration.md
+++ b/docs/plans/implementation-plan-1040-neutral-listing-orchestration.md
@@ -1,0 +1,72 @@
+# Implementation Plan — #1040 Extract destination-neutral listing orchestration
+
+**Issue:** #1040 · **Epic:** #1005 · **ADR-024 §4** · **Branch:** `1040-neutral-listing-orchestration`
+
+---
+
+## Phase 1 — Understand
+
+**Goal.** Lift the ~60% destination-neutral scaffolding out of the bulk **offer** pipeline so both `marketplace.offer.create` and the future `shop.product.publish` reuse it. Builders stay separate. Migrate the existing offer path onto the neutral primitives with **no behaviour change**.
+
+**Layer.** CORE (`listings`) + worker wiring. **Refactor of a hot subsystem** (#726/#734/#736/#737/#742).
+
+**AC.** Existing single + bulk offer creation green on the neutral primitives (full `pnpm test:integration`); no offer-specific names in the extracted orchestration.
+
+**Key finding (from research).** The batch aggregate, `bulk_batch_advancements` gate, `BulkOfferCreationProgressService`, `BulkOfferCreationRetryService`, `BulkOfferCreationSubmitService` + variant expansion are **already behaviourally neutral** — they carry no Allegro/offer logic, only offer-flavoured *names* and a coupling to `OfferCreationRecord` as the "child". Genuinely offer-specific (stays): `OfferBuilderService`, `OfferCreationExecutionService`, the Allegro `CreateOfferCommand`, the V1/V2 payload + worker handler. So this is mostly **rename + introduce an `operation` discriminator + abstract the child seam** — not a behavioural rewrite.
+
+**Non-goals.** No `shop.product.publish` implementation (that's #1041/#1042/#1043). No builder changes. No AI/description changes. No new behaviour on the offer path.
+
+---
+
+## Phase 2 — Research (surface map)
+
+Neutral-in-behaviour, offer-named (→ neutralize):
+- `BulkOfferCreationBatch` (entity + `BulkOfferCreationBatchOrmEntity` → table `bulk_offer_creation_batches`) + repo + port + `BulkBatchStatus` + `CreateBulkOfferCreationBatchInput`.
+- `BulkBatchAdvancement` (+ ORM table `bulk_batch_advancements`) + repo + port — already neutrally named (`BulkBatch*`).
+- `BulkOfferCreationProgressService` (advance/derive terminal) , `BulkOfferCreationRetryService` (reset+reopen+re-enqueue), `BulkOfferCreationSubmitService` (+ `expandVariantJobs`, master-stock resolution).
+- `OfferCreationEnqueueService` — V1/V2 routing is neutral, but pre-creates an `OfferCreationRecord` (offer-named child).
+
+Offer-specific (stays as-is):
+- `OfferBuilderService`, `OfferCreationExecutionService`, `OfferCreationRecord` (carries `externalOfferId`, `classificationReport` — offer concepts), `CreateOfferCommand`, `marketplace.offer.create` V1/V2 payload + `MarketplaceOfferCreateHandler`.
+
+Contract surface: `@openlinker/core/listings` barrel exports the bulk types/interfaces/ports/tokens; `@openlinker/core/listings/services` exports `ListingsModule` + service classes. ~58 files reference `BulkOfferCreation*`. Tokens in `listings.tokens.ts`.
+
+Tests (regression net the AC requires green): 6 service unit specs + 2 entity specs + 2 repo specs; int-specs `listings-bulk-offer-creation.int-spec.ts`, `listings-bulk-offer-creation-retry-failed.int-spec.ts`, `listings-create-offer.int-spec.ts`; worker `marketplace-offer-create.handler.spec.ts`.
+
+---
+
+## Phase 3 — Design (the decisions that need your call)
+
+The crux: the neutral progress/retry services currently couple to `OfferCreationRecord` as "the child". To be truly destination-neutral they must speak to the child through a **narrow neutral seam**, not the offer record.
+
+**Approved approach — symbol-neutralize + `operation` discriminator + TWO neutral seams, keep physical tables:**
+1. **Rename the neutral aggregate + services** `BulkOfferCreation* → BulkListing*` (`BulkListingBatch`, `BulkListingSubmitService`, `BulkListingProgressService`, `BulkListingRetryService`) + interfaces/tokens/params (`offerCreationRecordId` → `childId`). Add `operation` as **`as const` `BulkListingOperation = 'offer.create' | 'shop.publish'`**.
+2. **Keep DB table names unchanged** (`bulk_offer_creation_batches`, `bulk_batch_advancements`, `offer_creation_records`) — the renamed class keeps mapping to the existing table via `@Entity('…')`, **no data-migration risk**. Only the `operation` column is added. **Exclude the historical `1797…` migration from the rename** (it's immutable history; the table-name string stays). [fork A — confirmed]
+3. **Two neutral seams** (the crux):
+   - **`BatchChildRepositoryPort`** — `findByBatchId`, `resetForRetry`, … — implemented by `OfferCreationRecordRepository`. Lets neutral progress/retry read/reset children without naming `Offer`.
+   - **`ListingChildEnqueuerPort`** — `enqueueChild(batch, childInput)` / `reEnqueueChild(batch, child, retryWaveId)` — resolved by `batch.operation` (strategy). The offer path registers an **`OfferListingChildEnqueuer`** wrapping `OfferCreationEnqueueService` + the **V2-payload rebuild** (snapshot + batch AI flags). This is what keeps submit *and* retry neutral — both enqueue/re-enqueue through this seam, not `OfferCreation*` directly. `OfferCreationRecord` stays offer-specific. [fork B — confirmed]
+4. **Migrate the offer path**: `BulkListingSubmitService` does batch-create + variant expansion + per-child `enqueueChild` via the seam; `BulkListingRetryService` resets + `reEnqueueChild` via the seam; `BulkListingProgressService` advances by `childId`. The offer wrapper supplies the enqueuer + the offer child shape. **No behaviour change** — the existing int-specs are the oracle.
+5. **Barrel + tokens** updated; old `BulkOfferCreation*` names removed (the "no offer-specific names in the extracted orchestration" AC). **HTTP contract unchanged** — the bulk submit/retry controller routes + request/response **DTO field names stay byte-identical** (only internal symbols rename); an int-spec asserts the wire shape.
+
+---
+
+## Phase 4 — Step-by-step (high level; refined after scope decision)
+
+1. **Migration** (only if forks decide table/column changes): add `operation` column to `bulk_offer_creation_batches` (default `'offer.create'` for existing rows). Hand-authored, next timestamp.
+2. Neutral domain: `BulkListingBatch` entity + `operation` + `BulkListingOperation` `as const`; neutral types/ports; `BatchChildRepositoryPort`.
+3. Neutral services (rename + de-offer the 4 services); `OfferCreationRecordRepository implements BatchChildRepositoryPort`.
+4. Offer path migration: offer submit/enqueue/execute compose the neutral primitives; worker handler updated to neutral progress service.
+5. Barrel + `listings.tokens.ts` + `ListingsModule` rewiring.
+6. Update all ~58 references + every test (rename-through); add a neutrality assertion (no `Offer` in the extracted orchestration files).
+7. Quality gate: `pnpm lint && type-check && test`; **full `pnpm test:integration`** (the AC) + `migration:show`.
+
+---
+
+## Phase 5 — Validate / risks / OPEN QUESTIONS (need your decision before I implement)
+
+- **Risk: large rename across ~58 files + barrel contract surface.** Mitigated by "no behaviour change" + the existing test suite as the oracle (rename-through, run int-specs).
+- **Fork A — DB tables:** **keep physical table names** (recommended, zero migration risk) vs. rename them to neutral (`listing_orchestration_batches` …) which needs a careful rename migration on a hot table. Recommendation: keep names, neutralize only code symbols + add `operation`.
+- **Fork B — child record:** keep `OfferCreationRecord` offer-specific behind a neutral `BatchChildRepositoryPort` (recommended) vs. fully neutralize the child entity now (bigger, and the shop child shape isn't defined until #1042).
+- **Fork C — scope size:** full extraction now (this plan) vs. the issue's stated **fallback** ("parallel copy if extraction proves riskier than duplication") — i.e. land a minimal `operation` discriminator + defer aggressive renames. Given the subsystem is already behaviourally neutral, full extraction is feasible but touches many files in one PR.
+
+> This is a genuinely large refactor. I want your call on **A/B/C** before writing code — especially C (full neutralization in one PR vs. a smaller first slice), since it sets the PR size and risk.

--- a/libs/core/src/listings/application/interfaces/bulk-listing-retry.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/bulk-listing-retry.service.interface.ts
@@ -1,13 +1,13 @@
 /**
  * Bulk Offer Creation Retry Service Interface (#742)
  *
- * Re-enqueues only the failed children of a `BulkOfferCreationBatch`,
+ * Re-enqueues only the failed children of a `BulkListingBatch`,
  * reopening the batch counters + status so the worker handler's next
  * advancement wave drives terminal-status derivation again.
  *
  * Sibling to:
- *  - `IBulkOfferCreationSubmitService` (#736) — initial submit / HTTP intake.
- *  - `IBulkOfferCreationProgressService` (#737) — counter advancement + terminal-state derivation.
+ *  - `IBulkListingSubmitService` (#736) — initial submit / HTTP intake.
+ *  - `IBulkListingProgressService` (#737) — counter advancement + terminal-state derivation.
  *
  * Keeps the per-phase orchestration pattern uniform: each phase of the
  * bulk lifecycle (submit → run → progress → retry) is its own service with
@@ -15,9 +15,9 @@
  *
  * @module libs/core/src/listings/application/interfaces
  */
-import type { BulkOfferCreationRetryResult } from '../types/bulk-offer-creation-retry.types';
+import type { BulkListingRetryResult } from '../types/bulk-listing-retry.types';
 
-export interface IBulkOfferCreationRetryService {
+export interface IBulkListingRetryService {
   /**
    * Re-enqueue every `OfferCreationRecord` for the given batch whose status
    * is `'failed'`. Decrements `failedCount` per retried record (lock-stepped
@@ -28,7 +28,7 @@ export interface IBulkOfferCreationRetryService {
    * enqueued under a wave-distinct idempotency key.
    *
    * Throws:
-   * - `BulkOfferCreationBatchNotFoundException` → 404 (unknown batch id).
+   * - `BulkListingBatchNotFoundException` → 404 (unknown batch id).
    * - `NoFailedChildrenToRetryException` → 409 (batch exists but has zero
    *   failed children).
    * - `AdapterCapabilityNotSupportedException` → 422 (connection's adapter
@@ -36,5 +36,5 @@ export interface IBulkOfferCreationRetryService {
    * - `BulkRetryMissingSnapshotException` → 500 (failed record has
    *   `request === null` — documented invariant violation, non-retryable).
    */
-  retryFailed(batchId: string): Promise<BulkOfferCreationRetryResult>;
+  retryFailed(batchId: string): Promise<BulkListingRetryResult>;
 }

--- a/libs/core/src/listings/application/interfaces/bulk-listing-submit.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/bulk-listing-submit.service.interface.ts
@@ -2,7 +2,7 @@
  * Bulk Offer Creation Submit Service Interface (#736)
  *
  * Contract for the bulk-submission orchestration: validate connection +
- * capability, persist the parent `BulkOfferCreationBatch`, fan out to
+ * capability, persist the parent `BulkListingBatch`, fan out to
  * `IOfferCreationEnqueueService` once per product (emitting
  * `MarketplaceOfferCreatePayloadV2`), advance the batch to `'running'`,
  * and expose a `getBatch` read for the FE progress page.
@@ -10,7 +10,7 @@
  * Terminal-status derivation (deriving `completed | partially-failed |
  * failed` when `succeededCount + failedCount === totalCount`) lives in
  * this service per `architecture-overview.md` §7 and the entity header in
- * `bulk-offer-creation-batch.entity.ts`. The state-machine method that
+ * `bulk-listing-batch.entity.ts`. The state-machine method that
  * does the derivation is added by the worker handler change in **#737** —
  * this slice exposes only `submit` + `getBatch`.
  *
@@ -19,11 +19,11 @@
 
 import type {
   BulkBatchSummary,
-  BulkOfferCreationSubmitInput,
-  BulkOfferCreationSubmitResult,
-} from '../types/bulk-offer-creation-submit.types';
+  BulkListingSubmitInput,
+  BulkListingSubmitResult,
+} from '../types/bulk-listing-submit.types';
 
-export interface IBulkOfferCreationSubmitService {
+export interface IBulkListingSubmitService {
   /**
    * Validate + persist batch + fan out enqueues.
    *
@@ -41,7 +41,7 @@ export interface IBulkOfferCreationSubmitService {
    * is re-thrown — the FE wizard treats this as an end-to-end failure
    * and offers a fresh submit.
    */
-  submit(input: BulkOfferCreationSubmitInput): Promise<BulkOfferCreationSubmitResult>;
+  submit(input: BulkListingSubmitInput): Promise<BulkListingSubmitResult>;
 
   /**
    * Return the batch + every child `OfferCreationRecord` belonging to it,

--- a/libs/core/src/listings/application/services/__tests__/bulk-listing-progress.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/bulk-listing-progress.service.spec.ts
@@ -7,18 +7,18 @@
  *
  * @module libs/core/src/listings/application/services/__tests__
  */
-import { BulkOfferCreationProgressService } from '../bulk-offer-creation-progress.service';
-import { BulkOfferCreationBatch } from '../../../domain/entities/bulk-offer-creation-batch.entity';
-import { BULK_BATCH_STATUS } from '../../../domain/types/bulk-offer-creation-batch.types';
+import { BulkListingProgressService } from '../bulk-listing-progress.service';
+import { BulkListingBatch } from '../../../domain/entities/bulk-listing-batch.entity';
+import { BULK_BATCH_STATUS } from '../../../domain/types/bulk-listing-batch.types';
 import type { BulkBatchAdvancementRepositoryPort } from '../../../domain/ports/bulk-batch-advancement-repository.port';
-import type { BulkOfferCreationBatchRepositoryPort } from '../../../domain/ports/bulk-offer-creation-batch-repository.port';
+import type { BulkListingBatchRepositoryPort } from '../../../domain/ports/bulk-listing-batch-repository.port';
 
 const BATCH_ID = 'batch-uuid-1';
 const RECORD_ID = 'rec-uuid-1';
 
-const buildBatch = (overrides: Partial<BulkOfferCreationBatch> = {}): BulkOfferCreationBatch => {
+const buildBatch = (overrides: Partial<BulkListingBatch> = {}): BulkListingBatch => {
   const now = new Date('2026-05-17T10:00:00Z');
-  return new BulkOfferCreationBatch(
+  return new BulkListingBatch(
     overrides.id ?? BATCH_ID,
     overrides.connectionId ?? 'conn-1',
     overrides.initiatedBy ?? 'user-1',
@@ -32,9 +32,9 @@ const buildBatch = (overrides: Partial<BulkOfferCreationBatch> = {}): BulkOfferC
   );
 };
 
-describe('BulkOfferCreationProgressService', () => {
-  let service: BulkOfferCreationProgressService;
-  let batches: jest.Mocked<BulkOfferCreationBatchRepositoryPort>;
+describe('BulkListingProgressService', () => {
+  let service: BulkListingProgressService;
+  let batches: jest.Mocked<BulkListingBatchRepositoryPort>;
   let advancements: jest.Mocked<BulkBatchAdvancementRepositoryPort>;
 
   beforeEach(() => {
@@ -48,7 +48,7 @@ describe('BulkOfferCreationProgressService', () => {
       markAdvancedIfNotExists: jest.fn(),
       deleteForRecord: jest.fn(),
     };
-    service = new BulkOfferCreationProgressService(batches, advancements);
+    service = new BulkListingProgressService(batches, advancements);
   });
 
   it('skips counter increment when advancement already exists (idempotent retry)', async () => {

--- a/libs/core/src/listings/application/services/__tests__/bulk-listing-retry.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/bulk-listing-retry.service.spec.ts
@@ -23,19 +23,19 @@ import type { IIntegrationsService } from '@openlinker/core/integrations';
 import type { OfferManagerPort } from '@openlinker/core/listings';
 import type { JobEnqueuePort } from '@openlinker/core/sync';
 
-import { BulkOfferCreationBatch } from '../../../domain/entities/bulk-offer-creation-batch.entity';
+import { BulkListingBatch } from '../../../domain/entities/bulk-listing-batch.entity';
 import { AdapterCapabilityNotSupportedException } from '../../../domain/exceptions/adapter-capability-not-supported.exception';
-import { BulkOfferCreationBatchNotFoundException } from '../../../domain/exceptions/bulk-offer-creation-batch-not-found.exception';
+import { BulkListingBatchNotFoundException } from '../../../domain/exceptions/bulk-listing-batch-not-found.exception';
 import { BulkRetryMissingSnapshotException } from '../../../domain/exceptions/bulk-retry-missing-snapshot.exception';
 import { NoFailedChildrenToRetryException } from '../../../domain/exceptions/no-failed-children-to-retry.exception';
 import { OfferCreationRecord } from '../../../domain/entities/offer-creation-record.entity';
 import type { BulkBatchAdvancementRepositoryPort } from '../../../domain/ports/bulk-batch-advancement-repository.port';
-import type { BulkOfferCreationBatchRepositoryPort } from '../../../domain/ports/bulk-offer-creation-batch-repository.port';
+import type { BulkListingBatchRepositoryPort } from '../../../domain/ports/bulk-listing-batch-repository.port';
 import type { OfferCreationRecordRepositoryPort } from '../../../domain/ports/offer-creation-record-repository.port';
-import { BULK_BATCH_STATUS } from '../../../domain/types/bulk-offer-creation-batch.types';
+import { BULK_BATCH_STATUS } from '../../../domain/types/bulk-listing-batch.types';
 import type { OfferCreationStatus } from '../../../domain/types/offer-creation-record.types';
 import type { OfferCreationRequestSnapshot } from '../../../domain/types/offer-creation-request-snapshot.types';
-import { BulkOfferCreationRetryService } from '../bulk-offer-creation-retry.service';
+import { BulkListingRetryService } from '../bulk-listing-retry.service';
 
 const BATCH_ID = 'batch-uuid-1';
 const CONNECTION_ID = 'conn-allegro-1';
@@ -83,10 +83,10 @@ function makeRecord(
 }
 
 function makeBatch(
-  overrides: Partial<BulkOfferCreationBatch> = {}
-): BulkOfferCreationBatch {
+  overrides: Partial<BulkListingBatch> = {}
+): BulkListingBatch {
   const now = new Date('2026-05-18T09:00:00Z');
-  return new BulkOfferCreationBatch(
+  return new BulkListingBatch(
     overrides.id ?? BATCH_ID,
     overrides.connectionId ?? CONNECTION_ID,
     overrides.initiatedBy ?? 'user-1',
@@ -100,9 +100,9 @@ function makeBatch(
   );
 }
 
-describe('BulkOfferCreationRetryService', () => {
-  let service: BulkOfferCreationRetryService;
-  let batches: jest.Mocked<BulkOfferCreationBatchRepositoryPort>;
+describe('BulkListingRetryService', () => {
+  let service: BulkListingRetryService;
+  let batches: jest.Mocked<BulkListingBatchRepositoryPort>;
   let records: jest.Mocked<OfferCreationRecordRepositoryPort>;
   let advancements: jest.Mocked<BulkBatchAdvancementRepositoryPort>;
   let integrations: jest.Mocked<Pick<IIntegrationsService, 'getCapabilityAdapter'>>;
@@ -141,7 +141,7 @@ describe('BulkOfferCreationRetryService', () => {
       enqueueJob: jest.fn().mockResolvedValue({ jobId: 'job-1' }),
     } as unknown as jest.Mocked<JobEnqueuePort>;
 
-    service = new BulkOfferCreationRetryService(
+    service = new BulkListingRetryService(
       batches,
       records,
       advancements,
@@ -152,11 +152,11 @@ describe('BulkOfferCreationRetryService', () => {
 
   // ── Throw paths ─────────────────────────────────────────────────────
 
-  it('throws BulkOfferCreationBatchNotFoundException when batch missing', async () => {
+  it('throws BulkListingBatchNotFoundException when batch missing', async () => {
     batches.findById.mockResolvedValueOnce(null);
 
     await expect(service.retryFailed(BATCH_ID)).rejects.toBeInstanceOf(
-      BulkOfferCreationBatchNotFoundException
+      BulkListingBatchNotFoundException
     );
     expect(records.findByBulkBatchId).not.toHaveBeenCalled();
   });

--- a/libs/core/src/listings/application/services/__tests__/bulk-listing-submit.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/bulk-listing-submit.service.spec.ts
@@ -16,16 +16,16 @@ import type { IProductsService, ProductVariant } from '@openlinker/core/products
 import type { IInventoryQueryService } from '@openlinker/core/inventory';
 
 import type { OfferCreationRecord } from '../../../domain/entities/offer-creation-record.entity';
-import { BulkOfferCreationBatch } from '../../../domain/entities/bulk-offer-creation-batch.entity';
+import { BulkListingBatch } from '../../../domain/entities/bulk-listing-batch.entity';
 import { EmptyBulkSubmissionException } from '../../../domain/exceptions/empty-bulk-submission.exception';
-import type { BulkOfferCreationBatchRepositoryPort } from '../../../domain/ports/bulk-offer-creation-batch-repository.port';
+import type { BulkListingBatchRepositoryPort } from '../../../domain/ports/bulk-listing-batch-repository.port';
 import type { OfferCreationRecordRepositoryPort } from '../../../domain/ports/offer-creation-record-repository.port';
 import type { IOfferCreationEnqueueService } from '../../interfaces/offer-creation-enqueue.service.interface';
-import { BulkOfferCreationSubmitService } from '../bulk-offer-creation-submit.service';
+import { BulkListingSubmitService } from '../bulk-listing-submit.service';
 
-describe('BulkOfferCreationSubmitService', () => {
-  let service: BulkOfferCreationSubmitService;
-  let bulkBatchRepo: jest.Mocked<BulkOfferCreationBatchRepositoryPort>;
+describe('BulkListingSubmitService', () => {
+  let service: BulkListingSubmitService;
+  let bulkBatchRepo: jest.Mocked<BulkListingBatchRepositoryPort>;
   let offerCreationRecords: jest.Mocked<OfferCreationRecordRepositoryPort>;
   let enqueueService: jest.Mocked<IOfferCreationEnqueueService>;
   let integrations: jest.Mocked<IIntegrationsService>;
@@ -48,8 +48,8 @@ describe('BulkOfferCreationSubmitService', () => {
     ...overrides,
   });
 
-  const makeBatch = (overrides: Partial<BulkOfferCreationBatch> = {}): BulkOfferCreationBatch =>
-    new BulkOfferCreationBatch(
+  const makeBatch = (overrides: Partial<BulkListingBatch> = {}): BulkListingBatch =>
+    new BulkListingBatch(
       overrides.id ?? 'batch-1',
       overrides.connectionId ?? connectionId,
       overrides.initiatedBy ?? initiatedBy,
@@ -115,7 +115,7 @@ describe('BulkOfferCreationSubmitService', () => {
       getAvailabilityByVariantIds: jest.fn().mockResolvedValue([]),
     };
 
-    service = new BulkOfferCreationSubmitService(
+    service = new BulkListingSubmitService(
       bulkBatchRepo,
       offerCreationRecords,
       enqueueService,

--- a/libs/core/src/listings/application/services/bulk-listing-progress.service.interface.ts
+++ b/libs/core/src/listings/application/services/bulk-listing-progress.service.interface.ts
@@ -1,12 +1,12 @@
 /**
  * Bulk Offer Creation Progress Service Interface (#737)
  *
- * Core state-machine owner for `BulkOfferCreationBatch`. Called by the
+ * Core state-machine owner for `BulkListingBatch`. Called by the
  * worker's `marketplace.offer.create` handler after each child job
  * terminates, to increment the batch's counters and (when total reached)
  * derive the terminal status — `completed | partially-failed | failed`.
  *
- * Split from `BulkOfferCreationSubmitService` (which owns the HTTP-side
+ * Split from `BulkListingSubmitService` (which owns the HTTP-side
  * intake half — submit + transition to `running`) to keep the per-phase
  * orchestration pattern uniform with sibling services
  * (`OfferCreationEnqueueService` / `OfferCreationExecutionService` /
@@ -14,10 +14,10 @@
  *
  * @module libs/core/src/listings/application/services
  */
-import type { BulkOfferCreationBatch } from '../../domain/entities/bulk-offer-creation-batch.entity';
+import type { BulkListingBatch } from '../../domain/entities/bulk-listing-batch.entity';
 import type { BulkChildOutcome } from '../../domain/types/bulk-child-outcome.types';
 
-export interface IBulkOfferCreationProgressService {
+export interface IBulkListingProgressService {
   /**
    * Record that a single child offer-creation completed, advance the batch
    * counters accordingly, and derive the terminal status if the batch is
@@ -29,7 +29,7 @@ export interface IBulkOfferCreationProgressService {
    * without touching counters.
    *
    * Returns:
-   * - The post-update `BulkOfferCreationBatch` when the batch reached its
+   * - The post-update `BulkListingBatch` when the batch reached its
    *   terminal state on this call.
    * - `null` when the batch is still in progress, OR when the advancement
    *   was already recorded (idempotent retry path).
@@ -38,5 +38,5 @@ export interface IBulkOfferCreationProgressService {
     batchId: string,
     offerCreationRecordId: string,
     outcome: BulkChildOutcome,
-  ): Promise<BulkOfferCreationBatch | null>;
+  ): Promise<BulkListingBatch | null>;
 }

--- a/libs/core/src/listings/application/services/bulk-listing-progress.service.ts
+++ b/libs/core/src/listings/application/services/bulk-listing-progress.service.ts
@@ -1,7 +1,7 @@
 /**
  * Bulk Offer Creation Progress Service (#737)
  *
- * Worker-side state-machine for `BulkOfferCreationBatch`. Per
+ * Worker-side state-machine for `BulkListingBatch`. Per
  * `architecture-overview.md § 7`, orchestration policies live in core
  * application services, not in worker handlers — so the terminal-status
  * derivation rule lives here, with the handler reduced to a thin shell
@@ -13,33 +13,33 @@
  * double-increment the counters.
  *
  * @module libs/core/src/listings/application/services
- * @implements {IBulkOfferCreationProgressService}
+ * @implements {IBulkListingProgressService}
  */
 import { Inject, Injectable } from '@nestjs/common';
 
 import { Logger } from '@openlinker/shared/logging';
 
-import type { BulkOfferCreationBatch } from '../../domain/entities/bulk-offer-creation-batch.entity';
+import type { BulkListingBatch } from '../../domain/entities/bulk-listing-batch.entity';
 import { BulkBatchAdvancementRepositoryPort } from '../../domain/ports/bulk-batch-advancement-repository.port';
-import { BulkOfferCreationBatchRepositoryPort } from '../../domain/ports/bulk-offer-creation-batch-repository.port';
+import { BulkListingBatchRepositoryPort } from '../../domain/ports/bulk-listing-batch-repository.port';
 import type { BulkChildOutcome } from '../../domain/types/bulk-child-outcome.types';
 import {
   BULK_BATCH_STATUS,
   type BulkBatchStatus,
-} from '../../domain/types/bulk-offer-creation-batch.types';
+} from '../../domain/types/bulk-listing-batch.types';
 import {
   BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
-  BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
+  BULK_LISTING_BATCH_REPOSITORY_TOKEN,
 } from '../../listings.tokens';
-import type { IBulkOfferCreationProgressService } from './bulk-offer-creation-progress.service.interface';
+import type { IBulkListingProgressService } from './bulk-listing-progress.service.interface';
 
 @Injectable()
-export class BulkOfferCreationProgressService implements IBulkOfferCreationProgressService {
-  private readonly logger = new Logger(BulkOfferCreationProgressService.name);
+export class BulkListingProgressService implements IBulkListingProgressService {
+  private readonly logger = new Logger(BulkListingProgressService.name);
 
   constructor(
-    @Inject(BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN)
-    private readonly bulkBatchRepository: BulkOfferCreationBatchRepositoryPort,
+    @Inject(BULK_LISTING_BATCH_REPOSITORY_TOKEN)
+    private readonly bulkBatchRepository: BulkListingBatchRepositoryPort,
     @Inject(BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN)
     private readonly advancementRepository: BulkBatchAdvancementRepositoryPort
   ) {}
@@ -48,7 +48,7 @@ export class BulkOfferCreationProgressService implements IBulkOfferCreationProgr
     batchId: string,
     offerCreationRecordId: string,
     outcome: BulkChildOutcome
-  ): Promise<BulkOfferCreationBatch | null> {
+  ): Promise<BulkListingBatch | null> {
     const { created } = await this.advancementRepository.markAdvancedIfNotExists(
       batchId,
       offerCreationRecordId

--- a/libs/core/src/listings/application/services/bulk-listing-retry.service.ts
+++ b/libs/core/src/listings/application/services/bulk-listing-retry.service.ts
@@ -1,7 +1,7 @@
 /**
  * Bulk Offer Creation Retry Service (#742)
  *
- * Re-runs the failed children of a `BulkOfferCreationBatch`. Owns the
+ * Re-runs the failed children of a `BulkListingBatch`. Owns the
  * counter-reopen policy: deletes per-record `bulk_batch_advancements` rows,
  * decrements `failedCount` per-record (lock-stepped to local writes),
  * transitions terminal-state batches back to `'running'` after the loop,
@@ -9,8 +9,8 @@
  * idempotency key.
  *
  * Sibling to:
- *  - `BulkOfferCreationSubmitService` (#736) — initial submit.
- *  - `BulkOfferCreationProgressService` (#737) — counter advancement.
+ *  - `BulkListingSubmitService` (#736) — initial submit.
+ *  - `BulkListingProgressService` (#737) — counter advancement.
  *
  * Closes out the bulk-listing backend epic (#726).
  *
@@ -21,8 +21,8 @@
  * hot-path service. The retry service assembles the V2 payload inline.
  *
  * @module libs/core/src/listings/application/services
- * @implements {IBulkOfferCreationRetryService}
- * @see {@link IBulkOfferCreationRetryService} for the contract
+ * @implements {IBulkListingRetryService}
+ * @see {@link IBulkListingRetryService} for the contract
  */
 import { randomUUID } from 'node:crypto';
 
@@ -42,37 +42,37 @@ import {
 import { Logger } from '@openlinker/shared/logging';
 
 import { AdapterCapabilityNotSupportedException } from '../../domain/exceptions/adapter-capability-not-supported.exception';
-import { BulkOfferCreationBatchNotFoundException } from '../../domain/exceptions/bulk-offer-creation-batch-not-found.exception';
+import { BulkListingBatchNotFoundException } from '../../domain/exceptions/bulk-listing-batch-not-found.exception';
 import { BulkRetryMissingSnapshotException } from '../../domain/exceptions/bulk-retry-missing-snapshot.exception';
 import { NoFailedChildrenToRetryException } from '../../domain/exceptions/no-failed-children-to-retry.exception';
 import { BulkBatchAdvancementRepositoryPort } from '../../domain/ports/bulk-batch-advancement-repository.port';
-import { BulkOfferCreationBatchRepositoryPort } from '../../domain/ports/bulk-offer-creation-batch-repository.port';
+import { BulkListingBatchRepositoryPort } from '../../domain/ports/bulk-listing-batch-repository.port';
 import { isOfferCreator } from '../../domain/ports/capabilities/offer-creator.capability';
 import type { OfferManagerPort } from '../../domain/ports/offer-manager.port';
 import { OfferCreationRecordRepositoryPort } from '../../domain/ports/offer-creation-record-repository.port';
 import {
   BULK_BATCH_STATUS,
   type BulkBatchStatus,
-} from '../../domain/types/bulk-offer-creation-batch.types';
+} from '../../domain/types/bulk-listing-batch.types';
 import { OFFER_CREATION_STATUS } from '../../domain/types/offer-creation-record.types';
 import {
   BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
-  BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
+  BULK_LISTING_BATCH_REPOSITORY_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
 } from '../../listings.tokens';
-import type { IBulkOfferCreationRetryService } from '../interfaces/bulk-offer-creation-retry.service.interface';
+import type { IBulkListingRetryService } from '../interfaces/bulk-listing-retry.service.interface';
 import type {
-  BulkOfferCreationRetryAiFlags,
-  BulkOfferCreationRetryResult,
-} from '../types/bulk-offer-creation-retry.types';
+  BulkListingRetryAiFlags,
+  BulkListingRetryResult,
+} from '../types/bulk-listing-retry.types';
 
 @Injectable()
-export class BulkOfferCreationRetryService implements IBulkOfferCreationRetryService {
-  private readonly logger = new Logger(BulkOfferCreationRetryService.name);
+export class BulkListingRetryService implements IBulkListingRetryService {
+  private readonly logger = new Logger(BulkListingRetryService.name);
 
   constructor(
-    @Inject(BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN)
-    private readonly bulkBatchRepository: BulkOfferCreationBatchRepositoryPort,
+    @Inject(BULK_LISTING_BATCH_REPOSITORY_TOKEN)
+    private readonly bulkBatchRepository: BulkListingBatchRepositoryPort,
     @Inject(OFFER_CREATION_RECORD_REPOSITORY_TOKEN)
     private readonly offerCreationRecords: OfferCreationRecordRepositoryPort,
     @Inject(BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN)
@@ -83,11 +83,11 @@ export class BulkOfferCreationRetryService implements IBulkOfferCreationRetrySer
     private readonly jobEnqueue: JobEnqueuePort
   ) {}
 
-  async retryFailed(batchId: string): Promise<BulkOfferCreationRetryResult> {
+  async retryFailed(batchId: string): Promise<BulkListingRetryResult> {
     // 1. Verify batch exists.
     const batch = await this.bulkBatchRepository.findById(batchId);
     if (!batch) {
-      throw new BulkOfferCreationBatchNotFoundException(batchId);
+      throw new BulkListingBatchNotFoundException(batchId);
     }
 
     // 2. Load children + filter to failed. `findByBulkBatchId` returns
@@ -210,7 +210,7 @@ export class BulkOfferCreationRetryService implements IBulkOfferCreationRetrySer
    * `descriptionTone` strings log a WARN and drop to undefined (preserving
    * the retry rather than failing on a bad value).
    */
-  private extractAiFlags(sharedConfig: Record<string, unknown>): BulkOfferCreationRetryAiFlags {
+  private extractAiFlags(sharedConfig: Record<string, unknown>): BulkListingRetryAiFlags {
     const generateDescription = sharedConfig.generateDescription === true;
 
     const rawTone = sharedConfig.descriptionTone;

--- a/libs/core/src/listings/application/services/bulk-listing-submit.service.ts
+++ b/libs/core/src/listings/application/services/bulk-listing-submit.service.ts
@@ -1,7 +1,7 @@
 /**
  * Bulk Offer Creation Submit Service (#736)
  *
- * Composes the just-shipped `BulkOfferCreationBatch` aggregate (#734) into
+ * Composes the just-shipped `BulkListingBatch` aggregate (#734) into
  * an operator-facing bulk-listing flow: validates connection + adapter
  * capability up front, persists the parent batch row, fans N enqueues out
  * through the existing `IOfferCreationEnqueueService` (so the per-record
@@ -23,8 +23,8 @@
  * one variant listing. `totalCount` reflects the expanded count.
  *
  * @module libs/core/src/listings/application/services
- * @implements {IBulkOfferCreationSubmitService}
- * @see {@link IBulkOfferCreationSubmitService} for the service contract
+ * @implements {IBulkListingSubmitService}
+ * @see {@link IBulkListingSubmitService} for the service contract
  * @see {@link IOfferCreationEnqueueService} for the per-product enqueue half
  */
 
@@ -36,7 +36,7 @@ import {
   isOfferCreator,
   OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
 
-  BulkOfferCreationBatchRepositoryPort,
+  BulkListingBatchRepositoryPort,
   IOfferCreationEnqueueService,
   OfferCreationRecordRepositoryPort} from '@openlinker/core/listings';
 import type {
@@ -59,26 +59,26 @@ import {
 
 import { EmptyBulkSubmissionException } from '../../domain/exceptions/empty-bulk-submission.exception';
 import {
-  BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
+  BULK_LISTING_BATCH_REPOSITORY_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
 } from '../../listings.tokens';
-import type { IBulkOfferCreationSubmitService } from '../interfaces/bulk-offer-creation-submit.service.interface';
+import type { IBulkListingSubmitService } from '../interfaces/bulk-listing-submit.service.interface';
 import type {
   BulkBatchSummary,
-  BulkOfferCreationSubmitInput,
-  BulkOfferCreationSubmitResult,
+  BulkListingSubmitInput,
+  BulkListingSubmitResult,
   ExpandedVariantJob,
   PerProductOverride,
-} from '../types/bulk-offer-creation-submit.types';
+} from '../types/bulk-listing-submit.types';
 import type { EnqueueOfferCreationInput } from '../types/offer-creation-enqueue.types';
 
 @Injectable()
-export class BulkOfferCreationSubmitService implements IBulkOfferCreationSubmitService {
-  private readonly logger = new Logger(BulkOfferCreationSubmitService.name);
+export class BulkListingSubmitService implements IBulkListingSubmitService {
+  private readonly logger = new Logger(BulkListingSubmitService.name);
 
   constructor(
-    @Inject(BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN)
-    private readonly bulkBatchRepository: BulkOfferCreationBatchRepositoryPort,
+    @Inject(BULK_LISTING_BATCH_REPOSITORY_TOKEN)
+    private readonly bulkBatchRepository: BulkListingBatchRepositoryPort,
     @Inject(OFFER_CREATION_RECORD_REPOSITORY_TOKEN)
     private readonly offerCreationRecords: OfferCreationRecordRepositoryPort,
     @Inject(OFFER_CREATION_ENQUEUE_SERVICE_TOKEN)
@@ -91,7 +91,7 @@ export class BulkOfferCreationSubmitService implements IBulkOfferCreationSubmitS
     private readonly inventoryQuery: IInventoryQueryService
   ) {}
 
-  async submit(input: BulkOfferCreationSubmitInput): Promise<BulkOfferCreationSubmitResult> {
+  async submit(input: BulkListingSubmitInput): Promise<BulkListingSubmitResult> {
     if (input.productIds.length === 0) {
       throw new EmptyBulkSubmissionException();
     }
@@ -132,7 +132,7 @@ export class BulkOfferCreationSubmitService implements IBulkOfferCreationSubmitS
     );
 
     // 3. Persist the batch row. Status defaults to 'pending' per the
-    //    `CreateBulkOfferCreationBatchInput` contract; `sharedConfig` is
+    //    `CreateBulkListingBatchInput` contract; `sharedConfig` is
     //    stored as the unstructured persistence projection of the typed
     //    `BulkSharedConfig` shape so future schema iterations don't require
     //    a migration.
@@ -217,7 +217,7 @@ export class BulkOfferCreationSubmitService implements IBulkOfferCreationSubmitS
    * the operator-facing submit stays responsive for large selections.
    */
   private async expandVariantJobs(
-    input: BulkOfferCreationSubmitInput
+    input: BulkListingSubmitInput
   ): Promise<ExpandedVariantJob[]> {
     const uniqueSelectedIds = [...new Set(input.productIds)];
 
@@ -330,7 +330,7 @@ export class BulkOfferCreationSubmitService implements IBulkOfferCreationSubmitS
    * product by barcode.
    */
   private buildEnqueueInput(
-    input: BulkOfferCreationSubmitInput,
+    input: BulkListingSubmitInput,
     bulkBatchId: string,
     job: ExpandedVariantJob,
     masterStock: Map<string, number>
@@ -394,7 +394,7 @@ export class BulkOfferCreationSubmitService implements IBulkOfferCreationSubmitS
 }
 
 /*
- * Worker-handler seam: shipped as `BulkOfferCreationProgressService.advanceBatchStatus`
+ * Worker-handler seam: shipped as `BulkListingProgressService.advanceBatchStatus`
  * in #737. The terminal-state derivation rule lives there. See
- * `bulk-offer-creation-progress.service.ts`.
+ * `bulk-listing-progress.service.ts`.
  */

--- a/libs/core/src/listings/application/types/bulk-listing-retry.types.ts
+++ b/libs/core/src/listings/application/types/bulk-listing-retry.types.ts
@@ -1,8 +1,8 @@
 /**
  * Bulk Offer Creation Retry Types (#742)
  *
- * Result shape returned by `IBulkOfferCreationRetryService.retryFailed`,
- * plus the internal `BulkOfferCreationRetryAiFlags` projection extracted
+ * Result shape returned by `IBulkListingRetryService.retryFailed`,
+ * plus the internal `BulkListingRetryAiFlags` projection extracted
  * from the parent batch's `sharedConfig` JSONB at retry time. The submit
  * snapshot doesn't carry the AI flags (they're batch-scoped, not
  * per-record), so the retry service rebuilds them once per `retryFailed`
@@ -16,14 +16,14 @@
  */
 import type { OfferDescriptionTone } from '@openlinker/core/sync';
 
-import type { BulkBatchStatus } from '../../domain/types/bulk-offer-creation-batch.types';
+import type { BulkBatchStatus } from '../../domain/types/bulk-listing-batch.types';
 
-export interface BulkOfferCreationRetryAiFlags {
+export interface BulkListingRetryAiFlags {
   generateDescription: boolean;
   descriptionTone?: OfferDescriptionTone;
 }
 
-export interface BulkOfferCreationRetryResult {
+export interface BulkListingRetryResult {
   /**
    * Count of records re-enqueued. Always > 0 — `NoFailedChildrenToRetryException`
    * is thrown instead of returning a zero.

--- a/libs/core/src/listings/application/types/bulk-listing-submit.types.ts
+++ b/libs/core/src/listings/application/types/bulk-listing-submit.types.ts
@@ -4,12 +4,12 @@
  * Input / result contracts for the bulk submission service that fans an
  * N-product bulk submission out across the existing offer-creation enqueue
  * flow: validate connection + capability, persist a parent
- * `BulkOfferCreationBatch`, enqueue one `marketplace.offer.create` job per
+ * `BulkListingBatch`, enqueue one `marketplace.offer.create` job per
  * product carrying `MarketplaceOfferCreatePayloadV2`, return the batchId +
  * jobIds for FE polling.
  *
  * Worker-side handling (consuming the V2 payload, calling
- * `BulkOfferCreationBatchRepositoryPort.incrementCounters` on terminal
+ * `BulkListingBatchRepositoryPort.incrementCounters` on terminal
  * status) lands in **#737**; this slice defines the submit/read seam only.
  *
  * @module libs/core/src/listings/application/types
@@ -18,7 +18,7 @@
 import type { CreateOfferOverrides } from '@openlinker/core/listings';
 import type { OfferDescriptionTone } from '@openlinker/core/sync';
 
-import type { BulkOfferCreationBatch } from '../../domain/entities/bulk-offer-creation-batch.entity';
+import type { BulkListingBatch } from '../../domain/entities/bulk-listing-batch.entity';
 import type { OfferCreationRecord } from '../../domain/entities/offer-creation-record.entity';
 
 /**
@@ -58,14 +58,14 @@ export interface PerProductOverride {
 }
 
 /**
- * Service-layer input to `IBulkOfferCreationSubmitService.submit`.
+ * Service-layer input to `IBulkListingSubmitService.submit`.
  *
  * Distinct from the HTTP DTO: the controller maps from
  * `BulkOfferCreateRequestDto` to this shape and adds `initiatedBy` from
  * the authenticated session. Keeps the service free of HTTP framework
  * coupling.
  */
-export interface BulkOfferCreationSubmitInput {
+export interface BulkListingSubmitInput {
   /** Target marketplace connection id. */
   connectionId: string;
   /**
@@ -100,7 +100,7 @@ export interface BulkOfferCreationSubmitInput {
  * pre-#824 behaviour is byte-identical for them.
  *
  * Not exported from the package barrel — purely an implementation detail of
- * `BulkOfferCreationSubmitService`.
+ * `BulkListingSubmitService`.
  */
 export interface ExpandedVariantJob {
   /** The variant this offer-creation job lists. */
@@ -131,7 +131,7 @@ export interface ExpandedVariantJob {
  * Service-layer result returned by `submit`. The controller maps to
  * `BulkOfferCreateResponseDto` for the HTTP boundary.
  */
-export interface BulkOfferCreationSubmitResult {
+export interface BulkListingSubmitResult {
   /** Persisted batch id (UUID). */
   batchId: string;
   /**
@@ -144,12 +144,12 @@ export interface BulkOfferCreationSubmitResult {
 }
 
 /**
- * Aggregate summary returned by `IBulkOfferCreationSubmitService.getBatch`.
+ * Aggregate summary returned by `IBulkListingSubmitService.getBatch`.
  * The controller maps to `BulkBatchSummaryDto`; the FE poll page in #741
  * renders this shape directly.
  */
 export interface BulkBatchSummary {
-  batch: BulkOfferCreationBatch;
+  batch: BulkListingBatch;
   /**
    * Per-product child rows, ordered by `createdAt ASC` so the wizard's
    * review table renders rows in submission order even after retries.

--- a/libs/core/src/listings/application/types/offer-creation-enqueue.types.ts
+++ b/libs/core/src/listings/application/types/offer-creation-enqueue.types.ts
@@ -35,7 +35,7 @@ export interface EnqueueOfferCreationInput {
   /** Caller-supplied idempotency key; defaults to `offer-create:{record.id}` (per-call-unique). */
   idempotencyKey?: string;
   /**
-   * Parent BulkOfferCreationBatch id when this enqueue is part of a bulk
+   * Parent BulkListingBatch id when this enqueue is part of a bulk
    * submission (#736). When set the emitted job payload is
    * `MarketplaceOfferCreatePayloadV2` (carries `bulkBatchId` +
    * `generateDescription` + optional `descriptionTone`); when omitted, V1

--- a/libs/core/src/listings/domain/entities/bulk-batch-advancement.entity.ts
+++ b/libs/core/src/listings/domain/entities/bulk-batch-advancement.entity.ts
@@ -2,7 +2,7 @@
  * Bulk Batch Advancement Domain Entity (#737)
  *
  * Records that a single `OfferCreationRecord`'s outcome has been counted
- * toward its parent `BulkOfferCreationBatch`. Acts as the at-most-once
+ * toward its parent `BulkListingBatch`. Acts as the at-most-once
  * guard for the worker handler's counter-advancement path: composite-PK
  * `(bulkBatchId, offerCreationRecordId)` + INSERT-ON-CONFLICT-DO-NOTHING
  * makes the guarantee race-free across N concurrent worker invocations

--- a/libs/core/src/listings/domain/entities/bulk-listing-batch.entity.spec.ts
+++ b/libs/core/src/listings/domain/entities/bulk-listing-batch.entity.spec.ts
@@ -3,15 +3,15 @@
  *
  * @module libs/core/src/listings/domain/entities
  */
-import { BulkOfferCreationBatch } from './bulk-offer-creation-batch.entity';
-import type { BulkBatchStatus } from '../types/bulk-offer-creation-batch.types';
+import { BulkListingBatch } from './bulk-listing-batch.entity';
+import type { BulkBatchStatus } from '../types/bulk-listing-batch.types';
 
-describe('BulkOfferCreationBatch', () => {
+describe('BulkListingBatch', () => {
   it('should preserve all constructor fields', () => {
     const now = new Date('2026-05-17T10:00:00Z');
     const sharedConfig = { publishImmediately: true, shippingRatePackageId: 'pkg-1' };
 
-    const batch = new BulkOfferCreationBatch(
+    const batch = new BulkListingBatch(
       'batch-uuid',
       'conn-uuid',
       'user-1',

--- a/libs/core/src/listings/domain/entities/bulk-listing-batch.entity.ts
+++ b/libs/core/src/listings/domain/entities/bulk-listing-batch.entity.ts
@@ -14,9 +14,9 @@
  * @module libs/core/src/listings/domain/entities
  */
 
-import type { BulkBatchStatus } from '../types/bulk-offer-creation-batch.types';
+import type { BulkBatchStatus } from '../types/bulk-listing-batch.types';
 
-export class BulkOfferCreationBatch {
+export class BulkListingBatch {
   constructor(
     public readonly id: string,
     public readonly connectionId: string,

--- a/libs/core/src/listings/domain/entities/offer-creation-record.entity.ts
+++ b/libs/core/src/listings/domain/entities/offer-creation-record.entity.ts
@@ -34,7 +34,7 @@ export class OfferCreationRecord {
      */
     public readonly request: OfferCreationRequestSnapshot | null = null,
     /**
-     * Parent BulkOfferCreationBatch id. Null for single-offer attempts; set
+     * Parent BulkListingBatch id. Null for single-offer attempts; set
      * when the record was created as part of a bulk submission (#736).
      */
     public readonly bulkBatchId: string | null = null,

--- a/libs/core/src/listings/domain/exceptions/adapter-capability-not-supported.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/adapter-capability-not-supported.exception.ts
@@ -6,8 +6,8 @@
  * flows). Lets core stay NestJS-free — the controller / global filter maps
  * the domain exception to HTTP 422.
  *
- * Today this is thrown by `BulkOfferCreationRetryService`. Other services
- * (`OfferCreationEnqueueService`, `BulkOfferCreationSubmitService`) still
+ * Today this is thrown by `BulkListingRetryService`. Other services
+ * (`OfferCreationEnqueueService`, `BulkListingSubmitService`) still
  * throw the NestJS `UnprocessableEntityException` directly from core —
  * pre-existing violation tracked as a cross-cutting cleanup follow-up.
  *

--- a/libs/core/src/listings/domain/exceptions/bulk-listing-batch-not-found.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/bulk-listing-batch-not-found.exception.ts
@@ -1,17 +1,17 @@
 /**
  * Bulk Offer Creation Batch Not Found Exception
  *
- * Domain exception thrown when a BulkOfferCreationBatch with the specified
+ * Domain exception thrown when a BulkListingBatch with the specified
  * ID does not exist. Raised by the repository on update paths
  * (`incrementCounters`, `updateStatus`) that require the row to already
  * exist.
  *
  * @module libs/core/src/listings/domain/exceptions
  */
-export class BulkOfferCreationBatchNotFoundException extends Error {
+export class BulkListingBatchNotFoundException extends Error {
   constructor(id: string) {
     super(`Bulk offer creation batch not found: ${id}`);
-    this.name = 'BulkOfferCreationBatchNotFoundException';
+    this.name = 'BulkListingBatchNotFoundException';
     Error.captureStackTrace(this, this.constructor);
   }
 }

--- a/libs/core/src/listings/domain/exceptions/bulk-retry-missing-snapshot.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/bulk-retry-missing-snapshot.exception.ts
@@ -1,7 +1,7 @@
 /**
  * Bulk Retry Missing Snapshot Exception (#742)
  *
- * Thrown by `BulkOfferCreationRetryService.retryFailed` when a failed
+ * Thrown by `BulkListingRetryService.retryFailed` when a failed
  * `OfferCreationRecord` for a bulk batch has `request === null`. The
  * `request` snapshot is required to reconstruct the V2 payload for the
  * retry wave — without it, retry can't proceed for that record.

--- a/libs/core/src/listings/domain/exceptions/empty-bulk-submission.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/empty-bulk-submission.exception.ts
@@ -1,7 +1,7 @@
 /**
  * Empty Bulk Submission Exception
  *
- * Domain exception raised by `BulkOfferCreationSubmitService.submit` when
+ * Domain exception raised by `BulkListingSubmitService.submit` when
  * the caller passes an empty `productIds` array. The controller DTO
  * already enforces `@IsArray @ArrayMinSize(1) @ArrayMaxSize(100)`, so
  * surfacing this exception means the service was reached via an internal

--- a/libs/core/src/listings/domain/exceptions/no-failed-children-to-retry.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/no-failed-children-to-retry.exception.ts
@@ -1,7 +1,7 @@
 /**
  * No Failed Children to Retry Exception (#742)
  *
- * Thrown by `BulkOfferCreationRetryService.retryFailed` when the addressed
+ * Thrown by `BulkListingRetryService.retryFailed` when the addressed
  * batch exists but has zero `OfferCreationRecord` children at
  * `status='failed'` — i.e. nothing to retry.
  *

--- a/libs/core/src/listings/domain/ports/bulk-batch-advancement-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/bulk-batch-advancement-repository.port.ts
@@ -2,8 +2,8 @@
  * Bulk Batch Advancement Repository Port
  *
  * Persistence contract for `BulkBatchAdvancement`. Consumed by
- * `BulkOfferCreationProgressService` (gate for at-most-once counter
- * advancement, #737) and `BulkOfferCreationRetryService` (#742, to undo
+ * `BulkListingProgressService` (gate for at-most-once counter
+ * advancement, #737) and `BulkListingRetryService` (#742, to undo
  * the gate on retry).
  *
  * @module libs/core/src/listings/domain/ports

--- a/libs/core/src/listings/domain/ports/bulk-listing-batch-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/bulk-listing-batch-repository.port.ts
@@ -1,7 +1,7 @@
 /**
  * Bulk Offer Creation Batch Repository Port
  *
- * Persistence contract for BulkOfferCreationBatch. Implemented in the
+ * Persistence contract for BulkListingBatch. Implemented in the
  * listings infrastructure layer. Returns domain entities only — ORM
  * mapping stays inside the repository.
  *
@@ -13,13 +13,13 @@
  * @module libs/core/src/listings/domain/ports
  */
 
-import type { BulkOfferCreationBatch } from '../entities/bulk-offer-creation-batch.entity';
+import type { BulkListingBatch } from '../entities/bulk-listing-batch.entity';
 import type {
   BulkBatchStatus,
-  CreateBulkOfferCreationBatchInput,
-} from '../types/bulk-offer-creation-batch.types';
+  CreateBulkListingBatchInput,
+} from '../types/bulk-listing-batch.types';
 
-export interface BulkOfferCreationBatchRepositoryPort {
+export interface BulkListingBatchRepositoryPort {
   /**
    * Persist a new bulk batch.
    *
@@ -28,12 +28,12 @@ export interface BulkOfferCreationBatchRepositoryPort {
    * invariant. `id`, `createdAt`, and `updatedAt` are assigned by the
    * repository.
    */
-  create(input: CreateBulkOfferCreationBatchInput): Promise<BulkOfferCreationBatch>;
+  create(input: CreateBulkListingBatchInput): Promise<BulkListingBatch>;
 
   /**
    * Look up a batch by primary key. Returns null when not found.
    */
-  findById(id: string): Promise<BulkOfferCreationBatch | null>;
+  findById(id: string): Promise<BulkListingBatch | null>;
 
   /**
    * Atomically apply counter deltas via single-column `UPDATE` statements
@@ -52,13 +52,13 @@ export interface BulkOfferCreationBatchRepositoryPort {
    * decide whether the batch has reached its terminal state without an
    * additional `findById`.
    *
-   * Throws `BulkOfferCreationBatchNotFoundException` if the row is
+   * Throws `BulkListingBatchNotFoundException` if the row is
    * missing.
    */
   incrementCounters(
     id: string,
     deltas: { succeeded?: number; failed?: number },
-  ): Promise<BulkOfferCreationBatch>;
+  ): Promise<BulkListingBatch>;
 
   /**
    * Update batch lifecycle status. Idempotent at the same status value.
@@ -68,8 +68,8 @@ export interface BulkOfferCreationBatchRepositoryPort {
    * `succeededCount + failedCount === totalCount`) live in the
    * application service in #736 per architecture-overview.md § 7.
    *
-   * Throws `BulkOfferCreationBatchNotFoundException` if the row is
+   * Throws `BulkListingBatchNotFoundException` if the row is
    * missing.
    */
-  updateStatus(id: string, status: BulkBatchStatus): Promise<BulkOfferCreationBatch>;
+  updateStatus(id: string, status: BulkBatchStatus): Promise<BulkListingBatch>;
 }

--- a/libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts
@@ -107,7 +107,7 @@ export interface OfferCreationRecordRepositoryPort {
    * Return all records that belong to a bulk batch, ordered by
    * `createdAt ASC` for stable summary rendering. Returns an empty array
    * when the batch id is unknown — callers that need batch existence
-   * should query `BulkOfferCreationBatchRepositoryPort.findById` instead
+   * should query `BulkListingBatchRepositoryPort.findById` instead
    * (this port is intentionally agnostic to batch existence).
    *
    * Backed by `IDX_offer_creation_records_bulkBatchId` (#734).

--- a/libs/core/src/listings/domain/types/bulk-child-outcome.types.ts
+++ b/libs/core/src/listings/domain/types/bulk-child-outcome.types.ts
@@ -1,8 +1,8 @@
 /**
  * Bulk Child Outcome Types (#737)
  *
- * The terminal outcome a single child of a `BulkOfferCreationBatch` reports
- * back to the parent batch via `IBulkOfferCreationProgressService.advanceBatchStatus`.
+ * The terminal outcome a single child of a `BulkListingBatch` reports
+ * back to the parent batch via `IBulkListingProgressService.advanceBatchStatus`.
  * Maps the V2 sync-job's `JobOutcome` (`'ok' | 'business_failure'`) onto the
  * batch-counter axis (`succeeded` / `failed`) — the handler does that mapping
  * once at the call site.

--- a/libs/core/src/listings/domain/types/bulk-listing-batch.types.ts
+++ b/libs/core/src/listings/domain/types/bulk-listing-batch.types.ts
@@ -1,7 +1,7 @@
 /**
  * Bulk Offer Creation Batch Types
  *
- * Types for BulkOfferCreationBatch — the parent aggregate for a single bulk
+ * Types for BulkListingBatch — the parent aggregate for a single bulk
  * offer-creation submission (one row per "user clicks bulk-create on N
  * variants"). Child offer-creation attempts reference the batch via
  * `offer_creation_records.bulkBatchId`.
@@ -60,9 +60,9 @@ export const BULK_BATCH_STATUS = {
 >;
 
 /**
- * Input contract for `BulkOfferCreationBatchRepositoryPort.create`.
+ * Input contract for `BulkListingBatchRepositoryPort.create`.
  *
- * Dedicated input type (not `Omit<BulkOfferCreationBatch, ...>`) so the
+ * Dedicated input type (not `Omit<BulkListingBatch, ...>`) so the
  * write contract is decoupled from the entity's readonly shape and future
  * entity changes (added fields, derived behavior) don't silently affect
  * callers.
@@ -71,7 +71,7 @@ export const BULK_BATCH_STATUS = {
  * those defaults are applied by the repository at write time so the input
  * type captures the invariant.
  */
-export interface CreateBulkOfferCreationBatchInput {
+export interface CreateBulkListingBatchInput {
   /** Target marketplace connection id. */
   connectionId: string;
   /** Operator user id that submitted the bulk request. Required — bulk is

--- a/libs/core/src/listings/domain/types/offer-creation-record.types.ts
+++ b/libs/core/src/listings/domain/types/offer-creation-record.types.ts
@@ -94,7 +94,7 @@ export interface CreateOfferCreationRecordInput {
    */
   request?: OfferCreationRequestSnapshot | null;
   /**
-   * Parent BulkOfferCreationBatch id for records created via the bulk
+   * Parent BulkListingBatch id for records created via the bulk
    * submission flow (#736). Omitted or `null` for single-offer creates.
    */
   bulkBatchId?: string | null;

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -76,36 +76,36 @@ export type {
 } from './domain/types/offer-creation-request-snapshot.types';
 export type { OfferCreationRecordRepositoryPort } from './domain/ports/offer-creation-record-repository.port';
 export { OfferCreationRecordNotFoundException } from './domain/exceptions/offer-creation-record-not-found.exception';
-export { BulkOfferCreationBatch } from './domain/entities/bulk-offer-creation-batch.entity';
+export { BulkListingBatch } from './domain/entities/bulk-listing-batch.entity';
 export {
   BulkBatchStatusValues,
   BULK_BATCH_STATUS,
-} from './domain/types/bulk-offer-creation-batch.types';
+} from './domain/types/bulk-listing-batch.types';
 export type {
   BulkBatchStatus,
-  CreateBulkOfferCreationBatchInput,
-} from './domain/types/bulk-offer-creation-batch.types';
-export type { BulkOfferCreationBatchRepositoryPort } from './domain/ports/bulk-offer-creation-batch-repository.port';
-export { BulkOfferCreationBatchNotFoundException } from './domain/exceptions/bulk-offer-creation-batch-not-found.exception';
+  CreateBulkListingBatchInput,
+} from './domain/types/bulk-listing-batch.types';
+export type { BulkListingBatchRepositoryPort } from './domain/ports/bulk-listing-batch-repository.port';
+export { BulkListingBatchNotFoundException } from './domain/exceptions/bulk-listing-batch-not-found.exception';
 export { EmptyBulkSubmissionException } from './domain/exceptions/empty-bulk-submission.exception';
 export { BulkBatchAdvancement } from './domain/entities/bulk-batch-advancement.entity';
 export type { BulkBatchAdvancementRepositoryPort } from './domain/ports/bulk-batch-advancement-repository.port';
 export { BulkChildOutcomeValues } from './domain/types/bulk-child-outcome.types';
 export type { BulkChildOutcome } from './domain/types/bulk-child-outcome.types';
-export type { IBulkOfferCreationProgressService } from './application/services/bulk-offer-creation-progress.service.interface';
-export type { IBulkOfferCreationSubmitService } from './application/interfaces/bulk-offer-creation-submit.service.interface';
+export type { IBulkListingProgressService } from './application/services/bulk-listing-progress.service.interface';
+export type { IBulkListingSubmitService } from './application/interfaces/bulk-listing-submit.service.interface';
 export type {
   BulkSharedConfig,
   PerProductOverride,
-  BulkOfferCreationSubmitInput,
-  BulkOfferCreationSubmitResult,
+  BulkListingSubmitInput,
+  BulkListingSubmitResult,
   BulkBatchSummary,
-} from './application/types/bulk-offer-creation-submit.types';
-export type { IBulkOfferCreationRetryService } from './application/interfaces/bulk-offer-creation-retry.service.interface';
+} from './application/types/bulk-listing-submit.types';
+export type { IBulkListingRetryService } from './application/interfaces/bulk-listing-retry.service.interface';
 export type {
-  BulkOfferCreationRetryAiFlags,
-  BulkOfferCreationRetryResult,
-} from './application/types/bulk-offer-creation-retry.types';
+  BulkListingRetryAiFlags,
+  BulkListingRetryResult,
+} from './application/types/bulk-listing-retry.types';
 export { AdapterCapabilityNotSupportedException } from './domain/exceptions/adapter-capability-not-supported.exception';
 export { BulkRetryMissingSnapshotException } from './domain/exceptions/bulk-retry-missing-snapshot.exception';
 export { NoFailedChildrenToRetryException } from './domain/exceptions/no-failed-children-to-retry.exception';

--- a/libs/core/src/listings/infrastructure/persistence/entities/bulk-batch-advancement.orm-entity.ts
+++ b/libs/core/src/listings/infrastructure/persistence/entities/bulk-batch-advancement.orm-entity.ts
@@ -2,7 +2,7 @@
  * Bulk Batch Advancement ORM Entity (#737)
  *
  * TypeORM entity for the `bulk_batch_advancements` table — the at-most-once
- * guard for bulk-offer-creation counter advancement.
+ * guard for bulk-listing counter advancement.
  *
  * Composite PK on `(bulkBatchId, offerCreationRecordId)` makes the
  * INSERT-ON-CONFLICT-DO-NOTHING path in `BulkBatchAdvancementRepository`

--- a/libs/core/src/listings/infrastructure/persistence/entities/bulk-listing-batch.orm-entity.ts
+++ b/libs/core/src/listings/infrastructure/persistence/entities/bulk-listing-batch.orm-entity.ts
@@ -5,7 +5,7 @@
  * PostgreSQL. Parent aggregate for a bulk offer-creation submission.
  *
  * @module libs/core/src/listings/infrastructure/persistence/entities
- * @see {@link BulkOfferCreationBatch} for the corresponding domain entity
+ * @see {@link BulkListingBatch} for the corresponding domain entity
  */
 import {
   Entity,
@@ -16,12 +16,12 @@ import {
   Index,
 } from 'typeorm';
 
-import { BulkBatchStatus } from '../../../domain/types/bulk-offer-creation-batch.types';
+import { BulkBatchStatus } from '../../../domain/types/bulk-listing-batch.types';
 
 @Entity('bulk_offer_creation_batches')
 @Index('IDX_bulk_offer_creation_batches_connectionId', ['connectionId'])
 @Index('IDX_bulk_offer_creation_batches_status', ['status'])
-export class BulkOfferCreationBatchOrmEntity {
+export class BulkListingBatchOrmEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 

--- a/libs/core/src/listings/infrastructure/persistence/repositories/bulk-listing-batch.repository.spec.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/bulk-listing-batch.repository.spec.ts
@@ -11,21 +11,21 @@ import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import type { Repository, UpdateResult } from 'typeorm';
 
-import { BulkOfferCreationBatchRepository } from './bulk-offer-creation-batch.repository';
-import { BulkOfferCreationBatchOrmEntity } from '../entities/bulk-offer-creation-batch.orm-entity';
-import { BulkOfferCreationBatch } from '../../../domain/entities/bulk-offer-creation-batch.entity';
-import { BulkOfferCreationBatchNotFoundException } from '../../../domain/exceptions/bulk-offer-creation-batch-not-found.exception';
-import type { CreateBulkOfferCreationBatchInput } from '../../../domain/types/bulk-offer-creation-batch.types';
+import { BulkListingBatchRepository } from './bulk-listing-batch.repository';
+import { BulkListingBatchOrmEntity } from '../entities/bulk-listing-batch.orm-entity';
+import { BulkListingBatch } from '../../../domain/entities/bulk-listing-batch.entity';
+import { BulkListingBatchNotFoundException } from '../../../domain/exceptions/bulk-listing-batch-not-found.exception';
+import type { CreateBulkListingBatchInput } from '../../../domain/types/bulk-listing-batch.types';
 
-describe('BulkOfferCreationBatchRepository', () => {
-  let repository: BulkOfferCreationBatchRepository;
-  let ormRepository: jest.Mocked<Repository<BulkOfferCreationBatchOrmEntity>>;
+describe('BulkListingBatchRepository', () => {
+  let repository: BulkListingBatchRepository;
+  let ormRepository: jest.Mocked<Repository<BulkListingBatchOrmEntity>>;
 
   const now = new Date('2026-05-17T10:00:00Z');
 
   const buildOrm = (
-    overrides: Partial<BulkOfferCreationBatchOrmEntity> = {},
-  ): BulkOfferCreationBatchOrmEntity => ({
+    overrides: Partial<BulkListingBatchOrmEntity> = {},
+  ): BulkListingBatchOrmEntity => ({
     id: 'batch-uuid',
     connectionId: 'conn-uuid',
     initiatedBy: 'user-1',
@@ -47,25 +47,25 @@ describe('BulkOfferCreationBatchRepository', () => {
       findOne: jest.fn(),
       save: jest.fn(),
       increment: jest.fn(),
-    } as unknown as jest.Mocked<Repository<BulkOfferCreationBatchOrmEntity>>;
+    } as unknown as jest.Mocked<Repository<BulkListingBatchOrmEntity>>;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        BulkOfferCreationBatchRepository,
+        BulkListingBatchRepository,
         {
-          provide: getRepositoryToken(BulkOfferCreationBatchOrmEntity),
+          provide: getRepositoryToken(BulkListingBatchOrmEntity),
           useValue: mockOrmRepo,
         },
       ],
     }).compile();
 
-    repository = module.get<BulkOfferCreationBatchRepository>(BulkOfferCreationBatchRepository);
-    ormRepository = module.get(getRepositoryToken(BulkOfferCreationBatchOrmEntity));
+    repository = module.get<BulkListingBatchRepository>(BulkListingBatchRepository);
+    ormRepository = module.get(getRepositoryToken(BulkListingBatchOrmEntity));
   });
 
   describe('create', () => {
     it('should persist a new batch with defaults and return a domain entity', async () => {
-      const input: CreateBulkOfferCreationBatchInput = {
+      const input: CreateBulkListingBatchInput = {
         connectionId: 'conn-uuid',
         initiatedBy: 'user-1',
         totalCount: 10,
@@ -76,7 +76,7 @@ describe('BulkOfferCreationBatchRepository', () => {
       const result = await repository.create(input);
 
       expect(ormRepository.save).toHaveBeenCalledTimes(1);
-      const savedArg = ormRepository.save.mock.calls[0][0] as BulkOfferCreationBatchOrmEntity;
+      const savedArg = ormRepository.save.mock.calls[0][0] as BulkListingBatchOrmEntity;
       expect(savedArg.connectionId).toBe('conn-uuid');
       expect(savedArg.initiatedBy).toBe('user-1');
       expect(savedArg.totalCount).toBe(10);
@@ -85,7 +85,7 @@ describe('BulkOfferCreationBatchRepository', () => {
       expect(savedArg.failedCount).toBe(0);
       expect(savedArg.sharedConfig).toEqual({ publishImmediately: true });
 
-      expect(result).toBeInstanceOf(BulkOfferCreationBatch);
+      expect(result).toBeInstanceOf(BulkListingBatch);
       expect(result.id).toBe('batch-uuid');
       expect(result.status).toBe('pending');
       expect(result.succeededCount).toBe(0);
@@ -93,7 +93,7 @@ describe('BulkOfferCreationBatchRepository', () => {
     });
 
     it('should accept an empty sharedConfig object', async () => {
-      const input: CreateBulkOfferCreationBatchInput = {
+      const input: CreateBulkListingBatchInput = {
         connectionId: 'conn-uuid',
         initiatedBy: 'user-1',
         totalCount: 5,
@@ -103,7 +103,7 @@ describe('BulkOfferCreationBatchRepository', () => {
 
       const result = await repository.create(input);
 
-      const savedArg = ormRepository.save.mock.calls[0][0] as BulkOfferCreationBatchOrmEntity;
+      const savedArg = ormRepository.save.mock.calls[0][0] as BulkListingBatchOrmEntity;
       expect(savedArg.sharedConfig).toEqual({});
       expect(result.sharedConfig).toEqual({});
     });
@@ -116,7 +116,7 @@ describe('BulkOfferCreationBatchRepository', () => {
       const result = await repository.findById('batch-uuid');
 
       expect(ormRepository.findOne).toHaveBeenCalledWith({ where: { id: 'batch-uuid' } });
-      expect(result).toBeInstanceOf(BulkOfferCreationBatch);
+      expect(result).toBeInstanceOf(BulkListingBatch);
       expect(result?.id).toBe('batch-uuid');
     });
 
@@ -171,7 +171,7 @@ describe('BulkOfferCreationBatchRepository', () => {
       const result = await repository.incrementCounters('batch-uuid', { succeeded: 0, failed: 0 });
 
       expect(ormRepository.increment).not.toHaveBeenCalled();
-      expect(result).toBeInstanceOf(BulkOfferCreationBatch);
+      expect(result).toBeInstanceOf(BulkListingBatch);
     });
 
     it('should accept negative deltas (compensation flow)', async () => {
@@ -183,22 +183,22 @@ describe('BulkOfferCreationBatchRepository', () => {
       expect(ormRepository.increment).toHaveBeenCalledWith({ id: 'batch-uuid' }, 'succeededCount', -1);
     });
 
-    it('should throw BulkOfferCreationBatchNotFoundException when increment affects no rows', async () => {
+    it('should throw BulkListingBatchNotFoundException when increment affects no rows', async () => {
       ormRepository.increment.mockResolvedValue(buildUpdateResult(0));
 
       await expect(
         repository.incrementCounters('missing', { succeeded: 1 }),
-      ).rejects.toBeInstanceOf(BulkOfferCreationBatchNotFoundException);
+      ).rejects.toBeInstanceOf(BulkListingBatchNotFoundException);
       expect(ormRepository.findOne).not.toHaveBeenCalled();
     });
 
-    it('should throw BulkOfferCreationBatchNotFoundException when row is deleted between increment and read', async () => {
+    it('should throw BulkListingBatchNotFoundException when row is deleted between increment and read', async () => {
       ormRepository.increment.mockResolvedValue(buildUpdateResult(1));
       ormRepository.findOne.mockResolvedValue(null);
 
       await expect(
         repository.incrementCounters('batch-uuid', { succeeded: 1 }),
-      ).rejects.toBeInstanceOf(BulkOfferCreationBatchNotFoundException);
+      ).rejects.toBeInstanceOf(BulkListingBatchNotFoundException);
     });
   });
 
@@ -211,7 +211,7 @@ describe('BulkOfferCreationBatchRepository', () => {
       const result = await repository.updateStatus('batch-uuid', 'running');
 
       expect(ormRepository.findOne).toHaveBeenCalledWith({ where: { id: 'batch-uuid' } });
-      const savedArg = ormRepository.save.mock.calls[0][0] as BulkOfferCreationBatchOrmEntity;
+      const savedArg = ormRepository.save.mock.calls[0][0] as BulkListingBatchOrmEntity;
       expect(savedArg.status).toBe('running');
       expect(result.status).toBe('running');
     });
@@ -223,16 +223,16 @@ describe('BulkOfferCreationBatchRepository', () => {
 
       const result = await repository.updateStatus('batch-uuid', 'completed');
 
-      const savedArg = ormRepository.save.mock.calls[0][0] as BulkOfferCreationBatchOrmEntity;
+      const savedArg = ormRepository.save.mock.calls[0][0] as BulkListingBatchOrmEntity;
       expect(savedArg.status).toBe('completed');
       expect(result.status).toBe('completed');
     });
 
-    it('should throw BulkOfferCreationBatchNotFoundException when row is missing', async () => {
+    it('should throw BulkListingBatchNotFoundException when row is missing', async () => {
       ormRepository.findOne.mockResolvedValue(null);
 
       await expect(repository.updateStatus('missing', 'running')).rejects.toBeInstanceOf(
-        BulkOfferCreationBatchNotFoundException,
+        BulkListingBatchNotFoundException,
       );
       expect(ormRepository.save).not.toHaveBeenCalled();
     });
@@ -253,7 +253,7 @@ describe('BulkOfferCreationBatchRepository', () => {
       const result = await repository.findById('batch-uuid');
 
       expect(result).toEqual(
-        new BulkOfferCreationBatch(
+        new BulkListingBatch(
           'batch-uuid',
           'conn-uuid',
           'user-1',

--- a/libs/core/src/listings/infrastructure/persistence/repositories/bulk-listing-batch.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/bulk-listing-batch.repository.ts
@@ -1,41 +1,41 @@
 /**
  * Bulk Offer Creation Batch Repository
  *
- * TypeORM implementation of `BulkOfferCreationBatchRepositoryPort`. Handles
+ * TypeORM implementation of `BulkListingBatchRepositoryPort`. Handles
  * all ORM ↔ domain mapping privately; callers receive domain entities only.
- * Throws `BulkOfferCreationBatchNotFoundException` on update paths when the
+ * Throws `BulkListingBatchNotFoundException` on update paths when the
  * row does not exist.
  *
  * @module libs/core/src/listings/infrastructure/persistence/repositories
- * @implements {BulkOfferCreationBatchRepositoryPort}
+ * @implements {BulkListingBatchRepositoryPort}
  */
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
-import { BulkOfferCreationBatch } from '../../../domain/entities/bulk-offer-creation-batch.entity';
-import { BulkOfferCreationBatchNotFoundException } from '../../../domain/exceptions/bulk-offer-creation-batch-not-found.exception';
-import type { BulkOfferCreationBatchRepositoryPort } from '../../../domain/ports/bulk-offer-creation-batch-repository.port';
+import { BulkListingBatch } from '../../../domain/entities/bulk-listing-batch.entity';
+import { BulkListingBatchNotFoundException } from '../../../domain/exceptions/bulk-listing-batch-not-found.exception';
+import type { BulkListingBatchRepositoryPort } from '../../../domain/ports/bulk-listing-batch-repository.port';
 import type {
   BulkBatchStatus,
-  CreateBulkOfferCreationBatchInput,
-} from '../../../domain/types/bulk-offer-creation-batch.types';
-import { BulkOfferCreationBatchOrmEntity } from '../entities/bulk-offer-creation-batch.orm-entity';
+  CreateBulkListingBatchInput,
+} from '../../../domain/types/bulk-listing-batch.types';
+import { BulkListingBatchOrmEntity } from '../entities/bulk-listing-batch.orm-entity';
 
 @Injectable()
-export class BulkOfferCreationBatchRepository implements BulkOfferCreationBatchRepositoryPort {
+export class BulkListingBatchRepository implements BulkListingBatchRepositoryPort {
   constructor(
-    @InjectRepository(BulkOfferCreationBatchOrmEntity)
-    private readonly repository: Repository<BulkOfferCreationBatchOrmEntity>,
+    @InjectRepository(BulkListingBatchOrmEntity)
+    private readonly repository: Repository<BulkListingBatchOrmEntity>,
   ) {}
 
-  async create(input: CreateBulkOfferCreationBatchInput): Promise<BulkOfferCreationBatch> {
+  async create(input: CreateBulkListingBatchInput): Promise<BulkListingBatch> {
     const entity = this.buildOrmEntity(input);
     const saved = await this.repository.save(entity);
     return this.toDomain(saved);
   }
 
-  async findById(id: string): Promise<BulkOfferCreationBatch | null> {
+  async findById(id: string): Promise<BulkListingBatch | null> {
     const entity = await this.repository.findOne({ where: { id } });
     return entity ? this.toDomain(entity) : null;
   }
@@ -43,38 +43,38 @@ export class BulkOfferCreationBatchRepository implements BulkOfferCreationBatchR
   async incrementCounters(
     id: string,
     deltas: { succeeded?: number; failed?: number },
-  ): Promise<BulkOfferCreationBatch> {
+  ): Promise<BulkListingBatch> {
     if (deltas.succeeded !== undefined && deltas.succeeded !== 0) {
       const result = await this.repository.increment({ id }, 'succeededCount', deltas.succeeded);
       if (result.affected === 0) {
-        throw new BulkOfferCreationBatchNotFoundException(id);
+        throw new BulkListingBatchNotFoundException(id);
       }
     }
     if (deltas.failed !== undefined && deltas.failed !== 0) {
       const result = await this.repository.increment({ id }, 'failedCount', deltas.failed);
       if (result.affected === 0) {
-        throw new BulkOfferCreationBatchNotFoundException(id);
+        throw new BulkListingBatchNotFoundException(id);
       }
     }
     const refreshed = await this.repository.findOne({ where: { id } });
     if (!refreshed) {
-      throw new BulkOfferCreationBatchNotFoundException(id);
+      throw new BulkListingBatchNotFoundException(id);
     }
     return this.toDomain(refreshed);
   }
 
-  async updateStatus(id: string, status: BulkBatchStatus): Promise<BulkOfferCreationBatch> {
+  async updateStatus(id: string, status: BulkBatchStatus): Promise<BulkListingBatch> {
     const entity = await this.repository.findOne({ where: { id } });
     if (!entity) {
-      throw new BulkOfferCreationBatchNotFoundException(id);
+      throw new BulkListingBatchNotFoundException(id);
     }
     entity.status = status;
     const saved = await this.repository.save(entity);
     return this.toDomain(saved);
   }
 
-  private buildOrmEntity(input: CreateBulkOfferCreationBatchInput): BulkOfferCreationBatchOrmEntity {
-    const entity = new BulkOfferCreationBatchOrmEntity();
+  private buildOrmEntity(input: CreateBulkListingBatchInput): BulkListingBatchOrmEntity {
+    const entity = new BulkListingBatchOrmEntity();
     entity.connectionId = input.connectionId;
     entity.initiatedBy = input.initiatedBy;
     entity.status = 'pending';
@@ -85,8 +85,8 @@ export class BulkOfferCreationBatchRepository implements BulkOfferCreationBatchR
     return entity;
   }
 
-  private toDomain(entity: BulkOfferCreationBatchOrmEntity): BulkOfferCreationBatch {
-    return new BulkOfferCreationBatch(
+  private toDomain(entity: BulkListingBatchOrmEntity): BulkListingBatch {
+    return new BulkListingBatch(
       entity.id,
       entity.connectionId,
       entity.initiatedBy,

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -21,19 +21,19 @@ import { CategoryResolutionService } from './application/services/category-resol
 import { OfferMappingRepository } from './infrastructure/persistence/repositories/offer-mapping.repository';
 import { OfferCreationRecordOrmEntity } from './infrastructure/persistence/entities/offer-creation-record.orm-entity';
 import { OfferCreationRecordRepository } from './infrastructure/persistence/repositories/offer-creation-record.repository';
-import { BulkOfferCreationBatchOrmEntity } from './infrastructure/persistence/entities/bulk-offer-creation-batch.orm-entity';
-import { BulkOfferCreationBatchRepository } from './infrastructure/persistence/repositories/bulk-offer-creation-batch.repository';
+import { BulkListingBatchOrmEntity } from './infrastructure/persistence/entities/bulk-listing-batch.orm-entity';
+import { BulkListingBatchRepository } from './infrastructure/persistence/repositories/bulk-listing-batch.repository';
 import { BulkBatchAdvancementOrmEntity } from './infrastructure/persistence/entities/bulk-batch-advancement.orm-entity';
 import { BulkBatchAdvancementRepository } from './infrastructure/persistence/repositories/bulk-batch-advancement.repository';
-import { BulkOfferCreationProgressService } from './application/services/bulk-offer-creation-progress.service';
+import { BulkListingProgressService } from './application/services/bulk-listing-progress.service';
 import { OfferBuilderService } from './application/services/offer-builder.service';
 import { OfferCreationExecutionService } from './application/services/offer-creation-execution.service';
 import { SellerPoliciesCacheOrmEntity } from './infrastructure/persistence/entities/seller-policies-cache.orm-entity';
 import { SellerPoliciesCacheRepository } from './infrastructure/persistence/repositories/seller-policies-cache.repository';
 import { SellerPoliciesService } from './application/services/seller-policies.service';
 import { OfferCreationEnqueueService } from './application/services/offer-creation-enqueue.service';
-import { BulkOfferCreationSubmitService } from './application/services/bulk-offer-creation-submit.service';
-import { BulkOfferCreationRetryService } from './application/services/bulk-offer-creation-retry.service';
+import { BulkListingSubmitService } from './application/services/bulk-listing-submit.service';
+import { BulkListingRetryService } from './application/services/bulk-listing-retry.service';
 import { OfferStatusPollService } from './application/services/offer-status-poll.service';
 import { OfferStatusSyncService } from './application/services/offer-status-sync.service';
 import { OfferStatusSnapshotOrmEntity } from './infrastructure/persistence/entities/offer-status-snapshot.orm-entity';
@@ -44,15 +44,15 @@ import {
   OFFER_MAPPINGS_SERVICE_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
-  BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
+  BULK_LISTING_BATCH_REPOSITORY_TOKEN,
   BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
-  BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
+  BULK_LISTING_PROGRESS_SERVICE_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
   OFFER_BUILDER_SERVICE_TOKEN,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
   OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
-  BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN,
-  BULK_OFFER_CREATION_RETRY_SERVICE_TOKEN,
+  BULK_LISTING_SUBMIT_SERVICE_TOKEN,
+  BULK_LISTING_RETRY_SERVICE_TOKEN,
   OFFER_STATUS_POLL_SERVICE_TOKEN,
   OFFER_STATUS_SYNC_SERVICE_TOKEN,
   OFFER_STATUS_SNAPSHOT_REPOSITORY_TOKEN,
@@ -67,15 +67,15 @@ export {
   OFFER_MAPPINGS_SERVICE_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
-  BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
+  BULK_LISTING_BATCH_REPOSITORY_TOKEN,
   BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
-  BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
+  BULK_LISTING_PROGRESS_SERVICE_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
   OFFER_BUILDER_SERVICE_TOKEN,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
   OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
-  BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN,
-  BULK_OFFER_CREATION_RETRY_SERVICE_TOKEN,
+  BULK_LISTING_SUBMIT_SERVICE_TOKEN,
+  BULK_LISTING_RETRY_SERVICE_TOKEN,
   OFFER_STATUS_POLL_SERVICE_TOKEN,
   OFFER_STATUS_SYNC_SERVICE_TOKEN,
   OFFER_STATUS_SNAPSHOT_REPOSITORY_TOKEN,
@@ -88,7 +88,7 @@ export {
     TypeOrmModule.forFeature([
       IdentifierMappingOrmEntity,
       OfferCreationRecordOrmEntity,
-      BulkOfferCreationBatchOrmEntity,
+      BulkListingBatchOrmEntity,
       BulkBatchAdvancementOrmEntity,
       SellerPoliciesCacheOrmEntity,
       OfferStatusSnapshotOrmEntity,
@@ -111,14 +111,14 @@ export {
     CategoryResolutionService,
     OfferMappingRepository,
     OfferCreationRecordRepository,
-    BulkOfferCreationBatchRepository,
+    BulkListingBatchRepository,
     BulkBatchAdvancementRepository,
-    BulkOfferCreationProgressService,
+    BulkListingProgressService,
     OfferBuilderService,
     OfferCreationExecutionService,
     OfferCreationEnqueueService,
-    BulkOfferCreationSubmitService,
-    BulkOfferCreationRetryService,
+    BulkListingSubmitService,
+    BulkListingRetryService,
     OfferStatusPollService,
     OfferStatusSyncService,
     OfferStatusSnapshotRepository,
@@ -145,16 +145,16 @@ export {
       useExisting: OfferCreationRecordRepository,
     },
     {
-      provide: BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
-      useExisting: BulkOfferCreationBatchRepository,
+      provide: BULK_LISTING_BATCH_REPOSITORY_TOKEN,
+      useExisting: BulkListingBatchRepository,
     },
     {
       provide: BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
       useExisting: BulkBatchAdvancementRepository,
     },
     {
-      provide: BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
-      useExisting: BulkOfferCreationProgressService,
+      provide: BULK_LISTING_PROGRESS_SERVICE_TOKEN,
+      useExisting: BulkListingProgressService,
     },
     {
       provide: CATEGORY_RESOLUTION_SERVICE_TOKEN,
@@ -173,12 +173,12 @@ export {
       useExisting: OfferCreationEnqueueService,
     },
     {
-      provide: BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN,
-      useExisting: BulkOfferCreationSubmitService,
+      provide: BULK_LISTING_SUBMIT_SERVICE_TOKEN,
+      useExisting: BulkListingSubmitService,
     },
     {
-      provide: BULK_OFFER_CREATION_RETRY_SERVICE_TOKEN,
-      useExisting: BulkOfferCreationRetryService,
+      provide: BULK_LISTING_RETRY_SERVICE_TOKEN,
+      useExisting: BulkListingRetryService,
     },
     {
       provide: OFFER_STATUS_POLL_SERVICE_TOKEN,
@@ -207,15 +207,15 @@ export {
     OFFER_MAPPINGS_SERVICE_TOKEN,
     OFFER_MAPPING_REPOSITORY_TOKEN,
     OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
-    BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
+    BULK_LISTING_BATCH_REPOSITORY_TOKEN,
     BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
-    BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
+    BULK_LISTING_PROGRESS_SERVICE_TOKEN,
     CATEGORY_RESOLUTION_SERVICE_TOKEN,
     OFFER_BUILDER_SERVICE_TOKEN,
     OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
     OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
-    BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN,
-    BULK_OFFER_CREATION_RETRY_SERVICE_TOKEN,
+    BULK_LISTING_SUBMIT_SERVICE_TOKEN,
+    BULK_LISTING_RETRY_SERVICE_TOKEN,
     OFFER_STATUS_POLL_SERVICE_TOKEN,
     OFFER_STATUS_SYNC_SERVICE_TOKEN,
     SELLER_POLICIES_SERVICE_TOKEN,

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -9,24 +9,24 @@ export const OFFER_MAPPING_SYNC_SERVICE_TOKEN = Symbol('OfferMappingSyncService'
 export const OFFER_MAPPINGS_SERVICE_TOKEN = Symbol('IOfferMappingsService');
 export const OFFER_MAPPING_REPOSITORY_TOKEN = Symbol('OfferMappingRepositoryPort');
 export const OFFER_CREATION_RECORD_REPOSITORY_TOKEN = Symbol('OfferCreationRecordRepositoryPort');
-export const BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN = Symbol(
-  'BulkOfferCreationBatchRepositoryPort',
+export const BULK_LISTING_BATCH_REPOSITORY_TOKEN = Symbol(
+  'BulkListingBatchRepositoryPort',
 );
 export const BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN = Symbol(
   'BulkBatchAdvancementRepositoryPort',
 );
-export const BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN = Symbol(
-  'IBulkOfferCreationProgressService',
+export const BULK_LISTING_PROGRESS_SERVICE_TOKEN = Symbol(
+  'IBulkListingProgressService',
 );
 export const CATEGORY_RESOLUTION_SERVICE_TOKEN = Symbol('ICategoryResolutionService');
 export const OFFER_BUILDER_SERVICE_TOKEN = Symbol('IOfferBuilderService');
 export const OFFER_CREATION_EXECUTION_SERVICE_TOKEN = Symbol('IOfferCreationExecutionService');
 export const OFFER_CREATION_ENQUEUE_SERVICE_TOKEN = Symbol('IOfferCreationEnqueueService');
-export const BULK_OFFER_CREATION_SUBMIT_SERVICE_TOKEN = Symbol(
-  'IBulkOfferCreationSubmitService',
+export const BULK_LISTING_SUBMIT_SERVICE_TOKEN = Symbol(
+  'IBulkListingSubmitService',
 );
-export const BULK_OFFER_CREATION_RETRY_SERVICE_TOKEN = Symbol(
-  'IBulkOfferCreationRetryService',
+export const BULK_LISTING_RETRY_SERVICE_TOKEN = Symbol(
+  'IBulkListingRetryService',
 );
 export const OFFER_STATUS_POLL_SERVICE_TOKEN = Symbol('IOfferStatusPollService');
 export const OFFER_STATUS_SYNC_SERVICE_TOKEN = Symbol('IOfferStatusSyncService');

--- a/libs/core/src/shipping/domain/exceptions/shipment-not-found.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/shipment-not-found.exception.ts
@@ -5,7 +5,7 @@
  * exist. Raised by `ShipmentRepositoryPort.update` when no row matches —
  * i.e. infrastructure `Repository.update(id, ...)` returns `affected === 0`.
  *
- * Mirrors `BulkOfferCreationBatchNotFoundException` shape.
+ * Mirrors `BulkListingBatchNotFoundException` shape.
  *
  * @module libs/core/src/shipping/domain/exceptions
  */

--- a/libs/core/src/shipping/domain/types/shipment-status.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment-status.types.ts
@@ -44,7 +44,7 @@ export type ShipmentStatus = (typeof ShipmentStatusValues)[number];
  * Named-constant map for the shipment lifecycle status. Lets call sites
  * reference status values by name (`SHIPMENT_STATUS.Delivered`) rather
  * than repeating bare string literals. Mirrors the `BULK_BATCH_STATUS`
- * shape in `bulk-offer-creation-batch.types.ts`.
+ * shape in `bulk-listing-batch.types.ts`.
  */
 export const SHIPMENT_STATUS = {
   Draft: 'draft',

--- a/libs/core/src/shipping/domain/types/shipment.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment.types.ts
@@ -2,7 +2,7 @@
  * Shipment Input Types
  *
  * Repository write contracts decoupled from the `Shipment` entity's
- * readonly shape. Mirrors the `CreateBulkOfferCreationBatchInput` /
+ * readonly shape. Mirrors the `CreateBulkListingBatchInput` /
  * `OfferCreationRecord` discipline — entity-shape changes (added fields,
  * derived behavior) don't silently affect repository callers.
  *

--- a/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
@@ -122,8 +122,8 @@ export interface MarketplaceOfferCreatePayloadV2 {
   /** Pre-created OfferCreationRecord id — always set for V2 (bulk pre-creates). */
   offerCreationRecordId: string;
   /**
-   * Parent BulkOfferCreationBatch id. The worker handler (#737) uses this
-   * to call `BulkOfferCreationBatchRepositoryPort.incrementCounters` after
+   * Parent BulkListingBatch id. The worker handler (#737) uses this
+   * to call `BulkListingBatchRepositoryPort.incrementCounters` after
    * terminal status, and the bulk service uses it as part of the
    * idempotency key (`bulk:{batchId}:variant:{variantId}`).
    */


### PR DESCRIPTION
**Part of #1040** (ADR-024 §4) — the rename layer. **Does not close #1040** on its own; see "Remaining" below.

## What & why
ADR-024 §4 lifts the destination-neutral bulk-orchestration scaffolding out of the offer pipeline so `marketplace.offer.create` and the future `shop.product.publish` share it. The pipeline is already behaviourally neutral — this PR does the **pure rename** half (the largest, mechanical part), landed on its own so the structural seam work gets a focused follow-up review.

## Change (behaviour-identical)
- `BulkOfferCreation*` → `BulkListing*` (classes, interfaces, types), `BULK_OFFER_CREATION_*` tokens → `BULK_LISTING_*`, filenames + import paths. 22 files moved, 52 updated.
- **Preserved (no behaviour change):**
  - DB table names (`bulk_offer_creation_batches`, `bulk_batch_advancements`) — `@Entity('…')` keeps the renamed classes mapped to existing tables; **no migration**.
  - HTTP routes (`listings/bulk-create`, `:batchId`, `:batchId/retry-failed`) + request/response **DTO field names** — wire contract byte-identical.
  - The historical `1797…` migration class (excluded from the rename — renaming it would orphan its `migrations` row).
  - Offer-specific symbols (`OfferBuilderService`, `OfferCreationExecutionService`, `OfferCreationRecord`, the Allegro payload + worker handler) — intentionally untouched.

## Testing
Pure rename, so the existing suite is the oracle: `type-check` (repo-wide) ✓, full `pnpm test` ✓ (core 1078 / api 451 / worker 156 / all packages), **`apps/web` ✓ (1438)**, lint + `check:invariants` ✓.

## Remaining for #1040 (follow-up PR — keeps the issue open)
This rename does **not** yet satisfy the AC "no offer-specific names in the extracted orchestration": the neutrally-named services still call `OfferCreation*` internally. The follow-up adds:
1. **`operation` discriminator** on the batch (`'offer.create' | 'shop.publish'`, NOT NULL default — one additive migration).
2. **`BatchChildRepositoryPort`** (neutral child read/reset) + **`ListingChildEnqueuerPort`** + `OfferListingChildEnqueuer` (wraps `OfferCreationEnqueueService` + the V2-payload rebuild), resolved by `operation` — so submit + retry stop naming `Offer`.
3. Migrate the offer path onto the seams (no behaviour change) + full `pnpm test:integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)