### PR TITLE
fix(prestashop): PrestaShop 9 webservice adapter — order_details rename, missing order address hydration, irregular-plural unwrap

### DIFF
--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
@@ -323,6 +323,23 @@ describe('PrestashopOrderSourceAdapter', () => {
     };
     const baseOrderRows: PrestashopOrderRow[] = [];
 
+    // Resource-keyed getResource mock. Since #<issue> the adapter also hydrates
+    // the buyer address (and its country) inside getOrder, so the call sequence
+    // is no longer "order then address" — these tests dispatch by (resource,id)
+    // instead of relying on call order.
+    const keyedGetResource = (address: Record<string, unknown> | Error): void => {
+      mockHttpClient.getResource = jest.fn().mockImplementation((resource: string, id: string) => {
+        if (resource === 'orders') return Promise.resolve(baseOrder);
+        if (resource === 'addresses') {
+          return address instanceof Error
+            ? Promise.reject(address)
+            : Promise.resolve({ id, ...address });
+        }
+        if (resource === 'countries') return Promise.resolve({ id, iso_code: 'PL' });
+        return Promise.resolve({});
+      });
+    };
+
     it('should populate pickupPoint when inpostPsModuleType is official_inpost and address2 is a paczkomat code', async () => {
       const inpostConnection = createTestConnection({
         config: { inpostPsModuleType: 'official_inpost' },
@@ -332,17 +349,13 @@ describe('PrestashopOrderSourceAdapter', () => {
         orderMapper,
         inpostConnection
       );
-      mockHttpClient.getResource = jest
-        .fn()
-        .mockResolvedValueOnce(baseOrder)
-        .mockResolvedValueOnce({ id: '5', address2: 'POZ08A' });
+      keyedGetResource({ address2: 'POZ08A' });
       mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(baseOrderRows);
 
       const incoming = await inpostAdapter.getOrder({ externalOrderId: '42' });
 
       expect(incoming.pickupPoint).toEqual({ id: 'POZ08A' });
-      expect(mockHttpClient.getResource).toHaveBeenCalledTimes(2);
-      expect(mockHttpClient.getResource).toHaveBeenNthCalledWith(2, 'addresses', '5');
+      expect(mockHttpClient.getResource).toHaveBeenCalledWith('addresses', '5');
     });
 
     it('should leave pickupPoint undefined when inpostPsModuleType is none', async () => {
@@ -354,23 +367,23 @@ describe('PrestashopOrderSourceAdapter', () => {
         orderMapper,
         noneConnection
       );
-      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce(baseOrder);
+      keyedGetResource({ address2: 'POZ08A' });
       mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(baseOrderRows);
 
       const incoming = await noneAdapter.getOrder({ externalOrderId: '42' });
 
+      // pickupPoint stays undefined because the module type is not official_inpost,
+      // even though the address itself is hydrated for the buyer profile.
       expect(incoming.pickupPoint).toBeUndefined();
-      expect(mockHttpClient.getResource).toHaveBeenCalledTimes(1);
     });
 
     it('should leave pickupPoint undefined when inpostPsModuleType is absent', async () => {
-      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce(baseOrder);
+      keyedGetResource({ address2: 'POZ08A' });
       mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(baseOrderRows);
 
       const incoming = await adapter.getOrder({ externalOrderId: '42' });
 
       expect(incoming.pickupPoint).toBeUndefined();
-      expect(mockHttpClient.getResource).toHaveBeenCalledTimes(1);
     });
 
     it('should leave pickupPoint undefined when address2 does not match paczkomat format', async () => {
@@ -382,10 +395,7 @@ describe('PrestashopOrderSourceAdapter', () => {
         orderMapper,
         inpostConnection
       );
-      mockHttpClient.getResource = jest
-        .fn()
-        .mockResolvedValueOnce(baseOrder)
-        .mockResolvedValueOnce({ id: '5', address2: 'Piętro 2' });
+      keyedGetResource({ address2: 'Piętro 2' });
       mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(baseOrderRows);
 
       const incoming = await inpostAdapter.getOrder({ externalOrderId: '42' });
@@ -402,10 +412,7 @@ describe('PrestashopOrderSourceAdapter', () => {
         orderMapper,
         inpostConnection
       );
-      mockHttpClient.getResource = jest
-        .fn()
-        .mockResolvedValueOnce(baseOrder)
-        .mockRejectedValueOnce(new PrestashopApiException('Not Found', 404));
+      keyedGetResource(new PrestashopApiException('Not Found', 404));
       mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(baseOrderRows);
 
       const incoming = await inpostAdapter.getOrder({ externalOrderId: '42' });
@@ -422,10 +429,7 @@ describe('PrestashopOrderSourceAdapter', () => {
         orderMapper,
         inpostConnection
       );
-      mockHttpClient.getResource = jest
-        .fn()
-        .mockResolvedValueOnce(baseOrder)
-        .mockResolvedValueOnce({ id: '5', address2: 'poz08a' });
+      keyedGetResource({ address2: 'poz08a' });
       mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(baseOrderRows);
 
       const incoming = await inpostAdapter.getOrder({ externalOrderId: '42' });
@@ -442,10 +446,7 @@ describe('PrestashopOrderSourceAdapter', () => {
         orderMapper,
         inpostConnection
       );
-      mockHttpClient.getResource = jest
-        .fn()
-        .mockResolvedValueOnce(baseOrder)
-        .mockResolvedValueOnce({ id: '5', address2: 'WAW124' });
+      keyedGetResource({ address2: 'WAW124' });
       mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(baseOrderRows);
 
       const incoming = await inpostAdapter.getOrder({ externalOrderId: '42' });
@@ -470,6 +471,134 @@ describe('PrestashopOrderSourceAdapter', () => {
 
       expect(incoming.pickupPoint).toBeUndefined();
       expect(mockHttpClient.getResource).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getOrder — order line items (PS9 order_details rename)', () => {
+    it('should fetch order rows from the order_details resource (renamed from order_rows in PS9)', async () => {
+      const prestashopOrder: PrestashopOrder = {
+        id: '42',
+        reference: 'ORDER-042',
+        id_customer: '7',
+        current_state: '2',
+        total_paid: '99.99',
+        date_add: '2024-01-01 10:00:00',
+        date_upd: '2024-01-01 12:00:00',
+      };
+      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce(prestashopOrder);
+      mockHttpClient.listResources = jest.fn().mockResolvedValueOnce([]);
+
+      await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(mockHttpClient.listResources).toHaveBeenCalledWith('order_details', {
+        custom: { id_order: '42' },
+      });
+    });
+  });
+
+  describe('getOrder — buyer address hydration', () => {
+    const orderWithAddresses: PrestashopOrder = {
+      id: '42',
+      reference: 'ORDER-042',
+      id_customer: '7',
+      id_address_invoice: '11',
+      id_address_delivery: '11',
+      current_state: '2',
+      total_paid: '99.99',
+      date_add: '2024-01-01 10:00:00',
+      date_upd: '2024-01-01 12:00:00',
+    };
+
+    it('should hydrate billing/shipping address from the addresses resource and resolve country ISO-2', async () => {
+      mockHttpClient.getResource = jest.fn().mockImplementation((resource: string, id: string) => {
+        if (resource === 'orders') return Promise.resolve(orderWithAddresses);
+        if (resource === 'addresses') {
+          return Promise.resolve({
+            id,
+            firstname: 'Jan',
+            lastname: 'Kowalski',
+            company: 'ACME Sp. z o.o.',
+            address1: 'ul. Testowa 1',
+            address2: 'm. 4',
+            city: 'Poznań',
+            postcode: '60-001',
+            phone: '+48123456789',
+            id_country: '14',
+          });
+        }
+        if (resource === 'countries') return Promise.resolve({ id, iso_code: 'pl' });
+        return Promise.resolve({});
+      });
+      mockHttpClient.listResources = jest.fn().mockResolvedValueOnce([]);
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(incoming.billingAddress).toEqual({
+        firstName: 'Jan',
+        lastName: 'Kowalski',
+        company: 'ACME Sp. z o.o.',
+        address1: 'ul. Testowa 1',
+        address2: 'm. 4',
+        city: 'Poznań',
+        postalCode: '60-001',
+        country: 'PL',
+        phone: '+48123456789',
+      });
+      // Delivery uses the same address id (11) → shipping equals billing.
+      expect(incoming.shippingAddress).toEqual(incoming.billingAddress);
+      expect(mockHttpClient.getResource).toHaveBeenCalledWith('addresses', '11');
+      expect(mockHttpClient.getResource).toHaveBeenCalledWith('countries', '14');
+    });
+
+    it('should leave country empty and still hydrate the address when the country fetch fails', async () => {
+      mockHttpClient.getResource = jest.fn().mockImplementation((resource: string, id: string) => {
+        if (resource === 'orders') return Promise.resolve(orderWithAddresses);
+        if (resource === 'addresses') {
+          return Promise.resolve({ id, address1: 'ul. Testowa 1', city: 'Poznań', postcode: '60-001', id_country: '14' });
+        }
+        if (resource === 'countries') return Promise.reject(new Error('boom'));
+        return Promise.resolve({});
+      });
+      mockHttpClient.listResources = jest.fn().mockResolvedValueOnce([]);
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(incoming.billingAddress?.country).toBe('');
+      expect(incoming.billingAddress?.address1).toBe('ul. Testowa 1');
+    });
+
+    it('should leave addresses undefined when the order carries no address ids', async () => {
+      const orderNoAddr: PrestashopOrder = { ...orderWithAddresses };
+      delete orderNoAddr.id_address_invoice;
+      delete orderNoAddr.id_address_delivery;
+      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce(orderNoAddr);
+      mockHttpClient.listResources = jest.fn().mockResolvedValueOnce([]);
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(incoming.billingAddress).toBeUndefined();
+      expect(incoming.shippingAddress).toBeUndefined();
+      // Only the order itself is fetched — no address/country round-trips.
+      expect(mockHttpClient.getResource).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall back to billing address for shipping when delivery hydration fails', async () => {
+      const order: PrestashopOrder = { ...orderWithAddresses, id_address_invoice: '11', id_address_delivery: '22' };
+      mockHttpClient.getResource = jest.fn().mockImplementation((resource: string, id: string) => {
+        if (resource === 'orders') return Promise.resolve(order);
+        if (resource === 'addresses') {
+          if (id === '22') return Promise.reject(new Error('delivery 404'));
+          return Promise.resolve({ id, address1: 'Bill St 1', city: 'Warsaw', postcode: '00-001', id_country: '14' });
+        }
+        if (resource === 'countries') return Promise.resolve({ id, iso_code: 'PL' });
+        return Promise.resolve({});
+      });
+      mockHttpClient.listResources = jest.fn().mockResolvedValueOnce([]);
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(incoming.shippingAddress).toEqual(incoming.billingAddress);
+      expect(incoming.billingAddress?.address1).toBe('Bill St 1');
     });
   });
 });

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
@@ -335,6 +335,7 @@ describe('PrestashopOrderSourceAdapter', () => {
             ? Promise.reject(address)
             : Promise.resolve({ id, ...address });
         }
+        // Country value is irrelevant to pickup-point resolution; any ISO is fine here.
         if (resource === 'countries') return Promise.resolve({ id, iso_code: 'PL' });
         return Promise.resolve({});
       });

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
@@ -173,6 +173,22 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
     const config = this.connection.config as unknown as PrestashopConnectionConfig;
     const pickupPoint = await this.resolvePickupPoint(prestashopOrder, config);
 
+    // The order JSON carries only address IDs, so the mapper cannot populate
+    // billing/shipping bodies. Hydrate them from the address resources so
+    // downstream consumers (e.g. invoicing buyer-profile derivation) have a
+    // real address, incl. the B2B `company` field.
+    const billingAddress =
+      (mapped.billingAddress as IncomingOrderAddress | undefined) ??
+      (await this.hydrateAddress(
+        prestashopOrder.id_address_invoice as string | number | undefined
+      ));
+    const shippingAddress =
+      (mapped.shippingAddress as IncomingOrderAddress | undefined) ??
+      (await this.hydrateAddress(
+        prestashopOrder.id_address_delivery
+      )) ??
+      billingAddress;
+
     const items: IncomingOrderItem[] = mapped.items.map((item, index) => {
       const row = orderRows[index];
       const externalId =
@@ -217,8 +233,8 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
         prestashopOrder.id_customer !== undefined ? String(prestashopOrder.id_customer) : undefined,
       items,
       totals: mapped.totals,
-      shippingAddress: mapped.shippingAddress as IncomingOrderAddress | undefined,
-      billingAddress: mapped.billingAddress as IncomingOrderAddress | undefined,
+      shippingAddress,
+      billingAddress,
       placedAt: placedAtIso,
       createdAt: createdAtIso,
       updatedAt: updatedAtIso,
@@ -268,9 +284,69 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
     return { id: raw.toUpperCase() };
   }
 
+  private readonly countryIso2Cache = new Map<string, string>();
+
+  /**
+   * Resolve a country's ISO-3166 alpha-2 code from its PrestaShop id_country,
+   * cached per adapter instance. Returns '' on failure (callers default).
+   */
+  private async resolveCountryIso2(idCountry: string | number | undefined): Promise<string> {
+    if (idCountry === undefined || idCountry === null) return '';
+    const key = String(idCountry);
+    const cached = this.countryIso2Cache.get(key);
+    if (cached !== undefined) return cached;
+    try {
+      const country = await this.httpClient.getResource<{ iso_code?: string }>('countries', key);
+      const iso = (country.iso_code ?? '').toUpperCase();
+      this.countryIso2Cache.set(key, iso);
+      return iso;
+    } catch (error) {
+      this.logger.warn(`Failed to resolve country ${key}: ${(error as Error).message}`);
+      this.countryIso2Cache.set(key, '');
+      return '';
+    }
+  }
+
+  /**
+   * Fetch a PrestaShop address resource by id and map it to the neutral
+   * IncomingOrderAddress (incl. the B2B `company` field). Returns undefined
+   * when the id is absent or the fetch fails.
+   */
+  private async hydrateAddress(
+    addressId: string | number | undefined
+  ): Promise<IncomingOrderAddress | undefined> {
+    if (!addressId) return undefined;
+    try {
+      const a = await this.httpClient.getResource<PrestashopAddress & { company?: string }>(
+        'addresses',
+        String(addressId)
+      );
+      return {
+        firstName: a.firstname,
+        lastName: a.lastname,
+        company: a.company,
+        address1: a.address1 ?? '',
+        address2: a.address2,
+        city: a.city ?? '',
+        postalCode: a.postcode ?? '',
+        country: await this.resolveCountryIso2(a.id_country),
+        phone: a.phone,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Failed to hydrate address ${String(addressId)}: ${(error as Error).message}`
+      );
+      return undefined;
+    }
+  }
+
   private async fetchOrderRows(orderId: string | number): Promise<PrestashopOrderRow[]> {
     try {
-      return await this.httpClient.listResources<PrestashopOrderRow>('order_rows', {
+      // PrestaShop 9.x renamed the `order_rows` webservice resource to
+      // `order_details`; the row field shape (product_id/quantity/price/
+      // reference) is unchanged, so the existing PrestashopOrderRow mapping
+      // still applies.
+      return await this.httpClient.listResources<PrestashopOrderRow>('order_details', {
         custom: { id_order: orderId },
       });
     } catch (error) {

--- a/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-webservice.client.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-webservice.client.spec.ts
@@ -196,6 +196,61 @@ describe('PrestashopWebserviceClient', () => {
         PrestashopApiException
       );
     });
+
+    // Irregular -es plurals (`addresses` → `address`, `countries` → `country`)
+    // must unwrap to the inner object. The old `slice(0, -1)` computed
+    // `addresse` / `countrie`, which never matched, returning the envelope.
+    it('should unwrap the addresses resource (irregular -es plural)', async () => {
+      const mockResponse = {
+        prestashop: {
+          address: { id: '11', firstname: 'Jan', id_country: '14' },
+        },
+      };
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify(mockResponse)),
+      });
+
+      const result = await client.getResource<{ id: string; firstname: string }>('addresses', '11');
+
+      expect(result).toEqual({ id: '11', firstname: 'Jan', id_country: '14' });
+    });
+
+    it('should unwrap the countries resource (irregular -es plural)', async () => {
+      const mockResponse = {
+        prestashop: {
+          country: { id: '14', iso_code: 'PL' },
+        },
+      };
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify(mockResponse)),
+      });
+
+      const result = await client.getResource<{ iso_code: string }>('countries', '14');
+
+      expect(result.iso_code).toBe('PL');
+    });
+
+    it('should still unwrap the regular products resource', async () => {
+      const mockResponse = {
+        prestashop: { product: { id: '1', name: 'Test Product' } },
+      };
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify(mockResponse)),
+      });
+
+      const result = await client.getResource<{ id: string; name: string }>('products', '1');
+
+      expect(result).toEqual({ id: '1', name: 'Test Product' });
+    });
   });
 
   describe('listResources', () => {

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts
@@ -140,16 +140,26 @@ export class PrestashopWebserviceClient implements IPrestashopWebserviceClient {
       responseFormat
     );
 
-    // Unwrap single resource response
-    // PrestaShop JSON API returns: { product: { ... } } for single resources
-    // We need to unwrap it to return just the product object
+    // Unwrap single resource response.
+    // After the parser strips the `prestashop` wrapper, a single resource is
+    // `{ <singular>: { ... } }` — e.g. `{ product: {...} }`, `{ address: {...} }`,
+    // `{ country: {...} }`. The singular element name is NOT reliably the plural
+    // minus a trailing 's': irregular -es plurals (`addresses` → `address`,
+    // `countries` → `country`) and compound plurals (`order_histories` →
+    // `order_history`) all break `slice(0, -1)`, which would leave the envelope
+    // un-unwrapped and return `{ address: {...} }` instead of the inner object.
+    // Robust rule: when the parsed object has exactly one top-level key whose
+    // value is an object, that key is the resource wrapper — unwrap it. This is
+    // language-agnostic and covers every singular form. Already-flat responses
+    // (and multi-key shapes) fall through to "return as-is".
     const parsedObj = parsed as Record<string, unknown>;
-    const itemKey = resource.slice(0, -1); // e.g., 'product' (singular from 'products')
-
-    // Check if parsed object has the resource key (e.g., 'product')
-    if (parsedObj[itemKey] && typeof parsedObj[itemKey] === 'object') {
-      // Unwrap: return the inner object (e.g., parsed.product)
-      return parsedObj[itemKey] as T;
+    const topLevelKeys = Object.keys(parsedObj);
+    if (topLevelKeys.length === 1) {
+      const onlyKey = topLevelKeys[0];
+      const inner = parsedObj[onlyKey];
+      if (inner !== null && typeof inner === 'object') {
+        return inner as T;
+      }
     }
 
     // If no unwrapping needed, return as-is

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts
@@ -38,7 +38,12 @@ const IRREGULAR_RESOURCE_SINGULARS: Readonly<Record<string, string>> = {
   order_histories: 'order_history',
 };
 
-/** PrestaShop singular element name for a WS resource (handles irregular plurals). */
+/**
+ * PrestaShop singular element name for a WS resource (handles irregular plurals).
+ * WRITES ONLY — used to BUILD the request envelope (`{ prestashop: { <singular>: data } }`)
+ * and to unwrap write responses. Reads (`getResource`) don't use this: they strip the
+ * envelope by single-key shape, which is robust to every irregular singular without a map.
+ */
 function singularizeResource(resource: string): string {
   return IRREGULAR_RESOURCE_SINGULARS[resource] ?? resource.slice(0, -1);
 }


### PR DESCRIPTION
## What & why

Fixes three PrestaShop WebService adapter bugs discovered during a live **PrestaShop 9.0.2** end-to-end test. Together they break inbound order ingestion (and downstream invoicing/fulfillment).

### 1. `order_rows` → `order_details` (PS9 resource rename)
PrestaShop 9 renamed the order-lines WebService resource. The old `order_rows` call 400s, the error is swallowed, and `fetchOrderRows()` returns `[]` — so ingested orders carry **no line items**. The row field shape (`product_id` / `product_quantity` / `product_price` / `product_reference`) is unchanged, so only the resource name changes.

### 2. `OrderSource` buyer-address hydration
`getOrder()` mapped only the order JSON, which carries address **IDs**, not bodies — so `billingAddress` / `shippingAddress` were always `undefined` and invoicing 422'd with "buyer details unavailable". Now hydrates the `addresses` resource (incl. the B2B `company` field) and resolves the country ISO-3166 alpha-2 from `id_country` via the `countries` resource (cached per adapter instance). Shipping falls back to billing when delivery hydration is unavailable; a failed country fetch leaves `country: ''` but still returns the address.

### 3. `getResource` irregular-plural unwrap
`getResource()` computed the unwrap key as `resource.slice(0, -1)`, so `addresses` → `addresse` and `countries` → `countrie` never matched and it returned the `{ address: {...} }` / `{ country: {...} }` **envelope** instead of the inner object. Now unwraps the single top-level object key (language-agnostic — covers every irregular singular), preserving behaviour for `orders` / `products` and falling through to "return as-is" for already-flat or multi-key responses.

**Note on the defensive unwrap:** the reference implementation kept a `raw.address ?? raw` belt-and-suspenders unwrap in the hydration helpers. Since this PR fixes the root cause in `getResource` (#3), that defensive unwrap is now redundant, so the helpers consume the inner object directly. This keeps the helpers simple and exercises the real `getResource` fix in the adapter tests.

## How to test

```bash
pnpm --filter @openlinker/integrations-prestashop build
pnpm --filter @openlinker/integrations-prestashop type-check
pnpm --filter @openlinker/integrations-prestashop lint
pnpm --filter @openlinker/integrations-prestashop test
```

All 32 suites / 484 tests pass. New/updated unit tests cover:
- `getResource` unwrapping `addresses` and `countries` (and still `products`)
- `fetchOrderRows` calling `order_details`
- billing/shipping hydration with country ISO-2 resolution, country-fetch failure, missing address ids, and delivery→billing fallback

## Scope

All changes are localized to `libs/integrations/prestashop`. No core/contract changes.

Closes #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ahj1ADeHgYSEdBaQwDAooi
