### PR TITLE
feat(subiekt): FakeSubiektBridgeAdapter + bridge contract for Mac/Linux dev (#754)

### DIFF
--- a/docs/plans/analysis/ANALYSIS-implementation-plan-754-fake-subiekt-bridge.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-754-fake-subiekt-bridge.md
@@ -1,0 +1,42 @@
+# Pre-implement Analysis — #754 FakeSubiektBridgeAdapter
+
+**Plan:** `docs/plans/implementation-plan-754-fake-subiekt-bridge.md`
+**Gated:** 2026-06-17 · against worktree `754-fake-subiekt-bridge-adapter` @ `590cac51`
+
+## Verdict: ✅ READY
+
+No Critical findings. Greenfield package — every artifact is genuinely new, no contract surface is touched (additive `tsconfig.base.json` paths only), and the two invariants the tech-review flagged as gate risks both resolve cleanly. One minor open question (dep trimming) that doesn't block.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `libs/integrations/subiekt/` package | **NEW** | directory absent |
+| `SubiektBridgeClient` (contract interface) | **NEW** | 0 hits in `libs`/`apps` |
+| bridge DTOs (`BridgeIssueInvoiceRequest`, …) | **NEW** | 0 hits |
+| `SubiektBridgeUnreachableError` / `SubiektRejectedError` | **NEW** | 0 hits |
+| `FakeSubiektBridgeAdapter` | **NEW** | 0 hits |
+| `runSubiektBridgeContractTests` | **NEW** | 0 hits |
+| `@openlinker/integrations-subiekt` tsconfig paths | **NEW** | 0 occurrences in `tsconfig.base.json` |
+| `./testing` package-export pattern | **REUSE (precedent)** | `libs/integrations/inpost/package.json` ships `exports["./testing"]` + `src/testing.ts` + `src/testing/fake-*.adapter.ts` — mirror it |
+| package skeleton (package.json/tsconfig/jest) | **REUSE (template)** | mirror `libs/integrations/erli/` (#1019) verbatim, retargeting the jest `moduleNameMapper` |
+
+## Backward-compat findings
+
+**Critical:** none. No barrel export, port signature, DTO, Symbol token, or ORM schema is removed/renamed. No migration. No `apps/*/plugins.ts` edit.
+
+**Warnings:**
+1. **`check-libs-build-scripts`** scans every `libs/integrations/*` package for a non-empty `scripts.build`. The new package **must** carry `"build": "tsc -b"` — satisfied by the Erli-mirrored `package.json`. *(Handled in plan step 1.)*
+2. **`tsconfig.base.json`** gains two `@openlinker/integrations-subiekt` + `/*` paths entries — additive, no break.
+
+**Invariants that do NOT fire (verified):**
+- `check-create-adapter` — validates the scaffolder *templates* (`scripts/create-adapter-templates/`, tmpdir, `EXPECTED_FILE_COUNT=14`); it does **not** scan real integration packages. A hand-built package cannot trip it.
+- `check-jest-integration-mappers` (#917) — only fires for `@openlinker/integrations-*` packages imported in `apps/{api,worker}/src/plugins.ts`. #754 adds **no** plugins.ts entry → no mapper line needed.
+- `check-cross-context-imports` — the bridge contract + fake are Subiekt-native and import nothing from `@openlinker/core/*` (neutral↔bridge mapping is #753). No cross-context import to validate.
+- `check-service-interfaces` — scoped to `libs/core/src/**/application/services`; N/A.
+
+## Open questions
+
+1. **Workspace deps / tsconfig references — erli-parity vs trim-to-actuals.** The Erli template declares `@openlinker/{core,plugin-sdk,shared}` deps + tsconfig `references`. #754's fake + contract are self-contained (no core import yet), so those would be *declared-but-unused* until #753. Either keep erli-parity (cheap forward-compat for #753's runtime adapter) or trim to actuals now. Non-blocking; recommend **keep parity** to avoid churn when #753 lands. Verify `tsconfig.eslint.json` covers `libs/integrations/**` (glob) so the new package is type-aware-linted — the build/lint gate will surface it if not.
+
+Plan is implementation-ready.

--- a/docs/plans/implementation-plan-754-fake-subiekt-bridge.md
+++ b/docs/plans/implementation-plan-754-fake-subiekt-bridge.md
@@ -1,0 +1,120 @@
+# Implementation Plan — #754 `FakeSubiektBridgeAdapter` for Mac/Linux dev
+
+**Issue:** [#754](https://github.com/openlinker-project/openlinker/issues/754) · **Parent design:** #728 (`docs/specs/product-spec-728-invoicing-integration.md` §4.4 SC-1, AC-10)
+**Branch:** `754-fake-subiekt-bridge-adapter`
+**Layer:** Integration (new plugin package skeleton) + DX. **No runtime adapter, no NestJS wiring, no FE, no .NET.**
+
+---
+
+## 1. Understand the task
+
+Bootstrap the `@openlinker/integrations-subiekt` package and ship an **in-memory double of the Subiekt bridge's REST surface** so the real Subiekt adapter (#753) can be developed and unit-tested on Mac/Linux with **no Windows VM and no live bridge**. The bridge is a Windows .NET service (#752) that wraps InsERT's Sfera SDK; OL's adapter (#753) calls it over HTTP. This issue replaces that HTTP client with a deterministic fake in tests.
+
+**Role clarification (from the spec, decisive):** the fake doubles the **bridge client** (the HTTP surface the adapter *calls*), not `InvoicingPort`. SC-1: "implements bridge REST contract, returns mock data." AC-10: "consumed by OL adapter `*.spec.ts` tests." So `FakeSubiektBridgeAdapter implements SubiektBridgeClient`, and #753's `SubiektInvoicingAdapter` is constructed with it in tests.
+
+**Scope precision (review):** #754 enables developing and unit-testing the Subiekt **adapter** off-Windows. It does **not** by itself let OL's core/integration tests exercise the `'Invoicing'` capability end-to-end — that needs the real `SubiektInvoicingAdapter` wired with the fake client (#753). The PR description must state this so the boundary isn't over-claimed.
+
+**Why this is the right design (research-backed):** Subiekt nexo has no cloud API; its only surface is the Windows-only Sfera .NET/COM SDK, which can't be containerized — so the real dependency is *categorically un-runnable* on a contributor laptop. Per *Software Engineering at Google* (Ch. 13) and Fowler's taxonomy, that is exactly the case where an in-memory **fake** (not a mock/stub, and not record/replay — the bridge conversation is stateful + write-bearing, and re-recording would need the very Windows box we're avoiding) is the correct double, swapped at the seam. The Windows-bridge pattern itself is industry-standard (SellIntegro/SubSync/Orbis local Windows services over Sfera; QuickBooks Web Connector / Sage 50 internationally). **The load-bearing risk is fidelity drift** — see the dedicated section below.
+
+**Explicit non-goals (issue + spec):**
+- The real HTTP bridge client + the `SubiektInvoicingAdapter` (`InvoicingPort` impl) — **#753**.
+- The .NET bridge + its authoritative REST contract — **#752/#755/#756**.
+- Plugin manifest / descriptor / host registration (`apps/{api,worker}/plugins.ts`) — comes with the adapter (#753).
+- Any FE, connection-test, or production deployment.
+
+**Classification:** Integration (plugin scaffold) + DX.
+
+## 2. Research findings (conventions to mirror)
+
+- **Package skeleton template:** `libs/integrations/erli/` (newest, #1019) — `package.json`, `tsconfig.json`, `tsconfig.spec.json`, `jest.config.mjs`, flat `src/`.
+- **`/testing` sub-barrel precedent:** `libs/integrations/inpost/` — `src/testing.ts` barrel, `src/testing/fake-inpost-shipping.adapter.ts`, and the `package.json` `exports["./testing"]` declaration. Fake pattern: implements the contract, private state fields, `seed*` + `clear()` helpers, returns `Promise.resolve/reject` (not `async`) so failures surface as rejections.
+- **Workspace:** `pnpm-workspace.yaml` globs `libs/integrations/*` — **no edit needed**. `tsconfig.base.json` **does** need explicit `@openlinker/integrations-subiekt` + `/*` paths entries (every integration package has them).
+- **ESLint:** root `.eslintrc.js` applies; note the `consistent-type-imports` rule (`import type` for type-only) and `no-explicit-any: error`.
+- **Bridge surface (provisional):** the `sfera-api-main` reference exposes endpoints like `POST /api/przyjecie`; invoice issuance is "the next endpoint." #752 owns the **authoritative** REST contract — so #754 defines a **minimal provisional `SubiektBridgeClient`** (issue / customer-upsert / status-read per the AC) and flags it for reconciliation with #752.
+
+## 3. Design
+
+### Package layout (`libs/integrations/subiekt/`)
+```
+libs/integrations/subiekt/
+├── package.json            # name @openlinker/integrations-subiekt; exports "." + "./testing"
+├── tsconfig.json           # mirror erli (references core/shared/plugin-sdk)
+├── tsconfig.spec.json      # mirror erli
+├── jest.config.mjs         # mirror erli; moduleNameMapper → integrations-subiekt
+└── src/
+    ├── index.ts            # main barrel — exports the bridge contract types
+    ├── bridge/
+    │   ├── subiekt-bridge.client.ts   # interface SubiektBridgeClient (contract, no impl)
+    │   └── subiekt-bridge.types.ts    # bridge-native request/response DTOs + status union
+    ├── testing.ts          # /testing sub-barrel — exports the fake + the contract suite
+    └── testing/
+        ├── fake-subiekt-bridge.adapter.ts        # FakeSubiektBridgeAdapter implements SubiektBridgeClient
+        ├── subiekt-bridge-contract.suite.ts      # runSubiektBridgeContractTests(makeClient) — reusable (fidelity seam)
+        └── __tests__/fake-subiekt-bridge.adapter.spec.ts   # runs the contract suite against the fake
+```
+`bridge/subiekt-bridge.errors.ts` holds the two error classes (`SubiektBridgeUnreachableError`, `SubiektRejectedError`); exported from the main barrel so #753 can both throw (real client) and catch them.
+
+### Bridge contract — `SubiektBridgeClient` (Subiekt-native; provisional, #752 authoritative)
+The plugin package is **not** bound by the core agnosticism litmus — bridge DTOs may use Subiekt/PL terms (`nip`, KSeF states). The neutral↔bridge mapping is #753's adapter, not here. Methods cover exactly the AC's three endpoints:
+```ts
+export interface SubiektBridgeClient {
+  issueInvoice(req: BridgeIssueInvoiceRequest): Promise<BridgeIssueInvoiceResponse>;
+  upsertCustomer(req: BridgeUpsertCustomerRequest): Promise<BridgeUpsertCustomerResponse>;
+  getInvoiceStatus(req: BridgeInvoiceStatusRequest): Promise<BridgeInvoiceStatusResponse>;
+}
+```
+Types (`subiekt-bridge.types.ts`), provisional shapes:
+- `BridgeIssueInvoiceRequest` — `{ orderId, idempotencyKey?, documentType, currency, buyer: BridgeBuyer, lines: BridgeLine[] }`; `BridgeBuyer = { name, nip: string | null, address {...}, type: 'company'|'private' }`; `BridgeLine = { name, quantity, unitPriceGross, taxRate }`.
+- `BridgeIssueInvoiceResponse` — `{ providerInvoiceId, providerInvoiceNumber, regulatoryStatus: BridgeRegulatoryStatus, pdfUrl: string | null }`.
+- `BridgeUpsertCustomerRequest` — `{ buyer: BridgeBuyer }`; `BridgeUpsertCustomerResponse` — `{ providerCustomerId }`.
+- `BridgeInvoiceStatusRequest` — `{ providerInvoiceId }`; `BridgeInvoiceStatusResponse` — `{ status: BridgeInvoiceStatus, regulatoryStatus: BridgeRegulatoryStatus }`.
+- `BridgeRegulatoryStatus = 'none' | 'pending' | 'sent' | 'accepted' | 'rejected'` (KSeF-native; #753 maps → neutral `RegulatoryStatus`).
+- `BridgeInvoiceStatus = 'issued' | 'failed'` (bridge-native).
+All declared with `as const` unions where enumerated, per standards.
+
+### `FakeSubiektBridgeAdapter implements SubiektBridgeClient`
+- Deterministic defaults: `issueInvoice` → `{ providerInvoiceId: 'SUB-MOCK-1', providerInvoiceNumber: 'FV-MOCK-001', regulatoryStatus: 'sent', pdfUrl: null }` (counter-incremented per call so multiple issues differ); `upsertCustomer` → `{ providerCustomerId: 'KH-MOCK-1' }`; `getInvoiceStatus` → last-issued status (or seeded).
+- **Failure modes** (AC): `seedFailure('bridge-unreachable')` → rejects with a `BridgeUnreachableError`; `seedFailure('subiekt-rejected', { reason })` → rejects with a `SubiektRejectedError` carrying the reason. Errors are plain `Error` subclasses exported from the package (the real client throws the same shapes so adapter `.rejects` assertions are portable).
+- **Helpers:** `seed(partial)` to override the next response; `clear()` resets counters + seeded failure/overrides. Returns `Promise.resolve/reject` (no `async`) — matches the InPost precedent and keeps rejections as rejections.
+- JSDoc on every helper (AC).
+
+### Barrels & exports
+- `src/index.ts` — exports `SubiektBridgeClient` + all bridge types + the two error classes (so #753 imports the contract).
+- `src/testing.ts` — exports `FakeSubiektBridgeAdapter` **and** `runSubiektBridgeContractTests` (the reusable contract suite).
+- `package.json` `exports`: `"."` and `"./testing"` (mirror inpost). `tsc -b` emits `dist/testing.js` from `src/testing.ts`.
+- **Convention note:** unlike the existing `/testing` fakes (InPost's `FakeInpostShippingAdapter implements ShippingProviderManagerPort` — a *core port*), this fake doubles a **plugin-internal** contract (`SubiektBridgeClient`). A legitimate but novel use of `/testing`; the fake's file header states this so a future reader doesn't expect a core-port fake.
+
+### Fidelity & contract verification (research-driven — the load-bearing risk)
+A fake of an un-runnable dependency can **pass while the real bridge fails** (fidelity drift). Because no Mac/Linux contributor ever runs the real Sfera bridge, nothing organically corrects that drift. Mitigation per *SWE@Google* Ch. 13 — one **contract suite run against both** the fake and the real implementation:
+- #754 ships `runSubiektBridgeContractTests(makeClient: () => SubiektBridgeClient)` — a parameterized suite asserting the contract behaviour (issue returns a number+status; upsert returns a customer id; status read echoes the last issue; the two failure modes reject with the typed errors). The fake's spec runs it against `new FakeSubiektBridgeAdapter()`.
+- **Deferred verification (assigned to #752/#753):** when the real HTTP `SubiektBridgeClient` (#753) and the .NET bridge (#752) exist, the *same* suite runs against the real bridge in a **Windows-only CI job** (ideally owned by the bridge maintainer). That job is where any divergence surfaces. #754 builds the seam; it cannot run the real half (no bridge yet).
+- **Right-sized:** a single consumer + single bridge does **not** warrant Pact/broker machinery — the lightweight "one suite, two backends" form is proportionate (and is the documented recommendation).
+- `#752` owns the **authoritative** REST contract; `SubiektBridgeClient` is the TS expression of it. The contract suite is the reconciliation anchor — the bridge's file header flags `#752` as authoritative so divergence is caught by the shared suite, not silently.
+
+## 4. Step-by-step (each with acceptance)
+
+1. **Scaffold package** — `package.json` (name, `exports` `.`+`./testing`, deps `@openlinker/{core,shared,plugin-sdk}` workspace:*), `tsconfig.json`, `tsconfig.spec.json`, `jest.config.mjs` (all mirrored from erli; jest mapper → `integrations-subiekt`). ✅ `pnpm install` clean; `tsc -b` builds.
+2. **tsconfig.base.json** — add `@openlinker/integrations-subiekt` + `/*` paths. ✅ resolves.
+3. **Bridge contract** — `bridge/subiekt-bridge.client.ts` (interface) + `bridge/subiekt-bridge.types.ts` (DTOs + `as const` status unions) + error classes (`bridge/subiekt-bridge.errors.ts`). ✅ interface-only; no impl.
+4. **Fake** — `testing/fake-subiekt-bridge.adapter.ts` implementing the client with deterministic returns + `seed`/`seedFailure`/`clear`. ✅ no `any`, file header (notes it doubles a plugin-internal contract), JSDoc helpers.
+5. **Contract suite** — `testing/subiekt-bridge-contract.suite.ts` exporting `runSubiektBridgeContractTests(makeClient)` (the fidelity seam, reusable by #753 against the real client). ✅
+6. **Barrels** — `src/index.ts` (contract + types + errors), `src/testing.ts` (fake + contract suite). ✅ `./testing` export resolves.
+7. **Tests** — `testing/__tests__/fake-subiekt-bridge.adapter.spec.ts` runs `runSubiektBridgeContractTests(() => new FakeSubiektBridgeAdapter())` + fake-specific `seed`/`clear` assertions. ✅ `pnpm test` green.
+8. **Quality gate** — lint + type-check + test green; `check:invariants` unaffected (no plugins.ts edit → no jest-integration-mapper entry needed). **Verify** the new contract-only package doesn't trip `check-create-adapter` / `check-libs-build-scripts` (a gate concern — confirmed at `/pre-implement`).
+
+## 5. Validation
+
+- **Architecture:** plugin-internal contract + fake; no core dependency leak (bridge DTOs are Subiekt-native; neutral mapping deferred to #753). Fake implements the contract interface, mirrors the InPost fake pattern. ✅
+- **Naming:** `*.client.ts` (contract), `*.types.ts`, `*.adapter.ts` (fake), `*.spec.ts`. ✅
+- **Contract surface:** purely additive (new package, new `tsconfig.base.json` paths). No existing barrel/port/DTO/migration touched. ✅
+- **Testing:** fake's own unit specs satisfy the testable ACs now; AC-1/AC-10 ("adapter specs consume it") satisfied when #753's adapter lands and imports the contract + fake. ✅
+- **Security:** no secrets; no network; no DB. ✅
+
+## Resolved (post tech-review + research)
+1. **#753 coupling** — ✅ ship #754 standalone (fake + contract + fake's own tests, run via the contract suite). AC-1/AC-10 ("adapter specs consume it") close when #753 lands; the contract suite makes #753's adoption drop-in.
+2. **Provisional contract** — ✅ acceptable for a dev-only fake; the bridge file header flags `#752` as authoritative, and the shared contract suite is the reconciliation anchor.
+3. **Contract ownership** — ✅ #754 owns `SubiektBridgeClient` (only way it stays independent of #753).
+4. **Fidelity / contract testing** — ✅ added `runSubiektBridgeContractTests` seam + a "Fidelity & contract verification" section assigning real-bridge verification to #752/#753 (Windows CI job).
+5. **Scope claim** — ✅ PR will state #754 enables adapter dev off-Windows, not full-flow.
+
+_No open flags. Ready for the `/pre-implement` gate._

--- a/libs/integrations/subiekt/jest.config.mjs
+++ b/libs/integrations/subiekt/jest.config.mjs
@@ -1,0 +1,35 @@
+export default {
+  testEnvironment: 'node',
+  rootDir: '.',
+
+  // IMPORTANT: avoid running fixtures/contract-suite helpers as "tests"
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+
+  // ESM + TS support for Node16 module resolution
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
+  },
+
+  // Helps when TS/Node16 emits/assumes .js in import paths
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@openlinker/integrations-subiekt$': '<rootDir>/src/index.ts',
+    '^@openlinker/integrations-subiekt/(.*)$': '<rootDir>/src/$1',
+    '^@openlinker/core/(.*)$': '<rootDir>/../../core/src/$1',
+    '^@openlinker/shared/(.*)$': '<rootDir>/../../shared/src/$1',
+    '^@openlinker/plugin-sdk$': '<rootDir>/../../plugin-sdk/src/index.ts',
+  },
+
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '<rootDir>/coverage',
+  clearMocks: true,
+  testTimeout: 30000,
+};

--- a/libs/integrations/subiekt/package.json
+++ b/libs/integrations/subiekt/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@openlinker/integrations-subiekt",
+  "version": "0.1.0",
+  "description": "Subiekt nexo (Sfera bridge) invoicing adapter for OpenLinker",
+  "license": "Apache-2.0",
+  "author": "OpenLinker",
+  "private": true,
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "require": "./dist/testing.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "jest --config ./jest.config.mjs",
+    "test:watch": "jest --watch --config ./jest.config.mjs",
+    "test:cov": "jest --coverage --config ./jest.config.mjs",
+    "lint": "eslint \"src/**/*.ts\" --fix",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@openlinker/core": "workspace:*",
+    "@openlinker/plugin-sdk": "workspace:*",
+    "@openlinker/shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^10.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "20.11.30",
+    "@typescript-eslint/eslint-plugin": "7.3.1",
+    "@typescript-eslint/parser": "7.3.1",
+    "eslint": "8.57.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.2",
+    "typescript": "5.4.3"
+  }
+}

--- a/libs/integrations/subiekt/src/bridge/subiekt-bridge.client.ts
+++ b/libs/integrations/subiekt/src/bridge/subiekt-bridge.client.ts
@@ -1,0 +1,31 @@
+/**
+ * Subiekt Bridge Client — contract
+ *
+ * The HTTP surface OpenLinker's Subiekt adapter (#753) calls against the local
+ * Windows bridge (#752). Interface only — the real HTTP implementation is #753;
+ * the in-memory double is `FakeSubiektBridgeAdapter` (#754, this package's
+ * `/testing` sub-barrel). Covers exactly the three endpoints the adapter needs:
+ * issue an invoice, upsert a customer, read a document's status.
+ *
+ * @module libs/integrations/subiekt/bridge
+ * @see {@link FakeSubiektBridgeAdapter} for the in-memory test double
+ */
+import type {
+  BridgeInvoiceStatusRequest,
+  BridgeInvoiceStatusResponse,
+  BridgeIssueInvoiceRequest,
+  BridgeIssueInvoiceResponse,
+  BridgeUpsertCustomerRequest,
+  BridgeUpsertCustomerResponse,
+} from './subiekt-bridge.types';
+
+export interface SubiektBridgeClient {
+  /** Issue a fiscal document. Rejects with `SubiektBridgeUnreachableError` / `SubiektRejectedError` on failure. */
+  issueInvoice(req: BridgeIssueInvoiceRequest): Promise<BridgeIssueInvoiceResponse>;
+
+  /** Create-or-update a customer (kontrahent) in Subiekt. */
+  upsertCustomer(req: BridgeUpsertCustomerRequest): Promise<BridgeUpsertCustomerResponse>;
+
+  /** Read the current state of a previously-issued document. */
+  getInvoiceStatus(req: BridgeInvoiceStatusRequest): Promise<BridgeInvoiceStatusResponse>;
+}

--- a/libs/integrations/subiekt/src/bridge/subiekt-bridge.errors.ts
+++ b/libs/integrations/subiekt/src/bridge/subiekt-bridge.errors.ts
@@ -1,0 +1,27 @@
+/**
+ * Subiekt Bridge — error types
+ *
+ * The two failure shapes the bridge client surfaces. Both the real HTTP client
+ * (#753) and the in-memory fake (#754) throw these, so adapter `.rejects`
+ * assertions are portable across implementations.
+ *
+ * @module libs/integrations/subiekt/bridge
+ */
+
+/** The bridge service could not be reached (network / service-down). */
+export class SubiektBridgeUnreachableError extends Error {
+  constructor(message = 'Subiekt bridge is unreachable') {
+    super(message);
+    this.name = 'SubiektBridgeUnreachableError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+/** The bridge reached Subiekt, but Subiekt rejected the request (e.g. invalid NIP). */
+export class SubiektRejectedError extends Error {
+  constructor(public readonly reason: string) {
+    super(`Subiekt rejected the request: ${reason}`);
+    this.name = 'SubiektRejectedError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/integrations/subiekt/src/bridge/subiekt-bridge.types.ts
+++ b/libs/integrations/subiekt/src/bridge/subiekt-bridge.types.ts
@@ -1,0 +1,99 @@
+/**
+ * Subiekt Bridge — wire types
+ *
+ * Request/response shapes for the OpenLinker Subiekt Bridge REST surface — the
+ * Windows .NET service that wraps InsERT's Sfera SDK (#728 §3.1). These are
+ * **bridge-native** (Subiekt/PL dialect: `nip`, KSeF regulatory states) — the
+ * neutral ⇄ bridge mapping lives in the real adapter (#753), NOT here. The
+ * authoritative REST contract is owned by the bridge bootstrap issue (#752);
+ * these shapes are the TS expression of it and may be reconciled when #752
+ * lands — the shared contract suite is where divergence surfaces.
+ *
+ * @module libs/integrations/subiekt/bridge
+ */
+
+/**
+ * KSeF-native regulatory status the bridge reports for a document. The neutral
+ * `RegulatoryStatus` (`@openlinker/core/invoicing`) is derived from this by the
+ * #753 adapter — it is not referenced here.
+ */
+export const BridgeRegulatoryStatusValues = [
+  'none',
+  'pending',
+  'sent',
+  'accepted',
+  'rejected',
+] as const;
+export type BridgeRegulatoryStatus = (typeof BridgeRegulatoryStatusValues)[number];
+
+/** Bridge-side issuance result state. */
+export const BridgeInvoiceStateValues = ['issued', 'failed'] as const;
+export type BridgeInvoiceState = (typeof BridgeInvoiceStateValues)[number];
+
+/** Postal address as the bridge expects it. */
+export interface BridgeAddress {
+  line1: string;
+  line2: string | null;
+  city: string;
+  postalCode: string;
+  countryCode: string;
+}
+
+/** Buyer (kontrahent) in the bridge's dialect — `nip` is provider-native here. */
+export interface BridgeBuyer {
+  name: string;
+  nip: string | null;
+  address: BridgeAddress;
+  isCompany: boolean;
+}
+
+/** One invoice line in the bridge request. */
+export interface BridgeLine {
+  name: string;
+  quantity: number;
+  unitPriceGross: number;
+  taxRate: string;
+}
+
+/**
+ * Issue-invoice request. `documentType` is a provider-native string (the bridge
+ * resolves it to a Subiekt document kind); #752 owns the well-known values.
+ */
+export interface BridgeIssueInvoiceRequest {
+  orderId: string;
+  idempotencyKey?: string;
+  documentType: string;
+  currency: string;
+  buyer: BridgeBuyer;
+  lines: BridgeLine[];
+}
+
+/** Issue-invoice response. */
+export interface BridgeIssueInvoiceResponse {
+  providerInvoiceId: string;
+  providerInvoiceNumber: string;
+  state: BridgeInvoiceState;
+  regulatoryStatus: BridgeRegulatoryStatus;
+  pdfUrl: string | null;
+}
+
+/** Customer (kontrahent) upsert request. */
+export interface BridgeUpsertCustomerRequest {
+  buyer: BridgeBuyer;
+}
+
+/** Customer upsert response — the provider's customer id. */
+export interface BridgeUpsertCustomerResponse {
+  providerCustomerId: string;
+}
+
+/** Status-read request, keyed by the provider's invoice id. */
+export interface BridgeInvoiceStatusRequest {
+  providerInvoiceId: string;
+}
+
+/** Status-read response. */
+export interface BridgeInvoiceStatusResponse {
+  state: BridgeInvoiceState;
+  regulatoryStatus: BridgeRegulatoryStatus;
+}

--- a/libs/integrations/subiekt/src/index.ts
+++ b/libs/integrations/subiekt/src/index.ts
@@ -1,0 +1,31 @@
+/**
+ * @openlinker/integrations-subiekt — public barrel
+ *
+ * The Subiekt bridge contract (#754): the wire types, error shapes, and the
+ * `SubiektBridgeClient` interface OpenLinker's Subiekt adapter (#753) codes
+ * against. The in-memory test double lives on the `/testing` sub-barrel.
+ *
+ * @module libs/integrations/subiekt
+ */
+export type { SubiektBridgeClient } from './bridge/subiekt-bridge.client';
+export {
+  SubiektBridgeUnreachableError,
+  SubiektRejectedError,
+} from './bridge/subiekt-bridge.errors';
+export {
+  BridgeRegulatoryStatusValues,
+  BridgeInvoiceStateValues,
+} from './bridge/subiekt-bridge.types';
+export type {
+  BridgeRegulatoryStatus,
+  BridgeInvoiceState,
+  BridgeAddress,
+  BridgeBuyer,
+  BridgeLine,
+  BridgeIssueInvoiceRequest,
+  BridgeIssueInvoiceResponse,
+  BridgeUpsertCustomerRequest,
+  BridgeUpsertCustomerResponse,
+  BridgeInvoiceStatusRequest,
+  BridgeInvoiceStatusResponse,
+} from './bridge/subiekt-bridge.types';

--- a/libs/integrations/subiekt/src/testing.ts
+++ b/libs/integrations/subiekt/src/testing.ts
@@ -1,0 +1,17 @@
+/**
+ * @openlinker/integrations-subiekt/testing — test-double sub-barrel
+ *
+ * Plugin-internal test doubles for the Subiekt bridge (#754), consumed only
+ * from `*.spec.ts`: the in-memory `FakeSubiektBridgeAdapter` and the shared
+ * `runSubiektBridgeContractTests` fidelity suite (reusable by #753's real
+ * client). Kept off the main barrel because these are test-only — importing
+ * them from runtime code would pull test logic into the bundle.
+ *
+ * @module libs/integrations/subiekt/testing
+ */
+export { FakeSubiektBridgeAdapter } from './testing/fake-subiekt-bridge.adapter';
+export {
+  runSubiektBridgeContractTests,
+  sampleBridgeBuyer,
+  sampleIssueInvoiceRequest,
+} from './testing/subiekt-bridge-contract.suite';

--- a/libs/integrations/subiekt/src/testing/__tests__/fake-subiekt-bridge.adapter.spec.ts
+++ b/libs/integrations/subiekt/src/testing/__tests__/fake-subiekt-bridge.adapter.spec.ts
@@ -29,21 +29,21 @@ describe('FakeSubiektBridgeAdapter', () => {
       fake = new FakeSubiektBridgeAdapter();
     });
 
-    it('numbers successive invoices deterministically', async () => {
+    it('should number successive invoices deterministically', async () => {
       const a = await fake.issueInvoice(sampleIssueInvoiceRequest());
       const b = await fake.issueInvoice(sampleIssueInvoiceRequest());
       expect(a.providerInvoiceNumber).toBe('FV-MOCK-001');
       expect(b.providerInvoiceNumber).toBe('FV-MOCK-002');
     });
 
-    it('rejects with SubiektBridgeUnreachableError when that failure is seeded', async () => {
+    it('should reject with SubiektBridgeUnreachableError when that failure is seeded', async () => {
       fake.seedFailure('bridge-unreachable');
       await expect(fake.issueInvoice(sampleIssueInvoiceRequest())).rejects.toBeInstanceOf(
         SubiektBridgeUnreachableError,
       );
     });
 
-    it('rejects with SubiektRejectedError carrying the reason when seeded', async () => {
+    it('should reject with SubiektRejectedError carrying the reason when seeded', async () => {
       fake.seedFailure('subiekt-rejected', { reason: 'invalid NIP' });
       await expect(fake.upsertCustomer({ buyer: sampleBridgeBuyer() })).rejects.toThrow(
         'invalid NIP',
@@ -53,19 +53,19 @@ describe('FakeSubiektBridgeAdapter', () => {
       );
     });
 
-    it('seed() overrides response fields (e.g. an accepted regulatory status)', async () => {
+    it('should override response fields when seed() is used (e.g. an accepted regulatory status)', async () => {
       fake.seed({ regulatoryStatus: 'accepted' });
       const res = await fake.issueInvoice(sampleIssueInvoiceRequest());
       expect(res.regulatoryStatus).toBe('accepted');
     });
 
-    it('returns a failed status for an unknown provider invoice id', async () => {
+    it('should return a failed status for an unknown provider invoice id', async () => {
       const status = await fake.getInvoiceStatus({ providerInvoiceId: 'does-not-exist' });
       expect(status.state).toBe('failed');
       expect(status.regulatoryStatus).toBe('none');
     });
 
-    it('clear() resets counters and seeded failure', async () => {
+    it('should reset counters and seeded failure on clear()', async () => {
       fake.seedFailure('bridge-unreachable');
       fake.seed({ regulatoryStatus: 'accepted' });
       await fake.issueInvoice(sampleIssueInvoiceRequest()).catch(() => undefined);

--- a/libs/integrations/subiekt/src/testing/__tests__/fake-subiekt-bridge.adapter.spec.ts
+++ b/libs/integrations/subiekt/src/testing/__tests__/fake-subiekt-bridge.adapter.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * FakeSubiektBridgeAdapter — unit tests
+ *
+ * Runs the shared contract suite against the fake, then asserts the
+ * fake-specific helpers (deterministic numbering, seeded failure modes,
+ * `seed`/`clear`).
+ *
+ * @module libs/integrations/subiekt/testing
+ */
+import {
+  SubiektBridgeUnreachableError,
+  SubiektRejectedError,
+} from '../../bridge/subiekt-bridge.errors';
+import { FakeSubiektBridgeAdapter } from '../fake-subiekt-bridge.adapter';
+import {
+  runSubiektBridgeContractTests,
+  sampleBridgeBuyer,
+  sampleIssueInvoiceRequest,
+} from '../subiekt-bridge-contract.suite';
+
+describe('FakeSubiektBridgeAdapter', () => {
+  // The behavioural contract every SubiektBridgeClient must satisfy.
+  runSubiektBridgeContractTests(() => new FakeSubiektBridgeAdapter());
+
+  describe('fake-specific behaviour', () => {
+    let fake: FakeSubiektBridgeAdapter;
+
+    beforeEach(() => {
+      fake = new FakeSubiektBridgeAdapter();
+    });
+
+    it('numbers successive invoices deterministically', async () => {
+      const a = await fake.issueInvoice(sampleIssueInvoiceRequest());
+      const b = await fake.issueInvoice(sampleIssueInvoiceRequest());
+      expect(a.providerInvoiceNumber).toBe('FV-MOCK-001');
+      expect(b.providerInvoiceNumber).toBe('FV-MOCK-002');
+    });
+
+    it('rejects with SubiektBridgeUnreachableError when that failure is seeded', async () => {
+      fake.seedFailure('bridge-unreachable');
+      await expect(fake.issueInvoice(sampleIssueInvoiceRequest())).rejects.toBeInstanceOf(
+        SubiektBridgeUnreachableError,
+      );
+    });
+
+    it('rejects with SubiektRejectedError carrying the reason when seeded', async () => {
+      fake.seedFailure('subiekt-rejected', { reason: 'invalid NIP' });
+      await expect(fake.upsertCustomer({ buyer: sampleBridgeBuyer() })).rejects.toThrow(
+        'invalid NIP',
+      );
+      await expect(fake.upsertCustomer({ buyer: sampleBridgeBuyer() })).rejects.toBeInstanceOf(
+        SubiektRejectedError,
+      );
+    });
+
+    it('seed() overrides response fields (e.g. an accepted regulatory status)', async () => {
+      fake.seed({ regulatoryStatus: 'accepted' });
+      const res = await fake.issueInvoice(sampleIssueInvoiceRequest());
+      expect(res.regulatoryStatus).toBe('accepted');
+    });
+
+    it('returns a failed status for an unknown provider invoice id', async () => {
+      const status = await fake.getInvoiceStatus({ providerInvoiceId: 'does-not-exist' });
+      expect(status.state).toBe('failed');
+      expect(status.regulatoryStatus).toBe('none');
+    });
+
+    it('clear() resets counters and seeded failure', async () => {
+      fake.seedFailure('bridge-unreachable');
+      fake.seed({ regulatoryStatus: 'accepted' });
+      await fake.issueInvoice(sampleIssueInvoiceRequest()).catch(() => undefined);
+      fake.clear();
+      const res = await fake.issueInvoice(sampleIssueInvoiceRequest());
+      expect(res.providerInvoiceNumber).toBe('FV-MOCK-001');
+      expect(res.regulatoryStatus).toBe('sent');
+    });
+  });
+});

--- a/libs/integrations/subiekt/src/testing/fake-subiekt-bridge.adapter.ts
+++ b/libs/integrations/subiekt/src/testing/fake-subiekt-bridge.adapter.ts
@@ -1,0 +1,121 @@
+/**
+ * Fake Subiekt Bridge Adapter (#754)
+ *
+ * In-memory double of `SubiektBridgeClient` — a **plugin-internal contract**,
+ * not a core `*.port.ts` (a deliberate, novel use of the `/testing` seam). It
+ * lets Mac/Linux contributors develop and unit-test the real Subiekt adapter
+ * (#753) without a Windows VM or a live Sfera bridge — Subiekt nexo is
+ * Windows-only and cannot be containerized, so the real dependency is
+ * categorically un-runnable here (the textbook case for an in-memory fake).
+ *
+ * Returns deterministic mock data (`FV-MOCK-001`, …, `regulatoryStatus: 'sent'`)
+ * and supports seeded failure modes + `seed`/`clear` helpers. Consumed only
+ * from `*.spec.ts` via `@openlinker/integrations-subiekt/testing`.
+ *
+ * Fidelity caveat: a fake can pass while the real bridge fails. The shared
+ * `runSubiektBridgeContractTests` suite is the seam that keeps both honest — it
+ * must also run against the real client (#753) on a Windows CI job (#752).
+ *
+ * @module libs/integrations/subiekt/testing
+ */
+import type { SubiektBridgeClient } from '../bridge/subiekt-bridge.client';
+import {
+  SubiektBridgeUnreachableError,
+  SubiektRejectedError,
+} from '../bridge/subiekt-bridge.errors';
+import type {
+  BridgeInvoiceStatusRequest,
+  BridgeInvoiceStatusResponse,
+  BridgeIssueInvoiceRequest,
+  BridgeIssueInvoiceResponse,
+  BridgeUpsertCustomerRequest,
+  BridgeUpsertCustomerResponse,
+} from '../bridge/subiekt-bridge.types';
+
+type SeededFailure =
+  | { kind: 'bridge-unreachable' }
+  | { kind: 'subiekt-rejected'; reason: string };
+
+export class FakeSubiektBridgeAdapter implements SubiektBridgeClient {
+  private issueCounter = 0;
+  private seededFailure: SeededFailure | null = null;
+  private issueOverride: Partial<BridgeIssueInvoiceResponse> | null = null;
+  private readonly issuedById = new Map<string, BridgeIssueInvoiceResponse>();
+
+  issueInvoice(_req: BridgeIssueInvoiceRequest): Promise<BridgeIssueInvoiceResponse> {
+    const failure = this.failureError();
+    if (failure) {
+      return Promise.reject(failure);
+    }
+    this.issueCounter += 1;
+    const response: BridgeIssueInvoiceResponse = {
+      providerInvoiceId: `SUB-MOCK-${this.issueCounter}`,
+      providerInvoiceNumber: `FV-MOCK-${String(this.issueCounter).padStart(3, '0')}`,
+      state: 'issued',
+      regulatoryStatus: 'sent',
+      pdfUrl: null,
+      ...this.issueOverride,
+    };
+    this.issuedById.set(response.providerInvoiceId, response);
+    return Promise.resolve(response);
+  }
+
+  upsertCustomer(_req: BridgeUpsertCustomerRequest): Promise<BridgeUpsertCustomerResponse> {
+    const failure = this.failureError();
+    if (failure) {
+      return Promise.reject(failure);
+    }
+    return Promise.resolve({ providerCustomerId: 'KH-MOCK-1' });
+  }
+
+  getInvoiceStatus(req: BridgeInvoiceStatusRequest): Promise<BridgeInvoiceStatusResponse> {
+    const failure = this.failureError();
+    if (failure) {
+      return Promise.reject(failure);
+    }
+    const known = this.issuedById.get(req.providerInvoiceId);
+    return Promise.resolve(
+      known
+        ? { state: known.state, regulatoryStatus: known.regulatoryStatus }
+        : { state: 'failed', regulatoryStatus: 'none' },
+    );
+  }
+
+  // --- test helpers -----------------------------------------------------------
+
+  /**
+   * Make every subsequent call reject with the corresponding typed error until
+   * `clear()`. `'bridge-unreachable'` → `SubiektBridgeUnreachableError`;
+   * `'subiekt-rejected'` → `SubiektRejectedError` carrying `opts.reason`.
+   */
+  seedFailure(kind: 'bridge-unreachable'): void;
+  seedFailure(kind: 'subiekt-rejected', opts: { reason: string }): void;
+  seedFailure(kind: SeededFailure['kind'], opts?: { reason: string }): void {
+    this.seededFailure =
+      kind === 'subiekt-rejected'
+        ? { kind, reason: opts?.reason ?? 'rejected' }
+        : { kind };
+  }
+
+  /** Override fields on the next (and subsequent) `issueInvoice` response until `clear()`. */
+  seed(issueResponse: Partial<BridgeIssueInvoiceResponse>): void {
+    this.issueOverride = issueResponse;
+  }
+
+  /** Reset all in-memory state between tests. */
+  clear(): void {
+    this.issueCounter = 0;
+    this.seededFailure = null;
+    this.issueOverride = null;
+    this.issuedById.clear();
+  }
+
+  private failureError(): Error | null {
+    if (!this.seededFailure) {
+      return null;
+    }
+    return this.seededFailure.kind === 'bridge-unreachable'
+      ? new SubiektBridgeUnreachableError()
+      : new SubiektRejectedError(this.seededFailure.reason);
+  }
+}

--- a/libs/integrations/subiekt/src/testing/subiekt-bridge-contract.suite.ts
+++ b/libs/integrations/subiekt/src/testing/subiekt-bridge-contract.suite.ts
@@ -65,7 +65,7 @@ export function runSubiektBridgeContractTests(makeClient: () => SubiektBridgeCli
       client = makeClient();
     });
 
-    it('issues a document with a provider id, number and a known regulatory status', async () => {
+    it('should issue a document with a provider id, number and a known regulatory status', async () => {
       const res = await client.issueInvoice(sampleIssueInvoiceRequest());
       expect(res.providerInvoiceId).toBeTruthy();
       expect(res.providerInvoiceNumber).toBeTruthy();
@@ -73,12 +73,12 @@ export function runSubiektBridgeContractTests(makeClient: () => SubiektBridgeCli
       expect(BridgeRegulatoryStatusValues).toContain(res.regulatoryStatus);
     });
 
-    it('upserts a customer and returns a provider customer id', async () => {
+    it('should upsert a customer and return a provider customer id', async () => {
       const res = await client.upsertCustomer({ buyer: sampleBridgeBuyer() });
       expect(res.providerCustomerId).toBeTruthy();
     });
 
-    it('reads back the state of a just-issued document', async () => {
+    it('should read back the state of a just-issued document', async () => {
       const issued = await client.issueInvoice(sampleIssueInvoiceRequest());
       const status = await client.getInvoiceStatus({
         providerInvoiceId: issued.providerInvoiceId,

--- a/libs/integrations/subiekt/src/testing/subiekt-bridge-contract.suite.ts
+++ b/libs/integrations/subiekt/src/testing/subiekt-bridge-contract.suite.ts
@@ -1,0 +1,93 @@
+/**
+ * Subiekt Bridge — shared contract suite (fidelity seam)
+ *
+ * The happy-path behavioural contract every `SubiektBridgeClient` must satisfy.
+ * Run it against the in-memory fake here, and — when they exist — against the
+ * real HTTP client (#753) on a Windows CI job wired to a live bridge (#752).
+ * One suite, two backends: if the fake and the real bridge ever disagree, the
+ * suite goes red. This is the mitigation for the fake's fidelity-drift risk
+ * (SWE@Google Ch. 13); failure-mode behaviour is fake-specific (driven by the
+ * fake's `seedFailure` helper) and lives in the fake's own spec, not here.
+ *
+ * Uses ambient Jest globals (`describe`/`it`/`expect`) — call it from inside a
+ * spec file.
+ *
+ * @module libs/integrations/subiekt/testing
+ */
+import type { SubiektBridgeClient } from '../bridge/subiekt-bridge.client';
+import { BridgeRegulatoryStatusValues } from '../bridge/subiekt-bridge.types';
+import type {
+  BridgeBuyer,
+  BridgeIssueInvoiceRequest,
+} from '../bridge/subiekt-bridge.types';
+
+/** A representative bridge buyer for contract / adapter tests. */
+export function sampleBridgeBuyer(overrides: Partial<BridgeBuyer> = {}): BridgeBuyer {
+  return {
+    name: 'Przykład Sp. z o.o.',
+    nip: '1234567890',
+    isCompany: true,
+    address: {
+      line1: 'ul. Przykładowa 1',
+      line2: null,
+      city: 'Warszawa',
+      postalCode: '00-001',
+      countryCode: 'PL',
+    },
+    ...overrides,
+  };
+}
+
+/** A representative issue-invoice request for contract / adapter tests. */
+export function sampleIssueInvoiceRequest(
+  overrides: Partial<BridgeIssueInvoiceRequest> = {},
+): BridgeIssueInvoiceRequest {
+  return {
+    orderId: 'ol_order_sample',
+    idempotencyKey: 'idem-sample',
+    documentType: 'invoice',
+    currency: 'PLN',
+    buyer: sampleBridgeBuyer(),
+    lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123.0, taxRate: '23' }],
+    ...overrides,
+  };
+}
+
+/**
+ * Register the shared contract tests against a `SubiektBridgeClient` factory.
+ * `makeClient` is called once per test so each case starts from a fresh client.
+ */
+export function runSubiektBridgeContractTests(makeClient: () => SubiektBridgeClient): void {
+  describe('SubiektBridgeClient contract', () => {
+    let client: SubiektBridgeClient;
+
+    beforeEach(() => {
+      client = makeClient();
+    });
+
+    it('issues a document with a provider id, number and a known regulatory status', async () => {
+      const res = await client.issueInvoice(sampleIssueInvoiceRequest());
+      expect(res.providerInvoiceId).toBeTruthy();
+      expect(res.providerInvoiceNumber).toBeTruthy();
+      expect(res.state).toBe('issued');
+      expect(BridgeRegulatoryStatusValues).toContain(res.regulatoryStatus);
+    });
+
+    it('upserts a customer and returns a provider customer id', async () => {
+      const res = await client.upsertCustomer({ buyer: sampleBridgeBuyer() });
+      expect(res.providerCustomerId).toBeTruthy();
+    });
+
+    it('reads back the state of a just-issued document', async () => {
+      const issued = await client.issueInvoice(sampleIssueInvoiceRequest());
+      const status = await client.getInvoiceStatus({
+        providerInvoiceId: issued.providerInvoiceId,
+      });
+      // `regulatoryStatus` may legitimately advance on a real bridge (KSeF is
+      // async), so assert membership rather than equality — but the document is
+      // still `issued`.
+      expect(status.state).toBe('issued');
+      expect(BridgeRegulatoryStatusValues).toContain(status.regulatoryStatus);
+    });
+  });
+}

--- a/libs/integrations/subiekt/tsconfig.json
+++ b/libs/integrations/subiekt/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    { "path": "../../core" },
+    { "path": "../../shared" },
+    { "path": "../../plugin-sdk" }
+  ]
+}

--- a/libs/integrations/subiekt/tsconfig.spec.json
+++ b/libs/integrations/subiekt/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/__tests__/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,6 +783,46 @@ importers:
         specifier: 5.4.3
         version: 5.4.3
 
+  libs/integrations/subiekt:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^10.0.0
+        version: 10.3.0(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.1)(rxjs@7.8.1)
+      '@openlinker/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@openlinker/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../plugin-sdk
+      '@openlinker/shared':
+        specifier: workspace:*
+        version: link:../../shared
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.12
+        version: 29.5.12
+      '@types/node':
+        specifier: 20.11.30
+        version: 20.11.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: 7.3.1
+        version: 7.3.1(@typescript-eslint/parser@7.3.1(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/parser':
+        specifier: 7.3.1
+        version: 7.3.1(eslint@8.57.0)(typescript@5.4.3)
+      eslint:
+        specifier: 8.57.0
+        version: 8.57.0
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@20.11.30)(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3))
+      ts-jest:
+        specifier: 29.1.2
+        version: 29.1.2(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@20.11.30)(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3)))(typescript@5.4.3)
+      typescript:
+        specifier: 5.4.3
+        version: 5.4.3
+
   libs/integrations/woocommerce:
     dependencies:
       '@nestjs/common':

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -45,6 +45,8 @@
       "@openlinker/integrations-woocommerce/*": ["libs/integrations/woocommerce/src/*"],
       "@openlinker/integrations-erli": ["libs/integrations/erli/src/index.ts"],
       "@openlinker/integrations-erli/*": ["libs/integrations/erli/src/*"],
+      "@openlinker/integrations-subiekt": ["libs/integrations/subiekt/src/index.ts"],
+      "@openlinker/integrations-subiekt/*": ["libs/integrations/subiekt/src/*"],
       "@openlinker/plugin-sdk": ["libs/plugin-sdk/src/index.ts"],
       "@openlinker/plugin-sdk/*": ["libs/plugin-sdk/src/*"],
       "@openlinker/test-kit": ["libs/test-kit/src/index.ts"],


### PR DESCRIPTION
## What & why

Subiekt nexo is **Windows-only** (InsERT Sfera SDK) and cannot be containerized, so Mac/Linux contributors cannot run the real invoicing bridge locally. This adds the new `@openlinker/integrations-subiekt` package so the real Subiekt adapter (#753) can be developed and unit-tested anywhere, against an in-memory double.

This is the **test-double + contract** slice of the invoicing vertical. No core port, no NestJS wiring, no DI changes — the real HTTP client and its NestModule land in #753; the authoritative REST contract is owned by the bridge bootstrap issue #752.

## What's in it

- **`SubiektBridgeClient`** — the plugin-internal client contract the Subiekt adapter codes against: bridge-native wire types (`nip`, KSeF `BridgeRegulatoryStatus`, …), two typed error shapes (`SubiektBridgeUnreachableError`, `SubiektRejectedError`), and the three-method interface (`issueInvoice` / `upsertCustomer` / `getInvoiceStatus`). #754 provisionally owns this contract as the first issue to need it; the types are flagged for reconciliation when #752 lands.
- **`FakeSubiektBridgeAdapter`** (on the `/testing` sub-barrel) — in-memory double with deterministic output (`SUB-MOCK-*` / `FV-MOCK-001` / `regulatoryStatus: 'sent'`) plus `seedFailure` / `seed` / `clear` helpers. Consumed only from `*.spec.ts`, never runtime code.
- **`runSubiektBridgeContractTests`** — a shared happy-path contract suite (the **fidelity seam**, per SWE@Google Ch.13): run here against the fake, and against #753's real client on a Windows CI job. If the fake and the real bridge ever diverge, the suite goes red. Failure-mode behaviour stays fake-specific.

## Boundary notes

- The fake doubles a **plugin-internal client contract**, not a core `*.port.ts` — a deliberate use of the `/testing` seam (the documented mocking convention can't apply to a categorically un-runnable Windows dependency).
- Mirrors the existing `inpost` / `dpd-polska` `/testing` fake packages (file naming, package `exports`, jest config, `tsconfig.base.json` paths).
- `@nestjs/common` is kept as a peerDep (inert today) because #753 adds the NestModule to this same package — matching the `erli` skeleton convention.

## Testing

- 9/9 package unit tests (`pnpm --filter @openlinker/integrations-subiekt test`).
- Quality gate green: monorepo `type-check`, `lint` (0 errors), `build`, and all `check:invariants` (`check-libs-build-scripts` now 12 packages, `check-create-adapter` OK). Full `pnpm test` had only the known, unrelated `apps/web` `failed-orders-page` flake (passes 8/8 in isolation).

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)