### PR TITLE
feat(invoicing): RegulatoryTransmitter + RegulatoryStatusReader sub-capabilities (#1143)

### DIFF
--- a/docs/architecture/adrs/026-country-agnostic-invoicing-domain.md
+++ b/docs/architecture/adrs/026-country-agnostic-invoicing-domain.md
@@ -95,3 +95,9 @@ sequenceDiagram
 - Related ADRs: [ADR-002](./002-capability-ports-with-sub-capabilities.md) (sub-capability composition), [ADR-024](./024-destination-listing-capabilities.md) (capability-port precedent), [ADR-009](./009-persisted-offer-status-snapshots.md) (reconciled-status precedent)
 - Standards: EN 16931 (semantic invoice model), UNTDID 1001 (document types), UNCL 5305 (tax categories), ISO 6523 / ISO 4217; CTC taxonomy (post-audit / clearance / real-time reporting)
 - Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md)
+
+## Amendments
+
+> ADRs are append-only — the notes below **refine deferred details**, they do not change the decision.
+
+**Amendment (2026-06-23, #1143).** The deferred `RegulatoryTransmitter` interface (Decision 2) is realized as **two** ADR-002 sub-capabilities: a read-only `RegulatoryStatusReader` (`getClearanceStatus`) and `RegulatoryTransmitter extends RegulatoryStatusReader` (adds `submitForClearance`). Providers that transmit natively and only expose status (Subiekt → KSeF, #1121) implement the reader alone; providers OL submits to directly implement the full transmitter. Across CTC regimes (PL KSeF, IT SDI, FR PA, Peppol) and compliance vendors, "submit for clearance" and "read clearance status" are consistently distinct operations — Poland even makes `InvoiceRead`/`InvoiceWrite` independently grantable permissions — and the authority reference (KSeF number / SDI id) is knowable only by reading post-submit, so a transmitter is necessarily also a reader (the `extends` is a genuine `is-a`). Both methods return a neutral `RegulatoryClearanceResult` (`regulatoryStatus` + optional `clearanceReference`); a business verdict incl. `rejected` is returned as data, a transport/infra failure throws. This refines, not changes, Decision 2 — it fills the interface ADR-026 deferred to the KSeF issue.

--- a/docs/plans/analysis/ANALYSIS-regulatory-transmitter-capability.md
+++ b/docs/plans/analysis/ANALYSIS-regulatory-transmitter-capability.md
@@ -1,0 +1,59 @@
+# Pre-Implement Analysis — RegulatoryTransmitter sub-capability port + guard (#1143)
+
+**Plan:** `docs/plans/implementation-plan-regulatory-transmitter-capability.md`
+**Gate date:** 2026-06-23
+**Verdict:** ✅ **READY**
+
+Pure additive domain change (capability interfaces + guards + one neutral type + barrel exports). No reuse collision, no contract-surface break, no token, no ORM/migration. The codebase already *anticipates* this interface in doc-comments (`InvoicingPort`, `InvoiceRecord`, the migration) — #1143 fills a pre-described gap.
+
+---
+
+## Reuse findings
+
+| Plan artifact | Verdict | Evidence |
+|---|---|---|
+| `RegulatoryStatusReader` interface + `isRegulatoryStatusReader` | **NEW (confirmed absent)** | grep across `libs`/`apps` finds the symbol nowhere. |
+| `RegulatoryTransmitter` interface + `isRegulatoryTransmitter` | **NEW (confirmed absent)** | The only `RegulatoryTransmitter` hits are **doc-comment references** in `invoicing.port.ts:10,38`, `invoice-record.entity.ts:7`, `invoice-record.orm-entity.ts:6`, and `1808000000000-create-invoice-records.ts:8` — no actual interface declaration. The interface is genuinely new; the comments forward-reference exactly this issue. |
+| `RegulatoryClearanceResult` type | **NEW (confirmed absent)** | grep finds no definition; goes into the existing `invoicing.types.ts` (additive). |
+| `RegulatoryStatus` / `RegulatoryStatusValues` (the neutral CTC lifecycle) | **ALREADY EXISTS → reuse** | `libs/core/src/invoicing/domain/types/invoicing.types.ts:42-49` (from #751). The plan reuses, does not redefine. |
+| `InvoiceRecord` entity (method param) | **ALREADY EXISTS → reuse** | `libs/core/src/invoicing/domain/entities/invoice-record.entity.ts` — carries `regulatoryStatus` + `clearanceReference`. |
+| `capabilities/` directory under invoicing `domain/ports/` | **NEW (confirmed absent)** | Absent today; creating it mirrors `orders`/`listings`/`shipping` (`domain/ports/capabilities/`). |
+| Barrel exports for the two capability modules | **NEW (additive)** | `index.ts` currently exports 9 lines; plan adds 2 `export *` lines. |
+| DI token | **N/A — none introduced** | Plan explicitly: no token (capability-resolved per-connection via the guards). `invoicing.tokens.ts` holds only `INVOICE_RECORD_REPOSITORY_TOKEN`, untouched. |
+
+**No port/service/token/ORM/helper is reinvented.** The neutral lifecycle, the record, and the columns the methods drive all already ship.
+
+---
+
+## Backward-compatibility findings
+
+### 🟢 Top-level barrel — additive only (not Critical)
+- `@openlinker/core/invoicing` gains two `export *` lines (the capability modules + `RegulatoryClearanceResult` rides the existing `invoicing.types` star export). **No symbol removed or renamed** → no break.
+
+### 🟢 Port signatures — unchanged
+- `InvoicingPort` is **not** modified. The sub-capabilities are optional, adapter-declared interfaces narrowed via guards — exactly the `OfferManagerPort` sub-capability idiom. No implementer breaks.
+
+### 🟢 Symbol tokens — none added/changed
+- No token (per plan). `invoicing.tokens.ts` untouched → token-convention invariant unaffected.
+
+### 🟢 ORM schema / migration — none
+- `regulatoryStatus` + `clearanceReference` already exist on `invoice-record.orm-entity.ts` (migration `1808000000000-create-invoice-records.ts`, from #751). ADR-026's "no later migration" guarantee holds. **No migration.**
+
+### 🟢 `check:invariants` — no new violations
+- **cross-context:** the new capability files import only same-context symbols (`InvoicingPort`, `InvoiceRecord`, `RegulatoryClearanceResult`/`RegulatoryStatus`) via relative paths ≤ `../..` — matching the existing `offer-creator.capability.ts` / `fulfillment-status-reader.capability.ts` style. No cross-context edge added.
+- **check-service-interfaces:** no application service added → unaffected.
+- **No automated neutral-vocabulary script exists** (the issue AC's "neutral-vocabulary checks" overstates `check:invariants`, which has cross-context but no `nip`/`ksef` litmus). The litmus is review-enforced; plan keeps the files neutral. Not introducing a new invariant script (out of scope) is the correct call.
+
+---
+
+## Open questions
+
+1. **`extends` vs two independent flat capabilities** — *resolved in the plan* (§2 "Why `extends`"). Deep research (codebase + CTC domain) confirmed: OL's flat idiom holds because prior read/write pairs are *orthogonal*; the regulatory pair is a genuine `is-a` (submit logically entails read — the KSeF/SDI reference is knowable only by reading post-submit), so `extends` is the correct first capability-inheritance in the codebase, as a bounded documented exception. Not a blocker.
+2. **#1121 coordination** — #1121 (collaborator, open/unclaimed) needs `RegulatoryStatusReader`; #1143 defines it here so #1121 only *consumes* it. The plan ships a coordination comment + a one-line ADR-026 amendment. If #1121's author later prefers a single fat interface, it is a one-file delta. Low risk, surfaced.
+
+Neither blocks a clean implementation.
+
+---
+
+## Summary
+The plan is purely additive within the `invoicing` context: two new ADR-002 sub-capability interfaces (`RegulatoryStatusReader` + `RegulatoryTransmitter extends` it), their `is{Capability}` guards, one neutral `RegulatoryClearanceResult` type folded into the existing `invoicing.types.ts`, and two additive barrel exports. Nothing is reinvented (the neutral `RegulatoryStatus` lifecycle, `InvoiceRecord`, and the persistence columns all already exist), nothing is removed or renamed, there is no token and no migration, and no `check:invariants` rule is tripped. The one design choice (`extends` for a genuine read⊂transmit subset) is research-backed and documented. **Verdict: READY** — proceed to implementation.

--- a/docs/plans/implementation-plan-regulatory-transmitter-capability.md
+++ b/docs/plans/implementation-plan-regulatory-transmitter-capability.md
@@ -1,0 +1,239 @@
+# Implementation Plan — RegulatoryTransmitter sub-capability port + guard (#1143)
+
+**Branch:** `1143-regulatory-transmitter-capability`
+**Epic:** #1142 (KSeF e-invoicing), child C1
+**Layer:** CORE (invoicing domain — ports/capabilities + types + barrel; no infra, no service, no migration)
+**Design source:** [ADR-026 §Decision.2](../architecture/adrs/026-country-agnostic-invoicing-domain.md) + [ADR-002](../architecture/adrs/002-capability-ports-with-sub-capabilities.md)
+
+## 1. Goal & non-goals
+
+Define the deferred **regulatory clearance** sub-capability(ies) on the invoicing
+`InvoicingPort`, as the neutral seam every CTC regime (KSeF / IT SDI / ES SII)
+maps onto. `InvoiceRecord` already carries the persistence columns
+(`regulatoryStatus`, `clearanceReference`, from #751) — this issue adds the
+**interface + guard** that describes who populates them.
+
+**Non-goals (explicit):** any KSeF/provider implementation (C5/C6); the
+reconciliation worker job (#1121); any service wiring or `InvoiceService` change;
+any ORM/migration (columns exist, nullable — ADR-026 guarantees no schema change).
+
+## 2. The reconciliation decision (the crux — #1143 ⇄ #1121)
+
+#1143 frames a `RegulatoryTransmitter` (`submitForClearance` + `getClearanceStatus`).
+#1121 (collaborator) independently needs a **read-only** path: for Subiekt, the
+provider transmits to KSeF *natively* — OL only **reads** clearance status, never
+submits. ADR-026 §Decision.2 names only `RegulatoryTransmitter` with both methods.
+
+**Decision — Option (a): segregate the read half; the transmitter extends it.**
+
+- `RegulatoryStatusReader` — the read half: `getClearanceStatus(record)`. A
+  provider OL only polls (Subiekt) implements **this and only this**.
+- `RegulatoryTransmitter extends RegulatoryStatusReader` — adds
+  `submitForClearance(record)`. A provider OL submits to directly (a future
+  KSeF-direct adapter) implements the full interface; by extension it is also a
+  reader.
+
+**Why (a) over (b) — a single transmitter with both methods:**
+- **ISP.** Subiekt cannot honour `submitForClearance` (it doesn't submit); forcing
+  it to implement a throwing stub to satisfy a fat interface is the LSP/ISP smell
+  ADR-002 guards exist to avoid.
+- **Unblocks both issues cleanly.** #1143 defines *both* capabilities here (the
+  transmitter can't `extend` a reader that doesn't exist), so #1121 just *consumes*
+  `RegulatoryStatusReader` + `isRegulatoryStatusReader` — zero definition
+  collision, no "who owns the file" race.
+- **The reconciliation poller (#1121) narrows on the read guard** (`isRegulatoryStatusReader`),
+  so it works for *both* a read-only Subiekt adapter and a full transmitter.
+- Matches the established `OfferManagerPort` sub-capability idiom (`isOfferCreator(adapter: OfferManagerPort)`).
+
+This refines (does not contradict) ADR-026 — it extracts a narrower read capability
+from the named `RegulatoryTransmitter`. Per the issue, record it as a **one-line
+ADR-026 amendment note** and a coordination comment on #1121.
+
+### Why `extends` (not two independent flat capabilities) — research-backed
+
+Deep research (2026-06-23) on both the codebase and the CTC e-invoicing domain
+settled the one open sub-question — `RegulatoryTransmitter extends RegulatoryStatusReader`
+vs two independent flat capabilities:
+
+- **Codebase idiom is flat/independent — but for a reason that doesn't apply here.**
+  No capability interface in `libs/core` currently uses `extends`; the closest
+  read/write pair (`FulfillmentStatusReader` vs `OrderFulfillmentUpdater`) is two
+  *independent* interfaces. That is correct **because those concerns are
+  orthogonal** — reading the OMP's fulfilment view and pushing a status to it are
+  different directions with no subset relationship; an adapter can sensibly have
+  one without the other.
+- **The regulatory pair is a genuine `is-a`, not orthogonal.** Across clearance
+  regimes (PL KSeF, IT SDI) the official reference (KSeF number / IdSdI) is
+  assigned *only after* submission and is knowable *only by reading status* — so a
+  transmitter that cannot read the clearance status it just triggered is
+  meaningless. Submit logically entails read. This is exactly the LSP subset
+  relationship that warrants interface inheritance, where the prior orthogonal
+  pairs did not. `extends` is therefore the first such use in the codebase **by
+  correctness, not by accident** — a bounded, documented exception, not a new
+  sweeping pattern.
+- **Single read-guard coverage.** `extends` makes `isRegulatoryStatusReader`
+  structurally true for *every* transmitter (a transmitter is always a reader), so
+  the #1121 poller's one guard covers both Subiekt (read-only) and a future
+  KSeF-direct (transmitter) with no "the adapter forgot to also declare the reader"
+  failure mode.
+
+**External validation (durability):** the submit-vs-read-status split is the
+industry-standard, durable model, not a Subiekt quirk — Poland's KSeF defines
+`InvoiceRead` and `InvoiceWrite` as *independently grantable permissions* (a
+principal can hold read without write); Avalara (Send/Receive/Status), Sovos,
+Fonoa, Basware/Pagero, and Peppol (status is a *separate document/layer*) all
+expose transmit and status as separate operations; ViDA/decentralized-CTC keeps
+transmission and reporting structurally separate. A read-only status consumer is a
+recurring shape (PL/IT/FR/RO + a decade of LatAm PAC delegation), so the segregation
+ages well as more providers/countries are added.
+
+**Spain caveat — already accommodated.** Spain SII / Veri*factu are *synchronous*
+real-time reporting (status returned at submit, no clearance poll). Our shape
+handles this without change: `submitForClearance` **returns** a
+`RegulatoryClearanceResult`, so a synchronous regime reports its final status in
+the submit response; `getClearanceStatus` is the *optional* later poll for async
+regimes. No interface change is needed to cover RTR regimes.
+
+**Neutral-lifecycle altitude.** Real regimes expose *multiple* status channels
+(transport ack, technical MLR/MLS, business response, authority clearance). Core
+stays at the right altitude: the adapter collapses that multiplicity onto the
+single neutral `RegulatoryStatus` lifecycle + `clearanceReference` already defined
+in #751. Core never models the channel zoo.
+
+## 3. Design
+
+### New neutral result type (`domain/types/invoicing.types.ts`)
+```ts
+/** Outcome of a regulatory clearance submit/read — maps 1:1 onto InvoiceOutcomePatch. */
+export interface RegulatoryClearanceResult {
+  regulatoryStatus: RegulatoryStatus;        // existing neutral CTC lifecycle (#751)
+  clearanceReference?: string | null;        // authority ref (KSeF number, SDI id…), when present
+}
+```
+Both methods return this; it maps directly onto the existing `InvoiceOutcomePatch`
+(`regulatoryStatus` + `clearanceReference`) so a future service calls
+`repo.updateOutcome(...)` with no translation. Named `…Result` (not `…Snapshot`):
+it is returned by **both** submit and read, so a read-only-implying name would
+mislead.
+
+### Error / outcome contract (the seam #1121's poller and C5/C6 must agree on)
+Both methods follow the established outcome-as-data-vs-throw discipline (mirrors
+`OrderWritebackResult` + engineering-standards § Error Handling), pinned in each
+method's JSDoc:
+- **Business outcome → returned as data.** An authority verdict — including a
+  refusal — is a returned `RegulatoryClearanceResult` with the mapped neutral
+  status (`rejected`, `cleared`, `accepted`, `submitted`). `rejected` is a
+  first-class `RegulatoryStatusValues` member, **not** an exception.
+- **Transport / infrastructure failure → throws.** Inability to reach the
+  authority/provider (network, auth, 5xx) throws for the caller (the future
+  `InvoiceService` / #1121 poller) to handle + retry. The adapter converts
+  provider-native errors at its boundary.
+
+### `RegulatoryStatusReader` (`domain/ports/capabilities/regulatory-status-reader.capability.ts`)
+```ts
+export interface RegulatoryStatusReader {
+  /**
+   * Read the current clearance status of an issued document from the
+   * authority/provider. Returns the neutral status + `clearanceReference` when
+   * the authority has assigned one (KSeF number / SDI id are knowable only by
+   * reading, post-clearance). A business verdict — incl. `rejected` — is returned
+   * as data; a transport/infra failure throws.
+   */
+  getClearanceStatus(record: InvoiceRecord): Promise<RegulatoryClearanceResult>;
+}
+export function isRegulatoryStatusReader(
+  adapter: InvoicingPort,
+): adapter is InvoicingPort & RegulatoryStatusReader {
+  return typeof (adapter as Partial<RegulatoryStatusReader>).getClearanceStatus === 'function';
+}
+```
+
+### `RegulatoryTransmitter` (`domain/ports/capabilities/regulatory-transmitter.capability.ts`)
+```ts
+export interface RegulatoryTransmitter extends RegulatoryStatusReader {
+  /**
+   * Transmit an issued document to the tax authority for clearance. Returns the
+   * neutral status the submit yielded (a synchronous regime — Spain SII — reports
+   * the final status here; an async regime returns `submitted` and the caller
+   * later polls `getClearanceStatus`). A business refusal is returned as
+   * `rejected` data; a transport/infra failure throws. Should be a no-op
+   * returning current status if re-submitted for an already-cleared document
+   * where the regime allows.
+   */
+  submitForClearance(record: InvoiceRecord): Promise<RegulatoryClearanceResult>;
+}
+export function isRegulatoryTransmitter(
+  adapter: InvoicingPort,
+): adapter is InvoicingPort & RegulatoryTransmitter {
+  return typeof (adapter as Partial<RegulatoryTransmitter>).submitForClearance === 'function';
+}
+```
+
+**File-header rationale (required, not just the ADR note).** `regulatory-transmitter.capability.ts`'s
+header must explain *why* it `extends` (the first capability inheritance in the
+codebase): "a transmitter is necessarily also a reader — the authority reference
+is knowable only by reading post-submit, a genuine is-a — unlike OL's orthogonal
+`*Reader`/`*Updater` pairs; do **not** cargo-cult `extends` for orthogonal
+capabilities." Keeps the bounded exception from being copied where it doesn't apply.
+
+**Method input = `InvoiceRecord`** (not a bare `clearanceReference`): the record is
+the richest neutral handle the adapter can use (carries `clearanceReference`,
+`providerInvoiceId`, `orderId`, `connectionId`) and always exists at both call
+sites (the poller selects records; the submit path has a just-issued record). The
+adapter picks what it needs. Matches `submitForClearance(record)` in ADR-026 §Flow.
+
+**Neutral-vocabulary litmus (ADR-026):** zero `nip`/`ksef`/`vat`/`jpk`/`faktura`
+strings in the new files. (Note: there is no *automated* neutral-vocab invariant
+script in `check:invariants` today — cross-context is the only relevant gate; the
+litmus is enforced by review + these tests. Not introducing a new script — out of
+scope.)
+
+### Barrel (`index.ts`)
+Add `export * from './domain/ports/capabilities/regulatory-status-reader.capability';`
+and `…/regulatory-transmitter.capability';`. **No token** (capability-resolved
+per-connection via `isRegulatoryTransmitter`/`isRegulatoryStatusReader`).
+
+## 4. Steps
+
+1. `invoicing.types.ts` — add `RegulatoryClearanceResult` (after the existing
+   `RegulatoryStatus` block). Header litmus already present.
+2. Create `regulatory-status-reader.capability.ts` (interface + guard + header).
+3. Create `regulatory-transmitter.capability.ts` (`extends` reader + guard + header).
+4. Barrel: export both capability modules from `index.ts`.
+5. `__tests__/regulatory-capabilities.spec.ts` — guard unit tests (see §5).
+6. ADR-026 — **append** a dated `## Amendments` section recording how the deferred
+   interface was filled. Do **not** edit Decision 2's body (ADRs are append-only —
+   `docs/architecture/adrs/README.md`; this *refines*, not *changes*, the decision,
+   since Decision 2 explicitly defers the interface "to the KSeF issue" = #1143). Text:
+   > **Amendment (2026-06-23, #1143).** The deferred `RegulatoryTransmitter` interface
+   > (Decision 2) is realized as two ADR-002 sub-capabilities: a read-only
+   > `RegulatoryStatusReader` (`getClearanceStatus`) and `RegulatoryTransmitter extends
+   > RegulatoryStatusReader` (adds `submitForClearance`). Providers that transmit natively
+   > and only expose status (Subiekt → KSeF, #1121) implement the reader alone; providers
+   > OL submits to directly implement the full transmitter. This refines, not changes,
+   > Decision 2 — it fills the interface ADR-026 deferred to the KSeF issue.
+7. Coordination comment on #1121 announcing `RegulatoryStatusReader` is defined here.
+
+## 5. Tests (`__tests__/regulatory-capabilities.spec.ts`)
+
+Mock a minimal `InvoicingPort` base (the 4 base methods as `jest.fn()`), then:
+- `isRegulatoryStatusReader`: **true** when `getClearanceStatus` present; **false** on the base port.
+- `isRegulatoryTransmitter`: **true** when `submitForClearance` present; **false** on the base port and **false** on a reader-only adapter (segregation: a reader is not a transmitter).
+- A full transmitter (both methods) narrows **true** under *both* guards (the `extends` contract — a transmitter is always a reader).
+- Post-narrow type access compiles (the guard actually narrows the method on).
+
+## 6. Validation / risks
+
+- **Architecture:** pure domain ports + types + guards; no NestJS/TypeORM in the
+  files; no token, no service, no ORM, **no migration**. Cross-context surface:
+  only additive barrel exports → `check:invariants` (cross-context) unaffected.
+- **Naming:** `*.capability.ts` under `domain/ports/capabilities/`, `is{Capability}`
+  guards co-located — matches engineering-standards + ADR-002.
+- **Risk — #1121 coordination:** #1121 is open/unclaimed; defining
+  `RegulatoryStatusReader` here is the agreed reconciliation. Surfaced via the
+  coordination comment; if #1121's author prefers (b), the change is a 1-file
+  delta. Low risk.
+- **Quality gate:** `pnpm lint && pnpm type-check && pnpm test`. (Backend, but
+  no DB/integration surface — `test:integration` not required for this slice;
+  will still run the core unit suite.) Rebuild libs dist before type-check on a
+  fresh worktree.

--- a/libs/core/src/invoicing/domain/ports/capabilities/__tests__/regulatory-capabilities.spec.ts
+++ b/libs/core/src/invoicing/domain/ports/capabilities/__tests__/regulatory-capabilities.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * Regulatory clearance capability guards — unit tests (#1143)
+ *
+ * Covers the segregation contract: `RegulatoryStatusReader` (read half) vs
+ * `RegulatoryTransmitter extends RegulatoryStatusReader` (submit + read), and the
+ * `is{Capability}` guards that narrow an `InvoicingPort` to each.
+ *
+ * @module libs/core/src/invoicing/domain/ports/capabilities/__tests__
+ */
+import type { InvoicingPort } from '../../invoicing.port';
+import {
+  type RegulatoryStatusReader,
+  isRegulatoryStatusReader,
+} from '../regulatory-status-reader.capability';
+import {
+  type RegulatoryTransmitter,
+  isRegulatoryTransmitter,
+} from '../regulatory-transmitter.capability';
+
+// Minimal base `InvoicingPort` with none of the optional regulatory methods.
+const base: InvoicingPort = {
+  issueInvoice: jest.fn(),
+  getInvoice: jest.fn(),
+  upsertCustomer: jest.fn(),
+  getSupportedDocumentTypes: jest.fn(),
+};
+
+describe('isRegulatoryStatusReader', () => {
+  it('returns true when the adapter implements getClearanceStatus', () => {
+    const reader: InvoicingPort & RegulatoryStatusReader = {
+      ...base,
+      getClearanceStatus: jest.fn(),
+    };
+    expect(isRegulatoryStatusReader(reader)).toBe(true);
+  });
+
+  it('returns false on a base InvoicingPort without regulatory read-back', () => {
+    expect(isRegulatoryStatusReader(base)).toBe(false);
+  });
+
+  it('returns true for a full transmitter (a transmitter is always a reader)', () => {
+    const transmitter: InvoicingPort & RegulatoryTransmitter = {
+      ...base,
+      getClearanceStatus: jest.fn(),
+      submitForClearance: jest.fn(),
+    };
+    expect(isRegulatoryStatusReader(transmitter)).toBe(true);
+  });
+});
+
+describe('isRegulatoryTransmitter', () => {
+  it('returns true when the adapter implements submitForClearance', () => {
+    const transmitter: InvoicingPort & RegulatoryTransmitter = {
+      ...base,
+      getClearanceStatus: jest.fn(),
+      submitForClearance: jest.fn(),
+    };
+    expect(isRegulatoryTransmitter(transmitter)).toBe(true);
+  });
+
+  it('returns false on a base InvoicingPort', () => {
+    expect(isRegulatoryTransmitter(base)).toBe(false);
+  });
+
+  it('returns false on a read-only adapter (segregation: a reader is not a transmitter)', () => {
+    const reader: InvoicingPort & RegulatoryStatusReader = {
+      ...base,
+      getClearanceStatus: jest.fn(),
+    };
+    expect(isRegulatoryTransmitter(reader)).toBe(false);
+  });
+
+  it('returns false on a malformed transmitter that submits but cannot read (both methods required)', () => {
+    // A transmitter is necessarily also a reader; the guard must not narrow an
+    // adapter that exposes only `submitForClearance` (TS forbids it for a typed
+    // `implements RegulatoryTransmitter`, but a hand-rolled object could).
+    const malformed = { ...base, submitForClearance: jest.fn() } as InvoicingPort;
+    expect(isRegulatoryTransmitter(malformed)).toBe(false);
+  });
+});
+
+describe('guard narrowing', () => {
+  it('narrows the reader method on a positive isRegulatoryStatusReader', () => {
+    const reader: InvoicingPort & RegulatoryStatusReader = {
+      ...base,
+      getClearanceStatus: jest.fn(),
+    };
+    const adapter: InvoicingPort = reader;
+    if (isRegulatoryStatusReader(adapter)) {
+      // Compiles only because the guard narrowed `adapter` to include the method.
+      expect(typeof adapter.getClearanceStatus).toBe('function');
+    } else {
+      throw new Error('expected the reader to narrow');
+    }
+  });
+
+  it('narrows BOTH methods on a positive isRegulatoryTransmitter (the extends contract)', () => {
+    const transmitter: InvoicingPort & RegulatoryTransmitter = {
+      ...base,
+      getClearanceStatus: jest.fn(),
+      submitForClearance: jest.fn(),
+    };
+    const adapter: InvoicingPort = transmitter;
+    if (isRegulatoryTransmitter(adapter)) {
+      expect(typeof adapter.submitForClearance).toBe('function');
+      // `extends RegulatoryStatusReader` ⇒ the read method is in scope too.
+      expect(typeof adapter.getClearanceStatus).toBe('function');
+    } else {
+      throw new Error('expected the transmitter to narrow');
+    }
+  });
+});

--- a/libs/core/src/invoicing/domain/ports/capabilities/regulatory-status-reader.capability.ts
+++ b/libs/core/src/invoicing/domain/ports/capabilities/regulatory-status-reader.capability.ts
@@ -1,0 +1,46 @@
+/**
+ * Regulatory Status Reader Capability
+ *
+ * The READ half of the regulatory-clearance seam (#1143, ADR-026 §Decision.2,
+ * ADR-002 sub-capability pattern). An optional sub-capability of `InvoicingPort`:
+ * an invoicing adapter that can read back a tax authority's clearance status of
+ * an already-issued document declares `implements RegulatoryStatusReader`.
+ *
+ * This is the role a provider that **transmits natively** exposes — e.g. Subiekt
+ * sends the document to KSeF itself and OL only polls the resulting status
+ * (#1121). Such adapters implement THIS capability and *not* `RegulatoryTransmitter`.
+ * A provider OL submits to directly implements the full `RegulatoryTransmitter`
+ * (which extends this), so it is a reader too.
+ *
+ * Call sites resolve the `Invoicing` capability adapter per-connection, then
+ * narrow with `isRegulatoryStatusReader` before invoking — a provider without
+ * regulatory read-back (the `not-applicable` default) simply doesn't implement it.
+ *
+ * Neutral-vocabulary litmus (ADR-026): no `nip`/`ksef`/`vat`/`jpk`/`faktura` here.
+ *
+ * @module libs/core/src/invoicing/domain/ports/capabilities
+ * @see {@link RegulatoryTransmitter} for the submit+read superset capability
+ */
+import type { InvoiceRecord } from '../../entities/invoice-record.entity';
+import type { RegulatoryClearanceResult } from '../../types/invoicing.types';
+import type { InvoicingPort } from '../invoicing.port';
+
+export interface RegulatoryStatusReader {
+  /**
+   * Read the current clearance status of an issued document from the
+   * authority/provider. Returns the neutral status plus a `clearanceReference`
+   * when the authority has assigned one (the KSeF number / SDI id are knowable
+   * only by reading, after clearance). A business verdict — including `rejected`
+   * — is returned as data; a transport/infrastructure failure throws for the
+   * caller to handle and retry. `record` is the issued `InvoiceRecord` (carries
+   * `clearanceReference` / `providerInvoiceId` / ids); the adapter picks what it
+   * needs and performs no identifier mapping.
+   */
+  getClearanceStatus(record: InvoiceRecord): Promise<RegulatoryClearanceResult>;
+}
+
+export function isRegulatoryStatusReader(
+  adapter: InvoicingPort,
+): adapter is InvoicingPort & RegulatoryStatusReader {
+  return typeof (adapter as Partial<RegulatoryStatusReader>).getClearanceStatus === 'function';
+}

--- a/libs/core/src/invoicing/domain/ports/capabilities/regulatory-transmitter.capability.ts
+++ b/libs/core/src/invoicing/domain/ports/capabilities/regulatory-transmitter.capability.ts
@@ -1,0 +1,62 @@
+/**
+ * Regulatory Transmitter Capability
+ *
+ * The full SUBMIT + READ regulatory-clearance seam (#1143, ADR-026 §Decision.2,
+ * ADR-002 sub-capability pattern). An optional sub-capability of `InvoicingPort`:
+ * an invoicing adapter that **OL itself transmits through** to a tax authority
+ * (a future KSeF-direct adapter; IT SDI, ES SII…) declares `implements
+ * RegulatoryTransmitter`. The adapter maps the authority's regime states onto the
+ * neutral `RegulatoryStatus` lifecycle and returns a `clearanceReference`.
+ *
+ * **Why this `extends RegulatoryStatusReader`** — this is the FIRST capability
+ * interface in the codebase to extend another (OL's idiom is otherwise flat,
+ * independent capabilities composed via `implements A, B`). It is justified, not
+ * accidental: a transmitter is *necessarily* also a reader — the authority
+ * reference (KSeF number / SDI id) is assigned only after submission and is
+ * knowable only by reading status, so submit logically entails read. That is a
+ * genuine is-a (LSP subset), unlike OL's orthogonal `*Reader`/`*Updater` pairs
+ * (e.g. `FulfillmentStatusReader` vs `OrderFulfillmentUpdater`) which share no
+ * subset relationship. **Do NOT cargo-cult `extends` for orthogonal capabilities**
+ * — keep those flat and independent. The `extends` also lets the #1121
+ * reconciliation poller narrow every transmitter with the one
+ * `isRegulatoryStatusReader` guard.
+ *
+ * Neutral-vocabulary litmus (ADR-026): no `nip`/`ksef`/`vat`/`jpk`/`faktura` here.
+ *
+ * @module libs/core/src/invoicing/domain/ports/capabilities
+ * @see {@link RegulatoryStatusReader} for the read-only half (Subiekt-style providers)
+ */
+import type { InvoiceRecord } from '../../entities/invoice-record.entity';
+import type { RegulatoryClearanceResult } from '../../types/invoicing.types';
+import type { InvoicingPort } from '../invoicing.port';
+import type { RegulatoryStatusReader } from './regulatory-status-reader.capability';
+
+export interface RegulatoryTransmitter extends RegulatoryStatusReader {
+  /**
+   * Transmit an issued document to the tax authority for clearance. Returns the
+   * neutral status the submit yielded: a *synchronous* regime (Spain SII /
+   * Veri*factu) reports the final status here; an *asynchronous* clearance regime
+   * (KSeF, SDI) returns `submitted` and the caller later polls `getClearanceStatus`.
+   * A business refusal is returned as `rejected` data; a transport/infrastructure
+   * failure throws. Should be a no-op returning current status when re-submitted
+   * for an already-cleared document where the regime allows (exactly-once
+   * *issuance* is gated upstream on the command — ADR-026). `record` is the issued
+   * `InvoiceRecord`; the adapter performs no identifier mapping.
+   */
+  submitForClearance(record: InvoiceRecord): Promise<RegulatoryClearanceResult>;
+}
+
+export function isRegulatoryTransmitter(
+  adapter: InvoicingPort,
+): adapter is InvoicingPort & RegulatoryTransmitter {
+  // Multi-method capability: the narrowed type promises BOTH the transmit method
+  // and the inherited read method, so the runtime guard must verify both (unlike
+  // the single-method capability guards elsewhere). Otherwise an adapter exposing
+  // only `submitForClearance` would narrow to a contract it can't honour and the
+  // #1121 poller's `getClearanceStatus` call would hit `undefined`.
+  const partial = adapter as Partial<RegulatoryTransmitter>;
+  return (
+    typeof partial.submitForClearance === 'function' &&
+    typeof partial.getClearanceStatus === 'function'
+  );
+}

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -48,6 +48,26 @@ export const RegulatoryStatusValues = [
 ] as const;
 export type RegulatoryStatus = (typeof RegulatoryStatusValues)[number];
 
+/**
+ * Outcome of a regulatory clearance submit/read (#1143). Returned by both
+ * `RegulatoryTransmitter.submitForClearance` and `RegulatoryStatusReader.
+ * getClearanceStatus`, so it is named `…Result` (not `…Snapshot`, which would
+ * mislead as read-only). Maps 1:1 onto `InvoiceOutcomePatch`
+ * (`regulatoryStatus` + `clearanceReference`) so the future service/job persists
+ * it via `updateOutcome` with no translation. A business verdict (incl.
+ * `rejected`) is carried here as data; a transport/infra failure throws.
+ */
+export interface RegulatoryClearanceResult {
+  /** Neutral CTC clearance lifecycle the adapter mapped the regime's state onto. */
+  regulatoryStatus: RegulatoryStatus;
+  /**
+   * Authority-assigned reference (KSeF number, SDI id, …) when present — typically
+   * knowable only after the authority clears the document, so a read can surface
+   * a reference a prior submit could not. `null`/absent until assigned.
+   */
+  clearanceReference?: string | null;
+}
+
 /** Neutral B2B/B2C axis. Drives document-type policy in a future rules layer, not here. */
 export const BuyerTypeValues = ['company', 'private'] as const;
 export type BuyerType = (typeof BuyerTypeValues)[number];

--- a/libs/core/src/invoicing/index.ts
+++ b/libs/core/src/invoicing/index.ts
@@ -12,6 +12,8 @@ export * from './domain/types/invoicing.types';
 export * from './domain/entities/buyer-profile.entity';
 export * from './domain/entities/invoice-record.entity';
 export * from './domain/ports/invoicing.port';
+export * from './domain/ports/capabilities/regulatory-status-reader.capability';
+export * from './domain/ports/capabilities/regulatory-transmitter.capability';
 export * from './domain/ports/invoice-record-repository.port';
 export * from './domain/exceptions/invoice-record-not-found.exception';
 export * from './domain/exceptions/duplicate-invoice-record.exception';


### PR DESCRIPTION
## What & why

Fills the regulatory-clearance interface that **ADR-026 §Decision.2** deferred to the KSeF issue (epic #1142). Realized as **two** [ADR-002](../blob/main/docs/architecture/adrs/002-capability-ports-with-sub-capabilities.md) sub-capabilities of `InvoicingPort`, split by operation shape:

- **`RegulatoryStatusReader`** (read half) — `getClearanceStatus(record)`. The role a provider that transmits to the authority *natively* and only exposes status implements alone (Subiekt → KSeF, #1121).
- **`RegulatoryTransmitter extends RegulatoryStatusReader`** — adds `submitForClearance(record)`. The role a provider OL submits to *directly* implements (a future KSeF-direct adapter; IT SDI, ES SII…).

Both return a neutral `RegulatoryClearanceResult` (`regulatoryStatus` + optional `clearanceReference`) that maps 1:1 onto `InvoiceOutcomePatch`. **Contract:** a business verdict (incl. `rejected`) is returned as *data*; a transport/infra failure *throws*. A synchronous regime (Spain SII) reports final status in the submit response; an async clearance regime (KSeF, SDI) returns `submitted` and the caller polls `getClearanceStatus`.

## The one design call worth flagging

`RegulatoryTransmitter extends RegulatoryStatusReader` is the **first capability-inheritance in the codebase** — OL's idiom is otherwise flat, independent capabilities composed via `implements A, B`. It is justified by a genuine **is-a**: the authority reference (KSeF number / SDI id) is assigned only *after* submission and is knowable only by *reading* status, so a transmitter is necessarily also a reader (an LSP subset), unlike OL's orthogonal `*Reader`/`*Updater` pairs (e.g. `FulfillmentStatusReader` vs `OrderFulfillmentUpdater`) which share no subset relationship. The `extends` also lets the #1121 reconciliation poller narrow every transmitter with the single `isRegulatoryStatusReader` guard. The file header documents this and explicitly says **"do NOT cargo-cult `extends` for orthogonal capabilities."**

## Guard robustness (post tech-review)

`isRegulatoryTransmitter` is the first multi-method capability guard: its narrowed type promises **both** methods, so it verifies both `submitForClearance` **and** the inherited `getClearanceStatus` at runtime (unlike the single-method guards elsewhere) — a malformed adapter exposing only `submitForClearance` is correctly rejected, so the #1121 poller can't hit an `undefined` read method.

## Scope

- **No** DI token (capability-resolved per-connection via `IntegrationsService.getCapabilityAdapter`), **no** `CoreCapabilityValues` entry, **no** ORM/migration — the `regulatoryStatus` / `clearanceReference` columns already ship from #751.
- Pure domain: zero `@nestjs`/`typeorm` imports in the capability files.
- Additive barrel exports only.
- ADR-026 amended with an append-only `## Amendments` note (refines, does not change, Decision 2).
- Neutral-vocabulary litmus holds — the contract surface names no tax regime (KSeF/SDI/SII appear only in JSDoc examples, matching shipped precedent in `invoice-record.entity.ts` / `invoicing.types.ts`).

## Tests

9 unit tests for the two guards + port-narrowing: positive/negative/segregation (a reader is not a transmitter), the `extends` transitivity (a transmitter is always a reader), the malformed-transmitter rejection, and both-method narrowing.

## Quality gate

`pnpm type-check` ✅ · `pnpm lint` (incl. `check:invariants`) ✅ · `pnpm test` ✅ (all packages green; libs/core 1217).

Closes #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)