### PR TITLE
feat(orders): OrderStatusWriteback capability + lifecycle relay; inbound cancel → destination (#1158)

### DIFF
--- a/apps/worker/src/sync/handlers/marketplace-order-sync.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-order-sync.handler.ts
@@ -40,7 +40,8 @@ export class MarketplaceOrderSyncHandler implements SyncJobHandler {
       await this.orderIngestion.syncOrderFromSource(
         job.connectionId,
         payload.externalOrderId,
-        payload.sourceEventId
+        payload.sourceEventId,
+        payload.eventType
       );
 
       return { outcome: 'ok' };

--- a/docs/plans/implementation-plan-1158-order-status-writeback-relay.md
+++ b/docs/plans/implementation-plan-1158-order-status-writeback-relay.md
@@ -1,0 +1,137 @@
+# Implementation Plan — #1158 OrderStatusWriteback capability + lifecycle-relay (inbound cancel → destination)
+
+**Issue:** #1158 (Part of #1157; realises ADR-027). Closes #1132.
+**Branch:** `1158-order-status-writeback-relay`
+**Layer:** CORE (`orders`) + Integration (PrestaShop) + Worker (thin handler edit).
+
+---
+
+## 1. Goal (restated)
+
+Lay the foundation of the Posture-A lifecycle relay:
+1. A **role/platform-neutral, event-as-data** `OrderStatusWriteback` capability (per ADR-027).
+2. **PrestaShop implements it**, delegating to its existing `updateFulfillment` internals.
+3. A **core lifecycle-relay service** that propagates a lifecycle event to an order's other participants via the `isOrderStatusWriteback` guard — **zero platform-type branching**.
+4. **Wire inbound cancel → destination**: a source `cancelled` event routes through the relay to each destination; an already-shipped destination surfaces an **operator-visible** outcome, never a silent no-op (the #1132 fix).
+
+**Non-goals (this slice):** source-side writeback / Allegro impl (#1159); branch-1 shop-fulfilled → source (#1160); shop-as-source cancel detection (#1161); OL-owned canonical status / per-axis schema (#1032). No new `OrderStatus` values.
+
+## 2. Key existing facts (researched)
+
+- Capabilities live in `libs/core/src/orders/domain/ports/capabilities/` = interface + co-located `is{Capability}` guard, exported from `orders/index.ts`.
+- `OrderStatus` = `pending|processing|shipped|delivered|cancelled|refunded` (`domain/types/order.types.ts`). `DispatchCarrierHint = { platformType }`.
+- To subsume: `OrderDispatchNotifier.notifyDispatched(...)` (on `OrderSourcePort`) and `OrderFulfillmentUpdater.updateFulfillment({externalOrderId,status,trackingNumber?})` (on `OrderProcessorManagerPort`).
+- PrestaShop `PrestashopOrderProcessorManagerAdapter` already implements `OrderFulfillmentUpdater`; `updateFulfillment` resolves a PS state id, writes tracking, then `order_histories` state change w/ `sendmail` (idempotent — skips if already in state).
+- Inbound flow: `marketplace-order-sync.handler` carries `eventType` in the payload **but never uses it**; calls `OrderIngestionService.syncOrderFromSource(connId, externalOrderId, sourceEventId)` (no eventType). Job enqueue already dedups on `marketplace:${connId}:order:${eventKey}`.
+- Destinations of an order = `identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Order, internalOrderId)` minus the source connection (pattern used by `shipment-dispatch-notification.service`).
+- Adapter resolution: `IIntegrationsService.getCapabilityAdapter<T>(connId, capability)` + narrow with guard.
+
+## 3. Design
+
+### 3.1 Capability (event-as-data)
+
+`domain/types/order-lifecycle-event.types.ts` (NEW):
+```ts
+export const OrderLifecycleEventTypeValues = ['dispatched', 'cancelled'] as const;
+export type OrderLifecycleEventType = (typeof OrderLifecycleEventTypeValues)[number];
+
+export type OrderLifecycleEvent =
+  | { type: 'dispatched'; externalOrderId: string; trackingNumber?: string; carrier?: DispatchCarrierHint }
+  | { type: 'cancelled'; externalOrderId: string; reason?: string };
+
+export const OrderWritebackOutcomeValues = ['applied', 'unsupported', 'rejected'] as const;
+export type OrderWritebackOutcome = (typeof OrderWritebackOutcomeValues)[number];
+export interface OrderWritebackResult { outcome: OrderWritebackOutcome; detail?: string }
+```
+
+`domain/ports/capabilities/order-status-writeback.capability.ts` (NEW):
+```ts
+export interface OrderStatusWriteback {
+  write(event: OrderLifecycleEvent): Promise<OrderWritebackResult>;
+}
+export function isOrderStatusWriteback<T extends object>(a: T): a is T & OrderStatusWriteback {
+  return typeof (a as Partial<OrderStatusWriteback>).write === 'function';
+}
+```
+Role-agnostic guard (generic `T`) — same adapter object may be resolved as `OrderProcessorManager` (this slice) or `OrderSource` (later slices). Both exported from `orders/index.ts`.
+
+### 3.2 PrestaShop implements `OrderStatusWriteback`
+
+`PrestashopOrderProcessorManagerAdapter` adds `OrderStatusWriteback` to its `implements` + a `write(event)` that **delegates to existing internals**:
+- `dispatched` → `updateFulfillment({externalOrderId, status:'shipped', trackingNumber})` → `{outcome:'applied'}`.
+- `cancelled` → read the order; if `current_state` is already a **past-cancellable** state (shipped/delivered) → `{outcome:'rejected', detail:'already shipped'}` (do **not** force state 6); else `updateFulfillment({status:'cancelled'})` → `{outcome:'applied'}`.
+- Wrap PS exceptions → `{outcome:'rejected', detail}`. `OrderFulfillmentUpdater` **retained** (order provisioning / dispatch path unchanged).
+
+> The "already shipped" check lives in the **adapter** because the destination shop is authoritative for its own live state — more correct than the relay guessing from OL's source-derived snapshot.
+
+### 3.3 Core lifecycle-relay service
+
+`application/interfaces/order-lifecycle-relay.service.interface.ts` (NEW):
+```ts
+export interface OrderLifecycleRelayInput {
+  internalOrderId: string;
+  originConnectionId: string;          // excluded from targets (self-echo at participant level)
+  event: { type: 'dispatched'; trackingNumber?: string; carrier?: DispatchCarrierHint }
+       | { type: 'cancelled'; reason?: string };
+}
+export interface OrderLifecycleRelayTargetResult { connectionId: string; outcome: OrderWritebackOutcome; detail?: string }
+export interface OrderLifecycleRelayResult { targets: OrderLifecycleRelayTargetResult[] }
+export interface IOrderLifecycleRelayService { relay(input: OrderLifecycleRelayInput): Promise<OrderLifecycleRelayResult> }
+```
+`application/services/order-lifecycle-relay.service.ts` (NEW): for each target participant —
+1. `getExternalIds(Order, internalOrderId)` → targets = entries with `connectionId !== originConnectionId`.
+2. Resolve adapter `getCapabilityAdapter<OrderProcessorManagerPort>(connId, 'OrderProcessorManager')`; **narrow `isOrderStatusWriteback`** → if absent, `outcome:'unsupported'` (log debug, continue).
+3. `write({ ...event, externalOrderId })`; collect `{connectionId, outcome, detail}`.
+4. **Explicit failure surfacing:** `rejected`/`unsupported` logged at `warn` with order+connection; `applied` at `log`. Per-target isolation (one failure doesn't block siblings).
+
+**Guardrails in this slice (unidirectional source→destination):**
+- *Re-delivery* → existing **job dedup** (`marketplace:…:eventKey`) + **idempotent adapter writes** (PS skips if already in state). No duplicate writes.
+- *Regression / "already shipped"* → adapter-reported `rejected` (§3.2), surfaced visibly.
+- *Self-echo across participants* → **not reachable in this direction** (destinations aren't ingested as sources until #1161); the durable relay-log + cross-participant echo suppression lands with the bidirectional slices (#1160/#1161). **Deliberately deferred — see §6 scope decision.**
+
+### 3.4 Wire inbound cancel → destination
+
+- `OrderIngestionService.syncOrderFromSource(connId, externalOrderId, sourceEventId?, eventType?)` — add `eventType`. If `eventType === 'cancelled'`:
+  - resolve `internalOrderId = getInternalId(Order, externalOrderId, connId)`; if null → log warn ("cancel for unknown order") + return (can't cancel what we never created).
+  - update the OrderRecord snapshot status → `cancelled` (projection of source truth; reuse repository update path).
+  - `relay.relay({ internalOrderId, originConnectionId: connId, event: { type:'cancelled', reason } })`.
+  - return a result distinguishing this from the create/update path.
+  - **else** (created/updated/paid) → existing create/update path unchanged.
+- `marketplace-order-sync.handler` → pass `payload.eventType` into the call. (Handler stays thin; branching lives in core.)
+
+### 3.5 Wiring / tokens
+
+- `orders.tokens.ts`: `ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN = Symbol('IOrderLifecycleRelayService')`.
+- `orders.module.ts`: provide `OrderLifecycleRelayService` + `useExisting` token binding + export. (No new TypeOrm entity in the deferred-ledger scope.)
+- `orders/index.ts`: export capability, guard, event/result types, relay interface.
+
+## 4. Step-by-step
+
+1. `order-lifecycle-event.types.ts` + export. **AC:** types compile; `as const` unions.
+2. `order-status-writeback.capability.ts` (interface + guard) + export. **AC:** guard narrows; unit test for guard.
+3. PrestaShop `write()` + `implements`. **AC:** unit tests — dispatched→applied(+tracking); cancelled(not-shipped)→applied; cancelled(shipped)→rejected; PS error→rejected.
+4. Relay interface + service + token + module wiring. **AC:** unit tests — fans out to destinations; excludes origin; unsupported when guard fails; per-target outcomes; warn on rejected.
+5. `OrderIngestionService` eventType branch (+ interface) + handler passes eventType. **AC:** unit tests — cancelled routes to relay (not create); unknown order → warn+skip; non-cancel unchanged. **Closes #1132.**
+6. Integration test: source `cancelled` event → destination order transitioned to cancelled (happy path) + already-shipped → rejected surfaced. (`pnpm test:integration`, full suite — capability ripples into routing int-specs.)
+7. Quality gate: `pnpm lint` / `type-check` / `test` / `test:integration`.
+
+## 5. Validation (architecture / standards)
+
+- Capability + guard follow the established pattern; types in `*.types.ts`; relay is an app service implementing an interface via Symbol token (check-service-interfaces passes).
+- No platform-type branching in the relay (capability-guard dispatch) — ADR-027 invariant.
+- `OrderFulfillmentUpdater` retained for provisioning (ADR-027 migration); `OrderDispatchNotifier` fold-in completes in #1159 (Allegro) — not this slice.
+- No `any`; `Logger` from shared; cross-context only via barrels.
+
+## 6. Scope decision for the ⏸️ gate
+
+**Recommended:** ship the relay **without** a durable relay-log table this slice. Rationale: #1158 is unidirectional (source cancel → destination write); OL never ingests its own writes here, so cross-participant echo is not yet possible, and re-delivery is already covered by job-dedup + idempotent adapter writes. A durable `(order,event,source-event-id)` ledger + full self-echo suppression is additive guardrail infra that belongs with the **bidirectional** slices (#1160/#1161) where it is actually exercised — adding it now is speculative (a migration + ORM entity + repo for a flow that doesn't exist yet).
+
+**Alternative:** build the durable relay-log now (adds a migration + ORM entity + repository) for at-most-once + audit from day one.
+
+**Open question:** the "already shipped" guard is adapter-reported (§3.2). Acceptable, or do you want the relay to also consult Shipment state (adds an orders→shipping read dependency)?
+
+## 7. Risks
+
+- **Dependency ordering:** #1158 depends on ADR-027/spec landing via #1162 (cosmetic — no code import). Real dependency is #1159/#1160/#1161 consuming this capability.
+- **OL snapshot not updated on cancel (deliberate):** the relay owns **no canonical status** (ADR-027), so the cancel path does **not** mutate the `order_records` snapshot — it only propagates to destinations. OL's own record reflecting source-cancel is the deferred #1032 canonical-status axis; order-health already derives from `recordStatus` + `syncStatus[]`, not the snapshot status.
+- **Out-of-order cancel-before-create (known residual, #1160):** a `cancelled` event processed before the order's create/sync job leaves no destination to cancel; the later create then provisions the order as active. This slice **narrows** the prior total no-op but does not fully close the race — that needs the deferred monotonic / relay-log machinery (ADR-027 guardrails). Documented in code (`handleSourceCancellation`) and surfaced via warn-logging of non-`applied` relay outcomes; full resolution tracked with the bidirectional slices.

--- a/libs/core/src/orders/application/interfaces/order-ingestion.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-ingestion.service.interface.ts
@@ -32,10 +32,14 @@ export interface IOrderIngestionService {
 
   /**
    * Hydrate a marketplace order and route it to destination processor(s).
+   *
+   * `eventType === 'cancelled'` routes through the lifecycle relay (propagate the
+   * cancel to destinations) instead of the create/update path (#1158 / #1132).
    */
   syncOrderFromSource(
     connectionId: string,
     externalOrderId: string,
-    sourceEventId?: string
+    sourceEventId?: string,
+    eventType?: OrderFeedEventType
   ): Promise<OrderSyncResult[]>;
 }

--- a/libs/core/src/orders/application/interfaces/order-lifecycle-relay.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-lifecycle-relay.service.interface.ts
@@ -1,0 +1,43 @@
+/**
+ * Order Lifecycle Relay Service Interface
+ *
+ * The Posture-A lifecycle relay (#1157 / ADR-027): propagates a lifecycle event
+ * authored by one participant of an order to the order's *other* participants,
+ * via the single `OrderStatusWriteback` capability (guard-dispatched, no
+ * platform-type branching). Best-effort — OL owns no canonical status; it
+ * forwards facts authored by authoritative systems and reports a per-target
+ * outcome (it never throws on a single participant's failure).
+ *
+ * @module libs/core/src/orders/application/interfaces
+ * @see {@link OrderStatusWriteback} for the per-participant writeback contract
+ */
+import type { DispatchCarrierHint } from '../../domain/types/dispatch-carrier-hint.types';
+import type { OrderWritebackOutcome } from '../../domain/types/order-lifecycle-event.types';
+
+/**
+ * A lifecycle event to relay, keyed on the internal order. The relay resolves
+ * each target participant's own `externalOrderId`, so the caller supplies only
+ * the neutral event + its payload.
+ */
+export interface OrderLifecycleRelayInput {
+  internalOrderId: string;
+  /** The participant that authored the event — excluded from the targets (self-echo suppression at the participant level). */
+  originConnectionId: string;
+  event:
+    | { type: 'dispatched'; trackingNumber?: string; carrier?: DispatchCarrierHint }
+    | { type: 'cancelled'; reason?: string };
+}
+
+export interface OrderLifecycleRelayTargetResult {
+  connectionId: string;
+  outcome: OrderWritebackOutcome;
+  detail?: string;
+}
+
+export interface OrderLifecycleRelayResult {
+  targets: OrderLifecycleRelayTargetResult[];
+}
+
+export interface IOrderLifecycleRelayService {
+  relay(input: OrderLifecycleRelayInput): Promise<OrderLifecycleRelayResult>;
+}

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -22,6 +22,7 @@ import type {
 import type { IOrderSyncService } from '../../interfaces/order-sync.service.interface';
 import type { IOrderRecordService } from '../../interfaces/order-record.service.interface';
 import type { IOrderItemRefResolverService } from '../../interfaces/order-item-ref-resolver.service.interface';
+import type { IOrderLifecycleRelayService } from '../../interfaces/order-lifecycle-relay.service.interface';
 import { MissingOrderItemMappingError } from '../../../domain/exceptions/missing-order-item-mapping.error';
 import type { OrderRecord } from '../../../domain/entities/order-record.entity';
 
@@ -41,6 +42,7 @@ describe('OrderIngestionService', () => {
   let orderItemRefResolver: jest.Mocked<IOrderItemRefResolverService>;
   let customerIdentityResolver: jest.Mocked<ICustomerIdentityResolverService>;
   let customerProjectionUpdater: jest.Mocked<IOrderCustomerProjectionUpdaterService>;
+  let orderLifecycleRelay: jest.Mocked<IOrderLifecycleRelayService>;
 
   const connectionId = 'connection-123';
   const cursorKey = 'allegro.orders.lastEventId';
@@ -111,6 +113,10 @@ describe('OrderIngestionService', () => {
       updateProjectionsForOrder: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<IOrderCustomerProjectionUpdaterService>;
 
+    orderLifecycleRelay = {
+      relay: jest.fn().mockResolvedValue({ targets: [] }),
+    } as unknown as jest.Mocked<IOrderLifecycleRelayService>;
+
     service = new OrderIngestionService(
       integrationsService,
       syncCursors as unknown as ISyncCursorsService,
@@ -121,7 +127,8 @@ describe('OrderIngestionService', () => {
       orderSyncService,
       customerIdentityResolver,
       orderRecordService,
-      customerProjectionUpdater
+      customerProjectionUpdater,
+      orderLifecycleRelay
     );
   });
 
@@ -698,6 +705,87 @@ describe('OrderIngestionService', () => {
 
       expect(orderRecordService.persistIncomingSnapshot).toHaveBeenCalledTimes(1);
       expect(orderRecordService.persistOrder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('syncOrderFromSource – inbound cancellation (#1158 / #1132)', () => {
+    const externalOrderId = 'checkout-cancel-1';
+
+    it('relays a cancel to the order destinations and does NOT re-run the create path', async () => {
+      identifierMapping.getInternalId.mockResolvedValue('ol_order_cancel');
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        sourceConnectionId: connectionId,
+      } as unknown as OrderRecord);
+      orderLifecycleRelay.relay.mockResolvedValue({
+        targets: [{ connectionId: 'dest-conn-1', outcome: 'applied' }],
+      });
+
+      const result = await service.syncOrderFromSource(
+        connectionId,
+        externalOrderId,
+        'evt-1',
+        'cancelled'
+      );
+
+      expect(result).toEqual([]);
+      expect(orderLifecycleRelay.relay).toHaveBeenCalledWith({
+        internalOrderId: 'ol_order_cancel',
+        originConnectionId: connectionId,
+        event: { type: 'cancelled' },
+      });
+      // Must NOT hydrate or re-create the order (the #1132 bug was re-creating it).
+      expect(orderSource.getOrder).not.toHaveBeenCalled();
+      expect(orderRecordService.persistIncomingSnapshot).not.toHaveBeenCalled();
+      expect(orderRecordService.persistOrder).not.toHaveBeenCalled();
+      expect(orderSyncService.syncOrder).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the cancelled order was never ingested (no internal mapping)', async () => {
+      identifierMapping.getInternalId.mockResolvedValue(null);
+
+      const result = await service.syncOrderFromSource(
+        connectionId,
+        externalOrderId,
+        'evt-1',
+        'cancelled'
+      );
+
+      expect(result).toEqual([]);
+      expect(orderLifecycleRelay.relay).not.toHaveBeenCalled();
+    });
+
+    it('skips the relay for a destination-echo cancel (order originates from another connection)', async () => {
+      identifierMapping.getInternalId.mockResolvedValue('ol_order_cancel');
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        sourceConnectionId: 'allegro-connection',
+      } as unknown as OrderRecord);
+
+      const result = await service.syncOrderFromSource(
+        connectionId,
+        externalOrderId,
+        'evt-1',
+        'cancelled'
+      );
+
+      expect(result).toEqual([]);
+      expect(orderLifecycleRelay.relay).not.toHaveBeenCalled();
+    });
+
+    it('logs at warn when a destination rejects the cancel (e.g. already shipped)', async () => {
+      const warnSpy = jest.spyOn(service['logger'], 'warn');
+      identifierMapping.getInternalId.mockResolvedValue('ol_order_cancel');
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        sourceConnectionId: connectionId,
+      } as unknown as OrderRecord);
+      orderLifecycleRelay.relay.mockResolvedValue({
+        targets: [
+          { connectionId: 'dest-conn-1', outcome: 'rejected', detail: 'order already shipped' },
+        ],
+      });
+
+      await service.syncOrderFromSource(connectionId, externalOrderId, 'evt-1', 'cancelled');
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dest-conn-1=rejected'));
     });
   });
 });

--- a/libs/core/src/orders/application/services/__tests__/order-lifecycle-relay.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-lifecycle-relay.service.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Order Lifecycle Relay Service — unit tests (#1158 / ADR-027)
+ *
+ * @module libs/core/src/orders/application/services/__tests__
+ */
+import { OrderLifecycleRelayService } from '../order-lifecycle-relay.service';
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
+
+const origin = 'allegro-conn';
+
+const mapping = (connectionId: string, externalId: string) => ({
+  connectionId,
+  externalId,
+  platformType: 'x',
+  entityType: 'Order',
+});
+
+describe('OrderLifecycleRelayService', () => {
+  let service: OrderLifecycleRelayService;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let identifierMapping: jest.Mocked<IIdentifierMappingService>;
+
+  beforeEach(() => {
+    integrations = {
+      getCapabilityAdapter: jest.fn(),
+      getAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+    identifierMapping = {
+      getExternalIds: jest.fn(),
+    } as unknown as jest.Mocked<IIdentifierMappingService>;
+    service = new OrderLifecycleRelayService(integrations, identifierMapping);
+  });
+
+  it('writes the event to each non-origin participant and collects outcomes', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([
+      mapping(origin, 'allegro-1'),
+      mapping('ps-conn', 'ps-7'),
+    ]);
+    const adapter = { write: jest.fn().mockResolvedValue({ outcome: 'applied' }) };
+    integrations.getCapabilityAdapter.mockResolvedValue(adapter);
+
+    const result = await service.relay({
+      internalOrderId: 'ol_order_1',
+      originConnectionId: origin,
+      event: { type: 'cancelled', reason: 'buyer-cancel' },
+    });
+
+    expect(integrations.getCapabilityAdapter).toHaveBeenCalledTimes(1);
+    expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith('ps-conn', 'OrderProcessorManager');
+    expect(adapter.write).toHaveBeenCalledWith({
+      type: 'cancelled',
+      externalOrderId: 'ps-7',
+      reason: 'buyer-cancel',
+    });
+    expect(result.targets).toEqual([
+      { connectionId: 'ps-conn', outcome: 'applied', detail: undefined },
+    ]);
+  });
+
+  it('maps a dispatched event with tracking + carrier through to the participant', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([mapping('ps-conn', 'ps-7')]);
+    const adapter = { write: jest.fn().mockResolvedValue({ outcome: 'applied' }) };
+    integrations.getCapabilityAdapter.mockResolvedValue(adapter);
+
+    await service.relay({
+      internalOrderId: 'ol_order_1',
+      originConnectionId: origin,
+      event: { type: 'dispatched', trackingNumber: 'TRK1', carrier: { platformType: 'inpost' } },
+    });
+
+    expect(adapter.write).toHaveBeenCalledWith({
+      type: 'dispatched',
+      externalOrderId: 'ps-7',
+      trackingNumber: 'TRK1',
+      carrier: { platformType: 'inpost' },
+    });
+  });
+
+  it('excludes the origin participant (self-echo suppression)', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([mapping(origin, 'allegro-1')]);
+
+    const result = await service.relay({
+      internalOrderId: 'ol_order_1',
+      originConnectionId: origin,
+      event: { type: 'cancelled' },
+    });
+
+    expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+    expect(result.targets).toEqual([]);
+  });
+
+  it('reports unsupported when the participant does not implement OrderStatusWriteback', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([mapping('ps-conn', 'ps-7')]);
+    integrations.getCapabilityAdapter.mockResolvedValue({ createOrder: jest.fn() });
+
+    const result = await service.relay({
+      internalOrderId: 'ol_order_1',
+      originConnectionId: origin,
+      event: { type: 'cancelled' },
+    });
+
+    expect(result.targets[0]).toMatchObject({ connectionId: 'ps-conn', outcome: 'unsupported' });
+  });
+
+  it('reports unsupported when the participant adapter cannot be resolved', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([mapping('ps-conn', 'ps-7')]);
+    integrations.getCapabilityAdapter.mockRejectedValue(new Error('no adapter'));
+
+    const result = await service.relay({
+      internalOrderId: 'ol_order_1',
+      originConnectionId: origin,
+      event: { type: 'cancelled' },
+    });
+
+    expect(result.targets[0]).toMatchObject({ connectionId: 'ps-conn', outcome: 'unsupported' });
+  });
+
+  it('reports rejected and continues to the next participant when a write throws', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([
+      mapping('ps-a', 'a'),
+      mapping('ps-b', 'b'),
+    ]);
+    integrations.getCapabilityAdapter
+      .mockResolvedValueOnce({ write: jest.fn().mockRejectedValue(new Error('boom')) })
+      .mockResolvedValueOnce({ write: jest.fn().mockResolvedValue({ outcome: 'applied' }) });
+
+    const result = await service.relay({
+      internalOrderId: 'ol_order_1',
+      originConnectionId: origin,
+      event: { type: 'cancelled' },
+    });
+
+    expect(result.targets).toEqual([
+      { connectionId: 'ps-a', outcome: 'rejected', detail: 'boom' },
+      { connectionId: 'ps-b', outcome: 'applied', detail: undefined },
+    ]);
+  });
+
+  it('surfaces a rejected outcome returned by the adapter (e.g. already shipped)', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([mapping('ps-conn', 'ps-7')]);
+    integrations.getCapabilityAdapter.mockResolvedValue({
+      write: jest.fn().mockResolvedValue({ outcome: 'rejected', detail: 'order already shipped' }),
+    });
+
+    const result = await service.relay({
+      internalOrderId: 'ol_order_1',
+      originConnectionId: origin,
+      event: { type: 'cancelled' },
+    });
+
+    expect(result.targets[0]).toEqual({
+      connectionId: 'ps-conn',
+      outcome: 'rejected',
+      detail: 'order already shipped',
+    });
+  });
+
+  it('returns no targets when the order has only the origin participant', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([mapping(origin, 'allegro-1')]);
+
+    const result = await service.relay({
+      internalOrderId: 'ol_order_1',
+      originConnectionId: origin,
+      event: { type: 'cancelled' },
+    });
+
+    expect(result.targets).toEqual([]);
+  });
+});

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -41,11 +41,14 @@ import {
   ORDER_SYNC_SERVICE_TOKEN,
   ORDER_RECORD_SERVICE_TOKEN,
   ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN,
+  ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN,
 } from '../../orders.tokens';
 import { IOrderRecordService } from '../interfaces/order-record.service.interface';
 import { IOrderItemRefResolverService } from '../interfaces/order-item-ref-resolver.service.interface';
+import { IOrderLifecycleRelayService } from '../interfaces/order-lifecycle-relay.service.interface';
 import type { IncomingOrder } from '../../domain/types/incoming-order.types';
 import type { Order } from '../../domain/types/order.types';
+import type { OrderFeedEventType } from '../../domain/types/order-feed.types';
 import { Logger } from '@openlinker/shared/logging';
 import { MissingOrderItemMappingError } from '../../domain/exceptions/missing-order-item-mapping.error';
 
@@ -76,7 +79,9 @@ export class OrderIngestionService implements IOrderIngestionService {
     @Inject(ORDER_RECORD_SERVICE_TOKEN)
     private readonly orderRecordService: IOrderRecordService,
     @Inject(ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN)
-    private readonly customerProjectionUpdater: IOrderCustomerProjectionUpdaterService
+    private readonly customerProjectionUpdater: IOrderCustomerProjectionUpdaterService,
+    @Inject(ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN)
+    private readonly orderLifecycleRelay: IOrderLifecycleRelayService
   ) {}
 
   async ingestOrders(
@@ -178,8 +183,18 @@ export class OrderIngestionService implements IOrderIngestionService {
   async syncOrderFromSource(
     connectionId: string,
     externalOrderId: string,
-    sourceEventId?: string
+    sourceEventId?: string,
+    eventType?: OrderFeedEventType
   ): Promise<ReturnType<IOrderSyncService['syncOrder']> extends Promise<infer T> ? T : never> {
+    // Inbound cancellation (#1158): a source `cancelled` event must NOT re-run the
+    // create/update path (which would re-create the order — the #1132 bug). Route
+    // it through the lifecycle relay, which propagates the cancel to the order's
+    // destination(s) via OrderStatusWriteback. OL owns no canonical status here —
+    // it forwards the source's fact to the participants it already synced to.
+    if (eventType === 'cancelled') {
+      return this.handleSourceCancellation(connectionId, externalOrderId);
+    }
+
     const orderSource = await this.integrationsService.getCapabilityAdapter<OrderSourcePort>(
       connectionId,
       'OrderSource'
@@ -332,6 +347,68 @@ export class OrderIngestionService implements IOrderIngestionService {
     }
 
     return results;
+  }
+
+  /**
+   * Inbound source cancellation → destination(s) via the lifecycle relay (#1158).
+   * Resolves the existing internal order; if unknown (never ingested) there is
+   * nothing to cancel. Applies the same destination-echo guard as ingestion
+   * (ADR-017) so a re-read of an order OL itself created elsewhere doesn't
+   * propagate a spurious cancel. Returns an empty result set — a cancel is not
+   * an order-create, so there are no OrderSyncResults to report.
+   */
+  private async handleSourceCancellation(
+    connectionId: string,
+    externalOrderId: string
+  ): Promise<never[]> {
+    const internalOrderId = await this.identifierMapping.getInternalId(
+      CORE_ENTITY_TYPE.Order,
+      externalOrderId,
+      connectionId
+    );
+    if (!internalOrderId) {
+      this.logger.warn(
+        `Cancellation for unknown order: external ${externalOrderId} on connection ${connectionId} ` +
+          `has no internal mapping — nothing to cancel`
+      );
+      return [];
+    }
+
+    const existing = await this.orderRecordService.getOrderRecord(internalOrderId);
+    if (existing && existing.sourceConnectionId !== connectionId) {
+      // Destination-echo guard (ADR-017): a cancel re-read from a connection OL
+      // pushed the order INTO is not the authoritative source's cancel — skip.
+      this.logger.debug(
+        `Skipping destination-echo cancellation of order ${internalOrderId}: external id ` +
+          `${externalOrderId} on connection ${connectionId} maps to an order originating from ` +
+          `${existing.sourceConnectionId}`
+      );
+      return [];
+    }
+
+    const result = await this.orderLifecycleRelay.relay({
+      internalOrderId,
+      originConnectionId: connectionId,
+      event: { type: 'cancelled' },
+    });
+
+    const summary =
+      result.targets.map((t) => `${t.connectionId}=${t.outcome}`).join(', ') || 'no targets';
+    const message = `Cancellation relayed for order ${internalOrderId}: ${summary}`;
+    // Surface any non-`applied` target (e.g. a destination that already shipped,
+    // so the cancel was rejected) at warn — the cancel is never silently dropped.
+    //
+    // Known residual (#1160): a cancel that arrives *before* the order's
+    // create/sync job has run finds no targets here, and the later create then
+    // provisions the order as active. Fully closing that out-of-order race needs
+    // the deferred monotonic / relay-log machinery (ADR-027 guardrails) tracked
+    // with the bidirectional slices — out of scope for this unidirectional slice.
+    if (result.targets.some((t) => t.outcome !== 'applied')) {
+      this.logger.warn(message);
+    } else {
+      this.logger.log(message);
+    }
+    return [];
   }
 
   private async resolveCustomerId(

--- a/libs/core/src/orders/application/services/order-lifecycle-relay.service.ts
+++ b/libs/core/src/orders/application/services/order-lifecycle-relay.service.ts
@@ -1,0 +1,137 @@
+/**
+ * Order Lifecycle Relay Service
+ *
+ * Implements the Posture-A lifecycle relay (#1157 / ADR-027). For an order, it
+ * resolves the participants OL synced it to (via identifier mappings), excludes
+ * the event's origin, and writes the lifecycle event to each via the single
+ * `OrderStatusWriteback` capability — **dispatched by the `isOrderStatusWriteback`
+ * guard, never by platform type**. Per-target outcomes are collected and
+ * surfaced; one participant's failure never blocks the others, and a failure is
+ * never silently dropped.
+ *
+ * This slice (#1158) wires the **inbound cancel → destination** direction:
+ * targets are the order's destination (`OrderProcessorManager`) connections.
+ * Generalising target resolution to source participants (for dispatch / shop→
+ * shop) lands with the bidirectional slices (#1160/#1161).
+ *
+ * @module libs/core/src/orders/application/services
+ * @implements {IOrderLifecycleRelayService}
+ */
+import { Injectable, Inject } from '@nestjs/common';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import {
+  IIdentifierMappingService,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  CORE_ENTITY_TYPE,
+} from '@openlinker/core/identifier-mapping';
+import { Logger } from '@openlinker/shared/logging';
+import type { OrderProcessorManagerPort } from '../../domain/ports/order-processor-manager.port';
+import { isOrderStatusWriteback } from '../../domain/ports/capabilities/order-status-writeback.capability';
+import type { OrderLifecycleEvent } from '../../domain/types/order-lifecycle-event.types';
+import type {
+  IOrderLifecycleRelayService,
+  OrderLifecycleRelayInput,
+  OrderLifecycleRelayResult,
+  OrderLifecycleRelayTargetResult,
+} from '../interfaces/order-lifecycle-relay.service.interface';
+
+const ORDER_PROCESSOR_MANAGER_CAPABILITY = 'OrderProcessorManager';
+
+@Injectable()
+export class OrderLifecycleRelayService implements IOrderLifecycleRelayService {
+  private readonly logger = new Logger(OrderLifecycleRelayService.name);
+
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+    @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
+    private readonly identifierMapping: IIdentifierMappingService
+  ) {}
+
+  async relay(input: OrderLifecycleRelayInput): Promise<OrderLifecycleRelayResult> {
+    const externalIds = await this.identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.Order,
+      input.internalOrderId
+    );
+    const targets = externalIds.filter((e) => e.connectionId !== input.originConnectionId);
+
+    if (targets.length === 0) {
+      this.logger.debug(
+        `Lifecycle relay: order ${input.internalOrderId} has no target participants ` +
+          `(origin ${input.originConnectionId}); nothing to propagate`
+      );
+      return { targets: [] };
+    }
+
+    const results: OrderLifecycleRelayTargetResult[] = [];
+    for (const target of targets) {
+      results.push(await this.writeToTarget(input, target.connectionId, target.externalId));
+    }
+    return { targets: results };
+  }
+
+  private async writeToTarget(
+    input: OrderLifecycleRelayInput,
+    connectionId: string,
+    externalOrderId: string
+  ): Promise<OrderLifecycleRelayTargetResult> {
+    let adapter: OrderProcessorManagerPort;
+    try {
+      adapter = await this.integrations.getCapabilityAdapter<OrderProcessorManagerPort>(
+        connectionId,
+        ORDER_PROCESSOR_MANAGER_CAPABILITY
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Lifecycle relay: could not resolve OrderProcessorManager adapter for connection ` +
+          `${connectionId} (order ${input.internalOrderId}): ${this.message(error)}`
+      );
+      return { connectionId, outcome: 'unsupported', detail: 'adapter unresolved' };
+    }
+
+    if (!isOrderStatusWriteback(adapter)) {
+      this.logger.warn(
+        `Lifecycle relay: connection ${connectionId} does not implement OrderStatusWriteback — ` +
+          `skipping '${input.event.type}' for order ${input.internalOrderId}`
+      );
+      return { connectionId, outcome: 'unsupported', detail: 'OrderStatusWriteback not implemented' };
+    }
+
+    const event: OrderLifecycleEvent =
+      input.event.type === 'dispatched'
+        ? {
+            type: 'dispatched',
+            externalOrderId,
+            trackingNumber: input.event.trackingNumber,
+            carrier: input.event.carrier,
+          }
+        : { type: 'cancelled', externalOrderId, reason: input.event.reason };
+
+    try {
+      const result = await adapter.write(event);
+      if (result.outcome === 'applied') {
+        this.logger.log(
+          `Lifecycle relay: '${input.event.type}' applied to ${connectionId} for order ${input.internalOrderId}`
+        );
+      } else {
+        this.logger.warn(
+          `Lifecycle relay: '${input.event.type}' ${result.outcome} on ${connectionId} for order ` +
+            `${input.internalOrderId}${result.detail ? ` — ${result.detail}` : ''}`
+        );
+      }
+      return { connectionId, outcome: result.outcome, detail: result.detail };
+    } catch (error) {
+      const detail = this.message(error);
+      this.logger.warn(
+        `Lifecycle relay: '${input.event.type}' failed on ${connectionId} for order ` +
+          `${input.internalOrderId}: ${detail}`,
+        error instanceof Error ? error.stack : undefined
+      );
+      return { connectionId, outcome: 'rejected', detail };
+    }
+  }
+
+  private message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/libs/core/src/orders/domain/ports/capabilities/__tests__/order-status-writeback.capability.spec.ts
+++ b/libs/core/src/orders/domain/ports/capabilities/__tests__/order-status-writeback.capability.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * OrderStatusWriteback capability guard — unit tests (#1158 / ADR-027)
+ *
+ * @module libs/core/src/orders/domain/ports/capabilities/__tests__
+ */
+import {
+  type OrderStatusWriteback,
+  isOrderStatusWriteback,
+} from '../order-status-writeback.capability';
+
+describe('isOrderStatusWriteback', () => {
+  it('returns true when the adapter implements write', () => {
+    const withCap: OrderStatusWriteback = { write: jest.fn() };
+    expect(isOrderStatusWriteback(withCap)).toBe(true);
+  });
+
+  it('returns false when the adapter does not implement write', () => {
+    expect(isOrderStatusWriteback({ createOrder: jest.fn() })).toBe(false);
+  });
+
+  it('is role-agnostic — narrows any object that exposes write', () => {
+    const sourceLike = { listOrderFeed: jest.fn(), getOrder: jest.fn(), write: jest.fn() };
+    expect(isOrderStatusWriteback(sourceLike)).toBe(true);
+  });
+});

--- a/libs/core/src/orders/domain/ports/capabilities/order-status-writeback.capability.ts
+++ b/libs/core/src/orders/domain/ports/capabilities/order-status-writeback.capability.ts
@@ -1,0 +1,45 @@
+/**
+ * Order Status Writeback Capability (event-as-data)
+ *
+ * The single, **platform-neutral, role-agnostic** writeback capability of the
+ * Posture-A lifecycle relay (#1157 / ADR-027). Every order participant adapter
+ * — a source marketplace *or* a destination shop — declares `implements
+ * OrderStatusWriteback` and maps each {@link OrderLifecycleEvent} onto its own
+ * API. The relay dispatches through this one contract via {@link
+ * isOrderStatusWriteback}, with **zero platform-type branching**, so
+ * marketplace↔shop and shop→shop are served by construction.
+ *
+ * Collapses the writeback role of the earlier `OrderDispatchNotifier`
+ * (source-side, event-specific) and `OrderFulfillmentUpdater` (destination-side,
+ * generic status setter): the lifecycle event is carried as **data**, and
+ * per-participant support is reported via {@link OrderWritebackResult} rather
+ * than the type signature. `OrderFulfillmentUpdater` is retained for order
+ * *provisioning* (OL driving an order it created), outside the relay path.
+ *
+ * The guard is generic over the resolved adapter type because the same adapter
+ * object may be resolved as an `OrderProcessorManager` (destination) or an
+ * `OrderSource` (source) depending on the order's topology.
+ *
+ * @module libs/core/src/orders/domain/ports/capabilities
+ * @see {@link OrderLifecycleEvent} for the event payload
+ */
+import type {
+  OrderLifecycleEvent,
+  OrderWritebackResult,
+} from '../../types/order-lifecycle-event.types';
+
+export interface OrderStatusWriteback {
+  /**
+   * Apply a lifecycle event to this participant's order. Best-effort and
+   * idempotent at the adapter level (a re-applied event that's already in
+   * effect is a no-op `applied`). Returns the per-participant outcome; the
+   * relay surfaces non-`applied` outcomes to the operator.
+   */
+  write(event: OrderLifecycleEvent): Promise<OrderWritebackResult>;
+}
+
+export function isOrderStatusWriteback<T extends object>(
+  adapter: T,
+): adapter is T & OrderStatusWriteback {
+  return typeof (adapter as Partial<OrderStatusWriteback>).write === 'function';
+}

--- a/libs/core/src/orders/domain/types/order-lifecycle-event.types.ts
+++ b/libs/core/src/orders/domain/types/order-lifecycle-event.types.ts
@@ -1,0 +1,60 @@
+/**
+ * Order Lifecycle Event (event-as-data)
+ *
+ * The neutral, role/platform-agnostic payload propagated by the Posture-A
+ * lifecycle relay (#1157 / ADR-027). A lifecycle fact authored by one
+ * authoritative participant (a source marketplace or a destination shop) is
+ * forwarded to the order's other participants, each adapter mapping the event
+ * onto its own API.
+ *
+ * Modelled as a discriminated union — the lifecycle *event* is **data**, not a
+ * method/capability per event (mirrors the inbound `OrderFeedEventType`
+ * discriminator). New events are added as union members; the single
+ * `OrderStatusWriteback.write(event)` contract never grows new methods.
+ *
+ * Whether a given participant can honour a given event is reported via
+ * {@link OrderWritebackResult} — never via the type signature (avoids the
+ * silent-no-op / LSP trap when, e.g., a marketplace cannot accept a status).
+ *
+ * @module libs/core/src/orders/domain/types
+ * @see {@link OrderStatusWriteback} for the capability that consumes it
+ */
+import type { DispatchCarrierHint } from './dispatch-carrier-hint.types';
+
+export const OrderLifecycleEventTypeValues = ['dispatched', 'cancelled'] as const;
+export type OrderLifecycleEventType = (typeof OrderLifecycleEventTypeValues)[number];
+
+/**
+ * A lifecycle event targeted at a single participant. `externalOrderId` is the
+ * participant's own external order id, resolved upstream by the relay (the
+ * adapter performs no identifier mapping).
+ */
+export type OrderLifecycleEvent =
+  | {
+      type: 'dispatched';
+      externalOrderId: string;
+      trackingNumber?: string;
+      carrier?: DispatchCarrierHint;
+    }
+  | {
+      type: 'cancelled';
+      externalOrderId: string;
+      reason?: string;
+    };
+
+/**
+ * Outcome of a single writeback attempt against one participant.
+ * - `applied`     — the participant accepted and applied the event.
+ * - `unsupported` — the participant cannot express this event (e.g. no cancel
+ *   verb); a no-op, surfaced (not silent).
+ * - `rejected`    — the participant refused the event (e.g. cancel after the
+ *   order already shipped) or the write failed business-side.
+ */
+export const OrderWritebackOutcomeValues = ['applied', 'unsupported', 'rejected'] as const;
+export type OrderWritebackOutcome = (typeof OrderWritebackOutcomeValues)[number];
+
+export interface OrderWritebackResult {
+  outcome: OrderWritebackOutcome;
+  /** Operator-readable reason — required for `unsupported` / `rejected`. */
+  detail?: string;
+}

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -28,6 +28,22 @@ export { isOrderFulfillmentUpdater } from './domain/ports/capabilities/order-ful
 // shipment-status projection from the OMP's view.
 export type { FulfillmentStatusReader } from './domain/ports/capabilities/fulfillment-status-reader.capability';
 export { isFulfillmentStatusReader } from './domain/ports/capabilities/fulfillment-status-reader.capability';
+// Order status writeback (#1157 / ADR-027): the single platform-neutral,
+// role-agnostic writeback contract the lifecycle relay dispatches through.
+// Collapses the writeback role of OrderDispatchNotifier + OrderFulfillmentUpdater
+// (event-as-data); per-participant support reported via OrderWritebackResult.
+export type { OrderStatusWriteback } from './domain/ports/capabilities/order-status-writeback.capability';
+export { isOrderStatusWriteback } from './domain/ports/capabilities/order-status-writeback.capability';
+export type {
+  OrderLifecycleEvent,
+  OrderLifecycleEventType,
+  OrderWritebackOutcome,
+  OrderWritebackResult,
+} from './domain/types/order-lifecycle-event.types';
+export {
+  OrderLifecycleEventTypeValues,
+  OrderWritebackOutcomeValues,
+} from './domain/types/order-lifecycle-event.types';
 export type {
   FulfillmentStatus,
   FulfillmentStatusSnapshot,
@@ -117,6 +133,12 @@ export {
   OrderDestinationRetryInput,
   OrderDestinationRetryResult,
 } from './application/interfaces/order-destination-retry.service.interface';
+export type {
+  IOrderLifecycleRelayService,
+  OrderLifecycleRelayInput,
+  OrderLifecycleRelayResult,
+  OrderLifecycleRelayTargetResult,
+} from './application/interfaces/order-lifecycle-relay.service.interface';
 export * from './orders.tokens';
 
 // Domain entities

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -13,6 +13,7 @@ import { OrderIngestionService } from './application/services/order-ingestion.se
 import { OrderItemRefResolverService } from './application/services/order-item-ref-resolver.service';
 import { OrderRecordService } from './application/services/order-record.service';
 import { OrderDestinationRetryService } from './application/services/order-destination-retry.service';
+import { OrderLifecycleRelayService } from './application/services/order-lifecycle-relay.service';
 import { OrderRecordRepository } from './infrastructure/persistence/repositories/order-record.repository';
 import { OrderRecordOrmEntity } from './infrastructure/persistence/entities/order-record.orm-entity';
 import {
@@ -22,6 +23,7 @@ import {
   ORDER_RECORD_SERVICE_TOKEN,
   ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
   ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN,
+  ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN,
 } from './orders.tokens';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
@@ -50,6 +52,7 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     OrderItemRefResolverService,
     OrderRecordService,
     OrderDestinationRetryService,
+    OrderLifecycleRelayService,
     OrderRecordRepository,
     // Then provide token bindings using useExisting
     {
@@ -76,6 +79,10 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
       provide: ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN,
       useExisting: OrderItemRefResolverService,
     },
+    {
+      provide: ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN,
+      useExisting: OrderLifecycleRelayService,
+    },
   ],
   exports: [
     OrderRecordService, // Export service class for direct injection
@@ -84,6 +91,7 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     ORDER_RECORD_REPOSITORY_TOKEN,
     ORDER_RECORD_SERVICE_TOKEN,
     ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
+    ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN,
   ],
 })
 export class OrdersModule {}

--- a/libs/core/src/orders/orders.tokens.ts
+++ b/libs/core/src/orders/orders.tokens.ts
@@ -15,6 +15,7 @@ export const ORDER_RECORD_REPOSITORY_TOKEN = Symbol('OrderRecordRepositoryPort')
 export const ORDER_RECORD_SERVICE_TOKEN = Symbol('IOrderRecordService');
 export const ORDER_DESTINATION_RETRY_SERVICE_TOKEN = Symbol('IOrderDestinationRetryService');
 export const ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN = Symbol('IOrderItemRefResolverService');
+export const ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN = Symbol('IOrderLifecycleRelayService');
 
 
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.status-writeback.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.status-writeback.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * PrestaShop Order Processor Manager — OrderStatusWriteback (#1158 / ADR-027)
+ *
+ * The event-as-data writeback the lifecycle relay dispatches through. Delegates
+ * to `updateFulfillment` internals; refuses a cancel when the shop already
+ * shipped/delivered (reports `rejected`, never throws).
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/adapters/__tests__
+ */
+import {
+  createOrderProcessorManagerHarness,
+  type OrderProcessorHarness,
+} from '../../../__tests__/mocks/prestashop-order-processor-manager.factory';
+
+const STATE_ID: Record<string, number> = { shipped: 4, delivered: 5, cancelled: 6 };
+
+describe('PrestashopOrderProcessorManagerAdapter — OrderStatusWriteback.write', () => {
+  let adapter: OrderProcessorHarness['adapter'];
+  let mockHttpClient: OrderProcessorHarness['mockHttpClient'];
+  let mockOrderMapper: OrderProcessorHarness['mockOrderMapper'];
+
+  const PS_ORDER_ID = '5001';
+
+  beforeEach(() => {
+    ({ adapter, mockHttpClient, mockOrderMapper } = createOrderProcessorManagerHarness());
+    mockOrderMapper.mapStatusToPrestashopStateId = jest
+      .fn()
+      .mockImplementation((status: string) => STATE_ID[status] ?? 0);
+  });
+
+  describe('dispatched', () => {
+    it('transitions to the shipped state and returns applied', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '2', id_carrier: 7 });
+
+      const result = await adapter.write({ type: 'dispatched', externalOrderId: PS_ORDER_ID });
+
+      expect(result).toEqual({ outcome: 'applied' });
+      expect(mockHttpClient.createResource).toHaveBeenCalledWith(
+        'order_histories',
+        { id_order: PS_ORDER_ID, id_order_state: STATE_ID.shipped },
+        { sendEmail: true }
+      );
+    });
+
+    it('returns rejected (not thrown) when the WebService call fails', async () => {
+      mockHttpClient.getResource = jest.fn().mockRejectedValue(new Error('WS 500'));
+
+      const result = await adapter.write({ type: 'dispatched', externalOrderId: PS_ORDER_ID });
+
+      expect(result.outcome).toBe('rejected');
+      expect(result.detail).toContain('WS 500');
+    });
+  });
+
+  describe('cancelled', () => {
+    it('transitions to the cancelled state when the order has not shipped', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '2', id_carrier: 7 });
+
+      const result = await adapter.write({ type: 'cancelled', externalOrderId: PS_ORDER_ID });
+
+      expect(result).toEqual({ outcome: 'applied' });
+      expect(mockHttpClient.createResource).toHaveBeenCalledWith(
+        'order_histories',
+        { id_order: PS_ORDER_ID, id_order_state: STATE_ID.cancelled },
+        { sendEmail: true }
+      );
+    });
+
+    it('refuses to cancel an already-shipped order (rejected, no state write)', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '4', id_carrier: 7 });
+
+      const result = await adapter.write({ type: 'cancelled', externalOrderId: PS_ORDER_ID });
+
+      expect(result.outcome).toBe('rejected');
+      expect(result.detail).toContain('already shipped');
+      expect(mockHttpClient.createResource).not.toHaveBeenCalledWith(
+        'order_histories',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('refuses to cancel an already-delivered order (rejected)', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '5', id_carrier: 7 });
+
+      const result = await adapter.write({ type: 'cancelled', externalOrderId: PS_ORDER_ID });
+
+      expect(result.outcome).toBe('rejected');
+      expect(mockHttpClient.createResource).not.toHaveBeenCalledWith(
+        'order_histories',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -20,6 +20,9 @@ import type {
   OrderFulfillmentUpdater,
   OrderStatus,
   MappingOption,
+  OrderStatusWriteback,
+  OrderLifecycleEvent,
+  OrderWritebackResult,
 } from '@openlinker/core/orders';
 import type {
   FulfillmentStatusReader,
@@ -91,6 +94,7 @@ export class PrestashopOrderProcessorManagerAdapter
     OrderProcessorManagerPort,
     DestinationOptionsReader,
     OrderFulfillmentUpdater,
+    OrderStatusWriteback,
     FulfillmentStatusReader
 {
   private readonly logger = new Logger(PrestashopOrderProcessorManagerAdapter.name);
@@ -745,25 +749,12 @@ export class PrestashopOrderProcessorManagerAdapter
       }
 
       // A. State transition LAST — the single irreversible side-effect.
-      //    `sendmail: true` → `?sendmail=1` fires PS's order-state customer email.
-      //    Skipped when already in the target state → idempotent (no duplicate
-      //    "shipped" email on re-notify).
-      if (Number(order.current_state) !== targetStateId) {
-        await this.httpClient.createResource(
-          'order_histories',
-          { id_order: externalOrderId, id_order_state: targetStateId },
-          { sendEmail: true }
-        );
-        this.logger.log(
-          `PrestaShop order ${externalOrderId} → state ${targetStateId} (status='${status}') ` +
-            `via order_histories+sendmail (connection: ${this.connection.id})`
-        );
-      } else {
-        this.logger.debug(
-          `PrestaShop order ${externalOrderId} already in state ${targetStateId} — ` +
-            `skipping order_histories (connection: ${this.connection.id})`
-        );
-      }
+      await this.applyOrderStateTransition(
+        externalOrderId,
+        Number(order.current_state),
+        targetStateId,
+        status
+      );
     } catch (error) {
       if (
         error instanceof PrestashopResourceNotFoundException ||
@@ -781,6 +772,99 @@ export class PrestashopOrderProcessorManagerAdapter
         undefined,
         undefined,
         this.connection.id
+      );
+    }
+  }
+
+  /**
+   * `OrderStatusWriteback` (#1158 / ADR-027): the single event-as-data writeback
+   * the lifecycle relay dispatches through. Delegates to the same internals as
+   * `updateFulfillment` (state transition + tracking + state-email), mapping each
+   * neutral lifecycle event onto PrestaShop's order state. `OrderFulfillmentUpdater`
+   * is retained for OL-driven order provisioning, outside the relay path.
+   *
+   * The outcome is reported via `OrderWritebackResult` (never thrown): a
+   * `cancelled` event against an order PrestaShop has already shipped/delivered is
+   * `rejected` — the shop is authoritative for its own live state, so we surface
+   * the conflict rather than force a regressive transition.
+   */
+  async write(event: OrderLifecycleEvent): Promise<OrderWritebackResult> {
+    try {
+      if (event.type === 'dispatched') {
+        await this.updateFulfillment({
+          externalOrderId: event.externalOrderId,
+          status: 'shipped',
+          trackingNumber: event.trackingNumber,
+        });
+        return { outcome: 'applied' };
+      }
+
+      // event.type === 'cancelled' — refuse if the shop already shipped/delivered.
+      // One read here; the cancel carries no tracking, so we reuse the fetched
+      // state for the transition instead of re-reading via updateFulfillment.
+      const order = await this.httpClient.getResource<PrestashopOrder>(
+        'orders',
+        event.externalOrderId
+      );
+      const currentStateId = Number(order.current_state);
+      const [shippedStateId, deliveredStateId, cancelledStateId] = await Promise.all([
+        this.resolveStateId('shipped'),
+        this.resolveStateId('delivered'),
+        this.resolveStateId('cancelled'),
+      ]);
+      if (currentStateId === shippedStateId || currentStateId === deliveredStateId) {
+        this.logger.warn(
+          `PrestaShop order ${event.externalOrderId} already in state ${currentStateId} ` +
+            `(shipped/delivered) — refusing cancel writeback (connection: ${this.connection.id})`
+        );
+        return { outcome: 'rejected', detail: 'order already shipped' };
+      }
+
+      await this.applyOrderStateTransition(
+        event.externalOrderId,
+        currentStateId,
+        cancelledStateId,
+        'cancelled'
+      );
+      return { outcome: 'applied' };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `OrderStatusWriteback '${event.type}' failed for PrestaShop order ` +
+          `${event.externalOrderId}: ${detail} (connection: ${this.connection.id})`,
+        error
+      );
+      return { outcome: 'rejected', detail };
+    }
+  }
+
+  /**
+   * Apply a PrestaShop order-state transition via `order_histories` (+ the
+   * `sendmail=1` customer email). Idempotent — skips when the order is already in
+   * the target state, so a re-notify never fires a duplicate state email. Shared
+   * by `updateFulfillment` (dispatch / provisioning) and the `OrderStatusWriteback`
+   * cancel path so the latter doesn't re-fetch the order it already read.
+   */
+  private async applyOrderStateTransition(
+    externalOrderId: string,
+    currentStateId: number,
+    targetStateId: number,
+    status: OrderStatus
+  ): Promise<void> {
+    if (currentStateId !== targetStateId) {
+      await this.httpClient.createResource(
+        'order_histories',
+        { id_order: externalOrderId, id_order_state: targetStateId },
+        { sendEmail: true }
+      );
+      this.logger.log(
+        `PrestaShop order ${externalOrderId} → state ${targetStateId} (status='${status}') ` +
+          `via order_histories+sendmail (connection: ${this.connection.id})`
+      );
+    } else {
+      this.logger.debug(
+        `PrestaShop order ${externalOrderId} already in state ${targetStateId} — ` +
+          `skipping order_histories (connection: ${this.connection.id})`
       );
     }
   }


### PR DESCRIPTION
## What

Foundation slice of the Posture-A lifecycle relay (#1157 / ADR-027). Closes the silent inbound-cancellation no-op.

Closes #1158
Closes #1132

## Changes

- **`OrderStatusWriteback` capability** (event-as-data: `write({type:'dispatched'|'cancelled', …}) → OrderWritebackResult`) + role-agnostic `isOrderStatusWriteback` guard. The single, platform-neutral writeback contract; collapses the writeback role of `OrderDispatchNotifier` / `OrderFulfillmentUpdater`.
- **`OrderLifecycleRelayService`** (core) — propagates a lifecycle event to an order's participants, resolving each via the `isOrderStatusWriteback` guard with **zero platform-type branching**; per-target outcomes, per-participant isolation, non-`applied` outcomes surfaced (never silently dropped).
- **Inbound cancel → destination** — `OrderIngestionService` branches on `eventType==='cancelled'` → relay (instead of the create/update path that re-created the order). Handler passes `eventType` through. **Fixes #1132.**
- **PrestaShop implements `OrderStatusWriteback`** — delegates to a shared `applyOrderStateTransition` helper; refuses a cancel when the shop already shipped/delivered (`rejected`, reusing the already-fetched state — single read). `OrderFulfillmentUpdater` retained for OL-driven provisioning.

## Guardrails (this unidirectional slice)

Re-delivery covered by job-dedup + idempotent adapter writes; "already shipped" reported by the adapter (shop is authoritative for its live state). Durable relay-log + cross-participant self-echo suppression land with the bidirectional slices (#1160/#1161).

**Known residual (#1160):** a cancel that arrives *before* the order's create/sync job finds no targets; the later create then provisions the order as active. This slice *narrows* the prior total no-op but doesn't fully close the out-of-order race — that needs the deferred monotonic / relay-log machinery (ADR-027). Documented in `handleSourceCancellation` + plan §7.

## Testing

- Unit: capability guard (3); relay service (8 — fan-out, origin-exclusion, unsupported/rejected, per-target isolation); ingestion cancel branch (4, incl. warn-on-rejected); PrestaShop `write()` (5 — dispatched/cancelled/already-shipped/already-delivered/error).
- Integration: `allegro-order-sync-e2e` + `order-reingestion-echo-guard` green.
- Gate: `pnpm lint` (0 errors, invariants ✓), `pnpm type-check`, core (1191) + prestashop (409) unit suites green.

## Notes

- No migration (ledger deferred per the #1157 plan gate).
- Self-reviewed via `/tech-review` (deep) — verdict approve-with-changes; all four findings applied in this branch.
- Depends on ADR-027 + the spec from #1162 (docs only; no code import) — merging #1162 first keeps `main` coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)