### PR TITLE
feat(invoicing): batch retry endpoint POST /invoices/retry (#1245)

### DIFF
--- a/apps/api/src/invoicing/http/dto/retry-invoices-request.dto.ts
+++ b/apps/api/src/invoicing/http/dto/retry-invoices-request.dto.ts
@@ -1,0 +1,33 @@
+/**
+ * Retry Invoices Request DTO (#1245)
+ *
+ * Body for `POST /invoices/retry` (§7.2): the set of `InvoiceRecord` ids to
+ * re-attempt. Only records that are retry-eligible
+ * (`status === 'failed' && failureMode === 'rejected'`) are retried; every other
+ * state (issued / issuing / pending / in-doubt / unknown) is skipped server-side
+ * with a per-id reason. Neutral — no provider vocabulary.
+ *
+ * @module apps/api/src/invoicing/http/dto
+ */
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Max ids accepted in one batch. Bounds the synchronous fan-out (each id may
+ * cross the provider boundary) so a single request can't issue an unbounded
+ * number of provider calls.
+ */
+const MAX_BATCH_SIZE = 100;
+
+export class RetryInvoicesRequestDto {
+  @ApiProperty({
+    description: 'Invoice record ids to re-attempt (only failed+rejected records are retried).',
+    type: [String],
+    maxItems: MAX_BATCH_SIZE,
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(MAX_BATCH_SIZE)
+  @IsUUID('4', { each: true })
+  invoiceIds!: string[];
+}

--- a/apps/api/src/invoicing/http/dto/retry-invoices-response.dto.ts
+++ b/apps/api/src/invoicing/http/dto/retry-invoices-response.dto.ts
@@ -1,0 +1,45 @@
+/**
+ * Retry Invoices Response DTO (#1245)
+ *
+ * Result of `POST /invoices/retry` (§7.2): aggregate `retried` / `skipped`
+ * counts plus a per-id outcome summary. A `skipped` result carries a neutral,
+ * PII-free `reason` (the record was not in a retry-eligible state, or did not
+ * exist); a `retried` result carries no reason. Neutral — no provider
+ * vocabulary, never the raw provider rejection text.
+ *
+ * @module apps/api/src/invoicing/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/** Per-id outcome of a batch retry. */
+export const RetryOutcomeValues = ['retried', 'skipped'] as const;
+export type RetryOutcome = (typeof RetryOutcomeValues)[number];
+
+export class RetryInvoiceResultDto {
+  @ApiProperty({ description: 'Invoice record id this outcome refers to.' })
+  id!: string;
+
+  @ApiProperty({
+    description: 'Whether the record was re-attempted or skipped server-side.',
+    enum: RetryOutcomeValues,
+  })
+  outcome!: RetryOutcome;
+
+  @ApiPropertyOptional({
+    description:
+      'Neutral, PII-free reason a record was skipped (e.g. not in a retry-eligible ' +
+      'state, or not found). Absent for retried records.',
+  })
+  reason?: string;
+}
+
+export class RetryInvoicesResponseDto {
+  @ApiProperty({ description: 'Number of records re-attempted.' })
+  retried!: number;
+
+  @ApiProperty({ description: 'Number of records skipped server-side.' })
+  skipped!: number;
+
+  @ApiProperty({ description: 'Per-id outcome summary.', type: [RetryInvoiceResultDto] })
+  results!: RetryInvoiceResultDto[];
+}

--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -54,8 +54,9 @@ function makeInvoiceRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecor
     isIssued: true,
     ...overrides,
   };
-  // Mirror the real entity derivation (#1200) so the controller's AC-5 gate can
-  // call it: a live `issuing` lease is "in progress".
+  // Mirror the real entity derivations (#1200) so the controller's gates can call
+  // them: a live `issuing` lease is "in progress" (AC-5); `isReattemptableFailure`
+  // is the batch-retry eligibility gate (#1245).
   return {
     ...base,
     isLeaseLive(now: Date): boolean {
@@ -64,6 +65,9 @@ function makeInvoiceRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecor
         base.leaseExpiresAt !== null &&
         (base.leaseExpiresAt).getTime() > now.getTime()
       );
+    },
+    get isReattemptableFailure(): boolean {
+      return base.status === 'failed' && base.failureMode === 'rejected';
     },
   } as InvoiceRecord;
 }
