### PR TITLE
feat(invoicing): buyer-tax-id presence filter on GET /invoices (#1202)

### DIFF
--- a/apps/api/src/invoicing/http/dto/list-invoices-query.dto.ts
+++ b/apps/api/src/invoicing/http/dto/list-invoices-query.dto.ts
@@ -1,15 +1,12 @@
 /**
- * List Invoices Query DTO (#1119)
+ * List Invoices Query DTO (#1119, #1202)
  *
  * Query parameters for GET /invoices (AC-6). All fields optional.
  *
- * The AC-6 "with/without tax id" sub-filter is DELIBERATELY NOT exposed: the
- * persisted InvoiceRecord projection carries no buyer/tax-id column (the buyer
- * lives on the Order, never on the invoice projection), so the filter cannot be
- * served without a schema migration that is out of #1119 scope. It is omitted
- * from the public contract rather than accepted-and-ignored (which would mislead
- * a caller into thinking `hasTaxId=true` results were filtered). Tracked as a
- * #1119 follow-up so AC-6 sign-off is not claimed for an inert filter.
+ * The AC-6 "with/without tax id" sub-filter is exposed as `taxId=with|without`
+ * (#1202): it is served by the neutral denormalized `hasBuyerTaxId` column on the
+ * InvoiceRecord projection (set on the write path from the buyer at issue time),
+ * so no Order join is needed. Neutral presence concept — not "nip".
  *
  * @module apps/api/src/invoicing/http/dto
  */
@@ -59,6 +56,16 @@ export class ListInvoicesQueryDto {
   @IsOptional()
   @IsISO8601()
   issuedTo?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Filter by buyer-tax-id presence: "with" keeps invoices whose buyer ' +
+      'carried a tax id, "without" keeps those that did not.',
+    enum: ['with', 'without'],
+  })
+  @IsOptional()
+  @IsIn(['with', 'without'])
+  taxId?: 'with' | 'without';
 
   @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100, description: 'Page size' })
   @IsOptional()

--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -435,7 +435,7 @@ describe('InvoicingController', () => {
       );
     });
 
