### PR TITLE
feat(web,inpost): InPost connection settings + ShipX connection-test (#771)

### DIFF
--- a/apps/web/src/app/routes/route-lazy.test.ts
+++ b/apps/web/src/app/routes/route-lazy.test.ts
@@ -50,20 +50,20 @@ const lazyRoutes = collectLazyRoutes([
  * route reverted to eager `element:` form, which is exactly the regression
  * the parameterized test below is meant to catch.
  *
- * Today's breakdown (45 total):
+ * Today's breakdown (46 total):
  *   - 35 authenticated children (under `coreChildren`, counting per-children-node
  *     because grouped routes like orders/customers/inventory expose multiple
  *     lazy nodes — includes `/dev/ui` design-system page (#775), `/shipments` (#770),
  *     `/invoices` list page (#758), and `/invoices/:invoiceId` detail page (#1240))
  *   - 2 guest routes (forgot-password, reset-password — login stays eager)
- *   - 8 plugin routes (allegro callback + setup, prestashop setup, dpd setup,
- *     woocommerce setup, erli setup, subiekt setup, ksef setup)
+ *   - 9 plugin routes (allegro callback + setup, prestashop setup, dpd setup,
+ *     woocommerce setup, erli setup, subiekt setup, ksef setup, inpost setup)
  *
  * Routes that are intentionally eager (no page module to defer):
  *   - login (first-paint optimization — see `login.route.tsx`)
  *   - prompt-templates-legacy-redirects (inline `<Navigate>` element)
  */
-const EXPECTED_LAZY_ROUTE_COUNT = 45;
+const EXPECTED_LAZY_ROUTE_COUNT = 46;
 
 describe('route lazy contract', () => {
   it(`the registered route tree contains exactly ${EXPECTED_LAZY_ROUTE_COUNT} lazy routes`, () => {

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -42,7 +42,9 @@ type StructuredField =
   | 'subiektTriggerModel'
   | 'ksefEnvironment'
   | 'sellerNip'
-  | 'contextIdentifier';
+  | 'contextIdentifier'
+  | 'inpostEnvironment'
+  | 'inpostOrganizationId';
 
 function readString(config: Record<string, unknown>, key: string): string {
   const value = config[key];
@@ -88,6 +90,43 @@ function readTriggerModel(
 function readKsefEnvironment(config: Record<string, unknown>): '' | 'test' | 'demo' | 'prod' {
   const value = config.env;
   return value === 'test' || value === 'demo' || value === 'prod' ? value : '';
+}
+
+/** Read the InPost environment out of `config.environment` (#771). */
+function readInpostEnvironment(config: Record<string, unknown>): '' | 'sandbox' | 'production' {
+  const value = config.environment;
+  return value === 'sandbox' || value === 'production' ? value : '';
+}
+
+/**
+ * Read the InPost sender address out of `config.senderAddress` (#771). Returns
+ * a fully-populated form shape — empty-string fields where the operator hasn't
+ * filled them yet — so RHF's nested `register()` paths work without per-field
+ * undefined guards. Clone of `readSellerDefaults`'s shape-guard discipline.
+ */
+function readInpostSenderAddress(
+  config: Record<string, unknown>,
+): NonNullable<EditConnectionFormValues['inpostSenderAddress']> {
+  const raw =
+    typeof config.senderAddress === 'object' && config.senderAddress !== null
+      ? (config.senderAddress as Record<string, unknown>)
+      : {};
+  const address =
+    typeof raw.address === 'object' && raw.address !== null
+      ? (raw.address as Record<string, unknown>)
+      : {};
+  return {
+    name: typeof raw.name === 'string' ? raw.name : '',
+    email: typeof raw.email === 'string' ? raw.email : '',
+    phone: typeof raw.phone === 'string' ? raw.phone : '',
+    address: {
+      street: typeof address.street === 'string' ? address.street : '',
+      buildingNumber: typeof address.buildingNumber === 'string' ? address.buildingNumber : '',
+      city: typeof address.city === 'string' ? address.city : '',
+      postCode: typeof address.postCode === 'string' ? address.postCode : '',
+      countryCode: typeof address.countryCode === 'string' ? address.countryCode : '',
+    },
+  };
 }
 
 /**
@@ -239,6 +278,12 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
       ksefEnvironment: readKsefEnvironment(connection.config),
       sellerNip: readString(connection.config, 'sellerNip'),
       contextIdentifier: readString(connection.config, 'contextIdentifier'),
+      // InPost structured fields (#771) — read from `config.{environment,
+      // organizationId,senderAddress}`. Symmetric read-side hydration so an
+      // unrelated save doesn't blank the persisted InPost config.
+      inpostEnvironment: readInpostEnvironment(connection.config),
+      inpostOrganizationId: readString(connection.config, 'organizationId'),
+      inpostSenderAddress: readInpostSenderAddress(connection.config),
     },
     resolver: zodResolver(editConnectionSchema),
   });
@@ -328,6 +373,19 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
     const parsed = JSON.parse(form.getValues('configText')) as Record<string, unknown>;
     const merged = mergeStructuredIntoConfig(parsed, {
       subiektCapabilities: form.getValues('subiektCapabilities'),
+    });
+    form.setValue('configText', JSON.stringify(merged, null, 2), { shouldDirty: true });
+  }
+
+  // #771 — re-serialize the whole `inpostSenderAddress` object into configText.
+  // Clone of `syncSellerDefaultsToJson`: reads CURRENT form state, takes NO
+  // argument, and KEEPS the `!configIsParseable` early-return. The InPost
+  // section MUST setValue('inpostSenderAddress.*', …) BEFORE calling this.
+  function syncInpostSenderAddressToJson(): void {
+    if (!configIsParseable) return;
+    const parsed = JSON.parse(form.getValues('configText')) as Record<string, unknown>;
+    const merged = mergeStructuredIntoConfig(parsed, {
+      inpostSenderAddress: form.getValues('inpostSenderAddress'),
     });
     form.setValue('configText', JSON.stringify(merged, null, 2), { shouldDirty: true });
   }
@@ -448,6 +506,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
             syncStructuredToJson(field as StructuredField, value, options)
           }
           syncObjectToJson={syncSubiektCapabilitiesToJson}
+          syncInpostSenderAddressToJson={syncInpostSenderAddressToJson}
         />
       ) : null}
 

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -65,6 +65,53 @@ const allegroSellerDefaultsSchema = z.object({
 
 export type AllegroSellerDefaultsFormValues = z.input<typeof allegroSellerDefaultsSchema>;
 
+/**
+ * InPost sender-address structured schema (#771). Mirrors the shipped backend
+ * config DTO (`libs/integrations/inpost/.../inpost-connection-config.dto.ts`):
+ * `senderAddress: { name?, email, phone, address: { street, buildingNumber,
+ * city, postCode (NN-NNN), countryCode (ISO2) } }`. Every sub-field is optional
+ * at the FE level so the operator can save incremental progress; the BE DTO is
+ * the strict gate (email/phone/address required). Format IS enforced
+ * client-side when a value is present (email shape, PL postcode, ISO2 country)
+ * for fast, targeted feedback. Modelled on the `sellerDefaults` whole-object
+ * pattern: a nested `inpostSenderAddress` object on the form that the merge
+ * helper prunes into `config.senderAddress`.
+ */
+const inpostAddressSchema = z.object({
+  street: z.string().trim().max(200).optional(),
+  buildingNumber: z.string().trim().max(50).optional(),
+  city: z.string().trim().max(200).optional(),
+  postCode: z
+    .union([
+      z.string().regex(/^\d{2}-\d{3}$/, 'Postcode must use the PL format NN-NNN'),
+      z.literal(''),
+    ])
+    .optional(),
+  // Coerce to uppercase before the ISO2 check so a lowercase `pl` is accepted
+  // and normalized — parity with the setup wizard's countryCode transform
+  // (`inpost-setup.schema.ts`). `z.literal('')` is listed first so an empty
+  // value short-circuits before the transform (an uppercased '' would fail the regex).
+  countryCode: z
+    .union([
+      z.literal(''),
+      z
+        .string()
+        .trim()
+        .transform((v) => v.toUpperCase())
+        .pipe(z.string().regex(/^[A-Z]{2}$/, 'Country must be an ISO 3166-1 alpha-2 code (e.g. PL)')),
+    ])
+    .optional(),
+});
+
+const inpostSenderAddressSchema = z.object({
+  name: z.string().trim().max(200).optional(),
+  email: z.union([z.string().trim().email('Enter a valid email'), z.literal('')]).optional(),
+  phone: z.string().trim().max(30).optional(),
+  address: inpostAddressSchema.optional(),
+});
+
+export type InpostSenderAddressFormValues = z.input<typeof inpostSenderAddressSchema>;
+
 export const editConnectionSchema = z.object({
   name: z.string().trim().min(1, 'Connection name is required'),
   baseUrl: z.string().trim().optional(),
@@ -200,6 +247,15 @@ export const editConnectionSchema = z.object({
     ])
     .optional(),
   contextIdentifier: z.union([z.string().trim().max(64), z.literal('')]).optional(),
+  // InPost-only structured fields (#771). `inpostEnvironment` → flat
+  // `config.environment`, `inpostOrganizationId` → flat `config.organizationId`,
+  // `inpostSenderAddress` → whole-object `config.senderAddress`. Field names are
+  // `inpost*`-prefixed to avoid colliding with DPD's `environment` / other
+  // platforms' flat keys; the merge clauses map them to the real config keys.
+  // All optional at the FE level for incremental save; the BE DTO is the gate.
+  inpostEnvironment: z.union([z.enum(['sandbox', 'production']), z.literal('')]).optional(),
+  inpostOrganizationId: z.string().trim().optional(),
+  inpostSenderAddress: inpostSenderAddressSchema.optional(),
 });
 
 export type EditConnectionFormValues = z.input<typeof editConnectionSchema>;
@@ -274,6 +330,17 @@ export interface StructuredConfigPatch {
   sellerNip?: string;
   /** KSeF context identifier — `config.contextIdentifier` (#1152). Empty clears. */
   contextIdentifier?: string;
+  /** InPost environment → flat `config.environment` (#771). Empty string clears the key. */
+  inpostEnvironment?: 'sandbox' | 'production' | '';
+  /** InPost organization id → flat `config.organizationId` (#771). Empty clears. */
+  inpostOrganizationId?: string;
+  /**
+   * InPost sender address → whole-object `config.senderAddress` (#771). The
+   * merge helper writes a pruned object whenever a value is supplied (mirrors
+   * the `sellerDefaults` whole-object seam); pass `null` to clear the key, and
+   * an all-empty pruned object also drops the key (delete-on-empty).
+   */
+  inpostSenderAddress?: InpostSenderAddressFormValues | null;
 }
 
 /**
@@ -442,6 +509,35 @@ export function mergeStructuredIntoConfig(
       next.contextIdentifier = structured.contextIdentifier;
     }
   }
+  // InPost structured fields (#771). `inpostEnvironment`/`inpostOrganizationId`
+  // are flat (delete-on-empty); `inpostSenderAddress` is a whole-object pruned
+  // into `config.senderAddress` (clone of the `sellerDefaults` seam).
+  if (structured.inpostEnvironment !== undefined) {
+    if (structured.inpostEnvironment.length === 0) {
+      delete next.environment;
+    } else {
+      next.environment = structured.inpostEnvironment;
+    }
+  }
+  if (structured.inpostOrganizationId !== undefined) {
+    if (structured.inpostOrganizationId.length === 0) {
+      delete next.organizationId;
+    } else {
+      next.organizationId = structured.inpostOrganizationId;
+    }
+  }
+  if (structured.inpostSenderAddress !== undefined) {
+    if (structured.inpostSenderAddress === null) {
+      delete next.senderAddress;
+    } else {
+      const pruned = pruneEmptyInpostSenderAddress(structured.inpostSenderAddress);
+      if (Object.keys(pruned).length === 0) {
+        delete next.senderAddress;
+      } else {
+        next.senderAddress = pruned;
+      }
+    }
+  }
   return next;
 }
 
@@ -480,6 +576,39 @@ function pruneEmptySellerDefaults(
       safety.attachments = values.safetyInformation.attachments;
     }
     out.safetyInformation = safety;
+  }
+  return out;
+}
+
+/**
+ * Prune empty-string sub-fields out of the InPost sender address so the BE DTO
+ * sees a clean nested shape (the FE schema accepts `''` for incremental
+ * editing; the BE rejects it). Clone of `pruneEmptySellerDefaults`. The nested
+ * `address` object is dropped entirely when none of its fields are set.
+ */
+function pruneEmptyInpostSenderAddress(
+  values: InpostSenderAddressFormValues,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (values.name && values.name.length > 0) out.name = values.name;
+  if (values.email && values.email.length > 0) out.email = values.email;
+  if (values.phone && values.phone.length > 0) out.phone = values.phone;
+  if (values.address) {
+    const addr: Record<string, unknown> = {};
+    if (values.address.street && values.address.street.length > 0) {
+      addr.street = values.address.street;
+    }
+    if (values.address.buildingNumber && values.address.buildingNumber.length > 0) {
+      addr.buildingNumber = values.address.buildingNumber;
+    }
+    if (values.address.city && values.address.city.length > 0) addr.city = values.address.city;
+    if (values.address.postCode && values.address.postCode.length > 0) {
+      addr.postCode = values.address.postCode;
+    }
+    if (values.address.countryCode && values.address.countryCode.length > 0) {
+      addr.countryCode = values.address.countryCode;
+    }
+    if (Object.keys(addr).length > 0) out.address = addr;
   }
   return out;
 }

--- a/apps/web/src/features/connections/components/inpost-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/inpost-setup-form.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * InpostSetupForm — component tests (#771)
+ *
+ * Covers the wizard's non-trivial logic: per-step validation gates Next, the
+ * sender-address step renders after a valid account step, and a full walk
+ * submits the mapped nested-config + credentials payload via connections.create.
+ */
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { InpostSetupForm } from './inpost-setup-form';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
+
+afterEach(cleanup);
+
+function fillAccountStep(
+  container: HTMLElement,
+  values: { name: string; apiToken: string; organizationId: string },
+): void {
+  fireEvent.change(within(container).getByLabelText('Connection name'), { target: { value: values.name } });
+  fireEvent.change(within(container).getByLabelText('API token'), { target: { value: values.apiToken } });
+  fireEvent.change(within(container).getByLabelText('Organization ID'), {
+    target: { value: values.organizationId },
+  });
+}
+
+function fillSenderStep(container: HTMLElement): void {
+  fireEvent.change(within(container).getByLabelText('Sender email'), { target: { value: 'magazyn@acme.pl' } });
+  fireEvent.change(within(container).getByLabelText('Sender phone'), { target: { value: '+48111222333' } });
+  fireEvent.change(within(container).getByLabelText('Street'), { target: { value: 'ul. Magazynowa' } });
+  fireEvent.change(within(container).getByLabelText('Building number'), { target: { value: '1' } });
+  fireEvent.change(within(container).getByLabelText('City'), { target: { value: 'Warszawa' } });
+  fireEvent.change(within(container).getByLabelText('Postcode'), { target: { value: '00-001' } });
+  fireEvent.change(within(container).getByLabelText('Country'), { target: { value: 'PL' } });
+}
+
+async function advanceOneStep(container: HTMLElement): Promise<void> {
+  const before = container.querySelector('[aria-current="step"]')?.textContent ?? '';
+  fireEvent.click(within(container).getByRole('button', { name: 'Next' }));
+  await waitFor(() => {
+    const after = container.querySelector('[aria-current="step"]')?.textContent ?? '';
+    if (after === before) throw new Error('Step did not advance');
+  });
+}
+
+describe('InpostSetupForm', () => {
+  it('blocks Next while the account step is invalid', async () => {
+    const { container } = renderWithProviders(<InpostSetupForm />);
+
+    fireEvent.click(within(container).getByRole('button', { name: 'Next' }));
+
+    expect(await screen.findByText('API token is required')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Street')).toBeNull();
+  });
+
+  it('advances to the sender-address step once the account step is valid', async () => {
+    const { container } = renderWithProviders(<InpostSetupForm />);
+    fillAccountStep(container, { name: 'InPost — main', apiToken: 'shipx-token', organizationId: '123456' });
+
+    await advanceOneStep(container);
+
+    expect(screen.getByLabelText('Street')).toBeInTheDocument();
+    expect(screen.getByLabelText('Postcode')).toBeInTheDocument();
+  });
+
+  it('submits the mapped nested config + credentials after walking every step', async () => {
+    const create = vi.fn().mockResolvedValue(sampleConnection);
+    const apiClient = createMockApiClient({ connections: { create } });
+    const { container } = renderWithProviders(<InpostSetupForm />, { apiClient });
+
+    fillAccountStep(container, { name: 'InPost — main', apiToken: 'shipx-token', organizationId: '123456' });
+    await advanceOneStep(container);
+    fillSenderStep(container);
+    await advanceOneStep(container);
+
+    fireEvent.click(within(container).getByRole('button', { name: 'Create connection' }));
+
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platformType: 'inpost',
+        adapterKey: 'inpost.shipx.v1',
+        credentials: { apiToken: 'shipx-token' },
+        config: expect.objectContaining({
+          environment: 'sandbox',
+          organizationId: '123456',
+          senderAddress: expect.objectContaining({
+            email: 'magazyn@acme.pl',
+            phone: '+48111222333',
+            address: expect.objectContaining({
+              street: 'ul. Magazynowa',
+              buildingNumber: '1',
+              city: 'Warszawa',
+              postCode: '00-001',
+              countryCode: 'PL',
+            }),
+          }),
+        }),
+      }),
+    );
+    expect((create.mock.calls[0][0] as { enabledCapabilities?: unknown }).enabledCapabilities).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/connections/components/inpost-setup-form.tsx
+++ b/apps/web/src/features/connections/components/inpost-setup-form.tsx
@@ -1,0 +1,291 @@
+/**
+ * InPost Setup Form (#771)
+ *
+ * Guided wizard for creating an InPost (ShipX) carrier connection. Steps:
+ *   1. Account & credentials — name, API token, environment, organization id
+ *   2. Sender address — populated on every shipment
+ *   3. Review & connect
+ *
+ * Per-step validation runs on Next so the operator can't advance with invalid
+ * fields. Abandon-prevention warns on a dirty unload. InPost is shipping-only —
+ * no capabilities step (the API defaults to the adapter's supported set).
+ * Mirrors the DPD Polska setup form.
+ *
+ * @module features/connections/components
+ */
+import { useEffect, useState, type ReactElement } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm, type Path } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { useCreateConnectionMutation } from '../hooks/use-create-connection-mutation';
+import {
+  INPOST_SETUP_DEFAULT_VALUES,
+  inpostSetupSchema,
+  toCreateConnectionInput,
+  type InpostSetupFormSubmission,
+  type InpostSetupFormValues,
+} from './inpost-setup.schema';
+import { Alert } from '../../../shared/ui/alert';
+import { BackLink } from '../../../shared/ui/back-link';
+import { Button } from '../../../shared/ui/button';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
+import { SetupStepper } from '../../../shared/ui/setup-stepper';
+import { WizardLayout } from '../../../shared/ui/wizard-layout';
+import { useToast } from '../../../shared/ui/toast-provider';
+
+const STEP_LABELS = ['Account & credentials', 'Sender address', 'Review & connect'] as const;
+
+const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<InpostSetupFormValues>>> = [
+  ['name', 'apiToken', 'environment', 'organizationId'],
+  [
+    'senderName',
+    'senderEmail',
+    'senderPhone',
+    'senderStreet',
+    'senderBuildingNumber',
+    'senderCity',
+    'senderPostCode',
+    'senderCountryCode',
+  ],
+  [],
+];
+
+export function InpostSetupForm(): ReactElement {
+  const createConnection = useCreateConnectionMutation();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+  const form = useForm<InpostSetupFormValues, undefined, InpostSetupFormSubmission>({
+    defaultValues: INPOST_SETUP_DEFAULT_VALUES,
+    resolver: zodResolver(inpostSetupSchema),
+    mode: 'onBlur',
+  });
+
+  const [stepIndex, setStepIndex] = useState(0);
+  const [completedSteps, setCompletedSteps] = useState<ReadonlySet<number>>(new Set());
+
+  useEffect(() => {
+    function handleBeforeUnload(event: BeforeUnloadEvent): void {
+      if (!form.formState.isDirty) return;
+      event.preventDefault();
+      event.returnValue = '';
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [form.formState.isDirty]);
+
+  const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
+    error?.message ? [String(error.message)] : [],
+  );
+
+  async function goNext(): Promise<void> {
+    const fields = STEP_FIELDS[stepIndex];
+    if (fields.length > 0) {
+      const valid = await form.trigger([...fields]);
+      if (!valid) return;
+    }
+    setCompletedSteps((prev) => new Set(prev).add(stepIndex));
+    setStepIndex((i) => Math.min(i + 1, STEP_LABELS.length - 1));
+  }
+
+  function goBack(): void {
+    setStepIndex((i) => Math.max(i - 1, 0));
+  }
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      const created = await createConnection.mutateAsync(toCreateConnectionInput(values));
+      form.reset(values, { keepValues: true, keepDirty: false });
+      showToast({
+        tone: 'success',
+        title: 'Connection created',
+        description: `InPost connection "${created.name}" was created.`,
+      });
+      void navigate('/connections');
+    } catch {
+      return;
+    }
+  });
+
+  const values = form.watch();
+
+  return (
+    <WizardLayout
+      stepper={
+        <SetupStepper steps={STEP_LABELS} currentStep={stepIndex} completedSteps={completedSteps} />
+      }
+      summary={
+        <dl className="wizard-review-list">
+          <dt>Name</dt>
+          <dd>{values.name || '—'}</dd>
+          <dt>Environment</dt>
+          <dd className="mono-text">{values.environment}</dd>
+          <dt>Organization ID</dt>
+          <dd className="mono-text">{values.organizationId || '—'}</dd>
+          <dt>Sender</dt>
+          <dd>{values.senderCity ? `${values.senderCity}, ${values.senderCountryCode}` : '—'}</dd>
+        </dl>
+      }
+    >
+      <form className="wizard-card" onSubmit={(event) => void onSubmit(event)} noValidate>
+        <BackLink to="/connections/new" label="Connections" className="wizard-card__back" />
+
+        {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
+          <FormErrorSummary errors={validationMessages} />
+        ) : null}
+        {createConnection.error ? (
+          <Alert tone="error" title="Unable to create connection">
+            {createConnection.error.message}
+          </Alert>
+        ) : null}
+
+        {stepIndex === 0 ? (
+          <>
+            <Alert tone="info" title="Before you start">
+              Generate a ShipX <strong>API token</strong> and note your{' '}
+              <strong>organization id</strong> in the InPost ShipX panel. Use the sandbox
+              environment to verify before switching to production.
+            </Alert>
+
+            <FormField label="Connection name" name="name" error={form.formState.errors.name?.message}>
+              <Input
+                {...form.register('name')}
+                placeholder="InPost — main warehouse"
+                invalid={Boolean(form.formState.errors.name)}
+              />
+            </FormField>
+
+            <FormField
+              label="API token"
+              name="apiToken"
+              error={form.formState.errors.apiToken?.message}
+              description="ShipX Bearer token — stored securely on the server, never shown again after save."
+            >
+              <Input
+                {...form.register('apiToken')}
+                type="password"
+                className="mono-text"
+                autoComplete="off"
+                placeholder="••••••••••••••••••••••••••••••••"
+                invalid={Boolean(form.formState.errors.apiToken)}
+              />
+            </FormField>
+
+            <FormField
+              label="Environment"
+              name="environment"
+              error={form.formState.errors.environment?.message}
+            >
+              <Select
+                {...form.register('environment')}
+                invalid={Boolean(form.formState.errors.environment)}
+              >
+                <option value="sandbox">Sandbox</option>
+                <option value="production">Production</option>
+              </Select>
+            </FormField>
+
+            <FormField
+              label="Organization ID"
+              name="organizationId"
+              error={form.formState.errors.organizationId?.message}
+              description="ShipX organization id — a URL path parameter on every shipment endpoint."
+            >
+              <Input
+                {...form.register('organizationId')}
+                className="mono-text"
+                placeholder="123456"
+                invalid={Boolean(form.formState.errors.organizationId)}
+              />
+            </FormField>
+          </>
+        ) : null}
+
+        {stepIndex === 1 ? (
+          <>
+            <Alert tone="info" title="Sender address">
+              Used as the ShipX shipment sender. Polish postal format{' '}
+              <span className="mono-text">NN-NNN</span>.
+            </Alert>
+
+            <FormField label="Sender name (optional)" name="senderName" error={form.formState.errors.senderName?.message}>
+              <Input {...form.register('senderName')} placeholder="Sklep ACME" invalid={Boolean(form.formState.errors.senderName)} />
+            </FormField>
+            <FormField label="Sender email" name="senderEmail" error={form.formState.errors.senderEmail?.message}>
+              <Input {...form.register('senderEmail')} placeholder="magazyn@acme.pl" invalid={Boolean(form.formState.errors.senderEmail)} />
+            </FormField>
+            <FormField label="Sender phone" name="senderPhone" error={form.formState.errors.senderPhone?.message}>
+              <Input {...form.register('senderPhone')} className="mono-text" placeholder="+48111222333" invalid={Boolean(form.formState.errors.senderPhone)} />
+            </FormField>
+            <FormField label="Street" name="senderStreet" error={form.formState.errors.senderStreet?.message}>
+              <Input {...form.register('senderStreet')} placeholder="ul. Magazynowa" invalid={Boolean(form.formState.errors.senderStreet)} />
+            </FormField>
+            <FormField label="Building number" name="senderBuildingNumber" error={form.formState.errors.senderBuildingNumber?.message}>
+              <Input {...form.register('senderBuildingNumber')} className="mono-text" placeholder="1" invalid={Boolean(form.formState.errors.senderBuildingNumber)} />
+            </FormField>
+            <FormField label="City" name="senderCity" error={form.formState.errors.senderCity?.message}>
+              <Input {...form.register('senderCity')} placeholder="Warszawa" invalid={Boolean(form.formState.errors.senderCity)} />
+            </FormField>
+            <FormField
+              label="Postcode"
+              name="senderPostCode"
+              error={form.formState.errors.senderPostCode?.message}
+              description="PL format NN-NNN (e.g. 00-001)."
+            >
+              <Input {...form.register('senderPostCode')} className="mono-text" placeholder="00-001" invalid={Boolean(form.formState.errors.senderPostCode)} />
+            </FormField>
+            <FormField label="Country" name="senderCountryCode" error={form.formState.errors.senderCountryCode?.message} description="ISO 3166-1 alpha-2 (e.g. PL).">
+              <Input {...form.register('senderCountryCode')} className="mono-text" placeholder="PL" maxLength={2} invalid={Boolean(form.formState.errors.senderCountryCode)} />
+            </FormField>
+          </>
+        ) : null}
+
+        {stepIndex === 2 ? (
+          <dl className="wizard-review-list">
+            <dt>Name</dt>
+            <dd>{values.name || '—'}</dd>
+            <dt>Environment</dt>
+            <dd className="mono-text">{values.environment}</dd>
+            <dt>Organization ID</dt>
+            <dd className="mono-text">{values.organizationId || '—'}</dd>
+            <dt>Sender</dt>
+            <dd>
+              {[
+                values.senderStreet,
+                values.senderBuildingNumber,
+                values.senderPostCode,
+                values.senderCity,
+                values.senderCountryCode,
+              ]
+                .filter(Boolean)
+                .join(', ') || '—'}
+            </dd>
+          </dl>
+        ) : null}
+
+        <div className="wizard-actions">
+          <div className="wizard-actions__group">
+            {stepIndex > 0 ? (
+              <Button tone="secondary" type="button" onClick={goBack}>
+                Back
+              </Button>
+            ) : null}
+          </div>
+          <div className="wizard-actions__group">
+            {stepIndex < STEP_LABELS.length - 1 ? (
+              <Button type="button" onClick={() => void goNext()}>
+                Next
+              </Button>
+            ) : (
+              <Button type="submit" disabled={createConnection.isPending}>
+                {createConnection.isPending ? 'Creating...' : 'Create connection'}
+              </Button>
+            )}
+          </div>
+        </div>
+      </form>
+    </WizardLayout>
+  );
+}

--- a/apps/web/src/features/connections/components/inpost-setup.schema.test.ts
+++ b/apps/web/src/features/connections/components/inpost-setup.schema.test.ts
@@ -1,0 +1,94 @@
+/**
+ * InPost setup schema tests (#771)
+ *
+ * Covers the form → CreateConnectionInput mapping (nested sender address +
+ * address sub-object, optional sender name, credentials split) and the
+ * validation mirrors of the BE config validator (PL postcode, ISO country,
+ * required fields).
+ *
+ * @module features/connections/components
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  INPOST_ADAPTER_KEY,
+  INPOST_SETUP_DEFAULT_VALUES,
+  inpostSetupSchema,
+  toCreateConnectionInput,
+  type InpostSetupFormSubmission,
+} from './inpost-setup.schema';
+
+function validValues(overrides: Partial<InpostSetupFormSubmission> = {}): InpostSetupFormSubmission {
+  return {
+    name: 'InPost — main',
+    apiToken: 'shipx-token-123',
+    environment: 'sandbox',
+    organizationId: '123456',
+    senderName: 'Sklep ACME',
+    senderEmail: 'magazyn@acme.pl',
+    senderPhone: '+48111222333',
+    senderStreet: 'ul. Magazynowa',
+    senderBuildingNumber: '1',
+    senderCity: 'Warszawa',
+    senderPostCode: '00-001',
+    senderCountryCode: 'PL',
+    ...overrides,
+  };
+}
+
+describe('inpostSetupSchema', () => {
+  it('rejects the incomplete defaults', () => {
+    const result = inpostSetupSchema.safeParse(INPOST_SETUP_DEFAULT_VALUES);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-PL postcode', () => {
+    const result = inpostSetupSchema.safeParse(validValues({ senderPostCode: '00001' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid email', () => {
+    const result = inpostSetupSchema.safeParse(validValues({ senderEmail: 'not-an-email' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('uppercases and validates the country code', () => {
+    const result = inpostSetupSchema.safeParse(validValues({ senderCountryCode: 'pl' }));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.senderCountryCode).toBe('PL');
+  });
+});
+
+describe('toCreateConnectionInput', () => {
+  it('builds the nested config + credentials with the InPost adapter key', () => {
+    const input = toCreateConnectionInput(validValues());
+    expect(input.platformType).toBe('inpost');
+    expect(input.adapterKey).toBe(INPOST_ADAPTER_KEY);
+    expect(input.credentials).toEqual({ apiToken: 'shipx-token-123' });
+    expect(input.config).toMatchObject({
+      environment: 'sandbox',
+      organizationId: '123456',
+      senderAddress: {
+        name: 'Sklep ACME',
+        email: 'magazyn@acme.pl',
+        phone: '+48111222333',
+        address: {
+          street: 'ul. Magazynowa',
+          buildingNumber: '1',
+          city: 'Warszawa',
+          postCode: '00-001',
+          countryCode: 'PL',
+        },
+      },
+    });
+    // enabledCapabilities omitted so the API defaults to the adapter's set.
+    expect(input.enabledCapabilities).toBeUndefined();
+  });
+
+  it('drops the optional sender name when blank', () => {
+    const input = toCreateConnectionInput(validValues({ senderName: '' }));
+    const sender = (input.config as { senderAddress: Record<string, unknown> }).senderAddress;
+    expect(sender.name).toBeUndefined();
+    expect(sender.email).toBe('magazyn@acme.pl');
+  });
+});

--- a/apps/web/src/features/connections/components/inpost-setup.schema.ts
+++ b/apps/web/src/features/connections/components/inpost-setup.schema.ts
@@ -1,0 +1,93 @@
+/**
+ * InPost Setup Form Schema (#771)
+ *
+ * Zod schema + form → API payload mapping for the guided InPost (ShipX)
+ * connection wizard. InPost is a carrier (shipping-only) — it carries a single
+ * ShipX Bearer `apiToken` credential, an environment, an organization id, and
+ * the sender contact populated on every shipment.
+ *
+ * Client-side validation mirrors the BE config validator
+ * (`libs/integrations/inpost/.../inpost-connection-config.dto.ts`) for fast
+ * feedback; the server stays the authoritative gate. `enabledCapabilities` is
+ * intentionally omitted from the payload so the API defaults it to the
+ * adapter's full `supportedCapabilities` (`['ShippingProviderManager']`) —
+ * `ShippingProviderManager` is NOT in the FE's `CoreCapabilityValues`, so
+ * sending it would fail the create DTO's `@IsIn` with a 400.
+ *
+ * @module features/connections/components
+ */
+import { z } from 'zod';
+import type { CreateConnectionInput } from '../api/connections.types';
+
+export const INPOST_ADAPTER_KEY = 'inpost.shipx.v1';
+
+const PL_POSTAL = /^\d{2}-\d{3}$/;
+
+export const inpostSetupSchema = z.object({
+  name: z.string().trim().min(1, 'Connection name is required'),
+  // Credential (ShipX Bearer token) — required, write-only.
+  apiToken: z.string().trim().min(1, 'API token is required'),
+  // Account config.
+  environment: z.enum(['sandbox', 'production']),
+  organizationId: z.string().trim().min(1, 'Organization ID is required'),
+  // Sender contact (populated on every shipment).
+  senderName: z.string().trim().max(200).optional(),
+  senderEmail: z.string().trim().email('Enter a valid email'),
+  senderPhone: z.string().trim().min(1, 'Sender phone is required').max(30),
+  senderStreet: z.string().trim().min(1, 'Street is required').max(200),
+  senderBuildingNumber: z.string().trim().min(1, 'Building number is required').max(50),
+  senderCity: z.string().trim().min(1, 'City is required').max(200),
+  senderPostCode: z.string().trim().regex(PL_POSTAL, 'Postcode must use the PL format NN-NNN'),
+  senderCountryCode: z
+    .string()
+    .trim()
+    .transform((v) => v.toUpperCase())
+    .pipe(z.string().regex(/^[A-Z]{2}$/, 'Country must be an ISO 3166-1 alpha-2 code (e.g. PL)')),
+});
+
+export type InpostSetupFormValues = z.input<typeof inpostSetupSchema>;
+export type InpostSetupFormSubmission = z.output<typeof inpostSetupSchema>;
+
+export const INPOST_SETUP_DEFAULT_VALUES: InpostSetupFormValues = {
+  name: '',
+  apiToken: '',
+  environment: 'sandbox',
+  organizationId: '',
+  senderName: '',
+  senderEmail: '',
+  senderPhone: '',
+  senderStreet: '',
+  senderBuildingNumber: '',
+  senderCity: '',
+  senderPostCode: '',
+  senderCountryCode: 'PL',
+};
+
+export function toCreateConnectionInput(values: InpostSetupFormSubmission): CreateConnectionInput {
+  const senderAddress: Record<string, unknown> = {
+    email: values.senderEmail,
+    phone: values.senderPhone,
+    address: {
+      street: values.senderStreet,
+      buildingNumber: values.senderBuildingNumber,
+      city: values.senderCity,
+      postCode: values.senderPostCode,
+      countryCode: values.senderCountryCode,
+    },
+  };
+  if (values.senderName && values.senderName.length > 0) senderAddress.name = values.senderName;
+
+  return {
+    name: values.name,
+    platformType: 'inpost',
+    adapterKey: INPOST_ADAPTER_KEY,
+    config: {
+      environment: values.environment,
+      organizationId: values.organizationId,
+      senderAddress,
+    },
+    // Write-only: `apiToken` never round-trips back to the browser.
+    credentials: { apiToken: values.apiToken },
+    // enabledCapabilities OMITTED on purpose — see file header.
+  };
+}

--- a/apps/web/src/pages/connections/inpost-setup-page.tsx
+++ b/apps/web/src/pages/connections/inpost-setup-page.tsx
@@ -1,0 +1,26 @@
+/**
+ * InPost Setup Page
+ *
+ * Page wrapper for the guided InPost (ShipX) connection wizard.
+ */
+import type { ReactElement } from 'react';
+import { InpostSetupForm } from '../../features/connections/components/inpost-setup-form';
+import { PageLayout } from '../../shared/ui/page-layout';
+
+export function InpostSetupPage(): ReactElement {
+  return (
+    <PageLayout
+      eyebrow="Integrations"
+      title="Connect InPost"
+      description="Provide your ShipX API token, organization id, and sender address. OpenLinker uses them to create InPost shipments and labels."
+      summary={
+        <div className="toolbar__group">
+          <span className="toolbar-chip">ShipX API</span>
+          <span className="toolbar-chip">Guided setup</span>
+        </div>
+      }
+    >
+      <InpostSetupForm />
+    </PageLayout>
+  );
+}

--- a/apps/web/src/plugins/inpost/components/inpost-credentials-panel.test.tsx
+++ b/apps/web/src/plugins/inpost/components/inpost-credentials-panel.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * InpostCredentialsPanel Tests (#771)
+ *
+ * Pins the enter/rotate-API-token flow for the InPost plugin's own surface:
+ * the rotate affordance, the env-var fallback, the `{ apiToken }` mutation
+ * body, and the empty-input disable gate. Mirrors the PrestaShop / DPD panel
+ * tests.
+ *
+ * @module plugins/inpost/components
+ */
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMockApiClient,
+  findToastTitle,
+  renderWithProviders,
+  sampleConnection,
+} from '../../../test/test-utils';
+import { InpostCredentialsPanel } from './inpost-credentials-panel';
+
+describe('InpostCredentialsPanel', () => {
+  afterEach(cleanup);
+
+  it('renders the rotate affordance for a credentials-backed connection', () => {
+    renderWithProviders(<InpostCredentialsPanel connection={sampleConnection} />);
+    expect(screen.getByText('Rotate API token')).toBeInTheDocument();
+  });
+
+  it('falls back to the env-var disabled input when credentialsBacked=false', () => {
+    const envBackedConnection = { ...sampleConnection, credentialsBacked: false };
+    renderWithProviders(<InpostCredentialsPanel connection={envBackedConnection} />);
+    expect(
+      screen.getByDisplayValue('Environment variable (not editable via UI)'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /rotate/i })).not.toBeInTheDocument();
+  });
+
+  it('sends the rotated token as `apiToken` and surfaces a success toast', async () => {
+    const updateCredentials = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({
+      connections: { updateCredentials },
+    });
+    renderWithProviders(<InpostCredentialsPanel connection={sampleConnection} />, {
+      apiClient,
+    });
+
+    fireEvent.click(screen.getByText('Rotate API token'));
+    fireEvent.change(screen.getByPlaceholderText('New ShipX API token'), {
+      target: { value: 'shipx-token-123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save new token' }));
+
+    await waitFor(() => {
+      expect(updateCredentials).toHaveBeenCalledWith(sampleConnection.id, {
+        apiToken: 'shipx-token-123',
+      });
+    });
+    expect(await findToastTitle('Credentials rotated')).toBeInTheDocument();
+  });
+
+  it('disables save while the rotate input is empty', () => {
+    renderWithProviders(<InpostCredentialsPanel connection={sampleConnection} />);
+    fireEvent.click(screen.getByText('Rotate API token'));
+    expect(screen.getByRole('button', { name: 'Save new token' })).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText('New ShipX API token'), {
+      target: { value: 't' },
+    });
+    expect(screen.getByRole('button', { name: 'Save new token' })).toBeEnabled();
+  });
+});

--- a/apps/web/src/plugins/inpost/components/inpost-credentials-panel.tsx
+++ b/apps/web/src/plugins/inpost/components/inpost-credentials-panel.tsx
@@ -1,0 +1,103 @@
+/**
+ * InPost Credentials Panel (#771)
+ *
+ * Plugin-owned credentials affordance for InPost connections — enters/rotates
+ * the stored ShipX Bearer API token in place via PUT /credentials. Owns its
+ * toggle state, mutation, and toast; the parent `EditConnectionForm` renders
+ * this only when the plugin contributes it.
+ *
+ * Lives in the plugin (not core) because the rotation form is shaped to InPost's
+ * single-token credential model (`apiToken`) — surfacing it generically would
+ * mislabel the input for any other platform that opted in. Mirrors the
+ * PrestaShop / DPD panels.
+ *
+ * @module plugins/inpost/components
+ */
+import { useState, type FormEvent, type ReactElement } from 'react';
+import type { Connection } from '../../../features/connections';
+import { useUpdateConnectionCredentialsMutation } from '../../../features/connections';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { useToast } from '../../../shared/ui/toast-provider';
+
+export function InpostCredentialsPanel({ connection }: { connection: Connection }): ReactElement {
+  const [showRotate, setShowRotate] = useState(false);
+  const [apiToken, setApiToken] = useState('');
+  const rotate = useUpdateConnectionCredentialsMutation();
+  const { showToast } = useToast();
+
+  if (!connection.credentialsBacked) {
+    return (
+      <FormField label="Credentials" name="credentials">
+        <Input value="Environment variable (not editable via UI)" disabled />
+      </FormField>
+    );
+  }
+
+  const onRotate = async (event: FormEvent): Promise<void> => {
+    event.preventDefault();
+    if (apiToken.trim().length === 0) return;
+    try {
+      await rotate.mutateAsync({
+        connectionId: connection.id,
+        credentials: { apiToken: apiToken.trim() },
+      });
+      showToast({
+        tone: 'success',
+        title: 'Credentials rotated',
+        description: 'The new ShipX API token is now in use.',
+      });
+      setApiToken('');
+      setShowRotate(false);
+    } catch {
+      // surfaced via rotate.error
+    }
+  };
+
+  return (
+    <FormField
+      label="ShipX API token"
+      name="credentials"
+      description="ShipX Bearer token, stored securely on the server. Rotate to replace it without restarting the API."
+    >
+      {showRotate ? (
+        <div className="form-grid">
+          {rotate.error ? <Alert tone="error">{rotate.error.message}</Alert> : null}
+          <Input
+            type="password"
+            autoComplete="off"
+            className="mono-text"
+            placeholder="New ShipX API token"
+            value={apiToken}
+            onChange={(event) => setApiToken(event.target.value)}
+          />
+          <div className="form-actions">
+            <Button
+              type="button"
+              onClick={(event) => void onRotate(event)}
+              disabled={rotate.isPending || apiToken.trim().length === 0}
+            >
+              {rotate.isPending ? 'Rotating...' : 'Save new token'}
+            </Button>
+            <Button
+              tone="secondary"
+              type="button"
+              onClick={() => {
+                setShowRotate(false);
+                setApiToken('');
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button tone="secondary" type="button" onClick={() => setShowRotate(true)}>
+          Rotate API token
+        </Button>
+      )}
+    </FormField>
+  );
+}

--- a/apps/web/src/plugins/inpost/components/inpost-structured-section.test.tsx
+++ b/apps/web/src/plugins/inpost/components/inpost-structured-section.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * InpostStructuredSection tests (#771)
+ *
+ * Renders the plugin-owned structured section the way EditConnectionForm does
+ * (via renderWithProviders, so usePlatform('inpost') resolves and i18n is
+ * provided). Pins the flat-field sync routing, the whole-object sender-address
+ * serializer seam, and the parseable-JSON disable gate.
+ *
+ * @module plugins/inpost/components
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any -- test harness wraps RHF with a flexible form type */
+import type { ReactElement } from 'react';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, sampleConnection } from '../../../test/test-utils';
+import type { Connection } from '../../../features/connections';
+import { InpostStructuredSection } from './inpost-structured-section';
+
+const inpostConnection: Connection = {
+  ...sampleConnection,
+  id: 'inpost_1',
+  name: 'InPost ShipX',
+  platformType: 'inpost',
+  config: {},
+  adapterKey: 'inpost.shipx.v1',
+};
+
+interface HarnessProps {
+  configIsParseable?: boolean;
+  syncStructuredToJson?: (field: string, value: string) => void;
+  syncInpostSenderAddressToJson?: () => void;
+  defaultValues?: Record<string, unknown>;
+}
+
+function Harness({
+  configIsParseable = true,
+  syncStructuredToJson = vi.fn(),
+  syncInpostSenderAddressToJson = vi.fn(),
+  defaultValues = {},
+}: HarnessProps): ReactElement {
+  const form = useForm<any>({
+    defaultValues: {
+      inpostEnvironment: '',
+      inpostOrganizationId: '',
+      inpostSenderAddress: {
+        name: '',
+        email: '',
+        phone: '',
+        address: { street: '', buildingNumber: '', city: '', postCode: '', countryCode: '' },
+      },
+      ...defaultValues,
+    },
+  });
+  return (
+    <InpostStructuredSection
+      connection={inpostConnection}
+      form={form as any}
+      configIsParseable={configIsParseable}
+      syncStructuredToJson={syncStructuredToJson}
+      syncInpostSenderAddressToJson={syncInpostSenderAddressToJson}
+    />
+  );
+}
+
+describe('InpostStructuredSection', () => {
+  afterEach(cleanup);
+
+  it('routes the environment Select change to the inpostEnvironment field', () => {
+    const syncStructuredToJson = vi.fn();
+    renderWithProviders(<Harness syncStructuredToJson={syncStructuredToJson} />);
+
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'production' } });
+
+    expect(syncStructuredToJson).toHaveBeenCalledWith('inpostEnvironment', 'production');
+  });
+
+  it('routes organization id changes to the inpostOrganizationId field', () => {
+    const syncStructuredToJson = vi.fn();
+    renderWithProviders(<Harness syncStructuredToJson={syncStructuredToJson} />);
+
+    fireEvent.change(screen.getByPlaceholderText('123456'), { target: { value: '987654' } });
+
+    expect(syncStructuredToJson).toHaveBeenCalledWith('inpostOrganizationId', '987654');
+  });
+
+  it('re-serializes the whole sender address via syncInpostSenderAddressToJson on a sender-field change', () => {
+    const syncInpostSenderAddressToJson = vi.fn();
+    renderWithProviders(
+      <Harness syncInpostSenderAddressToJson={syncInpostSenderAddressToJson} />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Warszawa'), { target: { value: 'Kraków' } });
+
+    expect(syncInpostSenderAddressToJson).toHaveBeenCalled();
+  });
+
+  it('pre-fills sender fields from the hydrated form value', () => {
+    renderWithProviders(
+      <Harness
+        defaultValues={{
+          inpostSenderAddress: {
+            name: 'Sklep ACME',
+            email: 'magazyn@acme.pl',
+            phone: '+48111222333',
+            address: {
+              street: 'ul. Magazynowa',
+              buildingNumber: '1',
+              city: 'Warszawa',
+              postCode: '00-001',
+              countryCode: 'PL',
+            },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByDisplayValue('magazyn@acme.pl')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('00-001')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Warszawa')).toBeInTheDocument();
+  });
+
+  it('disables all inputs when configText is unparseable', () => {
+    renderWithProviders(<Harness configIsParseable={false} />);
+    expect(screen.getByRole('combobox')).toBeDisabled();
+    expect(screen.getByPlaceholderText('123456')).toBeDisabled();
+    expect(screen.getByPlaceholderText('00-001')).toBeDisabled();
+  });
+});

--- a/apps/web/src/plugins/inpost/components/inpost-structured-section.tsx
+++ b/apps/web/src/plugins/inpost/components/inpost-structured-section.tsx
@@ -1,0 +1,244 @@
+/**
+ * InPost Structured Section (#771)
+ *
+ * Plugin-owned structured-config inputs rendered inside `EditConnectionForm`
+ * when the connection's `platformType` is `'inpost'`. Carries:
+ *
+ *   - Environment (sandbox / production) → flat `config.environment`
+ *   - Organization id → flat `config.organizationId`
+ *   - Sender address (name?, email, phone, street, building number, city,
+ *     postcode, country) → whole-object `config.senderAddress`
+ *
+ * The two flat scalars sync through the host's per-field `syncStructuredToJson`
+ * (the merge clauses map `inpostEnvironment`/`inpostOrganizationId` to the real
+ * config keys). The nested sender address re-serializes via the host's
+ * `syncInpostSenderAddressToJson` whole-object seam after each `setValue`,
+ * mirroring the Allegro seller-defaults pattern.
+ *
+ * Credentials (the ShipX `apiToken`) are NOT here — they live in the dedicated
+ * `InpostCredentialsPanel`. Connection-test is the generic `ConnectionActions`
+ * Test button on the detail page (backed by the InPost connection tester).
+ *
+ * @module plugins/inpost/components
+ */
+import type { ReactElement } from 'react';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
+import { useTranslation } from '../../../shared/i18n';
+import type { StructuredConfigSectionProps } from '../../../shared/plugins';
+
+export function InpostStructuredSection({
+  form,
+  configIsParseable,
+  syncStructuredToJson,
+  syncInpostSenderAddressToJson,
+}: StructuredConfigSectionProps): ReactElement {
+  const { t } = useTranslation();
+
+  // Re-serialize the whole sender address after writing a single nested field.
+  // Gated on the host serializer being threaded in (always is, today) and on
+  // `configIsParseable` (the host serializer also early-returns when false).
+  function onSenderAddressChange(): void {
+    syncInpostSenderAddressToJson?.();
+  }
+
+  return (
+    <>
+      <FormField
+        label={t('inpost.settings.environment.label', 'Environment')}
+        name="inpostEnvironment"
+        error={form.formState.errors.inpostEnvironment?.message}
+        description={t(
+          'inpost.settings.environment.description',
+          'ShipX target environment. Use Sandbox to verify before switching to Production.',
+        )}
+      >
+        <Select
+          value={form.watch('inpostEnvironment') ?? ''}
+          onChange={(event) => syncStructuredToJson('inpostEnvironment', event.target.value)}
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.inpostEnvironment)}
+        >
+          <option value="">{t('inpost.settings.environment.unset', '— not set —')}</option>
+          <option value="sandbox">{t('inpost.settings.environment.sandbox', 'Sandbox')}</option>
+          <option value="production">
+            {t('inpost.settings.environment.production', 'Production')}
+          </option>
+        </Select>
+      </FormField>
+
+      <FormField
+        label={t('inpost.settings.organizationId.label', 'Organization ID')}
+        name="inpostOrganizationId"
+        error={form.formState.errors.inpostOrganizationId?.message}
+        description={t(
+          'inpost.settings.organizationId.description',
+          'ShipX organization id — a URL path parameter on every shipment endpoint.',
+        )}
+      >
+        <Input
+          className="mono-text"
+          value={form.watch('inpostOrganizationId') ?? ''}
+          onChange={(event) => syncStructuredToJson('inpostOrganizationId', event.target.value)}
+          placeholder="123456"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.inpostOrganizationId)}
+        />
+      </FormField>
+
+      <FormField
+        label={t('inpost.settings.sender.name.label', 'Sender name (optional)')}
+        name="inpostSenderAddress.name"
+        error={form.formState.errors.inpostSenderAddress?.name?.message}
+      >
+        <Input
+          {...form.register('inpostSenderAddress.name')}
+          onChange={(event) => {
+            form.setValue('inpostSenderAddress.name', event.target.value, { shouldDirty: true });
+            onSenderAddressChange();
+          }}
+          placeholder="Sklep ACME"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.inpostSenderAddress?.name)}
+        />
+      </FormField>
+
+      <FormField
+        label={t('inpost.settings.sender.email.label', 'Sender email')}
+        name="inpostSenderAddress.email"
+        error={form.formState.errors.inpostSenderAddress?.email?.message}
+      >
+        <Input
+          {...form.register('inpostSenderAddress.email')}
+          onChange={(event) => {
+            form.setValue('inpostSenderAddress.email', event.target.value, { shouldDirty: true });
+            onSenderAddressChange();
+          }}
+          placeholder="magazyn@acme.pl"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.inpostSenderAddress?.email)}
+        />
+      </FormField>
+
+      <FormField
+        label={t('inpost.settings.sender.phone.label', 'Sender phone')}
+        name="inpostSenderAddress.phone"
+        error={form.formState.errors.inpostSenderAddress?.phone?.message}
+      >
+        <Input
+          {...form.register('inpostSenderAddress.phone')}
+          className="mono-text"
+          onChange={(event) => {
+            form.setValue('inpostSenderAddress.phone', event.target.value, { shouldDirty: true });
+            onSenderAddressChange();
+          }}
+          placeholder="+48111222333"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.inpostSenderAddress?.phone)}
+        />
+      </FormField>
+
+      <FormField
+        label={t('inpost.settings.sender.street.label', 'Street')}
+        name="inpostSenderAddress.address.street"
+        error={form.formState.errors.inpostSenderAddress?.address?.street?.message}
+      >
+        <Input
+          {...form.register('inpostSenderAddress.address.street')}
+          onChange={(event) => {
+            form.setValue('inpostSenderAddress.address.street', event.target.value, {
+              shouldDirty: true,
+            });
+            onSenderAddressChange();
+          }}
+          placeholder="ul. Magazynowa"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.inpostSenderAddress?.address?.street)}
+        />
+      </FormField>
+
+      <FormField
+        label={t('inpost.settings.sender.buildingNumber.label', 'Building number')}
+        name="inpostSenderAddress.address.buildingNumber"
+        error={form.formState.errors.inpostSenderAddress?.address?.buildingNumber?.message}
+      >
+        <Input
+          {...form.register('inpostSenderAddress.address.buildingNumber')}
+          className="mono-text"
+          onChange={(event) => {
+            form.setValue('inpostSenderAddress.address.buildingNumber', event.target.value, {
+              shouldDirty: true,
+            });
+            onSenderAddressChange();
+          }}
+          placeholder="1"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.inpostSenderAddress?.address?.buildingNumber)}
+        />
+      </FormField>
+
+      <FormField
+        label={t('inpost.settings.sender.city.label', 'City')}
+        name="inpostSenderAddress.address.city"
+        error={form.formState.errors.inpostSenderAddress?.address?.city?.message}
+      >
+        <Input
+          {...form.register('inpostSenderAddress.address.city')}
+          onChange={(event) => {
+            form.setValue('inpostSenderAddress.address.city', event.target.value, {
+              shouldDirty: true,
+            });
+            onSenderAddressChange();
+          }}
+          placeholder="Warszawa"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.inpostSenderAddress?.address?.city)}
+        />
+      </FormField>
+
+      <FormField
+        label={t('inpost.settings.sender.postCode.label', 'Postcode')}
+        name="inpostSenderAddress.address.postCode"
+        error={form.formState.errors.inpostSenderAddress?.address?.postCode?.message}
+        description={t('inpost.settings.sender.postCode.description', 'PL format NN-NNN (e.g. 00-001).')}
+      >
+        <Input
+          {...form.register('inpostSenderAddress.address.postCode')}
+          className="mono-text"
+          onChange={(event) => {
+            form.setValue('inpostSenderAddress.address.postCode', event.target.value, {
+              shouldDirty: true,
+            });
+            onSenderAddressChange();
+          }}
+          placeholder="00-001"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.inpostSenderAddress?.address?.postCode)}
+        />
+      </FormField>
+
+      <FormField
+        label={t('inpost.settings.sender.countryCode.label', 'Country')}
+        name="inpostSenderAddress.address.countryCode"
+        error={form.formState.errors.inpostSenderAddress?.address?.countryCode?.message}
+        description={t('inpost.settings.sender.countryCode.description', 'ISO 3166-1 alpha-2 (e.g. PL).')}
+      >
+        <Input
+          {...form.register('inpostSenderAddress.address.countryCode')}
+          className="mono-text"
+          maxLength={2}
+          onChange={(event) => {
+            form.setValue('inpostSenderAddress.address.countryCode', event.target.value, {
+              shouldDirty: true,
+            });
+            onSenderAddressChange();
+          }}
+          placeholder="PL"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.inpostSenderAddress?.address?.countryCode)}
+        />
+      </FormField>
+    </>
+  );
+}

