### PR TITLE
docs(invoicing): Infakt invoicing spike — feasibility artifact + POC plan

### DIFF
--- a/docs/plans/implementation-plan-infakt-feasibility-poc.md
+++ b/docs/plans/implementation-plan-infakt-feasibility-poc.md
@@ -497,17 +497,35 @@ Infakt supports webhooks (push HTTP callbacks) for real-time event delivery. **K
 
 ### Webhook Payload Structure
 
+Confirmed live 2026-06-30 on sandbox (`User-Agent: Infakt-Webhooks/2`, `sentry-environment=sandbox`):
+
 ```json
 {
   "event": {
     "uuid": "3e18cd8c-09a3-b729-958b-f393b459b761",
-    "name": "invoice_processed_in_ksef",
+    "name": "<event_name>",
     "retry_counter": 1,
     "created_at": "2026-06-30T15:42:00Z"
   },
-  "resource": {
-    /* full invoice object — same shape as GET /invoices/{uuid}.json */
-  }
+  "resource": { /* shape depends on event — see below */ }
+}
+```
+
+**`draft_invoice_created` resource** (confirmed): full invoice object, same shape as `GET /invoices/{uuid}.json`.
+
+**`send_to_ksef_success` resource** (confirmed live):
+```json
+{
+  "status": "success",
+  "timestamps": {
+    "request_created_at": "2026-06-30 21:37:16 +0200",
+    "request_finished_at": "2026-06-30 21:38:16 +0200"
+  },
+  "ksef_number": "8201194127-20260630-981CFF400000-90",
+  "invoice_kind": "vat",
+  "invoice_uuid": "02070a43-43b1-4670-b7ec-321436eda8f1",
+  "request_uuid": "de9caa74-1cd8-452d-a04f-613fe23e2aa7",
+  "status_description": null
 }
 ```
 
@@ -529,12 +547,19 @@ function verifyInfaktSignature(rawBody: Buffer, secret: string, header: string):
 
 ### Known Event Types
 
-| Event name | Description |
-|---|---|
-| `invoice_processed_in_ksef` | Invoice clearance status changed in KSeF (pending/success/error) |
-| *(additional events visible only in UI webhook configuration)* | E.g. invoice paid, invoice created — exact names discoverable in Infakt dashboard |
+> ⚠️ Infakt documentation lists `invoice_processed_in_ksef` — **this name is WRONG**. Confirmed live event names from sandbox (2026-06-30):
 
-The `invoice_processed_in_ksef` event is the most relevant for OL: it fires when `ksef_data.status` changes, enabling event-driven `InvoiceRecord` update instead of polling `getClearanceStatus`.
+| Event name | Confirmed | Description |
+|---|---|---|
+| `draft_invoice_created` | ✅ live | Invoice created as draft |
+| `send_to_ksef_success` | ✅ live | KSeF clearance succeeded — `ksef_number` in resource |
+| `send_to_ksef_error` | inferred | KSeF clearance failed |
+| `invoice_created_via_async_api` | UI-listed | Invoice created via async API |
+| `invoice_creation_error_via_async_api` | UI-listed | Async API creation error |
+| `invoice_marked_as_paid` | UI-listed | Invoice marked paid |
+| `invoice_deleted` | UI-listed | Invoice deleted |
+
+**Key finding**: `send_to_ksef_success` carries `ksef_number` directly in the webhook resource — OL does **not** need to call `getClearanceStatus` after receiving this event. The webhook handler can update `InvoiceRecord.clearanceReference = ksef_number` and `regulatoryStatus = 'accepted'` in one step.
 
 ### Integration Architecture for OL
 
@@ -542,17 +567,22 @@ The `invoice_processed_in_ksef` event is the most relevant for OL: it fires when
 Infakt → POST /webhooks/infakt/{connectionId}
   ↓
 WebhookController (OL)
-  - verify X-Infakt-Signature (HMAC-SHA256)
-  - parse event.name + resource.uuid
-  - if invoice_processed_in_ksef: call InfaktInvoicingAdapter.getClearanceStatus(record)
-  - update InvoiceRecord.regulatoryStatus + clearanceReference in OL DB
+  - if verification_code present: echo back → webhook activated
+  - verify X-Infakt-Signature (HMAC-SHA256, reject 401 on failure)
+  - parse event.name
+  - if send_to_ksef_success:
+      extract ksef_number from resource directly (no getClearanceStatus call needed)
+      update InvoiceRecord.regulatoryStatus = 'accepted', clearanceReference = ksef_number
+  - if send_to_ksef_error:
+      update InvoiceRecord.regulatoryStatus = 'rejected'
+  - all other events: ACK 200 and ignore
 ```
 
 **Operator setup required**: After creating the Infakt connection in OL, the operator must manually add the webhook URL in the Infakt dashboard and paste the secret into OL's connection config. There is no way to automate this via API — it's a one-time manual step.
 
 ### Webhook vs Polling Trade-off
 
-| | Polling (`getClearanceStatus` in SyncJob) | Webhook (`invoice_processed_in_ksef`) |
+| | Polling (`getClearanceStatus` in SyncJob) | Webhook (`send_to_ksef_success`) |
 |---|---|---|
 | Latency | 30–60 s (cron interval) | ~0 s (immediate push) |
 | Infra dependency | None | Operator must configure webhook URL in Infakt UI |

--- a/docs/plans/implementation-plan-infakt-feasibility-poc.md
+++ b/docs/plans/implementation-plan-infakt-feasibility-poc.md
@@ -552,7 +552,7 @@ function verifyInfaktSignature(rawBody: Buffer, secret: string, header: string):
 
 | Event name | Confirmed | Description |
 |---|---|---|
-| `draft_invoice_created` | ✅ live | Invoice created as draft |
+| `draft_invoice_created` | ✅ live (×2) | Any document created as draft — `resource.kind` distinguishes `vat` vs `correction` |
 | `send_to_ksef_success` | ✅ live | KSeF clearance succeeded — `ksef_number` in resource |
 | `send_to_ksef_error` | inferred | KSeF clearance failed |
 | `invoice_created_via_async_api` | UI-listed | Invoice created via async API |

--- a/docs/plans/implementation-plan-infakt-feasibility-poc.md
+++ b/docs/plans/implementation-plan-infakt-feasibility-poc.md
@@ -42,7 +42,7 @@
 | **`getSupportedDocumentTypes`** | `invoice`, `corrected` | `invoice`, `receipt`, `credit-note`, `corrected` | `invoice`, `credit-note`, `corrected`, `advance`, `proforma` |
 | **`RegulatoryStatusReader`** | N/A (OL is transmitter) | ✅ reads KSeF status from bridge | ✅ reads `ksef_data.status` from Infakt |
 | **`RegulatoryTransmitter`** | ✅ OL submits FA(3) to KSeF directly | ❌ Subiekt submits | ❌ Infakt submits (trigger via API or auto) |
-| **`CorrectionIssuer`** | ✅ KOR XML | ✅ correcting document via bridge | ✅ `POST /v3/invoices` with `kind=corrective` |
+| **`CorrectionIssuer`** | ✅ KOR XML | ✅ correcting document via bridge | ✅ `POST /v3/corrective_invoices` (before/after pairs) |
 | **`RegulatoryDocumentReader`** | ✅ UPO + FA(3) stored in OL DB | ❌ | ❌ UPO not exposed in API |
 
 ### 2.3 KSeF Integration Model (critical difference)
@@ -443,7 +443,7 @@ Rejected — the POC is explicitly scoped to validate the API surface and capabi
 | getInvoice by UUID | `GET /invoices/{uuid}.json?invoice_type=vat` | ✅ 200, full document | `ksef_data: null` as expected pre-submission |
 | Status change | `PUT /invoices/{uuid}/change_status.json` | ❌ 404 | Action endpoints not available in sandbox |
 | Corrective invoice | `POST /invoices.json` `kind=corrective` | ⚠️ 201 but treated as vat | Sandbox ignores `kind=corrective`, `corrected_invoice_number`, `correction_reason` fields |
-| `/corrective_invoices.json` | `POST /corrective_invoices.json` | ❌ 500 internal | Separate endpoint crashes in sandbox |
+| `/corrective_invoices.json` | `POST /corrective_invoices.json` | ✅ 200, `number: 1/KOR/06/2026` | Works — correct endpoint + payload required; previous 500 was malformed body |
 | KSeF trigger | `POST /invoices/{uuid}/send_to_ksef.json` | ✅ 200, `status: pending`, `request_uuid` returned | Endpoint exists; clearance is async |
 | KSeF poll | `GET /invoices/{uuid}.json` → `ksef_data.status` | ✅ `success`, `ksef_number: 8201194127-20260630-693CFF400000-2D` | ~90 s to clear; invoice flips to `sent` in Infakt |
 | List invoices | `GET /invoices.json?invoice_type=vat` | ✅ 200, all 4 test invoices visible | `invoice_type` filter unreliable in sandbox (returns all kinds) |
@@ -456,7 +456,8 @@ The sandbox has notable gaps compared to the production API (confirmed via MCP s
 | Feature | Sandbox | Production |
 |---|---|---|
 | Invoice status change | ❌ 404 on action endpoints | ✅ `change_status`, `print`, `send_by_email` |
-| Corrective invoice | ⚠️ `kind` field ignored | ✅ Full corrective flow with `corrected_invoice_number` etc. |
+| Corrective invoice via `/invoices.json kind=corrective` | ⚠️ `kind` field ignored | ✅ Full corrective flow |
+| Corrective invoice via `/corrective_invoices.json` | ✅ works (confirmed 2026-06-30) | ✅ same |
 | `invoice_type` filter | ⚠️ Returns all kinds | ✅ Filters correctly |
 | KSeF integration | ✅ active on sandbox; `success` in ~90 s | ✅ same |
 | Bank account in transfer | ⚠️ Must be pre-configured | Same — requires setup in account settings |
@@ -467,7 +468,7 @@ The sandbox has notable gaps compared to the production API (confirmed via MCP s
 2. **`getInvoice`**: `GET /invoices/{uuid}.json?invoice_type=vat` — ✅ endpoint works. **Note**: `InvoicingPort.getInvoice` is a dead contract (§2.6) — core never calls it. The adapter implements it for completeness but it has no operational impact.
 3. **`upsertCustomer`**: `POST /clients.json` — ✅ confirmed. NIP-based dedup must search `GET /clients.json?nip={nip}` first.
 4. **`getClearanceStatus` (RegulatoryStatusReader)**: reads `ksef_data.status` from `getInvoice` response. Mapping: `null → 'not-applicable'`, `pending → 'submitted'`, `sent → 'submitted'`, `success → 'cleared'`, `error → 'rejected'`.
-5. **`issueCorrection` (CorrectionIssuer)**: NOT confirmed in sandbox (sandbox limitation). Production API supports it per schema. Adapter implementation should follow the `corrected_invoice_number + services[].{group, correction}` pattern confirmed from schema.
+5. **`issueCorrection` (CorrectionIssuer)**: ✅ **confirmed in sandbox** (2026-06-30). `POST /corrective_invoices.json` (not `/invoices.json kind=corrective`). Body wrapped in `corrective_invoice` key. Services as before/after pairs with same `group` id and `correction: false/true`. `unit_net_price` in PLN (not grosze). Response synchronous. Created `1/KOR/06/2026`, net -200 PLN, VAT -46 PLN. Previous 500 was a malformed payload.
 6. **KSeF trigger** (`POST /invoices/{uuid}/send_to_ksef.json`): ✅ **confirmed E2E in sandbox**. Returns `request_uuid + status: pending`. Infakt handles actual submission asynchronously. After ~90 s: `ksef_data.status = 'success'`, `ksef_number = '8201194127-20260630-693CFF400000-2D'`, invoice status flips to `sent`. **Full KSeF lifecycle confirmed.**
 7. **Bank accounts**: for `payment_method=transfer`, the account number must already exist in Infakt settings. Adapter should document this as a prerequisite or use `payment_method=cash` as default.
 
@@ -480,7 +481,7 @@ The sandbox has notable gaps compared to the production API (confirmed via MCP s
 - `InvoicingPort.upsertCustomer` → `POST/GET /clients.json` (NIP dedup) ✅
 - `InvoicingPort.getSupportedDocumentTypes` → static: `['invoice', 'corrected', 'prepayment', 'proforma']`
 - `RegulatoryStatusReader.getClearanceStatus` → reads `ksef_data` from getInvoice ✅ (endpoint confirmed)
-- `CorrectionIssuer.issueCorrection` → `POST /invoices.json` with `kind=corrective` ✅ (production only; sandbox ignores this)
+- `CorrectionIssuer.issueCorrection` → `POST /corrective_invoices.json` (before/after service pairs) ✅ (sandbox confirmed 2026-06-30)
 
 **Unsupported (out of scope for this adapter)**:
 - `RegulatoryTransmitter` — Infakt submits to KSeF internally; OL does not build FA(3) XML

--- a/docs/plans/implementation-plan-infakt-feasibility-poc.md
+++ b/docs/plans/implementation-plan-infakt-feasibility-poc.md
@@ -37,7 +37,7 @@
 | Capability | KSeF (direct) | Subiekt (bridge) | **Infakt (SaaS)** |
 |---|---|---|---|
 | **`issueInvoice`** | ✅ FA(3) XML → KSeF | ✅ via bridge → Subiekt ERP | ✅ `POST /v3/invoices` |
-| **`getInvoice`** | ✅ by KSeF number | ❌ always `null` (bridge limitation) | ✅ `GET /v3/invoices/{uuid}` |
+| **`getInvoice`** | ✅ by KSeF number | ❌ always `null` (bridge limitation) | ✅ `GET /v3/invoices/{uuid}` | ⚠️ **port is a dead contract** — core never calls it (see §2.6) |
 | **`upsertCustomer`** | N/A (taxpayer-keyed) | ✅ kontrahent via bridge | ✅ `POST/PUT /v3/clients` |
 | **`getSupportedDocumentTypes`** | `invoice`, `corrected` | `invoice`, `receipt`, `credit-note`, `corrected` | `invoice`, `credit-note`, `corrected`, `advance`, `proforma` |
 | **`RegulatoryStatusReader`** | N/A (OL is transmitter) | ✅ reads KSeF status from bridge | ✅ reads `ksef_data.status` from Infakt |
@@ -63,7 +63,7 @@ KSeF submission flow (when triggered via API):
 ```
 issueInvoice → invoice_uuid
 → [optional, if auto-submit not active] POST /invoices/{uuid}/send_to_ksef
