### PR TITLE
feat(prestashop): normalise variant attributes to semantic {group: value} names (#1050)

### DIFF
--- a/docs/plans/implementation-plan-prestashop-semantic-attributes.md
+++ b/docs/plans/implementation-plan-prestashop-semantic-attributes.md
@@ -1,0 +1,50 @@
+# Implementation Plan — PrestaShop semantic variant attributes (#1050)
+
+**Issue:** #1050 (prerequisite for #1038, epic #1005) · **Layer:** Integration (PrestaShop) only · **Size:** M
+
+## 1. Understand
+
+Make the PrestaShop product-master adapter emit `ProductVariant.attributes` as semantic `{ attributeGroupName: valueName }` (e.g. `{ "Color": "Red" }`) instead of the current positional `{ option_${index}: <product_option_value_id> }`, matching the WooCommerce shape so attribute mapping (#1038) has usable input.
+
+**Non-goals:** core changes (`ProductVariant.attributes` contract unchanged — only content); a migration/backfill (master-derived data self-heals on next sync; SQL can't resolve option ids → names); WooCommerce (already semantic); the attribute-mapping/projection itself (#1038).
+
+## 2. Research findings
+- `prestashop-product.mapper.ts:73` → `attributes['option_${index}'] = readAssociationId(ov)` (positional key + `product_option_value` id).
+- Adapter `getProductVariants` (`prestashop-product-master.adapter.ts` ~180–290) fetches `combinations`, maps each via `productMapper.mapVariant(combination, productId)`. Combinations carry `associations.product_option_values` → list of `{ id }` references.
+- WS client: `getResource(resource, id)` + `listResources(resource, filters?, limit?, offset?)` with `PrestashopQueryFilters` (has a `custom` escape hatch — used today for `id_product`).
+- Mapper has `getLocalizedField(field, langId=1)` for PS multi-language name fields; `mapProduct` resolves `name` that way. No `PrestashopProductOption`/`…OptionValue` types exist yet.
+- `attributes` **is** persisted (variants JSONB column) → existing rows hold positional shape until re-synced (self-heals; no migration).
+
+## 3. Design
+
+### Why semantic names, not the stable option-value id (alternative considered)
+PrestaShop `product_option_value` **ids are store-global and stable** (id 15 = "Red" in "Color" everywhere), so projection-correctness *alone* could be had cheaper by keying attributes on the attribute-**group id** (one WS call, no name resolution). Rejected because: (1) **cross-source consistency** — WooCommerce already emits `{ "Color": "Red" }`, and a single neutral attribute-mapping contract (#1038) requires one shape across sources, else mappings are name-keyed for WC and id-keyed for PS; (2) names are required for a usable authoring UI; (3) `attribute_value_mappings` author `Red → Czerwony`, far better than `15 → Czerwony`. So we resolve to names. (Confirmed the extra fetch is unavoidable: combination `associations.product_option_values` are **id-only** refs — the mapper's `readAssociationId` proves it — PS WS doesn't deep-embed them.)
+
+### 3.1 Types (`domain/types`)
+- `PrestashopProductOption { id; name: <localized> }` — attribute group (e.g. "Color").
+- `PrestashopProductOptionValue { id; name: <localized>; id_attribute_group }` — value + its group.
+
+### 3.2 Resolver (NEW — `infrastructure/.../prestashop-attribute.resolver.ts`) — **caching is the point**
+Master sync resolves the adapter **per product/job**, so a per-adapter cache wouldn't survive across products. Mirror the existing resolver-singleton pattern (`PrestashopCountryResolver`) but **hold it on the factory** (a field, constructed once) so its cache persists across product jobs for the process lifetime:
+- `PrestashopAttributeResolver` holds `Map<connectionId, { map: Map<optionValueId,{groupName,valueName}>; timestamp }>`, TTL 24h (option groups/values are a tiny, near-static set).
+- `getOptionValueMap(connectionId, client, langId): Promise<Map<…>>` — on miss/expired, **fetch the full set once** (`listResources('product_options')` + `listResources('product_option_values')`, `display=full`), build + cache. **Two WS calls per connection per TTL**, not per product — this is the fix for the review's IMPORTANT scaling item.
+- Localized names via a shared `readLocalizedField(field, langId)` util extracted from the mapper's private `getLocalizedField` (mapper delegates to it — no behaviour change, dedupes the parser).
+
+### 3.3 Adapter (`prestashop-product-master.adapter.ts` + factory)
+- Constructor gains `attributeResolver: PrestashopAttributeResolver`. Factory holds `private readonly attributeResolver = new PrestashopAttributeResolver()` (persists with the singleton factory) and passes it in.
+- `getProductVariants`: `const optionMap = await this.attributeResolver.getOptionValueMap(connection.id, httpClient, langId)`; build `resolve = (id) => optionMap.get(id) ?? null`; pass to `mapVariant`. On resolver error → log `warn`, pass `() => null` → positional fallback (a transient options fetch never breaks variant sync).
+
+### 3.4 Mapper (`prestashop-product.mapper.ts` + interface)
+- `mapVariant(combination, productId, resolveOptionValue?)`: resolver hit → `attributes[groupName] = valueName`; miss/unresolved id → `option_${index} = id` fallback (variant distinctness + back-compat); no resolver → current positional behaviour (existing callers/tests valid).
+
+### 3.5 Tests
+- **Resolver unit:** builds the map from `product_options` + `product_option_values` (mock WS); caches (second call → no WS); TTL expiry refetches; per-connection keying.
+- **Mapper unit:** semantic given resolver; positional fallback when absent / unresolved; empty when no option values.
+- **Adapter unit:** passes the resolver, semantic attributes on the variant, graceful fallback on resolver error. Update existing `mapVariant`/adapter specs to the new signature.
+
+## 4. Validate
+- `pnpm lint`, `pnpm type-check`, `pnpm test` (prestashop package + any core consumers). No migration → no `migration:show`. PS Testcontainer int-spec is **out of scope** (opt-in, heavy; unit coverage with mocked WS is the right level here — the option→name resolution is request-shape logic, not PS-behaviour-dependent).
+- Architecture: stays within the PrestaShop plugin; mapper does no I/O (adapter fetches, passes resolved data in); neutral `ProductVariant` contract unchanged.
+
+## Notes
+- Existing persisted positional attributes correct themselves on the next master sync — documented, no backfill.

--- a/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
+++ b/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
@@ -34,6 +34,7 @@ import { PrestashopAddressProvisioner } from '../infrastructure/provisioners/pre
 import { PrestashopCountryResolver } from '../infrastructure/provisioners/prestashop-country-resolver';
 import { PrestashopCurrencyResolver } from '../infrastructure/provisioners/prestashop-currency-resolver';
 import { PrestashopTaxRateResolver } from '../infrastructure/provisioners/prestashop-tax-rate.resolver';
+import { PrestashopAttributeResolver } from '../infrastructure/provisioners/prestashop-attribute.resolver';
 import type { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
 import { Logger } from '@openlinker/shared/logging';
 
@@ -44,6 +45,11 @@ import { Logger } from '@openlinker/shared/logging';
  */
 export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
   private readonly logger = new Logger(PrestashopAdapterFactory.name);
+
+  // Held on the factory (a process-singleton) so its option-value cache
+  // survives across the per-product adapter instances the master sync creates
+  // (#1050). A per-adapter cache would never hit.
+  private readonly attributeResolver = new PrestashopAttributeResolver();
 
   constructor(
     private readonly customerProvisioner?: PrestashopCustomerProvisioner,
@@ -97,7 +103,8 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
       httpClient,
       identifierMapping,
       productMapper,
-      connection
+      connection,
+      this.attributeResolver
     );
 
     const inventoryMaster = new PrestashopInventoryMasterAdapter(

--- a/libs/integrations/prestashop/src/domain/types/prestashop-product-option.types.ts
+++ b/libs/integrations/prestashop/src/domain/types/prestashop-product-option.types.ts
@@ -1,0 +1,50 @@
+/**
+ * PrestaShop Product Option Types (#1050)
+ *
+ * Response shapes for the `/product_options` (attribute groups, e.g. "Color")
+ * and `/product_option_values` (values, e.g. "Red") WS list endpoints, used by
+ * `PrestashopAttributeResolver` to turn a combination's positional
+ * `product_option_value` id-refs into semantic `{ attributeGroupName: valueName }`
+ * variant attributes. Only the fields the resolver consumes are typed; PS WS
+ * returns more.
+ *
+ * `name` is a PrestaShop localized field (flat string, JSON `[{id,value}]`, or
+ * XML `{language:[…]}`) — read via the product mapper's `localizeField`.
+ *
+ * @module libs/integrations/prestashop/src/domain/types
+ */
+
+/** `GET /product_options` row — an attribute group (e.g. "Color"). */
+export interface PrestashopProductOption {
+  id: string | number;
+  name?: unknown;
+}
+
+/** `GET /product_option_values` row — a value (e.g. "Red") + its owning group. */
+export interface PrestashopProductOptionValue {
+  id: string | number;
+  name?: unknown;
+  id_attribute_group?: string | number;
+}
+
+/** A `product_option_value` id resolved to its semantic group + value names. */
+export interface ResolvedOptionValue {
+  /** Attribute group name (e.g. "Color"). */
+  groupName: string;
+  /** Value name within the group (e.g. "Red"). */
+  valueName: string;
+}
+
+/**
+ * Resolves a combination's `product_option_value` id to its
+ * {@link ResolvedOptionValue}, or `null` when unknown. Passed into `mapVariant`
+ * so the mapper stays I/O-free.
+ */
+export type OptionValueResolver = (optionValueId: string) => ResolvedOptionValue | null;
+
+/**
+ * Reads a PrestaShop localized field into a single string for a language. The
+ * attribute resolver receives the product mapper's `localizeField` as this type
+ * so it reuses the one parser rather than re-implementing PS's field shapes.
+ */
+export type LocalizeFn = (field: unknown, langId?: number) => string | undefined;

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
@@ -12,6 +12,7 @@ import { createMockIdentifierMapping } from '../../../__tests__/mocks/mock-ident
 import { createTestConnection } from '../../../__tests__/fixtures/connection.fixture';
 import { samplePrestashopProduct } from '../../../__tests__/fixtures/prestashop-product.fixture';
 import { PrestashopProductMapper } from '../../mappers/prestashop-product.mapper';
+import { PrestashopAttributeResolver } from '../../provisioners/prestashop-attribute.resolver';
 import {
   PrestashopResourceNotFoundException,
   PrestashopNotSupportedException,
@@ -542,6 +543,76 @@ describe('PrestashopProductMasterAdapter', () => {
         undefined,
         undefined
       );
+    });
+  });
+
+  describe('getProductVariants — semantic attributes (#1050)', () => {
+    const externalProductId = '42';
+    const productId = 'internal-product-123';
+    const combinations: PrestashopCombination[] = [
+      {
+        id: '101',
+        id_product: '42',
+        reference: 'VAR-RED',
+        associations: { product_option_values: [{ id: '20' }] },
+      },
+    ];
+    const options = [{ id: '1', name: 'Color' }];
+    const optionValues = [{ id: '20', name: 'Red', id_attribute_group: '1' }];
+
+    function seedIdentifierMapping(): void {
+      mockIdentifierMapping.getExternalIds = jest.fn().mockResolvedValue([
+        { connectionId: connection.id, externalId: externalProductId, entityType: 'Product' },
+      ]);
+      mockIdentifierMapping.batchGetOrCreateInternalIds = jest
+        .fn()
+        .mockResolvedValue(new Map([['101:test-connection-id', 'internal-variant-1']]));
+    }
+
+    it('emits semantic { group: value } attributes when the resolver is wired', async () => {
+      seedIdentifierMapping();
+      mockHttpClient.getResource = jest.fn().mockResolvedValue(samplePrestashopProduct);
+      mockHttpClient.listResources = jest.fn((resource: string) => {
+        if (resource === 'combinations') return Promise.resolve(combinations);
+        if (resource === 'product_options') return Promise.resolve(options);
+        if (resource === 'product_option_values') return Promise.resolve(optionValues);
+        return Promise.resolve([]);
+      }) as unknown as typeof mockHttpClient.listResources;
+
+      const adapterWithResolver = new PrestashopProductMasterAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        productMapper,
+        connection,
+        new PrestashopAttributeResolver()
+      );
+
+      const result = await adapterWithResolver.getProductVariants(productId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].attributes).toEqual({ Color: 'Red' });
+    });
+
+    it('falls back to positional attributes when the option fetch fails', async () => {
+      seedIdentifierMapping();
+      mockHttpClient.getResource = jest.fn().mockResolvedValue(samplePrestashopProduct);
+      mockHttpClient.listResources = jest.fn((resource: string) => {
+        if (resource === 'combinations') return Promise.resolve(combinations);
+        return Promise.reject(new Error('options endpoint down'));
+      }) as unknown as typeof mockHttpClient.listResources;
+
+      const adapterWithResolver = new PrestashopProductMasterAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        productMapper,
+        connection,
+        new PrestashopAttributeResolver()
+      );
+
+      const result = await adapterWithResolver.getProductVariants(productId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].attributes).toEqual({ option_0: '20' });
     });
   });
 });

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
@@ -32,6 +32,8 @@ import {
   PrestashopResourceNotFoundException,
 } from '@openlinker/integrations-prestashop';
 import { Logger } from '@openlinker/shared/logging';
