### PR TITLE
feat(allegro,orders): Allegro OrderStatusWriteback + role-agnostic relay targeting (#1159)

### DIFF
--- a/docs/plans/analysis/ANALYSIS-implementation-plan-1159-allegro-order-status-writeback.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-1159-allegro-order-status-writeback.md
@@ -1,0 +1,37 @@
+# Pre-implement gate — #1159 Allegro OrderStatusWriteback + relay source-role targeting
+
+**Plan:** `docs/plans/implementation-plan-1159-allegro-order-status-writeback.md`
+**Date:** 2026-06-22
+**Verdict: ✅ READY**
+
+No reuse collisions, no contract-surface breaks, no migration. Greps run against the live tree at `9cac7822`.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `OrderStatusWriteback` capability + `isOrderStatusWriteback` + event types | **ALREADY EXISTS → reuse** | `libs/core/src/orders/domain/ports/capabilities/order-status-writeback.capability.ts` (merged #1158); exported from `@openlinker/core/orders` |
+| `ALLEGRO_FULFILLMENT_STATUS_CANCELLED` const | **NEW (confirmed absent)** | only `ALLEGRO_FULFILLMENT_STATUS_SENT` exists in `allegro-order-fulfillment.types.ts:15` |
+| Allegro `write()` method + `markSent` private | **NEW** (`markSent` absent in tree) | `AllegroOrderSourceAdapter` implements `OrderDispatchNotifier` only today |
+| Relay `resolveWriteback` private | **NEW** (`resolveWriteback` absent) | `order-lifecycle-relay.service.ts` currently hardcodes `'OrderProcessorManager'` |
+| `CapabilityNotSupportedException` / `CapabilityNotEnabledException` | **ALREADY EXISTS → reuse** | `libs/core/src/integrations/index.ts:79-80` (exported from barrel) |
+| New port / DI token / ORM entity / service / barrel export | **none** | plan adds none |
+
+## Backward-compatibility findings
+
+| Surface | Assessment |
+|---|---|
+| Top-level barrels | No symbol removed/renamed. `@openlinker/core/orders` / `@openlinker/core/integrations` consumed only via existing exports. **No break.** |
+| Port method signatures | `notifyDispatched` contract unchanged (`markSent` extraction is internal); `IOrderLifecycleRelayService.relay` contract unchanged. Adding `OrderStatusWriteback` to the Allegro `implements` is additive. **No break.** |
+| DTO shapes | None touched. |
+| Symbol tokens | None added/removed. |
+| ORM schema | No entity/migration. **N/A.** |
+| `check:invariants` | Relay's new imports (`CapabilityNotSupportedException`, `CapabilityNotEnabledException`) are `*Exception` symbols from the top-level `@openlinker/core/integrations` barrel — on the cross-context allow-list (domain exceptions) and the file already imports from that barrel. No deep-path / repo-URL / service-interface risk. **No trip.** |
+
+## Open questions / notes (non-blocking)
+
+1. **Simplify the relay catch:** `CapabilityNotEnabledException extends CapabilityNotSupportedException`, so `error instanceof CapabilityNotSupportedException` alone narrows both — the plan's explicit two-class check is harmless but redundant. Either is fine.
+2. **Allegro cancel-409 semantics** remain a `needs-sandbox-probe` (the plan now treats 409/4xx on cancel as `rejected`, the safe default) — not a gate blocker, just a documented unknown for the sandbox-verification follow-up.
+3. **End-to-end cancel→Allegro** is intentionally not wired here (needs the shop-origin trigger in #1160/#1161); the relay reach + adapter capability are unit-tested. Confirmed consistent with #1157 slice sequencing.
+
+**Proceed to implementation.**

--- a/docs/plans/implementation-plan-1159-allegro-order-status-writeback.md
+++ b/docs/plans/implementation-plan-1159-allegro-order-status-writeback.md
@@ -1,0 +1,89 @@
+# Implementation Plan — #1159 Allegro implements OrderStatusWriteback + relay source-role targeting
+
+**Issue:** #1159 (Part of #1157; ADR-027). Realises **User story S3** (marketplace side). Closes #1159.
+**Branch:** `1159-allegro-order-status-writeback`
+**Layer:** Integration (Allegro) + CORE (`orders` relay generalization).
+
+---
+
+## 1. Goal (restated)
+
+- **Allegro implements `OrderStatusWriteback`** — `dispatched` (mark-sent + waybill, reusing today's `notifyDispatched` mechanics) and `cancelled` (mark Allegro fulfillment `CANCELLED`), reporting `applied | unsupported | rejected` via `OrderWritebackResult`.
+- **Generalise the lifecycle relay** so it can target a **source-role** participant (Allegro is an `OrderSource`, not an `OrderProcessorManager`) — by resolving the participant's order capability from the registry, with **zero platform-type branching**. Today the relay hardcodes `'OrderProcessorManager'`, so it can never reach Allegro.
+
+**Non-goals (this slice):**
+- **Retiring `OrderDispatchNotifier`** — still live in `shipment-dispatch-notification.service` (`isOrderDispatchNotifier` + `notifyDispatched`); migrating that to the relay is #1160. #1159 is **additive**: Allegro implements `OrderStatusWriteback` *alongside* `notifyDispatched`.
+- **The shop-side cancel *trigger*** that calls the relay with a shop origin → Allegro target (that detection is #1160/#1161). #1159 ships the *capability + relay reach*; the end-to-end cancel→Allegro completes when a sibling provides the trigger.
+- **Refunds / money** — OL is never the money book of record (ADR-027). Cancel writeback is the fulfillment-status signal only.
+
+## 2. Verified facts
+
+- Allegro fulfillment status enum includes `CANCELLED`; set via `PUT /order/checkout-forms/{id}/fulfillment { status }` — the **same endpoint + flat body** the existing mark-sent uses (`ALLEGRO_FULFILLMENT_STATUS_SENT = 'SENT'`). Verified on developer.allegro.pl.
+- `AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptionsReader, OrderDispatchNotifier`; ctor `(connectionId, httpClient, connection)`. Sub-capabilities are **not** in the manifest — adding `OrderStatusWriteback` needs **no factory/manifest change** (runtime `isOrderStatusWriteback` guard).
+- Relay `writeToTarget` hardcodes `getCapabilityAdapter<OrderProcessorManagerPort>(connId, 'OrderProcessorManager')`. `getCapabilityAdapter` **throws** `CapabilityNotSupported/NotEnabled` when a connection lacks the capability.
+- `OrderStatusWriteback` / `OrderLifecycleEvent` / `OrderWritebackResult` are on `main`, exported from `@openlinker/core/orders`. PrestaShop already implements `write()`.
+
+## 3. Design
+
+### 3.1 Allegro adapter (`AllegroOrderSourceAdapter`)
+
+- Add `OrderStatusWriteback` to `implements`; import the three types from `@openlinker/core/orders`.
+- Add `ALLEGRO_FULFILLMENT_STATUS_CANCELLED = 'CANCELLED'` to `allegro-order-fulfillment.types.ts`.
+- **Extract** the current `notifyDispatched` body into a private `markSent(externalOrderId, trackingNumber?, carrier?): Promise<void>` (unchanged behaviour — 409/already ⇒ idempotent success; failures ⇒ `AllegroOrderDispatchRejectedException`). `notifyDispatched` becomes `return this.markSent(...)` (preserves its throwing `Promise<void>` contract for the still-live dispatch path).
+- Implement `write(event)`:
+  - `dispatched` → `try { await this.markSent(event.externalOrderId, event.trackingNumber, event.carrier); return { outcome: 'applied' } } catch (e) { return { outcome: 'rejected', detail } }`.
+  - `cancelled` → `PUT /order/checkout-forms/{id}/fulfillment { status: CANCELLED }`; success ⇒ `applied`; **any `AllegroApiException` (incl. 409) ⇒ `rejected`** with `detail = message`. **Do NOT reuse `isAlreadySentOrStale`'s "409 ⇒ success" branch here** — for cancel, a 409 is at least as likely to mean a *forbidden transition* (e.g. cancel after `SENT`) as "already cancelled", and masking that as `applied` would silently swallow a failed cancel (the conflict AC-3 wants surfaced). Treating 409/4xx as `rejected` is the safe default until Allegro's exact cancel-409 semantics are sandbox-verified (`needs-sandbox-probe`); a verified "already cancelled" signal can be upgraded to `applied` later. Mirrors PrestaShop's "report, never throw" `write()`.
+
+### 3.2 Relay source-role targeting (`OrderLifecycleRelayService`)
+
+- Replace the hardcoded resolution in `writeToTarget` with a role-agnostic resolver:
+  ```ts
+  const ORDER_PARTICIPANT_CAPABILITIES = ['OrderProcessorManager', 'OrderSource'] as const;
+
+  private async resolveWriteback(
+    connectionId: string,
+  ): Promise<{ adapter: OrderStatusWriteback; capability: string } | null> {
+    for (const capability of ORDER_PARTICIPANT_CAPABILITIES) {
+      try {
+        const adapter = await this.integrations.getCapabilityAdapter<object>(connectionId, capability);
+        if (isOrderStatusWriteback(adapter)) return { adapter, capability };
+      } catch (error) {
+        // CapabilityNotSupported/NotEnabled → this connection just isn't this
+        // role; try the next candidate. A connection-level failure (disabled /
+        // not-found) is real — rethrow so the caller surfaces it (warn), rather
+        // than masking it as a generic "no capability".
+        if (
+          error instanceof CapabilityNotSupportedException ||
+          error instanceof CapabilityNotEnabledException
+        ) {
+          continue;
+        }
+        throw error;
+      }
+    }
+    return null;
+  }
+  ```
+  `writeToTarget` resolves via `resolveWriteback`; on `null` → `{ outcome:'unsupported', detail:'no order-writeback capability' }`; on a thrown connection-level error → catch + warn + `{ outcome:'unsupported', detail:'adapter unresolved' }` (preserves #1158 observability). The applied/rejected log line **includes the resolved `capability`** so a cross-role (source vs destination) misroute is diagnosable. No platform-type branching; destinations resolve on the first candidate (OMP), Allegro on the second (OrderSource). Backward-compatible: existing #1158 cancel→destination still resolves OMP on the first try. (`CapabilityNotSupportedException` / `CapabilityNotEnabledException` import from `@openlinker/core/integrations`.)
+
+### 3.3 No new caller wiring
+
+The relay is reached today only by `OrderIngestionService.handleSourceCancellation` (origin = source). Allegro becomes a *reachable target* via 3.2; the trigger that makes a shop-origin cancel fan out to Allegro is #1160/#1161. Documented, not built here.
+
+## 4. Steps
+
+1. `allegro-order-fulfillment.types.ts`: add `ALLEGRO_FULFILLMENT_STATUS_CANCELLED`. **AC:** const exported.
+2. Allegro adapter: extract `markSent`, add `implements OrderStatusWriteback` + `write()`. **AC:** unit tests — dispatched(applied, +waybill), dispatched(rejected on POST fail), cancelled(applied), **cancelled(409→rejected)**, cancelled(rejected on 4xx); existing `notifyDispatched` tests still green.
+3. Relay: role-agnostic `resolveWriteback` (capability-exception → try next; connection-level error → surface). **AC:** unit tests — a target supporting only `OrderSource` is resolved + written; a connection-level failure (disabled/not-found) surfaces as `unsupported: 'adapter unresolved'` (warn), distinct from `'no order-writeback capability'`; existing OMP-target tests unchanged (OMP resolved on first try).
+4. Quality gate: `pnpm lint` / `type-check` / `test`; **full `pnpm test:integration`** (capability changes ripple into routing int-specs — issue note).
+
+## 5. Validation
+
+- Capability + guard pattern, types via barrel, Logger, no `any`, service-interface invariant intact (relay unchanged contract).
+- ADR-027 conformance: one event-as-data capability; relay dispatches by guard, no platform branching. `OrderFulfillmentUpdater`/`OrderDispatchNotifier` untouched (retirement deferred).
+- Allegro cancel verified against official docs (memory: never guess Allegro shapes).
+
+## 6. Risks
+
+- **Allegro cancel transition rules** — Allegro may reject `CANCELLED` after `SENT` (or other states). Handled: such rejections surface as `rejected` with the Allegro message (AC: "unsupported cases surface a clear result"). Exact post-SENT semantics are a `needs-sandbox-probe`, like the existing 409-on-SENT note.
+- **No end-to-end cancel→Allegro yet** — needs the shop-origin trigger (#1160/#1161). #1159 delivers the capability + relay reach, unit-tested; the relay generalization is the shared prerequisite #1160 also consumes.

--- a/libs/core/src/orders/application/services/__tests__/order-lifecycle-relay.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-lifecycle-relay.service.spec.ts
@@ -4,7 +4,7 @@
  * @module libs/core/src/orders/application/services/__tests__
  */
 import { OrderLifecycleRelayService } from '../order-lifecycle-relay.service';
-import type { IIntegrationsService } from '@openlinker/core/integrations';
+import { CapabilityNotSupportedException, type IIntegrationsService } from '@openlinker/core/integrations';
 import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
 
 const origin = 'allegro-conn';
@@ -167,5 +167,53 @@ describe('OrderLifecycleRelayService', () => {
     });
 
     expect(result.targets).toEqual([]);
+  });
+
+  it('resolves a source-role participant (OrderSource) when it is not an OrderProcessorManager (#1159)', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([mapping('allegro-dest', 'cf-9')]);
+    const adapter = { write: jest.fn().mockResolvedValue({ outcome: 'applied' }) };
+    integrations.getCapabilityAdapter.mockImplementation((_conn: string, capability: string) =>
+      capability === 'OrderSource'
+        ? Promise.resolve(adapter)
+        : Promise.reject(new CapabilityNotSupportedException('allegro.publicapi.v1', capability))
+    );
+
+    const result = await service.relay({
+      internalOrderId: 'ol_order_1',
+      originConnectionId: origin,
+      event: { type: 'cancelled', reason: 'buyer-cancel' },
+    });
+
+    // Destination tried first, then the source role — guard-dispatched, no platform branching.
+    expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith('allegro-dest', 'OrderProcessorManager');
+    expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith('allegro-dest', 'OrderSource');
+    expect(adapter.write).toHaveBeenCalledWith({
+      type: 'cancelled',
+      externalOrderId: 'cf-9',
+      reason: 'buyer-cancel',
+    });
+    expect(result.targets).toEqual([
+      { connectionId: 'allegro-dest', outcome: 'applied', detail: undefined },
+    ]);
+  });
+
+  it('surfaces a connection-level resolution failure as "adapter unresolved" without trying further roles (#1159)', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([mapping('ps-conn', 'ps-7')]);
+    // A non-capability error (e.g. connection disabled) must not be swallowed as a
+    // capability mismatch — it short-circuits the role loop and surfaces.
+    integrations.getCapabilityAdapter.mockRejectedValue(new Error('connection disabled'));
+
+    const result = await service.relay({
+      internalOrderId: 'ol_order_1',
+      originConnectionId: origin,
+      event: { type: 'cancelled' },
+    });
+
+    expect(integrations.getCapabilityAdapter).toHaveBeenCalledTimes(1);
+    expect(result.targets[0]).toEqual({
+      connectionId: 'ps-conn',
+      outcome: 'unsupported',
+      detail: 'adapter unresolved',
+    });
   });
 });

--- a/libs/core/src/orders/application/services/order-lifecycle-relay.service.ts
+++ b/libs/core/src/orders/application/services/order-lifecycle-relay.service.ts
@@ -9,24 +9,31 @@
  * surfaced; one participant's failure never blocks the others, and a failure is
  * never silently dropped.
  *
- * This slice (#1158) wires the **inbound cancel → destination** direction:
- * targets are the order's destination (`OrderProcessorManager`) connections.
- * Generalising target resolution to source participants (for dispatch / shop→
- * shop) lands with the bidirectional slices (#1160/#1161).
+ * Targets are resolved **role-agnostically** (#1159): each participant's order
+ * capability (`OrderProcessorManager` for shops, `OrderSource` for marketplaces)
+ * is tried in turn and narrowed via the guard — so the relay reaches both
+ * destinations and source marketplaces (e.g. Allegro) with no platform-type
+ * branching.
  *
  * @module libs/core/src/orders/application/services
  * @implements {IOrderLifecycleRelayService}
  */
 import { Injectable, Inject } from '@nestjs/common';
-import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+  CapabilityNotSupportedException,
+} from '@openlinker/core/integrations';
 import {
   IIdentifierMappingService,
   IDENTIFIER_MAPPING_SERVICE_TOKEN,
   CORE_ENTITY_TYPE,
 } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
-import type { OrderProcessorManagerPort } from '../../domain/ports/order-processor-manager.port';
-import { isOrderStatusWriteback } from '../../domain/ports/capabilities/order-status-writeback.capability';
+import {
+  isOrderStatusWriteback,
+  type OrderStatusWriteback,
+} from '../../domain/ports/capabilities/order-status-writeback.capability';
 import type { OrderLifecycleEvent } from '../../domain/types/order-lifecycle-event.types';
 import type {
   IOrderLifecycleRelayService,
@@ -35,7 +42,9 @@ import type {
   OrderLifecycleRelayTargetResult,
 } from '../interfaces/order-lifecycle-relay.service.interface';
 
-const ORDER_PROCESSOR_MANAGER_CAPABILITY = 'OrderProcessorManager';
+// Order-participant capabilities the relay can write back to, in resolution
+// preference order: a destination shop first, then a source marketplace.
+const ORDER_PARTICIPANT_CAPABILITIES = ['OrderProcessorManager', 'OrderSource'] as const;
 
 @Injectable()
 export class OrderLifecycleRelayService implements IOrderLifecycleRelayService {
@@ -75,27 +84,27 @@ export class OrderLifecycleRelayService implements IOrderLifecycleRelayService {
     connectionId: string,
     externalOrderId: string
   ): Promise<OrderLifecycleRelayTargetResult> {
-    let adapter: OrderProcessorManagerPort;
+    let resolved: { adapter: OrderStatusWriteback; capability: string } | null;
     try {
-      adapter = await this.integrations.getCapabilityAdapter<OrderProcessorManagerPort>(
-        connectionId,
-        ORDER_PROCESSOR_MANAGER_CAPABILITY
-      );
+      resolved = await this.resolveWriteback(connectionId);
     } catch (error) {
+      // Connection-level failure (disabled / not-found / construction) — distinct
+      // from a plain capability mismatch; surface it rather than masking it.
       this.logger.warn(
-        `Lifecycle relay: could not resolve OrderProcessorManager adapter for connection ` +
+        `Lifecycle relay: could not resolve an order adapter for connection ` +
           `${connectionId} (order ${input.internalOrderId}): ${this.message(error)}`
       );
       return { connectionId, outcome: 'unsupported', detail: 'adapter unresolved' };
     }
 
-    if (!isOrderStatusWriteback(adapter)) {
+    if (!resolved) {
       this.logger.warn(
-        `Lifecycle relay: connection ${connectionId} does not implement OrderStatusWriteback — ` +
+        `Lifecycle relay: connection ${connectionId} exposes no order-writeback capability — ` +
           `skipping '${input.event.type}' for order ${input.internalOrderId}`
       );
-      return { connectionId, outcome: 'unsupported', detail: 'OrderStatusWriteback not implemented' };
+      return { connectionId, outcome: 'unsupported', detail: 'no order-writeback capability' };
     }
+    const { adapter, capability } = resolved;
 
     const event: OrderLifecycleEvent =
       input.event.type === 'dispatched'
@@ -111,11 +120,11 @@ export class OrderLifecycleRelayService implements IOrderLifecycleRelayService {
       const result = await adapter.write(event);
       if (result.outcome === 'applied') {
         this.logger.log(
-          `Lifecycle relay: '${input.event.type}' applied to ${connectionId} for order ${input.internalOrderId}`
+          `Lifecycle relay: '${input.event.type}' applied to ${connectionId} (${capability}) for order ${input.internalOrderId}`
         );
       } else {
         this.logger.warn(
-          `Lifecycle relay: '${input.event.type}' ${result.outcome} on ${connectionId} for order ` +
+          `Lifecycle relay: '${input.event.type}' ${result.outcome} on ${connectionId} (${capability}) for order ` +
             `${input.internalOrderId}${result.detail ? ` — ${result.detail}` : ''}`
         );
       }
@@ -123,12 +132,44 @@ export class OrderLifecycleRelayService implements IOrderLifecycleRelayService {
     } catch (error) {
       const detail = this.message(error);
       this.logger.warn(
-        `Lifecycle relay: '${input.event.type}' failed on ${connectionId} for order ` +
+        `Lifecycle relay: '${input.event.type}' failed on ${connectionId} (${capability}) for order ` +
           `${input.internalOrderId}: ${detail}`,
         error instanceof Error ? error.stack : undefined
       );
       return { connectionId, outcome: 'rejected', detail };
     }
+  }
+
+  /**
+   * Resolve the participant's order-writeback adapter, role-agnostically (#1159).
+   * Tries each order-participant capability (destination first, then source); a
+   * capability mismatch on this connection falls through to the next candidate,
+   * while a connection-level failure (disabled / not-found) propagates so the
+   * caller surfaces it. Returns null when no order capability on the connection
+   * implements `OrderStatusWriteback`.
+   */
+  private async resolveWriteback(
+    connectionId: string
+  ): Promise<{ adapter: OrderStatusWriteback; capability: string } | null> {
+    for (const capability of ORDER_PARTICIPANT_CAPABILITIES) {
+      try {
+        const adapter = await this.integrations.getCapabilityAdapter<object>(
+          connectionId,
+          capability
+        );
+        if (isOrderStatusWriteback(adapter)) {
+          return { adapter, capability };
+        }
+      } catch (error) {
+        // CapabilityNotEnabledException extends CapabilityNotSupportedException,
+        // so this catches both: the connection just isn't this role — try next.
+        if (error instanceof CapabilityNotSupportedException) {
+          continue;
+        }
+        throw error;
+      }
+    }
+    return null;
   }
 
   private message(error: unknown): string {

--- a/libs/integrations/allegro/src/domain/types/allegro-order-fulfillment.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-order-fulfillment.types.ts
@@ -14,6 +14,15 @@
 /** Fulfillment status set on mark-sent. `needs-sandbox-probe`: enum spelling. */
 export const ALLEGRO_FULFILLMENT_STATUS_SENT = 'SENT';
 
+/**
+ * Fulfillment status set when OL relays an order cancellation to Allegro
+ * (#1159). Verified present in Allegro's fulfillment-status enum (set via the
+ * same `PUT /order/checkout-forms/{id}/fulfillment` endpoint). This is the
+ * seller-side handling signal only — it issues no refund (OL is never the money
+ * book of record, ADR-027). `needs-sandbox-probe`: post-SENT transition rules.
+ */
+export const ALLEGRO_FULFILLMENT_STATUS_CANCELLED = 'CANCELLED';
+
 export interface AllegroSetFulfillmentRequest {
   status: string;
 }

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -110,6 +110,59 @@ describe('AllegroOrderSourceAdapter', () => {
     });
   });
 
+  describe('write — OrderStatusWriteback (#1159)', () => {
+    it('dispatched: marks sent + attaches the waybill and returns applied', async () => {
+      const result = await adapter.write({
+        type: 'dispatched',
+        externalOrderId: 'cf-1',
+        trackingNumber: '680',
+        carrier: { platformType: 'inpost' },
+      });
+      expect(httpClient.put).toHaveBeenCalledWith('/order/checkout-forms/cf-1/fulfillment', {
+        status: 'SENT',
+      });
+      expect(httpClient.post).toHaveBeenCalledWith('/order/checkout-forms/cf-1/shipments', {
+        carrierId: 'INPOST',
+        waybill: '680',
+      });
+      expect(result).toEqual({ outcome: 'applied' });
+    });
+
+    it('dispatched: returns rejected (never throws) when the waybill POST fails', async () => {
+      httpClient.post.mockRejectedValueOnce(new AllegroApiException('bad carrier', 400));
+      const result = await adapter.write({
+        type: 'dispatched',
+        externalOrderId: 'cf-1',
+        trackingNumber: '680',
+        carrier: { platformType: 'inpost' },
+      });
+      expect(result.outcome).toBe('rejected');
+      expect(result.detail).toContain('bad carrier');
+    });
+
+    it('cancelled: sets the Allegro fulfillment status to CANCELLED and returns applied', async () => {
+      const result = await adapter.write({ type: 'cancelled', externalOrderId: 'cf-1' });
+      expect(httpClient.put).toHaveBeenCalledWith('/order/checkout-forms/cf-1/fulfillment', {
+        status: 'CANCELLED',
+      });
+      expect(result).toEqual({ outcome: 'applied' });
+    });
+
+    it('cancelled: returns rejected on a 4xx (e.g. forbidden transition)', async () => {
+      httpClient.put.mockRejectedValueOnce(new AllegroApiException('not allowed', 422));
+      const result = await adapter.write({ type: 'cancelled', externalOrderId: 'cf-1' });
+      expect(result.outcome).toBe('rejected');
+      expect(result.detail).toContain('not allowed');
+    });
+
+    it('cancelled: a 409 is rejected, NOT swallowed as applied (cancel ≠ mark-sent idempotency)', async () => {
+      httpClient.put.mockRejectedValueOnce(new AllegroApiException('conflict: already sent', 409));
+      const result = await adapter.write({ type: 'cancelled', externalOrderId: 'cf-1' });
+      expect(result.outcome).toBe('rejected');
+      expect(result.detail).toContain('conflict');
+    });
+  });
+
   describe('listOrderFeed', () => {
     it('should deduplicate events by checkoutFormId, map Allegro event types, and surface lastEventId as nextCursor', async () => {
       const mockResponse: AllegroOrderEventsResponse = {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -113,10 +113,7 @@ export class AllegroOrderSourceAdapter
       }
 
       // event.type === 'cancelled'
-      await this.httpClient.put(
-        `/order/checkout-forms/${event.externalOrderId}/fulfillment`,
-        { status: ALLEGRO_FULFILLMENT_STATUS_CANCELLED },
-      );
+      await this.putFulfillment(event.externalOrderId, ALLEGRO_FULFILLMENT_STATUS_CANCELLED);
       return { outcome: 'applied' };
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
@@ -144,10 +141,7 @@ export class AllegroOrderSourceAdapter
     // 1. Mark sent. Treat a 409 (stale optimistic-lock revision / already-sent)
     //    as success for idempotency. `needs-sandbox-probe`: exact 409 semantics.
     try {
-      await this.httpClient.put(
-        `/order/checkout-forms/${externalOrderId}/fulfillment`,
-        { status: ALLEGRO_FULFILLMENT_STATUS_SENT },
-      );
+      await this.putFulfillment(externalOrderId, ALLEGRO_FULFILLMENT_STATUS_SENT);
     } catch (error) {
       if (this.isAlreadySentOrStale(error)) {
         this.logger.debug(
@@ -170,6 +164,16 @@ export class AllegroOrderSourceAdapter
         throw this.toRejected(error, `attach waybill to Allegro order ${externalOrderId}`);
       }
     }
+  }
+
+  /**
+   * Set the Allegro order's fulfillment status. The single wire shape behind
+   * both the `dispatched` mark-sent step and the `cancelled` writeback — callers
+   * own their own success/failure semantics (idempotent-409 for SENT, surface for
+   * CANCELLED), so this helper stays a thin one-liner with no error handling.
+   */
+  private async putFulfillment(externalOrderId: string, status: string): Promise<void> {
+    await this.httpClient.put(`/order/checkout-forms/${externalOrderId}/fulfillment`, { status });
   }
 
   /** Map the neutral carrier hint → Allegro's fixed carrier vocab (OTHER+name fallback). */

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -14,6 +14,9 @@ import type {
   OrderSourcePort,
   SourceOptionsReader,
   OrderDispatchNotifier,
+  OrderStatusWriteback,
+  OrderLifecycleEvent,
+  OrderWritebackResult,
   DispatchCarrierHint,
   MappingOption,
 } from '@openlinker/core/orders';
@@ -42,6 +45,7 @@ import { ALLEGRO_PAYMENT_TYPE_OPTIONS } from '../../domain/types/allegro-payment
 import {
   ALLEGRO_CARRIER_BY_PLATFORM_TYPE,
   ALLEGRO_FULFILLMENT_STATUS_SENT,
+  ALLEGRO_FULFILLMENT_STATUS_CANCELLED,
   ALLEGRO_OTHER_CARRIER_ID,
 } from '../../domain/types/allegro-order-fulfillment.types';
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
@@ -61,7 +65,7 @@ type OrderFeedItem = OrderFeedOutput['items'][number];
  * does not need the identifier-mapping port itself.
  */
 export class AllegroOrderSourceAdapter
-  implements OrderSourcePort, SourceOptionsReader, OrderDispatchNotifier
+  implements OrderSourcePort, SourceOptionsReader, OrderDispatchNotifier, OrderStatusWriteback
 {
   private readonly logger = new Logger(AllegroOrderSourceAdapter.name);
 
@@ -74,43 +78,96 @@ export class AllegroOrderSourceAdapter
   }
 
   /**
-   * Order-side dispatch (#837): mark the Allegro order sent, and attach the
-   * waybill when one is supplied (own-contract branch). For the source-brokered
-   * branch (Allegro Delivery) no `trackingNumber` is passed — Allegro already
-   * holds the waybill it issued — so only the fulfillment status is set.
+   * Order-side dispatch (#837): `OrderDispatchNotifier` — mark the Allegro order
+   * sent (+ waybill). Retained for the still-live shipment-dispatch path; #1160
+   * folds it into the relay via `OrderStatusWriteback`. Delegates to the shared
+   * `markSent` helper so `notifyDispatched` and `write({dispatched})` stay in lockstep.
    */
   async notifyDispatched(input: {
     externalOrderId: string;
     trackingNumber?: string;
     carrier?: DispatchCarrierHint;
   }): Promise<void> {
+    await this.markSent(input.externalOrderId, input.trackingNumber, input.carrier);
+  }
+
+  /**
+   * `OrderStatusWriteback` (#1159 / ADR-027): the single event-as-data writeback
+   * the lifecycle relay dispatches through. `dispatched` reuses the mark-sent +
+   * waybill mechanics; `cancelled` sets Allegro's fulfillment status to
+   * `CANCELLED`. Reports the per-participant outcome via `OrderWritebackResult`
+   * and never throws (mirrors the PrestaShop adapter's `write`).
+   *
+   * A `cancelled` write Allegro refuses (incl. a 409 — e.g. the order is already
+   * `SENT`) is reported `rejected`, NOT swallowed as success: the operator must
+   * see the conflict. (We do not reuse the mark-sent `409 ⇒ success` branch here
+   * — its semantics are only safe for SENT.) Exact cancel transition rules are
+   * `needs-sandbox-probe`. No refund is issued — OL is never the money book of
+   * record (ADR-027).
+   */
+  async write(event: OrderLifecycleEvent): Promise<OrderWritebackResult> {
+    try {
+      if (event.type === 'dispatched') {
+        await this.markSent(event.externalOrderId, event.trackingNumber, event.carrier);
+        return { outcome: 'applied' };
+      }
+
+      // event.type === 'cancelled'
+      await this.httpClient.put(
+        `/order/checkout-forms/${event.externalOrderId}/fulfillment`,
+        { status: ALLEGRO_FULFILLMENT_STATUS_CANCELLED },
+      );
+      return { outcome: 'applied' };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `OrderStatusWriteback '${event.type}' rejected for Allegro order ` +
+          `${event.externalOrderId}: ${detail} (connection: ${this.connectionId})`,
+      );
+      return { outcome: 'rejected', detail };
+    }
+  }
+
+  /**
+   * Mark the Allegro order sent, and attach the waybill when one is supplied
+   * (own-contract branch). For the source-brokered branch (Allegro Delivery) no
+   * `trackingNumber` is passed — Allegro already holds the waybill it issued —
+   * so only the fulfillment status is set. Shared by `notifyDispatched` and the
+   * `OrderStatusWriteback` `dispatched` path. Throws `AllegroOrderDispatchRejectedException`
+   * on a non-idempotent failure (the `notifyDispatched` contract); `write` catches it.
+   */
+  private async markSent(
+    externalOrderId: string,
+    trackingNumber?: string,
+    carrier?: DispatchCarrierHint,
+  ): Promise<void> {
     // 1. Mark sent. Treat a 409 (stale optimistic-lock revision / already-sent)
     //    as success for idempotency. `needs-sandbox-probe`: exact 409 semantics.
     try {
       await this.httpClient.put(
-        `/order/checkout-forms/${input.externalOrderId}/fulfillment`,
+        `/order/checkout-forms/${externalOrderId}/fulfillment`,
         { status: ALLEGRO_FULFILLMENT_STATUS_SENT },
       );
     } catch (error) {
       if (this.isAlreadySentOrStale(error)) {
         this.logger.debug(
-          `Allegro order ${input.externalOrderId} fulfillment already sent / stale revision — treating as success (connection: ${this.connectionId})`,
+          `Allegro order ${externalOrderId} fulfillment already sent / stale revision — treating as success (connection: ${this.connectionId})`,
         );
       } else {
-        throw this.toRejected(error, `mark Allegro order ${input.externalOrderId} sent`);
+        throw this.toRejected(error, `mark Allegro order ${externalOrderId} sent`);
       }
     }
 
     // 2. Attach the waybill when present (own-contract branch).
-    if (input.trackingNumber) {
-      const { carrierId, carrierName } = this.resolveCarrier(input.carrier);
+    if (trackingNumber) {
+      const { carrierId, carrierName } = this.resolveCarrier(carrier);
       try {
         await this.httpClient.post(
-          `/order/checkout-forms/${input.externalOrderId}/shipments`,
-          { carrierId, waybill: input.trackingNumber, ...(carrierName ? { carrierName } : {}) },
+          `/order/checkout-forms/${externalOrderId}/shipments`,
+          { carrierId, waybill: trackingNumber, ...(carrierName ? { carrierName } : {}) },
         );
       } catch (error) {
-        throw this.toRejected(error, `attach waybill to Allegro order ${input.externalOrderId}`);
+        throw this.toRejected(error, `attach waybill to Allegro order ${externalOrderId}`);
       }
     }
   }


### PR DESCRIPTION
## What & why

Part of #1157 / ADR-027. Realises **user story S3** (marketplace side): Allegro becomes a writeback target for order-lifecycle events, and the relay can reach it.

### Allegro adapter implements `OrderStatusWriteback`
- `dispatched` reuses the extracted `markSent` (mark-sent + waybill) mechanics.
- `cancelled` sets the Allegro fulfillment status to `CANCELLED` via `PUT /order/checkout-forms/{id}/fulfillment` (endpoint + enum verified against developer.allegro.pl).
- Reports `applied | rejected`, **never throws** (mirrors the PrestaShop `write`). A cancel `409`/`4xx` is reported `rejected`, **not** masked as success — a 409 on cancel is at least as likely to mean a *forbidden transition* (cancel-after-SENT) as "already cancelled", so the operator sees the conflict rather than a silent no-op. Exact cancel-409 semantics remain a `needs-sandbox-probe`.
- No refund is issued — OL is never the money book of record (ADR-027).
- `notifyDispatched` is retained (delegates to `markSent`); the `OrderDispatchNotifier` retirement stays with #1160.

### Lifecycle relay — role-agnostic target resolution
- Replaces the hardcoded `'OrderProcessorManager'` resolution with a `resolveWriteback` that tries each order-participant capability (`OrderProcessorManager` then `OrderSource`) and narrows via the `isOrderStatusWriteback` guard — **zero platform-type branching**, so the relay reaches source marketplaces (Allegro), not just destinations.
- A capability mismatch falls through to the next candidate; a connection-level failure (disabled / not-found) is surfaced distinctly (`unsupported: 'adapter unresolved'` + warn) rather than masked. The applied/rejected log line carries the resolved capability for cross-role-misroute diagnosis.
- Backward-compatible: the existing #1158 cancel→destination path still resolves `OrderProcessorManager` on the first try.

### Not in this slice
- The shop-origin cancel **trigger** that fans a shop→Allegro cancel through the relay (#1160/#1161). This ships the capability + relay reach, unit-tested; the relay generalization is the shared prerequisite #1160 also consumes.
- Retiring `OrderDispatchNotifier` (#1160).

## How to test
- `pnpm --filter @openlinker/integrations-allegro test` — Allegro adapter `write()` (dispatched applied/+waybill, dispatched rejected, cancelled applied, cancelled 409→rejected, cancelled 4xx→rejected).
- `pnpm --filter @openlinker/core test order-lifecycle-relay` — source-role (`OrderSource`) target resolved + written; connection-level failure surfaced distinctly.

## Quality gate
`pnpm type-check` ✓ · `pnpm lint` + `check:invariants` ✓ (0 errors) · allegro unit 518 ✓ · core unit 1199 ✓ · order-ingestion integration ✓. No schema change / migration.

Closes #1159

🤖 Generated with [Claude Code](https://claude.com/claude-code)