--- a/apps/web/src/plugins/inpost/index.ts
+++ b/apps/web/src/plugins/inpost/index.ts
@@ -1,24 +1,41 @@
 /**
  * InPost plugin (FE)
  *
- * Carrier (shipping-only) FE plugin. v1 scope here (#768) is the webhook
- * runbook affordance on the connection-detail page — the manual webhook-setup
- * runbook that complements the backend shipment-status webhook ingestion. The
- * fuller InPost connection-settings surface (setup card, structured config,
- * credentials panel, trigger config) is owned by #771; this plugin grows those
- * slots there.
+ * Carrier (shipping-only) FE plugin. Contributes the guided setup route
+ * (build-time) plus the platform-side connection-settings surface (#771):
+ * a setup card, structured-config editing (environment, organization id,
+ * sender address), and a credentials panel for the ShipX API token. The
+ * webhook runbook `ConnectionActions` (#768) is retained.
+ *
+ * InPost declares one capability (`ShippingProviderManager`), so it contributes
+ * none of the marketplace slots.
  *
  * @module plugins/inpost
  */
 import type { OpenLinkerPlugin } from '../../shared/plugins';
 import { definePlugin } from '../define-plugin';
+import { InpostCredentialsPanel } from './components/inpost-credentials-panel';
+import { InpostStructuredSection } from './components/inpost-structured-section';
 import { InpostWebhookRunbook } from './components/inpost-webhook-runbook';
