### PR TITLE
fix(listings): bulk-batch advancement gate dedups via RETURNING rows (#1084)

### DIFF
--- a/apps/api/test/integration/listings/bulk-shop-publish.int-spec.ts
+++ b/apps/api/test/integration/listings/bulk-shop-publish.int-spec.ts
@@ -147,4 +147,32 @@ describe('Bulk Shop Publish Integration (#1044)', () => {
     expect(afterB?.failedCount).toBe(1);
     expect(afterB?.status).toBe('partially-failed');
   });
+
+  it('dedups a duplicate advance for the same child (at-most-once gate, #1084)', async () => {
+    // Real-DB coverage of the duplicate-advance path: a worker retry re-running
+    // the same child must NOT double-count. Guards the #1084 fix
+    // (markAdvancedIfNotExists deriving `created` from the RETURNING rows).
+    const { batchId, items } = await submitService().submit({
+      connectionId: shopConnectionId,
+      initiatedBy: 'user-int',
+      internalVariantIds: [VARIANT_A, VARIANT_B],
+      status: 'published',
+      stock: 1,
+    });
+    const [childA] = items;
+    const progress = progressService();
+
+    // First advance counts (1 of 2 → not terminal → returns null).
+    expect(await progress.advanceBatchStatus(batchId, childA.listingCreationRecordId, 'succeeded')).toBeNull();
+    expect((await submitService().getBatch(batchId))?.batch.succeededCount).toBe(1);
+
+    // Re-advancing the SAME child is a no-op (gate dedups). The regression guard
+    // is the counter holding at 1 below — before #1084 this double-counted to 2
+    // and flipped the batch to `completed`. (The null return alone is not proof:
+    // advanceBatchStatus also returns null on the non-terminal branch.)
+    expect(await progress.advanceBatchStatus(batchId, childA.listingCreationRecordId, 'succeeded')).toBeNull();
+    const afterDup = await submitService().getBatch(batchId);
+    expect(afterDup?.batch.succeededCount).toBe(1);
+    expect(afterDup?.batch.status).toBe('running');
+  });
 });

