### PR TITLE
feat(shipping,orders): branch-1 shop-fulfilled dispatch → source via lifecycle relay (#1160)

### DIFF
--- a/docs/plans/analysis/ANALYSIS-implementation-plan-1160-shop-fulfilled-source-writeback.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-1160-shop-fulfilled-source-writeback.md
@@ -1,0 +1,37 @@
+# Pre-implement gate — #1160 Shop-fulfilled (branch-1) → source writeback via the relay
+
+**Plan:** `docs/plans/implementation-plan-1160-shop-fulfilled-source-writeback.md`
+**Date:** 2026-06-22
+**Verdict: ✅ READY**
+
+Pure additive wiring inside one existing service. No new port/token/ORM/barrel; no contract-surface change; no migration. Greps run against the live tree at `3cede5d0`.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| Lifecycle relay (`relay()`, `OrderLifecycleRelayInput` dispatched event) | **ALREADY EXISTS → reuse** | `order-lifecycle-relay.service.ts`; input event `{type:'dispatched', trackingNumber?, carrier?}` |
+| `ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN` + `IOrderLifecycleRelayService` | **ALREADY EXISTS → reuse** | `orders.tokens.ts:18`; barrel `orders/index.ts:137` — exported from `@openlinker/core/orders` |
+| `FulfillmentStatusSyncService` (hook site) | **PARTIAL → extend** | `fulfillment-status-sync.service.ts:109` (`implements IFulfillmentStatusSyncService`) — add ctor dep + private `relayDispatchedToSource` / `isFirstDispatch` |
+| `FulfillmentStatusSnapshot` (no carrier field) | **ALREADY EXISTS** | `fulfillment-status-snapshot.types.ts:45-56` — `{status, trackingNumber, deliveredAt}`; carrier hint correctly omitted |
+| Transition-gate (at-most-once) | **ALREADY EXISTS → reuse** | `diffPatch` patches only on status change (L363); no new ledger |
+| New port / DI token / ORM entity / capability / barrel export | **none** | plan adds none |
+
+## Backward-compatibility findings
+
+| Surface | Assessment |
+|---|---|
+| Top-level barrels | No symbol removed/renamed. `@openlinker/core/orders` consumed via existing exports only. **No break.** |
+| Port / service signatures | `IFulfillmentStatusSyncService.sync()` unchanged (new logic is internal); relay consumed via its published interface. Adding a constructor dependency keeps the service-interface invariant (class still `implements IFulfillmentStatusSyncService`). **No break.** |
+| DTO shapes / Symbol tokens | None added/removed. |
+| ORM schema | No entity/migration (transition-gate, not a notify-ledger). **N/A.** |
+| Module wiring | `shipping.module.ts:76` already imports `OrdersModule`; `orders.module.ts:94` exports `ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN`. DI resolves with **no module edit**. |
+| `check:invariants` | Shipping→orders import of `IOrderLifecycleRelayService` + token from the top-level barrel is on the cross-context allow-list (`I*Service` + Symbol token). No deep-path / service-interface / repo-URL risk. **No trip.** |
+
+## Open questions / notes (non-blocking)
+
+1. **Scope confirmed by the user at the plan gate:** `OrderDispatchNotifier` retirement deferred to a follow-up; relay fires on dispatched/delivered only (not the `cancelled` transition). The two source-dispatch paths (branch-1 vs #837 OL-managed) are disjoint per order, so leaving #837 alone introduces no double-write.
+2. **Accepted residual:** relay-failure has no durable retry (the row is already `dispatched`); logged, surfaced, deferred to #861 (per-destination notify-state). Consistent with ADR-027.
+3. **Carrier omitted** for branch-1 (snapshot has none) → source adapter falls back (Allegro → OTHER + name); tracking still propagates.
+
+**Proceed to implementation.**

--- a/docs/plans/implementation-plan-1160-shop-fulfilled-source-writeback.md
+++ b/docs/plans/implementation-plan-1160-shop-fulfilled-source-writeback.md
@@ -1,0 +1,86 @@
+# Implementation Plan — #1160 Shop-fulfilled (branch-1) → source writeback via the lifecycle relay
+
+**Issue:** #1160 (Part of #1157; ADR-027). Realises **User story S1**. Closes #1160.
+**Branch:** `1160-shop-fulfilled-source-writeback`
+**Layer:** CORE (`shipping` branch-1 read-back → `orders` lifecycle relay).
+
+---
+
+## 1. Goal (restated)
+
+When the **destination shop fulfils** an order itself (branch-1, ADR-012 — OL generates no label), `FulfillmentStatusSyncService` reads the shop's status into a branch-1 `Shipment` row but **never tells the order's source**. Wire that last hop: on observing the shop transition to **dispatched** (shipped), fire the **lifecycle relay** so the order's source participant learns *sent + tracking* via `OrderStatusWriteback({dispatched})` — with **zero platform-type branching** (the relay already resolves targets role-agnostically, #1159).
+
+Because dispatch routes through the relay to "every non-origin participant", **shop → OL → shop** fulfilment propagation falls out by construction (the origin shop, e.g. PrestaShop, already implements `OrderStatusWriteback`).
+
+## 2. Non-goals (this slice)
+
+- **Retiring `OrderDispatchNotifier` / migrating the #837 operator-dispatch path** (`ShipmentDispatchNotificationService`). ADR-027 records that aspiration, and #1159's plan loosely attributed it to #1160 — but #1160's own AC is purely branch-1 → source. The two source-dispatch paths are **disjoint per order** (branch-1 = shop-fulfilled, no OL label, `Shipment` projected straight to `dispatched`; #837 = OL-managed label, `Shipment` gated on `generated` status), so they never double-fire for the same (order, participant) and the "one writer per participant" invariant is not violated by leaving #837 alone. Retiring `OrderDispatchNotifier` is a deliberate cross-cutting refactor (touches Allegro adapter + capability + guard + controller + FE + int-specs) — **a follow-up issue**, not bundled here.
+- **Branch-1 destination-shop *cancellation* → source.** #1160 is the dispatch/fulfilled half. Shop-as-source cancellation detection is #1161; destination-shop cancel-relay (if wanted) is a separate follow-up. We fire **only** on the dispatched/delivered transition, never on the `cancelled` transition.
+- **A durable per-destination "already notified" ledger.** ADR-027 defers per-destination notify-state to #861. This slice relies on the existing **transition-gate** for at-most-once (see §3.3).
+
+## 3. Verified facts (from research)
+
+- **Hook site:** `FulfillmentStatusSyncService.sync()` (`libs/core/src/shipping/application/services/fulfillment-status-sync.service.ts`). Two persist branches: new-row `createBranchOneShipment` (≈L250-260) and update `diffPatch`+`update` (≈L262-269). `diffPatch` **only patches on a status change** (`projectedStatus !== existing.status`, L363) — re-polls of an unchanged status produce an empty patch and no write.
+- **Snapshot shape:** `FulfillmentStatusSnapshot { status: FulfillmentStatus|null; trackingNumber: string|null; deliveredAt: Date|null }` — **no carrier field**. `FulfillmentStatus = 'delivered'|'dispatched'|'cancelled'`.
+- **Relay API:** `OrderLifecycleRelayService.relay({ internalOrderId, originConnectionId, event })` where the dispatched event input is `{ type:'dispatched'; trackingNumber?: string; carrier?: DispatchCarrierHint }` (relay adds each target's `externalOrderId`). Token `ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN` + `IOrderLifecycleRelayService` are exported from `@openlinker/core/orders`. The relay excludes `originConnectionId` and writes to every other participant via `isOrderStatusWriteback`; it surfaces per-target outcomes and **never throws on a single target failure** (but `relay()` itself can throw on an identifier-mapping failure).
+- **Module wiring:** `shipping.module.ts` already imports `OrdersModule`, which exports `ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN`. No module edit needed beyond injecting the token.
+- **Cross-context legality:** importing `IOrderLifecycleRelayService` + the token from `@openlinker/core/orders` into `libs/core/src/shipping/**` is an `I*Service` + Symbol-token import — on the cross-context allow-list.
+- **shop→shop:** PrestaShop implements `OrderStatusWriteback.write()` (merged #1158), so an origin PrestaShop reflects dispatch by construction.
+- **Self-echo:** branch-1 read-back keys on the *destination's* fulfillment status (not the source feed). OL's own writeback returning as the *source's* feed event is handled by the existing `OrderIngestionService` echo guard (`sourceConnectionId` comparison, ADR-017). No new echo handling needed here.
+
+## 4. Design
+
+### 4.1 `FulfillmentStatusSyncService` — inject the relay
+- Constructor: `@Inject(ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN) private readonly orderLifecycleRelay: IOrderLifecycleRelayService` (import both from `@openlinker/core/orders`).
+
+### 4.2 Fire the relay on the first dispatch transition
+A private best-effort helper:
+```ts
+private async relayDispatchedToSource(
+  internalOrderId: string,
+  originConnectionId: string,        // the destination shop being synced — relay excludes it
+  snapshot: FulfillmentStatusSnapshot,
+): Promise<void> {
+  try {
+    await this.orderLifecycleRelay.relay({
+      internalOrderId,
+      originConnectionId,
+      // No carrier hint — the branch-1 snapshot doesn't carry it; the source
+      // adapter falls back (Allegro → OTHER + name). Tracking is propagated.
+      event: { type: 'dispatched', trackingNumber: snapshot.trackingNumber ?? undefined },
+    });
+  } catch (error) {
+    // relay() catches per-target; this guards an identifier-mapping-level throw
+    // so one order's relay failure never breaks the fulfillment sync loop.
+    this.logger.warn(
+      `Branch-1 dispatch relay failed for order ${internalOrderId} ` +
+        `(origin ${originConnectionId}): ${this.message(error)}`,
+    );
+  }
+}
+```
+Call sites (gated so it fires **once**, on the first entry into dispatched-or-delivered):
+- **New-row branch** — after `createBranchOneShipment` + `recompute`, when `snapshot.status ∈ {dispatched, delivered}`. (A shop that jumps straight to `delivered` still implies it shipped → the source must learn *sent*.)
+- **Update branch** — after `update` + `recompute`, when the patch *first* reaches dispatched: `patch.status === SHIPMENT_STATUS.Dispatched`, **or** `patch.status === SHIPMENT_STATUS.Delivered && !existing.dispatchedAt` (direct-to-delivered with no prior dispatch). A `delivered` transition on an already-dispatched shipment does **not** re-fire.
+
+A small pure helper encodes the decision (`isFirstDispatch(existing, patch)` / `isInitialDispatch(snapshot.status)`), kept readable and unit-tested.
+
+### 4.3 At-most-once (no new ledger)
+The transition-gate **is** the at-most-once mechanism: the relay is invoked only inside the status-changed code path. On re-poll, an unchanged status yields an empty `diffPatch` → no write → no relay. A shop's dispatched→delivered progression fires the relay only on the dispatched (or direct-delivered) edge, never twice. This matches AC-2 ("No duplicate mark-sent on re-poll / re-delivery"). **Accepted residual:** if the relay write to the source *fails*, the `Shipment` row is already `dispatched`, so there is no automatic retry — the failure is logged (surfaced), and durable retry/per-destination notify-state is the deferred #861 work. Documented, not built.
+
+## 5. Steps
+
+1. **`fulfillment-status-sync.service.ts`** — inject `IOrderLifecycleRelayService`; add `relayDispatchedToSource` + the `isFirstDispatch` decision; call it in both persist branches. **AC:** relay fired exactly once on first dispatched/delivered; not fired on unchanged re-poll; not fired on `cancelled`; relay throw is caught + logged, loop continues.
+2. **`fulfillment-status-sync.service.spec.ts`** — unit tests: (a) new dispatched row → relay `{type:'dispatched', trackingNumber}` with `originConnectionId = connectionId`; (b) update idle→dispatched → relay fired; (c) re-poll unchanged status → relay NOT called; (d) dispatched→delivered (already dispatched) → relay NOT called; (e) direct→delivered (no prior dispatch) → relay fired; (f) `cancelled` transition → relay NOT called; (g) relay throws → `sync()` still completes, warn logged.
+3. **Integration** — extend/add a branch-1 int-spec (`apps/api/test/integration/`) asserting: destination-shop reports `dispatched` via a `FulfillmentStatusReader` stub → a source stub implementing `OrderStatusWriteback` receives `write({type:'dispatched', externalOrderId, trackingNumber})`; a second sync pass (unchanged status) does not re-call it. Reuse the dispatch-notify test-stub harness shape.
+4. **Quality gate:** `pnpm lint` / `type-check` / `test`; **full `pnpm test:integration`** (relay + fulfillment paths) per the issue note.
+
+## 6. Validation
+- Hexagonal: shipping (application) → orders (`I*Service` + token via barrel); no platform branching; relay dispatch by guard (ADR-027). No new ORM entity / migration.
+- Service-interface invariant intact (`FulfillmentStatusSyncService` keeps its existing interface; relay is a port dep).
+- No `any`; `Logger`; types via barrel.
+
+## 7. Risks
+- **Carrier unknown for branch-1** — the snapshot has no carrier; the source adapter falls back (Allegro → `OTHER` + name). Tracking still propagates. Acceptable; a richer branch-1 carrier identity is out of scope.
+- **No durable retry on relay failure** — accepted residual (transition-gate, not a ledger); deferred to #861. Logged, not silent.
+- **Scope tension on `OrderDispatchNotifier` retirement** — deliberately deferred (§2); surfaced at the plan gate for confirmation.

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -10,6 +10,7 @@ import type { IFulfillmentRoutingService } from '@openlinker/core/mappings';
 import { FULFILLMENT_PROCESSOR_KIND } from '@openlinker/core/mappings';
 import type {
   FulfillmentStatusReader,
+  IOrderLifecycleRelayService,
   IOrderRecordService,
   OrderRecord,
 } from '@openlinker/core/orders';
@@ -72,6 +73,7 @@ describe('FulfillmentStatusSyncService', () => {
   let routing: jest.Mocked<IFulfillmentRoutingService>;
   let integrations: jest.Mocked<IIntegrationsService>;
   let getFulfillmentStatus: jest.Mock;
+  let relay: jest.Mocked<IOrderLifecycleRelayService>;
   let service: FulfillmentStatusSyncService;
 
   beforeEach(() => {
@@ -114,12 +116,15 @@ describe('FulfillmentStatusSyncService', () => {
       getCapabilityAdapter: jest.fn().mockResolvedValue(ompAdapter),
     } as unknown as jest.Mocked<IIntegrationsService>;
 
+    relay = { relay: jest.fn().mockResolvedValue({ targets: [] }) };
+
     service = new FulfillmentStatusSyncService(
       shipments,
       orderRecords,
       routing,
       integrations,
       { recompute: jest.fn() },
+      relay,
     );
   });
 
@@ -173,6 +178,112 @@ describe('FulfillmentStatusSyncService', () => {
       const createInput = shipments.create.mock.calls[0][0];
       expect(createInput.initialStatus).toBe(SHIPMENT_STATUS.Delivered);
       expect(createInput.deliveredAt).toEqual(deliveredAt);
+    });
+  });
+
+  describe('#1160 — dispatch relay to source', () => {
+    it('relays dispatched + tracking to the source when a branch-1 row is born dispatched', async () => {
+      orderRecords.findMany.mockResolvedValue({ items: [makeOrderRecord()], total: 1 });
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Dispatched,
+        trackingNumber: 'PS-TRK-1',
+        deliveredAt: null,
+      });
+
+      await service.sync(PS, { limit: 100 });
+
+      expect(relay.relay).toHaveBeenCalledTimes(1);
+      expect(relay.relay).toHaveBeenCalledWith({
+        internalOrderId: 'ol_order_1',
+        originConnectionId: PS,
+        event: { type: 'dispatched', trackingNumber: 'PS-TRK-1' },
+      });
+    });
+
+    it('relays dispatched when the shop jumps straight to delivered (delivered implies sent)', async () => {
+      orderRecords.findMany.mockResolvedValue({ items: [makeOrderRecord()], total: 1 });
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Delivered,
+        trackingNumber: 'PS-TRK-1',
+        deliveredAt: new Date('2026-05-28T08:00:00.000Z'),
+      });
+
+      await service.sync(PS, { limit: 100 });
+
+      expect(relay.relay).toHaveBeenCalledTimes(1);
+      expect(relay.relay.mock.calls[0][0].event).toEqual({
+        type: 'dispatched',
+        trackingNumber: 'PS-TRK-1',
+      });
+    });
+
+    it('does NOT relay on an unchanged-status re-poll (at-most-once via the transition-gate)', async () => {
+      shipments.findBranchOneByOrderAndConnection.mockResolvedValue(
+        makeBranchOneShipment({
+          status: 'dispatched',
+          dispatchedAt: new Date('2026-05-27T10:00:00.000Z'),
+          trackingNumber: 'PS-TRK-1',
+        }),
+      );
+      orderRecords.findMany.mockResolvedValue({ items: [makeOrderRecord()], total: 1 });
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Dispatched,
+        trackingNumber: 'PS-TRK-1',
+        deliveredAt: null,
+      });
+
+      await service.sync(PS, { limit: 100 });
+
+      expect(shipments.update).not.toHaveBeenCalled();
+      expect(relay.relay).not.toHaveBeenCalled();
+    });
+
+    it('does NOT re-relay on the delivered transition of an already-dispatched shipment', async () => {
+      shipments.findBranchOneByOrderAndConnection.mockResolvedValue(
+        makeBranchOneShipment({
+          status: 'dispatched',
+          dispatchedAt: new Date('2026-05-27T10:00:00.000Z'),
+        }),
+      );
+      orderRecords.findMany.mockResolvedValue({ items: [makeOrderRecord()], total: 1 });
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Delivered,
+        trackingNumber: null,
+        deliveredAt: new Date('2026-05-28T08:00:00.000Z'),
+      });
+
+      await service.sync(PS, { limit: 100 });
+
+      expect(shipments.update).toHaveBeenCalledTimes(1); // status → delivered
+      expect(relay.relay).not.toHaveBeenCalled();
+    });
+
+    it('does NOT relay on a cancelled transition (out of #1160 dispatch scope)', async () => {
+      orderRecords.findMany.mockResolvedValue({ items: [makeOrderRecord()], total: 1 });
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Cancelled,
+        trackingNumber: null,
+        deliveredAt: null,
+      });
+
+      await service.sync(PS, { limit: 100 });
+
+      expect(shipments.create).toHaveBeenCalledTimes(1);
+      expect(relay.relay).not.toHaveBeenCalled();
+    });
+
+    it('keeps the sync loop alive when the relay throws (best-effort, surfaced)', async () => {
+      relay.relay.mockRejectedValue(new Error('relay boom'));
+      orderRecords.findMany.mockResolvedValue({ items: [makeOrderRecord()], total: 1 });
+      getFulfillmentStatus.mockResolvedValue({
+        status: FULFILLMENT_STATUS.Dispatched,
+        trackingNumber: 'PS-TRK-1',
+        deliveredAt: null,
+      });
+
+      const result = await service.sync(PS, { limit: 100 });
+
+      expect(result).toMatchObject({ created: 1, failed: 0 });
     });
   });
 

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.ts
@@ -30,8 +30,13 @@
  * returns scan stats; the caller (worker handler) advances the persisted
  * `connection_cursors` offset.
  *