+import { inpostSetupRoute } from './inpost-setup.route';
 
 export const inpostPlugin: OpenLinkerPlugin = definePlugin({
   id: 'inpost',
   platformType: 'inpost',
+  build: {
+    routes: [inpostSetupRoute],
+  },
   platform: {
     displayName: 'InPost',
+    setupCard: {
+      title: 'InPost',
+      description:
+        'Connect an InPost ShipX courier account. You will need a ShipX API token and your organization id.',
+      to: '/connections/new/inpost',
+      badge: 'ShipX API',
+    },
+    StructuredConfigSection: InpostStructuredSection,
+    CredentialsPanel: InpostCredentialsPanel,
     ConnectionActions: InpostWebhookRunbook,
   },
 });

--- a/apps/web/src/plugins/inpost/inpost-setup.route.tsx
+++ b/apps/web/src/plugins/inpost/inpost-setup.route.tsx
@@ -1,0 +1,16 @@
+/**
+ * Route: `/connections/new/inpost` — guided InPost (ShipX) wizard.
+ *
+ * @module plugins/inpost
+ */
+import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../../app/nav-registry.types';
+
+export const inpostSetupRoute: RouteObject = {
+  path: 'connections/new/inpost',
+  handle: { crumb: { group: 'Platform', title: 'Connect InPost' } } satisfies RouteCrumbHandle,
+  lazy: async () => {
+    const { InpostSetupPage } = await import('../../pages/connections/inpost-setup-page');
+    return { Component: InpostSetupPage };
+  },
+};

