### PR TITLE
feat(invoicing): KSeF regulatory status reconciliation job (#1121)

### DIFF
--- a/apps/api/src/migrations/1808000000000-create-invoice-records.ts
+++ b/apps/api/src/migrations/1808000000000-create-invoice-records.ts
@@ -4,10 +4,13 @@
  * Creates the `invoice_records` table — OL's non-authoritative projection of
  * fiscal documents issued through a provider for an order on an invoicing
  * connection (#751, ADR-026). Country-agnostic columns; `regulatoryStatus` /
- * `clearanceReference` are nullable-with-default and unused until a future
- * `RegulatoryTransmitter` adapter (KSeF/SDI/…) populates them. The partial
- * UNIQUE index on `(connectionId, idempotencyKey)` is the durable exactly-once
- * issuance guard.
+ * `clearanceReference` are nullable-with-default and populated by the read-only
+ * `RegulatoryStatusReader` reconciliation sub-capability (reads authoritative
+ * provider/CTC status, KSeF/SDI, #1121); a future `RegulatoryTransmitter` is the
+ * separate submit side. The partial UNIQUE index on
+ * `(connectionId, idempotencyKey)` is the durable exactly-once issuance guard.
+ * The reconciliation scan's supporting partial composite index is added in a
+ * later migration (`...-add-invoice-records-reconcile-index`).
  *
  * Generated: 2026-06-16 (synthetic sequential prefix per docs/migrations.md #1013).
  * @module apps/api/src/migrations

--- a/apps/api/src/migrations/1810000000000-add-invoice-records-reconcile-index.ts
+++ b/apps/api/src/migrations/1810000000000-add-invoice-records-reconcile-index.ts
@@ -1,0 +1,31 @@
+/**
+ * Add Invoice Records Reconcile Index Migration
+ *
+ * Adds `IDX_invoice_records_reconcile`, the partial composite index backing the
+ * KSeF regulatory-status reconciliation scan (#1121): `status = 'issued' AND
+ * regulatoryStatus NOT IN ('accepted','rejected','not-applicable')`,
+ * connection-scoped, ordered `updatedAt ASC, id ASC`. Partial so terminal /
+ * receipt rows (the bulk of the table over time) stay out of the index. Mirrors
+ * the existing partial-index idiom on `invoice_records`.
+ *
+ * Generated: 2026-06-23 (synthetic sequential prefix per docs/migrations.md #1013).
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddInvoiceRecordsReconcileIndex1810000000000 implements MigrationInterface {
+  name = 'AddInvoiceRecordsReconcileIndex1810000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX "IDX_invoice_records_reconcile"
+        ON "invoice_records" ("connectionId", "updatedAt", "id")
+        WHERE "status" = 'issued'
+          AND "regulatoryStatus" NOT IN ('accepted', 'rejected', 'not-applicable')
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_invoice_records_reconcile"`);
+  }
+}

--- a/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
+++ b/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
@@ -97,6 +97,7 @@ describe('SchedulerService', () => {
         'OL_INVENTORY_SYNC_CRON',
         'OL_PRODUCT_SYNC_CRON',
         'OL_PICKUP_POINT_REFRESH_CRON',
+        'OL_REGULATORY_RECONCILE_CRON',
       ];
       if (cronKeys.includes(key)) return defaultValue ?? '*/15 * * * *';
       return 'true';
@@ -172,6 +173,7 @@ describe('SchedulerService', () => {
         'master-inventory-sync',
         'master-product-sync',
         'pickup-point-refresh',
+        'regulatory-status-reconcile',
       ]);
     });
 
@@ -303,6 +305,86 @@ describe('SchedulerService', () => {
       ).resolves.not.toThrow();
 
       expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('regulatory-status reconcile task (#1121)', () => {
+    const defaultConfigGet = (key: string, defaultValue?: unknown): unknown => {
+      const cronKeys = [
+        'OL_INVENTORY_SYNC_CRON',
+        'OL_PRODUCT_SYNC_CRON',
+        'OL_PICKUP_POINT_REFRESH_CRON',
+        'OL_REGULATORY_RECONCILE_CRON',
+      ];
+      if (cronKeys.includes(key)) return defaultValue ?? '*/15 * * * *';
+      return 'true';
+    };
+
+    const getRegisteredTask = (): SchedulerTaskConfig | undefined =>
+      (service as unknown as { tasks: SchedulerTaskConfig[] }).tasks.find(
+        (t) => t.taskId === 'regulatory-status-reconcile'
+      );
+
+    it('registers a regulatory-status-reconcile task on onApplicationBootstrap (like the other three core tasks)', () => {
+      configService.get.mockImplementation(defaultConfigGet);
+
+      service.onApplicationBootstrap();
+
+      const registeredJobs = schedulerRegistry.addCronJob.mock.calls.map((c) => c[0]);
+      expect(registeredJobs).toContain('regulatory-status-reconcile');
+    });
+
+    it('the task is capability-scoped to Invoicing via listCapabilityAdapters({ capability: "Invoicing" })', async () => {
+      configService.get.mockImplementation(defaultConfigGet);
+      const conn = createConnection('conn-inv-1');
+      integrationsService.listCapabilityAdapters.mockResolvedValue([
+        { connectionId: 'conn-inv-1', connection: conn, adapter: {} as never, metadata: {} as never },
+      ]);
+
+      service.onApplicationBootstrap();
+      const task = getRegisteredTask();
+      expect(task?.connectionFilter).toBeDefined();
+
+      const connections = await task!.connectionFilter!();
+
+      expect(integrationsService.listCapabilityAdapters).toHaveBeenCalledWith({
+        capability: 'Invoicing',
+      });
+      expect(connections).toEqual([conn]);
+      expect(task?.platformType).toBeUndefined();
+    });
+
+    it('uses jobType invoicing.regulatoryStatus.reconcile and a payload with schemaVersion + limit', () => {
+      configService.get.mockImplementation(defaultConfigGet);
+
+      service.onApplicationBootstrap();
+      const task = getRegisteredTask();
+
+      expect(task?.jobType).toBe('invoicing.regulatoryStatus.reconcile');
+      const payload = task!.generatePayload(createConnection('conn-inv-1'));
+      expect(payload).toEqual({ schemaVersion: 1, limit: 100 });
+    });
+
+    it('does not register the task when OL_REGULATORY_RECONCILE_ENABLED is "false"', () => {
+      configService.get.mockImplementation((key: string, defaultValue?: unknown) => {
+        if (key === 'OL_REGULATORY_RECONCILE_ENABLED') return 'false';
+        return defaultConfigGet(key, defaultValue);
+      });
+
+      service.onApplicationBootstrap();
+
+      const registeredJobs = schedulerRegistry.addCronJob.mock.calls.map((c) => c[0]);
+      expect(registeredJobs).not.toContain('regulatory-status-reconcile');
+    });
+
+    it('generates a minute-rounded per-connection idempotency key', () => {
+      configService.get.mockImplementation(defaultConfigGet);
+
+      service.onApplicationBootstrap();
+      const task = getRegisteredTask();
+
+      const key = task!.generateIdempotencyKey(createConnection('conn-inv-1'), '2026-06-05-03-30');
+      expect(key).toBe('invoicing:conn-inv-1:regulatoryStatus:reconcile:2026-06-05-03-30');
     });
   });
 });

--- a/apps/api/src/sync/application/services/scheduler.service.ts
+++ b/apps/api/src/sync/application/services/scheduler.service.ts
@@ -29,6 +29,12 @@ import {
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { Logger } from '@openlinker/shared/logging';
 
+/**
+ * Default page size for the regulatory-status reconciliation fan-out payload
+ * (#1121). The worker handler clamps a payload-supplied `limit` to MAX_LIMIT.
+ */
+const REGULATORY_RECONCILE_DEFAULT_LIMIT = 100;
+
 @Injectable()
 export class SchedulerService implements OnApplicationBootstrap, OnModuleDestroy {
   private readonly logger = new Logger(SchedulerService.name);
@@ -54,6 +60,7 @@ export class SchedulerService implements OnApplicationBootstrap, OnModuleDestroy
     this.registerInventorySyncTask();
     this.registerProductSyncTask();
     this.registerPickupPointRefreshTask();
+    this.registerRegulatoryStatusReconcileTask();
 
     // Drain plugin-contributed tasks. Integration modules have already
     // populated the registry at `onModuleInit`; NestJS guarantees every
@@ -351,6 +358,45 @@ export class SchedulerService implements OnApplicationBootstrap, OnModuleDestroy
       }),
       generateIdempotencyKey: (connection, timestamp) =>
         `shipping:${connection.id}:pickupPoints:refresh:${timestamp}`,
+    });
+  }
+
+  /**
+   * Register the periodic KSeF regulatory-status reconciliation task (#1121).
+   *
+   * Enqueues `invoicing.regulatoryStatus.reconcile` for every active connection
+   * that supports the `Invoicing` capability (capability-scoped — the exact
+   * structural twin of `registerPickupPointRefreshTask`). The worker handler
+   * delegates to the core `RegulatoryStatusReconciliationService`, which reads
+   * authoritative status via the `RegulatoryStatusReader` sub-capability and
+   * refreshes the non-terminal frontier; connections whose adapter lacks the
+   * reader no-op cleanly. Every 30 minutes by default.
+   */
+  private registerRegulatoryStatusReconcileTask(): void {
+    const enabled = this.configService.get<string>('OL_REGULATORY_RECONCILE_ENABLED', 'true');
+    if (enabled === 'false') {
+      return;
+    }
+
+    const cron = this.configService.get<string>('OL_REGULATORY_RECONCILE_CRON', '*/30 * * * *');
+
+    this.tasks.push({
+      taskId: 'regulatory-status-reconcile',
+      jobType: 'invoicing.regulatoryStatus.reconcile',
+      cronExpression: cron,
+      enabledEnvVar: 'OL_REGULATORY_RECONCILE_ENABLED',
+      connectionFilter: async () => {
+        const adapters = await this.integrationsService.listCapabilityAdapters({
+          capability: 'Invoicing',
+        });
+        return (adapters ?? []).map((a) => a.connection);
+      },
+      generatePayload: () => ({
+        schemaVersion: 1,
+        limit: REGULATORY_RECONCILE_DEFAULT_LIMIT,
+      }),
+      generateIdempotencyKey: (connection, timestamp) =>
+        `invoicing:${connection.id}:regulatoryStatus:reconcile:${timestamp}`,
     });
   }
 }

