### PR TITLE
feat(orders,shipping,web): ship-by SLA + fulfillment rollup on order-health (#1108)

### DIFF
--- a/apps/api/src/migrations/1809000000000-add-order-fulfillment-state.ts
+++ b/apps/api/src/migrations/1809000000000-add-order-fulfillment-state.ts
@@ -1,0 +1,33 @@
+/**
+ * Add order_records.fulfillmentState + index (#1108)
+ *
+ * Persists a per-order fulfillment rollup (`not-shipped | dispatched |
+ * delivered | failed`) denormalized from the shipping context's `Shipment`
+ * rows, so the orders list can show "has this shipped?" and filter/sort on it
+ * without a cross-context query. Pushed from shipping via
+ * `IOrderRecordService.updateFulfillmentState`.
+ *
+ * Additive + nullable → backward-compatible: existing rows get NULL, treated as
+ * `not-shipped` by every derivation/filter/summary (no backfill — orders with
+ * prior shipments converge on the next shipment mutation or the reconciliation
+ * poll). `down()` drops the index then the column.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderFulfillmentState1809000000000 implements MigrationInterface {
+  name = 'AddOrderFulfillmentState1809000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "order_records" ADD "fulfillmentState" character varying`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_order_records_fulfillmentState" ON "order_records" ("fulfillmentState")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_order_records_fulfillmentState"`);
+    await queryRunner.query(`ALTER TABLE "order_records" DROP COLUMN "fulfillmentState"`);
+  }
+}

--- a/apps/api/src/orders/http/dto/list-orders-query.dto.ts
+++ b/apps/api/src/orders/http/dto/list-orders-query.dto.ts
@@ -23,6 +23,8 @@ import {
   OrderHealthValues,
   OrderRecordSortValues,
   OrderRecordSortDirectionValues,
+  SlaStateValues,
+  FulfillmentRollupStateValues,
 } from '@openlinker/core/orders';
 import {
   OrderSyncStatusFilter,
@@ -30,6 +32,8 @@ import {
   OrderHealth,
   OrderRecordSort,
   OrderRecordSortDirection,
+  SlaState,
+  FulfillmentRollupState,
 } from '@openlinker/core/orders';
 
 export class ListOrdersQueryDto {
@@ -112,6 +116,24 @@ export class ListOrdersQueryDto {
   @IsOptional()
   @IsDateString()
   dueBefore?: string;
+
+  @ApiPropertyOptional({
+    enum: SlaStateValues,
+    description:
+      'Ship-by SLA bucket filter (#1108): none | on_track | at_risk | overdue. Server-derived from the ship-by deadline + fulfillment (cleared once shipped); matches the badge the list renders.',
+  })
+  @IsOptional()
+  @IsEnum(SlaStateValues)
+  slaState?: SlaState;
+
+  @ApiPropertyOptional({
+    enum: FulfillmentRollupStateValues,
+    description:
+      'Fulfillment-rollup filter (#1108): not-shipped | dispatched | delivered | failed (not-shipped also matches orders with no shipments).',
+  })
+  @IsOptional()
+  @IsEnum(FulfillmentRollupStateValues)
+  fulfillmentState?: FulfillmentRollupState;
 
   @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
   @IsOptional()

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -10,8 +10,10 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   OrderRecordStatusValues,
   SYNC_ATTEMPTS_PER_DESTINATION_CAP,
+  SlaStateValues,
+  FulfillmentRollupStateValues,
 } from '@openlinker/core/orders';
-import { OrderRecordStatus } from '@openlinker/core/orders';
+import { OrderRecordStatus, SlaState, FulfillmentRollupState } from '@openlinker/core/orders';
 import { OrderSyncStatusResponseDto } from './order-sync-status-response.dto';
 import { SyncAttemptResponseDto } from './sync-attempt-response.dto';
 
@@ -65,4 +67,18 @@ export class OrderRecordResponseDto {
       'and the detail countdown read it without parsing the snapshot.',
   })
   dispatchByAt!: string | null;
+
+  @ApiProperty({
+    enum: FulfillmentRollupStateValues,
+    description:
+      'Per-order fulfillment rollup (#1108) of the order\'s shipment lifecycle. "not-shipped" when no shipment has progressed (also the default for orders with no shipments).',
+  })
+  fulfillmentState!: FulfillmentRollupState;
+
+  @ApiProperty({
+    enum: SlaStateValues,
+    description:
+      'Ship-by SLA bucket (#1108), server-derived from dispatchByAt + fulfillmentState (cleared to "none" once shipped). The single source of truth the list badge + filter agree on; the FE renders only the live countdown from dispatchByAt.',
+  })
+  slaState!: SlaState;
 }

--- a/apps/api/src/orders/http/dto/order-sla-summary-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-sla-summary-response.dto.ts
@@ -1,0 +1,29 @@
+/**
+ * Order SLA Summary Response DTO
+ *
+ * Response shape for GET /orders/sla-summary (#1108). Carries the count of
+ * order records per ship-by SLA bucket for the given source/customer/date
+ * scope. The four buckets partition the set, so `total` equals their sum —
+ * backs the list-page SLA KPI cells. Mirrors `OrderSlaSummary` in
+ * `@openlinker/core/orders`.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OrderSlaSummaryResponseDto {
+  @ApiProperty({ description: 'Total order records in scope (sum of the buckets)' })
+  total!: number;
+
+  @ApiProperty({ description: 'Orders with a ship-by deadline comfortably ahead (not shipped)' })
+  onTrack!: number;
+
+  @ApiProperty({ description: 'Orders within the at-risk window of their ship-by deadline (not shipped)' })
+  atRisk!: number;
+
+  @ApiProperty({ description: 'Orders past their ship-by deadline (not shipped)' })
+  overdue!: number;
+
+  @ApiProperty({ description: 'Orders with no deadline or already shipped' })
+  none!: number;
+}

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -53,6 +53,8 @@ describe('OrdersController', () => {
       updateSyncStatus: jest.fn(),
       findMany: jest.fn(),
       countByHealth: jest.fn(),
+      countBySla: jest.fn(),
+      updateFulfillmentState: jest.fn(),
     };
 
     const mockRetryService: jest.Mocked<IOrderDestinationRetryService> = {

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -31,11 +31,13 @@ import {
   OrderDestinationNotRetryableException,
   MissingSourceExternalIdException,
   IOrderDestinationRetryService,
+  deriveSlaState,
 } from '@openlinker/core/orders';
 import type { OrderRecord, OrderSyncStatus, SyncAttempt } from '@openlinker/core/orders';
 import { ListOrdersQueryDto } from './dto/list-orders-query.dto';
 import { OrderHealthSummaryQueryDto } from './dto/order-health-summary-query.dto';
 import { OrderHealthSummaryResponseDto } from './dto/order-health-summary-response.dto';
+import { OrderSlaSummaryResponseDto } from './dto/order-sla-summary-response.dto';
 import { OrderRecordResponseDto } from './dto/order-record-response.dto';
 import type { OrderSyncStatusResponseDto } from './dto/order-sync-status-response.dto';
 import type { SyncAttemptResponseDto } from './dto/sync-attempt-response.dto';
@@ -79,6 +81,8 @@ export class OrdersController {
       sort,
       dir,
       dueBefore,
+      slaState,
+      fulfillmentState,
       limit = 20,
       offset = 0,
     } = query;
@@ -95,6 +99,8 @@ export class OrdersController {
         sort,
         dir,
         dueBefore: dueBefore ? new Date(dueBefore) : undefined,
+        slaState,
+        fulfillmentState,
       },
       { limit, offset }
     );
@@ -125,6 +131,31 @@ export class OrdersController {
   ): Promise<OrderHealthSummaryResponseDto> {
     const { sourceConnectionId, customerId, createdFrom, createdTo } = query;
     return this.orderRecordRepository.countByHealth({
+      sourceConnectionId,
+      customerId,
+      createdFrom: createdFrom ? new Date(createdFrom) : undefined,
+      createdTo: createdTo ? new Date(createdTo) : undefined,
+    });
+  }
+
+  @Get('sla-summary')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Order ship-by SLA summary counts',
+    description:
+      'Returns the count of order records per ship-by SLA bucket (none | on_track | at_risk | overdue) for the given source/customer/date scope. The buckets partition the set, so `total` equals their sum — backs the list-page SLA KPI cells (#1108).',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Per-SLA-bucket counts',
+    type: OrderSlaSummaryResponseDto,
+  })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async slaSummary(
+    @Query() query: OrderHealthSummaryQueryDto
+  ): Promise<OrderSlaSummaryResponseDto> {
+    const { sourceConnectionId, customerId, createdFrom, createdTo } = query;
+    return this.orderRecordRepository.countBySla({
       sourceConnectionId,
       customerId,
       createdFrom: createdFrom ? new Date(createdFrom) : undefined,
@@ -196,6 +227,7 @@ export class OrdersController {
   }
 
   private toDto(order: OrderRecord): OrderRecordResponseDto {
+    const fulfillmentState = order.fulfillmentState ?? 'not-shipped';
     return {
       internalOrderId: order.internalOrderId,
       customerId: order.customerId,
@@ -208,6 +240,10 @@ export class OrdersController {
       createdAt: order.createdAt instanceof Date ? order.createdAt.toISOString() : order.createdAt,
       updatedAt: order.updatedAt instanceof Date ? order.updatedAt.toISOString() : order.updatedAt,
       dispatchByAt: order.dispatchByAt ? order.dispatchByAt.toISOString() : null,
+      fulfillmentState,
+      // BE-owned SLA bucket (#1108): single source of truth so the list filter +
+      // badge agree. The FE renders only the live countdown off dispatchByAt.
+      slaState: deriveSlaState(order.dispatchByAt, order.fulfillmentState, new Date()),
     };
   }
 

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -108,6 +108,7 @@ describe('ShipmentController', () => {
       // Default: order/customer unknown → customerId resolves to null.
       getOrderRecord: jest.fn().mockResolvedValue(null),
       findMany: jest.fn(),
+      updateFulfillmentState: jest.fn(),
     };
     controller = new ShipmentController(
       query,

--- a/apps/api/test/integration/orders-read.int-spec.ts
+++ b/apps/api/test/integration/orders-read.int-spec.ts
@@ -157,6 +157,105 @@ describe('Orders Read API Integration', () => {
     });
   });
 
+  // Ship-by SLA + fulfillment rollup (#1108) — exercises the new derived
+  // `slaState` (BE-owned, single source of truth) + the denormalized
+  // `fulfillmentState` column end-to-end through the migration + real DB.
+  describe('GET /orders — ship-by SLA + fulfillment (#1108)', () => {
+    it('should derive slaState=overdue and fulfillmentState=not-shipped for an overdue, unshipped order', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      await createTestOrderRecord(dataSource, { dispatchByAt: new Date(Date.now() - 60_000) });
+
+      const response = await http
+        .get('/orders')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      // NULL fulfillment column surfaces as `not-shipped`; a past deadline + not
+      // shipped derives `overdue`.
+      expect(response.body.items[0].fulfillmentState).toBe('not-shipped');
+      expect(response.body.items[0].slaState).toBe('overdue');
+    });
+
+    it('should clear slaState to none once the order has shipped', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      // Past deadline, but already dispatched → SLA pressure cleared.
+      await createTestOrderRecord(dataSource, {
+        dispatchByAt: new Date(Date.now() - 60_000),
+        fulfillmentState: 'dispatched',
+      });
+
+      const response = await http
+        .get('/orders')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(response.body.items[0].fulfillmentState).toBe('dispatched');
+      expect(response.body.items[0].slaState).toBe('none');
+    });
+
+    it('should filter by slaState and fulfillmentState', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      await createTestOrderRecord(dataSource, { dispatchByAt: new Date(Date.now() - 60_000) });
+      await createTestOrderRecord(dataSource, { fulfillmentState: 'dispatched' });
+
+      const overdue = await http
+        .get('/orders?slaState=overdue')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(overdue.body.total).toBe(1);
+      expect(overdue.body.items[0].slaState).toBe('overdue');
+
+      const dispatched = await http
+        .get('/orders?fulfillmentState=dispatched')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(dispatched.body.total).toBe(1);
+      expect(dispatched.body.items[0].fulfillmentState).toBe('dispatched');
+
+      // not-shipped also matches NULL-column rows.
+      const notShipped = await http
+        .get('/orders?fulfillmentState=not-shipped')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(notShipped.body.total).toBe(1);
+    });
+
+    it('should partition the set in GET /orders/sla-summary', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      await createTestOrderRecord(dataSource, { dispatchByAt: new Date(Date.now() - 60_000) });
+      await createTestOrderRecord(dataSource, { fulfillmentState: 'delivered' });
+      await createTestOrderRecord(dataSource, {});
+
+      const response = await http
+        .get('/orders/sla-summary')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(response.body.total).toBe(3);
+      expect(response.body.overdue).toBe(1);
+      // delivered (shipped) + no-deadline → none.
+      expect(response.body.none).toBe(2);
+      expect(
+        response.body.onTrack +
+          response.body.atRisk +
+          response.body.overdue +
+          response.body.none,
+      ).toBe(response.body.total);
+    });
+  });
+
   describe('GET /orders/:internalOrderId', () => {
     it('should return order detail by internal order id', async () => {
       const http = harness.getHttp();

--- a/apps/web/src/features/orders/api/orders.api.ts
+++ b/apps/web/src/features/orders/api/orders.api.ts
@@ -14,11 +14,13 @@ import type {
   RetryOrderDestinationResult,
   OrderHealthSummary,
   OrderHealthSummaryFilters,
+  OrderSlaSummary,
 } from './orders.types';
 
 export interface OrdersApi {
   list: (filters?: OrderFilters, pagination?: OrderPagination) => Promise<PaginatedOrders>;
   statusSummary: (filters?: OrderHealthSummaryFilters) => Promise<OrderHealthSummary>;
+  slaSummary: (filters?: OrderHealthSummaryFilters) => Promise<OrderSlaSummary>;
   getById: (internalOrderId: string) => Promise<OrderRecord>;
   retryDestination: (
     internalOrderId: string,
@@ -42,6 +44,8 @@ function buildQuery(filters?: OrderFilters, pagination?: OrderPagination): strin
   if (filters?.sort) params.set('sort', filters.sort);
   if (filters?.dir) params.set('dir', filters.dir);
   if (filters?.dueBefore) params.set('dueBefore', filters.dueBefore);
+  if (filters?.slaState) params.set('slaState', filters.slaState);
+  if (filters?.fulfillmentState) params.set('fulfillmentState', filters.fulfillmentState);
   if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
   if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
   const qs = params.toString();
@@ -65,6 +69,9 @@ export function createOrdersApi(request: ApiRequest): OrdersApi {
     },
     statusSummary(filters): Promise<OrderHealthSummary> {
       return request<OrderHealthSummary>(`/orders/status-summary${buildSummaryQuery(filters)}`);
+    },
+    slaSummary(filters): Promise<OrderSlaSummary> {
+      return request<OrderSlaSummary>(`/orders/sla-summary${buildSummaryQuery(filters)}`);
     },
     getById(internalOrderId): Promise<OrderRecord> {
       return request<OrderRecord>(`/orders/${internalOrderId}`);

--- a/apps/web/src/features/orders/api/orders.query-keys.ts
+++ b/apps/web/src/features/orders/api/orders.query-keys.ts
@@ -6,5 +6,7 @@ export const ordersQueryKeys = {
     ['orders', 'list', filters ?? {}, pagination ?? {}] as const,
   statusSummary: (filters?: OrderHealthSummaryFilters) =>
     ['orders', 'status-summary', filters ?? {}] as const,
+  slaSummary: (filters?: OrderHealthSummaryFilters) =>
+    ['orders', 'sla-summary', filters ?? {}] as const,
   detail: (internalOrderId: string) => ['orders', 'detail', internalOrderId] as const,
 };

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -48,6 +48,24 @@ export const SYNC_ATTEMPTS_PER_DESTINATION_CAP = 20;
 export const OrderRecordStatusValues = ['ready', 'awaiting_mapping'] as const;
 export type OrderRecordStatusValue = (typeof OrderRecordStatusValues)[number];
 
+// Per-order fulfillment rollup (#1108). Hand-mirrored from
+// `FulfillmentRollupStateValues` in `@openlinker/core/orders`. Shares spelling
+// with the FE `FulfillmentState` (lib/order-health.ts) minus the FE-only
+// `unavailable` render state (capability absent), which the BE never sends.
+export const FulfillmentRollupStateValues = [
+  'not-shipped',
+  'dispatched',
+  'delivered',
+  'failed',
+] as const;
+export type FulfillmentRollupStateValue = (typeof FulfillmentRollupStateValues)[number];
+
+// Ship-by SLA bucket (#1108). Hand-mirrored from `SlaStateValues` in
+// `@openlinker/core/orders`. BE-owned (single source of truth): the FE consumes
+// `slaState` and only renders the live countdown from `dispatchByAt`.
+export const SlaStateValues = ['none', 'on_track', 'at_risk', 'overdue'] as const;
+export type SlaStateValue = (typeof SlaStateValues)[number];
+
 export interface OrderRecord {
   internalOrderId: string;
   customerId: string | null;
@@ -67,6 +85,17 @@ export interface OrderRecord {
    * `@ApiPropertyOptional`) so older/absent payloads degrade gracefully.
    */
   dispatchByAt?: string | null;
+  /**
+   * Per-order fulfillment rollup (#1108). Optional on the FE contract so
+   * older/absent payloads degrade gracefully (treated as `not-shipped`).
+   */
+  fulfillmentState?: FulfillmentRollupStateValue;
+  /**
+   * BE-owned ship-by SLA bucket (#1108). The list badge + filter both read this
+   * (single source of truth); the FE only computes the live countdown from
+   * `dispatchByAt`. Optional for graceful degradation.
+   */
+  slaState?: SlaStateValue;
 }
 
 // Result ordering for the orders list (#927, extended #944). Mirrors
