### PR TITLE
feat(listings): provenance-aware category placement chain (#1037)

### DIFF
--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -682,7 +682,8 @@ describe('ListingsController', () => {
     it('returns method=auto_detect when the barcode resolves', async () => {
       integrationsService.getCapabilityAdapter.mockResolvedValue(opaqueAdapter);
       categoryResolution.resolveCategory.mockResolvedValue({
-        allegroCategoryId: '257933',
+        destinationCategoryId: '257933',
+        provenance: 'borrows',
         method: 'auto_detect',
       });
 
@@ -705,7 +706,8 @@ describe('ListingsController', () => {
     it('returns method=category_mapping when sourceCategoryIds resolve', async () => {
       integrationsService.getCapabilityAdapter.mockResolvedValue(opaqueAdapter);
       categoryResolution.resolveCategory.mockResolvedValue({
-        allegroCategoryId: '12345',
+        destinationCategoryId: '12345',
+        provenance: null,
         method: 'category_mapping',
       });
 
@@ -728,7 +730,8 @@ describe('ListingsController', () => {
     it('returns method=manual with null allegroCategoryId when nothing resolves', async () => {
       integrationsService.getCapabilityAdapter.mockResolvedValue(opaqueAdapter);
       categoryResolution.resolveCategory.mockResolvedValue({
-        allegroCategoryId: null,
+        destinationCategoryId: null,
+        provenance: null,
         method: 'manual',
       });
 

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -493,7 +493,9 @@ export class ListingsController {
     });
 
     return {
-      allegroCategoryId: result.allegroCategoryId,
+      // Wire field stays `allegroCategoryId` (FE contract); neutralising it +
+      // surfacing `provenance` is #1044's API/FE-surfaces job.
+      allegroCategoryId: result.destinationCategoryId,
       method: result.method,
     };
   }

--- a/docs/plans/implementation-plan-1037-provenance-aware-placement-chain.md
+++ b/docs/plans/implementation-plan-1037-provenance-aware-placement-chain.md
@@ -1,0 +1,95 @@
+# Implementation Plan — #1037 Provenance-aware placement chain
+
+**Issue:** #1037 · **Epic:** #1005 · **ADR-023 §1** · **Branch:** `1037-provenance-aware-placement-chain`
+
+---
+
+## Phase 1 — Understand
+
+**Goal.** Generalise `CategoryResolutionService` from a 2-step Allegro-named chain into a capability-gated, **provenance-aware** chain returning a neutral `{ destinationCategoryId, provenance, method }`, with the ADR-023 §1 ordering: **provision → barcode → per-source-category mapping → manual**.
+
+**Layer.** CORE (`listings` application service) + a small additive method on the `mappings` context's service interface. Backend only.
+
+**AC (from the issue).**
+- Allegro (owns) + a borrows-provenance destination both resolve via the **same** chain.
+- The provision step is a **no-op** when the destination lacks `CategoryProvisioner`.
+
+**Non-goals.**
+- `CategoryProvisioner` capability/guard/command — that's **#1041** (ADR-024). #1037 leaves a capability-gated no-op seam.
+- Provenance-keyed cross-connection mapping reuse (ERLI resolving Allegro's *rows*) — that's **#1045**. #1037 makes the chain provenance-*aware*; #1045 makes the mapping *lookup* provenance-keyed.
+- Attribute projection — **#1038/#1039**.
+- Neutralising the HTTP wire field (`allegroCategoryId`) / surfacing `provenance` to the FE — deferred to **#1044** (API + FE surfaces). This PR keeps the wire contract byte-identical.
+- The separate `EanMatchResult.allegroCategoryId` batch-match type + its allegro util + FE bulk types + mappings DTOs — unrelated to `CategoryResolutionResult`; untouched.
+
+---
+
+## Phase 2 — Research (what already ships)
+
+- `CategoryResolutionService` (`libs/core/src/listings/application/services/category-resolution.service.ts`): 2-step chain (barcode → mapping → manual), returns `{ allegroCategoryId, method }`. Resolves the `OfferManager` adapter via `IIntegrationsService.getCapabilityAdapter`, gates barcode on `isCategoryBarcodeMatcher`, calls `IMappingConfigService.resolveDestinationCategory(connectionId, sourceCategoryId)` (returns `string | null` — **no provenance**).
+- Types (`category-resolution.types.ts`): `CategoryResolutionMethodValues = ['auto_detect','category_mapping','manual']`; `CategoryResolutionResult.allegroCategoryId`. Exported via the `@openlinker/core/listings` barrel.
+- **Consumers of `CategoryResolutionResult` (the only ones):** `offer-builder.service.ts:158` (`return result.allegroCategoryId`) and the HTTP boundary `listings.controller.ts:496` → `ResolveCategoryResponseDto.allegroCategoryId` (`resolve-category.dto.ts`). The DTO imports only `CategoryResolutionMethodValues`/`CategoryResolutionMethod`, not the result interface.
+- Capability guards present: `isCategoryBrowser` (`category-browser.capability.ts`), `isCategoryParametersReader`, `isCategoryBarcodeMatcher`, `isEanCategoryMatcher`. **`CategoryProvisioner` is absent** (no file; not in `CoreCapabilityValues`).
+- Mappings context (post-#1036): `CategoryMapping.destinationTaxonomyProvenance: string`; `CategoryMappingRepositoryPort.findBySourceCategory(destinationConnectionId, sourceCategoryId): Promise<CategoryMapping | null>` (carries provenance); `IMappingConfigService.resolveDestinationCategory` flattens it to the id.
+
+---
+
+## Phase 3 — Design
+
+### D1 — `provenance` = capability-derived **relationship** union (ADR-literal)
+
+`CategoryProvenance = 'owns' | 'borrows' | 'open'`, derived from the **destination adapter's capabilities** (never `platformType`):
+- **`owns`** — adapter has `CategoryBrowser` (its own category tree): Allegro.
+- **`open`** — adapter has `CategoryProvisioner`: shops. *(Not reachable in #1037 — the guard lands in #1041; the seam yields `open` then.)*
+- **`borrows`** — neither (accepts ids, ships no tree): ERLI.
+
+This is what attribute projection (#1039) needs: `borrows` → emit source ids verbatim; `owns` → resolve against the destination's own dictionary. The owner-id string (`'allegro'`) is already carried by the mapping rows + the ids themselves; the *relationship* is the missing axis, so that's what the result adds.
+
+### D2 — derive provenance on the barcode path; preserve laziness + resilience (zero behaviour change)
+
+*Corrected during implementation against the existing specs* — two encode behaviour I must keep: (1) `getCapabilityAdapter` is **not** called when no `barcode` is supplied (laziness + perf); (2) an adapter-resolution failure is **caught** and falls through to mapping (resilience). So the chain must **not** resolve the adapter eagerly at the top.
+
+Instead: `provenance: CategoryProvenance | null`, derived from the destination adapter **on the barcode path** — i.e. wherever the adapter is already resolved (inside the existing `tryAutoDetect` try/catch). When the adapter resolves successfully, capture it and set `provenance`:
+- **`owns`** — `isCategoryBrowser(adapter) || isCategoryParametersReader(adapter)` (ADR-023: owns = "own category tree + per-category parameter schema").
+- **`open`** — `CategoryProvisioner` present (deferred to #1041 — unreachable in #1037).
+- **`borrows`** — otherwise.
+
+When no `barcode` is supplied (no adapter resolved), or adapter resolution throws (graceful fallback), or the result is manual without an adapter → `provenance: null`.
+
+**Why this still meets the AC:** the real offer-creation flow (`offer-builder.service.ts`) always calls `resolveCategory` **with** a barcode, so both `owns` (Allegro) and `borrows` (ERLI-class) get a populated `provenance`. The mapping-only path (wizard, no barcode) reports `provenance: null` until **#1045** makes the mapping *lookup* provenance-bearing — that's exactly #1045's scope ("Allegro-provenance mappings resolve for ERLI"). The chain is shared + capability-gated for both provenances now; population on the mapping-only path is #1045. **No new adapter resolution, same resilience, same "manual is 200" contract → existing service/controller specs stay green unmodified (bar the field rename).**
+
+### D3 — keep the HTTP/FE wire contract byte-identical (backend-only PR)
+
+`ResolveCategoryResponseDto` keeps `allegroCategoryId` + the existing `method` values. The controller maps the neutral result at the boundary (`allegroCategoryId: result.destinationCategoryId`). `provenance` is **not** surfaced yet (no consumer). Wire-neutralisation + provenance exposure is #1044's job. → no FE churn, no contract break.
+
+### D4 — `method`: add `'provision'`, keep the rest
+
+`CategoryResolutionMethodValues = ['provision','auto_detect','category_mapping','manual']`. `auto_detect`/`category_mapping` are already neutral step descriptors (not Allegro-named) and are on the wire — keep them. Add `'provision'` for the new step.
+
+### D5 — provision step = capability-gated no-op seam
+
+A private `tryProvision(adapter)` that returns `null` today, with a header comment marking it the **#1041** wiring point (`isCategoryProvisioner` + `provisionCategory`). The chain calls it first; it always falls through now. AC "no-op when the destination lacks CategoryProvisioner" holds trivially (nothing implements it yet) and is asserted by a unit test.
+
+### D6 — (dropped) no `mappings`-context change
+
+*Resolved by the tech-review:* with D2 deriving `provenance` from the destination adapter's capabilities (not the mapping row), there is **no consumer** in #1037 for a provenance-returning mapping lookup. The mapping step keeps calling the existing `IMappingConfigService.resolveDestinationCategory` (id only). The provenance-keyed mapping lookup is **#1045's** job. #1037 stays a pure `listings`-context change — no `mappings` edit.
+
+---
+
+## Phase 4 — Step-by-step
+
+1. **`category-resolution.types.ts`** — add `CategoryProvenanceValues = ['owns','borrows','open'] as const` + `CategoryProvenance`; add `'provision'` to `CategoryResolutionMethodValues`; rename `CategoryResolutionResult.allegroCategoryId` → `destinationCategoryId`; add `provenance: CategoryProvenance | null`. Update the file header. AC: type-check; barrel re-exports cleanly.
+2. **`category-resolution.service.ts`** — neutralise: chain provision (no-op seam) → barcode → mapping → manual; derive `provenance` on the barcode path from the resolved adapter (`isCategoryBrowser(a) || isCategoryParametersReader(a)` → `owns`, else `borrows`; `open` deferred to #1041); `null` when no adapter resolved (no barcode / fallback / manual). Return `{ destinationCategoryId, provenance, method }`. Neutral logging + header (drop "Allegro"/"3-step"). Preserve laziness (no adapter call without barcode) + resilience (catch adapter failure → mapping). AC: existing spec semantics hold + new provenance/provision assertions.
+3. **`offer-builder.service.ts:158`** — `result.allegroCategoryId` → `result.destinationCategoryId`. AC: offer-builder spec green.
+4. **`listings.controller.ts:496`** — `allegroCategoryId: result.destinationCategoryId` (wire field + `method` unchanged; `provenance` not surfaced). AC: controller spec green; response shape identical.
+5. **Tests** — update both spec files (`category-resolution.service.spec.ts` + `__tests__/category-resolution.service.spec.ts`; not identical — keep both, field-rename through) for `destinationCategoryId` + add `provenance` to expectations (`null` on the existing barcode-mock paths since the mock adapters lack `CategoryBrowser`/`CategoryParametersReader` → wait: barcode-resolved mock has no browser → `borrows`). Add new cases: provenance `owns` when adapter has `CategoryBrowser`/`CategoryParametersReader`, `borrows` when only `matchCategoryByBarcode`, `null` on no-barcode + manual paths, provision no-ops. Update `offer-builder` + `listings.controller` specs for the renamed field.
+7. **Quality gate**: `pnpm lint && type-check && test`; full `pnpm test:integration` for the listings slice (`listings-create-offer`, resolve-category routes); `migration:show` (expect none — no schema change).
+
+---
+
+## Phase 5 — Validate / risks / open questions
+
+- **Risk: barrel contract change on `CategoryResolutionResult`.** Contained — only core (offer-builder) + the DTO (method-only import) consume it; both updated in-PR. No external/plugin consumer.
+- **Risk: behaviour drift on the resolve-category route.** None — D2 preserves laziness + resilience; no new adapter resolution on any path. The existing controller/service specs are the oracle (only the renamed field changes).
+- **No migration** — pure code generalisation; the #1036 schema already carries provenance.
+- **Q1 — RESOLVED (tech-review):** no `IMappingConfigService` change in #1037 (D6 dropped); provenance comes from the adapter. Provenance-keyed mapping lookup → #1045.
+- **Q2 — RESOLVED:** `provenance` is the relationship union `owns/borrows/open` (D1) — ADR-literal, what attribute projection consumes.

--- a/libs/core/src/listings/application/interfaces/category-resolution.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/category-resolution.service.interface.ts
@@ -1,8 +1,9 @@
 /**
  * Category Resolution Service Interface
  *
- * Contract for resolving the marketplace category for an offer using a 3-step
- * fallback chain: auto-detect by barcode → category mapping → manual.
+ * Contract for the provenance-aware destination-category placement chain
+ * (ADR-023 §1), each step capability-gated:
+ * provision → barcode auto-detect → per-source-category mapping → manual.
  *
  * @module libs/core/src/listings/application/interfaces
  */
@@ -18,12 +19,16 @@ import type {
 
 export interface ICategoryResolutionService {
   /**
-   * Resolve the marketplace category for an offer.
+   * Resolve the destination category for a listing.
    *
-   * Fallback chain:
-   * 1. Auto-detect via GTIN/EAN — query marketplace for matching categories
-   * 2. Category mapping — look up source category in configured mappings
-   * 3. Manual — return null for merchant to pick
+   * Capability-gated chain (ADR-023 §1):
+   * 1. Provision — mirror/create on the destination (`CategoryProvisioner`, #1041)
+   * 2. Auto-detect via GTIN/EAN — query the destination catalog (`CategoryBarcodeMatcher`)
+   * 3. Category mapping — look up source category in configured mappings
+   * 4. Manual — return null for the operator to pick
+   *
+   * Returns `{ destinationCategoryId, provenance, method }`; `provenance`
+   * (owns/borrows/open) describes the destination taxonomy relationship.
    */
   resolveCategory(input: CategoryResolutionInput): Promise<CategoryResolutionResult>;
 

--- a/libs/core/src/listings/application/services/__tests__/category-resolution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/category-resolution.service.spec.ts
@@ -51,7 +51,11 @@ describe('CategoryResolutionService', () => {
       sourceCategoryIds: ['ps-cat-1'],
     });
 
-    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-123', method: 'auto_detect' });
+    expect(result).toEqual({
+      destinationCategoryId: 'allegro-cat-123',
+      provenance: 'borrows',
+      method: 'auto_detect',
+    });
     expect(marketplace.matchCategoryByBarcode).toHaveBeenCalledWith('5901234123457');
     expect(mappingConfig.resolveDestinationCategory).not.toHaveBeenCalled();
   });
@@ -66,7 +70,11 @@ describe('CategoryResolutionService', () => {
       sourceCategoryIds: ['ps-cat-1'],
     });
 
-    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-456', method: 'category_mapping' });
+    expect(result).toEqual({
+      destinationCategoryId: 'allegro-cat-456',
+      provenance: 'borrows',
+      method: 'category_mapping',
+    });
     expect(mappingConfig.resolveDestinationCategory).toHaveBeenCalledWith('conn-1', 'ps-cat-1');
   });
 
@@ -80,7 +88,11 @@ describe('CategoryResolutionService', () => {
       sourceCategoryIds: ['ps-cat-1'],
     });
 
-    expect(result).toEqual({ allegroCategoryId: null, method: 'manual' });
+    expect(result).toEqual({
+      destinationCategoryId: null,
+      provenance: 'borrows',
+      method: 'manual',
+    });
   });
 
   it('should skip auto-detect when no barcode is provided', async () => {
@@ -91,7 +103,11 @@ describe('CategoryResolutionService', () => {
       sourceCategoryIds: ['ps-cat-1'],
     });
 
-    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-789', method: 'category_mapping' });
+    expect(result).toEqual({
+      destinationCategoryId: 'allegro-cat-789',
+      provenance: null,
+      method: 'category_mapping',
+    });
     expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
   });
 
@@ -105,7 +121,11 @@ describe('CategoryResolutionService', () => {
       sourceCategoryIds: ['ps-cat-shallow', 'ps-cat-deep'],
     });
 
-    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-deep', method: 'category_mapping' });
+    expect(result).toEqual({
+      destinationCategoryId: 'allegro-cat-deep',
+      provenance: null,
+      method: 'category_mapping',
+    });
     expect(mappingConfig.resolveDestinationCategory).toHaveBeenCalledTimes(2);
     expect(mappingConfig.resolveDestinationCategory).toHaveBeenCalledWith('conn-1', 'ps-cat-shallow');
     expect(mappingConfig.resolveDestinationCategory).toHaveBeenCalledWith('conn-1', 'ps-cat-deep');
@@ -116,7 +136,11 @@ describe('CategoryResolutionService', () => {
       connectionId: 'conn-1',
     });
 
-    expect(result).toEqual({ allegroCategoryId: null, method: 'manual' });
+    expect(result).toEqual({
+      destinationCategoryId: null,
+      provenance: null,
+      method: 'manual',
+    });
   });
 
   it('should handle auto-detect error gracefully and fall back to mapping', async () => {
@@ -130,7 +154,8 @@ describe('CategoryResolutionService', () => {
     });
 
     expect(result).toEqual({
-      allegroCategoryId: 'allegro-cat-fallback',
+      destinationCategoryId: 'allegro-cat-fallback',
+      provenance: null,
       method: 'category_mapping',
     });
   });
@@ -146,6 +171,10 @@ describe('CategoryResolutionService', () => {
       sourceCategoryIds: ['ps-cat-1'],
     });
 
-    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-mapped', method: 'category_mapping' });
+    expect(result).toEqual({
+      destinationCategoryId: 'allegro-cat-mapped',
+      provenance: 'borrows',
+      method: 'category_mapping',
+    });
   });
 });

--- a/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
@@ -72,7 +72,11 @@ describe('OfferBuilderService', () => {
     categoryResolution = {
       resolveCategory: jest
         .fn()
-        .mockResolvedValue({ allegroCategoryId: 'allegro-cat-999', method: 'auto_detect' }),
+        .mockResolvedValue({
+          destinationCategoryId: 'allegro-cat-999',
+          provenance: 'owns',
+          method: 'auto_detect',
+        }),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -185,7 +189,8 @@ describe('OfferBuilderService', () => {
 
     it('throws OfferBuilderValidationException when resolution returns null', async () => {
       categoryResolution.resolveCategory.mockResolvedValue({
-        allegroCategoryId: null,
+        destinationCategoryId: null,
+        provenance: null,
         method: 'manual',
       });
 

--- a/libs/core/src/listings/application/services/category-resolution.service.spec.ts
+++ b/libs/core/src/listings/application/services/category-resolution.service.spec.ts
@@ -1,10 +1,12 @@
 /**
  * Category Resolution Service — unit tests
  *
- * Covers the 3-step single-resolve chain and the #795 batch path
- * (`resolveCategoriesBatch`): delegation to the `EanCategoryMatcher`
- * sub-capability when supported, and the `AdapterCapabilityNotSupportedException`
- * branch when the resolved adapter cannot batch-resolve EANs.
+ * Covers the provenance-aware single-resolve chain (provision → barcode →
+ * mapping → manual), provenance derivation from destination capabilities, and
+ * the #795 batch path (`resolveCategoriesBatch`): delegation to the
+ * `EanCategoryMatcher` sub-capability when supported, and the
+ * `AdapterCapabilityNotSupportedException` branch when the resolved adapter
+ * cannot batch-resolve EANs.
  *
  * @module libs/core/src/listings/application/services
  */
@@ -35,7 +37,8 @@ describe('CategoryResolutionService', () => {
   });
 
   describe('resolveCategory', () => {
-    it('should resolve via auto_detect when the adapter matches the barcode', async () => {
+    it('should resolve via auto_detect when the adapter matches the barcode (borrows provenance)', async () => {
+      // Adapter matches barcodes but ships no own category tree → borrows.
       integrationsService.getCapabilityAdapter.mockResolvedValue({
         updateOfferQuantity: jest.fn(),
         matchCategoryByBarcode: jest.fn().mockResolvedValue('allegro-cat-1'),
@@ -43,10 +46,42 @@ describe('CategoryResolutionService', () => {
 
       const result = await service.resolveCategory({ connectionId: CONNECTION_ID, barcode: '590' });
 
-      expect(result).toEqual({ allegroCategoryId: 'allegro-cat-1', method: 'auto_detect' });
+      expect(result).toEqual({
+        destinationCategoryId: 'allegro-cat-1',
+        provenance: 'borrows',
+        method: 'auto_detect',
+      });
     });
 
-    it('should fall back to category_mapping when auto_detect misses', async () => {
+    it('should report owns provenance when the adapter browses its own category tree', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        matchCategoryByBarcode: jest.fn().mockResolvedValue('allegro-cat-1'),
+        fetchCategories: jest.fn(),
+      });
+
+      const result = await service.resolveCategory({ connectionId: CONNECTION_ID, barcode: '590' });
+
+      expect(result).toEqual({
+        destinationCategoryId: 'allegro-cat-1',
+        provenance: 'owns',
+        method: 'auto_detect',
+      });
+    });
+
+    it('should report owns provenance when the adapter exposes per-category parameters', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        matchCategoryByBarcode: jest.fn().mockResolvedValue('allegro-cat-1'),
+        fetchCategoryParameters: jest.fn(),
+      });
+
+      const result = await service.resolveCategory({ connectionId: CONNECTION_ID, barcode: '590' });
+
+      expect(result.provenance).toBe('owns');
+    });
+
+    it('should fall back to category_mapping when auto_detect misses (carrying barcode-path provenance)', async () => {
       integrationsService.getCapabilityAdapter.mockResolvedValue({
         updateOfferQuantity: jest.fn(),
         matchCategoryByBarcode: jest.fn().mockResolvedValue(null),
@@ -59,7 +94,28 @@ describe('CategoryResolutionService', () => {
         sourceCategoryIds: ['src-1'],
       });
 
-      expect(result).toEqual({ allegroCategoryId: 'allegro-cat-mapped', method: 'category_mapping' });
+      expect(result).toEqual({
+        destinationCategoryId: 'allegro-cat-mapped',
+        provenance: 'borrows',
+        method: 'category_mapping',
+      });
+    });
+
+    it('should leave provenance null on the mapping path when no barcode is supplied', async () => {
+      mappingConfig.resolveDestinationCategory.mockResolvedValue('allegro-cat-mapped');
+
+      const result = await service.resolveCategory({
+        connectionId: CONNECTION_ID,
+        sourceCategoryIds: ['src-1'],
+      });
+
+      expect(result).toEqual({
+        destinationCategoryId: 'allegro-cat-mapped',
+        provenance: null,
+        method: 'category_mapping',
+      });
+      // Laziness preserved — no adapter resolution without a barcode.
+      expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
     });
 
     it('should return manual with null id when nothing resolves', async () => {
@@ -70,7 +126,25 @@ describe('CategoryResolutionService', () => {
 
       const result = await service.resolveCategory({ connectionId: CONNECTION_ID, barcode: '590' });
 
-      expect(result).toEqual({ allegroCategoryId: null, method: 'manual' });
+      expect(result).toEqual({
+        destinationCategoryId: null,
+        provenance: 'borrows',
+        method: 'manual',
+      });
+    });
+
+    it('should treat the provision step as a no-op until CategoryProvisioner ships (#1041)', async () => {
+      // Even a fully-capable adapter never yields method=provision today.
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        matchCategoryByBarcode: jest.fn().mockResolvedValue('allegro-cat-1'),
+        fetchCategories: jest.fn(),
+      });
+
+      const result = await service.resolveCategory({ connectionId: CONNECTION_ID, barcode: '590' });
+
+      expect(result.method).toBe('auto_detect');
+      expect(result.method).not.toBe('provision');
     });
   });
 

--- a/libs/core/src/listings/application/services/category-resolution.service.ts
+++ b/libs/core/src/listings/application/services/category-resolution.service.ts
@@ -1,10 +1,17 @@
 /**
  * Category Resolution Service
  *
- * Resolves the marketplace category for an offer using a 3-step fallback chain:
- * 1. Auto-detect via GTIN/EAN barcode (marketplace catalog lookup)
- * 2. Category mapping fallback (configured source → marketplace mappings)
- * 3. Manual pick (returns null for the merchant to choose)
+ * Resolves the destination category for a listing via the provenance-aware
+ * placement chain (ADR-023 §1), each step gated on a declared capability:
+ * 1. Provision — mirror/create on the destination (gated on `CategoryProvisioner`,
+ *    delivered by #1041; a no-op seam until then)
+ * 2. Barcode — GTIN/EAN catalog auto-detect (`CategoryBarcodeMatcher`)
+ * 3. Mapping — configured per-source-category → destination mapping
+ * 4. Manual — returns null for the operator to choose
+ *
+ * Returns a neutral `{ destinationCategoryId, provenance, method }`; `provenance`
+ * (owns/borrows/open) is derived from the destination adapter's capabilities,
+ * never its `platformType`.
  *
  * @module libs/core/src/listings/application/services
  * @implements {ICategoryResolutionService}
@@ -19,6 +26,8 @@ import type {
 } from '@openlinker/core/listings';
 import {
   isCategoryBarcodeMatcher,
+  isCategoryBrowser,
+  isCategoryParametersReader,
   isEanCategoryMatcher,
   AdapterCapabilityNotSupportedException,
 } from '@openlinker/core/listings';
@@ -26,6 +35,7 @@ import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/co
 import { IMappingConfigService, MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
 import type { ICategoryResolutionService } from '../interfaces/category-resolution.service.interface';
 import type {
+  CategoryProvenance,
   CategoryResolutionInput,
   CategoryResolutionResult,
 } from '../types/category-resolution.types';
@@ -44,31 +54,51 @@ export class CategoryResolutionService implements ICategoryResolutionService {
   async resolveCategory(input: CategoryResolutionInput): Promise<CategoryResolutionResult> {
     const { connectionId, barcode, sourceCategoryIds } = input;
 
-    // Step 1: Auto-detect via barcode
+    // `provenance` is populated once the destination adapter is resolved (the
+    // barcode step). Mapping-only / manual paths leave it null until #1045
+    // makes the mapping lookup provenance-bearing.
+    let provenance: CategoryProvenance | null = null;
+
+    // Step 1: Provision (open provenance). No-op seam — the `CategoryProvisioner`
+    // capability is delivered by #1041; until then this always falls through.
+    const provisioned = await this.tryProvision();
+    if (provisioned) {
+      this.logger.debug(
+        `Category resolved via provision (connection=${connectionId}, categoryId=${provisioned})`
+      );
+      return { destinationCategoryId: provisioned, provenance: 'open', method: 'provision' };
+    }
+
+    // Step 2: Auto-detect via barcode
     if (barcode) {
       const autoDetected = await this.tryAutoDetect(connectionId, barcode);
-      if (autoDetected) {
+      provenance = autoDetected.provenance;
+      if (autoDetected.categoryId) {
         this.logger.debug(
-          `Category resolved via auto_detect (connection=${connectionId}, barcode=${barcode}, categoryId=${autoDetected})`
+          `Category resolved via auto_detect (connection=${connectionId}, barcode=${barcode}, categoryId=${autoDetected.categoryId})`
         );
-        return { allegroCategoryId: autoDetected, method: 'auto_detect' };
+        return {
+          destinationCategoryId: autoDetected.categoryId,
+          provenance,
+          method: 'auto_detect',
+        };
       }
     }
 
-    // Step 2: Category mapping fallback
+    // Step 3: Category mapping fallback
     if (sourceCategoryIds && sourceCategoryIds.length > 0) {
       const mapped = await this.tryCategoryMapping(connectionId, sourceCategoryIds);
       if (mapped) {
         this.logger.debug(
           `Category resolved via category_mapping (connection=${connectionId}, categoryId=${mapped})`
         );
-        return { allegroCategoryId: mapped, method: 'category_mapping' };
+        return { destinationCategoryId: mapped, provenance, method: 'category_mapping' };
       }
     }
 
-    // Step 3: Manual pick
+    // Step 4: Manual pick
     this.logger.debug(`Category unresolved, manual pick required (connection=${connectionId})`);
-    return { allegroCategoryId: null, method: 'manual' };
+    return { destinationCategoryId: null, provenance, method: 'manual' };
   }
 
   async resolveCategoriesBatch(
@@ -91,25 +121,66 @@ export class CategoryResolutionService implements ICategoryResolutionService {
     return adapter.resolveCategoriesForBatchByEan(input);
   }
 
-  private async tryAutoDetect(connectionId: string, barcode: string): Promise<string | null> {
+  /**
+   * Provision step (ADR-023 §1, step 1) — mirror/create the source category on
+   * the destination. Gated on the `CategoryProvisioner` capability (ADR-024),
+   * delivered by #1041; a no-op until then, so the chain always falls through
+   * to the barcode step. #1041 resolves the destination adapter, narrows via
+   * `isCategoryProvisioner`, calls `provisionCategory(...)`, and returns the
+   * provisioned id (provenance `open`).
+   */
+  private tryProvision(): Promise<string | null> {
+    // No-op seam: returns a resolved Promise so the async contract #1041 fills
+    // is already in place at the call site (non-`async` avoids an empty-await lint).
+    return Promise.resolve(null);
+  }
+
+  /**
+   * Barcode step — resolve the destination adapter (capturing its provenance)
+   * and, when it supports barcode matching, auto-detect the category.
+   *
+   * Returns the matched category id (or null) alongside the destination's
+   * taxonomy provenance. On adapter-resolution failure the step degrades
+   * gracefully (null id, null provenance) so the chain can still fall through
+   * to mapping.
+   */
+  private async tryAutoDetect(
+    connectionId: string,
+    barcode: string
+  ): Promise<{ categoryId: string | null; provenance: CategoryProvenance | null }> {
     try {
       const marketplace = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
         connectionId,
         'OfferManager'
       );
+      const provenance = this.deriveProvenance(marketplace);
       if (!isCategoryBarcodeMatcher(marketplace)) {
         this.logger.debug(
-          `Marketplace adapter does not support matchCategoryByBarcode (connection=${connectionId})`
+          `Destination adapter does not support matchCategoryByBarcode (connection=${connectionId})`
         );
-        return null;
+        return { categoryId: null, provenance };
       }
-      return await marketplace.matchCategoryByBarcode(barcode);
+      return { categoryId: await marketplace.matchCategoryByBarcode(barcode), provenance };
     } catch (error) {
       this.logger.warn(
         `Auto-detect category failed (connection=${connectionId}): ${(error as Error).message}`
       );
-      return null;
+      return { categoryId: null, provenance: null };
     }
+  }
+
+  /**
+   * Derive how the destination relates to the taxonomy it resolves against,
+   * from its declared capabilities (never `platformType`). A destination that
+   * browses its own category tree / exposes per-category parameters `owns` the
+   * taxonomy (Allegro); one that does neither `borrows` it (ERLI). `open`
+   * (shop provisioning) is reachable once #1041 adds `CategoryProvisioner`.
+   */
+  private deriveProvenance(adapter: OfferManagerPort): CategoryProvenance {
+    if (isCategoryBrowser(adapter) || isCategoryParametersReader(adapter)) {
+      return 'owns';
+    }
+    return 'borrows';
   }
 
   private async tryCategoryMapping(

--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -155,7 +155,7 @@ export class OfferBuilderService implements IOfferBuilderService {
       connectionId: input.connectionId,
       barcode,
     });
-    return result.allegroCategoryId;
+    return result.destinationCategoryId;
   }
 
   private resolvePrice(

--- a/libs/core/src/listings/application/types/category-resolution.types.ts
+++ b/libs/core/src/listings/application/types/category-resolution.types.ts
@@ -1,39 +1,73 @@
 /**
  * Category Resolution Types
  *
- * Types for Allegro category resolution during offer creation.
- * The resolution service uses a 3-step fallback chain:
- * auto-detect by barcode → category mapping → manual.
+ * Types for the provenance-aware destination-category placement chain
+ * (ADR-023 §1). The resolution service walks a capability-gated fallback
+ * chain: provision → barcode → per-source-category mapping → manual,
+ * returning a neutral `{ destinationCategoryId, provenance, method }`.
  *
  * @module libs/core/src/listings/application/types
  */
 
 export const CategoryResolutionMethodValues = [
+  // ADR-023 §1 step 1 — destination provisions/mirrors the source category path.
+  // Gated on the `CategoryProvisioner` capability (delivered by #1041); a no-op
+  // until then, so this value is currently unreachable.
+  'provision',
+  // Step 2 — barcode/GTIN catalog auto-detect.
   'auto_detect',
+  // Step 3 — configured per-source-category mapping.
   'category_mapping',
+  // Step 4 — operator picks manually (no id resolved).
   'manual',
 ] as const;
 
 export type CategoryResolutionMethod = (typeof CategoryResolutionMethodValues)[number];
 
+/**
+ * How a destination relates to the taxonomy whose ids it resolves against
+ * (ADR-023). Derived from the destination adapter's *capabilities*, never its
+ * `platformType`. Drives attribute projection downstream (#1039): `borrows`
+ * destinations emit source-provenance ids verbatim; `owns` destinations
+ * resolve against their own dictionary.
+ */
+export const CategoryProvenanceValues = [
+  // Has its own category tree + per-category parameter schema (Allegro).
+  'owns',
+  // Accepts another connection's taxonomy ids verbatim, ships no own tree (ERLI).
+  'borrows',
+  // No fixed tree; placement is provisioning/mirroring (shop). Reachable once
+  // #1041 adds the `CategoryProvisioner` capability.
+  'open',
+] as const;
+
+export type CategoryProvenance = (typeof CategoryProvenanceValues)[number];
+
 export interface CategoryResolutionInput {
-  /** Allegro marketplace connection ID */
+  /** Destination marketplace/shop connection ID */
   connectionId: string;
   /**
-   * EAN or GTIN barcode for auto-detect (step 1).
+   * EAN or GTIN barcode for auto-detect (barcode step).
    * If omitted, auto-detect is skipped entirely.
    */
   barcode?: string | null;
   /**
-   * Source platform category IDs for mapping fallback (step 2), ordered deepest-first.
+   * Source platform category IDs for the mapping step, ordered deepest-first.
    * If both `barcode` and `sourceCategoryIds` are omitted, resolution returns `manual`.
    */
   sourceCategoryIds?: string[];
 }
 
 export interface CategoryResolutionResult {
-  /** Resolved Allegro category ID, or null if manual pick is needed */
-  allegroCategoryId: string | null;
+  /** Resolved destination category ID, or null if manual pick is needed */
+  destinationCategoryId: string | null;
+  /**
+   * Taxonomy relationship of the destination the id was resolved against, or
+   * `null` when no destination adapter was resolved (no-barcode / fallback /
+   * manual paths). Populated on the barcode path; the mapping-path provenance
+   * lands with #1045.
+   */
+  provenance: CategoryProvenance | null;
   /** Which resolution method produced the result */
   method: CategoryResolutionMethod;
 }

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -31,8 +31,12 @@ export type {
   CategoryResolutionInput,
   CategoryResolutionResult,
   CategoryResolutionMethod,
+  CategoryProvenance,
 } from './application/types/category-resolution.types';
-export { CategoryResolutionMethodValues } from './application/types/category-resolution.types';
+export {
+  CategoryResolutionMethodValues,
+  CategoryProvenanceValues,
+} from './application/types/category-resolution.types';
 export type { IOfferLinkingService } from './application/interfaces/offer-linking.service.interface';
 export type {
   OfferLinkMethod,


### PR DESCRIPTION
Closes #1037 · Epic #1005 · ADR-023 §1

## What & why
Generalises `CategoryResolutionService` from a 2-step Allegro-named chain into the ADR-023 §1 **capability-gated, provenance-aware** placement chain — `provision → barcode → per-source-category mapping → manual` — returning a neutral `{ destinationCategoryId, provenance, method }` (was `{ allegroCategoryId, method }`). This is the "brain" that offer creation (#1039) and shop publish (#1042) both call.

## Change
- **`provenance`** (`owns | borrows | open`) is derived from the destination adapter's **capabilities** — `CategoryBrowser`/`CategoryParametersReader` → `owns`, else `borrows`; never `platformType`. It's what attribute projection (#1039) consumes (`borrows` → emit source ids verbatim). Populated on the barcode path; `null` on mapping-only/manual until **#1045** makes the mapping lookup provenance-bearing.
- **Provision step** is a capability-gated **no-op seam** — `CategoryProvisioner` is delivered by **#1041**; the chain falls through until then (AC: "no-op when the destination lacks `CategoryProvisioner`").
- **Behaviour-preserving:** laziness (no adapter resolution without a barcode) + resilience (adapter-failure → mapping fallback) kept. **HTTP wire contract byte-identical** — the controller maps `destinationCategoryId` → the existing `allegroCategoryId` response field; neutralising the wire + surfacing `provenance` is **#1044**'s job.
- `offer-builder` reads the renamed field; the listings barrel now exports `CategoryProvenance` + `CategoryProvenanceValues`.

## Scope boundaries (deliberate)
- `CategoryProvisioner` capability/command → **#1041**.
- Provenance-*keyed* cross-connection mapping reuse (ERLI resolving Allegro's rows) → **#1045**.
- Wire-field neutralisation + FE `provenance` surfacing → **#1044**.
- The separate `EanMatchResult.allegroCategoryId` batch type + mappings DTOs are unrelated and untouched.

## Acceptance (issue)
- ✅ Allegro (`owns`) + a borrows-provenance destination resolve via the **same** capability-gated chain.
- ✅ Provision step is a no-op when `CategoryProvisioner` is absent (asserted by unit test).

## Testing
- Repo-wide `type-check` ✓, `lint` + `check:invariants` ✓, full `pnpm test` ✓ (core / api 451 / worker 156).
- Integration ✓ — the four specs touching this surface: `listings-create-offer`, `category-mapping-neutralisation`, `listings-bulk-offer-creation`, `listings-bulk-offer-creation-retry-failed` (23 passed / 1 skipped). No int-spec touches the resolve-category wire (grep-confirmed); the change is internal to `CategoryResolutionService` + a field rename covered by type-check.
- No migration (the #1036 schema already carries provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)