### PR TITLE
feat(invoicing): InvoicingPort + InvoiceRecord + repo + migration foundation (#751)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { HealthModule } from './health/health.module';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { CustomersModule } from '@openlinker/core/customers';
 import { ContentModule } from '@openlinker/core/content';
+import { InvoicingModule } from '@openlinker/core/invoicing';
 import { AiModule as CoreAiModule } from '@openlinker/core/ai';
 import { AuthModule } from './auth/auth.module';
 import { IntegrationsModule } from './integrations/integrations.module';
@@ -60,6 +61,7 @@ import { ShippingApiModule } from './shipping/shipping.module';
     CursorsModule,
     MappingsApiModule,
     ContentModule, // Product content draft buffer + reconcile + publish (#338)
+    InvoicingModule, // Invoicing domain foundation — port + record + repo (#751, ADR-026)
     CoreAiModule, // Editable prompt-template storage + render service (#341)
     AiApiModule, // REST surface for prompt templates (#341)
     ContentApiModule, // REST surface for product content editor + AI suggest (#339 + #342)

--- a/apps/api/src/migrations/1808000000000-create-invoice-records.ts
+++ b/apps/api/src/migrations/1808000000000-create-invoice-records.ts
@@ -1,0 +1,93 @@
+/**
+ * Create Invoice Records Table Migration
+ *
+ * Creates the `invoice_records` table — OL's non-authoritative projection of
+ * fiscal documents issued through a provider for an order on an invoicing
+ * connection (#751, ADR-026). Country-agnostic columns; `regulatoryStatus` /
+ * `clearanceReference` are nullable-with-default and unused until a future
+ * `RegulatoryTransmitter` adapter (KSeF/SDI/…) populates them. The partial
+ * UNIQUE index on `(connectionId, idempotencyKey)` is the durable exactly-once
+ * issuance guard.
+ *
+ * Generated: 2026-06-16 (synthetic sequential prefix per docs/migrations.md #1013).
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateInvoiceRecords1808000000000 implements MigrationInterface {
+  name = 'CreateInvoiceRecords1808000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+
+    const table = await queryRunner.getTable('invoice_records');
+    if (table) {
+      return;
+    }
+
+    await queryRunner.query(`
+      CREATE TABLE "invoice_records" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "connectionId" uuid NOT NULL,
+        "orderId" text NOT NULL,
+        "providerType" text NOT NULL,
+        "documentType" text NOT NULL,
+        "status" text NOT NULL,
+        "providerInvoiceId" text,
+        "providerInvoiceNumber" text,
+        "regulatoryStatus" text NOT NULL DEFAULT 'not-applicable',
+        "clearanceReference" text,
+        "idempotencyKey" text,
+        "pdfUrl" text,
+        "issuedAt" TIMESTAMP,
+        "errorMessage" text,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_invoice_records" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_invoice_records_order_connection"
+        ON "invoice_records" ("orderId", "connectionId")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_invoice_records_connectionId"
+        ON "invoice_records" ("connectionId")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_invoice_records_status"
+        ON "invoice_records" ("status")
+    `);
+
+    // Lookup of an issued document by provider id (transmission / reconcile).
+    await queryRunner.query(`
+      CREATE INDEX "IDX_invoice_records_provider_invoice_id"
+        ON "invoice_records" ("providerInvoiceId")
+        WHERE "providerInvoiceId" IS NOT NULL
+    `);
+
+    // Fiscal-dedup guard: exactly-once issuance on retry. Partial so rows
+    // without a key (manual one-off issues) don't collide on NULL.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "UQ_invoice_records_connection_idempotency"
+        ON "invoice_records" ("connectionId", "idempotencyKey")
+        WHERE "idempotencyKey" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."UQ_invoice_records_connection_idempotency"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_invoice_records_provider_invoice_id"`,
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_invoice_records_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_invoice_records_connectionId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_invoice_records_order_connection"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "invoice_records"`);
+  }
+}

--- a/apps/api/test/integration/invoicing/invoice-record-repository.int-spec.ts
+++ b/apps/api/test/integration/invoicing/invoice-record-repository.int-spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Invoice Records persistence Integration Test (#751)
+ *
+ * Proves the `CreateInvoiceRecords1808000000000` migration + real Postgres
+ * behaviour for the invoicing foundation (ADR-026): the table + columns exist,
+ * and the partial-unique fiscal-dedup index (`(connectionId, idempotencyKey)
+ * WHERE idempotencyKey IS NOT NULL`) actually rejects a duplicate while still
+ * allowing many NULL-key rows. The repository's domain-error conversion and
+ * mapping are unit-tested separately; this spec exercises the real index the
+ * unit test can only mock.
+ *
+ * @module apps/api/test/integration/invoicing
+ */
+import { InvoiceRecordOrmEntity } from '@openlinker/core/invoicing/orm-entities';
+import type { Repository } from 'typeorm';
+
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from '../setup';
+
+const CONNECTION_ID = '00000000-0000-0000-0000-000000000751';
+
+function row(overrides: Partial<InvoiceRecordOrmEntity> = {}): InvoiceRecordOrmEntity {
+  const entity = new InvoiceRecordOrmEntity();
+  Object.assign(
+    entity,
+    {
+      connectionId: CONNECTION_ID,
+      orderId: 'ol_order_int1',
+      providerType: 'subiekt',
+      documentType: 'invoice',
+      status: 'pending',
+      idempotencyKey: 'idem-int-1',
+    },
+    overrides,
+  );
+  return entity;
+}
+
+describe('invoice_records persistence (integration)', () => {
+  let harness: IntegrationTestHarness;
+  let repo: Repository<InvoiceRecordOrmEntity>;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  beforeEach(async () => {
+    await resetTestHarness();
+    repo = harness.getDataSource().getRepository(InvoiceRecordOrmEntity);
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('persists a row with neutral defaults and reads it back', async () => {
+    const saved = await repo.save(row());
+    expect(saved.id).toBeDefined();
+
+    const found = await repo.findOne({
+      where: { orderId: 'ol_order_int1', connectionId: CONNECTION_ID },
+    });
+    expect(found?.providerType).toBe('subiekt');
+    expect(found?.documentType).toBe('invoice');
+    // Migration default applied without the app setting it explicitly.
+    expect(found?.regulatoryStatus).toBe('not-applicable');
+    expect(found?.clearanceReference).toBeNull();
+  });
+
+  it('rejects a duplicate (connectionId, idempotencyKey) at the DB index', async () => {
+    await repo.save(row());
+    await expect(repo.save(row({ orderId: 'ol_order_int_dup' }))).rejects.toThrow();
+  });
+
+  it('allows multiple rows with a null idempotencyKey (partial index)', async () => {
+    const a = await repo.save(row({ idempotencyKey: null, orderId: 'ol_order_a' }));
+    const b = await repo.save(row({ idempotencyKey: null, orderId: 'ol_order_b' }));
+    expect(a.id).not.toBe(b.id);
+  });
+});

--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -54,6 +54,10 @@ const harness = createIntegrationTestHarness({
     // publish attempts. No ORM/migration FK, so nothing cascades from
     // connections; truncate explicitly so each shop-publish case starts clean.
     'listing_creation_records',
+    // invoice_records (#751) — order- + connection-scoped invoicing projection.
+    // No ORM/migration FK; truncate explicitly so each invoicing case (incl.
+    // the (connectionId, idempotencyKey) dedup assertion) starts clean.
+    'invoice_records',
     // product_content_field FKs to both products + connections, so it goes
     // before them.
     'product_content_field',

--- a/docs/architecture/adrs/026-country-agnostic-invoicing-domain.md
+++ b/docs/architecture/adrs/026-country-agnostic-invoicing-domain.md
@@ -1,0 +1,97 @@
+# ADR-026: Country-agnostic invoicing domain with capability decomposition
+
+- **Status**: Accepted
+- **Date**: 2026-06-16
+- **Authors**: @piotrswierzy
+
+## Context
+
+OpenLinker is adding invoicing (product spec #728, foundation #751). Poland is the first market (Subiekt adapter, KSeF clearance mandate), but the domain must be **international-by-design** — a DACH or IT operator on a different provider must never see Polish tax terminology. The risk is baking PL concepts (`NIP`, `KSeF`, `VAT` rates, `faktura`/`paragon`, `JPK`) into `libs/core`, which would force every future adapter to speak Polish.
+
+Two further forces shape the foundation: (1) a near-future feature lets operators configure **automation rules** ("auto-issue when an order is paid, full invoice for B2B, receipt for B2C, skip channel X"); (2) issuing a fiscal document and **transmitting it to a tax authority for clearance** (KSeF, IT SDI, ES SII…) are distinct acts with different lifecycles and failure modes — confirmed by every tax-compliance vendor (Avalara, Fonoa, Sovos) and by Stripe.
+
+## Decision
+
+1. **Neutral domain vocabulary, drawn from international standards — not invented.** Litmus test: zero `nip`/`ksef`/`vat`/`jpk`/`faktura` strings in `libs/core/src/invoicing`. We adopt the EN 16931 semantic model's blessed shapes: scheme-tagged tax identifiers (`{ scheme, value }`, per EN 16931 BT-30 / ISO 6523 and Stripe `tax_ids`), ISO 4217 currency, a neutral `taxRate`/`taxCode` string per line (PL `zw`/`np` map losslessly onto UNCL 5305 `E`/`O` inside the adapter), and an **open-world** `documentType` (UNTDID 1001 functional types `invoice`/`credit-note`/`corrected`/`proforma`/`prepayment`, plus `receipt` as a regime value the standard deliberately omits but our PL adapter needs).
+2. **Capability decomposition by shape.** Issuance is the base `InvoicingPort` (`issueInvoice`, `getInvoice`, `upsertCustomer`). **Regulatory transmission/clearance is an [ADR-002](./002-capability-ports-with-sub-capabilities.md) sub-capability** (`RegulatoryTransmitter` + `isRegulatoryTransmitter` guard) — method-bearing (`submitForClearance`, `getClearanceStatus`), so it reuses the existing pattern rather than a novel mechanism. The transmitter **interface is deferred** to the KSeF issue; #751 only carries its persistence columns (`regulatoryStatus`, `clearanceReference`, nullable) on `InvoiceRecord` so no later migration is needed. Provider feature variance that is *not* method-bearing (which document types a provider issues) is exposed by a small discovery method (Avalara `GetMandates` precedent), not a sweeping `getCapabilities()`.
+3. **The port is a dumb mechanism; policy sits above it.** `documentType` is **command data** the caller supplies — a future Event→Condition→Action rules layer (specification pattern for conditions) decides *whether/when/what-type* and composes an `IssueInvoiceCommand`; the adapter executes the fiscal mechanics of that type. Core never embeds trigger or document-type policy.
+4. **Exactly-once issuance** via an `idempotencyKey` on the command + a durable partial-unique index `(connectionId, idempotencyKey)` (mirrors the `webhook_deliveries` dedup gate); not `UNIQUE(connectionId, orderId)`, so corrective re-issue stays possible.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant EV as Trigger (configurable, #728 A4)
+    participant RL as Rules layer (future, ECA)
+    participant SVC as InvoiceService (core)
+    participant REPO as InvoiceRecordRepo (core)
+    participant PORT as InvoicingPort adapter (integration)
+    participant PRV as Provider (Subiekt)
+    participant TA as Tax authority (KSeF, future)
+
+    Note over EV,SVC: ── neutral, country-agnostic (libs/core) ──
+    EV->>RL: trigger fires (order created / paid / shipped, manual, or batched)
+    RL->>RL: evaluate conditions (paid? buyer.taxId? country? channel?) → choose documentType
+    RL->>SVC: issueInvoice(IssueInvoiceCommand{neutral: scheme-tagged taxId,<br/>currency, lines[taxRate], documentType, idempotencyKey})
+    SVC->>REPO: findByIdempotencyKey(connectionId, key)
+    alt already issued
+        REPO-->>SVC: existing InvoiceRecord
+        SVC-->>RL: return existing (no double-issue)
+    else first time
+        SVC->>REPO: create(pending InvoiceRecord)
+        SVC->>PORT: resolve via IntegrationsService.getCapabilityAdapter('Invoicing')
+        Note over PORT,PRV: ── country-specific (adapter + provider own NIP/VAT/faktura) ──
+        PORT->>PRV: map neutral → provider-native, issue document
+        PRV-->>PORT: provider invoice id / number / pdf
+        PORT-->>SVC: neutral InvoiceResult
+        SVC->>REPO: updateOutcome(issued)
+        opt isRegulatoryTransmitter (deferred capability)
+            SVC->>PORT: submitForClearance(record)
+            PORT->>TA: transmit (KSeF/SDI/SII…)
+            TA-->>PORT: clearance reference + status
+            PORT-->>SVC: neutral RegulatoryStatus + clearanceReference
+            SVC->>REPO: updateOutcome(regulatoryStatus, clearanceReference)
+        end
+    end
+```
+
+**Steps explained:**
+
+1. **Trigger** — a *configurable* signal starts the flow; **payment is not a precondition**. Per #728 A4 the per-connection trigger is one of order-created / paid / shipped, manual operator action, or a nightly batch — and B2B is routinely invoice-then-pay (deferred terms), while proforma/advance documents precede payment entirely. Today this is a direct call; tomorrow the rules layer is the caller. The port never assumes a payment state.
+2. **Policy decision (future)** — the ECA rules layer reads neutral facts (paid? buyer tax-id present? country? channel? order total?) and **chooses the `documentType` and whether to issue at all**. Payment status is just *one optional condition* here, never a hard gate. This logic lives *above* the port; core ships none of it in #751.
+3. **Command composition** — the caller hands the core service a fully-neutral `IssueInvoiceCommand`. No country concept is present: the buyer's tax id is `{ scheme, value }`, amounts carry an ISO-4217 `currency`, lines carry a string `taxRate`.
+4. **Idempotency gate** — the service looks up `findByIdempotencyKey`. A hit returns the existing record (steps 5–6) — a retried trigger never issues twice. The durable unique index is the authoritative backstop even if the in-process check races.
+5. **Persist intent** — a `pending` `InvoiceRecord` is written before any external call, so a crash mid-issue is observable and retryable.
+6. **Resolve the adapter** — the `Invoicing` capability adapter is resolved per-connection through `IntegrationsService` (identical to `OfferManager`/`ProductPublisher`).
+7. **Cross the boundary** — the adapter is the *only* place that knows NIP, VAT rates, KSeF, and the word *faktura*. It maps the neutral command to the provider's native shape and issues the document.
+8. **Neutral result back** — the adapter returns a neutral result (`providerInvoiceId`, number, pdf url, status); core updates the record to `issued`. Core still sees nothing country-specific.
+9. **Regulatory transmission (deferred)** — when (and only when) the resolved adapter implements `RegulatoryTransmitter`, the service submits the issued document for clearance; the adapter maps the authority's regime states onto the neutral `RegulatoryStatus` lifecycle (`submitted → cleared → accepted | rejected`) and returns a `clearanceReference`. KSeF is one instance of this; a non-PL adapter simply doesn't implement the guard and the block is skipped.
+
+## Alternatives considered
+
+- **Country-specific fields in core (`nip`, KSeF status enum, `vatRate`)**: rejected — breaks the international-by-design promise; the EN 16931 / UNTDID / UNCL standards already give neutral equivalents.
+- **A novel runtime `getCapabilities(): InvoiceCapability[]` on the port** (the original #751 sketch): rejected — regulatory transmission is *method-bearing*, which is exactly what ADR-002 `is{Capability}` guards already model; inventing a parallel capability mechanism duplicates ADR-002 and adds a third "capability" concept.
+- **Closed `documentType` union (`invoice | receipt`)**: rejected — the document-type set varies unbounded by regime (corrective, proforma, prepayment, self-billed…); an open-world set matches the `platformType`/capability open-world precedent (#576/#578).
+- **Put trigger/document-type policy inside the port (`issueInvoice(order)` decides)**: rejected — bakes one policy into the mechanism; every future automation variant would force a contract change. Stripe's draft/finalize/`auto_advance` split and BaseLinker's ECA model both keep policy above the primitive.
+
+## Consequences
+
+**Pros:**
+- A new country = a new adapter + neutral capability names; **zero core change**.
+- The future rules layer only ever composes a command — the port never re-cuts.
+- KSeF is invisible to non-PL adapters; the neutral `RegulatoryStatus` lifecycle is the single seam every clearance regime maps onto.
+- FE gates invoicing UI on neutral capability/feature checks, never on `platformType`.
+
+**Cons / trade-offs:**
+- The neutral vocabulary is a small upfront modelling tax (scheme-tagged ids, open-world doc types) versus a quick PL-shaped table.
+- `InvoiceRecord` carries clearance columns before any transmitter implements them (nullable until KSeF lands) — chosen over a later migration.
+
+**Migration path:** #751 ships the neutral domain + base port + record + repo + migration. The `RegulatoryTransmitter` sub-capability interface and the KSeF adapter land in a later #728 child; no schema change required then.
+
+## References
+
+- Related issues: #751, #728
+- Related ADRs: [ADR-002](./002-capability-ports-with-sub-capabilities.md) (sub-capability composition), [ADR-024](./024-destination-listing-capabilities.md) (capability-port precedent), [ADR-009](./009-persisted-offer-status-snapshots.md) (reconciled-status precedent)
+- Standards: EN 16931 (semantic invoice model), UNTDID 1001 (document types), UNCL 5305 (tax categories), ISO 6523 / ISO 4217; CTC taxonomy (post-audit / clearance / real-time reporting)
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md)

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -115,5 +115,6 @@ One pointer per section, identical format every time.
 | [ADR-023](./023-cross-platform-category-and-attribute-projection.md) | Cross-platform category placement and attribute projection | Accepted | 2026-06-13 |
 | [ADR-024](./024-destination-listing-capabilities.md) | Destination listing capabilities — marketplace OfferManager vs shop ProductPublisher | Accepted | 2026-06-13 |
 | [ADR-025](./025-erli-marketplace-adapter.md) | Erli marketplace adapter — reconciliation-first posture, API-key auth, Allegro-ID taxonomy reuse | Accepted | 2026-06-12 |
+| [ADR-026](./026-country-agnostic-invoicing-domain.md) | Country-agnostic invoicing domain with capability decomposition | Accepted | 2026-06-16 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-751-invoicing-port-foundation.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-751-invoicing-port-foundation.md
@@ -1,0 +1,46 @@
+# Pre-implement Analysis — #751 Invoicing port foundation
+
+**Plan:** `docs/plans/implementation-plan-751-invoicing-port-foundation.md`
+**Gated:** 2026-06-16 · against worktree `751-invoicing-port-foundation` @ `9a799af2`
+
+## Verdict: ✅ READY
+
+No Critical findings. Two Warnings, both already accounted for in the plan (a spec update that travels with the capability edit, and the migration the plan already specifies). Greenfield new context — zero reuse collisions, zero contract-surface breaks.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `libs/core/src/invoicing/` context | **NEW** | directory absent |
+| `InvoicingPort` | **NEW** | no hits in `libs/`/`apps/` |
+| `InvoiceRecordRepositoryPort` | **NEW** | no hits |
+| `RegulatoryTransmitter` capability (deferred) | **NEW** | no hits |
+| `InvoiceRecord` entity | **NEW** | no hits |
+| `BuyerProfile` entity | **NEW** | no hits |
+| `TaxIdentifier` / `BuyerAddress` / `InvoiceLine` types | **NEW** | no hits |
+| `DocumentType` / `*StatusValues` / `BuyerTypeValues` unions | **NEW** | `DocumentType` 0 occurrences in `libs/core/src` — no generic-name collision |
+| `INVOICE_RECORD_REPOSITORY_TOKEN` | **NEW** | no hits |
+| `InvoiceRecordNotFoundException` / `DuplicateInvoiceRecordException` | **NEW** | no hits |
+| `invoice_records` table | **NEW** | no `invoice_records` references; migration prefix `1808…` free |
+| `'Invoicing'` in `CoreCapabilityValues` | **PARTIAL (extend)** | absent today (`adapter.types.ts` holds 7 values); additive array entry |
+| `./invoicing` package.json export | **NEW** | no `invoicing` in `libs/core/package.json` |
+| `BuyerAddress` vs customers' `CustomerAddressProjection` | **NEW (deliberate non-reuse)** | plan documents the intentional local duplication; no coupling introduced |
+
+## Backward-compat findings
+
+**Critical:** none.
+
+**Warnings:**
+1. **`adapter.types.spec.ts` pins the `CoreCapabilityValues` array** (file confirmed present). Adding `'Invoicing'` requires updating that spec in the same change or `pnpm test` fails. *The plan already lists this as step 11.* — handled.
+2. **New ORM entity ⇒ migration required.** `invoice_records` table + `1808000000000-create-invoice-records.ts`. Timestamp is unique and `> 1807000000000` (current max on `main`), satisfying the migration-ordering guard (#1013). *Plan step 13.* — handled.
+
+**`check:invariants` surface:**
+- `check-service-interfaces` — **does not fire**: #751 creates no `application/services/*.service.ts` (port + repo + entities only).
+- `check-cross-context-imports` — **clean**: the new context introduces no cross-context barrel imports (command/record fields are plain `string` ids; the repository imports only its own ORM entity). The future adapter (#753) will add cross-context imports, out of scope here.
+- `check-migration-timestamps` — satisfied (unique, ordered, class-suffix-matched as planned).
+- `check-repo-urls` — ADR-026 uses bare `#NNN` + relative ADR links only; clean.
+- Barrel/runtime-exports (#591/#594) — `./invoicing` added; `orm-entities` sub-barrel correctly **deferred** (entity is glob-discovered by the data-source, no cross-context TS consumer yet).
+
+## Open questions
+
+None blocking. The plan's prior open questions were resolved during tech-review + research (scheme-tagged `TaxIdentifier`, open-world `DocumentType`, neutral `taxRate`, deferred `RegulatoryTransmitter` sub-capability, fiscal-dedup partial-unique index, deferred `orm-entities` sub-barrel). ADR-026 is written and indexed. The agnosticism litmus (`grep -rin 'nip\|ksef\|vat\|jpk\|faktura' libs/core/src/invoicing` → 0) should be run as an implementation self-check.

--- a/docs/plans/implementation-plan-751-invoicing-port-foundation.md
+++ b/docs/plans/implementation-plan-751-invoicing-port-foundation.md
@@ -1,0 +1,166 @@
+# Implementation Plan — #751 InvoicingPort + capability + InvoiceRecord + BuyerProfile + migration
+
+**Issue:** [#751](https://github.com/openlinker-project/openlinker/issues/751) · **Parent design:** #728 (`docs/specs/product-spec-728-invoicing-integration.md`)
+**Branch:** `751-invoicing-port-foundation`
+**Layer:** CORE (new bounded context) + one migration. **No HTTP, no adapter, no FE.**
+
+---
+
+## 1. Understand the task
+
+Stand up the **domain + persistence foundation** for the invoicing bounded context so the downstream adapter (#753), bridge (#752/#755/#756), fake (#754), and FE (#757–#759) issues have a stable contract to build against. Port-first per the #728 Gate-A decision: `InvoicingPort` is the capability; Subiekt is merely its first adapter (out of scope here).
+
+**Explicit non-goals (from the issue):**
+- Subiekt adapter (#753), bridge service (#752/#755/#756), fake adapter (#754).
+- HTTP API surface (no controller/DTO — v1 only an adapter consumes the port).
+- Any FE work.
+- Identifier-mapping of provider invoice/customer ids (adapter concern, #753).
+
+**Classification:** CORE domain logic + infrastructure persistence + DX (ADR).
+
+---
+
+## 2. Research findings (conventions to mirror)
+
+- **Context template:** `libs/core/src/content/` — barrel `index.ts`, `*.tokens.ts`, `orm-entities.ts` sub-barrel, `<ctx>.module.ts`, `domain/{entities,ports,types,exceptions}`, `infrastructure/persistence/{entities,repositories}`.
+- **Barrel rule (#594):** ORM entities are NOT exported from `index.ts`; they go on the host-only `@openlinker/core/invoicing/orm-entities` sub-path.
+- **`package.json` exports:** add `./invoicing` + `./invoicing/orm-entities` (mirror the `./content` pair). `tsconfig.base.json` needs **no** change — the `@openlinker/core/*` wildcard already resolves.
+- **Domain entities:** plain `public readonly` constructors, zero framework imports, derived state as getters only (ADR-011).
+- **`as const` unions:** `const XValues = [...] as const; type X = (typeof XValues)[number]`.
+- **ORM entity:** `@Entity('snake_table')`, `@PrimaryGeneratedColumn('uuid')`, `{ type: 'text'|'uuid'|'jsonb', nullable }`, `@CreateDateColumn`/`@UpdateDateColumn`, named `@Index` for partial indexes.
+- **Repository:** `@Injectable() implements XRepositoryPort`, `@InjectRepository(OrmEntity)`, private `toDomain` / `buildOrmEntity`.
+- **Module:** `TypeOrmModule.forFeature([OrmEntity])`, bind token via `useExisting`, export the token.
+- **Migration:** `apps/api/src/migrations/{13-digit}-{desc}.ts`; class name repeats the suffix; raw-SQL `up()`+`down()`; idempotency guards (`IF NOT EXISTS`); timestamp must exceed every migration on `origin/main` (max today `1807000000000`) → use **`1808000000000`**. Auto-discovered by the data-source glob; no registration needed.
+- **Capability registry:** `CoreCapabilityValues` in `libs/core/src/integrations/domain/types/adapter.types.ts` — add `'Invoicing'` (open-string set; runtime gate validates against adapter metadata, but the well-known list should carry it). A spec at `adapter.types.spec.ts` pins the array → update it.
+- **ADR-026 written** (`docs/architecture/adrs/026-country-agnostic-invoicing-domain.md`, indexed): country-agnostic invoicing domain + capability decomposition. Standards research (EN 16931 / UNTDID 1001 / UNCL 5305 / ISO 6523, and Stripe/Avalara/Fonoa/BaseLinker API shapes) drives the type vocabulary below; the original "novel runtime `getCapabilities()`" idea was **rejected** in favour of an ADR-002 sub-capability for regulatory transmission (deferred).
+
+---
+
+## 3. Design
+
+### Capability resolution model
+`InvoicingPort` is a **registry capability** (`'Invoicing'`), resolved per-connection via `IntegrationsService.getCapabilityAdapter<InvoicingPort>(connId, 'Invoicing')` — same shape as `OfferManagerPort`/`ShopProductManagerPort`. So there is **no fixed DI token** for the port; the only token is for the repository.
+
+### Capability decomposition (ADR-026)
+1. **Registry capability** `'Invoicing'` → adapter resolution (`CoreCapabilityValues`).
+2. **Issuance** = base `InvoicingPort` methods (every invoicing adapter implements).
+3. **Regulatory transmission/clearance** = an **ADR-002 sub-capability** `RegulatoryTransmitter` (`isRegulatoryTransmitter` guard) — method-bearing (`submitForClearance`, `getClearanceStatus`). **Interface DEFERRED to the KSeF issue**; #751 only carries its nullable persistence columns. KSeF/SDI/SII are instances; a non-PL adapter omits the guard.
+4. **Document-type support** = a small runtime discovery method `getSupportedDocumentTypes(): DocumentType[]` on the base port (Avalara `GetMandates` precedent) — value-level variance, not method-bearing.
+
+### Domain types (`domain/types/invoicing.types.ts`) — standards-aligned (ADR-026)
+```ts
+// Document type — OPEN-WORLD (regimes vary unbounded). Well-known neutral values
+// align to UNTDID 1001 functional types + `receipt` (the regime value the standard omits).
+export const DocumentTypeValues =
+  ['invoice', 'receipt', 'credit-note', 'corrected', 'proforma', 'prepayment'] as const;
+export type DocumentType = (typeof DocumentTypeValues)[number] | string; // open-world
+
+export const InvoiceStatusValues = ['pending', 'issued', 'failed'] as const;       // issuance lifecycle
+export type InvoiceStatus = (typeof InvoiceStatusValues)[number];
+
+// Neutral CTC clearance lifecycle (adapter maps KSeF/SDI/SII regime states onto it).
+export const RegulatoryStatusValues =
+  ['not-applicable', 'submitted', 'cleared', 'accepted', 'rejected'] as const;
+export type RegulatoryStatus = (typeof RegulatoryStatusValues)[number];
+
+export const BuyerTypeValues = ['company', 'private'] as const;                     // neutral B2B/B2C axis
+export type BuyerType = (typeof BuyerTypeValues)[number];
+
+// Scheme-tagged tax identifier — EN 16931 BT-30 / ISO 6523 / Stripe `tax_ids` shape.
+// `scheme` is an OPEN string ('pl-nip', 'eu-vat', 'de-ustid'); core never names a country's system.
+export interface TaxIdentifier { scheme: string; value: string }
+
+export interface BuyerAddress {
+  line1: string; line2: string | null; city: string; postalCode: string; countryIso2: string;
+}
+
+export interface InvoiceLine { name: string; quantity: number; unitPriceGross: number; taxRate: string }
+// taxRate is a neutral string code (NOT `vatRate`); provider resolves to its regime
+// (PL zw/np → UNCL 5305 E/O inside the adapter). provider identifier ('subiekt', …) is a plain open string.
+```
+
+### Domain entities
+- `BuyerProfile` (`domain/entities/buyer-profile.entity.ts`): `name, taxId: TaxIdentifier | null, address: BuyerAddress, type: BuyerType`. Derived getter `isCompany` (pure). **`taxId` is scheme-tagged** (`{ scheme, value }`), never a bare `nip` — the PL adapter maps `pl-nip`; `null` = no tax id. The `buyer.type` (B2B/B2C) + `taxId` presence are *inputs* a future rules layer reads to choose `documentType` — the choice is **not** made in core (ADR-026 §3). `BuyerAddress` is a **local** value shape (not the customers context's `CustomerAddressProjection`) — coupling for a value shape is premature; deliberate duplication.
+- `InvoiceRecord` (`domain/entities/invoice-record.entity.ts`): `id, connectionId, orderId, providerType, documentType, status, providerInvoiceId: string | null, providerInvoiceNumber: string | null, regulatoryStatus, clearanceReference: string | null, idempotencyKey: string | null, pdfUrl: string | null, issuedAt: Date | null, errorMessage: string | null, createdAt, updatedAt`.
+  - **`connectionId`** — settled: every record table in core is connection-scoped; `findByOrderId` needs it.
+  - **`idempotencyKey: string | null`** — persisted from `IssueInvoiceCommand.idempotencyKey`; backs the persistence-layer issue-once guard (dedup index below).
+  - **`regulatoryStatus` + `clearanceReference: string | null`** — the (nullable) transmission columns. Defaults `regulatoryStatus='not-applicable'`, `clearanceReference=null` until a future `RegulatoryTransmitter` adapter (KSeF) populates them. Carried now so adding transmission needs **no migration** (ADR-026 migration path).
+
+### Ports
+- `domain/ports/invoicing.port.ts` — `InvoicingPort` (base = issuance mechanism; **no `getCapabilities()`** — rejected per ADR-026):
+  ```ts
+  issueInvoice(cmd: IssueInvoiceCommand): Promise<InvoiceRecord>;
+  getInvoice(query: { orderId: string } | { providerInvoiceId: string }): Promise<InvoiceRecord | null>;
+  upsertCustomer(cmd: UpsertCustomerCommand): Promise<UpsertCustomerResult>;  // BuyerProfile → provider customer id
+  getSupportedDocumentTypes(): DocumentType[];                                // runtime discovery (Avalara GetMandates precedent)
+  ```
+  The port is a **pure mechanism** — it does not decide whether/when/what-type to issue (ADR-002 §3 separation; a future ECA rules layer composes the command). `documentType` is therefore **command data** (operator/rule-chosen; adapter may derive if absent), not a port branch.
+  Command/result types live in `domain/types/invoicing.types.ts`. `IssueInvoiceCommand` carries `{ connectionId, orderId, buyer: BuyerProfile, currency: string, lines: InvoiceLine[], documentType?: DocumentType, idempotencyKey? }`. **`currency`** (ISO 4217) sits on the command (single-currency invoice), mirroring the codebase `{ amount, currency }` money convention. `InvoiceLine = { name, quantity, unitPriceGross: number, taxRate: string }` — numeric amount per core's `number` money idiom; `taxRate` a neutral string code the provider resolves.
+  - `getInvoice` presence-discriminated union `{ orderId } | { providerInvoiceId }`; `providerInvoiceId` wins if both supplied.
+- `domain/ports/capabilities/regulatory-transmitter.capability.ts` — **DEFERRED to the KSeF issue, not built in #751.** Documented here as the ADR-026 landing spot: `RegulatoryTransmitter { submitForClearance(...); getClearanceStatus(...) }` + co-located `isRegulatoryTransmitter` guard. #751 ships only the nullable `regulatoryStatus`/`clearanceReference` columns it will later populate.
+- `domain/ports/invoice-record-repository.port.ts` — `InvoiceRecordRepositoryPort`: `create(input: CreateInvoiceRecordInput): Promise<InvoiceRecord>`, `findById(id)`, `findByOrderId(orderId, connectionId)`, `findByIdempotencyKey(connectionId, idempotencyKey)`, `updateOutcome(id, patch: InvoiceOutcomePatch): Promise<InvoiceRecord>`. Minimal surface — no findAll/pagination until a consumer needs it. `findByIdempotencyKey` is the read half of the issue-once gate (#755 checks it before issuing).
+
+### Infrastructure
+- `infrastructure/persistence/entities/invoice-record.orm-entity.ts` — `@Entity('invoice_records')`; indexes `(orderId, connectionId)`, `(connectionId)`, `(status)`, partial `(providerInvoiceId) WHERE providerInvoiceId IS NOT NULL`, and the **fiscal-dedup guard**: a named **partial UNIQUE index** on `(connectionId, idempotencyKey) WHERE idempotencyKey IS NOT NULL`. This is retry-safety (a re-submitted issue with the same key can't create a second row), consistent with OL's idempotency patterns and the `listing_creation_records` partial-index precedent. Deliberately **not** `UNIQUE(connectionId, orderId)` — legitimate re-issue (faktura korygująca) must stay possible.
+- `infrastructure/persistence/repositories/invoice-record.repository.ts` — implements the port; private mappers; `updateOutcome` throws `InvoiceRecordNotFoundException` when the row is absent. `create` converts the Postgres unique-violation on the dedup index into a domain error (`DuplicateInvoiceRecordException`) per the engineering-standards repository error-handling rule (never leak `QueryFailedError`).
+- `domain/exceptions/invoice-record-not-found.exception.ts`, `domain/exceptions/duplicate-invoice-record.exception.ts`.
+
+### Wiring
+- `invoicing.tokens.ts` — `INVOICE_RECORD_REPOSITORY_TOKEN = Symbol('InvoiceRecordRepositoryPort')` (no port token — capability-resolved).
+- `invoicing.module.ts` — `TypeOrmModule.forFeature([InvoiceRecordOrmEntity])`, provide repo + `useExisting` binding, export the token + module.
+- `index.ts` barrel — export entities, types, both ports, tokens, module. **Not** the ORM entity.
+- `libs/core/package.json` — add `./invoicing` only.
+- **`orm-entities.ts` sub-barrel + `./invoicing/orm-entities` export: DEFERRED** (review SUGGESTION). The data-source discovers the ORM entity by filesystem glob (`libs/core/src/**/*.orm-entity.ts`), not via the sub-barrel, so migrations/boot don't need it. The int-spec asserts through the **repository** (domain), so there is no cross-context ORM-entity consumer yet. Per engineering-standards ("add a `<ctx>/orm-entities` sub-barrel only when an external consumer needs it"), skip it until #753/#755 actually imports the entity type — adding it now is premature surface.
+- `apps/api/src/app.module.ts` — import `InvoicingModule` (domain+persistence only).
+- `libs/core/src/integrations/domain/types/adapter.types.ts` — add `'Invoicing'` to `CoreCapabilityValues`; update `adapter.types.spec.ts`.
+
+### Migration
+- `apps/api/src/migrations/1808000000000-create-invoice-records.ts` — `CREATE TABLE invoice_records (...)` + the secondary indexes **and** the partial UNIQUE dedup index on `(connectionId, idempotencyKey) WHERE idempotencyKey IS NOT NULL`; `down()` drops indexes then table. Idempotent guards (`IF [NOT] EXISTS`).
+
+### ADR — `docs/architecture/adrs/026-country-agnostic-invoicing-domain.md` ✅ WRITTEN + indexed
+Decision recorded: country-agnostic neutral vocabulary (litmus test: zero `nip`/`ksef`/`vat`/`jpk`/`faktura` in core; standards-aligned field names); capability decomposition (issuance base port + deferred ADR-002 `RegulatoryTransmitter` sub-capability + `getSupportedDocumentTypes` discovery); `documentType` as command data with the port a pure mechanism; idempotency via key + durable dedup. Includes a Mermaid sequence diagram + 9-step flow explanation and the rejected-alternatives list (incl. the originally-proposed novel `getCapabilities()`). Grounded in the standards/platform research (EN 16931, UNTDID 1001, UNCL 5305, ISO 6523; Stripe/Avalara/Fonoa/BaseLinker).
+
+---
+
+## 4. Step-by-step (each with acceptance)
+
+1. **Types** `domain/types/invoicing.types.ts` — all `as const` unions + `BuyerAddress`, `InvoiceLine` (numeric `unitPriceGross`), command/result types incl. `currency` on `IssueInvoiceCommand`. ✅ compiles, no `any`.
+2. **Entities** `buyer-profile.entity.ts`, `invoice-record.entity.ts` (incl. `connectionId`, `idempotencyKey`). ✅ readonly ctors, pure getters, no framework imports.
+3. **Exceptions** `invoice-record-not-found.exception.ts`, `duplicate-invoice-record.exception.ts`. ✅ extend Error, captureStackTrace.
+4. **Ports** `invoicing.port.ts` (`issueInvoice`/`getInvoice`/`upsertCustomer`/`getSupportedDocumentTypes`; **no** `getCapabilities`), `invoice-record-repository.port.ts` (incl. `findByIdempotencyKey`). `RegulatoryTransmitter` sub-capability **deferred** (KSeF issue). ✅ interface-only.
+5. **Tokens** `invoicing.tokens.ts`. ✅ Symbol-only file.
+6. **ORM entity** `invoice-record.orm-entity.ts`. ✅ `@Entity('invoice_records')` + secondary indexes + partial UNIQUE dedup index.
+7. **Repository** `invoice-record.repository.ts` + private mappers; unique-violation → `DuplicateInvoiceRecordException`. ✅ implements port; returns domain entities.
+8. **Module** `invoicing.module.ts`. ✅ forFeature + useExisting + export.
+9. **Barrel** `index.ts` (no ORM entity; **no** `orm-entities.ts` sub-barrel — deferred). ✅
+10. **package.json** exports add `./invoicing` only. ✅
+11. **Capability** add `'Invoicing'` to `CoreCapabilityValues` + update `adapter.types.spec.ts`. ✅ spec array updated.
+12. **App wiring** import `InvoicingModule` in `app.module.ts`. ✅ boots.
+13. **Migration** `1808000000000-create-invoice-records.ts` (cols incl. nullable `regulatoryStatus`/`clearanceReference`/`idempotencyKey`; secondary indexes + partial UNIQUE dedup index). ✅ up+down; `migration:show` clean; ordering guard green.
+14. **ADR-026** — ✅ already written + indexed (done ahead of implementation).
+15. **Tests** — unit specs:
+    - `invoicing.types.spec.ts` (union membership), `invoice-record.entity.spec.ts` / `buyer-profile.entity.spec.ts` (getters),
+    - `invoice-record.repository.spec.ts` (mock `Repository<OrmEntity>`; assert create→toDomain mapping, findByOrderId where-clause, `updateOutcome` not-found throw),
+    - plus an `*.int-spec.ts` (real Postgres, CI-only) asserting migration up + repository round-trip **and the dedup index** (a second `create` with the same `(connectionId, idempotencyKey)` raises `DuplicateInvoiceRecordException`). ✅ `pnpm test` green; int-spec runs in CI (no local Docker — verify locally via `migration:show` + unit specs).
+
+---
+
+## 5. Validation
+
+- **Architecture:** domain pure (no Nest/TypeORM in `domain/`); app→domain only; repo throws domain exception; capability-resolved port (no concrete adapter dependency). ✅
+- **Naming:** `*.port.ts`/`*.entity.ts`/`*.orm-entity.ts`/`*.repository.ts`/`*.tokens.ts`/`*.types.ts`. ✅
+- **Contract surface:** new context barrel only adds exports; `CoreCapabilityValues` is additive; new table — no break. Migration ordering guard respected (`1808…`). ✅
+- **Security:** no secrets; PII (buyer name/address/tax id) stored only as needed for an issued record (no raw credentials). class-validator DTOs N/A (no HTTP this issue). ✅
+- **Testing strategy:** unit (entities/types/repo-mapping) + one CI int-spec (migration round-trip + dedup). Repository coverage per acceptance. ✅
+- **Agnosticism:** litmus test — `grep -rin 'nip\|ksef\|vat\|jpk\|faktura' libs/core/src/invoicing` must return zero hits (ADR-026). Add as a self-check during implementation. ✅
+
+## Resolved (post-tech-review + research)
+1. **`connectionId` on `InvoiceRecord`** — ✅ part of the design (connection-scoping is structural).
+2. **`InvoiceLine` / money** — ✅ `currency` on the command; numeric `unitPriceGross`; neutral `taxRate` string (not `vatRate`); gross/net split deferred.
+3. **Country agnosticism** — ✅ standards-aligned neutral vocabulary (ADR-026): scheme-tagged `TaxIdentifier` (not `nip`), open-world `DocumentType`, neutral `RegulatoryStatus` + `clearanceReference`.
+4. **Capability mechanism** — ✅ **resolved by research**: regulatory transmission = deferred ADR-002 `RegulatoryTransmitter` sub-capability (method-bearing); doc-type variance = `getSupportedDocumentTypes` discovery. The novel runtime `getCapabilities()` is **rejected**.
+5. **Rules-readiness** — ✅ port stays a pure mechanism; `documentType` is command data; no rules engine in #751 (future ECA + specification pattern); the command is the seam.
+6. **Fiscal dedup** — ✅ partial UNIQUE `(connectionId, idempotencyKey) WHERE NOT NULL` + `DuplicateInvoiceRecordException`; not `UNIQUE(connectionId, orderId)`.
+7. **`orm-entities` sub-barrel** — ✅ deferred until a real cross-context consumer exists.
+
+_No open flags. Ready for the `/pre-implement` gate._

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -68,7 +68,7 @@ port interfaces in `libs/core/src/<context>/domain/ports/`. An adapter
 implements one or more of them.
 
 The well-known set is `CoreCapabilityValues`, declared verbatim at
-[`libs/core/src/integrations/domain/types/adapter.types.ts:22-33`](../libs/core/src/integrations/domain/types/adapter.types.ts#L22-L33):
+[`libs/core/src/integrations/domain/types/adapter.types.ts:22-36`](../libs/core/src/integrations/domain/types/adapter.types.ts#L22-L36):
 
 ```typescript
 export const CoreCapabilityValues = [
@@ -82,6 +82,9 @@ export const CoreCapabilityValues = [
   // is its provision sub-capability.
   'ProductPublisher',
   'CategoryProvisioner',
+  // Invoicing (ADR-026). Resolves an `InvoicingPort` (issuance mechanism);
+  // regulatory transmission/clearance is a deferred ADR-002 sub-capability.
+  'Invoicing',
 ] as const;
 ```
 
@@ -94,6 +97,7 @@ export const CoreCapabilityValues = [
 | `OfferManager`         | Marketplace offer/listing management (split into sub-capabilities). | [`libs/core/src/listings/domain/ports/offer-manager.port.ts`](../libs/core/src/listings/domain/ports/offer-manager.port.ts)         |
 | `ProductPublisher`     | Shop product publishing — create/own the product record (base shop-listing port, sub-capabilities). | [`libs/core/src/listings/domain/ports/shop-product-manager.port.ts`](../libs/core/src/listings/domain/ports/shop-product-manager.port.ts) |
 | `CategoryProvisioner`  | Mirror/create a destination category tree (shop sub-capability).    | [`libs/core/src/listings/domain/ports/capabilities/category-provisioner.capability.ts`](../libs/core/src/listings/domain/ports/capabilities/category-provisioner.capability.ts) |
+| `Invoicing`            | Issue fiscal documents through a provider (ADR-026); country-agnostic. | [`libs/core/src/invoicing/domain/ports/invoicing.port.ts`](../libs/core/src/invoicing/domain/ports/invoicing.port.ts) |
 
 **Open at the registry boundary (#576).** The set above is closed at
 the type-system level (`CoreCapability` union). At the registry

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -143,6 +143,16 @@
       "types": "./dist/shipping/index.d.ts",
       "require": "./dist/shipping/index.js",
       "default": "./dist/shipping/index.js"
+    },
+    "./invoicing": {
+      "types": "./dist/invoicing/index.d.ts",
+      "require": "./dist/invoicing/index.js",
+      "default": "./dist/invoicing/index.js"
+    },
+    "./invoicing/orm-entities": {
+      "types": "./dist/invoicing/orm-entities.d.ts",
+      "require": "./dist/invoicing/orm-entities.js",
+      "default": "./dist/invoicing/orm-entities.js"
     }
   },
   "files": [

--- a/libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts
+++ b/libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts
@@ -27,6 +27,8 @@ describe('adapter.types', () => {
         // Shop-listing (#1041, ADR-024)
         'ProductPublisher',
         'CategoryProvisioner',
+        // Invoicing (#751, ADR-026)
+        'Invoicing',
       ]);
     });
   });

--- a/libs/core/src/integrations/domain/types/adapter.types.ts
+++ b/libs/core/src/integrations/domain/types/adapter.types.ts
@@ -30,6 +30,9 @@ export const CoreCapabilityValues = [
   // is its provision sub-capability.
   'ProductPublisher',
   'CategoryProvisioner',
+  // Invoicing (ADR-026). Resolves an `InvoicingPort` (issuance mechanism);
+  // regulatory transmission/clearance is a deferred ADR-002 sub-capability.
+  'Invoicing',
 ] as const;
 
 /**

--- a/libs/core/src/invoicing/domain/entities/buyer-profile.entity.spec.ts
+++ b/libs/core/src/invoicing/domain/entities/buyer-profile.entity.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * BuyerProfile entity — unit tests
+ *
+ * @module libs/core/src/invoicing/domain/entities
+ */
+import { BuyerProfile } from './buyer-profile.entity';
+import type { BuyerAddress } from '../types/invoicing.types';
+
+const address: BuyerAddress = {
+  line1: 'ul. Przykładowa 1',
+  line2: null,
+  city: 'Warszawa',
+  postalCode: '00-001',
+  countryIso2: 'PL',
+};
+
+describe('BuyerProfile', () => {
+  describe('isCompany', () => {
+    it('returns true for a company buyer', () => {
+      const buyer = new BuyerProfile('Acme Sp. z o.o.', { scheme: 'pl-nip', value: '1234567890' }, address, 'company');
+      expect(buyer.isCompany).toBe(true);
+    });
+
+    it('returns false for a private buyer', () => {
+      const buyer = new BuyerProfile('Jan Kowalski', null, address, 'private');
+      expect(buyer.isCompany).toBe(false);
+    });
+  });
+
+  it('carries a scheme-tagged tax id (no bare nip field)', () => {
+    const buyer = new BuyerProfile('Acme', { scheme: 'eu-vat', value: 'PL1234567890' }, address, 'company');
+    expect(buyer.taxId).toEqual({ scheme: 'eu-vat', value: 'PL1234567890' });
+  });
+});

--- a/libs/core/src/invoicing/domain/entities/buyer-profile.entity.ts
+++ b/libs/core/src/invoicing/domain/entities/buyer-profile.entity.ts
@@ -1,0 +1,27 @@
+/**
+ * Buyer Profile — Domain Entity
+ *
+ * The party an invoice is issued to. Country-agnostic: the tax identity is a
+ * scheme-tagged {@link TaxIdentifier} (`pl-nip`/`eu-vat`/…), never a bare NIP.
+ * `type` (company/private) and `taxId` presence are *inputs* a future rules
+ * layer reads to choose the document type — the choice is not made here
+ * (ADR-026). Plain class, no framework decorators.
+ *
+ * @module libs/core/src/invoicing/domain/entities
+ */
+import type { BuyerAddress, BuyerType, TaxIdentifier } from '../types/invoicing.types';
+
+export class BuyerProfile {
+  constructor(
+    public readonly name: string,
+    /** Scheme-tagged tax id; `null` when the buyer has none (typically B2C). */
+    public readonly taxId: TaxIdentifier | null,
+    public readonly address: BuyerAddress,
+    public readonly type: BuyerType,
+  ) {}
+
+  /** Pure derivation: a business buyer (B2B). No I/O, no mutation. */
+  get isCompany(): boolean {
+    return this.type === 'company';
+  }
+}

--- a/libs/core/src/invoicing/domain/entities/invoice-record.entity.spec.ts
+++ b/libs/core/src/invoicing/domain/entities/invoice-record.entity.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * InvoiceRecord entity — unit tests
+ *
+ * @module libs/core/src/invoicing/domain/entities
+ */
+import { InvoiceRecord } from './invoice-record.entity';
+import type { InvoiceStatus } from '../types/invoicing.types';
+
+function makeRecord(status: InvoiceStatus): InvoiceRecord {
+  const now = new Date('2026-06-16T00:00:00.000Z');
+  return new InvoiceRecord(
+    'ol_invoice_1',
+    'conn_1',
+    'ol_order_1',
+    'subiekt',
+    'invoice',
+    status,
+    null,
+    null,
+    'not-applicable',
+    null,
+    'idem-1',
+    null,
+    null,
+    null,
+    now,
+    now,
+  );
+}
+
+describe('InvoiceRecord', () => {
+  describe('isIssued', () => {
+    it('returns true once issued', () => {
+      expect(makeRecord('issued').isIssued).toBe(true);
+    });
+
+    it('returns false while pending or failed', () => {
+      expect(makeRecord('pending').isIssued).toBe(false);
+      expect(makeRecord('failed').isIssued).toBe(false);
+    });
+  });
+
+  it('defaults regulatory fields to the not-applicable / null neutral state', () => {
+    const record = makeRecord('issued');
+    expect(record.regulatoryStatus).toBe('not-applicable');
+    expect(record.clearanceReference).toBeNull();
+  });
+});

--- a/libs/core/src/invoicing/domain/entities/invoice-record.entity.ts
+++ b/libs/core/src/invoicing/domain/entities/invoice-record.entity.ts
@@ -1,0 +1,43 @@
+/**
+ * Invoice Record — Domain Entity
+ *
+ * OL's projection of a fiscal document issued through a provider for an order
+ * on an invoicing connection. Country-agnostic (ADR-026): carries a neutral
+ * `documentType`, an issuance `status`, and the neutral regulatory-clearance
+ * fields (`regulatoryStatus`/`clearanceReference`) a future `RegulatoryTransmitter`
+ * adapter populates (KSeF/SDI/SII) — nullable until then. The provider owns the
+ * authoritative document; this is a non-authoritative projection (debug/retry).
+ *
+ * @module libs/core/src/invoicing/domain/entities
+ */
+import type { InvoiceStatus, RegulatoryStatus } from '../types/invoicing.types';
+
+export class InvoiceRecord {
+  constructor(
+    public readonly id: string,
+    public readonly connectionId: string,
+    public readonly orderId: string,
+    /** Provider identifier (open string, e.g. `subiekt`). */
+    public readonly providerType: string,
+    /** Neutral document type; well-known values in `DocumentTypeValues` (open-world). */
+    public readonly documentType: string,
+    public readonly status: InvoiceStatus,
+    public readonly providerInvoiceId: string | null,
+    public readonly providerInvoiceNumber: string | null,
+    public readonly regulatoryStatus: RegulatoryStatus,
+    /** Authority-assigned reference (KSeF number, SDI id, …); `null` until transmitted. */
+    public readonly clearanceReference: string | null,
+    /** Echoed from the issue command; backs the exactly-once dedup gate. */
+    public readonly idempotencyKey: string | null,
+    public readonly pdfUrl: string | null,
+    public readonly issuedAt: Date | null,
+    public readonly errorMessage: string | null,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+  ) {}
+
+  /** Pure derivation: the document was successfully issued by the provider. */
+  get isIssued(): boolean {
+    return this.status === 'issued';
+  }
+}

--- a/libs/core/src/invoicing/domain/exceptions/duplicate-invoice-record.exception.ts
+++ b/libs/core/src/invoicing/domain/exceptions/duplicate-invoice-record.exception.ts
@@ -1,0 +1,20 @@
+/**
+ * Duplicate Invoice Record Exception
+ *
+ * Domain error raised when a `create` collides with the fiscal-dedup guard
+ * (the partial-unique index on `(connectionId, idempotencyKey)`). The repository
+ * converts the Postgres unique-violation into this domain error so the
+ * application layer never sees `QueryFailedError` — exactly-once issuance: a
+ * retried issue with the same key cannot create a second document.
+ *
+ * @module libs/core/src/invoicing/domain/exceptions
+ */
+export class DuplicateInvoiceRecordException extends Error {
+  constructor(connectionId: string, idempotencyKey: string) {
+    super(
+      `Invoice record already exists for connection ${connectionId} with idempotency key ${idempotencyKey}`,
+    );
+    this.name = 'DuplicateInvoiceRecordException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/invoicing/domain/exceptions/invoice-record-not-found.exception.ts
+++ b/libs/core/src/invoicing/domain/exceptions/invoice-record-not-found.exception.ts
@@ -1,0 +1,14 @@
+/**
+ * Invoice Record Not Found Exception
+ *
+ * Thrown by the repository's update path when no `InvoiceRecord` matches the id.
+ *
+ * @module libs/core/src/invoicing/domain/exceptions
+ */
+export class InvoiceRecordNotFoundException extends Error {
+  constructor(id: string) {
+    super(`Invoice record not found: ${id}`);
+    this.name = 'InvoiceRecordNotFoundException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/invoicing/domain/ports/invoice-record-repository.port.ts
+++ b/libs/core/src/invoicing/domain/ports/invoice-record-repository.port.ts
@@ -1,0 +1,38 @@
+/**
+ * Invoice Record Repository Port
+ *
+ * Persistence contract for `InvoiceRecord` rows. Minimal surface — only what an
+ * application service needs (no findAll/pagination until a consumer asks).
+ * `findByIdempotencyKey` is the read half of the exactly-once issue gate.
+ *
+ * @module libs/core/src/invoicing/domain/ports
+ */
+import type { InvoiceRecord } from '../entities/invoice-record.entity';
+import type {
+  CreateInvoiceRecordInput,
+  InvoiceOutcomePatch,
+} from '../types/invoicing.types';
+
+export interface InvoiceRecordRepositoryPort {
+  /**
+   * Insert a new record. Throws `DuplicateInvoiceRecordException` when it
+   * collides with the `(connectionId, idempotencyKey)` dedup guard.
+   */
+  create(input: CreateInvoiceRecordInput): Promise<InvoiceRecord>;
+
+  findById(id: string): Promise<InvoiceRecord | null>;
+
+  findByOrderId(orderId: string, connectionId: string): Promise<InvoiceRecord | null>;
+
+  /** Read half of the exactly-once gate; `null` when no row holds the key. */
+  findByIdempotencyKey(
+    connectionId: string,
+    idempotencyKey: string,
+  ): Promise<InvoiceRecord | null>;
+
+  /**
+   * Apply an outcome patch to an existing record. Throws
+   * `InvoiceRecordNotFoundException` when the id does not exist.
+   */
+  updateOutcome(id: string, patch: InvoiceOutcomePatch): Promise<InvoiceRecord>;
+}

--- a/libs/core/src/invoicing/domain/ports/invoicing.port.ts
+++ b/libs/core/src/invoicing/domain/ports/invoicing.port.ts
@@ -1,0 +1,41 @@
+/**
+ * Invoicing Port
+ *
+ * Capability contract for issuing fiscal documents through a provider, resolved
+ * per-connection via the integrations registry (capability `'Invoicing'`), the
+ * same way `OfferManagerPort`/`ShopProductManagerPort` are. A pure mechanism:
+ * it issues what the command describes and does not decide whether/when/which
+ * document to issue — that policy lives above it in a future rules layer
+ * (ADR-026). Regulatory transmission/clearance (KSeF/SDI/…) is a separate
+ * ADR-002 sub-capability (`RegulatoryTransmitter`), added when the first such
+ * provider lands — not part of this base contract.
+ *
+ * @module libs/core/src/invoicing/domain/ports
+ */
+import type { InvoiceRecord } from '../entities/invoice-record.entity';
+import type {
+  DocumentType,
+  GetInvoiceQuery,
+  IssueInvoiceCommand,
+  UpsertCustomerCommand,
+  UpsertCustomerResult,
+} from '../types/invoicing.types';
+
+export interface InvoicingPort {
+  /** Issue a fiscal document for an order; returns the persisted projection. */
+  issueInvoice(cmd: IssueInvoiceCommand): Promise<InvoiceRecord>;
+
+  /** Fetch an issued document by order id or provider id; `null` when absent. */
+  getInvoice(query: GetInvoiceQuery): Promise<InvoiceRecord | null>;
+
+  /** Create-or-update the buyer as a customer in the provider. */
+  upsertCustomer(cmd: UpsertCustomerCommand): Promise<UpsertCustomerResult>;
+
+  /**
+   * Discovery: which neutral document types this provider can issue. Lets the
+   * caller adapt without country/provider string-matching (Avalara GetMandates
+   * precedent). Value-level variance — distinct from the method-bearing
+   * `RegulatoryTransmitter` sub-capability.
+   */
+  getSupportedDocumentTypes(): DocumentType[];
+}

--- a/libs/core/src/invoicing/domain/types/invoicing.types.spec.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Invoicing domain types — unit tests
+ *
+ * Pins the neutral `as const` vocabularies (ADR-026) so an accidental
+ * reorder/removal — or a country-specific value sneaking in — fails the build.
+ *
+ * @module libs/core/src/invoicing/domain/types
+ */
+import {
+  BuyerTypeValues,
+  DocumentTypeValues,
+  InvoiceStatusValues,
+  RegulatoryStatusValues,
+} from './invoicing.types';
+
+describe('invoicing.types', () => {
+  it('exposes the well-known neutral document types', () => {
+    expect([...DocumentTypeValues]).toEqual([
+      'invoice',
+      'receipt',
+      'credit-note',
+      'corrected',
+      'proforma',
+      'prepayment',
+    ]);
+  });
+
+  it('exposes the issuance lifecycle states', () => {
+    expect([...InvoiceStatusValues]).toEqual(['pending', 'issued', 'failed']);
+  });
+
+  it('exposes the neutral CTC clearance lifecycle', () => {
+    expect([...RegulatoryStatusValues]).toEqual([
+      'not-applicable',
+      'submitted',
+      'cleared',
+      'accepted',
+      'rejected',
+    ]);
+  });
+
+  it('exposes the neutral B2B/B2C buyer axis', () => {
+    expect([...BuyerTypeValues]).toEqual(['company', 'private']);
+  });
+
+  it('carries no country-specific document type', () => {
+    // Agnosticism guard (ADR-026): no faktura/paragon/Rechnung in the vocab.
+    for (const v of DocumentTypeValues) {
+      expect(v).not.toMatch(/faktura|paragon|rechnung|nip|ksef/i);
+    }
+  });
+});

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -1,0 +1,146 @@
+/**
+ * Invoicing Domain Types
+ *
+ * Country/regulatory-agnostic vocabulary for the invoicing bounded context
+ * (ADR-026). Names are drawn from international standards — never a country's
+ * tax system: scheme-tagged tax identifiers (EN 16931 BT-30 / ISO 6523),
+ * open-world document types (UNTDID 1001 functional types + `receipt`), a
+ * neutral CTC clearance lifecycle, and ISO-4217 currency on the command.
+ * Litmus test: no `nip`/`ksef`/`vat`/`jpk`/`faktura` appears here — those live
+ * behind the provider adapter.
+ *
+ * @module libs/core/src/invoicing/domain/types
+ */
+import type { BuyerProfile } from '../entities/buyer-profile.entity';
+
+/**
+ * Document type — OPEN-WORLD (regimes vary unbounded). Well-known neutral
+ * values align to UNTDID 1001 functional types, plus `receipt` (the simplified
+ * B2C document the international standard deliberately omits but PL/EU regimes
+ * need). Adapters may issue additional neutral types; the boundary accepts any
+ * string (mirrors the `CoreCapability` open-world idiom, #576).
+ */
+export const DocumentTypeValues = [
+  'invoice',
+  'receipt',
+  'credit-note',
+  'corrected',
+  'proforma',
+  'prepayment',
+] as const;
+export type DocumentType = (typeof DocumentTypeValues)[number];
+
+/** Issuance lifecycle of an `InvoiceRecord` (distinct from payment — see ADR-026). */
+export const InvoiceStatusValues = ['pending', 'issued', 'failed'] as const;
+export type InvoiceStatus = (typeof InvoiceStatusValues)[number];
+
+/**
+ * Neutral Continuous-Transaction-Controls clearance lifecycle. The adapter maps
+ * a regime's native states (KSeF, IT SDI, ES SII…) onto these. `not-applicable`
+ * is the default for providers without regulatory transmission.
+ */
+export const RegulatoryStatusValues = [
+  'not-applicable',
+  'submitted',
+  'cleared',
+  'accepted',
+  'rejected',
+] as const;
+export type RegulatoryStatus = (typeof RegulatoryStatusValues)[number];
+
+/** Neutral B2B/B2C axis. Drives document-type policy in a future rules layer, not here. */
+export const BuyerTypeValues = ['company', 'private'] as const;
+export type BuyerType = (typeof BuyerTypeValues)[number];
+
+/**
+ * Scheme-tagged tax identifier — EN 16931 BT-30 / ISO 6523 / Stripe `tax_ids`
+ * shape. `scheme` is an OPEN string the adapter interprets (`pl-nip`, `eu-vat`,
+ * `de-ustid`); core never names a country's identifier system.
+ */
+export interface TaxIdentifier {
+  scheme: string;
+  value: string;
+}
+
+/** Postal address on a buyer profile. `countryIso2` is ISO 3166-1 alpha-2. */
+export interface BuyerAddress {
+  line1: string;
+  line2: string | null;
+  city: string;
+  postalCode: string;
+  countryIso2: string;
+}
+
+/**
+ * One invoice line. `unitPriceGross` is numeric (matches core's `number` money
+ * idiom); `taxRate` is a neutral string code the provider resolves to its
+ * regime (a PL adapter maps `zw`/`np` onto UNCL 5305 `E`/`O`).
+ */
+export interface InvoiceLine {
+  name: string;
+  quantity: number;
+  unitPriceGross: number;
+  taxRate: string;
+}
+
+/**
+ * Command to issue a fiscal document. A pure description of *what* to issue;
+ * the port does not decide whether/when/which-type — a future rules layer
+ * composes this (ADR-026). `currency` is ISO 4217 (single-currency invoice).
+ * `documentType` is caller-supplied (open-world); the adapter may derive it
+ * when absent. `idempotencyKey` backs exactly-once issuance.
+ */
+export interface IssueInvoiceCommand {
+  connectionId: string;
+  orderId: string;
+  buyer: BuyerProfile;
+  currency: string;
+  lines: InvoiceLine[];
+  /** Neutral document type; well-known values in {@link DocumentTypeValues} (open-world). */
+  documentType?: string;
+  idempotencyKey?: string;
+}
+
+/** Query for an issued document by either internal order id or provider id. */
+export type GetInvoiceQuery = { orderId: string } | { providerInvoiceId: string };
+
+/** Command to create-or-update the buyer as a customer in the provider. */
+export interface UpsertCustomerCommand {
+  connectionId: string;
+  buyer: BuyerProfile;
+}
+
+/** Result of {@link UpsertCustomerCommand} — the provider's customer id. */
+export interface UpsertCustomerResult {
+  providerCustomerId: string;
+}
+
+/** Persistence input for a new `InvoiceRecord` row (pre-issue `pending` state). */
+export interface CreateInvoiceRecordInput {
+  connectionId: string;
+  orderId: string;
+  providerType: string;
+  /** Neutral document type; well-known values in {@link DocumentTypeValues} (open-world). */
+  documentType: string;
+  status: InvoiceStatus;
+  idempotencyKey: string | null;
+  providerInvoiceId?: string | null;
+  providerInvoiceNumber?: string | null;
+  regulatoryStatus?: RegulatoryStatus;
+  clearanceReference?: string | null;
+  pdfUrl?: string | null;
+  issuedAt?: Date | null;
+  errorMessage?: string | null;
+}
+
+/** Patch applied to an existing record after an issue / transmission attempt. */
+export interface InvoiceOutcomePatch {
+  status?: InvoiceStatus;
+  providerInvoiceId?: string | null;
+  providerInvoiceNumber?: string | null;
+  regulatoryStatus?: RegulatoryStatus;
+  clearanceReference?: string | null;
+  pdfUrl?: string | null;
+  issuedAt?: Date | null;
+  errorMessage?: string | null;
+}

--- a/libs/core/src/invoicing/index.ts
+++ b/libs/core/src/invoicing/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Invoicing Bounded Context — Public Surface
+ *
+ * Exports domain types/entities/exceptions/ports, the repository token, and the
+ * NestJS module. Country-agnostic by design (ADR-026) — no country/regulatory
+ * concept crosses this barrel. ORM entities are infrastructure detail and are
+ * deliberately NOT exported (no cross-context consumer needs them yet, #594).
+ *
+ * @module libs/core/src/invoicing
+ */
+export * from './domain/types/invoicing.types';
+export * from './domain/entities/buyer-profile.entity';
+export * from './domain/entities/invoice-record.entity';
+export * from './domain/ports/invoicing.port';
+export * from './domain/ports/invoice-record-repository.port';
+export * from './domain/exceptions/invoice-record-not-found.exception';
+export * from './domain/exceptions/duplicate-invoice-record.exception';
+export * from './invoicing.tokens';
+export { InvoicingModule } from './invoicing.module';

--- a/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
@@ -1,0 +1,87 @@
+/**
+ * Invoice Record ORM Entity
+ *
+ * TypeORM entity for the `invoice_records` table. The `regulatoryStatus` /
+ * `clearanceReference` columns are nullable and unused until a future
+ * `RegulatoryTransmitter` adapter populates them (ADR-026) — carried now so
+ * adding transmission needs no migration. The partial-unique index on
+ * `(connectionId, idempotencyKey)` is the durable exactly-once issue guard.
+ *
+ * @module libs/core/src/invoicing/infrastructure/persistence/entities
+ * @see {@link InvoiceRecord} for the corresponding domain entity
+ */
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { InvoiceStatus, RegulatoryStatus } from '../../../domain/types/invoicing.types';
+
+@Entity('invoice_records')
+@Index('IDX_invoice_records_order_connection', ['orderId', 'connectionId'])
+@Index('IDX_invoice_records_connectionId', ['connectionId'])
+@Index('IDX_invoice_records_status', ['status'])
+// Lookup of an issued document by provider id (transmission/reconcile paths).
+@Index('IDX_invoice_records_provider_invoice_id', ['providerInvoiceId'], {
+  where: '"providerInvoiceId" IS NOT NULL',
+})
+// Fiscal-dedup guard — exactly-once issuance on retry (ADR-026). Partial so
+// rows without a key (manual one-off issues) don't collide on NULL.
+@Index('UQ_invoice_records_connection_idempotency', ['connectionId', 'idempotencyKey'], {
+  unique: true,
+  where: '"idempotencyKey" IS NOT NULL',
+})
+export class InvoiceRecordOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  connectionId!: string;
+
+  @Column({ type: 'text' })
+  orderId!: string;
+
+  @Column({ type: 'text' })
+  providerType!: string;
+
+  /** Neutral document type; well-known values in `DocumentTypeValues` (open-world). */
+  @Column({ type: 'text' })
+  documentType!: string;
+
+  @Column({ type: 'text' })
+  status!: InvoiceStatus;
+
+  @Column({ type: 'text', nullable: true })
+  providerInvoiceId!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  providerInvoiceNumber!: string | null;
+
+  @Column({ type: 'text', default: 'not-applicable' })
+  regulatoryStatus!: RegulatoryStatus;
+
+  @Column({ type: 'text', nullable: true })
+  clearanceReference!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  idempotencyKey!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  pdfUrl!: string | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  issuedAt!: Date | null;
+
+  @Column({ type: 'text', nullable: true })
+  errorMessage!: string | null;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * InvoiceRecordRepository — unit tests
+ *
+ * Mocks the TypeORM repository; asserts ORM↔domain mapping, the dedup
+ * unique-violation → `DuplicateInvoiceRecordException` conversion, and the
+ * not-found throw on the update path.
+ *
+ * @module libs/core/src/invoicing/infrastructure/persistence/repositories
+ */
+import type { Repository } from 'typeorm';
+import { QueryFailedError } from 'typeorm';
+
+import { InvoiceRecordRepository } from './invoice-record.repository';
+import { InvoiceRecordOrmEntity } from '../entities/invoice-record.orm-entity';
+import { DuplicateInvoiceRecordException } from '../../../domain/exceptions/duplicate-invoice-record.exception';
+import { InvoiceRecordNotFoundException } from '../../../domain/exceptions/invoice-record-not-found.exception';
+import type { CreateInvoiceRecordInput } from '../../../domain/types/invoicing.types';
+
+function ormRow(overrides: Partial<InvoiceRecordOrmEntity> = {}): InvoiceRecordOrmEntity {
+  const now = new Date('2026-06-16T00:00:00.000Z');
+  const entity = new InvoiceRecordOrmEntity();
+  Object.assign(
+    entity,
+    {
+      id: 'ol_invoice_1',
+      connectionId: 'conn_1',
+      orderId: 'ol_order_1',
+      providerType: 'subiekt',
+      documentType: 'invoice',
+      status: 'pending',
+      providerInvoiceId: null,
+      providerInvoiceNumber: null,
+      regulatoryStatus: 'not-applicable',
+      clearanceReference: null,
+      idempotencyKey: 'idem-1',
+      pdfUrl: null,
+      issuedAt: null,
+      errorMessage: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+    overrides,
+  );
+  return entity;
+}
+
+const createInput: CreateInvoiceRecordInput = {
+  connectionId: 'conn_1',
+  orderId: 'ol_order_1',
+  providerType: 'subiekt',
+  documentType: 'invoice',
+  status: 'pending',
+  idempotencyKey: 'idem-1',
+};
+
+describe('InvoiceRecordRepository', () => {
+  let ormRepo: jest.Mocked<Repository<InvoiceRecordOrmEntity>>;
+  let repository: InvoiceRecordRepository;
+
+  beforeEach(() => {
+    ormRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+    } as unknown as jest.Mocked<Repository<InvoiceRecordOrmEntity>>;
+    repository = new InvoiceRecordRepository(ormRepo);
+  });
+
+  describe('create', () => {
+    it('persists and maps to a domain entity', async () => {
+      ormRepo.save.mockResolvedValue(ormRow());
+
+      const result = await repository.create(createInput);
+
+      expect(ormRepo.save).toHaveBeenCalledTimes(1);
+      expect(result.id).toBe('ol_invoice_1');
+      expect(result.documentType).toBe('invoice');
+      expect(result.regulatoryStatus).toBe('not-applicable');
+      expect(result.isIssued).toBe(false);
+    });
+
+    it('converts a unique-violation into DuplicateInvoiceRecordException', async () => {
+      ormRepo.save.mockRejectedValue(
+        new QueryFailedError(
+          '',
+          undefined,
+          new Error('duplicate key value violates unique constraint "UQ_invoice_records_connection_idempotency"'),
+        ),
+      );
+
+      await expect(repository.create(createInput)).rejects.toBeInstanceOf(
+        DuplicateInvoiceRecordException,
+      );
+    });
+
+    it('rethrows non-duplicate query failures unchanged', async () => {
+      const other = new QueryFailedError('', undefined, new Error('connection reset'));
+      ormRepo.save.mockRejectedValue(other);
+
+      await expect(repository.create(createInput)).rejects.toBe(other);
+    });
+  });
+
+  describe('findByOrderId', () => {
+    it('scopes the lookup by order + connection', async () => {
+      ormRepo.findOne.mockResolvedValue(ormRow());
+
+      const result = await repository.findByOrderId('ol_order_1', 'conn_1');
+
+      expect(ormRepo.findOne).toHaveBeenCalledWith({
+        where: { orderId: 'ol_order_1', connectionId: 'conn_1' },
+      });
+      expect(result?.orderId).toBe('ol_order_1');
+    });
+
+    it('returns null when absent', async () => {
+      ormRepo.findOne.mockResolvedValue(null);
+      expect(await repository.findByOrderId('missing', 'conn_1')).toBeNull();
+    });
+  });
+
+  describe('findByIdempotencyKey', () => {
+    it('reads the dedup gate by connection + key', async () => {
+      ormRepo.findOne.mockResolvedValue(ormRow());
+      await repository.findByIdempotencyKey('conn_1', 'idem-1');
+      expect(ormRepo.findOne).toHaveBeenCalledWith({
+        where: { connectionId: 'conn_1', idempotencyKey: 'idem-1' },
+      });
+    });
+  });
+
+  describe('updateOutcome', () => {
+    it('applies the patch and maps the result', async () => {
+      ormRepo.findOne.mockResolvedValue(ormRow());
+      ormRepo.save.mockResolvedValue(
+        ormRow({ status: 'issued', providerInvoiceId: 'FV/2026/01', issuedAt: new Date() }),
+      );
+
+      const result = await repository.updateOutcome('ol_invoice_1', {
+        status: 'issued',
+        providerInvoiceId: 'FV/2026/01',
+      });
+
+      expect(result.status).toBe('issued');
+      expect(result.providerInvoiceId).toBe('FV/2026/01');
+    });
+
+    it('throws InvoiceRecordNotFoundException when the row is absent', async () => {
+      ormRepo.findOne.mockResolvedValue(null);
+      await expect(
+        repository.updateOutcome('missing', { status: 'failed' }),
+      ).rejects.toBeInstanceOf(InvoiceRecordNotFoundException);
+    });
+  });
+});

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
@@ -1,0 +1,117 @@
+/**
+ * Invoice Record Repository
+ *
+ * TypeORM implementation of `InvoiceRecordRepositoryPort`. Maps ORM ↔ domain
+ * privately; callers receive domain entities only. Converts the Postgres
+ * unique-violation on the dedup index into `DuplicateInvoiceRecordException`
+ * (never leaks `QueryFailedError`), and throws `InvoiceRecordNotFoundException`
+ * on the update path when the row is absent.
+ *
+ * @module libs/core/src/invoicing/infrastructure/persistence/repositories
+ * @implements {InvoiceRecordRepositoryPort}
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
+
+import { InvoiceRecord } from '../../../domain/entities/invoice-record.entity';
+import { DuplicateInvoiceRecordException } from '../../../domain/exceptions/duplicate-invoice-record.exception';
+import { InvoiceRecordNotFoundException } from '../../../domain/exceptions/invoice-record-not-found.exception';
+import type { InvoiceRecordRepositoryPort } from '../../../domain/ports/invoice-record-repository.port';
+import type {
+  CreateInvoiceRecordInput,
+  InvoiceOutcomePatch,
+} from '../../../domain/types/invoicing.types';
+import { InvoiceRecordOrmEntity } from '../entities/invoice-record.orm-entity';
+
+@Injectable()
+export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
+  constructor(
+    @InjectRepository(InvoiceRecordOrmEntity)
+    private readonly repository: Repository<InvoiceRecordOrmEntity>,
+  ) {}
+
+  async create(input: CreateInvoiceRecordInput): Promise<InvoiceRecord> {
+    const entity = this.buildOrmEntity(input);
+    try {
+      const saved = await this.repository.save(entity);
+      return this.toDomain(saved);
+    } catch (error) {
+      if (
+        error instanceof QueryFailedError &&
+        error.message.includes('duplicate key') &&
+        input.idempotencyKey !== null
+      ) {
+        throw new DuplicateInvoiceRecordException(input.connectionId, input.idempotencyKey);
+      }
+      throw error;
+    }
+  }
+
+  async findById(id: string): Promise<InvoiceRecord | null> {
+    const entity = await this.repository.findOne({ where: { id } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async findByOrderId(orderId: string, connectionId: string): Promise<InvoiceRecord | null> {
+    const entity = await this.repository.findOne({ where: { orderId, connectionId } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async findByIdempotencyKey(
+    connectionId: string,
+    idempotencyKey: string,
+  ): Promise<InvoiceRecord | null> {
+    const entity = await this.repository.findOne({ where: { connectionId, idempotencyKey } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async updateOutcome(id: string, patch: InvoiceOutcomePatch): Promise<InvoiceRecord> {
+    const entity = await this.repository.findOne({ where: { id } });
+    if (!entity) {
+      throw new InvoiceRecordNotFoundException(id);
+    }
+    Object.assign(entity, patch);
+    const saved = await this.repository.save(entity);
+    return this.toDomain(saved);
+  }
+
+  private buildOrmEntity(input: CreateInvoiceRecordInput): InvoiceRecordOrmEntity {
+    const entity = new InvoiceRecordOrmEntity();
+    entity.connectionId = input.connectionId;
+    entity.orderId = input.orderId;
+    entity.providerType = input.providerType;
+    entity.documentType = input.documentType;
+    entity.status = input.status;
+    entity.idempotencyKey = input.idempotencyKey;
+    entity.providerInvoiceId = input.providerInvoiceId ?? null;
+    entity.providerInvoiceNumber = input.providerInvoiceNumber ?? null;
+    entity.regulatoryStatus = input.regulatoryStatus ?? 'not-applicable';
+    entity.clearanceReference = input.clearanceReference ?? null;
+    entity.pdfUrl = input.pdfUrl ?? null;
+    entity.issuedAt = input.issuedAt ?? null;
+    entity.errorMessage = input.errorMessage ?? null;
+    return entity;
+  }
+
+  private toDomain(entity: InvoiceRecordOrmEntity): InvoiceRecord {
+    return new InvoiceRecord(
+      entity.id,
+      entity.connectionId,
+      entity.orderId,
+      entity.providerType,
+      entity.documentType,
+      entity.status,
+      entity.providerInvoiceId,
+      entity.providerInvoiceNumber,
+      entity.regulatoryStatus,
+      entity.clearanceReference,
+      entity.idempotencyKey,
+      entity.pdfUrl,
+      entity.issuedAt,
+      entity.errorMessage,
+      entity.createdAt,
+      entity.updatedAt,
+    );
+  }
+}

--- a/libs/core/src/invoicing/invoicing.module.ts
+++ b/libs/core/src/invoicing/invoicing.module.ts
@@ -1,0 +1,31 @@
+/**
+ * Invoicing Module (core)
+ *
+ * NestJS module for the invoicing bounded context. Wires the `invoice_records`
+ * ORM entity into TypeORM and binds `InvoiceRecordRepository` to its port token.
+ * Issuance adapters are resolved per-connection through the integrations
+ * registry (capability `'Invoicing'`), so no `InvoicingPort` binding lives here.
+ *
+ * @module libs/core/src/invoicing
+ */
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { InvoiceRecordOrmEntity } from './infrastructure/persistence/entities/invoice-record.orm-entity';
+import { InvoiceRecordRepository } from './infrastructure/persistence/repositories/invoice-record.repository';
+import { INVOICE_RECORD_REPOSITORY_TOKEN } from './invoicing.tokens';
+
+export { INVOICE_RECORD_REPOSITORY_TOKEN } from './invoicing.tokens';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([InvoiceRecordOrmEntity])],
+  providers: [
+    InvoiceRecordRepository,
+    {
+      provide: INVOICE_RECORD_REPOSITORY_TOKEN,
+      useExisting: InvoiceRecordRepository,
+    },
+  ],
+  exports: [INVOICE_RECORD_REPOSITORY_TOKEN],
+})
+export class InvoicingModule {}

--- a/libs/core/src/invoicing/invoicing.tokens.ts
+++ b/libs/core/src/invoicing/invoicing.tokens.ts
@@ -1,0 +1,10 @@
+/**
+ * Invoicing Module Dependency Injection Tokens
+ *
+ * Symbol tokens for the invoicing bounded context. The `InvoicingPort` itself
+ * is capability-resolved per-connection (no fixed token); only the repository
+ * port needs a binding token.
+ *
+ * @module libs/core/src/invoicing
+ */
+export const INVOICE_RECORD_REPOSITORY_TOKEN = Symbol('InvoiceRecordRepositoryPort');

--- a/libs/core/src/invoicing/orm-entities.ts
+++ b/libs/core/src/invoicing/orm-entities.ts
@@ -1,0 +1,11 @@
+/**
+ * Invoicing — ORM Entities sub-barrel.
+ *
+ * Host-only seam (#594). See `libs/core/src/products/orm-entities.ts` for the
+ * full rationale and consumption rules. Consumed by integration-test fixtures
+ * that assert real persistence against the `invoice_records` table. Plugins and
+ * core port files are ESLint-blocked from importing this path.
+ *
+ * @module libs/core/src/invoicing/orm-entities
+ */
+export { InvoiceRecordOrmEntity } from './infrastructure/persistence/entities/invoice-record.orm-entity';

--- a/scripts/check-plugin-guide-quotes.mjs
+++ b/scripts/check-plugin-guide-quotes.mjs
@@ -49,8 +49,8 @@ const VERBATIM_QUOTES = [
     label: 'CoreCapabilityValues',
     sourceFile: 'libs/core/src/integrations/domain/types/adapter.types.ts',
     sourceStart: 22, // 1-indexed
-    sourceEnd: 33,
-    guideLinkSubstring: 'adapter.types.ts:22-33',
+    sourceEnd: 36,
+    guideLinkSubstring: 'adapter.types.ts:22-36',
     fenceOpen: '```typescript',
   },
 ];


### PR DESCRIPTION
## What & why

Stands up the **country/regulatory-agnostic invoicing bounded context** (`libs/core/src/invoicing/`) — the domain + persistence foundation the Subiekt adapter (#753), bridge (#752/#755/#756), and FE (#757–#759) build on. Product design: #728. Architecture decision: **[ADR-026](../blob/751-invoicing-port-foundation/docs/architecture/adrs/026-country-agnostic-invoicing-domain.md)**.

**No HTTP / adapter / FE** — those are explicit non-goals of #751.

## Design (ADR-026)

- **Neutral domain — zero country terms in core** (litmus: no `nip`/`ksef`/`vat`/`jpk`/`faktura` in `libs/core/src/invoicing`). Vocabulary is standards-aligned: scheme-tagged `TaxIdentifier` (EN 16931 BT-30 / ISO 6523, à la Stripe `tax_ids`), open-world `DocumentType` (UNTDID 1001 functional types + `receipt`), neutral CTC `RegulatoryStatus` lifecycle, ISO-4217 `currency` on the command.
- **`InvoicingPort`** (`issueInvoice` / `getInvoice` / `upsertCustomer` / `getSupportedDocumentTypes`) — a pure mechanism resolved per-connection via the new `'Invoicing'` capability. Document-type/timing **policy stays above the port** (future rules layer); the port never decides whether/when/what to issue. Regulatory transmission/clearance (KSeF/SDI/SII) is a **deferred ADR-002 sub-capability**, not a novel mechanism.
- **Persistence**: `InvoiceRecord` + `BuyerProfile` domain entities; `InvoiceRecordRepositoryPort` + TypeORM repository (converts the Postgres unique-violation → `DuplicateInvoiceRecordException`, never leaks `QueryFailedError`). `invoice_records` table (migration `1808000000000`) with a **partial-unique fiscal-dedup index** on `(connectionId, idempotencyKey) WHERE idempotencyKey IS NOT NULL` for exactly-once issuance. Nullable `regulatoryStatus`/`clearanceReference` columns are carried now so adding transmission needs no later migration.
- **Issuance ≠ payment**: the trigger is configurable policy (#728 A4), not gated on payment — B2B invoice-then-pay and proforma/advance precede payment (ADR-026 flow).

## Wiring

`'Invoicing'` added to `CoreCapabilityValues` (+ spec); `@openlinker/core/invoicing` (+ `/orm-entities` host seam) barrels & package.json exports; `InvoicingModule` registered in the API app; plugin-author-guide capability quote + table synced.

## How to test

- `pnpm lint && pnpm type-check && pnpm test` — all green (1160+ unit tests; `check:invariants` incl. migration-ordering, capability-spec, plugin-guide-quote, cross-context, service-interface).
- Unit specs: types / entities / repository mapping + dedup-conversion + not-found.
- CI int-spec (`apps/api/test/integration/invoicing/`): proves the migration and the **real** partial-unique index (rejects a dup, allows many NULL-key rows) against Testcontainers Postgres. (Not run locally — no Docker; validated statically via `check:invariants` + type-check.)

## Related

- Product design: #728 · ADR: ADR-026
- Follow-ups it unblocks: #752, #753, #754, #755, #756, #757, #758, #759

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)