### PR TITLE
chore(ci): cut self-hosted queue load via concurrency, draft/path gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    # `ready_for_review` so the heavy jobs (gated on `draft == false`) fire the
+    # moment a draft is marked ready — without it a dev would need an empty push
+    # to trigger full CI on un-drafting. Re-stating the default trio is required:
+    # naming `types` replaces the implicit [opened, synchronize, reopened].
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # Cancel superseded runs on the same ref so a dead, replaced run doesn't keep
 # holding scarce self-hosted slots and block the queue. Pushes to main rarely
@@ -15,11 +20,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Cheap path gate. Runs on GitHub-hosted runners so it never consumes a
+  # self-hosted slot. The four non-required heavy jobs (lint/test/integration/
+  # build) gate on `code == 'true'`; `Type Check` (the only required check) is
+  # intentionally NOT gated so it always reports — a docs-only or draft PR then
+  # spends 1 self-hosted slot instead of 5.
+  #
+  # `code` matches any changed file EXCEPT pure docs / markdown / the dev-stack
+  # compose file (none of which any CI job consumes — integration tests use
+  # Testcontainers, not docker-compose.yml). Dockerfile is deliberately NOT
+  # ignored: it feeds the future image build once CD is enabled.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!docker-compose.yml'
+
   lint:
     name: Lint
     timeout-minutes: 30
     # runs-on: ubuntu-latest
     runs-on: self-hosted
+    needs: changes
+    # Skip while draft, and skip when only docs/compose changed. Always run on
+    # push (post-merge to main/develop) where there's no PR draft context.
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.draft == false && needs.changes.outputs.code == 'true') }}
     steps:
       - uses: actions/checkout@v4
       # actions/checkout@v4 shallow-fetches only the triggering ref, so
@@ -77,6 +113,8 @@ jobs:
     timeout-minutes: 30
     # runs-on: ubuntu-latest
     runs-on: self-hosted
+    needs: changes
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.draft == false && needs.changes.outputs.code == 'true') }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
@@ -100,15 +138,15 @@ jobs:
     timeout-minutes: 45
     # runs-on: ubuntu-latest
     runs-on: self-hosted
-    # Run on push to main (after merge) and on PRs to catch issues early
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
-    # No `needs:` — this job re-installs deps + rebuilds libs itself, so it has
-    # no artifact dependency on `test`. Gating on `test` previously serialized
-    # the two longest jobs (unit ~6min, then integration ~10min), so integration
-    # only started after unit finished. Running them in parallel cuts the
-    # critical path by ~6min. Trade-off: integration spends compute even when
-    # unit tests fail on a PR — acceptable for the wall-clock win; both still
-    # gate the merge via branch protection.
+    # `needs: changes` only for the cheap path-gate output — NOT an artifact
+    # dependency on `test`. This job re-installs deps + rebuilds libs itself;
+    # gating on `test` previously serialized the two longest jobs (unit ~6min,
+    # then integration ~10min). Running them in parallel cuts the critical path
+    # by ~6min. Trade-off: integration spends compute even when unit tests fail
+    # on a PR — acceptable for the wall-clock win.
+    needs: changes
+    # Skip while draft / docs-only; always run on push (post-merge).
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.draft == false && needs.changes.outputs.code == 'true') }}
     env:
       OL_PII_HASH_SALT: ${{ vars.OL_PII_HASH_SALT }}
     steps:
@@ -174,6 +212,8 @@ jobs:
     timeout-minutes: 30
 #    runs-on: ubuntu-latest
     runs-on: self-hosted
+    needs: changes
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.draft == false && needs.changes.outputs.code == 'true') }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main, develop]
 
+# Cancel superseded runs on the same ref so a dead, replaced run doesn't keep
+# holding scarce self-hosted slots and block the queue. Pushes to main rarely
+# overlap; if a never-cancel-on-main policy is later wanted, gate with
+# `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -80,8 +88,9 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Build libs (workspace glob — auto-discovers new packages)
-        run: pnpm -r --filter "./libs/**" build
+      # No explicit libs build: `pnpm test:ci` already runs
+      # `pnpm -r --filter "./libs/**" build` before the tests, so a separate
+      # step here builds libs twice in this one job.
       - name: Run tests
         run: pnpm test:ci
 


### PR DESCRIPTION
## Summary

- Add a workflow-level `concurrency` group with `cancel-in-progress` so a superseded run on the same ref stops holding scarce self-hosted slots — the cheapest win for queue lag on a 2-runner (1 job each) setup.
- Gate the four non-required heavy jobs (`lint`, `test`, `test-integration`, `build`) on `draft == false` **and** a `dorny/paths-filter` "code changed" check, while keeping `Type Check` (the only required status check) always running. A draft or docs-only PR now spends 1 self-hosted slot instead of 5.
- Remove a redundant double libs-build inside the `test` job (`pnpm test:ci` already builds libs), and add `ready_for_review` to the PR triggers so full CI fires automatically when a draft is marked ready.

## Related issues

Closes #1091

## Test plan

Workflow-only change (no app code touched), so verification is mostly by reading the gating logic plus one live check:

- **YAML / logic review**: confirm `Type Check` has no `if`/`needs` (always reports for branch protection), and `lint`/`test`/`test-integration`/`build` carry `needs: changes` + `if: push OR (draft==false AND code changed)`.
- **Draft PR**: open this (or any) PR as a draft → only `Type Check` (+ GitHub-hosted `PHP Unit Tests`) should run; the four self-hosted heavy jobs should show **skipped**.
- **Ready for review**: click "Ready for review" → the four heavy jobs should kick off without needing an extra push.
- **Docs-only PR**: a branch touching only `docs/**` / `*.md` / `docker-compose.yml` → heavy jobs skipped, `Type Check` still green (so merge stays unblocked).
- **Push to `main`/`develop`**: full matrix still runs (no PR draft context → `event_name == 'push'` short-circuits the gate).

Edge cases confirmed by construction: `push` events have no `pull_request` context, so the `|| github.event_name == 'push'` clause keeps post-merge runs full; `synchronize` on a draft → skipped; `ready_for_review` → `draft` already `false` → runs.

## Quality gate

- [x] `pnpm lint` passes (zero errors)
- [x] `pnpm type-check` passes (zero errors)
- [x] `pnpm test` passes (all unit tests green)
- [ ] *Optional, Docker required:* `pnpm test:integration` — N/A, no `apps/api/test/integration/**` or adapter changes.

## Migrations

- [x] No ORM entity changed — trivially satisfied.

## ADR

- [x] No architectural decision (CI/build tooling only, no bounded-context or plugin-contract impact) — trivially satisfied.

## DCO sign-off

> Signed off with `git commit -s`.

---

<sub>By submitting this pull request, I confirm that my contributions are made under the terms of the [Apache License 2.0](../LICENSE), and I certify the [Developer Certificate of Origin](https://developercertificate.org/) by signing off my commits.</sub>