### PR TITLE
fix(ps-module): correct EventIdGenerator method call in ping.php (#1116)

### DIFF
--- a/apps/prestashop-module/openlinker/README.md
+++ b/apps/prestashop-module/openlinker/README.md
@@ -315,6 +315,6 @@ If a class does touch PS globals, it belongs in the real-PS integration test sui
 
 ## Related Documentation
 
-- [PrestaShop Webhook Integration](../../docs/webhooks/prestashop.md) - OpenLinker webhook integration guide
-- [PrestaShop Module Testing Guide](../../docs/prestashop-module-testing-guide.md) - Testing and troubleshooting
-- [Architecture Overview](../../docs/architecture-overview.md) - System architecture
+- [PrestaShop Webhook Integration](../../../docs/webhooks/prestashop.md) - OpenLinker webhook integration guide
+- [PrestaShop Module Testing Guide](../../../docs/prestashop-module-testing-guide.md) - Testing and troubleshooting
+- [Architecture Overview](../../../docs/architecture-overview.md) - System architecture

--- a/apps/prestashop-module/openlinker/controllers/front/ping.php
+++ b/apps/prestashop-module/openlinker/controllers/front/ping.php
@@ -67,18 +67,28 @@ class OpenLinkerPingModuleFrontController extends ModuleFrontController
 
         // Build a synthetic test_ping event. Fields mirror what an actionProductSave
         // event looks like so the OL intake's normal validation passes.
+        $connectionId = (string) Configuration::get('OPENLINKER_CONNECTION_ID');
+        $occurredAt = date('Y-m-d H:i:s');
+
         $event = new OutboxEvent();
-        $event->event_id = EventIdGenerator::generate();
+        $event->event_id = EventIdGenerator::generateEventId(
+            'prestashop',
+            $connectionId,
+            'test.ping',
+            'connection',
+            $connectionId,
+            $occurredAt
+        );
         $event->schema_version = 1;
         $event->provider = 'prestashop';
-        $event->connection_id = (string) Configuration::get('OPENLINKER_CONNECTION_ID');
+        $event->connection_id = $connectionId;
         // `test.` prefix is recognized by OL's webhook intake (`WebhookToJobHandler`)
         // as a verification event — skips job enqueue while still recording the
         // delivery, so the FE can show "last test ping at <ts>".
         $event->event_type = 'test.ping';
         $event->object_type = 'connection';
-        $event->external_id = $event->connection_id;
-        $event->occurred_at = date('Y-m-d H:i:s');
+        $event->external_id = $connectionId;
+        $event->occurred_at = $occurredAt;
         $event->payload_json = json_encode(['source' => 'install-verification']);
 
         try {

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -79,6 +79,14 @@ When a lesson hardens into a rule, **graduate it** to the canonical doc and leav
 **Applies to**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-delivery-shipping.adapter.ts` and the Allegro HTTP client interface.
 **Source**: Allegro shipping adapter implementation.
 
+## PS module PHP fatal errors surface as opaque `testPingTriggered=false` — debug via Apache logs, not OL logs
+
+**Context**: Configuring webhooks on a PrestaShop connection via "Re-configure webhooks" in the OL UI.
+**Problem**: `ping.php` called `EventIdGenerator::generate()`, a method that does not exist — only `EventIdGenerator::generateEventId(provider, connectionId, eventType, objectType, externalId, occurredAt)` exists. PHP threw a fatal `Error` (not `Exception`), bypassed all `catch (Exception $e)` blocks, and Apache returned HTTP 500. OL's `firePing()` saw `res.ok = false` and set `testPingTriggered: false`. There is no OL-side log of the failing request — the error is entirely inside the PS module PHP process.
+**Rule**: When debugging `testPingTriggered=false` after webhook install, **first check Apache error logs** inside the PS container (`docker compose exec prestashop tail -50 /var/log/apache2/error.log`) before investigating the OL side. A PHP `Fatal error: Call to undefined method` (or any other fatal) shows up there, not in NestJS logs. When writing PS module front controllers, prefer `catch (\Throwable $e)` over `catch (Exception $e)` to also catch PHP `Error` subclasses and return a structured 5xx rather than letting Apache serve a blank 500.
+**Applies to**: `apps/prestashop-module/openlinker/controllers/front/`, `apps/prestashop-module/openlinker/classes/EventIdGenerator.php`.
+**Source**: Discovered during local webhook setup; fixed in `apps/prestashop-module/openlinker/controllers/front/ping.php`.
+
 ## Allegro buyer-placed time is `lineItems[].boughtAt`, not a top-level checkout-form field
 
 **Context**: Capturing the buyer-placed timestamp from an Allegro order.


### PR DESCRIPTION

<!--
Thank you for contributing to OpenLinker!

Title: use Conventional Commits format — `feat(scope): subject`,
`fix(scope): subject`, `docs:`, `refactor:`, `test:`, `chore:`.
See CONTRIBUTING.md → Commits for the full type list.
-->

## Summary

<!-- 1–3 bullets: what changed and why. Focus on the why. -->

- ping.php called EventIdGenerator::generate() — a method that does not exist. PHP threw a fatal Error, which bypassed all catch (Exception $e) blocks, causing Apache to return HTTP 500. OL's firePing() saw res.ok = false and set testPingTriggered: false with no OL-side log of the failure.
- Fixed by replacing the call with the correct EventIdGenerator::generateEventId(provider, connectionId, eventType, objectType, externalId, occurredAt) with all six required arguments.
- Fixed broken relative doc links in README.md (../../docs/ → ../../../docs/).
- Added a docs/lessons.md entry documenting that PS module PHP fatals surface as testPingTriggered=false and must be debugged via Apache logs inside the PS container, not OL logs.

## Related issues

<!-- One `Closes #N` per issue this PR resolves. Issues are closed
     automatically when the PR merges — do not close them manually. -->

Closes #1116

## Test plan
<img width="1832" height="911" alt="image" src="https://github.com/user-attachments/assets/6ed89dc7-6c48-4987-b34b-707454a54384" />

```
[Nest] 176058  - 06/19/2026, 4:14:46 PM     LOG [PrestashopWebhookProvisioningAdapter] webhook_install.completed connectionId=912a11b3-9f29-4ad7 webhooksConfigured=true testPingTriggered=true actor=3c31193e-4a6a-4147-b4d6-7fc2b6e08024
```
<!-- How a reviewer verifies the change. Commands to run, paths to
     click through, edge cases to confirm. -->

- [x] Install OL PrestaShop module on a local PS instance
- [x] Create a PrestaShop connection in OL and click Re-configure webhooks
- [x] Verify testPingTriggered: true in the API response and that the webhook round-trip completes successfully
- [x] Confirm no PHP fatal errors appear in docker compose exec prestashop tail -50 /var/log/apache2/error.log

## Quality gate

- [x] `pnpm lint` passes (zero errors)
- [x] `pnpm type-check` passes (zero errors)
- [x] `pnpm test` passes (all unit tests green)
- [x] *Optional, Docker required:* `pnpm test:integration` passes — needed
      only if you touched `apps/api/test/integration/**` or any plugin's
      `infrastructure/adapters/`.



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>By submitting this pull request, I confirm that my contributions
are made under the terms of the [Apache License 2.0](../LICENSE), and I
certify the [Developer Certificate of Origin](https://developercertificate.org/)
by signing off my commits.</sub>
