### PR TITLE
feat(invoicing): Subiekt FE deltas — detail section, correction flow, HTTP endpoint

### DIFF
--- a/apps/api/src/invoicing/http/dto/issue-correction-request.dto.ts
+++ b/apps/api/src/invoicing/http/dto/issue-correction-request.dto.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue Correction Request DTO (#1241)
+ *
+ * Request body for `POST /invoices/:invoiceId/correct`. Carries only the
+ * caller-supplied correction fields; `connectionId` / `orderId` /
+ * `originalProviderInvoiceId` are resolved server-side from the original
+ * `InvoiceRecord` identified by `:invoiceId`.
+ *
+ * @module apps/api/src/invoicing/http/dto
+ */
+import { IsString, IsOptional, IsArray, ValidateNested, IsNumber, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CorrectionLineDto {
+  @ApiPropertyOptional({ description: '1-based line number of the original invoice line to correct.' })
+  @IsNumber()
+  @Min(1)
+  originalLineNumber!: number;
+
+  @ApiPropertyOptional({ description: 'New quantity (post-correction). Omit to leave quantity unchanged.' })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  newQuantity?: number;
+
+  @ApiPropertyOptional({ description: 'New gross unit price (post-correction). Omit to leave price unchanged.' })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  newUnitPriceGross?: number;
+}
+
+export class IssueCorrectionRequestDto {
+  @ApiPropertyOptional({ description: 'Free-text reason for correction (e.g. partial return).' })
+  @IsString()
+  @IsOptional()
+  reason?: string;
+
+  @ApiPropertyOptional({ type: [CorrectionLineDto], description: 'Per-line corrections — at least one line must be present.' })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CorrectionLineDto)
+  lines!: CorrectionLineDto[];
+
+  @ApiPropertyOptional({ description: 'Caller-supplied idempotency key for exactly-once issuance.' })
+  @IsString()
+  @IsOptional()
+  idempotencyKey?: string;
+}

--- a/apps/api/src/invoicing/http/dto/issue-correction-request.dto.ts
+++ b/apps/api/src/invoicing/http/dto/issue-correction-request.dto.ts
@@ -8,12 +8,12 @@
  *
  * @module apps/api/src/invoicing/http/dto
  */
-import { IsString, IsOptional, IsArray, ValidateNested, IsNumber, Min } from 'class-validator';
+import { IsString, IsOptional, IsArray, ValidateNested, IsNumber, Min, ArrayMinSize } from 'class-validator';
 import { Type } from 'class-transformer';
-import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CorrectionLineDto {
-  @ApiPropertyOptional({ description: '1-based line number of the original invoice line to correct.' })
+  @ApiProperty({ description: '1-based line number of the original invoice line to correct.' })
   @IsNumber()
   @Min(1)
   originalLineNumber!: number;
@@ -37,8 +37,9 @@ export class IssueCorrectionRequestDto {
   @IsOptional()
   reason?: string;
 
-  @ApiPropertyOptional({ type: [CorrectionLineDto], description: 'Per-line corrections — at least one line must be present.' })
+  @ApiProperty({ type: [CorrectionLineDto], description: 'Per-line corrections — at least one line must be present.' })
   @IsArray()
+  @ArrayMinSize(1)
   @ValidateNested({ each: true })
   @Type(() => CorrectionLineDto)
   lines!: CorrectionLineDto[];

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -61,6 +61,7 @@ import {
   CapabilityNotEnabledException,
 } from '@openlinker/core/integrations';
 import { IssueInvoiceRequestDto } from './dto/issue-invoice-request.dto';
+import { IssueCorrectionRequestDto } from './dto/issue-correction-request.dto';
 import { GetInvoiceForOrderQueryDto } from './dto/get-invoice-for-order-query.dto';
 import { ListInvoicesQueryDto } from './dto/list-invoices-query.dto';
 import { InvoiceRecordResponseDto } from './dto/invoice-record-response.dto';
@@ -280,6 +281,55 @@ export class InvoicingController {
         reason: `Re-attempt failed; surfaced for manual review (correlationId: ${correlationId}).`,
       };
     }
+  }
+
+  @Post('invoices/:invoiceId/correct')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Issue a correction of an already-issued invoice',
+    description:
+      'Issues a correcting document (faktura korygująca / credit-note) for the invoice ' +
+      'identified by :invoiceId. The original InvoiceRecord is resolved server-side to ' +
+      'extract connectionId, orderId, and originalProviderInvoiceId. Requires the ' +
+      'connection adapter to implement the CorrectionIssuer sub-capability.',
+  })
+  @ApiResponse({ status: 201, description: 'Correction invoice issued', type: InvoiceRecordResponseDto })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  @ApiResponse({ status: 422, description: 'Provider rejected the correction or adapter does not support corrections' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async issueCorrection(
+    @Param('invoiceId') invoiceId: string,
+    @Body() dto: IssueCorrectionRequestDto,
+  ): Promise<InvoiceRecordResponseDto> {
+    const original = await this.invoiceService.getInvoiceById(invoiceId);
+    if (!original) {
+      throw new NotFoundException(`Invoice not found: ${invoiceId}`);
+    }
+    if (!original.providerInvoiceId) {
+      throw new UnprocessableEntityException(
+        `Invoice ${invoiceId} has no provider invoice id — it may not be fully issued yet`,
+      );
+    }
+
+    let issued: InvoiceRecord;
+    try {
+      issued = await this.invoiceService.issueCorrection({
+        connectionId: original.connectionId,
+        orderId: original.orderId,
+        originalProviderInvoiceId: original.providerInvoiceId,
+        documentType: dto.lines.length > 0 ? 'corrected' : undefined,
+        reason: dto.reason,
+        lines: dto.lines.map((l) => ({
+          originalLineNumber: l.originalLineNumber,
+          newQuantity: l.newQuantity,
+          newUnitPriceGross: l.newUnitPriceGross,
+        })),
+        idempotencyKey: dto.idempotencyKey,
+      });
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
+    return this.toDto(issued);
   }
 
   @Get('orders/:orderId/invoice')

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -41,6 +41,7 @@ import {
   toIssueInvoiceCommand,
   InvalidBuyerProfileError,
   UnsupportedPriceTreatmentError,
+  DuplicateInvoiceRecordException,
 } from '@openlinker/core/invoicing';
 import type {
   InvoiceRecord,
@@ -445,6 +446,9 @@ export class InvoicingController {
    *     the global filter — they are not invoice-issuance rejections).
    */
   private toHttpException(error: unknown): Error {
+    if (error instanceof DuplicateInvoiceRecordException) {
+      return new ConflictException('An invoice record with this idempotency key already exists');
+    }
     if (
       error instanceof InvalidBuyerProfileError ||
       error instanceof UnsupportedPriceTreatmentError

--- a/apps/web/src/features/invoicing/api/invoicing.api.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.api.ts
@@ -7,6 +7,7 @@
  *   - `GET /invoices/:invoiceId` (detail page — W2 #1231)
  *   - `POST /invoices`
  *   - `POST /invoices/retry` (batch retry — W6 #1245)
+ *   - `POST /invoices/:invoiceId/correct` (correction — #1241)
  *
  * @module apps/web/src/features/invoicing/api
  */
@@ -14,6 +15,7 @@ import type {
   InvoiceFilters,
   InvoicePagination,
   InvoiceRecord,
+  IssueCorrectionInput,
   IssueInvoiceInput,
   PaginatedInvoices,
   RetryInvoicesInput,
@@ -35,6 +37,8 @@ export interface InvoicingApi {
   /** `POST /invoices/retry` — batch retry of failed+rejected records (W6 #1245).
    *  The server gates eligibility; non-eligible ids are skipped per-id. */
   retry: (input: RetryInvoicesInput) => Promise<RetryInvoicesResult>;
+  /** `POST /invoices/:invoiceId/correct` — issue a correcting document (#1241). */
+  issueCorrection: (invoiceId: string, input: IssueCorrectionInput) => Promise<InvoiceRecord>;
 }
 
 interface ApiRequest {
@@ -82,6 +86,13 @@ export function createInvoicingApi(request: ApiRequest): InvoicingApi {
     },
     retry(input): Promise<RetryInvoicesResult> {
       return request<RetryInvoicesResult>('/invoices/retry', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(input),
+      });
+    },
+    issueCorrection(invoiceId, input): Promise<InvoiceRecord> {
+      return request<InvoiceRecord>(`/invoices/${encodeURIComponent(invoiceId)}/correct`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(input),

--- a/apps/web/src/features/invoicing/api/invoicing.types.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.types.ts
@@ -174,3 +174,18 @@ export interface RetryInvoicesResult {
   skipped: number;
   results: RetryInvoiceResult[];
 }
+
+/** One corrected line for `POST /invoices/:invoiceId/correct` (#1241). */
+export interface CorrectionLineInput {
+  originalLineNumber: number;
+  newQuantity?: number;
+  newUnitPriceGross?: number;
+}
+
+/** `POST /invoices/:invoiceId/correct` request body (#1241). Mirrors
+ *  `IssueCorrectionCommand` minus the server-resolved fields. */
+export interface IssueCorrectionInput {
+  reason?: string;
+  lines: CorrectionLineInput[];
+  idempotencyKey?: string;
+}

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
@@ -20,6 +20,11 @@
  */
 import { useMemo, useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '../../../shared/ui/dialog';
 
 import { useConnectionsQuery, type Connection } from '../../connections';
 import { useTranslation } from '../../../shared/i18n';
@@ -99,9 +104,12 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
   const invoiceQuery = useOrderInvoiceQuery(order.internalOrderId, invoicingConnectionId);
   const issueMutation = useIssueInvoiceMutation();
 
-  // Per-provider plugin slot (resolved via platformType — ZERO literal strings here)
+  // Per-provider plugin slots (resolved via platformType — ZERO literal strings here)
   const platform = usePlatform(invoicingConnection?.platformType);
   const InvoiceDetailSection = platform?.invoiceDetailSection ?? null;
+  const InvoiceCorrectionFlow = platform?.invoiceCorrectionFlow ?? null;
+
+  const [correctionOpen, setCorrectionOpen] = useState(false);
 
   // Loading skeleton while connections settle
   if (connectionsQuery.isLoading) {
@@ -329,6 +337,29 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
           {/* Provider extras slot (e.g. KSeF UPO, Subiekt KSeF status) */}
           {InvoiceDetailSection && invoicingConnection ? (
             <InvoiceDetailSection invoice={invoice} connection={invoicingConnection} />
+          ) : null}
+
+          {/* Correction trigger — only when the provider supports the slot */}
+          {InvoiceCorrectionFlow && invoicingConnection ? (
+            <div className="order-invoice-panel__correction">
+              <Button tone="secondary" onClick={() => setCorrectionOpen(true)}>
+                {t('invoice.action.issueCorrection', 'Issue correction')}
+              </Button>
+              <Dialog open={correctionOpen} onOpenChange={setCorrectionOpen}>
+                <DialogContent aria-describedby={undefined}>
+                  <DialogTitle>{t('invoice.correction.dialogTitle', 'Issue correction')}</DialogTitle>
+                  <InvoiceCorrectionFlow
+                    invoice={invoice}
+                    connection={invoicingConnection}
+                    onClose={() => setCorrectionOpen(false)}
+                    onCorrectionIssued={() => {
+                      setCorrectionOpen(false);
+                      void invoiceQuery.refetch();
+                    }}
+                  />
+                </DialogContent>
+              </Dialog>
+            </div>
           ) : null}
         </div>
       ) : null}

--- a/apps/web/src/features/invoicing/hooks/use-issue-correction-mutation.ts
+++ b/apps/web/src/features/invoicing/hooks/use-issue-correction-mutation.ts
@@ -1,0 +1,34 @@
+/**
+ * useIssueCorrectionMutation (#1241)
+ *
+ * Mutation hook for `POST /invoices/:invoiceId/correct`. On success invalidates
+ * the invoicing query domain so the correction record appears immediately.
+ *
+ * @module apps/web/src/features/invoicing/hooks
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { invoicingQueryKeys } from '../api/invoicing.query-keys';
+import type { InvoiceRecord, IssueCorrectionInput } from '../api/invoicing.types';
+
+export interface IssueCorrectionVariables {
+  invoiceId: string;
+  input: IssueCorrectionInput;
+}
+
+export function useIssueCorrectionMutation(): UseMutationResult<
+  InvoiceRecord,
+  Error,
+  IssueCorrectionVariables
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ invoiceId, input }) => apiClient.invoicing.issueCorrection(invoiceId, input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: invoicingQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/invoicing/index.ts
+++ b/apps/web/src/features/invoicing/index.ts
@@ -16,7 +16,12 @@ export { useInvoiceQuery } from './hooks/use-invoice-query';
 export { useIssueInvoiceMutation } from './hooks/use-issue-invoice-mutation';
 export { useInvoicesQuery } from './hooks/use-invoices-query';
 export { useRetryInvoicesMutation } from './hooks/use-retry-invoices-mutation';
+export {
+  useIssueCorrectionMutation,
+  type IssueCorrectionVariables,
+} from './hooks/use-issue-correction-mutation';
 export { invoicingQueryKeys } from './api/invoicing.query-keys';
+export { RegulatoryStatusBadge } from './components/regulatory-status-badge';
 export type {
   InvoiceRecord,
   InvoiceStatus,
@@ -32,4 +37,6 @@ export type {
   RetryInvoicesResult,
   RetryInvoiceResult,
   RetryOutcome,
+  CorrectionLineInput,
+  IssueCorrectionInput,
 } from './api/invoicing.types';

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9859,3 +9859,59 @@ html[data-density='compact'] .status-badge {
   gap: var(--space-2);
 }
 
+/* ─ Shared wizard action bar ─ */
+.wizard__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+}
+.wizard__spacer {
+  flex: 1;
+}
+
+/* ─ Subiekt invoice correction dialog (#1241) ─ */
+.subiekt-correction__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  border: 0;
+  padding: 0 0 var(--space-3);
+}
+.subiekt-correction__reason {
+  margin-bottom: var(--space-4);
+}
+.subiekt-correction__table-scroll {
+  overflow-x: auto;
+}
+.subiekt-correction__col-qty {
+  min-width: 80px;
+}
+.subiekt-correction__col-price {
+  min-width: 100px;
+}
+.input--w-lp {
+  width: 60px;
+}
+.input--w-qty {
+  width: 80px;
+}
+.input--w-price {
+  width: 100px;
+}
+.subiekt-correction__note {
+  margin-top: var(--space-3);
+}
+
+/* ─ Correction trigger in order invoice panel (issued state) ─ */
+.order-invoice-panel__correction {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  justify-content: flex-end;
+}
+

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.test.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * SubiektInvoiceCorrectionFlow tests (#1241)
+ *
+ * @module plugins/subiekt/components
+ */
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient, sampleConnection } from '../../../test/test-utils';
+import type { InvoiceRecord } from '../../../features/invoicing/api/invoicing.types';
+import { SubiektInvoiceCorrectionFlow } from './subiekt-invoice-correction-flow';
+
+const subiektConnection = { ...sampleConnection, platformType: 'subiekt' };
+
+function makeInvoice(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
+  return {
+    id: 'ol_invoice_test',
+    connectionId: subiektConnection.id,
+    orderId: 'ol_order_test',
+    providerType: 'subiekt',
+    documentType: 'invoice',
+    status: 'issued',
+    providerInvoiceId: 'subiekt-101',
+    providerInvoiceNumber: 'FS 101/TEST/2026',
+    regulatoryStatus: 'accepted',
+    clearanceReference: '5260001246-20260625-A1B2-3D',
+    pdfUrl: 'https://subiekt.example/invoice.pdf',
+    failureMode: null,
+    failureCode: null,
+    failureReason: null,
+    issuedAt: '2026-06-25T10:00:00.000Z',
+    createdAt: '2026-06-25T09:59:00.000Z',
+    updatedAt: '2026-06-25T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+afterEach(() => cleanup());
+
+describe('SubiektInvoiceCorrectionFlow', () => {
+  it('renders the form header and invoice reference', async () => {
+    renderWithProviders(
+      <SubiektInvoiceCorrectionFlow
+        invoice={makeInvoice()}
+        connection={subiektConnection}
+        onClose={vi.fn()}
+        onCorrectionIssued={vi.fn()}
+      />,
+    );
+    expect(await screen.findByRole('heading', { name: /Issue correction/i })).toBeDefined();
+    expect(await screen.findByText(/FS 101\/TEST\/2026/i)).toBeDefined();
+  });
+
+  it('renders the reason textarea', async () => {
+    renderWithProviders(
+      <SubiektInvoiceCorrectionFlow
+        invoice={makeInvoice()}
+        connection={subiektConnection}
+        onClose={vi.fn()}
+        onCorrectionIssued={vi.fn()}
+      />,
+    );
+    expect(await screen.findByLabelText(/Reason for correction/i)).toBeDefined();
+  });
+
+  it('starts with one empty line row', async () => {
+    renderWithProviders(
+      <SubiektInvoiceCorrectionFlow
+        invoice={makeInvoice()}
+        connection={subiektConnection}
+        onClose={vi.fn()}
+        onCorrectionIssued={vi.fn()}
+      />,
+    );
+    const lineInputs = await screen.findAllByLabelText(/Line number/i);
+    expect(lineInputs).toHaveLength(1);
+  });
+
+  it('adds a line row on "+ Add line" click', async () => {
+    renderWithProviders(
+      <SubiektInvoiceCorrectionFlow
+        invoice={makeInvoice()}
+        connection={subiektConnection}
+        onClose={vi.fn()}
+        onCorrectionIssued={vi.fn()}
+      />,
+    );
+    const addBtn = await screen.findByText(/Add line/i);
+    fireEvent.click(addBtn);
+    const lineInputs = await screen.findAllByLabelText(/Line number/i);
+    expect(lineInputs).toHaveLength(2);
+  });
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const onClose = vi.fn();
+    renderWithProviders(
+      <SubiektInvoiceCorrectionFlow
+        invoice={makeInvoice()}
+        connection={subiektConnection}
+        onClose={onClose}
+        onCorrectionIssued={vi.fn()}
+      />,
+    );
+    fireEvent.click(await screen.findByText(/Cancel/i));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('submits issueCorrection with reason and line data on form submit', async () => {
+    const correctionInvoice = makeInvoice({ id: 'ol_invoice_correction' });
+    const issueCorrection = vi.fn().mockResolvedValue(correctionInvoice);
+    const onCorrectionIssued = vi.fn();
+    const onClose = vi.fn();
+
+    renderWithProviders(
+      <SubiektInvoiceCorrectionFlow
+        invoice={makeInvoice()}
+        connection={subiektConnection}
+        onClose={onClose}
+        onCorrectionIssued={onCorrectionIssued}
+      />,
+      { apiClient: createMockApiClient({ invoicing: { issueCorrection } }) },
+    );
+
+    // Fill reason
+    const reasonInput = await screen.findByLabelText(/Reason for correction/i);
+    fireEvent.change(reasonInput, { target: { value: 'Partial return' } });
+
+    // Fill line 1
+    const lineInput = await screen.findByLabelText(/Line number 1/i);
+    fireEvent.change(lineInput, { target: { value: '1' } });
+    const qtyInput = await screen.findByLabelText(/New qty, line 1/i);
+    fireEvent.change(qtyInput, { target: { value: '0' } });
+    const priceInput = await screen.findByLabelText(/New net, line 1/i);
+    fireEvent.change(priceInput, { target: { value: '34.84' } });
+
+    // Submit
+    fireEvent.click(await screen.findByRole('button', { name: /Issue correction/i }));
+
+    await waitFor(() => {
+      expect(issueCorrection).toHaveBeenCalledWith('ol_invoice_test', {
+        reason: 'Partial return',
+        lines: [{ originalLineNumber: 1, newQuantity: 0, newUnitPriceGross: 34.84 }],
+      });
+    });
+
+    await waitFor(() => expect(onCorrectionIssued).toHaveBeenCalledWith('ol_invoice_correction'));
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+  });
+
+  it('does not include empty line rows in the submission', async () => {
+    const issueCorrection = vi.fn().mockResolvedValue(makeInvoice({ id: 'ol_invoice_cor2' }));
+
+    renderWithProviders(
+      <SubiektInvoiceCorrectionFlow
+        invoice={makeInvoice()}
+        connection={subiektConnection}
+        onClose={vi.fn()}
+        onCorrectionIssued={vi.fn()}
+      />,
+      { apiClient: createMockApiClient({ invoicing: { issueCorrection } }) },
+    );
+
+    // Add a second line but leave it empty
+    fireEvent.click(await screen.findByText(/Add line/i));
+
+    // Only fill line 1
+    const lineInputs = await screen.findAllByLabelText(/Line number/i);
+    fireEvent.change(lineInputs[0], { target: { value: '2' } });
+
+    fireEvent.click(await screen.findByRole('button', { name: /Issue correction/i }));
+
+    await waitFor(() => {
+      const call = issueCorrection.mock.calls[0] as [string, { lines: { originalLineNumber: number }[] }];
+      expect(call[1].lines).toHaveLength(1);
+      expect(call[1].lines[0].originalLineNumber).toBe(2);
+    });
+  });
+});

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.test.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.test.tsx
@@ -139,6 +139,7 @@ describe('SubiektInvoiceCorrectionFlow', () => {
       expect(issueCorrection).toHaveBeenCalledWith('ol_invoice_test', {
         reason: 'Partial return',
         lines: [{ originalLineNumber: 1, newQuantity: 0, newUnitPriceGross: 34.84 }],
+        idempotencyKey: expect.stringMatching(/^sk-corr-/),
       });
     });
 

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
@@ -138,7 +138,7 @@ export function SubiektInvoiceCorrectionFlow({
         ) : null}
         {invoice.issuedAt ? (
           <span>
-            {t('subiekt.correction.issued', 'Issued')}{' '}
+            {t('subiekt.correction.issuedLabel', 'Issued')}{' '}
             <strong className="mono-text">
               {invoice.issuedAt.slice(0, 10)}
             </strong>

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
@@ -16,7 +16,7 @@
  *
  * @module plugins/subiekt/components
  */
-import { type ReactElement, useState } from 'react';
+import { type ReactElement, useState, useRef } from 'react';
 import { useTranslation } from '../../../shared/i18n';
 import { Button } from '../../../shared/ui/button';
 import { useToast } from '../../../shared/ui/toast-provider';
@@ -63,6 +63,13 @@ export function SubiektInvoiceCorrectionFlow({
 
   const [reason, setReason] = useState('');
   const [lines, setLines] = useState<LineRow[]>([emptyRow()]);
+  const [linesError, setLinesError] = useState<string | null>(null);
+
+  // Stable per-dialog-mount key — prevents re-issuing the same correction if
+  // the component re-renders or the user retries after a network timeout.
+  const idempotencyKeyRef = useRef(
+    `sk-corr-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
+  );
 
   function updateLine(index: number, field: keyof LineRow, value: string): void {
     setLines((prev) => prev.map((r, i) => (i === index ? { ...r, [field]: value } : r)));

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
@@ -1,0 +1,267 @@
+/**
+ * SubiektInvoiceCorrectionFlow (#1241)
+ *
+ * Per-provider `invoiceCorrectionFlow` slot for Subiekt. Issues a correcting
+ * document (faktura korygująca) via the #1241 HTTP endpoint
+ * `POST /invoices/:invoiceId/correct`. The operator supplies:
+ *   - an optional free-text reason;
+ *   - per-line new quantity and/or new unit price gross.
+ *
+ * The mockup shows N rows pre-populated from the original invoice lines. Since
+ * the FE has no access to line-item detail (the invoice record carries only the
+ * provider invoice ID), the operator enters line numbers explicitly. The form
+ * starts with ONE empty row and an "Add line" affordance for multi-line
+ * corrections. The host dialog owns the outer chrome; this component is
+ * content-only — call `onClose` to close the dialog.
+ *
+ * @module plugins/subiekt/components
+ */
+import { type ReactElement, useState } from 'react';
+import { useTranslation } from '../../../shared/i18n';
+import { Button } from '../../../shared/ui/button';
+import { useToast } from '../../../shared/ui/toast-provider';
+import type { InvoiceCorrectionFlowProps } from '../../../shared/plugins/plugin.types';
+import {
+  useIssueCorrectionMutation,
+  type CorrectionLineInput,
+} from '../../../features/invoicing';
+
+interface LineRow {
+  originalLineNumber: string;
+  newQuantity: string;
+  newUnitPriceGross: string;
+}
+
+function emptyRow(): LineRow {
+  return { originalLineNumber: '', newQuantity: '', newUnitPriceGross: '' };
+}
+
+function parseLineRows(rows: LineRow[]): CorrectionLineInput[] {
+  return rows
+    .filter((r) => r.originalLineNumber.trim() !== '')
+    .map((r) => {
+      const lineNum = parseInt(r.originalLineNumber, 10);
+      const qty = r.newQuantity.trim() !== '' ? parseFloat(r.newQuantity) : undefined;
+      const price =
+        r.newUnitPriceGross.trim() !== '' ? parseFloat(r.newUnitPriceGross) : undefined;
+      return {
+        originalLineNumber: lineNum,
+        ...(qty !== undefined && !Number.isNaN(qty) ? { newQuantity: qty } : {}),
+        ...(price !== undefined && !Number.isNaN(price) ? { newUnitPriceGross: price } : {}),
+      };
+    });
+}
+
+export function SubiektInvoiceCorrectionFlow({
+  invoice,
+  onClose,
+  onCorrectionIssued,
+}: InvoiceCorrectionFlowProps): ReactElement {
+  const { t } = useTranslation();
+  const { showToast } = useToast();
+  const mutation = useIssueCorrectionMutation();
+
+  const [reason, setReason] = useState('');
+  const [lines, setLines] = useState<LineRow[]>([emptyRow()]);
+
+  function updateLine(index: number, field: keyof LineRow, value: string): void {
+    setLines((prev) => prev.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+  }
+
+  function addLine(): void {
+    setLines((prev) => [...prev, emptyRow()]);
+  }
+
+  function removeLine(index: number): void {
+    setLines((prev) => (prev.length > 1 ? prev.filter((_, i) => i !== index) : prev));
+  }
+
+  function handleSubmit(): void {
+    const parsedLines = parseLineRows(lines);
+    mutation.mutate(
+      {
+        invoiceId: invoice.id,
+        input: {
+          reason: reason.trim() !== '' ? reason.trim() : undefined,
+          lines: parsedLines,
+        },
+      },
+      {
+        onSuccess: (correctionInvoice) => {
+          showToast({
+            tone: 'success',
+            title: t('subiekt.correction.issued', 'Correction issued'),
+            description: t(
+              'subiekt.correction.issuedBody',
+              'The correcting document was sent to Subiekt.',
+            ),
+          });
+          onCorrectionIssued(correctionInvoice.id);
+          onClose();
+        },
+        onError: (error) => {
+          showToast({
+            tone: 'error',
+            title: t('subiekt.correction.failed', 'Correction failed'),
+            description: error.message,
+          });
+        },
+      },
+    );
+  }
+
+  const isSubmitting = mutation.isPending;
+
+  return (
+    <div className="subiekt-correction">
+      {/* Header */}
+      <div className="section-card__head" style={{ border: 0, padding: '0 0 var(--space-3)' }}>
+        <h3>{t('subiekt.correction.title', 'Issue correction')}</h3>
+        <span className="section-card__provider">
+          {t('subiekt.correction.providerTag', 'Subiekt · slot')}
+        </span>
+      </div>
+
+      {/* Original invoice reference */}
+      <div className="corr__orig">
+        <span>
+          {t('subiekt.correction.correcting', 'Correcting')}{' '}
+          <strong>{invoice.providerInvoiceNumber ?? invoice.id}</strong>
+        </span>
+        {invoice.clearanceReference ? (
+          <span>
+            {t('subiekt.correction.ksefRef', 'KSeF')}{' '}
+            <strong className="mono-text">
+              {invoice.clearanceReference.slice(0, 14)}…
+            </strong>
+          </span>
+        ) : null}
+        {invoice.issuedAt ? (
+          <span>
+            {t('subiekt.correction.issued', 'Issued')}{' '}
+            <strong className="mono-text">
+              {invoice.issuedAt.slice(0, 10)}
+            </strong>
+          </span>
+        ) : null}
+      </div>
+
+      {/* Reason */}
+      <div className="field" style={{ marginBottom: 'var(--space-4)' }}>
+        <label htmlFor="sk-reason">
+          {t('subiekt.correction.reasonLabel', 'Reason for correction')}
+        </label>
+        <textarea
+          id="sk-reason"
+          className="textarea"
+          placeholder={t(
+            'subiekt.correction.reasonPlaceholder',
+            'e.g. Partial return of the order',
+          )}
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          disabled={isSubmitting}
+          rows={3}
+        />
+      </div>
+
+      {/* Line items */}
+      <div className="table-wrap" style={{ overflowX: 'auto' }}>
+        <table className="lineitems">
+          <thead>
+            <tr>
+              <th>{t('subiekt.correction.col.lp', 'Lp')}</th>
+              <th style={{ minWidth: '80px' }}>{t('subiekt.correction.col.newQty', 'New qty')}</th>
+              <th style={{ minWidth: '100px' }}>
+                {t('subiekt.correction.col.newPrice', 'New net')}
+              </th>
+              <th aria-label={t('subiekt.correction.col.remove', 'Remove')} />
+            </tr>
+          </thead>
+          <tbody>
+            {lines.map((row, i) => (
+              <tr key={i}>
+                <td>
+                  <input
+                    type="number"
+                    className="input input--num"
+                    value={row.originalLineNumber}
+                    onChange={(e) => updateLine(i, 'originalLineNumber', e.target.value)}
+                    placeholder="1"
+                    min={1}
+                    step={1}
+                    aria-label={`${t('subiekt.correction.lineNum', 'Line number')} ${i + 1}`}
+                    disabled={isSubmitting}
+                    style={{ width: '60px' }}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    className="input input--num"
+                    value={row.newQuantity}
+                    onChange={(e) => updateLine(i, 'newQuantity', e.target.value)}
+                    placeholder="—"
+                    min={0}
+                    step="any"
+                    aria-label={`${t('subiekt.correction.newQty', 'New qty, line')} ${i + 1}`}
+                    disabled={isSubmitting}
+                    style={{ width: '80px' }}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    className="input input--num"
+                    value={row.newUnitPriceGross}
+                    onChange={(e) => updateLine(i, 'newUnitPriceGross', e.target.value)}
+                    placeholder="—"
+                    min={0}
+                    step="any"
+                    aria-label={`${t('subiekt.correction.newPrice', 'New net, line')} ${i + 1}`}
+                    disabled={isSubmitting}
+                    style={{ width: '100px' }}
+                  />
+                </td>
+                <td>
+                  <Button
+                    tone="secondary"
+                    onClick={() => removeLine(i)}
+                    disabled={lines.length === 1 || isSubmitting}
+                    aria-label={`${t('subiekt.correction.removeLine', 'Remove line')} ${i + 1}`}
+                  >
+                    ✕
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <Button tone="secondary" onClick={addLine} disabled={isSubmitting}>
+        {t('subiekt.correction.addLine', '+ Add line')}
+      </Button>
+
+      <p className="corr-note" style={{ marginTop: 'var(--space-3)' }}>
+        {t(
+          'subiekt.correction.note',
+          'A correcting invoice (faktura korygująca) can adjust quantity and/or price per line — e.g. a returned unit or a post-sale price reduction. Subiekt transmits the correction to KSeF; OpenLinker tracks the status.',
+        )}
+      </p>
+
+      {/* Actions */}
+      <div className="wizard__actions">
+        <span style={{ flex: 1 }} />
+        <Button tone="secondary" onClick={onClose} disabled={isSubmitting}>
+          {t('subiekt.correction.cancel', 'Cancel')}
+        </Button>
+        <Button tone="primary" onClick={handleSubmit} disabled={isSubmitting}>
+          {isSubmitting
+            ? t('subiekt.correction.submitting', 'Issuing…')
+            : t('subiekt.correction.submit', 'Issue correction')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
@@ -65,14 +65,15 @@ export function SubiektInvoiceCorrectionFlow({
   const [lines, setLines] = useState<LineRow[]>([emptyRow()]);
   const [linesError, setLinesError] = useState<string | null>(null);
 
-  // Stable per-dialog-mount key — prevents re-issuing the same correction if
-  // the component re-renders or the user retries after a network timeout.
+  // Stable per-dialog-mount key — collapses post-timeout retries / duplicate tabs
+  // onto the same pending row so the same correcting document is never issued twice.
   const idempotencyKeyRef = useRef(
     `sk-corr-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
   );
 
   function updateLine(index: number, field: keyof LineRow, value: string): void {
     setLines((prev) => prev.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+    if (linesError) setLinesError(null);
   }
 
   function addLine(): void {
@@ -85,12 +86,23 @@ export function SubiektInvoiceCorrectionFlow({
 
   function handleSubmit(): void {
     const parsedLines = parseLineRows(lines);
+    if (parsedLines.length === 0) {
+      setLinesError(
+        t(
+          'subiekt.correction.linesRequired',
+          'At least one line with a line number is required.',
+        ),
+      );
+      return;
+    }
+    setLinesError(null);
     mutation.mutate(
       {
         invoiceId: invoice.id,
         input: {
           reason: reason.trim() !== '' ? reason.trim() : undefined,
           lines: parsedLines,
+          idempotencyKey: idempotencyKeyRef.current,
         },
       },
       {
@@ -122,7 +134,7 @@ export function SubiektInvoiceCorrectionFlow({
   return (
     <div className="subiekt-correction">
       {/* Header */}
-      <div className="section-card__head" style={{ border: 0, padding: '0 0 var(--space-3)' }}>
+      <div className="subiekt-correction__head">
         <h3>{t('subiekt.correction.title', 'Issue correction')}</h3>
         <span className="section-card__provider">
           {t('subiekt.correction.providerTag', 'Subiekt · slot')}
@@ -154,7 +166,7 @@ export function SubiektInvoiceCorrectionFlow({
       </div>
 
       {/* Reason */}
-      <div className="field" style={{ marginBottom: 'var(--space-4)' }}>
+      <div className="field subiekt-correction__reason">
         <label htmlFor="sk-reason">
           {t('subiekt.correction.reasonLabel', 'Reason for correction')}
         </label>
@@ -173,13 +185,13 @@ export function SubiektInvoiceCorrectionFlow({
       </div>
 
       {/* Line items */}
-      <div className="table-wrap" style={{ overflowX: 'auto' }}>
+      <div className="table-wrap subiekt-correction__table-scroll">
         <table className="lineitems">
           <thead>
             <tr>
               <th>{t('subiekt.correction.col.lp', 'Lp')}</th>
-              <th style={{ minWidth: '80px' }}>{t('subiekt.correction.col.newQty', 'New qty')}</th>
-              <th style={{ minWidth: '100px' }}>
+              <th className="subiekt-correction__col-qty">{t('subiekt.correction.col.newQty', 'New qty')}</th>
+              <th className="subiekt-correction__col-price">
                 {t('subiekt.correction.col.newPrice', 'New net')}
               </th>
               <th aria-label={t('subiekt.correction.col.remove', 'Remove')} />
@@ -191,7 +203,7 @@ export function SubiektInvoiceCorrectionFlow({
                 <td>
                   <input
                     type="number"
-                    className="input input--num"
+                    className="input input--num input--w-lp"
                     value={row.originalLineNumber}
                     onChange={(e) => updateLine(i, 'originalLineNumber', e.target.value)}
                     placeholder="1"
@@ -199,13 +211,12 @@ export function SubiektInvoiceCorrectionFlow({
                     step={1}
                     aria-label={`${t('subiekt.correction.lineNum', 'Line number')} ${i + 1}`}
                     disabled={isSubmitting}
-                    style={{ width: '60px' }}
                   />
                 </td>
                 <td>
                   <input
                     type="number"
-                    className="input input--num"
+                    className="input input--num input--w-qty"
                     value={row.newQuantity}
                     onChange={(e) => updateLine(i, 'newQuantity', e.target.value)}
                     placeholder="—"
@@ -213,13 +224,12 @@ export function SubiektInvoiceCorrectionFlow({
                     step="any"
                     aria-label={`${t('subiekt.correction.newQty', 'New qty, line')} ${i + 1}`}
                     disabled={isSubmitting}
-                    style={{ width: '80px' }}
                   />
                 </td>
                 <td>
                   <input
                     type="number"
-                    className="input input--num"
+                    className="input input--num input--w-price"
                     value={row.newUnitPriceGross}
                     onChange={(e) => updateLine(i, 'newUnitPriceGross', e.target.value)}
                     placeholder="—"
@@ -227,7 +237,6 @@ export function SubiektInvoiceCorrectionFlow({
                     step="any"
                     aria-label={`${t('subiekt.correction.newPrice', 'New net, line')} ${i + 1}`}
                     disabled={isSubmitting}
-                    style={{ width: '100px' }}
                   />
                 </td>
                 <td>
@@ -246,11 +255,17 @@ export function SubiektInvoiceCorrectionFlow({
         </table>
       </div>
 
+      {linesError ? (
+        <p className="field-error" role="alert">
+          {linesError}
+        </p>
+      ) : null}
+
       <Button tone="secondary" onClick={addLine} disabled={isSubmitting}>
         {t('subiekt.correction.addLine', '+ Add line')}
       </Button>
 
-      <p className="corr-note" style={{ marginTop: 'var(--space-3)' }}>
+      <p className="corr-note subiekt-correction__note">
         {t(
           'subiekt.correction.note',
           'A correcting invoice (faktura korygująca) can adjust quantity and/or price per line — e.g. a returned unit or a post-sale price reduction. Subiekt transmits the correction to KSeF; OpenLinker tracks the status.',
@@ -259,7 +274,7 @@ export function SubiektInvoiceCorrectionFlow({
 
       {/* Actions */}
       <div className="wizard__actions">
-        <span style={{ flex: 1 }} />
+        <span className="wizard__spacer" />
         <Button tone="secondary" onClick={onClose} disabled={isSubmitting}>
           {t('subiekt.correction.cancel', 'Cancel')}
         </Button>

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
@@ -256,7 +256,7 @@ export function SubiektInvoiceCorrectionFlow({
       </div>
 
       {linesError ? (
-        <p className="field-error" role="alert">
+        <p className="error-text" role="alert">
           {linesError}
         </p>
       ) : null}

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-detail-section.test.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-detail-section.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * SubiektInvoiceDetailSection tests (#1241)
+ *
+ * @module plugins/subiekt/components
+ */
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderWithProviders, sampleConnection } from '../../../test/test-utils';
+import type { InvoiceRecord } from '../../../features/invoicing/api/invoicing.types';
+import { SubiektInvoiceDetailSection } from './subiekt-invoice-detail-section';
+
+const subiektConnection = { ...sampleConnection, platformType: 'subiekt' };
+
+function makeInvoice(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
+  return {
+    id: 'ol_invoice_test',
+    connectionId: subiektConnection.id,
+    orderId: 'ol_order_test',
+    providerType: 'subiekt',
+    documentType: 'invoice',
+    status: 'issued',
+    providerInvoiceId: 'subiekt-101',
+    providerInvoiceNumber: 'FS 101/TEST/2026',
+    regulatoryStatus: 'not-applicable',
+    clearanceReference: null,
+    pdfUrl: null,
+    failureMode: null,
+    failureCode: null,
+    failureReason: null,
+    issuedAt: '2026-06-25T10:00:00.000Z',
+    createdAt: '2026-06-25T09:59:00.000Z',
+    updatedAt: '2026-06-25T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+afterEach(() => cleanup());
+
+describe('SubiektInvoiceDetailSection', () => {
+  it('renders nothing when regulatoryStatus is not-applicable and no pdfUrl', () => {
+    renderWithProviders(
+      <SubiektInvoiceDetailSection
+        invoice={makeInvoice()}
+        connection={subiektConnection}
+      />,
+    );
+    expect(screen.queryByText(/Regulatory status/i)).toBeNull();
+    expect(screen.queryByText(/KSeF status/i)).toBeNull();
+    expect(screen.queryByRole('link', { name: /Download PDF/i })).toBeNull();
+  });
+
+  it('renders KSeF status badge and clearance reference when regulatory data present', async () => {
+    renderWithProviders(
+      <SubiektInvoiceDetailSection
+        invoice={makeInvoice({
+          regulatoryStatus: 'accepted',
+          clearanceReference: '5260001246-20260625-A1B2-3D',
+        })}
+        connection={subiektConnection}
+      />,
+    );
+    expect(await screen.findByText(/KSeF status/i)).toBeDefined();
+    expect(await screen.findByText(/KSeF number/i)).toBeDefined();
+    expect(await screen.findByText('5260001246-20260625-A1B2-3D')).toBeDefined();
+  });
+
+  it('renders "Pending" when regulatoryStatus is accepted but no clearanceReference or providerInvoiceNumber', async () => {
+    renderWithProviders(
+      <SubiektInvoiceDetailSection
+        invoice={makeInvoice({
+          regulatoryStatus: 'submitted',
+          clearanceReference: null,
+          providerInvoiceNumber: null,
+        })}
+        connection={subiektConnection}
+      />,
+    );
+    expect(await screen.findByText(/Pending/i)).toBeDefined();
+  });
+
+  it('renders PDF download link when pdfUrl is set', async () => {
+    renderWithProviders(
+      <SubiektInvoiceDetailSection
+        invoice={makeInvoice({ pdfUrl: 'https://subiekt.example/invoice-101.pdf' })}
+        connection={subiektConnection}
+      />,
+    );
+    const link = await screen.findByRole('link', { name: /Download PDF/i });
+    expect(link.getAttribute('href')).toBe('https://subiekt.example/invoice-101.pdf');
+  });
+
+  it('renders both regulatory and PDF sections when both are present', async () => {
+    renderWithProviders(
+      <SubiektInvoiceDetailSection
+        invoice={makeInvoice({
+          regulatoryStatus: 'accepted',
+          clearanceReference: 'REF-001',
+          pdfUrl: 'https://subiekt.example/invoice.pdf',
+        })}
+        connection={subiektConnection}
+      />,
+    );
+    expect(await screen.findByText(/KSeF status/i)).toBeDefined();
+    expect(await screen.findByRole('link', { name: /Download PDF/i })).toBeDefined();
+  });
+
+  it('renders section when only pdfUrl is present (no regulatory data)', async () => {
+    renderWithProviders(
+      <SubiektInvoiceDetailSection
+        invoice={makeInvoice({ pdfUrl: 'https://subiekt.example/invoice.pdf' })}
+        connection={subiektConnection}
+      />,
+    );
+    expect(await screen.findByRole('link', { name: /Download PDF/i })).toBeDefined();
+    // No KSeF status row
+    expect(screen.queryByText(/KSeF status/i)).toBeNull();
+  });
+});

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-detail-section.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-detail-section.tsx
@@ -1,0 +1,82 @@
+/**
+ * SubiektInvoiceDetailSection (#1241)
+ *
+ * Per-provider `invoiceDetailSection` slot for Subiekt. Subiekt transmits
+ * invoices to KSeF natively — OpenLinker reads the clearance status from
+ * Subiekt (#1230) and links the PDF Subiekt renders. The slot is hidden when
+ * neither regulatory data nor a PDF URL is present (nothing to show).
+ *
+ * @module plugins/subiekt/components
+ */
+import type { ReactElement } from 'react';
+import { useTranslation } from '../../../shared/i18n';
+import type { InvoiceDetailSectionProps } from '../../../shared/plugins/plugin.types';
+import {
+  RegulatoryStatusBadge,
+  type RegulatoryStatus,
+} from '../../../features/invoicing';
+
+const NON_APPLICABLE: RegulatoryStatus = 'not-applicable';
+
+export function SubiektInvoiceDetailSection({
+  invoice,
+}: InvoiceDetailSectionProps): ReactElement | null {
+  const { t } = useTranslation();
+
+  const hasRegulatoryData = invoice.regulatoryStatus !== NON_APPLICABLE;
+  const hasPdf = Boolean(invoice.pdfUrl);
+
+  if (!hasRegulatoryData && !hasPdf) return null;
+
+  return (
+    <section className="detail-section">
+      <h2 className="detail-section__title">
+        {t('subiekt.invoice.detail.title', 'Regulatory status')}
+      </h2>
+      <p className="text-muted" style={{ fontSize: '12px', margin: '0 0 var(--space-3)' }}>
+        {t(
+          'subiekt.invoice.detail.note',
+          "Subiekt sent this to KSeF itself — OpenLinker reads the status, it doesn't transmit.",
+        )}
+      </p>
+      <dl className="invoice-panel__kv">
+        {hasRegulatoryData ? (
+          <>
+            <dt>{t('subiekt.invoice.detail.ksefStatus', 'KSeF status')}</dt>
+            <dd>
+              <RegulatoryStatusBadge status={invoice.regulatoryStatus} />
+              <span className="text-muted" style={{ fontSize: '11px', marginLeft: '6px' }}>
+                {t('subiekt.invoice.detail.readFrom', 'read from Subiekt')}
+              </span>
+            </dd>
+
+            <dt>{t('subiekt.invoice.detail.ksefNumber', 'KSeF number')}</dt>
+            <dd className="mono-text">
+              {invoice.clearanceReference ?? invoice.providerInvoiceNumber ?? (
+                <span className="text-muted">
+                  {t('subiekt.invoice.detail.pending', 'Pending')}
+                </span>
+              )}
+            </dd>
+          </>
+        ) : null}
+
+        {hasPdf ? (
+          <>
+            <dt>{t('subiekt.invoice.detail.pdf', 'Invoice PDF')}</dt>
+            <dd>
+              <a
+                href={invoice.pdfUrl ?? ''}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="link"
+              >
+                {t('subiekt.invoice.detail.downloadPdf', 'Download PDF')}
+              </a>
+            </dd>
+          </>
+        ) : null}
+      </dl>
+    </section>
+  );
+}

--- a/apps/web/src/plugins/subiekt/index.ts
+++ b/apps/web/src/plugins/subiekt/index.ts
@@ -42,6 +42,8 @@ import { definePlugin } from '../define-plugin';
 import { subiektSetupRoute } from './subiekt-setup.route';
 import { SubiektCredentialsPanel } from './components/subiekt-credentials-panel';
 import { SubiektStructuredSection } from './components/subiekt-structured-section';
+import { SubiektInvoiceDetailSection } from './components/subiekt-invoice-detail-section';
+import { SubiektInvoiceCorrectionFlow } from './components/subiekt-invoice-correction-flow';
 import { SUBIEKT_CAPABILITY_DESCRIPTORS } from './subiekt-capability-descriptors';
 
 export const subiektPlugin: OpenLinkerPlugin = definePlugin({
@@ -62,5 +64,7 @@ export const subiektPlugin: OpenLinkerPlugin = definePlugin({
     capabilityDescriptors: SUBIEKT_CAPABILITY_DESCRIPTORS,
     StructuredConfigSection: SubiektStructuredSection,
     CredentialsPanel: SubiektCredentialsPanel,
+    invoiceDetailSection: SubiektInvoiceDetailSection,
+    invoiceCorrectionFlow: SubiektInvoiceCorrectionFlow,
   },
 });

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -243,6 +243,8 @@ export function createMockApiClient(
       // explicit `overrides.invoicing.list` still wins.
       list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }),
       issue: vi.fn().mockResolvedValue(null),
+      retry: vi.fn().mockResolvedValue({ retried: 0, skipped: 0, results: [] }),
+      issueCorrection: vi.fn().mockResolvedValue(null),
       ...overrides.invoicing,
     } as ApiClient['invoicing'],
     orders: {

--- a/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
@@ -69,6 +69,7 @@ describe('InvoicingIssueHandler', () => {
       getInvoice: jest.fn(),
       getInvoiceById: jest.fn(),
       listInvoices: jest.fn(),
+      issueCorrection: jest.fn(),
     };
     handler = new InvoicingIssueHandler(invoiceService as unknown as IInvoiceService);
     warnSpy = jest

--- a/libs/core/src/invoicing/application/services/invoice.service.interface.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.interface.ts
@@ -14,6 +14,7 @@ import type {
   GetInvoiceByOrderQuery,
   InvoiceRecordFilters,
   InvoiceRecordPagination,
+  IssueCorrectionCommand,
   IssueInvoiceCommand,
   PaginatedInvoiceRecords,
 } from '../../domain/types/invoicing.types';
@@ -77,6 +78,17 @@ export interface IInvoiceService {
    * Returns `null` when no record holds the order on the connection.
    */
   getInvoice(query: GetInvoiceByOrderQuery): Promise<InvoiceRecord | null>;
+
+  /**
+   * Issue a correction of an already-issued document. Creates a new
+   * `InvoiceRecord` for the correcting document (status `pending` → `issued` on
+   * success). The original record is NOT mutated — corrections co-exist alongside
+   * the original in the projection. Throws `CapabilityNotSupportedException` if
+   * the connection's adapter does not implement `CorrectionIssuer`. Throws
+   * `CapabilityNotEnabledException` if the capability is not enabled on the
+   * connection.
+   */
+  issueCorrection(cmd: IssueCorrectionCommand): Promise<InvoiceRecord>;
 
   /**
    * Read OL's OWN `InvoiceRecord` projection by its primary id. Projection read —

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -27,8 +27,10 @@ import { InvoiceRecordRepositoryPort } from '../../domain/ports/invoice-record-r
 import { INVOICE_RECORD_REPOSITORY_TOKEN } from '../../invoicing.tokens';
 import type { InvoiceRecord } from '../../domain/entities/invoice-record.entity';
 import type { InvoicingPort } from '../../domain/ports/invoicing.port';
+import { isCorrectionIssuer } from '../../domain/ports/capabilities/correction-issuer.capability';
 import { DuplicateInvoiceRecordException } from '../../domain/exceptions/duplicate-invoice-record.exception';
 import { InvoiceRecordNotFoundException } from '../../domain/exceptions/invoice-record-not-found.exception';
+import { CapabilityNotSupportedException } from '@openlinker/core/integrations';
 import type {
   GetInvoiceByOrderQuery,
   InvoiceFailureCode,
@@ -36,6 +38,7 @@ import type {
   InvoiceOutcomePatch,
   InvoiceRecordFilters,
   InvoiceRecordPagination,
+  IssueCorrectionCommand,
   IssueInvoiceCommand,
   PaginatedInvoiceRecords,
 } from '../../domain/types/invoicing.types';
@@ -401,6 +404,79 @@ export class InvoiceService implements IInvoiceService {
     return reason.length <= MAX_FAILURE_REASON_LENGTH
       ? reason
       : reason.slice(0, MAX_FAILURE_REASON_LENGTH);
+  }
+
+  async issueCorrection(cmd: IssueCorrectionCommand): Promise<InvoiceRecord> {
+    // Persist intent before the provider call: `pending` row so a crash leaves
+    // a durable trace. Corrections do not share the idempotency-gate / CAS-lease
+    // of issueInvoice — each correction is a distinct new fiscal document with
+    // its own record; the caller supplies an idempotencyKey for dedup if needed.
+    const pending = await this.repo.create({
+      connectionId: cmd.connectionId,
+      orderId: cmd.orderId,
+      providerType: '',
+      documentType: cmd.documentType ?? 'corrected',
+      status: 'pending',
+      idempotencyKey: cmd.idempotencyKey ?? null,
+    });
+
+    const adapter = await this.integrations.getCapabilityAdapter<InvoicingPort>(
+      cmd.connectionId,
+      INVOICING_CAPABILITY,
+    );
+
+    if (!isCorrectionIssuer(adapter)) {
+      // Adapter resolved but doesn't implement CorrectionIssuer: update the row
+      // to failed (in-doubt) and throw so the caller can surface the 422.
+      await this.repo.updateOutcome(pending.id, {
+        status: 'failed',
+        errorMessage: 'Provider does not support correction issuance.',
+        failureMode: 'rejected',
+        failureCode: 'provider-rejected',
+        failureReason: 'The invoicing provider does not support corrections.',
+        leaseExpiresAt: null,
+      });
+      throw new CapabilityNotSupportedException(cmd.connectionId, 'CorrectionIssuer');
+    }
+
+    let issued: InvoiceRecord;
+    try {
+      issued = await adapter.issueCorrection(cmd);
+    } catch (error) {
+      const sanitized = this.sanitizeError(error);
+      const failureMode = this.classifyFailure(error);
+      const failureCode = this.classifyFailureCode(error, failureMode);
+      const failureReason = this.deriveFailureReason(failureCode);
+      this.logger.warn(
+        `Correction issuance failed for record ${pending.id} (failureMode=${failureMode}, failureCode=${failureCode}): ${sanitized}`,
+      );
+      await this.repo.updateOutcome(pending.id, {
+        status: 'failed',
+        errorMessage: sanitized,
+        failureMode,
+        failureCode,
+        failureReason,
+        leaseExpiresAt: null,
+      });
+      throw error;
+    }
+
+    return this.repo.updateOutcome(pending.id, {
+      status: 'issued',
+      providerType: issued.providerType,
+      documentType: issued.documentType,
+      providerInvoiceId: issued.providerInvoiceId,
+      providerInvoiceNumber: issued.providerInvoiceNumber,
+      regulatoryStatus: issued.regulatoryStatus,
+      clearanceReference: issued.clearanceReference,
+      pdfUrl: issued.pdfUrl,
+      issuedAt: issued.issuedAt,
+      errorMessage: null,
+      failureMode: null,
+      failureCode: null,
+      failureReason: null,
+      leaseExpiresAt: null,
+    });
   }
 
   async getInvoice(query: GetInvoiceByOrderQuery): Promise<InvoiceRecord | null> {


### PR DESCRIPTION
## Summary

- **Backend**: Adds `issueCorrection` to `IInvoiceService` + `InvoiceService` with the `CorrectionIssuer` sub-capability dispatch (fiscal-safe: pending row pre-created, updated atomically on outcome). Adds `POST /invoices/:invoiceId/correct` controller endpoint + `IssueCorrectionRequestDto`.
- **Frontend API layer**: `CorrectionLineInput` / `IssueCorrectionInput` types, `issueCorrection` API method, `useIssueCorrectionMutation` hook.
- **SubiektInvoiceDetailSection** (`invoiceDetailSection` slot): KSeF status badge + KSeF number + PDF download link; hidden when no regulatory data and no pdfUrl.
- **SubiektInvoiceCorrectionFlow** (`invoiceCorrectionFlow` slot): reason textarea + per-line line-number / new-qty / new-price inputs + add/remove rows + "Issue correction" submit with success/error toast.
- Both slots registered on `subiektPlugin.platform`.
- `RegulatoryStatusBadge` exported from `features/invoicing` barrel.
- 1745 FE tests pass; type-check + lint clean.

## Test plan

- [x] `pnpm --filter @openlinker/web test --run` — 1745 passed
- [x] `pnpm --filter @openlinker/web type-check` — zero errors
- [x] `pnpm --filter @openlinker/web lint` — zero errors
- [x] `pnpm type-check` — only 1 pre-existing error in `enqueue-sync-job.dto.ts` (not in diff)
- [ ] Manual: connect a Subiekt instance, open an issued invoice detail page → KSeF status badge + PDF link visible in the slot
- [ ] Manual: click "Issue correction" → dialog opens with reason textarea + line inputs → submit → correction created and status reflected

Closes #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WHzgkHr1p1DeynN5kMgC4