### PR TITLE
feat(web): KSeF UPO preview + download + FA(3) XML visualization (#1221, #1228)

### DIFF
--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -244,7 +244,7 @@ export function createApiClient({
     customers: createCustomersApi(request),
     health: createHealthApi(request),
     inventory: createInventoryApi(request),
-    invoicing: createInvoicingApi(request),
+    invoicing: createInvoicingApi(request, requestBlob),
     listings: createListingsApi(request),
     mappings: createMappingsApi(request),
     orders: createOrdersApi(request),

--- a/apps/web/src/features/invoicing/api/invoicing.api.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.api.ts
@@ -9,6 +9,7 @@
  *   - `POST /invoices/retry` (batch retry — W6 #1245)
  *   - `POST /invoices/:invoiceId/correct` (correction — #1241)
  *   - `GET /invoices/:invoiceId/upo` (UPO blob — #1234)
+ *   - `GET /invoices/:invoiceId/document?kind=source|rendered` (FA(3) doc — W3 #1231)
  *
  * @module apps/web/src/features/invoicing/api
  */
@@ -48,6 +49,13 @@ export interface InvoicingApi {
    * on the internal `invoice.id`, never on platform type (ADR-026).
    */
   downloadUpo: (invoiceId: string) => Promise<Blob>;
+  /**
+   * `GET /invoices/:invoiceId/document?kind=source|rendered` (W3 #1231) —
+   * fetch the issued FA(3) document. `kind=source` returns the original XML;
+   * `kind=rendered` returns a human-readable HTML rendering. Returns a Blob;
+   * content type is provider-defined.
+   */
+  downloadDocument: (invoiceId: string, kind: 'source' | 'rendered') => Promise<Blob>;
 }
 
 interface ApiRequest {
@@ -115,6 +123,9 @@ export function createInvoicingApi(request: ApiRequest, requestBlob: ApiBlobRequ
     downloadUpo(invoiceId): Promise<Blob> {
       return requestBlob(`/invoices/${encodeURIComponent(invoiceId)}/upo`);
 >>>>>>> 003bfc3d (feat(web): KSeF UPO preview + download in invoice-detail slot (B3/B5, #1221))
+    },
+    downloadDocument(invoiceId, kind): Promise<Blob> {
+      return requestBlob(`/invoices/${encodeURIComponent(invoiceId)}/document?kind=${kind}`);
     },
   };
 }

--- a/apps/web/src/features/invoicing/api/invoicing.api.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.api.ts
@@ -8,6 +8,7 @@
  *   - `POST /invoices`
  *   - `POST /invoices/retry` (batch retry — W6 #1245)
  *   - `POST /invoices/:invoiceId/correct` (correction — #1241)
+ *   - `GET /invoices/:invoiceId/upo` (UPO blob — #1234)
  *
  * @module apps/web/src/features/invoicing/api
  */
@@ -39,10 +40,22 @@ export interface InvoicingApi {
   retry: (input: RetryInvoicesInput) => Promise<RetryInvoicesResult>;
   /** `POST /invoices/:invoiceId/correct` — issue a correcting document (#1241). */
   issueCorrection: (invoiceId: string, input: IssueCorrectionInput) => Promise<InvoiceRecord>;
+  /**
+   * `GET /invoices/:invoiceId/upo` (#1234) — fetch the official UPO confirmation
+   * document for a cleared/accepted e-invoice as a Blob. Content type is
+   * provider-defined (PDF / XML); the caller derives the kind from `blob.type`.
+   * Capability-gated on `RegulatoryDocumentReader` server-side. Neutral: keyed
+   * on the internal `invoice.id`, never on platform type (ADR-026).
+   */
+  downloadUpo: (invoiceId: string) => Promise<Blob>;
 }
 
 interface ApiRequest {
   <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+interface ApiBlobRequest {
+  (path: string, init?: RequestInit): Promise<Blob>;
 }
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
@@ -63,7 +76,7 @@ function buildQuery(filters?: InvoiceFilters, pagination?: InvoicePagination): s
   return qs.length > 0 ? `?${qs}` : '';
 }
 
-export function createInvoicingApi(request: ApiRequest): InvoicingApi {
+export function createInvoicingApi(request: ApiRequest, requestBlob: ApiBlobRequest): InvoicingApi {
   return {
     getForOrder(orderId, connectionId): Promise<InvoiceRecord> {
       const params = new URLSearchParams({ connectionId });
@@ -91,12 +104,17 @@ export function createInvoicingApi(request: ApiRequest): InvoicingApi {
         body: JSON.stringify(input),
       });
     },
+<<<<<<< HEAD
     issueCorrection(invoiceId, input): Promise<InvoiceRecord> {
       return request<InvoiceRecord>(`/invoices/${encodeURIComponent(invoiceId)}/correct`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(input),
       });
+=======
+    downloadUpo(invoiceId): Promise<Blob> {
+      return requestBlob(`/invoices/${encodeURIComponent(invoiceId)}/upo`);
+>>>>>>> 003bfc3d (feat(web): KSeF UPO preview + download in invoice-detail slot (B3/B5, #1221))
     },
   };
 }

--- a/apps/web/src/features/invoicing/api/invoicing.api.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.api.ts
@@ -112,17 +112,15 @@ export function createInvoicingApi(request: ApiRequest, requestBlob: ApiBlobRequ
         body: JSON.stringify(input),
       });
     },
-<<<<<<< HEAD
     issueCorrection(invoiceId, input): Promise<InvoiceRecord> {
       return request<InvoiceRecord>(`/invoices/${encodeURIComponent(invoiceId)}/correct`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(input),
       });
-=======
+    },
     downloadUpo(invoiceId): Promise<Blob> {
       return requestBlob(`/invoices/${encodeURIComponent(invoiceId)}/upo`);
->>>>>>> 003bfc3d (feat(web): KSeF UPO preview + download in invoice-detail slot (B3/B5, #1221))
     },
     downloadDocument(invoiceId, kind): Promise<Blob> {
       return requestBlob(`/invoices/${encodeURIComponent(invoiceId)}/document?kind=${kind}`);

--- a/apps/web/src/features/invoicing/hooks/use-ksef-fa3.ts
+++ b/apps/web/src/features/invoicing/hooks/use-ksef-fa3.ts
@@ -1,0 +1,112 @@
+/**
+ * useKsefFa3
+ *
+ * Provides FA(3) document access for accepted KSeF invoices (#1228, B5):
+ *   - `loadView(invoiceId)` — fetch `kind=rendered` and expose as an object URL
+ *     for inline display in a sandboxed `<iframe>` inside the `.doc-preview` area.
+ *   - `downloadXml(invoiceId)` — fetch `kind=source` and trigger a browser download.
+ *
+ * The rendered view object URL is kept in state while visible; `clearView` revokes
+ * it and resets to placeholder state. Unmount cleanup revokes any live URL.
+ *
+ * Neutral: keyed on the internal `invoice.id`, never on platform type (ADR-026).
+ * Lives in `features/invoicing/hooks/` so it can use `useApiClient` freely
+ * (dep direction: plugins/ksef → features/invoicing is explicitly allowed).
+ *
+ * @module features/invoicing/hooks
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+}
+
+function xmlFilename(invoiceId: string): string {
+  return `ol-fa3-${invoiceId}.xml`;
+}
+
+interface UseKsefFa3 {
+  /** Object URL for the rendered FA(3) HTML/blob, or `null` when not loaded. */
+  viewObjectUrl: string | null;
+  isLoadingView: boolean;
+  viewError: Error | null;
+  /** Fetch the rendered FA(3) and expose it as an object URL for inline display. */
+  loadView: (invoiceId: string) => Promise<void>;
+  /** Clear the inline preview and revoke the object URL. */
+  clearView: () => void;
+  isDownloadingXml: boolean;
+  xmlError: Error | null;
+  /** Fetch the source FA(3) XML and trigger a browser download. */
+  downloadXml: (invoiceId: string) => Promise<void>;
+}
+
+export function useKsefFa3(): UseKsefFa3 {
+  const apiClient = useApiClient();
+  const [viewObjectUrl, setViewObjectUrl] = useState<string | null>(null);
+  const [isLoadingView, setIsLoadingView] = useState(false);
+  const [viewError, setViewError] = useState<Error | null>(null);
+  const [isDownloadingXml, setIsDownloadingXml] = useState(false);
+  const [xmlError, setXmlError] = useState<Error | null>(null);
+
+  const objectUrlRef = useRef<string | null>(null);
+
+  const revoke = useCallback((): void => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+  }, []);
+
+  const clearView = useCallback((): void => {
+    revoke();
+    setViewObjectUrl(null);
+    setViewError(null);
+  }, [revoke]);
+
+  const loadView = useCallback(
+    async (invoiceId: string): Promise<void> => {
+      setIsLoadingView(true);
+      setViewError(null);
+      try {
+        const blob = await apiClient.invoicing.downloadDocument(invoiceId, 'rendered');
+        revoke();
+        const url = URL.createObjectURL(blob);
+        objectUrlRef.current = url;
+        setViewObjectUrl(url);
+      } catch (caught) {
+        setViewError(caught instanceof Error ? caught : new Error(String(caught)));
+      } finally {
+        setIsLoadingView(false);
+      }
+    },
+    [apiClient, revoke],
+  );
+
+  const downloadXml = useCallback(
+    async (invoiceId: string): Promise<void> => {
+      setIsDownloadingXml(true);
+      setXmlError(null);
+      try {
+        const blob = await apiClient.invoicing.downloadDocument(invoiceId, 'source');
+        triggerBlobDownload(blob, xmlFilename(invoiceId));
+      } catch (caught) {
+        setXmlError(caught instanceof Error ? caught : new Error(String(caught)));
+      } finally {
+        setIsDownloadingXml(false);
+      }
+    },
+    [apiClient],
+  );
+
+  useEffect(() => revoke, [revoke]);
+
+  return { viewObjectUrl, isLoadingView, viewError, loadView, clearView, isDownloadingXml, xmlError, downloadXml };
+}

--- a/apps/web/src/features/invoicing/hooks/use-ksef-fa3.ts
+++ b/apps/web/src/features/invoicing/hooks/use-ksef-fa3.ts
@@ -38,14 +38,22 @@ interface UseKsefFa3 {
   viewObjectUrl: string | null;
   isLoadingView: boolean;
   viewError: Error | null;
-  /** Fetch the rendered FA(3) and expose it as an object URL for inline display. */
-  loadView: (invoiceId: string) => Promise<void>;
+  /**
+   * Fetch the rendered FA(3) and expose it as an object URL for inline display.
+   * Returns the caught error on failure (also stored in `viewError`), or `null`
+   * on success — callers use the return value to avoid reading stale React state.
+   */
+  loadView: (invoiceId: string) => Promise<Error | null>;
   /** Clear the inline preview and revoke the object URL. */
   clearView: () => void;
   isDownloadingXml: boolean;
   xmlError: Error | null;
-  /** Fetch the source FA(3) XML and trigger a browser download. */
-  downloadXml: (invoiceId: string) => Promise<void>;
+  /**
+   * Fetch the source FA(3) XML and trigger a browser download.
+   * Returns the caught error on failure (also stored in `xmlError`), or `null`
+   * on success — callers use the return value to avoid reading stale React state.
+   */
+  downloadXml: (invoiceId: string) => Promise<Error | null>;
 }
 
 export function useKsefFa3(): UseKsefFa3 {
@@ -72,7 +80,7 @@ export function useKsefFa3(): UseKsefFa3 {
   }, [revoke]);
 
   const loadView = useCallback(
-    async (invoiceId: string): Promise<void> => {
+    async (invoiceId: string): Promise<Error | null> => {
       setIsLoadingView(true);
       setViewError(null);
       try {
@@ -81,8 +89,11 @@ export function useKsefFa3(): UseKsefFa3 {
         const url = URL.createObjectURL(blob);
         objectUrlRef.current = url;
         setViewObjectUrl(url);
+        return null;
       } catch (caught) {
-        setViewError(caught instanceof Error ? caught : new Error(String(caught)));
+        const err = caught instanceof Error ? caught : new Error(String(caught));
+        setViewError(err);
+        return err;
       } finally {
         setIsLoadingView(false);
       }
@@ -91,14 +102,17 @@ export function useKsefFa3(): UseKsefFa3 {
   );
 
   const downloadXml = useCallback(
-    async (invoiceId: string): Promise<void> => {
+    async (invoiceId: string): Promise<Error | null> => {
       setIsDownloadingXml(true);
       setXmlError(null);
       try {
         const blob = await apiClient.invoicing.downloadDocument(invoiceId, 'source');
         triggerBlobDownload(blob, xmlFilename(invoiceId));
+        return null;
       } catch (caught) {
-        setXmlError(caught instanceof Error ? caught : new Error(String(caught)));
+        const err = caught instanceof Error ? caught : new Error(String(caught));
+        setXmlError(err);
+        return err;
       } finally {
         setIsDownloadingXml(false);
       }

--- a/apps/web/src/features/invoicing/hooks/use-ksef-upo-download.ts
+++ b/apps/web/src/features/invoicing/hooks/use-ksef-upo-download.ts
@@ -1,0 +1,82 @@
+/**
+ * useKsefUpoDownload
+ *
+ * One-shot action (NOT a TanStack mutation) that fetches a cleared/accepted
+ * e-invoice's official UPO confirmation document via
+ * `apiClient.invoicing.downloadUpo(id)` and triggers a browser download
+ * (#1234). Filename extension is derived from `blob.type` (PDF / XML).
+ * Exposes local `{ download, isDownloading, error }` — there's nothing to
+ * cache, so this is deliberately not a query/mutation hook.
+ *
+ * Neutral: keyed on the internal `invoice.id`, never on platform type (ADR-026).
+ * Lives in `features/invoicing/hooks/` so it can use `useApiClient` freely;
+ * the KSeF slot imports it from the `features/invoicing` barrel (dep direction:
+ * plugins/ksef → features/invoicing is explicitly allowed).
+ *
+ * @module features/invoicing/hooks
+ */
+import { useCallback, useState } from 'react';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+const EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
+  'application/pdf': 'pdf',
+  'application/xml': 'xml',
+  'text/xml': 'xml',
+};
+
+function extensionForBlob(blob: Blob): string {
+  const mime = blob.type.toLowerCase().split(';', 1)[0]?.trim() ?? '';
+  return EXTENSION_BY_MIME[mime] ?? 'bin';
+}
+
+/**
+ * Trigger a browser download for an already-fetched blob via an in-memory
+ * object URL + a programmatic `<a download>` click. Defers `revokeObjectURL`
+ * past the current tick — some engines cancel the in-flight download if the URL
+ * is revoked synchronously after `click()`. Mirrors the shipments label-download
+ * helper's anchor lifecycle (`features/shipments/lib/label-download.ts`).
+ */
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+}
+
+interface UseKsefUpoDownload {
+  /** Fetch + trigger the browser download. Resolves `true` on success, `false`
+   *  when the fetch failed (the error is also exposed via `error`). */
+  download: (invoiceId: string) => Promise<boolean>;
+  isDownloading: boolean;
+  error: Error | null;
+}
+
+export function useKsefUpoDownload(): UseKsefUpoDownload {
+  const apiClient = useApiClient();
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const download = useCallback(
+    async (invoiceId: string): Promise<boolean> => {
+      setIsDownloading(true);
+      setError(null);
+      try {
+        const blob = await apiClient.invoicing.downloadUpo(invoiceId);
+        triggerBlobDownload(blob, `ol-upo-${invoiceId}.${extensionForBlob(blob)}`);
+        return true;
+      } catch (caught) {
+        setError(caught instanceof Error ? caught : new Error(String(caught)));
+        return false;
+      } finally {
+        setIsDownloading(false);
+      }
+    },
+    [apiClient],
+  );
+
+  return { download, isDownloading, error };
+}

--- a/apps/web/src/features/invoicing/hooks/use-ksef-upo-preview.test.tsx
+++ b/apps/web/src/features/invoicing/hooks/use-ksef-upo-preview.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * useKsefUpoPreview Tests (#1234)
+ *
+ * Covers the object-URL lifecycle + content-type allowlist logic:
+ *   - PDF blob → kind 'pdf', objectUrl created
+ *   - XML blob (application/xml + text/xml) → kind 'xml'
+ *   - Unknown MIME → kind 'unsupported', no objectUrl created
+ *   - Error path: open returns false and exposes error
+ *   - Object URL revoked on close
+ *   - Object URL revoked on unmount (no leak)
+ */
+import { act, renderHook } from '@testing-library/react';
+import type { PropsWithChildren, ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { createMockApiClient } from '../../../test/test-utils';
+import { useKsefUpoPreview } from './use-ksef-upo-preview';
+
+function createWrapper(overrides: Partial<Parameters<typeof createMockApiClient>[0]>) {
+  const client = createMockApiClient(overrides);
+  return function Wrapper({ children }: PropsWithChildren): ReactElement {
+    return <ApiClientProvider client={client}>{children}</ApiClientProvider>;
+  };
+}
+
+describe('useKsefUpoPreview', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+
+  beforeEach(() => {
+    URL.createObjectURL = vi.fn((blob: Blob) => `blob:mock-${blob.type}`);
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  // Restore originals after each test so stubs don't leak.
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it('creates an objectUrl for a PDF blob and reports kind=pdf', async () => {
+    const pdfBlob = new Blob(['%PDF'], { type: 'application/pdf' });
+    const downloadUpo = vi.fn().mockResolvedValue(pdfBlob);
+    const wrapper = createWrapper({ invoicing: { downloadUpo } });
+
+    const { result } = renderHook(() => useKsefUpoPreview(), { wrapper });
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.open('inv_1');
+    });
+
+    expect(ok).toBe(true);
+    expect(downloadUpo).toHaveBeenCalledWith('inv_1');
+    expect(URL.createObjectURL).toHaveBeenCalledWith(pdfBlob);
+    expect(result.current.preview?.kind).toBe('pdf');
+    expect(result.current.preview?.objectUrl).toMatch(/^blob:mock/);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('reports kind=xml for application/xml blobs', async () => {
+    const xmlBlob = new Blob(['<xml/>'], { type: 'application/xml' });
+    const downloadUpo = vi.fn().mockResolvedValue(xmlBlob);
+    const wrapper = createWrapper({ invoicing: { downloadUpo } });
+
+    const { result } = renderHook(() => useKsefUpoPreview(), { wrapper });
+    await act(async () => { await result.current.open('inv_2'); });
+
+    expect(result.current.preview?.kind).toBe('xml');
+  });
+
+  it('reports kind=xml for text/xml blobs', async () => {
+    const xmlBlob = new Blob(['<xml/>'], { type: 'text/xml' });
+    const downloadUpo = vi.fn().mockResolvedValue(xmlBlob);
+    const wrapper = createWrapper({ invoicing: { downloadUpo } });
+
+    const { result } = renderHook(() => useKsefUpoPreview(), { wrapper });
+    await act(async () => { await result.current.open('inv_3'); });
+
+    expect(result.current.preview?.kind).toBe('xml');
+  });
+
+  it('reports kind=unsupported and does NOT create an objectUrl for unknown MIME', async () => {
+    const binBlob = new Blob(['data'], { type: 'application/octet-stream' });
+    const downloadUpo = vi.fn().mockResolvedValue(binBlob);
+    const wrapper = createWrapper({ invoicing: { downloadUpo } });
+
+    const { result } = renderHook(() => useKsefUpoPreview(), { wrapper });
+    await act(async () => { await result.current.open('inv_4'); });
+
+    expect(result.current.preview?.kind).toBe('unsupported');
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('returns false and exposes error when the fetch fails', async () => {
+    const fetchError = new Error('network error');
+    const downloadUpo = vi.fn().mockRejectedValue(fetchError);
+    const wrapper = createWrapper({ invoicing: { downloadUpo } });
+
+    const { result } = renderHook(() => useKsefUpoPreview(), { wrapper });
+    let ok = true;
+    await act(async () => { ok = await result.current.open('inv_5'); });
+
+    expect(ok).toBe(false);
+    expect(result.current.preview).toBeNull();
+    expect(result.current.error?.message).toBe('network error');
+  });
+
+  it('revokes the objectUrl when close() is called', async () => {
+    const pdfBlob = new Blob(['%PDF'], { type: 'application/pdf' });
+    const downloadUpo = vi.fn().mockResolvedValue(pdfBlob);
+    const wrapper = createWrapper({ invoicing: { downloadUpo } });
+
+    const { result } = renderHook(() => useKsefUpoPreview(), { wrapper });
+    await act(async () => { await result.current.open('inv_6'); });
+    const createdUrl = result.current.preview?.objectUrl ?? '';
+
+    act(() => { result.current.close(); });
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(createdUrl);
+    expect(result.current.preview).toBeNull();
+  });
+
+  it('revokes the objectUrl on unmount (no leak)', async () => {
+    const pdfBlob = new Blob(['%PDF'], { type: 'application/pdf' });
+    const downloadUpo = vi.fn().mockResolvedValue(pdfBlob);
+    const wrapper = createWrapper({ invoicing: { downloadUpo } });
+
+    const { result, unmount } = renderHook(() => useKsefUpoPreview(), { wrapper });
+    await act(async () => { await result.current.open('inv_7'); });
+    const createdUrl = result.current.preview?.objectUrl ?? '';
+
+    unmount();
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(createdUrl);
+  });
+});

--- a/apps/web/src/features/invoicing/hooks/use-ksef-upo-preview.ts
+++ b/apps/web/src/features/invoicing/hooks/use-ksef-upo-preview.ts
@@ -1,0 +1,114 @@
+/**
+ * useKsefUpoPreview
+ *
+ * One-shot action (NOT a TanStack mutation) that fetches a cleared/accepted
+ * e-invoice's official UPO confirmation document via
+ * `apiClient.invoicing.downloadUpo(id)` and exposes it as an in-memory object
+ * URL for inline preview (#1234) — the readable counterpart to
+ * `useKsefUpoDownload`, which forces a browser download. The official UPO is
+ * the legible confirmation operators/accountants need; previewing it in a
+ * sandboxed `<iframe>` avoids a round-trip to the downloads folder for a quick
+ * look.
+ *
+ * Only previewable content types (PDF / XML) yield an `objectUrl`; anything
+ * else is reported via `previewKind: 'unsupported'` so the slot can fall back
+ * to the download-only action. The object URL is created on `open` and revoked
+ * on `close` / unmount — safe single-owner lifecycle, never leaked.
+ *
+ * Neutral: keyed on the internal `invoice.id`, never on platform type (ADR-026).
+ * Lives in `features/invoicing/hooks/` so it can use `useApiClient` freely;
+ * the KSeF slot imports it from the `features/invoicing` barrel (dep direction:
+ * plugins/ksef → features/invoicing is explicitly allowed).
+ *
+ * @module features/invoicing/hooks
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+/** Previewable MIME types and the neutral preview kind each maps to. */
+const PREVIEW_KIND_BY_MIME: Readonly<Record<string, 'pdf' | 'xml'>> = {
+  'application/pdf': 'pdf',
+  'application/xml': 'xml',
+  'text/xml': 'xml',
+};
+
+export type UpoPreviewKind = 'pdf' | 'xml' | 'unsupported';
+
+function previewKindForBlob(blob: Blob): UpoPreviewKind {
+  const mime = blob.type.toLowerCase().split(';', 1)[0]?.trim() ?? '';
+  return PREVIEW_KIND_BY_MIME[mime] ?? 'unsupported';
+}
+
+interface UpoPreviewState {
+  objectUrl: string;
+  kind: UpoPreviewKind;
+}
+
+interface UseKsefUpoPreview {
+  /** Fetch the UPO + open the inline preview. Resolves `true` on success,
+   *  `false` when the fetch failed (the error is also exposed via `error`). */
+  open: (invoiceId: string) => Promise<boolean>;
+  /** Revoke the object URL and clear the preview. */
+  close: () => void;
+  /** The active preview, or `null` when closed. `kind === 'unsupported'` carries
+   *  no `objectUrl` — the caller offers download instead of an inline render. */
+  preview: UpoPreviewState | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useKsefUpoPreview(): UseKsefUpoPreview {
+  const apiClient = useApiClient();
+  const [preview, setPreview] = useState<UpoPreviewState | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Track the live object URL in a ref so `close` and the unmount cleanup can
+  // revoke the latest URL without re-subscribing on every preview change.
+  const objectUrlRef = useRef<string | null>(null);
+
+  const revoke = useCallback((): void => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+  }, []);
+
+  const close = useCallback((): void => {
+    revoke();
+    setPreview(null);
+    setError(null);
+  }, [revoke]);
+
+  const open = useCallback(
+    async (invoiceId: string): Promise<boolean> => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const blob = await apiClient.invoicing.downloadUpo(invoiceId);
+        const kind = previewKindForBlob(blob);
+        // Revoke any previously-open preview before replacing it.
+        revoke();
+        if (kind === 'unsupported') {
+          setPreview({ objectUrl: '', kind });
+          return true;
+        }
+        const objectUrl = URL.createObjectURL(blob);
+        objectUrlRef.current = objectUrl;
+        setPreview({ objectUrl, kind });
+        return true;
+      } catch (caught) {
+        setError(caught instanceof Error ? caught : new Error(String(caught)));
+        return false;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [apiClient, revoke],
+  );
+
+  // Revoke on unmount so a still-open preview never leaks its object URL.
+  useEffect(() => revoke, [revoke]);
+
+  return { open, close, preview, isLoading, error };
+}

--- a/apps/web/src/features/invoicing/index.ts
+++ b/apps/web/src/features/invoicing/index.ts
@@ -25,6 +25,9 @@ export {
   useIssueCorrectionMutation,
   type IssueCorrectionVariables,
 } from './hooks/use-issue-correction-mutation';
+export { useKsefUpoPreview } from './hooks/use-ksef-upo-preview';
+export type { UpoPreviewKind } from './hooks/use-ksef-upo-preview';
+export { useKsefUpoDownload } from './hooks/use-ksef-upo-download';
 export { invoicingQueryKeys } from './api/invoicing.query-keys';
 export type {
   InvoiceRecord,

--- a/apps/web/src/features/invoicing/index.ts
+++ b/apps/web/src/features/invoicing/index.ts
@@ -28,6 +28,7 @@ export {
 export { useKsefUpoPreview } from './hooks/use-ksef-upo-preview';
 export type { UpoPreviewKind } from './hooks/use-ksef-upo-preview';
 export { useKsefUpoDownload } from './hooks/use-ksef-upo-download';
+export { useKsefFa3 } from './hooks/use-ksef-fa3';
 export { invoicingQueryKeys } from './api/invoicing.query-keys';
 export type {
   InvoiceRecord,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9976,3 +9976,58 @@ html[data-density='compact'] .status-badge {
   line-height: 1.5;
 }
 
+/* ── Invoice detail slot-rows (#1228, B5 mockup pattern) ─────────────
+ * Horizontal key+hint | value rows used inside per-provider
+ * `invoiceDetailSection` slots. Mirrors the mockup's `.slot-row` layout.
+ */
+.slot-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3, 0.75rem);
+  padding: var(--space-3, 0.75rem) 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.slot-row:last-child { border-bottom: 0; }
+.slot-row__label { font-size: 0.8125rem; }
+.slot-row__hint { font-size: 0.71875rem; color: var(--text-muted); margin-top: 2px; }
+.slot-row__actions { display: flex; gap: var(--space-2, 0.5rem); align-items: center; }
+
+/* ── FA(3) inline preview area (#1228) ──────────────────────────────
+ * Fixed-height preview container for the FA(3) rendered invoice.
+ * Shows a chip label + placeholder/frame depending on load state.
+ */
+.doc-preview {
+  margin-top: var(--space-3, 0.75rem);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface-muted);
+  min-height: 150px;
+  display: grid;
+  place-items: center;
+  color: var(--text-disabled);
+  font-size: 0.75rem;
+  position: relative;
+  overflow: hidden;
+}
+.doc-preview__chip {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.59375rem;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-caps, 0.05em);
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
+}
+.doc-preview__frame {
+  width: 100%;
+  height: 100%;
+  min-height: 150px;
+  border: none;
+}
+

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9950,3 +9950,29 @@ html[data-density='compact'] .status-badge {
   justify-content: flex-end;
 }
 
+/* ── KSeF UPO inline preview dialog (#1234) ─────────────────────────
+ * Wider dialog hosting a sandboxed <iframe> render of the official UPO
+ * confirmation (PDF / XML). The frame fills the available height so the
+ * document is legible without a download round-trip.
+ * Namespaced under .ksef-upo-* so it doesn't collide with other dialogs.
+ */
+.dialog__content--wide {
+  width: min(920px, 94vw);
+  max-height: min(92vh, 880px);
+}
+
+.ksef-upo-preview__frame {
+  width: 100%;
+  height: min(70vh, 640px);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-shell);
+}
+
+.ksef-upo-preview__unsupported {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.test.tsx
@@ -1,16 +1,18 @@
 /**
- * KsefInvoiceDetailSection Tests (#1152, B4)
+ * KsefInvoiceDetailSection Tests (#1152, B4 + #1234, B3/B5)
  *
- * Covers the read-only KSeF regulatory region rendered into the neutral
- * invoice surfaces via the `invoiceDetailSection` slot:
+ * Covers the KSeF regulatory region rendered into the neutral invoice surfaces
+ * via the `invoiceDetailSection` slot:
  *   - renders the clearance badge + KSeF number when regulatory data exists
  *   - returns null when there is no KSeF data (not-applicable + no number)
  *   - prefers `clearanceReference` (the KSeF number) over `providerInvoiceNumber`
+ *   - UPO actions: shown only when `regulatoryStatus === 'accepted'`; hidden
+ *     for other statuses (submitted, cleared, rejected)
+ *   - Preview UPO: calls `invoicing.downloadUpo` on click and opens the dialog
  */
-import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
-import { LocaleProvider } from '../../../shared/i18n';
-import { sampleConnection } from '../../../test/test-utils';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
 import type { InvoiceRecord } from '../../../features/invoicing';
 import { KsefInvoiceDetailSection } from './ksef-invoice-detail-section';
 
@@ -37,19 +39,21 @@ function makeInvoice(over: Partial<InvoiceRecord> = {}): InvoiceRecord {
   };
 }
 
-function renderSection(invoice: InvoiceRecord): ReturnType<typeof render> {
-  return render(
-    <LocaleProvider>
-      <KsefInvoiceDetailSection invoice={invoice} connection={sampleConnection} />
-    </LocaleProvider>,
-  );
-}
+// jsdom lacks createObjectURL/revokeObjectURL; capture originals for restore.
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
 
 describe('KsefInvoiceDetailSection', () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
 
   it('renders the clearance badge and KSeF number when regulatory data exists', () => {
-    renderSection(makeInvoice());
+    renderWithProviders(
+      <KsefInvoiceDetailSection invoice={makeInvoice()} connection={sampleConnection} />,
+    );
     expect(screen.getByText('KSeF number')).toBeInTheDocument();
     expect(screen.getByText('1234567890-20260625-ABCDEF123456-7F')).toBeInTheDocument();
     // Neutral RegulatoryStatusBadge renders the accepted label.
@@ -57,35 +61,124 @@ describe('KsefInvoiceDetailSection', () => {
   });
 
   it('returns null when there is no KSeF data', () => {
-    const { container } = renderSection(
-      makeInvoice({
-        regulatoryStatus: 'not-applicable',
-        clearanceReference: null,
-        providerInvoiceNumber: null,
-      }),
+    renderWithProviders(
+      <KsefInvoiceDetailSection
+        invoice={makeInvoice({
+          regulatoryStatus: 'not-applicable',
+          clearanceReference: null,
+          providerInvoiceNumber: null,
+        })}
+        connection={sampleConnection}
+      />,
     );
-    expect(container).toBeEmptyDOMElement();
+    // Nothing KSeF-specific rendered — neither the section title nor any key.
+    expect(screen.queryByText('KSeF · National e-Invoicing System')).not.toBeInTheDocument();
+    expect(screen.queryByText('Clearance status')).not.toBeInTheDocument();
   });
 
   it('prefers clearanceReference over providerInvoiceNumber for the KSeF number', () => {
-    renderSection(
-      makeInvoice({
-        clearanceReference: 'KSEF-CLEARANCE-REF',
-        providerInvoiceNumber: 'FALLBACK-NUM',
-      }),
+    renderWithProviders(
+      <KsefInvoiceDetailSection
+        invoice={makeInvoice({
+          clearanceReference: 'KSEF-CLEARANCE-REF',
+          providerInvoiceNumber: 'FALLBACK-NUM',
+        })}
+        connection={sampleConnection}
+      />,
     );
     expect(screen.getByText('KSEF-CLEARANCE-REF')).toBeInTheDocument();
     expect(screen.queryByText('FALLBACK-NUM')).not.toBeInTheDocument();
   });
 
   it('falls back to providerInvoiceNumber when clearanceReference is null', () => {
-    renderSection(
-      makeInvoice({
-        regulatoryStatus: 'submitted',
-        clearanceReference: null,
-        providerInvoiceNumber: 'FV/2026/06/0142',
-      }),
+    renderWithProviders(
+      <KsefInvoiceDetailSection
+        invoice={makeInvoice({
+          regulatoryStatus: 'submitted',
+          clearanceReference: null,
+          providerInvoiceNumber: 'FV/2026/06/0142',
+        })}
+        connection={sampleConnection}
+      />,
     );
     expect(screen.getByText('FV/2026/06/0142')).toBeInTheDocument();
+  });
+
+  describe('UPO actions', () => {
+    it('shows Preview UPO + Download UPO only when status is accepted', () => {
+      renderWithProviders(
+        <KsefInvoiceDetailSection
+          invoice={makeInvoice({ regulatoryStatus: 'accepted' })}
+          connection={sampleConnection}
+        />,
+      );
+      expect(screen.getByRole('button', { name: 'Preview UPO' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Download UPO' })).toBeInTheDocument();
+    });
+
+    it('hides UPO actions when status is submitted (UPO not yet available)', () => {
+      renderWithProviders(
+        <KsefInvoiceDetailSection
+          invoice={makeInvoice({ regulatoryStatus: 'submitted' })}
+          connection={sampleConnection}
+        />,
+      );
+      expect(screen.queryByRole('button', { name: 'Preview UPO' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Download UPO' })).not.toBeInTheDocument();
+    });
+
+    it('hides UPO actions when status is cleared', () => {
+      renderWithProviders(
+        <KsefInvoiceDetailSection
+          invoice={makeInvoice({ regulatoryStatus: 'cleared' })}
+          connection={sampleConnection}
+        />,
+      );
+      expect(screen.queryByRole('button', { name: 'Preview UPO' })).not.toBeInTheDocument();
+    });
+
+    it('calls invoicing.downloadUpo when Preview UPO is clicked and opens the dialog', async () => {
+      URL.createObjectURL = vi.fn(() => 'blob:mock');
+      URL.revokeObjectURL = vi.fn();
+      const downloadUpo = vi.fn().mockResolvedValue(new Blob(['%PDF'], { type: 'application/pdf' }));
+      const apiClient = createMockApiClient({ invoicing: { downloadUpo } });
+
+      renderWithProviders(
+        <KsefInvoiceDetailSection
+          invoice={makeInvoice({ regulatoryStatus: 'accepted' })}
+          connection={sampleConnection}
+        />,
+        { apiClient },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Preview UPO' }));
+      await waitFor(() => {
+        expect(downloadUpo).toHaveBeenCalledWith('inv_1');
+      });
+      // The dialog opens after a successful fetch.
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+    });
+
+    it('calls invoicing.downloadUpo when Download UPO is clicked', async () => {
+      URL.createObjectURL = vi.fn(() => 'blob:mock');
+      URL.revokeObjectURL = vi.fn();
+      const downloadUpo = vi.fn().mockResolvedValue(new Blob(['%PDF'], { type: 'application/pdf' }));
+      const apiClient = createMockApiClient({ invoicing: { downloadUpo } });
+
+      renderWithProviders(
+        <KsefInvoiceDetailSection
+          invoice={makeInvoice({ regulatoryStatus: 'accepted' })}
+          connection={sampleConnection}
+        />,
+        { apiClient },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Download UPO' }));
+      await waitFor(() => {
+        expect(downloadUpo).toHaveBeenCalledWith('inv_1');
+      });
+    });
   });
 });

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.test.tsx
@@ -1,14 +1,17 @@
 /**
- * KsefInvoiceDetailSection Tests (#1152, B4 + #1234, B3/B5)
+ * KsefInvoiceDetailSection Tests (#1152, B4 + #1234, B3 + #1228, B5)
  *
  * Covers the KSeF regulatory region rendered into the neutral invoice surfaces
  * via the `invoiceDetailSection` slot:
  *   - renders the clearance badge + KSeF number when regulatory data exists
  *   - returns null when there is no KSeF data (not-applicable + no number)
  *   - prefers `clearanceReference` (the KSeF number) over `providerInvoiceNumber`
- *   - UPO actions: shown only when `regulatoryStatus === 'accepted'`; hidden
- *     for other statuses (submitted, cleared, rejected)
- *   - Preview UPO: calls `invoicing.downloadUpo` on click and opens the dialog
+ *   - UPO actions: shown only when `regulatoryStatus === 'accepted'`
+ *   - FA(3) actions (View + Download XML): shown only when `regulatoryStatus === 'accepted'`
+ *   - Preview UPO: calls `invoicing.downloadUpo` + opens dialog
+ *   - View FA(3): calls `invoicing.downloadDocument(id, 'rendered')` + shows inline frame
+ *   - Download XML: calls `invoicing.downloadDocument(id, 'source')`
+ *   - Slot is registered on the KSeF plugin descriptor
  */
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -39,7 +42,6 @@ function makeInvoice(over: Partial<InvoiceRecord> = {}): InvoiceRecord {
   };
 }
 
-// jsdom lacks createObjectURL/revokeObjectURL; capture originals for restore.
 const originalCreateObjectURL = URL.createObjectURL;
 const originalRevokeObjectURL = URL.revokeObjectURL;
 
@@ -56,7 +58,6 @@ describe('KsefInvoiceDetailSection', () => {
     );
     expect(screen.getByText('KSeF number')).toBeInTheDocument();
     expect(screen.getByText('1234567890-20260625-ABCDEF123456-7F')).toBeInTheDocument();
-    // Neutral RegulatoryStatusBadge renders the accepted label.
     expect(screen.getByText('KSeF: accepted')).toBeInTheDocument();
   });
 
@@ -71,12 +72,11 @@ describe('KsefInvoiceDetailSection', () => {
         connection={sampleConnection}
       />,
     );
-    // Nothing KSeF-specific rendered — neither the section title nor any key.
     expect(screen.queryByText('KSeF · National e-Invoicing System')).not.toBeInTheDocument();
     expect(screen.queryByText('Clearance status')).not.toBeInTheDocument();
   });
 
-  it('prefers clearanceReference over providerInvoiceNumber for the KSeF number', () => {
+  it('prefers clearanceReference over providerInvoiceNumber', () => {
     renderWithProviders(
       <KsefInvoiceDetailSection
         invoice={makeInvoice({
@@ -104,41 +104,31 @@ describe('KsefInvoiceDetailSection', () => {
     expect(screen.getByText('FV/2026/06/0142')).toBeInTheDocument();
   });
 
-  describe('UPO actions', () => {
-    it('shows Preview UPO + Download UPO only when status is accepted', () => {
+  describe('UPO actions (B3)', () => {
+    it('shows Preview + Download UPO only when status is accepted', () => {
       renderWithProviders(
         <KsefInvoiceDetailSection
           invoice={makeInvoice({ regulatoryStatus: 'accepted' })}
           connection={sampleConnection}
         />,
       );
-      expect(screen.getByRole('button', { name: 'Preview UPO' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Download UPO' })).toBeInTheDocument();
     });
 
-    it('hides UPO actions when status is submitted (UPO not yet available)', () => {
+    it('hides UPO actions when status is submitted', () => {
       renderWithProviders(
         <KsefInvoiceDetailSection
           invoice={makeInvoice({ regulatoryStatus: 'submitted' })}
           connection={sampleConnection}
         />,
       );
-      expect(screen.queryByRole('button', { name: 'Preview UPO' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Preview' })).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Download UPO' })).not.toBeInTheDocument();
     });
 
-    it('hides UPO actions when status is cleared', () => {
-      renderWithProviders(
-        <KsefInvoiceDetailSection
-          invoice={makeInvoice({ regulatoryStatus: 'cleared' })}
-          connection={sampleConnection}
-        />,
-      );
-      expect(screen.queryByRole('button', { name: 'Preview UPO' })).not.toBeInTheDocument();
-    });
-
-    it('calls invoicing.downloadUpo when Preview UPO is clicked and opens the dialog', async () => {
-      URL.createObjectURL = vi.fn(() => 'blob:mock');
+    it('calls downloadUpo when Preview is clicked and opens the UPO dialog', async () => {
+      URL.createObjectURL = vi.fn(() => 'blob:mock-upo');
       URL.revokeObjectURL = vi.fn();
       const downloadUpo = vi.fn().mockResolvedValue(new Blob(['%PDF'], { type: 'application/pdf' }));
       const apiClient = createMockApiClient({ invoicing: { downloadUpo } });
@@ -151,17 +141,12 @@ describe('KsefInvoiceDetailSection', () => {
         { apiClient },
       );
 
-      fireEvent.click(screen.getByRole('button', { name: 'Preview UPO' }));
-      await waitFor(() => {
-        expect(downloadUpo).toHaveBeenCalledWith('inv_1');
-      });
-      // The dialog opens after a successful fetch.
-      await waitFor(() => {
-        expect(screen.getByRole('dialog')).toBeInTheDocument();
-      });
+      fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+      await waitFor(() => expect(downloadUpo).toHaveBeenCalledWith('inv_1'));
+      await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
     });
 
-    it('calls invoicing.downloadUpo when Download UPO is clicked', async () => {
+    it('calls downloadUpo when Download UPO is clicked', async () => {
       URL.createObjectURL = vi.fn(() => 'blob:mock');
       URL.revokeObjectURL = vi.fn();
       const downloadUpo = vi.fn().mockResolvedValue(new Blob(['%PDF'], { type: 'application/pdf' }));
@@ -176,9 +161,81 @@ describe('KsefInvoiceDetailSection', () => {
       );
 
       fireEvent.click(screen.getByRole('button', { name: 'Download UPO' }));
-      await waitFor(() => {
-        expect(downloadUpo).toHaveBeenCalledWith('inv_1');
-      });
+      await waitFor(() => expect(downloadUpo).toHaveBeenCalledWith('inv_1'));
+    });
+  });
+
+  describe('FA(3) actions (B5)', () => {
+    it('shows FA(3) document row and doc-preview placeholder when status is accepted', () => {
+      renderWithProviders(
+        <KsefInvoiceDetailSection
+          invoice={makeInvoice({ regulatoryStatus: 'accepted' })}
+          connection={sampleConnection}
+        />,
+      );
+      expect(screen.getByText('FA(3) document')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Download XML' })).toBeInTheDocument();
+      expect(screen.getByText("Click 'View' to load the invoice.")).toBeInTheDocument();
+    });
+
+    it('hides FA(3) actions when status is submitted', () => {
+      renderWithProviders(
+        <KsefInvoiceDetailSection
+          invoice={makeInvoice({ regulatoryStatus: 'submitted' })}
+          connection={sampleConnection}
+        />,
+      );
+      expect(screen.queryByText('FA(3) document')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'View' })).not.toBeInTheDocument();
+    });
+
+    it('loads the FA(3) rendered document into the doc-preview frame on View click', async () => {
+      URL.createObjectURL = vi.fn(() => 'blob:fa3-rendered');
+      URL.revokeObjectURL = vi.fn();
+      const downloadDocument = vi
+        .fn()
+        .mockResolvedValue(new Blob(['<html>FA3</html>'], { type: 'text/html' }));
+      const apiClient = createMockApiClient({ invoicing: { downloadDocument } });
+
+      renderWithProviders(
+        <KsefInvoiceDetailSection
+          invoice={makeInvoice({ regulatoryStatus: 'accepted' })}
+          connection={sampleConnection}
+        />,
+        { apiClient },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'View' }));
+      await waitFor(() =>
+        expect(downloadDocument).toHaveBeenCalledWith('inv_1', 'rendered'),
+      );
+      const frame = await screen.findByTitle('FA(3) document preview');
+      expect(frame).toHaveAttribute('src', 'blob:fa3-rendered');
+      // sandbox attribute prevents script execution in the framed document.
+      expect(frame).toHaveAttribute('sandbox', '');
+    });
+
+    it('calls downloadDocument with kind=source when Download XML is clicked', async () => {
+      URL.createObjectURL = vi.fn(() => 'blob:xml');
+      URL.revokeObjectURL = vi.fn();
+      const downloadDocument = vi
+        .fn()
+        .mockResolvedValue(new Blob(['<?xml'], { type: 'application/xml' }));
+      const apiClient = createMockApiClient({ invoicing: { downloadDocument } });
+
+      renderWithProviders(
+        <KsefInvoiceDetailSection
+          invoice={makeInvoice({ regulatoryStatus: 'accepted' })}
+          connection={sampleConnection}
+        />,
+        { apiClient },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Download XML' }));
+      await waitFor(() =>
+        expect(downloadDocument).toHaveBeenCalledWith('inv_1', 'source'),
+      );
     });
   });
 });

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
@@ -96,26 +96,28 @@ export function KsefInvoiceDetailSection({
   }
 
   async function handleViewFa3(): Promise<void> {
-    await fa3.loadView(invoice.id);
-    if (fa3.viewError) {
+    // Use the returned error rather than reading fa3.viewError from the closure —
+    // that would be stale (React state hasn't re-rendered yet after the await).
+    const err = await fa3.loadView(invoice.id);
+    if (err) {
       showToast({
         tone: 'error',
         title: t('invoice.ksef.fa3ViewFailed', 'FA(3) preview failed'),
         description:
-          fa3.viewError.message ??
-          t('invoice.ksef.fa3ViewFailedDesc', 'Could not fetch the document.'),
+          err.message ?? t('invoice.ksef.fa3ViewFailedDesc', 'Could not fetch the document.'),
       });
     }
   }
 
   async function handleDownloadXml(): Promise<void> {
-    await fa3.downloadXml(invoice.id);
-    if (fa3.xmlError) {
+    // Same pattern: use the returned error, not the stale fa3.xmlError from closure.
+    const err = await fa3.downloadXml(invoice.id);
+    if (err) {
       showToast({
         tone: 'error',
         title: t('invoice.ksef.fa3XmlFailed', 'FA(3) XML download failed'),
         description:
-          fa3.xmlError.message ?? t('invoice.ksef.fa3XmlFailedDesc', 'Could not fetch the source document.'),
+          err.message ?? t('invoice.ksef.fa3XmlFailedDesc', 'Could not fetch the source document.'),
       });
     }
   }
@@ -282,7 +284,11 @@ export function KsefInvoiceDetailSection({
                 className="ksef-upo-preview__frame"
                 src={upoPreviewState.objectUrl}
                 title={t('invoice.ksef.upoFrameTitle', 'UPO confirmation preview')}
-                sandbox=""
+                // `allow-same-origin` is required for the browser's built-in PDF renderer
+                // (Chrome/Firefox) to display a blob: URL for PDF content. Without it
+                // sandbox="" blocks the PDF plugin and the frame renders blank.
+                // Scripts are still blocked — only `allow-same-origin` is granted.
+                sandbox={upoPreviewState.kind === 'pdf' ? 'allow-same-origin' : ''}
               />
             )}
             <DialogFooter>

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
@@ -1,7 +1,7 @@
 /**
  * KSeF Invoice Detail Section
  *
- * Per-provider `invoiceDetailSection` slot for KSeF connections (#1152, B4).
+ * Per-provider `invoiceDetailSection` slot for KSeF connections (#1152, B4 + B3/B5).
  * Rendered by the neutral `OrderInvoicePanel` and `InvoiceDetailPage` via
  * `usePlatform(connection.platformType).invoiceDetailSection` — ZERO
  * `platformType` literals here.
@@ -11,14 +11,29 @@
  *   - The authority-assigned KSeF number (`clearanceReference`), falling back
  *     to the provider invoice number (`providerInvoiceNumber`) when the
  *     clearance reference is not yet populated.
+ *   - UPO preview (sandboxed iframe) + download actions (#1234, B3/B5), gated
+ *     on `regulatoryStatus === 'accepted'` (the UPO exists only once the
+ *     authority has accepted the invoice).
  *
- * UPO download and FA(3) visualization are deferred to #1234 (B3/B5).
+ * FA(3) visualization: deferred — the UPO document itself (PDF or XML) is the
+ * KSeF-issued confirmation; a human-readable FA(3) rendering is tracked as a
+ * follow-up (#1228).
  *
  * @module plugins/ksef/components
  */
 import type { ReactElement } from 'react';
 import type { InvoiceDetailSectionProps } from '../../../shared/plugins';
-import { RegulatoryStatusBadge } from '../../../features/invoicing';
+import { RegulatoryStatusBadge, useKsefUpoDownload, useKsefUpoPreview } from '../../../features/invoicing';
+import { Button } from '../../../shared/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '../../../shared/ui/dialog';
+import { useToast } from '../../../shared/ui/toast-provider';
 import { useTranslation } from '../../../shared/i18n';
 
 /**
@@ -37,6 +52,9 @@ export function KsefInvoiceDetailSection({
   invoice,
 }: InvoiceDetailSectionProps): ReactElement | null {
   const { t } = useTranslation();
+  const upoDownload = useKsefUpoDownload();
+  const upoPreview = useKsefUpoPreview();
+  const { showToast } = useToast();
 
   const ksefNumber = resolveKsefNumber(invoice.clearanceReference, invoice.providerInvoiceNumber);
   const hasRegulatoryData = invoice.regulatoryStatus !== 'not-applicable';
@@ -46,27 +64,143 @@ export function KsefInvoiceDetailSection({
     return null;
   }
 
+  // UPO actions are available only once the authority has accepted the invoice —
+  // that's the terminal success state where the UPO document actually exists.
+  // Gate uses the neutral status field; no platform-type comparison.
+  const canUseUpo = invoice.regulatoryStatus === 'accepted';
+
+  async function handlePreviewUpo(): Promise<void> {
+    const ok = await upoPreview.open(invoice.id);
+    if (!ok) {
+      showToast({
+        tone: 'error',
+        title: t('invoice.ksef.upoPreviewFailed', 'UPO preview failed'),
+        description:
+          upoPreview.error?.message ??
+          t('invoice.ksef.upoPreviewFailedDesc', 'Could not fetch the confirmation document.'),
+      });
+    }
+  }
+
+  async function handleDownloadUpo(): Promise<void> {
+    const ok = await upoDownload.download(invoice.id);
+    if (!ok) {
+      showToast({
+        tone: 'error',
+        title: t('invoice.ksef.upoDownloadFailed', 'UPO download failed'),
+        description:
+          upoDownload.error?.message ??
+          t('invoice.ksef.upoDownloadFailedDesc', 'Could not fetch the confirmation document.'),
+      });
+    }
+  }
+
+  const preview = upoPreview.preview;
+
   return (
-    <section className="invoice-detail-section invoice-detail-section--ksef">
-      <h4 className="invoice-detail-section__title">
-        {t('invoice.ksef.sectionTitle', 'KSeF · National e-Invoicing System')}
-      </h4>
-      <dl className="invoice-detail-section__kv">
-        {hasRegulatoryData ? (
-          <>
-            <dt>{t('invoice.ksef.clearanceStatus', 'Clearance status')}</dt>
-            <dd>
-              <RegulatoryStatusBadge status={invoice.regulatoryStatus} />
-            </dd>
-          </>
+    <>
+      <section className="invoice-detail-section invoice-detail-section--ksef">
+        <h4 className="invoice-detail-section__title">
+          {t('invoice.ksef.sectionTitle', 'KSeF · National e-Invoicing System')}
+        </h4>
+        <dl className="invoice-detail-section__kv">
+          {hasRegulatoryData ? (
+            <>
+              <dt>{t('invoice.ksef.clearanceStatus', 'Clearance status')}</dt>
+              <dd>
+                <RegulatoryStatusBadge status={invoice.regulatoryStatus} />
+              </dd>
+            </>
+          ) : null}
+          {ksefNumber ? (
+            <>
+              <dt>{t('invoice.ksef.number', 'KSeF number')}</dt>
+              <dd className="mono-text">{ksefNumber}</dd>
+            </>
+          ) : null}
+        </dl>
+        {canUseUpo ? (
+          <div className="form-actions">
+            <Button
+              tone="secondary"
+              className="button--sm"
+              onClick={() => void handlePreviewUpo()}
+              disabled={upoPreview.isLoading}
+            >
+              {upoPreview.isLoading
+                ? t('invoice.ksef.upoPreviewLoading', 'Loading…')
+                : t('invoice.ksef.upoPreview', 'Preview UPO')}
+            </Button>
+            <Button
+              tone="secondary"
+              className="button--sm"
+              onClick={() => void handleDownloadUpo()}
+              disabled={upoDownload.isDownloading}
+            >
+              {upoDownload.isDownloading
+                ? t('invoice.ksef.upoDownloading', 'Downloading…')
+                : t('invoice.ksef.upoDownload', 'Download UPO')}
+            </Button>
+          </div>
         ) : null}
-        {ksefNumber ? (
-          <>
-            <dt>{t('invoice.ksef.number', 'KSeF number')}</dt>
-            <dd className="mono-text">{ksefNumber}</dd>
-          </>
+      </section>
+
+      <Dialog
+        open={preview !== null}
+        onOpenChange={(next) => {
+          if (!next) upoPreview.close();
+        }}
+      >
+        {preview !== null ? (
+          <DialogContent className="dialog__content--wide" aria-describedby="ksef-upo-preview-desc">
+            <DialogTitle>{t('invoice.ksef.upoDialogTitle', 'UPO confirmation')}</DialogTitle>
+            <DialogDescription id="ksef-upo-preview-desc">
+              {t(
+                'invoice.ksef.upoDialogDesc',
+                'Official confirmation (UPO) for this KSeF invoice.',
+              )}
+            </DialogDescription>
+            {preview.kind === 'unsupported' ? (
+              <p className="ksef-upo-preview__unsupported">
+                {t(
+                  'invoice.ksef.upoPreviewUnsupported',
+                  'This confirmation can’t be previewed inline. Use “Download UPO” to open it.',
+                )}
+              </p>
+            ) : (
+              <iframe
+                className="ksef-upo-preview__frame"
+                src={preview.objectUrl}
+                title={t('invoice.ksef.upoFrameTitle', 'UPO confirmation preview')}
+                // A `blob:` URL inherits the creating document's origin, so framed
+                // content would otherwise run with full app-origin privileges.
+                // An empty `sandbox` blocks scripts while still rendering the
+                // document (browsers display blob: PDFs/XML fine under it).
+                sandbox=""
+              />
+            )}
+            <DialogFooter>
+              {preview.kind === 'unsupported' ? (
+                <Button
+                  tone="secondary"
+                  className="button--sm"
+                  onClick={() => void handleDownloadUpo()}
+                  disabled={upoDownload.isDownloading}
+                >
+                  {upoDownload.isDownloading
+                    ? t('invoice.ksef.upoDownloading', 'Downloading…')
+                    : t('invoice.ksef.upoDownload', 'Download UPO')}
+                </Button>
+              ) : null}
+              <DialogClose asChild>
+                <Button tone="secondary" className="button--sm">
+                  {t('common.close', 'Close')}
+                </Button>
+              </DialogClose>
+            </DialogFooter>
+          </DialogContent>
         ) : null}
-      </dl>
-    </section>
+      </Dialog>
+    </>
   );
 }

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
@@ -1,29 +1,30 @@
 /**
  * KSeF Invoice Detail Section
  *
- * Per-provider `invoiceDetailSection` slot for KSeF connections (#1152, B4 + B3/B5).
+ * Per-provider `invoiceDetailSection` slot for KSeF connections (#1152, B4 + B3 + B5).
  * Rendered by the neutral `OrderInvoicePanel` and `InvoiceDetailPage` via
  * `usePlatform(connection.platformType).invoiceDetailSection` — ZERO
  * `platformType` literals here.
  *
- * Displays the KSeF-specific regulatory region:
- *   - KSeF clearance status via the neutral `RegulatoryStatusBadge`
- *   - The authority-assigned KSeF number (`clearanceReference`), falling back
- *     to the provider invoice number (`providerInvoiceNumber`) when the
- *     clearance reference is not yet populated.
- *   - UPO preview (sandboxed iframe) + download actions (#1234, B3/B5), gated
- *     on `regulatoryStatus === 'accepted'` (the UPO exists only once the
- *     authority has accepted the invoice).
- *
- * FA(3) visualization: deferred — the UPO document itself (PDF or XML) is the
- * KSeF-issued confirmation; a human-readable FA(3) rendering is tracked as a
- * follow-up (#1228).
+ * Displays the KSeF-specific regulatory region using the mockup's `.slot-row` layout:
+ *   - Clearance status badge (via neutral `RegulatoryStatusBadge`)
+ *   - KSeF number (`clearanceReference` → fallback `providerInvoiceNumber`)
+ *   - Official receipt (UPO): download + inline preview (#1234, B3), gated on
+ *     `regulatoryStatus === 'accepted'`
+ *   - FA(3) document: view rendered HTML inline + download source XML (#1228, B5),
+ *     gated on `regulatoryStatus === 'accepted'`
+ *   - Inline `.doc-preview` area for the FA(3) rendered document
  *
  * @module plugins/ksef/components
  */
 import type { ReactElement } from 'react';
 import type { InvoiceDetailSectionProps } from '../../../shared/plugins';
-import { RegulatoryStatusBadge, useKsefUpoDownload, useKsefUpoPreview } from '../../../features/invoicing';
+import {
+  RegulatoryStatusBadge,
+  useKsefUpoDownload,
+  useKsefUpoPreview,
+  useKsefFa3,
+} from '../../../features/invoicing';
 import { Button } from '../../../shared/ui/button';
 import {
   Dialog,
@@ -54,19 +55,18 @@ export function KsefInvoiceDetailSection({
   const { t } = useTranslation();
   const upoDownload = useKsefUpoDownload();
   const upoPreview = useKsefUpoPreview();
+  const fa3 = useKsefFa3();
   const { showToast } = useToast();
 
   const ksefNumber = resolveKsefNumber(invoice.clearanceReference, invoice.providerInvoiceNumber);
   const hasRegulatoryData = invoice.regulatoryStatus !== 'not-applicable';
 
-  // Nothing to show when there's no KSeF clearance data yet.
   if (!hasRegulatoryData && !ksefNumber) {
     return null;
   }
 
-  // UPO actions are available only once the authority has accepted the invoice —
-  // that's the terminal success state where the UPO document actually exists.
-  // Gate uses the neutral status field; no platform-type comparison.
+  // UPO and FA(3) are available only once the authority has accepted the invoice —
+  // that's the terminal success state where the UPO document and issued FA(3) exist.
   const canUseUpo = invoice.regulatoryStatus === 'accepted';
 
   async function handlePreviewUpo(): Promise<void> {
@@ -95,7 +95,32 @@ export function KsefInvoiceDetailSection({
     }
   }
 
-  const preview = upoPreview.preview;
+  async function handleViewFa3(): Promise<void> {
+    await fa3.loadView(invoice.id);
+    if (fa3.viewError) {
+      showToast({
+        tone: 'error',
+        title: t('invoice.ksef.fa3ViewFailed', 'FA(3) preview failed'),
+        description:
+          fa3.viewError.message ??
+          t('invoice.ksef.fa3ViewFailedDesc', 'Could not fetch the document.'),
+      });
+    }
+  }
+
+  async function handleDownloadXml(): Promise<void> {
+    await fa3.downloadXml(invoice.id);
+    if (fa3.xmlError) {
+      showToast({
+        tone: 'error',
+        title: t('invoice.ksef.fa3XmlFailed', 'FA(3) XML download failed'),
+        description:
+          fa3.xmlError.message ?? t('invoice.ksef.fa3XmlFailedDesc', 'Could not fetch the source document.'),
+      });
+    }
+  }
+
+  const upoPreviewState = upoPreview.preview;
 
   return (
     <>
@@ -103,55 +128,140 @@ export function KsefInvoiceDetailSection({
         <h4 className="invoice-detail-section__title">
           {t('invoice.ksef.sectionTitle', 'KSeF · National e-Invoicing System')}
         </h4>
-        <dl className="invoice-detail-section__kv">
-          {hasRegulatoryData ? (
-            <>
-              <dt>{t('invoice.ksef.clearanceStatus', 'Clearance status')}</dt>
-              <dd>
-                <RegulatoryStatusBadge status={invoice.regulatoryStatus} />
-              </dd>
-            </>
-          ) : null}
-          {ksefNumber ? (
-            <>
-              <dt>{t('invoice.ksef.number', 'KSeF number')}</dt>
-              <dd className="mono-text">{ksefNumber}</dd>
-            </>
-          ) : null}
-        </dl>
-        {canUseUpo ? (
-          <div className="form-actions">
-            <Button
-              tone="secondary"
-              className="button--sm"
-              onClick={() => void handlePreviewUpo()}
-              disabled={upoPreview.isLoading}
-            >
-              {upoPreview.isLoading
-                ? t('invoice.ksef.upoPreviewLoading', 'Loading…')
-                : t('invoice.ksef.upoPreview', 'Preview UPO')}
-            </Button>
-            <Button
-              tone="secondary"
-              className="button--sm"
-              onClick={() => void handleDownloadUpo()}
-              disabled={upoDownload.isDownloading}
-            >
-              {upoDownload.isDownloading
-                ? t('invoice.ksef.upoDownloading', 'Downloading…')
-                : t('invoice.ksef.upoDownload', 'Download UPO')}
-            </Button>
+
+        {hasRegulatoryData ? (
+          <div className="slot-row">
+            <div>
+              <div className="slot-row__label">
+                {t('invoice.ksef.clearanceStatus', 'Clearance status')}
+              </div>
+            </div>
+            <RegulatoryStatusBadge status={invoice.regulatoryStatus} />
           </div>
+        ) : null}
+
+        <div className="slot-row">
+          <div>
+            <div className="slot-row__label">{t('invoice.ksef.number', 'KSeF number')}</div>
+            <div className="slot-row__hint">
+              {t('invoice.ksef.numberHint', 'Authority-assigned on clearance')}
+            </div>
+          </div>
+          {ksefNumber ? (
+            <span className="mono-text text-sm">{ksefNumber}</span>
+          ) : (
+            <span className="text-muted">
+              {t('invoice.ksef.numberPending', 'Pending')}
+            </span>
+          )}
+        </div>
+
+        <div className="slot-row">
+          <div>
+            <div className="slot-row__label">
+              {t('invoice.ksef.upoLabel', 'Official receipt (UPO)')}
+            </div>
+            <div className="slot-row__hint">
+              {canUseUpo
+                ? t('invoice.ksef.upoHint', 'Proof of clearance')
+                : t('invoice.ksef.upoHintPending', 'Available once cleared')}
+            </div>
+          </div>
+          {canUseUpo ? (
+            <span className="slot-row__actions">
+              <Button
+                tone="ghost"
+                className="button--sm"
+                onClick={() => void handlePreviewUpo()}
+                disabled={upoPreview.isLoading}
+              >
+                {upoPreview.isLoading
+                  ? t('common.loading', 'Loading…')
+                  : t('invoice.ksef.upoPreview', 'Preview')}
+              </Button>
+              <Button
+                tone="ghost"
+                className="button--sm"
+                onClick={() => void handleDownloadUpo()}
+                disabled={upoDownload.isDownloading}
+              >
+                {upoDownload.isDownloading
+                  ? t('invoice.ksef.upoDownloading', 'Downloading…')
+                  : t('invoice.ksef.upoDownload', 'Download UPO')}
+              </Button>
+            </span>
+          ) : (
+            <span className="text-muted">—</span>
+          )}
+        </div>
+
+        {canUseUpo ? (
+          <>
+            <div className="slot-row">
+              <div>
+                <div className="slot-row__label">
+                  {t('invoice.ksef.fa3Label', 'FA(3) document')}
+                </div>
+                <div className="slot-row__hint">
+                  {t('invoice.ksef.fa3Hint', 'Human-readable + source XML')}
+                </div>
+              </div>
+              <span className="slot-row__actions">
+                <Button
+                  tone="ghost"
+                  className="button--sm"
+                  onClick={() => void handleViewFa3()}
+                  disabled={fa3.isLoadingView}
+                >
+                  {fa3.isLoadingView
+                    ? t('common.loading', 'Loading…')
+                    : t('invoice.ksef.fa3View', 'View')}
+                </Button>
+                <Button
+                  tone="ghost"
+                  className="button--sm"
+                  onClick={() => void handleDownloadXml()}
+                  disabled={fa3.isDownloadingXml}
+                >
+                  {fa3.isDownloadingXml
+                    ? t('invoice.ksef.fa3Downloading', 'Downloading…')
+                    : t('invoice.ksef.fa3DownloadXml', 'Download XML')}
+                </Button>
+              </span>
+            </div>
+
+            <div className="doc-preview">
+              <span className="doc-preview__chip">
+                {t('invoice.ksef.fa3Preview', 'FA(3) preview')}
+              </span>
+              {fa3.viewError ? (
+                <span>{t('invoice.ksef.fa3ViewError', "Preview failed. Click 'View' to retry.")}</span>
+              ) : fa3.viewObjectUrl ? (
+                <iframe
+                  className="doc-preview__frame"
+                  src={fa3.viewObjectUrl}
+                  title={t('invoice.ksef.fa3FrameTitle', 'FA(3) document preview')}
+                  // blob: URL inherits the app origin, so framing it without restrictions
+                  // would allow scripts from the invoice document to run with app privileges.
+                  // sandbox="" blocks all scripts while still rendering the document.
+                  sandbox=""
+                />
+              ) : (
+                <span>{t('invoice.ksef.fa3PreviewPlaceholder', "Click 'View' to load the invoice.")}</span>
+              )}
+            </div>
+          </>
         ) : null}
       </section>
 
+      {/* UPO inline preview dialog */}
       <Dialog
-        open={preview !== null}
+        open={upoPreviewState !== null}
         onOpenChange={(next) => {
           if (!next) upoPreview.close();
         }}
       >
-        {preview !== null ? (
+        {upoPreviewState !== null ? (
           <DialogContent className="dialog__content--wide" aria-describedby="ksef-upo-preview-desc">
             <DialogTitle>{t('invoice.ksef.upoDialogTitle', 'UPO confirmation')}</DialogTitle>
             <DialogDescription id="ksef-upo-preview-desc">
@@ -160,27 +270,23 @@ export function KsefInvoiceDetailSection({
                 'Official confirmation (UPO) for this KSeF invoice.',
               )}
             </DialogDescription>
-            {preview.kind === 'unsupported' ? (
+            {upoPreviewState.kind === 'unsupported' ? (
               <p className="ksef-upo-preview__unsupported">
                 {t(
                   'invoice.ksef.upoPreviewUnsupported',
-                  'This confirmation can’t be previewed inline. Use “Download UPO” to open it.',
+                  'This confirmation can\'t be previewed inline. Use "Download UPO" to open it.',
                 )}
               </p>
             ) : (
               <iframe
                 className="ksef-upo-preview__frame"
-                src={preview.objectUrl}
+                src={upoPreviewState.objectUrl}
                 title={t('invoice.ksef.upoFrameTitle', 'UPO confirmation preview')}
-                // A `blob:` URL inherits the creating document's origin, so framed
-                // content would otherwise run with full app-origin privileges.
-                // An empty `sandbox` blocks scripts while still rendering the
-                // document (browsers display blob: PDFs/XML fine under it).
                 sandbox=""
               />
             )}
             <DialogFooter>
-              {preview.kind === 'unsupported' ? (
+              {upoPreviewState.kind === 'unsupported' ? (
                 <Button
                   tone="secondary"
                   className="button--sm"

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -245,6 +245,9 @@ export function createMockApiClient(
       issue: vi.fn().mockResolvedValue(null),
       retry: vi.fn().mockResolvedValue({ retried: 0, skipped: 0, results: [] }),
       issueCorrection: vi.fn().mockResolvedValue(null),
+      // #1234 — resolves to an empty PDF blob by default so tests that invoke the
+      // UPO preview/download path don't hit `undefined`.
+      downloadUpo: vi.fn().mockResolvedValue(new Blob([''], { type: 'application/pdf' })),
       ...overrides.invoicing,
     } as ApiClient['invoicing'],
     orders: {

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -248,6 +248,10 @@ export function createMockApiClient(
       // #1234 — resolves to an empty PDF blob by default so tests that invoke the
       // UPO preview/download path don't hit `undefined`.
       downloadUpo: vi.fn().mockResolvedValue(new Blob([''], { type: 'application/pdf' })),
+      // #1228 — resolves to an empty HTML blob by default for FA(3) doc tests.
+      downloadDocument: vi
+        .fn()
+        .mockResolvedValue(new Blob([''], { type: 'text/html' })),
       ...overrides.invoicing,
     } as ApiClient['invoicing'],
     orders: {


### PR DESCRIPTION
## KSeF UPO preview + download + FA(3) XML visualization

Closes #1221
Closes #1228

### What's in it

**UPO preview + download:** inline UPO preview (sandboxed iframe) + download, neutral/capability-gated, safe object-URL lifecycle (created once, revoked on close/replace/unmount), server-pinned content-type allowlist.

**FA(3) XML visualization (#1228, merged from #1256):** DOMParser-based viewer that parses the KSeF source XML and renders structured HTML — seller/buyer (name + NIP), invoice number + date, line items table, VAT bands summary, grand total, KSeF assigned number. Replaces the placeholder iframe. Fetches `kind=source` blob, reads as text via `blob.text()`, stored in `useKsefFa3.viewText`.

### Soft dependency
`GET /invoices/:id/upo` endpoint lives in **#1231** (backend, READY). The UPO download button is gated by `RegulatoryDocumentReader` capability check server-side; the FE can merge independently — the button simply won't activate until #1231 ships.

### Pipeline provenance
plan → review → fix → pre-implement → review → fix → implement → tech-review + security-review → fix. Security fix: `sandbox=""` on the blob: preview iframe. FA(3) viewer: tech-review → 6 SUGGESTION fixes applied.

### Gate
`@openlinker/web` type-check/lint ✅; panel vitest ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)