### PR TITLE
chore(DX/infra): enhance CI workflow with concurrency control and remove redundant build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main, develop]
 
+# Cancel superseded runs on the same ref so a dead, replaced run doesn't keep
+# holding scarce self-hosted slots and block the queue. Pushes to main rarely
+# overlap; if a never-cancel-on-main policy is later wanted, gate with
+# `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -80,8 +88,9 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Build libs (workspace glob — auto-discovers new packages)
-        run: pnpm -r --filter "./libs/**" build
+      # No explicit libs build: `pnpm test:ci` already runs
+      # `pnpm -r --filter "./libs/**" build` before the tests, so a separate
+      # step here builds libs twice in this one job.
       - name: Run tests
         run: pnpm test:ci
 


### PR DESCRIPTION
<!--
Thank you for contributing to OpenLinker!

Title: use Conventional Commits format — `feat(scope): subject`,
`fix(scope): subject`, `docs:`, `refactor:`, `test:`, `chore:`.
See CONTRIBUTING.md → Commits for the full type list.
-->

## Summary

- Added concurrency settings to cancel superseded runs on the same ref, optimizing resource usage.
- Removed redundant build step for libraries as it is already handled in the test command, preventing unnecessary duplication in the CI process.


## Related issues

<!-- One `Closes #N` per issue this PR resolves. Issues are closed
     automatically when the PR merges — do not close them manually. -->

Closes #1091 

## Test plan

- a noticeable improvement in pipeline performance

---

<sub>By submitting this pull request, I confirm that my contributions
are made under the terms of the [Apache License 2.0](../LICENSE), and I
certify the [Developer Certificate of Origin](https://developercertificate.org/)
by signing off my commits.</sub>
