### PR TITLE
feat(integrations): KSeF 2.0 authentication & session crypto layer (#1147)

### DIFF
--- a/libs/integrations/ksef/src/application/factories/__tests__/ksef-adapter.factory.spec.ts
+++ b/libs/integrations/ksef/src/application/factories/__tests__/ksef-adapter.factory.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * KSeF adapter factory specs — credential resolution + fail-fast config errors.
+ *
+ * @module libs/integrations/ksef/src/application/factories
+ */
+import { KsefAdapterFactory } from '../ksef-adapter.factory';
+import { KsefConfigException } from '../../../domain/exceptions/ksef-config.exception';
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import { Connection, type IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+
+const idMapping = {} as IdentifierMappingPort;
+
+function connection(opts: {
+  config?: Record<string, unknown>;
+  credentialsRef?: string;
+} = {}): Connection {
+  return new Connection(
+    'conn-1',
+    'ksef',
+    'KSeF',
+    'active',
+    opts.config ?? { env: 'test' },
+    opts.credentialsRef ?? 'ref:ksef',
+    new Date(),
+    new Date(),
+    undefined,
+    [],
+  );
+}
+
+function resolver(map: Record<string, unknown>): CredentialsResolverPort {
+  return {
+    get: <T>(ref: string): Promise<T> => {
+      if (!(ref in map)) {
+        return Promise.reject(new Error(`no secret for ${ref}`));
+      }
+      return Promise.resolve(map[ref] as T);
+    },
+  };
+}
+
+describe('KsefAdapterFactory', () => {
+  it('should build an invoicing adapter for a valid ksef-token connection', async () => {
+    const factory = new KsefAdapterFactory();
+    const adapters = await factory.createAdapters(
+      connection(),
+      idMapping,
+      resolver({
+        'ref:ksef': { authType: 'ksef-token', secretRef: 'ref:secret' },
+        'ref:secret': { token: 'TKN', contextNip: '1234567890' },
+      }),
+    );
+    expect(adapters.invoicing).toBeDefined();
+  });
+
+  it('should throw when the environment is missing/invalid', async () => {
+    const factory = new KsefAdapterFactory();
+    await expect(
+      factory.createAdapters(connection({ config: {} }), idMapping, resolver({})),
+    ).rejects.toBeInstanceOf(KsefConfigException);
+  });
+
+  it('should throw when credentialsRef is absent', async () => {
+    const factory = new KsefAdapterFactory();
+    await expect(
+      factory.createAdapters(connection({ credentialsRef: '' }), idMapping, resolver({})),
+    ).rejects.toBeInstanceOf(KsefConfigException);
+  });
+
+  it('should throw when the credential shape is malformed', async () => {
+    const factory = new KsefAdapterFactory();
+    await expect(
+      factory.createAdapters(connection(), idMapping, resolver({ 'ref:ksef': { authType: 'ksef-token' } })),
+    ).rejects.toBeInstanceOf(KsefConfigException);
+  });
+
+  it('should reject the qualified-seal authType (deferred to C4)', async () => {
+    const factory = new KsefAdapterFactory();
+    await expect(
+      factory.createAdapters(
+        connection(),
+        idMapping,
+        resolver({ 'ref:ksef': { authType: 'qualified-seal', secretRef: 'ref:cert' } }),
+      ),
+    ).rejects.toBeInstanceOf(KsefConfigException);
+  });
+});

--- a/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
+++ b/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
@@ -1,54 +1,112 @@
 /**
  * KSeF Adapter Factory
  *
- * Single per-connection construction seam for the KSeF plugin. C2 builds the
- * stub `Invoicing` capability adapter; C3 resolves the connection's credentials
- * via the host `CredentialsResolverPort` and builds the concrete `KsefHttpClient`
- * (auth header injection, retry/backoff), and C4 wires the issuance mechanics.
+ * Single per-connection construction seam for the KSeF plugin. Resolves the
+ * connection's credentials via the host `CredentialsResolverPort`, validates
+ * the config + credential shape, and builds the concrete `KsefHttpClient` (auth
+ * header injection, retry/backoff, token lifecycle) wired to the per-connection
+ * capability adapters. C4 wires the issuance mechanics onto the same client.
  * Routing all construction through here keeps credential + environment
  * resolution in one place (the Allegro/Erli precedent).
  *
- * Not `@Injectable` — a plain class; the client it builds (C3) closes over one
+ * Not `@Injectable` — a plain class; the client it builds closes over one
  * connection's resolved secret, never a DI singleton.
+ *
+ * SECURITY: the resolved token is handed straight into the client's token
+ * material and never logged. A missing `credentialsRef`, unresolvable secret, or
+ * malformed credential shape fails fast with `KsefConfigException` before any
+ * request leaves the client (ADR-003).
+ *
+ * Qualified-seal (X.509) connections are not constructable until C4 — they
+ * throw `KsefConfigException` here so the connection fails loudly rather than
+ * half-wiring an unusable client.
  *
  * @module libs/integrations/ksef/src/application/factories
  */
+import type { CachePort } from '@openlinker/shared/cache';
 import type { CredentialsResolverPort } from '@openlinker/core/integrations';
 import type { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { KsefInvoicingAdapter } from '../../infrastructure/adapters/ksef-invoicing.adapter';
-import type { IKsefHttpClient } from '../../infrastructure/http/ksef-http-client.interface';
+import { createKsefHttpClient } from '../../infrastructure/http/ksef-http-client.factory';
+import type { KsefTokenAuthMaterial } from '../../infrastructure/http/auth/ksef-auth-handshake.service';
+import type {
+  KsefConnectionConfig,
+  KsefCredentials,
+  KsefEnvironment,
+} from '../../domain/types/ksef-connection.types';
+import { KsefEnvironmentValues } from '../../domain/types/ksef-connection.types';
+import { KsefConfigException } from '../../domain/exceptions/ksef-config.exception';
 import type { IKsefAdapterFactory, KsefAdapters } from '../interfaces/ksef-adapter.factory.interface';
 
 export type { KsefAdapters };
 
+/** Resolved ksef-token secret shape behind `secretRef` (host-decrypted). */
+interface KsefResolvedTokenSecret {
+  token: string;
+  contextNip: string;
+}
+
 export class KsefAdapterFactory implements IKsefAdapterFactory {
-  createAdapters(
+  constructor(private readonly cache?: CachePort) {}
+
+  async createAdapters(
     connection: Connection,
-    // identifierMapping, credentialsResolver unused in the C2 stub; kept on the
-    // signature so later phases extend behaviour without changing the factory
-    // contract (mirrors the Allegro/Erli precedent).
     _identifierMapping: IdentifierMappingPort,
-    _credentialsResolver: CredentialsResolverPort,
+    credentialsResolver: CredentialsResolverPort,
   ): Promise<KsefAdapters> {
-    // C3 replaces this placeholder with a credentials-resolved KsefHttpClient.
-    // The stub adapter never issues a request, so no secret is resolved in C2 —
-    // credentials are deliberately NOT read from connection.config (ADR-003).
-    const httpClient = this.createStubHttpClient();
-    return Promise.resolve({
-      invoicing: new KsefInvoicingAdapter(connection.id, httpClient),
+    const env = this.resolveEnvironment(connection);
+    const credentials = await this.resolveCredentials(connection, credentialsResolver);
+    const authMaterial = await this.resolveAuthMaterial(connection, credentials, credentialsResolver);
+
+    const { httpClient } = createKsefHttpClient({
+      connectionId: connection.id,
+      env,
+      authMaterial,
+      cache: this.cache,
     });
+
+    return { invoicing: new KsefInvoicingAdapter(connection.id, httpClient) };
   }
 
-  /**
-   * Placeholder transport for C2. Every method rejects so a stray call surfaces
-   * loudly rather than returning undefined; C3 swaps in the concrete client.
-   */
-  private createStubHttpClient(): IKsefHttpClient {
-    const notWired = (): Promise<never> =>
-      Promise.reject(new Error('KSeF HTTP client is not wired until C3'));
-    return {
-      get: notWired,
-      post: notWired,
-    };
+  private resolveEnvironment(connection: Connection): KsefEnvironment {
+    const config = connection.config as Partial<KsefConnectionConfig> | undefined;
+    const env = config?.env;
+    if (!env || !KsefEnvironmentValues.includes(env)) {
+      throw new KsefConfigException(`KSeF connection has no valid environment`, connection.id);
+    }
+    return env;
+  }
+
+  private async resolveCredentials(
+    connection: Connection,
+    credentialsResolver: CredentialsResolverPort,
+  ): Promise<KsefCredentials> {
+    if (!connection.credentialsRef) {
+      throw new KsefConfigException('KSeF connection has no credentialsRef', connection.id);
+    }
+    const credentials = await credentialsResolver.get<KsefCredentials>(connection.credentialsRef);
+    if (!credentials?.authType || !credentials?.secretRef) {
+      throw new KsefConfigException('KSeF credentials missing authType or secretRef', connection.id);
+    }
+    return credentials;
+  }
+
+  private async resolveAuthMaterial(
+    connection: Connection,
+    credentials: KsefCredentials,
+    credentialsResolver: CredentialsResolverPort,
+  ): Promise<KsefTokenAuthMaterial> {
+    if (credentials.authType !== 'ksef-token') {
+      // Qualified-seal needs real X.509/HSM material — deferred to C4.
+      throw new KsefConfigException(
+        `KSeF authType '${credentials.authType}' is not constructable until C4 (qualified-seal)`,
+        connection.id,
+      );
+    }
+    const secret = await credentialsResolver.get<KsefResolvedTokenSecret>(credentials.secretRef);
+    if (!secret?.token || !secret?.contextNip) {
+      throw new KsefConfigException('KSeF token secret missing token or contextNip', connection.id);
+    }
+    return { authType: 'ksef-token', token: secret.token, contextNip: secret.contextNip };
   }
 }

--- a/libs/integrations/ksef/src/domain/exceptions/ksef-api.exception.ts
+++ b/libs/integrations/ksef/src/domain/exceptions/ksef-api.exception.ts
@@ -11,6 +11,10 @@
  * `responseBody` is diagnostics-only — it may echo back submitted data, so it
  * MUST NOT be logged above `debug`, and never carries credential material.
  *
+ * `retryAfterMs` carries the parsed `Retry-After` delay (in milliseconds) on a
+ * `429` so the client's rate-limit backoff can honour the server's hint without
+ * overloading `responseBody`.
+ *
  * @module libs/integrations/ksef/src/domain/exceptions
  */
 export class KsefApiException extends Error {
@@ -19,6 +23,7 @@ export class KsefApiException extends Error {
     public readonly statusCode?: number,
     public readonly responseBody?: string,
     public readonly url?: string,
+    public readonly retryAfterMs?: number,
   ) {
     super(message);
     this.name = 'KsefApiException';

--- a/libs/integrations/ksef/src/domain/exceptions/ksef-network.exception.ts
+++ b/libs/integrations/ksef/src/domain/exceptions/ksef-network.exception.ts
@@ -1,0 +1,30 @@
+/**
+ * KSeF Network Exception
+ *
+ * Thrown for a transient transport failure against the KSeF API — DNS/TLS
+ * failure, connection refused, request timeout/abort, or a refresh attempt that
+ * could not reach the auth endpoint. Mirrors the Allegro precedent (#499):
+ * surfaced as a RETRYABLE error so the worker's retry classifier backs off and
+ * retries rather than marking the job dead, which is reserved for a genuine
+ * `KsefAuthenticationException` (credential rejection).
+ *
+ * Never carries credential material in its message.
+ *
+ * @module libs/integrations/ksef/src/domain/exceptions
+ */
+export class KsefNetworkException extends Error {
+  constructor(
+    message: string,
+    public readonly url?: string,
+    options?: { cause?: Error },
+  ) {
+    super(message);
+    this.name = 'KsefNetworkException';
+    if (options?.cause) {
+      this.cause = options.cause;
+    }
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, KsefNetworkException);
+    }
+  }
+}

--- a/libs/integrations/ksef/src/domain/exceptions/ksef-session-crypto.exception.ts
+++ b/libs/integrations/ksef/src/domain/exceptions/ksef-session-crypto.exception.ts
@@ -1,0 +1,32 @@
+/**
+ * KSeF Session Crypto Exception
+ *
+ * Thrown for any failure in the session/auth crypto layer — RSA-OAEP key
+ * wrapping, AES-256-CBC encrypt/decrypt, MF public-key fetch/validation, or
+ * malformed key material. Distinct from `KsefAuthenticationException` (a live
+ * 401/403 auth rejection): a crypto failure is a local primitive failure or a
+ * cert-trust problem, surfaced before (or independent of) any auth verdict.
+ *
+ * SECURITY: this exception MUST NOT carry key bytes, plaintext, or ciphertext.
+ * The optional `cause` is the underlying Node crypto error — it may carry an
+ * error `code` but never the inputs (Node crypto errors don't echo key/plaintext
+ * bytes). Callers log only `message` + `cause.code`, never `cause` verbatim into
+ * an external sink that might serialize buffers.
+ *
+ * @module libs/integrations/ksef/src/domain/exceptions
+ */
+export class KsefSessionCryptoException extends Error {
+  constructor(
+    message: string,
+    /** Machine-readable code for the failing operation (e.g. 'RSA_WRAP_FAILED'). */
+    public readonly errorCode?: string,
+    /** Underlying cause; never serialize verbatim to an external sink. */
+    public readonly cause?: Error,
+  ) {
+    super(message);
+    this.name = 'KsefSessionCryptoException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, KsefSessionCryptoException);
+    }
+  }
+}

--- a/libs/integrations/ksef/src/index.ts
+++ b/libs/integrations/ksef/src/index.ts
@@ -43,3 +43,5 @@ export {
 export { KsefApiException } from './domain/exceptions/ksef-api.exception';
 export { KsefAuthenticationException } from './domain/exceptions/ksef-authentication.exception';
 export { KsefConfigException } from './domain/exceptions/ksef-config.exception';
+export { KsefNetworkException } from './domain/exceptions/ksef-network.exception';
+export { KsefSessionCryptoException } from './domain/exceptions/ksef-session-crypto.exception';

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
@@ -31,9 +31,9 @@ import type { IKsefHttpClient } from '../http/ksef-http-client.interface';
 export class KsefInvoicingAdapter implements InvoicingPort {
   constructor(
     private readonly connectionId: string,
-    // Accepted (not stored) in the C2 stub so the factory call site is already
-    // shaped for C3, where the concrete client is wired in and retained.
-    _httpClient: IKsefHttpClient,
+    // Retained from C3: the concrete `KsefHttpClient` the C4 issuance mechanics
+    // call. Kept private until those methods land so the field is "used".
+    private readonly httpClient: IKsefHttpClient,
   ) {}
 
   issueInvoice(_cmd: IssueInvoiceCommand): Promise<InvoiceRecord> {
@@ -51,6 +51,15 @@ export class KsefInvoicingAdapter implements InvoicingPort {
   getSupportedDocumentTypes(): DocumentType[] {
     // No document type is issuable until C4 wires the issuance mechanics.
     return [];
+  }
+
+  /**
+   * The connection's transport. The C4 issuance methods (`issueInvoice` etc.)
+   * call `get`/`post` through here; exposed `protected` now so the wired client
+   * is genuinely referenced and the seam is ready without churning the surface.
+   */
+  protected get transport(): IKsefHttpClient {
+    return this.httpClient;
   }
 
   private notImplemented(method: string): Error {

--- a/libs/integrations/ksef/src/infrastructure/crypto/README.md
+++ b/libs/integrations/ksef/src/infrastructure/crypto/README.md
@@ -38,14 +38,17 @@ live KSeF test vectors land.
 
 `MfPublicKeyCacheService.fetchAndCachePublicKey(usage)`:
 
-- `GET /security/public-key-certificates`, filter by `usage`
+- `GET /security/public-key-certificates` returns a flat ARRAY of
+  `PublicKeyCertificate` (`certificate` DER-base64, `publicKeyId`, `validFrom`/
+  `validTo`, `usage` as an ARRAY). Filter by `usage` array membership
   (`KsefTokenEncryption` vs `SymmetricKeyEncryption` — required to avoid
-  key-confusion), pick the latest valid cert.
+  key-confusion), pick the latest valid cert. The selected `publicKeyId` is the
+  spec selector stamped onto the init-token / encrypted-symmetric-key payloads.
 - `validateMfPublicKeyCertificate` enforces the validity window + usage before
   the cert is trusted. (Root-of-trust pinning + OCSP/CRL is a tracked follow-up;
   KSeF serves these over TLS and C3 validates the window + usage.)
 - Cache key is `ksef:mf-public-key:{connectionId}:{usage}` — per-connection,
-  per-usage. TTL is derived from `validUntil - now - 5m` (never hardcoded), so a
+  per-usage. TTL is derived from `validTo - now - 5m` (never hardcoded), so a
   rotated cert can't be served past its lifetime. A cert cached but rotated early
   is detected as stale on read and refetched.
 

--- a/libs/integrations/ksef/src/infrastructure/crypto/README.md
+++ b/libs/integrations/ksef/src/infrastructure/crypto/README.md
@@ -1,0 +1,64 @@
+# KSeF Session Crypto (C3)
+
+KSeF-specific document-session crypto (ADR-026 — NOT a core abstraction). AES-256
+document encryption with an ephemeral key wrapped under an MF RSA public key.
+
+## Flow
+
+1. `KsefSessionCryptoService.initializeSession()` generates an AES-256 key + IV
+   via `crypto.randomBytes` (CSPRNG — never `Math.random`).
+2. Fetches the MF `SymmetricKeyEncryption` public key via
+   `MfPublicKeyCacheService` (cached).
+3. Wraps the AES key with RSA-OAEP / MGF1 / **SHA-256** (`rsa-key-wrapper.ts`).
+4. `encryptDocument` / `decryptDocument` apply AES-256-CBC with PKCS#7 padding
+   (`aes-cipher.ts`; Node applies/strips PKCS#7 automatically).
+
+The returned `SessionCryptoContext` carries the symmetric key, the RSA-wrapped
+key (+ the wrapping cert's SHA-256 hash for server-side audit/rotation), and an
+`expiresAt` = `min(session TTL, cert validity)`. The issuance flow (C4) reuses
+one context for a batch and re-initializes before `expiresAt`.
+
+## Crypto parameters (`ksef-crypto.constants.ts`)
+
+These are a **wire contract**, not tunables — a mismatch is rejected by the MF
+backend with an opaque 4xx, not a crypto error:
+
+| primitive | value |
+|-----------|-------|
+| RSA padding | RSA-OAEP |
+| OAEP / MGF1 hash | SHA-256 |
+| min RSA modulus | 2048 bits |
+| AES | AES-256-CBC / PKCS#7 |
+| AES key / IV | 32 / 16 bytes |
+
+Round-trip unit tests validate these against a self-generated key pair until
+live KSeF test vectors land.
+
+## MF public-key caching
+
+`MfPublicKeyCacheService.fetchAndCachePublicKey(usage)`:
+
+- `GET /security/public-key-certificates`, filter by `usage`
+  (`KsefTokenEncryption` vs `SymmetricKeyEncryption` — required to avoid
+  key-confusion), pick the latest valid cert.
+- `validateMfPublicKeyCertificate` enforces the validity window + usage before
+  the cert is trusted. (Root-of-trust pinning + OCSP/CRL is a tracked follow-up;
+  KSeF serves these over TLS and C3 validates the window + usage.)
+- Cache key is `ksef:mf-public-key:{connectionId}:{usage}` — per-connection,
+  per-usage. TTL is derived from `validUntil - now - 5m` (never hardcoded), so a
+  rotated cert can't be served past its lifetime. A cert cached but rotated early
+  is detected as stale on read and refetched.
+
+## Reusability note
+
+If a second CTC regime (IT SDI, ES SII) ships with identical AES + RSA-OAEP
+needs, a follow-up ADR-027 should propose a domain-level
+`RegulatoryTransmissionCryptoPort`. Until then this layer is KSeF-specific
+(ADR-026) — see the marker comment in `ksef-session-crypto.service.ts`.
+
+## Security
+
+Never log key bytes, the wrapped key, plaintext, or ciphertext. Crypto failures
+surface as `KsefSessionCryptoException` with a redacted message + an error code;
+the underlying Node error is attached as `cause` (it carries an op/arg name, not
+the bytes) and must not be serialized verbatim to an external sink.

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/aes-cipher.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/aes-cipher.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * AES-256-CBC cipher round-trip + validation specs.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/crypto
+ */
+import { randomBytes } from 'crypto';
+import { decryptAesCbc, encryptAesCbc } from '../aes-cipher';
+import { KSEF_AES_IV_BYTES, KSEF_AES_KEY_BYTES } from '../../http/ksef-crypto.constants';
+import { KsefSessionCryptoException } from '../../../domain/exceptions/ksef-session-crypto.exception';
+
+describe('aes-cipher', () => {
+  const key = new Uint8Array(randomBytes(KSEF_AES_KEY_BYTES));
+  const iv = new Uint8Array(randomBytes(KSEF_AES_IV_BYTES));
+
+  it('should recover the exact plaintext byte-for-byte when round-tripping', () => {
+    const plaintext = '<Faktura><NIP>1234567890</NIP></Faktura>';
+    const ciphertext = encryptAesCbc(plaintext, key, iv);
+    expect(decryptAesCbc(ciphertext, key, iv)).toBe(plaintext);
+  });
+
+  it('should round-trip a multi-byte UTF-8 plaintext without padding artifacts', () => {
+    const plaintext = 'zażółć gęślą jaźń — €';
+    expect(decryptAesCbc(encryptAesCbc(plaintext, key, iv), key, iv)).toBe(plaintext);
+  });
+
+  it('should throw KsefSessionCryptoException when the key length is wrong', () => {
+    expect(() => encryptAesCbc('x', new Uint8Array(16), iv)).toThrow(KsefSessionCryptoException);
+  });
+
+  it('should throw KsefSessionCryptoException when the IV length is wrong', () => {
+    expect(() => encryptAesCbc('x', key, new Uint8Array(8))).toThrow(KsefSessionCryptoException);
+  });
+
+  it('should throw KsefSessionCryptoException when decrypting with the wrong key', () => {
+    const ciphertext = encryptAesCbc('secret', key, iv);
+    const wrongKey = new Uint8Array(randomBytes(KSEF_AES_KEY_BYTES));
+    expect(() => decryptAesCbc(ciphertext, wrongKey, iv)).toThrow(KsefSessionCryptoException);
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/ksef-session-crypto.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/ksef-session-crypto.service.spec.ts
@@ -17,9 +17,10 @@ describe('KsefSessionCryptoService', () => {
 
   const cert: PublicKeyCertificate = {
     certificatePem: publicPem,
-    usage: 'SymmetricKeyEncryption',
+    usage: ['SymmetricKeyEncryption'],
     validFrom: new Date('2026-01-01T00:00:00Z'),
-    validUntil: new Date('2027-01-01T00:00:00Z'),
+    validTo: new Date('2027-01-01T00:00:00Z'),
+    publicKeyId: 'PKID-SYM' + 'z'.repeat(36),
     certificateHash: createHash('sha256').update(publicPem).digest('hex'),
   };
 
@@ -35,6 +36,9 @@ describe('KsefSessionCryptoService', () => {
     expect(ctx.symmetricKey.key.byteLength).toBe(KSEF_AES_KEY_BYTES);
     expect(ctx.symmetricKey.iv.byteLength).toBe(KSEF_AES_IV_BYTES);
     expect(ctx.wrappedKey.certificateHash).toBe(cert.certificateHash);
+    // The wrapping cert's publicKeyId rides along so C5 can stamp
+    // EncryptionInfo.publicKeyId on the session-open request.
+    expect(ctx.wrappedKey.publicKeyId).toBe(cert.publicKeyId);
 
     // The server (holding the private half) must recover the exact AES key.
     const unwrapped = unwrapKeyWithRsa(ctx.wrappedKey.wrappedKey, privatePem);
@@ -52,6 +56,6 @@ describe('KsefSessionCryptoService', () => {
   it('should bound the session expiry by the cert validity', async () => {
     const now = new Date('2026-12-31T23:50:00Z');
     const ctx = await service().initializeSession(now);
-    expect(ctx.expiresAt.getTime()).toBeLessThanOrEqual(cert.validUntil.getTime());
+    expect(ctx.expiresAt.getTime()).toBeLessThanOrEqual(cert.validTo.getTime());
   });
 });

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/ksef-session-crypto.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/ksef-session-crypto.service.spec.ts
@@ -53,6 +53,20 @@ describe('KsefSessionCryptoService', () => {
     expect(svc.decryptDocument(encrypted, ctx)).toBe(plaintext);
   });
 
+  it('should use a fresh IV per document (no CBC IV reuse under the session key)', async () => {
+    const svc = service();
+    const ctx = await svc.initializeSession();
+    const a = svc.encryptDocument('<Faktura>A</Faktura>', ctx);
+    const b = svc.encryptDocument('<Faktura>A</Faktura>', ctx);
+
+    // Distinct IVs → identical plaintext encrypts to distinct ciphertext.
+    expect(Array.from(a.iv)).not.toEqual(Array.from(b.iv));
+    expect(Array.from(a.ciphertext)).not.toEqual(Array.from(b.ciphertext));
+    // Each document still decrypts with its own carried IV.
+    expect(svc.decryptDocument(a, ctx)).toBe('<Faktura>A</Faktura>');
+    expect(svc.decryptDocument(b, ctx)).toBe('<Faktura>A</Faktura>');
+  });
+
   it('should bound the session expiry by the cert validity', async () => {
     const now = new Date('2026-12-31T23:50:00Z');
     const ctx = await service().initializeSession(now);

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/ksef-session-crypto.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/ksef-session-crypto.service.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * KSeF session crypto service specs — CSPRNG key gen, RSA wrap, AES round-trip.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/crypto
+ */
+import { createHash, generateKeyPairSync } from 'crypto';
+import { KsefSessionCryptoService } from '../ksef-session-crypto.service';
+import type { MfPublicKeyCacheService } from '../mf-public-key-cache.service';
+import { unwrapKeyWithRsa } from '../rsa-key-wrapper';
+import type { PublicKeyCertificate } from '../../http/ksef-crypto.types';
+import { KSEF_AES_IV_BYTES, KSEF_AES_KEY_BYTES } from '../../http/ksef-crypto.constants';
+
+describe('KsefSessionCryptoService', () => {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const publicPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+  const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+  const cert: PublicKeyCertificate = {
+    certificatePem: publicPem,
+    usage: 'SymmetricKeyEncryption',
+    validFrom: new Date('2026-01-01T00:00:00Z'),
+    validUntil: new Date('2027-01-01T00:00:00Z'),
+    certificateHash: createHash('sha256').update(publicPem).digest('hex'),
+  };
+
+  function service(): KsefSessionCryptoService {
+    const cache = {
+      fetchAndCachePublicKey: jest.fn().mockResolvedValue(cert),
+    } as unknown as MfPublicKeyCacheService;
+    return new KsefSessionCryptoService(cache);
+  }
+
+  it('should generate a 32-byte AES key + 16-byte IV and wrap the key under the MF cert', async () => {
+    const ctx = await service().initializeSession();
+    expect(ctx.symmetricKey.key.byteLength).toBe(KSEF_AES_KEY_BYTES);
+    expect(ctx.symmetricKey.iv.byteLength).toBe(KSEF_AES_IV_BYTES);
+    expect(ctx.wrappedKey.certificateHash).toBe(cert.certificateHash);
+
+    // The server (holding the private half) must recover the exact AES key.
+    const unwrapped = unwrapKeyWithRsa(ctx.wrappedKey.wrappedKey, privatePem);
+    expect(Array.from(unwrapped)).toEqual(Array.from(ctx.symmetricKey.key));
+  });
+
+  it('should round-trip a document through encrypt/decrypt', async () => {
+    const svc = service();
+    const ctx = await svc.initializeSession();
+    const plaintext = '<Faktura/>';
+    const encrypted = svc.encryptDocument(plaintext, ctx);
+    expect(svc.decryptDocument(encrypted, ctx)).toBe(plaintext);
+  });
+
+  it('should bound the session expiry by the cert validity', async () => {
+    const now = new Date('2026-12-31T23:50:00Z');
+    const ctx = await service().initializeSession(now);
+    expect(ctx.expiresAt.getTime()).toBeLessThanOrEqual(cert.validUntil.getTime());
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/mf-public-key-cache.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/mf-public-key-cache.service.spec.ts
@@ -1,6 +1,10 @@
 /**
  * MF public-key cache service specs — fetch/filter/select/validate + caching.
  *
+ * Wire shape reconciled to the spec `PublicKeyCertificate`: the endpoint returns
+ * a flat ARRAY; each entry has `certificate` (DER base64), `certificateId`,
+ * `publicKeyId`, `validFrom`/`validTo`, and `usage` as an ARRAY of operations.
+ *
  * @module libs/integrations/ksef/src/infrastructure/crypto
  */
 import { MfPublicKeyCacheService } from '../mf-public-key-cache.service';
@@ -26,36 +30,49 @@ function inMemoryCache(): CachePort & { store: Map<string, unknown> } {
   };
 }
 
+interface WireCert {
+  certificate: string;
+  certificateId?: string;
+  publicKeyId?: string;
+  usage: string[];
+  validFrom: string;
+  validTo: string;
+}
+
+/** A flat ARRAY of certificate entries (the spec response shape). */
 function certResponse(): {
-  data: {
-    certificates: Array<{ certificate: string; usage: string; validFrom: string; validUntil: string }>;
-  };
+  data: WireCert[];
   status: number;
   headers: Record<string, string>;
 } {
   return {
-    data: {
-      certificates: [
-        {
-          certificate: 'PEM-SYM-OLD',
-          usage: 'SymmetricKeyEncryption',
-          validFrom: '2026-01-01T00:00:00Z',
-          validUntil: '2026-02-01T00:00:00Z',
-        },
-        {
-          certificate: 'PEM-SYM-NEW',
-          usage: 'SymmetricKeyEncryption',
-          validFrom: '2026-05-01T00:00:00Z',
-          validUntil: '2027-05-01T00:00:00Z',
-        },
-        {
-          certificate: 'PEM-TOKEN',
-          usage: 'KsefTokenEncryption',
-          validFrom: '2026-05-01T00:00:00Z',
-          validUntil: '2027-05-01T00:00:00Z',
-        },
-      ],
-    },
+    data: [
+      {
+        certificate: 'REVMLVNZTS1PTEQ=',
+        certificateId: 'CID-SYM-OLD',
+        publicKeyId: 'PKID-SYM-OLD' + 'a'.repeat(32),
+        usage: ['SymmetricKeyEncryption'],
+        validFrom: '2026-01-01T00:00:00Z',
+        validTo: '2026-02-01T00:00:00Z',
+      },
+      {
+        certificate: 'REVMLVNZTS1ORVc=',
+        certificateId: 'CID-SYM-NEW',
+        publicKeyId: 'PKID-SYM-NEW' + 'b'.repeat(32),
+        usage: ['SymmetricKeyEncryption'],
+        validFrom: '2026-05-01T00:00:00Z',
+        validTo: '2027-05-01T00:00:00Z',
+      },
+      {
+        certificate: 'REVMLVRPS0VO',
+        certificateId: 'CID-TOKEN',
+        publicKeyId: 'PKID-TOKEN' + 'c'.repeat(34),
+        // A cert valid for both operations — usage membership, not equality.
+        usage: ['KsefTokenEncryption', 'SymmetricKeyEncryption'],
+        validFrom: '2025-01-01T00:00:00Z',
+        validTo: '2027-05-01T00:00:00Z',
+      },
+    ],
     status: 200,
     headers: {},
   };
@@ -69,32 +86,33 @@ describe('MfPublicKeyCacheService', () => {
     http.seed('GET', PATH, certResponse());
   });
 
-  it('should select the latest valid cert matching the requested usage', async () => {
+  it('should select the latest valid cert whose usage array includes the requested usage', async () => {
     const service = new MfPublicKeyCacheService('conn-1', http);
     const cert = await service.fetchAndCachePublicKey('SymmetricKeyEncryption');
-    expect(cert.certificatePem).toBe('PEM-SYM-NEW');
-    expect(cert.usage).toBe('SymmetricKeyEncryption');
+    // PKID-SYM-NEW has the latest validFrom among the symmetric-capable certs.
+    expect(cert.publicKeyId).toBe('PKID-SYM-NEW' + 'b'.repeat(32));
+    expect(cert.usage).toContain('SymmetricKeyEncryption');
+    expect(cert.certificatePem).toContain('BEGIN CERTIFICATE');
     expect(cert.certificateHash).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it('should return the token-encryption cert for the token usage', async () => {
+  it('should match a cert that lists the usage among several operations', async () => {
     const service = new MfPublicKeyCacheService('conn-1', http);
     const cert = await service.fetchAndCachePublicKey('KsefTokenEncryption');
-    expect(cert.certificatePem).toBe('PEM-TOKEN');
+    expect(cert.publicKeyId).toBe('PKID-TOKEN' + 'c'.repeat(34));
+    expect(cert.usage).toContain('KsefTokenEncryption');
   });
 
   it('should throw when no valid cert exists for the usage', async () => {
     const onlyExpired = {
-      data: {
-        certificates: [
-          {
-            certificate: 'PEM-EXPIRED',
-            usage: 'SymmetricKeyEncryption',
-            validFrom: '2000-01-01T00:00:00Z',
-            validUntil: '2000-02-01T00:00:00Z',
-          },
-        ],
-      },
+      data: [
+        {
+          certificate: 'RVhQSVJFRA==',
+          usage: ['SymmetricKeyEncryption'],
+          validFrom: '2000-01-01T00:00:00Z',
+          validTo: '2000-02-01T00:00:00Z',
+        },
+      ] as WireCert[],
       status: 200,
       headers: {},
     };
@@ -127,13 +145,12 @@ describe('MfPublicKeyCacheService', () => {
     it('should drop a cached-but-now-stale cert and refetch (rotation)', async () => {
       const cache = inMemoryCache();
       const key = 'ksef:mf-public-key:conn-1:SymmetricKeyEncryption';
-      // Pre-seed the cache with a cert whose window has already closed: a rotated
-      // cert the previous run cached before the MF rotated it early.
+      // Pre-seed the cache with a cert whose window has already closed.
       cache.store.set(key, {
         certificatePem: 'PEM-ROTATED-OUT',
-        usage: 'SymmetricKeyEncryption',
+        usage: ['SymmetricKeyEncryption'],
         validFrom: '2000-01-01T00:00:00Z',
-        validUntil: '2000-02-01T00:00:00Z',
+        validTo: '2000-02-01T00:00:00Z',
         certificateHash: 'stale-hash',
       });
 
@@ -142,25 +159,24 @@ describe('MfPublicKeyCacheService', () => {
 
       // The stale entry was validated, found expired, dropped, and the live
       // (currently-valid) cert fetched + re-cached in its place.
-      expect(cert.certificatePem).toBe('PEM-SYM-NEW');
+      expect(cert.publicKeyId).toBe('PKID-SYM-NEW' + 'b'.repeat(32));
       expect(http.calls.filter((c) => c.path === PATH)).toHaveLength(1);
-      expect(cache.store.get(key)).toMatchObject({ certificatePem: 'PEM-SYM-NEW' });
+      expect(cache.store.get(key)).toMatchObject({ publicKeyId: 'PKID-SYM-NEW' + 'b'.repeat(32) });
     });
 
     it('should not cache a freshly-fetched cert already inside its refresh margin', async () => {
       // A cert valid only 1 minute from now sits inside the 5-minute refresh
       // margin: usable for this call but not worth caching (next call refetches).
       const nearExpiry = {
-        data: {
-          certificates: [
-            {
-              certificate: 'PEM-NEAR-EXPIRY',
-              usage: 'SymmetricKeyEncryption',
-              validFrom: new Date(Date.now() - 60_000).toISOString(),
-              validUntil: new Date(Date.now() + 60_000).toISOString(),
-            },
-          ],
-        },
+        data: [
+          {
+            certificate: 'TkVBUi1FWFBJUlk=',
+            publicKeyId: 'PKID-NEAR' + 'd'.repeat(35),
+            usage: ['SymmetricKeyEncryption'],
+            validFrom: new Date(Date.now() - 60_000).toISOString(),
+            validTo: new Date(Date.now() + 60_000).toISOString(),
+          },
+        ] as WireCert[],
         status: 200,
         headers: {},
       };
@@ -171,7 +187,7 @@ describe('MfPublicKeyCacheService', () => {
 
       const cert = await service.fetchAndCachePublicKey('SymmetricKeyEncryption');
 
-      expect(cert.certificatePem).toBe('PEM-NEAR-EXPIRY');
+      expect(cert.publicKeyId).toBe('PKID-NEAR' + 'd'.repeat(35));
       expect(cache.store.size).toBe(0);
     });
 

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/mf-public-key-cache.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/mf-public-key-cache.service.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * MF public-key cache service specs — fetch/filter/select/validate + caching.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/crypto
+ */
+import { MfPublicKeyCacheService } from '../mf-public-key-cache.service';
+import { KsefSessionCryptoException } from '../../../domain/exceptions/ksef-session-crypto.exception';
+import { FakeKsefHttpClient } from '../../../testing/fake-ksef-http-client';
+import type { CachePort } from '@openlinker/shared/cache';
+
+const PATH = '/security/public-key-certificates';
+
+function inMemoryCache(): CachePort & { store: Map<string, unknown> } {
+  const store = new Map<string, unknown>();
+  return {
+    store,
+    get: <T>(key: string): Promise<T | null> => Promise.resolve((store.get(key) as T) ?? null),
+    set: <T>(key: string, value: T): Promise<void> => {
+      store.set(key, value);
+      return Promise.resolve();
+    },
+    delete: (key: string): Promise<void> => {
+      store.delete(key);
+      return Promise.resolve();
+    },
+  };
+}
+
+function certResponse(): {
+  data: {
+    certificates: Array<{ certificate: string; usage: string; validFrom: string; validUntil: string }>;
+  };
+  status: number;
+  headers: Record<string, string>;
+} {
+  return {
+    data: {
+      certificates: [
+        {
+          certificate: 'PEM-SYM-OLD',
+          usage: 'SymmetricKeyEncryption',
+          validFrom: '2026-01-01T00:00:00Z',
+          validUntil: '2026-02-01T00:00:00Z',
+        },
+        {
+          certificate: 'PEM-SYM-NEW',
+          usage: 'SymmetricKeyEncryption',
+          validFrom: '2026-05-01T00:00:00Z',
+          validUntil: '2027-05-01T00:00:00Z',
+        },
+        {
+          certificate: 'PEM-TOKEN',
+          usage: 'KsefTokenEncryption',
+          validFrom: '2026-05-01T00:00:00Z',
+          validUntil: '2027-05-01T00:00:00Z',
+        },
+      ],
+    },
+    status: 200,
+    headers: {},
+  };
+}
+
+describe('MfPublicKeyCacheService', () => {
+  let http: FakeKsefHttpClient;
+
+  beforeEach(() => {
+    http = new FakeKsefHttpClient();
+    http.seed('GET', PATH, certResponse());
+  });
+
+  it('should select the latest valid cert matching the requested usage', async () => {
+    const service = new MfPublicKeyCacheService('conn-1', http);
+    const cert = await service.fetchAndCachePublicKey('SymmetricKeyEncryption');
+    expect(cert.certificatePem).toBe('PEM-SYM-NEW');
+    expect(cert.usage).toBe('SymmetricKeyEncryption');
+    expect(cert.certificateHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('should return the token-encryption cert for the token usage', async () => {
+    const service = new MfPublicKeyCacheService('conn-1', http);
+    const cert = await service.fetchAndCachePublicKey('KsefTokenEncryption');
+    expect(cert.certificatePem).toBe('PEM-TOKEN');
+  });
+
+  it('should throw when no valid cert exists for the usage', async () => {
+    const onlyExpired = {
+      data: {
+        certificates: [
+          {
+            certificate: 'PEM-EXPIRED',
+            usage: 'SymmetricKeyEncryption',
+            validFrom: '2000-01-01T00:00:00Z',
+            validUntil: '2000-02-01T00:00:00Z',
+          },
+        ],
+      },
+      status: 200,
+      headers: {},
+    };
+    http.clear();
+    http.seed('GET', PATH, onlyExpired);
+    const service = new MfPublicKeyCacheService('conn-1', http);
+    await expect(service.fetchAndCachePublicKey('SymmetricKeyEncryption')).rejects.toBeInstanceOf(
+      KsefSessionCryptoException,
+    );
+  });
+
+  it('should serve a cached cert on the second call without refetching', async () => {
+    const cache = inMemoryCache();
+    const service = new MfPublicKeyCacheService('conn-1', http, cache);
+    await service.fetchAndCachePublicKey('SymmetricKeyEncryption');
+    await service.fetchAndCachePublicKey('SymmetricKeyEncryption');
+    const fetches = http.calls.filter((c) => c.path === PATH).length;
+    expect(fetches).toBe(1);
+  });
+
+  it('should scope the cache key by connection and usage', async () => {
+    const cache = inMemoryCache();
+    const service = new MfPublicKeyCacheService('conn-1', http, cache);
+    await service.fetchAndCachePublicKey('SymmetricKeyEncryption');
+    const keys = Array.from(cache.store.keys());
+    expect(keys).toContain('ksef:mf-public-key:conn-1:SymmetricKeyEncryption');
+  });
+
+  describe('rotation', () => {
+    it('should drop a cached-but-now-stale cert and refetch (rotation)', async () => {
+      const cache = inMemoryCache();
+      const key = 'ksef:mf-public-key:conn-1:SymmetricKeyEncryption';
+      // Pre-seed the cache with a cert whose window has already closed: a rotated
+      // cert the previous run cached before the MF rotated it early.
+      cache.store.set(key, {
+        certificatePem: 'PEM-ROTATED-OUT',
+        usage: 'SymmetricKeyEncryption',
+        validFrom: '2000-01-01T00:00:00Z',
+        validUntil: '2000-02-01T00:00:00Z',
+        certificateHash: 'stale-hash',
+      });
+
+      const service = new MfPublicKeyCacheService('conn-1', http, cache);
+      const cert = await service.fetchAndCachePublicKey('SymmetricKeyEncryption');
+
+      // The stale entry was validated, found expired, dropped, and the live
+      // (currently-valid) cert fetched + re-cached in its place.
+      expect(cert.certificatePem).toBe('PEM-SYM-NEW');
+      expect(http.calls.filter((c) => c.path === PATH)).toHaveLength(1);
+      expect(cache.store.get(key)).toMatchObject({ certificatePem: 'PEM-SYM-NEW' });
+    });
+
+    it('should not cache a freshly-fetched cert already inside its refresh margin', async () => {
+      // A cert valid only 1 minute from now sits inside the 5-minute refresh
+      // margin: usable for this call but not worth caching (next call refetches).
+      const nearExpiry = {
+        data: {
+          certificates: [
+            {
+              certificate: 'PEM-NEAR-EXPIRY',
+              usage: 'SymmetricKeyEncryption',
+              validFrom: new Date(Date.now() - 60_000).toISOString(),
+              validUntil: new Date(Date.now() + 60_000).toISOString(),
+            },
+          ],
+        },
+        status: 200,
+        headers: {},
+      };
+      http.clear();
+      http.seed('GET', PATH, nearExpiry);
+      const cache = inMemoryCache();
+      const service = new MfPublicKeyCacheService('conn-1', http, cache);
+
+      const cert = await service.fetchAndCachePublicKey('SymmetricKeyEncryption');
+
+      expect(cert.certificatePem).toBe('PEM-NEAR-EXPIRY');
+      expect(cache.store.size).toBe(0);
+    });
+
+    it('should degrade to a per-call fetch when no host cache is wired', async () => {
+      const service = new MfPublicKeyCacheService('conn-1', http);
+      await service.fetchAndCachePublicKey('SymmetricKeyEncryption');
+      await service.fetchAndCachePublicKey('SymmetricKeyEncryption');
+      expect(http.calls.filter((c) => c.path === PATH)).toHaveLength(2);
+    });
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/mf-public-key-cache.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/mf-public-key-cache.service.spec.ts
@@ -124,6 +124,28 @@ describe('MfPublicKeyCacheService', () => {
     );
   });
 
+  it('should throw CERT_BAD_ENCODING when the certificate payload is not valid base64', async () => {
+    const badEncoding = {
+      data: [
+        {
+          certificate: 'not valid base64 !!!',
+          usage: ['SymmetricKeyEncryption'],
+          validFrom: new Date(Date.now() - 60_000).toISOString(),
+          validTo: new Date(Date.now() + 3_600_000).toISOString(),
+        },
+      ] as WireCert[],
+      status: 200,
+      headers: {},
+    };
+    http.clear();
+    http.seed('GET', PATH, badEncoding);
+    const service = new MfPublicKeyCacheService('conn-1', http);
+    await expect(service.fetchAndCachePublicKey('SymmetricKeyEncryption')).rejects.toMatchObject({
+      name: 'KsefSessionCryptoException',
+      errorCode: 'CERT_BAD_ENCODING',
+    });
+  });
+
   it('should serve a cached cert on the second call without refetching', async () => {
     const cache = inMemoryCache();
     const service = new MfPublicKeyCacheService('conn-1', http, cache);

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/mf-public-key-validator.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/mf-public-key-validator.spec.ts
@@ -10,9 +10,9 @@ import { KsefSessionCryptoException } from '../../../domain/exceptions/ksef-sess
 function cert(overrides: Partial<PublicKeyCertificate> = {}): PublicKeyCertificate {
   return {
     certificatePem: '-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----',
-    usage: 'SymmetricKeyEncryption',
+    usage: ['SymmetricKeyEncryption'],
     validFrom: new Date('2026-01-01T00:00:00Z'),
-    validUntil: new Date('2027-01-01T00:00:00Z'),
+    validTo: new Date('2027-01-01T00:00:00Z'),
     certificateHash: 'abc123',
     ...overrides,
   };
@@ -39,7 +39,7 @@ describe('validateMfPublicKeyCertificate', () => {
   });
 
   it('should reject an expired cert', () => {
-    const expired = cert({ validUntil: new Date('2026-05-01T00:00:00Z') });
+    const expired = cert({ validTo: new Date('2026-05-01T00:00:00Z') });
     expect(() => validateMfPublicKeyCertificate(expired, 'SymmetricKeyEncryption', now)).toThrow(
       KsefSessionCryptoException,
     );

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/mf-public-key-validator.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/mf-public-key-validator.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * MF public-key certificate validator specs.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/crypto
+ */
+import { validateMfPublicKeyCertificate } from '../mf-public-key-validator';
+import type { PublicKeyCertificate } from '../../http/ksef-crypto.types';
+import { KsefSessionCryptoException } from '../../../domain/exceptions/ksef-session-crypto.exception';
+
+function cert(overrides: Partial<PublicKeyCertificate> = {}): PublicKeyCertificate {
+  return {
+    certificatePem: '-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----',
+    usage: 'SymmetricKeyEncryption',
+    validFrom: new Date('2026-01-01T00:00:00Z'),
+    validUntil: new Date('2027-01-01T00:00:00Z'),
+    certificateHash: 'abc123',
+    ...overrides,
+  };
+}
+
+describe('validateMfPublicKeyCertificate', () => {
+  const now = new Date('2026-06-01T00:00:00Z');
+
+  it('should pass for a valid in-window cert with matching usage', () => {
+    expect(() => validateMfPublicKeyCertificate(cert(), 'SymmetricKeyEncryption', now)).not.toThrow();
+  });
+
+  it('should reject a usage mismatch', () => {
+    expect(() => validateMfPublicKeyCertificate(cert(), 'KsefTokenEncryption', now)).toThrow(
+      KsefSessionCryptoException,
+    );
+  });
+
+  it('should reject a not-yet-valid cert', () => {
+    const future = cert({ validFrom: new Date('2026-07-01T00:00:00Z') });
+    expect(() => validateMfPublicKeyCertificate(future, 'SymmetricKeyEncryption', now)).toThrow(
+      KsefSessionCryptoException,
+    );
+  });
+
+  it('should reject an expired cert', () => {
+    const expired = cert({ validUntil: new Date('2026-05-01T00:00:00Z') });
+    expect(() => validateMfPublicKeyCertificate(expired, 'SymmetricKeyEncryption', now)).toThrow(
+      KsefSessionCryptoException,
+    );
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/rsa-key-wrapper.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/rsa-key-wrapper.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * RSA-OAEP key wrapper round-trip + validation specs.
+ *
+ * Uses a self-generated RSA-2048 key pair to round-trip a wrapped AES key —
+ * the production server holds the private half; here we hold both to assert the
+ * OAEP/SHA-256 parameters match end-to-end.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/crypto
+ */
+import { generateKeyPairSync, randomBytes } from 'crypto';
+import { unwrapKeyWithRsa, wrapKeyWithRsa } from '../rsa-key-wrapper';
+import { KsefSessionCryptoException } from '../../../domain/exceptions/ksef-session-crypto.exception';
+
+describe('rsa-key-wrapper', () => {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const publicPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+  const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+  it('should round-trip a 32-byte AES key through wrap/unwrap', () => {
+    const aesKey = new Uint8Array(randomBytes(32));
+    const wrapped = wrapKeyWithRsa(aesKey, publicPem);
+    expect(Array.from(unwrapKeyWithRsa(wrapped, privatePem))).toEqual(Array.from(aesKey));
+  });
+
+  it('should produce a wrapped key no larger than the RSA modulus (256 bytes for 2048-bit)', () => {
+    const wrapped = wrapKeyWithRsa(new Uint8Array(randomBytes(32)), publicPem);
+    expect(wrapped.byteLength).toBe(256);
+  });
+
+  it('should throw KsefSessionCryptoException for a malformed PEM', () => {
+    expect(() => wrapKeyWithRsa(new Uint8Array(32), 'not a pem')).toThrow(KsefSessionCryptoException);
+  });
+
+  it('should reject an under-sized RSA key', () => {
+    const small = generateKeyPairSync('rsa', { modulusLength: 1024 });
+    const smallPem = small.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    expect(() => wrapKeyWithRsa(new Uint8Array(32), smallPem)).toThrow(KsefSessionCryptoException);
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/crypto/aes-cipher.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/aes-cipher.ts
@@ -1,0 +1,69 @@
+/**
+ * AES-256-CBC Cipher (KSeF session crypto)
+ *
+ * Pure functions wrapping Node's `crypto` for AES-256-CBC document encryption.
+ * Node applies PKCS#7 padding automatically on `createCipheriv` and strips it
+ * on `createDecipheriv`, so no manual padding is done here (manual padding is a
+ * classic off-by-one source). Key + IV are caller-supplied (generated via
+ * `crypto.randomBytes` in `KsefSessionCryptoService`) — these helpers never
+ * generate or cache key material.
+ *
+ * SECURITY: never log the key, IV, plaintext, or ciphertext. Crypto failures
+ * are wrapped in `KsefSessionCryptoException` so the raw Node error (which may
+ * carry an arg name, never the bytes) doesn't leak past the boundary.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/crypto
+ */
+import { createCipheriv, createDecipheriv } from 'crypto';
+import {
+  KSEF_AES_ALGORITHM,
+  KSEF_AES_IV_BYTES,
+  KSEF_AES_KEY_BYTES,
+} from '../http/ksef-crypto.constants';
+import { KsefSessionCryptoException } from '../../domain/exceptions/ksef-session-crypto.exception';
+
+function assertKeyAndIv(key: Uint8Array, iv: Uint8Array): void {
+  if (key.byteLength !== KSEF_AES_KEY_BYTES) {
+    throw new KsefSessionCryptoException(
+      `AES key must be ${KSEF_AES_KEY_BYTES} bytes (got ${key.byteLength})`,
+      'AES_BAD_KEY_LENGTH',
+    );
+  }
+  if (iv.byteLength !== KSEF_AES_IV_BYTES) {
+    throw new KsefSessionCryptoException(
+      `AES IV must be ${KSEF_AES_IV_BYTES} bytes (got ${iv.byteLength})`,
+      'AES_BAD_IV_LENGTH',
+    );
+  }
+}
+
+/**
+ * Encrypt a UTF-8 plaintext with AES-256-CBC/PKCS#7. Returns ciphertext bytes;
+ * the caller transmits the accompanying IV separately (CBC IV-reuse is unsafe).
+ */
+export function encryptAesCbc(plaintext: string, key: Uint8Array, iv: Uint8Array): Uint8Array {
+  assertKeyAndIv(key, iv);
+  try {
+    const cipher = createCipheriv(KSEF_AES_ALGORITHM, key, iv);
+    return new Uint8Array(Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]));
+  } catch (err) {
+    throw new KsefSessionCryptoException('AES encrypt failed', 'AES_ENCRYPT_FAILED', err as Error);
+  }
+}
+
+/**
+ * Decrypt AES-256-CBC/PKCS#7 ciphertext back to a UTF-8 string. A corrupted
+ * ciphertext / wrong key surfaces as a padding error from Node, wrapped here so
+ * the raw error type never leaks.
+ */
+export function decryptAesCbc(ciphertext: Uint8Array, key: Uint8Array, iv: Uint8Array): string {
+  assertKeyAndIv(key, iv);
+  try {
+    const decipher = createDecipheriv(KSEF_AES_ALGORITHM, key, iv);
+    return Buffer.concat([decipher.update(Buffer.from(ciphertext)), decipher.final()]).toString(
+      'utf8',
+    );
+  } catch (err) {
+    throw new KsefSessionCryptoException('AES decrypt failed', 'AES_DECRYPT_FAILED', err as Error);
+  }
+}

--- a/libs/integrations/ksef/src/infrastructure/crypto/ksef-session-crypto.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/ksef-session-crypto.service.ts
@@ -54,14 +54,18 @@ export class KsefSessionCryptoService {
     const wrapped = wrapKeyWithRsa(symmetricKey.key, cert.certificatePem);
 
     const sessionCap = now.getTime() + SESSION_TTL_MS;
-    const certCap = cert.validUntil.getTime();
+    const certCap = cert.validTo.getTime();
     const expiresAt = new Date(Math.min(sessionCap, certCap));
 
     this.logger.debug(`Initialized KSeF session crypto (cert ${cert.certificateHash}, expires ${expiresAt.toISOString()})`);
 
     return {
       symmetricKey,
-      wrappedKey: { wrappedKey: wrapped, certificateHash: cert.certificateHash },
+      wrappedKey: {
+        wrappedKey: wrapped,
+        publicKeyId: cert.publicKeyId,
+        certificateHash: cert.certificateHash,
+      },
       expiresAt,
     };
   }

--- a/libs/integrations/ksef/src/infrastructure/crypto/ksef-session-crypto.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/ksef-session-crypto.service.ts
@@ -1,0 +1,98 @@
+/**
+ * KSeF Session Crypto Service
+ *
+ * Owns the document-session crypto lifecycle (ADR-026; KSeF-specific, NOT a core
+ * abstraction). Generates an ephemeral AES-256 key + IV via `crypto.randomBytes`,
+ * fetches the MF `SymmetricKeyEncryption` public key (cached), wraps the AES key
+ * with RSA-OAEP/SHA-256, and exposes AES-256-CBC document encrypt/decrypt.
+ *
+ * Lifecycle: `initializeSession()` is called on-demand by the issuance flow
+ * (C4) before encrypting a batch of documents; the returned `SessionCryptoContext`
+ * is reused for all documents until `expiresAt` (min of a self-imposed session
+ * TTL and the wrapping cert's validity, with a safety margin). The HTTP client
+ * never holds session state — this service is decoupled and lazy.
+ *
+ * SECURITY: never log key bytes, the wrapped key, plaintext, or ciphertext. The
+ * AES key/IV are generated with the CSPRNG `crypto.randomBytes`, never
+ * `Math.random`.
+ *
+ * FUTURE (ADR-027 candidate): if a second CTC regime (IT SDI, ES SII) ships with
+ * identical AES + RSA-OAEP needs, extract this to a domain-level
+ * `RegulatoryTransmissionCryptoPort` in libs/core. Until then it lives here.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/crypto
+ */
+import { randomBytes } from 'crypto';
+import { Logger } from '@openlinker/shared/logging';
+import type { EncryptedDocument, SessionCryptoContext, SymmetricKey } from '../http/ksef-crypto.types';
+import {
+  KSEF_AES_ALGORITHM,
+  KSEF_AES_IV_BYTES,
+  KSEF_AES_KEY_BYTES,
+} from '../http/ksef-crypto.constants';
+import { decryptAesCbc, encryptAesCbc } from './aes-cipher';
+import { wrapKeyWithRsa } from './rsa-key-wrapper';
+import type { MfPublicKeyCacheService } from './mf-public-key-cache.service';
+import { KsefSessionCryptoException } from '../../domain/exceptions/ksef-session-crypto.exception';
+
+/** Self-imposed session lifetime cap; the effective expiry is min(this, cert validity). */
+const SESSION_TTL_MS = 30 * 60_000;
+
+export class KsefSessionCryptoService {
+  private readonly logger = new Logger(KsefSessionCryptoService.name);
+
+  constructor(private readonly publicKeyCache: MfPublicKeyCacheService) {}
+
+  /**
+   * Generate an ephemeral AES-256 session key + IV and wrap the key under the
+   * active MF `SymmetricKeyEncryption` public key. Returns the context the
+   * issuance flow reuses for the batch.
+   */
+  async initializeSession(now: Date = new Date()): Promise<SessionCryptoContext> {
+    const symmetricKey = this.generateSymmetricKey();
+    const cert = await this.publicKeyCache.fetchAndCachePublicKey('SymmetricKeyEncryption');
+    const wrapped = wrapKeyWithRsa(symmetricKey.key, cert.certificatePem);
+
+    const sessionCap = now.getTime() + SESSION_TTL_MS;
+    const certCap = cert.validUntil.getTime();
+    const expiresAt = new Date(Math.min(sessionCap, certCap));
+
+    this.logger.debug(`Initialized KSeF session crypto (cert ${cert.certificateHash}, expires ${expiresAt.toISOString()})`);
+
+    return {
+      symmetricKey,
+      wrappedKey: { wrappedKey: wrapped, certificateHash: cert.certificateHash },
+      expiresAt,
+    };
+  }
+
+  /** Encrypt a document body with the session's AES key + IV. */
+  encryptDocument(plaintext: string, context: SessionCryptoContext): EncryptedDocument {
+    const { key, iv } = context.symmetricKey;
+    return {
+      algorithm: KSEF_AES_ALGORITHM,
+      ciphertext: encryptAesCbc(plaintext, key, iv),
+      iv,
+    };
+  }
+
+  /** Decrypt a document body with the session's AES key + the document's IV. */
+  decryptDocument(encrypted: EncryptedDocument, context: SessionCryptoContext): string {
+    return decryptAesCbc(encrypted.ciphertext, context.symmetricKey.key, encrypted.iv);
+  }
+
+  private generateSymmetricKey(): SymmetricKey {
+    try {
+      return {
+        key: new Uint8Array(randomBytes(KSEF_AES_KEY_BYTES)),
+        iv: new Uint8Array(randomBytes(KSEF_AES_IV_BYTES)),
+      };
+    } catch (err) {
+      throw new KsefSessionCryptoException(
+        'Failed to generate AES session key',
+        'AES_KEYGEN_FAILED',
+        err as Error,
+      );
+    }
+  }
+}

--- a/libs/integrations/ksef/src/infrastructure/crypto/ksef-session-crypto.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/ksef-session-crypto.service.ts
@@ -70,9 +70,17 @@ export class KsefSessionCryptoService {
     };
   }
 
-  /** Encrypt a document body with the session's AES key + IV. */
+  /**
+   * Encrypt a document body with the session's AES key and a FRESH per-document
+   * IV. The wrapped symmetric key is reused across the batch, but the IV must be
+   * unique per encryption — CBC IV reuse under the same key leaks plaintext
+   * structure. The IV travels alongside the ciphertext in the `EncryptedDocument`
+   * envelope (and is read back by `decryptDocument`), so it need not be the
+   * session IV.
+   */
   encryptDocument(plaintext: string, context: SessionCryptoContext): EncryptedDocument {
-    const { key, iv } = context.symmetricKey;
+    const { key } = context.symmetricKey;
+    const iv = this.generateIv();
     return {
       algorithm: KSEF_AES_ALGORITHM,
       ciphertext: encryptAesCbc(plaintext, key, iv),
@@ -89,7 +97,7 @@ export class KsefSessionCryptoService {
     try {
       return {
         key: new Uint8Array(randomBytes(KSEF_AES_KEY_BYTES)),
-        iv: new Uint8Array(randomBytes(KSEF_AES_IV_BYTES)),
+        iv: this.generateIv(),
       };
     } catch (err) {
       throw new KsefSessionCryptoException(
@@ -98,5 +106,9 @@ export class KsefSessionCryptoService {
         err as Error,
       );
     }
+  }
+
+  private generateIv(): Uint8Array {
+    return new Uint8Array(randomBytes(KSEF_AES_IV_BYTES));
   }
 }

--- a/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-cache.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-cache.service.ts
@@ -159,7 +159,11 @@ export class MfPublicKeyCacheService {
     usage: KsefCertificateUsage,
     now: Date,
   ): Promise<PublicKeyCertificate> {
-    const response = await this.httpClient.get<MfCertificatesResponse>(MF_CERTIFICATES_PATH);
+    // The MF public-key certificate endpoint is unauthenticated — it bootstraps
+    // the handshake before any token exists, so skip bearer injection.
+    const response = await this.httpClient.get<MfCertificatesResponse>(MF_CERTIFICATES_PATH, {
+      skipAuth: true,
+    });
     const entries = Array.isArray(response.data) ? response.data : [];
     const matching = entries
       .filter((entry) => (entry.usage ?? []).includes(usage))
@@ -207,7 +211,22 @@ export class MfPublicKeyCacheService {
     if (certificate.includes('-----BEGIN')) {
       return certificate;
     }
-    const lines = certificate.replace(/\s+/g, '').match(/.{1,64}/g) ?? [certificate];
+    const compact = certificate.replace(/\s+/g, '');
+    if (!this.isValidBase64(compact)) {
+      throw new KsefSessionCryptoException(
+        'MF certificate payload is not valid base64-DER',
+        'CERT_BAD_ENCODING',
+      );
+    }
+    const lines = compact.match(/.{1,64}/g) ?? [compact];
     return `-----BEGIN CERTIFICATE-----\n${lines.join('\n')}\n-----END CERTIFICATE-----\n`;
+  }
+
+  /** A non-empty, length-aligned base64 string (standard alphabet, padded). */
+  private isValidBase64(value: string): boolean {
+    if (value.length === 0 || value.length % 4 !== 0) {
+      return false;
+    }
+    return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
   }
 }

--- a/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-cache.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-cache.service.ts
@@ -1,0 +1,182 @@
+/**
+ * MF Public Key Cache Service
+ *
+ * Fetches MF public-key certificates from `GET /security/public-key-certificates`
+ * and caches the selected cert per `(connectionId, usage)` via the host cache.
+ * The cache TTL is derived from the cert's validity window (`validUntil - now`,
+ * minus a safety margin) — never a hardcoded constant — so a rotated cert can't
+ * be served past its lifetime. When no host cache is wired the service degrades
+ * to a per-call fetch.
+ *
+ * Used by both `KsefTokenEncryptor` (usage `KsefTokenEncryption`) and
+ * `KsefSessionCryptoService` (usage `SymmetricKeyEncryption`); the usage is a
+ * required selector to avoid key-confusion between the two cert kinds.
+ *
+ * SECURITY: logs only the cache key (connectionId + usage), the selected cert
+ * hash, and the derived TTL — never the PEM / key material.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/crypto
+ */
+import { createHash } from 'crypto';
+import type { CachePort } from '@openlinker/shared/cache';
+import { Logger } from '@openlinker/shared/logging';
+import type { IKsefHttpClient } from '../http/ksef-http-client.interface';
+import type { KsefCertificateUsage, PublicKeyCertificate } from '../http/ksef-crypto.types';
+import { validateMfPublicKeyCertificate } from './mf-public-key-validator';
+import { KsefSessionCryptoException } from '../../domain/exceptions/ksef-session-crypto.exception';
+
+/** Refetch this many ms before a cert's `validUntil`, so an in-flight wrap never races expiry. */
+const CERT_REFRESH_MARGIN_MS = 5 * 60_000;
+
+const MF_CERTIFICATES_PATH = '/security/public-key-certificates';
+
+/** Wire shape of one entry in the MF public-key-certificates response. */
+interface MfCertificateResponseEntry {
+  certificate: string;
+  usage: KsefCertificateUsage;
+  validFrom: string;
+  validUntil: string;
+}
+
+interface MfCertificatesResponse {
+  certificates: MfCertificateResponseEntry[];
+}
+
+/** Cached shape (PEM + ISO dates) — dates are re-hydrated to `Date` on read. */
+interface CachedCertificate {
+  certificatePem: string;
+  usage: KsefCertificateUsage;
+  validFrom: string;
+  validUntil: string;
+  certificateHash: string;
+}
+
+export class MfPublicKeyCacheService {
+  private readonly logger = new Logger(MfPublicKeyCacheService.name);
+
+  constructor(
+    private readonly connectionId: string,
+    private readonly httpClient: IKsefHttpClient,
+    private readonly cache?: CachePort,
+  ) {}
+
+  /**
+   * Resolve the active MF public-key cert for a usage, cache-first. On miss /
+   * expiry, fetches, selects the latest valid cert, validates it, and caches it
+   * with a validity-derived TTL.
+   */
+  async fetchAndCachePublicKey(usage: KsefCertificateUsage): Promise<PublicKeyCertificate> {
+    const cacheKey = this.cacheKeyFor(usage);
+    const now = new Date();
+
+    const cached = await this.readFromCache(cacheKey, usage, now);
+    if (cached) {
+      this.logger.debug(`MF public-key cache hit (${cacheKey})`);
+      return cached;
+    }
+
+    this.logger.debug(`MF public-key cache miss (${cacheKey}); fetching`);
+    const cert = await this.fetchActiveCertificate(usage, now);
+
+    await this.writeToCache(cacheKey, cert, now);
+    return cert;
+  }
+
+  private cacheKeyFor(usage: KsefCertificateUsage): string {
+    return `ksef:mf-public-key:${this.connectionId}:${usage}`;
+  }
+
+  private async readFromCache(
+    cacheKey: string,
+    usage: KsefCertificateUsage,
+    now: Date,
+  ): Promise<PublicKeyCertificate | null> {
+    if (!this.cache) {
+      return null;
+    }
+    const entry = await this.cache.get<CachedCertificate>(cacheKey);
+    if (!entry) {
+      return null;
+    }
+    const cert: PublicKeyCertificate = {
+      certificatePem: entry.certificatePem,
+      usage: entry.usage,
+      validFrom: new Date(entry.validFrom),
+      validUntil: new Date(entry.validUntil),
+      certificateHash: entry.certificateHash,
+    };
+    try {
+      validateMfPublicKeyCertificate(cert, usage, now);
+    } catch {
+      // A cached-but-now-stale cert (rotated early) → drop and refetch.
+      await this.cache.delete(cacheKey);
+      return null;
+    }
+    return cert;
+  }
+
+  private async writeToCache(
+    cacheKey: string,
+    cert: PublicKeyCertificate,
+    now: Date,
+  ): Promise<void> {
+    if (!this.cache) {
+      return;
+    }
+    const ttlMs = cert.validUntil.getTime() - CERT_REFRESH_MARGIN_MS - now.getTime();
+    if (ttlMs <= 0) {
+      // Cert is within the refresh margin of expiry — usable now but not worth
+      // caching; the next call refetches.
+      return;
+    }
+    const ttlSec = Math.floor(ttlMs / 1000);
+    const entry: CachedCertificate = {
+      certificatePem: cert.certificatePem,
+      usage: cert.usage,
+      validFrom: cert.validFrom.toISOString(),
+      validUntil: cert.validUntil.toISOString(),
+      certificateHash: cert.certificateHash,
+    };
+    await this.cache.set(cacheKey, entry, ttlSec);
+    this.logger.debug(`Cached MF public key (${cacheKey}) ttl=${ttlSec}s cert=${cert.certificateHash}`);
+  }
+
+  private async fetchActiveCertificate(
+    usage: KsefCertificateUsage,
+    now: Date,
+  ): Promise<PublicKeyCertificate> {
+    const response = await this.httpClient.get<MfCertificatesResponse>(MF_CERTIFICATES_PATH);
+    const matching = (response.data.certificates ?? [])
+      .filter((entry) => entry.usage === usage)
+      .map((entry) => this.toCertificate(entry))
+      // Latest-issued first.
+      .sort((a, b) => b.validFrom.getTime() - a.validFrom.getTime());
+
+    const active = matching.find((cert) => {
+      try {
+        validateMfPublicKeyCertificate(cert, usage, now);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    if (!active) {
+      throw new KsefSessionCryptoException(
+        `No valid MF public-key certificate for usage ${usage}`,
+        'CERT_NOT_FOUND',
+      );
+    }
+    return active;
+  }
+
+  private toCertificate(entry: MfCertificateResponseEntry): PublicKeyCertificate {
+    return {
+      certificatePem: entry.certificate,
+      usage: entry.usage,
+      validFrom: new Date(entry.validFrom),
+      validUntil: new Date(entry.validUntil),
+      certificateHash: createHash('sha256').update(entry.certificate).digest('hex'),
+    };
+  }
+}

--- a/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-cache.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-cache.service.ts
@@ -3,14 +3,18 @@
  *
  * Fetches MF public-key certificates from `GET /security/public-key-certificates`
  * and caches the selected cert per `(connectionId, usage)` via the host cache.
- * The cache TTL is derived from the cert's validity window (`validUntil - now`,
- * minus a safety margin) — never a hardcoded constant — so a rotated cert can't
- * be served past its lifetime. When no host cache is wired the service degrades
- * to a per-call fetch.
+ * The endpoint returns a flat ARRAY of `PublicKeyCertificate` entries — each
+ * carries `certificate` (DER, base64), `certificateId`, `publicKeyId` (the
+ * 44-char encryption-key selector), `validFrom`/`validTo`, and `usage` as an
+ * ARRAY of operations. The cache TTL is derived from the cert's validity window
+ * (`validTo - now`, minus a safety margin) — never a hardcoded constant — so a
+ * rotated cert can't be served past its lifetime. When no host cache is wired
+ * the service degrades to a per-call fetch.
  *
  * Used by both `KsefTokenEncryptor` (usage `KsefTokenEncryption`) and
  * `KsefSessionCryptoService` (usage `SymmetricKeyEncryption`); the usage is a
- * required selector to avoid key-confusion between the two cert kinds.
+ * required selector (matched against the cert's `usage` array) to avoid
+ * key-confusion between the two cert kinds.
  *
  * SECURITY: logs only the cache key (connectionId + usage), the selected cert
  * hash, and the derived TTL — never the PEM / key material.
@@ -25,29 +29,35 @@ import type { KsefCertificateUsage, PublicKeyCertificate } from '../http/ksef-cr
 import { validateMfPublicKeyCertificate } from './mf-public-key-validator';
 import { KsefSessionCryptoException } from '../../domain/exceptions/ksef-session-crypto.exception';
 
-/** Refetch this many ms before a cert's `validUntil`, so an in-flight wrap never races expiry. */
+/** Refetch this many ms before a cert's `validTo`, so an in-flight wrap never races expiry. */
 const CERT_REFRESH_MARGIN_MS = 5 * 60_000;
 
 const MF_CERTIFICATES_PATH = '/security/public-key-certificates';
 
-/** Wire shape of one entry in the MF public-key-certificates response. */
+/**
+ * Wire shape of one `PublicKeyCertificate` entry. `certificate` is DER bytes
+ * base64-encoded; `usage` is an array of operations the cert may be used for.
+ */
 interface MfCertificateResponseEntry {
   certificate: string;
-  usage: KsefCertificateUsage;
+  certificateId?: string;
+  publicKeyId?: string;
+  usage: string[];
   validFrom: string;
-  validUntil: string;
+  validTo: string;
 }
 
-interface MfCertificatesResponse {
-  certificates: MfCertificateResponseEntry[];
-}
+/** The endpoint returns a bare array of certificate entries. */
+type MfCertificatesResponse = MfCertificateResponseEntry[];
 
 /** Cached shape (PEM + ISO dates) — dates are re-hydrated to `Date` on read. */
 interface CachedCertificate {
   certificatePem: string;
-  usage: KsefCertificateUsage;
+  usage: KsefCertificateUsage[];
   validFrom: string;
-  validUntil: string;
+  validTo: string;
+  publicKeyId?: string;
+  certificateId?: string;
   certificateHash: string;
 }
 
@@ -62,8 +72,8 @@ export class MfPublicKeyCacheService {
 
   /**
    * Resolve the active MF public-key cert for a usage, cache-first. On miss /
-   * expiry, fetches, selects the latest valid cert, validates it, and caches it
-   * with a validity-derived TTL.
+   * expiry, fetches, selects the latest valid cert whose `usage` array includes
+   * the requested usage, validates it, and caches it with a validity-derived TTL.
    */
   async fetchAndCachePublicKey(usage: KsefCertificateUsage): Promise<PublicKeyCertificate> {
     const cacheKey = this.cacheKeyFor(usage);
@@ -102,7 +112,9 @@ export class MfPublicKeyCacheService {
       certificatePem: entry.certificatePem,
       usage: entry.usage,
       validFrom: new Date(entry.validFrom),
-      validUntil: new Date(entry.validUntil),
+      validTo: new Date(entry.validTo),
+      publicKeyId: entry.publicKeyId,
+      certificateId: entry.certificateId,
       certificateHash: entry.certificateHash,
     };
     try {
@@ -123,7 +135,7 @@ export class MfPublicKeyCacheService {
     if (!this.cache) {
       return;
     }
-    const ttlMs = cert.validUntil.getTime() - CERT_REFRESH_MARGIN_MS - now.getTime();
+    const ttlMs = cert.validTo.getTime() - CERT_REFRESH_MARGIN_MS - now.getTime();
     if (ttlMs <= 0) {
       // Cert is within the refresh margin of expiry — usable now but not worth
       // caching; the next call refetches.
@@ -134,7 +146,9 @@ export class MfPublicKeyCacheService {
       certificatePem: cert.certificatePem,
       usage: cert.usage,
       validFrom: cert.validFrom.toISOString(),
-      validUntil: cert.validUntil.toISOString(),
+      validTo: cert.validTo.toISOString(),
+      publicKeyId: cert.publicKeyId,
+      certificateId: cert.certificateId,
       certificateHash: cert.certificateHash,
     };
     await this.cache.set(cacheKey, entry, ttlSec);
@@ -146,8 +160,9 @@ export class MfPublicKeyCacheService {
     now: Date,
   ): Promise<PublicKeyCertificate> {
     const response = await this.httpClient.get<MfCertificatesResponse>(MF_CERTIFICATES_PATH);
-    const matching = (response.data.certificates ?? [])
-      .filter((entry) => entry.usage === usage)
+    const entries = Array.isArray(response.data) ? response.data : [];
+    const matching = entries
+      .filter((entry) => (entry.usage ?? []).includes(usage))
       .map((entry) => this.toCertificate(entry))
       // Latest-issued first.
       .sort((a, b) => b.validFrom.getTime() - a.validFrom.getTime());
@@ -171,12 +186,28 @@ export class MfPublicKeyCacheService {
   }
 
   private toCertificate(entry: MfCertificateResponseEntry): PublicKeyCertificate {
+    const certificatePem = this.toPem(entry.certificate);
     return {
-      certificatePem: entry.certificate,
-      usage: entry.usage,
+      certificatePem,
+      usage: (entry.usage ?? []) as KsefCertificateUsage[],
       validFrom: new Date(entry.validFrom),
-      validUntil: new Date(entry.validUntil),
-      certificateHash: createHash('sha256').update(entry.certificate).digest('hex'),
+      validTo: new Date(entry.validTo),
+      publicKeyId: entry.publicKeyId,
+      certificateId: entry.certificateId,
+      certificateHash: createHash('sha256').update(certificatePem).digest('hex'),
     };
+  }
+
+  /**
+   * Wrap a base64-DER X.509 certificate into a PEM block. `createPublicKey`
+   * (in the RSA wrapper) accepts a certificate PEM and extracts the SPKI. A
+   * payload that is already PEM (legacy/test fixtures) is passed through.
+   */
+  private toPem(certificate: string): string {
+    if (certificate.includes('-----BEGIN')) {
+      return certificate;
+    }
+    const lines = certificate.replace(/\s+/g, '').match(/.{1,64}/g) ?? [certificate];
+    return `-----BEGIN CERTIFICATE-----\n${lines.join('\n')}\n-----END CERTIFICATE-----\n`;
   }
 }

--- a/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-validator.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-validator.ts
@@ -1,0 +1,50 @@
+/**
+ * MF Public Key Certificate Validator
+ *
+ * Pure validation gate applied to every MF public-key certificate before it is
+ * trusted to wrap a session secret. A compromised, expired, or wrong-usage cert
+ * could trap session secrets behind a key an attacker owns, so we enforce the
+ * validity window and the declared `usage` matches the intended operation.
+ *
+ * NOTE: full chain-of-trust verification against a pinned MF root is DEFERRED —
+ * KSeF serves these certs over TLS from the MF backend, and the C3 scope
+ * validates the validity window + usage. Root-pinning + OCSP/CRL is a tracked
+ * follow-up (see crypto README); this function is the single seam to add it.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/crypto
+ */
+import type {
+  KsefCertificateUsage,
+  PublicKeyCertificate,
+} from '../http/ksef-crypto.types';
+import { KsefSessionCryptoException } from '../../domain/exceptions/ksef-session-crypto.exception';
+
+/**
+ * Validate a cert for a given usage at a given instant. Throws
+ * `KsefSessionCryptoException` on any of: not-yet-valid, expired, or usage
+ * mismatch. The message carries only the cert hash + usage, never key material.
+ */
+export function validateMfPublicKeyCertificate(
+  cert: PublicKeyCertificate,
+  usage: KsefCertificateUsage,
+  now: Date = new Date(),
+): void {
+  if (cert.usage !== usage) {
+    throw new KsefSessionCryptoException(
+      `MF cert usage mismatch: expected ${usage}, got ${cert.usage} (cert ${cert.certificateHash})`,
+      'CERT_USAGE_MISMATCH',
+    );
+  }
+  if (now.getTime() < cert.validFrom.getTime()) {
+    throw new KsefSessionCryptoException(
+      `MF cert not yet valid (validFrom ${cert.validFrom.toISOString()}, cert ${cert.certificateHash})`,
+      'CERT_NOT_YET_VALID',
+    );
+  }
+  if (now.getTime() >= cert.validUntil.getTime()) {
+    throw new KsefSessionCryptoException(
+      `MF cert expired (validUntil ${cert.validUntil.toISOString()}, cert ${cert.certificateHash})`,
+      'CERT_EXPIRED',
+    );
+  }
+}

--- a/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-validator.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-validator.ts
@@ -29,9 +29,9 @@ export function validateMfPublicKeyCertificate(
   usage: KsefCertificateUsage,
   now: Date = new Date(),
 ): void {
-  if (cert.usage !== usage) {
+  if (!cert.usage.includes(usage)) {
     throw new KsefSessionCryptoException(
-      `MF cert usage mismatch: expected ${usage}, got ${cert.usage} (cert ${cert.certificateHash})`,
+      `MF cert usage mismatch: expected ${usage}, got [${cert.usage.join(', ')}] (cert ${cert.certificateHash})`,
       'CERT_USAGE_MISMATCH',
     );
   }
@@ -41,9 +41,9 @@ export function validateMfPublicKeyCertificate(
       'CERT_NOT_YET_VALID',
     );
   }
-  if (now.getTime() >= cert.validUntil.getTime()) {
+  if (now.getTime() >= cert.validTo.getTime()) {
     throw new KsefSessionCryptoException(
-      `MF cert expired (validUntil ${cert.validUntil.toISOString()}, cert ${cert.certificateHash})`,
+      `MF cert expired (validTo ${cert.validTo.toISOString()}, cert ${cert.certificateHash})`,
       'CERT_EXPIRED',
     );
   }

--- a/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-validator.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/mf-public-key-validator.ts
@@ -29,6 +29,11 @@ export function validateMfPublicKeyCertificate(
   usage: KsefCertificateUsage,
   now: Date = new Date(),
 ): void {
+  // TODO(security): before go-live, production MUST add full chain-of-trust
+  // verification here — pin the MF root CA and check the cert chains to it, plus
+  // OCSP/CRL revocation. Today this gate only enforces the validity window +
+  // declared usage (C3 scope; see crypto README). This function is the single
+  // seam to add the pinning/revocation checks.
   if (!cert.usage.includes(usage)) {
     throw new KsefSessionCryptoException(
       `MF cert usage mismatch: expected ${usage}, got [${cert.usage.join(', ')}] (cert ${cert.certificateHash})`,

--- a/libs/integrations/ksef/src/infrastructure/crypto/rsa-key-wrapper.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/rsa-key-wrapper.ts
@@ -1,0 +1,99 @@
+/**
+ * RSA-OAEP Key Wrapper (KSeF session crypto)
+ *
+ * Pure functions wrapping Node's `crypto` for RSA-OAEP (MGF1 + SHA-256) key
+ * wrapping. KSeF wraps both the ephemeral AES session key (document session)
+ * and the (token | timestamp) auth blob under an MF public key. The OAEP hash
+ * is pinned to SHA-256 (`KSEF_RSA_OAEP_HASH`); a downgrade to SHA-1 or PKCS#1
+ * v1.5 would be silently rejected by the MF backend, so the padding is a wire
+ * contract, not a tunable.
+ *
+ * The public key is supplied as a PEM (certificate or SPKI). `createPublicKey`
+ * accepts an X.509 cert PEM and extracts the SPKI automatically. We validate
+ * the key is RSA and ≥ `KSEF_RSA_MIN_MODULUS_BITS` before trusting it.
+ *
+ * SECURITY: never log the plaintext, the wrapped bytes, or the private key.
+ * `unwrapKeyWithRsa` exists for round-trip unit coverage only — production
+ * never holds the MF private key (the server unwraps).
+ *
+ * @module libs/integrations/ksef/src/infrastructure/crypto
+ */
+import { constants, createPublicKey, privateDecrypt, publicEncrypt } from 'crypto';
+import type { KeyObject } from 'crypto';
+import { KSEF_RSA_MIN_MODULUS_BITS, KSEF_RSA_OAEP_HASH } from '../http/ksef-crypto.constants';
+import { KsefSessionCryptoException } from '../../domain/exceptions/ksef-session-crypto.exception';
+
+/**
+ * Load + validate an MF RSA public key from a PEM (cert or SPKI). Throws
+ * `KsefSessionCryptoException` on a non-RSA or under-sized key so we never wrap
+ * a session secret under a downgraded/malformed key.
+ */
+function loadRsaPublicKey(publicKeyPem: string): KeyObject {
+  let keyObject: KeyObject;
+  try {
+    keyObject = createPublicKey(publicKeyPem);
+  } catch (err) {
+    throw new KsefSessionCryptoException(
+      'Failed to parse MF RSA public key PEM',
+      'RSA_BAD_PEM',
+      err as Error,
+    );
+  }
+  if (keyObject.asymmetricKeyType !== 'rsa') {
+    throw new KsefSessionCryptoException(
+      `MF public key is not RSA (got ${keyObject.asymmetricKeyType ?? 'unknown'})`,
+      'RSA_WRONG_KEY_TYPE',
+    );
+  }
+  const modulusBits = keyObject.asymmetricKeyDetails?.modulusLength;
+  if (modulusBits !== undefined && modulusBits < KSEF_RSA_MIN_MODULUS_BITS) {
+    throw new KsefSessionCryptoException(
+      `MF RSA key too small: ${modulusBits} bits (min ${KSEF_RSA_MIN_MODULUS_BITS})`,
+      'RSA_KEY_TOO_SMALL',
+    );
+  }
+  return keyObject;
+}
+
+/**
+ * Wrap raw bytes (an AES key, or the auth token blob) under an MF RSA public
+ * key using RSA-OAEP / MGF1 / SHA-256.
+ */
+export function wrapKeyWithRsa(plaintext: Uint8Array, publicKeyPem: string): Uint8Array {
+  const key = loadRsaPublicKey(publicKeyPem);
+  try {
+    return new Uint8Array(
+      publicEncrypt(
+        { key, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: KSEF_RSA_OAEP_HASH },
+        Buffer.from(plaintext),
+      ),
+    );
+  } catch (err) {
+    throw new KsefSessionCryptoException('RSA-OAEP wrap failed', 'RSA_WRAP_FAILED', err as Error);
+  }
+}
+
+/**
+ * Unwrap bytes with an RSA private key (test/round-trip only — production never
+ * holds the MF private key). Pins the same OAEP/SHA-256 params as the wrap path.
+ */
+export function unwrapKeyWithRsa(wrappedKey: Uint8Array, privateKeyPem: string): Uint8Array {
+  try {
+    return new Uint8Array(
+      privateDecrypt(
+        {
+          key: privateKeyPem,
+          padding: constants.RSA_PKCS1_OAEP_PADDING,
+          oaepHash: KSEF_RSA_OAEP_HASH,
+        },
+        Buffer.from(wrappedKey),
+      ),
+    );
+  } catch (err) {
+    throw new KsefSessionCryptoException(
+      'RSA-OAEP unwrap failed',
+      'RSA_UNWRAP_FAILED',
+      err as Error,
+    );
+  }
+}

--- a/libs/integrations/ksef/src/infrastructure/http/README.md
+++ b/libs/integrations/ksef/src/infrastructure/http/README.md
@@ -23,13 +23,19 @@ request leaves.
 ## Auth handshake (ksef-token flow)
 
 1. `POST /auth/challenge` → `{ challenge, timestamp }`
-2. `KsefTokenEncryptor` RSA-OAEP-wraps `token|timestamp` under the MF
-   `KsefTokenEncryption` public key
-3. `POST /auth/ksef-token` → `{ referenceNumber }` (async)
-4. poll `GET /auth/{referenceNumber}` until `status=completed`
-   (exponential backoff to 5 s, 300 s deadline)
-5. `POST /auth/token/redeem` → `{ accessToken, refreshToken }` (JWTs)
-6. `parseJwtExpiry(accessToken)` → cache TTL (read from `exp`, never hardcoded)
+2. `KsefTokenEncryptor.buildInitRequest` RSA-OAEP-wraps `token|timestamp` under
+   the MF `KsefTokenEncryption` public key and assembles
+   `InitTokenAuthenticationRequest { challenge, contextIdentifier{type,value},
+   encryptedToken, publicKeyId? }`
+3. `POST /auth/ksef-token` → `{ referenceNumber, authenticationToken }` (async;
+   `authenticationToken` is the Bearer for the next two calls)
+4. poll `GET /auth/{referenceNumber}` (Bearer authenticationToken) until
+   `status.code === 200` (`100` = in progress; exponential backoff to 5 s,
+   300 s deadline)
+5. `POST /auth/token/redeem` (Bearer authenticationToken, NO body) →
+   `{ accessToken: TokenInfo, refreshToken: TokenInfo }`
+6. `parseJwtExpiry(accessToken.token)` → cache TTL (read from `exp`, never
+   hardcoded)
 
 The **qualified-seal** flow (XAdES signing → `POST /auth/xades-signature`) is
 DEFERRED to C4: it needs real X.509/HSM material and a vetted XML signing

--- a/libs/integrations/ksef/src/infrastructure/http/README.md
+++ b/libs/integrations/ksef/src/infrastructure/http/README.md
@@ -1,0 +1,65 @@
+# KSeF HTTP & Auth Layer (C3)
+
+Hand-rolled `fetch`-based transport for the KSeF Public API v2 (no axios), plus
+the authentication handshake. Mirrors the in-tree `AllegroHttpClient` precedent:
+retries, rate-limit backoff, token lifecycle, structured logging — never logging
+credential material.
+
+## Environment → base URL
+
+`resolveKsefBaseUrl(env)` (`ksef-hosts.ts`) maps the connection's `env` to the
+`/api/v2` base. An unknown environment throws `KsefConfigException` before any
+request leaves.
+
+| env  | base URL                              |
+|------|---------------------------------------|
+| test | `https://ksef-test.mf.gov.pl/api/v2`  |
+| demo | `https://ksef-demo.mf.gov.pl/api/v2`  |
+| prod | `https://ksef.mf.gov.pl/api/v2`       |
+
+> The exact hostnames are best-effort from the documented KSeF 2.0 sequence and
+> are validated against the live test endpoint when the client is first exercised.
+
+## Auth handshake (ksef-token flow)
+
+1. `POST /auth/challenge` → `{ challenge, timestamp }`
+2. `KsefTokenEncryptor` RSA-OAEP-wraps `token|timestamp` under the MF
+   `KsefTokenEncryption` public key
+3. `POST /auth/ksef-token` → `{ referenceNumber }` (async)
+4. poll `GET /auth/{referenceNumber}` until `status=completed`
+   (exponential backoff to 5 s, 300 s deadline)
+5. `POST /auth/token/redeem` → `{ accessToken, refreshToken }` (JWTs)
+6. `parseJwtExpiry(accessToken)` → cache TTL (read from `exp`, never hardcoded)
+
+The **qualified-seal** flow (XAdES signing → `POST /auth/xades-signature`) is
+DEFERRED to C4: it needs real X.509/HSM material and a vetted XML signing
+library. `KsefAuthXmlBuilder.signXades` and the factory both throw
+`KsefConfigException` for a qualified-seal connection until then.
+
+## Token lifecycle
+
+- The access token is produced lazily on the first authenticated request, then
+  cached with a TTL read from the JWT `exp`.
+- **Proactive refresh**: within 60 s of expiry the `refresh` callback rotates
+  the token before the request (single-flight per client).
+- **Reactive 401/403**: the client refreshes once and retries. The tagged
+  `RefreshOnUnauthorizedOutcome` distinguishes `credential-rejected`
+  (→ `KsefAuthenticationException`, non-retryable; the host's
+  `AuthFailureClassifierPort` flips the connection to `needs_reauth`) from
+  `network-failure` (→ `KsefNetworkException`, retryable).
+- `/auth/*` and `/security/public-key-certificates` are unauthenticated — the
+  client skips bearer injection so the handshake can bootstrap before any token.
+
+## Retry + rate-limit policy
+
+- Idempotent calls (`GET`, or `POST` with `options.idempotent`) retry transient
+  failures (5xx / network) with exponential backoff (1 s → 30 s).
+- Non-idempotent `POST` fails fast on 5xx/network.
+- `429` always backs off (`Retry-After`-aware) and retries within the budget.
+- Deterministic 4xx (other than 401/403) fail fast as `KsefApiException`.
+
+## Security
+
+No log line carries the access/refresh token, the `Authorization` header, the
+plaintext ksef-token, or request/response bodies that may carry credential
+material. Logs carry the trace id, method, path, status, and duration only.

--- a/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-auth-handshake.int-spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-auth-handshake.int-spec.ts
@@ -1,0 +1,68 @@
+/**
+ * KSeF auth handshake — live test-environment integration spec (env-gated).
+ *
+ * This is the ONLY place that asserts behaviour "against the KSeF test
+ * environment". It is gated on real sandbox credentials and SKIPS entirely when
+ * they are absent — so it never runs (and never hits the network) in the fast
+ * unit suite (the merge gate) or in CI without secrets.
+ *
+ * To run locally against the KSeF test tier, export:
+ *   KSEF_TEST_TOKEN=<static authorization token issued in the KSeF test app>
+ *   KSEF_TEST_NIP=<10-digit context NIP the token authenticates>
+ *   # optional: KSEF_TEST_ENV=test|demo  (default: test)
+ *
+ *   pnpm --filter @openlinker/integrations-ksef test ksef-auth-handshake.int-spec
+ *
+ * What it proves end-to-end (no mocks): the real handshake fetches the MF
+ * token-encryption public key, RSA-OAEP-wraps (token | challenge timestamp),
+ * submits, polls the async reference to completion, redeems, and parses a real
+ * access-token `exp` — and a subsequent authenticated GET succeeds with the
+ * bearer the handshake produced.
+ *
+ * SECURITY: credentials come only from the environment; nothing is logged.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+import { createKsefHttpClient } from '../ksef-http-client.factory';
+import type { KsefEnvironment } from '../../../domain/types/ksef-connection.types';
+
+const token = process.env.KSEF_TEST_TOKEN;
+const contextNip = process.env.KSEF_TEST_NIP;
+const env = (process.env.KSEF_TEST_ENV as KsefEnvironment | undefined) ?? 'test';
+const credsPresent = Boolean(token && contextNip);
+
+// `describe.skip` when creds are absent → the whole suite is reported skipped,
+// never executed, so the fast suite stays network-free and green.
+const maybeDescribe = credsPresent ? describe : describe.skip;
+
+maybeDescribe('KSeF auth handshake (live test environment)', () => {
+  // 5 minutes: the async reference poll can take tens of seconds in the sandbox.
+  jest.setTimeout(300_000);
+
+  it('should complete the ksef-token handshake and produce a usable access token', async () => {
+    const { handshake, httpClient } = createKsefHttpClient({
+      connectionId: 'int-spec-conn',
+      env,
+      authMaterial: {
+        authType: 'ksef-token',
+        token: token as string,
+        contextNip: contextNip as string,
+      },
+    });
+
+    const result = await handshake.authenticate({
+      authType: 'ksef-token',
+      token: token as string,
+      contextNip: contextNip as string,
+    });
+
+    expect(result.accessToken.split('.')).toHaveLength(3);
+    expect(result.refreshToken.length).toBeGreaterThan(0);
+    expect(result.accessTokenExpiresAt.getTime()).toBeGreaterThan(Date.now());
+
+    // The produced bearer must be accepted by a real authenticated read.
+    const ping = await httpClient.get('/security/public-key-certificates');
+    expect(ping.status).toBeGreaterThanOrEqual(200);
+    expect(ping.status).toBeLessThan(300);
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-auth-handshake.int-spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-auth-handshake.int-spec.ts
@@ -14,7 +14,7 @@
  *   pnpm --filter @openlinker/integrations-ksef test ksef-auth-handshake.int-spec
  *
  * What it proves end-to-end (no mocks): the real handshake fetches the MF
- * token-encryption public key, RSA-OAEP-wraps (token | challenge timestamp),
+ * token-encryption public key, RSA-OAEP-wraps (token | challenge timestamp-ms),
  * submits, polls the async reference to completion, redeems, and parses a real
  * access-token `exp` — and a subsequent authenticated GET succeeds with the
  * bearer the handshake produced.

--- a/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-hosts.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-hosts.spec.ts
@@ -7,10 +7,10 @@ import { resolveKsefBaseUrl } from '../ksef-hosts';
 import { KsefConfigException } from '../../../domain/exceptions/ksef-config.exception';
 
 describe('resolveKsefBaseUrl', () => {
-  it('should resolve each known environment to a v2 base URL', () => {
-    expect(resolveKsefBaseUrl('test')).toContain('/api/v2');
-    expect(resolveKsefBaseUrl('demo')).toContain('/api/v2');
-    expect(resolveKsefBaseUrl('prod')).toContain('/api/v2');
+  it('should resolve each known environment to its authoritative api.ksef host + /v2 base', () => {
+    expect(resolveKsefBaseUrl('test')).toBe('https://api-test.ksef.mf.gov.pl/v2');
+    expect(resolveKsefBaseUrl('demo')).toBe('https://api-demo.ksef.mf.gov.pl/v2');
+    expect(resolveKsefBaseUrl('prod')).toBe('https://api.ksef.mf.gov.pl/v2');
   });
 
   it('should throw KsefConfigException for an unknown environment', () => {

--- a/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-hosts.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-hosts.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * KSeF host resolution specs.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+import { resolveKsefBaseUrl } from '../ksef-hosts';
+import { KsefConfigException } from '../../../domain/exceptions/ksef-config.exception';
+
+describe('resolveKsefBaseUrl', () => {
+  it('should resolve each known environment to a v2 base URL', () => {
+    expect(resolveKsefBaseUrl('test')).toContain('/api/v2');
+    expect(resolveKsefBaseUrl('demo')).toContain('/api/v2');
+    expect(resolveKsefBaseUrl('prod')).toContain('/api/v2');
+  });
+
+  it('should throw KsefConfigException for an unknown environment', () => {
+    expect(() => resolveKsefBaseUrl('staging' as never)).toThrow(KsefConfigException);
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-http-client.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-http-client.spec.ts
@@ -29,7 +29,7 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 describe('KsefHttpClient', () => {
-  const baseUrl = 'https://ksef-test.mf.gov.pl/api/v2';
+  const baseUrl = 'https://api-test.ksef.mf.gov.pl/v2';
   let fetchMock: jest.MockedFunction<typeof fetch>;
   let lifecycle: KsefTokenLifecycle;
 

--- a/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-http-client.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-http-client.spec.ts
@@ -54,15 +54,28 @@ describe('KsefHttpClient', () => {
     expect((init.headers as Record<string, string>).Authorization).toBe('Bearer access-token');
   });
 
-  it('should NOT inject a bearer on the unauthenticated /auth and cert endpoints', async () => {
+  it('should NOT inject a bearer when skipAuth is set (unauthenticated bootstrap calls)', async () => {
     fetchMock.mockResolvedValue(jsonResponse(200, { challenge: 'c', timestamp: 't' }));
     const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
 
-    await client.post('/auth/challenge', undefined, { idempotent: true });
+    await client.post('/auth/challenge', undefined, { idempotent: true, skipAuth: true });
 
     expect(lifecycle.authenticate).not.toHaveBeenCalled();
     const init = fetchMock.mock.calls[0][1] as RequestInit;
     expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it('should run the handshake + inject a bearer for an /auth path without skipAuth', async () => {
+    // Path-prefix inference is gone: a future authenticated /auth/* sub-resource
+    // must NOT be silently bypassed — it goes through the normal auth path.
+    fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }));
+    const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+    await client.get('/auth/sessions');
+
+    expect(lifecycle.authenticate).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer access-token');
   });
 
   it('should refresh once and retry on a reactive 401, then succeed', async () => {
@@ -169,16 +182,15 @@ describe('KsefHttpClient', () => {
       await expect(client.get('/sessions/online')).rejects.toBeInstanceOf(KsefNetworkException);
     });
 
-    it('should treat a 403 like a 401 and attempt a single refresh', async () => {
-      fetchMock
-        .mockResolvedValueOnce(jsonResponse(403, { error: 'forbidden' }))
-        .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    it('should fail fast on a 403 as a non-retryable KsefApiException without refreshing', async () => {
+      // 403 is an authorization decision, not an expired token — refreshing
+      // can never change the outcome, so the client must not refresh+retry.
+      fetchMock.mockResolvedValue(jsonResponse(403, { error: 'forbidden' }));
       const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
 
-      const res = await client.get('/sessions/online');
-
-      expect(lifecycle.refresh).toHaveBeenCalledTimes(1);
-      expect(res.data).toEqual({ ok: true });
+      await expect(client.get('/sessions/online')).rejects.toBeInstanceOf(KsefApiException);
+      expect(lifecycle.refresh).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -198,6 +210,27 @@ describe('KsefHttpClient', () => {
 
       expect(res.data).toEqual({ ok: true });
       expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should carry the parsed Retry-After delay on the 429 KsefApiException when retries are exhausted', async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ error: 'slow down' }), {
+          status: 429,
+          headers: { 'content-type': 'application/json', 'retry-after': '2' },
+        }),
+      );
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle, {
+        maxRetries: 0,
+        initialDelayMs: 1,
+        maxDelayMs: 1,
+        backoffMultiplier: 1,
+      });
+
+      await expect(client.get('/sessions/online')).rejects.toMatchObject({
+        name: 'KsefApiException',
+        statusCode: 429,
+        retryAfterMs: 2000,
+      });
     });
 
     it('should retry an idempotent GET on a transient 503 then succeed', async () => {

--- a/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-http-client.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-http-client.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * KSeF HTTP client specs — token lifecycle, 401 refresh, retries, rate limit.
+ *
+ * `fetch` is mocked globally; the token lifecycle is a stub so the test asserts
+ * the client's orchestration (bearer injection, lazy handshake, reactive 401,
+ * retry policy) without real HTTP.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+import { KsefHttpClient, type KsefTokenLifecycle } from '../ksef-http-client';
+import type { KsefAuthenticationToken } from '../ksef-http-client.types';
+import { KsefAuthenticationException } from '../../../domain/exceptions/ksef-authentication.exception';
+import { KsefApiException } from '../../../domain/exceptions/ksef-api.exception';
+import { KsefNetworkException } from '../../../domain/exceptions/ksef-network.exception';
+
+function token(expiresInMs = 3_600_000, accessToken = 'access-token'): KsefAuthenticationToken {
+  return {
+    accessToken,
+    refreshToken: 'refresh-token',
+    accessTokenExpiresAt: new Date(Date.now() + expiresInMs),
+  };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('KsefHttpClient', () => {
+  const baseUrl = 'https://ksef-test.mf.gov.pl/api/v2';
+  let fetchMock: jest.MockedFunction<typeof fetch>;
+  let lifecycle: KsefTokenLifecycle;
+
+  beforeEach(() => {
+    fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+    global.fetch = fetchMock as unknown as typeof fetch;
+    lifecycle = {
+      authenticate: jest.fn().mockResolvedValue(token()),
+      refresh: jest.fn().mockResolvedValue(token()),
+    };
+  });
+
+  it('should lazily run the handshake and inject the bearer on the first authed GET', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+    const res = await client.get('/sessions/online');
+
+    expect(lifecycle.authenticate).toHaveBeenCalledTimes(1);
+    expect(res.data).toEqual({ ok: true });
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer access-token');
+  });
+
+  it('should NOT inject a bearer on the unauthenticated /auth and cert endpoints', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { challenge: 'c', timestamp: 't' }));
+    const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+    await client.post('/auth/challenge', undefined, { idempotent: true });
+
+    expect(lifecycle.authenticate).not.toHaveBeenCalled();
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it('should refresh once and retry on a reactive 401, then succeed', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { error: 'expired' }))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+    const res = await client.get('/sessions/online');
+
+    expect(lifecycle.refresh).toHaveBeenCalledTimes(1);
+    expect(res.data).toEqual({ ok: true });
+  });
+
+  it('should throw KsefAuthenticationException when refresh is rejected on 401', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(401, { error: 'invalid' }));
+    (lifecycle.refresh as jest.Mock).mockRejectedValue(new Error('credential rejected'));
+    const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+    await expect(client.get('/sessions/online')).rejects.toBeInstanceOf(KsefAuthenticationException);
+  });
+
+  it('should fail fast on a deterministic 400 without retrying', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(400, { error: 'bad request' }));
+    const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+    await expect(client.get('/sessions/online')).rejects.toBeInstanceOf(KsefApiException);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not retry a non-idempotent POST on 500', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(500, { error: 'server' }));
+    const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+    await expect(client.post('/sessions', { x: 1 })).rejects.toBeInstanceOf(KsefApiException);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  describe('proactive refresh (refresh-on-exp)', () => {
+    it('should proactively refresh when the cached token is inside the refresh window', async () => {
+      // Handshake yields a token already within the 60s proactive-refresh window
+      // (expires in 30s), so the next authed request must rotate it pre-flight.
+      (lifecycle.authenticate as jest.Mock).mockResolvedValue(token(30_000, 'stale-token'));
+      (lifecycle.refresh as jest.Mock).mockResolvedValue(token(3_600_000, 'fresh-token'));
+      // Fresh Response per call — a `fetch` Response body can only be read once,
+      // and these specs issue two requests against the same mock.
+      fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(200, { ok: true })));
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+      // First call runs the handshake and caches the (already-stale) token...
+      await client.get('/sessions/online');
+      // ...the second call sees it inside the refresh window and rotates first.
+      await client.get('/sessions/online');
+
+      expect(lifecycle.refresh).toHaveBeenCalledTimes(1);
+      const lastInit = fetchMock.mock.calls.at(-1)?.[1] as RequestInit;
+      expect((lastInit.headers as Record<string, string>).Authorization).toBe('Bearer fresh-token');
+    });
+
+    it('should NOT refresh while the cached token is comfortably before the refresh window', async () => {
+      (lifecycle.authenticate as jest.Mock).mockResolvedValue(token(3_600_000, 'fresh-token'));
+      // Fresh Response per call — a `fetch` Response body can only be read once,
+      // and these specs issue two requests against the same mock.
+      fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(200, { ok: true })));
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+      await client.get('/sessions/online');
+      await client.get('/sessions/online');
+
+      expect(lifecycle.authenticate).toHaveBeenCalledTimes(1);
+      expect(lifecycle.refresh).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the reactive path when proactive refresh throws', async () => {
+      // Token is inside the refresh window; the proactive refresh fails, but the
+      // request must still proceed with the existing token (which the server
+      // then accepts), rather than failing pre-flight.
+      (lifecycle.authenticate as jest.Mock).mockResolvedValue(token(30_000, 'stale-token'));
+      (lifecycle.refresh as jest.Mock).mockRejectedValue(new Error('refresh endpoint down'));
+      // Fresh Response per call — a `fetch` Response body can only be read once,
+      // and these specs issue two requests against the same mock.
+      fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(200, { ok: true })));
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+      await client.get('/sessions/online');
+      const res = await client.get('/sessions/online');
+
+      expect(res.data).toEqual({ ok: true });
+      const lastInit = fetchMock.mock.calls.at(-1)?.[1] as RequestInit;
+      // Proactive refresh failed → the stale token is still used (reactive 401
+      // would handle a true rejection on the wire).
+      expect((lastInit.headers as Record<string, string>).Authorization).toBe('Bearer stale-token');
+    });
+  });
+
+  describe('reactive 401 → network-failure refresh', () => {
+    it('should map a network-failure refresh to a retryable KsefNetworkException', async () => {
+      fetchMock.mockResolvedValue(jsonResponse(401, { error: 'expired' }));
+      (lifecycle.refresh as jest.Mock).mockRejectedValue(
+        new KsefNetworkException('auth endpoint unreachable'),
+      );
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+      await expect(client.get('/sessions/online')).rejects.toBeInstanceOf(KsefNetworkException);
+    });
+
+    it('should treat a 403 like a 401 and attempt a single refresh', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse(403, { error: 'forbidden' }))
+        .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+      const res = await client.get('/sessions/online');
+
+      expect(lifecycle.refresh).toHaveBeenCalledTimes(1);
+      expect(res.data).toEqual({ ok: true });
+    });
+  });
+
+  describe('rate limiting + transport', () => {
+    it('should back off on 429 then succeed on a retried idempotent GET', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ error: 'slow down' }), {
+            status: 429,
+            headers: { 'content-type': 'application/json', 'retry-after': '0' },
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+      const res = await client.get('/sessions/online');
+
+      expect(res.data).toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry an idempotent GET on a transient 503 then succeed', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse(503, { error: 'unavailable' }))
+        .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle, {
+        maxRetries: 2,
+        initialDelayMs: 1,
+        maxDelayMs: 2,
+        backoffMultiplier: 2,
+      });
+
+      const res = await client.get('/sessions/online');
+
+      expect(res.data).toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should surface a fetch network error as a KsefNetworkException', async () => {
+      fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle, {
+        maxRetries: 0,
+        initialDelayMs: 1,
+        maxDelayMs: 1,
+        backoffMultiplier: 1,
+      });
+
+      await expect(client.get('/sessions/online')).rejects.toBeInstanceOf(KsefNetworkException);
+    });
+
+    it('should surface an aborted request (timeout) as a KsefNetworkException', async () => {
+      // The client wraps each call in an AbortController with a request timeout;
+      // when fetch rejects with an AbortError the client maps it to a network
+      // exception. Simulate that by having fetch reject with an AbortError.
+      const abortErr = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+      fetchMock.mockRejectedValue(abortErr);
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle, {
+        maxRetries: 0,
+        initialDelayMs: 1,
+        maxDelayMs: 1,
+        backoffMultiplier: 1,
+      });
+
+      await expect(client.get('/sessions/online')).rejects.toBeInstanceOf(KsefNetworkException);
+    });
+
+    it('should read a binary success response through postExpectingBinary', async () => {
+      const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+      fetchMock.mockResolvedValue(
+        new Response(pdfBytes, {
+          status: 200,
+          headers: { 'content-type': 'application/pdf' },
+        }),
+      );
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+      const res = await client.postExpectingBinary('/sessions/REF/upo', { x: 1 }, { idempotent: true });
+
+      expect(res.contentType).toBe('application/pdf');
+      expect(Array.from(res.data)).toEqual(Array.from(pdfBytes));
+    });
+
+    it('should throw KsefApiException on a non-JSON success body for a JSON call', async () => {
+      fetchMock.mockResolvedValue(
+        new Response('not-json{', { status: 200, headers: { 'content-type': 'application/json' } }),
+      );
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
+
+      await expect(client.get('/sessions/online')).rejects.toBeInstanceOf(KsefApiException);
+    });
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-auth-handshake.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-auth-handshake.service.spec.ts
@@ -89,7 +89,7 @@ describe('KsefAuthHandshakeService', () => {
     const http = new FakeKsefHttpClient();
     const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
     http
-      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: '2026-06-23T12:00:00.000Z' }))
       .seed('POST', '/auth/ksef-token', ok(initResult('REF-1')))
       .seed('GET', '/auth/REF-1', ok(status(200)))
       .seed('POST', '/auth/token/redeem', ok(tokens(expSeconds)));
@@ -105,7 +105,7 @@ describe('KsefAuthHandshakeService', () => {
     const http = new FakeKsefHttpClient();
     const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
     http
-      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: '2026-06-23T12:00:00.000Z' }))
       .seed('POST', '/auth/ksef-token', ok(initResult('REF-A')))
       .seed('GET', '/auth/REF-A', ok(status(200)))
       .seed('POST', '/auth/token/redeem', ok(tokens(expSeconds)));
@@ -124,7 +124,7 @@ describe('KsefAuthHandshakeService', () => {
   it('should throw KsefAuthenticationException when the reference reports a terminal failure code', async () => {
     const http = new FakeKsefHttpClient();
     http
-      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: '2026-06-23T12:00:00.000Z' }))
       .seed('POST', '/auth/ksef-token', ok(initResult('REF-2')))
       .seed('GET', '/auth/REF-2', ok(status(450)));
 
@@ -142,7 +142,7 @@ describe('KsefAuthHandshakeService', () => {
   it('should throw when the submit returns no referenceNumber / authenticationToken', async () => {
     const http = new FakeKsefHttpClient();
     http
-      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: '2026-06-23T12:00:00.000Z' }))
       .seed('POST', '/auth/ksef-token', ok({ referenceNumber: '', authenticationToken: { token: '', validUntil: '' } }));
     const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
     await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
@@ -151,7 +151,7 @@ describe('KsefAuthHandshakeService', () => {
   it('should throw when redeem yields no access/refresh token', async () => {
     const http = new FakeKsefHttpClient();
     http
-      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: '2026-06-23T12:00:00.000Z' }))
       .seed('POST', '/auth/ksef-token', ok(initResult('REF-3')))
       .seed('GET', '/auth/REF-3', ok(status(200)))
       .seed('POST', '/auth/token/redeem', ok({}));
@@ -159,11 +159,13 @@ describe('KsefAuthHandshakeService', () => {
     await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
   });
 
-  it('should build the init request bound to the challenge + timestamp before submitting', async () => {
+  it('should build the init request bound to the challenge + epoch-ms timestamp before submitting', async () => {
     const http = new FakeKsefHttpClient();
     const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
+    const timestamp = '2026-06-23T12:00:00.000Z';
+    const timestampMs = Date.parse(timestamp);
     http
-      .seed('POST', '/auth/challenge', ok({ challenge: 'CH-9', timestamp: 'TS-42' }))
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH-9', timestamp }))
       .seed('POST', '/auth/ksef-token', ok(initResult('REF-4')))
       .seed('GET', '/auth/REF-4', ok(status(200)))
       .seed('POST', '/auth/token/redeem', ok(tokens(expSeconds)));
@@ -173,16 +175,41 @@ describe('KsefAuthHandshakeService', () => {
     const service = new KsefAuthHandshakeService('conn-1', http, encryptor);
     await service.authenticate(MATERIAL);
 
-    // token, contextNip, challenge, challengeTimestamp — the challenge + timestamp
-    // bind the ciphertext to this challenge window (replay defence).
-    expect(spy).toHaveBeenCalledWith('TKN', '1234567890', 'CH-9', 'TS-42');
+    // token, contextNip, challenge, challengeTimestampMs — the challenge +
+    // epoch-ms timestamp bind the ciphertext to this challenge window (replay
+    // defence). MF reference encodes the timestamp as Unix milliseconds.
+    expect(spy).toHaveBeenCalledWith('TKN', '1234567890', 'CH-9', String(timestampMs));
+  });
+
+  it('should prefer the server-supplied timestampMs over parsing the ISO timestamp', async () => {
+    const http = new FakeKsefHttpClient();
+    const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
+    http
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH-9', timestamp: '2026-06-23T12:00:00.000Z', timestampMs: 1_750_680_000_000 }))
+      .seed('POST', '/auth/ksef-token', ok(initResult('REF-6')))
+      .seed('GET', '/auth/REF-6', ok(status(200)))
+      .seed('POST', '/auth/token/redeem', ok(tokens(expSeconds)));
+
+    const encryptor = encryptorStub();
+    const spy = jest.spyOn(encryptor, 'buildInitRequest');
+    const service = new KsefAuthHandshakeService('conn-1', http, encryptor);
+    await service.authenticate(MATERIAL);
+
+    expect(spy).toHaveBeenCalledWith('TKN', '1234567890', 'CH-9', '1750680000000');
+  });
+
+  it('should throw KsefAuthenticationException when the challenge timestamp is unparseable', async () => {
+    const http = new FakeKsefHttpClient();
+    http.seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'not-a-date' }));
+    const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
+    await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
   });
 
   it('should treat status code 200 as ready and redeem', async () => {
     const http = new FakeKsefHttpClient();
     const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
     http
-      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: '2026-06-23T12:00:00.000Z' }))
       .seed('POST', '/auth/ksef-token', ok(initResult('REF-5')))
       .seed('GET', '/auth/REF-5', ok(status(200)))
       .seed('POST', '/auth/token/redeem', ok(tokens(expSeconds)));

--- a/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-auth-handshake.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-auth-handshake.service.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * KSeF auth handshake specs — challenge → submit → poll → redeem (ksef-token).
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http/auth
+ */
+import {
+  KsefAuthHandshakeService,
+  type KsefTokenAuthMaterial,
+} from '../ksef-auth-handshake.service';
+import { KsefTokenEncryptor } from '../ksef-token-encryptor.service';
+import type { MfPublicKeyCacheService } from '../../../crypto/mf-public-key-cache.service';
+import { FakeKsefHttpClient } from '../../../../testing/fake-ksef-http-client';
+import { KsefAuthenticationException } from '../../../../domain/exceptions/ksef-authentication.exception';
+import type { KsefHttpResponse } from '../../ksef-http-client.types';
+
+function jwt(expSeconds: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString('base64url');
+  return `${header}.${payload}.`;
+}
+
+function ok<T>(data: T): KsefHttpResponse<T> {
+  return { data, status: 200, headers: {} };
+}
+
+const MATERIAL: KsefTokenAuthMaterial = {
+  authType: 'ksef-token',
+  token: 'TKN',
+  contextNip: '1234567890',
+};
+
+function encryptorStub(): KsefTokenEncryptor {
+  const cache = {
+    fetchAndCachePublicKey: jest.fn().mockResolvedValue({
+      certificatePem: 'PEM',
+      usage: 'KsefTokenEncryption',
+      validFrom: new Date(0),
+      validUntil: new Date(Date.now() + 1e9),
+      certificateHash: 'h',
+    }),
+  } as unknown as MfPublicKeyCacheService;
+  const encryptor = new KsefTokenEncryptor(cache);
+  jest
+    .spyOn(encryptor, 'encryptToken')
+    .mockResolvedValue({ contextNip: '1234567890', encryptedToken: 'CIPHER', challengeTimestamp: 'ts' });
+  return encryptor;
+}
+
+describe('KsefAuthHandshakeService', () => {
+  it('should run challenge → submit → poll → redeem and return parsed tokens', async () => {
+    const http = new FakeKsefHttpClient();
+    const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
+    http
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: 'REF-1' }))
+      .seed('GET', '/auth/REF-1', ok({ status: 'completed' }))
+      .seed('POST', '/auth/token/redeem', ok({ accessToken: jwt(expSeconds), refreshToken: jwt(expSeconds) }));
+
+    const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
+    const result = await service.authenticate(MATERIAL);
+
+    expect(result.accessToken).toContain('.');
+    expect(result.accessTokenExpiresAt.getTime()).toBe(expSeconds * 1000);
+  });
+
+  it('should throw KsefAuthenticationException when the reference reports failed', async () => {
+    const http = new FakeKsefHttpClient();
+    http
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: 'REF-2' }))
+      .seed('GET', '/auth/REF-2', ok({ status: 'failed' }));
+
+    const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
+    await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
+  });
+
+  it('should throw when the challenge is incomplete', async () => {
+    const http = new FakeKsefHttpClient();
+    http.seed('POST', '/auth/challenge', ok({ challenge: '', timestamp: '' }));
+    const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
+    await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
+  });
+
+  it('should throw when the submit returns no referenceNumber', async () => {
+    const http = new FakeKsefHttpClient();
+    http
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: '' }));
+    const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
+    await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
+  });
+
+  it('should throw when redeem yields no access/refresh token', async () => {
+    const http = new FakeKsefHttpClient();
+    http
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: 'REF-3' }))
+      .seed('GET', '/auth/REF-3', ok({ status: 'completed' }))
+      .seed('POST', '/auth/token/redeem', ok({}));
+    const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
+    await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
+  });
+
+  it('should encrypt the token bound to the challenge timestamp before submitting', async () => {
+    const http = new FakeKsefHttpClient();
+    const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
+    http
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'TS-42' }))
+      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: 'REF-4' }))
+      .seed('GET', '/auth/REF-4', ok({ status: 'completed' }))
+      .seed('POST', '/auth/token/redeem', ok({ accessToken: jwt(expSeconds), refreshToken: jwt(expSeconds) }));
+
+    const encryptor = encryptorStub();
+    const spy = jest.spyOn(encryptor, 'encryptToken');
+    const service = new KsefAuthHandshakeService('conn-1', http, encryptor);
+    await service.authenticate(MATERIAL);
+
+    // token | contextNip | challengeTimestamp — the timestamp binds the
+    // ciphertext to this challenge window (replay defence).
+    expect(spy).toHaveBeenCalledWith('TKN', '1234567890', 'TS-42');
+  });
+
+  it('should poll through a processing status before completing', async () => {
+    const http = new FakeKsefHttpClient();
+    const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
+    // The fake replays the same seeded response per key; seed the poll to report
+    // completed so the loop resolves on the first poll. (A multi-status poll is
+    // exercised by the int-spec against the live endpoint.)
+    http
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: 'REF-5' }))
+      .seed('GET', '/auth/REF-5', ok({ status: 'completed' }))
+      .seed('POST', '/auth/token/redeem', ok({ accessToken: jwt(expSeconds), refreshToken: jwt(expSeconds) }));
+
+    const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
+    const result = await service.authenticate(MATERIAL);
+    expect(result.refreshToken).toContain('.');
+    // The poll endpoint was hit, then redeem.
+    expect(http.calls.some((c) => c.method === 'GET' && c.path === '/auth/REF-5')).toBe(true);
+    expect(http.calls.some((c) => c.method === 'POST' && c.path === '/auth/token/redeem')).toBe(true);
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-auth-handshake.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-auth-handshake.service.spec.ts
@@ -1,6 +1,12 @@
 /**
  * KSeF auth handshake specs — challenge → submit → poll → redeem (ksef-token).
  *
+ * Wire shapes reconciled to the authoritative KSeF 2.0 OpenAPI spec:
+ * `AuthenticationInitResponse` (referenceNumber + authenticationToken),
+ * `AuthenticationOperationStatusResponse` (status.code: 100 in-progress / 200
+ * success), `AuthenticationTokensResponse` (accessToken/refreshToken nested
+ * TokenInfo), redeem with no body + Bearer authenticationToken.
+ *
  * @module libs/integrations/ksef/src/infrastructure/http/auth
  */
 import {
@@ -12,6 +18,7 @@ import type { MfPublicKeyCacheService } from '../../../crypto/mf-public-key-cach
 import { FakeKsefHttpClient } from '../../../../testing/fake-ksef-http-client';
 import { KsefAuthenticationException } from '../../../../domain/exceptions/ksef-authentication.exception';
 import type { KsefHttpResponse } from '../../ksef-http-client.types';
+import type { InitTokenAuthenticationRequest } from '../../ksef-auth.types';
 
 function jwt(expSeconds: number): string {
   const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
@@ -23,26 +30,57 @@ function ok<T>(data: T): KsefHttpResponse<T> {
   return { data, status: 200, headers: {} };
 }
 
+/** `AuthenticationInitResponse` shape. */
+function initResult(referenceNumber: string): {
+  referenceNumber: string;
+  authenticationToken: { token: string; validUntil: string };
+} {
+  return {
+    referenceNumber,
+    authenticationToken: { token: 'AUTH-TKN', validUntil: '2030-01-01T00:00:00Z' },
+  };
+}
+
+/** `AuthenticationOperationStatusResponse` with a given status code. */
+function status(code: number): { status: { code: number; description: string } } {
+  return { status: { code, description: `status ${code}` } };
+}
+
+/** `AuthenticationTokensResponse` — nested TokenInfo. */
+function tokens(expSeconds: number): {
+  accessToken: { token: string; validUntil: string };
+  refreshToken: { token: string; validUntil: string };
+} {
+  return {
+    accessToken: { token: jwt(expSeconds), validUntil: '2030-01-01T00:00:00Z' },
+    refreshToken: { token: jwt(expSeconds), validUntil: '2030-01-01T00:00:00Z' },
+  };
+}
+
 const MATERIAL: KsefTokenAuthMaterial = {
   authType: 'ksef-token',
   token: 'TKN',
   contextNip: '1234567890',
 };
 
+const FAKE_INIT_REQUEST: InitTokenAuthenticationRequest = {
+  challenge: 'CH',
+  contextIdentifier: { type: 'Nip', value: '1234567890' },
+  encryptedToken: 'CIPHER',
+};
+
 function encryptorStub(): KsefTokenEncryptor {
   const cache = {
     fetchAndCachePublicKey: jest.fn().mockResolvedValue({
       certificatePem: 'PEM',
-      usage: 'KsefTokenEncryption',
+      usage: ['KsefTokenEncryption'],
       validFrom: new Date(0),
-      validUntil: new Date(Date.now() + 1e9),
+      validTo: new Date(Date.now() + 1e9),
       certificateHash: 'h',
     }),
   } as unknown as MfPublicKeyCacheService;
   const encryptor = new KsefTokenEncryptor(cache);
-  jest
-    .spyOn(encryptor, 'encryptToken')
-    .mockResolvedValue({ contextNip: '1234567890', encryptedToken: 'CIPHER', challengeTimestamp: 'ts' });
+  jest.spyOn(encryptor, 'buildInitRequest').mockResolvedValue(FAKE_INIT_REQUEST);
   return encryptor;
 }
 
@@ -52,9 +90,9 @@ describe('KsefAuthHandshakeService', () => {
     const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
     http
       .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
-      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: 'REF-1' }))
-      .seed('GET', '/auth/REF-1', ok({ status: 'completed' }))
-      .seed('POST', '/auth/token/redeem', ok({ accessToken: jwt(expSeconds), refreshToken: jwt(expSeconds) }));
+      .seed('POST', '/auth/ksef-token', ok(initResult('REF-1')))
+      .seed('GET', '/auth/REF-1', ok(status(200)))
+      .seed('POST', '/auth/token/redeem', ok(tokens(expSeconds)));
 
     const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
     const result = await service.authenticate(MATERIAL);
@@ -63,12 +101,32 @@ describe('KsefAuthHandshakeService', () => {
     expect(result.accessTokenExpiresAt.getTime()).toBe(expSeconds * 1000);
   });
 
-  it('should throw KsefAuthenticationException when the reference reports failed', async () => {
+  it('should authenticate the poll + redeem with the submit authenticationToken as Bearer', async () => {
+    const http = new FakeKsefHttpClient();
+    const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
+    http
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
+      .seed('POST', '/auth/ksef-token', ok(initResult('REF-A')))
+      .seed('GET', '/auth/REF-A', ok(status(200)))
+      .seed('POST', '/auth/token/redeem', ok(tokens(expSeconds)));
+
+    const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
+    await service.authenticate(MATERIAL);
+
+    const poll = http.calls.find((c) => c.method === 'GET' && c.path === '/auth/REF-A');
+    const redeem = http.calls.find((c) => c.method === 'POST' && c.path === '/auth/token/redeem');
+    expect(poll?.options?.headers?.Authorization).toBe('Bearer AUTH-TKN');
+    expect(redeem?.options?.headers?.Authorization).toBe('Bearer AUTH-TKN');
+    // Redeem carries no body (spec: redeem is body-less).
+    expect(redeem?.body).toBeUndefined();
+  });
+
+  it('should throw KsefAuthenticationException when the reference reports a terminal failure code', async () => {
     const http = new FakeKsefHttpClient();
     http
       .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
-      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: 'REF-2' }))
-      .seed('GET', '/auth/REF-2', ok({ status: 'failed' }));
+      .seed('POST', '/auth/ksef-token', ok(initResult('REF-2')))
+      .seed('GET', '/auth/REF-2', ok(status(450)));
 
     const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
     await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
@@ -81,11 +139,11 @@ describe('KsefAuthHandshakeService', () => {
     await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
   });
 
-  it('should throw when the submit returns no referenceNumber', async () => {
+  it('should throw when the submit returns no referenceNumber / authenticationToken', async () => {
     const http = new FakeKsefHttpClient();
     http
       .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
-      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: '' }));
+      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: '', authenticationToken: { token: '', validUntil: '' } }));
     const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
     await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
   });
@@ -94,48 +152,44 @@ describe('KsefAuthHandshakeService', () => {
     const http = new FakeKsefHttpClient();
     http
       .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
-      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: 'REF-3' }))
-      .seed('GET', '/auth/REF-3', ok({ status: 'completed' }))
+      .seed('POST', '/auth/ksef-token', ok(initResult('REF-3')))
+      .seed('GET', '/auth/REF-3', ok(status(200)))
       .seed('POST', '/auth/token/redeem', ok({}));
     const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
     await expect(service.authenticate(MATERIAL)).rejects.toBeInstanceOf(KsefAuthenticationException);
   });
 
-  it('should encrypt the token bound to the challenge timestamp before submitting', async () => {
+  it('should build the init request bound to the challenge + timestamp before submitting', async () => {
     const http = new FakeKsefHttpClient();
     const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
     http
-      .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'TS-42' }))
-      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: 'REF-4' }))
-      .seed('GET', '/auth/REF-4', ok({ status: 'completed' }))
-      .seed('POST', '/auth/token/redeem', ok({ accessToken: jwt(expSeconds), refreshToken: jwt(expSeconds) }));
+      .seed('POST', '/auth/challenge', ok({ challenge: 'CH-9', timestamp: 'TS-42' }))
+      .seed('POST', '/auth/ksef-token', ok(initResult('REF-4')))
+      .seed('GET', '/auth/REF-4', ok(status(200)))
+      .seed('POST', '/auth/token/redeem', ok(tokens(expSeconds)));
 
     const encryptor = encryptorStub();
-    const spy = jest.spyOn(encryptor, 'encryptToken');
+    const spy = jest.spyOn(encryptor, 'buildInitRequest');
     const service = new KsefAuthHandshakeService('conn-1', http, encryptor);
     await service.authenticate(MATERIAL);
 
-    // token | contextNip | challengeTimestamp — the timestamp binds the
-    // ciphertext to this challenge window (replay defence).
-    expect(spy).toHaveBeenCalledWith('TKN', '1234567890', 'TS-42');
+    // token, contextNip, challenge, challengeTimestamp — the challenge + timestamp
+    // bind the ciphertext to this challenge window (replay defence).
+    expect(spy).toHaveBeenCalledWith('TKN', '1234567890', 'CH-9', 'TS-42');
   });
 
-  it('should poll through a processing status before completing', async () => {
+  it('should treat status code 200 as ready and redeem', async () => {
     const http = new FakeKsefHttpClient();
     const expSeconds = Math.floor((Date.now() + 3_600_000) / 1000);
-    // The fake replays the same seeded response per key; seed the poll to report
-    // completed so the loop resolves on the first poll. (A multi-status poll is
-    // exercised by the int-spec against the live endpoint.)
     http
       .seed('POST', '/auth/challenge', ok({ challenge: 'CH', timestamp: 'ts' }))
-      .seed('POST', '/auth/ksef-token', ok({ referenceNumber: 'REF-5' }))
-      .seed('GET', '/auth/REF-5', ok({ status: 'completed' }))
-      .seed('POST', '/auth/token/redeem', ok({ accessToken: jwt(expSeconds), refreshToken: jwt(expSeconds) }));
+      .seed('POST', '/auth/ksef-token', ok(initResult('REF-5')))
+      .seed('GET', '/auth/REF-5', ok(status(200)))
+      .seed('POST', '/auth/token/redeem', ok(tokens(expSeconds)));
 
     const service = new KsefAuthHandshakeService('conn-1', http, encryptorStub());
     const result = await service.authenticate(MATERIAL);
     expect(result.refreshToken).toContain('.');
-    // The poll endpoint was hit, then redeem.
     expect(http.calls.some((c) => c.method === 'GET' && c.path === '/auth/REF-5')).toBe(true);
     expect(http.calls.some((c) => c.method === 'POST' && c.path === '/auth/token/redeem')).toBe(true);
   });

--- a/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-auth-xml-builder.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-auth-xml-builder.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * KSeF auth XML builder specs — envelope shape, escaping, deferred seal.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http/auth
+ */
+import { KsefAuthXmlBuilder } from '../ksef-auth-xml-builder';
+import { KsefConfigException } from '../../../../domain/exceptions/ksef-config.exception';
+
+describe('KsefAuthXmlBuilder', () => {
+  const builder = new KsefAuthXmlBuilder();
+
+  it('should build a well-formed unsigned AuthTokenRequest envelope', () => {
+    const xml = builder.buildAuthTokenRequest({
+      challenge: 'CH',
+      contextNip: '1234567890',
+      timestamp: '2026-06-23T12:00:00Z',
+    });
+    expect(xml).toContain('<AuthTokenRequest>');
+    expect(xml).toContain('<Challenge>CH</Challenge>');
+    expect(xml).toContain('<ContextNip>1234567890</ContextNip>');
+    expect(xml).toContain('<Timestamp>2026-06-23T12:00:00Z</Timestamp>');
+  });
+
+  it('should escape XML-significant characters in interpolated values', () => {
+    const xml = builder.buildAuthTokenRequest({
+      challenge: 'a&b<c>"d\'',
+      contextNip: '1',
+      timestamp: 't',
+    });
+    expect(xml).toContain('a&amp;b&lt;c&gt;&quot;d&apos;');
+    expect(xml).not.toMatch(/<Challenge>a&b/);
+  });
+
+  it('should throw for the deferred qualified-seal signing path', () => {
+    expect(() => builder.signXades('<AuthTokenRequest/>')).toThrow(KsefConfigException);
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-jwt-parser.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-jwt-parser.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * KSeF JWT expiry parser specs — happy path + malformed-token handling.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http/auth
+ */
+import { parseJwtExpiry } from '../ksef-jwt-parser';
+import { KsefAuthenticationException } from '../../../../domain/exceptions/ksef-authentication.exception';
+
+function jwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.`;
+}
+
+describe('parseJwtExpiry', () => {
+  it('should extract exp as a Date', () => {
+    const expSeconds = Math.floor(new Date('2026-06-23T12:00:00Z').getTime() / 1000);
+    expect(parseJwtExpiry(jwt({ exp: expSeconds })).getTime()).toBe(expSeconds * 1000);
+  });
+
+  it('should throw for a token without 3 segments', () => {
+    expect(() => parseJwtExpiry('a.b')).toThrow(KsefAuthenticationException);
+  });
+
+  it('should throw for an undecodable payload', () => {
+    expect(() => parseJwtExpiry('aaa.!!!!.ccc')).toThrow(KsefAuthenticationException);
+  });
+
+  it('should throw when exp is missing', () => {
+    expect(() => parseJwtExpiry(jwt({ sub: 'x' }))).toThrow(KsefAuthenticationException);
+  });
+
+  it('should not leak the token in the error message', () => {
+    const token = jwt({ sub: 'secret-subject' });
+    try {
+      parseJwtExpiry(token.replace('.', '')); // break segment count
+    } catch (err) {
+      expect((err as Error).message).not.toContain('secret-subject');
+    }
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-token-encryptor.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-token-encryptor.service.spec.ts
@@ -1,5 +1,7 @@
 /**
- * KSeF token encryptor specs — RSA-OAEP wrap of the token|timestamp payload.
+ * KSeF token encryptor specs — RSA-OAEP wrap of the token|timestamp payload +
+ * `InitTokenAuthenticationRequest` assembly (spec shape: challenge,
+ * contextIdentifier {type,value}, encryptedToken, publicKeyId?).
  *
  * @module libs/integrations/ksef/src/infrastructure/http/auth
  */
@@ -16,31 +18,48 @@ describe('KsefTokenEncryptor', () => {
 
   const cert: PublicKeyCertificate = {
     certificatePem: publicPem,
-    usage: 'KsefTokenEncryption',
+    usage: ['KsefTokenEncryption'],
     validFrom: new Date('2026-01-01T00:00:00Z'),
-    validUntil: new Date('2027-01-01T00:00:00Z'),
+    validTo: new Date('2027-01-01T00:00:00Z'),
+    publicKeyId: 'PKID-' + 'x'.repeat(39),
     certificateHash: createHash('sha256').update(publicPem).digest('hex'),
   };
 
-  it('should produce a base64 ciphertext that unwraps to token|timestamp', async () => {
+  it('should produce an init request whose ciphertext unwraps to token|timestamp', async () => {
     const fetchSpy = jest.fn().mockResolvedValue(cert);
     const cache = { fetchAndCachePublicKey: fetchSpy } as unknown as MfPublicKeyCacheService;
     const encryptor = new KsefTokenEncryptor(cache);
 
-    const result = await encryptor.encryptToken('TKN-123', '1234567890', '2026-06-23T12:00:00Z');
+    const result = await encryptor.buildInitRequest(
+      'TKN-123',
+      '1234567890',
+      'CH-NONCE',
+      '2026-06-23T12:00:00Z',
+    );
 
     expect(fetchSpy).toHaveBeenCalledWith('KsefTokenEncryption');
-    expect(result.contextNip).toBe('1234567890');
+    expect(result.challenge).toBe('CH-NONCE');
+    expect(result.contextIdentifier).toEqual({ type: 'Nip', value: '1234567890' });
+    expect(result.publicKeyId).toBe(cert.publicKeyId);
     const wrapped = new Uint8Array(Buffer.from(result.encryptedToken, 'base64'));
     const recovered = Buffer.from(unwrapKeyWithRsa(wrapped, privatePem)).toString('utf8');
     expect(recovered).toBe('TKN-123|2026-06-23T12:00:00Z');
+  });
+
+  it('should omit publicKeyId when the cert carries none', async () => {
+    const certNoId: PublicKeyCertificate = { ...cert, publicKeyId: undefined };
+    const cache = {
+      fetchAndCachePublicKey: jest.fn().mockResolvedValue(certNoId),
+    } as unknown as MfPublicKeyCacheService;
+    const result = await new KsefTokenEncryptor(cache).buildInitRequest('T', '111', 'CH', 'ts');
+    expect(result.publicKeyId).toBeUndefined();
   });
 
   it('should never echo the plaintext token in the result', async () => {
     const cache = {
       fetchAndCachePublicKey: jest.fn().mockResolvedValue(cert),
     } as unknown as MfPublicKeyCacheService;
-    const result = await new KsefTokenEncryptor(cache).encryptToken('SECRET', '111', 'ts');
+    const result = await new KsefTokenEncryptor(cache).buildInitRequest('SECRET', '111', 'CH', 'ts');
     expect(JSON.stringify(result)).not.toContain('SECRET');
   });
 });

--- a/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-token-encryptor.service.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-token-encryptor.service.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * KSeF token encryptor specs — RSA-OAEP wrap of the token|timestamp payload.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http/auth
+ */
+import { createHash, generateKeyPairSync } from 'crypto';
+import { KsefTokenEncryptor } from '../ksef-token-encryptor.service';
+import type { MfPublicKeyCacheService } from '../../../crypto/mf-public-key-cache.service';
+import { unwrapKeyWithRsa } from '../../../crypto/rsa-key-wrapper';
+import type { PublicKeyCertificate } from '../../ksef-crypto.types';
+
+describe('KsefTokenEncryptor', () => {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const publicPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+  const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+  const cert: PublicKeyCertificate = {
+    certificatePem: publicPem,
+    usage: 'KsefTokenEncryption',
+    validFrom: new Date('2026-01-01T00:00:00Z'),
+    validUntil: new Date('2027-01-01T00:00:00Z'),
+    certificateHash: createHash('sha256').update(publicPem).digest('hex'),
+  };
+
+  it('should produce a base64 ciphertext that unwraps to token|timestamp', async () => {
+    const fetchSpy = jest.fn().mockResolvedValue(cert);
+    const cache = { fetchAndCachePublicKey: fetchSpy } as unknown as MfPublicKeyCacheService;
+    const encryptor = new KsefTokenEncryptor(cache);
+
+    const result = await encryptor.encryptToken('TKN-123', '1234567890', '2026-06-23T12:00:00Z');
+
+    expect(fetchSpy).toHaveBeenCalledWith('KsefTokenEncryption');
+    expect(result.contextNip).toBe('1234567890');
+    const wrapped = new Uint8Array(Buffer.from(result.encryptedToken, 'base64'));
+    const recovered = Buffer.from(unwrapKeyWithRsa(wrapped, privatePem)).toString('utf8');
+    expect(recovered).toBe('TKN-123|2026-06-23T12:00:00Z');
+  });
+
+  it('should never echo the plaintext token in the result', async () => {
+    const cache = {
+      fetchAndCachePublicKey: jest.fn().mockResolvedValue(cert),
+    } as unknown as MfPublicKeyCacheService;
+    const result = await new KsefTokenEncryptor(cache).encryptToken('SECRET', '111', 'ts');
+    expect(JSON.stringify(result)).not.toContain('SECRET');
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-xades-signing.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/__tests__/ksef-xades-signing.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * XAdES signing specs — the qualified-seal path with a generated self-signed
+ * test cert.
+ *
+ * Two concerns are asserted here:
+ *  1. The PRODUCTION `KsefAuthXmlBuilder.signXades` stays a loud deferred stub
+ *     (qualified-seal signing lands in C4 with real X.509/HSM material).
+ *  2. The TEST-only `signXadesForTest` fixture produces a verifiable enveloped
+ *     signature over the unsigned AuthTokenRequest envelope using a generated
+ *     RSA-2048 self-signed key pair — giving C4 a known-good reference shape and
+ *     a round-trip (sign → verify) guarantee for the crypto, without shipping
+ *     the deferred production signer.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http/auth
+ */
+import { KsefAuthXmlBuilder } from '../ksef-auth-xml-builder';
+import { KsefConfigException } from '../../../../domain/exceptions/ksef-config.exception';
+import {
+  generateTestSigningMaterial,
+  signXadesForTest,
+  verifyXadesForTest,
+  type TestSigningMaterial,
+} from '../../../../testing/test-xades-signer';
+
+describe('XAdES signing', () => {
+  const builder = new KsefAuthXmlBuilder();
+  let material: TestSigningMaterial;
+  let unsignedXml: string;
+
+  beforeAll(() => {
+    material = generateTestSigningMaterial();
+    unsignedXml = builder.buildAuthTokenRequest({
+      challenge: 'CH-xades',
+      contextNip: '1234567890',
+      timestamp: '2026-06-23T12:00:00Z',
+    });
+  });
+
+  describe('production signXades (deferred to C4)', () => {
+    it('should throw KsefConfigException — the real qualified-seal path is not implemented', () => {
+      expect(() => builder.signXades(unsignedXml)).toThrow(KsefConfigException);
+    });
+  });
+
+  describe('test-only XAdES signer with a generated self-signed cert', () => {
+    it('should sign the unsigned envelope and embed the signature + X.509 cert', () => {
+      const signed = signXadesForTest(unsignedXml, material);
+
+      // The inner unsigned envelope is preserved verbatim (enveloped signature).
+      expect(signed).toContain('<AuthTokenRequest>');
+      expect(signed).toContain('<Challenge>CH-xades</Challenge>');
+      // The signature block + signer cert are embedded.
+      expect(signed).toContain('<ds:SignatureValue>');
+      expect(signed).toContain('<ds:X509Certificate>');
+      expect(signed).toContain(material.certificateB64);
+      expect(signed).toContain('rsa-sha256');
+    });
+
+    it('should produce a signature that verifies against the signer cert public key', () => {
+      const signed = signXadesForTest(unsignedXml, material);
+      expect(verifyXadesForTest(signed, unsignedXml, material)).toBe(true);
+    });
+
+    it('should fail verification when the signed envelope content is tampered', () => {
+      const signed = signXadesForTest(unsignedXml, material);
+      const tamperedUnsigned = unsignedXml.replace('1234567890', '9999999999');
+      // Recomputing the digest over different content must not match the
+      // signature minted over the original envelope.
+      expect(verifyXadesForTest(signed, tamperedUnsigned, material)).toBe(false);
+    });
+
+    it('should fail verification under a different key pair (wrong signer)', () => {
+      const signed = signXadesForTest(unsignedXml, material);
+      const otherMaterial = generateTestSigningMaterial();
+      expect(verifyXadesForTest(signed, unsignedXml, otherMaterial)).toBe(false);
+    });
+
+    it('should return false when no SignatureValue is present', () => {
+      expect(verifyXadesForTest('<no-signature/>', unsignedXml, material)).toBe(false);
+    });
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/http/auth/ksef-auth-handshake.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/ksef-auth-handshake.service.ts
@@ -1,0 +1,166 @@
+/**
+ * KSeF Auth Handshake Service
+ *
+ * Runs the KSeF 2.0 authentication handshake and yields the access/refresh JWT
+ * bundle the HTTP client injects + rotates. Sequence (ksef-token flow):
+ *
+ *   1. POST /auth/challenge            → { challenge, timestamp }
+ *   2. encrypt (token|timestamp)       → RSA-OAEP under MF token-enc key
+ *   3. POST /auth/ksef-token           → { referenceNumber }  (async)
+ *   4. poll GET /auth/{referenceNumber} until status=completed (backoff+timeout)
+ *   5. POST /auth/token/redeem         → { accessToken, refreshToken } (JWTs)
+ *   6. parse accessToken `exp`         → cache TTL (never hardcoded)
+ *
+ * The qualified-seal flow (step 2/3 via XAdES + /auth/xades-signature) is
+ * DEFERRED to C4: `authenticate` throws `KsefConfigException` for that authType
+ * so the connection fails loudly until the real X.509/HSM path lands.
+ *
+ * Partial-failure posture: challenge/submit transient (5xx/network) failures are
+ * retried by the HTTP client itself; a poll timeout throws
+ * `KsefAuthenticationException` (the sessionToken/reference is lost — the caller
+ * restarts the handshake). A `429` on any auth endpoint surfaces as the client's
+ * rate-limit retry, then as an auth exception if exhausted.
+ *
+ * SECURITY: never logs the token, challenge, accessToken, or refreshToken.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http/auth
+ */
+import { Logger } from '@openlinker/shared/logging';
+import type { IKsefHttpClient } from '../ksef-http-client.interface';
+import type { KsefAuthenticationToken } from '../ksef-http-client.types';
+import type {
+  AuthChallenge,
+  AuthSubmitResult,
+  AuthTokenRedeem,
+  KsefTokenEncryptionRequest,
+} from '../ksef-auth.types';
+import type { KsefTokenEncryptor } from './ksef-token-encryptor.service';
+import { parseJwtExpiry } from './ksef-jwt-parser';
+import { KsefAuthenticationException } from '../../../domain/exceptions/ksef-authentication.exception';
+
+/** Resolved ksef-token credential material handed in by the factory. */
+export interface KsefTokenAuthMaterial {
+  authType: 'ksef-token';
+  token: string;
+  contextNip: string;
+}
+
+/** Polling parameters for the async session-issuance step. */
+const POLL_MAX_ATTEMPTS = 60;
+const POLL_INITIAL_DELAY_MS = 500;
+const POLL_MAX_DELAY_MS = 5_000;
+const POLL_DEADLINE_MS = 300_000;
+
+export class KsefAuthHandshakeService {
+  private readonly logger = new Logger(KsefAuthHandshakeService.name);
+
+  constructor(
+    private readonly connectionId: string,
+    private readonly httpClient: IKsefHttpClient,
+    private readonly tokenEncryptor: KsefTokenEncryptor,
+  ) {}
+
+  /**
+   * Run the full handshake for the ksef-token flow and return the JWT bundle.
+   */
+  async authenticate(material: KsefTokenAuthMaterial): Promise<KsefAuthenticationToken> {
+    this.logger.log(`KSeF auth handshake started (connection ${this.connectionId})`);
+
+    const challenge = await this.requestChallenge();
+    const encrypted = await this.tokenEncryptor.encryptToken(
+      material.token,
+      material.contextNip,
+      challenge.timestamp,
+    );
+    const submit = await this.submitKsefToken(encrypted);
+    const redeemed = await this.pollForToken(submit.referenceNumber);
+    return this.toAuthenticationToken(redeemed);
+  }
+
+  private async requestChallenge(): Promise<AuthChallenge> {
+    const response = await this.httpClient.post<AuthChallenge>('/auth/challenge', undefined, {
+      idempotent: true,
+    });
+    if (!response.data.challenge || !response.data.timestamp) {
+      throw new KsefAuthenticationException('KSeF /auth/challenge returned an incomplete challenge');
+    }
+    return response.data;
+  }
+
+  private async submitKsefToken(
+    encrypted: KsefTokenEncryptionRequest,
+  ): Promise<AuthSubmitResult> {
+    // Submit is safe to repeat (the server issues a fresh reference each time
+    // from the same challenge), so opt into transient retries.
+    const response = await this.httpClient.post<AuthSubmitResult>(
+      '/auth/ksef-token',
+      { ...encrypted },
+      { idempotent: true },
+    );
+    if (!response.data.referenceNumber) {
+      throw new KsefAuthenticationException('KSeF /auth/ksef-token returned no referenceNumber');
+    }
+    return response.data;
+  }
+
+  /**
+   * Poll the async session-issuance status until completed, with exponential
+   * backoff capped at `POLL_MAX_DELAY_MS` and a hard `POLL_DEADLINE_MS` wall.
+   * `4xx` (other than the still-processing case) propagates from the client.
+   */
+  private async pollForToken(referenceNumber: string): Promise<AuthTokenRedeem> {
+    const deadline = Date.now() + POLL_DEADLINE_MS;
+    let delay = POLL_INITIAL_DELAY_MS;
+
+    for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt++) {
+      if (Date.now() > deadline) {
+        break;
+      }
+      const response = await this.httpClient.get<AuthTokenRedeem>(
+        `/auth/${encodeURIComponent(referenceNumber)}`,
+      );
+      const { status } = response.data;
+      if (status === 'completed') {
+        return this.redeem(referenceNumber);
+      }
+      if (status === 'failed') {
+        throw new KsefAuthenticationException(
+          `KSeF auth reference ${referenceNumber} reported failed status`,
+        );
+      }
+      this.logger.debug(
+        `KSeF auth poll attempt ${attempt + 1}: still processing (connection ${this.connectionId})`,
+      );
+      await this.sleep(delay);
+      delay = Math.min(delay * 2, POLL_MAX_DELAY_MS);
+    }
+
+    throw new KsefAuthenticationException(
+      `KSeF auth handshake timed out after ${POLL_DEADLINE_MS}ms (connection ${this.connectionId})`,
+    );
+  }
+
+  private async redeem(referenceNumber: string): Promise<AuthTokenRedeem> {
+    const response = await this.httpClient.post<AuthTokenRedeem>(
+      '/auth/token/redeem',
+      { referenceNumber },
+      { idempotent: true },
+    );
+    return response.data;
+  }
+
+  private toAuthenticationToken(redeemed: AuthTokenRedeem): KsefAuthenticationToken {
+    if (!redeemed.accessToken || !redeemed.refreshToken) {
+      throw new KsefAuthenticationException('KSeF redeem returned no access/refresh token');
+    }
+    return {
+      accessToken: redeemed.accessToken,
+      refreshToken: redeemed.refreshToken,
+      accessTokenExpiresAt: parseJwtExpiry(redeemed.accessToken),
+    };
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/libs/integrations/ksef/src/infrastructure/http/auth/ksef-auth-handshake.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/ksef-auth-handshake.service.ts
@@ -5,8 +5,9 @@
  * bundle the HTTP client injects + rotates. Sequence (ksef-token flow), all
  * reconciled to the authoritative spec:
  *
- *   1. POST /auth/challenge            → { challenge, timestamp }
- *   2. encrypt (token|timestamp)       → RSA-OAEP under MF token-enc key;
+ *   1. POST /auth/challenge            → { challenge, timestamp, timestampMs? }
+ *   2. encrypt (token|timestampMs)     → RSA-OAEP under MF token-enc key
+ *      (timestamp as epoch ms — MF reference uses ToUnixTimeMilliseconds());
  *      build InitTokenAuthenticationRequest { challenge, contextIdentifier,
  *      encryptedToken, publicKeyId? }
  *   3. POST /auth/ksef-token           → { referenceNumber, authenticationToken }
@@ -54,8 +55,13 @@ export interface KsefTokenAuthMaterial {
   contextNip: string;
 }
 
-/** Polling parameters for the async session-issuance step. */
-const POLL_MAX_ATTEMPTS = 60;
+/**
+ * Polling parameters for the async session-issuance step. The wall-clock
+ * `POLL_DEADLINE_MS` is the binding limit; `POLL_MAX_ATTEMPTS` is only a runaway
+ * safety cap. At capped 5s backoff a 300s deadline is ~60 polls, so 200 leaves
+ * generous headroom while still bounding a pathological zero-delay loop.
+ */
+const POLL_MAX_ATTEMPTS = 200;
 const POLL_INITIAL_DELAY_MS = 500;
 const POLL_MAX_DELAY_MS = 5_000;
 const POLL_DEADLINE_MS = 300_000;
@@ -76,11 +82,17 @@ export class KsefAuthHandshakeService {
     this.logger.log(`KSeF auth handshake started (connection ${this.connectionId})`);
 
     const challenge = await this.requestChallenge();
+    const tsMs = challenge.timestampMs ?? Date.parse(challenge.timestamp);
+    if (!Number.isFinite(tsMs)) {
+      throw new KsefAuthenticationException(
+        `KSeF /auth/challenge returned an unparseable timestamp (${challenge.timestamp})`,
+      );
+    }
     const initRequest = await this.tokenEncryptor.buildInitRequest(
       material.token,
       material.contextNip,
       challenge.challenge,
-      challenge.timestamp,
+      String(tsMs),
     );
     const init = await this.submitKsefToken(initRequest);
     const authToken = init.authenticationToken.token;
@@ -92,6 +104,7 @@ export class KsefAuthHandshakeService {
   private async requestChallenge(): Promise<AuthChallenge> {
     const response = await this.httpClient.post<AuthChallenge>('/auth/challenge', undefined, {
       idempotent: true,
+      skipAuth: true,
     });
     if (!response.data.challenge || !response.data.timestamp) {
       throw new KsefAuthenticationException('KSeF /auth/challenge returned an incomplete challenge');
@@ -107,7 +120,7 @@ export class KsefAuthHandshakeService {
     const response = await this.httpClient.post<AuthInitResult>(
       '/auth/ksef-token',
       { ...initRequest },
-      { idempotent: true },
+      { idempotent: true, skipAuth: true },
     );
     if (!response.data.referenceNumber || !response.data.authenticationToken?.token) {
       throw new KsefAuthenticationException(
@@ -119,20 +132,21 @@ export class KsefAuthHandshakeService {
 
   /**
    * Poll the async operation-status endpoint until `status.code === 200`
-   * (success), with exponential backoff capped at `POLL_MAX_DELAY_MS` and a hard
-   * `POLL_DEADLINE_MS` wall. The poll is authenticated with the submit step's
-   * `authenticationToken`. Code `100` is still-in-progress; any other terminal
-   * code throws.
+   * (success), with exponential backoff capped at `POLL_MAX_DELAY_MS`. The
+   * binding limit is the `POLL_DEADLINE_MS` wall clock (`while Date.now() <
+   * deadline`); `POLL_MAX_ATTEMPTS` is only a runaway safety cap. The poll is
+   * authenticated with the submit step's `authenticationToken`. Code `100` is
+   * still-in-progress; any other terminal code throws.
    */
   private async pollUntilReady(referenceNumber: string, authToken: string): Promise<void> {
     const deadline = Date.now() + POLL_DEADLINE_MS;
     let delay = POLL_INITIAL_DELAY_MS;
-    const auth = { headers: { Authorization: `Bearer ${authToken}` } };
+    // The poll carries the short-lived authentication token explicitly, so skip
+    // the client's lazy handshake + access-token injection.
+    const auth = { headers: { Authorization: `Bearer ${authToken}` }, skipAuth: true };
 
-    for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt++) {
-      if (Date.now() > deadline) {
-        break;
-      }
+    let attempt = 0;
+    while (Date.now() < deadline && attempt < POLL_MAX_ATTEMPTS) {
       const response = await this.httpClient.get<AuthOperationStatus>(
         `/auth/${encodeURIComponent(referenceNumber)}`,
         auth,
@@ -151,6 +165,7 @@ export class KsefAuthHandshakeService {
       );
       await this.sleep(delay);
       delay = Math.min(delay * 2, POLL_MAX_DELAY_MS);
+      attempt++;
     }
 
     throw new KsefAuthenticationException(
@@ -163,6 +178,7 @@ export class KsefAuthHandshakeService {
     // authenticationToken as Bearer.
     const response = await this.httpClient.post<AuthTokensResult>('/auth/token/redeem', undefined, {
       idempotent: true,
+      skipAuth: true,
       headers: { Authorization: `Bearer ${authToken}` },
     });
     return response.data;

--- a/libs/integrations/ksef/src/infrastructure/http/auth/ksef-auth-handshake.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/ksef-auth-handshake.service.ts
@@ -2,14 +2,20 @@
  * KSeF Auth Handshake Service
  *
  * Runs the KSeF 2.0 authentication handshake and yields the access/refresh JWT
- * bundle the HTTP client injects + rotates. Sequence (ksef-token flow):
+ * bundle the HTTP client injects + rotates. Sequence (ksef-token flow), all
+ * reconciled to the authoritative spec:
  *
  *   1. POST /auth/challenge            → { challenge, timestamp }
- *   2. encrypt (token|timestamp)       → RSA-OAEP under MF token-enc key
- *   3. POST /auth/ksef-token           → { referenceNumber }  (async)
- *   4. poll GET /auth/{referenceNumber} until status=completed (backoff+timeout)
- *   5. POST /auth/token/redeem         → { accessToken, refreshToken } (JWTs)
- *   6. parse accessToken `exp`         → cache TTL (never hardcoded)
+ *   2. encrypt (token|timestamp)       → RSA-OAEP under MF token-enc key;
+ *      build InitTokenAuthenticationRequest { challenge, contextIdentifier,
+ *      encryptedToken, publicKeyId? }
+ *   3. POST /auth/ksef-token           → { referenceNumber, authenticationToken }
+ *      (async; authenticationToken is the Bearer for the next two calls)
+ *   4. poll GET /auth/{referenceNumber} (Bearer authenticationToken) until
+ *      status.code === 200 (backoff+timeout)
+ *   5. POST /auth/token/redeem (Bearer authenticationToken, NO body)
+ *      → { accessToken: TokenInfo, refreshToken: TokenInfo }
+ *   6. parse accessToken.token `exp`   → cache TTL (never hardcoded)
  *
  * The qualified-seal flow (step 2/3 via XAdES + /auth/xades-signature) is
  * DEFERRED to C4: `authenticate` throws `KsefConfigException` for that authType
@@ -17,11 +23,12 @@
  *
  * Partial-failure posture: challenge/submit transient (5xx/network) failures are
  * retried by the HTTP client itself; a poll timeout throws
- * `KsefAuthenticationException` (the sessionToken/reference is lost — the caller
- * restarts the handshake). A `429` on any auth endpoint surfaces as the client's
- * rate-limit retry, then as an auth exception if exhausted.
+ * `KsefAuthenticationException` (the reference is lost — the caller restarts the
+ * handshake). A `429` on any auth endpoint surfaces as the client's rate-limit
+ * retry, then as an auth exception if exhausted.
  *
- * SECURITY: never logs the token, challenge, accessToken, or refreshToken.
+ * SECURITY: never logs the token, challenge, authenticationToken, accessToken,
+ * or refreshToken.
  *
  * @module libs/integrations/ksef/src/infrastructure/http/auth
  */
@@ -30,10 +37,12 @@ import type { IKsefHttpClient } from '../ksef-http-client.interface';
 import type { KsefAuthenticationToken } from '../ksef-http-client.types';
 import type {
   AuthChallenge,
-  AuthSubmitResult,
-  AuthTokenRedeem,
-  KsefTokenEncryptionRequest,
+  AuthInitResult,
+  AuthOperationStatus,
+  AuthTokensResult,
+  InitTokenAuthenticationRequest,
 } from '../ksef-auth.types';
+import { KSEF_AUTH_STATUS_IN_PROGRESS, KSEF_AUTH_STATUS_SUCCESS } from '../ksef-auth.types';
 import type { KsefTokenEncryptor } from './ksef-token-encryptor.service';
 import { parseJwtExpiry } from './ksef-jwt-parser';
 import { KsefAuthenticationException } from '../../../domain/exceptions/ksef-authentication.exception';
@@ -67,13 +76,16 @@ export class KsefAuthHandshakeService {
     this.logger.log(`KSeF auth handshake started (connection ${this.connectionId})`);
 
     const challenge = await this.requestChallenge();
-    const encrypted = await this.tokenEncryptor.encryptToken(
+    const initRequest = await this.tokenEncryptor.buildInitRequest(
       material.token,
       material.contextNip,
+      challenge.challenge,
       challenge.timestamp,
     );
-    const submit = await this.submitKsefToken(encrypted);
-    const redeemed = await this.pollForToken(submit.referenceNumber);
+    const init = await this.submitKsefToken(initRequest);
+    const authToken = init.authenticationToken.token;
+    await this.pollUntilReady(init.referenceNumber, authToken);
+    const redeemed = await this.redeem(authToken);
     return this.toAuthenticationToken(redeemed);
   }
 
@@ -88,44 +100,50 @@ export class KsefAuthHandshakeService {
   }
 
   private async submitKsefToken(
-    encrypted: KsefTokenEncryptionRequest,
-  ): Promise<AuthSubmitResult> {
+    initRequest: InitTokenAuthenticationRequest,
+  ): Promise<AuthInitResult> {
     // Submit is safe to repeat (the server issues a fresh reference each time
     // from the same challenge), so opt into transient retries.
-    const response = await this.httpClient.post<AuthSubmitResult>(
+    const response = await this.httpClient.post<AuthInitResult>(
       '/auth/ksef-token',
-      { ...encrypted },
+      { ...initRequest },
       { idempotent: true },
     );
-    if (!response.data.referenceNumber) {
-      throw new KsefAuthenticationException('KSeF /auth/ksef-token returned no referenceNumber');
+    if (!response.data.referenceNumber || !response.data.authenticationToken?.token) {
+      throw new KsefAuthenticationException(
+        'KSeF /auth/ksef-token returned no referenceNumber / authenticationToken',
+      );
     }
     return response.data;
   }
 
   /**
-   * Poll the async session-issuance status until completed, with exponential
-   * backoff capped at `POLL_MAX_DELAY_MS` and a hard `POLL_DEADLINE_MS` wall.
-   * `4xx` (other than the still-processing case) propagates from the client.
+   * Poll the async operation-status endpoint until `status.code === 200`
+   * (success), with exponential backoff capped at `POLL_MAX_DELAY_MS` and a hard
+   * `POLL_DEADLINE_MS` wall. The poll is authenticated with the submit step's
+   * `authenticationToken`. Code `100` is still-in-progress; any other terminal
+   * code throws.
    */
-  private async pollForToken(referenceNumber: string): Promise<AuthTokenRedeem> {
+  private async pollUntilReady(referenceNumber: string, authToken: string): Promise<void> {
     const deadline = Date.now() + POLL_DEADLINE_MS;
     let delay = POLL_INITIAL_DELAY_MS;
+    const auth = { headers: { Authorization: `Bearer ${authToken}` } };
 
     for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt++) {
       if (Date.now() > deadline) {
         break;
       }
-      const response = await this.httpClient.get<AuthTokenRedeem>(
+      const response = await this.httpClient.get<AuthOperationStatus>(
         `/auth/${encodeURIComponent(referenceNumber)}`,
+        auth,
       );
-      const { status } = response.data;
-      if (status === 'completed') {
-        return this.redeem(referenceNumber);
+      const code = response.data.status?.code;
+      if (code === KSEF_AUTH_STATUS_SUCCESS) {
+        return;
       }
-      if (status === 'failed') {
+      if (code !== KSEF_AUTH_STATUS_IN_PROGRESS) {
         throw new KsefAuthenticationException(
-          `KSeF auth reference ${referenceNumber} reported failed status`,
+          `KSeF auth reference ${referenceNumber} reported terminal status code ${code ?? 'unknown'}`,
         );
       }
       this.logger.debug(
@@ -140,23 +158,24 @@ export class KsefAuthHandshakeService {
     );
   }
 
-  private async redeem(referenceNumber: string): Promise<AuthTokenRedeem> {
-    const response = await this.httpClient.post<AuthTokenRedeem>(
-      '/auth/token/redeem',
-      { referenceNumber },
-      { idempotent: true },
-    );
+  private async redeem(authToken: string): Promise<AuthTokensResult> {
+    // Redeem takes NO body and is authenticated with the operation's
+    // authenticationToken as Bearer.
+    const response = await this.httpClient.post<AuthTokensResult>('/auth/token/redeem', undefined, {
+      idempotent: true,
+      headers: { Authorization: `Bearer ${authToken}` },
+    });
     return response.data;
   }
 
-  private toAuthenticationToken(redeemed: AuthTokenRedeem): KsefAuthenticationToken {
-    if (!redeemed.accessToken || !redeemed.refreshToken) {
+  private toAuthenticationToken(redeemed: AuthTokensResult): KsefAuthenticationToken {
+    if (!redeemed.accessToken?.token || !redeemed.refreshToken?.token) {
       throw new KsefAuthenticationException('KSeF redeem returned no access/refresh token');
     }
     return {
-      accessToken: redeemed.accessToken,
-      refreshToken: redeemed.refreshToken,
-      accessTokenExpiresAt: parseJwtExpiry(redeemed.accessToken),
+      accessToken: redeemed.accessToken.token,
+      refreshToken: redeemed.refreshToken.token,
+      accessTokenExpiresAt: parseJwtExpiry(redeemed.accessToken.token),
     };
   }
 

--- a/libs/integrations/ksef/src/infrastructure/http/auth/ksef-auth-xml-builder.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/ksef-auth-xml-builder.ts
@@ -1,0 +1,68 @@
+/**
+ * KSeF Auth Token Request XML Builder
+ *
+ * Builds the AuthTokenRequest XML envelope for the KSeF auth handshake. The
+ * ksef-token flow folds a simple challenge + context NIP + timestamp into the
+ * envelope (no signature); the qualified-seal flow appends an XAdES signature.
+ *
+ * DEFERRED (C4): the qualified-seal / XAdES-DSig path. Hand-rolling XAdES
+ * (SignatureMethod URIs, InclusiveNamespaces, canonicalization, cert chain
+ * ordering) has zero margin for error in a tax-authority context, so `signXades`
+ * is a documented stub that throws in production. C4 will evaluate a vetted XML
+ * signing library + real X.509/HSM material. Unit coverage of the *unsigned*
+ * builder is in scope for C3; the signed path is exercised only via the fake
+ * auth service.
+ *
+ * No external XML dependency: the unsigned envelope is small and fixed-shape, so
+ * we build it by string composition with strict escaping of interpolated values.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http/auth
+ */
+import { KsefConfigException } from '../../../domain/exceptions/ksef-config.exception';
+
+/** Escape the five XML predefined entities so an interpolated value can't break the envelope. */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export interface AuthTokenRequestFields {
+  challenge: string;
+  contextNip: string;
+  timestamp: string;
+}
+
+export class KsefAuthXmlBuilder {
+  /**
+   * Build the unsigned AuthTokenRequest XML envelope. Shared by both flows — the
+   * qualified-seal flow signs the result via `signXades`.
+   */
+  buildAuthTokenRequest(fields: AuthTokenRequestFields): string {
+    return [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<AuthTokenRequest>',
+      `<Challenge>${escapeXml(fields.challenge)}</Challenge>`,
+      `<ContextNip>${escapeXml(fields.contextNip)}</ContextNip>`,
+      `<Timestamp>${escapeXml(fields.timestamp)}</Timestamp>`,
+      '</AuthTokenRequest>',
+    ].join('');
+  }
+
+  /**
+   * Sign an AuthTokenRequest envelope with a qualified seal (XAdES).
+   *
+   * DEFERRED to C4: requires real X.509 material (HSM/PKCS#11) and a vetted XML
+   * signing library. Throws in production so a qualified-seal connection fails
+   * loudly until the real path lands; the fake auth service short-circuits this
+   * for unit coverage.
+   */
+  signXades(_unsignedXml: string): string {
+    throw new KsefConfigException(
+      'Qualified-seal (XAdES) signing is not implemented until C4; use a ksef-token connection',
+    );
+  }
+}

--- a/libs/integrations/ksef/src/infrastructure/http/auth/ksef-jwt-parser.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/ksef-jwt-parser.ts
@@ -1,0 +1,48 @@
+/**
+ * KSeF JWT Expiry Parser
+ *
+ * Pure helper that decodes a KSeF access/refresh JWT and extracts its `exp`
+ * claim as a `Date`. The token lifetime is read from `exp` at runtime — never
+ * hardcoded — so the client's proactive-refresh window tracks the real expiry.
+ *
+ * The JWT signature is intentionally NOT verified. This is safe because: (1) the
+ * token is server-issued and received over TLS; (2) it is never used for
+ * application/security logic — only `exp` is read to compute cache TTL; (3) it
+ * is echoed back to KSeF in the `Authorization` header, where the server
+ * re-validates it. Never trust other JWT claims for security decisions.
+ *
+ * SECURITY: throws only a redacted message on a malformed token — never echoes
+ * the (credential-bearing) token bytes into the error.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http/auth
+ */
+import { KsefAuthenticationException } from '../../../domain/exceptions/ksef-authentication.exception';
+
+/**
+ * Decode the JWT payload and return its `exp` as a `Date`.
+ *
+ * @throws KsefAuthenticationException if the token is not a well-formed JWT or
+ *   has no numeric `exp` claim. The message never includes the token.
+ */
+export function parseJwtExpiry(token: string): Date {
+  const segments = token.split('.');
+  if (segments.length !== 3) {
+    throw new KsefAuthenticationException('KSeF token is not a well-formed JWT (expected 3 segments)');
+  }
+  let payload: unknown;
+  try {
+    const json = Buffer.from(segments[1], 'base64url').toString('utf8');
+    payload = JSON.parse(json);
+  } catch {
+    throw new KsefAuthenticationException('KSeF token payload is not decodable JSON');
+  }
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    typeof (payload as { exp?: unknown }).exp !== 'number'
+  ) {
+    throw new KsefAuthenticationException('KSeF token has no numeric exp claim');
+  }
+  const expSeconds = (payload as { exp: number }).exp;
+  return new Date(expSeconds * 1000);
+}

--- a/libs/integrations/ksef/src/infrastructure/http/auth/ksef-token-encryptor.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/ksef-token-encryptor.service.ts
@@ -4,10 +4,11 @@
  * Encrypts the static authorization token for the ksef-token auth flow and
  * builds the `InitTokenAuthenticationRequest` submit body (`POST
  * /auth/ksef-token`). Fetches the MF `KsefTokenEncryption` public key (cached),
- * composes the `token|timestamp` payload (the challenge timestamp binds the
- * ciphertext to the challenge window and defeats replay), RSA-OAEP/SHA-256-wraps
- * it, and stamps the wrapping cert's `publicKeyId` so MF knows which key to
- * unwrap with.
+ * composes the `token|timestampMs` payload (the challenge timestamp — as epoch
+ * milliseconds, matching the MF reference impl's
+ * `Challenge.Timestamp.ToUnixTimeMilliseconds()` — binds the ciphertext to the
+ * challenge window and defeats replay), RSA-OAEP/SHA-256-wraps it, and stamps
+ * the wrapping cert's `publicKeyId` so MF knows which key to unwrap with.
  *
  * SECURITY: the plaintext token is received as a parameter and never logged or
  * retained; only the base64 ciphertext is returned. The token value never
@@ -26,18 +27,20 @@ export class KsefTokenEncryptor {
   constructor(private readonly publicKeyCache: MfPublicKeyCacheService) {}
 
   /**
-   * Encrypt `token|challengeTimestamp` under the active MF token-encryption key
-   * and assemble the `POST /auth/ksef-token` submit body. The context NIP is
-   * carried as the `Nip`-typed `contextIdentifier`.
+   * Encrypt `token|challengeTimestampMs` under the active MF token-encryption
+   * key and assemble the `POST /auth/ksef-token` submit body. The context NIP is
+   * carried as the `Nip`-typed `contextIdentifier`. `challengeTimestampMs` is the
+   * challenge timestamp expressed as epoch milliseconds (the MF reference impl
+   * uses `Challenge.Timestamp.ToUnixTimeMilliseconds()`).
    */
   async buildInitRequest(
     token: string,
     contextNip: string,
     challenge: string,
-    challengeTimestamp: string,
+    challengeTimestampMs: string,
   ): Promise<InitTokenAuthenticationRequest> {
     const cert = await this.publicKeyCache.fetchAndCachePublicKey('KsefTokenEncryption');
-    const payload = new TextEncoder().encode(`${token}|${challengeTimestamp}`);
+    const payload = new TextEncoder().encode(`${token}|${challengeTimestampMs}`);
     const wrapped = wrapKeyWithRsa(payload, cert.certificatePem);
     this.logger.debug(`Encrypted KSeF token for context (cert ${cert.certificateHash})`);
     return {

--- a/libs/integrations/ksef/src/infrastructure/http/auth/ksef-token-encryptor.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/ksef-token-encryptor.service.ts
@@ -1,10 +1,13 @@
 /**
  * KSeF Token Encryptor
  *
- * Encrypts the static authorization token for the ksef-token auth flow. Fetches
- * the MF `KsefTokenEncryption` public key (cached), composes the `token|timestamp`
- * payload (the challenge timestamp binds the ciphertext to the challenge window
- * and defeats replay), and RSA-OAEP/SHA-256-wraps it.
+ * Encrypts the static authorization token for the ksef-token auth flow and
+ * builds the `InitTokenAuthenticationRequest` submit body (`POST
+ * /auth/ksef-token`). Fetches the MF `KsefTokenEncryption` public key (cached),
+ * composes the `token|timestamp` payload (the challenge timestamp binds the
+ * ciphertext to the challenge window and defeats replay), RSA-OAEP/SHA-256-wraps
+ * it, and stamps the wrapping cert's `publicKeyId` so MF knows which key to
+ * unwrap with.
  *
  * SECURITY: the plaintext token is received as a parameter and never logged or
  * retained; only the base64 ciphertext is returned. The token value never
@@ -13,7 +16,7 @@
  * @module libs/integrations/ksef/src/infrastructure/http/auth
  */
 import { Logger } from '@openlinker/shared/logging';
-import type { KsefTokenEncryptionRequest } from '../ksef-auth.types';
+import type { InitTokenAuthenticationRequest } from '../ksef-auth.types';
 import { wrapKeyWithRsa } from '../../crypto/rsa-key-wrapper';
 import type { MfPublicKeyCacheService } from '../../crypto/mf-public-key-cache.service';
 
@@ -23,22 +26,25 @@ export class KsefTokenEncryptor {
   constructor(private readonly publicKeyCache: MfPublicKeyCacheService) {}
 
   /**
-   * Encrypt `token|challengeTimestamp` under the active MF token-encryption key.
-   * Returns the submit payload for `POST /auth/ksef-token`.
+   * Encrypt `token|challengeTimestamp` under the active MF token-encryption key
+   * and assemble the `POST /auth/ksef-token` submit body. The context NIP is
+   * carried as the `Nip`-typed `contextIdentifier`.
    */
-  async encryptToken(
+  async buildInitRequest(
     token: string,
     contextNip: string,
+    challenge: string,
     challengeTimestamp: string,
-  ): Promise<KsefTokenEncryptionRequest> {
+  ): Promise<InitTokenAuthenticationRequest> {
     const cert = await this.publicKeyCache.fetchAndCachePublicKey('KsefTokenEncryption');
     const payload = new TextEncoder().encode(`${token}|${challengeTimestamp}`);
     const wrapped = wrapKeyWithRsa(payload, cert.certificatePem);
     this.logger.debug(`Encrypted KSeF token for context (cert ${cert.certificateHash})`);
     return {
-      contextNip,
+      challenge,
+      contextIdentifier: { type: 'Nip', value: contextNip },
       encryptedToken: Buffer.from(wrapped).toString('base64'),
-      challengeTimestamp,
+      ...(cert.publicKeyId ? { publicKeyId: cert.publicKeyId } : {}),
     };
   }
 }

--- a/libs/integrations/ksef/src/infrastructure/http/auth/ksef-token-encryptor.service.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/auth/ksef-token-encryptor.service.ts
@@ -1,0 +1,44 @@
+/**
+ * KSeF Token Encryptor
+ *
+ * Encrypts the static authorization token for the ksef-token auth flow. Fetches
+ * the MF `KsefTokenEncryption` public key (cached), composes the `token|timestamp`
+ * payload (the challenge timestamp binds the ciphertext to the challenge window
+ * and defeats replay), and RSA-OAEP/SHA-256-wraps it.
+ *
+ * SECURITY: the plaintext token is received as a parameter and never logged or
+ * retained; only the base64 ciphertext is returned. The token value never
+ * appears in any log line or exception.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http/auth
+ */
+import { Logger } from '@openlinker/shared/logging';
+import type { KsefTokenEncryptionRequest } from '../ksef-auth.types';
+import { wrapKeyWithRsa } from '../../crypto/rsa-key-wrapper';
+import type { MfPublicKeyCacheService } from '../../crypto/mf-public-key-cache.service';
+
+export class KsefTokenEncryptor {
+  private readonly logger = new Logger(KsefTokenEncryptor.name);
+
+  constructor(private readonly publicKeyCache: MfPublicKeyCacheService) {}
+
+  /**
+   * Encrypt `token|challengeTimestamp` under the active MF token-encryption key.
+   * Returns the submit payload for `POST /auth/ksef-token`.
+   */
+  async encryptToken(
+    token: string,
+    contextNip: string,
+    challengeTimestamp: string,
+  ): Promise<KsefTokenEncryptionRequest> {
+    const cert = await this.publicKeyCache.fetchAndCachePublicKey('KsefTokenEncryption');
+    const payload = new TextEncoder().encode(`${token}|${challengeTimestamp}`);
+    const wrapped = wrapKeyWithRsa(payload, cert.certificatePem);
+    this.logger.debug(`Encrypted KSeF token for context (cert ${cert.certificateHash})`);
+    return {
+      contextNip,
+      encryptedToken: Buffer.from(wrapped).toString('base64'),
+      challengeTimestamp,
+    };
+  }
+}

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-auth.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-auth.types.ts
@@ -1,0 +1,88 @@
+/**
+ * KSeF Auth Handshake Types
+ *
+ * Wire shapes for the KSeF 2.0 authentication handshake: challenge issuance,
+ * the ksef-token / qualified-seal submit payloads, the reference-number poll
+ * for the issued session, and the redeem step that yields access/refresh JWTs.
+ * Adapter-internal (ADR-026): NIP, faktura, KSeF status etc. never reach core.
+ *
+ * Endpoint shapes here are inferred from the documented KSeF 2.0 sequence; live
+ * validation lands when the client is exercised against the test endpoint (C3
+ * acceptance criterion). Where the spec is ambiguous the field is optional and
+ * the handshake degrades safely.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+
+/**
+ * Response from `POST /auth/challenge`. `challenge` is the base64 nonce the
+ * client signs/encrypts; `timestamp` (server clock, ISO-8601) is folded into
+ * the encrypted token payload to bind the request to this challenge window.
+ */
+export interface AuthChallenge {
+  challenge: string;
+  timestamp: string;
+}
+
+/**
+ * Submit payload for the ksef-token flow (`POST /auth/ksef-token`): the
+ * RSA-OAEP-encrypted (token | timestamp) blob, base64-encoded, plus the NIP
+ * (context identifier) the token authenticates.
+ *
+ * SECURITY: `encryptedToken` is ciphertext, never the plaintext token — but it
+ * is still credential-derived material and MUST NOT be logged.
+ */
+export interface KsefTokenEncryptionRequest {
+  contextNip: string;
+  encryptedToken: string;
+  /** Echo of the challenge timestamp folded into the encrypted payload. */
+  challengeTimestamp: string;
+}
+
+/**
+ * Submit payload for the qualified-seal flow (`POST /auth/xades-signature`):
+ * the XAdES-signed AuthTokenRequest XML envelope. DEFERRED: real X.509 / HSM
+ * signing lands in C4; C3 ships only the unit-coverable builder shape.
+ */
+export interface QualifiedSealAuthRequest {
+  signedXml: string;
+}
+
+/**
+ * Response from a submit step (`/auth/ksef-token` or `/auth/xades-signature`).
+ * KSeF issues the session asynchronously: the submit returns a
+ * `referenceNumber` the client polls, not the final tokens.
+ */
+export interface AuthSubmitResult {
+  referenceNumber: string;
+}
+
+/**
+ * Status of an in-flight auth reference returned by the poll
+ * (`GET /auth/{referenceNumber}`). `accessToken`/`refreshToken` are present
+ * only once `status === 'completed'`.
+ */
+export const AuthRedeemStatusValues = ['processing', 'completed', 'failed'] as const;
+export type AuthRedeemStatus = (typeof AuthRedeemStatusValues)[number];
+
+/**
+ * Poll/redeem response (`GET /auth/{referenceNumber}` then
+ * `POST /auth/token/redeem`). Carries the issued JWTs once ready.
+ *
+ * SECURITY: token fields must never be logged.
+ */
+export interface AuthTokenRedeem {
+  status: AuthRedeemStatus;
+  accessToken?: string;
+  refreshToken?: string;
+}
+
+/**
+ * Refresh request/response (`POST /auth/token/refresh`). The refresh token is
+ * sent in the body (NOT as a bearer header); the response carries a rotated
+ * access token (and possibly a rotated refresh token).
+ */
+export interface AuthTokenRefreshResult {
+  accessToken: string;
+  refreshToken?: string;
+}

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-auth.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-auth.types.ts
@@ -2,41 +2,66 @@
  * KSeF Auth Handshake Types
  *
  * Wire shapes for the KSeF 2.0 authentication handshake: challenge issuance,
- * the ksef-token / qualified-seal submit payloads, the reference-number poll
- * for the issued session, and the redeem step that yields access/refresh JWTs.
+ * the ksef-token / xades submit payloads, the reference-number poll for the
+ * issued session, and the redeem step that yields access/refresh JWTs.
  * Adapter-internal (ADR-026): NIP, faktura, KSeF status etc. never reach core.
  *
- * Endpoint shapes here are inferred from the documented KSeF 2.0 sequence; live
- * validation lands when the client is exercised against the test endpoint (C3
- * acceptance criterion). Where the spec is ambiguous the field is optional and
- * the handshake degrades safely.
+ * Shapes here are reconciled to the AUTHORITATIVE KSeF 2.0 OpenAPI spec
+ * (api-test, v2.6.1) — see `AuthenticationChallengeResponse`,
+ * `InitTokenAuthenticationRequest`, `AuthenticationInitResponse`,
+ * `AuthenticationOperationStatusResponse`, `AuthenticationTokensResponse`,
+ * `AuthenticationTokenRefreshResponse`.
  *
  * @module libs/integrations/ksef/src/infrastructure/http
  */
 
 /**
- * Response from `POST /auth/challenge`. `challenge` is the base64 nonce the
- * client signs/encrypts; `timestamp` (server clock, ISO-8601) is folded into
- * the encrypted token payload to bind the request to this challenge window.
+ * Response from `POST /auth/challenge` (`AuthenticationChallengeResponse`).
+ * `challenge` is the 36-char nonce folded into the encrypted token payload;
+ * `timestamp` (server clock, ISO-8601) binds the request to the challenge
+ * window. `timestampMs` / `clientIp` are returned by the server but unused by
+ * the handshake.
  */
 export interface AuthChallenge {
   challenge: string;
   timestamp: string;
+  timestampMs?: number;
+  clientIp?: string;
 }
 
 /**
- * Submit payload for the ksef-token flow (`POST /auth/ksef-token`): the
- * RSA-OAEP-encrypted (token | timestamp) blob, base64-encoded, plus the NIP
- * (context identifier) the token authenticates.
+ * Context-identifier types KSeF accepts (`AuthenticationContextIdentifierType`).
+ * The OL ksef-token flow always authenticates against a NIP.
+ */
+export const KsefContextIdentifierTypeValues = [
+  'Nip',
+  'InternalId',
+  'NipVatUe',
+  'PeppolId',
+] as const;
+export type KsefContextIdentifierType = (typeof KsefContextIdentifierTypeValues)[number];
+
+/** The context the token authenticates (`AuthenticationContextIdentifier`). */
+export interface KsefContextIdentifier {
+  type: KsefContextIdentifierType;
+  value: string;
+}
+
+/**
+ * Submit body for the ksef-token flow (`POST /auth/ksef-token`,
+ * `InitTokenAuthenticationRequest`): the previously-issued `challenge`, the
+ * `contextIdentifier` the token authenticates, and the RSA-OAEP(SHA-256)
+ * -encrypted `token|timestamp` blob, base64-encoded. `publicKeyId` optionally
+ * identifies the MF cert used to encrypt the token (44 chars).
  *
  * SECURITY: `encryptedToken` is ciphertext, never the plaintext token — but it
  * is still credential-derived material and MUST NOT be logged.
  */
-export interface KsefTokenEncryptionRequest {
-  contextNip: string;
+export interface InitTokenAuthenticationRequest {
+  challenge: string;
+  contextIdentifier: KsefContextIdentifier;
   encryptedToken: string;
-  /** Echo of the challenge timestamp folded into the encrypted payload. */
-  challengeTimestamp: string;
+  publicKeyId?: string;
 }
 
 /**
@@ -49,40 +74,79 @@ export interface QualifiedSealAuthRequest {
 }
 
 /**
- * Response from a submit step (`/auth/ksef-token` or `/auth/xades-signature`).
- * KSeF issues the session asynchronously: the submit returns a
- * `referenceNumber` the client polls, not the final tokens.
+ * Issued JWT/expiry pair (`TokenInfo`). KSeF nests every issued token under
+ * this shape — `token` is the JWT, `validUntil` the server-asserted expiry.
+ *
+ * SECURITY: `token` must never be logged.
  */
-export interface AuthSubmitResult {
-  referenceNumber: string;
+export interface KsefTokenInfo {
+  token: string;
+  validUntil: string;
 }
 
 /**
- * Status of an in-flight auth reference returned by the poll
- * (`GET /auth/{referenceNumber}`). `accessToken`/`refreshToken` are present
- * only once `status === 'completed'`.
+ * Response from a submit step (`POST /auth/ksef-token` or
+ * `/auth/xades-signature`, `AuthenticationInitResponse`). KSeF issues the
+ * session asynchronously: the submit returns the `referenceNumber` to poll plus
+ * a short-lived `authenticationToken` (the Bearer used to authenticate the poll
+ * and the redeem call), NOT the final access/refresh tokens.
+ *
+ * SECURITY: `authenticationToken.token` must never be logged.
  */
-export const AuthRedeemStatusValues = ['processing', 'completed', 'failed'] as const;
-export type AuthRedeemStatus = (typeof AuthRedeemStatusValues)[number];
+export interface AuthInitResult {
+  referenceNumber: string;
+  authenticationToken: KsefTokenInfo;
+}
 
 /**
- * Poll/redeem response (`GET /auth/{referenceNumber}` then
- * `POST /auth/token/redeem`). Carries the issued JWTs once ready.
+ * Status-info block (`StatusInfo`) carried by the operation-status poll.
+ * `code` is an int32 processing-status code (100 = in progress, 200 = success;
+ * 4xx = various failures per the spec's status-code table); `description` is
+ * the human-readable text; `details` an optional string list.
+ */
+export interface KsefStatusInfo {
+  code: number;
+  description: string;
+  details?: string[];
+}
+
+/** Processing-status codes used by the auth poll (`StatusInfo.code`). */
+export const KSEF_AUTH_STATUS_IN_PROGRESS = 100;
+export const KSEF_AUTH_STATUS_SUCCESS = 200;
+
+/**
+ * Poll response (`GET /auth/{referenceNumber}`,
+ * `AuthenticationOperationStatusResponse`). `status.code === 200` signals the
+ * session is issued and ready to redeem; `100` is still-in-progress; any other
+ * code is a terminal failure. `isTokenRedeemed` / `refreshTokenValidUntil` are
+ * returned post-redeem.
+ */
+export interface AuthOperationStatus {
+  status: KsefStatusInfo;
+  startDate?: string;
+  isTokenRedeemed?: boolean | null;
+  lastTokenRefreshDate?: string | null;
+  refreshTokenValidUntil?: string | null;
+}
+
+/**
+ * Redeem response (`POST /auth/token/redeem`, `AuthenticationTokensResponse`).
+ * Authenticated with the submit step's `authenticationToken` as Bearer; carries
+ * the final access + refresh JWTs (each a nested `TokenInfo`).
  *
  * SECURITY: token fields must never be logged.
  */
-export interface AuthTokenRedeem {
-  status: AuthRedeemStatus;
-  accessToken?: string;
-  refreshToken?: string;
+export interface AuthTokensResult {
+  accessToken: KsefTokenInfo;
+  refreshToken: KsefTokenInfo;
 }
 
 /**
- * Refresh request/response (`POST /auth/token/refresh`). The refresh token is
- * sent in the body (NOT as a bearer header); the response carries a rotated
- * access token (and possibly a rotated refresh token).
+ * Refresh response (`POST /auth/token/refresh`,
+ * `AuthenticationTokenRefreshResponse`). Authenticated with the refresh token
+ * as Bearer (NOT a body field); carries only a rotated access token. The
+ * refresh token is not re-issued by this call.
  */
 export interface AuthTokenRefreshResult {
-  accessToken: string;
-  refreshToken?: string;
+  accessToken: KsefTokenInfo;
 }

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-crypto.constants.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-crypto.constants.ts
@@ -1,0 +1,41 @@
+/**
+ * KSeF Crypto Constants
+ *
+ * Pins the cryptographic primitives the KSeF 2.0 session/auth crypto layer
+ * uses, in one leaf module so the RSA wrapper, the AES cipher, and the token
+ * encryptor can't drift on padding/hash parameters (a silent server-side
+ * decrypt failure). All values are derived from the KSeF 2.0 specification
+ * (RSA-OAEP with MGF1+SHA-256 for key/token wrapping; AES-256-CBC with PKCS#7
+ * for document encryption) and are validated by round-trip unit tests against
+ * a self-generated key pair until live test vectors land (C4).
+ *
+ * SECURITY: changing any of these silently breaks interop with the MF backend —
+ * a wrapped key the server cannot unwrap is rejected with an opaque 4xx, not a
+ * crypto error. Treat them as a wire contract, not a tunable.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+
+/**
+ * RSA-OAEP hash for both the OAEP digest and the MGF1 mask-generation function.
+ * KSeF mandates SHA-256 (not SHA-1). Node's `crypto.publicEncrypt` defaults
+ * `mgf1HashAlgorithm` to `oaepHash`, so we pass `oaepHash` explicitly and let
+ * MGF1 follow — but we also pin the value here so the intent is documented.
+ */
+export const KSEF_RSA_OAEP_HASH = 'sha256';
+
+/** AES symmetric cipher: 256-bit key, CBC mode, PKCS#7 padding (Node default). */
+export const KSEF_AES_ALGORITHM = 'aes-256-cbc';
+
+/** AES-256 key length in bytes (256 bits). */
+export const KSEF_AES_KEY_BYTES = 32;
+
+/** AES-CBC initialization-vector length in bytes (128-bit block per NIST). */
+export const KSEF_AES_IV_BYTES = 16;
+
+/**
+ * Minimum acceptable RSA modulus size in bits. KSeF MF certificates are
+ * RSA-2048+; anything smaller is rejected as a malformed / downgraded key
+ * before we trust it to wrap a session secret.
+ */
+export const KSEF_RSA_MIN_MODULUS_BITS = 2048;

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-crypto.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-crypto.types.ts
@@ -68,7 +68,8 @@ export interface RsaWrappedKey {
 
 /**
  * AES-256-CBC-encrypted document payload. `iv` accompanies the ciphertext
- * because each session uses its own random IV (CBC IV-reuse is unsafe).
+ * because each document is encrypted under a fresh random IV (the symmetric key
+ * is reused per session, but CBC IV-reuse under the same key is unsafe).
  */
 export interface EncryptedDocument {
   /** Always `aes-256-cbc` (see `KSEF_AES_ALGORITHM`); carried for self-describing payloads. */

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-crypto.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-crypto.types.ts
@@ -1,0 +1,79 @@
+/**
+ * KSeF Session Crypto Types
+ *
+ * Shapes for the KSeF 2.0 session-crypto layer: the ephemeral symmetric key,
+ * the RSA-wrapped key submitted to MF, the encrypted document envelope, and the
+ * MF public-key certificate fetched from `GET /security/public-key-certificates`.
+ * Adapter-internal (ADR-026).
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+
+/**
+ * Intended usage of an MF public-key certificate. KSeF serves distinct certs
+ * for token encryption (auth handshake) vs symmetric-key wrapping (document
+ * session). Selecting the wrong one is a key-confusion risk, so the usage is a
+ * required filter on every fetch.
+ */
+export const KsefCertificateUsageValues = ['KsefTokenEncryption', 'SymmetricKeyEncryption'] as const;
+export type KsefCertificateUsage = (typeof KsefCertificateUsageValues)[number];
+
+/**
+ * An MF public-key certificate with its validity window. `certificatePem` is
+ * the PEM the RSA wrapper loads; `certificateHash` (SHA-256 of the PEM) is
+ * stamped onto wrapped keys so the server can identify which cert was used.
+ */
+export interface PublicKeyCertificate {
+  certificatePem: string;
+  usage: KsefCertificateUsage;
+  validFrom: Date;
+  validUntil: Date;
+  certificateHash: string;
+}
+
+/**
+ * Ephemeral AES-256 symmetric key + IV generated per document-transmission
+ * session via `crypto.randomBytes`. Held in memory only for the session
+ * lifetime; never persisted.
+ *
+ * SECURITY: `key` and `iv` bytes must never be logged.
+ */
+export interface SymmetricKey {
+  key: Uint8Array;
+  iv: Uint8Array;
+}
+
+/**
+ * An AES key wrapped under an MF RSA public key (RSA-OAEP, SHA-256). Submitted
+ * to MF to bootstrap the encrypted session. `certificateHash` identifies the
+ * wrapping cert so the server can unwrap and (on rotation) audit.
+ */
+export interface RsaWrappedKey {
+  wrappedKey: Uint8Array;
+  certificateHash: string;
+}
+
+/**
+ * AES-256-CBC-encrypted document payload. `iv` accompanies the ciphertext
+ * because each session uses its own random IV (CBC IV-reuse is unsafe).
+ */
+export interface EncryptedDocument {
+  /** Always `aes-256-cbc` (see `KSEF_AES_ALGORITHM`); carried for self-describing payloads. */
+  algorithm: 'aes-256-cbc';
+  ciphertext: Uint8Array;
+  iv: Uint8Array;
+}
+
+/**
+ * The full session-crypto context an issuance flow holds while encrypting one
+ * or more documents in a batch. Combines the symmetric key, its RSA-wrapped
+ * form, and an `expiresAt` (min of a self-imposed session TTL and the wrapping
+ * cert's `validUntil`) so the caller can proactively re-initialize before stale.
+ *
+ * SECURITY: `symmetricKey` carries raw key bytes — never log this object.
+ */
+export interface SessionCryptoContext {
+  symmetricKey: SymmetricKey;
+  wrappedKey: RsaWrappedKey;
+  expiresAt: Date;
+}

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-crypto.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-crypto.types.ts
@@ -19,15 +19,24 @@ export const KsefCertificateUsageValues = ['KsefTokenEncryption', 'SymmetricKeyE
 export type KsefCertificateUsage = (typeof KsefCertificateUsageValues)[number];
 
 /**
- * An MF public-key certificate with its validity window. `certificatePem` is
- * the PEM the RSA wrapper loads; `certificateHash` (SHA-256 of the PEM) is
- * stamped onto wrapped keys so the server can identify which cert was used.
+ * An MF public-key certificate with its validity window, reconciled to the spec
+ * `PublicKeyCertificate` shape. The wire response carries `certificate` (DER,
+ * base64), `usage` as an ARRAY of operations, `validFrom`/`validTo`, plus a
+ * `publicKeyId` (44 chars) used as the encryption-key selector and a
+ * `certificateId`.
+ *
+ * `certificatePem` is the PEM the RSA wrapper loads (built from the wire
+ * `certificate` DER). `publicKeyId` is stamped onto the encrypted-symmetric-key
+ * / init-token payloads so MF knows which key to unwrap with; `certificateHash`
+ * (SHA-256 of the PEM) is kept for log-safe identification.
  */
 export interface PublicKeyCertificate {
   certificatePem: string;
-  usage: KsefCertificateUsage;
+  usage: KsefCertificateUsage[];
   validFrom: Date;
-  validUntil: Date;
+  validTo: Date;
+  publicKeyId?: string;
+  certificateId?: string;
   certificateHash: string;
 }
 
@@ -45,11 +54,15 @@ export interface SymmetricKey {
 
 /**
  * An AES key wrapped under an MF RSA public key (RSA-OAEP, SHA-256). Submitted
- * to MF to bootstrap the encrypted session. `certificateHash` identifies the
- * wrapping cert so the server can unwrap and (on rotation) audit.
+ * to MF (as `EncryptionInfo.encryptedSymmetricKey`, base64) to bootstrap the
+ * encrypted session. `publicKeyId` (when the cert carried one) is the spec
+ * selector MF uses to pick the unwrapping key — surfaced as
+ * `EncryptionInfo.publicKeyId` by C5. `certificateHash` is kept for log-safe
+ * identification of the wrapping cert.
  */
 export interface RsaWrappedKey {
   wrappedKey: Uint8Array;
+  publicKeyId?: string;
   certificateHash: string;
 }
 
@@ -68,7 +81,7 @@ export interface EncryptedDocument {
  * The full session-crypto context an issuance flow holds while encrypting one
  * or more documents in a batch. Combines the symmetric key, its RSA-wrapped
  * form, and an `expiresAt` (min of a self-imposed session TTL and the wrapping
- * cert's `validUntil`) so the caller can proactively re-initialize before stale.
+ * cert's `validTo`) so the caller can proactively re-initialize before stale.
  *
  * SECURITY: `symmetricKey` carries raw key bytes — never log this object.
  */

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-hosts.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-hosts.ts
@@ -1,0 +1,31 @@
+/**
+ * KSeF Host Resolution
+ *
+ * Maps a `KsefEnvironment` to its Public API v2 base URL. Centralised so the
+ * client + factory never hand-build the host string. The `/v2` API-version
+ * segment is part of the base path (the adapterKey pins the same major version).
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+import type { KsefEnvironment } from '../../domain/types/ksef-connection.types';
+import { KsefConfigException } from '../../domain/exceptions/ksef-config.exception';
+
+const KSEF_BASE_URLS: Record<KsefEnvironment, string> = {
+  test: 'https://ksef-test.mf.gov.pl/api/v2',
+  demo: 'https://ksef-demo.mf.gov.pl/api/v2',
+  prod: 'https://ksef.mf.gov.pl/api/v2',
+};
+
+/**
+ * Resolve the KSeF base URL for an environment.
+ *
+ * @throws KsefConfigException for an unrecognised environment (a config error
+ *   on a pre-existing connection row, surfaced before any request leaves).
+ */
+export function resolveKsefBaseUrl(env: KsefEnvironment): string {
+  const baseUrl = KSEF_BASE_URLS[env];
+  if (!baseUrl) {
+    throw new KsefConfigException(`Unrecognised KSeF environment: ${String(env)}`);
+  }
+  return baseUrl;
+}

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-hosts.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-hosts.ts
@@ -5,15 +5,20 @@
  * client + factory never hand-build the host string. The `/v2` API-version
  * segment is part of the base path (the adapterKey pins the same major version).
  *
+ * Hosts are the authoritative KSeF API 2.0 bases (per the MF `srodowiska.md`
+ * environments table + the OpenAPI `servers` block): the API lives on the
+ * `api[-env].ksef.mf.gov.pl` host with a bare `/v2` base path — NOT on
+ * `ksef[-env].mf.gov.pl/api/v2`.
+ *
  * @module libs/integrations/ksef/src/infrastructure/http
  */
 import type { KsefEnvironment } from '../../domain/types/ksef-connection.types';
 import { KsefConfigException } from '../../domain/exceptions/ksef-config.exception';
 
 const KSEF_BASE_URLS: Record<KsefEnvironment, string> = {
-  test: 'https://ksef-test.mf.gov.pl/api/v2',
-  demo: 'https://ksef-demo.mf.gov.pl/api/v2',
-  prod: 'https://ksef.mf.gov.pl/api/v2',
+  test: 'https://api-test.ksef.mf.gov.pl/v2',
+  demo: 'https://api-demo.ksef.mf.gov.pl/v2',
+  prod: 'https://api.ksef.mf.gov.pl/v2',
 };
 
 /**

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.factory.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.factory.ts
@@ -1,0 +1,84 @@
+/**
+ * KSeF HTTP Client Factory
+ *
+ * Wires the per-connection KSeF transport graph and breaks the construction
+ * cycle (client → handshake → token-encryptor → public-key-cache → client) at
+ * the factory level using a mutable holder:
+ *
+ *   1. Construct `KsefHttpClient` first with a deferred token lifecycle that
+ *      reads the handshake from a holder. Its unauthenticated endpoints
+ *      (`/auth/*`, `/security/public-key-certificates`) work before any token
+ *      exists, so the cache + handshake can use the client.
+ *   2. Construct `MfPublicKeyCacheService`, `KsefTokenEncryptor`,
+ *      `KsefAuthHandshakeService` — all referencing that same client instance.
+ *   3. Populate the holder with the handshake.
+ *
+ * No service instantiates the client; the client never instantiates a service.
+ * This keeps the graph acyclic at the constructor level (no NestJS forwardRef).
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+import type { CachePort } from '@openlinker/shared/cache';
+import type { KsefEnvironment } from '../../domain/types/ksef-connection.types';
+import type { KsefAuthenticationToken } from './ksef-http-client.types';
+import { KsefHttpClient, type KsefTokenLifecycle } from './ksef-http-client';
+import { resolveKsefBaseUrl } from './ksef-hosts';
+import { MfPublicKeyCacheService } from '../crypto/mf-public-key-cache.service';
+import { KsefTokenEncryptor } from './auth/ksef-token-encryptor.service';
+import {
+  KsefAuthHandshakeService,
+  type KsefTokenAuthMaterial,
+} from './auth/ksef-auth-handshake.service';
+import { KsefConfigException } from '../../domain/exceptions/ksef-config.exception';
+
+export interface CreateKsefHttpClientInput {
+  connectionId: string;
+  env: KsefEnvironment;
+  /** Resolved ksef-token material. Qualified-seal wiring is deferred to C4. */
+  authMaterial: KsefTokenAuthMaterial;
+  cache?: CachePort;
+}
+
+export interface KsefHttpClientBundle {
+  httpClient: KsefHttpClient;
+  publicKeyCache: MfPublicKeyCacheService;
+  handshake: KsefAuthHandshakeService;
+}
+
+/**
+ * Build a fully-wired KSeF HTTP client + the auth/crypto services that share it.
+ */
+export function createKsefHttpClient(input: CreateKsefHttpClientInput): KsefHttpClientBundle {
+  const baseUrl = resolveKsefBaseUrl(input.env);
+
+  // Mutable holder populated in step 3; read lazily by the lifecycle callbacks.
+  const holder: { handshake: KsefAuthHandshakeService | null } = { handshake: null };
+
+  const runHandshake = (): Promise<KsefAuthenticationToken> => {
+    if (!holder.handshake) {
+      throw new KsefConfigException('KSeF auth handshake used before wiring completed');
+    }
+    return holder.handshake.authenticate(input.authMaterial);
+  };
+
+  const lifecycle: KsefTokenLifecycle = {
+    authenticate: () => runHandshake(),
+    // No dedicated refresh endpoint is wired yet (C4); a full re-handshake
+    // rotates the token. Cheap relative to the document flow and keeps the
+    // token-lifecycle contract honest.
+    refresh: () => runHandshake(),
+  };
+
+  // 1. Client first (its unauthenticated endpoints bootstrap the services).
+  const httpClient = new KsefHttpClient(input.connectionId, baseUrl, lifecycle);
+
+  // 2. Services share the one client instance.
+  const publicKeyCache = new MfPublicKeyCacheService(input.connectionId, httpClient, input.cache);
+  const tokenEncryptor = new KsefTokenEncryptor(publicKeyCache);
+  const handshake = new KsefAuthHandshakeService(input.connectionId, httpClient, tokenEncryptor);
+
+  // 3. Close the cycle.
+  holder.handshake = handshake;
+
+  return { httpClient, publicKeyCache, handshake };
+}

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.interface.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.interface.ts
@@ -1,30 +1,56 @@
 /**
  * KSeF HTTP Client Port
  *
- * Narrow transport contract the KSeF capability adapters code against. Keeping
- * it an interface — not a concrete client — lets adapter unit specs mock KSeF
- * HTTP without a real `fetch`, per engineering-standards § "Interface and
- * Implementation Separation".
+ * Transport contract the KSeF capability adapters + auth/crypto services code
+ * against. Keeping it an interface — not a concrete client — lets adapter and
+ * service unit specs mock KSeF HTTP without a real `fetch`, per
+ * engineering-standards § "Interface and Implementation Separation".
  *
- * STUB for C2: the concrete `KsefHttpClient` implementing this contract (auth
- * header injection, retry/backoff, structured logging) lands in C3. Credentials
- * are wired into the client at construction time (resolved via the host's
- * `CredentialsResolverPort` in the factory) — the method signatures here make
- * no credential assumptions, so the transport stays agnostic of the auth mode.
+ * Mirrors the Allegro client surface (#499 precedent): every method returns a
+ * `KsefHttpResponse<T>` carrying status + headers so callers can inspect them
+ * (e.g. the auth poll reads status to distinguish processing/completed), plus a
+ * `postExpectingBinary` for document endpoints (UPO PDFs). The client owns auth
+ * header injection, retry/backoff, rate-limit handling, token refresh, and
+ * structured logging (never credential material).
  *
- * Package-private: consumed only by the in-package `KsefAdapterFactory` (C3+)
- * via relative import; intentionally NOT re-exported from the package barrel
- * (siblings keep their clients private too).
+ * Package-private: consumed only by the in-package factory, auth handshake, and
+ * session-crypto services via relative import; intentionally NOT re-exported
+ * from the package barrel (siblings keep their clients private too).
  *
  * @module libs/integrations/ksef/src/infrastructure/http
  */
+import type {
+  KsefBinaryResponse,
+  KsefHttpRequestOptions,
+  KsefHttpResponse,
+} from './ksef-http-client.types';
+
 export interface IKsefHttpClient {
-  /** GET — idempotent; transient `5xx`/network failures are retried (C3). */
-  get<T>(path: string): Promise<T>;
+  /**
+   * GET — idempotent; transient `5xx`/network failures and `429` (with
+   * `Retry-After` backoff) are retried. `4xx` (other than auth) fails fast.
+   */
+  get<T = unknown>(path: string, options?: KsefHttpRequestOptions): Promise<KsefHttpResponse<T>>;
 
   /**
-   * POST — non-idempotent by default: a `5xx`/network failure fails fast (no
-   * retry) unless the caller opts in. Used for document submission (C3+).
+   * POST — non-idempotent by default: a `5xx`/network failure fails fast unless
+   * the caller sets `options.idempotent` (KSeF session sub-resource reads are
+   * POSTs but safe to repeat). `429` always backs off and retries.
    */
-  post<T>(path: string, body?: unknown): Promise<T>;
+  post<T = unknown>(
+    path: string,
+    body?: Record<string, unknown> | string,
+    options?: KsefHttpRequestOptions,
+  ): Promise<KsefHttpResponse<T>>;
+
+  /**
+   * POST a JSON body but read the SUCCESS response as raw bytes (e.g. a UPO
+   * document). Error responses are still parsed as the JSON KSeF error envelope
+   * through the same error path as every other call.
+   */
+  postExpectingBinary(
+    path: string,
+    body?: Record<string, unknown> | string,
+    options?: KsefHttpRequestOptions,
+  ): Promise<KsefBinaryResponse>;
 }

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.ts
@@ -14,11 +14,14 @@
  *  - Reactive 401: the `refresh` callback is invoked once; a tagged
  *    `RefreshOnUnauthorizedOutcome` distinguishes credential rejection
  *    (→ `KsefAuthenticationException`, non-retryable) from network failure
- *    (→ `KsefNetworkException`, retryable).
- *  - Auth + public-key endpoints are unauthenticated: callers pass
- *    `options.headers` to override, but the client also detects the `/auth/` and
- *    `/security/public-key-certificates` prefixes and skips bearer injection so
- *    the handshake can bootstrap before any token exists.
+ *    (→ `KsefNetworkException`, retryable). `403` is an authorization decision
+ *    — never refreshed — and fails fast as a non-retryable `KsefApiException`.
+ *  - Unauthenticated calls (the auth challenge/ksef-token bootstrap and the
+ *    public-key-certificate fetch) pass `options.skipAuth` so the client skips
+ *    the lazy handshake + bearer injection. Auth calls that carry their own
+ *    short-lived token (poll/redeem/refresh) also set `skipAuth` and supply an
+ *    explicit `Authorization` header. Explicit per-call flag rather than
+ *    path-prefix inference.
  *
  * SECURITY: never logs the access/refresh token, the Authorization header, or
  * request/response bodies that may carry credential-derived material. Logs carry
@@ -53,9 +56,6 @@ const DEFAULT_RETRY_CONFIG: KsefRetryConfig = {
 };
 
 const REQUEST_TIMEOUT_MS = 30_000;
-
-/** Unauthenticated endpoint prefixes — bearer header is skipped (bootstrap). */
-const UNAUTHENTICATED_PREFIXES = ['/auth/', '/security/public-key-certificates'];
 
 /**
  * Lazily runs the handshake (first authenticated request) and rotates the token
@@ -198,7 +198,7 @@ export class KsefHttpClient implements IKsefHttpClient {
   ): Promise<KsefHttpResponse<T>> {
     const traceId = randomUUID();
     const startTime = Date.now();
-    const requiresAuth = !this.isUnauthenticated(path);
+    const requiresAuth = !options?.skipAuth;
 
     if (requiresAuth) {
       await this.ensureFreshToken(traceId);
@@ -293,9 +293,11 @@ export class KsefHttpClient implements IKsefHttpClient {
   }
 
   /**
-   * Map an HTTP failure to the right domain exception. On `401` attempts a
-   * single reactive refresh, then signals a retry (success) / throws auth or
-   * network exception (per the tagged refresh outcome).
+   * Map an HTTP failure to the right domain exception. Only `401` (token
+   * expired/rejected) attempts a single reactive refresh, then signals a retry
+   * (success) / throws auth or network exception (per the tagged refresh
+   * outcome). `403` is an authorization decision — refreshing the token can
+   * never change it — so it fails fast as a non-retryable KsefApiException.
    */
   private async handleError(
     statusCode: number,
@@ -304,7 +306,7 @@ export class KsefHttpClient implements IKsefHttpClient {
     headers: Record<string, string>,
     traceId: string,
   ): Promise<never> {
-    if (statusCode === 401 || statusCode === 403) {
+    if (statusCode === 401) {
       const outcome = await this.refreshOnUnauthorized(traceId);
       if (outcome.ok) {
         throw new TokenRefreshedSignal();
@@ -325,25 +327,41 @@ export class KsefHttpClient implements IKsefHttpClient {
     }
 
     if (statusCode === 429) {
-      const retryAfterMs = headers['retry-after'] ? parseInt(headers['retry-after'], 10) * 1000 : undefined;
-      throw new KsefApiException(`KSeF rate limit exceeded: ${url}`, 429, retryAfterMs ? String(retryAfterMs) : undefined, url);
+      const retryAfterMs = this.parseRetryAfterHeader(headers['retry-after']);
+      throw new KsefApiException(`KSeF rate limit exceeded: ${url}`, 429, body, url, retryAfterMs);
     }
 
-    // 4xx (other than auth) and 5xx: KsefApiException carries diagnostics-only body.
+    // 403 (authorization denied) + other 4xx + 5xx: KsefApiException carries
+    // diagnostics-only body. 403 is non-retryable (the retry loop fails fast on
+    // any sub-500 status that isn't 429).
     this.logger.error(`[${traceId}] KSeF API error (${statusCode}) ${url}`);
     throw new KsefApiException(`KSeF API error (${statusCode}): ${url}`, statusCode, body, url);
   }
 
-  private parseRetryAfter(error: KsefApiException): number | undefined {
-    if (error.statusCode !== 429 || !error.responseBody) {
+  /**
+   * Parse the `Retry-After` header — either delta-seconds (`"120"`) or an
+   * HTTP-date (`"Wed, 21 Oct 2026 07:28:00 GMT"`) — into a millisecond delay.
+   */
+  private parseRetryAfterHeader(headerValue: string | undefined): number | undefined {
+    if (!headerValue) {
       return undefined;
     }
-    const parsed = Number(error.responseBody);
-    return Number.isFinite(parsed) ? parsed : undefined;
+    const seconds = Number(headerValue);
+    if (Number.isFinite(seconds)) {
+      return Math.max(0, seconds * 1000);
+    }
+    const dateMs = Date.parse(headerValue);
+    if (Number.isFinite(dateMs)) {
+      return Math.max(0, dateMs - Date.now());
+    }
+    return undefined;
   }
 
-  private isUnauthenticated(path: string): boolean {
-    return UNAUTHENTICATED_PREFIXES.some((prefix) => path.startsWith(prefix));
+  private parseRetryAfter(error: KsefApiException): number | undefined {
+    if (error.statusCode !== 429) {
+      return undefined;
+    }
+    return error.retryAfterMs;
   }
 
   private getAccessTokenOrThrow(): string {

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.ts
@@ -1,0 +1,406 @@
+/**
+ * KSeF HTTP Client
+ *
+ * Native-`fetch` (Node 18+) HTTP client for the KSeF Public API v2. Hand-rolls
+ * retries, rate-limit backoff, token lifecycle, and structured logging, mirroring
+ * the in-tree `AllegroHttpClient` precedent (no axios / @nestjs/axios).
+ *
+ * Token lifecycle:
+ *  - The access token is produced lazily by the injected `authenticate` callback
+ *    (the auth handshake) on the first authenticated request, then cached with a
+ *    TTL read from the JWT `exp` (never hardcoded).
+ *  - Proactive refresh: within `TOKEN_REFRESH_WINDOW_MS` of expiry, the
+ *    `refresh` callback rotates the token before the request.
+ *  - Reactive 401: the `refresh` callback is invoked once; a tagged
+ *    `RefreshOnUnauthorizedOutcome` distinguishes credential rejection
+ *    (→ `KsefAuthenticationException`, non-retryable) from network failure
+ *    (→ `KsefNetworkException`, retryable).
+ *  - Auth + public-key endpoints are unauthenticated: callers pass
+ *    `options.headers` to override, but the client also detects the `/auth/` and
+ *    `/security/public-key-certificates` prefixes and skips bearer injection so
+ *    the handshake can bootstrap before any token exists.
+ *
+ * SECURITY: never logs the access/refresh token, the Authorization header, or
+ * request/response bodies that may carry credential-derived material. Logs carry
+ * the trace id, method, path, status, and duration only.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ * @implements {IKsefHttpClient}
+ */
+import { randomUUID } from 'crypto';
+import { Logger } from '@openlinker/shared/logging';
+import type { IKsefHttpClient } from './ksef-http-client.interface';
+import type {
+  KsefAuthenticationToken,
+  KsefBinaryResponse,
+  KsefHttpRequestOptions,
+  KsefHttpResponse,
+  KsefRetryConfig,
+  RefreshOnUnauthorizedOutcome,
+} from './ksef-http-client.types';
+import { KsefApiException } from '../../domain/exceptions/ksef-api.exception';
+import { KsefAuthenticationException } from '../../domain/exceptions/ksef-authentication.exception';
+import { KsefNetworkException } from '../../domain/exceptions/ksef-network.exception';
+
+/** Refresh proactively within this window of the access-token expiry. */
+const TOKEN_REFRESH_WINDOW_MS = 60_000;
+
+const DEFAULT_RETRY_CONFIG: KsefRetryConfig = {
+  maxRetries: 3,
+  initialDelayMs: 1_000,
+  maxDelayMs: 30_000,
+  backoffMultiplier: 2,
+};
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+/** Unauthenticated endpoint prefixes — bearer header is skipped (bootstrap). */
+const UNAUTHENTICATED_PREFIXES = ['/auth/', '/security/public-key-certificates'];
+
+/**
+ * Lazily runs the handshake (first authenticated request) and rotates the token
+ * (proactive + reactive). Both callbacks are wired by the factory.
+ */
+export interface KsefTokenLifecycle {
+  /** Run the full auth handshake and return the initial token bundle. */
+  authenticate(traceId: string, logger: Logger): Promise<KsefAuthenticationToken>;
+  /** Rotate the access token (proactive/reactive). */
+  refresh(traceId: string, logger: Logger): Promise<KsefAuthenticationToken>;
+}
+
+/** Internal control-flow signal: token was rotated, retry the request now. */
+class TokenRefreshedSignal extends Error {
+  constructor() {
+    super('KSeF token refreshed; retry request');
+    this.name = 'TokenRefreshedSignal';
+  }
+}
+
+export class KsefHttpClient implements IKsefHttpClient {
+  private readonly logger = new Logger(KsefHttpClient.name);
+  private readonly baseUrl: string;
+  private readonly retryConfig: KsefRetryConfig;
+
+  private token: KsefAuthenticationToken | null = null;
+  private refreshInFlight: Promise<void> | null = null;
+
+  constructor(
+    private readonly connectionId: string,
+    baseUrl: string,
+    private readonly lifecycle: KsefTokenLifecycle,
+    retryConfig?: Partial<KsefRetryConfig>,
+  ) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+  }
+
+  async get<T = unknown>(path: string, options?: KsefHttpRequestOptions): Promise<KsefHttpResponse<T>> {
+    return this.request<T>('GET', path, undefined, options, true);
+  }
+
+  async post<T = unknown>(
+    path: string,
+    body?: Record<string, unknown> | string,
+    options?: KsefHttpRequestOptions,
+  ): Promise<KsefHttpResponse<T>> {
+    return this.request<T>('POST', path, body, options, options?.idempotent ?? false);
+  }
+
+  async postExpectingBinary(
+    path: string,
+    body?: Record<string, unknown> | string,
+    options?: KsefHttpRequestOptions,
+  ): Promise<KsefBinaryResponse> {
+    const response = await this.request<Uint8Array>(
+      'POST',
+      path,
+      body,
+      options,
+      options?.idempotent ?? false,
+      true,
+    );
+    return {
+      data: response.data,
+      contentType: response.headers['content-type'] ?? '',
+      status: response.status,
+      headers: response.headers,
+    };
+  }
+
+  /**
+   * Retry loop. Idempotent calls retry transient failures (5xx/network);
+   * non-idempotent calls fail fast except `429` (always backs off) and the
+   * token-refresh retry.
+   */
+  private async request<T>(
+    method: 'GET' | 'POST',
+    path: string,
+    body: Record<string, unknown> | string | undefined,
+    options: KsefHttpRequestOptions | undefined,
+    idempotent: boolean,
+    expectBinary = false,
+  ): Promise<KsefHttpResponse<T>> {
+    let lastError: Error | null = null;
+    let delay = this.retryConfig.initialDelayMs;
+
+    for (let attempt = 0; attempt <= this.retryConfig.maxRetries; attempt++) {
+      try {
+        return await this.executeRequest<T>(method, path, body, options, expectBinary);
+      } catch (error: unknown) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+
+        if (error instanceof TokenRefreshedSignal) {
+          continue; // Retry immediately with the rotated token.
+        }
+        if (error instanceof KsefAuthenticationException) {
+          throw error; // Credential rejection — never retry.
+        }
+        if (error instanceof KsefApiException) {
+          const status = error.statusCode;
+          if (status === 429) {
+            if (attempt < this.retryConfig.maxRetries) {
+              const retryAfter = this.parseRetryAfter(error) ?? delay;
+              this.logger.warn(`[${this.connectionId}] Rate limited (429); retry in ${retryAfter}ms`);
+              await this.sleep(retryAfter);
+              delay = Math.min(delay * this.retryConfig.backoffMultiplier, this.retryConfig.maxDelayMs);
+              continue;
+            }
+            throw error;
+          }
+          if (status !== undefined && status < 500) {
+            // Deterministic non-5xx — never retry. Covers 4xx and a parse
+            // failure on an otherwise-2xx body (a malformed response won't
+            // become valid on re-fetch); 429 is already handled above.
+            throw error;
+          }
+        }
+        // 5xx / network: retry only when idempotent.
+        if (idempotent && attempt < this.retryConfig.maxRetries) {
+          this.logger.warn(
+            `[${this.connectionId}] Request failed (attempt ${attempt + 1}); retry in ${delay}ms: ${lastError.message}`,
+          );
+          await this.sleep(delay);
+          delay = Math.min(delay * this.retryConfig.backoffMultiplier, this.retryConfig.maxDelayMs);
+          continue;
+        }
+        throw lastError;
+      }
+    }
+    throw lastError ?? new Error('KSeF request failed after retries');
+  }
+
+  private async executeRequest<T>(
+    method: 'GET' | 'POST',
+    path: string,
+    body: Record<string, unknown> | string | undefined,
+    options: KsefHttpRequestOptions | undefined,
+    expectBinary: boolean,
+  ): Promise<KsefHttpResponse<T>> {
+    const traceId = randomUUID();
+    const startTime = Date.now();
+    const requiresAuth = !this.isUnauthenticated(path);
+
+    if (requiresAuth) {
+      await this.ensureFreshToken(traceId);
+    }
+
+    const url = new URL(path.replace(/^\//, ''), `${this.baseUrl}/`);
+    if (options?.queryParams) {
+      for (const [key, value] of Object.entries(options.queryParams)) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+    if (options?.headers) {
+      for (const [key, value] of Object.entries(options.headers)) {
+        headers[key] = value;
+      }
+    }
+    if (requiresAuth) {
+      headers.Authorization = `Bearer ${this.getAccessTokenOrThrow()}`;
+    }
+    headers['X-Trace-Id'] = traceId;
+
+    const requestBody = body === undefined ? undefined : typeof body === 'string' ? body : JSON.stringify(body);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      this.logger.debug(`[${traceId}] ${method} ${url.pathname} (connection ${this.connectionId})`);
+
+      const response = await fetch(url.toString(), {
+        method,
+        headers,
+        body: requestBody,
+        signal: controller.signal,
+      });
+
+      const responseHeaders: Record<string, string> = {};
+      response.headers.forEach((value, key) => {
+        responseHeaders[key.toLowerCase()] = value;
+      });
+
+      const duration = Date.now() - startTime;
+      this.logger.debug(`[${traceId}] ${response.status} (${duration}ms) ${method} ${url.pathname}`);
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        await this.handleError(response.status, errorBody, url.toString(), responseHeaders, traceId);
+      }
+
+      if (expectBinary) {
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        return { data: bytes as unknown as T, status: response.status, headers: responseHeaders };
+      }
+
+      const text = await response.text();
+      let data: T;
+      try {
+        data = text ? (JSON.parse(text) as T) : ({} as T);
+      } catch {
+        throw new KsefApiException(
+          `Invalid JSON response from KSeF API: ${url.toString()}`,
+          response.status,
+          undefined,
+          url.toString(),
+        );
+      }
+      return { data, status: response.status, headers: responseHeaders };
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new KsefNetworkException(`KSeF request timed out after ${REQUEST_TIMEOUT_MS}ms`, url.toString());
+      }
+      if (
+        error instanceof KsefApiException ||
+        error instanceof KsefAuthenticationException ||
+        error instanceof KsefNetworkException ||
+        error instanceof TokenRefreshedSignal
+      ) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new KsefNetworkException(`KSeF network error: ${message}`, url.toString(), {
+        cause: error instanceof Error ? error : undefined,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Map an HTTP failure to the right domain exception. On `401` attempts a
+   * single reactive refresh, then signals a retry (success) / throws auth or
+   * network exception (per the tagged refresh outcome).
+   */
+  private async handleError(
+    statusCode: number,
+    body: string,
+    url: string,
+    headers: Record<string, string>,
+    traceId: string,
+  ): Promise<never> {
+    if (statusCode === 401 || statusCode === 403) {
+      const outcome = await this.refreshOnUnauthorized(traceId);
+      if (outcome.ok) {
+        throw new TokenRefreshedSignal();
+      }
+      if (outcome.reason === 'network-failure') {
+        throw new KsefNetworkException(
+          `KSeF token refresh failed (network): ${outcome.cause?.message ?? 'unknown'}`,
+          url,
+          { cause: outcome.cause },
+        );
+      }
+      this.logger.error(`[${traceId}] KSeF authentication failed (${statusCode})`);
+      throw new KsefAuthenticationException(
+        `KSeF authentication failed (${statusCode}) for ${url}`,
+        statusCode,
+        url,
+      );
+    }
+
+    if (statusCode === 429) {
+      const retryAfterMs = headers['retry-after'] ? parseInt(headers['retry-after'], 10) * 1000 : undefined;
+      throw new KsefApiException(`KSeF rate limit exceeded: ${url}`, 429, retryAfterMs ? String(retryAfterMs) : undefined, url);
+    }
+
+    // 4xx (other than auth) and 5xx: KsefApiException carries diagnostics-only body.
+    this.logger.error(`[${traceId}] KSeF API error (${statusCode}) ${url}`);
+    throw new KsefApiException(`KSeF API error (${statusCode}): ${url}`, statusCode, body, url);
+  }
+
+  private parseRetryAfter(error: KsefApiException): number | undefined {
+    if (error.statusCode !== 429 || !error.responseBody) {
+      return undefined;
+    }
+    const parsed = Number(error.responseBody);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  private isUnauthenticated(path: string): boolean {
+    return UNAUTHENTICATED_PREFIXES.some((prefix) => path.startsWith(prefix));
+  }
+
+  private getAccessTokenOrThrow(): string {
+    if (!this.token) {
+      throw new KsefAuthenticationException('KSeF access token unavailable after handshake');
+    }
+    return this.token.accessToken;
+  }
+
+  /**
+   * Lazily run the handshake on first authenticated request, then refresh
+   * proactively inside the refresh window. Single-flight per instance.
+   */
+  private async ensureFreshToken(traceId: string): Promise<void> {
+    if (!this.token) {
+      this.token = await this.lifecycle.authenticate(traceId, this.logger);
+      return;
+    }
+    if (Date.now() < this.token.accessTokenExpiresAt.getTime() - TOKEN_REFRESH_WINDOW_MS) {
+      return;
+    }
+    if (this.refreshInFlight) {
+      await this.refreshInFlight;
+      return;
+    }
+    this.refreshInFlight = this.lifecycle
+      .refresh(traceId, this.logger)
+      .then((rotated) => {
+        this.token = rotated;
+      })
+      .catch((err: unknown) => {
+        // Proactive refresh failure: fall back to the reactive 401 path on the
+        // actual request rather than failing pre-flight.
+        this.logger.warn(
+          `[${traceId}] Proactive token refresh failed; relying on reactive 401: ${(err as Error).message}`,
+        );
+      })
+      .finally(() => {
+        this.refreshInFlight = null;
+      });
+    await this.refreshInFlight;
+  }
+
+  private async refreshOnUnauthorized(traceId: string): Promise<RefreshOnUnauthorizedOutcome> {
+    try {
+      this.token = await this.lifecycle.refresh(traceId, this.logger);
+      return { ok: true };
+    } catch (error) {
+      const cause = error as Error;
+      if (cause instanceof KsefNetworkException) {
+        return { ok: false, reason: 'network-failure', cause };
+      }
+      return { ok: false, reason: 'credential-rejected', cause };
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.types.ts
@@ -1,0 +1,140 @@
+/**
+ * KSeF HTTP Client Types
+ *
+ * Type definitions for the KSeF HTTP client's request/response surface and
+ * token-refresh contract. Mirrors the Allegro precedent
+ * (`allegro-http-client.types.ts`): a tagged `RefreshOnUnauthorizedOutcome`
+ * distinguishes transient network failure from genuine credential rejection so
+ * the host's `AuthFailureClassifierPort` (ADR-008) can flip a connection to
+ * `needs_reauth` only on a real rejection, never on a one-second blip.
+ *
+ * Kept in a dedicated `.types.ts` file per engineering-standards "Type
+ * Definitions in Separate Files".
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+import type { Logger } from '@openlinker/shared/logging';
+import type { KsefEnvironment } from '../../domain/types/ksef-connection.types';
+
+export type { KsefEnvironment };
+
+/**
+ * HTTP request options carried into a single KSeF call. `queryParams` are
+ * stringified onto the URL; `headers` override the structural defaults except
+ * `Authorization` and `X-Trace-Id`, which the client owns. `idempotent` lets a
+ * caller opt a POST into the GET-style transient-retry policy (KSeF session
+ * sub-resource reads are POSTs but safe to retry).
+ */
+export interface KsefHttpRequestOptions {
+  headers?: Record<string, string>;
+  queryParams?: Record<string, string | number | boolean>;
+  /**
+   * Opt a non-idempotent verb (POST) into transient-failure retries. Defaults
+   * to false: a POST 5xx/network error fails fast unless the caller asserts the
+   * operation is safe to repeat.
+   */
+  idempotent?: boolean;
+}
+
+/** Parsed JSON response: data plus status + lowercased response headers. */
+export interface KsefHttpResponse<T = unknown> {
+  data: T;
+  status: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Binary response — raw bytes plus the provider-reported content type. Used for
+ * document endpoints (e.g. a UPO PDF) that return a document rather than JSON.
+ * `contentType` is the lowercased `content-type` header; the caller decides the
+ * default when it's absent.
+ */
+export interface KsefBinaryResponse {
+  data: Uint8Array;
+  contentType: string;
+  status: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * KSeF access-token bundle returned by the auth handshake's final redeem step.
+ *
+ * Token taxonomy (kept as distinct fields for clarity):
+ *  - `accessToken` — short-lived JWT; the ONLY field injected into the
+ *    outbound `Authorization: Bearer` header.
+ *  - `refreshToken` — longer-lived; held to rotate `accessToken` without
+ *    re-running the full challenge/redeem handshake. Never sent as a bearer.
+ *  - `accessTokenExpiresAt` — parsed from the access-token JWT `exp` at redeem
+ *    time (never hardcoded); drives proactive refresh.
+ *
+ * SECURITY: none of these fields may be logged.
+ */
+export interface KsefAuthenticationToken {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresAt: Date;
+}
+
+/**
+ * Token Refresh Result
+ *
+ * Returned by a `TokenRefreshCallback` on success: the rotated access token
+ * plus its parsed expiry so the client caches it and avoids an immediate
+ * re-refresh.
+ */
+export interface TokenRefreshResult {
+  accessToken: string;
+  expiresAt: Date;
+}
+
+/**
+ * Token Refresh Callback
+ *
+ * Invoked by `KsefHttpClient` on the proactive and reactive (401) refresh
+ * paths. Implementations own cross-process serialization (e.g. a Redis lock).
+ * Throwing surfaces as a `credential-rejected` (or `network-failure`, when the
+ * thrown error is a `KsefNetworkException`) outcome — see
+ * `RefreshOnUnauthorizedOutcome`.
+ */
+export type TokenRefreshCallback = (
+  connectionId: string,
+  traceId: string,
+  logger: Logger,
+) => Promise<TokenRefreshResult>;
+
+/**
+ * Reason a reactive (401) token refresh did not succeed (mirrors Allegro #499).
+ *
+ *  - `no-callback` — no `tokenRefreshCallback` registered. Defensive; treated
+ *    as auth failure for safety.
+ *  - `credential-rejected` — the auth endpoint responded 4xx/5xx or a local
+ *    pre-flight rejected. Non-retryable: requires manual re-auth.
+ *  - `network-failure` — the auth endpoint was unreachable (DNS/TLS/abort).
+ *    Transient: callers retry with backoff.
+ */
+export const RefreshOutcomeReasonValues = [
+  'no-callback',
+  'credential-rejected',
+  'network-failure',
+] as const;
+export type RefreshOutcomeReason = (typeof RefreshOutcomeReasonValues)[number];
+
+/**
+ * Tagged-result return type for the reactive 401 refresh path. Replaces a lossy
+ * `boolean` so the client maps `network-failure` → retryable network exception
+ * and `credential-rejected` → non-retryable auth exception.
+ */
+export type RefreshOnUnauthorizedOutcome =
+  | { ok: true }
+  | { ok: false; reason: RefreshOutcomeReason; cause?: Error };
+
+/**
+ * Per-call retry policy. Idempotent reads retry transient failures (5xx /
+ * network / 429-with-backoff); non-idempotent writes fail fast unless opted in.
+ */
+export interface KsefRetryConfig {
+  maxRetries: number;
+  initialDelayMs: number;
+  maxDelayMs: number;
+  backoffMultiplier: number;
+}

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.types.ts
@@ -34,6 +34,15 @@ export interface KsefHttpRequestOptions {
    * operation is safe to repeat.
    */
   idempotent?: boolean;
+  /**
+   * Skip the lazy handshake + bearer injection for a genuinely-unauthenticated
+   * call (the auth challenge/ksef-token bootstrap and the public-key-certificate
+   * fetch), or for an auth call that supplies its own `Authorization` header
+   * (the poll/redeem/refresh, which carry the short-lived authentication token).
+   * Explicit per-call flag rather than path-prefix inference so a future
+   * authenticated `/auth/*` sub-resource isn't silently bypassed.
+   */
+  skipAuth?: boolean;
 }
 
 /** Parsed JSON response: data plus status + lowercased response headers. */

--- a/libs/integrations/ksef/src/ksef-plugin.ts
+++ b/libs/integrations/ksef/src/ksef-plugin.ts
@@ -68,7 +68,7 @@ export function createKsefPlugin(): AdapterPlugin {
       capability: string,
       host: HostServices,
     ): Promise<T> {
-      const factory = new KsefAdapterFactory();
+      const factory = new KsefAdapterFactory(host.cache);
       const adapters = await factory.createAdapters(
         connection,
         host.identifierMapping,

--- a/libs/integrations/ksef/src/testing.ts
+++ b/libs/integrations/ksef/src/testing.ts
@@ -2,11 +2,19 @@
  * @openlinker/integrations-ksef/testing — test-double sub-barrel
  *
  * Plugin-internal test doubles for the KSeF plugin (#1144), consumed only from
- * `*.spec.ts`: the in-memory `FakeKsefInvoicingAdapter`. Kept off the main
- * barrel because these are test-only — importing them from runtime code would
- * pull test logic into the bundle. The real test behaviour (call capture,
- * configurable responses) lands in C9.
+ * `*.spec.ts`: the in-memory `FakeKsefInvoicingAdapter` (C2), plus the C3
+ * transport/auth doubles `FakeKsefHttpClient` and `FakeKsefAuthHandshakeService`.
+ * Kept off the main barrel because these are test-only — importing them from
+ * runtime code would pull test logic into the bundle.
  *
  * @module libs/integrations/ksef/src/testing
  */
 export { FakeKsefInvoicingAdapter } from './testing/fake-ksef-invoicing.adapter';
+export { FakeKsefHttpClient } from './testing/fake-ksef-http-client';
+export { FakeKsefAuthHandshakeService } from './testing/fake-ksef-auth.service';
+export {
+  generateTestSigningMaterial,
+  signXadesForTest,
+  verifyXadesForTest,
+  type TestSigningMaterial,
+} from './testing/test-xades-signer';

--- a/libs/integrations/ksef/src/testing/fake-ksef-auth.service.ts
+++ b/libs/integrations/ksef/src/testing/fake-ksef-auth.service.ts
@@ -1,0 +1,47 @@
+/**
+ * Fake KSeF Auth Handshake — test double
+ *
+ * Returns a fixed `KsefAuthenticationToken` (a short-lived JWT with a
+ * configurable `exp`) without running the real challenge/redeem handshake or
+ * needing a real cert / HTTP client. Lets adapter + client unit specs exercise
+ * the token lifecycle (proactive/reactive refresh) deterministically.
+ *
+ * Mints a real (unsigned) JWT shape so `parseJwtExpiry` round-trips against the
+ * seeded expiry. Consumed only from `*.spec.ts`.
+ *
+ * DEFERRED (C4): the qualified-seal / XAdES path is not modelled here — when
+ * real X.509/HSM signing lands, this harness will need a signing fixture; for
+ * C3 it covers only the ksef-token happy path.
+ *
+ * @module libs/integrations/ksef/src/testing
+ */
+import type { KsefAuthenticationToken } from '../infrastructure/http/ksef-http-client.types';
+
+/** Build an unsigned JWT whose payload carries the given `exp` (epoch seconds). */
+function makeFakeJwt(expSeconds: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString('base64url');
+  return `${header}.${payload}.`;
+}
+
+export class FakeKsefAuthHandshakeService {
+  authenticateCalls = 0;
+
+  constructor(private expiresAt: Date = new Date(Date.now() + 60 * 60_000)) {}
+
+  /** Override the token expiry returned by the next `authenticate`. */
+  setExpiry(expiresAt: Date): this {
+    this.expiresAt = expiresAt;
+    return this;
+  }
+
+  authenticate(): Promise<KsefAuthenticationToken> {
+    this.authenticateCalls += 1;
+    const expSeconds = Math.floor(this.expiresAt.getTime() / 1000);
+    return Promise.resolve({
+      accessToken: makeFakeJwt(expSeconds),
+      refreshToken: makeFakeJwt(expSeconds + 3600),
+      accessTokenExpiresAt: this.expiresAt,
+    });
+  }
+}

--- a/libs/integrations/ksef/src/testing/fake-ksef-http-client.ts
+++ b/libs/integrations/ksef/src/testing/fake-ksef-http-client.ts
@@ -1,0 +1,88 @@
+/**
+ * Fake KSeF HTTP Client — test double
+ *
+ * In-memory `IKsefHttpClient` for service/adapter unit specs: seed a response
+ * per `METHOD path` key and play it back, recording calls for assertions. No
+ * real `fetch`, no auth, no retries. Consumed only from `*.spec.ts`.
+ *
+ * Kept off the main barrel (exposed via `@openlinker/integrations-ksef/testing`)
+ * so test-only logic never enters the runtime bundle.
+ *
+ * @module libs/integrations/ksef/src/testing
+ */
+import type { IKsefHttpClient } from '../infrastructure/http/ksef-http-client.interface';
+import type {
+  KsefBinaryResponse,
+  KsefHttpRequestOptions,
+  KsefHttpResponse,
+} from '../infrastructure/http/ksef-http-client.types';
+
+interface RecordedCall {
+  method: 'GET' | 'POST';
+  path: string;
+  body?: unknown;
+  options?: KsefHttpRequestOptions;
+}
+
+export class FakeKsefHttpClient implements IKsefHttpClient {
+  readonly calls: RecordedCall[] = [];
+  private readonly jsonResponses = new Map<string, KsefHttpResponse<unknown>>();
+  private readonly binaryResponses = new Map<string, KsefBinaryResponse>();
+
+  /** Seed a JSON response for `GET path` / `POST path`. */
+  seed(method: 'GET' | 'POST', path: string, response: KsefHttpResponse<unknown>): this {
+    this.jsonResponses.set(this.key(method, path), response);
+    return this;
+  }
+
+  /** Seed a binary response for `POST path` (postExpectingBinary). */
+  seedBinary(path: string, response: KsefBinaryResponse): this {
+    this.binaryResponses.set(this.key('POST', path), response);
+    return this;
+  }
+
+  clear(): void {
+    this.calls.length = 0;
+    this.jsonResponses.clear();
+    this.binaryResponses.clear();
+  }
+
+  get<T = unknown>(path: string, options?: KsefHttpRequestOptions): Promise<KsefHttpResponse<T>> {
+    this.calls.push({ method: 'GET', path, options });
+    return Promise.resolve(this.lookup<T>('GET', path));
+  }
+
+  post<T = unknown>(
+    path: string,
+    body?: Record<string, unknown> | string,
+    options?: KsefHttpRequestOptions,
+  ): Promise<KsefHttpResponse<T>> {
+    this.calls.push({ method: 'POST', path, body, options });
+    return Promise.resolve(this.lookup<T>('POST', path));
+  }
+
+  postExpectingBinary(
+    path: string,
+    body?: Record<string, unknown> | string,
+    options?: KsefHttpRequestOptions,
+  ): Promise<KsefBinaryResponse> {
+    this.calls.push({ method: 'POST', path, body, options });
+    const response = this.binaryResponses.get(this.key('POST', path));
+    if (!response) {
+      return Promise.reject(new Error(`FakeKsefHttpClient: no binary response seeded for POST ${path}`));
+    }
+    return Promise.resolve(response);
+  }
+
+  private lookup<T>(method: 'GET' | 'POST', path: string): KsefHttpResponse<T> {
+    const response = this.jsonResponses.get(this.key(method, path));
+    if (!response) {
+      throw new Error(`FakeKsefHttpClient: no response seeded for ${method} ${path}`);
+    }
+    return response as KsefHttpResponse<T>;
+  }
+
+  private key(method: 'GET' | 'POST', path: string): string {
+    return `${method} ${path}`;
+  }
+}

--- a/libs/integrations/ksef/src/testing/test-xades-signer.ts
+++ b/libs/integrations/ksef/src/testing/test-xades-signer.ts
@@ -1,0 +1,110 @@
+/**
+ * Test-only XAdES Enveloped-Signature Signer
+ *
+ * A self-contained, dependency-free XAdES-style enveloped-signature signer used
+ * ONLY by `*.spec.ts` to exercise the qualified-seal auth shape with a generated
+ * self-signed test certificate. It is intentionally NOT the production signer:
+ * the production `KsefAuthXmlBuilder.signXades` stub stays deferred to C4 (real
+ * X.509/HSM material + a vetted XML-DSig library), per its documented intent.
+ *
+ * What this fixture proves at unit level:
+ *  - the (token | timestamp | challenge) AuthTokenRequest envelope can be signed
+ *    with an RSA private key (RSA-SHA256) tied to a self-signed cert;
+ *  - the resulting document embeds the signature value + the X.509 cert;
+ *  - the signature verifies against the cert's public key (round-trip), so a
+ *    future real signer has a known-good reference shape and a verify helper.
+ *
+ * Canonicalization is a simplified, deterministic byte serialization of the
+ * signed element (NOT W3C C14N) — sufficient for a sign/verify round-trip in a
+ * test, but explicitly not interop-grade. Do not promote this to production.
+ *
+ * SECURITY: test-only. Never imported from runtime code; never holds real keys.
+ *
+ * @module libs/integrations/ksef/src/testing
+ */
+import {
+  createSign,
+  createVerify,
+  generateKeyPairSync,
+  type KeyObject,
+} from 'crypto';
+
+const RSA_SHA256_ALG = 'RSA-SHA256';
+
+/** A generated self-signed-style RSA key pair + its SPKI/PKCS8 PEMs for tests. */
+export interface TestSigningMaterial {
+  privateKeyPem: string;
+  publicKeyPem: string;
+  privateKey: KeyObject;
+  publicKey: KeyObject;
+  /** Base64 DER of the SPKI, stamped into the envelope as a stand-in X509Certificate. */
+  certificateB64: string;
+}
+
+/** Generate an RSA-2048 key pair for the XAdES test signer. */
+export function generateTestSigningMaterial(): TestSigningMaterial {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+  const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+  const certificateB64 = publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+  return { privateKeyPem, publicKeyPem, privateKey, publicKey, certificateB64 };
+}
+
+/**
+ * Produce the byte string that is signed — the unsigned envelope as UTF-8. In a
+ * real XAdES signer this is the C14N of the referenced element; here it is the
+ * exact envelope string, which is deterministic and round-trippable.
+ */
+function canonicalizeForSigning(unsignedXml: string): Buffer {
+  return Buffer.from(unsignedXml, 'utf8');
+}
+
+/**
+ * Sign an unsigned AuthTokenRequest envelope and return an enveloped-signature
+ * document: the original envelope wrapped with a `<ds:Signature>` block carrying
+ * the RSA-SHA256 `<ds:SignatureValue>` and the signer cert in
+ * `<ds:X509Certificate>`.
+ */
+export function signXadesForTest(unsignedXml: string, material: TestSigningMaterial): string {
+  const signer = createSign(RSA_SHA256_ALG);
+  signer.update(canonicalizeForSigning(unsignedXml));
+  signer.end();
+  const signatureValue = signer.sign(material.privateKey).toString('base64');
+
+  return [
+    '<SignedAuthTokenRequest>',
+    unsignedXml,
+    '<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">',
+    '<ds:SignedInfo>',
+    '<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>',
+    '</ds:SignedInfo>',
+    `<ds:SignatureValue>${signatureValue}</ds:SignatureValue>`,
+    '<ds:KeyInfo><ds:X509Data>',
+    `<ds:X509Certificate>${material.certificateB64}</ds:X509Certificate>`,
+    '</ds:X509Data></ds:KeyInfo>',
+    '</ds:Signature>',
+    '</SignedAuthTokenRequest>',
+  ].join('');
+}
+
+/**
+ * Verify a document produced by `signXadesForTest` against the signer cert's
+ * public key: extracts the `<ds:SignatureValue>`, recomputes the digest over the
+ * inner envelope, and checks the RSA-SHA256 signature. Returns true on a valid
+ * signature.
+ */
+export function verifyXadesForTest(
+  signedXml: string,
+  unsignedXml: string,
+  material: TestSigningMaterial,
+): boolean {
+  const match = /<ds:SignatureValue>([^<]+)<\/ds:SignatureValue>/.exec(signedXml);
+  if (!match) {
+    return false;
+  }
+  const signatureValue = Buffer.from(match[1], 'base64');
+  const verifier = createVerify(RSA_SHA256_ALG);
+  verifier.update(canonicalizeForSigning(unsignedXml));
+  verifier.end();
+  return verifier.verify(material.publicKey, signatureValue);
+}


### PR DESCRIPTION
## What & why

Hand-rolled native-`fetch` **KSeF 2.0 auth + session-crypto layer** for the adapter — epic #1142, child **C3** (the program's longest technical pole). Mirrors the in-tree `AllegroHttpClient` pattern; no axios. All KSeF specifics stay in this package (ADR-026); `libs/core` untouched.

> **Stacked on #1180 (C2).** Base branch is `1144-ksef-plugin-skeleton`; retarget to `main` after C2 merges.

## Changes

- **`KsefHttpClient`** — `get`/`post`/`postExpectingBinary`; idempotent-GET retry on 5xx/network, **fail-fast on deterministic non-5xx** (incl. a parse error on a 2xx body), `429` backoff honouring `Retry-After`; per-request trace id.
- **Token lifecycle** — lazy handshake on first authed request; proactive refresh inside the **JWT-`exp`-derived** window (never hardcoded); reactive `401` → single refresh with a tagged outcome distinguishing credential rejection (`KsefAuthenticationException`, non-retryable) from network failure (`KsefNetworkException`, retryable). Distinct `authenticationToken → accessToken → refreshToken` taxonomy.
- **Auth handshake** — challenge → build `AuthTokenRequest` → submit → poll → redeem; **ksef-token** path encrypts `{token}|{timestampMs}` with RSA-OAEP (MGF1+SHA-256) using the MF public key.
- **Session crypto** — AES-256 key + 128-bit IV, AES-256-CBC/PKCS#7 for documents, RSA-OAEP key-wrap; MF public-key fetch + **cache + rotation** (never hardcoded; `KsefTokenEncryption` vs `SymmetricKeyEncryption` usages distinguished).
- Credentials resolved per-connection via host `CredentialsResolverPort`; **secrets never logged** (logs carry trace id / cert hash only).

## Verification

- `pnpm --filter @openlinker/integrations-ksef type-check` ✅
- `pnpm --filter @openlinker/integrations-ksef test` ✅ (15 suites / 89 tests, no network — RSA-OAEP+AES round-trips, handshake, refresh-on-exp proactive+reactive, key cache/rotation, status polling)
- `pnpm --filter @openlinker/integrations-ksef lint` ✅ · `pnpm check:invariants` ✅ · `libs/core` untouched
- Security sweep: no token/secret/key in any log call; credentials only via resolver; JWT `exp` drives TTL.

## Deferred (flagged, not faked)

- **Qualified-seal (XAdES) auth path** is stubbed (throws) — `ksef-token` is the v1 headless path; XAdES unit-coverage (#1147 AC) is a flagged follow-up. Reviewer to decide if it must land before merge.
- Reusable-CTC-crypto **ADR** deferred pending a second clearance regime.
- Test-env "against the real API" assertions are env-gated (skip without KSeF test creds).

## Note on provenance

Produced via the epic's multi-agent loop; the impl/final stages were interrupted by a spend limit + a StructuredOutput retry cap, so the skeleton's auth/crypto/client was completed and the http-client retry-classification + token-refresh test mocks were fixed in a verified follow-up pass (4 failing tests → all 89 green; suite time 41s→11s after removing retry-induced delays). Given the crypto stakes, reviewers should still scrutinize the RSA-OAEP/AES params against the KSeF spec.

Part of epic #1142. Blocks C5 (#1149); unblocks C9 (#1153, FakeKsefClient).

Closes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
