### PR TITLE
feat(listings): shop publish execution service + worker handler + persistence (#1042, #1072)

### DIFF
--- a/apps/api/src/migrations/1806000000000-add-listing-creation-records-table.ts
+++ b/apps/api/src/migrations/1806000000000-add-listing-creation-records-table.ts
@@ -1,0 +1,78 @@
+/**
+ * Add Listing Creation Records Table Migration
+ *
+ * Creates the `listing_creation_records` table tracking OL-initiated product
+ * publish attempts on shop destinations (OL → WooCommerce / Shopify, #1042,
+ * ADR-024). The shop-side sibling of `offer_creation_records`; a separate table
+ * keeps the hot marketplace offer path untouched. Lifecycle state
+ * (pending / draft / published / failed) and structured errors are queryable
+ * and indexed without polluting the generic identifier mapping table.
+ *
+ * Generated: 2026-06-15 (synthetic sequential prefix per docs/migrations.md #1013).
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddListingCreationRecordsTable1806000000000 implements MigrationInterface {
+  name = 'AddListingCreationRecordsTable1806000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+
+    const table = await queryRunner.getTable('listing_creation_records');
+
+    if (!table) {
+      await queryRunner.query(`
+        CREATE TABLE "listing_creation_records" (
+          "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+          "internalVariantId" text NOT NULL,
+          "connectionId" uuid NOT NULL,
+          "externalProductId" text,
+          "status" text NOT NULL,
+          "errors" jsonb,
+          "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+          "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+          CONSTRAINT "PK_listing_creation_records" PRIMARY KEY ("id")
+        )
+      `);
+
+      await queryRunner.query(`
+        CREATE INDEX "IDX_listing_creation_records_variant_connection"
+          ON "listing_creation_records" ("internalVariantId", "connectionId")
+      `);
+
+      await queryRunner.query(`
+        CREATE INDEX "IDX_listing_creation_records_connectionId"
+          ON "listing_creation_records" ("connectionId")
+      `);
+
+      await queryRunner.query(`
+        CREATE INDEX "IDX_listing_creation_records_status"
+          ON "listing_creation_records" ("status")
+      `);
+
+      // Partial composite index for `findByExternalProductIdAndConnectionId`.
+      // `WHERE "externalProductId" IS NOT NULL` keeps pending rows (null external
+      // id) out of the index. Name matches the ORM entity's explicit @Index.
+      await queryRunner.query(`
+        CREATE INDEX "IDX_listing_creation_records_external_product_connection"
+          ON "listing_creation_records" ("externalProductId", "connectionId")
+          WHERE "externalProductId" IS NOT NULL
+      `);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_listing_creation_records_external_product_connection"`
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_listing_creation_records_status"`);
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_listing_creation_records_connectionId"`
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_listing_creation_records_variant_connection"`
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "listing_creation_records"`);
+  }
+}

--- a/apps/api/test/integration/helpers/shop-test-product-publisher-stub.helper.ts
+++ b/apps/api/test/integration/helpers/shop-test-product-publisher-stub.helper.ts
@@ -1,0 +1,124 @@
+/**
+ * Shop Test ShopProductManagerPort Stub Helper (#1042)
+ *
+ * Boot-time-registered fake `ShopProductManagerPort` + `CategoryProvisioner`
+ * adapter for the shop-publish vertical int-spec. Mirrors
+ * `allegro-test-offer-manager-stub.helper.ts`: registers a test-only
+ * `adapterKey='shop.test.product-publisher.v1'` (capability `'ProductPublisher'`
+ * + `'CategoryProvisioner'`) with the running Nest app's `AdapterRegistryService`
+ * + `AdapterFactoryResolverService`, so a connection pointed at that adapterKey
+ * resolves through the production `IntegrationsService.getCapabilityAdapter`
+ * path. Programmable per-variant via `setNextPublishResult`.
+ *
+ * @module apps/api/test/integration/helpers
+ */
+import {
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterFactoryResolverService,
+  AdapterRegistryPort,
+} from '@openlinker/core/integrations';
+import {
+  ProductPublishRejectedException,
+  type CategoryProvisioner,
+  type CreateOfferValidationError,
+  type ProvisionCategoryCommand,
+  type ProvisionCategoryResult,
+  type PublishProductCommand,
+  type PublishProductResult,
+  type ShopProductManagerPort,
+} from '@openlinker/core/listings';
+
+import type { IntegrationTestHarness } from '../setup';
+
+export const SHOP_TEST_PUBLISHER_ADAPTER_KEY = 'shop.test.product-publisher.v1';
+export const SHOP_TEST_PUBLISHER_PLATFORM_TYPE = 'woocommerce';
+
+export type ScriptedPublishResult =
+  | { kind: 'success'; externalProductId: string; status: 'draft' | 'published' }
+  | { kind: 'failure'; statusCode: number; errors: CreateOfferValidationError[] };
+
+export interface ShopTestPublisherStub {
+  readonly adapterKey: string;
+  readonly platformType: string;
+  /** Script the next `publishProduct` for a given internal variant id. */
+  setNextPublishResult(internalVariantId: string, result: ScriptedPublishResult): void;
+  /** Last command the adapter received (for upsert assertions). */
+  lastCommand(): PublishProductCommand | null;
+  reset(): void;
+}
+
+export function installShopTestPublisherStub(
+  harness: IntegrationTestHarness
+): ShopTestPublisherStub {
+  const adapterRegistry = harness.getApp().get<AdapterRegistryPort>(ADAPTER_REGISTRY_TOKEN);
+  const factoryResolver = harness
+    .getApp()
+    .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
+
+  const scripts = new Map<string, ScriptedPublishResult>();
+  let lastCmd: PublishProductCommand | null = null;
+
+  const stub: ShopProductManagerPort & CategoryProvisioner = {
+    publishProduct(cmd: PublishProductCommand): Promise<PublishProductResult> {
+      lastCmd = cmd;
+      const script = scripts.get(cmd.internalVariantId);
+      if (!script) {
+        return Promise.reject(
+          new Error(
+            `shop-test-publisher-stub: no scripted result for variant ${cmd.internalVariantId}. ` +
+              `Call setNextPublishResult(variantId, ...) first.`
+          )
+        );
+      }
+      if (script.kind === 'failure') {
+        return Promise.reject(
+          new ProductPublishRejectedException(
+            SHOP_TEST_PUBLISHER_ADAPTER_KEY,
+            script.statusCode,
+            script.errors
+          )
+        );
+      }
+      return Promise.resolve({
+        externalProductId: script.externalProductId,
+        status: script.status,
+      });
+    },
+    provisionCategory(cmd: ProvisionCategoryCommand): Promise<ProvisionCategoryResult> {
+      // Mirror the source leaf id deterministically so assertions are stable.
+      const leaf = cmd.path.at(-1);
+      return Promise.resolve({
+        destinationCategoryId: `dest:${leaf?.sourceCategoryId ?? 'root'}`,
+      });
+    },
+  };
+
+  adapterRegistry.register({
+    adapterKey: SHOP_TEST_PUBLISHER_ADAPTER_KEY,
+    platformType: SHOP_TEST_PUBLISHER_PLATFORM_TYPE,
+    supportedCapabilities: ['ProductPublisher', 'CategoryProvisioner'],
+    displayName: 'Shop ProductPublisher (integration-test stub)',
+    version: '0.0.0-test',
+    isDefault: false,
+  });
+
+  factoryResolver.registerFactory(SHOP_TEST_PUBLISHER_ADAPTER_KEY, {
+    createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(stub as unknown as T),
+  });
+
+  return {
+    adapterKey: SHOP_TEST_PUBLISHER_ADAPTER_KEY,
+    platformType: SHOP_TEST_PUBLISHER_PLATFORM_TYPE,
+    setNextPublishResult(internalVariantId: string, result: ScriptedPublishResult): void {
+      scripts.set(internalVariantId, result);
+    },
+    lastCommand(): PublishProductCommand | null {
+      return lastCmd;
+    },
+    reset(): void {
+      scripts.clear();
+      lastCmd = null;
+    },
+  };
+}

--- a/apps/api/test/integration/listings/shop-product-publish.int-spec.ts
+++ b/apps/api/test/integration/listings/shop-product-publish.int-spec.ts
@@ -144,10 +144,12 @@ describe('Shop Product Publish Integration (#1042)', () => {
     );
   });
 
-  async function countRecords(): Promise<number> {
+  async function countRecordsForConnection(connectionId: string): Promise<number> {
     const rows = (await harness
       .getDataSource()
-      .query(`SELECT count(*)::int AS n FROM listing_creation_records`)) as { n: number }[];
+      .query(`SELECT count(*)::int AS n FROM listing_creation_records WHERE "connectionId" = $1`, [
+        connectionId,
+      ])) as { n: number }[];
     return rows[0].n;
   }
 