@@ -80,6 +109,7 @@ export const OrderSortValues = [
   'items',
   'status',
   'total',
+  'fulfillment',
 ] as const;
 export type OrderSortValue = (typeof OrderSortValues)[number];
 
@@ -127,6 +157,22 @@ export interface OrderFilters {
   dir?: OrderSortDirection;
   /** SLA "breaching / overdue" filter (#927): ISO instant; keeps orders with a ship-by deadline ≤ this. */
   dueBefore?: string;
+  /** Ship-by SLA bucket filter (#1108). */
+  slaState?: SlaStateValue;
+  /** Fulfillment-rollup filter (#1108). */
+  fulfillmentState?: FulfillmentRollupStateValue;
+}
+
+/**
+ * Per-SLA-bucket counts from `GET /orders/sla-summary` (#1108). Mirrors
+ * `OrderSlaSummaryResponseDto` (BE). `total` equals the sum of the buckets.
+ */
+export interface OrderSlaSummary {
+  total: number;
+  onTrack: number;
+  atRisk: number;
+  overdue: number;
+  none: number;
 }
 
 /**

--- a/apps/web/src/features/orders/hooks/use-order-sla-summary-query.ts
+++ b/apps/web/src/features/orders/hooks/use-order-sla-summary-query.ts
@@ -1,0 +1,27 @@
+/**
+ * Order SLA Summary Query Hook
+ *
+ * Fetches the per-ship-by-SLA-bucket counts from GET /orders/sla-summary
+ * (#1108). Backs the orders-list "overdue / at-risk" KPI cells. The buckets
+ * partition the set, so the counts sum to the total. Mirrors the status-summary
+ * hook (#929).
+ *
+ * @module apps/web/src/features/orders/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { ordersQueryKeys } from '../api/orders.query-keys';
+import type { OrderSlaSummary, OrderHealthSummaryFilters } from '../api/orders.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useOrderSlaSummaryQuery(
+  filters?: OrderHealthSummaryFilters,
+): UseQueryResult<OrderSlaSummary> {
+  const apiClient = useApiClient();
+
+  // Eventually-consistent with the table, same as the status-summary hook — the
+  // retry mutation invalidates the whole orders domain, re-syncing counts + rows.
+  return useQuery({
+    queryKey: ordersQueryKeys.slaSummary(filters),
+    queryFn: () => apiClient.orders.slaSummary(filters),
+  });
+}

--- a/apps/web/src/features/orders/lib/order-health.test.ts
+++ b/apps/web/src/features/orders/lib/order-health.test.ts
@@ -12,9 +12,11 @@ import {
   deriveFulfillment,
   deriveHealthLevel,
   deriveOrderHealth,
+  fulfillmentBadge,
   fulfillmentLabel,
   healthLabel,
   rollupSyncStatus,
+  slaBadge,
   syncCellLabel,
   totalUnits,
 } from './order-health';
@@ -201,5 +203,31 @@ describe('totalUnits', () => {
   it('sums item quantities', () => {
     expect(totalUnits([{ quantity: 2 }, { quantity: 3 }])).toBe(5);
     expect(totalUnits([])).toBe(0);
+  });
+});
+
+describe('slaBadge (#1108)', () => {
+  it('returns null when there is nothing to show (none / absent)', () => {
+    expect(slaBadge('none')).toBeNull();
+    expect(slaBadge(undefined)).toBeNull();
+  });
+
+  it('maps each actionable bucket to its label + tone', () => {
+    expect(slaBadge('overdue')).toEqual({ label: 'Overdue', tone: 'error' });
+    expect(slaBadge('at_risk')).toEqual({ label: 'At risk', tone: 'warning' });
+    expect(slaBadge('on_track')).toEqual({ label: 'On track', tone: 'success' });
+  });
+});
+
+describe('fulfillmentBadge (#1108)', () => {
+  it('treats absent (NULL) as not-shipped', () => {
+    expect(fulfillmentBadge(undefined)).toEqual({ label: 'Not shipped', tone: 'neutral' });
+  });
+
+  it('maps each rollup value to its label + tone', () => {
+    expect(fulfillmentBadge('not-shipped')).toEqual({ label: 'Not shipped', tone: 'neutral' });
+    expect(fulfillmentBadge('dispatched')).toEqual({ label: 'Dispatched', tone: 'info' });
+    expect(fulfillmentBadge('delivered')).toEqual({ label: 'Delivered', tone: 'success' });
+    expect(fulfillmentBadge('failed')).toEqual({ label: 'Dispatch failed', tone: 'error' });
   });
 });

--- a/apps/web/src/features/orders/lib/order-health.ts
+++ b/apps/web/src/features/orders/lib/order-health.ts
@@ -14,7 +14,13 @@
  *
  * @module apps/web/src/features/orders/lib
  */
-import type { OrderRecord, OrderHealthValue, OrderSyncStatus } from '../api/orders.types';
+import type {
+  OrderRecord,
+  OrderHealthValue,
+  OrderSyncStatus,
+  SlaStateValue,
+  FulfillmentRollupStateValue,
+} from '../api/orders.types';
 import type { StatusBadgeTone } from '../../../shared/ui/status-badge';
 
 // ── List-row health classification (#929) ──────────────────────────────────
@@ -135,6 +141,12 @@ export type FulfillmentState = (typeof FulfillmentStateValues)[number];
  * empty means no shipment exists yet. When no connection declares the
  * ShippingProviderManager capability the order can't be dispatched at all, so
  * the state collapses to `unavailable` (the panel + cell hide the affordance).