-→ poll ksef_data.status via getInvoice
+→ poll ksef_data.status via getClearanceStatus (reads GET /invoices/{uuid} internally)
 → status = 'success' → ksef_number available
 ```
 
@@ -84,14 +84,23 @@ Infakt exposes (confirmed from `infakt_meta_dictionary("invoice_types")`):
 - Implements `InvoicingPort` + `RegulatoryStatusReader` + `CorrectionIssuer`
 - Does NOT implement `RegulatoryTransmitter` (Infakt submits to KSeF, OL reads back)
 - Does NOT implement `RegulatoryDocumentReader` (no UPO download via API)
-- `getInvoice` WORKS (unlike Subiekt) — OL can read back issued invoices by UUID stored in `InvoiceRecord`
 - No local infrastructure required (pure cloud SaaS) — simplest deployment model of the three providers
 
-**Advantages over KSeF-direct**: no FA(3) XML generation, no AES session management, no async polling of KSeF directly, multi-currency support, proforma/OSS coverage, customer management.
+**Advantages over KSeF-direct**: no FA(3) XML generation, no AES session management, multi-currency support, proforma/OSS coverage, customer management.
 
-**Advantages over Subiekt**: no local .exe dependency, `getInvoice` works, cloud-native deployment.
+**Advantages over Subiekt**: no local .exe dependency, cloud-native deployment.
 
 **Limitations**: no UPO download, no paragon (receipt) support, KSeF integration must be activated on the Infakt account, Polish B2B only.
+
+### 2.6 `InvoicingPort.getInvoice` — dead contract (irrelevant for all providers)
+
+`InvoicingPort.getInvoice` is declared on the port but **never called by core `InvoiceService`**. Verified by grepping all call-sites:
+
+- `IInvoiceService.getInvoice` (HTTP layer method) reads **only from OL's own `invoice_records` table** via `this.repo.findByOrderId(...)` — comment in code states explicitly: *"Projection read of OL's OWN store — NEVER the provider/adapter."*
+- `invoicing.types.ts` documents: *"IInvoiceService.getInvoice answers from OL's store, never the adapter."*
+- Core calls the adapter only through: `issueInvoice`, `upsertCustomer`, `getSupportedDocumentTypes`, `getClearanceStatus`, `issueCorrection`.
+
+**Consequence**: The Subiekt `getInvoice → null` limitation is **practically irrelevant** — OL holds its own `InvoiceRecord` projection from the moment of issuance and never needs to re-fetch from the provider. The ❌ in the Subiekt column has no operational impact. Similarly, the ✅ for Infakt's `GET /invoices/{uuid}` is cosmetic — useful for debugging/POC but not load-bearing for the integration.
 
 ---
 
@@ -455,7 +464,7 @@ The sandbox has notable gaps compared to the production API (confirmed via MCP s
 ### Key Findings for Adapter Implementation
 
 1. **`issueInvoice`**: `POST /invoices.json` with `payment_method`, `client_id`, `services[]` — confirmed working. Invoice creates as `draft` — status lifecycle is managed by Infakt UI, not OL. OL stores the UUID in `InvoiceRecord.providerInvoiceId`.
-2. **`getInvoice`**: `GET /invoices/{uuid}.json?invoice_type=vat` — ✅ confirmed working by UUID. The `invoice_type` param is required in production; adapter must store the kind alongside UUID.
+2. **`getInvoice`**: `GET /invoices/{uuid}.json?invoice_type=vat` — ✅ endpoint works. **Note**: `InvoicingPort.getInvoice` is a dead contract (§2.6) — core never calls it. The adapter implements it for completeness but it has no operational impact.
 3. **`upsertCustomer`**: `POST /clients.json` — ✅ confirmed. NIP-based dedup must search `GET /clients.json?nip={nip}` first.
 4. **`getClearanceStatus` (RegulatoryStatusReader)**: reads `ksef_data.status` from `getInvoice` response. Mapping: `null → 'not-applicable'`, `pending → 'submitted'`, `sent → 'submitted'`, `success → 'cleared'`, `error → 'rejected'`.
 5. **`issueCorrection` (CorrectionIssuer)**: NOT confirmed in sandbox (sandbox limitation). Production API supports it per schema. Adapter implementation should follow the `corrected_invoice_number + services[].{group, correction}` pattern confirmed from schema.
@@ -467,7 +476,7 @@ The sandbox has notable gaps compared to the production API (confirmed via MCP s
 **✅ CONFIRMED FEASIBLE** with the following adapter profile:
 
 - `InvoicingPort.issueInvoice` → `POST /invoices.json` ✅
-- `InvoicingPort.getInvoice` → `GET /invoices/{uuid}.json?invoice_type={kind}` ✅
+- `InvoicingPort.getInvoice` → `GET /invoices/{uuid}.json?invoice_type={kind}` ✅ (dead contract — see §2.6; implemented for completeness)
 - `InvoicingPort.upsertCustomer` → `POST/GET /clients.json` (NIP dedup) ✅
 - `InvoicingPort.getSupportedDocumentTypes` → static: `['invoice', 'corrected', 'prepayment', 'proforma']`
 - `RegulatoryStatusReader.getClearanceStatus` → reads `ksef_data` from getInvoice ✅ (endpoint confirmed)
@@ -480,7 +489,81 @@ The sandbox has notable gaps compared to the production API (confirmed via MCP s
 
 ---
 
-## 11. Alignment Checklist
+## 11. Webhooks — Infakt Push Notifications
+
+### Mechanism
+
+Infakt supports webhooks (push HTTP callbacks) for real-time event delivery. **Key constraint: webhook subscriptions are configured exclusively via the Infakt web dashboard** (Ustawienia → Webhooki → "Dodaj webhook") — there is no REST API endpoint for programmatic webhook management. `GET/POST /api/v3/webhooks.json` → 404 on both production and sandbox; the MCP catalog exposes no webhook tool.
+
+### Webhook Payload Structure
+
+```json
+{
+  "event": {
+    "uuid": "3e18cd8c-09a3-b729-958b-f393b459b761",
+    "name": "invoice_processed_in_ksef",
+    "retry_counter": 1,
+    "created_at": "2026-06-30T15:42:00Z"
+  },
+  "resource": {
+    /* full invoice object — same shape as GET /invoices/{uuid}.json */
+  }
+}
+```
+
+### Security — Signature Verification
+
+Infakt sends the `X-Infakt-Signature` header on every webhook delivery:
+- **Algorithm**: HMAC-SHA256 of the raw request body
+- **Secret**: auto-generated per webhook subscription, visible in webhook details in the UI
+- **Expected response on bad signature**: HTTP 401
+
+```typescript
+import { createHmac, timingSafeEqual } from 'crypto';
+
+function verifyInfaktSignature(rawBody: Buffer, secret: string, header: string): boolean {
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(header));
+}
+```
+
+### Known Event Types
+
+| Event name | Description |
+|---|---|
+| `invoice_processed_in_ksef` | Invoice clearance status changed in KSeF (pending/success/error) |
+| *(additional events visible only in UI webhook configuration)* | E.g. invoice paid, invoice created — exact names discoverable in Infakt dashboard |
+
+The `invoice_processed_in_ksef` event is the most relevant for OL: it fires when `ksef_data.status` changes, enabling event-driven `InvoiceRecord` update instead of polling `getClearanceStatus`.
+
+### Integration Architecture for OL
+
+```
+Infakt → POST /webhooks/infakt/{connectionId}
+  ↓
+WebhookController (OL)
+  - verify X-Infakt-Signature (HMAC-SHA256)
+  - parse event.name + resource.uuid
+  - if invoice_processed_in_ksef: call InfaktInvoicingAdapter.getClearanceStatus(record)
+  - update InvoiceRecord.regulatoryStatus + clearanceReference in OL DB
+```
+
+**Operator setup required**: After creating the Infakt connection in OL, the operator must manually add the webhook URL in the Infakt dashboard and paste the secret into OL's connection config. There is no way to automate this via API — it's a one-time manual step.
+
+### Webhook vs Polling Trade-off
+
+| | Polling (`getClearanceStatus` in SyncJob) | Webhook (`invoice_processed_in_ksef`) |
+|---|---|---|
+| Latency | 30–60 s (cron interval) | ~0 s (immediate push) |
+| Infra dependency | None | Operator must configure webhook URL in Infakt UI |
+| Reliability | Always works | Requires internet-reachable OL endpoint |
+| MVP recommendation | ✅ Start here | Deferred to production hardening |
+
+**MVP decision**: polling is sufficient and requires zero operator setup. Webhooks are an optimization for production deployments where KSeF clearance latency matters.
+
+---
+
+## 12. Alignment Checklist
 
 - [x] Follows hexagonal architecture — integration layer only, ports consumed from core barrel
 - [x] Respects CORE vs Integration boundaries — zero core changes

--- a/docs/plans/implementation-plan-infakt-feasibility-poc.md
+++ b/docs/plans/implementation-plan-infakt-feasibility-poc.md
@@ -1,7 +1,7 @@
 # Implementation Plan: Infakt Invoicing — Feasibility Artifact + POC
 
 **Date**: 2026-06-30
-**Status**: Draft
+**Status**: Sandbox POC completed — see §10 Live Sandbox Results
 **Estimated Effort**: 2–3 days (adapter skeleton + sandbox verification)
 
 ---
@@ -375,7 +375,7 @@ Rejected — the POC is explicitly scoped to validate the API surface and capabi
 | Risk | Likelihood | Mitigation |
 |---|---|---|
 | Sandbox URL differs from assumed (`sandbox.infakt.pl`) | Medium | Verify in Phase 2 step 1 health check; configurable via `baseUrl` |
-| KSeF not active on sandbox account | High | POC script gates KSeF steps behind `INFAKT_KSEF_ACTIVE=true` env var |
+| KSeF integration in sandbox | Resolved | Sandbox has KSeF active; full `pending → success` flow confirmed live |
 | 422 error body shape differs from assumption | Low | Capture raw body in `InfaktApiException`; refine `failureCode` mapping |
 | Infakt rate limits during POC | Low | POC script is sequential, ~6 API calls total |
 | `POST /clients` NIP search pagination edge case | Low | Unit tested; not critical for POC |
@@ -420,7 +420,67 @@ Rejected — the POC is explicitly scoped to validate the API surface and capabi
 
 ---
 
-## 10. Alignment Checklist
+## 10. Live Sandbox Results (2026-06-30)
+
+**Sandbox URL confirmed**: `https://api.sandbox-infakt.pl/api/v3/`  
+**Auth**: `X-inFakt-ApiKey` header — ✅ works as documented  
+**Account**: sandbox@openlinker.io (test account, no KSeF integration active)
+
+| Step | Endpoint | Result | Notes |
+|---|---|---|---|
+| Auth check | `GET /invoices.json?invoice_type=vat` | ✅ 200, empty list | Key works |
+| Create client | `POST /clients.json` | ✅ 201, `id: 149358`, `uuid: 3e4173dc` | `company_name`, `nip`, `city` stored correctly |
+| Create invoice | `POST /invoices.json` `kind=vat`, `payment_method=cash` | ✅ 201, `uuid: 6e8db776`, `number: 1/06/2026` | Always creates as `draft` in sandbox |
+| getInvoice by UUID | `GET /invoices/{uuid}.json?invoice_type=vat` | ✅ 200, full document | `ksef_data: null` as expected pre-submission |
+| Status change | `PUT /invoices/{uuid}/change_status.json` | ❌ 404 | Action endpoints not available in sandbox |
+| Corrective invoice | `POST /invoices.json` `kind=corrective` | ⚠️ 201 but treated as vat | Sandbox ignores `kind=corrective`, `corrected_invoice_number`, `correction_reason` fields |
+| `/corrective_invoices.json` | `POST /corrective_invoices.json` | ❌ 500 internal | Separate endpoint crashes in sandbox |
+| KSeF trigger | `POST /invoices/{uuid}/send_to_ksef.json` | ✅ 200, `status: pending`, `request_uuid` returned | Endpoint exists; clearance is async |
+| KSeF poll | `GET /invoices/{uuid}.json` → `ksef_data.status` | ✅ `success`, `ksef_number: 8201194127-20260630-693CFF400000-2D` | ~90 s to clear; invoice flips to `sent` in Infakt |
+| List invoices | `GET /invoices.json?invoice_type=vat` | ✅ 200, all 4 test invoices visible | `invoice_type` filter unreliable in sandbox (returns all kinds) |
+| Bank account | `GET /bank_accounts.json` | ✅ 200, empty | Must be configured in account settings before `payment_method=transfer` |
+
+### Sandbox Limitations vs Production
+
+The sandbox has notable gaps compared to the production API (confirmed via MCP schema inspection):
+
+| Feature | Sandbox | Production |
+|---|---|---|
+| Invoice status change | ❌ 404 on action endpoints | ✅ `change_status`, `print`, `send_by_email` |
+| Corrective invoice | ⚠️ `kind` field ignored | ✅ Full corrective flow with `corrected_invoice_number` etc. |
+| `invoice_type` filter | ⚠️ Returns all kinds | ✅ Filters correctly |
+| KSeF integration | ✅ active on sandbox; `success` in ~90 s | ✅ same |
+| Bank account in transfer | ⚠️ Must be pre-configured | Same — requires setup in account settings |
+
+### Key Findings for Adapter Implementation
+
+1. **`issueInvoice`**: `POST /invoices.json` with `payment_method`, `client_id`, `services[]` — confirmed working. Invoice creates as `draft` — status lifecycle is managed by Infakt UI, not OL. OL stores the UUID in `InvoiceRecord.providerInvoiceId`.
+2. **`getInvoice`**: `GET /invoices/{uuid}.json?invoice_type=vat` — ✅ confirmed working by UUID. The `invoice_type` param is required in production; adapter must store the kind alongside UUID.
+3. **`upsertCustomer`**: `POST /clients.json` — ✅ confirmed. NIP-based dedup must search `GET /clients.json?nip={nip}` first.
+4. **`getClearanceStatus` (RegulatoryStatusReader)**: reads `ksef_data.status` from `getInvoice` response. Mapping: `null → 'not-applicable'`, `pending → 'submitted'`, `sent → 'submitted'`, `success → 'cleared'`, `error → 'rejected'`.
+5. **`issueCorrection` (CorrectionIssuer)**: NOT confirmed in sandbox (sandbox limitation). Production API supports it per schema. Adapter implementation should follow the `corrected_invoice_number + services[].{group, correction}` pattern confirmed from schema.
+6. **KSeF trigger** (`POST /invoices/{uuid}/send_to_ksef.json`): ✅ **confirmed E2E in sandbox**. Returns `request_uuid + status: pending`. Infakt handles actual submission asynchronously. After ~90 s: `ksef_data.status = 'success'`, `ksef_number = '8201194127-20260630-693CFF400000-2D'`, invoice status flips to `sent`. **Full KSeF lifecycle confirmed.**
+7. **Bank accounts**: for `payment_method=transfer`, the account number must already exist in Infakt settings. Adapter should document this as a prerequisite or use `payment_method=cash` as default.
+
+### Updated Feasibility Verdict
+
+**✅ CONFIRMED FEASIBLE** with the following adapter profile:
+
+- `InvoicingPort.issueInvoice` → `POST /invoices.json` ✅
+- `InvoicingPort.getInvoice` → `GET /invoices/{uuid}.json?invoice_type={kind}` ✅
+- `InvoicingPort.upsertCustomer` → `POST/GET /clients.json` (NIP dedup) ✅
+- `InvoicingPort.getSupportedDocumentTypes` → static: `['invoice', 'corrected', 'prepayment', 'proforma']`
+- `RegulatoryStatusReader.getClearanceStatus` → reads `ksef_data` from getInvoice ✅ (endpoint confirmed)
+- `CorrectionIssuer.issueCorrection` → `POST /invoices.json` with `kind=corrective` ✅ (production only; sandbox ignores this)
+
+**Unsupported (out of scope for this adapter)**:
+- `RegulatoryTransmitter` — Infakt submits to KSeF internally; OL does not build FA(3) XML
+- `RegulatoryDocumentReader` — UPO not exposed in Infakt API
+- Status finalization via API — Infakt action endpoints (`change_status`, etc.) not available in sandbox. In production they exist, but OL's approach is: issue draft → trigger `send_to_ksef` → wait for `ksef_data.status = 'success'` (which also flips invoice to `sent`). OL stores the UUID in `InvoiceRecord.providerInvoiceId` and reads status via `getClearanceStatus`.
+
+---
+
+## 11. Alignment Checklist
 
 - [x] Follows hexagonal architecture — integration layer only, ports consumed from core barrel
 - [x] Respects CORE vs Integration boundaries — zero core changes

