### PR TITLE
fix(api): map ConnectionNotFound/Disabled exceptions to 404/409 (#1087)

### DIFF
--- a/apps/api/src/common/filters/connection-exception.filter.spec.ts
+++ b/apps/api/src/common/filters/connection-exception.filter.spec.ts
@@ -1,0 +1,46 @@
+import type { ArgumentsHost } from '@nestjs/common';
+import { HttpStatus } from '@nestjs/common';
+import {
+  ConnectionDisabledException,
+  ConnectionNotFoundException,
+} from '@openlinker/core/identifier-mapping';
+import { ConnectionExceptionFilter } from './connection-exception.filter';
+
+function createHost(): { host: ArgumentsHost; status: jest.Mock; json: jest.Mock } {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  const host = {
+    switchToHttp: () => ({ getResponse: () => ({ status }) }),
+  } as unknown as ArgumentsHost;
+  return { host, status, json };
+}
+
+describe('ConnectionExceptionFilter', () => {
+  const filter = new ConnectionExceptionFilter();
+
+  it('should return 404 for a missing connection', () => {
+    const { host, status, json } = createHost();
+
+    filter.catch(new ConnectionNotFoundException('conn-1'), host);
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    expect(json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.NOT_FOUND,
+      error: 'ConnectionNotFoundException',
+      message: expect.stringContaining('conn-1'),
+    });
+  });
+
+  it('should return 409 for a disabled connection', () => {
+    const { host, status, json } = createHost();
+
+    filter.catch(new ConnectionDisabledException('conn-2'), host);
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.CONFLICT);
+    expect(json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.CONFLICT,
+      error: 'ConnectionDisabledException',
+      message: expect.stringContaining('disabled'),
+    });
+  });
+});

--- a/apps/api/src/common/filters/connection-exception.filter.ts
+++ b/apps/api/src/common/filters/connection-exception.filter.ts
@@ -1,0 +1,50 @@
+/**
+ * Connection Exception Filter
+ *
+ * Maps the connection-lifecycle domain exceptions into accurate HTTP statuses
+ * with a structured, operator-friendly body. Without this filter NestJS
+ * defaults to 500 Internal Server Error, misrepresenting an operator/
+ * configuration error as a server fault (#1087):
+ *
+ *  - `ConnectionNotFoundException`  → 404 Not Found
+ *  - `ConnectionDisabledException`  → 409 Conflict
+ *
+ * Sibling of `CapabilityNotSupportedFilter`; both are registered globally in
+ * `main.ts`. They catch disjoint exception types, so registration order is
+ * irrelevant.
+ *
+ * The 404 mapping assumes the connection is the addressed/primary resource of
+ * the request (true at every current throw site). A future endpoint where
+ * `connectionId` is merely a body field on a different addressed resource should
+ * catch `ConnectionNotFoundException` locally rather than emit a misleading 404.
+ *
+ * @module apps/api/src/common/filters
+ * @see {@link ConnectionNotFoundException} / {@link ConnectionDisabledException}
+ */
+
+import type { ArgumentsHost, ExceptionFilter } from '@nestjs/common';
+import { Catch, HttpStatus } from '@nestjs/common';
+import type { Response } from 'express';
+import {
+  ConnectionDisabledException,
+  ConnectionNotFoundException,
+} from '@openlinker/core/identifier-mapping';
+
+@Catch(ConnectionNotFoundException, ConnectionDisabledException)
+export class ConnectionExceptionFilter implements ExceptionFilter {
+  catch(
+    exception: ConnectionNotFoundException | ConnectionDisabledException,
+    host: ArgumentsHost,
+  ): void {
+    const response = host.switchToHttp().getResponse<Response>();
+    const statusCode =
+      exception instanceof ConnectionDisabledException
+        ? HttpStatus.CONFLICT
+        : HttpStatus.NOT_FOUND;
+    response.status(statusCode).json({
+      statusCode,
+      error: exception.name,
+      message: exception.message,
+    });
+  }
+}

