### PR TITLE
feat(erli): connection API-key auth — config/credentials validators + tester (#982)

### DIFF
--- a/docs/plans/implementation-plan-erli-connection-auth.md
+++ b/docs/plans/implementation-plan-erli-connection-auth.md
@@ -21,7 +21,7 @@ Realises **User story 1 (Connect)** from the spec.
 - No capability adapters (offers #984 / orders #993) — `supportedCapabilities` stays `[]`.
 - No FE work (#990).
 - No migration — reuses the encrypted `integration_credentials` table.
-- No live-endpoint verification — that is the #992 sandbox spike (see Open Question O1).
+- No capability adapters — the live endpoint set for offers/orders is confirmed against the #992 sandbox spike in #984/#993. The tester's probe (`GET /me`) was itself confirmed by #992 (see Open Question O1, resolved).
 
 ---
 
@@ -34,7 +34,7 @@ All three side-registrations are wired through `createErliPlugin().register(host
 ### Connection shape
 
 - **Credentials** (`integration_credentials`, resolved via `host.credentialsResolver.get`): `{ apiKey: string }`.
-- **Config** (`connection.config`): `{ baseUrl?: string }` — optional override; defaults to the prod constant `https://erli.pl/svc/shop-api` (already the base URL the #981 client test uses). The sandbox URL (`sandbox.erli.dev`, unconfirmed pending #992) drops in via this field with no code change.
+- **Config** (`connection.config`): `{ baseUrl?: string }` — optional override; defaults to the prod constant `https://erli.pl/svc/shop-api` (already the base URL the #981 client test uses). The sandbox URL (`https://sandbox.erli.dev/svc/shop-api`, confirmed by the #992 spike) drops in via this field with no code change.
 
 ### Per-connection client seam — `ErliAdapterFactory`
 
@@ -92,5 +92,5 @@ class ErliAdapterFactory {
 
 ## 5. Open questions for the user
 
-- **O1 — probe endpoint.** The tester needs one cheap authenticated GET. The live Erli endpoint set isn't confirmed until the #992 sandbox spike. Plan: a single named constant `ERLI_CONNECTION_PROBE_PATH` (best-guess, e.g. `/offers?limit=1` per the documented offers resource) with a comment tying confirmation to #992. Unit tests mock `fetch`, so they're endpoint-agnostic; only the live test depends on the real path. **Acceptable, or hold the tester's real path until #992?**
+- **O1 — probe endpoint (RESOLVED by #992).** The tester needs one cheap authenticated GET. The #992 sandbox spike confirmed `GET /me` ("get my shop") — auth-gated (bad key → 401), no parameters, no side effects — and that the originally-assumed `/offers?limit=1` does not exist (it 404s) on the real API. `ERLI_CONNECTION_PROBE_PATH = '/me'` is the single named constant; unit tests mock `fetch`, so they're endpoint-agnostic.
 - **O2 — factory scope.** Build the lean `ErliAdapterFactory` now (honours the #981 docblocks, gives #984/#993 the seam) vs. defer it to #984 and have the tester build its client inline. Plan recommends building it now.

--- a/docs/plans/implementation-plan-erli-connection-auth.md
+++ b/docs/plans/implementation-plan-erli-connection-auth.md
@@ -1,0 +1,96 @@
+# Implementation Plan — Erli connection: API-key auth + config/credentials shape validators + tester (#982)
+
+**Issue:** #982 · **Spec:** #978 · **ADR:** ADR-025 · **Branch:** `982-erli-connection-auth-validators-tester` (stacked on `981-erli-http-client`)
+**Layer:** Integration (plugin) + a thin boundary touch (none new — API exception mapping already exists).
+**Effort:** M.
+
+---
+
+## 1. Goal (restated)
+
+Make an Erli connection **creatable, validated, and testable** end-to-end:
+
+- An operator pastes an Erli **API key** in OL Admin → connection test passes → connection shows **Active**.
+- Invalid/missing key → a clear validation error, no connection created.
+- Secrets are never returned in API responses.
+
+Realises **User story 1 (Connect)** from the spec.
+
+### Non-goals
+
+- No capability adapters (offers #984 / orders #993) — `supportedCapabilities` stays `[]`.
+- No FE work (#990).
+- No migration — reuses the encrypted `integration_credentials` table.
+- No live-endpoint verification — that is the #992 sandbox spike (see Open Question O1).
+
+---
+
+## 2. Design
+
+Erli is **dependency-light** by ADR-025 (static API key, no OAuth). Mirror the **PrestaShop** patterns (hand-rolled validators, a `ConnectionTesterPort` adapter) rather than Allegro's class-validator DTO + OAuth machinery. **No new package dependency** (no `class-validator`).
+
+All three side-registrations are wired through `createErliPlugin().register(host)` — `createNestAdapterModule` already invokes `plugin.register(host)` in `onModuleInit` (`libs/plugin-sdk/src/create-nest-adapter-module.ts:187`), so **`erli-integration.module.ts` does not change**.
+
+### Connection shape
+
+- **Credentials** (`integration_credentials`, resolved via `host.credentialsResolver.get`): `{ apiKey: string }`.
+- **Config** (`connection.config`): `{ baseUrl?: string }` — optional override; defaults to the prod constant `https://erli.pl/svc/shop-api` (already the base URL the #981 client test uses). The sandbox URL (`sandbox.erli.dev`, unconfirmed pending #992) drops in via this field with no code change.
+
+### Per-connection client seam — `ErliAdapterFactory`
+
+The #981 HttpClient docblock and interface comment already attribute an **`ErliAdapterFactory` (#982)** as the single place that builds the per-connection `ErliHttpClient`. Introduce it now (lean), so the tester and the future #984/#993 adapters share one credential/baseUrl resolution path:
+
+```
+class ErliAdapterFactory {
+  async createHttpClient(connection, credentialsResolver, retryOverride?): Promise<IErliHttpClient>
+  private async resolveCredentials(connection, credentialsResolver): Promise<ErliCredentials>
+  private resolveBaseUrl(connection): string
+}
+```
+
+- `resolveCredentials` — guards `connection.credentialsRef` present, calls `credentialsResolver.get<ErliCredentials>(ref)`, guards non-empty `apiKey`; on any miss throws `ErliApiException` (the existing exception the client already uses for pre-flight config errors — no new exception type).
+- `resolveBaseUrl` — `config.baseUrl` (if a non-empty string) else `ERLI_DEFAULT_BASE_URL`.
+- The tester passes a **no-retry** override (`maxRetries: 0`) so a probe fails fast, matching `AllegroConnectionTesterAdapter`.
+
+> The factory is **not** yet wired into `createCapabilityAdapter` (dispatch table stays empty until #984/#993). It is only the client/credential builder seam this PR's tester needs and the docblocks already promise.
+
+### Files
+
+| # | Path | Purpose |
+|---|---|---|
+| F1 | `infrastructure/adapters/erli-connection.types.ts` | `ErliCredentials`, `ErliConnectionConfig` interfaces + `ERLI_DEFAULT_BASE_URL` const. |
+| F2 | `infrastructure/adapters/erli-connection-credentials-shape-validator.adapter.ts` | `implements ConnectionCredentialsShapeValidatorPort` — require non-empty `apiKey`; throw `InvalidCredentialsShapeException`. |
+| F3 | `infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts` | `implements ConnectionConfigShapeValidatorPort` — permissive; if `baseUrl` present it must be a non-empty https URL; throw `InvalidConnectionConfigException(pluginName, FlatValidationIssue[])`. |
+| F4 | `application/erli-adapter.factory.ts` | `ErliAdapterFactory` (above). |
+| F5 | `infrastructure/adapters/erli-connection-tester.adapter.ts` | `implements ConnectionTesterPort` — build client via factory (no-retry), cheap authenticated `GET ERLI_CONNECTION_PROBE_PATH`, map result to `ConnectionTestResult`. |
+| F6 | `erli-plugin.ts` (edit) | add `register(host)` registering the two validators + tester at `erliAdapterManifest.adapterKey`. |
+| F7 | tests (5) | see §4. |
+
+`index.ts` barrel: **no change** — validators/tester/factory stay package-private (siblings keep theirs private; the public surface is `ErliIntegrationModule` + manifest + typed exceptions).
+
+---
+
+## 3. Cross-context contract compliance
+
+- Imports from `@openlinker/core/integrations` only: `ConnectionConfigShapeValidatorPort`, `ConnectionCredentialsShapeValidatorPort`, `ConnectionTesterPort`, `ConnectionTestResult`, `CredentialsResolverPort`, `InvalidConnectionConfigException`, `InvalidCredentialsShapeException`, `FlatValidationIssue` — all top-level-barrel ports/types/exceptions (allowed shapes).
+- `Connection` from `@openlinker/core/identifier-mapping` (entity, allowed).
+- `HostServices` / `AdapterPlugin` from `@openlinker/plugin-sdk`.
+- `Logger` from `@openlinker/shared/logging`.
+- No `orm-entities`, no deep paths, no `any`. Tester catches typed Erli exceptions, never TypeORM errors.
+
+---
+
+## 4. Tests (unit; `pnpm --filter @openlinker/integrations-erli test`)
+
+- **T1** `erli-connection-credentials-shape-validator.adapter.spec.ts` — resolves for `{apiKey:'k'}`; rejects with `InvalidCredentialsShapeException` for missing / empty / non-string `apiKey`.
+- **T2** `erli-connection-config-shape-validator.adapter.spec.ts` — resolves for `{}` and `{baseUrl:'https://x'}`; rejects (`InvalidConnectionConfigException`, issues carry `path`/`message`) for non-string / http / malformed `baseUrl`.
+- **T3** `erli-adapter.factory.spec.ts` — `createHttpClient` resolves creds + default/override baseUrl, builds a client; throws `ErliApiException` on missing `credentialsRef` / empty `apiKey`. Uses `InMemoryCredentialsResolverAdapter` from `@openlinker/core/integrations/testing`.
+- **T4** `erli-connection-tester.adapter.spec.ts` — mock global `fetch`: 2xx → `{success:true, status, latencyMs}`; 401 → `{success:false}` with auth message; network throw → `{success:false}`. Seeds creds via `InMemoryCredentialsResolverAdapter`.
+- **T5** `erli-plugin.spec.ts` (edit) — replace the "register is undefined" assertion (lines 64-67) + the bare `host` stub (lines 29-31) with a `makeHostStub()` (jest.fn registries); assert `register(host)` calls all three registries with `erli.shopapi.v1` and an object exposing the right method (`validate` / `test`).
+
+---
+
+## 5. Open questions for the user
+
+- **O1 — probe endpoint.** The tester needs one cheap authenticated GET. The live Erli endpoint set isn't confirmed until the #992 sandbox spike. Plan: a single named constant `ERLI_CONNECTION_PROBE_PATH` (best-guess, e.g. `/offers?limit=1` per the documented offers resource) with a comment tying confirmation to #992. Unit tests mock `fetch`, so they're endpoint-agnostic; only the live test depends on the real path. **Acceptable, or hold the tester's real path until #992?**
+- **O2 — factory scope.** Build the lean `ErliAdapterFactory` now (honours the #981 docblocks, gives #984/#993 the seam) vs. defer it to #984 and have the tester build its client inline. Plan recommends building it now.

--- a/docs/plans/implementation-plan-erli-connection-auth.md
+++ b/docs/plans/implementation-plan-erli-connection-auth.md
@@ -49,7 +49,7 @@ class ErliAdapterFactory {
 ```
 
 - `resolveCredentials` — guards `connection.credentialsRef` present, calls `credentialsResolver.get<ErliCredentials>(ref)`, guards non-empty `apiKey`; on any miss throws `ErliApiException` (the existing exception the client already uses for pre-flight config errors — no new exception type).
-- `resolveBaseUrl` — `config.baseUrl` (if a non-empty string) else `ERLI_DEFAULT_BASE_URL`.
+- `resolveBaseUrl` — `config.baseUrl` (if a non-empty string) else `ERLI_DEFAULT_BASE_URL`; an override is re-validated against the https + Erli-host allowlist (`isAllowedErliBaseUrl`) and a disallowed value throws `ErliConfigException` (defense-in-depth vs. the create-time validator).
 - The tester passes a **no-retry** override (`maxRetries: 0`) so a probe fails fast, matching `AllegroConnectionTesterAdapter`.
 
 > The factory is **not** yet wired into `createCapabilityAdapter` (dispatch table stays empty until #984/#993). It is only the client/credential builder seam this PR's tester needs and the docblocks already promise.
@@ -60,7 +60,7 @@ class ErliAdapterFactory {
 |---|---|---|
 | F1 | `infrastructure/adapters/erli-connection.types.ts` | `ErliCredentials`, `ErliConnectionConfig` interfaces + `ERLI_DEFAULT_BASE_URL` const. |
 | F2 | `infrastructure/adapters/erli-connection-credentials-shape-validator.adapter.ts` | `implements ConnectionCredentialsShapeValidatorPort` — require non-empty `apiKey`; throw `InvalidCredentialsShapeException`. |
-| F3 | `infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts` | `implements ConnectionConfigShapeValidatorPort` — permissive; if `baseUrl` present it must be a non-empty https URL; throw `InvalidConnectionConfigException(pluginName, FlatValidationIssue[])`. |
+| F3 | `infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts` | `implements ConnectionConfigShapeValidatorPort` — permissive; if `baseUrl` present it must be a non-empty https URL targeting an Erli-owned host (SSRF allowlist, `domain/policies/erli-base-url.policy.ts`); throw `InvalidConnectionConfigException(pluginName, FlatValidationIssue[])`. |
 | F4 | `application/erli-adapter.factory.ts` | `ErliAdapterFactory` (above). |
 | F5 | `infrastructure/adapters/erli-connection-tester.adapter.ts` | `implements ConnectionTesterPort` — build client via factory (no-retry), cheap authenticated `GET ERLI_CONNECTION_PROBE_PATH`, map result to `ConnectionTestResult`. |
 | F6 | `erli-plugin.ts` (edit) | add `register(host)` registering the two validators + tester at `erliAdapterManifest.adapterKey`. |
@@ -83,7 +83,7 @@ class ErliAdapterFactory {
 ## 4. Tests (unit; `pnpm --filter @openlinker/integrations-erli test`)
 
 - **T1** `erli-connection-credentials-shape-validator.adapter.spec.ts` — resolves for `{apiKey:'k'}`; rejects with `InvalidCredentialsShapeException` for missing / empty / non-string `apiKey`.
-- **T2** `erli-connection-config-shape-validator.adapter.spec.ts` — resolves for `{}` and `{baseUrl:'https://x'}`; rejects (`InvalidConnectionConfigException`, issues carry `path`/`message`) for non-string / http / malformed `baseUrl`.
+- **T2** `erli-connection-config-shape-validator.adapter.spec.ts` — resolves for `{}` and an https Erli host; rejects (`InvalidConnectionConfigException`, issues carry `path`/`message`) for non-string / http / malformed / off-host / look-alike-host `baseUrl`. Plus **T2b** `erli-base-url.policy.spec.ts` covering the allowlist helper directly.
 - **T3** `erli-adapter.factory.spec.ts` — `createHttpClient` resolves creds + default/override baseUrl, builds a client; throws `ErliApiException` on missing `credentialsRef` / empty `apiKey`. Uses `InMemoryCredentialsResolverAdapter` from `@openlinker/core/integrations/testing`.
 - **T4** `erli-connection-tester.adapter.spec.ts` — mock global `fetch`: 2xx → `{success:true, status, latencyMs}`; 401 → `{success:false}` with auth message; network throw → `{success:false}`. Seeds creds via `InMemoryCredentialsResolverAdapter`.
 - **T5** `erli-plugin.spec.ts` (edit) — replace the "register is undefined" assertion (lines 64-67) + the bare `host` stub (lines 29-31) with a `makeHostStub()` (jest.fn registries); assert `register(host)` calls all three registries with `erli.shopapi.v1` and an object exposing the right method (`validate` / `test`).

--- a/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
+++ b/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
@@ -26,9 +26,26 @@ const connection: Connection = {
   updatedAt: new Date(),
 };
 
-// The skeleton's factory never reads the host bag; replace with a
-// WooCommerce-style makeHostStub() when #982 adds register(host) tests.
+// The capability factory never reads the host bag; register(host) does.
 const host = {} as HostServices;
+
+/** Host stub exposing only the registries `register(host)` touches (#982). */
+function makeRegisterHost(): {
+  host: HostServices;
+  configRegistry: { register: jest.Mock };
+  credentialsRegistry: { register: jest.Mock };
+  testerRegistry: { register: jest.Mock };
+} {
+  const configRegistry = { register: jest.fn() };
+  const credentialsRegistry = { register: jest.fn() };
+  const testerRegistry = { register: jest.fn() };
+  const hostStub = {
+    connectionConfigShapeValidatorRegistry: configRegistry,
+    connectionCredentialsShapeValidatorRegistry: credentialsRegistry,
+    connectionTesterRegistry: testerRegistry,
+  } as unknown as HostServices;
+  return { host: hostStub, configRegistry, credentialsRegistry, testerRegistry };
+}
 
 describe('erliAdapterManifest', () => {
   it('should declare the erli.shopapi.v1 adapter key', () => {
@@ -61,9 +78,36 @@ describe('createErliPlugin', () => {
     expect(createErliPlugin().manifest).toBe(erliAdapterManifest);
   });
 
-  it('should not define a register hook while the skeleton has no side-registrations', () => {
-    // Side-registrations (connection tester, shape validators) arrive in #982.
-    expect(createErliPlugin().register).toBeUndefined();
+  describe('register', () => {
+    it('should register the config-shape validator at erli.shopapi.v1 (#982)', () => {
+      const { host, configRegistry } = makeRegisterHost();
+      createErliPlugin().register?.(host);
+
+      expect(configRegistry.register).toHaveBeenCalledWith(
+        'erli.shopapi.v1',
+        expect.objectContaining({ validate: expect.any(Function) }),
+      );
+    });
+
+    it('should register the credentials-shape validator at erli.shopapi.v1 (#982)', () => {
+      const { host, credentialsRegistry } = makeRegisterHost();
+      createErliPlugin().register?.(host);
+
+      expect(credentialsRegistry.register).toHaveBeenCalledWith(
+        'erli.shopapi.v1',
+        expect.objectContaining({ validate: expect.any(Function) }),
+      );
+    });
+
+    it('should register the connection tester at erli.shopapi.v1 (#982)', () => {
+      const { host, testerRegistry } = makeRegisterHost();
+      createErliPlugin().register?.(host);
+
+      expect(testerRegistry.register).toHaveBeenCalledWith(
+        'erli.shopapi.v1',
+        expect.objectContaining({ test: expect.any(Function) }),
+      );
+    });
   });
 
   describe('createCapabilityAdapter', () => {

--- a/libs/integrations/erli/src/application/__tests__/erli-adapter.factory.spec.ts
+++ b/libs/integrations/erli/src/application/__tests__/erli-adapter.factory.spec.ts
@@ -106,12 +106,25 @@ describe('ErliAdapterFactory', () => {
   });
 
   it('should throw ErliConfigException when a config.baseUrl override is not https', async () => {
-    // Defense-in-depth: the config-shape validator gates https at create/update,
-    // but a pre-existing/externally-written row could carry plain http — the
-    // factory must refuse it rather than send the bearer key over cleartext.
+    // Defense-in-depth: the config-shape validator gates the https + host
+    // allowlist at create/update, but a pre-existing/externally-written row could
+    // carry plain http — the factory must refuse it rather than send the bearer
+    // key over cleartext.
     await expect(
       factory.createHttpClient(
         connection({ config: { baseUrl: 'http://sandbox.erli.dev/svc/shop-api' } }),
+        resolverFor({ apiKey: 'k-123' }),
+      ),
+    ).rejects.toBeInstanceOf(ErliConfigException);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should throw ErliConfigException when a config.baseUrl override targets a non-Erli host (SSRF)', async () => {
+    // An https URL is not enough — the host must be Erli-owned, else a
+    // misconfigured row would ship the bearer key to an attacker-controlled host.
+    await expect(
+      factory.createHttpClient(
+        connection({ config: { baseUrl: 'https://evil.example.com/svc/shop-api' } }),
         resolverFor({ apiKey: 'k-123' }),
       ),
     ).rejects.toBeInstanceOf(ErliConfigException);

--- a/libs/integrations/erli/src/application/__tests__/erli-adapter.factory.spec.ts
+++ b/libs/integrations/erli/src/application/__tests__/erli-adapter.factory.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Erli Adapter Factory — unit tests
+ *
+ * Verifies per-connection credential + base-URL resolution and the
+ * pre-flight config guards (#982). Stubs `global.fetch` to assert the built
+ * client hits the resolved base URL with the resolved bearer key.
+ *
+ * @module libs/integrations/erli/src/application/__tests__
+ */
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { ErliConfigException } from '../../domain/exceptions/erli-config.exception';
+import { ErliAdapterFactory } from '../erli-adapter.factory';
+
+function connection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn-1',
+    platformType: 'erli',
+    name: 'Erli',
+    status: 'active',
+    config: {},
+    credentialsRef: 'ref-1',
+    enabledCapabilities: [],
+    adapterKey: 'erli.shopapi.v1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function resolverFor(credentials: unknown): CredentialsResolverPort {
+  return { get: jest.fn().mockResolvedValue(credentials) };
+}
+
+function okResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (): string | null => null },
+    text: (): Promise<string> => Promise.resolve('{}'),
+  } as unknown as Response;
+}
+
+const originalFetch = global.fetch;
+
+describe('ErliAdapterFactory', () => {
+  let factory: ErliAdapterFactory;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    factory = new ErliAdapterFactory();
+    fetchMock = jest.fn().mockResolvedValue(okResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  type FetchCall = [url: string, init: { headers: Record<string, string> }];
+  function lastCall(): FetchCall {
+    const calls = fetchMock.mock.calls as FetchCall[];
+    return calls[calls.length - 1];
+  }
+  function lastFetchUrl(): string {
+    return lastCall()[0];
+  }
+  function lastFetchHeaders(): Record<string, string> {
+    return lastCall()[1].headers;
+  }
+
+  it('should build a client targeting the default prod base URL (prefix preserved) with the resolved bearer key', async () => {
+    const client = await factory.createHttpClient(
+      connection(),
+      resolverFor({ apiKey: 'k-123' }),
+    );
+    await client.get('/probe');
+
+    expect(lastFetchUrl()).toBe('https://erli.pl/svc/shop-api/probe');
+    expect(lastFetchHeaders().Authorization).toBe('Bearer k-123');
+  });
+
+  it('should honour a config.baseUrl override', async () => {
+    const client = await factory.createHttpClient(
+      connection({ config: { baseUrl: 'https://sandbox.erli.dev/svc/shop-api' } }),
+      resolverFor({ apiKey: 'k-123' }),
+    );
+    await client.get('/probe');
+
+    expect(lastFetchUrl()).toBe('https://sandbox.erli.dev/svc/shop-api/probe');
+  });
+
+  it('should throw ErliConfigException when credentialsRef is missing', async () => {
+    await expect(
+      factory.createHttpClient(
+        connection({ credentialsRef: undefined }),
+        resolverFor({ apiKey: 'k' }),
+      ),
+    ).rejects.toBeInstanceOf(ErliConfigException);
+  });
+
+  it('should throw ErliConfigException when the resolved apiKey is empty', async () => {
+    await expect(
+      factory.createHttpClient(connection(), resolverFor({ apiKey: '  ' })),
+    ).rejects.toBeInstanceOf(ErliConfigException);
+  });
+});

--- a/libs/integrations/erli/src/application/__tests__/erli-adapter.factory.spec.ts
+++ b/libs/integrations/erli/src/application/__tests__/erli-adapter.factory.spec.ts
@@ -104,4 +104,17 @@ describe('ErliAdapterFactory', () => {
       factory.createHttpClient(connection(), resolverFor({ apiKey: '  ' })),
     ).rejects.toBeInstanceOf(ErliConfigException);
   });
+
+  it('should throw ErliConfigException when a config.baseUrl override is not https', async () => {
+    // Defense-in-depth: the config-shape validator gates https at create/update,
+    // but a pre-existing/externally-written row could carry plain http — the
+    // factory must refuse it rather than send the bearer key over cleartext.
+    await expect(
+      factory.createHttpClient(
+        connection({ config: { baseUrl: 'http://sandbox.erli.dev/svc/shop-api' } }),
+        resolverFor({ apiKey: 'k-123' }),
+      ),
+    ).rejects.toBeInstanceOf(ErliConfigException);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/libs/integrations/erli/src/application/erli-adapter.factory.ts
+++ b/libs/integrations/erli/src/application/erli-adapter.factory.ts
@@ -1,0 +1,68 @@
+/**
+ * Erli Adapter Factory
+ *
+ * Single per-connection construction seam for the Erli plugin: resolves the
+ * connection's static API key + base URL and builds a configured
+ * `ErliHttpClient`. The #982 connection tester and the future #984 (offers) /
+ * #993 (orders) capability adapters all route through here so credential and
+ * base-URL resolution lives in one place.
+ *
+ * Not `@Injectable` — a plain class; the client it builds closes over one
+ * connection's API key (ADR-025 static-key model, never a DI singleton).
+ *
+ * @module libs/integrations/erli/src/application
+ */
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { ErliConfigException } from '../domain/exceptions/erli-config.exception';
+import {
+  ERLI_DEFAULT_BASE_URL,
+  type ErliConnectionConfig,
+  type ErliCredentials,
+} from '../domain/types/erli-connection.types';
+import { ErliHttpClient } from '../infrastructure/http/erli-http-client';
+import type { IErliHttpClient } from '../infrastructure/http/erli-http-client.interface';
+import type { RetryConfig } from '../infrastructure/http/erli-http-client.types';
+
+export class ErliAdapterFactory {
+  /**
+   * Build a per-connection Erli HTTP client. Pass `retryConfig` to override the
+   * default retry budget — the connection tester passes a no-retry config so a
+   * probe fails fast.
+   */
+  async createHttpClient(
+    connection: Connection,
+    credentialsResolver: CredentialsResolverPort,
+    retryConfig?: Partial<RetryConfig>,
+  ): Promise<IErliHttpClient> {
+    const { apiKey } = await this.resolveCredentials(connection, credentialsResolver);
+    const baseUrl = this.resolveBaseUrl(connection);
+    return new ErliHttpClient(connection.id, baseUrl, apiKey, retryConfig);
+  }
+
+  private async resolveCredentials(
+    connection: Connection,
+    credentialsResolver: CredentialsResolverPort,
+  ): Promise<ErliCredentials> {
+    if (!connection.credentialsRef) {
+      throw new ErliConfigException(
+        `Erli connection ${connection.id} is missing credentialsRef`,
+        connection.id,
+      );
+    }
+    const credentials = await credentialsResolver.get<ErliCredentials>(connection.credentialsRef);
+    if (typeof credentials?.apiKey !== 'string' || credentials.apiKey.trim().length === 0) {
+      throw new ErliConfigException(
+        `Erli connection ${connection.id} credentials are missing a non-empty apiKey`,
+        connection.id,
+      );
+    }
+    return credentials;
+  }
+
+  private resolveBaseUrl(connection: Connection): string {
+    const config = (connection.config ?? {}) as ErliConnectionConfig;
+    const override = config.baseUrl?.trim();
+    return override && override.length > 0 ? override : ERLI_DEFAULT_BASE_URL;
+  }
+}

--- a/libs/integrations/erli/src/application/erli-adapter.factory.ts
+++ b/libs/integrations/erli/src/application/erli-adapter.factory.ts
@@ -64,6 +64,27 @@ export class ErliAdapterFactory implements IErliAdapterFactory {
   private resolveBaseUrl(connection: Connection): string {
     const config = (connection.config ?? {}) as ErliConnectionConfig;
     const override = config.baseUrl?.trim();
-    return override && override.length > 0 ? override : ERLI_DEFAULT_BASE_URL;
+    if (!override || override.length === 0) {
+      return ERLI_DEFAULT_BASE_URL;
+    }
+    // Defense-in-depth: the config-shape validator gates https at create/update,
+    // but a pre-existing or externally-written connection row could carry a
+    // plain-http baseUrl — which would send the bearer key over cleartext. Re-check
+    // here so the property doesn't rest solely on create-time validation (PR1057-TECH-03).
+    if (!this.isHttpsUrl(override)) {
+      throw new ErliConfigException(
+        `Erli connection ${connection.id} has a non-https baseUrl`,
+        connection.id,
+      );
+    }
+    return override;
+  }
+
+  private isHttpsUrl(value: string): boolean {
+    try {
+      return new URL(value).protocol === 'https:';
+    } catch {
+      return false;
+    }
   }
 }

--- a/libs/integrations/erli/src/application/erli-adapter.factory.ts
+++ b/libs/integrations/erli/src/application/erli-adapter.factory.ts
@@ -23,8 +23,9 @@ import {
 import { ErliHttpClient } from '../infrastructure/http/erli-http-client';
 import type { IErliHttpClient } from '../infrastructure/http/erli-http-client.interface';
 import type { RetryConfig } from '../infrastructure/http/erli-http-client.types';
+import type { IErliAdapterFactory } from './interfaces/erli-adapter.factory.interface';
 
-export class ErliAdapterFactory {
+export class ErliAdapterFactory implements IErliAdapterFactory {
   /**
    * Build a per-connection Erli HTTP client. Pass `retryConfig` to override the
    * default retry budget — the connection tester passes a no-retry config so a

--- a/libs/integrations/erli/src/application/erli-adapter.factory.ts
+++ b/libs/integrations/erli/src/application/erli-adapter.factory.ts
@@ -15,6 +15,7 @@
 import type { CredentialsResolverPort } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { ErliConfigException } from '../domain/exceptions/erli-config.exception';
+import { isAllowedErliBaseUrl } from '../domain/policies/erli-base-url.policy';
 import {
   ERLI_DEFAULT_BASE_URL,
   type ErliConnectionConfig,
@@ -67,24 +68,17 @@ export class ErliAdapterFactory implements IErliAdapterFactory {
     if (!override || override.length === 0) {
       return ERLI_DEFAULT_BASE_URL;
     }
-    // Defense-in-depth: the config-shape validator gates https at create/update,
-    // but a pre-existing or externally-written connection row could carry a
-    // plain-http baseUrl — which would send the bearer key over cleartext. Re-check
-    // here so the property doesn't rest solely on create-time validation (PR1057-TECH-03).
-    if (!this.isHttpsUrl(override)) {
+    // Defense-in-depth: the config-shape validator enforces the https + Erli-host
+    // allowlist at create/update, but a pre-existing or externally-written row
+    // could carry a plain-http or off-host baseUrl — which would send the bearer
+    // key over cleartext or to an attacker-controlled host (SSRF). Re-check here
+    // so the property doesn't rest solely on create-time validation (PR1057-TECH-03).
+    if (!isAllowedErliBaseUrl(override)) {
       throw new ErliConfigException(
-        `Erli connection ${connection.id} has a non-https baseUrl`,
+        `Erli connection ${connection.id} has a disallowed baseUrl (must be https and an Erli-owned host)`,
         connection.id,
       );
     }
     return override;
-  }
-
-  private isHttpsUrl(value: string): boolean {
-    try {
-      return new URL(value).protocol === 'https:';
-    } catch {
-      return false;
-    }
   }
 }

--- a/libs/integrations/erli/src/application/interfaces/erli-adapter.factory.interface.ts
+++ b/libs/integrations/erli/src/application/interfaces/erli-adapter.factory.interface.ts
@@ -1,0 +1,31 @@
+/**
+ * Erli Adapter Factory Interface
+ *
+ * Contract for the single per-connection construction seam of the Erli plugin:
+ * resolve a connection's static API key + base URL and build a configured
+ * `ErliHttpClient`. Mirrors the `IAllegroAdapterFactory` /
+ * `IPrestashopAdapterFactory` precedent so consumers (the #982 connection
+ * tester, the future #984 offers / #993 orders adapters) depend on the
+ * abstraction rather than the concrete factory class.
+ *
+ * @module libs/integrations/erli/src/application/interfaces
+ */
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+// eslint-disable-next-line no-restricted-imports -- local relative import is intentional here; barrel path would create a runtime cycle
+import type { IErliHttpClient } from '../../infrastructure/http/erli-http-client.interface';
+// eslint-disable-next-line no-restricted-imports -- local relative import is intentional here; barrel path would create a runtime cycle
+import type { RetryConfig } from '../../infrastructure/http/erli-http-client.types';
+
+export interface IErliAdapterFactory {
+  /**
+   * Build a per-connection Erli HTTP client. Pass `retryConfig` to override the
+   * default retry budget — the connection tester passes a no-retry config so a
+   * probe fails fast.
+   */
+  createHttpClient(
+    connection: Connection,
+    credentialsResolver: CredentialsResolverPort,
+    retryConfig?: Partial<RetryConfig>,
+  ): Promise<IErliHttpClient>;
+}

--- a/libs/integrations/erli/src/domain/policies/__tests__/erli-base-url.policy.spec.ts
+++ b/libs/integrations/erli/src/domain/policies/__tests__/erli-base-url.policy.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Erli base-URL policy — unit tests
+ *
+ * Exercises the SSRF allowlist guard directly: apex + subdomain Erli hosts pass,
+ * non-https / off-host / look-alike hosts fail. Both the config-shape validator
+ * and the adapter factory delegate here, so locking the helper locks both call
+ * sites (#982 / PR1057-SUG-02).
+ *
+ * @module libs/integrations/erli/src/domain/policies/__tests__
+ */
+import { isAllowedErliBaseUrl, isAllowedErliHost } from '../erli-base-url.policy';
+
+describe('erli-base-url.policy', () => {
+  describe('isAllowedErliHost', () => {
+    it.each(['erli.pl', 'erli.dev', 'sandbox.erli.dev', 'api.shop.erli.pl', 'ERLI.PL'])(
+      'accepts Erli-owned host %s',
+      (host) => {
+        expect(isAllowedErliHost(host)).toBe(true);
+      },
+    );
+
+    it.each(['evil.com', 'noterli.pl', 'erli.pl.evil.com', 'erlipl', 'erli.com'])(
+      'rejects non-Erli host %s',
+      (host) => {
+        expect(isAllowedErliHost(host)).toBe(false);
+      },
+    );
+  });
+
+  describe('isAllowedErliBaseUrl', () => {
+    it.each([
+      'https://erli.pl/svc/shop-api',
+      'https://sandbox.erli.dev/svc/shop-api',
+    ])('accepts https Erli URL %s', (url) => {
+      expect(isAllowedErliBaseUrl(url)).toBe(true);
+    });
+
+    it.each([
+      'http://erli.pl/svc/shop-api', // not https
+      'https://evil.example.com/svc', // off-host
+      'https://erli.pl.evil.com/svc', // look-alike
+      'not-a-url', // unparseable
+      'ftp://erli.pl', // wrong protocol
+    ])('rejects %s', (url) => {
+      expect(isAllowedErliBaseUrl(url)).toBe(false);
+    });
+  });
+});

--- a/libs/integrations/erli/src/domain/policies/erli-base-url.policy.ts
+++ b/libs/integrations/erli/src/domain/policies/erli-base-url.policy.ts
@@ -1,0 +1,46 @@
+/**
+ * Erli base-URL policy
+ *
+ * SSRF guard for the operator-set `connection.config.baseUrl` override. The base
+ * URL becomes a server-side authenticated GET carrying the static API key, so an
+ * arbitrary host would let a misconfigured/compromised connection exfiltrate the
+ * bearer key. The override must therefore be https AND target an Erli-owned host.
+ *
+ * The confirmed host set (prod `erli.pl`, sandbox `sandbox.erli.dev`, both #992)
+ * lives here as the single source of truth shared by the create/update validator
+ * and the per-connection factory (defense-in-depth). A `null` connection.config
+ * (no override) is unaffected — the default prod base URL is used.
+ *
+ * @module libs/integrations/erli/src/domain/policies
+ */
+
+/** Apex Erli hosts; a base-URL host must equal one of these or be a subdomain of it. */
+export const ERLI_ALLOWED_BASE_URL_HOSTS = ['erli.pl', 'erli.dev'] as const;
+
+/**
+ * True when `host` is an Erli-owned host — exactly an apex host or a subdomain of
+ * one. The leading-dot suffix check prevents look-alikes (`noterli.pl`,
+ * `erli.pl.evil.com`) from slipping through.
+ */
+export function isAllowedErliHost(host: string): boolean {
+  const normalized = host.toLowerCase();
+  return ERLI_ALLOWED_BASE_URL_HOSTS.some(
+    (allowed) => normalized === allowed || normalized.endsWith(`.${allowed}`),
+  );
+}
+
+/**
+ * True when `value` is a syntactically valid, https, Erli-owned base URL. The
+ * single guard both the config-shape validator and the adapter factory call so
+ * the SSRF/cleartext property can't drift between the create-time gate and the
+ * per-connection construction seam.
+ */
+export function isAllowedErliBaseUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  return url.protocol === 'https:' && isAllowedErliHost(url.hostname);
+}

--- a/libs/integrations/erli/src/domain/types/erli-connection.types.ts
+++ b/libs/integrations/erli/src/domain/types/erli-connection.types.ts
@@ -34,6 +34,7 @@ export interface ErliConnectionConfig {
  * The base carries a path prefix (`/svc/shop-api`). The #981 client normalizes
  * the base to a trailing slash and strips leading slashes from request paths,
  * so the prefix survives the `new URL(path, base)` join and an absolute path
- * cannot escape the configured origin.
+ * cannot escape the configured origin. The host itself is constrained to the
+ * Erli allowlist — see `domain/policies/erli-base-url.policy.ts`.
  */
 export const ERLI_DEFAULT_BASE_URL = 'https://erli.pl/svc/shop-api';

--- a/libs/integrations/erli/src/domain/types/erli-connection.types.ts
+++ b/libs/integrations/erli/src/domain/types/erli-connection.types.ts
@@ -1,0 +1,39 @@
+/**
+ * Erli Connection Types
+ *
+ * Credential + config shapes for an Erli connection, plus the default Shop API
+ * base URL. Erli auth is a single static bearer API key (ADR-025) — no OAuth,
+ * no refresh — so credentials carry only `apiKey`. The base URL is an optional
+ * config override: the sandbox host (unconfirmed until the #992 spike) drops in
+ * via `connection.config.baseUrl` with no code change.
+ *
+ * Lives in `domain/types/` (not infrastructure) so the application-layer
+ * factory can depend on it without inverting the hexagonal layer direction —
+ * mirrors the Allegro/PrestaShop connection-type layout.
+ *
+ * @module libs/integrations/erli/src/domain/types
+ */
+
+/** Encrypted credentials for an Erli connection (resolved via host.credentialsResolver). */
+export interface ErliCredentials {
+  apiKey: string;
+}
+
+/** Non-secret per-connection config stored on `connection.config`. */
+export interface ErliConnectionConfig {
+  /** Optional Shop API base URL override; defaults to {@link ERLI_DEFAULT_BASE_URL}. */
+  baseUrl?: string;
+}
+
+/**
+ * Production Erli Shop API base URL (https://erli.pl/svc/shop-api/doc/). The
+ * sandbox host (pending the #992 verification spike) overrides this through
+ * `connection.config.baseUrl`.
+ *
+ * The base carries a path prefix (`/svc/shop-api`). The #981 client normalizes
+ * the base to a trailing slash and strips leading slashes from request paths,
+ * so the prefix survives the `new URL(path, base)` join and an absolute path
+ * cannot escape the configured origin. Adapters (#984/#993) still confirm the
+ * concrete endpoint set against the #992 spike.
+ */
+export const ERLI_DEFAULT_BASE_URL = 'https://erli.pl/svc/shop-api';

--- a/libs/integrations/erli/src/domain/types/erli-connection.types.ts
+++ b/libs/integrations/erli/src/domain/types/erli-connection.types.ts
@@ -4,8 +4,9 @@
  * Credential + config shapes for an Erli connection, plus the default Shop API
  * base URL. Erli auth is a single static bearer API key (ADR-025) — no OAuth,
  * no refresh — so credentials carry only `apiKey`. The base URL is an optional
- * config override: the sandbox host (unconfirmed until the #992 spike) drops in
- * via `connection.config.baseUrl` with no code change.
+ * config override: the sandbox host (`https://sandbox.erli.dev/svc/shop-api`,
+ * confirmed by the #992 spike) drops in via `connection.config.baseUrl` with no
+ * code change.
  *
  * Lives in `domain/types/` (not infrastructure) so the application-layer
  * factory can depend on it without inverting the hexagonal layer direction —
@@ -27,13 +28,12 @@ export interface ErliConnectionConfig {
 
 /**
  * Production Erli Shop API base URL (https://erli.pl/svc/shop-api/doc/). The
- * sandbox host (pending the #992 verification spike) overrides this through
- * `connection.config.baseUrl`.
+ * sandbox host (`https://sandbox.erli.dev/svc/shop-api`, confirmed by the #992
+ * spike) overrides this through `connection.config.baseUrl`.
  *
  * The base carries a path prefix (`/svc/shop-api`). The #981 client normalizes
  * the base to a trailing slash and strips leading slashes from request paths,
  * so the prefix survives the `new URL(path, base)` join and an absolute path
- * cannot escape the configured origin. Adapters (#984/#993) still confirm the
- * concrete endpoint set against the #992 spike.
+ * cannot escape the configured origin.
  */
 export const ERLI_DEFAULT_BASE_URL = 'https://erli.pl/svc/shop-api';

--- a/libs/integrations/erli/src/erli-plugin.ts
+++ b/libs/integrations/erli/src/erli-plugin.ts
@@ -11,7 +11,8 @@
  * capability enumeration for every platform. #993 adds `'OrderSource'` and
  * #984 adds `'OfferManager'` together with the adapters that deliver them
  * (the platform-level capability roadmap lives in the #978 spec and ADR-025).
- * Side-registrations (connection tester, shape validators) arrive with #982.
+ * Side-registrations (connection tester + config/credentials shape validators)
+ * land here in `register(host)` (#982); `createNestAdapterModule` invokes it.
  *
  * Erli needs no plugin-specific NestJS providers, so the host wires it via
  * `createNestAdapterModule` — see `erli-integration.module.ts`.
@@ -22,6 +23,9 @@
 import { dispatchCapability, type AdapterPlugin, type HostServices } from '@openlinker/plugin-sdk';
 import type { AdapterMetadata } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
+import { ErliConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/erli-connection-config-shape-validator.adapter';
+import { ErliConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/erli-connection-credentials-shape-validator.adapter';
+import { ErliConnectionTesterAdapter } from './infrastructure/adapters/erli-connection-tester.adapter';
 
 /** Human-readable plugin identifier surfaced in dispatch errors (#573). */
 const ERLI_BRAND = 'Erli';
@@ -52,6 +56,19 @@ export const erliAdapterManifest: AdapterMetadata = {
 export function createErliPlugin(): AdapterPlugin {
   return {
     manifest: erliAdapterManifest,
+
+    register(host: HostServices): void {
+      const adapterKey = erliAdapterManifest.adapterKey;
+      host.connectionConfigShapeValidatorRegistry.register(
+        adapterKey,
+        new ErliConnectionConfigShapeValidatorAdapter(ERLI_BRAND),
+      );
+      host.connectionCredentialsShapeValidatorRegistry.register(
+        adapterKey,
+        new ErliConnectionCredentialsShapeValidatorAdapter(ERLI_BRAND),
+      );
+      host.connectionTesterRegistry.register(adapterKey, new ErliConnectionTesterAdapter());
+    },
 
     createCapabilityAdapter<T>(
       _connection: Connection,

--- a/libs/integrations/erli/src/index.ts
+++ b/libs/integrations/erli/src/index.ts
@@ -17,6 +17,10 @@ export { erliAdapterManifest, createErliPlugin } from './erli-plugin';
 // Host wiring
 export { ErliIntegrationModule } from './erli-integration.module';
 
+// Per-connection construction-seam contract (#982) — mirrors
+// IAllegroAdapterFactory / IPrestashopAdapterFactory.
+export type { IErliAdapterFactory } from './application/interfaces/erli-adapter.factory.interface';
+
 // HTTP-client domain exceptions (#981). The client + interface stay
 // package-private (siblings keep theirs private too); these typed exceptions
 // are the public surface — they feed the host RetryClassifier /

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-config-shape-validator.adapter.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * Erli Connection Config Shape Validator — unit tests
+ *
+ * Verifies the permissive config check (empty config valid; optional `baseUrl`
+ * must be a non-empty https URL when present) and the flat-issue rejection
+ * payload (#982).
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
+ */
+import { InvalidConnectionConfigException } from '@openlinker/core/integrations';
+import { ErliConnectionConfigShapeValidatorAdapter } from '../erli-connection-config-shape-validator.adapter';
+
+describe('ErliConnectionConfigShapeValidatorAdapter', () => {
+  const validator = new ErliConnectionConfigShapeValidatorAdapter();
+
+  it('should resolve for an empty config (no required fields)', async () => {
+    await expect(validator.validate({})).resolves.toBeUndefined();
+  });
+
+  it('should resolve when baseUrl is a valid https URL', async () => {
+    await expect(
+      validator.validate({ baseUrl: 'https://sandbox.erli.dev/svc/shop-api' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should reject when baseUrl is a non-https URL', async () => {
+    await expect(validator.validate({ baseUrl: 'http://erli.pl/svc' })).rejects.toBeInstanceOf(
+      InvalidConnectionConfigException,
+    );
+  });
+
+  it('should reject when baseUrl is not a valid URL', async () => {
+    await expect(validator.validate({ baseUrl: 'not-a-url' })).rejects.toBeInstanceOf(
+      InvalidConnectionConfigException,
+    );
+  });
+
+  it('should reject when baseUrl is an empty string', async () => {
+    await expect(validator.validate({ baseUrl: '' })).rejects.toBeInstanceOf(
+      InvalidConnectionConfigException,
+    );
+  });
+
+  it('should carry a flat { path, message } issue for baseUrl', async () => {
+    await expect(validator.validate({ baseUrl: 'not-a-url' })).rejects.toMatchObject({
+      pluginName: 'Erli',
+      errors: [{ path: 'baseUrl', message: expect.any(String) }],
+    });
+  });
+});

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-config-shape-validator.adapter.spec.ts
@@ -29,6 +29,24 @@ describe('ErliConnectionConfigShapeValidatorAdapter', () => {
     );
   });
 
+  it('should resolve when baseUrl is the apex prod host', async () => {
+    await expect(validator.validate({ baseUrl: 'https://erli.pl/svc/shop-api' })).resolves.toBeUndefined();
+  });
+
+  it('should reject an https URL whose host is not Erli-owned (SSRF guard)', async () => {
+    await expect(validator.validate({ baseUrl: 'https://evil.example.com/svc' })).rejects.toMatchObject({
+      errors: [{ path: 'baseUrl', message: expect.stringContaining('host must be') }],
+    });
+  });
+
+  it('should reject a look-alike host that merely ends with the apex string', async () => {
+    // `noterli.pl` is NOT a subdomain of `erli.pl` — the leading-dot suffix
+    // check must reject it rather than match on a bare endsWith.
+    await expect(validator.validate({ baseUrl: 'https://noterli.pl/svc' })).rejects.toBeInstanceOf(
+      InvalidConnectionConfigException,
+    );
+  });
+
   it('should reject when baseUrl is not a valid URL', async () => {
     await expect(validator.validate({ baseUrl: 'not-a-url' })).rejects.toBeInstanceOf(
       InvalidConnectionConfigException,

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-credentials-shape-validator.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-credentials-shape-validator.adapter.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Erli Connection Credentials Shape Validator — unit tests
+ *
+ * Verifies the single-field `apiKey` shape check and the
+ * `InvalidCredentialsShapeException` rejection path (#982).
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
+ */
+import { InvalidCredentialsShapeException } from '@openlinker/core/integrations';
+import { ErliConnectionCredentialsShapeValidatorAdapter } from '../erli-connection-credentials-shape-validator.adapter';
+
+describe('ErliConnectionCredentialsShapeValidatorAdapter', () => {
+  const validator = new ErliConnectionCredentialsShapeValidatorAdapter();
+
+  it('should resolve when a non-empty apiKey string is present', async () => {
+    await expect(validator.validate({ apiKey: 'secret-key' })).resolves.toBeUndefined();
+  });
+
+  it('should reject when apiKey is missing', async () => {
+    await expect(validator.validate({})).rejects.toBeInstanceOf(InvalidCredentialsShapeException);
+  });
+
+  it('should reject when apiKey is an empty/whitespace string', async () => {
+    await expect(validator.validate({ apiKey: '   ' })).rejects.toBeInstanceOf(
+      InvalidCredentialsShapeException,
+    );
+  });
+
+  it('should reject when apiKey is not a string', async () => {
+    await expect(validator.validate({ apiKey: 123 })).rejects.toBeInstanceOf(
+      InvalidCredentialsShapeException,
+    );
+  });
+
+  it('should carry the plugin name in the rejection', async () => {
+    await expect(validator.validate({})).rejects.toMatchObject({ pluginName: 'Erli' });
+  });
+});

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
@@ -84,6 +84,24 @@ describe('ErliConnectionTesterAdapter', () => {
     expect(result.message).toContain('Erli network error');
   });
 
+  it('should collapse an unrecognized error to a fixed message (no detail leak)', async () => {
+    // A non-Erli error must NOT have its raw message surfaced in the result —
+    // only recognized Erli exceptions carry bounded, bearer-safe messages.
+    const leakyFactory = {
+      createHttpClient: jest
+        .fn()
+        .mockRejectedValue(new Error('connect ECONNREFUSED https://internal.host/secret-path')),
+    } as unknown as ConstructorParameters<typeof ErliConnectionTesterAdapter>[0];
+    const leakyTester = new ErliConnectionTesterAdapter(leakyFactory);
+
+    const result = await leakyTester.test(connection(), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBeUndefined();
+    expect(result.message).toBe('Erli probe failed');
+    expect(result.message).not.toContain('internal.host');
+  });
+
   it('should return a failure (not throw) when credential resolution fails', async () => {
     // No HTTP call is made — the factory throws ErliConfigException before the
     // probe; the tester must still return a structured failure, never throw.

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
@@ -61,7 +61,7 @@ describe('ErliConnectionTesterAdapter', () => {
 
     expect(result.success).toBe(true);
     expect(result.status).toBe(200);
-    expect(result.message).toBe('OK');
+    expect(result.message).toContain('provisional');
     expect(result.latencyMs).toBeGreaterThanOrEqual(0);
   });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Erli Connection Tester — unit tests
+ *
+ * Stubs `global.fetch` to verify the probe maps a 2xx to success, a 401 to a
+ * clear auth failure, and a transport error to a failure result — never
+ * throwing (the tester always returns a `ConnectionTestResult`) (#982).
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
+ */
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { ErliConnectionTesterAdapter } from '../erli-connection-tester.adapter';
+
+function connection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn-1',
+    platformType: 'erli',
+    name: 'Erli',
+    status: 'active',
+    config: {},
+    credentialsRef: 'ref-1',
+    enabledCapabilities: [],
+    adapterKey: 'erli.shopapi.v1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+const resolver: CredentialsResolverPort = { get: jest.fn().mockResolvedValue({ apiKey: 'k-123' }) };
+
+function fakeResponse(ok: boolean, status: number): Response {
+  return {
+    ok,
+    status,
+    headers: { get: (): string | null => null },
+    text: (): Promise<string> => Promise.resolve(ok ? '{}' : ''),
+  } as unknown as Response;
+}
+
+const originalFetch = global.fetch;
+
+describe('ErliConnectionTesterAdapter', () => {
+  let tester: ErliConnectionTesterAdapter;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    tester = new ErliConnectionTesterAdapter();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('should return success with the probe status on a 2xx response', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(true, 200));
+
+    const result = await tester.test(connection(), resolver);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.message).toBe('OK');
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should return a failure with status 401 when the key is rejected', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(false, 401));
+
+    const result = await tester.test(connection(), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(401);
+  });
+
+  it('should return a failure (not throw) on a transport error', async () => {
+    fetchMock.mockRejectedValue(new Error('socket hang up'));
+
+    const result = await tester.test(connection(), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBeUndefined();
+    expect(result.message).toContain('Erli network error');
+  });
+
+  it('should return a failure (not throw) when credential resolution fails', async () => {
+    // No HTTP call is made — the factory throws ErliConfigException before the
+    // probe; the tester must still return a structured failure, never throw.
+    const result = await tester.test(connection({ credentialsRef: undefined }), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.message.length).toBeGreaterThan(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
@@ -74,14 +74,39 @@ describe('ErliConnectionTesterAdapter', () => {
     expect(result.status).toBe(401);
   });
 
-  it('should return a failure (not throw) on a transport error', async () => {
-    fetchMock.mockRejectedValue(new Error('socket hang up'));
+  it('should return a failure (not throw) on a transport error, collapsing the raw cause', async () => {
+    fetchMock.mockRejectedValue(new Error('connect ECONNREFUSED 10.0.0.1:443 /secret-path'));
 
     const result = await tester.test(connection(), resolver);
 
     expect(result.success).toBe(false);
     expect(result.status).toBeUndefined();
-    expect(result.message).toContain('Erli network error');
+    // Bounded fixed string — the raw undici cause (which can embed host/path)
+    // must not reach the operator-facing result (PR1057-SEC-01).
+    expect(result.message).toBe('Erli connection failed (network error)');
+    expect(result.message).not.toContain('ECONNREFUSED');
+    expect(result.message).not.toContain('secret-path');
+  });
+
+  it('should return a failure with status 403 when the key is forbidden', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(false, 403));
+
+    const result = await tester.test(connection(), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(403);
+  });
+
+  it('should surface status 429 on a rate-limit response', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(false, 429));
+
+    const result = await tester.test(connection(), resolver);
+
+    expect(result.success).toBe(false);
+    // Rate-limit carries retryAfterMs, not statusCode — the tester maps it to 429
+    // so the operator sees the real cause (PR1057-TECH-02).
+    expect(result.status).toBe(429);
+    expect(result.message).toContain('rate limit');
   });
 
   it('should collapse an unrecognized error to a fixed message (no detail leak)', async () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
@@ -9,6 +9,7 @@
  */
 import type { CredentialsResolverPort } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
+import { ErliApiException } from '../../../domain/exceptions/erli-api.exception';
 import { ErliConnectionTesterAdapter } from '../erli-connection-tester.adapter';
 
 function connection(overrides: Partial<Connection> = {}): Connection {
@@ -125,6 +126,30 @@ describe('ErliConnectionTesterAdapter', () => {
     expect(result.status).toBeUndefined();
     expect(result.message).toBe('Erli probe failed');
     expect(result.message).not.toContain('internal.host');
+  });
+
+  it('should never surface ErliApiException.responseBody in the result message', async () => {
+    // The tester surfaces `ErliApiException.message` verbatim because it is
+    // bounded and bearer-safe. `responseBody` is a SEPARATE field that "may echo
+    // back submitted data" (see the exception docblock) and must never leak to
+    // OL Admin. This locks that property so a future #981 change can't fold the
+    // body into `.message` unnoticed (PR1057-SUG-04).
+    const responseBody = 'apiKey=super-secret-echoed-back';
+    const apiError = new ErliApiException('Erli GET /me failed (422)', 422, responseBody);
+    const throwingFactory = {
+      createHttpClient: jest.fn().mockResolvedValue({
+        get: jest.fn().mockRejectedValue(apiError),
+      }),
+    } as unknown as ConstructorParameters<typeof ErliConnectionTesterAdapter>[0];
+    const throwingTester = new ErliConnectionTesterAdapter(throwingFactory);
+
+    const result = await throwingTester.test(connection(), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(422);
+    expect(result.message).toBe('Erli GET /me failed (422)');
+    expect(result.message).not.toContain(responseBody);
+    expect(result.message).not.toContain('super-secret');
   });
 
   it('should return a failure (not throw) when credential resolution fails', async () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-tester.adapter.spec.ts
@@ -61,7 +61,7 @@ describe('ErliConnectionTesterAdapter', () => {
 
     expect(result.success).toBe(true);
     expect(result.status).toBe(200);
-    expect(result.message).toContain('provisional');
+    expect(result.message).toContain('credentials accepted');
     expect(result.latencyMs).toBeGreaterThanOrEqual(0);
   });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts
@@ -4,7 +4,8 @@
  * Validates the non-secret config for an Erli connection. Erli needs no
  * required config (the API key lives in credentials), so an empty config is
  * valid; the only constraint is that the optional `baseUrl` override, when
- * present, is a non-empty https URL. Registered against
+ * present, is a non-empty https URL targeting an Erli-owned host (SSRF guard —
+ * the base URL carries the bearer key on every request). Registered against
  * `ConnectionConfigShapeValidatorRegistryService` at `erli.shopapi.v1`;
  * `ConnectionService` maps the thrown exception to a 400 at the API boundary.
  *
@@ -19,6 +20,7 @@ import {
   type FlatValidationIssue,
   InvalidConnectionConfigException,
 } from '@openlinker/core/integrations';
+import { ERLI_ALLOWED_BASE_URL_HOSTS, isAllowedErliHost } from '../../domain/policies/erli-base-url.policy';
 
 export class ErliConnectionConfigShapeValidatorAdapter
   implements ConnectionConfigShapeValidatorPort
@@ -32,8 +34,16 @@ export class ErliConnectionConfigShapeValidatorAdapter
     if (baseUrl !== undefined) {
       if (typeof baseUrl !== 'string' || baseUrl.trim().length === 0) {
         issues.push({ path: 'baseUrl', message: 'must be a non-empty string when provided' });
-      } else if (!this.isHttpsUrl(baseUrl)) {
-        issues.push({ path: 'baseUrl', message: 'must be a valid https URL' });
+      } else {
+        const parsed = this.parseHttpsUrl(baseUrl);
+        if (!parsed) {
+          issues.push({ path: 'baseUrl', message: 'must be a valid https URL' });
+        } else if (!isAllowedErliHost(parsed.hostname)) {
+          issues.push({
+            path: 'baseUrl',
+            message: `host must be ${ERLI_ALLOWED_BASE_URL_HOSTS.join(' or ')} (or a subdomain)`,
+          });
+        }
       }
     }
 
@@ -43,11 +53,12 @@ export class ErliConnectionConfigShapeValidatorAdapter
     return Promise.resolve();
   }
 
-  private isHttpsUrl(value: string): boolean {
+  private parseHttpsUrl(value: string): URL | null {
     try {
-      return new URL(value).protocol === 'https:';
+      const url = new URL(value);
+      return url.protocol === 'https:' ? url : null;
     } catch {
-      return false;
+      return null;
     }
   }
 }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts
@@ -1,0 +1,53 @@
+/**
+ * Erli Connection Config Shape Validator
+ *
+ * Validates the non-secret config for an Erli connection. Erli needs no
+ * required config (the API key lives in credentials), so an empty config is
+ * valid; the only constraint is that the optional `baseUrl` override, when
+ * present, is a non-empty https URL. Registered against
+ * `ConnectionConfigShapeValidatorRegistryService` at `erli.shopapi.v1`;
+ * `ConnectionService` maps the thrown exception to a 400 at the API boundary.
+ *
+ * Hand-rolled (no class-validator) — one optional field doesn't justify a DTO
+ * graph, and Erli stays dependency-light.
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters
+ * @see {@link ConnectionConfigShapeValidatorPort}
+ */
+import {
+  type ConnectionConfigShapeValidatorPort,
+  type FlatValidationIssue,
+  InvalidConnectionConfigException,
+} from '@openlinker/core/integrations';
+
+export class ErliConnectionConfigShapeValidatorAdapter
+  implements ConnectionConfigShapeValidatorPort
+{
+  constructor(private readonly pluginName: string = 'Erli') {}
+
+  validate(config: Record<string, unknown>): Promise<void> {
+    const issues: FlatValidationIssue[] = [];
+    const baseUrl = config.baseUrl;
+
+    if (baseUrl !== undefined) {
+      if (typeof baseUrl !== 'string' || baseUrl.trim().length === 0) {
+        issues.push({ path: 'baseUrl', message: 'must be a non-empty string when provided' });
+      } else if (!this.isHttpsUrl(baseUrl)) {
+        issues.push({ path: 'baseUrl', message: 'must be a valid https URL' });
+      }
+    }
+
+    if (issues.length > 0) {
+      return Promise.reject(new InvalidConnectionConfigException(this.pluginName, issues));
+    }
+    return Promise.resolve();
+  }
+
+  private isHttpsUrl(value: string): boolean {
+    try {
+      return new URL(value).protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+}

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-credentials-shape-validator.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-credentials-shape-validator.adapter.ts
@@ -1,0 +1,38 @@
+/**
+ * Erli Connection Credentials Shape Validator
+ *
+ * Validates the credentials payload for an Erli connection: a single non-empty
+ * `apiKey` string (ADR-025 static bearer key). Registered against
+ * `ConnectionCredentialsShapeValidatorRegistryService` at `erli.shopapi.v1`;
+ * `ConnectionService` maps the thrown exception to a 400 at the API boundary.
+ *
+ * Hand-rolled (no class-validator) like the PrestaShop credentials validator —
+ * one required field doesn't justify a DTO graph, and Erli stays
+ * dependency-light.
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters
+ * @see {@link ConnectionCredentialsShapeValidatorPort}
+ */
+import {
+  type ConnectionCredentialsShapeValidatorPort,
+  InvalidCredentialsShapeException,
+} from '@openlinker/core/integrations';
+
+export class ErliConnectionCredentialsShapeValidatorAdapter
+  implements ConnectionCredentialsShapeValidatorPort
+{
+  constructor(private readonly pluginName: string = 'Erli') {}
+
+  validate(credentials: Record<string, unknown>): Promise<void> {
+    const apiKey = credentials.apiKey;
+    if (typeof apiKey !== 'string' || apiKey.trim().length === 0) {
+      return Promise.reject(
+        new InvalidCredentialsShapeException(
+          this.pluginName,
+          'must include a non-empty `apiKey` string',
+        ),
+      );
+    }
+    return Promise.resolve();
+  }
+}

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
@@ -33,10 +33,12 @@ import { ErliNetworkException } from '../../domain/exceptions/erli-network.excep
 import { ErliRateLimitException } from '../../domain/exceptions/erli-rate-limit.exception';
 
 /**
- * PLACEHOLDER probe path — replaced by #992 with a confirmed cheap
- * authenticated Erli endpoint. Must require auth so a bad key returns 401/403.
+ * Probe path — verified against the live Erli Shop API (#992 spike). `GET /me`
+ * is the cheap authenticated identity endpoint: it requires auth (a bad key
+ * returns 401), takes no parameters, and has no side effects. The previously
+ * assumed `/offers?limit=1` does not exist on the real API.
  */
-const ERLI_CONNECTION_PROBE_PATH = '/offers?limit=1';
+const ERLI_CONNECTION_PROBE_PATH = '/me';
 
 /** No-retry budget: a connection probe should fail fast, not back off. */
 const NO_RETRY = { maxRetries: 0, initialDelayMs: 0, maxDelayMs: 0, backoffMultiplier: 1 } as const;
@@ -58,10 +60,9 @@ export class ErliConnectionTesterAdapter implements ConnectionTesterPort {
       return {
         success: true,
         status: response.status,
-        // The probe endpoint is provisional until the #992 sandbox spike confirms
-        // it actually requires auth. Until then a 2xx proves reachability but not
-        // a verified credential, so the message stays conservative (#982/#992).
-        message: 'Connection reachable (probe endpoint provisional until #992)',
+        // `GET /me` requires auth, so a 2xx confirms both reachability and a
+        // valid credential (endpoint verified against the sandbox, #992).
+        message: 'Connection reachable and credentials accepted',
         latencyMs: Date.now() - startedAt,
       };
     } catch (error) {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
@@ -8,12 +8,11 @@
  * `ConnectionTestResult`. Registered against `ConnectionTesterRegistryService`
  * at `erli.shopapi.v1`.
  *
- * NOTE (#992): the probe PATH below is a PLACEHOLDER. The live Erli Shop API
- * endpoint set is not confirmed until the #992 sandbox verification spike, so
- * this is not yet a live-verified probe. The tester's auth/result logic is
- * endpoint-agnostic and the unit tests mock `fetch`; `ERLI_CONNECTION_PROBE_PATH`
- * is the single line #992 updates once a confirmed cheap authenticated
- * endpoint is known.
+ * The probe path ({@link ERLI_CONNECTION_PROBE_PATH}) is `GET /me`, confirmed
+ * against the live Erli Shop API during the #992 sandbox spike. The tester's
+ * auth/result logic is endpoint-agnostic and the unit tests mock `fetch`, so
+ * `ERLI_CONNECTION_PROBE_PATH` is the single line to change should the probe
+ * endpoint ever move.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  * @see {@link ConnectionTesterPort}

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
@@ -1,0 +1,73 @@
+/**
+ * Erli Connection Tester
+ *
+ * Probes a live Erli connection with one cheap authenticated GET so OL Admin
+ * can show the connection Active (or a clear failure) right after the operator
+ * pastes their API key. Builds a no-retry per-connection client via
+ * `ErliAdapterFactory` and maps the outcome to the neutral
+ * `ConnectionTestResult`. Registered against `ConnectionTesterRegistryService`
+ * at `erli.shopapi.v1`.
+ *
+ * NOTE (#992): the probe PATH below is a PLACEHOLDER. The live Erli Shop API
+ * endpoint set is not confirmed until the #992 sandbox verification spike, so
+ * this is not yet a live-verified probe. The tester's auth/result logic is
+ * endpoint-agnostic and the unit tests mock `fetch`; `ERLI_CONNECTION_PROBE_PATH`
+ * is the single line #992 updates once a confirmed cheap authenticated
+ * endpoint is known.
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters
+ * @see {@link ConnectionTesterPort}
+ */
+import type {
+  ConnectionTesterPort,
+  ConnectionTestResult,
+  CredentialsResolverPort,
+} from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { ErliAdapterFactory } from '../../application/erli-adapter.factory';
+import { ErliAuthenticationException } from '../../domain/exceptions/erli-authentication.exception';
+
+/**
+ * PLACEHOLDER probe path — replaced by #992 with a confirmed cheap
+ * authenticated Erli endpoint. Must require auth so a bad key returns 401/403.
+ */
+const ERLI_CONNECTION_PROBE_PATH = '/offers?limit=1';
+
+/** No-retry budget: a connection probe should fail fast, not back off. */
+const NO_RETRY = { maxRetries: 0, initialDelayMs: 0, maxDelayMs: 0, backoffMultiplier: 1 } as const;
+
+export class ErliConnectionTesterAdapter implements ConnectionTesterPort {
+  constructor(private readonly factory: ErliAdapterFactory = new ErliAdapterFactory()) {}
+
+  async test(
+    connection: Connection,
+    credentialsResolver: CredentialsResolverPort,
+  ): Promise<ConnectionTestResult> {
+    const startedAt = Date.now();
+    try {
+      const client = await this.factory.createHttpClient(connection, credentialsResolver, NO_RETRY);
+      const response = await client.get(ERLI_CONNECTION_PROBE_PATH);
+      return {
+        success: true,
+        status: response.status,
+        message: 'OK',
+        latencyMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      return this.toFailure(error, Date.now() - startedAt);
+    }
+  }
+
+  private toFailure(error: unknown, latencyMs: number): ConnectionTestResult {
+    if (error instanceof ErliAuthenticationException) {
+      return { success: false, status: error.statusCode, message: error.message, latencyMs };
+    }
+    const err = error as { statusCode?: number; message?: string };
+    return {
+      success: false,
+      status: typeof err.statusCode === 'number' ? err.statusCode : undefined,
+      message: err.message ?? 'Erli probe failed',
+      latencyMs,
+    };
+  }
+}

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
@@ -25,7 +25,11 @@ import type {
 } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { ErliAdapterFactory } from '../../application/erli-adapter.factory';
+import { ErliApiException } from '../../domain/exceptions/erli-api.exception';
 import { ErliAuthenticationException } from '../../domain/exceptions/erli-authentication.exception';
+import { ErliConfigException } from '../../domain/exceptions/erli-config.exception';
+import { ErliNetworkException } from '../../domain/exceptions/erli-network.exception';
+import { ErliRateLimitException } from '../../domain/exceptions/erli-rate-limit.exception';
 
 /**
  * PLACEHOLDER probe path — replaced by #992 with a confirmed cheap
@@ -59,15 +63,21 @@ export class ErliConnectionTesterAdapter implements ConnectionTesterPort {
   }
 
   private toFailure(error: unknown, latencyMs: number): ConnectionTestResult {
-    if (error instanceof ErliAuthenticationException) {
-      return { success: false, status: error.statusCode, message: error.message, latencyMs };
+    // Only a recognized Erli exception's message/status reaches the
+    // operator-facing result: their messages are bounded and never carry the
+    // bearer key. Any other error (e.g. a raw fetch/undici error, whose message
+    // can embed internal request details) collapses to a fixed string so
+    // nothing unexpected is surfaced in OL Admin.
+    if (
+      error instanceof ErliAuthenticationException ||
+      error instanceof ErliApiException ||
+      error instanceof ErliNetworkException ||
+      error instanceof ErliConfigException ||
+      error instanceof ErliRateLimitException
+    ) {
+      const status = 'statusCode' in error && typeof error.statusCode === 'number' ? error.statusCode : undefined;
+      return { success: false, status, message: error.message, latencyMs };
     }
-    const err = error as { statusCode?: number; message?: string };
-    return {
-      success: false,
-      status: typeof err.statusCode === 'number' ? err.statusCode : undefined,
-      message: err.message ?? 'Erli probe failed',
-      latencyMs,
-    };
+    return { success: false, status: undefined, message: 'Erli probe failed', latencyMs };
   }
 }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
@@ -25,6 +25,7 @@ import type {
 } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { ErliAdapterFactory } from '../../application/erli-adapter.factory';
+import type { IErliAdapterFactory } from '../../application/interfaces/erli-adapter.factory.interface';
 import { ErliApiException } from '../../domain/exceptions/erli-api.exception';
 import { ErliAuthenticationException } from '../../domain/exceptions/erli-authentication.exception';
 import { ErliConfigException } from '../../domain/exceptions/erli-config.exception';
@@ -41,7 +42,10 @@ const ERLI_CONNECTION_PROBE_PATH = '/offers?limit=1';
 const NO_RETRY = { maxRetries: 0, initialDelayMs: 0, maxDelayMs: 0, backoffMultiplier: 1 } as const;
 
 export class ErliConnectionTesterAdapter implements ConnectionTesterPort {
-  constructor(private readonly factory: ErliAdapterFactory = new ErliAdapterFactory()) {}
+  // Depends on the IErliAdapterFactory abstraction (defaulting to the concrete
+  // factory) so the construction seam is injectable and the infra→application
+  // edge is against an interface, not a concrete application class.
+  constructor(private readonly factory: IErliAdapterFactory = new ErliAdapterFactory()) {}
 
   async test(
     connection: Connection,

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
@@ -58,7 +58,10 @@ export class ErliConnectionTesterAdapter implements ConnectionTesterPort {
       return {
         success: true,
         status: response.status,
-        message: 'OK',
+        // The probe endpoint is provisional until the #992 sandbox spike confirms
+        // it actually requires auth. Until then a 2xx proves reachability but not
+        // a verified credential, so the message stays conservative (#982/#992).
+        message: 'Connection reachable (probe endpoint provisional until #992)',
         latencyMs: Date.now() - startedAt,
       };
     } catch (error) {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-tester.adapter.ts
@@ -70,19 +70,37 @@ export class ErliConnectionTesterAdapter implements ConnectionTesterPort {
   }
 
   private toFailure(error: unknown, latencyMs: number): ConnectionTestResult {
-    // Only a recognized Erli exception's message/status reaches the
-    // operator-facing result: their messages are bounded and never carry the
-    // bearer key. Any other error (e.g. a raw fetch/undici error, whose message
-    // can embed internal request details) collapses to a fixed string so
-    // nothing unexpected is surfaced in OL Admin.
+    // Rate-limit carries `retryAfterMs`, not `statusCode`, so surface the 429 it
+    // represents — otherwise the operator loses the real cause (PR1057-TECH-02).
+    if (error instanceof ErliRateLimitException) {
+      return {
+        success: false,
+        status: 429,
+        message: 'Erli rate limit reached while probing the connection',
+        latencyMs,
+      };
+    }
+    // A network-exception message wraps the raw undici cause, which can embed the
+    // resolved host/path; collapse it to a bounded fixed string so no internal
+    // request detail reaches OL Admin (PR1057-SEC-01).
+    if (error instanceof ErliNetworkException) {
+      return {
+        success: false,
+        status: undefined,
+        message: 'Erli connection failed (network error)',
+        latencyMs,
+      };
+    }
+    // Auth / API / config messages are bounded and never carry the bearer key,
+    // so they reach the operator-facing result verbatim. Anything else (e.g. a
+    // raw fetch/undici error) collapses to a fixed string.
     if (
       error instanceof ErliAuthenticationException ||
       error instanceof ErliApiException ||
-      error instanceof ErliNetworkException ||
-      error instanceof ErliConfigException ||
-      error instanceof ErliRateLimitException
+      error instanceof ErliConfigException
     ) {
-      const status = 'statusCode' in error && typeof error.statusCode === 'number' ? error.statusCode : undefined;
+      const status =
+        'statusCode' in error && typeof error.statusCode === 'number' ? error.statusCode : undefined;
       return { success: false, status, message: error.message, latencyMs };
     }
     return { success: false, status: undefined, message: 'Erli probe failed', latencyMs };


### PR DESCRIPTION
## What & why

Implements **#982** — makes an Erli connection creatable, validated, and testable (spec #978 "User story 1: Connect"). Erli uses a static API-key bearer (ADR-022), so this is much lighter than Allegro's OAuth flow.

- **`ErliConnectionCredentialsShapeValidatorAdapter`** — requires a non-empty `apiKey`; hand-rolled like PrestaShop (no `class-validator` dep).
- **`ErliConnectionConfigShapeValidatorAdapter`** — permissive; an optional `baseUrl` override must be a non-empty https URL targeting an **Erli-owned host** (SSRF allowlist).
- **`ErliAdapterFactory`** — single per-connection seam that resolves `apiKey` + base URL and builds the `ErliHttpClient`; reused by the tester and the future #984/#993 adapters. Throws `ErliConfigException` on bad config (missing/empty key, or a `baseUrl` that isn't https + Erli-owned — defense-in-depth beyond the create/update validator).
- **`ErliConnectionTesterAdapter`** — no-retry authenticated probe (`GET /me`) → `ConnectionTestResult` (never throws).
- **`domain/policies/erli-base-url.policy.ts`** — single source of truth for the base-URL SSRF guard (`isAllowedErliBaseUrl`), shared by the validator and the factory.
- Wired via `createErliPlugin().register(host)`; module stays on `createNestAdapterModule` (no plugin-specific Nest providers).

Connection types live in `domain/types/` so the application factory depends on domain, not infrastructure. Secrets are never logged or returned.

## Stacking

Stacked on **#981 / #1056** (`981-erli-http-client`). Targets `main`; **draft** until #1019 + #1056 merge, then rebase → ready.

## Testing

`pnpm --filter @openlinker/integrations-erli` type-check ✅ · lint ✅ · 85/85 unit tests ✅ · `pnpm check:invariants` ✅. Tester/validator/factory/base-URL-policy all unit-tested (fetch mocked).

## Reviews run

Tech-lead + security + architecture (NestJS/hexagonal/SDK-reuse) reviews completed; all actionable findings addressed. SDK reuse confirmed idiomatic (register-hook + host registries + core ports/exceptions, nothing reinvented).

## Probe endpoint — verified (#992)

The connection probe is `GET /me` ("get my shop"), **confirmed against the live Erli Shop API in the #992 sandbox spike**: auth-gated (a bad key returns 401), no parameters, no side effects. The earlier-assumed `/offers?limit=1` does **not** exist on the real API (404s). So "connection shows Active" is live-trustworthy. (Earlier revisions described `/me` as a placeholder pending #992 — that caveat is resolved.)

## `baseUrl` SSRF — closed (was a #992 follow-up)

Operator-set `config.baseUrl` becomes a server-side authenticated GET carrying the API key. It's now constrained to **https + an Erli-owned host** (`erli.pl` / `erli.dev` or a subdomain — apex + look-alike hosts like `erli.pl.evil.com` rejected), enforced both at the create/update validator and re-checked in the factory. Since the #992 spike confirmed the host set, the previously-deferred allowlist is implemented here rather than left as a follow-up.

Closes #982
