### PR TITLE
feat(prestashop): ProductPublisher adapter — publish product fields to PrestaShop (#1107)

### DIFF
--- a/apps/api/test/integration/connection-capabilities.int-spec.ts
+++ b/apps/api/test/integration/connection-capabilities.int-spec.ts
@@ -55,10 +55,12 @@ describe('Connection Capabilities Integration', () => {
     const created = await createConnection(dto);
 
     expect(created.supportedCapabilities.sort()).toEqual([
+      'CategoryProvisioner',
       'InventoryMaster',
       'OrderProcessorManager',
       'OrderSource',
       'ProductMaster',
+      'ProductPublisher',
     ]);
     expect(created.enabledCapabilities.sort()).toEqual(created.supportedCapabilities.sort());
   });
@@ -104,10 +106,12 @@ describe('Connection Capabilities Integration', () => {
 
     expect(updated.body.enabledCapabilities).toEqual(['ProductMaster']);
     expect(updated.body.supportedCapabilities.sort()).toEqual([
+      'CategoryProvisioner',
       'InventoryMaster',
       'OrderProcessorManager',
       'OrderSource',
       'ProductMaster',
+      'ProductPublisher',
     ]);
   });
 

--- a/docs/plans/analysis/ANALYSIS-1107-prestashop-product-publisher.md
+++ b/docs/plans/analysis/ANALYSIS-1107-prestashop-product-publisher.md
@@ -1,0 +1,98 @@
+# Pre-Implement Analysis: PrestaShop ProductPublisher + CategoryProvisioner Adapter
+
+**Plan**: `docs/plans/implementation-plan-prestashop-product-publisher.md`
+**Issue**: #1107
+**Gate run**: 2026-06-18
+**Verdict**: ✅ READY — one plan correction required before coding starts (see §Plan Corrections)
+
+---
+
+## Reuse Audit
+
+All CORE contracts the plan depends on exist and are exported correctly. No plan artifact collides with anything already in the repo.
+
+| Plan Artifact | Status | Location |
+|---|---|---|
+| `ShopProductManagerPort` | EXISTS — export confirmed | `@openlinker/core/listings` barrel, line 278 |
+| `CategoryProvisioner` | EXISTS — export confirmed | `@openlinker/core/listings` barrel, line 279 |
+| `isCategoryProvisioner()` type guard | EXISTS — export confirmed | `@openlinker/core/listings` barrel, line 280 |
+| `PublishProductCommand` / `PublishProductResult` | EXISTS | `libs/core/src/listings/domain/types/product-publish.types.ts` |
+| `ProvisionCategoryCommand` / `ProvisionCategoryResult` | EXISTS | `libs/core/src/listings/domain/types/category-provision.types.ts` |
+| `ProductPublishRejectedException` | EXISTS — export confirmed | `@openlinker/core/listings` barrel, line 293 |
+| `'ProductPublisher'` in `CoreCapabilityValues` | EXISTS | `libs/core/src/integrations/domain/types/adapter.types.ts:31` |
+| `'CategoryProvisioner'` in `CoreCapabilityValues` | EXISTS | `libs/core/src/integrations/domain/types/adapter.types.ts:32` |
+| `PrestashopApiException` barrel export | EXISTS | `libs/integrations/prestashop/src/index.ts:42` |
+| `PrestashopAuthenticationException` barrel export | EXISTS | `libs/integrations/prestashop/src/index.ts:40` |
+| `IPrestashopWebserviceClient` | EXISTS | `libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.interface.ts` |
+| `prestashop-product-publish.types.ts` | ABSENT — new file | `infrastructure/adapters/product-publisher/` (to be created) |
+| `prestashop-product-publisher.adapter.ts` | ABSENT — new file | `infrastructure/adapters/product-publisher/` (to be created) |
+| `prestashop-product-publisher.adapter.spec.ts` | ABSENT — new file | `infrastructure/adapters/product-publisher/__tests__/` (to be created) |
+| `productPublisher` in `PrestashopAdapters` | ABSENT — new field | `prestashop-adapter.factory.interface.ts` (to be added) |
+| `PrestashopLangField` / `langField` helper | ABSENT — new | (to be created in types file) |
+
+---
+
+## Backward-Compat Findings
+
+All plan modifications are **purely additive**. No existing consumer can break.
+
+| Touch point | Change | Impact |
+|---|---|---|
+| `PrestashopAdapters` interface | Adds optional `productPublisher?` field | Safe — all existing destructuring patterns unaffected |
+| Factory `createAdapters` return | Adds `productPublisher` to the returned object | Safe — callers that don't destructure `productPublisher` are unaffected |
+| `prestashopAdapterManifest.supportedCapabilities` | Adds `'ProductPublisher'`, `'CategoryProvisioner'` | Additive — `IntegrationsService` only checks membership, never iterates exhaustively for routing |
+| `createCapabilityAdapter` dispatch table | Adds two new capability entries | Additive — existing entries untouched |
+| ORM entities | None modified | No migration required |
+| Barrel exports (`libs/integrations/prestashop/src/index.ts`) | No new exports required (adapter is internal) | No impact |
+
+---
+
+## Plan Corrections
+
+### C1 — `CategoryProvisioner` needs its own dispatch entry (REQUIRED FIX)
+
+**Plan claim (Phase 4c):**
+> "CategoryProvisioner does not need its own dispatch entry — it is a sub-capability of ProductPublisher, narrowed by `isCategoryProvisioner(adapter)` at call sites."
+
+**Actual WooCommerce reference (`woocommerce-plugin.ts`, lines 141–144):**
+```typescript
+ProductPublisher: () =>
+  new WooCommerceProductPublisherAdapter(httpClient, connection),
+CategoryProvisioner: () =>
+  new WooCommerceProductPublisherAdapter(httpClient, connection),
+```
+
+The reference adapter **does** add a `CategoryProvisioner` dispatch entry — it creates a fresh (stateless) instance. Without it, `dispatchCapability` would throw `"{plugin} adapter does not support capability: CategoryProvisioner"` when `IntegrationsService.getCapabilityAdapter(connId, 'CategoryProvisioner')` is called.
+
+**Correction**: In Phase 4c, add both entries to the dispatch table:
+```typescript
+ProductPublisher: () => adapters.productPublisher,
+CategoryProvisioner: () => adapters.productPublisher,
+```
+
+The factory builds one instance stored in `adapters.productPublisher`; both dispatch entries return that same reference (unlike WooCommerce which creates two independent instances — either approach is correct since the adapter is stateless, but reusing the factory instance avoids double-construction).
+
+---
+
+## Open Questions
+
+### Q1 — Does `PrestashopAuthenticationException extends PrestashopApiException`?
+
+The `toPublishError` guard in Phase 2 uses:
+```typescript
+error instanceof PrestashopApiException &&
+!(error instanceof PrestashopAuthenticationException) &&
+error.statusCode >= 400 && error.statusCode < 500
+```
+
+If `PrestashopAuthenticationException` is a subclass of `PrestashopApiException`, the `!(...auth...)` guard is needed to prevent a 401 from being swallowed as a `ProductPublishRejectedException`. If it isn't a subclass, the guard is redundant but harmless. **Either way the logic is safe.** No action required — but confirming the exception hierarchy in `libs/integrations/prestashop/src/domain/exceptions/` during Phase 2 is recommended.
+
+### Q2 — `stock_availables` behaviour with combinations (acknowledged in plan)
+
+The plan targets simple products (one `stock_available` row with `id_product_attribute = 0`). The "take first result" strategy in `updateStock` is safe for the current bulk-flow scope. Noted as a known limitation.
+
+---
+
+## Summary
+
+The plan is structurally sound and all referenced CORE contracts exist. The single required correction is the `CategoryProvisioner` dispatch entry (§C1) — without it the capability will be unreachable at runtime even though it's declared in the manifest. All other plan details align with the codebase and the WooCommerce reference. Implementation can proceed after applying that correction.

--- a/docs/plans/implementation-plan-1107-prestashop-product-publisher.md
+++ b/docs/plans/implementation-plan-1107-prestashop-product-publisher.md
@@ -1,0 +1,408 @@
+# Implementation Plan: PrestaShop ProductPublisher + CategoryProvisioner Adapter
+
+**Issue**: #1107
+**Epic**: #1005 / ADR-024 — ShopProductManager capability across shop adapters
+**Branch**: `1107-prestashop-product-publisher`
+**Layer**: Integration — `libs/integrations/prestashop/`
+
+---
+
+## Overview
+
+Add `PrestashopProductPublisherAdapter` implementing `ShopProductManagerPort` and the `CategoryProvisioner` sub-capability. This is the direct PrestaShop sibling of the shipped WooCommerce adapter (#1043), following the same structural pattern and contract surface.
+
+The adapter enables the bulk-offer creation flow to publish products to a PrestaShop master catalog, including hierarchical category provisioning. No CORE changes are required — the contracts (`ShopProductManagerPort`, `CategoryProvisioner`, `ProductPublishRejectedException`) already exist and are stable.
+
+### Primary objectives
+
+1. Implement `publishProduct` — create or upsert a product via the PrestaShop WebService XML API, including multi-category assignment and stock via `stock_availables`.
+2. Implement `provisionCategory` — walk a `ProvisionCategoryCommand.path`, find-or-create each node with exact name + parent match, return the leaf `destinationCategoryId`.
+3. Wire the new adapter into the plugin manifest, dispatch table, and factory.
+
+### Non-goals / deferred
+
+- No media/image upload to PS (WooCommerce uses direct `imageUrls`; PS WS images require multipart; deferred to a follow-up).
+- No PS-specific attribute handling beyond passing raw field values via `platformParams`.
+- No integration tests (pure adapter over a mocked client; unit tests are sufficient).
+- No new DB migrations (pure integration layer).
+
+---
+
+## Architecture & Design
+
+### Layer assignment
+
+| Component | Layer | Package |
+|---|---|---|
+| `PrestashopProductPublisherAdapter` | Integration adapter | `@openlinker/integrations-prestashop` |
+| `prestashop-product-publish.types.ts` | Integration types | `@openlinker/integrations-prestashop` |
+| Plugin wiring (manifest + factory) | Integration plugin | `@openlinker/integrations-prestashop` |
+
+### Ports involved
+
+| Port / Capability | Location | Status |
+|---|---|---|
+| `ShopProductManagerPort` | `libs/core/src/listings/domain/ports/shop-product-manager.port.ts` | Existing — do not modify |
+| `CategoryProvisioner` | `libs/core/src/listings/domain/ports/capabilities/category-provisioner.capability.ts` | Existing — do not modify |
+| `isCategoryProvisioner()` type guard | same file | Existing |
+| `PublishProductCommand` / `PublishProductResult` | `libs/core/src/listings/domain/types/product-publish.types.ts` | Existing |
+| `ProvisionCategoryCommand` / `ProvisionCategoryResult` | `libs/core/src/listings/domain/types/category-provision.types.ts` | Existing |
+| `ProductPublishRejectedException` | `libs/core/src/listings/domain/exceptions/product-publish-rejected.exception.ts` | Existing |
+
+### Key design decisions
+
+**D1 — Stock via `stock_availables`, not inline on the product body.**
+PrestaShop creates a `stock_available` row automatically on product creation; you cannot set `quantity` inline during `createResource('products', ...)`. After create, `listResources('stock_availables', { custom: { 'filter[id_product]': productId } })` returns the auto-generated row, then `updateResource('stock_availables', saId, { id: saId, id_product: productId, quantity: String(cmd.stock) })` sets the quantity. Upsert path (PUT products) must also refresh stock.
+
+**D2 — Language-scoped text fields.**
+PrestaShop WS requires multilingual fields (`name`, `description`, `link_rewrite`, `meta_title`, `meta_description`) as `{ language: [{ '@_id': '1', '#text': value }] }`. The adapter hardcodes language ID `'1'` (the default/primary language). Operators override via `platformParams.languageId` if needed.
+
+**D3 — Multi-category via `associations.categories`.**
+Primary category: `id_category_default`. All assigned categories (including primary): `associations.categories.category` as `[{ id: '12' }, { id: '34' }]`.
+
+**D4 — Error mapping boundary.**
+`PrestashopApiException` with `statusCode >= 400 && statusCode < 500` (excluding `PrestashopAuthenticationException` which is 401) → `ProductPublishRejectedException`. `PrestashopAuthenticationException` and all non-4xx exceptions propagate unchanged — same policy as `WooCommerceProductPublisherAdapter.toPublishError`.
+
+**D5 — `platformParams` passthrough.**
+`cmd.platformParams` fields are spread first onto the product body; explicit mapped fields (price, active, name, etc.) then overwrite any conflicting keys. This matches the WooCommerce reference.
+
+**D6 — Idempotency of `provisionCategory`.**
+The `listResources('categories', ...)` query uses `custom: { 'filter[name]': name, 'filter[id_parent]': String(parentId) }` then exact-name comparison on the result. If the category exists, it is reused; if absent, it is created. This is the same find-or-create pattern as WooCommerce.
+
+---
+
+## Data flow
+
+```
+publishProduct(cmd)
+  ├── externalProductId? → PUT /api/products/{id}   (upsert)
+  │                      → updateStock(productId, cmd.stock)
+  └── (none)            → POST /api/products         (create)
+                         → updateStock(newProductId, cmd.stock)
+
+provisionCategory({ path: [root, ..., leaf] })
+  for each node in path:
+    → listResources('categories', filter[name]+filter[id_parent])
+    → exact match? → reuse id
+    → no match    → createResource('categories', { name, id_parent, link_rewrite, active: '1' })
+  → return { destinationCategoryId: leafId, createdPath?: [...] }
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Wire types
+
+**File**: `libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publish.types.ts`
+
+Define all PS-specific wire shapes used by the adapter. Keep CORE types untouched; these are integration-internal only.
+
+```typescript
+// Language-scoped field helper
+export interface PrestashopLangField {
+  language: Array<{ '@_id': string; '#text': string }>;
+}
+// Build a single-language field value for the default language
+export function langField(value: string, languageId = '1'): PrestashopLangField {
+  return { language: [{ '@_id': languageId, '#text': value }] };
+}
+
+// Minimal request shape for POST/PUT /api/products
+export interface PrestashopProductWriteBody {
+  id?: string | number;
+  name: PrestashopLangField;
+  description?: PrestashopLangField;
+  link_rewrite: PrestashopLangField;
+  price: string;                    // tax-excluded, string per PS WS convention
+  active: '0' | '1';
+  id_category_default: string;
+  associations?: {
+    categories?: { category: Array<{ id: string }> };
+  };
+  meta_title?: PrestashopLangField;
+  meta_description?: PrestashopLangField;
+  [key: string]: unknown;           // platformParams passthrough
+}
+
+// Product response from GET/POST/PUT /api/products
+export interface PrestashopProductResponse {
+  id: string | number;
+  active: string | number;
+  // other fields not needed by the adapter
+}
+
+// Response from GET /api/categories (list item)
+export interface PrestashopCategoryListItem {
+  id: string | number;
+  name: string | PrestashopLangField;
+  id_parent: string | number;
+}
+
+// Response from POST /api/categories
+export interface PrestashopCategoryResponse {
+  id: string | number;
+  name: string | PrestashopLangField;
+  id_parent: string | number;
+}
+
+// stock_available list item
+export interface PrestashopStockAvailableItem {
+  id: string | number;
+  id_product: string | number;
+  quantity: string | number;
+}
+```
+
+**Acceptance criteria**: All types compile under strict mode. No imports from CORE packages (integration-internal).
+
+---
+
+### Phase 2 — Implement the adapter
+
+**File**: `libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts`
+
+```
+PrestashopProductPublisherAdapter
+  implements ShopProductManagerPort, CategoryProvisioner
+
+constructor(
+  private readonly client: IPrestashopWebserviceClient,
+  private readonly connection: Connection,
+)
+```
+
+#### `publishProduct(cmd: PublishProductCommand): Promise<PublishProductResult>`
+
+1. Read `languageId` from `cmd.platformParams?.languageId ?? '1'`.
+2. Build the product body:
+   - Spread `cmd.platformParams` first (un-modeled fields pass through).
+   - Overwrite with mapped fields: `name`, `description` (if `cmd.content?.description`), `link_rewrite` (from SEO slug if present, else slugified title, else `link_rewrite_fallback`), `price` (string `cmd.price.amount.toFixed(2)`), `active` (`cmd.status === 'published' ? '1' : '0'`), `id_category_default` (`cmd.destinationCategoryIds[0]`), `associations.categories.category` (all category IDs mapped to `{ id: String(id) }`).
+3. If `cmd.externalProductId` is set: `updateResource('products', cmd.externalProductId, { id: cmd.externalProductId, ...body })` → then update stock.
+4. Else: `createResource('products', body)` → then update stock.
+5. After create/update, call private `updateStock(productId, cmd.stock)`.
+6. Return `{ externalProductId: String(response.id), status: cmd.status }`.
+7. Wrap in `try/catch`: call `this.toPublishError(err)`.
+
+#### `updateStock(productId: string, quantity: number): Promise<void>` (private)
+
+1. `listResources<PrestashopStockAvailableItem>('stock_availables', { custom: { 'filter[id_product]': productId } })`.
+2. Take first result (PS creates one `stock_available` per product, more for combinations — for simple products there is exactly one with `id_product_attribute = 0`). If none found, log a warning and return (non-fatal; stock may not be managed).
+3. `updateResource('stock_availables', saId, { id: String(sa.id), id_product: productId, quantity: String(quantity) })`.
+
+#### `provisionCategory(cmd: ProvisionCategoryCommand): Promise<ProvisionCategoryResult>`
+
+1. Start with `parentId = '0'` (root) and `createdIds: string[] = []`.
+2. For each node in `cmd.path`:
+   a. `listResources<PrestashopCategoryListItem>('categories', { custom: { 'filter[name]': node.name, 'filter[id_parent]': parentId } })`.
+   b. Find exact name match (compare string form; PS multilingual response may wrap in `langField` shape — extract text with a helper).
+   c. If found: `parentId = String(match.id)`.
+   d. If not found: `createResource('categories', { name: langField(node.name, languageId), id_parent: parentId, link_rewrite: langField(slugify(node.name), languageId), active: '1' })`. Set `parentId = String(newCat.id)`, push to `createdIds`.
+3. Return `{ destinationCategoryId: parentId, createdPath: createdIds.length ? createdIds : undefined }`.
+
+#### `toPublishError(error: unknown): never` (private)
+
+```typescript
+import {
+  PrestashopApiException,
+  PrestashopAuthenticationException,
+} from '@openlinker/integrations-prestashop';
+
+if (
+  error instanceof PrestashopApiException &&
+  !(error instanceof PrestashopAuthenticationException) &&
+  error.statusCode >= 400 &&
+  error.statusCode < 500
+) {
+  throw new ProductPublishRejectedException(
+    'prestashop.webservice.v1',
+    error.statusCode,
+    [{ code: String(error.statusCode), message: error.message }],
+  );
+}
+throw error;
+```
+
+#### Helper: `slugify(text: string): string` (private)
+
+Converts a category name to a PS-compatible `link_rewrite`: lowercase, replace spaces and non-alphanumeric chars with hyphens, deduplicate hyphens, trim. No external deps needed.
+
+#### Helper: `extractLangText(value: string | PrestashopLangField): string` (private)
+
+PS list responses may return `name` as a plain string (when single language and no multilingual config) or as a `PrestashopLangField` struct. This helper handles both.
+
+**Acceptance criteria**:
+- Create path calls `createResource('products', ...)` then `updateStock`.
+- Upsert path calls `updateResource('products', id, ...)` then `updateStock`.
+- `status: 'draft'` maps to `active: '0'`; `status: 'published'` maps to `active: '1'`.
+- `platformParams` fields that don't conflict with mapped fields pass through unchanged.
+- A 400–499 `PrestashopApiException` surfaces as `ProductPublishRejectedException`.
+- A `PrestashopAuthenticationException` (401) is rethrown as-is.
+- A 5xx `PrestashopApiException` is rethrown as-is.
+- `provisionCategory` reuses an existing node by exact name+parent match.
+- `provisionCategory` creates missing nodes and threads `parentId` root-to-leaf.
+
+---
+
+### Phase 3 — Unit tests
+
+**File**: `libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__/prestashop-product-publisher.adapter.spec.ts`
+
+Mock `IPrestashopWebserviceClient` with `jest.fn()` on each method.
+
+#### `publishProduct` test cases
+
+| Test | What it covers |
+|---|---|
+| `should POST a new product and return externalProductId` | create path, `createResource` called, stock updated via `listResources` + `updateResource` |
+| `should PUT to existing id when externalProductId is set (upsert)` | upsert path, `createResource` NOT called, `updateResource` called with product id |
+| `should map status "published" → active "1"` | field mapping |
+| `should map status "draft" → active "0"` | field mapping |
+| `should assign multi-category via associations and set id_category_default to first` | `destinationCategoryIds: ['10', '11']` |
+| `should pass platformParams through without overriding mapped fields` | `platformParams: { active: '0', tax_class: 'reduced' }` — explicit `active` wins; `tax_class` passes through |
+| `should throw ProductPublishRejectedException on 4xx PrestashopApiException` | 400 → rejection |
+| `should propagate PrestashopAuthenticationException (401) unchanged` | 401 → rethrow |
+| `should propagate 5xx PrestashopApiException unchanged` | 503 → rethrow |
+
+#### `provisionCategory` test cases
+
+| Test | What it covers |
+|---|---|
+| `should reuse an existing category by exact name+parent match` | `listResources` returns match → no `createResource` |
+| `should create a missing root category and return its id` | `listResources` returns `[]` → `createResource` called |
+| `should create hierarchical path root→leaf, threading parentId` | two nodes, two `createResource` calls, second call uses first's id as `id_parent` |
+| `should include createdPath only for created nodes` | mixed: root found, leaf created → `createdPath` contains only leaf id |
+
+**Mock setup pattern** (following WooCommerce spec):
+
+```typescript
+function makeClient(): jest.Mocked<IPrestashopWebserviceClient> {
+  return {
+    createResource: jest.fn(),
+    updateResource: jest.fn(),
+    listResources: jest.fn(),
+    getResource: jest.fn(),
+    deleteResource: jest.fn(),
+  };
+}
+```
+
+**Default stock mock**: `listResources` for `stock_availables` returns `[{ id: '1', id_product: '<productId>', quantity: '0' }]`; `updateResource` for `stock_availables` resolves void.
+
+**Acceptance criteria**: All test cases pass with `pnpm test`. Coverage of adapter public methods ≥ 90%.
+
+---
+
+### Phase 4 — Plugin wiring
+
+#### 4a — Extend `PrestashopAdapters` interface
+
+**File**: `libs/integrations/prestashop/src/application/interfaces/prestashop-adapter.factory.interface.ts`
+
+Add:
+```typescript
+import type { PrestashopProductPublisherAdapter } from '../../infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter';
+
+// In PrestashopAdapters:
+productPublisher?: PrestashopProductPublisherAdapter;
+```
+
+#### 4b — Instantiate in factory
+
+**File**: `libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts`
+
+After the existing adapters block (around line 166), add:
+
+```typescript
+const productPublisher = new PrestashopProductPublisherAdapter(httpClient, connection);
+```
+
+Add `productPublisher` to the returned object:
+
+```typescript
+return {
+  productMaster,
+  inventoryMaster,
+  orderSource,
+  orderProcessorManager,
+  productPublisher,
+};
+```
+
+#### 4c — Update plugin manifest and dispatch table
+
+**File**: `libs/integrations/prestashop/src/prestashop-plugin.ts`
+
+1. In `prestashopAdapterManifest.supportedCapabilities`, add `'ProductPublisher'` and `'CategoryProvisioner'`:
+
+```typescript
+supportedCapabilities: [
+  'ProductMaster',
+  'InventoryMaster',
+  'OrderSource',
+  'OrderProcessorManager',
+  'ProductPublisher',
+  'CategoryProvisioner',
+],
+```
+
+2. In `createCapabilityAdapter`, add `ProductPublisher` to the dispatch table:
+
+```typescript
+ProductPublisher: () => adapters.productPublisher,
+```
+
+Note: `CategoryProvisioner` does not need its own dispatch entry — it is a sub-capability of `ProductPublisher`, narrowed by `isCategoryProvisioner(adapter)` at call sites. The manifest declares it so that `IntegrationsService.getCapabilityAdapter` resolves it, but the adapter is retrieved via `ProductPublisher` and the type guard narrows it. This is identical to how `OfferCreator` relates to `OfferManagerPort` in the Allegro adapter.
+
+**Acceptance criteria**:
+- `prestashopAdapterManifest.supportedCapabilities` includes `'ProductPublisher'` and `'CategoryProvisioner'`.
+- `createCapabilityAdapter('ProductPublisher', ...)` returns the `PrestashopProductPublisherAdapter` instance.
+- `isCategoryProvisioner(adapter)` returns `true` for the returned adapter (because it implements `provisionCategory`).
+
+---
+
+## Validation Checklist
+
+- [x] Follows hexagonal architecture: adapter in `libs/integrations/prestashop/`, no domain logic, no CORE mutations
+- [x] Respects CORE vs Integration boundary: ports and exception types imported from `@openlinker/core/listings`; infrastructure exceptions from `@openlinker/integrations-prestashop`
+- [x] Uses existing patterns: mirrors `WooCommerceProductPublisherAdapter` structure exactly; reuses `IPrestashopWebserviceClient`
+- [x] Idempotency: `provisionCategory` is find-or-create (safe to retry); `publishProduct` with `externalProductId` is a PUT (idempotent upsert)
+- [x] Error handling: 4xx → `ProductPublishRejectedException`; 401 / 5xx propagate
+- [x] Testing strategy: unit tests with mocked client; covers create, upsert, status, multi-category, category find-or-create, all error branches
+- [x] Naming conventions: `PrestashopProductPublisherAdapter`, `prestashop-product-publisher.adapter.ts`, `prestashop-product-publish.types.ts`
+- [x] File structure: `infrastructure/adapters/product-publisher/` folder, `__tests__/` subfolder
+- [x] No migrations needed (no ORM entities changed)
+- [x] TypeScript strict mode: explicit return types on all public methods, no `any`
+- [x] No `console.log` — no logging needed in this adapter (errors propagate; the caller logs)
+- [x] `pnpm lint && pnpm type-check && pnpm test` must be green before commit
+
+---
+
+## Questions & Assumptions
+
+**Q1 — Language ID hardcoding.**
+Assumed `languageId = '1'` is the default PS language. Operators who have a non-default primary language can pass `platformParams.languageId` to override. This is the simplest approach; a configurable default can be added to `PrestashopConnectionConfig` in a follow-up.
+
+**Q2 — Image upload.**
+PS WS image upload is a multipart `POST /api/images/products/{id}` — structurally different from WooCommerce's `imageUrls` array. Deferred. The adapter ignores `cmd.content?.imageUrls` for now.
+
+**Q3 — `stock_availables` for products with combinations.**
+A PS product with attribute combinations generates multiple `stock_available` rows (one per combination). This adapter targets simple products (the bulk-flow maps one variant → one product). `updateStock` takes the first row with `id_product_attribute = '0'` if multiple rows are present, which corresponds to the simple/master stock. This assumption is documented inline.
+
+**Q4 — `CategoryProvisioner` in manifest vs dispatch.**
+Confirmed by cross-referencing `AllegroOfferManagerAdapter`: sub-capabilities (`OfferCreator`, `CategoryBrowser`, etc.) appear in `supportedCapabilities` but share the parent adapter's dispatch entry (`OfferManager`). Same pattern applies here: `CategoryProvisioner` is in the manifest, resolved via `ProductPublisher` dispatch + `isCategoryProvisioner` guard.
+
+---
+
+## File Summary
+
+| Action | File |
+|---|---|
+| **Create** | `libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publish.types.ts` |
+| **Create** | `libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts` |
+| **Create** | `libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__/prestashop-product-publisher.adapter.spec.ts` |
+| **Modify** | `libs/integrations/prestashop/src/application/interfaces/prestashop-adapter.factory.interface.ts` |
+| **Modify** | `libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts` |
+| **Modify** | `libs/integrations/prestashop/src/prestashop-plugin.ts` |
+
+No migrations. No CORE changes. No frontend changes.

--- a/docs/plans/implementation-plan-1107-prestashop-product-publisher.md
+++ b/docs/plans/implementation-plan-1107-prestashop-product-publisher.md
@@ -352,7 +352,14 @@ supportedCapabilities: [
 ProductPublisher: () => adapters.productPublisher,
 ```
 
-Note: `CategoryProvisioner` does not need its own dispatch entry — it is a sub-capability of `ProductPublisher`, narrowed by `isCategoryProvisioner(adapter)` at call sites. The manifest declares it so that `IntegrationsService.getCapabilityAdapter` resolves it, but the adapter is retrieved via `ProductPublisher` and the type guard narrows it. This is identical to how `OfferCreator` relates to `OfferManagerPort` in the Allegro adapter.
+Note: `CategoryProvisioner` **does** need its own dispatch entry alongside `ProductPublisher`. `IntegrationsService.getCapabilityAdapter` resolves adapters by capability string directly — without a `CategoryProvisioner` entry in the dispatch table, `dispatchCapability` throws "adapter does not support capability: CategoryProvisioner" even though the adapter implements `provisionCategory`. The dispatch table therefore maps both strings to the same adapter instance:
+
+```typescript
+ProductPublisher: () => adapters.productPublisher,
+CategoryProvisioner: () => adapters.productPublisher,
+```
+
+This differs from Allegro's `OfferCreator` pattern (which shares the `OfferManager` dispatch entry and is narrowed by type guard at call sites) — here `CategoryProvisioner` is resolved as a first-class capability string, so it must have its own entry.
 
 **Acceptance criteria**:
 - `prestashopAdapterManifest.supportedCapabilities` includes `'ProductPublisher'` and `'CategoryProvisioner'`.
@@ -390,7 +397,7 @@ PS WS image upload is a multipart `POST /api/images/products/{id}` — structura
 A PS product with attribute combinations generates multiple `stock_available` rows (one per combination). This adapter targets simple products (the bulk-flow maps one variant → one product). `updateStock` takes the first row with `id_product_attribute = '0'` if multiple rows are present, which corresponds to the simple/master stock. This assumption is documented inline.
 
 **Q4 — `CategoryProvisioner` in manifest vs dispatch.**
-Confirmed by cross-referencing `AllegroOfferManagerAdapter`: sub-capabilities (`OfferCreator`, `CategoryBrowser`, etc.) appear in `supportedCapabilities` but share the parent adapter's dispatch entry (`OfferManager`). Same pattern applies here: `CategoryProvisioner` is in the manifest, resolved via `ProductPublisher` dispatch + `isCategoryProvisioner` guard.
+Unlike Allegro's sub-capabilities (`OfferCreator`, `CategoryBrowser`, etc.) which share the `OfferManager` dispatch entry and are narrowed by type guard at call sites, `CategoryProvisioner` here **requires its own dispatch entry**. `IntegrationsService.getCapabilityAdapter('CategoryProvisioner', ...)` resolves by capability string; without a matching entry in the dispatch table, `dispatchCapability` throws at runtime. The shipped `prestashop-plugin.ts` therefore maps both `ProductPublisher` and `CategoryProvisioner` to the same `adapters.productPublisher` instance.
 
 ---
 

--- a/libs/integrations/prestashop/src/__tests__/prestashop-plugin.spec.ts
+++ b/libs/integrations/prestashop/src/__tests__/prestashop-plugin.spec.ts
@@ -127,12 +127,53 @@ describe('createPrestashopPlugin → createCapabilityAdapter', () => {
     expect(adapter).toBe(stubOpm);
   });
 
+  it('returns the productPublisher adapter for capability=ProductPublisher', async () => {
+    const stubProductPublisher = { kind: 'productPublisher' };
+    jest.spyOn(PrestashopAdapterFactory.prototype, 'createAdapters').mockResolvedValue({
+      productMaster: {},
+      inventoryMaster: {},
+      orderSource: {},
+      orderProcessorManager: undefined,
+      productPublisher: stubProductPublisher,
+    } as unknown as PrestashopAdapters);
+
+    const plugin = createPrestashopPlugin(makeDeps());
+    const adapter = await plugin.createCapabilityAdapter(
+      makeConnection(),
+      'ProductPublisher',
+      makeHost(),
+    );
+
+    expect(adapter).toBe(stubProductPublisher);
+  });
+
+  it('returns the productPublisher adapter for capability=CategoryProvisioner', async () => {
+    const stubProductPublisher = { kind: 'productPublisher' };
+    jest.spyOn(PrestashopAdapterFactory.prototype, 'createAdapters').mockResolvedValue({
+      productMaster: {},
+      inventoryMaster: {},
+      orderSource: {},
+      orderProcessorManager: undefined,
+      productPublisher: stubProductPublisher,
+    } as unknown as PrestashopAdapters);
+
+    const plugin = createPrestashopPlugin(makeDeps());
+    const adapter = await plugin.createCapabilityAdapter(
+      makeConnection(),
+      'CategoryProvisioner',
+      makeHost(),
+    );
+
+    expect(adapter).toBe(stubProductPublisher);
+  });
+
   it('throws for an unsupported capability via the dispatchCapability helper', async () => {
     jest.spyOn(PrestashopAdapterFactory.prototype, 'createAdapters').mockResolvedValue({
       productMaster: {},
       inventoryMaster: {},
       orderSource: {},
       orderProcessorManager: undefined,
+      productPublisher: {},
     } as unknown as PrestashopAdapters);
 
     const plugin = createPrestashopPlugin(makeDeps());
@@ -141,7 +182,7 @@ describe('createPrestashopPlugin → createCapabilityAdapter', () => {
       plugin.createCapabilityAdapter(makeConnection(), 'OfferManager', makeHost()),
     ).rejects.toThrow(
       'PrestaShop adapter does not support capability: OfferManager. ' +
-        'Supported capabilities: ProductMaster, InventoryMaster, OrderSource, OrderProcessorManager',
+        'Supported capabilities: ProductMaster, InventoryMaster, OrderSource, OrderProcessorManager, ProductPublisher, CategoryProvisioner',
     );
   });
 });

--- a/libs/integrations/prestashop/src/application/__tests__/prestashop-adapter.factory.spec.ts
+++ b/libs/integrations/prestashop/src/application/__tests__/prestashop-adapter.factory.spec.ts
@@ -73,6 +73,7 @@ describe('PrestashopAdapterFactory', () => {
       expect(adapters.productMaster).toBeDefined();
       expect(adapters.inventoryMaster).toBeDefined();
       expect(adapters.orderSource).toBeDefined();
+      expect(adapters.productPublisher).toBeDefined();
     });
 
     it('should resolve credentials', async () => {

--- a/libs/integrations/prestashop/src/application/interfaces/prestashop-adapter.factory.interface.ts
+++ b/libs/integrations/prestashop/src/application/interfaces/prestashop-adapter.factory.interface.ts
@@ -17,6 +17,8 @@ import type { PrestashopInventoryMasterAdapter } from '../../infrastructure/adap
 import type { PrestashopOrderSourceAdapter } from '../../infrastructure/adapters/prestashop-order-source.adapter';
 // eslint-disable-next-line no-restricted-imports -- local relative import is intentional here; barrel path would create a runtime cycle
 import type { PrestashopOrderProcessorManagerAdapter } from '../../infrastructure/adapters/prestashop-order-processor-manager.adapter';
+// eslint-disable-next-line no-restricted-imports -- local relative import is intentional here; barrel path would create a runtime cycle
+import type { PrestashopProductPublisherAdapter } from '../../infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter';
 
 /**
  * PrestaShop adapter instances
@@ -30,6 +32,7 @@ export interface PrestashopAdapters {
   inventoryMaster: PrestashopInventoryMasterAdapter;
   orderSource: PrestashopOrderSourceAdapter;
   orderProcessorManager?: PrestashopOrderProcessorManagerAdapter;
+  productPublisher?: PrestashopProductPublisherAdapter;
 }
 
 /**

--- a/libs/integrations/prestashop/src/application/interfaces/prestashop-adapter.factory.interface.ts
+++ b/libs/integrations/prestashop/src/application/interfaces/prestashop-adapter.factory.interface.ts
@@ -45,7 +45,7 @@ export interface IPrestashopAdapterFactory {
    * Create all PrestaShop adapters for a connection
    *
    * Validates connection configuration and credentials, then creates
-   * all capability adapters (ProductMaster, InventoryMaster, OrderSource, OrderProcessorManager).
+   * all capability adapters (ProductMaster, InventoryMaster, OrderSource, OrderProcessorManager, ProductPublisher).
    *
    * @param connection - Connection entity
    * @param identifierMapping - Identifier mapping service

--- a/libs/integrations/prestashop/src/application/interfaces/prestashop-adapter.factory.interface.ts
+++ b/libs/integrations/prestashop/src/application/interfaces/prestashop-adapter.factory.interface.ts
@@ -32,7 +32,7 @@ export interface PrestashopAdapters {
   inventoryMaster: PrestashopInventoryMasterAdapter;
   orderSource: PrestashopOrderSourceAdapter;
   orderProcessorManager?: PrestashopOrderProcessorManagerAdapter;
-  productPublisher?: PrestashopProductPublisherAdapter;
+  productPublisher: PrestashopProductPublisherAdapter;
 }
 
 /**

--- a/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
+++ b/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
@@ -29,6 +29,7 @@ import { PrestashopProductMasterAdapter } from '../infrastructure/adapters/prest
 import { PrestashopInventoryMasterAdapter } from '../infrastructure/adapters/prestashop-inventory-master.adapter';
 import { PrestashopOrderSourceAdapter } from '../infrastructure/adapters/prestashop-order-source.adapter';
 import { PrestashopOrderProcessorManagerAdapter } from '../infrastructure/adapters/prestashop-order-processor-manager.adapter';
+import { PrestashopProductPublisherAdapter } from '../infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter';
 import type { PrestashopCustomerProvisioner } from '../infrastructure/provisioners/prestashop-customer-provisioner';
 import { PrestashopAddressProvisioner } from '../infrastructure/provisioners/prestashop-address-provisioner';
 import { PrestashopCountryResolver } from '../infrastructure/provisioners/prestashop-country-resolver';
@@ -164,6 +165,8 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
       );
     }
 
+    const productPublisher = new PrestashopProductPublisherAdapter(httpClient, connection);
+
     this.logger.log(`PrestaShop adapters created successfully for connection: ${connection.id}`);
 
     return {
@@ -171,6 +174,7 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
       inventoryMaster,
       orderSource,
       orderProcessorManager,
+      productPublisher,
     };
   }
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__/prestashop-product-publisher.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__/prestashop-product-publisher.adapter.spec.ts
@@ -239,6 +239,56 @@ describe('PrestashopProductPublisherAdapter', () => {
         ProductPublishRejectedException,
       );
     });
+
+    it('should emit a warning when imageUrls are provided (v1 deferral)', async () => {
+      client.createResource.mockResolvedValue({ id: '1', active: '1' });
+      withDefaultStockMock(client);
+
+      const result = await adapter.publishProduct(
+        baseCommand({
+          content: { title: 'Widget', description: 'A widget', imageUrls: ['https://example.com/img.jpg'] },
+        }),
+      );
+
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([expect.stringContaining('imageUrls')]),
+      );
+      expect(result.externalProductId).toBe('1');
+    });
+
+    it('should emit a warning when parameters are provided (v1 deferral)', async () => {
+      client.createResource.mockResolvedValue({ id: '1', active: '1' });
+      withDefaultStockMock(client);
+
+      const result = await adapter.publishProduct(
+        baseCommand({ parameters: [{ id: 'brand', values: ['Acme'], section: 'offer' }] }),
+      );
+
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([expect.stringContaining('parameters')]),
+      );
+    });
+
+    it('should derive result status from response.active, not cmd.status', async () => {
+      // PS echoes back the persisted state; the contract requires observing it.
+      client.createResource.mockResolvedValue({ id: '1', active: '0' }); // PS persisted draft
+      withDefaultStockMock(client);
+
+      const result = await adapter.publishProduct(baseCommand({ status: 'published' }));
+
+      expect(result.status).toBe('draft');
+    });
+
+    it('should use rootCategoryId sentinel (2) when destinationCategoryIds is empty', async () => {
+      client.createResource.mockResolvedValue({ id: '1', active: '1' });
+      withDefaultStockMock(client);
+
+      await adapter.publishProduct(baseCommand({ destinationCategoryIds: [] }));
+
+      const body = client.createResource.mock.calls[0][1];
+      // '0' is not a valid PS parent; Home (id 2) is the first visible level
+      expect(body.id_category_default).toBe('2');
+    });
   });
 
   describe('provisionCategory', () => {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__/prestashop-product-publisher.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__/prestashop-product-publisher.adapter.spec.ts
@@ -1,0 +1,307 @@
+/**
+ * PrestaShop Product Publisher Adapter — unit spec
+ *
+ * Covers `publishProduct` (create vs upsert, status mapping, multi-category,
+ * platformParams passthrough, 4xx → rejection, 5xx propagation, 401 propagation)
+ * and `provisionCategory` (find-vs-create, hierarchical parent threading, mixed
+ * found/created path). WebService client is mocked.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__
+ */
+import {
+  ProductPublishRejectedException,
+  type PublishProductCommand,
+} from '@openlinker/core/listings';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { PrestashopApiException, PrestashopAuthenticationException } from '@openlinker/integrations-prestashop';
+
+import type { IPrestashopWebserviceClient } from '../../../http/prestashop-webservice.client.interface';
+import { PrestashopProductPublisherAdapter } from '../prestashop-product-publisher.adapter';
+
+const CONNECTION_ID = 'conn-ps-1';
+
+function makeClient(): jest.Mocked<IPrestashopWebserviceClient> {
+  return {
+    getResource: jest.fn(),
+    listResources: jest.fn(),
+    createResource: jest.fn(),
+    updateResource: jest.fn(),
+    deleteResource: jest.fn(),
+  };
+}
+
+const connection: Connection = {
+  id: CONNECTION_ID,
+  platformType: 'prestashop',
+  name: 'Test PS',
+  status: 'active',
+  config: { baseUrl: 'https://shop.example', langId: 1 } as Record<string, unknown>,
+  credentialsRef: 'cred-1',
+  adapterKey: 'prestashop.webservice.v1',
+  enabledCapabilities: ['ProductPublisher', 'CategoryProvisioner'],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as unknown as Connection;
+
+function baseCommand(overrides: Partial<PublishProductCommand> = {}): PublishProductCommand {
+  return {
+    internalVariantId: 'ol_variant_aaaa',
+    connectionId: CONNECTION_ID,
+    destinationCategoryIds: ['12'],
+    price: { amount: 19.99, currency: 'PLN' },
+    stock: 5,
+    status: 'published',
+    content: { title: 'Widget', description: 'A widget' },
+    ...overrides,
+  };
+}
+
+/** Wire up default stock_availables mock so publishProduct tests don't fail on stock update. */
+function withDefaultStockMock(client: jest.Mocked<IPrestashopWebserviceClient>): void {
+  client.listResources.mockImplementation((resource) => {
+    if (resource === 'stock_availables') {
+      return Promise.resolve([{ id: '1', id_product: '100', quantity: '0' }]);
+    }
+    return Promise.resolve([]);
+  });
+  client.updateResource.mockResolvedValue({ id: '1' });
+}
+
+describe('PrestashopProductPublisherAdapter', () => {
+  let client: jest.Mocked<IPrestashopWebserviceClient>;
+  let adapter: PrestashopProductPublisherAdapter;
+
+  beforeEach(() => {
+    client = makeClient();
+    adapter = new PrestashopProductPublisherAdapter(client, connection);
+  });
+
+  describe('publishProduct', () => {
+    it('should POST a new product and return externalProductId', async () => {
+      client.createResource.mockResolvedValue({ id: '100', active: '1' });
+      withDefaultStockMock(client);
+
+      const result = await adapter.publishProduct(baseCommand());
+
+      expect(client.createResource).toHaveBeenCalledTimes(1);
+      const [resource, body] = client.createResource.mock.calls[0];
+      expect(resource).toBe('products');
+      expect(body).toMatchObject({
+        price: '19.99',
+        active: '1',
+        id_category_default: '12',
+      });
+      expect(result).toEqual({ externalProductId: '100', status: 'published' });
+    });
+
+    it('should PUT to existing id when externalProductId is set (upsert)', async () => {
+      client.updateResource
+        .mockResolvedValueOnce({ id: '100', active: '0' }) // product update
+        .mockResolvedValueOnce({ id: '1' }); // stock update
+      client.listResources.mockResolvedValue([{ id: '1', id_product: '100', quantity: '0' }]);
+
+      const result = await adapter.publishProduct(
+        baseCommand({ externalProductId: '100', status: 'draft' }),
+      );
+
+      expect(client.createResource).not.toHaveBeenCalled();
+      expect(client.updateResource).toHaveBeenNthCalledWith(
+        1,
+        'products',
+        '100',
+        expect.objectContaining({ id: '100', active: '0' }),
+      );
+      expect(result).toEqual({ externalProductId: '100', status: 'draft' });
+    });
+
+    it('should map status "published" → active "1"', async () => {
+      client.createResource.mockResolvedValue({ id: '1', active: '1' });
+      withDefaultStockMock(client);
+
+      await adapter.publishProduct(baseCommand({ status: 'published' }));
+
+      const body = client.createResource.mock.calls[0][1];
+      expect(body.active).toBe('1');
+    });
+
+    it('should map status "draft" → active "0"', async () => {
+      client.createResource.mockResolvedValue({ id: '1', active: '0' });
+      withDefaultStockMock(client);
+
+      await adapter.publishProduct(baseCommand({ status: 'draft' }));
+
+      const body = client.createResource.mock.calls[0][1];
+      expect(body.active).toBe('0');
+    });
+
+    it('should assign multi-category via associations and set id_category_default to first', async () => {
+      client.createResource.mockResolvedValue({ id: '1', active: '1' });
+      withDefaultStockMock(client);
+
+      await adapter.publishProduct(
+        baseCommand({ destinationCategoryIds: ['10', '11'] }),
+      );
+
+      const body = client.createResource.mock.calls[0][1];
+      expect(body.id_category_default).toBe('10');
+      expect((body.associations as Record<string, unknown>)?.categories).toEqual({
+        category: [{ id: '10' }, { id: '11' }],
+      });
+    });
+
+    it('should pass platformParams through without overriding mapped fields', async () => {
+      client.createResource.mockResolvedValue({ id: '1', active: '1' });
+      withDefaultStockMock(client);
+
+      await adapter.publishProduct(
+        baseCommand({ platformParams: { active: '0', id_manufacturer: '5' } }),
+      );
+
+      const body = client.createResource.mock.calls[0][1];
+      // Explicit mapped `active` wins over platformParams
+      expect(body.active).toBe('1');
+      // Un-modeled knob passes through
+      expect(body.id_manufacturer).toBe('5');
+    });
+
+    it('should update stock after product creation', async () => {
+      client.createResource.mockResolvedValue({ id: '42', active: '1' });
+      client.listResources.mockResolvedValue([{ id: '7', id_product: '42', quantity: '0' }]);
+      client.updateResource.mockResolvedValue({ id: '7' });
+
+      await adapter.publishProduct(baseCommand({ stock: 10 }));
+
+      expect(client.listResources).toHaveBeenCalledWith(
+        'stock_availables',
+        expect.objectContaining({ custom: { 'filter[id_product]': '42' } }),
+      );
+      expect(client.updateResource).toHaveBeenCalledWith(
+        'stock_availables',
+        '7',
+        expect.objectContaining({ id: '7', id_product: '42', quantity: '10' }),
+      );
+    });
+
+    it('should resolve successfully and not call updateResource when no stock_available row exists', async () => {
+      client.createResource.mockResolvedValue({ id: '55', active: '1' });
+      client.listResources.mockResolvedValue([]);
+
+      const result = await adapter.publishProduct(baseCommand({ stock: 3 }));
+
+      expect(result).toEqual({ externalProductId: '55', status: 'published' });
+      expect(client.updateResource).not.toHaveBeenCalled();
+    });
+
+    it('should throw ProductPublishRejectedException on 4xx PrestashopApiException', async () => {
+      client.createResource.mockRejectedValue(
+        new PrestashopApiException('Invalid product data', 400),
+      );
+
+      await expect(adapter.publishProduct(baseCommand())).rejects.toMatchObject({
+        name: 'ProductPublishRejectedException',
+        statusCode: 400,
+      });
+      await expect(adapter.publishProduct(baseCommand())).rejects.toBeInstanceOf(
+        ProductPublishRejectedException,
+      );
+    });
+
+    it('should propagate PrestashopAuthenticationException (401) unchanged', async () => {
+      const err = new PrestashopAuthenticationException('Unauthorized', CONNECTION_ID);
+      client.createResource.mockRejectedValue(err);
+
+      await expect(adapter.publishProduct(baseCommand())).rejects.toBe(err);
+      await expect(adapter.publishProduct(baseCommand())).rejects.not.toBeInstanceOf(
+        ProductPublishRejectedException,
+      );
+    });
+
+    it('should propagate 5xx PrestashopApiException unchanged', async () => {
+      const err = new PrestashopApiException('Gateway timeout', 503);
+      client.createResource.mockRejectedValue(err);
+
+      await expect(adapter.publishProduct(baseCommand())).rejects.toBe(err);
+      await expect(adapter.publishProduct(baseCommand())).rejects.not.toBeInstanceOf(
+        ProductPublishRejectedException,
+      );
+    });
+  });
+
+  describe('provisionCategory', () => {
+    it('should reuse an existing category by exact name+parent match', async () => {
+      client.listResources.mockResolvedValue([
+        { id: '5', name: 'Gadgets', id_parent: '0' },
+        { id: '6', name: 'Gadgets Pro', id_parent: '0' }, // near-match, must not reuse
+      ]);
+
+      const result = await adapter.provisionCategory({
+        connectionId: CONNECTION_ID,
+        path: [{ sourceCategoryId: 'src-1', name: 'Gadgets' }],
+      });
+
+      expect(client.createResource).not.toHaveBeenCalled();
+      expect(result).toEqual({ destinationCategoryId: '5' });
+    });
+
+    it('should create a missing root category and return its id', async () => {
+      client.listResources.mockResolvedValue([]);
+      client.createResource.mockResolvedValue({ id: '10', name: 'Electronics', id_parent: '0' });
+
+      const result = await adapter.provisionCategory({
+        connectionId: CONNECTION_ID,
+        path: [{ sourceCategoryId: 'r', name: 'Electronics' }],
+      });
+
+      expect(client.createResource).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ destinationCategoryId: '10', createdPath: ['10'] });
+    });
+
+    it('should create hierarchical path root→leaf, threading parentId', async () => {
+      client.listResources.mockResolvedValue([]);
+      client.createResource
+        .mockResolvedValueOnce({ id: '10', name: 'Electronics', id_parent: '0' })
+        .mockResolvedValueOnce({ id: '11', name: 'Phones', id_parent: '10' });
+
+      const result = await adapter.provisionCategory({
+        connectionId: CONNECTION_ID,
+        path: [
+          { sourceCategoryId: 'r', name: 'Electronics' },
+          { sourceCategoryId: 'l', name: 'Phones' },
+        ],
+      });
+
+      expect(client.createResource).toHaveBeenNthCalledWith(
+        1,
+        'categories',
+        expect.objectContaining({ id_parent: '0' }),
+      );
+      expect(client.createResource).toHaveBeenNthCalledWith(
+        2,
+        'categories',
+        expect.objectContaining({ id_parent: '10' }),
+      );
+      expect(result).toEqual({ destinationCategoryId: '11', createdPath: ['10', '11'] });
+    });
+
+    it('should include createdPath only for created nodes (mixed found/created)', async () => {
+      client.listResources
+        .mockResolvedValueOnce([{ id: '5', name: 'Gadgets', id_parent: '0' }]) // root found
+        .mockResolvedValueOnce([]); // leaf absent
+      client.createResource.mockResolvedValue({
+        id: '20',
+        name: 'Smart Gadgets',
+        id_parent: '5',
+      });
+
+      const result = await adapter.provisionCategory({
+        connectionId: CONNECTION_ID,
+        path: [
+          { sourceCategoryId: 'r', name: 'Gadgets' },
+          { sourceCategoryId: 'l', name: 'Smart Gadgets' },
+        ],
+      });
+
+      expect(result).toEqual({ destinationCategoryId: '20', createdPath: ['20'] });
+    });
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__/prestashop-product-publisher.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__/prestashop-product-publisher.adapter.spec.ts
@@ -192,6 +192,20 @@ describe('PrestashopProductPublisherAdapter', () => {
       expect(client.updateResource).not.toHaveBeenCalled();
     });
 
+    it('should resolve successfully when stock_availables WS call throws (best-effort stock)', async () => {
+      // If updateStock throws, publishProduct must still return the result so that the
+      // core service can persist the identifier mapping. A raw throw would prevent mapping
+      // persistence and cause the next retry to call createResource again, producing a
+      // duplicate orphaned PS product.
+      client.createResource.mockResolvedValue({ id: '77', active: '1' });
+      client.listResources.mockRejectedValue(new PrestashopApiException('WS error', 503));
+
+      const result = await adapter.publishProduct(baseCommand({ stock: 5 }));
+
+      expect(result).toEqual({ externalProductId: '77', status: 'published' });
+      expect(client.updateResource).not.toHaveBeenCalled();
+    });
+
     it('should throw ProductPublishRejectedException on 4xx PrestashopApiException', async () => {
       client.createResource.mockRejectedValue(
         new PrestashopApiException('Invalid product data', 400),
@@ -273,7 +287,8 @@ describe('PrestashopProductPublisherAdapter', () => {
       expect(client.createResource).toHaveBeenNthCalledWith(
         1,
         'categories',
-        expect.objectContaining({ id_parent: '0' }),
+        // root sentinel is PS Home (id 2), not 0 — see provisionCategory comment
+        expect.objectContaining({ id_parent: '2' }),
       );
       expect(client.createResource).toHaveBeenNthCalledWith(
         2,

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publish.types.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publish.types.ts
@@ -15,14 +15,6 @@ export interface PrestashopLangField {
 }
 
 /**
- * Build a single-language text value for PS WS multilingual fields.
- * Defaults to language ID `'1'` (primary language).
- */
-export function langField(value: string, languageId = '1'): PrestashopLangField {
-  return { language: [{ '@_id': languageId, '#text': value }] };
-}
-
-/**
  * Minimal request body for POST/PUT /api/products.
  *
  * A permissive index signature lets `platformParams` merge un-modeled fields

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publish.types.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publish.types.ts
@@ -1,0 +1,74 @@
+/**
+ * PrestaShop Product-Publish Wire Types
+ *
+ * Request/response shapes for the PrestaShop WebService API `products`,
+ * `categories`, and `stock_availables` resources, as used by
+ * `PrestashopProductPublisherAdapter` (#1107). Integration-internal only —
+ * CORE types are not modified.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/adapters/product-publisher
+ */
+
+/** Language-scoped text field, as required by the PrestaShop WebService multilingual API. */
+export interface PrestashopLangField {
+  language: Array<{ '@_id': string; '#text': string }>;
+}
+
+/**
+ * Build a single-language text value for PS WS multilingual fields.
+ * Defaults to language ID `'1'` (primary language).
+ */
+export function langField(value: string, languageId = '1'): PrestashopLangField {
+  return { language: [{ '@_id': languageId, '#text': value }] };
+}
+
+/**
+ * Minimal request body for POST/PUT /api/products.
+ *
+ * A permissive index signature lets `platformParams` merge un-modeled fields
+ * (e.g. `id_manufacturer`, `weight`) without widening the typed surface.
+ * Explicit, modelled fields always win over any un-modeled key.
+ */
+export interface PrestashopProductWriteBody {
+  id?: string | number;
+  name: PrestashopLangField;
+  description?: PrestashopLangField;
+  link_rewrite: PrestashopLangField;
+  /** Tax-excluded price; PS WS convention uses a decimal string. */
+  price: string;
+  active: '0' | '1';
+  id_category_default: string;
+  associations?: {
+    categories?: { category: Array<{ id: string }> };
+  };
+  meta_title?: PrestashopLangField;
+  meta_description?: PrestashopLangField;
+  [key: string]: unknown;
+}
+
+/** Minimal product response from GET/POST/PUT /api/products. */
+export interface PrestashopProductResponse {
+  id: string | number;
+  active: string | number;
+}
+
+/** Category item from GET /api/categories (list response). */
+export interface PrestashopCategoryListItem {
+  id: string | number;
+  name: string | PrestashopLangField;
+  id_parent: string | number;
+}
+
+/** Response from POST /api/categories. */
+export interface PrestashopCategoryResponse {
+  id: string | number;
+  name: string | PrestashopLangField;
+  id_parent: string | number;
+}
+
+/** Item from GET /api/stock_availables (list response). */
+export interface PrestashopStockAvailableItem {
+  id: string | number;
+  id_product: string | number;
+  quantity: string | number;
+}

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts
@@ -92,7 +92,13 @@ export class PrestashopProductPublisherAdapter
     const languageId = String(
       (this.connection.config?.langId as number | undefined) ?? 1,
     );
-    let parentId = '0'; // PS WS root sentinel
+    // PS category tree: id 1 = Root (hidden), id 2 = Home (first visible level).
+    // Creating under id_parent='0' is not a valid PS parent and may be rejected or
+    // land outside the visible tree. Default to Home (2); operators with a custom
+    // root can set connection.config.rootCategoryId to override.
+    let parentId = String(
+      (this.connection.config?.rootCategoryId as number | string | undefined) ?? 2,
+    );
     const createdPath: string[] = [];
 
     for (const node of cmd.path) {
@@ -163,24 +169,35 @@ export class PrestashopProductPublisherAdapter
   }
 
   private async updateStock(productId: string, quantity: number): Promise<void> {
-    const rows = await this.client.listResources<PrestashopStockAvailableItem>('stock_availables', {
-      custom: { 'filter[id_product]': productId },
-    });
+    // Fully best-effort: PS creates the product before returning, so if any step here
+    // throws the core service won't persist the identifier mapping and the retry will
+    // call createResource again — producing a duplicate orphaned PS product. An unset
+    // stock heals on the next inventory sync; a duplicate product has no auto-recovery.
+    try {
+      const rows = await this.client.listResources<PrestashopStockAvailableItem>('stock_availables', {
+        custom: { 'filter[id_product]': productId },
+      });
 
-    const row = rows[0];
-    if (!row) {
+      const row = rows[0];
+      if (!row) {
+        this.logger.warn(
+          `No stock_available row found for product ${productId} on connection ${this.connection.id} — stock not updated.`,
+        );
+        return;
+      }
+
+      const saId = String(row.id);
+      await this.client.updateResource('stock_availables', saId, {
+        id: saId,
+        id_product: productId,
+        quantity: String(quantity),
+      });
+    } catch (err) {
       this.logger.warn(
-        `No stock_available row found for product ${productId} on connection ${this.connection.id} — stock not updated.`,
+        `Stock update failed for product ${productId} on connection ${this.connection.id} — left unset. Will self-heal on next inventory sync.`,
+        (err as Error).stack,
       );
-      return;
     }
-
-    const saId = String(row.id);
-    await this.client.updateResource('stock_availables', saId, {
-      id: saId,
-      id_product: productId,
-      quantity: String(quantity),
-    });
   }
 
   private toPublishError(error: unknown): never {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts
@@ -24,6 +24,7 @@ import {
   type ProvisionCategoryResult,
   type PublishProductCommand,
   type PublishProductResult,
+  type PublishProductStatus,
   type ShopProductManagerPort,
 } from '@openlinker/core/listings';
 import { PrestashopApiException } from '@openlinker/integrations-prestashop';
@@ -59,6 +60,31 @@ export class PrestashopProductPublisherAdapter
       cmd.platformParams?.languageId ?? (this.connection.config?.langId as number | undefined) ?? 1,
     );
 
+    // Collect v1 deferral warnings before the API call so the caller knows what was skipped.
+    const warnings: string[] = [];
+
+    // v1 deferral: PS WS images require binary multipart upload to
+    // /images/products/{id} — unlike WooCommerce's URL reference model, each
+    // image needs a separate POST with raw bytes. Not yet implemented; the
+    // operator is warned so products are not silently image-less.
+    if (cmd.content?.imageUrls != null && cmd.content.imageUrls.length > 0) {
+      warnings.push(
+        'imageUrls: image upload is not yet supported for PrestaShop in this adapter version — ' +
+          'images skipped. PrestaShop WebService images require binary multipart upload to /images/products/{id}.',
+      );
+    }
+
+    // v1 deferral: PrestaShop parameters would map to product Features + FeatureValues
+    // (separate PS WS resources requiring multi-step provisioning). Not yet
+    // implemented; the operator is warned so attributes are not silently dropped.
+    if (cmd.parameters != null && cmd.parameters.length > 0) {
+      warnings.push(
+        'parameters: category/attribute parameters are not yet supported for PrestaShop in this ' +
+          'adapter version — parameters skipped. PrestaShop features require separate ' +
+          'feature + feature_value resources.',
+      );
+    }
+
     const body = this.buildProductBody(cmd, languageId);
     const isUpsert = cmd.externalProductId != null && cmd.externalProductId !== '';
 
@@ -85,7 +111,15 @@ export class PrestashopProductPublisherAdapter
     const productId = String(response.id);
     await this.updateStock(productId, cmd.stock);
 
-    return { externalProductId: productId, status: cmd.status };
+    // Derive the observed status from response.active (the contract says
+    // PublishProductResult.status is the state observed after the call, not the
+    // requested state — PS always echoes back what it persisted).
+    const status: PublishProductStatus = String(response.active) === '1' ? 'published' : 'draft';
+    return {
+      externalProductId: productId,
+      status,
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
   }
 
   async provisionCategory(cmd: ProvisionCategoryCommand): Promise<ProvisionCategoryResult> {
@@ -143,7 +177,12 @@ export class PrestashopProductPublisherAdapter
       link_rewrite: langField(slug, languageId),
       price: cmd.price.amount.toFixed(2),
       active: cmd.status === 'published' ? '1' : '0',
-      id_category_default: cmd.destinationCategoryIds[0] ?? '0',
+      // Fall back to PS Home category (id 2) when no category is provided — '0' is
+      // not a valid PS parent and may be rejected. Home is the first visible level
+      // in the PS category tree; operators can override via connection.config.rootCategoryId.
+      id_category_default:
+        cmd.destinationCategoryIds[0] ??
+        String((this.connection.config?.rootCategoryId as number | string | undefined) ?? 2),
     };
 
     if (cmd.content?.description != null) {
@@ -200,7 +239,7 @@ export class PrestashopProductPublisherAdapter
     }
   }
 
-  private toPublishError(error: unknown): never {
+  private toPublishError(error: unknown): unknown {
     if (
       error instanceof PrestashopApiException &&
       error.statusCode != null &&
@@ -208,11 +247,11 @@ export class PrestashopProductPublisherAdapter
       error.statusCode < 500
     ) {
       const adapterKey = this.connection.adapterKey ?? DEFAULT_ADAPTER_KEY;
-      throw new ProductPublishRejectedException(adapterKey, error.statusCode, [
+      return new ProductPublishRejectedException(adapterKey, error.statusCode, [
         { code: String(error.statusCode), message: error.message },
       ]);
     }
-    throw error;
+    return error;
   }
 
   private slugify(text: string): string {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts
@@ -1,0 +1,213 @@
+/**
+ * PrestaShop Product Publisher Adapter (#1107)
+ *
+ * Implements `ShopProductManagerPort` (capability `'ProductPublisher'`) plus the
+ * `CategoryProvisioner` sub-capability against the PrestaShop WebService XML API.
+ * Pure transport: the core `ProductPublishExecutionService` owns identifier mapping
+ * and record lifecycle — this adapter shapes the neutral `PublishProductCommand`
+ * onto PrestaShop's `products` / `categories` / `stock_availables` resources and
+ * maps failures back to the neutral `ProductPublishRejectedException`.
+ *
+ * Publish model (ADR-024 §1/§3): each OL variant publishes as its own simple
+ * product (create on first publish, upsert via `externalProductId` thereafter).
+ * Stock is set via the auto-created `stock_availables` row after create/upsert —
+ * PS WS does not accept `quantity` inline on the product body.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/adapters/product-publisher
+ */
+import { Logger } from '@openlinker/shared/logging';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import {
+  ProductPublishRejectedException,
+  type CategoryProvisioner,
+  type ProvisionCategoryCommand,
+  type ProvisionCategoryResult,
+  type PublishProductCommand,
+  type PublishProductResult,
+  type ShopProductManagerPort,
+} from '@openlinker/core/listings';
+import { PrestashopApiException } from '@openlinker/integrations-prestashop';
+
+import type { IPrestashopWebserviceClient } from '../../http/prestashop-webservice.client.interface';
+import {
+  langField,
+  type PrestashopCategoryListItem,
+  type PrestashopCategoryResponse,
+  type PrestashopLangField,
+  type PrestashopProductResponse,
+  type PrestashopProductWriteBody,
+  type PrestashopStockAvailableItem,
+} from './prestashop-product-publish.types';
+
+const DEFAULT_ADAPTER_KEY = 'prestashop.webservice.v1';
+
+export class PrestashopProductPublisherAdapter
+  implements ShopProductManagerPort, CategoryProvisioner
+{
+  private readonly logger = new Logger(PrestashopProductPublisherAdapter.name);
+
+  constructor(
+    private readonly client: IPrestashopWebserviceClient,
+    private readonly connection: Connection,
+  ) {}
+
+  async publishProduct(cmd: PublishProductCommand): Promise<PublishProductResult> {
+    const languageId = String(
+      cmd.platformParams?.languageId ?? (this.connection.config?.langId as number | undefined) ?? 1,
+    );
+
+    const body = this.buildProductBody(cmd, languageId);
+    const isUpsert = cmd.externalProductId != null && cmd.externalProductId !== '';
+
+    this.logger.debug(
+      `Publishing variant=${cmd.internalVariantId} connection=${this.connection.id} ` +
+        `mode=${isUpsert ? 'upsert' : 'create'} status=${cmd.status}`,
+    );
+
+    let response: PrestashopProductResponse;
+    try {
+      if (isUpsert) {
+        response = await this.client.updateResource<PrestashopProductResponse>(
+          'products',
+          String(cmd.externalProductId),
+          { id: String(cmd.externalProductId), ...body },
+        );
+      } else {
+        response = await this.client.createResource<PrestashopProductResponse>('products', body);
+      }
+    } catch (err) {
+      this.toPublishError(err);
+    }
+
+    const productId = String(response!.id);
+    await this.updateStock(productId, cmd.stock);
+
+    return { externalProductId: productId, status: cmd.status };
+  }
+
+  async provisionCategory(cmd: ProvisionCategoryCommand): Promise<ProvisionCategoryResult> {
+    const languageId = String(
+      (this.connection.config?.langId as number | undefined) ?? 1,
+    );
+    let parentId = '0';
+    const createdPath: string[] = [];
+
+    for (const node of cmd.path) {
+      const rows = await this.client.listResources<PrestashopCategoryListItem>('categories', {
+        custom: { 'filter[name]': node.name, 'filter[id_parent]': parentId },
+      });
+
+      const match = rows.find(
+        (row) => this.extractLangText(row.name) === node.name,
+      );
+
+      if (match) {
+        parentId = String(match.id);
+        continue;
+      }
+
+      const created = await this.client.createResource<PrestashopCategoryResponse>('categories', {
+        name: langField(node.name, languageId),
+        id_parent: parentId,
+        link_rewrite: langField(this.slugify(node.name), languageId),
+        active: '1',
+      });
+
+      parentId = String(created.id);
+      createdPath.push(parentId);
+    }
+
+    return {
+      destinationCategoryId: parentId,
+      ...(createdPath.length > 0 ? { createdPath } : {}),
+    };
+  }
+
+  private buildProductBody(
+    cmd: PublishProductCommand,
+    languageId: string,
+  ): PrestashopProductWriteBody {
+    const title = cmd.content?.title ?? '';
+    const slug = (cmd.content?.seo?.slug ?? this.slugify(title)) || 'product';
+
+    const body: PrestashopProductWriteBody = {
+      ...(cmd.platformParams ?? {}),
+      name: langField(title, languageId),
+      link_rewrite: langField(slug, languageId),
+      price: cmd.price.amount.toFixed(2),
+      active: cmd.status === 'published' ? '1' : '0',
+      id_category_default: cmd.destinationCategoryIds[0] ?? '0',
+    };
+
+    if (cmd.content?.description != null) {
+      body.description = langField(cmd.content.description, languageId);
+    }
+
+    if (cmd.destinationCategoryIds.length > 0) {
+      body.associations = {
+        categories: {
+          category: cmd.destinationCategoryIds.map((id) => ({ id: String(id) })),
+        },
+      };
+    }
+
+    if (cmd.content?.seo?.title != null) {
+      body.meta_title = langField(cmd.content.seo.title, languageId);
+    }
+    if (cmd.content?.seo?.description != null) {
+      body.meta_description = langField(cmd.content.seo.description, languageId);
+    }
+
+    return body;
+  }
+
+  private async updateStock(productId: string, quantity: number): Promise<void> {
+    const rows = await this.client.listResources<PrestashopStockAvailableItem>('stock_availables', {
+      custom: { 'filter[id_product]': productId },
+    });
+
+    const row = rows[0];
+    if (!row) {
+      this.logger.warn(
+        `No stock_available row found for product ${productId} on connection ${this.connection.id} — stock not updated.`,
+      );
+      return;
+    }
+
+    const saId = String(row.id);
+    await this.client.updateResource('stock_availables', saId, {
+      id: saId,
+      id_product: productId,
+      quantity: String(quantity),
+    });
+  }
+
+  private toPublishError(error: unknown): never {
+    if (
+      error instanceof PrestashopApiException &&
+      error.statusCode != null &&
+      error.statusCode >= 400 &&
+      error.statusCode < 500
+    ) {
+      const adapterKey = this.connection.adapterKey ?? DEFAULT_ADAPTER_KEY;
+      throw new ProductPublishRejectedException(adapterKey, error.statusCode, [
+        { code: String(error.statusCode), message: error.message },
+      ]);
+    }
+    throw error;
+  }
+
+  private slugify(text: string): string {
+    return text
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  private extractLangText(value: string | PrestashopLangField): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+    return value.language[0]?.['#text'] ?? '';
+  }
+}

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts
@@ -29,17 +29,20 @@ import {
 import { PrestashopApiException } from '@openlinker/integrations-prestashop';
 
 import type { IPrestashopWebserviceClient } from '../../http/prestashop-webservice.client.interface';
-import {
-  langField,
-  type PrestashopCategoryListItem,
-  type PrestashopCategoryResponse,
-  type PrestashopLangField,
-  type PrestashopProductResponse,
-  type PrestashopProductWriteBody,
-  type PrestashopStockAvailableItem,
+import type {
+  PrestashopCategoryListItem,
+  PrestashopCategoryResponse,
+  PrestashopLangField,
+  PrestashopProductResponse,
+  PrestashopProductWriteBody,
+  PrestashopStockAvailableItem,
 } from './prestashop-product-publish.types';
 
 const DEFAULT_ADAPTER_KEY = 'prestashop.webservice.v1';
+
+function langField(value: string, languageId = '1'): PrestashopLangField {
+  return { language: [{ '@_id': languageId, '#text': value }] };
+}
 
 export class PrestashopProductPublisherAdapter
   implements ShopProductManagerPort, CategoryProvisioner
@@ -76,10 +79,10 @@ export class PrestashopProductPublisherAdapter
         response = await this.client.createResource<PrestashopProductResponse>('products', body);
       }
     } catch (err) {
-      this.toPublishError(err);
+      throw this.toPublishError(err);
     }
 
-    const productId = String(response!.id);
+    const productId = String(response.id);
     await this.updateStock(productId, cmd.stock);
 
     return { externalProductId: productId, status: cmd.status };
@@ -89,7 +92,7 @@ export class PrestashopProductPublisherAdapter
     const languageId = String(
       (this.connection.config?.langId as number | undefined) ?? 1,
     );
-    let parentId = '0';
+    let parentId = '0'; // PS WS root sentinel
     const createdPath: string[] = [];
 
     for (const node of cmd.path) {
@@ -97,9 +100,7 @@ export class PrestashopProductPublisherAdapter
         custom: { 'filter[name]': node.name, 'filter[id_parent]': parentId },
       });
 
-      const match = rows.find(
-        (row) => this.extractLangText(row.name) === node.name,
-      );
+      const match = rows.find((row) => this.extractLangText(row.name, languageId) === node.name);
 
       if (match) {
         parentId = String(match.id);
@@ -204,10 +205,12 @@ export class PrestashopProductPublisherAdapter
       .replace(/^-+|-+$/g, '');
   }
 
-  private extractLangText(value: string | PrestashopLangField): string {
-    if (typeof value === 'string') {
-      return value;
-    }
-    return value.language[0]?.['#text'] ?? '';
+  private extractLangText(value: string | PrestashopLangField, languageId: string): string {
+    if (typeof value === 'string') return value;
+    return (
+      value.language.find((l) => l['@_id'] === languageId)?.['#text'] ??
+      value.language[0]?.['#text'] ??
+      ''
+    );
   }
 }

--- a/libs/integrations/prestashop/src/prestashop-plugin.ts
+++ b/libs/integrations/prestashop/src/prestashop-plugin.ts
@@ -69,6 +69,8 @@ export const prestashopAdapterManifest: AdapterMetadata = {
     'InventoryMaster',
     'OrderSource',
     'OrderProcessorManager',
+    'ProductPublisher',
+    'CategoryProvisioner',
   ],
   displayName: 'PrestaShop WebService v1',
   version: '1.0.0',
@@ -169,6 +171,13 @@ export function createPrestashopPlugin(deps: CreatePrestashopPluginDeps): Adapte
             }
             return adapters.orderProcessorManager;
           },
+          // ProductPublisher and CategoryProvisioner are both implemented by
+          // PrestashopProductPublisherAdapter. CategoryProvisioner needs its
+          // own dispatch entry because IntegrationsService.getCapabilityAdapter
+          // looks up by capability string — dispatchCapability would throw
+          // "adapter does not support capability: CategoryProvisioner" without it.
+          ProductPublisher: () => adapters.productPublisher,
+          CategoryProvisioner: () => adapters.productPublisher,
         },
         PRESTASHOP_BRAND,
       );


### PR DESCRIPTION
## Summary

- Adds PrestashopProductPublisherAdapter implementing ShopProductManagerPort (ProductPublisher) and CategoryProvisioner sub-capability against the PrestaShop WebService XML API — pure transport layer; identifier mapping and record lifecycle stay in the core ProductPublishExecutionService.

- Publish model follows ADR-024 §1/§3: each OL variant publishes as its own simple PS product (create on first publish, upsert via externalProductId thereafter). Stock is written to stock_availables after create/upsert — PS WS does not accept quantity inline on the product body.

- CategoryProvisioner.provisionCategory walks the requested path depth-first, matches existing nodes by exact name+parent, and creates missing nodes on the fly via the WS categories resource. Language ID is resolved from the connection's langId config when matching multilingual category names.

- Registers 'ProductPublisher' and 'CategoryProvisioner' in prestashopAdapterManifest.supportedCapabilities and adds both to the dispatchCapability table in createPrestashopPlugin (both resolve to the same adapter instance). Updates the connection-capabilities int-spec to cover both new capabilities.

## Follow-up from tech review:
- langField factory moved out of *.types.ts — types file now contains only interface/type declarations per engineering standards
- throw this.toPublishError(err) replaces bare call in catch block, eliminating the unsound response! non-null assertion
- extractLangText now resolves by @_id before falling back to index 0, preventing silent duplicate category creation on multi-language PS stores
- productPublisher marked required (non-optional) in PrestashopAdapters interface — the factory creates it unconditionally; ? created a type hole in dispatchCapability
- v1 deferral warnings emitted (not silently dropped) when `imageUrls` or `parameters` are present on the command — operator sees what was skipped and why
- `publishProduct` now derives `result.status` from `response.active` (PS-echoed persisted state) instead of `cmd.status` — satisfies the contract that `PublishProductResult.status` reflects what PS actually stored
- `id_category_default` falls back to PS Home category (id `2`) when `destinationCategoryIds` is empty — `'0'` is not a valid PS parent and may be rejected by the WS
- `toPublishError` changed from `throw` to `return` (return type `unknown` instead of `never`) — caller now does `throw this.toPublishError(err)`, making control flow explicit and removing the unsound `response!` assertion
## Related issues

Closes #1107

## Test plan

- [x] pnpm test — unit spec at prestashop-produpasses (create, upsert, category provisioning,stock update, 4xx → ProductPublishRejectedException)
- [x] pnpm lint && pnpm type-check — zero errors
- [x] pnpm test:integration — connection-capabih ProductPublisher and CategoryProvisionerlisted for the PrestaShop adapter
- [x] Manual smoke: connect a PrestaShop store, trigger product publish via the product publisher flow, verify product and
stock appear in the PS back-office

## Quality gate

- [x] pnpm lint passes (zero errors)
- [x] pnpm type-check passes (zero errors)
- [x] pnpm test passes (all unit tests green)
- [x] pnpm test:integration passes — connection-capabilities.int-spec.ts is touched on this branch

🤖 Generated with Claude Code

<sub>By submitting this pull request, I confirm that my contributions are made under the terms of the Apache License 2.0, and I certify the Developer Certificate of Orig</sub>

---