### PR TITLE
feat(shipping): needs_reauth classifiers + DPD validationInfo detail + retry int-spec

### DIFF
--- a/apps/api/test/integration/shipment-dispatch-retry.int-spec.ts
+++ b/apps/api/test/integration/shipment-dispatch-retry.int-spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Shipment Dispatch Retry Integration Test (#1101)
+ *
+ * Regression guard for the failed-pre-waybill retry wedge: a dispatch that
+ * fails before a waybill is minted leaves a terminal `(orderId, connectionId)`
+ * row with `providerShipmentId = NULL`. The partial-unique
+ * `UQ_shipments_branch_one_per_order_conn` index forbids a second waybill-less
+ * row, so a naive retry `create()` would raise a duplicate-key error and wedge
+ * every retry. `ShipmentDispatchService` reuses + resets that branch-one row
+ * instead — this spec exercises that against the REAL Postgres constraint
+ * (a mocked repository can't reproduce the index violation).
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import {
+  IShipmentDispatchService,
+  ShipmentDispatchInput,
+  ShippingProviderRejectionException,
+  SHIPMENT_DISPATCH_SERVICE_TOKEN,
+} from '@openlinker/core/shipping';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+import {
+  INPOST_TEST_ADAPTER_KEY,
+  InpostTestShippingStubHandle,
+  installInpostTestShippingStub,
+} from './helpers/inpost-test-shipping-stub.helper';
+
+const RECIPIENT = {
+  email: 'buyer@example.com',
+  phone: '+48500600700',
+  address: {
+    street: 'Krakowska',
+    buildingNumber: '12',
+    city: 'Poznań',
+    postCode: '60-001',
+    countryCode: 'PL',
+  },
+};
+const PARCEL = { dimensions: { length: 200, width: 150, height: 100 }, weightGrams: 1200 };
+
+interface ShipmentRow {
+  id: string;
+  status: string;
+  providerShipmentId: string | null;
+}
+
+describe('Shipment Dispatch Retry Integration (#1101)', () => {
+  let harness: IntegrationTestHarness;
+  let stub: InpostTestShippingStubHandle;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    stub = installInpostTestShippingStub(harness);
+  });
+
+  afterEach(async () => {
+    stub.resetFailures();
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  const dispatchService = (): IShipmentDispatchService =>
+    harness.getApp().get<IShipmentDispatchService>(SHIPMENT_DISPATCH_SERVICE_TOKEN);
+  const routingService = (): IFulfillmentRoutingService =>
+    harness.getApp().get<IFulfillmentRoutingService>(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+
+  async function shipmentRows(orderId: string): Promise<ShipmentRow[]> {
+    return harness
+      .getDataSource()
+      .query(
+        'SELECT "id", "status", "providerShipmentId" FROM "shipments" WHERE "orderId" = $1 ORDER BY "createdAt"',
+        [orderId],
+      ) as Promise<ShipmentRow[]>;
+  }
+
+  async function seedManagedCarrier(): Promise<{ sourceId: string; carrierId: string }> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.publicapi.v1',
+      enabledCapabilities: ['OrderSource'],
+    });
+    const carrier = await createTestConnection(dataSource, {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: INPOST_TEST_ADAPTER_KEY,
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    await routingService().replaceRules(source.id, [
+      {
+        sourceDeliveryMethodId: 'allegro-courier',
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: carrier.id,
+      },
+    ]);
+    return { sourceId: source.id, carrierId: carrier.id };
+  }
+
+  it('should reuse the failed branch-one row on retry — no UQ_shipments_branch_one_per_order_conn violation', async () => {
+    const { sourceId } = await seedManagedCarrier();
+    const input: ShipmentDispatchInput = {
+      sourceConnectionId: sourceId,
+      sourceDeliveryMethodId: 'allegro-courier',
+      orderId: 'ol_order_retry_1',
+      shippingMethod: 'kurier',
+      recipient: RECIPIENT,
+      parcel: PARCEL,
+    };
+
+    // Dispatch 1: the provider rejects before a waybill is minted → the service
+    // persists a `failed`, null-waybill row and rethrows.
+    stub.failOrder(input.orderId);
+    await expect(dispatchService().dispatch(input)).rejects.toBeInstanceOf(
+      ShippingProviderRejectionException,
+    );
+    const afterFail = await shipmentRows(input.orderId);
+    expect(afterFail).toHaveLength(1);
+    expect(afterFail[0]).toMatchObject({ status: 'failed', providerShipmentId: null });
+    const failedRowId = afterFail[0].id;
+
+    // Dispatch 2 (credentials "fixed"): must reuse + reset the existing
+    // branch-one row, NOT insert a duplicate (which the partial-unique index
+    // would reject with a QueryFailedError).
+    stub.resetFailures();
+    const retry = await dispatchService().dispatch(input);
+    expect(retry.kind).toBe('dispatched');
+
+    const afterRetry = await shipmentRows(input.orderId);
+    expect(afterRetry).toHaveLength(1); // reused, not duplicated
+    // Same row id proves REUSE (reset in place), not delete-and-recreate.
+    expect(afterRetry[0].id).toBe(failedRowId);
+    expect(afterRetry[0].status).toBe('generated');
+    expect(afterRetry[0].providerShipmentId).toMatch(/^stub-/);
+  });
+});

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-1103-1105-shipping-followups.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-1103-1105-shipping-followups.md
@@ -1,0 +1,46 @@
+# Pre-Implement Analysis — `implementation-plan-1103-1105-shipping-followups.md` (#1103, #1104, #1105)
+
+**Date**: 2026-06-18
+**Gate**: read-only readiness check (no code written, plan unedited beyond the tech-review pass)
+
+## Verdict: ✅ READY
+
+No reuse collisions, no contract breaks, no migration. The plan reuses the existing
+`AuthFailureClassifierPort` seam and the `host.authFailureClassifierRegistry` registration
+pattern (two live precedents), and the #1104 change is purely additive on an open-shape field.
+
+## Reuse findings
+
+| Plan artifact | Status | Evidence |
+|---|---|---|
+| `AuthFailureClassifierPort` (the port the classifiers implement) | **EXISTS → reuse** | `libs/core/src/sync/domain/ports/auth-failure-classifier.port.ts`, exported from the `@openlinker/core/sync` barrel (`index.ts:16`) |
+| `host.authFailureClassifierRegistry` (registration seam) | **EXISTS → reuse** | `libs/plugin-sdk/src/host-services.ts:109`; wired in `create-nest-adapter-module.ts:126,153` |
+| `DpdAuthFailureClassifierAdapter` | **NEW (confirmed absent)** | only `allegro-…` and `woocommerce-…` classifiers exist under `libs/integrations/**`; no DPD one |
+| `InpostAuthFailureClassifierAdapter` | **NEW (confirmed absent)** | same — no InPost classifier today |
+| Registration precedent to mirror | **EXISTS** | `allegro-plugin.ts:119` **and** `woocommerce` plugin (`host.authFailureClassifierRegistry.register(...)`) — two precedents |
+| `ShippingProviderRejectionException.providerDetails` (#1104 target) | **EXISTS → extend** | `libs/core/src/shipping/domain/exceptions/shipping-provider-rejection.exception.ts:53` — `Record<string, unknown>`, open shape |
+| DPD `reject()` + `validationInfo` types | **EXISTS → extend** | `dpd-shipment.mapper.ts:370`; `DpdValidationInfo` in `dpd-rest.types.ts:126` |
+| `shipment-dispatch-retry.int-spec.ts` | **NEW** | harness precedent: `apps/api/test/integration/shipment-dispatch.int-spec.ts` |
+
+## Backward-compatibility findings
+
+| Surface | Assessment | Severity |
+|---|---|---|
+| Top-level barrels | No exported symbol removed/renamed. The two new classifiers are plugin-internal (registered, not exported on a core barrel). | none |
+| Port signatures | `AuthFailureClassifierPort.isCredentialRejected` is **implemented**, not modified. | none |
+| `providerDetails` shape (#1104) | **Additive** — adds a `validationInfo` key. Other consumers read disjoint plugin-specific keys: InPost `providerDetails.fieldErrors` (`inpost-shipping.adapter.ts:141`), Allegro `providerDetails.errors`. No consumer asserts the DPD `{errorCode, info}` exact shape outside the DPD plugin. | none (additive) |
+| Symbol tokens | None added/removed. | none |
+| ORM schema | No entity/column change → **no migration**. | none |
+| `check:invariants` | Plugin adapters import `AuthFailureClassifierPort` from the top-level `@openlinker/core/sync` barrel (allowed capability-port cross-context import); int-spec is test-only. No cross-context / deep-barrel / service-interface rule expected to trip. | none |
+
+## Open questions
+
+- **None blocking.** The one risk the plan originally flagged (does the background sync-job path
+  throw an exception the classifier recognises?) was resolved during the tech-review pass and is
+  now documented as confirmed in the plan: both DPD clients (REST + SOAP `dpd-info-soap-client.ts:149,158`)
+  throw `DpdUnauthorizedException`, and InPost's single client throws `InpostUnauthorizedException` —
+  both extend `ShippingProviderAuthException`, so the classifier fires on the
+  `marketplace-shipment-status-sync` / `fulfillment-status-sync` job path.
+- **Scoped-out (acknowledged, not a blocker):** the synchronous `POST /shipments/generate-label`
+  path is intentionally NOT wired to flag `needs_reauth` (#1103 Part B), per the AC's "or explicitly
+  scoped out with a reason" clause and the user's approval.

--- a/docs/plans/implementation-plan-1103-1105-shipping-followups.md
+++ b/docs/plans/implementation-plan-1103-1105-shipping-followups.md
@@ -1,0 +1,75 @@
+# Implementation Plan — Shipping/DPD hardening round 2 (#1103, #1104, #1105)
+
+Follow-ups to PR #1102. Three cohesive shipping-domain fixes in one branch
+(`1103-1105-shipping-followups`).
+
+---
+
+## 1. Understand the task
+
+| Issue | Goal | Layer |
+|---|---|---|
+| #1103 | A carrier 401/403 flips the connection to `needs_reauth` | Integration (classifiers) + wiring |
+| #1104 | DPD `NOT_PROCESSED` surfaces field-level `validationInfo` in `providerDetails` | Integration (DPD mapper) |
+| #1105 | Integration test for the failed-pre-waybill retry against the real UQ constraint | CORE testing |
+
+**Non-goals**: no new HTTP-client behaviour; no change to the 502 mapping shipped in #1102; no move of shipping dispatch onto the job bus.
+
+---
+
+## 2. Research findings (live repo)
+
+- **Auth-failure classifier seam (#819, ADR-008)**: `AuthFailureClassifierPort.isCredentialRejected(cause)` (`libs/core/src/sync/domain/ports/auth-failure-classifier.port.ts`). Consumed **only** by `SyncJobRunner` (`apps/worker/src/sync/sync-job.runner.ts:315` → `flagConnectionNeedsReauth(job.connectionId)` → `connectionPort.update(id, { status: 'needs_reauth' })`). Registered per-plugin via `host.authFailureClassifierRegistry.register(...)`.
+- **Precedent**: `AllegroAuthFailureClassifierAdapter` is a one-liner — `return cause instanceof AllegroAuthenticationException`. Registered in `allegro-plugin.ts:119`.
+- **Shipping runs on the job path**: `apps/worker/src/sync/handlers/marketplace-shipment-status-sync.handler.ts`, `…fulfillment-status-sync.handler.ts`, `…shipment-sync-by-external-id.handler.ts` all run through `SyncJobRunner`. So a carrier credential rejection thrown on a background sync **already reaches the classifier dispatch** — it just returns `false` today because no shipping classifier is registered.
+- **Synchronous path is separate**: `POST /shipments/generate-label` → `ShipmentDispatchService` (no `SyncJobRunner`). `shipment.controller.ts:404` maps `ShippingProviderAuthException` → 502 and the `:409` comment marks the needs_reauth flip as this issue's deferred work.
+- **DPD/InPost plugins** both expose `register(host)` and already call `host.*Registry.register(...)` — the classifier registry is available on the same bag.
+- **#1104**: `reject()` (`dpd-shipment.mapper.ts:370`) already passes the **first** `DpdValidationInfo` as `providerDetails: { errorCode, info }`. `DpdValidationInfo` = `{ errorCode?: string; info?: string }` (`dpd-rest.types.ts:126`). `assertCreateSucceededAndExtractWaybill` picks one via `firstValidation(...)` (`:149`). The full array (package- + parcel-level) is discarded.
+- **#1105**: `apps/api/test/integration/shipment-dispatch.int-spec.ts` is the existing harness (real Postgres via the test harness; `resetTestHarness()` between tests).
+
+---
+
+## 3. Design
+
+### #1103 — needs_reauth on carrier auth failure
+
+**Part A (in scope — mirrors Allegro):** register a classifier per shipping plugin that recognises the carrier's auth exception. Both `DpdUnauthorizedException` and `InpostUnauthorizedException` extend the core `ShippingProviderAuthException` (PR #1102), so the classifier is a one-liner.
+
+- `DpdAuthFailureClassifierAdapter implements AuthFailureClassifierPort` → `cause instanceof DpdUnauthorizedException`.
+- `InpostAuthFailureClassifierAdapter` → `cause instanceof InpostUnauthorizedException`.
+- Register each in the plugin's `register(host)` via `host.authFailureClassifierRegistry.register(...)`.
+
+Effect: any shipping **sync job** (status-sync / fulfillment-sync / sync-by-external-id) that fails with a carrier 401/403 now flags the connection `needs_reauth` — the silent-background-failure case, which is the high-value one.
+
+**Part B (synchronous generate-label flag) — RECOMMEND SCOPING OUT, with reason:** the `POST /shipments/generate-label` path already returns an **actionable 502 to the operator in real time** (they're present and can react). The needs_reauth flag exists primarily to stop the *scheduler* from enqueuing dead-on-arrival background jobs — exactly what Part A covers. Wiring the synchronous controller path would add a connection-status-update dependency to the API shipping controller (or core dispatch service) for marginal value. Scope out here; tracked as a one-line note on #1103 for a future tiny follow-up if operators want the flag set on manual dispatch too.
+
+> **Verified (tech-review):** the DPD SOAP InfoServices client throws the **same** `DpdUnauthorizedException` on 401/403 (`dpd-info-soap-client.ts:149,158`) as the REST client, and InPost uses a single `inpost-http-client.ts` that throws `InpostUnauthorizedException` for every path. Both extend `ShippingProviderAuthException` (#1102). So a classifier checking `instanceof DpdUnauthorizedException` / `instanceof InpostUnauthorizedException` fires on the `marketplace-shipment-status-sync` / `fulfillment-status-sync` job path — Part A delivers real behavior, no extra client changes needed.
+
+### #1104 — carry full validationInfo into providerDetails
+
+Change `reject()` to accept the **array** of `DpdValidationInfo` (or collect package + parcel `validationInfo` at the call sites in `assertCreateSucceededAndExtractWaybill`) and place all `{ errorCode, info }` entries in `providerDetails.validationInfo`, keeping the first `errorCode` as the `providerCode` discriminator. Backwards-compatible shape: `providerDetails = { errorCode, info, validationInfo: [...] }`.
+
+### #1105 — integration test
+
+New `apps/api/test/integration/shipment-dispatch-retry.int-spec.ts` mirroring `shipment-dispatch.int-spec.ts`: dispatch with a failing label → assert `failed` + null waybill row; re-dispatch → assert success, single row reused, no UQ violation.
+
+---
+
+## 4. Step-by-step implementation
+
+1. **#1103a** `libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-auth-failure-classifier.adapter.ts` — new adapter (**with the standard file header**, Allegro adapter as template) + `*.spec.ts`. Export from the package barrel (mirror Allegro). The spec asserts the **negative** too: `isCredentialRejected` → `true` for `DpdUnauthorizedException`, `false` for `ShippingProviderRejectionException` + a network exception (so a 422/validation reject never flags the connection).
+2. **#1103a** Register it in `libs/integrations/dpd-polska/src/*plugin*.ts` `register(host)` via `host.authFailureClassifierRegistry.register(...)`.
+3. **#1103a** Same for InPost: `inpost-auth-failure-classifier.adapter.ts` (+ file header) + spec (same negative assertion) + register in the InPost plugin.
+4. **#1103b** Add a one-line note to #1103 documenting the synchronous-path scope-out (comment on issue at ship time).
+5. **#1104** Extend `reject()` + the two call sites in `dpd-shipment.mapper.ts` to carry all `validationInfo` entries into `providerDetails` (additive shape `{ errorCode, info, validationInfo: [...] }`; quick-grep first for any consumer asserting the current exact shape); update `dpd-shipment.mapper.spec.ts` with a `NOT_PROCESSED` + `INCORRECT_*_POSTAL_CODE` case.
+6. **#1105** Add `shipment-dispatch-retry.int-spec.ts`. **Force the failure deterministically**: register a stub `ShippingProviderManager` adapter via `AdapterRegistryService` + `AdapterFactoryResolverService` whose `generateLabel` rejects (mirrors `allegro-prestashop-carrier-mapping.int-spec.ts`'s stub-registration approach). Assert (a) a `failed` / null-waybill row after dispatch 1; (b) dispatch 2 for the same `(orderId, connectionId)` does **not** raise the `UQ_…` violation and leaves exactly one row. `maxWorkers:1` + `resetTestHarness()` per the testing guide.
+7. Quality gate: `pnpm lint && pnpm type-check && pnpm test`, then `pnpm test:integration` for the new int-spec.
+
+---
+
+## 5. Validation
+
+- **Architecture**: classifiers live in each plugin's `infrastructure/adapters/`, implement the core `AuthFailureClassifierPort`, registered via `HostServices` — no CORE ↔ Integration violation. #1104 stays inside the DPD plugin. #1105 is test-only.
+- **Naming**: `*-auth-failure-classifier.adapter.ts` / `{Platform}AuthFailureClassifierAdapter` (matches Allegro).
+- **Testing**: unit spec per classifier; mapper spec for #1104; int-spec for #1105.
+- **Risk**: the only real unknown is whether DPD background tracking auth throws `DpdUnauthorizedException` (REST) vs a SOAP exception — verified during step 1–2; if divergent, noted as a follow-up rather than expanding this PR.

--- a/libs/integrations/dpd-polska/src/dpd-plugin.ts
+++ b/libs/integrations/dpd-polska/src/dpd-plugin.ts
@@ -17,6 +17,7 @@ import { dispatchCapability, type AdapterPlugin, type HostServices } from '@open
 import type { AdapterMetadata } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { createDpdShippingAdapter } from './application/dpd-adapter.factory';
+import { DpdAuthFailureClassifierAdapter } from './infrastructure/adapters/dpd-auth-failure-classifier.adapter';
 import { DpdConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/dpd-connection-config-shape-validator.adapter';
 import { buildDpdSchedulerTasks } from './infrastructure/scheduler/dpd-scheduler-tasks';
 
@@ -49,6 +50,14 @@ export function createDpdPlugin(): AdapterPlugin {
       );
       // No credentials-shape validator: the `{ login, password }` shape is
       // enforced at adapter construction time by the factory.
+
+      // Auth-failure classifier (#819 / #1103): a non-retryable 401/403 from
+      // either DPD client flips the connection to `needs_reauth` on the
+      // SyncJobRunner path (e.g. the shipment-status poll below).
+      host.authFailureClassifierRegistry.register(
+        dpdAdapterManifest.adapterKey,
+        new DpdAuthFailureClassifierAdapter(),
+      );
 
       // Shipment-status poll (#965, ADR-022) — the only DPD tracking path
       // (no DPD webhook). Env-gated; takes effect worker-side via the scheduler.

--- a/libs/integrations/dpd-polska/src/index.ts
+++ b/libs/integrations/dpd-polska/src/index.ts
@@ -27,6 +27,10 @@ export type {
 } from './domain/types/dpd-config.types';
 export type { DpdCredentials } from './domain/types/dpd-credentials.types';
 
+// Auth-failure classifier (#819 / #1103) — exported for host-side discovery;
+// the plugin self-registers it against `host.authFailureClassifierRegistry`.
+export { DpdAuthFailureClassifierAdapter } from './infrastructure/adapters/dpd-auth-failure-classifier.adapter';
+
 // Plugin descriptor + host wiring
 export { dpdAdapterManifest, createDpdPlugin } from './dpd-plugin';
 export { DpdIntegrationModule } from './dpd-integration.module';

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-auth-failure-classifier.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-auth-failure-classifier.adapter.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * DPD Auth Failure Classifier Adapter — Unit Tests
+ *
+ * Pins that only `DpdUnauthorizedException` is treated as a terminal credential
+ * rejection (#819) — provider rejections (validation 4xx), transient network
+ * failures, and unknown errors must NOT flag the connection for re-auth.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__
+ */
+import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
+import { DpdAuthFailureClassifierAdapter } from '../dpd-auth-failure-classifier.adapter';
+import { DpdUnauthorizedException } from '../../../domain/exceptions/dpd-unauthorized.exception';
+import { DpdNetworkException } from '../../../domain/exceptions/dpd-network.exception';
+
+describe('DpdAuthFailureClassifierAdapter', () => {
+  const classifier = new DpdAuthFailureClassifierAdapter();
+
+  it('classifies DpdUnauthorizedException as a credential rejection', () => {
+    expect(classifier.isCredentialRejected(new DpdUnauthorizedException('401 MISSING_PERMISSION'))).toBe(
+      true,
+    );
+  });
+
+  it('does not classify a provider rejection (validation 4xx) as a credential rejection', () => {
+    const cause = new ShippingProviderRejectionException(
+      'dpd',
+      'INCORRECT_RECEIVER_POSTAL_CODE',
+      'Incorrect receiver postal code',
+    );
+    expect(classifier.isCredentialRejected(cause)).toBe(false);
+  });
+
+  it('does not classify a transient network failure as a credential rejection', () => {
+    expect(classifier.isCredentialRejected(new DpdNetworkException('timeout'))).toBe(false);
+  });
+
+  it('does not classify unknown errors as credential rejections', () => {
+    expect(classifier.isCredentialRejected(new Error('boom'))).toBe(false);
+    expect(classifier.isCredentialRejected('string error')).toBe(false);
+    expect(classifier.isCredentialRejected(undefined)).toBe(false);
+  });
+});

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-auth-failure-classifier.adapter.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-auth-failure-classifier.adapter.ts
@@ -1,0 +1,32 @@
+/**
+ * DPD Polska Auth Failure Classifier Adapter
+ *
+ * Implements `AuthFailureClassifierPort` (#819) for DPD Polska — answers the
+ * `SyncJobRunner`'s "does this terminal failure mean the connection's
+ * credentials were rejected (re-authentication required)?" question for DPD's
+ * exception hierarchy. Self-registered by the DPD plugin's `register(host)`
+ * against `AuthFailureClassifierRegistryService`.
+ *
+ * Credential-rejection (return `true`):
+ *   - `DpdUnauthorizedException` — thrown by BOTH the DPDServices REST client
+ *     and the DPD InfoServices SOAP client on a non-retryable `401`/`403`
+ *     (bad Basic-auth pair / `MISSING_PERMISSION`). It extends the core
+ *     `ShippingProviderAuthException` (#1102), so checking the plugin subclass
+ *     here covers every DPD path that can surface a credential rejection.
+ *
+ * Everything else (return `false`):
+ *   - `ShippingProviderRejectionException` (deterministic 4xx / validation
+ *     rejects — a business problem, not a credential one),
+ *   - `DpdNetworkException` (retryable transport), unknown errors.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/adapters
+ * @implements {AuthFailureClassifierPort}
+ */
+import type { AuthFailureClassifierPort } from '@openlinker/core/sync';
+import { DpdUnauthorizedException } from '../../domain/exceptions/dpd-unauthorized.exception';
+
+export class DpdAuthFailureClassifierAdapter implements AuthFailureClassifierPort {
+  isCredentialRejected(cause: unknown): boolean {
+    return cause instanceof DpdUnauthorizedException;
+  }
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/__tests__/dpd-shipment.mapper.spec.ts
@@ -351,6 +351,36 @@ describe('assertCreateSucceededAndExtractWaybill', () => {
     const error = run(() => assertCreateSucceededAndExtractWaybill(res));
     expect(error).toMatchObject({ providerCode: 'command.success-without-shipment-id' });
   });
+
+  it('should surface PACKAGE-level validationInfo (hidden behind NOT_PROCESSED) in providerDetails (#1104)', () => {
+    // The real demo shape: a top-level NOT_PROCESSED whose field-level reason
+    // lives at the PACKAGE level, with an empty parcel validationInfo array.
+    const res: DpdGeneratePackagesNumbersResponse = {
+      status: 'NOT_PROCESSED',
+      packages: [
+        {
+          status: 'INCORRECT_DATA',
+          validationInfo: [
+            { errorCode: 'INCORRECT_RECEIVER_POSTAL_CODE', info: 'Incorrect receiver postal code: (60-001)' },
+            { errorCode: 'INCORRECT_SENDER_POSTAL_CODE', info: 'Incorrect sender postal code: (01-612)' },
+          ],
+          parcels: [{ status: 'NOT_PROCESSED', validationInfo: [] }],
+        },
+      ],
+    };
+
+    const error = run(() => assertCreateSucceededAndExtractWaybill(res));
+    expect(error).toBeInstanceOf(ShippingProviderRejectionException);
+    // First package entry drives the discriminator (parcel validationInfo empty).
+    expect(error).toMatchObject({ providerCode: 'INCORRECT_RECEIVER_POSTAL_CODE' });
+    // The full set is carried for structured logs / the API response.
+    expect(
+      (error as ShippingProviderRejectionException).providerDetails?.validationInfo,
+    ).toEqual([
+      { errorCode: 'INCORRECT_RECEIVER_POSTAL_CODE', info: 'Incorrect receiver postal code: (60-001)' },
+      { errorCode: 'INCORRECT_SENDER_POSTAL_CODE', info: 'Incorrect sender postal code: (01-612)' },
+    ]);
+  });
 });
 
 describe('toGenerateLabelResult', () => {

--- a/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/mappers/dpd-shipment.mapper.ts
@@ -146,16 +146,24 @@ export function assertCreateSucceededAndExtractWaybill(
 ): string {
   const pkg = res.packages?.[0];
   const parcel = pkg?.parcels?.[0];
-  const info = firstValidation(parcel?.validationInfo) ?? firstValidation(pkg?.validationInfo);
+  // Collect every validation entry across both levels (parcel-first so the
+  // primary discriminator/message keeps the existing precedence). DPD often
+  // returns the real field-level reason at the PACKAGE level with an empty
+  // parcel array (e.g. INCORRECT_*_POSTAL_CODE behind a top-level NOT_PROCESSED),
+  // so both are surfaced into `providerDetails.validationInfo` (#1104).
+  const allInfos: DpdValidationInfo[] = [
+    ...(parcel?.validationInfo ?? []),
+    ...(pkg?.validationInfo ?? []),
+  ];
 
   if (res.status !== DPD_STATUS_OK) {
-    throw reject(info, `DPD create rejected (batch status: ${res.status})`);
+    throw reject(allInfos, `DPD create rejected (batch status: ${res.status})`);
   }
   if (!pkg || pkg.status !== DPD_STATUS_OK) {
-    throw reject(info, `DPD create rejected (package status: ${pkg?.status ?? 'missing'})`);
+    throw reject(allInfos, `DPD create rejected (package status: ${pkg?.status ?? 'missing'})`);
   }
   if (!parcel || parcel.status !== DPD_STATUS_OK) {
-    throw reject(info, `DPD create rejected (parcel status: ${parcel?.status ?? 'missing'})`);
+    throw reject(allInfos, `DPD create rejected (parcel status: ${parcel?.status ?? 'missing'})`);
   }
   if (!parcel.waybill) {
     throw new ShippingProviderRejectionException(
@@ -363,15 +371,21 @@ function resolveRecipientName(recipient: ShipmentRecipient): string | undefined 
   return composed.length > 0 ? composed : undefined;
 }
 
-function firstValidation(infos?: DpdValidationInfo[]): DpdValidationInfo | undefined {
-  return infos && infos.length > 0 ? infos[0] : undefined;
-}
-
-function reject(info: DpdValidationInfo | undefined, fallback: string): ShippingProviderRejectionException {
+/**
+ * Build the rejection from every collected validation entry. The first entry
+ * (parcel-first precedence) drives the `providerCode` discriminator + message;
+ * the full set is carried on `providerDetails.validationInfo` so a future
+ * `NOT_PROCESSED` surfaces the field-level reason in structured logs / the API
+ * response without a debug probe (#1104).
+ */
+function reject(allInfos: DpdValidationInfo[], fallback: string): ShippingProviderRejectionException {
+  const first = allInfos[0];
   return new ShippingProviderRejectionException(
     DPD_BRAND,
-    info?.errorCode ?? null,
-    info?.info ?? fallback,
-    info ? { errorCode: info.errorCode, info: info.info } : undefined,
+    first?.errorCode ?? null,
+    first?.info ?? fallback,
+    allInfos.length > 0
+      ? { errorCode: first.errorCode, info: first.info, validationInfo: allInfos }
+      : undefined,
   );
 }

--- a/libs/integrations/inpost/src/index.ts
+++ b/libs/integrations/inpost/src/index.ts
@@ -27,6 +27,10 @@ export type {
 } from './domain/types/inpost-config.types';
 export type { InpostCredentials } from './domain/types/inpost-credentials.types';
 
+// Auth-failure classifier (#819 / #1103) — exported for host-side discovery;
+// the plugin self-registers it against `host.authFailureClassifierRegistry`.
+export { InpostAuthFailureClassifierAdapter } from './infrastructure/adapters/inpost-auth-failure-classifier.adapter';
+
 // Plugin descriptor + host wiring
 export { inpostAdapterManifest, createInpostPlugin } from './inpost-plugin';
 export { InpostIntegrationModule } from './inpost-integration.module';

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-auth-failure-classifier.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-auth-failure-classifier.adapter.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * InPost Auth Failure Classifier Adapter — Unit Tests
+ *
+ * Pins that only `InpostUnauthorizedException` is treated as a terminal
+ * credential rejection (#819) — provider rejections (validation 4xx), transient
+ * network failures, and unknown errors must NOT flag the connection for re-auth.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/adapters/__tests__
+ */
+import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
+import { InpostAuthFailureClassifierAdapter } from '../inpost-auth-failure-classifier.adapter';
+import { InpostUnauthorizedException } from '../../../domain/exceptions/inpost-unauthorized.exception';
+import { InpostNetworkException } from '../../../domain/exceptions/inpost-network.exception';
+
+describe('InpostAuthFailureClassifierAdapter', () => {
+  const classifier = new InpostAuthFailureClassifierAdapter();
+
+  it('classifies InpostUnauthorizedException as a credential rejection', () => {
+    expect(classifier.isCredentialRejected(new InpostUnauthorizedException('401 unauthorized'))).toBe(
+      true,
+    );
+  });
+
+  it('does not classify a provider rejection (validation 4xx) as a credential rejection', () => {
+    const cause = new ShippingProviderRejectionException('inpost', 'target_point', 'bad point');
+    expect(classifier.isCredentialRejected(cause)).toBe(false);
+  });
+
+  it('does not classify a transient network failure as a credential rejection', () => {
+    expect(classifier.isCredentialRejected(new InpostNetworkException('timeout'))).toBe(false);
+  });
+
+  it('does not classify unknown errors as credential rejections', () => {
+    expect(classifier.isCredentialRejected(new Error('boom'))).toBe(false);
+    expect(classifier.isCredentialRejected('string error')).toBe(false);
+    expect(classifier.isCredentialRejected(undefined)).toBe(false);
+  });
+});

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-auth-failure-classifier.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-auth-failure-classifier.adapter.ts
@@ -1,0 +1,31 @@
+/**
+ * InPost Auth Failure Classifier Adapter
+ *
+ * Implements `AuthFailureClassifierPort` (#819) for InPost — answers the
+ * `SyncJobRunner`'s "does this terminal failure mean the connection's
+ * credentials were rejected (re-authentication required)?" question for InPost's
+ * exception hierarchy. Self-registered by the InPost plugin's `register(host)`
+ * against `AuthFailureClassifierRegistryService`.
+ *
+ * Credential-rejection (return `true`):
+ *   - `InpostUnauthorizedException` — thrown by the single ShipX HTTP client on
+ *     a non-retryable `401 unauthorized` / `403 access_forbidden` (bad/expired
+ *     API token or insufficient permissions). It extends the core
+ *     `ShippingProviderAuthException` (#1102), so this covers every InPost path.
+ *
+ * Everything else (return `false`):
+ *   - `ShippingProviderRejectionException` (deterministic 4xx / field-validation
+ *     rejects — a business problem, not a credential one),
+ *   - `InpostNetworkException` (retryable transport), unknown errors.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/adapters
+ * @implements {AuthFailureClassifierPort}
+ */
+import type { AuthFailureClassifierPort } from '@openlinker/core/sync';
+import { InpostUnauthorizedException } from '../../domain/exceptions/inpost-unauthorized.exception';
+
+export class InpostAuthFailureClassifierAdapter implements AuthFailureClassifierPort {
+  isCredentialRejected(cause: unknown): boolean {
+    return cause instanceof InpostUnauthorizedException;
+  }
+}

--- a/libs/integrations/inpost/src/inpost-plugin.ts
+++ b/libs/integrations/inpost/src/inpost-plugin.ts
@@ -16,6 +16,7 @@ import { dispatchCapability, type AdapterPlugin, type HostServices } from '@open
 import type { AdapterMetadata } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { createInpostShippingAdapter } from './application/inpost-adapter.factory';
+import { InpostAuthFailureClassifierAdapter } from './infrastructure/adapters/inpost-auth-failure-classifier.adapter';
 import { InpostConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/inpost-connection-config-shape-validator.adapter';
 import { InpostInboundWebhookDecoderAdapter } from './infrastructure/adapters/inpost-inbound-webhook-decoder.adapter';
 import { InpostWebhookEventTranslatorAdapter } from './infrastructure/adapters/inpost-webhook-event-translator.adapter';
@@ -50,6 +51,14 @@ export function createInpostPlugin(): AdapterPlugin {
       );
       // No credentials-shape validator: the `{ apiToken }` shape is enforced
       // at adapter construction time by the factory (deeper than this boundary).
+
+      // Auth-failure classifier (#819 / #1103): a non-retryable 401/403 from the
+      // ShipX client flips the connection to `needs_reauth` on the SyncJobRunner
+      // path (e.g. the shipment-status poll below).
+      host.authFailureClassifierRegistry.register(
+        inpostAdapterManifest.adapterKey,
+        new InpostAuthFailureClassifierAdapter(),
+      );
 
       // #768 / ADR-021 — third-party-native webhook ingress. The decoder
       // (provider-keyed) authenticates + decodes InPost's `Shipment.Tracking`


### PR DESCRIPTION
## What & why

Three cohesive shipping-domain follow-ups from PR #1102, grounded in the DPD demo-enablement work.

### #1103 — flip connection to `needs_reauth` on carrier auth failure
Register `DpdAuthFailureClassifierAdapter` + `InpostAuthFailureClassifierAdapter` against the #819 auth-failure classifier registry (mirroring the Allegro/WooCommerce precedent — one-line `instanceof` checks). A non-retryable carrier 401/403 on the **SyncJobRunner path** (shipment-status / fulfillment-status sync) now flips the connection to `needs_reauth`, so the scheduler stops enqueuing dead-on-arrival jobs. Both carrier auth exceptions already extend `ShippingProviderAuthException` (#1102); for DPD the **same** `DpdUnauthorizedException` is thrown by both the REST and SOAP InfoServices clients, so the classifier covers every DPD path.

**Scoped out (deliberate):** flagging on the synchronous `POST /shipments/generate-label` path. That path already returns an actionable **502** to the operator in real time; the `needs_reauth` flag exists to stop *background* dead jobs, which Part A covers. Tracked as a tiny optional follow-up on #1103.

### #1104 — surface DPD `validationInfo` detail in `providerDetails`
`reject()` now carries the full `validationInfo` array (package **and** parcel level) into `ShippingProviderRejectionException.providerDetails`. A top-level `NOT_PROCESSED` (whose real field-level reason — e.g. `INCORRECT_*_POSTAL_CODE` — lives at the package level with an empty parcel array) now surfaces the cause in structured logs / the API response without a debug probe. Additive: the existing `errorCode`/`info` keys are unchanged.

### #1105 — integration test for the failed-pre-waybill retry wedge
New `shipment-dispatch-retry.int-spec.ts` against real Postgres: a dispatch that fails before minting a waybill, then a retry — asserts the branch-one row is **reused in place** (same id, `failed → generated`), no `UQ_shipments_branch_one_per_order_conn` violation. A mocked repo can't reproduce the index, so this guards the #1101 fix at the DB level.

## Testing
- Unit: DPD + InPost classifier specs (positive + 3 negatives each); DPD mapper spec with the real `NOT_PROCESSED` shape.
- Integration: retry int-spec (Testcontainers) — passes, asserts same-row reuse.
- Full gate green: `type-check`, `lint` + invariants, dpd unit 116, inpost unit 75.

## Reviewed
Deep `/tech-review` pass applied (strengthened the int-spec to assert row-id reuse). No migration. No CORE ↔ Integration boundary change.

Closes #1103
Closes #1104
Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)