### PR TITLE
fix(erli): add ErliConnectionActions — webhook configure UI

### DIFF
--- a/apps/web/src/plugins/erli/components/erli-connection-actions.test.tsx
+++ b/apps/web/src/plugins/erli/components/erli-connection-actions.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * ErliConnectionActions Tests
+ */
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMockApiClient,
+  findToastTitle,
+  renderWithProviders,
+  sampleConnection,
+} from '../../../test/test-utils';
+import { ErliConnectionActions } from './erli-connection-actions';
+
+const erliConnection = { ...sampleConnection, platformType: 'erli' };
+
+const withCallbackUrl = {
+  ...erliConnection,
+  config: { callbackBaseUrl: 'https://ol.example.com' },
+};
+const withCallbackUrlConfigured = {
+  ...withCallbackUrl,
+  config: { ...withCallbackUrl.config, webhooksConfigured: true },
+};
+
+describe('ErliConnectionActions', () => {
+  afterEach(cleanup);
+
+  it('shows the callbackBaseUrl guard when config.callbackBaseUrl is absent', () => {
+    renderWithProviders(<ErliConnectionActions connection={erliConnection} />);
+    expect(screen.getByText(/before configuring webhooks/)).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('shows the Configure webhooks button when callbackBaseUrl is set', () => {
+    renderWithProviders(<ErliConnectionActions connection={withCallbackUrl} />);
+    expect(screen.getByRole('button', { name: 'Configure webhooks' })).toBeInTheDocument();
+    expect(screen.queryByText(/before configuring webhooks/)).not.toBeInTheDocument();
+  });
+
+  it('shows Re-configure when webhooksConfigured is true', () => {
+    renderWithProviders(<ErliConnectionActions connection={withCallbackUrlConfigured} />);
+    expect(screen.getByRole('button', { name: 'Re-configure webhooks' })).toBeInTheDocument();
+    expect(screen.getByText(/Currently configured/)).toBeInTheDocument();
+  });
+
+  it('shows a success toast when webhooksConfigured and testPingTriggered', async () => {
+    const installWebhooks = vi
+      .fn()
+      .mockResolvedValue({ webhooksConfigured: true, testPingTriggered: true });
+    const apiClient = createMockApiClient({ connections: { installWebhooks } });
+    renderWithProviders(<ErliConnectionActions connection={withCallbackUrl} />, { apiClient });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure webhooks' }));
+
+    expect(await findToastTitle('Webhooks configured')).toBeInTheDocument();
+  });
+
+  it('shows a warning toast when webhooksConfigured but testPingTriggered is false', async () => {
+    const installWebhooks = vi
+      .fn()
+      .mockResolvedValue({ webhooksConfigured: true, testPingTriggered: false });
+    const apiClient = createMockApiClient({ connections: { installWebhooks } });
+    renderWithProviders(<ErliConnectionActions connection={withCallbackUrl} />, { apiClient });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure webhooks' }));
+
+    expect(await findToastTitle('Webhooks configured (ping not received)')).toBeInTheDocument();
+  });
+
+  it('shows an error toast when the mutation rejects', async () => {
+    const installWebhooks = vi.fn().mockRejectedValue(new Error('Network error'));
+    const apiClient = createMockApiClient({ connections: { installWebhooks } });
+    renderWithProviders(<ErliConnectionActions connection={withCallbackUrl} />, { apiClient });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure webhooks' }));
+
+    expect(await findToastTitle('Configuration push failed')).toBeInTheDocument();
+  });
+
+  it('disables the button while the mutation is pending', async () => {
+    let resolve!: (v: unknown) => void;
+    const installWebhooks = vi.fn().mockReturnValue(new Promise((r) => (resolve = r)));
+    const apiClient = createMockApiClient({ connections: { installWebhooks } });
+    renderWithProviders(<ErliConnectionActions connection={withCallbackUrl} />, { apiClient });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure webhooks' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Configuring...' })).toBeDisabled(),
+    );
+
+    resolve({ webhooksConfigured: true, testPingTriggered: true });
+  });
+});