@@ -106,6 +110,7 @@ describe('InvoicingController', () => {
     invoiceService = {
       issueInvoice: jest.fn(),
       getInvoice: jest.fn().mockResolvedValue(null),
+      getInvoiceById: jest.fn().mockResolvedValue(null),
       listInvoices: jest.fn(),
     } as unknown as jest.Mocked<IInvoiceService>;
     orders = {
@@ -452,6 +457,127 @@ describe('InvoicingController', () => {
         limit: 20,
         offset: 0,
       });
+    });
+  });
+
+  describe('retryInvoices (#1245)', () => {
+    it('retries only failed+rejected records and reuses the record idempotencyKey', async () => {
+      const eligible = makeInvoiceRecord({
+        id: 'inv_fail',
+        status: 'failed',
+        failureMode: 'rejected',
+        idempotencyKey: 'key-fail',
+      });
+      invoiceService.getInvoiceById.mockResolvedValue(eligible);
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord());
+      invoiceService.issueInvoice.mockResolvedValue(makeInvoiceRecord({ status: 'issued' }));
+
+      const res = await controller.retryInvoices({ invoiceIds: ['inv_fail'] });
+
+      expect(res.retried).toBe(1);
+      expect(res.skipped).toBe(0);
+      expect(res.results).toEqual([{ id: 'inv_fail', outcome: 'retried' }]);
+      // Reuses the record's OWN key so the service resumes THAT row (R2/R3). The
+      // command rebuilt from the order snapshot carries no scheme-tagged buyer tax
+      // id (the projection doesn't persist it) → buyer.taxId is null.
+      expect(invoiceService.issueInvoice).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idempotencyKey: 'key-fail',
+          buyer: expect.objectContaining({ taxId: null }),
+        }),
+      );
+    });
+
+    it('skips an issued record server-side (never re-issues a done document)', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(makeInvoiceRecord({ status: 'issued' }));
+
+      const res = await controller.retryInvoices({ invoiceIds: ['inv_1'] });
+
+      expect(res.retried).toBe(0);
+      expect(res.skipped).toBe(1);
+      expect(res.results[0].outcome).toBe('skipped');
+      expect(res.results[0].reason).toContain('status=issued');
+      expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
+    });
+
+    it('skips an in-doubt failed record (a document may exist — no blind retry)', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(
+        makeInvoiceRecord({ status: 'failed', failureMode: 'in-doubt' }),
+      );
+
+      const res = await controller.retryInvoices({ invoiceIds: ['inv_1'] });
+
+      expect(res.skipped).toBe(1);
+      expect(res.results[0].reason).toContain('failureMode=in-doubt');
+      expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
+    });
+
+    it('skips issuing and pending records server-side', async () => {
+      invoiceService.getInvoiceById
+        .mockResolvedValueOnce(makeInvoiceRecord({ id: 'inv_issuing', status: 'issuing' }))
+        .mockResolvedValueOnce(makeInvoiceRecord({ id: 'inv_pending', status: 'pending' }));
+
+      const res = await controller.retryInvoices({ invoiceIds: ['inv_issuing', 'inv_pending'] });
+
+      expect(res.retried).toBe(0);
+      expect(res.skipped).toBe(2);
+      expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
+    });
+
+    it('skips an unknown id with a not-found reason', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(null);
+
+      const res = await controller.retryInvoices({ invoiceIds: ['nope'] });
+
+      expect(res.skipped).toBe(1);
+      expect(res.results[0].reason).toContain('not found');
+    });
+
+    it('captures a provider re-rejection as skipped without aborting the rest of the batch', async () => {
+      const eligible = makeInvoiceRecord({ status: 'failed', failureMode: 'rejected' });
+      const ok = makeInvoiceRecord({ id: 'inv_ok', status: 'failed', failureMode: 'rejected' });
+      invoiceService.getInvoiceById
+        .mockResolvedValueOnce(eligible)
+        .mockResolvedValueOnce(ok);
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord());
+      invoiceService.issueInvoice
+        .mockRejectedValueOnce(new Error('provider rejected again'))
+        .mockResolvedValueOnce(makeInvoiceRecord({ status: 'issued' }));
+
+      const res = await controller.retryInvoices({ invoiceIds: ['inv_1', 'inv_ok'] });
+
+      expect(res.retried).toBe(1);
+      expect(res.skipped).toBe(1);
+      // The neutral reason never echoes the raw provider message.
+      const failed = res.results.find((r) => r.id === 'inv_1');
+      expect(failed?.outcome).toBe('skipped');
+      expect(failed?.reason).not.toContain('provider rejected again');
+      expect(failed?.reason).toContain('correlationId');
+    });
+
+    it('de-duplicates repeated ids so an id is attempted at most once', async () => {
+      const eligible = makeInvoiceRecord({ status: 'failed', failureMode: 'rejected' });
+      invoiceService.getInvoiceById.mockResolvedValue(eligible);
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord());
+      invoiceService.issueInvoice.mockResolvedValue(makeInvoiceRecord({ status: 'issued' }));
+
+      const res = await controller.retryInvoices({ invoiceIds: ['inv_1', 'inv_1'] });
+
+      expect(res.results).toHaveLength(1);
+      expect(invoiceService.issueInvoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips an eligible record whose backing order is no longer available', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(
+        makeInvoiceRecord({ status: 'failed', failureMode: 'rejected' }),
+      );
+      orders.getOrderRecord.mockResolvedValue(null);
+
+      const res = await controller.retryInvoices({ invoiceIds: ['inv_1'] });
+
+      expect(res.skipped).toBe(1);
+      expect(res.results[0].reason).toContain('order');
+      expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -461,7 +461,7 @@ describe('InvoicingController', () => {
   });
 
   describe('retryInvoices (#1245)', () => {
-    it('retries only failed+rejected records and reuses the record idempotencyKey', async () => {
+    it('should retry only failed+rejected records and reuse the record idempotencyKey', async () => {
       const eligible = makeInvoiceRecord({
         id: 'inv_fail',
         status: 'failed',
@@ -488,7 +488,7 @@ describe('InvoicingController', () => {
       );
     });
 
-    it('skips an issued record server-side (never re-issues a done document)', async () => {
+    it('should skip an issued record server-side (never re-issues a done document)', async () => {
       invoiceService.getInvoiceById.mockResolvedValue(makeInvoiceRecord({ status: 'issued' }));
 
       const res = await controller.retryInvoices({ invoiceIds: ['inv_1'] });
@@ -500,7 +500,7 @@ describe('InvoicingController', () => {
       expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
     });
 
-    it('skips an in-doubt failed record (a document may exist — no blind retry)', async () => {
+    it('should skip an in-doubt failed record (a document may exist — no blind retry)', async () => {
       invoiceService.getInvoiceById.mockResolvedValue(
         makeInvoiceRecord({ status: 'failed', failureMode: 'in-doubt' }),
       );
@@ -512,7 +512,7 @@ describe('InvoicingController', () => {
       expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
     });
 
-    it('skips issuing and pending records server-side', async () => {
+    it('should skip issuing and pending records server-side', async () => {
       invoiceService.getInvoiceById
         .mockResolvedValueOnce(makeInvoiceRecord({ id: 'inv_issuing', status: 'issuing' }))
         .mockResolvedValueOnce(makeInvoiceRecord({ id: 'inv_pending', status: 'pending' }));
@@ -524,7 +524,7 @@ describe('InvoicingController', () => {
       expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
     });
 
-    it('skips an unknown id with a not-found reason', async () => {
+    it('should skip an unknown id with a not-found reason', async () => {
       invoiceService.getInvoiceById.mockResolvedValue(null);
 
       const res = await controller.retryInvoices({ invoiceIds: ['nope'] });
@@ -533,7 +533,7 @@ describe('InvoicingController', () => {
       expect(res.results[0].reason).toContain('not found');
     });
 
-    it('captures a provider re-rejection as skipped without aborting the rest of the batch', async () => {
+    it('should capture a provider re-rejection as skipped without aborting the rest of the batch', async () => {
       const eligible = makeInvoiceRecord({ status: 'failed', failureMode: 'rejected' });
       const ok = makeInvoiceRecord({ id: 'inv_ok', status: 'failed', failureMode: 'rejected' });
       invoiceService.getInvoiceById
@@ -555,7 +555,7 @@ describe('InvoicingController', () => {
       expect(failed?.reason).toContain('correlationId');
     });
 
-    it('de-duplicates repeated ids so an id is attempted at most once', async () => {
+    it('should de-duplicate repeated ids so an id is attempted at most once', async () => {
       const eligible = makeInvoiceRecord({ status: 'failed', failureMode: 'rejected' });
       invoiceService.getInvoiceById.mockResolvedValue(eligible);
       orders.getOrderRecord.mockResolvedValue(makeOrderRecord());
@@ -567,7 +567,7 @@ describe('InvoicingController', () => {
       expect(invoiceService.issueInvoice).toHaveBeenCalledTimes(1);
     });
 
-    it('skips an eligible record whose backing order is no longer available', async () => {
+    it('should skip an eligible record whose backing order is no longer available', async () => {
       invoiceService.getInvoiceById.mockResolvedValue(
         makeInvoiceRecord({ status: 'failed', failureMode: 'rejected' }),
       );

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -184,6 +184,7 @@ export class InvoicingController {
       'At most 100 ids per request. Returns a per-id outcome summary.',
   })
   @ApiResponse({ status: 200, description: 'Per-id retry summary', type: RetryInvoicesResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation error (empty array, non-UUID ids, or batch > 100)' })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async retryInvoices(@Body() dto: RetryInvoicesRequestDto): Promise<RetryInvoicesResponseDto> {
     // De-duplicate ids while preserving first-seen order so a caller that repeats

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -181,7 +181,7 @@ export class InvoicingController {
       'document). Issued / issuing / pending / in-doubt / unknown ids are skipped ' +
       'server-side with a neutral per-id reason, never re-issued. Reuses the ' +
       'single-invoice issue/retry primitive per id (no parallel bulk pipeline). ' +
-      'Returns a per-id outcome summary.',
+      'At most 100 ids per request. Returns a per-id outcome summary.',
   })
   @ApiResponse({ status: 200, description: 'Per-id retry summary', type: RetryInvoicesResponseDto })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })
@@ -242,7 +242,10 @@ export class InvoicingController {
     }
 
     try {
-      const order = this.rehydrateOrder(record.orderId, orderRecord);
+      // Use the OrderRecord's own internalOrderId for the rehydration error
+      // message, matching the single-issue path's argument (record.orderId is the
+      // same value, but this keeps the two call sites consistent).
+      const order = this.rehydrateOrder(orderRecord.internalOrderId, orderRecord);
       const command = toIssueInvoiceCommand({
         order,
         connectionId: record.connectionId,

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -65,6 +65,9 @@ import { GetInvoiceForOrderQueryDto } from './dto/get-invoice-for-order-query.dt
 import { ListInvoicesQueryDto } from './dto/list-invoices-query.dto';
 import { InvoiceRecordResponseDto } from './dto/invoice-record-response.dto';
 import { PaginatedInvoicesResponseDto } from './dto/paginated-invoices-response.dto';
+import { RetryInvoicesRequestDto } from './dto/retry-invoices-request.dto';
+import { RetryInvoicesResponseDto } from './dto/retry-invoices-response.dto';
+import type { RetryInvoiceResultDto } from './dto/retry-invoices-response.dto';
 
 @Roles('admin')
 @ApiBearerAuth()
@@ -166,6 +169,113 @@ export class InvoicingController {
       throw this.toHttpException(error);
     }
     return this.toDto(issued);
+  }
+
+  @Post('invoices/retry')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Batch re-attempt failed invoice issuances',
+    description:
+      'Re-attempts ONLY records that are retry-eligible (status=failed AND ' +
+      'failureMode=rejected — a terminal rejection where the provider created no ' +
+      'document). Issued / issuing / pending / in-doubt / unknown ids are skipped ' +
+      'server-side with a neutral per-id reason, never re-issued. Reuses the ' +
+      'single-invoice issue/retry primitive per id (no parallel bulk pipeline). ' +
+      'Returns a per-id outcome summary.',
+  })
+  @ApiResponse({ status: 200, description: 'Per-id retry summary', type: RetryInvoicesResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async retryInvoices(@Body() dto: RetryInvoicesRequestDto): Promise<RetryInvoicesResponseDto> {
+    // De-duplicate ids while preserving first-seen order so a caller that repeats
+    // an id gets ONE outcome and the same id is never re-attempted twice in a
+    // single request (a second attempt could cross the provider boundary again).
+    const uniqueIds = [...new Set(dto.invoiceIds)];
+
+    const results: RetryInvoiceResultDto[] = [];
+    for (const invoiceId of uniqueIds) {
+      results.push(await this.retryOne(invoiceId));
+    }
+
+    const retried = results.filter((r) => r.outcome === 'retried').length;
+    return { retried, skipped: results.length - retried, results };
+  }
+
+  /**
+   * Re-attempt a SINGLE invoice record by id, reusing the exact issue/retry
+   * primitive the manual `POST /invoices` endpoint uses. Server-side eligibility
+   * gate (NEVER re-issues a non-eligible record):
+   *   - record not found                          -> skipped (not-found).
+   *   - NOT `isReattemptableFailure`              -> skipped (status/<failureMode>):
+   *     this excludes `issued`, `issuing`, `pending`, and `in-doubt` `failed` rows.
+   *   - eligible (`failed` + `rejected`)          -> rebuild the command from the
+   *     order snapshot (reusing the record's own idempotencyKey so the service
+   *     resumes THAT row, R2/R3) and call `issueInvoice`. A provider re-rejection
+   *     or rehydration failure is captured as `skipped` with a neutral reason — it
+   *     must NOT abort the rest of the batch, and the raw provider/PII text is
+   *     never returned.
+   *
+   * The buyer tax id is NOT recoverable from the `InvoiceRecord` projection (it is
+   * supplied per-request to the single endpoint and not persisted), so the rebuilt
+   * command derives the buyer from the order snapshot alone (`buyerTaxId: null`),
+   * matching a keyless re-issue through `POST /invoices`.
+   */
+  private async retryOne(invoiceId: string): Promise<RetryInvoiceResultDto> {
+    const record = await this.invoiceService.getInvoiceById(invoiceId);
+    if (!record) {
+      return { id: invoiceId, outcome: 'skipped', reason: 'Invoice record not found.' };
+    }
+    if (!record.isReattemptableFailure) {
+      return {
+        id: invoiceId,
+        outcome: 'skipped',
+        reason: `Not retry-eligible (status=${record.status}, failureMode=${record.failureMode ?? 'none'}).`,
+      };
+    }
+
+    const orderRecord = await this.orders.getOrderRecord(record.orderId);
+    if (!orderRecord) {
+      return {
+        id: invoiceId,
+        outcome: 'skipped',
+        reason: 'The order backing this invoice is no longer available.',
+      };
+    }
+
+    try {
+      const order = this.rehydrateOrder(record.orderId, orderRecord);
+      const command = toIssueInvoiceCommand({
+        order,
+        connectionId: record.connectionId,
+        // The projection does not persist the scheme-tagged buyer tax id; rebuild
+        // from the order snapshot alone (matches a keyless single re-issue).
+        buyerTaxId: null,
+        // Pass the record's neutral documentType through when it carried one
+        // (''/empty means "let the adapter derive it", as on the pending row).
+        documentType: record.documentType.length > 0 ? record.documentType : undefined,
+        // Reuse the record's OWN key so the service resumes THIS row rather than
+        // starting a fresh attempt (R2/R3, exactly-once dedup).
+        idempotencyKey: record.idempotencyKey ?? undefined,
+      });
+      await this.invoiceService.issueInvoice(command);
+      return { id: invoiceId, outcome: 'retried' };
+    } catch (error) {
+      // A re-rejection / rehydration failure for ONE id must not abort the batch.
+      // Log the bounded internal diagnostic with a correlation id; surface only a
+      // neutral, PII-free reason referencing that id.
+      const correlationId = `inv-retry-${Date.now().toString(36)}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+      this.logger.warn(
+        `Batch retry failed for invoice ${invoiceId} (${correlationId}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return {
+        id: invoiceId,
+        outcome: 'skipped',
+        reason: `Re-attempt failed; surfaced for manual review (correlationId: ${correlationId}).`,
+      };
+    }
   }
 
   @Get('orders/:orderId/invoice')

--- a/libs/core/src/invoicing/application/services/invoice.service.interface.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.interface.ts
@@ -79,6 +79,14 @@ export interface IInvoiceService {
   getInvoice(query: GetInvoiceByOrderQuery): Promise<InvoiceRecord | null>;
 
   /**
+   * Read OL's OWN `InvoiceRecord` projection by its primary id. Projection read —
+   * NEVER queries the provider/adapter. Returns `null` when no record exists.
+   * Backs the batch-retry endpoint's per-id eligibility check (#1245), which
+   * keys retry-eligibility on `InvoiceRecord.isReattemptableFailure`.
+   */
+  getInvoiceById(invoiceId: string): Promise<InvoiceRecord | null>;
+
+  /**
    * Read-only AC-6 list (#1119) of OL's OWN `InvoiceRecord` projection, filtered
    * + paginated. The cross-context list seam the HTTP layer calls — apps/** reach
    * the invoice projection through this service interface, NEVER the repository

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -519,6 +519,25 @@ describe('InvoiceService', () => {
     });
   });
 
+  describe('getInvoiceById (#1245)', () => {
+    it('delegates to repo.findById and never touches the adapter', async () => {
+      const record = makeRecord({ id: 'inv-1', status: 'failed' });
+      repo.findById.mockResolvedValue(record);
+
+      const result = await service.getInvoiceById('inv-1');
+
+      expect(repo.findById).toHaveBeenCalledWith('inv-1');
+      expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+      expect(result).toBe(record);
+    });
+
+    it('returns null when no record holds the id', async () => {
+      repo.findById.mockResolvedValue(null);
+
+      expect(await service.getInvoiceById('missing')).toBeNull();
+    });
+  });
+
   describe('fiscal-safety lease invariant (#1200)', () => {
     it('keeps the CAS lease strictly above the max supported provider timeout (enforced by construction, not by comment)', () => {
       // If this ever fails, an expired lease could be re-claimed while the

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -520,7 +520,7 @@ describe('InvoiceService', () => {
   });
 
   describe('getInvoiceById (#1245)', () => {
-    it('delegates to repo.findById and never touches the adapter', async () => {
+    it('should delegate to repo.findById and never touch the adapter', async () => {
       const record = makeRecord({ id: 'inv-1', status: 'failed' });
       repo.findById.mockResolvedValue(record);
 
@@ -531,7 +531,7 @@ describe('InvoiceService', () => {
       expect(result).toBe(record);
     });
 
-    it('returns null when no record holds the id', async () => {
+    it('should return null when no record holds the id', async () => {
       repo.findById.mockResolvedValue(null);
 
       expect(await service.getInvoiceById('missing')).toBeNull();

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -404,6 +404,11 @@ export class InvoiceService implements IInvoiceService {
     return this.repo.findByOrderId(query.orderId, query.connectionId);
   }
 
+  async getInvoiceById(invoiceId: string): Promise<InvoiceRecord | null> {
+    // Projection read of OL's OWN store by primary id — NEVER the provider/adapter.
+    return this.repo.findById(invoiceId);
+  }
+
   async listInvoices(
     filter: InvoiceRecordFilters,
     pagination: InvoiceRecordPagination,


### PR DESCRIPTION
## What

Adds a batch retry endpoint so operators can re-attempt many failed invoice issuances in one call instead of one order at a time.

`POST /invoices/retry`
- **Request**: `{ invoiceIds: string[] }`
- **Response**: `{ retried: number, skipped: number, results: { id, outcome: 'retried' | 'skipped', reason? }[] }` (§7.2 frozen shape + a neutral per-id `reason` on skips)

## Behaviour

- Retries **only** records that are retry-eligible — `status === 'failed' && failureMode === 'rejected'` (the entity's `isReattemptableFailure` derivation: a terminal rejection where the provider created **no** document).
- **Server-side skips** `issued` / `issuing` / `pending` / `in-doubt` / unknown ids with a neutral, PII-free per-id reason — never re-issuing them.
- **Reuses the single-invoice issue/retry primitive** per id (no parallel bulk pipeline): per eligible id it loads the order, rehydrates it, rebuilds the `IssueInvoiceCommand` reusing the record's **own** `idempotencyKey` (so the service resumes *that* row — R2/R3 exactly-once), and calls `issueInvoice`.
- A provider re-rejection or rehydration failure for one id is captured as `skipped` with a correlation id; it never aborts the batch and never leaks provider/PII text.
- Repeated ids are de-duplicated so an id is attempted at most once.
- Core: new `IInvoiceService.getInvoiceById` (delegates to `repo.findById`) backs the per-id eligibility check.

## Note on buyer tax id

The buyer's scheme-tagged tax id is not persisted on the `InvoiceRecord` projection, so the rebuilt command derives the buyer from the order snapshot alone (`buyer.taxId = null`) — matching a keyless re-issue through `POST /invoices`.

## Stacked on #1214

This PR is **stacked on #1214** (`1200-invoicing-exactly-once`, W1) — the base is that branch, not `main`. The eligibility gate keys on `failureMode === 'rejected'` and the `issuing` / `in-doubt` states, all of which are introduced by W1; they do not exist on `main` yet. **Until #1214 merges, this PR's diff includes W1's commits.** After #1214 lands on `main`, retarget this PR's base to `main`.

## Scoped checks

`@openlinker/core` + `@openlinker/api` type-check green; core invoicing 93/93; api invoicing 36/36 (+11 new W6 tests); eslint 0 errors on changed files.

Closes #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4ShufMjpq73tHU3W9EDsD