-    it('forwards the taxId=without filter to listInvoices (#1202)', async () => {
+    it('should forward taxId=without to listInvoices when taxId filter is provided (#1202)', async () => {
       invoiceService.listInvoices.mockResolvedValue({ items: [], total: 0 });
       await controller.listInvoices({ taxId: 'without', limit: 20, offset: 0 });
       const filter = invoiceService.listInvoices.mock.calls[0][0] as Record<string, unknown>;

--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -418,6 +418,7 @@ describe('InvoicingController', () => {
         regulatoryStatus: 'cleared',
         issuedFrom: '2026-06-01T00:00:00.000Z',
         issuedTo: '2026-06-30T00:00:00.000Z',
+        taxId: 'with',
         limit: 10,
         offset: 5,
       });
@@ -428,16 +429,17 @@ describe('InvoicingController', () => {
           regulatoryStatus: 'cleared',
           issuedFrom: new Date('2026-06-01T00:00:00.000Z'),
           issuedTo: new Date('2026-06-30T00:00:00.000Z'),
+          taxId: 'with',
         },
         { limit: 10, offset: 5 },
       );
     });
 
-    it('does not forward a tax-id filter (AC-6 sub-filter deferred — not in the contract)', async () => {
+    it('forwards the taxId=without filter to listInvoices (#1202)', async () => {
       invoiceService.listInvoices.mockResolvedValue({ items: [], total: 0 });
-      await controller.listInvoices({ limit: 20, offset: 0 });
+      await controller.listInvoices({ taxId: 'without', limit: 20, offset: 0 });
       const filter = invoiceService.listInvoices.mock.calls[0][0] as Record<string, unknown>;
-      expect(filter).not.toHaveProperty('hasTaxId');
+      expect(filter.taxId).toBe('without');
     });
 
     it('returns { items, total, limit, offset } with DTOs omitting errorMessage + idempotencyKey', async () => {

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -326,10 +326,9 @@ export class InvoicingController {
     summary: 'List invoice records',
     description:
       'Paginated list with AC-6 filters: status, connection, regulatory status, ' +
-      'issued date range. The AC-6 "with/without tax id" sub-filter is NOT exposed ' +
-      'here: the persisted InvoiceRecord projection has no buyer/tax-id column (the ' +
-      'buyer lives on the Order), so it cannot be served without a schema migration ' +
-      'that is out of #1119 scope. Tracked as #1202; not silently "done".',
+      'issued date range, and buyer-tax-id presence (taxId=with|without, #1202). ' +
+      'The taxId filter is served by the neutral denormalized hasBuyerTaxId column ' +
+      'on the projection (set on the write path), so no Order join is needed.',
   })
   @ApiResponse({
     status: 200,
@@ -346,6 +345,7 @@ export class InvoicingController {
       regulatoryStatus: query.regulatoryStatus,
       issuedFrom: query.issuedFrom ? new Date(query.issuedFrom) : undefined,
       issuedTo: query.issuedTo ? new Date(query.issuedTo) : undefined,
+      taxId: query.taxId,
     };
     const page = await this.invoiceService.listInvoices(filter, { limit, offset });
     return {

--- a/apps/api/src/migrations/1815000000000-add-invoice-buyer-tax-id-presence.ts
+++ b/apps/api/src/migrations/1815000000000-add-invoice-buyer-tax-id-presence.ts
@@ -1,0 +1,35 @@
+/**
+ * Add invoice_records.hasBuyerTaxId (#1202)
+ *
+ * Denormalizes whether the buyer carried a tax identifier at issue time onto the
+ * InvoiceRecord projection, so the GET /invoices `taxId=with|without` list filter
+ * can be served without joining to the Order. Neutral presence concept — a
+ * boolean, NOT a stored "nip" value (ADR-026).
+ *
+ * Set on the write path (`InvoiceService.issueInvoice` → `create`) from the
+ * command's buyer. Additive + `NOT NULL DEFAULT false` → existing rows backfill
+ * to `false` in one statement (a legacy invoice's buyer tax-id presence is
+ * unknown to the projection; `false` keeps it out of the `with` bucket rather
+ * than mislabelling it). `down()` drops the column.
+ *
+ * Prefix `1815000000000` is strictly greater than the current migration tail
+ * (`1811000000000`) and leaves room for the in-flight W1–W3 invoicing migrations
+ * (`1812`–`1814`) that land on their own PRs.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddInvoiceBuyerTaxIdPresence1815000000000 implements MigrationInterface {
+  name = 'AddInvoiceBuyerTaxIdPresence1815000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "invoice_records" ADD "hasBuyerTaxId" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "invoice_records" DROP COLUMN "hasBuyerTaxId"`);
+  }
+}

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -71,6 +71,7 @@ function makeRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
     overrides.failureCode === undefined ? null : overrides.failureCode,
     overrides.failureReason === undefined ? null : overrides.failureReason,
     overrides.leaseExpiresAt === undefined ? null : overrides.leaseExpiresAt,
+    overrides.hasBuyerTaxId,
   );
 }
 
@@ -196,7 +197,7 @@ describe('InvoiceService', () => {
       );
     });
 
-    it('(a3) sets hasBuyerTaxId=false on the pending row when the buyer has no tax id (#1202)', async () => {
+    it('(a3) should set hasBuyerTaxId=false on the pending row when the buyer has no tax id (#1202)', async () => {
       repo.findByIdempotencyKey.mockResolvedValue(null);
       repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));
       adapter.issueInvoice.mockResolvedValue(makeIssuedFromAdapter());

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -216,6 +216,25 @@ describe('InvoiceService', () => {
       );
     });
 
+    it('(a4) should set hasBuyerTaxId=false on the pending row when the buyer tax id value is blank (#1202)', async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));
+      adapter.issueInvoice.mockResolvedValue(makeIssuedFromAdapter());
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'issued' }));
+
+      const blankTaxBuyer = new BuyerProfile(
+        'ACME Sp. z o.o.',
+        { scheme: 'pl-nip', value: '' },
+        { line1: 'ul. X 1', line2: null, city: 'Poznań', postalCode: '60-001', countryIso2: 'PL' },
+        'company',
+      );
+      await service.issueInvoice(makeCmd({ buyer: blankTaxBuyer }));
+
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ hasBuyerTaxId: false }),
+      );
+    });
+
     it('(b) idempotent replay (issued): returns the issued row as-is, adapter NEVER called, NO second create', async () => {
       const issued = makeRecord({ status: 'issued' });
       repo.findByIdempotencyKey.mockResolvedValue(issued);

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -153,6 +153,8 @@ describe('InvoiceService', () => {
           status: 'pending',
           idempotencyKey: KEY,
           documentType: '',
+          // Buyer carries a tax id -> denormalized presence flag is true (#1202).
+          hasBuyerTaxId: true,
         }),
       );
       expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(CONNECTION, 'Invoicing');
@@ -191,6 +193,25 @@ describe('InvoiceService', () => {
       expect(repo.updateOutcome).toHaveBeenCalledWith(
         'rec-1',
         expect.objectContaining({ providerType: 'subiekt', documentType: 'invoice' }),
+      );
+    });
+
+    it('(a3) sets hasBuyerTaxId=false on the pending row when the buyer has no tax id (#1202)', async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));
+      adapter.issueInvoice.mockResolvedValue(makeIssuedFromAdapter());
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'issued' }));
+
+      const noTaxBuyer = new BuyerProfile(
+        'Jan Kowalski',
+        null,
+        { line1: 'ul. Y 2', line2: null, city: 'Kraków', postalCode: '30-001', countryIso2: 'PL' },
+        'private',
+      );
+      await service.issueInvoice(makeCmd({ buyer: noTaxBuyer }));
+
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ hasBuyerTaxId: false }),
       );
     });
 

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -170,7 +170,8 @@ export class InvoiceService implements IInvoiceService {
         idempotencyKey: key ?? null,
         // Neutral denormalized presence flag (#1202): captured at create time
         // from the command's buyer so the taxId list filter needs no Order join.
-        hasBuyerTaxId: cmd.buyer.taxId !== null,
+        // Non-null but empty-string values are treated as absent (no tax id).
+        hasBuyerTaxId: cmd.buyer.taxId !== null && cmd.buyer.taxId.value.length > 0,
       });
     } catch (error) {
       // (5) Create-race: a concurrent same-key call won the dedup guard between

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -168,6 +168,9 @@ export class InvoiceService implements IInvoiceService {
         documentType: cmd.documentType ?? '',
         status: 'pending',
         idempotencyKey: key ?? null,
+        // Neutral denormalized presence flag (#1202): captured at create time
+        // from the command's buyer so the taxId list filter needs no Order join.
+        hasBuyerTaxId: cmd.buyer.taxId !== null,
       });
     } catch (error) {
       // (5) Create-race: a concurrent same-key call won the dedup guard between

--- a/libs/core/src/invoicing/domain/entities/invoice-record.entity.ts
+++ b/libs/core/src/invoicing/domain/entities/invoice-record.entity.ts
@@ -68,6 +68,13 @@ export class InvoiceRecord {
      * `status === 'issuing'` AND the lease is in the future.
      */
     public readonly leaseExpiresAt: Date | null = null,
+    /**
+     * Whether the buyer carried a tax identifier at issue time. A neutral,
+     * denormalized presence flag (NOT the tax-id value, NOT "nip") that backs the
+     * `taxId=with|without` list filter (#1202) without joining to the Order. Set
+     * once on the write path; defaults `false` for legacy rows with no backfill.
+     */
+    public readonly hasBuyerTaxId: boolean = false,
   ) {}
 
   /** Pure derivation: the document was successfully issued by the provider. */

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -306,6 +306,11 @@ export interface CreateInvoiceRecordInput {
   failureCode?: InvoiceFailureCode | null;
   /** Short, PII-free failure summary (W1); `null` for a non-`failed` create. */
   failureReason?: string | null;
+  /**
+   * Whether the buyer carried a tax identifier at issue time (#1202). Neutral
+   * presence flag set on the write path; defaults `false` when omitted.
+   */
+  hasBuyerTaxId?: boolean;
 }
 
 /**
@@ -314,14 +319,10 @@ export interface CreateInvoiceRecordInput {
  * POST re-issue gate does NOT widen this surface: it reads the order's single
  * projection row via the existing `findByOrderId(orderId, connectionId)`
  * primitive (surfaced as `IInvoiceService.getInvoice`), so `findMany` stays a
- * pure AC-6 list query. No `hasTaxId`: the InvoiceRecord projection has no
- * buyer/tax-id column (the buyer lives on the Order), so the AC-6
- * "with/without tax id" sub-filter cannot be served without denormalizing
- * `buyerTaxId` onto the projection + a migration + a backfill — out of #1119
- * scope. It is therefore absent from this filter surface AND from the public
- * `ListInvoicesQueryDto` (where `forbidNonWhitelisted` rejects `hasTaxId` with
- * a 400 rather than accepting-and-ignoring it). Tracked as #1202; AC-6
- * sign-off must NOT be claimed for this sub-filter until it ships.
+ * pure AC-6 list query. The `taxId` filter (#1202) is served by the neutral
+ * denormalized `hasBuyerTaxId` column on the projection (set on the write path),
+ * NOT by joining to the Order: `'with'` → `hasBuyerTaxId = true`, `'without'` →
+ * `false`.
  */
 export interface InvoiceRecordFilters {
   status?: InvoiceStatus;
@@ -331,6 +332,12 @@ export interface InvoiceRecordFilters {
   issuedFrom?: Date;
   /** Inclusive upper bound on `issuedAt`. */
   issuedTo?: Date;
+  /**
+   * Filter by buyer-tax-id presence (#1202): `'with'` keeps rows where the buyer
+   * carried a tax id, `'without'` keeps rows where it did not. Neutral presence
+   * concept (not "nip"); maps to the denormalized `hasBuyerTaxId` column.
+   */
+  taxId?: 'with' | 'without';
 }
 
 /** Pagination window for {@link InvoiceRecordRepositoryPort.findMany}. */

--- a/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
@@ -123,6 +123,14 @@ export class InvoiceRecordOrmEntity {
   @Column({ type: 'timestamp', nullable: true })
   leaseExpiresAt!: Date | null;
 
+  /**
+   * Neutral denormalized flag: did the buyer carry a tax identifier at issue
+   * time (#1202)? Backs the `taxId=with|without` list filter without joining to
+   * the Order. Not "nip" — a presence boolean. Defaults `false` for legacy rows.
+   */
+  @Column({ type: 'boolean', default: false })
+  hasBuyerTaxId!: boolean;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
@@ -124,6 +124,32 @@ describe('InvoiceRecordRepository', () => {
       expect(saved.failureReason).toBeNull();
     });
 
+    it('persists hasBuyerTaxId from the input and maps it back (#1202)', async () => {
+      let savedEntity: InvoiceRecordOrmEntity | undefined;
+      ormRepo.save.mockImplementation((entity) => {
+        savedEntity = entity as InvoiceRecordOrmEntity;
+        return Promise.resolve(ormRow({ hasBuyerTaxId: savedEntity.hasBuyerTaxId }));
+      });
+
+      const result = await repository.create({ ...createInput, hasBuyerTaxId: true });
+
+      expect(savedEntity?.hasBuyerTaxId).toBe(true);
+      expect(result.hasBuyerTaxId).toBe(true);
+    });
+
+    it('defaults hasBuyerTaxId to false when the input omits it (#1202)', async () => {
+      let savedEntity: InvoiceRecordOrmEntity | undefined;
+      ormRepo.save.mockImplementation((entity) => {
+        savedEntity = entity as InvoiceRecordOrmEntity;
+        return Promise.resolve(ormRow({ hasBuyerTaxId: savedEntity.hasBuyerTaxId }));
+      });
+
+      const result = await repository.create(createInput);
+
+      expect(savedEntity?.hasBuyerTaxId).toBe(false);
+      expect(result.hasBuyerTaxId).toBe(false);
+    });
+
     it('converts a unique-violation into DuplicateInvoiceRecordException', async () => {
       ormRepo.save.mockRejectedValue(
         new QueryFailedError(
@@ -366,6 +392,20 @@ describe('InvoiceRecordRepository', () => {
       await repository.findMany({ issuedFrom: from, issuedTo: to }, PAGE);
       expect(qb.andWhere).toHaveBeenCalledWith('inv.issuedAt >= :issuedFrom', { issuedFrom: from });
       expect(qb.andWhere).toHaveBeenCalledWith('inv.issuedAt <= :issuedTo', { issuedTo: to });
+    });
+
+    it('maps taxId=with to hasBuyerTaxId = true (#1202)', async () => {
+      await repository.findMany({ taxId: 'with' }, PAGE);
+      expect(qb.andWhere).toHaveBeenCalledWith('inv.hasBuyerTaxId = :hasBuyerTaxId', {
+        hasBuyerTaxId: true,
+      });
+    });
+
+    it('maps taxId=without to hasBuyerTaxId = false (#1202)', async () => {
+      await repository.findMany({ taxId: 'without' }, PAGE);
+      expect(qb.andWhere).toHaveBeenCalledWith('inv.hasBuyerTaxId = :hasBuyerTaxId', {
+        hasBuyerTaxId: false,
+      });
     });
 
     it('orders by inv.createdAt DESC and applies skip/take from pagination', async () => {

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.spec.ts
@@ -37,6 +37,7 @@ function ormRow(overrides: Partial<InvoiceRecordOrmEntity> = {}): InvoiceRecordO
       pdfUrl: null,
       issuedAt: null,
       errorMessage: null,
+      hasBuyerTaxId: false,
       createdAt: now,
       updatedAt: now,
     },
@@ -124,7 +125,7 @@ describe('InvoiceRecordRepository', () => {
       expect(saved.failureReason).toBeNull();
     });
 
-    it('persists hasBuyerTaxId from the input and maps it back (#1202)', async () => {
+    it('should persist hasBuyerTaxId=true and map it back when the input carries the flag (#1202)', async () => {
       let savedEntity: InvoiceRecordOrmEntity | undefined;
       ormRepo.save.mockImplementation((entity) => {
         savedEntity = entity as InvoiceRecordOrmEntity;
@@ -137,7 +138,7 @@ describe('InvoiceRecordRepository', () => {
       expect(result.hasBuyerTaxId).toBe(true);
     });
 
-    it('defaults hasBuyerTaxId to false when the input omits it (#1202)', async () => {
+    it('should default hasBuyerTaxId to false when the input omits the flag (#1202)', async () => {
       let savedEntity: InvoiceRecordOrmEntity | undefined;
       ormRepo.save.mockImplementation((entity) => {
         savedEntity = entity as InvoiceRecordOrmEntity;
@@ -394,14 +395,14 @@ describe('InvoiceRecordRepository', () => {
       expect(qb.andWhere).toHaveBeenCalledWith('inv.issuedAt <= :issuedTo', { issuedTo: to });
     });
 
-    it('maps taxId=with to hasBuyerTaxId = true (#1202)', async () => {
+    it('should filter by hasBuyerTaxId = true when taxId=with is provided (#1202)', async () => {
       await repository.findMany({ taxId: 'with' }, PAGE);
       expect(qb.andWhere).toHaveBeenCalledWith('inv.hasBuyerTaxId = :hasBuyerTaxId', {
         hasBuyerTaxId: true,
       });
     });
 
-    it('maps taxId=without to hasBuyerTaxId = false (#1202)', async () => {
+    it('should filter by hasBuyerTaxId = false when taxId=without is provided (#1202)', async () => {
       await repository.findMany({ taxId: 'without' }, PAGE);
       expect(qb.andWhere).toHaveBeenCalledWith('inv.hasBuyerTaxId = :hasBuyerTaxId', {
         hasBuyerTaxId: false,

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
@@ -187,6 +187,11 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
     if (filter.issuedTo !== undefined) {
       qb.andWhere('inv.issuedAt <= :issuedTo', { issuedTo: filter.issuedTo });
     }
+    if (filter.taxId !== undefined) {
+      qb.andWhere('inv.hasBuyerTaxId = :hasBuyerTaxId', {
+        hasBuyerTaxId: filter.taxId === 'with',
+      });
+    }
 
     qb.orderBy('inv.createdAt', 'DESC').skip(pagination.offset).take(pagination.limit);
 
@@ -268,6 +273,7 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
     entity.failureReason = input.failureReason ?? null;
     // A freshly-created `pending` row holds no in-flight lease (#1200).
     entity.leaseExpiresAt = null;
+    entity.hasBuyerTaxId = input.hasBuyerTaxId ?? false;
     return entity;
   }
 
@@ -293,6 +299,7 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
       entity.failureCode,
       entity.failureReason,
       entity.leaseExpiresAt,
+      entity.hasBuyerTaxId,
     );
   }
 }


### PR DESCRIPTION
## What

Implements the AC-6 "with/without tax id" list sub-filter on `GET /invoices` that #1119 deliberately deferred pending a schema migration.

## Changes

- **Migration `1815000000000`**: denormalizes a neutral boolean `hasBuyerTaxId` onto `invoice_records` (`NOT NULL DEFAULT false` — backfills legacy rows to `false` in one statement). Neutral presence concept, NOT a stored `nip` value (ADR-026 neutral core).
- **Write path**: `InvoiceService.issueInvoice` populates `hasBuyerTaxId` from the command's buyer (`cmd.buyer.taxId !== null`) when it creates the pending row, so the flag is captured before any provider call.
- **Core**: `CreateInvoiceRecordInput` + `InvoiceRecord` entity + `InvoiceRecordFilters` gain the field / `taxId` filter; `findMany` maps `taxId=with|without` → `hasBuyerTaxId = true|false`; repo `toDomain`/`toOrm` round-trip the column.
- **API**: `ListInvoicesQueryDto` gains `taxId?: 'with' | 'without'` (`@IsIn`-validated); the controller forwards it; replaced the stale "deferred / not exposed" prose in the DTO + Swagger description.

## Tests

- Repo: `taxId` filter both directions + `create` round-trip + default-false.
- Service: derives the flag from the buyer (with + without tax id).
- Controller: forwards `taxId` to `listInvoices`.

## Migration ordering

Prefix `1815` is strictly greater than the current `main` tail (`1811`) and leaves room for the in-flight W1–W3 invoicing migrations (`1812`–`1814`) that land on their own PRs.

## Scoped checks

`@openlinker/core` + `@openlinker/api` type-check green; core invoicing 111/111; api invoicing 25/25; eslint 0 errors on changed files.

Closes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4ShufMjpq73tHU3W9EDsD