--- a/apps/web/src/plugins/inpost/inpost.test.ts
+++ b/apps/web/src/plugins/inpost/inpost.test.ts
@@ -1,0 +1,55 @@
+/**
+ * inpostPlugin smoke tests (#771)
+ *
+ * Asserts the InPost plugin's static surface: identity, the guided setup route,
+ * and the shipping carrier platform contributions (display name, setup card,
+ * structured-config editing, credentials panel, webhook-runbook connection
+ * actions). InPost is a carrier — it deliberately contributes none of the
+ * marketplace slots. Behavioural coverage lives in the component tests.
+ *
+ * @module plugins/inpost
+ */
+import { describe, expect, it } from 'vitest';
+
+import { inpostPlugin } from './index';
+
+describe('inpostPlugin', () => {
+  describe('identity', () => {
+    it('has the stable kebab-case id', () => {
+      expect(inpostPlugin.id).toBe('inpost');
+    });
+    it('declares the matching platformType', () => {
+      expect(inpostPlugin.platformType).toBe('inpost');
+    });
+  });
+
+  describe('build contributions', () => {
+    it('contributes the guided setup route', () => {
+      const paths = (inpostPlugin.build?.routes ?? []).map((route) => route.path);
+      expect(paths).toContain('connections/new/inpost');
+    });
+    it('does NOT contribute API namespaces or an offer-creation wizard (carrier-only)', () => {
+      expect(inpostPlugin.build?.apiNamespaces).toBeUndefined();
+      expect(inpostPlugin.build?.offerCreationWizard).toBeUndefined();
+    });
+  });
+
+  describe('platform contributions', () => {
+    it('declares the display name', () => {
+      expect(inpostPlugin.platform?.displayName).toBe('InPost');
+    });
+    it('contributes the setup card pointing to the guided wizard', () => {
+      expect(inpostPlugin.platform?.setupCard?.to).toBe('/connections/new/inpost');
+      expect(inpostPlugin.platform?.setupCard?.badge).toBe('ShipX API');
+    });
+    it('contributes structured-config editing, a credentials panel, and connection actions', () => {
+      expect(inpostPlugin.platform?.StructuredConfigSection).toBeDefined();
+      expect(inpostPlugin.platform?.CredentialsPanel).toBeDefined();
+      expect(inpostPlugin.platform?.ConnectionActions).toBeDefined();
+    });
+    it('does NOT contribute marketplace slots (carrier-only)', () => {
+      expect(inpostPlugin.platform?.ExtraConfigSection).toBeUndefined();
+      expect(inpostPlugin.platform?.supportsListingEdit).toBeUndefined();
+    });
+  });
+});

