### PR TITLE
feat(erli): OrderStatusWriteback cancelled path — absolute stock-restore (#1175)

### DIFF
--- a/docs/plans/analysis/ANALYSIS-erli-order-status-writeback.md
+++ b/docs/plans/analysis/ANALYSIS-erli-order-status-writeback.md
@@ -1,0 +1,125 @@
+# Pre-implement Analysis: Erli `OrderStatusWriteback` — cancelled event → absolute stock restore
+
+**Plan**: `docs/plans/implementation-plan-erli-order-status-writeback.md`
+**Issue**: #1198
+**Analysed**: 2026-06-25
+**Verdict**: ✅ READY
+
+All referenced contracts exist and are confirmed in the live tree. No new ports, tokens, schema changes, or SDK extensions required. Two important code-level corrections needed during implementation (see below) — neither blocks starting.
+
+---
+
+## Phase B — Reuse Audit
+
+| Plan Artifact | Status | File Path |
+|---|---|---|
+| `OrderStatusWriteback` capability port | **ALREADY EXISTS** | `libs/core/src/orders/domain/ports/capabilities/order-status-writeback.capability.ts` |
+| `isOrderStatusWriteback` type guard | **ALREADY EXISTS** | same file; exported from `libs/core/src/orders/index.ts:35` |
+| `OrderWritebackResult` / `OrderWritebackOutcome` | **ALREADY EXISTS** | `libs/core/src/orders/domain/types/order-lifecycle-event.types.ts` (outcome values: `applied \| unsupported \| rejected`) |
+| `OrderLifecycleRelayService.relay()` | **ALREADY EXISTS** | `libs/core/src/orders/application/services/order-lifecycle-relay.service.ts` |
+| `OrderIngestionService.handleSourceCancellation` → calls relay | **ALREADY EXISTS** | `libs/core/src/orders/application/services/order-ingestion.service.ts` |
+| `ErliOrderSourceAdapter.write()` skeleton (returns `unsupported` for `cancelled`) | **ALREADY EXISTS** | `libs/integrations/erli/src/infrastructure/adapters/erli-order-source.adapter.ts` |
+| `ErliOfferManagerAdapter.updateOfferQuantity()` w/ frozen-stock | **ALREADY EXISTS** | `libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts` |
+| `ERLI_PRODUCT_ID_PATTERN` | **ALREADY EXISTS** (needs extraction) | `libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts:126` — NOT yet in `erli.constants.ts` |
+| `ErliAdapterFactory.createAdapters()` | **ALREADY EXISTS** (needs extension) | `libs/integrations/erli/src/application/erli-adapter.factory.ts` |
+| `IErliAdapterFactory.createAdapters()` | **ALREADY EXISTS** (needs extension) | `libs/integrations/erli/src/application/interfaces/erli-adapter.factory.interface.ts` |
+| `erli-plugin.ts` / `createErliPlugin()` | **ALREADY EXISTS** (needs dep added) | `libs/integrations/erli/src/erli-plugin.ts` |
+| `ErliIntegrationModule` (currently a `DynamicModule` via `createNestAdapterModule`) | **ALREADY EXISTS** (needs conversion to class) | `libs/integrations/erli/src/erli-integration.module.ts` |
+| `ErliWebhookProvisioningModule` (has own `onModuleInit`) | **ALREADY EXISTS** | `libs/integrations/erli/src/erli-webhook-provisioning.module.ts` |
+| `IInventoryQueryService` + `getAvailabilityByVariantIds()` | **ALREADY EXISTS** | `libs/core/src/inventory/application/services/inventory-query.service.interface.ts` |
+| `INVENTORY_QUERY_SERVICE_TOKEN` | **ALREADY EXISTS** | `libs/core/src/inventory/inventory.tokens.ts:16` |
+| `InventoryModule` exports `INVENTORY_QUERY_SERVICE_TOKEN` | **ALREADY EXISTS** | `libs/core/src/inventory/inventory.module.ts` — explicit `exports` array confirmed |
+| `VariantAvailability.totalAvailable` | **ALREADY EXISTS** | `libs/core/src/inventory/domain/types/inventory.types.ts` (shape: `{ productVariantId, totalAvailable, locationCount }`) |
+| `erli-order-source.adapter.spec.ts` test file | **ALREADY EXISTS** | `libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts` |
+| Worker's `AppModule` imports `InventoryModule` | **ALREADY EXISTS** | `apps/worker/src/app.module.ts:36` — no new import needed |
+| `ErliIntegrationModule` in worker plugins | **ALREADY EXISTS** | `apps/worker/src/plugins.ts:51` |
+| `ErliIntegrationModule` in API plugins | **ALREADY EXISTS** | `apps/api/src/plugins.ts:47` |
+| `ErliPluginDeps` interface | **ABSENT** | Does not exist; plan hedges with "or equivalent deps interface" — implementer must add the type |
+
+**No reinvention detected.** All ports, tokens, services, and test scaffolding the plan depends on are present. The only genuinely new code is the `write('cancelled')` implementation body, the factory/constructor wiring changes, the module conversion, and the test additions.
+
+---
+
+## Phase C — Backward-Compatibility Checklist
+
+| Surface | Change | Severity | Notes |
+|---|---|---|---|
+| `IErliAdapterFactory.createAdapters()` signature | New optional `inventoryQuery?` param appended | ✅ OK | Optional parameter, all existing call sites remain valid |
+| `ErliOrderSourceAdapter` constructor | Two new params added | ✅ OK | Constructed only inside `ErliAdapterFactory`; no external callers |
+| `ErliIntegrationModule` exported shape | `DynamicModule` object → `@Module` class | ✅ OK | Both are valid `PluginEntry` values in the NestJS import array; external API (`import { ErliIntegrationModule }`) unchanged |
+| `erli-order-source.adapter.spec.ts` existing test | Line 388: `'reports unsupported for a cancelled event'` | ⚠️ **Warning — must update** | This test currently asserts `unsupported` unconditionally. After implementation `cancelled` returns `applied` (happy path) or `unsupported` only when `inventoryQuery` is missing. The test **must be replaced**, not just added beside. Failure to update it will cause the existing test to fail. |
+| `@openlinker/core/*` barrel exports | No changes | ✅ OK | Plan correctly makes zero CORE modifications |
+| `OfferManagerPort` / `OrderSourcePort` signatures | No changes | ✅ OK | |
+| ORM schema / migrations | No changes | ✅ OK | |
+| `check-cross-context-imports` invariant | Imports `@openlinker/core/inventory` barrel + `@openlinker/core/listings` barrel | ✅ OK | Both are top-level barrel imports; allowed cross-context pattern |
+
+---
+
+## Important Corrections (act on these before committing)
+
+### ⚠️ IMPORTANT-1 — Positional indexing in `restockOnCancellation` will silently assign wrong stock
+
+**Where**: Step 1.3, `restockOnCancellation` implementation, line:
+```typescript
+const stockByOfferId = new Map(
+  offerIds.map((id, i) => [id, availabilities[i]?.totalAvailable ?? 0]),  // ← WRONG
+);
+```
+
+**Problem**: `getAvailabilityByVariantIds` does not guarantee that its output array order matches the input array order. Using positional index `i` to correlate input IDs with output rows can silently assign wrong stock quantities (e.g., item A gets item B's stock).
+
+**Correct approach** — match the reference implementation in `OfferStockRestoreService` (line 113):
+```typescript
+const availability = await this.inventoryQuery.getAvailabilityByVariantIds(offerIds);
+const stockByVariantId = new Map(
+  availability.map((row) => [row.productVariantId, row.totalAvailable]),
+);
+// then: stockByVariantId.get(offerId) ?? 0
+```
+`VariantAvailability.productVariantId` is the correct key. Since for Erli `offerId === variantId`, `stockByVariantId.get(offerId)` works directly.
+
+### ⚠️ IMPORTANT-2 — Existing `cancelled` test at spec:388 must be updated, not just extended
+
+**Where**: `libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts:388`
+
+Current test:
+```typescript
+it('reports unsupported for a cancelled event (Erli has no cancel writeback verb)', async () => {
+  const result = await adapter.write({ type: 'cancelled', externalOrderId: ORDER_ID });
+  // asserts outcome === 'unsupported'
+```
+
+After implementation, this test **will fail** because `write('cancelled')` will perform the stock restore (returning `applied` on success). The plan's Phase 3 lists the `unsupported` scenario only for when `inventoryQuery` is not wired — correct — but does not call out that the existing test at line 388 must be replaced. Replace it with the happy-path test (scenario 1 from Phase 3) and add scenario 5 (`unsupported` when `inventoryQuery` is absent) as a separate test using a different adapter instance constructed without `inventoryQuery`.
+
+---
+
+## Minor Corrections (low-risk, action during implementation)
+
+### W3 — `validateErliOrder` vs `assertErliOrder`
+Plan (Step 1.3) references `validateErliOrder(response.data)`. The actual function in `erli-order-source.adapter.ts` is `assertErliOrder()`. Use the correct name.
+
+### W4 — Step 1.4 is mandatory, not conditional
+Plan says "If the pattern is already in a shared location (check `erli.constants.ts`), skip this step." It is NOT in `erli.constants.ts` — it's only in `erli-offer-manager.adapter.ts:126`. Step 1.4 must execute.
+
+### W5 — `INTEGRATIONS_SERVICE_TOKEN` in Step 2.2 pseudo-code should be omitted
+The plan's Step 2.2 pseudo-code includes `@Inject(INTEGRATIONS_SERVICE_TOKEN)` in the constructor. `AllegroIntegrationModule` does NOT inject `IIntegrationsService` — it's not needed for plugin registration. Including it would add an unnecessary DI dependency. Follow Allegro's actual constructor, not the plan's pseudo-code for this field.
+
+### W6 — `ErliPluginDeps` interface must be created
+No such interface exists in `erli-plugin.ts`. The implementer must add it (or add the `inventoryQuery` dep to `createErliPlugin()`'s explicit parameter type) in Step 2.1.
+
+---
+
+## Open Questions Resolved by Live Code
+
+| Plan Question | Resolution |
+|---|---|
+| Q3: Is it safe to import `InventoryModule` directly in `ErliIntegrationModule`? | **Yes** — `InventoryModule` already imported in `apps/worker/src/app.module.ts` and other worker modules. No circular risk. |
+| Is `getAvailabilityByVariantIds` zero-fill guaranteed? | **Yes** — documented in interface file and confirmed in reference implementation comments. |
+| Does `InventoryModule` export the token for injection? | **Yes** — explicit `exports` array at line 76-82 includes `INVENTORY_QUERY_SERVICE_TOKEN`. |
+| Does worker already include `ErliIntegrationModule`? | **Yes** — `apps/worker/src/plugins.ts:51`. |
+
+---
+
+## Verdict Summary
+
+**READY.** All contracts, tokens, ports, and modules referenced by the plan exist in the live tree. No CORE changes, no migration, no SDK widening. The two **Important** corrections (positional indexing and the existing cancelled test) must be addressed during implementation but do not require replanning — they are code-level corrections to the implementation snippets in the plan, not architectural changes.

--- a/docs/plans/implementation-plan-erli-order-status-writeback.md
+++ b/docs/plans/implementation-plan-erli-order-status-writeback.md
@@ -1,0 +1,609 @@
+# Implementation Plan: Erli `OrderStatusWriteback` — cancelled event → absolute stock restore
+
+**Date**: 2026-06-25
+**Status**: Ready for Review
+**Estimated Effort**: 1–1.5 days
+**Issue**: #1198
+**ADRs**: ADR-027 (lifecycle relay), ADR-025 §4a (deferred Erli stock restore)
+**Supersedes**: #1146 framing (OfferStockRestorer path was the pre-ADR-027 approach)
+
+---
+
+## 1. Task Summary
+
+**Objective**: Implement `OrderStatusWriteback` for the Erli marketplace adapter so that a source-cancelled order triggers an absolute stock-restore on all Erli offers that were part of the order. The restore uses master-authoritative inventory quantities (no read-modify-write from Erli).
+
+**Context**: ADR-027 (accepted 2026-06-22, shipped #1157–#1161 / #1171) introduced a platform-neutral lifecycle-relay (`OrderLifecycleRelayService`) that propagates a `{ type: 'cancelled' }` event to every order participant implementing `OrderStatusWriteback`. `OrderIngestionService.handleSourceCancellation` already calls the relay on every inbound source cancellation.
+
+The relay reaches a participant by resolving it via `getCapabilityAdapter` for `'OrderProcessorManager'` or `'OrderSource'`, then narrowing via the `isOrderStatusWriteback` guard. `ErliOrderSourceAdapter` already declares `implements OrderStatusWriteback` (added alongside #993) but its `write({ type: 'cancelled' })` returns `'unsupported'` with a note pointing to the pre-ADR-027 `OfferStockRestorer` compensating path (#1146).
+
+This task closes ADR-025 §4a: Erli auto-decrements stock on purchase but has no automatic stock-restore on cancellation. The relay is the correct ADR-027 path; the `write()` implementation just needs to perform the restore instead of returning `'unsupported'`.
+
+**Classification**: Integration (Erli plugin) + Infrastructure (adapter, factory, module wiring)
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- Update `ErliOrderSourceAdapter.write({ type: 'cancelled' })` to restore stock via absolute `updateOfferQuantity` calls for every line item in the cancelled order.
+- Inject `IInventoryQueryService` as a plugin-specific dep via a custom `ErliIntegrationModule` (switching from `createNestAdapterModule`).
+- Update `ErliAdapterFactory.createAdapters()` to accept `inventoryQuery` and share the constructed `ErliOfferManagerAdapter` reference with `ErliOrderSourceAdapter` (so the restore inherits the frozen-stock cache logic).
+- Unit tests for all `write('cancelled')` scenarios.
+- No changes to CORE (`libs/core/src/`).
+
+### Out of Scope
+- Implementing `write({ type: 'dispatched' })` — already gated on `OL_ERLI_DISPATCH_WRITEBACK_ENABLED` (#992, separate issue).
+- Removing or altering the existing `OfferStockRestorer` / `restoreStockOnCancellation` path on `ErliOfferManagerAdapter` — it remains as-is; this plan adds a second (relay-driven) path that supersedes it for relay-triggered cancellations, but the existing path is not broken.
+- Adding `IInventoryQueryService` to `HostServices` in `@openlinker/plugin-sdk` (would widen the SDK contract; kept lean per ADR-003 §host-bag).
+- Multi-location inventory aggregation changes — `getAvailabilityByVariantIds` already sums across all locations.
+
+### Constraints
+- **No CORE changes**: do not extend `OrderProcessorManagerPort`, do not add Erli-specific calls in core relay or ingestion code.
+- **No read-modify-write**: the restore is a pure absolute set from master inventory. Never read Erli stock and add/subtract.
+- **Idempotent**: re-running `write('cancelled')` on the same order must be safe (absolute set is naturally idempotent; frozen-stock skip is also idempotent).
+- **No silent drops**: non-`applied` results must be returned to the relay — never log-and-return-`applied`.
+- Depends on #993 (`ErliOrderSourceAdapter`) being merged (it is, per codebase state).
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: Integration (`libs/integrations/erli/src/`)
+
+**Capabilities Involved**:
+- `OrderStatusWriteback` (port: `libs/core/src/orders/domain/ports/capabilities/order-status-writeback.capability.ts`) — already declared on `ErliOrderSourceAdapter`; `write()` body needs implementation.
+- `OfferManagerPort.updateOfferQuantity` — the existing absolute-set path reused for the restore.
+- `IInventoryQueryService.getAvailabilityByVariantIds` — master-authoritative stock lookup; provided by `@openlinker/core/inventory`.
+
+**Existing Services / Patterns Reused**:
+- `ErliOrderSourceAdapter.write()` skeleton and `'dispatched'` branch — already exists.
+- `ErliOfferManagerAdapter.updateOfferQuantity()` — handles frozen-stock cache check + PATCH `/products/{id} { stock }`. **Reused via shared reference**: the factory passes the constructed offer manager to the order source so `write('cancelled')` delegates through it.
+- `ErliOrderItem.externalId` — the seller-keyed product ID set by OL on offer creation. Because Erli uses `ol_variant_*` IDs as product IDs, `externalId` is simultaneously the Erli offer ID (for `updateOfferQuantity`) and the OL variant ID (for `getAvailabilityByVariantIds`). No identifier mapping step needed.
+- `ErliAdapterFactory.createAdapters()` — already constructs both adapters sharing one HTTP client. Extended to also share the offer manager reference and pass `inventoryQuery`.
+- Custom NestJS module pattern from `AllegroIntegrationModule` / `PrestashopIntegrationModule` — adopted for `ErliIntegrationModule` to inject `INVENTORY_QUERY_SERVICE_TOKEN`.
+
+**New Components Required**:
+- None at the CORE or port level.
+- Module boilerplate for custom `ErliIntegrationModule` (small — ~35 LOC).
+- Extended factory signature and `ErliOrderSourceAdapter` constructor params.
+
+**Core vs Integration Justification**:
+This is purely an Erli-specific mapping of the neutral `{ type: 'cancelled' }` event onto Erli's stock-PATCH API. The relay itself (`OrderLifecycleRelayService`) and the trigger (`OrderIngestionService.handleSourceCancellation`) are already in CORE and require no changes. Adding anything to CORE would violate the "zero platform-type branching" rule of ADR-027.
+
+---
+
+## 4. External / Domain Research
+
+### Erli Order Wire Shape
+- `GET /orders/{externalOrderId}` → `ErliOrder` (already used by `getOrder()` in `ErliOrderSourceAdapter`).
+- `ErliOrder.items: ErliOrderItem[]` where `item.externalId: string` = the seller-keyed product ID OL set on offer creation. For Erli, offer IDs follow `ol_variant_{32-hex}` — the OL internal variant ID.
+- This dual-purpose ID means: `item.externalId` → use directly as both `offerId` (for `updateOfferQuantity`) and `variantId` (for `getAvailabilityByVariantIds`). No extra identifier mapping call.
+
+### Frozen-Stock Interaction (ADR-025 §4b / #1066)
+- `ErliOfferManagerAdapter.updateOfferQuantity()` already checks the per-offer frozen-stock cache. If the offer's stock is seller-frozen, it skips the PATCH and logs a warning.
+- By delegating through `offerManager.updateOfferQuantity()`, `write('cancelled')` automatically inherits this behavior: frozen-stock offers are skipped silently (not an error — the relay should receive `applied` for the order, with a logged warning per frozen offer).
+
+### Master Inventory (`IInventoryQueryService`)
+- `getAvailabilityByVariantIds(variantIds: readonly string[]): Promise<readonly VariantAvailability[]>`
+- Zero-fills variants with no inventory rows (`totalAvailable: 0`) — this is the right behavior for stock restore: if OL has no record of stock, set Erli to 0.
+- Already wired in `@openlinker/core/inventory` (`InventoryModule` exports `INVENTORY_QUERY_SERVICE_TOKEN`).
+
+### Internal Patterns
+- **Reference**: `AllegroIntegrationModule` / `PrestashopIntegrationModule` for custom module pattern with plugin-specific deps.
+- **Reference**: `OfferStockRestoreService` (`libs/core/src/listings/application/services/offer-stock-restore.service.ts`) for the same `getAvailabilityByVariantIds` + `updateOfferQuantity` pattern (though it operates at the core service layer, the logic is the same).
+- **Reference**: `prestashop-order-processor-manager.adapter.ts` for the `write()` result-return pattern (never throw; return `OrderWritebackResult`).
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+- **Q1**: Does `ErliOrder.items` include cancelled/returned item lines, or only active items? Assumption: all items (no filtering by item status) — restoring all to master inventory is correct regardless.
+- **Q2**: If the Erli order is not found (404) when `write('cancelled')` fires — should this be `rejected` or `applied`? Assumption: `rejected` with detail. The relay will surface it to the operator.
+- **Q3**: `InventoryModule` is currently imported transitively in the API app. Is it safe to import directly in `ErliIntegrationModule`? Assumption: yes — `InventoryModule` is the standard NestJS module for the inventory bounded context; all feature modules that need it import it.
+
+### Assumptions
+- `#993` is fully merged and `ErliOrderSourceAdapter.write()` skeleton is in main (confirmed by codebase state).
+- `ErliOrder.items[].externalId` is non-empty for all purchasable products (OL always sets it on offer creation). Items with empty/absent `externalId` are skipped with a debug log (defensive).
+- `IInventoryQueryService.getAvailabilityByVariantIds` with unknown variant IDs returns zero-filled rows — this is the documented behavior.
+- The `InventoryModule` from `@openlinker/core/inventory` is importable by `ErliIntegrationModule` (NestJS module cross-context imports are allowed; confirmed by architecture overview §Cross-context deps).
+- No migration is needed (no schema changes).
+
+### Documentation Gaps
+- ADR-025 §4a deferred the stock-restore mechanism but didn't specify the ADR-027 relay path would supersede it. The plan closes that gap as the new canonical approach.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1: Factory and Adapter Wiring
+
+**Goal**: Thread `IInventoryQueryService` and the shared offer manager reference into `ErliOrderSourceAdapter` without touching CORE or the plugin-sdk.
+
+---
+
+#### Step 1.1 — Update `IErliAdapterFactory` interface
+
+**File**: `libs/integrations/erli/src/application/interfaces/erli-adapter.factory.interface.ts`
+
+**Action**: Add `inventoryQuery: IInventoryQueryService` as a new parameter to `createAdapters()`. Import `IInventoryQueryService` from `@openlinker/core/inventory`.
+
+```typescript
+import type { IInventoryQueryService } from '@openlinker/core/inventory';
+
+export interface IErliAdapterFactory {
+  createAdapters(
+    connection: Connection,
+    identifierMapping: IdentifierMappingPort,
+    credentialsResolver: CredentialsResolverPort,
+    cache?: CachePort,
+    inventoryQuery?: IInventoryQueryService,
+  ): Promise<ErliAdapters>;
+  // ...
+}
+```
+
+`inventoryQuery` is optional (`?`) so that existing tests and the connection-tester path (which calls `createHttpClient`, not `createAdapters`) don't break. The order-source adapter handles `undefined` inventoryQuery by returning `'unsupported'` for `'cancelled'` (see Step 1.3).
+
+**Acceptance**: `pnpm type-check` passes. Interface file compiles.
+
+---
+
+#### Step 1.2 — Update `ErliAdapterFactory.createAdapters()`
+
+**File**: `libs/integrations/erli/src/application/erli-adapter.factory.ts`
+
+**Action**: Accept the new `inventoryQuery` param. Construct `ErliOfferManagerAdapter` first (unchanged), then pass it and `inventoryQuery` to `ErliOrderSourceAdapter`.
+
+```typescript
+async createAdapters(
+  connection: Connection,
+  _identifierMapping: IdentifierMappingPort,
+  credentialsResolver: CredentialsResolverPort,
+  cache?: CachePort,
+  inventoryQuery?: IInventoryQueryService,
+): Promise<ErliAdapters> {
+  const httpClient = await this.createHttpClient(connection, credentialsResolver);
+  const config = (connection.config ?? {}) as ErliConnectionConfig;
+  const offerManager = new ErliOfferManagerAdapter(
+    connection.id,
+    ERLI_ADAPTER_KEY,
+    httpClient,
+    config.defaultDispatchTime,
+    cache,
+  );
+  return {
+    offerManager,
+    orderSource: new ErliOrderSourceAdapter(
+      connection.id,
+      httpClient,
+      offerManager,      // shared reference so write() inherits frozen-stock logic
+      inventoryQuery,
+    ),
+  };
+}
+```
+
+**Key**: `offerManager` is constructed before `orderSource` so the shared reference is safe. Both close over the same `IErliHttpClient` instance (unchanged from current behavior).
+
+**Acceptance**: Factory tests still pass; the new `orderSource` constructor accepts the additional params.
+
+---
+
+#### Step 1.3 — Update `ErliOrderSourceAdapter` constructor and `write('cancelled')`
+
+**File**: `libs/integrations/erli/src/infrastructure/adapters/erli-order-source.adapter.ts`
+
+**Action**:
+
+1. Add constructor parameters:
+   ```typescript
+   constructor(
+     private readonly connectionId: string,
+     private readonly httpClient: IErliHttpClient,
+     private readonly offerManager: OfferManagerPort,
+     private readonly inventoryQuery?: IInventoryQueryService,
+   ) {}
+   ```
+   Import `OfferManagerPort` from `@openlinker/core/listings` and `IInventoryQueryService` + `INVENTORY_QUERY_SERVICE_TOKEN` from `@openlinker/core/inventory`.
+
+2. Replace the `write({ type: 'cancelled' })` branch:
+
+   ```typescript
+   if (event.type === 'cancelled') {
+     return this.restockOnCancellation(event.externalOrderId);
+   }
+   ```
+
+3. Add private `restockOnCancellation(externalOrderId: string): Promise<OrderWritebackResult>`:
+
+   ```typescript
+   private async restockOnCancellation(externalOrderId: string): Promise<OrderWritebackResult> {
+     if (!this.inventoryQuery) {
+       return {
+         outcome: 'unsupported',
+         detail: 'Erli stock-restore requires inventoryQuery wiring (not available in this context).',
+       };
+     }
+
+     let order: ErliOrder;
+     try {
+       const response = await this.httpClient.get<ErliOrder>(`/orders/${externalOrderId}`);
+       order = validateErliOrder(response.data); // reuse existing validator
+     } catch (error) {
+       const detail = error instanceof Error ? error.message : String(error);
+       this.logger.warn(`OrderStatusWriteback 'cancelled': failed to fetch Erli order (connection: ${this.connectionId}): ${detail}`);
+       return { outcome: 'rejected', detail: `could not fetch Erli order: ${detail}` };
+     }
+
+     const offerIds = order.items
+       .map((item) => item.externalId)
+       .filter((id): id is string => typeof id === 'string' && ERLI_PRODUCT_ID_PATTERN.test(id));
+
+     if (offerIds.length === 0) {
+       this.logger.debug(`OrderStatusWriteback 'cancelled': Erli order has no restorable items (connection: ${this.connectionId})`);
+       return { outcome: 'applied' };
+     }
+
+     // externalId doubles as OL variant ID (Erli uses ol_variant_* as product IDs)
+     const availabilities = await this.inventoryQuery.getAvailabilityByVariantIds(offerIds);
+     const stockByOfferId = new Map(
+       offerIds.map((id, i) => [id, availabilities[i]?.totalAvailable ?? 0]),
+     );
+
+     const errors: string[] = [];
+     for (const offerId of offerIds) {
+       try {
+         await this.offerManager.updateOfferQuantity({
+           offerId,
+           quantity: stockByOfferId.get(offerId) ?? 0,
+         });
+       } catch (error) {
+         const detail = error instanceof Error ? error.message : String(error);
+         this.logger.warn(`OrderStatusWriteback 'cancelled': stock-restore failed for offer ${offerId} (connection: ${this.connectionId}): ${detail}`);
+         errors.push(`${offerId}: ${detail}`);
+       }
+     }
+
+     if (errors.length > 0) {
+       return {
+         outcome: 'rejected',
+         detail: `stock-restore failed for ${errors.length}/${offerIds.length} offer(s): ${errors.slice(0, 3).join('; ')}`,
+       };
+     }
+     return { outcome: 'applied' };
+   }
+   ```
+
+**Design notes**:
+- `ERLI_PRODUCT_ID_PATTERN` is already defined in `erli-offer-manager.adapter.ts`. Extracted to a shared constants file or imported from there (see Step 1.4).
+- `validateErliOrder` is reused from the existing `getOrder()` path in `erli-order-source.adapter.ts`.
+- Partial failures: if ANY offer fails to restore, return `rejected` so the relay surfaces it to the operator. The relay's "one participant's failure never blocks the others" guarantee only applies across participants, not within one participant's own multi-offer restore.
+- Frozen-stock: `offerManager.updateOfferQuantity()` handles the frozen check internally; frozen offers emit a warn log and return void (not an error), so `errors` stays clean for them.
+- No PII logged: only `connectionId` and `offerId` (which is an internal OL ID, not buyer info).
+
+**Acceptance**: `write({ type: 'cancelled', externalOrderId: '...' })` no longer returns `'unsupported'`. Unit tests pass (see Phase 3).
+
+---
+
+#### Step 1.4 — Extract `ERLI_PRODUCT_ID_PATTERN` to shared constants (if needed)
+
+**File**: `libs/integrations/erli/src/erli.constants.ts` (or wherever `ERLI_ADAPTER_KEY` lives)
+
+**Action**: Move (or re-export) `ERLI_PRODUCT_ID_PATTERN` from `erli-offer-manager.adapter.ts` to the shared constants file so both `erli-order-source.adapter.ts` and `erli-offer-manager.adapter.ts` can import it without a cross-file relative dep.
+
+If the pattern is already in a shared location (check `erli.constants.ts`), skip this step.
+
+**Acceptance**: No duplicate regex definitions. Both adapter files import from the same source.
+
+---
+
+### Phase 2: Module Wiring
+
+**Goal**: Convert `ErliIntegrationModule` from `createNestAdapterModule` (no custom DI) to a custom NestJS module that injects `INVENTORY_QUERY_SERVICE_TOKEN` and passes it to `createErliPlugin`.
+
+---
+
+#### Step 2.1 — Update `erli-plugin.ts` to accept `inventoryQuery` dep
+
+**File**: `libs/integrations/erli/src/erli-plugin.ts`
+
+**Action**:
+
+1. Add `inventoryQuery: IInventoryQueryService` to the `ErliPluginDeps` type (or the equivalent deps interface). Import from `@openlinker/core/inventory`.
+
+2. In `createCapabilityAdapter`, thread it to the factory:
+   ```typescript
+   createCapabilityAdapter: async (connection, capability, host) => {
+     const factory = new ErliAdapterFactory();
+     const adapters = await factory.createAdapters(
+       connection,
+       host.identifierMapping,
+       host.credentialsResolver,
+       host.cache,
+       deps.inventoryQuery,  // ← new
+     );
+     return dispatchCapability(capability, { OfferManager: () => adapters.offerManager, OrderSource: () => adapters.orderSource }, 'Erli');
+   },
+   ```
+
+**Acceptance**: `createErliPlugin({ ..., inventoryQuery })` typechecks. Plugin descriptor carries the dep via closure.
+
+---
+
+#### Step 2.2 — Convert `ErliIntegrationModule` to a custom module
+
+**File**: `libs/integrations/erli/src/erli-integration.module.ts`
+
+**Action**: Replace `createNestAdapterModule(plugin)` with a full custom `@Module` implementing `OnModuleInit`. Model after `AllegroIntegrationModule`.
+
+```typescript
+@Module({
+  imports: [InventoryModule, ErliWebhookProvisioningModule],
+})
+export class ErliIntegrationModule implements OnModuleInit {
+  private readonly logger = new Logger(ErliIntegrationModule.name);
+
+  constructor(
+    @Inject(ADAPTER_REGISTRY_TOKEN) private readonly adapterRegistry: IAdapterRegistryService,
+    @Inject(FACTORY_RESOLVER_TOKEN) private readonly factoryResolver: AdapterFactoryResolverService,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN) private readonly integrationsService: IIntegrationsService,
+    @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN) private readonly identifierMapping: IIdentifierMappingService,
+    @Inject(CREDENTIALS_RESOLVER_TOKEN) private readonly credentialsResolver: CredentialsResolverPort,
+    @Inject(INVENTORY_QUERY_SERVICE_TOKEN) private readonly inventoryQuery: IInventoryQueryService,
+    // other HostServices fields needed for host bag:
+    @Inject(CONNECTION_TESTER_REGISTRY_TOKEN) private readonly connectionTesterRegistry: ...,
+    // etc — mirror the fields used in AllegroIntegrationModule.onModuleInit
+  ) {}
+
+  onModuleInit(): void {
+    const plugin = createErliPlugin({
+      inventoryQuery: this.inventoryQuery,
+    });
+    const host: HostServices = {
+      logger: new Logger('Erli'),
+      adapterRegistry: this.adapterRegistry,
+      factoryResolver: this.factoryResolver,
+      identifierMapping: this.identifierMapping,
+      credentialsResolver: this.credentialsResolver,
+      // ... other host services from @Inject'd fields
+    };
+    host.adapterRegistry.register(plugin.manifest);
+    host.factoryResolver.registerFactory(plugin.manifest.adapterKey, {
+      createAdapter: (connection, capability) =>
+        plugin.createCapabilityAdapter(connection, capability, host),
+    });
+    plugin.register?.(host);
+  }
+}
+```
+
+Key imports:
+- `InventoryModule` from `@openlinker/core/inventory` (NestJS module — allowed cross-context import for `imports: [...]`).
+- `INVENTORY_QUERY_SERVICE_TOKEN`, `IInventoryQueryService` from `@openlinker/core/inventory`.
+- All `HOST_*_TOKEN` symbols from their respective barrels (already imported for the webhook provisioning module pattern).
+
+**Note**: The `ErliWebhookProvisioningModule` already injects `@Inject()`'d fields (webhookProvisioningRegistry, connectionPort, etc.). The new custom `ErliIntegrationModule` wraps the full plugin registration in `onModuleInit`, and `ErliWebhookProvisioningModule` can remain as a sub-module handling its own `onModuleInit` registration, OR its logic can be folded into this module. Prefer keeping it separate (matching the current structure — less change surface).
+
+**Acceptance**: `ErliIntegrationModule` compiles; `pnpm start:dev:api` boots without errors; Erli connection creation still works end-to-end.
+
+---
+
+### Phase 3: Tests
+
+**Goal**: Cover all meaningful `write('cancelled')` scenarios with unit tests.
+
+---
+
+#### Step 3.1 — Add `write('cancelled')` unit tests
+
+**File**: `libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts`
+
+**Test cases** (test name pattern: `should [expected behaviour] when [condition]`):
+
+1. **`should return applied and restore stock for each line item when order is found`**
+   - Mock `httpClient.get('/orders/ord-1')` → `ErliOrder` with 2 items (`externalId: 'ol_variant_aaa...'`, `'ol_variant_bbb...'`)
+   - Mock `inventoryQuery.getAvailabilityByVariantIds(['ol_variant_aaa...', 'ol_variant_bbb...'])` → `[{ totalAvailable: 10 }, { totalAvailable: 5 }]`
+   - Assert `offerManager.updateOfferQuantity` called twice with correct quantities
+   - Assert result: `{ outcome: 'applied' }`
+
+2. **`should return applied with no-op when order has no restorable items`**
+   - Order has items with `externalId` in non-`ol_variant_*` format (or absent)
+   - Assert `updateOfferQuantity` not called
+   - Assert result: `{ outcome: 'applied' }`
+
+3. **`should return rejected when Erli order fetch fails`**
+   - Mock `httpClient.get` throws `ErliApiException`
+   - Assert result: `{ outcome: 'rejected', detail: expect.stringContaining('could not fetch') }`
+   - Assert `updateOfferQuantity` not called
+
+4. **`should return rejected when one offer stock restore fails`**
+   - Order with 2 items; second `updateOfferQuantity` throws
+   - Assert result: `{ outcome: 'rejected', detail: expect.stringContaining('1/2') }`
+
+5. **`should return unsupported when inventoryQuery is not wired`**
+   - Construct `ErliOrderSourceAdapter` without `inventoryQuery` (pass `undefined`)
+   - Assert result: `{ outcome: 'unsupported' }`
+
+6. **`should return applied with zero stock when variant has no inventory row`**
+   - `getAvailabilityByVariantIds` returns `{ totalAvailable: 0 }` for all variants
+   - Assert `updateOfferQuantity` called with `quantity: 0`
+   - Assert result: `{ outcome: 'applied' }`
+
+7. **`should not call updateOfferQuantity for items with frozen stock (frozen behavior via mock)`**
+   - Mock `offerManager.updateOfferQuantity` to succeed (frozen-stock logic is internal to `ErliOfferManagerAdapter`; at this unit test layer, the mock just returns void — no failure)
+   - This is tested at the integration level via `ErliOfferManagerAdapter` tests for frozen-stock. Unit test just verifies the flow.
+
+**Mocking strategy**: Use `jest.Mocked<OfferManagerPort>` for `offerManager` (mock `updateOfferQuantity`). Use `jest.Mocked<IInventoryQueryService>` for `inventoryQuery`. Use `jest.Mocked<IErliHttpClient>` for `httpClient`. No real HTTP or DB.
+
+**Acceptance**: `pnpm test --filter @openlinker/integrations-erli` passes. All new test cases green.
+
+---
+
+### Phase 4: Quality Gate
+
+**Goal**: Ensure the change passes the full repo quality gate before commit.
+
+#### Step 4.1 — Run quality gate
+
+```bash
+pnpm lint        # ESLint + check:invariants (cross-context import check)
+pnpm type-check  # TypeScript strict check
+pnpm test        # All unit tests
+```
+
+All three must pass with zero errors before committing.
+
+---
+
+### Implementation Details
+
+**New Components**:
+- None at the domain/port level.
+- Module boilerplate: `ErliIntegrationModule` converted to custom NestJS module (~40 LOC delta).
+
+**Configuration Changes**:
+- No new environment variables.
+- No new flags (the `inventoryQuery` dep is always wired when the module boots).
+
+**Database Migrations**: None — no schema changes.
+
+**Events**: No new events. The relay already emits the `OrderLifecycleEvent` via existing `handleSourceCancellation` path.
+
+**Error Handling**:
+- Order fetch failure → `rejected` (relay surfaces to operator).
+- `updateOfferQuantity` failure for one or more offers → `rejected` with count/detail.
+- Missing `inventoryQuery` wiring → `unsupported` (graceful degradation for tests or future plugin contexts that don't provide inventory).
+- Frozen stock → `updateOfferQuantity` returns void (handled internally by offer manager); stock restore silently skips frozen offers, returns `applied`.
+
+**Retry behavior**: `updateOfferQuantity` issues a PATCH and retries per the HTTP client's retry config. The relay itself can re-fire on retry (idempotent absolute set — always safe). No additional dedup needed.
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Add `IInventoryQueryService` to `HostServices` (plugin-sdk)
+- **Description**: Extend the `HostServices` bag with `inventoryQuery?: IInventoryQueryService` so all plugins can access it without a custom module.
+- **Why Rejected**: ADR-003 explicitly states "Plugin-specific cross-package ports are passed into the descriptor's constructor closure — intentionally not in the host bag, to keep the contract surface lean." Stock-query is currently Erli-specific; widening the host bag for one plugin's use case contradicts this. If multiple plugins later need it, promote it at that point.
+- **Trade-off**: Less module boilerplate (skip Step 2.2), but prematurely widens the plugin SDK contract.
+
+### Alternative 2: Keep `write('cancelled')` as `'unsupported'`, rely on `OfferStockRestorer` exclusively
+- **Description**: Leave the current `'unsupported'` return as-is. The `OfferStockRestorer` path (#1146 / `restoreStockOnCancellation`) already performs the stock restore on cancellation.
+- **Why Rejected**: ADR-027 explicitly rejects method/capability-per-event patterns and mandates the relay path. Having two paths for the same outcome (OfferStockRestorer and relay) risks double-restores and complicates reasoning. The relay is the canonical post-ADR-027 path; the `OfferStockRestorer` path is pre-ADR-027 and this issue is specifically to wire the relay path.
+- **Trade-off**: Zero code change. But violates ADR-027's design principle and leaves the relay silently bypassed for Erli (non-`applied` is surfaced as a warn, which is noise without remedy).
+
+### Alternative 3: Add `OrderStatusWriteback` to `ErliOfferManagerAdapter`
+- **Description**: Implement `write()` on `ErliOfferManagerAdapter` instead of `ErliOrderSourceAdapter`.
+- **Why Rejected**: The relay resolves participants via `OrderProcessorManager` or `OrderSource` capabilities. `ErliOfferManagerAdapter` is resolved as `OfferManager` — the relay never reaches it. This approach requires either adding a new resolution capability to the relay (CORE change) or making `ErliOfferManagerAdapter` also act as `OrderSource` (architectural confusion). Not viable without CORE changes.
+
+### Alternative 4: Implement the full order-item resolution in a dedicated `ErliOrderStatusWritebackAdapter`
+- **Description**: Create a new adapter class solely for `OrderStatusWriteback` that combines order fetching, inventory lookup, and stock patching.
+- **Why Rejected**: Overkill. `ErliOrderSourceAdapter` already has the order fetch infrastructure (`getOrder`, `httpClient`, validated wire types). Adding two constructor params and one private method is far simpler and keeps the offer-ID-to-variant-ID dual-use intact without a new file.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ No CORE changes (`libs/core/src/` untouched).
+- ✅ `OrderStatusWriteback` port already in CORE; this plan only implements it in the integration layer.
+- ✅ Cross-context imports: `@openlinker/core/inventory` (barrel) for `InventoryModule`, `IInventoryQueryService`, `INVENTORY_QUERY_SERVICE_TOKEN`; `@openlinker/core/listings` (barrel) for `OfferManagerPort`. Both are barrel-only, allowed by the cross-context rule.
+- ✅ `InventoryModule` imported in `ErliIntegrationModule` for `imports: [...]` — NestJS module class cross-context import is explicitly allowed by the architecture overview.
+
+### Naming Conventions
+- ✅ New private method: `restockOnCancellation` (camelCase, action-noun pattern).
+- ✅ No new files; existing file naming unchanged.
+
+### Existing Patterns
+- ✅ `write()` return pattern: matches `PrestashopOrderProcessorManagerAdapter.write()` (never throw; always return `OrderWritebackResult`).
+- ✅ Factory param threading: matches how `cache?: CachePort` is already threaded through `createAdapters()`.
+- ✅ Custom module pattern: matches `AllegroIntegrationModule` / `PrestashopIntegrationModule`.
+
+### Risks
+- **Double restore**: If `OfferStockRestorer` path (#1146) is still active and the relay path fires on the same cancellation, stock may be restored twice in quick succession. Both are absolute sets, so the second is a no-op at the API level (idempotent). Risk: low. Mitigation: document in code; eventual cleanup of the OfferStockRestorer path is a separate issue.
+- **Partial restore / partial failure**: If `updateOfferQuantity` fails for one offer in a multi-item order, the relay receives `rejected`. The relay surfaces this to the operator (logs warn). There is no per-offer retry granularity in the relay. Mitigation: individual offer PATCH failures are already retried by the HTTP client's retry budget. Persistent failures leave Erli under-stocked, which is visible via `erli-offer-status-sync`.
+- **Module conversion surface**: Switching `ErliIntegrationModule` from `createNestAdapterModule` to a custom module touches module wiring and could regress adapter registration (connection tester, webhook provisioner, etc.). Mitigation: follow `AllegroIntegrationModule` as exact template; run `pnpm test:integration` against the Erli plugin suites.
+- **`inventoryQuery` unavailable in worker**: `InventoryModule` must be imported in the Worker app's module graph (via `ErliIntegrationModule`) as well. Verify `apps/worker/src/plugins.ts` includes `ErliIntegrationModule` and that `InventoryModule` is compatible with the Worker's `AppModule`. If not, the order source will get `undefined` inventory query and return `'unsupported'` (graceful degradation per Step 1.3).
+
+### Edge Cases
+- **Order with zero items** (empty `items` array): `offerIds` = `[]`; `updateOfferQuantity` not called; return `applied`. Handled.
+- **All items have non-OL `externalId`** (e.g. seller set custom IDs): filtered out by `ERLI_PRODUCT_ID_PATTERN` test; `offerIds` = `[]`; return `applied`. Handled.
+- **Partial externalId validity** (some items valid, some not): only valid `ol_variant_*` IDs are restored; others silently skipped. Acceptable — non-OL offers are outside OL's inventory management scope.
+- **`getAvailabilityByVariantIds` returns fewer rows than requested** (should not happen per docs — zero-fills): Map lookup falls back to `?? 0`; safe.
+- **Relay fires twice for the same cancellation** (at-least-once relay delivery): absolute set is idempotent; second fire is a no-op at Erli. Safe.
+
+### Backward Compatibility
+- ✅ No change to the CORE relay or ingestion logic.
+- ✅ No change to `ErliOfferManagerAdapter` public API.
+- ✅ `createAdapters()` signature change is backward-compatible (`inventoryQuery` is optional).
+- ✅ `ErliOrderSourceAdapter` constructor change is internal to the factory — no external callers.
+- ⚠️ `ErliIntegrationModule` module conversion: external API is unchanged (same module class name, same `forRoot()` if applicable). The internal wiring changes. Integration tests should verify adapter registration still works.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+**File**: `libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts`
+
+Scenarios (see Phase 3 for full detail):
+- `write('cancelled')` happy path: fetches order, restores stock for all `ol_variant_*` items → `applied`
+- `write('cancelled')` no restorable items → `applied` (no-op)
+- `write('cancelled')` order fetch fails → `rejected`
+- `write('cancelled')` one offer stock patch fails → `rejected` with count detail
+- `write('cancelled')` `inventoryQuery` not wired → `unsupported`
+- `write('cancelled')` zero master stock → `updateOfferQuantity` called with `quantity: 0` → `applied`
+
+Existing tests for `write('dispatched')` must remain green (no regression).
+
+### Integration Tests
+No new integration tests required — the unit tests cover the critical paths. The existing Erli integration test suite (if any for `ErliIntegrationModule` boot) should be run to verify module wiring.
+
+### Mocking Strategy
+- `OfferManagerPort` mocked via `jest.Mocked<OfferManagerPort>` (not `ErliOfferManagerAdapter` concrete class — always mock ports, not implementations).
+- `IInventoryQueryService` mocked via `jest.Mocked<IInventoryQueryService>`.
+- `IErliHttpClient` mocked via existing pattern in `erli-order-source.adapter.spec.ts`.
+
+### Acceptance Criteria
+- [ ] `ErliOrderSourceAdapter.write({ type: 'cancelled', externalOrderId: '...' })` performs absolute stock set for all `ol_variant_*` line items in the order and returns `{ outcome: 'applied' }` on success.
+- [ ] `write('cancelled')` returns `{ outcome: 'rejected' }` when the Erli order is not found or when any offer stock PATCH fails; the relay surfaces this to the operator.
+- [ ] `write('cancelled')` returns `{ outcome: 'unsupported' }` when `inventoryQuery` is not wired (graceful degradation).
+- [ ] Frozen-stock offers are skipped without triggering a `rejected` outcome (handled internally by `updateOfferQuantity`).
+- [ ] `write('dispatched')` branch is unchanged and still functions as before.
+- [ ] No core files (`libs/core/src/`) are modified.
+- [ ] `pnpm lint` passes with zero errors.
+- [ ] `pnpm type-check` passes with zero errors.
+- [ ] `pnpm test` passes with all new and existing tests green.
+- [ ] `ErliIntegrationModule` boots successfully in the API and Worker apps (manual smoke-test or integration test).
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture — implementation is in the integration layer; CORE relay and ports unchanged.
+- [x] Respects CORE vs Integration boundaries — no CORE modifications; `@openlinker/core/*` barrel imports only.
+- [x] Uses existing patterns — factory threading pattern (`cache?` → `inventoryQuery?`); custom module pattern (Allegro/PrestaShop reference); `write()` never-throw return pattern.
+- [x] Idempotency considered — absolute stock set is idempotent by construction; double-relay is safe.
+- [x] Event-driven patterns — the relay path is used; `write()` is the ADR-027 event-as-data dispatch target.
+- [x] Rate limits & retries — `updateOfferQuantity` goes through `ErliHttpClient` which has retry config; PATCH calls are idempotent so retries are safe.
+- [x] Error handling comprehensive — order fetch failure → `rejected`; partial offer failure → `rejected`; frozen stock → silent skip (no error); missing dep → `unsupported`.
+- [x] Testing strategy complete — unit tests for all `write('cancelled')` scenarios defined in Phase 3.
+- [x] Naming conventions followed — `restockOnCancellation` (private method); no new exported names.
+- [x] File structure matches standards — changes localized to `libs/integrations/erli/src/`; no new files except possibly constants extraction.
+- [x] Plan is execution-ready — all file paths, method signatures, and test cases specified; no open blockers.
+- [x] No migration needed — no schema changes.
+
+---
+
+## Related Documentation
+
+- [ADR-027: Order status writeback capability & lifecycle relay](../architecture/adrs/027-order-status-writeback-capability-and-relay.md)
+- [ADR-025: Erli marketplace adapter](../architecture/adrs/025-erli-marketplace-adapter.md) — §4a deferred stock restore, §4b frozen-stock
+- [Architecture Overview — OfferManagerPort sub-capabilities](../architecture-overview.md#offerManagerPort)
+- [Architecture Overview — Cross-context dependencies](../architecture-overview.md#cross-context-dependencies-in-core)
+- [Engineering Standards](../engineering-standards.md)
+- [Testing Guide](../testing-guide.md)
+- **Reference implementation**: `libs/core/src/listings/application/services/offer-stock-restore.service.ts` (same `getAvailabilityByVariantIds` + `updateOfferQuantity` pattern)
+- **Reference implementation**: `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts` (`write()` result-return pattern)
+- **Related issues**: #1146 (OfferStockRestorer, pre-ADR-027 path), #993 (ErliOrderSourceAdapter), #1157–#1161 / #1171 (relay shipped)

--- a/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
+++ b/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
@@ -276,8 +276,9 @@ describe('createErliPlugin', () => {
 });
 
 describe('ErliIntegrationModule', () => {
-  it('should construct a DynamicModule via createNestAdapterModule when the package is loaded', () => {
-    expect(ErliIntegrationModule.module).toBeDefined();
-    expect(ErliIntegrationModule.imports?.length).toBeGreaterThan(0);
+  it('should be a NestJS @Module class with declared imports', () => {
+    const imports: unknown[] = Reflect.getMetadata('imports', ErliIntegrationModule);
+    expect(Array.isArray(imports)).toBe(true);
+    expect(imports.length).toBeGreaterThan(0);
   });
 });

--- a/libs/integrations/erli/src/application/erli-adapter.factory.ts
+++ b/libs/integrations/erli/src/application/erli-adapter.factory.ts
@@ -14,6 +14,7 @@
  */
 import type { CredentialsResolverPort } from '@openlinker/core/integrations';
 import type { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import type { IInventoryQueryService } from '@openlinker/core/inventory';
 import type { CachePort } from '@openlinker/shared';
 import { ErliConfigException } from '../domain/exceptions/erli-config.exception';
 import { isAllowedErliBaseUrl } from '../domain/policies/erli-base-url.policy';
@@ -50,26 +51,40 @@ export class ErliAdapterFactory implements IErliAdapterFactory {
    * method (rather than the constructor as Allegro does) because Erli's factory
    * is constructed argument-less inside `createCapabilityAdapter` — an Erli-local
    * choice; the cache still arrives from `host.cache` either way.
+   *
+   * `inventoryQuery` enables the #1198 `OrderStatusWriteback` `cancelled`
+   * stock-restore path in `ErliOrderSourceAdapter`. Optional — absent means that
+   * path reports `unsupported` (same fail-open posture as `cache`).
    */
   async createAdapters(
     connection: Connection,
     _identifierMapping: IdentifierMappingPort,
     credentialsResolver: CredentialsResolverPort,
     cache?: CachePort,
+    inventoryQuery?: IInventoryQueryService,
   ): Promise<ErliAdapters> {
     const httpClient = await this.createHttpClient(connection, credentialsResolver);
     const config = (connection.config ?? {}) as ErliConnectionConfig;
+    // Construct the offer manager first so its reference can be shared with the
+    // order-source adapter (which needs it for the `cancelled` stock-restore path).
+    const offerManager = new ErliOfferManagerAdapter(
+      connection.id,
+      ERLI_ADAPTER_KEY,
+      httpClient,
+      config.defaultDispatchTime,
+      cache,
+    );
     return {
-      offerManager: new ErliOfferManagerAdapter(
-        connection.id,
-        ERLI_ADAPTER_KEY,
-        httpClient,
-        config.defaultDispatchTime,
-        cache,
-      ),
+      offerManager,
       // Shares the one per-connection HTTP client with the offer adapter, exactly
       // as Allegro shares one client across its order-source + offer adapters.
-      orderSource: new ErliOrderSourceAdapter(connection.id, httpClient),
+      // Also shares the offer-manager reference for the stock-restore writeback.
+      orderSource: new ErliOrderSourceAdapter(
+        connection.id,
+        httpClient,
+        offerManager,
+        inventoryQuery,
+      ),
     };
   }
 

--- a/libs/integrations/erli/src/application/interfaces/erli-adapter.factory.interface.ts
+++ b/libs/integrations/erli/src/application/interfaces/erli-adapter.factory.interface.ts
@@ -12,8 +12,14 @@
  */
 import type { CredentialsResolverPort } from '@openlinker/core/integrations';
 import type { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
-import type { OfferCreator, OfferFieldUpdater, OfferManagerPort } from '@openlinker/core/listings';
-import type { OrderSourcePort } from '@openlinker/core/orders';
+import type { IInventoryQueryService } from '@openlinker/core/inventory';
+import type {
+  OfferCreator,
+  OfferFieldUpdater,
+  OfferManagerPort,
+  OfferStockRestorer,
+} from '@openlinker/core/listings';
+import type { OrderSourcePort, OrderStatusWriteback } from '@openlinker/core/orders';
 import type { CachePort } from '@openlinker/shared';
 // eslint-disable-next-line no-restricted-imports -- local relative import is intentional here; barrel path would create a runtime cycle
 import type { IErliHttpClient } from '../../infrastructure/http/erli-http-client.interface';
@@ -22,8 +28,8 @@ import type { RetryConfig } from '../../infrastructure/http/erli-http-client.typ
 
 /** Per-connection Erli capability adapters resolved by `createAdapters` (#984/#993). */
 export interface ErliAdapters {
-  offerManager: OfferManagerPort & OfferCreator & OfferFieldUpdater;
-  orderSource: OrderSourcePort;
+  offerManager: OfferManagerPort & OfferCreator & OfferFieldUpdater & OfferStockRestorer;
+  orderSource: OrderSourcePort & OrderStatusWriteback;
 }
 
 export interface IErliAdapterFactory {
@@ -33,13 +39,17 @@ export interface IErliAdapterFactory {
    * behaviour without churning this signature or the plugin's dispatch call site
    * (mirrors the Allegro precedent). `cache` is the host-provided distributed
    * cache (`host.cache`) the offer adapter uses for the #1066 frozen-stock flag;
-   * optional — absent means the adapter fails open (pushes stock).
+   * optional — absent means the adapter fails open (pushes stock). `inventoryQuery`
+   * is the master-inventory read service for the #1198 `OrderStatusWriteback`
+   * `cancelled` stock-restore path; optional — absent means that path reports
+   * `unsupported`.
    */
   createAdapters(
     connection: Connection,
     identifierMapping: IdentifierMappingPort,
     credentialsResolver: CredentialsResolverPort,
     cache?: CachePort,
+    inventoryQuery?: IInventoryQueryService,
   ): Promise<ErliAdapters>;
 
   /**

--- a/libs/integrations/erli/src/erli-integration.module.ts
+++ b/libs/integrations/erli/src/erli-integration.module.ts
@@ -1,34 +1,165 @@
 /**
  * Erli Integration Module
  *
- * Host wiring for the Erli Shop API v1 plugin. Erli has no plugin-specific
- * NestJS providers, so it uses the SDK's `createNestAdapterModule` directly:
- * the helper imports the integrations/sync/identifier-mapping modules, builds
- * the `HostServices` bag from DI, and registers the manifest + factory.
+ * Host wiring for the Erli Shop API v1 plugin. Converted from
+ * `createNestAdapterModule` to a full custom `@Module` class (#1198) to
+ * support injecting `INVENTORY_QUERY_SERVICE_TOKEN` from the DI container for
+ * the `OrderStatusWriteback` `cancelled` stock-restore path (#1198 / #997).
  *
- * Added to `apps/api/src/plugins.ts` and `apps/worker/src/plugins.ts` as
- * the single edit point that enables the plugin in both hosts.
- *
- * This stays on `createNestAdapterModule` unless Erli later needs
- * plugin-scoped NestJS providers (TypeORM entities, NestJS-managed
- * services). ADR-025's auth model — static API key, no OAuth, no
- * token-refresh — makes that unlikely, so the follow-up issues (#981 HTTP
- * client, #982 validators, #984/#993 adapters) should not reflexively flip
- * this to a custom `@Module` the way Allegro/PrestaShop do: HTTP clients
- * and shape validators are plain classes, and validators register via
- * `plugin.register(host)`, which this helper already invokes.
+ * Added to `apps/api/src/plugins.ts` and `apps/worker/src/plugins.ts` as the
+ * single edit point that enables the plugin in both hosts.
  *
  * @module libs/integrations/erli/src
  */
-import type { DynamicModule } from '@nestjs/common';
-import { createNestAdapterModule } from '@openlinker/plugin-sdk';
+import type { OnModuleInit } from '@nestjs/common';
+import { Module, Inject, Optional } from '@nestjs/common';
+import type { AdapterFactoryPort } from '@openlinker/core/integrations';
+import {
+  IntegrationsModule,
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  AdapterFactoryResolverService,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterRegistryPort,
+  CONNECTION_TESTER_REGISTRY_TOKEN,
+  ConnectionTesterRegistryService,
+  EMAIL_NORMALIZER_REGISTRY_TOKEN,
+  EmailNormalizerRegistryService,
+  WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
+  WebhookProvisioningRegistryService,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  WebhookEventTranslatorRegistryService,
+  INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
+  InboundWebhookDecoderRegistryService,
+  CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  ConnectionConfigShapeValidatorRegistryService,
+  CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  ConnectionCredentialsShapeValidatorRegistryService,
+  INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
+  OAuthCompletionRegistryService,
+  CREDENTIALS_RESOLVER_TOKEN,
+  CredentialsResolverPort,
+} from '@openlinker/core/integrations';
+import {
+  SyncModule,
+  RETRY_CLASSIFIER_REGISTRY_TOKEN,
+  RetryClassifierRegistryService,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+  AuthFailureClassifierRegistryService,
+  SCHEDULER_TASK_REGISTRY_TOKEN,
+  SchedulerTaskRegistryService,
+} from '@openlinker/core/sync';
+import {
+  IdentifierMappingModule,
+  IDENTIFIER_MAPPING_PORT_TOKEN,
+  IdentifierMappingPort,
+  type Connection,
+} from '@openlinker/core/identifier-mapping';
+import {
+  InventoryModule,
+  INVENTORY_QUERY_SERVICE_TOKEN,
+  type IInventoryQueryService,
+} from '@openlinker/core/inventory';
+import { Logger } from '@openlinker/shared/logging';
+import { CACHE_PORT_TOKEN, type CachePort } from '@openlinker/shared';
+import type { HostServices } from '@openlinker/plugin-sdk';
 import { createErliPlugin } from './erli-plugin';
 import { ErliWebhookProvisioningModule } from './erli-webhook-provisioning.module';
 
-export const ErliIntegrationModule: DynamicModule = createNestAdapterModule({
-  plugin: createErliPlugin(),
-  // #996: the automated webhook provisioner needs NestJS-injected ConnectionPort
-  // + IWebhookSecretService (not in HostServices), so it self-registers from
-  // this companion module rather than from plugin.register(host).
-  imports: [ErliWebhookProvisioningModule],
-});
+@Module({
+  imports: [
+    IntegrationsModule,
+    SyncModule,
+    IdentifierMappingModule,
+    InventoryModule,
+    // #996: the automated webhook provisioner needs NestJS-injected ConnectionPort
+    // + IWebhookSecretService (not in HostServices), so it self-registers from
+    // this companion module rather than from plugin.register(host).
+    ErliWebhookProvisioningModule,
+  ],
+})
+export class ErliIntegrationModule implements OnModuleInit {
+  private readonly logger = new Logger(ErliIntegrationModule.name);
+
+  constructor(
+    @Inject(ADAPTER_REGISTRY_TOKEN)
+    private readonly adapterRegistry: AdapterRegistryPort,
+    @Inject(ADAPTER_FACTORY_RESOLVER_TOKEN)
+    private readonly factoryResolver: AdapterFactoryResolverService,
+    @Inject(CONNECTION_TESTER_REGISTRY_TOKEN)
+    private readonly connectionTesterRegistry: ConnectionTesterRegistryService,
+    @Inject(EMAIL_NORMALIZER_REGISTRY_TOKEN)
+    private readonly emailNormalizerRegistry: EmailNormalizerRegistryService,
+    @Inject(WEBHOOK_PROVISIONING_REGISTRY_TOKEN)
+    private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
+    @Inject(WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN)
+    private readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService,
+    @Inject(INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN)
+    private readonly inboundWebhookDecoderRegistry: InboundWebhookDecoderRegistryService,
+    @Inject(CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN)
+    private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
+    @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
+    private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
+    @Inject(INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN)
+    private readonly oauthCompletionRegistry: OAuthCompletionRegistryService,
+    @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly retryClassifierRegistry: RetryClassifierRegistryService,
+    @Inject(AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly authFailureClassifierRegistry: AuthFailureClassifierRegistryService,
+    @Inject(SCHEDULER_TASK_REGISTRY_TOKEN)
+    private readonly schedulerTaskRegistry: SchedulerTaskRegistryService,
+    @Inject(IDENTIFIER_MAPPING_PORT_TOKEN)
+    private readonly identifierMapping: IdentifierMappingPort,
+    @Inject(CREDENTIALS_RESOLVER_TOKEN)
+    private readonly credentialsResolver: CredentialsResolverPort,
+    @Inject(INVENTORY_QUERY_SERVICE_TOKEN)
+    private readonly inventoryQuery: IInventoryQueryService,
+    @Optional()
+    @Inject(CACHE_PORT_TOKEN)
+    private readonly cache?: CachePort,
+  ) {}
+
+  onModuleInit(): void {
+    this.logger.log('Registering Erli plugin (manifest + factory + side registries)...');
+
+    const plugin = createErliPlugin({ inventoryQuery: this.inventoryQuery });
+
+    const host: HostServices = {
+      logger: (context: string) => new Logger(context),
+      identifierMapping: this.identifierMapping,
+      credentialsResolver: this.credentialsResolver,
+      cache: this.cache,
+      adapterRegistry: this.adapterRegistry,
+      factoryResolver: this.factoryResolver,
+      connectionTesterRegistry: this.connectionTesterRegistry,
+      emailNormalizerRegistry: this.emailNormalizerRegistry,
+      retryClassifierRegistry: this.retryClassifierRegistry,
+      authFailureClassifierRegistry: this.authFailureClassifierRegistry,
+      schedulerTaskRegistry: this.schedulerTaskRegistry,
+      webhookProvisioningRegistry: this.webhookProvisioningRegistry,
+      webhookEventTranslatorRegistry: this.webhookEventTranslatorRegistry,
+      inboundWebhookDecoderRegistry: this.inboundWebhookDecoderRegistry,
+      connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
+      connectionCredentialsShapeValidatorRegistry: this.connectionCredentialsShapeValidatorRegistry,
+      oauthCompletionRegistry: this.oauthCompletionRegistry,
+    };
+
+    host.adapterRegistry.register(plugin.manifest);
+    const factoryAdapter: AdapterFactoryPort = {
+      createCapabilityAdapter: <T>(
+        conn: Connection,
+        cap: string,
+        idMap: IdentifierMappingPort,
+        credRes: CredentialsResolverPort,
+      ): Promise<T> =>
+        plugin.createCapabilityAdapter<T>(conn, cap, {
+          ...host,
+          identifierMapping: idMap,
+          credentialsResolver: credRes,
+        }),
+    };
+    host.factoryResolver.registerFactory(plugin.manifest.adapterKey, factoryAdapter);
+    plugin.register?.(host);
+
+    this.logger.log('Erli plugin registered successfully');
+  }
+}

--- a/libs/integrations/erli/src/erli-plugin.ts
+++ b/libs/integrations/erli/src/erli-plugin.ts
@@ -9,14 +9,17 @@
  * error as fatal). #984 adds `'OfferManager'` (offers) with
  * `ErliOfferManagerAdapter`; #993 adds `'OrderSource'`.
  *
- * Side-registrations land in `register(host)` (`createNestAdapterModule`
- * invokes it): connection tester + config/credentials shape validators (#982),
- * retry + auth-failure classifiers over the Erli exception hierarchy (#984,
- * ADR-008 — without these a revoked static key would retry-storm instead of
- * flipping the connection to `needs_reauth`).
+ * Side-registrations land in `register(host)`: connection tester +
+ * config/credentials shape validators (#982), retry + auth-failure classifiers
+ * over the Erli exception hierarchy (#984, ADR-008 — without these a revoked
+ * static key would retry-storm instead of flipping the connection to
+ * `needs_reauth`).
  *
- * Erli needs no plugin-specific NestJS providers, so the host wires it via
- * `createNestAdapterModule` — see `erli-integration.module.ts`.
+ * #1198: `createErliPlugin` now accepts an optional `ErliPluginDeps` bag. The
+ * `inventoryQuery` dep enables the `OrderStatusWriteback` `cancelled`
+ * stock-restore path in `ErliOrderSourceAdapter`. Erli's module was converted
+ * from `createNestAdapterModule` to a custom `@Module` class to inject this dep
+ * from the DI container — see `erli-integration.module.ts`.
  *
  * @module libs/integrations/erli/src
  * @see {@link erliAdapterManifest} for the static manifest (#575 pattern)
@@ -24,6 +27,7 @@
 import { dispatchCapability, type AdapterPlugin, type HostServices } from '@openlinker/plugin-sdk';
 import type { AdapterMetadata } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { IInventoryQueryService } from '@openlinker/core/inventory';
 import { ErliAdapterFactory } from './application/erli-adapter.factory';
 import { ERLI_ADAPTER_KEY } from './erli.constants';
 import { ErliAuthFailureClassifierAdapter } from './infrastructure/adapters/erli-auth-failure-classifier.adapter';
@@ -57,7 +61,21 @@ export const erliAdapterManifest: AdapterMetadata = {
   isDefault: true,
 };
 
-export function createErliPlugin(): AdapterPlugin {
+/**
+ * Plugin-specific dependencies not available from the framework-neutral
+ * `HostServices` bag. Passed to `createErliPlugin` so the DI host can supply
+ * them from the NestJS container without widening the SDK `HostServices`
+ * contract (#1198 / ADR-003 plugin-sdk trust model).
+ */
+export interface ErliPluginDeps {
+  /**
+   * Master-inventory read service for the `OrderStatusWriteback` `cancelled`
+   * stock-restore path (#1198). When absent the path reports `unsupported`.
+   */
+  inventoryQuery: IInventoryQueryService;
+}
+
+export function createErliPlugin(deps?: ErliPluginDeps): AdapterPlugin {
   return {
     manifest: erliAdapterManifest,
 
@@ -88,8 +106,7 @@ export function createErliPlugin(): AdapterPlugin {
       // `erli-orders-poll` order-source poll (#993) — `buildErliSchedulerTasks`
       // now returns both. Registered unconditionally; each task's env gate
       // (OL_ERLI_OFFER_STATUS_SYNC_SCHEDULER_ENABLED / OL_ERLI_ORDERS_POLL_SCHEDULER_ENABLED)
-      // is re-checked by the scheduler at each tick (no ConfigService dependency —
-      // Erli is wired via createNestAdapterModule).
+      // is re-checked by the scheduler at each tick.
       for (const task of buildErliSchedulerTasks()) {
         host.schedulerTaskRegistry.register(task);
       }
@@ -103,10 +120,9 @@ export function createErliPlugin(): AdapterPlugin {
         ERLI_ADAPTER_KEY,
         new ErliWebhookEventTranslator(),
       );
-      // The webhook PROVISIONER (#996) is registered by `ErliWebhookProvisioningModule`
-      // (composed via `createNestAdapterModule({ imports })`), NOT here: it needs
-      // NestJS-injected `ConnectionPort` + `IWebhookSecretService` that aren't in
-      // the framework-neutral `HostServices` bag.
+      // The webhook PROVISIONER (#996) is registered by `ErliWebhookProvisioningModule`,
+      // NOT here: it needs NestJS-injected `ConnectionPort` + `IWebhookSecretService`
+      // that aren't in the framework-neutral `HostServices` bag.
     },
 
     async createCapabilityAdapter<T>(
@@ -122,6 +138,10 @@ export function createErliPlugin(): AdapterPlugin {
         // #1066: distributed frozen-stock flag. Optional on HostServices — when
         // absent the offer adapter fails open (pushes stock = pre-#1066 behaviour).
         host.cache,
+        // #1198: master-inventory query for the `cancelled` stock-restore path.
+        // Only present when `ErliIntegrationModule` injected `inventoryQuery` via
+        // `createErliPlugin({ inventoryQuery: this.inventoryQuery })`.
+        deps?.inventoryQuery,
       );
       return dispatchCapability<T>(
         capability,

--- a/libs/integrations/erli/src/erli.constants.ts
+++ b/libs/integrations/erli/src/erli.constants.ts
@@ -1,10 +1,20 @@
 /**
  * Erli Plugin Constants
  *
- * Single source of truth for the Erli adapter key, shared by the manifest
- * (`erli-plugin.ts`) and the per-connection factory / adapters without a
- * circular import (a leaf module both sides depend on).
+ * Single source of truth for the Erli adapter key and shared patterns, used
+ * by the manifest (`erli-plugin.ts`) and the per-connection factory / adapters
+ * without a circular import (a leaf module both sides depend on).
  *
  * @module libs/integrations/erli/src
  */
 export const ERLI_ADAPTER_KEY = 'erli.shopapi.v1';
+
+/**
+ * Seller-keyed product-id allowlist pattern. The id is interpolated into the
+ * request path, so it MUST exclude `/`, `?`, `#`, and `..` (path-traversal /
+ * injection) regardless of any future #992 charset change; `encodeURIComponent`
+ * is the backstop. Today the id is the OL internal variant id. If #992 switches
+ * the seller-key format, this constant AND all call sites that use it must change
+ * in lockstep (a mismatch fails closed: updates throw, never send).
+ */
+export const ERLI_PRODUCT_ID_PATTERN = /^ol_variant_[a-f0-9]{32}$/;

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts
@@ -16,6 +16,8 @@
  * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
  */
 import { isOrderStatusWriteback, type OrderFeedInput } from '@openlinker/core/orders';
+import type { IInventoryQueryService } from '@openlinker/core/inventory';
+import type { OfferManagerPort, OfferStockRestorer } from '@openlinker/core/listings';
 import { ErliApiException } from '../../../domain/exceptions/erli-api.exception';
 import type { IErliHttpClient } from '../../http/erli-http-client.interface';
 import type { ErliHttpResponse } from '../../http/erli-http-client.types';
@@ -385,12 +387,92 @@ describe('ErliOrderSourceAdapter', () => {
       expect(isOrderStatusWriteback(adapter)).toBe(true);
     });
 
-    it('reports unsupported for a cancelled event (Erli has no cancel writeback verb)', async () => {
-      const result = await adapter.write({ type: 'cancelled', externalOrderId: ORDER_ID });
+    // #1198: `cancelled` now triggers stock-restore instead of unconditional
+    // `unsupported`. The nested describe below covers the full test matrix.
+    describe('cancelled — stock-restore (#1198)', () => {
+      // A valid OL internal variant id (32 lower-hex chars after the prefix).
+      const OFFER_ID = 'ol_variant_aabbccdd11223344aabbccdd11223344';
 
-      expect(result.outcome).toBe('unsupported');
-      expect(client.patch).not.toHaveBeenCalled();
-      expect(client.post).not.toHaveBeenCalled();
+      let offerManager: { restoreStockOnCancellation: jest.Mock; updateOfferQuantity: jest.Mock };
+      let inventoryQuery: { getAvailabilityByVariantIds: jest.Mock };
+      let wiredAdapter: ErliOrderSourceAdapter;
+
+      beforeEach(() => {
+        offerManager = {
+          restoreStockOnCancellation: jest.fn().mockResolvedValue(undefined),
+          updateOfferQuantity: jest.fn(),
+        };
+        inventoryQuery = {
+          getAvailabilityByVariantIds: jest.fn().mockResolvedValue([
+            { productVariantId: OFFER_ID, totalAvailable: 5, locationCount: 1 },
+          ]),
+        };
+        wiredAdapter = new ErliOrderSourceAdapter(
+          CONNECTION_ID,
+          client,
+          offerManager as unknown as OfferManagerPort & OfferStockRestorer,
+          inventoryQuery as unknown as IInventoryQueryService,
+        );
+        // Happy-path order: one item whose externalId doubles as the variant id.
+        client.get.mockResolvedValue(
+          ok(
+            buildErliOrder({
+              items: [
+                { id: 1, externalId: OFFER_ID, quantity: 2, unitPrice: 5000, name: 'Widget', sku: 'SKU-A' },
+              ],
+            }),
+          ),
+        );
+      });
+
+      it('should return applied and restore stock using master-authoritative quantity', async () => {
+        const result = await wiredAdapter.write({ type: 'cancelled', externalOrderId: ORDER_ID });
+
+        expect(result.outcome).toBe('applied');
+        expect(inventoryQuery.getAvailabilityByVariantIds).toHaveBeenCalledWith([OFFER_ID]);
+        expect(offerManager.restoreStockOnCancellation).toHaveBeenCalledWith([
+          { externalOfferId: OFFER_ID, quantity: 5 },
+        ]);
+      });
+
+      it('should restore to zero when master-inventory reports zero stock', async () => {
+        inventoryQuery.getAvailabilityByVariantIds.mockResolvedValue([
+          { productVariantId: OFFER_ID, totalAvailable: 0, locationCount: 1 },
+        ]);
+
+        await wiredAdapter.write({ type: 'cancelled', externalOrderId: ORDER_ID });
+
+        expect(offerManager.restoreStockOnCancellation).toHaveBeenCalledWith([
+          { externalOfferId: OFFER_ID, quantity: 0 },
+        ]);
+      });
+
+      it('should report rejected when the order fetch fails', async () => {
+        client.get.mockRejectedValue(new ErliApiException('upstream error', 503));
+
+        const result = await wiredAdapter.write({ type: 'cancelled', externalOrderId: ORDER_ID });
+
+        expect(result.outcome).toBe('rejected');
+        expect(result.detail).toContain('Failed to fetch Erli order');
+        expect(offerManager.restoreStockOnCancellation).not.toHaveBeenCalled();
+      });
+
+      it('should report rejected when restoreStockOnCancellation throws', async () => {
+        offerManager.restoreStockOnCancellation.mockRejectedValue(new Error('write failed'));
+
+        const result = await wiredAdapter.write({ type: 'cancelled', externalOrderId: ORDER_ID });
+
+        expect(result.outcome).toBe('rejected');
+      });
+
+      it('should report unsupported when the adapter is not wired (no offerManager or inventoryQuery)', async () => {
+        // `adapter` from the outer beforeEach has no offerManager/inventoryQuery.
+        const result = await adapter.write({ type: 'cancelled', externalOrderId: ORDER_ID });
+
+        expect(result.outcome).toBe('unsupported');
+        expect(client.patch).not.toHaveBeenCalled();
+        expect(client.post).not.toHaveBeenCalled();
+      });
     });
 
     it('reports unsupported (no PATCH, no POST) when the #992 writeback gate is OFF by default (#1086)', async () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -104,6 +104,7 @@ import type { CachePort } from '@openlinker/shared';
 import { Logger } from '@openlinker/shared/logging';
 import { ErliApiException } from '../../domain/exceptions/erli-api.exception';
 import { ErliConfigException } from '../../domain/exceptions/erli-config.exception';
+import { ERLI_PRODUCT_ID_PATTERN } from '../../erli.constants';
 import type { ErliDispatchTime } from '../../domain/types/erli-connection.types';
 import type { IErliHttpClient } from '../http/erli-http-client.interface';
 import type {
@@ -114,16 +115,6 @@ import type {
   ErliProductPatchBody,
   ErliProductResource,
 } from './erli-product.types';
-
-/**
- * Seller-keyed product-id allowlist. The id is interpolated into the request
- * path, so it MUST exclude `/`, `?`, `#`, and `..` (path-traversal / injection)
- * regardless of any future #992 charset change; `encodeURIComponent` is the
- * backstop. Today the id is the OL internal variant id — if #992 switches the
- * seller-key format, this pattern AND {@link ErliOfferManagerAdapter.resolveErliProductId}
- * must change in lockstep (a mismatch fails closed: updates throw, never send).
- */
-const ERLI_PRODUCT_ID_PATTERN = /^ol_variant_[a-f0-9]{32}$/;
 
 /**
  * Maps OL patch-body keys to the Erli field name carried in

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-order-source.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-order-source.adapter.ts
@@ -45,10 +45,13 @@
  *   `PATCH /orders/{id}/status { status: 'sent' }` (the enum has no `dispatched`;
  *   `sent` is the dispatch state), then register an external shipment via
  *   `POST /shipping/external` ONLY when a waybill is present.
- * - **`cancelled`** — reported `unsupported`: Erli's order-status enum has no
- *   operator-driven cancel verb, and the compensating stock-restore (#997 Half B)
- *   lives in `ErliOfferManagerAdapter.restoreStockOnCancellation`, wired by the
- *   future cancel-observe hook (Q-T2 / #1146), NOT by this status writeback.
+ * - **`cancelled`** — absolute stock-restore (#1198 / #997 Half A): fetches the
+ *   cancelled order, resolves master-authoritative stock per offer from
+ *   `IInventoryQueryService.getAvailabilityByVariantIds`, and delegates
+ *   absolute-set writes to `ErliOfferManagerAdapter.restoreStockOnCancellation`
+ *   (which calls `updateOfferQuantity` and honours the frozen-stock cache).
+ *   Reports `unsupported` when either `offerManager` or `inventoryQuery` was not
+ *   wired (pre-#1198 callers / tests that don't provide those deps).
  *
  * #992 RELEASE GATE (#1086 review): the endpoint/verb/status token are
  * #992-PROVISIONAL (`erli-fulfillment.types.ts`). To avoid writing to an
@@ -83,6 +86,12 @@ import type {
   OrderStatusWriteback,
   OrderWritebackResult,
 } from '@openlinker/core/orders';
+import type { IInventoryQueryService } from '@openlinker/core/inventory';
+import type {
+  OfferManagerPort,
+  OfferStockRestorer,
+  OfferStockRestoreTarget,
+} from '@openlinker/core/listings';
 import { Logger } from '@openlinker/shared/logging';
 import { ErliApiException } from '../../domain/exceptions/erli-api.exception';
 import { ErliOrderDispatchRejectedException } from '../../domain/exceptions/erli-order-dispatch-rejected.exception';
@@ -126,10 +135,16 @@ export class ErliOrderSourceAdapter implements OrderSourcePort, OrderStatusWrite
    * Shares the per-connection `ErliHttpClient` with the sibling
    * `ErliOfferManagerAdapter` (both built by `ErliAdapterFactory.createAdapters`).
    * No `IdentifierMappingPort`: identity resolution is downstream in core (#995).
+   *
+   * `offerManager` and `inventoryQuery` power the #1198 `cancelled` stock-restore
+   * path. Both are optional so unit-test bootstraps and the pre-#1198 factory
+   * callers stay valid; absent means that path reports `unsupported`.
    */
   constructor(
     private readonly connectionId: string,
     private readonly httpClient: IErliHttpClient,
+    private readonly offerManager?: OfferManagerPort & OfferStockRestorer,
+    private readonly inventoryQuery?: IInventoryQueryService,
   ) {}
 
   /**
@@ -264,9 +279,14 @@ export class ErliOrderSourceAdapter implements OrderSourcePort, OrderStatusWrite
    *   #992-gated default-OFF: when the gate is off, reported `unsupported`
    *   (surfaced, not a silent success) so the relay/operator sees nothing was
    *   propagated to the live order. A write failure is reported `rejected`.
-   * - `cancelled` → `unsupported`: Erli has no operator-driven cancel verb; the
-   *   compensating stock-restore is `ErliOfferManagerAdapter.restoreStockOnCancellation`,
-   *   wired by the future cancel-observe hook (Q-T2 / #1146), not this writeback.
+   * - `cancelled` → absolute stock-restore (#1198 / #997 Half A): fetches the
+   *   order to read its line items, resolves master-authoritative stock per variant
+   *   via `inventoryQuery`, and delegates absolute-set writes to `offerManager`
+   *   (`ErliOfferManagerAdapter.restoreStockOnCancellation` → `updateOfferQuantity`,
+   *   which already honours the frozen-stock cache). Reports `unsupported` when
+   *   either `offerManager` or `inventoryQuery` is absent (pre-wired callers and
+   *   tests that don't set up those deps), `applied` on success, `rejected` on any
+   *   error (order-fetch failure, inventory-read failure, or stock-write failure).
    *
    * `externalOrderId` is resolved upstream by the relay (this adapter does no
    * identifier mapping). Log hygiene: NEVER log `trackingNumber` / `externalOrderId`
@@ -274,12 +294,24 @@ export class ErliOrderSourceAdapter implements OrderSourcePort, OrderStatusWrite
    */
   async write(event: OrderLifecycleEvent): Promise<OrderWritebackResult> {
     if (event.type === 'cancelled') {
-      return {
-        outcome: 'unsupported',
-        detail:
-          'Erli has no operator-driven order-cancel writeback; stock-restore is the ' +
-          'offer-adapter compensating path wired by the Q-T2 cancel-observe hook (#1146).',
-      };
+      if (!this.offerManager || !this.inventoryQuery) {
+        return {
+          outcome: 'unsupported',
+          detail:
+            'Erli cancelled stock-restore is not wired: offerManager or inventoryQuery is absent.',
+        };
+      }
+      try {
+        await this.restockOnCancellation(event.externalOrderId, this.offerManager, this.inventoryQuery);
+        return { outcome: 'applied' };
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          `OrderStatusWriteback 'cancelled' (stock-restore) rejected for Erli order ` +
+            `(connection: ${this.connectionId}): ${detail}`,
+        );
+        return { outcome: 'rejected', detail };
+      }
     }
 
     // event.type === 'dispatched'
@@ -311,6 +343,64 @@ export class ErliOrderSourceAdapter implements OrderSourcePort, OrderStatusWrite
       );
       return { outcome: 'rejected', detail };
     }
+  }
+
+  /**
+   * Fetch the order, resolve master-authoritative stock per variant, and issue
+   * absolute-set stock-restore writes via the shared offer-manager reference.
+   *
+   * Erli ID duality: for Erli, `item.externalId` is the OL internal variant id
+   * (the seller key), which doubles as both the Erli offer id (path key for
+   * `updateOfferQuantity`) and the OL inventory variant id (key for
+   * `getAvailabilityByVariantIds`) — no identifier mapping step is needed.
+   *
+   * Absolute-set semantics: master is authoritative including 0, so a sold-out
+   * variant restores to 0 rather than being backfilled. The frozen-stock check
+   * lives inside `updateOfferQuantity` (via `restoreStockOnCancellation`) and
+   * silently skips seller-frozen offers — consistent with ADR-025 §4b.
+   *
+   * Throws on order-fetch failure, inventory-read failure, or write failure.
+   * `write('cancelled')` catches and maps to `rejected`.
+   */
+  private async restockOnCancellation(
+    externalOrderId: string,
+    offerManager: OfferManagerPort & OfferStockRestorer,
+    inventoryQuery: IInventoryQueryService,
+  ): Promise<void> {
+    // 1. Fetch the order to learn which offer IDs need restocking.
+    let response;
+    try {
+      response = await this.httpClient.get<unknown>(erliOrderPath(externalOrderId));
+    } catch (error) {
+      throw new Error(
+        `Failed to fetch Erli order for stock-restore: ${(error as Error).message}`,
+      );
+    }
+    const order = assertErliOrder(response.data);
+
+    // Collect unique offer IDs. Dedupe because an order might theoretically
+    // repeat the same externalId across items (e.g. split-line quantities).
+    const offerIds = [...new Set(order.items.map((item) => item.externalId))];
+    if (offerIds.length === 0) {
+      return;
+    }
+
+    // 2. Resolve master-authoritative stock per variant. Key by `productVariantId`
+    //    — output order is NOT guaranteed to match input order, so positional
+    //    indexing would silently assign wrong quantities. `?? 0` is the zero-fill
+    //    safety net for any variant id the service doesn't return a row for.
+    const availability = await inventoryQuery.getAvailabilityByVariantIds(offerIds);
+    const stockByVariantId = new Map(
+      availability.map((row) => [row.productVariantId, row.totalAvailable]),
+    );
+
+    // 3. Build restore targets and dispatch via the shared offer-manager reference.
+    //    Absolute-set: master is authoritative including 0.
+    const targets: OfferStockRestoreTarget[] = offerIds.map((offerId) => ({
+      externalOfferId: offerId,
+      quantity: stockByVariantId.get(offerId) ?? 0,
+    }));
+    await offerManager.restoreStockOnCancellation(targets);
   }
 
   /**


### PR DESCRIPTION

When an order is cancelled, ErliOrderSourceAdapter.write('cancelled') now fetches the order, resolves master-authoritative stock per offer via IInventoryQueryService.getAvailabilityByVariantIds, and delegates absolute-set writes to ErliOfferManagerAdapter.restoreStockOnCancellation. Frozen offers are silently skipped (ADR-025 §4b). Reports unsupported when offerManager or inventoryQuery is not wired (backward-compatible with pre-#1198 callers).

ErliIntegrationModule converted from createNestAdapterModule to a full custom @Module class (mirrors AllegroIntegrationModule) to inject INVENTORY_QUERY_SERVICE_TOKEN from the DI container. createErliPlugin now accepts an optional ErliPluginDeps bag carrying inventoryQuery; plugin-specific deps stay out of the framework-neutral HostServices contract (ADR-003).

Closes #1175

<!--
Thank you for contributing to OpenLinker!

Title: use Conventional Commits format — `feat(scope): subject`,
`fix(scope): subject`, `docs:`, `refactor:`, `test:`, `chore:`.
See CONTRIBUTING.md → Commits for the full type list.
-->

## Summary

<!-- 1–3 bullets: what changed and why. Focus on the why. -->

-

## Related issues

<!-- One `Closes #N` per issue this PR resolves. Issues are closed
     automatically when the PR merges — do not close them manually. -->

Closes #

## Test plan

<!-- How a reviewer verifies the change. Commands to run, paths to
     click through, edge cases to confirm. -->

-

## Quality gate

- [ ] `pnpm lint` passes (zero errors)
- [ ] `pnpm type-check` passes (zero errors)
- [ ] `pnpm test` passes (all unit tests green)
- [ ] *Optional, Docker required:* `pnpm test:integration` passes — needed
      only if you touched `apps/api/test/integration/**` or any plugin's
      `infrastructure/adapters/`.

## Migrations

- [ ] If this PR changes an ORM entity, a migration is included under
      `apps/api/src/migrations/` (or the plugin package), `pnpm --filter
      @openlinker/api migration:show` confirms it's listed, and both
      `up()` and `down()` were tested locally. See
      [`docs/migrations.md`](../docs/migrations.md). Tick this box for
      PRs that don't touch schemas too — it's trivially satisfied.

## ADR

- [ ] If this PR makes a non-trivial architectural decision (affects
      multiple contexts, the plugin contract, or has alternatives worth
      documenting), an ADR should be included under
      `docs/architecture/adrs/` or referenced in the PR description.
      ADRs are a recommendation, not a hard gate — see
      [`docs/architecture/adrs/README.md`](../docs/architecture/adrs/README.md)
      § "When to write an ADR" for the decision criteria. Tick this box
      for PRs that don't make architectural decisions too — it's
      trivially satisfied.

## DCO sign-off

> Sign off every commit with `git commit -s`. OpenLinker uses the
> [Developer Certificate of Origin](https://developercertificate.org/)
> as its contributor attestation (see
> [CONTRIBUTING.md → Commits](../CONTRIBUTING.md#commits)). Automated
> enforcement is deferred until after the org transfer; sign off anyway
> so the history is consistent when enforcement starts.

<details>
<summary><strong>Adding a new integration adapter?</strong> (expand)</summary>

If this PR introduces a new package under `libs/integrations/<x>/`,
declare its status so reviewers know what bar to apply:

- [ ] **alpha** — experimental; API may change, no production traffic
      yet
- [ ] **beta** — stable contract, real-world use ongoing, breaking
      changes flagged in PR title
- [ ] **stable** — production-ready; breaking changes follow semver

See [`docs/architecture-overview.md`](../docs/architecture-overview.md)
for the adapter / capability contract and
[`GOVERNANCE.md`](../GOVERNANCE.md) for the policy on plugin authors
co-maintaining their own adapter.

</details>

<details>
<summary><strong>UI changes?</strong> Attach screenshots at three widths (expand)</summary>

Per [`docs/frontend-ui-style-guide.md` § Responsive](../docs/frontend-ui-style-guide.md#responsive),
mobile and tablet are first-class. Capture after-shots at all three
breakpoints:

- **Mobile** (360 × 812):
- **Tablet** (768 × 1024):
- **Desktop** (1440 × 900):

</details>

---

<sub>By submitting this pull request, I confirm that my contributions
are made under the terms of the [Apache License 2.0](../LICENSE), and I
certify the [Developer Certificate of Origin](https://developercertificate.org/)
by signing off my commits.</sub>
