### PR TITLE
fix(prestashop): create-idempotent product publish via stable reference (#1107)

### DIFF
--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__/prestashop-product-publisher.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/__tests__/prestashop-product-publisher.adapter.spec.ts
@@ -114,6 +114,53 @@ describe('PrestashopProductPublisherAdapter', () => {
       expect(result).toEqual({ externalProductId: '100', status: 'draft' });
     });
 
+    it('should stamp reference = internalVariantId on create (idempotency key, #1107)', async () => {
+      client.createResource.mockResolvedValue({ id: '100', active: '1' });
+      withDefaultStockMock(client);
+
+      await adapter.publishProduct(baseCommand({ internalVariantId: 'ol_variant_xyz' }));
+
+      const body = client.createResource.mock.calls[0][1] as { reference?: string };
+      expect(body.reference).toBe('ol_variant_xyz');
+    });
+
+    it('should adopt an orphaned product by reference instead of creating a duplicate (#1107)', async () => {
+      // A prior create succeeded but core never persisted the mapping (orphan).
+      client.listResources.mockImplementation((resource) => {
+        if (resource === 'products') {
+          return Promise.resolve([{ id: '900', reference: 'ol_variant_aaaa' }]);
+        }
+        return Promise.resolve([{ id: '1', id_product: '900', quantity: '0' }]); // stock_availables
+      });
+      client.updateResource
+        .mockResolvedValueOnce({ id: '900', active: '1' }) // adopted product update
+        .mockResolvedValueOnce({ id: '1' }); // stock update
+
+      const result = await adapter.publishProduct(baseCommand()); // no externalProductId → create path
+
+      expect(client.createResource).not.toHaveBeenCalled();
+      expect(client.listResources).toHaveBeenCalledWith('products', {
+        custom: { 'filter[reference]': 'ol_variant_aaaa' },
+      });
+      expect(client.updateResource).toHaveBeenNthCalledWith(
+        1,
+        'products',
+        '900',
+        expect.objectContaining({ id: '900', reference: 'ol_variant_aaaa' }),
+      );
+      expect(result.externalProductId).toBe('900');
+    });
+
+    it('should propagate a reference-lookup failure rather than risk a duplicate (#1107)', async () => {
+      // An ambiguous lookup (transport error) must NOT fall through to create.
+      client.listResources.mockRejectedValue(new PrestashopApiException('WS down', 503));
+
+      await expect(adapter.publishProduct(baseCommand())).rejects.toBeInstanceOf(
+        PrestashopApiException,
+      );
+      expect(client.createResource).not.toHaveBeenCalled();
+    });
+
     it('should map status "published" → active "1"', async () => {
       client.createResource.mockResolvedValue({ id: '1', active: '1' });
       withDefaultStockMock(client);
@@ -166,7 +213,11 @@ describe('PrestashopProductPublisherAdapter', () => {
 
     it('should update stock after product creation', async () => {
       client.createResource.mockResolvedValue({ id: '42', active: '1' });
-      client.listResources.mockResolvedValue([{ id: '7', id_product: '42', quantity: '0' }]);
+      client.listResources.mockImplementation((resource) =>
+        resource === 'products'
+          ? Promise.resolve([]) // no orphan → create path
+          : Promise.resolve([{ id: '7', id_product: '42', quantity: '0' }]),
+      );
       client.updateResource.mockResolvedValue({ id: '7' });
 
       await adapter.publishProduct(baseCommand({ stock: 10 }));
@@ -198,7 +249,13 @@ describe('PrestashopProductPublisherAdapter', () => {
       // persistence and cause the next retry to call createResource again, producing a
       // duplicate orphaned PS product.
       client.createResource.mockResolvedValue({ id: '77', active: '1' });
-      client.listResources.mockRejectedValue(new PrestashopApiException('WS error', 503));
+      // The reference lookup ('products') must succeed (miss → create); only the
+      // stock_availables read throws, exercising the best-effort stock path.
+      client.listResources.mockImplementation((resource) =>
+        resource === 'products'
+          ? Promise.resolve([])
+          : Promise.reject(new PrestashopApiException('WS error', 503)),
+      );
 
       const result = await adapter.publishProduct(baseCommand({ stock: 5 }));
 
@@ -210,6 +267,7 @@ describe('PrestashopProductPublisherAdapter', () => {
       client.createResource.mockRejectedValue(
         new PrestashopApiException('Invalid product data', 400),
       );
+      client.listResources.mockResolvedValue([]); // create path: no orphan → reaches createResource
 
       await expect(adapter.publishProduct(baseCommand())).rejects.toMatchObject({
         name: 'ProductPublishRejectedException',
@@ -223,6 +281,7 @@ describe('PrestashopProductPublisherAdapter', () => {
     it('should propagate PrestashopAuthenticationException (401) unchanged', async () => {
       const err = new PrestashopAuthenticationException('Unauthorized', CONNECTION_ID);
       client.createResource.mockRejectedValue(err);
+      client.listResources.mockResolvedValue([]);
 
       await expect(adapter.publishProduct(baseCommand())).rejects.toBe(err);
       await expect(adapter.publishProduct(baseCommand())).rejects.not.toBeInstanceOf(
@@ -233,6 +292,7 @@ describe('PrestashopProductPublisherAdapter', () => {
     it('should propagate 5xx PrestashopApiException unchanged', async () => {
       const err = new PrestashopApiException('Gateway timeout', 503);
       client.createResource.mockRejectedValue(err);
+      client.listResources.mockResolvedValue([]);
 
       await expect(adapter.publishProduct(baseCommand())).rejects.toBe(err);
       await expect(adapter.publishProduct(baseCommand())).rejects.not.toBeInstanceOf(

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publish.types.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publish.types.ts
@@ -26,6 +26,12 @@ export interface PrestashopProductWriteBody {
   name: PrestashopLangField;
   description?: PrestashopLangField;
   link_rewrite: PrestashopLangField;
+  /**
+   * Stable, server-side idempotency key (= OL `internalVariantId`). Stamped on
+   * every create so a retry can look the product up by `reference` and adopt the
+   * orphan instead of creating a duplicate (#1107 create-idempotency guard).
+   */
+  reference?: string;
   /** Tax-excluded price; PS WS convention uses a decimal string. */
   price: string;
   active: '0' | '1';
@@ -42,6 +48,12 @@ export interface PrestashopProductWriteBody {
 export interface PrestashopProductResponse {
   id: string | number;
   active: string | number;
+}
+
+/** Item from GET /api/products (list response, used for the reference lookup). */
+export interface PrestashopProductListItem {
+  id: string | number;
+  reference?: string;
 }
 
 /** Category item from GET /api/categories (list response). */

--- a/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/product-publisher/prestashop-product-publisher.adapter.ts
@@ -34,6 +34,7 @@ import type {
   PrestashopCategoryListItem,
   PrestashopCategoryResponse,
   PrestashopLangField,
+  PrestashopProductListItem,
   PrestashopProductResponse,
   PrestashopProductWriteBody,
   PrestashopStockAvailableItem,
@@ -102,7 +103,21 @@ export class PrestashopProductPublisherAdapter
           { id: String(cmd.externalProductId), ...body },
         );
       } else {
-        response = await this.client.createResource<PrestashopProductResponse>('products', body);
+        // Create-idempotency guard (#1107, Piotr review): a prior attempt may have
+        // created the product but died before core persisted the identifier
+        // mapping, leaving an orphan. Because `body.reference` = internalVariantId
+        // is a stable server-side key, look it up first and ADOPT the orphan
+        // (update it) instead of creating a duplicate. A lookup miss → first
+        // publish → create. A lookup error propagates (mapped below) rather than
+        // falling through to create, so a flaky GET can never spawn a duplicate.
+        const orphanId = await this.findExistingByReference(cmd.internalVariantId);
+        response =
+          orphanId != null
+            ? await this.client.updateResource<PrestashopProductResponse>('products', orphanId, {
+                id: orphanId,
+                ...body,
+              })
+            : await this.client.createResource<PrestashopProductResponse>('products', body);
       }
     } catch (err) {
       throw this.toPublishError(err);
@@ -175,6 +190,9 @@ export class PrestashopProductPublisherAdapter
       ...(cmd.platformParams ?? {}),
       name: langField(title, languageId),
       link_rewrite: langField(slug, languageId),
+      // Stable idempotency key — see findExistingByReference (#1107). Explicit so
+      // it always wins over any un-modeled platformParams.reference.
+      reference: cmd.internalVariantId,
       price: cmd.price.amount.toFixed(2),
       active: cmd.status === 'published' ? '1' : '0',
       // Fall back to PS Home category (id 2) when no category is provided — '0' is
@@ -207,11 +225,26 @@ export class PrestashopProductPublisherAdapter
     return body;
   }
 
+  /**
+   * Look up an existing product by its stable `reference` (= internalVariantId).
+   * Returns the PS product id of a prior orphaned create, or null on a genuine
+   * miss (first publish). Throws on a transport/API failure — the caller must NOT
+   * treat an ambiguous lookup as "no match" and create, or the duplicate-product
+   * hazard this guard closes would reopen (#1107).
+   */
+  private async findExistingByReference(reference: string): Promise<string | null> {
+    const rows = await this.client.listResources<PrestashopProductListItem>('products', {
+      custom: { 'filter[reference]': reference },
+    });
+    const match = rows.find((row) => String(row.reference ?? '') === reference) ?? rows[0];
+    return match ? String(match.id) : null;
+  }
+
   private async updateStock(productId: string, quantity: number): Promise<void> {
-    // Fully best-effort: PS creates the product before returning, so if any step here
-    // throws the core service won't persist the identifier mapping and the retry will
-    // call createResource again — producing a duplicate orphaned PS product. An unset
-    // stock heals on the next inventory sync; a duplicate product has no auto-recovery.
+    // Fully best-effort: PS creates the product before returning, so if any step
+    // here throws the core service won't persist the identifier mapping. The retry
+    // no longer duplicates — findExistingByReference adopts the orphan by its
+    // stable `reference` (#1107). An unset stock heals on the next inventory sync.
     try {
       const rows = await this.client.listResources<PrestashopStockAvailableItem>('stock_availables', {
         custom: { 'filter[id_product]': productId },


### PR DESCRIPTION
## Problem

Piotr flagged this on PR #1077 (16:53 tech-lead review, "🟡 Important #1"): the PrestaShop product publisher (#1107, now on `main`) is **not create-idempotent**. PS creates the product before returning, so if `createResource` succeeds but the process dies before core persists the `externalProductId` identifier mapping, the retry calls `createResource` again — producing a **duplicate orphaned PS product with no auto-recovery** (an unset stock self-heals on the next inventory sync; a duplicate product silently corrupts the catalog).

The adapter itself documented the gap candidly; this PR closes it.

## Fix

Piotr's suggested mitigation — a stable server-side idempotency key + look-before-create:

- Stamp `reference = internalVariantId` on every create (`PrestashopProductWriteBody.reference`, explicit so it wins over `platformParams`).
- On the create path, `findExistingByReference` looks the product up by `reference` **first**:
  - **miss** → genuine first publish → `createResource`;
  - **hit** → adopt the orphan (`updateResource` by its id) — no duplicate;
  - **lookup error** → propagates (mapped through `toPublishError`); it never falls through to create, so a flaky GET cannot reopen the hazard.

The `updateStock` step stays best-effort (it self-heals); only the *create* needed the guard.

## Tests

- 3 new unit tests: stamps `reference`; adopts an orphan instead of duplicating; propagates a reference-lookup failure rather than risking a duplicate.
- Existing create-path tests updated to discriminate the new `products` lookup from the `stock_availables` read.
- 23/23 publisher specs, 407/407 PrestaShop units, ps type-check + lint clean.

## Classification

**Type**: Integration (PrestaShop) · **Layer**: Infrastructure (adapter) · no migration, no CORE change.

Closes the #1077 review's Important #1. Refs #1107, ADR-024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
