### PR TITLE
fix(shipping): DPD demo enablement — sandbox host, postal-code, auth 502, retry reuse

### DIFF
--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -31,6 +31,7 @@ import {
   ShipmentCancellationNotSupportedException,
   ShipmentNotCancellableException,
   ShipmentNotFoundException,
+  ShippingProviderAuthException,
   ShippingProviderRejectionException,
   UndispatchableResolutionException,
   OrderNotDispatchablePaymentStatusException,
@@ -297,6 +298,19 @@ describe('ShipmentController', () => {
     it('should map ShippingProviderRejectionException to 502', async () => {
       dispatch.dispatch.mockRejectedValue(
         new ShippingProviderRejectionException('inpost', 'PARCEL_TOO_LARGE', 'parcel exceeds size'),
+      );
+      await expect(controller.generateLabel(makeGenerateLabelDto())).rejects.toBeInstanceOf(
+        BadGatewayException,
+      );
+    });
+
+    it('should map a ShippingProviderAuthException (carrier 401/403) to 502, not the 500 "Unclassified" path', async () => {
+      // Regression: a carrier rejecting OUR credentials previously fell through
+      // to 500 + an "Unclassified shipping-command error" log (it was a
+      // plugin-private exception the controller couldn't see). It now maps to a
+      // deliberate 502.
+      dispatch.dispatch.mockRejectedValue(
+        new ShippingProviderAuthException('dpd', 'DPDServices … failed (401)'),
       );
       await expect(controller.generateLabel(makeGenerateLabelDto())).rejects.toBeInstanceOf(
         BadGatewayException,

--- a/apps/api/src/shipping/http/shipment.controller.ts
+++ b/apps/api/src/shipping/http/shipment.controller.ts
@@ -62,6 +62,7 @@ import {
   ShipmentCancellationNotSupportedException,
   ShipmentNotCancellableException,
   ShipmentNotFoundException,
+  ShippingProviderAuthException,
   ShippingProviderRejectionException,
   UndispatchableResolutionException,
   OrderNotDispatchablePaymentStatusException,
@@ -399,6 +400,15 @@ export class ShipmentController {
       error instanceof DispatchProtocolNotSupportedException
     ) {
       return new UnprocessableEntityException(error.message);
+    }
+    if (error instanceof ShippingProviderAuthException) {
+      // The carrier rejected OUR stored credentials (401/403) — an upstream
+      // configuration problem, not an OL fault. Map to 502 (same family as a
+      // provider rejection) and explicitly NOT the "Unclassified" 500 path, so
+      // operators see "carrier rejected us" rather than "OpenLinker crashed".
+      // Flipping the connection to `needs_reauth` via the #819 auth-failure
+      // classifier registry is a tracked follow-up.
+      return new BadGatewayException(error.message);
     }
     if (error instanceof ShippingProviderRejectionException) {
       return new BadGatewayException(error.message);

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -379,6 +379,58 @@ describe('ShipmentDispatchService', () => {
       expect(adapter.generateLabel).not.toHaveBeenCalled();
     });
 
+    it('should reuse a failed branch-one shipment on retry instead of inserting a duplicate', async () => {
+      // Regression: a prior dispatch that failed before minting a waybill leaves
+      // a terminal `(order, connection)` row with providerShipmentId = NULL. The
+      // partial-unique index forbids a second such row, so the retry must reset
+      // and reuse it rather than `create()` a duplicate (which threw
+      // UQ_shipments_branch_one_per_order_conn and wedged every retry).
+      routing.resolve.mockResolvedValue(
+        resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier, processorConnectionId: INPOST }),
+      );
+      repository.findActiveByOrderId.mockResolvedValue(null);
+      const failed = makeShipment({
+        id: 'ol_shipment_prior',
+        status: 'failed',
+        failedAt: new Date(),
+        errorMessage: 'previous 401',
+      });
+      repository.findBranchOneByOrderAndConnection.mockResolvedValue(failed);
+      const reset = makeShipment({ id: 'ol_shipment_prior', status: 'draft' });
+      const generated = makeShipment({
+        id: 'ol_shipment_prior',
+        status: 'generated',
+        providerShipmentId: 'dpd-1',
+      });
+      repository.update.mockResolvedValueOnce(reset).mockResolvedValueOnce(generated);
+      adapter.generateLabel.mockResolvedValue({
+        providerShipmentId: 'dpd-1',
+        trackingNumber: 'dpd-1',
+        labelPdfRef: 'dpd:label:1',
+      });
+
+      const result = await service.dispatch(makeInput({ deliveryIntent: 'address' }));
+
+      // No duplicate INSERT — the prior row is recycled.
+      expect(repository.create).not.toHaveBeenCalled();
+      // First update resets the failed row back to a clean draft for this attempt.
+      expect(repository.update).toHaveBeenNthCalledWith(
+        1,
+        'ol_shipment_prior',
+        expect.objectContaining({
+          status: 'draft',
+          shippingMethod: 'kurier',
+          failedAt: null,
+          errorMessage: null,
+        }),
+      );
+      // The label is generated against the reused shipment id.
+      expect(adapter.generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ shipmentId: 'ol_shipment_prior' }),
+      );
+      expect(result).toEqual({ kind: 'dispatched', shipment: generated });
+    });
+
     it('should persist failed and rethrow when generateLabel rejects', async () => {
       routing.resolve.mockResolvedValue(resolution());
       repository.findActiveByOrderId.mockResolvedValue(null);

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
@@ -201,14 +201,37 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
       );
     }
 
-    const shipment = await this.shipments.create({
-      orderId: input.orderId,
-      connectionId: processorConnectionId,
-      shippingMethod,
-      deliveryIntent: intent,
-      paczkomatId: input.paczkomatId,
-      sourceDeliveryMethodId: input.sourceDeliveryMethodId ?? undefined,
-    });
+    // A prior dispatch that failed BEFORE a waybill was minted leaves a
+    // terminal `(orderId, connectionId)` row with `providerShipmentId = NULL`.
+    // The partial-unique `UQ_shipments_branch_one_per_order_conn` index forbids
+    // inserting a second waybill-less row, so a plain `create()` would throw a
+    // duplicate-key error and wedge every retry (the `findActiveByOrderId` guard
+    // above is status-based and waves terminal `failed` rows through). Reset and
+    // reuse that row instead — the active guard already returned for any
+    // still-in-flight attempt, so anything found here is terminal and safe to
+    // recycle for this fresh attempt.
+    const priorBranchOne = await this.shipments.findBranchOneByOrderAndConnection(
+      input.orderId,
+      processorConnectionId,
+    );
+    const shipment = priorBranchOne
+      ? await this.shipments.update(priorBranchOne.id, {
+          status: SHIPMENT_STATUS.Draft,
+          shippingMethod,
+          deliveryIntent: intent,
+          paczkomatId: input.paczkomatId ?? null,
+          sourceDeliveryMethodId: input.sourceDeliveryMethodId ?? null,
+          failedAt: null,
+          errorMessage: null,
+        })
+      : await this.shipments.create({
+          orderId: input.orderId,
+          connectionId: processorConnectionId,
+          shippingMethod,
+          deliveryIntent: intent,
+          paczkomatId: input.paczkomatId,
+          sourceDeliveryMethodId: input.sourceDeliveryMethodId ?? undefined,
+        });
 
     // NOTE: if generateLabel commits provider-side but its response fails, the
     // shipment is marked `failed` (catch below) and a later re-dispatch starts a

--- a/libs/core/src/shipping/domain/exceptions/shipping-provider-auth.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/shipping-provider-auth.exception.ts
@@ -1,0 +1,29 @@
+/**
+ * Shipping Provider Auth Exception
+ *
+ * Neutral, cross-boundary seam for a shipping carrier rejecting OUR
+ * credentials (HTTP 401 / 403) — a bad/expired key, wrong account, or
+ * insufficient permission. Sibling of {@link ShippingProviderRejectionException}:
+ * a credential failure is distinct from a command rejection, so the HTTP
+ * controller can map it deliberately (502 Bad Gateway) instead of letting it
+ * fall through to a misleading 500 "Unclassified" error.
+ *
+ * **Closed-core, open-runtime** (matches #576 / #580 / #769): no per-plugin
+ * subclass is required, but plugin-private exceptions (e.g.
+ * `DpdUnauthorizedException`, `InpostUnauthorizedException`) MAY extend this so
+ * the core controller can classify them via `instanceof` without importing the
+ * plugin type (which would violate the CORE ↔ Integration boundary).
+ *
+ * @module libs/core/src/shipping/domain/exceptions
+ */
+export class ShippingProviderAuthException extends Error {
+  constructor(
+    public readonly providerName: string,
+    message: string,
+    public readonly connectionId?: string,
+  ) {
+    super(message);
+    this.name = 'ShippingProviderAuthException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/shipping/domain/types/shipment.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment.types.ts
@@ -64,12 +64,22 @@ export interface CreateShipmentInput {
 
 /**
  * Partial-update patch. Every field is optional — only the fields present
- * on the patch are written. Pass an explicit `null` for `errorMessage` to
- * clear a previously-recorded error (e.g. on a successful retry from
- * `failed` back to `draft`).
+ * on the patch are written. Pass an explicit `null` for `errorMessage` /
+ * `failedAt` to clear a previously-recorded failure (e.g. when a failed
+ * branch-1 attempt is reset back to `draft` for re-dispatch, #<retry-reuse>).
+ *
+ * The dispatch-shape fields (`shippingMethod` / `deliveryIntent` /
+ * `paczkomatId` / `sourceDeliveryMethodId`) are writable so a re-dispatch can
+ * reuse the existing branch-1 row instead of inserting a duplicate (which the
+ * partial-unique `UQ_shipments_branch_one_per_order_conn` index forbids) while
+ * still reflecting the current attempt's parameters.
  */
 export interface UpdateShipmentInput {
   status?: ShipmentStatus;
+  shippingMethod?: ShippingMethod;
+  deliveryIntent?: DeliveryIntent | null;
+  paczkomatId?: string | null;
+  sourceDeliveryMethodId?: string | null;
   providerShipmentId?: string;
   trackingNumber?: string;
   /**
@@ -84,6 +94,6 @@ export interface UpdateShipmentInput {
   dispatchedAt?: Date;
   deliveredAt?: Date;
   cancelledAt?: Date;
-  failedAt?: Date;
+  failedAt?: Date | null;
   errorMessage?: string | null;
 }

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -113,6 +113,7 @@ export { ShipmentNotCancellableException } from './domain/exceptions/shipment-no
 export { ShipmentCancellationNotSupportedException } from './domain/exceptions/shipment-cancellation-not-supported.exception';
 export { PickupPointFinderNotSupportedException } from './domain/exceptions/pickup-point-finder-not-supported.exception';
 export { ShippingProviderRejectionException } from './domain/exceptions/shipping-provider-rejection.exception';
+export { ShippingProviderAuthException } from './domain/exceptions/shipping-provider-auth.exception';
 export { LabelDocumentNotSupportedException } from './domain/exceptions/label-document-not-supported.exception';
 export { LabelNotAvailableException } from './domain/exceptions/label-not-available.exception';
 export { DispatchProtocolNotSupportedException } from './domain/exceptions/dispatch-protocol-not-supported.exception';

--- a/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts
+++ b/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts
@@ -187,6 +187,12 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
   private buildUpdatePayload(patch: UpdateShipmentInput): Partial<ShipmentOrmEntity> {
     const payload: Partial<ShipmentOrmEntity> = {};
     if (patch.status !== undefined) payload.status = patch.status;
+    if (patch.shippingMethod !== undefined) payload.shippingMethod = patch.shippingMethod;
+    if (patch.deliveryIntent !== undefined) payload.deliveryIntent = patch.deliveryIntent;
+    if (patch.paczkomatId !== undefined) payload.paczkomatId = patch.paczkomatId;
+    if (patch.sourceDeliveryMethodId !== undefined) {
+      payload.sourceDeliveryMethodId = patch.sourceDeliveryMethodId;
+    }
     if (patch.providerShipmentId !== undefined) {
       payload.providerShipmentId = patch.providerShipmentId;
     }

--- a/libs/integrations/dpd-polska/src/application/dpd-adapter.factory.ts
+++ b/libs/integrations/dpd-polska/src/application/dpd-adapter.factory.ts
@@ -21,11 +21,13 @@ import { DpdShippingAdapter } from '../infrastructure/adapters/dpd-shipping.adap
 import { DpdHttpClient } from '../infrastructure/http/dpd-http-client';
 import { DpdInfoSoapClient } from '../infrastructure/http/dpd-info-soap-client';
 
-// OQ-3 (#962): test is credentials-gated, not host-gated — both environments
-// resolve to the same DPDServices host today. Split here if a sandbox host
-// surfaces; nothing else changes.
+// OQ-3 (#962) RESOLVED: the DPDServices test environment is host-gated, not
+// credentials-gated. The demo account (login `test`, FID 1495) authenticates
+// only against the `…demo…` host — confirmed from the DPD-supplied DEMO Postman
+// environment (`DPD_SERVICES_REST_WSDL = https://dpdservicesdemo.dpd.com.pl/public`)
+// and a live auth probe. Sending demo creds to the production host returns 401.
 const BASE_URLS: Readonly<Record<DpdEnvironment, string>> = {
-  sandbox: 'https://dpdservices.dpd.com.pl',
+  sandbox: 'https://dpdservicesdemo.dpd.com.pl',
   production: 'https://dpdservices.dpd.com.pl',
 };
 

--- a/libs/integrations/dpd-polska/src/domain/exceptions/dpd-unauthorized.exception.ts
+++ b/libs/integrations/dpd-polska/src/domain/exceptions/dpd-unauthorized.exception.ts
@@ -4,14 +4,18 @@
  * Thrown when DPDServices rejects the request with `401` (bad Basic-auth
  * pair / `MISSING_PERMISSION`) or `403`. Not retryable.
  *
+ * Extends the neutral core `ShippingProviderAuthException` so the HTTP
+ * controller classifies it (→ 502) via `instanceof` without importing this
+ * plugin-private type (CORE ↔ Integration boundary). Importing a core exception
+ * here follows the existing `ShippingProviderRejectionException` precedent.
+ *
  * @module libs/integrations/dpd-polska/src/domain/exceptions
  */
-export class DpdUnauthorizedException extends Error {
-  constructor(
-    message: string,
-    public readonly connectionId?: string,
-  ) {
-    super(message);
+import { ShippingProviderAuthException } from '@openlinker/core/shipping';
+
+export class DpdUnauthorizedException extends ShippingProviderAuthException {
+  constructor(message: string, connectionId?: string) {
+    super('dpd', message, connectionId);
     this.name = 'DpdUnauthorizedException';
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, DpdUnauthorizedException);

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
@@ -103,9 +103,20 @@ describe('buildCreatePackagesRequest', () => {
       name: 'Jan Kowalski', // firstName + lastName
       address: 'Krakowska 12', // street + buildingNumber
       city: 'Poznań',
-      postalCode: '60-001',
+      postalCode: '60001', // NN-NNN → bare digits (DPD rejects the hyphenated form)
       countryCode: 'PL',
     });
+  });
+
+  it('should strip the hyphen from sender + receiver postal codes (DPD wants bare NNNNN)', () => {
+    // DPD returns INCORRECT_*_POSTAL_CODE (opaque NOT_PROCESSED) for the Polish
+    // NN-NNN display form; confirmed against the demo (`01-612` rejected,
+    // `01612` accepted).
+    const req = buildCreatePackagesRequest(makeCmd(), makeConfig());
+    const pkg = req.packages[0];
+
+    expect(pkg.sender.postalCode).toBe('00001'); // config '00-001'
+    expect(pkg.receiver?.postalCode).toBe('60001'); // order '60-001'
   });
 
   it('should prefer recipient.name over first/last when present', () => {

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
@@ -311,6 +311,18 @@ function toPickupPointAddress(point: DpdPoint): PickupPointAddress {
   };
 }
 
+/**
+ * DPD Polska's `postalCode` field expects bare digits (`NNNNN`), not the Polish
+ * `NN-NNN` display form OpenLinker carries — sending the hyphenated form is
+ * rejected as `INCORRECT_SENDER_POSTAL_CODE` / `INCORRECT_RECEIVER_POSTAL_CODE`
+ * (surfaced opaquely as a top-level `NOT_PROCESSED` status). Strip every
+ * non-digit; an already-bare code passes through unchanged. Confirmed against
+ * the DPDServices demo (`01-612` rejected, `01612` accepted).
+ */
+function toDpdPostalCode(postalCode: string): string {
+  return postalCode.replace(/\D/g, '');
+}
+
 function toSenderPeer(sender: DpdSenderContact): DpdSenderOrReceiver {
   return {
     company: sender.company,
@@ -318,7 +330,7 @@ function toSenderPeer(sender: DpdSenderContact): DpdSenderOrReceiver {
     address: sender.address,
     city: sender.city,
     countryCode: sender.countryCode,
-    postalCode: sender.postalCode,
+    postalCode: toDpdPostalCode(sender.postalCode),
     phone: sender.phone,
     email: sender.email,
   };
@@ -337,7 +349,7 @@ function toReceiverPeer(recipient: ShipmentRecipient, address: ShipmentAddress):
     address: `${address.street} ${address.buildingNumber}`.trim(),
     city: address.city,
     countryCode: address.countryCode,
-    postalCode: address.postCode,
+    postalCode: toDpdPostalCode(address.postCode),
     phone: recipient.phone,
     email: recipient.email,
   };

--- a/libs/integrations/inpost/src/domain/exceptions/inpost-unauthorized.exception.ts
+++ b/libs/integrations/inpost/src/domain/exceptions/inpost-unauthorized.exception.ts
@@ -5,14 +5,17 @@
  * `403 access_forbidden` — a bad/expired API token or insufficient token
  * permissions. Not retryable.
  *
+ * Extends the neutral core `ShippingProviderAuthException` so the HTTP
+ * controller classifies it (→ 502) via `instanceof` without importing this
+ * plugin-private type (CORE ↔ Integration boundary).
+ *
  * @module libs/integrations/inpost/src/domain/exceptions
  */
-export class InpostUnauthorizedException extends Error {
-  constructor(
-    message: string,
-    public readonly connectionId?: string,
-  ) {
-    super(message);
+import { ShippingProviderAuthException } from '@openlinker/core/shipping';
+
+export class InpostUnauthorizedException extends ShippingProviderAuthException {
+  constructor(message: string, connectionId?: string) {
+    super('inpost', message, connectionId);
     this.name = 'InpostUnauthorizedException';
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InpostUnauthorizedException);


### PR DESCRIPTION
## What & why

Four related shipping-dispatch fixes surfaced while bringing the **DPD demo environment up end-to-end**. Verified against the live DPDServices demo API: `generatePackagesNumbers` now mints a real waybill (`0000871223003Q`) where every attempt previously failed.

### 1. DPD sandbox base URL (resolves DPD OQ-3, #962)
`environment: sandbox` resolved to the **production** DPDServices host, so demo credentials always 401'd. The DPD-supplied DEMO Postman environment + a live auth probe confirm the test host is `https://dpdservicesdemo.dpd.com.pl`. Sandbox now points there; production unchanged.

### 2. Postal-code normalization
DPD Polska's `postalCode` wants bare `NNNNN`, not the Polish `NN-NNN` form OL carries — the hyphenated value is rejected as `INCORRECT_{SENDER,RECEIVER}_POSTAL_CODE`, surfaced opaquely as a top-level `NOT_PROCESSED` (no waybill). The shipment mapper now strips non-digits from sender + receiver postal codes. Confirmed against demo: `01-612` rejected, `01612` accepted.

### 3. Provider-auth failure → 502, not 500 (Closes #1100)
A carrier rejecting our credentials (401/403) threw a plugin-private exception the controller couldn't see, so it fell through to 500 + an "Unclassified shipping-command error" log. Added neutral core `ShippingProviderAuthException`; `DpdUnauthorizedException` / `InpostUnauthorizedException` extend it; `toHttpException` maps it to 502.

### 4. Failed pre-waybill dispatch no longer wedges retry (Closes #1101)
A dispatch failing before a waybill left a terminal `(order, connection)` row with `providerShipmentId NULL`; the partial-unique `UQ_shipments_branch_one_per_order_conn` index then rejected the next dispatch (the status-based `findActiveByOrderId` guard waved the failed row through). Dispatch now reuses + resets the prior branch-one row instead of inserting a duplicate; `UpdateShipmentInput` widened with the dispatch-shape fields.

## Testing

- Unit tests added: auth → 502 mapping (controller), fail-then-retry reuse (dispatch), postal-code stripping (mapper).
- Full gate green on the branch: `type-check`, `lint` + invariants, affected suites (dispatch 33, controller 45, DPD 60, InPost 11).
- Manually verified end-to-end against the DPDServices demo (waybill minted).

## Follow-ups (not in this PR)
- #1100 deferred AC: flip the connection to `needs_reauth` via the #819 auth-failure classifier registry.
- #1101 deferred AC: integration test against the real unique constraint.
- Carry DPD `validationInfo` detail into `ShippingProviderRejectionException.providerDetails` so a future `NOT_PROCESSED` shows the field-level reason without a debug probe.

Closes #1100
Closes #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)