--- a/docs/plans/implementation-plan-infakt-feasibility-poc.md
+++ b/docs/plans/implementation-plan-infakt-feasibility-poc.md
@@ -1,0 +1,446 @@
+# Implementation Plan: Infakt Invoicing — Feasibility Artifact + POC
+
+**Date**: 2026-06-30
+**Status**: Draft
+**Estimated Effort**: 2–3 days (adapter skeleton + sandbox verification)
+
+---
+
+## 1. Task Summary
+
+**Objective**: Determine whether Infakt can be integrated into OpenLinker's country-agnostic invoicing domain as a third `Invoicing`-capable adapter, verify it live against a sandbox, and produce a comparison artifact (Infakt vs KSeF-direct vs Subiekt).
+
+**Context**: OpenLinker's invoicing layer (ADR-026) is intentionally country-agnostic. The `InvoicingPort` base + composable sub-capabilities (`RegulatoryStatusReader`, `RegulatoryTransmitter`, `CorrectionIssuer`, `RegulatoryDocumentReader`) let adapters declare only what their provider can do. Infakt is a Polish SaaS accounting platform with a comprehensive REST API v3, webhook support, and built-in KSeF integration.
+
+**Classification**: Integration — `libs/integrations/infakt/` adapter package, POC-scope only (no migration, no FE).
+
+---
+
+## 2. Feasibility Artifact: Infakt vs KSeF-direct vs Subiekt
+
+> Researched 2026-06-30 via Infakt MCP (meta_schema, meta_catalog, meta_dictionary, ksef_integration_status). API surface confirmed against live production account (read-only calls only).
+
+### 2.1 Provider Model Comparison
+
+| Dimension | KSeF (direct) | Subiekt nexo (bridge) | **Infakt (SaaS)** |
+|---|---|---|---|
+| **Deployment** | Cloud (KSeF gov API) | Local Windows .exe required | Cloud REST API |
+| **Auth** | Public-key session (AES-CBC) | Bridge token (optional, LAN) | API key (`X-inFakt-ApiKey`) |
+| **PL-only** | Yes (KSeF is PL) | Yes | Yes (PL tax accounting) |
+| **OSS/EU VAT** | No | Unclear | ✅ native OSS invoice type |
+| **Receipts/paragon** | No | ✅ | No |
+| **Multi-currency** | No (PLN only) | ✅ | ✅ PLN, EUR, USD |
+| **Proforma** | No | Unclear | ✅ (not a fiscal doc) |
+
+### 2.2 InvoicingPort Capability Matrix
+
+| Capability | KSeF (direct) | Subiekt (bridge) | **Infakt (SaaS)** |
+|---|---|---|---|
+| **`issueInvoice`** | ✅ FA(3) XML → KSeF | ✅ via bridge → Subiekt ERP | ✅ `POST /v3/invoices` |
+| **`getInvoice`** | ✅ by KSeF number | ❌ always `null` (bridge limitation) | ✅ `GET /v3/invoices/{uuid}` |
+| **`upsertCustomer`** | N/A (taxpayer-keyed) | ✅ kontrahent via bridge | ✅ `POST/PUT /v3/clients` |
+| **`getSupportedDocumentTypes`** | `invoice`, `corrected` | `invoice`, `receipt`, `credit-note`, `corrected` | `invoice`, `credit-note`, `corrected`, `advance`, `proforma` |
+| **`RegulatoryStatusReader`** | N/A (OL is transmitter) | ✅ reads KSeF status from bridge | ✅ reads `ksef_data.status` from Infakt |
+| **`RegulatoryTransmitter`** | ✅ OL submits FA(3) to KSeF directly | ❌ Subiekt submits | ❌ Infakt submits (trigger via API or auto) |
+| **`CorrectionIssuer`** | ✅ KOR XML | ✅ correcting document via bridge | ✅ `POST /v3/invoices` with `kind=corrective` |
+| **`RegulatoryDocumentReader`** | ✅ UPO + FA(3) stored in OL DB | ❌ | ❌ UPO not exposed in API |
+
+### 2.3 KSeF Integration Model (critical difference)
+
+```
+KSeF-direct:     OL → FA(3) XML → KSeF API              (OL = transmitter = RegulatoryTransmitter)
+Subiekt:         OL → bridge → Subiekt ERP → KSeF       (OL reads status = RegulatoryStatusReader)
+Infakt:          OL → Infakt API → Infakt → KSeF        (OL reads status = RegulatoryStatusReader)
+                 OR: OL triggers via POST /invoices/{uuid}/send_to_ksef → Infakt submits
+```
+
+Infakt KSeF statuses (from `ksef_data` on every invoice):
+- `sent` → submitted to KSeF processing queue
+- `success` → registered in KSeF, `ksef_number` available
+- `error` → rejected, `status_description` contains reason
+
+KSeF submission flow (when triggered via API):
+```
+issueInvoice → invoice_uuid
+→ [optional, if auto-submit not active] POST /invoices/{uuid}/send_to_ksef
+→ poll ksef_data.status via getInvoice
+→ status = 'success' → ksef_number available
+```
+
+### 2.4 Invoice Types Available
+
+Infakt exposes (confirmed from `infakt_meta_dictionary("invoice_types")`):
+- `vat` → maps to OL `DocumentType='invoice'`
+- `corrective` → maps to OL `DocumentType='corrected'`
+- `advance` → maps to OL `DocumentType='prepayment'`
+- `final` → maps to OL `DocumentType='invoice'` (final settlement)
+- `oss` → maps to OL `DocumentType='invoice'` (EU OSS)
+- `proforma` → maps to OL `DocumentType='proforma'`
+
+### 2.5 Feasibility Verdict
+
+**✅ Infakt CAN be integrated** with the following characteristics:
+
+- Implements `InvoicingPort` + `RegulatoryStatusReader` + `CorrectionIssuer`
+- Does NOT implement `RegulatoryTransmitter` (Infakt submits to KSeF, OL reads back)
+- Does NOT implement `RegulatoryDocumentReader` (no UPO download via API)
+- `getInvoice` WORKS (unlike Subiekt) — OL can read back issued invoices by UUID stored in `InvoiceRecord`
+- No local infrastructure required (pure cloud SaaS) — simplest deployment model of the three providers
+
+**Advantages over KSeF-direct**: no FA(3) XML generation, no AES session management, no async polling of KSeF directly, multi-currency support, proforma/OSS coverage, customer management.
+
+**Advantages over Subiekt**: no local .exe dependency, `getInvoice` works, cloud-native deployment.
+
+**Limitations**: no UPO download, no paragon (receipt) support, KSeF integration must be activated on the Infakt account, Polish B2B only.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: Integration — `libs/integrations/infakt/` (new workspace package `@openlinker/integrations-infakt`)
+
+**Ports involved** (all existing, no new CORE ports needed):
+- `InvoicingPort` (base)
+- `RegulatoryStatusReader` sub-capability
+- `CorrectionIssuer` sub-capability
+
+**Existing Services Reused**:
+- `createNestAdapterModule` from `@openlinker/plugin-sdk` — same wiring as Subiekt (no plugin-private NestJS providers needed)
+- `dispatchCapability` from `@openlinker/plugin-sdk`
+- `Logger` from `@openlinker/shared/logging`
+
+**New Components (POC scope)**:
+- `InfaktInvoicingAdapter` — implements `InvoicingPort + RegulatoryStatusReader + CorrectionIssuer`
+- `InfaktHttpClient` — fetch-based REST client (pattern: `ErliHttpClient`)
+- `InfaktAdapterFactory` — constructs adapter from connection config
+- `infaktAdapterManifest` + `createInfaktPlugin()` — plugin descriptor
+- `poc-sandbox-test.ts` — standalone Node test script
+
+**Core vs Integration Justification**:
+All new code lives in `libs/integrations/infakt/`. Core `InvoicingPort` and sub-capabilities are consumed verbatim — no core changes. This follows the ADR-026 / ADR-003 model exactly.
+
+---
+
+## 4. External System Research (Infakt API v3)
+
+**Confirmed via MCP (2026-06-30):**
+
+| Aspect | Detail |
+|---|---|
+| **Authentication** | `X-inFakt-ApiKey: <key>` header on every request |
+| **Base URL (prod)** | `https://app.infakt.pl/api/v3/` |
+| **Base URL (sandbox)** | `https://sandbox.infakt.pl/api/v3/` |
+| **Rate limits** | Not documented in MCP; assumed standard REST (backoff on 429) |
+| **Invoice create** | `POST /invoices` with `payment_method`, `client_*` fields, `services[]` |
+| **Invoice read** | `GET /invoices/{uuid}?invoice_type=vat` — returns full doc incl. `ksef_data` |
+| **Corrective invoice** | `POST /invoices` with `kind=corrective`, `corrected_invoice_number`, `correction_reason_symbol`, `services[].group + .correction` |
+| **Client upsert** | `POST /clients` / `PUT /clients/{uuid}` — `company_name`, `nip`, address fields |
+| **KSeF trigger** | `POST /invoices/{uuid}/send_to_ksef` — async, poll via `/async_tasks/{ref}` |
+| **Async polling** | `GET /async_tasks/{reference}` → `status` field (201=done, pending otherwise) |
+| **KSeF status** | `GET /invoices/{uuid}` → `ksef_data.status` (`sent` / `success` / `error`) |
+| **Webhooks** | Invoice lifecycle events (not in MCP catalog, available in Infakt REST docs) |
+
+**⚠️ IMPORTANT — Sandbox**: The current MCP connection is to the **production** Infakt account. All live POC testing MUST target `https://sandbox.infakt.pl/api/v3/`. The sandbox requires a separate account registered at `sandbox.infakt.pl`. Sandbox API key is separate from production.
+
+**Connection config shape** (stored in `connection.config`):
+```json
+{
+  "apiKey": "sandbox-api-key-here",
+  "baseUrl": "https://sandbox.infakt.pl/api/v3/"
+}
+```
+The `baseUrl` defaults to production if absent, allowing the same adapter code for both environments.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+1. **Sandbox account setup**: Does the user have a sandbox account at `sandbox.infakt.pl`? The POC test script requires a sandbox API key (not the production one).
+2. **KSeF active on sandbox?**: Is the KSeF integration active on the sandbox account? If not, the KSeF trigger step requires manual activation.
+3. **Webhooks**: Infakt webhook format and authentication method needs verification against REST docs (not visible in MCP catalog).
+4. **UPO download**: Is there a `/invoices/{uuid}/upo` or similar endpoint? Not visible in MCP — needs REST doc check.
+5. **Idempotency**: Does Infakt REST API support idempotency keys (e.g., `Idempotency-Key` header)? If not, the adapter must manage dedup at the OL layer.
+
+### Assumptions
+- **A1**: `invoiceCreate` is idempotent via OL-side exactly-once gate (InvoiceService dedup) — not relying on Infakt-side idempotency.
+- **A2**: `connection.config.apiKey` holds the Infakt API key; `connection.config.baseUrl` is optional (defaults to prod URL).
+- **A3**: The `getInvoice` implementation reads the `providerInvoiceId` stored in `InvoiceRecord` (set by `issueInvoice`) to call `GET /invoices/{uuid}`.
+- **A4**: KSeF auto-submit (when KSeF integration is active on Infakt account) means `issueInvoice` may immediately return `ksef_data.status='sent'`; the adapter returns `regulatoryStatus='submitted'` in `IssueInvoiceResult` and the reconciliation job (`marketplace.invoice.reconcile`) polls `getClearanceStatus` later.
+- **A5**: No migration needed — POC does not persist to DB; `InvoiceRecord` is transient in the POC.
+
+### Documentation Gaps
+- Infakt webhook endpoint format / auth not covered by MCP tools.
+- Infakt rate limits not documented in MCP.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1 — Adapter Skeleton (1 day)
+
+**Goal**: A compilable `libs/integrations/infakt/` package that passes `pnpm type-check` and unit tests.
+
+**Steps**:
+
+1. **Bootstrap package**
+   - File: `libs/integrations/infakt/package.json`
+   - Copy from `libs/integrations/subiekt/package.json`, set `name: "@openlinker/integrations-infakt"`, `version: "0.1.0"`
+   - File: `libs/integrations/infakt/tsconfig.json` — copy from subiekt
+   - Add to `pnpm-workspace.yaml` under `packages`
+   - Acceptance: `pnpm --filter @openlinker/integrations-infakt build` completes
+
+2. **Wire types**
+   - File: `libs/integrations/infakt/src/domain/types/infakt.types.ts`
+   - Wire types for Infakt REST wire format: `InfaktInvoice`, `InfaktInvoiceCreatePayload`, `InfaktCorrectiveInvoicePayload`, `InfaktClient`, `InfaktKsefData`, `InfaktAsyncTaskStatus`
+   - No `any` — use typed interfaces matching confirmed API schema
+   - Acceptance: no TypeScript errors, file exports all types
+
+3. **HTTP client**
+   - File: `libs/integrations/infakt/src/infrastructure/http/infakt-http-client.ts`
+   - Pattern: `ErliHttpClient` — fetch-based, constructor takes `{ apiKey, baseUrl }`
+   - Methods: `get<T>(path, params?)`, `post<T>(path, body)`, `put<T>(path, body)`
+   - `X-inFakt-ApiKey` header injected automatically
+   - Retries on 429 (exponential backoff, max 3)
+   - Acceptance: unit test mocking global `fetch` — all 3 verbs + retry logic covered
+
+4. **InfaktInvoicingAdapter**
+   - File: `libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts`
+   - `class InfaktInvoicingAdapter implements InvoicingPort, RegulatoryStatusReader, CorrectionIssuer`
+   - `getSupportedDocumentTypes()` → `['invoice', 'credit-note', 'corrected', 'prepayment', 'proforma']`
+   - `issueInvoice(cmd)`:
+     - Map neutral `IssueInvoiceCommand` → `InfaktInvoiceCreatePayload`
+     - `POST /invoices` → receive `{ uuid, number, ksef_data }`
+     - Map result → `IssueInvoiceResult { record: InvoiceRecord, providerInvoiceId: uuid }`
+     - Set `regulatoryStatus` based on `ksef_data.status`: `sent` → `'submitted'`, `success` → `'cleared'`, `null` → `'not-applicable'`
+   - `getInvoice(query)`:
+     - Query by `providerInvoiceId` (uuid stored in record): `GET /invoices/{uuid}?invoice_type=vat`
+     - Returns `InvoiceRecord | null`
+   - `upsertCustomer(cmd)`:
+     - Search by NIP: `GET /clients?nip={nip}`, if found → `PUT /clients/{uuid}`, else `POST /clients`
+     - Returns `UpsertCustomerResult { externalCustomerId: uuid }`
+   - `getClearanceStatus(record)` (`RegulatoryStatusReader`):
+     - `GET /invoices/{providerInvoiceId}?invoice_type=vat` → read `ksef_data`
+     - Map to `RegulatoryClearanceResult`
+   - `issueCorrection(cmd)` (`CorrectionIssuer`):
+     - Map `IssueCorrectionCommand` → `InfaktCorrectiveInvoicePayload`
+     - `POST /invoices` with `kind=corrective`, `corrected_invoice_number`, `correction_reason_symbol`
+     - Returns `InvoiceRecord`
+   - Acceptance: unit tests (mocked HTTP client) for all 5 methods, happy path + error paths
+
+5. **Error mapping**
+   - File: `libs/integrations/infakt/src/domain/exceptions/infakt-api.exception.ts`
+   - `InfaktApiException extends Error` with `statusCode`, `body`
+   - Adapter wraps 4xx/5xx HTTP errors; `issueInvoice` on 422 (buyer NIP invalid) → `failureCode: 'buyer-tax-id-invalid'`
+   - Acceptance: unit test verifies 422 → correct `failureCode`
+
+6. **Adapter factory**
+   - File: `libs/integrations/infakt/src/application/infakt-adapter.factory.ts`
+   - Reads `connection.config.apiKey` and optional `connection.config.baseUrl` (defaults to prod)
+   - Builds `InfaktHttpClient` + `InfaktInvoicingAdapter`
+   - Acceptance: unit test with mock connection config
+
+7. **Plugin descriptor**
+   - File: `libs/integrations/infakt/src/infakt-plugin.ts`
+   - Pattern: `createSubiektPlugin()` — same shape
+   - Manifest: `adapterKey: 'infakt.accounting.v1'`, `platformType: 'infakt'`, `supportedCapabilities: ['Invoicing']`, `isDefault: true`
+   - `register(host)`: registers `InfaktConnectionConfigShapeValidatorAdapter` + `InfaktConnectionTesterAdapter`
+   - Acceptance: `subiektAdapterManifest` pattern — static export + `createInfaktPlugin()` returns same reference
+
+8. **Barrel + NestJS module**
+   - File: `libs/integrations/infakt/src/index.ts`
+   - File: `libs/integrations/infakt/src/infakt-integration.module.ts`
+   - Pattern: `createNestAdapterModule(createInfaktPlugin())` — no custom providers
+   - Acceptance: passes `pnpm type-check`
+
+### Phase 2 — Live POC Test Script (0.5 day)
+
+**Goal**: A standalone Node/tsx script that exercises the real Infakt sandbox API end-to-end.
+
+**⚠️ Prereq**: Sandbox account at `sandbox.infakt.pl` with API key. Set `INFAKT_SANDBOX_API_KEY` env var before running.
+
+1. **POC test script**
+   - File: `libs/integrations/infakt/scripts/poc-sandbox-test.ts`
+   - Run with: `tsx libs/integrations/infakt/scripts/poc-sandbox-test.ts`
+   - Steps executed:
+     1. `GET /health` (confirm sandbox reachable)
+     2. `POST /clients` — create test client (company: `OL POC Test Sp. z o.o.`, NIP: `1234563218`)
+     3. `POST /invoices` — create VAT invoice for the client (service: `Usługa testowa`, 100 PLN net, 23% VAT)
+     4. `GET /invoices/{uuid}?invoice_type=vat` — read back, assert fields
+     5. `POST /invoices` with `kind=corrective` — create correction (full cancellation)
+     6. `GET /invoices/{corrective_uuid}?invoice_type=corrective` — read back correction
+     7. [If KSeF active] `POST /invoices/{uuid}/send_to_ksef` — trigger KSeF submission
+     8. [If KSeF active] Poll `GET /invoices/{uuid}` until `ksef_data.status = 'success'` or `'error'` (max 30s)
+   - Output: structured log per step with ✅/❌
+   - Acceptance: all non-KSeF steps ✅ on first run against sandbox
+
+2. **README for sandbox test**
+   - File: `libs/integrations/infakt/scripts/README.md`
+   - Documents: sandbox account setup, env vars, how to run, expected output
+
+### Phase 3 — Connection Validator + Tester (0.5 day)
+
+**Goal**: Config shape validation and connection test so OL can validate an Infakt connection before saving.
+
+1. **Config shape validator**
+   - File: `libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-config-shape-validator.adapter.ts`
+   - Validates `connection.config`: `apiKey` (non-empty string), optional `baseUrl` (valid HTTPS URL)
+   - Acceptance: unit test — missing `apiKey` → validation error
+
+2. **Connection tester**
+   - File: `libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-tester.adapter.ts`
+   - Calls `GET /invoices?invoice_type=vat&limit=1` — returns OK if 200, error if 401/403
+   - Acceptance: unit test with mocked HTTP — 401 → test failure message
+
+### Phase 4 — Unit Tests (covered per step above; consolidated)
+
+- `libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.spec.ts`
+  - `issueInvoice`: happy path, buyer-NIP-invalid 422, HTTP 500
+  - `getInvoice`: found, not found
+  - `upsertCustomer`: create new, update existing by NIP
+  - `getClearanceStatus`: sent, success, error
+  - `issueCorrection`: happy path
+- `libs/integrations/infakt/src/infrastructure/http/infakt-http-client.spec.ts`
+  - Auth header injection, 429 retry, error passthrough
+
+---
+
+## 7. File Structure
+
+```
+libs/integrations/infakt/
+├── package.json                                   # @openlinker/integrations-infakt
+├── tsconfig.json
+├── src/
+│   ├── index.ts                                   # barrel: exports manifest, module, plugin factory
+│   ├── infakt-plugin.ts                           # createInfaktPlugin(), infaktAdapterManifest
+│   ├── infakt-integration.module.ts               # createNestAdapterModule(createInfaktPlugin())
+│   ├── application/
+│   │   └── infakt-adapter.factory.ts
+│   ├── domain/
+│   │   ├── exceptions/
+│   │   │   └── infakt-api.exception.ts
+│   │   └── types/
+│   │       └── infakt.types.ts
+│   └── infrastructure/
+│       ├── adapters/
+│       │   ├── infakt-invoicing.adapter.ts
+│       │   ├── infakt-invoicing.adapter.spec.ts
+│       │   ├── infakt-connection-config-shape-validator.adapter.ts
+│       │   └── infakt-connection-tester.adapter.ts
+│       └── http/
+│           ├── infakt-http-client.ts
+│           └── infakt-http-client.spec.ts
+└── scripts/
+    ├── README.md
+    └── poc-sandbox-test.ts
+```
+
+**No changes to**:
+- `libs/core/` — no new ports, no new types
+- `apps/api/src/plugins.ts` — plugin NOT registered in prod (POC only)
+- `apps/api/src/migrations/` — no schema changes needed for POC
+
+---
+
+## 8. Alternatives Considered
+
+### Alt 1: KSeF-direct re-use (OL submits FA(3) to KSeF, Infakt only stores)
+Not viable — Infakt's API does not expose raw FA(3) XML upload; KSeF submission happens through Infakt's own session management. OL cannot bypass Infakt to talk to KSeF directly when using Infakt as the provider.
+
+### Alt 2: Implement `RegulatoryTransmitter` (OL triggers KSeF via Infakt API)
+Partially viable — OL can call `POST /invoices/{uuid}/send_to_ksef` which triggers Infakt→KSeF submission. However, this is still "Infakt submits, OL triggers" — not direct `RegulatoryTransmitter` semantics. The cleaner model is: OL calls `issueInvoice`, Infakt auto-submits if KSeF integration is active, OL reads back status via `getClearanceStatus`. If we want explicit control we'd add a `RegulatorySubmitter` sub-capability pointing at the trigger endpoint — deferred.
+
+### Alt 3: Full production implementation before POC
+Rejected — the POC is explicitly scoped to validate the API surface and capability mapping. Production implementation follows only after the POC confirms the adapter pattern works.
+
+---
+
+## 9. Validation & Risks
+
+### Architecture Compliance
+- ✅ Integration layer only — `libs/integrations/infakt/`, zero core changes
+- ✅ `InvoicingPort` + sub-capabilities consumed from `@openlinker/core/invoicing`
+- ✅ Plugin descriptor pattern matches `createSubiektPlugin()` / `createAllegroPlugin()`
+- ✅ HTTP client is fetch-based (not Axios) — matches project standard
+- ✅ No `any` types — wire types fully typed in `infakt.types.ts`
+
+### Naming Conventions
+- ✅ `InfaktInvoicingAdapter` → `{Platform}{Capability}Adapter`
+- ✅ `infakt-invoicing.adapter.ts`, `infakt-http-client.ts`, `infakt.types.ts`
+- ✅ `infakt.accounting.v1` adapter key (follows `subiekt.invoicing.v1` pattern)
+
+### Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Sandbox URL differs from assumed (`sandbox.infakt.pl`) | Medium | Verify in Phase 2 step 1 health check; configurable via `baseUrl` |
+| KSeF not active on sandbox account | High | POC script gates KSeF steps behind `INFAKT_KSEF_ACTIVE=true` env var |
+| 422 error body shape differs from assumption | Low | Capture raw body in `InfaktApiException`; refine `failureCode` mapping |
+| Infakt rate limits during POC | Low | POC script is sequential, ~6 API calls total |
+| `POST /clients` NIP search pagination edge case | Low | Unit tested; not critical for POC |
+| `getInvoice` requires `invoice_type` param | Confirmed | Schema shows `?invoice_type=vat` required; adapter stores type in `InvoiceRecord.metadata` |
+
+### Edge Cases
+- **Buyer without NIP** (private person): `upsertCustomer` must handle `client_business_activity_kind: 'private_person'` with no NIP — search by email/name instead
+- **Correction of already-sent-to-KSeF invoice**: corrective invoice automatically linked to original KSeF number via `corrected_invoice_number`
+- **Multi-currency invoice**: `currency` field on create; `getClearanceStatus` returns PLN-equivalent KSeF number regardless
+
+### Backward Compatibility
+- ✅ No breaking changes — new package, not registered in host apps for POC
+
+---
+
+## 10. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `infakt-invoicing.adapter.spec.ts` — mocked `InfaktHttpClient`, all 5 port methods
+- `infakt-http-client.spec.ts` — mocked `fetch`, auth header, retry logic
+- `infakt-connection-config-shape-validator.adapter.spec.ts` — valid/invalid configs
+- Command: `pnpm --filter @openlinker/integrations-infakt test`
+
+### Integration / Sandbox Tests
+- `poc-sandbox-test.ts` — standalone script against `sandbox.infakt.pl`
+- Not a Jest `*.int-spec.ts` — sandbox requires external account, not Testcontainers
+- Run manually: `INFAKT_SANDBOX_API_KEY=xxx tsx libs/integrations/infakt/scripts/poc-sandbox-test.ts`
+
+### Mocking Strategy
+- Unit tests: mock `InfaktHttpClient` at the interface level (constructor param)
+- HTTP client tests: mock `global.fetch`
+- No DB, no NestJS DI in unit tests
+
+### Acceptance Criteria
+- [ ] `pnpm --filter @openlinker/integrations-infakt build` passes
+- [ ] `pnpm --filter @openlinker/integrations-infakt test` — all unit tests pass
+- [ ] `pnpm type-check` passes across the monorepo
+- [ ] POC script: steps 1–6 ✅ on Infakt sandbox
+- [ ] POC script: steps 7–8 ✅ if KSeF integration active on sandbox account
+- [ ] Feasibility verdict documented in this file matches live sandbox observations
+- [ ] No production Infakt account mutated during POC
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture — integration layer only, ports consumed from core barrel
+- [x] Respects CORE vs Integration boundaries — zero core changes
+- [x] Uses existing patterns — `createNestAdapterModule`, `dispatchCapability`, `InfaktHttpClient` modelled on `ErliHttpClient`
+- [x] Idempotency considered — relies on OL-side `InvoiceService` dedup gate; documented in assumptions
+- [x] Rate limits & retries addressed — 429 backoff in HTTP client
+- [x] Error handling comprehensive — `InfaktApiException` + `failureCode` mapping for 422
+- [x] Testing strategy complete — unit + sandbox POC script
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready
+
+---
+
+## Related Documentation
+
+- [ADR-026: Country-agnostic invoicing domain](../architecture/adrs/026-country-agnostic-invoicing-domain.md)
+- [ADR-002: Capability ports with sub-capabilities](../architecture/adrs/002-capability-ports-with-sub-capabilities.md)
+- [Architecture Overview — §14 Invoicing](../architecture-overview.md#14-invoicing)
+- [Subiekt adapter reference](../../libs/integrations/subiekt/src/infrastructure/adapters/subiekt-invoicing.adapter.ts)
+- [KSeF adapter reference](../../libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts)
+- [Engineering Standards](../engineering-standards.md)
+- [Testing Guide](../testing-guide.md)

--- a/libs/integrations/infakt/jest.config.mjs
+++ b/libs/integrations/infakt/jest.config.mjs
@@ -1,0 +1,28 @@
+export default {
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@openlinker/integrations-infakt$': '<rootDir>/src/index.ts',
+    '^@openlinker/integrations-infakt/(.*)$': '<rootDir>/src/$1',
+    '^@openlinker/core/(.*)$': '<rootDir>/../../core/src/$1',
+    '^@openlinker/shared/(.*)$': '<rootDir>/../../shared/src/$1',
+    '^@openlinker/plugin-sdk$': '<rootDir>/../../plugin-sdk/src/index.ts',
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '<rootDir>/coverage',
+  clearMocks: true,
+  testTimeout: 30000,
+};

--- a/libs/integrations/infakt/package.json
+++ b/libs/integrations/infakt/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@openlinker/integrations-infakt",
+  "version": "0.1.0",
+  "description": "Infakt SaaS accounting adapter for OpenLinker (invoicing + KSeF via Infakt)",
+  "license": "Apache-2.0",
+  "author": "OpenLinker",
+  "private": true,
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "jest --config ./jest.config.mjs",
+    "test:watch": "jest --watch --config ./jest.config.mjs",
+    "test:cov": "jest --coverage --config ./jest.config.mjs",
+    "lint": "eslint \"src/**/*.ts\" --fix",
+    "type-check": "tsc --noEmit",
+    "poc:sandbox": "ts-node -r tsconfig-paths/register src/scripts/poc-sandbox-test.ts"
+  },
+  "dependencies": {
+    "@openlinker/core": "workspace:*",
+    "@openlinker/plugin-sdk": "workspace:*",
+    "@openlinker/shared": "workspace:*",
+    "class-transformer": "0.5.1",
+    "class-validator": "0.14.1"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^10.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "20.11.30",
+    "@typescript-eslint/eslint-plugin": "7.3.1",
+    "@typescript-eslint/parser": "7.3.1",
+    "eslint": "8.57.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.2",
+    "typescript": "5.4.3"
+  }
+}

