### PR TITLE
feat(erli): offer-status reconciliation — OfferStatusReader + scheduler task (#989)

### DIFF
--- a/docs/plans/implementation-plan-erli-offer-status-recon.md
+++ b/docs/plans/implementation-plan-erli-offer-status-recon.md
@@ -14,12 +14,12 @@ Give OL trustworthy Erli offer status despite async 202 + ~20-min cache lag. Aft
 2. **`erli-offer-manager.adapter.ts`**:
    - `implements … OfferStatusReader`.
    - `getOfferStatus(externalOfferId)` — reuses `fetchErliProduct` (GET via `productPath`, validate+encode → hostile id fails closed); 404 → `OfferNotFoundOnMarketplaceException(externalOfferId, connectionId)` (capability contract); other transport errors propagate. Maps via `mapErliStatusToReadResult` (module fn).
-   - **Flip `createOffer` 202 → `'validating'`** — safe now that an `OfferStatusReader` exists (the core poll's `OFFER_POLL_NOT_SUPPORTED` path no longer fires). #984 docblock updated.
+   - **`createOffer` 202 stays `'draft'`** (NOT flipped to `'validating'`). Although an `OfferStatusReader` now exists, the Allegro-tuned `OfferStatusPollService` treats a GET-404 as terminal on iteration 1 and its ~9.5-min budget is shorter than Erli's ~20-min cache lag — flipping to `'validating'` would let the poller falsely fail valid-but-not-yet-readable offers. Steady-state reconciliation (the `erli-offer-status-sync` scheduler task below) is the correct mechanism to surface the real status, not the creation poller. The #984 docblock + adapter comment record this.
 3. **`infrastructure/scheduler/erli-scheduler-tasks.ts`** (new) — `buildErliSchedulerTasks()` → one `SchedulerTaskConfig` `erli-offer-status-sync` (jobType `marketplace.offer.statusSync`, cursor `erli.offerStatus.scanOffset`, hourly default, `enabledEnvVar OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED`). No `ConfigService` (Erli uses `createNestAdapterModule`); registered unconditionally, the env gate is re-checked by the scheduler at each tick.
 4. **`erli-plugin.ts` `register(host)`** — `host.schedulerTaskRegistry.register(task)` for each.
 
 ## Tests
-`getOfferStatus` mapping (active/accepted/inactive/undefined → publicationStatus; rejected → inactive + ERLI_REJECTED validationError); 404 → `OfferNotFoundOnMarketplaceException`; non-404 propagates; hostile id fails closed; `isOfferStatusReader(adapter)` true; createOffer now returns `'validating'`; plugin registers the scheduler task. **113 erli tests green, type-check + lint clean.**
+`getOfferStatus` mapping (active/accepted/inactive/undefined → publicationStatus; rejected → inactive + ERLI_REJECTED validationError); 404 → `OfferNotFoundOnMarketplaceException`; non-404 propagates; hostile id fails closed; `isOfferStatusReader(adapter)` true; createOffer still returns `'draft'` (see Implementation §2 — deliberately not flipped to `'validating'`); plugin registers the scheduler task. **113 erli tests green, type-check + lint clean.**
 
 ## Risks
 - **#992-provisional**: Erli status field name + value set unconfirmed → isolated in `erli-product.types.ts`.

--- a/docs/plans/implementation-plan-erli-offer-status-recon.md
+++ b/docs/plans/implementation-plan-erli-offer-status-recon.md
@@ -1,0 +1,30 @@
+# Implementation Plan — #989: Erli offer-status reconciliation snapshot
+
+**Date**: 2026-06-15 · **Status**: Implemented · **Effort**: M · **Branch**: `989-erli-offer-status-recon` (off `986-erli-variant-grouping`) · **ADR**: ADR-025 §1 · Wave-4.
+
+## Goal
+Give OL trustworthy Erli offer status despite async 202 + ~20-min cache lag. After listing, OL eventually shows the real status (accepted/active/inactive/rejected), not just "submitted"; rejected offers reflect as such.
+
+## Decisions (code-verified)
+- **Reuse the platform-agnostic core snapshot infra — NO migration.** `offer_status_snapshots` + `OfferStatusSyncService` are connection-keyed and resolve the adapter via `getCapabilityAdapter<OfferManagerPort>` + `isOfferStatusReader`. Erli only (a) implements `OfferStatusReader` and (b) registers a scheduler task enqueuing the existing `marketplace.offer.statusSync` job. No new worker handler, no core change.
+- **No core enum change.** Erli's `accepted/active/inactive/rejected` maps onto the closed `OfferPublicationStatus = active|activating|inactivating|inactive|ended`: `active`→`active`; `accepted` (stored, still propagating)→`activating`; `rejected`→`inactive` + reason in `validationErrors` (`OfferStatusReadResult` carries them); `inactive`/unknown→`inactive`. Avoids the data-migration risk an enum change carries (offer-status-read.types ADR-009 note).
+
+## Implementation
+1. **`erli-product.types.ts`** — `ErliProductStatus` (provisional #992) + `status?`/`statusReason?` on `ErliProductResource` (the read shape shared with #988's `fetchErliProduct`).
+2. **`erli-offer-manager.adapter.ts`**:
+   - `implements … OfferStatusReader`.
+   - `getOfferStatus(externalOfferId)` — reuses `fetchErliProduct` (GET via `productPath`, validate+encode → hostile id fails closed); 404 → `OfferNotFoundOnMarketplaceException(externalOfferId, connectionId)` (capability contract); other transport errors propagate. Maps via `mapErliStatusToReadResult` (module fn).
+   - **Flip `createOffer` 202 → `'validating'`** — safe now that an `OfferStatusReader` exists (the core poll's `OFFER_POLL_NOT_SUPPORTED` path no longer fires). #984 docblock updated.
+3. **`infrastructure/scheduler/erli-scheduler-tasks.ts`** (new) — `buildErliSchedulerTasks()` → one `SchedulerTaskConfig` `erli-offer-status-sync` (jobType `marketplace.offer.statusSync`, cursor `erli.offerStatus.scanOffset`, hourly default, `enabledEnvVar OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED`). No `ConfigService` (Erli uses `createNestAdapterModule`); registered unconditionally, the env gate is re-checked by the scheduler at each tick.
+4. **`erli-plugin.ts` `register(host)`** — `host.schedulerTaskRegistry.register(task)` for each.
+
+## Tests
+`getOfferStatus` mapping (active/accepted/inactive/undefined → publicationStatus; rejected → inactive + ERLI_REJECTED validationError); 404 → `OfferNotFoundOnMarketplaceException`; non-404 propagates; hostile id fails closed; `isOfferStatusReader(adapter)` true; createOffer now returns `'validating'`; plugin registers the scheduler task. **113 erli tests green, type-check + lint clean.**
+
+## Risks
+- **#992-provisional**: Erli status field name + value set unconfirmed → isolated in `erli-product.types.ts`.
+- **Status mapping lossy-ish**: `accepted` vs `active` distinction depends on Erli exposing both; if not, both collapse to `active`/`activating` — adjust the one mapping fn. Confirm at #992.
+- Scheduler cron/page-size are hardcoded defaults (no ConfigService); tune via env if needed (only the enable gate is env-driven today).
+
+## Related
+- Wave-4 meta-plan · ADR-025 §1 · #816 (`offer_status_snapshots`) · #984 (createOffer) · #988 (`fetchErliProduct`)

--- a/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
+++ b/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
@@ -43,18 +43,21 @@ function makeRegisterHost(): {
   testerRegistry: { register: jest.Mock };
   retryClassifierRegistry: { register: jest.Mock };
   authFailureClassifierRegistry: { register: jest.Mock };
+  schedulerTaskRegistry: { register: jest.Mock };
 } {
   const configRegistry = { register: jest.fn() };
   const credentialsRegistry = { register: jest.fn() };
   const testerRegistry = { register: jest.fn() };
   const retryClassifierRegistry = { register: jest.fn() };
   const authFailureClassifierRegistry = { register: jest.fn() };
+  const schedulerTaskRegistry = { register: jest.fn() };
   const hostStub = {
     connectionConfigShapeValidatorRegistry: configRegistry,
     connectionCredentialsShapeValidatorRegistry: credentialsRegistry,
     connectionTesterRegistry: testerRegistry,
     retryClassifierRegistry,
     authFailureClassifierRegistry,
+    schedulerTaskRegistry,
   } as unknown as HostServices;
   return {
     host: hostStub,
@@ -63,6 +66,7 @@ function makeRegisterHost(): {
     testerRegistry,
     retryClassifierRegistry,
     authFailureClassifierRegistry,
+    schedulerTaskRegistry,
   };
 }
 
@@ -139,6 +143,20 @@ describe('createErliPlugin', () => {
       expect(authFailureClassifierRegistry.register).toHaveBeenCalledWith(
         'erli.shopapi.v1',
         expect.objectContaining({ isCredentialRejected: expect.any(Function) }),
+      );
+    });
+
+    it('should register the erli-offer-status-sync scheduler task (#989)', () => {
+      const { host, schedulerTaskRegistry } = makeRegisterHost();
+      createErliPlugin().register?.(host);
+
+      expect(schedulerTaskRegistry.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: 'erli-offer-status-sync',
+          platformType: 'erli',
+          jobType: 'marketplace.offer.statusSync',
+          enabledEnvVar: 'OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED',
+        }),
       );
     });
   });

--- a/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
+++ b/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
@@ -146,18 +146,43 @@ describe('createErliPlugin', () => {
       );
     });
 
