### PR TITLE
feat(prestashop): emit cancelled OrderFeed event on source-order cancellation (#1161)

### DIFF
--- a/docs/plans/analysis/ANALYSIS-implementation-plan-1161-ps-source-cancellation-detection.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-1161-ps-source-cancellation-detection.md
@@ -1,0 +1,45 @@
+# Pre-Implement Gate — #1161 Shop-as-source cancellation detection
+
+**Plan:** `docs/plans/implementation-plan-1161-ps-source-cancellation-detection.md`
+**Issue:** #1161 (part of #1157, ADR-027)
+**Gate run:** read-only reuse + backward-compat audit against the live tree.
+
+## Verdict: ✅ READY
+
+No Critical or Warning contract breaks. No reuse collision that reinvents an exported symbol. The change is purely additive, intra-package (PrestaShop infrastructure), and the downstream contract (`OrderFeedEventType` union, ingestion→relay path) already accommodates the new value.
+
+---
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `cancelled` `OrderFeedEventType` | **ALREADY EXISTS → reuse** (correct) | `libs/core/src/orders/domain/types/order-feed.types.ts:20` — already in the union; plan consumes, never redefines. |
+| Ingestion→relay path for `cancelled` | **ALREADY EXISTS → reuse** (correct) | `order-ingestion.service.ts:194` `handleSourceCancellation` → `orderLifecycleRelay.relay({type:'cancelled'})`. No core change needed. |
+| `PRESTASHOP_DEFAULT_CANCELLED_STATE_ID = 6` | **NEW (confirmed absent)** | No exported PS order-state constant exists. The cancel=6 fact lives only as **inline literals** in `prestashop-order.mapper.ts` (`:106` id→status, `:418` status→id switch). Nothing to import. |
+| `prestashop-order-state.types.ts` | **NEW** | File does not exist (`infrastructure/mappers/` has only `prestashop-order.mapper.ts` + interfaces). |
+| `resolveFeedEventType` private helper | **NEW** | No existing feed-event-type helper; current derivation is inline at adapter `:80`. |
+| Int-spec stub seam | **ALREADY EXISTS → reuse** (correct) | `AdapterRegistryService` + `AdapterFactoryResolverService` (carrier-mapping pattern, testing-guide §Vertical-slice). |
+
+### Reuse observation (non-blocking, already adjudicated)
+The "PS default cancelled state = `6`" fact will now live in **three** places: `mapOrderStatus` (`:106`), `mapStatusToPrestashopStateId` (`:418`, a `switch` that already centralizes default-install state ids), and the new constant. The plan's `/tech-review` consciously chose **option (a)** — leave the mapper untouched rather than ship a one-of-seven extraction or widen scope to fold the whole table (plan §8). This gate concurs: the existing sites are inline literals, not a reusable export, so the new constant does not *reinvent* anything. If a single source of truth is ever wanted, `mapStatusToPrestashopStateId`'s switch is the natural consolidation target — noted for a future cleanup, not this slice.
+
+---
+
+## Backward-compatibility findings
+
+| Surface | Result |
+|---|---|
+| Top-level barrels (`@openlinker/integrations-prestashop`, `@openlinker/core/orders`) | ✅ No change. New types file is internal to PS infra; **not** re-exported from `src/index.ts`. Constant consumed only by the adapter (same-package relative import, ≤ `../..` depth). |
+| Port signature (`OrderSourcePort.listOrderFeed`) | ✅ Unchanged. Return type `OrderFeedOutput` / `OrderFeedItem` unchanged — only the *value* of the already-typed `eventType` field now exercises a pre-existing union member. |
+| DTO shapes | ✅ None touched. |
+| Symbol tokens | ✅ None. |
+| ORM schema / migration | ✅ None — no entity change, no migration (matches plan §5). |
+| `check:invariants` | ✅ Clear. `check-cross-context-imports` — no new cross-context import (`OrderFeedEventType` already imported as a type in the adapter). `check-service-interfaces` — scopes `libs/core` only, N/A. No deep-barrel imports, no migration-timestamp involvement. |
+| Downstream consumers of the new value | ✅ Safe. `OrderIngestionService` already branches on `cancelled` (`:194`); job payload types `eventType` as `OrderFeedEventType`; the orders-poll handler passes it through. No switch elsewhere breaks on the now-produced value. |
+| Existing PS feed spec | ✅ No regression. The line-95 `eventTypes:['cancelled']` test uses non-state-6 orders → still yields 0 items. |
+
+---
+
+## Open questions
+None blocking. One forward-looking note (already in plan §7): detection keys on default state id `6`, so renumbered-state installs are undetected — documented v1 limitation, name-resolution is the tracked follow-up. No decision required to implement this slice.

--- a/docs/plans/implementation-plan-1161-ps-source-cancellation-detection.md
+++ b/docs/plans/implementation-plan-1161-ps-source-cancellation-detection.md
@@ -1,0 +1,106 @@
+# Implementation Plan — #1161 Shop-as-source cancellation detection in the OrderSource feed
+
+**Issue:** [#1161](https://github.com/openlinker-project/openlinker/issues/1161) — part of #1157 (order-status round-trip), ADR-027. Completes User story S3 for shop origins.
+**Branch:** `1161-ps-source-cancellation-detection`
+**Layer:** Integration (PrestaShop) — Infrastructure adapter. **No CORE change. No migration.**
+**Review:** revised after a deep `/tech-review` pass (🔄 Approve-with-changes) — all IMPORTANT + SUGGESTION items folded in (see §8).
+
+---
+
+## 1. Goal
+
+PrestaShop's `OrderSource` feed currently emits only `created` / `updated`, so an origin-shop cancellation can't even be *observed* by core — blocking shop→OL→shop and shop→OL→marketplace cancel-from-origin. Allegro already maps `CANCEL → cancelled`; PrestaShop is the sole gap.
+
+Make `PrestashopOrderSourceAdapter.listOrderFeed` emit a `cancelled` `OrderFeedEventType` when a PrestaShop order is in the canceled state. **The entire downstream path already exists** and needs no changes.
+
+### Non-goals
+- Any relay / core change. `OrderIngestionService.syncOrderFromSource` (line 194) already routes `eventType === 'cancelled'` → `handleSourceCancellation` → `orderLifecycleRelay.relay({ event: { type: 'cancelled' } })`, with the ADR-017 destination-echo guard. Verified.
+- Scheduler change. The `prestashop-orders-poll` payload sets **no `eventTypes`**, so `cancelled` flows through unfiltered. Verified.
+- Touching `mapOrderStatus` / the PS order-state table. Out of scope — see §8 decision.
+- Dynamic order-state-name resolution (multilingual / renumbered installs) — see §7 Known limitation.
+- `refunded` (state 7), `paid`, or any non-cancellation transition. Strictly the cancel signal.
+
+---
+
+## 2. Research findings (grounding)
+
+| Fact | Evidence |
+|---|---|
+| Feed never emits `cancelled` | `prestashop-order-source.adapter.ts:80` — `eventType = createdAt === occurredAt ? 'created' : 'updated'` |
+| `cancelled` is a valid feed type | `order-feed.types.ts:20` — `OrderFeedEventTypeValues = ['created','updated','cancelled','paid']` |
+| List response carries `current_state` | Query builder defaults `display=full` (`prestashop-query.builder.ts:72`); `PrestashopOrder.current_state` typed (`prestashop.mapper.interface.ts:76`). **No extra fetch needed.** |
+| PS canceled = state id `6` (default install) | `prestashop-order.mapper.ts:106` — `if (statusNum === 6) return 'cancelled'` |
+| Downstream wiring complete | `order-ingestion.service.ts:194` routes cancelled → `handleSourceCancellation` → relay |
+| Poll doesn't filter event types | `prestashop-scheduler-tasks.ts:73-77` — payload has no `eventTypes` |
+| Allegro reference | `allegro-order-source.adapter.ts:659` — `if (t.includes('CANCEL')) return 'cancelled'` |
+
+---
+
+## 3. Design
+
+`current_state === 6` denotes a PrestaShop cancellation. Emit `cancelled` with **precedence over** created/updated.
+
+**Why precedence is load-bearing (not just cosmetic):** a cancelled order has `date_upd > date_add`, so without precedence it would read as `updated`. But the stronger, safety-critical reason is re-poll robustness: an order that **stays cancelled** but gets re-touched at the source (admin note, status-history write, any `date_upd` bump) must keep emitting `cancelled`. If it ever flipped to `updated`, `syncOrderFromSource` would re-enter the create/update path and **resurrect a cancelled order as active**. Checking `current_state === 6` first guarantees a still-cancelled order always re-emits `cancelled` (an idempotent no-op at the relay), never `updated`. This invariant must not be broken by a future edit.
+
+**`eventKey`** stays `${externalOrderId}:${occurredAt}:${eventType}` — already includes `eventType`, so a `cancelled` event is dedupe-distinct from a prior `created`/`updated` at a different `date_upd`. Re-emission is safe end-to-end: the per-event `dedupeKey` dedupes at enqueue, the relay is at-most-once (#1158), and the ADR-017 destination-echo guard prevents a cancel re-read on a connection OL pushed the order *into* from propagating spuriously.
+
+---
+
+## 4. Step-by-step
+
+### Step 1 — Named constant (single source of truth for the feed path)
+**File:** new `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order-state.types.ts`
+- `export const PRESTASHOP_DEFAULT_CANCELLED_STATE_ID = 6;` — name encodes the **default-install** assumption at every call site (§7). Docblock: PS default "Canceled" state id; renumbered installs are a documented v1 limitation.
+- **AC:** constant exported; file header present.
+
+### Step 2 — Feed emits `cancelled`
+**File:** `prestashop-order-source.adapter.ts` (`listOrderFeed`)
+- Add a private pure helper `resolveFeedEventType(order, createdAt, occurredAt): OrderFeedEventType`:
+  - `order.current_state !== undefined && Number(order.current_state) === PRESTASHOP_DEFAULT_CANCELLED_STATE_ID` → `'cancelled'` (explicit undefined guard for legibility — `Number(undefined) === 6` is already `false`, but the guard states intent);
+  - else `createdAt === occurredAt ? 'created' : 'updated'`.
+- Inline comment on the helper records the §3 resurrection-safety invariant (cancel checked first so a re-touched still-cancelled order never flips to `updated`).
+- Call it inside the existing `.map`. No change to cursor computation, `eventKey` shape, or eventTypes filtering.
+- **AC:** a `current_state: '6'` order yields `eventType: 'cancelled'`; non-cancelled unaffected.
+
+### Step 3 — Unit tests
+**File:** `__tests__/prestashop-order-source.adapter.spec.ts`
+- cancelled order (`current_state: '6'`, `date_upd > date_add`) → `eventType: 'cancelled'` (not `'updated'`); `eventKey` ends `:cancelled`.
+- cancellation precedence when `date_add === date_upd` → still `'cancelled'`.
+- **re-touched still-cancelled** order (`current_state: '6'`, `date_upd > date_add`) stays `'cancelled'` — regression guard for the §3 invariant.
+- non-cancelled `current_state: '2'` with `date_upd > date_add` → still `'updated'`; equal dates → `'created'`.
+- detection×filter interaction:
+  - cancelled order is **retained** when `eventTypes: ['cancelled']` (the actual S3 relay path);
+  - cancelled order is **filtered out** when `eventTypes: ['created','updated']`.
+- cursor still advances to max `date_upd` with a cancelled item present.
+- **AC:** new cases green; existing cases untouched.
+
+### Step 4 — Integration coverage (committed criterion, not open-ended)
+1. Grep existing int-specs for an ingestion→relay `cancelled` assertion (the relay path is platform-neutral; #1158/#1159 cover the marketplace-origin cancel).
+2. If no **shop-source** `cancelled` path is exercised end-to-end, add **one** ingestion-level int-spec via the public `AdapterRegistryService` + `AdapterFactoryResolverService` stub seam (carrier-mapping pattern) — register a stub PS `OrderSource` emitting a `cancelled` feed item, assert the relay targets the destination. **Not** a PS Testcontainer (12-min boot, ~zero marginal assurance over the unit test).
+3. Run the full **`pnpm test:integration`** regardless (issue architecture note).
+- **AC:** shop-origin cancellation → other participant reached (or clear unsupported result); full int-suite green.
+
+---
+
+## 5. Quality gate
+`pnpm lint` · `pnpm type-check` · `pnpm test` (prestashop package) · `pnpm test:integration`. No `migration:show` (no schema change).
+
+## 6. Files touched
+- `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order-state.types.ts` (new)
+- `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts`
+- `libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts`
+- (conditional) one `apps/api/test/integration/**` int-spec per §4.2
+
+## 7. Known limitation (documented, not a regression)
+Cancellation keys on the PrestaShop **default** "Canceled" state id (`6`), matching the existing `mapOrderStatus`. Installs that renumber order states won't be detected. A name-resolved upgrade (mirroring `prestashop-fulfillment-status.mapper.ts`'s `CANCEL_REGEX` + `resolveStateId('cancelled')`) is the robust follow-up; it adds a per-poll `order_states` lookup on the hot feed path, so it's deliberately out of scope for this MVP slice.
+
+## 8. Tech-review resolutions
+- **Mapper asymmetry (IMPORTANT):** chose option (a) — **leave `mapOrderStatus` untouched.** Extracting only `6` of its seven sibling state-id literals would be a confusing half-measure; fully extracting the table widens scope into an unrelated file + its spec for a no-op refactor. The `6` lives in two surfaces (status-string mapping vs feed event-type) that are independently obvious; the new constant + this note are the cross-reference. Net: change stays confined to the one path that needs new behavior.
+- **Precedence invariant (IMPORTANT):** documented in §3 and pinned as an inline comment on the helper (Step 2).
+- **Constant name (SUGGESTION):** `PRESTASHOP_DEFAULT_CANCELLED_STATE_ID`.
+- **Test matrix (SUGGESTION):** added retained/filtered-by-eventTypes cases + the re-touched-stays-cancelled regression guard (Step 3).
+- **Int decision (SUGGESTION):** Step 4 now commits to a grep-then-conditional-stub-seam criterion, explicitly avoiding the PS Testcontainer.
+- **Undefined guard (SUGGESTION):** explicit `current_state !== undefined` in the helper (Step 2).
+
+## 9. Risks
+**Low.** Pure additive event-type derivation on an existing hot path; no I/O added; downstream + scheduler verified to already handle `cancelled`. Mild file-proximity to in-flight #1129 (touches the same adapter's `getOrder()`, a different method) — possible trivial merge brush, not blocking.

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
@@ -110,6 +110,142 @@ describe('PrestashopOrderSourceAdapter', () => {
       expect(result.items).toHaveLength(0);
       expect(result.nextCursor).toBe('2024-01-02 12:00:00');
     });
+
+    describe('cancellation detection (#1161)', () => {
+      it('should emit a cancelled event for an order in the canceled state (state 6)', async () => {
+        const orders: PrestashopOrder[] = [
+          {
+            id: '7',
+            current_state: '6',
+            date_add: '2024-03-01 09:00:00',
+            date_upd: '2024-03-02 14:00:00',
+          },
+        ];
+        mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(orders);
+
+        const result = await adapter.listOrderFeed({ fromCursor: null, limit: 10 });
+
+        expect(result.items[0]).toMatchObject({
+          externalOrderId: '7',
+          eventType: 'cancelled',
+          occurredAt: '2024-03-02 14:00:00',
+        });
+        // eventKey carries the event type so a cancel is dedupe-distinct from a
+        // prior created/updated at a different date_upd.
+        expect(result.items[0].eventKey).toBe('7:2024-03-02 14:00:00:cancelled');
+      });
+
+      it('should take cancellation precedence even when date_add === date_upd', async () => {
+        const orders: PrestashopOrder[] = [
+          {
+            id: '8',
+            current_state: '6',
+            date_add: '2024-03-03 10:00:00',
+            date_upd: '2024-03-03 10:00:00',
+          },
+        ];
+        mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(orders);
+
+        const result = await adapter.listOrderFeed({ fromCursor: null, limit: 10 });
+
+        expect(result.items[0].eventType).toBe('cancelled');
+      });
+
+      it('should keep emitting cancelled for a re-touched order that stays canceled (no flip to updated)', async () => {
+        // Regression guard: a still-cancelled order whose date_upd bumped again
+        // must NOT read as `updated` (which would re-create it as active).
+        const orders: PrestashopOrder[] = [
+          {
+            id: '9',
+            current_state: '6',
+            date_add: '2024-03-04 10:00:00',
+            date_upd: '2024-03-05 11:30:00',
+          },
+        ];
+        mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(orders);
+
+        const result = await adapter.listOrderFeed({
+          fromCursor: '2024-03-05 00:00:00',
+          limit: 10,
+        });
+
+        expect(result.items[0].eventType).toBe('cancelled');
+      });
+
+      it('should not treat a non-canceled updated order as cancelled', async () => {
+        const orders: PrestashopOrder[] = [
+          {
+            id: '10',
+            current_state: '2',
+            date_add: '2024-03-06 09:00:00',
+            date_upd: '2024-03-07 09:00:00',
+          },
+        ];
+        mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(orders);
+
+        const result = await adapter.listOrderFeed({ fromCursor: null, limit: 10 });
+
+        expect(result.items[0].eventType).toBe('updated');
+      });
+
+      it('should classify an order with no current_state as created/updated (undefined guard)', async () => {
+        const orders: PrestashopOrder[] = [
+          {
+            id: '13',
+            date_add: '2024-03-12 09:00:00',
+            date_upd: '2024-03-13 09:00:00',
+          },
+        ];
+        mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(orders);
+
+        const result = await adapter.listOrderFeed({ fromCursor: null, limit: 10 });
+
+        expect(result.items[0].eventType).toBe('updated');
+      });
+
+      it('should retain a cancelled order when eventTypes filters for ["cancelled"]', async () => {
+        const orders: PrestashopOrder[] = [
+          {
+            id: '11',
+            current_state: '6',
+            date_add: '2024-03-08 09:00:00',
+            date_upd: '2024-03-09 09:00:00',
+          },
+        ];
+        mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(orders);
+
+        const result = await adapter.listOrderFeed({
+          fromCursor: null,
+          limit: 10,
+          eventTypes: ['cancelled'],
+        });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].externalOrderId).toBe('11');
+      });
+
+      it('should filter out a cancelled order when eventTypes is ["created","updated"]', async () => {
+        const orders: PrestashopOrder[] = [
+          {
+            id: '12',
+            current_state: '6',
+            date_add: '2024-03-10 09:00:00',
+            date_upd: '2024-03-11 09:00:00',
+          },
+        ];
+        mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(orders);
+
+        const result = await adapter.listOrderFeed({
+          fromCursor: null,
+          limit: 10,
+          eventTypes: ['created', 'updated'],
+        });
+
+        expect(result.items).toHaveLength(0);
+        // Cursor still advances past the filtered-out cancelled order.
+        expect(result.nextCursor).toBe('2024-03-11 09:00:00');
+      });
+    });
   });
 
   describe('getOrder', () => {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
@@ -14,6 +14,7 @@ import type {
   OrderFeedInput,
   OrderFeedOutput,
   OrderFeedItem,
+  OrderFeedEventType,
   IncomingOrder,
   IncomingOrderItem,
   IncomingOrderAddress,
@@ -26,6 +27,7 @@ import type {
   PrestashopOrder,
   PrestashopOrderRow,
 } from '../mappers/prestashop.mapper.interface';
+import { PRESTASHOP_DEFAULT_CANCELLED_STATE_ID } from '../mappers/prestashop-order-state.types';
 import {
   PrestashopApiException,
   PrestashopResourceNotFoundException,
@@ -77,7 +79,7 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
       const externalOrderId = String(o.id);
       const occurredAt = typeof o.date_upd === 'string' ? o.date_upd : new Date().toISOString();
       const createdAt = typeof o.date_add === 'string' ? o.date_add : occurredAt;
-      const eventType = createdAt === occurredAt ? 'created' : 'updated';
+      const eventType = this.resolveFeedEventType(o, createdAt, occurredAt);
       return {
         externalOrderId,
         eventType,
@@ -105,6 +107,35 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
       items: filtered,
       nextCursor: nextCursor ?? input.fromCursor ?? null,
     };
+  }
+
+  /**
+   * Derive the feed event type for a PrestaShop order row.
+   *
+   * Cancellation is checked **first**, with precedence over created/updated.
+   * This ordering is load-bearing, not cosmetic: an order that stays cancelled
+   * but gets re-touched at the source (admin note, status-history write — any
+   * `date_upd` bump) must keep emitting `cancelled`. If it ever flipped to
+   * `updated`, `OrderIngestionService.syncOrderFromSource` would re-enter the
+   * create/update path and resurrect a cancelled order as active (#1161). A
+   * still-cancelled order therefore re-emits `cancelled` (an idempotent no-op
+   * at the lifecycle relay) on every re-read — never `updated`.
+   *
+   * Keys on the default-install "Canceled" state id; renumbered installs are a
+   * documented v1 limitation (see `prestashop-order-state.types.ts`).
+   */
+  private resolveFeedEventType(
+    order: PrestashopOrder,
+    createdAt: string,
+    occurredAt: string
+  ): OrderFeedEventType {
+    if (
+      order.current_state !== undefined &&
+      Number(order.current_state) === PRESTASHOP_DEFAULT_CANCELLED_STATE_ID
+    ) {
+      return 'cancelled';
+    }
+    return createdAt === occurredAt ? 'created' : 'updated';
   }
 
   async getOrder(input: { externalOrderId: string }): Promise<IncomingOrder> {

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order-state.types.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order-state.types.ts
@@ -1,0 +1,21 @@
+/**
+ * PrestaShop Order-State Constants
+ *
+ * Numeric PrestaShop `order_state` ids the adapters key on. PrestaShop ships a
+ * fixed set of default order states on a clean install; this module names the
+ * one the order-source feed needs so the magic number doesn't sit inline.
+ *
+ * Scope: the **default-install** state ids. Installs that renumber order states
+ * are a documented v1 limitation (#1161) — the robust path is name resolution
+ * via `GET /order_states` (see `prestashop-order-processor-manager.adapter.ts`
+ * `resolveStateId`), deliberately out of scope for the hot feed path.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/mappers
+ * @see {@link PrestashopOrderMapper.mapOrderStatus} for the sibling id→status table
+ */
+
+/**
+ * Default-install PrestaShop id for the "Canceled" order state. Used by the
+ * order-source feed to emit a `cancelled` OrderFeedEventType (#1161).
+ */
+export const PRESTASHOP_DEFAULT_CANCELLED_STATE_ID = 6;


### PR DESCRIPTION
## What

Completes **#1157 User story S3 for shop origins** (ADR-027): the PrestaShop `OrderSource` feed now emits a `cancelled` `OrderFeedEventType` when a source order is in the canceled state, so an origin-shop cancellation can be observed by core and propagated to the other participant.

Before this, the feed emitted only `created` / `updated`, so shop→OL→shop and shop→OL→marketplace cancel-from-origin couldn't even be observed. Allegro already maps `CANCEL → cancelled`; **PrestaShop was the sole gap**.

`Closes #1161`

## How

`PrestashopOrderSourceAdapter.listOrderFeed` now derives the event type via a pure private `resolveFeedEventType` helper:

- `current_state === 6` (PrestaShop default **"Canceled"**) → `cancelled`, **with precedence over** created/updated.
- **Precedence is load-bearing, not cosmetic:** a still-cancelled order that gets re-touched at the source (admin note / status-history write — any `date_upd` bump) must keep emitting `cancelled`. If it ever flipped to `updated`, `OrderIngestionService.syncOrderFromSource` would re-enter the create/update path and **resurrect a cancelled order as active**. Checking state 6 first guarantees a still-cancelled order re-emits `cancelled` (an idempotent no-op at the relay) on every re-read.

`current_state` is already present on the feed list response (the WS query builder defaults `display=full`), so **no extra HTTP call** is added on the hot poll path.

### The downstream path already exists — nothing else changed
- `OrderIngestionService.syncOrderFromSource` already routes `eventType === 'cancelled'` → `handleSourceCancellation` → `OrderLifecycleRelay.relay({ type: 'cancelled' })`, with the ADR-017 destination-echo guard (#1158 / #1159, both on `main`).
- The `prestashop-orders-poll` payload sets **no `eventTypes`** filter, so `cancelled` flows through unfiltered.
- **No CORE change. No migration.**

## Files
- `…/mappers/prestashop-order-state.types.ts` (new) — `PRESTASHOP_DEFAULT_CANCELLED_STATE_ID = 6`
- `…/adapters/prestashop-order-source.adapter.ts` — `resolveFeedEventType` helper + wiring
- `…/adapters/__tests__/prestashop-order-source.adapter.spec.ts` — 7 new cases
- plan + pre-implement analysis docs

## Known limitation (documented)
Detection keys on the **default-install** "Canceled" state id (`6`), matching the existing `mapOrderStatus`. Installs that renumber order states won't be detected; name resolution (mirroring `prestashop-fulfillment-status.mapper.ts`'s `CANCEL_REGEX` / `resolveStateId('cancelled')`) is the robust follow-up — deliberately out of scope here to avoid a per-poll `order_states` lookup on the hot feed path.

## Test plan
- **Unit:** 7 new cases under `cancellation detection (#1161)` — state-6 detection, precedence (incl. `date_add === date_upd`), re-touched-stays-cancelled regression guard, defined-non-6 + absent `current_state` (undefined guard), retained-under-`['cancelled']` filter, filtered-out-under-`['created','updated']` (cursor still advances). PS unit suite **30 suites / 418 → 419 tests** green.
- **Integration:** full `pnpm test:integration` green — **60 suites, 301 passed / 1 skipped, 0 failures**. The shop-source `cancelled` → relay → destination composition is covered: the PS adapter→`cancelled` emission (unit), the ingestion→relay routing (`order-ingestion.service.spec.ts:714-786`, platform-neutral), and relay→destination (#1158/#1159). A dedicated PS-Testcontainer cancel int-spec was deliberately not added — it would re-assert covered behavior at ~10-min boot cost; a platform-agnostic cancel-relay int-spec is a reasonable separate follow-up.
- `pnpm lint` (incl. `check:invariants`) + `pnpm type-check` green.

## Process
Deep `/tech-review` (×2) → all suggestions applied → `/pre-implement` gate `READY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)