### PR TITLE
feat(mappings,listings): attribute projection service + attribute mapping tables (#1038)

### DIFF
--- a/apps/api/src/migrations/1805000000000-add-attribute-mappings.ts
+++ b/apps/api/src/migrations/1805000000000-add-attribute-mappings.ts
@@ -1,0 +1,91 @@
+/**
+ * Migration: add `attribute_mappings` + `attribute_value_mappings` tables
+ *
+ * Storage for attribute projection (#1038, ADR-023 §4): maps a source product
+ * attribute key → a destination parameter name, scoped by source + destination
+ * connection with an optional per-category override, plus per-value
+ * translations.
+ *
+ * Index design: Postgres treats NULL ≠ NULL in unique indexes, so the parent
+ * ships two partial unique indexes — one for the connection-wide default
+ * (`destination_category_id IS NULL`), one for per-category overrides
+ * (`destination_category_id IS NOT NULL`). Mirrors the ORM-entity decorators
+ * for synchronize↔migration parity. `gen_random_uuid()` is built-in on PG ≥ 13
+ * (Testcontainers + prod run PG 16).
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAttributeMappings1805000000000 implements MigrationInterface {
+  name = 'AddAttributeMappings1805000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "attribute_mappings" (
+        "id"                         UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+        "source_connection_id"       UUID         NOT NULL,
+        "destination_connection_id"  UUID         NOT NULL,
+        "source_attribute_key"       VARCHAR(255) NOT NULL,
+        "destination_parameter_name" VARCHAR(255) NOT NULL,
+        "destination_category_id"    VARCHAR(100) NULL,
+        "created_at"                 TIMESTAMP    NOT NULL DEFAULT now(),
+        "updated_at"                 TIMESTAMP    NOT NULL DEFAULT now(),
+        CONSTRAINT "FK_attribute_mappings_source_connection"
+          FOREIGN KEY ("source_connection_id")      REFERENCES "connections"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_attribute_mappings_destination_connection"
+          FOREIGN KEY ("destination_connection_id") REFERENCES "connections"("id") ON DELETE CASCADE
+      )
+    `);
+
+    // Connection-wide default: at most one row per (source, destination, key) when no category override.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_attribute_mappings_default"
+        ON "attribute_mappings" ("source_connection_id", "destination_connection_id", "source_attribute_key")
+        WHERE "destination_category_id" IS NULL
+    `);
+
+    // Per-category override: at most one row per (source, destination, key, category) when category is set.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_attribute_mappings_per_category"
+        ON "attribute_mappings" ("source_connection_id", "destination_connection_id", "source_attribute_key", "destination_category_id")
+        WHERE "destination_category_id" IS NOT NULL
+    `);
+
+    // Supports the per-projection getAttributeMappings(destinationConnectionId)
+    // read (neither partial unique index is left-prefixed on destination).
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IX_attribute_mappings_destination"
+        ON "attribute_mappings" ("destination_connection_id")
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "attribute_value_mappings" (
+        "id"                   UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+        "attribute_mapping_id" UUID         NOT NULL,
+        "source_value"         VARCHAR(255) NOT NULL,
+        "destination_value"    VARCHAR(255) NOT NULL,
+        "created_at"           TIMESTAMP    NOT NULL DEFAULT now(),
+        "updated_at"           TIMESTAMP    NOT NULL DEFAULT now(),
+        CONSTRAINT "FK_attribute_value_mappings_mapping"
+          FOREIGN KEY ("attribute_mapping_id") REFERENCES "attribute_mappings"("id") ON DELETE CASCADE
+      )
+    `);
+
+    // Unique as an INDEX (not a table constraint) to match the ORM @Index the
+    // integration harness builds via synchronize.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_attribute_value_mappings_mapping_source"
+        ON "attribute_value_mappings" ("attribute_mapping_id", "source_value")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "UQ_attribute_value_mappings_mapping_source"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "attribute_value_mappings"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IX_attribute_mappings_destination"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "UQ_attribute_mappings_per_category"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "UQ_attribute_mappings_default"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "attribute_mappings"`);
+  }
+}

--- a/apps/api/test/integration/attribute-mappings.int-spec.ts
+++ b/apps/api/test/integration/attribute-mappings.int-spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Attribute Mappings Integration Test (#1038)
+ *
+ * Verifies the `attribute_mappings` + `attribute_value_mappings` schema against
+ * real Postgres (Testcontainers; schema built by the harness):
+ *  - the two partial unique indexes enforce NULL-distinct semantics on the
+ *    nullable `destination_category_id` (connection-wide default vs per-category);
+ *  - the value-mapping FK cascades on parent delete;
+ *  - the `MappingConfigService` round-trip (upsert create → replace values →
+ *    delete) works end-to-end, including the cascade/orphan-delete child replace.
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  IMappingConfigService,
+  MAPPING_CONFIG_SERVICE_TOKEN,
+} from '@openlinker/core/mappings';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+
+const INSERT_MAPPING = `
+  INSERT INTO attribute_mappings
+    (source_connection_id, destination_connection_id, source_attribute_key,
+     destination_parameter_name, destination_category_id)
+  VALUES ($1, $2, $3, $4, $5)
+  RETURNING id
+`;
+
+const INSERT_VALUE = `
+  INSERT INTO attribute_value_mappings (attribute_mapping_id, source_value, destination_value)
+  VALUES ($1, $2, $3)
+`;
+
+describe('Attribute Mappings Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  function getService(): IMappingConfigService {
+    return harness.getApp().get<IMappingConfigService>(MAPPING_CONFIG_SERVICE_TOKEN);
+  }
+
+  async function seedDestination(): Promise<string> {
+    const conn = await createTestConnection(harness.getDataSource(), {
+      platformType: 'allegro',
+      name: 'Allegro destination',
+      adapterKey: 'allegro.publicapi.v1',
+      enabledCapabilities: ['OfferManager'],
+    });
+    return conn.id;
+  }
+
+  async function seedSource(name: string): Promise<string> {
+    const conn = await createTestConnection(harness.getDataSource(), {
+      platformType: 'prestashop',
+      name,
+      adapterKey: 'prestashop.webservice.v1',
+      enabledCapabilities: ['ProductMaster'],
+    });
+    return conn.id;
+  }
+
+  describe('partial unique indexes (NULL-distinct on destination_category_id)', () => {
+    it('rejects a duplicate connection-wide default (category NULL) for the same key', async () => {
+      const ds = harness.getDataSource();
+      const dest = await seedDestination();
+      const src = await seedSource('PS A');
+
+      await ds.query(INSERT_MAPPING, [src, dest, 'Color', 'Kolor', null]);
+      await expect(
+        ds.query(INSERT_MAPPING, [src, dest, 'Color', 'Barwa', null])
+      ).rejects.toThrow(/duplicate key|unique/i);
+    });
+
+    it('allows a per-category override alongside the connection-wide default', async () => {
+      const ds = harness.getDataSource();
+      const dest = await seedDestination();
+      const src = await seedSource('PS A');
+
+      await ds.query(INSERT_MAPPING, [src, dest, 'Color', 'Kolor', null]);
+      // Same (src, dest, key) but a category id → permitted by the per-category index.
+      await expect(
+        ds.query(INSERT_MAPPING, [src, dest, 'Color', 'Kolor', 'cat-1'])
+      ).resolves.toBeDefined();
+      // Duplicate within the same category → rejected.
+      await expect(
+        ds.query(INSERT_MAPPING, [src, dest, 'Color', 'Inny', 'cat-1'])
+      ).rejects.toThrow(/duplicate key|unique/i);
+    });
+  });
+
+  describe('value-mapping cascade', () => {
+    it('deletes child value rows when the parent mapping is deleted', async () => {
+      const ds = harness.getDataSource();
+      const dest = await seedDestination();
+      const src = await seedSource('PS A');
+
+      const [{ id }] = (await ds.query(INSERT_MAPPING, [
+        src,
+        dest,
+        'Color',
+        'Kolor',
+        null,
+      ])) as { id: string }[];
+      await ds.query(INSERT_VALUE, [id, 'Red', 'Czerwony']);
+
+      await ds.query(`DELETE FROM attribute_mappings WHERE id = $1`, [id]);
+
+      const rows = (await ds.query(
+        `SELECT 1 FROM attribute_value_mappings WHERE attribute_mapping_id = $1`,
+        [id]
+      )) as unknown[];
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe('MappingConfigService round-trip', () => {
+    it('upserts (create → replace values → delete) end-to-end', async () => {
+      const service = getService();
+      const dest = await seedDestination();
+      const src = await seedSource('PS A');
+
+      const created = await service.upsertAttributeMapping(dest, {
+        sourceConnectionId: src,
+        sourceAttributeKey: 'Color',
+        destinationParameterName: 'Kolor',
+        values: [{ sourceValue: 'Red', destinationValue: 'Czerwony' }],
+      });
+      expect(created.destinationCategoryId).toBeNull();
+      expect(created.values).toHaveLength(1);
+
+      // Re-upsert same key replaces the value set (orphan-delete) in place.
+      const updated = await service.upsertAttributeMapping(dest, {
+        sourceConnectionId: src,
+        sourceAttributeKey: 'Color',
+        destinationParameterName: 'Kolor',
+        values: [
+          { sourceValue: 'Red', destinationValue: 'Czerwony' },
+          { sourceValue: 'Blue', destinationValue: 'Niebieski' },
+        ],
+      });
+      expect(updated.id).toBe(created.id);
+      expect(updated.values).toHaveLength(2);
+
+      const all = await service.getAttributeMappings(dest);
+      expect(all).toHaveLength(1);
+      expect(all[0].values).toHaveLength(2);
+
+      await service.deleteAttributeMapping(created.id);
+      expect(await service.getAttributeMappings(dest)).toHaveLength(0);
+    });
+  });
+});

--- a/apps/api/test/integration/attribute-mappings.int-spec.ts
+++ b/apps/api/test/integration/attribute-mappings.int-spec.ts
@@ -136,6 +136,8 @@ describe('Attribute Mappings Integration', () => {
       });
       expect(created.destinationCategoryId).toBeNull();
       expect(created.values).toHaveLength(1);
+      // Upsert-return path is fully hydrated (matches the read path).
+      expect(created.values[0].attributeMappingId).toBe(created.id);
 
       // Re-upsert same key replaces the value set (orphan-delete) in place.
       const updated = await service.upsertAttributeMapping(dest, {

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-attribute-projection.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-attribute-projection.md
@@ -1,0 +1,41 @@
+# Pre-Implement Gate — Attribute projection (#1038)
+
+**Plan**: `docs/plans/implementation-plan-attribute-projection.md`
+**Date**: 2026-06-14
+**Verdict**: ✅ **READY**
+
+## Reuse audit (does it already exist?)
+
+| Plan artifact | Status | Evidence |
+|---|---|---|
+| `AttributeMapping` / `AttributeValueMapping` entities | **NEW** | no `class AttributeMapping` in `libs/core/src` |
+| `AttributeMappingOrmEntity` / `AttributeValueMappingOrmEntity` | **NEW** | no `attribute_mappings` / `attribute_value_mappings` table in any `*.orm-entity.ts` or migration |
+| `AttributeMappingRepositoryPort` + impl | **NEW** | no existing port/repo |
+| `ATTRIBUTE_MAPPING_REPOSITORY_TOKEN` | **NEW** | not in `mappings.tokens.ts` |
+| `AttributeMappingInput` | **NEW** | not in `mapping.types.ts` |
+| `getAttributeMappings`/`upsertAttributeMapping`/`deleteAttributeMapping` on `IMappingConfigService` | **PARTIAL (extend)** | interface exists with category methods; mirror them |
+| `AttributeProjectionService` + `IAttributeProjectionService` | **NEW** | no match in `libs/core/src` |
+| `ATTRIBUTE_PROJECTION_SERVICE_TOKEN` | **NEW** | not in `listings.tokens.ts` |
+| `ResolvedParameter` / `AttributeProjectionInput` / `AttributeProjectionResult` | **NEW** | not in listings types |
+
+A repo-wide grep for `AttributeProjectionService|ATTRIBUTE_*_TOKEN|attribute_mappings|class AttributeMapping|ResolvedParameter|AttributeMappingInput` across `libs/core/src` + `apps/api/src` returned **zero hits**. Greenfield confirmed.
+
+**Reuse to honour** (don't reinvent): `CategoryMapping` stack (entity/orm/repo/upsert pattern), `MappingConfigService`, `CategoryResolutionService` (sibling), `CategoryParametersReader` + `isCategoryParametersReader`, `CategoryParameter`/`CategoryParameterSection`, `IIntegrationsService.getCapabilityAdapter`.
+
+## Backward-compatibility checklist
+
+| Surface | Finding | Severity |
+|---|---|---|
+| Top-level barrels | Only **additive** exports (`AttributeMapping`, `AttributeValueMapping`, `AttributeMappingInput` on mappings; `IAttributeProjectionService` + types on listings). No removals/renames. | OK |
+| Port/interface signatures | `IMappingConfigService` gains 3 methods — sole in-repo implementor is `MappingConfigService` (updated in plan). Test mocks use partial `jest.Mocked`, unaffected. | Warning (handled) |
+| Symbol tokens | Two new tokens added via `export *` from `*.tokens.ts`; none removed. | OK |
+| ORM schema | Two new tables ⇒ migration required → `1805000000000` (origin/main tail is `1804000000000`; strictly-greater ordering #1013 satisfied). Partial unique indexes declared on the ORM entity for synchronize↔migration parity (the #1036 lesson). | Warning (handled) |
+| `check:invariants` | `listings → mappings` + `listings → integrations` cross-context edges already exist (no new edge). `AttributeProjectionService implements IAttributeProjectionService` satisfies `check-service-interfaces`. Migration-ordering guard satisfied. Keep `AttributeProjectionService` off `listings/index.ts` (only `/services`) — `barrel-purity.spec.ts` present and will catch a slip. | OK |
+
+## Open questions
+
+- **`AttributeProjectionInput` carries `sourceConnectionId`** — the plan adds it (refinement over the issue's earlier sketch) so source-scoped (B′) mappings resolve correctly. Confirmed as the right call; not a blocker.
+
+## Summary
+
+The plan is **READY** to implement. Every proposed artifact is confirmed net-new (zero collisions), the only contract changes are additive (new tables, tokens, service, and three interface methods on the single-implementor `IMappingConfigService`), the migration timestamp `1805000000000` clears the ordering invariant, and the listings barrel-purity guard is in place to keep the new service off the pure contract barrel. Mirror the category-mapping stack verbatim for storage and the `CategoryResolutionService` shape for projection. No revision needed before coding.

--- a/docs/plans/implementation-plan-attribute-projection.md
+++ b/docs/plans/implementation-plan-attribute-projection.md
@@ -1,0 +1,220 @@
+# Implementation Plan: Attribute projection service + attribute_mappings / attribute_value_mappings (#1038)
+
+**Date**: 2026-06-14
+**Status**: Ready for Review
+**Estimated Effort**: ~1 day
+**Issue**: #1038 (epic #1005, ADR-023 §3/§4/§Storage)
+
+---
+
+## 1. Task Summary
+
+**Objective**: Project a product variant's descriptive `attributes` (`Record<string,string>`, e.g. `{ Color: 'Red' }`) into a destination's neutral parameter shape (`ResolvedParameter[]`), resolving dictionary value-ids at projection time from the live category schema, with operator-authored attribute→parameter and value→value mappings persisted in two new tables.
+
+**Context**: After #1050 PrestaShop variants emit semantic attribute names, and WooCommerce already does — so attribute mapping now has a consistent input across sources. Category placement (#1037) is done; the parameter schema (`CategoryParameter`, #1035) carries `multiValue`/`dictionary`/`section`. This is the parameter-population half of cross-platform listing (ADR-023 §3/§4).
+
+**Classification**: CORE (mappings storage + listings projection) + Infrastructure (migration).
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- `mappings` context: `AttributeMapping` + `AttributeValueMapping` entities, ORM entities (with partial unique indexes), repository port + impl, `IMappingConfigService` read/write methods, token, module wiring, migration `1805000000000`.
+- `listings` context: `AttributeProjectionService` (+ interface, token, types), provenance-aware projection, module wiring.
+- Unit specs for the service + repository; int-spec for the storage round-trip + partial-index NULL-distinct semantics + value-mapping cascade.
+
+### Out of Scope (Non-Goals)
+- Wiring projection into offer creation (#1039).
+- Shop `ProductPublisher` capability handling (#1041+).
+- HTTP controller / FE authoring surface for attribute mappings — **storage + service now, cockpit later** (same Option-A deferral #1036 used for categories). No controller/DTO in this PR.
+- `CategoryResolutionResult` / placement chain (#1037, done).
+
+### Constraints
+- Greenfield tables — no data migration/backfill.
+- Migration timestamp **must be `1805000000000`** (current tail is `1804000000000`; strictly-greater ordering invariant #1013).
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: CORE (`libs/core/src/mappings` storage; `libs/core/src/listings` projection) + Infrastructure (migration in `apps/api/src/migrations`).
+
+**Capabilities Involved**: `OfferManagerPort` + `CategoryParametersReader` sub-capability (`isCategoryParametersReader` guard) to fetch the live `CategoryParameter[]` for dictionary resolution. Resolved via `IIntegrationsService.getCapabilityAdapter<OfferManagerPort>(connectionId, 'OfferManager')`.
+
+**Existing Services Reused**:
+- `IMappingConfigService` / `MappingConfigService` — extended with attribute methods (mirrors the category methods exactly).
+- `IIntegrationsService` — adapter resolution (same as `CategoryResolutionService`).
+
+**New Components**:
+- `mappings`: `AttributeMapping`, `AttributeValueMapping` (domain entities); `AttributeMappingOrmEntity`, `AttributeValueMappingOrmEntity`; `AttributeMappingRepositoryPort` + `AttributeMappingRepository`; `ATTRIBUTE_MAPPING_REPOSITORY_TOKEN`; `AttributeMappingInput` type.
+- `listings`: `IAttributeProjectionService` + `AttributeProjectionService`; `ATTRIBUTE_PROJECTION_SERVICE_TOKEN`; `attribute-projection.types.ts` (`AttributeProjectionInput`, `ResolvedParameter`, `AttributeProjectionResult`).
+
+**Core vs Integration Justification**: Both halves are platform-agnostic. Storage is operator config (mappings context owns all mapping tables). Projection consumes the neutral `CategoryParameter` contract + `OfferManagerPort` capability — no platform branching; any destination that implements `CategoryParametersReader` ("owns" its taxonomy) gets dictionary resolution, others get pass-through. Adapters are untouched.
+
+---
+
+## 4. External / Domain Research
+
+### Internal patterns (verified against current main, post #1035/#1036/#1037/#1050)
+
+**Category-mapping stack** (the storage blueprint — mirror exactly):
+- Entity `CategoryMapping` (`mappings/domain/entities/category-mapping.entity.ts`) — pure class, positional constructor.
+- ORM `category_mappings` (`mappings/infrastructure/persistence/entities/category-mapping.orm-entity.ts`) — two partial unique indexes declared **on the entity** via `@Index(name, [...cols], { unique: true, where: '"col" IS [NOT] NULL' })` (synchronize↔migration parity, the #1036 lesson).
+- Repo port `CategoryMappingRepositoryPort` (`findByDestinationConnection`, `findBySourceCategory`, `upsertMapping`, `deleteMapping`); impl uses **find-then-save** upsert with `IsNull()` for the nullable column (TypeORM `ON CONFLICT` can't target partial indexes).
+- `IMappingConfigService` category methods + `MappingConfigService` delegate-to-repo.
+- `mappings.tokens.ts` (`Symbol('…RepositoryPort')`), `mappings.module.ts` (`TypeOrmModule.forFeature`, `useExisting` token binding, export token + `MappingConfigService`), barrel re-exports tokens/entity/input-type/service-interface.
+- Migration `1804000000000-neutralise-category-mappings.ts` — partial-index DDL shape verbatim:
+  ```sql
+  CREATE UNIQUE INDEX "UQ_category_mappings_src_dest_cat"
+    ON "category_mappings" ("source_connection_id","destination_connection_id","source_category_id")
+    WHERE "source_connection_id" IS NOT NULL;
+  ```
+
+**Listings sibling** `CategoryResolutionService` (`listings/application/services/category-resolution.service.ts`):
+- `@Injectable()`, implements `ICategoryResolutionService`, `new Logger(CategoryResolutionService.name)`.
+- Ctor: `@Inject(INTEGRATIONS_SERVICE_TOKEN) IIntegrationsService`, `@Inject(MAPPING_CONFIG_SERVICE_TOKEN) IMappingConfigService` (cross-context barrel imports).
+- Resolves adapter: `await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(connectionId, 'OfferManager')`, then narrows with `is*` guards.
+- Main barrel `listings/index.ts` = **pure contracts only** (interfaces, types, tokens, guards) — service classes + `ListingsModule` live on `listings/services` sub-barrel; `barrel-purity.spec.ts` guards the split.
+
+**`CategoryParameter`** (`listings/domain/types/category-parameter.types.ts`): `{ id, name, type, required, multiValue?, unit?, dictionary?: {id,value,dependsOnValueIds?}[], restrictions, dependsOn?, section }`; `CategoryParameterSection = 'offer' | 'product'`. `CategoryParametersReader.fetchCategoryParameters({ categoryId }): Promise<CategoryParameter[]>`.
+
+**`ProductVariant.attributes`**: `Record<string, string> | null` (`products/domain/entities/product-variant.entity.ts`).
+
+---
+
+## 5. Questions & Assumptions
+
+### Resolved decisions
+- **Scope B′ (authoritative — issue body + prior claim comment)**: `attribute_mappings` carries **both** `source_connection_id` and `destination_connection_id` as **NOT NULL**, plus a **nullable** `destination_category_id` → **two** partial unique indexes (split on `destination_category_id IS NULL` / `IS NOT NULL`). No `destination_taxonomy_provenance`, no `destination_section`, no native ids stored (provenance is derived at projection time from the adapter capability, not persisted — unlike category mappings where the resolved category's provenance is a property of the row).
+
+### Assumptions (safe defaults)
+- **`AttributeProjectionInput` carries `sourceConnectionId`** (refinement over the earlier draft, which omitted it). B′ scopes mappings by source connection, so the projection must be source-aware to pick the right mapping set — otherwise two sources mapping `"Color"` differently for the same destination collide. Input: `{ sourceConnectionId, destinationConnectionId, destinationCategoryId, attributes }`.
+- **Mapping match key = `destinationParameterName` against `CategoryParameter.name`** (case-sensitive exact) in the owns path; pass-through path emits `{ id: destinationParameterName }` directly.
+- **Category precedence**: a category-specific mapping (`destinationCategoryId === input.destinationCategoryId`) wins over the connection-wide default (`destinationCategoryId IS NULL`) for the same `(sourceConnectionId, sourceAttributeKey)`.
+- **Dictionary value match**: exact, case-insensitive, against `dictionary[].value` → `{ id: param.id, valuesIds: [entry.id], section }`. No fuzzy matching.
+- **`delete` by surrogate `id`** (no HTTP consumer yet; tests/future cockpit call it).
+- **uuid PK + FK ON DELETE CASCADE** for both tables; `attribute_value_mappings.attribute_mapping_id` cascades from parent.
+
+### Documentation gaps
+- None blocking. ADR-023 §4 originally framed source-scoping as deferred; B′ (issue body) supersedes — note in the PR, no ADR change needed (B′ is *more* aligned with §4's source-scoped intent).
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1 — mappings storage (domain + persistence)
+**Goal**: Two new mapping tables + repository + service methods, mirroring the category stack.
+
+1. **Domain entities** — `mappings/domain/entities/attribute-mapping.entity.ts`, `attribute-value-mapping.entity.ts`
+   - `AttributeMapping`: `id, sourceConnectionId, destinationConnectionId, sourceAttributeKey, destinationParameterName, destinationCategoryId: string|null, values: AttributeValueMapping[]` (pure positional-ctor class; `values` defaults `[]`).
+   - `AttributeValueMapping`: `id, attributeMappingId, sourceValue, destinationValue`.
+   - **Acceptance**: pure classes, no framework imports.
+
+2. **Types** — `mappings/domain/types/mapping.types.ts` (extend)
+   - `AttributeMappingInput { sourceConnectionId: string; sourceAttributeKey: string; destinationParameterName: string; destinationCategoryId?: string | null; values?: { sourceValue: string; destinationValue: string }[] }`.
+
+3. **ORM entities** — `mappings/infrastructure/persistence/entities/attribute-mapping.orm-entity.ts`, `attribute-value-mapping.orm-entity.ts`
+   - `attribute_mappings`: columns + **two partial unique indexes** on `(source_connection_id, destination_connection_id, source_attribute_key)` `WHERE destination_category_id IS NULL` and `(…, destination_category_id)` `WHERE destination_category_id IS NOT NULL`. `@OneToMany('values', { cascade: true, orphanedRowAction: 'delete', eager: true })` to value rows — so a single `repo.save(parent-with-values)` inserts/updates/removes children atomically (no hand-rolled transaction).
+   - `attribute_value_mappings`: `@ManyToOne` back to parent, FK `attribute_mapping_id` (`onDelete: 'CASCADE'`), unique `(attribute_mapping_id, source_value)`.
+   - **Acceptance**: index `where` clauses mirror migration verbatim (synchronize parity).
+
+4. **Repository port** — `mappings/domain/ports/attribute-mapping-repository.port.ts`
+   - `findByDestinationConnection(destinationConnectionId): Promise<AttributeMapping[]>` (joins values), `upsertMapping(destinationConnectionId, input): Promise<AttributeMapping>`, `deleteMapping(id): Promise<void>`.
+
+5. **Repository impl** — `mappings/infrastructure/persistence/repositories/attribute-mapping.repository.ts`
+   - `toDomain` (parent + mapped children), find-then-save upsert keyed on `(sourceConnectionId, destinationConnectionId, sourceAttributeKey, destinationCategoryId|IsNull())`; set the parent's `values` from `input.values` and `save` — `cascade` + `orphanedRowAction: 'delete'` replaces the child set atomically (no manual delete/transaction). Convert duplicate-key `QueryFailedError` → domain error if needed.
+   - **Acceptance**: upsert create + update paths; `findByDestinationConnection` returns parents with `values` populated.
+
+6. **Service methods** — extend `IMappingConfigService` + `MappingConfigService`
+   - `getAttributeMappings(destinationConnectionId)`, `upsertAttributeMapping(destinationConnectionId, input)`, `deleteAttributeMapping(id)` → delegate to the new repo (inject `ATTRIBUTE_MAPPING_REPOSITORY_TOKEN`).
+
+7. **Token + module + barrel**
+   - `mappings.tokens.ts`: `export const ATTRIBUTE_MAPPING_REPOSITORY_TOKEN = Symbol('AttributeMappingRepositoryPort');`
+   - `mappings.module.ts`: add both ORM entities to `forFeature`, provide `AttributeMappingRepository` + `useExisting` token binding.
+   - `mappings/index.ts`: export `AttributeMapping`, `AttributeValueMapping`, `AttributeMappingInput`.
+
+8. **Migration** — `apps/api/src/migrations/1805000000000-add-attribute-mappings.ts`
+   - `up()`: `CREATE TABLE` both (mirror existing uuid-default + FK convention), two partial unique indexes, child unique + FK CASCADE. `down()`: drop in reverse.
+   - **Acceptance**: `pnpm --filter @openlinker/api migration:show` lists it; `check:invariants` migration-ordering passes (1805 > 1804).
+
+### Phase 2 — listings projection
+**Goal**: `AttributeProjectionService` producing `ResolvedParameter[]` + diagnostics.
+
+9. **Types** — `listings/application/types/attribute-projection.types.ts`
+   - `AttributeProjectionInput { sourceConnectionId; destinationConnectionId; destinationCategoryId; attributes: Record<string,string> }`.
+   - `ResolvedParameter { id: string; values?: string[]; valuesIds?: string[]; section: CategoryParameterSection }`. **`id` dual semantics** (document on the type): owns path → the live `CategoryParameter.id`; pass-through path → the `destinationParameterName` (the adapter interprets).
+   - `AttributeProjectionResult { parameters: ResolvedParameter[]; unmappedSourceKeys: string[]; unresolvedRequired: { id: string; name: string }[] }`.
+
+10. **Interface** — `listings/application/interfaces/attribute-projection.service.interface.ts`
+    - `IAttributeProjectionService { project(input: AttributeProjectionInput): Promise<AttributeProjectionResult> }`.
+
+11. **Service** — `listings/application/services/attribute-projection.service.ts`
+    - Ctor: `@Inject(INTEGRATIONS_SERVICE_TOKEN) IIntegrationsService`, `@Inject(MAPPING_CONFIG_SERVICE_TOKEN) IMappingConfigService`.
+    - Fetch mappings: `getAttributeMappings(destinationConnectionId)` → filter to `sourceConnectionId === input.sourceConnectionId` → collapse to one mapping per `sourceAttributeKey` with category-specific winning over category-NULL.
+    - Resolve adapter; **owns** (`isCategoryParametersReader`): fetch `CategoryParameter[]`; per param, find a mapping whose `destinationParameterName` matches `param.name` **trimmed + case-insensitive** and whose source attribute is present in `attributes`; map value via value mappings (fallback to raw value when unmapped); `type==='dictionary'` → **trimmed case-insensitive** `dictionary[].value` match → `{ id, valuesIds:[entry.id], section }`, else `{ id, values:[value], section }`; `required` param unresolved → `unresolvedRequired`.
+    - **not-owns** (no reader → borrows/open): pass-through — per mapped+present attribute emit `{ id: destinationParameterName, values:[mappedValue], section:'offer' }`.
+    - Source attribute present but unmapped → `unmappedSourceKeys` (+ `debug` log).
+
+12. **Token + module + barrel**
+    - `listings.tokens.ts`: `export const ATTRIBUTE_PROJECTION_SERVICE_TOKEN = Symbol('IAttributeProjectionService');`
+    - `listings.module.ts`: provide `AttributeProjectionService` + `useExisting` token binding; export token.
+    - `listings/services/index.ts`: export `AttributeProjectionService` class. `listings/index.ts`: export `IAttributeProjectionService` + the new types (contracts only — keep service class off the main barrel).
+
+### Phase 3 — tests
+13. **Unit** — `attribute-projection.service.spec.ts` (owns dictionary→valuesIds, owns free-text→values, required-unmapped→unresolvedRequired, not-owns pass-through, unmapped→unmappedSourceKeys, category-specific-over-default precedence, source-connection filtering); `attribute-mapping.repository.spec.ts` if pure-logic warrants (else covered by int-spec).
+14. **Int-spec** — `apps/api/test/integration/mappings/attribute-mappings.int-spec.ts`: partial unique indexes (NULL-distinct: same key with NULL vs a category id coexist; duplicate within same partial rejected), value-mapping cascade delete, `MappingConfigService` round-trip via real Postgres.
+
+---
+
+## 7. Alternatives Considered
+
+- **Scope A (drop `source_connection_id`)** — one nullable column, two indexes, lighter. **Rejected**: superseded by the issue body's B′; #1050 making source keys semantic doesn't remove the need to disambiguate *which* source's `"Color"` a mapping is for when multiple sources feed one destination. B′ is the correct source-scoped default and still only two indexes (category nullable, not source).
+- **Store provenance/section on the mapping row** (mirror category). **Rejected**: attribute provenance is a runtime property of the destination adapter capability (owns/borrows/open), not of the mapping; `section` comes from the live `CategoryParameter`. Persisting them would duplicate runtime truth and risk drift.
+- **`repo.upsert` (ON CONFLICT)** instead of find-then-save. **Rejected**: Postgres `ON CONFLICT` can't target a *partial* unique index cleanly with the nullable category column — same reason #1036 used find-then-save.
+
+---
+
+## 8. Validation & Risks
+
+- **Architecture**: ✅ domain pure; projection depends on `IMappingConfigService` + `IIntegrationsService` interfaces; storage in `mappings`; cross-context via top-level barrels; service implements an interface (`check-service-interfaces`).
+- **Naming**: ✅ `*.entity.ts` / `*.orm-entity.ts` / `*.repository.ts` / `*.service.ts` + `I*Service`; `ATTRIBUTE_*_TOKEN` Symbols.
+- **Risks**:
+  - *synchronize↔migration drift* — declare the partial indexes on the ORM entity (integration harness uses `synchronize`). Mitigated by mirroring the #1036 pattern + the int-spec asserting NULL-distinct.
+  - *barrel purity* — keep `AttributeProjectionService` off `listings/index.ts` (only on `/services`); `barrel-purity.spec.ts` guards.
+  - *migration ordering* — fixed `1805000000000`; re-prefix if `migration:generate` is used.
+  - *cross-context cycle* — `listings → mappings` already exists; no new cycle.
+- **Edge cases**: empty `attributes`; mapping with no value mappings (pass source value through); dictionary value not found (required→`unresolvedRequired`, optional→omit); multi-value params (v1 emits single value; `multiValue` honoured later — note, not blocking).
+- **Backward compatibility**: ✅ additive — new tables, new methods, new service; no existing contract changes.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+- **Unit**: `libs/core/src/listings/application/services/__tests__/attribute-projection.service.spec.ts` (mock `IIntegrationsService` + `IMappingConfigService`); repository pure-logic if any.
+- **Integration**: `apps/api/test/integration/mappings/attribute-mappings.int-spec.ts` (Testcontainers Postgres).
+- **Mocking**: mock ports/interfaces in unit; real DB in int-spec (never mocked).
+- **Acceptance**:
+  - [ ] Allegro-style dictionary parameter → `{ id, valuesIds }`; free-text → `{ id, values }`.
+  - [ ] Unmapped optional source key → `unmappedSourceKeys`; required unresolved → `unresolvedRequired`.
+  - [ ] not-owns destination → pass-through `{ id: destinationParameterName, values, section:'offer' }`.
+  - [ ] Two partial unique indexes enforce NULL-distinct; value-mapping FK cascades.
+  - [ ] Migration up/down verified; `pnpm lint` (incl. invariants), `pnpm type-check`, `pnpm test`, int-spec green.
+
+---
+
+## 10. Alignment Checklist
+- [x] Hexagonal architecture; CORE/Integration boundary respected
+- [x] Reuses existing patterns (category stack, CategoryResolutionService)
+- [x] Idempotency (find-then-save upsert; projection is pure/read-only)
+- [x] Error handling (domain errors from repo; capability guard for owns/not-owns)
+- [x] Testing strategy complete (unit + int-spec)
+- [x] Naming + file structure per standards
+- [x] Migration ordering (1805 > 1804)
+- [x] Execution-ready
+
+---
+
+## Related Documentation
+- [Architecture Overview](../architecture-overview.md) · [Engineering Standards](../engineering-standards.md) · [Testing Guide](../testing-guide.md) · [Migrations](../migrations.md)
+- ADR-023 (cross-platform category & attribute projection) §3/§4/§Storage

--- a/libs/core/src/listings/application/interfaces/attribute-projection.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/attribute-projection.service.interface.ts
@@ -1,0 +1,25 @@
+/**
+ * Attribute Projection Service Interface
+ *
+ * Contract for projecting a product variant's `attributes` into a destination's
+ * neutral parameter shape (#1038, ADR-023 §4). Provenance-aware: a destination
+ * that owns its taxonomy (`CategoryParametersReader`) gets dictionary value-id
+ * resolution; one that borrows/opens its taxonomy gets a name-keyed
+ * pass-through.
+ *
+ * @module libs/core/src/listings/application/interfaces
+ */
+
+import type {
+  AttributeProjectionInput,
+  AttributeProjectionResult,
+} from '../types/attribute-projection.types';
+
+export interface IAttributeProjectionService {
+  /**
+   * Project the input variant attributes into destination parameters. Pure
+   * read-only — performs no writes; surfaces unmapped / unresolved-required
+   * diagnostics for the caller (offer builder / publish gate).
+   */
+  project(input: AttributeProjectionInput): Promise<AttributeProjectionResult>;
+}

--- a/libs/core/src/listings/application/services/__tests__/attribute-projection.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/attribute-projection.service.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for AttributeProjectionService (#1038).
+ */
+import { AttributeProjectionService } from '../attribute-projection.service';
+import { AttributeMapping, AttributeValueMapping } from '@openlinker/core/mappings';
+import type { IMappingConfigService } from '@openlinker/core/mappings';
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import type { CategoryParameter } from '@openlinker/core/listings';
+
+const SRC = 'conn-source';
+const DEST = 'conn-dest';
+const CAT = 'cat-123';
+
+function mapping(
+  sourceAttributeKey: string,
+  destinationParameterName: string,
+  opts: {
+    destinationCategoryId?: string | null;
+    sourceConnectionId?: string;
+    values?: { sourceValue: string; destinationValue: string }[];
+    id?: string;
+  } = {}
+): AttributeMapping {
+  const id = opts.id ?? `m-${sourceAttributeKey}-${opts.destinationCategoryId ?? 'null'}`;
+  return new AttributeMapping(
+    id,
+    opts.sourceConnectionId ?? SRC,
+    DEST,
+    sourceAttributeKey,
+    destinationParameterName,
+    opts.destinationCategoryId ?? null,
+    (opts.values ?? []).map((v, i) => new AttributeValueMapping(`${id}-v${i}`, id, v.sourceValue, v.destinationValue))
+  );
+}
+
+function param(partial: Partial<CategoryParameter> & { id: string; name: string }): CategoryParameter {
+  return {
+    type: 'string',
+    required: false,
+    restrictions: {},
+    section: 'offer',
+    ...partial,
+  };
+}
+
+describe('AttributeProjectionService', () => {
+  let service: AttributeProjectionService;
+  let integrations: jest.Mocked<Pick<IIntegrationsService, 'getCapabilityAdapter'>>;
+  let mappingConfig: jest.Mocked<Pick<IMappingConfigService, 'getAttributeMappings'>>;
+
+  const ownsAdapter = (params: CategoryParameter[]): unknown => ({
+    updateOfferQuantity: jest.fn(),
+    fetchCategoryParameters: jest.fn().mockResolvedValue(params),
+  });
+  const passthroughAdapter = (): unknown => ({ updateOfferQuantity: jest.fn() });
+
+  function build(
+    adapter: unknown,
+    mappings: AttributeMapping[]
+  ): AttributeProjectionService {
+    integrations = {
+      getCapabilityAdapter: jest.fn().mockResolvedValue(adapter),
+    } as jest.Mocked<Pick<IIntegrationsService, 'getCapabilityAdapter'>>;
+    mappingConfig = {
+      getAttributeMappings: jest.fn().mockResolvedValue(mappings),
+    } as jest.Mocked<Pick<IMappingConfigService, 'getAttributeMappings'>>;
+    return new AttributeProjectionService(
+      integrations as unknown as IIntegrationsService,
+      mappingConfig as unknown as IMappingConfigService
+    );
+  }
+
+  const input = (attributes: Record<string, string>) => ({
+    sourceConnectionId: SRC,
+    destinationConnectionId: DEST,
+    destinationCategoryId: CAT,
+    attributes,
+  });
+
+  it('resolves a dictionary parameter to its entry id (owns)', async () => {
+    const params = [
+      param({
+        id: 'p-color',
+        name: 'Kolor',
+        type: 'dictionary',
+        required: true,
+        dictionary: [
+          { id: 'd-red', value: 'Czerwony' },
+          { id: 'd-blue', value: 'Niebieski' },
+        ],
+      }),
+    ];
+    service = build(ownsAdapter(params), [
+      mapping('Color', 'Kolor', { values: [{ sourceValue: 'Red', destinationValue: 'Czerwony' }] }),
+    ]);
+
+    const result = await service.project(input({ Color: 'Red' }));
+
+    expect(result.parameters).toEqual([
+      { id: 'p-color', valuesIds: ['d-red'], section: 'offer' },
+    ]);
+    expect(result.unresolvedRequired).toEqual([]);
+    expect(result.unmappedSourceKeys).toEqual([]);
+  });
+
+  it('emits free-text values for a non-dictionary parameter (owns)', async () => {
+    const params = [param({ id: 'p-mat', name: 'Material', type: 'string' })];
+    service = build(ownsAdapter(params), [mapping('Fabric', 'Material')]);
+
+    const result = await service.project(input({ Fabric: 'Cotton' }));
+
+    expect(result.parameters).toEqual([{ id: 'p-mat', values: ['Cotton'], section: 'offer' }]);
+  });
+
+  it('surfaces a required parameter with no mapping as unresolvedRequired', async () => {
+    const params = [param({ id: 'p-brand', name: 'Marka', required: true })];
+    service = build(ownsAdapter(params), []);
+
+    const result = await service.project(input({ Color: 'Red' }));
+
+    expect(result.unresolvedRequired).toEqual([{ id: 'p-brand', name: 'Marka' }]);
+    expect(result.parameters).toEqual([]);
+  });
+
+  it('surfaces a required dictionary param whose value is not in the dictionary', async () => {
+    const params = [
+      param({
+        id: 'p-color',
+        name: 'Kolor',
+        type: 'dictionary',
+        required: true,
+        dictionary: [{ id: 'd-red', value: 'Czerwony' }],
+      }),
+    ];
+    service = build(ownsAdapter(params), [mapping('Color', 'Kolor')]); // no value translation
+
+    const result = await service.project(input({ Color: 'Magenta' }));
+
+    expect(result.parameters).toEqual([]);
+    expect(result.unresolvedRequired).toEqual([{ id: 'p-color', name: 'Kolor' }]);
+  });
+
+  it('passes through name-keyed parameters when the destination does not own its taxonomy', async () => {
+    service = build(passthroughAdapter(), [
+      mapping('Color', 'colour', { values: [{ sourceValue: 'Red', destinationValue: 'red' }] }),
+    ]);
+
+    const result = await service.project(input({ Color: 'Red' }));
+
+    expect(result.parameters).toEqual([{ id: 'colour', values: ['red'], section: 'offer' }]);
+  });
+
+  it('reports present-but-unmapped source attributes', async () => {
+    const params = [param({ id: 'p-mat', name: 'Material' })];
+    service = build(ownsAdapter(params), [mapping('Fabric', 'Material')]);
+
+    const result = await service.project(input({ Fabric: 'Cotton', Color: 'Red' }));
+
+    expect(result.unmappedSourceKeys).toEqual(['Color']);
+  });
+
+  it('prefers a category-specific mapping over the connection-wide default', async () => {
+    const params = [param({ id: 'p-mat', name: 'Material' })];
+    service = build(ownsAdapter(params), [
+      mapping('Fabric', 'Material', { destinationCategoryId: null, values: [{ sourceValue: 'C', destinationValue: 'default' }] }),
+      mapping('Fabric', 'Material', { destinationCategoryId: CAT, values: [{ sourceValue: 'C', destinationValue: 'specific' }] }),
+    ]);
+
+    const result = await service.project(input({ Fabric: 'C' }));
+
+    expect(result.parameters).toEqual([{ id: 'p-mat', values: ['specific'], section: 'offer' }]);
+  });
+
+  it('ignores mappings belonging to a different source connection', async () => {
+    const params = [param({ id: 'p-mat', name: 'Material' })];
+    service = build(ownsAdapter(params), [
+      mapping('Fabric', 'Material', { sourceConnectionId: 'other-source' }),
+    ]);
+
+    const result = await service.project(input({ Fabric: 'Cotton' }));
+
+    expect(result.parameters).toEqual([]);
+    expect(result.unmappedSourceKeys).toEqual(['Fabric']);
+  });
+});

--- a/libs/core/src/listings/application/services/attribute-projection.service.ts
+++ b/libs/core/src/listings/application/services/attribute-projection.service.ts
@@ -1,0 +1,182 @@
+/**
+ * Attribute Projection Service
+ *
+ * Projects a product variant's descriptive `attributes` into a destination's
+ * neutral `ResolvedParameter[]` (#1038, ADR-023 §4), provenance-aware:
+ *  - **owns** (`isCategoryParametersReader`): fetch the live category schema,
+ *    match each parameter to a configured attribute mapping, resolve dictionary
+ *    values to their entry ids; required parameters that can't be populated are
+ *    surfaced in `unresolvedRequired`.
+ *  - **borrows / open** (no parameters reader): name-keyed pass-through — emit
+ *    `{ id: destinationParameterName, values, section: 'offer' }` per mapped,
+ *    present attribute for the adapter to interpret.
+ *
+ * Mappings are source-scoped; a per-category mapping overrides the
+ * connection-wide default for the same source attribute key.
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {IAttributeProjectionService}
+ */
+
+import { Injectable, Inject } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import type { OfferManagerPort, CategoryParameter } from '@openlinker/core/listings';
+import { isCategoryParametersReader } from '@openlinker/core/listings';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import {
+  IMappingConfigService,
+  MAPPING_CONFIG_SERVICE_TOKEN,
+  type AttributeMapping,
+} from '@openlinker/core/mappings';
+import type { IAttributeProjectionService } from '../interfaces/attribute-projection.service.interface';
+import type {
+  AttributeProjectionInput,
+  AttributeProjectionResult,
+  ResolvedParameter,
+} from '../types/attribute-projection.types';
+
+@Injectable()
+export class AttributeProjectionService implements IAttributeProjectionService {
+  private readonly logger = new Logger(AttributeProjectionService.name);
+
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+    @Inject(MAPPING_CONFIG_SERVICE_TOKEN)
+    private readonly mappingConfig: IMappingConfigService
+  ) {}
+
+  async project(input: AttributeProjectionInput): Promise<AttributeProjectionResult> {
+    const { sourceConnectionId, destinationConnectionId, destinationCategoryId, attributes } = input;
+
+    const all = await this.mappingConfig.getAttributeMappings(destinationConnectionId);
+    const applicable = this.selectApplicableMappings(
+      all,
+      sourceConnectionId,
+      destinationCategoryId
+    );
+
+    const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+      destinationConnectionId,
+      'OfferManager'
+    );
+
+    const parameters: ResolvedParameter[] = [];
+    const unresolvedRequired: { id: string; name: string }[] = [];
+    const usedSourceKeys = new Set<string>();
+
+    if (isCategoryParametersReader(adapter)) {
+      const params = await adapter.fetchCategoryParameters({ categoryId: destinationCategoryId });
+      for (const param of params) {
+        const mapping = this.findMappingForParameter(applicable, param.name);
+        const sourceValue = mapping ? attributes[mapping.sourceAttributeKey] : undefined;
+        if (!mapping || sourceValue === undefined || sourceValue === '') {
+          if (param.required) unresolvedRequired.push({ id: param.id, name: param.name });
+          continue;
+        }
+        usedSourceKeys.add(mapping.sourceAttributeKey);
+        const resolved = this.toResolvedParameter(param, this.mapValue(mapping, sourceValue));
+        if (resolved) {
+          parameters.push(resolved);
+        } else if (param.required) {
+          unresolvedRequired.push({ id: param.id, name: param.name });
+        }
+      }
+    } else {
+      // borrows / open — name-keyed pass-through.
+      for (const mapping of applicable.values()) {
+        const sourceValue = attributes[mapping.sourceAttributeKey];
+        if (sourceValue === undefined || sourceValue === '') continue;
+        usedSourceKeys.add(mapping.sourceAttributeKey);
+        parameters.push({
+          id: mapping.destinationParameterName,
+          values: [this.mapValue(mapping, sourceValue)],
+          section: 'offer',
+        });
+      }
+    }
+
+    const unmappedSourceKeys = Object.keys(attributes).filter((key) => {
+      const present = attributes[key] !== undefined && attributes[key] !== '';
+      if (!present || usedSourceKeys.has(key)) return false;
+      this.logger.debug(
+        `Unmapped source attribute "${key}" (destination=${destinationConnectionId}, category=${destinationCategoryId})`
+      );
+      return true;
+    });
+
+    return { parameters, unmappedSourceKeys, unresolvedRequired };
+  }
+
+  /**
+   * Source-scope the mappings and collapse to one per source attribute key,
+   * with a per-category mapping (`destinationCategoryId === category`) taking
+   * precedence over the connection-wide default (`destinationCategoryId === null`).
+   */
+  private selectApplicableMappings(
+    all: AttributeMapping[],
+    sourceConnectionId: string,
+    destinationCategoryId: string
+  ): Map<string, AttributeMapping> {
+    const byKey = new Map<string, AttributeMapping>();
+    for (const mapping of all) {
+      if (mapping.sourceConnectionId !== sourceConnectionId) continue;
+      if (
+        mapping.destinationCategoryId !== null &&
+        mapping.destinationCategoryId !== destinationCategoryId
+      ) {
+        continue;
+      }
+      const existing = byKey.get(mapping.sourceAttributeKey);
+      if (!existing) {
+        byKey.set(mapping.sourceAttributeKey, mapping);
+        continue;
+      }
+      const candidateIsSpecific = mapping.destinationCategoryId !== null;
+      const existingIsSpecific = existing.destinationCategoryId !== null;
+      if (candidateIsSpecific && !existingIsSpecific) {
+        byKey.set(mapping.sourceAttributeKey, mapping);
+      }
+    }
+    return byKey;
+  }
+
+  private findMappingForParameter(
+    applicable: Map<string, AttributeMapping>,
+    parameterName: string
+  ): AttributeMapping | undefined {
+    const target = this.normalize(parameterName);
+    for (const mapping of applicable.values()) {
+      if (this.normalize(mapping.destinationParameterName) === target) return mapping;
+    }
+    return undefined;
+  }
+
+  private mapValue(mapping: AttributeMapping, sourceValue: string): string {
+    const target = this.normalize(sourceValue);
+    const match = mapping.values.find((v) => this.normalize(v.sourceValue) === target);
+    return match ? match.destinationValue : sourceValue;
+  }
+
+  private toResolvedParameter(
+    param: CategoryParameter,
+    destinationValue: string
+  ): ResolvedParameter | null {
+    if (param.type === 'dictionary') {
+      const target = this.normalize(destinationValue);
+      const entry = (param.dictionary ?? []).find((e) => this.normalize(e.value) === target);
+      if (!entry) {
+        this.logger.debug(
+          `Dictionary value "${destinationValue}" not found for parameter "${param.name}" (id=${param.id})`
+        );
+        return null;
+      }
+      return { id: param.id, valuesIds: [entry.id], section: param.section };
+    }
+    return { id: param.id, values: [destinationValue], section: param.section };
+  }
+
+  private normalize(value: string): string {
+    return value.trim().toLowerCase();
+  }
+}