--- a/apps/web/src/shared/plugins/plugin.types.ts
+++ b/apps/web/src/shared/plugins/plugin.types.ts
@@ -188,6 +188,15 @@ export interface StructuredConfigSectionProps {
    * it MUST gate their inputs on `configIsParseable`.
    */
   syncObjectToJson?: () => void;
+  /**
+   * #771 — whole-object serializer for the InPost sender address. Same shape as
+   * `syncObjectToJson` (no field argument; the host serializer reads current
+   * form state) but dedicated to `inpostSenderAddress` so it can coexist with
+   * the subiekt-capabilities serializer on the same prop bag. Additive and
+   * optional: existing plugins ignore it. Early-returns when raw JSON is
+   * unparseable, so the InPost section gates its inputs on `configIsParseable`.
+   */
+  syncInpostSenderAddressToJson?: () => void;
 }
 
 /**

--- a/docs/plans/analysis/ANALYSIS-inpost-connection-settings.md
+++ b/docs/plans/analysis/ANALYSIS-inpost-connection-settings.md
@@ -1,0 +1,48 @@
+# Pre-implement gate — InPost connection settings FE (#771)
+
+**Plan:** `docs/plans/implementation-plan-inpost-connection-settings.md`
+**Gated:** 2026-06-28 · read-only, no code/plan edits
+
+## Verdict: ✅ READY
+
+No Critical contract breaks; no reuse collisions. Every new artifact is confirmed
+absent; every change is additive. Two Warnings (FE contract-test count bumps + a
+small additive factory-helper export) — both already anticipated in the plan.
+
+The plan's headline value is **scope correction**: #771 (written 2026-05-17 against
+the spec's intended design) assumes OAuth, a trigger model, and a PS-module dropdown
+that the *shipped* adapter (#764/#765/#768) does not implement. The plan builds the
+real contract (apiToken + senderAddress config) and descopes the rest with reasons —
+this gate confirms those reasons against the tree.
+
+## Reuse findings
+
+| Plan artifact | Verdict | Evidence |
+|---|---|---|
+| `inpost-structured-section.tsx` (+test) | **NEW** | inpost plugin has only `index.ts` + `inpost-webhook-runbook.{tsx,test.tsx}`. |
+| `inpost-credentials-panel.tsx` (+test) | **NEW** | absent. |
+| `inpost-setup.route.tsx` | **NEW** | absent; mirror `prestashop-setup.route.tsx`. |
+| `inpost-connection-tester.adapter.ts` (+spec) | **NEW** | no tester in `libs/integrations/inpost/.../adapters/`; confirms `POST /connections/:id/test` currently 400s for InPost. |
+| InPost fields in `edit-connection.schema.ts` | **NEW (extend)** | grep for `environment`/`organizationId`/`senderAddress` → none; only PS-side `inpostPsModuleType` exists. Additive `StructuredField`/`StructuredConfigPatch` extension. |
+| `index.ts` slots (`setupCard`/`StructuredConfigSection`/`CredentialsPanel`/`build.routes`) | **CHANGE (additive)** | currently only `displayName` + `ConnectionActions`. |
+| `inpost-plugin.ts` tester registration | **CHANGE (additive)** | `register(host)` hook already exists (registers 5 other registries); `connectionTesterRegistry` is on `HostServices`. One added line. |
+| `ConnectionTesterPort` | **REUSE** | existing port (`libs/core/src/integrations/domain/ports/connection-tester.port.ts`); tester implements it — no signature change. |
+
+## Backward-compat findings
+
+**Critical:** none. No core-barrel export removed/renamed, no port signature changed, no DTO shape broken, no Symbol token touched, no ORM/migration.
+
+**Warnings:**
+1. **FE contract tests — count bumps (will fail lint/test if missed).** Adding the `/connections/new/inpost` lazy setup route requires bumping `EXPECTED_LAZY_ROUTE_COUNT` (currently **45 → 46**) in `apps/web/src/app/routes/route-lazy.test.ts`, and adding a `handle.crumb` to the route + the matching `route-handle.test.ts` assertion. Plan Step 4 calls this out.
+2. **Factory-helper export (additive).** `BASE_URLS` / `extractConfig` / `resolveApiToken` in `inpost-adapter.factory.ts` are currently **not exported**. The tester should reuse them — export them (additive, no break) rather than duplicating the base-URL map. Trivial.
+
+**`check:invariants` exposure:** low. InPost is already in `apps/web/src/plugins/index.ts` and `apps/api/src/plugins.ts`, so **no jest-integration `moduleNameMapper` churn** and no `plugins.ts` edit. The tester lives in `libs/integrations/inpost` and imports `ConnectionTesterPort` from `@openlinker/core/integrations` (already a dependency) — no new cross-context deny pattern. No `platformType` literal dispatch in shared FE code (registry-driven plugin).
+
+## Open questions
+
+None blocking. Confirmed-resolved:
+- Connection-test → include the backend tester (user decision); probe `GET /v1/points?per_page=1`, `maxRetries: 0`.
+- Credentials → ShipX `apiToken` (write-only), not OAuth.
+- Descoped (trigger model / PS-module / capability toggles / PL catalog) → documented in the plan + to be noted on #771 so ACs aren't silently dropped.
+
+One thing to decide at implementation, not blocking: whether `senderAddress` is collected only in the guided **setup route** or also editable via `StructuredConfigSection` on the edit form (plan does both — fine, mirrors PrestaShop).

--- a/docs/plans/implementation-plan-inpost-connection-settings.md
+++ b/docs/plans/implementation-plan-inpost-connection-settings.md
@@ -1,0 +1,71 @@
+# Implementation Plan — InPost connection settings FE (#771)
+
+> Connection-settings UI for InPost connections, **scope-corrected** against the
+> shipped ShipX adapter (#764/#765/#768). The issue (written 2026-05-17 against the
+> spec's intended design) assumes OAuth + a trigger model + a PS-module dropdown that
+> the shipped backend does not implement. This plan builds what the real adapter
+> contract supports and descopes the rest with reasons.
+
+## 1. Understand the task
+
+**Goal.** Let an operator fully configure an InPost connection from the UI: environment,
+organization id, sender address, and the ShipX API token — with validation, a guided
+setup card, and the (already-shipped) webhook runbook.
+
+**Layer.** Frontend (`apps/web` plugin contribution) + connections-feature schema. One
+**optional** small backend slice (connection-test tester) is the only non-FE item — see
+fork below.
+
+**Non-goals (descoped with reasons):**
+- **OAuth credentials** → adapter uses a single Bearer `apiToken` (`inpost-credentials.types.ts`); build that, not OAuth.
+- **Trigger-model dropdown** → no `triggerModel` config field exists; webhook+scheduler are passive (#768/#772). Persisting it = dead config. Defer until the backend models it.
+- **PS InPost module dropdown** → already shipped by **#1155** on the *PrestaShop* connection (`inpostPsModuleType`); the InPost adapter never reads it.
+- **Capability toggles** → InPost declares one capability (`ShippingProviderManager`); nothing meaningful to toggle.
+- **PL catalog** → i18n is a no-op seam (English fallback only); use `t('inpost.settings.*', 'English')` per the Subiekt precedent. A real PL catalog is deferred infra (#612 follow-up).
+
+## 2. Research — shipped contract (verified)
+
+- **Config DTO** `libs/integrations/inpost/src/application/dto/inpost-connection-config.dto.ts`: `environment: 'sandbox'|'production'`, `organizationId: string`, `senderAddress: { name?, email, phone, address: { street, buildingNumber, city, postCode (NN-NNN), countryCode (ISO2) } }`. Validator registered at `inpost.shipx.v1`.
+- **Credentials** `inpost-credentials.types.ts`: `{ apiToken: string }` — ShipX Bearer token, resolved from `credentialsRef`, validated in `inpost-adapter.factory.ts`.
+- **Manifest** `inpost-plugin.ts`: `adapterKey: 'inpost.shipx.v1'`, `platformType: 'inpost'`, `supportedCapabilities: ['ShippingProviderManager']`.
+- **FE pattern**: PrestaShop is the worked example — `setupCard` + `build.routes` setup route + `StructuredConfigSection` (RHF + `syncStructuredToJson`) + `CredentialsPanel` (rotate via `PUT /connections/:id/credentials`). Config persists via `PATCH /connections/:id` `config` jsonb; credentials persist separately. Schema + `mergeStructuredIntoConfig` live in `features/connections/components/edit-connection.schema.ts`.
+- **Connection-test**: generic FE button already exists (`ConnectionActionsPanel` → `POST /connections/:id/test`); **no InPost backend tester registered**.
+
+## 3. Design — recommended scope (FE-focused)
+
+Mirror the PrestaShop plugin shape:
+
+1. **`InpostStructuredSection`** (`StructuredConfigSection`) on the edit form — environment select, organizationId, and the nested senderAddress fields, each wired through `syncStructuredToJson`. Nested `senderAddress.*` mapped via a `mergeStructuredIntoConfig` clause (whole-object serializer, mirroring Subiekt/Allegro nested patterns).
+2. **`InpostCredentialsPanel`** (`CredentialsPanel`) — enter/rotate the ShipX `apiToken` via `useUpdateConnectionCredentialsMutation` (`{ apiToken }`).
+3. **`setupCard`** + a guided **setup route** (`/connections/new/inpost`, `build.routes`) collecting name + apiToken + the config, POSTing to `/connections` with `platformType: 'inpost'`, `adapterKey: 'inpost.shipx.v1'`.
+4. **Zod schema** additions in `edit-connection.schema.ts` matching the DTO (email, `^\d{2}-\d{3}$` postCode, ISO2 country, required fields), delete-on-empty semantics.
+5. Keep the existing **webhook runbook** `ConnectionActions` (#768).
+6. **i18n**: all labels via `t('inpost.settings.*', 'English fallback')`.
+7. **Tests**: structured-section + credentials-panel + setup-route (renderWithProviders), schema validation, route-lazy/route-handle contract bumps.
+
+### Connection-test — DECIDED: include the backend tester (Option B)
+The generic FE test button already renders + calls `POST /connections/:id/test`, but no InPost tester is registered, so `ConnectionService.testConnection` throws `400 "Connection testing is not supported for adapter inpost.shipx.v1"`. We add the tester so the button is meaningful. Low surface — confirmed:
+- `ConnectionTesterPort.test(connection, credentialsResolver): Promise<ConnectionTestResult>` (`libs/core/src/integrations/domain/ports/connection-tester.port.ts`); result `{ success, status?, message, latencyMs }`.
+- InPost plugin **already has** `register(host)` and `connectionTesterRegistry` is on `HostServices` — no host edits.
+- Probe: `GET /v1/points?per_page=1` (authenticated, read-only, already used by `findPickupPoints`). Build the `InpostHttpClient` from `environment`→baseURL + resolved `apiToken`, reusing the factory's helpers (export `BASE_URLS`/`extractConfig`/`resolveApiToken` if needed rather than duplicating).
+- Pattern to mirror: `AllegroConnectionTesterAdapter` (`maxRetries: 0`, map success/exception → result + latency).
+
+## 4. Step-by-step plan
+
+1. `edit-connection.schema.ts` — add InPost structured fields + Zod + `mergeStructuredIntoConfig` clause (nested `senderAddress`). *AC:* schema round-trips a created connection; validation matches the DTO.
+2. `plugins/inpost/components/inpost-structured-section.tsx` (+ test) — env select, organizationId, senderAddress fields; `syncStructuredToJson`. *AC:* renders, persists to `config`, validates.
+3. `plugins/inpost/components/inpost-credentials-panel.tsx` (+ test) — enter/rotate `apiToken`. *AC:* rotation calls `PUT /credentials` with `{ apiToken }`.
+4. `plugins/inpost/inpost-setup.route.tsx` (+ route-lazy/route-handle count bumps) — guided create. *AC:* creates a working InPost connection from the UI.
+5. `plugins/inpost/index.ts` — add `setupCard`, `StructuredConfigSection`, `CredentialsPanel`, `build.routes`. *AC:* slots resolve in EditConnectionForm + PlatformPicker.
+6. **Backend tester** `libs/integrations/inpost/src/infrastructure/adapters/inpost-connection-tester.adapter.ts` (+ spec) — `implements ConnectionTesterPort`; builds `InpostHttpClient` (env→baseURL + resolved `apiToken`), probes `GET /v1/points?per_page=1` with `maxRetries: 0`, maps success/exception → `ConnectionTestResult` (success, status, message, latencyMs). *AC:* OK on valid creds; `success:false` + status on 401/403; never throws. Reuse factory helpers (`BASE_URLS`/`extractConfig`/`resolveApiToken`) — export them if currently private rather than duplicating the base-url map.
+7. **Register the tester** in `libs/integrations/inpost/src/inpost-plugin.ts` `register(host)`: `host.connectionTesterRegistry.register('inpost.shipx.v1', new InpostConnectionTesterAdapter());`. *AC:* `POST /connections/:id/test` no longer 400s for InPost.
+8. Operator guide note in `docs/integrations/inpost/` (if present) — configuring an InPost connection + the test button.
+9. Quality gate: `pnpm --filter @openlinker/web type-check lint test` + `pnpm --filter @openlinker/integrations-inpost test`; full `pnpm lint`/`type-check`/`test`.
+
+## 5. Validate
+- **Architecture:** plugin contribution only; no host-internal imports; no `platformType` literal dispatch in shared code (registry-driven).
+- **Naming:** `kebab-case.tsx` components, `*.schema.ts`, `*.route.tsx`, `*.test.tsx`.
+- **State:** server→TanStack Query, form→RHF+Zod, config jsonb via PATCH, credentials via PUT.
+- **Security:** `apiToken` is write-only credentials (never config, never echoed); no secrets in FE.
+- **Responsive:** mobile/tablet per style guide (forms `max-width` per breakpoint); "open on desktop to edit" affordance already host-provided.
+- **Scope honesty:** the descoped items get a closing note on #771 so the issue's ACs aren't silently dropped.

--- a/libs/integrations/inpost/src/application/inpost-adapter.factory.ts
+++ b/libs/integrations/inpost/src/application/inpost-adapter.factory.ts
@@ -23,7 +23,11 @@ import type { InpostCredentials } from '../domain/types/inpost-credentials.types
 import { InpostShippingAdapter } from '../infrastructure/adapters/inpost-shipping.adapter';
 import { InpostHttpClient } from '../infrastructure/http/inpost-http-client';
 
-const BASE_URLS: Readonly<Record<InpostEnvironment, string>> = {
+/**
+ * ShipX environment → base URL. Exported (#771) so the connection-tester
+ * adapter can build a probe `InpostHttpClient` without duplicating the map.
+ */
+export const BASE_URLS: Readonly<Record<InpostEnvironment, string>> = {
   sandbox: 'https://sandbox-api-shipx-pl.easypack24.net',
   production: 'https://api-shipx-pl.easypack24.net',
 };