--- a/apps/api/src/listings/http/bulk-listing.controller.ts
+++ b/apps/api/src/listings/http/bulk-listing.controller.ts
@@ -120,12 +120,10 @@ export class BulkListingController {
       if (error instanceof EmptyBulkSubmissionException) {
         throw new BadRequestException(error.message);
       }
-      // CapabilityNotSupportedException is mapped to HTTP 422 by the
-      // global `CapabilityNotSupportedFilter`. Other domain exceptions
-      // (`ConnectionNotFoundException`, `ConnectionDisabledException`)
-      // currently bubble up as HTTP 500 — the same posture as the
-      // existing single-offer POST endpoint. Mapping is a cross-cutting
-      // concern tracked outside #736.
+      // Remaining domain exceptions are mapped by global filters:
+      // `CapabilityNotSupportedException` → 400 (`CapabilityNotSupportedFilter`),
+      // `ConnectionNotFoundException` → 404 / `ConnectionDisabledException` → 409
+      // (`ConnectionExceptionFilter`, #1087). Re-throw so they reach those filters.
       throw error;
     }
   }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -16,6 +16,7 @@ import * as express from 'express';
 import { installNestLogger } from '@openlinker/shared/logging/nest';
 import { AppModule } from './app.module';
 import { CapabilityNotSupportedFilter } from './common/filters/capability-not-supported.filter';
+import { ConnectionExceptionFilter } from './common/filters/connection-exception.filter';
 
 async function bootstrap(): Promise<void> {
   // Route shared `Logger` calls through @nestjs/common before any other work,
@@ -74,8 +75,10 @@ async function bootstrap(): Promise<void> {
     }),
   );
 
-  // Map capability-related domain errors to 400 instead of the default 500
-  app.useGlobalFilters(new CapabilityNotSupportedFilter());
+  // Map capability + connection-lifecycle domain errors to accurate HTTP
+  // statuses instead of the default 500 (#1087). Filters catch disjoint
+  // exception types, so registration order is irrelevant.
+  app.useGlobalFilters(new CapabilityNotSupportedFilter(), new ConnectionExceptionFilter());
 
   // Swagger API documentation
   const config = new DocumentBuilder()

--- a/apps/api/src/mappings/http/fulfillment-routing.controller.spec.ts
+++ b/apps/api/src/mappings/http/fulfillment-routing.controller.spec.ts
@@ -1,11 +1,12 @@
 /**
  * Fulfillment Routing Controller unit tests (#836).
  *
- * Mocks IFulfillmentRoutingService. Covers delegation + DTO mapping and the
- * full domain-exception → HTTP mapping (404 / 400) at the boundary.
+ * Mocks IFulfillmentRoutingService. Covers delegation + DTO mapping, the
+ * local routing-error → 400 mapping, and that connection-lifecycle exceptions
+ * propagate untouched to the global `ConnectionExceptionFilter` (#1087).
  */
 
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
 import {
   type IFulfillmentRoutingService,
   FulfillmentRoutingRule,
@@ -73,10 +74,10 @@ describe('FulfillmentRoutingController', () => {
       ]);
     });
 
-    it('should map ConnectionNotFoundException to 404', async () => {
+    it('should propagate ConnectionNotFoundException to the global filter (→ 404)', async () => {
       routing.getRules.mockRejectedValue(new ConnectionNotFoundException(SOURCE));
 
-      await expect(controller.getRules(SOURCE)).rejects.toBeInstanceOf(NotFoundException);
+      await expect(controller.getRules(SOURCE)).rejects.toBeInstanceOf(ConnectionNotFoundException);
     });
   });
 
@@ -91,10 +92,10 @@ describe('FulfillmentRoutingController', () => {
       expect(result).toEqual([{ processorKind: 'omp_fulfilled', processorConnectionId: 'conn-ps' }]);
     });
 
-    it('should map ConnectionNotFoundException to 404', async () => {
+    it('should propagate ConnectionNotFoundException to the global filter (→ 404)', async () => {
       routing.getCandidateProcessors.mockRejectedValue(new ConnectionNotFoundException(SOURCE));
 
-      await expect(controller.getCandidates(SOURCE)).rejects.toBeInstanceOf(NotFoundException);
+      await expect(controller.getCandidates(SOURCE)).rejects.toBeInstanceOf(ConnectionNotFoundException);
     });
   });
 
@@ -122,16 +123,16 @@ describe('FulfillmentRoutingController', () => {
       await expect(controller.replaceRules(SOURCE, dto())).rejects.toBeInstanceOf(BadRequestException);
     });
 
-    it('should map ConnectionDisabledException to 400', async () => {
+    it('should propagate ConnectionDisabledException to the global filter (→ 409)', async () => {
       routing.replaceRules.mockRejectedValue(new ConnectionDisabledException('conn-inpost'));
 
-      await expect(controller.replaceRules(SOURCE, dto())).rejects.toBeInstanceOf(BadRequestException);
+      await expect(controller.replaceRules(SOURCE, dto())).rejects.toBeInstanceOf(ConnectionDisabledException);
     });
 
-    it('should map ConnectionNotFoundException to 404', async () => {
+    it('should propagate ConnectionNotFoundException to the global filter (→ 404)', async () => {
       routing.replaceRules.mockRejectedValue(new ConnectionNotFoundException(SOURCE));
 
-      await expect(controller.replaceRules(SOURCE, dto())).rejects.toBeInstanceOf(NotFoundException);
+      await expect(controller.replaceRules(SOURCE, dto())).rejects.toBeInstanceOf(ConnectionNotFoundException);
     });
   });
 });