@@ -221,8 +223,8 @@ describe('Shop Product Publish Integration (#1042)', () => {
     expect(second.outcome).toBe('ok');
     // The adapter saw the existing external id (upsert).
     expect(publisher.lastCommand()?.externalProductId).toBe('wc-100');
-    // Two attempt rows (one per publish), still a single mapping.
-    expect(await countRecords()).toBe(2);
+    // Two attempt rows (one per publish) for this shop, still a single mapping.
+    expect(await countRecordsForConnection(shopConnectionId)).toBe(2);
     const mapping = harness
       .getApp()
       .get<IIdentifierMappingService>(IDENTIFIER_MAPPING_SERVICE_TOKEN);

--- a/apps/api/test/integration/listings/shop-product-publish.int-spec.ts
+++ b/apps/api/test/integration/listings/shop-product-publish.int-spec.ts
@@ -1,0 +1,251 @@
+/**
+ * Shop Product Publish Integration Test (#1042)
+ *
+ * Exercises `ProductPublishExecutionService.executePublish` end-to-end against
+ * real Postgres (Testcontainers; migration `AddListingCreationRecordsTable1806…`
+ * applied by the harness) with a **fake** `ShopProductManagerPort` +
+ * `CategoryProvisioner` and a **fake** `ProductMaster`, both registered through
+ * the production `AdapterRegistryService` + `AdapterFactoryResolverService`
+ * seams (the carrier-mapping / bulk-wizard precedent). Asserts:
+ *  - first publish persists a `listing_creation_records` row + the `ShopProduct`
+ *    identifier mapping, outcome `ok`;
+ *  - re-publish upserts (command carries `externalProductId`, no duplicate
+ *    mapping);
+ *  - a rejecting adapter yields `business_failure` + a `failed` record.
+ *
+ * The full builder→adapter logic is also unit-tested against fakes
+ * (`product-publish-{builder,execution}.service.spec.ts`); this spec proves the
+ * Nest wiring + the new migration + real persistence.
+ *
+ * @module apps/api/test/integration/listings
+ */
+import {
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterFactoryResolverService,
+  AdapterRegistryPort,
+} from '@openlinker/core/integrations';
+import {
+  CORE_ENTITY_TYPE,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  IIdentifierMappingService,
+} from '@openlinker/core/identifier-mapping';
+import {
+  type IProductPublishExecutionService,
+  PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN,
+} from '@openlinker/core/listings';
+
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from '../setup';
+import { createTestConnection } from '../helpers/test-connection.helper';
+import {
+  installShopTestPublisherStub,
+  type ShopTestPublisherStub,
+} from '../helpers/shop-test-product-publisher-stub.helper';
+
+const PRODUCT_MASTER_ADAPTER_KEY = 'product.test.master.v1';
+const PRODUCT_ID = 'ol_product_int1';
+const VARIANT_ID = 'ol_variant_int1';
+
+function installProductMasterStub(harness: IntegrationTestHarness): void {
+  const registry = harness.getApp().get<AdapterRegistryPort>(ADAPTER_REGISTRY_TOKEN);
+  const resolver = harness
+    .getApp()
+    .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
+
+  const stub = {
+    getProduct: (): Promise<unknown> =>
+      Promise.resolve({
+        id: PRODUCT_ID,
+        name: 'Integration Widget',
+        description: 'Seeded widget',
+        images: ['http://example/img.png'],
+        price: 19.99,
+        currency: 'PLN',
+        categories: ['src-leaf'],
+      }),
+    getProductCategories: (): Promise<unknown> =>
+      Promise.resolve([{ id: 'src-leaf', name: 'Gadgets', depth: 0 }]),
+  };
+
+  registry.register({
+    adapterKey: PRODUCT_MASTER_ADAPTER_KEY,
+    platformType: 'prestashop',
+    supportedCapabilities: ['ProductMaster'],
+    displayName: 'ProductMaster (integration-test stub)',
+    version: '0.0.0-test',
+    isDefault: false,
+  });
+  resolver.registerFactory(PRODUCT_MASTER_ADAPTER_KEY, {
+    createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(stub as unknown as T),
+  });
+}
+
+describe('Shop Product Publish Integration (#1042)', () => {
+  let harness: IntegrationTestHarness;
+  let publisher: ShopTestPublisherStub;
+  let shopConnectionId: string;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    publisher = installShopTestPublisherStub(harness);
+    installProductMasterStub(harness);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  function execution(): IProductPublishExecutionService {
+    return harness
+      .getApp()
+      .get<IProductPublishExecutionService>(PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN);
+  }
+
+  beforeEach(async () => {
+    publisher.reset();
+
+    const master = await createTestConnection(harness.getDataSource(), {
+      platformType: 'prestashop',
+      name: 'Master catalog',
+      adapterKey: PRODUCT_MASTER_ADAPTER_KEY,
+      enabledCapabilities: ['ProductMaster'],
+    });
+
+    const shop = await createTestConnection(harness.getDataSource(), {
+      platformType: publisher.platformType,
+      name: 'Shop destination',
+      adapterKey: publisher.adapterKey,
+      enabledCapabilities: ['ProductPublisher', 'CategoryProvisioner'],
+      config: { masterCatalogConnectionId: master.id },
+    });
+    shopConnectionId = shop.id;
+
+    // Seed the master product + variant (real DB rows the builder reads via
+    // IProductsService.getVariant). Raw SQL — there is no products orm-entities
+    // sub-barrel to import in tests.
+    const ds = harness.getDataSource();
+    await ds.query(
+      `INSERT INTO products (id, name, "createdAt", "updatedAt") VALUES ($1, $2, now(), now())`,
+      [PRODUCT_ID, 'Integration Widget']
+    );
+    await ds.query(
+      `INSERT INTO product_variants (id, "productId", attributes, "createdAt", "updatedAt")
+       VALUES ($1, $2, $3::jsonb, now(), now())`,
+      [VARIANT_ID, PRODUCT_ID, JSON.stringify({})]
+    );
+  });
+
+  async function countRecords(): Promise<number> {
+    const rows = (await harness
+      .getDataSource()
+      .query(`SELECT count(*)::int AS n FROM listing_creation_records`)) as { n: number }[];
+    return rows[0].n;
+  }
+
+  it('publishes a new product, persisting the record + ShopProduct mapping (ok)', async () => {
+    publisher.setNextPublishResult(VARIANT_ID, {
+      kind: 'success',
+      externalProductId: 'wc-100',
+      status: 'published',
+    });
+
+    const result = await execution().executePublish({
+      internalVariantId: VARIANT_ID,
+      connectionId: shopConnectionId,
+      stock: 4,
+      status: 'published',
+    });
+
+    expect(result.outcome).toBe('ok');
+    expect(result.listingCreationRecord.status).toBe('published');
+    expect(result.listingCreationRecord.externalProductId).toBe('wc-100');
+
+    // The real AttributeProjectionService ran (category was provisioned) and
+    // resolved the destination under 'ProductPublisher' without throwing. The
+    // stub is not a CategoryParametersReader and no attribute mappings are
+    // seeded → name-keyed pass-through yields no parameters.
+    expect(publisher.lastCommand()?.destinationCategoryIds).toEqual(['dest:src-leaf']);
+    expect(publisher.lastCommand()?.parameters).toBeUndefined();
+
+    // Real persistence: the record row exists.
+    const rows = (await harness
+      .getDataSource()
+      .query(`SELECT status, "externalProductId" FROM listing_creation_records WHERE id = $1`, [
+        result.listingCreationRecord.id,
+      ])) as { status: string; externalProductId: string }[];
+    expect(rows[0]).toEqual({ status: 'published', externalProductId: 'wc-100' });
+
+    // Real persistence: the ShopProduct mapping was created, connection-scoped.
+    const mapping = harness
+      .getApp()
+      .get<IIdentifierMappingService>(IDENTIFIER_MAPPING_SERVICE_TOKEN);
+    const externalIds = await mapping.getExternalIds(CORE_ENTITY_TYPE.ShopProduct, VARIANT_ID);
+    expect(externalIds.find((m) => m.connectionId === shopConnectionId)?.externalId).toBe('wc-100');
+  });
+
+  it('upserts on re-publish — command carries externalProductId, no duplicate record blow-up', async () => {
+    publisher.setNextPublishResult(VARIANT_ID, {
+      kind: 'success',
+      externalProductId: 'wc-100',
+      status: 'published',
+    });
+    await execution().executePublish({
+      internalVariantId: VARIANT_ID,
+      connectionId: shopConnectionId,
+      stock: 4,
+      status: 'published',
+    });
+
+    // Second publish: mapping now exists → upsert path.
+    publisher.setNextPublishResult(VARIANT_ID, {
+      kind: 'success',
+      externalProductId: 'wc-100',
+      status: 'published',
+    });
+    const second = await execution().executePublish({
+      internalVariantId: VARIANT_ID,
+      connectionId: shopConnectionId,
+      stock: 9,
+      status: 'published',
+    });
+
+    expect(second.outcome).toBe('ok');
+    // The adapter saw the existing external id (upsert).
+    expect(publisher.lastCommand()?.externalProductId).toBe('wc-100');
+    // Two attempt rows (one per publish), still a single mapping.
+    expect(await countRecords()).toBe(2);
+    const mapping = harness
+      .getApp()
+      .get<IIdentifierMappingService>(IDENTIFIER_MAPPING_SERVICE_TOKEN);
+    const externalIds = await mapping.getExternalIds(CORE_ENTITY_TYPE.ShopProduct, VARIANT_ID);
+    expect(externalIds.filter((m) => m.connectionId === shopConnectionId)).toHaveLength(1);
+  });
+
+  it('records business_failure when the shop rejects the publish', async () => {
+    publisher.setNextPublishResult(VARIANT_ID, {
+      kind: 'failure',
+      statusCode: 422,
+      errors: [{ code: 'INVALID_CATEGORY', message: 'bad category' }],
+    });
+
+    const result = await execution().executePublish({
+      internalVariantId: VARIANT_ID,
+      connectionId: shopConnectionId,
+      stock: 4,
+      status: 'published',
+    });
+
+    expect(result.outcome).toBe('business_failure');
+    expect(result.listingCreationRecord.status).toBe('failed');
+    expect(result.listingCreationRecord.errors?.[0]?.code).toBe('INVALID_CATEGORY');
+  });
+});

--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -50,6 +50,10 @@ const harness = createIntegrationTestHarness({
     'sync_jobs',
     'inventory_items',
     'order_records',
+    // listing_creation_records (#1042) — variant- + connection-scoped shop
+    // publish attempts. No ORM/migration FK, so nothing cascades from
+    // connections; truncate explicitly so each shop-publish case starts clean.
+    'listing_creation_records',
     // product_content_field FKs to both products + connections, so it goes
     // before them.
     'product_content_field',

--- a/apps/worker/src/sync/handlers/__tests__/shop-product-publish.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/shop-product-publish.handler.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Shop Product Publish Handler — unit spec
+ *
+ * Covers payload validation (schemaVersion / variant / stock / status),
+ * delegation to the execution service, and outcome passthrough.
+ *
+ * @module apps/worker/src/sync/handlers/__tests__
+ */
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import type { SyncJob } from '@openlinker/core/sync';
+
+import { ShopProductPublishHandler } from '../shop-product-publish.handler';
+
+const CONN = 'conn-shop-1';
+
+function createJob(payload: unknown): SyncJob {
+  return {
+    id: 'job-1',
+    jobType: 'shop.product.publish',
+    connectionId: CONN,
+    payload: payload as Record<string, unknown>,
+    status: 'running',
+    attempts: 1,
+    maxAttempts: 3,
+    nextRunAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as unknown as SyncJob;
+}
+
+const validPayload = {
+  schemaVersion: 1,
+  internalVariantId: 'ol_variant_aaaa',
+  status: 'published',
+  stock: 5,
+};
+
+describe('ShopProductPublishHandler', () => {
+  let execution: { executePublish: jest.Mock };
+  let handler: ShopProductPublishHandler;
+
+  beforeEach(() => {
+    execution = {
+      executePublish: jest.fn().mockResolvedValue({
+        listingCreationRecord: { id: 'rec-1', status: 'published', externalProductId: 'wc-1' },
+        outcome: 'ok',
+      }),
+    };
+    handler = new ShopProductPublishHandler(execution as never);
+  });
+
+  it('should delegate a valid payload to the execution service and return its outcome', async () => {
+    const result = await handler.execute(createJob(validPayload));
+
+    expect(execution.executePublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        internalVariantId: 'ol_variant_aaaa',
+        connectionId: CONN,
+        stock: 5,
+        status: 'published',
+      })
+    );
+    expect(result).toEqual({ outcome: 'ok' });
+  });
+
+  it('should pass through a business_failure outcome', async () => {
+    execution.executePublish.mockResolvedValue({
+      listingCreationRecord: { id: 'rec-1', status: 'failed', externalProductId: null },
+      outcome: 'business_failure',
+    });
+    const result = await handler.execute(createJob(validPayload));
+    expect(result).toEqual({ outcome: 'business_failure' });
+  });
+
+  it.each([
+    ['unsupported schemaVersion', { ...validPayload, schemaVersion: 2 }],
+    ['missing internalVariantId', { ...validPayload, internalVariantId: '' }],
+    ['invalid stock', { ...validPayload, stock: -1 }],
+    ['invalid status', { ...validPayload, status: 'active' }],
+  ])('should reject %s', async (_label, payload) => {
+    await expect(handler.execute(createJob(payload))).rejects.toBeInstanceOf(SyncJobExecutionError);
+    expect(execution.executePublish).not.toHaveBeenCalled();
+  });
+
+  it('should wrap a transient execution error as SyncJobExecutionError', async () => {
+    execution.executePublish.mockRejectedValue(new Error('redis down'));
+    await expect(handler.execute(createJob(validPayload))).rejects.toBeInstanceOf(
+      SyncJobExecutionError
+    );
+  });
+});

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -27,6 +27,7 @@ import { AutoMatchVariantsHandler } from './auto-match-variants.handler';
 import { MasterInventorySyncAllHandler } from './master-inventory-sync-all.handler';
 import { MasterProductSyncAllHandler } from './master-product-sync-all.handler';
 import { PickupPointRefreshHandler } from './pickup-point-refresh.handler';
+import { ShopProductPublishHandler } from './shop-product-publish.handler';
 
 @Injectable()
 export class HandlerRegistrationService implements OnModuleInit {
@@ -49,7 +50,8 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly autoMatchVariantsHandler: AutoMatchVariantsHandler,
     private readonly masterInventorySyncAllHandler: MasterInventorySyncAllHandler,
     private readonly masterProductSyncAllHandler: MasterProductSyncAllHandler,
-    private readonly pickupPointRefreshHandler: PickupPointRefreshHandler
+    private readonly pickupPointRefreshHandler: PickupPointRefreshHandler,
+    private readonly shopProductPublishHandler: ShopProductPublishHandler
   ) {}
 
   onModuleInit(): void {
@@ -114,5 +116,8 @@ export class HandlerRegistrationService implements OnModuleInit {
       'inventory.propagateToMarketplaces',
       this.inventoryPropagateHandler
     );
+
+    // Register shop product publish handler (#1042, ADR-024)
+    this.handlerRegistry.register('shop.product.publish', this.shopProductPublishHandler);
   }
 }

--- a/apps/worker/src/sync/handlers/shop-product-publish.handler.ts
+++ b/apps/worker/src/sync/handlers/shop-product-publish.handler.ts
@@ -1,0 +1,138 @@
+/**
+ * Shop Product Publish Handler
+ *
+ * Handles sync jobs of type `shop.product.publish` (#1042, ADR-024): validate
+ * the `ShopProductPublishPayloadV1` wire shape → delegate to
+ * `ProductPublishExecutionService.executePublish` → return the business outcome.
+ *
+ * A thin shell: orchestration (create-vs-upsert, category provisioning,
+ * attribute projection, mapping, record lifecycle) lives in the core execution
+ * service per architecture-overview.md §7. No AI / bulk side-effects (those are
+ * marketplace-offer-only today).
+ *
+ * The payload's `destinationCategoryIds` / `parameters` fields are reserved for
+ * a future pre-resolved enqueue path (#1044); today the builder re-resolves
+ * category placement + attribute projection, so the handler threads only the
+ * publish inputs the execution service consumes.
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import { Inject, Injectable } from '@nestjs/common';
+
+import {
+  type IProductPublishExecutionService,
+  PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN,
+} from '@openlinker/core/listings';
+import type {
+  ShopProductPublishPayloadV1,
+  SyncJob as SyncJobEntity,
+  SyncJobHandler,
+  SyncJobHandlerResult,
+} from '@openlinker/core/sync';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import { Logger } from '@openlinker/shared/logging';
+
+type SyncJob = SyncJobEntity;
+
+@Injectable()
+export class ShopProductPublishHandler implements SyncJobHandler {
+  private readonly logger = new Logger(ShopProductPublishHandler.name);
+
+  constructor(
+    @Inject(PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN)
+    private readonly productPublish: IProductPublishExecutionService
+  ) {}
+
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
+    const payload = this.getPayload(job);
+
+    this.logger.log(
+      `Executing shop.product.publish job ${job.id} variant=${payload.internalVariantId} connection=${job.connectionId} status=${payload.status}`
+    );
+
+    try {
+      const { listingCreationRecord, outcome } = await this.productPublish.executePublish({
+        internalVariantId: payload.internalVariantId,
+        connectionId: job.connectionId,
+        stock: payload.stock,
+        status: payload.status,
+        price: payload.price,
+        content: payload.content,
+        idempotencyKey: payload.idempotencyKey,
+        listingCreationRecordId: payload.listingCreationRecordId,
+      });
+
+      this.logger.log(
+        `Shop product publish finished: job=${job.id} recordId=${listingCreationRecord.id} status=${listingCreationRecord.status} outcome=${outcome} externalProductId=${listingCreationRecord.externalProductId ?? 'n/a'}`
+      );
+
+      return { outcome };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SyncJobExecutionError(
+        `shop.product.publish job failed: ${message}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  private getPayload(job: SyncJob): ShopProductPublishPayloadV1 {
+    const payload = job.payload as unknown as Partial<ShopProductPublishPayloadV1>;
+
+    if (!payload || typeof payload !== 'object') {
+      throw new SyncJobExecutionError(
+        `Missing payload for job: ${job.id}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    if (payload.schemaVersion !== 1) {
+      throw new SyncJobExecutionError(
+        `Unsupported schemaVersion (${String(payload.schemaVersion)}) in payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    if (typeof payload.internalVariantId !== 'string' || payload.internalVariantId.length === 0) {
+      throw new SyncJobExecutionError(
+        `Missing or invalid internalVariantId in payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    if (typeof payload.stock !== 'number' || !Number.isInteger(payload.stock) || payload.stock < 0) {
+      throw new SyncJobExecutionError(
+        `Missing or invalid stock in payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    if (payload.status !== 'draft' && payload.status !== 'published') {
+      throw new SyncJobExecutionError(
+        `Missing or invalid status in payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    return {
+      schemaVersion: 1,
+      internalVariantId: payload.internalVariantId,
+      status: payload.status,
+      stock: payload.stock,
+      price: payload.price,
+      destinationCategoryIds: payload.destinationCategoryIds,
+      content: payload.content,
+      parameters: payload.parameters,
+      idempotencyKey: payload.idempotencyKey,
+      listingCreationRecordId: payload.listingCreationRecordId,
+    };
+  }
+}

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -37,6 +37,7 @@ import { AutoMatchVariantsHandler } from './handlers/auto-match-variants.handler
 import { MasterInventorySyncAllHandler } from './handlers/master-inventory-sync-all.handler';
 import { MasterProductSyncAllHandler } from './handlers/master-product-sync-all.handler';
 import { PickupPointRefreshHandler } from './handlers/pickup-point-refresh.handler';
+import { ShopProductPublishHandler } from './handlers/shop-product-publish.handler';
 import { HandlerRegistrationService } from './handlers/handler-registration.service';
 
 @Module({
@@ -73,6 +74,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     MasterInventorySyncAllHandler,
     MasterProductSyncAllHandler,
     PickupPointRefreshHandler,
+    ShopProductPublishHandler,
     HandlerRegistrationService,
   ],
 })

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-shop-publish-execution.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-shop-publish-execution.md
@@ -1,0 +1,47 @@
+# Pre-implement gate — Shop publish execution + neutral param channel (#1042 + #1072)
+
+**Plan:** `docs/plans/implementation-plan-shop-publish-execution.md`
+**Date:** 2026-06-15 · **Gate:** read-only readiness (no code, no plan edits)
+
+## Verdict: ✅ READY
+
+No reuse collisions; every edited contract surface is additive. Two minor implementation notes (below) — neither blocks; both are mechanical.
+
+## Reuse findings (does it already exist?)
+
+| Plan artifact | Verdict | Evidence |
+|---|---|---|
+| `ProductPublishExecutionService` / `IProductPublishExecutionService` | **NEW** | absent |
+| `ProductPublishBuilderService` / `IProductPublishBuilderService` | **NEW** | absent |
+| `ListingCreationRecord` entity + types (`ListingCreationStatus*`, `LISTING_CREATION_STATUS`, `ListingCreationError`, `CreateListingCreationRecordInput`) | **NEW** | absent |
+| `ListingCreationRecordRepositoryPort` + impl | **NEW** | absent |
+| ORM `@Entity('listing_creation_records')` | **NEW** | absent |
+| `BuildPublishProductCommandInput`, `ExecutePublishInput/Result` | **NEW** | absent |
+| `ShopProductPublishHandler` (`shop-product-publish.handler.ts`) | **NEW** | absent |
+| Migration touching `listing_creation_records` | **NEW** | absent |
+| Tokens `LISTING_CREATION_RECORD_REPOSITORY_TOKEN`, `PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN`, `PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN` | **NEW** | absent in `listings.tokens.ts` |
+| `ProductPublishRejectedException` | **EXISTS → reuse** | `listings/domain/exceptions/product-publish-rejected.exception.ts` (shipped by #1041) — execution service throws/maps it; do not recreate |
+| `ShopProductPublishPayloadV1`, `PublishProductCommand`, `ShopProductManagerPort`, `CategoryProvisioner`, `OfferParameter` | **EXISTS → reuse/extend** | all on `main` (#1041 + #1039) |
+
+## Backward-compat findings (edited surfaces)
+
+| Surface | Result | Detail |
+|---|---|---|
+| `CORE_ENTITY_TYPE` + `CoreEntityType` (`identifier-mapping.types.ts:19-63`) | **Additive** | `ShopProduct` absent; **zero** exhaustive consumers (no `switch`/`Record<CoreEntityType>`/`assertNever`). ⚠️ add to **both** `CoreEntityTypeValues` (the `as const` array) **and** the `satisfies Record<CoreEntityType, CoreEntityType>` guard or type-check fails. |
+| `PublishProductCommand` (`product-publish.types.ts`) | **Additive** | only consumer is `ShopProductManagerPort`; optional `parameters?: OfferParameter[]` breaks nothing. Import `OfferParameter` **same-context relative** (`./offer-parameter.types`), not via the barrel. |
+| `ShopProductPublishPayloadV1` (`shop-job-payloads.types.ts`) | **Additive** | already type-imports from `@openlinker/core/listings`; add `parameters?` there. |
+| `CategoryResolutionInput` (`category-resolution.types.ts`) | **Additive** | 4 callers all construct selectively; optional `sourceCategoryPath?` is safe. |
+| `tryProvision()` (`category-resolution.service.ts:132-136`) | **Additive** | private no-op today; filling it changes only the open/provision branch — marketplaces (no `CategoryProvisioner`) fall through unchanged. Constructor already injects `IIntegrationsService` — no new dep. |
+| `listings/index.ts` + `listings.module.ts` (`services` subpath) | **Additive** | new exports/providers append-only. ⚠️ **barrel-purity spec** (`listings/__tests__/barrel-purity.spec.ts`) hard-codes a FORBIDDEN service-class list; add `ProductPublishExecutionService` + `ProductPublishBuilderService` to it, export those **classes only** from `@openlinker/core/listings/services`, and export their **interfaces/types/port + tokens** from the pure barrel. |
+| Migration ordering | **Additive** | `1806000000000` > main tail `1805000000000` (invariant satisfied); sibling table — `offer_creation_records` untouched. |
+| Worker registry / jest-mapper | **No break** | registry spec auto-covers `shop.product.publish` via the `JobTypeValues` loop; core-only handler needs no `moduleNameMapper` edit. |
+
+## Open questions (non-blocking)
+
+1. **`ListingCreationError` aliasing `OfferCreationError`** — the alias keeps the shop path off an offer-named import while avoiding a near-duplicate; acceptable, but if a reviewer prefers a standalone neutral type, define it fresh (trivial). Decide at implementation.
+2. **`#1072` closure wording** — both #1072 ACs are met at the command/execution layer here; the adapter-shaping bullet is #1043. Plan targets `Closes #1042` + `Closes #1072` with an #1043 note; downgrade to `Part of #1072` at ship if over-claimed.
+3. **Int-spec placement** — `apps/api/test/integration/listings/` (app harness covers type-check; avoids the worker-int-spec gate-escape noted in lessons). Fake `ShopProductManagerPort` registered via `AdapterRegistryService` + `AdapterFactoryResolverService` (carrier-mapping precedent).
+
+## Summary
+
+Clean, additive vertical slice with no reuse collisions and no contract breaks. The only watch-items are mechanical: keep the `CoreEntityType` array + `satisfies` guard in lockstep, and extend the barrel-purity FORBIDDEN list for the two new service classes. Proceed to implementation.

--- a/docs/plans/implementation-plan-shop-publish-execution.md
+++ b/docs/plans/implementation-plan-shop-publish-execution.md
@@ -1,0 +1,133 @@
+# Implementation Plan — Shop publish execution service + neutral param channel (#1042 + #1072)
+
+**Issues:** #1042 (execution service + worker handler + persistence) · #1072 (unify shop command onto neutral `OfferParameter` channel) · Part of #1005 · ADR-024
+**Branch:** `1042-1072-shop-publish-execution`
+**Layer:** CORE (listings application/domain/infrastructure) + sync contract + worker interface + a migration.
+
+---
+
+## 1. Understand the task
+
+Build the **execution half** of the shop-publish vertical the #1041 capabilities (now on `main`) unblocked: a `shop.product.publish` job that publishes a master product onto a shop destination (WooCommerce, …) via `ShopProductManagerPort.publishProduct`. Bundled with #1072 — carry projected attributes on the command via the **typed neutral `OfferParameter` channel** (merged in #1039) instead of the `platformParams` interim I used in #1070.
+
+**Deliver (the ADR-024 §Flow shop path):**
+- Persistence: `listing_creation_records` table + `ListingCreationRecord` entity + repo port/impl + migration (a **sibling** of `offer_creation_records`, not a rename — keeps the hot offer path untouched).
+- `ProductPublishBuilderService` — builds `PublishProductCommand` from (variant, connection, stock, status, price?, content?): resolve category (incl. open-provenance **provisioning**) + project attributes → `parameters: OfferParameter[]`, with a `business_failure` publish gate (mirrors `OfferBuilderService`).
+- Fill the `CategoryResolutionService.tryProvision()` no-op seam: resolve `ShopProductManagerPort`, guard `isCategoryProvisioner`, `provisionCategory(sourcePath)`.
+- `ProductPublishExecutionService` — load/create record → build command → resolve adapter (`getCapabilityAdapter<ShopProductManagerPort>(id,'ProductPublisher')`) → create-vs-upsert via `IdentifierMapping` → `publishProduct` → persist outcome (`ok | business_failure`), catching `ProductPublishRejectedException`.
+- `ShopProductPublishHandler` worker handler + registration.
+- **#1072**: add `parameters?: OfferParameter[]` to `PublishProductCommand` + `ShopProductPublishPayloadV1`; soften the `platformParams` JSDoc; the builder/execution produce the typed field from projection.
+
+**Non-goals (explicit):**
+- **WooCommerce adapter** (#1043) — no real `ShopProductManagerPort` implementation; this slice is verified against a **fake** shop adapter. Adapter-side param *shaping* (the remaining #1072 scope bullet) lands in #1043.
+- **API controllers + FE wizard** (#1044).
+- **Bulk** shop publish (reuse the neutral `BulkListing*` orchestration later).
+- **Separate `VisibilitySetter` capability** — visibility is carried on the command's `status` (`draft|published`); `publishProduct` honours it. A decoupled set-visibility capability is deferred.
+- **Multi-category beyond the primary** — resolve one destination category into the `destinationCategoryIds` array (single element); true multi-category is a follow-up.
+
+---
+
+## 2. Research — templates (verified in-repo, with file:line)
+
+| Concern | Template |
+|---|---|
+| Execution service shape (deps, resolve+guard, record lifecycle, `business_failure` derivation, idempotent mapping) | `offer-creation-execution.service.ts` (constructor `:70-81`; resolve+guard `:106-114`; create `:118`; rejection catch `:120-129`; mapping `:132-144`; status update `:147-152`; outcome `:221-251`) |
+| Builder + projection + publish gate | `offer-builder.service.ts` (projection call `:215-220`; Gate-2 required-param `:222-239`; command assembly `:149-172`) |
+| Record entity/types/ORM/port/impl | `offer-creation-record.*` (entity, `offer-creation-record.types.ts`, `*.orm-entity.ts` `@Entity('offer_creation_records')`, port, repository `toDomain`/`buildOrmEntity` `:149-177`) |
+| Migration | `1784000000000-add-offer-creation-records-table.ts`; **newest on main = `1805000000000` → use `1806000000000`** |
+| Worker handler + registration | `marketplace-offer-create.handler.ts` (`execute` `:76-130`); `handler-registration.service.ts` (`:55-117`); `sync-worker.module.ts` providers `:54-76` |
+| Category provisioning seam | `category-resolution.service.ts` (`tryProvision()` no-op `:124-136`, call site `:64`; already injects `IIntegrationsService` `:48`) |
+| Neutral param channel | `offer-parameter.types.ts` (`OfferParameter`); `attribute-projection.types.ts:36` (`ResolvedParameter = OfferParameter`, alias); `project()` returns `parameters: ResolvedParameter[]` |
+| Shop contract (#1041, on main) | `shop-product-manager.port.ts`, `product-publish.types.ts` (`PublishProductCommand` — no `parameters` field yet), `category-provisioner.capability.ts` (`isCategoryProvisioner`) |
+| Identifier mapping | `identifier-mapping.service.ts` (`getExternalIds` `:85-93`, `createMapping` `:107-144`, `DuplicateIdentifierMappingError` idempotent path); `CORE_ENTITY_TYPE` (`:54-62` — **no shop-product type; add `ShopProduct`**) |
+| Registry test (auto-covers new job type via `JobTypeValues` loop) | `sync-job-handler.registry.spec.ts:112-118` — no edit |
+| jest-integration mapper guard | core-only handler → **no mapper edit** (`@openlinker/core/*` already mapped) |
+
+---
+
+## 3. Design
+
+### 3.1 Persistence — sibling `listing_creation_records`
+`ListingCreationRecord` mirrors `OfferCreationRecord` minus offer-only fields (no `classificationReport`, no `bulkBatchId` for MVP):
+```
+ListingCreationStatusValues = ['pending', 'draft', 'published', 'failed']   // shop lifecycle (no validating/active)
+ListingCreationRecord { id, internalVariantId, connectionId, externalProductId|null,
+                        status, errors|null, createdAt, updatedAt }
+```
+Errors reuse the neutral `OfferCreationError` shape (`{field?,code,message}`) — re-exported as `ListingCreationError` alias to avoid an offer-named import on the shop path. Repo port = the subset actually used: `create`, `findById`, `findLatestByVariantAndConnection`, `updateStatus`, `updateExternalIdAndStatus`, `findByExternalProductIdAndConnectionId`. ORM `@Entity('listing_creation_records')` with indexes `(internalVariantId, connectionId)`, `(connectionId)`, `(status)`, partial `(externalProductId, connectionId) WHERE externalProductId IS NOT NULL`. Migration `1806000000000`.
+
+### 3.2 Create-vs-upsert mapping
+Add `ShopProduct: 'ShopProduct'` to `CORE_ENTITY_TYPE` (additive). The execution service:
+- `getExternalIds(ShopProduct, internalVariantId)` filtered to `connectionId` → if found, set `command.externalProductId` (upsert); else create.
+- After `publishProduct`, `createMapping(ShopProduct, result.externalProductId, connectionId, internalVariantId)`, treating `DuplicateIdentifierMappingError` as an idempotent prior success (exact offer-path idiom).
+
+### 3.3 `ProductPublishBuilderService`
+Mirror `OfferBuilderService`:
+- Fetch variant + master product (via `IProductsService` / `ProductMasterPort`), source categories (`getProductCategories`).
+- **Resolve destination category — provisioning-only for MVP, in this builder (tech-review IMPORTANT):** resolve the destination `getCapabilityAdapter<ShopProductManagerPort>(connectionId, 'ProductPublisher')`; `if (isCategoryProvisioner(adapter) && sourceCategoryPath.length) destinationCategoryIds = [await adapter.provisionCategory({ connectionId, path })]`, where `path` (root→leaf `{sourceCategoryId,name}`) is built from the master product's `getProductCategories()`. No provisioner / no source categories → `destinationCategoryIds = []` (WooCommerce publishes uncategorised; not a gate failure). **Shop category-MAPPING fallback is deferred** to a follow-up — this PR does not touch the shared, marketplace-shaped `CategoryResolutionService`.
+- Project attributes via `IAttributeProjectionService.project(...)` → `parameters: OfferParameter[]`; Gate on `unresolvedRequired` (shop has no offer/product section gate split — treat all `unresolvedRequired` as blocking unless operator-supplied). Validation failures throw a neutral `ProductPublishBuilderValidationException` (do **not** reuse the offer-named `OfferBuilderValidationException`).
+- Assemble `PublishProductCommand` incl. `parameters`, `destinationCategoryIds`, price/stock/content/status. **No `platformParams` for attributes.**
+
+> **Dropped from the original plan (tech-review):** filling `CategoryResolutionService.tryProvision()` + extending `CategoryResolutionInput.sourceCategoryPath`. That service resolves `'OfferManager'` and runs on every marketplace offer creation (the hot #824 path); wiring shop provisioning there would throw+catch a wrong-capability resolution per offer and introduce a capability-name branch. Provisioning lives in the shop builder instead; the shared service is left untouched.
+
+### 3.4 `ProductPublishExecutionService`
+Deps: `ProductPublishBuilder`, `ListingCreationRecordRepo`, `IIdentifierMappingService`, `IIntegrationsService`. Flow (mirrors offer execution, minus poll/classification):
+load/create record (`pending`) → **resolve create-vs-upsert**: `getExternalIds(ShopProduct, internalVariantId)` **filtered by `connectionId`** → set `command.externalProductId` when found (the reverse lookup is `(entityType, internalId)`-keyed, NOT connection-scoped, so the filter is mandatory) → build command (catch `ProductPublishBuilderValidationException` → `failed`/`business_failure`) → resolve `getCapabilityAdapter<ShopProductManagerPort>(connectionId, 'ProductPublisher')` (no extra guard — `ProductPublisher` *is* the base port) → `publishProduct` (catch `ProductPublishRejectedException` → `failed`/`business_failure`) → **on first publish only** `createMapping(ShopProduct, externalProductId, connectionId, internalVariantId)` catching `DuplicateIdentifierMappingError` as the idempotent-retry path (skip `createMapping` on upsert — mapping exists) → `updateExternalIdAndStatus(record, externalProductId, status)` → outcome (`published|draft → ok`; `failed → business_failure`).
+
+> **Concurrency note (document in the service header):** two concurrent *first* publishes of the same variant create two distinct shop products (shop create is not platform-idempotent; the mapping records one). Bounded by the job-level `idempotencyKey` dedup (#726 at-most-once) — the enqueue gate is the guard, not a DB constraint.
+
+### 3.6 #1072 contract edits
+- `product-publish.types.ts`: add `parameters?: OfferParameter[]` to `PublishProductCommand`; reword the `platformParams` JSDoc to "un-modeled shop knobs only (NOT category parameters — those travel on `parameters`)".
+- `shop-job-payloads.types.ts`: add `parameters?: OfferParameter[]` to `ShopProductPublishPayloadV1`.
+
+### Layer compliance
+All new domain types/ports framework-free; services in `application/services`, each backed by an `I*Service` interface (per `check-service-interfaces`); ORM only in `infrastructure/persistence`; `OfferParameter` is domain (no domain→application edge); cross-context imports via top-level barrels; tokens in `listings.tokens.ts` (`export *`).
+
+---
+
+## 4. Step-by-step implementation
+
+| # | File | Action |
+|---|---|---|
+| 1 | `identifier-mapping/domain/types/identifier-mapping.types.ts` | **edit** — add `ShopProduct: 'ShopProduct'` to `CORE_ENTITY_TYPE` |
+| 2 | `listings/domain/types/listing-creation-record.types.ts` | **new** — `ListingCreationStatusValues`/`Status`/`LISTING_CREATION_STATUS`, `ListingCreationError` (alias of `OfferCreationError`), `CreateListingCreationRecordInput` |
+| 3 | `listings/domain/entities/listing-creation-record.entity.ts` | **new** — immutable record entity |
+| 4 | `listings/domain/ports/listing-creation-record-repository.port.ts` | **new** — 6-method port |
+| 5 | `listings/infrastructure/persistence/entities/listing-creation-record.orm-entity.ts` | **new** — `@Entity('listing_creation_records')` |
+| 6 | `listings/infrastructure/persistence/repositories/listing-creation-record.repository.ts` | **new** — impl + `toDomain`/`buildOrmEntity` |
+| 7 | `listings/domain/types/product-publish.types.ts` | **edit (#1072)** — add `parameters?: OfferParameter[]`; reword `platformParams` JSDoc |
+| 8 | `listings/application/types/product-publish-builder.types.ts` | **new** — `BuildPublishProductCommandInput` |
+| 9 | `listings/application/interfaces/product-publish-builder.service.interface.ts` | **new** — `IProductPublishBuilderService` |
+| 10 | `listings/application/services/product-publish-builder.service.ts` | **new** — builder |
+| 11 | `listings/application/types/product-publish-execution.types.ts` | **new** — `ExecutePublishInput`/`Result` |
+| 12 | `listings/application/interfaces/product-publish-execution.service.interface.ts` | **new** — `IProductPublishExecutionService` |
+| 13 | `listings/domain/exceptions/product-publish-builder-validation.exception.ts` | **new** — neutral `ProductPublishBuilderValidationException` (+ `ProductPublishBuilderValidationIssue`) |
+| 14 | `listings/application/services/product-publish-execution.service.ts` | **new** — execution service (incl. connection-scoped create-vs-upsert lookup) |
+| 15 | `listings/listings.tokens.ts` | **edit** — `LISTING_CREATION_RECORD_REPOSITORY_TOKEN`, `PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN`, `PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN` |
+| 16 | `listings/listings.module.ts` | **edit** — ORM `forFeature`, 3 providers + token bindings + exports |
+| 17 | `listings/index.ts` | **edit** — export entity, types, repo port, builder/execution interfaces + IO types + the new exception |
+| 18 | `sync/domain/types/shop-job-payloads.types.ts` | **edit (#1072)** — add `parameters?: OfferParameter[]` |
+| 19 | `apps/api/src/migrations/1806000000000-add-listing-creation-records-table.ts` | **new** — table + indexes (`up`/`down`) |
+| 20 | `apps/worker/src/sync/handlers/shop-product-publish.handler.ts` | **new** — `SyncJobHandler`, validate `ShopProductPublishPayloadV1`, call execution service |
+| 21 | `apps/worker/src/sync/handlers/handler-registration.service.ts` | **edit** — register `'shop.product.publish'` |
+| 22 | `apps/worker/src/sync/sync-worker.module.ts` | **edit** — add handler provider |
+| 23 | `listings/__tests__/barrel-purity.spec.ts` | **edit** — add the 2 new service classes to the FORBIDDEN list |
+
+### Tests
+- `product-publish-execution.service.spec.ts` — happy publish (create + upsert), `ProductPublishRejectedException` → `business_failure`, builder-validation → `business_failure`, idempotent mapping. **Fake `ShopProductManagerPort` adapter** (satisfies #1042's "fake shop adapter" AC at unit-vertical level).
+- `product-publish-builder.service.spec.ts` — projection→`parameters`, category-unresolved gate, content/price fallback.
+- `category-resolution.service.spec.ts` — extend: provision path (provisioner present → id+`open`; absent → fall through).
+- `shop-product-publish.handler.spec.ts` — payload validation + delegation + outcome passthrough.
+- **Integration test (real, per #1042 AC)** — `apps/api/test/integration/listings/shop-product-publish.int-spec.ts`: boot the Nest app (real Postgres via the shared harness), register a **fake `ShopProductManagerPort`** through the public `AdapterRegistryService` + `AdapterFactoryResolverService` seams (the `allegro-prestashop-carrier-mapping.int-spec.ts` pattern), invoke `ProductPublishExecutionService.executePublish(...)` from the container, and assert: a `listing_creation_records` row persisted with `status='published'` + the correct `externalProductId`; the `ShopProduct` identifier mapping created; re-running upserts (no duplicate row/mapping); a rejecting fake adapter yields `outcome='business_failure'` + a `failed` record. Covers persistence + execution + fake adapter end-to-end.
+
+### Quality gate
+`pnpm lint` (+ invariants: migration-timestamp ordering, service-interfaces, cross-context) · `pnpm type-check` · `pnpm test`. Migration: `pnpm --filter @openlinker/api migration:show`.
+
+---
+
+## 5. Validation & risks
+
+- **Architecture:** core-only; honours CORE↔integration boundary (no platform string anywhere); resolve-then-guard; `OfferParameter` keeps the command domain-pure.
+- **Migration:** sibling table (no touch to `offer_creation_records`); synthetic prefix `1806000000000` > main tail `1805…` (ordering invariant).
+- **#1072 closure (tech-review ruling):** ship as **`Closes #1042`, `Part of #1072`**. #1072's scope explicitly names the WooCommerce adapter (#1043) as "the sole shaper" and lists #1043 as a dependency, so the channel-establishing + execution-production half lands here but #1072 stays open until #1043 ships the adapter shaping.
+- **Risks / size:** large but de-risked by the tech-review — the only edit to a shared hot path (the `category-resolution.service` `tryProvision` fill) was **dropped**; provisioning now lives in the new shop builder, so no existing marketplace code path changes behaviour. Remaining watch-item: the `CORE_ENTITY_TYPE.ShopProduct` addition (additive — keep the `CoreEntityTypeValues` array and the `satisfies Record<CoreEntityType,…>` guard in lockstep). The #1042 Testcontainers **integration test** is **in scope** (see Tests) — exercises the execution service + real `listing_creation_records` persistence against a fake shop adapter via the app harness.

--- a/libs/core/src/identifier-mapping/domain/types/__tests__/identifier-mapping.types.spec.ts
+++ b/libs/core/src/identifier-mapping/domain/types/__tests__/identifier-mapping.types.spec.ts
@@ -18,7 +18,9 @@ describe('identifier-mapping.types', () => {
       // Guards against silent reordering or accidental additions/removals
       // of the published well-known set. The architecture doc enumerates
       // the same values at §"Internal Identifier Format". `Shipment`
-      // joined in #763 (foundation slice for the InPost shipping epic).
+      // joined in #763 (foundation slice for the InPost shipping epic);
+      // `ShopProduct` joined in #1042 (variant→destination-product key for
+      // the shop-publish vertical).
       expect([...CoreEntityTypeValues]).toEqual([
         'Product',
         'ProductVariant',
@@ -28,6 +30,7 @@ describe('identifier-mapping.types', () => {
         'Inventory',
         'Customer',
         'Shipment',
+        'ShopProduct',
       ]);
     });
   });

--- a/libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts
@@ -25,6 +25,10 @@ export const CoreEntityTypeValues = [
   'Inventory',
   'Customer',
   'Shipment',
+  // Destination shop product record — maps an OL variant to its external
+  // product id on a shop connection (the publish create-vs-upsert key, #1042).
+  // Distinct from `Product` (master catalog) and `Offer` (marketplace listing).
+  'ShopProduct',
 ] as const;
 
 /**
@@ -60,6 +64,7 @@ export const CORE_ENTITY_TYPE = {
   Inventory: 'Inventory',
   Customer: 'Customer',
   Shipment: 'Shipment',
+  ShopProduct: 'ShopProduct',
 } as const satisfies Record<CoreEntityType, CoreEntityType>;
 
 /**

--- a/libs/core/src/listings/__tests__/barrel-purity.spec.ts
+++ b/libs/core/src/listings/__tests__/barrel-purity.spec.ts
@@ -28,6 +28,8 @@ const FORBIDDEN_EXPORTS = [
   'OfferCreationExecutionService',
   'SellerPoliciesService',
   'OfferCreationEnqueueService',
+  'ProductPublishBuilderService',
+  'ProductPublishExecutionService',
 ] as const;
 
 describe('@openlinker/core/listings barrel purity (#359)', () => {

--- a/libs/core/src/listings/application/interfaces/product-publish-builder.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/product-publish-builder.service.interface.ts
@@ -1,0 +1,37 @@
+/**
+ * Product Publish Builder Service Interface
+ *
+ * Contract for assembling a platform-neutral `PublishProductCommand` from an OL
+ * internal variant id plus shop publish options. Implementations resolve the
+ * parent master product, provision the destination category (open-provenance),
+ * project attributes into neutral `OfferParameter[]`, and assemble the command
+ * consumed by `ShopProductManagerPort.publishProduct`.
+ *
+ * @module libs/core/src/listings/application/interfaces
+ */
+
+import type { PublishProductCommand } from '@openlinker/core/listings';
+import type { BuildPublishProductCommandInput } from '../types/product-publish-builder.types';
+
+export interface IProductPublishBuilderService {
+  /**
+   * Resolve and assemble a `PublishProductCommand` for the given variant and
+   * shop connection.
+   *
+   * Failure modes:
+   * - Unknown variant → `ProductPublishBuilderValidationException` (`internalVariantId`, `NOT_FOUND`)
+   * - Unknown shop connection → `ConnectionNotFoundException`
+   * - Shop connection missing `masterCatalogConnectionId` in config →
+   *   `MasterCatalogConnectionNotConfiguredException`
+   * - Cannot resolve price/currency → `ProductPublishBuilderValidationException` (`price.*`, `REQUIRED`)
+   * - Unresolved required destination parameter → `ProductPublishBuilderValidationException`
+   *   (`parameters.*`, `PARAMETER_REQUIRED`)
+   *
+   * Category placement is best-effort (open-provenance provisioning when the
+   * destination supports `CategoryProvisioner`; otherwise uncategorised — not a
+   * gate failure, since shops publish uncategorised products).
+   */
+  buildPublishProductCommand(
+    input: BuildPublishProductCommandInput
+  ): Promise<PublishProductCommand>;
+}

--- a/libs/core/src/listings/application/interfaces/product-publish-execution.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/product-publish-execution.service.interface.ts
@@ -1,0 +1,33 @@
+/**
+ * Product Publish Execution Service Interface
+ *
+ * Contract for the core orchestration step that turns an OL internal variant
+ * plus publish options into a live shop product record (outbound, OL →
+ * WooCommerce / Shopify). Used by the `shop.product.publish` worker handler and
+ * the future REST endpoint (#1044) so both paths share identical semantics.
+ *
+ * Per `architecture-overview.md` §6, orchestration policies live in core
+ * application services rather than worker handlers.
+ *
+ * @module libs/core/src/listings/application/interfaces
+ */
+
+import type {
+  ExecutePublishProductInput,
+  ExecutePublishProductResult,
+} from '../types/product-publish-execution.types';
+
+export interface IProductPublishExecutionService {
+  /**
+   * Execute the full publish flow: resolve create-vs-upsert via
+   * `IdentifierMapping` (`ShopProduct`, connection-scoped), build the neutral
+   * `PublishProductCommand`, invoke the shop adapter, persist the
+   * `ListingCreationRecord` + the `ShopProduct` mapping (first publish only).
+   *
+   * Terminal domain failures (builder validation, master-catalog misconfig,
+   * shop reject) are caught and persisted to the record as `status='failed'`
+   * with structured errors — the method resolves normally in those cases so
+   * the calling worker job isn't retried. Transient / unknown errors propagate.
+   */
+  executePublish(input: ExecutePublishProductInput): Promise<ExecutePublishProductResult>;
+}

--- a/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Product Publish Builder Service — unit spec
+ *
+ * Covers command assembly: variant-not-found gate, price fallback/gate,
+ * category provisioning (provisioner present → provisioned id; absent →
+ * uncategorised), attribute projection → `parameters`, and the required-param
+ * publish gate.
+ *
+ * @module libs/core/src/listings/application/services/__tests__
+ */
+
+import { ProductPublishBuilderValidationException } from '../../../domain/exceptions/product-publish-builder-validation.exception';
+import { MasterCatalogConnectionNotConfiguredException } from '../../../domain/exceptions/master-catalog-connection-not-configured.exception';
+import { ProductPublishBuilderService } from '../product-publish-builder.service';
+
+const CONN = 'conn-shop-1';
+const MASTER = 'conn-master-1';
+const VARIANT = 'ol_variant_aaaa';
+
+describe('ProductPublishBuilderService', () => {
+  let products: { getVariant: jest.Mock };
+  let connectionPort: { get: jest.Mock };
+  let integrations: { getCapabilityAdapter: jest.Mock };
+  let projection: { project: jest.Mock };
+  let productMaster: { getProduct: jest.Mock; getProductCategories: jest.Mock };
+  let shopAdapter: { publishProduct: jest.Mock; provisionCategory?: jest.Mock };
+  let service: ProductPublishBuilderService;
+
+  const baseInput = {
+    internalVariantId: VARIANT,
+    connectionId: CONN,
+    stock: 3,
+    status: 'published' as const,
+  };
+
+  beforeEach(() => {
+    products = {
+      getVariant: jest
+        .fn()
+        .mockResolvedValue({ id: VARIANT, productId: 'prod-1', attributes: { Brand: 'Acme' }, ean: null, gtin: null, sku: null }),
+    };
+    connectionPort = {
+      get: jest.fn().mockResolvedValue({ config: { masterCatalogConnectionId: MASTER } }),
+    };
+    productMaster = {
+      getProduct: jest
+        .fn()
+        .mockResolvedValue({ name: 'Widget', description: 'A widget', images: ['http://img'], price: 12.5, currency: 'PLN' }),
+      getProductCategories: jest
+        .fn()
+        .mockResolvedValue([
+          { id: 'src-root', name: 'Electronics', depth: 0 },
+          { id: 'src-leaf', name: 'Phones', depth: 1 },
+        ]),
+    };
+    shopAdapter = {
+      publishProduct: jest.fn(),
+      provisionCategory: jest.fn().mockResolvedValue({ destinationCategoryId: 'dest-leaf' }),
+    };
+    projection = {
+      project: jest
+        .fn()
+        .mockResolvedValue({ parameters: [{ id: 'Brand', values: ['Acme'], section: 'product' }], unmappedSourceKeys: [], unresolvedRequired: [] }),
+    };
+    integrations = {
+      getCapabilityAdapter: jest.fn((_id: string, capability: string) =>
+        capability === 'ProductMaster' ? Promise.resolve(productMaster) : Promise.resolve(shopAdapter)
+      ),
+    };
+
+    service = new ProductPublishBuilderService(
+      products as never,
+      connectionPort as never,
+      integrations as never,
+      projection as never
+    );
+  });
+
+  it('should build a command with provisioned category + projected parameters', async () => {
+    const command = await service.buildPublishProductCommand(baseInput);
+
+    // Provision walked root→leaf.
+    expect(shopAdapter.provisionCategory).toHaveBeenCalledWith({
+      connectionId: CONN,
+      path: [
+        { sourceCategoryId: 'src-root', name: 'Electronics' },
+        { sourceCategoryId: 'src-leaf', name: 'Phones' },
+      ],
+    });
+    expect(command.destinationCategoryIds).toEqual(['dest-leaf']);
+    // Projection must resolve the destination under 'ProductPublisher' — a shop
+    // connection never supports the marketplace 'OfferManager' capability.
+    expect(projection.project).toHaveBeenCalledWith(
+      expect.objectContaining({ destinationCapability: 'ProductPublisher' })
+    );
+    expect(command.parameters).toEqual([{ id: 'Brand', values: ['Acme'], section: 'product' }]);
+    expect(command.price).toEqual({ amount: 12.5, currency: 'PLN' });
+    expect(command.content).toEqual(
+      expect.objectContaining({ title: 'Widget', description: 'A widget', imageUrls: ['http://img'] })
+    );
+    expect(command.status).toBe('published');
+  });
+
+  it('should publish uncategorised when the shop adapter is not a CategoryProvisioner', async () => {
+    delete shopAdapter.provisionCategory; // not a provisioner
+
+    const command = await service.buildPublishProductCommand(baseInput);
+
+    expect(command.destinationCategoryIds).toEqual([]);
+    // No category ⇒ no projection ⇒ no parameters.
+    expect(projection.project).not.toHaveBeenCalled();
+    expect(command.parameters).toBeUndefined();
+  });
+
+  it('should throw when the variant is not found', async () => {
+    products.getVariant.mockResolvedValue(null);
+    await expect(service.buildPublishProductCommand(baseInput)).rejects.toBeInstanceOf(
+      ProductPublishBuilderValidationException
+    );
+  });
+
+  it('should throw MasterCatalogConnectionNotConfigured when config lacks the master id', async () => {
+    connectionPort.get.mockResolvedValue({ config: {} });
+    await expect(service.buildPublishProductCommand(baseInput)).rejects.toBeInstanceOf(
+      MasterCatalogConnectionNotConfiguredException
+    );
+  });
+
+  it('should gate on unresolved required destination parameters', async () => {
+    projection.project.mockResolvedValue({
+      parameters: [],
+      unmappedSourceKeys: [],
+      unresolvedRequired: [{ id: 'GTIN', name: 'GTIN', section: 'product' }],
+    });
+
+    await expect(service.buildPublishProductCommand(baseInput)).rejects.toBeInstanceOf(
+      ProductPublishBuilderValidationException
+    );
+  });
+
+  it('should gate on an unresolvable price', async () => {
+    productMaster.getProduct.mockResolvedValue({ name: 'X', description: null, images: null, price: null, currency: null });
+    await expect(service.buildPublishProductCommand(baseInput)).rejects.toBeInstanceOf(
+      ProductPublishBuilderValidationException
+    );
+  });
+});

--- a/libs/core/src/listings/application/services/__tests__/product-publish-execution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-execution.service.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Product Publish Execution Service — unit spec
+ *
+ * Covers the orchestration policy against a **fake** `ShopProductManagerPort`:
+ * happy create, upsert (existing mapping → externalProductId set, no new
+ * mapping), shop rejection → `business_failure`, builder validation →
+ * `business_failure`, and idempotent mapping (DuplicateIdentifierMappingError
+ * swallowed).
+ *
+ * @module libs/core/src/listings/application/services/__tests__
+ */
+
+import { DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
+import { ProductPublishRejectedException } from '@openlinker/core/listings';
+
+import { ListingCreationRecord } from '../../../domain/entities/listing-creation-record.entity';
+import { ProductPublishBuilderValidationException } from '../../../domain/exceptions/product-publish-builder-validation.exception';
+import type { ListingCreationStatus } from '../../../domain/types/listing-creation-record.types';
+import { ProductPublishExecutionService } from '../product-publish-execution.service';
+
+const CONN = 'conn-shop-1';
+const VARIANT = 'ol_variant_aaaa';
+const EXT = 'wc-product-42';
+
+function makeRecord(
+  status: ListingCreationStatus,
+  externalProductId: string | null = null
+): ListingCreationRecord {
+  return new ListingCreationRecord(
+    'rec-1',
+    VARIANT,
+    CONN,
+    externalProductId,
+    status,
+    null,
+    new Date(),
+    new Date()
+  );
+}
+
+describe('ProductPublishExecutionService', () => {
+  let builder: { buildPublishProductCommand: jest.Mock };
+  let records: {
+    create: jest.Mock;
+    findById: jest.Mock;
+    updateStatus: jest.Mock;
+    updateExternalIdAndStatus: jest.Mock;
+  };
+  let identifierMapping: { getExternalIds: jest.Mock; createMapping: jest.Mock };
+  let integrations: { getCapabilityAdapter: jest.Mock };
+  let adapter: { publishProduct: jest.Mock };
+  let service: ProductPublishExecutionService;
+
+  const input = { internalVariantId: VARIANT, connectionId: CONN, stock: 5, status: 'published' as const };
+
+  beforeEach(() => {
+    builder = {
+      buildPublishProductCommand: jest.fn().mockResolvedValue({
+        internalVariantId: VARIANT,
+        connectionId: CONN,
+        destinationCategoryIds: [],
+        price: { amount: 10, currency: 'PLN' },
+        stock: 5,
+        status: 'published',
+      }),
+    };
+    records = {
+      create: jest.fn().mockResolvedValue(makeRecord('pending')),
+      findById: jest.fn(),
+      updateStatus: jest.fn(),
+      updateExternalIdAndStatus: jest
+        .fn()
+        .mockResolvedValue(makeRecord('published', EXT)),
+    };
+    identifierMapping = {
+      getExternalIds: jest.fn().mockResolvedValue([]),
+      createMapping: jest.fn().mockResolvedValue(undefined),
+    };
+    adapter = {
+      publishProduct: jest.fn().mockResolvedValue({ externalProductId: EXT, status: 'published' }),
+    };
+    integrations = { getCapabilityAdapter: jest.fn().mockResolvedValue(adapter) };
+
+    service = new ProductPublishExecutionService(
+      builder as never,
+      records as never,
+      identifierMapping as never,
+      integrations as never
+    );
+  });
+
+  it('should publish a new product, persist the mapping, and report ok', async () => {
+    const result = await service.executePublish(input);
+
+    expect(adapter.publishProduct).toHaveBeenCalledTimes(1);
+    expect(identifierMapping.createMapping).toHaveBeenCalledWith(
+      'ShopProduct',
+      EXT,
+      CONN,
+      VARIANT
+    );
+    expect(records.updateExternalIdAndStatus).toHaveBeenCalledWith('rec-1', EXT, 'published', null);
+    expect(result.outcome).toBe('ok');
+    expect(result.listingCreationRecord.status).toBe('published');
+  });
+
+  it('should upsert when a connection-scoped mapping already exists (no new mapping)', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([
+      { externalId: 'other-conn-prod', connectionId: 'conn-other', entityType: 'ShopProduct', platformType: 'x' },
+      { externalId: EXT, connectionId: CONN, entityType: 'ShopProduct', platformType: 'woocommerce' },
+    ]);
+
+    await service.executePublish(input);
+
+    // Command carries the existing external product id (upsert).
+    expect(adapter.publishProduct).toHaveBeenCalledWith(
+      expect.objectContaining({ externalProductId: EXT })
+    );
+    // No new mapping on upsert.
+    expect(identifierMapping.createMapping).not.toHaveBeenCalled();
+  });
+
+  it('should record business_failure when the shop rejects the publish', async () => {
+    adapter.publishProduct.mockRejectedValue(
+      new ProductPublishRejectedException('woocommerce.restapi.v1', 422, [
+        { code: 'INVALID', message: 'bad' },
+      ])
+    );
+    records.updateStatus.mockResolvedValue(makeRecord('failed'));
+
+    const result = await service.executePublish(input);
+
+    expect(records.updateStatus).toHaveBeenCalledWith(
+      'rec-1',
+      'failed',
+      expect.arrayContaining([expect.objectContaining({ code: 'INVALID' })])
+    );
+    expect(result.outcome).toBe('business_failure');
+  });
+
+  it('should record business_failure when builder validation fails', async () => {
+    builder.buildPublishProductCommand.mockRejectedValue(
+      new ProductPublishBuilderValidationException([
+        { field: 'price.amount', code: 'REQUIRED', message: 'no price' },
+      ])
+    );
+    records.updateStatus.mockResolvedValue(makeRecord('failed'));
+
+    const result = await service.executePublish(input);
+
+    expect(adapter.publishProduct).not.toHaveBeenCalled();
+    expect(result.outcome).toBe('business_failure');
+  });
+
+  it('should treat DuplicateIdentifierMappingError as an idempotent retry', async () => {
+    identifierMapping.createMapping.mockRejectedValue(
+      new DuplicateIdentifierMappingError('ShopProduct', EXT, 'woocommerce', CONN)
+    );
+
+    const result = await service.executePublish(input);
+
+    expect(result.outcome).toBe('ok');
+  });
+
+  it('should propagate a transient (non-domain) adapter error for worker retry', async () => {
+    adapter.publishProduct.mockRejectedValue(new Error('network down'));
+
+    await expect(service.executePublish(input)).rejects.toThrow('network down');
+    expect(records.updateStatus).not.toHaveBeenCalled();
+  });
+});

--- a/libs/core/src/listings/application/services/attribute-projection.service.ts
+++ b/libs/core/src/listings/application/services/attribute-projection.service.ts
@@ -47,7 +47,8 @@ export class AttributeProjectionService implements IAttributeProjectionService {
   ) {}
 
   async project(input: AttributeProjectionInput): Promise<AttributeProjectionResult> {
-    const { sourceConnectionId, destinationConnectionId, destinationCategoryId, attributes } = input;
+    const { sourceConnectionId, destinationConnectionId, destinationCategoryId, attributes } =
+      input;
 
     const all = await this.mappingConfig.getAttributeMappings(destinationConnectionId);
     const applicable = this.selectApplicableMappings(
@@ -58,7 +59,7 @@ export class AttributeProjectionService implements IAttributeProjectionService {
 
     const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
       destinationConnectionId,
-      'OfferManager'
+      input.destinationCapability ?? 'OfferManager'
     );
 
     const parameters: ResolvedParameter[] = [];

--- a/libs/core/src/listings/application/services/product-publish-builder.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-builder.service.ts
@@ -1,0 +1,285 @@
+/**
+ * Product Publish Builder Service
+ *
+ * Assembles a platform-neutral `PublishProductCommand` from an OL internal
+ * variant id. Fetches variant metadata via `IProductsService`, resolves the
+ * parent master product via `ProductMasterPort` (name/description/images/price/
+ * categories), **provisions** the destination category on the shop
+ * (open-provenance, via `CategoryProvisioner` when the destination supports it),
+ * projects the variant's attributes into neutral `OfferParameter[]` via
+ * `IAttributeProjectionService`, and validates required fields — throwing
+ * `ProductPublishBuilderValidationException` so `ProductPublishExecutionService`
+ * maps it to `business_failure` (ADR-007).
+ *
+ * Shop-side sibling of `OfferBuilderService`. Two deliberate departures:
+ *  - Category placement is **provisioning-only** here (not the marketplace
+ *    `CategoryResolutionService` chain, which resolves `'OfferManager'` and runs
+ *    on the offer hot path). No provisioner / no source categories → publish
+ *    uncategorised (not a gate failure).
+ *  - The publish gate has no offer/product section split — every unresolved
+ *    required destination parameter blocks.
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {IProductPublishBuilderService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+
+import { Logger } from '@openlinker/shared/logging';
+import { CONNECTION_PORT_TOKEN, ConnectionPort } from '@openlinker/core/identifier-mapping';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import type {
+  OfferParameter,
+  ProvisionCategoryCommand,
+  PublishProductCommand,
+  PublishProductContent,
+  ShopProductManagerPort,
+} from '@openlinker/core/listings';
+import { isCategoryProvisioner } from '@openlinker/core/listings';
+import type { Category, ProductMasterPort } from '@openlinker/core/products';
+import { IProductsService, PRODUCTS_SERVICE_TOKEN } from '@openlinker/core/products';
+
+import { MasterCatalogConnectionNotConfiguredException } from '../../domain/exceptions/master-catalog-connection-not-configured.exception';
+import type { ProductPublishBuilderValidationIssue } from '../../domain/exceptions/product-publish-builder-validation.exception';
+import { ProductPublishBuilderValidationException } from '../../domain/exceptions/product-publish-builder-validation.exception';
+import { ATTRIBUTE_PROJECTION_SERVICE_TOKEN } from '../../listings.tokens';
+import { IAttributeProjectionService } from '../interfaces/attribute-projection.service.interface';
+import type { IProductPublishBuilderService } from '../interfaces/product-publish-builder.service.interface';
+import type { BuildPublishProductCommandInput } from '../types/product-publish-builder.types';
+
+@Injectable()
+export class ProductPublishBuilderService implements IProductPublishBuilderService {
+  private readonly logger = new Logger(ProductPublishBuilderService.name);
+
+  constructor(
+    @Inject(PRODUCTS_SERVICE_TOKEN)
+    private readonly productsService: IProductsService,
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connectionPort: ConnectionPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+    @Inject(ATTRIBUTE_PROJECTION_SERVICE_TOKEN)
+    private readonly attributeProjection: IAttributeProjectionService
+  ) {}
+
+  async buildPublishProductCommand(
+    input: BuildPublishProductCommandInput
+  ): Promise<PublishProductCommand> {
+    const issues: ProductPublishBuilderValidationIssue[] = [];
+
+    const variant = await this.productsService.getVariant(input.internalVariantId);
+    if (!variant) {
+      throw new ProductPublishBuilderValidationException([
+        {
+          field: 'internalVariantId',
+          code: 'NOT_FOUND',
+          message: `Variant ${input.internalVariantId} not found`,
+        },
+      ]);
+    }
+
+    const connection = await this.connectionPort.get(input.connectionId);
+    const masterConnectionId = this.readMasterCatalogConnectionId(connection.config);
+    if (!masterConnectionId) {
+      throw new MasterCatalogConnectionNotConfiguredException(input.connectionId);
+    }
+
+    const productMaster = await this.integrationsService.getCapabilityAdapter<ProductMasterPort>(
+      masterConnectionId,
+      'ProductMaster'
+    );
+    const product = await productMaster.getProduct(variant.productId);
+
+    const price = this.resolvePrice(input, product, issues);
+    if (issues.length > 0) {
+      throw new ProductPublishBuilderValidationException(issues);
+    }
+
+    const destinationCategoryIds = await this.provisionCategory(input.connectionId, productMaster, variant.productId);
+    const parameters = await this.projectParameters(
+      input,
+      masterConnectionId,
+      destinationCategoryIds[0] ?? null,
+      variant.attributes ?? {}
+    );
+
+    const content = this.buildContent(input.content, product);
+
+    const command: PublishProductCommand = {
+      internalVariantId: input.internalVariantId,
+      connectionId: input.connectionId,
+      destinationCategoryIds,
+      // `price` is guaranteed defined here — `issues` would have caught it above.
+      price: price as { amount: number; currency: string },
+      stock: input.stock,
+      status: input.status,
+      ...(content ? { content } : {}),
+      ...(parameters.length > 0 ? { parameters } : {}),
+      ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
+    };
+
+    this.logger.debug(
+      `Built PublishProductCommand for variant=${input.internalVariantId} connection=${input.connectionId} categories=${destinationCategoryIds.length} params=${parameters.length} status=${input.status}`
+    );
+
+    return command;
+  }
+
+  /**
+   * Provision the destination category path (open-provenance, ADR-024 §2) when
+   * the shop adapter supports `CategoryProvisioner`. Best-effort: no provisioner
+   * or no source categories → `[]` (publish uncategorised). The source path is
+   * built from the master product's categories ordered root→leaf by `depth`.
+   */
+  private async provisionCategory(
+    connectionId: string,
+    productMaster: ProductMasterPort,
+    productId: string
+  ): Promise<string[]> {
+    const adapter = await this.integrationsService.getCapabilityAdapter<ShopProductManagerPort>(
+      connectionId,
+      'ProductPublisher'
+    );
+    if (!isCategoryProvisioner(adapter)) {
+      return [];
+    }
+
+    const categories = await productMaster.getProductCategories(productId);
+    const path = this.toProvisionPath(categories);
+    if (path.length === 0) {
+      return [];
+    }
+
+    const cmd: ProvisionCategoryCommand = { connectionId, path };
+    const result = await adapter.provisionCategory(cmd);
+    return [result.destinationCategoryId];
+  }
+
+  /**
+   * Order the product's source categories root→leaf and map them to the
+   * provision path shape. MVP best-effort: sorts by `depth` ascending
+   * (root→leaf); platforms without a depth report keep the returned order.
+   * Assumes a single category branch — multi-branch products provision the
+   * combined ordered list (a documented MVP limitation, refined alongside
+   * multi-category placement).
+   */
+  private toProvisionPath(categories: Category[]): { sourceCategoryId: string; name: string }[] {
+    return [...categories]
+      .sort((a, b) => (a.depth ?? 0) - (b.depth ?? 0))
+      .map((c) => ({ sourceCategoryId: c.id, name: c.name }));
+  }
+
+  /**
+   * Project the variant's attributes into neutral `OfferParameter[]` and gate
+   * on unresolved required destination parameters (all sections — shops have no
+   * offer/product split). `destinationCategoryId` null (uncategorised) ⇒ skip
+   * projection (no category schema to project against).
+   */
+  private async projectParameters(
+    input: BuildPublishProductCommandInput,
+    sourceConnectionId: string,
+    destinationCategoryId: string | null,
+    attributes: Record<string, string>
+  ): Promise<OfferParameter[]> {
+    if (!destinationCategoryId) {
+      return [];
+    }
+    const projection = await this.attributeProjection.project({
+      sourceConnectionId,
+      destinationConnectionId: input.connectionId,
+      destinationCategoryId,
+      attributes,
+      // Shop connections expose the schema reader under `ProductPublisher`, not
+      // the marketplace `OfferManager` (which they don't support — resolving it
+      // would throw `CapabilityNotSupportedException`).
+      destinationCapability: 'ProductPublisher',
+    });
+
+    if (projection.unresolvedRequired.length > 0) {
+      throw new ProductPublishBuilderValidationException(
+        projection.unresolvedRequired.map((param) => ({
+          field: `parameters.${param.name}`,
+          code: 'PARAMETER_REQUIRED',
+          message: `Required destination parameter "${param.name}" (id=${param.id}) has no resolvable value; map the source attribute or supply it explicitly`,
+        }))
+      );
+    }
+
+    if (projection.unmappedSourceKeys.length > 0) {
+      this.logger.warn(
+        `Omitting ${projection.unmappedSourceKeys.length} unmapped source attribute(s) for variant=${input.internalVariantId} connection=${input.connectionId}: ${projection.unmappedSourceKeys.join(', ')}`
+      );
+    }
+
+    return projection.parameters;
+  }
+
+  /**
+   * Merge caller content overrides with master-product fallbacks, stripping
+   * null/undefined so adapters see a consistent "absent field". Returns
+   * `undefined` when nothing resolved (keeps the command shape tidy).
+   */
+  private buildContent(
+    overrides: PublishProductContent | undefined,
+    product: { name: string; description: string | null; images: string[] | null }
+  ): PublishProductContent | undefined {
+    const title = overrides?.title ?? product.name;
+    const description = overrides?.description ?? product.description;
+    const imageUrls = overrides?.imageUrls ?? product.images;
+
+    const content: PublishProductContent = {};
+    if (title != null) content.title = title;
+    if (description != null) content.description = description;
+    if (imageUrls != null) content.imageUrls = imageUrls;
+    if (overrides?.seo != null) content.seo = overrides.seo;
+
+    return Object.keys(content).length > 0 ? content : undefined;
+  }
+
+  private resolvePrice(
+    input: BuildPublishProductCommandInput,
+    product: { price: number | null; currency: string | null },
+    issues: ProductPublishBuilderValidationIssue[]
+  ): { amount: number; currency: string } | null {
+    if (input.price) {
+      return input.price;
+    }
+    const amount = product.price;
+    const currency = product.currency;
+    if (typeof amount !== 'number') {
+      issues.push({
+        field: 'price.amount',
+        code: 'REQUIRED',
+        message:
+          'Price amount could not be resolved from input or master product; provide input.price explicitly',
+      });
+      return null;
+    }
+    if (amount <= 0) {
+      issues.push({
+        field: 'price.amount',
+        code: 'NON_POSITIVE',
+        message: `Master product price (${amount}) is not a positive value; provide input.price explicitly`,
+      });
+      return null;
+    }
+    if (!currency) {
+      issues.push({
+        field: 'price.currency',
+        code: 'REQUIRED',
+        message:
+          'Currency could not be resolved from input or master product; provide input.price explicitly',
+      });
+      return null;
+    }
+    return { amount, currency };
+  }
+
+  private readMasterCatalogConnectionId(
+    config: Record<string, unknown> | null | undefined
+  ): string | null {
+    if (!config) return null;
+    const value = config['masterCatalogConnectionId'];
+    return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+}

--- a/libs/core/src/listings/application/services/product-publish-execution.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-execution.service.ts
@@ -1,0 +1,264 @@
+/**
+ * Product Publish Execution Service
+ *
+ * Owns the orchestration policy for publishing a product onto a shop destination
+ * (OL → WooCommerce / Shopify, #1042, ADR-024). The `shop.product.publish`
+ * worker handler and the future REST endpoint (#1044) both delegate here so
+ * publish semantics stay in one place (architecture-overview.md §6).
+ *
+ * Flow:
+ *   1. Load or create the ListingCreationRecord.
+ *   2. Resolve create-vs-upsert: look up the `ShopProduct` IdentifierMapping for
+ *      this (variant, connection) → set `externalProductId` for an upsert.
+ *   3. Build the neutral PublishProductCommand (ProductPublishBuilderService).
+ *   4. Resolve the shop adapter and call `publishProduct`.
+ *   5. On first publish, persist the IdentifierMapping (idempotent on retry).
+ *   6. Update the record with externalProductId + final status.
+ *
+ * Terminal domain failures (builder validation, master-catalog misconfig, shop
+ * reject) are caught and recorded as `status='failed'`; the method resolves
+ * normally so the worker runner treats the job as succeeded and does not retry.
+ * Transient / unknown errors propagate.
+ *
+ * Concurrency: two concurrent *first* publishes of the same variant create two
+ * distinct shop products (shop create is not platform-idempotent; the mapping
+ * records one). Bounded by the job-level `idempotencyKey` dedup (#726
+ * at-most-once enqueue) — the enqueue gate is the guard, not a DB constraint.
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {IProductPublishExecutionService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+
+import {
+  CORE_ENTITY_TYPE,
+  DuplicateIdentifierMappingError,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  IIdentifierMappingService,
+} from '@openlinker/core/identifier-mapping';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import type {
+  CreateOfferValidationError,
+  PublishProductCommand,
+  PublishProductResult,
+  ShopProductManagerPort,
+} from '@openlinker/core/listings';
+import { ProductPublishRejectedException } from '@openlinker/core/listings';
+import type { JobOutcome } from '@openlinker/core/sync';
+import { Logger } from '@openlinker/shared/logging';
+
+import type { ListingCreationRecord } from '../../domain/entities/listing-creation-record.entity';
+import { ListingCreationInvariantException } from '../../domain/exceptions/listing-creation-invariant.exception';
+import { ListingCreationRecordNotFoundException } from '../../domain/exceptions/listing-creation-record-not-found.exception';
+import { MasterCatalogConnectionNotConfiguredException } from '../../domain/exceptions/master-catalog-connection-not-configured.exception';
+import type { ProductPublishBuilderValidationIssue } from '../../domain/exceptions/product-publish-builder-validation.exception';
+import { ProductPublishBuilderValidationException } from '../../domain/exceptions/product-publish-builder-validation.exception';
+import { ListingCreationRecordRepositoryPort } from '../../domain/ports/listing-creation-record-repository.port';
+import {
+  LISTING_CREATION_STATUS,
+  type ListingCreationError,
+} from '../../domain/types/listing-creation-record.types';
+import {
+  LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
+  PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,
+} from '../../listings.tokens';
+import { IProductPublishBuilderService } from '../interfaces/product-publish-builder.service.interface';
+import type { IProductPublishExecutionService } from '../interfaces/product-publish-execution.service.interface';
+import type {
+  ExecutePublishProductInput,
+  ExecutePublishProductResult,
+} from '../types/product-publish-execution.types';
+
+@Injectable()
+export class ProductPublishExecutionService implements IProductPublishExecutionService {
+  private readonly logger = new Logger(ProductPublishExecutionService.name);
+
+  constructor(
+    @Inject(PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN)
+    private readonly builder: IProductPublishBuilderService,
+    @Inject(LISTING_CREATION_RECORD_REPOSITORY_TOKEN)
+    private readonly listingRecords: ListingCreationRecordRepositoryPort,
+    @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
+    private readonly identifierMapping: IIdentifierMappingService,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService
+  ) {}
+
+  async executePublish(input: ExecutePublishProductInput): Promise<ExecutePublishProductResult> {
+    const record = await this.loadOrCreateRecord(input);
+
+    // Create-vs-upsert: the `ShopProduct` mapping is keyed (entityType,
+    // internalId) on the reverse lookup, so filter by connectionId to get
+    // *this* shop's external product id.
+    const existingExternalProductId = await this.resolveExistingExternalProductId(input);
+
+    let command: PublishProductCommand;
+    try {
+      command = await this.builder.buildPublishProductCommand({
+        internalVariantId: input.internalVariantId,
+        connectionId: input.connectionId,
+        stock: input.stock,
+        status: input.status,
+        price: input.price,
+        content: input.content,
+        idempotencyKey: input.idempotencyKey,
+      });
+    } catch (error) {
+      const terminal = this.mapBuilderException(error);
+      if (terminal) {
+        const updated = await this.listingRecords.updateStatus(
+          record.id,
+          LISTING_CREATION_STATUS.Failed,
+          terminal
+        );
+        return this.buildResult(updated, input.connectionId);
+      }
+      throw error;
+    }
+
+    if (existingExternalProductId) {
+      command = { ...command, externalProductId: existingExternalProductId };
+    }
+
+    const adapter = await this.integrationsService.getCapabilityAdapter<ShopProductManagerPort>(
+      input.connectionId,
+      'ProductPublisher'
+    );
+
+    let result: PublishProductResult;
+    try {
+      result = await adapter.publishProduct(command);
+    } catch (error) {
+      if (error instanceof ProductPublishRejectedException) {
+        const updated = await this.listingRecords.updateStatus(
+          record.id,
+          LISTING_CREATION_STATUS.Failed,
+          this.mapRejectionErrors(error)
+        );
+        return this.buildResult(updated, input.connectionId);
+      }
+      throw error;
+    }
+
+    // First publish only — persist the variant → external-product mapping.
+    // Upserts already have it. `DuplicateIdentifierMappingError` means a prior
+    // attempt inserted it; that is exactly what we wanted, so continue.
+    if (!existingExternalProductId) {
+      try {
+        await this.identifierMapping.createMapping(
+          CORE_ENTITY_TYPE.ShopProduct,
+          result.externalProductId,
+          input.connectionId,
+          input.internalVariantId
+        );
+      } catch (error) {
+        if (!(error instanceof DuplicateIdentifierMappingError)) {
+          throw error;
+        }
+      }
+    }
+
+    const finalRecord = await this.listingRecords.updateExternalIdAndStatus(
+      record.id,
+      result.externalProductId,
+      result.status,
+      null
+    );
+    return this.buildResult(finalRecord, input.connectionId);
+  }
+
+  private async resolveExistingExternalProductId(
+    input: ExecutePublishProductInput
+  ): Promise<string | null> {
+    const mappings = await this.identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.ShopProduct,
+      input.internalVariantId
+    );
+    const forConnection = mappings.find((m) => m.connectionId === input.connectionId);
+    return forConnection?.externalId ?? null;
+  }
+
+  private async loadOrCreateRecord(
+    input: ExecutePublishProductInput
+  ): Promise<ListingCreationRecord> {
+    if (input.listingCreationRecordId) {
+      const existing = await this.listingRecords.findById(input.listingCreationRecordId);
+      if (!existing) {
+        throw new ListingCreationRecordNotFoundException(input.listingCreationRecordId);
+      }
+      return existing;
+    }
+    return this.listingRecords.create({
+      internalVariantId: input.internalVariantId,
+      connectionId: input.connectionId,
+      status: LISTING_CREATION_STATUS.Pending,
+      externalProductId: null,
+      errors: null,
+    });
+  }
+
+  /**
+   * Map an `ListingCreationRecord` to its `JobOutcome`. `published`/`draft` →
+   * `ok` (the publish itself succeeded); `failed` → `business_failure`. A final
+   * `pending` is an unreachable invariant.
+   */
+  private recordToOutcome(record: ListingCreationRecord): JobOutcome {
+    switch (record.status) {
+      case LISTING_CREATION_STATUS.Failed:
+        return 'business_failure';
+      case LISTING_CREATION_STATUS.Published:
+      case LISTING_CREATION_STATUS.Draft:
+        return 'ok';
+      case LISTING_CREATION_STATUS.Pending:
+        throw new ListingCreationInvariantException(record.id, record.status);
+      default: {
+        const _exhaustive: never = record.status;
+        return _exhaustive;
+      }
+    }
+  }
+
+  private buildResult(
+    record: ListingCreationRecord,
+    connectionId: string
+  ): ExecutePublishProductResult {
+    const outcome = this.recordToOutcome(record);
+    if (outcome === 'business_failure') {
+      this.logger.warn(
+        `Product publish recorded business_failure. recordId=${record.id} connectionId=${connectionId} errorCount=${record.errors?.length ?? 0}`
+      );
+    }
+    return { listingCreationRecord: record, outcome };
+  }
+
+  private mapBuilderException(error: unknown): ListingCreationError[] | null {
+    if (error instanceof ProductPublishBuilderValidationException) {
+      return error.issues.map((issue: ProductPublishBuilderValidationIssue) => ({
+        field: issue.field,
+        code: issue.code,
+        message: issue.message,
+      }));
+    }
+    if (error instanceof MasterCatalogConnectionNotConfiguredException) {
+      // Re-word channel-neutral for the shop record — the shared exception's
+      // message is marketplace/offer-worded (reused from the offer path).
+      return [
+        {
+          field: 'connection.config.masterCatalogConnectionId',
+          code: 'MASTER_CATALOG_NOT_CONFIGURED',
+          message: `Shop connection ${error.marketplaceConnectionId} has no masterCatalogConnectionId configured; cannot resolve master product data to publish`,
+        },
+      ];
+    }
+    return null;
+  }
+
+  private mapRejectionErrors(error: ProductPublishRejectedException): ListingCreationError[] {
+    return error.errors.map((e: CreateOfferValidationError) => ({
+      field: e.field,
+      code: e.code,
+      message: e.message,
+    }));
+  }
+}

--- a/libs/core/src/listings/application/types/attribute-projection.types.ts
+++ b/libs/core/src/listings/application/types/attribute-projection.types.ts
@@ -22,6 +22,17 @@ export interface AttributeProjectionInput {
   destinationCategoryId: string;
   /** The variant's descriptive attributes (e.g. `{ Color: 'Red' }`). */
   attributes: Record<string, string>;
+  /**
+   * Capability the destination adapter is resolved under to read its live
+   * category schema (the `CategoryParametersReader` provenance branch). Defaults
+   * to `'OfferManager'` (the marketplace offer path). The shop-publish path
+   * (#1042) passes `'ProductPublisher'` — a shop connection never supports
+   * `'OfferManager'`, so resolving it would throw. The structural
+   * `isCategoryParametersReader` guard is capability-agnostic: a destination
+   * without a parameters reader falls through to the name-keyed pass-through
+   * branch regardless of which capability resolved it.
+   */
+  destinationCapability?: string;
 }
 
 /**

--- a/libs/core/src/listings/application/types/product-publish-builder.types.ts
+++ b/libs/core/src/listings/application/types/product-publish-builder.types.ts
@@ -1,0 +1,34 @@
+/**
+ * Product Publish Builder Types
+ *
+ * Input shape for `IProductPublishBuilderService.buildPublishProductCommand`.
+ * The service resolves the OL variant + parent master product, provisions the
+ * destination category (open-provenance, via `CategoryProvisioner`), projects
+ * the variant's attributes into neutral `OfferParameter[]`, and produces a
+ * neutral `PublishProductCommand` for any shop adapter implementing
+ * `ShopProductManagerPort.publishProduct` (#1042, #1072).
+ *
+ * @module libs/core/src/listings/application/types
+ */
+
+import type { PublishProductContent, PublishProductStatus } from '@openlinker/core/listings';
+
+export interface BuildPublishProductCommandInput {
+  /** OL internal variant id being published. */
+  internalVariantId: string;
+  /** Target shop connection id. */
+  connectionId: string;
+  /** Stock quantity to expose on the shop. */
+  stock: number;
+  /** Target publication state (`draft` | `published`). */
+  status: PublishProductStatus;
+  /**
+   * Optional explicit price. When omitted, the builder resolves a price from the
+   * master product (requires both amount and currency).
+   */
+  price?: { amount: number; currency: string };
+  /** Optional owned-record content overrides; missing fields fall back to the master product. */
+  content?: PublishProductContent;
+  /** Optional idempotency key forwarded to the produced command. */
+  idempotencyKey?: string;
+}

--- a/libs/core/src/listings/application/types/product-publish-execution.types.ts
+++ b/libs/core/src/listings/application/types/product-publish-execution.types.ts
@@ -1,0 +1,50 @@
+/**
+ * Product Publish Execution Types
+ *
+ * Input/result contract for `IProductPublishExecutionService.executePublish`,
+ * the core orchestration step of an OL → shop product publish (#1042).
+ *
+ * @module libs/core/src/listings/application/types
+ */
+
+import type { PublishProductContent, PublishProductStatus } from '@openlinker/core/listings';
+import type { JobOutcome } from '@openlinker/core/sync';
+
+import type { ListingCreationRecord } from '../../domain/entities/listing-creation-record.entity';
+
+export interface ExecutePublishProductInput {
+  /** OL internal variant id being published. */
+  internalVariantId: string;
+  /** Target shop connection id. */
+  connectionId: string;
+  /** Stock quantity to expose on the shop. */
+  stock: number;
+  /** Target publication state (`draft` | `published`). */
+  status: PublishProductStatus;
+  /** Optional caller-supplied price; when omitted, builder falls back to master product. */
+  price?: { amount: number; currency: string };
+  /** Optional owned-record content overrides. */
+  content?: PublishProductContent;
+  /** Optional idempotency key threaded to the adapter. */
+  idempotencyKey?: string;
+  /**
+   * Existing ListingCreationRecord id to update, if the caller pre-created one.
+   * When absent, the service creates a fresh record with status='pending'.
+   */
+  listingCreationRecordId?: string;
+}
+
+export interface ExecutePublishProductResult {
+  /** Terminal-state record after the flow finishes (success or recorded failure). */
+  listingCreationRecord: ListingCreationRecord;
+  /**
+   * Business outcome:
+   * - `'ok'` when the record landed in `published` / `draft`,
+   * - `'business_failure'` when the record landed in `failed` (builder
+   *   validation, master-catalog misconfig, shop rejection).
+   *
+   * Threaded back through the worker handler to `SyncJobRunner`
+   * (`sync_jobs.outcome`).
+   */
+  outcome: JobOutcome;
+}

--- a/libs/core/src/listings/domain/entities/listing-creation-record.entity.ts
+++ b/libs/core/src/listings/domain/entities/listing-creation-record.entity.ts
@@ -1,0 +1,32 @@
+/**
+ * Listing Creation Record Domain Entity
+ *
+ * Tracks the lifecycle of an OL-initiated product publish onto a shop
+ * destination (OL → WooCommerce / Shopify / …, #1042, ADR-024). Complements the
+ * `IdentifierMapping` row (`entityType: 'ShopProduct'`) which records the
+ * variant → external-product linkage once the product exists — this record
+ * tracks the *publish attempt* itself, including pending state before the
+ * adapter is called and structured errors when the shop rejects it.
+ *
+ * Immutable (anemic) per ADR-011 — state changes go through repository methods.
+ *
+ * @module libs/core/src/listings/domain/entities
+ */
+
+import type {
+  ListingCreationError,
+  ListingCreationStatus,
+} from '../types/listing-creation-record.types';
+
+export class ListingCreationRecord {
+  constructor(
+    public readonly id: string,
+    public readonly internalVariantId: string,
+    public readonly connectionId: string,
+    public readonly externalProductId: string | null,
+    public readonly status: ListingCreationStatus,
+    public readonly errors: ListingCreationError[] | null,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date
+  ) {}
+}

--- a/libs/core/src/listings/domain/exceptions/listing-creation-invariant.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/listing-creation-invariant.exception.ts
@@ -1,0 +1,25 @@
+/**
+ * Listing Creation Invariant Exception
+ *
+ * Domain exception thrown when `ProductPublishExecutionService.executePublish`
+ * is about to return with the underlying `ListingCreationRecord` still in its
+ * initial `pending` status. That state is unreachable in normal flow — the
+ * orchestrator either persists a terminal `failed` status on a domain rejection
+ * or transitions to `published`/`draft` on success.
+ *
+ * Surfacing the violation as a typed exception (rather than a bare `Error`) lets
+ * the worker runner classify it as a non-retryable code bug and mirrors the
+ * offer path's {@link OfferCreationInvariantException}.
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+export class ListingCreationInvariantException extends Error {
+  constructor(recordId: string, actualStatus: string) {
+    super(
+      `ListingCreationRecord ${recordId} returned in invariant-violating status: ` +
+        `${actualStatus}. Expected one of: failed | published | draft.`
+    );
+    this.name = 'ListingCreationInvariantException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/listings/domain/exceptions/listing-creation-record-not-found.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/listing-creation-record-not-found.exception.ts
@@ -1,0 +1,16 @@
+/**
+ * Listing Creation Record Not Found Exception
+ *
+ * Thrown by `ListingCreationRecordRepositoryPort` update paths when the target
+ * row does not exist. Mirrors `OfferCreationRecordNotFoundException`.
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+
+export class ListingCreationRecordNotFoundException extends Error {
+  constructor(public readonly recordId: string) {
+    super(`Listing creation record not found: ${recordId}`);
+    this.name = 'ListingCreationRecordNotFoundException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/listings/domain/exceptions/product-publish-builder-validation.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/product-publish-builder-validation.exception.ts
@@ -1,0 +1,36 @@
+/**
+ * Product Publish Builder Validation Exception
+ *
+ * Domain exception raised by `ProductPublishBuilderService` when one or more
+ * required fields for publishing a product to a shop cannot be resolved from
+ * the variant, master product, caller overrides, or attribute projection
+ * (e.g. an unresolved required destination parameter). Carries a list of
+ * field-level issues so callers surface all problems at once.
+ *
+ * The shop-side neutral sibling of `OfferBuilderValidationException` — kept
+ * distinct so the shop builder does not import an offer-named symbol. The
+ * execution service maps it to a `failed` record + `business_failure` outcome.
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+
+export interface ProductPublishBuilderValidationIssue {
+  /** Dotted path of the field the issue applies to (e.g. `parameters.Brand`). */
+  field: string;
+  /** Machine-readable code (e.g. `NOT_FOUND`, `REQUIRED`). */
+  code: string;
+  /** Human-readable message suitable for operator display. */
+  message: string;
+}
+
+export class ProductPublishBuilderValidationException extends Error {
+  constructor(public readonly issues: ProductPublishBuilderValidationIssue[]) {
+    super(
+      `Product publish builder validation failed (${issues.length} issue${
+        issues.length === 1 ? '' : 's'
+      }): ${issues.map((i) => `${i.field}:${i.code}`).join(', ')}`
+    );
+    this.name = 'ProductPublishBuilderValidationException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/listings/domain/ports/listing-creation-record-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/listing-creation-record-repository.port.ts
@@ -1,0 +1,74 @@
+/**
+ * Listing Creation Record Repository Port
+ *
+ * Persistence contract for `ListingCreationRecord` (shop publish lifecycle,
+ * #1042). Implemented in the listings infrastructure layer. Returns domain
+ * entities only — ORM mapping stays inside the repository. The method set is
+ * the subset the shop publish execution service actually uses (no bulk /
+ * classification / retry methods — those are marketplace-offer-only today).
+ *
+ * @module libs/core/src/listings/domain/ports
+ */
+
+import type { ListingCreationRecord } from '../entities/listing-creation-record.entity';
+import type {
+  CreateListingCreationRecordInput,
+  ListingCreationError,
+  ListingCreationStatus,
+} from '../types/listing-creation-record.types';
+
+export interface ListingCreationRecordRepositoryPort {
+  /**
+   * Persist a new listing creation record. `id`, `createdAt`, and `updatedAt`
+   * are assigned by the repository.
+   */
+  create(input: CreateListingCreationRecordInput): Promise<ListingCreationRecord>;
+
+  /** Look up a record by primary key. Returns null when not found. */
+  findById(id: string): Promise<ListingCreationRecord | null>;
+
+  /**
+   * Return the most-recently-created record for a (internalVariantId,
+   * connectionId) pair, ordered `createdAt DESC`. Null when none exists.
+   * Multiple records per pair are expected (retry attempts after failures).
+   */
+  findLatestByVariantAndConnection(
+    variantId: string,
+    connectionId: string
+  ): Promise<ListingCreationRecord | null>;
+
+  /**
+   * Look up the record that produced a given shop product. Matches by
+   * (externalProductId, connectionId) so cross-connection collisions do not
+   * return a false positive. Returns null when no record has been linked.
+   */
+  findByExternalProductIdAndConnectionId(
+    externalProductId: string,
+    connectionId: string
+  ): Promise<ListingCreationRecord | null>;
+
+  /**
+   * Update status (and optionally errors). `errors` semantics: omit to
+   * preserve, `null` to clear, array to replace. Throws
+   * `ListingCreationRecordNotFoundException` if the record does not exist.
+   */
+  updateStatus(
+    id: string,
+    status: ListingCreationStatus,
+    errors?: ListingCreationError[] | null
+  ): Promise<ListingCreationRecord>;
+
+  /**
+   * Atomically set externalProductId, status, and errors in a single write
+   * (avoids the `externalProductId set but status still 'pending'` intermediate
+   * state two separate updates would leave on a mid-write crash). `errors`
+   * follows the same three-valued semantics as `updateStatus`. Throws
+   * `ListingCreationRecordNotFoundException` if the record does not exist.
+   */
+  updateExternalIdAndStatus(
+    id: string,
+    externalProductId: string,
+    status: ListingCreationStatus,
+    errors?: ListingCreationError[] | null
+  ): Promise<ListingCreationRecord>;
+}

--- a/libs/core/src/listings/domain/types/listing-creation-record.types.ts
+++ b/libs/core/src/listings/domain/types/listing-creation-record.types.ts
@@ -1,0 +1,67 @@
+/**
+ * Listing Creation Record Types
+ *
+ * Types for `ListingCreationRecord` — OL's persisted lifecycle tracker for a
+ * product published outbound onto a **shop** destination (OL → WooCommerce /
+ * Shopify / …) via `ShopProductManagerPort.publishProduct` (#1042, ADR-024).
+ * The shop-side sibling of `offer-creation-record.types.ts`; a separate table
+ * keeps the hot marketplace offer path untouched.
+ *
+ * The shop lifecycle has no async-validation hop — a publish lands directly at
+ * `draft` or `published` (or `failed`), so the status set is narrower than the
+ * marketplace `OfferCreationStatus` (which carries `validating` / `active`).
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+import type { OfferCreationError } from './offer-creation-record.types';
+
+/**
+ * Neutral structured error persisted in `ListingCreationRecord.errors`. Reuses
+ * the marketplace `OfferCreationError` shape (`{ field?, code, message }`) — it
+ * is platform-neutral — re-exported under a listing-neutral name so the shop
+ * path doesn't import an offer-named symbol at call sites.
+ */
+export type ListingCreationError = OfferCreationError;
+
+/**
+ * Persisted lifecycle status for an OL-initiated shop product publish.
+ *
+ * - `pending`: Job enqueued, shop adapter not yet called.
+ * - `draft`: Adapter created/updated the product record, not buyer-visible.
+ * - `published`: Product record live and visible on the storefront.
+ * - `failed`: Publish was rejected terminally. See `errors` on the record.
+ */
+export const ListingCreationStatusValues = ['pending', 'draft', 'published', 'failed'] as const;
+
+export type ListingCreationStatus = (typeof ListingCreationStatusValues)[number];
+
+/**
+ * Named-constant map for the listing-creation lifecycle status (mirrors
+ * `OFFER_CREATION_STATUS`, #668). `as const satisfies Record<Capitalize<…>, …>`
+ * keeps the map in lockstep with the union on both axes.
+ */
+export const LISTING_CREATION_STATUS = {
+  Pending: 'pending',
+  Draft: 'draft',
+  Published: 'published',
+  Failed: 'failed',
+} as const satisfies Record<Capitalize<ListingCreationStatus>, ListingCreationStatus>;
+
+/**
+ * Input contract for `ListingCreationRecordRepositoryPort.create`. Dedicated
+ * input type (not `Omit<ListingCreationRecord, …>`) so the write contract is
+ * decoupled from the entity's readonly shape.
+ */
+export interface CreateListingCreationRecordInput {
+  /** OL internal variant id being published. */
+  internalVariantId: string;
+  /** Target shop connection id. */
+  connectionId: string;
+  /** Initial lifecycle status — typically `'pending'`. */
+  status: ListingCreationStatus;
+  /** Shop-native product id, if already known at creation time. Null otherwise. */
+  externalProductId?: string | null;
+  /** Structured errors when the initial status is already `'failed'`. Null otherwise. */
+  errors?: ListingCreationError[] | null;
+}

--- a/libs/core/src/listings/domain/types/product-publish.types.ts
+++ b/libs/core/src/listings/domain/types/product-publish.types.ts
@@ -10,15 +10,17 @@
  * draft/published status, owned-record content/images/SEO, and price/stock as
  * product fields (ADR-024 §1, §3).
  *
- * Platform-specific fields (and projected category parameters, applied by the
- * #1042 builder) ride in `platformParams` as an opaque record the adapter
- * interprets — mirroring `CreateOfferOverrides.platformParams`. The command is
- * deliberately free of the application-layer `ResolvedParameter` shape so it
- * stays domain-pure (no domain→application edge).
+ * Projected/operator category parameters travel on the typed neutral
+ * `parameters: OfferParameter[]` field (#1072) — the same domain channel the
+ * offer side uses (#1039), not the opaque `platformParams` bag. `OfferParameter`
+ * is a domain type, so the command references it without a domain→application
+ * edge. `platformParams` is reserved for un-modeled shop knobs only.
  *
  * @module libs/core/src/listings/domain/types
  * @see {@link ShopProductManagerPort} for the port that consumes these.
  */
+
+import type { OfferParameter } from './offer-parameter.types';
 
 /**
  * Publication state of a shop product. Distinct from record existence and from
@@ -82,6 +84,17 @@ export interface PublishProductCommand {
   /** Owned-record content fields (title, description, images, SEO). */
   content?: PublishProductContent;
   /**
+   * Neutral, section-tagged projected/operator category parameters (#1072,
+   * ADR-024 §Flow). Produced by core (attribute projection on the ADR-023
+   * open-provenance pass-through); shaped to the shop's wire form **only** in
+   * the destination adapter (WooCommerce → global/custom attributes, Shopify →
+   * category metafields). Shares the exact `OfferParameter` channel the offer
+   * side uses (#1039) so offer and shop carry projected parameters identically
+   * — they do **not** ride `platformParams`. Absent/empty ⇒ no projected
+   * parameters for this product.
+   */
+  parameters?: OfferParameter[];
+  /**
    * Shop-native product id when this is an upsert (already published). Absent /
    * `null` → create a new product and map it. Resolved by the #1042 execution
    * service via `IdentifierMapping`.
@@ -90,9 +103,10 @@ export interface PublishProductCommand {
   /** Optional idempotency key for deduplication at the adapter / job layer. */
   idempotencyKey?: string;
   /**
-   * Platform-specific fields the adapter interprets directly (tax class,
-   * shipping class, product type, projected category parameters, …). The
-   * core command stays platform-neutral; adapters read only the keys they know.
+   * Un-modeled platform-specific shop knobs the adapter interprets directly
+   * (tax class, shipping class, product type, …). **NOT** category parameters —
+   * those travel on `parameters` as the neutral `OfferParameter` channel (#1072).
+   * The core command stays platform-neutral; adapters read only the keys they know.
    */
   platformParams?: Record<string, unknown>;
 }

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -299,5 +299,30 @@ export type {
 } from './domain/types/category-provision.types';
 export { ProductPublishRejectedException } from './domain/exceptions/product-publish-rejected.exception';
 
+// Shop publish execution (#1042, #1072) — pure contracts only (the two service
+// classes live on `@openlinker/core/listings/services`, never here).
+export { ListingCreationRecord } from './domain/entities/listing-creation-record.entity';
+export {
+  ListingCreationStatusValues,
+  LISTING_CREATION_STATUS,
+} from './domain/types/listing-creation-record.types';
+export type {
+  ListingCreationStatus,
+  ListingCreationError,
+  CreateListingCreationRecordInput,
+} from './domain/types/listing-creation-record.types';
+export type { ListingCreationRecordRepositoryPort } from './domain/ports/listing-creation-record-repository.port';
+export { ListingCreationInvariantException } from './domain/exceptions/listing-creation-invariant.exception';
+export { ListingCreationRecordNotFoundException } from './domain/exceptions/listing-creation-record-not-found.exception';
+export { ProductPublishBuilderValidationException } from './domain/exceptions/product-publish-builder-validation.exception';
+export type { ProductPublishBuilderValidationIssue } from './domain/exceptions/product-publish-builder-validation.exception';
+export type { IProductPublishBuilderService } from './application/interfaces/product-publish-builder.service.interface';
+export type { BuildPublishProductCommandInput } from './application/types/product-publish-builder.types';
+export type { IProductPublishExecutionService } from './application/interfaces/product-publish-execution.service.interface';
+export type {
+  ExecutePublishProductInput,
+  ExecutePublishProductResult,
+} from './application/types/product-publish-execution.types';
+
 // Tokens
 export * from './listings.tokens';

--- a/libs/core/src/listings/infrastructure/persistence/entities/listing-creation-record.orm-entity.ts
+++ b/libs/core/src/listings/infrastructure/persistence/entities/listing-creation-record.orm-entity.ts
@@ -1,0 +1,63 @@
+/**
+ * Listing Creation Record ORM Entity
+ *
+ * TypeORM entity for the `listing_creation_records` table — OL-initiated shop
+ * product publish attempts (#1042). Sibling of `offer_creation_records`.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/entities
+ * @see {@link ListingCreationRecord} for the corresponding domain entity
+ */
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+import type {
+  ListingCreationError,
+  ListingCreationStatus,
+} from '../../../domain/types/listing-creation-record.types';
+
+@Entity('listing_creation_records')
+@Index(['internalVariantId', 'connectionId'])
+@Index(['connectionId'])
+@Index(['status'])
+// Partial composite index for the `findByExternalProductIdAndConnectionId`
+// lookup. `WHERE "externalProductId" IS NOT NULL` keeps pending rows (null
+// external id) out of the index. Explicit name so the migration `down()` can
+// target it deterministically.
+@Index(
+  'IDX_listing_creation_records_external_product_connection',
+  ['externalProductId', 'connectionId'],
+  {
+    where: '"externalProductId" IS NOT NULL',
+  }
+)
+export class ListingCreationRecordOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'text' })
+  internalVariantId!: string;
+
+  @Column({ type: 'uuid' })
+  connectionId!: string;
+
+  @Column({ type: 'text', nullable: true })
+  externalProductId!: string | null;
+
+  @Column({ type: 'text' })
+  status!: ListingCreationStatus;
+
+  @Column({ type: 'jsonb', nullable: true })
+  errors!: ListingCreationError[] | null;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/libs/core/src/listings/infrastructure/persistence/repositories/listing-creation-record.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/listing-creation-record.repository.ts
@@ -1,0 +1,123 @@
+/**
+ * Listing Creation Record Repository
+ *
+ * TypeORM implementation of `ListingCreationRecordRepositoryPort` (#1042).
+ * Handles ORM ↔ domain mapping privately; callers receive domain entities only.
+ * Throws `ListingCreationRecordNotFoundException` on update paths when the row
+ * does not exist.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/repositories
+ * @implements {ListingCreationRecordRepositoryPort}
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { ListingCreationRecord } from '../../../domain/entities/listing-creation-record.entity';
+import { ListingCreationRecordNotFoundException } from '../../../domain/exceptions/listing-creation-record-not-found.exception';
+import type { ListingCreationRecordRepositoryPort } from '../../../domain/ports/listing-creation-record-repository.port';
+import type {
+  CreateListingCreationRecordInput,
+  ListingCreationError,
+  ListingCreationStatus,
+} from '../../../domain/types/listing-creation-record.types';
+import { ListingCreationRecordOrmEntity } from '../entities/listing-creation-record.orm-entity';
+
+@Injectable()
+export class ListingCreationRecordRepository implements ListingCreationRecordRepositoryPort {
+  constructor(
+    @InjectRepository(ListingCreationRecordOrmEntity)
+    private readonly repository: Repository<ListingCreationRecordOrmEntity>
+  ) {}
+
+  async create(input: CreateListingCreationRecordInput): Promise<ListingCreationRecord> {
+    const entity = this.buildOrmEntity(input);
+    const saved = await this.repository.save(entity);
+    return this.toDomain(saved);
+  }
+
+  async findById(id: string): Promise<ListingCreationRecord | null> {
+    const entity = await this.repository.findOne({ where: { id } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async findLatestByVariantAndConnection(
+    variantId: string,
+    connectionId: string
+  ): Promise<ListingCreationRecord | null> {
+    const entity = await this.repository.findOne({
+      where: { internalVariantId: variantId, connectionId },
+      order: { createdAt: 'DESC' },
+    });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async findByExternalProductIdAndConnectionId(
+    externalProductId: string,
+    connectionId: string
+  ): Promise<ListingCreationRecord | null> {
+    const entity = await this.repository.findOne({
+      where: { externalProductId, connectionId },
+    });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async updateStatus(
+    id: string,
+    status: ListingCreationStatus,
+    errors?: ListingCreationError[] | null
+  ): Promise<ListingCreationRecord> {
+    const entity = await this.repository.findOne({ where: { id } });
+    if (!entity) {
+      throw new ListingCreationRecordNotFoundException(id);
+    }
+    entity.status = status;
+    if (errors !== undefined) {
+      entity.errors = errors;
+    }
+    const saved = await this.repository.save(entity);
+    return this.toDomain(saved);
+  }
+
+  async updateExternalIdAndStatus(
+    id: string,
+    externalProductId: string,
+    status: ListingCreationStatus,
+    errors?: ListingCreationError[] | null
+  ): Promise<ListingCreationRecord> {
+    const entity = await this.repository.findOne({ where: { id } });
+    if (!entity) {
+      throw new ListingCreationRecordNotFoundException(id);
+    }
+    entity.externalProductId = externalProductId;
+    entity.status = status;
+    if (errors !== undefined) {
+      entity.errors = errors;
+    }
+    const saved = await this.repository.save(entity);
+    return this.toDomain(saved);
+  }
+
+  private buildOrmEntity(input: CreateListingCreationRecordInput): ListingCreationRecordOrmEntity {
+    const entity = new ListingCreationRecordOrmEntity();
+    entity.internalVariantId = input.internalVariantId;
+    entity.connectionId = input.connectionId;
+    entity.status = input.status;
+    entity.externalProductId = input.externalProductId ?? null;
+    entity.errors = input.errors ?? null;
+    return entity;
+  }
+
+  private toDomain(entity: ListingCreationRecordOrmEntity): ListingCreationRecord {
+    return new ListingCreationRecord(
+      entity.id,
+      entity.internalVariantId,
+      entity.connectionId,
+      entity.externalProductId,
+      entity.status,
+      entity.errors,
+      entity.createdAt,
+      entity.updatedAt
+    );
+  }
+}

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -29,6 +29,10 @@ import { BulkBatchAdvancementRepository } from './infrastructure/persistence/rep
 import { BulkListingProgressService } from './application/services/bulk-listing-progress.service';
 import { OfferBuilderService } from './application/services/offer-builder.service';
 import { OfferCreationExecutionService } from './application/services/offer-creation-execution.service';
+import { ListingCreationRecordOrmEntity } from './infrastructure/persistence/entities/listing-creation-record.orm-entity';
+import { ListingCreationRecordRepository } from './infrastructure/persistence/repositories/listing-creation-record.repository';
+import { ProductPublishBuilderService } from './application/services/product-publish-builder.service';
+import { ProductPublishExecutionService } from './application/services/product-publish-execution.service';
 import { SellerPoliciesCacheOrmEntity } from './infrastructure/persistence/entities/seller-policies-cache.orm-entity';
 import { SellerPoliciesCacheRepository } from './infrastructure/persistence/repositories/seller-policies-cache.repository';
 import { SellerPoliciesService } from './application/services/seller-policies.service';
@@ -60,6 +64,9 @@ import {
   OFFER_STATUS_SNAPSHOT_REPOSITORY_TOKEN,
   SELLER_POLICIES_SERVICE_TOKEN,
   SELLER_POLICIES_CACHE_TOKEN,
+  LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
+  PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,
+  PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN,
 } from './listings.tokens';
 
 // Re-export tokens for convenience
@@ -84,6 +91,9 @@ export {
   OFFER_STATUS_SNAPSHOT_REPOSITORY_TOKEN,
   SELLER_POLICIES_SERVICE_TOKEN,
   SELLER_POLICIES_CACHE_TOKEN,
+  LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
+  PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,
+  PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN,
 } from './listings.tokens';
 
 @Module({
@@ -91,6 +101,7 @@ export {
     TypeOrmModule.forFeature([
       IdentifierMappingOrmEntity,
       OfferCreationRecordOrmEntity,
+      ListingCreationRecordOrmEntity,
       BulkListingBatchOrmEntity,
       BulkBatchAdvancementOrmEntity,
       SellerPoliciesCacheOrmEntity,
@@ -120,6 +131,9 @@ export {
     BulkListingProgressService,
     OfferBuilderService,
     OfferCreationExecutionService,
+    ListingCreationRecordRepository,
+    ProductPublishBuilderService,
+    ProductPublishExecutionService,
     OfferCreationEnqueueService,
     BulkListingSubmitService,
     BulkListingRetryService,
@@ -177,6 +191,18 @@ export {
       useExisting: OfferCreationExecutionService,
     },
     {
+      provide: LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
+      useExisting: ListingCreationRecordRepository,
+    },
+    {
+      provide: PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,
+      useExisting: ProductPublishBuilderService,
+    },
+    {
+      provide: PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN,
+      useExisting: ProductPublishExecutionService,
+    },
+    {
       provide: OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
       useExisting: OfferCreationEnqueueService,
     },
@@ -228,6 +254,9 @@ export {
     OFFER_STATUS_SYNC_SERVICE_TOKEN,
     SELLER_POLICIES_SERVICE_TOKEN,
     SELLER_POLICIES_CACHE_TOKEN,
+    LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
+    PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,
+    PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN,
   ],
 })
 export class ListingsModule {}

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -34,3 +34,9 @@ export const OFFER_STATUS_SYNC_SERVICE_TOKEN = Symbol('IOfferStatusSyncService')
 export const OFFER_STATUS_SNAPSHOT_REPOSITORY_TOKEN = Symbol('OfferStatusSnapshotRepositoryPort');
 export const SELLER_POLICIES_SERVICE_TOKEN = Symbol('ISellerPoliciesService');
 export const SELLER_POLICIES_CACHE_TOKEN = Symbol('SellerPoliciesCacheRepositoryPort');
+// Shop publish (#1042, ADR-024)
+export const LISTING_CREATION_RECORD_REPOSITORY_TOKEN = Symbol(
+  'ListingCreationRecordRepositoryPort'
+);
+export const PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN = Symbol('IProductPublishBuilderService');
+export const PRODUCT_PUBLISH_EXECUTION_SERVICE_TOKEN = Symbol('IProductPublishExecutionService');

--- a/libs/core/src/listings/services/index.ts
+++ b/libs/core/src/listings/services/index.ts
@@ -31,3 +31,5 @@ export { OfferBuilderService } from '../application/services/offer-builder.servi
 export { OfferCreationExecutionService } from '../application/services/offer-creation-execution.service';
 export { SellerPoliciesService } from '../application/services/seller-policies.service';
 export { OfferCreationEnqueueService } from '../application/services/offer-creation-enqueue.service';
+export { ProductPublishBuilderService } from '../application/services/product-publish-builder.service';
+export { ProductPublishExecutionService } from '../application/services/product-publish-execution.service';

--- a/libs/core/src/sync/domain/types/shop-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/shop-job-payloads.types.ts
@@ -13,6 +13,7 @@
 import type {
   PublishProductStatus,
   PublishProductContent,
+  OfferParameter,
 } from '@openlinker/core/listings';
 
 /**
@@ -43,6 +44,13 @@ export interface ShopProductPublishPayloadV1 {
   destinationCategoryIds?: string[];
   /** Optional owned-record content overrides (title, description, images, SEO). */
   content?: PublishProductContent;
+  /**
+   * Neutral, section-tagged projected category parameters (#1072) — the same
+   * `OfferParameter` channel the offer payload uses. Mirrors
+   * `PublishProductCommand.parameters`; the execution service threads it through
+   * to `publishProduct`. Omitted when no parameters were projected.
+   */
+  parameters?: OfferParameter[];
   /** Optional idempotency key forwarded to the adapter. */
   idempotencyKey?: string;
   /**


### PR DESCRIPTION
## What & why

Adds the **shop-publish vertical keystone** for the OL → shop (WooCommerce/Shopify) publish path (epic #1005, ADR-024). The capability adapter that implements `ShopProductManagerPort` is a separate follow-up (#1043), so this slice is an **inert keystone**: the services, persistence, migration, and worker handler exist and are fully unit + integration tested, but nothing triggers a real publish in production yet.

## #1042 — execution + persistence

- **`ProductPublishBuilderService`** — assembles a neutral `PublishProductCommand` from an internal variant id: resolves the master product via `ProductMasterPort` (`config.masterCatalogConnectionId`), provisions the destination category when the shop supports `CategoryProvisioner` (open-provenance, publish-uncategorised when absent), projects variant attributes into `OfferParameter[]`, and gates required fields — throwing `ProductPublishBuilderValidationException` so the execution service maps it to `business_failure` (ADR-007).
- **`ProductPublishExecutionService`** — owns the orchestration policy: load-or-create the `ListingCreationRecord`, resolve **create-vs-upsert** via the `ShopProduct` identifier mapping (reverse lookup filtered by `connectionId`), publish, persist the mapping on first publish only (idempotent on `DuplicateIdentifierMappingError`), and derive `ok | business_failure`. Transient/unknown errors propagate for worker retry (never marked `failed`).
- **`listing_creation_records`** table (migration `1806000000000`) — sibling of `offer_creation_records`; indexes on `(internalVariantId, connectionId)`, `(connectionId)`, `(status)`, plus a partial index on `externalProductId` WHERE NOT NULL.
- **`CORE_ENTITY_TYPE.ShopProduct`** — keys the variant → destination-product mapping.
- **`ShopProductPublishHandler`** (`shop.product.publish`) — validates the payload (schemaVersion, variant, stock, status) and delegates; wraps failures in `SyncJobExecutionError`.

## #1072 — neutral parameter channel

- Add `parameters?: OfferParameter[]` to `PublishProductCommand` and `ShopProductPublishPayloadV1`. `platformParams` is no longer the attribute carrier (reserved for un-modeled per-platform knobs). Optional-add → backward compatible.
- `AttributeProjectionService.project` gains an optional `destinationCapability` (default `'OfferManager'`); the shop path passes `'ProductPublisher'` — a shop connection never supports the marketplace `OfferManager` capability, so resolving it would throw. (Found and fixed during the deep tech-review pass — without it, every categorised shop publish would loop on retry.)

## Tech-review fixes applied

A deep tech-review of the diff surfaced one BLOCKING (projection capability mismatch above), one IMPORTANT (the reused `MasterCatalogConnectionNotConfiguredException` is marketplace-worded → the shop record now persists a channel-neutral message), and three SUGGESTIONs (int-spec `parameters` assertion, `ListingCreationInvariantException` for the unreachable `pending` branch mirroring the offer path, import-formatting). All applied.

## Testing

- **39 unit specs**: builder, execution (happy / upsert / shop-reject / builder-validation / idempotent-dup / transient-rethrow), worker handler, the `CORE_ENTITY_TYPE` guard, and the projection capability regression guard.
- **Integration spec** (`apps/api/test/integration/listings/shop-product-publish.int-spec.ts`): real Postgres (Testcontainers) + the new migration, exercising the execution vertical against a fake `ProductMaster` + fake `ProductPublisher` registered through the production `AdapterRegistryService` / `AdapterFactoryResolverService` seams — asserts real `listing_creation_records` + `ShopProduct` mapping persistence, upsert (no duplicate mapping), and `business_failure` on reject. Runs in CI (Docker); not executed locally (no Docker on this machine).
- `pnpm lint`, `pnpm type-check`, and the full `pnpm test` suite all green; `check:invariants` (migration ordering, cross-context imports, service interfaces) pass.

## Scope notes

- Closing **#1072** here: the command/payload now carry the neutral `parameters` channel and `platformParams` is retired as the attribute carrier. The WooCommerce adapter that *serializes* `parameters` is #1043; that's adapter shaping, tracked separately — hence `Part of #1072`.

Closes #1042
Part of #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)