### PR TITLE
feat(web): collect full KSeF seller profile in the connection wizard (#1223)

### DIFF
--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -42,6 +42,12 @@ type StructuredField =
   | 'subiektTriggerModel'
   | 'ksefEnvironment'
   | 'sellerNip'
+  | 'sellerName'
+  | 'sellerAddressLine1'
+  | 'sellerAddressLine2'
+  | 'sellerCity'
+  | 'sellerPostalCode'
+  | 'sellerCountryIso2'
   | 'contextIdentifier'
   | 'inpostEnvironment'
   | 'inpostOrganizationId';
@@ -126,6 +132,47 @@ function readInpostSenderAddress(
       postCode: typeof address.postCode === 'string' ? address.postCode : '',
       countryCode: typeof address.countryCode === 'string' ? address.countryCode : '',
     },
+  };
+}
+
+/**
+ * Read the KSeF seller config sub-object out of `config.seller` (#1223).
+ * Returns a flat object of form-field values so the edit form can hydrate the
+ * seller profile fields. Falls back to the old flat `config.sellerNip` for
+ * connections saved before the nested shape was introduced.
+ */
+function readKsefSeller(config: Record<string, unknown>): {
+  sellerNip: string;
+  sellerName: string;
+  sellerAddressLine1: string;
+  sellerAddressLine2: string;
+  sellerCity: string;
+  sellerPostalCode: string;
+  sellerCountryIso2: string;
+} {
+  const seller =
+    typeof config.seller === 'object' && config.seller !== null
+      ? (config.seller as Record<string, unknown>)
+      : {};
+  const address =
+    typeof seller.address === 'object' && seller.address !== null
+      ? (seller.address as Record<string, unknown>)
+      : {};
+  // Fallback: if config.seller.nip is absent, read legacy flat config.sellerNip.
+  const nip =
+    typeof seller.nip === 'string'
+      ? seller.nip
+      : typeof config.sellerNip === 'string'
+        ? config.sellerNip
+        : '';
+  return {
+    sellerNip: nip,
+    sellerName: typeof seller.name === 'string' ? seller.name : '',
+    sellerAddressLine1: typeof address.line1 === 'string' ? address.line1 : '',
+    sellerAddressLine2: typeof address.line2 === 'string' ? address.line2 : '',
+    sellerCity: typeof address.city === 'string' ? address.city : '',
+    sellerPostalCode: typeof address.postalCode === 'string' ? address.postalCode : '',
+    sellerCountryIso2: typeof address.countryIso2 === 'string' ? address.countryIso2 : '',
   };
 }
 
@@ -274,9 +321,11 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
       subiektBridgeUrl: readString(connection.config, 'subiektBridgeUrl'),
       subiektTriggerModel: readTriggerModel(connection.config),
       subiektCapabilities: readSubiektCapabilities(connection.config),
-      // KSeF structured fields (#1152) — read from `config.{env,sellerNip,contextIdentifier}`.
+      // KSeF structured fields (#1152, #1223) — env from `config.env`; seller
+      // profile from nested `config.seller` (with legacy flat `config.sellerNip`
+      // fallback); context identifier from `config.contextIdentifier`.
       ksefEnvironment: readKsefEnvironment(connection.config),
-      sellerNip: readString(connection.config, 'sellerNip'),
+      ...readKsefSeller(connection.config),
       contextIdentifier: readString(connection.config, 'contextIdentifier'),
       // InPost structured fields (#771) — read from `config.{environment,
       // organizationId,senderAddress}`. Symmetric read-side hydration so an

