### PR TITLE
feat(erli): multi-variant grouping via externalVariantGroup (#986)

### DIFF
--- a/docs/plans/implementation-plan-erli-variant-grouping.md
+++ b/docs/plans/implementation-plan-erli-variant-grouping.md
@@ -1,0 +1,186 @@
+# Implementation Plan — Erli multi-variant grouping (`externalVariantGroup`) — #986
+
+> Story #986 in the #978 Erli offers half. Depends on #984 (offer-manager) /
+> #985 (category-param reuse) / #988 (frozen-field) — all already in this base.
+> Sequential stack: this lands purely in the `// #986:` seam of
+> `buildCreateBody` + additive wire types in `erli-product.types.ts`. It does
+> NOT touch the `#985` taxonomy logic, the `#988` create/PATCH/frozen logic, the
+> factory, the plugin, or any core contract.
+
+## 1. Goal
+
+Emit Erli's **explicit** variant grouping so a multi-variant OL product lists as
+**one** buyer-facing Erli listing instead of N unrelated ones (spec §5 story 3).
+Each variant is its own Erli product keyed by its own `externalId`
+(`resolveErliProductId(cmd)` = the OL variant id, already the case);
+`externalVariantGroup.id` (the parent/base OL product id) groups the siblings;
+distinguishing axes are declared via a per-variant `attributes[]` array.
+
+Unlike Allegro (Product-Catalog **auto**-grouping off GTIN + a distinguishing
+parameter — no explicit group field), Erli grouping is explicit via the group
+id. Single-variant / simple products pass through **ungrouped** — no
+`externalVariantGroup`, no grouping `attributes`.
+
+## 2. Key design question — resolved (data source for group id + attributes)
+
+**Where do the group id (parent product id) and the variant's distinguishing
+attributes come from, and does the factory change?**
+
+Evidence gathered from the live repo:
+
+| Source | Carries group id? | Carries variant attributes? |
+|---|---|---|
+| `CreateOfferCommand` (`@openlinker/core/listings`, `offer-create.types.ts`) | **No** — fields are `internalVariantId`, `connectionId`, `price`, `stock`, `publishImmediately`, `overrides` (`title`/`description`/`categoryId`/`productCardId`/`imageUrls`/`platformParams`), `idempotencyKey`, `variantBarcode`, `productCardId`. No parent-product id, no sibling/group info, no `attributes`. | **No** |
+| `ProductVariant` entity (`libs/core/src/products`) | `productId` (the natural group anchor) | `attributes: Record<string,string> \| null` (the distinguishing axes) |
+| `OfferBuilderService` | Fetches the variant + parent product internally (`variant.productId`, `productMaster.getProduct(...)`) but **does not thread either onto the command** | same |
+| #824 multi-variant expansion (`BulkListingSubmitService.expandVariantJobs`) | Fans out one job **per sibling variant** keyed by `variantId`; siblings drop the FE `productCardId` so each self-links by barcode — but the emitted `CreateOfferCommand` stays the flat shape (no group id, no attributes) | same |
+
+**Conclusion.** The grouping inputs exist in core (on `ProductVariant`) but are
+**not** on the neutral `CreateOfferCommand` and never reach any adapter today.
+Allegro doesn't need them (auto-grouping); Erli does (explicit). To populate the
+group, the adapter would need **one** of:
+
+1. a products-service / `IIntegrationsService` dependency → **new factory dep +
+   new core wiring** (the adapter would fetch the variant + siblings itself), or
+2. core threading `parentProductId` + `attributes` onto `CreateOfferCommand` via
+   `OfferBuilderService` (which already loads both) → **a cross-cutting change to
+   the neutral contract shared by Allegro/eBay/Woo/Shopify**.
+
+**Decision: do neither structural change now. Factory is UNCHANGED.** Both
+options are out of proportion to a single sequential-stack story and contradict
+the established posture (#984/#985/#988 deliberately avoided factory churn; the
+factory comment explicitly says #985/#986/#988 should "extend behaviour without
+churning this signature"). Instead:
+
+- **Wire shape + `buildCreateBody` seam land now** (the additive, isolated,
+  low-risk part the issue scopes): `ErliProductCreateBody` gains optional
+  `externalVariantGroup?: { id: string }` and a variant `attributes?: {
+  name: string; value: string }[]`; `buildCreateBody`'s `// #986:` seam reads
+  the grouping inputs from a forward-compatible, **adapter-neutral** location on
+  the command — `overrides.platformParams` (the documented opaque
+  adapter-interpreted bag) — under an Erli-scoped key, and emits
+  `externalVariantGroup` + `attributes` **only** when a group id is present AND
+  the product is genuinely multi-variant.
+- **Core plumbing that POPULATES that location is explicitly DEFERRED.** Until a
+  follow-up threads `parentProductId` + sibling-distinguishing `attributes`
+  through `OfferBuilderService`/the bulk expansion into
+  `overrides.platformParams.erliVariantGroup`, the key is absent → the adapter
+  emits **ungrouped** — which is exactly the required single/simple passthrough
+  behaviour, so the adapter is *correct today* and *grouped automatically* the
+  moment the data arrives. No dead code: the seam is exercised by unit tests
+  feeding the command shape directly, the same way #985 tests feed
+  `platformParams.parameters`.
+
+This is the smallest correct approach: zero core-contract change, zero factory
+change, wire shapes isolated to `erli-product.types.ts`, and a single documented
+deferral for the core data-population follow-up.
+
+### 2a. The Erli-scoped `platformParams` contract (this story's micro-contract)
+
+`overrides.platformParams.erliVariantGroup` (read defensively, narrowed — no
+`any`):
+
+```ts
+// Provisional, read-only on the command; populated by a deferred core follow-up.
+{ groupId: string; attributes?: { name: string; value: string }[] }
+```
+
+- `groupId` — the parent/base OL product id; becomes `externalVariantGroup.id`.
+  Present ⇒ the product is multi-variant (the populator sets it only then).
+  Absent / empty ⇒ ungrouped.
+- `attributes` — the variant's distinguishing axes (`{name,value}`), already
+  flattened from `ProductVariant.attributes` (`Record<string,string>`) by the
+  populator. Emitted verbatim onto the create body. Absent ⇒ no `attributes`.
+
+Reading from `platformParams` mirrors the #985 precedent
+(`platformParams.parameters`/`.productParameters`) — Erli reads only the keys it
+knows; the neutral command stays platform-neutral; no new top-level command
+field is invented for one platform.
+
+## 3. Changes
+
+### 3.1 `erli-product.types.ts` (additive wire shapes, PROVISIONAL #992)
+
+- New interface `ErliVariantGroupRef { id: string }`.
+- New interface `ErliVariantAttribute { name: string; value: string }`.
+- On `ErliProductCreateBody`: add `externalVariantGroup?: ErliVariantGroupRef`
+  and `attributes?: ErliVariantAttribute[]` (both optional; omitted ⇒ ungrouped).
+- Update the file header: replace "Variant grouping (#986) remains absent." with
+  a one-line note that #986 adds the provisional group/attribute shapes (still
+  PROVISIONAL until the #992 sandbox spike — single reconciliation point).
+- `ErliProductPatchBody = ErliProductCreateBody` is unchanged structurally;
+  grouping is create-only (the adapter never emits group/attributes on PATCH —
+  `buildPatchFromFields` is untouched), matching the #985 create-only posture.
+
+### 3.2 `erli-offer-manager.adapter.ts` — the `// #986:` seam
+
+- Replace the `// #986: externalVariantGroup is assembled here.` placeholder with
+  a call that reads `cmd.overrides?.platformParams?.erliVariantGroup`, narrows it
+  with a local type-guard (`isErliVariantGroupInput`), and when a non-empty
+  `groupId` is present sets `body.externalVariantGroup = { id: groupId }` and,
+  if `attributes` is a non-empty well-formed `{name,value}[]`, sets
+  `body.attributes`.
+- A free function `buildVariantGroup(cmd)` + guard, co-located with the existing
+  `buildExternalCategories` / `buildExternalAttributes` free functions and their
+  `isAllegroParameterShape` guard, for symmetry and testability. No `any` — narrow
+  `unknown` via the guard exactly like `isAllegroParameterShape`.
+- `resolveErliProductId(cmd)` is REUSED unchanged for the per-variant external id
+  (already `cmd.internalVariantId`). No path/security change — grouping touches
+  only the body.
+- Update the adapter header's "Out of scope … variant grouping #986" line to
+  note #986 now emits create-time grouping from `platformParams.erliVariantGroup`
+  (data population deferred to core follow-up).
+
+### 3.3 No changes
+
+Factory, plugin, module, HTTP client, validators, tester, retry/auth
+classifiers, core contracts — all untouched.
+
+## 4. Tests (`erli-offer-manager.adapter.spec.ts`, new `variant grouping (#986)` describe)
+
+Feed the command shape directly (mirrors the #985 `platformParams` tests):
+
+1. **Multi-variant → group + attributes present**: `platformParams.erliVariantGroup
+   = { groupId: 'ol_product_…', attributes: [{name:'Color',value:'Red'}] }` ⇒ body
+   has `externalVariantGroup: { id: 'ol_product_…' }` and `attributes:
+   [{name:'Color',value:'Red'}]`.
+2. **Single/simple → ungrouped**: no `erliVariantGroup` key (or empty `groupId`)
+   ⇒ body has neither `externalVariantGroup` nor grouping `attributes`.
+3. **Sibling variants share the same group id**: two commands with different
+   `internalVariantId` but the same `groupId` ⇒ both bodies carry the same
+   `externalVariantGroup.id` (and each still POSTs to its own variant path).
+4. **Attributes mapping / hygiene**: `groupId` present but `attributes` absent ⇒
+   `externalVariantGroup` set, no `attributes` key; malformed attribute entries
+   (missing `name`/`value`, non-string) are dropped; empty `attributes` ⇒ key
+   omitted.
+5. **Grouping is create-only**: a field-update / quantity-update PATCH never
+   carries `externalVariantGroup` or grouping `attributes` (regression guard on
+   the create-only posture).
+
+Update the spec header issue list to `(#984, #985, #986, #988)`.
+
+## 5. Risks / deferrals
+
+- **R1 (primary, documented above): core does not yet populate
+  `platformParams.erliVariantGroup`.** Consequence: Erli offers list ungrouped
+  until the follow-up lands — identical to today's behaviour, no regression. The
+  follow-up (thread `parentProductId` + flattened sibling-distinguishing
+  `attributes` through `OfferBuilderService` / the #824 expansion) is the
+  natural home because both inputs are already loaded there; it is intentionally
+  **out of this story's scope** (it changes the core contract + the bulk path,
+  which deserves its own issue). Flagged in the leftover-concerns of the report.
+- **R2 (#992): wire shapes provisional.** `externalVariantGroup`/`attributes`
+  field names + the group-id semantics (parent id vs a dedicated group key) are
+  unconfirmed until the sandbox spike. Contained to `erli-product.types.ts`
+  (single reconciliation point) per the existing PROVISIONAL convention.
+- **R3: attribute axis selection.** Emitting *all* of a variant's `attributes`
+  vs only the axes that actually distinguish siblings is a populator concern
+  (core), not the adapter's — the adapter emits what it's given. Noted so the
+  follow-up decides the distinguishing-axis policy.
+
+## 6. Gate
+
+`pnpm --filter "@openlinker/integrations-erli^..." build`, then type-check +
+lint + test on `@openlinker/integrations-erli`. No `any`; types from the
+`@openlinker/core/listings` barrel; wire shapes isolated in
+`erli-product.types.ts`.

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -331,6 +331,7 @@ describe('ErliOfferManagerAdapter', () => {
         await adapter.createOffer(
           createCmd({
             overrides: {
+              categoryId: '18654',
               platformParams: {
                 erliVariantGroup: {
                   groupId: GROUP_ID,
@@ -359,7 +360,7 @@ describe('ErliOfferManagerAdapter', () => {
 
       it('should ignore an empty groupId (treats as ungrouped)', async () => {
         await adapter.createOffer(
-          createCmd({ overrides: { platformParams: { erliVariantGroup: { groupId: '' } } } }),
+          createCmd({ overrides: { categoryId: '18654', platformParams: { erliVariantGroup: { groupId: '' } } } }),
         );
 
         const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
@@ -373,10 +374,10 @@ describe('ErliOfferManagerAdapter', () => {
         const platformParams = { erliVariantGroup: { groupId: GROUP_ID } };
 
         await adapter.createOffer(
-          createCmd({ internalVariantId: variantA, overrides: { platformParams } }),
+          createCmd({ internalVariantId: variantA, overrides: { categoryId: '18654', platformParams } }),
         );
         await adapter.createOffer(
-          createCmd({ internalVariantId: variantB, overrides: { platformParams } }),
+          createCmd({ internalVariantId: variantB, overrides: { categoryId: '18654', platformParams } }),
         );
 
         const [pathA, bodyA] = httpClient.post.mock.calls[0] as [string, { externalVariantGroup?: unknown }];
@@ -389,7 +390,7 @@ describe('ErliOfferManagerAdapter', () => {
 
       it('should emit externalVariantGroup with no attributes key when attributes are absent', async () => {
         await adapter.createOffer(
-          createCmd({ overrides: { platformParams: { erliVariantGroup: { groupId: GROUP_ID } } } }),
+          createCmd({ overrides: { categoryId: '18654', platformParams: { erliVariantGroup: { groupId: GROUP_ID } } } }),
         );
 
         const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
@@ -401,6 +402,7 @@ describe('ErliOfferManagerAdapter', () => {
         await adapter.createOffer(
           createCmd({
             overrides: {
+              categoryId: '18654',
               platformParams: {
                 erliVariantGroup: {
                   groupId: GROUP_ID,

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Erli Offer Manager Adapter — unit tests (#984, #985, #988)
+ * Erli Offer Manager Adapter — unit tests (#984, #985, #986, #988)
  *
  * Mocks `IErliHttpClient` to verify: seller-keyed path build (validate+encode),
  * 202→'draft' create mapping, sparse PATCH for field/quantity updates, the
@@ -320,6 +320,114 @@ describe('ErliOfferManagerAdapter', () => {
           expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('12345'));
         } finally {
           debugSpy.mockRestore();
+        }
+      });
+    });
+
+    describe('variant grouping (#986)', () => {
+      const GROUP_ID = `ol_product_${'b'.repeat(32)}`;
+
+      it('should emit externalVariantGroup + attributes for a multi-variant product', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              platformParams: {
+                erliVariantGroup: {
+                  groupId: GROUP_ID,
+                  attributes: [{ name: 'Color', value: 'Red' }],
+                },
+              },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as {
+          externalVariantGroup?: unknown;
+          attributes?: unknown;
+        };
+        expect(body.externalVariantGroup).toEqual({ id: GROUP_ID });
+        expect(body.attributes).toEqual([{ name: 'Color', value: 'Red' }]);
+      });
+
+      it('should list ungrouped (no externalVariantGroup/attributes) for a single/simple product', async () => {
+        await adapter.createOffer(createCmd());
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).not.toHaveProperty('externalVariantGroup');
+        expect(body).not.toHaveProperty('attributes');
+      });
+
+      it('should ignore an empty groupId (treats as ungrouped)', async () => {
+        await adapter.createOffer(
+          createCmd({ overrides: { platformParams: { erliVariantGroup: { groupId: '' } } } }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).not.toHaveProperty('externalVariantGroup');
+        expect(body).not.toHaveProperty('attributes');
+      });
+
+      it('should give sibling variants the same group id while each posts to its own path', async () => {
+        const variantA = `ol_variant_${'a'.repeat(32)}`;
+        const variantB = `ol_variant_${'c'.repeat(32)}`;
+        const platformParams = { erliVariantGroup: { groupId: GROUP_ID } };
+
+        await adapter.createOffer(
+          createCmd({ internalVariantId: variantA, overrides: { platformParams } }),
+        );
+        await adapter.createOffer(
+          createCmd({ internalVariantId: variantB, overrides: { platformParams } }),
+        );
+
+        const [pathA, bodyA] = httpClient.post.mock.calls[0] as [string, { externalVariantGroup?: unknown }];
+        const [pathB, bodyB] = httpClient.post.mock.calls[1] as [string, { externalVariantGroup?: unknown }];
+        expect(pathA).toBe(`products/${variantA}`);
+        expect(pathB).toBe(`products/${variantB}`);
+        expect(bodyA.externalVariantGroup).toEqual({ id: GROUP_ID });
+        expect(bodyB.externalVariantGroup).toEqual({ id: GROUP_ID });
+      });
+
+      it('should emit externalVariantGroup with no attributes key when attributes are absent', async () => {
+        await adapter.createOffer(
+          createCmd({ overrides: { platformParams: { erliVariantGroup: { groupId: GROUP_ID } } } }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body.externalVariantGroup).toEqual({ id: GROUP_ID });
+        expect(body).not.toHaveProperty('attributes');
+      });
+
+      it('should drop malformed attribute entries and omit the key when none survive', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              platformParams: {
+                erliVariantGroup: {
+                  groupId: GROUP_ID,
+                  attributes: [
+                    { name: 'Color', value: 'Red' },
+                    { name: 'Size' }, // missing value → dropped
+                    { value: 'X' }, // missing name → dropped
+                    { name: 5, value: 'Y' }, // non-string name → dropped
+                  ],
+                },
+              },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { attributes?: unknown };
+        expect(body.attributes).toEqual([{ name: 'Color', value: 'Red' }]);
+      });
+
+      it('should never emit grouping on a field-update or quantity PATCH (create-only)', async () => {
+        await adapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'T' } });
+        await adapter.updateOfferQuantity({ offerId: VALID_ID, quantity: 3 });
+
+        for (const call of httpClient.patch.mock.calls) {
+          const body = call[1] as Record<string, unknown>;
+          expect(body).not.toHaveProperty('externalVariantGroup');
+          expect(body).not.toHaveProperty('attributes');
         }
       });
     });

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -36,8 +36,17 @@
  * already exists (`updateOfferQuantity`); #993 only needs to observe the
  * `cancelled` event and call it.
  *
- * Out of scope (own issues, marked seams): variant grouping #986, master-price
- * → offer propagation (no core trigger today), offer-status reconciliation #989.
+ * Variant grouping (#986): the create body carries `externalVariantGroup` (the
+ * parent/base product id shared by sibling variants) + per-variant `attributes`
+ * when the command's `overrides.platformParams.erliVariantGroup` is populated.
+ * Single/simple products omit it and list ungrouped. The CORE plumbing that
+ * POPULATES that key (threading the parent product id + flattened distinguishing
+ * attributes through OfferBuilderService / the #824 bulk expansion) is a deferred
+ * follow-up — until it lands, the key is absent and offers list ungrouped (no
+ * regression). Create-path only; `buildPatchFromFields` never emits grouping.
+ *
+ * Out of scope (own issues, marked seams): master-price → offer propagation (no
+ * core trigger today), offer-status reconciliation #989.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  * @see {@link OfferManagerPort}
@@ -67,6 +76,7 @@ import type {
   ErliProductImage,
   ErliProductPatchBody,
   ErliProductResource,
+  ErliVariantAttribute,
 } from './erli-product.types';
 
 /**
@@ -293,7 +303,16 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
     if (externalAttributes.length > 0) {
       body.externalAttributes = externalAttributes;
     }
-    // #986: externalVariantGroup is assembled here.
+    // #986: explicit multi-variant grouping. Present only when core populated
+    // `overrides.platformParams.erliVariantGroup` (deferred follow-up); single/
+    // simple products list ungrouped.
+    const group = buildVariantGroup(cmd);
+    if (group) {
+      body.externalVariantGroup = { id: group.id };
+      if (group.attributes.length > 0) {
+        body.attributes = group.attributes;
+      }
+    }
     return body;
   }
 
@@ -492,6 +511,68 @@ function buildExternalAttributes(cmd: CreateOfferCommand): {
     }
   }
   return { attributes, droppedParamIds };
+}
+
+function toUnknownArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? (value as unknown[]) : [];
+}
+
+/** Resolved #986 grouping inputs after narrowing the opaque platformParams bag. */
+interface ResolvedVariantGroup {
+  id: string;
+  attributes: ErliVariantAttribute[];
+}
+
+/**
+ * Read the #986 grouping inputs from the command's adapter-neutral
+ * `overrides.platformParams.erliVariantGroup` bag (mirrors how #985 reads
+ * `platformParams.parameters`). Returns null — list UNGROUPED — when the key is
+ * absent or carries no non-empty `groupId` (single/simple products, and the
+ * not-yet-populated default state until the deferred core follow-up lands).
+ * Distinguishing `attributes` are narrowed per-entry; malformed entries drop.
+ */
+function buildVariantGroup(cmd: CreateOfferCommand): ResolvedVariantGroup | null {
+  const candidate = cmd.overrides?.platformParams?.erliVariantGroup;
+  if (!isErliVariantGroupShape(candidate)) {
+    return null;
+  }
+  const attributes: ErliVariantAttribute[] = [];
+  for (const entry of toUnknownArray(candidate.attributes)) {
+    if (isVariantAttributeShape(entry)) {
+      attributes.push({ name: entry.name, value: entry.value });
+    }
+  }
+  return { id: candidate.groupId, attributes };
+}
+
+/** Erli grouping input on `platformParams`, after narrowing. */
+interface ErliVariantGroupShape {
+  groupId: string;
+  attributes?: unknown;
+}
+
+/**
+ * Narrow the opaque `platformParams.erliVariantGroup` value: require a non-empty
+ * `groupId: string`. `attributes` (if present) is validated per-entry in
+ * {@link buildVariantGroup}, so it stays `unknown` here.
+ */
+function isErliVariantGroupShape(candidate: unknown): candidate is ErliVariantGroupShape {
+  if (typeof candidate !== 'object' || candidate === null) {
+    return false;
+  }
+  const c = candidate as { groupId?: unknown };
+  return typeof c.groupId === 'string' && c.groupId.length > 0;
+}
+
+/** Narrow a single distinguishing-attribute entry to `{ name, value }` strings. */
+function isVariantAttributeShape(candidate: unknown): candidate is ErliVariantAttribute {
+  if (typeof candidate !== 'object' || candidate === null) {
+    return false;
+  }
+  const c = candidate as { name?: unknown; value?: unknown };
+  return (
+    typeof c.name === 'string' && c.name.length > 0 && typeof c.value === 'string' && c.value.length > 0
+  );
 }
 
 function flattenDescription(input: string | OfferDescriptionUpdate): string {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -13,7 +13,8 @@
  *
  * The #985 taxonomy fields (`externalCategories` / `externalAttributes`, tagged
  * `source:"allegro"`, reusing OL's already-resolved Allegro ids — ADR-025 §3)
- * are layered in here. Variant grouping (#986) is added by its own issue.
+ * and the #986 variant-grouping shapes (`externalVariantGroup` + per-variant
+ * `attributes`) are layered in here as the same single reconciliation point.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  */
@@ -57,6 +58,29 @@ export interface ErliExternalAttribute {
 }
 
 /**
+ * Multi-variant grouping reference (#986). `id` is the parent/base OL product id
+ * shared by every sibling variant; Erli uses it to render the N sibling products
+ * as ONE buyer-facing listing. Unlike Allegro (Product-Catalog auto-grouping off
+ * GTIN), Erli grouping is explicit via this id. Single/simple products omit it.
+ * PROVISIONAL (#992): the wire key + whether the group id is the parent product
+ * id or a dedicated group key is unconfirmed until the sandbox spike.
+ */
+export interface ErliVariantGroupRef {
+  id: string;
+}
+
+/**
+ * A variant's distinguishing axis (#986), e.g. `{ name: 'Color', value: 'Red' }`.
+ * Declared per-variant so Erli can present selectable options within the grouped
+ * listing. Flattened from OL `ProductVariant.attributes` (`Record<string,string>`)
+ * by the (deferred) core populator before it reaches the command.
+ */
+export interface ErliVariantAttribute {
+  name: string;
+  value: string;
+}
+
+/**
  * Create-product body — `POST /products/{externalId}`. Erli requires
  * `name, images, price, stock, dispatchTime` on create; the optional keys are
  * supplied when the neutral command carries them.
@@ -76,6 +100,13 @@ export interface ErliProductCreateBody {
   externalCategories?: ErliExternalCategory[];
   /** Allegro parameter reuse (#985); omitted when empty. */
   externalAttributes?: ErliExternalAttribute[];
+  /**
+   * Multi-variant grouping (#986); omitted for single/simple products so they
+   * list ungrouped. Present ⇒ this product is one sibling of a grouped listing.
+   */
+  externalVariantGroup?: ErliVariantGroupRef;
+  /** Distinguishing axes within a grouped listing (#986); omitted when empty. */
+  attributes?: ErliVariantAttribute[];
 }
 
 /**


### PR DESCRIPTION
## What & why

Implements **#986** — the Erli-adapter half of multi-variant offer grouping: when grouping data is present, the create payload carries `externalVariantGroup` (parent ref + distinguishing attributes) so Erli groups sibling variant offers into one buyer-facing listing.

- `buildCreateBody` variant seam reads `overrides.platformParams.erliVariantGroup`.
- Provisional wire types (`ErliVariantGroupRef` / `ErliVariantAttribute`) isolated in `erli-product.types.ts` (#992 reconciliation point).

## ⚠️ Dormant until a core populator lands

Nothing in core currently threads `parentProductId` + variant `attributes` into `overrides.platformParams.erliVariantGroup`, so offers list **ungrouped** today — the adapter is complete and tested but inert until that core seam exists. Tracking note posted on issue #986; a core-populator follow-up issue is the prerequisite to activate this.

## Stacking

Stacked on **#988** (`988-erli-stock-price-frozen`). Targets `main`; **draft** until the stack merges.

## Testing

`pnpm --filter @openlinker/integrations-erli` type-check, lint, unit tests, and `pnpm check:invariants` all green.

Part of #986 — adapter half only; multi-variant grouping stays dormant until the core populator (#1065) threads `erliVariantGroup`, so do not auto-close #986 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)