-    it('should register the erli-offer-status-sync scheduler task (#989)', () => {
-      const { host, schedulerTaskRegistry } = makeRegisterHost();
-      createErliPlugin().register?.(host);
+    it('should register the erli-offer-status-sync scheduler task when opt-in env is set (#989, #1063)', () => {
+      const prev = process.env.OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED;
+      process.env.OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED = 'true';
+      try {
+        const { host, schedulerTaskRegistry } = makeRegisterHost();
+        createErliPlugin().register?.(host);
 
-      expect(schedulerTaskRegistry.register).toHaveBeenCalledWith(
-        expect.objectContaining({
-          taskId: 'erli-offer-status-sync',
-          platformType: 'erli',
-          jobType: 'marketplace.offer.statusSync',
-          enabledEnvVar: 'OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED',
-        }),
-      );
+        expect(schedulerTaskRegistry.register).toHaveBeenCalledWith(
+          expect.objectContaining({
+            taskId: 'erli-offer-status-sync',
+            platformType: 'erli',
+            jobType: 'marketplace.offer.statusSync',
+            enabledEnvVar: 'OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED',
+          }),
+        );
+      } finally {
+        if (prev === undefined) delete process.env.OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED;
+        else process.env.OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED = prev;
+      }
+    });
+
+    it('should NOT register the offer-status-sync task by default — opt-in, #992-provisional status field (#1063)', () => {
+      const prev = process.env.OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED;
+      delete process.env.OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED;
+      try {
+        const { host, schedulerTaskRegistry } = makeRegisterHost();
+        createErliPlugin().register?.(host);
+
+        // Specific to the offer-status task: other Erli scheduler tasks (e.g. the
+        // orders-poll backstop, #993) register unconditionally and must be unaffected.
+        expect(schedulerTaskRegistry.register).not.toHaveBeenCalledWith(
+          expect.objectContaining({ taskId: 'erli-offer-status-sync' }),
+        );
+      } finally {
+        if (prev === undefined) delete process.env.OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED;
+        else process.env.OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED = prev;
+      }
     });
   });
 

