### PR TITLE
fix(invoicing): close R2/R3 exactly-once gaps in InvoiceService (#1200)

### DIFF
--- a/apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts
+++ b/apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts
@@ -12,7 +12,7 @@
  * @module apps/api/src/invoicing/http/dto
  */
 import { ApiProperty } from '@nestjs/swagger';
-import { InvoiceStatus, RegulatoryStatus } from '@openlinker/core/invoicing';
+import { InvoiceStatus, InvoiceStatusValues, RegulatoryStatus } from '@openlinker/core/invoicing';
 
 export class InvoiceRecordResponseDto {
   @ApiProperty({ description: 'Internal invoice record id' })
@@ -30,7 +30,9 @@ export class InvoiceRecordResponseDto {
   @ApiProperty({ description: 'Neutral document type (open-world)' })
   documentType!: string;
 
-  @ApiProperty({ description: 'Issuance lifecycle status', enum: ['pending', 'issued', 'failed'] })
+  // Reference the live const (not a hardcoded array) so the published enum can
+  // never drift from InvoiceStatus — `issuing` (#1200) is a serializable value.
+  @ApiProperty({ description: 'Issuance lifecycle status', enum: InvoiceStatusValues })
   status!: InvoiceStatus;
 
   @ApiProperty({ description: 'Provider-assigned document id', nullable: true })

--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -30,7 +30,7 @@ import { InvoicingController } from './invoicing.controller';
 const NOW = new Date('2026-06-23T10:00:00.000Z');
 
 function makeInvoiceRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
-  return {
+  const base = {
     id: 'inv_1',
     connectionId: 'conn_1',
     orderId: 'ol_order_1',
@@ -45,10 +45,24 @@ function makeInvoiceRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecor
     pdfUrl: null,
     issuedAt: NOW,
     errorMessage: 'internal diagnostic',
+    failureMode: null,
+    leaseExpiresAt: null,
     createdAt: NOW,
     updatedAt: NOW,
     isIssued: true,
     ...overrides,
+  };
+  // Mirror the real entity derivation (#1200) so the controller's AC-5 gate can
+  // call it: a live `issuing` lease is "in progress".
+  return {
+    ...base,
+    isLeaseLive(now: Date): boolean {
+      return (
+        base.status === 'issuing' &&
+        base.leaseExpiresAt !== null &&
+        (base.leaseExpiresAt as Date).getTime() > now.getTime()
+      );
+    },
   } as InvoiceRecord;
 }
 
@@ -131,6 +145,26 @@ describe('InvoicingController', () => {
       orders.getOrderRecord.mockResolvedValue(makeOrderRecord());
       invoiceService.getInvoice.mockResolvedValue(makeInvoiceRecord({ status: 'pending' }));
       await expect(controller.issueInvoice(dto)).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('409 Conflict when a row under a LIVE issuing lease is in progress (#1200)', async () => {
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord());
+      invoiceService.getInvoice.mockResolvedValue(
+        makeInvoiceRecord({ status: 'issuing', leaseExpiresAt: new Date(Date.now() + 60_000) }),
+      );
+      await expect(controller.issueInvoice(dto)).rejects.toBeInstanceOf(ConflictException);
+      // An original attempt is mid-flight: never report a fresh 201, never re-issue.
+      expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
+    });
+
+    it('does NOT 409 an EXPIRED issuing lease — it is re-claimable, so issuance proceeds (#1200)', async () => {
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord());
+      invoiceService.getInvoice.mockResolvedValue(
+        makeInvoiceRecord({ status: 'issuing', leaseExpiresAt: new Date(Date.now() - 60_000) }),
+      );
+      invoiceService.issueInvoice.mockResolvedValue(makeInvoiceRecord({ status: 'issued' }));
+      await controller.issueInvoice(dto);
+      expect(invoiceService.issueInvoice).toHaveBeenCalled();
     });
 
     it('422 when the order record is not `ready` (snapshot unavailable)', async () => {

--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -60,7 +60,7 @@ function makeInvoiceRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecor
       return (
         base.status === 'issuing' &&
         base.leaseExpiresAt !== null &&
-        (base.leaseExpiresAt as Date).getTime() > now.getTime()
+        (base.leaseExpiresAt).getTime() > now.getTime()
       );
     },
   } as InvoiceRecord;

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -102,7 +102,8 @@ export class InvoicingController {
     // AC-5 re-issue gate. Read the order's CURRENT invoice projection on this
     // connection (single-row primitive — not the list query). Allow issuance
     // only when there is no record yet ("not issued") or the prior attempt
-    // `failed`; reject `issued` (already done) and `pending` (in progress).
+    // `failed`; reject `issued` (already done) and an in-progress attempt —
+    // `pending`, or `issuing` under a LIVE CAS lease (#1200) — as 409.
     const existing = await this.invoiceService.getInvoice({
       orderId: dto.orderId,
       connectionId: dto.connectionId,
@@ -111,7 +112,12 @@ export class InvoicingController {
       if (existing.status === 'issued') {
         throw new ConflictException(`Invoice already issued for order: ${dto.orderId}`);
       }
-      if (existing.status === 'pending') {
+      // `pending` (intent persisted, not yet claimed) and a LIVE `issuing` lease
+      // (an attempt currently crossing the provider boundary) are both "in
+      // progress". A re-issue must NOT be reported as a fresh 201 success while an
+      // original attempt is in flight (#1200) — surface 409 so the caller retries
+      // later. An EXPIRED `issuing` lease falls through: it is re-claimable below.
+      if (existing.status === 'pending' || existing.isLeaseLive(new Date())) {
         throw new ConflictException(`Invoice issuance already in progress for order: ${dto.orderId}`);
       }
     }

--- a/apps/api/src/migrations/1812000000000-add-invoice-record-retry-guards.ts
+++ b/apps/api/src/migrations/1812000000000-add-invoice-record-retry-guards.ts
@@ -1,0 +1,44 @@
+/**
+ * Add Invoice Record Retry Guards Migration (#1200)
+ *
+ * Closes the R2/R3 exactly-once gaps on `invoice_records`:
+ *   - `failureMode` (nullable text): the neutral failure discriminator
+ *     (`rejected` | `in-doubt`). Set on a `failed` outcome so the read-gate can
+ *     re-attempt a terminal `rejected` row but never an `in-doubt` one (a
+ *     document may already exist). `null` for non-`failed` rows.
+ *   - `leaseExpiresAt` (nullable timestamp): the expiry of the `issuing` CAS
+ *     lease. Set when an attempt claims the in-flight slot; `null` otherwise.
+ *     Backs the atomic `claimForIssue` guard that lets exactly one concurrent
+ *     same-key retry cross the provider boundary.
+ *
+ * The `status` column gains a new logical value `issuing` (no DB enum — it is a
+ * plain text column, so no type change is required). The partial-unique create
+ * guard `UQ_invoice_records_connection_idempotency` is unchanged: these columns
+ * ADD retry-path guards alongside it.
+ *
+ * Generated: 2026-06-25 (synthetic sequential prefix per docs/migrations.md #1013).
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddInvoiceRecordRetryGuards1812000000000 implements MigrationInterface {
+  name = 'AddInvoiceRecordRetryGuards1812000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "invoice_records" ADD COLUMN IF NOT EXISTS "failureMode" text`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "invoice_records" ADD COLUMN IF NOT EXISTS "leaseExpiresAt" TIMESTAMP`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "invoice_records" DROP COLUMN IF EXISTS "leaseExpiresAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "invoice_records" DROP COLUMN IF EXISTS "failureMode"`,
+    );
+  }
+}

--- a/libs/core/src/invoicing/application/services/invoice.service.interface.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.interface.ts
@@ -30,45 +30,44 @@ export interface IInvoiceService {
    * (`adapter.issueInvoice(cmd)`) and patch the row `issued`/`failed`;
    * (5) a create-race that trips the dedup guard re-reads and returns the winner.
    *
-   * ACCEPTED-RISK CONTRACT — three explicit risks the future ECA caller MUST heed:
+   * FISCAL-SAFETY INVARIANT (governs all retry behaviour): a real fiscal document
+   * must NEVER be double-issued. When it is UNCERTAIN whether the provider already
+   * created a document, the SVC does NOT auto-re-attempt — it surfaces the record
+   * for manual reconciliation. A stuck/needs-attention row is always preferable to
+   * a duplicate document.
+   *
+   * EXACTLY-ONCE CONTRACT — one remaining caller obligation (R1) plus the now-CLOSED
+   * concurrency/in-doubt gaps (R2/R3, #1200):
    *
    * - (R1) Exactly-once requires `idempotencyKey`. When omitted, NO deduplication
    *   happens (no read-gate, no DB unique guard): two keyless calls for the same
    *   order produce two pending rows and two real provider documents. Callers
-   *   needing exactly-once MUST supply a stable `idempotencyKey`.
+   *   needing exactly-once MUST supply a stable `idempotencyKey`. (Unchanged.)
    *
-   * - (R2) non-`issued`-row retry is single-flight-only. A same-key call whose
-   *   prior attempt left a non-`issued` row (`failed` OR `pending`) re-attempts by
-   *   REUSING that row (`updateOutcome`, not `create`). The partial unique index
-   *   only guards the create path, so two CONCURRENT same-key retries can both read
-   *   the row and both call the provider — two documents. Non-`issued`-row retries
-   *   are exactly-once ONLY when serialized.
+   * - (R2 — CLOSED, #1200) Concurrent same-key retry no longer double-issues. Before
+   *   re-crossing the provider boundary the SVC performs an ATOMIC compare-and-swap
+   *   claim (`InvoiceRecordRepositoryPort.claimForIssue`) that flips the row to
+   *   `issuing` under a time-bounded lease ONLY when no live attempt already holds
+   *   it. Of two concurrent same-key retries exactly ONE wins the claim and calls
+   *   the provider; the loser backs off WITHOUT crossing the boundary. The lease
+   *   expiry lets a crash-orphaned `issuing` row be re-claimed later.
    *
-   * - (R3) non-`issued`-row retry may double-issue an in-doubt document. The
-   *   read-gate re-attempts on ANY non-`issued` hit — `failed` AND `pending` (it
-   *   only short-circuits on `issued`). The SVC cannot distinguish a terminal
-   *   provider rejection from a transient transport failure (it must not
-   *   value-import the adapter error subclasses), so any non-`issued` row is always
-   *   treated as re-attemptable. Two double-issue exposures result:
-   *     • A `failed` hit may correspond to an in-doubt transport failure where the
-   *       provider actually DID issue; the retry re-crosses the boundary and may
-   *       double-issue a real fiscal document.
-   *     • A `pending` hit is the STRONGEST in-doubt case: it means a prior same-key
-   *       attempt persisted intent and crashed/raced mid-adapter-call, OR an
-   *       ORIGINAL attempt for that key is STILL IN FLIGHT. The SVC does not exclude
-   *       a concurrent in-flight original, so a retry on a `pending` hit can
-   *       double-issue alongside it. This is the path with the highest exactly-once
-   *       exposure.
-   *   Deliberate MVP trade-off: never-retrying non-`issued` rows would brick
-   *   transient failures and orphan crash-interrupted `pending` intents (worse),
-   *   while a deterministic terminal rejection simply fails again with no
-   *   double-issue.
+   * - (R3 — CLOSED, #1200) In-doubt retry no longer double-issues. The adapter
+   *   stamps a NEUTRAL `failureMode` (`rejected` | `in-doubt`) on the errors it
+   *   throws; the SVC reads it STRUCTURALLY (no adapter error-subclass value-import)
+   *   and persists it on the `failed` row. The read-gate then:
+   *     • re-attempts a `failed` row ONLY when `failureMode === 'rejected'` — a
+   *       TERMINAL rejection where the provider definitely created NO document;
+   *     • NEVER auto-re-attempts an `in-doubt` `failed` row (a document MAY exist) —
+   *       it is returned for manual reconciliation;
+   *     • NEVER re-attempts a row under a LIVE `issuing` lease (an original attempt
+   *       is still in flight) — closing the `pending` half of R3 alongside R2.
+   *   Any failure whose mode cannot be read structurally collapses to the
+   *   fiscal-safe `in-doubt` (never auto-re-attempted).
    *
-   * Follow-up (R2/R3 closure): see GitHub issue #1200 — neutral
-   * `retryable` discriminator (so `failed` rows from terminal vs. transient
-   * outcomes are distinguishable) + compare-and-swap/lease on
-   * `InvoiceRecordRepositoryPort` (so a `pending` row's still-in-flight original is
-   * excluded before a retry re-crosses the boundary).
+   * Closure tracked by GitHub issue #1200 (follow-up to #1118): neutral
+   * `failureMode` discriminator + CAS/lease (`claimForIssue`) on
+   * `InvoiceRecordRepositoryPort`.
    */
   issueInvoice(cmd: IssueInvoiceCommand): Promise<InvoiceRecord>;
 

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -63,6 +63,8 @@ function makeRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
     overrides.errorMessage === undefined ? null : overrides.errorMessage,
     overrides.createdAt ?? new Date('2026-06-22T10:00:00.000Z'),
     overrides.updatedAt ?? new Date('2026-06-22T10:00:00.000Z'),
+    overrides.failureMode === undefined ? null : overrides.failureMode,
+    overrides.leaseExpiresAt === undefined ? null : overrides.leaseExpiresAt,
   );
 }
 
@@ -99,8 +101,14 @@ describe('InvoiceService', () => {
       findByOrderId: jest.fn(),
       findByIdempotencyKey: jest.fn(),
       updateOutcome: jest.fn(),
+      claimForIssue: jest.fn(),
       findMany: jest.fn(),
     };
+    // Default: every claim succeeds (returns a record with the live lease). Tests
+    // that exercise a contended/lost claim override this per-case.
+    repo.claimForIssue.mockImplementation((id: string) =>
+      Promise.resolve(makeRecord({ id, status: 'issuing' })),
+    );
     adapter = {
       issueInvoice: jest.fn(),
       getInvoice: jest.fn(),
@@ -152,7 +160,10 @@ describe('InvoiceService', () => {
         clearanceReference: 'KSEF-XYZ',
         pdfUrl: 'https://prov/inv.pdf',
         issuedAt: adapterResult.issuedAt,
+        // A successful issue clears the failure mode + releases the lease (#1200).
         errorMessage: null,
+        failureMode: null,
+        leaseExpiresAt: null,
       });
       expect(result).toBe(finalRecord);
     });
@@ -229,10 +240,30 @@ describe('InvoiceService', () => {
       repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'failed' }));
 
       await expect(service.issueInvoice(makeCmd())).rejects.toBe(rejection);
+      // A plain Error carries no neutral failureMode, so it collapses to the
+      // fiscal-safe 'in-doubt' (#1200) and the lease is released.
       expect(repo.updateOutcome).toHaveBeenCalledWith('rec-1', {
         status: 'failed',
         errorMessage: 'provider rejected: invalid tax rate',
+        failureMode: 'in-doubt',
+        leaseExpiresAt: null,
       });
+    });
+
+    it("(d2) failureMode discriminator: a 'rejected'-marked throwable persists failureMode 'rejected'", async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));
+      const rejection = Object.assign(new Error('provider rejected: invalid tax rate'), {
+        failureMode: 'rejected' as const,
+      });
+      adapter.issueInvoice.mockRejectedValue(rejection);
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'failed' }));
+
+      await expect(service.issueInvoice(makeCmd())).rejects.toBe(rejection);
+      expect(repo.updateOutcome).toHaveBeenCalledWith(
+        'rec-1',
+        expect.objectContaining({ status: 'failed', failureMode: 'rejected' }),
+      );
     });
 
     it('(e) unreachable transport: adapter throws -> failed + rethrow (per-design propagation)', async () => {
@@ -259,8 +290,13 @@ describe('InvoiceService', () => {
       expect(adapter.issueInvoice).toHaveBeenCalledWith(expect.objectContaining({ documentType: 'credit-note' }));
     });
 
-    it('(h) retry-after-failure: failed hit -> NOT returned, NO second create, re-call adapter, updateOutcome(hit.id, issued + errorMessage:null)', async () => {
-      const failedHit = makeRecord({ id: 'failed-rec', status: 'failed', errorMessage: 'stale boom' });
+    it("(h) retry-after-terminal-rejection: a 'rejected' failed hit IS re-attempted (claim, re-call adapter, updateOutcome issued + errorMessage:null)", async () => {
+      const failedHit = makeRecord({
+        id: 'failed-rec',
+        status: 'failed',
+        failureMode: 'rejected',
+        errorMessage: 'stale boom',
+      });
       repo.findByIdempotencyKey.mockResolvedValue(failedHit);
       adapter.issueInvoice.mockResolvedValue(makeIssuedFromAdapter());
       repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'failed-rec', status: 'issued' }));
@@ -268,6 +304,7 @@ describe('InvoiceService', () => {
       await service.issueInvoice(makeCmd());
 
       expect(repo.create).not.toHaveBeenCalled();
+      expect(repo.claimForIssue).toHaveBeenCalledWith('failed-rec', expect.any(Date));
       expect(adapter.issueInvoice).toHaveBeenCalledTimes(1);
       expect(repo.updateOutcome).toHaveBeenCalledWith(
         'failed-rec',
@@ -275,7 +312,7 @@ describe('InvoiceService', () => {
       );
     });
 
-    it('(h2) pending hit is returned to the re-attempt path (re-call adapter on the existing row)', async () => {
+    it('(h2) pending hit (no live lease) is re-attempted via an atomic claim, then issued on the existing row', async () => {
       const pendingHit = makeRecord({ id: 'pending-rec', status: 'pending' });
       repo.findByIdempotencyKey.mockResolvedValue(pendingHit);
       adapter.issueInvoice.mockResolvedValue(makeIssuedFromAdapter());
@@ -284,6 +321,7 @@ describe('InvoiceService', () => {
       await service.issueInvoice(makeCmd());
 
       expect(repo.create).not.toHaveBeenCalled();
+      expect(repo.claimForIssue).toHaveBeenCalledWith('pending-rec', expect.any(Date));
       expect(repo.updateOutcome).toHaveBeenCalledWith('pending-rec', expect.objectContaining({ status: 'issued' }));
     });
 
@@ -299,14 +337,103 @@ describe('InvoiceService', () => {
       expect(adapter.issueInvoice).toHaveBeenCalledTimes(1);
     });
 
-    it('(j) failed-row retry always re-attempts (R2/R3 regression anchor)', async () => {
-      const failedHit = makeRecord({ id: 'f', status: 'failed', errorMessage: 'prior terminal rejection' });
-      repo.findByIdempotencyKey.mockResolvedValue(failedHit);
+    it('(j) R3: an in-doubt failed hit is NOT re-attempted — surfaced for manual reconciliation, NO provider call', async () => {
+      const inDoubtHit = makeRecord({
+        id: 'f',
+        status: 'failed',
+        failureMode: 'in-doubt',
+        errorMessage: 'transport timeout — document may exist',
+      });
+      repo.findByIdempotencyKey.mockResolvedValue(inDoubtHit);
+
+      const result = await service.issueInvoice(makeCmd());
+
+      // Fiscal-safety invariant: a document MAY already exist, so the SVC must NOT
+      // re-cross the boundary. It returns the stuck row untouched.
+      expect(result).toBe(inDoubtHit);
+      expect(repo.claimForIssue).not.toHaveBeenCalled();
+      expect(adapter.issueInvoice).not.toHaveBeenCalled();
+      expect(repo.updateOutcome).not.toHaveBeenCalled();
+    });
+
+    it('(j2) R3: a failed hit with NO recorded failureMode is treated as in-doubt — NOT re-attempted', async () => {
+      const unknownModeHit = makeRecord({ id: 'f', status: 'failed', failureMode: null });
+      repo.findByIdempotencyKey.mockResolvedValue(unknownModeHit);
+
+      const result = await service.issueInvoice(makeCmd());
+
+      expect(result).toBe(unknownModeHit);
+      expect(adapter.issueInvoice).not.toHaveBeenCalled();
+    });
+
+    it('(l) R2/R3 pending: a row under a LIVE issuing lease is NOT re-attempted (no claim, no provider call)', async () => {
+      const liveLeaseHit = makeRecord({
+        id: 'in-flight',
+        status: 'issuing',
+        leaseExpiresAt: new Date(Date.now() + 60_000),
+      });
+      repo.findByIdempotencyKey.mockResolvedValue(liveLeaseHit);
+
+      const result = await service.issueInvoice(makeCmd());
+
+      // An original attempt is still in flight; never race a second provider call.
+      expect(result).toBe(liveLeaseHit);
+      expect(repo.claimForIssue).not.toHaveBeenCalled();
+      expect(adapter.issueInvoice).not.toHaveBeenCalled();
+    });
+
+    it('(l2) R2: an EXPIRED issuing lease is re-claimable — claim then re-attempt', async () => {
+      const expiredLeaseHit = makeRecord({
+        id: 'stale',
+        status: 'issuing',
+        leaseExpiresAt: new Date(Date.now() - 60_000),
+      });
+      repo.findByIdempotencyKey.mockResolvedValue(expiredLeaseHit);
       adapter.issueInvoice.mockResolvedValue(makeIssuedFromAdapter());
-      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'f', status: 'issued' }));
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'stale', status: 'issued' }));
 
       await service.issueInvoice(makeCmd());
 
+      expect(repo.claimForIssue).toHaveBeenCalledWith('stale', expect.any(Date));
+      expect(adapter.issueInvoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('(m) R2 single-flight: a LOST claim (claimForIssue -> null) backs off WITHOUT calling the provider', async () => {
+      const reattemptable = makeRecord({ id: 'contended', status: 'pending' });
+      repo.findByIdempotencyKey.mockResolvedValue(reattemptable);
+      // The CAS lost to a concurrent same-key retry: null = slot held / terminal.
+      repo.claimForIssue.mockResolvedValue(null);
+      // findById re-reads the current row to return to the caller.
+      const currentRow = makeRecord({ id: 'contended', status: 'issuing' });
+      repo.findById.mockResolvedValue(currentRow);
+
+      const result = await service.issueInvoice(makeCmd());
+
+      expect(adapter.issueInvoice).not.toHaveBeenCalled();
+      expect(repo.updateOutcome).not.toHaveBeenCalled();
+      expect(result).toBe(currentRow);
+    });
+
+    it('(m2) R2 concurrency: of two same-key attempts on one re-attemptable row, EXACTLY ONE crosses the provider boundary', async () => {
+      const reattemptable = makeRecord({ id: 'race', status: 'pending' });
+      repo.findByIdempotencyKey.mockResolvedValue(reattemptable);
+
+      // Simulate the atomic CAS: only the FIRST claimer wins; the rest get null.
+      let claimed = false;
+      repo.claimForIssue.mockImplementation((id: string) => {
+        if (claimed) {
+          return Promise.resolve(null);
+        }
+        claimed = true;
+        return Promise.resolve(makeRecord({ id, status: 'issuing' }));
+      });
+      adapter.issueInvoice.mockResolvedValue(makeIssuedFromAdapter());
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'race', status: 'issued' }));
+      repo.findById.mockResolvedValue(makeRecord({ id: 'race', status: 'issuing' }));
+
+      await Promise.all([service.issueInvoice(makeCmd()), service.issueInvoice(makeCmd())]);
+
+      // The provider boundary is crossed exactly once despite two concurrent retries.
       expect(adapter.issueInvoice).toHaveBeenCalledTimes(1);
     });
 

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -56,8 +56,17 @@ const MAX_ERROR_MESSAGE_LENGTH = 500;
 /**
  * Lifetime of an `issuing` CAS lease (#1200). Bounds how long a crashed
  * mid-call attempt can block same-key retries before the slot becomes
- * re-claimable. Kept comfortably longer than a real provider issuance round-trip
- * so a slow-but-live attempt is never stolen out from under itself.
+ * re-claimable.
+ *
+ * FISCAL SAFETY — this MUST stay strictly greater than the longest possible
+ * single provider round-trip, or an expired lease could be re-claimed while the
+ * original call is still in flight → a SECOND provider call → a double-issued
+ * fiscal document. Today the Subiekt adapter caps its per-request `timeoutMs` at
+ * 120 s at config validation (subiekt-adapter.factory.ts), so 5 min leaves a
+ * comfortable 2.5× margin. If any provider's max round-trip (incl. transport
+ * retries) is ever allowed to approach this bound, raise the lease (or assert
+ * `maxProviderTimeout < ISSUING_LEASE_MS` at config validation) — the margin must
+ * be by construction, not by coincidence.
  */
 const ISSUING_LEASE_MS = 5 * 60 * 1000;
 

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -28,8 +28,10 @@ import { INVOICE_RECORD_REPOSITORY_TOKEN } from '../../invoicing.tokens';
 import type { InvoiceRecord } from '../../domain/entities/invoice-record.entity';
 import type { InvoicingPort } from '../../domain/ports/invoicing.port';
 import { DuplicateInvoiceRecordException } from '../../domain/exceptions/duplicate-invoice-record.exception';
+import { InvoiceRecordNotFoundException } from '../../domain/exceptions/invoice-record-not-found.exception';
 import type {
   GetInvoiceByOrderQuery,
+  InvoiceFailureMode,
   InvoiceOutcomePatch,
   InvoiceRecordFilters,
   InvoiceRecordPagination,
@@ -51,6 +53,25 @@ const INVOICING_CAPABILITY = 'Invoicing';
  */
 const MAX_ERROR_MESSAGE_LENGTH = 500;
 
+/**
+ * Lifetime of an `issuing` CAS lease (#1200). Bounds how long a crashed
+ * mid-call attempt can block same-key retries before the slot becomes
+ * re-claimable. Kept comfortably longer than a real provider issuance round-trip
+ * so a slow-but-live attempt is never stolen out from under itself.
+ */
+const ISSUING_LEASE_MS = 5 * 60 * 1000;
+
+/**
+ * Neutral shape the SVC reads STRUCTURALLY off a caught adapter throwable to
+ * classify the failure mode (#1200) — it is NOT an adapter error subclass and is
+ * NOT value-imported. Adapters expose a neutral `failureMode` on their thrown
+ * errors; the SVC reads it duck-typed. Anything it cannot read as the terminal
+ * `'rejected'` is treated as the fiscal-safe `'in-doubt'`.
+ */
+interface NeutralFailureCarrier {
+  failureMode?: unknown;
+}
+
 @Injectable()
 export class InvoiceService implements IInvoiceService {
   private readonly logger = new Logger(InvoiceService.name);
@@ -65,19 +86,13 @@ export class InvoiceService implements IInvoiceService {
   async issueInvoice(cmd: IssueInvoiceCommand): Promise<InvoiceRecord> {
     // (1) Idempotency read-gate. Only when a key is supplied (R1: keyless calls
     // are never deduplicated). An already-`issued` hit is returned verbatim — no
-    // second provider document. ANY non-`issued` hit (`failed` AND `pending`)
-    // re-attempts by REUSING that row (R2/R3): any non-`issued` row is treated as
-    // re-attemptable. A `pending` hit may be a still-in-flight original attempt for
-    // the same key — not excluded here — so a retry can double-issue alongside it
-    // (R3, highest exactly-once exposure).
+    // second provider document. A non-`issued` hit is resumed under the
+    // fiscal-safety invariant (see resumeExisting): R2/R3 closure (#1200).
     const key = cmd.idempotencyKey;
     if (key !== undefined) {
       const existing = await this.repo.findByIdempotencyKey(cmd.connectionId, key);
       if (existing) {
-        if (existing.status === 'issued') {
-          return existing;
-        }
-        return this.issueWithAdapter(cmd, existing.id);
+        return this.resumeExisting(cmd, existing);
       }
     }
 
@@ -100,15 +115,13 @@ export class InvoiceService implements IInvoiceService {
       });
     } catch (error) {
       // (5) Create-race: a concurrent same-key call won the dedup guard between
-      // our read-gate and create. Re-read by key and return/continue the winner.
-      // Guarded by `key !== undefined` — the guard cannot fire keyless.
+      // our read-gate and create. Re-read by key and resume the winner under the
+      // SAME fiscal-safety gate. Guarded by `key !== undefined` — the guard
+      // cannot fire keyless.
       if (key !== undefined && error instanceof DuplicateInvoiceRecordException) {
         const winner = await this.repo.findByIdempotencyKey(cmd.connectionId, key);
         if (winner) {
-          if (winner.status === 'issued') {
-            return winner;
-          }
-          return this.issueWithAdapter(cmd, winner.id);
+          return this.resumeExisting(cmd, winner);
         }
       }
       throw error;
@@ -118,16 +131,87 @@ export class InvoiceService implements IInvoiceService {
   }
 
   /**
-   * Steps (3)+(4): resolve the per-connection `'Invoicing'` adapter, cross the
-   * CORE<->Integration boundary, and patch the `recordId` row with the outcome.
-   * On success -> `issued` + the six provider fields. On any throw (terminal
-   * rejection OR unreachable transport — indistinguishable by design, see R3) ->
-   * `failed` + a sanitized errorMessage, then rethrow (per-design propagation).
+   * Decide how to resume an EXISTING same-key record, enforcing the fiscal-safety
+   * invariant before any retry re-crosses the provider boundary (#1200). Shared
+   * by the read-gate and the create-race re-read so both honour the same rules:
+   *
+   *   - `issued`           -> return verbatim (idempotent replay).
+   *   - live `issuing`     -> return as-is; another attempt holds the slot. NO
+   *                           provider call (closes R2 + the `pending` half of R3).
+   *   - in-doubt `failed`  -> return as-is for manual reconciliation. NO provider
+   *                           call (a document may already exist — closes R3's
+   *                           `failed` half).
+   *   - re-attemptable     -> `pending`, expired `issuing`, or a terminal
+   *                           `rejected` `failed`: claim the slot atomically and,
+   *                           only on a WIN, re-cross the boundary. A lost claim
+   *                           returns the contended row WITHOUT a provider call.
+   */
+  private async resumeExisting(
+    cmd: IssueInvoiceCommand,
+    existing: InvoiceRecord,
+  ): Promise<InvoiceRecord> {
+    if (existing.status === 'issued') {
+      return existing;
+    }
+
+    const now = new Date();
+    if (existing.isLeaseLive(now)) {
+      // R2/R3: an original attempt is still in flight under a live lease. Surface
+      // the in-flight row; NEVER race a second provider call alongside it.
+      this.logger.warn(
+        `Invoice record ${existing.id} is claimed by a live in-flight attempt; not re-attempting`,
+      );
+      return existing;
+    }
+
+    if (existing.status === 'failed' && !existing.isReattemptableFailure) {
+      // R3: an in-doubt failure — the provider MAY have issued a document. Block
+      // the auto-re-attempt and surface for manual reconciliation.
+      this.logger.warn(
+        `Invoice record ${existing.id} failed in-doubt (failureMode=${existing.failureMode ?? 'unknown'}); ` +
+          `not auto-re-attempting — surfaced for manual reconciliation`,
+      );
+      return existing;
+    }
+
+    // Re-attemptable: `pending`, an expired `issuing` lease, or a terminal
+    // `rejected` `failed`. issueWithAdapter claims the slot atomically first so
+    // exactly one concurrent same-key retry crosses the boundary (R2).
+    return this.issueWithAdapter(cmd, existing.id);
+  }
+
+  /**
+   * Steps (3)+(4): atomically CLAIM the in-flight slot, resolve the per-connection
+   * `'Invoicing'` adapter, cross the CORE<->Integration boundary, and patch the
+   * `recordId` row with the outcome. On success -> `issued` + the six provider
+   * fields (lease cleared). On a throw -> `failed` + a sanitized errorMessage + a
+   * neutral `failureMode` read STRUCTURALLY off the throwable (lease cleared),
+   * then rethrow (per-design propagation).
+   *
+   * The CAS claim (claimForIssue) is the R2 single-flight guard: a concurrent
+   * same-key retry that fails to claim backs off WITHOUT calling the provider.
    */
   private async issueWithAdapter(
     cmd: IssueInvoiceCommand,
     recordId: string,
   ): Promise<InvoiceRecord> {
+    // (3a) Atomic claim. A null return means a live attempt already holds the
+    // slot (or the row went terminal): back off WITHOUT crossing the boundary.
+    const leaseExpiresAt = new Date(Date.now() + ISSUING_LEASE_MS);
+    const claimed = await this.repo.claimForIssue(recordId, leaseExpiresAt);
+    if (claimed === null) {
+      this.logger.warn(
+        `Could not claim invoice record ${recordId} for issuance ` +
+          `(held by a live attempt or already terminal); not re-attempting`,
+      );
+      const current = await this.repo.findById(recordId);
+      if (current) {
+        return current;
+      }
+      // Vanished between claim and re-read — surface as not-found per contract.
+      throw new InvoiceRecordNotFoundException(recordId);
+    }
+
     const adapter = await this.integrations.getCapabilityAdapter<InvoicingPort>(
       cmd.connectionId,
       INVOICING_CAPABILITY,
@@ -138,14 +222,18 @@ export class InvoiceService implements IInvoiceService {
       issued = await adapter.issueInvoice(cmd);
     } catch (error) {
       const sanitized = this.sanitizeError(error);
+      const failureMode = this.classifyFailure(error);
       // Log the BOUNDED diagnostic + record id only — never the raw (unbounded,
       // possibly buyer-echoing) provider message to an external sink.
       this.logger.warn(
-        `Invoice issuance failed for record ${recordId}: ${sanitized}`,
+        `Invoice issuance failed for record ${recordId} (failureMode=${failureMode}): ${sanitized}`,
       );
       const patch: InvoiceOutcomePatch = {
         status: 'failed',
         errorMessage: sanitized,
+        failureMode,
+        // Release the lease: the attempt is over (terminal rejection or in-doubt).
+        leaseExpiresAt: null,
       };
       await this.repo.updateOutcome(recordId, patch);
       throw error;
@@ -166,10 +254,30 @@ export class InvoiceService implements IInvoiceService {
       clearanceReference: issued.clearanceReference,
       pdfUrl: issued.pdfUrl,
       issuedAt: issued.issuedAt,
-      // Clear any stale message from a prior failed attempt on this row.
+      // Clear any stale message + failure mode from a prior failed attempt, and
+      // release the `issuing` lease — the record is now terminal `issued`.
       errorMessage: null,
+      failureMode: null,
+      leaseExpiresAt: null,
     };
     return this.repo.updateOutcome(recordId, patch);
+  }
+
+  /**
+   * Classify a caught adapter throwable into the neutral {@link InvoiceFailureMode}
+   * (#1200) WITHOUT value-importing any adapter error subclass. The adapter stamps
+   * a neutral `failureMode` on the errors it throws; the SVC reads it STRUCTURALLY
+   * (duck-typed) here.
+   *
+   * Fiscal-safe default: ONLY an explicit, recognised `'rejected'` is treated as a
+   * terminal no-document failure (safe to re-attempt). EVERYTHING else — an
+   * absent/unknown/`'in-doubt'` marker, a plain `Error`, a non-error throwable —
+   * collapses to `'in-doubt'`, which the read-gate will NOT auto-re-attempt. An
+   * unclassifiable failure must never be assumed safe to re-issue.
+   */
+  private classifyFailure(error: unknown): InvoiceFailureMode {
+    const mode = (error as NeutralFailureCarrier | null)?.failureMode;
+    return mode === 'rejected' ? 'rejected' : 'in-doubt';
   }
 
   async getInvoice(query: GetInvoiceByOrderQuery): Promise<InvoiceRecord | null> {

--- a/libs/core/src/invoicing/domain/entities/invoice-record.entity.spec.ts
+++ b/libs/core/src/invoicing/domain/entities/invoice-record.entity.spec.ts
@@ -4,9 +4,12 @@
  * @module libs/core/src/invoicing/domain/entities
  */
 import { InvoiceRecord } from './invoice-record.entity';
-import type { InvoiceStatus } from '../types/invoicing.types';
+import type { InvoiceFailureMode, InvoiceStatus } from '../types/invoicing.types';
 
-function makeRecord(status: InvoiceStatus): InvoiceRecord {
+function makeRecord(
+  status: InvoiceStatus,
+  extras: { failureMode?: InvoiceFailureMode | null; leaseExpiresAt?: Date | null } = {},
+): InvoiceRecord {
   const now = new Date('2026-06-16T00:00:00.000Z');
   return new InvoiceRecord(
     'ol_invoice_1',
@@ -25,6 +28,8 @@ function makeRecord(status: InvoiceStatus): InvoiceRecord {
     null,
     now,
     now,
+    extras.failureMode ?? null,
+    extras.leaseExpiresAt ?? null,
   );
 }
 
@@ -44,5 +49,46 @@ describe('InvoiceRecord', () => {
     const record = makeRecord('issued');
     expect(record.regulatoryStatus).toBe('not-applicable');
     expect(record.clearanceReference).toBeNull();
+  });
+
+  describe('isReattemptableFailure (#1200)', () => {
+    it('is true ONLY for a terminal rejected failure', () => {
+      expect(makeRecord('failed', { failureMode: 'rejected' }).isReattemptableFailure).toBe(true);
+    });
+
+    it('is false for an in-doubt failure (a document may already exist)', () => {
+      expect(makeRecord('failed', { failureMode: 'in-doubt' }).isReattemptableFailure).toBe(false);
+    });
+
+    it('is false for a failed row with no recorded mode (fiscal-safe default)', () => {
+      expect(makeRecord('failed', { failureMode: null }).isReattemptableFailure).toBe(false);
+    });
+
+    it('is false for non-failed statuses', () => {
+      expect(makeRecord('pending').isReattemptableFailure).toBe(false);
+      expect(makeRecord('issuing').isReattemptableFailure).toBe(false);
+      expect(makeRecord('issued').isReattemptableFailure).toBe(false);
+    });
+  });
+
+  describe('isLeaseLive (#1200)', () => {
+    const now = new Date('2026-06-16T12:00:00.000Z');
+
+    it('is true for an issuing row whose lease is in the future', () => {
+      const live = makeRecord('issuing', { leaseExpiresAt: new Date(now.getTime() + 60_000) });
+      expect(live.isLeaseLive(now)).toBe(true);
+    });
+
+    it('is false for an issuing row whose lease has expired', () => {
+      const expired = makeRecord('issuing', { leaseExpiresAt: new Date(now.getTime() - 1) });
+      expect(expired.isLeaseLive(now)).toBe(false);
+    });
+
+    it('is false for an issuing row with no lease, and for non-issuing statuses', () => {
+      expect(makeRecord('issuing', { leaseExpiresAt: null }).isLeaseLive(now)).toBe(false);
+      expect(
+        makeRecord('pending', { leaseExpiresAt: new Date(now.getTime() + 60_000) }).isLeaseLive(now),
+      ).toBe(false);
+    });
   });
 });

--- a/libs/core/src/invoicing/domain/entities/invoice-record.entity.ts
+++ b/libs/core/src/invoicing/domain/entities/invoice-record.entity.ts
@@ -10,7 +10,11 @@
  *
  * @module libs/core/src/invoicing/domain/entities
  */
-import type { InvoiceStatus, RegulatoryStatus } from '../types/invoicing.types';
+import type {
+  InvoiceFailureMode,
+  InvoiceStatus,
+  RegulatoryStatus,
+} from '../types/invoicing.types';
 
 export class InvoiceRecord {
   constructor(
@@ -34,10 +38,46 @@ export class InvoiceRecord {
     public readonly errorMessage: string | null,
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
+    /**
+     * Neutral failure discriminator (#1200) — `null` unless `status === 'failed'`.
+     * `rejected` = provider definitely created no document (safe to re-attempt);
+     * `in-doubt` = the request may have issued a document (UNSAFE to re-attempt,
+     * surfaced for manual reconciliation). See {@link InvoiceFailureMode}.
+     */
+    public readonly failureMode: InvoiceFailureMode | null = null,
+    /**
+     * Lease expiry for the `issuing` CAS claim (#1200) — `null` unless this
+     * record currently holds the in-flight slot. A claim is only contended while
+     * `status === 'issuing'` AND the lease is in the future.
+     */
+    public readonly leaseExpiresAt: Date | null = null,
   ) {}
 
   /** Pure derivation: the document was successfully issued by the provider. */
   get isIssued(): boolean {
     return this.status === 'issued';
+  }
+
+  /**
+   * Pure derivation (#1200): a `failed` row is safe to re-attempt ONLY when the
+   * provider DEFINITELY created no document — a terminal `rejected` failure. An
+   * `in-doubt` failure (or an absent mode) is NEVER re-attemptable: the document
+   * may already exist, so it is surfaced for manual reconciliation.
+   */
+  get isReattemptableFailure(): boolean {
+    return this.status === 'failed' && this.failureMode === 'rejected';
+  }
+
+  /**
+   * Pure derivation (#1200): is this record's `issuing` claim still live at
+   * `now`? A live claim means another attempt holds the in-flight slot and a
+   * concurrent retry must NOT re-cross the provider boundary.
+   */
+  isLeaseLive(now: Date): boolean {
+    return (
+      this.status === 'issuing' &&
+      this.leaseExpiresAt !== null &&
+      this.leaseExpiresAt.getTime() > now.getTime()
+    );
   }
 }

--- a/libs/core/src/invoicing/domain/ports/invoice-record-repository.port.ts
+++ b/libs/core/src/invoicing/domain/ports/invoice-record-repository.port.ts
@@ -42,15 +42,20 @@ export interface InvoiceRecordRepositoryPort {
   /**
    * Atomic compare-and-swap claim of the in-flight issuance slot (#1200, closes
    * R2 + the `pending` half of R3). Conditionally flips a record to `issuing`
-   * with a fresh lease ONLY when no live attempt already holds it — i.e. the row
-   * is `pending`/`failed`, OR it is `issuing` with an EXPIRED lease (a crashed
-   * prior attempt whose lease lapsed). Performed as a single guarded UPDATE so
-   * exactly one concurrent same-key retry can win the slot.
+   * with a fresh lease ONLY when no live attempt already holds it AND a re-attempt
+   * is fiscally safe — i.e. the row is `pending`, OR a TERMINAL-`rejected` `failed`
+   * row (provider definitely created no document), OR `issuing` with an EXPIRED
+   * lease (a crashed prior attempt whose lease lapsed). An in-doubt/mode-less
+   * `failed` row is NEVER claimed here (a document may already exist) — the fiscal
+   * invariant is enforced at this persistence boundary, not only in the service.
+   * Performed as a single guarded UPDATE so exactly one concurrent same-key retry
+   * can win the slot.
    *
    * Returns the claimed record (now `issuing`, lease = `leaseExpiresAt`) on a
-   * WIN; returns `null` when the slot is held by a live `issuing` lease or the
-   * row is already terminal (`issued`) — the caller MUST then back off WITHOUT
-   * crossing the provider boundary. NEVER claims an `issued` row.
+   * WIN; returns `null` when the slot is held by a live `issuing` lease, the row
+   * is already terminal (`issued`), or it is an in-doubt `failed` row — the caller
+   * MUST then back off WITHOUT crossing the provider boundary. NEVER claims an
+   * `issued` row.
    *
    * The fiscal contract: a `null` return is a SAFE non-action (a stuck/contended
    * record is preferable to a double-issued document). Throws

--- a/libs/core/src/invoicing/domain/ports/invoice-record-repository.port.ts
+++ b/libs/core/src/invoicing/domain/ports/invoice-record-repository.port.ts
@@ -40,6 +40,25 @@ export interface InvoiceRecordRepositoryPort {
   updateOutcome(id: string, patch: InvoiceOutcomePatch): Promise<InvoiceRecord>;
 
   /**
+   * Atomic compare-and-swap claim of the in-flight issuance slot (#1200, closes
+   * R2 + the `pending` half of R3). Conditionally flips a record to `issuing`
+   * with a fresh lease ONLY when no live attempt already holds it — i.e. the row
+   * is `pending`/`failed`, OR it is `issuing` with an EXPIRED lease (a crashed
+   * prior attempt whose lease lapsed). Performed as a single guarded UPDATE so
+   * exactly one concurrent same-key retry can win the slot.
+   *
+   * Returns the claimed record (now `issuing`, lease = `leaseExpiresAt`) on a
+   * WIN; returns `null` when the slot is held by a live `issuing` lease or the
+   * row is already terminal (`issued`) — the caller MUST then back off WITHOUT
+   * crossing the provider boundary. NEVER claims an `issued` row.
+   *
+   * The fiscal contract: a `null` return is a SAFE non-action (a stuck/contended
+   * record is preferable to a double-issued document). Throws
+   * `InvoiceRecordNotFoundException` when the id does not exist.
+   */
+  claimForIssue(id: string, leaseExpiresAt: Date): Promise<InvoiceRecord | null>;
+
+  /**
    * Read-only paginated list (#1119). Backs ONLY the AC-6 list endpoint;
    * ordered newest-first (`createdAt` DESC). The POST re-issue gate is served by
    * `findByOrderId` (the single-row order primitive), NOT this list query, so

--- a/libs/core/src/invoicing/domain/types/invoicing.types.spec.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.spec.ts
@@ -9,6 +9,7 @@
 import {
   BuyerTypeValues,
   DocumentTypeValues,
+  InvoiceFailureModeValues,
   InvoiceStatusValues,
   RegulatoryStatusValues,
 } from './invoicing.types';
@@ -26,7 +27,12 @@ describe('invoicing.types', () => {
   });
 
   it('exposes the issuance lifecycle states', () => {
-    expect([...InvoiceStatusValues]).toEqual(['pending', 'issued', 'failed']);
+    // `issuing` (#1200) is the in-flight CAS-claim state between pending and terminal.
+    expect([...InvoiceStatusValues]).toEqual(['pending', 'issuing', 'issued', 'failed']);
+  });
+
+  it('exposes the neutral failure-mode discriminator (#1200)', () => {
+    expect([...InvoiceFailureModeValues]).toEqual(['rejected', 'in-doubt']);
   });
 
   it('exposes the neutral CTC clearance lifecycle', () => {

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -31,9 +31,38 @@ export const DocumentTypeValues = [
 ] as const;
 export type DocumentType = (typeof DocumentTypeValues)[number];
 
-/** Issuance lifecycle of an `InvoiceRecord` (distinct from payment — see ADR-026). */
-export const InvoiceStatusValues = ['pending', 'issued', 'failed'] as const;
+/**
+ * Issuance lifecycle of an `InvoiceRecord` (distinct from payment — see ADR-026).
+ *
+ * `issuing` (#1200) is the in-flight CLAIM state: a record an attempt has leased
+ * to cross the provider boundary. It sits between `pending` (intent persisted,
+ * not yet claimed) and the terminal `issued`/`failed`. A concurrent same-key
+ * retry that finds a record under a LIVE `issuing` lease must NOT re-cross the
+ * boundary — exactly one attempt may hold the slot (closes R2 + the `pending`
+ * half of R3). The lease has an expiry (`leaseExpiresAt`) so a crash mid-call
+ * does not orphan the record forever.
+ */
+export const InvoiceStatusValues = ['pending', 'issuing', 'issued', 'failed'] as const;
 export type InvoiceStatus = (typeof InvoiceStatusValues)[number];
+
+/**
+ * Neutral failure discriminator (#1200) — the fiscal-safety pivot for re-attempt.
+ * Carried from the provider adapter into the neutral outcome WITHOUT core ever
+ * value-importing an adapter error subclass: the service reads it STRUCTURALLY
+ * off the caught throwable (see `InvoiceService.classifyFailure`).
+ *
+ *   - `rejected`: a TERMINAL provider rejection — the provider DEFINITELY did not
+ *     create a document (e.g. invalid tax data). A `failed` row of this kind is
+ *     SAFE to re-attempt: re-crossing the boundary cannot double-issue.
+ *   - `in-doubt`: a transient/indeterminate transport failure — the request MAY
+ *     have reached the provider and a document MAY have been created (timeout,
+ *     reset, unknown error). A `failed` row of this kind is UNSAFE to re-attempt:
+ *     it is surfaced for manual reconciliation, never auto-re-issued. This is the
+ *     FISCAL-SAFE DEFAULT: any failure whose mode the service cannot read
+ *     structurally is treated as `in-doubt`.
+ */
+export const InvoiceFailureModeValues = ['rejected', 'in-doubt'] as const;
+export type InvoiceFailureMode = (typeof InvoiceFailureModeValues)[number];
 
 /**
  * Neutral Continuous-Transaction-Controls clearance lifecycle. The adapter maps
@@ -163,6 +192,8 @@ export interface CreateInvoiceRecordInput {
   pdfUrl?: string | null;
   issuedAt?: Date | null;
   errorMessage?: string | null;
+  /** Neutral failure discriminator (#1200); `null` for a non-`failed` create. */
+  failureMode?: InvoiceFailureMode | null;
 }
 
 /**
@@ -227,4 +258,16 @@ export interface InvoiceOutcomePatch {
   pdfUrl?: string | null;
   issuedAt?: Date | null;
   errorMessage?: string | null;
+  /**
+   * Neutral failure discriminator (#1200). Set when patching a `failed` outcome
+   * so the read-gate can tell a re-attemptable terminal rejection (`rejected`)
+   * from an unsafe in-doubt transport failure (`in-doubt`). Cleared (`null`) on a
+   * successful `issued` patch alongside `errorMessage`.
+   */
+  failureMode?: InvoiceFailureMode | null;
+  /**
+   * Lease expiry for the `issuing` CAS claim (#1200). Set when an attempt claims
+   * the in-flight slot; cleared (`null`) on the terminal `issued`/`failed` patch.
+   */
+  leaseExpiresAt?: Date | null;
 }

--- a/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
@@ -19,7 +19,11 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-import { InvoiceStatus, RegulatoryStatus } from '../../../domain/types/invoicing.types';
+import {
+  InvoiceFailureMode,
+  InvoiceStatus,
+  RegulatoryStatus,
+} from '../../../domain/types/invoicing.types';
 
 @Entity('invoice_records')
 @Index('IDX_invoice_records_order_connection', ['orderId', 'connectionId'])
@@ -78,6 +82,21 @@ export class InvoiceRecordOrmEntity {
 
   @Column({ type: 'text', nullable: true })
   errorMessage!: string | null;
+
+  /**
+   * Neutral failure discriminator (#1200) — `null` unless `status = 'failed'`.
+   * `rejected` (terminal, no document) is re-attemptable; `in-doubt` is not.
+   */
+  @Column({ type: 'text', nullable: true })
+  failureMode!: InvoiceFailureMode | null;
+
+  /**
+   * Lease expiry for the `issuing` CAS claim (#1200) — `null` unless this row
+   * currently holds the in-flight slot. Backs the atomic `claimForIssue` guard
+   * that lets exactly one concurrent same-key retry cross the provider boundary.
+   */
+  @Column({ type: 'timestamp', nullable: true })
+  leaseExpiresAt!: Date | null;
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
@@ -19,11 +19,8 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-import {
-  InvoiceFailureMode,
-  InvoiceStatus,
-  RegulatoryStatus,
-} from '../../../domain/types/invoicing.types';
+import type { InvoiceFailureMode } from '../../../domain/types/invoicing.types';
+import { InvoiceStatus, RegulatoryStatus } from '../../../domain/types/invoicing.types';
 
 @Entity('invoice_records')
 @Index('IDX_invoice_records_order_connection', ['orderId', 'connectionId'])

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
@@ -187,6 +187,76 @@ describe('InvoiceRecordRepository', () => {
         repository.updateOutcome('missing', { status: 'failed' }),
       ).rejects.toBeInstanceOf(InvoiceRecordNotFoundException);
     });
+
+    it('persists the #1200 failureMode + lease fields when patched', async () => {
+      ormRepo.findOne.mockResolvedValue(ormRow({ status: 'issuing' }));
+      ormRepo.save.mockImplementation((e) => Promise.resolve(e as InvoiceRecordOrmEntity));
+
+      const result = await repository.updateOutcome('ol_invoice_1', {
+        status: 'failed',
+        failureMode: 'in-doubt',
+        leaseExpiresAt: null,
+      });
+
+      const saved = ormRepo.save.mock.calls[0][0] as InvoiceRecordOrmEntity;
+      expect(saved.failureMode).toBe('in-doubt');
+      expect(saved.leaseExpiresAt).toBeNull();
+      expect(result.failureMode).toBe('in-doubt');
+    });
+  });
+
+  describe('claimForIssue (#1200 CAS)', () => {
+    let updateQb: {
+      update: jest.Mock;
+      set: jest.Mock;
+      where: jest.Mock;
+      andWhere: jest.Mock;
+      execute: jest.Mock;
+    };
+
+    beforeEach(() => {
+      updateQb = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn(),
+      };
+      ormRepo.createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(updateQb) as unknown as typeof ormRepo.createQueryBuilder;
+    });
+
+    it('returns the claimed (issuing) record on a winning CAS (affected > 0)', async () => {
+      updateQb.execute.mockResolvedValue({ affected: 1, raw: [] });
+      const lease = new Date('2026-06-25T12:05:00.000Z');
+      ormRepo.findOne.mockResolvedValue(ormRow({ status: 'issuing', leaseExpiresAt: lease }));
+
+      const result = await repository.claimForIssue('ol_invoice_1', lease);
+
+      expect(updateQb.set).toHaveBeenCalledWith({ status: 'issuing', leaseExpiresAt: lease });
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe('issuing');
+    });
+
+    it('returns null on a LOST CAS (affected 0) when the row still exists', async () => {
+      updateQb.execute.mockResolvedValue({ affected: 0, raw: [] });
+      // Existence disambiguation read finds the (contended) row.
+      ormRepo.findOne.mockResolvedValue(ormRow({ status: 'issuing' }));
+
+      const result = await repository.claimForIssue('ol_invoice_1', new Date());
+
+      expect(result).toBeNull();
+    });
+
+    it('throws InvoiceRecordNotFoundException when affected 0 and the row is absent', async () => {
+      updateQb.execute.mockResolvedValue({ affected: 0, raw: [] });
+      ormRepo.findOne.mockResolvedValue(null);
+
+      await expect(repository.claimForIssue('missing', new Date())).rejects.toBeInstanceOf(
+        InvoiceRecordNotFoundException,
+      );
+    });
   });
 
   describe('findMany', () => {

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
@@ -77,6 +77,9 @@ describe('InvoiceRecordRepository', () => {
     ormRepo = {
       findOne: jest.fn(),
       save: jest.fn(),
+      // `create` hydrates a RETURNING raw row into an entity (#1200 claimForIssue);
+      // the real impl copies fields, so a pass-through is faithful enough here.
+      create: jest.fn((raw) => raw as InvoiceRecordOrmEntity),
       createQueryBuilder: jest.fn().mockReturnValue(qb),
     } as unknown as jest.Mocked<Repository<InvoiceRecordOrmEntity>>;
     repository = new InvoiceRecordRepository(ormRepo);
@@ -211,6 +214,7 @@ describe('InvoiceRecordRepository', () => {
       set: jest.Mock;
       where: jest.Mock;
       andWhere: jest.Mock;
+      returning: jest.Mock;
       execute: jest.Mock;
     };
 
@@ -220,6 +224,7 @@ describe('InvoiceRecordRepository', () => {
         set: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockReturnThis(),
         execute: jest.fn(),
       };
       ormRepo.createQueryBuilder = jest
@@ -227,16 +232,53 @@ describe('InvoiceRecordRepository', () => {
         .mockReturnValue(updateQb) as unknown as typeof ormRepo.createQueryBuilder;
     });
 
-    it('returns the claimed (issuing) record on a winning CAS (affected > 0)', async () => {
-      updateQb.execute.mockResolvedValue({ affected: 1, raw: [] });
+    it('returns the claimed (issuing) record from the RETURNING row on a winning CAS (affected > 0)', async () => {
       const lease = new Date('2026-06-25T12:05:00.000Z');
-      ormRepo.findOne.mockResolvedValue(ormRow({ status: 'issuing', leaseExpiresAt: lease }));
+      // Single-statement win: the row comes back via RETURNING (`raw`), NOT a
+      // follow-up read — closes the won-but-stale-re-read race (#1200).
+      updateQb.execute.mockResolvedValue({
+        affected: 1,
+        raw: [ormRow({ status: 'issuing', leaseExpiresAt: lease })],
+      });
 
       const result = await repository.claimForIssue('ol_invoice_1', lease);
 
       expect(updateQb.set).toHaveBeenCalledWith({ status: 'issuing', leaseExpiresAt: lease });
+      expect(updateQb.returning).toHaveBeenCalledWith('*');
+      // Fiscal guard at the persistence boundary (#1200): the claim predicate
+      // must only re-claim a TERMINAL-`rejected` failed row — never an in-doubt
+      // one — so an in-doubt failure can never be re-issued even via a direct
+      // claimForIssue call that bypasses the service gate.
+      const claimSql = updateQb.andWhere.mock.calls[0][0] as string;
+      expect(claimSql).toContain(`"failureMode" = 'rejected'`);
+      expect(claimSql).not.toMatch(/status IN \('pending', 'failed'\)/);
+      // No separate re-read on the happy path.
+      expect(ormRepo.findOne).not.toHaveBeenCalled();
       expect(result).not.toBeNull();
       expect(result?.status).toBe('issuing');
+    });
+
+    it('falls back to a re-read when a win returns no RETURNING row, and NEVER downgrades a win to null', async () => {
+      // Driver that does not honour RETURNING: affected > 0 but empty raw. A WON
+      // claim must resolve to the row, never to a (false) contended-loss null.
+      updateQb.execute.mockResolvedValue({ affected: 1, raw: [] });
+      ormRepo.findOne.mockResolvedValue(ormRow({ status: 'issuing' }));
+
+      const result = await repository.claimForIssue('ol_invoice_1', new Date());
+
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe('issuing');
+    });
+
+    it('throws (does NOT return null) when a win cannot be read back at all', async () => {
+      // affected > 0 (we provably hold the lease) but the row is unreadable: fail
+      // loud rather than silently report a loss that would orphan the held row.
+      updateQb.execute.mockResolvedValue({ affected: 1, raw: [] });
+      ormRepo.findOne.mockResolvedValue(null);
+
+      await expect(repository.claimForIssue('ol_invoice_1', new Date())).rejects.toBeInstanceOf(
+        InvoiceRecordNotFoundException,
+      );
     });
 
     it('returns null on a LOST CAS (affected 0) when the row still exists', async () => {

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
@@ -249,7 +249,7 @@ describe('InvoiceRecordRepository', () => {
       // must only re-claim a TERMINAL-`rejected` failed row — never an in-doubt
       // one — so an in-doubt failure can never be re-issued even via a direct
       // claimForIssue call that bypasses the service gate.
-      const claimSql = updateQb.andWhere.mock.calls[0][0] as string;
+      const claimSql = (updateQb.andWhere.mock.calls as unknown[][])[0][0] as string;
       expect(claimSql).toContain(`"failureMode" = 'rejected'`);
       expect(claimSql).not.toMatch(/status IN \('pending', 'failed'\)/);
       // No separate re-read on the happy path.

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
@@ -87,6 +87,52 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
   }
 
   /**
+   * Atomic compare-and-swap claim of the in-flight issuance slot (#1200). A
+   * SINGLE guarded UPDATE flips the row to `issuing` with a fresh lease ONLY when
+   * no live attempt holds it — i.e. the row is `pending`/`failed`, OR it is
+   * `issuing` with an EXPIRED lease. Postgres serialises the row-level write, so
+   * of two concurrent same-key retries exactly one matches the WHERE and updates;
+   * the loser's `affected` is 0 and it must back off WITHOUT a provider call.
+   *
+   * An `issued` row never matches (no `issued` in the allowed-status set), so a
+   * terminal document is never re-claimed. Returns the claimed row on a win,
+   * `null` on a loss; throws `InvoiceRecordNotFoundException` when the id is
+   * absent (distinguished from a contended loss by a follow-up existence read).
+   */
+  async claimForIssue(id: string, leaseExpiresAt: Date): Promise<InvoiceRecord | null> {
+    const now = new Date();
+    const result = await this.repository
+      .createQueryBuilder()
+      .update(InvoiceRecordOrmEntity)
+      .set({ status: 'issuing', leaseExpiresAt })
+      .where('id = :id', { id })
+      .andWhere(
+        // Claimable iff NOT currently held by a live attempt and NOT terminal:
+        //   - pending / failed (no live lease by definition), OR
+        //   - issuing with an expired lease (a crashed prior attempt).
+        `(status IN ('pending', 'failed') OR (status = 'issuing' AND ("leaseExpiresAt" IS NULL OR "leaseExpiresAt" <= :now)))`,
+        { now },
+      )
+      .execute();
+
+    if (result.affected && result.affected > 0) {
+      // Claim won. Re-read through the entity mapper so the caller gets a fully
+      // hydrated domain record (the UPDATE's raw row is not entity-shaped).
+      const claimed = await this.repository.findOne({ where: { id } });
+      return claimed ? this.toDomain(claimed) : null;
+    }
+
+    // No row updated: either the id does not exist, or the slot is held by a live
+    // attempt / already terminal. Disambiguate so the contract can throw
+    // not-found vs. signal a contended-loss (`null`).
+    const exists = await this.repository.findOne({ where: { id }, select: { id: true } });
+    if (!exists) {
+      throw new InvoiceRecordNotFoundException(id);
+    }
+    return null;
+  }
+
+  /**
    * Read-only AC-6 list (#1119). One `andWhere` per PRESENT filter only —
    * absent filters never constrain the query. The `issuedFrom`/`issuedTo`
    * bounds are inclusive and apply to `inv.issuedAt`. Ordered newest-first by
@@ -137,6 +183,9 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
     entity.pdfUrl = input.pdfUrl ?? null;
     entity.issuedAt = input.issuedAt ?? null;
     entity.errorMessage = input.errorMessage ?? null;
+    entity.failureMode = input.failureMode ?? null;
+    // A freshly-created `pending` row holds no in-flight lease (#1200).
+    entity.leaseExpiresAt = null;
     return entity;
   }
 
@@ -158,6 +207,8 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
       entity.errorMessage,
       entity.createdAt,
       entity.updatedAt,
+      entity.failureMode,
+      entity.leaseExpiresAt,
     );
   }
 }

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
@@ -107,24 +107,48 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
       .set({ status: 'issuing', leaseExpiresAt })
       .where('id = :id', { id })
       .andWhere(
-        // Claimable iff NOT currently held by a live attempt and NOT terminal:
-        //   - pending / failed (no live lease by definition), OR
+        // Claimable iff NOT currently held by a live attempt and NOT terminal AND
+        // NOT an in-doubt failure (a document may already exist — #1200). Defends
+        // the fiscal invariant at the PERSISTENCE boundary, not just in the SVC:
+        //   - pending (no lease by definition), OR
+        //   - a TERMINAL-`rejected` failed row (definitely no document — safe), OR
         //   - issuing with an expired lease (a crashed prior attempt).
-        `(status IN ('pending', 'failed') OR (status = 'issuing' AND ("leaseExpiresAt" IS NULL OR "leaseExpiresAt" <= :now)))`,
+        // An `issued`, an in-doubt/mode-less `failed`, or a live `issuing` row
+        // NEVER matches, so it can never be re-claimed and re-issued.
+        `(status = 'pending'
+          OR (status = 'failed' AND "failureMode" = 'rejected')
+          OR (status = 'issuing' AND ("leaseExpiresAt" IS NULL OR "leaseExpiresAt" <= :now)))`,
         { now },
       )
+      // Single statement: RETURNING hands back the just-claimed row in the SAME
+      // write, so there is no UPDATE->read window in which another tx can mutate
+      // the row out from under us (closes the won-but-stale-re-read race).
+      .returning('*')
       .execute();
 
     if (result.affected && result.affected > 0) {
-      // Claim won. Re-read through the entity mapper so the caller gets a fully
-      // hydrated domain record (the UPDATE's raw row is not entity-shaped).
+      const raw = Array.isArray(result.raw) ? result.raw[0] : undefined;
+      if (raw) {
+        // RETURNING gives the raw row shape; hydrate it through the repository's
+        // entity metadata so the caller gets a fully-typed domain record.
+        const entity = this.repository.create(raw as Partial<InvoiceRecordOrmEntity>);
+        return this.toDomain(entity);
+      }
+      // We provably WON the claim (affected > 0) but could not read the row back
+      // (e.g. a driver that does not honour RETURNING). This attempt now HOLDS the
+      // lease, so it MUST NOT be reported as a contended loss (which would make the
+      // holder back off and orphan the row). Re-read; if still unreadable, fail
+      // loud rather than silently downgrade a win to a loss.
       const claimed = await this.repository.findOne({ where: { id } });
-      return claimed ? this.toDomain(claimed) : null;
+      if (claimed) {
+        return this.toDomain(claimed);
+      }
+      throw new InvoiceRecordNotFoundException(id);
     }
 
     // No row updated: either the id does not exist, or the slot is held by a live
-    // attempt / already terminal. Disambiguate so the contract can throw
-    // not-found vs. signal a contended-loss (`null`).
+    // attempt / already terminal / an in-doubt failure. Disambiguate so the
+    // contract can throw not-found vs. signal a contended-loss (`null`).
     const exists = await this.repository.findOne({ where: { id }, select: { id: true } });
     if (!exists) {
       throw new InvoiceRecordNotFoundException(id);

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
@@ -127,11 +127,12 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
       .execute();
 
     if (result.affected && result.affected > 0) {
-      const raw = Array.isArray(result.raw) ? result.raw[0] : undefined;
+      const rawRows = (Array.isArray(result.raw) ? result.raw : []) as unknown[];
+      const raw = rawRows[0] as Partial<InvoiceRecordOrmEntity> | undefined;
       if (raw) {
         // RETURNING gives the raw row shape; hydrate it through the repository's
         // entity metadata so the caller gets a fully-typed domain record.
-        const entity = this.repository.create(raw as Partial<InvoiceRecordOrmEntity>);
+        const entity = this.repository.create(raw);
         return this.toDomain(entity);
       }
       // We provably WON the claim (affected > 0) but could not read the row back

--- a/libs/integrations/subiekt/src/domain/exceptions/__tests__/subiekt-bridge-transport.exception.spec.ts
+++ b/libs/integrations/subiekt/src/domain/exceptions/__tests__/subiekt-bridge-transport.exception.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * SubiektBridgeTransportError — unit tests (#1200)
+ *
+ * Pins the neutral `failureMode` discriminator the core `InvoiceService` reads
+ * STRUCTURALLY off this error. The transport retryability axis maps 1:1 onto the
+ * neutral fiscal mode: a PROVEN-safe transport failure (request never left the
+ * host) means no document was created (`rejected`, safe to re-attempt); an
+ * indeterminate one means a document MAY exist (`in-doubt`, unsafe).
+ *
+ * @module libs/integrations/subiekt/src/domain/exceptions
+ */
+import { SubiektBridgeTransportError } from '../subiekt-bridge-transport.exception';
+
+describe('SubiektBridgeTransportError (#1200 failureMode)', () => {
+  it("maps retryability 'safe' -> failureMode 'rejected' (no document created)", () => {
+    const error = new SubiektBridgeTransportError('connect refused', 'safe');
+    expect(error.failureMode).toBe('rejected');
+    expect(error.retryable).toBe(true);
+  });
+
+  it("maps retryability 'indeterminate' -> failureMode 'in-doubt' (document may exist)", () => {
+    const error = new SubiektBridgeTransportError('timeout', 'indeterminate');
+    expect(error.failureMode).toBe('in-doubt');
+    expect(error.retryable).toBe(false);
+  });
+});

--- a/libs/integrations/subiekt/src/domain/exceptions/subiekt-bridge-auth.exception.ts
+++ b/libs/integrations/subiekt/src/domain/exceptions/subiekt-bridge-auth.exception.ts
@@ -17,6 +17,13 @@ export class SubiektBridgeAuthError extends Error {
   /** Bridge HTTP status that triggered this (401 or 403). */
   readonly status: number;
 
+  /**
+   * Neutral failure discriminator (#1200) read STRUCTURALLY by core. A 401/403 is
+   * rejected at the bridge BEFORE the request reaches Subiekt, so NO document was
+   * created — the row is SAFE to re-attempt once the credential is fixed.
+   */
+  readonly failureMode = 'rejected' as const;
+
   constructor(status: number) {
     super('Subiekt bridge authentication failed (check bridge token/credentials)');
     this.name = 'SubiektBridgeAuthError';

--- a/libs/integrations/subiekt/src/domain/exceptions/subiekt-bridge-transport.exception.ts
+++ b/libs/integrations/subiekt/src/domain/exceptions/subiekt-bridge-transport.exception.ts
@@ -31,6 +31,19 @@ export class SubiektBridgeTransportError extends Error {
   readonly retryability: SubiektTransportRetryability;
   readonly retryable: boolean;
 
+  /**
+   * Neutral failure discriminator the core `InvoiceService` reads STRUCTURALLY
+   * (#1200) to decide fiscal re-attemptability — core never value-imports this
+   * class. The transport retryability axis maps 1:1 onto the neutral mode:
+   *   - `'safe'`          -> `'rejected'`: the request PROVABLY never left the
+   *                          host (connect-refused / DNS-failure), so NO document
+   *                          was created — SAFE to re-attempt.
+   *   - `'indeterminate'` -> `'in-doubt'`: the POST MAY have been received and
+   *                          acted on (timeout / reset / unknown), so a document
+   *                          MAY exist — UNSAFE to auto-re-attempt.
+   */
+  readonly failureMode: 'rejected' | 'in-doubt';
+
   constructor(
     message: string,
     retryability: SubiektTransportRetryability,
@@ -43,6 +56,7 @@ export class SubiektBridgeTransportError extends Error {
     this.name = 'SubiektBridgeTransportError';
     this.retryability = retryability;
     this.retryable = retryability === 'safe';
+    this.failureMode = retryability === 'safe' ? 'rejected' : 'in-doubt';
     Error.captureStackTrace(this, this.constructor);
   }
 }

--- a/libs/integrations/subiekt/src/domain/exceptions/subiekt-config.exception.ts
+++ b/libs/integrations/subiekt/src/domain/exceptions/subiekt-config.exception.ts
@@ -11,6 +11,13 @@
  */
 
 export class SubiektConfigException extends Error {
+  /**
+   * Neutral failure discriminator (#1200) read STRUCTURALLY by core. A
+   * deterministic config / SSRF-guard failure raised BEFORE any request leaves
+   * the client — NO document was created, so SAFE to re-attempt once fixed.
+   */
+  readonly failureMode = 'rejected' as const;
+
   constructor(
     message: string,
     readonly field: string,

--- a/libs/integrations/subiekt/src/domain/exceptions/subiekt-invoice-rejected.exception.ts
+++ b/libs/integrations/subiekt/src/domain/exceptions/subiekt-invoice-rejected.exception.ts
@@ -11,6 +11,14 @@
  */
 
 export class SubiektInvoiceRejectedError extends Error {
+  /**
+   * Neutral failure discriminator the core `InvoiceService` reads STRUCTURALLY
+   * (#1200) to decide re-attemptability — core never value-imports this class.
+   * A rejection is TERMINAL: the provider definitely created NO document, so the
+   * row is SAFE to re-attempt.
+   */
+  readonly failureMode = 'rejected' as const;
+
   constructor(readonly reason: string) {
     super(`Subiekt rejected the invoice: ${reason}`);
     this.name = 'SubiektInvoiceRejectedError';

--- a/libs/integrations/subiekt/src/domain/exceptions/subiekt-unsupported-document-type.exception.ts
+++ b/libs/integrations/subiekt/src/domain/exceptions/subiekt-unsupported-document-type.exception.ts
@@ -10,6 +10,13 @@
  */
 
 export class SubiektUnsupportedDocumentTypeError extends Error {
+  /**
+   * Neutral failure discriminator (#1200) read STRUCTURALLY by core. A
+   * deterministic caller-contract violation raised in the mapper before any
+   * request leaves the adapter — NO document was created, so SAFE to re-attempt.
+   */
+  readonly failureMode = 'rejected' as const;
+
   constructor(readonly documentType: string) {
     super(
       `Subiekt does not support document type "${documentType}". Supported: invoice, receipt.`,

--- a/libs/integrations/subiekt/src/infrastructure/adapters/__tests__/subiekt-invoicing.adapter.spec.ts
+++ b/libs/integrations/subiekt/src/infrastructure/adapters/__tests__/subiekt-invoicing.adapter.spec.ts
@@ -122,9 +122,10 @@ describe('SubiektInvoicingAdapter', () => {
     it('translates seedFailure(subiekt-rejected) -> SubiektInvoiceRejectedError (terminal)', async () => {
       const { adapter, bridge } = makeAdapter();
       bridge.seedFailure('subiekt-rejected', { reason: 'invalid NIP' });
-      await expect(adapter.issueInvoice(command())).rejects.toBeInstanceOf(
-        SubiektInvoiceRejectedError,
-      );
+      const caught = await adapter.issueInvoice(command()).catch((e: unknown) => e);
+      expect(caught).toBeInstanceOf(SubiektInvoiceRejectedError);
+      // #1200 neutral discriminator: a terminal rejection => no document => safe.
+      expect(caught).toMatchObject({ failureMode: 'rejected' });
     });
 
     it("translates seed({state:'failed'}) -> SubiektInvoiceRejectedError (terminal)", async () => {
@@ -149,6 +150,8 @@ describe('SubiektInvoicingAdapter', () => {
       await expect(adapter.issueInvoice(command())).rejects.toMatchObject({
         retryability: 'indeterminate',
         retryable: false,
+        // #1200: an indeterminate transport failure => document may exist => in-doubt.
+        failureMode: 'in-doubt',
       });
     });
 


### PR DESCRIPTION
Closes the two open exactly-once gaps on `InvoiceService.issueInvoice` (R2/R3 from #1200), upholding the overriding fiscal-safety invariant: **a real fiscal document must NEVER be double-issued.** When it is uncertain whether the provider already created a document, the service does NOT auto-re-attempt — it blocks and surfaces the record for manual reconciliation. A stuck/needs-attention row is always preferable to a duplicate fiscal document.

## The two gaps

- **R2 — concurrent same-key retry double-issue.** The partial unique index only guarded the `create` path. The read-gate re-attempted any non-`issued` row by reusing it (`updateOutcome`), so two concurrent same-key retries could both read it and both call the provider → two documents.
- **R3 — in-doubt retry double-issue.** Core could not tell a terminal provider rejection (definitely no document) from a transient/in-doubt transport failure (a document may exist), because core must not value-import adapter error subclasses. So every non-`issued` row was treated as re-attemptable — a `failed` row whose provider actually issued, or a `pending` row whose original is still in flight, could double-issue.

## The closure

**1. Neutral `failureMode` discriminator (R3).** The Subiekt adapter now stamps a neutral `failureMode` (`'rejected' | 'in-doubt'`) on the errors it throws — a provider rejection / auth / config / unsupported-type ⇒ `'rejected'` (definitely no document, safe to re-attempt); a transport `'safe'` ⇒ `'rejected'`, `'indeterminate'` ⇒ `'in-doubt'` (a document may exist, unsafe). `InvoiceService` reads it **structurally** off the caught throwable (no adapter error-subclass value-import) and persists it on the `failed` row. The read-gate re-attempts a `failed` row **only** when `failureMode === 'rejected'`; an in-doubt — or any unreadable/unknown — failure collapses to the fiscal-safe `'in-doubt'` and is never auto-re-attempted.

**2. CAS / lease on `InvoiceRecordRepositoryPort` (R2 + pending half of R3).** A new atomic `claimForIssue(id, leaseExpiresAt)` flips a re-attemptable row to a new `'issuing'` status under a time-bounded lease via a single guarded `UPDATE`. Of two concurrent same-key retries, exactly one wins the claim and crosses the provider boundary; the loser backs off **without** calling the provider. A row under a **live** `issuing` lease is never re-attempted (the original is still in flight); an **expired** lease is re-claimable so a crash does not orphan the record. The existing create-path partial-unique-index guard is unchanged — these are added retry-path guards.

Migration `1812000000000` adds nullable `failureMode` + `leaseExpiresAt` columns to `invoice_records` (`status` gains the logical value `issuing`; it is a plain text column, no type change). The R2/R3 prose on `IInvoiceService` is rewritten to describe the now-closed contract.

## Acceptance — covered by tests

- A terminal-rejection (`failureMode: 'rejected'`) `failed` row **is** re-attemptable; an in-doubt `failed` row (and a mode-less one) is **not** re-attempted (no double-issue).
- A `pending`/`issuing` row under a live in-flight lease is not re-attempted; a lost CAS claim backs off without a provider call; two concurrent same-key attempts cross the provider boundary **exactly once**.
- No adapter error subclass is value-imported into `libs/core` (the discriminator is read structurally).
- R2/R3 prose on `IInvoiceService` updated.

Targeted tests: `@openlinker/core` invoicing (83) + `@openlinker/integrations-subiekt` (137) green; `@openlinker/core` and `@openlinker/api` type-check clean.

Closes #1200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txy9aqLujJBG1dSwGd4z3f