### PR TITLE
fix(web): DataTable horizontal scroll when sidebar is visible

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2444,6 +2444,11 @@ textarea {
   box-shadow: var(--shadow-xs);
 }
 
+.data-table__container:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
 /* Virtualized mode: the inner scroller owns both axes. */
 .data-table__container--virtual {
   overflow: visible;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2430,7 +2430,8 @@ textarea {
  * surface look.
  */
 .data-table {
-  width: 100%;
+  width: auto;
+  min-width: 100%;
   border-collapse: collapse;
   font-size: 0.8125rem;
 }

--- a/apps/web/src/shared/ui/data-table.test.tsx
+++ b/apps/web/src/shared/ui/data-table.test.tsx
@@ -444,4 +444,40 @@ describe('DataTable', () => {
 
     expect(container.querySelector('.data-table__virtual-scroller')).toBeNull();
   });
+
+  it('exposes the plain (non-virtualized) container as a keyboard-accessible scrollable region', () => {
+    const { container } = renderWithRouter(
+      <DataTable<TestRow>
+        caption="Invoices"
+        columns={[{ id: 'name', header: 'Name', cell: (row): string => row.name }]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+      />,
+    );
+
+    const dataTableContainer = container.querySelector('.data-table__container');
+    expect(dataTableContainer).toHaveAttribute('tabindex', '0');
+    expect(dataTableContainer).toHaveAttribute('role', 'region');
+    expect(dataTableContainer).toHaveAttribute('aria-label', 'Invoices (scrollable)');
+  });
+
+  it('does not mark the container as a scrollable region when rendering mobile cards', () => {
+    const { restore } = mockMobileViewport();
+    try {
+      const { container } = renderWithRouter(
+        <DataTable<TestRow>
+          cardView={{ title: (row): string => row.name }}
+          columns={[{ id: 'name', header: 'Name', cell: (row): string => row.name }]}
+          rowKey={(row): string => row.id}
+          rows={ROWS}
+        />,
+      );
+
+      const dataTableContainer = container.querySelector('.data-table__container');
+      expect(dataTableContainer).not.toHaveAttribute('tabindex');
+      expect(dataTableContainer).not.toHaveAttribute('role');
+    } finally {
+      restore();
+    }
+  });
 });

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -304,8 +304,21 @@ export function DataTable<Row>({
     return rows;
   }
 
+  const plainScrollable = !renderCards && !virtualizeActive;
+
   return (
-    <div className={containerClasses}>
+    <div
+      className={containerClasses}
+      tabIndex={plainScrollable ? 0 : undefined}
+      role={plainScrollable ? 'region' : undefined}
+      aria-label={
+        plainScrollable
+          ? typeof caption === 'string'
+            ? `${caption} (scrollable)`
+            : 'Scrollable table'
+          : undefined
+      }
+    >
       {!renderCards ? (
         virtualizeActive ? (
           <div

--- a/docs/frontend-ui-style-guide.md
+++ b/docs/frontend-ui-style-guide.md
@@ -648,7 +648,7 @@ Parity matrix — what changes across sizes:
 
 Rules:
 
-- **No horizontal scrolling** at any breakpoint except inside `RawPayloadPanel` and virtualized tables' column-overflow area. `RawPayloadPanel` also scrolls vertically when content exceeds its `max-height` cap (#390).
+- **No horizontal scrolling** at any breakpoint except inside `RawPayloadPanel` and a table's own column-overflow area (`.data-table__container`, `overflow-x: auto` — both the virtualized scroller and the plain container). Dense tables (e.g. an 8-column invoices list) grow to their natural content width and scroll horizontally within that container rather than crushing columns; simple 2–4 column tables stay at `100%` width with no scrollbar since their natural width never exceeds the container. `RawPayloadPanel` also scrolls vertically when content exceeds its `max-height` cap (#390).
 - **Tap targets ≥ 44 px** on mobile for every interactive element (`.btn--sm` grows to 36 px min on touch; icon buttons to 40 px).
 - Text must remain readable at `13 px` body — no shrinking below that on mobile.
 - Status banners stack their action buttons below the body on mobile instead of pushing off-screen.


### PR DESCRIPTION
## Summary

- `.data-table { width: 100% }` forced all columns to compress into the available container width. When the 240 px sidebar is visible (≥1024 px), dense tables (e.g. the 8-column invoices list) had no horizontal scroll — columns were just silently squeezed.
- Changed to `width: auto; min-width: 100%`: table fills the container when columns fit, grows to natural content width when they don't — triggering the existing `overflow-x: auto` on `.data-table__container` to show a horizontal scrollbar.
- Simple tables (2–4 columns) are unaffected: their natural width is always ≤ container, so `min-width: 100%` keeps them filling the full width as before.

## Test plan

- [ ] Open `/invoices` at a 1024–1280 px viewport with the sidebar visible — table should show a horizontal scrollbar instead of crushed columns
- [ ] Open any simple 2–4 column table (e.g. connections list) — should still fill 100% width with no unnecessary scrollbar
- [ ] `data-table.test.tsx` — 18/18 pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)