### PR TITLE
docs(invoicing): FE redesign mockup + implementation plans (design backing) (#1239)

### DIFF
--- a/docs/plans/implementation-plan-invoicing-backend.md
+++ b/docs/plans/implementation-plan-invoicing-backend.md
@@ -1,0 +1,317 @@
+# Implementation Plan: Invoicing Backend — close every seam the FE design needs
+
+**Date**: 2026-06-25
+**Status**: Draft — execution-ready for a backend-orchestrator agent
+**Estimated Effort**: ~4–6 dev-days across 6 work items (4 edit unmerged PRs, 1 existing issue, 1 new issue)
+
+> **Companion**: `docs/plans/implementation-plan-invoicing-fe-redesign.md` (the FE
+> program). This plan **freezes the contracts** that the parallel FE orchestrator
+> binds to — see §7 FROZEN CONTRACTS.
+
+> **Process constraints (hard)**: this plan is doc-only (uncommitted, no plan PR,
+> no worktree). It creates **no** GitHub issues except **one** (N2, batch
+> endpoint) which has no home PR. Every other item **edits an unmerged PR in
+> place** or implements an already-open issue. Resource-constrained machine:
+> scope checks to touched packages (`pnpm --filter <pkg> lint|type-check|test`),
+> commit signed `--no-verify -s -S`, never the full pre-commit hook.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Implement every backend seam the merged invoicing FE design
+depends on, with **zero debt / zero trade-offs** — so the FE renders at full
+fidelity rather than degrading. The work is small and surgical: most of it
+**extends PRs already in flight**.
+
+**Context**: The FE redesign (mockup + FE plan) surfaced a precise set of
+backend dependencies (FE plan §9). GitHub state moved since: `#1229`+`#1230`
+now share **#1238**; `#1214` already adds `issuing` + `failureMode` to the
+domain; `#1231` already ships the UPO endpoint + a slim order-invoice
+projection + a `RegulatoryDocumentReader` capability. This plan fills the
+remaining gaps on top of that.
+
+**Classification**: Interface (response DTOs + endpoints) + Infrastructure
+(persistence/migrations) + Integration (KSeF/Subiekt adapters). Core stays
+neutral (ADR-026).
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope (do everything)
+1. **[EDIT #1214]** Expose `failureMode` (+ sanitized `failureCode`/`failureReason`) on the invoice response DTO. (`status:'issuing'` is **already** exposed.)
+2. **[EDIT #1231]** Add `GET /invoices/:invoiceId` (full record) + persist & expose the **issued-document content** (seller/buyer/lines/VAT) for the detail "Invoice contents" card. (UPO endpoint + slim order projection **already** exist here.)
+3. **[EDIT #1189]** Persist the issued **FA(3) XML** + serve a document fetch (XML + human-readable) via the existing `RegulatoryDocumentReader` seam.
+4. **[EDIT #1238]** Subiekt correction supports **price *and* quantity** per line; confirm `getClearanceStatus` is wired into the #1121 reconcile; reconcile the Subiekt↔bridge **endpoint paths**.
+5. **[IMPLEMENT #1202]** Denormalize buyer tax-id onto `invoice_records` + `?taxId=with|without` filter on `GET /invoices`.
+6. **[NEW issue N2]** Batch retry endpoint (server retries only `rejected`; skips `issued`/`in-doubt`).
+
+### Out of Scope
+- All FE work (separate plan/orchestrator).
+- KSeF/Subiekt feature scope beyond the above (the adapters' own issues stand).
+- Receipts/fiscalization (paragony) — invoice-only per the FE plan.
+- New ADRs (the neutral contract is governed by the existing ADR-026; no
+  cross-context decision is introduced — see §3).
+
+### Constraints
+- Maximize edits to unmerged PRs; reuse open issues (auto-close via `Closes #N`).
+- Neutral core (ADR-026): no `nip`/`ksef`/`vat`/`faktura` in `libs/core`
+  invoicing types; provider specifics stay in adapters.
+- Migrations follow `docs/migrations.md` (synthetic sequential prefix, strictly
+  greater than current tail; #1214 already adds `1812000000000`).
+
+---
+
+## 3. Architecture Mapping
+
+**Target layers**: Interface (`apps/api/src/invoicing/http`, `.../orders/http`),
+Core domain/infra (`libs/core/src/invoicing`), Integrations
+(`libs/integrations/{ksef,subiekt}`).
+
+**Capabilities involved** (all already exist — extended, not invented):
+- `InvoicingPort`, `RegulatoryStatusReader`, `RegulatoryTransmitter`.
+- `RegulatoryDocumentReader` (added by #1231 for UPO) — **reused** for FA(3)
+  document fetch (W3).
+
+**Core vs Integration**: the DTO/endpoint/persistence work is core+interface and
+stays neutral. FA(3)-XML persistence and Subiekt correction-price are
+**adapter-internal** (KSeF/Subiekt packages) — they surface through the neutral
+`RegulatoryDocumentReader` / `InvoicingPort` (+ correction) contracts. No new
+core port is required; `RegulatoryDocumentReader` gains a neutral `documentKind`
+discriminator rather than a KSeF-named method (keeps ADR-026 intact).
+
+**No new ADR**: this is additive within ADR-026's existing neutral surface; the
+one judgment call (persist issued-document content vs reconstruct from order) is
+recorded in §8 Alternatives, not an ADR (single-context, no plugin-contract
+change).
+
+---
+
+## 4. External / Domain Research (current-state, verified)
+
+- **#1214** (`1200-invoicing-exactly-once`): `InvoiceStatusValues = ['pending','issuing','issued','failed']`; `InvoiceFailureModeValues = ['rejected','in-doubt']`; `failureMode` on entity + `InvoiceOutcomePatch`; migration `1812000000000-add-invoice-record-retry-guards.ts`. Response DTO `status!: InvoiceStatus` (so `issuing` is already serialized) **but no `failureMode` field**. `errorMessage` deliberately omitted (PII).
+- **#1231** (`1224-ksef-upo-endpoint`): `@Controller('invoices')` with `GET /invoices/:invoiceId/upo`; `RegulatoryDocumentReader` capability; `OrderInvoiceProjectionDto = { invoiceId, regulatoryStatus, clearanceReference, upoReference }` (slim — **no document content**) on the order response; KSeF adapter implements `RegulatoryDocumentReader`. **No `GET /invoices/:invoiceId`** (only `/upo`).
+- **#1189** (`1151-ksef-kor-corrections`): KSeF adapter builds FA(3) XML at issue and submits it; clearance mapper `200 → accepted` (no `cleared`). XML is built but **not persisted for later fetch**.
+- **#1238** (`1229-1230-subiekt-corrections-clearance`): Subiekt correction + `getClearanceStatus` in progress.
+- **Merged**: `InvoiceRecord` projection (no buyer/lines columns); HTTP API `POST /invoices`, `GET /orders/:orderId/invoice?connectionId=`, `GET /invoices` (filters).
+
+---
+
+## 5. Questions & Assumptions
+
+### Assumptions (safe defaults)
+- **Issued-document content** is persisted **at issue time** (snapshot), not
+  reconstructed from the live order — an order can change after the invoice is
+  issued, and the document must reflect what was issued. Stored neutrally as a
+  jsonb column on `invoice_records` (or a 1:1 child table). [§8 Alt-1]
+- `GET /invoices/:invoiceId` returns the **same** `InvoiceRecordResponseDto` as
+  the list/get-per-order; the rich content is a **separate** content endpoint
+  (so the list DTO stays slim and the content seam is independently cacheable).
+- `failureCode` is a **closed neutral enum** (PII-free); `failureReason` is an
+  optional short localizable-key-or-sanitized string. Adapters map their native
+  error to a `failureCode`; unknown → `provider-error`.
+- N2 batch retry reuses the single-invoice retry primitive per id (no parallel
+  bulk pipeline) — mirrors the bulk-offer precedent (architecture-overview
+  §Listings bulk-flow).
+
+### Open questions (non-blocking; defaulted)
+- Q1: content endpoint path — default `GET /invoices/:invoiceId/content`
+  (neutral) vs folding content into the detail DTO. **Default: separate
+  endpoint** (keeps detail DTO == list DTO).
+- Q2: FA(3) document fetch shape — default extend `RegulatoryDocumentReader`
+  with `documentKind: 'upo' | 'source' | 'rendered'` so UPO + FA(3)-XML +
+  FA(3)-HTML share one neutral method (§7).
+
+---
+
+## 6. Proposed Implementation Plan (per work item)
+
+> Each item names the **branch to edit** (or NEW). Steps are small + testable.
+> Sequencing in §9.
+
+### W1 — Expose `failureMode` (+ `failureCode`/`failureReason`) on the response DTO — **EDIT PR #1214** (`1200-invoicing-exactly-once`)
+**Goal**: FE can distinguish `rejected` (safe to retry) from `in-doubt` (no blind
+retry) — the fiscal-safety unblocker. `issuing` is already exposed.
+
+**Steps**:
+1. **Core types** — `libs/core/src/invoicing/domain/types/invoicing.types.ts`:
+   add `InvoiceFailureCodeValues` (`as const`, e.g. `['buyer-tax-id-invalid','provider-rejected','transport-timeout','provider-error']`) + `InvoiceFailureCode` type; add `failureCode?: InvoiceFailureCode | null` + `failureReason?: string | null` to `InvoiceRecord` + `CreateInvoiceRecordInput` + `InvoiceOutcomePatch`. (Reuse the existing `failureMode` already added here.)
+2. **ORM + migration** — `.../infrastructure/persistence/entities/invoice-record.orm-entity.ts` + **extend the existing `1812000000000` migration** (same PR, not yet merged) to add `failure_code` + `failure_reason` nullable columns (alongside `failure_mode`).
+3. **Repository mapping** — `.../repositories/invoice-record.repository.ts`: map the two new columns in `toDomain`/`toOrm`.
+4. **Response DTO** — `apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts`: add `failureMode!: InvoiceFailureMode | null`, `failureCode!: InvoiceFailureCode | null`, `failureReason!: string | null` (`@ApiProperty` each). **Still omit `errorMessage`** (PII).
+5. **Controller** — `invoicing.controller.ts toDto`: map the three fields.
+6. **Service** — where a failure is recorded (`InvoiceService` issue/retry path), set `failureMode` (already) + derive `failureCode` from the adapter's neutral error (`failureMode==='rejected'`→ provider's rejection code; `in-doubt`→ `transport-timeout`/`provider-error`).
+**Acceptance**: `GET /invoices`/`/orders/:id/invoice` responses carry
+`status:'issuing'` + `failureMode` + `failureCode` + `failureReason`; unit +
+controller spec updated; `pnpm --filter @openlinker/api --filter @openlinker/core test` green.
+
+### W2 — `GET /invoices/:invoiceId` + issued-document **content** — **EDIT PR #1231** (`1224-ksef-upo-endpoint`)
+**Goal**: back the detail page (full record) and its "Invoice contents" card.
+
+**Steps**:
+1. **Repository** — `InvoiceRecordRepositoryPort` + impl: add `findById(invoiceId): Promise<InvoiceRecord | null>` (port already gains methods in this PR).
+2. **Service + controller** — `InvoiceService.getInvoiceById` + `@Get(':invoiceId')` on the existing `@Controller('invoices')`, returning `InvoiceRecordResponseDto`; `404` when absent. (Sits beside the existing `/:invoiceId/upo`.)
+3. **Issued-document content (snapshot at issue)**:
+   - Core: new neutral type `IssuedDocumentContent` (`libs/core/src/invoicing/domain/types/invoicing.types.ts`) — see §7. Persist it: jsonb column `document_content` on `invoice_records` (new migration, prefix > `1812000000000`).
+   - `InvoiceService.issueInvoice`: when the adapter returns success, snapshot content from the `IssueInvoiceCommand` (buyer, lines, currency) + seller (resolved by the adapter / connection config, returned on the result) + computed VAT breakdown, and persist via `updateOutcome`/a dedicated repo method.
+   - **Adapter surface**: extend the `InvoicingPort.issueInvoice` result (or `InvoiceRecord`) to carry the seller block the adapter resolved (KSeF: from `KsefSellerConfig`; Subiekt: from the bridge document) — neutral shape, no provider names.
+   - Interface: `GET /invoices/:invoiceId/content` → `IssuedDocumentContentDto` (§7); `404`/`409` when no content yet.
+4. **Order projection** (optional reuse): the slim `OrderInvoiceProjectionDto` stays as-is for the order response; the rich content lives behind the content endpoint.
+**Acceptance**: detail endpoint returns the record; content endpoint returns
+seller/buyer/lines/VAT for an issued invoice; int-spec covers both; existing
+UPO int-spec stays green.
+
+### W3 — Persist FA(3) XML + document fetch — **EDIT PR #1189** (`1151-ksef-kor-corrections`)
+**Goal**: back the KSeF FA(3) visualization (HTML) + XML download.
+
+**Steps**:
+1. **KSeF adapter** — persist the built FA(3) XML at issue (adapter-private store keyed by the provider invoice id, or returned for core to persist as an opaque document blob — prefer core-persisted opaque blob to avoid adapter-side storage).
+2. **`RegulatoryDocumentReader`** — extend the neutral capability with a `documentKind` param: `getRegulatoryDocument(record, kind: 'upo' | 'source' | 'rendered')` returning `{ contentType, bytes }` (or a URL). KSeF maps `source`→FA(3) XML, `rendered`→HTML, `upo`→UPO (existing). Keep the method neutral (no `fa3`/`ksef` in core).
+3. **Interface** — `GET /invoices/:invoiceId/document?kind=source|rendered` beside `/upo` (or generalize `/upo` → `/document?kind=upo`, keeping `/upo` as an alias for back-compat with #1231).
+**Acceptance**: for a cleared KSeF invoice, XML + HTML fetch return bytes;
+`accepted` (never `cleared`) verified in the adapter mapper; KSeF package tests green.
+
+### W4 — Subiekt correction price + clearance wiring + bridge paths — **EDIT PR #1238** (`1229-1230-subiekt-corrections-clearance`)
+**Goal**: Subiekt correction parity (price *and* qty) + Subiekt invoices get
+KSeF status/number + working E2E.
+
+**Steps**:
+1. **Correction** — ensure the Subiekt correction command/adapter carries **corrected price per line**, not only quantity (bridge KOR endpoint, bridge-repo #6, must accept it; coordinate the wire shape `{lp, newQty, newUnitNet}`).
+2. **`getClearanceStatus`** — confirm `SubiektInvoicingAdapter implements RegulatoryStatusReader` and that the #1206/#1121 reconcile job picks Subiekt up (guard `isRegulatoryStatusReader`); Subiekt invoices then get `regulatoryStatus` + `clearanceReference` (KSeF number) refreshed.
+3. **Bridge path reconciliation** — verify the live bridge routes; align the OL Subiekt adapter (`SubiektBridgeHttpClient`) and the bridge so they agree (`/api/invoices` vs `/api/faktury`, etc.). Pick the authoritative set, fix the other side. (May be a bridge-repo change + an OL adapter change.)
+**Acceptance**: Subiekt correction issues with adjusted price+qty; a Subiekt
+invoice shows non-`not-applicable` `regulatoryStatus` after reconcile; Subiekt
+adapter int-spec (HTTP-seam fake) exercises the real paths.
+
+### W5 — Tax-id list filter — **IMPLEMENT open issue #1202**
+**Steps**:
+1. **Migration** — denormalize buyer tax-id presence onto `invoice_records`
+   (`buyer_tax_id_scheme` / `buyer_tax_id_value` nullable, or a boolean
+   `has_buyer_tax_id`). New migration, prefix > W2's.
+2. **Write path** — `InvoiceService.issueInvoice` populates it from the command's buyer.
+3. **Query** — `InvoiceRecordRepositoryPort.findMany` + repo: accept a `taxId: 'with' | 'without'` filter; `GET /invoices` query DTO gains `?taxId=`.
+**Acceptance**: `GET /invoices?taxId=with|without` filters correctly; query DTO
+validated; list int-spec covers both.
+
+### W6 — Batch retry endpoint — **NEW issue N2** (`/create-issue`)
+**Steps**:
+1. **Issue** — `[IMPL] feat(invoicing): batch issue/retry endpoint` (small, self-contained).
+2. **Endpoint** — `POST /invoices/retry` (body: `{ invoiceIds: string[] }` or `{ orderIds, connectionId }`); for each, reuse the single-invoice retry primitive; **server-side skip** any record not in a retry-eligible state (`failed` + `failureMode==='rejected'`); skip `issued`/`issuing`/`in-doubt`. Returns a per-id outcome summary `{ retried, skipped, results: [{id, outcome}] }`.
+**Acceptance**: bulk retry re-attempts only eligible rows, reports skipped;
+controller spec covers the skip rules.
+
+### Implementation details (cross-cutting)
+- **Migrations**: 3 new (W1 extends existing #1214 migration; W2 content column; W5 tax-id column) — each prefix strictly greater than the current tail, synthetic sequential per `docs/migrations.md`.
+- **Error handling**: adapters map native errors to neutral `failureMode` (already) + `failureCode`; repositories convert infra errors to domain errors (existing pattern).
+- **Idempotency**: unchanged — single-invoice issue/retry idempotency (#1200) is reused by N2; content snapshot is write-once at issue.
+- **Events**: none new.
+
+---
+
+## 7. FROZEN CONTRACTS (the FE orchestrator binds to these)
+
+### 7.1 `InvoiceRecordResponseDto` (additions — W1)
+```
+status: 'pending' | 'issuing' | 'issued' | 'failed'        // 'issuing' already shipped (#1214)
+failureMode: 'rejected' | 'in-doubt' | null                // NEW (W1)
+failureCode: 'buyer-tax-id-invalid' | 'provider-rejected'
+           | 'transport-timeout' | 'provider-error' | null // NEW (W1) — closed neutral enum, PII-free
+failureReason: string | null                               // NEW (W1) — short sanitized/localizable, no PII
+// unchanged: id, connectionId, orderId, providerType, documentType,
+// providerInvoiceId, providerInvoiceNumber, regulatoryStatus, clearanceReference,
+// pdfUrl, issuedAt, createdAt, updatedAt.  errorMessage stays OMITTED.
+```
+FE rule: Retry is allowed **iff** `status==='failed' && failureMode==='rejected'`.
+`regulatoryStatus` success terminal = **`accepted`** (KSeF emits `accepted`, not `cleared`).
+
+### 7.2 Endpoints
+| Method | Path | Request | Response | Item |
+|---|---|---|---|---|
+| GET | `/invoices/:invoiceId` | — | `InvoiceRecordResponseDto` (404 if absent) | W2 |
+| GET | `/invoices/:invoiceId/content` | — | `IssuedDocumentContentDto` (404/409 if no content) | W2 |
+| GET | `/invoices/:invoiceId/upo` | — | document bytes (Content-Type per provider) | exists (#1231) |
+| GET | `/invoices/:invoiceId/document?kind=source\|rendered` | — | document bytes (XML / HTML) | W3 |
+| GET | `/invoices?…&taxId=with\|without` | query | `PaginatedInvoicesResponseDto` | W5 |
+| POST | `/invoices/retry` | `{ invoiceIds: string[] }` | `{ retried: number, skipped: number, results: {id, outcome}[] }` | W6 |
+
+### 7.3 `IssuedDocumentContentDto` (neutral — W2)
+```
+seller:   { name: string; taxId: { scheme: string; value: string }; address: BuyerAddress }
+buyer:    { name: string; taxId: { scheme: string; value: string } | null; address: BuyerAddress }
+lines:    { name: string; quantity: number; unitNet: number; taxRate: string;
+            net: number; vat: number; gross: number }[]
+vatBreakdown: { rate: string; net: number; vat: number; gross: number }[]
+totals:   { net: number; vat: number; gross: number }
+currency: string            // ISO 4217
+issueDate: string | null    // ISO
+saleDate:  string | null    // ISO
+payment:   { method: string | null; paidAt: string | null } | null
+```
+(`BuyerAddress` = the existing neutral `{ line1, line2|null, city, postalCode, countryIso2 }`.)
+
+### 7.4 Existing — FE just consumes (no backend change)
+- `connection.status` (`active|disabled|error|needs_reauth`) → needs-reauth affordance.
+- `connection.config.invoicing.triggerModel` (`manual|auto-on-paid|auto-on-shipped`) → wizard trigger (KSeF + Subiekt), read by #1120/#1206.
+- `providerType` + `connectionId` on the DTO → the list Connection column.
+
+---
+
+## 8. Alternatives Considered
+- **Alt-1 (content): reconstruct from the live order instead of snapshotting at issue.** Rejected — the order can change after issuance; the document must reflect what was issued. Snapshot is the only correct source. Trade-off: a jsonb column / child row; acceptable.
+- **Alt-2 (FA(3) doc): adapter-side storage of the XML.** Rejected — prefer core-persisted opaque document blob via the neutral `RegulatoryDocumentReader` so the interface layer doesn't reach into a plugin and storage policy is uniform.
+- **Alt-3 (failureCode): free-text only.** Rejected — a closed neutral enum lets the FE localize copy and keeps PII out; free-text reason stays optional/sanitized.
+- **Alt-4 (batch): a parallel bulk pipeline.** Rejected — reuse the single-invoice retry primitive per id (bulk-offer precedent), no new orchestration.
+
+## 9. Validation, Risks & Orchestration
+
+### Architecture / standards
+- ✅ Neutral core (ADR-026): new types carry no provider vocabulary; `failureCode` is a neutral enum; FA(3)/UPO ride the neutral `RegulatoryDocumentReader`.
+- ✅ Hexagonal: DTOs in interface layer; persistence in infra; adapters map native→neutral.
+- ✅ `as const` unions for `failureCode`; migrations per `docs/migrations.md`.
+
+### Risks / edge cases
+- **Migration ordering** — three new migrations (incl. extending #1214's). Each must be strictly-greater synthetic prefix; verify with `pnpm --filter @openlinker/api migration:show`.
+- **Content backfill** — pre-existing invoices have no `document_content`; the content endpoint returns 409/empty for them (no backfill; FE shows "content unavailable" gracefully).
+- **Bridge path mismatch (W4)** — touches a second repo; verify against the running bridge before asserting fixed.
+- **Backward compat** — all DTO additions are additive/nullable; no breaking change.
+
+### Orchestration order (for the backend agent)
+1. **W1 (#1214)** — first; cross-cutting unblocker for FE fiscal-safety. Ships independently.
+2. **W2 (#1231)** — detail endpoint + content; unblocks the detail page + Invoice-contents card.
+3. **W3 (#1189), W4 (#1238), W5 (#1202), W6 (N2)** — parallel after W1/W2 (independent surfaces). W6 first needs the `/create-issue`.
+
+### FE dependency map (what the FE orchestrator waits on)
+- FE **in-doubt/issuing states + bulk eligibility** ⇐ **W1**.
+- FE **invoice detail page + Invoice-contents card** ⇐ **W2**.
+- FE **FA(3) visualization / XML download** ⇐ **W3**.
+- FE **Subiekt clearance surfacing + correction price** ⇐ **W4**.
+- FE **tax-id filter** ⇐ **W5**; FE **bulk retry** ⇐ **W6** (degrades to sequential without it).
+
+---
+
+## 10. Testing Strategy & Acceptance
+
+- **Unit** (`*.spec.ts`): `InvoiceService` failure-code derivation + content snapshot; repository `findById`/content/tax-id mapping; controller `toDto` (new fields) + new endpoints; KSeF document mapper (`accepted`, doc kinds); Subiekt correction price mapping + `getClearanceStatus`.
+- **Integration** (`*.int-spec.ts`): `GET /invoices/:id` + `/content` + `/document` happy/404/409; `GET /invoices?taxId=`; `POST /invoices/retry` skip rules; reuse the existing UPO int-spec.
+- **Acceptance**:
+  - [ ] Response DTO exposes `status:'issuing'`, `failureMode`, `failureCode`, `failureReason`; never `errorMessage`.
+  - [ ] `GET /invoices/:invoiceId` + `/content` + `/document?kind=` return correct shapes (§7).
+  - [ ] KSeF success = `accepted` end-to-end; FA(3) XML+HTML fetchable.
+  - [ ] Subiekt correction carries price+qty; Subiekt invoice gets clearance via reconcile.
+  - [ ] `?taxId=with|without` filters; `POST /invoices/retry` retries only `rejected`.
+  - [ ] Migrations show clean; touched-package `lint`+`type-check`+`test` green.
+
+## 11. Alignment Checklist
+- [x] Hexagonal layers + neutral core (ADR-026)
+- [x] Edits unmerged PRs in place; 1 new issue (N2) only
+- [x] Idempotency reused (#1200); content snapshot write-once
+- [x] Migrations per `docs/migrations.md` (strictly-greater synthetic prefixes)
+- [x] Error handling neutral (failureMode/failureCode); no PII in DTO
+- [x] Contracts frozen for the FE orchestrator (§7)
+- [x] Testing strategy complete; execution-ready; doc-only (no PR/issues except N2)
+
+## Related
+- `docs/plans/implementation-plan-invoicing-fe-redesign.md` (FE companion, §9 seam list)
+- `docs/architecture-overview.md` §Invoicing, ADR-026
+- PRs: #1214, #1231, #1189, #1238, #1206 · issues: #1202, #1200, #1120, #1121, #1224, #1228, #1229, #1230

--- a/docs/plans/implementation-plan-invoicing-fe-redesign.md
+++ b/docs/plans/implementation-plan-invoicing-fe-redesign.md
@@ -1,0 +1,508 @@
+# Implementation Plan: Invoicing FE Redesign + Gap-Fill (KSeF + Subiekt + Common Base)
+
+**Date**: 2026-06-25
+**Status**: Draft — feeds `/frontend-design:frontend-design`
+**Estimated Effort**: ~3 waves; A ≈ 4–6 d, B ≈ 4–6 d, C ≈ backend-gated (FE ≈ 3–4 d once seams land)
+
+> **Process note.** This plan is the engineering roadmap. The next step is
+> `/frontend-design:frontend-design` per screen, which produces the visual
+> design. **All `/frontend-design` output (design docs, mockups, copy,
+> annotations, component/file names) MUST be in ENGLISH.** No new GitHub issues
+> are created for this program (user directive) — existing issues are reused;
+> work lands across the in-flight KSeF FE branch + one new neutral-base PR (see
+> §11 Reconciliation & Delivery).
+
+---
+
+## 1. Task Summary
+
+**Objective**: Redesign and complete the operator-facing invoicing UI in
+`apps/web` as a cohesive surface built on a **thick neutral base + thin
+per-provider slots**, covering both invoicing providers (KSeF direct-transmit;
+Subiekt-via-bridge) plus the missing screens (invoice detail, status timeline,
+re-issue/correction, sanitized failure reasons, batch ops, doc-type config).
+
+**Context**: The neutral invoicing FE merged today (#1211: `OrderInvoicePanel`,
+`/invoices` list, Subiekt connection settings) is a thin first cut. KSeF FE is
+mid-flight as a draft stack (#1191, #1232–#1235) built off a **pre-#1211**
+baseline that re-implements parallels (a second `/invoices`, a second panel).
+This program unifies all of it on one neutral base, completes the gap screens,
+and re-homes the KSeF work onto provider slots.
+
+**Classification**: Frontend (design + implementation). Backend changes are
+explicitly **out of scope** here and handed off as separate tasks (§9); the FE
+is designed to the target core contract.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope (full A + B + C)
+- **Wave A — Neutral base**: redesign `OrderInvoicePanel` + `/invoices` list;
+  new invoice **detail page** (`/invoices/:invoiceId`); status **timeline**
+  (static stepper); sanitized **failure-reason** display; empty/loading/error
+  polish; batch operations (multi-select issue/retry).
+- **Wave B — Per-provider slots**: KSeF connection wizard + seller profile;
+  UPO preview/download; FA(3) visualization; KSeF-number surfacing; Subiekt
+  parity (regulatory badge once its reader lands).
+- **Wave C — Backend-gated FE**: re-issue (state-dependent) + per-provider
+  **correction** flow; with/without-tax-id list filter; per-provider
+  **document-type config**.
+- **One new FE plugin slot**: `PlatformContribution.invoiceDetailSection` +
+  a per-provider **correction-flow** slot (see §3, §6).
+
+### Out of Scope
+- All backend changes (handed off as separate tasks — §9). FE designs to the
+  target contract and feature-gates affordances whose seam is absent.
+- New GitHub issues for this program (reuse existing).
+- Bulk export, invoice template/mapping editor, regulatory-webhook UI,
+  separate analytics dashboard.
+- **Receipts / fiscalization** (paragony, fiscal printers → MF fiscal system).
+  KSeF carries only structured FA(3) **invoices** (B2B/B2G); receipts are a
+  separate fiscal path. The UI issues **invoices only** — there is **no
+  document-type picker** anywhere. Core's open-world `DocumentType` keeps
+  `receipt`/others for the future, but no surface offers them. (The simplified-
+  invoice nuance — paragon with NIP ≤ 450 zł — is also out of scope.)
+- Closing/superseding the in-flight KSeF FE PRs — they are **reworked in
+  place** (§11).
+
+### Constraints
+- ZERO `platformType === 'x'` literals outside `apps/web/src/plugins/`
+  (ESLint-enforced). Per-provider variance flows through `usePlatform()` slots
+  and `connection.supportedCapabilities.includes(...)` capability gates.
+- FE dependency rules (`app → pages → features → shared`; `shared` ⊄ features).
+- Resource-constrained dev machine: never run the full pre-commit hook; scope
+  checks to `apps/web` (`pnpm --filter @openlinker/web lint|type-check|test`).
+
+---
+
+## 3. Architecture Mapping
+
+**Target layer**: App/Frontend only — `apps/web/src/{features/invoicing,
+pages/invoicing,plugins/{ksef,subiekt},shared/plugins}`.
+
+**Contracts consumed (neutral core, ADR-026)** — verified on `origin/main`:
+- `InvoiceStatus` = `pending | issued | failed`.
+- `RegulatoryStatus` = `not-applicable | submitted | cleared | accepted |
+  rejected` — **FE `invoicing.types.ts` already matches core verbatim** (no
+  drift; an earlier diagnosis note was a misreport).
+- `DocumentType` open-world (`invoice|receipt|credit-note|corrected|proforma|
+  prepayment`), POST field stays `string`.
+- HTTP API (merged #1203/#1174): `POST /invoices`, `GET
+  /orders/:orderId/invoice?connectionId=`, `GET /invoices` (filters
+  status/connectionId/regulatoryStatus/issuedFrom/issuedTo, limit/offset).
+- `InvoiceRecordResponseDto` OMITS `errorMessage` (PII) and `idempotencyKey`.
+
+**Existing FE assets reused**:
+- `features/invoicing/` barrel: `OrderInvoicePanel`, `useOrderInvoiceQuery`,
+  `useIssueInvoiceMutation`, `useInvoicesQuery`, `invoicingQueryKeys`,
+  transport types. Internal: `invoice-status-badge`, `regulatory-status-badge`,
+  `invoice-pdf-link`, `document-type-select`, `resolveIssueErrorMessage`.
+- `pages/invoicing/invoices-list-page.tsx`.
+- `plugins/subiekt/` (structured section, credentials panel, setup route,
+  `subiekt-capability-descriptors.ts`).
+- Plugin contract `shared/plugins/plugin.types.ts` — slots
+  `StructuredConfigSection`, `CredentialsPanel`, `ConnectionActions`,
+  `setupCard`, `capabilityDescriptors`, `OfferValidationContribution`, etc.
+- Shared UI: `StatusBadge` (7 tones, `pulse`), `DataTable`, `Dialog`/
+  `ConfirmDialog`, `FormField`, `PageLayout`, `KeyValueList`, `Tabs`,
+  `SetupStepper`, `EmptyState`/`ErrorState`/`LoadingState`, `BulkActionBar`.
+
+**New FE components required** (see §6 for the slot/neutral split):
+- `PlatformContribution.invoiceDetailSection?: ComponentType<{ invoice:
+  InvoiceRecord; connection: Connection }>` — content-only, `usePlatform`-
+  resolved, capability-gated by the caller. Reused by panel + list-row +
+  detail page.
+- `PlatformContribution.invoiceCorrectionFlow?` — per-provider correction
+  form/modal (different steps per integration; see §6/D-Q user decision).
+- `plugins/ksef/` plugin folder (does not exist on main).
+- Neutral: invoice detail page + route, status timeline, failure-reason
+  surface, batch action bar wiring, a `use-invoice-query` (detail) +
+  `use-regulatory-document` (UPO/FA(3)) hook.
+
+**Core vs Integration**: 100% frontend. The neutral↔provider split is the FE
+mirror of ADR-026 — no new ADR required for the architecture (the existing
+ADR-026 governs it). The two new FE plugin slots are additive, mirroring the
+established `StructuredConfigSection`/`bulkOfferRowSection` precedent, so they
+do not warrant a standalone ADR. (A backend ADR may be warranted for the
+sanitized-failure-code enum — that decision belongs to the backend task, §9.)
+
+---
+
+## 4. External / Domain Research
+
+### Provider posture (drives slot variance)
+- **KSeF** (`ksef.publicapi.v2`, draft #1189): OL transmits directly →
+  implements `RegulatoryTransmitter`. Connection config: `env`
+  (`test|demo|prod`, required) + nested `seller{nip,name,address}` (required at
+  issue). Credentials: `authType` (`ksef-token|qualified-seal`) + `secretRef`.
+  Doc types: `invoice`, `corrected` (KOR). Surfaces: KSeF number, UPO download,
+  FA(3) XML.
+- **Subiekt** (`subiekt.invoicing.v1`, merged): bridge-transmits to KSeF
+  natively → today implements `InvoicingPort` only; `RegulatoryStatusReader`
+  lands via **#1230**. Config: `bridgeBaseUrl` (SSRF-guarded) + optional
+  `timeoutMs`; credentials: optional `bridgeToken`. Doc types: `invoice` (FV),
+  `receipt` (PA). Corrections via bridge: **#1229** (bridge KOR endpoint =
+  bridge-repo issue #6). Bridge now exposes a **real PDF endpoint** (bridge PR
+  #4/#5) → `pdfUrl` can be populated.
+- **⚠️ Verify before live-data wiring**: the OL Subiekt adapter calls
+  `/api/invoices`, `/api/customers/upsert`, `/api/invoices/{id}/status`; the
+  .NET bridge historically exposed `/api/faktury`, `/api/kontrahenci/upsert`,
+  `/api/faktury/{id}/status`. The bridge's hexagonal refactor (PR #1/#5) may
+  have reconciled this. Backend/bridge concern — does not block FE design, but
+  E2E on Subiekt is blocked until confirmed.
+
+### Capability-driven rendering
+Regulatory affordances render off `connection.supportedCapabilities` +
+provider `capabilityDescriptors` (the `'Show KSeF status badge'` label is
+already provider-supplied for Subiekt). KSeF auto-gets the regulatory section
+via its `RegulatoryTransmitter` capability; Subiekt gets it once #1230 ships.
+
+---
+
+## 5. Questions & Assumptions
+
+### Resolved (grill-me, locked)
+- Deliverable = design + FE impl; backend separate. Architecture = thick
+  neutral base + thin per-provider slots. Scope = full A+B+C. Re-issue =
+  state-dependent (Retry for failed/pending; Correction for issued). Timeline =
+  static stepper. Correction form = **per-provider slot** (different steps per
+  integration — "a form for everything = a form for nothing"). Reconciliation =
+  rework in-flight KSeF PRs in place; separate PR for merged base; minimize new
+  issues; create nothing yet.
+
+### Open (need confirmation before the relevant wave; do not block A)
+- **D-Q1 (detail-page seam)**: no `GET /invoices/:invoiceId` exists (only
+  `getForOrder` + `list`). Assumption: add a backend seam (§9); interim,
+  detail page can hydrate from `list` filtered by id or from `getForOrder`.
+- **D-Q2 (re-issue/correction trigger seam)**: `POST /invoices` 409s on issued.
+  Correction needs a backend trigger (KSeF KOR #1151 / Subiekt #1229).
+  Assumption: per-provider correction slot calls a provider-specific endpoint;
+  FE designs the form, backend exposes the trigger.
+- **D-Q3 (failure-code seam)**: DTO omits `errorMessage`. Assumption: backend
+  adds a PII-free `failureCode` enum + optional `failureReason`; FE renders
+  `failureCode → localized copy`. Until then, failure-reason display shows the
+  existing generic copy (graceful degradation).
+- **D-Q4 (batch endpoint)**: no bulk issue/retry endpoint. Assumption: backend
+  adds one; FE multi-select degrades to per-row sequential calls if absent.
+
+### Documentation gaps
+- None blocking. `docs/frontend-architecture.md` slot reference will need a row
+  added for `invoiceDetailSection` + `invoiceCorrectionFlow` when they land.
+
+---
+
+## 6. Proposed Implementation Plan
+
+> Each wave is independently shippable. Wave A is pure FE with no backend
+> dependency (except the detail-page seam D-Q1, which has an interim path).
+> The neutral/slot split per screen is the §6.0 table.
+
+### 6.0 Neutral base vs per-provider slot — per-screen ownership
+
+| Surface | Ownership | Mechanism |
+|---|---|---|
+| `OrderInvoicePanel` | **Neutral** + optional provider extras | `invoiceDetailSection` slot, capability-gated |
+| `/invoices` list (+ per-row KSeF#/UPO action) | **Neutral** | `invoiceDetailSection` (row variant) / `usePlatform` per row |
+| Invoice **detail** page shell | **Neutral** + provider extras | `invoiceDetailSection` slot |
+| Status **timeline** (stepper) | **Neutral** | none. Success terminal = `accepted` (KSeF maps `200 → accepted`); `cleared` is reserved for split-clearance regimes and no current provider emits it |
+| **Issuance state machine** (`pending` / `issuing` / `issued` / `failed·rejected` / `in-doubt`) | **Neutral** | reads `status` + `failureMode` from the DTO. `issuing` (live lease) and `in-doubt` → **no blind Retry** |
+| Failure / in-doubt display | **Neutral** | `rejected` → directive error + Retry (nothing issued); `in-doubt` → warning + "check provider / mark resolved", **never auto-retry** (duplicate-document risk, #1200) |
+| Connection-health affordance (`needs_reauth` / `error`) | **Neutral** | reads `connection.status`; surfaces a re-authenticate CTA instead of hiding the panel |
+| Batch ops (retry only `rejected`) | **Neutral** | `BulkActionBar` — skips `issued` and `in-doubt` rows |
+| Connection wizard + seller profile | **Per-provider slot** | `setupCard` + `StructuredConfigSection` + `CredentialsPanel` |
+| UPO preview/download | **Neutral hook** + provider slot | `use-regulatory-document` (neutral) + `invoiceDetailSection` affordance |
+| FA(3) visualization | **Per-provider slot** | `invoiceDetailSection` (KSeF) |
+| Correction form | **Per-provider slot** | `invoiceCorrectionFlow` slot |
+| Document-type config | **Per-provider slot** | new connection-edit slot, driven by `getSupportedDocumentTypes()` |
+
+### Wave A — Neutral base (no backend dependency; start immediately)
+
+**A0. Add the `invoiceDetailSection` slot to the plugin contract**
+- **File**: `apps/web/src/shared/plugins/plugin.types.ts` (+ doc row in
+  `docs/frontend-architecture.md`).
+- **Action**: Add `invoiceDetailSection?: ComponentType<{ invoice:
+  InvoiceRecord; connection: Connection }>` to `PlatformContribution`
+  (content-only; mirrors `bulkOfferRowSection`). Resolve via
+  `usePlatform(connection.platformType)`; the host caller owns the capability
+  gate. **Note** the `shared/plugins` feature-import allow-list: `InvoiceRecord`
+  must be importable — re-export the type from `features/invoicing` and, if the
+  ESLint allow-list disallows it, hoist `InvoiceRecord` to a `shared/types`
+  boundary (follow the `EditConnectionFormValues` exemption precedent).
+- **Acceptance**: type-check passes; an absent slot renders nothing.
+
+**A1. Redesign `OrderInvoicePanel` + `/invoices` list (visual + IA pass)**
+- **Files**: `features/invoicing/components/order-invoice-panel.tsx`,
+  `features/invoicing/components/invoice-status-badge.tsx`,
+  `features/invoicing/components/regulatory-status-badge.tsx`,
+  `pages/invoicing/invoices-list-page.tsx`.
+- **Action**: Apply the `/frontend-design` output: clearer status hierarchy,
+  regulatory affordance placement, connection-picker UX when an order has >1
+  invoicing connection, consistent badge tones, render `invoiceDetailSection`
+  for provider extras. Binds only to neutral core types. Specifically:
+  - **Full issuance state machine** on the panel: `pending`, `issuing` (live
+    lease — locked, no action), `issued`, `failed·rejected` (Retry), and
+    `in-doubt` (warning, **no Retry** — "check provider / mark resolved").
+    Gate Retry on `failureMode === 'rejected'` only.
+  - **Connection-health**: when the resolved invoicing connection is
+    `needs_reauth`/`error`, render a re-authenticate affordance instead of
+    issue/status (don't silently hide the panel).
+  - **`/invoices` list**: add a **Connection/provider column** (`providerType` /
+    `connectionId`), a `needs-review` row treatment for `in-doubt`, and the
+    bulk-retry confirm that skips `issued`/`in-doubt`.
+- **Acceptance**: panel + list render all `InvoiceRecord` fields incl.
+  `status:'issuing'` + `failureMode`; an `in-doubt` invoice exposes **no
+  one-click Retry**; existing tests updated; `pnpm --filter @openlinker/web
+  test` green.
+
+**A2. Invoice detail page (`/invoices/:invoiceId`)**
+- **Files**: `pages/invoicing/invoice-detail-page.tsx` (new),
+  `features/invoicing/hooks/use-invoice-query.ts` (new),
+  `app/routes/invoices.route.tsx` (add child route + `handle.crumb`),
+  `nav-registry` unchanged (detail is not a nav item).
+- **Action**: Neutral detail shell — all `InvoiceRecord` fields, regulatory
+  status, clearance reference, PDF link, document type, timestamps, timeline
+  (A3), failure reason (A5), and the provider `invoiceDetailSection`.
+  Data source per D-Q1 (interim: filter `list`/reuse `getForOrder`).
+  Carries the same issuance state machine as A1 (incl. `in-doubt` with no blind
+  retry) and the per-provider `invoiceCorrectionFlow` trigger for `issued`.
+- **Acceptance**: route lazy-loaded (+ `route-lazy`/`route-handle` test counts
+  bumped); renders **loading / not-found(404) / error** page states plus the
+  per-invoice states.
+
+**A3. Status timeline (static stepper)**
+- **File**: `features/invoicing/components/invoice-timeline.tsx` (new).
+- **Action**: Two-lane stepper — issuance `created → issued` (with `issuing`
+  in-flight + `failed`/`in-doubt` error branches) over clearance `submitted →
+  accepted` (terminal success label is **`accepted`**, not `cleared`). Highlight
+  current state; show timestamps only where present (`issuedAt`,
+  `createdAt`/`updatedAt`). No backend seam.
+- **Acceptance**: renders for every status combination; unit-tested.
+
+**A4. Empty / loading / error / skeleton polish**
+- **Files**: all `features/invoicing` surfaces + `pages/invoicing`.
+- **Action**: Unify feedback states per `docs/frontend-architecture.md § Async
+  UX`; retryable errors, skeletons, deliberate empty states.
+
+**A5. Failure-state model + sanitized failure reason**
+- **Files**: `features/invoicing/lib/issue-error-message.ts`,
+  `order-invoice-panel.tsx`, `invoice-detail-page.tsx`,
+  `features/invoicing/api/invoicing.types.ts` (add `'issuing'` to the status
+  union + `failureMode?: 'rejected' | 'in-doubt'` + optional sanitized
+  `failureCode?`/`failureReason?` once the seam lands).
+- **Action**: Drive the **rejected vs in-doubt** split off `failureMode`
+  (#1200/#1214). `rejected` → directive error + Retry; `in-doubt` → warning,
+  **no Retry**, "check provider / mark resolved" (fiscal-safety: a blind retry
+  on an in-doubt row risks a duplicate document). Render neutral
+  `failureCode → t()` copy (no PII; the DTO still omits `errorMessage`).
+- **Blocked on the §9 DTO seam** (expose `status:'issuing'` + `failureMode`
+  [+ optional `failureCode`]). Until then the FE shows generic copy and treats
+  any non-`rejected` failure as in-doubt (fiscal-safe default).
+
+### Wave B — Per-provider slots (KSeF; absorbs the in-flight stack)
+
+**B1. KSeF plugin scaffold + connection wizard** — `plugins/ksef/index.ts`,
+`plugins/ksef/ksef-setup.route.tsx`, `features/connections/components/
+ksef-setup.schema.ts`, `plugins/ksef/components/ksef-structured-section.tsx`,
+`ksef-credentials-panel.tsx`. Register in `plugins/index.ts`. **Reuses #1152 /
+reworks PR #1191**. Salvage #1191's Zod schemas + NIP normalization.
+Wizard fields: **Connection & access** (name, `env`, `authType`, write-only
+token — the 4 required to connect) + the **neutral invoice trigger-model**
+(`config.invoicing.triggerModel`: manual / auto-on-paid / auto-on-shipped — read
+by #1120/#1206 for *every* invoicing connection, so KSeF carries it too, not
+just Subiekt). KSeF success label is **`accepted`** everywhere (never `cleared`).
+
+**B2. KSeF full seller profile in wizard** — extend B1 with nested
+`config.seller.{nip,name,address}` + shared create/edit assembly helper.
+**Reuses #1223 / reworks PR #1232**.
+
+**B3. UPO preview + download (neutral hook + KSeF slot affordance)** —
+`features/invoicing/hooks/use-regulatory-document.ts` (neutral blob fetch via
+`requestBlob`/`ApiError`); KSeF `invoiceDetailSection` renders sandboxed-iframe
+preview + download (salvage #1234's `sandbox=""`, object-URL lifecycle,
+content-type allowlist). **Reuses #1221 / reworks PR #1234. DEPENDS-ON the
+UPO/RegulatoryDocument backend seam (#1224 / PR #1231 — keep it).**
+
+**B4. KSeF number + clearance reference surfacing** — render neutral
+`regulatoryStatus`/`clearanceReference` in panel/list/detail; KSeF-specific
+labels via `capabilityDescriptors` (no literal in shared UI). **Reuses part of
+#1152 / absorbs #1235's KSeF columns**.
+
+**B5. Full FA(3) visualization (HTML/PDF) + XML download** — KSeF
+`invoiceDetailSection` rendering human-readable FA(3) + XML download, via the
+B3 document hook extended to FA(3) doc kinds. **Reuses #1228. DEPENDS-ON the
+FA(3) XML persistence backend seam (§9).**
+
+**B6. Subiekt regulatory parity** — no extra FE work beyond ensuring the
+regulatory badge/section is provider-agnostic + capability-gated; it lights up
+for Subiekt once **#1230** (`getClearanceStatus`) ships.
+
+### Wave C — Backend-gated FE
+
+**C1. Re-issue / correction** — state-dependent affordance on panel + detail:
+`failed/pending → Retry` (existing mutation, controller-owned dedup); `issued →
+Issue correction` opening the **per-provider `invoiceCorrectionFlow` slot**
+(new slot, per-provider steps). **Reuses #1220 / reworks PR #1233. DEPENDS-ON
+the correction-trigger seam (#1151 KSeF KOR / #1229 Subiekt) + #1200.**
+
+**C2. Batch operations** — multi-select on `/invoices` → bulk issue/retry via
+`BulkActionBar`; neutral, capability-gated. **DEPENDS-ON a batch endpoint (§9);
+degrades to sequential per-row calls if absent.**
+
+**C3. With/without-tax-id list filter** — one filter control + URL param on
+`/invoices`. **DEPENDS-ON #1202 (backend denormalization).**
+
+**C4. (DROPPED — invoice-only scope).** Receipts are out of scope, so issuance
+is always an invoice; no document-type picker or per-provider doc-type config
+is needed. `getSupportedDocumentTypes()` still informs the (now fixed) "Invoice"
+label but drives no UI choice.
+
+### Implementation details
+- **New components**: invoice detail page, `invoice-timeline`,
+  `use-invoice-query`, `use-regulatory-document`, `plugins/ksef/*`, two new
+  plugin slots (`invoiceDetailSection`, `invoiceCorrectionFlow`), doc-type
+  config slot.
+- **Config changes**: none (no new env vars).
+- **Migrations**: none (FE only).
+- **Events**: none.
+- **Error handling**: `ApiError` normalization (existing); capability-disabled
+  discriminator via `CapabilityErrorBody` (existing); failure-code copy table.
+
+---
+
+## 7. Alternatives Considered
+
+- **Cienka baza, grube ekrany per-provider** (separate rich KSeF/Subiekt
+  panels): rejected — duplicates list/panel/detail per provider, risks
+  base↔provider drift, more code. Locked decision = thick neutral base.
+- **Supersede the in-flight KSeF FE PRs (close + recreate)**: rejected by user
+  — work not on main is reworked **in place** in its existing PR/branch;
+  minimizes new artifacts and preserves review history.
+- **Force-supersede re-issue (one button overwriting an issued doc)**:
+  rejected — fiscally unsound; corrections are the legal mechanism. Locked =
+  state-dependent Retry/Correction.
+- **Generic correction form for all providers**: rejected by user — per-
+  provider slot with integration-specific steps ("a form for everything = a
+  form for nothing").
+- **Event-sourced timeline**: rejected — needs a new backend events table;
+  static stepper chosen (core has no transition timestamps).
+
+---
+
+## 8. Validation & Risks
+
+- **Architecture compliance** ✅ — neutral base + `usePlatform` slots, no
+  `platformType` literals, FE dependency direction respected.
+- **Naming** ✅ — `kebab-case.tsx` files, `use-*.ts` hooks, `*.route.tsx`,
+  `*.test.tsx`; feature public barrel only.
+- **Risks**:
+  - *In-flight KSeF stack divergence* — PRs #1191/#1232–#1235 branched
+    pre-#1211; reworking them onto post-#1211 main is a rewrite, not a rebase.
+    Mitigation: rebase onto main, re-home onto `features/invoicing` +
+    `plugins/ksef`, salvage reviewed logic (Zod/NIP/iframe/object-URL).
+  - *Backend seams (D-Q1–4)* gate A5/B3/B5/C1–C3. Mitigation: each FE
+    affordance feature-gates and degrades gracefully when its seam is absent;
+    Wave A core ships without any seam.
+  - *Subiekt bridge endpoint mismatch* — blocks Subiekt E2E (not design).
+    Mitigation: verify/handoff to backend before live Subiekt testing.
+  - *`shared/plugins` feature-import allow-list* — adding `InvoiceRecord` to
+    the slot prop may require an ESLint allow-list edit or a `shared/types`
+    hoist (precedent exists). Mitigation: A0 handles it explicitly.
+- **Backward compatibility**: redesigned neutral components keep the same
+  public barrel exports; the new slot is additive (absent ⇒ no render).
+
+---
+
+## 9. Backend Seams to Hand Off (separate tasks — design FE to target contract)
+
+| Seam | Drives | Existing issue / status |
+|---|---|---|
+| `GET /invoices/:invoiceId` | A2 detail page | NEW (interim: `list`/`getForOrder`) |
+| Issued-document **content** projection (seller, buyer/recipient, line items, net/VAT/gross, dates, payment) | A2 detail "Invoice contents" card | NEW — **not on `InvoiceRecord`** (no buyer/lines columns); from the order-snapshot invoice projection (#1224) or the provider document (FA(3)/Subiekt). FE renders it behind this seam; degrades to order-sourced preview if absent. |
+| **Expose `status:'issuing'` + `failureMode` (`rejected`\|`in-doubt`) on the response DTO** | A1/A5 issuance state machine — the FE can't render the rejected-vs-in-doubt split (and therefore can't suppress the unsafe Retry) without these | #1200 / PR #1214 add the columns/logic; **the response DTO must surface them** (it currently exposes only `status` pending/issued/failed). Without it the FE treats every failure as in-doubt (fiscal-safe default) — degraded but correct. |
+| PII-free `failureCode` (+`failureReason`) on response DTO | A5 | NEW (may warrant a small backend ADR) |
+| Connection `status` (`needs_reauth`/`error`) on the connections read | A1 connection-health affordance | **EXISTS** — `ConnectionStatus` already carries these; FE just consumes `connection.status`. No new seam. |
+| Neutral `config.invoicing.triggerModel` on the connection (KSeF + Subiekt) | B1/B2 wizard trigger-model | **EXISTS** — #1120/#1206 read it generically for every invoicing connection; FE writes it on the KSeF wizard too. No new seam. |
+| UPO / `RegulatoryDocument` endpoint + order-snapshot projection | B3 | #1224 / PR #1231 (in flight — **keep**) |
+| FA(3) XML persistence + fetch | B5 | #1228 (backend half) |
+| Correction trigger (per provider) | C1 | #1151 (KSeF KOR), #1229 (Subiekt) — corrections cover quantity and price per line |
+| Exactly-once (re-issue safety) | C1 | #1200 / PR #1214 |
+| Batch issue/retry endpoint | C2 | NEW |
+| Tax-id denormalization on `invoice_records` | C3 | #1202 |
+| Subiekt `RegulatoryStatusReader.getClearanceStatus` | B6 | #1230 |
+| Subiekt bridge endpoint-path reconciliation | Subiekt E2E | verify (bridge repo) |
+
+---
+
+## 10. Testing Strategy & Acceptance Criteria
+
+- **Unit (Vitest + Testing Library)**, colocated `*.test.tsx`: redesigned
+  panel/list/detail render states; timeline per status combination;
+  failure-code copy resolution; `use-invoice-query`/`use-regulatory-document`
+  hooks; KSeF wizard schema validation + NIP normalization; slot resolution via
+  `usePlatform` (absent ⇒ no render). Mock the API client; never hit network.
+- **Route contract**: bump `EXPECTED_LAZY_ROUTE_COUNT`
+  (`route-lazy.test.ts`) + add `handle.crumb` (`route-handle.test.ts`) for the
+  detail route.
+- **Lint guard**: confirm zero `platformType` literals outside `plugins/`
+  (existing ESLint rule).
+- **Commands (scoped — never the full hook)**: `pnpm --filter @openlinker/web
+  lint && pnpm --filter @openlinker/web type-check && pnpm --filter
+  @openlinker/web test`.
+- **Acceptance**:
+  - [ ] All neutral screens bind only to core types; provider extras only via
+    slots; no `platformType` literals outside `plugins/`.
+  - [ ] KSeF affordances render exclusively through `plugins/ksef` slots +
+    capability gates; one `/invoices` page, one `OrderInvoicePanel`.
+  - [ ] Detail page, timeline, redesigned panel/list, batch select ship in A;
+    KSeF wizard/UPO/FA(3) in B; re-issue/correction/filters in C.
+  - [ ] Backend-gated affordances degrade gracefully when their seam is absent.
+  - [ ] **Fiscal-safety**: an `in-doubt` (or unknown) failure never exposes a
+    one-click Retry on panel, detail, or bulk; `issuing` is shown as a locked
+    in-flight state; Retry is gated on `failureMode === 'rejected'`.
+  - [ ] Clearance success renders as **`accepted`** (no `cleared` label for KSeF).
+  - [ ] Invoice detail renders **loading / not-found / error** page states; the
+    `/invoices` list shows a **connection/provider** column.
+  - [ ] `/frontend-design` design artifacts are in English.
+  - [ ] `apps/web` lint + type-check + test green.
+
+---
+
+## 11. Reconciliation & Delivery (PR strategy — no new issues)
+
+- **On `main` already (#1211 neutral base + Subiekt plugin)** → redesign in a
+  **NEW separate PR** (`feat(web): invoicing UI redesign — neutral base`).
+  Carries A0–A5 + C2–C4 neutral parts. Reuses no new issue (or attaches to an
+  existing umbrella if one is later designated).
+- **NOT on `main` (KSeF FE stack #1191/#1232–#1235 on branch
+  `1152-web-ksef-connection-upo`)** → rework the redesign **IN those existing
+  PRs/branch** (rebase onto post-#1211 main, re-home onto `features/invoicing`
+  + `plugins/ksef`). Carries B1–B5 + C1. Reuses issues
+  #1152/#1220/#1221/#1222/#1223/#1228.
+- **Keep** backend PR #1231 (#1224 UPO seam).
+- **No new GitHub issues** created for this program (user directive); **create
+  nothing yet** — this plan + `/frontend-design` first.
+
+---
+
+## 12. Alignment Checklist
+
+- [x] Frontend-only; respects `app→pages→features→shared` + neutral/slot split
+- [x] No `platformType` literals outside `plugins/` (capability-gated)
+- [x] Reuses existing slot/registry patterns (one additive slot per new need)
+- [x] Idempotency: re-issue is controller-owned dedup; correction is explicit
+- [x] Async UX states (loading/empty/error/success) on every screen
+- [x] Error handling: `ApiError` + sanitized failure-code copy
+- [x] Testing strategy scoped to `apps/web` (resource-constrained machine)
+- [x] Naming + file-structure conventions followed
+- [x] Backend seams enumerated + handed off; FE degrades gracefully
+- [x] `/frontend-design` output mandated in English
+- [x] Plan saved as markdown
+
+---
+
+## Related Documentation
+- `docs/architecture-overview.md` (Invoicing context, ADR-026 neutral core)
+- `docs/frontend-architecture.md` (plugin slots, `usePlatform`, dependency rules)
+- `docs/frontend-ui-style-guide.md` (visual vocabulary for `/frontend-design`)
+- `docs/engineering-standards.md` (naming, types, testing)

--- a/docs/plans/invoicing-ui-mockup.html
+++ b/docs/plans/invoicing-ui-mockup.html
@@ -1,0 +1,1350 @@
+<title>OpenLinker Invoicing — A1 Mockup</title>
+<style>
+/* ============================================================
+   OpenLinker design tokens — copied verbatim from
+   apps/web/src/index.css (light + dark). The redesign reshapes
+   the existing system; it invents no new palette or type.
+   ============================================================ */
+:root {
+  --font-sans: 'IBM Plex Sans', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+
+  --bg-canvas: oklch(99% 0.003 80);
+  --bg-shell: oklch(97.5% 0.004 80);
+  --bg-surface: #ffffff;
+  --bg-surface-elevated: oklch(99% 0.003 80);
+  --bg-surface-muted: oklch(96% 0.005 80);
+  --bg-surface-hover: oklch(93% 0.006 80);
+  --bg-strong: oklch(93% 0.006 80);
+
+  --border-subtle: oklch(93.5% 0.006 80);
+  --border-default: oklch(88% 0.008 80);
+  --border-strong: oklch(78% 0.010 80);
+
+  --text-primary: oklch(20% 0.012 80);
+  --text-secondary: oklch(38% 0.010 80);
+  --text-muted: oklch(52% 0.008 80);
+  --text-disabled: oklch(70% 0.005 80);
+  --text-on-primary: oklch(18% 0.012 50);
+  --text-link: oklch(50% 0.14 250);
+
+  --accent-primary: oklch(68% 0.18 50);
+  --accent-primary-hover: oklch(62% 0.19 50);
+  --accent-primary-active: oklch(56% 0.20 50);
+  --accent-primary-soft: oklch(96% 0.04 60);
+  --accent-primary-border: oklch(85% 0.10 55);
+  --accent-ring: oklch(68% 0.18 50 / 0.30);
+
+  --status-success: oklch(54% 0.14 150);
+  --status-success-soft: oklch(96% 0.04 150);
+  --status-success-border: oklch(85% 0.08 150);
+  --status-success-fg: oklch(36% 0.12 150);
+
+  --status-warning: oklch(72% 0.16 85);
+  --status-warning-soft: oklch(96% 0.05 85);
+  --status-warning-border: oklch(85% 0.10 85);
+  --status-warning-fg: oklch(42% 0.12 80);
+
+  --status-error: oklch(58% 0.20 25);
+  --status-error-soft: oklch(96% 0.04 25);
+  --status-error-border: oklch(85% 0.10 25);
+  --status-error-fg: oklch(42% 0.16 25);
+
+  --status-info: oklch(56% 0.14 245);
+  --status-info-soft: oklch(96% 0.03 245);
+  --status-info-border: oklch(85% 0.08 245);
+  --status-info-fg: oklch(40% 0.12 245);
+
+  --status-review: oklch(58% 0.16 290);
+  --status-review-soft: oklch(96% 0.04 290);
+  --status-review-border: oklch(85% 0.08 290);
+  --status-review-fg: oklch(42% 0.14 290);
+
+  --status-neutral: oklch(55% 0.008 80);
+  --status-neutral-soft: oklch(95% 0.005 80);
+  --status-neutral-border: oklch(85% 0.008 80);
+  --status-neutral-fg: oklch(38% 0.010 80);
+
+  --shadow-sm: 0 1px 2px rgb(15 18 26 / 0.04), 0 1px 3px rgb(15 18 26 / 0.06);
+  --shadow-md: 0 2px 4px rgb(15 18 26 / 0.04), 0 6px 16px rgb(15 18 26 / 0.08);
+  --shadow-focus: 0 0 0 3px var(--accent-ring);
+
+  --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem;
+  --space-5: 1.5rem; --space-6: 2rem; --space-7: 3rem; --space-8: 4rem;
+
+  --radius-xs: 4px; --radius-sm: 6px; --radius-md: 8px; --radius-lg: 10px;
+  --radius-xl: 14px; --radius-pill: 9999px;
+
+  --duration-fast: 120ms; --duration-normal: 180ms;
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --tracking-caps: 0.08em; --tracking-wide: 0.02em; --tracking-tight: -0.012em;
+}
+html[data-theme='dark'] {
+  --bg-canvas: oklch(14% 0.005 270);
+  --bg-shell: oklch(16% 0.006 270);
+  --bg-surface: oklch(19% 0.007 270);
+  --bg-surface-elevated: oklch(22% 0.008 270);
+  --bg-surface-muted: oklch(24% 0.009 270);
+  --bg-surface-hover: oklch(28% 0.010 270);
+  --bg-strong: oklch(28% 0.010 270);
+  --border-subtle: oklch(24% 0.010 270);
+  --border-default: oklch(30% 0.012 270);
+  --border-strong: oklch(42% 0.014 270);
+  --text-primary: oklch(96% 0.006 270);
+  --text-secondary: oklch(78% 0.010 270);
+  --text-muted: oklch(60% 0.012 270);
+  --text-disabled: oklch(42% 0.012 270);
+  --text-on-primary: oklch(16% 0.012 50);
+  --text-link: oklch(76% 0.14 245);
+  --accent-primary: oklch(72% 0.18 50);
+  --accent-primary-hover: oklch(78% 0.18 50);
+  --accent-primary-soft: oklch(28% 0.08 50);
+  --accent-primary-border: oklch(40% 0.14 55);
+  --accent-ring: oklch(72% 0.18 50 / 0.40);
+  --status-success: oklch(68% 0.16 150); --status-success-soft: oklch(26% 0.06 150); --status-success-border: oklch(36% 0.10 150); --status-success-fg: oklch(86% 0.14 150);
+  --status-warning: oklch(78% 0.16 85); --status-warning-soft: oklch(26% 0.06 85); --status-warning-border: oklch(36% 0.10 85); --status-warning-fg: oklch(88% 0.14 85);
+  --status-error: oklch(66% 0.20 25); --status-error-soft: oklch(26% 0.08 25); --status-error-border: oklch(38% 0.12 25); --status-error-fg: oklch(86% 0.14 25);
+  --status-info: oklch(68% 0.14 245); --status-info-soft: oklch(26% 0.06 245); --status-info-border: oklch(36% 0.10 245); --status-info-fg: oklch(86% 0.12 245);
+  --status-review: oklch(70% 0.15 290); --status-review-soft: oklch(26% 0.07 290); --status-review-border: oklch(36% 0.10 290); --status-review-fg: oklch(86% 0.13 290);
+  --status-neutral: oklch(60% 0.012 270); --status-neutral-soft: oklch(24% 0.009 270); --status-neutral-border: oklch(34% 0.012 270); --status-neutral-fg: oklch(78% 0.010 270);
+  --shadow-md: 0 2px 4px rgb(0 0 0 / 0.30), 0 6px 16px rgb(0 0 0 / 0.40);
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg-canvas);
+  color: var(--text-primary);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+.tabular { font-variant-numeric: tabular-nums; }
+.mono { font-family: var(--font-mono); }
+:focus-visible { outline: none; box-shadow: var(--shadow-focus); border-radius: var(--radius-xs); }
+
+/* ── Mockup chrome ─────────────────────────────────────────── */
+.chrome {
+  position: sticky; top: 0; z-index: 20;
+  display: flex; align-items: center; gap: var(--space-4);
+  flex-wrap: wrap;
+  padding: var(--space-3) var(--space-5);
+  background: var(--bg-shell);
+  border-bottom: 1px solid var(--border-default);
+}
+.chrome__brand { display: flex; align-items: center; gap: var(--space-2); font-weight: 600; letter-spacing: var(--tracking-tight); }
+.chrome__dot { width: 10px; height: 10px; border-radius: var(--radius-pill); background: var(--accent-primary); box-shadow: 0 0 0 3px var(--accent-primary-soft); }
+.chrome__tag { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); padding: 2px 8px; border: 1px solid var(--border-default); border-radius: var(--radius-pill); }
+.chrome__spacer { flex: 1; }
+
+.segmented { display: inline-flex; background: var(--bg-surface-muted); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: 3px; gap: 2px; }
+.segmented button {
+  font: inherit; font-size: 13px; font-weight: 500;
+  border: 0; background: transparent; color: var(--text-secondary);
+  padding: 6px 14px; border-radius: var(--radius-sm); cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out), color var(--duration-fast) var(--ease-out);
+}
+.segmented button:hover { color: var(--text-primary); }
+.segmented button[aria-pressed='true'] { background: var(--bg-surface); color: var(--text-primary); box-shadow: var(--shadow-sm); }
+
+.icon-toggle {
+  font: inherit; font-size: 13px; cursor: pointer;
+  background: var(--bg-surface); color: var(--text-secondary);
+  border: 1px solid var(--border-default); border-radius: var(--radius-sm);
+  padding: 6px 12px;
+}
+.icon-toggle:hover { background: var(--bg-surface-hover); }
+
+.stage { max-width: 1180px; margin: 0 auto; padding: var(--space-6) var(--space-5) var(--space-8); }
+.view { display: none; }
+.view.is-active { display: block; }
+
+/* ── Annotation note ───────────────────────────────────────── */
+.note {
+  display: flex; gap: var(--space-2); align-items: flex-start;
+  font-size: 12.5px; color: var(--text-secondary);
+  background: var(--accent-primary-soft); border: 1px solid var(--accent-primary-border);
+  border-radius: var(--radius-md); padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-5);
+}
+.note b { color: var(--text-primary); font-weight: 600; }
+.note__k { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--accent-primary-active, var(--accent-primary)); }
+
+/* ── Status badge (mono + caps + dot) ──────────────────────── */
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 500;
+  text-transform: uppercase; letter-spacing: var(--tracking-caps);
+  padding: 3px 9px 3px 7px; border-radius: var(--radius-pill);
+  border: 1px solid; white-space: nowrap;
+}
+.badge::before { content: ''; width: 6px; height: 6px; border-radius: var(--radius-pill); background: currentColor; flex: none; }
+.badge--neutral { color: var(--status-neutral-fg); background: var(--status-neutral-soft); border-color: var(--status-neutral-border); }
+.badge--warning { color: var(--status-warning-fg); background: var(--status-warning-soft); border-color: var(--status-warning-border); }
+.badge--success { color: var(--status-success-fg); background: var(--status-success-soft); border-color: var(--status-success-border); }
+.badge--error   { color: var(--status-error-fg);   background: var(--status-error-soft);   border-color: var(--status-error-border); }
+.badge--info    { color: var(--status-info-fg);    background: var(--status-info-soft);    border-color: var(--status-info-border); }
+.badge--review  { color: var(--status-review-fg);  background: var(--status-review-soft);  border-color: var(--status-review-border); }
+.badge--pulse::before { animation: pulse 1.6s var(--ease-out) infinite; }
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+/* ── Buttons ───────────────────────────────────────────────── */
+.btn {
+  font: inherit; font-size: 13px; font-weight: 500; cursor: pointer;
+  border-radius: var(--radius-sm); padding: 8px 14px; border: 1px solid transparent;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+.btn--primary { background: var(--accent-primary); color: var(--text-on-primary); }
+.btn--primary:hover { background: var(--accent-primary-hover); }
+.btn--secondary { background: var(--bg-surface); color: var(--text-primary); border-color: var(--border-default); }
+.btn--secondary:hover { background: var(--bg-surface-hover); }
+.btn--ghost { background: transparent; color: var(--text-secondary); }
+.btn--ghost:hover { background: var(--bg-surface-hover); color: var(--text-primary); }
+.btn--sm { font-size: 12px; padding: 5px 10px; }
+.btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Order-detail page (faithful to the real layout) ───────── */
+.op-eyebrow { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); }
+.op-title { margin: 4px 0 var(--space-5); font-size: 18px; letter-spacing: var(--tracking-tight); }
+.order-header { display: grid; gap: var(--space-2); margin-bottom: var(--space-4); }
+.order-header__top { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+.order-header__top h1 { margin: 0; font-size: 22px; letter-spacing: var(--tracking-tight); }
+.order-header__sub { display: flex; gap: var(--space-3); flex-wrap: wrap; align-items: center; font-size: 12.5px; color: var(--text-muted); }
+.order-route { display: inline-flex; align-items: center; gap: 8px; }
+.order-route__dot { width: 7px; height: 7px; border-radius: var(--radius-pill); background: var(--accent-primary); }
+.order-summary-line { display: flex; align-items: center; gap: var(--space-2); font-size: 13px; flex-wrap: wrap; }
+.thumb { width: 24px; height: 24px; border-radius: var(--radius-sm); background: var(--bg-surface-muted); border: 1px solid var(--border-default); display: grid; place-items: center; font-size: 11px; color: var(--text-muted); flex: none; }
+.order-health { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-3); margin: var(--space-4) 0 var(--space-5); }
+.order-health__cell { background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: var(--space-3) var(--space-4); }
+.order-health__k { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); }
+.order-health__v { font-size: 15px; font-weight: 600; margin-top: 2px; }
+.order-health__hint { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.detail-section { background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); padding: var(--space-4) var(--space-5); margin-bottom: var(--space-5); }
+.detail-section__title { margin: 0 0 var(--space-3); font-size: 13px; font-weight: 600; }
+.split-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); align-items: start; }
+@media (max-width: 900px) { .split-grid { grid-template-columns: 1fr; } .order-health { grid-template-columns: 1fr; } }
+.stack { display: grid; gap: var(--space-5); }
+.stack .detail-section, .stack .panel { margin-bottom: 0; }
+.lineitems { width: 100%; border-collapse: collapse; font-size: 13px; }
+.lineitems th { text-align: left; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); padding: 6px 8px; border-bottom: 1px solid var(--border-default); }
+.lineitems th.r, .lineitems td.r { text-align: right; }
+.lineitems td { padding: 8px; border-bottom: 1px solid var(--border-subtle); }
+.totals { margin-top: var(--space-3); display: grid; gap: 4px; max-width: 280px; margin-left: auto; font-size: 13px; }
+.totals__row { display: flex; justify-content: space-between; }
+.totals__row--total { border-top: 1px solid var(--border-default); padding-top: 6px; font-weight: 600; }
+.kvl { display: grid; grid-template-columns: max-content 1fr; gap: 8px var(--space-4); font-size: 13px; }
+.kvl dt { color: var(--text-muted); }
+.kvl dd { margin: 0; }
+.addr { line-height: 1.6; }
+/* In the order stack the invoice panel sits flush with sibling sections */
+.stack .panel__head { padding-top: var(--space-4); }
+
+/* ── Invoice panel (the redesigned OrderInvoicePanel) ──────── */
+.panel {
+  background: var(--bg-surface); border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); overflow: hidden;
+}
+.panel__head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-4) var(--space-4) var(--space-3); }
+.panel__title { margin: 0; font-size: 13px; font-weight: 600; }
+.panel__provider { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: var(--tracking-caps); }
+
+/* signature: dual-lifecycle rail */
+.rail { padding: 0 var(--space-4) var(--space-4); display: grid; gap: var(--space-3); }
+.rail__track { display: grid; grid-template-columns: auto 1fr; gap: var(--space-3); align-items: center; }
+.rail__lane-label { font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); width: 56px; }
+.rail__steps { display: flex; align-items: center; }
+.rail__step { display: flex; align-items: center; gap: 6px; flex: 1; }
+.rail__node { width: 11px; height: 11px; border-radius: var(--radius-pill); border: 2px solid var(--border-strong); background: var(--bg-surface); flex: none; }
+.rail__line { height: 2px; flex: 1; background: var(--border-default); }
+.rail__caption { font-size: 10px; color: var(--text-disabled); white-space: nowrap; }
+.rail__step--done .rail__node { background: var(--status-success); border-color: var(--status-success); }
+.rail__step--done .rail__caption { color: var(--text-secondary); }
+.rail__step--done .rail__line { background: var(--status-success); }
+.rail__step--active .rail__node { border-color: var(--accent-primary); background: var(--accent-primary); box-shadow: 0 0 0 3px var(--accent-primary-soft); }
+.rail__step--active .rail__caption { color: var(--text-primary); font-weight: 600; }
+.rail__step--error .rail__node { background: var(--status-error); border-color: var(--status-error); }
+.rail__step--error .rail__caption { color: var(--status-error-fg); font-weight: 600; }
+.rail--reg .rail__step--na .rail__node { border-style: dashed; }
+
+.panel__body { padding: var(--space-4); border-top: 1px solid var(--border-subtle); display: grid; gap: var(--space-3); }
+.kv { display: grid; grid-template-columns: 110px 1fr; gap: var(--space-2) var(--space-3); font-size: 13px; }
+.kv dt { color: var(--text-muted); }
+.kv dd { margin: 0; color: var(--text-primary); }
+.kv dd.mono { font-size: 12px; }
+.link { color: var(--text-link); text-decoration: none; font-weight: 500; }
+.link:hover { text-decoration: underline; }
+.link::after { content: ' ↗'; font-size: 0.85em; color: var(--text-muted); }
+.muted { color: var(--text-muted); }
+.dash { color: var(--text-disabled); }
+
+.panel__actions { padding: var(--space-4); border-top: 1px solid var(--border-subtle); display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+.field { display: grid; gap: 4px; }
+.field label { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: var(--tracking-caps); font-family: var(--font-mono); }
+.select, .input {
+  font: inherit; font-size: 13px; color: var(--text-primary);
+  background: var(--bg-surface); border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm); padding: 7px 10px; min-width: 150px;
+}
+.select:hover, .input:hover { border-color: var(--border-strong); }
+.spacer { flex: 1; }
+
+.inline-alert { display: flex; gap: var(--space-2); align-items: flex-start; font-size: 12.5px; border-radius: var(--radius-md); padding: var(--space-3); border: 1px solid; }
+.inline-alert--error { color: var(--status-error-fg); background: var(--status-error-soft); border-color: var(--status-error-border); }
+.inline-alert--warning { color: var(--status-warning-fg); background: var(--status-warning-soft); border-color: var(--status-warning-border); }
+.inline-alert__bar { width: 3px; border-radius: var(--radius-pill); background: currentColor; align-self: stretch; flex: none; }
+.notice { font-size: 12.5px; color: var(--text-muted); padding: var(--space-3) var(--space-4); }
+.skeleton { height: 14px; border-radius: var(--radius-xs); background: linear-gradient(90deg, var(--bg-surface-muted), var(--bg-surface-hover), var(--bg-surface-muted)); background-size: 200% 100%; animation: shimmer 1.4s linear infinite; }
+@keyframes shimmer { from { background-position: 200% 0; } to { background-position: -200% 0; } }
+
+/* panel state switcher */
+.state-bar { display: flex; gap: var(--space-2); flex-wrap: wrap; margin-bottom: var(--space-4); }
+.chip { font: inherit; font-size: 12px; cursor: pointer; padding: 5px 11px; border-radius: var(--radius-pill); border: 1px solid var(--border-default); background: var(--bg-surface); color: var(--text-secondary); }
+.chip[aria-pressed='true'] { background: var(--text-primary); color: var(--bg-surface); border-color: var(--text-primary); }
+.chip:hover:not([aria-pressed='true']) { background: var(--bg-surface-hover); }
+
+/* ── List page ─────────────────────────────────────────────── */
+.page-head { margin-bottom: var(--space-5); }
+.page-head__eyebrow { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); }
+.page-head h1 { margin: 4px 0 4px; font-size: 24px; letter-spacing: var(--tracking-tight); }
+.page-head p { margin: 0; color: var(--text-secondary); font-size: 14px; }
+
+.toolbar { display: flex; gap: var(--space-2); flex-wrap: wrap; align-items: flex-end; margin-bottom: var(--space-4); }
+.toolbar .field { gap: 3px; }
+.toolbar .spacer { flex: 1; min-width: 0; }
+
+.card { background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); overflow: hidden; }
+.table-wrap { overflow-x: auto; }
+table.dt { width: 100%; border-collapse: collapse; font-size: 13px; }
+.dt thead th {
+  text-align: left; font-family: var(--font-mono); font-size: 10.5px; font-weight: 500;
+  text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted);
+  padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-default);
+  background: var(--bg-surface-muted); white-space: nowrap;
+}
+.dt tbody td { padding: 10px var(--space-4); border-bottom: 1px solid var(--border-subtle); vertical-align: middle; }
+.dt tbody tr { cursor: pointer; transition: background var(--duration-fast) var(--ease-out); }
+.dt tbody tr:hover { background: var(--bg-surface-hover); }
+.dt tbody tr:last-child td { border-bottom: 0; }
+.cell-id { font-family: var(--font-mono); font-size: 12px; color: var(--text-secondary); }
+.cell-strong { font-weight: 500; }
+.cell-time { color: var(--text-muted); font-size: 12px; font-variant-numeric: tabular-nums; }
+.checkbox { width: 15px; height: 15px; accent-color: var(--accent-primary); cursor: pointer; }
+
+.pager { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) var(--space-4); border-top: 1px solid var(--border-subtle); font-size: 12.5px; color: var(--text-muted); }
+.pager__nav { display: flex; gap: var(--space-2); }
+
+/* bulk action bar */
+.bulkbar { display: none; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-4); background: var(--text-primary); color: var(--bg-surface); border-radius: var(--radius-md); margin-bottom: var(--space-3); }
+.bulkbar.is-on { display: flex; }
+.bulkbar__count { font-weight: 600; font-size: 13px; }
+.bulkbar .btn--secondary { background: transparent; color: var(--bg-surface); border-color: oklch(100% 0 0 / 0.25); }
+.bulkbar .btn--secondary:hover { background: oklch(100% 0 0 / 0.12); }
+
+/* feedback states */
+.feedback { display: grid; place-items: center; text-align: center; gap: var(--space-3); padding: var(--space-8) var(--space-5); }
+.feedback__glyph { width: 44px; height: 44px; border-radius: var(--radius-md); display: grid; place-items: center; background: var(--bg-surface-muted); border: 1px solid var(--border-default); color: var(--text-muted); font-size: 20px; }
+.feedback h3 { margin: 0; font-size: 15px; }
+.feedback p { margin: 0; max-width: 360px; color: var(--text-muted); font-size: 13px; }
+
+.list-state { display: none; }
+.list-state.is-active { display: block; }
+
+/* ── Invoice detail page (A2 + A3 timeline + A5 failure) ───── */
+.backlink { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; color: var(--text-muted); text-decoration: none; margin-bottom: var(--space-3); }
+.backlink:hover { color: var(--text-primary); }
+.detail-head { display: flex; align-items: flex-start; gap: var(--space-3); flex-wrap: wrap; margin-bottom: var(--space-5); }
+.detail-head__main { flex: 1; min-width: 0; }
+.detail-head__eyebrow { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); }
+.detail-head h1 { margin: 4px 0 6px; font-size: 22px; letter-spacing: var(--tracking-tight); font-family: var(--font-mono); }
+.detail-head__sub { font-size: 13px; color: var(--text-secondary); display: flex; gap: var(--space-3); flex-wrap: wrap; }
+.detail-head__badges { display: flex; gap: var(--space-2); align-items: center; }
+
+.detail-grid { display: grid; grid-template-columns: 1fr 320px; gap: var(--space-5); align-items: start; }
+@media (max-width: 900px) { .detail-grid { grid-template-columns: 1fr; } }
+.detail-col { display: grid; gap: var(--space-5); }
+.section-card { background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); overflow: hidden; }
+.section-card__head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle); }
+.section-card__head h3 { margin: 0; font-size: 13px; font-weight: 600; }
+.section-card__provider { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); border: 1px solid var(--border-default); border-radius: var(--radius-pill); padding: 2px 8px; }
+.section-card__body { padding: var(--space-4); }
+.kv-wide { display: grid; grid-template-columns: 140px 1fr; gap: var(--space-3) var(--space-4); font-size: 13px; }
+.kv-wide dt { color: var(--text-muted); }
+.kv-wide dd { margin: 0; }
+.copy-id { display: inline-flex; align-items: center; gap: 6px; }
+.copy-id button { font: inherit; font-size: 10px; cursor: pointer; border: 1px solid var(--border-default); background: var(--bg-surface); color: var(--text-muted); border-radius: var(--radius-xs); padding: 1px 6px; }
+.copy-id button:hover { background: var(--bg-surface-hover); color: var(--text-primary); }
+
+/* UPO / FA(3) provider slot */
+.slot-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) 0; border-bottom: 1px solid var(--border-subtle); }
+.slot-row:last-child { border-bottom: 0; }
+.slot-row__label { font-size: 13px; }
+.slot-row__hint { font-size: 11.5px; color: var(--text-muted); }
+.doc-preview { margin-top: var(--space-3); border: 1px solid var(--border-default); border-radius: var(--radius-md); background: var(--bg-surface-muted); height: 150px; display: grid; place-items: center; color: var(--text-disabled); font-size: 12px; position: relative; overflow: hidden; }
+.doc-preview__chip { position: absolute; top: 8px; left: 8px; font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-pill); padding: 2px 8px; }
+
+/* vertical timeline (A3) */
+.timeline { display: grid; gap: 0; padding: var(--space-2) var(--space-1); }
+.tl-item { display: grid; grid-template-columns: 22px 1fr; gap: var(--space-3); }
+.tl-rail { display: grid; justify-items: center; }
+.tl-node { width: 12px; height: 12px; border-radius: var(--radius-pill); border: 2px solid var(--border-strong); background: var(--bg-surface); margin-top: 2px; flex: none; }
+.tl-line { width: 2px; flex: 1; background: var(--border-default); min-height: 18px; }
+.tl-body { padding-bottom: var(--space-4); }
+.tl-title { font-size: 13px; font-weight: 500; }
+.tl-time { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+.tl-note { font-size: 12px; color: var(--text-muted); }
+.tl-item--done .tl-node { background: var(--status-success); border-color: var(--status-success); }
+.tl-item--done .tl-line { background: var(--status-success); }
+.tl-item--active .tl-node { border-color: var(--accent-primary); background: var(--accent-primary); box-shadow: 0 0 0 3px var(--accent-primary-soft); }
+.tl-item--active .tl-title { font-weight: 600; }
+.tl-item--error .tl-node { background: var(--status-error); border-color: var(--status-error); }
+.tl-item--error .tl-title { color: var(--status-error-fg); }
+.tl-item--pending .tl-node { border-color: var(--status-warning); border-style: dashed; }
+.tl-item--pending .tl-title { color: var(--text-muted); }
+.tl-lane-head { font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); margin: var(--space-2) 0 var(--space-1) 34px; }
+
+.action-stack { display: grid; gap: var(--space-2); }
+.action-stack .btn { justify-content: center; }
+.action-hint { font-size: 11.5px; color: var(--text-muted); text-align: center; }
+
+/* invoice contents (the document as written) */
+.parties { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); margin-bottom: var(--space-4); }
+@media (max-width: 560px) { .parties { grid-template-columns: 1fr; } }
+.party__label { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); margin-bottom: 4px; }
+.party__name { font-weight: 600; font-size: 13px; }
+.party__line { font-size: 12.5px; color: var(--text-secondary); }
+.party__nip { font-family: var(--font-mono); font-size: 12px; color: var(--text-secondary); }
+.inv-meta { display: flex; gap: var(--space-5); flex-wrap: wrap; font-size: 12.5px; margin-bottom: var(--space-4); }
+.inv-meta div span { color: var(--text-muted); }
+.lines-inv th, .lines-inv td { white-space: nowrap; }
+.lines-inv td:nth-child(2) { white-space: normal; }
+.vat-breakdown { margin-top: var(--space-4); margin-left: auto; max-width: 380px; width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.vat-breakdown th, .vat-breakdown td { padding: 6px 8px; text-align: right; border-bottom: 1px solid var(--border-subtle); font-variant-numeric: tabular-nums; }
+.vat-breakdown th:first-child, .vat-breakdown td:first-child { text-align: left; }
+.vat-breakdown thead th { font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); }
+.vat-breakdown tfoot td { font-weight: 600; border-top: 1px solid var(--border-default); border-bottom: 0; }
+.seam-tag { font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--status-warning-fg); background: var(--status-warning-soft); border: 1px solid var(--status-warning-border); border-radius: var(--radius-pill); padding: 2px 8px; }
+
+/* caveat note (warning-toned) */
+.note--warn { background: var(--status-warning-soft); border-color: var(--status-warning-border); }
+.note--warn .note__k { color: var(--status-warning-fg); }
+
+/* ── Connection setup wizard (Wave B) ──────────────────────── */
+.wizard { max-width: 660px; }
+.wizard__step { margin-bottom: var(--space-5); }
+.wizard__step-title { display: flex; align-items: center; gap: var(--space-2); font-size: 13px; font-weight: 600; margin-bottom: var(--space-3); }
+.wizard__num { width: 20px; height: 20px; border-radius: var(--radius-pill); background: var(--accent-primary-soft); color: var(--accent-primary-active); border: 1px solid var(--accent-primary-border); display: grid; place-items: center; font-family: var(--font-mono); font-size: 11px; flex: none; }
+.form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3) var(--space-4); }
+@media (max-width: 560px) { .form-grid { grid-template-columns: 1fr; } }
+.form-grid .field--full { grid-column: 1 / -1; }
+.field .input, .field .select { width: 100%; }
+.field__hint { font-size: 11px; color: var(--text-muted); }
+.field__lockhint { font-size: 11px; color: var(--text-muted); display: inline-flex; gap: 4px; align-items: center; }
+.toggle-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) 0; border-top: 1px solid var(--border-subtle); }
+.toggle-row__text { font-size: 13px; }
+.toggle-row__text small { display: block; color: var(--text-muted); font-size: 11.5px; }
+.switch { width: 38px; height: 22px; border-radius: var(--radius-pill); background: var(--bg-strong); border: 1px solid var(--border-default); position: relative; cursor: pointer; flex: none; padding: 0; }
+.switch::after { content: ''; position: absolute; top: 2px; left: 2px; width: 16px; height: 16px; border-radius: var(--radius-pill); background: var(--bg-surface); box-shadow: var(--shadow-sm); transition: left var(--duration-fast) var(--ease-out); }
+.switch[aria-checked='true'] { background: var(--accent-primary); border-color: var(--accent-primary); }
+.switch[aria-checked='true']::after { left: 18px; }
+.wizard__actions { display: flex; gap: var(--space-2); justify-content: flex-end; margin-top: var(--space-5); padding-top: var(--space-4); border-top: 1px solid var(--border-subtle); }
+.wizard__actions .spacer { flex: 1; }
+.disabled-opt { color: var(--text-disabled); }
+
+/* ── Correction flow (Wave C, per-provider slot) ───────────── */
+.corr { max-width: 720px; }
+.corr__orig { display: flex; gap: var(--space-4); flex-wrap: wrap; font-size: 12.5px; color: var(--text-secondary); margin-bottom: var(--space-4); padding: var(--space-3); background: var(--bg-surface-muted); border-radius: var(--radius-md); }
+.corr__orig b { color: var(--text-primary); }
+.input--num { width: 84px; text-align: right; min-width: 0; }
+.corr-note { font-size: 12px; color: var(--text-muted); margin-top: var(--space-3); }
+.textarea { font: inherit; font-size: 13px; width: 100%; min-height: 64px; resize: vertical; color: var(--text-primary); background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-sm); padding: 8px 10px; }
+.textarea:hover { border-color: var(--border-strong); }
+
+/* ── Bulk confirm modal + result banner (Wave C) ───────────── */
+.modal-scrim { position: fixed; inset: 0; background: rgb(15 18 26 / 0.45); display: none; align-items: center; justify-content: center; padding: var(--space-4); z-index: 50; }
+.modal-scrim.is-open { display: flex; }
+.modal { background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-lg); box-shadow: 0 24px 48px rgb(15 18 26 / 0.22), 0 8px 16px rgb(15 18 26 / 0.12); max-width: 420px; width: 100%; overflow: hidden; }
+.modal__head { padding: var(--space-4) var(--space-4) 0; }
+.modal__head h3 { margin: 0; font-size: 15px; }
+.modal__body { padding: var(--space-3) var(--space-4); color: var(--text-secondary); font-size: 13px; }
+.modal__foot { display: flex; gap: var(--space-2); justify-content: flex-end; padding: var(--space-3) var(--space-4) var(--space-4); }
+.result-banner { display: flex; align-items: center; gap: var(--space-2); padding: var(--space-3) var(--space-4); border-radius: var(--radius-md); border: 1px solid; margin-bottom: var(--space-3); font-size: 13px; }
+.result-banner--success { background: var(--status-success-soft); border-color: var(--status-success-border); color: var(--status-success-fg); }
+.result-banner__dismiss { margin-left: auto; }
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}
+.legend { margin-top: var(--space-6); font-size: 12px; color: var(--text-muted); border-top: 1px solid var(--border-subtle); padding-top: var(--space-4); display: grid; gap: var(--space-2); }
+.legend code { font-family: var(--font-mono); background: var(--bg-surface-muted); padding: 1px 5px; border-radius: var(--radius-xs); font-size: 11px; }
+</style>
+
+<div class="chrome">
+  <span class="chrome__brand"><span class="chrome__dot"></span> OpenLinker</span>
+  <span class="chrome__tag">Invoicing · A1 redesign</span>
+  <div class="chrome__spacer"></div>
+  <div class="segmented" role="tablist" aria-label="Mockup view">
+    <button role="tab" aria-pressed="true" data-view="panel">Order panel</button>
+    <button role="tab" aria-pressed="false" data-view="list">Invoices list</button>
+    <button role="tab" aria-pressed="false" data-view="detail">Invoice detail</button>
+    <button role="tab" aria-pressed="false" data-view="setup">Connection setup</button>
+    <button role="tab" aria-pressed="false" data-view="correction">Correction</button>
+  </div>
+  <button class="icon-toggle" id="theme">Dark</button>
+</div>
+
+<div class="stage">
+
+  <!-- ================= VIEW 1: ORDER PANEL ================= -->
+  <section class="view is-active" data-view="panel">
+    <div class="note note--warn">
+      <span class="note__k">Not 1:1</span>
+      <span>This order page is <b>not a pixel-faithful copy</b> of OpenLinker's real order detail — it only sets the context. <b>Focus on the Invoice card</b> (and its placement); the surrounding sections are approximations.</span>
+    </div>
+    <div class="note">
+      <span class="note__k">A1 · panel in context</span>
+      <span>The <b>Invoice card sits in the right column, directly under Delivery</b> — its real place in the order-detail layout (full-width Pricing on top, then the Summary/Sync · Delivery/Invoice/Customer split). Switch the invoice state below to preview each case.</span>
+    </div>
+
+    <div class="state-bar" role="group" aria-label="Preview connection">
+      <button class="chip" aria-pressed="true"  data-pprov="ksef">KSeF</button>
+      <button class="chip" aria-pressed="false" data-pprov="subiekt">Subiekt</button>
+    </div>
+    <div class="state-bar" role="group" aria-label="Preview invoice state">
+      <button class="chip" aria-pressed="false" data-state="not-issued">Not issued</button>
+      <button class="chip" aria-pressed="true"  data-state="pending">Pending</button>
+      <button class="chip" aria-pressed="false" data-state="issuing">Issuing</button>
+      <button class="chip" aria-pressed="false" data-state="issued">Issued</button>
+      <button class="chip" aria-pressed="false" data-state="failed">Failed · rejected</button>
+      <button class="chip" aria-pressed="false" data-state="in-doubt">Failed · in-doubt</button>
+      <button class="chip" aria-pressed="false" data-state="needs-reauth">Needs re-auth</button>
+      <button class="chip" aria-pressed="false" data-state="multi">Multiple connections</button>
+    </div>
+
+    <a class="backlink" href="#" onclick="return false">← Orders</a>
+    <div class="op-eyebrow">Orders</div>
+    <h2 class="op-title">Order detail</h2>
+
+    <header class="order-header">
+      <div class="order-header__top">
+        <h1>Order DIAYIGRWL</h1>
+        <span class="badge badge--neutral">Processing</span>
+        <span class="badge badge--success">Shipped</span>
+      </div>
+      <div class="order-header__sub">
+        <span class="mono">ol_order_0918…a6a</span>
+        <span class="order-route"><span class="order-route__dot"></span> presta <span aria-hidden="true">→</span> <span class="muted">PrestaShop</span></span>
+        <span>Placed <span class="mono tabular">Jun 25, 2026, 2:21 AM</span></span>
+      </div>
+      <div class="order-summary-line"><span class="thumb">O</span> <strong>1 item · 1 unit</strong> <span class="muted">—</span> <a class="link" href="#" onclick="return false">OL-MUG-LIN-300</a> <span class="muted">·</span> <span class="mono tabular">€56.00</span></div>
+    </header>
+
+    <div class="order-health" role="group" aria-label="Order health">
+      <div class="order-health__cell"><div class="order-health__k">Sync</div><div class="order-health__v">Synced</div><div class="order-health__hint">PrestaShop · order #171</div></div>
+      <div class="order-health__cell"><div class="order-health__k">Fulfillment</div><div class="order-health__v">Shipped</div><div class="order-health__hint">InPost · tracking active</div></div>
+      <div class="order-health__cell"><div class="order-health__k">Total</div><div class="order-health__v mono tabular">€56.00</div><div class="order-health__hint">1 item · source-priced</div></div>
+    </div>
+
+    <div class="detail-section">
+      <h3 class="detail-section__title">Pricing &amp; tax</h3>
+      <table class="lineitems">
+        <thead><tr><th>Product</th><th class="r">Qty</th><th class="r">Unit price</th><th class="r">Total</th></tr></thead>
+        <tbody><tr>
+          <td><span style="display:inline-flex;gap:8px;align-items:center"><span class="thumb">O</span><span class="mono" style="font-size:12px">OL-MUG-LIN-300</span></span></td>
+          <td class="r tabular">1</td><td class="r mono tabular">€49.00</td><td class="r mono tabular">€49.00</td>
+        </tr></tbody>
+      </table>
+      <div class="totals">
+        <div class="totals__row"><span>Subtotal</span><span class="mono tabular">€49.00</span></div>
+        <div class="totals__row"><span>Shipping</span><span class="mono tabular">€7.00</span></div>
+        <div class="totals__row totals__row--total"><span>Total</span><span class="mono tabular">€56.00</span></div>
+      </div>
+    </div>
+
+    <div class="split-grid">
+      <div class="stack">
+        <div class="detail-section"><h3 class="detail-section__title">Summary</h3>
+          <dl class="kvl"><dt>Order #</dt><dd class="mono">DIAYIGRWL</dd><dt>Status</dt><dd>Processing</dd><dt>Source</dt><dd>presta</dd><dt>Placed</dt><dd>Jun 25, 2026, 2:21 AM</dd><dt>Received (OL)</dt><dd>Jun 25, 2026, 11:26 AM</dd></dl></div>
+        <div class="detail-section"><h3 class="detail-section__title">Sync status</h3>
+          <p class="muted" style="font-size:13px;margin:0">Synced to PrestaShop · order #171. Idempotent create — a retry won’t double-create.</p></div>
+      </div>
+      <div class="stack">
+        <div class="detail-section"><h3 class="detail-section__title">Delivery</h3>
+          <dl class="kvl"><dt>Ship to</dt><dd class="addr">Jan Kowalski<br>Testowa 21/2<br>11-234 Warszawa<br>PL</dd><dt>Carrier</dt><dd>InPost — Paczkomat</dd></dl></div>
+
+        <!-- INVOICE PANEL — right column, directly under Delivery (the corrected placement) -->
+        <div class="panel" id="panel"><!-- filled by JS --></div>
+
+        <div class="detail-section"><h3 class="detail-section__title">Customer</h3>
+          <dl class="kvl"><dt>Name</dt><dd>Jan Kowalski</dd><dt>Email</dt><dd class="mono" style="font-size:12px">jan.kowalski@example.pl</dd></dl></div>
+      </div>
+    </div>
+
+    <div class="detail-section"><h3 class="detail-section__title">Activity</h3>
+      <p class="muted" style="font-size:13px;margin:0">Order received · system · ingest — Jun 25, 2026, 11:26 AM</p></div>
+
+    <div class="legend">
+      <div><b>Placement.</b> The Invoice card lives in the right stack between <b>Delivery</b> and <b>Customer</b>, matching the live order-detail DOM — not a separate sidebar.</div>
+      <div><b>States.</b> <code>not-issued</code> → Issue. <code>pending</code> → pulsing dot, no action. <code>issued</code> → number + clearance + slot extras. <code>failed</code> → directive error + Retry. <code>multiple connections</code> → the picker chooses <b>where to issue</b> (pre-issuance only); once issued, the order locks to that connection and the picker is gone — no accidental duplicate on the wrong one.</div>
+    </div>
+  </section>
+
+  <!-- ================= VIEW 2: INVOICES LIST ================= -->
+  <section class="view" data-view="list">
+    <div class="note">
+      <span class="note__k">A1 · list</span>
+      <span><b>/invoices</b> — every issued document across connections. Filters live in the URL; the table surfaces both lifecycles per row. Select rows to act in bulk. Toggle empty / error below to preview those states.</span>
+    </div>
+
+    <div class="state-bar" role="group" aria-label="Preview list state">
+      <button class="chip" aria-pressed="true"  data-list="data">With data</button>
+      <button class="chip" aria-pressed="false" data-list="empty">Empty</button>
+      <button class="chip" aria-pressed="false" data-list="error">Error</button>
+    </div>
+
+    <div class="page-head">
+      <div class="page-head__eyebrow">Invoicing</div>
+      <h1>Invoices</h1>
+      <p>Fiscal documents issued for your orders, with their marketplace clearance status.</p>
+    </div>
+
+    <div class="toolbar">
+      <div class="field"><label for="f-status">Status</label>
+        <select class="select" id="f-status"><option>All statuses</option><option>Pending</option><option>Issued</option><option>Failed</option></select></div>
+      <div class="field"><label for="f-reg">Clearance</label>
+        <select class="select" id="f-reg"><option>All clearance</option><option>Submitted</option><option>Cleared</option><option>Accepted</option><option>Rejected</option><option>Not applicable</option></select></div>
+      <div class="field"><label for="f-conn">Connection</label>
+        <select class="select" id="f-conn"><option>All connections</option><option>KSeF (production)</option><option>Subiekt nexo</option></select></div>
+      <div class="field"><label for="f-from">Issued from</label><input class="input" id="f-from" type="date"></div>
+      <div class="field"><label for="f-to">Issued to</label><input class="input" id="f-to" type="date"></div>
+      <div class="field"><label for="f-taxid">Buyer tax ID</label>
+        <select class="select" id="f-taxid" title="Needs buyer tax-id denormalized onto invoice records (#1202)"><option>Any</option><option>With tax ID</option><option>Without tax ID</option></select></div>
+      <div class="spacer"></div>
+      <button class="btn btn--ghost btn--sm" id="clear-filters">Clear filters</button>
+    </div>
+
+    <!-- DATA state -->
+    <div class="list-state is-active" data-list="data">
+      <div id="bulk-result"></div>
+      <div class="bulkbar" id="bulkbar">
+        <span class="bulkbar__count" id="bulk-count">2 selected</span>
+        <div class="spacer"></div>
+        <button class="btn btn--secondary btn--sm" id="bulk-retry">Retry issuing</button>
+        <button class="btn btn--secondary btn--sm" id="bulk-clear">Clear selection</button>
+      </div>
+      <div class="card">
+        <div class="table-wrap">
+          <table class="dt">
+            <thead><tr>
+              <th style="width:36px"><input class="checkbox" type="checkbox" id="check-all" aria-label="Select all"></th>
+              <th>Order</th><th>Connection</th><th>Document</th><th>Number</th><th>Status</th><th>Clearance</th><th>Issued</th><th style="width:80px"></th>
+            </tr></thead>
+            <tbody id="rows"><!-- filled by JS --></tbody>
+          </table>
+        </div>
+        <div class="pager">
+          <span>Showing <span class="tabular">1–7</span> of <span class="tabular">143</span></span>
+          <div class="pager__nav">
+            <button class="btn btn--secondary btn--sm" disabled>Previous</button>
+            <button class="btn btn--secondary btn--sm">Next</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- EMPTY state -->
+    <div class="list-state" data-list="empty">
+      <div class="card"><div class="feedback">
+        <div class="feedback__glyph">⌷</div>
+        <h3>No invoices yet</h3>
+        <p>When you issue an invoice from an order, it shows up here. Open a shipped order to issue its first document.</p>
+        <button class="btn btn--primary btn--sm">Go to orders</button>
+      </div></div>
+    </div>
+
+    <!-- ERROR state -->
+    <div class="list-state" data-list="error">
+      <div class="card"><div class="feedback">
+        <div class="feedback__glyph" style="color:var(--status-error-fg)">!</div>
+        <h3>Couldn’t load invoices</h3>
+        <p>The request didn’t complete. Check your connection and try again — your filters are kept.</p>
+        <button class="btn btn--secondary btn--sm">Try again</button>
+      </div></div>
+    </div>
+
+    <div class="modal-scrim" id="bulk-modal" role="dialog" aria-modal="true" aria-label="Confirm retry">
+      <div class="modal">
+        <div class="modal__head"><h3>Retry issuing?</h3></div>
+        <div class="modal__body">This re-attempts issuing for the <b>rejected</b> invoices in your selection (<b><span id="bulk-modal-count">0</span></b> selected). Already-issued and <b>in-doubt</b> invoices are skipped — in-doubt ones need manual review first, so nothing is duplicated.</div>
+        <div class="modal__foot"><button class="btn btn--secondary btn--sm" onclick="closeBulkModal()">Cancel</button><button class="btn btn--primary btn--sm" onclick="confirmBulk()">Retry issuing</button></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= VIEW 3: INVOICE DETAIL ================= -->
+  <section class="view" data-view="detail">
+    <div class="note">
+      <span class="note__k">A2 · detail · A3 timeline · A5 failure</span>
+      <span><b>Invoice detail</b> (<code>/invoices/:id</code>). One neutral shell; the per-provider <code>invoiceDetailSection</code> slot changes the regulatory region. <b>KSeF</b> transmits to the authority itself → it owns the UPO + FA(3) document. <b>Subiekt</b> transmits to KSeF natively → OpenLinker only <b>reads</b> the status (needs #1230) and links the PDF Subiekt renders. Switch provider and state below.</span>
+    </div>
+
+    <div class="state-bar" role="group" aria-label="Preview provider">
+      <button class="chip" aria-pressed="true"  data-prov="ksef">KSeF</button>
+      <button class="chip" aria-pressed="false" data-prov="subiekt">Subiekt</button>
+    </div>
+    <div class="state-bar" role="group" aria-label="Preview detail state">
+      <button class="chip" aria-pressed="true"  data-detail="issued">Issued</button>
+      <button class="chip" aria-pressed="false" data-detail="pending">Pending</button>
+      <button class="chip" aria-pressed="false" data-detail="failed">Failed · rejected</button>
+      <button class="chip" aria-pressed="false" data-detail="in-doubt">Failed · in-doubt</button>
+    </div>
+    <div class="state-bar" role="group" aria-label="Preview page load state">
+      <button class="chip" aria-pressed="true"  data-detailpage="loaded">Loaded</button>
+      <button class="chip" aria-pressed="false" data-detailpage="loading">Loading</button>
+      <button class="chip" aria-pressed="false" data-detailpage="notfound">Not found</button>
+      <button class="chip" aria-pressed="false" data-detailpage="error">Error</button>
+    </div>
+
+    <a class="backlink" href="#" onclick="return false">← Invoices</a>
+    <div id="detail"><!-- filled by JS --></div>
+  </section>
+
+  <!-- ================= VIEW 4: CONNECTION SETUP ================= -->
+  <section class="view" data-view="setup">
+    <div class="note">
+      <span class="note__k">B · connection setup</span>
+      <span>Two separate invoicing connections behind the same <code>setupCard</code> + <code>StructuredConfigSection</code> + <code>CredentialsPanel</code> slots. To <b>connect</b> KSeF you only need an environment + auth (token) — that authorises your KSeF mailbox. The <b>seller details</b> print on invoices (the issuer block) and aren’t fetched from KSeF, so they’re collected separately and needed before your first issue. <b>Subiekt</b> is an <b>invoicing-only</b> connection (your store/warehouse stays PrestaShop, Allegro, …) and gets its seller details from Subiekt itself.</span>
+    </div>
+
+    <div class="state-bar" role="group" aria-label="Choose connection to set up">
+      <button class="chip" aria-pressed="true"  data-setupprov="ksef">KSeF</button>
+      <button class="chip" aria-pressed="false" data-setupprov="subiekt">Subiekt</button>
+    </div>
+
+    <a class="backlink" href="#" onclick="return false">← Connections</a>
+    <div class="op-eyebrow">Connections · New</div>
+    <h2 class="op-title" id="setup-title">Connect KSeF</h2>
+
+    <div class="detail-section"><div id="setup-wizard" class="wizard"><!-- filled by JS --></div></div>
+  </section>
+
+  <!-- ================= VIEW 5: CORRECTION ================= -->
+  <section class="view" data-view="correction">
+    <div class="note">
+      <span class="note__k">C · correction (per-provider slot)</span>
+      <span>Launched from <b>Issue correction</b> on an issued invoice. The form is a <b>per-provider slot</b> — KSeF emits a <b>KOR</b> (corrected line state + reason, linked to the original KSeF number); Subiekt issues a correcting document by <b>adjusted quantities</b> + reason. Different steps per integration, by design.</span>
+    </div>
+
+    <div class="state-bar" role="group" aria-label="Choose provider">
+      <button class="chip" aria-pressed="true"  data-corrprov="ksef">KSeF (KOR)</button>
+      <button class="chip" aria-pressed="false" data-corrprov="subiekt">Subiekt</button>
+    </div>
+
+    <div class="detail-section corr"><div id="corr"><!-- filled by JS --></div></div>
+  </section>
+</div>
+
+<script>
+/* ---------- view switch ---------- */
+const tabs = document.querySelectorAll('.segmented [data-view]');
+const views = document.querySelectorAll('.view[data-view]');
+tabs.forEach(t => t.addEventListener('click', () => {
+  tabs.forEach(x => x.setAttribute('aria-pressed', String(x === t)));
+  views.forEach(v => v.classList.toggle('is-active', v.dataset.view === t.dataset.view));
+}));
+
+/* ---------- theme ---------- */
+const themeBtn = document.getElementById('theme');
+themeBtn.addEventListener('click', () => {
+  const dark = document.documentElement.getAttribute('data-theme') === 'dark';
+  document.documentElement.setAttribute('data-theme', dark ? 'light' : 'dark');
+  themeBtn.textContent = dark ? 'Dark' : 'Light';
+});
+
+/* ---------- panel states ---------- */
+function railHTML(issuance, reg) {
+  // issuance lane: not-issued | pending | issued ; reg lane: na | submitted | cleared
+  const iSteps = [
+    { key: 'created', cap: 'Created' },
+    { key: 'pending', cap: 'Pending' },
+    { key: 'issued',  cap: 'Issued' },
+  ];
+  const rSteps = [
+    { key: 'submitted', cap: 'Submitted' },
+    { key: 'accepted',  cap: 'Accepted' },
+  ];
+  const iRank = { 'not-issued': 0, pending: 1, issuing: 1, issued: 2, failed: 1, 'in-doubt': 1 }[issuance];
+  const issuanceErrored = issuance === 'failed' || issuance === 'in-doubt';
+  // `isComplete` → the current step is a reached terminal (issued / accepted),
+  // so it renders green (done) not orange (active). Orange/active is reserved
+  // for steps that are genuinely in progress (pending / issuing / submitted).
+  const lane = (steps, rank, isError, errIdx, isComplete) => steps.map((s, idx) => {
+    let cls = '';
+    if (isError && idx === errIdx) cls = 'rail__step--error';
+    else if (idx < rank) cls = 'rail__step--done';
+    else if (idx === rank) cls = isComplete ? 'rail__step--done' : 'rail__step--active';
+    const line = idx < steps.length - 1 ? '<span class="rail__line"></span>' : '';
+    return `<span class="rail__step ${cls}"><span class="rail__node"></span><span class="rail__caption">${s.cap}</span>${line}</span>`;
+  }).join('');
+
+  const regRank = { na: -1, submitted: 0, cleared: 1, accepted: 1 }[reg];
+  const regLane = reg === 'na'
+    ? `<span class="rail__step rail__step--na"><span class="rail__node"></span><span class="rail__caption muted">Not applicable</span></span>`
+    : lane(rSteps, regRank, false, -1, reg === 'accepted' || reg === 'cleared');
+
+  return `
+    <div class="rail__track"><span class="rail__lane-label">Issuance</span>
+      <span class="rail__steps">${lane(iSteps, iRank, issuanceErrored, 1, issuance === 'issued')}</span></div>
+    <div class="rail__track rail--reg"><span class="rail__lane-label">Clearance</span>
+      <span class="rail__steps">${regLane}</span></div>`;
+}
+
+const slotKsef = `
+  <div class="kv">
+    <dt>KSeF number</dt><dd class="mono">5260001246-20260625-A1B2C3D4E5F6-7K</dd>
+    <dt>UPO</dt><dd><a class="link" href="#" onclick="return false">Download receipt</a></dd>
+  </div>`;
+
+/* Per-connection config the order panel reads. KSeF and Subiekt are SEPARATE
+   connections — different document types, numbers, clearance vocab, and
+   detail-slot extras. The card differs by connection, not just copy. */
+const pProv = {
+  ksef: {
+    name: 'KSeF', label: 'KSeF (production)', issuedNumber: 'FV/2026/06/0142',
+    clearanceKey: 'accepted', clearanceBadge: '<span class="badge badge--success">KSeF · accepted</span>',
+    docOptions: '<option>Invoice (faktura)</option>',
+    reject: 'The provider rejected the buyer’s tax ID. Check the NIP on the order’s customer, then retry. Nothing was issued.',
+    slot: `
+      <div class="kv">
+        <dt>KSeF number</dt><dd class="mono" style="font-size:12px">5260001246-20260625-A1B2…7K</dd>
+        <dt>UPO</dt><dd><a class="link" href="#" onclick="return false">Download receipt</a></dd>
+        <dt>FA(3)</dt><dd><a class="link" href="#" onclick="return false">View document</a></dd>
+      </div>`,
+  },
+  subiekt: {
+    name: 'Subiekt', label: 'Subiekt nexo', issuedNumber: 'FS 171/CENTRALA/2026',
+    clearanceKey: 'accepted', clearanceBadge: '<span class="badge badge--success">KSeF · accepted</span>',
+    docOptions: '<option>Invoice (faktura)</option><option>Receipt (paragon)</option>',
+    reject: 'Subiekt rejected the document. Check the order’s data, then retry. Nothing was issued.',
+    slot: `
+      <div class="kv">
+        <dt>KSeF status</dt><dd><span class="badge badge--success">KSeF · accepted</span> <span class="muted" style="font-size:11px">read from Subiekt</span></dd>
+        <dt>Invoice PDF</dt><dd><a class="link" href="#" onclick="return false">Download PDF</a></dd>
+      </div>
+      <p class="muted" style="font-size:11px;margin:6px 0 0">Clearance tracking lights up once the Subiekt status read ships (#1230). Until then a Subiekt invoice issues but shows no KSeF status here.</p>`,
+  },
+};
+
+const PANEL = {
+  'not-issued': (P) => `
+    <div class="panel__head"><div style="display:flex;align-items:center;gap:8px"><h3 class="panel__title">Invoice</h3><span class="panel__provider">${P.name}</span></div><span class="badge badge--neutral">Not issued</span></div>
+    <div class="rail">${railHTML('not-issued','na')}</div>
+    <div class="panel__actions">
+      <span class="muted" style="font-size:11.5px">Issues a structured VAT invoice (faktura).</span>
+      <div class="spacer"></div>
+      <button class="btn btn--primary">Issue invoice</button>
+    </div>`,
+  'pending': (P) => `
+    <div class="panel__head"><div style="display:flex;align-items:center;gap:8px"><h3 class="panel__title">Invoice</h3><span class="panel__provider">${P.name}</span></div><span class="badge badge--warning badge--pulse">Pending</span></div>
+    <div class="rail">${railHTML('pending','submitted')}</div>
+    <div class="panel__body"><div style="display:grid;gap:8px"><div class="skeleton" style="width:60%"></div><div class="skeleton" style="width:40%"></div></div></div>
+    <div class="notice">Issuing in progress on ${P.label}. This refreshes automatically when the provider responds.</div>`,
+  'issued': (P) => `
+    <div class="panel__head">
+      <div style="display:flex;align-items:center;gap:8px"><h3 class="panel__title">Invoice</h3><span class="panel__provider">${P.name}</span></div>
+      <span class="badge badge--success">Issued</span>
+    </div>
+    <div class="rail">${railHTML('issued', P.clearanceKey)}</div>
+    <div class="panel__body">
+      <div class="kv">
+        <dt>Number</dt><dd class="cell-strong"><a class="link" href="#" onclick="return false">${P.issuedNumber}</a></dd>
+        <dt>Document</dt><dd>Invoice</dd>
+        <dt>Clearance</dt><dd>${P.clearanceBadge}</dd>
+        <dt>Issued</dt><dd class="mono">2026-06-25 14:08</dd>
+        <dt>Invoiced via</dt><dd>${P.label} <span class="muted">· locked</span></dd>
+      </div>
+      ${P.slot}
+    </div>`,
+  'issuing': (P) => `
+    <div class="panel__head"><div style="display:flex;align-items:center;gap:8px"><h3 class="panel__title">Invoice</h3><span class="panel__provider">${P.name}</span></div><span class="badge badge--info badge--pulse">Issuing…</span></div>
+    <div class="rail">${railHTML('issuing','na')}</div>
+    <div class="notice">An issue attempt is in progress and this invoice is locked while it runs. It finishes or releases automatically — no action needed, and a second attempt can’t start until this one clears.</div>`,
+  'failed': (P) => `
+    <div class="panel__head"><div style="display:flex;align-items:center;gap:8px"><h3 class="panel__title">Invoice</h3><span class="panel__provider">${P.name}</span></div><span class="badge badge--error">Failed</span></div>
+    <div class="rail">${railHTML('failed','na')}</div>
+    <div class="panel__body">
+      <div class="inline-alert inline-alert--error"><span class="inline-alert__bar"></span>
+        <span><b>${P.reject}</b></span></div>
+    </div>
+    <div class="panel__actions">
+      <span class="muted" style="font-size:11.5px">Rejected — nothing was issued, so it’s safe to retry once the cause is fixed.</span>
+      <div class="spacer"></div>
+      <button class="btn btn--secondary">Retry</button>
+    </div>`,
+  'in-doubt': (P) => `
+    <div class="panel__head"><div style="display:flex;align-items:center;gap:8px"><h3 class="panel__title">Invoice</h3><span class="panel__provider">${P.name}</span></div><span class="badge badge--warning">Needs review</span></div>
+    <div class="rail">${railHTML('in-doubt','na')}</div>
+    <div class="panel__body">
+      <div class="inline-alert inline-alert--warning"><span class="inline-alert__bar"></span>
+        <div><b>We couldn’t confirm whether this invoice was issued.</b> The request to ${P.label} timed out or was interrupted, so a document may already exist there. <b>Don’t retry blindly</b> — open ${P.name}, check for an invoice on this order, then mark it resolved or re-issue.
+        <div style="margin-top:6px"><span class="mono" style="font-size:11px;color:var(--text-muted)">failureMode: in-doubt</span></div></div></div>
+    </div>
+    <div class="panel__actions">
+      <div class="spacer"></div>
+      <button class="btn btn--secondary">Check ${P.name}</button>
+      <button class="btn btn--secondary">Mark resolved</button>
+    </div>`,
+  'needs-reauth': (P) => `
+    <div class="panel__head"><div style="display:flex;align-items:center;gap:8px"><h3 class="panel__title">Invoice</h3><span class="panel__provider">${P.name}</span></div><span class="badge badge--warning">Connection</span></div>
+    <div class="panel__body">
+      <div class="inline-alert inline-alert--warning"><span class="inline-alert__bar"></span>
+        <div><b>${P.label} needs to reconnect.</b> Its access expired, so invoices can’t be issued until you re-authenticate this connection.</div></div>
+    </div>
+    <div class="panel__actions">
+      <div class="spacer"></div>
+      <button class="btn btn--primary">Re-authenticate</button>
+    </div>`,
+  'multi': () => `
+    <div class="panel__head"><h3 class="panel__title">Invoice</h3><span class="badge badge--neutral">Not issued</span></div>
+    <div class="notice">This order isn’t invoiced yet, and more than one connection can issue it. Choose where to issue — <b>once issued, the order locks to that connection</b> and this picker goes away. Nothing is sent until you choose and click Issue. <span class="muted">(The KSeF/Subiekt toggle above is ignored here — the picker chooses the connection.)</span></div>
+    <div class="panel__actions" style="padding-bottom:var(--space-2)">
+      <div class="field" style="flex:1"><label for="conn">Issue on connection</label>
+        <select class="select" id="conn" style="width:100%" onchange="pickConn(this.value)">
+          <option value="">Select a connection…</option>
+          <option value="ksef">KSeF (production)</option>
+          <option value="subiekt">Subiekt nexo</option>
+        </select></div>
+    </div>
+    <div id="multi-body" aria-live="polite"></div>`,
+};
+const panelEl = document.getElementById('panel');
+const stateChips = document.querySelectorAll('[data-state]');
+const pprovChips = document.querySelectorAll('[data-pprov]');
+let curPanelProv = 'ksef', curPanelState = 'pending';
+function renderPanel() {
+  panelEl.innerHTML = PANEL[curPanelState](pProv[curPanelProv]);
+  stateChips.forEach(c => c.setAttribute('aria-pressed', String(c.dataset.state === curPanelState)));
+  pprovChips.forEach(c => c.setAttribute('aria-pressed', String(c.dataset.pprov === curPanelProv)));
+}
+stateChips.forEach(c => c.addEventListener('click', () => { curPanelState = c.dataset.state; renderPanel(); }));
+pprovChips.forEach(c => c.addEventListener('click', () => { curPanelProv = c.dataset.pprov; renderPanel(); }));
+renderPanel();
+
+/* Multiple-connections flow — pre-issuance ONLY. The picker exists to choose
+   WHERE to issue; the order has no invoice yet on any connection. Once issued,
+   the panel switches to the regular issued state, bound + locked to that
+   connection (the "Invoiced via … · locked" row), and the picker is gone.
+   Knowing the order is already invoiced WITHOUT a connection requires the
+   order-snapshot invoice projection (#1224) — today's getInvoiceForOrder needs
+   a connectionId, which is what makes the naive picker confusing. */
+window.pickConn = function (v) {
+  const body = document.getElementById('multi-body');
+  if (!body) return;
+  if (!v) { body.innerHTML = ''; return; }
+  const P = pProv[v];
+  body.innerHTML = `
+    <div class="rail">${railHTML('not-issued', 'na')}</div>
+    <div class="panel__actions">
+      <p class="muted" style="font-size:11.5px;margin:0;width:100%">Will issue a VAT invoice on <b>${P.label}</b> — this choice locks once issued.</p>
+      <div class="spacer"></div>
+      <button class="btn btn--primary">Issue invoice</button>
+    </div>`;
+};
+
+/* ---------- list rows ---------- */
+const ROWS = [
+  { order:'ol_order_9f3c…a21', conn:'KSeF', doc:'Invoice', num:'FV/2026/06/0142', st:['success','Issued'], reg:['success','KSeF · accepted'], time:'2026-06-25 14:08' },
+  { order:'ol_order_77b1…c0e', conn:'KSeF', doc:'Invoice', num:'FV/2026/06/0141', st:['warning','Pending','pulse'], reg:['info','KSeF · submitted'], time:'2026-06-25 13:52' },
+  { order:'ol_order_4ad9…91f', conn:'Subiekt', doc:'Invoice', num:'FS 168/CENTRALA/2026', st:['success','Issued'], reg:['success','KSeF · accepted'], time:'2026-06-25 11:20' },
+  { order:'ol_order_2c8e…77a', conn:'KSeF', doc:'Invoice', num:'—', st:['error','Failed'], reg:['neutral','—'], time:'2026-06-25 10:04' },
+  { order:'ol_order_d4e7…b1a', conn:'Subiekt', doc:'Invoice', num:'FS 167/CENTRALA/2026', st:['warning','Needs review'], reg:['neutral','—'], time:'2026-06-25 09:30' },
+  { order:'ol_order_b5f0…d33', conn:'KSeF', doc:'Corrected', num:'KOR/2026/06/0012', st:['success','Issued'], reg:['error','KSeF · rejected'], time:'2026-06-24 18:41' },
+  { order:'ol_order_e1a2…4b8', conn:'KSeF', doc:'Invoice', num:'FV/2026/06/0140', st:['success','Issued'], reg:['success','KSeF · accepted'], time:'2026-06-24 16:15' },
+];
+function badge([tone,label,pulse]) {
+  if (label === '—') return '<span class="dash">—</span>';
+  return `<span class="badge badge--${tone} ${pulse?'badge--pulse':''}">${label}</span>`;
+}
+function rowAction(label) {
+  if (label === 'Failed') return '<button class="btn btn--ghost btn--sm">Retry</button>';
+  if (label === 'Needs review') return '<button class="btn btn--ghost btn--sm">Review</button>';
+  return '<button class="btn btn--ghost btn--sm">View</button>';
+}
+document.getElementById('rows').innerHTML = ROWS.map((r,i) => `
+  <tr>
+    <td><input class="checkbox row-check" type="checkbox" aria-label="Select ${r.num}"></td>
+    <td class="cell-id">${r.order}</td>
+    <td>${r.conn}</td>
+    <td>${r.doc}</td>
+    <td class="cell-strong mono" style="font-size:12px">${r.num === '—' ? '<span class="dash">—</span>' : r.num}</td>
+    <td>${badge(r.st)}</td>
+    <td>${badge(r.reg)}</td>
+    <td class="cell-time">${r.time}</td>
+    <td>${rowAction(r.st[1])}</td>
+  </tr>`).join('');
+
+/* selection → bulk bar */
+const bulkbar = document.getElementById('bulkbar');
+const bulkCount = document.getElementById('bulk-count');
+function refreshBulk() {
+  const n = document.querySelectorAll('.row-check:checked').length;
+  bulkbar.classList.toggle('is-on', n > 0);
+  bulkCount.textContent = n + ' selected';
+}
+document.addEventListener('change', (e) => {
+  if (e.target.id === 'check-all') {
+    document.querySelectorAll('.row-check').forEach(c => { c.checked = e.target.checked; });
+  }
+  if (e.target.classList.contains('row-check') || e.target.id === 'check-all') refreshBulk();
+});
+
+/* bulk retry → confirm modal → result banner */
+const bulkModal = document.getElementById('bulk-modal');
+const bulkResult = document.getElementById('bulk-result');
+function selCount() { return document.querySelectorAll('.row-check:checked').length; }
+function clearSel() {
+  document.querySelectorAll('.row-check, #check-all').forEach((c) => { c.checked = false; });
+  refreshBulk();
+}
+function closeBulkModal() { bulkModal.classList.remove('is-open'); }
+function confirmBulk() {
+  const n = selCount();
+  closeBulkModal();
+  bulkResult.innerHTML = `<div class="result-banner result-banner--success"><span>Retried ${n} selected — issuing re-attempted. Already-issued invoices were skipped. Refresh to see updated statuses.</span><button class="btn btn--ghost btn--sm result-banner__dismiss" onclick="document.getElementById('bulk-result').innerHTML=''">Dismiss</button></div>`;
+  clearSel();
+}
+document.getElementById('bulk-retry').addEventListener('click', () => {
+  const n = selCount();
+  if (!n) return;
+  document.getElementById('bulk-modal-count').textContent = String(n);
+  bulkModal.classList.add('is-open');
+});
+document.getElementById('bulk-clear').addEventListener('click', clearSel);
+bulkModal.addEventListener('click', (e) => { if (e.target === bulkModal) closeBulkModal(); });
+
+/* list state switch */
+const listChips = document.querySelectorAll('[data-list]');
+const listStates = document.querySelectorAll('.list-state[data-list]');
+listChips.forEach(c => c.addEventListener('click', () => {
+  listChips.forEach(x => x.setAttribute('aria-pressed', String(x === c)));
+  listStates.forEach(s => s.classList.toggle('is-active', s.dataset.list === c.dataset.list));
+}));
+
+/* ---------- invoice detail (A2 / A3 / A5) ---------- */
+function tlItem(cls, title, time, note, last) {
+  return `<div class="tl-item tl-item--${cls}">
+    <div class="tl-rail"><span class="tl-node"></span>${last ? '' : '<span class="tl-line"></span>'}</div>
+    <div class="tl-body"><div class="tl-title">${title}</div>${time ? `<div class="tl-time">${time}</div>` : ''}${note ? `<div class="tl-note">${note}</div>` : ''}</div>
+  </div>`;
+}
+function copyId(v) { return `<span class="copy-id mono">${v}<button type="button">Copy</button></span>`; }
+
+/* The document as written — seller, recipient, goods, VAT. NOT carried by the
+   neutral InvoiceRecord projection; sourced from the order-snapshot invoice
+   projection (#1224) or the provider document (FA(3)/Subiekt). Hence the seam tag. */
+function invoiceContents() {
+  return `
+    <div class="parties">
+      <div><div class="party__label">Seller</div>
+        <div class="party__name">OpenLinker Demo Sp. z o.o.</div>
+        <div class="party__nip">NIP 526-000-12-46</div>
+        <div class="party__line">ul. Przykładowa 1, 00-001 Warszawa, PL</div></div>
+      <div><div class="party__label">Bill to</div>
+        <div class="party__name">Jan Kowalski</div>
+        <div class="party__line">Testowa 21/2, 11-234 Warszawa, PL</div>
+        <div class="party__line muted">Private buyer · no tax ID</div></div>
+    </div>
+    <div class="inv-meta">
+      <div><span>Issue date</span><br><span class="mono">2026-06-25</span></div>
+      <div><span>Sale date</span><br><span class="mono">2026-06-25</span></div>
+      <div><span>Currency</span><br><span class="mono">EUR</span></div>
+      <div><span>Payment</span><br>Online · paid</div>
+    </div>
+    <div class="table-wrap">
+      <table class="lineitems lines-inv">
+        <thead><tr><th>#</th><th>Description</th><th class="r">Qty</th><th class="r">Unit net</th><th class="r">VAT</th><th class="r">Net</th><th class="r">VAT amt</th><th class="r">Gross</th></tr></thead>
+        <tbody>
+          <tr><td class="tabular">1</td><td>Linen mug 300 ml <span class="mono muted" style="font-size:11px">OL-MUG-LIN-300</span></td><td class="r tabular">1</td><td class="r mono tabular">39.84</td><td class="r tabular">23%</td><td class="r mono tabular">39.84</td><td class="r mono tabular">9.16</td><td class="r mono tabular">49.00</td></tr>
+          <tr><td class="tabular">2</td><td>Delivery — InPost</td><td class="r tabular">1</td><td class="r mono tabular">5.69</td><td class="r tabular">23%</td><td class="r mono tabular">5.69</td><td class="r mono tabular">1.31</td><td class="r mono tabular">7.00</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <table class="vat-breakdown">
+      <thead><tr><th>VAT rate</th><th>Net</th><th>VAT</th><th>Gross</th></tr></thead>
+      <tbody><tr><td>23%</td><td class="mono">45.53</td><td class="mono">10.47</td><td class="mono">56.00</td></tr></tbody>
+      <tfoot><tr><td>Total (EUR)</td><td class="mono">45.53</td><td class="mono">10.47</td><td class="mono">56.00</td></tr></tfoot>
+    </table>`;
+}
+
+/* Per-provider regulatory slot (the invoiceDetailSection seam). KSeF transmits
+   directly → it owns the UPO + FA(3) document. Subiekt transmits to KSeF
+   natively → OpenLinker only READS the status (RegulatoryStatusReader, #1230)
+   and links Subiekt's PDF; no UPO/FA(3) from OL. */
+const REG_SLOT = {
+  ksef: {
+    title: 'Regulatory clearance', tag: 'KSeF · slot',
+    issued: `
+      <div class="slot-row"><div><div class="slot-row__label">Clearance status</div></div><span class="badge badge--success">KSeF · accepted</span></div>
+      <div class="slot-row"><div><div class="slot-row__label">KSeF number</div><div class="slot-row__hint">Authority-assigned on clearance</div></div>${copyId('5260001246-20260625-A1B2C3D4E5F6-7K')}</div>
+      <div class="slot-row"><div><div class="slot-row__label">Official receipt (UPO)</div><div class="slot-row__hint">Proof of clearance</div></div><a class="link" href="#" onclick="return false">Download UPO</a></div>
+      <div class="slot-row"><div><div class="slot-row__label">FA(3) document</div><div class="slot-row__hint">Human-readable + source XML</div></div><span style="display:flex;gap:8px"><a class="link" href="#" onclick="return false">View</a><a class="link" href="#" onclick="return false">Download XML</a></span></div>
+      <div class="doc-preview"><span class="doc-preview__chip">FA(3) preview</span>Rendered invoice preview</div>`,
+    pending: `
+      <div class="slot-row"><div><div class="slot-row__label">Clearance status</div></div><span class="badge badge--info">KSeF · submitted</span></div>
+      <div class="slot-row"><div><div class="slot-row__label">KSeF number</div><div class="slot-row__hint">Assigned after clearance</div></div><span class="dash">Pending</span></div>
+      <div class="slot-row"><div><div class="slot-row__label">Official receipt (UPO)</div><div class="slot-row__hint">Available once cleared</div></div><span class="dash">—</span></div>`,
+  },
+  subiekt: {
+    title: 'Regulatory status', tag: 'Subiekt · slot · read-only',
+    issued: `
+      <p class="muted" style="font-size:12px;margin:0 0 var(--space-3)">Subiekt sent this to KSeF itself — OpenLinker reads the status, it doesn’t transmit. <span class="seam-tag">needs #1230</span></p>
+      <div class="slot-row"><div><div class="slot-row__label">KSeF status</div><div class="slot-row__hint">Read from Subiekt</div></div><span class="badge badge--success">KSeF · accepted</span></div>
+      <div class="slot-row"><div><div class="slot-row__label">KSeF number</div></div>${copyId('5260001246-20260625-77B1C0E2F0A9-3D')}</div>
+      <div class="slot-row"><div><div class="slot-row__label">Invoice PDF</div><div class="slot-row__hint">Rendered by Subiekt</div></div><a class="link" href="#" onclick="return false">Download PDF</a></div>`,
+    pending: `
+      <p class="muted" style="font-size:12px;margin:0 0 var(--space-3)">Subiekt submitted this to KSeF — OpenLinker polls for the result. <span class="seam-tag">needs #1230</span></p>
+      <div class="slot-row"><div><div class="slot-row__label">KSeF status</div><div class="slot-row__hint">Last read just now</div></div><span class="badge badge--info">KSeF · submitted</span></div>
+      <div class="slot-row"><div><div class="slot-row__label">KSeF number</div></div><span class="dash">Pending</span></div>
+      <div class="slot-row"><div><div class="slot-row__label">Invoice PDF</div><div class="slot-row__hint">Rendered by Subiekt</div></div><a class="link" href="#" onclick="return false">Download PDF</a></div>`,
+  },
+};
+
+const PROV = {
+  ksef:    { name: 'KSeF',    conn: 'KSeF (production)',     num: { issued: 'FV/2026/06/0142', pending: 'FV/2026/06/0141' }, pid: { issued: 'a1b2c3d4', pending: '77b1c0e2' }, accepted: 'Accepted',  clearanceNote: 'Submitted to KSeF',           correctionHint: 'This invoice is accepted in KSeF. To change it, issue a correction (KOR) — the original stays on record.', rejectTitle: 'The provider rejected the buyer’s tax ID (NIP).', rejectBody: 'Fix the NIP on the order’s customer, then retry.', rejectCode: 'buyer-tax-id-invalid' },
+  subiekt: { name: 'Subiekt', conn: 'Subiekt nexo', num: { issued: 'FS 171/CENTRALA/2026', pending: 'FS 170/CENTRALA/2026' }, pid: { issued: '171', pending: '170' }, accepted: 'Accepted', clearanceNote: 'Submitted to KSeF by Subiekt', correctionHint: 'Subiekt transmitted this to KSeF. Issue a correction in Subiekt (reason + adjusted lines); OpenLinker tracks the resulting status.', rejectTitle: 'Subiekt rejected the document.', rejectBody: 'Subiekt returned a validation error. Check the order’s data, then retry.', rejectCode: 'provider-rejected' },
+};
+
+function buildDetail(prov, state) {
+  const P = PROV[prov];
+  const reg = REG_SLOT[prov];
+  const problem = state === 'failed' || state === 'in-doubt'; // no confirmed document
+  const stBadge = {
+    issued: '<span class="badge badge--success">Issued</span>',
+    pending: '<span class="badge badge--warning badge--pulse">Pending</span>',
+    failed: '<span class="badge badge--error">Failed</span>',
+    'in-doubt': '<span class="badge badge--warning">Needs review</span>',
+  }[state];
+  const regBadge = state === 'issued'
+    ? '<span class="badge badge--success">KSeF · accepted</span>'
+    : state === 'pending' ? '<span class="badge badge--info">KSeF · submitted</span>' : '';
+  const num = problem ? '—' : P.num[state];
+
+  const document = `
+    <dt>Document type</dt><dd>Invoice${problem ? ' <span class="muted">(intended)</span>' : ''}</dd>
+    <dt>Status</dt><dd>${stBadge}</dd>
+    <dt>Provider number</dt><dd>${num === '—' ? '<span class="dash">— none confirmed</span>' : `<span class="cell-strong">${copyId(num)}</span>`}</dd>
+    ${problem ? '' : `<dt>Provider ID</dt><dd>${copyId(P.pid[state])}</dd>`}
+    <dt>${problem ? 'Last attempt' : 'Issued'}</dt><dd class="mono">2026-06-25 ${problem ? '10:04' : '14:08'}</dd>
+    <dt>Order</dt><dd><a class="link" href="#" onclick="return false">ol_order_…</a></dd>
+    <dt>Invoiced via</dt><dd>${P.conn} <span class="muted">· locked to this connection</span></dd>`;
+
+  const regulatory = problem ? '' : (state === 'issued' ? reg.issued : reg.pending);
+  const contents = problem ? '' : invoiceContents();
+
+  let failure = '';
+  if (state === 'failed') {
+    failure = `<div class="inline-alert inline-alert--error"><span class="inline-alert__bar"></span>
+      <div><b>${P.rejectTitle}</b> ${P.rejectBody} Nothing was issued, so there’s no document to correct.
+      <div style="margin-top:6px"><span class="mono" style="font-size:11px;color:var(--text-muted)">reason: ${P.rejectCode}</span></div></div></div>`;
+  } else if (state === 'in-doubt') {
+    failure = `<div class="inline-alert inline-alert--warning"><span class="inline-alert__bar"></span>
+      <div><b>We couldn’t confirm whether this invoice was issued.</b> The request to ${P.conn} timed out or was interrupted, so a document may already exist there. Open ${P.name} and check for an invoice on this order before re-issuing — a blind retry could create a duplicate.
+      <div style="margin-top:6px"><span class="mono" style="font-size:11px;color:var(--text-muted)">failureMode: in-doubt</span></div></div></div>`;
+  }
+
+  const timeline = state === 'failed'
+    ? `<div class="tl-lane-head">Issuance</div>${tlItem('done', 'Created', '2026-06-25 10:04')}${tlItem('error', 'Issuing failed', '2026-06-25 10:04', prov === 'subiekt' ? 'Subiekt rejected the request' : 'Provider rejected the request', true)}`
+    : state === 'in-doubt'
+      ? `<div class="tl-lane-head">Issuance</div>${tlItem('done', 'Created', '2026-06-25 10:04')}${tlItem('error', 'Outcome unknown', '2026-06-25 10:04', 'Request interrupted — may or may not have issued', true)}`
+    : state === 'pending'
+      ? `<div class="tl-lane-head">Issuance</div>${tlItem('done', 'Created', '2026-06-25 13:52')}${tlItem('done', 'Issued', '2026-06-25 13:52', '', true)}<div class="tl-lane-head">Clearance</div>${tlItem('active', P.clearanceNote, '2026-06-25 13:52', 'Awaiting the authority’s decision')}${tlItem('pending', 'Accepted', '', 'Not yet', true)}`
+      : `<div class="tl-lane-head">Issuance</div>${tlItem('done', 'Created', '2026-06-25 14:07')}${tlItem('done', 'Issued', '2026-06-25 14:08', 'Provider number ' + num)}<div class="tl-lane-head">Clearance</div>${tlItem('done', P.clearanceNote, '2026-06-25 14:08')}${tlItem('done', P.accepted, '2026-06-25 14:09', 'KSeF number assigned', true)}`;
+
+  const actions = state === 'failed'
+    ? `<button class="btn btn--secondary">View order customer</button><button class="btn btn--primary">Retry</button><div class="action-hint">Rejected — nothing was issued, so retry is safe once the cause is fixed.</div>`
+    : state === 'in-doubt'
+      ? `<button class="btn btn--secondary">Check ${P.name}</button><button class="btn btn--secondary">Mark resolved</button><div class="action-hint">No blind retry — confirm in ${P.name} first to avoid a duplicate document.</div>`
+    : state === 'pending'
+      ? `<button class="btn btn--secondary">Refresh status</button><div class="action-hint">Clearance is in progress. This page refreshes automatically when KSeF responds.</div>`
+      : `<button class="btn btn--secondary">Download PDF</button><button class="btn btn--primary">Issue correction</button><div class="action-hint">${P.correctionHint}</div>`;
+
+  const h1 = state === 'failed' ? 'Invoice — not issued'
+    : state === 'in-doubt' ? 'Invoice — outcome unknown'
+    : num;
+
+  return {
+    h1,
+    badges: stBadge + (regBadge ? ' ' + regBadge : ''),
+    contents, document, regulatory, regTitle: reg.title, regTag: reg.tag, failure, timeline, actions,
+  };
+}
+
+let curProv = 'ksef', curState = 'issued', curPageState = 'loaded';
+const detailEl = document.getElementById('detail');
+const detailChips = document.querySelectorAll('[data-detail]');
+const provChips = document.querySelectorAll('[data-prov]');
+const pageChips = document.querySelectorAll('[data-detailpage]');
+function detailFeedback(kind) {
+  if (kind === 'loading') {
+    return `<div class="section-card"><div class="section-card__body"><div style="display:grid;gap:10px;max-width:420px"><div class="skeleton" style="width:50%;height:22px"></div><div class="skeleton" style="width:80%"></div><div class="skeleton" style="width:65%"></div><div class="skeleton" style="width:72%"></div></div></div></div>`;
+  }
+  if (kind === 'notfound') {
+    return `<div class="card"><div class="feedback"><div class="feedback__glyph">⌀</div><h3>Invoice not found</h3><p>No invoice exists at this address — it may live on a different connection, or the link is stale.</p><button class="btn btn--secondary btn--sm">Back to invoices</button></div></div>`;
+  }
+  return `<div class="card"><div class="feedback"><div class="feedback__glyph" style="color:var(--status-error-fg)">!</div><h3>Couldn’t load this invoice</h3><p>The request didn’t complete. Check your connection and try again.</p><button class="btn btn--secondary btn--sm">Try again</button></div></div>`;
+}
+function renderDetail() {
+  detailChips.forEach(c => c.setAttribute('aria-pressed', String(c.dataset.detail === curState)));
+  provChips.forEach(c => c.setAttribute('aria-pressed', String(c.dataset.prov === curProv)));
+  pageChips.forEach(c => c.setAttribute('aria-pressed', String(c.dataset.detailpage === curPageState)));
+  if (curPageState !== 'loaded') {
+    detailEl.innerHTML = detailFeedback(curPageState);
+    return;
+  }
+  const P = PROV[curProv];
+  const d = buildDetail(curProv, curState);
+  detailEl.innerHTML = `
+    <div class="detail-head">
+      <div class="detail-head__main">
+        <div class="detail-head__eyebrow">Invoice · ${P.name}</div>
+        <h1>${d.h1}</h1>
+        <div class="detail-head__sub"><span>Order <a class="link" href="#" onclick="return false">ol_order…</a></span><span>·</span><span>${P.conn}</span></div>
+      </div>
+      <div class="detail-head__badges">${d.badges}</div>
+    </div>
+    <div class="detail-grid">
+      <div class="detail-col">
+        ${d.failure ? `<div class="section-card"><div class="section-card__head"><h3>What went wrong</h3></div><div class="section-card__body">${d.failure}</div></div>` : ''}
+        ${d.contents ? `<div class="section-card"><div class="section-card__head"><h3>Invoice contents</h3><span class="seam-tag" title="Not on the InvoiceRecord projection — needs the order-snapshot invoice projection (#1224) or the provider document">needs backend seam</span></div><div class="section-card__body">${d.contents}</div></div>` : ''}
+        <div class="section-card"><div class="section-card__head"><h3>Document</h3><span class="section-card__provider">projection</span></div>
+          <div class="section-card__body"><dl class="kv-wide">${d.document}</dl></div></div>
+        ${d.regulatory ? `<div class="section-card"><div class="section-card__head"><h3>${d.regTitle}</h3><span class="section-card__provider">${d.regTag}</span></div><div class="section-card__body">${d.regulatory}</div></div>` : ''}
+      </div>
+      <div class="detail-col">
+        <div class="section-card"><div class="section-card__head"><h3>Lifecycle</h3></div>
+          <div class="section-card__body"><div class="timeline">${d.timeline}</div></div></div>
+        <div class="section-card"><div class="section-card__head"><h3>Actions</h3></div>
+          <div class="section-card__body"><div class="action-stack">${d.actions}</div></div></div>
+      </div>
+    </div>`;
+  detailChips.forEach(c => c.setAttribute('aria-pressed', String(c.dataset.detail === curState)));
+  provChips.forEach(c => c.setAttribute('aria-pressed', String(c.dataset.prov === curProv)));
+}
+detailChips.forEach(c => c.addEventListener('click', () => { curState = c.dataset.detail; renderDetail(); }));
+provChips.forEach(c => c.addEventListener('click', () => { curProv = c.dataset.prov; renderDetail(); }));
+pageChips.forEach(c => c.addEventListener('click', () => { curPageState = c.dataset.detailpage; renderDetail(); }));
+renderDetail();
+
+/* ---------- connection setup wizards (Wave B) ---------- */
+const SETUP = {
+  ksef: `
+    <div class="wizard__step">
+      <div class="wizard__step-title"><span class="wizard__num">1</span> Connection &amp; access <span class="muted" style="font-weight:400;font-size:11px">· required to connect</span></div>
+      <div class="form-grid">
+        <div class="field field--full"><label for="ks-name">Connection name</label><input class="input" id="ks-name" placeholder="KSeF (production)"><span class="field__hint">A label you’ll recognise in the connections list.</span></div>
+        <div class="field"><label for="ks-env">KSeF environment</label>
+          <select class="select" id="ks-env"><option>Production</option><option>Demo</option><option>Test</option></select></div>
+        <div class="field"><label for="ks-auth">Auth method</label>
+          <select class="select" id="ks-auth"><option>API token</option><option class="disabled-opt" disabled>Qualified seal (coming soon)</option></select></div>
+        <div class="field field--full"><label for="ks-token">KSeF token</label><input class="input" id="ks-token" type="password" placeholder="••••••••••••">
+          <span class="field__lockhint">Authorises access to your company’s KSeF mailbox. Stored encrypted — shown only once.</span></div>
+        <div class="field field--full"><label for="ks-trigger">Issue invoices</label>
+          <select class="select" id="ks-trigger"><option>Manually — I’ll issue from each order</option><option>Automatically when the order is paid</option><option>Automatically when the order ships</option></select>
+          <span class="field__hint">When OpenLinker should issue — the same per-connection trigger every invoicing connection has.</span></div>
+      </div>
+    </div>
+    <div class="wizard__step">
+      <div class="wizard__step-title"><span class="wizard__num">2</span> Seller details <span class="seam-tag">needed before you issue</span></div>
+      <div class="note" style="margin:0 0 var(--space-3)"><span class="note__k">why</span><span>These print on every invoice (the issuer block). OpenLinker <b>doesn’t fetch them from KSeF</b> — KSeF only clears the invoices you send it. Connect now and add these before your first issue.</span></div>
+      <div class="form-grid">
+        <div class="field"><label for="ks-nip">Tax ID (NIP)</label><input class="input" id="ks-nip" placeholder="526-000-12-46"></div>
+        <div class="field"><label for="ks-legal">Legal name</label><input class="input" id="ks-legal" placeholder="OpenLinker Demo Sp. z o.o."></div>
+        <div class="field field--full"><label for="ks-l1">Address line 1</label><input class="input" id="ks-l1" placeholder="ul. Przykładowa 1"></div>
+        <div class="field field--full"><label for="ks-l2">Address line 2 <span class="muted">(optional)</span></label><input class="input" id="ks-l2"></div>
+        <div class="field"><label for="ks-city">City</label><input class="input" id="ks-city" placeholder="Warszawa"></div>
+        <div class="field"><label for="ks-zip">Postal code</label><input class="input" id="ks-zip" placeholder="00-001"></div>
+        <div class="field field--full"><label for="ks-country">Country</label><select class="select" id="ks-country"><option>PL — Poland</option><option>DE — Germany</option><option>CZ — Czechia</option></select></div>
+      </div>
+    </div>
+    <div class="wizard__actions">
+      <span class="spacer"></span>
+      <button class="btn btn--secondary">Test connection</button>
+      <button class="btn btn--primary">Create connection</button>
+    </div>`,
+  subiekt: `
+    <div class="wizard__step">
+      <div class="wizard__step-title"><span class="wizard__num">1</span> Connection</div>
+      <div class="form-grid">
+        <div class="field field--full"><label for="sb-name">Connection name</label><input class="input" id="sb-name" placeholder="Subiekt nexo"><span class="field__hint">A label you’ll recognise in the connections list.</span></div>
+        <div class="field field--full"><label for="sb-url">Subiekt service URL</label><input class="input" id="sb-url" placeholder="https://192.168.1.50:5005"><span class="field__hint">The address OpenLinker reaches your Subiekt at. Use HTTPS off your local network.</span></div>
+        <div class="field field--full"><label for="sb-token">Access token <span class="muted">(optional)</span></label><input class="input" id="sb-token" type="password" placeholder="••••••••••••"><span class="field__lockhint">Optional on a trusted local network; required otherwise. Stored encrypted.</span></div>
+      </div>
+    </div>
+    <div class="wizard__step" style="margin-top: var(--space-5)">
+      <div class="wizard__step-title"><span class="wizard__num">2</span> Invoicing behaviour</div>
+      <div class="form-grid">
+        <div class="field field--full"><label for="sb-trigger">Issue invoices</label>
+          <select class="select" id="sb-trigger"><option>Manually — I’ll issue from each order</option><option>Automatically when the order is paid</option><option>Automatically when the order ships</option></select>
+          <span class="field__hint">When OpenLinker should ask Subiekt to issue an invoice.</span></div>
+      </div>
+      <div class="toggle-row">
+        <div class="toggle-row__text">Show KSeF clearance status<small>Surface the KSeF status Subiekt reports, on invoices and the list.</small></div>
+        <button class="switch" role="switch" aria-checked="true" aria-label="Show KSeF clearance status" onclick="this.setAttribute('aria-checked', this.getAttribute('aria-checked')==='true'?'false':'true')"></button>
+      </div>
+      <p class="field__hint" style="margin-top:var(--space-2)">Seller details (your company, tax ID, address) come from Subiekt itself — nothing to enter here. Subiekt also transmits the invoice to KSeF; OpenLinker reads the status.</p>
+    </div>
+    <div class="wizard__actions">
+      <span class="spacer"></span>
+      <button class="btn btn--secondary">Test connection</button>
+      <button class="btn btn--primary">Create connection</button>
+    </div>`,
+};
+const setupWizard = document.getElementById('setup-wizard');
+const setupTitle = document.getElementById('setup-title');
+const setupChips = document.querySelectorAll('[data-setupprov]');
+function renderSetup(prov) {
+  setupWizard.innerHTML = SETUP[prov];
+  setupTitle.textContent = prov === 'ksef' ? 'Connect KSeF' : 'Connect Subiekt';
+  setupChips.forEach(c => c.setAttribute('aria-pressed', String(c.dataset.setupprov === prov)));
+}
+setupChips.forEach(c => c.addEventListener('click', () => renderSetup(c.dataset.setupprov)));
+renderSetup('ksef');
+
+/* ---------- correction flow (Wave C, per-provider slot) ---------- */
+const CORRECTION = {
+  ksef: `
+    <div class="section-card__head" style="border:0;padding:0 0 var(--space-3)"><h3>Issue correction (KOR)</h3><span class="section-card__provider">KSeF · slot</span></div>
+    <div class="corr__orig"><span>Correcting <b>FV/2026/06/0142</b></span><span>KSeF <b class="mono">5260…7K</b></span><span>Issued <b class="mono">2026-06-25</b></span></div>
+    <div class="field" style="margin-bottom:var(--space-4)"><label for="kor-reason">Reason for correction</label><textarea class="textarea" id="kor-reason" placeholder="e.g. Customer returned 1 unit"></textarea></div>
+    <div class="table-wrap"><table class="lineitems">
+      <thead><tr><th>Description</th><th class="r">Orig qty</th><th class="r">Orig net</th><th class="r">Corrected qty</th><th class="r">Corrected net</th></tr></thead>
+      <tbody>
+        <tr><td>Linen mug 300 ml</td><td class="r tabular">1</td><td class="r mono tabular">39.84</td><td class="r"><input class="input input--num" value="0" aria-label="Corrected qty, line 1"></td><td class="r"><input class="input input--num" value="0.00" aria-label="Corrected net, line 1"></td></tr>
+        <tr><td>Delivery — InPost</td><td class="r tabular">1</td><td class="r mono tabular">5.69</td><td class="r"><input class="input input--num" value="1" aria-label="Corrected qty, line 2"></td><td class="r"><input class="input input--num" value="5.69" aria-label="Corrected net, line 2"></td></tr>
+      </tbody>
+    </table></div>
+    <p class="corr-note">The KOR records the <b>difference</b> vs the original (after − before) and links the original KSeF number. The original invoice stays on record.</p>
+    <div class="wizard__actions"><span class="spacer"></span><button class="btn btn--secondary">Cancel</button><button class="btn btn--primary">Issue correction</button></div>`,
+  subiekt: `
+    <div class="section-card__head" style="border:0;padding:0 0 var(--space-3)"><h3>Issue correction</h3><span class="section-card__provider">Subiekt · slot</span></div>
+    <div class="corr__orig"><span>Correcting <b>FS 171/CENTRALA/2026</b></span><span>KSeF <b class="mono">5260…3D</b></span><span>Issued <b class="mono">2026-06-25</b></span></div>
+    <div class="field" style="margin-bottom:var(--space-4)"><label for="sk-reason">Reason for correction</label><textarea class="textarea" id="sk-reason" placeholder="e.g. Partial return of the order"></textarea></div>
+    <div class="table-wrap"><table class="lineitems">
+      <thead><tr><th>Lp</th><th>Description</th><th class="r">Orig qty</th><th class="r">Orig net</th><th class="r">New qty</th><th class="r">New net</th></tr></thead>
+      <tbody>
+        <tr><td class="tabular">1</td><td>Linen mug 300 ml</td><td class="r tabular">1</td><td class="r mono tabular">39.84</td><td class="r"><input class="input input--num" value="1" aria-label="New qty, line 1"></td><td class="r"><input class="input input--num" value="34.84" aria-label="New net, line 1"></td></tr>
+        <tr><td class="tabular">2</td><td>Delivery — InPost</td><td class="r tabular">1</td><td class="r mono tabular">5.69</td><td class="r"><input class="input input--num" value="1" aria-label="New qty, line 2"></td><td class="r"><input class="input input--num" value="5.69" aria-label="New net, line 2"></td></tr>
+      </tbody>
+    </table></div>
+    <p class="corr-note">A correcting invoice (faktura korygująca) can adjust <b>quantity and/or price</b> per line — e.g. a returned unit or a post-sale price reduction. Subiekt transmits the correction to KSeF; OpenLinker tracks the status.</p>
+    <div class="wizard__actions"><span class="spacer"></span><button class="btn btn--secondary">Cancel</button><button class="btn btn--primary">Issue correction</button></div>`,
+};
+const corrEl = document.getElementById('corr');
+const corrChips = document.querySelectorAll('[data-corrprov]');
+function renderCorr(prov) {
+  corrEl.innerHTML = CORRECTION[prov];
+  corrChips.forEach(c => c.setAttribute('aria-pressed', String(c.dataset.corrprov === prov)));
+}
+corrChips.forEach(c => c.addEventListener('click', () => renderCorr(c.dataset.corrprov)));
+renderCorr('ksef');
+</script>


### PR DESCRIPTION
## Design backing — invoicing module UI

Commits the interactive UI mockup (`docs/plans/invoicing-ui-mockup.html`) + the FE and backend implementation plans, so the design is reviewable in-repo.

- Mockup: 5 tabs (Order panel · Invoices list · Invoice detail · Connection setup · Correction), real design tokens + `shared/ui` patterns, KSeF/Subiekt per-provider, all states (issuing / rejected / in-doubt / needs-reauth / loading / not-found / error).
- Plans: `implementation-plan-invoicing-fe-redesign.md` (FE) + `implementation-plan-invoicing-backend.md` (frozen contracts).
- A `/tech-review` pass was applied; fiscal-safety states + KSeF `accepted` label folded in.

Closes #1239. Part of epic #1242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxiT3zzNeepZX9k4QpTs5R
