### PR TITLE
feat(erli): honor frozen stock on the quantity-sync hot path (#1066)

### DIFF
--- a/docs/plans/implementation-plan-erli-category-param.md
+++ b/docs/plans/implementation-plan-erli-category-param.md
@@ -13,7 +13,7 @@ Populate the Erli offer-create body (`POST /products/{externalId}`) with `extern
 The Erli adapter reads the **same command fields the Allegro adapter reads** → ADR-025 §3 reuse mandate. **Factory signature unchanged.**
 
 ## 3. Scope / non-goals
-**In:** `ErliExternalCategory`/`ErliExternalAttribute` wire types; `externalCategories`/`externalAttributes` on `ErliProductCreateBody`; mapping in `buildCreateBody`; graceful "no Allegro data → list without taxonomy"; unit tests.
+**In:** `ErliExternalCategory`/`ErliExternalAttribute` wire types; `externalCategories`/`externalAttributes` on `ErliProductCreateBody`; mapping in `buildCreateBody`; "no Allegro category → hard-reject the create with a clear error" (per ADR-025 §3 / AC-3); unit tests.
 **Out:** Erli-native authoring (#978 §6.2); variants (#986); stock/price/frozen (#988); status (#989); PATCH-path category mapping (create-only — `buildPatchFromFields` untouched); factory change; any taxonomy fetch.
 
 ## 4. `erli-product.types.ts` additions (additive; provisional #992)
@@ -35,13 +35,13 @@ Replace the `// #985:` seam with two helpers; assemble after the barcode block (
 - **`buildExternalAttributes(cmd)`**: concat `platformParams.parameters` + `.productParameters` (Erli has one flat list — offer/product split irrelevant on Erli). Narrow each `unknown` entry with a guard mirroring `isAllegroOfferParameterShape` (`allegro-offer-manager.adapter.ts:127-139`): require non-empty `id: string`. Map: `valuesIds` non-empty → `{type:'dictionary', values:valuesIds}`; else `values` non-empty → `{type:'string', values}`; `rangeValue`-only → **dropped v1** (debug-logged); empty → skip. Pure module functions (style: `toErliPrice`).
 
 ## 6. "No Allegro data" handling
-ADR-025 §3 / #978 §6.2 = no Erli-native fallback, **not** a hard create failure. No `categoryId` + no params → omit both keys; offer still creates (price/stock/title/barcode). Add one `logger.warn` ("no Allegro category; listing without taxonomy reuse — #985/#978 §6.2") for observability. Decision (Open Q2): graceful-omit + warn is the reversible low-risk default; if product wants hard-reject, add a one-branch `OfferCreateRejectedException` preflight.
+ADR-025 §3 / #978 §6.2 = no Erli-native taxonomy fallback. **Decision (Open Q2 — resolved to hard-reject):** when no Allegro `categoryId` resolves, `buildCreateBody` throws `OfferCreateRejectedException(adapterKey, 422, [{field:'category', code:'NO_ALLEGRO_TAXONOMY', …}])` *before* any POST — the create fails with a clear error, which `OfferCreationExecutionService` maps to `business_failure`. This matches AC-3 ("clear skip/**error**") and ADR-025 §3 ("products without Allegro taxonomy data are skipped with a clear error"). Rationale for choosing hard-reject over graceful-omit: an Erli offer with no category is not a useful listing, and surfacing it as a terminal rejection gives the operator an actionable signal rather than a silently-degraded offer. Parameters (attributes) alone, without a category, do not satisfy the requirement.
 
 ## 7. Idempotency / errors
 No new HTTP calls — one `POST {idempotent:true}` (`adapter:72`). `buildCreateBody` stays sync. Error mapping unchanged (`toCreateRejected` → `OfferCreateRejectedException`, no responseBody leak). Malformed param entries dropped silently (guard), never throw.
 
 ## 8. Unit tests (`erli-offer-manager.adapter.spec.ts`, assert on `post.mock.calls[0][1]`)
-1. category mapping; 2. dictionary attr (`valuesIds`→type:dictionary); 3. string attr (`values`→type:string); 4. offer+product merge into one flat list; 5. **skip-case** (no data → no keys, offer still POSTs, status `'draft'`); 6. empty-attrs → key omitted; 7. malformed entry dropped; 8. `rangeValue`-only dropped; 9. regression: existing "basic fields" exact-match still holds.
+1. category mapping; 2. dictionary attr (`valuesIds`→type:dictionary); 3. string attr (`values`→type:string); 4. offer+product merge into one flat list; 5. **no-taxonomy reject-case** (no `categoryId` → `OfferCreateRejectedException`, `post` NOT called); 6. empty-attrs → key omitted; 7. malformed entry dropped; 8. `rangeValue`-only dropped; 9. regression: existing "basic fields" exact-match still holds.
 
 ## 9. Architecture / cross-context
 No CORE change; types-only barrel imports from `@openlinker/core/listings` (no deep paths, no new cross-context import); all new shapes in `erli-product.types.ts` (single #992 point); no `any` (`unknown`+guard). Update file headers (`adapter:17-19`, `types:11-12`) — #985 taxonomy reuse now implemented (was listed out-of-scope).
@@ -50,11 +50,11 @@ No CORE change; types-only barrel imports from `@openlinker/core/listings` (no d
 - **R1 (#992-provisional):** field names/`type` set unconfirmed → isolated in `erli-product.types.ts`.
 - **R2 (`type` set):** Erli may want `integer`/`float` (neutral `CategoryParameterType` has them) vs v1's `dictionary|string|number`; single change point (Open Q1).
 - **R3 (ranges dropped):** rare; debug-logged.
-- **R4 (skip-vs-error):** reversible (Open Q2).
+- **R4 (skip-vs-error):** resolved to hard-reject (Open Q2) — matches ADR-025 §3 + AC-3.
 
 ## 11. Open questions
 1. **`type` discriminator + ranges** (#992): does Erli accept only `dictionary|string|number`? how to express ranges? v1 defaults non-dict→string, drops ranges.
-2. **Skip vs hard-error** when no Allegro category (product): v1 omits+warns.
+2. **Skip vs hard-error** when no Allegro category (product): **resolved → hard-error** (`OfferCreateRejectedException` before POST), per ADR-025 §3 + AC-3.
 3. **`unit` source** (#992 / issue author): command parameter entries do NOT carry `unit` (only neutral `CategoryParameter` metadata does, which the adapter never receives). So `ErliExternalAttribute.unit` is type-present but **unwired in v1**. Surface to the issue author — the issue's "optional unit" can't be honored from the command alone today.
 
 ## Related

--- a/docs/plans/implementation-plan-erli-category-param.md
+++ b/docs/plans/implementation-plan-erli-category-param.md
@@ -1,0 +1,61 @@
+# Implementation Plan — #985: Erli category & parameter mapping via Allegro-ID reuse (`source:"allegro"`)
+
+**Date**: 2026-06-15 · **Status**: Ready for Review · **Effort**: M · **Branch**: `985-erli-category-param` (off `984-erli-offer-manager`) · **ADR**: ADR-025 §3 · Part of Wave-4 (see `implementation-plan-erli-wave4-orchestration.md`).
+
+## 1. Task summary
+Populate the Erli offer-create body (`POST /products/{externalId}`) with `externalCategories` + `externalAttributes` tagged `source:"allegro"`, reusing OL's **already-resolved Allegro category id + parameter ids** that ride on `CreateOfferCommand`. Erli processes only the `id` (names ignored — ADR-025 §3). No Erli-native taxonomy authoring. Lands in the `// #985:` seam at `erli-offer-manager.adapter.ts:134` + additive wire types in `erli-product.types.ts`. Unit tests only; no CORE change, no migration.
+
+## 2. Key design question — RESOLVED (no new factory dep)
+**Allegro ids arrive on the command** (verified):
+- Category: `cmd.overrides.categoryId` (resolved by `OfferBuilderService` `offer-builder.service.ts:77-85,111`; Allegro adapter reads the same field `allegro-offer-manager.adapter.ts:1448,1469`).
+- Parameters: `cmd.overrides.platformParams.parameters` (offer-section) + `…​.productParameters` (product-section), passed through verbatim by `OfferBuilderService:102,113-115`; entry shape `{ id; values?; valuesIds?; rangeValue? }` (`serialize-allegro-parameters.ts:45-50`).
+
+The Erli adapter reads the **same command fields the Allegro adapter reads** → ADR-025 §3 reuse mandate. **Factory signature unchanged.**
+
+## 3. Scope / non-goals
+**In:** `ErliExternalCategory`/`ErliExternalAttribute` wire types; `externalCategories`/`externalAttributes` on `ErliProductCreateBody`; mapping in `buildCreateBody`; graceful "no Allegro data → list without taxonomy"; unit tests.
+**Out:** Erli-native authoring (#978 §6.2); variants (#986); stock/price/frozen (#988); status (#989); PATCH-path category mapping (create-only — `buildPatchFromFields` untouched); factory change; any taxonomy fetch.
+
+## 4. `erli-product.types.ts` additions (additive; provisional #992)
+```typescript
+export type ErliExternalAttributeType = 'dictionary' | 'string' | 'number';
+export interface ErliExternalCategory { source: 'allegro'; id: string; }
+export interface ErliExternalAttribute {
+  source: 'allegro'; id: string; type: ErliExternalAttributeType; values: string[]; unit?: string;
+}
+// on ErliProductCreateBody (both optional, omitted when empty):
+//   externalCategories?: ErliExternalCategory[];
+//   externalAttributes?: ErliExternalAttribute[];
+```
+Designed so #986 (`externalVariantGroup`), #988 (stock/price/frozen), #989 (status) extend the same file without reshaping these.
+
+## 5. `buildCreateBody` mapping
+Replace the `// #985:` seam with two helpers; assemble after the barcode block (omit keys when empty):
+- **`buildExternalCategories(cmd)`**: `cmd.overrides?.categoryId` non-empty → `[{source:'allegro', id}]`; else `[]`.
+- **`buildExternalAttributes(cmd)`**: concat `platformParams.parameters` + `.productParameters` (Erli has one flat list — offer/product split irrelevant on Erli). Narrow each `unknown` entry with a guard mirroring `isAllegroOfferParameterShape` (`allegro-offer-manager.adapter.ts:127-139`): require non-empty `id: string`. Map: `valuesIds` non-empty → `{type:'dictionary', values:valuesIds}`; else `values` non-empty → `{type:'string', values}`; `rangeValue`-only → **dropped v1** (debug-logged); empty → skip. Pure module functions (style: `toErliPrice`).
+
+## 6. "No Allegro data" handling
+ADR-025 §3 / #978 §6.2 = no Erli-native fallback, **not** a hard create failure. No `categoryId` + no params → omit both keys; offer still creates (price/stock/title/barcode). Add one `logger.warn` ("no Allegro category; listing without taxonomy reuse — #985/#978 §6.2") for observability. Decision (Open Q2): graceful-omit + warn is the reversible low-risk default; if product wants hard-reject, add a one-branch `OfferCreateRejectedException` preflight.
+
+## 7. Idempotency / errors
+No new HTTP calls — one `POST {idempotent:true}` (`adapter:72`). `buildCreateBody` stays sync. Error mapping unchanged (`toCreateRejected` → `OfferCreateRejectedException`, no responseBody leak). Malformed param entries dropped silently (guard), never throw.
+
+## 8. Unit tests (`erli-offer-manager.adapter.spec.ts`, assert on `post.mock.calls[0][1]`)
+1. category mapping; 2. dictionary attr (`valuesIds`→type:dictionary); 3. string attr (`values`→type:string); 4. offer+product merge into one flat list; 5. **skip-case** (no data → no keys, offer still POSTs, status `'draft'`); 6. empty-attrs → key omitted; 7. malformed entry dropped; 8. `rangeValue`-only dropped; 9. regression: existing "basic fields" exact-match still holds.
+
+## 9. Architecture / cross-context
+No CORE change; types-only barrel imports from `@openlinker/core/listings` (no deep paths, no new cross-context import); all new shapes in `erli-product.types.ts` (single #992 point); no `any` (`unknown`+guard). Update file headers (`adapter:17-19`, `types:11-12`) — #985 taxonomy reuse now implemented (was listed out-of-scope).
+
+## 10. Risks
+- **R1 (#992-provisional):** field names/`type` set unconfirmed → isolated in `erli-product.types.ts`.
+- **R2 (`type` set):** Erli may want `integer`/`float` (neutral `CategoryParameterType` has them) vs v1's `dictionary|string|number`; single change point (Open Q1).
+- **R3 (ranges dropped):** rare; debug-logged.
+- **R4 (skip-vs-error):** reversible (Open Q2).
+
+## 11. Open questions
+1. **`type` discriminator + ranges** (#992): does Erli accept only `dictionary|string|number`? how to express ranges? v1 defaults non-dict→string, drops ranges.
+2. **Skip vs hard-error** when no Allegro category (product): v1 omits+warns.
+3. **`unit` source** (#992 / issue author): command parameter entries do NOT carry `unit` (only neutral `CategoryParameter` metadata does, which the adapter never receives). So `ErliExternalAttribute.unit` is type-present but **unwired in v1**. Surface to the issue author — the issue's "optional unit" can't be honored from the command alone today.
+
+## Related
+- Wave-4 meta-plan · ADR-025 · #984 plan (`implementation-plan-erli-offer-manager.md`) · Spec #978 §6.2

--- a/docs/plans/implementation-plan-erli-frozen-stock.md
+++ b/docs/plans/implementation-plan-erli-frozen-stock.md
@@ -1,0 +1,147 @@
+# Implementation Plan — #1066: Erli honor frozen `stock` on the quantity-sync hot path
+
+**Date**: 2026-06-15 · **Status**: Planned · **Effort**: S–M · **Branch**: `1066-erli-frozen-stock` (off the #989 tip) · **ADR**: ADR-025 §4b. Plugin-only change — **no CORE change, no schema migration, no factory-signature churn**.
+
+## Goal
+
+Stop OL overwriting a seller-frozen Erli `stock` on every inventory tick, **without** adding a per-tick GET to the hot `updateOfferQuantity` path. Today (`#988`/#1061): frozen-field exclusion (`dropFrozenFields`) only runs on `updateOfferFields`, which GETs the live product first; `updateOfferQuantity` deliberately blind-PATCHes `stock` for per-tick performance, so a frozen stock is clobbered.
+
+The reconciliation task `erli-offer-status-sync` (#989) **already GETs each mapped offer** (`getOfferStatus` → `fetchErliProduct`) and already sees `frozenFields`. We piggyback on that GET: when reconciliation observes a frozen `stock`, cache a per-offer flag; `updateOfferQuantity` reads that cached flag and skips the stock PATCH when set. Zero added GET on the hot path.
+
+## Decisions (code-verified)
+
+### D1 — Persistence: plugin-local `CachePort`, NOT a new table. **No TypeORM migration.**
+
+The frozen-stock flag is persisted via the **host-provided `CachePort`** (`HostServices.cache`, `@openlinker/shared` → Redis-backed in apps), keyed per `(connectionId, externalOfferId)`. Rationale, evaluated against the alternatives:
+
+| Option | Verdict | Why |
+|---|---|---|
+| **`CachePort` (chosen)** | ✅ | Already on `HostServices`; already wired into Erli's module via `createNestAdapterModule` (the same DI path Allegro uses — `host.cache`). Plugin-owned, no core surface change, no migration. The flag is *derived, refreshable state* (re-asserted every reconciliation tick), not a system of record — exactly the cache's contract (hard TTL, tolerate miss). |
+| Reuse `offer_status_snapshots` (add a `stockFrozen` column) | ❌ | (1) Requires a **core schema migration** on a `libs/core` ORM entity + widening `OfferStatusSnapshotRepositoryPort` / `UpsertOfferStatusSnapshotCommand` / the neutral `OfferStatusReadResult` — a cross-cutting core change to serve one plugin's quirk. (2) The snapshot is written by the **core** `OfferStatusSyncService`, which only ever sees the neutral `OfferStatusReadResult` (`publicationStatus` + `validationErrors`) — it has no channel to carry an Erli-specific `frozenFields` signal without polluting the neutral contract. (3) `updateOfferQuantity` lives in the **plugin** and must not reach into a core repository port (cross-context `*RepositoryPort` import is ESLint-forbidden from `libs/integrations/**`). Decisively rejected. |
+| New Erli-owned ORM entity + repository | ❌ | Erli is wired via `createNestAdapterModule` precisely *because it has no plugin-specific NestJS providers* (`erli-integration.module.ts` docblock). A TypeORM entity would force flipping Erli to a custom `@Module` with `TypeOrmModule.forFeature`, a migration, and a repository — heavyweight for a refreshable boolean. YAGNI. |
+| In-process memory map | ❌ | Lost on restart and not shared across api/worker processes; the writer (reconciliation, runs in worker) and reader (`updateOfferQuantity`, runs wherever inventory sync runs) are different processes. Must be distributed. |
+
+**Cache miss = fail OPEN (push stock).** This preserves today's behaviour exactly when the flag is unknown (first run, TTL expiry, cache down, `host.cache` undefined in unit-test hosts). The only behaviour change is the *positive* case: flag present and `true` ⇒ skip. A frozen stock is at worst overwritten once between reconciliation ticks — the same eventual-consistency posture ADR-025 §1 already takes for stock drift, and reconciliation re-asserts the flag on its next pass.
+
+**Key identity (the linchpin — see Risks).** The write path (`getOfferStatus` / `updateOfferFields`) and the read path (`updateOfferQuantity`) MUST produce the **same** cache key for the same offer, or the feature silently no-ops (every read misses → fail-open → AC unmet, zero test signal). Today both sides key on the OL `ol_variant_*` id — the write side via `mapping.externalId` (the value `OfferStatusSyncService` passes to `getOfferStatus`), the read side via `cmd.offerId` — and they coincide. But that's an emergent property of two independent call paths, not an invariant the adapter enforces. To make it enforced rather than asserted:
+
+- The key string is built by a **single private method** `frozenStockCacheKey(externalOfferId)` used by **both** writer and reader, so they cannot drift.
+- That builder MUST interpolate **`this.connectionId`** (the constructor-injected trusted field — never a value off `cmd`) and take only `externalOfferId` as a parameter, so two connections sharing a variant id read/write disjoint flags (cross-connection isolation; covered by the #992 cache-key note in Risks).
+- A test exercises the write→read round-trip on one key (write via `getOfferStatus(VALID_ID)` with frozen stock, read via `updateOfferQuantity({ offerId: VALID_ID })` against the **same** mocked cache, assert PATCH skipped).
+
+**Key + TTL:**
+- Key: `erli:frozen-stock:{connectionId}:{externalOfferId}` (mirrors the colon-namespaced convention; `externalOfferId` is the validated `ol_variant_*` seller key — see "id hygiene in the key builder" below).
+- TTL: a small multiple of the **actual** reconciliation cadence so a stale flag self-heals if reconciliation stops. The cron defaults hourly (`ERLI_OFFER_STATUS_SYNC_CRON = '0 0 * * * *'`). The TTL is sized for the **worst case** — an operator who loosens the cron to a daily scan — so it must exceed 24 h: propose **TTL = 26 h**. Note the eventual-consistency window is bounded by the *cron cadence* (re-asserted every tick while reconciliation runs), not by the TTL; the TTL only matters once reconciliation stops. Colocate the TTL constant adjacent to the cron constant's documented cadence with a comment linking the two, so a future cron change re-prompts the TTL.
+- Value stored: `boolean` (`true` = stock frozen). **Write-on-frozen-only:** on a reconciliation pass that sees stock **frozen**, `set(key, true, TTL)`; on a pass that sees stock **not** frozen, `delete(key)` (transition frozen→not-frozen). Rationale: "known not-frozen" and "unknown" both read as fail-open (push), so storing `false` buys nothing operationally while adding a Redis write on every tick for every not-frozen offer (the overwhelming majority — write amplification). `delete` is idempotent and cheap when the key is already absent. This also avoids the bodyless-GET clobber (see D3 / step 3).
+
+### D2 — The frozen-stock signal is read where the GET already happens (`getOfferStatus`).
+
+`fetchErliProduct` already returns `ErliProductResource.frozenFields`. `getOfferStatus` is the **only** steady-state path that GETs every mapped offer. So the cache **write** happens inside `getOfferStatus` (or a small helper it calls) — no new GET, no new scheduler task, no core change. `updateOfferFields` also GETs and could opportunistically refresh the flag too (cheap, same `current.frozenFields` already in hand) — include it as a secondary writer (it only fires on content edits, but keeps the flag fresher). The reconciliation task is the *primary* writer because it sweeps all offers on a cadence.
+
+### D3 — `stock` re-enters `PATCH_KEY_TO_ERLI_FROZEN_NAME`? **No.**
+
+That map drives `dropFrozenFields` on the *field-update* path, which reads live `frozenFields` per call. The quantity path doesn't read live frozen state — it reads the *cache*. Keep `stock` out of that map (the #1061 comment is correct for `updateOfferFields`); the quantity-path check is a separate cache lookup. Add the frozen-stock Erli wire-name as its own provisional constant (`ERLI_FROZEN_STOCK_FIELD = 'stock'`) used by the cache-write detection and documented as #992-provisional.
+
+**Colocation + single #992 change point.** Place `ERLI_FROZEN_STOCK_FIELD` immediately adjacent to `PATCH_KEY_TO_ERLI_FROZEN_NAME` (the existing block already carries a thorough comment explaining `stock`'s deliberate absence and the #1066 deferral, adapter lines ~103–113). Update that comment from "#1066 deferred / dead code" to "#1066: honored via the cache flag, see `ERLI_FROZEN_STOCK_FIELD`", so the single #992 reconciliation point stays visibly singular and the two constants encoding the same provisional wire vocabulary sit together. Both constants stay **module-local** in `erli-offer-manager.adapter.ts` (matching the existing `ERLI_PRODUCT_ID_PATTERN` / `PATCH_KEY_TO_ERLI_FROZEN_NAME` precedent in that same file — this is deliberate precedent-following under the project's colocate-constants allowance, **not** a `*.types.ts` omission; no new constants module).
+
+## Implementation
+
+All changes in `libs/integrations/erli/`.
+
+### 1. Thread `CachePort` to the adapter (factory + plugin)
+
+- **Import**: `import type { CachePort } from '@openlinker/shared';` (top-level barrel — `libs/shared/src/index.ts` does `export * from './cache'`; matches Allegro's `allegro-adapter.factory.ts`). Use `import type` so the import is erasable and adds no runtime coupling (consistent with the adapter's existing type-only imports). Do **not** use the `@openlinker/shared/cache` subpath, and do **not** copy the local `@openlinker/shared/logging` subpath pattern for this type.
+- `erli-plugin.ts` `createCapabilityAdapter`: pass `host.cache` into `factory.createAdapters(...)`. The factory signature already carries `identifierMapping` it doesn't use "so #985/#986/#988 extend behaviour without churning this signature" — add `cache?: CachePort` as a trailing optional arg to `createAdapters`. (Threading note: Allegro threads `host.cache` via the `AllegroAdapterFactory` **constructor** and keeps `createAdapters` at 3 args; Erli's factory is constructed argument-less inside `createCapabilityAdapter` (`new ErliAdapterFactory()`), so we pass `host.cache` into `createAdapters` instead — an Erli-local choice, **not** a 1:1 copy of Allegro. Both stay plugin-local with no boundary impact; the cache still arrives from `host.cache` either way.)
+- `erli-adapter.factory.ts`: accept `cache?: CachePort` as a trailing optional arg on `createAdapters`, pass to `new ErliOfferManagerAdapter(connection.id, ERLI_ADAPTER_KEY, httpClient, cache)`.
+- `ErliOfferManagerAdapter` constructor: add `private readonly cache?: CachePort`. Tolerate `undefined` (unit-test hosts, `CacheModule`-less bootstraps) — fail-open everywhere it's consulted.
+- **No factory-return-type change**: `ErliAdapters.offerManager` stays typed `OfferManagerPort & OfferCreator & OfferFieldUpdater`. The concrete class also implements `OfferStatusReader` and the cache-write happens inside `getOfferStatus`, but that method is reached via core `OfferStatusReader` capability dispatch (`OfferStatusSyncService`), not through the `ErliAdapters` bag — so the union union stays unchanged and no Symbol token / Nest provider is introduced (the adapter is a plain factory-constructed class).
+
+### 2. Frozen-stock cache helpers (private adapter methods + module constants)
+
+- `ERLI_FROZEN_STOCK_FIELD = 'stock'` — provisional Erli wire-name (#992), the value looked for in `frozenFields`. Module-local, colocated with `PATCH_KEY_TO_ERLI_FROZEN_NAME` (see D3).
+- `ERLI_FROZEN_STOCK_CACHE_TTL_SEC` (26 h, module-local, colocated with the cron-cadence note) and a `private frozenStockCacheKey(externalOfferId): string | null` builder returning `erli:frozen-stock:{connectionId}:{encodeURIComponent(externalOfferId)}`. **Id hygiene (fail-open, mirrors `productPath`):** validate `externalOfferId` against the same `ERLI_PRODUCT_ID_PATTERN` and **return `null`** on a non-match (don't build a key from an unvalidated string); also `encodeURIComponent` the id as the backstop so a stray `:` can't cause namespace-separator confusion across connections. This keeps the read path's fail-open posture while ensuring the cache key derives from the **same** validated id the wire path uses — so the #992 seller-key change can't silently widen the cache surface. The builder uses `this.connectionId` (trusted, constructor-injected), never a value off `cmd`.
+- `private async writeFrozenStockFlag(externalOfferId, frozenFields: string[] | undefined): Promise<void>` — guard `if (!this.cache) return;`; compute `key = frozenStockCacheKey(externalOfferId)` and bail if `null`. **Only act when `frozenFields` is a defined array** (the GET actually carried frozen info); treat `undefined` (bodyless 2xx) as "no info — leave the cache untouched" (no `set`, no `delete`). When defined: if `(frozenFields).includes(ERLI_FROZEN_STOCK_FIELD)` → `set(key, true, TTL)`; else → `delete(key)` (write-on-frozen-only / delete-on-unfreeze, per D1). Swallow cache errors with a `logger.debug` (a cache write must never break reconciliation).
+- `private async isStockFrozenCached(externalOfferId): Promise<boolean>` — compute `key = frozenStockCacheKey(externalOfferId)`; return `false` (fail-open) if `null` (invalid/hostile id), if `!this.cache`, or on `undefined`/`null`/miss/cache-error from `this.cache.get<boolean>(key)`.
+
+### 3. Write the flag where the GET already happens
+
+- In `getOfferStatus`, after `fetchErliProduct` succeeds, call `await this.writeFrozenStockFlag(externalOfferId, product.frozenFields)` **before** mapping/returning. Place it so a 404 (→ `OfferNotFoundOnMarketplaceException`) does NOT write (offer not on Erli). A 204 / bodyless 2xx leaves `product.frozenFields` `undefined` — the helper's defined-array guard (step 2) means this writes **nothing** (it does not clobber a previously-cached `true` with a stale `false`/`delete`), which is the correct "GET carried no frozen info" semantics.
+- In `updateOfferFields`, after `current` is resolved, opportunistically `await this.writeFrozenStockFlag(cmd.externalOfferId, current.frozenFields)` (secondary writer; cheap, frozenFields already in hand). On the 404 fail-open branch `current` is `{}` so `frozenFields` is `undefined` — the helper no-ops, no special-casing needed.
+
+### 4. Read the flag on the hot path (`updateOfferQuantity`)
+
+```
+async updateOfferQuantity(cmd: UpdateOfferQuantityCommand): Promise<void> {
+  // #1066 / ADR-025 §4b: honor a seller-frozen stock WITHOUT a per-tick GET.
+  // The flag is cached during erli-offer-status-sync reconciliation (which
+  // already GETs each offer); cache miss fails OPEN (push), preserving the
+  // pre-#1066 behaviour when the flag is unknown.
+  if (await this.isStockFrozenCached(cmd.offerId)) {
+    this.logger.debug(`Skipping stock push for frozen Erli offer [connectionId=${this.connectionId}]`);
+    return;
+  }
+  const body: ErliProductPatchBody = { stock: cmd.quantity };
+  await this.httpClient.patch(this.productPath(cmd.offerId), body);
+}
+```
+Note: `cmd.offerId` reaches `isStockFrozenCached` **before** `productPath` validates it on the push branch. The cache-key builder (step 2) applies the **same** `ERLI_PRODUCT_ID_PATTERN` validate-or-`null` + `encodeURIComponent` hygiene as `productPath`, so a hostile/malformed id never reaches the Redis keyspace: it yields a `null` key → `isStockFrozenCached` returns `false` (fail-open) → push branch runs → `productPath` throws as today. Behaviour unchanged for hostile ids, and no unvalidated string is interpolated into a cache key.
+
+### 5. Docblock + comment updates
+
+- **Adapter file-header docblock** (the load-bearing stale claim, `erli-offer-manager.adapter.ts` lines ~26–33, the "Frozen-field ownership (#988, ADR-025 §4b)" paragraph): this is the block whose "The hot `updateOfferQuantity` inventory path deliberately does NOT pre-fetch … stock drift is guarded by reconciliation (#989), not a per-PATCH GET" sentence now contradicts the new behaviour and **must** be revised — frozen-`stock` is honored on the quantity path via the reconciliation-cached flag (#1066), without a per-tick GET. (Not just the class-level wording — the file header carries the stale claim.)
+- `updateOfferQuantity` inline comment: replace the "#1066 deferred" note with the cached-flag explanation (cache miss = fail-open = pre-#1066 behaviour).
+- `PATCH_KEY_TO_ERLI_FROZEN_NAME` comment: keep `stock` out, but update the trailing note — frozen-stock is now honored via the cache flag (not this map), and cross-reference `ERLI_FROZEN_STOCK_FIELD` so the single #992/#1066 reconciliation point stays singular (see D3).
+
+### 6. ADR-025 — sweep all #1066-deferral references
+
+Amend §4b to record that frozen-`stock` is now honored on the quantity path via a reconciliation-populated cache flag (no per-tick GET); cite #1066. **Then sweep the rest of the ADR for #1066-as-deferred wording so nothing contradicts §4b** — at minimum: §Context ("Frozen stock on the quantity-sync path is a v1 follow-up (#1066)"), §Decision 4a, and §Consequences/Cons ("Frozen stock on the quantity path … are v1 follow-ups (#1066, #993)"). Leave #993 framed as deferred; only the #1066 frozen-stock items flip to "honored". Note the bounded-window caveat explicitly: frozen-stock is honored **from the first reconciliation pass onward**; the sub-cadence window (a freeze landing between ticks) is accepted per ADR-025 §1's reconciliation-first / eventual-consistency posture. (Doc-only; same wave.)
+
+## Tests (`erli-offer-manager.adapter.spec.ts`)
+
+Add a new `describe` block whose adapter is constructed with a `jest.Mocked<CachePort>` (4th constructor arg). **Existing quantity-path tests stay as-is** — the default spec builds the adapter without a cache (`new ErliOfferManagerAdapter('conn-1', ERLI_ADAPTER_KEY, httpClient)`), and because `isStockFrozenCached` fail-opens when `this.cache` is `undefined`, those tests (including the existing `expect(httpClient.get).not.toHaveBeenCalled()` no-GET assertion) remain green unchanged and serve as the "no cache wired → fail-open + no GET" coverage. **Do not retrofit them with a cache mock** (unnecessary churn that contradicts the fail-open design).
+
+New cache-wired cases:
+
+- **write→read round-trip on one key (the linchpin)**: write via `getOfferStatus(VALID_ID)` with `frozenFields: ['stock']`, then read via `updateOfferQuantity({ offerId: VALID_ID })` against the **same** mocked cache, assert the PATCH is skipped. Exercises that writer and reader build the identical key (none of the per-path cases below do).
+- **frozen → stock push skipped**: `cache.get` resolves `true` ⇒ `updateOfferQuantity` issues **no** `httpClient.patch`.
+- **not-frozen → stock pushed**: `cache.get` resolves `null` (key absent — write-on-frozen-only means not-frozen is `delete`d, not stored `false`) ⇒ one PATCH `{ stock }` (asserts AC + normal path unchanged).
+- **cache miss → stock pushed (fail-open)**: `cache.get` resolves `null` ⇒ PATCH issued.
+- **cache read error → stock pushed (fail-open)**: `cache.get` rejects ⇒ PATCH issued (error swallowed).
+- **hostile/malformed id → no cache touch, PATCH path runs**: `updateOfferQuantity({ offerId: 'not-a-valid-id' })` ⇒ `cache.get` **not** called (key builder returns `null`), and the push branch's `productPath` throws (behaviour unchanged for hostile ids; no unvalidated string in the keyspace).
+- **cross-connection key isolation**: two adapters built with different `connectionId`s produce **disjoint** cache keys for the same variant id (guards the connection-scoping invariant against a future refactor).
+- **reconciliation writes the flag (frozen)**: `getOfferStatus` with `frozenFields: ['stock']` ⇒ `cache.set` called with the key + `true` + `ERLI_FROZEN_STOCK_CACHE_TTL_SEC`.
+- **reconciliation clears the flag (not-frozen)**: `getOfferStatus` with `frozenFields: []` ⇒ `cache.delete` called with the key (write-on-frozen-only / delete-on-unfreeze); **no** `cache.set(..., false, …)`.
+- **bodyless 2xx leaves the cache untouched**: `getOfferStatus` where `fetchErliProduct` returns `{}` (`frozenFields` `undefined`) ⇒ **no** `cache.set` and **no** `cache.delete` (the undefined-array guard preserves a previously-cached `true`).
+- **`getOfferStatus` 404 does NOT touch the cache**: no `cache.set`/`cache.delete` on the `OfferNotFoundOnMarketplaceException` branch.
+- **`updateOfferFields` opportunistically writes the flag** (secondary writer): `frozenFields: ['stock']` ⇒ `cache.set(..., true, …)`.
+- **no-GET invariant preserved**: cache-wired `updateOfferQuantity` (frozen and not-frozen) issues **no** `httpClient.get` — guards the AC "no additional GET on the hot path" (complements the existing cache-less no-GET assertion).
+
+## Risks
+
+- **Read-key/write-key identity (mitigated, not just noted)**: the feature is a silent no-op if the writer and reader build different keys. Mitigated by the single `frozenStockCacheKey` builder shared by both paths + the write→read round-trip test (D1, Tests) — no longer left as an unguarded assumption.
+- **#992-provisional**: the Erli frozen wire-name for stock (`ERLI_FROZEN_STOCK_FIELD = 'stock'`), the `frozenFields` shape, and the seller-key format are unconfirmed until the sandbox spike — isolated in `erli-product.types.ts` + the colocated adapter constants (single change point, same posture as #988). **If #992 switches the seller-key format** (e.g. to a free-form SKU/barcode), the cache-key builder's `ERLI_PRODUCT_ID_PATTERN` validation must be re-confirmed in lockstep with `productPath` (both already share the pattern) — a loosened pattern without that re-confirmation would let externally-sourced ids into the Redis keyspace at high cardinality (bounded by the 26 h TTL, but still). Extend the existing "#992 changes `productPath` + `resolveErliProductId` together" coupling note to include the cache-key builder.
+- **Eventual consistency window**: a stock frozen *between* reconciliation ticks is overwritten once until the next pass caches the flag (≤ reconciliation cadence, default 1 h). Acceptable per ADR-025 §1 reconciliation-first posture; tighten the cron if a deployment needs a smaller window. The window is bounded by the **cron cadence** (re-asserted each tick), not the TTL. Documented in the adapter docblock.
+- **Cache availability**: if `host.cache` is absent or Redis is down, the feature silently no-ops (fail-open = pre-#1066 behaviour). No correctness regression, only the frozen-stock guarantee lapses — logged at debug.
+
+## Quality gate (scoped — constrained machine)
+
+From `…/.claude/worktrees/1066-erli-frozen-stock`:
+```
+pnpm --filter @openlinker/integrations-erli type-check
+pnpm exec eslint <changed files>
+pnpm --filter @openlinker/integrations-erli test
+```
+No core change ⇒ no `migration:show`, no full-repo build/test.
+
+## Files changed
+
+- `libs/integrations/erli/src/erli-plugin.ts` — pass `host.cache` into `createAdapters`.
+- `libs/integrations/erli/src/application/erli-adapter.factory.ts` — accept + forward `cache?: CachePort`.
+- `libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts` — `cache` ctor dep; `writeFrozenStockFlag` / `isStockFrozenCached`; write in `getOfferStatus` + `updateOfferFields`; read in `updateOfferQuantity`; constants; docblock/comments.
+- `libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts` — (optional) note `stock` as a recognised `frozenFields` member (#992-provisional); no shape change required (`frozenFields: string[]` already covers it).
+- `libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts` — cache mock + the cases above.
+- `docs/architecture/adrs/025-erli-marketplace-adapter.md` — §4b amendment (doc-only).
+
+## Related
+
+- ADR-025 §4b · #988/#1061 (frozen-field exclusion + the `stock` map omission this completes) · #989 (`getOfferStatus` / reconciliation — the GET we piggyback on) · #816 (`offer_status_snapshots` — the reconciliation infra, deliberately *not* extended) · `CachePort` (`@openlinker/shared`, on `HostServices.cache`).

--- a/docs/plans/implementation-plan-erli-offer-status-recon.md
+++ b/docs/plans/implementation-plan-erli-offer-status-recon.md
@@ -14,12 +14,12 @@ Give OL trustworthy Erli offer status despite async 202 + ~20-min cache lag. Aft
 2. **`erli-offer-manager.adapter.ts`**:
    - `implements … OfferStatusReader`.
    - `getOfferStatus(externalOfferId)` — reuses `fetchErliProduct` (GET via `productPath`, validate+encode → hostile id fails closed); 404 → `OfferNotFoundOnMarketplaceException(externalOfferId, connectionId)` (capability contract); other transport errors propagate. Maps via `mapErliStatusToReadResult` (module fn).
-   - **Flip `createOffer` 202 → `'validating'`** — safe now that an `OfferStatusReader` exists (the core poll's `OFFER_POLL_NOT_SUPPORTED` path no longer fires). #984 docblock updated.
+   - **`createOffer` 202 stays `'draft'`** (NOT flipped to `'validating'`). Although an `OfferStatusReader` now exists, the Allegro-tuned `OfferStatusPollService` treats a GET-404 as terminal on iteration 1 and its ~9.5-min budget is shorter than Erli's ~20-min cache lag — flipping to `'validating'` would let the poller falsely fail valid-but-not-yet-readable offers. Steady-state reconciliation (the `erli-offer-status-sync` scheduler task below) is the correct mechanism to surface the real status, not the creation poller. The #984 docblock + adapter comment record this.
 3. **`infrastructure/scheduler/erli-scheduler-tasks.ts`** (new) — `buildErliSchedulerTasks()` → one `SchedulerTaskConfig` `erli-offer-status-sync` (jobType `marketplace.offer.statusSync`, cursor `erli.offerStatus.scanOffset`, hourly default, `enabledEnvVar OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED`). No `ConfigService` (Erli uses `createNestAdapterModule`); registered unconditionally, the env gate is re-checked by the scheduler at each tick.
 4. **`erli-plugin.ts` `register(host)`** — `host.schedulerTaskRegistry.register(task)` for each.
 
 ## Tests
-`getOfferStatus` mapping (active/accepted/inactive/undefined → publicationStatus; rejected → inactive + ERLI_REJECTED validationError); 404 → `OfferNotFoundOnMarketplaceException`; non-404 propagates; hostile id fails closed; `isOfferStatusReader(adapter)` true; createOffer now returns `'validating'`; plugin registers the scheduler task. **113 erli tests green, type-check + lint clean.**
+`getOfferStatus` mapping (active/accepted/inactive/undefined → publicationStatus; rejected → inactive + ERLI_REJECTED validationError); 404 → `OfferNotFoundOnMarketplaceException`; non-404 propagates; hostile id fails closed; `isOfferStatusReader(adapter)` true; createOffer still returns `'draft'` (see Implementation §2 — deliberately not flipped to `'validating'`); plugin registers the scheduler task. **113 erli tests green, type-check + lint clean.**
 
 ## Risks
 - **#992-provisional**: Erli status field name + value set unconfirmed → isolated in `erli-product.types.ts`.

--- a/docs/plans/implementation-plan-erli-offer-status-recon.md
+++ b/docs/plans/implementation-plan-erli-offer-status-recon.md
@@ -1,0 +1,30 @@
+# Implementation Plan — #989: Erli offer-status reconciliation snapshot
+
+**Date**: 2026-06-15 · **Status**: Implemented · **Effort**: M · **Branch**: `989-erli-offer-status-recon` (off `986-erli-variant-grouping`) · **ADR**: ADR-025 §1 · Wave-4.
+
+## Goal
+Give OL trustworthy Erli offer status despite async 202 + ~20-min cache lag. After listing, OL eventually shows the real status (accepted/active/inactive/rejected), not just "submitted"; rejected offers reflect as such.
+
+## Decisions (code-verified)
+- **Reuse the platform-agnostic core snapshot infra — NO migration.** `offer_status_snapshots` + `OfferStatusSyncService` are connection-keyed and resolve the adapter via `getCapabilityAdapter<OfferManagerPort>` + `isOfferStatusReader`. Erli only (a) implements `OfferStatusReader` and (b) registers a scheduler task enqueuing the existing `marketplace.offer.statusSync` job. No new worker handler, no core change.
+- **No core enum change.** Erli's `accepted/active/inactive/rejected` maps onto the closed `OfferPublicationStatus = active|activating|inactivating|inactive|ended`: `active`→`active`; `accepted` (stored, still propagating)→`activating`; `rejected`→`inactive` + reason in `validationErrors` (`OfferStatusReadResult` carries them); `inactive`/unknown→`inactive`. Avoids the data-migration risk an enum change carries (offer-status-read.types ADR-009 note).
+
+## Implementation
+1. **`erli-product.types.ts`** — `ErliProductStatus` (provisional #992) + `status?`/`statusReason?` on `ErliProductResource` (the read shape shared with #988's `fetchErliProduct`).
+2. **`erli-offer-manager.adapter.ts`**:
+   - `implements … OfferStatusReader`.
+   - `getOfferStatus(externalOfferId)` — reuses `fetchErliProduct` (GET via `productPath`, validate+encode → hostile id fails closed); 404 → `OfferNotFoundOnMarketplaceException(externalOfferId, connectionId)` (capability contract); other transport errors propagate. Maps via `mapErliStatusToReadResult` (module fn).
+   - **Flip `createOffer` 202 → `'validating'`** — safe now that an `OfferStatusReader` exists (the core poll's `OFFER_POLL_NOT_SUPPORTED` path no longer fires). #984 docblock updated.
+3. **`infrastructure/scheduler/erli-scheduler-tasks.ts`** (new) — `buildErliSchedulerTasks()` → one `SchedulerTaskConfig` `erli-offer-status-sync` (jobType `marketplace.offer.statusSync`, cursor `erli.offerStatus.scanOffset`, hourly default, `enabledEnvVar OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED`). No `ConfigService` (Erli uses `createNestAdapterModule`); registered unconditionally, the env gate is re-checked by the scheduler at each tick.
+4. **`erli-plugin.ts` `register(host)`** — `host.schedulerTaskRegistry.register(task)` for each.
+
+## Tests
+`getOfferStatus` mapping (active/accepted/inactive/undefined → publicationStatus; rejected → inactive + ERLI_REJECTED validationError); 404 → `OfferNotFoundOnMarketplaceException`; non-404 propagates; hostile id fails closed; `isOfferStatusReader(adapter)` true; createOffer now returns `'validating'`; plugin registers the scheduler task. **113 erli tests green, type-check + lint clean.**
+
+## Risks
+- **#992-provisional**: Erli status field name + value set unconfirmed → isolated in `erli-product.types.ts`.
+- **Status mapping lossy-ish**: `accepted` vs `active` distinction depends on Erli exposing both; if not, both collapse to `active`/`activating` — adjust the one mapping fn. Confirm at #992.
+- Scheduler cron/page-size are hardcoded defaults (no ConfigService); tune via env if needed (only the enable gate is env-driven today).
+
+## Related
+- Wave-4 meta-plan · ADR-025 §1 · #816 (`offer_status_snapshots`) · #984 (createOffer) · #988 (`fetchErliProduct`)

--- a/docs/plans/implementation-plan-erli-stock-price-frozen.md
+++ b/docs/plans/implementation-plan-erli-stock-price-frozen.md
@@ -1,0 +1,115 @@
+# Implementation Plan — Erli stock & price sync + frozen-field ownership (#988)
+
+Branch: `988-erli-stock-price-frozen` (at #985 tip). Plugin-only change; no CORE change, no
+factory-signature change. Types come from the `@openlinker/core/listings` barrel; the frozen
+wire shape is isolated in `erli-product.types.ts` (provisional, #992).
+
+## Scope (locked)
+
+| Sub-deliverable | Status | Action |
+|---|---|---|
+| 1. Stock push (master inventory → offer quantity) | already works | Confirm + note; add unit test if gap. |
+| 2. Price-at-listing | already works (#984 `buildCreateBody`) | Confirm; **master-price propagation out of scope** (no core trigger exists). |
+| 3. Frozen-field exclusion before field-update PATCH | **THE deliverable** | Implement `fetchErliProduct` + frozen filtering in `updateOfferFields`. |
+| 4. Stock-restore-on-cancel | **DEFERRED / BLOCKED** | Document; needs #993 order ingestion. No dead code. |
+
+## 1. Stock push — verified, nothing to build
+
+Confirmed against real code:
+- Core `InventorySyncService.updateOfferQuantity` (`libs/core/src/inventory/application/services/inventory-sync.service.ts`)
+  resolves the `OfferManager` adapter per connection and calls `marketplace.updateOfferQuantity(item)`.
+- #984's `ErliOfferManagerAdapter.updateOfferQuantity` implements that port: `PATCH products/{id} { stock }`.
+
+The propagation chain (master inventory → core sync → port → Erli PATCH) is complete and
+already covered by the existing `updateOfferQuantity` spec cases. **No new code or test** — adding
+another would duplicate existing coverage.
+
+## 2. Price — listing done, propagation out of scope
+
+- `buildCreateBody` already maps `cmd.price` → `body.price` (verified). Price-at-listing ships.
+- There is **no master-price → offer propagation path in core today**. Grep confirms the only
+  `updateOfferFields` caller is `IntegrationsContentPublisherService` (description-only). Building a
+  master-price trigger would be a new CORE orchestrator — out of scope and explicitly excluded.
+  Documented here; no code.
+
+## 3. Frozen-field exclusion (the deliverable)
+
+ADR-025 §4b: "before any PATCH, fields marked `frozen` by seller-panel edits are excluded so OL
+never overwrites a manual edit … per-nested-field granularity."
+
+### 3a. Read type + wire shape (provisional #992) — `erli-product.types.ts`
+
+Add a read-side `ErliProductResource` type with a **per-field frozen marker**. Erli's exact shape is
+unconfirmed (#992 sandbox), so model the most plausible: a top-level `frozenFields: string[]`
+listing the names of frozen fields (e.g. `["price","name","description","stock"]`). This is the single
+reconciliation point; #989 (status) will reuse the same `fetchErliProduct` read path. Clearly marked
+PROVISIONAL.
+
+A small canonical mapping of OL patch-body keys → Erli frozen-field names lives in the adapter
+(`price`, `name`, `description`, `stock`). Per-nested-field granularity = we evaluate each patch key
+independently against the frozen set.
+
+### 3b. Shared read helper — `fetchErliProduct(externalId)`
+
+Private adapter method:
+```
+private async fetchErliProduct(externalId: string): Promise<ErliProductResource> {
+  const res = await this.httpClient.get<ErliProductResource>(this.productPath(externalId));
+  return res.data;
+}
+```
+Reuses the existing `productPath` (validate+encode) and `IErliHttpClient.get`. #989 reuses it for
+status (locked by the meta-plan).
+
+### 3c. `updateOfferFields` — drop frozen fields before PATCH
+
+1. Build the sparse patch from supplied fields (existing `buildPatchFromFields`).
+2. `fetchErliProduct(externalOfferId)` → read `frozenFields`.
+3. For each patch key, if its Erli frozen-name is in the frozen set, delete it from the body and
+   `logger.debug(...)` (no PII).
+4. If the body is now empty → skip the PATCH entirely (no-op; nothing to write).
+5. Otherwise PATCH the surviving keys.
+
+The GET is acceptable here: field-updates are low-frequency (operator/content edits), exactly where
+seller manual edits collide.
+
+### 3d. Quantity-path decision (justified)
+
+`updateOfferQuantity` is the **high-frequency inventory-sync** path. Applying frozen-exclusion there
+means a GET per quantity update — doubling API calls + latency on the hottest path. **Decision: do
+NOT pre-fetch on the quantity path in this wave.** Rationale:
+- Stock is the one field Erli **auto-mutates** (decrement on sale); a seller freezing *stock* is far
+  rarer than freezing price/title/description, and the cost (2× calls on every inventory tick) is
+  paid on every product on every sync.
+- The reconciliation-first posture (ADR-025 §1, #989) is the correct long-term guard for stock
+  drift, not a per-PATCH GET.
+This keeps inventory sync single-call. If a frozen-stock requirement materializes, it becomes an
+opt-in flag in a later wave — noted, not built (YAGNI).
+
+## 4. Stock-restore-on-cancel — DEFERRED (blocked on #993)
+
+ADR-025 §4a wants a pure-plugin compensation: on order cancellation, OL issues a stock-restore PATCH
+(Erli won't restore). That trigger is the Erli order-cancel signal, which only exists once Erli order
+ingestion (OrderSource / inbox poll = #993) lands. There is **no cancel signal to hook today**, so we
+build **no trigger and no dead code** (YAGNI). When #993 ships, its ingestion observes the
+`cancelled` event and calls the **already-existing** `updateOfferQuantity` to restore stock — #993
+only needs to wire the trigger. Documented in the adapter docblock + this plan.
+
+## Files changed
+
+- `libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts` — add `ErliProductResource` read type + `frozenFields` (provisional).
+- `libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts` — `fetchErliProduct`, frozen-filter in `updateOfferFields`, docblock update (scope: §4 deferred, quantity-path decision).
+- `libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts` — frozen-exclusion tests.
+
+## Tests (frozen-exclusion)
+
+- frozen field dropped (frozen `price` → not in PATCH; non-frozen `title` survives).
+- non-frozen field patched (no frozen markers → full PATCH, GET shape asserted).
+- all-supplied-frozen → no PATCH issued (no-op).
+- the GET read shape (`fetchErliProduct` issues `GET products/{id}`).
+- quantity path issues NO GET (single PATCH only) — guards the §3d decision.
+
+## Quality gate
+
+`pnpm --filter "@openlinker/integrations-erli^..." build` then
+`pnpm --filter @openlinker/integrations-erli` type-check + lint + test.

--- a/docs/plans/implementation-plan-erli-variant-grouping.md
+++ b/docs/plans/implementation-plan-erli-variant-grouping.md
@@ -1,0 +1,186 @@
+# Implementation Plan — Erli multi-variant grouping (`externalVariantGroup`) — #986
+
+> Story #986 in the #978 Erli offers half. Depends on #984 (offer-manager) /
+> #985 (category-param reuse) / #988 (frozen-field) — all already in this base.
+> Sequential stack: this lands purely in the `// #986:` seam of
+> `buildCreateBody` + additive wire types in `erli-product.types.ts`. It does
+> NOT touch the `#985` taxonomy logic, the `#988` create/PATCH/frozen logic, the
+> factory, the plugin, or any core contract.
+
+## 1. Goal
+
+Emit Erli's **explicit** variant grouping so a multi-variant OL product lists as
+**one** buyer-facing Erli listing instead of N unrelated ones (spec §5 story 3).
+Each variant is its own Erli product keyed by its own `externalId`
+(`resolveErliProductId(cmd)` = the OL variant id, already the case);
+`externalVariantGroup.id` (the parent/base OL product id) groups the siblings;
+distinguishing axes are declared via a per-variant `attributes[]` array.
+
+Unlike Allegro (Product-Catalog **auto**-grouping off GTIN + a distinguishing
+parameter — no explicit group field), Erli grouping is explicit via the group
+id. Single-variant / simple products pass through **ungrouped** — no
+`externalVariantGroup`, no grouping `attributes`.
+
+## 2. Key design question — resolved (data source for group id + attributes)
+
+**Where do the group id (parent product id) and the variant's distinguishing
+attributes come from, and does the factory change?**
+
+Evidence gathered from the live repo:
+
+| Source | Carries group id? | Carries variant attributes? |
+|---|---|---|
+| `CreateOfferCommand` (`@openlinker/core/listings`, `offer-create.types.ts`) | **No** — fields are `internalVariantId`, `connectionId`, `price`, `stock`, `publishImmediately`, `overrides` (`title`/`description`/`categoryId`/`productCardId`/`imageUrls`/`platformParams`), `idempotencyKey`, `variantBarcode`, `productCardId`. No parent-product id, no sibling/group info, no `attributes`. | **No** |
+| `ProductVariant` entity (`libs/core/src/products`) | `productId` (the natural group anchor) | `attributes: Record<string,string> \| null` (the distinguishing axes) |
+| `OfferBuilderService` | Fetches the variant + parent product internally (`variant.productId`, `productMaster.getProduct(...)`) but **does not thread either onto the command** | same |
+| #824 multi-variant expansion (`BulkListingSubmitService.expandVariantJobs`) | Fans out one job **per sibling variant** keyed by `variantId`; siblings drop the FE `productCardId` so each self-links by barcode — but the emitted `CreateOfferCommand` stays the flat shape (no group id, no attributes) | same |
+
+**Conclusion.** The grouping inputs exist in core (on `ProductVariant`) but are
+**not** on the neutral `CreateOfferCommand` and never reach any adapter today.
+Allegro doesn't need them (auto-grouping); Erli does (explicit). To populate the
+group, the adapter would need **one** of:
+
+1. a products-service / `IIntegrationsService` dependency → **new factory dep +
+   new core wiring** (the adapter would fetch the variant + siblings itself), or
+2. core threading `parentProductId` + `attributes` onto `CreateOfferCommand` via
+   `OfferBuilderService` (which already loads both) → **a cross-cutting change to
+   the neutral contract shared by Allegro/eBay/Woo/Shopify**.
+
+**Decision: do neither structural change now. Factory is UNCHANGED.** Both
+options are out of proportion to a single sequential-stack story and contradict
+the established posture (#984/#985/#988 deliberately avoided factory churn; the
+factory comment explicitly says #985/#986/#988 should "extend behaviour without
+churning this signature"). Instead:
+
+- **Wire shape + `buildCreateBody` seam land now** (the additive, isolated,
+  low-risk part the issue scopes): `ErliProductCreateBody` gains optional
+  `externalVariantGroup?: { id: string }` and a variant `attributes?: {
+  name: string; value: string }[]`; `buildCreateBody`'s `// #986:` seam reads
+  the grouping inputs from a forward-compatible, **adapter-neutral** location on
+  the command — `overrides.platformParams` (the documented opaque
+  adapter-interpreted bag) — under an Erli-scoped key, and emits
+  `externalVariantGroup` + `attributes` **only** when a group id is present AND
+  the product is genuinely multi-variant.
+- **Core plumbing that POPULATES that location is explicitly DEFERRED.** Until a
+  follow-up threads `parentProductId` + sibling-distinguishing `attributes`
+  through `OfferBuilderService`/the bulk expansion into
+  `overrides.platformParams.erliVariantGroup`, the key is absent → the adapter
+  emits **ungrouped** — which is exactly the required single/simple passthrough
+  behaviour, so the adapter is *correct today* and *grouped automatically* the
+  moment the data arrives. No dead code: the seam is exercised by unit tests
+  feeding the command shape directly, the same way #985 tests feed
+  `platformParams.parameters`.
+
+This is the smallest correct approach: zero core-contract change, zero factory
+change, wire shapes isolated to `erli-product.types.ts`, and a single documented
+deferral for the core data-population follow-up.
+
+### 2a. The Erli-scoped `platformParams` contract (this story's micro-contract)
+
+`overrides.platformParams.erliVariantGroup` (read defensively, narrowed — no
+`any`):
+
+```ts
+// Provisional, read-only on the command; populated by a deferred core follow-up.
+{ groupId: string; attributes?: { name: string; value: string }[] }
+```
+
+- `groupId` — the parent/base OL product id; becomes `externalVariantGroup.id`.
+  Present ⇒ the product is multi-variant (the populator sets it only then).
+  Absent / empty ⇒ ungrouped.
+- `attributes` — the variant's distinguishing axes (`{name,value}`), already
+  flattened from `ProductVariant.attributes` (`Record<string,string>`) by the
+  populator. Emitted verbatim onto the create body. Absent ⇒ no `attributes`.
+
+Reading from `platformParams` mirrors the #985 precedent
+(`platformParams.parameters`/`.productParameters`) — Erli reads only the keys it
+knows; the neutral command stays platform-neutral; no new top-level command
+field is invented for one platform.
+
+## 3. Changes
+
+### 3.1 `erli-product.types.ts` (additive wire shapes, PROVISIONAL #992)
+
+- New interface `ErliVariantGroupRef { id: string }`.
+- New interface `ErliVariantAttribute { name: string; value: string }`.
+- On `ErliProductCreateBody`: add `externalVariantGroup?: ErliVariantGroupRef`
+  and `attributes?: ErliVariantAttribute[]` (both optional; omitted ⇒ ungrouped).
+- Update the file header: replace "Variant grouping (#986) remains absent." with
+  a one-line note that #986 adds the provisional group/attribute shapes (still
+  PROVISIONAL until the #992 sandbox spike — single reconciliation point).
+- `ErliProductPatchBody = ErliProductCreateBody` is unchanged structurally;
+  grouping is create-only (the adapter never emits group/attributes on PATCH —
+  `buildPatchFromFields` is untouched), matching the #985 create-only posture.
+
+### 3.2 `erli-offer-manager.adapter.ts` — the `// #986:` seam
+
+- Replace the `// #986: externalVariantGroup is assembled here.` placeholder with
+  a call that reads `cmd.overrides?.platformParams?.erliVariantGroup`, narrows it
+  with a local type-guard (`isErliVariantGroupInput`), and when a non-empty
+  `groupId` is present sets `body.externalVariantGroup = { id: groupId }` and,
+  if `attributes` is a non-empty well-formed `{name,value}[]`, sets
+  `body.attributes`.
+- A free function `buildVariantGroup(cmd)` + guard, co-located with the existing
+  `buildExternalCategories` / `buildExternalAttributes` free functions and their
+  `isAllegroParameterShape` guard, for symmetry and testability. No `any` — narrow
+  `unknown` via the guard exactly like `isAllegroParameterShape`.
+- `resolveErliProductId(cmd)` is REUSED unchanged for the per-variant external id
+  (already `cmd.internalVariantId`). No path/security change — grouping touches
+  only the body.
+- Update the adapter header's "Out of scope … variant grouping #986" line to
+  note #986 now emits create-time grouping from `platformParams.erliVariantGroup`
+  (data population deferred to core follow-up).
+
+### 3.3 No changes
+
+Factory, plugin, module, HTTP client, validators, tester, retry/auth
+classifiers, core contracts — all untouched.
+
+## 4. Tests (`erli-offer-manager.adapter.spec.ts`, new `variant grouping (#986)` describe)
+
+Feed the command shape directly (mirrors the #985 `platformParams` tests):
+
+1. **Multi-variant → group + attributes present**: `platformParams.erliVariantGroup
+   = { groupId: 'ol_product_…', attributes: [{name:'Color',value:'Red'}] }` ⇒ body
+   has `externalVariantGroup: { id: 'ol_product_…' }` and `attributes:
+   [{name:'Color',value:'Red'}]`.
+2. **Single/simple → ungrouped**: no `erliVariantGroup` key (or empty `groupId`)
+   ⇒ body has neither `externalVariantGroup` nor grouping `attributes`.
+3. **Sibling variants share the same group id**: two commands with different
+   `internalVariantId` but the same `groupId` ⇒ both bodies carry the same
+   `externalVariantGroup.id` (and each still POSTs to its own variant path).
+4. **Attributes mapping / hygiene**: `groupId` present but `attributes` absent ⇒
+   `externalVariantGroup` set, no `attributes` key; malformed attribute entries
+   (missing `name`/`value`, non-string) are dropped; empty `attributes` ⇒ key
+   omitted.
+5. **Grouping is create-only**: a field-update / quantity-update PATCH never
+   carries `externalVariantGroup` or grouping `attributes` (regression guard on
+   the create-only posture).
+
+Update the spec header issue list to `(#984, #985, #986, #988)`.
+
+## 5. Risks / deferrals
+
+- **R1 (primary, documented above): core does not yet populate
+  `platformParams.erliVariantGroup`.** Consequence: Erli offers list ungrouped
+  until the follow-up lands — identical to today's behaviour, no regression. The
+  follow-up (thread `parentProductId` + flattened sibling-distinguishing
+  `attributes` through `OfferBuilderService` / the #824 expansion) is the
+  natural home because both inputs are already loaded there; it is intentionally
+  **out of this story's scope** (it changes the core contract + the bulk path,
+  which deserves its own issue). Flagged in the leftover-concerns of the report.
+- **R2 (#992): wire shapes provisional.** `externalVariantGroup`/`attributes`
+  field names + the group-id semantics (parent id vs a dedicated group key) are
+  unconfirmed until the sandbox spike. Contained to `erli-product.types.ts`
+  (single reconciliation point) per the existing PROVISIONAL convention.
+- **R3: attribute axis selection.** Emitting *all* of a variant's `attributes`
+  vs only the axes that actually distinguish siblings is a populator concern
+  (core), not the adapter's — the adapter emits what it's given. Noted so the
+  follow-up decides the distinguishing-axis policy.
+
+## 6. Gate
+
+`pnpm --filter "@openlinker/integrations-erli^..." build`, then type-check +
+lint + test on `@openlinker/integrations-erli`. No `any`; types from the
+`@openlinker/core/listings` barrel; wire shapes isolated in
+`erli-product.types.ts`.

--- a/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
+++ b/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
@@ -43,18 +43,21 @@ function makeRegisterHost(): {
   testerRegistry: { register: jest.Mock };
   retryClassifierRegistry: { register: jest.Mock };
   authFailureClassifierRegistry: { register: jest.Mock };
+  schedulerTaskRegistry: { register: jest.Mock };
 } {
   const configRegistry = { register: jest.fn() };
   const credentialsRegistry = { register: jest.fn() };
   const testerRegistry = { register: jest.fn() };
   const retryClassifierRegistry = { register: jest.fn() };
   const authFailureClassifierRegistry = { register: jest.fn() };
+  const schedulerTaskRegistry = { register: jest.fn() };
   const hostStub = {
     connectionConfigShapeValidatorRegistry: configRegistry,
     connectionCredentialsShapeValidatorRegistry: credentialsRegistry,
     connectionTesterRegistry: testerRegistry,
     retryClassifierRegistry,
     authFailureClassifierRegistry,
+    schedulerTaskRegistry,
   } as unknown as HostServices;
   return {
     host: hostStub,
@@ -63,6 +66,7 @@ function makeRegisterHost(): {
     testerRegistry,
     retryClassifierRegistry,
     authFailureClassifierRegistry,
+    schedulerTaskRegistry,
   };
 }
 
@@ -139,6 +143,20 @@ describe('createErliPlugin', () => {
       expect(authFailureClassifierRegistry.register).toHaveBeenCalledWith(
         'erli.shopapi.v1',
         expect.objectContaining({ isCredentialRejected: expect.any(Function) }),
+      );
+    });
+
+    it('should register the erli-offer-status-sync scheduler task (#989)', () => {
+      const { host, schedulerTaskRegistry } = makeRegisterHost();
+      createErliPlugin().register?.(host);
+
+      expect(schedulerTaskRegistry.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: 'erli-offer-status-sync',
+          platformType: 'erli',
+          jobType: 'marketplace.offer.statusSync',
+          enabledEnvVar: 'OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED',
+        }),
       );
     });
   });

--- a/libs/integrations/erli/src/application/erli-adapter.factory.ts
+++ b/libs/integrations/erli/src/application/erli-adapter.factory.ts
@@ -14,6 +14,7 @@
  */
 import type { CredentialsResolverPort } from '@openlinker/core/integrations';
 import type { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import type { CachePort } from '@openlinker/shared';
 import { ErliConfigException } from '../domain/exceptions/erli-config.exception';
 import { isAllowedErliBaseUrl } from '../domain/policies/erli-base-url.policy';
 import {
@@ -41,11 +42,19 @@ export class ErliAdapterFactory implements IErliAdapterFactory {
    * adapter today but kept so #985/#986/#988 extend behaviour without churning
    * this signature or the plugin's dispatch call site (Allegro pays the same
    * unused-dep cost deliberately).
+   *
+   * `cache` is the host-provided distributed cache (`host.cache`); the offer
+   * adapter uses it for the #1066 frozen-stock flag. Optional — when absent the
+   * adapter fails open (pushes stock) exactly as before. Threaded through this
+   * method (rather than the constructor as Allegro does) because Erli's factory
+   * is constructed argument-less inside `createCapabilityAdapter` — an Erli-local
+   * choice; the cache still arrives from `host.cache` either way.
    */
   async createAdapters(
     connection: Connection,
     _identifierMapping: IdentifierMappingPort,
     credentialsResolver: CredentialsResolverPort,
+    cache?: CachePort,
   ): Promise<ErliAdapters> {
     const httpClient = await this.createHttpClient(connection, credentialsResolver);
     const config = (connection.config ?? {}) as ErliConnectionConfig;
@@ -55,6 +64,7 @@ export class ErliAdapterFactory implements IErliAdapterFactory {
         ERLI_ADAPTER_KEY,
         httpClient,
         config.defaultDispatchTime,
+        cache,
       ),
     };
   }

--- a/libs/integrations/erli/src/erli-plugin.ts
+++ b/libs/integrations/erli/src/erli-plugin.ts
@@ -96,6 +96,9 @@ export function createErliPlugin(): AdapterPlugin {
         connection,
         host.identifierMapping,
         host.credentialsResolver,
+        // #1066: distributed frozen-stock flag. Optional on HostServices — when
+        // absent the offer adapter fails open (pushes stock = pre-#1066 behaviour).
+        host.cache,
       );
       return dispatchCapability<T>(
         capability,

--- a/libs/integrations/erli/src/erli-plugin.ts
+++ b/libs/integrations/erli/src/erli-plugin.ts
@@ -31,6 +31,7 @@ import { ErliConnectionConfigShapeValidatorAdapter } from './infrastructure/adap
 import { ErliConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/erli-connection-credentials-shape-validator.adapter';
 import { ErliConnectionTesterAdapter } from './infrastructure/adapters/erli-connection-tester.adapter';
 import { ErliRetryClassifierAdapter } from './infrastructure/adapters/erli-retry-classifier.adapter';
+import { buildErliSchedulerTasks } from './infrastructure/scheduler/erli-scheduler-tasks';
 
 /** Human-readable plugin identifier surfaced in dispatch errors (#573). */
 const ERLI_BRAND = 'Erli';
@@ -76,6 +77,13 @@ export function createErliPlugin(): AdapterPlugin {
         ERLI_ADAPTER_KEY,
         new ErliAuthFailureClassifierAdapter(),
       );
+      // Offer-status reconciliation scheduler task (#989). Registered
+      // unconditionally; the OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED env gate
+      // is re-checked by the scheduler at each tick (no ConfigService dependency —
+      // Erli is wired via createNestAdapterModule).
+      for (const task of buildErliSchedulerTasks()) {
+        host.schedulerTaskRegistry.register(task);
+      }
     },
 
     async createCapabilityAdapter<T>(

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -1,18 +1,20 @@
 /**
- * Erli Offer Manager Adapter — unit tests (#984, #985, #986, #988)
+ * Erli Offer Manager Adapter — unit tests (#984, #985, #986, #988, #989)
  *
  * Mocks `IErliHttpClient` to verify: seller-keyed path build (validate+encode),
- * 202→'draft' create mapping, sparse PATCH for field/quantity updates, the
- * safe 4xx→OfferCreateRejectedException mapping (no responseBody leak), auth
- * propagation, hostile-id rejection, imageUrl hygiene, the #985 Allegro
- * category/parameter reuse (source:"allegro" externalCategories/Attributes),
- * and the #988 frozen-field exclusion (read-before-PATCH drops frozen fields;
- * all-frozen → no-op; hot quantity path stays single-call).
+ * 202→'validating' create mapping (#989), sparse PATCH for field/quantity
+ * updates, the safe 4xx→OfferCreateRejectedException mapping (no responseBody
+ * leak), auth propagation, hostile-id rejection, imageUrl hygiene, the #985
+ * Allegro category/parameter reuse, the #988 frozen-field exclusion, and the
+ * #989 OfferStatusReader.getOfferStatus mapping (Erli status → neutral
+ * OfferPublicationStatus; 404 → OfferNotFoundOnMarketplaceException).
  *
  * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
  */
 import {
+  isOfferStatusReader,
   OfferCreateRejectedException,
+  OfferNotFoundOnMarketplaceException,
   type CreateOfferCommand,
   type UpdateOfferFieldsCommand,
   type UpdateOfferQuantityCommand,
@@ -69,14 +71,14 @@ describe('ErliOfferManagerAdapter', () => {
   });
 
   describe('createOffer', () => {
-    it("should submit to the seller-keyed product path and return status 'draft' on 202", async () => {
+    it("should submit to the seller-keyed product path and return status 'validating' on 202", async () => {
       const result = await adapter.createOffer(createCmd());
 
       expect(httpClient.post).toHaveBeenCalledTimes(1);
       const [path, , options] = httpClient.post.mock.calls[0];
       expect(path).toBe(`products/${VALID_ID}`);
       expect(options).toEqual({ idempotent: true });
-      expect(result).toEqual({ externalOfferId: VALID_ID, status: 'draft' });
+      expect(result).toEqual({ externalOfferId: VALID_ID, status: 'validating' });
     });
 
     it('should map the basic command fields into the create body', async () => {
@@ -597,6 +599,60 @@ describe('ErliOfferManagerAdapter', () => {
       await expect(
         adapter.updateOfferQuantity({ offerId: 'evil/../x', quantity: 1 }),
       ).rejects.toBeInstanceOf(ErliConfigException);
+    });
+  });
+
+  describe('getOfferStatus (#989)', () => {
+    it('should be detectable as an OfferStatusReader', () => {
+      expect(isOfferStatusReader(adapter)).toBe(true);
+    });
+
+    it.each([
+      ['active', 'active'],
+      ['accepted', 'activating'],
+      ['inactive', 'inactive'],
+      [undefined, 'inactive'],
+    ])('should map Erli status %s → publicationStatus %s', async (erliStatus, expected) => {
+      httpClient.get.mockResolvedValueOnce({ status: 200, data: { status: erliStatus } });
+
+      const result = await adapter.getOfferStatus(VALID_ID);
+
+      expect(result.publicationStatus).toBe(expected);
+      expect(result.validationErrors).toEqual([]);
+      expect(httpClient.get).toHaveBeenCalledWith(`products/${VALID_ID}`);
+    });
+
+    it('should map rejected → inactive carrying the reason in validationErrors', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        status: 200,
+        data: { status: 'rejected', statusReason: 'EAN already used' },
+      });
+
+      const result = await adapter.getOfferStatus(VALID_ID);
+
+      expect(result.publicationStatus).toBe('inactive');
+      expect(result.validationErrors).toEqual([
+        { code: 'ERLI_REJECTED', message: 'EAN already used' },
+      ]);
+    });
+
+    it('should throw OfferNotFoundOnMarketplaceException on a 404', async () => {
+      httpClient.get.mockRejectedValueOnce(new ErliApiException('not found', 404));
+
+      await expect(adapter.getOfferStatus(VALID_ID)).rejects.toBeInstanceOf(
+        OfferNotFoundOnMarketplaceException,
+      );
+    });
+
+    it('should propagate non-404 transport errors', async () => {
+      httpClient.get.mockRejectedValueOnce(new ErliApiException('server error', 500));
+
+      await expect(adapter.getOfferStatus(VALID_ID)).rejects.toBeInstanceOf(ErliApiException);
+    });
+
+    it('should reject a hostile externalOfferId before any GET', async () => {
+      await expect(adapter.getOfferStatus('evil/../x')).rejects.toBeInstanceOf(ErliConfigException);
+      expect(httpClient.get).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -1,11 +1,13 @@
 /**
- * Erli Offer Manager Adapter — unit tests (#984, #985)
+ * Erli Offer Manager Adapter — unit tests (#984, #985, #988)
  *
  * Mocks `IErliHttpClient` to verify: seller-keyed path build (validate+encode),
  * 202→'draft' create mapping, sparse PATCH for field/quantity updates, the
  * safe 4xx→OfferCreateRejectedException mapping (no responseBody leak), auth
- * propagation, hostile-id rejection, imageUrl hygiene, and the #985 Allegro
- * category/parameter reuse (source:"allegro" externalCategories/Attributes).
+ * propagation, hostile-id rejection, imageUrl hygiene, the #985 Allegro
+ * category/parameter reuse (source:"allegro" externalCategories/Attributes),
+ * and the #988 frozen-field exclusion (read-before-PATCH drops frozen fields;
+ * all-frozen → no-op; hot quantity path stays single-call).
  *
  * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
  */
@@ -54,7 +56,8 @@ describe('ErliOfferManagerAdapter', () => {
 
   beforeEach(() => {
     httpClient = {
-      get: jest.fn(),
+      // Default read: no frozen fields, so field-updates PATCH everything supplied.
+      get: jest.fn().mockResolvedValue({ status: 200, data: { frozenFields: [] } }),
       post: jest.fn().mockResolvedValue({ status: 202, data: undefined }),
       patch: jest.fn().mockResolvedValue({ status: 202, data: undefined }),
     };
@@ -360,6 +363,54 @@ describe('ErliOfferManagerAdapter', () => {
         adapter.updateOfferFields({ externalOfferId: 'evil/../x', fields: { title: 'x' } }),
       ).rejects.toBeInstanceOf(ErliConfigException);
     });
+
+    describe('frozen-field exclusion (#988)', () => {
+      it('should read the live product via GET before patching', async () => {
+        await adapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'New' } });
+
+        expect(httpClient.get).toHaveBeenCalledWith(`products/${VALID_ID}`);
+      });
+
+      it('should drop a supplied field that is frozen and patch the rest', async () => {
+        httpClient.get.mockResolvedValue({ status: 200, data: { frozenFields: ['price'] } });
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'Keep me', price: { amount: '79.00', currency: 'PLN' } },
+        });
+
+        // price frozen → dropped; name survives.
+        expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, { name: 'Keep me' });
+      });
+
+      it('should patch every supplied field when none are frozen', async () => {
+        httpClient.get.mockResolvedValue({ status: 200, data: { frozenFields: [] } });
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'T', price: { amount: '5.00', currency: 'PLN' } },
+        });
+
+        expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
+          name: 'T',
+          price: { amount: 5, currency: 'PLN' },
+        });
+      });
+
+      it('should issue NO patch when every supplied field is frozen', async () => {
+        httpClient.get.mockResolvedValue({
+          status: 200,
+          data: { frozenFields: ['name', 'price'] },
+        });
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'T', price: { amount: '5.00', currency: 'PLN' } },
+        });
+
+        expect(httpClient.patch).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('updateOfferQuantity', () => {
@@ -368,6 +419,13 @@ describe('ErliOfferManagerAdapter', () => {
       await adapter.updateOfferQuantity(cmd);
 
       expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, { stock: 7 });
+    });
+
+    it('should NOT pre-fetch the product (hot inventory path stays single-call, #988 §3d)', async () => {
+      await adapter.updateOfferQuantity({ offerId: VALID_ID, quantity: 7 });
+
+      expect(httpClient.get).not.toHaveBeenCalled();
+      expect(httpClient.patch).toHaveBeenCalledTimes(1);
     });
 
     it('should reject a hostile offerId', async () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -26,7 +26,10 @@ import { ErliConfigException } from '../../../domain/exceptions/erli-config.exce
 import { ErliNetworkException } from '../../../domain/exceptions/erli-network.exception';
 import { ERLI_ADAPTER_KEY } from '../../../erli.constants';
 import type { IErliHttpClient } from '../../http/erli-http-client.interface';
-import { ErliOfferManagerAdapter } from '../erli-offer-manager.adapter';
+import {
+  ErliOfferManagerAdapter,
+  ERLI_FROZEN_STOCK_CACHE_TTL_SEC,
+} from '../erli-offer-manager.adapter';
 
 const VALID_ID = `ol_variant_${'a'.repeat(32)}`;
 
@@ -664,8 +667,8 @@ describe('ErliOfferManagerAdapter', () => {
     let cache: jest.Mocked<CachePort>;
     let cachedAdapter: ErliOfferManagerAdapter;
     const EXPECTED_KEY = `erli:frozen-stock:conn-1:${VALID_ID}`;
-    // 26h — must match ERLI_FROZEN_STOCK_CACHE_TTL_SEC in the adapter.
-    const EXPECTED_TTL = 26 * 60 * 60;
+    // Imported from the adapter — single source of truth, no hand-synced copy.
+    const EXPECTED_TTL = ERLI_FROZEN_STOCK_CACHE_TTL_SEC;
 
     beforeEach(() => {
       cache = {

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Erli Offer Manager Adapter — unit tests (#984, #985, #988)
+ * Erli Offer Manager Adapter — unit tests (#984, #985, #986, #988)
  *
  * Mocks `IErliHttpClient` to verify: seller-keyed path build (validate+encode),
  * 202→'draft' create mapping, sparse PATCH for field/quantity updates, the
@@ -313,6 +313,114 @@ describe('ErliOfferManagerAdapter', () => {
 
         const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
         expect(body).not.toHaveProperty('externalAttributes');
+      });
+    });
+
+    describe('variant grouping (#986)', () => {
+      const GROUP_ID = `ol_product_${'b'.repeat(32)}`;
+
+      it('should emit externalVariantGroup + attributes for a multi-variant product', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              platformParams: {
+                erliVariantGroup: {
+                  groupId: GROUP_ID,
+                  attributes: [{ name: 'Color', value: 'Red' }],
+                },
+              },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as {
+          externalVariantGroup?: unknown;
+          attributes?: unknown;
+        };
+        expect(body.externalVariantGroup).toEqual({ id: GROUP_ID });
+        expect(body.attributes).toEqual([{ name: 'Color', value: 'Red' }]);
+      });
+
+      it('should list ungrouped (no externalVariantGroup/attributes) for a single/simple product', async () => {
+        await adapter.createOffer(createCmd());
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).not.toHaveProperty('externalVariantGroup');
+        expect(body).not.toHaveProperty('attributes');
+      });
+
+      it('should ignore an empty groupId (treats as ungrouped)', async () => {
+        await adapter.createOffer(
+          createCmd({ overrides: { platformParams: { erliVariantGroup: { groupId: '' } } } }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).not.toHaveProperty('externalVariantGroup');
+        expect(body).not.toHaveProperty('attributes');
+      });
+
+      it('should give sibling variants the same group id while each posts to its own path', async () => {
+        const variantA = `ol_variant_${'a'.repeat(32)}`;
+        const variantB = `ol_variant_${'c'.repeat(32)}`;
+        const platformParams = { erliVariantGroup: { groupId: GROUP_ID } };
+
+        await adapter.createOffer(
+          createCmd({ internalVariantId: variantA, overrides: { platformParams } }),
+        );
+        await adapter.createOffer(
+          createCmd({ internalVariantId: variantB, overrides: { platformParams } }),
+        );
+
+        const [pathA, bodyA] = httpClient.post.mock.calls[0] as [string, { externalVariantGroup?: unknown }];
+        const [pathB, bodyB] = httpClient.post.mock.calls[1] as [string, { externalVariantGroup?: unknown }];
+        expect(pathA).toBe(`products/${variantA}`);
+        expect(pathB).toBe(`products/${variantB}`);
+        expect(bodyA.externalVariantGroup).toEqual({ id: GROUP_ID });
+        expect(bodyB.externalVariantGroup).toEqual({ id: GROUP_ID });
+      });
+
+      it('should emit externalVariantGroup with no attributes key when attributes are absent', async () => {
+        await adapter.createOffer(
+          createCmd({ overrides: { platformParams: { erliVariantGroup: { groupId: GROUP_ID } } } }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body.externalVariantGroup).toEqual({ id: GROUP_ID });
+        expect(body).not.toHaveProperty('attributes');
+      });
+
+      it('should drop malformed attribute entries and omit the key when none survive', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              platformParams: {
+                erliVariantGroup: {
+                  groupId: GROUP_ID,
+                  attributes: [
+                    { name: 'Color', value: 'Red' },
+                    { name: 'Size' }, // missing value → dropped
+                    { value: 'X' }, // missing name → dropped
+                    { name: 5, value: 'Y' }, // non-string name → dropped
+                  ],
+                },
+              },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { attributes?: unknown };
+        expect(body.attributes).toEqual([{ name: 'Color', value: 'Red' }]);
+      });
+
+      it('should never emit grouping on a field-update or quantity PATCH (create-only)', async () => {
+        await adapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'T' } });
+        await adapter.updateOfferQuantity({ offerId: VALID_ID, quantity: 3 });
+
+        for (const call of httpClient.patch.mock.calls) {
+          const body = call[1] as Record<string, unknown>;
+          expect(body).not.toHaveProperty('externalVariantGroup');
+          expect(body).not.toHaveProperty('attributes');
+        }
       });
     });
   });

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -323,6 +323,7 @@ describe('ErliOfferManagerAdapter', () => {
         await adapter.createOffer(
           createCmd({
             overrides: {
+              categoryId: '18654',
               platformParams: {
                 erliVariantGroup: {
                   groupId: GROUP_ID,
@@ -351,7 +352,7 @@ describe('ErliOfferManagerAdapter', () => {
 
       it('should ignore an empty groupId (treats as ungrouped)', async () => {
         await adapter.createOffer(
-          createCmd({ overrides: { platformParams: { erliVariantGroup: { groupId: '' } } } }),
+          createCmd({ overrides: { categoryId: '18654', platformParams: { erliVariantGroup: { groupId: '' } } } }),
         );
 
         const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
@@ -365,10 +366,10 @@ describe('ErliOfferManagerAdapter', () => {
         const platformParams = { erliVariantGroup: { groupId: GROUP_ID } };
 
         await adapter.createOffer(
-          createCmd({ internalVariantId: variantA, overrides: { platformParams } }),
+          createCmd({ internalVariantId: variantA, overrides: { categoryId: '18654', platformParams } }),
         );
         await adapter.createOffer(
-          createCmd({ internalVariantId: variantB, overrides: { platformParams } }),
+          createCmd({ internalVariantId: variantB, overrides: { categoryId: '18654', platformParams } }),
         );
 
         const [pathA, bodyA] = httpClient.post.mock.calls[0] as [string, { externalVariantGroup?: unknown }];
@@ -381,7 +382,7 @@ describe('ErliOfferManagerAdapter', () => {
 
       it('should emit externalVariantGroup with no attributes key when attributes are absent', async () => {
         await adapter.createOffer(
-          createCmd({ overrides: { platformParams: { erliVariantGroup: { groupId: GROUP_ID } } } }),
+          createCmd({ overrides: { categoryId: '18654', platformParams: { erliVariantGroup: { groupId: GROUP_ID } } } }),
         );
 
         const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
@@ -393,6 +394,7 @@ describe('ErliOfferManagerAdapter', () => {
         await adapter.createOffer(
           createCmd({
             overrides: {
+              categoryId: '18654',
               platformParams: {
                 erliVariantGroup: {
                   groupId: GROUP_ID,

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -426,6 +426,30 @@ describe('ErliOfferManagerAdapter', () => {
 
         expect(httpClient.patch).not.toHaveBeenCalled();
       });
+
+      it('should fail open and PATCH the full body when the GET 404s in the cache-lag window', async () => {
+        // ADR-025: a just-created offer GET-404s during Erli's ~20-min cache lag (#1061).
+        httpClient.get.mockRejectedValue(new ErliApiException('not found', 404));
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'T', price: { amount: '5.00', currency: 'PLN' } },
+        });
+
+        expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
+          name: 'T',
+          price: { amount: 5, currency: 'PLN' },
+        });
+      });
+
+      it('should re-throw a non-404 GET error rather than failing open', async () => {
+        httpClient.get.mockRejectedValue(new ErliApiException('server error', 500));
+
+        await expect(
+          adapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'T' } }),
+        ).rejects.toBeInstanceOf(ErliApiException);
+        expect(httpClient.patch).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -228,10 +228,7 @@ describe('ErliOfferManagerAdapter', () => {
       it('should map a dictionary parameter (valuesIds → type:dictionary)', async () => {
         await adapter.createOffer(
           createCmd({
-            overrides: {
-              categoryId: '18654',
-              platformParams: { parameters: [{ id: '11323', valuesIds: ['11323_1'] }] },
-            },
+            parameters: [{ id: '11323', valuesIds: ['11323_1'], section: 'offer' }],
           }),
         );
 
@@ -244,10 +241,7 @@ describe('ErliOfferManagerAdapter', () => {
       it('should map a free-text parameter (values → type:string)', async () => {
         await adapter.createOffer(
           createCmd({
-            overrides: {
-              categoryId: '18654',
-              platformParams: { parameters: [{ id: '224017', values: ['Acme'] }] },
-            },
+            parameters: [{ id: '224017', values: ['Acme'], section: 'product' }],
           }),
         );
 
@@ -260,13 +254,10 @@ describe('ErliOfferManagerAdapter', () => {
       it('should merge offer-section and product-section params into one flat list', async () => {
         await adapter.createOffer(
           createCmd({
-            overrides: {
-              categoryId: '18654',
-              platformParams: {
-                parameters: [{ id: '11323', valuesIds: ['11323_1'] }],
-                productParameters: [{ id: '224017', values: ['Acme'] }],
-              },
-            },
+            parameters: [
+              { id: '11323', valuesIds: ['11323_1'], section: 'offer' },
+              { id: '224017', values: ['Acme'], section: 'product' },
+            ],
           }),
         );
 
@@ -293,21 +284,13 @@ describe('ErliOfferManagerAdapter', () => {
         expect(body).not.toHaveProperty('externalAttributes');
       });
 
-      it('should drop malformed parameter entries (missing/empty id)', async () => {
+      it('should drop empty-id parameter entries', async () => {
         await adapter.createOffer(
           createCmd({
-            overrides: {
-              categoryId: '18654',
-              platformParams: {
-                parameters: [
-                  { id: '', values: ['x'] },
-                  { values: ['no id'] },
-                  null,
-                  'garbage',
-                  { id: '11323', valuesIds: ['11323_1'] },
-                ],
-              },
-            },
+            parameters: [
+              { id: '', values: ['x'], section: 'offer' },
+              { id: '11323', valuesIds: ['11323_1'], section: 'offer' },
+            ],
           }),
         );
 
@@ -320,12 +303,7 @@ describe('ErliOfferManagerAdapter', () => {
       it('should drop a rangeValue-only parameter (no values/valuesIds) in v1', async () => {
         await adapter.createOffer(
           createCmd({
-            overrides: {
-              categoryId: '18654',
-              platformParams: {
-                parameters: [{ id: '12345', rangeValue: { from: '1', to: '10' } }],
-              },
-            },
+            parameters: [{ id: '12345', rangeValue: { from: '1', to: '10' }, section: 'offer' }],
           }),
         );
 

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -2,7 +2,7 @@
  * Erli Offer Manager Adapter — unit tests (#984, #985, #986, #988, #989)
  *
  * Mocks `IErliHttpClient` to verify: seller-keyed path build (validate+encode),
- * 202→'validating' create mapping (#989), sparse PATCH for field/quantity
+ * 202→'draft' create mapping (#989/#1063), sparse PATCH for field/quantity
  * updates, the safe 4xx→OfferCreateRejectedException mapping (no responseBody
  * leak), auth propagation, hostile-id rejection, imageUrl hygiene, the #985
  * Allegro category/parameter reuse, the #988 frozen-field exclusion, and the
@@ -71,14 +71,17 @@ describe('ErliOfferManagerAdapter', () => {
   });
 
   describe('createOffer', () => {
-    it("should submit to the seller-keyed product path and return status 'validating' on 202", async () => {
+    it("should submit to the seller-keyed product path and return status 'draft' on 202", async () => {
       const result = await adapter.createOffer(createCmd());
 
       expect(httpClient.post).toHaveBeenCalledTimes(1);
       const [path, , options] = httpClient.post.mock.calls[0];
       expect(path).toBe(`products/${VALID_ID}`);
       expect(options).toEqual({ idempotent: true });
-      expect(result).toEqual({ externalOfferId: VALID_ID, status: 'validating' });
+      // 'draft' (not 'validating'): avoids the Allegro-tuned creation poll that
+      // would falsely fail valid offers during Erli's ~20-min cache lag (#1063);
+      // the steady-state erli-offer-status-sync reconciles publication instead.
+      expect(result).toEqual({ externalOfferId: VALID_ID, status: 'draft' });
     });
 
     it('should map the basic command fields into the create body', async () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -383,6 +383,22 @@ describe('ErliOfferManagerAdapter', () => {
         expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, { name: 'Keep me' });
       });
 
+      it('should patch the full body when the GET returns an empty body (no frozen info)', async () => {
+        // The client yields `data: undefined` for a 204 / empty-body 2xx; the read
+        // must degrade to "nothing frozen" rather than throwing on current.frozenFields (#1061).
+        httpClient.get.mockResolvedValue({ status: 200, data: undefined });
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'T', price: { amount: '5.00', currency: 'PLN' } },
+        });
+
+        expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
+          name: 'T',
+          price: { amount: 5, currency: 'PLN' },
+        });
+      });
+
       it('should patch every supplied field when none are frozen', async () => {
         httpClient.get.mockResolvedValue({ status: 200, data: { frozenFields: [] } });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -676,7 +676,7 @@ describe('ErliOfferManagerAdapter', () => {
         set: jest.fn().mockResolvedValue(undefined),
         delete: jest.fn().mockResolvedValue(undefined),
       };
-      cachedAdapter = new ErliOfferManagerAdapter('conn-1', ERLI_ADAPTER_KEY, httpClient, cache);
+      cachedAdapter = new ErliOfferManagerAdapter('conn-1', ERLI_ADAPTER_KEY, httpClient, undefined, cache);
     });
 
     it('should skip the stock PATCH after reconciliation observed a frozen stock (write→read round-trip)', async () => {
@@ -733,8 +733,8 @@ describe('ErliOfferManagerAdapter', () => {
     });
 
     it('should produce disjoint keys per connection for the same variant id', async () => {
-      const adapterA = new ErliOfferManagerAdapter('conn-A', ERLI_ADAPTER_KEY, httpClient, cache);
-      const adapterB = new ErliOfferManagerAdapter('conn-B', ERLI_ADAPTER_KEY, httpClient, cache);
+      const adapterA = new ErliOfferManagerAdapter('conn-A', ERLI_ADAPTER_KEY, httpClient, undefined, cache);
+      const adapterB = new ErliOfferManagerAdapter('conn-B', ERLI_ADAPTER_KEY, httpClient, undefined, cache);
 
       await adapterA.updateOfferQuantity({ offerId: VALID_ID, quantity: 1 });
       await adapterB.updateOfferQuantity({ offerId: VALID_ID, quantity: 1 });

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -20,6 +20,7 @@ import {
 import { ErliApiException } from '../../../domain/exceptions/erli-api.exception';
 import { ErliAuthenticationException } from '../../../domain/exceptions/erli-authentication.exception';
 import { ErliConfigException } from '../../../domain/exceptions/erli-config.exception';
+import { ErliNetworkException } from '../../../domain/exceptions/erli-network.exception';
 import { ERLI_ADAPTER_KEY } from '../../../erli.constants';
 import type { IErliHttpClient } from '../../http/erli-http-client.interface';
 import { ErliOfferManagerAdapter } from '../erli-offer-manager.adapter';
@@ -395,7 +396,7 @@ describe('ErliOfferManagerAdapter', () => {
 
         expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
           name: 'T',
-          price: { amount: 5, currency: 'PLN' },
+          price: 500,
         });
       });
 
@@ -409,7 +410,7 @@ describe('ErliOfferManagerAdapter', () => {
 
         expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
           name: 'T',
-          price: { amount: 5, currency: 'PLN' },
+          price: 500,
         });
       });
 
@@ -438,12 +439,26 @@ describe('ErliOfferManagerAdapter', () => {
 
         expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, {
           name: 'T',
-          price: { amount: 5, currency: 'PLN' },
+          price: 500,
         });
       });
 
-      it('should re-throw a non-404 GET error rather than failing open', async () => {
-        httpClient.get.mockRejectedValue(new ErliApiException('server error', 500));
+      it('should re-throw a transient network/5xx GET error rather than failing open', async () => {
+        // The client surfaces a transient 5xx / connection failure as
+        // ErliNetworkException (NOT ErliApiException — only deterministic 4xx
+        // become ErliApiException). Only a 404 fails open; everything else,
+        // including this realistic transient error, must re-throw so the
+        // runner's retry classifier decides (#1061).
+        httpClient.get.mockRejectedValue(new ErliNetworkException('connection reset'));
+
+        await expect(
+          adapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'T' } }),
+        ).rejects.toBeInstanceOf(ErliNetworkException);
+        expect(httpClient.patch).not.toHaveBeenCalled();
+      });
+
+      it('should re-throw a non-404 ErliApiException (e.g. 403) rather than failing open', async () => {
+        httpClient.get.mockRejectedValue(new ErliApiException('forbidden', 403));
 
         await expect(
           adapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'T' } }),

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -37,9 +37,12 @@ function createCmd(overrides: Partial<CreateOfferCommand> = {}): CreateOfferComm
     stock: 10,
     publishImmediately: true,
     ...rest,
+    // Default to a resolvable Allegro category: ADR-025 §3 makes a missing one a
+    // terminal rejection, so the happy-path/unrelated tests must carry one.
     overrides: {
       title: 'Default Widget',
       imageUrls: ['https://cdn.example.com/default.jpg'],
+      categoryId: '18654',
       ...ov,
     },
   };
@@ -75,13 +78,20 @@ describe('ErliOfferManagerAdapter', () => {
     it('should map the basic command fields into the create body', async () => {
       await adapter.createOffer(
         createCmd({
-          overrides: { title: 'Widget', description: 'A nice widget', imageUrls: ['https://cdn.example.com/a.jpg'] },
+          overrides: {
+            categoryId: '18654',
+            title: 'Widget',
+            description: 'A nice widget',
+            imageUrls: ['https://cdn.example.com/a.jpg'],
+          },
           variantBarcode: '5901234123457',
         }),
       );
 
       const body = httpClient.post.mock.calls[0][1];
-      expect(body).toEqual({
+      // toMatchObject: this test covers basic-field mapping, not taxonomy
+      // (externalCategories is asserted by the #985 reuse tests).
+      expect(body).toMatchObject({
         price: 4999,
         stock: 10,
         images: [{ url: 'https://cdn.example.com/a.jpg' }],
@@ -100,7 +110,12 @@ describe('ErliOfferManagerAdapter', () => {
 
     it('should let a per-offer platformParams.dispatchTime override the connection default', async () => {
       await adapter.createOffer(
-        createCmd({ overrides: { platformParams: { dispatchTime: { period: 5, unit: 'hour' } } } }),
+        createCmd({
+          overrides: {
+            categoryId: '18654',
+            platformParams: { dispatchTime: { period: 5, unit: 'hour' } },
+          },
+        }),
       );
       const body = httpClient.post.mock.calls[0][1] as { dispatchTime?: unknown };
       expect(body.dispatchTime).toEqual({ period: 5, unit: 'hour' });
@@ -144,6 +159,7 @@ describe('ErliOfferManagerAdapter', () => {
       await adapter.createOffer(
         createCmd({
           overrides: {
+            categoryId: '18654',
             imageUrls: ['https://cdn.example.com/ok.jpg', 'http://x/insecure.jpg', 'https://169.254.169.254/meta'],
           },
         }),
@@ -261,14 +277,12 @@ describe('ErliOfferManagerAdapter', () => {
         ]);
       });
 
-      it('should omit both taxonomy keys and still POST when no Allegro data is present', async () => {
-        const result = await adapter.createOffer(createCmd());
-
-        expect(httpClient.post).toHaveBeenCalledTimes(1);
-        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
-        expect(body).not.toHaveProperty('externalCategories');
-        expect(body).not.toHaveProperty('externalAttributes');
-        expect(result.status).toBe('draft');
+      it('should throw OfferCreateRejectedException and NOT POST when no Allegro taxonomy resolves (ADR-025 §3)', async () => {
+        // Explicitly clear the helper's default categoryId so no Allegro taxonomy resolves.
+        await expect(
+          adapter.createOffer(createCmd({ overrides: { categoryId: undefined } })),
+        ).rejects.toBeInstanceOf(OfferCreateRejectedException);
+        expect(httpClient.post).not.toHaveBeenCalled();
       });
 
       it('should omit externalAttributes when the category is present but no params map', async () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -19,6 +19,7 @@ import {
   type UpdateOfferFieldsCommand,
   type UpdateOfferQuantityCommand,
 } from '@openlinker/core/listings';
+import type { CachePort } from '@openlinker/shared';
 import { ErliApiException } from '../../../domain/exceptions/erli-api.exception';
 import { ErliAuthenticationException } from '../../../domain/exceptions/erli-authentication.exception';
 import { ErliConfigException } from '../../../domain/exceptions/erli-config.exception';
@@ -655,6 +656,150 @@ describe('ErliOfferManagerAdapter', () => {
 
     it('should reject a hostile externalOfferId before any GET', async () => {
       await expect(adapter.getOfferStatus('evil/../x')).rejects.toBeInstanceOf(ErliConfigException);
+      expect(httpClient.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('frozen-stock cache flag (#1066)', () => {
+    let cache: jest.Mocked<CachePort>;
+    let cachedAdapter: ErliOfferManagerAdapter;
+    const EXPECTED_KEY = `erli:frozen-stock:conn-1:${VALID_ID}`;
+    // 26h — must match ERLI_FROZEN_STOCK_CACHE_TTL_SEC in the adapter.
+    const EXPECTED_TTL = 26 * 60 * 60;
+
+    beforeEach(() => {
+      cache = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+      };
+      cachedAdapter = new ErliOfferManagerAdapter('conn-1', ERLI_ADAPTER_KEY, httpClient, cache);
+    });
+
+    it('should skip the stock PATCH after reconciliation observed a frozen stock (write→read round-trip)', async () => {
+      // Linchpin: writer (getOfferStatus) and reader (updateOfferQuantity) MUST
+      // build the same key. Drive a real round-trip through one mocked cache.
+      const store = new Map<string, unknown>();
+      cache.set.mockImplementation((key, value) => {
+        store.set(key, value);
+        return Promise.resolve();
+      });
+      cache.get.mockImplementation((key) => Promise.resolve((store.get(key) ?? null) as never));
+      httpClient.get.mockResolvedValueOnce({
+        status: 200,
+        data: { status: 'active', frozenFields: ['stock'] },
+      });
+
+      await cachedAdapter.getOfferStatus(VALID_ID);
+      await cachedAdapter.updateOfferQuantity({ offerId: VALID_ID, quantity: 7 });
+
+      expect(httpClient.patch).not.toHaveBeenCalled();
+    });
+
+    it('should NOT PATCH stock when the cached flag is true (frozen → skipped)', async () => {
+      cache.get.mockResolvedValue(true);
+
+      await cachedAdapter.updateOfferQuantity({ offerId: VALID_ID, quantity: 7 });
+
+      expect(cache.get).toHaveBeenCalledWith(EXPECTED_KEY);
+      expect(httpClient.patch).not.toHaveBeenCalled();
+    });
+
+    it('should PATCH stock when the cached flag is absent (not-frozen → pushed)', async () => {
+      cache.get.mockResolvedValue(null);
+
+      await cachedAdapter.updateOfferQuantity({ offerId: VALID_ID, quantity: 7 });
+
+      expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, { stock: 7 });
+    });
+
+    it('should PATCH stock when the cache read errors (fail-open)', async () => {
+      cache.get.mockRejectedValue(new Error('redis down'));
+
+      await cachedAdapter.updateOfferQuantity({ offerId: VALID_ID, quantity: 7 });
+
+      expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, { stock: 7 });
+    });
+
+    it('should not touch the cache and still run the push path for a hostile id', async () => {
+      await expect(
+        cachedAdapter.updateOfferQuantity({ offerId: 'not-a-valid-id', quantity: 1 }),
+      ).rejects.toBeInstanceOf(ErliConfigException);
+
+      expect(cache.get).not.toHaveBeenCalled();
+    });
+
+    it('should produce disjoint keys per connection for the same variant id', async () => {
+      const adapterA = new ErliOfferManagerAdapter('conn-A', ERLI_ADAPTER_KEY, httpClient, cache);
+      const adapterB = new ErliOfferManagerAdapter('conn-B', ERLI_ADAPTER_KEY, httpClient, cache);
+
+      await adapterA.updateOfferQuantity({ offerId: VALID_ID, quantity: 1 });
+      await adapterB.updateOfferQuantity({ offerId: VALID_ID, quantity: 1 });
+
+      const keyA = cache.get.mock.calls[0][0];
+      const keyB = cache.get.mock.calls[1][0];
+      expect(keyA).toBe(`erli:frozen-stock:conn-A:${VALID_ID}`);
+      expect(keyB).toBe(`erli:frozen-stock:conn-B:${VALID_ID}`);
+      expect(keyA).not.toBe(keyB);
+    });
+
+    it('should set the flag with the TTL when reconciliation sees a frozen stock', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        status: 200,
+        data: { status: 'active', frozenFields: ['stock'] },
+      });
+
+      await cachedAdapter.getOfferStatus(VALID_ID);
+
+      expect(cache.set).toHaveBeenCalledWith(EXPECTED_KEY, true, EXPECTED_TTL);
+      expect(cache.delete).not.toHaveBeenCalled();
+    });
+
+    it('should delete the flag (not store false) when reconciliation sees stock not frozen', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        status: 200,
+        data: { status: 'active', frozenFields: [] },
+      });
+
+      await cachedAdapter.getOfferStatus(VALID_ID);
+
+      expect(cache.delete).toHaveBeenCalledWith(EXPECTED_KEY);
+      expect(cache.set).not.toHaveBeenCalled();
+    });
+
+    it('should leave the cache untouched on a bodyless 2xx (frozenFields undefined)', async () => {
+      httpClient.get.mockResolvedValueOnce({ status: 200, data: undefined });
+
+      await cachedAdapter.getOfferStatus(VALID_ID);
+
+      expect(cache.set).not.toHaveBeenCalled();
+      expect(cache.delete).not.toHaveBeenCalled();
+    });
+
+    it('should not touch the cache when getOfferStatus 404s', async () => {
+      httpClient.get.mockRejectedValueOnce(new ErliApiException('not found', 404));
+
+      await expect(cachedAdapter.getOfferStatus(VALID_ID)).rejects.toBeInstanceOf(
+        OfferNotFoundOnMarketplaceException,
+      );
+      expect(cache.set).not.toHaveBeenCalled();
+      expect(cache.delete).not.toHaveBeenCalled();
+    });
+
+    it('should opportunistically set the flag from updateOfferFields (secondary writer)', async () => {
+      httpClient.get.mockResolvedValue({ status: 200, data: { frozenFields: ['stock'] } });
+
+      await cachedAdapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'T' } });
+
+      expect(cache.set).toHaveBeenCalledWith(EXPECTED_KEY, true, EXPECTED_TTL);
+    });
+
+    it('should issue NO GET on the hot quantity path whether frozen or not (#1066 AC)', async () => {
+      cache.get.mockResolvedValueOnce(true);
+      await cachedAdapter.updateOfferQuantity({ offerId: VALID_ID, quantity: 7 });
+      cache.get.mockResolvedValueOnce(null);
+      await cachedAdapter.updateOfferQuantity({ offerId: VALID_ID, quantity: 7 });
+
       expect(httpClient.get).not.toHaveBeenCalled();
     });
   });

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -1,10 +1,11 @@
 /**
- * Erli Offer Manager Adapter — unit tests (#984)
+ * Erli Offer Manager Adapter — unit tests (#984, #985)
  *
  * Mocks `IErliHttpClient` to verify: seller-keyed path build (validate+encode),
  * 202→'draft' create mapping, sparse PATCH for field/quantity updates, the
  * safe 4xx→OfferCreateRejectedException mapping (no responseBody leak), auth
- * propagation, hostile-id rejection, and imageUrl hygiene.
+ * propagation, hostile-id rejection, imageUrl hygiene, and the #985 Allegro
+ * category/parameter reuse (source:"allegro" externalCategories/Attributes).
  *
  * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
  */
@@ -196,6 +197,127 @@ describe('ErliOfferManagerAdapter', () => {
         adapter.createOffer(createCmd({ internalVariantId: 'ol_variant_../admin' })),
       ).rejects.toBeInstanceOf(ErliConfigException);
       expect(httpClient.post).not.toHaveBeenCalled();
+    });
+
+    describe('category & parameter reuse (#985)', () => {
+      it('should map overrides.categoryId into a source:"allegro" externalCategories entry', async () => {
+        await adapter.createOffer(createCmd({ overrides: { categoryId: '18654' } }));
+
+        const body = httpClient.post.mock.calls[0][1] as {
+          externalCategories?: unknown;
+        };
+        expect(body.externalCategories).toEqual([{ source: 'allegro', id: '18654' }]);
+      });
+
+      it('should map a dictionary parameter (valuesIds → type:dictionary)', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              categoryId: '18654',
+              platformParams: { parameters: [{ id: '11323', valuesIds: ['11323_1'] }] },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '11323', type: 'dictionary', values: ['11323_1'] },
+        ]);
+      });
+
+      it('should map a free-text parameter (values → type:string)', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              categoryId: '18654',
+              platformParams: { parameters: [{ id: '224017', values: ['Acme'] }] },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '224017', type: 'string', values: ['Acme'] },
+        ]);
+      });
+
+      it('should merge offer-section and product-section params into one flat list', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              categoryId: '18654',
+              platformParams: {
+                parameters: [{ id: '11323', valuesIds: ['11323_1'] }],
+                productParameters: [{ id: '224017', values: ['Acme'] }],
+              },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '11323', type: 'dictionary', values: ['11323_1'] },
+          { source: 'allegro', id: '224017', type: 'string', values: ['Acme'] },
+        ]);
+      });
+
+      it('should omit both taxonomy keys and still POST when no Allegro data is present', async () => {
+        const result = await adapter.createOffer(createCmd());
+
+        expect(httpClient.post).toHaveBeenCalledTimes(1);
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).not.toHaveProperty('externalCategories');
+        expect(body).not.toHaveProperty('externalAttributes');
+        expect(result.status).toBe('draft');
+      });
+
+      it('should omit externalAttributes when the category is present but no params map', async () => {
+        await adapter.createOffer(createCmd({ overrides: { categoryId: '18654' } }));
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).toHaveProperty('externalCategories');
+        expect(body).not.toHaveProperty('externalAttributes');
+      });
+
+      it('should drop malformed parameter entries (missing/empty id)', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              categoryId: '18654',
+              platformParams: {
+                parameters: [
+                  { id: '', values: ['x'] },
+                  { values: ['no id'] },
+                  null,
+                  'garbage',
+                  { id: '11323', valuesIds: ['11323_1'] },
+                ],
+              },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '11323', type: 'dictionary', values: ['11323_1'] },
+        ]);
+      });
+
+      it('should drop a rangeValue-only parameter (no values/valuesIds) in v1', async () => {
+        await adapter.createOffer(
+          createCmd({
+            overrides: {
+              categoryId: '18654',
+              platformParams: {
+                parameters: [{ id: '12345', rangeValue: { from: '1', to: '10' } }],
+              },
+            },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).not.toHaveProperty('externalAttributes');
+      });
     });
   });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -194,16 +194,17 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
       return body;
     }
     const frozen = new Set(frozenFields);
-    const result: ErliProductPatchBody = {};
-    for (const key of Object.keys(body) as (keyof ErliProductPatchBody)[]) {
+    // Shallow-copy then delete frozen keys — avoids a per-key index-write cast
+    // while preserving each value's own type.
+    const result: ErliProductPatchBody = { ...body };
+    for (const key of Object.keys(result) as (keyof ErliProductPatchBody)[]) {
       const erliName = PATCH_KEY_TO_ERLI_FROZEN_NAME[key];
       if (erliName !== undefined && frozen.has(erliName)) {
         this.logger.debug(
           `Skipping frozen Erli field "${erliName}" on field-update [connectionId=${this.connectionId}]`,
         );
-        continue;
+        delete result[key];
       }
-      result[key] = body[key] as never;
     }
     return result;
   }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -9,10 +9,12 @@
  *
  * Async write model (ADR-025): Erli returns HTTP 202 (validated + stored,
  * ~20-min cache lag — no read-after-write). A 202/2xx create maps to
- * `CreateOfferResult.status = 'validating'`: the core poll then reads the real
- * Erli status back via this adapter's `OfferStatusReader.getOfferStatus` (#989)
- * and the steady-state `erli-offer-status-sync` scheduler task reconciles mapped
- * offers into `offer_status_snapshots` — never trusting the 202 as confirmation.
+ * `CreateOfferResult.status = 'draft'` (submitted, not confirmed — it does NOT
+ * schedule the Allegro-tuned creation poll, whose 404-is-terminal + ~9.5-min
+ * budget collide with Erli's ~20-min lag; review #1063). Publication is instead
+ * reconciled by the steady-state `erli-offer-status-sync` scheduler task, which
+ * reads the real Erli status back via this adapter's `OfferStatusReader.getOfferStatus`
+ * (#989) into `offer_status_snapshots` — never trusting the 202 as confirmation.
  *
  * Category/parameter reuse (#985): the create body carries `externalCategories`
  * + `externalAttributes` tagged `source:"allegro"`, built from the already-
@@ -145,10 +147,14 @@ export class ErliOfferManagerAdapter
       // Auth / network / rate-limit propagate to the runner + classifiers.
       throw error;
     }
-    // 202/2xx = submitted, not confirmed (ADR-025). 'validating' schedules the
-    // core status poll, which reads the real Erli status back via this adapter's
-    // OfferStatusReader (#989) — safe now that getOfferStatus exists.
-    return { externalOfferId, status: 'validating' };
+    // 202/2xx = submitted, not confirmed (ADR-025). Stay 'draft' (outcome 'ok',
+    // no creation poll): the Allegro-tuned OfferStatusPollService treats a GET
+    // 404 as terminal OFFER_NOT_FOUND on the first iteration and its ~9.5-min
+    // budget is shorter than Erli's documented ~20-min cache lag — flipping to
+    // 'validating' would falsely fail valid offers (review #1063). Publication is
+    // reconciled by the steady-state erli-offer-status-sync task instead, which
+    // tolerates the lag; that path still exercises getOfferStatus (#989).
+    return { externalOfferId, status: 'draft' };
   }
 
   async updateOfferFields(cmd: UpdateOfferFieldsCommand): Promise<void> {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -86,11 +86,16 @@ const ERLI_PRODUCT_ID_PATTERN = /^ol_variant_[a-f0-9]{32}$/;
  * PROVISIONAL alongside the wire shape in `erli-product.types.ts` (#992): if the
  * confirmed frozen-name set differs, this is the single change point.
  */
+// OL patch-key → Erli frozen-marker wire name. Provisional #992 wire vocabulary,
+// coupled to `ErliProductResource.frozenFields` (erli-product.types.ts) — reconcile
+// both against the sandbox together. `stock` is intentionally absent: the hot
+// quantity path (`updateOfferQuantity`) does not read frozen state in v1, so a
+// `stock` entry here would be dead code asserting a guarantee no path delivers.
+// Honoring frozen-stock is deferred to #1066 (ADR-025 §4b).
 const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, string>> = {
   price: 'price',
   name: 'name',
   description: 'description',
-  stock: 'stock',
 };
 
 export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, OfferFieldUpdater {
@@ -138,7 +143,20 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
     const body = this.buildPatchFromFields(cmd.fields);
     // #988 / ADR-025 §4b: never overwrite a field the seller froze in the panel.
     // Read the live product, drop frozen keys per-field; an empty body is a no-op.
-    const current = await this.fetchErliProduct(cmd.externalOfferId);
+    let current: ErliProductResource;
+    try {
+      current = await this.fetchErliProduct(cmd.externalOfferId);
+    } catch (error) {
+      // ADR-025 is reconciliation-first: within Erli's ~20-min read-after-write
+      // cache lag a just-created offer GET-404s. Fail open — PATCH the full body
+      // (frozen state unknown, and a just-created offer has no manual freezes yet)
+      // rather than blocking the update. Re-throw anything that isn't a 404 (#1061).
+      if (error instanceof ErliApiException && error.statusCode === 404) {
+        current = {} as ErliProductResource;
+      } else {
+        throw error;
+      }
+    }
     const filtered = this.dropFrozenFields(body, current.frozenFields);
     if (Object.keys(filtered).length === 0) {
       this.logger.debug(
@@ -191,6 +209,10 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
   }
 
   async updateOfferQuantity(cmd: UpdateOfferQuantityCommand): Promise<void> {
+    // Frozen-stock is intentionally NOT honored here in v1: this runs on every
+    // inventory tick and skips the read-before-write GET for performance, so a
+    // seller-frozen `stock` is not detectable on this path. Deferred to #1066
+    // (ADR-025 §4b) — to be done without a per-tick GET via a cached frozen flag.
     const body: ErliProductPatchBody = { stock: cmd.quantity };
     await this.httpClient.patch(this.productPath(cmd.offerId), body);
   }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -21,9 +21,23 @@
  * (ADR-025 §3); no Erli-native taxonomy authoring. Applies to the create path
  * only — `buildPatchFromFields` is untouched.
  *
- * Out of scope (own issues, marked seams): variant grouping #986, stock/price
- * master sourcing + frozen-field exclusion #988, offer-status reconciliation
- * #989.
+ * Frozen-field ownership (#988, ADR-025 §4b): Erli marks seller-panel manual
+ * edits `frozen`; OL must not overwrite them. `updateOfferFields` reads the
+ * current product (`fetchErliProduct`) and DROPS any supplied field whose Erli
+ * frozen-name is in `frozenFields` before issuing the PATCH (per-nested-field
+ * granularity); an all-frozen update issues no PATCH. The hot `updateOfferQuantity`
+ * inventory path deliberately does NOT pre-fetch — that would double every
+ * inventory tick's API calls; stock drift is guarded by reconciliation (#989),
+ * not a per-PATCH GET (decision recorded in the #988 plan).
+ *
+ * Stock-restore-on-cancel (#988 / ADR-025 §4a) is DEFERRED to the orders half:
+ * it needs an Erli order-cancel signal (OrderSource / inbox poll, #993) that
+ * does not exist yet — no trigger is wired here (YAGNI). The restore mechanism
+ * already exists (`updateOfferQuantity`); #993 only needs to observe the
+ * `cancelled` event and call it.
+ *
+ * Out of scope (own issues, marked seams): variant grouping #986, master-price
+ * → offer propagation (no core trigger today), offer-status reconciliation #989.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  * @see {@link OfferManagerPort}
@@ -52,6 +66,7 @@ import type {
   ErliProductCreateBody,
   ErliProductImage,
   ErliProductPatchBody,
+  ErliProductResource,
 } from './erli-product.types';
 
 /**
@@ -63,6 +78,20 @@ import type {
  * must change in lockstep (a mismatch fails closed: updates throw, never send).
  */
 const ERLI_PRODUCT_ID_PATTERN = /^ol_variant_[a-f0-9]{32}$/;
+
+/**
+ * Maps OL patch-body keys to the Erli field name carried in
+ * {@link ErliProductResource.frozenFields} (#988, ADR-025 §4b). Only the keys a
+ * field-update can supply are listed; an unmapped key is never treated as frozen.
+ * PROVISIONAL alongside the wire shape in `erli-product.types.ts` (#992): if the
+ * confirmed frozen-name set differs, this is the single change point.
+ */
+const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, string>> = {
+  price: 'price',
+  name: 'name',
+  description: 'description',
+  stock: 'stock',
+};
 
 export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, OfferFieldUpdater {
   private readonly logger = new Logger(ErliOfferManagerAdapter.name);
@@ -107,7 +136,55 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
 
   async updateOfferFields(cmd: UpdateOfferFieldsCommand): Promise<void> {
     const body = this.buildPatchFromFields(cmd.fields);
-    await this.httpClient.patch(this.productPath(cmd.externalOfferId), body);
+    // #988 / ADR-025 §4b: never overwrite a field the seller froze in the panel.
+    // Read the live product, drop frozen keys per-field; an empty body is a no-op.
+    const current = await this.fetchErliProduct(cmd.externalOfferId);
+    const filtered = this.dropFrozenFields(body, current.frozenFields);
+    if (Object.keys(filtered).length === 0) {
+      this.logger.debug(
+        `Erli field-update is a no-op — all supplied fields are frozen [connectionId=${this.connectionId}]`,
+      );
+      return;
+    }
+    await this.httpClient.patch(this.productPath(cmd.externalOfferId), filtered);
+  }
+
+  /**
+   * Read the current Erli product (#988). Reuses {@link productPath}
+   * (validate+encode) so a hostile id fails closed exactly as the write paths
+   * do. #989 reuses this read path for offer-status reconciliation.
+   */
+  private async fetchErliProduct(externalId: string): Promise<ErliProductResource> {
+    const res = await this.httpClient.get<ErliProductResource>(this.productPath(externalId));
+    return res.data;
+  }
+
+  /**
+   * Return a copy of the patch body with every key the seller has frozen removed
+   * (per-nested-field granularity, ADR-025 §4b). Each OL patch key maps to its
+   * Erli frozen-name via {@link PATCH_KEY_TO_ERLI_FROZEN_NAME}; a key with no
+   * mapping is never considered frozen. Dropped keys are debug-logged (no PII).
+   */
+  private dropFrozenFields(
+    body: ErliProductPatchBody,
+    frozenFields: string[] | undefined,
+  ): ErliProductPatchBody {
+    if (!frozenFields || frozenFields.length === 0) {
+      return body;
+    }
+    const frozen = new Set(frozenFields);
+    const result: ErliProductPatchBody = {};
+    for (const key of Object.keys(body) as (keyof ErliProductPatchBody)[]) {
+      const erliName = PATCH_KEY_TO_ERLI_FROZEN_NAME[key];
+      if (erliName !== undefined && frozen.has(erliName)) {
+        this.logger.debug(
+          `Skipping frozen Erli field "${erliName}" on field-update [connectionId=${this.connectionId}]`,
+        );
+        continue;
+      }
+      result[key] = body[key] as never;
+    }
+    return result;
   }
 
   async updateOfferQuantity(cmd: UpdateOfferQuantityCommand): Promise<void> {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -27,10 +27,20 @@
  * edits `frozen`; OL must not overwrite them. `updateOfferFields` reads the
  * current product (`fetchErliProduct`) and DROPS any supplied field whose Erli
  * frozen-name is in `frozenFields` before issuing the PATCH (per-nested-field
- * granularity); an all-frozen update issues no PATCH. The hot `updateOfferQuantity`
- * inventory path deliberately does NOT pre-fetch — that would double every
- * inventory tick's API calls; stock drift is guarded by reconciliation (#989),
- * not a per-PATCH GET (decision recorded in the #988 plan).
+ * granularity); an all-frozen update issues no PATCH.
+ *
+ * Frozen-`stock` on the hot path (#1066, ADR-025 §4b): `updateOfferQuantity`
+ * runs on every inventory tick and deliberately does NOT pre-fetch — a per-tick
+ * GET would double the tick's API calls. Frozen-`stock` is instead honored via a
+ * per-offer cache flag populated by the steady-state `erli-offer-status-sync`
+ * reconciliation (#989), which already GETs each mapped offer and sees
+ * `frozenFields`. `getOfferStatus` (and opportunistically `updateOfferFields`)
+ * writes that flag; `updateOfferQuantity` reads it and skips the stock PATCH when
+ * set. A cache miss fails OPEN (push), preserving the pre-#1066 behaviour when the
+ * flag is unknown. The honoring holds from the first reconciliation pass onward;
+ * a freeze landing between ticks is overwritten once until the next pass — the
+ * reconciliation-first / eventual-consistency posture of ADR-025 §1 (window
+ * bounded by the cron cadence, not the cache TTL).
  *
  * Stock-restore-on-cancel (#988 / ADR-025 §4a) is DEFERRED to the orders half:
  * it needs an Erli order-cancel signal (OrderSource / inbox poll, #993) that
@@ -69,6 +79,7 @@ import {
   type UpdateOfferFieldsCommand,
   type UpdateOfferQuantityCommand,
 } from '@openlinker/core/listings';
+import type { CachePort } from '@openlinker/shared';
 import { Logger } from '@openlinker/shared/logging';
 import { ErliApiException } from '../../domain/exceptions/erli-api.exception';
 import { ErliConfigException } from '../../domain/exceptions/erli-config.exception';
@@ -103,15 +114,36 @@ const ERLI_PRODUCT_ID_PATTERN = /^ol_variant_[a-f0-9]{32}$/;
  */
 // OL patch-key → Erli frozen-marker wire name. Provisional #992 wire vocabulary,
 // coupled to `ErliProductResource.frozenFields` (erli-product.types.ts) — reconcile
-// both against the sandbox together. `stock` is intentionally absent: the hot
-// quantity path (`updateOfferQuantity`) does not read frozen state in v1, so a
-// `stock` entry here would be dead code asserting a guarantee no path delivers.
-// Honoring frozen-stock is deferred to #1066 (ADR-025 §4b).
+// both against the sandbox together. `stock` is intentionally absent from THIS map:
+// it drives `dropFrozenFields` on the field-update path, which reads live
+// `frozenFields` per call — the quantity path doesn't read live frozen state. Frozen
+// `stock` IS now honored (#1066, ADR-025 §4b), but via the separate cache-flag check
+// in `updateOfferQuantity` (see {@link ERLI_FROZEN_STOCK_FIELD}), not this map.
 const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, string>> = {
   price: 'price',
   name: 'name',
   description: 'description',
 };
+
+/**
+ * Erli `frozenFields` wire-name for stock (#1066, ADR-025 §4b). Looked for during
+ * reconciliation to populate the per-offer frozen-stock cache flag the hot
+ * `updateOfferQuantity` path reads. Colocated with {@link PATCH_KEY_TO_ERLI_FROZEN_NAME}
+ * (the same provisional #992 wire vocabulary): if the sandbox spike confirms a
+ * different name, this is the single change point alongside that map.
+ */
+const ERLI_FROZEN_STOCK_FIELD = 'stock';
+
+/**
+ * Frozen-stock cache TTL (#1066). Sized for the WORST-case reconciliation cadence
+ * (an operator who loosens the reconciliation cron `ERLI_OFFER_STATUS_SYNC_CRON` in
+ * erli-scheduler-tasks.ts from hourly to daily) — so it must exceed 24h. The
+ * eventual-consistency window is bounded by the cron cadence (the flag is re-asserted
+ * every reconciliation tick), not this TTL; the TTL only governs self-healing once
+ * reconciliation STOPS. If that cron default changes, re-evaluate this constant in
+ * lockstep.
+ */
+const ERLI_FROZEN_STOCK_CACHE_TTL_SEC = 26 * 60 * 60;
 
 export class ErliOfferManagerAdapter
   implements OfferManagerPort, OfferCreator, OfferFieldUpdater, OfferStatusReader
@@ -128,6 +160,12 @@ export class ErliOfferManagerAdapter
      * is absent; create fails closed if neither is present (Erli requires it).
      */
     private readonly defaultDispatchTime?: ErliDispatchTime,
+    /**
+     * Distributed cache for the per-offer frozen-stock flag (#1066). Optional:
+     * unit-test hosts and `CacheModule`-less bootstraps leave it `undefined`, in
+     * which case every consult fails open (push stock = pre-#1066 behaviour).
+     */
+    private readonly cache?: CachePort,
   ) {}
 
   async createOffer(cmd: CreateOfferCommand): Promise<CreateOfferResult> {
@@ -175,6 +213,10 @@ export class ErliOfferManagerAdapter
         throw error;
       }
     }
+    // #1066: opportunistically refresh the frozen-stock cache flag — `frozenFields`
+    // is already in hand from the read above. On the 404 fail-open branch `current`
+    // is `{}` so `frozenFields` is undefined and the helper no-ops.
+    await this.writeFrozenStockFlag(cmd.externalOfferId, current.frozenFields);
     const filtered = this.dropFrozenFields(body, current.frozenFields);
     if (Object.keys(filtered).length === 0) {
       this.logger.debug(
@@ -202,6 +244,11 @@ export class ErliOfferManagerAdapter
       }
       throw error;
     }
+    // #1066: this is the primary writer of the frozen-stock cache flag — the
+    // reconciliation sweep GETs every mapped offer here, so the hot quantity path
+    // gets the flag without its own GET. Written before mapping/returning; a 404
+    // (handled above → OfferNotFoundOnMarketplaceException) never reaches here.
+    await this.writeFrozenStockFlag(externalOfferId, product.frozenFields);
     return mapErliStatusToReadResult(product);
   }
 
@@ -248,12 +295,99 @@ export class ErliOfferManagerAdapter
   }
 
   async updateOfferQuantity(cmd: UpdateOfferQuantityCommand): Promise<void> {
-    // Frozen-stock is intentionally NOT honored here in v1: this runs on every
-    // inventory tick and skips the read-before-write GET for performance, so a
-    // seller-frozen `stock` is not detectable on this path. Deferred to #1066
-    // (ADR-025 §4b) — to be done without a per-tick GET via a cached frozen flag.
+    // #1066 / ADR-025 §4b: honor a seller-frozen stock WITHOUT a per-tick GET.
+    // The flag is cached during erli-offer-status-sync reconciliation (which
+    // already GETs each offer); a cache miss fails OPEN (push), preserving the
+    // pre-#1066 behaviour when the flag is unknown. The key builder applies the
+    // same validate-or-null + encode hygiene as `productPath`, so a hostile id
+    // reads as a miss here and still throws on the push branch below.
+    if (await this.isStockFrozenCached(cmd.offerId)) {
+      this.logger.debug(
+        `Skipping stock push for frozen Erli offer [connectionId=${this.connectionId}, offerId=${cmd.offerId}]`,
+      );
+      return;
+    }
     const body: ErliProductPatchBody = { stock: cmd.quantity };
     await this.httpClient.patch(this.productPath(cmd.offerId), body);
+  }
+
+  /**
+   * Build the connection-scoped frozen-stock cache key (#1066). Both writer
+   * (`writeFrozenStockFlag`) and reader (`isStockFrozenCached`) go through this
+   * single builder so they cannot drift to disjoint keys. Validates the id with
+   * the same {@link ERLI_PRODUCT_ID_PATTERN} as {@link productPath} and returns
+   * `null` on a non-match (never builds a key from an unvalidated string);
+   * `encodeURIComponent` is the backstop so a stray `:` can't blur the
+   * namespace separator across connections. Uses the trusted constructor-injected
+   * `this.connectionId`, never a value off the command.
+   */
+  private frozenStockCacheKey(externalOfferId: string): string | null {
+    if (!ERLI_PRODUCT_ID_PATTERN.test(externalOfferId)) {
+      return null;
+    }
+    return `erli:frozen-stock:${this.connectionId}:${encodeURIComponent(externalOfferId)}`;
+  }
+
+  /**
+   * Persist the per-offer frozen-stock flag from a reconciliation read (#1066).
+   * Write-on-frozen-only: stock frozen → `set(true)`; stock NOT frozen →
+   * `delete` (unfreeze transition) — "known not-frozen" and "unknown" both read
+   * as fail-open, so storing `false` buys nothing but write amplification. A
+   * bodyless 2xx leaves `frozenFields` `undefined` (GET carried no frozen info):
+   * leave the cache untouched so a previously-cached `true` is not clobbered.
+   * Cache errors are swallowed at debug — a cache write must never break
+   * reconciliation.
+   */
+  private async writeFrozenStockFlag(
+    externalOfferId: string,
+    frozenFields: string[] | undefined,
+  ): Promise<void> {
+    if (!this.cache || frozenFields === undefined) {
+      return;
+    }
+    const key = this.frozenStockCacheKey(externalOfferId);
+    if (key === null) {
+      return;
+    }
+    try {
+      if (frozenFields.includes(ERLI_FROZEN_STOCK_FIELD)) {
+        await this.cache.set(key, true, ERLI_FROZEN_STOCK_CACHE_TTL_SEC);
+      } else {
+        await this.cache.delete(key);
+      }
+    } catch (error) {
+      this.logger.debug(
+        `Frozen-stock cache write failed (ignored) [connectionId=${this.connectionId}, offerId=${externalOfferId}]: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Read the cached frozen-stock flag for the hot quantity path (#1066). Returns
+   * `false` (fail-open ⇒ push) when the id is invalid/hostile (null key), no
+   * cache is wired, the key is absent, or the cache read errors — so the only
+   * behaviour change vs. pre-#1066 is the positive case (cached `true` ⇒ skip).
+   */
+  private async isStockFrozenCached(externalOfferId: string): Promise<boolean> {
+    if (!this.cache) {
+      return false;
+    }
+    const key = this.frozenStockCacheKey(externalOfferId);
+    if (key === null) {
+      return false;
+    }
+    try {
+      return (await this.cache.get<boolean>(key)) === true;
+    } catch (error) {
+      this.logger.debug(
+        `Frozen-stock cache read failed (failing open) [connectionId=${this.connectionId}, offerId=${externalOfferId}]: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return false;
+    }
   }
 
   /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -302,8 +302,12 @@ export class ErliOfferManagerAdapter
     // same validate-or-null + encode hygiene as `productPath`, so a hostile id
     // reads as a miss here and still throws on the push branch below.
     if (await this.isStockFrozenCached(cmd.offerId)) {
-      this.logger.debug(
-        `Skipping stock push for frozen Erli offer [connectionId=${this.connectionId}, offerId=${cmd.offerId}]`,
+      // warn (not debug): a frozen offer means OL stops propagating stock — INCLUDING
+      // a drop to 0 — so a sold-out variant can oversell on Erli until the seller
+      // unfreezes. Surface the skipped quantity so operators can spot oversell-risk
+      // freezes (PR1067-TECH-02).
+      this.logger.warn(
+        `Skipping stock push for seller-frozen Erli offer (stock=${cmd.quantity} not propagated) [connectionId=${this.connectionId}, offerId=${cmd.offerId}]`,
       );
       return;
     }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -143,7 +143,7 @@ const ERLI_FROZEN_STOCK_FIELD = 'stock';
  * reconciliation STOPS. If that cron default changes, re-evaluate this constant in
  * lockstep.
  */
-const ERLI_FROZEN_STOCK_CACHE_TTL_SEC = 26 * 60 * 60;
+export const ERLI_FROZEN_STOCK_CACHE_TTL_SEC = 26 * 60 * 60;
 
 export class ErliOfferManagerAdapter
   implements OfferManagerPort, OfferCreator, OfferFieldUpdater, OfferStatusReader

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -164,11 +164,19 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
     if (externalCategories.length > 0) {
       body.externalCategories = externalCategories;
     } else {
-      // No Allegro category → list without taxonomy reuse (ADR-025 §3 / #978
-      // §6.2): graceful-omit, not a hard create failure.
-      this.logger.warn(
-        `Erli offer has no Allegro category; listing without taxonomy reuse — #985/#978 §6.2 [connectionId=${this.connectionId}]`,
-      );
+      // ADR-025 §3: OL builds no Erli-native taxonomy in v1 — a product without
+      // resolved Allegro taxonomy cannot list on Erli. Fail closed with a clear,
+      // terminal rejection (OfferCreationExecutionService derives business_failure
+      // from OfferCreateRejectedException) rather than silently listing it
+      // untaxonomised (spec #978 §6).
+      throw new OfferCreateRejectedException(this.adapterKey, 422, [
+        {
+          field: 'category',
+          code: 'NO_ALLEGRO_TAXONOMY',
+          message:
+            'No Allegro category resolved for this product; Erli v1 requires Allegro-ID taxonomy reuse (ADR-025 §3).',
+        },
+      ]);
     }
     const externalAttributes = buildExternalAttributes(cmd);
     if (externalAttributes.length > 0) {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -9,10 +9,10 @@
  *
  * Async write model (ADR-025): Erli returns HTTP 202 (validated + stored,
  * ~20-min cache lag — no read-after-write). A 202/2xx create maps to
- * `CreateOfferResult.status = 'draft'` ("submitted, not yet confirmed") — NOT
- * `'validating'`, which would schedule the #989 status poll that has no
- * `OfferStatusReader` yet and would flip the record to `business_failure`.
- * #989 introduces `OfferStatusReader` and flips this to `'validating'`.
+ * `CreateOfferResult.status = 'validating'`: the core poll then reads the real
+ * Erli status back via this adapter's `OfferStatusReader.getOfferStatus` (#989)
+ * and the steady-state `erli-offer-status-sync` scheduler task reconciles mapped
+ * offers into `offer_status_snapshots` — never trusting the 202 as confirmation.
  *
  * Category/parameter reuse (#985): the create body carries `externalCategories`
  * + `externalAttributes` tagged `source:"allegro"`, built from the already-
@@ -53,6 +53,7 @@
  */
 import {
   OfferCreateRejectedException,
+  OfferNotFoundOnMarketplaceException,
   type CreateOfferCommand,
   type CreateOfferResult,
   type CreateOfferValidationError,
@@ -61,6 +62,8 @@ import {
   type OfferFieldUpdate,
   type OfferFieldUpdater,
   type OfferManagerPort,
+  type OfferStatusReadResult,
+  type OfferStatusReader,
   type UpdateOfferFieldsCommand,
   type UpdateOfferQuantityCommand,
 } from '@openlinker/core/listings';
@@ -108,7 +111,9 @@ const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, 
   description: 'description',
 };
 
-export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, OfferFieldUpdater {
+export class ErliOfferManagerAdapter
+  implements OfferManagerPort, OfferCreator, OfferFieldUpdater, OfferStatusReader
+{
   private readonly logger = new Logger(ErliOfferManagerAdapter.name);
 
   constructor(
@@ -140,13 +145,10 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
       // Auth / network / rate-limit propagate to the runner + classifiers.
       throw error;
     }
-    // 202/2xx = submitted, not confirmed (ADR-025). 'draft' → outcome 'ok',
-    // no status poll. #989 flips to 'validating' once OfferStatusReader exists.
-    // `cmd.publishImmediately` is intentionally not actionable here: Erli's write
-    // is async with no read-after-write, so the live publication state can't be
-    // confirmed synchronously — it is reconciled later via #989's OfferStatusReader
-    // regardless of the requested flag.
-    return { externalOfferId, status: 'draft' };
+    // 202/2xx = submitted, not confirmed (ADR-025). 'validating' schedules the
+    // core status poll, which reads the real Erli status back via this adapter's
+    // OfferStatusReader (#989) — safe now that getOfferStatus exists.
+    return { externalOfferId, status: 'validating' };
   }
 
   async updateOfferFields(cmd: UpdateOfferFieldsCommand): Promise<void> {
@@ -175,6 +177,26 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
       return;
     }
     await this.httpClient.patch(this.productPath(cmd.externalOfferId), filtered);
+  }
+
+  /**
+   * OfferStatusReader (#989). Reads the real Erli-side status (despite the
+   * async-202 cache lag) and maps it to the neutral `OfferPublicationStatus`.
+   * Reuses {@link fetchErliProduct}. A 404 (offer not on Erli) becomes
+   * `OfferNotFoundOnMarketplaceException`; other transport errors propagate so
+   * the runner's transient-retry path absorbs the blip (capability contract).
+   */
+  async getOfferStatus(externalOfferId: string): Promise<OfferStatusReadResult> {
+    let product: ErliProductResource;
+    try {
+      product = await this.fetchErliProduct(externalOfferId);
+    } catch (error) {
+      if (error instanceof ErliApiException && error.statusCode === 404) {
+        throw new OfferNotFoundOnMarketplaceException(externalOfferId, this.connectionId);
+      }
+      throw error;
+    }
+    return mapErliStatusToReadResult(product);
   }
 
   /**
@@ -455,6 +477,33 @@ function readDispatchTimeParam(
   return candidate.unit === undefined
     ? { period }
     : { period, unit: candidate.unit as ErliDispatchTime['unit'] };
+}
+
+/**
+ * Map Erli's native product status onto the neutral closed `OfferPublicationStatus`
+ * union (#989). Erli has no `'rejected'` member in OL's union, so a rejection is
+ * surfaced as `'inactive'` carrying the reason in `validationErrors` (no core enum
+ * change — additive-only per offer-status-read.types ADR-009 note). `'accepted'`
+ * (stored but still propagating through Erli's ~20-min cache) → `'activating'`.
+ * Unknown/absent → `'inactive'` (conservative; never claims live).
+ */
+function mapErliStatusToReadResult(product: ErliProductResource): OfferStatusReadResult {
+  switch (product.status) {
+    case 'active':
+      return { publicationStatus: 'active', validationErrors: [] };
+    case 'accepted':
+      return { publicationStatus: 'activating', validationErrors: [] };
+    case 'rejected':
+      return {
+        publicationStatus: 'inactive',
+        validationErrors: [
+          { code: 'ERLI_REJECTED', message: product.statusReason ?? 'Erli rejected the offer.' },
+        ],
+      };
+    case 'inactive':
+    default:
+      return { publicationStatus: 'inactive', validationErrors: [] };
+  }
 }
 
 /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -156,7 +156,10 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
    */
   private async fetchErliProduct(externalId: string): Promise<ErliProductResource> {
     const res = await this.httpClient.get<ErliProductResource>(this.productPath(externalId));
-    return res.data;
+    // The client returns `data: undefined` for a 204 / empty-body 2xx. Treat a
+    // bodyless read as "no frozen info known" (empty resource) so the PATCH still
+    // proceeds rather than throwing on `current.frozenFields` (review #1061).
+    return res.data ?? ({} as ErliProductResource);
   }
 
   /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -14,9 +14,16 @@
  * `OfferStatusReader` yet and would flip the record to `business_failure`.
  * #989 introduces `OfferStatusReader` and flips this to `'validating'`.
  *
- * Out of scope (own issues, marked seams): category/parameters #985, variant
- * grouping #986, stock/price master sourcing + frozen-field exclusion #988,
- * offer-status reconciliation #989.
+ * Category/parameter reuse (#985): the create body carries `externalCategories`
+ * + `externalAttributes` tagged `source:"allegro"`, built from the already-
+ * resolved Allegro ids riding on the command (`overrides.categoryId` +
+ * `overrides.platformParams.parameters`/`.productParameters`). Erli processes
+ * only the ids (ADR-025 §3); no Erli-native taxonomy authoring. Applies to the
+ * create path only — `buildPatchFromFields` is untouched.
+ *
+ * Out of scope (own issues, marked seams): variant grouping #986, stock/price
+ * master sourcing + frozen-field exclusion #988, offer-status reconciliation
+ * #989.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  * @see {@link OfferManagerPort}
@@ -40,6 +47,8 @@ import { ErliConfigException } from '../../domain/exceptions/erli-config.excepti
 import type { ErliDispatchTime } from '../../domain/types/erli-connection.types';
 import type { IErliHttpClient } from '../http/erli-http-client.interface';
 import type {
+  ErliExternalAttribute,
+  ErliExternalCategory,
   ErliProductCreateBody,
   ErliProductImage,
   ErliProductPatchBody,
@@ -150,7 +159,21 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
     if (cmd.variantBarcode != null) {
       body.ean = cmd.variantBarcode;
     }
-    // #985: category/parameter payload (source:"allegro") is assembled here.
+    // #985: reuse OL's already-resolved Allegro ids (source:"allegro").
+    const externalCategories = buildExternalCategories(cmd);
+    if (externalCategories.length > 0) {
+      body.externalCategories = externalCategories;
+    } else {
+      // No Allegro category → list without taxonomy reuse (ADR-025 §3 / #978
+      // §6.2): graceful-omit, not a hard create failure.
+      this.logger.warn(
+        `Erli offer has no Allegro category; listing without taxonomy reuse — #985/#978 §6.2 [connectionId=${this.connectionId}]`,
+      );
+    }
+    const externalAttributes = buildExternalAttributes(cmd);
+    if (externalAttributes.length > 0) {
+      body.externalAttributes = externalAttributes;
+    }
     // #986: externalVariantGroup is assembled here.
     return body;
   }
@@ -302,6 +325,83 @@ function readDispatchTimeParam(
   return candidate.unit === undefined
     ? { period }
     : { period, unit: candidate.unit as ErliDispatchTime['unit'] };
+}
+
+/**
+ * Map the OL-resolved Allegro category id (`overrides.categoryId`) into the
+ * single-element `source:"allegro"` category list. Empty when absent (#985).
+ */
+function buildExternalCategories(cmd: CreateOfferCommand): ErliExternalCategory[] {
+  const categoryId = cmd.overrides?.categoryId;
+  if (typeof categoryId === 'string' && categoryId.length > 0) {
+    return [{ source: 'allegro', id: categoryId }];
+  }
+  return [];
+}
+
+/**
+ * Flatten the Allegro offer-section + product-section parameter lists into one
+ * `source:"allegro"` attribute array (Erli has a single flat list — the
+ * offer/product split is Allegro-only). Each entry is narrowed with
+ * {@link isAllegroParameterShape}; dictionary value-ids win over free-text
+ * scalars, range-only and malformed entries are dropped (#985).
+ */
+function buildExternalAttributes(cmd: CreateOfferCommand): ErliExternalAttribute[] {
+  const platformParams = cmd.overrides?.platformParams;
+  const raw = [
+    ...toUnknownArray(platformParams?.parameters),
+    ...toUnknownArray(platformParams?.productParameters),
+  ];
+  const attributes: ErliExternalAttribute[] = [];
+  for (const entry of raw) {
+    if (!isAllegroParameterShape(entry)) {
+      continue;
+    }
+    if (entry.valuesIds !== undefined && entry.valuesIds.length > 0) {
+      attributes.push({ source: 'allegro', id: entry.id, type: 'dictionary', values: entry.valuesIds });
+    } else if (entry.values !== undefined && entry.values.length > 0) {
+      attributes.push({ source: 'allegro', id: entry.id, type: 'string', values: entry.values });
+    }
+    // rangeValue-only / empty → dropped in v1 (#985 risk R3).
+  }
+  return attributes;
+}
+
+function toUnknownArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? (value as unknown[]) : [];
+}
+
+/** Allegro command-parameter entry, after narrowing. */
+interface AllegroParameterShape {
+  id: string;
+  values?: string[];
+  valuesIds?: string[];
+}
+
+/**
+ * Narrow an untyped `platformParams.parameters` entry to the Allegro parameter
+ * shape (mirrors `isAllegroOfferParameterShape` in the Allegro adapter): require
+ * a non-empty `id: string`, and `values`/`valuesIds` (when present) must be
+ * string arrays. Anything else is dropped — Erli would reject it anyway.
+ */
+function isAllegroParameterShape(candidate: unknown): candidate is AllegroParameterShape {
+  if (typeof candidate !== 'object' || candidate === null) {
+    return false;
+  }
+  const c = candidate as { id?: unknown; values?: unknown; valuesIds?: unknown };
+  if (typeof c.id !== 'string' || c.id.length === 0) {
+    return false;
+  }
+  if (c.values !== undefined && (!Array.isArray(c.values) || !c.values.every((v) => typeof v === 'string'))) {
+    return false;
+  }
+  if (
+    c.valuesIds !== undefined &&
+    (!Array.isArray(c.valuesIds) || !c.valuesIds.every((v) => typeof v === 'string'))
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function flattenDescription(input: string | OfferDescriptionUpdate): string {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -36,8 +36,17 @@
  * already exists (`updateOfferQuantity`); #993 only needs to observe the
  * `cancelled` event and call it.
  *
- * Out of scope (own issues, marked seams): variant grouping #986, master-price
- * → offer propagation (no core trigger today), offer-status reconciliation #989.
+ * Variant grouping (#986): the create body carries `externalVariantGroup` (the
+ * parent/base product id shared by sibling variants) + per-variant `attributes`
+ * when the command's `overrides.platformParams.erliVariantGroup` is populated.
+ * Single/simple products omit it and list ungrouped. The CORE plumbing that
+ * POPULATES that key (threading the parent product id + flattened distinguishing
+ * attributes through OfferBuilderService / the #824 bulk expansion) is a deferred
+ * follow-up — until it lands, the key is absent and offers list ungrouped (no
+ * regression). Create-path only; `buildPatchFromFields` never emits grouping.
+ *
+ * Out of scope (own issues, marked seams): master-price → offer propagation (no
+ * core trigger today), offer-status reconciliation #989.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  * @see {@link OfferManagerPort}
@@ -67,6 +76,7 @@ import type {
   ErliProductImage,
   ErliProductPatchBody,
   ErliProductResource,
+  ErliVariantAttribute,
 } from './erli-product.types';
 
 /**
@@ -285,7 +295,16 @@ export class ErliOfferManagerAdapter implements OfferManagerPort, OfferCreator, 
     if (externalAttributes.length > 0) {
       body.externalAttributes = externalAttributes;
     }
-    // #986: externalVariantGroup is assembled here.
+    // #986: explicit multi-variant grouping. Present only when core populated
+    // `overrides.platformParams.erliVariantGroup` (deferred follow-up); single/
+    // simple products list ungrouped.
+    const group = buildVariantGroup(cmd);
+    if (group) {
+      body.externalVariantGroup = { id: group.id };
+      if (group.attributes.length > 0) {
+        body.attributes = group.attributes;
+      }
+    }
     return body;
   }
 
@@ -476,6 +495,68 @@ function buildExternalAttributes(cmd: CreateOfferCommand): ErliExternalAttribute
     // range-only / empty → dropped in v1 (#985 risk R3).
   }
   return attributes;
+}
+
+function toUnknownArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? (value as unknown[]) : [];
+}
+
+/** Resolved #986 grouping inputs after narrowing the opaque platformParams bag. */
+interface ResolvedVariantGroup {
+  id: string;
+  attributes: ErliVariantAttribute[];
+}
+
+/**
+ * Read the #986 grouping inputs from the command's adapter-neutral
+ * `overrides.platformParams.erliVariantGroup` bag (mirrors how #985 reads
+ * `platformParams.parameters`). Returns null — list UNGROUPED — when the key is
+ * absent or carries no non-empty `groupId` (single/simple products, and the
+ * not-yet-populated default state until the deferred core follow-up lands).
+ * Distinguishing `attributes` are narrowed per-entry; malformed entries drop.
+ */
+function buildVariantGroup(cmd: CreateOfferCommand): ResolvedVariantGroup | null {
+  const candidate = cmd.overrides?.platformParams?.erliVariantGroup;
+  if (!isErliVariantGroupShape(candidate)) {
+    return null;
+  }
+  const attributes: ErliVariantAttribute[] = [];
+  for (const entry of toUnknownArray(candidate.attributes)) {
+    if (isVariantAttributeShape(entry)) {
+      attributes.push({ name: entry.name, value: entry.value });
+    }
+  }
+  return { id: candidate.groupId, attributes };
+}
+
+/** Erli grouping input on `platformParams`, after narrowing. */
+interface ErliVariantGroupShape {
+  groupId: string;
+  attributes?: unknown;
+}
+
+/**
+ * Narrow the opaque `platformParams.erliVariantGroup` value: require a non-empty
+ * `groupId: string`. `attributes` (if present) is validated per-entry in
+ * {@link buildVariantGroup}, so it stays `unknown` here.
+ */
+function isErliVariantGroupShape(candidate: unknown): candidate is ErliVariantGroupShape {
+  if (typeof candidate !== 'object' || candidate === null) {
+    return false;
+  }
+  const c = candidate as { groupId?: unknown };
+  return typeof c.groupId === 'string' && c.groupId.length > 0;
+}
+
+/** Narrow a single distinguishing-attribute entry to `{ name, value }` strings. */
+function isVariantAttributeShape(candidate: unknown): candidate is ErliVariantAttribute {
+  if (typeof candidate !== 'object' || candidate === null) {
+    return false;
+  }
+  const c = candidate as { name?: unknown; value?: unknown };
+  return (
+    typeof c.name === 'string' && c.name.length > 0 && typeof c.value === 'string' && c.value.length > 0
+  );
 }
 
 function flattenDescription(input: string | OfferDescriptionUpdate): string {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -16,10 +16,10 @@
  *
  * Category/parameter reuse (#985): the create body carries `externalCategories`
  * + `externalAttributes` tagged `source:"allegro"`, built from the already-
- * resolved Allegro ids riding on the command (`overrides.categoryId` +
- * `overrides.platformParams.parameters`/`.productParameters`). Erli processes
- * only the ids (ADR-025 §3); no Erli-native taxonomy authoring. Applies to the
- * create path only — `buildPatchFromFields` is untouched.
+ * resolved Allegro ids riding on the command (`overrides.categoryId` + the
+ * neutral section-tagged `cmd.parameters`, #1071). Erli processes only the ids
+ * (ADR-025 §3); no Erli-native taxonomy authoring. Applies to the create path
+ * only — `buildPatchFromFields` is untouched.
  *
  * Out of scope (own issues, marked seams): variant grouping #986, stock/price
  * master sourcing + frozen-field exclusion #988, offer-status reconciliation
@@ -348,68 +348,31 @@ function buildExternalCategories(cmd: CreateOfferCommand): ErliExternalCategory[
 }
 
 /**
- * Flatten the Allegro offer-section + product-section parameter lists into one
- * `source:"allegro"` attribute array (Erli has a single flat list — the
- * offer/product split is Allegro-only). Each entry is narrowed with
- * {@link isAllegroParameterShape}; dictionary value-ids win over free-text
- * scalars, range-only and malformed entries are dropped (#985).
+ * Flatten the neutral, section-tagged `cmd.parameters` (#1071) into one
+ * `source:"allegro"` attribute array — Erli has a single flat list, so the
+ * Allegro offer/product section split collapses away. Dictionary value-ids win
+ * over free-text scalars; range-only and empty entries are dropped in v1
+ * (#985 risk R3).
+ *
+ * Reads `cmd.parameters` — where `OfferBuilderService` puts the resolved
+ * parameters — NOT `overrides.platformParams`, which no longer carries category
+ * parameters post-#1071 (reading it produced an empty list and silently shipped
+ * offers without their Allegro attribute reuse).
  */
 function buildExternalAttributes(cmd: CreateOfferCommand): ErliExternalAttribute[] {
-  const platformParams = cmd.overrides?.platformParams;
-  const raw = [
-    ...toUnknownArray(platformParams?.parameters),
-    ...toUnknownArray(platformParams?.productParameters),
-  ];
   const attributes: ErliExternalAttribute[] = [];
-  for (const entry of raw) {
-    if (!isAllegroParameterShape(entry)) {
+  for (const param of cmd.parameters ?? []) {
+    if (param.id.length === 0) {
       continue;
     }
-    if (entry.valuesIds !== undefined && entry.valuesIds.length > 0) {
-      attributes.push({ source: 'allegro', id: entry.id, type: 'dictionary', values: entry.valuesIds });
-    } else if (entry.values !== undefined && entry.values.length > 0) {
-      attributes.push({ source: 'allegro', id: entry.id, type: 'string', values: entry.values });
+    if (param.valuesIds !== undefined && param.valuesIds.length > 0) {
+      attributes.push({ source: 'allegro', id: param.id, type: 'dictionary', values: param.valuesIds });
+    } else if (param.values !== undefined && param.values.length > 0) {
+      attributes.push({ source: 'allegro', id: param.id, type: 'string', values: param.values });
     }
-    // rangeValue-only / empty → dropped in v1 (#985 risk R3).
+    // range-only / empty → dropped in v1 (#985 risk R3).
   }
   return attributes;
-}
-
-function toUnknownArray(value: unknown): unknown[] {
-  return Array.isArray(value) ? (value as unknown[]) : [];
-}
-
-/** Allegro command-parameter entry, after narrowing. */
-interface AllegroParameterShape {
-  id: string;
-  values?: string[];
-  valuesIds?: string[];
-}
-
-/**
- * Narrow an untyped `platformParams.parameters` entry to the Allegro parameter
- * shape (mirrors `isAllegroOfferParameterShape` in the Allegro adapter): require
- * a non-empty `id: string`, and `values`/`valuesIds` (when present) must be
- * string arrays. Anything else is dropped — Erli would reject it anyway.
- */
-function isAllegroParameterShape(candidate: unknown): candidate is AllegroParameterShape {
-  if (typeof candidate !== 'object' || candidate === null) {
-    return false;
-  }
-  const c = candidate as { id?: unknown; values?: unknown; valuesIds?: unknown };
-  if (typeof c.id !== 'string' || c.id.length === 0) {
-    return false;
-  }
-  if (c.values !== undefined && (!Array.isArray(c.values) || !c.values.every((v) => typeof v === 'string'))) {
-    return false;
-  }
-  if (
-    c.valuesIds !== undefined &&
-    (!Array.isArray(c.valuesIds) || !c.valuesIds.every((v) => typeof v === 'string'))
-  ) {
-    return false;
-  }
-  return true;
 }
 
 function flattenDescription(input: string | OfferDescriptionUpdate): string {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -9,8 +9,11 @@
  * minor units (grosze, PLN-only — no currency field), `images` is an array of
  * image objects, the barcode key is `ean`, and `dispatchTime` is a required
  * create field. This file is the SINGLE wire-shape reconciliation point — the
- * adapter imports wire shapes only from here. Category/parameters (#985) and
- * variant grouping (#986) are layered in by their own issues.
+ * adapter imports wire shapes only from here.
+ *
+ * The #985 taxonomy fields (`externalCategories` / `externalAttributes`, tagged
+ * `source:"allegro"`, reusing OL's already-resolved Allegro ids — ADR-025 §3)
+ * are layered in here. Variant grouping (#986) is added by its own issue.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  */
@@ -21,6 +24,36 @@ export interface ErliProductImage {
   url: string;
   isVariantImage?: boolean;
   isLifestyleImage?: boolean;
+}
+
+/**
+ * Value-kind discriminator for an `externalAttribute` (#985). v1 maps Allegro
+ * `valuesIds` → `dictionary` and free-text `values` → `string`; `number` is
+ * reserved (single change point if #992 confirms Erli wants `integer`/`float`).
+ */
+export type ErliExternalAttributeType = 'dictionary' | 'string' | 'number';
+
+/**
+ * Category reuse tagged `source:"allegro"` (#985). Erli processes only the `id`
+ * (the OL-resolved Allegro category id); names are ignored (ADR-025 §3).
+ */
+export interface ErliExternalCategory {
+  source: 'allegro';
+  id: string;
+}
+
+/**
+ * Parameter reuse tagged `source:"allegro"` (#985). `id` is the OL-resolved
+ * Allegro parameter id; `values` carries dictionary value-ids or free-text
+ * scalars depending on `type`. `unit` is type-present but unwired in v1 — the
+ * neutral command parameter entries don't carry unit metadata.
+ */
+export interface ErliExternalAttribute {
+  source: 'allegro';
+  id: string;
+  type: ErliExternalAttributeType;
+  values: string[];
+  unit?: string;
 }
 
 /**
@@ -39,6 +72,10 @@ export interface ErliProductCreateBody {
   ean?: string;
   sku?: string;
   dispatchTime?: ErliDispatchTime;
+  /** Allegro category reuse (#985); omitted when empty. */
+  externalCategories?: ErliExternalCategory[];
+  /** Allegro parameter reuse (#985); omitted when empty. */
+  externalAttributes?: ErliExternalAttribute[];
 }
 
 /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -13,7 +13,8 @@
  *
  * The #985 taxonomy fields (`externalCategories` / `externalAttributes`, tagged
  * `source:"allegro"`, reusing OL's already-resolved Allegro ids — ADR-025 §3)
- * are layered in here. Variant grouping (#986) is added by its own issue.
+ * and the #986 variant-grouping shapes (`externalVariantGroup` + per-variant
+ * `attributes`) are layered in here as the same single reconciliation point.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  */
@@ -57,6 +58,29 @@ export interface ErliExternalAttribute {
 }
 
 /**
+ * Multi-variant grouping reference (#986). `id` is the parent/base OL product id
+ * shared by every sibling variant; Erli uses it to render the N sibling products
+ * as ONE buyer-facing listing. Unlike Allegro (Product-Catalog auto-grouping off
+ * GTIN), Erli grouping is explicit via this id. Single/simple products omit it.
+ * PROVISIONAL (#992): the wire key + whether the group id is the parent product
+ * id or a dedicated group key is unconfirmed until the sandbox spike.
+ */
+export interface ErliVariantGroupRef {
+  id: string;
+}
+
+/**
+ * A variant's distinguishing axis (#986), e.g. `{ name: 'Color', value: 'Red' }`.
+ * Declared per-variant so Erli can present selectable options within the grouped
+ * listing. Flattened from OL `ProductVariant.attributes` (`Record<string,string>`)
+ * by the (deferred) core populator before it reaches the command.
+ */
+export interface ErliVariantAttribute {
+  name: string;
+  value: string;
+}
+
+/**
  * Create-product body — `POST /products/{externalId}`. Erli requires
  * `name, images, price, stock, dispatchTime` on create; the optional keys are
  * supplied when the neutral command carries them.
@@ -76,6 +100,13 @@ export interface ErliProductCreateBody {
   externalCategories?: ErliExternalCategory[];
   /** Allegro parameter reuse (#985); omitted when empty. */
   externalAttributes?: ErliExternalAttribute[];
+  /**
+   * Multi-variant grouping (#986); omitted for single/simple products so they
+   * list ungrouped. Present ⇒ this product is one sibling of a grouped listing.
+   */
+  externalVariantGroup?: ErliVariantGroupRef;
+  /** Distinguishing axes within a grouped listing (#986); omitted when empty. */
+  attributes?: ErliVariantAttribute[];
 }
 
 /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -136,7 +136,18 @@ export type ErliProductPatchBody = Pick<
  * {@link ErliOfferManagerAdapter.fetchErliProduct}'s consumers are the single
  * change point. #989 reuses this same read path for offer-status reconciliation.
  */
+/**
+ * Erli-side publication status of a product/offer (read side, #989).
+ * PROVISIONAL (#992): exact value set unconfirmed; the adapter maps it to the
+ * neutral closed `OfferPublicationStatus` union.
+ */
+export type ErliProductStatus = 'accepted' | 'active' | 'inactive' | 'rejected';
+
 export interface ErliProductResource {
-  /** Erli field names the seller has frozen via manual panel edits. */
+  /** Erli field names the seller has frozen via manual panel edits (#988). */
   frozenFields?: string[];
+  /** Current Erli-side publication status (#989). */
+  status?: ErliProductStatus;
+  /** Rejection / inactivation detail Erli supplies, when present (#989). */
+  statusReason?: string;
 }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -90,3 +90,22 @@ export type ErliProductPatchBody = Pick<
   ErliProductCreateBody,
   'name' | 'price' | 'stock' | 'description'
 >;
+
+/**
+ * Provisional read-side product resource — `GET /products/{externalId}` (#988 /
+ * #992). The single field #988 needs is {@link ErliProductResource.frozenFields}:
+ * Erli marks seller-panel manual edits `frozen` (ADR-025 §4b, per-nested-field
+ * granularity), and OL must NOT overwrite a frozen field on a subsequent PATCH.
+ *
+ * PROVISIONAL: the exact wire shape of the frozen marker is unconfirmed until
+ * the #992 sandbox spike. Modelled here as a flat list of frozen Erli field
+ * names (e.g. `["price","name","description","stock"]`) — the most plausible
+ * shape and the simplest to evaluate per-field. If #992 reveals a different
+ * shape (e.g. a per-field `{ value, frozen }` object), this type and
+ * {@link ErliOfferManagerAdapter.fetchErliProduct}'s consumers are the single
+ * change point. #989 reuses this same read path for offer-status reconciliation.
+ */
+export interface ErliProductResource {
+  /** Erli field names the seller has frozen via manual panel edits. */
+  frozenFields?: string[];
+}

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -144,7 +144,12 @@ export type ErliProductPatchBody = Pick<
 export type ErliProductStatus = 'accepted' | 'active' | 'inactive' | 'rejected';
 
 export interface ErliProductResource {
-  /** Erli field names the seller has frozen via manual panel edits (#988). */
+  /**
+   * Erli field names the seller has frozen via manual panel edits (#988). May
+   * include `"stock"` (#1066): reconciliation reads it to populate the per-offer
+   * frozen-stock cache flag the hot quantity path honors. No shape change — the
+   * flat `string[]` already covers it (#992-provisional, same as the other names).
+   */
   frozenFields?: string[];
   /** Current Erli-side publication status (#989). */
   status?: ErliProductStatus;

--- a/libs/integrations/erli/src/infrastructure/scheduler/erli-scheduler-tasks.ts
+++ b/libs/integrations/erli/src/infrastructure/scheduler/erli-scheduler-tasks.ts
@@ -1,0 +1,51 @@
+/**
+ * Erli Scheduler Tasks
+ *
+ * Builds the `SchedulerTaskConfig` instances Erli contributes to the core
+ * `SchedulerTaskRegistryService`. One task today:
+ *
+ *   - `erli-offer-status-sync` (#989) — steady-state refresh of mapped Erli
+ *     offers' publication status into `offer_status_snapshots` (the reconciliation
+ *     that turns an async-202 "submitted" into the real accepted/active/inactive/
+ *     rejected status — ADR-025 §1). Default hourly. Rolling scan-offset cursor
+ *     key `erli.offerStatus.scanOffset`. Reuses the platform-agnostic core
+ *     `marketplace.offer.statusSync` job + `OfferStatusSyncService`, which resolve
+ *     the Erli adapter via the `OfferStatusReader` capability (#989) — no new
+ *     worker handler.
+ *
+ * Unlike the Allegro tasks (which read cron/page-size overrides off a NestJS
+ * `ConfigService`), Erli is wired via `createNestAdapterModule` and has no
+ * plugin-scoped `ConfigService`, so this builder takes no config: the task is
+ * registered unconditionally with sensible defaults and the
+ * `OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED` env gate is re-checked by the
+ * scheduler at each cron tick (set it to `"false"` to disable without a config
+ * dependency at registration time).
+ *
+ * @module libs/integrations/erli/src/infrastructure/scheduler
+ * @see {@link SchedulerTaskConfig} in `@openlinker/core/sync`.
+ */
+import type { SchedulerTaskConfig } from '@openlinker/core/sync';
+
+/** Hourly (6-field cron: sec min hour day month dow). */
+const ERLI_OFFER_STATUS_SYNC_CRON = '0 0 * * * *';
+/** Mapped offers refreshed per run (rolling scan-offset). */
+const ERLI_OFFER_STATUS_SYNC_PAGE_LIMIT = 50;
+
+export function buildErliSchedulerTasks(): SchedulerTaskConfig[] {
+  return [
+    {
+      taskId: 'erli-offer-status-sync',
+      platformType: 'erli',
+      jobType: 'marketplace.offer.statusSync',
+      cronExpression: ERLI_OFFER_STATUS_SYNC_CRON,
+      enabledEnvVar: 'OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED',
+      generatePayload: () => ({
+        schemaVersion: 1,
+        limit: ERLI_OFFER_STATUS_SYNC_PAGE_LIMIT,
+        cursorKey: 'erli.offerStatus.scanOffset',
+      }),
+      generateIdempotencyKey: (connection, timestamp) =>
+        `marketplace:${connection.id}:offer:status:sync:${timestamp}`,
+    },
+  ];
+}


### PR DESCRIPTION
## What & why

OpenLinker is the inventory master and pushes stock to Erli via the hot `updateOfferQuantity` PATCH, which deliberately **skips** a read-before-write GET for per-tick performance. As a result a seller-frozen `stock` (ADR-025 §4b) was overwritten on every inventory tick — the v1 limitation shipped in #988 / #1061.

This change honors frozen-stock on the hot path **without** adding a per-tick GET:

- Piggyback on the steady-state `erli-offer-status-sync` reconciliation (#989), which already GETs each mapped offer and sees `frozenFields`.
- When reconciliation observes a frozen `stock`, cache a per-offer flag via the host `CachePort`; `updateOfferQuantity` reads that cached flag and skips the stock PATCH when set. **Zero** added GET on the hot path.

### Design highlights

- **Single key builder** (`frozenStockCacheKey`) shared by writer and reader so the two paths cannot drift to disjoint keys. Connection-scoped (uses the trusted constructor `connectionId`, never a value off the command), id-validated against the same `ol_variant_*` pattern as `productPath`, `encodeURIComponent`-guarded.
- **Primary writer** = `getOfferStatus` (the reconciliation sweep); **secondary writer** = `updateOfferFields` (its GET is already in hand, keeps the flag fresher on content edits).
- **Write-on-frozen-only**: frozen → `set(true, 26h TTL)`; not-frozen → `delete`. "Known not-frozen" and "unknown" both fail open, so storing `false` only buys write amplification. TTL sized for the worst-case (daily) reconciliation cadence; the eventual-consistency window is bounded by the cron cadence, not the TTL.
- **Fail-open everywhere**: cache miss / no cache wired / read error all push stock — behaviour is byte-identical to pre-#1066 except for the positive (cached-frozen) case.
- `CachePort` threaded from `host.cache` through the factory to the adapter; optional throughout, so cache-less bootstraps and unit-test hosts keep working.

## How tested

Scoped gate (constrained machine — no full-repo run):

- `pnpm --filter @openlinker/integrations-erli type-check` — clean
- `pnpm exec eslint <changed files>` — clean
- `pnpm --filter @openlinker/integrations-erli test` — 129 passed

New unit coverage in `erli-offer-manager.adapter.spec.ts` (`frozen-stock cache flag (#1066)`):
- write→read round-trip on one mocked cache → PATCH skipped (key-drift linchpin)
- cached flag true → no PATCH; absent → PATCH; read error → PATCH (fail-open)
- hostile id → no cache touch, still throws on push branch
- disjoint keys per connection for the same variant id
- writer sets `(true, TTL)` on frozen, `delete` on not-frozen, no-op on bodyless 2xx, no touch on 404
- **no GET on the hot quantity path whether frozen or not** (the #1066 AC)

## Stacking

This PR is **stacked on the Erli plugin + reconciliation branch (#1063 / #989)** — the full Erli plugin and the `erli-offer-status-sync` reconciliation path are not on `main` yet. Diff against `main` will therefore include the upstream Erli work until those land; review the latest commit (`feat(erli): honor frozen stock…`) for the #1066 change in isolation.

## Acceptance criteria

- [x] A seller-frozen `stock` is not overwritten by an inventory tick.
- [x] No additional GET on the `updateOfferQuantity` hot path.
- [ ] ADR-025 §4b updated — the ADR is not on this branch; it lives on the ADR-025 PR (#983). The doc update lands there.
- [x] Unit coverage for: frozen → push skipped; not-frozen → pushed.

Three of four ACs are met on this branch (the ADR doc lives elsewhere), so this is **Part of #1066** rather than a clean `Closes`.

Part of #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
