### PR TITLE
feat(erli): frozen-field exclusion on offer PATCH; confirm stock/price sync (#988)

### DIFF
--- a/docs/plans/implementation-plan-erli-stock-price-frozen.md
+++ b/docs/plans/implementation-plan-erli-stock-price-frozen.md
@@ -1,0 +1,115 @@
+# Implementation Plan — Erli stock & price sync + frozen-field ownership (#988)
+
+Branch: `988-erli-stock-price-frozen` (at #985 tip). Plugin-only change; no CORE change, no
+factory-signature change. Types come from the `@openlinker/core/listings` barrel; the frozen
+wire shape is isolated in `erli-product.types.ts` (provisional, #992).
+
+## Scope (locked)
+
+| Sub-deliverable | Status | Action |
+|---|---|---|
+| 1. Stock push (master inventory → offer quantity) | already works | Confirm + note; add unit test if gap. |
+| 2. Price-at-listing | already works (#984 `buildCreateBody`) | Confirm; **master-price propagation out of scope** (no core trigger exists). |
+| 3. Frozen-field exclusion before field-update PATCH | **THE deliverable** | Implement `fetchErliProduct` + frozen filtering in `updateOfferFields`. |
+| 4. Stock-restore-on-cancel | **DEFERRED / BLOCKED** | Document; needs #993 order ingestion. No dead code. |
+
+## 1. Stock push — verified, nothing to build
+
+Confirmed against real code:
+- Core `InventorySyncService.updateOfferQuantity` (`libs/core/src/inventory/application/services/inventory-sync.service.ts`)
+  resolves the `OfferManager` adapter per connection and calls `marketplace.updateOfferQuantity(item)`.
+- #984's `ErliOfferManagerAdapter.updateOfferQuantity` implements that port: `PATCH products/{id} { stock }`.
+
+The propagation chain (master inventory → core sync → port → Erli PATCH) is complete and
+already covered by the existing `updateOfferQuantity` spec cases. **No new code or test** — adding
+another would duplicate existing coverage.
+
+## 2. Price — listing done, propagation out of scope
+
+- `buildCreateBody` already maps `cmd.price` → `body.price` (verified). Price-at-listing ships.
+- There is **no master-price → offer propagation path in core today**. Grep confirms the only
+  `updateOfferFields` caller is `IntegrationsContentPublisherService` (description-only). Building a
+  master-price trigger would be a new CORE orchestrator — out of scope and explicitly excluded.
+  Documented here; no code.
+
+## 3. Frozen-field exclusion (the deliverable)
+
+ADR-025 §4b: "before any PATCH, fields marked `frozen` by seller-panel edits are excluded so OL
+never overwrites a manual edit … per-nested-field granularity."
+
+### 3a. Read type + wire shape (provisional #992) — `erli-product.types.ts`
+
+Add a read-side `ErliProductResource` type with a **per-field frozen marker**. Erli's exact shape is
+unconfirmed (#992 sandbox), so model the most plausible: a top-level `frozenFields: string[]`
+listing the names of frozen fields (e.g. `["price","name","description","stock"]`). This is the single
+reconciliation point; #989 (status) will reuse the same `fetchErliProduct` read path. Clearly marked
+PROVISIONAL.
+
+A small canonical mapping of OL patch-body keys → Erli frozen-field names lives in the adapter
+(`price`, `name`, `description`, `stock`). Per-nested-field granularity = we evaluate each patch key
+independently against the frozen set.
+
+### 3b. Shared read helper — `fetchErliProduct(externalId)`
+
+Private adapter method:
+```
+private async fetchErliProduct(externalId: string): Promise<ErliProductResource> {
+  const res = await this.httpClient.get<ErliProductResource>(this.productPath(externalId));
+  return res.data;
+}
+```
+Reuses the existing `productPath` (validate+encode) and `IErliHttpClient.get`. #989 reuses it for
+status (locked by the meta-plan).
+
+### 3c. `updateOfferFields` — drop frozen fields before PATCH
+
+1. Build the sparse patch from supplied fields (existing `buildPatchFromFields`).
+2. `fetchErliProduct(externalOfferId)` → read `frozenFields`.
+3. For each patch key, if its Erli frozen-name is in the frozen set, delete it from the body and
+   `logger.debug(...)` (no PII).
+4. If the body is now empty → skip the PATCH entirely (no-op; nothing to write).
+5. Otherwise PATCH the surviving keys.
+
+The GET is acceptable here: field-updates are low-frequency (operator/content edits), exactly where
+seller manual edits collide.
+
+### 3d. Quantity-path decision (justified)
+
+`updateOfferQuantity` is the **high-frequency inventory-sync** path. Applying frozen-exclusion there
+means a GET per quantity update — doubling API calls + latency on the hottest path. **Decision: do
+NOT pre-fetch on the quantity path in this wave.** Rationale:
+- Stock is the one field Erli **auto-mutates** (decrement on sale); a seller freezing *stock* is far
+  rarer than freezing price/title/description, and the cost (2× calls on every inventory tick) is
+  paid on every product on every sync.
+- The reconciliation-first posture (ADR-025 §1, #989) is the correct long-term guard for stock
+  drift, not a per-PATCH GET.
+This keeps inventory sync single-call. If a frozen-stock requirement materializes, it becomes an
+opt-in flag in a later wave — noted, not built (YAGNI).
+
+## 4. Stock-restore-on-cancel — DEFERRED (blocked on #993)
+
+ADR-025 §4a wants a pure-plugin compensation: on order cancellation, OL issues a stock-restore PATCH
+(Erli won't restore). That trigger is the Erli order-cancel signal, which only exists once Erli order
+ingestion (OrderSource / inbox poll = #993) lands. There is **no cancel signal to hook today**, so we
+build **no trigger and no dead code** (YAGNI). When #993 ships, its ingestion observes the
+`cancelled` event and calls the **already-existing** `updateOfferQuantity` to restore stock — #993
+only needs to wire the trigger. Documented in the adapter docblock + this plan.
+
+## Files changed
+
+- `libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts` — add `ErliProductResource` read type + `frozenFields` (provisional).
+- `libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts` — `fetchErliProduct`, frozen-filter in `updateOfferFields`, docblock update (scope: §4 deferred, quantity-path decision).
+- `libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts` — frozen-exclusion tests.
+
+## Tests (frozen-exclusion)
+
+- frozen field dropped (frozen `price` → not in PATCH; non-frozen `title` survives).
+- non-frozen field patched (no frozen markers → full PATCH, GET shape asserted).
+- all-supplied-frozen → no PATCH issued (no-op).
+- the GET read shape (`fetchErliProduct` issues `GET products/{id}`).
+- quantity path issues NO GET (single PATCH only) — guards the §3d decision.
+
+## Quality gate
+
+`pnpm --filter "@openlinker/integrations-erli^..." build` then
+`pnpm --filter @openlinker/integrations-erli` type-check + lint + test.

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -391,6 +391,22 @@ describe('ErliOfferManagerAdapter', () => {
         expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, { name: 'Keep me' });
       });
 
+      it('should patch the full body when the GET returns an empty body (no frozen info)', async () => {
+        // The client yields `data: undefined` for a 204 / empty-body 2xx; the read
+        // must degrade to "nothing frozen" rather than throwing on current.frozenFields (#1061).
+        httpClient.get.mockResolvedValue({ status: 200, data: undefined });
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'T', price: { amount: '5.00', currency: 'PLN' } },
+        });
+
+        expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
+          name: 'T',
+          price: { amount: 5, currency: 'PLN' },
+        });
+      });
+
       it('should patch every supplied field when none are frozen', async () => {
         httpClient.get.mockResolvedValue({ status: 200, data: { frozenFields: [] } });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -21,6 +21,7 @@ import { Logger } from '@openlinker/shared/logging';
 import { ErliApiException } from '../../../domain/exceptions/erli-api.exception';
 import { ErliAuthenticationException } from '../../../domain/exceptions/erli-authentication.exception';
 import { ErliConfigException } from '../../../domain/exceptions/erli-config.exception';
+import { ErliNetworkException } from '../../../domain/exceptions/erli-network.exception';
 import { ERLI_ADAPTER_KEY } from '../../../erli.constants';
 import type { IErliHttpClient } from '../../http/erli-http-client.interface';
 import { ErliOfferManagerAdapter } from '../erli-offer-manager.adapter';
@@ -403,7 +404,7 @@ describe('ErliOfferManagerAdapter', () => {
 
         expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
           name: 'T',
-          price: { amount: 5, currency: 'PLN' },
+          price: 500,
         });
       });
 
@@ -417,7 +418,7 @@ describe('ErliOfferManagerAdapter', () => {
 
         expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
           name: 'T',
-          price: { amount: 5, currency: 'PLN' },
+          price: 500,
         });
       });
 