--- a/libs/core/src/listings/application/types/attribute-projection.types.ts
+++ b/libs/core/src/listings/application/types/attribute-projection.types.ts
@@ -1,0 +1,53 @@
+/**
+ * Attribute Projection Types
+ *
+ * I/O shapes for `AttributeProjectionService` (#1038, ADR-023 §4): projecting a
+ * product variant's `attributes` into a destination's neutral parameter shape,
+ * resolving dictionary value-ids from the live category schema.
+ *
+ * @module libs/core/src/listings/application/types
+ */
+
+import type { CategoryParameterSection } from '../../domain/types/category-parameter.types';
+
+/**
+ * Projection input. `sourceConnectionId` selects the source-scoped attribute
+ * mappings; `destinationCategoryId` selects the category schema (owns path) and
+ * any per-category mapping overrides.
+ */
+export interface AttributeProjectionInput {
+  sourceConnectionId: string;
+  destinationConnectionId: string;
+  destinationCategoryId: string;
+  /** The variant's descriptive attributes (e.g. `{ Color: 'Red' }`). */
+  attributes: Record<string, string>;
+}
+
+/**
+ * One projected destination parameter.
+ *
+ * `id` dual semantics: on the **owns** path it is the live `CategoryParameter.id`
+ * (the destination's parameter identifier); on the **pass-through** path it is
+ * the `destinationParameterName` (the adapter interprets, since no schema is
+ * available to resolve an id). `valuesIds` carries resolved dictionary entry ids
+ * (owns + dictionary type); `values` carries free-text / pass-through values.
+ */
+export interface ResolvedParameter {
+  id: string;
+  values?: string[];
+  valuesIds?: string[];
+  section: CategoryParameterSection;
+}
+
+/**
+ * Projection result. `parameters` are ready for the adapter to serialize;
+ * `unmappedSourceKeys` are present source attributes that didn't reach the
+ * destination (no mapping, or mapped to a parameter absent from the category);
+ * `unresolvedRequired` are required destination parameters that couldn't be
+ * populated — the publish gate (#1039) consumes these.
+ */
+export interface AttributeProjectionResult {
+  parameters: ResolvedParameter[];
+  unmappedSourceKeys: string[];
+  unresolvedRequired: { id: string; name: string }[];
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -37,6 +37,12 @@ export {
   CategoryResolutionMethodValues,
   CategoryProvenanceValues,
 } from './application/types/category-resolution.types';
+export type { IAttributeProjectionService } from './application/interfaces/attribute-projection.service.interface';
+export type {
+  AttributeProjectionInput,
+  AttributeProjectionResult,
+  ResolvedParameter,
+} from './application/types/attribute-projection.types';
 export type { IOfferLinkingService } from './application/interfaces/offer-linking.service.interface';
 export type {
   OfferLinkMethod,

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -18,6 +18,7 @@ import { OfferLinkingService } from './application/services/offer-linking.servic
 import { OfferMappingSyncService } from './application/services/offer-mapping-sync.service';
 import { OfferMappingsService } from './application/services/offer-mappings.service';
 import { CategoryResolutionService } from './application/services/category-resolution.service';
+import { AttributeProjectionService } from './application/services/attribute-projection.service';
 import { OfferMappingRepository } from './infrastructure/persistence/repositories/offer-mapping.repository';
 import { OfferCreationRecordOrmEntity } from './infrastructure/persistence/entities/offer-creation-record.orm-entity';
 import { OfferCreationRecordRepository } from './infrastructure/persistence/repositories/offer-creation-record.repository';
@@ -48,6 +49,7 @@ import {
   BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
   BULK_LISTING_PROGRESS_SERVICE_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
+  ATTRIBUTE_PROJECTION_SERVICE_TOKEN,
   OFFER_BUILDER_SERVICE_TOKEN,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
   OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
@@ -71,6 +73,7 @@ export {
   BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
   BULK_LISTING_PROGRESS_SERVICE_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
+  ATTRIBUTE_PROJECTION_SERVICE_TOKEN,
   OFFER_BUILDER_SERVICE_TOKEN,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
   OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
@@ -109,6 +112,7 @@ export {
     OfferMappingSyncService,
     OfferMappingsService,
     CategoryResolutionService,
+    AttributeProjectionService,
     OfferMappingRepository,
     OfferCreationRecordRepository,
     BulkListingBatchRepository,
@@ -159,6 +163,10 @@ export {
     {
       provide: CATEGORY_RESOLUTION_SERVICE_TOKEN,
       useExisting: CategoryResolutionService,
+    },
+    {
+      provide: ATTRIBUTE_PROJECTION_SERVICE_TOKEN,
+      useExisting: AttributeProjectionService,
     },
     {
       provide: OFFER_BUILDER_SERVICE_TOKEN,

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -4,6 +4,7 @@
  * @module libs/core/src/listings
  */
 
+export const ATTRIBUTE_PROJECTION_SERVICE_TOKEN = Symbol('IAttributeProjectionService');
 export const OFFER_LINKING_SERVICE_TOKEN = Symbol('OfferLinkingService');
 export const OFFER_MAPPING_SYNC_SERVICE_TOKEN = Symbol('OfferMappingSyncService');
 export const OFFER_MAPPINGS_SERVICE_TOKEN = Symbol('IOfferMappingsService');

--- a/libs/core/src/listings/services/index.ts
+++ b/libs/core/src/listings/services/index.ts
@@ -26,6 +26,7 @@ export { OfferLinkingService } from '../application/services/offer-linking.servi
 export { OfferMappingSyncService } from '../application/services/offer-mapping-sync.service';
 export { OfferMappingsService } from '../application/services/offer-mappings.service';
 export { CategoryResolutionService } from '../application/services/category-resolution.service';
+export { AttributeProjectionService } from '../application/services/attribute-projection.service';
 export { OfferBuilderService } from '../application/services/offer-builder.service';
 export { OfferCreationExecutionService } from '../application/services/offer-creation-execution.service';
 export { SellerPoliciesService } from '../application/services/seller-policies.service';

--- a/libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts
+++ b/libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts
@@ -13,12 +13,14 @@ import type { CarrierMapping } from '../../domain/entities/carrier-mapping.entit
 import type { PaymentMapping } from '../../domain/entities/payment-mapping.entity';
 import type { CategoryMapping } from '../../domain/entities/category-mapping.entity';
 import type { OrderStateMapping } from '../../domain/entities/order-state-mapping.entity';
+import type { AttributeMapping } from '../../domain/entities/attribute-mapping.entity';
 import type {
   StatusMappingInput,
   CarrierMappingInput,
   PaymentMappingInput,
   CategoryMappingInput,
   OrderStateMappingInput,
+  AttributeMappingInput,
 } from '../../domain/types/mapping.types';
 
 export interface IMappingConfigService {
@@ -91,4 +93,17 @@ export interface IMappingConfigService {
     destinationConnectionId: string,
     sourceCategoryId: string
   ): Promise<string | null>;
+
+  /**
+   * Attribute mappings for a destination connection (#1038, ADR-023 §4) — the
+   * full set across source connections and categories, each with its value
+   * translations. The projection service filters by source connection +
+   * category in memory.
+   */
+  getAttributeMappings(destinationConnectionId: string): Promise<AttributeMapping[]>;
+  upsertAttributeMapping(
+    destinationConnectionId: string,
+    input: AttributeMappingInput
+  ): Promise<AttributeMapping>;
+  deleteAttributeMapping(id: string): Promise<void>;
 }

--- a/libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts
+++ b/libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts
@@ -13,12 +13,14 @@ import {
   PAYMENT_MAPPING_REPOSITORY_TOKEN,
   CATEGORY_MAPPING_REPOSITORY_TOKEN,
   ORDER_STATE_MAPPING_REPOSITORY_TOKEN,
+  ATTRIBUTE_MAPPING_REPOSITORY_TOKEN,
 } from '../../../mappings.tokens';
 import type { StatusMappingRepositoryPort } from '../../../domain/ports/status-mapping-repository.port';
 import type { CarrierMappingRepositoryPort } from '../../../domain/ports/carrier-mapping-repository.port';
 import type { PaymentMappingRepositoryPort } from '../../../domain/ports/payment-mapping-repository.port';
 import type { CategoryMappingRepositoryPort } from '../../../domain/ports/category-mapping-repository.port';
 import type { OrderStateMappingRepositoryPort } from '../../../domain/ports/order-state-mapping-repository.port';
+import type { AttributeMappingRepositoryPort } from '../../../domain/ports/attribute-mapping-repository.port';
 import { StatusMapping } from '../../../domain/entities/status-mapping.entity';
 import { CarrierMapping } from '../../../domain/entities/carrier-mapping.entity';
 import { PaymentMapping } from '../../../domain/entities/payment-mapping.entity';
@@ -32,6 +34,7 @@ describe('MappingConfigService', () => {
   let paymentRepo: jest.Mocked<PaymentMappingRepositoryPort>;
   let categoryRepo: jest.Mocked<CategoryMappingRepositoryPort>;
   let orderStateRepo: jest.Mocked<OrderStateMappingRepositoryPort>;
+  let attributeRepo: jest.Mocked<AttributeMappingRepositoryPort>;
 
   const CONNECTION_ID = 'conn-uuid-1';
 
@@ -58,6 +61,11 @@ describe('MappingConfigService', () => {
       findByConnectionId: jest.fn(),
       replaceForConnection: jest.fn(),
     };
+    attributeRepo = {
+      findByDestinationConnection: jest.fn(),
+      upsertMapping: jest.fn(),
+      deleteMapping: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -67,6 +75,7 @@ describe('MappingConfigService', () => {
         { provide: PAYMENT_MAPPING_REPOSITORY_TOKEN, useValue: paymentRepo },
         { provide: CATEGORY_MAPPING_REPOSITORY_TOKEN, useValue: categoryRepo },
         { provide: ORDER_STATE_MAPPING_REPOSITORY_TOKEN, useValue: orderStateRepo },
+        { provide: ATTRIBUTE_MAPPING_REPOSITORY_TOKEN, useValue: attributeRepo },
       ],
     }).compile();
 

--- a/libs/core/src/mappings/application/services/mapping-config.service.ts
+++ b/libs/core/src/mappings/application/services/mapping-config.service.ts
@@ -17,24 +17,28 @@ import type { CarrierMapping } from '../../domain/entities/carrier-mapping.entit
 import type { PaymentMapping } from '../../domain/entities/payment-mapping.entity';
 import type { CategoryMapping } from '../../domain/entities/category-mapping.entity';
 import type { OrderStateMapping } from '../../domain/entities/order-state-mapping.entity';
+import type { AttributeMapping } from '../../domain/entities/attribute-mapping.entity';
 import type {
   StatusMappingInput,
   CarrierMappingInput,
   PaymentMappingInput,
   CategoryMappingInput,
   OrderStateMappingInput,
+  AttributeMappingInput,
 } from '../../domain/types/mapping.types';
 import { StatusMappingRepositoryPort } from '../../domain/ports/status-mapping-repository.port';
 import { CarrierMappingRepositoryPort } from '../../domain/ports/carrier-mapping-repository.port';
 import { PaymentMappingRepositoryPort } from '../../domain/ports/payment-mapping-repository.port';
 import { CategoryMappingRepositoryPort } from '../../domain/ports/category-mapping-repository.port';
 import { OrderStateMappingRepositoryPort } from '../../domain/ports/order-state-mapping-repository.port';
+import { AttributeMappingRepositoryPort } from '../../domain/ports/attribute-mapping-repository.port';
 import {
   STATUS_MAPPING_REPOSITORY_TOKEN,
   CARRIER_MAPPING_REPOSITORY_TOKEN,
   PAYMENT_MAPPING_REPOSITORY_TOKEN,
   CATEGORY_MAPPING_REPOSITORY_TOKEN,
   ORDER_STATE_MAPPING_REPOSITORY_TOKEN,
+  ATTRIBUTE_MAPPING_REPOSITORY_TOKEN,
 } from '../../mappings.tokens';
 
 @Injectable()
@@ -49,7 +53,9 @@ export class MappingConfigService implements IMappingConfigService {
     @Inject(CATEGORY_MAPPING_REPOSITORY_TOKEN)
     private readonly categoryRepo: CategoryMappingRepositoryPort,
     @Inject(ORDER_STATE_MAPPING_REPOSITORY_TOKEN)
-    private readonly orderStateRepo: OrderStateMappingRepositoryPort
+    private readonly orderStateRepo: OrderStateMappingRepositoryPort,
+    @Inject(ATTRIBUTE_MAPPING_REPOSITORY_TOKEN)
+    private readonly attributeRepo: AttributeMappingRepositoryPort
   ) {}
 
   getStatusMappings(connectionId: string): Promise<StatusMapping[]> {
@@ -149,5 +155,20 @@ export class MappingConfigService implements IMappingConfigService {
       sourceCategoryId
     );
     return mapping?.destinationCategoryId ?? null;
+  }
+
+  getAttributeMappings(destinationConnectionId: string): Promise<AttributeMapping[]> {
+    return this.attributeRepo.findByDestinationConnection(destinationConnectionId);
+  }
+
+  upsertAttributeMapping(
+    destinationConnectionId: string,
+    input: AttributeMappingInput
+  ): Promise<AttributeMapping> {
+    return this.attributeRepo.upsertMapping(destinationConnectionId, input);
+  }
+
+  deleteAttributeMapping(id: string): Promise<void> {
+    return this.attributeRepo.deleteMapping(id);
   }
 }

--- a/libs/core/src/mappings/domain/entities/attribute-mapping.entity.ts
+++ b/libs/core/src/mappings/domain/entities/attribute-mapping.entity.ts
@@ -1,0 +1,29 @@
+/**
+ * Attribute Mapping Domain Entity
+ *
+ * Source/destination-neutral mapping from a source product attribute key (e.g.
+ * `"Color"` on a PrestaShop/WooCommerce variant) to a destination parameter
+ * name (e.g. Allegro `"Kolor"`), used by attribute projection (#1038, ADR-023
+ * §4) to populate a listing's category parameters. Scoped by both connection
+ * ids; an optional `destinationCategoryId` carries a per-category override on
+ * top of the connection-wide default (`null`). Pure domain entity, no framework
+ * deps.
+ *
+ * @module libs/core/src/mappings/domain/entities
+ */
+
+import type { AttributeValueMapping } from './attribute-value-mapping.entity';
+
+export class AttributeMapping {
+  constructor(
+    public readonly id: string,
+    public readonly sourceConnectionId: string,
+    public readonly destinationConnectionId: string,
+    public readonly sourceAttributeKey: string,
+    public readonly destinationParameterName: string,
+    public readonly destinationCategoryId: string | null,
+    /** Per-value translations (e.g. `Red → Czerwony`). Empty when source and
+     * destination value vocabularies already agree. */
+    public readonly values: AttributeValueMapping[],
+  ) {}
+}

--- a/libs/core/src/mappings/domain/entities/attribute-value-mapping.entity.ts
+++ b/libs/core/src/mappings/domain/entities/attribute-value-mapping.entity.ts
@@ -1,0 +1,18 @@
+/**
+ * Attribute Value Mapping Domain Entity
+ *
+ * A single source-value → destination-value translation belonging to an
+ * {@link AttributeMapping} (e.g. `Red → Czerwony`). Pure domain entity, no
+ * framework deps (#1038, ADR-023 §4).
+ *
+ * @module libs/core/src/mappings/domain/entities
+ */
+
+export class AttributeValueMapping {
+  constructor(
+    public readonly id: string,
+    public readonly attributeMappingId: string,
+    public readonly sourceValue: string,
+    public readonly destinationValue: string,
+  ) {}
+}

--- a/libs/core/src/mappings/domain/ports/attribute-mapping-repository.port.ts
+++ b/libs/core/src/mappings/domain/ports/attribute-mapping-repository.port.ts
@@ -1,0 +1,31 @@
+/**
+ * Attribute Mapping Repository Port
+ *
+ * Persistence contract for attribute-mapping operations (#1038, ADR-023 §4).
+ * Per-row upsert + delete, keyed on
+ * (sourceConnectionId, destinationConnectionId, sourceAttributeKey,
+ * destinationCategoryId). The aggregate includes its value translations.
+ *
+ * @module libs/core/src/mappings/domain/ports
+ */
+
+import type { AttributeMapping } from '../entities/attribute-mapping.entity';
+import type { AttributeMappingInput } from '../types/mapping.types';
+
+export interface AttributeMappingRepositoryPort {
+  /** All attribute mappings (with their value translations) for a destination connection. */
+  findByDestinationConnection(destinationConnectionId: string): Promise<AttributeMapping[]>;
+
+  /**
+   * Create or update one attribute mapping (and replace its value set), keyed on
+   * (sourceConnectionId, destinationConnectionId, sourceAttributeKey,
+   * destinationCategoryId — `null` ⇒ the connection-wide default row).
+   */
+  upsertMapping(
+    destinationConnectionId: string,
+    input: AttributeMappingInput
+  ): Promise<AttributeMapping>;
+
+  /** Delete a mapping by surrogate id (value rows cascade). */
+  deleteMapping(id: string): Promise<void>;
+}

--- a/libs/core/src/mappings/domain/types/mapping.types.ts
+++ b/libs/core/src/mappings/domain/types/mapping.types.ts
@@ -51,3 +51,20 @@ export interface CategoryMappingInput {
    */
   destinationTaxonomyProvenance?: string;
 }
+
+/**
+ * Upsert input for an attribute mapping (#1038, ADR-023 §4). Maps a source
+ * attribute key to a destination parameter name, scoped by source connection
+ * with an optional per-category override (`destinationCategoryId` null ⇒
+ * connection-wide default). `values` carries the per-value translations and
+ * **replaces** the existing set on each upsert.
+ */
+export interface AttributeMappingInput {
+  sourceConnectionId: string;
+  sourceAttributeKey: string;
+  destinationParameterName: string;
+  /** Per-category override; `null`/omitted ⇒ the connection-wide default row. */
+  destinationCategoryId?: string | null;
+  /** Source→destination value translations (e.g. `Red → Czerwony`). */
+  values?: { sourceValue: string; destinationValue: string }[];
+}

--- a/libs/core/src/mappings/index.ts
+++ b/libs/core/src/mappings/index.ts
@@ -16,12 +16,15 @@ export { CarrierMapping } from './domain/entities/carrier-mapping.entity';
 export { PaymentMapping } from './domain/entities/payment-mapping.entity';
 export { CategoryMapping } from './domain/entities/category-mapping.entity';
 export { OrderStateMapping } from './domain/entities/order-state-mapping.entity';
+export { AttributeMapping } from './domain/entities/attribute-mapping.entity';
+export { AttributeValueMapping } from './domain/entities/attribute-value-mapping.entity';
 export type {
   StatusMappingInput,
   CarrierMappingInput,
   PaymentMappingInput,
   CategoryMappingInput,
   OrderStateMappingInput,
+  AttributeMappingInput,
 } from './domain/types/mapping.types';
 
 // Fulfillment routing (#832)

--- a/libs/core/src/mappings/infrastructure/persistence/entities/attribute-mapping.orm-entity.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/entities/attribute-mapping.orm-entity.ts
@@ -1,0 +1,73 @@
+/**
+ * Attribute Mapping ORM Entity
+ *
+ * TypeORM entity for the `attribute_mappings` table (#1038, ADR-023 §4). Maps a
+ * source attribute key to a destination parameter name, scoped by source +
+ * destination connection with an optional per-category override.
+ *
+ * Uniqueness is two partial unique indexes (NULL-distinct on the nullable
+ * `destination_category_id`) declared here AND created by the migration — the
+ * decorators keep synchronize-built schemas (integration tests) in parity with
+ * the migration-built production schema; index names match the migration.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/entities
+ */
+
+import {
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { AttributeValueMappingOrmEntity } from './attribute-value-mapping.orm-entity';
+
+@Entity('attribute_mappings')
+@Index('IX_attribute_mappings_destination', ['destinationConnectionId'])
+@Index(
+  'UQ_attribute_mappings_default',
+  ['sourceConnectionId', 'destinationConnectionId', 'sourceAttributeKey'],
+  { unique: true, where: '"destination_category_id" IS NULL' }
+)
+@Index(
+  'UQ_attribute_mappings_per_category',
+  ['sourceConnectionId', 'destinationConnectionId', 'sourceAttributeKey', 'destinationCategoryId'],
+  { unique: true, where: '"destination_category_id" IS NOT NULL' }
+)
+export class AttributeMappingOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', name: 'source_connection_id' })
+  sourceConnectionId!: string;
+
+  @Column({ type: 'uuid', name: 'destination_connection_id' })
+  destinationConnectionId!: string;
+
+  @Column({ type: 'varchar', length: 255, name: 'source_attribute_key' })
+  sourceAttributeKey!: string;
+
+  @Column({ type: 'varchar', length: 255, name: 'destination_parameter_name' })
+  destinationParameterName!: string;
+
+  @Column({ type: 'varchar', length: 100, name: 'destination_category_id', nullable: true })
+  destinationCategoryId!: string | null;
+
+  // Cascade + orphan-delete: setting `values` and saving the parent
+  // inserts/updates/removes the child set atomically (no manual transaction).
+  // Eager so reads return the full aggregate.
+  @OneToMany(() => AttributeValueMappingOrmEntity, (v) => v.attributeMapping, {
+    cascade: true,
+    orphanedRowAction: 'delete',
+    eager: true,
+  })
+  values!: AttributeValueMappingOrmEntity[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/libs/core/src/mappings/infrastructure/persistence/entities/attribute-value-mapping.orm-entity.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/entities/attribute-value-mapping.orm-entity.ts
@@ -1,0 +1,50 @@
+/**
+ * Attribute Value Mapping ORM Entity
+ *
+ * TypeORM entity for the `attribute_value_mappings` table (#1038, ADR-023 §4).
+ * A child of `attribute_mappings` carrying one source-value → destination-value
+ * translation. FK cascades on parent delete; unique per `(attribute_mapping_id,
+ * source_value)`.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/entities
+ */
+
+import {
+  Entity,
+  Index,
+  ManyToOne,
+  JoinColumn,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { AttributeMappingOrmEntity } from './attribute-mapping.orm-entity';
+
+@Entity('attribute_value_mappings')
+@Index('UQ_attribute_value_mappings_mapping_source', ['attributeMappingId', 'sourceValue'], {
+  unique: true,
+})
+export class AttributeValueMappingOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', name: 'attribute_mapping_id' })
+  attributeMappingId!: string;
+
+  @ManyToOne(() => AttributeMappingOrmEntity, (m) => m.values, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'attribute_mapping_id' })
+  attributeMapping!: AttributeMappingOrmEntity;
+
+  @Column({ type: 'varchar', length: 255, name: 'source_value' })
+  sourceValue!: string;
+
+  @Column({ type: 'varchar', length: 255, name: 'destination_value' })
+  destinationValue!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/libs/core/src/mappings/infrastructure/persistence/repositories/attribute-mapping.repository.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/repositories/attribute-mapping.repository.ts
@@ -76,7 +76,12 @@ export class AttributeMappingRepository implements AttributeMappingRepositoryPor
         return child;
       });
 
-      return em.save(entity);
+      const persisted = await em.save(entity);
+      // Re-read so the returned children are fully hydrated (scalar
+      // `attributeMappingId`, ids, timestamps) — identical to the read path.
+      // Cascade-save doesn't reliably set the child FK scalar on new in-memory
+      // rows.
+      return em.findOneOrFail(AttributeMappingOrmEntity, { where: { id: persisted.id } });
     });
     return this.toDomain(saved);
   }

--- a/libs/core/src/mappings/infrastructure/persistence/repositories/attribute-mapping.repository.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/repositories/attribute-mapping.repository.ts
@@ -1,0 +1,102 @@
+/**
+ * Attribute Mapping Repository
+ *
+ * Implements AttributeMappingRepositoryPort using TypeORM (#1038, ADR-023 §4).
+ * Upsert is find-then-save (not `repo.upsert`) because uniqueness is enforced by
+ * partial unique indexes over a nullable `destination_category_id`, which
+ * TypeORM's `ON CONFLICT` target cannot express. The value-translation children
+ * are replaced via the relation's cascade + orphan-delete on a single save.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/repositories
+ * @implements {AttributeMappingRepositoryPort}
+ */
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { AttributeMappingOrmEntity } from '../entities/attribute-mapping.orm-entity';
+import { AttributeValueMappingOrmEntity } from '../entities/attribute-value-mapping.orm-entity';
+import type { AttributeMappingRepositoryPort } from '../../../domain/ports/attribute-mapping-repository.port';
+import { AttributeMapping } from '../../../domain/entities/attribute-mapping.entity';
+import { AttributeValueMapping } from '../../../domain/entities/attribute-value-mapping.entity';
+import type { AttributeMappingInput } from '../../../domain/types/mapping.types';
+
+@Injectable()
+export class AttributeMappingRepository implements AttributeMappingRepositoryPort {
+  constructor(
+    @InjectRepository(AttributeMappingOrmEntity)
+    private readonly repo: Repository<AttributeMappingOrmEntity>
+  ) {}
+
+  async findByDestinationConnection(destinationConnectionId: string): Promise<AttributeMapping[]> {
+    const entities = await this.repo.find({
+      where: { destinationConnectionId },
+      order: { sourceAttributeKey: 'ASC', id: 'ASC' },
+    });
+    return entities.map((e) => this.toDomain(e));
+  }
+
+  async upsertMapping(
+    destinationConnectionId: string,
+    input: AttributeMappingInput
+  ): Promise<AttributeMapping> {
+    const destinationCategoryId = input.destinationCategoryId ?? null;
+    // Find-then-save in one transaction so the value-set replace (delete old +
+    // insert new) is atomic with the parent update — a partial failure must not
+    // leave a renamed parent with the wrong value rows.
+    const saved = await this.repo.manager.transaction(async (em) => {
+      const existing = await em.findOne(AttributeMappingOrmEntity, {
+        where: {
+          sourceConnectionId: input.sourceConnectionId,
+          destinationConnectionId,
+          sourceAttributeKey: input.sourceAttributeKey,
+          destinationCategoryId:
+            destinationCategoryId === null ? IsNull() : destinationCategoryId,
+        },
+      });
+
+      const entity = existing ?? em.create(AttributeMappingOrmEntity, { destinationConnectionId });
+      entity.sourceConnectionId = input.sourceConnectionId;
+      entity.sourceAttributeKey = input.sourceAttributeKey;
+      entity.destinationParameterName = input.destinationParameterName;
+      entity.destinationCategoryId = destinationCategoryId;
+
+      // Clear existing value rows up front. The relation's cascade +
+      // orphanedRowAction would otherwise re-insert the new set *before*
+      // deleting the orphans, colliding on the (attribute_mapping_id,
+      // source_value) unique index when a value (e.g. "Red") is carried across
+      // the upsert.
+      if (existing) {
+        await em.delete(AttributeValueMappingOrmEntity, { attributeMappingId: existing.id });
+      }
+      entity.values = (input.values ?? []).map((v) => {
+        const child = new AttributeValueMappingOrmEntity();
+        child.sourceValue = v.sourceValue;
+        child.destinationValue = v.destinationValue;
+        return child;
+      });
+
+      return em.save(entity);
+    });
+    return this.toDomain(saved);
+  }
+
+  async deleteMapping(id: string): Promise<void> {
+    await this.repo.delete({ id });
+  }
+
+  private toDomain(entity: AttributeMappingOrmEntity): AttributeMapping {
+    return new AttributeMapping(
+      entity.id,
+      entity.sourceConnectionId,
+      entity.destinationConnectionId,
+      entity.sourceAttributeKey,
+      entity.destinationParameterName,
+      entity.destinationCategoryId,
+      (entity.values ?? []).map(
+        (v) =>
+          new AttributeValueMapping(v.id, v.attributeMappingId, v.sourceValue, v.destinationValue)
+      )
+    );
+  }
+}

--- a/libs/core/src/mappings/mappings.module.ts
+++ b/libs/core/src/mappings/mappings.module.ts
@@ -18,12 +18,15 @@ import { StatusMappingOrmEntity } from './infrastructure/persistence/entities/st
 import { CarrierMappingOrmEntity } from './infrastructure/persistence/entities/carrier-mapping.orm-entity';
 import { PaymentMappingOrmEntity } from './infrastructure/persistence/entities/payment-mapping.orm-entity';
 import { CategoryMappingOrmEntity } from './infrastructure/persistence/entities/category-mapping.orm-entity';
+import { AttributeMappingOrmEntity } from './infrastructure/persistence/entities/attribute-mapping.orm-entity';
+import { AttributeValueMappingOrmEntity } from './infrastructure/persistence/entities/attribute-value-mapping.orm-entity';
 import { OrderStateMappingOrmEntity } from './infrastructure/persistence/entities/order-state-mapping.orm-entity';
 import { FulfillmentRoutingRuleOrmEntity } from './infrastructure/persistence/entities/fulfillment-routing-rule.orm-entity';
 import { StatusMappingRepository } from './infrastructure/persistence/repositories/status-mapping.repository';
 import { CarrierMappingRepository } from './infrastructure/persistence/repositories/carrier-mapping.repository';
 import { PaymentMappingRepository } from './infrastructure/persistence/repositories/payment-mapping.repository';
 import { CategoryMappingRepository } from './infrastructure/persistence/repositories/category-mapping.repository';
+import { AttributeMappingRepository } from './infrastructure/persistence/repositories/attribute-mapping.repository';
 import { OrderStateMappingRepository } from './infrastructure/persistence/repositories/order-state-mapping.repository';
 import { FulfillmentRoutingRepository } from './infrastructure/persistence/repositories/fulfillment-routing.repository';
 import { MappingConfigService } from './application/services/mapping-config.service';
@@ -34,6 +37,7 @@ import {
   CARRIER_MAPPING_REPOSITORY_TOKEN,
   PAYMENT_MAPPING_REPOSITORY_TOKEN,
   CATEGORY_MAPPING_REPOSITORY_TOKEN,
+  ATTRIBUTE_MAPPING_REPOSITORY_TOKEN,
   ORDER_STATE_MAPPING_REPOSITORY_TOKEN,
   FULFILLMENT_ROUTING_REPOSITORY_TOKEN,
   FULFILLMENT_ROUTING_SERVICE_TOKEN,
@@ -46,6 +50,8 @@ import {
       CarrierMappingOrmEntity,
       PaymentMappingOrmEntity,
       CategoryMappingOrmEntity,
+      AttributeMappingOrmEntity,
+      AttributeValueMappingOrmEntity,
       OrderStateMappingOrmEntity,
       FulfillmentRoutingRuleOrmEntity,
     ]),
@@ -60,6 +66,7 @@ import {
     CarrierMappingRepository,
     PaymentMappingRepository,
     CategoryMappingRepository,
+    AttributeMappingRepository,
     OrderStateMappingRepository,
     FulfillmentRoutingRepository,
     MappingConfigService,
@@ -79,6 +86,10 @@ import {
     {
       provide: CATEGORY_MAPPING_REPOSITORY_TOKEN,
       useExisting: CategoryMappingRepository,
+    },
+    {
+      provide: ATTRIBUTE_MAPPING_REPOSITORY_TOKEN,
+      useExisting: AttributeMappingRepository,
     },
     {
       provide: ORDER_STATE_MAPPING_REPOSITORY_TOKEN,

--- a/libs/core/src/mappings/mappings.tokens.ts
+++ b/libs/core/src/mappings/mappings.tokens.ts
@@ -11,6 +11,7 @@ export const STATUS_MAPPING_REPOSITORY_TOKEN = Symbol('StatusMappingRepositoryPo
 export const CARRIER_MAPPING_REPOSITORY_TOKEN = Symbol('CarrierMappingRepositoryPort');
 export const PAYMENT_MAPPING_REPOSITORY_TOKEN = Symbol('PaymentMappingRepositoryPort');
 export const CATEGORY_MAPPING_REPOSITORY_TOKEN = Symbol('CategoryMappingRepositoryPort');
+export const ATTRIBUTE_MAPPING_REPOSITORY_TOKEN = Symbol('AttributeMappingRepositoryPort');
 export const ORDER_STATE_MAPPING_REPOSITORY_TOKEN = Symbol('OrderStateMappingRepositoryPort');
 export const FULFILLMENT_ROUTING_REPOSITORY_TOKEN = Symbol('FulfillmentRoutingRepositoryPort');
 export const FULFILLMENT_ROUTING_SERVICE_TOKEN = Symbol('IFulfillmentRoutingService');

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -96,6 +96,9 @@ describe('OrderSyncService', () => {
       upsertCategoryMapping: jest.fn(),
       deleteCategoryMapping: jest.fn(),
       resolveDestinationCategory: jest.fn(),
+      getAttributeMappings: jest.fn(),
+      upsertAttributeMapping: jest.fn(),
+      deleteAttributeMapping: jest.fn(),
     } as jest.Mocked<IMappingConfigService>;
 
     syncLock = {


### PR DESCRIPTION
## What & why

Project a product variant's descriptive `attributes` (`{ Color: 'Red' }`) into a destination's neutral parameter shape, resolving dictionary value-ids from the live category schema, with operator-authored attribute→parameter and value→value mappings persisted in two new tables. The parameter-population half of cross-platform listing (epic #1005, ADR-023 §3/§4). Unblocked by #1035 (`CategoryParameter.multiValue`/dictionary), #1036 (neutral mapping stack), and #1050 (semantic PrestaShop variant attributes — merged).

Storage + service only. The HTTP/FE authoring surface and offer-creation wiring (#1039) are deferred (same Option-A precedent as #1036).

## Scope decision (B′ — per the issue body)

`attribute_mappings` carries **both** `source_connection_id` and `destination_connection_id` (NOT NULL) + a nullable `destination_category_id` → **two** partial unique indexes (NULL-distinct on the category). No provenance/section columns — attribute provenance (owns/borrows/open) is derived at projection time from the destination adapter capability, not persisted.

## mappings (storage)
- `AttributeMapping` + `AttributeValueMapping` domain entities; ORM entities with the two partial unique indexes (declared on the entity for synchronize↔migration parity) + a plain index on `destination_connection_id`; value rows FK-cascade on parent delete.
- `AttributeMappingRepositoryPort` + repo — find-then-save upsert **in a transaction**; the value set is replaced by pre-clearing children then cascade-insert (avoids TypeORM's insert-before-orphan-delete unique collision).
- `IMappingConfigService`: `getAttributeMappings` / `upsertAttributeMapping` / `deleteAttributeMapping`; `ATTRIBUTE_MAPPING_REPOSITORY_TOKEN`; module + barrel wiring. Migration `1805000000000`.

## listings (projection)
- `AttributeProjectionService` (+ `IAttributeProjectionService`, token, types). Source-scoped mappings with per-category precedence over the connection-wide default. **owns** (`isCategoryParametersReader`): resolve dictionary values → entry ids, surface required-unresolved; **borrows/open**: name-keyed pass-through; present-but-unmapped source keys reported. Parameter-name + dictionary-value matching is trimmed + case-insensitive. `AttributeProjectionInput` carries `sourceConnectionId` so projection is source-aware.

## Tests
- `AttributeProjectionService` unit spec — owns dictionary→valuesIds, owns free-text→values, required-unmapped, dictionary-miss→unresolvedRequired, pass-through, unmapped reporting, category precedence, source-connection filtering.
- `attribute-mappings.int-spec` (Testcontainers) — partial-index NULL-distinct (default vs per-category), value-mapping cascade, `MappingConfigService` round-trip incl. value-set replacement.
- Extended `mapping-config` + `order-sync` mocks for the new interface methods.

## Quality gate
`pnpm lint` (incl. all `check:invariants` — migration ordering 1805 > 1804, cross-context, service-interfaces) ✓ · `pnpm type-check` ✓ · `pnpm test` (every package) ✓ · int-spec 4/4 ✓ · `migration:show` lists `AddAttributeMappings1805000000000`.

A deep tech-review of the diff added: transactional upsert (atomicity), migration↔ORM index-type parity, and the destination-connection read index.

Closes #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)