### PR TITLE
fix(sync): use timestamptz for nextRunAt/lockedAt — prevent 2h job skip on UTC+2

### DIFF
--- a/apps/api/src/migrations/1817000000000-fix-sync-jobs-timestamp-tz.ts
+++ b/apps/api/src/migrations/1817000000000-fix-sync-jobs-timestamp-tz.ts
@@ -1,0 +1,34 @@
+/**
+ * Fix sync_jobs timestamp columns to include timezone (#1121).
+ *
+ * `nextRunAt` and `lockedAt` were declared as `timestamp without time zone`.
+ * TypeORM serialises JS `Date` objects to TIMESTAMP columns using local-wall-
+ * clock strings (`getFullYear`/`getMonth`/…), not UTC ISO strings — so on a
+ * UTC+2 host every newly-created job gets `nextRunAt = wallclock + 2h` stored,
+ * and the worker's `WHERE "nextRunAt" <= NOW()` (UTC) skips the row for two
+ * hours after creation.
+ *
+ * The fix: `USING … AT TIME ZONE 'UTC'` casts the stored "naïve" timestamps
+ * back to absolute UTC timestamptz — i.e. each stored value is reinterpreted
+ * AS IF it was in UTC (which it actually is — TypeORM was writing UTC-epoch
+ * values through local-time formatting, so the numbers are already in UTC).
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixSyncJobsTimestampTz1817000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "sync_jobs"
+        ALTER COLUMN "nextRunAt" TYPE timestamptz USING "nextRunAt" AT TIME ZONE 'UTC',
+        ALTER COLUMN "lockedAt"  TYPE timestamptz USING "lockedAt"  AT TIME ZONE 'UTC'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "sync_jobs"
+        ALTER COLUMN "nextRunAt" TYPE timestamp WITHOUT TIME ZONE USING "nextRunAt" AT TIME ZONE 'UTC',
+        ALTER COLUMN "lockedAt"  TYPE timestamp WITHOUT TIME ZONE USING "lockedAt"  AT TIME ZONE 'UTC'
+    `);
+  }
+}

--- a/apps/api/src/migrations/1818000000000-fix-sync-jobs-timestamp-tz.ts
+++ b/apps/api/src/migrations/1818000000000-fix-sync-jobs-timestamp-tz.ts
@@ -1,17 +1,25 @@
 /**
- * Fix sync_jobs timestamp columns to include timezone (#1121).
+ * Fix sync_jobs timestamp columns to include timezone.
  *
- * `nextRunAt` and `lockedAt` were declared as `timestamp without time zone`.
- * TypeORM serialises JS `Date` objects to TIMESTAMP columns using local-wall-
- * clock strings (`getFullYear`/`getMonth`/…), not UTC ISO strings — so on a
- * UTC+2 host every newly-created job gets `nextRunAt = wallclock + 2h` stored,
- * and the worker's `WHERE "nextRunAt" <= NOW()` (UTC) skips the row for two
- * hours after creation.
+ * `nextRunAt`, `lockedAt`, `createdAt`, and `updatedAt` were declared as
+ * `timestamp without time zone`. A tz-naive column compared against a
+ * timezone-aware JS `Date` parameter (see `sync-job.repository.ts`'s
+ * `"nextRunAt" <= $2` / `"lockedAt" < :threshold` gating queries) is
+ * host-timezone-dependent: on a non-UTC host the comparison can be off by
+ * the host's UTC offset, so due jobs are skipped for that long.
  *
- * The fix: `USING … AT TIME ZONE 'UTC'` casts the stored "naïve" timestamps
- * back to absolute UTC timestamptz — i.e. each stored value is reinterpreted
- * AS IF it was in UTC (which it actually is — TypeORM was writing UTC-epoch
- * values through local-time formatting, so the numbers are already in UTC).
+ * The fix going forward: `timestamptz` columns make every future write and
+ * comparison an absolute-instant operation, independent of both the
+ * database session timezone and the application host's local timezone.
+ *
+ * This migration is a value-preserving type change for existing rows —
+ * `USING … AT TIME ZONE 'UTC'` relabels each already-stored naive value as
+ * UTC without altering its digits. It does not retroactively correct any
+ * rows that were skewed by the pre-fix bug; if this deployment's host ran
+ * in a non-UTC timezone, audit in-flight `queued` rows and consider
+ * reinterpreting the backlog `AT TIME ZONE '<host-zone>'` instead. Because
+ * skewed rows only ever had a `nextRunAt` in the past relative to "now",
+ * they self-heal within one host-offset window after this migration runs.
  */
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
@@ -20,7 +28,9 @@ export class FixSyncJobsTimestampTz1818000000000 implements MigrationInterface {
     await queryRunner.query(`
       ALTER TABLE "sync_jobs"
         ALTER COLUMN "nextRunAt" TYPE timestamptz USING "nextRunAt" AT TIME ZONE 'UTC',
-        ALTER COLUMN "lockedAt"  TYPE timestamptz USING "lockedAt"  AT TIME ZONE 'UTC'
+        ALTER COLUMN "lockedAt"  TYPE timestamptz USING "lockedAt"  AT TIME ZONE 'UTC',
+        ALTER COLUMN "createdAt" TYPE timestamptz USING "createdAt" AT TIME ZONE 'UTC',
+        ALTER COLUMN "updatedAt" TYPE timestamptz USING "updatedAt" AT TIME ZONE 'UTC'
     `);
   }
 
