### PR TITLE
feat(web): bulk shipment dispatch UI — batch generate-labels + handover protocol (#1109)

### DIFF
--- a/apps/web/src/features/orders/components/bulk-dispatch-dialog.schema.ts
+++ b/apps/web/src/features/orders/components/bulk-dispatch-dialog.schema.ts
@@ -1,0 +1,22 @@
+/**
+ * Bulk-dispatch dialog Zod schema (#1109)
+ *
+ * The shared parcel profile and every per-order override validate against the
+ * SAME `parcelSchema` — an override can never submit dims/weight the single-order
+ * form would have rejected (which would 422 mid-batch). Mirrors the parcel rules
+ * in `generate-label-form.schema.ts`.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import { z } from 'zod';
+
+/** Parcel dimensions + weight, shared by the batch profile and per-order rows. */
+export const parcelSchema = z.object({
+  length: z.coerce.number().int().positive('Length must be a positive integer'),
+  width: z.coerce.number().int().positive('Width must be a positive integer'),
+  height: z.coerce.number().int().positive('Height must be a positive integer'),
+  weightGrams: z.coerce.number().int().positive('Weight must be a positive integer'),
+});
+
+export type ParcelFormValues = z.input<typeof parcelSchema>;
+export type ParcelSubmission = z.output<typeof parcelSchema>;

--- a/apps/web/src/features/orders/components/bulk-dispatch-dialog.test.tsx
+++ b/apps/web/src/features/orders/components/bulk-dispatch-dialog.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * BulkDispatchDialog tests (#1109)
+ *
+ * Covers the dialog's risk-bearing behaviour: the multi-source fan-out + merge
+ * (incl. a rejected group synthesizing per-order failures, NOT vanishing),
+ * ineligible orders surfaced with a reason, the empty-eligible guard, and the
+ * per-carrier protocol affordance.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
+import { BulkDispatchDialog } from './bulk-dispatch-dialog';
+import type { OrderRecord } from '../api/orders.types';
+import type { Shipment } from '../../shipments';
+
+const COURIER_SNAPSHOT = {
+  customerEmail: 'buyer@example.com',
+  shipping: { methodId: 'dpd-courier', methodName: 'DPD Kurier' },
+  shippingAddress: {
+    firstName: 'Anna',
+    lastName: 'Nowak',
+    address1: 'ul. Testowa 1',
+    city: 'Warszawa',
+    postalCode: '00-001',
+    country: 'PL',
+    phone: '+48500600700',
+  },
+};
+
+function order(overrides: Partial<OrderRecord> & { snapshot?: Record<string, unknown> }): OrderRecord {
+  const { snapshot, ...rest } = overrides;
+  return {
+    internalOrderId: 'ol_order_1',
+    customerId: null,
+    sourceConnectionId: 'conn_a',
+    sourceEventId: null,
+    orderSnapshot: snapshot ?? COURIER_SNAPSHOT,
+    syncStatus: [],
+    syncAttempts: [],
+    recordStatus: 'ready',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...rest,
+  } as OrderRecord;
+}
+
+function shipment(id: string, carrier: string, connectionId: string): Shipment {
+  return {
+    id,
+    orderId: 'ol_order_x',
+    customerId: null,
+    connectionId,
+    shippingMethod: 'kurier',
+    status: 'generated',
+    providerShipmentId: 'prov_1',
+    paczkomatId: null,
+    trackingNumber: null,
+    carrier,
+    labelPdfRef: 'ref',
+    dispatchedAt: null,
+    deliveredAt: null,
+    cancelledAt: null,
+    failedAt: null,
+    errorMessage: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+async function fillProfileAndApply(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+  await user.type(screen.getByLabelText('Default length in millimetres'), '300');
+  await user.type(screen.getByLabelText('Default width in millimetres'), '200');
+  await user.type(screen.getByLabelText('Default height in millimetres'), '100');
+  await user.type(screen.getByLabelText('Default weight in grams'), '500');
+  await user.click(screen.getByRole('button', { name: 'Apply to all rows' }));
+}
+
+const noop = (): void => {};
+
+describe('BulkDispatchDialog', () => {
+  it('dispatches a batch and shows per-order results + a per-carrier protocol button', async () => {
+    const user = userEvent.setup();
+    const bulkGenerateLabels = vi.fn().mockResolvedValue({
+      results: [
+        { kind: 'dispatched', orderId: 'ol_order_1', shipment: shipment('ol_shipment_1', 'inpost', 'conn_carrier') },
+        { kind: 'failed', orderId: 'ol_order_2', error: 'Carrier rejected: postcode invalid' },
+      ],
+    });
+    const apiClient = createMockApiClient({ shipments: { bulkGenerateLabels } });
+
+    const orders = [
+      order({ internalOrderId: 'ol_order_1' }),
+      order({ internalOrderId: 'ol_order_2' }),
+    ];
+
+    renderWithProviders(
+      <BulkDispatchDialog open orders={orders} onOpenChange={noop} channelLabelFor={() => 'Allegro'} onComplete={noop} />,
+      { apiClient },
+    );
+
+    await fillProfileAndApply(user);
+    await user.click(screen.getByRole('button', { name: 'Dispatch 2 orders' }));
+
+    expect(await screen.findByRole('heading', { name: 'Batch complete' })).toBeInTheDocument();
+    // Both outcomes are rendered.
+    expect(screen.getByText('ol_order_1')).toBeInTheDocument();
+    expect(screen.getByText('Carrier rejected: postcode invalid')).toBeInTheDocument();
+    // One protocol download for the single carrier (InPost).
+    expect(screen.getByRole('button', { name: /InPost \(1\)/ })).toBeInTheDocument();
+    expect(bulkGenerateLabels).toHaveBeenCalledTimes(1);
+  });
+
+  it('synthesizes per-order failures when a source group request rejects (no silent drop)', async () => {
+    const user = userEvent.setup();
+    const bulkGenerateLabels = vi.fn().mockRejectedValue(new Error('Network error'));
+    const apiClient = createMockApiClient({ shipments: { bulkGenerateLabels } });
+
+    const orders = [
+      order({ internalOrderId: 'ol_order_1', sourceConnectionId: 'conn_a' }),
+      order({ internalOrderId: 'ol_order_2', sourceConnectionId: 'conn_a' }),
+    ];
+
+    renderWithProviders(
+      <BulkDispatchDialog open orders={orders} onOpenChange={noop} channelLabelFor={() => 'Allegro'} onComplete={noop} />,
+      { apiClient },
+    );
+
+    await fillProfileAndApply(user);
+    await user.click(screen.getByRole('button', { name: 'Dispatch 2 orders' }));
+
+    expect(await screen.findByRole('heading', { name: 'Batch complete' })).toBeInTheDocument();
+    // Both orders surface as failed with the group error — neither vanishes.
+    expect(screen.getByText('ol_order_1')).toBeInTheDocument();
+    expect(screen.getByText('ol_order_2')).toBeInTheDocument();
+    expect(screen.getAllByText('Network error')).toHaveLength(2);
+    // No dispatched shipments → no protocol button.
+    expect(screen.queryByRole('button', { name: /protocol|\(\d+\)/ })).not.toBeInTheDocument();
+  });
+
+  it('fans out one request per source connection', async () => {
+    const user = userEvent.setup();
+    const bulkGenerateLabels = vi.fn().mockResolvedValue({ results: [] });
+    const apiClient = createMockApiClient({ shipments: { bulkGenerateLabels } });
+
+    const orders = [
+      order({ internalOrderId: 'ol_order_1', sourceConnectionId: 'conn_a' }),
+      order({ internalOrderId: 'ol_order_2', sourceConnectionId: 'conn_b' }),
+    ];
+
+    renderWithProviders(
+      <BulkDispatchDialog open orders={orders} onOpenChange={noop} channelLabelFor={() => 'Src'} onComplete={noop} />,
+      { apiClient },
+    );
+
+    await fillProfileAndApply(user);
+    await user.click(screen.getByRole('button', { name: 'Dispatch 2 orders' }));
+
+    await waitFor(() => expect(bulkGenerateLabels).toHaveBeenCalledTimes(2));
+  });
+
+  it('surfaces an ineligible (COD) order with its reason and excludes it from the batch', () => {
+    const orders = [
+      order({ internalOrderId: 'ol_order_1' }),
+      order({ internalOrderId: 'ol_order_cod', snapshot: { ...COURIER_SNAPSHOT, paymentStatus: 'cod' } }),
+    ];
+
+    renderWithProviders(
+      <BulkDispatchDialog open orders={orders} onOpenChange={noop} channelLabelFor={() => 'Allegro'} onComplete={noop} />,
+    );
+
+    // Title reflects only the eligible count; the COD reason is visible.
+    expect(screen.getByText('Dispatch 1 of 2 orders')).toBeInTheDocument();
+    expect(screen.getByText('COD — enter amount')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dispatch 1 order' })).toBeEnabled();
+  });
+
+  it('disables dispatch when no order is eligible', () => {
+    const orders = [
+      order({ internalOrderId: 'ol_order_cod', snapshot: { ...COURIER_SNAPSHOT, paymentStatus: 'cod' } }),
+    ];
+
+    renderWithProviders(
+      <BulkDispatchDialog open orders={orders} onOpenChange={noop} channelLabelFor={() => 'Allegro'} onComplete={noop} />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText(/None of the selected orders can be bulk-dispatched/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Dispatch 0 orders/ })).toBeDisabled();
+  });
+});

--- a/apps/web/src/features/orders/components/bulk-dispatch-dialog.tsx
+++ b/apps/web/src/features/orders/components/bulk-dispatch-dialog.tsx
@@ -16,6 +16,7 @@
  * @module apps/web/src/features/orders/components
  */
 import { useMemo, useReducer, useState, type ReactElement } from 'react';
+import { Link } from 'react-router-dom';
 
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
@@ -67,7 +68,8 @@ const EMPTY_PARCEL: ParcelFields = { length: '', width: '', height: '', weightGr
 type OverrideState = Record<string, ParcelFields>;
 type OverrideAction =
   | { type: 'set'; orderId: string; field: keyof ParcelFields; value: string }
-  | { type: 'applyAll'; ids: string[]; parcel: ParcelFields };
+  | { type: 'applyAll'; ids: string[]; parcel: ParcelFields }
+  | { type: 'reset' };
 
 function overrideReducer(state: OverrideState, action: OverrideAction): OverrideState {
   switch (action.type) {
@@ -81,6 +83,8 @@ function overrideReducer(state: OverrideState, action: OverrideAction): Override
       for (const id of action.ids) next[id] = { ...action.parcel };
       return next;
     }
+    case 'reset':
+      return {};
   }
 }
 
@@ -128,6 +132,11 @@ export function BulkDispatchDialog({
     setPhase('compose');
     setResults([]);
     setRowErrors({});
+    // Clear the operator-entered parcel state too, so a later open with a
+    // different selection starts clean rather than showing the prior batch's
+    // dims + stale per-order overrides.
+    setProfile(EMPTY_PARCEL);
+    dispatchOverride({ type: 'reset' });
     onOpenChange(false);
   }
 
@@ -401,9 +410,9 @@ function IneligibleRow({
       </StatusBadge>
       <span className="bulk-dispatch__row-hint">
         {reason ? DISPATCH_INELIGIBILITY_HINT[reason] : ''}{' '}
-        <a className="bulk-dispatch__link" href={`/orders/${ref}`}>
+        <Link className="bulk-dispatch__link" to={`/orders/${ref}`}>
           dispatch individually ›
-        </a>
+        </Link>
       </span>
     </div>
   );
@@ -431,26 +440,29 @@ function ResultView({
   onDownloadProtocol: (shipmentIds: string[], carrierLabel: string) => void;
   onClose: () => void;
 }): ReactElement {
-  const dispatched = results.filter((r): r is Extract<PerOrderDispatchResult, { kind: 'dispatched' }> => r.kind === 'dispatched');
+  const dispatchedCount = results.filter((r) => r.kind === 'dispatched').length;
   const failed = results.filter((r) => r.kind === 'failed').length;
   const omp = results.filter((r) => r.kind === 'omp_fulfilled').length;
 
   // Group dispatched shipments by carrier connection — the protocol endpoint
   // rejects mixed-carrier batches, so one download per carrier connection.
+  // Derive `dispatched` inside the memo so the dep is the stable `results` ref.
   const carrierGroups = useMemo(() => {
-    const dr: DispatchedResult[] = dispatched.map((r) => ({ orderId: r.orderId, shipment: r.shipment }));
+    const dr: DispatchedResult[] = results
+      .filter((r): r is Extract<PerOrderDispatchResult, { kind: 'dispatched' }> => r.kind === 'dispatched')
+      .map((r) => ({ orderId: r.orderId, shipment: r.shipment }));
     return Array.from(groupBy(dr, (d) => d.shipment.connectionId).entries()).map(([connectionId, group]) => ({
       connectionId,
       carrierLabel: getCarrierDisplayName(group[0]?.shipment.carrier ?? null) ?? 'Carrier',
       shipmentIds: group.map((g) => g.shipment.id),
     }));
-  }, [dispatched]);
+  }, [results]);
 
   return (
     <>
       <DialogTitle>Batch complete</DialogTitle>
       <DialogDescription id="bulk-dispatch-desc">
-        <strong>{dispatched.length} dispatched</strong>
+        <strong>{dispatchedCount} dispatched</strong>
         {omp > 0 ? ` · ${omp} fulfilled by store` : ''}
         {failed > 0 ? ` · ${failed} failed` : ''}
       </DialogDescription>

--- a/apps/web/src/features/orders/components/bulk-dispatch-dialog.tsx
+++ b/apps/web/src/features/orders/components/bulk-dispatch-dialog.tsx
@@ -1,0 +1,498 @@
+/**
+ * Bulk Dispatch Dialog (#1109)
+ *
+ * Batch label-generation for a multi-select of orders. Three phases:
+ *  1. compose  — shared parcel profile + per-order override rows; ineligible
+ *     orders surfaced with a reason (never silently dropped).
+ *  2. submitting — groups eligible orders by source connection and fans out one
+ *     `bulkGenerateLabels` call per group (`Promise.allSettled`), so one source's
+ *     failure doesn't sink the others.
+ *  3. result   — merged per-order outcomes; dispatched shipments grouped by
+ *     carrier connection, with one handover-protocol download per carrier.
+ *
+ * Per-order overrides validate against the SAME parcel schema as the shared
+ * profile, so a row can't submit dims the single-order form would reject.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import { useMemo, useReducer, useState, type ReactElement } from 'react';
+
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { Dialog, DialogContent, DialogTitle, DialogDescription, DialogFooter } from '../../../shared/ui/dialog';
+import { Input } from '../../../shared/ui/input';
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
+import { useToast } from '../../../shared/ui/toast-provider';
+import {
+  useBulkGenerateLabelsMutation,
+  useProtocolDownload,
+  getCarrierDisplayName,
+  type BulkDispatchItem,
+  type PerOrderDispatchResult,
+  type Shipment,
+} from '../../shipments';
+
+import type { OrderRecord } from '../api/orders.types';
+import {
+  buildDispatchItem,
+  classifyDispatchEligibility,
+  groupBy,
+  DISPATCH_INELIGIBILITY_LABEL,
+  DISPATCH_INELIGIBILITY_HINT,
+  type DispatchEligibility,
+} from '../lib/dispatch-input';
+import { parcelSchema, type ParcelSubmission } from './bulk-dispatch-dialog.schema';
+
+interface BulkDispatchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The selected orders to dispatch (may span source connections). */
+  orders: readonly OrderRecord[];
+  /** connectionId → human channel label, for the per-row source pill. */
+  channelLabelFor: (connectionId: string) => string;
+  /** Called after a batch completes so the page can clear its selection. */
+  onComplete: () => void;
+}
+
+/** RHF-free parcel field values as the inputs hold them (strings). */
+interface ParcelFields {
+  length: string;
+  width: string;
+  height: string;
+  weightGrams: string;
+}
+
+const EMPTY_PARCEL: ParcelFields = { length: '', width: '', height: '', weightGrams: '' };
+
+type OverrideState = Record<string, ParcelFields>;
+type OverrideAction =
+  | { type: 'set'; orderId: string; field: keyof ParcelFields; value: string }
+  | { type: 'applyAll'; ids: string[]; parcel: ParcelFields };
+
+function overrideReducer(state: OverrideState, action: OverrideAction): OverrideState {
+  switch (action.type) {
+    case 'set':
+      return {
+        ...state,
+        [action.orderId]: { ...(state[action.orderId] ?? EMPTY_PARCEL), [action.field]: action.value },
+      };
+    case 'applyAll': {
+      const next: OverrideState = { ...state };
+      for (const id of action.ids) next[id] = { ...action.parcel };
+      return next;
+    }
+  }
+}
+
+/** A dispatched per-order result paired with its shipment (for carrier grouping). */
+interface DispatchedResult {
+  orderId: string;
+  shipment: Shipment;
+}
+
+export function BulkDispatchDialog({
+  open,
+  onOpenChange,
+  orders,
+  channelLabelFor,
+  onComplete,
+}: BulkDispatchDialogProps): ReactElement {
+  const { showToast } = useToast();
+  const mutation = useBulkGenerateLabelsMutation();
+  const protocolDownload = useProtocolDownload();
+
+  // Classify once per open selection. Eligible rows feed the batch; ineligible
+  // rows are shown with a reason.
+  const classified = useMemo<DispatchEligibility[]>(
+    () => orders.map((o) => classifyDispatchEligibility(o)),
+    [orders],
+  );
+  const eligible = useMemo(() => classified.filter((c) => c.eligible), [classified]);
+  const ineligible = useMemo(() => classified.filter((c) => !c.eligible), [classified]);
+
+  // Shared parcel profile (top of dialog). Plain local state — applied to rows
+  // via "Apply to all rows"; per-row overrides hold the authoritative values.
+  const [profile, setProfile] = useState<ParcelFields>(EMPTY_PARCEL);
+  const [overrides, dispatchOverride] = useReducer(overrideReducer, {} as OverrideState);
+  const [phase, setPhase] = useState<'compose' | 'submitting' | 'result'>('compose');
+  const [results, setResults] = useState<PerOrderDispatchResult[]>([]);
+  const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
+
+  const rowParcel = (orderId: string): ParcelFields => overrides[orderId] ?? profile;
+
+  function applyProfileToAll(): void {
+    dispatchOverride({ type: 'applyAll', ids: eligible.map((e) => e.order.internalOrderId), parcel: profile });
+  }
+
+  function resetAndClose(): void {
+    setPhase('compose');
+    setResults([]);
+    setRowErrors({});
+    onOpenChange(false);
+  }
+
+  async function handleSubmit(): Promise<void> {
+    // Validate each eligible row's effective parcel against the shared schema —
+    // an override can't submit dims the single-order form would reject.
+    const errors: Record<string, string> = {};
+    const items: { sourceConnectionId: string; item: BulkDispatchItem }[] = [];
+    for (const entry of eligible) {
+      const id = entry.order.internalOrderId;
+      const parsed = parcelSchema.safeParse(rowParcel(id));
+      if (!parsed.success) {
+        errors[id] = parsed.error.issues[0]?.message ?? 'Invalid parcel';
+        continue;
+      }
+      const parcel: ParcelSubmission = parsed.data;
+      items.push({
+        sourceConnectionId: entry.order.sourceConnectionId,
+        item: buildDispatchItem({
+          order: entry.order,
+          snapshot: entry.snapshot,
+          shippingMethod: entry.shippingMethod,
+          parcel,
+          paczkomatId: entry.paczkomatId,
+        }),
+      });
+    }
+    if (Object.keys(errors).length > 0) {
+      setRowErrors(errors);
+      return;
+    }
+    setRowErrors({});
+    setPhase('submitting');
+
+    // Group by source connection and fan out one request per group.
+    const groups = groupBy(items, (i) => i.sourceConnectionId);
+    const settled = await Promise.allSettled(
+      Array.from(groups.entries()).map(([sourceConnectionId, groupItems]) =>
+        mutation.mutateAsync({ sourceConnectionId, items: groupItems.map((g) => g.item) }),
+      ),
+    );
+
+    // Merge per-order results. A rejected group has no per-order rows — synthesize
+    // a `failed` outcome for every order in it so nothing silently vanishes.
+    const merged: PerOrderDispatchResult[] = [];
+    const groupEntries = Array.from(groups.entries());
+    settled.forEach((outcome, index) => {
+      const [, groupItems] = groupEntries[index];
+      if (outcome.status === 'fulfilled') {
+        merged.push(...outcome.value.results);
+      } else {
+        const error = outcome.reason instanceof Error ? outcome.reason.message : 'Dispatch failed';
+        for (const g of groupItems) {
+          merged.push({ kind: 'failed', orderId: g.item.orderId, error });
+        }
+      }
+    });
+
+    setResults(merged);
+    setPhase('result');
+
+    const dispatched = merged.filter((r) => r.kind === 'dispatched').length;
+    const failed = merged.filter((r) => r.kind === 'failed').length;
+    showToast({
+      tone: failed > 0 ? (dispatched > 0 ? 'warning' : 'error') : 'success',
+      title: 'Batch complete',
+      description: `${dispatched} dispatched${failed > 0 ? ` · ${failed} failed` : ''}.`,
+    });
+    onComplete();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? onOpenChange(true) : resetAndClose())}>
+      <DialogContent className="bulk-dispatch" aria-describedby="bulk-dispatch-desc">
+        {phase === 'result' ? (
+          <ResultView
+            results={results}
+            protocolDownloading={protocolDownload.isDownloading}
+            onDownloadProtocol={(ids, label) => void protocolDownload.download(ids, label)}
+            onClose={resetAndClose}
+          />
+        ) : (
+          <>
+            <DialogTitle>Dispatch {eligible.length === orders.length ? orders.length : `${eligible.length} of ${orders.length}`} orders</DialogTitle>
+            <DialogDescription id="bulk-dispatch-desc">
+              Generate labels for the selected orders — dispatched in per-source batches.
+            </DialogDescription>
+
+            <fieldset disabled={phase === 'submitting'} className="bulk-dispatch__body">
+              <ParcelProfile profile={profile} onChange={setProfile} onApplyAll={applyProfileToAll} />
+
+              <p className="bulk-dispatch__summary">
+                <strong>{eligible.length} ready</strong>
+                {ineligible.length > 0
+                  ? ` · ${ineligible.length} need attention — fix at source or dispatch individually`
+                  : ''}
+              </p>
+
+              <div className="bulk-dispatch__rows">
+                {eligible.map((entry) => (
+                  <EligibleRow
+                    key={entry.order.internalOrderId}
+                    entry={entry}
+                    channelLabelFor={channelLabelFor}
+                    parcel={rowParcel(entry.order.internalOrderId)}
+                    error={rowErrors[entry.order.internalOrderId]}
+                    onField={(field, value) =>
+                      dispatchOverride({ type: 'set', orderId: entry.order.internalOrderId, field, value })
+                    }
+                  />
+                ))}
+                {ineligible.map((entry) => (
+                  <IneligibleRow key={entry.order.internalOrderId} entry={entry} channelLabelFor={channelLabelFor} />
+                ))}
+              </div>
+
+              {ineligible.length > 0 && eligible.length > 0 ? (
+                <p className="bulk-dispatch__note">Only the {eligible.length} ready orders will be dispatched.</p>
+              ) : null}
+              {eligible.length === 0 ? (
+                <Alert tone="warning">None of the selected orders can be bulk-dispatched. Dispatch them individually from each order.</Alert>
+              ) : null}
+            </fieldset>
+
+            <DialogFooter>
+              <Button tone="ghost" onClick={resetAndClose} disabled={phase === 'submitting'}>
+                Cancel
+              </Button>
+              <Button
+                tone="primary"
+                onClick={() => void handleSubmit()}
+                disabled={eligible.length === 0 || phase === 'submitting'}
+              >
+                {phase === 'submitting' ? 'Dispatching…' : `Dispatch ${eligible.length} order${eligible.length === 1 ? '' : 's'}`}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ParcelProfile({
+  profile,
+  onChange,
+  onApplyAll,
+}: {
+  profile: ParcelFields;
+  onChange: (next: ParcelFields) => void;
+  onApplyAll: () => void;
+}): ReactElement {
+  const set = (field: keyof ParcelFields) => (value: string) => onChange({ ...profile, [field]: value });
+  return (
+    <div className="bulk-dispatch__profile">
+      <div className="bulk-dispatch__profile-fields">
+        <div className="bulk-dispatch__field">
+          <span className="bulk-dispatch__field-label">Dimensions (mm)</span>
+          <div className="bulk-dispatch__dims">
+            <DimInput label="Default length in millimetres" value={profile.length} onChange={set('length')} />
+            <span className="bulk-dispatch__times">×</span>
+            <DimInput label="Default width in millimetres" value={profile.width} onChange={set('width')} />
+            <span className="bulk-dispatch__times">×</span>
+            <DimInput label="Default height in millimetres" value={profile.height} onChange={set('height')} />
+          </div>
+        </div>
+        <div className="bulk-dispatch__field">
+          <span className="bulk-dispatch__field-label">Weight (g)</span>
+          <DimInput label="Default weight in grams" value={profile.weightGrams} onChange={set('weightGrams')} wide />
+        </div>
+        <Button tone="secondary" className="button--sm bulk-dispatch__apply" onClick={onApplyAll}>
+          Apply to all rows
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function DimInput({
+  label,
+  value,
+  onChange,
+  wide = false,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  wide?: boolean;
+}): ReactElement {
+  return (
+    <Input
+      type="number"
+      inputMode="numeric"
+      min={1}
+      aria-label={label}
+      className={wide ? 'bulk-dispatch__num bulk-dispatch__num--wide' : 'bulk-dispatch__num'}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
+function EligibleRow({
+  entry,
+  channelLabelFor,
+  parcel,
+  error,
+  onField,
+}: {
+  entry: DispatchEligibility;
+  channelLabelFor: (connectionId: string) => string;
+  parcel: ParcelFields;
+  error?: string;
+  onField: (field: keyof ParcelFields, value: string) => void;
+}): ReactElement {
+  const { order, snapshot, shippingMethod } = entry;
+  const ref = order.internalOrderId;
+  const buyer = [snapshot.shippingAddress?.firstName, snapshot.shippingAddress?.lastName]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+  return (
+    <div className="bulk-dispatch__row">
+      <div className="bulk-dispatch__row-id">
+        <span className="bulk-dispatch__src">{channelLabelFor(order.sourceConnectionId)}</span>
+        <span className="mono bulk-dispatch__ordid">{ref}</span>
+        {buyer ? <span className="text-muted bulk-dispatch__buyer">{buyer}</span> : null}
+      </div>
+      <StatusBadge tone={shippingMethod === 'paczkomat' ? 'info' : 'neutral'} compact>
+        {shippingMethod === 'paczkomat' ? 'Paczkomat' : 'Courier'}
+      </StatusBadge>
+      <div className="bulk-dispatch__dims">
+        <DimInput label={`Length for ${ref}`} value={parcel.length} onChange={(v) => onField('length', v)} />
+        <span className="bulk-dispatch__times">×</span>
+        <DimInput label={`Width for ${ref}`} value={parcel.width} onChange={(v) => onField('width', v)} />
+        <span className="bulk-dispatch__times">×</span>
+        <DimInput label={`Height for ${ref}`} value={parcel.height} onChange={(v) => onField('height', v)} />
+      </div>
+      <DimInput label={`Weight for ${ref}`} value={parcel.weightGrams} onChange={(v) => onField('weightGrams', v)} wide />
+      <StatusBadge tone="success" withDot compact>
+        Ready
+      </StatusBadge>
+      {error ? <span className="bulk-dispatch__row-error" role="alert">{error}</span> : null}
+    </div>
+  );
+}
+
+function IneligibleRow({
+  entry,
+  channelLabelFor,
+}: {
+  entry: DispatchEligibility;
+  channelLabelFor: (connectionId: string) => string;
+}): ReactElement {
+  const { order, snapshot, reason } = entry;
+  const ref = order.internalOrderId;
+  const buyer = [snapshot.shippingAddress?.firstName, snapshot.shippingAddress?.lastName]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+  return (
+    <div className="bulk-dispatch__row bulk-dispatch__row--ineligible">
+      <div className="bulk-dispatch__row-id">
+        <span className="bulk-dispatch__src">{channelLabelFor(order.sourceConnectionId)}</span>
+        <span className="mono bulk-dispatch__ordid">{ref}</span>
+        {buyer ? <span className="text-muted bulk-dispatch__buyer">{buyer}</span> : null}
+      </div>
+      <span className="bulk-dispatch__row-spacer" aria-hidden="true" />
+      <StatusBadge tone="warning" withDot compact>
+        {reason ? DISPATCH_INELIGIBILITY_LABEL[reason] : 'Not dispatchable'}
+      </StatusBadge>
+      <span className="bulk-dispatch__row-hint">
+        {reason ? DISPATCH_INELIGIBILITY_HINT[reason] : ''}{' '}
+        <a className="bulk-dispatch__link" href={`/orders/${ref}`}>
+          dispatch individually ›
+        </a>
+      </span>
+    </div>
+  );
+}
+
+const RESULT_TONE: Record<PerOrderDispatchResult['kind'], StatusBadgeTone> = {
+  dispatched: 'success',
+  omp_fulfilled: 'info',
+  failed: 'error',
+};
+const RESULT_LABEL: Record<PerOrderDispatchResult['kind'], string> = {
+  dispatched: 'Dispatched',
+  omp_fulfilled: 'Fulfilled by store',
+  failed: 'Failed',
+};
+
+function ResultView({
+  results,
+  protocolDownloading,
+  onDownloadProtocol,
+  onClose,
+}: {
+  results: PerOrderDispatchResult[];
+  protocolDownloading: boolean;
+  onDownloadProtocol: (shipmentIds: string[], carrierLabel: string) => void;
+  onClose: () => void;
+}): ReactElement {
+  const dispatched = results.filter((r): r is Extract<PerOrderDispatchResult, { kind: 'dispatched' }> => r.kind === 'dispatched');
+  const failed = results.filter((r) => r.kind === 'failed').length;
+  const omp = results.filter((r) => r.kind === 'omp_fulfilled').length;
+
+  // Group dispatched shipments by carrier connection — the protocol endpoint
+  // rejects mixed-carrier batches, so one download per carrier connection.
+  const carrierGroups = useMemo(() => {
+    const dr: DispatchedResult[] = dispatched.map((r) => ({ orderId: r.orderId, shipment: r.shipment }));
+    return Array.from(groupBy(dr, (d) => d.shipment.connectionId).entries()).map(([connectionId, group]) => ({
+      connectionId,
+      carrierLabel: getCarrierDisplayName(group[0]?.shipment.carrier ?? null) ?? 'Carrier',
+      shipmentIds: group.map((g) => g.shipment.id),
+    }));
+  }, [dispatched]);
+
+  return (
+    <>
+      <DialogTitle>Batch complete</DialogTitle>
+      <DialogDescription id="bulk-dispatch-desc">
+        <strong>{dispatched.length} dispatched</strong>
+        {omp > 0 ? ` · ${omp} fulfilled by store` : ''}
+        {failed > 0 ? ` · ${failed} failed` : ''}
+      </DialogDescription>
+
+      <div className="bulk-dispatch__results">
+        {results.map((r) => (
+          <div key={r.orderId} className="bulk-dispatch__result-row">
+            <span className="mono bulk-dispatch__ordid">{r.orderId}</span>
+            <StatusBadge tone={RESULT_TONE[r.kind]} withDot compact>
+              {RESULT_LABEL[r.kind]}
+            </StatusBadge>
+            {r.kind === 'failed' ? <span className="bulk-dispatch__result-detail text-muted">{r.error}</span> : null}
+            {r.kind === 'dispatched' ? (
+              <span className="bulk-dispatch__result-detail text-muted">tracking appears within ~5 min</span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      <DialogFooter className="bulk-dispatch__result-footer">
+        {carrierGroups.length > 0 ? (
+          <div className="bulk-dispatch__protocols">
+            <span className="text-muted bulk-dispatch__protocols-label">Handover protocol:</span>
+            {carrierGroups.map((g) => (
+              <Button
+                key={g.connectionId}
+                tone="secondary"
+                className="button--sm"
+                disabled={protocolDownloading}
+                onClick={() => onDownloadProtocol(g.shipmentIds, g.carrierLabel)}
+              >
+                ⤓ {g.carrierLabel} ({g.shipmentIds.length})
+              </Button>
+            ))}
+          </div>
+        ) : (
+          <span />
+        )}
+        <Button tone="primary" onClick={onClose}>
+          Close
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -55,6 +55,12 @@ import {
   type GenerateLabelFormSubmission,
   type GenerateLabelFormValues,
 } from './generate-label-form.schema';
+import {
+  buildDispatchItem,
+  classifyDeliveryMethod,
+  detectMissingFields,
+  resolveShippingMethod,
+} from '../lib/dispatch-input';
 
 interface GenerateLabelFormProps {
   /** The full order record — supplies recipient pre-fill + routing keys. */
@@ -84,28 +90,6 @@ function isWithinPickupPointRetryWindow(createdAtIso: string): boolean {
   return Date.now() - createdAt < PICKUP_POINT_RETRY_WINDOW_MS;
 }
 
-/**
- * Locker-method keyword tokens (#954). A delivery method whose name/id matches
- * resolves to a pickup point (paczkomat / parcel locker), not a courier
- * doorstep delivery. Heuristic until the snapshot carries the method
- * authoritatively (#952 populates `shipping.methodId`/`methodName`); a
- * platform-provided locker flag is the longer-term replacement.
- */
-const LOCKER_METHOD_RE = /paczkomat|locker|automat|punkt|pickup|one\s*box|one\s*punkt/i;
-
-/**
- * Classify the buyer's source delivery method as a locker (pickup-point) or
- * courier shipment. Returns `'unknown'` when the snapshot doesn't carry the
- * method yet (pre-#952) — callers fall back to other signals.
- */
-function classifyDeliveryMethod(
-  shipping: ParsedOrderSnapshot['shipping'],
-): 'locker' | 'courier' | 'unknown' {
-  if (!shipping) return 'unknown';
-  const haystack = `${shipping.methodName ?? ''} ${shipping.methodId}`;
-  return LOCKER_METHOD_RE.test(haystack) ? 'locker' : 'courier';
-}
-
 export function GenerateLabelForm({
   order,
   onSuccess,
@@ -118,8 +102,7 @@ export function GenerateLabelForm({
   // `pickupPoint` presence alone (which was circular). A resolved pickup point
   // or a locker-classified method ⇒ paczkomat flow.
   const methodClass = classifyDeliveryMethod(snapshot.shipping);
-  const shippingMethod: 'paczkomat' | 'kurier' =
-    hasPickupPoint || methodClass === 'locker' ? 'paczkomat' : 'kurier';
+  const shippingMethod = resolveShippingMethod(snapshot);
   // Clear courier signal: the method is known-courier, or — until the snapshot
   // carries the method (#952) — the order has a full street address but no
   // pickup point. Suppresses the locker retry hint on courier orders that will
@@ -231,7 +214,25 @@ export function GenerateLabelForm({
   }, [mutation.isPending]);
 
   const onSubmit: SubmitHandler<GenerateLabelFormSubmission> = async (values) => {
-    const input = buildGenerateLabelInput({ order, snapshot, values, shippingMethod });
+    const input: GenerateLabelInput = {
+      sourceConnectionId: order.sourceConnectionId,
+      ...buildDispatchItem({
+        order,
+        snapshot,
+        shippingMethod,
+        parcel: {
+          length: values.length,
+          width: values.width,
+          height: values.height,
+          weightGrams: values.weightGrams,
+        },
+        paczkomatId: values.paczkomatId,
+        cod:
+          values.codAmount && values.codAmount.length > 0
+            ? { amount: values.codAmount, currency: values.codCurrency ?? 'PLN' }
+            : undefined,
+      }),
+    };
     try {
       const result = await mutation.mutateAsync(input);
       if (result.kind === 'dispatched') {
@@ -484,57 +485,6 @@ export function GenerateLabelForm({
   );
 }
 
-interface MissingField {
-  id: string;
-  message: string;
-}
-
-/**
- * Detect snapshot fields the BE `GenerateLabelDto` requires that the order
- * snapshot didn't supply. For paczkomat shipments the address block is
- * optional (parcel goes to the locker, not the buyer's home), so address-side
- * misses don't count.
- *
- * The BE rules this mirrors (`apps/api/src/shipping/http/dto/generate-label.dto.ts`):
- * - `recipient.email` — `@IsEmail()` (always required)
- * - `recipient.phone` — `@IsNotEmpty()` (always required)
- * - `recipient.address.{street,buildingNumber,city,postCode,countryCode}` —
- *   all `@IsNotEmpty()` when the address block is sent. Country code must be
- *   a valid ISO 3166-1 alpha-2 code (the BE just checks `IsString IsNotEmpty`,
- *   but downstream carriers reject anything else).
- */
-function detectMissingFields(
-  snapshot: ParsedOrderSnapshot,
-  shippingMethod: 'paczkomat' | 'kurier',
-): MissingField[] {
-  const missing: MissingField[] = [];
-  if (!snapshot.customerEmail) {
-    missing.push({ id: 'email', message: 'Buyer email is missing from the order snapshot.' });
-  }
-  const phone = snapshot.shippingAddress?.phone;
-  if (!phone || phone.trim().length === 0) {
-    missing.push({ id: 'phone', message: 'Buyer phone is missing from the shipping address.' });
-  }
-  // For courier shipments the full address is required by the carrier.
-  if (shippingMethod === 'kurier') {
-    const a = snapshot.shippingAddress;
-    if (!a?.address1) missing.push({ id: 'street', message: 'Shipping street is missing.' });
-    if (!a?.city) missing.push({ id: 'city', message: 'Shipping city is missing.' });
-    if (!a?.postalCode) missing.push({ id: 'postCode', message: 'Shipping postal code is missing.' });
-    if (!a?.country || !isIsoAlpha2(a.country)) {
-      missing.push({
-        id: 'country',
-        message: 'Shipping country must be a 2-letter ISO code (e.g. PL).',
-      });
-    }
-  }
-  return missing;
-}
-
-function isIsoAlpha2(code: string): boolean {
-  return /^[A-Za-z]{2}$/.test(code);
-}
-
 function buildRecipientPreview(snapshot: ParsedOrderSnapshot): KeyValueItem[] {
   const items: KeyValueItem[] = [];
   const a = snapshot.shippingAddress;
@@ -564,73 +514,6 @@ function buildRecipientPreview(snapshot: ParsedOrderSnapshot): KeyValueItem[] {
   }
 
   return items;
-}
-
-function buildGenerateLabelInput(args: {
-  order: OrderRecord;
-  snapshot: ParsedOrderSnapshot;
-  values: GenerateLabelFormSubmission;
-  shippingMethod: 'paczkomat' | 'kurier';
-}): GenerateLabelInput {
-  const { order, snapshot, values, shippingMethod } = args;
-  const a = snapshot.shippingAddress;
-
-  // Paczkomat shipments don't need a delivery address — the parcel goes to
-  // the locker. Skip the block entirely (tech-review BLOCKING fix — avoids
-  // sending the `'—'` building-number placeholder we used to send).
-  //
-  // For courier shipments, the pre-flight gate in `detectMissingFields`
-  // guarantees a, address1, city, postalCode, and an ISO-alpha-2 country are
-  // present by the time we reach here — submit is disabled otherwise. Still
-  // guard with `if` so a bug in the gate doesn't crash the form.
-  const address =
-    shippingMethod === 'kurier' && a && a.address1 && a.city && a.postalCode && a.country
-      ? {
-          // BE requires both `street` AND `buildingNumber` to be non-empty.
-          // OL's address1 typically carries street + number combined; pass
-          // the same string to both so the BE validator accepts the call
-          // and the carrier system sees the full address in either slot.
-          street: a.address1,
-          buildingNumber: a.address1,
-          city: a.city,
-          postCode: a.postalCode,
-          countryCode: a.country.toUpperCase(),
-        }
-      : undefined;
-
-  return {
-    sourceConnectionId: order.sourceConnectionId,
-    sourceDeliveryMethodId: snapshot.shipping?.methodId ?? null,
-    orderId: order.internalOrderId,
-    // Send the carrier-neutral intent (#979, ADR-020); the BE resolves the
-    // carrier-specific method. The form's internal point-vs-courier
-    // classification (paczkomat ⇒ pickup point, kurier ⇒ address) maps 1:1.
-    deliveryIntent: shippingMethod === 'paczkomat' ? 'pickup_point' : 'address',
-    paczkomatId: values.paczkomatId && values.paczkomatId.length > 0 ? values.paczkomatId : undefined,
-    recipient: {
-      // Address optionals are `string | null | undefined` (#939 — snapshot
-      // serialises absent fields as null); coalesce null → undefined for the
-      // recipient contract.
-      firstName: a?.firstName ?? undefined,
-      lastName: a?.lastName ?? undefined,
-      // `detectMissingFields` blocks submit when customerEmail is absent, so the
-      // `??` only fires defensively (e.g. snapshots predating #948, or hash-only
-      // PII mode where the email isn't persisted).
-      email: snapshot.customerEmail ?? '',
-      phone: a?.phone ?? '',
-      address,
-    },
-    parcel: {
-      dimensions: { length: values.length, width: values.width, height: values.height },
-      weightGrams: values.weightGrams,
-    },
-    // COD (#966) — only when the operator entered an amount. Normalise a
-    // comma decimal separator to a dot for the wire shape.
-    cod:
-      values.codAmount && values.codAmount.length > 0
-        ? { amount: values.codAmount.replace(',', '.'), currency: values.codCurrency ?? 'PLN' }
-        : undefined,
-  };
 }
 
 function collectValidationMessages(

--- a/apps/web/src/features/orders/lib/dispatch-input.test.ts
+++ b/apps/web/src/features/orders/lib/dispatch-input.test.ts
@@ -1,0 +1,233 @@
+/**
+ * dispatch-input tests (#1109)
+ *
+ * Covers the risk-bearing pure logic: the bulk eligibility classifier, the
+ * shared payload builder, and the per-source cap / grouping helpers.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildDispatchItem,
+  capSelectionPerSource,
+  classifyDispatchEligibility,
+  groupBy,
+  resolveShippingMethod,
+  sourcesAtCap,
+} from './dispatch-input';
+import { parseOrderSnapshot } from '../api/order-snapshot.schema';
+import type { OrderRecord } from '../api/orders.types';
+
+function order(overrides: Partial<OrderRecord> & { snapshot?: Record<string, unknown> }): OrderRecord {
+  const { snapshot, ...rest } = overrides;
+  return {
+    internalOrderId: 'ol_order_1',
+    customerId: null,
+    sourceConnectionId: 'conn_a',
+    sourceEventId: null,
+    orderSnapshot: snapshot ?? {},
+    syncStatus: [],
+    syncAttempts: [],
+    recordStatus: 'ready',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...rest,
+  } as OrderRecord;
+}
+
+/** A snapshot complete enough for a courier dispatch (email + phone + address). */
+const COURIER_SNAPSHOT = {
+  customerEmail: 'buyer@example.com',
+  shipping: { methodId: 'dpd-courier', methodName: 'DPD Kurier' },
+  shippingAddress: {
+    firstName: 'Anna',
+    lastName: 'Nowak',
+    address1: 'ul. Testowa 1',
+    city: 'Warszawa',
+    postalCode: '00-001',
+    country: 'PL',
+    phone: '+48500600700',
+  },
+};
+
+/** A locker snapshot with a resolved buyer pickup point. Carries a full buyer
+ * address too (locker orders still include it) — phone lives in the address
+ * sub-tree, which only survives parsing when the address is complete. */
+const PACZKOMAT_SNAPSHOT = {
+  customerEmail: 'buyer@example.com',
+  shipping: { methodId: 'inpost-locker', methodName: 'InPost Paczkomat' },
+  shippingAddress: {
+    firstName: 'Jan',
+    lastName: 'Kowalski',
+    address1: 'ul. Locker 2',
+    city: 'Poznań',
+    postalCode: '60-001',
+    country: 'PL',
+    phone: '+48500600700',
+  },
+  pickupPoint: { id: 'POZ08A', name: 'Paczkomat POZ08A' },
+};
+
+describe('resolveShippingMethod', () => {
+  it('resolves paczkomat when a pickup point is present', () => {
+    expect(resolveShippingMethod(parseOrderSnapshot(PACZKOMAT_SNAPSHOT))).toBe('paczkomat');
+  });
+  it('resolves kurier for a courier method', () => {
+    expect(resolveShippingMethod(parseOrderSnapshot(COURIER_SNAPSHOT))).toBe('kurier');
+  });
+});
+
+describe('classifyDispatchEligibility', () => {
+  it('is eligible for a complete courier order', () => {
+    const result = classifyDispatchEligibility(order({ snapshot: COURIER_SNAPSHOT }));
+    expect(result.eligible).toBe(true);
+    expect(result.shippingMethod).toBe('kurier');
+  });
+
+  it('is eligible for a paczkomat order with a resolved pickup point', () => {
+    const result = classifyDispatchEligibility(order({ snapshot: PACZKOMAT_SNAPSHOT }));
+    expect(result.eligible).toBe(true);
+    expect(result.paczkomatId).toBe('POZ08A');
+  });
+
+  it('excludes COD orders (need a per-order amount)', () => {
+    const result = classifyDispatchEligibility(
+      order({ snapshot: { ...COURIER_SNAPSHOT, paymentStatus: 'cod' } }),
+    );
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toBe('cod');
+  });
+
+  it('excludes payment-blocked orders (awaiting / refunded)', () => {
+    expect(
+      classifyDispatchEligibility(order({ snapshot: { ...COURIER_SNAPSHOT, paymentStatus: 'awaiting' } }))
+        .reason,
+    ).toBe('payment-blocked');
+    expect(
+      classifyDispatchEligibility(order({ snapshot: { ...COURIER_SNAPSHOT, paymentStatus: 'refunded' } }))
+        .reason,
+    ).toBe('payment-blocked');
+  });
+
+  it('excludes a paczkomat order whose buyer locker is unresolved', () => {
+    const snapshot = { ...PACZKOMAT_SNAPSHOT, pickupPoint: undefined };
+    const result = classifyDispatchEligibility(order({ snapshot }));
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toBe('needs-paczkomat');
+  });
+
+  it('excludes a courier order missing recipient fields', () => {
+    const snapshot = { ...COURIER_SNAPSHOT, shippingAddress: { phone: '+48500600700' } };
+    const result = classifyDispatchEligibility(order({ snapshot }));
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toBe('missing-recipient');
+  });
+
+  it('excludes already-shipped orders', () => {
+    expect(
+      classifyDispatchEligibility(order({ snapshot: COURIER_SNAPSHOT, fulfillmentState: 'dispatched' }))
+        .reason,
+    ).toBe('already-shipped');
+    expect(
+      classifyDispatchEligibility(order({ snapshot: COURIER_SNAPSHOT, fulfillmentState: 'delivered' }))
+        .reason,
+    ).toBe('already-shipped');
+  });
+
+  it('excludes orders not yet ready (awaiting mapping)', () => {
+    const result = classifyDispatchEligibility(
+      order({ snapshot: COURIER_SNAPSHOT, recordStatus: 'awaiting_mapping' }),
+    );
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toBe('not-ready');
+  });
+});
+
+describe('buildDispatchItem', () => {
+  it('builds a courier payload with the recipient address', () => {
+    const o = order({ snapshot: COURIER_SNAPSHOT });
+    const item = buildDispatchItem({
+      order: o,
+      snapshot: parseOrderSnapshot(COURIER_SNAPSHOT),
+      shippingMethod: 'kurier',
+      parcel: { length: 300, width: 200, height: 100, weightGrams: 500 },
+    });
+    expect(item.deliveryIntent).toBe('address');
+    expect(item.orderId).toBe('ol_order_1');
+    expect(item.recipient.address?.city).toBe('Warszawa');
+    expect(item.recipient.address?.countryCode).toBe('PL');
+    expect(item.parcel.dimensions).toEqual({ length: 300, width: 200, height: 100 });
+  });
+
+  it('builds a paczkomat payload with no address and the pickup-point id', () => {
+    const item = buildDispatchItem({
+      order: order({ snapshot: PACZKOMAT_SNAPSHOT }),
+      snapshot: parseOrderSnapshot(PACZKOMAT_SNAPSHOT),
+      shippingMethod: 'paczkomat',
+      parcel: { length: 300, width: 200, height: 100, weightGrams: 500 },
+      paczkomatId: 'POZ08A',
+    });
+    expect(item.deliveryIntent).toBe('pickup_point');
+    expect(item.paczkomatId).toBe('POZ08A');
+    expect(item.recipient.address).toBeUndefined();
+  });
+
+  it('normalises a comma decimal in the COD amount', () => {
+    const item = buildDispatchItem({
+      order: order({ snapshot: COURIER_SNAPSHOT }),
+      snapshot: parseOrderSnapshot(COURIER_SNAPSHOT),
+      shippingMethod: 'kurier',
+      parcel: { length: 1, width: 1, height: 1, weightGrams: 1 },
+      cod: { amount: '129,90', currency: 'PLN' },
+    });
+    expect(item.cod).toEqual({ amount: '129.90', currency: 'PLN' });
+  });
+});
+
+describe('groupBy', () => {
+  it('groups items preserving insertion order', () => {
+    const grouped = groupBy(
+      [
+        { id: 'a', k: 1 },
+        { id: 'b', k: 2 },
+        { id: 'c', k: 1 },
+      ],
+      (x) => x.k,
+    );
+    expect([...grouped.keys()]).toEqual([1, 2]);
+    expect(grouped.get(1)?.map((x) => x.id)).toEqual(['a', 'c']);
+  });
+});
+
+describe('capSelectionPerSource', () => {
+  it('caps each source independently, preserving order', () => {
+    const orders = [
+      { sourceConnectionId: 'a', id: 1 },
+      { sourceConnectionId: 'a', id: 2 },
+      { sourceConnectionId: 'a', id: 3 },
+      { sourceConnectionId: 'b', id: 4 },
+      { sourceConnectionId: 'b', id: 5 },
+    ];
+    const capped = capSelectionPerSource(orders, 2);
+    expect(capped.map((o) => o.id)).toEqual([1, 2, 4, 5]);
+  });
+
+  it('keeps everything when under the cap', () => {
+    const orders = [
+      { sourceConnectionId: 'a', id: 1 },
+      { sourceConnectionId: 'b', id: 2 },
+    ];
+    expect(capSelectionPerSource(orders, 25)).toHaveLength(2);
+  });
+});
+
+describe('sourcesAtCap', () => {
+  it('flags only sources that reached the cap', () => {
+    const orders = [
+      { sourceConnectionId: 'a' },
+      { sourceConnectionId: 'a' },
+      { sourceConnectionId: 'b' },
+    ];
+    const atCap = sourcesAtCap(orders, 2);
+    expect(atCap.has('a')).toBe(true);
+    expect(atCap.has('b')).toBe(false);
+  });
+});

--- a/apps/web/src/features/orders/lib/dispatch-input.ts
+++ b/apps/web/src/features/orders/lib/dispatch-input.ts
@@ -1,0 +1,272 @@
+/**
+ * Dispatch input + eligibility (shared by single + bulk label flows)
+ *
+ * Pure, framework-free helpers that turn an `OrderRecord` + its parsed snapshot
+ * into the dispatch payload the shipping API consumes, and classify whether an
+ * order can be dispatched in a bulk batch. Extracted from `GenerateLabelForm`
+ * (#769) so the single-order form and the bulk-dispatch dialog (#1109) produce
+ * identical payloads and can't drift. No I/O.
+ *
+ * @module apps/web/src/features/orders/lib
+ */
+import type { BulkDispatchItem } from '../../shipments';
+import type { OrderRecord } from '../api/orders.types';
+import { parseOrderSnapshot, type ParsedOrderSnapshot, type PaymentStatus } from '../api/order-snapshot.schema';
+
+/** Internal locker-vs-courier classification of the order's delivery method. */
+export type ResolvedShippingMethod = 'paczkomat' | 'kurier';
+
+/**
+ * Locker-method keyword tokens (#954) — mirrors `GenerateLabelForm`. A delivery
+ * method whose name/id matches resolves to a pickup point (locker), not a
+ * courier doorstep delivery.
+ */
+const LOCKER_METHOD_RE = /paczkomat|locker|automat|punkt|pickup|one\s*box|one\s*punkt/i;
+
+/** Payment statuses that block dispatch entirely (#938) — FE mirror of the BE
+ *  blocking set. `cod` is dispatchable in the single-order flow but excluded
+ *  from bulk (handled separately in `classifyDispatchEligibility`). */
+export const DISPATCH_BLOCKING_PAYMENT_STATUSES: ReadonlySet<PaymentStatus> = new Set<PaymentStatus>([
+  'awaiting',
+  'refunded',
+]);
+
+export function classifyDeliveryMethod(
+  shipping: ParsedOrderSnapshot['shipping'],
+): 'locker' | 'courier' | 'unknown' {
+  if (!shipping) return 'unknown';
+  const haystack = `${shipping.methodName ?? ''} ${shipping.methodId}`;
+  return LOCKER_METHOD_RE.test(haystack) ? 'locker' : 'courier';
+}
+
+/** Resolve the order's locker-vs-courier method from its snapshot. A resolved
+ *  pickup point or a locker-classified method ⇒ paczkomat; else courier. */
+export function resolveShippingMethod(snapshot: ParsedOrderSnapshot): ResolvedShippingMethod {
+  const hasPickupPoint = snapshot.pickupPoint !== undefined;
+  return hasPickupPoint || classifyDeliveryMethod(snapshot.shipping) === 'locker'
+    ? 'paczkomat'
+    : 'kurier';
+}
+
+export interface MissingField {
+  id: string;
+  message: string;
+}
+
+function isIsoAlpha2(code: string): boolean {
+  return /^[A-Za-z]{2}$/.test(code);
+}
+
+/**
+ * Snapshot fields the BE `GenerateLabelDto` requires that the order snapshot
+ * didn't supply. Paczkomat shipments skip the address block (parcel goes to the
+ * locker). Mirrors `GenerateLabelForm.detectMissingFields`.
+ */
+export function detectMissingFields(
+  snapshot: ParsedOrderSnapshot,
+  shippingMethod: ResolvedShippingMethod,
+): MissingField[] {
+  const missing: MissingField[] = [];
+  if (!snapshot.customerEmail) {
+    missing.push({ id: 'email', message: 'Buyer email is missing from the order snapshot.' });
+  }
+  const phone = snapshot.shippingAddress?.phone;
+  if (!phone || phone.trim().length === 0) {
+    missing.push({ id: 'phone', message: 'Buyer phone is missing from the shipping address.' });
+  }
+  if (shippingMethod === 'kurier') {
+    const a = snapshot.shippingAddress;
+    if (!a?.address1) missing.push({ id: 'street', message: 'Shipping street is missing.' });
+    if (!a?.city) missing.push({ id: 'city', message: 'Shipping city is missing.' });
+    if (!a?.postalCode) missing.push({ id: 'postCode', message: 'Shipping postal code is missing.' });
+    if (!a?.country || !isIsoAlpha2(a.country)) {
+      missing.push({ id: 'country', message: 'Shipping country must be a 2-letter ISO code (e.g. PL).' });
+    }
+  }
+  return missing;
+}
+
+export interface DispatchParcel {
+  length: number;
+  width: number;
+  height: number;
+  weightGrams: number;
+}
+
+/**
+ * Build one order's dispatch payload (minus the batch-level `sourceConnectionId`)
+ * from its snapshot + an operator-supplied parcel. The shared payload builder for
+ * both the single-order form and the bulk dialog — paczkomat shipments omit the
+ * address (parcel goes to the locker); courier shipments require it (the
+ * eligibility gate guarantees the fields are present before this is called).
+ */
+export function buildDispatchItem(args: {
+  order: OrderRecord;
+  snapshot: ParsedOrderSnapshot;
+  shippingMethod: ResolvedShippingMethod;
+  parcel: DispatchParcel;
+  paczkomatId?: string;
+  cod?: { amount: string; currency: string };
+}): BulkDispatchItem {
+  const { order, snapshot, shippingMethod, parcel, paczkomatId, cod } = args;
+  const a = snapshot.shippingAddress;
+
+  const address =
+    shippingMethod === 'kurier' && a && a.address1 && a.city && a.postalCode && a.country
+      ? {
+          // BE requires both street + buildingNumber non-empty; OL's address1
+          // carries street + number combined, so pass it to both slots.
+          street: a.address1,
+          buildingNumber: a.address1,
+          city: a.city,
+          postCode: a.postalCode,
+          countryCode: a.country.toUpperCase(),
+        }
+      : undefined;
+
+  return {
+    sourceDeliveryMethodId: snapshot.shipping?.methodId ?? null,
+    orderId: order.internalOrderId,
+    deliveryIntent: shippingMethod === 'paczkomat' ? 'pickup_point' : 'address',
+    paczkomatId: paczkomatId && paczkomatId.length > 0 ? paczkomatId : undefined,
+    recipient: {
+      firstName: a?.firstName ?? undefined,
+      lastName: a?.lastName ?? undefined,
+      email: snapshot.customerEmail ?? '',
+      phone: a?.phone ?? '',
+      address,
+    },
+    parcel: {
+      dimensions: { length: parcel.length, width: parcel.width, height: parcel.height },
+      weightGrams: parcel.weightGrams,
+    },
+    cod:
+      cod && cod.amount.length > 0
+        ? { amount: cod.amount.replace(',', '.'), currency: cod.currency }
+        : undefined,
+  };
+}
+
+export const DISPATCH_INELIGIBILITY_REASONS = [
+  'missing-recipient',
+  'needs-paczkomat',
+  'cod',
+  'payment-blocked',
+  'already-shipped',
+  'not-ready',
+] as const;
+export type DispatchIneligibilityReason = (typeof DISPATCH_INELIGIBILITY_REASONS)[number];
+
+/** Short STATUS-badge label per ineligibility reason. */
+export const DISPATCH_INELIGIBILITY_LABEL: Record<DispatchIneligibilityReason, string> = {
+  'missing-recipient': 'Missing recipient',
+  'needs-paczkomat': 'Needs paczkomat',
+  cod: 'COD — enter amount',
+  'payment-blocked': 'Payment not cleared',
+  'already-shipped': 'Already shipped',
+  'not-ready': 'Awaiting mapping',
+};
+
+/** One-line reason hint shown under an ineligible row. */
+export const DISPATCH_INELIGIBILITY_HINT: Record<DispatchIneligibilityReason, string> = {
+  'missing-recipient': 'Recipient data is incomplete — fix at source, then dispatch individually.',
+  'needs-paczkomat': 'Buyer locker not resolved — dispatch individually.',
+  cod: 'Cash-on-delivery amount needed — dispatch individually.',
+  'payment-blocked': 'Payment is not cleared — resolve payment, then dispatch.',
+  'already-shipped': 'A shipment already exists for this order.',
+  'not-ready': 'Order is still awaiting mapping.',
+};
+
+/**
+ * Per-order dispatch readiness. Carries the parsed snapshot + resolved method so
+ * the bulk dialog renders the row and builds the payload from a single classify
+ * call. `eligible: false` rows are surfaced (with `reason`), never dropped.
+ */
+export interface DispatchEligibility {
+  order: OrderRecord;
+  snapshot: ParsedOrderSnapshot;
+  shippingMethod: ResolvedShippingMethod;
+  eligible: boolean;
+  reason?: DispatchIneligibilityReason;
+  /** Resolved buyer pickup-point id for paczkomat orders (empty for courier). */
+  paczkomatId?: string;
+}
+
+/**
+ * Classify whether an order can be dispatched in a bulk batch. Pure function of
+ * the record + its snapshot. Bulk excludes COD and unresolved-paczkomat orders
+ * (they need per-order operator input) and surfaces them as "dispatch
+ * individually" rather than silently skipping.
+ */
+export function classifyDispatchEligibility(order: OrderRecord): DispatchEligibility {
+  const snapshot = parseOrderSnapshot(order.orderSnapshot);
+  const shippingMethod = resolveShippingMethod(snapshot);
+  const paczkomatId = snapshot.pickupPoint?.id;
+  const base = { order, snapshot, shippingMethod, paczkomatId } as const;
+
+  if (order.fulfillmentState === 'dispatched' || order.fulfillmentState === 'delivered') {
+    return { ...base, eligible: false, reason: 'already-shipped' };
+  }
+  if (order.recordStatus !== 'ready') {
+    return { ...base, eligible: false, reason: 'not-ready' };
+  }
+  if (snapshot.paymentStatus && DISPATCH_BLOCKING_PAYMENT_STATUSES.has(snapshot.paymentStatus)) {
+    return { ...base, eligible: false, reason: 'payment-blocked' };
+  }
+  if (snapshot.paymentStatus === 'cod') {
+    return { ...base, eligible: false, reason: 'cod' };
+  }
+  if (shippingMethod === 'paczkomat' && !paczkomatId) {
+    return { ...base, eligible: false, reason: 'needs-paczkomat' };
+  }
+  if (detectMissingFields(snapshot, shippingMethod).length > 0) {
+    return { ...base, eligible: false, reason: 'missing-recipient' };
+  }
+  return { ...base, eligible: true };
+}
+
+// ── Grouping helpers (multi-source fan-out + per-carrier protocol) ──────────
+
+/** Generic stable group-by into a Map (insertion order preserved). */
+export function groupBy<T, K>(items: readonly T[], keyFn: (item: T) => K): Map<K, T[]> {
+  const map = new Map<K, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    const bucket = map.get(key);
+    if (bucket) bucket.push(item);
+    else map.set(key, [item]);
+  }
+  return map;
+}
+
+/** Source-connection ids that have reached the per-source selection cap. */
+export function sourcesAtCap(
+  orders: ReadonlyArray<{ sourceConnectionId: string }>,
+  cap: number,
+): Set<string> {
+  const atCap = new Set<string>();
+  for (const [sourceId, group] of groupBy(orders, (o) => o.sourceConnectionId)) {
+    if (group.length >= cap) atCap.add(sourceId);
+  }
+  return atCap;
+}
+
+/**
+ * Cap a candidate selection to at most `cap` orders per source connection,
+ * preserving input order. Used by "select all visible" so a single source can't
+ * exceed the per-request limit (#1109 — the cap is per source-group, not global).
+ */
+export function capSelectionPerSource<T extends { sourceConnectionId: string }>(
+  orders: readonly T[],
+  cap: number,
+): T[] {
+  const perSource = new Map<string, number>();
+  const kept: T[] = [];
+  for (const order of orders) {
+    const count = perSource.get(order.sourceConnectionId) ?? 0;
+    if (count >= cap) continue;
+    perSource.set(order.sourceConnectionId, count + 1);
+    kept.push(order);
+  }
+  return kept;
+}

--- a/apps/web/src/features/shipments/api/shipments.api.ts
+++ b/apps/web/src/features/shipments/api/shipments.api.ts
@@ -8,6 +8,8 @@
  * @module apps/web/src/features/shipments/api
  */
 import type {
+  BulkDispatchResult,
+  BulkGenerateLabelsInput,
   DispatchResult,
   GenerateLabelInput,
   NotifyDispatchedResult,
@@ -44,6 +46,17 @@ export interface ShipmentsApi {
    *  Blob. Content type is provider-dependent (PDF / ZPL / PNG); the browser
    *  filename comes from the server's `Content-Disposition` header. */
   downloadLabel: (id: string) => Promise<Blob>;
+
+  /** `POST /shipments/bulk/generate-labels` (#1109) — batch-dispatch up to 25
+   *  orders for ONE source connection. Returns 200 with a per-order result for
+   *  every item even on partial failure (`kind: dispatched | omp_fulfilled |
+   *  failed`). The UI fans out one call per source group. */
+  bulkGenerateLabels: (input: BulkGenerateLabelsInput) => Promise<BulkDispatchResult>;
+
+  /** `POST /shipments/bulk/protocol` (#1109) — carrier handover protocol for a
+   *  set of dispatched shipments as a Blob. The BE rejects mixed-carrier batches,
+   *  so the caller passes shipment ids grouped by a single carrier connection. */
+  downloadProtocol: (shipmentIds: string[]) => Promise<Blob>;
 }
 
 interface ApiRequest {
@@ -105,6 +118,20 @@ export function createShipmentsApi(
     },
     downloadLabel(id): Promise<Blob> {
       return requestBlob(`/shipments/${encodeURIComponent(id)}/label`);
+    },
+    bulkGenerateLabels(input): Promise<BulkDispatchResult> {
+      return request<BulkDispatchResult>('/shipments/bulk/generate-labels', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(input),
+      });
+    },
+    downloadProtocol(shipmentIds): Promise<Blob> {
+      return requestBlob('/shipments/bulk/protocol', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ shipmentIds }),
+      });
     },
   };
 }

--- a/apps/web/src/features/shipments/api/shipments.types.ts
+++ b/apps/web/src/features/shipments/api/shipments.types.ts
@@ -177,6 +177,42 @@ export interface DispatchResult {
   shipment?: Shipment;
 }
 
+/**
+ * Max items per `POST /shipments/bulk/generate-labels` request (BE
+ * `BULK_DISPATCH_MAX_ITEMS` / `@ArrayMaxSize`). The bulk-dispatch UI (#1109)
+ * batches one request per source connection, so this cap is enforced
+ * **per source group** at selection time.
+ */
+export const BULK_DISPATCH_MAX_ITEMS = 25;
+
+/** One order's full dispatch payload inside a bulk request — the single-order
+ * `GenerateLabelInput` minus the batch-level `sourceConnectionId`. */
+export type BulkDispatchItem = Omit<GenerateLabelInput, 'sourceConnectionId'>;
+
+/** `POST /shipments/bulk/generate-labels` request body — mirrors the BE
+ * `BulkGenerateLabelsDto`. One source connection per request; `items` ≤ 25. */
+export interface BulkGenerateLabelsInput {
+  sourceConnectionId: string;
+  items: BulkDispatchItem[];
+}
+
+/**
+ * Per-order outcome in a bulk response — mirrors the BE
+ * `PerOrderDispatchResultDto` discriminated union. `dispatched` carries the
+ * created `shipment`; `failed` carries the operator-readable `error`;
+ * `omp_fulfilled` means the destination store ships it (no OL label).
+ */
+export type PerOrderDispatchResult =
+  | { kind: 'dispatched'; orderId: string; shipment: Shipment }
+  | { kind: 'omp_fulfilled'; orderId: string }
+  | { kind: 'failed'; orderId: string; error: string };
+
+/** `POST /shipments/bulk/generate-labels` response — mirrors
+ * `BulkDispatchResultResponseDto`. Returns 200 even on partial failure. */
+export interface BulkDispatchResult {
+  results: PerOrderDispatchResult[];
+}
+
 /** `POST /shipments/:id/notify-dispatched` response (#769). */
 export interface NotifyDispatchedResult {
   shipmentId: string;

--- a/apps/web/src/features/shipments/hooks/use-bulk-generate-labels-mutation.ts
+++ b/apps/web/src/features/shipments/hooks/use-bulk-generate-labels-mutation.ts
@@ -1,0 +1,32 @@
+/**
+ * useBulkGenerateLabelsMutation
+ *
+ * Mutation hook for `POST /shipments/bulk/generate-labels` (#1109) — one source
+ * connection per call. On success, invalidates the entire `shipments` domain so
+ * the `/shipments` page refetches. The bulk-dispatch dialog calls `mutateAsync`
+ * once per source group inside a `Promise.allSettled` fan-out and merges the
+ * per-order results itself (orders queries are invalidated by the dialog, since
+ * cross-feature query keys aren't reached into from here).
+ *
+ * @module apps/web/src/features/shipments/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { shipmentsQueryKeys } from '../api/shipments.query-keys';
+import type { BulkDispatchResult, BulkGenerateLabelsInput } from '../api/shipments.types';
+
+export function useBulkGenerateLabelsMutation(): UseMutationResult<
+  BulkDispatchResult,
+  Error,
+  BulkGenerateLabelsInput
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input) => apiClient.shipments.bulkGenerateLabels(input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: shipmentsQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/shipments/hooks/use-label-download.ts
+++ b/apps/web/src/features/shipments/hooks/use-label-download.ts
@@ -3,41 +3,15 @@
  *
  * One-shot action (NOT a TanStack mutation) that fetches a shipment's label
  * document via `apiClient.shipments.downloadLabel(id)` and triggers a browser
- * download through an in-memory object URL + programmatic `<a download>` click.
- *
- * Filename: a blob-URL download cannot read the server's `Content-Disposition`
- * header (the object URL carries no HTTP headers), so the extension is derived
- * from `blob.type` — which `Response.blob()` populates from the response
- * `Content-Type`. This mirrors the backend's content-type → extension mapping
- * so a PDF/ZPL/PNG label saves with the right extension.
- *
- * Exposes local `{ download, isDownloading, error }` state — there's nothing to
- * cache, so this is deliberately not a query/mutation hook.
+ * download. Filename extension is derived from `blob.type` (see
+ * `lib/label-download`). Exposes local `{ download, isDownloading, error }` —
+ * there's nothing to cache, so this is deliberately not a query/mutation hook.
  *
  * @module apps/web/src/features/shipments/hooks
  */
 import { useCallback, useState } from 'react';
 import { useApiClient } from '../../../app/api/api-client-provider';
-
-/**
- * Map a label blob's MIME type to a download-filename extension. Mirrors the
- * backend `extensionForContentType` (apps/api shipment.controller) — the two
- * can't share code across the FE/BE boundary, so the small map is duplicated.
- */
-const EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
-  'application/pdf': 'pdf',
-  'image/png': 'png',
-  'application/zpl': 'zpl',
-  'application/x-zpl': 'zpl',
-  'text/zpl': 'zpl',
-  'application/epl': 'epl',
-  'application/x-epl': 'epl',
-};
-
-function extensionForBlob(blob: Blob): string {
-  const mime = blob.type.toLowerCase().split(';', 1)[0]?.trim() ?? '';
-  return EXTENSION_BY_MIME[mime] ?? 'bin';
-}
+import { extensionForBlob, triggerBlobDownload } from '../lib/label-download';
 
 interface UseLabelDownload {
   /** Fetch + trigger the browser download. Resolves `true` on success, `false`
@@ -56,33 +30,14 @@ export function useLabelDownload(): UseLabelDownload {
     async (shipmentId: string): Promise<boolean> => {
       setIsDownloading(true);
       setError(null);
-      let objectUrl: string | null = null;
       try {
         const blob = await apiClient.shipments.downloadLabel(shipmentId);
-        objectUrl = URL.createObjectURL(blob);
-        const anchor = document.createElement('a');
-        anchor.href = objectUrl;
-        anchor.download = `ol-shipment-${shipmentId}.${extensionForBlob(blob)}`;
-        document.body.appendChild(anchor);
-        anchor.click();
-        anchor.remove();
-        // Defer revoke past the current tick: some engines cancel the in-flight
-        // download if the object URL is revoked synchronously after click().
-        if (objectUrl) {
-          const toRevoke = objectUrl;
-          setTimeout(() => URL.revokeObjectURL(toRevoke), 0);
-          objectUrl = null;
-        }
+        triggerBlobDownload(blob, `ol-shipment-${shipmentId}.${extensionForBlob(blob)}`);
         return true;
       } catch (caught) {
         setError(caught instanceof Error ? caught : new Error(String(caught)));
         return false;
       } finally {
-        // Only fires on the error path (success nulls `objectUrl` after
-        // scheduling the deferred revoke above).
-        if (objectUrl) {
-          URL.revokeObjectURL(objectUrl);
-        }
         setIsDownloading(false);
       }
     },

--- a/apps/web/src/features/shipments/hooks/use-protocol-download.ts
+++ b/apps/web/src/features/shipments/hooks/use-protocol-download.ts
@@ -1,0 +1,59 @@
+/**
+ * useProtocolDownload
+ *
+ * One-shot action (NOT a TanStack mutation) that fetches a carrier handover
+ * protocol via `apiClient.shipments.downloadProtocol(shipmentIds)` and triggers
+ * a browser download. The BE rejects mixed-carrier batches, so callers pass a
+ * single carrier's dispatched-shipment ids and the carrier label for the
+ * filename. Exposes local `{ download, isDownloading, error }`.
+ *
+ * @module apps/web/src/features/shipments/hooks
+ */
+import { useCallback, useState } from 'react';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { extensionForBlob, triggerBlobDownload } from '../lib/label-download';
+
+interface UseProtocolDownload {
+  /** Fetch + trigger the protocol download for one carrier's shipments.
+   *  Resolves `true` on success, `false` on failure (error also on `error`). */
+  download: (shipmentIds: string[], carrierLabel?: string) => Promise<boolean>;
+  isDownloading: boolean;
+  error: Error | null;
+}
+
+function filenameSlug(carrierLabel: string | undefined): string {
+  const slug = (carrierLabel ?? 'handover')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug.length > 0 ? slug : 'handover';
+}
+
+export function useProtocolDownload(): UseProtocolDownload {
+  const apiClient = useApiClient();
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const download = useCallback(
+    async (shipmentIds: string[], carrierLabel?: string): Promise<boolean> => {
+      setIsDownloading(true);
+      setError(null);
+      try {
+        const blob = await apiClient.shipments.downloadProtocol(shipmentIds);
+        triggerBlobDownload(
+          blob,
+          `ol-${filenameSlug(carrierLabel)}-protocol.${extensionForBlob(blob)}`,
+        );
+        return true;
+      } catch (caught) {
+        setError(caught instanceof Error ? caught : new Error(String(caught)));
+        return false;
+      } finally {
+        setIsDownloading(false);
+      }
+    },
+    [apiClient],
+  );
+
+  return { download, isDownloading, error };
+}

--- a/apps/web/src/features/shipments/index.ts
+++ b/apps/web/src/features/shipments/index.ts
@@ -17,12 +17,17 @@ export type {
   GenerateLabelInput,
   NotifyDispatchedResult,
   KnownCarrier,
+  BulkDispatchItem,
+  BulkGenerateLabelsInput,
+  BulkDispatchResult,
+  PerOrderDispatchResult,
 } from './api/shipments.types';
 export {
   KNOWN_CARRIER_VALUES,
   SHIPPING_METHOD_LABEL,
   SHIPPING_METHOD_VALUES,
   SHIPMENT_STATUS_VALUES,
+  BULK_DISPATCH_MAX_ITEMS,
 } from './api/shipments.types';
 export {
   PROCESSOR_FILTER_VALUES,
@@ -40,5 +45,7 @@ export { useGenerateLabelMutation } from './hooks/use-generate-label-mutation';
 export { useCancelShipmentMutation } from './hooks/use-cancel-shipment-mutation';
 export { useNotifyDispatchedMutation } from './hooks/use-notify-dispatched-mutation';
 export { useLabelDownload } from './hooks/use-label-download';
+export { useBulkGenerateLabelsMutation } from './hooks/use-bulk-generate-labels-mutation';
+export { useProtocolDownload } from './hooks/use-protocol-download';
 export { ShipmentStatusBadge } from './components/shipment-status-badge';
 export { buildCarrierTrackingUrl, getCarrierDisplayName } from './lib/carrier-tracking-url';

--- a/apps/web/src/features/shipments/lib/label-download.ts
+++ b/apps/web/src/features/shipments/lib/label-download.ts
@@ -1,0 +1,46 @@
+/**
+ * Label / protocol blob-download helpers
+ *
+ * Shared helpers for the imperative document downloads (`useLabelDownload`,
+ * `useProtocolDownload`). A blob-URL download can't read the server's
+ * `Content-Disposition`, so the filename extension is derived from `blob.type`
+ * (which `Response.blob()` populates from the response `Content-Type`). Mirrors
+ * the backend `extensionForContentType` (apps/api shipment.controller) — the two
+ * can't share code across the FE/BE boundary, so the small map lives here once
+ * for both download hooks (#1109).
+ *
+ * @module apps/web/src/features/shipments/lib
+ */
+
+const EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
+  'application/pdf': 'pdf',
+  'image/png': 'png',
+  'application/zpl': 'zpl',
+  'application/x-zpl': 'zpl',
+  'text/zpl': 'zpl',
+  'application/epl': 'epl',
+  'application/x-epl': 'epl',
+};
+
+/** Map a document blob's MIME type to a download-filename extension. */
+export function extensionForBlob(blob: Blob): string {
+  const mime = blob.type.toLowerCase().split(';', 1)[0]?.trim() ?? '';
+  return EXTENSION_BY_MIME[mime] ?? 'bin';
+}
+
+/**
+ * Trigger a browser download for an already-fetched blob via an in-memory
+ * object URL + a programmatic `<a download>` click. Defers `revokeObjectURL`
+ * past the current tick — some engines cancel the in-flight download if the URL
+ * is revoked synchronously after `click()`.
+ */
+export function triggerBlobDownload(blob: Blob, filename: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7822,6 +7822,219 @@ html[data-density='compact'] .status-badge {
   background: var(--accent-primary-soft);
 }
 
+/* ── Bulk dispatch dialog (#1109) ─────────────────────────────────────
+ * Batch generate-labels surface: shared parcel profile + per-order override
+ * rows + result view. Composes the Dialog primitive; widened for the row table.
+ */
+.bulk-dispatch {
+  width: min(880px, calc(100vw - var(--space-6)));
+  max-width: min(880px, calc(100vw - var(--space-6)));
+}
+
+.bulk-dispatch__body {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+.bulk-dispatch__profile {
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-canvas);
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.bulk-dispatch__profile-fields {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-5);
+  flex-wrap: wrap;
+}
+
+.bulk-dispatch__field-label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: var(--space-1);
+}
+
+.bulk-dispatch__dims {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  white-space: nowrap;
+}
+
+.bulk-dispatch__times {
+  color: var(--text-disabled);
+}
+
+.bulk-dispatch__num {
+  width: 52px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.bulk-dispatch__num--wide {
+  width: 68px;
+}
+
+.bulk-dispatch__apply {
+  margin-left: auto;
+}
+
+.bulk-dispatch__summary {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  margin: 0 0 var(--space-2);
+}
+
+.bulk-dispatch__note {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: var(--space-3) 0 0;
+}
+
+.bulk-dispatch__rows {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  max-height: 46vh;
+  overflow-y: auto;
+}
+
+.bulk-dispatch__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto auto auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.bulk-dispatch__row:last-child {
+  border-bottom: 0;
+}
+
+.bulk-dispatch__row--ineligible {
+  background: var(--bg-canvas);
+  grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+.bulk-dispatch__row-id {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.bulk-dispatch__src {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  background: var(--bg-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  padding: 0 var(--space-1);
+  align-self: flex-start;
+}
+
+.bulk-dispatch__ordid {
+  font-size: 0.75rem;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bulk-dispatch__buyer {
+  font-size: 0.75rem;
+}
+
+.bulk-dispatch__row-error {
+  grid-column: 1 / -1;
+  font-size: 0.75rem;
+  color: var(--status-error-fg);
+}
+
+.bulk-dispatch__row-spacer {
+  display: block;
+}
+
+.bulk-dispatch__row-hint {
+  font-size: 0.75rem;
+  color: var(--status-warning-fg);
+  grid-column: 1 / -1;
+}
+
+.bulk-dispatch__link {
+  color: var(--text-link);
+}
+
+.bulk-dispatch__results {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  max-height: 52vh;
+  overflow-y: auto;
+}
+
+.bulk-dispatch__result-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.bulk-dispatch__result-row:last-child {
+  border-bottom: 0;
+}
+
+.bulk-dispatch__result-detail {
+  font-size: 0.8125rem;
+}
+
+.bulk-dispatch__result-footer {
+  justify-content: space-between;
+}
+
+.bulk-dispatch__protocols {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.bulk-dispatch__protocols-label {
+  font-size: 0.75rem;
+}
+
+@media (max-width: 767.98px) {
+  /* Stack each row's controls so dims/weight don't overflow on a phone. */
+  .bulk-dispatch__row,
+  .bulk-dispatch__row--ineligible {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+  .bulk-dispatch__profile-fields {
+    gap: var(--space-3);
+  }
+  .bulk-dispatch__apply {
+    margin-left: 0;
+  }
+}
+
 /* ── Bulk listing wizard (#740) ─────────────────────────────────────
  * The wizard composes existing primitives (DataTable, Dialog, SetupStepper,
  * Button, FormField). Only the page-level scaffolding lives here.

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -24,13 +24,15 @@
  *
  * @module pages/orders
  */
-import { useEffect, useMemo, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { DataTableSkeleton } from '../../shared/ui/data-table-skeleton';
 import { Button } from '../../shared/ui/button';
+import { BulkActionBar } from '../../shared/ui/bulk-action-bar';
+import { CheckboxCell } from '../../shared/ui/checkbox-cell';
 import { Chip } from '../../shared/ui/chip';
 import { Select } from '../../shared/ui/select';
 import { TimeDisplay } from '../../shared/ui/time-display';
@@ -47,6 +49,9 @@ import { useOrderSlaSummaryQuery } from '../../features/orders/hooks/use-order-s
 import { useRetryOrderDestinationMutation } from '../../features/orders/hooks/use-retry-order-destination-mutation';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
 import { deriveOrderHealth, slaBadge, fulfillmentBadge } from '../../features/orders/lib/order-health';
+import { capSelectionPerSource, sourcesAtCap } from '../../features/orders/lib/dispatch-input';
+import { BulkDispatchDialog } from '../../features/orders/components/bulk-dispatch-dialog';
+import { BULK_DISPATCH_MAX_ITEMS } from '../../features/shipments';
 import type {
   OrderRecord,
   OrderFilters,
@@ -331,8 +336,130 @@ export function OrdersListPage(): ReactElement {
   const channelLabel = (platform: string | undefined): string | undefined =>
     platform ? (CHANNEL_LABELS[platform] ?? platform) : undefined;
 
+  // Resolve a connectionId to a human channel label (never undefined) for the
+  // bulk-dispatch per-row source pill.
+  const channelLabelForBulk = (connectionId: string): string =>
+    channelLabel(platformByConnection.get(connectionId)) ?? 'Source';
+
+  // ── Bulk dispatch selection (#1109) ───────────────────────────────────────
+  // Local Set (not URL state — the URL would balloon on every checkbox toggle).
+  // The 25-cap is enforced PER SOURCE connection, since the bulk endpoint takes
+  // one source per request and the dialog fans out one call per source group.
+  const items = query.data?.items ?? [];
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkOpen, setBulkOpen] = useState(false);
+
+  // Already-shipped orders can't be dispatched — their checkbox is disabled.
+  const isSelectable = (order: OrderRecord): boolean =>
+    order.fulfillmentState !== 'dispatched' && order.fulfillmentState !== 'delivered';
+
+  const selectableItems = useMemo(() => items.filter(isSelectable), [items]);
+  const selectedOrders = useMemo(
+    () => items.filter((o) => selectedIds.has(o.internalOrderId)),
+    [items, selectedIds],
+  );
+  // Source groups that have hit the per-source cap — their unselected rows
+  // disable (but already-selected rows stay toggleable so you can deselect).
+  const atCapSources = useMemo(
+    () => sourcesAtCap(selectedOrders, BULK_DISPATCH_MAX_ITEMS),
+    [selectedOrders],
+  );
+  // The header "select all" caps each source independently, so its target count
+  // is the capped selectable set — header reads `all` only once that's reached.
+  const cappedSelectableCount = useMemo(
+    () => capSelectionPerSource(selectableItems, BULK_DISPATCH_MAX_ITEMS).length,
+    [selectableItems],
+  );
+  const selectedVisibleCount = useMemo(
+    () => selectableItems.reduce((n, o) => n + (selectedIds.has(o.internalOrderId) ? 1 : 0), 0),
+    [selectableItems, selectedIds],
+  );
+  const headerCheckboxState: 'all' | 'some' | 'none' =
+    selectedVisibleCount === 0
+      ? 'none'
+      : selectedVisibleCount >= cappedSelectableCount
+        ? 'all'
+        : 'some';
+  const distinctSelectedSources = useMemo(
+    () => new Set(selectedOrders.map((o) => o.sourceConnectionId)).size,
+    [selectedOrders],
+  );
+
+  function toggleSelectRow(order: OrderRecord): void {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      const id = order.internalOrderId;
+      if (next.has(id)) {
+        next.delete(id);
+        return next;
+      }
+      // Enforce the per-source cap on add (count from current page's selection).
+      const sourceCount = items.reduce(
+        (n, o) =>
+          o.sourceConnectionId === order.sourceConnectionId && prev.has(o.internalOrderId) ? n + 1 : n,
+        0,
+      );
+      if (sourceCount >= BULK_DISPATCH_MAX_ITEMS) return prev;
+      next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectHeader(): void {
+    setSelectedIds((prev) => {
+      const allSelected =
+        selectableItems.length > 0 && selectableItems.every((o) => prev.has(o.internalOrderId));
+      if (allSelected) return new Set();
+      return new Set(
+        capSelectionPerSource(selectableItems, BULK_DISPATCH_MAX_ITEMS).map((o) => o.internalOrderId),
+      );
+    });
+  }
+
+  function clearSelection(): void {
+    setSelectedIds(new Set());
+  }
+
   const columns: DataTableColumn<OrderRecord>[] = useMemo(
     () => [
+      {
+        id: 'select',
+        // Header rendered manually for the indeterminate (tri-state) checkbox.
+        header: (
+          <CheckboxCell
+            state={headerCheckboxState}
+            onToggle={toggleSelectHeader}
+            ariaLabel={
+              headerCheckboxState === 'all' ? 'Unselect all visible orders' : 'Select all visible orders'
+            }
+          />
+        ),
+        cell: (order) => {
+          if (!isSelectable(order)) {
+            return (
+              <CheckboxCell
+                state="none"
+                disabled
+                onToggle={() => {}}
+                ariaLabel={`${order.internalOrderId} is already shipped`}
+                tooltip="Already shipped"
+              />
+            );
+          }
+          const checked = selectedIds.has(order.internalOrderId);
+          const disabled = !checked && atCapSources.has(order.sourceConnectionId);
+          return (
+            <CheckboxCell
+              state={checked ? 'all' : 'none'}
+              disabled={disabled}
+              onToggle={() => { toggleSelectRow(order); }}
+              ariaLabel={checked ? `Unselect ${order.internalOrderId}` : `Select ${order.internalOrderId}`}
+              tooltip={disabled ? `Max ${BULK_DISPATCH_MAX_ITEMS} per source` : undefined}
+            />
+          );
+        },
+        align: 'left',
+      },
       {
         id: 'order',
         header: 'Order',
@@ -521,7 +648,16 @@ export function OrdersListPage(): ReactElement {
     // mutation's pending/variables change — the last two so the inline Retry
     // reflects its in-flight state. `handleRetry` closes over the stable
     // `mutate` handle, so it doesn't need to be a dep.
-    [locale, platformByConnection, retryMutation.isPending, retryMutation.variables],
+    [
+      locale,
+      platformByConnection,
+      retryMutation.isPending,
+      retryMutation.variables,
+      // Selection state — the select column re-renders as checkboxes toggle (#1109).
+      selectedIds,
+      atCapSources,
+      headerCheckboxState,
+    ],
   );
 
   function handleRetry(internalOrderId: string, destinationConnectionId: string): void {
@@ -911,8 +1047,39 @@ export function OrdersListPage(): ReactElement {
               </Button>
             </div>
           </div>
+
+          {/* Bulk dispatch (#1109) — multi-select → batch generate-labels. The
+              cap is per source; a selection may span sources (dispatched in
+              per-source groups). */}
+          <BulkActionBar
+            count={selectedOrders.length}
+            itemNoun="order"
+            hint={
+              distinctSelectedSources > 1
+                ? `${distinctSelectedSources} sources · max ${BULK_DISPATCH_MAX_ITEMS} per source`
+                : `Max ${BULK_DISPATCH_MAX_ITEMS} per source`
+            }
+            actions={
+              <>
+                <Button tone="ghost" onClick={clearSelection}>
+                  Clear
+                </Button>
+                <Button tone="primary" onClick={() => { setBulkOpen(true); }}>
+                  Dispatch {selectedOrders.length}
+                </Button>
+              </>
+            }
+          />
         </>
       )}
+
+      <BulkDispatchDialog
+        open={bulkOpen}
+        onOpenChange={setBulkOpen}
+        orders={selectedOrders}
+        channelLabelFor={channelLabelForBulk}
+        onComplete={clearSelection}
+      />
     </PageLayout>
   );
 }

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -9,7 +9,7 @@
  *
  * @module apps/web/src/pages/products
  */
-import { useCallback, useMemo, useState, type ChangeEvent, type ReactElement, type ReactNode } from 'react';
+import { useCallback, useMemo, useState, type ReactElement, type ReactNode } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
@@ -21,6 +21,7 @@ import { Input } from '../../shared/ui/input';
 import { ProductThumbnail } from '../../shared/ui/product-thumbnail';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { BulkActionBar } from '../../shared/ui/bulk-action-bar';
+import { CheckboxCell } from '../../shared/ui/checkbox-cell';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { useProductsQuery } from '../../features/products/hooks/use-products-query';
 import type { Product, ProductFilters } from '../../features/products/api/products.types';
@@ -385,40 +386,5 @@ export function ProductsListPage(): ReactElement {
         </>
       )}
     </PageLayout>
-  );
-}
-
-interface CheckboxCellProps {
-  state: 'all' | 'some' | 'none';
-  onToggle: () => void;
-  disabled?: boolean;
-  ariaLabel: string;
-  tooltip?: string;
-}
-
-function CheckboxCell({
-  state,
-  onToggle,
-  disabled = false,
-  ariaLabel,
-  tooltip,
-}: CheckboxCellProps): ReactElement {
-  return (
-    <input
-      type="checkbox"
-      checked={state === 'all'}
-      ref={(el) => {
-        if (el) el.indeterminate = state === 'some';
-      }}
-      disabled={disabled}
-      onChange={(e: ChangeEvent<HTMLInputElement>) => {
-        e.stopPropagation();
-        onToggle();
-      }}
-      // Stop click from bubbling to a row-click handler if a parent sets one.
-      onClick={(e) => { e.stopPropagation(); }}
-      aria-label={ariaLabel}
-      title={tooltip}
-    />
   );
 }

--- a/apps/web/src/shared/ui/checkbox-cell.test.tsx
+++ b/apps/web/src/shared/ui/checkbox-cell.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CheckboxCell } from './checkbox-cell';
+
+describe('CheckboxCell', () => {
+  it('renders checked for the "all" state', () => {
+    render(<CheckboxCell state="all" onToggle={() => {}} ariaLabel="Select all" />);
+    expect(screen.getByRole('checkbox', { name: 'Select all' })).toBeChecked();
+  });
+
+  it('renders the indeterminate DOM property for the "some" state', () => {
+    render(<CheckboxCell state="some" onToggle={() => {}} ariaLabel="Some selected" />);
+    const box = screen.getByRole<HTMLInputElement>('checkbox', { name: 'Some selected' });
+    expect(box.indeterminate).toBe(true);
+    expect(box.checked).toBe(false);
+  });
+
+  it('calls onToggle when clicked', async () => {
+    const onToggle = vi.fn();
+    const user = userEvent.setup();
+    render(<CheckboxCell state="none" onToggle={onToggle} ariaLabel="Select row" />);
+    await user.click(screen.getByRole('checkbox', { name: 'Select row' }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onToggle when disabled', async () => {
+    const onToggle = vi.fn();
+    const user = userEvent.setup();
+    render(<CheckboxCell state="none" disabled onToggle={onToggle} ariaLabel="Disabled row" tooltip="Max reached" />);
+    const box = screen.getByRole('checkbox', { name: 'Disabled row' });
+    expect(box).toBeDisabled();
+    await user.click(box);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/shared/ui/checkbox-cell.tsx
+++ b/apps/web/src/shared/ui/checkbox-cell.tsx
@@ -1,0 +1,50 @@
+/**
+ * CheckboxCell
+ *
+ * Tri-state selection checkbox for `DataTable` multi-select (header = all/some/none,
+ * rows = all/none). Renders a native `<input type="checkbox">` so it inherits the
+ * platform a11y + keyboard behavior; the `some` state drives the DOM `indeterminate`
+ * property (not expressible in JSX, hence the ref). Stops click/change from bubbling
+ * to a row-click handler.
+ *
+ * Lifted from products-list-page (#739) to `shared/ui` for reuse by the bulk
+ * shipment-dispatch selection (#1109).
+ */
+import type { ChangeEvent, ReactElement } from 'react';
+
+export interface CheckboxCellProps {
+  state: 'all' | 'some' | 'none';
+  onToggle: () => void;
+  disabled?: boolean;
+  ariaLabel: string;
+  tooltip?: string;
+}
+
+export function CheckboxCell({
+  state,
+  onToggle,
+  disabled = false,
+  ariaLabel,
+  tooltip,
+}: CheckboxCellProps): ReactElement {
+  return (
+    <input
+      type="checkbox"
+      checked={state === 'all'}
+      ref={(el) => {
+        if (el) el.indeterminate = state === 'some';
+      }}
+      disabled={disabled}
+      onChange={(e: ChangeEvent<HTMLInputElement>) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      // Stop click from bubbling to a row-click handler if a parent sets one.
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
+      aria-label={ariaLabel}
+      title={tooltip}
+    />
+  );
+}

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -69,6 +69,8 @@ export { CopyableId } from './copyable-id';
 export { DensityToggle, useDensity } from './density-toggle';
 export type { Density } from './density-toggle';
 
-// ── Bulk-selection (#739) ──────────────────────────────────────────
+// ── Bulk-selection (#739, #1109) ────────────────────────────────────
 export { BulkActionBar } from './bulk-action-bar';
 export type { BulkActionBarProps } from './bulk-action-bar';
+export { CheckboxCell } from './checkbox-cell';
+export type { CheckboxCellProps } from './checkbox-cell';

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -371,6 +371,8 @@ export function createMockApiClient(
         destinations: [],
       }),
       downloadLabel: vi.fn().mockResolvedValue(new Blob([new Uint8Array([0x25, 0x50])])),
+      bulkGenerateLabels: vi.fn().mockResolvedValue({ results: [] }),
+      downloadProtocol: vi.fn().mockResolvedValue(new Blob([new Uint8Array([0x25, 0x50])])),
       ...overrides.shipments,
     } as ApiClient['shipments'],
     syncJobs: {

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-1109-bulk-shipment-dispatch-ui.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-1109-bulk-shipment-dispatch-ui.md
@@ -1,0 +1,43 @@
+# Pre-implement analysis — #1109 bulk shipment dispatch UI
+
+**Plan:** `docs/plans/implementation-plan-1109-bulk-shipment-dispatch-ui.md`
+**Gate run:** read-only reuse + contract audit against the live tree (FE-only; backend bulk endpoints already merged & wired).
+
+## Verdict: ✅ READY
+
+No Critical findings. The change is FE-only, purely additive at every contract surface, and consumes the already-shipped `POST /shipments/bulk/generate-labels` + `/shipments/bulk/protocol` endpoints as-is. The only two "modify an existing consumer" touch-points are low-risk refactors covered by existing tests.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `shipments.bulkGenerateLabels` API method | **NEW** | `ShipmentsApi` has `list/generateLabel/cancel/notifyDispatched/downloadLabel` only (`features/shipments/api/shipments.api.ts`); grep for `bulkGenerateLabels`/`bulk/generate-labels` across `apps/web/src` → 0 hits |
+| `shipments.downloadProtocol` (blob) | **NEW** | same grep → 0 hits; `requestBlob(path, init)` already supports POST+body |
+| `BulkGenerateLabelsInput` / `BulkDispatchResult` / `PerOrderDispatchResult` types | **NEW** | not present in `shipments.types.ts` |
+| `useBulkGenerateLabelsMutation`, protocol-download hook | **NEW** | shipments barrel exports neither |
+| `features/orders/lib/dispatch-input.ts` (`buildDispatchItem`, `classifyDispatchEligibility`, group-by-source / group-by-carrier helpers) | **NEW (extracted)** | `orders/lib` exists (`order-health.ts`); logic currently private in `generate-label-form.tsx` (`buildGenerateLabelInput`, `detectMissingFields`) → extract + reuse |
+| `shared/ui/checkbox-cell.tsx` | **PARTIAL → lift** | `CheckboxCell` is page-local in `products-list-page.tsx`; not in `shared/ui/`. Lift down + re-point products import |
+| `BulkActionBar` | **ALREADY EXISTS → reuse** | `shared/ui/bulk-action-bar.tsx` (count + hint + actions) |
+| `useLabelDownload` blob pattern, `Dialog`/`DialogFooter`, `StatusBadge`, `StructuredErrorList`, `ConfirmDialog`, `parseOrderSnapshot`, `useToast` | **ALREADY EXISTS → reuse** | `shared/ui/*`, `features/orders/api/order-snapshot.schema.ts` |
+| `BulkDispatchDialog` + schema | **NEW** | same-feature component; page deep-imports it (no barrel change) |
+
+## Backward-compatibility findings
+
+| Surface | Assessment | Severity |
+|---|---|---|
+| `ShipmentsApi` interface + `createShipmentsApi` | Two methods **added**; nothing removed/retyped | none (additive) |
+| shipments barrel (`features/shipments/index.ts`) | Hooks/types **added** | none (additive) |
+| `createMockApiClient` (`apps/web/src/test/test-utils.tsx`) | `shipments` mock **extended** with `bulkGenerateLabels` + `downloadProtocol` | Warning — every existing shipments-mock test must still satisfy the type; deep-partial mock means additive is safe |
+| `products-list-page.tsx` | `CheckboxCell` import re-pointed to `shared/ui` (no behavior change) | Warning — products component tests must stay green |
+| `generate-label-form.tsx` | Refactored to import extracted `buildDispatchItem`/eligibility helpers (behavior preserved) | Warning — single-form tests must stay green |
+| Backend / core / DTOs / Symbol tokens / ORM / migration | **Untouched** | none |
+| `check:invariants` (cross-context, service-interface, migration-timestamps) | Backend-only checks; FE change can't trip them | none |
+| FE ESLint (feature deep-import ban, design-token drift) | New helpers live in canonical `lib/`; new `shared/ui` primitive is allowed; **no new CSS tokens planned** (reuse existing) — if any added, mirror to `tokens.ts` | none if token rule honored |
+
+## Open questions
+None blocking. Design decisions already resolved with the user: orders-list entry; multi-source via per-source fan-out (`Promise.allSettled`); exclude COD/unresolved-paczkomat orders (surface "dispatch individually"); shared parcel default + per-order override; one handover-protocol download per carrier connection. The 25-cap is per source-group, enforced at selection.
+
+## Notes for implementation
+- Keep the **group-by-source** (dispatch fan-out) and **group-by-carrier** (protocol) logic as pure, unit-tested helpers in `orders/lib` — they're the main effort and the highest-value test target.
+- Extract `buildDispatchItem` so single + bulk produce identical payloads (anti-drift).
+- Measure overflow with the DOM, not screenshots (a class collision clipped a badge during mockup review; the typed primitives avoid it in the real build).

--- a/docs/plans/implementation-plan-1109-bulk-shipment-dispatch-ui.md
+++ b/docs/plans/implementation-plan-1109-bulk-shipment-dispatch-ui.md
@@ -1,0 +1,145 @@
+# Implementation Plan — #1109 bulk shipment dispatch UI
+
+**Issue:** #1109 — `[IMPL] feat(web): bulk shipment dispatch UI (batch generate-labels + handover protocol)`
+**Branch:** `1109-bulk-shipment-dispatch-ui`
+**Layer:** Frontend only (`apps/web`). No backend/core/migration changes — the bulk endpoints are already wired.
+**Effort:** S–M (FE-only, but the per-order-override dialog + eligibility pre-flight push it past trivial).
+
+---
+
+## 1. Understand the task
+
+Surface the already-shipped bulk-fulfillment backend as an operator UI. Two endpoints exist and are consumed **as-is**:
+
+- `POST /shipments/bulk/generate-labels` — body `{ sourceConnectionId, items: BulkDispatchItem[1..25] }`, returns **200** `{ results: PerOrderDispatchResult[] }` where each result is `{ kind: 'dispatched', orderId, shipment } | { kind: 'omp_fulfilled', orderId } | { kind: 'failed', orderId, error }`. Partial failure is normal (200 with mixed results).
+- `POST /shipments/bulk/protocol` — body `{ shipmentIds: string[1..25] }`, returns **binary** (provider MIME) carrier handover protocol.
+
+Each `BulkDispatchItem` is the single-order `GenerateLabelInput` minus `sourceConnectionId` — i.e. a full dispatch payload: derived `recipient`/`deliveryIntent`/`paczkomatId` + operator-supplied `parcel` (dims + weight) + optional `cod`.
+
+**Non-goals (issue-stated):** backend changes; auto-dispatch/scheduling; bulk cancel.
+
+### Decisions locked with the user (design fork)
+
+1. **Entry point:** the **orders list page** (`apps/web/src/pages/orders/orders-list-page.tsx`) — dispatch starts pre-shipment, from orders.
+2. **COD / manual-input orders:** **excluded from bulk** and surfaced as "dispatch individually" with a reason (never silently dropped). Bulk only handles orders whose payload is fully derivable from the snapshot + the shared parcel.
+3. **Parcel:** **shared default + per-order override** — one L×W×H + weight pre-fills every selected order; each row can be tweaked before submit.
+
+### Two connection axes (drives the multi-source + protocol decisions)
+
+The endpoints expose **two distinct connection axes**, and the UX honors both:
+
+- **Source connection** — `POST /shipments/bulk/generate-labels` takes one `sourceConnectionId` per request. **Decision: multi-source via fan-out.** The operator selects freely across sources; the FE **groups the selection by `sourceConnectionId` and fires one bulk request per group** (each group capped at 25), then merges the per-order results into one view. No backend change; no source-filter friction.
+- **Carrier connection** — `POST /shipments/bulk/protocol` rejects mixed-carrier batches (asserts a single carrier `connectionId`). A dispatched batch can span carriers (different delivery methods route differently), so **Decision: one protocol download per carrier** — after dispatch, group dispatched shipments by their carrier `connectionId` and render one "Download {carrier} protocol" action per group.
+
+The 25-cap is therefore **per source-group**, enforced at selection time (an order whose source-group is already at 25 shows a disabled checkbox with a "Max 25 per source" tooltip).
+
+---
+
+## 2. Research (done — key reuse map)
+
+| Need | Reuse / precedent | Path |
+|---|---|---|
+| Multi-select on a list | `Set<string>` local state + header tri-state + 25 cap (no URL state) | `apps/web/src/pages/products/products-list-page.tsx` (#739) |
+| Checkbox cell | `CheckboxCell` — **currently page-local in products**; lift to `shared/ui` | `shared/ui/` (new) |
+| Bulk action bar | `BulkActionBar` (count + hint + actions, sticky, a11y) | `shared/ui/bulk-action-bar.tsx` |
+| Per-order payload build | `buildGenerateLabelInput` + `detectMissingFields` + locker/courier classify — **currently private in the single form**; extract to `orders/lib` | `features/orders/components/generate-label-form.tsx` |
+| Snapshot parse (recipient, address, pickupPoint, paymentStatus, shipping.method) | `parseOrderSnapshot` / `ParsedOrderSnapshot` | `features/orders/api/order-snapshot.schema.ts` |
+| Binary download (imperative blob → `<a download>`) | `useLabelDownload` pattern (GET); protocol is POST-with-body via `requestBlob(path, init)` | `features/shipments/hooks/use-label-download.ts` |
+| Modal / confirm | `ConfirmDialog`, `Dialog` (radix-wrapped) | `shared/ui/` |
+| Result list | `StructuredErrorList` for failures + a compact success summary | `shared/ui/structured-error-list.tsx` |
+| Toasts | `useToast()` | `shared/ui/toast-provider.tsx` |
+
+API-client seam: `createShipmentsApi(request, requestBlob)` composed in `app/api/api-client.ts`; tests via `createMockApiClient({ shipments: {...} })` in `test/test-utils.tsx`.
+
+---
+
+## 3. Design
+
+### 3.1 Data layer — `features/shipments`
+
+- **`api/shipments.types.ts`**: add
+  - `BulkDispatchItem = Omit<GenerateLabelInput, 'sourceConnectionId'>`
+  - `BulkGenerateLabelsInput { sourceConnectionId: string; items: BulkDispatchItem[] }`
+  - `PerOrderDispatchResult` union (`dispatched | omp_fulfilled | failed`) + `BulkDispatchResult { results: PerOrderDispatchResult[] }`
+- **`api/shipments.api.ts`**: add to `ShipmentsApi`
+  - `bulkGenerateLabels(input): Promise<BulkDispatchResult>` → `POST /shipments/bulk/generate-labels`
+  - `downloadProtocol(shipmentIds: string[]): Promise<Blob>` → `requestBlob('/shipments/bulk/protocol', { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify({ shipmentIds }) })`
+- **`hooks/use-bulk-generate-labels-mutation.ts`**: `useMutation` → invalidates `shipmentsQueryKeys.all` **and** `ordersQueryKeys.all` (dispatch flips order fulfillment) on success.
+- **`hooks/use-protocol-download.ts`**: imperative blob-download hook mirroring `useLabelDownload` (filename `ol-handover-protocol.{ext}`, same MIME→ext map — extract the map so it isn't triple-duplicated, or keep local per existing precedent; lean to a tiny shared `lib/label-download.ts` in shipments).
+- **`index.ts`** barrel + **`test/test-utils.tsx`** mock: export the new hooks/types; add `bulkGenerateLabels` + `downloadProtocol` to the shipments mock.
+
+### 3.2 Orders dispatch lib — `features/orders/lib/dispatch-input.ts` (new, pure)
+
+Extract from the single form (and refactor the form to import these — anti-drift):
+- `buildDispatchItem(order, snapshot, parcel, cod?): BulkDispatchItem` — the snapshot→payload derivation currently in `buildGenerateLabelInput` (recipient/address/deliveryIntent/paczkomat).
+- `classifyDispatchEligibility(order): DispatchEligibility` — pure, returns
+  - `{ eligible: true, deliveryIntent, paczkomatId? }`, or
+  - `{ eligible: false, reason }` where reason ∈ `missing-recipient` (incomplete snapshot per `detectMissingFields`), `needs-paczkomat` (locker method, no buyer-resolved pickup point — would need manual typing), `cod` (COD order — per-order amount needed), `already-dispatched` (`fulfillmentState` dispatched/delivered), `omp-fulfilled`/`not-ready` (recordStatus), `payment-blocked` (snapshot paymentStatus in the #928 blocking set).
+- Unit-tested in isolation (this is the risk-bearing logic).
+
+The single `generate-label-form.tsx` keeps its own form UX but calls `buildDispatchItem` so single + bulk produce identical payloads.
+
+### 3.3 Shared primitive — `shared/ui/checkbox-cell.tsx` (lift from products)
+
+Move `CheckboxCell` (+ its CSS) to `shared/ui`; re-point products-list-page to the shared import. Keeps one selection-checkbox implementation.
+
+### 3.4 Orders list page — multi-select + bulk bar
+
+- Local `useState<Set<string>>` selection (not URL state), header tri-state checkbox. The **25-cap is per source-group**: a row whose `sourceConnectionId` group already holds 25 shows a disabled checkbox + "Max 25 per source" tooltip. Selection may span sources freely.
+- Selection is offered only for **candidate** rows (not already dispatched/delivered). A selected order that turns out ineligible is still surfaced in the dialog (not blocked at the checkbox) so the reason is visible.
+- `BulkActionBar` (count + per-source hint + "Dispatch N") → opens `BulkDispatchDialog`. No single-source guard — multi-source is supported via fan-out (3.5).
+
+### 3.5 `features/orders/components/bulk-dispatch-dialog.tsx` (new)
+
+A `Dialog` with three states:
+1. **Compose** — shared parcel profile (L×W×H + weight, RHF + zod, reuse `generate-label-form.schema` parcel bits) at top; a per-order table: order id + recipient summary + **source pill** (the batch may span sources) + eligibility badge. Eligible rows show editable dims/weight pre-filled from the shared profile (override). Ineligible rows show the reason + a "dispatch individually" link to the order detail. Submit is enabled when ≥1 eligible order.
+2. **Submitting** — `fieldset disabled`, progress note. The FE groups eligible items by `sourceConnectionId` and **fans out one `bulkGenerateLabels` call per source group** (capped at 25 each — the selection cap guarantees this), awaiting all via `Promise.allSettled` so one source's failure doesn't sink the others.
+3. **Result** — merged per-order outcomes across all groups: dispatched (✓ + tracking-pending), omp_fulfilled (info), failed (`StructuredErrorList` with `error`). Dispatched shipments are **grouped by carrier `connectionId`**, rendering **one "Download {carrier} protocol" action per carrier group** (`downloadProtocol(shipmentIdsForThatCarrier)`).
+
+Items posted = eligible orders only, each `buildDispatchItem(order, snapshot, perOrderParcel)`. The dialog owns the **group-by-source fan-out + group-by-carrier protocol** orchestration; the `bulkGenerateLabels` api method stays a thin single-request call matching the endpoint.
+
+### 3.6 Styling
+
+New CSS in `index.css` under a `/* ── Bulk dispatch dialog (#1109) ── */` section, tokens only; every new `--token` (none expected) mirrored to `tokens.ts`. Responsive: the per-order table collapses to stacked cards under `--bp` (reuse DataTable card precedent or a simple stacked layout).
+
+---
+
+## 4. Step-by-step
+
+1. `shared/ui/checkbox-cell.tsx` — lift `CheckboxCell` + CSS from products; re-point products-list-page. *(AC: reuse; no behavior change — products tests still green.)*
+2. `features/orders/lib/dispatch-input.ts` — extract `buildDispatchItem` + `classifyDispatchEligibility` (+ move `detectMissingFields`/classify helpers); refactor `generate-label-form.tsx` to import them. *(AC: single-form behavior unchanged; new unit tests pass.)*
+3. shipments data layer (3.1) — types + api methods + 2 hooks + barrel + mock. *(AC: type-check; mock supports new methods.)*
+4. `bulk-dispatch-dialog.tsx` (3.5) + schema + CSS. *(AC: compose→submit→result states; 25-cap; per-order results; protocol download; ineligible surfaced.)*
+5. orders-list-page wiring (3.4) — selection state, checkbox column, single-connection guard, `BulkActionBar`, dialog mount. *(AC: multi-select + cap + bulk trigger.)*
+6. Tests (3.7 below) + quality gate.
+
+## 4b. Tests
+
+- `dispatch-input.spec.ts` (unit) — eligibility classifier across all reasons; `buildDispatchItem` payload shape (paczkomat vs courier address derivation).
+- `bulk-dispatch-dialog.test.tsx` — happy path (2 eligible → submit → 1 dispatched/1 failed result + protocol button enabled); ineligible order surfaced with reason; 25-cap message; empty-eligible disables submit. `createMockApiClient` for `bulkGenerateLabels` + `downloadProtocol`.
+- `use-bulk-generate-labels-mutation` covered via the dialog test (invalidation) or a focused hook test.
+- orders-list-page existing test stays green (selection additive).
+
+---
+
+## 5. Validate
+
+- **Architecture:** FE-only; `pages → features → shared` respected (page consumes shipments+orders features; `CheckboxCell` moves *down* to shared). No `shared → features` edge. Server state via TanStack Query; selection + dialog state are local `useState`; parcel form via RHF+zod. ✓
+- **Reuse over new:** BulkActionBar, useLabelDownload pattern, parseOrderSnapshot, ConfirmDialog/Dialog, StructuredErrorList all reused; the one extraction (dispatch-input) removes duplication rather than adding it. ✓
+- **Contract surfaces:** no barrel removals; additive only (shipments barrel + api + mock). Bulk endpoints consumed as-is — no DTO drift risk since FE types mirror the response union. ✓
+- **Honesty ACs:** 25-cap explicit (no silent truncation); ineligible/payment-blocked orders surfaced with reasons; partial-failure results shown per order. ✓
+- **Security:** admin-guarded endpoints; no secrets in FE; no auth logic duplicated (payment gate is server-authoritative — FE eligibility is UX only). ✓
+- **Responsive:** per-order table → stacked cards; bulk bar sticky. ✓
+
+### Tech-review refinements (folded in)
+
+- **Rejected fan-out group ≠ silent drop.** When a source-group's `bulkGenerateLabels` call rejects (network/5xx), the merge synthesizes a `failed` outcome for every order in that group (carrying the group error) — they must appear in the result table, never vanish. Unit-tested.
+- **Per-source cap on "select all".** The 25-cap is per source-group, so the header tri-state toggle caps each source independently (not the first-25). Extracted as a pure `capSelectionPerSource` helper in `orders/lib`, unit-tested; the header all/some/none state reflects the multi-group selection.
+- **Overrides reuse the shared zod rules.** Per-order dim/weight overrides validate with the same schema as the shared profile (no bypass that 422s mid-batch). Per-order state is one typed `useReducer`, not a loose map.
+- **a11y:** per-order dim/weight inputs carry explicit `aria-label`s including the order id (mirrors the single form).
+- **COD coverage:** excluding COD from v1 bulk is tracked as a fast-follow on #1109 (PL is COD-heavy).
+
+### Risks / open items
+- **Per-order-override surface** is the main scope risk — keep the per-order row minimal (dims+weight only; everything else derived/read-only).
+- **Fan-out orchestration** (group-by-source dispatch + group-by-carrier protocol) is the second scope risk — keep it as pure grouping helpers in `orders/lib` (testable) with `Promise.allSettled` so a partial group failure degrades gracefully. This is the bulk of the M-effort.
+- The MIME→extension map would be a third copy — extract a tiny shared helper in shipments `lib/` rather than duplicate.


### PR DESCRIPTION
## What & why

Surfaces the already-wired bulk-fulfillment endpoints (`POST /shipments/bulk/generate-labels` + `/shipments/bulk/protocol`) as an operator UI — they were shipped but unusable without calling the API directly. **FE-only**; endpoints consumed as-is. Entry from the orders list: multi-select → `BulkDispatchDialog`. The non-deferred sibling of #1108, carved out of the #1032 OMS review.

## How it works

- **Multi-select on the orders list** — local `Set` state (not URL — would balloon on every toggle), header tri-state checkbox, **25-cap enforced per source connection** (already-shipped rows disabled with a tooltip).
- **`BulkDispatchDialog`** — shared parcel profile (L×W×H + weight) with "Apply to all rows" + per-order override rows. Ineligible orders (COD / unresolved-paczkomat / missing-recipient / payment-blocked / already-shipped / not-ready) are **surfaced with a reason + "dispatch individually" link — never silently dropped** (an explicit AC).
- **Multi-source** — selection may span source connections; the dialog groups by source and fans out **one bulk request per group** (`Promise.allSettled`). A rejected group **synthesizes per-order failures** so nothing vanishes from the result view.
- **Per-carrier handover protocol** — dispatched shipments are grouped by carrier connection (the protocol endpoint rejects mixed-carrier batches); one download per carrier.

## Reuse + anti-drift

- Lifted `CheckboxCell` from the products page into `shared/ui` (one selection primitive; products re-pointed).
- Extracted `buildDispatchItem` + `classifyDispatchEligibility` into `features/orders/lib/dispatch-input` so the single-order form and the bulk dialog produce **identical payloads**; the single form now consumes it.
- Per-order overrides validate against the **same parcel zod schema** as the shared profile (no override can submit dims the single form would reject).
- Extracted the blob-download helper so the label + protocol hooks share the MIME→extension map.

## Design

Mockup built against the real OKLCH token system, screenshotted + DOM-verified across all four states (orders-list selection, compose, submitting, result) via `/frontend-design`. Composes existing primitives (`Dialog`, `DataTable`, `StatusBadge`, `BulkActionBar`, `Input`) — no new visual identity, responsive (rows stack on mobile).

## Tests

- `dispatch-input` (17) — eligibility classifier across every reason, payload builder (paczkomat vs courier), per-source cap, grouping.
- `BulkDispatchDialog` (5) — fan-out + merge, **rejected-group synthesis**, ineligible surfacing, empty-eligible guard, per-carrier protocol.
- `CheckboxCell` (4).

## Quality gate

`pnpm lint` ✓ (0 errors; design-token drift, cross-context, service-interface invariants pass) · `pnpm type-check` ✓ · `pnpm test` ✓ (web 1472 · api 467 · worker 167). No backend/core/migration changes → `test:integration` n/a.

## Reviews applied

`/pre-implement` (READY) + `/tech-review` (Approve with changes) — all three IMPORTANT items folded in + tested: rejected-group failure synthesis, per-source cap, override schema validation.

**Deferred follow-up (tracked):** COD orders are excluded from bulk v1 (PL is COD-heavy) — surfaced as "dispatch individually"; a batch-level COD acknowledgement is a fast-follow.

Related: non-deferred slice of #1032 (Gate D = DEFER).

Closes #1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)