### PR TITLE
docs: showcase all shipped integrations + add capability reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,18 @@ If you sell on your own shop *and* on marketplaces like Allegro, you've already 
 | Integration | Role | Status |
 |---|---|---|
 | **[PrestaShop](./libs/integrations/prestashop/)** | Shop *(source + destination)* | ✅ Live |
-| **[Allegro](./libs/integrations/allegro/)** | Marketplace *(source + offers)* | ✅ Live |
+| **[WooCommerce](./libs/integrations/woocommerce/)** *([guide](./docs/integrations/woocommerce/setup-guide.md))* | Shop *(source + destination + inventory)* | ✅ Live |
+| **[Allegro](./libs/integrations/allegro/)** | Marketplace *(source + offers + shipping)* | ✅ Live |
+| **[Erli](./libs/integrations/erli/)** *([guide](./docs/integrations/erli/setup-guide.md))* | Marketplace *(offers + source)* | ✅ Live |
 | **[AI router](./libs/integrations/ai/)** *(Anthropic, OpenAI)* | Content suggestion | ✅ Live |
-| **Subiekt nexo** *([#728](https://github.com/openlinker-project/openlinker/issues/728))* | Invoicing *(via Sfera bridge — first `InvoicingPort` adapter)* | 🚧 In progress |
-| **InPost** *([#727](https://github.com/openlinker-project/openlinker/issues/727))* | Shipping *(ShipX — paczkomat + kurier, labels, webhooks)* | 🚧 In progress |
-| **[WooCommerce](./libs/integrations/woocommerce/)** | Shop *(source + destination + inventory)* | ✅ Live |
+| **[InPost](./libs/integrations/inpost/)** *([guide](./docs/integrations/inpost/setup-guide.md))* | Shipping *(ShipX — paczkomat + kurier, labels, webhooks)* | ✅ Live |
+| **[DPD](./libs/integrations/dpd-polska/)** *([guide](./docs/integrations/dpd-polska/setup-guide.md))* | Shipping *(REST labels + protocols, SOAP tracking)* | ✅ Live |
+| **[Subiekt nexo](./libs/integrations/subiekt/)** *([guide](./docs/integrations/subiekt/setup-guide.md))* | Invoicing *(via Sfera bridge — first `InvoicingPort` adapter)* | ✅ Live |
+| **[KSeF](./libs/integrations/ksef/)** *([guide](./docs/integrations/ksef/setup-guide.md))* | Invoicing *(Polish national e-invoicing)* | 🚧 In progress |
 | Shopify · BigCommerce · Magento | Shop | 📋 Planned |
 | eBay · Amazon · OLX · Empik · Bol | Marketplace | 📋 Planned |
-| DPD · DHL · FedEx · ORLEN Paczka · GLS | Shipping *(pending `ShippingProviderPort` from #727)* | 📋 Planned |
-| Fakturownia · iFirma · wFirma · inFakt | Invoicing *(siblings of Subiekt under `InvoicingPort`)* | 📋 Planned |
+| DHL · FedEx · ORLEN Paczka · GLS | Shipping *(siblings under `ShippingProviderManagerPort`)* | 📋 Planned |
+| Fakturownia · iFirma · wFirma · inFakt | Invoicing *(siblings under `InvoicingPort`)* | 📋 Planned |
 
 Planned items are open for community contributions — see [Adding your own integration](#adding-your-own-integration) below.
 
@@ -62,13 +65,15 @@ OpenLinker is built around a small set of capability ports. Each integration imp
 
 | Capability | What it does | Integrations |
 |---|---|---|
-| **Catalog & inventory** | Read products, variants, and stock from a master shop | PrestaShop |
-| **Orders** | Ingest from any source *(event journal or watermark)*; create + manage them in a destination shop | PrestaShop *(source + destination)* · Allegro *(source only)* |
-| **Offers / listings** | Manage marketplace offers — categories, prices, quantities, seller policies, GPSR data | Allegro |
+| **Catalog & inventory** | Read products, variants, and stock from a master shop | PrestaShop · WooCommerce |
+| **Orders** | Ingest from any source *(event journal or watermark)*; create + manage them in a destination shop | PrestaShop *(source + destination)* · WooCommerce *(source + destination)* · Allegro *(source)* · Erli *(source)* |
+| **Offers / listings** | Manage marketplace offers — categories, prices, quantities, seller policies, GPSR data | Allegro · Erli |
+| **Shipping** | Generate labels + handover protocols, fetch tracking *(via `ShippingProviderManagerPort`)* | Allegro · InPost · DPD |
+| **Invoicing** | Issue fiscal documents and, where supported, submit them to a tax authority for clearance *(via `InvoicingPort`)* | Subiekt nexo · KSeF |
 | **Content suggestion** | Provider-agnostic AI completions with editable, versioned prompts | AI router *(Anthropic, OpenAI)* |
-| **Auth & ops** | Per-integration connection testers, webhook provisioners, OAuth, retry classifiers, credentials/config validators | PrestaShop · Allegro |
+| **Auth & ops** | Per-integration connection testers, webhook provisioners, OAuth, retry classifiers, credentials/config validators | All integrations |
 
-See [`docs/architecture-overview.md`](./docs/architecture-overview.md) for the full port signatures, the offer sub-capability inventory, and the contracts plugin authors implement against.
+See [`docs/capabilities.md`](./docs/capabilities.md) for the full, code-synced vocabulary — every capability port, its base contract, and all 31 sub-capabilities with descriptions and guards — and [`docs/architecture-overview.md`](./docs/architecture-overview.md) for the contracts plugin authors implement against.
 
 **Host-provided, regardless of integration:** encrypted credentials store · multi-connection per platform type *(two PrestaShop stores from one instance)* · identifier mapping with a single unified seed *(`ol_product_*`, `ol_order_*`, `ol_variant_*`, …)* · customer identity resolution with optional email-fallback · PII-aware storage *(full or hash-only)* · sync-job orchestration with retry classification + outcome tracking · browser-based admin UI.
 
@@ -121,12 +126,14 @@ How OpenLinker measures against the standard set of multichannel-orchestration f
 | **Orders** | | |
 | Ingest orders from any source *(marketplace or shop)* | ✅ | `OrderSourcePort` |
 | Create + manage orders in destination shop | ✅ | `OrderProcessorManagerPort` |
-| Generate invoices, receipts, accounting export | — | *Out of scope; integrate accounting separately* |
+| Generate invoices / fiscal documents *(+ tax-authority clearance)* | ✅ | `InvoicingPort` — Subiekt nexo, KSeF |
+| Accounting export / GL / valuation | — | *Out of scope; integrate accounting separately* |
 | **Inventory & catalog** | | |
 | Read products, variants, attributes | ✅ | `ProductMasterPort` |
 | Read inventory levels | ✅ | `InventoryMasterPort` |
 | Multi-location / multi-warehouse stock | 🛣️ | `InventoryMasterPort` accepts `locationId`; not yet exercised by an adapter |
-| Bulk catalog operations | ⚠️ | `OfferQuantityBatchUpdater` sub-capability defined; not yet implemented |
+| Bulk offer creation | ✅ | Bulk offer-creation batch *(Allegro)* + bulk shop-publish *(WooCommerce)* |
+| Bulk quantity batch-update | ⚠️ | `OfferQuantityBatchUpdater` sub-capability defined; no adapter implements it yet |
 | **Marketplace listings** | | |
 | Create + update offers *(categories, policies, GPSR)* | ✅ | `OfferManagerPort` + sub-capability ports |
 | AI offer descriptions | ✅ | `AiCompletionPort` |
@@ -139,11 +146,11 @@ How OpenLinker measures against the standard set of multichannel-orchestration f
 | Carrier mapping *(marketplace ↔ physical carrier)* | ✅ | Host-provided carrier-mapping service |
 | Pickup-point handling *(Paczkomat, etc.)* | ✅ | Through `OrderSourcePort` order shape |
 | Buyer-paid shipping cost round-trip | ✅ | `OrderProcessorManagerPort` + plugin-owned shop module |
-| Generate shipping labels | 🛣️ | `ShippingProviderManagerPort` planned |
-| Push tracking back to marketplace | 🛣️ | Paired with `ShippingProviderManagerPort` |
+| Generate shipping labels + handover protocols | ✅ | `ShippingProviderManagerPort` — InPost, DPD, Allegro |
+| Fetch tracking + push status back to marketplace | ✅ | `ShippingProviderManagerPort` tracking + order-status writeback *(ADR-027)* |
 | **Payments** | | |
 | Payment status from order data | ✅ | Part of the `IncomingOrder` shape from `OrderSourcePort` |
-| Refunds via return flow | ✅ | `OrderProcessorManagerPort.processReturn` |
+| Refunds / returns lifecycle | 🛣️ | OL-owned order-status state machine deferred (#1032); the `refunded` payment status is read-only forward-compat *(no source emits it in v1)* |
 | Payment provider integrations *(Stripe, P24, …)* | 🛣️ | `PaymentProcessorPort` planned |
 | **Operations** | | |
 | Multiple shops + marketplaces in one instance | ✅ | Host-provided connection model |

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -484,6 +484,8 @@ interface OfferManagerPort {
 
 Each is an independent interface + co-located `is{Capability}(adapter)` type guard. Adapters declare the capabilities they support via `implements OfferManagerPort, OfferLister, OfferCreator, …`; call sites narrow via the guard before invoking the method — after the guard TypeScript knows the method is present.
 
+> The table below is a curated highlight. The **complete, code-synced inventory of all 31 sub-capabilities across every port** (with descriptions and guards) lives in [`docs/capabilities.md`](./capabilities.md).
+
 | Capability | Method |
 |---|---|
 | `OfferLister` | `listOffers(input)` |
@@ -499,9 +501,9 @@ Each is an independent interface + co-located `is{Capability}(adapter)` type gua
 | `SellerPoliciesReader` | `fetchSellerPolicies()` |
 | `CatalogProductReader` | `findProductsByBarcode(input)`, `getProduct(input)` |
 
-**Current Implementation**: `AllegroOfferManagerAdapter` (implements every capability except `OfferQuantityBatchUpdater`).
+**Current Implementations**: `AllegroOfferManagerAdapter` (implements every capability except `OfferQuantityBatchUpdater`); `ErliOfferManagerAdapter` (registered at `erli.shopapi.v1`, reconciliation-first posture per [ADR-025](./architecture/adrs/025-erli-marketplace-adapter.md), #984).
 
-**Future Implementations**: `ShopifyOfferManagerAdapter`, `WooCommerceOfferManagerAdapter`, `EbayOfferManagerAdapter`, `ErliOfferManagerAdapter` (#984 — plugin skeleton registered at `erli.shopapi.v1`, reconciliation-first posture per [ADR-025](./architecture/adrs/025-erli-marketplace-adapter.md)).
+**Future Implementations**: `ShopifyOfferManagerAdapter`, `EbayOfferManagerAdapter`.
 
 ### Future Capability Ports
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,0 +1,135 @@
+# Capability & Sub-capability Reference
+
+The canonical, code-synced inventory of every capability port, its base
+contract, and its composable sub-capabilities. This is the developer-facing
+counterpart to the integration showcase in the [README](../README.md); for the
+*why* of the capability-ports + sub-capabilities design see
+[ADR-002](./architecture/adrs/002-capability-ports-with-sub-capabilities.md)
+and the [Architecture Overview](./architecture-overview.md).
+
+**How to read this:** core depends on **capability ports** (business roles).
+The base port carries only the method *every* adapter of that role must
+implement; optional behaviour is split into **sub-capabilities** — independent
+interfaces in `domain/ports/capabilities/`, each with a co-located
+`is{Capability}(adapter)` type-guard. Call sites narrow with the guard before
+invoking, and degrade gracefully when an adapter doesn't implement it.
+
+> **Source of truth.** Every name below is generated from
+> `libs/core/src/**/domain/ports/**`. When you add a port or sub-capability,
+> update this file in the same PR. If a table here disagrees with the code, the
+> code wins — fix the doc.
+
+---
+
+## Capability ports
+
+| Port | Context | Registry capability | What it does | Base method(s) |
+|---|---|---|---|---|
+| `ProductMasterPort` | products | `ProductMaster` | Source of truth for the product catalog — read/write products, variants, and categories. | `getProduct` · `getProducts` · `createProduct` · `updateProduct` · `deleteProduct` · `getProductVariants` · `upsertProductVariant` · `getProductCategories` · `assignCategories` · `searchProducts` · `listExternalIds` |
+| `InventoryMasterPort` | inventory | `InventoryMaster` | Source of truth for stock levels; carries the (largely dormant) reservation surface. | `getInventory` · `listInventory` · `adjustInventory` · `reserveInventory` · `releaseInventory` · `getAvailableQuantity` |
+| `OrderSourcePort` | orders | `OrderSource` | Cursor-based, read-only ingestion of orders from any source (marketplace journal or shop watermark). | `listOrderFeed` · `getOrder` |
+| `OrderProcessorManagerPort` | orders | `OrderProcessorManager` | Create orders on a destination shop. | `createOrder` |
+| `OfferManagerPort` | listings | `OfferManager` | Manage marketplace offers/listings; base contract is the inventory-driven quantity update. | `updateOfferQuantity` |
+| `ShopProductManagerPort` | listings | `ProductPublisher` | Publish a product as a native listing on a shop (the shop-publish flow). | `publishProduct` |
+| `ShippingProviderManagerPort` | shipping | `ShippingProviderManager` *(open-world — see note)* | Generate shipping labels, read tracking, and list supported shipping methods. | `generateLabel` · `getTracking` · `getSupportedMethods` |
+| `InvoicingPort` | invoicing | `Invoicing` | Issue fiscal documents, fetch them, upsert a customer, and report supported document types. | `issueInvoice` · `getInvoice` · `upsertCustomer` · `getSupportedDocumentTypes` |
+| `ContentPublisherPort` | content | *(internal — not registry-resolved)* | Publish a content field (e.g. a product description) to a channel or the master. | `publish` |
+
+**Open-world capability vocabulary (#576).** The closed, well-known set is
+`CoreCapabilityValues` = `ProductMaster`, `InventoryMaster`, `OrderSource`,
+`OrderProcessorManager`, `OfferManager`, `ProductPublisher`,
+`CategoryProvisioner`, `Invoicing`. Adapters may register **additional**
+capability strings at runtime without a core change — `ShippingProviderManager`
+is the live example (declared in the InPost / DPD / Allegro manifests, resolved
+through the registry, but intentionally *not* a member of the closed set). The
+runtime gate validates a connection's request against the adapter's
+`supportedCapabilities`, not against the closed union.
+
+> **Which integration implements what** is each adapter's own declaration: its
+> `supportedCapabilities` manifest (`libs/integrations/<p>/src/<p>-plugin.ts`) is
+> the source of truth, and the capability-level showcase across all integrations
+> lives in the [root README](../README.md#capabilities). This file stays the
+> platform-neutral *vocabulary* — the ports and sub-capabilities themselves.
+
+---
+
+## Sub-capabilities
+
+Each is an independent interface + co-located `is{Capability}` guard. Adapters
+declare what they support via `implements <BasePort>, <SubCapability>, …`.
+
+### `OfferManagerPort` (listings) — 18
+
+| Sub-capability | What it does | Method(s) | Guard |
+|---|---|---|---|
+| `OfferLister` | Page through the seller's existing offers. | `listOffers` | `isOfferLister` |
+| `OfferReader` | Fetch a single offer by external id. | `getOffer` | `isOfferReader` |
+| `OfferEventReader` | Read the marketplace's incremental offer-event journal. | `listOfferEvents` | `isOfferEventReader` |
+| `OfferCreator` | Create a new offer / listing. | `createOffer` | `isOfferCreator` |
+| `OfferFieldUpdater` | Partially update offer fields (e.g. description text). | `updateOfferFields` | `isOfferFieldUpdater` |
+| `OfferStatusReader` | Read an offer's live publication status. | `getOfferStatus` | `isOfferStatusReader` |
+| `OfferStockRestorer` | Restore offer stock after a cancellation. | `restoreStockOnCancellation` | `isOfferStockRestorer` |
+| `OfferQuantityBatchUpdater` | Bulk-update quantities for many offers in one call. | `updateOfferQuantitiesBatch` | `isOfferQuantityBatchUpdater` |
+| `OfferSmartClassificationReader` | Fetch the marketplace's smart/auto classification for an offer. | `getOfferSmartClassification` | `isOfferSmartClassificationReader` |
+| `CategoryBrowser` | Browse the marketplace category tree. | `fetchCategories` | `isCategoryBrowser` |
+| `CategoryBarcodeMatcher` | Auto-detect a category from a product barcode. | `matchCategoryByBarcode` | `isCategoryBarcodeMatcher` |
+| `CategoryParametersReader` | Read the parameter schema a category requires. | `fetchCategoryParameters` | `isCategoryParametersReader` |
+| `EanCategoryMatcher` | Resolve categories for a batch of products by EAN. | `resolveCategoriesForBatchByEan` | `isEanCategoryMatcher` |
+| `CatalogProductReader` | Look up marketplace catalog products by barcode / id. | `findProductsByBarcode` · `getProduct` | `isCatalogProductReader` |
+| `SellerPoliciesReader` | Surface the seller's saved return / shipping / warranty policies. | `fetchSellerPolicies` | `isSellerPoliciesReader` |
+| `ResponsibleProducerReader` | List GPSR responsible-producer entries. | `fetchResponsibleProducers` | `isResponsibleProducerReader` |
+| `SafetyAttachmentUploader` | Upload a GPSR safety attachment (manual, label, …). | `uploadSafetyAttachment` | `isSafetyAttachmentUploader` |
+| `TaxonomyBorrower` | Reuse another platform's resolved taxonomy for a destination. | `getBorrowedTaxonomy` | `isTaxonomyBorrower` |
+
+**Adapter coverage:** Allegro implements every sub-capability except
+`OfferQuantityBatchUpdater` (see the [README Implementations](../README.md#implementations)
+section); Erli implements a reconciliation-first subset
+([ADR-025](./architecture/adrs/025-erli-marketplace-adapter.md)).
+
+### `ShopProductManagerPort` (listings) — 1
+
+| Sub-capability | What it does | Method(s) | Guard |
+|---|---|---|---|
+| `CategoryProvisioner` | Create / ensure a category exists on the destination shop before publishing. Also a registry-level capability (`CategoryProvisioner` ∈ `CoreCapabilityValues`). | `provisionCategory` | `isCategoryProvisioner` |
+
+### `OrderProcessorManagerPort` / `OrderSourcePort` (orders) — 5
+
+| Sub-capability | What it does | Method(s) | Guard |
+|---|---|---|---|
+| `OrderFulfillmentUpdater` | Push a post-create status + tracking update to a destination order. | `updateFulfillment` | `isOrderFulfillmentUpdater` |
+| `OrderStatusWriteback` | Relay an order-status change back to the originating marketplace (event-as-data). | `write` | `isOrderStatusWriteback` |
+| `FulfillmentStatusReader` | Read a destination order's current fulfillment status. | `getFulfillmentStatus` | `isFulfillmentStatusReader` |
+| `DestinationOptionsReader` | List a destination's carriers / order-statuses / payment-methods for mapping. | `listCarriers` · `listOrderStatuses` · `listPaymentMethods` | `isDestinationOptionsReader` |
+| `SourceOptionsReader` | List a source's order-statuses / delivery-methods / payment-methods for mapping. | `listOrderStatuses` · `listDeliveryMethods` · `listPaymentMethods` | `isSourceOptionsReader` |
+
+The canonical OL-owned order-lifecycle state machine (authoritative
+`updateOrderStatus` / `cancelOrder` / `processReturn` / `getOrders`) is
+**deferred** — see [#1032](https://github.com/openlinker-project/openlinker/issues/1032).
+
+### `ShippingProviderManagerPort` (shipping) — 4
+
+| Sub-capability | What it does | Method(s) | Guard |
+|---|---|---|---|
+| `LabelDocumentReader` | Fetch the label document for an already-registered shipment. | `fetchLabel` | `isLabelDocumentReader` |
+| `DispatchProtocolReader` | Generate a handover / dispatch protocol for a batch of shipments. | `generateProtocol` | `isDispatchProtocolReader` |
+| `PickupPointFinder` | Search the carrier's pickup points / lockers (e.g. Paczkomat). | `findPickupPoints` | `isPickupPointFinder` |
+| `ShipmentCanceller` | Cancel / void a registered shipment. | `cancelShipment` | `isShipmentCanceller` |
+
+### `InvoicingPort` (invoicing) — 3
+
+| Sub-capability | What it does | Method(s) | Guard |
+|---|---|---|---|
+| `RegulatoryStatusReader` | Read the clearance status of a previously-submitted document. | `getClearanceStatus` | `isRegulatoryStatusReader` |
+| `RegulatoryTransmitter` *(extends `RegulatoryStatusReader`)* | Submit a document to the tax authority for clearance (+ read its status). | `submitForClearance` | `isRegulatoryTransmitter` |
+| `CorrectionIssuer` | Issue a correcting document (e.g. KSeF `KOR`) against an original. | `issueCorrection` | `isCorrectionIssuer` |
+
+See [ADR-026](./architecture/adrs/026-country-agnostic-invoicing-domain.md) for
+the country-agnostic invoicing design.
+
+---
+
+## Adding a capability or sub-capability
+
+1. **Port** → `libs/core/src/<ctx>/domain/ports/<name>.port.ts`; export from the context barrel. If it should be registry-resolvable, decide whether it joins the closed `CoreCapabilityValues` set or stays an open-world string (#576).
+2. **Sub-capability** → `libs/core/src/<ctx>/domain/ports/capabilities/<name>.capability.ts`: the interface **plus** the co-located `is{Capability}` guard. Export both from the context barrel.
+3. **Update this file** in the same PR — add the row(s) above. The counts in each section heading are part of the contract; bump them.

--- a/docs/integrations/dpd-polska/setup-guide.md
+++ b/docs/integrations/dpd-polska/setup-guide.md
@@ -1,0 +1,60 @@
+# DPD Polska Integration — Setup Guide
+
+Step-by-step: from a DPD Polska account to a working OpenLinker shipping
+connection that generates labels + handover protocols over the REST
+`DPDServices` API and fetches tracking over the SOAP `DPDInfoServices` API.
+
+**Adapter:** `dpd.polska.rest.v1` · **Capability:** `ShippingProviderManager`
+
+## Prerequisites
+
+- A DPD Polska account with API access.
+- A **master FID** (`masterFid`, numeric) — your DPD customer/federation id.
+- API **login + password** for the DPD services.
+- OpenLinker API + worker running.
+- A sender address (returned on labels) in Polish format.
+
+> **Transport split:** labels + handover protocols use the REST `DPDServices`
+> API; tracking uses the separate SOAP `DPDInfoServices` host. The adapter is
+> dual-transport — both must be reachable.
+
+## 1. Obtain your DPD credentials
+
+1. Request API access from DPD Polska (gated; the REST `DPDServices` Swagger and
+   the SOAP `DPDInfoServices` WSDL are issued with your account).
+2. Note your **master FID** (`masterFid`) — numeric string.
+3. Note your service **login** and **password** (the credentials half of the
+   connection, stored encrypted).
+4. Confirm which **environment** you've been issued — sandbox/demo or production.
+
+## 2. Create a DPD connection in OpenLinker
+
+1. Open OL Admin → Integrations → Connections → **New Connection**.
+2. Platform: **DPD**.
+3. Fill the **sender address**:
+   - `address`, `city`
+   - `postalCode` — PL format `NN-NNN`
+   - `countryCode` — ISO 3166-1 alpha-2 (e.g. `PL`)
+   - `company` / `name` / `phone` / `email` (optional)
+4. **Master FID**: your numeric `masterFid`.
+5. **Environment**: sandbox or production (must match the issued credentials).
+6. **Login / password**: the DPD service credentials from Step 1.
+7. Click **Test Connection**, then **Save**.
+
+## 3. Capability
+
+| Capability | What it does |
+|---|---|
+| `ShippingProviderManager` | Generate package numbers + labels and handover protocols over REST `DPDServices`; fetch tracking events over SOAP `DPDInfoServices`. |
+
+## 4. Troubleshooting
+
+- **`masterFid must be a numeric string`** — strip any non-digit characters from the FID.
+- **`postalCode must match the PL format NN-NNN`** — sender postcode must be `NN-NNN`.
+- **Auth / `needs_reauth`** — login, password, or environment mismatch; the DPD auth-failure classifier flags the connection for re-auth. Re-check credentials against the issued environment.
+- **Labels generate but tracking is empty** — tracking is a *separate* SOAP host (`DPDInfoServices`); verify it's reachable independently of the REST endpoint.
+
+## Related
+
+- Reference plan / epic: [#961](https://github.com/openlinker-project/openlinker/issues/961) (children #962–#966)
+- Capability port: `ShippingProviderManagerPort` (see [`docs/architecture-overview.md`](../../architecture-overview.md))

--- a/docs/integrations/inpost/setup-guide.md
+++ b/docs/integrations/inpost/setup-guide.md
@@ -1,0 +1,60 @@
+# InPost (ShipX) Integration — Setup Guide
+
+Step-by-step: from an InPost ShipX account to a working OpenLinker shipping
+connection that generates labels (paczkomat + kurier), fetches tracking, and
+ingests shipment-status webhooks.
+
+**Adapter:** `inpost.shipx.v1` · **Capability:** `ShippingProviderManager`
+
+## Prerequisites
+
+- An InPost **ShipX** account with an organization (`organizationId`) provisioned by InPost.
+- A long-lived **ShipX Bearer API token** generated in the InPost manager portal.
+- OpenLinker API + worker running.
+- A sender address (returned on labels) in Polish format.
+
+## 1. Obtain your ShipX credentials
+
+1. Log in to the InPost ShipX manager portal.
+2. Note your **organization id** (`organizationId`) — the numeric id of your ShipX organization.
+3. Generate a **Bearer API token** (long-lived, portal-generated). Copy it — it's the secret half of the connection (`apiToken`).
+
+> Sandbox vs production are distinct ShipX environments with separate base URLs and tokens. Use a sandbox token while validating, then swap to production.
+
+## 2. Create an InPost connection in OpenLinker
+
+1. Open OL Admin → Integrations → Connections → **New Connection**.
+2. Platform: **InPost**.
+3. Fill the **sender address** (used as the label's sender):
+   - `street`, `buildingNumber`, `city`
+   - `postCode` — PL format `NN-NNN`
+   - `countryCode` — ISO 3166-1 alpha-2 (e.g. `PL`)
+   - `name` (optional), `email`, `phone`
+4. **Organization id**: your ShipX `organizationId`.
+5. **API token**: paste the ShipX Bearer token from Step 1 (stored encrypted).
+6. Click **Test Connection** — exercises a ShipX call and expects a success result.
+7. Click **Save**.
+
+## 3. Capability
+
+| Capability | What it does |
+|---|---|
+| `ShippingProviderManager` | Generate labels (paczkomat + kurier) + handover protocols, fetch tracking snapshots, and receive ShipX shipment-status webhooks. |
+
+## 4. Webhooks (optional but recommended)
+
+InPost ShipX can push shipment-status events to OpenLinker so terminal states
+(`delivered`, etc.) propagate without polling. Configure the webhook target in
+the ShipX portal to point at your OL webhook endpoint for this connection.
+Without webhooks, OL falls back to polling tracking at a conservative cadence.
+
+## 5. Troubleshooting
+
+- **Test Connection fails with 401** — the `apiToken` is wrong, expired, or from the other environment (sandbox token against production URL or vice-versa).
+- **`postCode must match the PL format NN-NNN`** — the sender postcode must be `NN-NNN` (e.g. `01-234`).
+- **Labels missing the sender** — re-check the sender address block on the connection config.
+
+## Related
+
+- Reference plan: [#727](https://github.com/openlinker-project/openlinker/issues/727)
+- Capability port: `ShippingProviderManagerPort` (see [`docs/architecture-overview.md`](../../architecture-overview.md))

--- a/docs/plans/implementation-plan-1253-showcase-all-integrations.md
+++ b/docs/plans/implementation-plan-1253-showcase-all-integrations.md
@@ -1,0 +1,51 @@
+# Implementation Plan — #1253 Showcase all shipped integrations in docs
+
+## 1. Goal & classification
+
+Docs-only. Make the public-facing docs reflect the **9 shipped, registered** integration packages instead of reading as an Allegro+PrestaShop hub. No code, no tests, no migration.
+
+**Layer:** DX (documentation). **Non-goals:** the marketing site (`openlinker.io`); any code/manifest change; writing exhaustive setup guides (InPost/DPD guides mirror the lean existing ones).
+
+## 2. Ground truth (verified against manifests on `origin/main`)
+
+| Package | `supportedCapabilities` (manifest) | FE plugin | Maturity signal (latest merged) |
+|---|---|---|---|
+| prestashop | ProductMaster, InventoryMaster, OrderSource, OrderProcessorManager | ✅ | reference adapter |
+| woocommerce | ProductMaster, InventoryMaster, OrderSource, OrderProcessorManager | ✅ | shop-publish + bulk + FE (#1083) |
+| allegro | OrderSource, OfferManager, **ShippingProviderManager** | ✅ | mature |
+| erli | OfferManager, OrderSource | ✅ | borrowed-taxonomy mapping (#1250); 18 commits |
+| inpost | **ShippingProviderManager** | ✅ | connection settings + ShipX test (#1252/#771) |
+| dpd-polska | **ShippingProviderManager** | ✅ | needs_reauth + validationInfo + retry int-spec (#1106) |
+| ksef | **Invoicing** | ✅ | connection settings + KSeF-no/UPO (#1152); epic #1142 |
+| subiekt | **Invoicing** | ✅ | FE detail/correction/HTTP (#1249) |
+| ai | (content router) | n/a | Live |
+
+`ShippingProviderManager` and `Invoicing` are **real registered capabilities** — the new Capabilities-table rows and the "What we cover" updates are grounded, not aspirational.
+
+## 3. Files to change
+
+1. **`README.md` — Integrations table** (~L40–53): add **Erli** (marketplace) and **KSeF** (invoicing) rows linking their existing `docs/integrations/*/setup-guide.md`; re-status **DPD** off "Planned"; set **InPost / Subiekt** to confirmed status. Drop the now-stale "pending `ShippingProviderPort`" qualifier (the port exists).
+2. **`README.md` — Capabilities table** (~L63–69): add a **Shipping** row (Allegro · InPost · DPD → `ShippingProviderManagerPort`) and an **Invoicing** row (KSeF · Subiekt → `InvoicingPort`); add **WooCommerce** to Catalog & inventory and Orders rows.
+3. **`README.md` — "What we cover" table** (~L113–160): flip the now-false lines — "Generate invoices … — Out of scope" → ✅ `InvoicingPort` (KSeF/Subiekt); "Generate shipping labels 🛣️ planned" → ✅ `ShippingProviderManagerPort`; "Push tracking back 🛣️" → ✅ (order-status writeback #1157 + shipment status).
+4. **`docs/integrations/inpost/setup-guide.md`** (new) — mirror the woocommerce guide skeleton (Prerequisites · credentials · create connection · capabilities · troubleshooting).
+5. **`docs/integrations/dpd-polska/setup-guide.md`** (new) — same skeleton; carries the REST-creds caveat.
+6. **`docs/architecture-overview.md:504`** — adjust the `OfferManagerPort` "Future Implementations" line so Erli's registered skeleton isn't listed as purely future.
+
+## 4. Capability → integration mapping (for the Capabilities table)
+
+- Catalog & inventory → PrestaShop · WooCommerce
+- Orders → PrestaShop (src+dest) · WooCommerce (src+dest) · Allegro (source) · Erli (source)
+- Offers / listings → Allegro · Erli
+- Shipping → Allegro · InPost · DPD *(new row)*
+- Invoicing → KSeF · Subiekt *(new row)*
+- Content suggestion → AI
+- Auth & ops → all
+
+## 5. Open decision (maintainer call — see issue Assumptions)
+
+Status labels for InPost / DPD / KSeF are a judgment call; recommendation in the work-session pause. Everything else is mechanical.
+
+## 6. Validation
+
+- No code touched → `check:invariants` / type-check / tests unaffected (markdown isn't linted).
+- AC verification: re-grep README for all 8 platform names; confirm both new guides exist; confirm no "Planned" label on a registered package.


### PR DESCRIPTION
## What & why

The public docs read as an Allegro+PrestaShop hub while **9 integration packages** ship and register in both `apps/api` and `apps/worker`. This brings the docs in line with reality and adds the missing capability reference.

Statuses were confirmed with the maintainer (registration ≠ "Live"): **InPost, DPD, Erli, Subiekt, WooCommerce → Live; KSeF → In progress.**

## Changes (docs-only)

**`README.md`**
- **Integrations table** — all 9 shipped integrations surfaced (adds **Erli** + **KSeF**, which were entirely absent; re-statuses InPost/DPD/Subiekt to ✅ Live; drops the stale "pending `ShippingProviderPort`" qualifier on DPD).
- **Capabilities table** — adds **Shipping** (`ShippingProviderManagerPort`) and **Invoicing** (`InvoicingPort`) rows; folds WooCommerce + Erli into the existing rows.
- **"What we cover" scorecard** — flips now-shipped flows (invoicing, label generation, tracking writeback) off planned/out-of-scope; splits bulk offer-creation (shipped) from bulk quantity batch-update (unimplemented); corrects the refunds line off the phantom `OrderProcessorManagerPort.processReturn` (deferred #1032, consistent with #1140).

**`docs/capabilities.md` (new)** — the code-synced **vocabulary**: 9 capability ports + all **31 sub-capabilities**, each with a description, method(s), and `is*` guard. Notes the open-world capability design (#576). Per-integration coverage stays with each adapter's `supportedCapabilities` manifest + the root README (per-package READMEs tracked in **#1254**). Caught & fixed a grouping bug: `CategoryProvisioner` is a `ShopProductManagerPort` sub-capability, not `OfferManager`.

**`docs/architecture-overview.md`** — moves `ErliOfferManagerAdapter` from Future → Current Implementations; points the partial inline sub-capability table at the full `capabilities.md`.

**`docs/integrations/{inpost,dpd-polska}/setup-guide.md` (new)** — built from the real connection-config + credentials DTOs (`inpost.shipx.v1`, `dpd.polska.rest.v1`).

## Verification

- All 9 packages appear in the README Integrations table; no registered package mislabeled "Planned"; all 6 guide links resolve.
- `capabilities.md` sub-capability counts (18+1+5+4+3) = **31**, matching the 31 `*.capability.ts` files in core; all 31 guards present.
- Docs-only — pre-commit full `tsc` + lint passed; smart-test scoped it as touching no workspace package.

## Follow-up

- **#1254** — per-integration package READMEs (8 missing, incl. Allegro) + README "Implementations" blurbs for the 6 shipped integrations without one.

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)