### PR TITLE
docs(orders): correct OrderProcessorManagerPort surface to match real port

### DIFF
--- a/apps/web/src/features/invoicing/index.ts
+++ b/apps/web/src/features/invoicing/index.ts
@@ -26,7 +26,6 @@ export {
   type IssueCorrectionVariables,
 } from './hooks/use-issue-correction-mutation';
 export { invoicingQueryKeys } from './api/invoicing.query-keys';
-export { RegulatoryStatusBadge } from './components/regulatory-status-badge';
 export type {
   InvoiceRecord,
   InvoiceStatus,

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -153,7 +153,7 @@ The system is organized into the following core bounded contexts:
 - **Location**: `libs/core/src/orders/`
 - **Capabilities**:
   - `OrderSourcePort` — cursor-based order-event ingestion from marketplaces *and* shops (`listOrderFeed` + `getOrder({externalOrderId})`)
-  - `OrderProcessorManagerPort` — order lifecycle on the destination shop (create / update-status / cancel / return)
+  - `OrderProcessorManagerPort` — destination-shop order creation (`createOrder`, the only base-port method); post-create status/tracking and lifecycle reads live in composable sub-capabilities (`OrderFulfillmentUpdater`, `OrderStatusWriteback`, …). The canonical OL-owned lifecycle state machine is deferred (#1032).
 
 ### 5. Customers
 - **Responsibility**: Customer identity resolution, customer projections, multi-origin identity management
@@ -407,42 +407,35 @@ export class ProductSyncService {
 
 ### OrderProcessorManagerPort
 
-**Purpose**: Orchestrates order lifecycle (creation, status changes, cancellations, returns).
+**Purpose**: Create orders on a destination shop. The base port carries only `createOrder` — the single method every order destination must implement. Post-create status/tracking writes, lifecycle reads, and option discovery are split into composable sub-capabilities (mirroring `OfferManagerPort`); a full OL-owned order-lifecycle state machine (`updateOrderStatus` / `cancelOrder` / `processReturn` / `getOrders` as authoritative operations) is **deferred** — see #1032.
 
 **Interface**:
 ```typescript
 interface OrderProcessorManagerPort {
   /**
-   * Create a new order
+   * Create a new order on the destination shop.
+   *
+   * Returns the destination-native external order id (OrderRef.orderId),
+   * never an internal OpenLinker id (#909). Idempotency and the
+   * external↔internal mapping write are owned by OrderSyncService under a
+   * per-(order, destination) lock — the adapter creates unconditionally.
+   * Lines MUST be priced at the buyer-paid source price (#895, ADR-014).
    */
-  createOrder(order: OrderCreate): Promise<Order>;
-  
-  /**
-   * Get order by ID
-   */
-  getOrder(orderId: string): Promise<Order>;
-  
-  /**
-   * Update order status
-   */
-  updateOrderStatus(orderId: string, status: OrderStatus): Promise<Order>;
-  
-  /**
-   * Cancel an order
-   */
-  cancelOrder(orderId: string, reason?: string): Promise<Order>;
-  
-  /**
-   * Process return/refund
-   */
-  processReturn(orderId: string, returnData: ReturnData): Promise<Order>;
-  
-  /**
-   * Get orders with filters
-   */
-  getOrders(filters: OrderFilters): Promise<Order[]>;
+  createOrder(order: OrderCreate): Promise<OrderRef>;
 }
 ```
+
+**Sub-capabilities** (in `libs/core/src/orders/domain/ports/capabilities/`):
+
+Each is an independent interface + co-located `is{Capability}(adapter)` type guard. Destinations declare what they support via `implements OrderProcessorManagerPort, OrderFulfillmentUpdater, …`; call sites resolve the destination adapter via `getCapabilityAdapter<OrderProcessorManagerPort>(connectionId, 'OrderProcessorManager')`, narrow with the guard, and degrade gracefully (skip) when a destination doesn't implement it.
+
+| Capability | Method(s) | Notes |
+|---|---|---|
+| `OrderFulfillmentUpdater` | `updateFulfillment({ externalOrderId, status, trackingNumber? })` | Push a post-create status + tracking update to the destination order (#837). PrestaShop maps the neutral `OrderStatus` to its native state. |
+| `OrderStatusWriteback` | `write(event: OrderLifecycleEvent)` | Relay-based, source-bound order-status round-trip — push a status change back to the originating marketplace (#1157, [ADR-027](./architecture/adrs/027-order-status-writeback-capability-and-relay.md)). |
+| `FulfillmentStatusReader` | `getFulfillmentStatus({ externalOrderId })` | Read a destination order's current fulfillment status. |
+| `DestinationOptionsReader` | `listCarriers()`, `listOrderStatuses()`, `listPaymentMethods()` | Discover the destination's option vocabulary for mapping. |
+| `SourceOptionsReader` | `listOrderStatuses()`, `listDeliveryMethods()`, `listPaymentMethods()` | Discover a source's option vocabulary for mapping. |
 
 **Current Implementations**: `PrestashopOrderProcessorAdapter`, `WooCommerceOrderProcessorAdapter`
 

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -292,15 +292,18 @@ import { Injectable } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
 import type {
   OrderProcessorManagerPort,
+  OrderFulfillmentUpdater,
   OrderCreate,
-  Order,
+  OrderRef,
   OrderStatus,
 } from '@openlinker/core/orders';
 import type { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import type { XHttpClient } from '../http/x-http-client';
 
 @Injectable()
-export class XOrderProcessorManagerAdapter implements OrderProcessorManagerPort {
+export class XOrderProcessorManagerAdapter
+  implements OrderProcessorManagerPort, OrderFulfillmentUpdater
+{
   private readonly logger = new Logger(XOrderProcessorManagerAdapter.name);
 
   constructor(
@@ -309,18 +312,27 @@ export class XOrderProcessorManagerAdapter implements OrderProcessorManagerPort 
     // ... other plugin-internal deps
   ) {}
 
-  async createOrder(order: OrderCreate): Promise<Order> {
+  // Base-port method — the only one every order destination must implement.
+  async createOrder(order: OrderCreate): Promise<OrderRef> {
     // 1. Translate internal IDs → external IDs via identifierMapping
     // 2. Call the platform API
-    // 3. Map response → unified Order
+    // 3. Return the destination-native external order id (never an internal id)
     // 4. Translate platform errors → domain exceptions
   }
 
-  async updateOrderStatus(orderId: string, status: OrderStatus): Promise<Order> {
+  // Optional sub-capability — implement only the capabilities your platform
+  // supports, and declare each in the `implements` clause so call sites can
+  // narrow with the co-located `is{Capability}` guard.
+  async updateFulfillment(input: {
+    externalOrderId: string;
+    status: OrderStatus;
+    trackingNumber?: string;
+  }): Promise<void> {
     // ...
   }
 
-  // Throw for unsupported operations rather than returning a half-baked result.
+  // Don't stub capabilities you don't support — omit them from `implements`
+  // entirely; call sites skip gracefully when the guard returns false.
 }
 ```
 

--- a/docs/specs/product-spec-727-inpost-integration.md
+++ b/docs/specs/product-spec-727-inpost-integration.md
@@ -319,7 +319,7 @@ User-visible. Engineering AC (rate limits, retry policies, exact ShipX field map
 
 **AC-7** (US-3 + US-7): clicking "Generate label" calls ShipX → label PDF returned within 5 seconds, downloadable from order panel; status updates to `generated`. While status is `generated` (not yet dispatched), "Cancel + re-issue" button is available; clicking voids the existing label and re-opens the generation flow for the same order.
 
-**AC-8** (US-8): tracking number and shipment status auto-propagate to Allegro (via `OrderProcessorManagerPort.updateOrderStatus` or equivalent) and PrestaShop (order status + tracking field) when label is generated and when InPost webhook events fire.
+**AC-8** (US-8): tracking number and shipment status auto-propagate to Allegro (via the `OrderFulfillmentUpdater` / `OrderStatusWriteback` sub-capability of `OrderProcessorManagerPort`) and PrestaShop (order status + tracking field) when label is generated and when InPost webhook events fire.
 
 **AC-9** (US-8): when InPost webhook signals `delivered` (or equivalent terminal event), OL updates Shipment status, propagates to source platforms, no operator action required. If webhook isn't provisioned, OL polls tracking endpoint at a conservative cadence.
 


### PR DESCRIPTION
## What & why

`docs/architecture-overview.md` documented `OrderProcessorManagerPort` as a fat interface (`createOrder` / `getOrder` / `updateOrderStatus` / `cancelOrder` / `processReturn` / `getOrders`), but the real port at `libs/core/src/orders/domain/ports/order-processor-manager.port.ts` defines **only** `createOrder(): Promise<OrderRef>`. Status/tracking, lifecycle reads, and option discovery live in composable sub-capabilities under `domain/ports/capabilities/`; the canonical OL-owned lifecycle state machine is deferred (#1032). The doc overstated current capability and would mislead a contributor or evaluator reading it as ground truth.

## Changes

- **`docs/architecture-overview.md`** — rewrite the `OrderProcessorManagerPort` section: base port = `createOrder` only (returning `OrderRef`, #909), plus a sub-capability table (`OrderFulfillmentUpdater`, `OrderStatusWriteback`, `FulfillmentStatusReader`, `DestinationOptionsReader`, `SourceOptionsReader`) mirroring the `OfferManagerPort` pattern. Fix the Orders bounded-context capability bullet to match.
- **`docs/plugin-author-guide.md`** — fix the sample order-processor adapter (phantom `updateOrderStatus` → real `createOrder: Promise<OrderRef>` + the `OrderFulfillmentUpdater.updateFulfillment` sub-capability).
- **`docs/specs/product-spec-727-inpost-integration.md`** — AC-8 now names the real sub-capabilities instead of the phantom `updateOrderStatus`.

Every method signature in the new table was verified against the live capability files and barrel exports.

## Drive-by fix (separate commit)

The pre-commit `tsc` was already red on `main` (unrelated to these docs): `apps/web/src/features/invoicing/index.ts` exported `RegulatoryStatusBadge` twice (`TS2300` duplicate identifier), slipped in with the #1240 invoicing FE work. Removed the stray second export in a clearly-separated `fix(web):` commit so the docs change could land without `--no-verify`. The single intentional export documented in the file header remains. **Heads-up: this means `main` is currently failing `pnpm type-check` until this merges** — happy to split it into a standalone hotfix if preferred.

## Acceptance criteria (#1140)

- [x] Doc matches the real port + capability split.
- [x] No phantom methods documented as if implemented.

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)