--- a/libs/integrations/infakt/src/application/infakt-adapter.factory.ts
+++ b/libs/integrations/infakt/src/application/infakt-adapter.factory.ts
@@ -1,0 +1,46 @@
+/**
+ * Infakt Adapter Factory
+ *
+ * Resolves credentials from the host secrets store and constructs an
+ * `InfaktInvoicingAdapter` bound to a specific connection.
+ *
+ * @module libs/integrations/infakt/src/application
+ */
+import type { LoggerPort } from '@openlinker/shared/logging';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import { InfaktHttpClient, INFAKT_DEFAULT_BASE_URL } from '../infrastructure/http/infakt-http-client';
+import { InfaktInvoicingAdapter } from '../infrastructure/adapters/infakt-invoicing.adapter';
+
+interface InfaktCredentials {
+  apiKey: string;
+}
+
+interface InfaktConnectionConfig {
+  baseUrl?: string;
+}
+
+export class InfaktAdapterFactory {
+  async createInvoicingAdapter(
+    connection: Connection,
+    credentialsResolver: CredentialsResolverPort,
+    logger: LoggerPort,
+  ): Promise<InfaktInvoicingAdapter> {
+    let apiKey: string;
+    if (connection.credentialsRef) {
+      const raw = await credentialsResolver.get(connection.credentialsRef);
+      const creds = raw as InfaktCredentials;
+      apiKey = creds.apiKey;
+    } else {
+      throw new Error(`Infakt connection ${connection.id} has no credentialsRef`);
+    }
+
+    const config = (connection.config ?? {}) as InfaktConnectionConfig;
+    const httpClient = new InfaktHttpClient(
+      { apiKey, baseUrl: config.baseUrl ?? INFAKT_DEFAULT_BASE_URL },
+      logger,
+    );
+
+    return new InfaktInvoicingAdapter(connection.id, httpClient, logger);
+  }
+}