@@ -28,7 +38,9 @@ export class FixSyncJobsTimestampTz1818000000000 implements MigrationInterface {
     await queryRunner.query(`
       ALTER TABLE "sync_jobs"
         ALTER COLUMN "nextRunAt" TYPE timestamp WITHOUT TIME ZONE USING "nextRunAt" AT TIME ZONE 'UTC',
-        ALTER COLUMN "lockedAt"  TYPE timestamp WITHOUT TIME ZONE USING "lockedAt"  AT TIME ZONE 'UTC'
+        ALTER COLUMN "lockedAt"  TYPE timestamp WITHOUT TIME ZONE USING "lockedAt"  AT TIME ZONE 'UTC',
+        ALTER COLUMN "createdAt" TYPE timestamp WITHOUT TIME ZONE USING "createdAt" AT TIME ZONE 'UTC',
+        ALTER COLUMN "updatedAt" TYPE timestamp WITHOUT TIME ZONE USING "updatedAt" AT TIME ZONE 'UTC'
     `);
   }
 }

--- a/apps/api/src/migrations/1818000000000-fix-sync-jobs-timestamp-tz.ts
+++ b/apps/api/src/migrations/1818000000000-fix-sync-jobs-timestamp-tz.ts
@@ -15,7 +15,7 @@
  */
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class FixSyncJobsTimestampTz1817000000000 implements MigrationInterface {
+export class FixSyncJobsTimestampTz1818000000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       ALTER TABLE "sync_jobs"

--- a/apps/worker/test/integration/job-intake-execution.int-spec.ts
+++ b/apps/worker/test/integration/job-intake-execution.int-spec.ts
@@ -14,6 +14,7 @@ import { createTestSyncJob, getSyncJobById } from './helpers/test-sync-job.helpe
 import { SYNC_JOB_REPOSITORY_TOKEN } from '@openlinker/core/sync';
 import { SyncJobRepositoryPort } from '@openlinker/core/sync';
 import { SyncJobRequest } from '@openlinker/core/sync';
+import { SyncJobOrmEntity } from '@openlinker/core/sync/orm-entities';
 import { randomUUID } from 'crypto';
 
 describe('Job Intake → Execution Integration', () => {
@@ -205,6 +206,47 @@ describe('Job Intake → Execution Integration', () => {
       const dbJob2 = await getSyncJobById(harness.getDataSource(), job2.id);
       expect(dbJob1?.status).toBe('running');
       expect(dbJob2?.status).toBe('running');
+    });
+
+    // Regression test for the timestamptz fix: nextRunAt/lockedAt were
+    // `timestamp without time zone`, making the due-job comparison
+    // timezone-dependent and causing due jobs to be skipped on non-UTC
+    // hosts. With `timestamptz` columns the comparison is an absolute
+    // instant regardless of the session's timezone.
+    it('should find due jobs created under a non-UTC Postgres session timezone', async () => {
+      const connection = await createTestConnection(harness.getDataSource(), {
+        platformType: 'prestashop',
+        status: 'active',
+      });
+
+      const dataSource = harness.getDataSource();
+      const queryRunner = dataSource.createQueryRunner();
+      await queryRunner.connect();
+
+      let insertedId: string;
+      try {
+        await queryRunner.query(`SET TIME ZONE 'Europe/Warsaw'`);
+        const repository = queryRunner.manager.getRepository(SyncJobOrmEntity);
+        const saved = await repository.save(
+          repository.create({
+            jobType: 'master.product.syncByExternalId',
+            connectionId: connection.id,
+            payloadJson: { schemaVersion: 1, externalId: '1', objectType: 'Product' },
+            status: 'queued',
+            idempotencyKey: `test-tz-${randomUUID()}`,
+            attempts: 0,
+            maxAttempts: 10,
+            nextRunAt: new Date(),
+          }),
+        );
+        insertedId = saved.id;
+      } finally {
+        await queryRunner.release();
+      }
+
+      const lockedJobs = await jobRepository.findAndLockDueJobs(10, 'tz-regression-worker');
+
+      expect(lockedJobs.some((j) => j.id === insertedId)).toBe(true);
     });
   });
 

--- a/libs/core/src/sync/infrastructure/persistence/entities/sync-job.orm-entity.ts
+++ b/libs/core/src/sync/infrastructure/persistence/entities/sync-job.orm-entity.ts
@@ -63,10 +63,10 @@ export class SyncJobOrmEntity {
   @Column({ type: 'text', nullable: true })
   lastError!: string | null;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ type: 'timestamptz' })
   createdAt!: Date;
 
