### PR TITLE
feat(erli): native inbound-webhook decoder + signature verifier (#1145)

### DIFF
--- a/docs/plans/analysis/ANALYSIS-implementation-plan-erli-inbound-webhook-decoder.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-erli-inbound-webhook-decoder.md
@@ -1,0 +1,58 @@
+# Pre-Implementation Readiness Gate: Erli Inbound Webhook Decoder (#1145)
+
+**Date**: 2026-06-23
+**Plan**: `docs/plans/implementation-plan-erli-inbound-webhook-decoder.md`
+**Branch**: `1145-erli-inbound-webhook-decoder` (stacked on #1081 / `996-erli-webhooks`)
+**Gate type**: read-only — reuse audit + backward-compatibility check. No code/plan edited.
+
+---
+
+## Verdict
+
+**Structural: `READY`** — no reuse collisions, no contract-surface breaks. Every artifact the plan assumes pre-exists was confirmed in the live tree; the only net-new file is the decoder adapter + its spec.
+
+**Operational: `GO-with-scaffolding-only`** — implementation can land the full structure (adapter skeleton, registration, unit tests against a fixture-signed scheme), but `verify()` **cannot reach a shippable state** until the plan's BLOCKING Phase 0 sandbox spike confirms Erli's real delivery-time auth scheme (#992). Shipping `verify()` blind risks false-reject (status quo) or false-accept (security hole). This is an Open Question, not a structural defect — hence `READY` on the gate's own taxonomy, with the spike called out below.
+
+---
+
+## Reuse findings (Phase B)
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `ErliInboundWebhookDecoderAdapter` (+ spec) | **NEW (confirmed absent)** | `ls libs/integrations/erli/src/infrastructure/adapters/` → no `*decoder*`/`*inbound*` file |
+| `InboundWebhookDecoderPort` | **ALREADY EXISTS → reuse** | `libs/core/src/integrations/domain/ports/inbound-webhook-decoder.port.ts` |
+| `DecodeResult` / `WebhookVerifyResult` / `InboundWebhookEnvelope` types | **ALREADY EXISTS → reuse** | `libs/core/src/integrations/domain/types/inbound-webhook-decoder.types.ts` |
+| Decoder registry | **ALREADY EXISTS → reuse** | `libs/core/src/integrations/infrastructure/adapters/inbound-webhook-decoder-registry.service.ts`; exposed as `host.inboundWebhookDecoderRegistry` (`libs/plugin-sdk/src/host-services.ts:134`) |
+| Secret-retrieval seam | **ALREADY EXISTS → reuse** | `WebhookSecretProviderPort.getSecret(provider, connectionId)` (`webhook-secret-provider.port.ts:37`); host calls it then passes `secret` into `verify()` — decoder needs no DI |
+| Receive pipeline | **ALREADY EXISTS → reuse** | `webhook.service.ts:64` `decoderRegistry.get(provider) ?? defaultDecoder` → `:76` `verify` → `:89` `extractEnvelope` — exactly as the plan assumes |
+| InPost precedent (template) | **EXISTS → follow** | adapter + spec both present in `libs/integrations/inpost/.../adapters/` |
+| `erli-webhook.types.ts` constants | **PARTIAL (extend)** | file exists; plan adds confirmed header/field-name constants (additive) |
+| `ErliWebhookEventTranslator` | **EXISTS → reuse** | already registered at `erli-plugin.ts:102` under `ERLI_ADAPTER_KEY` |
+| Port / token / ORM / migration / DTO / capability | **NONE created** | plan adds no new CORE port, Symbol token, ORM entity, migration, controller, DTO, or capability |
+
+No artifact the plan marks "new" already exists; no artifact it assumes exists is missing.
+
+## Backward-compatibility findings (Phase C)
+
+| Surface | Result |
+|---|---|
+| Top-level barrels (`@openlinker/core/integrations`) | **No change** — decoder consumes existing exports; adds nothing to the barrel |
+| Port method signatures | **No change** — implements `InboundWebhookDecoderPort` as-is |
+| DTO shapes | **No change** |
+| Symbol tokens | **No change** |
+| ORM schema / migrations | **None** — no persistence change |
+| `erli-plugin.ts` `register()` | **Additive only** — new `host.inboundWebhookDecoderRegistry.register('erli', …)` line beside the existing translator registration (`:102`). Registers by `platformType` (`'erli'`, `:51`), NOT `ERLI_ADAPTER_KEY` — correct per ADR-021 |
+| `check:invariants` | **No expected trip** — decoder lives in `libs/integrations/**`, imports the port via the `@openlinker/core/integrations` top-level barrel (no deep import); no cross-context or service-interface rule applies to a pure adapter |
+
+**Intended behavior change (not a break):** registering a native decoder flips `provider='erli'` deliveries from "100% rejected by the OL-HMAC default" to "decoded + verified." No other provider is affected (registry is per-provider).
+
+## Open questions (block a *shippable* verify(), not the structure)
+
+1. **#992 — Erli delivery auth scheme (BLOCKING Phase 0).** Unconfirmed: signature vs. echoed-`accessToken`; header/field names; presence + signature-coverage of a timestamp; how a delivery signals which hook fired; body shape. Until captured from a real sandbox delivery, `verify()` and the `eventId` timestamp component (A4) are assumption-driven. Requires a public callback tunnel + a triggered sandbox order.
+2. **Stacked-PR hygiene** — branch carries #1081's diff until it merges; rebase onto `main` before final PR (already in the plan).
+
+---
+
+## One-paragraph summary
+
+The plan is structurally **READY**: every port, registry, type, secret seam, and pipeline stage it relies on was confirmed present in the live tree, the InPost decoder is a faithful template, and the work is purely additive (one new adapter + spec + one `register()` line) with zero CORE/DTO/token/ORM/migration change and no contract-surface break. The single gate-stopping reality is operational, not structural: the BLOCKING Phase 0 spike (#992) — Erli's real delivery-time signature scheme is unknown, so `verify()` and the `eventId` timestamp can be *scaffolded* but not *finalized to ship* without capturing a live sandbox delivery. Recommended posture: **GO-with-scaffolding-only** — build the adapter shape, registration, and unit tests now; gate the final `verify()` implementation + provisional-flag removal on the spike.

--- a/docs/plans/implementation-plan-erli-inbound-webhook-decoder.md
+++ b/docs/plans/implementation-plan-erli-inbound-webhook-decoder.md
@@ -93,7 +93,7 @@ Confirmed today:
 - **A1 (most likely)**: Erli echoes the `accessToken` (shared secret) on each delivery in a header (candidate names to probe: `x-erli-token`, `authorization`, `x-webhook-token`). `verify` = timing-safe compare of the echoed token against `secret`; **no** timestamp → `timestampMs: undefined` (replay-window skipped, acceptable because `eventId` Postgres dedup is the authoritative idempotency gate and the #993 poll backstops loss).
 - **A2 (fallback)**: If Erli HMAC-signs, copy the InPost HMAC path verbatim (swap header names + base64/hex per the spike).
 - **A3**: Event type rides a body field (`type`) or a per-hook header; if neither exists, default `eventType` to `'orderStatusChanged'` → translator maps to `'updated'` → a safe full re-pull (matches the translator's existing unknown→updated fallback).
-- **A4**: `eventId = sha256(connectionId + ':' + externalId + ':' + eventType)[:N]` (deterministic; collapses retries, distinguishes created vs status-changed). Correctness guarantee is the idempotent downstream re-read, so best-effort dedup suffices.
+- **A4**: `eventId = sha256(connectionId + ':' + externalId + ':' + eventType + ':' + occurredAt)[:N]` — the timestamp component is **load-bearing**, mirroring InPost's `deriveEventId(record, parcelId, occurredAt)`. WITHOUT it, every `orderStatusChanged` delivery for the same order hashes identically and the Postgres `(provider, connectionId, eventId)` dedup gate would **drop all status changes after the first** (`purchased→shipped→cancelled` would ingest only the first transition). Prefer a provider-supplied event id if the spike finds one. **Fallback if Erli sends no per-event timestamp/id (resolve in the spike):** distinct status-changes for one order become indistinguishable by `eventId`; the webhook then degrades to a *single* low-latency nudge per order and the #993 inbox poll carries correctness for subsequent transitions. This degradation MUST be called out in the decoder file header if it ships, not left implicit.
 
 ### Documentation Gaps
 - `erli-webhook.types.ts` is entirely `#992-PROVISIONAL`. The spike confirms/repairs it; this plan's Phase 0 updates those facts in the same PR.
@@ -118,7 +118,7 @@ Confirmed today:
 1. **`erli-inbound-webhook-decoder.adapter.ts`** — `libs/integrations/erli/src/infrastructure/adapters/`.
    - File header per standards (purpose, ADR-021/ADR-025, the trigger-not-source-of-truth note like InPost).
    - `verify({ rawBody, headers, secret })`: implement the confirmed scheme (A1 token-compare or A2 HMAC). Always timing-safe (`crypto.timingSafeEqual`). Return `{ ok:false }` on any missing/mismatch; return `timestampMs` only if Erli sends a signature-covered timestamp.
-   - `extractEnvelope(rawBody, headers)`: parse JSON total-ly; `reject` on non-JSON/non-object/missing order id; build `InboundWebhookEnvelope` with `eventType` (mapped to `'orderCreated'|'orderStatusChanged'` so the translator's switch hits), `objectType:'order'`, `externalId` = the order id (defensive `unknown`→non-empty-string narrowing, same as the translator), `occurredAt`, and a deterministic `eventId` (A4). Use `ignore` (202) for a recognizable setup-ping/unknown-topic so Erli doesn't retry-storm.
+   - `extractEnvelope(rawBody, headers)`: parse JSON total-ly; `reject` on non-JSON/non-object/missing order id; build `InboundWebhookEnvelope` with `eventType` carrying the **raw Erli literal** (`'orderCreated'|'orderStatusChanged'`) because `ErliWebhookEventTranslator.resolveEventType` switches on exactly those strings. NB: the `^[a-z]+\.[a-z_]+$` dotted-format constraint lives only in `DefaultWebhookDecoder`'s `WebhookRequestDto` — it is NOT a host-wide envelope invariant, so emitting `orderStatusChanged` is fine. Set `objectType:'order'` (the translator hardcodes `domain:'order'` and ignores `objectType`, so this is host-event metadata only), `externalId` = the order id (defensive `unknown`→non-empty-string narrowing, same as the translator), `occurredAt`, and a deterministic `eventId` (A4). Use `ignore` (202) for a recognizable setup-ping/unknown-topic so Erli doesn't retry-storm.
    - **Acceptance**: pure + total; no `Logger`/DI/I/O; no secret ever logged.
 2. Reuse/extend `erli-webhook.types.ts` for confirmed header/field-name constants (don't inline literals in the adapter).
    - **Acceptance**: type-check clean; constants single-sourced.
@@ -134,6 +134,7 @@ Confirmed today:
    ```
    Update the adjacent comment (the current one says the path is dead until the decoder lands — flip it to "decoder live").
    - **Acceptance**: provider `'erli'` now resolves a native decoder instead of falling to the OL-HMAC default; `erli-plugin.spec.ts` asserts the registration.
+   - **Cross-check (insurance against a silent dead-letter)**: the decoder is `provider`-keyed (`'erli'`) but the downstream translator is `adapterKey`-keyed (`'erli.shopapi.v1'`) and the job handler resolves it via `metadata.adapterKey` (host-populated from the connection). Confirm the Erli connection's `adapterKey` resolves to `erli.shopapi.v1` so the existing translator is found after decode — the path already works for InPost, but verify it in the int-spec (Phase 4).
 
 ### Phase 3 — Unit tests
 **Steps**:
@@ -143,10 +144,12 @@ Confirmed today:
    - A "never logs the secret" assertion (mirror the provisioner spec).
    - **Acceptance**: full erli suite green; coverage ≥ adapter threshold (70%).
 
-### Phase 4 — Integration vertical slice (OPTIONAL)
+### Phase 4 — Integration vertical slice (RECOMMENDED — do unless time-boxed out)
 **Steps**:
-1. If time allows, an `apps/api` int-spec posting a signed Erli delivery to `POST /webhooks/erli/:connectionId` and asserting it verifies → publishes → routes to `marketplace.order.sync` (and that a tampered sig 401s). Otherwise rely on adapter unit specs + the existing core webhook int-specs (consciously noted, same call #1081 made for orders).
-   - **Acceptance**: green; or an explicit note in the PR that the slice was deferred.
+1. An `apps/api` int-spec posting a signed Erli delivery to `POST /webhooks/erli/:connectionId` and asserting it verifies → publishes → routes to `marketplace.order.sync`, **and that a tampered signature 401s**. This is the highest-value assertion because it proves the decoder is actually *wired* under `provider='erli'` (the registry-key-mismatch class of bug) and that the `adapterKey` translator-lookup resolves — neither is covered by unit tests. Since this is a signature-verification surface, bump it above a nice-to-have.
+   - No new plugin is added to `plugins.ts`, so the `jest-integration.cjs` `moduleNameMapper` guard (#917) should be a no-op — but confirm.
+   - If genuinely time-boxed out, fall back to adapter unit specs + the existing core webhook int-specs and **state the deferral explicitly in the PR** (same conscious call #1081 made for orders).
+   - **Acceptance**: green; or an explicit deferral note in the PR.
 
 ### Configuration / Migrations / Events
 - **Config**: none new (secret already provisioned; `callbackBaseUrl` already on the connection).
@@ -228,6 +231,9 @@ Confirmed today:
 ---
 
 ## Related Documentation
-- ADR-021 (inbound-webhook decoder pattern), ADR-025 (Erli reconciliation-first posture), ADR-015 (translator totality)
+- **ADR-021** — Third-party-native inbound webhook ingestion via a per-provider decoder (the pattern this implements).
+- **ADR-015** — Capability-driven, plugin-translated inbound webhook event routing (the translator's home; the decoder feeds it). Totality (never-throw) is the translator/decoder contract enforced here.
+- **ADR-025** — Erli reconciliation-first posture (poll authoritative, webhook is a nudge).
+- Cite ADR-021 + ADR-015 in the decoder file header. Do NOT copy InPost's ADR-008 reference — that's the auth-failure-classifier/reauth decision and is not relevant to this decoder.
 - `docs/plans/implementation-plan-erli-webhooks.md` (#996 parent), Issue #1145, PR #1081
 - InPost precedent: `libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts`

--- a/docs/plans/implementation-plan-erli-inbound-webhook-decoder.md
+++ b/docs/plans/implementation-plan-erli-inbound-webhook-decoder.md
@@ -1,0 +1,233 @@
+# Implementation Plan: Erli-native Inbound Webhook Decoder + Signature Verifier (#1145)
+
+**Date**: 2026-06-23
+**Status**: Draft / Ready for Review
+**Estimated Effort**: ~1.5 days code + 0.5 day sandbox spike (spike is blocking)
+**Issue**: #1145 (`Closes #1145`)
+**Depends on**: #1081 / #996 (branch `996-erli-webhooks`) — this branch is **stacked** on it; rebase onto `main` before final PR once #1081 merges.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Make the Erli inbound-webhook *receive* path functional by implementing an Erli-native `InboundWebhookDecoderPort` (signature verifier + envelope extractor) and registering it under `provider = 'erli'`, so real Erli deliveries authenticate and route through the **already-shipped** `ErliWebhookEventTranslator` → core routing policy → `marketplace.order.sync`.
+
+**Context**: #996 (PR #1081) shipped the Erli webhook *translator* + *provisioner* (`PUT /hooks` sets the shared `accessToken`), but the receive path is dead: the host's fail-closed OL-HMAC `DefaultWebhookDecoder` rejects 100% of real Erli deliveries because no Erli-native decoder is registered. This is an accepted reconciliation-first posture (the #993 inbox poll is authoritative, ADR-025), so order ingestion is unaffected — but webhooks contribute zero low-latency value until this lands. #1145 closes that gap.
+
+**Classification**: Integration (plugin-layer only). No CORE change, no migration, no frontend. Adds a second implementation of the existing `InboundWebhookDecoderPort` (the InPost adapter is the working precedent).
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- `ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPort` (`verify` + `extractEnvelope`).
+- Registration via `host.inboundWebhookDecoderRegistry.register('erli', …)` in `erli-plugin.ts`'s `register(host)`.
+- Unit tests mirroring the InPost decoder spec (valid sig, tampered sig, missing headers, malformed body, ignore vs reject, deterministic `eventId`).
+- A **blocking sandbox verification spike** (Phase 0) to confirm Erli's actual delivery auth scheme, captured as updated facts in `erli-webhook.types.ts` (drop the `#992-PROVISIONAL` flags it confirms).
+
+### Out of Scope
+- Changing the translator, provisioner, inbox poll, or any CORE contract.
+- Frontend (the connection-actions "Configure webhooks" affordance already exists for the provisioner).
+- An integration vertical-slice int-spec is **optional** (see Phase 4) — adapter unit tests + existing core webhook int-specs are the baseline gate.
+- A new ADR — #1145 is a routine second implementation of the existing **ADR-021** decoder pattern under the **ADR-025** reconciliation-first posture. No new architectural decision.
+
+### Constraints
+- Stacked on #1081; keep the diff limited to net-new Erli files + the one `register()` edit.
+- Decoder must be **pure + total** (ADR-015): never throw unbounded; `verify` → `{ ok, timestampMs? }`, `extractEnvelope` → `route | ignore | reject`.
+- Fail-closed: an unconfirmed/auth-failing delivery must `{ ok: false }` (401), never silently route.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: Integration — `libs/integrations/erli/src/infrastructure/adapters/`.
+
+**Capabilities / Ports Involved** (all existing — none new):
+- `InboundWebhookDecoderPort` — `libs/core/src/integrations/domain/ports/inbound-webhook-decoder.port.ts`. Two methods:
+  - `verify({ rawBody: Buffer; headers: Record<string,string>; secret: string }): WebhookVerifyResult` → `{ ok: boolean; timestampMs?: number }`.
+  - `extractEnvelope(rawBody: Buffer, headers: Record<string,string>): DecodeResult` → `{ action:'route'; envelope } | { action:'ignore'; reason } | { action:'reject'; reason }`.
+- `InboundWebhookDecoderRegistryService` — keyed by **`provider`** (the `/webhooks/:provider/:connectionId` path segment = `'erli'`), exposed as `host.inboundWebhookDecoderRegistry` (`libs/plugin-sdk/src/host-services.ts`).
+- `WebhookSecretProviderPort.getSecret(provider, connectionId)` — the **host** resolves the secret and passes it into `verify({ secret })`. The decoder does **not** fetch it (no NestJS DI needed in the decoder).
+
+**Existing Services Reused**:
+- `ErliWebhookEventTranslator` (already registered by `adapterKey`) — the decoder hands off to it downstream via the host pipeline; no direct call.
+- Host receive pipeline (`apps/api/src/webhooks/.../webhook.service.ts`): `decoder = registry.get(provider) ?? defaultDecoder` → `assertConnectionUsable` → `getSecret` → `verify` → replay-window check (only if `timestampMs` returned) → `extractEnvelope` → Postgres dedup on `(provider, connectionId, eventId)` → publish → (separate handler) translator → routing policy.
+
+**New Components Required**:
+- `erli-inbound-webhook-decoder.adapter.ts` (+ `__tests__/…spec.ts`).
+- One `register()` line in `erli-plugin.ts`.
+- Possibly small additions to `erli-webhook.types.ts` (confirmed header/field names from the spike).
+
+**Core vs Integration Justification**: Pure Integration. The signature scheme is Erli-specific; CORE already exposes the seam (port + registry + secret provider). Mirrors InPost (`InpostInboundWebhookDecoderAdapter`, registered `host.inboundWebhookDecoderRegistry.register('inpost', …)`).
+
+---
+
+## 4. External / Domain Research
+
+### Erli delivery auth scheme — ⚠️ THE load-bearing unknown (#992-BLOCKED)
+
+Confirmed today:
+- Provisioning works (`PUT /hooks/{orderCreated|orderStatusChanged}` body `{ url, accessToken }`, verified #992). The `url` is a single endpoint `…/webhooks/erli/{connectionId}` shared by both hooks.
+- The provisioner doc *hypothesizes* the `accessToken` (= the rotated webhook secret) is "echoed back on each delivery for signature verification."
+
+**NOT confirmed anywhere in the repo** (must come from the spike):
+1. Does Erli **HMAC-sign** deliveries, or just **echo the `accessToken`** as a shared bearer token? (changes `verify` from constant-time HMAC compare → constant-time token compare.)
+2. Header/field names carrying the signature/token and (if any) timestamp.
+3. Whether a timestamp is present and **covered** by the signature (drives whether we return `timestampMs` for the replay-window check — InPost returns it, the default decoder requires it; if Erli has none, we return `undefined` and the host skips replay).
+4. How a delivery signals **which hook fired** (`orderCreated` vs `orderStatusChanged`) — header? body `type` field? The translator reads `event.eventType` expecting exactly those literals, so the decoder must surface it.
+5. The delivery **body shape** (the translator/`erli-webhook.types.ts` assume id-only `{ orderId }`, also `#992-PROVISIONAL`).
+
+### Internal precedent (the template to copy)
+- `libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts` — HMAC-SHA256 (base64) over `{timestamp}.{rawBody}`, header `x-inpost-signature`/`x-inpost-timestamp`, `timestampMs = Date.parse(iso)`; `extractEnvelope` ignores non-matching topics (202), rejects malformed (400), derives a deterministic `eventId`. Stateless POJO, `new …Adapter()` with no args, registered in the plain `register(host)`.
+- Its spec (`__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts`) is the test template.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions (resolved by Phase 0 spike)
+- OQ-1..5 = the five unknowns in §4. **All are blocking for a shippable `verify()`.**
+
+### Assumptions (safe defaults if the spike is inconclusive)
+- **A1 (most likely)**: Erli echoes the `accessToken` (shared secret) on each delivery in a header (candidate names to probe: `x-erli-token`, `authorization`, `x-webhook-token`). `verify` = timing-safe compare of the echoed token against `secret`; **no** timestamp → `timestampMs: undefined` (replay-window skipped, acceptable because `eventId` Postgres dedup is the authoritative idempotency gate and the #993 poll backstops loss).
+- **A2 (fallback)**: If Erli HMAC-signs, copy the InPost HMAC path verbatim (swap header names + base64/hex per the spike).
+- **A3**: Event type rides a body field (`type`) or a per-hook header; if neither exists, default `eventType` to `'orderStatusChanged'` → translator maps to `'updated'` → a safe full re-pull (matches the translator's existing unknown→updated fallback).
+- **A4**: `eventId = sha256(connectionId + ':' + externalId + ':' + eventType)[:N]` (deterministic; collapses retries, distinguishes created vs status-changed). Correctness guarantee is the idempotent downstream re-read, so best-effort dedup suffices.
+
+### Documentation Gaps
+- `erli-webhook.types.ts` is entirely `#992-PROVISIONAL`. The spike confirms/repairs it; this plan's Phase 0 updates those facts in the same PR.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 0 — Sandbox verification spike (BLOCKING) 🔬
+**Goal**: Capture a real Erli sandbox delivery and confirm OQ-1..5.
+
+**Steps**:
+1. Stand up a public callback (ngrok/webhook.site) and provision a sandbox Erli connection's hooks at it (`callbackBaseUrl` → tunnel; reuse the existing provisioner).
+2. Trigger a sandbox order (or status change) so Erli fires a real delivery; capture **full headers + raw body** for both `orderCreated` and `orderStatusChanged`.
+3. Record: signature/token header name + format, timestamp presence/format/coverage, the field/header that distinguishes the hook, and the body shape.
+4. **Acceptance**: a written record of one real delivery per hook type; `erli-webhook.types.ts` updated to confirmed facts (provisional flags dropped for what's now verified). If the spike is genuinely impossible in sandbox, proceed under A1/A3 and label the decoder `PROVISIONAL` with a follow-up verify-in-staging task — but prefer confirming.
+
+> If you reach this phase and the spike cannot be completed, **stop and flag it** — shipping `verify()` on an unconfirmed scheme is the one thing that can make this worse than the status quo (false-accept = security hole).
+
+### Phase 1 — Decoder adapter
+**Steps**:
+1. **`erli-inbound-webhook-decoder.adapter.ts`** — `libs/integrations/erli/src/infrastructure/adapters/`.
+   - File header per standards (purpose, ADR-021/ADR-025, the trigger-not-source-of-truth note like InPost).
+   - `verify({ rawBody, headers, secret })`: implement the confirmed scheme (A1 token-compare or A2 HMAC). Always timing-safe (`crypto.timingSafeEqual`). Return `{ ok:false }` on any missing/mismatch; return `timestampMs` only if Erli sends a signature-covered timestamp.
+   - `extractEnvelope(rawBody, headers)`: parse JSON total-ly; `reject` on non-JSON/non-object/missing order id; build `InboundWebhookEnvelope` with `eventType` (mapped to `'orderCreated'|'orderStatusChanged'` so the translator's switch hits), `objectType:'order'`, `externalId` = the order id (defensive `unknown`→non-empty-string narrowing, same as the translator), `occurredAt`, and a deterministic `eventId` (A4). Use `ignore` (202) for a recognizable setup-ping/unknown-topic so Erli doesn't retry-storm.
+   - **Acceptance**: pure + total; no `Logger`/DI/I/O; no secret ever logged.
+2. Reuse/extend `erli-webhook.types.ts` for confirmed header/field-name constants (don't inline literals in the adapter).
+   - **Acceptance**: type-check clean; constants single-sourced.
+
+### Phase 2 — Registration
+**Steps**:
+1. In `erli-plugin.ts` `register(host)`, beside the existing translator registration, add:
+   ```ts
+   host.inboundWebhookDecoderRegistry.register(
+     erliAdapterManifest.platformType, // 'erli' — provider key, NOT ERLI_ADAPTER_KEY
+     new ErliInboundWebhookDecoderAdapter(),
+   );
+   ```
+   Update the adjacent comment (the current one says the path is dead until the decoder lands — flip it to "decoder live").
+   - **Acceptance**: provider `'erli'` now resolves a native decoder instead of falling to the OL-HMAC default; `erli-plugin.spec.ts` asserts the registration.
+
+### Phase 3 — Unit tests
+**Steps**:
+1. **`__tests__/erli-inbound-webhook-decoder.adapter.spec.ts`** mirroring the InPost spec:
+   - `verify`: valid (→ `ok:true`, `timestampMs` iff applicable); tampered token/signature → `ok:false`; missing header(s) → `ok:false`; (HMAC path) wrong-length guard.
+   - `extractEnvelope`: valid `orderCreated`/`orderStatusChanged` → `route` with correct `eventType`/`externalId`; deterministic `eventId` (same in → same out); unknown topic/ping → `ignore`; non-JSON / missing order id → `reject`.
+   - A "never logs the secret" assertion (mirror the provisioner spec).
+   - **Acceptance**: full erli suite green; coverage ≥ adapter threshold (70%).
+
+### Phase 4 — Integration vertical slice (OPTIONAL)
+**Steps**:
+1. If time allows, an `apps/api` int-spec posting a signed Erli delivery to `POST /webhooks/erli/:connectionId` and asserting it verifies → publishes → routes to `marketplace.order.sync` (and that a tampered sig 401s). Otherwise rely on adapter unit specs + the existing core webhook int-specs (consciously noted, same call #1081 made for orders).
+   - **Acceptance**: green; or an explicit note in the PR that the slice was deferred.
+
+### Configuration / Migrations / Events
+- **Config**: none new (secret already provisioned; `callbackBaseUrl` already on the connection).
+- **Migrations**: none.
+- **Events**: none new — reuses `events.inbound.webhooks` → `WebhookEventTranslator` → routing policy → `marketplace.order.sync`.
+- **Error handling**: rely on host mapping — `verify` false → 401, `reject` → 400, `ignore`/`route` → 202. No new exceptions.
+
+---
+
+## 7. Alternatives Considered
+
+- **A. Loosen the default OL-HMAC decoder to accept Erli** — rejected: pollutes the host with provider-specific logic, violates ADR-021's provider-keyed decoder seam, and couples CORE to Erli's scheme.
+- **B. Skip webhooks entirely, rely on the #993 poll** — rejected as the *end state* (webhooks are the low-latency win #1145 exists to deliver) but is exactly the safe fallback if the spike fails; that's why the poll stays authoritative (ADR-025).
+- **C. NestJS module for the decoder (like the provisioner)** — rejected: the decoder needs no injected services (the host passes `secret` into `verify`); a stateless POJO in `register(host)` is correct, matching InPost.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Hexagonal: Integration adapter implements a CORE port; CORE untouched.
+- ✅ Provider-keyed decoder per ADR-021; translator stays `adapterKey`-keyed.
+- ✅ Pure + total adapter (ADR-015); no DI/I/O/logging of secrets.
+
+### Naming Conventions
+- ✅ `erli-inbound-webhook-decoder.adapter.ts` / `ErliInboundWebhookDecoderAdapter` (matches `{System}{Capability}Adapter` + InPost sibling).
+
+### Risks
+- **R1 — unconfirmed scheme (HIGH)**: building `verify()` blind risks false-reject (status quo) or false-accept (security hole). **Mitigation**: Phase 0 is blocking; fail-closed default; never ship A1 to prod without confirmation.
+- **R2 — no timestamp ⇒ no replay window (MED)**: if Erli sends no signed timestamp, replay protection relies solely on the Postgres `eventId` dedup. **Mitigation**: deterministic `eventId` + idempotent downstream re-read + the poll backstop. Acceptable, documented.
+- **R3 — stacked-PR hygiene (LOW)**: diff carries #1081 until it merges. **Mitigation**: rebase onto `main` before final PR.
+- **R4 — event-type ambiguity (LOW)**: if the hook isn't distinguishable, default to `updated`/full re-pull (safe).
+
+### Edge Cases
+- Setup ping / unknown topic → `ignore` (202, no retry storm).
+- Body present but order id missing/blank → `reject` (400).
+- Verified request reaching extract without the expected fields → `reject` (don't fabricate).
+
+### Backward Compatibility
+- ✅ Additive — registering a native decoder only changes behavior for `provider='erli'` deliveries (currently 100% rejected). No other provider affected.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts` (mirrors InPost).
+- `erli-plugin.spec.ts` — assert decoder registered under `'erli'`.
+
+### Integration Tests
+- Optional `apps/api/test/integration/.../erli-webhook-receive.int-spec.ts` (Phase 4).
+
+### Mocking Strategy
+- Sign fixtures with a known secret via the confirmed scheme; call the adapter directly (no host needed for unit tests).
+
+### Acceptance Criteria
+- [ ] Phase 0 spike documented; `erli-webhook.types.ts` provisional flags resolved for confirmed facts.
+- [ ] `verify` authenticates a genuine delivery and rejects a tampered one (fail-closed).
+- [ ] `extractEnvelope` yields a translator-compatible envelope with deterministic `eventId`.
+- [ ] Decoder registered under `provider='erli'`; real deliveries no longer hit the default decoder.
+- [ ] Full erli suite green; type-check + lint + `check:invariants` clean.
+- [ ] `Closes #1145`; rebased onto `main` after #1081 merges.
+
+---
+
+## 10. Alignment Checklist
+- [x] Follows hexagonal architecture
+- [x] Respects CORE vs Integration boundaries (no CORE change)
+- [x] Uses existing patterns (InPost decoder; no new abstraction/ADR)
+- [x] Idempotency considered (deterministic `eventId` + Postgres dedup)
+- [x] Event-driven (reuses inbound-webhook stream + translator)
+- [x] Rate limits & retries addressed (`ignore` avoids retry storms; poll backstop)
+- [x] Error handling comprehensive (verify/reject/ignore → 401/400/202)
+- [x] Testing strategy complete
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready (modulo the blocking Phase 0 spike)
+
+---
+
+## Related Documentation
+- ADR-021 (inbound-webhook decoder pattern), ADR-025 (Erli reconciliation-first posture), ADR-015 (translator totality)
+- `docs/plans/implementation-plan-erli-webhooks.md` (#996 parent), Issue #1145, PR #1081
+- InPost precedent: `libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts`

--- a/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
+++ b/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
@@ -48,6 +48,7 @@ function makeRegisterHost(): {
   schedulerTaskRegistry: { register: jest.Mock };
   webhookEventTranslatorRegistry: { register: jest.Mock };
   webhookProvisioningRegistry: { register: jest.Mock };
+  inboundWebhookDecoderRegistry: { register: jest.Mock };
 } {
   const configRegistry = { register: jest.fn() };
   const credentialsRegistry = { register: jest.fn() };
@@ -58,6 +59,7 @@ function makeRegisterHost(): {
   const schedulerTaskRegistry = { register: jest.fn() };
   const webhookEventTranslatorRegistry = { register: jest.fn() };
   const webhookProvisioningRegistry = { register: jest.fn() };
+  const inboundWebhookDecoderRegistry = { register: jest.fn() };
   const hostStub = {
     connectionConfigShapeValidatorRegistry: configRegistry,
     connectionCredentialsShapeValidatorRegistry: credentialsRegistry,
@@ -68,6 +70,7 @@ function makeRegisterHost(): {
     schedulerTaskRegistry,
     webhookEventTranslatorRegistry,
     webhookProvisioningRegistry,
+    inboundWebhookDecoderRegistry,
   } as unknown as HostServices;
   return {
     host: hostStub,
@@ -80,6 +83,7 @@ function makeRegisterHost(): {
     schedulerTaskRegistry,
     webhookEventTranslatorRegistry,
     webhookProvisioningRegistry,
+    inboundWebhookDecoderRegistry,
   };
 }
 
@@ -231,6 +235,21 @@ describe('createErliPlugin', () => {
       expect(webhookEventTranslatorRegistry.register).toHaveBeenCalledWith(
         'erli.shopapi.v1',
         expect.objectContaining({ translate: expect.any(Function) }),
+      );
+    });
+
+    it('should register the native inbound webhook decoder under provider "erli" (#1145)', () => {
+      // Decoder is provider-keyed ('erli'), NOT adapterKey-keyed — the host
+      // resolves it by the /webhooks/:provider path segment (ADR-021).
+      const { host, inboundWebhookDecoderRegistry } = makeRegisterHost();
+      createErliPlugin().register?.(host);
+
+      expect(inboundWebhookDecoderRegistry.register).toHaveBeenCalledWith(
+        'erli',
+        expect.objectContaining({
+          verify: expect.any(Function),
+          extractEnvelope: expect.any(Function),
+        }),
       );
     });
 

--- a/libs/integrations/erli/src/erli-plugin.ts
+++ b/libs/integrations/erli/src/erli-plugin.ts
@@ -31,6 +31,7 @@ import { ErliConnectionConfigShapeValidatorAdapter } from './infrastructure/adap
 import { ErliConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/erli-connection-credentials-shape-validator.adapter';
 import { ErliConnectionTesterAdapter } from './infrastructure/adapters/erli-connection-tester.adapter';
 import { ErliEmailNormalizerAdapter } from './infrastructure/adapters/erli-email-normalizer.adapter';
+import { ErliInboundWebhookDecoderAdapter } from './infrastructure/adapters/erli-inbound-webhook-decoder.adapter';
 import { ErliRetryClassifierAdapter } from './infrastructure/adapters/erli-retry-classifier.adapter';
 import { ErliWebhookEventTranslator } from './infrastructure/adapters/erli-webhook-event-translator.adapter';
 import { buildErliSchedulerTasks } from './infrastructure/scheduler/erli-scheduler-tasks';
@@ -93,12 +94,17 @@ export function createErliPlugin(): AdapterPlugin {
       for (const task of buildErliSchedulerTasks()) {
         host.schedulerTaskRegistry.register(task);
       }
-      // Inbound webhook scaffolding (#996, ADR-015). The translator decodes
-      // Erli's id-only order webhooks into a neutral CanonicalInboundEvent the
-      // core routing policy maps to marketplace.order.sync. PROVISIONAL (#992):
-      // the host's fail-closed OL-HMAC default rejects 100% of real Erli
-      // webhooks until the native InboundWebhookDecoderPort lands, so this is
-      // fail-safe scaffolding — the #993 inbox poll is the authoritative path.
+      // Inbound webhook path (#996 translator + #1145 native decoder, ADR-021/015).
+      // Decoder (provider-keyed) authenticates Erli's `Authorization: Bearer
+      // {accessToken}` deliveries at ingress and decodes the id+status body into
+      // the neutral envelope; the translator (adapterKey-keyed) then maps the
+      // decoded event onto a CanonicalInboundEvent the core routing policy sends
+      // to marketplace.order.sync. The #993 inbox poll remains the authoritative
+      // ingestion path (ADR-025) — the webhook is a low-latency nudge.
+      host.inboundWebhookDecoderRegistry.register(
+        erliAdapterManifest.platformType,
+        new ErliInboundWebhookDecoderAdapter(),
+      );
       host.webhookEventTranslatorRegistry.register(
         ERLI_ADAPTER_KEY,
         new ErliWebhookEventTranslator(),

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts
@@ -105,7 +105,15 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
       expect(result.envelope.objectType).toBe('order');
       expect(result.envelope.eventId).toMatch(/^erli-[0-9a-f]{32}$/);
       expect(typeof result.envelope.occurredAt).toBe('string');
-      expect(result.envelope.payload).toEqual({ id: 'order-42', status: 'purchased' });
+      // Only the advisory status hint is forwarded — never the raw body.
+      expect(result.envelope.payload).toEqual({ status: 'purchased' });
+    });
+
+    it('should omit payload entirely when the body carries no status', () => {
+      const result = adapter.extractEnvelope(bodyBuf({ id: 'order-7' }), {});
+      expect(result.action).toBe('route');
+      if (result.action !== 'route') return;
+      expect(result.envelope.payload).toBeUndefined();
     });
 
     it('should derive a deterministic eventId from id + status', () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Erli Inbound Webhook Decoder Adapter Tests (#1145)
+ *
+ * Asserts the decode seam confirmed against the Erli Shop API docs (#992):
+ * `verify` is a timing-safe compare of the `Authorization: Bearer {accessToken}`
+ * token against the per-connection secret (no HMAC, no timestamp → no
+ * `timestampMs`); `extractEnvelope` reads the `{ id, status }` body, routes order
+ * events with a deterministic id+status `eventId`, ignores non-order bodies, and
+ * rejects malformed ones. The Bearer secret is never logged.
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
+ */
+import { ErliInboundWebhookDecoderAdapter } from '../erli-inbound-webhook-decoder.adapter';
+
+const SECRET = 'super-secret-erli-webhook-token-DO-NOT-LOG';
+
+function bodyBuf(value: unknown): Buffer {
+  return Buffer.from(typeof value === 'string' ? value : JSON.stringify(value), 'utf8');
+}
+
+describe('ErliInboundWebhookDecoderAdapter', () => {
+  let adapter: ErliInboundWebhookDecoderAdapter;
+
+  beforeEach(() => {
+    adapter = new ErliInboundWebhookDecoderAdapter();
+  });
+
+  describe('verify', () => {
+    it('should accept a matching Bearer token and return no timestampMs', () => {
+      const result = adapter.verify({
+        rawBody: bodyBuf({ id: 'o-1', status: 'pending' }),
+        headers: { authorization: `Bearer ${SECRET}` },
+        secret: SECRET,
+      });
+
+      expect(result).toEqual({ ok: true });
+      expect(result.timestampMs).toBeUndefined();
+    });
+
+    it('should be case-insensitive on the header name and the Bearer scheme', () => {
+      const result = adapter.verify({
+        rawBody: bodyBuf({ id: 'o-1' }),
+        headers: { Authorization: `bEaReR ${SECRET}` },
+        secret: SECRET,
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('should reject a wrong token', () => {
+      expect(
+        adapter.verify({
+          rawBody: bodyBuf({ id: 'o-1' }),
+          headers: { authorization: 'Bearer not-the-secret' },
+          secret: SECRET,
+        }),
+      ).toEqual({ ok: false });
+    });
+
+    it('should reject a missing Authorization header', () => {
+      expect(
+        adapter.verify({ rawBody: bodyBuf({ id: 'o-1' }), headers: {}, secret: SECRET }),
+      ).toEqual({ ok: false });
+    });
+
+    it('should reject a non-Bearer scheme', () => {
+      expect(
+        adapter.verify({
+          rawBody: bodyBuf({ id: 'o-1' }),
+          headers: { authorization: `Basic ${SECRET}` },
+          secret: SECRET,
+        }),
+      ).toEqual({ ok: false });
+    });
+
+    it('should reject an empty Bearer token', () => {
+      expect(
+        adapter.verify({
+          rawBody: bodyBuf({ id: 'o-1' }),
+          headers: { authorization: 'Bearer    ' },
+          secret: SECRET,
+        }),
+      ).toEqual({ ok: false });
+    });
+
+    it('should reject a token of a different length without throwing', () => {
+      expect(
+        adapter.verify({
+          rawBody: bodyBuf({ id: 'o-1' }),
+          headers: { authorization: 'Bearer short' },
+          secret: SECRET,
+        }),
+      ).toEqual({ ok: false });
+    });
+  });
+
+  describe('extractEnvelope', () => {
+    it('should route an order body, surfacing id as externalId and orderStatusChanged eventType', () => {
+      const result = adapter.extractEnvelope(bodyBuf({ id: 'order-42', status: 'purchased' }), {});
+
+      expect(result.action).toBe('route');
+      if (result.action !== 'route') return;
+      expect(result.envelope.externalId).toBe('order-42');
+      expect(result.envelope.eventType).toBe('orderStatusChanged');
+      expect(result.envelope.objectType).toBe('order');
+      expect(result.envelope.eventId).toMatch(/^erli-[0-9a-f]{32}$/);
+      expect(typeof result.envelope.occurredAt).toBe('string');
+      expect(result.envelope.payload).toEqual({ id: 'order-42', status: 'purchased' });
+    });
+
+    it('should derive a deterministic eventId from id + status', () => {
+      const a = adapter.extractEnvelope(bodyBuf({ id: 'order-42', status: 'purchased' }), {});
+      const b = adapter.extractEnvelope(bodyBuf({ id: 'order-42', status: 'purchased' }), {});
+      expect(a.action).toBe('route');
+      expect(b.action).toBe('route');
+      if (a.action !== 'route' || b.action !== 'route') return;
+      expect(a.envelope.eventId).toBe(b.envelope.eventId);
+    });
+
+    it('should distinguish different status transitions for the same order', () => {
+      const shipped = adapter.extractEnvelope(bodyBuf({ id: 'order-42', status: 'shipped' }), {});
+      const cancelled = adapter.extractEnvelope(
+        bodyBuf({ id: 'order-42', status: 'cancelled' }),
+        {},
+      );
+      if (shipped.action !== 'route' || cancelled.action !== 'route') {
+        throw new Error('expected both to route');
+      }
+      expect(shipped.envelope.eventId).not.toBe(cancelled.envelope.eventId);
+    });
+
+    it('should ignore a well-formed body with no order id (e.g. productsNeedSync / ping)', () => {
+      const result = adapter.extractEnvelope(
+        bodyBuf({ externalProductIds: ['123'], fields: ['status'] }),
+        {},
+      );
+      expect(result.action).toBe('ignore');
+    });
+
+    it('should reject a non-JSON body', () => {
+      expect(adapter.extractEnvelope(bodyBuf('not json'), {}).action).toBe('reject');
+    });
+
+    it('should reject a non-object JSON body', () => {
+      expect(adapter.extractEnvelope(bodyBuf('123'), {}).action).toBe('reject');
+    });
+
+    it('should ignore a body whose id is blank', () => {
+      expect(adapter.extractEnvelope(bodyBuf({ id: '   ' }), {}).action).toBe('ignore');
+    });
+  });
+
+  it('should NEVER log the secret across any channel', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => undefined);
+
+    adapter.verify({
+      rawBody: bodyBuf({ id: 'o-1', status: 'pending' }),
+      headers: { authorization: `Bearer ${SECRET}` },
+      secret: SECRET,
+    });
+    adapter.extractEnvelope(bodyBuf({ id: 'o-1', status: 'pending' }), {});
+
+    const allLogged = [logSpy, warnSpy, errorSpy, debugSpy]
+      .flatMap((spy) => spy.mock.calls)
+      .flatMap((call) => call.map((arg) => String(arg)))
+      .join('\n');
+
+    expect(allLogged).not.toContain(SECRET);
+
+    jest.restoreAllMocks();
+  });
+});

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-webhook-event-translator.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-webhook-event-translator.adapter.spec.ts
@@ -21,7 +21,7 @@ function makeEvent(overrides: Partial<InboundWebhookEvent> = {}): InboundWebhook
     receivedAt: '2026-06-16T10:00:01.000Z',
     objectType: 'order',
     externalId: 'erli-order-fake-123',
-    payload: { orderId: 'erli-order-fake-123' },
+    payload: { id: 'erli-order-fake-123' },
     ...overrides,
   };
 }
@@ -41,7 +41,7 @@ describe('ErliWebhookEventTranslator', () => {
       externalId: 'erli-order-fake-123',
       eventType: 'created',
       occurredAt: '2026-06-16T10:00:00.000Z',
-      payload: { orderId: 'erli-order-fake-123' },
+      payload: { id: 'erli-order-fake-123' },
     });
   });
 
@@ -53,7 +53,7 @@ describe('ErliWebhookEventTranslator', () => {
 
   it('should fall back to the payload order-id field when externalId is empty', () => {
     const result = translator.translate(
-      makeEvent({ externalId: '', payload: { orderId: 'erli-order-fake-999' } }),
+      makeEvent({ externalId: '', payload: { id: 'erli-order-fake-999' } }),
     );
 
     expect(result).toMatchObject({ domain: 'order', externalId: 'erli-order-fake-999' });
@@ -61,11 +61,11 @@ describe('ErliWebhookEventTranslator', () => {
 
   it('should pass occurredAt and payload through unchanged', () => {
     const result = translator.translate(
-      makeEvent({ occurredAt: '2026-01-01T00:00:00.000Z', payload: { orderId: 'x-1', extra: 7 } }),
+      makeEvent({ occurredAt: '2026-01-01T00:00:00.000Z', payload: { id: 'x-1', extra: 7 } }),
     );
 
     expect(result?.occurredAt).toBe('2026-01-01T00:00:00.000Z');
-    expect(result?.payload).toEqual({ orderId: 'x-1', extra: 7 });
+    expect(result?.payload).toEqual({ id: 'x-1', extra: 7 });
   });
 
   it('should return null for an unknown event type without throwing', () => {
@@ -82,7 +82,7 @@ describe('ErliWebhookEventTranslator', () => {
   });
 
   it('should return null when the order id is a blank / whitespace string', () => {
-    const result = translator.translate(makeEvent({ externalId: '   ', payload: { orderId: '  ' } }));
+    const result = translator.translate(makeEvent({ externalId: '   ', payload: { id: '  ' } }));
 
     expect(result).toBeNull();
   });
@@ -91,7 +91,7 @@ describe('ErliWebhookEventTranslator', () => {
     const result = translator.translate(
       makeEvent({
         externalId: '',
-        payload: { orderId: 42 as unknown as string },
+        payload: { id: 42 as unknown as string },
       }),
     );
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-inbound-webhook-decoder.adapter.ts
@@ -113,7 +113,12 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
         occurredAt: new Date().toISOString(),
         objectType: 'order',
         externalId,
-        payload: record,
+        // Forward ONLY the advisory status hint — never the raw body. The order
+        // is re-pulled authoritatively downstream (trigger-not-truth), so a
+        // minimal payload avoids carrying any field Erli might add later onto
+        // the published event (mirrors the order mapper's PII-off-metadata
+        // discipline; InPost forwards no payload at all).
+        ...(status ? { payload: { status } } : {}),
       },
     };
   }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-inbound-webhook-decoder.adapter.ts
@@ -1,0 +1,154 @@
+/**
+ * Erli Inbound Webhook Decoder Adapter (#1145, ADR-021)
+ *
+ * Authenticates + decodes Erli order webhooks at the host ingress, keyed by
+ * `provider = 'erli'`. Closes the dead receive path left by #996: without a
+ * native decoder the host's fail-closed OL-HMAC default rejected 100% of real
+ * Erli deliveries.
+ *
+ * verify (confirmed against the Erli Shop API docs, https://erli.pl/svc/shop-api/doc/):
+ * Erli authenticates each delivery with `Authorization: Bearer {accessToken}`,
+ * echoing back the exact shared secret OL set via `PUT /hooks` — there is NO
+ * HMAC signature and NO timestamp. So verify is a timing-safe compare of the
+ * Bearer token against the per-connection secret the host resolves via
+ * `WebhookSecretProviderPort` and passes in. With no signed timestamp we return
+ * no `timestampMs`, so the host's shared replay-window check is correctly
+ * skipped (the `eventId` Postgres dedup + the #993 poll are the safety net).
+ *
+ * extract: the body is `{ id, status }` (id = external order id). We read ONLY
+ * the id (and status, for dedup) — never trust the wire status as state. The
+ * body carries no created-vs-updated discriminator, so we emit `orderStatusChanged`
+ * (→ translator `updated` → a full re-pull via `getOrder`). ADR-015
+ * trigger-not-truth: an imperfect payload degrades to a redundant re-read,
+ * never wrong state.
+ *
+ * Totality (ADR-015): verify/extract never throw; extract returns
+ * route | ignore | reject. The Bearer secret is never logged (no logging here).
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters
+ * @see {@link InboundWebhookDecoderPort} for the port interface
+ * @see {@link ErliWebhookEventTranslator} for the downstream (adapterKey-keyed) translator
+ */
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type {
+  DecodeResult,
+  InboundWebhookDecoderPort,
+  WebhookVerifyResult,
+} from '@openlinker/core/integrations';
+import {
+  ERLI_WEBHOOK_ORDER_ID_FIELD,
+  ERLI_WEBHOOK_ORDER_STATUS_FIELD,
+  type ErliWebhookEventType,
+} from './erli-webhook.types';
+
+const AUTHORIZATION_HEADER = 'authorization';
+const BEARER_PREFIX = 'bearer ';
+
+/**
+ * The body carries no created-vs-updated discriminator (both hooks POST the same
+ * shape to the same URL), so every Erli webhook decodes to `orderStatusChanged`
+ * → the translator maps it to `updated` → a safe full re-pull. Typed against the
+ * hook-name union so a vocabulary change is caught at compile time.
+ */
+const DEFAULT_EVENT_TYPE: ErliWebhookEventType = 'orderStatusChanged';
+
+export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPort {
+  verify(input: {
+    rawBody: Buffer;
+    headers: Record<string, string>;
+    secret: string;
+  }): WebhookVerifyResult {
+    const authorization = this.header(input.headers, AUTHORIZATION_HEADER);
+    if (!authorization || !authorization.toLowerCase().startsWith(BEARER_PREFIX)) {
+      return { ok: false };
+    }
+    const token = authorization.slice(BEARER_PREFIX.length).trim();
+    if (token.length === 0) {
+      return { ok: false };
+    }
+
+    // Timing-safe compare against the per-connection shared secret. Guard length
+    // first — timingSafeEqual throws on unequal-length buffers.
+    const provided = Buffer.from(token);
+    const expected = Buffer.from(input.secret);
+    if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+      return { ok: false };
+    }
+
+    // Erli sends no signed timestamp, so we return none → the host skips the
+    // shared replay-window check (eventId dedup + #993 poll backstop instead).
+    return { ok: true };
+  }
+
+  extractEnvelope(rawBody: Buffer, _headers: Record<string, string>): DecodeResult {
+    let body: unknown;
+    try {
+      body = JSON.parse(rawBody.toString('utf8'));
+    } catch {
+      return { action: 'reject', reason: 'body is not valid JSON' };
+    }
+    if (typeof body !== 'object' || body === null) {
+      return { action: 'reject', reason: 'body is not a JSON object' };
+    }
+
+    const record = body as Record<string, unknown>;
+    const externalId = this.nonEmptyString(record[ERLI_WEBHOOK_ORDER_ID_FIELD]);
+    if (externalId === null) {
+      // Well-formed JSON object but no order id — not an order webhook (e.g. a
+      // productsNeedSync delivery or a setup ping). Ack-and-ignore (202) rather
+      // than 400 so non-order traffic isn't treated as malformed.
+      return { action: 'ignore', reason: 'no order id in webhook body' };
+    }
+
+    const status = this.nonEmptyString(record[ERLI_WEBHOOK_ORDER_STATUS_FIELD]) ?? '';
+
+    return {
+      action: 'route',
+      envelope: {
+        eventId: this.deriveEventId(externalId, status),
+        eventType: DEFAULT_EVENT_TYPE,
+        // Erli sends no event timestamp; stamp decode-time so the required
+        // `occurredAt` is populated. Advisory only (the re-pull is authoritative)
+        // and deliberately NOT part of `eventId`, so true retries still dedup.
+        occurredAt: new Date().toISOString(),
+        objectType: 'order',
+        externalId,
+        payload: record,
+      },
+    };
+  }
+
+  /**
+   * Deterministic dedup key from the stable body fields `id` + `status`. Same
+   * order + same status collapses true retries; a distinct transition
+   * (pending → shipped → cancelled) yields a distinct id. Best-effort — the
+   * idempotent downstream re-read is the correctness guarantee.
+   */
+  private deriveEventId(externalId: string, status: string): string {
+    const hash = createHash('sha256').update(`${externalId}:${status}`).digest('hex').slice(0, 32);
+    return `erli-${hash}`;
+  }
+
+  /**
+   * Case-insensitive header lookup. The host normally lowercases header names,
+   * but Erli's exact casing on `Authorization` is not separately confirmed
+   * (#1145 residual), so we match defensively regardless of casing.
+   */
+  private header(headers: Record<string, string>, name: string): string | null {
+    const target = name.toLowerCase();
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() === target) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  private nonEmptyString(value: unknown): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+}

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-webhook.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-webhook.types.ts
@@ -1,66 +1,75 @@
 /**
  * Erli Webhook Wire Types
  *
- * Provisional shapes for Erli's inbound *webhook* bodies — the low-latency
- * trigger path (#996) that complements the mandatory inbox poll (#993). Models
- * the two order-relevant event literals and the id-only webhook body shape.
+ * Shapes for Erli's inbound *webhook* bodies — the low-latency trigger path
+ * (#996) that complements the mandatory inbox poll (#993). Models the two
+ * order-relevant hook names and the id+status webhook body shape.
  *
- * PROVISIONAL (#992): the webhook body shape, the field that carries the order
- * id, the event-type discriminator vocabulary (`orderCreated` /
- * `orderStatusChanged`), and the signature/header scheme are ALL UNCONFIRMED
- * until the sandbox spike. This file is the SINGLE reconciliation point for
- * every webhook wire assumption — `ErliWebhookEventTranslator` (and the future
- * native `InboundWebhookDecoderPort`, the load-bearing #992 follow-up) read
- * webhook shapes only from here, so confirming the spike is a one-file edit.
+ * Confirmed against the official Erli Shop API docs (https://erli.pl/svc/shop-api/doc/,
+ * the #992 follow-up #1145):
+ *   - Delivery auth is `Authorization: Bearer {accessToken}` — Erli echoes the
+ *     exact shared secret set via `PUT /hooks`. There is NO HMAC signature, NO
+ *     timestamp header, and NO timestamp in the body.
+ *   - The delivery body is `{ "id": "...", "status": "..." }` — the order id
+ *     rides `id` (NOT `orderId`), alongside the seller-facing `status`.
+ *   - The body carries NO event-type discriminator: `orderCreated` and
+ *     `orderStatusChanged` are registered hook NAMES (`ErliWebhookEventTypeValues`,
+ *     used by the provisioner) but both POST the same shape to the same URL, so
+ *     the native decoder cannot tell them apart from the body and defaults to a
+ *     re-pull (ADR-015 trigger-not-truth — the #993 poll re-reads authoritative
+ *     state regardless).
  *
- * When #992 lands, these symbols flip:
- *   - `ErliWebhookEventTypeValues` — the literal discriminator strings.
- *   - `ERLI_WEBHOOK_ORDER_ID_FIELD` — the body field carrying the order id.
- *   - `ErliWebhookBody` — the full provisional body shape.
- * (The webhook event-type vocabulary is intentionally mirrored against the
- * inbox vocabulary in `erli-inbox.types.ts`; they are distinct wire surfaces
- * that #992 may reconcile to a single source.)
+ * This file is the SINGLE reconciliation point for every webhook wire assumption
+ * — `ErliWebhookEventTranslator` and `ErliInboundWebhookDecoderAdapter` read
+ * webhook shapes only from here.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  */
 
 /**
- * Order-relevant webhook event-type discriminators (#992-PROVISIONAL).
+ * Order-relevant webhook hook names registered via `PUT /hooks/{hookName}`.
  *
- * `as const` + union per engineering standards — no runtime enum.
+ * NOTE: these are the registration/hook-name vocabulary, NOT a body field — the
+ * delivery body does not echo which hook fired (see file header). `as const` +
+ * union per engineering standards (no runtime enum).
  */
 export const ErliWebhookEventTypeValues = ['orderCreated', 'orderStatusChanged'] as const;
 
 export type ErliWebhookEventType = (typeof ErliWebhookEventTypeValues)[number];
 
 /**
- * The body field carrying the external order id (#992-PROVISIONAL).
- *
- * Erli webhooks are id-only triggers (ADR-015 trigger-not-truth): the body
- * carries the order id, not the full order, which is pulled downstream by the
- * `marketplace.order.sync` job via `ErliOrderSourceAdapter.getOrder`.
+ * The body field carrying the external order id — confirmed `id` (#1145, Erli
+ * Shop API docs). Erli webhooks are id-only triggers (ADR-015 trigger-not-truth):
+ * the order is pulled downstream by `marketplace.order.sync` via
+ * `ErliOrderSourceAdapter.getOrder`; the body is never the source of truth.
  */
-export const ERLI_WEBHOOK_ORDER_ID_FIELD = 'orderId';
+export const ERLI_WEBHOOK_ORDER_ID_FIELD = 'id';
 
 /**
- * Provisional id-only Erli webhook body (#992-PROVISIONAL).
- *
- * Modelled as a generic record because the exact field set is unconfirmed; the
- * translator narrows it defensively from `unknown` rather than trusting the
- * declared shape (the id originates from an untrusted body in the future
- * native-decoder path).
+ * The body field carrying the seller-facing order status (#1145). Advisory only
+ * — used to discriminate distinct status transitions for dedup (`eventId`),
+ * never trusted as authoritative state.
+ */
+export const ERLI_WEBHOOK_ORDER_STATUS_FIELD = 'status';
+
+/**
+ * Erli webhook delivery body: `{ id, status }` (#1145). Modelled defensively —
+ * the decoder narrows both fields from `unknown` rather than trusting the
+ * declared shape (the body is untrusted until the Bearer token is verified).
  */
 export interface ErliWebhookBody {
-  /** External Erli order id — field name provisional (`ERLI_WEBHOOK_ORDER_ID_FIELD`). */
+  /** External Erli order id (`ERLI_WEBHOOK_ORDER_ID_FIELD`). */
   [ERLI_WEBHOOK_ORDER_ID_FIELD]: string;
+  /** Seller-facing order status (`ERLI_WEBHOOK_ORDER_STATUS_FIELD`); advisory. */
+  status?: string;
 }
 
 /**
  * Webhook registration (#996), verified against the live Erli Shop API (#992).
  * `PUT /hooks/{hookName}` registers a callback `{ url, accessToken }`; the
- * `accessToken` is the shared secret Erli echoes back on each delivery for
- * signature verification. hookName enum (full): `checkBuyability`,
- * `productsNeedSync`, `orderCreated`, `orderStatusChanged`,
+ * `accessToken` is the shared secret Erli echoes back on each delivery in the
+ * `Authorization: Bearer` header for verification (#1145). hookName enum (full):
+ * `checkBuyability`, `productsNeedSync`, `orderCreated`, `orderStatusChanged`,
  * `orderSellerStatusChanged`. The provisioner registers the two order-relevant
  * hooks (`orderCreated`, `orderStatusChanged` — `ErliWebhookEventTypeValues`).
  */


### PR DESCRIPTION
## Erli-native inbound-webhook decoder + signature verifier (#1145)

Closes the dead receive path left by #996: the host's fail-closed OL-HMAC default decoder rejected 100% of real Erli deliveries because no Erli-native `InboundWebhookDecoderPort` was registered. Now real deliveries authenticate and route through the existing `ErliWebhookEventTranslator` → core routing policy → `marketplace.order.sync`.

Pure Integration — **no CORE change, no migration, no frontend**. Second implementation of the existing ADR-021 decoder port; mirrors the InPost precedent.

> **Stacked on #1081** (`996-erli-webhooks`) — based on that branch so this diff shows only the #1145 delta. Rebase onto `main` once #1081 merges.

### Scheme — confirmed against the official Erli Shop API docs
The #992 follow-up resolved the blocking unknown via [erli.pl/svc/shop-api/doc](https://erli.pl/svc/shop-api/doc/) (authoritative published contract; a live sandbox capture was consciously skipped — see Testing):

- **Delivery auth is `Authorization: Bearer {accessToken}`** — Erli echoes back the exact secret OL set via `PUT /hooks`. **No HMAC, no signature, no timestamp.** `verify()` is a length-guarded **timing-safe compare** of the Bearer token against the per-connection secret (`getSecret('erli', connectionId)`), case-insensitive on header name + scheme. Returns no `timestampMs`, so the host correctly skips the replay-window check.
- **Body is `{ id, status }`** — order id rides **`id`** (NOT `orderId`). This corrected a latent bug: the provisional `ERLI_WEBHOOK_ORDER_ID_FIELD` was `'orderId'`, so the translator would have dead-lettered every real delivery. Fixed in the types + translator spec.
- **No event-type discriminator in the body** → emit `orderStatusChanged` → `updated` → a full re-pull via `getOrder` (ADR-015 trigger-not-truth). `OrderIngestionService` upserts, so a genuine `orderCreated` arriving as `updated` still creates the order.
- **`eventId = sha256(id:status)`** — collapses true retries, distinguishes transitions without a wire timestamp. `occurredAt` is decode-time stamped (advisory) and deliberately excluded from `eventId`.
- Forwarded `payload` narrowed to `{ status }` (or omitted) — never the raw body (PII-off-metadata discipline).

### Process
Plan → tech-review(plan) → pre-implement gate → implement → tech-review(impl), fixing all findings after each review. Plan + analysis docs are in `docs/plans/` on the branch.

### Testing
- **erli suite 250/250 green**, package type-check + changed-file lint clean.
- Decoder unit spec: verify (accept / wrong / missing / non-Bearer / empty / length / case-insensitive), extract (route / ignore / reject / deterministic + transition-distinct `eventId` / payload narrowing), never-logs-secret.
- Plugin spec asserts the decoder is registered under `provider='erli'` with the `verify`+`extractEnvelope` shape.
- **Integration vertical-slice (Phase 4) consciously DEFERRED**: the plugin-spec registration assertion proves the wiring under `provider='erli'`; the verify→401 / decode→publish→route pipeline is generic host logic already covered by core webhook int-specs; and the #993 inbox poll remains the authoritative ingestion path (ADR-025) so residual doc-vs-reality drift never loses orders. Worth adding when the Erli orders E2E harness lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