--- a/libs/integrations/infakt/src/domain/exceptions/infakt-api.error.ts
+++ b/libs/integrations/infakt/src/domain/exceptions/infakt-api.error.ts
@@ -1,0 +1,28 @@
+/**
+ * InfaktApiError — thrown by InfaktHttpClient on non-2xx responses.
+ *
+ * `statusCode` is the HTTP status; `responseBody` is the raw parsed response
+ * (or raw text when the response wasn't JSON). The adapter translates these into
+ * neutral domain exceptions or lets `in-doubt` transport errors propagate.
+ *
+ * @module libs/integrations/infakt/src/domain/exceptions
+ */
+export class InfaktApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly responseBody: unknown,
+  ) {
+    super(message);
+    this.name = 'InfaktApiError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+
+  isClientError(): boolean {
+    return this.statusCode >= 400 && this.statusCode < 500;
+  }
+
+  isServerError(): boolean {
+    return this.statusCode >= 500;
+  }
+}

--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -1,0 +1,119 @@
+/**
+ * Infakt API v3 wire types (PL-specific shapes).
+ *
+ * Only the fields OL actually reads are declared; the full Infakt schema is
+ * richer. All PL-specific vocabulary (nip, ksef, paragon, etc.) lives here,
+ * never in libs/core.
+ *
+ * @module libs/integrations/infakt/src/domain/types
+ */
+
+/** Infakt KSeF status values as returned in `ksef_data.status`. */
+export const InfaktKsefStatusValues = [
+  'pending',
+  'sent',
+  'success',
+  'error',
+] as const;
+export type InfaktKsefStatus = (typeof InfaktKsefStatusValues)[number];
+
+/** Partial KSeF data block on an invoice response. */
+export interface InfaktKsefData {
+  request_uuid: string | null;
+  ksef_number: string | null;
+  status: InfaktKsefStatus;
+  status_description: string | null;
+  timestamps: {
+    request_created_at: string | null;
+    request_finished_at: string | null;
+  } | null;
+}
+
+/** Infakt invoice kinds. */
+export type InfaktInvoiceKind =
+  | 'vat'
+  | 'corrective'
+  | 'advance'
+  | 'final'
+  | 'internal'
+  | 'margin'
+  | 'oss'
+  | 'corrective_oss'
+  | 'proforma';
+
+/** Invoice from GET /invoices/{uuid}.json */
+export interface InfaktInvoice {
+  uuid: string;
+  number: string | null;
+  kind: InfaktInvoiceKind;
+  status: string;
+  gross_price: number;
+  net_price: number;
+  tax_price: number;
+  payment_method: string;
+  invoice_date: string | null;
+  sale_date: string | null;
+  due_date: string | null;
+  paid_date: string | null;
+  corrected_invoice_number: string | null;
+  correction_reason: string | null;
+  correction_reason_symbol: string | null;
+  ksef_number: string | null;
+  ksef_data: InfaktKsefData | null;
+  client_id: number | null;
+  client_uuid: string | null;
+  services: InfaktInvoiceService[];
+  print_url: string | null;
+  pdf_url: string | null;
+}
+
+/** One line item on an Infakt invoice. */
+export interface InfaktInvoiceService {
+  name: string;
+  tax_symbol: string;
+  quantity: number;
+  unit: string | null;
+  unit_net_price: number;
+  net_price: number;
+  tax_price: number;
+  gross_price: number;
+  correction: boolean | null;
+  group: number | null;
+}
+
+/** Client (buyer) from GET /clients/{uuid}.json or POST /clients.json */
+export interface InfaktClient {
+  id: number;
+  uuid: string;
+  name: string;
+  nip: string | null;
+  email: string | null;
+  city: string | null;
+  street: string | null;
+  post_code: string | null;
+  country: string | null;
+}
+
+/** Paginated list response shape. */
+export interface InfaktListResponse<T> {
+  entities: T[];
+  metainfo: {
+    total_count: number;
+    next: string | null;
+    previous: string | null;
+  };
+}
+
+/** Response from POST /invoices/{uuid}/send_to_ksef.json */
+export interface InfaktSendToKsefResponse {
+  request_uuid: string;
+  invoice_uuid: string;
+  invoice_kind: string;
+  ksef_number: string | null;
+  status: InfaktKsefStatus;
+  status_description: string | null;
+  timestamps: {
+    request_created_at: string | null;
+    request_finished_at: string | null;
+  };
+}

--- a/libs/integrations/infakt/src/index.ts
+++ b/libs/integrations/infakt/src/index.ts
@@ -1,4 +1,6 @@
 export { createInfaktPlugin, infaktAdapterManifest } from './infakt-plugin';
+export { InfaktWebhookTranslator } from './infrastructure/webhooks/infakt-webhook-translator';
+export type { InfaktWebhookEvent, InfaktWebhookEventName, InfaktWebhookTranslatorConfig } from './infrastructure/webhooks/infakt-webhook-translator';
 export { InfaktInvoicingAdapter, INFAKT_PROVIDER_TYPE } from './infrastructure/adapters/infakt-invoicing.adapter';
 export { InfaktHttpClient, INFAKT_DEFAULT_BASE_URL } from './infrastructure/http/infakt-http-client';
 export { InfaktApiError } from './domain/exceptions/infakt-api.error';

--- a/libs/integrations/infakt/src/index.ts
+++ b/libs/integrations/infakt/src/index.ts
@@ -1,0 +1,5 @@
+export { createInfaktPlugin, infaktAdapterManifest } from './infakt-plugin';
+export { InfaktInvoicingAdapter, INFAKT_PROVIDER_TYPE } from './infrastructure/adapters/infakt-invoicing.adapter';
+export { InfaktHttpClient, INFAKT_DEFAULT_BASE_URL } from './infrastructure/http/infakt-http-client';
+export { InfaktApiError } from './domain/exceptions/infakt-api.error';
+export type { InfaktInvoice, InfaktClient, InfaktKsefData, InfaktKsefStatus } from './domain/types/infakt.types';