--- a/apps/web/src/features/connections/components/edit-connection.schema.test.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { editConnectionSchema, mergeStructuredIntoConfig } from './edit-connection.schema';
+import { buildKsefSellerConfig } from './ksef-setup.schema';
+import type { KsefSellerProfileInput } from './ksef-seller-config';
 
 describe('mergeStructuredIntoConfig', () => {
   it('writes a new baseUrl into an empty config', () => {
@@ -317,5 +319,160 @@ describe('mergeStructuredIntoConfig — inpostPsModuleType (#767/#1155)', () => 
   it('does not create the key when empty string is patched into an empty config', () => {
     const result = mergeStructuredIntoConfig({}, { inpostPsModuleType: '' });
     expect('inpostPsModuleType' in result).toBe(false);
+  });
+});
+
+describe('mergeStructuredIntoConfig — KSeF seller profile (#1223)', () => {
+  it('assembles the nested config.seller shape resolveSeller reads', () => {
+    const result = mergeStructuredIntoConfig(
+      { env: 'prod' },
+      {
+        sellerNip: '12-3456789-0',
+        sellerName: 'ACME Sp. z o.o.',
+        sellerAddressLine1: 'ul. Przykładowa 1',
+        sellerCity: 'Warszawa',
+        sellerPostalCode: '00-001',
+        sellerCountryIso2: 'pl',
+      },
+    );
+    // NIP normalised to digits, country upper-cased, blank line2 omitted.
+    expect(result.seller).toEqual({
+      nip: '1234567890',
+      name: 'ACME Sp. z o.o.',
+      address: {
+        line1: 'ul. Przykładowa 1',
+        city: 'Warszawa',
+        postalCode: '00-001',
+        countryIso2: 'PL',
+      },
+    });
+    // No flat sellerNip — the canonical location is config.seller.nip.
+    expect(result.sellerNip).toBeUndefined();
+    expect(result.env).toBe('prod');
+  });
+
+  it('preserves untouched seller siblings on a single-field patch', () => {
+    const base = {
+      seller: {
+        nip: '1234567890',
+        name: 'ACME',
+        address: { line1: 'ul. A 1', city: 'Kraków', postalCode: '30-001', countryIso2: 'PL' },
+      },
+    };
+    const result = mergeStructuredIntoConfig(base, { sellerCity: 'Gdańsk' });
+    expect(result.seller).toEqual({
+      nip: '1234567890',
+      name: 'ACME',
+      address: { line1: 'ul. A 1', city: 'Gdańsk', postalCode: '30-001', countryIso2: 'PL' },
+    });
+  });
+
+  it('drops an emptied address object and an emptied seller object', () => {
+    const base = {
+      seller: { address: { city: 'Łódź' } },
+    };
+    const result = mergeStructuredIntoConfig(base, { sellerCity: '' });
+    expect('seller' in result).toBe(false);
+  });
+
+  it('does not touch config.seller when no seller sub-field is on the patch', () => {
+    const base = { seller: { nip: '1234567890' }, env: 'test' };
+    const result = mergeStructuredIntoConfig(base, { ksefEnvironment: 'demo' });
+    expect(result.seller).toEqual({ nip: '1234567890' });
+    expect(result.env).toBe('demo');
+  });
+});
+
+describe('KSeF seller assembly — create/edit parity (#1223)', () => {
+  // Feeds the identical flat seller input through the create path
+  // (buildKsefSellerConfig) and the edit path (mergeStructuredIntoConfig onto an
+  // empty config) and asserts both produce the same nested config.seller. Guards
+  // against the two flows' normalization/assembly drifting apart now that they
+  // share one source (ksef-seller-config).
+  const cases: Array<{ name: string; input: KsefSellerProfileInput }> = [
+    {
+      name: 'full profile with separators + lower-case country',
+      input: {
+        sellerNip: '12-3456789-0',
+        sellerName: '  ACME Sp. z o.o.  ',
+        sellerAddressLine1: ' ul. Przykładowa 1 ',
+        sellerAddressLine2: '',
+        sellerCity: 'Warszawa',
+        sellerPostalCode: '00-001',
+        sellerCountryIso2: 'pl',
+      },
+    },
+    {
+      name: 'NIP only, no address',
+      input: { sellerNip: '1234567890' },
+    },
+    {
+      name: 'name + partial address',
+      input: { sellerName: 'Solo', sellerCity: 'Kraków' },
+    },
+    {
+      name: 'lone country default (hollow profile)',
+      input: { sellerCountryIso2: 'PL' },
+    },
+    {
+      name: 'completely empty',
+      input: {},
+    },
+  ];
+
+  for (const { name, input } of cases) {
+    it(`produces identical config.seller via create and edit paths — ${name}`, () => {
+      const createSeller = buildKsefSellerConfig(input);
+      const editSeller = mergeStructuredIntoConfig({}, input).seller;
+      expect(editSeller).toEqual(createSeller);
+    });
+  }
+
+  it('does not write a hollow seller from a lone PL country default', () => {
+    expect(buildKsefSellerConfig({ sellerCountryIso2: 'PL' })).toBeUndefined();
+    expect('seller' in mergeStructuredIntoConfig({}, { sellerCountryIso2: 'PL' })).toBe(false);
+  });
+});
+
+describe('editConnectionSchema — KSeF postal code validation (#1223)', () => {
+  const base = {
+    name: 'KSeF main',
+    configText: '{"env":"prod"}',
+  };
+
+  it('rejects a malformed PL postal code', () => {
+    const result = editConnectionSchema.safeParse({
+      ...base,
+      sellerPostalCode: '1234',
+      sellerCountryIso2: 'PL',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a well-formed PL postal code', () => {
+    const result = editConnectionSchema.safeParse({
+      ...base,
+      sellerPostalCode: '00-001',
+      sellerCountryIso2: 'PL',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('allows an empty postal code for incremental save', () => {
+    const result = editConnectionSchema.safeParse({
+      ...base,
+      sellerPostalCode: '',
+      sellerCountryIso2: 'PL',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('skips the PL format check for a non-PL country', () => {
+    const result = editConnectionSchema.safeParse({
+      ...base,
+      sellerPostalCode: 'SW1A 1AA',
+      sellerCountryIso2: 'GB',
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -370,6 +370,10 @@ export interface StructuredConfigPatch {
    * reads. Empty string clears that leaf; the merge helper drops an emptied
    * `address` / `seller` object so a hollow profile is never persisted. NIP is
    * normalised to digits only, matching the create path.
+   *
+   * The read-side counterpart is `readKsefSeller()` in `EditConnectionForm.tsx`,
+   * which hydrates from `config.seller.*` (with a legacy flat `config.sellerNip`
+   * fallback for connections saved before the nested shape was introduced).
    */
   sellerNip?: string;
   sellerName?: string;

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -3,6 +3,7 @@ import type { UpdateConnectionInput } from '../api/connections.types';
 import { POLISH_VOIVODESHIP_VALUES } from '../types/polish-voivodeship.types';
 import { INVOICE_TRIGGER_MODEL_VALUES } from '../types/invoice-trigger-model.types';
 import { normalizeNip } from './ksef-nip';
+import { applyKsefSellerToConfig } from './ksef-seller-config';
 
 /**
  * Connection-level seller-defaults schema (#430 / #445). Each sub-field is
@@ -112,151 +113,188 @@ const inpostSenderAddressSchema = z.object({
 
 export type InpostSenderAddressFormValues = z.input<typeof inpostSenderAddressSchema>;
 
-export const editConnectionSchema = z.object({
-  name: z.string().trim().min(1, 'Connection name is required'),
-  baseUrl: z.string().trim().optional(),
-  // WooCommerce-only structured field surfacing `config.siteUrl` — the key
-  // the WooCommerce backend config DTO validates (#975). Mirrors the setup
-  // wizard's https-only rule (Basic Auth credentials must not travel in
-  // cleartext); empty string stays allowed (delete-on-empty merge semantics).
-  siteUrl: z
-    .union([
-      z
-        .url('Site URL must be a valid URL (e.g. https://shop.example.com)')
-        .refine((value) => value.startsWith('https://'), 'Site URL must use HTTPS'),
-      z.literal(''),
-    ])
-    .optional(),
-  shopId: z.string().trim().optional(),
-  // Optional override for the split-host case (webservice host ≠ public storefront).
-  // Accepts a validated URL or an empty string (to unset). See #271 / #283.
-  storefrontBaseUrl: z
-    .union([
-      z
-        .url('Storefront URL must be a valid URL')
-        .refine(
-          (value) => value.startsWith('http://') || value.startsWith('https://'),
-          'Storefront URL must use http:// or https://',
-        ),
-      z.literal(''),
-    ])
-    .optional(),
-  // OL's URL from PrestaShop's perspective — used by the webhook auto-install
-  // flow (#168). FE pre-fills this from `window.location.origin` on first
-  // render when empty so most operators don't have to think about it; dev
-  // override is `http://host.docker.internal:3000`.
-  openlinkerCallbackBaseUrl: z
-    .union([
-      z
-        .url('Callback URL must be a valid URL')
-        .refine(
-          (value) => value.startsWith('http://') || value.startsWith('https://'),
-          'Callback URL must use http:// or https://',
-        ),
-      z.literal(''),
-    ])
-    .optional(),
-  masterCatalogConnectionId: z
-    .union([z.string().uuid('Product catalog must be a valid connection ID'), z.literal('')])
-    .optional(),
-  // PrestaShop-only structured field surfacing `config.defaultCarrierId`
-  // (#517). Stored as a string on the form so the same `<Select>`
-  // primitive can serve both this field and the per-method mapping
-  // dropdown (which uses string `id_reference` values). `mergeStructuredIntoConfig`
-  // coerces to an integer at submit; non-integer/zero/negative input is
-  // refused with a Zod refine.
-  defaultCarrierId: z
-    .union([
-      z.string().refine((v) => v === '' || /^[1-9]\d*$/.test(v.trim()), {
-        message: 'Default carrier ID must be a positive integer.',
-      }),
-      z.literal(''),
-    ])
-    .optional(),
-  // WooCommerce-only structured field surfacing `config.inventory.unmanagedStockQuantity`
-  // (#969 §7.3). Quantity reported for products with stock management disabled but
-  // `stock_status=instock`. String on the form (same shape as defaultCarrierId);
-  // `mergeStructuredIntoConfig` coerces to an integer nested under `inventory` at
-  // submit. Empty clears the override so the adapter default (1000) applies.
-  unmanagedStockQuantity: z
-    .union([
-      z.string().refine((v) => v === '' || /^[1-9]\d*$/.test(v.trim()), {
-        message: 'Unmanaged stock quantity must be a positive integer.',
-      }),
-      z.literal(''),
-    ])
-    .optional(),
-  // PS-only structured field for the installed InPost PS module type (#767/#1155).
-  // Controls whether OL reads the paczkomat locker code from address2 on order
-  // ingestion. '' (empty string, select sentinel) = clear the key; 'official_inpost' = enabled.
-  inpostPsModuleType: z.union([z.literal('official_inpost'), z.literal('')]).optional(),
-  configText: z
-    .string()
-    .trim()
-    .min(2, 'Configuration JSON is required')
-    .refine((value) => {
-      try {
-        JSON.parse(value);
-        return true;
-      } catch {
-        return false;
-      }
-    }, 'Configuration must be valid JSON'),
-  adapterKey: z.string().trim().optional(),
-  // #430 — Allegro-only structured fields. Always optional at the form
-  // level; the BE DTO validates strict shape on PATCH.
-  sellerDefaults: allegroSellerDefaultsSchema.optional(),
-  // #759 — Subiekt-only structured fields.
-  // Bridge URL → flat `config.subiektBridgeUrl`. URL-or-empty (empty unsets,
-  // delete-on-empty merge). Mirrors `storefrontBaseUrl` (http/https allowed).
-  subiektBridgeUrl: z
-    .union([
-      z
-        .url('Bridge URL must be a valid URL')
-        .refine(
-          (value) => value.startsWith('http://') || value.startsWith('https://'),
-          'Bridge URL must use http:// or https://',
-        ),
-      z.literal(''),
-    ])
-    .optional(),
-  // Invoice trigger model → NESTED `config.invoicing.triggerModel` (NOT flat).
-  // Empty allowed for unset. The 4 values mirror the live BE reader
-  // `getInvoiceTriggerModel` (see `types/invoice-trigger-model.types.ts`).
-  subiektTriggerModel: z.union([z.enum(INVOICE_TRIGGER_MODEL_VALUES), z.literal('')]).optional(),
-  // Capability toggles → whole-object `config.capabilities.<key> = boolean`.
-  subiektCapabilities: z.record(z.string(), z.boolean()).optional(),
-  // KSeF-only structured fields surfacing `config.env` / `config.sellerNip` /
-  // `config.contextIdentifier` (#1152). `ksefEnvironment` maps to the BE C2
-  // `KsefConnectionConfig.env` enum (the one config-validator-gated field);
-  // the other two are FE-additive context fields. All optional client-side so
-  // the operator can save incremental progress; the server is the strict gate.
-  ksefEnvironment: z.union([z.enum(['test', 'demo', 'prod']), z.literal('')]).optional(),
-  // NIP normalization mirrors the setup wizard (`ksef-setup.schema.ts`): strip
-  // dashes/spaces the operator may paste, then enforce 10 digits. Without this
-  // parity a value saved with separators on create fails the edit-schema check.
-  sellerNip: z
-    .union([
-      z
-        .string()
-        .transform(normalizeNip)
-        .refine((v) => v === '' || /^\d{10}$/.test(v), {
-          message: 'Seller NIP must be 10 digits.',
+export const editConnectionSchema = z
+  .object({
+    name: z.string().trim().min(1, 'Connection name is required'),
+    baseUrl: z.string().trim().optional(),
+    // WooCommerce-only structured field surfacing `config.siteUrl` — the key
+    // the WooCommerce backend config DTO validates (#975). Mirrors the setup
+    // wizard's https-only rule (Basic Auth credentials must not travel in
+    // cleartext); empty string stays allowed (delete-on-empty merge semantics).
+    siteUrl: z
+      .union([
+        z
+          .url('Site URL must be a valid URL (e.g. https://shop.example.com)')
+          .refine((value) => value.startsWith('https://'), 'Site URL must use HTTPS'),
+        z.literal(''),
+      ])
+      .optional(),
+    shopId: z.string().trim().optional(),
+    // Optional override for the split-host case (webservice host ≠ public storefront).
+    // Accepts a validated URL or an empty string (to unset). See #271 / #283.
+    storefrontBaseUrl: z
+      .union([
+        z
+          .url('Storefront URL must be a valid URL')
+          .refine(
+            (value) => value.startsWith('http://') || value.startsWith('https://'),
+            'Storefront URL must use http:// or https://',
+          ),
+        z.literal(''),
+      ])
+      .optional(),
+    // OL's URL from PrestaShop's perspective — used by the webhook auto-install
+    // flow (#168). FE pre-fills this from `window.location.origin` on first
+    // render when empty so most operators don't have to think about it; dev
+    // override is `http://host.docker.internal:3000`.
+    openlinkerCallbackBaseUrl: z
+      .union([
+        z
+          .url('Callback URL must be a valid URL')
+          .refine(
+            (value) => value.startsWith('http://') || value.startsWith('https://'),
+            'Callback URL must use http:// or https://',
+          ),
+        z.literal(''),
+      ])
+      .optional(),
+    masterCatalogConnectionId: z
+      .union([z.string().uuid('Product catalog must be a valid connection ID'), z.literal('')])
+      .optional(),
+    // PrestaShop-only structured field surfacing `config.defaultCarrierId`
+    // (#517). Stored as a string on the form so the same `<Select>`
+    // primitive can serve both this field and the per-method mapping
+    // dropdown (which uses string `id_reference` values). `mergeStructuredIntoConfig`
+    // coerces to an integer at submit; non-integer/zero/negative input is
+    // refused with a Zod refine.
+    defaultCarrierId: z
+      .union([
+        z.string().refine((v) => v === '' || /^[1-9]\d*$/.test(v.trim()), {
+          message: 'Default carrier ID must be a positive integer.',
         }),
-      z.literal(''),
-    ])
-    .optional(),
-  contextIdentifier: z.union([z.string().trim().max(64), z.literal('')]).optional(),
-  // InPost-only structured fields (#771). `inpostEnvironment` → flat
-  // `config.environment`, `inpostOrganizationId` → flat `config.organizationId`,
-  // `inpostSenderAddress` → whole-object `config.senderAddress`. Field names are
-  // `inpost*`-prefixed to avoid colliding with DPD's `environment` / other
-  // platforms' flat keys; the merge clauses map them to the real config keys.
-  // All optional at the FE level for incremental save; the BE DTO is the gate.
-  inpostEnvironment: z.union([z.enum(['sandbox', 'production']), z.literal('')]).optional(),
-  inpostOrganizationId: z.string().trim().optional(),
-  inpostSenderAddress: inpostSenderAddressSchema.optional(),
-});
+        z.literal(''),
+      ])
+      .optional(),
+    // WooCommerce-only structured field surfacing `config.inventory.unmanagedStockQuantity`
+    // (#969 §7.3). Quantity reported for products with stock management disabled but
+    // `stock_status=instock`. String on the form (same shape as defaultCarrierId);
+    // `mergeStructuredIntoConfig` coerces to an integer nested under `inventory` at
+    // submit. Empty clears the override so the adapter default (1000) applies.
+    unmanagedStockQuantity: z
+      .union([
+        z.string().refine((v) => v === '' || /^[1-9]\d*$/.test(v.trim()), {
+          message: 'Unmanaged stock quantity must be a positive integer.',
+        }),
+        z.literal(''),
+      ])
+      .optional(),
+    // PS-only structured field for the installed InPost PS module type (#767/#1155).
+    // Controls whether OL reads the paczkomat locker code from address2 on order
+    // ingestion. '' (empty string, select sentinel) = clear the key; 'official_inpost' = enabled.
+    inpostPsModuleType: z.union([z.literal('official_inpost'), z.literal('')]).optional(),
+    configText: z
+      .string()
+      .trim()
+      .min(2, 'Configuration JSON is required')
+      .refine((value) => {
+        try {
+          JSON.parse(value);
+          return true;
+        } catch {
+          return false;
+        }
+      }, 'Configuration must be valid JSON'),
+    adapterKey: z.string().trim().optional(),
+    // #430 — Allegro-only structured fields. Always optional at the form
+    // level; the BE DTO validates strict shape on PATCH.
+    sellerDefaults: allegroSellerDefaultsSchema.optional(),
+    // #759 — Subiekt-only structured fields.
+    // Bridge URL → flat `config.subiektBridgeUrl`. URL-or-empty (empty unsets,
+    // delete-on-empty merge). Mirrors `storefrontBaseUrl` (http/https allowed).
+    subiektBridgeUrl: z
+      .union([
+        z
+          .url('Bridge URL must be a valid URL')
+          .refine(
+            (value) => value.startsWith('http://') || value.startsWith('https://'),
+            'Bridge URL must use http:// or https://',
+          ),
+        z.literal(''),
+      ])
+      .optional(),
+    // Invoice trigger model → NESTED `config.invoicing.triggerModel` (NOT flat).
+    // Empty allowed for unset. The 4 values mirror the live BE reader
+    // `getInvoiceTriggerModel` (see `types/invoice-trigger-model.types.ts`).
+    subiektTriggerModel: z.union([z.enum(INVOICE_TRIGGER_MODEL_VALUES), z.literal('')]).optional(),
+    // Capability toggles → whole-object `config.capabilities.<key> = boolean`.
+    subiektCapabilities: z.record(z.string(), z.boolean()).optional(),
+    // KSeF-only structured fields surfacing `config.env` / `config.seller.{nip,name,address}` /
+    // `config.contextIdentifier` (#1152, #1223). `ksefEnvironment` maps to the BE C2
+    // `KsefConnectionConfig.env` enum (the one config-validator-gated field). The
+    // seller-profile fields assemble the nested `config.seller` shape the adapter's
+    // `resolveSeller` requires for issuance — this is the canonical NIP location (no
+    // flat `config.sellerNip`). All optional client-side so the operator can save
+    // incremental progress; the server is the strict gate.
+    ksefEnvironment: z.union([z.enum(['test', 'demo', 'prod']), z.literal('')]).optional(),
+    // NIP normalization mirrors the setup wizard (`ksef-setup.schema.ts`): strip
+    // dashes/spaces the operator may paste, then enforce 10 digits. Without this
+    // parity a value saved with separators on create fails the edit-schema check.
+    sellerNip: z
+      .union([
+        z
+          .string()
+          .transform(normalizeNip)
+          .refine((v) => v === '' || /^\d{10}$/.test(v), {
+            message: 'Seller NIP must be 10 digits.',
+          }),
+        z.literal(''),
+      ])
+      .optional(),
+    sellerName: z.union([z.string().trim().max(512), z.literal('')]).optional(),
+    sellerAddressLine1: z.union([z.string().trim().max(512), z.literal('')]).optional(),
+    sellerAddressLine2: z.union([z.string().trim().max(512), z.literal('')]).optional(),
+    sellerCity: z.union([z.string().trim().max(256), z.literal('')]).optional(),
+    sellerPostalCode: z.union([z.string().trim().max(32), z.literal('')]).optional(),
+    sellerCountryIso2: z
+      .union([
+        z
+          .string()
+          .trim()
+          .transform((value) => value.toUpperCase())
+          .refine((v) => v === '' || /^[A-Z]{2}$/.test(v), {
+            message: 'Country must be a 2-letter ISO code (e.g. PL).',
+          }),
+        z.literal(''),
+      ])
+      .optional(),
+    contextIdentifier: z.union([z.string().trim().max(64), z.literal('')]).optional(),
+    // InPost-only structured fields (#771). `inpostEnvironment` → flat
+    // `config.environment`, `inpostOrganizationId` → flat `config.organizationId`,
+    // `inpostSenderAddress` → whole-object `config.senderAddress`. Field names are
+    // `inpost*`-prefixed to avoid colliding with DPD's `environment` / other
+    // platforms' flat keys; the merge clauses map them to the real config keys.
+    // All optional at the FE level for incremental save; the BE DTO is the gate.
+    inpostEnvironment: z.union([z.enum(['sandbox', 'production']), z.literal('')]).optional(),
+    inpostOrganizationId: z.string().trim().optional(),
+    inpostSenderAddress: inpostSenderAddressSchema.optional(),
+  })
+  .superRefine((values, ctx) => {
+    // KSeF postal code is PL-format-gated (#1223), matching the create wizard.
+    // Empty stays allowed for incremental save. KSeF is PL-domestic, so an
+    // unset/blank country on this partial-edit form is treated as PL; an explicit
+    // non-PL country opts out of the check.
+    const postalCode = (values.sellerPostalCode ?? '').trim();
+    if (postalCode.length === 0) return;
+    const countryIso2 = (values.sellerCountryIso2 ?? '').trim().toUpperCase();
+    const isDomesticPl = countryIso2 === '' || countryIso2 === 'PL';
+    if (isDomesticPl && !/^\d{2}-\d{3}$/.test(postalCode)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['sellerPostalCode'],
+        message: 'Postal code must use the PL format NN-NNN.',
+      });
+    }
+  });
 
 export type EditConnectionFormValues = z.input<typeof editConnectionSchema>;
 export type EditConnectionFormSubmission = z.output<typeof editConnectionSchema>;
@@ -326,8 +364,20 @@ export interface StructuredConfigPatch {
   subiektCapabilities?: Record<string, boolean>;
   /** KSeF environment — `config.env` (#1152). Empty string clears the key. */
   ksefEnvironment?: string;
-  /** KSeF seller NIP — `config.sellerNip` (#1152). Empty string clears the key. */
+  /**
+   * KSeF seller-profile sub-fields (#1223). Each maps onto a leaf of the nested
+   * `config.seller.{nip,name,address}` shape the adapter's `resolveSeller`
+   * reads. Empty string clears that leaf; the merge helper drops an emptied
+   * `address` / `seller` object so a hollow profile is never persisted. NIP is
+   * normalised to digits only, matching the create path.
+   */
   sellerNip?: string;
+  sellerName?: string;
+  sellerAddressLine1?: string;
+  sellerAddressLine2?: string;
+  sellerCity?: string;
+  sellerPostalCode?: string;
+  sellerCountryIso2?: string;
   /** KSeF context identifier — `config.contextIdentifier` (#1152). Empty clears. */
   contextIdentifier?: string;
   /** InPost environment → flat `config.environment` (#771). Empty string clears the key. */
@@ -482,7 +532,7 @@ export function mergeStructuredIntoConfig(
       next.capabilities = enabled;
     }
   }
-  // KSeF structured fields — map directly onto `config.{env,sellerNip,contextIdentifier}`.
+  // KSeF structured fields — map onto `config.{env,seller,contextIdentifier}`.
   // `env` is the wire key (matching the BE `KsefConnectionConfig.env`); the form
   // field is named `ksefEnvironment` to avoid colliding with DPD's `environment`.
   if (structured.ksefEnvironment !== undefined) {
@@ -492,16 +542,13 @@ export function mergeStructuredIntoConfig(
       next.env = structured.ksefEnvironment;
     }
   }
-  if (structured.sellerNip !== undefined) {
-    // Store digits-only, matching the create path's normalized value
-    // (`ksef-setup.schema.ts` strips `[\s-]` before persisting `config.sellerNip`).
-    const normalizedNip = normalizeNip(structured.sellerNip);
-    if (normalizedNip.length === 0) {
-      delete next.sellerNip;
-    } else {
-      next.sellerNip = normalizedNip;
-    }
-  }
+  // Seller assembly + leaf normalization is shared with the create path via
+  // `applyKsefSellerToConfig` (#1223). It returns a new config; copy its seller
+  // resolution back onto `next` (set or delete) so the surrounding merge of
+  // non-seller keys is preserved.
+  const withSeller = applyKsefSellerToConfig(next, structured);
+  if ('seller' in withSeller) next.seller = withSeller.seller;
+  else delete next.seller;
   if (structured.contextIdentifier !== undefined) {
     if (structured.contextIdentifier.length === 0) {
       delete next.contextIdentifier;

--- a/apps/web/src/features/connections/components/ksef-seller-config.ts
+++ b/apps/web/src/features/connections/components/ksef-seller-config.ts
@@ -1,0 +1,168 @@
+/**
+ * KSeF Seller-Profile Assembly
+ *
+ * Single source of truth for assembling the nested `config.seller` shape the
+ * KSeF adapter's `resolveSeller` reads (`{ nip, name, address: { line1, line2?,
+ * city, postalCode, countryIso2 } }`, #1223). Both the create path
+ * (`ksef-setup.schema.ts`) and the edit path (`edit-connection.schema.ts`)
+ * consume this module so the persisted shape — and the per-leaf normalization
+ * rules (NIP digits-only, name/address trim, country uppercase) — cannot drift
+ * between the two flows.
+ *
+ * `applyKsefSellerToConfig` is the one assembly primitive: it touches only the
+ * seller leaves present on the patch (so the edit path's per-field sync preserves
+ * untouched siblings) and drops an emptied `address` / `seller` object so a
+ * hollow profile is never persisted. `buildKsefSellerConfig` is the create-path
+ * convenience wrapper that assembles a fresh profile from scratch by applying a
+ * full input onto an empty config.
+ *
+ * NIP is the canonical `config.seller.nip` location — there is no flat
+ * `config.sellerNip`.
+ *
+ * @module features/connections/components
+ */
+import { normalizeNip } from './ksef-nip';
+
+/**
+ * Flat seller-profile sub-fields collected by the wizard. Shared between the
+ * create path (`ksef-setup.schema.ts`) and the edit path
+ * (`edit-connection.schema.ts`) so both flows assemble the identical nested
+ * `config.seller` shape.
+ */
+export interface KsefSellerProfileInput {
+  sellerNip?: string;
+  sellerName?: string;
+  sellerAddressLine1?: string;
+  sellerAddressLine2?: string;
+  sellerCity?: string;
+  sellerPostalCode?: string;
+  sellerCountryIso2?: string;
+}
+
+/** Normalize a NIP to digits only (strip the dashes/spaces an operator pastes). */
+function normalizeSellerNip(value: string): string {
+  return normalizeNip(value);
+}
+
+/** Trim a free-text leaf (name, address line, city, postal code). */
+function normalizeTextLeaf(value: string): string {
+  return value.trim();
+}
+
+/** Trim + upper-case an ISO 3166-1 alpha-2 country code. */
+function normalizeCountryIso2(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+/**
+ * Whether any seller sub-field is present on the patch. Used by the edit path to
+ * skip the seller branch entirely when a non-seller field (e.g. environment) is
+ * the only thing changing.
+ */
+export function patchTouchesSeller(input: KsefSellerProfileInput): boolean {
+  return (
+    input.sellerNip !== undefined ||
+    input.sellerName !== undefined ||
+    input.sellerAddressLine1 !== undefined ||
+    input.sellerAddressLine2 !== undefined ||
+    input.sellerCity !== undefined ||
+    input.sellerPostalCode !== undefined ||
+    input.sellerCountryIso2 !== undefined
+  );
+}
+
+function setOrDeleteLeaf(
+  target: Record<string, unknown>,
+  key: string,
+  normalized: string,
+): void {
+  if (normalized.length === 0) delete target[key];
+  else target[key] = normalized;
+}
+
+/**
+ * Apply seller sub-field patches onto an existing `config` object, returning a
+ * new config. Only sub-fields present on the patch are touched; siblings are
+ * preserved. An emptied leaf is deleted, and an emptied `address` / `seller`
+ * object is dropped so a hollow profile is never persisted.
+ *
+ * The create path applies a full input onto `{}`; the edit path applies a
+ * per-field patch onto the live config — both run through the identical
+ * normalization here.
+ */
+export function applyKsefSellerToConfig(
+  base: Record<string, unknown>,
+  input: KsefSellerProfileInput,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...base };
+  if (!patchTouchesSeller(input)) return next;
+
+  const seller: Record<string, unknown> =
+    typeof next.seller === 'object' && next.seller !== null
+      ? { ...(next.seller as Record<string, unknown>) }
+      : {};
+  const address: Record<string, unknown> =
+    typeof seller.address === 'object' && seller.address !== null
+      ? { ...(seller.address as Record<string, unknown>) }
+      : {};
+
+  if (input.sellerNip !== undefined) {
+    setOrDeleteLeaf(seller, 'nip', normalizeSellerNip(input.sellerNip));
+  }
+  if (input.sellerName !== undefined) {
+    setOrDeleteLeaf(seller, 'name', normalizeTextLeaf(input.sellerName));
+  }
+  if (input.sellerAddressLine1 !== undefined) {
+    setOrDeleteLeaf(address, 'line1', normalizeTextLeaf(input.sellerAddressLine1));
+  }
+  if (input.sellerAddressLine2 !== undefined) {
+    setOrDeleteLeaf(address, 'line2', normalizeTextLeaf(input.sellerAddressLine2));
+  }
+  if (input.sellerCity !== undefined) {
+    setOrDeleteLeaf(address, 'city', normalizeTextLeaf(input.sellerCity));
+  }
+  if (input.sellerPostalCode !== undefined) {
+    setOrDeleteLeaf(address, 'postalCode', normalizeTextLeaf(input.sellerPostalCode));
+  }
+  if (input.sellerCountryIso2 !== undefined) {
+    setOrDeleteLeaf(address, 'countryIso2', normalizeCountryIso2(input.sellerCountryIso2));
+  }
+
+  if (Object.keys(address).length === 0) delete seller.address;
+  else seller.address = address;
+
+  if (isHollowSeller(seller)) delete next.seller;
+  else next.seller = seller;
+
+  return next;
+}
+
+/**
+ * A seller whose only content is an address carrying a lone `countryIso2` is
+ * hollow — it carries no real profile, just the PL country default the create
+ * wizard seeds. Treat it as empty so a `seller: { address: { countryIso2 } }`
+ * shell isn't persisted (#1223 review). Anything beyond that lone leaf (a NIP, a
+ * name, a second address field) makes the profile real.
+ */
+function isHollowSeller(seller: Record<string, unknown>): boolean {
+  const sellerKeys = Object.keys(seller);
+  if (sellerKeys.length === 0) return true;
+  if (sellerKeys.length !== 1 || sellerKeys[0] !== 'address') return false;
+  const address = seller.address as Record<string, unknown>;
+  const addressKeys = Object.keys(address);
+  return addressKeys.length === 1 && addressKeys[0] === 'countryIso2';
+}
+
+/**
+ * Assemble the nested `config.seller` object from a full seller input, returning
+ * `undefined` when no seller sub-field is supplied so an empty profile doesn't
+ * write a hollow `seller` key. Convenience wrapper over
+ * `applyKsefSellerToConfig` — the single assembly primitive both create and edit
+ * share.
+ */
+export function buildKsefSellerConfig(
+  input: KsefSellerProfileInput,
+): Record<string, unknown> | undefined {
+  const assembled = applyKsefSellerToConfig({}, input);
+  return assembled.seller as Record<string, unknown> | undefined;
+}

--- a/apps/web/src/features/connections/components/ksef-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/ksef-setup-form.test.tsx
@@ -96,13 +96,55 @@ describe('KsefSetupForm', () => {
     };
     expect(payload.platformType).toBe('ksef');
     expect(payload.adapterKey).toBe('ksef.publicapi.v2');
-    // env (the C2 config-validator-gated field) + normalised NIP land in config.
+    // env (the C2 config-validator-gated field) + normalised NIP (nested under
+    // `config.seller`, the shape `resolveSeller` reads) land in config. Country
+    // defaults to PL, so the seller carries an address with just the ISO code.
     expect(payload.config.env).toBe('prod');
-    expect(payload.config.sellerNip).toBe('1234567890');
+    expect(payload.config.seller).toEqual({
+      nip: '1234567890',
+      address: { countryIso2: 'PL' },
+    });
     // Write-only: secret travels only in credentials, never in config.
     expect(payload.credentials).toEqual({ authType: 'qualified-seal', secret: 'super-secret-token' });
     expect(JSON.stringify(payload.config)).not.toContain('super-secret-token');
 
     expect(await findToastTitle('Connection created')).toBeInTheDocument();
+  });
+
+  it('assembles the full nested seller profile (#1223) from name + address fields', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'conn-ksef', name: 'KSeF main' });
+    const apiClient = createMockApiClient({ connections: { create } });
+    renderWithProviders(<KsefSetupForm />, { apiClient });
+
+    fireEvent.change(screen.getByLabelText('Connection name'), { target: { value: 'KSeF main' } });
+    fireEvent.change(screen.getByLabelText('Seller NIP'), { target: { value: '1234567890' } });
+    fireEvent.change(screen.getByLabelText('Seller legal name'), {
+      target: { value: 'ACME Sp. z o.o.' },
+    });
+    fireEvent.change(screen.getByLabelText('Address line 1'), {
+      target: { value: 'ul. Przykładowa 1' },
+    });
+    fireEvent.change(screen.getByLabelText('City'), { target: { value: 'Warszawa' } });
+    fireEvent.change(screen.getByLabelText('Postal code'), { target: { value: '00-001' } });
+    // Country lower-cased on input is normalised to uppercase by the schema.
+    fireEvent.change(screen.getByLabelText('Country'), { target: { value: 'pl' } });
+    fireEvent.change(screen.getByLabelText('Authentication secret'), {
+      target: { value: 'tok_secret_value' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect KSeF' }));
+
+    await waitFor(() => expect(create).toHaveBeenCalled());
+    const payload = create.mock.calls[0][0] as { config: Record<string, unknown> };
+    // The nested shape `resolveSeller` reads; `line2` is omitted when blank.
+    expect(payload.config.seller).toEqual({
+      nip: '1234567890',
+      name: 'ACME Sp. z o.o.',
+      address: {
+        line1: 'ul. Przykładowa 1',
+        city: 'Warszawa',
+        postalCode: '00-001',
+        countryIso2: 'PL',
+      },
+    });
   });
 });

--- a/apps/web/src/features/connections/components/ksef-setup-form.tsx
+++ b/apps/web/src/features/connections/components/ksef-setup-form.tsx
@@ -145,7 +145,7 @@ export function KsefSetupForm(): ReactElement {
         label="Seller NIP"
         name="sellerNip"
         error={form.formState.errors.sellerNip?.message}
-        description="10-digit Polish tax identifier of the issuing seller. Optional."
+        description="10-digit Polish tax identifier of the issuing seller. Required to issue invoices."
       >
         <Input
           {...form.register('sellerNip')}
@@ -153,6 +153,90 @@ export function KsefSetupForm(): ReactElement {
           inputMode="numeric"
           autoComplete="off"
           invalid={Boolean(form.formState.errors.sellerNip)}
+        />
+      </FormField>
+
+      <FormField
+        label="Seller legal name"
+        name="sellerName"
+        error={form.formState.errors.sellerName?.message}
+        description="Registered company name (Podmiot1) printed on the invoice. Required to issue."
+      >
+        <Input
+          {...form.register('sellerName')}
+          placeholder="ACME Sp. z o.o."
+          autoComplete="off"
+          invalid={Boolean(form.formState.errors.sellerName)}
+        />
+      </FormField>
+
+      <FormField
+        label="Address line 1"
+        name="sellerAddressLine1"
+        error={form.formState.errors.sellerAddressLine1?.message}
+        description="Street and building number. Required to issue."
+      >
+        <Input
+          {...form.register('sellerAddressLine1')}
+          placeholder="ul. Przykładowa 1"
+          autoComplete="off"
+          invalid={Boolean(form.formState.errors.sellerAddressLine1)}
+        />
+      </FormField>
+
+      <FormField
+        label="Address line 2"
+        name="sellerAddressLine2"
+        error={form.formState.errors.sellerAddressLine2?.message}
+        description="Apartment, suite, or unit. Optional."
+      >
+        <Input
+          {...form.register('sellerAddressLine2')}
+          placeholder="(optional)"
+          autoComplete="off"
+          invalid={Boolean(form.formState.errors.sellerAddressLine2)}
+        />
+      </FormField>
+
+      <FormField
+        label="City"
+        name="sellerCity"
+        error={form.formState.errors.sellerCity?.message}
+        description="Required to issue."
+      >
+        <Input
+          {...form.register('sellerCity')}
+          placeholder="Warszawa"
+          autoComplete="off"
+          invalid={Boolean(form.formState.errors.sellerCity)}
+        />
+      </FormField>
+
+      <FormField
+        label="Postal code"
+        name="sellerPostalCode"
+        error={form.formState.errors.sellerPostalCode?.message}
+        description="Required to issue."
+      >
+        <Input
+          {...form.register('sellerPostalCode')}
+          placeholder="00-001"
+          autoComplete="off"
+          invalid={Boolean(form.formState.errors.sellerPostalCode)}
+        />
+      </FormField>
+
+      <FormField
+        label="Country"
+        name="sellerCountryIso2"
+        error={form.formState.errors.sellerCountryIso2?.message}
+        description="ISO 3166-1 alpha-2 code. Defaults to PL."
+      >
+        <Input
+          {...form.register('sellerCountryIso2')}
+          placeholder="PL"
+          autoComplete="off"
+          invalid={Boolean(form.formState.errors.sellerCountryIso2)}
         />
       </FormField>
 

--- a/apps/web/src/features/connections/components/ksef-setup.schema.ts
+++ b/apps/web/src/features/connections/components/ksef-setup.schema.ts
@@ -13,10 +13,17 @@
  *
  *   - `config.env` → `KsefConnectionConfig.env` (`test` | `demo` | `prod`),
  *     the one field the BE config validator currently gates.
- *   - `config.sellerNip` / `config.contextIdentifier` are FE-additive context
- *     fields the operator supplies for display + future scoping; they are not
- *     gated by the C2 config validator yet (it only requires `env`), so they
- *     stay optional client-side and the server remains the authoritative gate.
+ *   - `config.seller.{nip,name,address}` → `KsefSellerConfig` (#1223). The
+ *     adapter's `resolveSeller` (`ksef-adapter.factory.ts`) requires a
+ *     well-formed seller profile and throws `KsefConfigException` at issuance
+ *     when it's missing — so the wizard collects the full profile (NIP, legal
+ *     name, postal address) and persists the nested `config.seller` shape the
+ *     adapter reads. This is the canonical NIP location; there is no flat
+ *     `config.sellerNip`. The fields stay optional client-side (so the
+ *     operator can save incremental progress); the server is the strict gate.
+ *   - `config.contextIdentifier` is an FE-additive context field the operator
+ *     supplies for display + future scoping; not gated by the C2 config
+ *     validator yet (it only requires `env`).
  *   - `credentials.authType` → `KsefCredentials.authType`
  *     (`ksef-token` | `qualified-seal`).
  *   - `credentials.secret` carries the write-only secret the operator pastes.
@@ -29,6 +36,8 @@
 import { z } from 'zod';
 import type { CreateConnectionInput } from '../api/connections.types';
 import { normalizeNip } from './ksef-nip';
+import { buildKsefSellerConfig } from './ksef-seller-config';
+export type { KsefSellerProfileInput } from './ksef-seller-config';
 
 export const KSEF_ADAPTER_KEY = 'ksef.publicapi.v2';
 
@@ -45,24 +54,64 @@ export type KsefAuthType = (typeof KSEF_AUTH_TYPE_VALUES)[number];
 // the C2 config validator only requires `env`; the server is the strict gate.
 const NIP_DIGITS = /^\d{10}$/;
 
-export const ksefSetupSchema = z.object({
-  name: z.string().trim().min(1, 'Connection name is required'),
-  environment: z.enum(KSEF_ENVIRONMENT_VALUES),
-  sellerNip: z
-    .union([
-      z
-        .string()
-        .trim()
-        .transform(normalizeNip)
-        .pipe(z.string().regex(NIP_DIGITS, 'Seller NIP must be 10 digits')),
-      z.literal(''),
-    ])
-    .optional(),
-  contextIdentifier: z.string().trim().max(64).optional(),
-  authType: z.enum(KSEF_AUTH_TYPE_VALUES),
-  // Write-only secret (KSeF authorization token / qualified-seal reference).
-  secret: z.string().trim().min(1, 'Authentication secret is required'),
-});
+// ISO 3166-1 alpha-2 — two uppercase letters. Mirrors the adapter's
+// `address.countryIso2` field. Defaults to `PL` since KSeF is Polish-domestic.
+const COUNTRY_ISO2 = /^[A-Z]{2}$/;
+
+// Polish postal code — NN-NNN. Enforced only for PL addresses (KSeF is
+// PL-domestic); `''` stays allowed so the operator can save incremental
+// progress. Shared verbatim with the edit schema (`edit-connection.schema.ts`).
+export const POLISH_POSTAL_CODE = /^\d{2}-\d{3}$/;
+
+export const ksefSetupSchema = z
+  .object({
+    name: z.string().trim().min(1, 'Connection name is required'),
+    environment: z.enum(KSEF_ENVIRONMENT_VALUES),
+    sellerNip: z
+      .union([
+        z
+          .string()
+          .trim()
+          .transform(normalizeNip)
+          .pipe(z.string().regex(NIP_DIGITS, 'Seller NIP must be 10 digits')),
+        z.literal(''),
+      ])
+      .optional(),
+    sellerName: z.string().trim().max(512).optional(),
+    sellerAddressLine1: z.string().trim().max(512).optional(),
+    sellerAddressLine2: z.string().trim().max(512).optional(),
+    sellerCity: z.string().trim().max(256).optional(),
+    sellerPostalCode: z.string().trim().max(32).optional(),
+    sellerCountryIso2: z
+      .union([
+        z
+          .string()
+          .trim()
+          .transform((value) => value.toUpperCase())
+          .pipe(z.string().regex(COUNTRY_ISO2, 'Country must be a 2-letter ISO code (e.g. PL)')),
+        z.literal(''),
+      ])
+      .optional(),
+    contextIdentifier: z.string().trim().max(64).optional(),
+    authType: z.enum(KSEF_AUTH_TYPE_VALUES),
+    // Write-only secret (KSeF authorization token / qualified-seal reference).
+    secret: z.string().trim().min(1, 'Authentication secret is required'),
+  })
+  // Postal code is PL-format-gated (KSeF is PL-domestic). Empty stays allowed
+  // for incremental save; the rule applies only when the seller country is PL
+  // (the wizard default). The `sellerCountryIso2` transform has already
+  // upper-cased the value by the time the refine runs.
+  .superRefine((values, ctx) => {
+    const postalCode = (values.sellerPostalCode ?? '').trim();
+    const countryIso2 = (values.sellerCountryIso2 ?? '').trim().toUpperCase();
+    if (countryIso2 === 'PL' && postalCode.length > 0 && !POLISH_POSTAL_CODE.test(postalCode)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['sellerPostalCode'],
+        message: 'Postal code must use the PL format NN-NNN.',
+      });
+    }
+  });
 
 export type KsefSetupFormValues = z.input<typeof ksefSetupSchema>;
 export type KsefSetupFormSubmission = z.output<typeof ksefSetupSchema>;
@@ -71,14 +120,27 @@ export const KSEF_SETUP_DEFAULT_VALUES: KsefSetupFormValues = {
   name: '',
   environment: 'test',
   sellerNip: '',
+  sellerName: '',
+  sellerAddressLine1: '',
+  sellerAddressLine2: '',
+  sellerCity: '',
+  sellerPostalCode: '',
+  sellerCountryIso2: 'PL',
   contextIdentifier: '',
   authType: 'ksef-token',
   secret: '',
 };
 
+// `buildKsefSellerConfig` (assembly) lives in the shared `ksef-seller-config`
+// module so the create path here and the edit path
+// (`edit-connection.schema.ts`) normalize + assemble the nested `config.seller`
+// shape through one source. Re-exported for back-compat with existing imports.
+export { buildKsefSellerConfig } from './ksef-seller-config';
+
 export function toCreateConnectionInput(values: KsefSetupFormSubmission): CreateConnectionInput {
   const config: Record<string, unknown> = { env: values.environment };
-  if (values.sellerNip && values.sellerNip.length > 0) config.sellerNip = values.sellerNip;
+  const seller = buildKsefSellerConfig(values);
+  if (seller) config.seller = seller;
   if (values.contextIdentifier && values.contextIdentifier.length > 0) {
     config.contextIdentifier = values.contextIdentifier;
   }

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.test.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.test.tsx
@@ -15,7 +15,7 @@
 import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
-import { renderWithProviders, createMockApiClient, sampleConnection } from '../../../test/test-utils';
+import { renderWithProviders, createMockApiClient, sampleConnection, findToastDescription } from '../../../test/test-utils';
 import { ApiError } from '../../../shared/api/api-error';
 import type { Connection } from '../../connections';
 import type { OrderRecord } from '../../orders';
@@ -256,7 +256,7 @@ describe('OrderInvoicePanel — issue flow', () => {
       apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()), issue } }),
     });
     await user.click(await screen.findByRole('button', { name: /issue invoice/i }));
-    expect(await screen.findByText(/Invoicing is not enabled for this connection/i)).toBeInTheDocument();
+    expect(await findToastDescription(/Invoicing is not enabled for this connection/i)).toBeInTheDocument();
     expect(document.body.textContent).not.toContain('adapter subiekt-gt');
   });
 });

--- a/apps/web/src/plugins/ksef/components/ksef-structured-section.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-structured-section.tsx
@@ -5,7 +5,8 @@
  * when the connection's `platformType` is `'ksef'`. Carries:
  *
  *   - Environment (`config.env`) — the C2 config-validator-gated field
- *   - Seller NIP (`config.sellerNip`) — FE-additive context field
+ *   - Seller profile (`config.seller.{nip,name,address}`, #1223) — NIP,
+ *     legal name, and postal address the adapter's `resolveSeller` reads.
  *   - Context identifier (`config.contextIdentifier`) — FE-additive context field
  *
  * Credentials (auth type + secret) are NOT edited here — they live in the
@@ -59,7 +60,7 @@ export function KsefStructuredSection({
         label="Seller NIP"
         name="sellerNip"
         error={form.formState.errors.sellerNip?.message}
-        description="10-digit Polish tax identifier of the issuing seller. Optional."
+        description="10-digit Polish tax identifier of the issuing seller. Required to issue invoices."
       >
         <Input
           value={form.watch('sellerNip') ?? ''}
@@ -68,6 +69,96 @@ export function KsefStructuredSection({
           inputMode="numeric"
           disabled={!configIsParseable}
           invalid={Boolean(form.formState.errors.sellerNip)}
+        />
+      </FormField>
+      <FormField
+        label="Seller legal name"
+        name="sellerName"
+        error={form.formState.errors.sellerName?.message}
+        description="Registered company name (Podmiot1) printed on the invoice. Required to issue."
+      >
+        <Input
+          value={form.watch('sellerName') ?? ''}
+          onChange={(event) => syncStructuredToJson('sellerName', event.target.value)}
+          placeholder="ACME Sp. z o.o."
+          autoComplete="off"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.sellerName)}
+        />
+      </FormField>
+      <FormField
+        label="Address line 1"
+        name="sellerAddressLine1"
+        error={form.formState.errors.sellerAddressLine1?.message}
+        description="Street and building number. Required to issue."
+      >
+        <Input
+          value={form.watch('sellerAddressLine1') ?? ''}
+          onChange={(event) => syncStructuredToJson('sellerAddressLine1', event.target.value)}
+          placeholder="ul. Przykładowa 1"
+          autoComplete="off"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.sellerAddressLine1)}
+        />
+      </FormField>
+      <FormField
+        label="Address line 2"
+        name="sellerAddressLine2"
+        error={form.formState.errors.sellerAddressLine2?.message}
+        description="Apartment, suite, or unit. Optional."
+      >
+        <Input
+          value={form.watch('sellerAddressLine2') ?? ''}
+          onChange={(event) => syncStructuredToJson('sellerAddressLine2', event.target.value)}
+          placeholder="(optional)"
+          autoComplete="off"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.sellerAddressLine2)}
+        />
+      </FormField>
+      <FormField
+        label="City"
+        name="sellerCity"
+        error={form.formState.errors.sellerCity?.message}
+        description="Required to issue."
+      >
+        <Input
+          value={form.watch('sellerCity') ?? ''}
+          onChange={(event) => syncStructuredToJson('sellerCity', event.target.value)}
+          placeholder="Warszawa"
+          autoComplete="off"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.sellerCity)}
+        />
+      </FormField>
+      <FormField
+        label="Postal code"
+        name="sellerPostalCode"
+        error={form.formState.errors.sellerPostalCode?.message}
+        description="Required to issue."
+      >
+        <Input
+          value={form.watch('sellerPostalCode') ?? ''}
+          onChange={(event) => syncStructuredToJson('sellerPostalCode', event.target.value)}
+          placeholder="00-001"
+          autoComplete="off"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.sellerPostalCode)}
+        />
+      </FormField>
+      <FormField
+        label="Country"
+        name="sellerCountryIso2"
+        error={form.formState.errors.sellerCountryIso2?.message}
+        description="ISO 3166-1 alpha-2 code. Defaults to PL."
+      >
+        <Input
+          value={form.watch('sellerCountryIso2') ?? ''}
+          onChange={(event) => syncStructuredToJson('sellerCountryIso2', event.target.value)}
+          placeholder="PL"
+          autoComplete="off"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.sellerCountryIso2)}
         />
       </FormField>
       <FormField


### PR DESCRIPTION
Adds the full KSeF seller profile (legal name + postal address) to the KSeF connection wizard (#1223). The adapter's `resolveSeller` reads `config.seller.{nip,name,address}` — the wizard now collects and persists this nested shape. Also updates the edit-connection path. Stacks on #1191 (KSeF connection scaffold).

Closes #1223