+ * On the **first** transition into dispatched/delivered it also relays the
+ * shop's "shipped" fact back to the order's source via the lifecycle relay
+ * (#1160 / ADR-027) — best-effort, transition-gated for at-most-once.
+ *
  * @module libs/core/src/shipping/application/services
  * @implements {IFulfillmentStatusSyncService}
+ * @see {@link IOrderLifecycleRelayService} for the source writeback path
  */
 
 import { Inject, Injectable } from '@nestjs/common';
@@ -50,11 +55,13 @@ import {
 import {
   type FulfillmentStatus,
   type FulfillmentStatusSnapshot,
+  type IOrderLifecycleRelayService,
   type IOrderRecordService,
   type OrderProcessorManagerPort,
   type OrderRecord,
   FULFILLMENT_STATUS,
   isFulfillmentStatusReader,
+  ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN,
   ORDER_RECORD_SERVICE_TOKEN,
 } from '@openlinker/core/orders';
 
@@ -105,6 +112,29 @@ function projectStatus(status: FulfillmentStatus): ShipmentStatus {
 const ORDER_PROCESSOR_MANAGER_CAPABILITY = 'OrderProcessorManager';
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+/**
+ * A freshly-projected branch-1 row is the destination shop's first "shipped"
+ * signal when it is born at `dispatched` or (shop jumped straight there)
+ * `delivered` — delivered implies it was sent, so the source still needs the
+ * mark-sent. `cancelled` is out of #1160's dispatch scope.
+ */
+function isInitialDispatch(status: FulfillmentStatus | null): boolean {
+  return status === FULFILLMENT_STATUS.Dispatched || status === FULFILLMENT_STATUS.Delivered;
+}
+
+/**
+ * On an UPDATE, fire the dispatch relay only on the FIRST entry into
+ * dispatched-or-delivered: a `dispatched` transition, or a direct→`delivered`
+ * transition on a row that was never dispatched. A `delivered` transition on an
+ * already-dispatched row must NOT re-fire (the source was told at dispatch).
+ */
+function isFirstDispatchTransition(existing: Shipment, patch: UpdateShipmentInput): boolean {
+  return (
+    patch.status === SHIPMENT_STATUS.Dispatched ||
+    (patch.status === SHIPMENT_STATUS.Delivered && !existing.dispatchedAt)
+  );
+}
+
 @Injectable()
 export class FulfillmentStatusSyncService implements IFulfillmentStatusSyncService {
   private readonly logger = new Logger(FulfillmentStatusSyncService.name);
@@ -124,6 +154,10 @@ export class FulfillmentStatusSyncService implements IFulfillmentStatusSyncServi
     private readonly integrations: IIntegrationsService,
     @Inject(ORDER_FULFILLMENT_PROJECTION_SERVICE_TOKEN)
     private readonly fulfillmentProjection: IOrderFulfillmentProjectionService,
+    // #1160: relay a shop-observed dispatch back to the order's source
+    // participant. Cross-context I*Service + Symbol token via the orders barrel.
+    @Inject(ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN)
+    private readonly orderLifecycleRelay: IOrderLifecycleRelayService,
   ) {}
 
   async sync(
@@ -258,6 +292,11 @@ export class FulfillmentStatusSyncService implements IFulfillmentStatusSyncServi
           // Project the order rollup (#1108); also the reconciliation backstop
           // that heals any best-effort projection dropped on the write-path.
           await this.fulfillmentProjection.recompute(record.internalOrderId);
+          // #1160: a branch-1 row born dispatched/delivered is the shop's first
+          // shipped signal — relay mark-sent + tracking to the order's source.
+          if (isInitialDispatch(snapshot.status)) {
+            await this.relayDispatchedToSource(record.internalOrderId, connectionId, snapshot);
+          }
         } else {
           const patch = this.diffPatch(existing, snapshot);
           if (Object.keys(patch).length > 0) {
@@ -265,6 +304,12 @@ export class FulfillmentStatusSyncService implements IFulfillmentStatusSyncServi
             updated += 1;
             if (patch.status) {
               await this.fulfillmentProjection.recompute(record.internalOrderId);
+            }
+            // #1160: relay only on the FIRST transition into dispatched/delivered;
+            // the transition-gate (diffPatch returns empty on unchanged status)
+            // makes this at-most-once across re-polls — no separate ledger.
+            if (isFirstDispatchTransition(existing, patch)) {
+              await this.relayDispatchedToSource(record.internalOrderId, connectionId, snapshot);
             }
           }
         }
@@ -380,6 +425,35 @@ export class FulfillmentStatusSyncService implements IFulfillmentStatusSyncServi
       patch.trackingNumber = snapshot.trackingNumber;
     }
     return patch;
+  }
+
+  /**
+   * Relay a shop-observed dispatch back to the order's source participant
+   * (#1160). The destination shop is the event origin and is excluded by the
+   * relay; the source marketplace (or, shop→shop, the origin shop) receives
+   * `OrderStatusWriteback({dispatched})`. No carrier hint — the branch-1
+   * snapshot doesn't carry one; the source adapter falls back (Allegro → OTHER
+   * + name). Best-effort: per-target failures are surfaced by the relay, and an
+   * identifier-mapping-level throw is caught here so one order never breaks the
+   * sync loop. Durable retry / per-destination notify-state is deferred (#861).
+   */
+  private async relayDispatchedToSource(
+    internalOrderId: string,
+    originConnectionId: string,
+    snapshot: FulfillmentStatusSnapshot,
+  ): Promise<void> {
+    try {
+      await this.orderLifecycleRelay.relay({
+        internalOrderId,
+        originConnectionId,
+        event: { type: 'dispatched', trackingNumber: snapshot.trackingNumber ?? undefined },
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Branch-1 dispatch relay failed for order ${internalOrderId} ` +
+          `(origin ${originConnectionId}): ${this.message(error)}`,
+      );
+    }
   }
 
   private zeroResult(


### PR DESCRIPTION
## What & why

Part of #1157 / ADR-027. Realises **user story S1** — the fulfilment half of the order-status round-trip.

When the destination shop fulfils an order itself (**branch-1**, ADR-012 — OL generates no label), `FulfillmentStatusSyncService` reads the shop's status into a branch-1 `Shipment` row but never told the order's **source**. This wires that last hop:

- On the **first** transition into `dispatched` (or a direct→`delivered`, since delivered implies it shipped), the service fires `OrderLifecycleRelayService.relay({ type: 'dispatched', trackingNumber })` with the **destination shop as origin**.
- The relay (generalized in #1159) excludes the origin and writes to the order's source via `OrderStatusWriteback` with **zero platform-type branching** — so **shop → OL → shop** fulfilment propagation falls out by construction (an origin PrestaShop already implements `write()`).

### Design notes
- **At-most-once for free** via the existing transition-gate: `diffPatch` only patches on a status *change*, so the relay fires once; re-polls of an unchanged status produce an empty patch → no relay. No new ledger.
- **Best-effort:** relay failure is caught + logged, never breaks the fulfilment sync loop. (`relay()` itself surfaces per-target outcomes and doesn't throw on a single target.)
- **No carrier hint** — the branch-1 fulfilment snapshot carries no carrier; the source adapter falls back (Allegro → `OTHER` + name). Tracking still propagates.
- **No ORM/migration**; DI resolves via existing wiring (`shipping.module` already imports `OrdersModule`, which exports the relay token).

### Scoped out (confirmed at the plan gate)
- **`OrderDispatchNotifier` retirement** — the #837 operator-dispatch path is **disjoint per order** from branch-1 (OL-managed label vs shop-fulfilled, no double-write), so it's left for a deliberate follow-up rather than bundled here.
- **Branch-1 *cancellation* relay** (dispatch-only this slice) and a **durable per-destination notify ledger** (deferred to #861, the accepted no-auto-retry residual).

## How to test
- `pnpm --filter @openlinker/core test fulfillment-status-sync` — 6 dispatch-relay cases: born-dispatched, direct-delivered, unchanged re-poll (no re-fire), delivered-after-dispatch (no re-fire), cancelled-skip, relay-throw resilience.

## Quality gate
`pnpm type-check` ✓ · `pnpm lint` + `check:invariants` ✓ (0 errors) · core unit **1205** ✓ · full `pnpm test:integration` **60 suites / 301 passed / 1 skipped** ✓ (DI-resolution + regression). No schema change.

**Testing note:** behaviour is covered by the unit suite + the full integration run (which proves the new DI injection resolves and nothing regressed). A dedicated branch-1 end-to-end relay int-spec is a reasonable follow-up — there's no existing branch-1 fulfilment harness to extend, so it'd be a bespoke addition disproportionate to this change.

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)