--- a/docs/plans/implementation-plan-bulk-batch-advancement-gate.md
+++ b/docs/plans/implementation-plan-bulk-batch-advancement-gate.md
@@ -1,0 +1,54 @@
+# Implementation Plan — Fix bulk-batch at-most-once advancement gate (#1084)
+
+## 1. Goal & layer
+
+**CORE / infrastructure bug fix.** `BulkBatchAdvancementRepository.markAdvancedIfNotExists` never dedups against
+real Postgres — it returns `created: result.identifiers.length > 0`, which is **always truthy** for the composite
+user-supplied `@PrimaryColumn` PK (`bulkBatchId`, `offerCreationRecordId`). TypeORM echoes the input PK into
+`identifiers` even when `ON CONFLICT DO NOTHING` inserted nothing. Result: a worker **retry** of a bulk child
+double-counts `succeededCount`/`failedCount` (affects bulk-offer-creation **and** bulk-shop-publish).
+
+**Non-goals:** changing the advancement schema, the progress service, or the retry service. One-line repo fix + tests.
+
+## 2. Research — the correct signal (proven in-repo)
+
+`webhook-delivery.repository.ts:insertIfNew` (#711 Postgres dedup gate) uses the identical `INSERT … ON CONFLICT
+DO NOTHING` pattern and detects insert-vs-conflict via the **RETURNING rows**:
+`const inserted = (insertResult.raw as Entity[])?.[0]; isNew = !!inserted`. Postgres `RETURNING` yields the
+inserted row on insert and **0 rows on conflict**, so `result.raw.length` is the battle-tested signal. `result.identifiers`
+is unreliable for non-generated/composite PKs (it reflects the *input*, not the DB outcome).
+
+Retry-flow check: `BulkListingRetryService` (#742) calls `deleteForRecord(batchId, recordId)` before re-enqueuing a
+failed child — so the retry wave's re-advance inserts a fresh row (`created: true`) and counts. That delete only makes
+sense if the gate is meant to dedup; the fix restores the intended design. No existing test does a
+duplicate-advance-*without*-delete (the untested path that surfaced the bug), so none breaks.
+
+## 3. Design / steps
+
+1. **Fix the gate** — `libs/core/src/listings/infrastructure/persistence/repositories/bulk-batch-advancement.repository.ts`:
+   change `created: result.identifiers.length > 0` → `created: (result.raw as unknown[]).length > 0` (mirroring the
+   webhook gate). Update the file-header comment (it currently documents the wrong `identifiers` signal).
+   - AC: a second `markAdvancedIfNotExists(batchId, sameRecordId)` returns `{ created: false }`.
+
+2. **Unit spec** — `…/repositories/__tests__/bulk-batch-advancement.repository.spec.ts` (new): mock the TypeORM
+   repository's `createQueryBuilder().insert().values().orIgnore().execute()` chain to return `{ raw: [{}] }`
+   (insert) vs `{ raw: [] }` (conflict); assert `created` maps `true`/`false`. Validates the signal logic without a DB.
+
+3. **Int-spec (real-DB dedup)** — re-add the duplicate-advance assertion to
+   `apps/api/test/integration/listings/bulk-shop-publish.int-spec.ts` (the one removed in #1044's CI fix): advance a
+   child once (counter → 1), advance the **same** child again → `advanceBatchStatus` returns `null` (gate skip) and the
+   counter holds at 1. This is the first real-DB coverage of the dedup path. (Runs in CI; no local Docker.)
+
+## 4. Validation / risks
+
+- **Shared infra** — used by bulk-offer (#737/#742) + bulk-shop-publish (#1044). The fix only changes the
+  duplicate-without-delete path (was double-counting, now a no-op); the normal once-per-child and delete-then-readvance
+  paths are unchanged. Run the **full** `pnpm test` (offer-bulk progress/submit/retry unit specs) + `pnpm test:integration`
+  in CI.
+- **No migration** (no schema change). **No barrel/contract change** (repo internals only).
+- Confidence is high (proven webhook precedent); the int-spec is the CI guard since local Docker is unavailable.
+
+## 5. Pre-implement gate
+
+Skipped — trivial, self-contained one-line infra fix with no new ports/services/tokens/ORM/barrel surface. The reuse
++ contract-break classes the gate guards against don't apply.

--- a/libs/core/src/listings/infrastructure/persistence/repositories/__tests__/bulk-batch-advancement.repository.spec.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/__tests__/bulk-batch-advancement.repository.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Bulk Batch Advancement Repository — unit spec
+ *
+ * Guards the #1084 fix: `markAdvancedIfNotExists` must derive `created` from the
+ * RETURNING rows (`result.raw`), not `result.identifiers` (which echoes the
+ * input composite PK and is always non-empty). Mocks the TypeORM insert
+ * query-builder chain so the signal logic is verified without a database.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/repositories/__tests__
+ */
+import type { Repository } from 'typeorm';
+
+import { BulkBatchAdvancementRepository } from '../bulk-batch-advancement.repository';
+import type { BulkBatchAdvancementOrmEntity } from '../../entities/bulk-batch-advancement.orm-entity';
+
+/**
+ * Build a repo whose `createQueryBuilder().insert().values().orIgnore().execute()`
+ * resolves to a TypeORM `InsertResult`-shaped object with the given `raw` rows
+ * and a (deliberately always-populated) `identifiers` array — mirroring how
+ * TypeORM echoes the input PK regardless of the conflict outcome.
+ */
+function makeRepo(rawRows: unknown[]): {
+  repo: BulkBatchAdvancementRepository;
+  execute: jest.Mock;
+} {
+  const execute = jest.fn().mockResolvedValue({
+    raw: rawRows,
+    // Always non-empty — the trap the #1084 fix avoids relying on.
+    identifiers: [{ bulkBatchId: 'b', offerCreationRecordId: 'r' }],
+  });
+  const builder = {
+    insert: jest.fn().mockReturnThis(),
+    values: jest.fn().mockReturnThis(),
+    orIgnore: jest.fn().mockReturnThis(),
+    execute,
+  };
+  const ormRepository = {
+    createQueryBuilder: jest.fn().mockReturnValue(builder),
+    delete: jest.fn().mockResolvedValue({ affected: 0 }),
+  } as unknown as Repository<BulkBatchAdvancementOrmEntity>;
+
+  return { repo: new BulkBatchAdvancementRepository(ormRepository), execute };
+}
+
+describe('BulkBatchAdvancementRepository', () => {
+  describe('markAdvancedIfNotExists', () => {
+    it('should report created=true when the insert returns a row (fresh advance)', async () => {
+      const { repo } = makeRepo([{ bulkBatchId: 'b', offerCreationRecordId: 'r' }]);
+      await expect(repo.markAdvancedIfNotExists('b', 'r')).resolves.toEqual({ created: true });
+    });
+
+    it('should report created=false when ON CONFLICT returns no row (duplicate advance)', async () => {
+      const { repo } = makeRepo([]);
+      await expect(repo.markAdvancedIfNotExists('b', 'r')).resolves.toEqual({ created: false });
+    });
+
+    it('should report created=false (not throw) when raw is undefined', async () => {
+      // TypeORM leaves `raw` undefined on the empty-valueSet early-return path;
+      // the Array.isArray guard must treat that as "not created", not crash.
+      const { repo } = makeRepo(undefined as unknown as unknown[]);
+      await expect(repo.markAdvancedIfNotExists('b', 'r')).resolves.toEqual({ created: false });
+    });
+  });
+});

--- a/libs/core/src/listings/infrastructure/persistence/repositories/bulk-batch-advancement.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/bulk-batch-advancement.repository.ts
@@ -6,10 +6,14 @@
  * a `(bulkBatchId, offerCreationRecordId)` row already exists, in one
  * round-trip, without a transaction.
  *
- * `result.identifiers.length` is the boundary signal: if the insert landed,
- * TypeORM returns the inserted PK; if it was a no-op (row existed),
- * `identifiers` is empty. Both paths return successfully — no exception
- * leaks for the contention case.
+ * The **RETURNING rows** (`result.raw`) are the boundary signal: Postgres
+ * `INSERT … ON CONFLICT DO NOTHING RETURNING …` yields the inserted row on a
+ * fresh insert and **0 rows on conflict**, so `result.raw.length > 0` ⇔ the row
+ * was newly created. (`result.identifiers` is NOT usable here — TypeORM echoes
+ * the *input* PK for a non-generated composite `@PrimaryColumn`, so it is always
+ * non-empty regardless of the conflict outcome; #1084.) Mirrors the proven
+ * `webhook-delivery.repository.ts:insertIfNew` gate (#711). Both paths return
+ * successfully — no exception leaks for the contention case.
  *
  * @module libs/core/src/listings/infrastructure/persistence/repositories
  * @implements {BulkBatchAdvancementRepositoryPort}
@@ -38,7 +42,11 @@ export class BulkBatchAdvancementRepository implements BulkBatchAdvancementRepos
       .values({ bulkBatchId, offerCreationRecordId })
       .orIgnore()
       .execute();
-    return { created: result.identifiers.length > 0 };
+    // RETURNING rows, not `identifiers` (#1084): empty ⇒ ON CONFLICT skipped the
+    // insert (row already existed) ⇒ not newly created. `Array.isArray` guards
+    // the (here-unreachable) empty-valueSet path where TypeORM leaves `raw`
+    // undefined, matching the webhook-delivery gate's defensiveness.
+    return { created: Array.isArray(result.raw) && result.raw.length > 0 };
   }
 
   async deleteForRecord(


### PR DESCRIPTION
## What & why

The bulk-batch at-most-once advancement gate never deduped against real Postgres. `BulkBatchAdvancementRepository.markAdvancedIfNotExists` derived `created` from `result.identifiers.length`, which is **always ≥ 1** for the composite user-supplied `@PrimaryColumn` PK (`bulkBatchId`, `offerCreationRecordId`) — TypeORM echoes the *input* PK into `identifiers` regardless of whether `ON CONFLICT DO NOTHING` actually inserted. So `created` was always `true`, and a worker **retry** of a bulk child double-counted `succeededCount`/`failedCount`, potentially deriving the wrong terminal status or overshooting `totalCount`.

Affects both bulk flows that share the aggregate: bulk-offer-creation (#737/#742) and bulk-shop-publish (#1044).

## Fix

Derive `created` from the **RETURNING rows** (`result.raw`) instead — Postgres `INSERT … ON CONFLICT DO NOTHING RETURNING …` yields the inserted row on a fresh insert and **0 rows on conflict**. Guarded with `Array.isArray` to match the proven [`webhook-delivery.repository.ts:insertIfNew`](../blob/main/libs/core/src/webhooks/infrastructure/persistence/repositories/webhook-delivery.repository.ts) gate (#711), which uses the identical pattern. The `@CreateDateColumn advancedAt` forces TypeORM to emit `RETURNING` even without an explicit `.returning()` (verified in the TypeORM source).

Only the **duplicate-advance-without-delete** path changes (double-count → no-op). The normal once-per-child path and the retry-wave path (`BulkListingRetryService` `deleteForRecord` → re-advance → fresh row → counts, #742) are unchanged.

## Testing

- **Unit spec** (`bulk-batch-advancement.repository.spec.ts`): mocks the insert chain with an always-populated `identifiers` (the trap) and varying `raw` — asserts `created` maps from `raw` (`true`/`false`/`undefined→false`). Fails against the old implementation, passes against the fix.
- **Real-Postgres int-spec** (`bulk-shop-publish.int-spec.ts`): a duplicate `advanceBatchStatus` for the same child holds the counter at 1 (before #1084 it double-counted to 2 and flipped the batch to `completed`) — the dedup path that previously had zero real-DB coverage and surfaced the bug in PR #1083.
- Full `pnpm lint` (+ invariants), `pnpm type-check`, and full `pnpm test` (core 1143, worker 167, api 464, all integration packages) green. No migration, no contract change.

Reviewed via a deep adversarial tech-review (confirmed the TypeORM signal in-source; added the `Array.isArray` null-guard + an `undefined`-`raw` unit case it surfaced).

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)