@@ -446,12 +447,26 @@ describe('ErliOfferManagerAdapter', () => {
 
         expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
           name: 'T',
-          price: { amount: 5, currency: 'PLN' },
+          price: 500,
         });
       });
 
-      it('should re-throw a non-404 GET error rather than failing open', async () => {
-        httpClient.get.mockRejectedValue(new ErliApiException('server error', 500));
+      it('should re-throw a transient network/5xx GET error rather than failing open', async () => {
+        // The client surfaces a transient 5xx / connection failure as
+        // ErliNetworkException (NOT ErliApiException — only deterministic 4xx
+        // become ErliApiException). Only a 404 fails open; everything else,
+        // including this realistic transient error, must re-throw so the
+        // runner's retry classifier decides (#1061).
+        httpClient.get.mockRejectedValue(new ErliNetworkException('connection reset'));
+
+        await expect(
+          adapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'T' } }),
+        ).rejects.toBeInstanceOf(ErliNetworkException);
+        expect(httpClient.patch).not.toHaveBeenCalled();
+      });
+
+      it('should re-throw a non-404 ErliApiException (e.g. 403) rather than failing open', async () => {
+        httpClient.get.mockRejectedValue(new ErliApiException('forbidden', 403));
 
         await expect(
           adapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'T' } }),

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -1,11 +1,13 @@
 /**
- * Erli Offer Manager Adapter — unit tests (#984, #985)
+ * Erli Offer Manager Adapter — unit tests (#984, #985, #988)
  *
  * Mocks `IErliHttpClient` to verify: seller-keyed path build (validate+encode),
  * 202→'draft' create mapping, sparse PATCH for field/quantity updates, the
  * safe 4xx→OfferCreateRejectedException mapping (no responseBody leak), auth
- * propagation, hostile-id rejection, imageUrl hygiene, and the #985 Allegro
- * category/parameter reuse (source:"allegro" externalCategories/Attributes).
+ * propagation, hostile-id rejection, imageUrl hygiene, the #985 Allegro
+ * category/parameter reuse (source:"allegro" externalCategories/Attributes),
+ * and the #988 frozen-field exclusion (read-before-PATCH drops frozen fields;
+ * all-frozen → no-op; hot quantity path stays single-call).
  *
  * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
  */
