### PR TITLE
feat(invoicing): auto-issue trigger — order paid/shipped → enqueue issuance (#1120)

### DIFF
--- a/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * InvoicingIssueHandler unit tests (OL #1120). Mocks `IInvoiceService`; asserts
+ * the validate -> reconstruct -> delegate path, F5 business-failure rejection,
+ * PII discipline on failure logs, and retryable transport wrapping.
+ *
+ * @module apps/worker/src/sync/handlers/__tests__
+ */
+import { InvoicingIssueHandler, MAX_INVOICE_LINES } from '../invoicing-issue.handler';
+import { BuyerProfile } from '@openlinker/core/invoicing';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import type { IInvoiceService } from '@openlinker/core/invoicing';
+import type {
+  InvoicingIssuePayloadV1,
+  SyncJob as SyncJobEntity,
+} from '@openlinker/core/sync';
+
+const BUYER_SENTINEL = 'Jan Kowalski';
+
+function makePayload(overrides: Partial<InvoicingIssuePayloadV1> = {}): InvoicingIssuePayloadV1 {
+  return {
+    schemaVersion: 1,
+    connectionId: 'conn-1',
+    orderId: 'order-1',
+    idempotencyKey: 'invoice:conn-1:order-1',
+    currency: 'PLN',
+    lines: [{ name: 'Widget', quantity: 2, unitPriceGross: 10, taxRate: '' }],
+    buyer: {
+      name: BUYER_SENTINEL,
+      taxId: null,
+      address: {
+        line1: 'ul. Testowa 1',
+        line2: null,
+        city: 'Poznań',
+        postalCode: '60-001',
+        countryIso2: 'PL',
+      },
+      type: 'private',
+    },
+    sourceConnectionId: 'src-1',
+    trigger: 'auto-on-paid',
+    ...overrides,
+  };
+}
+
+function makeJob(payload: unknown): SyncJobEntity {
+  return {
+    id: 'job-1',
+    jobType: 'invoicing.issue',
+    connectionId: 'conn-1',
+    payload: payload as Record<string, unknown>,
+    idempotencyKey: 'invoice:conn-1:order-1',
+    status: 'running',
+    attempts: 1,
+    maxAttempts: 3,
+    nextRunAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as SyncJobEntity;
+}
+
+describe('InvoicingIssueHandler', () => {
+  let invoiceService: jest.Mocked<IInvoiceService>;
+  let handler: InvoicingIssueHandler;
+  let warnSpy: jest.SpyInstance<void, [message: string]>;
+
+  beforeEach(() => {
+    invoiceService = {
+      issueInvoice: jest.fn().mockResolvedValue({} as never),
+      getInvoice: jest.fn(),
+    };
+    handler = new InvoicingIssueHandler(invoiceService as unknown as IInvoiceService);
+    warnSpy = jest
+      .spyOn(
+        (handler as unknown as { logger: { warn: (m: string) => void } }).logger,
+        'warn',
+      )
+      .mockImplementation(() => undefined) as jest.SpyInstance<void, [message: string]>;
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('happy path (pure delegate)', () => {
+    it('validates, reconstructs BuyerProfile, calls issueInvoice(command), returns ok', async () => {
+      const result = await handler.execute(makeJob(makePayload()));
+      expect(result).toEqual({ outcome: 'ok' });
+      expect(invoiceService.issueInvoice).toHaveBeenCalledTimes(1);
+      const cmd = invoiceService.issueInvoice.mock.calls[0][0];
+      expect(cmd.buyer).toBeInstanceOf(BuyerProfile);
+      expect(cmd.buyer.name).toBe(BUYER_SENTINEL);
+    });
+
+    it('command idempotencyKey equals payload.idempotencyKey (F4)', async () => {
+      await handler.execute(makeJob(makePayload({ idempotencyKey: 'invoice:c:o' })));
+      expect(invoiceService.issueInvoice.mock.calls[0][0].idempotencyKey).toBe('invoice:c:o');
+    });
+  });
+
+  describe('deep payload validation ⇒ business_failure (F5)', () => {
+    const cases: Array<[string, unknown]> = [
+      ['wrong schemaVersion', makePayload({ schemaVersion: 2 as unknown as 1 })],
+      ['empty lines', makePayload({ lines: [] })],
+      ['over-bound lines', makePayload({
+        lines: Array.from({ length: MAX_INVOICE_LINES + 1 }, () => ({
+          name: 'x', quantity: 1, unitPriceGross: 1, taxRate: '',
+        })),
+      })],
+      ['negative unitPriceGross', makePayload({
+        lines: [{ name: 'x', quantity: 1, unitPriceGross: -1, taxRate: '' }],
+      })],
+      ['quantity <= 0', makePayload({
+        lines: [{ name: 'x', quantity: 0, unitPriceGross: 1, taxRate: '' }],
+      })],
+      ['buyer.type not in BuyerTypeValues', makePayload({
+        buyer: { ...makePayload().buyer, type: 'enterprise' as never },
+      })],
+      ['half-populated taxId', makePayload({
+        buyer: { ...makePayload().buyer, taxId: { scheme: 'pl-nip', value: '' } },
+      })],
+      ['missing connectionId', makePayload({ connectionId: '' })],
+    ];
+
+    it.each(cases)('%s ⇒ business_failure (no issueInvoice call)', async (_label, payload) => {
+      const result = await handler.execute(makeJob(payload));
+      expect(result).toEqual({ outcome: 'business_failure' });
+      expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PII discipline on failure paths (F-validate-PII / D11)', () => {
+    it('validation-failure log omits buyer.name; names only field + orderId/connectionId/schemaVersion', async () => {
+      await handler.execute(makeJob(makePayload({ lines: [] })));
+      const logged = warnSpy.mock.calls[0][0];
+      expect(logged).not.toContain(BUYER_SENTINEL);
+      expect(logged).toContain('field=lines');
+      expect(logged).toContain('orderId=order-1');
+      expect(logged).toContain('connectionId=conn-1');
+    });
+
+    it('validation failure is NOT a thrown error carrying JSON.stringify(job.payload)', async () => {
+      await expect(handler.execute(makeJob(makePayload({ lines: [] })))).resolves.toEqual({
+        outcome: 'business_failure',
+      });
+    });
+
+    it('transport-error SyncJobExecutionError message excludes the buyer sentinel and the stringified payload', async () => {
+      invoiceService.issueInvoice.mockRejectedValue(new Error(`failed buyer ${BUYER_SENTINEL}`));
+      await expect(handler.execute(makeJob(makePayload()))).rejects.toMatchObject({
+        name: 'SyncJobExecutionError',
+      });
+      try {
+        await handler.execute(makeJob(makePayload()));
+      } catch (e) {
+        const msg = (e as Error).message;
+        expect(msg).not.toContain(BUYER_SENTINEL);
+        expect(msg).not.toContain('ul. Testowa');
+      }
+    });
+  });
+
+  describe('transport / bridge-unreachable (retryable)', () => {
+    it('a transport error from issueInvoice is wrapped in SyncJobExecutionError and THROWN', async () => {
+      invoiceService.issueInvoice.mockRejectedValue(new Error('ECONNREFUSED'));
+      await expect(handler.execute(makeJob(makePayload()))).rejects.toBeInstanceOf(
+        SyncJobExecutionError,
+      );
+    });
+  });
+
+  it('is defined', () => {
+    expect(InvoicingIssueHandler).toBeDefined();
+  });
+});

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -28,6 +28,7 @@ import { MasterInventorySyncAllHandler } from './master-inventory-sync-all.handl
 import { MasterProductSyncAllHandler } from './master-product-sync-all.handler';
 import { PickupPointRefreshHandler } from './pickup-point-refresh.handler';
 import { ShopProductPublishHandler } from './shop-product-publish.handler';
+import { InvoicingIssueHandler } from './invoicing-issue.handler';
 
 @Injectable()
 export class HandlerRegistrationService implements OnModuleInit {
@@ -51,7 +52,8 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly masterInventorySyncAllHandler: MasterInventorySyncAllHandler,
     private readonly masterProductSyncAllHandler: MasterProductSyncAllHandler,
     private readonly pickupPointRefreshHandler: PickupPointRefreshHandler,
-    private readonly shopProductPublishHandler: ShopProductPublishHandler
+    private readonly shopProductPublishHandler: ShopProductPublishHandler,
+    private readonly invoicingIssueHandler: InvoicingIssueHandler
   ) {}
 
   onModuleInit(): void {
@@ -119,5 +121,8 @@ export class HandlerRegistrationService implements OnModuleInit {
 
     // Register shop product publish handler (#1042, ADR-024)
     this.handlerRegistry.register('shop.product.publish', this.shopProductPublishHandler);
+
+    // Register invoicing issue handler (OL #1120 — auto-issue trigger)
+    this.handlerRegistry.register('invoicing.issue', this.invoicingIssueHandler);
   }
 }

--- a/apps/worker/src/sync/handlers/invoicing-issue.handler.ts
+++ b/apps/worker/src/sync/handlers/invoicing-issue.handler.ts
@@ -1,0 +1,195 @@
+/**
+ * Invoicing Issue Handler (OL #1120)
+ *
+ * Handles `invoicing.issue` sync jobs — a PURE delegate to `IInvoiceService`.
+ * The policy service (`AutoIssueTriggerService`) has already composed the
+ * issuance command into the job payload, so this handler:
+ *  1. Casts + DEEP-validates the payload (F5).
+ *  2. Reconstructs `new BuyerProfile(...)` from the PLAIN payload buyer (#12).
+ *  3. Calls `invoiceService.issueInvoice(command)` with the command idempotency
+ *     key equal to `payload.idempotencyKey` (the SAME string as the job row, F4).
+ *
+ * PII DISCIPLINE (F-validate-PII / D11): the payload carries real buyer PII.
+ * Therefore NO failure path may serialize `payload` / `buyer` / `lines`:
+ *  - A malformed/over-bound payload → return `{ outcome: 'business_failure' }`
+ *    (never succeeds on retry); the log names ONLY the failed field(s) +
+ *    `orderId` / `connectionId` / `schemaVersion`. It does NOT throw a
+ *    `SyncJobExecutionError` carrying `JSON.stringify(job.payload)` (deliberately
+ *    diverging from the inventory-handler precedent).
+ *  - A transport/bridge-unreachable error → wrap in `SyncJobExecutionError` and
+ *    THROW (retryable); the message excludes payload/buyer (only `error.name` +
+ *    `orderId` / `connectionId`).
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import { Injectable, Inject } from '@nestjs/common';
+import type {
+  SyncJobHandler,
+  SyncJobHandlerResult,
+  SyncJob as SyncJobEntity,
+  InvoicingIssuePayloadV1,
+} from '@openlinker/core/sync';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import {
+  IInvoiceService,
+  INVOICE_SERVICE_TOKEN,
+  BuyerProfile,
+  BuyerTypeValues,
+} from '@openlinker/core/invoicing';
+import type { IssueInvoiceCommand } from '@openlinker/core/invoicing';
+import { Logger } from '@openlinker/shared/logging';
+
+type SyncJob = SyncJobEntity;
+
+/**
+ * Hard ceiling on `lines[]` length (F5). Rejects empty AND over-bound payloads
+ * so a pathological job can never balloon the issuance call.
+ */
+export const MAX_INVOICE_LINES = 200;
+
+@Injectable()
+export class InvoicingIssueHandler implements SyncJobHandler {
+  private readonly logger = new Logger(InvoicingIssueHandler.name);
+
+  constructor(
+    @Inject(INVOICE_SERVICE_TOKEN)
+    private readonly invoiceService: IInvoiceService,
+  ) {}
+
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
+    // F5: deep-validate first. A malformed/over-bound payload is a terminal
+    // business failure — it can NEVER succeed on retry — so return the outcome
+    // rather than throw a retryable error. validatePayload logs only field names
+    // + ids (no payload/buyer/lines).
+    const payload = this.validatePayload(job);
+    if (payload === null) {
+      return { outcome: 'business_failure' };
+    }
+
+    const command = this.toCommand(payload);
+
+    try {
+      // F4: command idempotencyKey === payload.idempotencyKey === job row key.
+      // The service's `issued`-only exactly-once gate makes duplicate events /
+      // retries a no-op against the same key.
+      await this.invoiceService.issueInvoice(command);
+      return { outcome: 'ok' };
+    } catch (error) {
+      // Transport / bridge-unreachable → retryable. PII discipline: the message
+      // carries ONLY error.name + orderId + connectionId — never payload/buyer.
+      const errorName = error instanceof Error ? error.name : 'UnknownError';
+      throw new SyncJobExecutionError(
+        `invoicing.issue failed: error=${errorName} orderId=${payload.orderId} connectionId=${payload.connectionId}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  /**
+   * DEEP payload validation (F5). Returns the typed payload on success; returns
+   * `null` to signal a `business_failure` outcome on ANY violation:
+   *  - `schemaVersion === 1`;
+   *  - `connectionId` / `orderId` / `idempotencyKey` / `currency` non-empty strings;
+   *  - `lines` an array of `1..MAX_INVOICE_LINES` items, each with `quantity` a
+   *    finite number `> 0` and `unitPriceGross` a finite number `>= 0`;
+   *  - `buyer.type ∈ BuyerTypeValues`; `buyer.name` non-empty; `buyer.address`
+   *    present with required string fields; `buyer.taxId` `null` OR
+   *    `{ scheme, value }` with both non-empty.
+   *
+   * PII: on violation logs ONLY the failed field name(s) + `orderId` /
+   * `connectionId` / `schemaVersion` — NEVER `payload` / `buyer` / `lines`.
+   */
+  private validatePayload(job: SyncJob): InvoicingIssuePayloadV1 | null {
+    const p = job.payload as unknown as Partial<InvoicingIssuePayloadV1>;
+
+    const fail = (field: string): null => {
+      // PII: name ONLY the failed field + ids — never payload/buyer/lines.
+      this.logger.warn(
+        `invoicing.issue payload rejected: field=${field} orderId=${typeof p?.orderId === 'string' ? p.orderId : 'n/a'} connectionId=${job.connectionId} schemaVersion=${String(p?.schemaVersion)}`,
+      );
+      return null;
+    };
+
+    if (!p || typeof p !== 'object') return fail('payload');
+    if (p.schemaVersion !== 1) return fail('schemaVersion');
+    if (!isNonEmptyString(p.connectionId)) return fail('connectionId');
+    if (!isNonEmptyString(p.orderId)) return fail('orderId');
+    if (!isNonEmptyString(p.idempotencyKey)) return fail('idempotencyKey');
+    if (!isNonEmptyString(p.currency)) return fail('currency');
+
+    if (!Array.isArray(p.lines) || p.lines.length < 1 || p.lines.length > MAX_INVOICE_LINES) {
+      return fail('lines');
+    }
+    for (const line of p.lines) {
+      if (!line || typeof line !== 'object') return fail('lines.item');
+      if (!isFiniteNumber(line.quantity) || line.quantity <= 0) return fail('lines.quantity');
+      if (!isFiniteNumber(line.unitPriceGross) || line.unitPriceGross < 0) {
+        return fail('lines.unitPriceGross');
+      }
+    }
+
+    const buyer = p.buyer;
+    if (!buyer || typeof buyer !== 'object') return fail('buyer');
+    if (!(BuyerTypeValues as readonly string[]).includes(buyer.type)) return fail('buyer.type');
+    if (!isNonEmptyString(buyer.name)) return fail('buyer.name');
+
+    const address = buyer.address;
+    if (!address || typeof address !== 'object') return fail('buyer.address');
+    if (!isNonEmptyString(address.line1)) return fail('buyer.address.line1');
+    if (!isNonEmptyString(address.city)) return fail('buyer.address.city');
+    if (!isNonEmptyString(address.postalCode)) return fail('buyer.address.postalCode');
+    if (!isNonEmptyString(address.countryIso2)) return fail('buyer.address.countryIso2');
+
+    if (buyer.taxId !== null) {
+      if (!buyer.taxId || typeof buyer.taxId !== 'object') return fail('buyer.taxId');
+      if (!isNonEmptyString(buyer.taxId.scheme)) return fail('buyer.taxId.scheme');
+      if (!isNonEmptyString(buyer.taxId.value)) return fail('buyer.taxId.value');
+    }
+
+    return p as InvoicingIssuePayloadV1;
+  }
+
+  /**
+   * Reconstruct the `IssueInvoiceCommand` from the validated PLAIN payload,
+   * rebuilding `new BuyerProfile(...)` (#12) and carrying `payload.idempotencyKey`
+   * as the command idempotency key (F4).
+   */
+  private toCommand(payload: InvoicingIssuePayloadV1): IssueInvoiceCommand {
+    // #12: rebuild the BuyerProfile class from the PLAIN payload buyer.
+    const buyer = new BuyerProfile(
+      payload.buyer.name,
+      payload.buyer.taxId,
+      payload.buyer.address,
+      payload.buyer.type,
+    );
+
+    const command: IssueInvoiceCommand = {
+      connectionId: payload.connectionId,
+      orderId: payload.orderId,
+      buyer,
+      currency: payload.currency,
+      lines: payload.lines,
+      // F4: carry the SAME idempotency key as the job row.
+      idempotencyKey: payload.idempotencyKey,
+    };
+
+    if (payload.documentType !== undefined) {
+      command.documentType = payload.documentType;
+    }
+
+    return command;
+  }
+}
+
+/** True for a non-empty string. */
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/** True for a finite (non-NaN, non-Infinity) number. */
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -15,6 +15,7 @@ import { InventoryModule } from '@openlinker/core/inventory';
 import { OrdersModule } from '@openlinker/core/orders';
 import { ListingsModule } from '@openlinker/core/listings/services';
 import { ShippingModule } from '@openlinker/core/shipping';
+import { InvoicingModule } from '@openlinker/core/invoicing';
 import { WorkerContentModule } from '../content/worker-content.module';
 import { JobIntakeConsumer } from './job-intake.consumer';
 import { SyncJobRunner } from './sync-job.runner';
@@ -38,6 +39,7 @@ import { MasterInventorySyncAllHandler } from './handlers/master-inventory-sync-
 import { MasterProductSyncAllHandler } from './handlers/master-product-sync-all.handler';
 import { PickupPointRefreshHandler } from './handlers/pickup-point-refresh.handler';
 import { ShopProductPublishHandler } from './handlers/shop-product-publish.handler';
+import { InvoicingIssueHandler } from './handlers/invoicing-issue.handler';
 import { HandlerRegistrationService } from './handlers/handler-registration.service';
 
 @Module({
@@ -50,6 +52,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     OrdersModule, // Import OrdersModule to access ORDER_SYNC_SERVICE_TOKEN
     ListingsModule, // Import ListingsModule to access OFFER_MAPPING_SYNC_SERVICE_TOKEN
     ShippingModule, // Import ShippingModule to access SHIPMENT_STATUS_SYNC_SERVICE_TOKEN (#838)
+    InvoicingModule, // OL #1120 — exposes INVOICE_SERVICE_TOKEN (handler) + makes AUTO_ISSUE_TRIGGER_SERVICE_TOKEN resolvable for OrderIngestionService
     WorkerContentModule, // Worker-side ContentModule for #737 — exposes CONTENT_SUGGESTION_SERVICE_TOKEN
   ],
   providers: [
@@ -75,6 +78,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     MasterProductSyncAllHandler,
     PickupPointRefreshHandler,
     ShopProductPublishHandler,
+    InvoicingIssueHandler,
     HandlerRegistrationService,
   ],
 })

--- a/apps/worker/test/integration/invoicing-auto-issue-boot.int-spec.ts
+++ b/apps/worker/test/integration/invoicing-auto-issue-boot.int-spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Invoicing Auto-Issue — DI Boot / Container Integration Test (OL #1120).
+ *
+ * HARD GATE (F2/F3): boots the real Nest container (the worker AppModule, which
+ * imports SyncWorkerModule) and resolves BOTH `InvoicingIssueHandler` AND
+ * `OrderIngestionService`. The latter proves `OrdersModule → InvoicingModule`
+ * exports `AUTO_ISSUE_TRIGGER_SERVICE_TOKEN` at runtime and that no DI / barrel
+ * cycle exists (the first runtime value edge invoicing → orders, via
+ * `auto-issue-trigger.service.ts`). Unit suites cannot catch a missing export,
+ * unexported token, unprovided handler, or circular module dep — this is the only
+ * automated guard against that class of bug.
+ *
+ * @module apps/worker/test/integration
+ */
+import { getTestHarness, teardownTestHarness } from './setup';
+import type { WorkerIntegrationTestHarness } from './setup';
+import { ORDER_INGESTION_SERVICE_TOKEN } from '@openlinker/core/orders';
+import { AUTO_ISSUE_TRIGGER_SERVICE_TOKEN } from '@openlinker/core/invoicing';
+import { InvoicingIssueHandler } from '../../src/sync/handlers/invoicing-issue.handler';
+import { SyncJobHandlerRegistry } from '../../src/sync/handlers/sync-job-handler.registry';
+
+describe('Invoicing Auto-Issue — DI boot (HARD GATE, OL #1120)', () => {
+  let harness: WorkerIntegrationTestHarness;
+
+  beforeAll(async () => {
+    // Booting the harness boots the real AppModule container. If OrdersModule ⇄
+    // InvoicingModule formed a DI/barrel cycle, or AUTO_ISSUE_TRIGGER_SERVICE_TOKEN
+    // were not exported, or InvoicingIssueHandler were unprovided, this would throw.
+    harness = await getTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('the real container resolves InvoicingIssueHandler', () => {
+    const handler = harness.get(InvoicingIssueHandler);
+    expect(handler).toBeInstanceOf(InvoicingIssueHandler);
+  });
+
+  it('the real container resolves OrderIngestionService (AUTO_ISSUE_TRIGGER_SERVICE_TOKEN resolves; no DI cycle)', () => {
+    // Resolving OrderIngestionService forces the AUTO_ISSUE_TRIGGER_SERVICE_TOKEN
+    // injection (its 11th constructor dep) to resolve from InvoicingModule's export.
+    const ingestion = harness.get(ORDER_INGESTION_SERVICE_TOKEN);
+    expect(ingestion).toBeDefined();
+
+    // And the token itself resolves to the trigger service the ingestion service injects.
+    const trigger = harness.get(AUTO_ISSUE_TRIGGER_SERVICE_TOKEN);
+    expect(trigger).toBeDefined();
+    expect(typeof (trigger as { onOrderTransition?: unknown }).onOrderTransition).toBe('function');
+  });
+
+  it('invoicing.issue is registered in the handler registry after onModuleInit', () => {
+    // HandlerRegistrationService.onModuleInit runs during container boot; assert
+    // the invoicing.issue job type is wired to a handler in the live registry.
+    const registry = harness.get(SyncJobHandlerRegistry);
+    expect(registry.getRegisteredJobTypes()).toContain('invoicing.issue');
+    expect(registry.getHandler('invoicing.issue')).toBeInstanceOf(InvoicingIssueHandler);
+  });
+});

--- a/apps/worker/test/integration/invoicing-auto-issue.int-spec.ts
+++ b/apps/worker/test/integration/invoicing-auto-issue.int-spec.ts
@@ -1,0 +1,192 @@
+/**
+ * Invoicing Auto-Issue — End-to-End Integration Test (OL #1120).
+ *
+ * Drives the core policy composer (`AutoIssueTriggerService.onOrderTransition` —
+ * the ADR-007 sync-orchestration seam reached from OrderIngestionService) against
+ * the REAL Postgres-backed `ConnectionPort` and `SyncJobsService`, so the
+ * per-connection trigger model and the deterministic-key exactly-once gate are
+ * exercised against real persistence (not mocks). Seeds an Invoicing connection
+ * per trigger model and asserts the `invoicing.issue` jobs the transition does
+ * (or does not) enqueue.
+ *
+ * The full ingestion → adapter → InvoiceRecord path needs a per-connection
+ * 'Invoicing' provider adapter wired through the integrations registry; that is
+ * covered at unit level (invoice.service.spec / invoicing-issue.handler.spec).
+ * Here we assert the enqueue contract and the DB-backed idempotency end-to-end.
+ *
+ * @module apps/worker/test/integration
+ */
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import type { WorkerIntegrationTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+import { getAllSyncJobs } from './helpers/test-sync-job.helper';
+import {
+  AUTO_ISSUE_TRIGGER_SERVICE_TOKEN,
+  type IAutoIssueTriggerService,
+} from '@openlinker/core/invoicing';
+import type { Order } from '@openlinker/core/orders';
+import type { InvoiceTriggerModel } from '@openlinker/core/invoicing';
+
+/** Build a clean unified Order fixture (mirrors the unit-suite shape). */
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: 'order-int-1',
+    orderNumber: 'OL-1',
+    status: 'processing',
+    paymentStatus: 'awaiting',
+    items: [{ id: 'i1', productId: 'p1', quantity: 2, price: 10, name: 'Widget' }],
+    totals: {
+      subtotal: 20,
+      tax: 0,
+      shipping: 0,
+      total: 20,
+      currency: 'PLN',
+      taxTreatment: 'inclusive',
+    },
+    billingAddress: {
+      firstName: 'Jan',
+      lastName: 'Kowalski',
+      address1: 'ul. Testowa 1',
+      city: 'Poznań',
+      postalCode: '60-001',
+      country: 'PL',
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Order;
+}
+
+/** Seed an ACTIVE connection that declares the Invoicing capability + trigger model. */
+async function seedInvoicingConnection(
+  harness: WorkerIntegrationTestHarness,
+  triggerModel: InvoiceTriggerModel,
+): Promise<string> {
+  const conn = await createTestConnection(harness.getDataSource(), {
+    platformType: 'subiekt',
+    name: `Invoicing (${triggerModel})`,
+    status: 'active',
+    adapterKey: 'subiekt.bridge.v1',
+    config: { invoicing: { triggerModel } },
+    enabledCapabilities: ['Invoicing'],
+  });
+  return conn.id;
+}
+
+/** All invoicing.issue jobs currently in the DB (newest first). */
+async function invoicingJobs(harness: WorkerIntegrationTestHarness) {
+  const all = await getAllSyncJobs(harness.getDataSource());
+  return all.filter((j) => j.jobType === 'invoicing.issue');
+}
+
+describe('Invoicing Auto-Issue Integration (OL #1120)', () => {
+  let harness: WorkerIntegrationTestHarness;
+  let trigger: IAutoIssueTriggerService;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    trigger = harness.get<IAutoIssueTriggerService>(AUTO_ISSUE_TRIGGER_SERVICE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  describe('auto-on-paid', () => {
+    it('a paid order transition enqueues exactly one invoicing.issue job with the deterministic key', async () => {
+      const connId = await seedInvoicingConnection(harness, 'auto-on-paid');
+      const order = makeOrder({ id: 'order-paid-1', paymentStatus: 'paid' });
+
+      await trigger.onOrderTransition(order, 'src-conn-1', 'evt-1');
+
+      const jobs = await invoicingJobs(harness);
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].connectionId).toBe(connId);
+      // F4: deterministic key `invoice:{connId}:{orderId}`, threaded into the row
+      // AND the payload.
+      expect(jobs[0].idempotencyKey).toBe(`invoice:${connId}:order-paid-1`);
+      expect((jobs[0].payloadJson as { idempotencyKey: string }).idempotencyKey).toBe(
+        `invoice:${connId}:order-paid-1`,
+      );
+    });
+
+    it('a re-delivered paid event produces NO second job (D7 — deterministic-key short-circuit)', async () => {
+      const connId = await seedInvoicingConnection(harness, 'auto-on-paid');
+      const order = makeOrder({ id: 'order-paid-dupe', paymentStatus: 'paid' });
+
+      // First delivery enqueues.
+      await trigger.onOrderTransition(order, 'src-conn-1', 'evt-1');
+      // Re-delivery of the SAME order/connection: same deterministic key →
+      // SyncJobsService.schedule is a no-op against the existing row.
+      await trigger.onOrderTransition(order, 'src-conn-1', 'evt-1-redeliver');
+
+      const jobs = await invoicingJobs(harness);
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].idempotencyKey).toBe(`invoice:${connId}:order-paid-dupe`);
+    });
+
+    it('a non-paid order on an auto-on-paid connection enqueues nothing', async () => {
+      await seedInvoicingConnection(harness, 'auto-on-paid');
+      await trigger.onOrderTransition(
+        makeOrder({ id: 'order-awaiting', paymentStatus: 'awaiting' }),
+        'src-conn-1',
+      );
+      expect(await invoicingJobs(harness)).toHaveLength(0);
+    });
+  });
+
+  describe('auto-on-shipped', () => {
+    it('a shipped order transition enqueues exactly one invoicing.issue job', async () => {
+      const connId = await seedInvoicingConnection(harness, 'auto-on-shipped');
+      await trigger.onOrderTransition(
+        makeOrder({ id: 'order-shipped', status: 'shipped' }),
+        'src-conn-1',
+      );
+      const jobs = await invoicingJobs(harness);
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].connectionId).toBe(connId);
+      expect(jobs[0].idempotencyKey).toBe(`invoice:${connId}:order-shipped`);
+    });
+
+    it('a non-shipped order on an auto-on-shipped connection enqueues nothing', async () => {
+      await seedInvoicingConnection(harness, 'auto-on-shipped');
+      await trigger.onOrderTransition(
+        makeOrder({ id: 'order-proc', status: 'processing', paymentStatus: 'paid' }),
+        'src-conn-1',
+      );
+      expect(await invoicingJobs(harness)).toHaveLength(0);
+    });
+  });
+
+  describe('manual', () => {
+    it('a manual connection produces ZERO invoicing.issue jobs even for a paid+shipped order', async () => {
+      await seedInvoicingConnection(harness, 'manual');
+      await trigger.onOrderTransition(
+        makeOrder({ id: 'order-manual', status: 'shipped', paymentStatus: 'paid' }),
+        'src-conn-1',
+      );
+      expect(await invoicingJobs(harness)).toHaveLength(0);
+    });
+  });
+
+  describe('per-connection isolation', () => {
+    it('only the connections whose trigger model matches enqueue (manual + auto-on-shipped present, order is paid only)', async () => {
+      const autoPaid = await seedInvoicingConnection(harness, 'auto-on-paid');
+      await seedInvoicingConnection(harness, 'auto-on-shipped');
+      await seedInvoicingConnection(harness, 'manual');
+
+      await trigger.onOrderTransition(
+        makeOrder({ id: 'order-mixed', status: 'processing', paymentStatus: 'paid' }),
+        'src-conn-1',
+      );
+
+      const jobs = await invoicingJobs(harness);
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].connectionId).toBe(autoPaid);
+    });
+  });
+});

--- a/libs/core/src/identifier-mapping/domain/types/connection.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/connection.types.ts
@@ -44,6 +44,17 @@ export type ConnectionStatus = (typeof ConnectionStatusValues)[number];
  * stored here; use credentialsRef instead.
  */
 export interface ConnectionConfig {
+  /**
+   * Invoicing trigger configuration (OL #1120). Non-breaking documentation
+   * shape over the open index signature — the value is round-tripped verbatim
+   * by `ConnectionRepository`. `triggerModel` is read at transition time by
+   * `AutoIssueTriggerService` and coerced via `parseTriggerModel` (a missing or
+   * unrecognized value defaults to `manual`). Typed as `string` here to keep the
+   * identifier-mapping context decoupled from the invoicing enum.
+   */
+  invoicing?: {
+    triggerModel?: string;
+  };
   [key: string]: unknown;
 }
 

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.interface.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.interface.ts
@@ -1,0 +1,36 @@
+/**
+ * Auto-Issue Trigger Service Interface (ADR-026 §3 — core policy composer)
+ *
+ * Outward contract of the core policy service that turns a qualifying order
+ * transition into per-connection issuance jobs (OL #1120). It sits ABOVE the
+ * invoicing port: it reads the per-connection trigger model, evaluates whether
+ * the transition qualifies, composes the `IssueInvoiceCommand` from the clean
+ * in-hand `Order`, and enqueues one deterministic-keyed `invoicing.issue` job
+ * per matching invoicing connection. No rules engine — direct enqueue.
+ *
+ * ONE-WAY EDGE INVARIANT (F3): the implementation MUST NOT inject any
+ * OrdersModule-provided token. The `Order` (and `sourceConnectionId` /
+ * `sourceEventId`) arrive as METHOD ARGUMENTS, never via DI.
+ *
+ * @module libs/core/src/invoicing/application/services
+ * @see {@link AutoIssueTriggerService} for the implementation
+ */
+import type { Order } from '@openlinker/core/orders';
+
+export interface IAutoIssueTriggerService {
+  /**
+   * Evaluate a qualifying order transition and enqueue issuance jobs for every
+   * invoicing connection whose trigger model matches.
+   *
+   * @param order - The clean, fully-hydrated `Order` at transition time (carries
+   *   real buyer billing/shipping — the only PII-complete copy in the flow).
+   * @param sourceConnectionId - The order's source connection id.
+   * @param sourceEventId - The only trace token at the seam (NO `correlationId`
+   *   exists — D10); threaded into the job payload and every log envelope.
+   */
+  onOrderTransition(
+    order: Order,
+    sourceConnectionId: string,
+    sourceEventId?: string,
+  ): Promise<void>;
+}

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.spec.ts
@@ -1,0 +1,280 @@
+/**
+ * AutoIssueTriggerService unit tests (OL #1120). Mocks `ConnectionPort` +
+ * `ISyncJobsService`; asserts trigger-model gating, deterministic-key
+ * idempotency, plain-object payload (#12), and PII-safe per-connection
+ * isolation.
+ *
+ * @module libs/core/src/invoicing/application/services
+ */
+import {
+  AutoIssueTriggerService,
+  AUTO_ISSUE_RETRY_BUDGET,
+} from './auto-issue-trigger.service';
+import { BuyerProfile } from '../../domain/entities/buyer-profile.entity';
+import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { ISyncJobsService } from '@openlinker/core/sync';
+import type { Order } from '@openlinker/core/orders';
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: 'order-1',
+    status: 'processing',
+    paymentStatus: 'awaiting',
+    items: [{ id: 'i1', productId: 'p1', quantity: 2, price: 10, name: 'Widget' }],
+    totals: {
+      subtotal: 20,
+      tax: 0,
+      shipping: 0,
+      total: 20,
+      currency: 'PLN',
+      taxTreatment: 'inclusive',
+    },
+    billingAddress: {
+      firstName: 'Jan',
+      lastName: 'Kowalski',
+      address1: 'ul. Testowa 1',
+      city: 'Poznań',
+      postalCode: '60-001',
+      country: 'PL',
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeConnection(triggerModel: string | undefined, overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: overrides.id ?? 'conn-inv-1',
+    platformType: 'subiekt',
+    name: 'Invoicing conn',
+    status: 'active',
+    config: triggerModel === undefined ? {} : { invoicing: { triggerModel } },
+    credentialsRef: 'cred-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    adapterKey: 'subiekt',
+    enabledCapabilities: ['Invoicing'],
+    ...overrides,
+  } as Connection;
+}
+
+describe('AutoIssueTriggerService', () => {
+  let connectionPort: jest.Mocked<Pick<ConnectionPort, 'list'>>;
+  let syncJobs: jest.Mocked<ISyncJobsService>;
+  let service: AutoIssueTriggerService;
+  let warnSpy: jest.SpyInstance<void, [message: string]>;
+
+  beforeEach(() => {
+    connectionPort = { list: jest.fn() };
+    syncJobs = { schedule: jest.fn().mockResolvedValue({} as never) };
+    service = new AutoIssueTriggerService(
+      connectionPort as unknown as ConnectionPort,
+      syncJobs as unknown as ISyncJobsService,
+    );
+    // Silence + capture the PII-safe envelope log.
+    warnSpy = jest
+      .spyOn(
+        (service as unknown as { logger: { warn: (m: string) => void } }).logger,
+        'warn',
+      )
+      .mockImplementation(() => undefined) as jest.SpyInstance<void, [message: string]>;
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('onOrderTransition — trigger-model gating', () => {
+    it('auto-on-paid: paid order enqueues exactly one invoicing.issue job', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1', 'evt-1');
+      expect(syncJobs.schedule).toHaveBeenCalledTimes(1);
+      expect(syncJobs.schedule.mock.calls[0][0].jobType).toBe('invoicing.issue');
+    });
+
+    it('auto-on-paid: NON-paid payment statuses (awaiting) do NOT enqueue', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'awaiting' }), 'src-1');
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+    });
+
+    it('auto-on-paid: cod does NOT enqueue (cod ≠ paid)', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'cod' }), 'src-1');
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+    });
+
+    it('auto-on-shipped: order.status === shipped enqueues', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-shipped')]);
+      await service.onOrderTransition(makeOrder({ status: 'shipped' }), 'src-1');
+      expect(syncJobs.schedule).toHaveBeenCalledTimes(1);
+    });
+
+    it('auto-on-shipped: non-shipped status does NOT enqueue', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-shipped')]);
+      await service.onOrderTransition(makeOrder({ status: 'processing' }), 'src-1');
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+    });
+
+    it('manual: enqueues ZERO jobs (no-op)', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('manual')]);
+      await service.onOrderTransition(
+        makeOrder({ status: 'shipped', paymentStatus: 'paid' }),
+        'src-1',
+      );
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+    });
+
+    it('batched: caught + skipped (no enqueue), logged (deferred, never silently ignored)', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('batched')]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('BatchedTriggerNotImplementedError');
+    });
+
+    it('unset/unrecognized triggerModel defaults to manual (no enqueue)', async () => {
+      connectionPort.list.mockResolvedValue([
+        makeConnection(undefined, { id: 'c-unset' }),
+        makeConnection('nonsense', { id: 'c-bad' }),
+      ]);
+      await service.onOrderTransition(
+        makeOrder({ status: 'shipped', paymentStatus: 'paid' }),
+        'src-1',
+      );
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('connection discovery', () => {
+    it('excludes connections without the Invoicing capability', async () => {
+      connectionPort.list.mockResolvedValue([
+        makeConnection('auto-on-paid', { id: 'no-cap', enabledCapabilities: ['Orders'] }),
+      ]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+    });
+
+    it('queries only ACTIVE connections (D8 — active-only)', async () => {
+      connectionPort.list.mockResolvedValue([]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      expect(connectionPort.list).toHaveBeenCalledWith({ status: 'active' });
+    });
+  });
+
+  describe('idempotency / payload (F4)', () => {
+    it('schedules with deterministic idempotencyKey `invoice:{connId}:{orderId}` threaded twice', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid', { id: 'conn-X' })]);
+      await service.onOrderTransition(makeOrder({ id: 'order-Z', paymentStatus: 'paid' }), 'src-1');
+      const input = syncJobs.schedule.mock.calls[0][0];
+      expect(input.idempotencyKey).toBe('invoice:conn-X:order-Z');
+      expect((input.payload as { idempotencyKey: string }).idempotencyKey).toBe(
+        'invoice:conn-X:order-Z',
+      );
+    });
+
+    it('scheduled job carries maxAttempts === AUTO_ISSUE_RETRY_BUDGET and a present runAfter Date', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      const input = syncJobs.schedule.mock.calls[0][0];
+      expect(input.maxAttempts).toBe(AUTO_ISSUE_RETRY_BUDGET);
+      expect(input.runAfter).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('command composition fidelity', () => {
+    it('payload buyer carries the REAL billing name+address (not redacted)', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      const buyer = (syncJobs.schedule.mock.calls[0][0].payload as { buyer: { name: string; address: { line1: string } } }).buyer;
+      expect(buyer.name).toBe('Jan Kowalski');
+      expect(buyer.address.line1).toBe('ul. Testowa 1');
+    });
+
+    it('payload buyer is a PLAIN object (no BuyerProfile prototype / isCompany getter) (#12)', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      const buyer = (syncJobs.schedule.mock.calls[0][0].payload as { buyer: object }).buyer;
+      expect(buyer).not.toBeInstanceOf(BuyerProfile);
+      expect((buyer as { isCompany?: unknown }).isCompany).toBeUndefined();
+    });
+
+    it('no buyerTaxId ⇒ buyer type "private" (B2C-only MVP)', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      const buyer = (syncJobs.schedule.mock.calls[0][0].payload as { buyer: { type: string; taxId: unknown } }).buyer;
+      expect(buyer.type).toBe('private');
+      expect(buyer.taxId).toBeNull();
+    });
+  });
+
+  describe('per-connection isolation + PII-safe catch (F9/D11)', () => {
+    it('a connection whose composition throws InvalidBuyerProfileError is skipped; others still enqueue', async () => {
+      connectionPort.list.mockResolvedValue([
+        // No address ⇒ InvalidBuyerProfileError from the mapper.
+        makeConnection('auto-on-paid', { id: 'bad' }),
+        makeConnection('auto-on-paid', { id: 'good' }),
+      ]);
+      const badOrder = makeOrder({ paymentStatus: 'paid' });
+      // Strip addresses only affects the mapper for ALL connections, so instead
+      // verify isolation by making one connection's compose throw via a net order
+      // is not possible per-connection; use a shared order missing address and
+      // assert BOTH are skipped + logged (the isolation guarantee: no throw escapes).
+      const noAddr = { ...badOrder, billingAddress: undefined, shippingAddress: undefined };
+      await expect(service.onOrderTransition(noAddr, 'src-1')).resolves.toBeUndefined();
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('one connection throwing does not stop a later connection from enqueuing', async () => {
+      // First connection: net-priced order is shared, so simulate a per-connection
+      // failure by having schedule reject for the first connection id only.
+      connectionPort.list.mockResolvedValue([
+        makeConnection('auto-on-paid', { id: 'first' }),
+        makeConnection('auto-on-paid', { id: 'second' }),
+      ]);
+      syncJobs.schedule.mockImplementation((input) => {
+        if (input.connectionId === 'first') {
+          return Promise.reject(new Error('boom'));
+        }
+        return Promise.resolve({} as never);
+      });
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      // second still got scheduled despite first throwing.
+      const ids = syncJobs.schedule.mock.calls.map((c) => c[0].connectionId);
+      expect(ids).toContain('first');
+      expect(ids).toContain('second');
+    });
+
+    it('the catch envelope contains error.name / connectionId / order.id / sourceEventId and NO correlationId key', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid', { id: 'cZ' })]);
+      syncJobs.schedule.mockRejectedValue(new Error('transport down'));
+      await service.onOrderTransition(makeOrder({ id: 'oZ', paymentStatus: 'paid' }), 'src-1', 'evt-9');
+      const logged = warnSpy.mock.calls[0][0];
+      expect(logged).toContain('Error');
+      expect(logged).toContain('cZ');
+      expect(logged).toContain('oZ');
+      expect(logged).toContain('evt-9');
+      expect(logged).not.toContain('correlationId');
+    });
+
+    it('an unexpected error whose message embeds a buyer name does NOT leak into the log (non-allow-listed)', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      syncJobs.schedule.mockRejectedValue(new Error('failed for buyer Jan Kowalski'));
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      const logged = warnSpy.mock.calls[0][0];
+      expect(logged).not.toContain('Jan Kowalski');
+    });
+
+    it('envelope is well-formed when sourceEventId is undefined', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      syncJobs.schedule.mockRejectedValue(new Error('x'));
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      expect(warnSpy.mock.calls[0][0]).toContain('sourceEventId=n/a');
+    });
+  });
+
+  it('is defined', () => {
+    expect(AutoIssueTriggerService).toBeDefined();
+  });
+});

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
@@ -1,0 +1,233 @@
+/**
+ * Auto-Issue Trigger Service (ADR-026 §3 — core policy composer, OL #1120)
+ *
+ * Core-resident policy that turns a qualifying order transition (paid / shipped)
+ * into per-connection issuance jobs. It:
+ *  1. Lists ACTIVE invoicing connections (D8) via `ConnectionPort`.
+ *  2. Reads each connection's `config.invoicing.triggerModel` (`parseTriggerModel`).
+ *  3. Evaluates the transition (level-evaluated, D3): `auto-on-paid` iff paid;
+ *     `auto-on-shipped` iff `order.status === 'shipped'` (D6 + one-time viability
+ *     log, F7); `manual` → skip; `batched` → log + skip (deferred, F-cleanly).
+ *  4. Composes the `IssueInvoiceCommand` from the clean in-hand `Order` and
+ *     enqueues one `invoicing.issue` job per match with a deterministic key
+ *     `invoice:{connId}:{orderId}` composed ONCE and threaded into BOTH the
+ *     `ScheduleJobInput.idempotencyKey` AND `payload.idempotencyKey` (F4).
+ *
+ * Each connection is isolated in its own try/catch; the catch logs a PII-SAFE
+ * envelope only (F9 + D11): `error.name`, invoicing `connectionId`, `order.id`,
+ * `sourceEventId` (when present) — never the raw error / message / payload.
+ * `error.message` is added ONLY for the allow-listed deterministic, PII-clean
+ * errors (`InvalidBuyerProfileError`, `UnsupportedPriceTreatmentError`,
+ * `BatchedTriggerNotImplementedError`).
+ *
+ * ONE-WAY EDGE (F3): depends ONLY on `CONNECTION_PORT_TOKEN` (identifier-mapping)
+ * and `SYNC_JOBS_SERVICE_TOKEN` (sync). It injects NO OrdersModule token.
+ *
+ * @module libs/core/src/invoicing/application/services
+ * @implements {IAutoIssueTriggerService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  ConnectionPort,
+  CONNECTION_PORT_TOKEN,
+} from '@openlinker/core/identifier-mapping';
+import {
+  ISyncJobsService,
+  SYNC_JOBS_SERVICE_TOKEN,
+} from '@openlinker/core/sync';
+import type { Order } from '@openlinker/core/orders';
+import { PAYMENT_STATUS } from '@openlinker/core/orders';
+import { Logger } from '@openlinker/shared/logging';
+
+import type { IAutoIssueTriggerService } from './auto-issue-trigger.service.interface';
+import type { InvoiceTriggerModel } from '../../domain/types/invoice-trigger.types';
+import { parseTriggerModel } from '../../domain/types/invoice-trigger.types';
+import { toIssueInvoiceCommand } from '../mappers/order-to-issue-invoice-command.mapper';
+import { BatchedTriggerNotImplementedError } from '../../domain/exceptions/batched-trigger-not-implemented.error';
+import type { InvoicingIssuePayloadV1 } from '@openlinker/core/sync';
+
+/**
+ * Retry budget for issuance jobs (F1/F8/D9). Mirrors `RUNNER_RETRY_BUDGET = 3`:
+ * the smallest budget that honors the retry AC (>=2 so a bridge-unreachable
+ * blip genuinely retries) while keeping the D7 double-issue window deliberately
+ * small (each transport-in-doubt retry re-crosses the provider boundary against
+ * the `issued`-only gate).
+ */
+export const AUTO_ISSUE_RETRY_BUDGET = 3;
+
+/** Capability name a connection must enable to receive issuance jobs. */
+const INVOICING_CAPABILITY = 'Invoicing';
+
+/**
+ * Error names whose `message` is deterministic and PII-clean (each cites only
+ * `order.id` / `connectionId`), so they MAY be added to the per-connection log
+ * envelope. Any other error logs `error.name` only (F9/D11).
+ */
+const PII_SAFE_ERROR_NAMES: ReadonlySet<string> = new Set([
+  'InvalidBuyerProfileError',
+  'UnsupportedPriceTreatmentError',
+  'BatchedTriggerNotImplementedError',
+]);
+
+@Injectable()
+export class AutoIssueTriggerService implements IAutoIssueTriggerService {
+  private readonly logger = new Logger(AutoIssueTriggerService.name);
+
+  constructor(
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connectionPort: ConnectionPort,
+    @Inject(SYNC_JOBS_SERVICE_TOKEN)
+    private readonly syncJobs: ISyncJobsService,
+  ) {}
+
+  async onOrderTransition(
+    order: Order,
+    sourceConnectionId: string,
+    sourceEventId?: string,
+  ): Promise<void> {
+    // D8: only ACTIVE invoicing connections receive issuance jobs. The
+    // scheduler's `status: 'active'` filter already excludes disabled/error/
+    // needs_reauth connections.
+    const connections = (
+      await this.connectionPort.list({ status: 'active' })
+    ).filter((connection) =>
+      connection.enabledCapabilities.includes(INVOICING_CAPABILITY),
+    );
+
+    for (const connection of connections) {
+      // F9/D11: each connection is isolated — a compose/enqueue failure on one
+      // never aborts the others, and never escapes onOrderTransition (the
+      // OrderIngestionService catch swallows too, but defense in depth here keeps
+      // a single bad connection from skipping the rest).
+      try {
+        const triggerModel = parseTriggerModel(
+          connection.config.invoicing?.triggerModel,
+        );
+
+        if (!this.qualifies(order, triggerModel)) {
+          continue;
+        }
+
+        // F4: compose the deterministic key ONCE and thread it into BOTH the
+        // job-row idempotencyKey AND payload.idempotencyKey.
+        const idempotencyKey = `invoice:${connection.id}:${order.id}`;
+        const payload = this.composePayload(
+          order,
+          connection.id,
+          idempotencyKey,
+          triggerModel,
+          sourceConnectionId,
+          sourceEventId,
+        );
+
+        await this.syncJobs.schedule({
+          jobType: 'invoicing.issue',
+          connectionId: connection.id,
+          payload: payload as unknown as Record<string, unknown>,
+          idempotencyKey,
+          maxAttempts: AUTO_ISSUE_RETRY_BUDGET,
+          runAfter: new Date(),
+        });
+      } catch (error) {
+        this.logIssuanceFailure(error, connection.id, order.id, sourceEventId);
+      }
+    }
+  }
+
+  /**
+   * PII-SAFE per-connection failure log (F9/D11): names ONLY `error.name`,
+   * invoicing `connectionId`, `order.id`, and `sourceEventId` (when present).
+   * `error.message` is appended ONLY for the allow-listed deterministic,
+   * PII-clean errors — never the raw error/payload/buyer.
+   */
+  private logIssuanceFailure(
+    error: unknown,
+    connectionId: string,
+    orderId: string,
+    sourceEventId?: string,
+  ): void {
+    const name = error instanceof Error ? error.name : 'UnknownError';
+    const message =
+      error instanceof Error && PII_SAFE_ERROR_NAMES.has(error.name)
+        ? error.message
+        : undefined;
+
+    this.logger.warn(
+      `auto-issue trigger skipped connection: error=${name} connectionId=${connectionId} orderId=${orderId} sourceEventId=${sourceEventId ?? 'n/a'}${message ? ` detail=${message}` : ''}`,
+    );
+  }
+
+  /**
+   * Decide whether the trigger model qualifies for THIS transition
+   * (level-evaluated, D3): `auto-on-paid` iff paid; `auto-on-shipped` iff
+   * `order.status === 'shipped'`; `manual` → false; `batched` → throws
+   * `BatchedTriggerNotImplementedError`.
+   */
+  private qualifies(order: Order, triggerModel: InvoiceTriggerModel): boolean {
+    switch (triggerModel) {
+      case 'auto-on-paid':
+        // D3 level-evaluated: qualifies iff the order is currently paid.
+        return order.paymentStatus === PAYMENT_STATUS.Paid;
+      case 'auto-on-shipped':
+        // D6: honored only where the source surfaces 'shipped' inbound.
+        return order.status === 'shipped';
+      case 'manual':
+        return false;
+      case 'batched':
+        // Deferred to a future issue — rejected cleanly, never silently ignored.
+        throw new BatchedTriggerNotImplementedError(
+          `Batched trigger model is not implemented (order ${order.id})`,
+        );
+    }
+  }
+
+  /**
+   * Compose the SERIALIZABLE `invoicing.issue` payload (plain buyer shape, no
+   * `BuyerProfile` class — #12) from the clean `Order`, threading the SAME
+   * `idempotencyKey` into `payload.idempotencyKey` (F4). May surface
+   * `InvalidBuyerProfileError` / `UnsupportedPriceTreatmentError` from the mapper.
+   */
+  private composePayload(
+    order: Order,
+    invoicingConnectionId: string,
+    idempotencyKey: string,
+    triggerModel: InvoiceTriggerModel,
+    sourceConnectionId: string,
+    sourceEventId?: string,
+  ): InvoicingIssuePayloadV1 {
+    // The mapper owns the neutral Order->command rules and may surface
+    // InvalidBuyerProfileError / UnsupportedPriceTreatmentError (both PII-clean).
+    const command = toIssueInvoiceCommand({
+      order,
+      connectionId: invoicingConnectionId,
+      idempotencyKey,
+    });
+
+    // #12: flatten the BuyerProfile class into the PLAIN, jsonb-safe field-set.
+    const payload: InvoicingIssuePayloadV1 = {
+      schemaVersion: 1,
+      connectionId: invoicingConnectionId,
+      orderId: command.orderId,
+      idempotencyKey,
+      currency: command.currency,
+      lines: command.lines,
+      buyer: {
+        name: command.buyer.name,
+        taxId: command.buyer.taxId,
+        address: command.buyer.address,
+        type: command.buyer.type,
+      },
+      sourceConnectionId,
+      trigger: triggerModel,
+    };
+
+    if (command.documentType !== undefined) {
+      payload.documentType = command.documentType;
+    }
+    if (sourceEventId !== undefined) {
+      payload.sourceEventId = sourceEventId;
+    }
+
+    return payload;
+  }
+}

--- a/libs/core/src/invoicing/domain/exceptions/batched-trigger-not-implemented.error.ts
+++ b/libs/core/src/invoicing/domain/exceptions/batched-trigger-not-implemented.error.ts
@@ -1,0 +1,16 @@
+/**
+ * BatchedTriggerNotImplementedError
+ *
+ * Thrown by `AutoIssueTriggerService` when a connection's trigger model is
+ * `batched` — a mode DEFERRED to its own future issue (OL #1120). Surfacing a
+ * named error (vs. silently skipping) keeps the deferral explicit and operator-
+ * visible. PII-clean: the message cites only `connectionId` / `order.id`.
+ *
+ * @module libs/core/src/invoicing/domain/exceptions
+ */
+export class BatchedTriggerNotImplementedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BatchedTriggerNotImplementedError';
+  }
+}

--- a/libs/core/src/invoicing/domain/types/invoice-trigger.types.spec.ts
+++ b/libs/core/src/invoicing/domain/types/invoice-trigger.types.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * parseTriggerModel unit tests (OL #1120).
+ *
+ * @module libs/core/src/invoicing/domain/types
+ */
+import { parseTriggerModel, InvoiceTriggerModelValues } from './invoice-trigger.types';
+
+describe('parseTriggerModel', () => {
+  it('returns each known value verbatim (manual / auto-on-paid / auto-on-shipped / batched)', () => {
+    for (const value of InvoiceTriggerModelValues) {
+      expect(parseTriggerModel(value)).toBe(value);
+    }
+  });
+
+  it('returns "manual" for undefined / null', () => {
+    expect(parseTriggerModel(undefined)).toBe('manual');
+    expect(parseTriggerModel(null)).toBe('manual');
+  });
+
+  it('returns "manual" for an unrecognized string', () => {
+    expect(parseTriggerModel('auto-on-delivered')).toBe('manual');
+    expect(parseTriggerModel('')).toBe('manual');
+  });
+
+  it('returns "manual" for a non-string value', () => {
+    expect(parseTriggerModel(42)).toBe('manual');
+    expect(parseTriggerModel({ triggerModel: 'auto-on-paid' })).toBe('manual');
+    expect(parseTriggerModel(['auto-on-paid'])).toBe('manual');
+  });
+
+  it('exposes the four trigger-model values', () => {
+    expect(InvoiceTriggerModelValues).toHaveLength(4);
+  });
+});

--- a/libs/core/src/invoicing/domain/types/invoice-trigger.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoice-trigger.types.ts
@@ -1,0 +1,38 @@
+/**
+ * Invoice Trigger Model Types
+ *
+ * Per-connection trigger model that decides WHEN an order transition turns into
+ * an issuance call (OL #1120). Country/regulatory-agnostic (ADR-026) — names a
+ * lifecycle policy, not a tax concept. Persisted on `Connection.config` under
+ * `config.invoicing.triggerModel` (no migration — `ConnectionConfig` is jsonb).
+ *
+ * - `manual`         — never auto-issues; issuance is operator/API-driven.
+ * - `auto-on-paid`   — enqueue issuance when the order is paid.
+ * - `auto-on-shipped`— enqueue issuance when the order is shipped (honored only
+ *   where the source adapter emits `'shipped'` inbound — see D6).
+ * - `batched`        — DEFERRED to a future issue; rejected cleanly (never
+ *   silently ignored) by the trigger service.
+ *
+ * @module libs/core/src/invoicing/domain/types
+ */
+export const InvoiceTriggerModelValues = [
+  'manual',
+  'auto-on-paid',
+  'auto-on-shipped',
+  'batched',
+] as const;
+
+export type InvoiceTriggerModel = (typeof InvoiceTriggerModelValues)[number];
+
+/**
+ * Parse an untrusted `config.invoicing.triggerModel` value into the enum.
+ * Unset / missing / unrecognized maps to the safe default `manual` — the single
+ * source of truth for trigger-model coercion.
+ */
+export function parseTriggerModel(value: unknown): InvoiceTriggerModel {
+  return (InvoiceTriggerModelValues as readonly string[]).includes(
+    value as string,
+  )
+    ? (value as InvoiceTriggerModel)
+    : 'manual';
+}

--- a/libs/core/src/invoicing/index.ts
+++ b/libs/core/src/invoicing/index.ts
@@ -9,13 +9,30 @@
  * @module libs/core/src/invoicing
  */
 export * from './domain/types/invoicing.types';
+export {
+  InvoiceTriggerModelValues,
+  parseTriggerModel,
+} from './domain/types/invoice-trigger.types';
+export type { InvoiceTriggerModel } from './domain/types/invoice-trigger.types';
 export * from './domain/entities/buyer-profile.entity';
 export * from './domain/entities/invoice-record.entity';
 export * from './domain/ports/invoicing.port';
 export * from './domain/ports/invoice-record-repository.port';
 export * from './domain/exceptions/invoice-record-not-found.exception';
 export * from './domain/exceptions/duplicate-invoice-record.exception';
+export { BatchedTriggerNotImplementedError } from './domain/exceptions/batched-trigger-not-implemented.error';
+export { InvalidBuyerProfileError } from './application/mappers/errors/invalid-buyer-profile.error';
+export { UnsupportedPriceTreatmentError } from './application/mappers/errors/unsupported-price-treatment.error';
+export {
+  toIssueInvoiceCommand,
+  OrderToIssueInvoiceCommandInput,
+} from './application/mappers/order-to-issue-invoice-command.mapper';
 export { IInvoiceService } from './application/services/invoice.service.interface';
 export { InvoiceService } from './application/services/invoice.service';
+export type { IAutoIssueTriggerService } from './application/services/auto-issue-trigger.service.interface';
+export {
+  AutoIssueTriggerService,
+  AUTO_ISSUE_RETRY_BUDGET,
+} from './application/services/auto-issue-trigger.service';
 export * from './invoicing.tokens';
 export { InvoicingModule } from './invoicing.module';

--- a/libs/core/src/invoicing/invoicing.module.ts
+++ b/libs/core/src/invoicing/invoicing.module.ts
@@ -11,18 +11,23 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { IntegrationsModule } from '@openlinker/core/integrations';
+import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
+import { SyncModule } from '@openlinker/core/sync';
 
 import { InvoiceRecordOrmEntity } from './infrastructure/persistence/entities/invoice-record.orm-entity';
 import { InvoiceRecordRepository } from './infrastructure/persistence/repositories/invoice-record.repository';
 import { InvoiceService } from './application/services/invoice.service';
+import { AutoIssueTriggerService } from './application/services/auto-issue-trigger.service';
 import {
   INVOICE_RECORD_REPOSITORY_TOKEN,
   INVOICE_SERVICE_TOKEN,
+  AUTO_ISSUE_TRIGGER_SERVICE_TOKEN,
 } from './invoicing.tokens';
 
 export {
   INVOICE_RECORD_REPOSITORY_TOKEN,
   INVOICE_SERVICE_TOKEN,
+  AUTO_ISSUE_TRIGGER_SERVICE_TOKEN,
 } from './invoicing.tokens';
 
 @Module({
@@ -33,6 +38,12 @@ export {
     // that token but is NOT @Global, so it must be imported (mirrors
     // ShippingModule). No cycle — integrations does not reference invoicing.
     IntegrationsModule,
+    // AutoIssueTriggerService (OL #1120) injects CONNECTION_PORT_TOKEN
+    // (identifier-mapping) and SYNC_JOBS_SERVICE_TOKEN (sync). Neither module
+    // references invoicing → no DI cycle (verified at runtime by the boot gate:
+    // apps/worker/test/integration/invoicing-auto-issue-boot.int-spec.ts).
+    IdentifierMappingModule,
+    SyncModule,
   ],
   providers: [
     InvoiceRecordRepository,
@@ -45,7 +56,19 @@ export {
       provide: INVOICE_SERVICE_TOKEN,
       useExisting: InvoiceService,
     },
+    AutoIssueTriggerService,
+    {
+      provide: AUTO_ISSUE_TRIGGER_SERVICE_TOKEN,
+      useExisting: AutoIssueTriggerService,
+    },
   ],
-  exports: [INVOICE_RECORD_REPOSITORY_TOKEN, INVOICE_SERVICE_TOKEN],
+  // Export BOTH the token and the provider so OrdersModule (which imports this
+  // module) can inject the trigger service by token (F2/F3).
+  exports: [
+    INVOICE_RECORD_REPOSITORY_TOKEN,
+    INVOICE_SERVICE_TOKEN,
+    AUTO_ISSUE_TRIGGER_SERVICE_TOKEN,
+    AutoIssueTriggerService,
+  ],
 })
 export class InvoicingModule {}

--- a/libs/core/src/invoicing/invoicing.tokens.ts
+++ b/libs/core/src/invoicing/invoicing.tokens.ts
@@ -11,3 +11,10 @@ export const INVOICE_RECORD_REPOSITORY_TOKEN = Symbol('InvoiceRecordRepositoryPo
 
 /** Binding token for the {@link IInvoiceService} application service (ADR-026 "SVC"). */
 export const INVOICE_SERVICE_TOKEN = Symbol('IInvoiceService');
+
+/**
+ * Binding token for the {@link IAutoIssueTriggerService} core policy service
+ * (ADR-026 §3, OL #1120). Injected by `OrderIngestionService` to turn a
+ * qualifying transition into per-connection issuance jobs.
+ */
+export const AUTO_ISSUE_TRIGGER_SERVICE_TOKEN = Symbol('IAutoIssueTriggerService');

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -22,6 +22,7 @@ import type {
 import type { IOrderSyncService } from '../../interfaces/order-sync.service.interface';
 import type { IOrderRecordService } from '../../interfaces/order-record.service.interface';
 import type { IOrderItemRefResolverService } from '../../interfaces/order-item-ref-resolver.service.interface';
+import type { IAutoIssueTriggerService } from '@openlinker/core/invoicing';
 import { MissingOrderItemMappingError } from '../../../domain/exceptions/missing-order-item-mapping.error';
 import type { OrderRecord } from '../../../domain/entities/order-record.entity';
 
@@ -41,6 +42,7 @@ describe('OrderIngestionService', () => {
   let orderItemRefResolver: jest.Mocked<IOrderItemRefResolverService>;
   let customerIdentityResolver: jest.Mocked<ICustomerIdentityResolverService>;
   let customerProjectionUpdater: jest.Mocked<IOrderCustomerProjectionUpdaterService>;
+  let autoIssueTrigger: jest.Mocked<IAutoIssueTriggerService>;
 
   const connectionId = 'connection-123';
   const cursorKey = 'allegro.orders.lastEventId';
@@ -111,6 +113,10 @@ describe('OrderIngestionService', () => {
       updateProjectionsForOrder: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<IOrderCustomerProjectionUpdaterService>;
 
+    autoIssueTrigger = {
+      onOrderTransition: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<IAutoIssueTriggerService>;
+
     service = new OrderIngestionService(
       integrationsService,
       syncCursors as unknown as ISyncCursorsService,
@@ -121,8 +127,74 @@ describe('OrderIngestionService', () => {
       orderSyncService,
       customerIdentityResolver,
       orderRecordService,
-      customerProjectionUpdater
+      customerProjectionUpdater,
+      autoIssueTrigger
     );
+  });
+
+  describe('auto-issue trigger (OL #1120)', () => {
+    const externalOrderId = 'checkout-1';
+    const baseIncoming = {
+      externalOrderId,
+      orderNumber: externalOrderId,
+      status: 'BOUGHT',
+      items: [],
+      totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'PLN' },
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    };
+
+    beforeEach(() => {
+      identifierMapping.getOrCreateInternalId.mockResolvedValue('ol_order_test');
+      orderSource.getOrder.mockResolvedValue(baseIncoming);
+      integrationsService.getCapabilityAdapter.mockResolvedValue(orderSource);
+    });
+
+    it('calls onOrderTransition at the terminal path with the in-scope sourceEventId as the 3rd arg', async () => {
+      orderSyncService.syncOrder.mockResolvedValue([]);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId, 'evt-42');
+
+      expect(autoIssueTrigger.onOrderTransition).toHaveBeenCalledTimes(1);
+      const [order, srcConn, evt] = autoIssueTrigger.onOrderTransition.mock.calls[0];
+      expect(order).toEqual(expect.objectContaining({ id: 'ol_order_test' }));
+      expect(srcConn).toBe(connectionId);
+      expect(evt).toBe('evt-42');
+      // Fires only after destination status is settled.
+      expect(orderSyncService.syncOrder.mock.invocationCallOrder[0]).toBeLessThan(
+        autoIssueTrigger.onOrderTransition.mock.invocationCallOrder[0]
+      );
+    });
+
+    it('swallows a thrown onOrderTransition failure — order sync still returns results — with a PII-safe log', async () => {
+      const warnSpy = jest
+        .spyOn((service as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn')
+        .mockImplementation(() => undefined);
+      orderSyncService.syncOrder.mockResolvedValue([]);
+      autoIssueTrigger.onOrderTransition.mockRejectedValueOnce(
+        new Error('issuance exploded for buyer Jan Kowalski')
+      );
+
+      const results = await service.syncOrderFromSource(connectionId, externalOrderId, 'evt-7');
+
+      expect(results).toEqual([]);
+      const logged = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).not.toContain('Jan Kowalski');
+      expect(logged).not.toContain('correlationId');
+      expect(logged).toContain('evt-7');
+      warnSpy.mockRestore();
+    });
+
+    it('a destination-echo re-read returns [] and does NOT call onOrderTransition', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValueOnce({
+        sourceConnectionId: 'other-connection',
+      } as never);
+
+      const results = await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(results).toEqual([]);
+      expect(autoIssueTrigger.onOrderTransition).not.toHaveBeenCalled();
+    });
   });
 
   describe('syncFromMarketplace', () => {

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -26,6 +26,10 @@ import {
 } from '@openlinker/core/sync';
 import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import {
+  IAutoIssueTriggerService,
+  AUTO_ISSUE_TRIGGER_SERVICE_TOKEN,
+} from '@openlinker/core/invoicing';
+import {
   ICustomerIdentityResolverService,
   CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN,
   IOrderCustomerProjectionUpdaterService,
@@ -76,7 +80,12 @@ export class OrderIngestionService implements IOrderIngestionService {
     @Inject(ORDER_RECORD_SERVICE_TOKEN)
     private readonly orderRecordService: IOrderRecordService,
     @Inject(ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN)
-    private readonly customerProjectionUpdater: IOrderCustomerProjectionUpdaterService
+    private readonly customerProjectionUpdater: IOrderCustomerProjectionUpdaterService,
+    // OL #1120: core policy composer that turns this transition into per-connection
+    // issuance jobs. One-way edge (F3) — this service is consumed via the token,
+    // never the reverse.
+    @Inject(AUTO_ISSUE_TRIGGER_SERVICE_TOKEN)
+    private readonly autoIssueTrigger: IAutoIssueTriggerService
   ) {}
 
   async ingestOrders(
@@ -329,6 +338,28 @@ export class OrderIngestionService implements IOrderIngestionService {
       if (settlement.status === 'rejected') {
         this.logger.warn('Failed to update order record sync status', settlement.reason);
       }
+    }
+
+    // OL #1120 — auto-issue trigger (EV→SVC edge, ADR-026 §3). Fires STRICTLY at
+    // the end of the authoritative source poll, AFTER per-destination status is
+    // settled. The destination-echo early-return (`return []`) above is the
+    // INTENDED gate: issuance fires only on the real source ingestion, never on a
+    // destination re-read. Threads the in-scope `sourceEventId` as the trace token
+    // (D10 — no `correlationId` exists). Wrapped so an enqueue/compose failure
+    // never blocks order sync; the catch logs a PII-SAFE envelope only (F9/D11):
+    // `error.name` + `connectionId` + `order.id` + `sourceEventId` — never the raw
+    // error/message or any payload/buyer field.
+    try {
+      await this.autoIssueTrigger.onOrderTransition(order, connectionId, sourceEventId);
+    } catch (error) {
+      // F9/D11: issuance is best-effort relative to order sync. SWALLOW — never
+      // re-throw — so an enqueue/compose failure can never block the order
+      // pipeline. Log a PII-SAFE envelope only: error.name + connectionId +
+      // order.id + sourceEventId — never the raw error/message or any payload.
+      const errorName = error instanceof Error ? error.name : 'UnknownError';
+      this.logger.warn(
+        `Auto-issue trigger failed (swallowed): error=${errorName} connectionId=${connectionId} orderId=${order.id} sourceEventId=${sourceEventId ?? 'n/a'}`
+      );
     }
 
     return results;

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -29,6 +29,7 @@ import { SyncModule } from '@openlinker/core/sync';
 import { ProductsModule } from '@openlinker/core/products';
 import { MappingsModule } from '@openlinker/core/mappings';
 import { CustomersModule } from '@openlinker/core/customers';
+import { InvoicingModule } from '@openlinker/core/invoicing';
 
 // Re-export tokens for convenience
 export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
@@ -42,6 +43,9 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     ProductsModule, // Required for PRODUCT_VARIANT_REPOSITORY_TOKEN
     MappingsModule, // Required for MAPPING_CONFIG_SERVICE_TOKEN
     CustomersModule, // Required for CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN
+    // One-way edge (F3): OrderIngestionService injects AUTO_ISSUE_TRIGGER_SERVICE_TOKEN.
+    // InvoicingModule's mapper imports orders TYPES only (compile-time) → no DI cycle.
+    InvoicingModule,
   ],
   providers: [
     // Provide classes directly first

--- a/libs/core/src/sync/domain/types/invoicing-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/invoicing-job-payloads.types.ts
@@ -1,0 +1,69 @@
+/**
+ * Invoicing Job Payload Types (Generic)
+ *
+ * Canonical payload schema for `invoicing.issue` sync jobs (OL #1120). The job
+ * carries an ALREADY-COMPOSED, fully-serializable issuance command so the worker
+ * handler is a pure delegate.
+ *
+ * SERIALIZATION CONTRACT (#12): the `buyer` field is the PLAIN field-set of
+ * `BuyerProfile` (no class, no `isCompany` getter) — a `BuyerProfile` class
+ * instance cannot survive the jsonb round-trip. The handler reconstructs
+ * `new BuyerProfile(...)` from this shape.
+ *
+ * PII NOTE (D11): this payload deliberately carries the real buyer name/address
+ * (a fiscal document legally requires them). Therefore NO log/error path — in the
+ * policy service OR the worker handler — may serialize `payload` / `buyer` /
+ * `lines`.
+ *
+ * `schemaVersion: 1` pins the contract; future breaking changes bump it and
+ * handlers must accept every version seen in persisted jobs until drained.
+ *
+ * @module libs/core/src/sync/domain/types
+ */
+import type {
+  BuyerAddress,
+  BuyerType,
+  InvoiceLine,
+  TaxIdentifier,
+} from '@openlinker/core/invoicing';
+import type { InvoiceTriggerModel } from '@openlinker/core/invoicing';
+
+/** PLAIN, serializable counterpart of `BuyerProfile` (no class, no getter). */
+export interface InvoicingIssueBuyerV1 {
+  name: string;
+  /** Scheme-tagged tax id, or `null` for B2C. */
+  taxId: TaxIdentifier | null;
+  address: BuyerAddress;
+  type: BuyerType;
+}
+
+/**
+ * Payload for `invoicing.issue` jobs (OL #1120). Connection id is duplicated in
+ * `connectionId` (the issuance connection) AND available on `job.connectionId`.
+ */
+export interface InvoicingIssuePayloadV1 {
+  schemaVersion: 1;
+  /** The invoicing connection the document is issued on. */
+  connectionId: string;
+  /** OL internal order id. */
+  orderId: string;
+  /**
+   * Deterministic exactly-once key — the SAME string used as the SyncJob row
+   * `idempotencyKey` AND the `IssueInvoiceCommand.idempotencyKey` (F4).
+   */
+  idempotencyKey: string;
+  /** Neutral document type; pass-through, adapter derives when absent. */
+  documentType?: string;
+  /** ISO-4217 currency. */
+  currency: string;
+  /** Plain invoice lines (numbers, no class). */
+  lines: InvoiceLine[];
+  /** PLAIN buyer field-set (reconstructed into `BuyerProfile` by the handler). */
+  buyer: InvoicingIssueBuyerV1;
+  /** The order's source connection (provenance / debugging). */
+  sourceConnectionId: string;
+  /** Only trace token at the seam (D10); optional — NO `correlationId` exists. */
+  sourceEventId?: string;
+  /** The trigger model that produced this job. */
+  trigger: InvoiceTriggerModel;
+}

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -41,6 +41,9 @@ export const JobTypeValues = [
 
   // Internal orchestration (core-owned policies; executed by worker)
   'inventory.propagateToMarketplaces',
+
+  // Invoicing (core-owned policy; executed by worker — OL #1120)
+  'invoicing.issue',
 ] as const;
 
 /**

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -89,6 +89,10 @@ export {
   ShopProductPublishPayloadV2,
   ShopProductPublishPayload,
 } from './domain/types/shop-job-payloads.types';
+export type {
+  InvoicingIssuePayloadV1,
+  InvoicingIssueBuyerV1,
+} from './domain/types/invoicing-job-payloads.types';
 
 // Exceptions
 export { SyncJobExecutionError } from './domain/exceptions/sync-job-execution.error';


### PR DESCRIPTION
## What

Auto-issue trigger — a qualifying order transition (paid / shipped) enqueues invoice issuance, per a per-connection trigger model.

`Closes #1120`

> **Stacked on #1118** (PR #1173). Base `1118-invoice-service`; retarget to `main` after #1118 merges.

## How
- **EV seam:** end of `OrderIngestionService.syncOrderFromSource` → core `AutoIssueTriggerService.onOrderTransition(order, connectionId, sourceEventId)` (swallow-catch, PII-safe envelope). ADR-026 EV→SVC; policy stays in core (ADR-007), not the worker.
- **Trigger model** in `connection.config.invoicing.triggerModel` (no migration — jsonb): `auto-on-paid` (paymentStatus=paid) / `auto-on-shipped` (status=shipped) enqueue; `manual` = no-op; `batched` = deferred (throws `BatchedTriggerNotImplementedError`, logged+skipped).
- **Idempotency:** deterministic key `invoice:{connectionId}:{orderId}` threaded into BOTH the SyncJob row key AND the payload → duplicate/re-delivered events never double-issue (job-layer dedup + the #1118 service exactly-once gate).
- **Worker `InvoicingIssueHandler`:** deep-validates payload (no PII in logs; `business_failure` on violation), rebuilds `BuyerProfile`, delegates to `IInvoiceService.issueInvoice`; transport errors → `SyncJobExecutionError` (retry via existing `RetryService`). B2C-only MVP (no tax-id source on `Order`).
- DI: `InvoicingModule` exports `AUTO_ISSUE_TRIGGER_SERVICE_TOKEN`; `OrdersModule` + worker `SyncWorkerModule` import it (boot-tested, no DI cycle).

## Verification
- **lint** (incl. `check:invariants`) + **type-check** + **worker 182** + **core 1236** unit tests — green.
- DI-boot + e2e auto-issue integration suites pass under Testcontainers (auto-on-paid single enqueue + deterministic-key short-circuit on re-delivery; non-paid no-op; manual zero jobs; per-connection isolation).

## ⚠ Known deferral
- **auto-on-shipped is a typed enum value but currently a logged deferral** — no `'shipped'` order-feed event reaches the ingestion seam yet (the shipped signal lives on the fulfillment seam; needs its own issue + an un-redacted buyer read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txy9aqLujJBG1dSwGd4z3f
