### PR TITLE
docs(adr): ADR-025 — Erli marketplace adapter (reconciliation-first, API-key auth, Allegro-ID reuse)

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1675,4 +1675,5 @@ Future: Worker processes jobs
 
 - [Engineering Standards](./engineering-standards.md) - Coding standards and conventions
 - [AI Coding Assistant Guide](./ai-coding-assistant.md) - Behaviour, reasoning expectations and guardrails for AI coding assistants
+- [ADR-025: Erli marketplace adapter](./architecture/adrs/025-erli-marketplace-adapter.md) - reconciliation-first posture, static API-key auth, Allegro-ID taxonomy reuse
 

--- a/docs/architecture/adrs/025-erli-marketplace-adapter.md
+++ b/docs/architecture/adrs/025-erli-marketplace-adapter.md
@@ -2,7 +2,7 @@
 
 - **Status**: Accepted
 - **Date**: 2026-06-12
-- **Authors**: OpenLinker maintainers
+- **Authors**: @norbert-kulus-blockydevs
 
 ## Context
 
@@ -18,7 +18,7 @@ Erli is the second PL marketplace OpenLinker integrates (product spec #978, issu
 
 1. **Reconciliation-first posture.** No Erli write is treated as confirmed by its 202 response. Offer state is reconciled from snapshot reads (mirroring the `offer_status_snapshots` model of [ADR-009](./009-persisted-offer-status-snapshots.md)); order ingestion uses webhooks only as a low-latency *trigger* with a scheduled **inbox poll as the mandatory backstop** (the same trigger-vs-reconciliation split as PrestaShop's #904), converging idempotently on `OrderIngestionService.syncOrderFromSource`.
 2. **Static API-key bearer auth.** Credentials are a single `apiKey` in the encrypted `integration_credentials` store, resolved via `host.credentialsResolver`. No OAuth completion port, no token-refresh service.
-3. **Allegro-ID taxonomy reuse.** Erli offers are populated with the product's already-resolved **Allegro** category/parameter ids (`source:"allegro"` in `externalCategories` / `externalAttributes`). OL builds no Erli-native taxonomy path in v1; products without Allegro taxonomy data are skipped with a clear error (spec #978 §6).
+3. **Allegro-ID taxonomy reuse.** Erli offers are populated with the product's already-resolved **Allegro** category/parameter ids, tagged `source:"allegro"` (the concrete field names are pinned by the implementing PR, #984+). OL builds no Erli-native taxonomy path in v1; products without Allegro taxonomy data are skipped with a clear error (spec #978 §6).
 4. **Adapter-level stock/ownership invariants.** The adapter owns two Erli-specific compensations: (a) on order cancellation OL issues a stock-restore PATCH (because Erli won't), and (b) before any PATCH, fields marked `frozen` by seller-panel edits are excluded so OL never overwrites a manual edit.
 
 ## Alternatives considered

--- a/docs/architecture/adrs/025-erli-marketplace-adapter.md
+++ b/docs/architecture/adrs/025-erli-marketplace-adapter.md
@@ -1,0 +1,49 @@
+# ADR-025: Erli marketplace adapter — reconciliation-first posture, API-key auth, Allegro-ID taxonomy reuse
+
+- **Status**: Accepted
+- **Date**: 2026-06-12
+- **Authors**: OpenLinker maintainers
+
+## Context
+
+Erli is the second PL marketplace OpenLinker integrates (product spec #978, issues #980–#998). Its Shop API differs from Allegro's in ways that would silently break assumptions baked into the Allegro adapter if copied:
+
+- **Async writes**: create/update requests return HTTP **202** — validated and stored, but propagated with a ~20-minute cache lag. Read-after-write lies.
+- **Fragile webhooks**: order webhooks are fire-once with a 5-second timeout and **no retry**; a missed webhook is silently lost.
+- **Static API key**: one bearer key from the seller panel — no OAuth2, no refresh, no expiry signal.
+- **Allegro-sourced taxonomy**: Erli accepts category/parameter ids tagged `source:"allegro"` and resolves them against Allegro's own taxonomy (names ignored, only ids processed).
+- **Asymmetric stock**: Erli auto-decrements stock on purchase but does **not** restore it on cancellation; seller-panel manual edits mark fields `frozen`, and API writes must not overwrite frozen fields (per-nested-field granularity).
+
+## Decision
+
+1. **Reconciliation-first posture.** No Erli write is treated as confirmed by its 202 response. Offer state is reconciled from snapshot reads (mirroring the `offer_status_snapshots` model of [ADR-009](./009-persisted-offer-status-snapshots.md)); order ingestion uses webhooks only as a low-latency *trigger* with a scheduled **inbox poll as the mandatory backstop** (the same trigger-vs-reconciliation split as PrestaShop's #904), converging idempotently on `OrderIngestionService.syncOrderFromSource`.
+2. **Static API-key bearer auth.** Credentials are a single `apiKey` in the encrypted `integration_credentials` store, resolved via `host.credentialsResolver`. No OAuth completion port, no token-refresh service.
+3. **Allegro-ID taxonomy reuse.** Erli offers are populated with the product's already-resolved **Allegro** category/parameter ids (`source:"allegro"` in `externalCategories` / `externalAttributes`). OL builds no Erli-native taxonomy path in v1; products without Allegro taxonomy data are skipped with a clear error (spec #978 §6).
+4. **Adapter-level stock/ownership invariants.** The adapter owns two Erli-specific compensations: (a) on order cancellation OL issues a stock-restore PATCH (because Erli won't), and (b) before any PATCH, fields marked `frozen` by seller-panel edits are excluded so OL never overwrites a manual edit.
+
+## Alternatives considered
+
+- **Trust 202 as write confirmation (Allegro-style synchronous semantics)**: rejected — the ~20-min cache lag would show operators "live" offers that Erli later rejects; reconciliation is the only honest source of truth.
+- **Webhook-only order ingestion**: rejected — no-retry/5 s webhooks guarantee silent order loss under any downtime; the inbox poll (cursor = newest-read inbox message id) is required for correctness, webhooks only improve latency.
+- **Erli-native taxonomy authoring**: rejected for v1 — duplicates the category/parameter mapping effort the operator already invested for Allegro and kills the near-free-listing value proposition (spec #978 risk R2). Revisit only for products with no Allegro data.
+- **OAuth-style credential rotation layer**: rejected — Erli has no OAuth; wrapping a static key in a rotation abstraction adds machinery with nothing to rotate. The auth-failure classifier ([ADR-008](./008-auth-failure-classifier-connection-reauth.md)) covers revoked-key detection.
+
+## Consequences
+
+**Pros:**
+- Operator-visible state is always reconciled truth, never optimistic 202 echo.
+- Order ingestion survives webhook loss by construction.
+- Listing onto Erli reuses Allegro mappings — the integration's core economic bet.
+
+**Cons / trade-offs:**
+- Status freshness is bounded by poll/reconcile cadence (minutes, not seconds).
+- Allegro-ID reuse couples Erli listing quality to the operator's Allegro taxonomy hygiene; products without Allegro data cannot list in v1.
+- Frozen-field exclusion means OL silently skips fields the seller edited manually (no conflict UI in v1 — spec #978 §6).
+
+## References
+
+- Related issues: #978 (product spec), #980–#998 (implementation), #983 (this ADR)
+- Related ADRs: [ADR-009](./009-persisted-offer-status-snapshots.md), [ADR-008](./008-auth-failure-classifier-connection-reauth.md), [ADR-015](./015-inbound-event-routing-capability-translated.md)
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md)
+- Product spec: [docs/specs/product-spec-978-erli-marketplace-integration.md](../../specs/product-spec-978-erli-marketplace-integration.md)
+- Erli Shop API documentation: https://erli.pl/svc/shop-api/doc/

--- a/docs/architecture/adrs/025-erli-marketplace-adapter.md
+++ b/docs/architecture/adrs/025-erli-marketplace-adapter.md
@@ -12,14 +12,14 @@ Erli is the second PL marketplace OpenLinker integrates (product spec #978, issu
 - **Fragile webhooks**: order webhooks are fire-once with a 5-second timeout and **no retry**; a missed webhook is silently lost.
 - **Static API key**: one bearer key from the seller panel — no OAuth2, no refresh, no expiry signal.
 - **Allegro-sourced taxonomy**: Erli accepts category/parameter ids tagged `source:"allegro"` and resolves them against Allegro's own taxonomy (names ignored, only ids processed).
-- **Asymmetric stock**: Erli auto-decrements stock on purchase but does **not** restore it on cancellation; seller-panel manual edits mark fields `frozen`, and API writes must not overwrite frozen fields (per-nested-field granularity).
+- **Asymmetric stock**: Erli auto-decrements stock on purchase but does **not** restore it on cancellation; seller-panel manual edits mark fields `frozen`, and API writes must not overwrite frozen **content** fields (`price`/`name`/`description`). Frozen `stock` on the quantity-sync path is a v1 follow-up (#1066).
 
 ## Decision
 
 1. **Reconciliation-first posture.** No Erli write is treated as confirmed by its 202 response. Offer state is reconciled from snapshot reads (mirroring the `offer_status_snapshots` model of [ADR-009](./009-persisted-offer-status-snapshots.md)); order ingestion uses webhooks only as a low-latency *trigger* with a scheduled **inbox poll as the mandatory backstop** (the same trigger-vs-reconciliation split as PrestaShop's #904), converging idempotently on `OrderIngestionService.syncOrderFromSource`.
 2. **Static API-key bearer auth.** Credentials are a single `apiKey` in the encrypted `integration_credentials` store, resolved via `host.credentialsResolver`. No OAuth completion port, no token-refresh service.
 3. **Allegro-ID taxonomy reuse.** Erli offers are populated with the product's already-resolved **Allegro** category/parameter ids, tagged `source:"allegro"` (the concrete field names are pinned by the implementing PR, #984+). OL builds no Erli-native taxonomy path in v1; products without Allegro taxonomy data are skipped with a clear error (spec #978 §6).
-4. **Adapter-level stock/ownership invariants.** The adapter owns two Erli-specific compensations: (a) on order cancellation OL issues a stock-restore PATCH (because Erli won't), and (b) before any PATCH, fields marked `frozen` by seller-panel edits are excluded so OL never overwrites a manual edit.
+4. **Adapter-level stock/ownership invariants.** The adapter owns two Erli-specific compensations: (a) on order cancellation OL issues a stock-restore PATCH (because Erli won't) — **deferred to #993**, as core has no order-cancellation orchestration yet (`OrderProcessorManagerPort` only has `createOrder`); and (b) on the field-update path (`updateOfferFields` — `price`/`name`/`description`) the adapter reads the live resource and excludes any field the seller marked `frozen`, so OL never overwrites a manual edit. Frozen `stock` is **not** honored on the hot quantity path (`updateOfferQuantity`) in v1 — that path skips the read-before-write GET for per-tick performance; honoring it without a per-tick GET (via a frozen flag cached during reconciliation) is **deferred to #1066**.
 
 ## Alternatives considered
 
@@ -38,7 +38,7 @@ Erli is the second PL marketplace OpenLinker integrates (product spec #978, issu
 **Cons / trade-offs:**
 - Status freshness is bounded by poll/reconcile cadence (minutes, not seconds).
 - Allegro-ID reuse couples Erli listing quality to the operator's Allegro taxonomy hygiene; products without Allegro data cannot list in v1.
-- Frozen-field exclusion means OL silently skips fields the seller edited manually (no conflict UI in v1 — spec #978 §6).
+- Frozen-field exclusion means OL silently skips **content** fields (`price`/`name`/`description`) the seller edited manually (no conflict UI in v1 — spec #978 §6). Frozen `stock` on the quantity path and the cancel-restore PATCH are v1 follow-ups (#1066, #993).
 
 ## References
 

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -105,6 +105,7 @@ One pointer per section, identical format every time.
 | [ADR-013](./013-neutral-oauth-completion-port.md) | Neutral OAuth-completion port — relocate Allegro OAuth into the plugin | Accepted | 2026-05-28 |
 | [ADR-014](./014-source-authoritative-order-pricing.md) | Source-authoritative order pricing | Proposed | 2026-05-30 |
 | [ADR-015](./015-inbound-event-routing-capability-translated.md) | Capability-driven, plugin-translated inbound webhook event routing | Accepted | 2026-05-30 |
+| [ADR-016](./016-prestashop-order-create-via-validateorder.md) | Create PrestaShop orders through `validateOrder`, not the raw webservice | Proposed | 2026-05-30 |
 | [ADR-017](./017-cross-origin-order-reingestion-guard.md) | Skip re-ingestion of orders re-read from a destination connection | Accepted | 2026-06-01 |
 | [ADR-018](./018-dpd-polska-rest-api-over-soap.md) | DPD Polska transport: native REST DPDServices API over legacy SOAP | Proposed | 2026-06-02 |
 | [ADR-019](./019-synchronous-bulk-shipment-dispatch.md) | Synchronous bulk shipment dispatch (loop the per-order seam) | Accepted | 2026-06-03 |

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -113,5 +113,6 @@ One pointer per section, identical format every time.
 | [ADR-022](./022-dpd-tracking-soap-dpdinfoservices.md) | DPD Polska tracking transport: SOAP DPDInfoServices (dual-transport plugin) | Proposed | 2026-06-11 |
 | [ADR-023](./023-cross-platform-category-and-attribute-projection.md) | Cross-platform category placement and attribute projection | Accepted | 2026-06-13 |
 | [ADR-024](./024-destination-listing-capabilities.md) | Destination listing capabilities — marketplace OfferManager vs shop ProductPublisher | Accepted | 2026-06-13 |
+| [ADR-025](./025-erli-marketplace-adapter.md) | Erli marketplace adapter — reconciliation-first posture, API-key auth, Allegro-ID taxonomy reuse | Accepted | 2026-06-12 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/docs/specs/product-spec-978-erli-marketplace-integration.md
+++ b/docs/specs/product-spec-978-erli-marketplace-integration.md
@@ -145,7 +145,7 @@ Rationale:
 
 - **Build sequencing: offers first, orders second** — chosen at Gate C (rationale above).
 - **Allegro-ID reuse** for category/parameter resolution (`source:"allegro"`) — locked as a design constraint at issue creation.
-- **Async/reconciliation posture:** Erli writes are HTTP 202 + ~20-min cache lag; no-retry 5 s webhooks. The adapter is *reconciliation-first* (snapshot-based offer status, inbox poll as mandatory order backstop), not synchronous-confirmation like Allegro. Tier 2 / ADR decision, flagged here because it shapes the "manage offers" UX promise.
+- **Async/reconciliation posture:** Erli writes are HTTP 202 + ~20-min cache lag; no-retry 5 s webhooks. The adapter is *reconciliation-first* (snapshot-based offer status, inbox poll as mandatory order backstop), not synchronous-confirmation like Allegro. Tier 2 / ADR decision (see [ADR-025](../architecture/adrs/025-erli-marketplace-adapter.md)), flagged here because it shapes the "manage offers" UX promise.
 
 ## 5. Product specification
 


### PR DESCRIPTION
## What & why

Splits **ADR-025** out of the Erli plugin-skeleton PR (#1019) so each issue maps to its own PR — #1019 now covers the skeleton (#980) only, this PR covers the ADR (#983) only.

ADR-025 records the non-obvious Erli architecture decisions before the build leans on them:
- **Reconciliation-first posture** — Erli writes return HTTP 202 with ~20-min cache lag; webhooks are no-retry/5 s → inbox poll is a mandatory backstop, offer status is snapshot-reconciled (à la ADR-009), not synchronous confirmation like Allegro.
- **Static API-key bearer auth** vs Allegro OAuth2 — why the lighter model is acceptable (no OAuth, no token-refresh).
- **Allegro-ID taxonomy reuse** (`source:"allegro"`) — reuse the Allegro category/parameter resolver rather than authoring an Erli-native taxonomy.
- **Asymmetric stock** (auto-decrement on sale, manual restore on cancel) + `frozen`-field ownership as adapter-level invariants.

Docs-only: the ADR file, its ADR-index row, and the cross-link from the #978 product spec. The capability-matrix entries for Erli in `architecture-overview.md` (with their inline `see ADR-025` references) ship with the skeleton PR #1019 — those are #980's deliverable; this PR provides the ADR they point at.

## How to test

- `pnpm lint` / `pnpm type-check` — green (docs-only).
- ADR renders; ADR-index row present; spec links to ADR-025.

Closes #983
