### PR TITLE
fix(integrations): default Subiekt line stawkaVAT to PL 23% — main currently rejects every invoice (#753 follow-up)

### DIFF
--- a/libs/integrations/subiekt/src/infrastructure/mappers/subiekt-line.mapper.ts
+++ b/libs/integrations/subiekt/src/infrastructure/mappers/subiekt-line.mapper.ts
@@ -9,16 +9,27 @@
  *   - `unitPriceGross` -> `cenaBrutto`
  *   - `taxRate`        -> `stawkaVAT`
  *
+ * TAX-REGIME DEFAULT (Subiekt-specific): the neutral core `InvoiceLine` leaves
+ * `taxRate` empty by design — core never names a tax rate on the order contract
+ * ("the provider adapter resolves the regime rate", see the core line mapper).
+ * The Subiekt bridge REQUIRES a non-empty `stawkaVAT` ("StawkaVAT jest wymagana")
+ * and parses Polish rate symbols ("23","8","5","0","zw","np"). When the neutral
+ * line carries no rate we therefore default to the Polish standard rate "23".
+ * A rate the source DID supply passes through verbatim.
+ *
  * @module libs/integrations/subiekt/src/infrastructure/mappers
  */
 import type { InvoiceLine } from '@openlinker/core/invoicing';
 import type { BridgeLine } from '../../bridge/subiekt-bridge.types';
+
+/** Polish standard VAT rate — used when the neutral line carries no rate. */
+const DEFAULT_PL_VAT_RATE = '23';
 
 export function toBridgeLines(lines: InvoiceLine[]): BridgeLine[] {
   return lines.map((line) => ({
     name: line.name,
     ilosc: line.quantity,
     cenaBrutto: line.unitPriceGross,
-    stawkaVAT: line.taxRate,
+    stawkaVAT: line.taxRate.trim().length > 0 ? line.taxRate.trim() : DEFAULT_PL_VAT_RATE,
   }));
 }


### PR DESCRIPTION
## What

Defaults the Subiekt invoice line `stawkaVAT` to the Polish standard rate `"23"` when the neutral `InvoiceLine` carries no `taxRate`. A rate the source DID supply passes through verbatim (trimmed).

## Why this is a follow-up to an already-merged PR

#1130 (#753, the Subiekt adapter) was **squash-merged into `main` before this fix existed**. The bug was caught afterwards, during the live end-to-end run against the real bridge + Subiekt demo Nexo — so the fix landed on the `753-subiekt-invoicing-adapter` branch **after** its PR had closed, and never reached `main`.

**`main` is currently broken for Subiekt issuance without this:** the neutral core `InvoiceLine` leaves `taxRate` empty by design (core never names a tax regime on the order contract — the provider adapter resolves the rate), so the adapter sent `stawkaVAT=""` and the bridge rejected **every** invoice with `"StawkaVAT jest wymagana"`. The mocks mirror the contract, so unit tests never hit it — only a real bridge call surfaced it.

## Verification

- Live: B2B `FS 169/CENTRALA/2026` issued through the UI — netto 110.58 + VAT 25.43 = brutto 136.01 (23% computed correctly).
- 135 `@openlinker/integrations-subiekt` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txy9aqLujJBG1dSwGd4z3f