+ *
+ * **Twin (#1108):** the BE `deriveFulfillmentRollup`
+ * (`libs/core/src/shipping/domain/fulfillment-rollup.ts`) encodes the same
+ * precedence to populate `order.fulfillmentState` (which the list reads
+ * directly). Keep both in lockstep if the precedence changes; `unavailable`
+ * is a FE-only render state that the BE rollup never produces.
  */
 export function deriveFulfillment(
   shipmentStatuses: readonly string[] | null,
@@ -168,4 +180,50 @@ export function fulfillmentLabel(state: FulfillmentState): string {
 /** Sum of item quantities — the "M unit" half of the header summary line. */
 export function totalUnits(items: readonly { quantity: number }[]): number {
   return items.reduce((sum, item) => sum + item.quantity, 0);
+}
+
+// ── Ship-by SLA + fulfillment-rollup badges (#1108) ─────────────────────────
+// The BE owns `slaState` + `fulfillmentState` (single source of truth); these
+// maps only choose label + tone. Colour is never the only signal — paired with
+// the badge label (StatusBadge enforces dot + text).
+
+/** Label + tone per ship-by SLA bucket. `none` renders nothing (no affordance). */
+export const ORDER_SLA_META: Record<
+  Exclude<SlaStateValue, 'none'>,
+  { label: string; tone: StatusBadgeTone }
+> = {
+  overdue: { label: 'Overdue', tone: 'error' },
+  at_risk: { label: 'At risk', tone: 'warning' },
+  on_track: { label: 'On track', tone: 'success' },
+};
+
+/**
+ * Resolve the SLA badge for an order, or `null` when there's nothing to show
+ * (`none` — no deadline or already shipped). Reads the BE-owned `slaState`; the
+ * FE never re-derives the bucket.
+ */
+export function slaBadge(
+  slaState: SlaStateValue | undefined,
+): { label: string; tone: StatusBadgeTone } | null {
+  if (!slaState || slaState === 'none') return null;
+  return ORDER_SLA_META[slaState];
+}
+
+/** Label + tone per fulfillment-rollup value, for the list/detail row badge. */
+export const ORDER_FULFILLMENT_META: Record<
+  FulfillmentRollupStateValue,
+  { label: string; tone: StatusBadgeTone }
+> = {
+  'not-shipped': { label: 'Not shipped', tone: 'neutral' },
+  dispatched: { label: 'Dispatched', tone: 'info' },
+  delivered: { label: 'Delivered', tone: 'success' },
+  failed: { label: 'Dispatch failed', tone: 'error' },
+};
+
+/** Fulfillment badge for an order row. NULL/absent ≡ `not-shipped`. */
+export function fulfillmentBadge(state: FulfillmentRollupStateValue | undefined): {
+  label: string;
+  tone: StatusBadgeTone;
+} {
+  return ORDER_FULFILLMENT_META[state ?? 'not-shipped'];
 }

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -43,9 +43,10 @@ import { useTranslation, getBcp47Locale } from '../../shared/i18n';
 import type { LocaleCode } from '../../shared/i18n';
 import { useOrdersQuery } from '../../features/orders/hooks/use-orders-query';
 import { useOrderStatusSummaryQuery } from '../../features/orders/hooks/use-order-status-summary-query';
+import { useOrderSlaSummaryQuery } from '../../features/orders/hooks/use-order-sla-summary-query';
 import { useRetryOrderDestinationMutation } from '../../features/orders/hooks/use-retry-order-destination-mutation';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
-import { deriveOrderHealth } from '../../features/orders/lib/order-health';
+import { deriveOrderHealth, slaBadge, fulfillmentBadge } from '../../features/orders/lib/order-health';
 import type {
   OrderRecord,
   OrderFilters,
@@ -53,11 +54,15 @@ import type {
   OrderHealthSummary,
   OrderSortValue,
   OrderSortDirection,
+  SlaStateValue,
+  FulfillmentRollupStateValue,
 } from '../../features/orders/api/orders.types';
 import {
   OrderHealthValues,
   OrderSortValues,
   OrderSortDirectionValues,
+  SlaStateValues,
+  FulfillmentRollupStateValues,
 } from '../../features/orders/api/orders.types';
 import { useConnectionsQuery } from '../../features/connections';
 
@@ -122,6 +127,7 @@ const SORT_KEY_TO_COLUMN: Record<OrderSortValue, string> = {
   items: 'items',
   status: 'status',
   total: 'total',
+  fulfillment: 'fulfillment',
 };
 const COLUMN_TO_SORT_KEY: Record<string, OrderSortValue> = {
   shipBy: 'dispatchBy',
@@ -130,6 +136,7 @@ const COLUMN_TO_SORT_KEY: Record<string, OrderSortValue> = {
   items: 'items',
   status: 'status',
   total: 'total',
+  fulfillment: 'fulfillment',
 };
 
 /**
@@ -144,7 +151,33 @@ const DEFAULT_DIR: Record<OrderSortValue, OrderSortDirection> = {
   items: 'desc',
   status: 'asc',
   total: 'desc',
+  fulfillment: 'asc',
 };
+
+/** Type-guard for the `slaState` URL filter (#1108). */
+function isSlaState(value: string | null): value is SlaStateValue {
+  return value !== null && (SlaStateValues as readonly string[]).includes(value);
+}
+
+/** Type-guard for the `fulfillmentState` URL filter (#1108). */
+function isFulfillmentState(value: string | null): value is FulfillmentRollupStateValue {
+  return value !== null && (FulfillmentRollupStateValues as readonly string[]).includes(value);
+}
+
+/** SLA filter dropdown options (#1108) — `none` is omitted (not a triage state). */
+const SLA_FILTER_OPTIONS: readonly { value: SlaStateValue; label: string }[] = [
+  { value: 'overdue', label: 'Overdue' },
+  { value: 'at_risk', label: 'At risk' },
+  { value: 'on_track', label: 'On track' },
+];
+
+/** Fulfillment filter dropdown options (#1108). */
+const FULFILLMENT_FILTER_OPTIONS: readonly { value: FulfillmentRollupStateValue; label: string }[] = [
+  { value: 'not-shipped', label: 'Not shipped' },
+  { value: 'dispatched', label: 'Dispatched' },
+  { value: 'delivered', label: 'Delivered' },
+  { value: 'failed', label: 'Dispatch failed' },
+];
 
 /**
  * Order-column primary label (#939). The source marketplace often has no
@@ -235,6 +268,10 @@ export function OrdersListPage(): ReactElement {
   const createdFromIso = createdFrom ? `${createdFrom}T00:00:00.000Z` : undefined;
   const createdToIso = createdTo ? `${createdTo}T23:59:59.999Z` : undefined;
   const breaching = searchParams.get('due') === 'breaching';
+  const rawSla = searchParams.get('slaState');
+  const slaState = isSlaState(rawSla) ? rawSla : undefined;
+  const rawFulfillment = searchParams.get('fulfillmentState');
+  const fulfillmentState = isFulfillmentState(rawFulfillment) ? rawFulfillment : undefined;
   const offset = Number(searchParams.get('offset') ?? '0');
 
   // "Breaching soon / overdue" cutoff — stable per toggle (not recomputed each
@@ -254,6 +291,8 @@ export function OrdersListPage(): ReactElement {
     createdFrom: createdFromIso,
     createdTo: createdToIso,
     dueBefore,
+    slaState,
+    fulfillmentState,
   };
   const pagination = { limit: PAGE_SIZE, offset };
 
@@ -273,6 +312,9 @@ export function OrdersListPage(): ReactElement {
   );
   const summaryQuery = useOrderStatusSummaryQuery(summaryScope);
   const summary = summaryQuery.data;
+  // SLA KPI counts (#1108) — same scope as the health summary.
+  const slaSummaryQuery = useOrderSlaSummaryQuery(summaryScope);
+  const slaSummary = slaSummaryQuery.data;
 
   const retryMutation = useRetryOrderDestinationMutation();
 
@@ -391,18 +433,39 @@ export function OrdersListPage(): ReactElement {
           const due = order.dispatchByAt ?? null;
           const view = formatShipBy(due);
           if (!due || !view) return <span className="text-muted">—</span>;
+          // BE-owned SLA bucket drives the badge (#1108) — single source of truth
+          // the filter agrees with; the live countdown stays client-side. Falls
+          // back to the client-derived urgency for older payloads without slaState.
+          const sla = slaBadge(order.slaState);
+          const tone = sla ? sla.tone : SHIP_BY_TONE[view.level];
+          const label = sla ? sla.label : view.remaining;
           return (
             <span className="orders-cell-stack">
-              <StatusBadge tone={SHIP_BY_TONE[view.level]} withDot compact>
-                {view.remaining}
+              <StatusBadge tone={tone} withDot compact>
+                {label}
               </StatusBadge>
-              <span className="text-muted orders-cell-sub">
+              <span className="text-muted orders-cell-sub mono tabular">
+                {sla ? `${view.remaining} · ` : ''}
                 <TimeDisplay iso={due} format="date" />
               </span>
             </span>
           );
         },
         hideBelow: 768,
+      },
+      {
+        id: 'fulfillment',
+        header: 'Fulfillment',
+        sortable: true,
+        cell: (order) => {
+          const f = fulfillmentBadge(order.fulfillmentState);
+          return (
+            <StatusBadge tone={f.tone} withDot compact>
+              {f.label}
+            </StatusBadge>
+          );
+        },
+        hideBelow: 1024,
       },
       {
         id: 'createdAt',
@@ -549,6 +612,7 @@ export function OrdersListPage(): ReactElement {
   function refreshAll(): void {
     void query.refetch();
     void summaryQuery.refetch();
+    void slaSummaryQuery.refetch();
   }
 
   // `R` keyboard shortcut — operator-cockpit "refresh everything visible".
@@ -654,13 +718,48 @@ export function OrdersListPage(): ReactElement {
               onChange={(e) => { setFilterParam('createdTo', e.target.value); }}
             />
           </label>
+          <Select
+            aria-label="Filter by ship-by SLA"
+            value={slaState ?? ''}
+            onChange={(e) => { setFilterParam('slaState', e.target.value); }}
+          >
+            <option value="">Any SLA</option>
+            {SLA_FILTER_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </Select>
+          <Select
+            aria-label="Filter by fulfillment"
+            value={fulfillmentState ?? ''}
+            onChange={(e) => { setFilterParam('fulfillmentState', e.target.value); }}
+          >
+            <option value="">Any fulfillment</option>
+            {FULFILLMENT_FILTER_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </Select>
         </div>
       </div>
 
-      <div className="ds-row" style={{ gap: 'var(--space-2)', flexWrap: 'wrap' }}>
+      <div className="ds-row" style={{ gap: 'var(--space-2)', flexWrap: 'wrap', alignItems: 'center' }}>
         <Chip tone="warning" active={breaching} onClick={toggleBreaching}>
           Ship-by ≤ 24h / overdue
         </Chip>
+        {/* SLA KPI affordance (#1108) — at-a-glance overdue / at-risk counts. */}
+        {slaSummary && (slaSummary.overdue > 0 || slaSummary.atRisk > 0) && (
+          <span className="ds-row" style={{ gap: 'var(--space-2)', alignItems: 'center' }}>
+            <StatusBadge tone="error" withDot compact>
+              {slaSummary.overdue} overdue
+            </StatusBadge>
+            <StatusBadge tone="warning" withDot compact>
+              {slaSummary.atRisk} at risk
+            </StatusBadge>
+          </span>
+        )}
         {query.data && (
           <span
             className="text-muted mono tabular"
@@ -752,6 +851,8 @@ export function OrdersListPage(): ReactElement {
                 const h = deriveOrderHealth(order);
                 const source = channelLabel(platformByConnection.get(order.sourceConnectionId));
                 const shipBy = formatShipBy(order.dispatchByAt ?? null);
+                const sla = slaBadge(order.slaState);
+                const fulfillment = fulfillmentBadge(order.fulfillmentState);
                 const failed = order.syncStatus.find((s) => s.status === 'failed');
                 const isRetrying =
                   retryMutation.isPending &&
@@ -769,11 +870,18 @@ export function OrdersListPage(): ReactElement {
                     <StatusBadge tone={h.tone} withDot compact>
                       {h.label}
                     </StatusBadge>
-                    {shipBy && (
+                    <StatusBadge tone={fulfillment.tone} withDot compact>
+                      {fulfillment.label}
+                    </StatusBadge>
+                    {sla ? (
+                      <StatusBadge tone={sla.tone} withDot compact>
+                        {sla.label}
+                      </StatusBadge>
+                    ) : shipBy ? (
                       <StatusBadge tone={SHIP_BY_TONE[shipBy.level]} withDot compact>
                         {shipBy.remaining}
                       </StatusBadge>
-                    )}
+                    ) : null}
                     {failed && order.recordStatus !== 'awaiting_mapping' ? (
                       <Button
                         tone="ghost"

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-1108-order-health-shipment-sla.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-1108-order-health-shipment-sla.md
@@ -1,0 +1,34 @@
+# Pre-implement analysis — #1108 (order-health: shipment state + ship-by SLA)
+
+**Plan:** `docs/plans/implementation-plan-1108-order-health-shipment-sla.md`
+**Gate date:** 2026-06-18 · **Verdict: `NEEDS-REVISION`**
+
+One reuse collision (fulfillment-state vocabulary) must be reconciled in the plan before coding. Everything else is additive and clean; the migration is an expected Warning.
+
+## Reuse findings
+
+| Plan artifact | Verdict | Evidence |
+|---|---|---|
+| `SlaStateValues` / `SlaState` (`none\|on_track\|at_risk\|overdue`) | **NEW (absent)** | No `SlaState`/`slaState`/`at_risk` anywhere in `libs/core` or `apps/web`. |
+| `deriveSlaState(...)` helper (core + FE) | **NEW (absent)** | Not found. |
+| `FulfillmentStateValues` / `FulfillmentState` (core, new) | **⚠ COLLISION → revise** | Core orders **already exports** `FulfillmentStatus` (`['delivered','dispatched','cancelled']`, the OMP read-back view) from the top-level barrel (`orders/index.ts:32,36`, `fulfillment-status-snapshot.types.ts:36`). FE **already** has `FulfillmentStateValues` (`['not-shipped','dispatched','delivered','failed','unavailable']`, hyphenated) in `apps/web/.../order-health.ts:124`. The plan's new core `FulfillmentState` (`not_shipped\|dispatched\|delivered\|failed`) is a **third, near-identical vocabulary** and is one character off the existing exported `FulfillmentStatus`. |
+| `order_records.fulfillmentState` column | **NEW (absent)** | No fulfillment column on `order-record.orm-entity.ts` (only `recordStatus`, `syncStatus`, `dispatchByAt`). |
+| `IOrderRecordService.updateFulfillmentState(orderId, state)` | **PARTIAL (extend)** | Interface exists (`order-record.service.interface.ts:19`, methods: `persistOrder`, `updateSyncStatus`, `persistIncomingSnapshot`, `getOrderRecord`). Method is new/additive — mirror `updateSyncStatus`. **Only one impl** (`order-record.service.ts`) to update. |
+| shipping `recomputeOrderFulfillment(orderId)` + write-path calls | **NEW (absent)** | No order-level fulfillment rollup in shipping today. |
+| `slaState` / `fulfillmentState` on list/summary DTOs + filters | **PARTIAL (extend)** | `dispatchByAt` already on `OrderRecordResponseDto`; new fields are additive. |
+
+## Backward-compatibility findings
+
+- **Warning — migration required.** New `order_records.fulfillmentState` column + index. Latest migration is `1808000000000-create-invoice-records.ts`; the new file MUST sort **after** it (e.g. `1809000000000-...`) to satisfy the migration-ordering guard (#1020). Provide up + down; verify `migration:show`.
+- **Low (additive) — `IOrderRecordService` gains a method.** It's consumed cross-context by `shipping` (imports `IOrderRecordService` from `@openlinker/core/orders` — confirmed in shipment-dispatch/status-sync specs). Adding a method is additive and the *sanctioned* push-direction (`shipping → orders`); **no `orders → shipping` edge is introduced** (good — that would be a cross-context cycle). Update the single impl + any inline `jest.Mocked<IOrderRecordService>` test objects.
+- **Low (additive) — response DTO fields.** `slaState` + `fulfillmentState` are new optional fields; no removed/retyped field → no break.
+- **`check:invariants`: expected clean.** No deep-barrel imports planned; cross-context surface stays `IOrderRecordService` + token; `as const` unions in `*.types.ts`; service keeps its `implements` clause. Confirm the FE↔core type alignment doesn't tempt a deep import.
+
+## Open questions (resolve in the plan before coding)
+
+1. **Fulfillment-state naming + vocabulary (blocking-for-clarity).** Pick a name that doesn't collide with the existing exported `FulfillmentStatus`. Options: (a) reuse/rename to something explicit like `OrderFulfillmentRollup`/`FulfillmentRollupState`; (b) align the **value spelling** with the FE (`not-shipped` hyphen vs `not_shipped` underscore) and decide whether `unavailable` (FE-only render state from shipping-capability) belongs in the stored vocab (recommend: **no** — keep it FE-render-only, store `not_shipped`/null). Whatever is chosen, the FE `FulfillmentState` and the new core type should share one spelling to avoid a translation layer.
+2. **Rollup precedence ownership.** Confirm the rollup derivation (N shipments → one state) lives in **shipping** (it owns shipment status) and orders only *stores* the pushed value — the plan says this; keep it so (orders must not import shipping).
+3. **SLA × fulfillment interaction.** Confirm the "overdue clears once shipped" rule is computed where both signals are available (FE has both off the row post-change; or define an `effectiveSla` that the BE leaves raw and the FE combines). Plan leans FE-combine — make it explicit.
+
+## Bottom line
+`NEEDS-REVISION`: the design is sound and almost entirely additive (no contract breaks; migration is expected and acknowledged; cross-context direction is correct). The one must-fix before coding is the **fulfillment-state vocabulary collision** — three overlapping types (`FulfillmentStatus` core / `FulfillmentState` FE / proposed `FulfillmentState` core). Reconcile the name + spelling in the plan, then proceed.

--- a/docs/plans/implementation-plan-1108-order-health-shipment-sla.md
+++ b/docs/plans/implementation-plan-1108-order-health-shipment-sla.md
@@ -1,0 +1,79 @@
+# Implementation Plan — #1108 fold shipment state + ship-by SLA into derived order-health
+
+**Issue:** [#1108](https://github.com/openlinker-project/openlinker/issues/1108) · **Branch:** `1108-order-health-shipment-sla`
+**Source:** non-deferred read-only slice carved out of #1032 (spec `docs/specs/product-spec-1032-order-status-state-machine.md`). Extends #929 (derived order-health) + #927 (`dispatchByAt`).
+
+## 1. Understand
+
+**Goal:** make an order's *real* state legible at a glance and filterable — fold in (a) the **ship-by SLA** (overdue / at-risk) and (b) **shipment/fulfillment state** — on top of the existing sync-only order-health.
+
+**Layer:** Core (derivation + SQL) + API (DTO/filters) + Frontend (list/detail rendering + filter). Read-only / derive-only.
+
+**Non-goals (hard):** no OL-owned status transitions / cancel-propagation / outbound writes (that's the DEFERRED #1032 end-state); no SLA *enforcement* (surface only); no multi-destination reconciled rollup.
+
+## 2. Research findings (verified)
+
+- **Order-health** = `OrderHealthValues = [awaiting_mapping, needs_attention, synced, awaiting_dispatch]`, derived in two places from `recordStatus` + `syncStatus[]`:
+  - BE: `order-record.repository.ts` — `COUNT(*) FILTER` summary + `applyHealthFilter` (TypeORM QB; SQL fragments `IS_MAPPING` / `HAS_FAILED` / `HAS_SYNCED`).
+  - FE: `apps/web/src/features/orders/lib/order-health.ts` — pure `deriveOrderHealth(order)`.
+- **`dispatchByAt`** is already a denormalized, indexed `timestamptz` column on `order_records` (#927), already in `OrderRecordResponseDto`, already rendered as a tone-coded **Ship-by countdown** on the list (`orders-list-page.tsx`) and detail. It is **not** fulfillment-aware and **not** a health/filter dimension.
+- **Shipment state** lives only in `shipments` (shipping context); `Shipment.orderId` → order. Orders context does **not** read shipments. **`orders → shipping` would create a dependency cycle** (shipping already depends on `IOrderRecordService`).
+- FE already has `deriveFulfillment(shipmentStatuses, hasShippingCapability) → not-shipped|dispatched|delivered|failed|unavailable` and fetches shipments per-order on **detail** (`useOrderShipmentsQuery`), composed app-side — not on the list.
+
+## 3. Design
+
+### Decision 1 — SLA is an ORTHOGONAL axis, not a 5th health bucket
+Sync-health answers "did it sync to destinations?"; SLA answers "is dispatch late?". Merging SLA into the 4-value enum breaks its documented precedence and conflates two questions. So model SLA as a **separate, derived signal**:
+
+```
+SlaStateValues = ['none', 'on_track', 'at_risk', 'overdue'] as const
+```
+derived from `dispatchByAt` vs `now` (+ a configurable at-risk window). `none` when `dispatchByAt` is null **or** the order is already shipped (see source-of-truth rule below).
+
+- **Backend is the single source of truth for `slaState`** (tech-review fix). The BE derives the bucket from the order's own indexed `dispatchByAt` **and applies the "cleared once shipped" rule using the row's `fulfillmentState`** (Decision 2) — so `slaState` is `none` once `fulfillmentState ∈ {dispatched, delivered}`. The BE exposes `slaState` on the list response and uses the **same** derivation for the health/SLA summary counts and the list **filter + sort**. This guarantees the list filter and the row badge agree.
+- **The at-risk window is one constant, owned by the BE** (a single exported const in the core types; default 24h). The FE does **not** re-derive the bucket — it consumes `slaState` from the response and computes only the **live ticking countdown** label from `dispatchByAt` (legitimately time-relative/client-side; the existing `formatShipBy` already does this). No duplicated business logic (`frontend-architecture.md` App Boundary).
+
+### Decision 2 — Shipment/fulfillment state denormalized onto `order_records` (CHOSEN: scope B)
+To make fulfillment **server-side filterable/sortable** on the list (full AC coverage), denormalize a rollup column onto `order_records`, kept fresh by the shipping write-path. This respects the dependency direction (`shipping → orders` already exists; orders never imports shipping).
+
+- **New column** `order_records.fulfillmentState` (nullable varchar, indexed) holding a per-order rollup. **NULL ≡ `not-shipped`** in all derivations (no backfill needed for correctness; see backfill note).
+- **Type name (tech-review fix): `FulfillmentRollupState`** — deliberately distinct from the existing exported `FulfillmentStatus` (the OMP read-back view, `delivered|dispatched|cancelled`). **One shared value spelling with the FE**: `['not-shipped', 'dispatched', 'delivered', 'failed'] as const` (hyphenated, matching the FE's existing `deriveFulfillment` output so no translation layer). `unavailable` stays **FE-render-only** (computed from shipping-capability; never stored).
+- **Rollup derivation lives in SHIPPING** (it owns shipment status). A single shipping helper `recomputeOrderFulfillment(orderId)` loads the order's shipments, derives the rollup (`delivered` > `dispatched` (generated/dispatched/in-transit) > `failed` (all terminal failed/cancelled) > `not-shipped`), and calls **`IOrderRecordService.updateFulfillmentState(orderId, state)`** (new additive method on the existing orders service interface; mirrors the existing `updateSyncStatus`).
+- **Write-path call-sites:** invoke `recomputeOrderFulfillment` after any shipment status mutation — `ShipmentDispatchService`, `ShipmentStatusSyncService`, `ShipmentCancellationService`, `FulfillmentStatusSyncService` (+ bulk variants). Best-effort, logged; a failed projection never fails the shipment op.
+- **Reconciliation backstop (tech-review fix):** `FulfillmentStatusSyncService` already polls/derives shipment state per order — it calls `recomputeOrderFulfillment` too, so a dropped best-effort projection self-heals on the next poll tick.
+- **Backfill / NULL semantics (tech-review fix):** treat `NULL` as `not-shipped` everywhere (derivation, filter, summary), so existing orders are correct-by-default on day one; orders with prior shipments converge to their true rollup on the next shipment mutation **or** the reconciliation poll. No data migration required — the column ships nullable with a documented NULL≡not-shipped rule. (If a same-day accurate fulfillment filter on historical orders is later wanted, a one-shot backfill from `shipments` is a follow-up, not part of this slice.)
+- **Migration** required: add column + index. **Synthetic sequential prefix** strictly greater than the current tail `1808000000000` → **`1809000000000-add-order-fulfillment-state.ts`**, class suffix `…1809000000000`, `up()` + `down()`, NOT a `Date.now()` prefix (`docs/migrations.md` rule 3; guarded by `check-migration-timestamps.mjs`). Verify `migration:show`.
+
+### Recommendation (resolved at gate → scope B)
+**Decision 1 (server-side SLA, BE-owned bucket incl. cleared-once-shipped) + Decision 2 (denormalized `FulfillmentRollupState` projection).** Both signals server-side filterable/sortable; full AC coverage. ~M (migration + write-path). The FE reads `fulfillmentState` + `slaState` off the order row — no per-list app-layer shipments fetch — and computes only the live ship-by countdown client-side.
+
+## 4. Steps
+
+**Core — types & SLA derivation**
+1. New `orders/domain/types/order-sla.types.ts` and `order-fulfillment.types.ts` (dedicated files, mirroring `fulfillment-status-snapshot.types.ts`): `SlaStateValues`/`SlaState` (`none|on_track|at_risk|overdue`) + `SLA_AT_RISK_WINDOW_MS` const; `FulfillmentRollupStateValues`/`FulfillmentRollupState` (`not-shipped|dispatched|delivered|failed`). Pure helpers `deriveSlaState(dispatchByAt, fulfillmentState, now)` (applies cleared-once-shipped) and `deriveFulfillmentRollup(shipmentStatuses)`. Extend summary types with SLA + fulfillment counts (sibling interfaces). Export all from the `orders` barrel. + unit specs (precedence + NULL≡not-shipped + cleared-once-shipped).
+
+**Core — persistence + projection**
+2. Migration (`apps/api/src/migrations/`) — add `order_records.fulfillmentState` (nullable varchar) + index. Per `docs/migrations.md`; verify with `migration:show`.
+3. `order-record.orm-entity.ts` — add the `fulfillmentState` column. `order-record.repository.ts` — persist it; add SQL fragments + `applySlaFilter` (over `dispatchByAt`) + `applyFulfillmentFilter` (over the new column) + sort; extend the `COUNT(*) FILTER` summary.
+4. `orders` service interface + impl — add `updateFulfillmentState(orderId, state)` to `IOrderRecordService` / `OrderRecordService` (+ repo method). Domain entity stays anemic (persistence-only mutation).
+
+**Shipping — rollup write-path**
+5. New shipping helper `recomputeOrderFulfillment(orderId)` (loads order's shipments via `ShipmentRepositoryPort.findByOrderId`, derives the rollup, calls `IOrderRecordService.updateFulfillmentState`). Best-effort + logged.
+6. Call it from the shipment-status mutation sites: `ShipmentDispatchService`, `ShipmentStatusSyncService`, `ShipmentCancellationService`, `FulfillmentStatusSyncService` (+ bulk). + unit specs for the rollup precedence.
+
+**API**
+7. Order list/summary DTO + query params — expose `slaState` + `fulfillmentState`; add both as filter + sort; add summary counts. (`dispatchByAt` already exposed.)
+
+**Frontend** (use `/frontend-design:frontend-design` for new visuals; responsive mobile+tablet+desktop)
+8. FE order types + `order-health.ts` — add `slaState` + `fulfillmentState` to the `OrderRecord` FE type; **consume `slaState` from the response** (do NOT re-derive the bucket); reconcile the existing FE `FulfillmentState`/`deriveFulfillment` to the shared `not-shipped|dispatched|delivered|failed` spelling (keep `unavailable` as the FE-only capability-absent render state). SLA badge tone map; the live ship-by countdown stays client-side via the existing `formatShipBy`.
+9. Order list — fulfillment-state cell/badge + SLA badge; SLA + fulfillment **filter controls backed by URL search params** (mirroring the existing `health` filter — `frontend-architecture.md` URL-state rule); KPI strip counts.
+10. Order detail / health-summary strip — fold SLA + the row-level fulfillment state into the existing summary (Fulfillment cell already exists).
+
+**Tests**: unit (`deriveSlaState` + rollup precedence, core & FE), int-spec (list filter/sort/summary for both axes; the shipping→order projection write-path), component (badges/filters).
+
+## 5. Validate
+- Architecture: **no `orders → shipping` import** (projection is pushed *from* shipping via `IOrderRecordService`); rollup derivation stays in shipping; SLA stays intra-order. `as const` unions in `*.types.ts`. No `any`. Anemic entity (mutation via repo/service).
+- Migration validated (`migration:show`, up/down). Naming/headers/`pnpm check:invariants` clean. Responsive FE. Projection failures never fail the shipment op.
+
+## Gate resolution
+**Scope B chosen (2026-06-18):** Decision 1 + Decision 2 (denormalized `fulfillmentState` projection) for full server-side fulfillment filtering. ~M, includes a migration + the shipping write-path.

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -15,6 +15,7 @@ import type {
   OrderRecordPagination,
   PaginatedOrderRecords,
 } from '../../domain/types/order-record.types';
+import type { FulfillmentRollupState } from '../../domain/types/order-fulfillment.types';
 
 export interface IOrderRecordService {
   /**
@@ -91,4 +92,15 @@ export interface IOrderRecordService {
     filters: OrderRecordFilters,
     pagination: OrderRecordPagination
   ): Promise<PaginatedOrderRecords>;
+
+  /**
+   * Push a per-order fulfillment rollup (#1108) onto the order record. The
+   * cross-context surface the shipping context calls after a shipment-status
+   * change (`shipping → orders`, via this service — never the repository port).
+   * Best-effort/idempotent; a missing order row is a no-op.
+   */
+  updateFulfillmentState(
+    internalOrderId: string,
+    fulfillmentState: FulfillmentRollupState
+  ): Promise<void>;
 }

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -20,6 +20,7 @@ import type {
   OrderRecordPagination,
   PaginatedOrderRecords,
 } from '../../domain/types/order-record.types';
+import type { FulfillmentRollupState } from '../../domain/types/order-fulfillment.types';
 import { getPiiConfig } from '@openlinker/shared/config';
 import { ORDER_RECORD_REPOSITORY_TOKEN } from '../../orders.tokens';
 
@@ -263,6 +264,13 @@ export class OrderRecordService implements IOrderRecordService {
     pagination: OrderRecordPagination
   ): Promise<PaginatedOrderRecords> {
     return this.repository.findMany(filters, pagination);
+  }
+
+  async updateFulfillmentState(
+    internalOrderId: string,
+    fulfillmentState: FulfillmentRollupState
+  ): Promise<void> {
+    await this.repository.updateFulfillmentState(internalOrderId, fulfillmentState);
   }
 
   /**

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -11,6 +11,7 @@ import type { OrderRecordStatus } from '../types/order-record.types';
 import type { OrderSyncStatus, SyncAttempt } from '../types/order-sync.types';
 import { PaymentStatusValues } from '../types/payment-status.types';
 import type { PaymentStatus } from '../types/payment-status.types';
+import type { FulfillmentRollupState } from '../types/order-fulfillment.types';
 
 export type { OrderSyncStatus, SyncAttempt } from '../types/order-sync.types';
 
@@ -47,6 +48,14 @@ export class OrderRecord {
      * re-pulled order with a changed window stays fresh.
      */
     public readonly dispatchByAt: Date | null = null,
+    /**
+     * Per-order fulfillment rollup (#1108) — a denormalized projection of the
+     * order's shipment lifecycle, pushed from the shipping context via
+     * `updateFulfillmentState`. `null` ≡ `not-shipped` (no backfill needed).
+     * Lets the orders list show/filter "has this shipped?" without reaching
+     * into the shipping context.
+     */
+    public readonly fulfillmentState: FulfillmentRollupState | null = null,
   ) {}
 
   /**

--- a/libs/core/src/orders/domain/order-sla.spec.ts
+++ b/libs/core/src/orders/domain/order-sla.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for deriveSlaState (#1108).
+ *
+ * @module libs/core/src/orders/domain
+ */
+import { deriveSlaState } from './order-sla';
+import { SLA_AT_RISK_WINDOW_MS } from './types/order-sla.types';
+
+describe('deriveSlaState', () => {
+  const now = new Date('2026-06-18T12:00:00.000Z');
+  const future = (ms: number): Date => new Date(now.getTime() + ms);
+  const past = (ms: number): Date => new Date(now.getTime() - ms);
+
+  it('should return none when the order has already shipped (dispatched)', () => {
+    // even with an overdue deadline, a shipped order carries no SLA pressure
+    expect(deriveSlaState(past(60_000), 'dispatched', now)).toBe('none');
+  });
+
+  it('should return none when the order has already shipped (delivered)', () => {
+    expect(deriveSlaState(past(60_000), 'delivered', now)).toBe('none');
+  });
+
+  it('should return none when there is no ship-by deadline', () => {
+    expect(deriveSlaState(null, 'not-shipped', now)).toBe('none');
+    expect(deriveSlaState(null, null, now)).toBe('none');
+  });
+
+  it('should return overdue when the deadline has passed and not shipped', () => {
+    expect(deriveSlaState(past(1), 'not-shipped', now)).toBe('overdue');
+    // NULL fulfillment is treated as not-shipped
+    expect(deriveSlaState(past(1), null, now)).toBe('overdue');
+    // a failed shipment does not clear SLA pressure (still needs dispatch)
+    expect(deriveSlaState(past(1), 'failed', now)).toBe('overdue');
+  });
+
+  it('should return overdue exactly at the deadline (deadline <= now)', () => {
+    expect(deriveSlaState(new Date(now), 'not-shipped', now)).toBe('overdue');
+  });
+
+  it('should return at_risk when the deadline is within the at-risk window', () => {
+    expect(deriveSlaState(future(60_000), 'not-shipped', now)).toBe('at_risk');
+    expect(deriveSlaState(future(SLA_AT_RISK_WINDOW_MS), 'not-shipped', now)).toBe('at_risk');
+  });
+
+  it('should return on_track when the deadline is beyond the at-risk window', () => {
+    expect(deriveSlaState(future(SLA_AT_RISK_WINDOW_MS + 1), 'not-shipped', now)).toBe('on_track');
+  });
+});

--- a/libs/core/src/orders/domain/order-sla.ts
+++ b/libs/core/src/orders/domain/order-sla.ts
@@ -1,0 +1,42 @@
+/**
+ * Ship-by SLA Derivation
+ *
+ * Pure derivation of an order's ship-by SLA bucket (#1108) from its
+ * `dispatchByAt` deadline and fulfillment rollup. No I/O, no framework deps —
+ * the single source of truth for the SLA bucket, consumed by the API response
+ * mapper (the orders SQL filter/summary encode the same rule).
+ *
+ * @module libs/core/src/orders/domain
+ * @see {@link SlaState} for the bucket vocabulary + precedence
+ */
+import type { FulfillmentRollupState } from './types/order-fulfillment.types';
+import { SLA_AT_RISK_WINDOW_MS, type SlaState } from './types/order-sla.types';
+
+/**
+ * Derive the ship-by SLA bucket. `null` fulfillmentState ≡ `not-shipped`.
+ *
+ * An order that has already shipped (`dispatched` / `delivered`) carries no SLA
+ * pressure → `none`, regardless of `dispatchByAt`. See {@link SlaState} for the
+ * full precedence.
+ */
+export function deriveSlaState(
+  dispatchByAt: Date | null,
+  fulfillmentState: FulfillmentRollupState | null,
+  now: Date,
+): SlaState {
+  if (fulfillmentState === 'dispatched' || fulfillmentState === 'delivered') {
+    return 'none';
+  }
+  if (dispatchByAt === null) {
+    return 'none';
+  }
+  const deadline = dispatchByAt.getTime();
+  const nowMs = now.getTime();
+  if (deadline <= nowMs) {
+    return 'overdue';
+  }
+  if (deadline <= nowMs + SLA_AT_RISK_WINDOW_MS) {
+    return 'at_risk';
+  }
+  return 'on_track';
+}

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -15,6 +15,8 @@ import type {
   OrderHealthSummary,
   OrderHealthSummaryFilters,
 } from '../types/order-record.types';
+import type { OrderSlaSummary } from '../types/order-sla.types';
+import type { FulfillmentRollupState } from '../types/order-fulfillment.types';
 import type { SyncAttempt } from '../types/order-sync.types';
 
 export interface OrderRecordRepositoryPort {
@@ -63,4 +65,23 @@ export interface OrderRecordRepositoryPort {
    * date subset only — `health` itself is intentionally not a valid input.
    */
   countByHealth(filters: OrderHealthSummaryFilters): Promise<OrderHealthSummary>;
+
+  /**
+   * Count order records per ship-by SLA bucket (#1108) for the list KPI strip.
+   * Same scope subset + partition semantics as {@link countByHealth}; encodes
+   * the {@link SlaState} precedence (incl. cleared-once-shipped) against the
+   * server clock.
+   */
+  countBySla(filters: OrderHealthSummaryFilters): Promise<OrderSlaSummary>;
+
+  /**
+   * Push a per-order fulfillment rollup (#1108) onto the order record. Called
+   * from the shipping context after a shipment-status change (best-effort
+   * projection). Idempotent absolute-set; a missing order row is a no-op (never
+   * throws) so it can't fail the shipment operation.
+   */
+  updateFulfillmentState(
+    internalOrderId: string,
+    fulfillmentState: FulfillmentRollupState
+  ): Promise<void>;
 }

--- a/libs/core/src/orders/domain/types/order-fulfillment.types.ts
+++ b/libs/core/src/orders/domain/types/order-fulfillment.types.ts
@@ -1,0 +1,53 @@
+/**
+ * Order Fulfillment Rollup Types
+ *
+ * A per-order rollup of the order's shipment lifecycle (#1108), denormalized
+ * onto `order_records.fulfillmentState` so the orders list can show "has this
+ * shipped?" and filter/sort on it without reaching into the shipping context.
+ *
+ * **Distinct from `FulfillmentStatus`** (`fulfillment-status-snapshot.types.ts`):
+ * that union is the destination OMP's read-back view (#834). This one is OL's
+ * own rollup over the `Shipment` rows it owns. The rollup derivation lives in
+ * the shipping context (it owns shipment status) and is pushed onto the order
+ * via `IOrderRecordService.updateFulfillmentState`; orders never imports
+ * shipping.
+ *
+ * **Shared spelling with the FE**: the values intentionally match the FE
+ * `deriveFulfillment` output (`apps/web/.../order-health.ts`) so no translation
+ * layer is needed. The FE-only `unavailable` (shipping-capability absent) is a
+ * render concern and is deliberately NOT part of this stored vocabulary.
+ *
+ * **NULL semantics**: a NULL column value is treated as `not-shipped` in every
+ * derivation, filter, and summary — so existing orders are correct-by-default
+ * with no backfill; an order with prior shipments converges to its true rollup
+ * on the next shipment mutation or the reconciliation poll.
+ *
+ * @module libs/core/src/orders/domain/types
+ */
+
+/**
+ * Per-order fulfillment rollup values (#1108).
+ *
+ * PRECEDENCE (highest wins) — the shipping-side `deriveFulfillmentRollup`
+ * helper and the orders SQL filter/summary must both encode exactly this:
+ *   1. `delivered`   — any shipment delivered
+ *   2. `dispatched`  — any shipment in `generated | dispatched | in-transit`
+ *   3. `failed`      — shipments exist AND all are terminal `failed | cancelled`
+ *   4. `not-shipped` — the residual: no shipments, or only `draft` (also NULL)
+ */
+export const FulfillmentRollupStateValues = [
+  'not-shipped',
+  'dispatched',
+  'delivered',
+  'failed',
+] as const;
+
+/**
+ * Per-order fulfillment rollup type (#1108).
+ */
+export type FulfillmentRollupState = (typeof FulfillmentRollupStateValues)[number];
+
+/**
+ * Convenience: the stored-column type. `null` ≡ `not-shipped` (see module doc).
+ */
+export type FulfillmentRollupStateOrNull = FulfillmentRollupState | null;

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -7,6 +7,8 @@
  * @module libs/core/src/orders/domain/types
  */
 import type { OrderRecord } from '../entities/order-record.entity';
+import type { SlaState } from './order-sla.types';
+import type { FulfillmentRollupState } from './order-fulfillment.types';
 
 /**
  * Sync status filter values for order queries
@@ -128,10 +130,23 @@ export interface OrderRecordFilters {
    */
   dueBefore?: Date;
   /**
-   * Result ordering (#927/#944). Maps to a SQL `ORDER BY` by
+   * Ship-by SLA bucket filter (#1108). Encodes the {@link SlaState} rule in SQL
+   * (incl. the "cleared once shipped" guard via `fulfillmentState`), evaluated
+   * against the repository's server `now`. Matches the badge the FE renders from
+   * the response `slaState` (single source of truth).
+   */
+  slaState?: SlaState;
+  /**
+   * Fulfillment-rollup filter (#1108). NULL column ≡ `not-shipped`, so the
+   * `not-shipped` filter also matches rows with no stored value.
+   */
+  fulfillmentState?: FulfillmentRollupState;
+  /**
+   * Result ordering (#927/#944/#1108). Maps to a SQL `ORDER BY` by
    * `OrderRecordRepository.applySort`. `dispatchBy` (ship-by deadline, NULLs
    * last) is the list's triage default; the JSONB-derived keys (`customer`,
-   * `items`, `status`, `total`) back the clickable sortable columns (#944).
+   * `items`, `status`, `total`) back the clickable sortable columns (#944);
+   * `fulfillment` orders by the rollup ordinal (#1108).
    */
   sort?: OrderRecordSort;
   /**
@@ -155,6 +170,7 @@ export const OrderRecordSortValues = [
   'items',
   'status',
   'total',
+  'fulfillment',
 ] as const;
 export type OrderRecordSort = (typeof OrderRecordSortValues)[number];
 

--- a/libs/core/src/orders/domain/types/order-sla.types.ts
+++ b/libs/core/src/orders/domain/types/order-sla.types.ts
@@ -1,0 +1,57 @@
+/**
+ * Order Ship-by SLA Types
+ *
+ * The dispatch-SLA axis (#1108): is this order late to ship? Derived from the
+ * order's own `dispatchByAt` deadline (#927) reconciled with its fulfillment
+ * rollup (#1108) — an order that has already shipped carries no SLA pressure.
+ *
+ * **Orthogonal to order-health.** Sync-health (`order-record.types.ts`) answers
+ * "did it sync to destinations?"; SLA answers "is dispatch late?". They are
+ * separate axes — SLA is NOT a fifth health bucket.
+ *
+ * **Single source of truth (BE).** `slaState` is computed server-side via
+ * `deriveSlaState` and surfaced on the order response; the FE consumes it and
+ * never re-derives the bucket (it computes only the live ticking countdown from
+ * `dispatchByAt`). The list filter + summary encode the same rule in SQL. This
+ * guarantees the list filter and the row badge agree.
+ *
+ * @module libs/core/src/orders/domain/types
+ */
+
+/**
+ * Ship-by SLA bucket values (#1108).
+ *
+ * PRECEDENCE (the rule `deriveSlaState` and the orders SQL filter/summary both
+ * encode):
+ *   - `none`     — no deadline (`dispatchByAt` null) OR already shipped
+ *                  (`fulfillmentState ∈ { dispatched, delivered }`)
+ *   - `overdue`  — not shipped AND `dispatchByAt <= now`
+ *   - `at_risk`  — not shipped AND `now < dispatchByAt <= now + SLA_AT_RISK_WINDOW_MS`
+ *   - `on_track` — not shipped AND `dispatchByAt > now + SLA_AT_RISK_WINDOW_MS`
+ */
+export const SlaStateValues = ['none', 'on_track', 'at_risk', 'overdue'] as const;
+
+/**
+ * Ship-by SLA bucket type (#1108).
+ */
+export type SlaState = (typeof SlaStateValues)[number];
+
+/**
+ * At-risk lead window: an order whose ship-by deadline falls within this window
+ * ahead of `now` (and hasn't shipped) is `at_risk`. Single owned constant so the
+ * derivation helper and the SQL filter/summary share one threshold. 24 hours.
+ */
+export const SLA_AT_RISK_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Aggregate count of order records per SLA bucket (#1108) for the list KPI
+ * strip. `total` equals the sum of the four buckets for the same filter scope.
+ * Reuses `OrderHealthSummaryFilters` for its scope subset.
+ */
+export interface OrderSlaSummary {
+  total: number;
+  onTrack: number;
+  atRisk: number;
+  overdue: number;
+  none: number;
+}

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -89,6 +89,19 @@ export {
   OrderRecordSortDirection,
   OrderRecordSortDirectionValues,
 } from './domain/types/order-record.types';
+// Ship-by SLA axis + fulfillment rollup (#1108)
+export {
+  SlaState,
+  SlaStateValues,
+  SLA_AT_RISK_WINDOW_MS,
+  OrderSlaSummary,
+} from './domain/types/order-sla.types';
+export {
+  FulfillmentRollupState,
+  FulfillmentRollupStateValues,
+  FulfillmentRollupStateOrNull,
+} from './domain/types/order-fulfillment.types';
+export { deriveSlaState } from './domain/order-sla';
 
 // Services
 export { IOrderSyncService, OrderSyncRequest, OrderSyncResult } from './application/interfaces/order-sync.service.interface';

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -87,6 +87,17 @@ export class OrderRecordOrmEntity {
   @Index()
   dispatchByAt!: Date | null;
 
+  /**
+   * Per-order fulfillment rollup (#1108) — denormalized projection of the
+   * order's shipment lifecycle (`not-shipped | dispatched | delivered |
+   * failed`), pushed from the shipping context. Indexed so the orders list can
+   * filter/sort on it. NULL ≡ `not-shipped` (column ships nullable; no
+   * backfill — orders converge on the next shipment mutation / reconcile poll).
+   */
+  @Column({ type: 'varchar', nullable: true })
+  @Index()
+  fulfillmentState!: string | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -30,6 +30,9 @@ import type {
   OrderRecordSort,
   OrderRecordSortDirection,
 } from '../../../domain/types/order-record.types';
+import type { SlaState, OrderSlaSummary } from '../../../domain/types/order-sla.types';
+import { SLA_AT_RISK_WINDOW_MS } from '../../../domain/types/order-sla.types';
+import type { FulfillmentRollupState } from '../../../domain/types/order-fulfillment.types';
 
 @Injectable()
 export class OrderRecordRepository implements OrderRecordRepositoryPort {
@@ -122,6 +125,14 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
 
     if (filters.health) {
       this.applyHealthFilter(qb, filters.health);
+    }
+
+    if (filters.fulfillmentState) {
+      this.applyFulfillmentFilter(qb, filters.fulfillmentState);
+    }
+
+    if (filters.slaState) {
+      this.applySlaFilter(qb, filters.slaState);
     }
 
     this.applySort(qb, filters.sort, filters.dir);
@@ -281,6 +292,12 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
           'DESC'
         );
         return;
+      case 'fulfillment':
+        qb.orderBy(OrderRecordRepository.FULFILLMENT_ORDINAL, d('ASC')).addOrderBy(
+          'rec.createdAt',
+          'DESC'
+        );
+        return;
       case 'createdAt':
       default:
         // No-sort default stays createdAt DESC (unchanged for non-list callers).
@@ -317,6 +334,152 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
         );
         break;
     }
+  }
+
+  /**
+   * "Not shipped" guard (#1108): an order carries SLA pressure only while it
+   * hasn't shipped. NULL `fulfillmentState` ≡ `not-shipped`, so it counts as not
+   * shipped. Shared by the SLA filter + the SLA summary so the badge, filter,
+   * and KPI all agree.
+   */
+  private static readonly NOT_SHIPPED =
+    `(rec."fulfillmentState" IS NULL OR rec."fulfillmentState" NOT IN ('dispatched','delivered'))`;
+
+  /**
+   * Fulfillment-rollup sort ordinal (#1108) — most-actionable first when
+   * ascending: failed(0) < not-shipped(1) < dispatched(2) < delivered(3).
+   * NULL ≡ not-shipped(1).
+   */
+  private static readonly FULFILLMENT_ORDINAL =
+    `CASE rec."fulfillmentState" WHEN 'failed' THEN 0 WHEN 'dispatched' THEN 2 ` +
+    `WHEN 'delivered' THEN 3 ELSE 1 END`;
+
+  /**
+   * Narrow a `findMany` query to a single fulfillment-rollup value (#1108).
+   * `not-shipped` also matches NULL (the documented NULL≡not-shipped rule).
+   */
+  private applyFulfillmentFilter(
+    qb: SelectQueryBuilder<OrderRecordOrmEntity>,
+    state: FulfillmentRollupState
+  ): void {
+    if (state === 'not-shipped') {
+      qb.andWhere(`(rec."fulfillmentState" IS NULL OR rec."fulfillmentState" = 'not-shipped')`);
+      return;
+    }
+    qb.andWhere(`rec."fulfillmentState" = :fulfillmentState`, { fulfillmentState: state });
+  }
+
+  /**
+   * Narrow a `findMany` query to a single SLA bucket (#1108). Encodes the
+   * {@link SlaState} precedence against the repository's server `now`, incl. the
+   * "cleared once shipped" guard — the SQL twin of `deriveSlaState`; keep both
+   * in lockstep. NULL deadlines / shipped orders are `none`.
+   */
+  private applySlaFilter(qb: SelectQueryBuilder<OrderRecordOrmEntity>, slaState: SlaState): void {
+    const now = new Date();
+    const riskCutoff = new Date(now.getTime() + SLA_AT_RISK_WINDOW_MS);
+    const notShipped = OrderRecordRepository.NOT_SHIPPED;
+    switch (slaState) {
+      case 'none':
+        qb.andWhere(`(NOT ${notShipped}) OR rec."dispatchByAt" IS NULL`);
+        break;
+      case 'overdue':
+        qb.andWhere(`${notShipped} AND rec."dispatchByAt" IS NOT NULL AND rec."dispatchByAt" <= :slaNow`, {
+          slaNow: now,
+        });
+        break;
+      case 'at_risk':
+        qb.andWhere(
+          `${notShipped} AND rec."dispatchByAt" > :slaNow AND rec."dispatchByAt" <= :slaCutoff`,
+          { slaNow: now, slaCutoff: riskCutoff }
+        );
+        break;
+      case 'on_track':
+        qb.andWhere(`${notShipped} AND rec."dispatchByAt" > :slaCutoff`, { slaCutoff: riskCutoff });
+        break;
+    }
+  }
+
+  /**
+   * SLA-bucket count summary (#1108) for the list KPI strip — the SLA twin of
+   * `countByHealth`. One aggregate query partitioning every in-scope record into
+   * exactly one bucket via `COUNT(*) FILTER (...)`, encoding the same precedence
+   * as `applySlaFilter` / `deriveSlaState`. `now` is the server clock.
+   */
+  async countBySla(filters: OrderHealthSummaryFilters): Promise<OrderSlaSummary> {
+    // Per-query server clock. The list-row `slaState` (controller `toDto`) and
+    // the `applySlaFilter` predicate each take their own `new Date()`, so a row
+    // exactly on the at-risk boundary could bucket differently by milliseconds —
+    // immaterial at the 24h window, and the same eventual-consistency posture as
+    // the health summary. Thread a single `now` if exactness is ever required.
+    const now = new Date();
+    const riskCutoff = new Date(now.getTime() + SLA_AT_RISK_WINDOW_MS);
+    const notShipped = OrderRecordRepository.NOT_SHIPPED;
+    const qb = this.repository
+      .createQueryBuilder('rec')
+      .select('COUNT(*)', 'total')
+      .addSelect(
+        `COUNT(*) FILTER (WHERE ${notShipped} AND rec."dispatchByAt" IS NOT NULL AND rec."dispatchByAt" <= :slaNow)`,
+        'overdue'
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE ${notShipped} AND rec."dispatchByAt" > :slaNow AND rec."dispatchByAt" <= :slaCutoff)`,
+        'at_risk'
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE ${notShipped} AND rec."dispatchByAt" > :slaCutoff)`,
+        'on_track'
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE (NOT ${notShipped}) OR rec."dispatchByAt" IS NULL)`,
+        'none'
+      )
+      .setParameters({ slaNow: now, slaCutoff: riskCutoff });
+
+    if (filters.sourceConnectionId) {
+      qb.andWhere('rec.sourceConnectionId = :sourceConnectionId', {
+        sourceConnectionId: filters.sourceConnectionId,
+      });
+    }
+    if (filters.customerId) {
+      qb.andWhere('rec.customerId = :customerId', { customerId: filters.customerId });
+    }
+    if (filters.createdFrom) {
+      qb.andWhere('rec.createdAt >= :createdFrom', { createdFrom: filters.createdFrom });
+    }
+    if (filters.createdTo) {
+      qb.andWhere('rec.createdAt <= :createdTo', { createdTo: filters.createdTo });
+    }
+
+    const raw = await qb.getRawOne<{
+      total: string;
+      on_track: string;
+      at_risk: string;
+      overdue: string;
+      none: string;
+    }>();
+
+    return {
+      total: Number(raw?.total ?? 0),
+      onTrack: Number(raw?.on_track ?? 0),
+      atRisk: Number(raw?.at_risk ?? 0),
+      overdue: Number(raw?.overdue ?? 0),
+      none: Number(raw?.none ?? 0),
+    };
+  }
+
+  /**
+   * Push a fulfillment-rollup value onto the order (#1108). Called from the
+   * shipping context after any shipment-status mutation (best-effort projection).
+   * Idempotent — sets the absolute value. No-op (no throw) when the order row
+   * doesn't exist, so a shipment that references an order OL hasn't recorded
+   * never fails the shipment op.
+   */
+  async updateFulfillmentState(
+    internalOrderId: string,
+    fulfillmentState: FulfillmentRollupState
+  ): Promise<void> {
+    await this.repository.update({ internalOrderId }, { fulfillmentState });
   }
 
   async upsert(orderRecord: OrderRecord): Promise<OrderRecord> {
@@ -447,7 +610,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       entity.createdAt,
       entity.updatedAt,
       syncAttempts,
-      entity.dispatchByAt
+      entity.dispatchByAt,
+      (entity.fulfillmentState as FulfillmentRollupState | null) ?? null
     );
   }
 
@@ -479,6 +643,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     }));
     entity.recordStatus = orderRecord.recordStatus;
     entity.dispatchByAt = orderRecord.dispatchByAt;
+    entity.fulfillmentState = orderRecord.fulfillmentState;
     entity.createdAt = orderRecord.createdAt;
     entity.updatedAt = orderRecord.updatedAt;
     return entity;

--- a/libs/core/src/shipping/application/interfaces/order-fulfillment-projection.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/order-fulfillment-projection.service.interface.ts
@@ -1,0 +1,18 @@
+/**
+ * Order Fulfillment Projection Service Interface
+ *
+ * Contract for pushing a per-order fulfillment rollup (#1108) onto the orders
+ * context after a shipment-status change. The shipping context owns shipment
+ * status, derives the rollup, and projects it via `IOrderRecordService`
+ * (`shipping → orders`).
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+export interface IOrderFulfillmentProjectionService {
+  /**
+   * Recompute the order's fulfillment rollup from its current shipments and push
+   * it onto the order record. Best-effort: a failure is logged, never thrown, so
+   * it can't fail the shipment operation that triggered it.
+   */
+  recompute(orderId: string): Promise<void>;
+}

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -92,6 +92,7 @@ describe('FulfillmentStatusSyncService', () => {
       persistIncomingSnapshot: jest.fn(),
       getOrderRecord: jest.fn(),
       findMany: jest.fn(),
+      updateFulfillmentState: jest.fn(),
     };
 
     routing = {
@@ -118,6 +119,7 @@ describe('FulfillmentStatusSyncService', () => {
       orderRecords,
       routing,
       integrations,
+      { recompute: jest.fn() },
     );
   });
 

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.ts
@@ -59,6 +59,7 @@ import {
 } from '@openlinker/core/orders';
 
 import type { IFulfillmentStatusSyncService } from '../interfaces/fulfillment-status-sync.service.interface';
+import { IOrderFulfillmentProjectionService } from '../interfaces/order-fulfillment-projection.service.interface';
 import type {
   FulfillmentStatusSyncOptions,
   FulfillmentStatusSyncResult,
@@ -72,7 +73,10 @@ import {
 import { SHIPPING_METHOD } from '../../domain/types/shipping-method.types';
 import type { Shipment } from '../../domain/entities/shipment.entity';
 import type { UpdateShipmentInput } from '../../domain/types/shipment.types';
-import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+import {
+  ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN,
+  SHIPMENT_REPOSITORY_TOKEN,
+} from '../../shipping.tokens';
 
 /**
  * Project the OMP's neutral `FulfillmentStatus` onto the shipping
@@ -118,6 +122,8 @@ export class FulfillmentStatusSyncService implements IFulfillmentStatusSyncServi
     private readonly routing: IFulfillmentRoutingService,
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrations: IIntegrationsService,
+    @Inject(ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN)
+    private readonly fulfillmentProjection: IOrderFulfillmentProjectionService,
   ) {}
 
   async sync(
@@ -249,11 +255,17 @@ export class FulfillmentStatusSyncService implements IFulfillmentStatusSyncServi
             snapshot,
           );
           created += 1;
+          // Project the order rollup (#1108); also the reconciliation backstop
+          // that heals any best-effort projection dropped on the write-path.
+          await this.fulfillmentProjection.recompute(record.internalOrderId);
         } else {
           const patch = this.diffPatch(existing, snapshot);
           if (Object.keys(patch).length > 0) {
             await this.shipments.update(existing.id, patch);
             updated += 1;
+            if (patch.status) {
+              await this.fulfillmentProjection.recompute(record.internalOrderId);
+            }
           }
         }
       } catch (error) {

--- a/libs/core/src/shipping/application/services/order-fulfillment-projection.service.ts
+++ b/libs/core/src/shipping/application/services/order-fulfillment-projection.service.ts
@@ -1,0 +1,50 @@
+/**
+ * Order Fulfillment Projection Service
+ *
+ * Derives a per-order fulfillment rollup (#1108) from the order's shipments and
+ * pushes it onto the orders context via `IOrderRecordService.updateFulfillmentState`.
+ * Called by the shipment-mutation services after any status change, and by the
+ * branch-1 fulfillment-status poll as a reconciliation backstop, so the orders
+ * list reflects "has this shipped?" without a cross-context query.
+ *
+ * Best-effort by design: the rollup is a denormalized read-optimisation, never a
+ * source of truth — a projection failure is logged and swallowed so it can never
+ * fail the shipment operation that triggered it (the poll backstop heals drift).
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IOrderFulfillmentProjectionService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import {
+  type IOrderRecordService,
+  ORDER_RECORD_SERVICE_TOKEN,
+} from '@openlinker/core/orders';
+
+import type { IOrderFulfillmentProjectionService } from '../interfaces/order-fulfillment-projection.service.interface';
+import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import { deriveFulfillmentRollup } from '../../domain/fulfillment-rollup';
+import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+
+@Injectable()
+export class OrderFulfillmentProjectionService implements IOrderFulfillmentProjectionService {
+  private readonly logger = new Logger(OrderFulfillmentProjectionService.name);
+
+  constructor(
+    @Inject(SHIPMENT_REPOSITORY_TOKEN)
+    private readonly shipments: ShipmentRepositoryPort,
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecords: IOrderRecordService,
+  ) {}
+
+  async recompute(orderId: string): Promise<void> {
+    try {
+      const shipments = await this.shipments.findByOrderId(orderId);
+      const rollup = deriveFulfillmentRollup(shipments.map((s) => s.status));
+      await this.orderRecords.updateFulfillmentState(orderId, rollup);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Fulfillment-rollup projection failed for order ${orderId}: ${message}`);
+    }
+  }
+}

--- a/libs/core/src/shipping/application/services/shipment-cancellation.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-cancellation.service.spec.ts
@@ -77,7 +77,9 @@ describe('ShipmentCancellationService', () => {
       resolveAdapterMetadata: jest.fn(),
       listCapabilityAdapters: jest.fn(),
     };
-    service = new ShipmentCancellationService(repository, integrations);
+    service = new ShipmentCancellationService(repository, integrations, {
+      recompute: jest.fn(),
+    });
   });
 
   it('should void the provider shipment and persist cancelled for a generated shipment', async () => {

--- a/libs/core/src/shipping/application/services/shipment-cancellation.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-cancellation.service.ts
@@ -20,6 +20,7 @@ import { Logger } from '@openlinker/shared/logging';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 
 import type { IShipmentCancellationService } from '../interfaces/shipment-cancellation.service.interface';
+import { IOrderFulfillmentProjectionService } from '../interfaces/order-fulfillment-projection.service.interface';
 import type { Shipment } from '../../domain/entities/shipment.entity';
 import { ShipmentCancellationNotSupportedException } from '../../domain/exceptions/shipment-cancellation-not-supported.exception';
 import { ShipmentNotCancellableException } from '../../domain/exceptions/shipment-not-cancellable.exception';
@@ -28,7 +29,10 @@ import { isShipmentCanceller } from '../../domain/ports/capabilities/shipment-ca
 import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
 import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
 import { SHIPMENT_STATUS, type ShipmentStatus } from '../../domain/types/shipment-status.types';
-import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+import {
+  ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN,
+  SHIPMENT_REPOSITORY_TOKEN,
+} from '../../shipping.tokens';
 
 /** Capability the shipment's connection must declare to resolve a provider adapter. */
 const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
@@ -48,6 +52,8 @@ export class ShipmentCancellationService implements IShipmentCancellationService
     private readonly shipments: ShipmentRepositoryPort,
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrations: IIntegrationsService,
+    @Inject(ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN)
+    private readonly fulfillmentProjection: IOrderFulfillmentProjectionService,
   ) {}
 
   async cancel(shipmentId: string): Promise<Shipment> {
@@ -93,9 +99,12 @@ export class ShipmentCancellationService implements IShipmentCancellationService
       }
     }
 
-    return this.shipments.update(shipmentId, {
+    const cancelled = await this.shipments.update(shipmentId, {
       status: SHIPMENT_STATUS.Cancelled,
       cancelledAt: new Date(),
     });
+    // Reflect the cancellation in the order's fulfillment rollup (#1108).
+    await this.fulfillmentProjection.recompute(shipment.orderId);
+    return cancelled;
   }
 }

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -76,6 +76,7 @@ describe('ShipmentDispatchNotificationService', () => {
       persistIncomingSnapshot: jest.fn(),
       getOrderRecord: jest.fn().mockResolvedValue(makeRecord()),
       findMany: jest.fn(),
+      updateFulfillmentState: jest.fn(),
     };
     identifierMapping = {
       getInternalId: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -143,8 +143,16 @@ describe('ShipmentDispatchService', () => {
       updateSyncStatus: jest.fn(),
       getOrderRecord: jest.fn().mockResolvedValue(null),
       findMany: jest.fn(),
+      updateFulfillmentState: jest.fn(),
     };
-    service = new ShipmentDispatchService(repository, routing, integrations, orders);
+    const fulfillmentProjection = { recompute: jest.fn() };
+    service = new ShipmentDispatchService(
+      repository,
+      routing,
+      integrations,
+      orders,
+      fulfillmentProjection,
+    );
   });
 
   describe('payment-status dispatch gate (#938)', () => {

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
@@ -36,6 +36,7 @@ import {
 } from '@openlinker/core/orders';
 
 import type { IShipmentDispatchService } from '../interfaces/shipment-dispatch.service.interface';
+import { IOrderFulfillmentProjectionService } from '../interfaces/order-fulfillment-projection.service.interface';
 import type {
   ShipmentDispatchInput,
   ShipmentDispatchResult,
@@ -51,7 +52,10 @@ import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.p
 import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
 import { SHIPMENT_STATUS } from '../../domain/types/shipment-status.types';
 import { DISPATCH_BLOCKING_PAYMENT_STATUSES } from '../types/dispatch-payment-policy.types';
-import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+import {
+  ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN,
+  SHIPMENT_REPOSITORY_TOKEN,
+} from '../../shipping.tokens';
 
 /** Capability the resolved processor connection must declare to issue a label. */
 const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
@@ -72,6 +76,8 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
     private readonly integrations: IIntegrationsService,
     @Inject(ORDER_RECORD_SERVICE_TOKEN)
     private readonly orders: IOrderRecordService,
+    @Inject(ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN)
+    private readonly fulfillmentProjection: IOrderFulfillmentProjectionService,
   ) {}
 
   async dispatch(input: ShipmentDispatchInput): Promise<ShipmentDispatchResult> {
@@ -253,13 +259,16 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
         cod: input.cod,
       });
 
-      return await this.shipments.update(shipment.id, {
+      const generated = await this.shipments.update(shipment.id, {
         status: SHIPMENT_STATUS.Generated,
         providerShipmentId: result.providerShipmentId,
         // Some providers issue tracking asynchronously; leave null when absent.
         trackingNumber: result.trackingNumber ?? undefined,
         labelPdfRef: result.labelPdfRef,
       });
+      // Project the order's fulfillment rollup (#1108) — best-effort, never throws.
+      await this.fulfillmentProjection.recompute(input.orderId);
+      return generated;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(
@@ -272,6 +281,8 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
         failedAt: new Date(),
         errorMessage: message,
       });
+      // Reflect the failed shipment in the order rollup (#1108) before surfacing.
+      await this.fulfillmentProjection.recompute(input.orderId);
       throw error;
     }
   }

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
@@ -112,7 +112,9 @@ describe('ShipmentStatusSyncService', () => {
       },
     );
 
-    service = new ShipmentStatusSyncService(shipments, integrations, orderRecords);
+    service = new ShipmentStatusSyncService(shipments, integrations, orderRecords, {
+      recompute: jest.fn(),
+    });
   });
 
   describe('page mechanics', () => {

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.ts
@@ -46,6 +46,7 @@ import {
 } from '@openlinker/core/orders';
 
 import type { IShipmentStatusSyncService } from '../interfaces/shipment-status-sync.service.interface';
+import { IOrderFulfillmentProjectionService } from '../interfaces/order-fulfillment-projection.service.interface';
 import type {
   ShipmentStatusSyncOptions,
   ShipmentStatusSyncResult,
@@ -61,7 +62,10 @@ import {
   TerminalShipmentStatusValues,
 } from '../../domain/types/shipment-status.types';
 import type { UpdateShipmentInput } from '../../domain/types/shipment.types';
-import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+import {
+  ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN,
+  SHIPMENT_REPOSITORY_TOKEN,
+} from '../../shipping.tokens';
 
 const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
 const ORDER_PROCESSOR_MANAGER_CAPABILITY = 'OrderProcessorManager';
@@ -99,6 +103,8 @@ export class ShipmentStatusSyncService implements IShipmentStatusSyncService {
     private readonly integrations: IIntegrationsService,
     @Inject(ORDER_RECORD_SERVICE_TOKEN)
     private readonly orderRecords: IOrderRecordService,
+    @Inject(ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN)
+    private readonly fulfillmentProjection: IOrderFulfillmentProjectionService,
   ) {}
 
   async sync(
@@ -141,6 +147,10 @@ export class ShipmentStatusSyncService implements IShipmentStatusSyncService {
         if (Object.keys(patch).length > 0) {
           await this.shipments.update(shipment.id, patch);
           updated += 1;
+          // A terminal-status change moves the order rollup (#1108) — reproject.
+          if (patch.status) {
+            await this.fulfillmentProjection.recompute(shipment.orderId);
+          }
         }
         if (didPush) {
           propagated += 1;
@@ -197,6 +207,9 @@ export class ShipmentStatusSyncService implements IShipmentStatusSyncService {
     const { patch } = await this.buildPatchAndMaybePush(shipment, snapshot);
     if (Object.keys(patch).length > 0) {
       await this.shipments.update(shipment.id, patch);
+      if (patch.status) {
+        await this.fulfillmentProjection.recompute(shipment.orderId);
+      }
     }
   }
 

--- a/libs/core/src/shipping/domain/fulfillment-rollup.spec.ts
+++ b/libs/core/src/shipping/domain/fulfillment-rollup.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for deriveFulfillmentRollup (#1108).
+ *
+ * @module libs/core/src/shipping/domain
+ */
+import { deriveFulfillmentRollup } from './fulfillment-rollup';
+
+describe('deriveFulfillmentRollup', () => {
+  it('should return not-shipped for an order with no shipments', () => {
+    expect(deriveFulfillmentRollup([])).toBe('not-shipped');
+  });
+
+  it('should return not-shipped when only draft shipments exist', () => {
+    expect(deriveFulfillmentRollup(['draft'])).toBe('not-shipped');
+    expect(deriveFulfillmentRollup(['draft', 'draft'])).toBe('not-shipped');
+  });
+
+  it('should return delivered when any shipment is delivered (highest precedence)', () => {
+    expect(deriveFulfillmentRollup(['delivered'])).toBe('delivered');
+    // delivered wins over an in-progress sibling and a failed sibling
+    expect(deriveFulfillmentRollup(['failed', 'delivered', 'dispatched'])).toBe('delivered');
+  });
+
+  it('should return dispatched for any in-progress shipment (generated/dispatched/in-transit)', () => {
+    expect(deriveFulfillmentRollup(['generated'])).toBe('dispatched');
+    expect(deriveFulfillmentRollup(['dispatched'])).toBe('dispatched');
+    expect(deriveFulfillmentRollup(['in-transit'])).toBe('dispatched');
+    // in-progress wins over a failed/draft sibling
+    expect(deriveFulfillmentRollup(['cancelled', 'in-transit'])).toBe('dispatched');
+    expect(deriveFulfillmentRollup(['draft', 'generated'])).toBe('dispatched');
+  });
+
+  it('should return failed only when every shipment is terminal failed/cancelled', () => {
+    expect(deriveFulfillmentRollup(['failed'])).toBe('failed');
+    expect(deriveFulfillmentRollup(['cancelled'])).toBe('failed');
+    expect(deriveFulfillmentRollup(['failed', 'cancelled'])).toBe('failed');
+  });
+
+  it('should not return failed when a non-terminal shipment coexists', () => {
+    // a draft alongside a failed re-issue means the order can still ship
+    expect(deriveFulfillmentRollup(['failed', 'draft'])).toBe('not-shipped');
+  });
+});

--- a/libs/core/src/shipping/domain/fulfillment-rollup.ts
+++ b/libs/core/src/shipping/domain/fulfillment-rollup.ts
@@ -1,0 +1,55 @@
+/**
+ * Order Fulfillment Rollup Derivation
+ *
+ * Pure derivation of a per-order fulfillment rollup (#1108) from the order's
+ * shipment statuses. Lives in the shipping context because shipping owns
+ * shipment status; the resulting `FulfillmentRollupState` (an orders-owned
+ * type) is pushed onto the order via `IOrderRecordService.updateFulfillmentState`.
+ * No I/O, no framework deps.
+ *
+ * @module libs/core/src/shipping/domain
+ * @see {@link FulfillmentRollupState} for the vocabulary + precedence
+ */
+import type { FulfillmentRollupState } from '@openlinker/core/orders';
+
+import type { ShipmentStatus } from './types/shipment-status.types';
+
+/** Shipment statuses that mean "physically on its way or in progress". */
+const IN_PROGRESS: ReadonlySet<ShipmentStatus> = new Set<ShipmentStatus>([
+  'generated',
+  'dispatched',
+  'in-transit',
+]);
+
+/** Terminal non-success shipment statuses. */
+const TERMINAL_FAILURE: ReadonlySet<ShipmentStatus> = new Set<ShipmentStatus>([
+  'failed',
+  'cancelled',
+]);
+
+/**
+ * Roll an order's shipment statuses up to a single fulfillment state.
+ * Empty input (no shipments) → `not-shipped`. See {@link FulfillmentRollupState}
+ * for the precedence this encodes.
+ *
+ * **Twin:** the FE `deriveFulfillment` in `apps/web/.../lib/order-health.ts`
+ * encodes the same precedence over the same shipment-status inputs (for the
+ * order-detail panel). Keep both in lockstep if the precedence changes.
+ */
+export function deriveFulfillmentRollup(
+  shipmentStatuses: readonly ShipmentStatus[],
+): FulfillmentRollupState {
+  if (shipmentStatuses.length === 0) {
+    return 'not-shipped';
+  }
+  if (shipmentStatuses.includes('delivered')) {
+    return 'delivered';
+  }
+  if (shipmentStatuses.some((status) => IN_PROGRESS.has(status))) {
+    return 'dispatched';
+  }
+  if (shipmentStatuses.every((status) => TERMINAL_FAILURE.has(status))) {
+    return 'failed';
+  }
+  return 'not-shipped';
+}

--- a/libs/core/src/shipping/shipping.module.ts
+++ b/libs/core/src/shipping/shipping.module.ts
@@ -42,9 +42,11 @@ import { ShipmentDispatchNotificationService } from './application/services/ship
 import { ShipmentStatusSyncService } from './application/services/shipment-status-sync.service';
 import { FulfillmentStatusSyncService } from './application/services/fulfillment-status-sync.service';
 import { ShipmentLabelService } from './application/services/shipment-label.service';
+import { OrderFulfillmentProjectionService } from './application/services/order-fulfillment-projection.service';
 import {
   BULK_SHIPMENT_DISPATCH_SERVICE_TOKEN,
   FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN,
+  ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN,
   PICKUP_POINT_CACHE_TOKEN,
   PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
   PICKUP_POINT_SEARCH_CACHE_TOKEN,
@@ -152,6 +154,13 @@ import {
     {
       provide: SHIPMENT_LABEL_SERVICE_TOKEN,
       useExisting: ShipmentLabelService,
+    },
+    // #1108 fulfillment-rollup projection: pushes a per-order rollup onto the
+    // orders context after any shipment-status mutation (best-effort).
+    OrderFulfillmentProjectionService,
+    {
+      provide: ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN,
+      useExisting: OrderFulfillmentProjectionService,
     },
   ],
   exports: [

--- a/libs/core/src/shipping/shipping.tokens.ts
+++ b/libs/core/src/shipping/shipping.tokens.ts
@@ -26,3 +26,6 @@ export const SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN = Symbol(
 export const SHIPMENT_STATUS_SYNC_SERVICE_TOKEN = Symbol('IShipmentStatusSyncService');
 export const FULFILLMENT_STATUS_SYNC_SERVICE_TOKEN = Symbol('IFulfillmentStatusSyncService');
 export const SHIPMENT_LABEL_SERVICE_TOKEN = Symbol('IShipmentLabelService');
+export const ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN = Symbol(
+  'IOrderFulfillmentProjectionService',
+);


### PR DESCRIPTION
## What & why

Surfaces two operator signals on the orders list, derived from data OL already persists. **Read-only / derive-only** — no OL-owned status transitions (that's the deferred #1032 state machine). The non-deferred slice carved out of #1032.

- **Ship-by SLA bucket** (`none | on_track | at_risk | overdue`) — turns the previously-inert `dispatchByAt` into a triage signal. **BE-owned single source of truth**: derived from `dispatchByAt` reconciled with fulfillment (cleared once shipped). The FE consumes `slaState` and never re-derives the bucket, so the list filter and the badge always agree; only the live countdown stays client-side.
- **Per-order fulfillment rollup** (`not-shipped | dispatched | delivered | failed`) — denormalized onto `order_records.fulfillmentState`, **projected from the shipping context** after any shipment-status change. `NULL ≡ not-shipped` (no backfill).

## How it's built (architecture)

- **Core:** `order-sla` / `order-fulfillment` types + pure `deriveSlaState` / `deriveFulfillmentRollup` helpers; `fulfillmentState` column + **migration `1809000000000`**; repo `slaState`/`fulfillment` filters + sort + `countBySla` summary; `updateFulfillmentState` on `IOrderRecordService`.
- **Shipping → orders projection:** `OrderFulfillmentProjectionService` (best-effort, logged) wired into the 4 shipment-mutation services (dispatch, status-sync, cancellation, branch-1 fulfillment-sync). Pushed via the orders **service interface** — respects the `shipping → orders` direction; **no `orders → shipping` edge** (verified by `check-cross-context-imports`). The branch-1 fulfillment poll doubles as the reconciliation backstop for any dropped best-effort projection.
- **API:** list `slaState`/`fulfillmentState` filters, response fields, `GET /orders/sla-summary`.
- **Web:** SLA + fulfillment badges (reused `StatusBadge`), URL-state filter controls, KPI counts — responsive (card-view parity). No new visual primitives.

## How to test

- Backend unit: `deriveSlaState`, `deriveFulfillmentRollup` (precedence, cleared-once-shipped, NULL≡not-shipped).
- Integration (`orders-read.int-spec.ts`): `slaState`/`fulfillmentState` filters + `/orders/sla-summary` partition, end-to-end through the migration + real DB.
- FE unit: `slaBadge` / `fulfillmentBadge` mappers.

## Quality gate

`pnpm lint` ✓ (incl. all invariants) · `pnpm type-check` ✓ · `pnpm test` ✓ · `pnpm test:integration` ✓ (59 suites / 287 passed) · `migration:show` ✓.

## Reviews applied

Passed `/pre-implement` + two `/tech-review` rounds. Fulfillment-vocabulary collision resolved (`FulfillmentRollupState`, distinct from the existing `FulfillmentStatus`); single-source-of-truth `slaState`; synthetic migration prefix; NULL semantics; lockstep comments on the twin derivations; integration coverage added.

**Deferred follow-up (non-blocking):** the SLA KPI renders as count badges rather than clickable KPI-strip segments (filtering is via the toolbar select) — a UX-consistency nicety, not an AC gap.

Related: non-deferred slice of #1032 (Gate D = DEFER); extends #929 (order-health) + #927 (`dispatchByAt`).

Closes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)