--- a/apps/api/test/integration/invoicing/invoice-record-reconcile-query.int-spec.ts
+++ b/apps/api/test/integration/invoicing/invoice-record-reconcile-query.int-spec.ts
@@ -1,0 +1,184 @@
+/**
+ * Invoice Records reconcile-query Integration Test (#1121)
+ *
+ * Proves, against a real Postgres + the `IDX_invoice_records_reconcile` partial
+ * composite index, the behaviour the unit test can only mock:
+ *  - `findIssuedNonTerminal` selects issued + non-terminal records and EXCLUDES
+ *    issued/terminal (accepted/rejected) + receipts/not-applicable;
+ *  - ordering is `updatedAt ASC, id ASC` and `take = limit` (no offset);
+ *  - after a run writes rows to terminal, a follow-up query returns the
+ *    previously-unreached non-terminal rows (skip-free coverage, decision #5);
+ *  - `updateOutcome` with a patch that OMITS `clearanceReference` leaves an
+ *    existing column value intact (real-DB proof of decision #8b).
+ *
+ * @module apps/api/test/integration/invoicing
+ */
+import { InvoiceRecordOrmEntity } from '@openlinker/core/invoicing/orm-entities';
+// Deep import of the infrastructure repository (host-only test seam): the
+// repository class is intentionally NOT on the bounded-context public barrel,
+// so we reach it via the `@openlinker/core/*` wildcard the same way the
+// orm-entities sub-barrel is consumed.
+import { InvoiceRecordRepository } from '@openlinker/core/invoicing/infrastructure/persistence/repositories/invoice-record.repository';
+import type { RegulatoryStatus } from '@openlinker/core/invoicing';
+import type { Repository } from 'typeorm';
+
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from '../setup';
+
+const CONNECTION_ID = '00000000-0000-0000-0000-000000001121';
+const OTHER_CONNECTION_ID = '00000000-0000-0000-0000-000000001122';
+
+let orderSeq = 0;
+
+function row(overrides: Partial<InvoiceRecordOrmEntity> = {}): InvoiceRecordOrmEntity {
+  orderSeq += 1;
+  const entity = new InvoiceRecordOrmEntity();
+  Object.assign(
+    entity,
+    {
+      connectionId: CONNECTION_ID,
+      orderId: `ol_order_${orderSeq}`,
+      providerType: 'subiekt',
+      documentType: 'invoice',
+      status: 'issued',
+      idempotencyKey: null,
+      regulatoryStatus: 'submitted' as RegulatoryStatus,
+      clearanceReference: null,
+    },
+    overrides,
+  );
+  return entity;
+}
+
+describe('invoice_records reconcile query (integration)', () => {
+  let harness: IntegrationTestHarness;
+  let ormRepo: Repository<InvoiceRecordOrmEntity>;
+  let repo: InvoiceRecordRepository;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  beforeEach(async () => {
+    await resetTestHarness();
+    ormRepo = harness.getDataSource().getRepository(InvoiceRecordOrmEntity);
+    repo = new InvoiceRecordRepository(ormRepo);
+    orderSeq = 0;
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('findIssuedNonTerminal selects only issued + non-terminal records', async () => {
+    await ormRepo.save(row({ regulatoryStatus: 'submitted' }));
+    await ormRepo.save(row({ regulatoryStatus: 'cleared' }));
+    // Excluded: pending / failed issuance status (not yet issued).
+    await ormRepo.save(row({ status: 'pending', regulatoryStatus: 'submitted' }));
+    await ormRepo.save(row({ status: 'failed', regulatoryStatus: 'submitted' }));
+
+    const { items, total } = await repo.findIssuedNonTerminal(CONNECTION_ID, { limit: 100 });
+
+    expect(total).toBe(2);
+    expect(items.every((r) => r.status === 'issued')).toBe(true);
+    expect(items.map((r) => r.regulatoryStatus).sort()).toEqual(['cleared', 'submitted']);
+  });
+
+  it('excludes issued/terminal (accepted, rejected) records', async () => {
+    await ormRepo.save(row({ regulatoryStatus: 'submitted' }));
+    await ormRepo.save(row({ regulatoryStatus: 'accepted' }));
+    await ormRepo.save(row({ regulatoryStatus: 'rejected' }));
+
+    const { items, total } = await repo.findIssuedNonTerminal(CONNECTION_ID, { limit: 100 });
+
+    expect(total).toBe(1);
+    expect(items[0].regulatoryStatus).toBe('submitted');
+  });
+
+  it('excludes receipts / not-applicable records (never polled)', async () => {
+    await ormRepo.save(row({ regulatoryStatus: 'submitted' }));
+    await ormRepo.save(
+      row({ documentType: 'receipt', regulatoryStatus: 'not-applicable' }),
+    );
+
+    const { items, total } = await repo.findIssuedNonTerminal(CONNECTION_ID, { limit: 100 });
+
+    expect(total).toBe(1);
+    expect(items[0].regulatoryStatus).toBe('submitted');
+  });
+
+  it('orders results updatedAt ASC, id ASC', async () => {
+    const a = await ormRepo.save(row({ regulatoryStatus: 'submitted' }));
+    const b = await ormRepo.save(row({ regulatoryStatus: 'submitted' }));
+    const c = await ormRepo.save(row({ regulatoryStatus: 'submitted' }));
+    // Force distinct updatedAt: bump `a` so it becomes the newest.
+    await ormRepo.update(a.id, { regulatoryStatus: 'cleared' });
+
+    const { items } = await repo.findIssuedNonTerminal(CONNECTION_ID, { limit: 100 });
+    const ids = items.map((r) => r.id);
+
+    // b and c keep their original (older) updatedAt; a was just touched (newest).
+    expect(ids.indexOf(a.id)).toBe(2);
+    expect(new Set(ids)).toEqual(new Set([a.id, b.id, c.id]));
+  });
+
+  it('caps the result set at take = limit (no offset)', async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await ormRepo.save(row({ regulatoryStatus: 'submitted' }));
+    }
+
+    const { items, total } = await repo.findIssuedNonTerminal(CONNECTION_ID, { limit: 2 });
+
+    expect(items).toHaveLength(2);
+    // total reflects the full matching set, not the page.
+    expect(total).toBe(5);
+  });
+
+  it('does not leak other connections rows', async () => {
+    await ormRepo.save(row({ regulatoryStatus: 'submitted' }));
+    await ormRepo.save(
+      row({ connectionId: OTHER_CONNECTION_ID, regulatoryStatus: 'submitted' }),
+    );
+
+    const { items, total } = await repo.findIssuedNonTerminal(CONNECTION_ID, { limit: 100 });
+
+    expect(total).toBe(1);
+    expect(items[0].connectionId).toBe(CONNECTION_ID);
+  });
+
+  it('after writing rows to terminal, a follow-up query returns the previously-unreached non-terminal rows (skip-free, decision #5)', async () => {
+    const r1 = await ormRepo.save(row({ regulatoryStatus: 'submitted' }));
+    await ormRepo.save(row({ regulatoryStatus: 'submitted' }));
+
+    // First run: page size 1 — picks up the oldest row only.
+    const first = await repo.findIssuedNonTerminal(CONNECTION_ID, { limit: 1 });
+    expect(first.total).toBe(2);
+    expect(first.items).toHaveLength(1);
+
+    // Reconcile the picked row to a terminal status; it drops out of the frontier.
+    await repo.updateOutcome(first.items[0].id, { regulatoryStatus: 'accepted' });
+
+    // Follow-up run: the previously-unreached non-terminal row now surfaces.
+    const second = await repo.findIssuedNonTerminal(CONNECTION_ID, { limit: 1 });
+    expect(second.total).toBe(1);
+    expect(second.items[0].id).not.toBe(first.items[0].id);
+    expect([r1.id, second.items[0].id]).toContain(second.items[0].id);
+  });
+
+  it('updateOutcome with a patch omitting clearanceReference leaves an existing column value intact (decision #8b)', async () => {
+    const saved = await ormRepo.save(
+      row({ regulatoryStatus: 'submitted', clearanceReference: 'KSEF-EXISTING' }),
+    );
+
+    // Patch the status only — clearanceReference key omitted.
+    await repo.updateOutcome(saved.id, { regulatoryStatus: 'accepted' });
+
+    const reread = await ormRepo.findOneOrFail({ where: { id: saved.id } });
+    expect(reread.regulatoryStatus).toBe('accepted');
+    expect(reread.clearanceReference).toBe('KSEF-EXISTING');
+  });
+});

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -28,6 +28,7 @@ import { MasterInventorySyncAllHandler } from './master-inventory-sync-all.handl
 import { MasterProductSyncAllHandler } from './master-product-sync-all.handler';
 import { PickupPointRefreshHandler } from './pickup-point-refresh.handler';
 import { ShopProductPublishHandler } from './shop-product-publish.handler';
+import { RegulatoryStatusReconcileHandler } from './regulatory-status-reconcile.handler';
 
 @Injectable()
 export class HandlerRegistrationService implements OnModuleInit {
@@ -51,7 +52,8 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly masterInventorySyncAllHandler: MasterInventorySyncAllHandler,
     private readonly masterProductSyncAllHandler: MasterProductSyncAllHandler,
     private readonly pickupPointRefreshHandler: PickupPointRefreshHandler,
-    private readonly shopProductPublishHandler: ShopProductPublishHandler
+    private readonly shopProductPublishHandler: ShopProductPublishHandler,
+    private readonly regulatoryStatusReconcileHandler: RegulatoryStatusReconcileHandler
   ) {}
 
   onModuleInit(): void {
@@ -119,5 +121,11 @@ export class HandlerRegistrationService implements OnModuleInit {
 
     // Register shop product publish handler (#1042, ADR-024)
     this.handlerRegistry.register('shop.product.publish', this.shopProductPublishHandler);
+
+    // Register KSeF regulatory-status reconciliation handler (#1121)
+    this.handlerRegistry.register(
+      'invoicing.regulatoryStatus.reconcile',
+      this.regulatoryStatusReconcileHandler
+    );
   }
 }