--- a/apps/api/src/mappings/http/fulfillment-routing.controller.ts
+++ b/apps/api/src/mappings/http/fulfillment-routing.controller.ts
@@ -21,7 +21,6 @@ import {
   HttpStatus,
   Inject,
   BadRequestException,
-  NotFoundException,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
@@ -31,10 +30,6 @@ import {
   IncompatibleProcessorException,
   DuplicateRoutingRuleException,
 } from '@openlinker/core/mappings';
-import {
-  ConnectionNotFoundException,
-  ConnectionDisabledException,
-} from '@openlinker/core/identifier-mapping';
 import { UpsertRoutingRulesDto } from './dto/upsert-routing-rules.dto';
 import { RoutingRuleResponseDto } from './dto/routing-rule-response.dto';
 import { CandidateProcessorResponseDto } from './dto/candidate-processor-response.dto';
@@ -87,8 +82,9 @@ export class FulfillmentRoutingController {
   @ApiOperation({ summary: 'Replace all fulfillment-routing rules for a source connection' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [RoutingRuleResponseDto] })
-  @ApiResponse({ status: 400, description: 'Incompatible processor, duplicate method, or disabled connection' })
+  @ApiResponse({ status: 400, description: 'Incompatible processor or duplicate method' })
   @ApiResponse({ status: 404, description: 'Connection not found' })
+  @ApiResponse({ status: 409, description: 'Connection disabled' })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async replaceRules(
     @Param('connectionId') connectionId: string,
@@ -103,17 +99,15 @@ export class FulfillmentRoutingController {
   }
 
   /**
-   * Map the full set of routing domain exceptions to HTTP. `replaceRules` /
-   * `getCandidateProcessors` resolve adapter metadata, so connection errors
-   * surface here alongside the compatibility/duplicate errors — none may fall
-   * through to a 500 on ordinary bad input.
+   * Map the routing-specific domain exceptions to HTTP. Connection-lifecycle
+   * exceptions (`ConnectionNotFoundException` → 404, `ConnectionDisabledException`
+   * → 409) are intentionally NOT mapped here — they propagate to the global
+   * `ConnectionExceptionFilter` (#1087) so the connection-status contract stays
+   * consistent across every endpoint. Only the genuinely-local routing errors
+   * map to 400; anything else falls through to Nest's default handling.
    */
   private toHttpException(error: unknown): Error {
-    if (error instanceof ConnectionNotFoundException) {
-      return new NotFoundException(error.message);
-    }
     if (
-      error instanceof ConnectionDisabledException ||
       error instanceof IncompatibleProcessorException ||
       error instanceof DuplicateRoutingRuleException
     ) {

--- a/apps/api/test/integration/listings-bulk-offer-creation.int-spec.ts
+++ b/apps/api/test/integration/listings-bulk-offer-creation.int-spec.ts
@@ -163,14 +163,26 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
         .expect(400);
     });
 
-    // NOTE: a happy-path POST → enqueue end-to-end test for "unknown
-    // connection" is intentionally out of scope. The bulk service relies
-    // on `IntegrationsService.getCapabilityAdapter` to surface
-    // `ConnectionNotFoundException`, but the API has no global filter
-    // mapping that domain exception to HTTP 404 today (the existing
-    // single-offer endpoint has the same behaviour). Mapping is a
-    // separate cross-cutting concern tracked by the API's
-    // exception-filter posture — not by #736.
+    it('returns 404 for a well-formed but unknown connectionId (#1087)', async () => {
+      // The bulk service resolves the adapter via
+      // `IntegrationsService.getCapabilityAdapter`, which throws
+      // `ConnectionNotFoundException` for an unknown connection. The global
+      // `ConnectionExceptionFilter` (#1087) maps that to 404 — before the
+      // filter it surfaced as a misleading 500.
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      await http
+        .post('/listings/bulk-create')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          connectionId: CONN_A, // valid UUID, no such connection seeded
+          productIds: ['ol_variant_a'],
+          sharedConfig: { stock: 5, publishImmediately: false },
+        })
+        .expect(404);
+    });
 
     it('returns 401 without a bearer token', async () => {
       const http = harness.getHttp();

--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -17,9 +17,17 @@ import express from 'express';
 import cookieParser from 'cookie-parser';
 import { createIntegrationTestHarness } from '@openlinker/test-kit';
 import { AppModule } from '../../src/app.module';
+import { CapabilityNotSupportedFilter } from '../../src/common/filters/capability-not-supported.filter';
+import { ConnectionExceptionFilter } from '../../src/common/filters/connection-exception.filter';
 
 const harness = createIntegrationTestHarness({
   imports: [AppModule],
+  // Mirror `main.ts`'s global exception filters so int-specs see the same
+  // HTTP status mapping the running app does (domain exceptions → 400/404/409
+  // rather than a default 500).
+  configureApp: (app) => {
+    app.useGlobalFilters(new CapabilityNotSupportedFilter(), new ConnectionExceptionFilter());
+  },
   configureBodyParser: (app) => {
     // 1) /webhooks: JSON parser with a `verify` hook that captures the raw
     //    request bytes for HMAC signature verification. Must run before any

--- a/libs/test-kit/src/harness.ts
+++ b/libs/test-kit/src/harness.ts
@@ -107,6 +107,13 @@ class IntegrationTestHarnessImpl implements IntegrationTestHarness {
       this.app.useGlobalPipes(new ValidationPipe(pipeOptions));
     }
 
+    // Run after pipes, before init — lets callers register the same global
+    // exception filters their production bootstrap applies (the `main.ts`
+    // filters are not otherwise wired into the int-test app).
+    if (this.config.configureApp) {
+      this.config.configureApp(this.app);
+    }
+
     await this.app.init();
 
     // Resolve DataSource — required for `reset()` to issue truncates.

--- a/libs/test-kit/src/types.ts
+++ b/libs/test-kit/src/types.ts
@@ -53,6 +53,16 @@ export interface IntegrationTestHarnessConfig {
   configureBodyParser?: (app: INestApplication) => void;
 
   /**
+   * Optional app-configuration hook, run after body-parser + validation-pipe
+   * setup and immediately before `app.init()`. Receives the `INestApplication`
+   * so callers can register the same global exception filters / interceptors
+   * their production bootstrap applies — without this, the filters wired in
+   * `main.ts` (`app.useGlobalFilters(...)`) are NOT applied to the int-test app,
+   * so domain exceptions surface as 500 instead of their mapped status.
+   */
+  configureApp?: (app: INestApplication) => void;
+
+  /**
    * Tables to TRUNCATE between tests, in foreign-key-aware order.
    *
    * Caller-owned. apps/api lists its 12 canonical tables; plugin authors


### PR DESCRIPTION
## What & why

`ConnectionNotFoundException` / `ConnectionDisabledException` (`@openlinker/core/identifier-mapping`, both extend plain `Error`) had **no global exception filter**, so they surfaced as **500 Internal Server Error** on every endpoint that resolves a connection — misrepresenting an operator/config error as a server fault. Several listings/offer-creation + shop-publish controllers already documented `@ApiResponse 404/409` for these, but the responses were actually 500. Surfaced during the #1083 shop-publish review.

## Change

- **New global `ConnectionExceptionFilter`** (sibling of `CapabilityNotSupportedFilter`, same structured `{ statusCode, error, message }` body): `ConnectionNotFoundException → 404`, `ConnectionDisabledException → 409`. Registered in `main.ts`. The filters `@Catch` disjoint types, so registration order is irrelevant.
- **Reconciled the one pre-existing divergence:** `fulfillment-routing.controller` mapped `ConnectionDisabledException → 400` locally (it would have *won* over the global filter). Its `toHttpException` now drops both connection branches and lets them propagate to the global filter, so the connection-status contract is consistent everywhere (Disabled → 409 there too). Only the genuinely-local routing errors (`IncompatibleProcessor`/`DuplicateRoutingRule`) stay 400. Swagger `@ApiResponse` updated accordingly.

## Testing

- **Filter unit spec** — 404 for missing, 409 for disabled.
- **Bulk-offer int-spec** — promoted the previously-*skipped* "unknown connection" case into a real `404` assertion (the gap that block documented; runs in CI).
- **fulfillment-routing controller spec** — updated to assert connection exceptions *propagate* (the global filter now owns their HTTP status).
- Full `pnpm test` api suite (466) + lint + invariants + type-check green. No core/domain change, no migration.

Reviewed via a deep adversarial tech-review (confirmed 409 is the right semantic for `disabled`, filter ordering is safe, and the int-spec UUID reaches the service); applied its IMPORTANT finding (the fulfillment-routing reconciliation) + comment/doc cleanups.

Closes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)