### PR TITLE
feat(listings): wire category + attribute projection into offer creation (#1039)

### DIFF
--- a/docs/architecture/adrs/023-cross-platform-category-and-attribute-projection.md
+++ b/docs/architecture/adrs/023-cross-platform-category-and-attribute-projection.md
@@ -169,6 +169,8 @@ The Allegro naming is welded through the vertical; neutralisation must cover all
 - `CategoryResolutionResult.allegroCategoryId` → `destinationCategoryId` (+ `provenance`).
 - API DTOs + the FE mapping editor and create-offer wizard.
 
+> **Addendum (2026-06-15, #1039) — parameter carriage.** Projected parameters travel as the neutral domain type `OfferParameter` (`{id, values?, valuesIds?, section}`) on the first-class `CreateOfferCommand.parameters` field — *not* through the opaque `overrides.platformParams` bag (reserved for un-modeled platform knobs: delivery policy id, invoice type, …). The offer/product **section split** and wire-key naming live **only** in the destination adapter (Allegro: `body.parameters[]` vs `productSet[].product.parameters[]`). The publish gate enforces **offer-section** required params at the core builder; **product-section** required params are deferred to the adapter / marketplace because Allegro catalog smart-link (#431/#808) and bulk self-link (#824) inherit them from the catalog card. The application-layer `ResolvedParameter` is an alias of `OfferParameter`. The FE wizard's transitional Allegro-shaped `platformParams.parameters`/`productParameters` channel collapses onto `CreateOfferCommand.parameters` in #1071; the shop-side `PublishProductCommand` adopts the same neutral channel in #1072.
+
 ## Storage
 
 **Category — evolve + migrate (real production rows exist):**

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-1039-wire-projection-offer-creation.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-1039-wire-projection-offer-creation.md
@@ -1,0 +1,41 @@
+# Pre-implement analysis: #1039 — Wire category + attribute projection into offer creation
+
+**Gated**: `docs/plans/implementation-plan-1039-wire-projection-offer-creation.md` · #1039
+**Date**: 2026-06-15
+**Verdict**: ✅ **READY**
+
+Read-only gate against the live worktree. No Critical findings; no contract break; no migration. One minor open question (type-alias vs distinct identical-shape type) and one documented transitional coupling, neither blocking.
+
+---
+
+## Reuse findings (Phase B)
+
+| Plan artifact | Verdict | Evidence |
+|---|---|---|
+| `OfferParameter` domain type (`listings/domain/types/offer-parameter.types.ts`) | **NEW (confirmed absent)** | No `OfferParameter` anywhere in `libs/ apps/`. Only `AllegroOfferParameter` (integration-isolated, `allegro/src/domain/types/allegro-api.types.ts:6`) and the application-layer `ResolvedParameter`. No domain-layer neutral offer-parameter type exists to reuse. |
+| `CategoryParameterSection` (referenced by new type) | **ALREADY EXISTS → reuse** | `listings/domain/types/category-parameter.types.ts:52-53` (`['offer','product']`); exported from barrel `index.ts:225,229`. |
+| `CreateOfferCommand.parameters?: OfferParameter[]` | **NEW field, additive** | `offer-create.types.ts:65` has no `parameters` field today; optional add is backward-compatible. |
+| `AttributeProjectionService` / `ATTRIBUTE_PROJECTION_SERVICE_TOKEN` | **ALREADY EXISTS → reuse** | Token `listings.tokens.ts:7`; provider `listings.module.ts:115,168-170`; same module as `OfferBuilderService` (`:121`) → constructor injection needs no barrel change. |
+| `CategoryResolutionService.resolveCategory(sourceCategoryIds)` | **ALREADY EXISTS → reuse** | accepts `sourceCategoryIds` post-#1037; no change. |
+| `business_failure` mapping | **ALREADY EXISTS → reuse** | `offer-creation-execution.service.ts:271,221` maps `OfferBuilderValidationException` → `Failed` → `business_failure`. No change. |
+| `Product.categories` / `ProductVariant.attributes` access | **ALREADY EXISTS → reuse** | both via `@openlinker/core/products` barrel already imported in `offer-builder.service.ts:26`; no new deep import. |
+
+## Backward-compat findings (Phase C)
+
+| Surface | Result | Severity |
+|---|---|---|
+| Top-level barrel `@openlinker/core/listings` | New `OfferParameter` export is a unique name; `ResolvedParameter` kept as alias → no duplicate/collision | ✅ none |
+| Port method signatures | No `*Port` signature changes (additive optional command field only) | ✅ none |
+| DTO shapes | No request/response DTO field removed/required/retyped | ✅ none |
+| Symbol tokens | No token removed/renamed; reuses `ATTRIBUTE_PROJECTION_SERVICE_TOKEN` | ✅ none |
+| ORM schema | No `*.orm-entity.ts` touched → **no migration** | ✅ none |
+| `check:invariants` | `OfferBuilderService implements IOfferBuilderService` unchanged (ctor dep is orthogonal to `check-service-interfaces`); no cross-context/deep-barrel import introduced | ✅ none |
+
+## Open questions (non-blocking)
+
+1. **`ResolvedParameter` = `OfferParameter` alias vs. two distinct identical-shape types.** The reuse probe flagged a *semantic* preference to keep them distinct (projection-output vs command-input). They are structurally identical and the projected output literally becomes `command.parameters`, so the alias is correct and lowest-churn; keeping them distinct is also acceptable. **Decision deferred to implementation** — either satisfies the gate. Recommendation: alias now, split later only if the shapes diverge.
+2. **Transitional dual-channel coupling.** Gate-2's "subtract operator-supplied param ids read from legacy `platformParams.parameters`/`productParameters`" makes the core builder read Allegro-shaped keys transitionally. Documented in the plan and slated for removal in **#1071** (FE migration collapses to the single neutral channel). Not a contract break; acceptable as a tracked transition.
+
+## Notes
+- Allegro is the **sole** live `createOffer` consumer (grep-verified) → the adapter-side change has a single consumer, minimal blast radius.
+- Follow-ups already filed: **#1071** (FE neutral-param migration + single-channel collapse), **#1072** (shop `PublishProductCommand` carriage unification).

--- a/docs/plans/implementation-plan-1039-wire-projection-offer-creation.md
+++ b/docs/plans/implementation-plan-1039-wire-projection-offer-creation.md
@@ -1,0 +1,146 @@
+# Implementation Plan: Wire category + attribute projection into offer creation (#1039)
+
+**Date**: 2026-06-15
+**Status**: Ready for Review
+**Estimated Effort**: ~1–1.5 days
+**Issue**: Closes #1039 · Epic #1005 · ADR-023 §1/§3/§5 · ADR-024 §Flow
+**Branch**: `1039-wire-projection-offer-creation`
+
+---
+
+## 1. Understand the task
+
+**Goal**: Make `OfferBuilderService` (core/listings) actually *use* the placement + projection machinery merged this week. Today it resolves the destination category **barcode-only** and **never projects attributes**, so the per-source-category mapping (#1037) and `AttributeProjectionService` (#1038/#1054) are dead on the real offer path.
+
+**Approach = the ADR-faithful end-state (D1-C), not the MVP shortcut.** Verified against ADR-023/024: both ADRs depict the pipeline currency as a **typed neutral parameter list** (ADR-023:156, ADR-024:89 `ResolvedParameter[]`), and ADR-023's Decision mandates **no platform strings/ids in core** + **all platform shaping in the adapter** (it rejected a per-platform projector "because adapters would hold no platform code"). `platformParams` appears in **zero** ADRs — its use as the projected-param carrier (PR #1070) is an unrecorded implementation compromise. So #1039 introduces the **first-class neutral channel** the ADRs draw, and records the carriage decision in ADR-023.
+
+**Layer**: CORE (new domain type + builder wiring) + a contained **Integration** change (Allegro adapter consumes the new channel) + a small **doc** edit (ADR-023 contract-surface note).
+
+**Non-goals (filed as follow-ups, see §6)**:
+- FE wizard still emits Allegro-shaped `platformParams.parameters`/`productParameters`; migrating it to the neutral channel + deleting `serializeAllegroParameters` + collapsing the adapter to a single channel → **follow-up issue**.
+- Unifying the shop `PublishProductCommand` onto the same neutral parameter channel (revisit #1070's `platformParams` carriage) → **follow-up issue**.
+- No mapping-authoring API/FE (#1044), no shop publish (#1041/#1042/#1043), no ERLI reuse (#1045), no migration.
+
+**Acceptance (from the issue)**:
+1. An Allegro offer with a mapped source category + dictionary attributes publishes with valid parameters.
+2. An unmapped required category/parameter yields `business_failure` carrying the unmapped keys.
+
+## Revisions (post tech-review)
+
+- **B1 (blocking, applied) — Gate-2 is scoped to `section === 'offer'` required params only.** Allegro's catalog smart-link (#431/#808) inherits **product-section** params (Brand/EAN/Model…) from the card and early-returns in the adapter (`allegro-offer-manager.adapter.ts:1562`), and the bulk path (#824) self-links every variant — so gating product-section required params at the builder would false-fail offers that succeed via card inheritance, **regressing shipped behavior**. Product-section required validation is deferred to the adapter / Allegro's `2xx`-with-`validationErrors`. To filter by section the builder needs section on each unresolved entry → `AttributeProjectionResult.unresolvedRequired` gains a `section` field (additive, populated owns-path only).
+- **I1 (applied) — the merge lives in the adapter, not the builder.** The builder sets `command.parameters = projected only` and reads operator **offer-param ids** (from `platformParams.parameters`) *only* for the Gate-2 subtraction. The Allegro adapter performs the actual merge of `cmd.parameters` with the legacy `platformParams.parameters/productParameters` (operator wins by id). No double-merge; core never un-shapes Allegro's offer/product split.
+- **I2 (applied) — typed guard, no `any`.** Reading operator param ids from `platformParams` uses an `isOfferParameterIdShape`-style narrowing, not `any`.
+- **I3 (applied) — full integration sweep.** Audit/adjust `listings-create-offer` + bulk int-specs for the new gate and run the **full** `pnpm test:integration`, not just the one slice.
+- **S1** — projection's schema fetch routes through the adapter's cached `fetchCategoryParameters` (24h TTL) — confirm, no raw fetch per offer.
+- **S3** — record the carriage decision in ADR-023 as a dated **addendum** line (don't rewrite the Accepted body).
+- **S4** — projection re-runs on retry (#742) against current mapping state — intended reconcile-forward; noted.
+
+---
+
+## 2. Research — verified surfaces
+
+| Surface | File | Status for #1039 |
+|---|---|---|
+| `OfferBuilderService.buildCreateOfferCommand` | `listings/application/services/offer-builder.service.ts:51` | barcode-only; no projection — **edit site** |
+| `OfferBuilderService.resolveCategory` | `…:144` | passes only `{connectionId, barcode}` — add `sourceCategoryIds` |
+| `CategoryResolutionService.resolveCategory` | `…/category-resolution.service.ts:54` | already accepts `sourceCategoryIds`, returns `{destinationCategoryId, provenance, method}` — no change |
+| `AttributeProjectionService.project` | `…/attribute-projection.service.ts:49` | returns `{parameters: ResolvedParameter[], unmappedSourceKeys, unresolvedRequired}` — **re-type output to domain `OfferParameter`** (alias keeps it source-compat) |
+| `ResolvedParameter` | `application/types/attribute-projection.types.ts:35` | referenced only inside listings (types + service + barrel) — safe to make an alias of the new domain type |
+| `OfferBuilderValidationException` | `domain/exceptions/offer-builder-validation.exception.ts` | `issues: {field,code,message}[]` — reuse for the parameter gate |
+| `OfferCreationExecutionService.mapBuilderException → recordToOutcome` | `…/offer-creation-execution.service.ts:271,221` | already maps `OfferBuilderValidationException` → `Failed` → `business_failure` — **no change** |
+| `Product.categories?: string[]` (#1034) | `products/domain/entities/product.entity.ts:38` | source ids; already fetched at `offer-builder.service.ts:75` |
+| `ProductVariant.attributes` | `products/domain/entities/product-variant.entity.ts:21` | projection input; already fetched at line 54 |
+| Allegro param consumption | `allegro-offer-manager.adapter.ts:1550` (`platformParams.parameters`), `:1621` (`platformParams.productParameters`); split done by FE `serializeAllegroParameters` | sole live `createOffer` consumer (grep-verified) |
+| Tokens / module | `listings.tokens.ts`, `listings.module.ts` | `ATTRIBUTE_PROJECTION_SERVICE_TOKEN` exists; `AttributeProjectionService` already a provider in `ListingsModule` (same module as `OfferBuilderService`) → injectable directly |
+
+**Verified**: Allegro is the **only** adapter implementing `createOffer`; the smart-link `unique` branch early-returns (`…:1562`) so product-section params are dropped (inherited from the card) while offer-section `body.parameters` still applies.
+
+---
+
+## 3. Design (D1-C — typed neutral channel, adapter is sole shaper)
+
+### 3.1 New canonical domain type
+`listings/domain/types/offer-parameter.types.ts`:
+```ts
+export interface OfferParameter {
+  id: string;             // owns-path: live CategoryParameter.id; pass-through: destinationParameterName
+  values?: string[];      // free-text / pass-through
+  valuesIds?: string[];   // resolved dictionary entry ids (owns + dictionary type)
+  section: CategoryParameterSection;   // neutral 'offer' | 'product'
+}
+```
+- `AttributeProjectionResult.parameters` re-typed to `OfferParameter[]`; the projection service imports the domain type (application→domain is allowed). `export type ResolvedParameter = OfferParameter` kept as a deprecated alias so the barrel + any in-flight PRs don't break.
+- This is the real answer to PR #1070's objection ("don't let the command reference an application type"): **model the concept in the domain**, don't hide it in an opaque bag.
+
+### 3.2 First-class command channel
+`CreateOfferCommand.parameters?: OfferParameter[]` (domain→domain, clean). `platformParams` is **no longer** the carrier for category parameters — it reverts to its documented role (un-modeled platform knobs: `deliveryPolicyId`, `invoice`, `handlingTime`, warranty ids).
+
+### 3.3 Builder flow (ADR-023: two gates; ADR-024:89 currency)
+```
+fetch variant → connection → masterConnectionId → productMaster.getProduct()
+  ↓
+resolveCategory({ connectionId, barcode, sourceCategoryIds: product.categories }) → categoryId
+  ↓
+push price issues
+  ↓
+GATE 1: issues (category null | price) → throw OfferBuilderValidationException        ← business_failure
+  ↓  (categoryId guaranteed non-null)
+project({ sourceConnectionId: masterConnectionId, destinationConnectionId: connectionId,
+          destinationCategoryId: categoryId, attributes: variant.attributes ?? {} })
+  ↓
+merge: projected OfferParameter[]  ⊕  operator-supplied (transitional: ids read from
+       legacy platformParams.parameters/productParameters) — operator wins by id
+  ↓
+GATE 2: required params still unpopulated after merge → throw OfferBuilderValidationException
+        (one issue per param: field `parameters.<name>`, code `PARAMETER_REQUIRED`)   ← business_failure
+  ↓
+unmappedSourceKeys → logger.warn (omit + warn; offer still publishes)
+  ↓
+command.parameters = merged OfferParameter[]
+```
+**Gate-2 correctness (the wizard hazard):** projection's `unresolvedRequired` is computed from mappings only and is blind to operator-supplied params. To avoid a false `business_failure` on a valid wizard offer, the builder **subtracts operator-supplied parameter ids** (read from the legacy `platformParams.parameters`/`productParameters` `id` fields — ids only, no shaping) from `unresolvedRequired` before gating. When no mappings AND no operator params exist, an offer with required params correctly fails (AC2); a wizard offer where the operator supplied them passes.
+
+### 3.4 Adapter = sole platform shaper
+`AllegroOfferManagerAdapter.applyPlatformParams` gains a consumer for `cmd.parameters`:
+- split by `section`: `'offer'` → `body.parameters[]`; `'product'` → `body.productSet[0].product.parameters[]` (inline path only — the `unique` smart-link branch still inherits product params from the card; **offer-section params from `cmd.parameters` are applied before the early-return**, mirroring today's `body.parameters`).
+- **transition merge**: legacy `platformParams.parameters`/`productParameters` (FE wizard) still read; operator-supplied wins by `id`. (Removed in the FE-migration follow-up.)
+- reuse `isAllegroOfferParameterShape` (it validates `id`/`values`/`valuesIds`; the extra `section` is ignored — stripped before attaching).
+
+### 3.5 ADR record
+Add a short note to **ADR-023 §Contract surface** (and a pointer from ADR-024): *projected/operator parameters travel as the neutral domain `OfferParameter[]` on `CreateOfferCommand.parameters`; the offer/product section split and wire-key naming live in the adapter; `platformParams` is reserved for un-modeled platform knobs.* Records the carriage decision that #1070 left implicit.
+
+---
+
+## 4. Step-by-step plan
+
+1. **`listings/domain/types/offer-parameter.types.ts`** — new domain `OfferParameter` + barrel export. *AC: domain type, no app import.*
+2. **`attribute-projection.types.ts`** — `parameters: OfferParameter[]`; `export type ResolvedParameter = OfferParameter` (deprecated alias). **`attribute-projection.service.ts`** — import the domain type. *AC: projection returns `OfferParameter[]`; existing spec passes unchanged.*
+3. **`offer-create.types.ts`** — add `CreateOfferCommand.parameters?: OfferParameter[]` with doc. *AC: additive, optional.*
+4. **`offer-builder.service.ts`** — inject `IAttributeProjectionService`; pass `sourceCategoryIds: product.categories` into `resolveCategory`; run projection after Gate 1; merge + Gate-2 (with operator-id subtraction); `logger.warn` unmapped; set `command.parameters`. *AC: AC1 + AC2; wizard offers with operator params don't false-fail Gate 2.*
+5. **`allegro-offer-manager.adapter.ts`** — consume `cmd.parameters`, section-split, transitional merge with legacy keys (operator wins by id), smart-link product-param note + offer-params-before-early-return. *AC: command with `cmd.parameters` emits valid offer+product params; legacy FE path unchanged; `unique` path inherits product params.*
+6. **Tests** — builder spec (sourceCategoryIds forwarded; projected → `command.parameters`; `unresolvedRequired` → `business_failure` with keys; operator-supplied subtracted from gate; unmapped → warn+build; projection not called when category null). Allegro adapter spec (`cmd.parameters` section-split; legacy precedence by id; `unique` drops product params, keeps offer params). Projection spec updated for the type alias (should be a no-op).
+7. **ADR-023** §Contract-surface note + ADR-024 pointer.
+8. **Quality gate** — rebuild libs (`pnpm -r --filter "./libs/**" build`), then `pnpm lint`, `pnpm type-check`, `pnpm --filter @openlinker/core test -- offer-builder attribute-projection`, `pnpm --filter @openlinker/integrations-allegro test -- offer-manager`, full `pnpm test`; `pnpm test:integration` listings create-offer slice. No migration.
+
+---
+
+## 5. Validation & Risks
+
+- **ADR fidelity** ✅ — typed neutral currency (ADR-023:156 / ADR-024:89); platform shaping confined to the adapter (ADR-023 Decision); `business_failure` reuse (ADR-007). Carriage decision now recorded.
+- **Risk — wizard false-fail (Gate 2)**: mitigated by operator-id subtraction (§3.3) + an explicit test.
+- **Risk — Allegro regressions**: dual-channel transition with operator-wins-by-id; smart-link `unique` product-param drop is asserted, not accidental.
+- **Risk — `ResolvedParameter` alias**: only internal references; alias keeps barrel + open PRs (#1070) compiling.
+- **Risk — `Product.categories` empty (pre-#1034 syncs)**: resolution → manual → null → Gate-1 `business_failure` with an actionable message (correct).
+- **Backward compat** ✅ — additive optional command field; no-mappings/no-attributes offers behave as today.
+
+## 6. Follow-up issues (filed)
+- **FE neutral parameter migration + single-channel collapse** — wizard emits neutral `OfferParameter[]` (section-tagged); delete `serializeAllegroParameters`; remove the legacy `platformParams.parameters`/`productParameters` path from the Allegro adapter so `cmd.parameters` is the sole channel. (Epic #1005, ADR-023/024.)
+- **Shop-side carriage unification** — `PublishProductCommand` carries the neutral `OfferParameter`/`ListingParameter` list instead of `platformParams` (revisit #1070); the offer and shop sides share one parameter channel. (Epic #1005, ADR-024.)
+
+## 7. Alignment checklist
+- [x] Hexagonal boundary respected — platform split stays in the adapter
+- [x] Reuses projection + resolution + `business_failure` plumbing; canonical neutral type modeled in domain
+- [x] Ports/tokens via Symbol injection
+- [x] No migration / no ORM change
+- [x] Tests cover both gates, the wizard-subtraction, the adapter split, smart-link behavior
+- [x] Carriage decision recorded in ADR-023; follow-ups filed for FE + shop unification

--- a/libs/core/src/listings/application/services/__tests__/attribute-projection.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/attribute-projection.service.spec.ts
@@ -118,7 +118,9 @@ describe('AttributeProjectionService', () => {
 
     const result = await service.project(input({ Color: 'Red' }));
 
-    expect(result.unresolvedRequired).toEqual([{ id: 'p-brand', name: 'Marka' }]);
+    expect(result.unresolvedRequired).toEqual([
+      { id: 'p-brand', name: 'Marka', section: 'offer' },
+    ]);
     expect(result.parameters).toEqual([]);
   });
 
@@ -137,7 +139,9 @@ describe('AttributeProjectionService', () => {
     const result = await service.project(input({ Color: 'Magenta' }));
 
     expect(result.parameters).toEqual([]);
-    expect(result.unresolvedRequired).toEqual([{ id: 'p-color', name: 'Kolor' }]);
+    expect(result.unresolvedRequired).toEqual([
+      { id: 'p-color', name: 'Kolor', section: 'offer' },
+    ]);
   });
 
   it('passes through name-keyed parameters when the destination does not own its taxonomy', async () => {

--- a/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
@@ -15,8 +15,13 @@ import { PRODUCTS_SERVICE_TOKEN } from '@openlinker/core/products';
 import type { IProductsService, ProductVariant } from '@openlinker/core/products';
 
 import { OfferBuilderService } from '../offer-builder.service';
-import { CATEGORY_RESOLUTION_SERVICE_TOKEN } from '../../../listings.tokens';
+import {
+  ATTRIBUTE_PROJECTION_SERVICE_TOKEN,
+  CATEGORY_RESOLUTION_SERVICE_TOKEN,
+} from '../../../listings.tokens';
 import type { ICategoryResolutionService } from '../../interfaces/category-resolution.service.interface';
+import type { IAttributeProjectionService } from '../../interfaces/attribute-projection.service.interface';
+import type { AttributeProjectionResult } from '../../types/attribute-projection.types';
 import { OfferBuilderValidationException } from '../../../domain/exceptions/offer-builder-validation.exception';
 import { MasterCatalogConnectionNotConfiguredException } from '../../../domain/exceptions/master-catalog-connection-not-configured.exception';
 
@@ -26,7 +31,14 @@ describe('OfferBuilderService', () => {
   let connectionPort: jest.Mocked<Pick<ConnectionPort, 'get'>>;
   let integrationsService: jest.Mocked<Pick<IIntegrationsService, 'getCapabilityAdapter'>>;
   let categoryResolution: jest.Mocked<Pick<ICategoryResolutionService, 'resolveCategory'>>;
+  let attributeProjection: jest.Mocked<IAttributeProjectionService>;
   let productMaster: { getProduct: jest.Mock };
+
+  const emptyProjection: AttributeProjectionResult = {
+    parameters: [],
+    unmappedSourceKeys: [],
+    unresolvedRequired: [],
+  };
 
   const VARIANT_ID = 'ol_variant_123';
   const MARKETPLACE_CONN_ID = 'conn-allegro';
@@ -78,6 +90,9 @@ describe('OfferBuilderService', () => {
           method: 'auto_detect',
         }),
     };
+    attributeProjection = {
+      project: jest.fn().mockResolvedValue(emptyProjection),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -86,6 +101,7 @@ describe('OfferBuilderService', () => {
         { provide: CONNECTION_PORT_TOKEN, useValue: connectionPort },
         { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
         { provide: CATEGORY_RESOLUTION_SERVICE_TOKEN, useValue: categoryResolution },
+        { provide: ATTRIBUTE_PROJECTION_SERVICE_TOKEN, useValue: attributeProjection },
       ],
     }).compile();
 
@@ -383,6 +399,174 @@ describe('OfferBuilderService', () => {
         'https://example.com/img1.jpg',
         'https://example.com/img2.jpg',
       ]);
+    });
+  });
+
+  describe('attribute projection (#1039)', () => {
+    it('forwards the master product categories as sourceCategoryIds to resolution', async () => {
+      productMaster.getProduct.mockResolvedValue({
+        id: 'ol_product_456',
+        name: 'Test Product',
+        sku: 'SKU-1',
+        description: 'desc',
+        price: 49.99,
+        currency: 'PLN',
+        images: ['https://example.com/img1.jpg'],
+        categories: ['ps-cat-15', 'ps-cat-22'],
+      });
+
+      await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+      });
+
+      expect(categoryResolution.resolveCategory).toHaveBeenCalledWith({
+        connectionId: MARKETPLACE_CONN_ID,
+        barcode: '5901234123457',
+        sourceCategoryIds: ['ps-cat-15', 'ps-cat-22'],
+      });
+    });
+
+    it('projects against the resolved category and puts the parameters on the command', async () => {
+      productsService.getVariant.mockResolvedValue({
+        ...(defaultVariant as unknown as Record<string, unknown>),
+        attributes: { Color: 'Red' },
+      } as unknown as ProductVariant);
+      attributeProjection.project.mockResolvedValue({
+        parameters: [{ id: '224017', valuesIds: ['11954'], section: 'product' }],
+        unmappedSourceKeys: [],
+        unresolvedRequired: [],
+      });
+
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+      });
+
+      expect(attributeProjection.project).toHaveBeenCalledWith({
+        sourceConnectionId: MASTER_CONN_ID,
+        destinationConnectionId: MARKETPLACE_CONN_ID,
+        destinationCategoryId: 'allegro-cat-999',
+        attributes: { Color: 'Red' },
+      });
+      expect(result.parameters).toEqual([
+        { id: '224017', valuesIds: ['11954'], section: 'product' },
+      ]);
+    });
+
+    it('omits the parameters field when projection yields none', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+      });
+
+      expect(result).not.toHaveProperty('parameters');
+    });
+
+    it('business_failures when an OFFER-section required param is unresolved', async () => {
+      attributeProjection.project.mockResolvedValue({
+        parameters: [],
+        unmappedSourceKeys: [],
+        unresolvedRequired: [{ id: 'cond-1', name: 'Stan', section: 'offer' }],
+      });
+
+      const error = await service
+        .buildCreateOfferCommand({
+          internalVariantId: VARIANT_ID,
+          connectionId: MARKETPLACE_CONN_ID,
+          stock: 1,
+        })
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(OfferBuilderValidationException);
+      expect((error as OfferBuilderValidationException).issues).toEqual([
+        expect.objectContaining({ field: 'parameters.Stan', code: 'PARAMETER_REQUIRED' }),
+      ]);
+    });
+
+    it('does NOT gate PRODUCT-section required params (deferred to adapter / card inheritance)', async () => {
+      attributeProjection.project.mockResolvedValue({
+        parameters: [],
+        unmappedSourceKeys: [],
+        unresolvedRequired: [{ id: 'brand-1', name: 'Marka', section: 'product' }],
+      });
+
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+      });
+
+      expect(result.internalVariantId).toBe(VARIANT_ID);
+    });
+
+    it('subtracts operator-supplied offer-param ids before gating (no false business_failure)', async () => {
+      attributeProjection.project.mockResolvedValue({
+        parameters: [],
+        unmappedSourceKeys: [],
+        unresolvedRequired: [{ id: 'cond-1', name: 'Stan', section: 'offer' }],
+      });
+
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+        overrides: { platformParams: { parameters: [{ id: 'cond-1', values: ['Nowy'] }] } },
+      });
+
+      expect(result.internalVariantId).toBe(VARIANT_ID);
+    });
+
+    it('builds and warns (no throw) when there are unmapped source keys', async () => {
+      const warnSpy = jest
+        .spyOn((service as unknown as { logger: { warn: jest.Mock } }).logger, 'warn')
+        .mockImplementation(() => undefined);
+      attributeProjection.project.mockResolvedValue({
+        parameters: [],
+        unmappedSourceKeys: ['Material', 'Pattern'],
+        unresolvedRequired: [],
+      });
+
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+      });
+
+      expect(result.internalVariantId).toBe(VARIANT_ID);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Material, Pattern'));
+    });
+
+    it('propagates a projection infra error (not swallowed → job retries)', async () => {
+      attributeProjection.project.mockRejectedValue(new Error('Allegro category-params fetch failed'));
+
+      await expect(
+        service.buildCreateOfferCommand({
+          internalVariantId: VARIANT_ID,
+          connectionId: MARKETPLACE_CONN_ID,
+          stock: 1,
+        })
+      ).rejects.toThrow('Allegro category-params fetch failed');
+    });
+
+    it('does not project when the category is unresolved (Gate 1 throws first)', async () => {
+      categoryResolution.resolveCategory.mockResolvedValue({
+        destinationCategoryId: null,
+        provenance: null,
+        method: 'manual',
+      });
+
+      await expect(
+        service.buildCreateOfferCommand({
+          internalVariantId: VARIANT_ID,
+          connectionId: MARKETPLACE_CONN_ID,
+          stock: 1,
+        })
+      ).rejects.toBeInstanceOf(OfferBuilderValidationException);
+      expect(attributeProjection.project).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/core/src/listings/application/services/attribute-projection.service.ts
+++ b/libs/core/src/listings/application/services/attribute-projection.service.ts
@@ -62,7 +62,7 @@ export class AttributeProjectionService implements IAttributeProjectionService {
     );
 
     const parameters: ResolvedParameter[] = [];
-    const unresolvedRequired: { id: string; name: string }[] = [];
+    const unresolvedRequired: AttributeProjectionResult['unresolvedRequired'] = [];
     const usedSourceKeys = new Set<string>();
 
     if (isCategoryParametersReader(adapter)) {
@@ -71,7 +71,9 @@ export class AttributeProjectionService implements IAttributeProjectionService {
         const mapping = this.findMappingForParameter(applicable, param.name);
         const sourceValue = mapping ? attributes[mapping.sourceAttributeKey] : undefined;
         if (!mapping || sourceValue === undefined || sourceValue === '') {
-          if (param.required) unresolvedRequired.push({ id: param.id, name: param.name });
+          if (param.required) {
+            unresolvedRequired.push({ id: param.id, name: param.name, section: param.section });
+          }
           continue;
         }
         usedSourceKeys.add(mapping.sourceAttributeKey);
@@ -79,7 +81,7 @@ export class AttributeProjectionService implements IAttributeProjectionService {
         if (resolved) {
           parameters.push(resolved);
         } else if (param.required) {
-          unresolvedRequired.push({ id: param.id, name: param.name });
+          unresolvedRequired.push({ id: param.id, name: param.name, section: param.section });
         }
       }
     } else {

--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -4,10 +4,20 @@
  * Assembles a platform-neutral `CreateOfferCommand` from an OL internal variant
  * id. Fetches variant metadata via `IProductsService`, resolves the parent
  * master product via `ProductMasterPort` (for name/description/images/price),
- * resolves the marketplace category via `ICategoryResolutionService`, and
- * validates required fields. Throws `OfferBuilderValidationException` with a
- * list of issues when anything is missing so callers can surface all problems
- * at once.
+ * resolves the marketplace category via `ICategoryResolutionService`
+ * (barcode → per-source-category mapping → manual, provenance-aware), projects
+ * the variant's attributes into neutral `OfferParameter[]` via
+ * `IAttributeProjectionService`, and validates required fields. Throws
+ * `OfferBuilderValidationException` with a list of issues when anything is
+ * missing so callers can surface all problems at once — `OfferCreationExecution`
+ * maps that to `business_failure` (ADR-007).
+ *
+ * Two publish gates (ADR-023 §5):
+ *  1. unresolved category / price → `business_failure`.
+ *  2. unresolved **offer-section** required parameters → `business_failure`.
+ *     Product-section required params are deferred to the adapter / marketplace
+ *     because Allegro catalog smart-link (#431/#808) inherits them from the
+ *     card; gating them here would false-fail card-linked / bulk (#824) offers.
  *
  * @module libs/core/src/listings/application/services
  * @implements {IOfferBuilderService}
@@ -18,7 +28,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
 import { CONNECTION_PORT_TOKEN, ConnectionPort } from '@openlinker/core/identifier-mapping';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
-import type { CreateOfferCommand } from '@openlinker/core/listings';
+import type { CreateOfferCommand, OfferParameter } from '@openlinker/core/listings';
 import type { ProductMasterPort } from '@openlinker/core/products';
 import {
   IProductsService,
@@ -28,7 +38,11 @@ import {
 import { MasterCatalogConnectionNotConfiguredException } from '../../domain/exceptions/master-catalog-connection-not-configured.exception';
 import type { OfferBuilderValidationIssue } from '../../domain/exceptions/offer-builder-validation.exception';
 import { OfferBuilderValidationException } from '../../domain/exceptions/offer-builder-validation.exception';
-import { CATEGORY_RESOLUTION_SERVICE_TOKEN } from '../../listings.tokens';
+import {
+  ATTRIBUTE_PROJECTION_SERVICE_TOKEN,
+  CATEGORY_RESOLUTION_SERVICE_TOKEN,
+} from '../../listings.tokens';
+import { IAttributeProjectionService } from '../interfaces/attribute-projection.service.interface';
 import { ICategoryResolutionService } from '../interfaces/category-resolution.service.interface';
 import type { IOfferBuilderService } from '../interfaces/offer-builder.service.interface';
 import type { BuildCreateOfferCommandInput } from '../types/offer-builder.types';
@@ -45,7 +59,9 @@ export class OfferBuilderService implements IOfferBuilderService {
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrationsService: IIntegrationsService,
     @Inject(CATEGORY_RESOLUTION_SERVICE_TOKEN)
-    private readonly categoryResolution: ICategoryResolutionService
+    private readonly categoryResolution: ICategoryResolutionService,
+    @Inject(ATTRIBUTE_PROJECTION_SERVICE_TOKEN)
+    private readonly attributeProjection: IAttributeProjectionService
   ) {}
 
   async buildCreateOfferCommand(input: BuildCreateOfferCommandInput): Promise<CreateOfferCommand> {
@@ -74,7 +90,11 @@ export class OfferBuilderService implements IOfferBuilderService {
     );
     const product = await productMaster.getProduct(variant.productId);
 
-    const categoryId = await this.resolveCategory(input, variant.ean ?? variant.gtin ?? null);
+    const categoryId = await this.resolveCategory(
+      input,
+      variant.ean ?? variant.gtin ?? null,
+      product.categories
+    );
     if (!categoryId) {
       issues.push({
         field: 'overrides.categoryId',
@@ -86,9 +106,21 @@ export class OfferBuilderService implements IOfferBuilderService {
 
     const price = this.resolvePrice(input, product, issues);
 
+    // Gate 1 — category / price. Throw before projection: projection needs a
+    // resolved category, and surfacing all field problems at once is the
+    // builder's contract.
     if (issues.length > 0) {
       throw new OfferBuilderValidationException(issues);
     }
+
+    // `categoryId` is guaranteed non-null here — Gate 1 pushed a `REQUIRED`
+    // issue and threw otherwise.
+    const parameters = await this.projectParameters(
+      input,
+      masterConnectionId,
+      categoryId as string,
+      variant.attributes ?? {}
+    );
 
     const title = input.overrides?.title ?? product.name;
     const description = input.overrides?.description ?? product.description;
@@ -123,6 +155,11 @@ export class OfferBuilderService implements IOfferBuilderService {
       publishImmediately: input.publishImmediately ?? false,
       overrides: Object.keys(cleanedOverrides).length > 0 ? cleanedOverrides : undefined,
       idempotencyKey: input.idempotencyKey,
+      // Neutral projected parameters (#1039). The adapter merges these with any
+      // operator-supplied `platformParams.parameters`/`productParameters` and
+      // shapes them to platform wire. Omitted when empty so offers with no
+      // mappable attributes keep their existing command shape.
+      ...(parameters.length > 0 ? { parameters } : {}),
       // #431 — smart-link by barcode. Pre-resolved here so adapters that
       // need it (Allegro) don't have to re-fetch the variant.
       variantBarcode: variant.ean ?? variant.gtin ?? null,
@@ -135,7 +172,7 @@ export class OfferBuilderService implements IOfferBuilderService {
     };
 
     this.logger.debug(
-      `Built CreateOfferCommand for variant=${input.internalVariantId} connection=${input.connectionId} categoryId=${categoryId ?? 'null'} productCardId=${command.productCardId ?? 'null'}`
+      `Built CreateOfferCommand for variant=${input.internalVariantId} connection=${input.connectionId} categoryId=${categoryId ?? 'null'} params=${parameters.length} productCardId=${command.productCardId ?? 'null'}`
     );
 
     return command;
@@ -143,19 +180,96 @@ export class OfferBuilderService implements IOfferBuilderService {
 
   private async resolveCategory(
     input: BuildCreateOfferCommandInput,
-    barcode: string | null
+    barcode: string | null,
+    sourceCategoryIds: string[] | undefined
   ): Promise<string | null> {
     if (input.overrides?.categoryId) {
       return input.overrides.categoryId;
     }
-    if (!barcode) {
+    const hasSourceCategories = sourceCategoryIds != null && sourceCategoryIds.length > 0;
+    // Nothing to resolve from: no override, no barcode, no source categories.
+    if (!barcode && !hasSourceCategories) {
       return null;
     }
     const result = await this.categoryResolution.resolveCategory({
       connectionId: input.connectionId,
       barcode,
+      // Only include when present so the call shape stays minimal (the chain
+      // treats an absent list the same as an empty one).
+      ...(hasSourceCategories ? { sourceCategoryIds } : {}),
     });
     return result.destinationCategoryId;
+  }
+
+  /**
+   * Project the variant's attributes into neutral `OfferParameter[]` and apply
+   * Gate 2 (offer-section required params). Returns the projected parameters
+   * for the command; the adapter merges them with operator-supplied params.
+   */
+  private async projectParameters(
+    input: BuildCreateOfferCommandInput,
+    sourceConnectionId: string,
+    destinationCategoryId: string,
+    attributes: Record<string, string>
+  ): Promise<OfferParameter[]> {
+    const projection = await this.attributeProjection.project({
+      sourceConnectionId,
+      destinationConnectionId: input.connectionId,
+      destinationCategoryId,
+      attributes,
+    });
+
+    // Gate 2 — offer-section required params only. Product-section required
+    // params are deferred to the adapter / marketplace (Allegro catalog-card
+    // inheritance, #431/#808; bulk self-link, #824). Operator-supplied
+    // offer-section params (FE wizard, carried on `platformParams.parameters`)
+    // satisfy the requirement, so subtract their ids before gating.
+    const operatorOfferParamIds = this.readOperatorOfferParamIds(input.overrides?.platformParams);
+    const blockingRequired = projection.unresolvedRequired.filter(
+      (param) => param.section === 'offer' && !operatorOfferParamIds.has(param.id)
+    );
+    if (blockingRequired.length > 0) {
+      throw new OfferBuilderValidationException(
+        blockingRequired.map((param) => ({
+          field: `parameters.${param.name}`,
+          code: 'PARAMETER_REQUIRED',
+          message: `Required offer parameter "${param.name}" (id=${param.id}) has no resolvable value; map the source attribute or supply it explicitly`,
+        }))
+      );
+    }
+
+    if (projection.unmappedSourceKeys.length > 0) {
+      this.logger.warn(
+        `Omitting ${projection.unmappedSourceKeys.length} unmapped source attribute(s) for variant=${input.internalVariantId} connection=${input.connectionId}: ${projection.unmappedSourceKeys.join(', ')}`
+      );
+    }
+
+    return projection.parameters;
+  }
+
+  /**
+   * Collect the ids of operator-supplied **offer-section** parameters from the
+   * (transitional) FE channel `platformParams.parameters`. Ids only, narrowed
+   * with a type guard — used solely to keep Gate 2 from false-failing a wizard
+   * offer whose required param the operator already supplied. Removed once the
+   * FE migrates to the neutral channel (#1071).
+   */
+  private readOperatorOfferParamIds(
+    platformParams: Record<string, unknown> | undefined
+  ): Set<string> {
+    const ids = new Set<string>();
+    const raw = platformParams?.['parameters'];
+    if (!Array.isArray(raw)) return ids;
+    for (const entry of raw) {
+      if (
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as { id?: unknown }).id === 'string'
+      ) {
+        ids.add((entry as { id: string }).id);
+      }
+    }
+    return ids;
   }
 
   private resolvePrice(

--- a/libs/core/src/listings/application/types/attribute-projection.types.ts
+++ b/libs/core/src/listings/application/types/attribute-projection.types.ts
@@ -9,6 +9,7 @@
  */
 
 import type { CategoryParameterSection } from '../../domain/types/category-parameter.types';
+import type { OfferParameter } from '../../domain/types/offer-parameter.types';
 
 /**
  * Projection input. `sourceConnectionId` selects the source-scoped attribute
@@ -26,28 +27,26 @@ export interface AttributeProjectionInput {
 /**
  * One projected destination parameter.
  *
- * `id` dual semantics: on the **owns** path it is the live `CategoryParameter.id`
- * (the destination's parameter identifier); on the **pass-through** path it is
- * the `destinationParameterName` (the adapter interprets, since no schema is
- * available to resolve an id). `valuesIds` carries resolved dictionary entry ids
- * (owns + dictionary type); `values` carries free-text / pass-through values.
+ * Alias of the canonical domain {@link OfferParameter} (#1039): projection is
+ * the producer, and its output travels verbatim on `CreateOfferCommand
+ * .parameters`. Kept as a named alias so existing projection-internal call
+ * sites read in projection terms while the command references the domain type
+ * directly (no domain→application edge).
  */
-export interface ResolvedParameter {
-  id: string;
-  values?: string[];
-  valuesIds?: string[];
-  section: CategoryParameterSection;
-}
+export type ResolvedParameter = OfferParameter;
 
 /**
  * Projection result. `parameters` are ready for the adapter to serialize;
  * `unmappedSourceKeys` are present source attributes that didn't reach the
  * destination (no mapping, or mapped to a parameter absent from the category);
  * `unresolvedRequired` are required destination parameters that couldn't be
- * populated — the publish gate (#1039) consumes these.
+ * populated — the publish gate (#1039) consumes these. `section` lets the gate
+ * enforce **offer-section** required params at the builder while deferring
+ * product-section ones to the adapter / marketplace (Allegro catalog-card
+ * inheritance, #431/#808).
  */
 export interface AttributeProjectionResult {
   parameters: ResolvedParameter[];
   unmappedSourceKeys: string[];
-  unresolvedRequired: { id: string; name: string }[];
+  unresolvedRequired: { id: string; name: string; section: CategoryParameterSection }[];
 }

--- a/libs/core/src/listings/domain/types/offer-create.types.ts
+++ b/libs/core/src/listings/domain/types/offer-create.types.ts
@@ -10,6 +10,8 @@
  * @module libs/core/src/listings/domain/types
  */
 
+import type { OfferParameter } from './offer-parameter.types';
+
 /**
  * Overrides for fields that can optionally be customized per-offer.
  * Any field omitted here falls back to a value derived by the core builder
@@ -75,6 +77,19 @@ export interface CreateOfferCommand {
   publishImmediately: boolean;
   /** Optional overrides and platform-specific fields. */
   overrides?: CreateOfferOverrides;
+  /**
+   * Neutral, section-tagged offer/category parameters (#1039, ADR-023 §3 /
+   * ADR-024 §Flow) — produced in core by attribute projection (and, in the
+   * end-state, operator picks). The destination adapter is the **only** place
+   * that shapes these to platform wire: Allegro splits by `section` into
+   * `body.parameters[]` (offer) vs `productSet[].product.parameters[]`
+   * (product); a borrows/open destination maps them to its own param shape.
+   *
+   * Distinct from `overrides.platformParams`, which carries un-modeled
+   * platform knobs (delivery policy id, invoice type, …) the adapter reads
+   * by key. Absent/empty ⇒ no projected parameters for this offer.
+   */
+  parameters?: OfferParameter[];
   /** Optional idempotency key for deduplication at the adapter / job layer. */
   idempotencyKey?: string;
   /**

--- a/libs/core/src/listings/domain/types/offer-parameter.types.ts
+++ b/libs/core/src/listings/domain/types/offer-parameter.types.ts
@@ -1,0 +1,34 @@
+/**
+ * Offer Parameter Type
+ *
+ * Neutral, section-tagged marketplace offer/category parameter — the canonical
+ * domain shape that travels on `CreateOfferCommand.parameters` (#1039, ADR-023
+ * §3 / ADR-024 §Flow). Produced by core (attribute projection + operator
+ * picks); shaped to platform wire **only** in the destination adapter (Allegro
+ * splits by `section` into `body.parameters[]` vs `productSet[].product
+ * .parameters[]`; a borrows/open destination maps it to its own param shape).
+ *
+ * Modelled in the domain (not carried through the opaque `platformParams` bag)
+ * so `CreateOfferCommand` can reference it without a domain→application edge —
+ * the application-layer `ResolvedParameter` is an alias of this type.
+ *
+ * @module libs/core/src/listings/domain/types
+ * @see {@link CategoryParameterSection} for the offer/product axis
+ */
+
+import type { CategoryParameterSection } from './category-parameter.types';
+
+export interface OfferParameter {
+  /**
+   * Destination parameter identifier. On the **owns** path this is the live
+   * `CategoryParameter.id`; on the **borrows/open** pass-through path it is the
+   * destination parameter name the adapter interprets.
+   */
+  id: string;
+  /** Free-text / pass-through values. */
+  values?: string[];
+  /** Resolved dictionary entry ids (owns path + dictionary-typed parameter). */
+  valuesIds?: string[];
+  /** Neutral offer/product axis; the adapter buckets the wire payload on it. */
+  section: CategoryParameterSection;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -168,6 +168,7 @@ export type {
   CreateOfferResultStatus,
   CreateOfferValidationError,
 } from './domain/types/offer-create.types';
+export type { OfferParameter } from './domain/types/offer-parameter.types';
 export type { SellerPolicy, SellerPolicies } from './domain/types/seller-policies.types';
 export { OfferCreateRejectedException } from './domain/exceptions/offer-create-rejected.exception';
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -1211,6 +1211,71 @@ describe('AllegroOfferManagerAdapter', () => {
       expect(body).not.toHaveProperty('unknownField');
     });
 
+    it('splits neutral cmd.parameters by section into offer + product params (#1039)', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-neutral', publication: { status: 'INACTIVE' } })
+      );
+
+      await adapter.createOffer({
+        ...baseCmd,
+        parameters: [
+          { id: 'cond-1', values: ['Nowy'], section: 'offer' },
+          { id: '248811', valuesIds: ['248811_canon'], section: 'product' },
+        ],
+      });
+
+      const body = httpClient.post.mock.calls[0][1] as {
+        parameters?: Array<{ id: string }>;
+        productSet?: Array<{ product?: { parameters?: Array<{ id: string }> } }>;
+      };
+      // Offer-section → body.parameters; section field stripped to wire shape.
+      expect(body.parameters).toEqual([{ id: 'cond-1', values: ['Nowy'] }]);
+      // Product-section → productSet[0].product.parameters (inline path).
+      expect(body.productSet?.[0]?.product?.parameters).toEqual([
+        { id: '248811', valuesIds: ['248811_canon'] },
+      ]);
+    });
+
+    it('lets operator-supplied platformParams win by id over projected cmd.parameters (#1039)', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-merge', publication: { status: 'INACTIVE' } })
+      );
+
+      await adapter.createOffer({
+        ...baseCmd,
+        parameters: [{ id: 'cond-1', values: ['Projected'], section: 'offer' }],
+        overrides: {
+          ...baseCmd.overrides,
+          platformParams: { parameters: [{ id: 'cond-1', values: ['Operator'] }] },
+        },
+      });
+
+      const body = httpClient.post.mock.calls[0][1] as { parameters?: Array<{ values?: string[] }> };
+      expect(body.parameters).toEqual([{ id: 'cond-1', values: ['Operator'] }]);
+    });
+
+    it('lets operator productParameters win by id over projected product params (#1039)', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-prod-merge', publication: { status: 'INACTIVE' } })
+      );
+
+      await adapter.createOffer({
+        ...baseCmd,
+        parameters: [{ id: '248811', valuesIds: ['projected_brand'], section: 'product' }],
+        overrides: {
+          ...baseCmd.overrides,
+          platformParams: { productParameters: [{ id: '248811', valuesIds: ['operator_brand'] }] },
+        },
+      });
+
+      const body = httpClient.post.mock.calls[0][1] as {
+        productSet?: Array<{ product?: { parameters?: Array<{ valuesIds?: string[] }> } }>;
+      };
+      expect(body.productSet?.[0]?.product?.parameters).toEqual([
+        { id: '248811', valuesIds: ['operator_brand'] },
+      ]);
+    });
+
     it('omits afterSalesServices entirely when impliedWarrantyId is set but warrantyId, returnPolicyId are not (#406)', async () => {
       httpClient.post.mockResolvedValue(
         mockHttpResponse({ id: 'allegro-offer-iwar-only', publication: { status: 'INACTIVE' } })

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -40,6 +40,7 @@ import type {
   UpdateOfferQuantityCommand,
   UpdateOfferFieldsCommand,
   CreateOfferCommand,
+  OfferParameter,
   CreateOfferResult,
   CreateOfferResultStatus,
   CreateOfferValidationError,
@@ -1501,14 +1502,46 @@ export class AllegroOfferManagerAdapter
     // ensures `this.sellerDefaults` is defined by the time we get here).
     body.location = { ...this.sellerDefaults!.location };
 
-    this.applyPlatformParams(body, platformParams, cardLinkResult);
+    this.applyPlatformParams(body, platformParams, cmd.parameters, cardLinkResult);
 
     return body;
+  }
+
+  /**
+   * Merge core-projected neutral parameters (#1039) with the operator-supplied
+   * legacy `platformParams.parameters`/`productParameters` (FE wizard) for one
+   * section, keyed by parameter `id`. **Operator-supplied wins** — a manual
+   * pick overrides a projected value for the same parameter. The neutral
+   * `section` field is dropped here (the offer/product split is the caller's
+   * concern); the result is the Allegro wire shape.
+   *
+   * Transitional: once the FE emits the neutral channel (#1071) the legacy
+   * `legacyRaw` source disappears and this collapses to a passthrough.
+   */
+  private mergeSectionParameters(
+    projected: readonly OfferParameter[],
+    legacyRaw: unknown
+  ): AllegroOfferParameter[] {
+    const byId = new Map<string, AllegroOfferParameter>();
+    for (const param of projected) {
+      byId.set(param.id, {
+        id: param.id,
+        ...(param.values ? { values: param.values } : {}),
+        ...(param.valuesIds ? { valuesIds: param.valuesIds } : {}),
+      });
+    }
+    if (Array.isArray(legacyRaw)) {
+      for (const entry of legacyRaw) {
+        if (isAllegroOfferParameterShape(entry)) byId.set(entry.id, entry);
+      }
+    }
+    return Array.from(byId.values());
   }
 
   private applyPlatformParams(
     body: AllegroProductOfferCreateRequest,
     platformParams: Record<string, unknown>,
+    projectedParameters: readonly OfferParameter[] | undefined,
     cardLinkResult: ResolveProductCardResult
   ): void {
     const deliveryPolicyId = platformParams['deliveryPolicyId'];
@@ -1547,9 +1580,17 @@ export class AllegroOfferManagerAdapter
       body.payments = { invoice };
     }
 
-    const parameters = platformParams['parameters'];
-    if (Array.isArray(parameters)) {
-      body.parameters = parameters.filter(isAllegroOfferParameterShape);
+    // Offer-section parameters: core-projected (#1039) merged with the legacy
+    // FE `platformParams.parameters` (operator wins by id). Applied before the
+    // smart-link short-circuit so card-linked offers still carry offer-section
+    // params (the card only supplies product-section ones).
+    const offerProjected = (projectedParameters ?? []).filter((p) => p.section === 'offer');
+    const offerParameters = this.mergeSectionParameters(
+      offerProjected,
+      platformParams['parameters']
+    );
+    if (offerParameters.length > 0) {
+      body.parameters = offerParameters;
     }
 
     // #431 — smart-link short-circuit. When the variant's EAN uniquely
@@ -1618,10 +1659,15 @@ export class AllegroOfferManagerAdapter
     // needed at this site. Keeping a single sanitization point per request
     // lifecycle avoids "why is this being sanitized — wasn't it already?"
     // reader confusion.
-    const productParameters = platformParams['productParameters'];
-    const filtered = Array.isArray(productParameters)
-      ? productParameters.filter(isAllegroOfferParameterShape)
-      : [];
+    // Product-section parameters: core-projected (#1039) merged with the legacy
+    // FE `platformParams.productParameters` (operator wins by id). Reached only
+    // on the inline-product path — the `unique` smart-link branch above
+    // early-returned, inheriting product params from the catalog card.
+    const productProjected = (projectedParameters ?? []).filter((p) => p.section === 'product');
+    const filtered = this.mergeSectionParameters(
+      productProjected,
+      platformParams['productParameters']
+    );
     // `parameters` is attached only when the operator supplied any — Allegro
     // rejects an explicit empty array on inline products. Spread-with-conditional
     // keeps the construction declarative and avoids a post-create mutation.


### PR DESCRIPTION
## What & why

Part of #1005 · ADR-023 §1/§3/§5 · ADR-024 §Flow. Turns on the placement + projection machinery merged this week (#1037 chain, #1038/#1054 projection, #1034 `Product.categories`): until now `OfferBuilderService` resolved the destination category **barcode-only** and **never projected attributes**, so the per-source-category mapping fallback and `AttributeProjectionService` were dead on the real offer path.

Implements the **ADR-faithful** carriage (not the MVP shortcut): projected parameters travel as a neutral domain `OfferParameter` on the first-class `CreateOfferCommand.parameters` field — the typed currency ADR-023:156 / ADR-024:89 depict — **not** through the opaque `platformParams` bag. The Allegro adapter is the **sole** platform-shaper.

## Changes

- **`OfferParameter`** — new neutral domain type (`{id, values?, valuesIds?, section}`); the application-layer `ResolvedParameter` becomes its alias. `CreateOfferCommand.parameters?: OfferParameter[]` added (additive/optional).
- **`OfferBuilderService`** — feeds `sourceCategoryIds: product.categories` into category resolution; projects the variant's attributes after the category resolves; sets `command.parameters`. Two publish gates (ADR-023 §5):
  1. unresolved category / price → `business_failure`;
  2. unresolved **offer-section** required params → `business_failure` carrying the unmapped keys.
- **Allegro adapter** — consumes `cmd.parameters`, splits by `section` into `body.parameters[]` (offer) / `productSet[].product.parameters[]` (product), and merges with the legacy FE `platformParams.parameters`/`productParameters` (**operator wins by id**). Offer-section params are applied **before** the smart-link early-return.
- ADR-023 dated addendum records the carriage decision. Follow-ups filed: **#1071** (FE neutral-param migration + single-channel collapse), **#1072** (shop-side `PublishProductCommand` unification).

## Design note — the B1 gate scoping (important)

Gate-2 enforces **offer-section** required params only. **Product-section** required params are deferred to the adapter / marketplace, because Allegro catalog smart-link (#431/#808) and bulk self-link (#824) **inherit product params from the catalog card** — gating them at the builder would false-fail card-linked / bulk offers. The adapter's `unique` smart-link branch already early-returns without product params (inherited), while offer-section params still flow. `unresolvedRequired` gained a `section` field to make this distinction.

## Behavior changes to be aware of

- **Projection now runs on every Allegro offer build** (including the single-offer wizard). On the owns-path it does a category-params fetch — the **cached** `fetchCategoryParameters` (24h TTL, connection-scoped), so it's a network call only on first-use-per-category; transients are retryable (infra error → job retry). New build-time dependency, consciously accepted per ADR-023 (publish-time projection).
- **Required offer-section params that have no source attribute (Allegro "Stan"/condition) are operator-supply-only.** Verified safe: the bulk path threads operator `platformParams` (`bulk-listing-submit.service.ts:386`) and the FE wizard collects/validates required params → they arrive on `platformParams.parameters` and Gate-2 subtracts them. Only an API-direct submit that omits a required offer param newly hard-fails — which is AC2's intended `business_failure`. #1071's FE migration must preserve collecting these.
- A configured attribute mapping can now **auto-fill** a projected param the operator didn't pick on the wizard path (operator-wins-by-id, so strictly additive).

## How tested

- `pnpm lint` (0 errors; all 13 invariants) ✅ · `pnpm type-check` ✅ · `pnpm test` (full unit suite, 0 failures) ✅.
- New unit coverage: `offer-builder.service.spec` — `sourceCategoryIds` forwarding, projected→`command.parameters`, offer-section required→`business_failure`, operator-id subtraction, **product-section required NOT gated**, unmapped→warn, projection-infra-error propagation, no-project-when-category-null. `allegro-offer-manager.adapter.spec` — section split, operator-wins-by-id for **both** sections.
- No migration (no ORM entity touched). Integration: no listings int-spec exercises the build path (`listings-create-offer` tests the status-poll GET only); CI runs the full suite.

Closes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)