--- a/libs/integrations/erli/src/erli-plugin.ts
+++ b/libs/integrations/erli/src/erli-plugin.ts
@@ -31,6 +31,7 @@ import { ErliConnectionConfigShapeValidatorAdapter } from './infrastructure/adap
 import { ErliConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/erli-connection-credentials-shape-validator.adapter';
 import { ErliConnectionTesterAdapter } from './infrastructure/adapters/erli-connection-tester.adapter';
 import { ErliRetryClassifierAdapter } from './infrastructure/adapters/erli-retry-classifier.adapter';
+import { buildErliSchedulerTasks } from './infrastructure/scheduler/erli-scheduler-tasks';
 
 /** Human-readable plugin identifier surfaced in dispatch errors (#573). */
 const ERLI_BRAND = 'Erli';
@@ -76,6 +77,13 @@ export function createErliPlugin(): AdapterPlugin {
         ERLI_ADAPTER_KEY,
         new ErliAuthFailureClassifierAdapter(),
       );
+      // Offer-status reconciliation scheduler task (#989). Registered
+      // unconditionally; the OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED env gate
+      // is re-checked by the scheduler at each tick (no ConfigService dependency —
+      // Erli is wired via createNestAdapterModule).
+      for (const task of buildErliSchedulerTasks()) {
+        host.schedulerTaskRegistry.register(task);
+      }
     },
 
     async createCapabilityAdapter<T>(

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -2,7 +2,7 @@
  * Erli Offer Manager Adapter — unit tests (#984, #985, #986, #988, #989)
  *
  * Mocks `IErliHttpClient` to verify: seller-keyed path build (validate+encode),
- * 202→'validating' create mapping (#989), sparse PATCH for field/quantity
+ * 202→'draft' create mapping (#989/#1063), sparse PATCH for field/quantity
  * updates, the safe 4xx→OfferCreateRejectedException mapping (no responseBody
  * leak), auth propagation, hostile-id rejection, imageUrl hygiene, the #985
  * Allegro category/parameter reuse, the #988 frozen-field exclusion, and the
@@ -72,14 +72,17 @@ describe('ErliOfferManagerAdapter', () => {
   });
 
   describe('createOffer', () => {
-    it("should submit to the seller-keyed product path and return status 'validating' on 202", async () => {
+    it("should submit to the seller-keyed product path and return status 'draft' on 202", async () => {
       const result = await adapter.createOffer(createCmd());
 
       expect(httpClient.post).toHaveBeenCalledTimes(1);
       const [path, , options] = httpClient.post.mock.calls[0];
       expect(path).toBe(`products/${VALID_ID}`);
       expect(options).toEqual({ idempotent: true });
-      expect(result).toEqual({ externalOfferId: VALID_ID, status: 'validating' });
+      // 'draft' (not 'validating'): avoids the Allegro-tuned creation poll that
+      // would falsely fail valid offers during Erli's ~20-min cache lag (#1063);
+      // the steady-state erli-offer-status-sync reconciles publication instead.
+      expect(result).toEqual({ externalOfferId: VALID_ID, status: 'draft' });
     });
 
     it('should map the basic command fields into the create body', async () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -1,18 +1,20 @@
 /**
- * Erli Offer Manager Adapter — unit tests (#984, #985, #986, #988)
+ * Erli Offer Manager Adapter — unit tests (#984, #985, #986, #988, #989)
  *
  * Mocks `IErliHttpClient` to verify: seller-keyed path build (validate+encode),
- * 202→'draft' create mapping, sparse PATCH for field/quantity updates, the
- * safe 4xx→OfferCreateRejectedException mapping (no responseBody leak), auth
- * propagation, hostile-id rejection, imageUrl hygiene, the #985 Allegro
- * category/parameter reuse (source:"allegro" externalCategories/Attributes),
- * and the #988 frozen-field exclusion (read-before-PATCH drops frozen fields;
- * all-frozen → no-op; hot quantity path stays single-call).
+ * 202→'validating' create mapping (#989), sparse PATCH for field/quantity
+ * updates, the safe 4xx→OfferCreateRejectedException mapping (no responseBody
+ * leak), auth propagation, hostile-id rejection, imageUrl hygiene, the #985
+ * Allegro category/parameter reuse, the #988 frozen-field exclusion, and the
+ * #989 OfferStatusReader.getOfferStatus mapping (Erli status → neutral
+ * OfferPublicationStatus; 404 → OfferNotFoundOnMarketplaceException).
  *
  * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
  */
 import {
+  isOfferStatusReader,
   OfferCreateRejectedException,
+  OfferNotFoundOnMarketplaceException,
   type CreateOfferCommand,
   type UpdateOfferFieldsCommand,
   type UpdateOfferQuantityCommand,
@@ -70,14 +72,14 @@ describe('ErliOfferManagerAdapter', () => {
   });
 
   describe('createOffer', () => {
-    it("should submit to the seller-keyed product path and return status 'draft' on 202", async () => {
+    it("should submit to the seller-keyed product path and return status 'validating' on 202", async () => {
       const result = await adapter.createOffer(createCmd());
 
       expect(httpClient.post).toHaveBeenCalledTimes(1);
       const [path, , options] = httpClient.post.mock.calls[0];
       expect(path).toBe(`products/${VALID_ID}`);
       expect(options).toEqual({ idempotent: true });
-      expect(result).toEqual({ externalOfferId: VALID_ID, status: 'draft' });
+      expect(result).toEqual({ externalOfferId: VALID_ID, status: 'validating' });
     });
 
     it('should map the basic command fields into the create body', async () => {
@@ -605,6 +607,60 @@ describe('ErliOfferManagerAdapter', () => {
       await expect(
         adapter.updateOfferQuantity({ offerId: 'evil/../x', quantity: 1 }),
       ).rejects.toBeInstanceOf(ErliConfigException);
+    });
+  });
+
+  describe('getOfferStatus (#989)', () => {
+    it('should be detectable as an OfferStatusReader', () => {
+      expect(isOfferStatusReader(adapter)).toBe(true);
+    });
+
+    it.each([
+      ['active', 'active'],
+      ['accepted', 'activating'],
+      ['inactive', 'inactive'],
+      [undefined, 'inactive'],
+    ])('should map Erli status %s → publicationStatus %s', async (erliStatus, expected) => {
+      httpClient.get.mockResolvedValueOnce({ status: 200, data: { status: erliStatus } });
+
+      const result = await adapter.getOfferStatus(VALID_ID);
+
+      expect(result.publicationStatus).toBe(expected);
+      expect(result.validationErrors).toEqual([]);
+      expect(httpClient.get).toHaveBeenCalledWith(`products/${VALID_ID}`);
+    });
+
+    it('should map rejected → inactive carrying the reason in validationErrors', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        status: 200,
+        data: { status: 'rejected', statusReason: 'EAN already used' },
+      });
+
+      const result = await adapter.getOfferStatus(VALID_ID);
+
+      expect(result.publicationStatus).toBe('inactive');
+      expect(result.validationErrors).toEqual([
+        { code: 'ERLI_REJECTED', message: 'EAN already used' },
+      ]);
+    });
+
+    it('should throw OfferNotFoundOnMarketplaceException on a 404', async () => {
+      httpClient.get.mockRejectedValueOnce(new ErliApiException('not found', 404));
+
+      await expect(adapter.getOfferStatus(VALID_ID)).rejects.toBeInstanceOf(
+        OfferNotFoundOnMarketplaceException,
+      );
+    });
+
+    it('should propagate non-404 transport errors', async () => {
+      httpClient.get.mockRejectedValueOnce(new ErliApiException('server error', 500));
+
+      await expect(adapter.getOfferStatus(VALID_ID)).rejects.toBeInstanceOf(ErliApiException);
+    });
+
+    it('should reject a hostile externalOfferId before any GET', async () => {
+      await expect(adapter.getOfferStatus('evil/../x')).rejects.toBeInstanceOf(ErliConfigException);
+      expect(httpClient.get).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -9,10 +9,10 @@
  *
  * Async write model (ADR-025): Erli returns HTTP 202 (validated + stored,
  * ~20-min cache lag — no read-after-write). A 202/2xx create maps to
- * `CreateOfferResult.status = 'draft'` ("submitted, not yet confirmed") — NOT
- * `'validating'`, which would schedule the #989 status poll that has no
- * `OfferStatusReader` yet and would flip the record to `business_failure`.
- * #989 introduces `OfferStatusReader` and flips this to `'validating'`.
+ * `CreateOfferResult.status = 'validating'`: the core poll then reads the real
+ * Erli status back via this adapter's `OfferStatusReader.getOfferStatus` (#989)
+ * and the steady-state `erli-offer-status-sync` scheduler task reconciles mapped
+ * offers into `offer_status_snapshots` — never trusting the 202 as confirmation.
  *
  * Category/parameter reuse (#985): the create body carries `externalCategories`
  * + `externalAttributes` tagged `source:"allegro"`, built from the already-
@@ -53,6 +53,7 @@
  */
 import {
   OfferCreateRejectedException,
+  OfferNotFoundOnMarketplaceException,
   type CreateOfferCommand,
   type CreateOfferResult,
   type CreateOfferValidationError,
@@ -61,6 +62,8 @@ import {
   type OfferFieldUpdate,
   type OfferFieldUpdater,
   type OfferManagerPort,
+  type OfferStatusReadResult,
+  type OfferStatusReader,
   type UpdateOfferFieldsCommand,
   type UpdateOfferQuantityCommand,
 } from '@openlinker/core/listings';
@@ -108,7 +111,9 @@ const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, 
   description: 'description',
 };
 
-export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, OfferFieldUpdater {
+export class ErliOfferManagerAdapter
+  implements OfferManagerPort, OfferCreator, OfferFieldUpdater, OfferStatusReader
+{
   private readonly logger = new Logger(ErliOfferManagerAdapter.name);
 
   constructor(
@@ -140,13 +145,10 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
       // Auth / network / rate-limit propagate to the runner + classifiers.
       throw error;
     }
-    // 202/2xx = submitted, not confirmed (ADR-025). 'draft' → outcome 'ok',
-    // no status poll. #989 flips to 'validating' once OfferStatusReader exists.
-    // `cmd.publishImmediately` is intentionally not actionable here: Erli's write
-    // is async with no read-after-write, so the live publication state can't be
-    // confirmed synchronously — it is reconciled later via #989's OfferStatusReader
-    // regardless of the requested flag.
-    return { externalOfferId, status: 'draft' };
+    // 202/2xx = submitted, not confirmed (ADR-025). 'validating' schedules the
+    // core status poll, which reads the real Erli status back via this adapter's
+    // OfferStatusReader (#989) — safe now that getOfferStatus exists.
+    return { externalOfferId, status: 'validating' };
   }
 
   async updateOfferFields(cmd: UpdateOfferFieldsCommand): Promise<void> {
@@ -175,6 +177,26 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
       return;
     }
     await this.httpClient.patch(this.productPath(cmd.externalOfferId), filtered);
+  }
+
+  /**
+   * OfferStatusReader (#989). Reads the real Erli-side status (despite the
+   * async-202 cache lag) and maps it to the neutral `OfferPublicationStatus`.
+   * Reuses {@link fetchErliProduct}. A 404 (offer not on Erli) becomes
+   * `OfferNotFoundOnMarketplaceException`; other transport errors propagate so
+   * the runner's transient-retry path absorbs the blip (capability contract).
+   */
+  async getOfferStatus(externalOfferId: string): Promise<OfferStatusReadResult> {
+    let product: ErliProductResource;
+    try {
+      product = await this.fetchErliProduct(externalOfferId);
+    } catch (error) {
+      if (error instanceof ErliApiException && error.statusCode === 404) {
+        throw new OfferNotFoundOnMarketplaceException(externalOfferId, this.connectionId);
+      }
+      throw error;
+    }
+    return mapErliStatusToReadResult(product);
   }
 
   /**
@@ -463,6 +485,33 @@ function readDispatchTimeParam(
   return candidate.unit === undefined
     ? { period }
     : { period, unit: candidate.unit as ErliDispatchTime['unit'] };
+}
+
+/**
+ * Map Erli's native product status onto the neutral closed `OfferPublicationStatus`
+ * union (#989). Erli has no `'rejected'` member in OL's union, so a rejection is
+ * surfaced as `'inactive'` carrying the reason in `validationErrors` (no core enum
+ * change — additive-only per offer-status-read.types ADR-009 note). `'accepted'`
+ * (stored but still propagating through Erli's ~20-min cache) → `'activating'`.
+ * Unknown/absent → `'inactive'` (conservative; never claims live).
+ */
+function mapErliStatusToReadResult(product: ErliProductResource): OfferStatusReadResult {
+  switch (product.status) {
+    case 'active':
+      return { publicationStatus: 'active', validationErrors: [] };
+    case 'accepted':
+      return { publicationStatus: 'activating', validationErrors: [] };
+    case 'rejected':
+      return {
+        publicationStatus: 'inactive',
+        validationErrors: [
+          { code: 'ERLI_REJECTED', message: product.statusReason ?? 'Erli rejected the offer.' },
+        ],
+      };
+    case 'inactive':
+    default:
+      return { publicationStatus: 'inactive', validationErrors: [] };
+  }
 }
 
 /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -9,10 +9,12 @@
  *
  * Async write model (ADR-025): Erli returns HTTP 202 (validated + stored,
  * ~20-min cache lag — no read-after-write). A 202/2xx create maps to
- * `CreateOfferResult.status = 'validating'`: the core poll then reads the real
- * Erli status back via this adapter's `OfferStatusReader.getOfferStatus` (#989)
- * and the steady-state `erli-offer-status-sync` scheduler task reconciles mapped
- * offers into `offer_status_snapshots` — never trusting the 202 as confirmation.
+ * `CreateOfferResult.status = 'draft'` (submitted, not confirmed — it does NOT
+ * schedule the Allegro-tuned creation poll, whose 404-is-terminal + ~9.5-min
+ * budget collide with Erli's ~20-min lag; review #1063). Publication is instead
+ * reconciled by the steady-state `erli-offer-status-sync` scheduler task, which
+ * reads the real Erli status back via this adapter's `OfferStatusReader.getOfferStatus`
+ * (#989) into `offer_status_snapshots` — never trusting the 202 as confirmation.
  *
  * Category/parameter reuse (#985): the create body carries `externalCategories`
  * + `externalAttributes` tagged `source:"allegro"`, built from the already-
@@ -145,10 +147,14 @@ export class ErliOfferManagerAdapter
       // Auth / network / rate-limit propagate to the runner + classifiers.
       throw error;
     }
-    // 202/2xx = submitted, not confirmed (ADR-025). 'validating' schedules the
-    // core status poll, which reads the real Erli status back via this adapter's
-    // OfferStatusReader (#989) — safe now that getOfferStatus exists.
-    return { externalOfferId, status: 'validating' };
+    // 202/2xx = submitted, not confirmed (ADR-025). Stay 'draft' (outcome 'ok',
+    // no creation poll): the Allegro-tuned OfferStatusPollService treats a GET
+    // 404 as terminal OFFER_NOT_FOUND on the first iteration and its ~9.5-min
+    // budget is shorter than Erli's documented ~20-min cache lag — flipping to
+    // 'validating' would falsely fail valid offers (review #1063). Publication is
+    // reconciled by the steady-state erli-offer-status-sync task instead, which
+    // tolerates the lag; that path still exercises getOfferStatus (#989).
+    return { externalOfferId, status: 'draft' };
   }
 
   async updateOfferFields(cmd: UpdateOfferFieldsCommand): Promise<void> {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -136,7 +136,18 @@ export type ErliProductPatchBody = Pick<
  * {@link ErliOfferManagerAdapter.fetchErliProduct}'s consumers are the single
  * change point. #989 reuses this same read path for offer-status reconciliation.
  */
+/**
+ * Erli-side publication status of a product/offer (read side, #989).
+ * PROVISIONAL (#992): exact value set unconfirmed; the adapter maps it to the
+ * neutral closed `OfferPublicationStatus` union.
+ */
+export type ErliProductStatus = 'accepted' | 'active' | 'inactive' | 'rejected';
+
 export interface ErliProductResource {
-  /** Erli field names the seller has frozen via manual panel edits. */
+  /** Erli field names the seller has frozen via manual panel edits (#988). */
   frozenFields?: string[];
+  /** Current Erli-side publication status (#989). */
+  status?: ErliProductStatus;
+  /** Rejection / inactivation detail Erli supplies, when present (#989). */
+  statusReason?: string;
 }

--- a/libs/integrations/erli/src/infrastructure/scheduler/erli-scheduler-tasks.ts
+++ b/libs/integrations/erli/src/infrastructure/scheduler/erli-scheduler-tasks.ts
@@ -15,25 +15,39 @@
  *
  * Unlike the Allegro tasks (which read cron/page-size overrides off a NestJS
  * `ConfigService`), Erli is wired via `createNestAdapterModule` and has no
- * plugin-scoped `ConfigService`, so this builder takes no config: the task is
- * registered unconditionally with sensible defaults and the
- * `OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED` env gate is re-checked by the
- * scheduler at each cron tick (set it to `"false"` to disable without a config
- * dependency at registration time).
+ * plugin-scoped `ConfigService`, so this builder takes no config.
+ *
+ * **Opt-in, default OFF until #992 (review #1063).** The Erli `status` wire field
+ * is still unconfirmed; if the real GET response doesn't carry it with the
+ * expected values, `mapErliStatusToReadResult` falls to `inactive` and the
+ * reconciliation would write `inactive` snapshots for every mapped offer —
+ * surfacing live offers as inactive in the Listings UI. So this builder returns
+ * the task ONLY when `OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED === 'true'`
+ * (inverting Allegro's default-on). Once enabled, the scheduler's per-tick env
+ * gate still toggles it at runtime. Flip the default back to opt-out when #992
+ * confirms the field.
  *
  * @module libs/integrations/erli/src/infrastructure/scheduler
  * @see {@link SchedulerTaskConfig} in `@openlinker/core/sync`.
  */
 import type { SchedulerTaskConfig } from '@openlinker/core/sync';
 
-/** Hourly (6-field cron: sec min hour day month dow). */
-const ERLI_OFFER_STATUS_SYNC_CRON = '0 0 * * * *';
+/** Hourly (5-field cron: min hour day month dow — aligned with the Allegro tasks). */
+const ERLI_OFFER_STATUS_SYNC_CRON = '0 * * * *';
 /** Mapped offers refreshed per run (rolling scan-offset). */
 const ERLI_OFFER_STATUS_SYNC_PAGE_LIMIT = 50;
 
 export function buildErliSchedulerTasks(): SchedulerTaskConfig[] {
-  return [
-    {
+  const tasks: SchedulerTaskConfig[] = [];
+
+  // offer-status-sync — OPT-IN, default OFF (review #1063): don't reconcile
+  // against the still-#992-provisional Erli `status` field until it's confirmed
+  // (a wrong/absent field would write `inactive` for every mapped offer). The
+  // scheduler's per-tick gate still toggles it at runtime once enabled. This
+  // gates ONLY this task — any other Erli task (e.g. the orders-poll backstop) is
+  // pushed unconditionally below.
+  if (process.env.OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED === 'true') {
+    tasks.push({
       taskId: 'erli-offer-status-sync',
       platformType: 'erli',
       jobType: 'marketplace.offer.statusSync',
@@ -46,6 +60,8 @@ export function buildErliSchedulerTasks(): SchedulerTaskConfig[] {
       }),
       generateIdempotencyKey: (connection, timestamp) =>
         `marketplace:${connection.id}:offer:status:sync:${timestamp}`,
-    },
-  ];
+    });
+  }
+
+  return tasks;
 }

--- a/libs/integrations/erli/src/infrastructure/scheduler/erli-scheduler-tasks.ts
+++ b/libs/integrations/erli/src/infrastructure/scheduler/erli-scheduler-tasks.ts
@@ -1,0 +1,51 @@
+/**
+ * Erli Scheduler Tasks
+ *
+ * Builds the `SchedulerTaskConfig` instances Erli contributes to the core
+ * `SchedulerTaskRegistryService`. One task today:
+ *
+ *   - `erli-offer-status-sync` (#989) — steady-state refresh of mapped Erli
+ *     offers' publication status into `offer_status_snapshots` (the reconciliation
+ *     that turns an async-202 "submitted" into the real accepted/active/inactive/
+ *     rejected status — ADR-025 §1). Default hourly. Rolling scan-offset cursor
+ *     key `erli.offerStatus.scanOffset`. Reuses the platform-agnostic core
+ *     `marketplace.offer.statusSync` job + `OfferStatusSyncService`, which resolve
+ *     the Erli adapter via the `OfferStatusReader` capability (#989) — no new
+ *     worker handler.
+ *
+ * Unlike the Allegro tasks (which read cron/page-size overrides off a NestJS
+ * `ConfigService`), Erli is wired via `createNestAdapterModule` and has no
+ * plugin-scoped `ConfigService`, so this builder takes no config: the task is
+ * registered unconditionally with sensible defaults and the
+ * `OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED` env gate is re-checked by the
+ * scheduler at each cron tick (set it to `"false"` to disable without a config
+ * dependency at registration time).
+ *
+ * @module libs/integrations/erli/src/infrastructure/scheduler
+ * @see {@link SchedulerTaskConfig} in `@openlinker/core/sync`.
+ */
+import type { SchedulerTaskConfig } from '@openlinker/core/sync';
+
+/** Hourly (6-field cron: sec min hour day month dow). */
+const ERLI_OFFER_STATUS_SYNC_CRON = '0 0 * * * *';
+/** Mapped offers refreshed per run (rolling scan-offset). */
+const ERLI_OFFER_STATUS_SYNC_PAGE_LIMIT = 50;
+
+export function buildErliSchedulerTasks(): SchedulerTaskConfig[] {
+  return [
+    {
+      taskId: 'erli-offer-status-sync',
+      platformType: 'erli',
+      jobType: 'marketplace.offer.statusSync',
+      cronExpression: ERLI_OFFER_STATUS_SYNC_CRON,
+      enabledEnvVar: 'OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED',
+      generatePayload: () => ({
+        schemaVersion: 1,
+        limit: ERLI_OFFER_STATUS_SYNC_PAGE_LIMIT,
+        cursorKey: 'erli.offerStatus.scanOffset',
+      }),
+      generateIdempotencyKey: (connection, timestamp) =>
+        `marketplace:${connection.id}:offer:status:sync:${timestamp}`,
+    },
+  ];
+}


### PR DESCRIPTION
## What & why

Implements **#989** — trustworthy Erli offer status despite the async 202 + ~20-min cache lag (**ADR-025** decision 1, reconciliation-first). Reuses the platform-agnostic `offer_status_snapshots` + `OfferStatusSyncService` infra — **no migration, no core change**.

- `ErliOfferManagerAdapter implements OfferStatusReader`; `getOfferStatus` reuses `fetchErliProduct` (404 → `OfferNotFoundOnMarketplaceException`, non-404 propagates), maps Erli `accepted/active/inactive/rejected` onto the closed `OfferPublicationStatus` (`rejected` → `inactive` + reason in `validationErrors`; no enum change).
- **`createOffer` 202 stays `'draft'` (NOT flipped to `'validating'`)** — although an `OfferStatusReader` now exists, the Allegro-tuned `OfferStatusPollService` treats a GET-404 as terminal on iteration 1 with a ~9.5-min budget < Erli's ~20-min cache lag, so flipping would falsely fail valid-but-not-yet-readable offers. Steady-state reconciliation (the scheduler task below) surfaces the real status instead.
- New `erli-offer-status-sync` `SchedulerTaskConfig` (jobType `marketplace.offer.statusSync`, cursor `erli.offerStatus.scanOffset`). **Opt-in, default OFF** (`OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED=true`) until #992 confirms the Erli `status` wire field — a wrong/absent field would otherwise map every offer to `inactive`. Cron aligned to the Allegro 5-field form.

## Status / stacking

Targets `main`; base of the consolidated Erli stack (#1077 → #1081 → #1086 → #1099). Ready for review.

## Testing

`pnpm --filter @openlinker/integrations-erli` type-check, lint, **155 unit tests** (incl. registered-when-opt-in + not-registered-by-default), and `pnpm check:invariants` — all green.

## Follow-up (#992)

Erli `status` field name + value set unconfirmed → isolated in `erli-product.types.ts`; flip the scheduler default back to opt-out once confirmed at the sandbox.

Closes #989