### PR TITLE
feat(listings): ShopProductManager port + CategoryProvisioner capability (#1041)

### DIFF
--- a/docs/plans/analysis/ANALYSIS-implementation-plan-product-publisher-category-provisioner-capabilities.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-product-publisher-category-provisioner-capabilities.md
@@ -1,0 +1,53 @@
+# Pre-implement gate — ProductPublisher + CategoryProvisioner capabilities (#1041)
+
+**Plan:** `docs/plans/implementation-plan-product-publisher-category-provisioner-capabilities.md`
+**Date:** 2026-06-15 · **Gate:** read-only readiness (no code, no plan edits)
+
+## Verdict: ✅ READY
+
+No reuse collisions, no contract-surface breaks. Every proposed artifact is confirmed
+absent; every edited surface is additive. The merged ADR-023 category-resolution service
+already names the exact contract this plan defines, corroborating the naming.
+
+## Reuse findings (does it already exist?)
+
+| Plan artifact | Verdict | Evidence |
+|---|---|---|
+| `ShopProductManagerPort` (base port) | **NEW** | no `*Port` of that name under `libs/core/src/**/domain/ports/**` |
+| `CategoryProvisioner` capability + `isCategoryProvisioner` | **NEW** | no `*.capability.ts`, no `provisionCategory` method anywhere |
+| `publishProduct` method | **NEW** | absent in libs/core + libs/integrations |
+| `PublishProductCommand/Result/Status/Content` | **NEW** | absent |
+| `ProvisionCategoryCommand/Result` | **NEW** | absent |
+| `ProductPublishRejectedException` | **NEW** | absent |
+| `ShopProductPublishPayloadV1` + `shop-job-payloads.types.ts` | **NEW** | only `marketplace-job-payloads.types.ts` / `master-job-payloads.types.ts` exist |
+| `'shop.product.publish'` job type | **NEW** | absent from `JobTypeValues` |
+| `'ProductPublisher'` / `'CategoryProvisioner'` capability names | **NEW** | absent from `CoreCapabilityValues` (current: ProductMaster, InventoryMaster, OrderProcessorManager, OrderSource, OfferManager) |
+
+**Adjacent (not a collision):** `ProductMasterPort.assignCategories` (`products/domain/ports/product-master.port.ts:148`) *attaches* a product to existing categories — it does **not create/mirror** a category tree. Distinct from `CategoryProvisioner.provisionCategory`. ADR-024 §2 explicitly calls this out ("Today no capability *creates* categories"). No overlap.
+
+**Corroborating signal (strengthens the plan):** the merged `listings/application/services/category-resolution.service.ts` already ships a no-op `tryProvision()` seam whose JSDoc states it will be *"Gated on the `CategoryProvisioner` capability (ADR-024) … uses `isCategoryProvisioner`, calls `provisionCategory(...)`"* and returns `provenance: 'open'`. The plan's names (`CategoryProvisioner`, `isCategoryProvisioner`, `provisionCategory`) match this downstream consumer exactly — #1042 wires straight into it.
+
+## Backward-compat findings
+
+| Surface | Result | Detail |
+|---|---|---|
+| Top-level barrels | **No break** | `listings/index.ts` + `sync/index.ts` + `integrations/index.ts` gain exports only (additive). `CoreCapabilityValues`/`CoreCapability` already re-exported from `integrations/index.ts:49-50`; `JobTypeValues`/`JobType` from `sync/index.ts:43,55`. |
+| Port signatures | **No break** | `ShopProductManagerPort` is net-new; no existing port changes. |
+| Symbol tokens | **No break** | no new tokens (capabilities are guard-resolved); `listings.tokens.ts` untouched. |
+| DTOs | **No break (additive)** | `create-connection.dto.ts:114` + `update-connection.dto.ts:56` use `@IsIn(CoreCapabilityValues, { each: true })` → adding members only widens the accepted set; `connection-response.dto.ts:53,61` is Swagger `enum` only. |
+| ORM schema | **N/A** | no ORM entity touched → no migration required. |
+| `check:invariants` | **No trip** | additions are within-context (listings, sync, integrations) + same-context relative imports; sync→listings value import of `PublishProductStatus`/`PublishProductContent` follows the existing precedent (`marketplace-job-payloads.types.ts` already imports `CreateOfferOverrides` from `@openlinker/core/listings`). No cross-context repo-port import; barrel-purity unaffected (no service classes added). |
+| Exhaustiveness | **No break** | repo-wide search found **zero** `assertNever` / `Record<JobType>` / `Record<CoreCapability>` / `[K in …]` maps keyed on `JobType` or `CoreCapability`. Adding union members is safe. |
+
+## Open questions (non-blocking)
+
+1. **Name↔interface skew** — capability name `'ProductPublisher'` maps to interface `ShopProductManagerPort` (because `publishProduct` is the base port's mandatory method, mirroring `OfferManagerPort` + `updateOfferQuantity`). This is the one place a core capability name diverges from its interface name. Accepted by design (umbrella scalability); must be documented in the `ShopProductManagerPort` header so #1042/#1044/#1043 authors resolve `getCapabilityAdapter<ShopProductManagerPort>(id, 'ProductPublisher')` without confusion.
+2. **`'CategoryProvisioner'` as a first-class registry name** — unlike `OfferCreator` (a sub-capability NOT in `CoreCapabilityValues`), #1041 registers `CategoryProvisioner` as a name so the brain can resolve it independently and the FE can gate on it. Deliberate divergence from the OfferCreator precedent; fine.
+3. **Result naming** — plan uses `ProvisionCategoryResult`; ADR-024 §2 writes `CategoryProvisionResult`. Plan already records the alias in the type-file header. Cosmetic.
+
+## Summary
+
+The slice is a clean, additive contract-surface expansion with zero reuse collisions and zero
+backward-compat breaks. The umbrella `ShopProductManagerPort` + `CategoryProvisioner`
+sub-capability design matches the 20/20 base-port-anchored guard invariant and the names the
+already-merged category-resolution seam expects. Proceed to implementation.

--- a/docs/plans/implementation-plan-product-publisher-category-provisioner-capabilities.md
+++ b/docs/plans/implementation-plan-product-publisher-category-provisioner-capabilities.md
@@ -1,0 +1,241 @@
+# Implementation Plan — `ProductPublisher` + `CategoryProvisioner` capabilities (core)
+
+**Issue:** #1041 · Part of #1005 (cross-platform listing) · ADR-024 §1, §2, §3
+**Branch:** `1041-product-publisher-category-provisioner-capabilities`
+**Layer:** CORE (listings + integrations + sync contract surface only)
+
+---
+
+## 1. Understand the task
+
+Stand up the **contract surface** for shop-side product publishing — the keystone that
+unblocks #1042 (execution service), #1043 (WooCommerce adapter), #1044 (API/FE). This is
+the shop-listing sibling of the marketplace `OfferCreator` path (ADR-024).
+
+Deliver:
+- A base shop-listing **port** `ShopProductManagerPort` (`listings/domain/ports/`) — the
+  structural sibling of `OfferManagerPort`, carrying the one mandatory shop verb
+  `publishProduct(cmd)` — plus one **sub-capability** `CategoryProvisioner.provisionCategory(cmd)`
+  + `isCategoryProvisioner` guard under `listings/domain/ports/capabilities/`.
+- **Command/result + exception types**: `PublishProductCommand` / `PublishProductResult`
+  (multi-category, draft/published status, owned-record fields, price/stock as fields,
+  visibility); `ProvisionCategoryCommand` / `ProvisionCategoryResult`;
+  `ProductPublishRejectedException`.
+- Register `'ProductPublisher'` + `'CategoryProvisioner'` in `CoreCapabilityValues`.
+- Register `'shop.product.publish'` in `JobTypeValues` + a `ShopProductPublishPayloadV1`
+  payload type.
+- Barrel exports (`listings/index.ts`, `sync/index.ts`).
+
+**Non-goals (explicitly deferred to downstream issues):**
+- No `ProductPublishExecutionService`, worker handler, or persistence (#1042).
+- No WooCommerce adapter / manifest capability declaration (#1043).
+- No API controllers / DTOs / FE wizard (#1044).
+- No new DI **tokens** — capabilities are resolved through
+  `IntegrationsService.getCapabilityAdapter<T>` + guards, not injected. Tokens land with
+  the services in #1042. (The issue's "+ tokens" mention is satisfied at the service layer.)
+
+**Acceptance (from #1041):** capabilities resolve via `getCapabilityAdapter` + guards; the
+job type validates; barrels export cleanly; `pnpm type-check` green.
+
+---
+
+## 2. Research — patterns reused (verified in-repo)
+
+| Concern | Precedent file |
+|---|---|
+| Capability interface + `is*` guard | `listings/domain/ports/capabilities/offer-creator.capability.ts`; shipping `dispatch-protocol-reader.capability.ts` |
+| Command/result neutral types | `listings/domain/types/offer-create.types.ts` (`CreateOfferCommand/Result`) |
+| Rejection exception | `listings/domain/exceptions/offer-create-rejected.exception.ts` |
+| Capability-name registry | `integrations/domain/types/adapter.types.ts` (`CoreCapabilityValues`) |
+| Job type + payload | `sync/domain/types/sync-job.types.ts` (`JobTypeValues`) + `marketplace-job-payloads.types.ts` |
+| Resolve-then-guard usage | `offer-creation-execution.service.ts:106-110` — `getCapabilityAdapter<OfferManagerPort>(…, 'OfferManager')` then `isOfferCreator(adapter)` |
+
+**Safety checks done:** no `Record<JobType>` / `Record<CoreCapability>` exhaustive maps and
+no `assertNever` over job type / capability exist — both value additions are purely additive.
+`CoreCapabilityValues` feeds connection DTOs (`@IsIn`) — adding values only widens what is
+accepted (intended). The lone `assertNever` (`inbound-routing-policy.service.ts:157`) is over
+`event.domain`, unaffected.
+
+---
+
+## 3. Design
+
+### 3.1 Guard base-type decision — `ShopProductManagerPort` umbrella
+
+**Decided (tech-review ruling + product owner):** introduce a base shop-listing port
+`ShopProductManagerPort` as the structural **sibling of `OfferManagerPort`**, and make
+`CategoryProvisioner` a sub-capability guarded against it — mirroring
+`OfferManagerPort` + `isOfferCreator` exactly.
+
+Rejected alternative (Option A, original plan): two independent capabilities with
+`object`-param `is*` guards. Every one of the 20 capability guards in `libs/core` (16 in
+`listings`, 4 in `shipping`) narrows from a concrete base port; an `object`-param guard would
+be the first to break that invariant, and under by-name `getCapabilityAdapter<T>` resolution
+it rarely even fires. The umbrella keeps the guard pattern uniform and scales as the shop side
+grows more verbs (unpublish, `setVisibility`, status-read — ADR-024 §3 already foreshadows
+visibility as a first-class axis).
+
+**Shape (mirrors `OfferManagerPort`'s "one mandatory method + guarded sub-capabilities"):**
+- `ShopProductManagerPort` carries the **one mandatory** shop-listing verb
+  `publishProduct(cmd)` — the irreducible shop operation, exactly as `OfferManagerPort` carries
+  the mandatory `updateOfferQuantity`. A truly empty umbrella base is rejected by
+  `@typescript-eslint`'s no-empty-interface rule and would be a weaker model anyway.
+- `CategoryProvisioner` is the sub-capability:
+  `isCategoryProvisioner(adapter: ShopProductManagerPort): adapter is ShopProductManagerPort & CategoryProvisioner`.
+- #1042's execution service resolves `getCapabilityAdapter<ShopProductManagerPort>(id, 'ProductPublisher')`
+  and calls `isCategoryProvisioner(adapter)` to optionally provision — the exact resolve-then-guard
+  shape used by `offer-creation-execution.service.ts:106-110`. The ADR-023 brain may resolve
+  `getCapabilityAdapter<CategoryProvisioner>(id, 'CategoryProvisioner')` by name independently.
+
+**Capability names (`CoreCapabilityValues`):** add `'ProductPublisher'` and `'CategoryProvisioner'`
+per #1041. `'ProductPublisher'` is the operator/registry name that resolves a
+`ShopProductManagerPort` (it is what a shop adapter declares and what #1044's FE CTA gates on).
+
+**Documented consequence:** because `publishProduct` lives on the base port (mirroring
+`updateOfferQuantity` on `OfferManagerPort`), there is **no `product-publisher.capability.ts`**
+file, and the capability name `'ProductPublisher'` maps to interface `ShopProductManagerPort`
+(the one name↔interface skew in the contract — every other core capability is name-aligned).
+The skew is the cost of the umbrella and is documented in the `ShopProductManagerPort` header.
+
+### 3.2 `PublishProductCommand` shape (ADR-024 §1, §3)
+
+Expresses what `createOffer` cannot — multi-category, draft/published status, owned-record
+content fields, price/stock as product fields, visibility — and omits offer-only concepts
+(catalog-card link, required-param gate). Platform-specific fields ride in
+`platformParams: Record<string, unknown>` (same escape hatch as `CreateOfferOverrides`).
+
+```
+PublishProductStatusValues = ['draft', 'published'] as const   // §3 visibility axis
+PublishProductCommand {
+  internalVariantId: string
+  connectionId: string
+  destinationCategoryIds: string[]          // multi-category (§ADR-024 Woo)
+  price: { amount: number; currency: string }
+  stock: number                              // price/stock as product fields
+  status: PublishProductStatus               // draft | published (visibility decoupled from create)
+  content?: PublishProductContent            // owned-record fields (named type, not inline)
+  externalProductId?: string | null          // set → upsert; absent → create
+  idempotencyKey?: string
+  platformParams?: Record<string, unknown>   // projected attrs ride here (see note)
+}
+PublishProductContent {                      // extracted so the job payload can reference it
+  title?: string                             // without indexed-access coupling
+  description?: string | null
+  imageUrls?: string[] | null
+  seo?: { title?: string; description?: string | null; slug?: string }
+}
+PublishProductResult {
+  externalProductId: string
+  status: PublishProductStatus               // observed publication state after the call
+  warnings?: string[]                         // non-fatal (optional-attr omissions etc.)
+}
+```
+
+**Projected attributes are deliberately NOT a field on the command.** `ResolvedParameter`
+lives in `listings/application/types/` — referencing it from a `domain/types/` command would
+create a domain→application edge (hexagonal violation). The offer-side precedent confirms the
+shape: `CreateOfferCommand` (domain) carries no `ResolvedParameter`; the builder applies
+projected parameters (via `platformParams` / adapter-specific serialization). #1042's
+`ProductPublishBuilderService` does the same for the shop path, so the keystone command stays
+domain-pure and free of a premature near-duplicate.
+
+### 3.3 `ProvisionCategoryCommand` shape (ADR-024 §2)
+
+Mirror a source category path on the destination, create-if-missing (hierarchical), return
+the destination id.
+
+```
+ProvisionCategoryCommand {
+  connectionId: string
+  path: { sourceCategoryId: string; name: string }[]   // root→leaf, mirrored/created in order
+}
+ProvisionCategoryResult {
+  destinationCategoryId: string                          // resolved leaf id
+  createdPath?: string[]                                  // ids of nodes created this call (observability)
+}
+```
+
+> Naming note: ADR-024 §2's signature writes `CategoryProvisionResult`; the verb-first
+> `ProvisionCategoryCommand`/`ProvisionCategoryResult` pair (matching `CreateOfferCommand/Result`)
+> is used here — the ADR wording is the outlier and the file header records the alias.
+
+### 3.4 `ProductPublishRejectedException`
+
+Mirror `OfferCreateRejectedException` (adapterKey, statusCode, neutral message). Thrown by a
+shop adapter when the platform rejects a publish and no record was created. Reuses
+`CreateOfferValidationError` for the `errors[]` shape (no near-duplicate error type).
+
+### 3.5 `ShopProductPublishPayloadV1` (sync)
+
+New file `sync/domain/types/shop-job-payloads.types.ts` (shop ≠ marketplace taxonomy). Lean
+wire shape carrying what #1042's execution service needs to rebuild a `PublishProductCommand`;
+`connectionId` comes from `job.connectionId`, not the payload (matches
+`MarketplaceOfferCreatePayloadV1`).
+
+```
+ShopProductPublishPayloadV1 {
+  schemaVersion: 1
+  internalVariantId: string
+  status: PublishProductStatus
+  stock: number
+  price?: { amount: number; currency: string }
+  destinationCategoryIds?: string[]
+  content?: PublishProductContent
+  idempotencyKey?: string
+  listingCreationRecordId?: string            // optional; generalised record lands in #1042
+}
+```
+
+### Layer compliance
+Pure domain/contract types + interfaces; no framework imports, no I/O, no services. Cross-file
+imports stay within `@openlinker/core/listings` (top-level barrel) and same-context relative
+paths (`../../types/…`). `sync` payload value-imports `PublishProductStatus` from
+`@openlinker/core/listings` (sync already cross-imports listings for `CreateOfferOverrides`).
+
+---
+
+## 4. Step-by-step implementation
+
+| # | File | Action | Acceptance |
+|---|---|---|---|
+| 1 | `listings/domain/types/product-publish.types.ts` | **new** — `PublishProductStatusValues`/`PublishProductStatus`, `PublishProductContent`, `PublishProductCommand`, `PublishProductResult` | compiles; domain-pure (no application-layer imports) |
+| 2 | `listings/domain/types/category-provision.types.ts` | **new** — `ProvisionCategoryCommand`, `ProvisionCategoryResult` | compiles |
+| 3 | `listings/domain/ports/shop-product-manager.port.ts` | **new** — `ShopProductManagerPort` base port (mandatory `publishProduct`) | mirrors `offer-manager.port.ts`; header documents name↔interface skew |
+| 4 | `listings/domain/ports/capabilities/category-provisioner.capability.ts` | **new** — `CategoryProvisioner` iface + `isCategoryProvisioner` | guard narrows `ShopProductManagerPort → … & CategoryProvisioner` |
+| 5 | `listings/domain/exceptions/product-publish-rejected.exception.ts` | **new** — `ProductPublishRejectedException` | mirrors offer-create-rejected |
+| 6 | `listings/index.ts` | **edit** — export port + capability/guard + 3 type groups + exception | barrel-purity spec stays green |
+| 7 | `integrations/domain/types/adapter.types.ts` | **edit** — add `'ProductPublisher'`, `'CategoryProvisioner'` to `CoreCapabilityValues` | type-check green |
+| 8 | `sync/domain/types/shop-job-payloads.types.ts` | **new** — `ShopProductPublishPayloadV1` | compiles |
+| 9 | `sync/domain/types/sync-job.types.ts` | **edit** — add `'shop.product.publish'` to `JobTypeValues` (new `// Shop (cross-platform listing)` group) | type-check green |
+| 10 | `sync/index.ts` | **edit** — export `ShopProductPublishPayloadV1` | barrel exports cleanly |
+
+### Tests
+- `listings/domain/ports/capabilities/__tests__/category-provisioner.capability.spec.ts` —
+  guard true/false on a `ShopProductManagerPort` stub with/without `provisionCategory`
+  (mirrors existing capability specs in `__tests__/`).
+- `listings/domain/exceptions/__tests__/product-publish-rejected.exception.spec.ts` —
+  locks the neutral message format (singular/plural error count), the structured fields, and
+  the no-body-leak guarantee (added per the deep `/tech-review` coverage-parity suggestion).
+- `integrations/domain/types/__tests__/adapter.types.spec.ts` — extend to assert the two new
+  values are present in `CoreCapabilityValues` (file already exists).
+- `sync/domain/types/*` — add a small spec asserting `'shop.product.publish'` ∈ `JobTypeValues`
+  if a sibling spec convention exists; otherwise covered by type-check.
+
+### Quality gate
+`pnpm lint` · `pnpm type-check` · `pnpm test`. No migration (no ORM entity changed). No
+integration tests (no adapter/handler in scope).
+
+---
+
+## 5. Validation
+
+- **Architecture:** contract-only additions in the domain layer; honours CORE↔integration
+  boundary (no adapter, no platform string). Capability-presence model preserved.
+- **Naming:** `*.capability.ts` + `is{Capability}`, `*.types.ts`, `*.exception.ts` per
+  engineering-standards.
+- **`as const` unions:** `PublishProductStatusValues`, capability/job-type values all follow the
+  runtime-array + derived-union rule.
+- **Security:** no secrets; exception message carries no payload body (mirrors the
+  offer-create-rejected precedent).
+- **Risk:** very low — additive contract surface, no behavioural code path wired yet. A
+  half-built capability is inert until #1042/#1043 bind an adapter + handler.

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -68,7 +68,7 @@ port interfaces in `libs/core/src/<context>/domain/ports/`. An adapter
 implements one or more of them.
 
 The well-known set is `CoreCapabilityValues`, declared verbatim at
-[`libs/core/src/integrations/domain/types/adapter.types.ts:22-28`](../libs/core/src/integrations/domain/types/adapter.types.ts#L22-L28):
+[`libs/core/src/integrations/domain/types/adapter.types.ts:22-33`](../libs/core/src/integrations/domain/types/adapter.types.ts#L22-L33):
 
 ```typescript
 export const CoreCapabilityValues = [
@@ -77,6 +77,11 @@ export const CoreCapabilityValues = [
   'OrderProcessorManager',
   'OrderSource',
   'OfferManager',
+  // Shop-listing (cross-platform listing, ADR-024). 'ProductPublisher' resolves
+  // a `ShopProductManagerPort` (the base shop-listing port); 'CategoryProvisioner'
+  // is its provision sub-capability.
+  'ProductPublisher',
+  'CategoryProvisioner',
 ] as const;
 ```
 
@@ -87,6 +92,8 @@ export const CoreCapabilityValues = [
 | `OrderProcessorManager`| Order lifecycle on the destination shop (create / status).| [`libs/core/src/orders/domain/ports/order-processor-manager.port.ts`](../libs/core/src/orders/domain/ports/order-processor-manager.port.ts) |
 | `OrderSource`          | Cursor-based order-event ingestion.                       | [`libs/core/src/orders/domain/ports/order-source.port.ts`](../libs/core/src/orders/domain/ports/order-source.port.ts)               |
 | `OfferManager`         | Marketplace offer/listing management (split into sub-capabilities). | [`libs/core/src/listings/domain/ports/offer-manager.port.ts`](../libs/core/src/listings/domain/ports/offer-manager.port.ts)         |
+| `ProductPublisher`     | Shop product publishing — create/own the product record (base shop-listing port, sub-capabilities). | [`libs/core/src/listings/domain/ports/shop-product-manager.port.ts`](../libs/core/src/listings/domain/ports/shop-product-manager.port.ts) |
+| `CategoryProvisioner`  | Mirror/create a destination category tree (shop sub-capability).    | [`libs/core/src/listings/domain/ports/capabilities/category-provisioner.capability.ts`](../libs/core/src/listings/domain/ports/capabilities/category-provisioner.capability.ts) |
 
 **Open at the registry boundary (#576).** The set above is closed at
 the type-system level (`CoreCapability` union). At the registry

--- a/libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts
+++ b/libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts
@@ -13,7 +13,7 @@ import { CoreCapabilityValues } from '../adapter.types';
 
 describe('adapter.types', () => {
   describe('CoreCapabilityValues', () => {
-    it('should expose the documented five well-known capabilities', () => {
+    it('should expose the documented well-known capabilities', () => {
       // Guards against silent reordering or accidental additions/removals
       // of the published well-known set. If this fails, either the set
       // genuinely changed (update the test + arch doc) or someone extended
@@ -24,6 +24,9 @@ describe('adapter.types', () => {
         'OrderProcessorManager',
         'OrderSource',
         'OfferManager',
+        // Shop-listing (#1041, ADR-024)
+        'ProductPublisher',
+        'CategoryProvisioner',
       ]);
     });
   });

--- a/libs/core/src/integrations/domain/types/adapter.types.ts
+++ b/libs/core/src/integrations/domain/types/adapter.types.ts
@@ -25,6 +25,11 @@ export const CoreCapabilityValues = [
   'OrderProcessorManager',
   'OrderSource',
   'OfferManager',
+  // Shop-listing (cross-platform listing, ADR-024). 'ProductPublisher' resolves
+  // a `ShopProductManagerPort` (the base shop-listing port); 'CategoryProvisioner'
+  // is its provision sub-capability.
+  'ProductPublisher',
+  'CategoryProvisioner',
 ] as const;
 
 /**

--- a/libs/core/src/listings/domain/exceptions/__tests__/product-publish-rejected.exception.spec.ts
+++ b/libs/core/src/listings/domain/exceptions/__tests__/product-publish-rejected.exception.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Product Publish Rejected Exception — unit spec
+ *
+ * Locks the neutral message format (singular vs plural error count) and the
+ * structured fields core services persist (adapterKey, statusCode, errors), and
+ * asserts the message never embeds a request/response body (no secret leak).
+ *
+ * @module libs/core/src/listings/domain/exceptions/__tests__
+ */
+
+import type { CreateOfferValidationError } from '../../types/offer-create.types';
+import { ProductPublishRejectedException } from '../product-publish-rejected.exception';
+
+function makeError(code: string): CreateOfferValidationError {
+  return { code, message: `boom: ${code}` };
+}
+
+describe('ProductPublishRejectedException', () => {
+  it('exposes the structured fields and a stable name', () => {
+    const errors = [makeError('PARAMETER_REQUIRED')];
+    const ex = new ProductPublishRejectedException('woocommerce.restapi.v1', 422, errors);
+
+    expect(ex).toBeInstanceOf(Error);
+    expect(ex.name).toBe('ProductPublishRejectedException');
+    expect(ex.adapterKey).toBe('woocommerce.restapi.v1');
+    expect(ex.statusCode).toBe(422);
+    expect(ex.errors).toBe(errors);
+  });
+
+  it('uses the singular "error" form for exactly one error', () => {
+    const ex = new ProductPublishRejectedException('woocommerce.restapi.v1', 400, [
+      makeError('A'),
+    ]);
+    expect(ex.message).toBe(
+      'Shop woocommerce.restapi.v1 rejected product publish (status=400, 1 error)',
+    );
+  });
+
+  it('uses the plural "errors" form for zero or multiple errors', () => {
+    const none = new ProductPublishRejectedException('woocommerce.restapi.v1', 400, []);
+    expect(none.message).toBe(
+      'Shop woocommerce.restapi.v1 rejected product publish (status=400, 0 errors)',
+    );
+
+    const many = new ProductPublishRejectedException('woocommerce.restapi.v1', 422, [
+      makeError('A'),
+      makeError('B'),
+    ]);
+    expect(many.message).toBe(
+      'Shop woocommerce.restapi.v1 rejected product publish (status=422, 2 errors)',
+    );
+  });
+
+  it('does not embed validation-error detail in the message (no leak)', () => {
+    const ex = new ProductPublishRejectedException('woocommerce.restapi.v1', 422, [
+      makeError('SECRET_ish_detail'),
+    ]);
+    expect(ex.message).not.toContain('SECRET_ish_detail');
+    expect(ex.message).not.toContain('boom');
+  });
+});

--- a/libs/core/src/listings/domain/exceptions/product-publish-rejected.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/product-publish-rejected.exception.ts
@@ -1,0 +1,37 @@
+/**
+ * Product Publish Rejected Exception
+ *
+ * Neutral domain exception thrown by any shop adapter implementing
+ * `ShopProductManagerPort.publishProduct` when the destination rejects the
+ * publish and no product record was created or updated (e.g. a WooCommerce 4xx
+ * response). Carries the platform's validation errors mapped into the neutral
+ * `CreateOfferValidationError` shape so core services can persist them without
+ * depending on any specific integration package.
+ *
+ * Mirrors `OfferCreateRejectedException` (the marketplace-side analogue). The
+ * error message carries only the adapter key, status code, and error count —
+ * never the request/response body — so secrets can't leak through it.
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+
+import type { CreateOfferValidationError } from '../types/offer-create.types';
+
+export class ProductPublishRejectedException extends Error {
+  constructor(
+    /** Adapter key of the shop that rejected the publish (e.g. 'woocommerce.restapi.v1'). */
+    public readonly adapterKey: string,
+    /** HTTP status code when the rejection came from an API call. `0` for preflight validation. */
+    public readonly statusCode: number,
+    /** Neutral validation errors describing why the shop rejected the publish. */
+    public readonly errors: CreateOfferValidationError[],
+  ) {
+    super(
+      `Shop ${adapterKey} rejected product publish (status=${statusCode}, ${errors.length} error${
+        errors.length === 1 ? '' : 's'
+      })`,
+    );
+    this.name = 'ProductPublishRejectedException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/listings/domain/ports/capabilities/__tests__/category-provisioner.capability.spec.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/__tests__/category-provisioner.capability.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * Category Provisioner Capability — type guard spec
+ *
+ * Coverage for `isCategoryProvisioner(adapter)`: true when `provisionCategory`
+ * is a function on the `ShopProductManagerPort` adapter, false when absent, and
+ * false when the slot exists but is not callable. Mirrors
+ * `offer-manager-capabilities.spec.ts`.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities/__tests__
+ */
+
+import type { ShopProductManagerPort } from '../../shop-product-manager.port';
+import { isCategoryProvisioner } from '../category-provisioner.capability';
+
+function makeAdapter(extra: Record<string, unknown> = {}): ShopProductManagerPort {
+  return { publishProduct: jest.fn(), ...extra } as unknown as ShopProductManagerPort;
+}
+
+describe('isCategoryProvisioner', () => {
+  it('returns true when `provisionCategory` is a function', () => {
+    expect(isCategoryProvisioner(makeAdapter({ provisionCategory: jest.fn() }))).toBe(true);
+  });
+
+  it('returns false when `provisionCategory` is absent', () => {
+    expect(isCategoryProvisioner(makeAdapter())).toBe(false);
+  });
+
+  it('returns false when `provisionCategory` is present but non-function', () => {
+    expect(isCategoryProvisioner(makeAdapter({ provisionCategory: 'not a function' }))).toBe(false);
+  });
+});

--- a/libs/core/src/listings/domain/ports/capabilities/category-provisioner.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/category-provisioner.capability.ts
@@ -1,0 +1,39 @@
+/**
+ * Category Provisioner Capability
+ *
+ * Optional sub-capability of `ShopProductManagerPort` — shop adapters that can
+ * mirror a source category path onto the destination (creating missing nodes)
+ * declare `implements CategoryProvisioner`. Call sites narrow via
+ * `isCategoryProvisioner(adapter)` before invoking `provisionCategory`; after
+ * the guard TypeScript knows the method is present.
+ *
+ * This is ADR-023's placement step #1 made real (ADR-024 §2): only shops can
+ * *create* categories — marketplaces map into a fixed tree and never implement
+ * this. Distinct from `ProductMasterPort.assignCategories`, which attaches a
+ * product to already-existing categories rather than creating the tree.
+ *
+ * Mirrors the `OfferCreator` precedent (an optional capability guarded against
+ * the base `OfferManagerPort`) per engineering-standards §"Port sub-capabilities".
+ * The registry capability name is `'CategoryProvisioner'` (#1041) — unlike
+ * `OfferCreator`, it is a first-class name in `CoreCapabilityValues` so the
+ * ADR-023 resolution brain can resolve it independently and the FE can gate on
+ * it.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+
+import type {
+  ProvisionCategoryCommand,
+  ProvisionCategoryResult,
+} from '../../types/category-provision.types';
+import type { ShopProductManagerPort } from '../shop-product-manager.port';
+
+export interface CategoryProvisioner {
+  provisionCategory(cmd: ProvisionCategoryCommand): Promise<ProvisionCategoryResult>;
+}
+
+export function isCategoryProvisioner(
+  adapter: ShopProductManagerPort,
+): adapter is ShopProductManagerPort & CategoryProvisioner {
+  return typeof (adapter as Partial<CategoryProvisioner>).provisionCategory === 'function';
+}

--- a/libs/core/src/listings/domain/ports/shop-product-manager.port.ts
+++ b/libs/core/src/listings/domain/ports/shop-product-manager.port.ts
@@ -1,0 +1,47 @@
+/**
+ * Shop Product Manager Port
+ *
+ * Canonical capability contract for **shop** product listing/publishing — the
+ * structural sibling of `OfferManagerPort` on the shop side of ADR-024. Where a
+ * marketplace adapter lists a thin offer over a catalog card (`OfferManagerPort`
+ * + `OfferCreator`, …), a shop adapter creates/owns the product record itself
+ * (content, images, SEO, multi-category placement, price/stock as fields,
+ * draft/published visibility).
+ *
+ * Like `OfferManagerPort`, the base port carries only the one method every
+ * shop-listing adapter must implement: `publishProduct`. Additional shop
+ * behaviours (category provisioning today; unpublish / set-visibility /
+ * status-read as the surface grows) live as distinct capability interfaces
+ * under `./capabilities/`, declared via `implements` and narrowed at call sites
+ * with the co-located `is{Capability}` guards (e.g. `isCategoryProvisioner`).
+ *
+ * Capability name ↔ interface skew (documented once, here): the registry
+ * capability name for this port is **`'ProductPublisher'`** (what an adapter
+ * declares in `supportedCapabilities`, what `enabledCapabilities` carries, and
+ * what the FE CTA gates on — #1041/#1044), resolved as
+ * `getCapabilityAdapter<ShopProductManagerPort>(connectionId, 'ProductPublisher')`.
+ * The interface is named `ShopProductManagerPort` (the umbrella that accretes
+ * sub-capabilities) rather than `ProductPublisherPort`. This is the one place a
+ * core capability name diverges from its backing interface name; every other
+ * core capability is name-aligned.
+ *
+ * Domain-only: no framework dependencies.
+ *
+ * @module libs/core/src/listings/domain/ports
+ * @see {@link CategoryProvisioner} for the first sub-capability.
+ */
+
+import type {
+  PublishProductCommand,
+  PublishProductResult,
+} from '../types/product-publish.types';
+
+export interface ShopProductManagerPort {
+  /**
+   * Create-or-upsert a product record on the shop destination. Throws
+   * `ProductPublishRejectedException` when the shop rejects the publish and no
+   * record was created/updated; a non-throwing result means the
+   * `externalProductId` exists on the shop.
+   */
+  publishProduct(cmd: PublishProductCommand): Promise<PublishProductResult>;
+}

--- a/libs/core/src/listings/domain/types/category-provision.types.ts
+++ b/libs/core/src/listings/domain/types/category-provision.types.ts
@@ -1,0 +1,58 @@
+/**
+ * Category Provision Types
+ *
+ * Command and result types for mirroring a source category path onto a shop
+ * destination, creating any missing nodes, via
+ * `CategoryProvisioner.provisionCategory`. This is ADR-023's placement step #1
+ * made real (ADR-024 §2): only shops implement it — marketplaces map into a
+ * fixed tree and can never *create* a category. Distinct from
+ * `ProductMasterPort.assignCategories`, which only attaches a product to
+ * already-existing categories.
+ *
+ * Naming: the verb-first `ProvisionCategoryCommand`/`ProvisionCategoryResult`
+ * pair matches the `CreateOfferCommand`/`CreateOfferResult` precedent. ADR-024
+ * §2's signature writes `CategoryProvisionResult` — the verb-first name used
+ * here is canonical; the ADR wording is the outlier.
+ *
+ * @module libs/core/src/listings/domain/types
+ * @see {@link CategoryProvisioner} for the capability that consumes these.
+ */
+
+/**
+ * One node of a source category path, root → leaf.
+ */
+export interface ProvisionCategoryPathNode {
+  /** Source-platform category id (provenance-bearing; e.g. a PrestaShop category id). */
+  sourceCategoryId: string;
+  /** Human-readable node name, used to create the node on the destination if missing. */
+  name: string;
+}
+
+/**
+ * Command to mirror a source category path onto a shop destination,
+ * create-if-missing and hierarchical.
+ */
+export interface ProvisionCategoryCommand {
+  /** Target shop connection id. */
+  connectionId: string;
+  /**
+   * The category path to mirror, ordered root → leaf. The adapter walks the
+   * path, creating any node absent on the destination (e.g. WooCommerce
+   * `POST products/categories` with `parent`), and returns the leaf id.
+   */
+  path: ProvisionCategoryPathNode[];
+}
+
+/**
+ * Result returned by `CategoryProvisioner.provisionCategory`.
+ */
+export interface ProvisionCategoryResult {
+  /** Destination category id of the resolved leaf node. */
+  destinationCategoryId: string;
+  /**
+   * Destination ids of nodes that were created during this call (as opposed to
+   * matched to existing nodes). Observability only; omitted when nothing was
+   * created.
+   */
+  createdPath?: string[];
+}

--- a/libs/core/src/listings/domain/types/product-publish.types.ts
+++ b/libs/core/src/listings/domain/types/product-publish.types.ts
@@ -1,0 +1,115 @@
+/**
+ * Product Publish Types
+ *
+ * Command and result types for publishing a master catalog product onto a
+ * **shop** destination (WooCommerce, Shopify, …) via
+ * `ShopProductManagerPort.publishProduct`. The shop-listing sibling of
+ * `offer-create.types.ts`: where a marketplace `createOffer` lists a thin
+ * sell-record over a catalog card into a closed taxonomy, a shop publish
+ * creates/owns the product record itself — multi-category placement,
+ * draft/published status, owned-record content/images/SEO, and price/stock as
+ * product fields (ADR-024 §1, §3).
+ *
+ * Platform-specific fields (and projected category parameters, applied by the
+ * #1042 builder) ride in `platformParams` as an opaque record the adapter
+ * interprets — mirroring `CreateOfferOverrides.platformParams`. The command is
+ * deliberately free of the application-layer `ResolvedParameter` shape so it
+ * stays domain-pure (no domain→application edge).
+ *
+ * @module libs/core/src/listings/domain/types
+ * @see {@link ShopProductManagerPort} for the port that consumes these.
+ */
+
+/**
+ * Publication state of a shop product. Distinct from record existence and from
+ * data sync — a shop publish does not assume create ⇒ visible (ADR-024 §3:
+ * Woo `status` draft→publish; Shopify `status` + per-channel publish).
+ *
+ * - `draft`: record created/updated on the shop, not buyer-visible.
+ * - `published`: record live and visible on the storefront.
+ */
+export const PublishProductStatusValues = ['draft', 'published'] as const;
+export type PublishProductStatus = (typeof PublishProductStatusValues)[number];
+
+/**
+ * Owned-record content fields. Extracted as a named type (not inline on the
+ * command) so the `shop.product.publish` job payload can reference the same
+ * shape without indexed-access coupling.
+ *
+ * Fields typed `T | null | undefined` follow the `CreateOfferOverrides`
+ * convention: both `null` and `undefined` mean "no value supplied" and fall
+ * back to a value the builder derives from the master variant/product.
+ */
+export interface PublishProductContent {
+  /** Product title. Falls back to variant/product name. */
+  title?: string;
+  /** Product description (HTML or rich text). `null`/`undefined` → no override. */
+  description?: string | null;
+  /** Image URLs in display order. `null`/`undefined` → no override. */
+  imageUrls?: string[] | null;
+  /** SEO metadata for the storefront product page. */
+  seo?: {
+    title?: string;
+    description?: string | null;
+    slug?: string;
+  };
+}
+
+/**
+ * Command to publish (create-or-upsert) a product onto a shop destination.
+ *
+ * Shop-neutral contract. WooCommerce, Shopify, … adapters translate this into
+ * their platform-specific create/update product API call internally.
+ */
+export interface PublishProductCommand {
+  /** OL internal variant id being published. */
+  internalVariantId: string;
+  /** Target shop connection id. */
+  connectionId: string;
+  /**
+   * Destination category ids the product is placed under. Multiple, because
+   * shops (unlike marketplaces) allow multi-category placement (ADR-024 §1).
+   * Resolved/provisioned upstream by the ADR-023 placement chain +
+   * `CategoryProvisioner`.
+   */
+  destinationCategoryIds: string[];
+  /** Product price. Currency should match the shop/connection locale. */
+  price: { amount: number; currency: string };
+  /** Stock quantity, as a product/variant field on the shop. */
+  stock: number;
+  /** Target publication state (visibility is decoupled from record creation). */
+  status: PublishProductStatus;
+  /** Owned-record content fields (title, description, images, SEO). */
+  content?: PublishProductContent;
+  /**
+   * Shop-native product id when this is an upsert (already published). Absent /
+   * `null` → create a new product and map it. Resolved by the #1042 execution
+   * service via `IdentifierMapping`.
+   */
+  externalProductId?: string | null;
+  /** Optional idempotency key for deduplication at the adapter / job layer. */
+  idempotencyKey?: string;
+  /**
+   * Platform-specific fields the adapter interprets directly (tax class,
+   * shipping class, product type, projected category parameters, …). The
+   * core command stays platform-neutral; adapters read only the keys they know.
+   */
+  platformParams?: Record<string, unknown>;
+}
+
+/**
+ * Result returned by `ShopProductManagerPort.publishProduct`.
+ *
+ * A non-throwing response means the product record was successfully created or
+ * updated on the shop (the `externalProductId` exists). Adapters throw
+ * `ProductPublishRejectedException` only on rejections where no record was
+ * created/updated.
+ */
+export interface PublishProductResult {
+  /** Shop-native id of the created/updated product. */
+  externalProductId: string;
+  /** Observed publication state immediately after the publish call. */
+  status: PublishProductStatus;
+  /** Non-fatal warnings (e.g. an optional attribute the shop dropped). Omitted when empty. */
+  warnings?: string[];
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -278,5 +278,25 @@ export type {
 } from './domain/types/responsible-producer.types';
 export { ResponsibleProducerKindValues } from './domain/types/responsible-producer.types';
 
+// Shop-listing capabilities (#1041, ADR-024): the shop sibling of OfferManager.
+// `ShopProductManagerPort` is the base port (mandatory `publishProduct`, registry
+// name 'ProductPublisher'); `CategoryProvisioner` is its provision sub-capability.
+export type { ShopProductManagerPort } from './domain/ports/shop-product-manager.port';
+export type { CategoryProvisioner } from './domain/ports/capabilities/category-provisioner.capability';
+export { isCategoryProvisioner } from './domain/ports/capabilities/category-provisioner.capability';
+export { PublishProductStatusValues } from './domain/types/product-publish.types';
+export type {
+  PublishProductStatus,
+  PublishProductContent,
+  PublishProductCommand,
+  PublishProductResult,
+} from './domain/types/product-publish.types';
+export type {
+  ProvisionCategoryPathNode,
+  ProvisionCategoryCommand,
+  ProvisionCategoryResult,
+} from './domain/types/category-provision.types';
+export { ProductPublishRejectedException } from './domain/exceptions/product-publish-rejected.exception';
+
 // Tokens
 export * from './listings.tokens';

--- a/libs/core/src/sync/domain/types/shop-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/shop-job-payloads.types.ts
@@ -1,0 +1,54 @@
+/**
+ * Shop Job Payload Types (Generic)
+ *
+ * Canonical payload schemas for shop.* sync jobs — the shop-listing
+ * counterpart to `marketplace-job-payloads.types.ts`. Today: the
+ * `shop.product.publish` job (ADR-024) that publishes a master catalog product
+ * onto a shop destination (WooCommerce, Shopify, …). The job is executed by the
+ * #1042 worker handler; this file defines the wire shape only.
+ *
+ * @module libs/core/src/sync/domain/types
+ */
+
+import type {
+  PublishProductStatus,
+  PublishProductContent,
+} from '@openlinker/core/listings';
+
+/**
+ * Payload for `shop.product.publish` jobs (ADR-024).
+ *
+ * Lean wire shape carrying what the #1042 execution service needs to rebuild a
+ * `PublishProductCommand`. Connection id is taken from `job.connectionId`, not
+ * the payload (mirrors `MarketplaceOfferCreatePayloadV1`).
+ *
+ * `schemaVersion: 1` pins the contract. Future breaking changes bump
+ * `schemaVersion`; handlers must accept all versions they have seen in
+ * persisted jobs until the backlog is drained.
+ */
+export interface ShopProductPublishPayloadV1 {
+  schemaVersion: 1;
+  /** OL internal variant id being published. */
+  internalVariantId: string;
+  /** Target publication state (draft vs published). */
+  status: PublishProductStatus;
+  /** Stock quantity, as a product/variant field on the shop. */
+  stock: number;
+  /** Optional explicit price; when omitted the builder falls back to master product. */
+  price?: { amount: number; currency: string };
+  /**
+   * Destination category ids resolved/provisioned upstream by the ADR-023
+   * placement chain. Omitted when category placement is deferred / manual.
+   */
+  destinationCategoryIds?: string[];
+  /** Optional owned-record content overrides (title, description, images, SEO). */
+  content?: PublishProductContent;
+  /** Optional idempotency key forwarded to the adapter. */
+  idempotencyKey?: string;
+  /**
+   * Pre-created listing-record id, if the caller wanted the record visible
+   * before the job ran. When omitted, the #1042 execution service creates a
+   * fresh record. (The generalised listing-creation record lands in #1042.)
+   */
+  listingCreationRecordId?: string;
+}

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -33,6 +33,9 @@ export const JobTypeValues = [
 
   'master.variants.autoMatch',
 
+  // Shop (cross-platform listing, ADR-024; executed by worker)
+  'shop.product.publish',
+
   // Shipping (core-owned; capability-scoped, executed by worker)
   'shipping.pickupPoint.refreshFrequent',
 

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -80,6 +80,7 @@ export {
   MasterInventorySyncAllPayloadV1,
   MasterProductSyncAllPayloadV1,
 } from './domain/types/master-job-payloads.types';
+export { ShopProductPublishPayloadV1 } from './domain/types/shop-job-payloads.types';
 
 // Exceptions
 export { SyncJobExecutionError } from './domain/exceptions/sync-job-execution.error';

--- a/scripts/check-plugin-guide-quotes.mjs
+++ b/scripts/check-plugin-guide-quotes.mjs
@@ -49,8 +49,8 @@ const VERBATIM_QUOTES = [
     label: 'CoreCapabilityValues',
     sourceFile: 'libs/core/src/integrations/domain/types/adapter.types.ts',
     sourceStart: 22, // 1-indexed
-    sourceEnd: 28,
-    guideLinkSubstring: 'adapter.types.ts:22-28',
+    sourceEnd: 33,
+    guideLinkSubstring: 'adapter.types.ts:22-33',
     fenceOpen: '```typescript',
   },
 ];


### PR DESCRIPTION
## What & why

Stands up the **shop-side product-publishing contract surface** — the keystone of the cross-platform listing epic (#1005, ADR-024) that unblocks #1042 (execution service), #1043 (WooCommerce adapter), and #1044 (API/FE). Contract-only and **inert**: no adapter, handler, or persistence yet, so a half-built shop-publish path in `main` does nothing until a connection declares the capability.

The shop sibling of `OfferManagerPort` + `OfferCreator`:

- **`ShopProductManagerPort`** (`listings/domain/ports/shop-product-manager.port.ts`) — base shop-listing port with the one mandatory verb `publishProduct`, mirroring `OfferManagerPort` + `updateOfferQuantity`. The umbrella that future shop verbs (unpublish, set-visibility, status-read) hang off as sub-capabilities.
- **`CategoryProvisioner`** sub-capability + `isCategoryProvisioner` guard (narrows from `ShopProductManagerPort`, identical idiom to `isOfferCreator`). This is ADR-023's placement step #1 made real — only shops can *create* categories. The already-merged `category-resolution.service.ts` `tryProvision()` seam wires straight into it.
- **Types/exception**: `PublishProductCommand`/`Result`/`Status`/`Content` (multi-category, draft↔published visibility, owned-record content/SEO, price+stock as fields, create-vs-upsert), `ProvisionCategoryCommand`/`Result`, `ProductPublishRejectedException` (mirrors `OfferCreateRejectedException`).
- **Registry**: `'ProductPublisher'` + `'CategoryProvisioner'` → `CoreCapabilityValues`; `'shop.product.publish'` → `JobTypeValues` + `ShopProductPublishPayloadV1`.
- Barrels (`listings`, `sync`) + plugin-author-guide capability table kept in sync with the `check-plugin-guide-quotes` invariant.

## Design decisions

- **Umbrella over independent guards** (tech-review ruling): all 20 existing capability guards narrow from a concrete base port; an `object`-param guard would break that invariant. `ShopProductManagerPort` keeps the pattern uniform and scales as the shop side grows verbs.
- **Command stays domain-pure**: projected attributes ride `platformParams` (the `CreateOfferCommand` precedent) rather than referencing the application-layer `ResolvedParameter` — avoids a domain→application edge.
- **One documented name↔interface skew**: capability name `'ProductPublisher'` resolves interface `ShopProductManagerPort` (because `publishProduct` is the base method). Documented in the port header.

## Testing

`pnpm lint` (incl. all 13 invariants) ✅ · `pnpm type-check` (all packages) ✅ · `pnpm test` (10 packages, 3208 tests) ✅. No migration (no ORM entity touched). New specs: `category-provisioner.capability.spec.ts` (guard true/absent/non-function) + `product-publish-rejected.exception.spec.ts` (message format, fields, no-body-leak); `adapter.types.spec.ts` updated for the two new capability names.

## Process

Plan + pre-implement analysis committed alongside (`docs/plans/`). Ran `/plan` → `/pre-implement` (READY) → `/tech-review` (deep, ✅ Approve). Two forward-looking review suggestions (neutral `ListingValidationError` alias, shared money type) intentionally deferred to #1043.

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)