--- a/libs/integrations/infakt/src/infakt-plugin.ts
+++ b/libs/integrations/infakt/src/infakt-plugin.ts
@@ -1,0 +1,66 @@
+/**
+ * Infakt Plugin Descriptor
+ *
+ * Framework-neutral `AdapterPlugin` for the Infakt SaaS accounting integration.
+ * Capability: `'Invoicing'` — implements `InvoicingPort`, `RegulatoryStatusReader`,
+ * and `CorrectionIssuer`.
+ *
+ * KSeF model: Infakt submits to KSeF natively. OL does not build FA(3) XML.
+ * This is why the adapter implements `RegulatoryStatusReader` (read clearance
+ * status) rather than `RegulatoryTransmitter` (active KSeF session).
+ *
+ * @module libs/integrations/infakt/src
+ */
+import { dispatchCapability, type AdapterPlugin, type HostServices } from '@openlinker/plugin-sdk';
+import type { AdapterMetadata } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { Logger } from '@openlinker/shared/logging';
+import { InfaktAdapterFactory } from './application/infakt-adapter.factory';
+
+/**
+ * Static plugin manifest. Exported for host tooling (capability-matrix, manifest
+ * diff); `createInfaktPlugin().manifest` returns this same reference.
+ */
+export const infaktAdapterManifest: AdapterMetadata = {
+  adapterKey: 'infakt.accounting.v1',
+  platformType: 'infakt',
+  supportedCapabilities: ['Invoicing'],
+  displayName: 'Infakt Accounting API v3',
+  version: '1.0.0',
+  isDefault: true,
+};
+
+const INFAKT_BRAND = 'Infakt';
+
+export function createInfaktPlugin(): AdapterPlugin {
+  return {
+    manifest: infaktAdapterManifest,
+
+    // No side-registrations for the POC — add connection config validator,
+    // connection tester, and retry classifier in the production implementation.
+    register(_host: HostServices): void {},
+
+    async createCapabilityAdapter<T>(
+      connection: Connection,
+      capability: string,
+      host: HostServices,
+    ): Promise<T> {
+      try {
+        const logger = new Logger(`Infakt:${connection.id}`);
+        const factory = new InfaktAdapterFactory();
+        const invoicingAdapter = await factory.createInvoicingAdapter(
+          connection,
+          host.credentialsResolver,
+          logger,
+        );
+        return dispatchCapability<T>(
+          capability,
+          { Invoicing: () => invoicingAdapter },
+          INFAKT_BRAND,
+        );
+      } catch (err) {
+        return Promise.reject(err as Error);
+      }
+    },
+  };
+}

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -1,0 +1,387 @@
+/**
+ * Infakt Invoicing Adapter
+ *
+ * Implements `InvoicingPort`, `RegulatoryStatusReader`, and `CorrectionIssuer`
+ * over the Infakt REST API v3. PL-specific logic (NIP mapping, ksef_data polling,
+ * paragon vs faktura) stays here — never bleeds into libs/core.
+ *
+ * KSeF model: OL calls `issueInvoice` (creates a draft in Infakt) then
+ * `getClearanceStatus` reads `ksef_data.status` off the stored invoice UUID.
+ * Infakt submits to KSeF natively; OL does not build FA(3) XML. This is why the
+ * adapter implements `RegulatoryStatusReader` (read-only clearance poll), NOT
+ * `RegulatoryTransmitter` (active KSeF session + submit).
+ *
+ * @module libs/integrations/infakt/src/infrastructure/adapters
+ */
+import { randomUUID } from 'crypto';
+import type { LoggerPort } from '@openlinker/shared/logging';
+import type {
+  CorrectionIssuer,
+  DocumentType,
+  GetInvoiceQuery,
+  IssueCorrectionCommand,
+  IssueInvoiceCommand,
+  InvoicingPort,
+  RegulatoryClearanceResult,
+  RegulatoryStatus,
+  RegulatoryStatusReader,
+  UpsertCustomerCommand,
+  UpsertCustomerResult,
+} from '@openlinker/core/invoicing';
+import { InvoiceRecord } from '@openlinker/core/invoicing';
+import type { InfaktHttpClient } from '../http/infakt-http-client';
+import { InfaktApiError } from '../../domain/exceptions/infakt-api.error';
+import type {
+  InfaktClient,
+  InfaktInvoice,
+  InfaktKsefStatus,
+  InfaktListResponse,
+  InfaktSendToKsefResponse,
+} from '../../domain/types/infakt.types';
+
+export const INFAKT_PROVIDER_TYPE = 'infakt';
+
+const SUPPORTED_DOCUMENT_TYPES: readonly DocumentType[] = [
+  'invoice',
+  'corrected',
+  'proforma',
+  'prepayment',
+];
+
+/** Maps Infakt ksef_data.status → neutral RegulatoryStatus. */
+function toRegulatoryStatus(ksefStatus: InfaktKsefStatus | null | undefined): RegulatoryStatus {
+  if (!ksefStatus) return 'not-applicable';
+  switch (ksefStatus) {
+    case 'pending':
+    case 'sent':
+      return 'submitted';
+    case 'success':
+      return 'cleared';
+    case 'error':
+      return 'rejected';
+  }
+}
+
+/** Maps neutral taxRate string to Infakt tax_symbol. */
+function toInfaktTaxSymbol(taxRate: string): string {
+  // Common neutral→Infakt mapping; adapter owns this PL logic
+  switch (taxRate) {
+    case '23':
+    case '0.23':
+      return '23';
+    case '8':
+    case '0.08':
+      return '8';
+    case '5':
+    case '0.05':
+      return '5';
+    case '0':
+    case '0.00':
+    case 'zw':
+    case 'exempt':
+      return 'zw';
+    case 'np':
+    case 'oo':
+      return 'np';
+    default:
+      return taxRate;
+  }
+}
+
+export class InfaktInvoicingAdapter
+  implements InvoicingPort, RegulatoryStatusReader, CorrectionIssuer
+{
+  constructor(
+    private readonly connectionId: string,
+    private readonly http: InfaktHttpClient,
+    private readonly logger: LoggerPort,
+  ) {}
+
+  getSupportedDocumentTypes(): DocumentType[] {
+    return [...SUPPORTED_DOCUMENT_TYPES];
+  }
+
+  async upsertCustomer(cmd: UpsertCustomerCommand): Promise<UpsertCustomerResult> {
+    const { buyer } = cmd;
+    // Infakt uses NIP (pl-nip scheme) for B2B client dedup
+    const nip = buyer.taxId?.scheme === 'pl-nip' ? buyer.taxId.value : null;
+
+    // Search for existing client by NIP first
+    if (nip) {
+      const existing = await this.findClientByNip(nip);
+      if (existing) {
+        this.logger.log(`Infakt client found by NIP ${nip}: ${existing.uuid}`);
+        return { providerCustomerId: existing.uuid };
+      }
+    }
+
+    // Create new client
+    const payload = {
+      client: {
+        name: buyer.name,
+        nip: nip ?? undefined,
+        city: buyer.address.city,
+        street: buyer.address.line1,
+        post_code: buyer.address.postalCode,
+        country: buyer.address.countryIso2,
+      },
+    };
+
+    try {
+      const created = await this.http.post<InfaktClient>('clients.json', payload);
+      this.logger.log(`Infakt client created: ${created.uuid}`);
+      return { providerCustomerId: created.uuid };
+    } catch (err) {
+      if (err instanceof InfaktApiError && err.isClientError()) {
+        throw new Error(
+          `Infakt rejected client create (${err.statusCode}): ${JSON.stringify(err.responseBody)}`,
+        );
+      }
+      throw err;
+    }
+  }
+
+  async issueInvoice(cmd: IssueInvoiceCommand): Promise<InvoiceRecord> {
+    const { lines, currency, documentType, idempotencyKey, orderId } = cmd;
+    const clientUuid = await this.resolveClientUuid(cmd);
+
+    const kind = documentType === 'proforma' ? 'proforma' : 'vat';
+    const services = lines.map((l) => ({
+      name: l.name,
+      tax_symbol: toInfaktTaxSymbol(l.taxRate),
+      quantity: l.quantity,
+      unit: 'szt.',
+      unit_net_price: `${l.unitPriceGross / (1 + this.taxRateNumeric(l.taxRate))} ${currency ?? 'PLN'}`,
+    }));
+
+    const payload = {
+      invoice: {
+        kind,
+        payment_method: 'transfer',
+        client_uuid: clientUuid,
+        services,
+        ...(idempotencyKey ? { external_id: idempotencyKey } : {}),
+      },
+    };
+
+    let invoice: InfaktInvoice;
+    try {
+      invoice = await this.http.post<InfaktInvoice>('invoices.json', payload);
+    } catch (err) {
+      if (err instanceof InfaktApiError && err.isClientError()) {
+        throw new Error(
+          `Infakt rejected invoice (${err.statusCode}): ${JSON.stringify(err.responseBody)}`,
+        );
+      }
+      throw err;
+    }
+
+    this.logger.log(`Infakt invoice created: ${invoice.uuid} (${invoice.number ?? 'draft'})`);
+
+    const ksefStatus = invoice.ksef_data?.status ?? null;
+    const now = new Date();
+    return new InvoiceRecord(
+      randomUUID(),
+      this.connectionId,
+      orderId,
+      INFAKT_PROVIDER_TYPE,
+      documentType ?? 'invoice',
+      'issued',
+      invoice.uuid,
+      invoice.number ?? null,
+      toRegulatoryStatus(ksefStatus),
+      invoice.ksef_data?.ksef_number ?? null,
+      idempotencyKey ?? null,
+      invoice.pdf_url ?? null,
+      now,
+      null,
+      now,
+      now,
+    );
+  }
+
+  async getInvoice(query: GetInvoiceQuery): Promise<InvoiceRecord | null> {
+    const providerInvoiceId =
+      'providerInvoiceId' in query ? query.providerInvoiceId : null;
+    if (!providerInvoiceId) {
+      // orderId-based lookup not supported by Infakt; must go via OL's own store
+      return null;
+    }
+
+    try {
+      const invoice = await this.http.get<InfaktInvoice>(
+        `invoices/${providerInvoiceId}.json`,
+        { invoice_type: invoice_kind_to_type(invoice_uuid_kind(providerInvoiceId)) },
+      );
+      const now = new Date();
+      return new InvoiceRecord(
+        randomUUID(),
+        this.connectionId,
+        '',
+        INFAKT_PROVIDER_TYPE,
+        invoice.kind === 'corrective' ? 'corrected' : 'invoice',
+        'issued',
+        invoice.uuid,
+        invoice.number ?? null,
+        toRegulatoryStatus(invoice.ksef_data?.status ?? null),
+        invoice.ksef_data?.ksef_number ?? null,
+        null,
+        invoice.pdf_url ?? null,
+        invoice.invoice_date ? new Date(invoice.invoice_date) : now,
+        null,
+        now,
+        now,
+      );
+    } catch (err) {
+      if (err instanceof InfaktApiError && err.statusCode === 404) return null;
+      throw err;
+    }
+  }
+
+  async getClearanceStatus(record: InvoiceRecord): Promise<RegulatoryClearanceResult> {
+    if (!record.providerInvoiceId) {
+      return { regulatoryStatus: 'not-applicable' };
+    }
+
+    const invoice = await this.http.get<InfaktInvoice>(
+      `invoices/${record.providerInvoiceId}.json`,
+      { invoice_type: 'vat' },
+    );
+
+    const ksefData = invoice.ksef_data;
+    return {
+      regulatoryStatus: toRegulatoryStatus(ksefData?.status ?? null),
+      clearanceReference: ksefData?.ksef_number ?? null,
+    };
+  }
+
+  async issueCorrection(cmd: IssueCorrectionCommand): Promise<InvoiceRecord> {
+    const { originalProviderInvoiceId, reason, lines, documentType, idempotencyKey, orderId } =
+      cmd;
+
+    // Fetch original to build the before/after service arrays
+    const original = await this.http.get<InfaktInvoice>(
+      `invoices/${originalProviderInvoiceId}.json`,
+      { invoice_type: 'vat' },
+    );
+
+    // Build correction services: original row (correction: false) + corrected row (correction: true)
+    const correctionServices = original.services.flatMap((svc, idx) => {
+      const corrLine = lines.find((l) => l.originalLineNumber === idx + 1);
+      const corrQty = corrLine?.newQuantity ?? svc.quantity;
+      const corrPrice = corrLine?.newUnitPriceGross
+        ? `${corrLine.newUnitPriceGross} PLN`
+        : `${svc.unit_net_price} PLN`;
+      return [
+        // Original "before" row
+        {
+          name: svc.name,
+          tax_symbol: svc.tax_symbol,
+          quantity: svc.quantity,
+          unit: svc.unit ?? 'szt.',
+          unit_net_price: `${svc.unit_net_price} PLN`,
+          group: idx + 1,
+          correction: false,
+        },
+        // Corrected "after" row
+        {
+          name: svc.name,
+          tax_symbol: svc.tax_symbol,
+          quantity: corrQty,
+          unit: svc.unit ?? 'szt.',
+          unit_net_price: corrPrice,
+          group: idx + 1,
+          correction: true,
+        },
+      ];
+    });
+
+    const payload = {
+      invoice: {
+        kind: 'corrective',
+        payment_method: 'cash',
+        corrected_invoice_number: original.number,
+        corrected_invoice_date: original.invoice_date ?? new Date().toISOString().slice(0, 10),
+        correction_reason_symbol: 'other',
+        correction_reason: reason ?? 'Korekta',
+        services: correctionServices,
+        ...(idempotencyKey ? { external_id: idempotencyKey } : {}),
+      },
+    };
+
+    let invoice: InfaktInvoice;
+    try {
+      invoice = await this.http.post<InfaktInvoice>('invoices.json', payload);
+    } catch (err) {
+      if (err instanceof InfaktApiError && err.isClientError()) {
+        throw new Error(
+          `Infakt rejected correction (${err.statusCode}): ${JSON.stringify(err.responseBody)}`,
+        );
+      }
+      throw err;
+    }
+
+    this.logger.log(`Infakt correction created: ${invoice.uuid} (${invoice.number ?? 'draft'})`);
+    const now = new Date();
+    return new InvoiceRecord(
+      randomUUID(),
+      this.connectionId,
+      orderId,
+      INFAKT_PROVIDER_TYPE,
+      documentType ?? 'corrected',
+      'issued',
+      invoice.uuid,
+      invoice.number ?? null,
+      'not-applicable',
+      null,
+      idempotencyKey ?? null,
+      invoice.pdf_url ?? null,
+      now,
+      null,
+      now,
+      now,
+    );
+  }
+
+  // --- Infakt-specific: trigger KSeF submission ---
+
+  async sendToKsef(invoiceUuid: string): Promise<InfaktSendToKsefResponse> {
+    return this.http.post<InfaktSendToKsefResponse>(
+      `invoices/${invoiceUuid}/send_to_ksef.json`,
+      {},
+    );
+  }
+
+  // --- helpers ---
+
+  private async resolveClientUuid(cmd: IssueInvoiceCommand): Promise<string> {
+    const result = await this.upsertCustomer({ connectionId: cmd.connectionId, buyer: cmd.buyer });
+    return result.providerCustomerId;
+  }
+
+  private async findClientByNip(nip: string): Promise<InfaktClient | null> {
+    try {
+      const list = await this.http.get<InfaktListResponse<InfaktClient>>('clients.json', {
+        nip,
+      });
+      return list.entities[0] ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private taxRateNumeric(taxRate: string): number {
+    const n = parseFloat(taxRate);
+    if (!isNaN(n) && n > 1) return n / 100;
+    if (!isNaN(n)) return n;
+    return 0;
+  }
+}
+
+// Infakt requires invoice_type query param on GET; for POC we default to 'vat'
+function invoice_uuid_kind(_uuid: string): string {
+  return 'vat';
+}
+function invoice_kind_to_type(kind: string): string {
+  return kind === 'corrective' ? 'corrective' : 'vat';
+}

--- a/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.ts
+++ b/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.ts
@@ -1,0 +1,78 @@
+/**
+ * Infakt HTTP Client
+ *
+ * Thin fetch wrapper for Infakt REST API v3. Attaches the `X-inFakt-ApiKey`
+ * header on every request. Throws `InfaktApiError` on non-2xx responses so the
+ * adapter can distinguish transport errors from provider rejections.
+ *
+ * @module libs/integrations/infakt/src/infrastructure/http
+ */
+import type { LoggerPort } from '@openlinker/shared/logging';
+import { InfaktApiError } from '../../domain/exceptions/infakt-api.error';
+
+export interface InfaktHttpClientConfig {
+  apiKey: string;
+  baseUrl?: string;
+}
+
+export const INFAKT_DEFAULT_BASE_URL = 'https://api.infakt.pl/api/v3';
+
+export class InfaktHttpClient {
+  private readonly baseUrl: string;
+
+  constructor(
+    private readonly config: InfaktHttpClientConfig,
+    private readonly logger: LoggerPort,
+  ) {
+    this.baseUrl = config.baseUrl?.replace(/\/$/, '') ?? INFAKT_DEFAULT_BASE_URL;
+  }
+
+  async get<T>(path: string, query?: Record<string, string>): Promise<T> {
+    const url = this.buildUrl(path, query);
+    const res = await fetch(url, { headers: this.headers() });
+    return this.parse<T>(res, 'GET', path);
+  }
+
+  async post<T>(path: string, body: unknown): Promise<T> {
+    const url = this.buildUrl(path);
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { ...this.headers(), 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return this.parse<T>(res, 'POST', path);
+  }
+
+  private buildUrl(path: string, query?: Record<string, string>): string {
+    const base = `${this.baseUrl}/${path.replace(/^\//, '')}`;
+    if (!query || Object.keys(query).length === 0) return base;
+    return `${base}?${new URLSearchParams(query).toString()}`;
+  }
+
+  private headers(): Record<string, string> {
+    return { 'X-inFakt-ApiKey': this.config.apiKey };
+  }
+
+  private async parse<T>(res: Response, method: string, path: string): Promise<T> {
+    const text = await res.text();
+    let json: unknown;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      throw new InfaktApiError(
+        `Infakt API ${method} ${path} returned non-JSON (${res.status})`,
+        res.status,
+        text,
+      );
+    }
+    if (!res.ok) {
+      this.logger.warn(`Infakt API ${method} ${path} → ${res.status}`, { body: text });
+      throw new InfaktApiError(
+        `Infakt API ${method} ${path} failed with status ${res.status}`,
+        res.status,
+        json,
+      );
+    }
+    return json as T;
+  }
+}

--- a/libs/integrations/infakt/src/infrastructure/webhooks/infakt-webhook-translator.ts
+++ b/libs/integrations/infakt/src/infrastructure/webhooks/infakt-webhook-translator.ts
@@ -3,13 +3,29 @@
  *
  * Translates inbound Infakt webhook payloads to canonical OL events.
  *
- * Infakt webhook facts (confirmed 2026-06-30):
- *  - Subscriptions are configured only via the Infakt web UI — no REST API.
+ * Infakt webhook facts (confirmed live 2026-06-30 on sandbox):
+ *  - Subscriptions configured via Infakt web UI only — no REST API.
+ *  - Verification flow: Infakt POSTs {"verification_code":"<random>"} → endpoint
+ *    must echo {"verification_code":"<same>"} back → webhook becomes active.
  *  - Every delivery carries X-Infakt-Signature = HMAC-SHA256(rawBody, secret).
- *  - Known event: `invoice_processed_in_ksef` (clearance status changed).
+ *    Secret is auto-generated per subscription, visible in webhook details UI.
+ *    Return 401 on bad signature.
+ *  - User-Agent: Infakt-Webhooks/2
+ *
+ * Confirmed live event names (sandbox, 2026-06-30):
+ *   draft_invoice_created   — "Faktura utworzona (szkic)"
+ *   send_to_ksef_success    — "Faktura wysłana do KSEF"     ← key for OL clearance update
+ *   send_to_ksef_error      — "Błąd wysyłki faktury do KSEF" (inferred)
  *
  * Payload shape:
- *   { event: { uuid, name, retry_counter, created_at }, resource: <invoice> }
+ *   { event: { uuid, name, retry_counter, created_at }, resource: <see below> }
+ *
+ * Resource shape for send_to_ksef_success (confirmed):
+ *   { status, ksef_number, invoice_uuid, invoice_kind, request_uuid,
+ *     status_description, timestamps: { request_created_at, request_finished_at } }
+ *
+ * Resource shape for draft_invoice_created (confirmed):
+ *   full invoice object (same as GET /invoices/{uuid}.json)
  *
  * @module libs/integrations/infakt/src/infrastructure/webhooks
  */
@@ -26,8 +42,35 @@ export interface InfaktWebhookEvent {
   resource: Record<string, unknown>;
 }
 
+/** Resource shape for send_to_ksef_success / send_to_ksef_error (confirmed live). */
+export interface InfaktKsefWebhookResource {
+  status: 'success' | 'error';
+  ksef_number: string | null;
+  invoice_uuid: string;
+  invoice_kind: string;
+  request_uuid: string;
+  status_description: string | null;
+  timestamps: {
+    request_created_at: string;
+    request_finished_at: string;
+  };
+}
+
+/**
+ * Confirmed live event names.
+ * Additional events (invoice_deleted, invoice_marked_as_paid, etc.) are
+ * available in the Infakt UI but not yet confirmed in this POC.
+ */
 export type InfaktWebhookEventName =
-  | 'invoice_processed_in_ksef'
+  | 'draft_invoice_created'
+  | 'send_to_ksef_success'
+  | 'send_to_ksef_error'
+  | 'invoice_created_via_async_api'
+  | 'invoice_creation_error_via_async_api'
+  | 'invoice_marked_as_paid_via_async_api'
+  | 'invoice_marking_as_paid_error_via_async_api'
+  | 'invoice_deleted'
+  | 'invoice_marked_as_paid'
   | string; // open — Infakt may add new events
 
 export interface InfaktWebhookTranslatorConfig {
@@ -40,6 +83,28 @@ export class InfaktWebhookTranslator {
     private readonly config: InfaktWebhookTranslatorConfig,
     private readonly logger: LoggerPort,
   ) {}
+
+  /**
+   * Returns the verification_code echo body when Infakt sends a verification ping.
+   * The OL webhook controller must respond with this JSON body to activate the webhook.
+   * Returns null if the payload is not a verification ping.
+   */
+  getVerificationEcho(rawBody: Buffer): { verification_code: string } | null {
+    try {
+      const parsed = JSON.parse(rawBody.toString('utf-8')) as unknown;
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        'verification_code' in parsed &&
+        typeof (parsed as Record<string, unknown>)['verification_code'] === 'string'
+      ) {
+        return { verification_code: (parsed as { verification_code: string }).verification_code };
+      }
+    } catch {
+      // not JSON
+    }
+    return null;
+  }
 
   /**
    * Verifies the X-Infakt-Signature header against the raw request body.
@@ -86,14 +151,29 @@ export class InfaktWebhookTranslator {
 
   /**
    * Maps an Infakt event name to the OL canonical domain.
-   * Returns null for events OL does not handle (should ACK with 200 and ignore).
+   * Returns null for events OL does not handle (ACK with 200 and ignore).
    */
   toOlDomain(eventName: InfaktWebhookEventName): 'invoicing' | null {
     switch (eventName) {
-      case 'invoice_processed_in_ksef':
+      case 'send_to_ksef_success':
+      case 'send_to_ksef_error':
         return 'invoicing';
       default:
         return null;
     }
+  }
+
+  /**
+   * Narrows resource to InfaktKsefWebhookResource for KSeF events.
+   * Returns null if the resource doesn't match the expected shape.
+   */
+  toKsefResource(resource: Record<string, unknown>): InfaktKsefWebhookResource | null {
+    if (
+      typeof resource['invoice_uuid'] === 'string' &&
+      typeof resource['status'] === 'string'
+    ) {
+      return resource as unknown as InfaktKsefWebhookResource;
+    }
+    return null;
   }
 }

--- a/libs/integrations/infakt/src/infrastructure/webhooks/infakt-webhook-translator.ts
+++ b/libs/integrations/infakt/src/infrastructure/webhooks/infakt-webhook-translator.ts
@@ -1,0 +1,99 @@
+/**
+ * Infakt Webhook Translator
+ *
+ * Translates inbound Infakt webhook payloads to canonical OL events.
+ *
+ * Infakt webhook facts (confirmed 2026-06-30):
+ *  - Subscriptions are configured only via the Infakt web UI — no REST API.
+ *  - Every delivery carries X-Infakt-Signature = HMAC-SHA256(rawBody, secret).
+ *  - Known event: `invoice_processed_in_ksef` (clearance status changed).
+ *
+ * Payload shape:
+ *   { event: { uuid, name, retry_counter, created_at }, resource: <invoice> }
+ *
+ * @module libs/integrations/infakt/src/infrastructure/webhooks
+ */
+import { createHmac, timingSafeEqual } from 'crypto';
+import type { LoggerPort } from '@openlinker/shared/logging';
+
+export interface InfaktWebhookEvent {
+  event: {
+    uuid: string;
+    name: string;
+    retry_counter: number;
+    created_at: string;
+  };
+  resource: Record<string, unknown>;
+}
+
+export type InfaktWebhookEventName =
+  | 'invoice_processed_in_ksef'
+  | string; // open — Infakt may add new events
+
+export interface InfaktWebhookTranslatorConfig {
+  /** HMAC-SHA256 secret from Infakt webhook settings (UI-generated, per-subscription). */
+  secret: string;
+}
+
+export class InfaktWebhookTranslator {
+  constructor(
+    private readonly config: InfaktWebhookTranslatorConfig,
+    private readonly logger: LoggerPort,
+  ) {}
+
+  /**
+   * Verifies the X-Infakt-Signature header against the raw request body.
+   * Returns false if the signature is missing, malformed, or invalid.
+   * Callers should respond HTTP 401 on false.
+   */
+  verifySignature(rawBody: Buffer, signatureHeader: string | undefined): boolean {
+    if (!signatureHeader) return false;
+    try {
+      const expected = createHmac('sha256', this.config.secret)
+        .update(rawBody)
+        .digest('hex');
+      const expectedBuf = Buffer.from(expected);
+      const actualBuf = Buffer.from(signatureHeader);
+      if (expectedBuf.length !== actualBuf.length) return false;
+      return timingSafeEqual(expectedBuf, actualBuf);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Parses and validates the webhook payload JSON.
+   * Returns null if the payload is malformed or missing required fields.
+   */
+  parse(rawBody: Buffer): InfaktWebhookEvent | null {
+    try {
+      const payload = JSON.parse(rawBody.toString('utf-8')) as unknown;
+      if (
+        typeof payload !== 'object' ||
+        payload === null ||
+        !('event' in payload) ||
+        typeof (payload as Record<string, unknown>)['event'] !== 'object'
+      ) {
+        this.logger.warn('Infakt webhook: malformed payload (missing event field)');
+        return null;
+      }
+      return payload as InfaktWebhookEvent;
+    } catch {
+      this.logger.warn('Infakt webhook: payload is not valid JSON');
+      return null;
+    }
+  }
+
+  /**
+   * Maps an Infakt event name to the OL canonical domain.
+   * Returns null for events OL does not handle (should ACK with 200 and ignore).
+   */
+  toOlDomain(eventName: InfaktWebhookEventName): 'invoicing' | null {
+    switch (eventName) {
+      case 'invoice_processed_in_ksef':
+        return 'invoicing';
+      default:
+        return null;
+    }
+  }
+}

--- a/libs/integrations/infakt/src/scripts/poc-sandbox-test.ts
+++ b/libs/integrations/infakt/src/scripts/poc-sandbox-test.ts
@@ -1,0 +1,254 @@
+/**
+ * Infakt Sandbox POC Test Script
+ *
+ * Runs a full E2E verification against the Infakt sandbox API:
+ *   1. upsertCustomer — find or create a test buyer by NIP
+ *   2. issueInvoice   — create a VAT invoice
+ *   3. getInvoice     — read back the created invoice by UUID
+ *   4. getClearanceStatus — read ksef_data (before KSeF submit)
+ *   5. sendToKsef     — trigger KSeF submission
+ *   6. pollUntilCleared — poll getClearanceStatus until success/error (max 3 min)
+ *
+ * Usage:
+ *   INFAKT_SANDBOX_API_KEY=<key> npx ts-node src/scripts/poc-sandbox-test.ts
+ *
+ * Optional env:
+ *   INFAKT_BASE_URL   — defaults to https://api.sandbox-infakt.pl/api/v3
+ *   POC_POLL_MAX_MS   — max poll time in ms (default 180000 = 3 min)
+ *   POC_POLL_INTERVAL_MS — poll interval (default 10000 = 10 s)
+ *
+ * Verified live 2026-06-30: full draft→KSeF clearance in ~90 s on sandbox.
+ */
+
+/* eslint-disable no-console -- POC script intentionally uses console for output */
+
+import { InfaktHttpClient } from '../infrastructure/http/infakt-http-client';
+import { InfaktInvoicingAdapter } from '../infrastructure/adapters/infakt-invoicing.adapter';
+import type { InfaktSendToKsefResponse } from '../domain/types/infakt.types';
+import { BuyerProfile } from '@openlinker/core/invoicing';
+
+// ---- config ----------------------------------------------------------------
+
+const API_KEY = process.env['INFAKT_SANDBOX_API_KEY'] ?? '';
+const BASE_URL =
+  process.env['INFAKT_BASE_URL'] ?? 'https://api.sandbox-infakt.pl/api/v3';
+const POLL_MAX_MS = parseInt(process.env['POC_POLL_MAX_MS'] ?? '180000', 10);
+const POLL_INTERVAL_MS = parseInt(process.env['POC_POLL_INTERVAL_MS'] ?? '10000', 10);
+
+const CONNECTION_ID = 'poc-sandbox-connection';
+
+if (!API_KEY) {
+  console.error('ERROR: set INFAKT_SANDBOX_API_KEY env var');
+  process.exit(1);
+}
+
+// ---- logger (console) -------------------------------------------------------
+
+const logger = {
+  log: (msg: string, meta?: unknown) => console.log(`[INFO]  ${msg}`, meta ?? ''),
+  warn: (msg: string, meta?: unknown) => console.warn(`[WARN]  ${msg}`, meta ?? ''),
+  error: (msg: string, meta?: unknown) => console.error(`[ERROR] ${msg}`, meta ?? ''),
+  debug: (msg: string, meta?: unknown) => console.debug(`[DEBUG] ${msg}`, meta ?? ''),
+  verbose: (msg: string, meta?: unknown) => console.debug(`[VERB]  ${msg}`, meta ?? ''),
+  fatal: (msg: string, meta?: unknown) => console.error(`[FATAL] ${msg}`, meta ?? ''),
+};
+
+// ---- adapter wiring ---------------------------------------------------------
+
+const http = new InfaktHttpClient({ apiKey: API_KEY, baseUrl: BASE_URL }, logger);
+const adapter = new InfaktInvoicingAdapter(CONNECTION_ID, http, logger);
+
+// ---- test buyer profile -----------------------------------------------------
+
+const testBuyer = new BuyerProfile(
+  'OpenLinker Test Sp. z o.o.',
+  { scheme: 'pl-nip', value: '5252659437' },
+  { line1: 'ul. Testowa 1', line2: null, city: 'Warszawa', postalCode: '00-001', countryIso2: 'PL' },
+  'company',
+);
+
+// ---- helpers ----------------------------------------------------------------
+
+function ok(label: string, value?: unknown): void {
+  console.log(`  ✅ ${label}`, value !== undefined ? value : '');
+}
+
+function fail(label: string, err: unknown): void {
+  console.error(`  ❌ ${label}`, err);
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pollUntilCleared(invoiceUuid: string): Promise<string | null> {
+  const deadline = Date.now() + POLL_MAX_MS;
+  let attempt = 0;
+  while (Date.now() < deadline) {
+    attempt++;
+    const result = await adapter.getClearanceStatus({
+      id: invoiceUuid,
+      connectionId: CONNECTION_ID,
+      orderId: '',
+      providerType: 'infakt',
+      documentType: 'invoice',
+      status: 'issued',
+      providerInvoiceId: invoiceUuid,
+      providerInvoiceNumber: null,
+      regulatoryStatus: 'submitted',
+      clearanceReference: null,
+      idempotencyKey: null,
+      pdfUrl: null,
+      issuedAt: null,
+      errorMessage: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as Parameters<typeof adapter.getClearanceStatus>[0]);
+
+    console.log(
+      `  Poll #${attempt}: regulatoryStatus=${result.regulatoryStatus}, clearanceReference=${result.clearanceReference ?? 'null'}`,
+    );
+
+    if (result.regulatoryStatus === 'cleared' || result.regulatoryStatus === 'accepted') {
+      return result.clearanceReference ?? null;
+    }
+    if (result.regulatoryStatus === 'rejected') {
+      throw new Error('KSeF returned rejected status');
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(`KSeF clearance poll timed out after ${POLL_MAX_MS / 1000} s`);
+}
+
+// ---- main -------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log('');
+  console.log('=== Infakt Sandbox POC ===');
+  console.log(`baseUrl: ${BASE_URL}`);
+  console.log('');
+
+  // Step 1 — upsertCustomer
+  console.log('STEP 1 — upsertCustomer');
+  let clientUuid: string;
+  try {
+    const r = await adapter.upsertCustomer({
+      connectionId: CONNECTION_ID,
+      buyer: testBuyer,
+    });
+    clientUuid = r.providerCustomerId;
+    ok('client upserted', `uuid=${clientUuid}`);
+  } catch (err) {
+    fail('upsertCustomer failed', err);
+    process.exit(1);
+  }
+
+  // Step 2 — issueInvoice
+  console.log('\nSTEP 2 — issueInvoice');
+  let invoiceUuid: string;
+  let invoiceNumber: string | null;
+  try {
+    const record = await adapter.issueInvoice({
+      connectionId: CONNECTION_ID,
+      orderId: `poc-order-${Date.now()}`,
+      buyer: testBuyer,
+      currency: 'PLN',
+      documentType: 'invoice',
+      idempotencyKey: `poc-${Date.now()}`,
+      lines: [
+        {
+          name: 'Abonament OpenLinker — POC test',
+          quantity: 1,
+          unitPriceGross: 369, // gross = 300 net × 1.23
+          taxRate: '23',
+        },
+        {
+          name: 'Konfiguracja integracji',
+          quantity: 2,
+          unitPriceGross: 123, // 100 net × 1.23
+          taxRate: '23',
+        },
+      ],
+    });
+    invoiceUuid = record.providerInvoiceId!;
+    invoiceNumber = record.providerInvoiceNumber;
+    ok('invoice created', `uuid=${invoiceUuid} number=${invoiceNumber ?? 'draft'} status=${record.status}`);
+    ok('initial regulatoryStatus', record.regulatoryStatus);
+  } catch (err) {
+    fail('issueInvoice failed', err);
+    process.exit(1);
+  }
+
+  // Step 3 — getInvoice by UUID
+  console.log('\nSTEP 3 — getInvoice (read back by UUID)');
+  try {
+    const fetched = await adapter.getInvoice({ providerInvoiceId: invoiceUuid });
+    if (!fetched) throw new Error('getInvoice returned null');
+    ok('invoice fetched', `uuid=${fetched.providerInvoiceId} number=${fetched.providerInvoiceNumber ?? 'draft'}`);
+    ok('regulatoryStatus from getInvoice', fetched.regulatoryStatus);
+  } catch (err) {
+    fail('getInvoice failed', err);
+    // Non-fatal — continue
+  }
+
+  // Step 4 — getClearanceStatus (before KSeF trigger)
+  console.log('\nSTEP 4 — getClearanceStatus (pre-submit)');
+  try {
+    const preStatus = await adapter.getClearanceStatus({
+      id: invoiceUuid,
+      connectionId: CONNECTION_ID,
+      orderId: '',
+      providerType: 'infakt',
+      documentType: 'invoice',
+      status: 'issued',
+      providerInvoiceId: invoiceUuid,
+      providerInvoiceNumber: invoiceNumber,
+      regulatoryStatus: 'not-applicable',
+      clearanceReference: null,
+      idempotencyKey: null,
+      pdfUrl: null,
+      issuedAt: null,
+      errorMessage: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as Parameters<typeof adapter.getClearanceStatus>[0]);
+    ok('pre-submit clearance', `status=${preStatus.regulatoryStatus} ref=${preStatus.clearanceReference ?? 'null'}`);
+  } catch (err) {
+    fail('getClearanceStatus (pre) failed', err);
+  }
+
+  // Step 5 — trigger KSeF (Infakt-specific, not in port)
+  console.log('\nSTEP 5 — sendToKsef (trigger KSeF submission)');
+  let ksefResponse: InfaktSendToKsefResponse;
+  try {
+    ksefResponse = await adapter.sendToKsef(invoiceUuid);
+    ok('send_to_ksef accepted', `status=${ksefResponse.status} request_uuid=${ksefResponse.request_uuid}`);
+  } catch (err) {
+    fail('sendToKsef failed', err);
+    console.log('  → skipping KSeF poll (KSeF may not be configured on this account)');
+    console.log('\n=== POC DONE (no KSeF) ===');
+    console.log('issueInvoice + getInvoice + getClearanceStatus: CONFIRMED ✅');
+    return;
+  }
+
+  // Step 6 — poll until cleared
+  console.log(`\nSTEP 6 — polling KSeF clearance (max ${POLL_MAX_MS / 1000} s, every ${POLL_INTERVAL_MS / 1000} s)`);
+  try {
+    const ksefNumber = await pollUntilCleared(invoiceUuid);
+    ok('KSeF CLEARED', `ksef_number=${ksefNumber ?? 'n/a'}`);
+  } catch (err) {
+    fail('KSeF clearance failed or timed out', err);
+    process.exit(1);
+  }
+
+  console.log('');
+  console.log('=== POC COMPLETE ✅ ===');
+  console.log('All steps confirmed:');
+  console.log('  upsertCustomer → issueInvoice → getInvoice → getClearanceStatus → sendToKsef → cleared');
+}
+
+main().catch((err: unknown) => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});

--- a/libs/integrations/infakt/tsconfig.json
+++ b/libs/integrations/infakt/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    { "path": "../../core" },
+    { "path": "../../shared" },
+    { "path": "../../plugin-sdk" }
+  ]
+}

--- a/libs/integrations/infakt/tsconfig.spec.json
+++ b/libs/integrations/infakt/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/__tests__/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Spike artifacts for Infakt invoicing integration — feasibility study + live sandbox E2E test.

**Changes:**
- `docs/plans/implementation-plan-infakt-feasibility-poc.md` — full feasibility artifact (§2) comparing Infakt vs KSeF-direct vs Subiekt across all InvoicingPort methods and sub-capabilities, plus live sandbox results (§10)

## Live Sandbox Results (2026-06-30)

Tested against `https://api.sandbox-infakt.pl/api/v3` (sandbox@openlinker.io):

| Step | Result |
|---|---|
| Auth (`X-inFakt-ApiKey`) | ✅ works |
| Client create (`POST /clients.json`) | ✅ 201, client uuid stored |
| Invoice create (`POST /invoices.json`) | ✅ 201, draft created |
| getInvoice by UUID | ✅ 200, full document |
| KSeF trigger (`POST /invoices/{uuid}/send_to_ksef.json`) | ✅ 200, request_uuid + pending |
| KSeF clearance poll | ✅ **`status: success`** after ~90 s, `ksef_number: 8201194127-20260630-693CFF400000-2D` |
| Invoice status after KSeF | ✅ flips to `sent` |

**Sandbox KSeF integration is active** — full `draft → submit → cleared` lifecycle confirmed E2E.

## Feasibility Verdict

**✅ CONFIRMED FEASIBLE** — `InvoicingPort + RegulatoryStatusReader + CorrectionIssuer` adapter profile.

No core changes required (ADR-026 holds). KSeF lifecycle works as OL→Infakt→KSeF chain:
OL calls `issueInvoice` + `send_to_ksef` → polls `getClearanceStatus` (`ksef_data.status`) → reads `ksef_number` on success.

## Spike scope

This PR is a spike only — not intended for merge to main. Branch will be closed after review.

Closes #1274