### PR TITLE
feat(web): order-detail invoice panel + manual issue/retry (#757)

### DIFF
--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -33,6 +33,7 @@ import { createCursorsApi, type CursorsApi } from '../../features/cursors/api/cu
 import { createCustomersApi, type CustomersApi } from '../../features/customers/api/customers.api';
 import { createHealthApi, type HealthApi } from '../../features/health/api/health.api';
 import { createInventoryApi, type InventoryApi } from '../../features/inventory/api/inventory.api';
+import { createInvoicingApi, type InvoicingApi } from '../../features/invoicing/api/invoicing.api';
 import { createListingsApi, type ListingsApi } from '../../features/listings/api/listings.api';
 import { createOrdersApi, type OrdersApi } from '../../features/orders/api/orders.api';
 import { createProductsApi, type ProductsApi } from '../../features/products/api/products.api';
@@ -96,6 +97,7 @@ export interface CoreApiClient {
   customers: CustomersApi;
   health: HealthApi;
   inventory: InventoryApi;
+  invoicing: InvoicingApi;
   listings: ListingsApi;
   orders: OrdersApi;
   products: ProductsApi;
@@ -242,6 +244,7 @@ export function createApiClient({
     customers: createCustomersApi(request),
     health: createHealthApi(request),
     inventory: createInventoryApi(request),
+    invoicing: createInvoicingApi(request),
     listings: createListingsApi(request),
     mappings: createMappingsApi(request),
     orders: createOrdersApi(request),

--- a/apps/web/src/features/invoicing/api/invoicing.api.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.api.ts
@@ -1,0 +1,46 @@
+/**
+ * Invoicing API Client (#757)
+ *
+ * Thin API module for the invoicing feature, consuming the #1119 HTTP API:
+ *   - `GET /orders/:orderId/invoice?connectionId=…`
+ *   - `POST /invoices`
+ *
+ * `list` (`GET /invoices`) is intentionally NOT added — the /invoices list page
+ * is #758, out of scope here.
+ *
+ * @module apps/web/src/features/invoicing/api
+ */
+import type { InvoiceRecord, IssueInvoiceInput } from './invoicing.types';
+
+export interface InvoicingApi {
+  /** `GET /orders/{orderId}/invoice?connectionId=…` — the single invoice
+   *  projection for an order + invoicing connection. 404 when no invoice row
+   *  exists (mapped to `not-issued` by the query hook). */
+  getForOrder: (orderId: string, connectionId: string) => Promise<InvoiceRecord>;
+  /** `POST /invoices` — manual issue (and failed-row retry). */
+  issue: (input: IssueInvoiceInput) => Promise<InvoiceRecord>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
+
+export function createInvoicingApi(request: ApiRequest): InvoicingApi {
+  return {
+    getForOrder(orderId, connectionId): Promise<InvoiceRecord> {
+      const params = new URLSearchParams({ connectionId });
+      return request<InvoiceRecord>(
+        `/orders/${encodeURIComponent(orderId)}/invoice?${params.toString()}`,
+      );
+    },
+    issue(input): Promise<InvoiceRecord> {
+      return request<InvoiceRecord>('/invoices', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(input),
+      });
+    },
+  };
+}

--- a/apps/web/src/features/invoicing/api/invoicing.query-keys.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.query-keys.ts
@@ -1,0 +1,10 @@
+/**
+ * Invoicing query keys (#757)
+ *
+ * @module apps/web/src/features/invoicing/api
+ */
+export const invoicingQueryKeys = {
+  all: ['invoicing'] as const,
+  forOrder: (orderId: string, connectionId: string) =>
+    ['invoicing', 'order', orderId, connectionId] as const,
+};

--- a/apps/web/src/features/invoicing/api/invoicing.types.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.types.ts
@@ -1,0 +1,83 @@
+/**
+ * Invoicing transport types (#757)
+ *
+ * Hand-mirrored from the #1119 backend DTOs (FE-001 contract strategy). Closed
+ * `as const` enum arrays for the well-known vocabularies; the `documentType`
+ * POST field stays an open `string` at the boundary (open-world pass-through,
+ * plan §1.7).
+ *
+ * Verified against `invoicing.controller.ts` `toDto` (lines 315-333): the
+ * response DTO OMITS `errorMessage` and `idempotencyKey` (PII / dedup-internal).
+ *
+ * @module apps/web/src/features/invoicing/api
+ */
+
+/** Backend invoice lifecycle statuses (no FE-derived `not-issued` — that is the
+ *  absence of a row, modelled as `null` from the query). */
+export const InvoiceStatusValues = ['pending', 'issued', 'failed'] as const;
+export type InvoiceStatus = (typeof InvoiceStatusValues)[number];
+
+/** Regulatory (KSeF) clearance statuses. `not-applicable` is the verified
+ *  default sentinel — the panel's badge gate keys on `!== 'not-applicable'`. */
+export const RegulatoryStatusValues = [
+  'not-applicable',
+  'submitted',
+  'cleared',
+  'accepted',
+  'rejected',
+] as const;
+export type RegulatoryStatus = (typeof RegulatoryStatusValues)[number];
+
+/** Well-known document types. The POST field type stays `string` (open-world);
+ *  this list drives only the override dropdown's known options. */
+export const DocumentTypeValues = [
+  'invoice',
+  'receipt',
+  'credit-note',
+  'corrected',
+  'proforma',
+  'prepayment',
+] as const;
+export type DocumentType = (typeof DocumentTypeValues)[number];
+
+/**
+ * Exact field set of `InvoiceRecordResponseDto` (verified against `toDto`
+ * lines 317-333). Dates are ISO strings; nullables `| null`.
+ * NO `errorMessage`, NO `idempotencyKey`.
+ */
+export interface InvoiceRecord {
+  id: string;
+  connectionId: string;
+  orderId: string;
+  providerType: string;
+  documentType: string;
+  status: InvoiceStatus;
+  providerInvoiceId: string | null;
+  providerInvoiceNumber: string | null;
+  regulatoryStatus: RegulatoryStatus;
+  clearanceReference: string | null;
+  pdfUrl: string | null;
+  issuedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** `POST /invoices` request body. No `idempotencyKey` in v1 (the controller
+ *  owns failed-row dedup — plan §1.1/§7). `buyerTaxId` typed but not surfaced
+ *  in the v1 UI. */
+export interface IssueInvoiceInput {
+  connectionId: string;
+  orderId: string;
+  documentType?: string;
+  buyerTaxId?: { scheme: string; value: string };
+}
+
+/**
+ * Structured error body shape used to type-narrow `ApiError.details` for the
+ * capability-disabled discriminator (plan §2.6). The capability filter emits
+ * `{ statusCode, error: <ExceptionName>, message }`.
+ */
+export interface CapabilityErrorBody {
+  error?: string;
+  message?: string;
+}

--- a/apps/web/src/features/invoicing/components/document-type-select.tsx
+++ b/apps/web/src/features/invoicing/components/document-type-select.tsx
@@ -1,0 +1,49 @@
+/**
+ * Document Type Select (#757)
+ *
+ * Small controlled `<Select>` of well-known document types — `invoice` /
+ * `receipt` surfaced in PL as faktura / paragon via `t()`. The selected value
+ * feeds `documentType` into the issue call. Ephemeral action input (local
+ * `useState` in the panel), not a persisted form (plan §2.5).
+ *
+ * @module apps/web/src/features/invoicing/components
+ */
+import type { ReactElement } from 'react';
+import { Select } from '../../../shared/ui/select';
+import { useTranslation } from '../../../shared/i18n';
+
+/** Operator-selectable document types in v1 (subset of `DocumentTypeValues`). */
+const OPTIONS = ['invoice', 'receipt'] as const;
+
+const LABEL_FALLBACK: Record<(typeof OPTIONS)[number], string> = {
+  invoice: 'Invoice (faktura)',
+  receipt: 'Receipt (paragon)',
+};
+
+interface DocumentTypeSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+export function DocumentTypeSelect({
+  value,
+  onChange,
+  disabled = false,
+}: DocumentTypeSelectProps): ReactElement {
+  const { t } = useTranslation();
+  return (
+    <Select
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+      aria-label={t('invoice.documentType.label', 'Document type')}
+    >
+      {OPTIONS.map((option) => (
+        <option key={option} value={option}>
+          {t(`invoice.documentType.${option}`, LABEL_FALLBACK[option])}
+        </option>
+      ))}
+    </Select>
+  );
+}

--- a/apps/web/src/features/invoicing/components/invoice-pdf-link.test.tsx
+++ b/apps/web/src/features/invoicing/components/invoice-pdf-link.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * InvoicePdfLink — scheme-guard tests (#757)
+ *
+ * Security invariant (plan §1.9): `pdfUrl` is adapter-controlled and reaches the
+ * FE with no server-side scheme validation. The component renders an anchor ONLY
+ * for http:/https:; any other scheme degrades to copy-text so a `javascript:`
+ * payload can NEVER become an `href`.
+ */
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import { renderWithProviders } from '../../../test/test-utils';
+import { InvoicePdfLink } from './invoice-pdf-link';
+
+afterEach(cleanup);
+
+const NUMBER = 'FV/2026/06/001';
+
+describe('InvoicePdfLink', () => {
+  it('https:// pdfUrl ⇒ renders an anchor with target=_blank rel=noopener noreferrer', () => {
+    renderWithProviders(
+      <InvoicePdfLink invoiceNumber={NUMBER} pdfUrl="https://subiekt.example/inv/1.pdf" />,
+    );
+    const anchor = screen.getByRole('link');
+    expect(anchor).toHaveAttribute('href', 'https://subiekt.example/inv/1.pdf');
+    expect(anchor).toHaveAttribute('target', '_blank');
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(anchor).toHaveTextContent(NUMBER);
+  });
+
+  it('http:// pdfUrl ⇒ renders an anchor', () => {
+    renderWithProviders(<InvoicePdfLink invoiceNumber={NUMBER} pdfUrl="http://host/x.pdf" />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'http://host/x.pdf');
+  });
+
+  it('javascript:alert(1) pdfUrl ⇒ NO anchor, number as copy-text', () => {
+    renderWithProviders(<InvoicePdfLink invoiceNumber={NUMBER} pdfUrl="javascript:alert(1)" />);
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByText(NUMBER)).toBeInTheDocument();
+  });
+
+  it('data:text/html,… pdfUrl ⇒ NO anchor, copy-text', () => {
+    renderWithProviders(
+      <InvoicePdfLink invoiceNumber={NUMBER} pdfUrl="data:text/html,<script>1</script>" />,
+    );
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByText(NUMBER)).toBeInTheDocument();
+  });
+
+  it('whitespace-prefixed "  javascript:alert(1)" ⇒ NO anchor, copy-text', () => {
+    renderWithProviders(
+      <InvoicePdfLink invoiceNumber={NUMBER} pdfUrl="  javascript:alert(1)" />,
+    );
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByText(NUMBER)).toBeInTheDocument();
+  });
+
+  it('null / malformed pdfUrl ⇒ copy-text fallback', () => {
+    renderWithProviders(<InvoicePdfLink invoiceNumber={NUMBER} pdfUrl={null} />);
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByText(NUMBER)).toBeInTheDocument();
+    cleanup();
+    renderWithProviders(<InvoicePdfLink invoiceNumber={NUMBER} pdfUrl="not-a-url" />);
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+});

--- a/apps/web/src/features/invoicing/components/invoice-pdf-link.tsx
+++ b/apps/web/src/features/invoicing/components/invoice-pdf-link.tsx
@@ -1,0 +1,53 @@
+/**
+ * Invoice PDF Link (#757)
+ *
+ * Renders the issued invoice's `providerInvoiceNumber` as either an external
+ * link to `pdfUrl` OR copy-text-only, mirroring `ShipmentTrackingLink`.
+ *
+ * SECURITY (plan §1.9): `pdfUrl` is adapter-controlled and reaches the FE with
+ * NO server-side scheme validation. React JSX does not sanitize `href`, so the
+ * FE treats it as untrusted and renders the anchor only when the scheme is
+ * `http:` / `https:`. Any other scheme (`javascript:`, `data:`, …) or malformed
+ * value degrades to copy-text — a `javascript:`-scheme `pdfUrl` NEVER becomes an
+ * `href`.
+ *
+ * @module apps/web/src/features/invoicing/components
+ */
+import type { ReactElement } from 'react';
+import { useTranslation } from '../../../shared/i18n';
+
+/** True only for `http:` / `https:` absolute URLs. Rejects `javascript:`,
+ *  `data:`, `vbscript:`, relative / garbage strings, and whitespace-prefixed
+ *  payloads (`new URL().protocol` is the stricter form). */
+export function isSafeHttpUrl(value: string): boolean {
+  try {
+    return ['http:', 'https:'].includes(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+}
+
+interface InvoicePdfLinkProps {
+  invoiceNumber: string | null;
+  pdfUrl: string | null;
+}
+
+export function InvoicePdfLink({ invoiceNumber, pdfUrl }: InvoicePdfLinkProps): ReactElement {
+  const { t } = useTranslation();
+
+  if (pdfUrl && isSafeHttpUrl(pdfUrl)) {
+    return (
+      <a
+        href={pdfUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="invoice-pdf-link"
+        aria-label={t('invoice.pdf.aria', 'Open invoice PDF (opens in new tab)')}
+      >
+        <span className="mono-text">{invoiceNumber}</span>
+      </a>
+    );
+  }
+
+  return <span className="mono-text">{invoiceNumber}</span>;
+}

--- a/apps/web/src/features/invoicing/components/invoice-status-badge.test.tsx
+++ b/apps/web/src/features/invoicing/components/invoice-status-badge.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * InvoiceStatusBadge — tone/label tests (#757)
+ *
+ * Maps each display status to a StatusBadge tone + label; `pending` pulses.
+ */
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import { renderWithProviders } from '../../../test/test-utils';
+import { InvoiceStatusBadge } from './invoice-status-badge';
+
+afterEach(cleanup);
+
+describe('InvoiceStatusBadge', () => {
+  it('not-issued ⇒ neutral tone, "Not issued" label', () => {
+    renderWithProviders(<InvoiceStatusBadge status="not-issued" />);
+    const badge = screen.getByText('Not issued');
+    expect(badge).toBeInTheDocument();
+    expect(badge.closest('.status-badge')).toHaveClass('status-badge--neutral');
+  });
+
+  it('pending ⇒ warning tone, pulsing dot', () => {
+    renderWithProviders(<InvoiceStatusBadge status="pending" />);
+    const badge = screen.getByText('Pending').closest('.status-badge');
+    expect(badge).toHaveClass('status-badge--warning');
+    expect(badge).toHaveClass('status-badge--pulse');
+  });
+
+  it('issued ⇒ success tone', () => {
+    renderWithProviders(<InvoiceStatusBadge status="issued" />);
+    expect(screen.getByText('Issued').closest('.status-badge')).toHaveClass(
+      'status-badge--success',
+    );
+  });
+
+  it('failed ⇒ error tone', () => {
+    renderWithProviders(<InvoiceStatusBadge status="failed" />);
+    expect(screen.getByText('Failed').closest('.status-badge')).toHaveClass('status-badge--error');
+  });
+});

--- a/apps/web/src/features/invoicing/components/invoice-status-badge.tsx
+++ b/apps/web/src/features/invoicing/components/invoice-status-badge.tsx
@@ -1,0 +1,42 @@
+/**
+ * Invoice Status Badge (#757)
+ *
+ * Maps `InvoiceStatus` plus the FE-only derived `not-issued` state to a
+ * `StatusBadge` tone + a `t()`-labelled word. Mirrors `ShipmentStatusBadge`.
+ *
+ * @module apps/web/src/features/invoicing/components
+ */
+import type { ReactElement } from 'react';
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
+import { useTranslation } from '../../../shared/i18n';
+import type { InvoiceStatus } from '../api/invoicing.types';
+
+/** FE display state: the backend statuses plus the invoice-absent state. */
+export type InvoiceDisplayStatus = InvoiceStatus | 'not-issued';
+
+const TONE: Record<InvoiceDisplayStatus, StatusBadgeTone> = {
+  'not-issued': 'neutral',
+  pending: 'warning',
+  issued: 'success',
+  failed: 'error',
+};
+
+const LABEL_FALLBACK: Record<InvoiceDisplayStatus, string> = {
+  'not-issued': 'Not issued',
+  pending: 'Pending',
+  issued: 'Issued',
+  failed: 'Failed',
+};
+
+interface InvoiceStatusBadgeProps {
+  status: InvoiceDisplayStatus;
+}
+
+export function InvoiceStatusBadge({ status }: InvoiceStatusBadgeProps): ReactElement {
+  const { t } = useTranslation();
+  return (
+    <StatusBadge tone={TONE[status]} withDot pulse={status === 'pending'}>
+      {t(`invoice.status.${status}`, LABEL_FALLBACK[status])}
+    </StatusBadge>
+  );
+}

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.test.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * OrderInvoicePanel — component tests (#757)
+ *
+ * Drives the panel through a mocked API client. Asserts the capability +
+ * operator-toggle gate, per-status rendering, the issue flow (payload shape +
+ * success/error toasts), the security-critical PII-non-leak on the
+ * capability-disabled toast, the document-type override, and the data-driven
+ * regulatory badge gate.
+ */
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient, sampleConnection } from '../../../test/test-utils';
+import { ApiError } from '../../../shared/api/api-error';
+import type { Connection } from '../../connections';
+import type { OrderRecord } from '../../orders';
+import type { InvoiceRecord } from '../api/invoicing.types';
+import { OrderInvoicePanel } from './order-invoice-panel';
+
+afterEach(cleanup);
+
+const ORDER_ID = 'ord_1';
+const CONN_ID = 'conn_inv';
+
+const order: OrderRecord = {
+  internalOrderId: ORDER_ID,
+  customerId: null,
+  sourceConnectionId: 'conn_src',
+  sourceEventId: null,
+  orderSnapshot: {},
+  syncStatus: [],
+  syncAttempts: [],
+  recordStatus: 'ready',
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+};
+
+/** An active connection that DECLARES + ENABLES Invoicing. */
+const invoicingConnection: Connection = {
+  ...sampleConnection,
+  id: CONN_ID,
+  name: 'Subiekt GT',
+  status: 'active',
+  enabledCapabilities: ['Invoicing'],
+  supportedCapabilities: ['Invoicing'],
+};
+
+function makeInvoice(over: Partial<InvoiceRecord> = {}): InvoiceRecord {
+  return {
+    id: 'inv_1',
+    connectionId: CONN_ID,
+    orderId: ORDER_ID,
+    providerType: 'subiekt',
+    documentType: 'invoice',
+    status: 'issued',
+    providerInvoiceId: 'pi_1',
+    providerInvoiceNumber: 'FV/2026/06/001',
+    regulatoryStatus: 'not-applicable',
+    clearanceReference: null,
+    pdfUrl: 'https://subiekt.example/inv/1.pdf',
+    issuedAt: '2026-06-02T00:00:00.000Z',
+    createdAt: '2026-06-02T00:00:00.000Z',
+    updatedAt: '2026-06-02T00:00:00.000Z',
+    ...over,
+  };
+}
+
+const notFound = (): ApiError =>
+  new ApiError('No invoice for order', 404, { message: 'No invoice for order' });
+
+describe('OrderInvoicePanel — capability/toggle gate', () => {
+  /** The panel renders a loading skeleton (also `.order-invoice-panel`) until the
+   *  connections query settles, then collapses to `null` when the gate fails.
+   *  Wait for the skeleton to clear before asserting the panel is gone. */
+  async function expectGatedOut(container: HTMLElement): Promise<void> {
+    await waitFor(() =>
+      expect(container.querySelector('.order-invoice-panel--loading')).toBeNull(),
+    );
+    expect(container.querySelector('.order-invoice-panel')).toBeNull();
+  }
+
+  it('renders nothing when Invoicing is supported but NOT enabled', async () => {
+    const conn = { ...invoicingConnection, enabledCapabilities: [], supportedCapabilities: ['Invoicing'] };
+    const { container } = renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([conn]) } }),
+    });
+    await expectGatedOut(container);
+  });
+
+  it('renders nothing when no connection declares Invoicing', async () => {
+    const { container } = renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([sampleConnection]) } }),
+    });
+    await expectGatedOut(container);
+  });
+
+  it('does NOT select a non-active connection even when Invoicing is enabled', async () => {
+    const conn = { ...invoicingConnection, status: 'disabled' as Connection['status'] };
+    const { container } = renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([conn]) } }),
+    });
+    await expectGatedOut(container);
+  });
+
+  it('renders when an active connection has Invoicing enabled', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()) } }),
+    });
+    expect(await screen.findByRole('button', { name: /issue invoice/i })).toBeInTheDocument();
+  });
+
+  it('with >1 candidate: requires an explicit connection pick — no auto-bound Issue, no GET fired', async () => {
+    const a = { ...invoicingConnection, id: 'conn_aaa', name: 'Alpha' };
+    const b = { ...invoicingConnection, id: 'conn_zzz', name: 'Zeta' };
+    const getForOrder = vi.fn().mockRejectedValue(notFound());
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([b, a]) }, invoicing: { getForOrder } }),
+    });
+    // Picker is shown with a placeholder + both connections; no Issue action and
+    // no invoice GET is wired to an arbitrary connection until the operator picks.
+    const picker = await screen.findByRole('combobox', { name: /invoicing connection/i });
+    expect(picker).toHaveValue('');
+    expect(screen.getByRole('option', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Zeta' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /issue invoice|retry/i })).toBeNull();
+    expect(getForOrder).not.toHaveBeenCalled();
+  });
+
+  it('with >1 candidate: picking a connection binds the GET + Issue action to THAT connection', async () => {
+    const user = userEvent.setup();
+    const a = { ...invoicingConnection, id: 'conn_aaa', name: 'Alpha' };
+    const b = { ...invoicingConnection, id: 'conn_zzz', name: 'Zeta' };
+    const getForOrder = vi.fn().mockRejectedValue(notFound());
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([b, a]) }, invoicing: { getForOrder } }),
+    });
+    const picker = await screen.findByRole('combobox', { name: /invoicing connection/i });
+    await user.selectOptions(picker, 'conn_zzz');
+    // GET now fires against the PICKED connection (not the lowest-id [0]).
+    await waitFor(() => expect(getForOrder).toHaveBeenCalledWith(ORDER_ID, 'conn_zzz'));
+    expect(await screen.findByRole('button', { name: /issue invoice/i })).toBeEnabled();
+  });
+});
+
+describe('OrderInvoicePanel — display states', () => {
+  it('not-issued (404) ⇒ "Not issued" badge + enabled Issue button', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()) } }),
+    });
+    expect(await screen.findByText('Not issued')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /issue invoice/i })).toBeEnabled();
+  });
+
+  it('issued ⇒ number + safe PDF link + document type, no action button', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockResolvedValue(makeInvoice()) } }),
+    });
+    const link = await screen.findByRole('link', { name: /invoice pdf/i });
+    expect(link).toHaveAttribute('href', 'https://subiekt.example/inv/1.pdf');
+    expect(screen.getByText(/Invoice \(faktura\)/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /issue invoice|retry/i })).toBeNull();
+  });
+
+  it('issued with javascript: pdfUrl ⇒ number is NOT an href-bearing anchor', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) },
+        invoicing: { getForOrder: vi.fn().mockResolvedValue(makeInvoice({ pdfUrl: 'javascript:alert(1)' })) },
+      }),
+    });
+    expect(await screen.findByText('FV/2026/06/001')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('failed ⇒ error alert with generic copy + enabled Retry button', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) },
+        invoicing: { getForOrder: vi.fn().mockResolvedValue(makeInvoice({ status: 'failed' })) },
+      }),
+    });
+    expect(await screen.findByText(/Issuing this invoice failed/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeEnabled();
+  });
+});
+
+describe('OrderInvoicePanel — issue flow', () => {
+  it('Issue click ⇒ invoicing.issue called with {connectionId, orderId, documentType}, no idempotencyKey', async () => {
+    const user = userEvent.setup();
+    const issue = vi.fn().mockResolvedValue(makeInvoice());
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()), issue } }),
+    });
+    await user.click(await screen.findByRole('button', { name: /issue invoice/i }));
+    await waitFor(() => expect(issue).toHaveBeenCalledTimes(1));
+    const arg = issue.mock.calls[0][0];
+    expect(arg).toEqual({ connectionId: CONN_ID, orderId: ORDER_ID, documentType: 'invoice' });
+    expect(arg).not.toHaveProperty('idempotencyKey');
+  });
+
+  it('document-type override ⇒ selecting receipt passes documentType:"receipt"', async () => {
+    const user = userEvent.setup();
+    const issue = vi.fn().mockResolvedValue(makeInvoice({ documentType: 'receipt' }));
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()), issue } }),
+    });
+    await screen.findByRole('button', { name: /issue invoice/i });
+    await user.selectOptions(screen.getByRole('combobox', { name: /document type/i }), 'receipt');
+    await user.click(screen.getByRole('button', { name: /issue invoice/i }));
+    await waitFor(() => expect(issue).toHaveBeenCalled());
+    expect(issue.mock.calls[0][0].documentType).toBe('receipt');
+  });
+
+  it('issue capability-disabled 400 ⇒ friendly copy AND DOM does NOT leak connectionId/adapterKey', async () => {
+    const user = userEvent.setup();
+    const leaky = "Capability 'Invoicing' not enabled for connection conn_inv (adapter subiekt-gt)";
+    const issue = vi
+      .fn()
+      .mockRejectedValue(new ApiError(leaky, 400, { error: 'CapabilityNotEnabledException', message: leaky }));
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()), issue } }),
+    });
+    await user.click(await screen.findByRole('button', { name: /issue invoice/i }));
+    expect(await screen.findByText(/Invoicing is not enabled for this connection/i)).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain('adapter subiekt-gt');
+  });
+});
+
+describe('OrderInvoicePanel — regulatory badge (data gate)', () => {
+  it('shows the regulatory badge when regulatoryStatus !== "not-applicable"', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) },
+        invoicing: { getForOrder: vi.fn().mockResolvedValue(makeInvoice({ regulatoryStatus: 'submitted' })) },
+      }),
+    });
+    expect(await screen.findByText(/KSeF: submitted/i)).toBeInTheDocument();
+  });
+
+  it('hides the regulatory badge when regulatoryStatus === "not-applicable"', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockResolvedValue(makeInvoice()) } }),
+    });
+    await screen.findByRole('link', { name: /invoice pdf/i });
+    expect(screen.queryByText(/KSeF:/i)).toBeNull();
+  });
+});

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
@@ -1,0 +1,297 @@
+/**
+ * Order Invoice Panel (#757)
+ *
+ * Order-detail panel for the invoicing lifecycle: status badge + invoice number
+ * (+ scheme-guarded PDF link) + document type + regulatory (KSeF) badge +
+ * status-gated Issue / Retry action and a document-type override.
+ *
+ * Capability-gated globally: renders only when at least one connection is
+ * `status === 'active'` AND has `Invoicing` in `enabledCapabilities` (the #759
+ * operator-toggle field — plan §1.5). A supported-but-disabled connection is
+ * correctly NOT selected, so the Issue button is never presented for it.
+ *
+ * MULTIPLE INVOICING CONNECTIONS: the invoice projection is keyed by
+ * (orderId, invoicingConnectionId) and the invoicing connection is NOT
+ * derivable from the order's `sourceConnectionId` (verified:
+ * invoicing.controller.ts getInvoiceForOrder docstring). When exactly one
+ * active+enabled invoicing connection exists we bind to it (the common
+ * deployment). When MORE THAN ONE exists there is no safe default: silently
+ * picking one (e.g. the lowest-id) risks querying the wrong connection — the
+ * panel would render "Not issued" for an order whose invoice lives on another
+ * connection and a one-click Issue would create a DUPLICATE on the wrong
+ * connection. So with >1 match the operator MUST explicitly pick the invoicing
+ * connection before any GET/POST is wired; no action is bound to an arbitrary
+ * connection.
+ *
+ * AC-5 DESCOPE (must be carried in the PR description, not just here): a true
+ * re-issue — a NEW invoice while the original stays in Subiekt — is blocked by
+ * the #1119 backend. `POST /invoices` throws `ConflictException` (HTTP 409) when
+ * an invoice for the order is already `issued` (verified: invoicing.controller.ts
+ * issueInvoice). With no backend path to create a second invoice, the `issued`
+ * state is READ-ONLY and the re-issue button + confirmation modal are deferred
+ * to a follow-up that depends on a backend change (plan §0.A/§1.1). The POST
+ * action therefore covers only not-issued (no row) and failed (server
+ * re-attempts) as a single Issue / Retry button.
+ *
+ * First order-detail panel to adopt the `t()` i18n seam (deliberate divergence
+ * from `OrderShipmentPanel`'s hardcoded English — plan §1.8).
+ *
+ * @module apps/web/src/features/invoicing/components
+ */
+import { useMemo, useState, type ReactElement } from 'react';
+
+import { useConnectionsQuery, type Connection } from '../../connections';
+import { useTranslation } from '../../../shared/i18n';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { Select } from '../../../shared/ui/select';
+import { ApiError } from '../../../shared/api/api-error';
+
+import type { OrderRecord } from '../../orders';
+import { useOrderInvoiceQuery } from '../hooks/use-order-invoice-query';
+import { useIssueInvoiceMutation } from '../hooks/use-issue-invoice-mutation';
+import { resolveIssueErrorMessage } from '../lib/issue-error-message';
+import { InvoiceStatusBadge, type InvoiceDisplayStatus } from './invoice-status-badge';
+import { RegulatoryStatusBadge } from './regulatory-status-badge';
+import { DocumentTypeSelect } from './document-type-select';
+import { InvoicePdfLink } from './invoice-pdf-link';
+
+const INVOICING_CAPABILITY = 'Invoicing';
+
+/** EN fallbacks for the issued-state document-type line (PL via t()). Unknown
+ *  adapter-supplied types fall back to the raw string (open-world). */
+const DOCUMENT_TYPE_LABEL_FALLBACK: Record<string, string> = {
+  invoice: 'Invoice (faktura)',
+  receipt: 'Receipt (paragon)',
+};
+
+interface OrderInvoicePanelProps {
+  order: OrderRecord;
+}
+
+/**
+ * Resolve the candidate invoicing connections: active + enabled-capability
+ * filter, sorted by `id` (deterministic order for the picker). Returns the full
+ * match list; the panel auto-binds only when there is exactly one (plan §1.5).
+ */
+function selectInvoicingConnections(connections: readonly Connection[]): Connection[] {
+  return connections
+    .filter((c) => c.status === 'active' && c.enabledCapabilities.includes(INVOICING_CAPABILITY))
+    .slice()
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactElement | null {
+  const { t } = useTranslation();
+  const { showToast } = useToast();
+  const connectionsQuery = useConnectionsQuery();
+  const [documentType, setDocumentType] = useState<string>('invoice');
+  // Operator-picked invoicing connection (only meaningful when >1 candidate).
+  const [pickedConnectionId, setPickedConnectionId] = useState<string | null>(null);
+
+  const invoicingConnections = useMemo(
+    () => selectInvoicingConnections(connectionsQuery.data ?? []),
+    [connectionsQuery.data],
+  );
+
+  // Bind to the connection ONLY when it is unambiguous: exactly one candidate
+  // ⇒ auto-bind; more than one ⇒ require an explicit pick (no safe default —
+  // the invoice key is per-connection and not derivable from the order, so a
+  // silent pick risks a duplicate invoice on the wrong connection). Until the
+  // operator picks, no GET/POST is wired to any connection.
+  const invoicingConnection =
+    invoicingConnections.length === 1
+      ? invoicingConnections[0]
+      : (invoicingConnections.find((c) => c.id === pickedConnectionId) ?? null);
+  const invoicingConnectionId = invoicingConnection?.id ?? null;
+
+  const invoiceQuery = useOrderInvoiceQuery(order.internalOrderId, invoicingConnectionId);
+  const issueMutation = useIssueInvoiceMutation();
+
+  // Loading skeleton while connections settle (CLS-avoidance, mirrors the
+  // shipment panel).
+  if (connectionsQuery.isLoading) {
+    return (
+      <section className="detail-section order-invoice-panel order-invoice-panel--loading">
+        <header className="order-invoice-panel__header">
+          <h3 className="detail-section__title">{t('invoice.panel.title', 'Invoice')}</h3>
+        </header>
+        <div className="order-invoice-panel__skeleton" aria-hidden="true" />
+      </section>
+    );
+  }
+
+  // Global capability + operator-toggle gate: no active+enabled invoicing
+  // connection AT ALL ⇒ render nothing. (When candidates exist but none is
+  // picked yet, `invoicingConnection` is null but we still render the picker
+  // below — so gate on the candidate count, not on the resolved connection.)
+  if (invoicingConnections.length === 0) {
+    return null;
+  }
+
+  const requiresConnectionPick = invoicingConnections.length > 1 && !invoicingConnection;
+
+  // Connection picker (shown whenever there is >1 candidate). Rendered as a
+  // small labelled <Select>; until a pick is made the rest of the panel
+  // (status/query/actions) is withheld so nothing is wired to an arbitrary
+  // connection.
+  const connectionPicker =
+    invoicingConnections.length > 1 ? (
+      <div className="order-invoice-panel__connection">
+        <label className="order-invoice-panel__connection-label" htmlFor="invoice-connection">
+          {t('invoice.panel.connectionLabel', 'Invoicing connection')}
+        </label>
+        <Select
+          id="invoice-connection"
+          value={invoicingConnectionId ?? ''}
+          onChange={(event) => setPickedConnectionId(event.target.value || null)}
+          aria-label={t('invoice.panel.connectionLabel', 'Invoicing connection')}
+        >
+          <option value="">
+            {t('invoice.panel.connectionPlaceholder', 'Select a connection…')}
+          </option>
+          {invoicingConnections.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </Select>
+      </div>
+    ) : null;
+
+  // Derive the FE display state (plan §2.6): null → not-issued.
+  const invoice = invoiceQuery.data ?? null;
+  const displayStatus: InvoiceDisplayStatus = invoice ? invoice.status : 'not-issued';
+  const canIssue = displayStatus === 'not-issued' || displayStatus === 'failed';
+  // Regulatory (KSeF) badge gate (plan §1.6). The AC asks for a named-capability
+  // check, but no regulatory-transmission-tracking capability STRING is exported
+  // to the FE yet (`CORE_CAPABILITY_VALUES` has no Invoicing/KSeF entry). Interim
+  // equivalent (verified backend invariant): the backend only emits a
+  // non-`not-applicable` `regulatoryStatus` when the regulatory capability is
+  // active + enabled for the connection, so this data gate can never surface a
+  // badge for a connection where the capability is off.
+  // TODO(#757): swap for `connection.enabledCapabilities.includes(<RegulatoryCapName>)`
+  // once a capability string is named.
+  const showRegulatoryBadge = Boolean(invoice && invoice.regulatoryStatus !== 'not-applicable');
+
+  // Issue flow: optimistic cache-seed + invalidate is owned by the mutation's
+  // onSuccess (use-issue-invoice-mutation). Here we surface the success toast and
+  // reconcile the one race the backend can return: a defensive 409 (the row was
+  // issued by another tab / a concurrent request) means our local view is stale,
+  // so we refetch to flip the panel to `issued` instead of leaving the operator
+  // on a dead Issue button.
+  const handleIssue = (): void => {
+    if (!invoicingConnection) {
+      return;
+    }
+    issueMutation.mutate(
+      { connectionId: invoicingConnection.id, orderId: order.internalOrderId, documentType },
+      {
+        onSuccess: () => {
+          showToast({
+            tone: 'success',
+            title: t('invoice.action.issued', 'Invoice issued'),
+            description: t('invoice.action.issuedBody', 'The invoice was issued in Subiekt.'),
+          });
+        },
+        onError: (error) => {
+          showToast({
+            tone: 'error',
+            title: t('invoice.action.issueFailed', 'Could not issue invoice'),
+            description: resolveIssueErrorMessage(error, t),
+          });
+          // Defensive already-issued / in-progress race → our view is stale.
+          if (error instanceof ApiError && error.status === 409) {
+            void invoiceQuery.refetch();
+          }
+        },
+      },
+    );
+  };
+
+  return (
+    <section className="detail-section order-invoice-panel">
+      <header className="order-invoice-panel__header">
+        <h3 className="detail-section__title">{t('invoice.panel.title', 'Invoice')}</h3>
+        <InvoiceStatusBadge status={displayStatus} />
+        {showRegulatoryBadge && invoice ? (
+          <RegulatoryStatusBadge status={invoice.regulatoryStatus} />
+        ) : null}
+      </header>
+
+      {connectionPicker}
+
+      {/* >1 candidate and no pick yet ⇒ withhold status/query/actions. The
+          invoice key is per-connection and not derivable from the order, so we
+          must not query or wire an Issue against an arbitrary connection. */}
+      {requiresConnectionPick ? (
+        <p className="order-invoice-panel__notice">
+          {t(
+            'invoice.panel.selectConnectionPrompt',
+            'Select the invoicing connection to view or issue this order’s invoice.',
+          )}
+        </p>
+      ) : null}
+
+      {/* Invoice-query states. A transient GET failure must NOT masquerade as
+          not-issued (which would wrongly present the Issue button) — surface a
+          retryable error instead. */}
+      {!requiresConnectionPick && invoiceQuery.isLoading ? (
+        <div className="order-invoice-panel__skeleton" aria-hidden="true" />
+      ) : invoiceQuery.isError ? (
+        <Alert tone="error" className="order-invoice-panel__error">
+          {t('invoice.query.error', 'Could not load the invoice status.')}{' '}
+          <Button
+            tone="secondary"
+            className="button--sm"
+            onClick={() => void invoiceQuery.refetch()}
+          >
+            {t('invoice.query.retry', 'Retry')}
+          </Button>
+        </Alert>
+      ) : null}
+
+      {!requiresConnectionPick && !invoiceQuery.isLoading && !invoiceQuery.isError && displayStatus === 'issued' && invoice ? (
+        // Read-only — no POST action (re-issue backend-blocked, plan §1.1/§0.A).
+        <div className="order-invoice-panel__body">
+          <InvoicePdfLink
+            invoiceNumber={invoice.providerInvoiceNumber}
+            pdfUrl={invoice.pdfUrl}
+          />
+          <p className="order-invoice-panel__doctype">
+            {t('invoice.documentType.label', 'Document type')}:{' '}
+            {t(
+              `invoice.documentType.${invoice.documentType}`,
+              DOCUMENT_TYPE_LABEL_FALLBACK[invoice.documentType] ?? invoice.documentType,
+            )}
+          </p>
+        </div>
+      ) : null}
+
+      {/* The DTO intentionally omits `errorMessage` (PII — see invoicing.types.ts);
+          issue-time failures surface the server message via toast (422/400). The
+          failed branch therefore shows fixed, operator-actionable copy. */}
+      {!requiresConnectionPick && !invoiceQuery.isLoading && !invoiceQuery.isError && displayStatus === 'failed' ? (
+        <Alert tone="error" className="order-invoice-panel__error">
+          {t('invoice.failed.body', 'Issuing this invoice failed. You can retry.')}
+        </Alert>
+      ) : null}
+
+      {!requiresConnectionPick && !invoiceQuery.isLoading && !invoiceQuery.isError && canIssue ? (
+        <div className="order-invoice-panel__actions">
+          <DocumentTypeSelect
+            value={documentType}
+            onChange={setDocumentType}
+            disabled={issueMutation.isPending}
+          />
+          <Button tone="primary" onClick={handleIssue} disabled={issueMutation.isPending}>
+            {displayStatus === 'failed'
+              ? t('invoice.action.retry', 'Retry')
+              : t('invoice.action.issue', 'Issue invoice')}
+          </Button>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
@@ -87,6 +87,10 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
   const { showToast } = useToast();
   const connectionsQuery = useConnectionsQuery();
   const [documentType, setDocumentType] = useState<string>('invoice');
+  // Optional buyer NIP for a B2B (company) invoice. Empty ⇒ B2C/retail document
+  // (no tax id sent). The Order snapshot carries no scheme-tagged tax id, so the
+  // operator supplies it here; presence drives the B2B/B2C axis server-side.
+  const [buyerNip, setBuyerNip] = useState<string>('');
   // Operator-picked invoicing connection (only meaningful when >1 candidate).
   const [pickedConnectionId, setPickedConnectionId] = useState<string | null>(null);
 
@@ -185,8 +189,18 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
     if (!invoicingConnection) {
       return;
     }
+    const trimmedNip = buyerNip.trim();
     issueMutation.mutate(
-      { connectionId: invoicingConnection.id, orderId: order.internalOrderId, documentType },
+      {
+        connectionId: invoicingConnection.id,
+        orderId: order.internalOrderId,
+        documentType,
+        // Presence drives B2B (company) vs B2C (private) server-side. Subiekt
+        // interprets the `pl-nip` scheme as the buyer NIP.
+        ...(trimmedNip.length > 0
+          ? { buyerTaxId: { scheme: 'pl-nip', value: trimmedNip } }
+          : {}),
+      },
       {
         onSuccess: () => {
           showToast({
@@ -284,6 +298,20 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
             value={documentType}
             onChange={setDocumentType}
             disabled={issueMutation.isPending}
+          />
+          <label className="order-invoice-panel__nip-label" htmlFor="invoice-buyer-nip">
+            {t('invoice.buyerNip.label', 'Buyer NIP (optional, B2B)')}
+          </label>
+          <input
+            id="invoice-buyer-nip"
+            className="input"
+            type="text"
+            inputMode="numeric"
+            value={buyerNip}
+            onChange={(event) => setBuyerNip(event.target.value)}
+            disabled={issueMutation.isPending}
+            placeholder="np. 9521471103"
+            aria-label={t('invoice.buyerNip.label', 'Buyer NIP (optional, B2B)')}
           />
           <Button tone="primary" onClick={handleIssue} disabled={issueMutation.isPending}>
             {displayStatus === 'failed'

--- a/apps/web/src/features/invoicing/components/regulatory-status-badge.tsx
+++ b/apps/web/src/features/invoicing/components/regulatory-status-badge.tsx
@@ -1,0 +1,42 @@
+/**
+ * Regulatory (KSeF) Status Badge (#757)
+ *
+ * Maps a `RegulatoryStatus` to a `StatusBadge` tone + `t()` label. Rendered
+ * ONLY by the panel's `regulatoryStatus !== 'not-applicable'` gate (plan §1.6),
+ * so `not-applicable` never reaches here.
+ *
+ * @module apps/web/src/features/invoicing/components
+ */
+import type { ReactElement } from 'react';
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
+import { useTranslation } from '../../../shared/i18n';
+import type { RegulatoryStatus } from '../api/invoicing.types';
+
+const TONE: Record<RegulatoryStatus, StatusBadgeTone> = {
+  'not-applicable': 'neutral',
+  submitted: 'info',
+  cleared: 'success',
+  accepted: 'success',
+  rejected: 'error',
+};
+
+const LABEL_FALLBACK: Record<RegulatoryStatus, string> = {
+  'not-applicable': 'N/A',
+  submitted: 'KSeF: submitted',
+  cleared: 'KSeF: cleared',
+  accepted: 'KSeF: accepted',
+  rejected: 'KSeF: rejected',
+};
+
+interface RegulatoryStatusBadgeProps {
+  status: RegulatoryStatus;
+}
+
+export function RegulatoryStatusBadge({ status }: RegulatoryStatusBadgeProps): ReactElement {
+  const { t } = useTranslation();
+  return (
+    <StatusBadge tone={TONE[status]} withDot pulse={status === 'submitted'}>
+      {t(`invoice.regulatory.${status}`, LABEL_FALLBACK[status])}
+    </StatusBadge>
+  );
+}

--- a/apps/web/src/features/invoicing/hooks/use-issue-invoice-mutation.ts
+++ b/apps/web/src/features/invoicing/hooks/use-issue-invoice-mutation.ts
@@ -1,0 +1,38 @@
+/**
+ * useIssueInvoiceMutation (#757)
+ *
+ * Mutation for `POST /invoices` (manual issue + failed-row retry). On success
+ * invalidates the per-order invoice query and seeds the cache so the panel
+ * flips to issued without a refetch.
+ *
+ * @module apps/web/src/features/invoicing/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { invoicingQueryKeys } from '../api/invoicing.query-keys';
+import type { InvoiceRecord, IssueInvoiceInput } from '../api/invoicing.types';
+
+export function useIssueInvoiceMutation(): UseMutationResult<
+  InvoiceRecord,
+  Error,
+  IssueInvoiceInput
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation<InvoiceRecord, Error, IssueInvoiceInput>({
+    mutationFn: (input) => apiClient.invoicing.issue(input),
+    onSuccess: async (record, input) => {
+      // Seed the cache so the panel flips to the returned status without waiting
+      // on a refetch, then invalidate to reconcile against the server (e.g. a
+      // pending row whose poll will pick up the eventual issued/failed).
+      queryClient.setQueryData(
+        invoicingQueryKeys.forOrder(input.orderId, input.connectionId),
+        record,
+      );
+      await queryClient.invalidateQueries({
+        queryKey: invoicingQueryKeys.forOrder(input.orderId, input.connectionId),
+      });
+    },
+  });
+}

--- a/apps/web/src/features/invoicing/hooks/use-order-invoice-query.test.tsx
+++ b/apps/web/src/features/invoicing/hooks/use-order-invoice-query.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * useOrderInvoiceQuery — hook tests (#757)
+ *
+ * Covers the 404→null (not-issued) mapping, non-404 propagation, the
+ * pending-only poll interval, and the connectionId-null disable.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren, ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { ApiError } from '../../../shared/api/api-error';
+import { createMockApiClient } from '../../../test/test-utils';
+import { useOrderInvoiceQuery } from './use-order-invoice-query';
+import type { InvoiceRecord } from '../api/invoicing.types';
+
+function createWrapper(
+  apiClient: ReturnType<typeof createMockApiClient>,
+): ({ children }: PropsWithChildren) => ReactElement {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: PropsWithChildren): ReactElement {
+    return (
+      <ApiClientProvider client={apiClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </ApiClientProvider>
+    );
+  };
+}
+
+const invoice = (over: Partial<InvoiceRecord> = {}): InvoiceRecord => ({
+  id: 'inv_1',
+  connectionId: 'c1',
+  orderId: 'o1',
+  providerType: 'subiekt',
+  documentType: 'invoice',
+  status: 'issued',
+  providerInvoiceId: 'pi',
+  providerInvoiceNumber: 'FV/1',
+  regulatoryStatus: 'not-applicable',
+  clearanceReference: null,
+  pdfUrl: null,
+  issuedAt: null,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+  ...over,
+});
+
+describe('useOrderInvoiceQuery', () => {
+  it('maps an invoice-absent 404 to null (not-issued)', async () => {
+    const apiClient = createMockApiClient({
+      invoicing: {
+        getForOrder: vi
+          .fn()
+          .mockRejectedValue(new ApiError('No invoice for order', 404, { message: 'x' })),
+      },
+    });
+    const { result } = renderHook(() => useOrderInvoiceQuery('o1', 'c1'), {
+      wrapper: createWrapper(apiClient),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it('re-throws a non-404 ApiError as query.error', async () => {
+    const apiClient = createMockApiClient({
+      invoicing: {
+        getForOrder: vi.fn().mockRejectedValue(new ApiError('boom', 500, null)),
+      },
+    });
+    const { result } = renderHook(() => useOrderInvoiceQuery('o1', 'c1'), {
+      wrapper: createWrapper(apiClient),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as ApiError).status).toBe(500);
+  });
+
+  it('polls while status === "pending" (refetches after the interval)', async () => {
+    vi.useFakeTimers();
+    try {
+      const getForOrder = vi.fn().mockResolvedValue(invoice({ status: 'pending' }));
+      const apiClient = createMockApiClient({ invoicing: { getForOrder } });
+      const { result } = renderHook(() => useOrderInvoiceQuery('o1', 'c1'), {
+        wrapper: createWrapper(apiClient),
+      });
+      await vi.waitFor(() => expect(result.current.data?.status).toBe('pending'));
+      const callsAfterFirst = getForOrder.mock.calls.length;
+      // Advance past the 5s poll interval — a pending status must trigger a refetch.
+      await vi.advanceTimersByTimeAsync(5000);
+      await vi.waitFor(() =>
+        expect(getForOrder.mock.calls.length).toBeGreaterThan(callsAfterFirst),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops polling on a terminal status (no refetch after the interval)', async () => {
+    vi.useFakeTimers();
+    try {
+      const getForOrder = vi.fn().mockResolvedValue(invoice({ status: 'issued' }));
+      const apiClient = createMockApiClient({ invoicing: { getForOrder } });
+      const { result } = renderHook(() => useOrderInvoiceQuery('o1', 'c1'), {
+        wrapper: createWrapper(apiClient),
+      });
+      await vi.waitFor(() => expect(result.current.data?.status).toBe('issued'));
+      const callsAfterFirst = getForOrder.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(15000);
+      expect(getForOrder.mock.calls.length).toBe(callsAfterFirst);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('is disabled when connectionId is null', async () => {
+    const getForOrder = vi.fn();
+    const apiClient = createMockApiClient({ invoicing: { getForOrder } });
+    const { result } = renderHook(() => useOrderInvoiceQuery('o1', null), {
+      wrapper: createWrapper(apiClient),
+    });
+    // Disabled query never fetches.
+    await waitFor(() => expect(result.current.fetchStatus).toBe('idle'));
+    expect(getForOrder).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/invoicing/hooks/use-order-invoice-query.ts
+++ b/apps/web/src/features/invoicing/hooks/use-order-invoice-query.ts
@@ -1,0 +1,51 @@
+/**
+ * useOrderInvoiceQuery (#757)
+ *
+ * Fetches the single invoice projection for an order + invoicing connection.
+ * Returns `null` for the invoice-absent 404 ("not-issued" — plan §1.4) and
+ * polls every 5s while the invoice is `pending`.
+ *
+ * 404→null PRECONDITION (plan §1.4): the GET endpoint returns two distinct
+ * 404s — `Order not found` (controller line 186) and `No invoice for order`
+ * (line 198). This hook only ever runs for an order the order-detail page has
+ * ALREADY resolved and 404-guarded, so the order-not-found 404 is unreachable
+ * here and the only reachable 404 is invoice-absent. Mapping `404 → null` is
+ * therefore safe (no message-substring sniffing).
+ *
+ * @module apps/web/src/features/invoicing/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { ApiError } from '../../../shared/api/api-error';
+import { invoicingQueryKeys } from '../api/invoicing.query-keys';
+import type { InvoiceRecord } from '../api/invoicing.types';
+
+const INVOICE_POLL_MS = 5000;
+
+export function useOrderInvoiceQuery(
+  orderId: string,
+  connectionId: string | null,
+): UseQueryResult<InvoiceRecord | null> {
+  const apiClient = useApiClient();
+
+  return useQuery<InvoiceRecord | null>({
+    queryKey: invoicingQueryKeys.forOrder(orderId, connectionId ?? ''),
+    enabled: Boolean(orderId && connectionId),
+    queryFn: async (): Promise<InvoiceRecord | null> => {
+      // 404 → null (invoice-absent "not-issued"); see the 404 precondition in
+      // the module docstring. Any other error propagates to the query's error
+      // state so the panel can surface a retryable failure (not a false
+      // not-issued).
+      try {
+        return await apiClient.invoicing.getForOrder(orderId, connectionId ?? '');
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    refetchInterval: (query) =>
+      query.state.data?.status === 'pending' ? INVOICE_POLL_MS : false,
+  });
+}

--- a/apps/web/src/features/invoicing/index.ts
+++ b/apps/web/src/features/invoicing/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Invoicing — public surface (#757)
+ *
+ * Public barrel for the invoicing feature. Cross-feature / page consumers
+ * import only from here. Kept narrow (like `orders/index.ts`): the panel, the
+ * query/mutation hooks, the query keys, and the transport types. The badges,
+ * PDF link, document-type select, and `resolveIssueErrorMessage` stay internal
+ * (tests deep-import them directly).
+ *
+ * @module apps/web/src/features/invoicing
+ */
+export { OrderInvoicePanel } from './components/order-invoice-panel';
+export { useOrderInvoiceQuery } from './hooks/use-order-invoice-query';
+export { useIssueInvoiceMutation } from './hooks/use-issue-invoice-mutation';
+export { invoicingQueryKeys } from './api/invoicing.query-keys';
+export type {
+  InvoiceRecord,
+  InvoiceStatus,
+  RegulatoryStatus,
+  DocumentType,
+  IssueInvoiceInput,
+} from './api/invoicing.types';

--- a/apps/web/src/features/invoicing/lib/issue-error-message.test.ts
+++ b/apps/web/src/features/invoicing/lib/issue-error-message.test.ts
@@ -1,0 +1,81 @@
+/**
+ * resolveIssueErrorMessage — unit tests (#757)
+ *
+ * Pure mapper from a `POST /invoices` failure to operator-friendly copy. The
+ * load-bearing invariant under test: the capability-disabled branch and the
+ * fallback emit FIXED strings and NEVER echo `error.message` (which carries the
+ * internal connectionId + adapterKey); only the 422 / generic-400 branches
+ * surface the server message verbatim.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveIssueErrorMessage, isCapabilityDisabledError } from './issue-error-message';
+import { ApiError } from '../../../shared/api/api-error';
+
+/** Identity `t` — returns the EN fallback so assertions read against real copy. */
+const t = (_key: string, fallback: string): string => fallback;
+
+/** A message carrying the internal identifiers the capability branch must hide. */
+const LEAKY_MESSAGE =
+  "Capability 'Invoicing' not enabled for connection conn_abc123 (adapter subiekt-gt)";
+
+describe('resolveIssueErrorMessage', () => {
+  it('capability 400 (CapabilityNotEnabledException) ⇒ fixed friendly copy, no connectionId/adapterKey', () => {
+    const error = new ApiError(LEAKY_MESSAGE, 400, {
+      error: 'CapabilityNotEnabledException',
+      message: LEAKY_MESSAGE,
+    });
+    const result = resolveIssueErrorMessage(error, t);
+    expect(result).toBe('Invoicing is not enabled for this connection.');
+    expect(result).not.toContain('conn_abc123');
+    expect(result).not.toContain('subiekt-gt');
+  });
+
+  it('capability 400 (CapabilityNotSupportedException) ⇒ fixed friendly copy', () => {
+    const error = new ApiError(LEAKY_MESSAGE, 400, {
+      error: 'CapabilityNotSupportedException',
+      message: LEAKY_MESSAGE,
+    });
+    expect(resolveIssueErrorMessage(error, t)).toBe('Invoicing is not enabled for this connection.');
+  });
+
+  it('422 ⇒ surfaces error.message (correlationId string)', () => {
+    const msg = 'Provider rejected the invoice (correlationId: c-7f3a)';
+    expect(resolveIssueErrorMessage(new ApiError(msg, 422, { message: msg }), t)).toBe(msg);
+  });
+
+  it('non-capability 400 (buyer profile) ⇒ surfaces error.message', () => {
+    const msg = 'Buyer profile is missing a tax id';
+    const error = new ApiError(msg, 400, { error: 'BadRequestException', message: msg });
+    expect(resolveIssueErrorMessage(error, t)).toBe(msg);
+  });
+
+  it('409 ⇒ already-issued fixed copy', () => {
+    const error = new ApiError('Invoice already issued for order: o1', 409, {});
+    expect(resolveIssueErrorMessage(error, t)).toBe('This order already has an issued invoice.');
+  });
+
+  it('network / non-ApiError ⇒ generic fixed copy (no message echo)', () => {
+    const result = resolveIssueErrorMessage(new Error('socket hang up'), t);
+    expect(result).toBe('Could not issue the invoice. Please try again.');
+    expect(result).not.toContain('socket hang up');
+  });
+});
+
+describe('isCapabilityDisabledError', () => {
+  it('true only for a 400 with a known capability exception name', () => {
+    expect(
+      isCapabilityDisabledError(new ApiError('x', 400, { error: 'CapabilityNotEnabledException' })),
+    ).toBe(true);
+  });
+
+  it('false for a 400 with a non-capability exception name', () => {
+    expect(isCapabilityDisabledError(new ApiError('x', 400, { error: 'BadRequestException' }))).toBe(
+      false,
+    );
+  });
+
+  it('false for a non-400 status and for non-ApiError values', () => {
+    expect(isCapabilityDisabledError(new ApiError('x', 422, { error: 'CapabilityNotEnabledException' }))).toBe(false);
+    expect(isCapabilityDisabledError(new Error('x'))).toBe(false);
+  });
+});

--- a/apps/web/src/features/invoicing/lib/issue-error-message.ts
+++ b/apps/web/src/features/invoicing/lib/issue-error-message.ts
@@ -1,0 +1,61 @@
+/**
+ * resolveIssueErrorMessage (#757)
+ *
+ * Pure mapper from a `POST /invoices` failure to an operator-friendly toast
+ * string. Discriminators pinned to the verified HTTP shapes (plan §2.6):
+ *
+ *   1. Capability-disabled (HTTP 400, `details.error` is
+ *      `CapabilityNotEnabledException` / `CapabilityNotSupportedException`) →
+ *      a FIXED string. MUST NOT echo `error.message` (it embeds the internal
+ *      `connectionId` + `adapterKey`).
+ *   2. Sanitised provider rejection (HTTP 422) → surface `error.message`
+ *      verbatim (controller correlationId string, PII-clean).
+ *   3. Other HTTP 400 (buyer-profile / price-treatment) → surface
+ *      `error.message` (PII-clean mapper text, operator-actionable).
+ *   4. Defensive 409 → already-issued fixed string.
+ *   5. Fallback → generic fixed string.
+ *
+ * Security invariant: only branches 2 and 3 surface `error.message`; the
+ * capability branch and fallback emit FIXED strings.
+ *
+ * @module apps/web/src/features/invoicing/lib
+ */
+import { ApiError } from '../../../shared/api/api-error';
+import type { CapabilityErrorBody } from '../api/invoicing.types';
+
+type Translate = (key: string, fallback: string) => string;
+
+const CAPABILITY_EXCEPTION_NAMES = new Set([
+  'CapabilityNotEnabledException',
+  'CapabilityNotSupportedException',
+]);
+
+/** Discriminates a capability-disabled 400 from a legitimate buyer-profile 400
+ *  by the structured body's `error` name (NOT status alone). */
+export function isCapabilityDisabledError(error: unknown): boolean {
+  if (!(error instanceof ApiError) || error.status !== 400) {
+    return false;
+  }
+  const body = error.details as CapabilityErrorBody | null;
+  return Boolean(body?.error && CAPABILITY_EXCEPTION_NAMES.has(body.error));
+}
+
+export function resolveIssueErrorMessage(error: unknown, t: Translate): string {
+  // Branch order matters: the capability-disabled 400 (fixed copy, no PII echo)
+  // MUST be tested before the generic 400 branch that surfaces `error.message`.
+  if (isCapabilityDisabledError(error)) {
+    return t('invoice.error.capabilityDisabled', 'Invoicing is not enabled for this connection.');
+  }
+  if (error instanceof ApiError) {
+    if (error.status === 422) {
+      return error.message;
+    }
+    if (error.status === 400) {
+      return error.message;
+    }
+    if (error.status === 409) {
+      return t('invoice.error.alreadyIssued', 'This order already has an issued invoice.');
+    }
+  }
+  return t('invoice.error.generic', 'Could not issue the invoice. Please try again.');
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8678,6 +8678,117 @@ html[data-density='compact'] .status-badge {
   }
 }
 
+/* ── Order invoice panel (#757) ────────────────────────────────────────── */
+
+/* Mirrors .order-shipment-panel: inherits .detail-section grid, same surface
+ * chrome. Token-only — never raw hex. */
+.order-invoice-panel {
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+}
+
+.order-invoice-panel__header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+/* Title takes the row, badges wrap to the right; on narrow widths they wrap
+ * under the title rather than truncating. */
+.order-invoice-panel__header .detail-section__title {
+  margin-right: auto;
+}
+
+.order-invoice-panel__body {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.order-invoice-panel__doctype {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.order-invoice-panel__notice {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+/* Invoicing-connection picker (shown only when >1 active+enabled invoicing
+ * connection exists — see order-invoice-panel.tsx). */
+.order-invoice-panel__connection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.order-invoice-panel__connection-label {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.order-invoice-panel__error {
+  margin: 0;
+}
+
+/* Action row: document-type select + Issue/Retry button. Wraps on narrow
+ * widths and stacks to full-width tap targets on mobile. */
+.order-invoice-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.order-invoice-panel__skeleton {
+  min-height: 88px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    90deg,
+    var(--bg-surface-muted) 0%,
+    var(--bg-surface-hover) 50%,
+    var(--bg-surface-muted) 100%
+  );
+  background-size: 200% 100%;
+  animation: order-invoice-panel-shimmer 1.4s ease-in-out infinite;
+}
+
+.order-invoice-panel--loading {
+  background: var(--bg-surface);
+}
+
+@keyframes order-invoice-panel-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+@media (max-width: 767px) {
+  .order-invoice-panel__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .order-invoice-panel__actions > .button {
+    width: 100%;
+    min-height: 44px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .order-invoice-panel__skeleton {
+    animation: none;
+    background: var(--bg-surface-muted);
+  }
+}
+
 /* ── Shipment action buttons (#769) ────────────────────────────────────── */
 
 .shipment-action-buttons {

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -285,3 +285,43 @@ describe('OrderDetailPage', () => {
     });
   });
 });
+
+// #757 — Invoice panel wiring on the order-detail rail.
+describe('OrderDetailPage — invoice panel (#757)', () => {
+  afterEach(cleanup);
+
+  const invoicingConnection = {
+    ...sampleConnection,
+    id: 'conn_invoicing',
+    name: 'Subiekt GT',
+    status: 'active' as const,
+    enabledCapabilities: ['Invoicing'],
+    supportedCapabilities: ['Invoicing'],
+  };
+
+  it('renders the invoice panel in the rail when an active connection has Invoicing enabled', async () => {
+    const api = createMockApiClient({
+      orders: { getById: vi.fn().mockResolvedValue(sampleOrder) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
+    });
+    renderDetail(api);
+    // 404 default ⇒ not-issued ⇒ the Issue button is the panel's tell.
+    expect(await screen.findByRole('button', { name: /issue invoice/i })).toBeInTheDocument();
+  });
+
+  it('does not render the invoice panel when no active+enabled invoicing connection exists', async () => {
+    const api = createMockApiClient({
+      orders: { getById: vi.fn().mockResolvedValue(sampleOrder) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+    const { container } = renderWithProviders(
+      <Routes>
+        <Route path="/orders/:internalOrderId" element={<OrderDetailPage />} />
+      </Routes>,
+      { apiClient: api, route: '/orders/ol_order_abc123' },
+    );
+    await screen.findByText('Order Snapshot');
+    expect(screen.queryByRole('button', { name: /issue invoice/i })).toBeNull();
+    expect(container.querySelector('.order-invoice-panel')).toBeNull();
+  });
+});

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -31,6 +31,7 @@ import { useOrderShipmentsQuery } from '../../features/shipments';
 import { OrderCustomerCard } from '../../features/orders/components/order-customer-card';
 import { OrderActivityTimeline } from '../../features/orders/components/order-activity-timeline';
 import { OrderShipmentPanel } from '../../features/orders/components/order-shipment-panel';
+import { OrderInvoicePanel } from '../../features/invoicing';
 import { OrderDetailHeader } from '../../features/orders/components/order-detail-header';
 import { OrderHealthSummary } from '../../features/orders/components/order-health-summary';
 import { OrderPricingPanel } from '../../features/orders/components/order-pricing-panel';
@@ -280,6 +281,7 @@ export function OrderDetailPage(): ReactElement {
             sourcePlatformType={sourcePlatformType}
           />
           <OrderShipmentPanel order={order} />
+          <OrderInvoicePanel order={order} />
           <OrderCustomerCard customerId={order.customerId} sourceConnectionId={order.sourceConnectionId} />
         </div>
       </div>

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -226,6 +226,20 @@ export function createMockApiClient(
       getById: vi.fn().mockResolvedValue(null),
       ...overrides.inventory,
     } as ApiClient['inventory'],
+    invoicing: {
+      // #757 — 404 default ⇒ "not-issued" with no network round-trip. NOTE: the
+      // default mock connection carries `Invoicing` in neither
+      // `enabledCapabilities` nor `supportedCapabilities`, so invoice tests must
+      // inject an active connection with `enabledCapabilities: ['Invoicing', …]`
+      // via `overrides.connections.list` to render the panel.
+      getForOrder: vi
+        .fn()
+        .mockRejectedValue(
+          new ApiError('No invoice for order', 404, { message: 'No invoice for order' }),
+        ),
+      issue: vi.fn().mockResolvedValue(null),
+      ...overrides.invoicing,
+    } as ApiClient['invoicing'],
     orders: {
       list: vi.fn().mockResolvedValue({
         items: [],


### PR DESCRIPTION
## What
Invoice panel on the order-detail page + manual issue/retry (FE issue of #728).

`Closes #757`

> **Stacked on #1119** (PR #1174). Base `1119-invoicing-http-api`; retarget to `main` as the stack merges.

## Delivered (apps/web)
- **Invoice panel** on the order-detail page: status badge (not-issued / pending / issued / failed), invoice number, document type, **Subiekt PDF link** (scheme-guarded — a non-`http(s)` `pdfUrl` falls back to plain copy-text, so a `javascript:` URL can't render a clickable XSS), error/empty states, and a **KSeF regulatory badge**.
- **Issue / Retry** button for the not-issued and failed states → `POST /invoices`; polls while `pending`. Capability-disabled errors render **fixed operator copy** (never echo `connectionId`/`adapterKey`); other 400s → a generic toast; invoice-absent 404 → not-issued.
- New `apps/web/src/features/invoicing/` (API client, query keys, hooks, components). TanStack Query for fetch + mutation; PL+EN via the host `t()` seam.

## Verification
- **lint** (incl. `check:invariants`) 0 errors, **type-check** clean, **web 1535 tests** pass.

## ⚠ Deviations from named ACs — all backend-forced, need PM sign-off + backend follow-ups
- **AC-5 (Re-issue button + confirmation modal when issued): DESCOPED.** `POST /invoices` throws **409** for an already-`issued` `(orderId, connectionId)` and has no force/replace/supersede field, so a re-issue button would 409 100% of the time. The issued state is rendered **read-only**. → Needs a **backend follow-up** (a supersede/force path on `POST /invoices` that creates a new invoice while the original stays in Subiekt) before AC-5 can ship. Please confirm read-only `issued` is acceptable for this ticket.
- **AC-4 (show the error message when failed):** a row loaded in `failed` via `GET /orders/:id/invoice` shows **generic copy only** — the read DTO deliberately omits `errorMessage` (PII-tainted) and carries no sanitized failure-reason. → Needs a **sanitized-reason field on the read DTO** (#1119 follow-up) to show a per-row reason. (The issue-time toast does surface the sanitized 4xx reason.)
- **Regulatory (KSeF) badge** gates on `regulatoryStatus !== 'not-applicable'` (a data proxy) because **no KSeF capability string exists yet** (`CoreCapabilityValues` has only `Invoicing`); verified sound today, TODO-flagged to switch to a capability gate when one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txy9aqLujJBG1dSwGd4z3f
