### PR TITLE
feat(web): Erli connection setup UI + plugin registration (#990)

### DIFF
--- a/apps/web/src/app/routes/route-lazy.test.ts
+++ b/apps/web/src/app/routes/route-lazy.test.ts
@@ -50,19 +50,19 @@ const lazyRoutes = collectLazyRoutes([
  * route reverted to eager `element:` form, which is exactly the regression
  * the parameterized test below is meant to catch.
  *
- * Today's breakdown (40 total):
+ * Today's breakdown (41 total):
  *   - 33 authenticated children (under `coreChildren`, counting per-children-node
  *     because grouped routes like orders/customers/inventory expose multiple
  *     lazy nodes — includes `/dev/ui` design-system page (#775) and `/shipments` (#770))
  *   - 2 guest routes (forgot-password, reset-password — login stays eager)
- *   - 5 plugin routes (allegro callback + setup, prestashop setup, dpd setup,
- *     woocommerce setup)
+ *   - 6 plugin routes (allegro callback + setup, prestashop setup, dpd setup,
+ *     woocommerce setup, erli setup)
  *
  * Routes that are intentionally eager (no page module to defer):
  *   - login (first-paint optimization — see `login.route.tsx`)
  *   - prompt-templates-legacy-redirects (inline `<Navigate>` element)
  */
-const EXPECTED_LAZY_ROUTE_COUNT = 40;
+const EXPECTED_LAZY_ROUTE_COUNT = 41;
 
 describe('route lazy contract', () => {
   it(`the registered route tree contains exactly ${EXPECTED_LAZY_ROUTE_COUNT} lazy routes`, () => {

--- a/apps/web/src/features/connections/components/erli-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * ErliSetupForm Tests
+ *
+ * Coverage for the single-step Erli setup wizard. Tests form validation,
+ * submission via the generic create-connection mutation, and the post-create
+ * "Test connection" flow that surfaces a ConnectionTestResult.
+ */
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMockApiClient,
+  findToastTitle,
+  renderWithProviders,
+} from '../../../test/test-utils';
+import { ErliSetupForm } from './erli-setup-form';
+
+describe('ErliSetupForm', () => {
+  afterEach(cleanup);
+
+  it('renders the required form fields', () => {
+    renderWithProviders(<ErliSetupForm />);
+    expect(screen.getByLabelText('Connection name')).toBeInTheDocument();
+    expect(screen.getByLabelText('API key')).toBeInTheDocument();
+    expect(screen.getByLabelText('Base URL (optional)')).toBeInTheDocument();
+  });
+
+  it('requires connection name to be non-empty', async () => {
+    renderWithProviders(<ErliSetupForm />);
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Connection name is required')[0]).toBeInTheDocument();
+    });
+  });
+
+  it('requires the API key to be non-empty', async () => {
+    renderWithProviders(<ErliSetupForm />);
+    fireEvent.change(screen.getByLabelText('Connection name'), {
+      target: { value: 'My Erli Store' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('API key is required')[0]).toBeInTheDocument();
+    });
+  });
+
+  it('rejects a non-HTTPS base URL override', async () => {
+    renderWithProviders(<ErliSetupForm />);
+    fireEvent.change(screen.getByLabelText('Connection name'), {
+      target: { value: 'My Erli Store' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk_test_123' },
+    });
+    fireEvent.change(screen.getByLabelText('Base URL (optional)'), {
+      target: { value: 'http://api.erli.pl' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Base URL must use HTTPS')[0]).toBeInTheDocument();
+    });
+  });
+
+  it('submits the API key and omits config when no base URL is given', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Erli Store' });
+    const apiClient = createMockApiClient({ connections: { create } });
+
+    renderWithProviders(<ErliSetupForm />, { apiClient });
+
+    fireEvent.change(screen.getByLabelText('Connection name'), {
+      target: { value: 'My Erli Store' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk_test_123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'My Erli Store',
+          platformType: 'erli',
+          adapterKey: 'erli.shopapi.v1',
+          config: {},
+          credentials: { apiKey: 'sk_test_123' },
+        }),
+      );
+    });
+    expect(await findToastTitle('Connection created')).toBeInTheDocument();
+  });
+
+  it('includes baseUrl in config when supplied', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Erli Store' });
+    const apiClient = createMockApiClient({ connections: { create } });
+
+    renderWithProviders(<ErliSetupForm />, { apiClient });
+
+    fireEvent.change(screen.getByLabelText('Connection name'), {
+      target: { value: 'My Erli Store' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk_test_123' },
+    });
+    fireEvent.change(screen.getByLabelText('Base URL (optional)'), {
+      target: { value: 'https://api.erli.pl' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: { baseUrl: 'https://api.erli.pl' },
+        }),
+      );
+    });
+  });
+
+  it('surfaces the test-connection result after a successful create', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Erli Store' });
+    const test = vi
+      .fn()
+      .mockResolvedValue({ success: true, status: 200, message: 'OK', latencyMs: 42 });
+    const apiClient = createMockApiClient({ connections: { create, test } });
+
+    renderWithProviders(<ErliSetupForm />, { apiClient });
+
+    fireEvent.change(screen.getByLabelText('Connection name'), {
+      target: { value: 'My Erli Store' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk_test_123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
+
+    // After create, the test affordance replaces the connect button.
+    const testButton = await screen.findByRole('button', { name: 'Test connection' });
+    fireEvent.click(testButton);
+
+    await waitFor(() => {
+      expect(test).toHaveBeenCalledWith('conn-1');
+    });
+    expect(await screen.findByText('Connection test passed')).toBeInTheDocument();
+  });
+
+  it('surfaces a failing test-connection result', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Erli Store' });
+    const test = vi
+      .fn()
+      .mockResolvedValue({ success: false, status: 401, message: 'Unauthorized', latencyMs: 10 });
+    const apiClient = createMockApiClient({ connections: { create, test } });
+
+    renderWithProviders(<ErliSetupForm />, { apiClient });
+
+    fireEvent.change(screen.getByLabelText('Connection name'), {
+      target: { value: 'My Erli Store' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk_test_123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
+
+    const testButton = await screen.findByRole('button', { name: 'Test connection' });
+    fireEvent.click(testButton);
+
+    expect(await screen.findByText('Connection test failed')).toBeInTheDocument();
+    expect(screen.getByText(/Unauthorized/)).toBeInTheDocument();
+  });
+
+  it('disables the submit button during the create mutation', async () => {
+    const create = vi
+      .fn()
+      .mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ id: 'conn-1', name: 'My Erli Store' }), 100),
+          ),
+      );
+    const apiClient = createMockApiClient({ connections: { create } });
+
+    renderWithProviders(<ErliSetupForm />, { apiClient });
+
+    fireEvent.change(screen.getByLabelText('Connection name'), {
+      target: { value: 'My Erli Store' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk_test_123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
+
+    await waitFor(() => {
+      const button = screen.getByRole('button', { name: /Connecting|Connect Erli/ });
+      expect(button).toBeDisabled();
+    });
+  });
+});

--- a/apps/web/src/features/connections/components/erli-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.test.tsx
@@ -168,6 +168,34 @@ describe('ErliSetupForm', () => {
     expect(screen.getByText(/Unauthorized/)).toBeInTheDocument();
   });
 
+  it('surfaces the "Unable to test connection" alert when the test request rejects', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Erli Store' });
+    // A rejected test request (network failure / 5xx) leaves testResult null and
+    // surfaces the error via testConnection.error — distinct from a resolved
+    // { success: false } result.
+    const test = vi.fn().mockRejectedValue(new Error('Network unreachable'));
+    const apiClient = createMockApiClient({ connections: { create, test } });
+
+    renderWithProviders(<ErliSetupForm />, { apiClient });
+
+    fireEvent.change(screen.getByLabelText('Connection name'), {
+      target: { value: 'My Erli Store' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk_test_123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
+
+    const testButton = await screen.findByRole('button', { name: 'Test connection' });
+    fireEvent.click(testButton);
+
+    expect(await screen.findByText('Unable to test connection')).toBeInTheDocument();
+    expect(screen.getByText(/Network unreachable/)).toBeInTheDocument();
+    // The success/fail result alert must NOT appear on the rejected path.
+    expect(screen.queryByText('Connection test passed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Connection test failed')).not.toBeInTheDocument();
+  });
+
   it('disables the submit button during the create mutation', async () => {
     const create = vi
       .fn()

--- a/apps/web/src/features/connections/components/erli-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.test.tsx
@@ -196,6 +196,36 @@ describe('ErliSetupForm', () => {
     expect(screen.queryByText('Connection test failed')).not.toBeInTheDocument();
   });
 
+  it('clears a stale failed result when a subsequent test request rejects', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Erli Store' });
+    // First test resolves a failed result; the re-test rejects.
+    const test = vi
+      .fn()
+      .mockResolvedValueOnce({ success: false, status: 401, message: 'Unauthorized', latencyMs: 10 })
+      .mockRejectedValueOnce(new Error('Network unreachable'));
+    const apiClient = createMockApiClient({ connections: { create, test } });
+
+    renderWithProviders(<ErliSetupForm />, { apiClient });
+
+    fireEvent.change(screen.getByLabelText('Connection name'), {
+      target: { value: 'My Erli Store' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk_test_123' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
+
+    const testButton = await screen.findByRole('button', { name: 'Test connection' });
+
+    // First test → resolved failure result shown.
+    fireEvent.click(testButton);
+    expect(await screen.findByText('Connection test failed')).toBeInTheDocument();
+
+    // Re-test → rejects. The stale failed-result alert must be cleared, leaving
+    // only the "Unable to test connection" error (PR1064-TECH-01).
+    fireEvent.click(testButton);
+    expect(await screen.findByText('Unable to test connection')).toBeInTheDocument();
+    expect(screen.queryByText('Connection test failed')).not.toBeInTheDocument();
+  });
+
   it('disables the submit button during the create mutation', async () => {
     const create = vi
       .fn()

--- a/apps/web/src/features/connections/components/erli-setup-form.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.tsx
@@ -83,6 +83,10 @@ export function ErliSetupForm(): ReactElement {
 
   const onTest = async (): Promise<void> => {
     if (!createdConnectionId) return;
+    // Clear any prior result first: otherwise a re-test that rejects would render
+    // a stale resolved-result Alert alongside the "unable to test" error Alert
+    // (PR1064-TECH-01).
+    setTestResult(null);
     try {
       const result = await testConnection.mutateAsync(createdConnectionId);
       setTestResult(result);

--- a/apps/web/src/features/connections/components/erli-setup-form.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.tsx
@@ -1,0 +1,191 @@
+/**
+ * Erli Setup Form
+ *
+ * Single-step wizard for creating an Erli connection. Collects:
+ *   - Connection name
+ *   - Shop API key (the only credential — sent as a Bearer token by the BE)
+ *   - Optional advanced base URL override (config)
+ *
+ * Simpler than the WooCommerce form — one credential, no capabilities step
+ * (capabilities default silently to the adapter manifest's supported set on
+ * the omitted path). After a successful create the form surfaces a
+ * "Test connection" affordance that calls the generic `/connections/:id/test`
+ * endpoint and renders the `ConnectionTestResult`. Abandon-prevention triggers
+ * a native confirm dialog when the form is dirty and the tab is closed.
+ *
+ * @module features/connections/components
+ */
+import { useEffect, useState, type ReactElement } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { useCreateConnectionMutation } from '../hooks/use-create-connection-mutation';
+import { useTestConnectionMutation } from '../hooks/use-test-connection-mutation';
+import type { ConnectionTestResult } from '../api/connections.types';
+import {
+  ERLI_SETUP_DEFAULT_VALUES,
+  erliSetupSchema,
+  toCreateConnectionInput,
+  type ErliSetupFormSubmission,
+  type ErliSetupFormValues,
+} from './erli-setup.schema';
+import { Alert } from '../../../shared/ui/alert';
+import { BackLink } from '../../../shared/ui/back-link';
+import { Button } from '../../../shared/ui/button';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { useToast } from '../../../shared/ui/toast-provider';
+
+export function ErliSetupForm(): ReactElement {
+  const createConnection = useCreateConnectionMutation();
+  const testConnection = useTestConnectionMutation();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+  const [createdConnectionId, setCreatedConnectionId] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<ConnectionTestResult | null>(null);
+
+  const form = useForm<ErliSetupFormValues, undefined, ErliSetupFormSubmission>({
+    defaultValues: ERLI_SETUP_DEFAULT_VALUES,
+    resolver: zodResolver(erliSetupSchema),
+    mode: 'onBlur',
+  });
+
+  // Abandon-prevention.
+  useEffect(() => {
+    function handleBeforeUnload(event: BeforeUnloadEvent): void {
+      if (!form.formState.isDirty || createdConnectionId !== null) return;
+      event.preventDefault();
+      event.returnValue = '';
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [form.formState.isDirty, createdConnectionId]);
+
+  const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
+    error?.message ? [String(error.message)] : [],
+  );
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      const created = await createConnection.mutateAsync(toCreateConnectionInput(values));
+      form.reset(values, { keepValues: true, keepDirty: false });
+      setCreatedConnectionId(created.id);
+      showToast({
+        tone: 'success',
+        title: 'Connection created',
+        description: `Erli connection "${created.name}" was created.`,
+      });
+    } catch {
+      return;
+    }
+  });
+
+  const onTest = async (): Promise<void> => {
+    if (!createdConnectionId) return;
+    try {
+      const result = await testConnection.mutateAsync(createdConnectionId);
+      setTestResult(result);
+    } catch {
+      // surfaced via testConnection.error
+    }
+  };
+
+  return (
+    <form className="wizard-card" onSubmit={(event) => void onSubmit(event)} noValidate>
+      <BackLink to="/connections/new" label="Connections" className="wizard-card__back" />
+
+      {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
+        <FormErrorSummary errors={validationMessages} />
+      ) : null}
+      {createConnection.error ? (
+        <Alert tone="error" title="Unable to create connection">
+          {createConnection.error.message}
+        </Alert>
+      ) : null}
+
+      <Alert tone="info" title="Before you start">
+        In your Erli seller panel, generate a <strong>Shop API key</strong>. OpenLinker sends it as a
+        bearer token on every request to the Erli Shop API. The key is stored securely on the server
+        and only shown once.
+      </Alert>
+
+      <FormField
+        label="Connection name"
+        name="name"
+        error={form.formState.errors.name?.message}
+        description="A label to identify this Erli account in OpenLinker."
+      >
+        <Input
+          {...form.register('name')}
+          placeholder="My Erli Store"
+          autoComplete="off"
+          invalid={Boolean(form.formState.errors.name)}
+        />
+      </FormField>
+
+      <FormField
+        label="API key"
+        name="apiKey"
+        error={form.formState.errors.apiKey?.message}
+        description="Your Erli Shop API key — generated in the Erli seller panel."
+      >
+        <Input
+          {...form.register('apiKey')}
+          type="password"
+          placeholder="••••••••••••••••••••••••••••••••"
+          autoComplete="off"
+          invalid={Boolean(form.formState.errors.apiKey)}
+        />
+      </FormField>
+
+      <FormField
+        label="Base URL (optional)"
+        name="baseUrl"
+        error={form.formState.errors.baseUrl?.message}
+        description="Advanced — override the default Erli API base URL. Must use HTTPS. Leave blank to use the default."
+      >
+        <Input
+          {...form.register('baseUrl')}
+          className="mono-text"
+          placeholder="https://api.erli.pl"
+          autoComplete="off"
+          invalid={Boolean(form.formState.errors.baseUrl)}
+        />
+      </FormField>
+
+      {createdConnectionId ? (
+        <>
+          {testResult ? (
+            <Alert
+              tone={testResult.success ? 'success' : 'error'}
+              title={testResult.success ? 'Connection test passed' : 'Connection test failed'}
+            >
+              {testResult.message}
+              {typeof testResult.latencyMs === 'number' ? ` (${testResult.latencyMs}ms)` : null}
+            </Alert>
+          ) : null}
+          {testConnection.error ? (
+            <Alert tone="error" title="Unable to test connection">
+              {testConnection.error.message}
+            </Alert>
+          ) : null}
+          <div className="form-actions">
+            <Button type="button" onClick={() => void onTest()} disabled={testConnection.isPending}>
+              {testConnection.isPending ? 'Testing…' : 'Test connection'}
+            </Button>
+            <Button tone="secondary" type="button" onClick={() => void navigate('/connections')}>
+              Done
+            </Button>
+          </div>
+        </>
+      ) : (
+        <div className="form-actions">
+          <Button type="submit" disabled={createConnection.isPending}>
+            {createConnection.isPending ? 'Connecting…' : 'Connect Erli'}
+          </Button>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/apps/web/src/features/connections/components/erli-setup.schema.ts
+++ b/apps/web/src/features/connections/components/erli-setup.schema.ts
@@ -1,0 +1,64 @@
+/**
+ * Erli Setup Form Schema
+ *
+ * Zod schema + form → API payload mapping for the guided Erli connection
+ * wizard. Erli is a marketplace authenticated with a single Shop API key
+ * (sent as a Bearer token by the BE adapter, #981). The form collects a
+ * connection name, the required `apiKey` credential, and an optional advanced
+ * `baseUrl` config override. `enabledCapabilities` is intentionally omitted
+ * from the payload so the API defaults it to the adapter manifest's supported
+ * set (#984/#993 ship `OfferManager` / `OrderSource`).
+ *
+ * @module features/connections/components
+ */
+import { z } from 'zod';
+import type { CreateConnectionInput } from '../api/connections.types';
+
+export const ERLI_ADAPTER_KEY = 'erli.shopapi.v1';
+
+// Mirrors the BE config DTO posture (optional https-only base URL override).
+const isHttps = (value: string): boolean => value.startsWith('https://');
+
+export const erliSetupSchema = z.object({
+  name: z.string().trim().min(1, 'Connection name is required'),
+  apiKey: z.string().trim().min(1, 'API key is required'),
+  baseUrl: z
+    .union([
+      z
+        .string()
+        .trim()
+        .url('Base URL must be a valid URL (e.g. https://api.erli.pl)')
+        .refine(isHttps, 'Base URL must use HTTPS'),
+      z.literal(''),
+    ])
+    .optional(),
+});
+
+export type ErliSetupFormValues = z.input<typeof erliSetupSchema>;
+export type ErliSetupFormSubmission = z.output<typeof erliSetupSchema>;
+
+export const ERLI_SETUP_DEFAULT_VALUES: ErliSetupFormValues = {
+  name: '',
+  apiKey: '',
+  baseUrl: '',
+};
+
+export function toCreateConnectionInput(values: ErliSetupFormSubmission): CreateConnectionInput {
+  const config: Record<string, unknown> = {};
+  if (values.baseUrl && values.baseUrl.length > 0) {
+    config.baseUrl = values.baseUrl;
+  }
+
+  return {
+    name: values.name,
+    platformType: 'erli',
+    adapterKey: ERLI_ADAPTER_KEY,
+    credentials: { apiKey: values.apiKey },
+    config,
+    // enabledCapabilities is OMITTED on purpose: on the omitted path
+    // `ConnectionService.create` defaults to the adapter manifest's supported
+    // set (`rest.enabledCapabilities ?? [...metadata.supportedCapabilities]`),
+    // so the Erli connection lands with the capabilities the registered
+    // `erli.shopapi.v1` adapter actually delivers.
+  };
+}

--- a/apps/web/src/pages/connections/erli-setup-page.tsx
+++ b/apps/web/src/pages/connections/erli-setup-page.tsx
@@ -1,0 +1,26 @@
+/**
+ * Erli Setup Page
+ *
+ * Page wrapper for the guided Erli connection wizard.
+ */
+import type { ReactElement } from 'react';
+import { ErliSetupForm } from '../../features/connections/components/erli-setup-form';
+import { PageLayout } from '../../shared/ui/page-layout';
+
+export function ErliSetupPage(): ReactElement {
+  return (
+    <PageLayout
+      eyebrow="Integrations"
+      title="Connect Erli"
+      description="Provide your Erli Shop API key. OpenLinker uses it to sync offers and orders with your Erli seller account."
+      summary={
+        <div className="toolbar__group">
+          <span className="toolbar-chip">API key</span>
+          <span className="toolbar-chip">Guided setup</span>
+        </div>
+      }
+    >
+      <ErliSetupForm />
+    </PageLayout>
+  );
+}

--- a/apps/web/src/plugins/erli/components/erli-credentials-panel.test.tsx
+++ b/apps/web/src/plugins/erli/components/erli-credentials-panel.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * ErliCredentialsPanel Tests
+ *
+ * Coverage for the rotate-API-key flow for Erli connections. Erli carries a
+ * single `apiKey` credential, so the panel rotates one field (unlike the
+ * WooCommerce key/secret pair).
+ */
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMockApiClient,
+  findToastTitle,
+  renderWithProviders,
+  sampleConnection,
+} from '../../../test/test-utils';
+import { ErliCredentialsPanel } from './erli-credentials-panel';
+
+const erliConnection = { ...sampleConnection, platformType: 'erli' };
+
+describe('ErliCredentialsPanel', () => {
+  afterEach(cleanup);
+
+  it('renders the rotate affordance for a credentials-backed connection', () => {
+    renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />);
+    expect(screen.getByText('Rotate API key')).toBeInTheDocument();
+  });
+
+  it('falls back to the env-var disabled input when credentialsBacked=false', () => {
+    const envBacked = { ...erliConnection, credentialsBacked: false };
+    renderWithProviders(<ErliCredentialsPanel connection={envBacked} />);
+    expect(
+      screen.getByDisplayValue('Environment variable (not editable via UI)'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /rotate/i })).not.toBeInTheDocument();
+  });
+
+  it('sends the new apiKey and surfaces a success toast', async () => {
+    const updateCredentials = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ connections: { updateCredentials } });
+    renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />, { apiClient });
+
+    fireEvent.click(screen.getByText('Rotate API key'));
+    fireEvent.change(screen.getByPlaceholderText('New API key'), {
+      target: { value: 'sk_new_456' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save new API key' }));
+
+    await waitFor(() => {
+      expect(updateCredentials).toHaveBeenCalledWith(erliConnection.id, { apiKey: 'sk_new_456' });
+    });
+    expect(await findToastTitle('Credentials rotated')).toBeInTheDocument();
+  });
+
+  it('disables save while the field is empty', () => {
+    renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />);
+    fireEvent.click(screen.getByText('Rotate API key'));
+    expect(screen.getByRole('button', { name: 'Save new API key' })).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('New API key'), {
+      target: { value: 'sk_new_456' },
+    });
+    expect(screen.getByRole('button', { name: 'Save new API key' })).toBeEnabled();
+  });
+
+  it('collapses the form after a successful save', async () => {
+    const updateCredentials = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ connections: { updateCredentials } });
+    renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />, { apiClient });
+
+    fireEvent.click(screen.getByText('Rotate API key'));
+    fireEvent.change(screen.getByPlaceholderText('New API key'), {
+      target: { value: 'sk_new_456' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save new API key' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Rotate API key')).toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('New API key')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/plugins/erli/components/erli-credentials-panel.tsx
+++ b/apps/web/src/plugins/erli/components/erli-credentials-panel.tsx
@@ -1,0 +1,101 @@
+/**
+ * Erli Credentials Panel
+ *
+ * Plugin-owned credentials affordance for Erli connections — rotates the
+ * stored Shop API key in place via PUT /credentials. Owns its own toggle
+ * state, mutation, and toast feedback; the parent `EditConnectionForm`
+ * renders this only when the plugin contributes it. When the credential is
+ * env-backed (`credentialsBacked === false`) the panel shows a read-only
+ * affordance instead.
+ *
+ * @module plugins/erli/components
+ */
+import { useState, type FormEvent, type ReactElement } from 'react';
+import type { Connection } from '../../../features/connections';
+import { useUpdateConnectionCredentialsMutation } from '../../../features/connections';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { useToast } from '../../../shared/ui/toast-provider';
+
+export function ErliCredentialsPanel({ connection }: { connection: Connection }): ReactElement {
+  const [showRotate, setShowRotate] = useState(false);
+  const [apiKey, setApiKey] = useState('');
+  const rotate = useUpdateConnectionCredentialsMutation();
+  const { showToast } = useToast();
+
+  if (!connection.credentialsBacked) {
+    return (
+      <FormField label="API Key" name="credentials">
+        <Input value="Environment variable (not editable via UI)" disabled />
+      </FormField>
+    );
+  }
+
+  const canSubmit = apiKey.trim().length > 0;
+
+  const onRotate = async (event: FormEvent): Promise<void> => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    try {
+      await rotate.mutateAsync({
+        connectionId: connection.id,
+        credentials: { apiKey: apiKey.trim() },
+      });
+      showToast({
+        tone: 'success',
+        title: 'Credentials rotated',
+        description: 'The new Erli API key is now in use.',
+      });
+      setApiKey('');
+      setShowRotate(false);
+    } catch {
+      // surfaced via rotate.error
+    }
+  };
+
+  return (
+    <FormField
+      label="API Key"
+      name="credentials"
+      description="Stored securely on the server. Rotate to replace the key without restarting the API."
+    >
+      {showRotate ? (
+        <div className="form-grid">
+          {rotate.error ? <Alert tone="error">{rotate.error.message}</Alert> : null}
+          <Input
+            type="password"
+            autoComplete="off"
+            placeholder="New API key"
+            value={apiKey}
+            onChange={(event) => setApiKey(event.target.value)}
+          />
+          <div className="form-actions">
+            <Button
+              type="button"
+              onClick={(event) => void onRotate(event)}
+              disabled={rotate.isPending || !canSubmit}
+            >
+              {rotate.isPending ? 'Rotating...' : 'Save new API key'}
+            </Button>
+            <Button
+              tone="secondary"
+              type="button"
+              onClick={() => {
+                setShowRotate(false);
+                setApiKey('');
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button tone="secondary" type="button" onClick={() => setShowRotate(true)}>
+          Rotate API key
+        </Button>
+      )}
+    </FormField>
+  );
+}

--- a/apps/web/src/plugins/erli/erli-setup.route.tsx
+++ b/apps/web/src/plugins/erli/erli-setup.route.tsx
@@ -1,0 +1,16 @@
+/**
+ * Route: `/connections/new/erli` — guided Erli wizard.
+ *
+ * @module plugins/erli
+ */
+import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../../app/nav-registry.types';
+
+export const erliSetupRoute: RouteObject = {
+  path: 'connections/new/erli',
+  handle: { crumb: { group: 'Platform', title: 'Connect Erli' } } satisfies RouteCrumbHandle,
+  lazy: async () => {
+    const { ErliSetupPage } = await import('../../pages/connections/erli-setup-page');
+    return { Component: ErliSetupPage };
+  },
+};

--- a/apps/web/src/plugins/erli/erli.test.ts
+++ b/apps/web/src/plugins/erli/erli.test.ts
@@ -1,0 +1,61 @@
+/**
+ * erliPlugin smoke tests
+ *
+ * Asserts the Erli plugin's static surface: identity, the guided setup route,
+ * and the platform contributions (display name, setup card, credentials panel).
+ * Also confirms the live plugin registry includes Erli so the connection-type
+ * picker renders it. Behavioural coverage lives in the consumer tests
+ * (erli-setup-form / erli-credentials-panel).
+ *
+ * @module plugins/erli
+ */
+import { describe, expect, it } from 'vitest';
+
+import { plugins } from '../index';
+import { erliPlugin } from './index';
+
+describe('erliPlugin', () => {
+  describe('identity', () => {
+    it('has the stable kebab-case id', () => {
+      expect(erliPlugin.id).toBe('erli');
+    });
+    it('declares the matching platformType', () => {
+      expect(erliPlugin.platformType).toBe('erli');
+    });
+  });
+
+  describe('build contributions', () => {
+    it('contributes the guided setup route', () => {
+      const paths = (erliPlugin.build?.routes ?? []).map((route) => route.path);
+      expect(paths).toContain('connections/new/erli');
+    });
+    it('does NOT contribute API namespaces or an offer-creation wizard', () => {
+      expect(erliPlugin.build?.apiNamespaces).toBeUndefined();
+      expect(erliPlugin.build?.offerCreationWizard).toBeUndefined();
+    });
+  });
+
+  describe('platform contributions', () => {
+    it('declares the display name', () => {
+      expect(erliPlugin.platform?.displayName).toBe('Erli');
+    });
+    it('contributes the setup card pointing to the guided wizard', () => {
+      expect(erliPlugin.platform?.setupCard?.to).toBe('/connections/new/erli');
+      expect(erliPlugin.platform?.setupCard?.badge).toBe('API key');
+    });
+    it('contributes a credentials panel', () => {
+      expect(erliPlugin.platform?.CredentialsPanel).toBeDefined();
+    });
+    it('does NOT contribute structured-config edit or marketplace slots', () => {
+      expect(erliPlugin.platform?.StructuredConfigSection).toBeUndefined();
+      expect(erliPlugin.platform?.ConnectionActions).toBeUndefined();
+    });
+  });
+
+  describe('registration', () => {
+    it('is present in the live plugin registry (drives the connection-type picker)', () => {
+      expect(plugins.map((p) => p.id)).toContain('erli');
+      expect(plugins.map((p) => p.platformType)).toContain('erli');
+    });
+  });
+});

--- a/apps/web/src/plugins/erli/index.ts
+++ b/apps/web/src/plugins/erli/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Erli plugin
+ *
+ * Unified contribution (#990) — Erli contributes the guided setup route
+ * (build-time) and platform-side affordances (setup card, credentials panel).
+ * Erli is a marketplace authenticated with a single Shop API key (sent as a
+ * bearer token by the BE adapter, #981), so the only credential the operator
+ * supplies is `apiKey`; `baseUrl` is an optional advanced config override.
+ *
+ * Structured config *editing* is intentionally not contributed — the only
+ * config field is the optional `baseUrl`, set at create time via the guided
+ * wizard; the edit form falls back to the generic raw-JSON config block for
+ * the rare post-create change.
+ *
+ * @module plugins/erli
+ */
+import type { OpenLinkerPlugin } from '../../shared/plugins';
+import { definePlugin } from '../define-plugin';
+import { ErliCredentialsPanel } from './components/erli-credentials-panel';
+import { erliSetupRoute } from './erli-setup.route';
+
+export const erliPlugin: OpenLinkerPlugin = definePlugin({
+  id: 'erli',
+  platformType: 'erli',
+  build: {
+    routes: [erliSetupRoute],
+  },
+  platform: {
+    displayName: 'Erli',
+    setupCard: {
+      title: 'Erli',
+      description: 'Connect your Erli seller account with your Shop API key.',
+      to: '/connections/new/erli',
+      badge: 'API key',
+    },
+    CredentialsPanel: ErliCredentialsPanel,
+  },
+});

--- a/apps/web/src/plugins/index.ts
+++ b/apps/web/src/plugins/index.ts
@@ -43,6 +43,7 @@ import type { OpenLinkerPlugin } from '../shared/plugins';
 import { allegroPlugin } from './allegro';
 import { assertUniquePluginInvariants } from './assert-unique-plugin-invariants';
 import { dpdPlugin } from './dpd';
+import { erliPlugin } from './erli';
 import { inpostPlugin } from './inpost';
 import { prestashopPlugin } from './prestashop';
 import { woocommercePlugin } from './woocommerce';
@@ -53,6 +54,7 @@ export const plugins: readonly OpenLinkerPlugin[] = [
   dpdPlugin,
   inpostPlugin,
   woocommercePlugin,
+  erliPlugin,
 ];
 
 assertUniquePluginInvariants(plugins);

--- a/docs/plans/implementation-plan-erli-connection-fe.md
+++ b/docs/plans/implementation-plan-erli-connection-fe.md
@@ -1,0 +1,36 @@
+# Implementation Plan — #990: FE Erli connection setup UI + web plugin registration
+
+**Date**: 2026-06-15 · **Status**: Ready to implement (turnkey) · **Effort**: M · **Branch**: `990-erli-connection-fe` (off `origin/main` — R4 resolved: FE uses only the generic connection API already in `main`; #982 is BE-only). Wave-4.
+
+> **Why this is a plan, not code (this session):** the FE follows an elaborate per-platform convention (form + page + route + registration + tests) in `apps/web`, where the org subagent spend-limit (hit mid-session) removed the ideal delegation path and solo FE iteration (vitest/RTL) couldn't be validated cheaply. This plan is code-grounded and turnkey: mirror WooCommerce (the closest precedent — credentials-based, no OAuth) scoped to Erli's single API key.
+
+## Scope (issue #990 ACs)
+- Operator can create an Erli connection from web admin (enter API key, see test result, see Active status).
+- Erli appears in the connection-type picker, driven by the plugin registry (no hard-coding / no `platformType` literal dispatch).
+- FE tests (`*.test.tsx`); no new ESLint/type errors.
+
+## Exact files (mirror WooCommerce; Erli = single `apiKey` credential + optional `baseUrl` config)
+
+1. **`apps/web/src/plugins/erli/index.ts`** — `definePlugin({ id:'erli', platformType:'erli', build:{ routes:[erliSetupRoute] }, platform:{ displayName:'Erli', setupCard:{ title:'Erli', description:'Connect your Erli seller account with your Shop API key.', to:'/connections/new/erli', badge:'API key' }, CredentialsPanel: ErliCredentialsPanel } })`. (No `StructuredConfigSection` needed — Erli has only an optional `baseUrl`; can omit or add a tiny one. Mirror `plugins/woocommerce/index.ts`.)
+2. **`apps/web/src/plugins/erli/erli-setup.route.tsx`** — `RouteObject` `path:'connections/new/erli'`, `handle.crumb {group:'Platform', title:'Connect Erli'}`, lazy-import `ErliSetupPage`. (Mirror `woocommerce-setup.route.tsx`.)
+3. **`apps/web/src/pages/connections/erli-setup-page.tsx`** — page shell composing the setup form. (Mirror `woocommerce-setup-page.tsx`.)
+4. **`apps/web/src/features/connections/components/erli-setup-form.tsx`** — the create form: a single **API key** field (+ optional advanced `baseUrl`), name field, submit via the generic `useCreateConnectionMutation` with `{ platformType:'erli', name, config:{ baseUrl? }, credentials:{ apiKey } }`, then "Test connection" via `useTestConnectionMutation`, surfacing the `ConnectionTestResult`. (Mirror `woocommerce-setup-form.tsx` / `dpd-setup-form.tsx`, simplified to one credential.) Use RHF + Zod (`apiKey` required non-empty) per FE conventions.
+5. **`apps/web/src/plugins/erli/components/erli-credentials-panel.tsx`** — edit-time API-key rotation via `useUpdateConnectionCredentialsMutation({ connectionId, credentials:{ apiKey } })`; honour `connection.credentialsBacked` (read-only affordance when env-backed). (Mirror `woocommerce-credentials-panel.tsx`, one field.)
+6. **Register** `erliPlugin` in `apps/web/src/plugins/index.ts` (import + add to the `plugins` array — single edit point; `assertUniquePluginInvariants` validates id/platformType uniqueness).
+7. **Tests** (`*.test.tsx`, vitest + RTL): setup-form renders + submits API key + shows test result; credentials-panel rotates; plugin registry includes erli (picker shows it). Mirror `woocommerce-*.test.tsx` + `platform-picker.test.tsx`.
+
+## Status surfacing
+Already registry-driven: `connections-list-page.tsx` + `ConnectionEntityLabel` key off `platformType` + `usePlatform`/`usePlatforms` and `toStatusTone(ConnectionStatus)` — no Erli-specific code needed once the plugin is registered. (Verify the list renders the Erli `displayName` + Active/error tone.)
+
+## Runtime caveat (R4)
+Builds + unit-tests off `main`. A *live* "Test connection" only succeeds once the Erli BE stack (incl. #982 connection tester/validators) is deployed to the target API — the FE calls the generic `/connections/:id/test`, which dispatches to the BE Erli connection tester registered at `erli.shopapi.v1`.
+
+## Gate (FE-specific — NOT the integrations dep-build)
+`pnpm install --prefer-offline` then `pnpm --filter @openlinker/web type-check + lint + test` (`tsc -b` / `vitest run`). No `@openlinker/*` workspace dep-build (apps/web has none).
+
+## Risks
+- Convention drift vs the per-platform setup-form/page/route pattern — mitigated by mirroring WooCommerce file-for-file.
+- `platformType` literal dispatch is ESLint-banned outside `plugins/<platformType>/` — keep all Erli-specific logic inside `plugins/erli/` + the registry-driven surfaces.
+
+## Related
+- Wave-4 meta-plan · `plugins/woocommerce/*` (precedent) · #982 (BE connection API) · spec #978 (User story 1 Connect, FE half)


### PR DESCRIPTION
## What & why

Implements **#990** — operators can create an Erli connection from the web admin (spec #978 "User story 1: Connect"). Mirrors the WooCommerce plugin (closest precedent — credentials-based, no OAuth), scoped to Erli's single API key.

- `apps/web/src/plugins/erli/` — `definePlugin` (id/platformType `erli`, setup card, `CredentialsPanel`), `erli-setup.route.tsx`, `components/erli-credentials-panel.tsx`.
- `pages/connections/erli-setup-page.tsx` + `features/connections/components/erli-setup-form.tsx` + `erli-setup.schema.ts` (RHF + Zod, `apiKey` required).
- Registered in `plugins/index.ts`; picker + status surfacing are registry-driven (no `platformType` literal dispatch).

## Independent of the BE stack

Branched off `main` — uses only the generic connection API already in `main`. **Draft** because a *live* "Test connection" only succeeds once the Erli BE (#982 tester/validators, registered at `erli.shopapi.v1`) is deployed; builds + unit tests are green off `main` today.

## Testing

`pnpm --filter @openlinker/web` type-check green; **1463 tests pass** (incl. new Erli setup-form / credentials-panel / picker specs).

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