-  @UpdateDateColumn()
+  @UpdateDateColumn({ type: 'timestamptz' })
   updatedAt!: Date;
 }
 

--- a/libs/core/src/sync/infrastructure/persistence/entities/sync-job.orm-entity.ts
+++ b/libs/core/src/sync/infrastructure/persistence/entities/sync-job.orm-entity.ts
@@ -51,10 +51,10 @@ export class SyncJobOrmEntity {
   @Column({ default: 10 })
   maxAttempts!: number;
 
-  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  @Column({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
   nextRunAt!: Date;
 
-  @Column({ type: 'timestamp', nullable: true })
+  @Column({ type: 'timestamptz', nullable: true })
   lockedAt!: Date | null;
 
   @Column({ type: 'varchar', nullable: true })


### PR DESCRIPTION
## Problem

`nextRunAt` and `lockedAt` on `sync_jobs` were declared as `timestamp` (timezone-naive). The raw SQL comparison `WHERE "nextRunAt" <= $2` (and the TypeORM `"lockedAt" < :threshold` query) interprets a naive column value in the Postgres session's timezone, while the JS `Date` parameter is an absolute instant. On a non-UTC host/session, that mismatch shifts the effective comparison by the session's UTC offset, so on a UTC+2 host the worker was silently skipping eligible jobs for up to ~2 hours past their due time.

## Fix

- Changed `nextRunAt`, `lockedAt`, `createdAt`, and `updatedAt` to `timestamptz` in `sync-job.orm-entity.ts`; `timestamptz` columns are compared as absolute instants, independent of session/host timezone
- Added migration `1818000000000-fix-sync-jobs-timestamp-tz` that converts existing rows with `USING ... AT TIME ZONE 'UTC'`; this is a value-preserving type change, the already-stored digits are relabeled as UTC without altering them. It does not retroactively correct any `nextRunAt` values that were already skewed by the pre-fix comparison bug (those self-heal within one host-offset window since they were only ever in the past relative to "now")
- Added a Testcontainers regression test (`apps/worker/test/integration/job-intake-execution.int-spec.ts`) that creates a sync job under a non-UTC Postgres session timezone and asserts `findAndLockDueJobs` still picks it up immediately

## Test plan

- [ ] Run `pnpm --filter @openlinker/api migration:show` and confirm the migration appears as pending
- [ ] Run migration; no errors
- [ ] On a UTC+2 host: create a sync job, verify it runs on schedule without 2h delay
- [ ] Worker integration test passes

Closes #1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