--- a/apps/web/src/plugins/erli/components/erli-connection-actions.tsx
+++ b/apps/web/src/plugins/erli/components/erli-connection-actions.tsx
@@ -1,0 +1,102 @@
+/**
+ * Erli Connection Actions
+ *
+ * Plugin-owned action rows rendered inside `ConnectionActionsPanel` for
+ * Erli connections. Exposes the "Configure webhooks" action (#1216) — guards
+ * against a missing `config.callbackBaseUrl` (required by the backend before
+ * it can register Erli webhook subscriptions) with an instructional message
+ * instead of surfacing a raw 400.
+ *
+ * @module plugins/erli/components
+ */
+import type { ReactElement } from 'react';
+import type { Connection } from '../../../features/connections';
+import { useConfigureWebhooksMutation } from '../../../features/connections';
+import { Button } from '../../../shared/ui/button';
+import { useToast } from '../../../shared/ui/toast-provider';
+
+interface ErliConnectionActionsProps {
+  connection: Connection;
+}
+
+export function ErliConnectionActions({
+  connection,
+}: ErliConnectionActionsProps): ReactElement {
+  const configureWebhooks = useConfigureWebhooksMutation();
+  const { showToast } = useToast();
+
+  const config =
+    typeof connection.config === 'object' && connection.config !== null
+      ? (connection.config as Record<string, unknown>)
+      : {};
+
+  const hasCallbackBaseUrl =
+    typeof config.callbackBaseUrl === 'string' && config.callbackBaseUrl.length > 0;
+
+  const webhooksConfigured = config.webhooksConfigured === true;
+
+  async function handleConfigureWebhooks(): Promise<void> {
+    try {
+      const result = await configureWebhooks.mutateAsync(connection.id);
+      if (result.webhooksConfigured && result.testPingTriggered) {
+        showToast({
+          tone: 'success',
+          title: 'Webhooks configured',
+          description: 'Erli webhook subscriptions registered and verified by a test ping.',
+        });
+      } else if (result.webhooksConfigured) {
+        showToast({
+          tone: 'warning',
+          title: 'Webhooks configured (ping not received)',
+          description:
+            'Subscriptions registered but the test ping did not arrive. Click again to retry, or wait for the next real event.',
+        });
+      } else {
+        showToast({
+          tone: 'error',
+          title: 'Configuration push failed',
+          description: result.warning ?? 'Erli did not accept the webhook registration.',
+        });
+      }
+    } catch (error) {
+      showToast({
+        tone: 'error',
+        title: 'Configuration push failed',
+        description: (error as Error).message,
+      });
+    }
+  }
+
+  return (
+    <div className="action-list__item">
+      <div>
+        <strong>Configure webhooks</strong>
+        {hasCallbackBaseUrl ? (
+          <p className="muted-text">
+            Register Erli webhook subscriptions and rotate the webhook secret.
+            {webhooksConfigured ? ' Currently configured ✓' : ''}
+          </p>
+        ) : (
+          <p className="muted-text">
+            Set <code>callbackBaseUrl</code> on this connection before configuring webhooks. Open{' '}
+            <strong>Edit connection</strong>, add <code>callbackBaseUrl</code> (the public
+            OpenLinker URL Erli posts webhooks to), then return here.
+          </p>
+        )}
+      </div>
+      {hasCallbackBaseUrl && (
+        <Button
+          tone={webhooksConfigured ? 'secondary' : 'primary'}
+          disabled={configureWebhooks.isPending}
+          onClick={() => void handleConfigureWebhooks()}
+        >
+          {configureWebhooks.isPending
+            ? 'Configuring...'
+            : webhooksConfigured
+              ? 'Re-configure webhooks'
+              : 'Configure webhooks'}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/plugins/erli/erli.test.ts
+++ b/apps/web/src/plugins/erli/erli.test.ts
@@ -49,9 +49,11 @@ describe('erliPlugin', () => {
     it('contributes a credentials panel', () => {
       expect(erliPlugin.platform?.CredentialsPanel).toBeDefined();
     });
-    it('does NOT contribute structured-config edit or connection-action slots', () => {
+    it('does NOT contribute a structured-config edit slot', () => {
       expect(erliPlugin.platform?.StructuredConfigSection).toBeUndefined();
-      expect(erliPlugin.platform?.ConnectionActions).toBeUndefined();
+    });
+    it('contributes a ConnectionActions component for webhook install (#1216)', () => {
+      expect(erliPlugin.platform?.ConnectionActions).toBeDefined();
     });
     it('contributes the bulk-offer config section + offer validation (#1096)', () => {
       expect(erliPlugin.platform?.bulkOfferConfigSection?.component).toBeDefined();

--- a/apps/web/src/plugins/erli/index.ts
+++ b/apps/web/src/plugins/erli/index.ts
@@ -19,6 +19,7 @@ import { lazy } from 'react';
 import { erliBulkConfigIsComplete, erliOfferValidation } from '../../features/listings';
 import type { OpenLinkerPlugin } from '../../shared/plugins';
 import { definePlugin } from '../define-plugin';
+import { ErliConnectionActions } from './components/erli-connection-actions';
 import { ErliCredentialsPanel } from './components/erli-credentials-panel';
 import { erliSetupRoute } from './erli-setup.route';
 
@@ -57,6 +58,7 @@ export const erliPlugin: OpenLinkerPlugin = definePlugin({
       badge: 'API key',
     },
     CredentialsPanel: ErliCredentialsPanel,
+    ConnectionActions: ErliConnectionActions,
     // Bulk offer creation (#1096): dispatch time, no policies, PLN-only.
     bulkOfferConfigSection: {
       component: ErliBulkConfigSectionLazy,

--- a/docs/integrations/erli/setup-guide.md
+++ b/docs/integrations/erli/setup-guide.md
@@ -139,7 +139,7 @@ but recommended.
      a tunnel that exposes your local API (`:3000`) on a public `https` URL — e.g.
      `cloudflared tunnel --url http://localhost:3000` — and set `callbackBaseUrl`
      to the tunnel URL.
-2. On **Connection detail → Actions**, click **Install webhooks**.
+2. On **Connection detail → Actions**, click **Configure webhooks**.
 
 OpenLinker rotates a per-connection webhook secret and registers two hooks with
 Erli (`orderCreated`, `orderStatusChanged`). The callback URL is


### PR DESCRIPTION
## Summary

- Adds `ErliConnectionActions` component to the Erli plugin's `ConnectionActions` platform contribution slot
- Reuses the existing `useConfigureWebhooksMutation` hook; surfaces loading / success / warning / error toast states
- Guards against a missing `config.callbackBaseUrl` with an instructional message instead of an opaque 400 from the backend
- Updates `erli.test.ts` smoke test to assert the slot is now contributed
- Fixes §5 button label in the Erli operator guide ("Install webhooks" → "Configure webhooks")

## Test plan

- [ ] `ErliConnectionActions` unit tests: 7 cases covering guard state, primary/secondary button states, all toast outcomes, and pending-disabled
- [ ] `erliPlugin` smoke test updated: `ConnectionActions` now expected defined; `StructuredConfigSection` still undefined
- [ ] Manual: Erli connection detail → Actions tab shows "Configure webhooks" action

Closes #1216