--- a/apps/worker/src/sync/handlers/regulatory-status-reconcile.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/regulatory-status-reconcile.handler.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for `RegulatoryStatusReconcileHandler` (#1121).
+ *
+ * Mocks `IRegulatoryStatusReconciliationService`. Pins payload validation, the
+ * `limit` clamp to MAX_LIMIT (decision #13), the ok outcome, and OL-shaped error
+ * wrapping. No cursor assertions (the cursor is dropped — decision #5).
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import type { IRegulatoryStatusReconciliationService } from '@openlinker/core/invoicing';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import type { SyncJob } from '@openlinker/core/sync';
+import { RegulatoryStatusReconcileHandler } from './regulatory-status-reconcile.handler';
+
+function makeJob(payload: unknown): SyncJob {
+  return {
+    id: 'job-1',
+    jobType: 'invoicing.regulatoryStatus.reconcile',
+    connectionId: 'conn-1',
+    payload,
+    idempotencyKey: 'invoicing:conn-1:regulatoryStatus:reconcile:2026-06-05-03-00',
+    status: 'running',
+    attempts: 1,
+    maxAttempts: 10,
+    nextRunAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as SyncJob;
+}
+
+const ZEROED = { scanned: 0, updated: 0, skippedTerminal: 0, readErrors: 0, total: 0 };
+
+describe('RegulatoryStatusReconcileHandler', () => {
+  let reconciliationService: jest.Mocked<IRegulatoryStatusReconciliationService>;
+  let handler: RegulatoryStatusReconcileHandler;
+
+  beforeEach(() => {
+    reconciliationService = {
+      reconcile: jest.fn().mockResolvedValue(ZEROED),
+    };
+    handler = new RegulatoryStatusReconcileHandler(reconciliationService);
+  });
+
+  describe('getPayload', () => {
+    it('throws an OL-shaped SyncJobExecutionError when the payload is missing/invalid', async () => {
+      await expect(handler.execute(makeJob(undefined))).rejects.toBeInstanceOf(
+        SyncJobExecutionError,
+      );
+      await expect(handler.execute(makeJob({ schemaVersion: 2 }))).rejects.toBeInstanceOf(
+        SyncJobExecutionError,
+      );
+      expect(reconciliationService.reconcile).not.toHaveBeenCalled();
+    });
+
+    it('defaults limit to DEFAULT_LIMIT when payload.limit is absent or not a positive number', async () => {
+      await handler.execute(makeJob({ schemaVersion: 1 }));
+      expect(reconciliationService.reconcile).toHaveBeenLastCalledWith('conn-1', { limit: 100 });
+
+      await handler.execute(makeJob({ schemaVersion: 1, limit: -5 }));
+      expect(reconciliationService.reconcile).toHaveBeenLastCalledWith('conn-1', { limit: 100 });
+    });
+
+    it('clamps an out-of-range payload.limit down to MAX_LIMIT (decision #13)', async () => {
+      await handler.execute(makeJob({ schemaVersion: 1, limit: 100000 }));
+      expect(reconciliationService.reconcile).toHaveBeenCalledWith('conn-1', { limit: 500 });
+    });
+
+    it('passes through a valid in-range limit unchanged', async () => {
+      await handler.execute(makeJob({ schemaVersion: 1, limit: 250 }));
+      expect(reconciliationService.reconcile).toHaveBeenCalledWith('conn-1', { limit: 250 });
+    });
+  });
+
+  describe('execute', () => {
+    it('delegates to reconciliationService.reconcile(connectionId, { limit }) and returns { outcome: "ok" }', async () => {
+      const result = await handler.execute(makeJob({ schemaVersion: 1, limit: 50 }));
+
+      expect(reconciliationService.reconcile).toHaveBeenCalledWith('conn-1', { limit: 50 });
+      expect(result).toEqual({ outcome: 'ok' });
+    });
+
+    it('wraps a thrown error in an OL-shaped SyncJobExecutionError carrying job id / type / connectionId', async () => {
+      reconciliationService.reconcile.mockRejectedValue(new Error('repo down'));
+
+      await expect(handler.execute(makeJob({ schemaVersion: 1, limit: 50 }))).rejects.toMatchObject({
+        name: 'SyncJobExecutionError',
+        jobId: 'job-1',
+        jobType: 'invoicing.regulatoryStatus.reconcile',
+        connectionId: 'conn-1',
+      });
+    });
+  });
+});

--- a/apps/worker/src/sync/handlers/regulatory-status-reconcile.handler.ts
+++ b/apps/worker/src/sync/handlers/regulatory-status-reconcile.handler.ts
@@ -1,0 +1,104 @@
+/**
+ * Regulatory Status Reconcile Handler (#1121)
+ *
+ * Thin delegate for jobs of type `invoicing.regulatoryStatus.reconcile`.
+ * Refreshes one page of a connection's issued + non-terminal invoice records via
+ * the core `RegulatoryStatusReconciliationService` (which reads authoritative
+ * provider/CTC status through the `RegulatoryStatusReader` sub-capability). The
+ * scheduler fans this out, one job per `Invoicing` connection; connections whose
+ * adapter lacks the reader no-op in the service.
+ *
+ * NO cursor (the reconciliation frontier is a shrinking set walked from offset 0
+ * every run — plan decision #5), so this handler does NOT inject
+ * `ConnectionCursorRepositoryPort`. The payload `limit` is validated AND clamped
+ * to `MAX_LIMIT` (decision #13). The outer catch only ever interpolates
+ * OL-shaped messages — the service never re-throws a raw provider error past its
+ * per-record loop (#8e).
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import type {
+  SyncJobHandler,
+  SyncJobHandlerResult,
+  SyncJob as SyncJobEntity,
+  RegulatoryStatusReconcilePayloadV1,
+} from '@openlinker/core/sync';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+import {
+  IRegulatoryStatusReconciliationService,
+  REGULATORY_STATUS_RECONCILIATION_SERVICE_TOKEN,
+} from '@openlinker/core/invoicing';
+import { Logger } from '@openlinker/shared/logging';
+
+type SyncJob = SyncJobEntity;
+
+const DEFAULT_LIMIT = 100;
+/** Upper bound on the page size (decision #13) — caps `take` regardless of payload. */
+const MAX_LIMIT = 500;
+
+@Injectable()
+export class RegulatoryStatusReconcileHandler implements SyncJobHandler {
+  private readonly logger = new Logger(RegulatoryStatusReconcileHandler.name);
+
+  constructor(
+    @Inject(REGULATORY_STATUS_RECONCILIATION_SERVICE_TOKEN)
+    private readonly reconciliationService: IRegulatoryStatusReconciliationService,
+  ) {}
+
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
+    const payload = this.getPayload(job);
+
+    this.logger.log(
+      `Executing invoicing.regulatoryStatus.reconcile job ${job.id} for connection ${job.connectionId} (limit=${payload.limit})`,
+    );
+
+    try {
+      const result = await this.reconciliationService.reconcile(job.connectionId, {
+        limit: payload.limit,
+      });
+
+      this.logger.log(
+        `invoicing.regulatoryStatus.reconcile completed (connection=${job.connectionId}): scanned=${result.scanned}, updated=${result.updated}, skippedTerminal=${result.skippedTerminal}, readErrors=${result.readErrors}, total=${result.total}`,
+      );
+
+      return { outcome: 'ok' };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SyncJobExecutionError(
+        `Regulatory status reconcile failed: ${message}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  private getPayload(job: SyncJob): RegulatoryStatusReconcilePayloadV1 {
+    const payload = job.payload as Partial<RegulatoryStatusReconcilePayloadV1> | undefined;
+
+    if (
+      payload === null ||
+      typeof payload !== 'object' ||
+      payload.schemaVersion !== 1
+    ) {
+      throw new SyncJobExecutionError(
+        `Invalid invoicing.regulatoryStatus.reconcile payload: expected an object with schemaVersion=1`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+
+    // Default an absent / non-positive limit to DEFAULT_LIMIT, then clamp to
+    // MAX_LIMIT so a payload-supplied limit can never blow the page size past
+    // the cap (decision #13).
+    const limit = Math.min(
+      typeof payload.limit === 'number' && payload.limit > 0 ? payload.limit : DEFAULT_LIMIT,
+      MAX_LIMIT,
+    );
+
+    return { schemaVersion: 1, limit };
+  }
+}

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -15,6 +15,7 @@ import { InventoryModule } from '@openlinker/core/inventory';
 import { OrdersModule } from '@openlinker/core/orders';
 import { ListingsModule } from '@openlinker/core/listings/services';
 import { ShippingModule } from '@openlinker/core/shipping';
+import { InvoicingModule } from '@openlinker/core/invoicing';
 import { WorkerContentModule } from '../content/worker-content.module';
 import { JobIntakeConsumer } from './job-intake.consumer';
 import { SyncJobRunner } from './sync-job.runner';
@@ -38,6 +39,7 @@ import { MasterInventorySyncAllHandler } from './handlers/master-inventory-sync-
 import { MasterProductSyncAllHandler } from './handlers/master-product-sync-all.handler';
 import { PickupPointRefreshHandler } from './handlers/pickup-point-refresh.handler';
 import { ShopProductPublishHandler } from './handlers/shop-product-publish.handler';
+import { RegulatoryStatusReconcileHandler } from './handlers/regulatory-status-reconcile.handler';
 import { HandlerRegistrationService } from './handlers/handler-registration.service';
 
 @Module({
@@ -50,6 +52,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     OrdersModule, // Import OrdersModule to access ORDER_SYNC_SERVICE_TOKEN
     ListingsModule, // Import ListingsModule to access OFFER_MAPPING_SYNC_SERVICE_TOKEN
     ShippingModule, // Import ShippingModule to access SHIPMENT_STATUS_SYNC_SERVICE_TOKEN (#838)
+    InvoicingModule, // Import InvoicingModule to access REGULATORY_STATUS_RECONCILIATION_SERVICE_TOKEN (#1121)
     WorkerContentModule, // Worker-side ContentModule for #737 — exposes CONTENT_SUGGESTION_SERVICE_TOKEN
   ],
   providers: [
@@ -75,6 +78,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     MasterProductSyncAllHandler,
     PickupPointRefreshHandler,
     ShopProductPublishHandler,
+    RegulatoryStatusReconcileHandler,
     HandlerRegistrationService,
   ],
 })

--- a/apps/worker/test/integration/regulatory-status-reconcile-di.int-spec.ts
+++ b/apps/worker/test/integration/regulatory-status-reconcile-di.int-spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Regulatory Status Reconcile worker-module DI smoke test (#1121)
+ *
+ * Boots the worker DI graph and asserts `RegulatoryStatusReconcileHandler`
+ * resolves — i.e. `SyncWorkerModule` imports `InvoicingModule` and the
+ * `REGULATORY_STATUS_RECONCILIATION_SERVICE_TOKEN` is EXPORTED from
+ * `InvoicingModule` (a missing export would fail the worker's DI at boot,
+ * decision #12). Also asserts the handler is registered for the
+ * `invoicing.regulatoryStatus.reconcile` job type.
+ *
+ * @module apps/worker/test/integration
+ */
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { WorkerIntegrationTestHarness } from './setup';
+import { RegulatoryStatusReconcileHandler } from '../../src/sync/handlers/regulatory-status-reconcile.handler';
+import { SyncJobHandlerRegistry } from '../../src/sync/handlers/sync-job-handler.registry';
+
+describe('regulatory-status reconcile worker DI (integration)', () => {
+  let harness: WorkerIntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('RegulatoryStatusReconcileHandler resolves from the worker DI graph', () => {
+    // A missing InvoicingModule import / un-exported reconciliation-service
+    // token would have failed the app boot in beforeAll; reaching here AND
+    // resolving the handler instance proves the graph wired up.
+    const handler = harness.get(RegulatoryStatusReconcileHandler);
+    expect(handler).toBeInstanceOf(RegulatoryStatusReconcileHandler);
+  });
+
+  it('the handler is registered for jobType invoicing.regulatoryStatus.reconcile', () => {
+    const registry = harness.get(SyncJobHandlerRegistry);
+    const handler = registry.getHandler('invoicing.regulatoryStatus.reconcile');
+
+    expect(handler).not.toBeNull();
+    expect(handler).toBeInstanceOf(RegulatoryStatusReconcileHandler);
+  });
+});

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -99,6 +99,7 @@ describe('InvoiceService', () => {
       findByOrderId: jest.fn(),
       findByIdempotencyKey: jest.fn(),
       updateOutcome: jest.fn(),
+      findIssuedNonTerminal: jest.fn(),
     };
     adapter = {
       issueInvoice: jest.fn(),

--- a/libs/core/src/invoicing/application/services/regulatory-status-reconciliation.service.interface.ts
+++ b/libs/core/src/invoicing/application/services/regulatory-status-reconciliation.service.interface.ts
@@ -1,0 +1,49 @@
+/**
+ * Regulatory Status Reconciliation Service Interface
+ *
+ * Contract for the KSeF regulatory-status reconciliation sweep (#1121): for one
+ * connection, refresh `InvoiceRecord.regulatoryStatus` / `clearanceReference` of
+ * `issued` records whose regulatory status is still NON-terminal by reading
+ * authoritative status via the `RegulatoryStatusReader` sub-capability. The read
+ * is authoritative; terminal reads are written back so the record drops out of
+ * the next sweep. Receipts / `not-applicable` are never polled (excluded by the
+ * repository query).
+ *
+ * Paging is offset-0 every run (no cursor): the non-terminal frontier is a
+ * SHRINKING set, so it is walked from the front ordered `updatedAt ASC` — a
+ * connection with more non-terminal rows than `limit` is covered across multiple
+ * ticks, skip-free and starvation-bounded (plan decision #5).
+ *
+ * @module libs/core/src/invoicing/application/services
+ */
+
+export interface RegulatoryStatusReconcileOptions {
+  /** Page size: max number of non-terminal records to reconcile this run. */
+  limit: number;
+}
+
+export interface RegulatoryStatusReconcileResult {
+  /** Records read this run. */
+  scanned: number;
+  /** Records whose projection was updated (status and/or clearanceReference). */
+  updated: number;
+  /** Records skipped because the RECORD was already terminal (race guard). */
+  skippedTerminal: number;
+  /** Records whose authoritative read threw (counted, sweep continued). */
+  readErrors: number;
+  /** Total non-terminal records matching the query (for coverage logging). */
+  total: number;
+}
+
+export interface IRegulatoryStatusReconciliationService {
+  /**
+   * Reconcile one page of the connection's issued + non-terminal invoice
+   * records. Connections whose adapter does not implement
+   * `RegulatoryStatusReader` are skipped with a zeroed result (no throw).
+   * Idempotent and safe to re-run: no upstream change yields a clean no-op.
+   */
+  reconcile(
+    connectionId: string,
+    opts: RegulatoryStatusReconcileOptions,
+  ): Promise<RegulatoryStatusReconcileResult>;
+}

--- a/libs/core/src/invoicing/application/services/regulatory-status-reconciliation.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/regulatory-status-reconciliation.service.spec.ts
@@ -1,0 +1,319 @@
+/**
+ * Unit tests for `RegulatoryStatusReconciliationService` (#1121).
+ *
+ * Mocks the repository and a `RegulatoryStatusReader` adapter (no #753/Subiekt
+ * code). Pins the selection scope, the write/monotonicity/idempotency rules
+ * (plan decision #8), the guard-miss no-op, bounded error logging, and
+ * eventual coverage.
+ *
+ * @module libs/core/src/invoicing/application/services
+ */
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+
+import { InvoiceRecord } from '../../domain/entities/invoice-record.entity';
+import type { InvoiceRecordRepositoryPort } from '../../domain/ports/invoice-record-repository.port';
+import type { InvoicingPort } from '../../domain/ports/invoicing.port';
+import type { RegulatoryStatusReader } from '../../domain/ports/capabilities/regulatory-status-reader.capability';
+import type { RegulatoryStatus } from '../../domain/types/invoicing.types';
+import type { RegulatoryStatusReadResult } from '../../domain/types/regulatory-status-read.types';
+import { RegulatoryStatusReconciliationService } from './regulatory-status-reconciliation.service';
+
+const CONNECTION_ID = 'conn-invoicing-1';
+
+function makeRecord(
+  overrides: Partial<{
+    id: string;
+    status: 'pending' | 'issued' | 'failed';
+    regulatoryStatus: RegulatoryStatus;
+    clearanceReference: string | null;
+  }> = {},
+): InvoiceRecord {
+  return new InvoiceRecord(
+    overrides.id ?? 'rec-1',
+    CONNECTION_ID,
+    'order-1',
+    'subiekt',
+    'invoice',
+    overrides.status ?? 'issued',
+    'prov-inv-1',
+    'FV/1',
+    overrides.regulatoryStatus ?? 'submitted',
+    overrides.clearanceReference ?? null,
+    'idem-1',
+    null,
+    new Date('2026-06-01T10:00:00Z'),
+    null,
+    new Date('2026-06-01T10:00:00Z'),
+    new Date('2026-06-01T10:00:00Z'),
+  );
+}
+
+/** A base Invoicing adapter that does NOT implement RegulatoryStatusReader. */
+function baseAdapter(): InvoicingPort {
+  return {
+    issueInvoice: jest.fn(),
+    getInvoice: jest.fn(),
+    upsertCustomer: jest.fn(),
+    getSupportedDocumentTypes: jest.fn().mockReturnValue(['invoice']),
+  } as unknown as InvoicingPort;
+}
+
+/** An Invoicing adapter that also implements the RegulatoryStatusReader sub-capability. */
+function readerAdapter(
+  read: RegulatoryStatusReadResult | ((record: InvoiceRecord) => Promise<RegulatoryStatusReadResult>),
+): InvoicingPort & RegulatoryStatusReader {
+  const fn =
+    typeof read === 'function'
+      ? jest.fn(read)
+      : jest.fn().mockResolvedValue(read);
+  return {
+    ...baseAdapter(),
+    readRegulatoryStatus: fn,
+  } as unknown as InvoicingPort & RegulatoryStatusReader;
+}
+
+describe('RegulatoryStatusReconciliationService', () => {
+  let service: RegulatoryStatusReconciliationService;
+  let repo: jest.Mocked<InvoiceRecordRepositoryPort>;
+  let integrations: jest.Mocked<IIntegrationsService>;
+
+  beforeEach(() => {
+    repo = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      findByOrderId: jest.fn(),
+      findByIdempotencyKey: jest.fn(),
+      updateOutcome: jest.fn().mockImplementation((id: string) => Promise.resolve(makeRecord({ id }))),
+      findIssuedNonTerminal: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+    } as unknown as jest.Mocked<InvoiceRecordRepositoryPort>;
+
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+      resolveAdapterMetadata: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    service = new RegulatoryStatusReconciliationService(repo, integrations);
+  });
+
+  describe('selection scope', () => {
+    it('queries only issued + non-terminal records (delegates the predicate to the repo)', async () => {
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        readerAdapter({ regulatoryStatus: 'submitted', clearanceReference: null }),
+      );
+      repo.findIssuedNonTerminal.mockResolvedValue({
+        items: [makeRecord({ regulatoryStatus: 'submitted' })],
+        total: 1,
+      });
+
+      await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(CONNECTION_ID, 'Invoicing');
+      expect(repo.findIssuedNonTerminal).toHaveBeenCalledWith(CONNECTION_ID, { limit: 50 });
+    });
+
+    it('does not query the repo and returns a zeroed result when the adapter is not a RegulatoryStatusReader', async () => {
+      integrations.getCapabilityAdapter.mockResolvedValue(baseAdapter());
+
+      const result = await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      expect(repo.findIssuedNonTerminal).not.toHaveBeenCalled();
+      expect(repo.updateOutcome).not.toHaveBeenCalled();
+      expect(result).toEqual({ scanned: 0, updated: 0, skippedTerminal: 0, readErrors: 0, total: 0 });
+    });
+  });
+
+  describe('write / reconciliation semantics (decision #8)', () => {
+    it('writes a non-terminal record terminal when the authoritative read returns accepted (8a)', async () => {
+      const record = makeRecord({ regulatoryStatus: 'submitted' });
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        readerAdapter({ regulatoryStatus: 'accepted', clearanceReference: 'KSEF-123' }),
+      );
+      repo.findIssuedNonTerminal.mockResolvedValue({ items: [record], total: 1 });
+
+      const result = await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      expect(repo.updateOutcome).toHaveBeenCalledWith(record.id, {
+        regulatoryStatus: 'accepted',
+        clearanceReference: 'KSEF-123',
+      });
+      expect(result.updated).toBe(1);
+    });
+
+    it('writes a non-terminal record terminal when the authoritative read returns rejected (8a)', async () => {
+      const record = makeRecord({ regulatoryStatus: 'submitted' });
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        readerAdapter({ regulatoryStatus: 'rejected', clearanceReference: null }),
+      );
+      repo.findIssuedNonTerminal.mockResolvedValue({ items: [record], total: 1 });
+
+      await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      expect(repo.updateOutcome).toHaveBeenCalledWith(record.id, { regulatoryStatus: 'rejected' });
+    });
+
+    it('defensive-skips a record whose CURRENT status is already terminal (race guard, 8a) and increments skippedTerminal', async () => {
+      const reader = readerAdapter({ regulatoryStatus: 'submitted', clearanceReference: null });
+      integrations.getCapabilityAdapter.mockResolvedValue(reader);
+      // A row that slipped through the predicate but is already terminal.
+      repo.findIssuedNonTerminal.mockResolvedValue({
+        items: [makeRecord({ regulatoryStatus: 'accepted' })],
+        total: 1,
+      });
+
+      const result = await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      expect((reader.readRegulatoryStatus as jest.Mock)).not.toHaveBeenCalled();
+      expect(repo.updateOutcome).not.toHaveBeenCalled();
+      expect(result.skippedTerminal).toBe(1);
+      expect(result.scanned).toBe(0);
+    });
+
+    it('preserves an existing clearanceReference when the read returns null AND omits the clearanceReference key from the patch (8b)', async () => {
+      const record = makeRecord({ regulatoryStatus: 'submitted', clearanceReference: 'KSEF-EXISTING' });
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        readerAdapter({ regulatoryStatus: 'accepted', clearanceReference: null }),
+      );
+      repo.findIssuedNonTerminal.mockResolvedValue({ items: [record], total: 1 });
+
+      await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      const patch = ((repo.updateOutcome as jest.Mock).mock.calls[0] as [unknown, Record<string, unknown>])[1];
+      expect(patch).toEqual({ regulatoryStatus: 'accepted' });
+      expect('clearanceReference' in patch).toBe(false);
+    });
+
+    it('persists clearanceReference only when the read is non-null and changed (8b)', async () => {
+      const record = makeRecord({ regulatoryStatus: 'submitted', clearanceReference: null });
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        readerAdapter({ regulatoryStatus: 'cleared', clearanceReference: 'KSEF-NEW' }),
+      );
+      repo.findIssuedNonTerminal.mockResolvedValue({ items: [record], total: 1 });
+
+      await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      expect(repo.updateOutcome).toHaveBeenCalledWith(record.id, {
+        regulatoryStatus: 'cleared',
+        clearanceReference: 'KSEF-NEW',
+      });
+    });
+
+    it('does not call updateOutcome when nothing changed (no-op write, 8c)', async () => {
+      const record = makeRecord({ regulatoryStatus: 'submitted', clearanceReference: 'KSEF-1' });
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        readerAdapter({ regulatoryStatus: 'submitted', clearanceReference: 'KSEF-1' }),
+      );
+      repo.findIssuedNonTerminal.mockResolvedValue({ items: [record], total: 1 });
+
+      const result = await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      expect(repo.updateOutcome).not.toHaveBeenCalled();
+      expect(result.updated).toBe(0);
+      expect(result.scanned).toBe(1);
+    });
+  });
+
+  describe('error handling (decision #8d / #8e)', () => {
+    it('increments readErrors and continues the sweep when readRegulatoryStatus throws', async () => {
+      const failing = makeRecord({ id: 'rec-fail', regulatoryStatus: 'submitted' });
+      const ok = makeRecord({ id: 'rec-ok', regulatoryStatus: 'submitted' });
+      const reader = readerAdapter((record) =>
+        record.id === 'rec-fail'
+          ? Promise.reject(new Error('boom'))
+          : Promise.resolve({ regulatoryStatus: 'accepted', clearanceReference: null }),
+      );
+      integrations.getCapabilityAdapter.mockResolvedValue(reader);
+      repo.findIssuedNonTerminal.mockResolvedValue({ items: [failing, ok], total: 2 });
+
+      const result = await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      expect(result.readErrors).toBe(1);
+      // The sweep continued and reconciled the second record.
+      expect(repo.updateOutcome).toHaveBeenCalledWith('rec-ok', { regulatoryStatus: 'accepted' });
+      expect(result.updated).toBe(1);
+    });
+
+    it('logs only connectionId + record.id + error.name / bounded message — never the raw provider string (8d)', async () => {
+      const longSecret = 'X'.repeat(2000);
+      const reader = readerAdapter(() => Promise.reject(new Error(longSecret)));
+      integrations.getCapabilityAdapter.mockResolvedValue(reader);
+      repo.findIssuedNonTerminal.mockResolvedValue({
+        items: [makeRecord({ id: 'rec-secret', regulatoryStatus: 'submitted' })],
+        total: 1,
+      });
+
+      const errorSpy = jest
+        .spyOn(
+          (service as unknown as { logger: { error: (m: string) => void } }).logger,
+          'error',
+        )
+        .mockImplementation(() => undefined);
+
+      await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const logged = errorSpy.mock.calls[0][0];
+      expect(logged).toContain(CONNECTION_ID);
+      expect(logged).toContain('rec-secret');
+      expect(logged).toContain('Error');
+      // The raw, unbounded provider message must never reach the log sink.
+      expect(logged).not.toContain(longSecret);
+      expect(logged).toContain('…[truncated]');
+    });
+
+    it('returns normally (does not re-throw) when a per-record read throws, so nothing reaches the handler (8e)', async () => {
+      const reader = readerAdapter(() => Promise.reject(new Error('provider down')));
+      integrations.getCapabilityAdapter.mockResolvedValue(reader);
+      repo.findIssuedNonTerminal.mockResolvedValue({
+        items: [makeRecord({ regulatoryStatus: 'submitted' })],
+        total: 1,
+      });
+
+      await expect(service.reconcile(CONNECTION_ID, { limit: 50 })).resolves.toMatchObject({
+        readErrors: 1,
+      });
+    });
+  });
+
+  describe('eventual coverage (decision #5 / #8f)', () => {
+    it('reads the limit oldest-by-updatedAt rows when total > limit, and a follow-up run reaches the rest (no permanent skip)', async () => {
+      const reader = readerAdapter({ regulatoryStatus: 'accepted', clearanceReference: null });
+      integrations.getCapabilityAdapter.mockResolvedValue(reader);
+
+      // First run: repo returns the first page (limit=1) of a total of 2.
+      repo.findIssuedNonTerminal.mockResolvedValueOnce({
+        items: [makeRecord({ id: 'rec-old', regulatoryStatus: 'submitted' })],
+        total: 2,
+      });
+      const first = await service.reconcile(CONNECTION_ID, { limit: 1 });
+      expect(first.total).toBe(2);
+      expect(first.updated).toBe(1);
+
+      // Second run (rec-old now terminal, dropped out): the previously-unreached
+      // row surfaces — no permanent skip.
+      repo.findIssuedNonTerminal.mockResolvedValueOnce({
+        items: [makeRecord({ id: 'rec-new', regulatoryStatus: 'submitted' })],
+        total: 1,
+      });
+      const second = await service.reconcile(CONNECTION_ID, { limit: 1 });
+      expect(second.total).toBe(1);
+      expect(repo.updateOutcome).toHaveBeenCalledWith('rec-new', { regulatoryStatus: 'accepted' });
+    });
+  });
+
+  describe('idempotency', () => {
+    it('a re-run with no upstream change is a clean no-op (no updateOutcome calls)', async () => {
+      const record = makeRecord({ regulatoryStatus: 'submitted', clearanceReference: 'KSEF-9' });
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        readerAdapter({ regulatoryStatus: 'submitted', clearanceReference: 'KSEF-9' }),
+      );
+      repo.findIssuedNonTerminal.mockResolvedValue({ items: [record], total: 1 });
+
+      await service.reconcile(CONNECTION_ID, { limit: 50 });
+      await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      expect(repo.updateOutcome).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/core/src/invoicing/application/services/regulatory-status-reconciliation.service.ts
+++ b/libs/core/src/invoicing/application/services/regulatory-status-reconciliation.service.ts
@@ -1,0 +1,208 @@
+/**
+ * Regulatory Status Reconciliation Service (#1121)
+ *
+ * Core application service that refreshes `InvoiceRecord.regulatoryStatus` /
+ * `clearanceReference` for one connection's `issued`, NON-terminal records by
+ * reading authoritative provider/CTC status via the read-only
+ * `RegulatoryStatusReader` ADR-002 sub-capability. The read is AUTHORITATIVE;
+ * terminal reads are written back so reconciled rows drop out of the next sweep.
+ * Depends ONLY on ports (`InvoiceRecordRepositoryPort` + `IIntegrationsService`),
+ * never concrete adapters; nothing from `libs/integrations` is imported. No
+ * `faktura`/`ksef`/`NIP` vocabulary lives here.
+ *
+ * Paging is offset-0 every run (NO cursor): the non-terminal frontier is a
+ * SHRINKING set (terminal/changed reads bump `updatedAt`, pushing rows to the
+ * back), so it is walked from the front ordered `updatedAt ASC, id ASC`. A
+ * connection with more non-terminal rows than `limit` is covered across multiple
+ * 30-min ticks — skip-free and starvation-bounded by
+ * `ceil(non_terminal_count / limit)` runs (plan decisions #5/#8f).
+ *
+ * Error & write discipline (plan decision #8):
+ *  - (8a) the defensive terminal skip applies to the RECORD's current status,
+ *    NEVER to the read result; a terminal READ is always written.
+ *  - (8b) `clearanceReference` is monotonic: the patch OMITS the key unless the
+ *    read returns a non-null, changed value (Object.assign would clobber).
+ *  - (8c) write-on-change; empty patch is a no-op.
+ *  - (8d) per-record read errors are caught, counted, and logged BOUNDED
+ *    (ids + error.name / sanitized message only) — never the raw provider string.
+ *  - (8e) no raw-provider-error re-throw past the per-record loop.
+ *
+ * @module libs/core/src/invoicing/application/services
+ * @implements {IRegulatoryStatusReconciliationService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+} from '@openlinker/core/integrations';
+
+import type {
+  IRegulatoryStatusReconciliationService,
+  RegulatoryStatusReconcileOptions,
+  RegulatoryStatusReconcileResult,
+} from './regulatory-status-reconciliation.service.interface';
+import type { InvoiceRecord } from '../../domain/entities/invoice-record.entity';
+import { InvoiceRecordRepositoryPort } from '../../domain/ports/invoice-record-repository.port';
+import { INVOICE_RECORD_REPOSITORY_TOKEN } from '../../invoicing.tokens';
+import type { InvoicingPort } from '../../domain/ports/invoicing.port';
+import {
+  isRegulatoryStatusReader,
+  type RegulatoryStatusReader,
+} from '../../domain/ports/capabilities/regulatory-status-reader.capability';
+import type { InvoiceOutcomePatch } from '../../domain/types/invoicing.types';
+import { isTerminalRegulatoryStatus } from '../../domain/types/invoicing.types';
+import type { RegulatoryStatusReadResult } from '../../domain/types/regulatory-status-read.types';
+
+/** Capability the connection must declare; the reader is a runtime-detected sub-capability. */
+const INVOICING_CAPABILITY = 'Invoicing';
+
+/**
+ * Max length of a sanitized, operator-facing read-error diagnostic. A
+ * `RegulatoryStatusReader` adapter is third-party-shaped and its error may echo
+ * buyer/KSeF-side data — bound it before logging (same idiom as `InvoiceService`).
+ */
+const MAX_ERROR_MESSAGE_LENGTH = 500;
+
+@Injectable()
+export class RegulatoryStatusReconciliationService
+  implements IRegulatoryStatusReconciliationService
+{
+  private readonly logger = new Logger(RegulatoryStatusReconciliationService.name);
+
+  constructor(
+    @Inject(INVOICE_RECORD_REPOSITORY_TOKEN)
+    private readonly repo: InvoiceRecordRepositoryPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+  ) {}
+
+  async reconcile(
+    connectionId: string,
+    opts: RegulatoryStatusReconcileOptions,
+  ): Promise<RegulatoryStatusReconcileResult> {
+    const result: RegulatoryStatusReconcileResult = {
+      scanned: 0,
+      updated: 0,
+      skippedTerminal: 0,
+      readErrors: 0,
+      total: 0,
+    };
+
+    // Resolve the per-connection Invoicing adapter. The reader is a runtime
+    // sub-capability (ADR-002) — an adapter that cannot read regulatory status
+    // is a clean no-op (warn + zeroed result), NEVER a throw: the scheduler
+    // fans out to every Invoicing connection and most never implement it.
+    const adapter = await this.integrations.getCapabilityAdapter<InvoicingPort>(
+      connectionId,
+      INVOICING_CAPABILITY,
+    );
+
+    if (!isRegulatoryStatusReader(adapter)) {
+      this.logger.warn(
+        `Connection ${connectionId} Invoicing adapter does not implement RegulatoryStatusReader — skipping reconciliation (no-op).`,
+      );
+      return result;
+    }
+
+    const { items, total } = await this.repo.findIssuedNonTerminal(connectionId, {
+      limit: opts.limit,
+    });
+    result.total = total;
+
+    for (const record of items) {
+      // (8a) Defensive race guard: the selection predicate already excludes
+      // terminal records, but a concurrent write could have flipped one. The
+      // skip applies to the RECORD's CURRENT status only — never to a read
+      // result (a terminal read is always written, below).
+      if (isTerminalRegulatoryStatus(record.regulatoryStatus)) {
+        result.skippedTerminal += 1;
+        continue;
+      }
+
+      let read: RegulatoryStatusReadResult;
+      try {
+        read = await this.readStatus(adapter, record);
+      } catch (error) {
+        // (8d) Per-record read errors are caught, counted, and logged BOUNDED
+        // (ids + error.name + sanitized message) — never the raw provider
+        // string. (8e) The sweep continues; nothing re-throws past the loop.
+        result.readErrors += 1;
+        const err = error instanceof Error ? error : new Error(String(error));
+        this.logger.error(
+          `Regulatory status read failed (connection=${connectionId}, record=${record.id}): ${err.name}: ${this.sanitizeError(error)}`,
+        );
+        continue;
+      }
+
+      result.scanned += 1;
+
+      // (8b/8c) Write-on-change. The patch omits the clearanceReference key
+      // unless the read returns a non-null, changed value — an empty patch is
+      // a no-op (idempotent, safe to re-run).
+      const patch = this.buildPatch(record, read);
+      if (Object.keys(patch).length === 0) {
+        continue;
+      }
+
+      await this.repo.updateOutcome(record.id, patch);
+      result.updated += 1;
+    }
+
+    return result;
+  }
+
+  /**
+   * Build the outcome patch by CONDITIONAL KEY INSERTION (plan decision #8b/#8c).
+   * `clearanceReference` is set ONLY when the read returns a non-null, changed
+   * value — the key is OMITTED otherwise so `updateOutcome`'s `Object.assign` +
+   * `save` cannot NULL a prior reference. Terminal reads ARE included (#8a).
+   */
+  private buildPatch(
+    record: InvoiceRecord,
+    read: RegulatoryStatusReadResult,
+  ): InvoiceOutcomePatch {
+    const patch: InvoiceOutcomePatch = {};
+
+    // (8a) The read is authoritative — a terminal read IS written so the row
+    // drops out of the next sweep. Only set the key when the status changed.
+    if (read.regulatoryStatus !== record.regulatoryStatus) {
+      patch.regulatoryStatus = read.regulatoryStatus;
+    }
+
+    // (8b) clearanceReference is monotonic: set the key ONLY when the read
+    // returns a non-null, CHANGED value. Omitting the key prevents
+    // `updateOutcome`'s `Object.assign` from clobbering a prior reference with
+    // null (a later read that returns null must not wipe an earlier reference).
+    if (read.clearanceReference !== null && read.clearanceReference !== record.clearanceReference) {
+      patch.clearanceReference = read.clearanceReference;
+    }
+
+    return patch;
+  }
+
+  /**
+   * Read authoritative status for one record via the narrowed reader adapter.
+   * Wrapped by the per-record try/catch in `reconcile` (#8d/#8e).
+   */
+  private async readStatus(
+    adapter: InvoicingPort & RegulatoryStatusReader,
+    record: InvoiceRecord,
+  ): Promise<RegulatoryStatusReadResult> {
+    return adapter.readRegulatoryStatus(record);
+  }
+
+  /**
+   * Length-bounded, operator-facing diagnostic for a per-record read error.
+   * INTERNAL-ONLY; may contain provider-echoed data — never log the raw,
+   * unbounded message to an external sink (#8d).
+   */
+  private sanitizeError(error: unknown): string {
+    const raw = error instanceof Error ? error.message : String(error);
+    if (raw.length <= MAX_ERROR_MESSAGE_LENGTH) {
+      return raw;
+    }
+    const marker = '…[truncated]';
+    return raw.slice(0, MAX_ERROR_MESSAGE_LENGTH - marker.length) + marker;
+  }
+}

--- a/libs/core/src/invoicing/domain/entities/invoice-record.entity.ts
+++ b/libs/core/src/invoicing/domain/entities/invoice-record.entity.ts
@@ -4,9 +4,12 @@
  * OL's projection of a fiscal document issued through a provider for an order
  * on an invoicing connection. Country-agnostic (ADR-026): carries a neutral
  * `documentType`, an issuance `status`, and the neutral regulatory-clearance
- * fields (`regulatoryStatus`/`clearanceReference`) a future `RegulatoryTransmitter`
- * adapter populates (KSeF/SDI/SII) — nullable until then. The provider owns the
- * authoritative document; this is a non-authoritative projection (debug/retry).
+ * fields (`regulatoryStatus`/`clearanceReference`) the read-only
+ * `RegulatoryStatusReader` reconciliation sub-capability populates by reading
+ * authoritative provider/CTC status (KSeF/SDI/SII, #1121) — nullable until first
+ * reconciled. A future `RegulatoryTransmitter` is the separate submit-side
+ * sub-capability. The provider owns the authoritative document; this is a
+ * non-authoritative projection (debug/retry).
  *
  * @module libs/core/src/invoicing/domain/entities
  */

--- a/libs/core/src/invoicing/domain/ports/capabilities/regulatory-status-reader.capability.spec.ts
+++ b/libs/core/src/invoicing/domain/ports/capabilities/regulatory-status-reader.capability.spec.ts
@@ -1,0 +1,11 @@
+/**
+ * Unit tests for the `RegulatoryStatusReader` ADR-002 sub-capability guard
+ * (`isRegulatoryStatusReader`).
+ *
+ * @module libs/core/src/invoicing/domain/ports/capabilities
+ */
+describe('isRegulatoryStatusReader', () => {
+  it.todo('returns true for an Invoicing adapter that implements readRegulatoryStatus');
+  it.todo('returns false for an Invoicing adapter without readRegulatoryStatus');
+  it.todo('returns false when readRegulatoryStatus is present but not a function');
+});

--- a/libs/core/src/invoicing/domain/ports/capabilities/regulatory-status-reader.capability.ts
+++ b/libs/core/src/invoicing/domain/ports/capabilities/regulatory-status-reader.capability.ts
@@ -1,0 +1,43 @@
+/**
+ * Regulatory Status Reader Capability
+ *
+ * Optional READ-ONLY sub-capability of `InvoicingPort` (ADR-002) — adapters that
+ * can read the authoritative provider-/CTC-side regulatory status of a
+ * previously-issued document declare `implements RegulatoryStatusReader`. Used by
+ * the KSeF regulatory-status reconciliation job (#1121) to refresh
+ * `InvoiceRecord.regulatoryStatus` / `clearanceReference` for issued records whose
+ * regulatory status is still non-terminal.
+ *
+ * READ-ONLY by design: it reads status back, it does NOT submit/transmit to the
+ * authority. For Subiekt the bridge only reads (Subiekt transmits to KSeF
+ * natively); the submit side is the still-future, separate `RegulatoryTransmitter`
+ * sub-capability. Detected at runtime by the {@link isRegulatoryStatusReader}
+ * type guard — NOT advertised as a capability string in `supportedCapabilities`
+ * (same idiom as `OfferStatusReader` under `OfferManager`).
+ *
+ * Returns the raw neutral observation only; mapping a regime's native state onto
+ * the neutral `RegulatoryStatus` lifecycle is owned by the adapter. See
+ * `offer-status-reader.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/invoicing/domain/ports/capabilities
+ */
+import type { InvoiceRecord } from '../../entities/invoice-record.entity';
+import type { RegulatoryStatusReadResult } from '../../types/regulatory-status-read.types';
+import type { InvoicingPort } from '../invoicing.port';
+
+export interface RegulatoryStatusReader {
+  /**
+   * Read the authoritative regulatory status for an already-issued record.
+   * The adapter returns a neutral observation already mapped onto
+   * {@link RegulatoryStatusReadResult}.
+   */
+  readRegulatoryStatus(record: InvoiceRecord): Promise<RegulatoryStatusReadResult>;
+}
+
+export function isRegulatoryStatusReader(
+  adapter: InvoicingPort,
+): adapter is InvoicingPort & RegulatoryStatusReader {
+  return (
+    typeof (adapter as Partial<RegulatoryStatusReader>).readRegulatoryStatus === 'function'
+  );
+}

--- a/libs/core/src/invoicing/domain/ports/invoice-record-repository.port.ts
+++ b/libs/core/src/invoicing/domain/ports/invoice-record-repository.port.ts
@@ -35,4 +35,17 @@ export interface InvoiceRecordRepositoryPort {
    * `InvoiceRecordNotFoundException` when the id does not exist.
    */
   updateOutcome(id: string, patch: InvoiceOutcomePatch): Promise<InvoiceRecord>;
+
+  /**
+   * Select `issued` records on the connection whose regulatory status is
+   * NON-terminal (NOT in `TerminalRegulatoryStatusValues` — so receipts /
+   * `not-applicable` are excluded structurally). Ordered `updatedAt ASC, id ASC`
+   * (oldest-reconciled-first), capped at `opts.limit` — NO offset (the
+   * reconciliation frontier is a SHRINKING set, walked from offset 0 every run;
+   * see #1121 plan decision #5). Backs the regulatory-status reconciliation job.
+   */
+  findIssuedNonTerminal(
+    connectionId: string,
+    opts: { limit: number },
+  ): Promise<{ items: InvoiceRecord[]; total: number }>;
 }

--- a/libs/core/src/invoicing/domain/ports/invoicing.port.ts
+++ b/libs/core/src/invoicing/domain/ports/invoicing.port.ts
@@ -7,7 +7,10 @@
  * it issues what the command describes and does not decide whether/when/which
  * document to issue — that policy lives above it in a future rules layer
  * (ADR-026). Regulatory transmission/clearance (KSeF/SDI/…) is a separate
- * ADR-002 sub-capability (`RegulatoryTransmitter`), added when the first such
+ * ADR-002 sub-capability. The READ side is `RegulatoryStatusReader` (#1121),
+ * read-only reconciliation that populates the neutral regulatory fields by
+ * reading authoritative provider/CTC status; the still-future SUBMIT side is
+ * `RegulatoryTransmitter`, added when the first transmitting
  * provider lands — not part of this base contract.
  *
  * @module libs/core/src/invoicing/domain/ports
@@ -34,8 +37,9 @@ export interface InvoicingPort {
   /**
    * Discovery: which neutral document types this provider can issue. Lets the
    * caller adapt without country/provider string-matching (Avalara GetMandates
-   * precedent). Value-level variance — distinct from the method-bearing
-   * `RegulatoryTransmitter` sub-capability.
+   * precedent). Value-level variance, distinct from the method-bearing
+   * regulatory sub-capabilities (`RegulatoryStatusReader` / future
+   * `RegulatoryTransmitter`).
    */
   getSupportedDocumentTypes(): DocumentType[];
 }

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -48,6 +48,25 @@ export const RegulatoryStatusValues = [
 ] as const;
 export type RegulatoryStatus = (typeof RegulatoryStatusValues)[number];
 
+/**
+ * Terminal regulatory statuses — once a record reaches one of these the
+ * reconciliation job (#1121) stops polling it. `not-applicable` (receipts not
+ * sent to a CTC authority) is terminal-from-birth and never polled. Single
+ * source of truth for the non-terminal selection predicate; mirrored in the
+ * repository query and the `IDX_invoice_records_reconcile` partial index.
+ */
+export const TerminalRegulatoryStatusValues = [
+  'accepted',
+  'rejected',
+  'not-applicable',
+] as const;
+export type TerminalRegulatoryStatus = (typeof TerminalRegulatoryStatusValues)[number];
+
+/** True when `status` is a terminal regulatory status (no longer polled). */
+export function isTerminalRegulatoryStatus(status: RegulatoryStatus): boolean {
+  return (TerminalRegulatoryStatusValues as readonly string[]).includes(status);
+}
+
 /** Neutral B2B/B2C axis. Drives document-type policy in a future rules layer, not here. */
 export const BuyerTypeValues = ['company', 'private'] as const;
 export type BuyerType = (typeof BuyerTypeValues)[number];

--- a/libs/core/src/invoicing/domain/types/regulatory-status-read.types.ts
+++ b/libs/core/src/invoicing/domain/types/regulatory-status-read.types.ts
@@ -1,0 +1,24 @@
+/**
+ * Regulatory Status Read Types
+ *
+ * Neutral observation contract for `RegulatoryStatusReader.readRegulatoryStatus`.
+ * An invoicing adapter reports the authoritative provider-/CTC-side regulatory
+ * state of a previously-issued document (KSeF/SDI/SII). The adapter performs the
+ * regime→neutral mapping; OL writes the neutral observation verbatim (subject to
+ * the reconciliation service's write-on-change / monotonicity rules). Mirrors
+ * `OfferStatusReadResult` (#816 / ADR-009).
+ *
+ * READ-ONLY: this sub-capability never transmits to the authority (Subiekt does
+ * that natively); it only reads status back for reconciliation.
+ *
+ * @module libs/core/src/invoicing/domain/types
+ * @see {@link RegulatoryStatusReader} for the capability
+ */
+import type { RegulatoryStatus } from './invoicing.types';
+
+export interface RegulatoryStatusReadResult {
+  /** Neutral CTC clearance status; adapter maps the regime's native state. */
+  regulatoryStatus: RegulatoryStatus;
+  /** Authority-assigned reference (KSeF number, SDI id, …); `null` when none yet. */
+  clearanceReference: string | null;
+}

--- a/libs/core/src/invoicing/index.ts
+++ b/libs/core/src/invoicing/index.ts
@@ -9,13 +9,22 @@
  * @module libs/core/src/invoicing
  */
 export * from './domain/types/invoicing.types';
+export * from './domain/types/regulatory-status-read.types';
 export * from './domain/entities/buyer-profile.entity';
 export * from './domain/entities/invoice-record.entity';
 export * from './domain/ports/invoicing.port';
 export * from './domain/ports/invoice-record-repository.port';
+export type { RegulatoryStatusReader } from './domain/ports/capabilities/regulatory-status-reader.capability';
+export { isRegulatoryStatusReader } from './domain/ports/capabilities/regulatory-status-reader.capability';
 export * from './domain/exceptions/invoice-record-not-found.exception';
 export * from './domain/exceptions/duplicate-invoice-record.exception';
 export { IInvoiceService } from './application/services/invoice.service.interface';
 export { InvoiceService } from './application/services/invoice.service';
+export type {
+  IRegulatoryStatusReconciliationService,
+  RegulatoryStatusReconcileOptions,
+  RegulatoryStatusReconcileResult,
+} from './application/services/regulatory-status-reconciliation.service.interface';
+export { RegulatoryStatusReconciliationService } from './application/services/regulatory-status-reconciliation.service';
 export * from './invoicing.tokens';
 export { InvoicingModule } from './invoicing.module';

--- a/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
@@ -2,10 +2,13 @@
  * Invoice Record ORM Entity
  *
  * TypeORM entity for the `invoice_records` table. The `regulatoryStatus` /
- * `clearanceReference` columns are nullable and unused until a future
- * `RegulatoryTransmitter` adapter populates them (ADR-026) — carried now so
- * adding transmission needs no migration. The partial-unique index on
- * `(connectionId, idempotencyKey)` is the durable exactly-once issue guard.
+ * `clearanceReference` columns are populated by the read-only
+ * `RegulatoryStatusReader` reconciliation sub-capability, which reads
+ * authoritative provider/CTC status (ADR-002 / ADR-026, #1121); a future
+ * `RegulatoryTransmitter` is the separate submit side. The partial-unique index
+ * on `(connectionId, idempotencyKey)` is the durable exactly-once issue guard;
+ * `IDX_invoice_records_reconcile` is the partial composite index that backs the
+ * reconciliation scan (issued + non-terminal, ordered `updatedAt ASC, id ASC`).
  *
  * @module libs/core/src/invoicing/infrastructure/persistence/entities
  * @see {@link InvoiceRecord} for the corresponding domain entity
@@ -34,6 +37,13 @@ import { InvoiceStatus, RegulatoryStatus } from '../../../domain/types/invoicing
 @Index('UQ_invoice_records_connection_idempotency', ['connectionId', 'idempotencyKey'], {
   unique: true,
   where: '"idempotencyKey" IS NOT NULL',
+})
+// Reconciliation scan (#1121): issued + non-terminal regulatory status, ordered
+// `updatedAt ASC, id ASC`, connection-scoped. Partial so terminal/receipt rows
+// (the bulk of the table over time) stay out of the index.
+@Index('IDX_invoice_records_reconcile', ['connectionId', 'updatedAt', 'id'], {
+  where:
+    '"status" = \'issued\' AND "regulatoryStatus" NOT IN (\'accepted\', \'rejected\', \'not-applicable\')',
 })
 export class InvoiceRecordOrmEntity {
   @PrimaryGeneratedColumn('uuid')

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
@@ -22,6 +22,7 @@ import type {
   CreateInvoiceRecordInput,
   InvoiceOutcomePatch,
 } from '../../../domain/types/invoicing.types';
+import { TerminalRegulatoryStatusValues } from '../../../domain/types/invoicing.types';
 import { InvoiceRecordOrmEntity } from '../entities/invoice-record.orm-entity';
 
 @Injectable()
@@ -74,6 +75,31 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
     Object.assign(entity, patch);
     const saved = await this.repository.save(entity);
     return this.toDomain(saved);
+  }
+
+  async findIssuedNonTerminal(
+    connectionId: string,
+    opts: { limit: number },
+  ): Promise<{ items: InvoiceRecord[]; total: number }> {
+    // Selection predicate (single source of truth in `TerminalRegulatoryStatusValues`,
+    // mirrored by the `IDX_invoice_records_reconcile` partial index):
+    //   status = 'issued' AND regulatoryStatus NOT IN (TerminalRegulatoryStatusValues)
+    // Connection-scoped, ordered `updatedAt ASC, id ASC` (oldest-reconciled first),
+    // capped at `opts.limit` with NO offset — the non-terminal frontier is a
+    // shrinking set walked from offset 0 every run (#1121 plan decision #5).
+    const [entities, total] = await this.repository
+      .createQueryBuilder('record')
+      .where('record.connectionId = :connectionId', { connectionId })
+      .andWhere('record.status = :status', { status: 'issued' })
+      .andWhere('record.regulatoryStatus NOT IN (:...terminal)', {
+        terminal: [...TerminalRegulatoryStatusValues],
+      })
+      .orderBy('record.updatedAt', 'ASC')
+      .addOrderBy('record.id', 'ASC')
+      .take(opts.limit)
+      .getManyAndCount();
+
+    return { items: entities.map((e) => this.toDomain(e)), total };
   }
 
   private buildOrmEntity(input: CreateInvoiceRecordInput): InvoiceRecordOrmEntity {

--- a/libs/core/src/invoicing/invoicing.module.ts
+++ b/libs/core/src/invoicing/invoicing.module.ts
@@ -15,14 +15,17 @@ import { IntegrationsModule } from '@openlinker/core/integrations';
 import { InvoiceRecordOrmEntity } from './infrastructure/persistence/entities/invoice-record.orm-entity';
 import { InvoiceRecordRepository } from './infrastructure/persistence/repositories/invoice-record.repository';
 import { InvoiceService } from './application/services/invoice.service';
+import { RegulatoryStatusReconciliationService } from './application/services/regulatory-status-reconciliation.service';
 import {
   INVOICE_RECORD_REPOSITORY_TOKEN,
   INVOICE_SERVICE_TOKEN,
+  REGULATORY_STATUS_RECONCILIATION_SERVICE_TOKEN,
 } from './invoicing.tokens';
 
 export {
   INVOICE_RECORD_REPOSITORY_TOKEN,
   INVOICE_SERVICE_TOKEN,
+  REGULATORY_STATUS_RECONCILIATION_SERVICE_TOKEN,
 } from './invoicing.tokens';
 
 @Module({
@@ -45,7 +48,19 @@ export {
       provide: INVOICE_SERVICE_TOKEN,
       useExisting: InvoiceService,
     },
+    RegulatoryStatusReconciliationService,
+    {
+      provide: REGULATORY_STATUS_RECONCILIATION_SERVICE_TOKEN,
+      useExisting: RegulatoryStatusReconciliationService,
+    },
   ],
-  exports: [INVOICE_RECORD_REPOSITORY_TOKEN, INVOICE_SERVICE_TOKEN],
+  exports: [
+    INVOICE_RECORD_REPOSITORY_TOKEN,
+    INVOICE_SERVICE_TOKEN,
+    // Exported so the worker's SyncWorkerModule can inject the reconciliation
+    // service into RegulatoryStatusReconcileHandler — providing-without-exporting
+    // would fail the worker's DI at boot (#1121 plan decision #12).
+    REGULATORY_STATUS_RECONCILIATION_SERVICE_TOKEN,
+  ],
 })
 export class InvoicingModule {}

--- a/libs/core/src/invoicing/invoicing.tokens.ts
+++ b/libs/core/src/invoicing/invoicing.tokens.ts
@@ -11,3 +11,12 @@ export const INVOICE_RECORD_REPOSITORY_TOKEN = Symbol('InvoiceRecordRepositoryPo
 
 /** Binding token for the {@link IInvoiceService} application service (ADR-026 "SVC"). */
 export const INVOICE_SERVICE_TOKEN = Symbol('IInvoiceService');
+
+/**
+ * Binding token for the {@link IRegulatoryStatusReconciliationService} (#1121).
+ * Refreshes `InvoiceRecord.regulatoryStatus` / `clearanceReference` for issued,
+ * non-terminal records via the `RegulatoryStatusReader` sub-capability.
+ */
+export const REGULATORY_STATUS_RECONCILIATION_SERVICE_TOKEN = Symbol(
+  'IRegulatoryStatusReconciliationService',
+);

--- a/libs/core/src/sync/domain/types/invoicing-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/invoicing-job-payloads.types.ts
@@ -1,0 +1,19 @@
+/**
+ * Invoicing Job Payload Types
+ *
+ * Canonical payload schemas for invoicing.* sync jobs (core-owned,
+ * capability-scoped; executed by the worker).
+ *
+ * @module libs/core/src/sync/domain/types
+ */
+
+/**
+ * Payload for `invoicing.regulatoryStatus.reconcile` (#1121). Carries only the
+ * page size — there is NO cursor: the reconciliation frontier is a shrinking set
+ * walked from offset 0 every run (plan decision #5).
+ */
+export interface RegulatoryStatusReconcilePayloadV1 {
+  schemaVersion: 1;
+  /** Page size: max number of non-terminal records to reconcile this run. */
+  limit: number;
+}

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -39,6 +39,10 @@ export const JobTypeValues = [
   // Shipping (core-owned; capability-scoped, executed by worker)
   'shipping.pickupPoint.refreshFrequent',
 
+  // Invoicing (core-owned; capability-scoped, executed by worker)
+  // KSeF regulatory-status reconciliation sweep (#1121).
+  'invoicing.regulatoryStatus.reconcile',
+
   // Internal orchestration (core-owned policies; executed by worker)
   'inventory.propagateToMarketplaces',
 ] as const;

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -89,6 +89,7 @@ export {
   ShopProductPublishPayloadV2,
   ShopProductPublishPayload,
 } from './domain/types/shop-job-payloads.types';
+export { RegulatoryStatusReconcilePayloadV1 } from './domain/types/invoicing-job-payloads.types';
 
 // Exceptions
 export { SyncJobExecutionError } from './domain/exceptions/sync-job-execution.error';


### PR DESCRIPTION
## What
Scheduled KSeF regulatory-status reconciliation job — refreshes `InvoiceRecord.regulatoryStatus` (+ `clearanceReference`) for `issued` records stuck in a non-terminal regulatory state.

`Closes #1121`

> **Stacked on #1118** (PR #1173). Base `1118-invoice-service`; retarget to `main` after #1118 merges.

## How
- **Scheduling:** a core, capability-scoped sweep in `SchedulerService` (structural twin of the pickup-point refresh) — fans out one per-connection job over connections that support `Invoicing`; adapters lacking the read sub-capability no-op.
- **New read-only `RegulatoryStatusReader` ADR-002 sub-capability** (+ `isRegulatoryStatusReader` guard, cloned from the `OfferStatusReader` idiom). Subiekt's bridge only READS status (Subiekt transmits to KSeF natively) → this is read-only reconciliation, **not** `submitForClearance`, and is **not** folded into the base `InvoicingPort`.
- **Core `RegulatoryStatusReconciliationService`:** resolves the connection's `Invoicing` adapter, narrows via the guard, reads authoritative status per record, persists via `updateOutcome`. Read is authoritative; terminal states (`accepted`/`rejected`/`not-applicable`) drop out of the scan.
- **`findIssuedNonTerminal`** query (offset 0, `ORDER BY updatedAt ASC` — shrinking-set safe, **no cursor**) excludes `not-applicable` (receipts) so they're never polled. New partial-index migration backs the scan. Monotonic `clearanceReference` (omit the key when the read is null). Bounded / PII-safe error logging.
- Thin worker handler delegates to the core service.

## Verification
- **type-check** clean; **worker 173** + **core 1220** unit tests; **lint 0 errors**.
- DI-boot + reconcile-query integration specs run under Testcontainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txy9aqLujJBG1dSwGd4z3f