@@ -55,7 +57,8 @@ describe('ErliOfferManagerAdapter', () => {
 
   beforeEach(() => {
     httpClient = {
-      get: jest.fn(),
+      // Default read: no frozen fields, so field-updates PATCH everything supplied.
+      get: jest.fn().mockResolvedValue({ status: 200, data: { frozenFields: [] } }),
       post: jest.fn().mockResolvedValue({ status: 202, data: undefined }),
       patch: jest.fn().mockResolvedValue({ status: 202, data: undefined }),
     };
@@ -368,6 +371,54 @@ describe('ErliOfferManagerAdapter', () => {
         adapter.updateOfferFields({ externalOfferId: 'evil/../x', fields: { title: 'x' } }),
       ).rejects.toBeInstanceOf(ErliConfigException);
     });
+
+    describe('frozen-field exclusion (#988)', () => {
+      it('should read the live product via GET before patching', async () => {
+        await adapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'New' } });
+
+        expect(httpClient.get).toHaveBeenCalledWith(`products/${VALID_ID}`);
+      });
+
+      it('should drop a supplied field that is frozen and patch the rest', async () => {
+        httpClient.get.mockResolvedValue({ status: 200, data: { frozenFields: ['price'] } });
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'Keep me', price: { amount: '79.00', currency: 'PLN' } },
+        });
+
+        // price frozen → dropped; name survives.
+        expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, { name: 'Keep me' });
+      });
+
+      it('should patch every supplied field when none are frozen', async () => {
+        httpClient.get.mockResolvedValue({ status: 200, data: { frozenFields: [] } });
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'T', price: { amount: '5.00', currency: 'PLN' } },
+        });
+
+        expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
+          name: 'T',
+          price: { amount: 5, currency: 'PLN' },
+        });
+      });
+
+      it('should issue NO patch when every supplied field is frozen', async () => {
+        httpClient.get.mockResolvedValue({
+          status: 200,
+          data: { frozenFields: ['name', 'price'] },
+        });
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'T', price: { amount: '5.00', currency: 'PLN' } },
+        });
+
+        expect(httpClient.patch).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('updateOfferQuantity', () => {
@@ -376,6 +427,13 @@ describe('ErliOfferManagerAdapter', () => {
       await adapter.updateOfferQuantity(cmd);
 
       expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, { stock: 7 });
+    });
+
+    it('should NOT pre-fetch the product (hot inventory path stays single-call, #988 §3d)', async () => {
+      await adapter.updateOfferQuantity({ offerId: VALID_ID, quantity: 7 });
+
+      expect(httpClient.get).not.toHaveBeenCalled();
+      expect(httpClient.patch).toHaveBeenCalledTimes(1);
     });
 
     it('should reject a hostile offerId', async () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -434,6 +434,30 @@ describe('ErliOfferManagerAdapter', () => {
 
         expect(httpClient.patch).not.toHaveBeenCalled();
       });
+
+      it('should fail open and PATCH the full body when the GET 404s in the cache-lag window', async () => {
+        // ADR-025: a just-created offer GET-404s during Erli's ~20-min cache lag (#1061).
+        httpClient.get.mockRejectedValue(new ErliApiException('not found', 404));
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'T', price: { amount: '5.00', currency: 'PLN' } },
+        });
+
+        expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
+          name: 'T',
+          price: { amount: 5, currency: 'PLN' },
+        });
+      });
+
+      it('should re-throw a non-404 GET error rather than failing open', async () => {
+        httpClient.get.mockRejectedValue(new ErliApiException('server error', 500));
+
+        await expect(
+          adapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'T' } }),
+        ).rejects.toBeInstanceOf(ErliApiException);
+        expect(httpClient.patch).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -194,16 +194,17 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
       return body;
     }
     const frozen = new Set(frozenFields);