+import type { PrestashopAttributeResolver } from '../provisioners/prestashop-attribute.resolver';
+import type { OptionValueResolver } from '../../domain/types/prestashop-product-option.types';
 
 /**
  * PrestaShop Product Master Adapter
@@ -45,7 +47,11 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     private readonly httpClient: IPrestashopWebserviceClient,
     private readonly identifierMapping: IdentifierMappingPort,
     private readonly productMapper: IPrestashopProductMapper,
-    private readonly connection: Connection
+    private readonly connection: Connection,
+    // Optional so existing constructions (tests) stay valid; the factory always
+    // supplies a process-singleton instance so its option-value cache persists
+    // across per-product adapter instances (#1050).
+    private readonly attributeResolver?: PrestashopAttributeResolver
   ) {}
 
   async getProduct(productId: string): Promise<Product> {
@@ -75,11 +81,7 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     );
 
     // Map to OpenLinker schema
-    const config = this.connection.config as unknown as PrestashopConnectionConfig;
-    // Support both preferredLanguageId (new) and langId (deprecated, backward compatibility)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
-    const configLangId: number | undefined = config.preferredLanguageId ?? config.langId;
-    const langIdValue: number = configLangId ?? 1;
+    const langIdValue: number = this.resolveLangId();
 
     const mapped = this.productMapper.mapProduct(prestashopProduct, langIdValue);
 
@@ -118,11 +120,7 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     const idMap = await this.identifierMapping.batchGetOrCreateInternalIds(mappingRequests);
 
     // Map products with internal IDs
-    const config = this.connection.config as unknown as PrestashopConnectionConfig;
-    // Support both preferredLanguageId (new) and langId (deprecated, backward compatibility)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
-    const configLangId: number | undefined = config.preferredLanguageId ?? config.langId;
-    const langIdValue: number = configLangId ?? 1;
+    const langIdValue: number = this.resolveLangId();
 
     return prestashopProducts
       .map((prestashopProduct) => {
@@ -261,6 +259,12 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     const productEan = this.normalizeEan(prestashopProduct.ean13);
     const productGtin = this.normalizeGtin(prestashopProduct.upc);
 
+    // Resolve the option-value id → semantic-name map so variants carry
+    // `{ Color: 'Red' }` instead of positional ids (#1050). A transient options
+    // fetch must never break variant sync — on failure we fall back to the
+    // positional shape via a null resolver.
+    const resolveOptionValue = await this.buildOptionValueResolver();
+
     // Map variants with internal IDs
     return combinations
       .map((combination) => {
@@ -273,7 +277,7 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
           return null;
         }
 
-        const mapped = this.productMapper.mapVariant(combination, productId);
+        const mapped = this.productMapper.mapVariant(combination, productId, resolveOptionValue);
         if (combinations.length === 1) {
           if (!mapped.ean && productEan) {
             mapped.ean = productEan;
@@ -288,6 +292,47 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
         };
       })
       .filter((v): v is ProductVariant => v !== null);
+  }
+
+  /**
+   * Build the per-call resolver that turns a combination's
+   * `product_option_value` id into `{ groupName, valueName }` (#1050). Returns
+   * `undefined` (mapper falls back to the positional shape) when no resolver is
+   * wired or the option dictionary can't be fetched — a transient options
+   * failure must not break variant sync.
+   */
+  private async buildOptionValueResolver(): Promise<OptionValueResolver | undefined> {
+    if (!this.attributeResolver) {
+      return undefined;
+    }
+    try {
+      const optionMap = await this.attributeResolver.getOptionValueMap(
+        this.connection.id,
+        this.httpClient,
+        (field, langId) => this.productMapper.localizeField(field, langId),
+        this.resolveLangId()
+      );
+      return (optionValueId: string) => optionMap.get(optionValueId) ?? null;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to resolve PrestaShop option values (connection: ${this.connection.id}); ` +
+          `falling back to positional variant attributes: ${(error as Error).message}`
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Resolve the connection's preferred language id for localized reads,
+   * supporting both `preferredLanguageId` (current) and `langId` (deprecated),
+   * defaulting to 1. Single source for product, product-list, and attribute
+   * localization so all three agree on language.
+   */
+  private resolveLangId(): number {
+    const config = this.connection.config as unknown as PrestashopConnectionConfig;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- prestashop connection config is dynamically shaped; narrowed to number | undefined here
+    const configLangId: number | undefined = config.preferredLanguageId ?? config.langId;
+    return configLangId ?? 1;
   }
 
   private normalizeEan(value?: string | null): string | null {

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
@@ -8,6 +8,7 @@
  */
 import { PrestashopProductMapper } from '../prestashop-product.mapper';
 import type { PrestashopProduct, PrestashopCombination } from '../prestashop.mapper.interface';
+import type { OptionValueResolver } from '../../../domain/types/prestashop-product-option.types';
 
 const STOREFRONT_BASE_URL = 'https://shop.test';
 
@@ -682,6 +683,64 @@ describe('PrestashopProductMapper', () => {
 
       expect(result.ean).toBeNull();
       expect(result.gtin).toBeNull();
+    });
+
+    it('should emit semantic attributes when a resolver resolves the option-value ids (#1050)', () => {
+      const combination: PrestashopCombination = {
+        id: '100',
+        id_product: '1',
+        reference: 'TEST-001-RED',
+        associations: {
+          product_option_values: [{ id: '20' }, { id: '30' }],
+        },
+      };
+      const resolve: OptionValueResolver = (id) =>
+        id === '20'
+          ? { groupName: 'Color', valueName: 'Red' }
+          : id === '30'
+            ? { groupName: 'Size', valueName: 'M' }
+            : null;
+
+      const result = mapper.mapVariant(combination, 'internal-product-id', resolve);
+
+      expect(result.attributes).toEqual({ Color: 'Red', Size: 'M' });
+    });
+
+    it('should fall back to the positional id for option values the resolver cannot resolve (#1050)', () => {
+      const combination: PrestashopCombination = {
+        id: '100',
+        id_product: '1',
+        reference: 'TEST-001-RED',
+        associations: {
+          product_option_values: [{ id: '20' }, { id: '99' }],
+        },
+      };
+      const resolve: OptionValueResolver = (id) =>
+        id === '20' ? { groupName: 'Color', valueName: 'Red' } : null;
+
+      const result = mapper.mapVariant(combination, 'internal-product-id', resolve);
+
+      expect(result.attributes).toEqual({ Color: 'Red', option_1: '99' });
+    });
+  });
+
+  describe('localizeField', () => {
+    it('should read a flat string field', () => {
+      expect(mapper.localizeField('Red')).toBe('Red');
+    });
+
+    it('should read the preferred language from a JSON [{id,value}] field', () => {
+      const field = [
+        { id: '1', value: 'Red' },
+        { id: '2', value: 'Czerwony' },
+      ];
+      expect(mapper.localizeField(field, 1)).toBe('Red');
+      expect(mapper.localizeField(field, 2)).toBe('Czerwony');
+    });
+
+    it('should return undefined for an empty field', () => {
+      expect(mapper.localizeField(undefined)).toBeUndefined();
+      expect(mapper.localizeField('   ')).toBeUndefined();
     });
   });
 });

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
@@ -14,6 +14,7 @@ import type {
   PrestashopProduct,
   PrestashopCombination,
 } from './prestashop.mapper.interface';
+import type { OptionValueResolver } from '../../domain/types/prestashop-product-option.types';
 import type { PrestashopProductMapperOptions } from './prestashop-product.mapper.types';
 
 /**
@@ -55,7 +56,11 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
     };
   }
 
-  mapVariant(combination: PrestashopCombination, productId: string): Omit<ProductVariant, 'id'> {
+  mapVariant(
+    combination: PrestashopCombination,
+    productId: string,
+    resolveOptionValue?: OptionValueResolver
+  ): Omit<ProductVariant, 'id'> {
     const attributes: Record<string, string> = {};
     const ean = normalizeToEan13(combination.ean13 ?? null);
     const gtin = normalizeBarcode(combination.upc ?? null);
@@ -69,7 +74,16 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
     );
     optionValues.forEach((ov, index) => {
       const id = this.readAssociationId(ov);
-      if (id !== null) {
+      if (id === null) {
+        return;
+      }
+      // Prefer semantic `{ attributeGroupName: valueName }` (#1050); fall back
+      // to the positional id shape when no resolver is supplied or the id is
+      // unknown (keeps variants distinct + back-compat).
+      const resolved = resolveOptionValue?.(id) ?? null;
+      if (resolved) {
+        attributes[resolved.groupName] = resolved.valueName;
+      } else {
         attributes[`option_${index}`] = id;
       }
     });
@@ -100,6 +114,10 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
    * @param preferredLangId - Preferred language ID (defaults to 1)
    * @returns Extracted text value (trimmed, or undefined if empty/whitespace)
    */
+  localizeField(field: unknown, langId: number = 1): string | undefined {
+    return this.getLocalizedField(field, langId);
+  }
+
   private getLocalizedField(field: unknown, preferredLangId: number = 1): string | undefined {
     if (!field) {
       return undefined;

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
@@ -10,6 +10,7 @@
 import type { Product, ProductVariant } from '@openlinker/core/products';
 import type { Inventory } from '@openlinker/core/inventory';
 import type { Order, OrderCreate, OrderStatus } from '@openlinker/core/orders';
+import type { OptionValueResolver } from '../../domain/types/prestashop-product-option.types';
 
 /**
  * PrestaShop product data (from API response)
@@ -140,9 +141,30 @@ export interface IPrestashopProductMapper {
    *
    * @param combination - PrestaShop combination data
    * @param productId - Internal OpenLinker product ID
+   * @param resolveOptionValue - Optional resolver turning a combination's
+   *   `product_option_value` id into `{ attributeGroupName, valueName }` so the
+   *   variant carries semantic attributes (e.g. `{ Color: 'Red' }`). When
+   *   omitted or unresolved, falls back to the positional `option_${index}` id
+   *   shape (variant distinctness + back-compat). The mapper performs no I/O —
+   *   the adapter fetches the option dictionary and passes this in (#1050).
    * @returns OpenLinker ProductVariant (without ID - ID mapping handled by adapter)
    */
-  mapVariant(combination: PrestashopCombination, productId: string): Omit<ProductVariant, 'id'>;
+  mapVariant(
+    combination: PrestashopCombination,
+    productId: string,
+    resolveOptionValue?: OptionValueResolver
+  ): Omit<ProductVariant, 'id'>;
+
+  /**
+   * Read a PrestaShop localized field (flat string, JSON `[{id,value}]`, or XML
+   * `{language:[…]}`) into a single trimmed string for the given language.
+   * Exposed so the attribute resolver reuses the one battle-tested parser
+   * rather than duplicating it (#1050).
+   *
+   * @param field - Raw localized field value from a PS WS response
+   * @param langId - Preferred language ID (default: 1)
+   */
+  localizeField(field: unknown, langId?: number): string | undefined;
 }
 
 /**

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-attribute.resolver.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-attribute.resolver.spec.ts
@@ -55,6 +55,17 @@ describe('PrestashopAttributeResolver', () => {
     expect(map.get('30')).toEqual({ groupName: 'Size', valueName: 'M' });
   });
 
+  it('should request only the fields it needs (display field-selection)', async () => {
+    await resolver.getOptionValueMap('conn-1', client, localize);
+
+    expect(client.listResources).toHaveBeenCalledWith('product_options', {
+      display: '[id,name]',
+    });
+    expect(client.listResources).toHaveBeenCalledWith('product_option_values', {
+      display: '[id,name,id_attribute_group]',
+    });
+  });
+
   it('should omit option values whose attribute group cannot be resolved', async () => {
     const map = await resolver.getOptionValueMap('conn-1', client, localize);
 

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-attribute.resolver.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-attribute.resolver.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for PrestashopAttributeResolver (#1050)
+ *
+ * Verifies the option-value id → semantic-name map is built from
+ * `/product_options` + `/product_option_values`, cached per connection with a
+ * TTL, and keyed per connection.
+ */
+import { PrestashopAttributeResolver } from '../prestashop-attribute.resolver';
+import type { IPrestashopWebserviceClient } from '../../http/prestashop-webservice.client.interface';
+
+describe('PrestashopAttributeResolver', () => {
+  let resolver: PrestashopAttributeResolver;
+  let client: jest.Mocked<IPrestashopWebserviceClient>;
+  // The product mapper's localizeField, simplified for the test: reads a flat
+  // string or the first {value} of a JSON-shape localized field.
+  const localize = (field: unknown): string | undefined => {
+    if (typeof field === 'string') return field.trim() || undefined;
+    if (Array.isArray(field)) {
+      const node = field[0] as { value?: unknown } | undefined;
+      return node?.value !== undefined ? String(node.value) : undefined;
+    }
+    return undefined;
+  };
+
+  const OPTIONS = [
+    { id: '1', name: 'Color' },
+    { id: '2', name: 'Size' },
+  ];
+  const OPTION_VALUES = [
+    { id: '20', name: 'Red', id_attribute_group: '1' },
+    { id: '30', name: 'M', id_attribute_group: '2' },
+    // Value whose group is unknown → omitted from the map.
+    { id: '40', name: 'Orphan', id_attribute_group: '99' },
+  ];
+
+  beforeEach(() => {
+    resolver = new PrestashopAttributeResolver();
+    client = {
+      getResource: jest.fn(),
+      listResources: jest.fn((resource: string) => {
+        if (resource === 'product_options') return Promise.resolve([...OPTIONS]);
+        if (resource === 'product_option_values') return Promise.resolve([...OPTION_VALUES]);
+        return Promise.resolve([]);
+      }),
+      createResource: jest.fn(),
+      updateResource: jest.fn(),
+      deleteResource: jest.fn(),
+    } as unknown as jest.Mocked<IPrestashopWebserviceClient>;
+  });
+
+  it('should build the option-value id → semantic-name map', async () => {
+    const map = await resolver.getOptionValueMap('conn-1', client, localize);
+
+    expect(map.get('20')).toEqual({ groupName: 'Color', valueName: 'Red' });
+    expect(map.get('30')).toEqual({ groupName: 'Size', valueName: 'M' });
+  });
+
+  it('should omit option values whose attribute group cannot be resolved', async () => {
+    const map = await resolver.getOptionValueMap('conn-1', client, localize);
+
+    expect(map.has('40')).toBe(false);
+  });
+
+  it('should cache per connection — a second call makes no WS request', async () => {
+    await resolver.getOptionValueMap('conn-1', client, localize);
+    await resolver.getOptionValueMap('conn-1', client, localize);
+
+    // Two list calls on the first build (options + values), none on the cache hit.
+    expect(client.listResources).toHaveBeenCalledTimes(2);
+  });
+
+  it('should fetch independently for different connections', async () => {
+    await resolver.getOptionValueMap('conn-1', client, localize);
+    await resolver.getOptionValueMap('conn-2', client, localize);
+
+    expect(client.listResources).toHaveBeenCalledTimes(4);
+  });
+
+  it('should refetch after the cache is cleared', async () => {
+    await resolver.getOptionValueMap('conn-1', client, localize);
+    resolver.clearCache('conn-1');
+    await resolver.getOptionValueMap('conn-1', client, localize);
+
+    expect(client.listResources).toHaveBeenCalledTimes(4);
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-attribute.resolver.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-attribute.resolver.ts
@@ -1,0 +1,109 @@
+/**
+ * PrestaShop Attribute Resolver (#1050)
+ *
+ * Builds a `product_option_value` id → `{ groupName, valueName }` lookup so the
+ * product mapper can emit semantic variant attributes (`{ Color: 'Red' }`)
+ * instead of positional `{ option_0: '15' }` ids — matching the WooCommerce
+ * shape so attribute mapping (#1038) has a single neutral input across sources.
+ *
+ * PrestaShop combinations reference option values by **id only**; the human
+ * names live on `/product_options` (groups) + `/product_option_values` (values).
+ * Both are a tiny, near-static set, so the resolver fetches the full set **once
+ * per connection per TTL** and caches it — not per product. The master sync
+ * resolves the adapter per product/job, so this resolver must be held on the
+ * process-singleton factory for its cache to survive across product jobs.
+ *
+ * Localization reuses the product mapper's battle-tested parser (passed in as
+ * `localize`) rather than re-implementing PS's flat/JSON/XML field shapes here.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/provisioners
+ */
+import { Logger } from '@openlinker/shared/logging';
+import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
+import type {
+  PrestashopProductOption,
+  PrestashopProductOptionValue,
+  ResolvedOptionValue,
+  LocalizeFn,
+} from '../../domain/types/prestashop-product-option.types';
+
+interface CacheEntry {
+  map: Map<string, ResolvedOptionValue>;
+  timestamp: number;
+}
+
+/**
+ * Cache TTL (24h). Option groups/values change rarely, but the cache expires so
+ * configuration edits in PrestaShop admin eventually surface without a restart.
+ */
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export class PrestashopAttributeResolver {
+  private readonly logger = new Logger(PrestashopAttributeResolver.name);
+  private readonly cache = new Map<string, CacheEntry>();
+
+  /**
+   * Resolve (and cache) the option-value id → semantic-name map for a connection.
+   *
+   * Fetches `/product_options` + `/product_option_values` once per connection
+   * per TTL. Values whose group or own name can't be localized are omitted (the
+   * mapper falls back to the positional id for those).
+   *
+   * @param connectionId - Cache key
+   * @param client - PrestaShop WebService client for this connection
+   * @param localize - Localized-field reader (the product mapper's `localizeField`)
+   * @param langId - Preferred language ID (default: 1)
+   */
+  async getOptionValueMap(
+    connectionId: string,
+    client: IPrestashopWebserviceClient,
+    localize: LocalizeFn,
+    langId = 1
+  ): Promise<Map<string, ResolvedOptionValue>> {
+    const cached = this.cache.get(connectionId);
+    if (cached !== undefined) {
+      if (Date.now() - cached.timestamp < CACHE_TTL_MS) {
+        return cached.map;
+      }
+      this.cache.delete(connectionId);
+    }
+
+    const [options, values] = await Promise.all([
+      client.listResources<PrestashopProductOption>('product_options'),
+      client.listResources<PrestashopProductOptionValue>('product_option_values'),
+    ]);
+
+    const groupNameById = new Map<string, string>();
+    for (const option of options ?? []) {
+      const name = localize(option.name, langId);
+      if (name) {
+        groupNameById.set(String(option.id), name);
+      }
+    }
+
+    const map = new Map<string, ResolvedOptionValue>();
+    for (const value of values ?? []) {
+      const valueName = localize(value.name, langId);
+      const groupId = value.id_attribute_group;
+      const groupName = groupId !== undefined ? groupNameById.get(String(groupId)) : undefined;
+      if (valueName && groupName) {
+        map.set(String(value.id), { groupName, valueName });
+      }
+    }
+
+    this.cache.set(connectionId, { map, timestamp: Date.now() });
+    this.logger.debug(
+      `Built option-value map for connection ${connectionId}: ${map.size} resolvable values`
+    );
+    return map;
+  }
+
+  /** Clear the cache for one connection, or all connections when omitted. */
+  clearCache(connectionId?: string): void {
+    if (connectionId) {
+      this.cache.delete(connectionId);
+    } else {
+      this.cache.clear();
+    }
+  }
+}

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-attribute.resolver.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-attribute.resolver.ts
@@ -68,9 +68,16 @@ export class PrestashopAttributeResolver {
       this.cache.delete(connectionId);
     }
 
+    // Field-selection keeps this per-connection bootstrap lean — we only read
+    // id/name (+ id_attribute_group for values), not full option bodies. Uses
+    // the same `display` override `listExternalIds` relies on.
     const [options, values] = await Promise.all([
-      client.listResources<PrestashopProductOption>('product_options'),
-      client.listResources<PrestashopProductOptionValue>('product_option_values'),
+      client.listResources<PrestashopProductOption>('product_options', {
+        display: '[id,name]',
+      }),
+      client.listResources<PrestashopProductOptionValue>('product_option_values', {
+        display: '[id,name,id_attribute_group]',
+      }),
     ]);
 
     const groupNameById = new Map<string, string>();


### PR DESCRIPTION
## What & why

The PrestaShop product-master adapter emitted variant `attributes` as positional `{ option_0: <product_option_value_id> }` — non-semantic and divergent from WooCommerce's `{ Color: 'Red' }` shape. The attribute-projection work (#1038, epic #1005 / ADR-023) needs a **single neutral attribute input across sources**, so PrestaShop must resolve its combinations' id-only option references to semantic `{ attributeGroupName: valueName }` names.

This is the unblocking prerequisite for #1038.

## Changes (Integration / PrestaShop only)

- **`PrestashopAttributeResolver`** (new) — builds a `product_option_value` id → `{ groupName, valueName }` map from `/product_options` + `/product_option_values`. Fetched **once per connection per TTL (24h)** and cached. Held on the **singleton adapter factory** (a field) so the cache survives the per-product adapter instances the master sync creates — a per-adapter cache would never hit.
- **`mapVariant(combination, productId, resolveOptionValue?)`** — emits semantic attributes when a resolver is supplied; falls back to the positional `option_${index}` id **per value** when the resolver is absent or an id is unknown (keeps variants distinct + back-compat). The mapper stays I/O-free — the adapter fetches and passes the resolver in.
- **`localizeField`** (new public passthrough on the mapper) — the resolver reuses the mapper's battle-tested localized-field parser instead of duplicating PS's flat/JSON/XML field shapes.
- **Language id threaded** from the connection config via a shared `resolveLangId()` (deduped from `getProduct`/`getProducts`) so attribute names match the store's preferred language, not a hardcoded lang 1.
- **Graceful degradation** — a transient option-fetch failure logs a `warn` and falls back to the positional shape; it never breaks variant sync.

## Non-goals

Core contract unchanged (`ProductVariant.attributes` shape is the same — only its *content* is now semantic). No migration/backfill: master-derived data, so existing persisted positional attributes self-heal on the next sync. The attribute mapping/projection itself is #1038.

## Tests

- **Resolver unit** — map build, omit-unresolvable-group, per-connection cache (second call → no WS), per-connection independence, refetch-after-clear.
- **Mapper unit** — semantic given resolver, positional fallback for unresolved ids, `localizeField` (flat / JSON-by-lang / empty).
- **Adapter unit** — semantic attributes when the resolver is wired, positional fallback when the option fetch fails.

## Quality gate

`pnpm type-check` ✓ · `pnpm lint` ✓ (0 errors/0 warnings) · `pnpm test` ✓ (prestashop 381/381; full suite green). No schema change → no migration.

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)