### PR TITLE
feat(erli): category & parameter mapping via Allegro-ID reuse (#985)

### DIFF
--- a/docs/plans/implementation-plan-erli-category-param.md
+++ b/docs/plans/implementation-plan-erli-category-param.md
@@ -13,7 +13,7 @@ Populate the Erli offer-create body (`POST /products/{externalId}`) with `extern
 The Erli adapter reads the **same command fields the Allegro adapter reads** → ADR-025 §3 reuse mandate. **Factory signature unchanged.**
 
 ## 3. Scope / non-goals
-**In:** `ErliExternalCategory`/`ErliExternalAttribute` wire types; `externalCategories`/`externalAttributes` on `ErliProductCreateBody`; mapping in `buildCreateBody`; graceful "no Allegro data → list without taxonomy"; unit tests.
+**In:** `ErliExternalCategory`/`ErliExternalAttribute` wire types; `externalCategories`/`externalAttributes` on `ErliProductCreateBody`; mapping in `buildCreateBody`; "no Allegro category → hard-reject the create with a clear error" (per ADR-025 §3 / AC-3); unit tests.
 **Out:** Erli-native authoring (#978 §6.2); variants (#986); stock/price/frozen (#988); status (#989); PATCH-path category mapping (create-only — `buildPatchFromFields` untouched); factory change; any taxonomy fetch.
 
 ## 4. `erli-product.types.ts` additions (additive; provisional #992)
@@ -35,13 +35,13 @@ Replace the `// #985:` seam with two helpers; assemble after the barcode block (
 - **`buildExternalAttributes(cmd)`**: concat `platformParams.parameters` + `.productParameters` (Erli has one flat list — offer/product split irrelevant on Erli). Narrow each `unknown` entry with a guard mirroring `isAllegroOfferParameterShape` (`allegro-offer-manager.adapter.ts:127-139`): require non-empty `id: string`. Map: `valuesIds` non-empty → `{type:'dictionary', values:valuesIds}`; else `values` non-empty → `{type:'string', values}`; `rangeValue`-only → **dropped v1** (debug-logged); empty → skip. Pure module functions (style: `toErliPrice`).
 
 ## 6. "No Allegro data" handling
-ADR-025 §3 / #978 §6.2 = no Erli-native fallback, **not** a hard create failure. No `categoryId` + no params → omit both keys; offer still creates (price/stock/title/barcode). Add one `logger.warn` ("no Allegro category; listing without taxonomy reuse — #985/#978 §6.2") for observability. Decision (Open Q2): graceful-omit + warn is the reversible low-risk default; if product wants hard-reject, add a one-branch `OfferCreateRejectedException` preflight.
+ADR-025 §3 / #978 §6.2 = no Erli-native taxonomy fallback. **Decision (Open Q2 — resolved to hard-reject):** when no Allegro `categoryId` resolves, `buildCreateBody` throws `OfferCreateRejectedException(adapterKey, 422, [{field:'category', code:'NO_ALLEGRO_TAXONOMY', …}])` *before* any POST — the create fails with a clear error, which `OfferCreationExecutionService` maps to `business_failure`. This matches AC-3 ("clear skip/**error**") and ADR-025 §3 ("products without Allegro taxonomy data are skipped with a clear error"). Rationale for choosing hard-reject over graceful-omit: an Erli offer with no category is not a useful listing, and surfacing it as a terminal rejection gives the operator an actionable signal rather than a silently-degraded offer. Parameters (attributes) alone, without a category, do not satisfy the requirement.
 
 ## 7. Idempotency / errors
 No new HTTP calls — one `POST {idempotent:true}` (`adapter:72`). `buildCreateBody` stays sync. Error mapping unchanged (`toCreateRejected` → `OfferCreateRejectedException`, no responseBody leak). Malformed param entries dropped silently (guard), never throw.
 
 ## 8. Unit tests (`erli-offer-manager.adapter.spec.ts`, assert on `post.mock.calls[0][1]`)
-1. category mapping; 2. dictionary attr (`valuesIds`→type:dictionary); 3. string attr (`values`→type:string); 4. offer+product merge into one flat list; 5. **skip-case** (no data → no keys, offer still POSTs, status `'draft'`); 6. empty-attrs → key omitted; 7. malformed entry dropped; 8. `rangeValue`-only dropped; 9. regression: existing "basic fields" exact-match still holds.
+1. category mapping; 2. dictionary attr (`valuesIds`→type:dictionary); 3. string attr (`values`→type:string); 4. offer+product merge into one flat list; 5. **no-taxonomy reject-case** (no `categoryId` → `OfferCreateRejectedException`, `post` NOT called); 6. empty-attrs → key omitted; 7. malformed entry dropped; 8. `rangeValue`-only dropped; 9. regression: existing "basic fields" exact-match still holds.
 
 ## 9. Architecture / cross-context
 No CORE change; types-only barrel imports from `@openlinker/core/listings` (no deep paths, no new cross-context import); all new shapes in `erli-product.types.ts` (single #992 point); no `any` (`unknown`+guard). Update file headers (`adapter:17-19`, `types:11-12`) — #985 taxonomy reuse now implemented (was listed out-of-scope).
@@ -50,11 +50,11 @@ No CORE change; types-only barrel imports from `@openlinker/core/listings` (no d
 - **R1 (#992-provisional):** field names/`type` set unconfirmed → isolated in `erli-product.types.ts`.
 - **R2 (`type` set):** Erli may want `integer`/`float` (neutral `CategoryParameterType` has them) vs v1's `dictionary|string|number`; single change point (Open Q1).
 - **R3 (ranges dropped):** rare; debug-logged.
-- **R4 (skip-vs-error):** reversible (Open Q2).
+- **R4 (skip-vs-error):** resolved to hard-reject (Open Q2) — matches ADR-025 §3 + AC-3.
 
 ## 11. Open questions
 1. **`type` discriminator + ranges** (#992): does Erli accept only `dictionary|string|number`? how to express ranges? v1 defaults non-dict→string, drops ranges.
-2. **Skip vs hard-error** when no Allegro category (product): v1 omits+warns.
+2. **Skip vs hard-error** when no Allegro category (product): **resolved → hard-error** (`OfferCreateRejectedException` before POST), per ADR-025 §3 + AC-3.
 3. **`unit` source** (#992 / issue author): command parameter entries do NOT carry `unit` (only neutral `CategoryParameter` metadata does, which the adapter never receives). So `ErliExternalAttribute.unit` is type-present but **unwired in v1**. Surface to the issue author — the issue's "optional unit" can't be honored from the command alone today.
 
 ## Related

--- a/docs/plans/implementation-plan-erli-category-param.md
+++ b/docs/plans/implementation-plan-erli-category-param.md
@@ -1,0 +1,61 @@
+# Implementation Plan — #985: Erli category & parameter mapping via Allegro-ID reuse (`source:"allegro"`)
+
+**Date**: 2026-06-15 · **Status**: Ready for Review · **Effort**: M · **Branch**: `985-erli-category-param` (off `984-erli-offer-manager`) · **ADR**: ADR-025 §3 · Part of Wave-4 (see `implementation-plan-erli-wave4-orchestration.md`).
+
+## 1. Task summary
+Populate the Erli offer-create body (`POST /products/{externalId}`) with `externalCategories` + `externalAttributes` tagged `source:"allegro"`, reusing OL's **already-resolved Allegro category id + parameter ids** that ride on `CreateOfferCommand`. Erli processes only the `id` (names ignored — ADR-025 §3). No Erli-native taxonomy authoring. Lands in the `// #985:` seam at `erli-offer-manager.adapter.ts:134` + additive wire types in `erli-product.types.ts`. Unit tests only; no CORE change, no migration.
+
+## 2. Key design question — RESOLVED (no new factory dep)
+**Allegro ids arrive on the command** (verified):
+- Category: `cmd.overrides.categoryId` (resolved by `OfferBuilderService` `offer-builder.service.ts:77-85,111`; Allegro adapter reads the same field `allegro-offer-manager.adapter.ts:1448,1469`).
+- Parameters: `cmd.overrides.platformParams.parameters` (offer-section) + `…​.productParameters` (product-section), passed through verbatim by `OfferBuilderService:102,113-115`; entry shape `{ id; values?; valuesIds?; rangeValue? }` (`serialize-allegro-parameters.ts:45-50`).
+
+The Erli adapter reads the **same command fields the Allegro adapter reads** → ADR-025 §3 reuse mandate. **Factory signature unchanged.**
+
+## 3. Scope / non-goals
+**In:** `ErliExternalCategory`/`ErliExternalAttribute` wire types; `externalCategories`/`externalAttributes` on `ErliProductCreateBody`; mapping in `buildCreateBody`; graceful "no Allegro data → list without taxonomy"; unit tests.
+**Out:** Erli-native authoring (#978 §6.2); variants (#986); stock/price/frozen (#988); status (#989); PATCH-path category mapping (create-only — `buildPatchFromFields` untouched); factory change; any taxonomy fetch.
+
+## 4. `erli-product.types.ts` additions (additive; provisional #992)
+```typescript
+export type ErliExternalAttributeType = 'dictionary' | 'string' | 'number';
+export interface ErliExternalCategory { source: 'allegro'; id: string; }
+export interface ErliExternalAttribute {
+  source: 'allegro'; id: string; type: ErliExternalAttributeType; values: string[]; unit?: string;
+}
+// on ErliProductCreateBody (both optional, omitted when empty):
+//   externalCategories?: ErliExternalCategory[];
+//   externalAttributes?: ErliExternalAttribute[];
+```
+Designed so #986 (`externalVariantGroup`), #988 (stock/price/frozen), #989 (status) extend the same file without reshaping these.
+
+## 5. `buildCreateBody` mapping
+Replace the `// #985:` seam with two helpers; assemble after the barcode block (omit keys when empty):
+- **`buildExternalCategories(cmd)`**: `cmd.overrides?.categoryId` non-empty → `[{source:'allegro', id}]`; else `[]`.
+- **`buildExternalAttributes(cmd)`**: concat `platformParams.parameters` + `.productParameters` (Erli has one flat list — offer/product split irrelevant on Erli). Narrow each `unknown` entry with a guard mirroring `isAllegroOfferParameterShape` (`allegro-offer-manager.adapter.ts:127-139`): require non-empty `id: string`. Map: `valuesIds` non-empty → `{type:'dictionary', values:valuesIds}`; else `values` non-empty → `{type:'string', values}`; `rangeValue`-only → **dropped v1** (debug-logged); empty → skip. Pure module functions (style: `toErliPrice`).
+
+## 6. "No Allegro data" handling
+ADR-025 §3 / #978 §6.2 = no Erli-native fallback, **not** a hard create failure. No `categoryId` + no params → omit both keys; offer still creates (price/stock/title/barcode). Add one `logger.warn` ("no Allegro category; listing without taxonomy reuse — #985/#978 §6.2") for observability. Decision (Open Q2): graceful-omit + warn is the reversible low-risk default; if product wants hard-reject, add a one-branch `OfferCreateRejectedException` preflight.
+
+## 7. Idempotency / errors
+No new HTTP calls — one `POST {idempotent:true}` (`adapter:72`). `buildCreateBody` stays sync. Error mapping unchanged (`toCreateRejected` → `OfferCreateRejectedException`, no responseBody leak). Malformed param entries dropped silently (guard), never throw.
+
+## 8. Unit tests (`erli-offer-manager.adapter.spec.ts`, assert on `post.mock.calls[0][1]`)
+1. category mapping; 2. dictionary attr (`valuesIds`→type:dictionary); 3. string attr (`values`→type:string); 4. offer+product merge into one flat list; 5. **skip-case** (no data → no keys, offer still POSTs, status `'draft'`); 6. empty-attrs → key omitted; 7. malformed entry dropped; 8. `rangeValue`-only dropped; 9. regression: existing "basic fields" exact-match still holds.
+
+## 9. Architecture / cross-context
+No CORE change; types-only barrel imports from `@openlinker/core/listings` (no deep paths, no new cross-context import); all new shapes in `erli-product.types.ts` (single #992 point); no `any` (`unknown`+guard). Update file headers (`adapter:17-19`, `types:11-12`) — #985 taxonomy reuse now implemented (was listed out-of-scope).
+
+## 10. Risks
+- **R1 (#992-provisional):** field names/`type` set unconfirmed → isolated in `erli-product.types.ts`.
+- **R2 (`type` set):** Erli may want `integer`/`float` (neutral `CategoryParameterType` has them) vs v1's `dictionary|string|number`; single change point (Open Q1).
+- **R3 (ranges dropped):** rare; debug-logged.
+- **R4 (skip-vs-error):** reversible (Open Q2).
+
+## 11. Open questions
+1. **`type` discriminator + ranges** (#992): does Erli accept only `dictionary|string|number`? how to express ranges? v1 defaults non-dict→string, drops ranges.
+2. **Skip vs hard-error** when no Allegro category (product): v1 omits+warns.
+3. **`unit` source** (#992 / issue author): command parameter entries do NOT carry `unit` (only neutral `CategoryParameter` metadata does, which the adapter never receives). So `ErliExternalAttribute.unit` is type-present but **unwired in v1**. Surface to the issue author — the issue's "optional unit" can't be honored from the command alone today.
+
+## Related
+- Wave-4 meta-plan · ADR-025 · #984 plan (`implementation-plan-erli-offer-manager.md`) · Spec #978 §6.2

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -15,6 +15,7 @@ import {
   type UpdateOfferFieldsCommand,
   type UpdateOfferQuantityCommand,
 } from '@openlinker/core/listings';
+import { Logger } from '@openlinker/shared/logging';
 import { ErliApiException } from '../../../domain/exceptions/erli-api.exception';
 import { ErliAuthenticationException } from '../../../domain/exceptions/erli-authentication.exception';
 import { ErliConfigException } from '../../../domain/exceptions/erli-config.exception';
@@ -300,15 +301,22 @@ describe('ErliOfferManagerAdapter', () => {
         ]);
       });
 
-      it('should drop a rangeValue-only parameter (no values/valuesIds) in v1', async () => {
-        await adapter.createOffer(
-          createCmd({
-            parameters: [{ id: '12345', rangeValue: { from: '1', to: '10' }, section: 'offer' }],
-          }),
-        );
+      it('should drop a rangeValue-only parameter (no values/valuesIds) in v1 and debug-log it', async () => {
+        const debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+        try {
+          await adapter.createOffer(
+            createCmd({
+              parameters: [{ id: '12345', rangeValue: { from: '1', to: '10' }, section: 'offer' }],
+            }),
+          );
 
-        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
-        expect(body).not.toHaveProperty('externalAttributes');
+          const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+          expect(body).not.toHaveProperty('externalAttributes');
+          // The dropped param id is surfaced so it isn't silently lost (#985 R3).
+          expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('12345'));
+        } finally {
+          debugSpy.mockRestore();
+        }
       });
     });
   });

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -228,10 +228,7 @@ describe('ErliOfferManagerAdapter', () => {
       it('should map a dictionary parameter (valuesIds → type:dictionary)', async () => {
         await adapter.createOffer(
           createCmd({
-            overrides: {
-              categoryId: '18654',
-              platformParams: { parameters: [{ id: '11323', valuesIds: ['11323_1'] }] },
-            },
+            parameters: [{ id: '11323', valuesIds: ['11323_1'], section: 'offer' }],
           }),
         );
 
@@ -244,10 +241,7 @@ describe('ErliOfferManagerAdapter', () => {
       it('should map a free-text parameter (values → type:string)', async () => {
         await adapter.createOffer(
           createCmd({
-            overrides: {
-              categoryId: '18654',
-              platformParams: { parameters: [{ id: '224017', values: ['Acme'] }] },
-            },
+            parameters: [{ id: '224017', values: ['Acme'], section: 'product' }],
           }),
         );
 
@@ -260,13 +254,10 @@ describe('ErliOfferManagerAdapter', () => {
       it('should merge offer-section and product-section params into one flat list', async () => {
         await adapter.createOffer(
           createCmd({
-            overrides: {
-              categoryId: '18654',
-              platformParams: {
-                parameters: [{ id: '11323', valuesIds: ['11323_1'] }],
-                productParameters: [{ id: '224017', values: ['Acme'] }],
-              },
-            },
+            parameters: [
+              { id: '11323', valuesIds: ['11323_1'], section: 'offer' },
+              { id: '224017', values: ['Acme'], section: 'product' },
+            ],
           }),
         );
 
@@ -293,21 +284,13 @@ describe('ErliOfferManagerAdapter', () => {
         expect(body).not.toHaveProperty('externalAttributes');
       });
 
-      it('should drop malformed parameter entries (missing/empty id)', async () => {
+      it('should drop empty-id parameter entries', async () => {
         await adapter.createOffer(
           createCmd({
-            overrides: {
-              categoryId: '18654',
-              platformParams: {
-                parameters: [
-                  { id: '', values: ['x'] },
-                  { values: ['no id'] },
-                  null,
-                  'garbage',
-                  { id: '11323', valuesIds: ['11323_1'] },
-                ],
-              },
-            },
+            parameters: [
+              { id: '', values: ['x'], section: 'offer' },
+              { id: '11323', valuesIds: ['11323_1'], section: 'offer' },
+            ],
           }),
         );
 
@@ -320,12 +303,7 @@ describe('ErliOfferManagerAdapter', () => {
       it('should drop a rangeValue-only parameter (no values/valuesIds) in v1', async () => {
         await adapter.createOffer(
           createCmd({
-            overrides: {
-              categoryId: '18654',
-              platformParams: {
-                parameters: [{ id: '12345', rangeValue: { from: '1', to: '10' } }],
-              },
-            },
+            parameters: [{ id: '12345', rangeValue: { from: '1', to: '10' }, section: 'offer' }],
           }),
         );
 

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -37,9 +37,12 @@ function createCmd(overrides: Partial<CreateOfferCommand> = {}): CreateOfferComm
     stock: 10,
     publishImmediately: true,
     ...rest,
+    // Default to a resolvable Allegro category: ADR-025 §3 makes a missing one a
+    // terminal rejection, so the happy-path/unrelated tests must carry one.
     overrides: {
       title: 'Default Widget',
       imageUrls: ['https://cdn.example.com/default.jpg'],
+      categoryId: '18654',
       ...ov,
     },
   };
@@ -75,13 +78,20 @@ describe('ErliOfferManagerAdapter', () => {
     it('should map the basic command fields into the create body', async () => {
       await adapter.createOffer(
         createCmd({
-          overrides: { title: 'Widget', description: 'A nice widget', imageUrls: ['https://cdn.example.com/a.jpg'] },
+          overrides: {
+            categoryId: '18654',
+            title: 'Widget',
+            description: 'A nice widget',
+            imageUrls: ['https://cdn.example.com/a.jpg'],
+          },
           variantBarcode: '5901234123457',
         }),
       );
 
       const body = httpClient.post.mock.calls[0][1];
-      expect(body).toEqual({
+      // toMatchObject: this test covers basic-field mapping, not taxonomy
+      // (externalCategories is asserted by the #985 reuse tests).
+      expect(body).toMatchObject({
         price: 4999,
         stock: 10,
         images: [{ url: 'https://cdn.example.com/a.jpg' }],
@@ -100,7 +110,12 @@ describe('ErliOfferManagerAdapter', () => {
 
     it('should let a per-offer platformParams.dispatchTime override the connection default', async () => {
       await adapter.createOffer(
-        createCmd({ overrides: { platformParams: { dispatchTime: { period: 5, unit: 'hour' } } } }),
+        createCmd({
+          overrides: {
+            categoryId: '18654',
+            platformParams: { dispatchTime: { period: 5, unit: 'hour' } },
+          },
+        }),
       );
       const body = httpClient.post.mock.calls[0][1] as { dispatchTime?: unknown };
       expect(body.dispatchTime).toEqual({ period: 5, unit: 'hour' });
@@ -144,6 +159,7 @@ describe('ErliOfferManagerAdapter', () => {
       await adapter.createOffer(
         createCmd({
           overrides: {
+            categoryId: '18654',
             imageUrls: ['https://cdn.example.com/ok.jpg', 'http://x/insecure.jpg', 'https://169.254.169.254/meta'],
           },
         }),
@@ -261,14 +277,12 @@ describe('ErliOfferManagerAdapter', () => {
         ]);
       });
 
-      it('should omit both taxonomy keys and still POST when no Allegro data is present', async () => {
-        const result = await adapter.createOffer(createCmd());
-
-        expect(httpClient.post).toHaveBeenCalledTimes(1);
-        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
-        expect(body).not.toHaveProperty('externalCategories');
-        expect(body).not.toHaveProperty('externalAttributes');
-        expect(result.status).toBe('draft');
+      it('should throw OfferCreateRejectedException and NOT POST when no Allegro taxonomy resolves (ADR-025 §3)', async () => {
+        // Explicitly clear the helper's default categoryId so no Allegro taxonomy resolves.
+        await expect(
+          adapter.createOffer(createCmd({ overrides: { categoryId: undefined } })),
+        ).rejects.toBeInstanceOf(OfferCreateRejectedException);
+        expect(httpClient.post).not.toHaveBeenCalled();
       });
 
       it('should omit externalAttributes when the category is present but no params map', async () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -1,10 +1,11 @@
 /**
- * Erli Offer Manager Adapter — unit tests (#984)
+ * Erli Offer Manager Adapter — unit tests (#984, #985)
  *
  * Mocks `IErliHttpClient` to verify: seller-keyed path build (validate+encode),
  * 202→'draft' create mapping, sparse PATCH for field/quantity updates, the
  * safe 4xx→OfferCreateRejectedException mapping (no responseBody leak), auth
- * propagation, hostile-id rejection, and imageUrl hygiene.
+ * propagation, hostile-id rejection, imageUrl hygiene, and the #985 Allegro
+ * category/parameter reuse (source:"allegro" externalCategories/Attributes).
  *
  * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
  */
@@ -196,6 +197,127 @@ describe('ErliOfferManagerAdapter', () => {
         adapter.createOffer(createCmd({ internalVariantId: 'ol_variant_../admin' })),
       ).rejects.toBeInstanceOf(ErliConfigException);
       expect(httpClient.post).not.toHaveBeenCalled();
+    });
+
+    describe('category & parameter reuse (#985)', () => {
+      it('should map overrides.categoryId into a source:"allegro" externalCategories entry', async () => {
+        await adapter.createOffer(createCmd({ overrides: { categoryId: '18654' } }));
+
+        const body = httpClient.post.mock.calls[0][1] as {
+          externalCategories?: unknown;
+        };
+        expect(body.externalCategories).toEqual([{ source: 'allegro', id: '18654' }]);
+      });
+
+      it('should map a dictionary parameter (valuesIds → type:dictionary)', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              categoryId: '18654',
+              platformParams: { parameters: [{ id: '11323', valuesIds: ['11323_1'] }] },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '11323', type: 'dictionary', values: ['11323_1'] },
+        ]);
+      });
+
+      it('should map a free-text parameter (values → type:string)', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              categoryId: '18654',
+              platformParams: { parameters: [{ id: '224017', values: ['Acme'] }] },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '224017', type: 'string', values: ['Acme'] },
+        ]);
+      });
+
+      it('should merge offer-section and product-section params into one flat list', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              categoryId: '18654',
+              platformParams: {
+                parameters: [{ id: '11323', valuesIds: ['11323_1'] }],
+                productParameters: [{ id: '224017', values: ['Acme'] }],
+              },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '11323', type: 'dictionary', values: ['11323_1'] },
+          { source: 'allegro', id: '224017', type: 'string', values: ['Acme'] },
+        ]);
+      });
+
+      it('should omit both taxonomy keys and still POST when no Allegro data is present', async () => {
+        const result = await adapter.createOffer(createCmd());
+
+        expect(httpClient.post).toHaveBeenCalledTimes(1);
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).not.toHaveProperty('externalCategories');
+        expect(body).not.toHaveProperty('externalAttributes');
+        expect(result.status).toBe('draft');
+      });
+
+      it('should omit externalAttributes when the category is present but no params map', async () => {
+        await adapter.createOffer(createCmd({ overrides: { categoryId: '18654' } }));
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).toHaveProperty('externalCategories');
+        expect(body).not.toHaveProperty('externalAttributes');
+      });
+
+      it('should drop malformed parameter entries (missing/empty id)', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              categoryId: '18654',
+              platformParams: {
+                parameters: [
+                  { id: '', values: ['x'] },
+                  { values: ['no id'] },
+                  null,
+                  'garbage',
+                  { id: '11323', valuesIds: ['11323_1'] },
+                ],
+              },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '11323', type: 'dictionary', values: ['11323_1'] },
+        ]);
+      });
+
+      it('should drop a rangeValue-only parameter (no values/valuesIds) in v1', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              categoryId: '18654',
+              platformParams: {
+                parameters: [{ id: '12345', rangeValue: { from: '1', to: '10' } }],
+              },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).not.toHaveProperty('externalAttributes');
+      });
     });
   });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -169,7 +169,10 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
       // terminal rejection (OfferCreationExecutionService derives business_failure
       // from OfferCreateRejectedException) rather than silently listing it
       // untaxonomised (spec #978 §6).
-      throw new OfferCreateRejectedException(this.adapterKey, 422, [
+      // statusCode 0 = preflight rejection (no API call made), per the
+      // OfferCreateRejectedException contract — matches the real-API path's
+      // `error.statusCode ?? 0`.
+      throw new OfferCreateRejectedException(this.adapterKey, 0, [
         {
           field: 'category',
           code: 'NO_ALLEGRO_TAXONOMY',
@@ -178,7 +181,12 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
         },
       ]);
     }
-    const externalAttributes = buildExternalAttributes(cmd);
+    const { attributes: externalAttributes, droppedParamIds } = buildExternalAttributes(cmd);
+    if (droppedParamIds.length > 0) {
+      this.logger.debug(
+        `Dropped ${droppedParamIds.length} unsupported Erli parameter(s) (range-only/empty, #985 R3) [connectionId=${this.connectionId}]: ${droppedParamIds.join(', ')}`,
+      );
+    }
     if (externalAttributes.length > 0) {
       body.externalAttributes = externalAttributes;
     }
@@ -359,8 +367,12 @@ function buildExternalCategories(cmd: CreateOfferCommand): ErliExternalCategory[
  * parameters post-#1071 (reading it produced an empty list and silently shipped
  * offers without their Allegro attribute reuse).
  */
-function buildExternalAttributes(cmd: CreateOfferCommand): ErliExternalAttribute[] {
+function buildExternalAttributes(cmd: CreateOfferCommand): {
+  attributes: ErliExternalAttribute[];
+  droppedParamIds: string[];
+} {
   const attributes: ErliExternalAttribute[] = [];
+  const droppedParamIds: string[] = [];
   for (const param of cmd.parameters ?? []) {
     if (param.id.length === 0) {
       continue;
@@ -369,10 +381,14 @@ function buildExternalAttributes(cmd: CreateOfferCommand): ErliExternalAttribute
       attributes.push({ source: 'allegro', id: param.id, type: 'dictionary', values: param.valuesIds });
     } else if (param.values !== undefined && param.values.length > 0) {
       attributes.push({ source: 'allegro', id: param.id, type: 'string', values: param.values });
+    } else {
+      // range-only / empty → dropped in v1 (#985 risk R3). Recorded so the
+      // caller can debug-log it (an operator-supplied parameter that never
+      // reaches Erli is otherwise undiagnosable).
+      droppedParamIds.push(param.id);
     }
-    // range-only / empty → dropped in v1 (#985 risk R3).
   }
-  return attributes;
+  return { attributes, droppedParamIds };
 }
 
 function flattenDescription(input: string | OfferDescriptionUpdate): string {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -164,11 +164,19 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
     if (externalCategories.length > 0) {
       body.externalCategories = externalCategories;
     } else {
-      // No Allegro category → list without taxonomy reuse (ADR-025 §3 / #978
-      // §6.2): graceful-omit, not a hard create failure.
-      this.logger.warn(
-        `Erli offer has no Allegro category; listing without taxonomy reuse — #985/#978 §6.2 [connectionId=${this.connectionId}]`,
-      );
+      // ADR-025 §3: OL builds no Erli-native taxonomy in v1 — a product without
+      // resolved Allegro taxonomy cannot list on Erli. Fail closed with a clear,
+      // terminal rejection (OfferCreationExecutionService derives business_failure
+      // from OfferCreateRejectedException) rather than silently listing it
+      // untaxonomised (spec #978 §6).
+      throw new OfferCreateRejectedException(this.adapterKey, 422, [
+        {
+          field: 'category',
+          code: 'NO_ALLEGRO_TAXONOMY',
+          message:
+            'No Allegro category resolved for this product; Erli v1 requires Allegro-ID taxonomy reuse (ADR-025 §3).',
+        },
+      ]);
     }
     const externalAttributes = buildExternalAttributes(cmd);
     if (externalAttributes.length > 0) {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -14,9 +14,16 @@
  * `OfferStatusReader` yet and would flip the record to `business_failure`.
  * #989 introduces `OfferStatusReader` and flips this to `'validating'`.
  *
- * Out of scope (own issues, marked seams): category/parameters #985, variant
- * grouping #986, stock/price master sourcing + frozen-field exclusion #988,
- * offer-status reconciliation #989.
+ * Category/parameter reuse (#985): the create body carries `externalCategories`
+ * + `externalAttributes` tagged `source:"allegro"`, built from the already-
+ * resolved Allegro ids riding on the command (`overrides.categoryId` +
+ * `overrides.platformParams.parameters`/`.productParameters`). Erli processes
+ * only the ids (ADR-025 §3); no Erli-native taxonomy authoring. Applies to the
+ * create path only — `buildPatchFromFields` is untouched.
+ *
+ * Out of scope (own issues, marked seams): variant grouping #986, stock/price
+ * master sourcing + frozen-field exclusion #988, offer-status reconciliation
+ * #989.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  * @see {@link OfferManagerPort}
@@ -40,6 +47,8 @@ import { ErliConfigException } from '../../domain/exceptions/erli-config.excepti
 import type { ErliDispatchTime } from '../../domain/types/erli-connection.types';
 import type { IErliHttpClient } from '../http/erli-http-client.interface';
 import type {
+  ErliExternalAttribute,
+  ErliExternalCategory,
   ErliProductCreateBody,
   ErliProductImage,
   ErliProductPatchBody,
@@ -150,7 +159,21 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
     if (cmd.variantBarcode != null) {
       body.ean = cmd.variantBarcode;
     }
-    // #985: category/parameter payload (source:"allegro") is assembled here.
+    // #985: reuse OL's already-resolved Allegro ids (source:"allegro").
+    const externalCategories = buildExternalCategories(cmd);
+    if (externalCategories.length > 0) {
+      body.externalCategories = externalCategories;
+    } else {
+      // No Allegro category → list without taxonomy reuse (ADR-025 §3 / #978
+      // §6.2): graceful-omit, not a hard create failure.
+      this.logger.warn(
+        `Erli offer has no Allegro category; listing without taxonomy reuse — #985/#978 §6.2 [connectionId=${this.connectionId}]`,
+      );
+    }
+    const externalAttributes = buildExternalAttributes(cmd);
+    if (externalAttributes.length > 0) {
+      body.externalAttributes = externalAttributes;
+    }
     // #986: externalVariantGroup is assembled here.
     return body;
   }
@@ -302,6 +325,83 @@ function readDispatchTimeParam(
   return candidate.unit === undefined
     ? { period }
     : { period, unit: candidate.unit as ErliDispatchTime['unit'] };
+}
+
+/**
+ * Map the OL-resolved Allegro category id (`overrides.categoryId`) into the
+ * single-element `source:"allegro"` category list. Empty when absent (#985).
+ */
+function buildExternalCategories(cmd: CreateOfferCommand): ErliExternalCategory[] {
+  const categoryId = cmd.overrides?.categoryId;
+  if (typeof categoryId === 'string' && categoryId.length > 0) {
+    return [{ source: 'allegro', id: categoryId }];
+  }
+  return [];
+}
+
+/**
+ * Flatten the Allegro offer-section + product-section parameter lists into one
+ * `source:"allegro"` attribute array (Erli has a single flat list — the
+ * offer/product split is Allegro-only). Each entry is narrowed with
+ * {@link isAllegroParameterShape}; dictionary value-ids win over free-text
+ * scalars, range-only and malformed entries are dropped (#985).
+ */
+function buildExternalAttributes(cmd: CreateOfferCommand): ErliExternalAttribute[] {
+  const platformParams = cmd.overrides?.platformParams;
+  const raw = [
+    ...toUnknownArray(platformParams?.parameters),
+    ...toUnknownArray(platformParams?.productParameters),
+  ];
+  const attributes: ErliExternalAttribute[] = [];
+  for (const entry of raw) {
+    if (!isAllegroParameterShape(entry)) {
+      continue;
+    }
+    if (entry.valuesIds !== undefined && entry.valuesIds.length > 0) {
+      attributes.push({ source: 'allegro', id: entry.id, type: 'dictionary', values: entry.valuesIds });
+    } else if (entry.values !== undefined && entry.values.length > 0) {
+      attributes.push({ source: 'allegro', id: entry.id, type: 'string', values: entry.values });
+    }
+    // rangeValue-only / empty → dropped in v1 (#985 risk R3).
+  }
+  return attributes;
+}
+
+function toUnknownArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? (value as unknown[]) : [];
+}
+
+/** Allegro command-parameter entry, after narrowing. */
+interface AllegroParameterShape {
+  id: string;
+  values?: string[];
+  valuesIds?: string[];
+}
+
+/**
+ * Narrow an untyped `platformParams.parameters` entry to the Allegro parameter
+ * shape (mirrors `isAllegroOfferParameterShape` in the Allegro adapter): require
+ * a non-empty `id: string`, and `values`/`valuesIds` (when present) must be
+ * string arrays. Anything else is dropped — Erli would reject it anyway.
+ */
+function isAllegroParameterShape(candidate: unknown): candidate is AllegroParameterShape {
+  if (typeof candidate !== 'object' || candidate === null) {
+    return false;
+  }
+  const c = candidate as { id?: unknown; values?: unknown; valuesIds?: unknown };
+  if (typeof c.id !== 'string' || c.id.length === 0) {
+    return false;
+  }
+  if (c.values !== undefined && (!Array.isArray(c.values) || !c.values.every((v) => typeof v === 'string'))) {
+    return false;
+  }
+  if (
+    c.valuesIds !== undefined &&
+    (!Array.isArray(c.valuesIds) || !c.valuesIds.every((v) => typeof v === 'string'))
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function flattenDescription(input: string | OfferDescriptionUpdate): string {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -16,10 +16,10 @@
  *
  * Category/parameter reuse (#985): the create body carries `externalCategories`
  * + `externalAttributes` tagged `source:"allegro"`, built from the already-
- * resolved Allegro ids riding on the command (`overrides.categoryId` +
- * `overrides.platformParams.parameters`/`.productParameters`). Erli processes
- * only the ids (ADR-025 §3); no Erli-native taxonomy authoring. Applies to the
- * create path only — `buildPatchFromFields` is untouched.
+ * resolved Allegro ids riding on the command (`overrides.categoryId` + the
+ * neutral section-tagged `cmd.parameters`, #1071). Erli processes only the ids
+ * (ADR-025 §3); no Erli-native taxonomy authoring. Applies to the create path
+ * only — `buildPatchFromFields` is untouched.
  *
  * Out of scope (own issues, marked seams): variant grouping #986, stock/price
  * master sourcing + frozen-field exclusion #988, offer-status reconciliation
@@ -348,68 +348,31 @@ function buildExternalCategories(cmd: CreateOfferCommand): ErliExternalCategory[
 }
 
 /**
- * Flatten the Allegro offer-section + product-section parameter lists into one
- * `source:"allegro"` attribute array (Erli has a single flat list — the
- * offer/product split is Allegro-only). Each entry is narrowed with
- * {@link isAllegroParameterShape}; dictionary value-ids win over free-text
- * scalars, range-only and malformed entries are dropped (#985).
+ * Flatten the neutral, section-tagged `cmd.parameters` (#1071) into one
+ * `source:"allegro"` attribute array — Erli has a single flat list, so the
+ * Allegro offer/product section split collapses away. Dictionary value-ids win
+ * over free-text scalars; range-only and empty entries are dropped in v1
+ * (#985 risk R3).
+ *
+ * Reads `cmd.parameters` — where `OfferBuilderService` puts the resolved
+ * parameters — NOT `overrides.platformParams`, which no longer carries category
+ * parameters post-#1071 (reading it produced an empty list and silently shipped
+ * offers without their Allegro attribute reuse).
  */
 function buildExternalAttributes(cmd: CreateOfferCommand): ErliExternalAttribute[] {
-  const platformParams = cmd.overrides?.platformParams;
-  const raw = [
-    ...toUnknownArray(platformParams?.parameters),
-    ...toUnknownArray(platformParams?.productParameters),
-  ];
   const attributes: ErliExternalAttribute[] = [];
-  for (const entry of raw) {
-    if (!isAllegroParameterShape(entry)) {
+  for (const param of cmd.parameters ?? []) {
+    if (param.id.length === 0) {
       continue;
     }
-    if (entry.valuesIds !== undefined && entry.valuesIds.length > 0) {
-      attributes.push({ source: 'allegro', id: entry.id, type: 'dictionary', values: entry.valuesIds });
-    } else if (entry.values !== undefined && entry.values.length > 0) {
-      attributes.push({ source: 'allegro', id: entry.id, type: 'string', values: entry.values });
+    if (param.valuesIds !== undefined && param.valuesIds.length > 0) {
+      attributes.push({ source: 'allegro', id: param.id, type: 'dictionary', values: param.valuesIds });
+    } else if (param.values !== undefined && param.values.length > 0) {
+      attributes.push({ source: 'allegro', id: param.id, type: 'string', values: param.values });
     }
-    // rangeValue-only / empty → dropped in v1 (#985 risk R3).
+    // range-only / empty → dropped in v1 (#985 risk R3).
   }
   return attributes;
-}
-
-function toUnknownArray(value: unknown): unknown[] {
-  return Array.isArray(value) ? (value as unknown[]) : [];
-}
-
-/** Allegro command-parameter entry, after narrowing. */
-interface AllegroParameterShape {
-  id: string;
-  values?: string[];
-  valuesIds?: string[];
-}
-
-/**
- * Narrow an untyped `platformParams.parameters` entry to the Allegro parameter
- * shape (mirrors `isAllegroOfferParameterShape` in the Allegro adapter): require
- * a non-empty `id: string`, and `values`/`valuesIds` (when present) must be
- * string arrays. Anything else is dropped — Erli would reject it anyway.
- */
-function isAllegroParameterShape(candidate: unknown): candidate is AllegroParameterShape {
-  if (typeof candidate !== 'object' || candidate === null) {
-    return false;
-  }
-  const c = candidate as { id?: unknown; values?: unknown; valuesIds?: unknown };
-  if (typeof c.id !== 'string' || c.id.length === 0) {
-    return false;
-  }
-  if (c.values !== undefined && (!Array.isArray(c.values) || !c.values.every((v) => typeof v === 'string'))) {
-    return false;
-  }
-  if (
-    c.valuesIds !== undefined &&
-    (!Array.isArray(c.valuesIds) || !c.valuesIds.every((v) => typeof v === 'string'))
-  ) {
-    return false;
-  }
-  return true;
 }
 
 function flattenDescription(input: string | OfferDescriptionUpdate): string {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -9,8 +9,11 @@
  * minor units (grosze, PLN-only — no currency field), `images` is an array of
  * image objects, the barcode key is `ean`, and `dispatchTime` is a required
  * create field. This file is the SINGLE wire-shape reconciliation point — the
- * adapter imports wire shapes only from here. Category/parameters (#985) and
- * variant grouping (#986) are layered in by their own issues.
+ * adapter imports wire shapes only from here.
+ *
+ * The #985 taxonomy fields (`externalCategories` / `externalAttributes`, tagged
+ * `source:"allegro"`, reusing OL's already-resolved Allegro ids — ADR-025 §3)
+ * are layered in here. Variant grouping (#986) is added by its own issue.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  */
@@ -21,6 +24,36 @@ export interface ErliProductImage {
   url: string;
   isVariantImage?: boolean;
   isLifestyleImage?: boolean;
+}
+
+/**
+ * Value-kind discriminator for an `externalAttribute` (#985). v1 maps Allegro
+ * `valuesIds` → `dictionary` and free-text `values` → `string`; `number` is
+ * reserved (single change point if #992 confirms Erli wants `integer`/`float`).
+ */
+export type ErliExternalAttributeType = 'dictionary' | 'string' | 'number';
+
+/**
+ * Category reuse tagged `source:"allegro"` (#985). Erli processes only the `id`
+ * (the OL-resolved Allegro category id); names are ignored (ADR-025 §3).
+ */
+export interface ErliExternalCategory {
+  source: 'allegro';
+  id: string;
+}
+
+/**
+ * Parameter reuse tagged `source:"allegro"` (#985). `id` is the OL-resolved
+ * Allegro parameter id; `values` carries dictionary value-ids or free-text
+ * scalars depending on `type`. `unit` is type-present but unwired in v1 — the
+ * neutral command parameter entries don't carry unit metadata.
+ */
+export interface ErliExternalAttribute {
+  source: 'allegro';
+  id: string;
+  type: ErliExternalAttributeType;
+  values: string[];
+  unit?: string;
 }
 
 /**
@@ -39,6 +72,10 @@ export interface ErliProductCreateBody {
   ean?: string;
   sku?: string;
   dispatchTime?: ErliDispatchTime;
+  /** Allegro category reuse (#985); omitted when empty. */
+  externalCategories?: ErliExternalCategory[];
+  /** Allegro parameter reuse (#985); omitted when empty. */
+  externalAttributes?: ErliExternalAttribute[];
 }
 
 /**


### PR DESCRIPTION
## What & why

Implements **#985** — populates the Erli offer payload with the product's already-resolved **Allegro** category + parameter ids (`source:"allegro"`), per **ADR-025** decision 3 (Allegro-ID taxonomy reuse). OL builds no Erli-native taxonomy path in v1; products without Allegro taxonomy data are skipped with a clear error (spec #978 §6).

- `buildCreateBody` category/parameter seam in `erli-offer-manager.adapter.ts`.
- Provisional Erli wire types (`ErliExternalCategory` / `ErliExternalAttribute`) isolated in `erli-product.types.ts` — single #992-sandbox reconciliation point.
- `unit` left unwired in v1 (no factory dep added).

## Stacking

Stacked on **#1058** (`984-erli-offer-manager`). Targets `main`; **draft** until the stack merges (order: #1059 → #1019 → #1056 → #1057 → #1058 → this). The inline `ADR-025` references resolve once #1059 lands.

## Testing

`pnpm --filter @openlinker/integrations-erli` type-check, lint, unit tests, and `pnpm check:invariants` all green.

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