@@ -38,7 +42,7 @@ export async function createInpostShippingAdapter(
   return new InpostShippingAdapter(client, config);
 }
 
-function extractConfig(connection: Connection): InpostConnectionConfig {
+export function extractConfig(connection: Connection): InpostConnectionConfig {
   const raw = (connection.config ?? {}) as Record<string, unknown>;
 
   const environment = raw.environment;
@@ -75,7 +79,7 @@ function extractConfig(connection: Connection): InpostConnectionConfig {
   };
 }
 
-async function resolveApiToken(
+export async function resolveApiToken(
   connection: Connection,
   credentialsResolver: CredentialsResolverPort,
 ): Promise<string> {

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-connection-tester.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-connection-tester.adapter.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * InPost Connection Tester Adapter Unit Tests (#771)
+ *
+ * Exercises the probe + error-translation paths so every outcome produces a
+ * structured, UI-safe `ConnectionTestResult` instead of throwing — happy path,
+ * auth rejection (401/403 → InpostUnauthorizedException), transport failure,
+ * and an under-provisioned config.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/adapters/__tests__
+ */
+import { Connection } from '@openlinker/core/identifier-mapping';
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import { InpostConnectionTesterAdapter } from '../inpost-connection-tester.adapter';
+import { InpostHttpClient } from '../../http/inpost-http-client';
+import { InpostUnauthorizedException } from '../../../domain/exceptions/inpost-unauthorized.exception';
+import { InpostNetworkException } from '../../../domain/exceptions/inpost-network.exception';
+
+describe('InpostConnectionTesterAdapter', () => {
+  const tester = new InpostConnectionTesterAdapter();
+  const resolver: CredentialsResolverPort = {
+    get: jest.fn().mockResolvedValue({ apiToken: 'token-123' }),
+  } as unknown as CredentialsResolverPort;
+
+  function buildConnection(config: Record<string, unknown>): Connection {
+    return new Connection(
+      'inpost_1',
+      'inpost',
+      'InPost ShipX',
+      'active',
+      config,
+      'db:ref',
+      new Date(),
+      new Date(),
+      'inpost.shipx.v1',
+      ['ShippingProviderManager'],
+    );
+  }
+
+  const validConfig = {
+    environment: 'sandbox',
+    organizationId: '123456',
+    senderAddress: {
+      email: 'magazyn@acme.pl',
+      phone: '+48111222333',
+      address: {
+        street: 'ul. Magazynowa',
+        buildingNumber: '1',
+        city: 'Warszawa',
+        postCode: '00-001',
+        countryCode: 'PL',
+      },
+    },
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns success with status 200 when the probe resolves', async () => {
+    jest.spyOn(InpostHttpClient.prototype, 'request').mockResolvedValue([] as never);
+
+    const result = await tester.test(buildConnection(validConfig), resolver);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.message).toBe('OK');
+    expect(typeof result.latencyMs).toBe('number');
+  });
+
+  it('maps an auth rejection to success:false with status 401', async () => {
+    jest
+      .spyOn(InpostHttpClient.prototype, 'request')
+      .mockRejectedValue(new InpostUnauthorizedException('access_forbidden'));
+
+    const result = await tester.test(buildConnection(validConfig), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(401);
+    expect(result.message).toBe('access_forbidden');
+  });
+
+  it('never throws on a transport failure — maps to success:false with no status', async () => {
+    jest
+      .spyOn(InpostHttpClient.prototype, 'request')
+      .mockRejectedValue(new InpostNetworkException('ShipX network error'));
+
+    const result = await tester.test(buildConnection(validConfig), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBeUndefined();
+    expect(result.message).toBe('ShipX network error');
+  });
+
+  it('never throws on an under-provisioned config — surfaces the config error', async () => {
+    const requestSpy = jest.spyOn(InpostHttpClient.prototype, 'request');
+
+    const result = await tester.test(buildConnection({ environment: 'sandbox' }), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('organizationId');
+    // Probe never ran — config validation short-circuited before any HTTP call.
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+});

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-connection-tester.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-connection-tester.adapter.ts
@@ -1,0 +1,83 @@
+/**
+ * InPost Connection Tester Adapter (#771)
+ *
+ * Implements `ConnectionTesterPort` for InPost connections. Performs a cheap
+ * authenticated probe against `GET /v1/points?per_page=1` (the same read-only
+ * ShipX endpoint `findPickupPoints` uses) to validate that the stored ShipX
+ * Bearer token + environment base URL still work.
+ *
+ * Never throws — all failures (invalid/under-provisioned config, auth
+ * rejection, transport error) are translated into a structured
+ * `ConnectionTestResult` with `success: false`. Reuses the adapter factory's
+ * `BASE_URLS` / `extractConfig` / `resolveApiToken` helpers so the base-URL map
+ * and config/credentials resolution stay single-sourced. The probe client runs
+ * with `maxRetries: 0` so a stale token surfaces as an immediate, clear failure.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/adapters
+ * @implements {ConnectionTesterPort}
+ */
+import type {
+  ConnectionTesterPort,
+  ConnectionTestResult,
+  CredentialsResolverPort,
+} from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { BASE_URLS, extractConfig, resolveApiToken } from '../../application/inpost-adapter.factory';
+import { InpostUnauthorizedException } from '../../domain/exceptions/inpost-unauthorized.exception';
+import { InpostHttpClient } from '../http/inpost-http-client';
+
+export class InpostConnectionTesterAdapter implements ConnectionTesterPort {
+  async test(
+    connection: Connection,
+    credentialsResolver: CredentialsResolverPort,
+  ): Promise<ConnectionTestResult> {
+    const startedAt = Date.now();
+    try {
+      const config = extractConfig(connection);
+      const apiToken = await resolveApiToken(connection, credentialsResolver);
+
+      const client = new InpostHttpClient(BASE_URLS[config.environment], apiToken, {
+        maxRetries: 0,
+        initialDelayMs: 0,
+        backoffMultiplier: 1,
+        maxDelayMs: 0,
+      });
+
+      await client.request<unknown>({
+        method: 'GET',
+        path: '/v1/points',
+        query: { per_page: 1 },
+      });
+
+      return {
+        success: true,
+        status: 200,
+        message: 'OK',
+        latencyMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        status: resolveStatus(error),
+        message: error instanceof Error ? error.message : 'InPost probe failed',
+        latencyMs: Date.now() - startedAt,
+      };
+    }
+  }
+}
+
+/**
+ * Best-effort HTTP status for the failure result. ShipX auth rejections (401 /
+ * 403) map to `InpostUnauthorizedException`, surfaced here as `401`. Other
+ * exceptions may carry a numeric `status`/`statusCode`; otherwise the status is
+ * omitted and the operator reads the message.
+ */
+function resolveStatus(error: unknown): number | undefined {
+  if (error instanceof InpostUnauthorizedException) {
+    return 401;
+  }
+  const err = error as { statusCode?: number; status?: number };
+  if (typeof err.statusCode === 'number') return err.statusCode;
+  if (typeof err.status === 'number') return err.status;
+  return undefined;
+}

--- a/libs/integrations/inpost/src/inpost-plugin.ts
+++ b/libs/integrations/inpost/src/inpost-plugin.ts
@@ -18,6 +18,7 @@ import type { Connection } from '@openlinker/core/identifier-mapping';
 import { createInpostShippingAdapter } from './application/inpost-adapter.factory';
 import { InpostAuthFailureClassifierAdapter } from './infrastructure/adapters/inpost-auth-failure-classifier.adapter';
 import { InpostConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/inpost-connection-config-shape-validator.adapter';
+import { InpostConnectionTesterAdapter } from './infrastructure/adapters/inpost-connection-tester.adapter';
 import { InpostInboundWebhookDecoderAdapter } from './infrastructure/adapters/inpost-inbound-webhook-decoder.adapter';
 import { InpostWebhookEventTranslatorAdapter } from './infrastructure/adapters/inpost-webhook-event-translator.adapter';
 import { buildInpostSchedulerTasks } from './infrastructure/scheduler/inpost-scheduler-tasks';
@@ -51,6 +52,14 @@ export function createInpostPlugin(): AdapterPlugin {
       );
       // No credentials-shape validator: the `{ apiToken }` shape is enforced
       // at adapter construction time by the factory (deeper than this boundary).
+
+      // #771 — connection-test probe. Makes `POST /connections/:id/test`
+      // meaningful for InPost (it 400s without a registered tester): a cheap
+      // authenticated `GET /v1/points` probe validates the stored token.
+      host.connectionTesterRegistry.register(
+        inpostAdapterManifest.adapterKey,
+        new InpostConnectionTesterAdapter(),
+      );
 
       // Auth-failure classifier (#819 / #1103): a non-retryable 401/403 from the
       // ShipX client flips the connection to `needs_reauth` on the SyncJobRunner


### PR DESCRIPTION
Closes #771 · Part of #727 (InPost integration).

## What & why

Operators can now fully configure an InPost connection from the UI. The issue (written 2026-05-17 against the *spec's intended* design) is **scope-corrected** against the InPost ShipX adapter that actually shipped (#764/#765/#768): the adapter uses a single Bearer **`apiToken`** (not OAuth), a rich **`senderAddress`** config, and a passive webhook+poll model (no operator trigger model).

## FE (`apps/web`)

- **Guided setup wizard** `/connections/new/inpost` (`setupCard` + 3-step form) collecting name + ShipX `apiToken` + config (`environment`, `organizationId`, `senderAddress`). Strict Zod validation (email, NN-NNN postcode, ISO2 country, required contact).
- **`StructuredConfigSection`** on the edit form: environment select, organization id, and the nested `senderAddress` (name / email / phone / address.{street, buildingNumber, city, postCode, countryCode}) — flat scalars via `syncStructuredToJson`, nested address via a new optional `StructuredConfigSectionProps.syncInpostSenderAddressToJson` whole-object seam (mirrors the Allegro seller-defaults pattern). Delete-on-empty + format-when-present validation.
- **`CredentialsPanel`** to enter/rotate the ShipX Bearer `apiToken` (`PUT /connections/:id/credentials`, write-only).
- Retains the shipped webhook-runbook `ConnectionActions` (#768). Strings via the `t(key, 'fallback')` i18n seam (English). `EXPECTED_LAZY_ROUTE_COUNT` 45 → 46.

## Backend (`libs/integrations/inpost`)

- **`InpostConnectionTesterAdapter`** (`ConnectionTesterPort`) probing `GET /v1/points?per_page=1` with `maxRetries: 0`; never throws (maps auth rejection → 401, transport/config errors → `success: false`). Registered at `inpost.shipx.v1` in the plugin's existing `register(host)`. Reuses the factory's now-exported `BASE_URLS` / `extractConfig` / `resolveApiToken` (no duplicated base-URL map). This makes the generic connection-test button meaningful for InPost (previously 400'd).

## Descoped vs the issue (documented; the shipped adapter has no contract for these)

- **OAuth → apiToken** (adapter is single-token Bearer).
- **Trigger-model dropdown** — no `triggerModel` config the adapter reads; webhook+poll are passive (#768/#772). Persisting it would be dead config.
- **PS InPost module dropdown** — already shipped by **#1155** on the *PrestaShop* connection (`inpostPsModuleType`); the InPost adapter never reads it.
- **Capability toggles** — InPost declares one capability (`ShippingProviderManager`); nothing meaningful to toggle.
- **PL catalog** — i18n is a no-op seam (English fallback only); a PL catalog loader is deferred infra.

A closing note on #771 records these so the original ACs aren't silently dropped.

Pipeline: plan → tech-review (plan) → pre-implement (READY) → implement → tech-review (diff, Approve) → fix (countryCode uppercase parity edit↔setup).

## Test plan

- **Unit (FE):** structured-section, credentials-panel, setup-form + setup-schema, plugin smoke.
- **Unit (BE):** `inpost-connection-tester.adapter.spec.ts` — success (200), auth → 401, transport-throw → no status, under-provisioned config → surfaced + no HTTP call.

## Quality gate

- [x] `pnpm lint` (0 errors; all `check:invariants` green)
- [x] `pnpm type-check` (full)
- [x] `pnpm --filter @openlinker/web test` (1798)
- [x] `pnpm --filter @openlinker/integrations-inpost test` (79)

No migration (no ORM/schema change). No int-spec touched (tester is unit-covered).

## DCO sign-off

Signed off with `git commit -s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)