-    const result: ErliProductPatchBody = {};
-    for (const key of Object.keys(body) as (keyof ErliProductPatchBody)[]) {
+    // Shallow-copy then delete frozen keys — avoids a per-key index-write cast
+    // while preserving each value's own type.
+    const result: ErliProductPatchBody = { ...body };
+    for (const key of Object.keys(result) as (keyof ErliProductPatchBody)[]) {
       const erliName = PATCH_KEY_TO_ERLI_FROZEN_NAME[key];
       if (erliName !== undefined && frozen.has(erliName)) {
         this.logger.debug(
           `Skipping frozen Erli field "${erliName}" on field-update [connectionId=${this.connectionId}]`,
         );
-        continue;
+        delete result[key];
       }
-      result[key] = body[key] as never;
     }
     return result;
   }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -86,11 +86,16 @@ const ERLI_PRODUCT_ID_PATTERN = /^ol_variant_[a-f0-9]{32}$/;
  * PROVISIONAL alongside the wire shape in `erli-product.types.ts` (#992): if the
  * confirmed frozen-name set differs, this is the single change point.
  */
+// OL patch-key → Erli frozen-marker wire name. Provisional #992 wire vocabulary,
+// coupled to `ErliProductResource.frozenFields` (erli-product.types.ts) — reconcile
+// both against the sandbox together. `stock` is intentionally absent: the hot
+// quantity path (`updateOfferQuantity`) does not read frozen state in v1, so a
+// `stock` entry here would be dead code asserting a guarantee no path delivers.
+// Honoring frozen-stock is deferred to #1066 (ADR-025 §4b).
 const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, string>> = {
   price: 'price',
   name: 'name',
   description: 'description',
-  stock: 'stock',
 };
 
 export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, OfferFieldUpdater {
@@ -138,7 +143,20 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
     const body = this.buildPatchFromFields(cmd.fields);
     // #988 / ADR-025 §4b: never overwrite a field the seller froze in the panel.
     // Read the live product, drop frozen keys per-field; an empty body is a no-op.
-    const current = await this.fetchErliProduct(cmd.externalOfferId);
+    let current: ErliProductResource;
+    try {
+      current = await this.fetchErliProduct(cmd.externalOfferId);
+    } catch (error) {
+      // ADR-025 is reconciliation-first: within Erli's ~20-min read-after-write
+      // cache lag a just-created offer GET-404s. Fail open — PATCH the full body
+      // (frozen state unknown, and a just-created offer has no manual freezes yet)
+      // rather than blocking the update. Re-throw anything that isn't a 404 (#1061).
+      if (error instanceof ErliApiException && error.statusCode === 404) {
+        current = {} as ErliProductResource;
+      } else {
+        throw error;
+      }
+    }
     const filtered = this.dropFrozenFields(body, current.frozenFields);
     if (Object.keys(filtered).length === 0) {
       this.logger.debug(
@@ -191,6 +209,10 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
   }
 
   async updateOfferQuantity(cmd: UpdateOfferQuantityCommand): Promise<void> {
+    // Frozen-stock is intentionally NOT honored here in v1: this runs on every
+    // inventory tick and skips the read-before-write GET for performance, so a
+    // seller-frozen `stock` is not detectable on this path. Deferred to #1066
+    // (ADR-025 §4b) — to be done without a per-tick GET via a cached frozen flag.
     const body: ErliProductPatchBody = { stock: cmd.quantity };
     await this.httpClient.patch(this.productPath(cmd.offerId), body);
   }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -21,9 +21,23 @@
  * (ADR-025 §3); no Erli-native taxonomy authoring. Applies to the create path
  * only — `buildPatchFromFields` is untouched.
  *
- * Out of scope (own issues, marked seams): variant grouping #986, stock/price
- * master sourcing + frozen-field exclusion #988, offer-status reconciliation
- * #989.
+ * Frozen-field ownership (#988, ADR-025 §4b): Erli marks seller-panel manual
+ * edits `frozen`; OL must not overwrite them. `updateOfferFields` reads the
+ * current product (`fetchErliProduct`) and DROPS any supplied field whose Erli
+ * frozen-name is in `frozenFields` before issuing the PATCH (per-nested-field
+ * granularity); an all-frozen update issues no PATCH. The hot `updateOfferQuantity`
+ * inventory path deliberately does NOT pre-fetch — that would double every
+ * inventory tick's API calls; stock drift is guarded by reconciliation (#989),
+ * not a per-PATCH GET (decision recorded in the #988 plan).
+ *
+ * Stock-restore-on-cancel (#988 / ADR-025 §4a) is DEFERRED to the orders half:
+ * it needs an Erli order-cancel signal (OrderSource / inbox poll, #993) that
+ * does not exist yet — no trigger is wired here (YAGNI). The restore mechanism
+ * already exists (`updateOfferQuantity`); #993 only needs to observe the
+ * `cancelled` event and call it.
+ *
+ * Out of scope (own issues, marked seams): variant grouping #986, master-price
+ * → offer propagation (no core trigger today), offer-status reconciliation #989.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  * @see {@link OfferManagerPort}
@@ -52,6 +66,7 @@ import type {
   ErliProductCreateBody,
   ErliProductImage,
   ErliProductPatchBody,
+  ErliProductResource,
 } from './erli-product.types';
 
 /**
@@ -63,6 +78,20 @@ import type {
  * must change in lockstep (a mismatch fails closed: updates throw, never send).
  */
 const ERLI_PRODUCT_ID_PATTERN = /^ol_variant_[a-f0-9]{32}$/;
+
+/**
+ * Maps OL patch-body keys to the Erli field name carried in
+ * {@link ErliProductResource.frozenFields} (#988, ADR-025 §4b). Only the keys a
+ * field-update can supply are listed; an unmapped key is never treated as frozen.
+ * PROVISIONAL alongside the wire shape in `erli-product.types.ts` (#992): if the
+ * confirmed frozen-name set differs, this is the single change point.
+ */
+const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, string>> = {
+  price: 'price',
+  name: 'name',
+  description: 'description',
+  stock: 'stock',
+};
 
 export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, OfferFieldUpdater {
   private readonly logger = new Logger(ErliOfferManagerAdapter.name);
@@ -107,7 +136,55 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
 
   async updateOfferFields(cmd: UpdateOfferFieldsCommand): Promise<void> {
     const body = this.buildPatchFromFields(cmd.fields);
-    await this.httpClient.patch(this.productPath(cmd.externalOfferId), body);
+    // #988 / ADR-025 §4b: never overwrite a field the seller froze in the panel.
+    // Read the live product, drop frozen keys per-field; an empty body is a no-op.
+    const current = await this.fetchErliProduct(cmd.externalOfferId);
+    const filtered = this.dropFrozenFields(body, current.frozenFields);
+    if (Object.keys(filtered).length === 0) {
+      this.logger.debug(
+        `Erli field-update is a no-op — all supplied fields are frozen [connectionId=${this.connectionId}]`,
+      );
+      return;
+    }
+    await this.httpClient.patch(this.productPath(cmd.externalOfferId), filtered);
+  }
+
+  /**
+   * Read the current Erli product (#988). Reuses {@link productPath}
+   * (validate+encode) so a hostile id fails closed exactly as the write paths
+   * do. #989 reuses this read path for offer-status reconciliation.
+   */
+  private async fetchErliProduct(externalId: string): Promise<ErliProductResource> {
+    const res = await this.httpClient.get<ErliProductResource>(this.productPath(externalId));
+    return res.data;
+  }
+
+  /**
+   * Return a copy of the patch body with every key the seller has frozen removed
+   * (per-nested-field granularity, ADR-025 §4b). Each OL patch key maps to its
+   * Erli frozen-name via {@link PATCH_KEY_TO_ERLI_FROZEN_NAME}; a key with no
+   * mapping is never considered frozen. Dropped keys are debug-logged (no PII).
+   */
+  private dropFrozenFields(
+    body: ErliProductPatchBody,
+    frozenFields: string[] | undefined,
+  ): ErliProductPatchBody {
+    if (!frozenFields || frozenFields.length === 0) {
+      return body;
+    }
+    const frozen = new Set(frozenFields);
+    const result: ErliProductPatchBody = {};
+    for (const key of Object.keys(body) as (keyof ErliProductPatchBody)[]) {
+      const erliName = PATCH_KEY_TO_ERLI_FROZEN_NAME[key];
+      if (erliName !== undefined && frozen.has(erliName)) {
+        this.logger.debug(
+          `Skipping frozen Erli field "${erliName}" on field-update [connectionId=${this.connectionId}]`,
+        );
+        continue;
+      }
+      result[key] = body[key] as never;
+    }
+    return result;
   }
 
   async updateOfferQuantity(cmd: UpdateOfferQuantityCommand): Promise<void> {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -156,7 +156,10 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
    */
   private async fetchErliProduct(externalId: string): Promise<ErliProductResource> {
     const res = await this.httpClient.get<ErliProductResource>(this.productPath(externalId));
-    return res.data;
+    // The client returns `data: undefined` for a 204 / empty-body 2xx. Treat a
+    // bodyless read as "no frozen info known" (empty resource) so the PATCH still
+    // proceeds rather than throwing on `current.frozenFields` (review #1061).
+    return res.data ?? ({} as ErliProductResource);
   }
 
   /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -152,7 +152,7 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
       // (frozen state unknown, and a just-created offer has no manual freezes yet)
       // rather than blocking the update. Re-throw anything that isn't a 404 (#1061).
       if (error instanceof ErliApiException && error.statusCode === 404) {
-        current = {} as ErliProductResource;
+        current = {};
       } else {
         throw error;
       }
@@ -177,7 +177,7 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
     // The client returns `data: undefined` for a 204 / empty-body 2xx. Treat a
     // bodyless read as "no frozen info known" (empty resource) so the PATCH still
     // proceeds rather than throwing on `current.frozenFields` (review #1061).
-    return res.data ?? ({} as ErliProductResource);
+    return res.data ?? {};
   }
 
   /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -90,3 +90,22 @@ export type ErliProductPatchBody = Pick<
   ErliProductCreateBody,
   'name' | 'price' | 'stock' | 'description'
 >;
+
+/**
+ * Provisional read-side product resource — `GET /products/{externalId}` (#988 /
+ * #992). The single field #988 needs is {@link ErliProductResource.frozenFields}:
+ * Erli marks seller-panel manual edits `frozen` (ADR-025 §4b, per-nested-field
+ * granularity), and OL must NOT overwrite a frozen field on a subsequent PATCH.
+ *
+ * PROVISIONAL: the exact wire shape of the frozen marker is unconfirmed until
+ * the #992 sandbox spike. Modelled here as a flat list of frozen Erli field
+ * names (e.g. `["price","name","description","stock"]`) — the most plausible
+ * shape and the simplest to evaluate per-field. If #992 reveals a different
+ * shape (e.g. a per-field `{ value, frozen }` object), this type and
+ * {@link ErliOfferManagerAdapter.fetchErliProduct}'s consumers are the single
+ * change point. #989 reuses this same read path for offer-status reconciliation.
+ */
+export interface ErliProductResource {
+  /** Erli field names the seller has frozen via manual panel edits. */
+  frozenFields?: string[];
+}


### PR DESCRIPTION
## What & why

Implements **#988** — the `frozen`-field ownership invariant from **ADR-025** decision 4: before any offer `PATCH`, fields the seller marked `frozen` (manual panel edits) are excluded so OL never overwrites them.

- `fetchErliProduct` GET helper (reuses `productPath` allowlist + `encodeURIComponent`) to read current resource incl. `frozenFields`.
- `dropFrozenFields` filters the sparse PATCH; all-frozen → no-op (logged at debug).
- Stock/price master sync confirmed against the existing offer-quantity/field seams.

## Out of scope

Cancel-restore stock PATCH (ADR-025 decision 4a) is **deferred to #993** — there is no order-cancellation orchestration in core yet (`OrderProcessorManagerPort` has only `createOrder`); it needs Erli order ingestion first. Only frozen-field exclusion ships here.

## Stacking

Stacked on **#985** (`985-erli-category-param`). Targets `main`; **draft** until the stack merges.

## Testing

`pnpm --filter @openlinker/integrations-erli` type-check, lint, unit tests, and `pnpm check:invariants` all green.

Part of #988 — frozen-field exclusion for content (price/name/description) only; frozen-stock is deferred to #1066 and cancel-restore to #993, so do not auto-close #988 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)