### PR TITLE
docs(release): four-axis versioning & release strategy ADR + RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,95 @@
+# Releasing OpenLinker
+
+How OpenLinker is versioned, tagged, and released. The *why* lives in
+[ADR-029](./docs/architecture/adrs/029-versioning-and-release-strategy.md); the
+npm-package contract lives in [PUBLIC_API.md](./PUBLIC_API.md). This document is
+the operational how-to.
+
+> **Status:** the product release line described here is the agreed target.
+> Tooling (release-please) and the first tag land in #1137; `/v1` API
+> versioning lands in #1133. Until those merge, there are no tags yet.
+
+## The four version axes
+
+OpenLinker has **four independent version numbers**, each on its own cadence.
+Don't conflate them.
+
+| Axis | Answers | Example | Moves when | Tool |
+|---|---|---|---|---|
+| **Product** | "What OpenLinker am I running?" | `v0.3.1` | you cut a release | release-please |
+| **Package (npm)** | "What `@openlinker/core` does my plugin pin?" | `@openlinker/core@0.4.0` | a published package changes | Changesets *(deferred)* |
+| **HTTP API** | "What endpoint contract do I call?" | `/v1/orders` | a breaking API change ships | NestJS `enableVersioning` |
+| **Demo** | "What's on the public demo?" | running `v0.3.1` | you cut a release | CD from tag |
+
+## Branching
+
+Trunk-based / GitHub Flow (see [CONTRIBUTING.md](./CONTRIBUTING.md)):
+
+- Branch off `main` per issue (`{issue}-{kebab-description}`), PR back, squash-merge.
+- `main` is always the release candidate.
+- `release/x.y` branches are created **lazily** — only the first time a fix must
+  be backported to an older release while `main` has moved on. Not pre-emptively.
+
+## Versioning policy
+
+- **Product** follows SemVer with the pre-1.0 `0.x` convention: while `0.x`, the
+  **minor** segment is the pseudo-major (breaking) and **patch** is the
+  pseudo-minor (additive). Promotion to `1.0.0` is when the public surface and
+  plugin SDK are committed (see [PUBLIC_API.md](./PUBLIC_API.md) § Versioning policy).
+- Conventional Commits drive the bump: `feat:` → minor, `fix:` → patch,
+  `feat!:` / `BREAKING CHANGE:` → major (pre-1.0: a `0.x` minor).
+- Tags are `vX.Y.Z` (and `vX.Y.Z-rc.N` for release candidates).
+
+## Cutting a product release
+
+release-please watches `main` and keeps an open **"chore: release X.Y.Z"** PR
+that accumulates the pending version bump + `CHANGELOG.md` from Conventional
+Commits.
+
+1. Merge feature/fix PRs to `main` as normal — nothing releases yet.
+2. When ready, **review and merge the release-please Release PR**.
+3. On merge, release-please writes `CHANGELOG.md`, bumps the version, and creates
+   the **`vX.Y.Z` tag + GitHub Release**.
+4. `cd.yml` fires on the tag → builds the image → deploys to **prod**
+   (`OL_DEMO_MODE` off) and **demo** (`OL_DEMO_MODE=true` + seed).
+
+> **CD trigger caveat:** a tag pushed by release-please's default `GITHUB_TOKEN`
+> will not trigger a *separate* workflow. Either run the deploy steps in the same
+> job (gated on `steps.release.outputs.release_created`), or authenticate
+> release-please with a PAT / GitHub App token so the tag push re-triggers
+> `on: push: tags`.
+
+## CHANGELOG
+
+- `CHANGELOG.md` (repo root) is the single product changelog, Keep-a-Changelog
+  style, **generated** by release-please from Conventional Commits. Don't
+  hand-edit it.
+- Per-package changelogs do not exist yet — they arrive with npm publishing
+  (Changesets), as separate files for a different audience (plugin authors).
+
+## Demo deployments
+
+- The demo runs a **known-good release tag**, the same image as production, with
+  `OL_DEMO_MODE=true` + the sandbox seed. It advances only when you cut a release.
+- **Never deploy the demo from `main`** — a green CI does not prove the app boots,
+  migrates, or seeds cleanly.
+- To preview unreleased work for an event, cut a **pre-release** tag
+  (`vX.Y.Z-rc.N`) from a commit you've verified and point the demo at it; prod
+  stays on the last stable tag.
+- Demo go-live depends on #1124 (read-only redaction) + #1127 (demo-session endpoint).
+
+## HTTP API versioning
+
+- Endpoints are served under `/v1` (`VersioningType.URI`, `defaultVersion: '1'`).
+- A breaking API change ships as `/v2` with `/v1` kept alive for a documented
+  deprecation window — it does **not** force a product major.
+- `GET /v1/health` reports the running product version + API version from a single
+  source, so the tag, the Release, the CHANGELOG, and the live process agree.
+
+## Package npm publishing (deferred)
+
+Not active yet. All 7 publishable packages are `private: true`. When the first
+publish becomes concrete (the trigger in [PUBLIC_API.md](./PUBLIC_API.md) §
+Future enforcement), adopt **Changesets** scoped to those packages — a `fixed`
+lockstep group for `plugin-sdk` + `core` + reference adapters — running beside
+release-please with a disjoint scope. The product `vX.Y.Z` line is unaffected.

--- a/docs/architecture/adrs/029-versioning-and-release-strategy.md
+++ b/docs/architecture/adrs/029-versioning-and-release-strategy.md
@@ -1,0 +1,47 @@
+# ADR-029: Versioning and release strategy (four axes)
+
+- **Status**: Accepted
+- **Date**: 2026-06-30
+- **Authors**: @piotrswierzy
+
+## Context
+
+OpenLinker has no decided release strategy: **0 git tags**, all workspace packages pinned `0.1.0`, `cd.yml` a disabled placeholder, the HTTP API a flat unversioned surface. The prior thinking is split across `#1137` (product tags + CHANGELOG), `#1133` (API versioning), `#596`/`#552`/[`PUBLIC_API.md`](../../../PUBLIC_API.md) (npm package SemVer, deferred), and `#1127` (demo mode as a runtime flag). "Versioning" here is **four independent axes** on different cadences; conflating them forces wrong couplings (e.g. making `@openlinker/core`'s npm version *be* the product version drags SDK majors onto unrelated app changes — Lerna's documented fixed-mode drawback). The repo is dual-natured: a deployable app (api + worker + web) **and** soon-to-publish libraries (plugin-sdk, core, adapters). It already mandates Conventional Commits and trunk-based/GitHub Flow.
+
+## Decision
+
+Adopt a **hybrid, sequenced** model — one product release line now, package npm versioning deferred — keeping the four axes separate (the Grafana precedent):
+
+1. **Product release (Axis 1)** — single lockstep product version: one `vX.Y.Z` tag + GitHub Release + one Keep-a-Changelog `CHANGELOG.md`, via **release-please** (root/single-package mode, Release-PR model, driven by Conventional Commits).
+2. **Package npm SemVer (Axis 2)** — unchanged from `PUBLIC_API.md`: **Changesets**, scoped to the 7 publishable packages, adopted at first npm publish; packages stay `private: true` until then. A `fixed` lockstep group for plugin-sdk + core + adapters is the eventual default.
+3. **HTTP API version (Axis 3)** — `/v1` URI versioning + a runtime version surface (`GET /v1/health`); slow cadence, `/v2` + deprecation window for breaks. Executed by `#1133`.
+4. **Demo deploy (Axis 4)** — demo runs a **known-good release tag** (same image as prod, `OL_DEMO_MODE=true`), never continuously from `main`; `-rc.N` tags preview unreleased work.
+
+release-please (product) and Changesets (npm) coexist with **disjoint scopes** — this does not contradict `PUBLIC_API.md`, which governs Axis 2 only. **Sequencing:** `#1133` → release-please plumbing (+ remove stale `develop` from `ci.yml`) → cut `v0.1.0` → demo CD from tag → (deferred) Changesets + npm publish.
+
+## Alternatives considered
+
+- **Changesets for everything (incl. product line).** Rejected: produces per-package changelogs, not the single product CHANGELOG self-hosters want, and adds per-PR intent-file friction on top of Conventional Commits we already write.
+- **Single global version across app + libs (pure lockstep).** Rejected: couples SDK SemVer to app releases — forces library majors for unrelated app changes.
+- **Continuous demo deploy from `main`.** Rejected: green CI doesn't prove the app boots/seeds; a tag is the breakage firewall.
+- **git-cliff / manual tags.** Rejected: changelog-only — no Release PR, tagging, or CD trigger; rebuilds release-please by hand.
+- **git-flow (`develop`/`release` branches).** Rejected: trunk-based is already codified; `release/x.y` is introduced lazily at first backport.
+
+## Consequences
+
+**Pros:**
+- One unambiguous "what am I running" answer for self-hosters; unblocks the awesome-selfhosted tagged-release gate.
+- Zero per-PR friction (release-please reads existing commits); axes evolve independently.
+
+**Cons / trade-offs:**
+- Two release tools long-term (release-please + Changesets) — acceptable while scopes stay disjoint.
+- release-please's tag won't trigger a separate workflow under the default `GITHUB_TOKEN`; needs a PAT/App token or in-job deploy.
+
+**Migration path:**
+- `#1133` lands `/v1` first; then release-please + `RELEASING.md`; then `v0.1.0`; Changesets at first publish per the `PUBLIC_API.md` trigger.
+
+## References
+
+- Related issues: #1277, #1137, #1133, #596, #552, #1127
+- Primary docs: [PUBLIC_API.md](../../../PUBLIC_API.md), [RELEASING.md](../../../RELEASING.md)
+- Related ADRs: [ADR-021](./021-third-party-native-inbound-webhook-ingestion.md)

--- a/docs/architecture/adrs/029-versioning-and-release-strategy.md
+++ b/docs/architecture/adrs/029-versioning-and-release-strategy.md
@@ -40,6 +40,20 @@ release-please (product) and Changesets (npm) coexist with **disjoint scopes** �
 **Migration path:**
 - `#1133` lands `/v1` first; then release-please + `RELEASING.md`; then `v0.1.0`; Changesets at first publish per the `PUBLIC_API.md` trigger.
 
+## Worked scenarios
+
+How the axes behave in practice (the throughline: product version moves when you merge a release PR; demo only ever runs a tag; API and package versions run on their own clocks):
+
+| Scenario | What happens |
+|---|---|
+| **Feature ships** — `feat:`/`fix:` PRs merge to `main` | release-please accumulates a "release 0.3.0" PR; merging it tags `v0.3.0` → CD deploys the image to prod (flag off) + demo (flag on). |
+| **`main` breaks** after a green-CI merge | Demo is unaffected — it runs the last tag, not `main`. Fix forward; demo advances only at the next release. |
+| **Urgent patch** while `main` carries unfinished work | Lazily branch `release/0.3` from tag `v0.3.0`, commit the fix there → `v0.3.1`; forward-port to `main`. |
+| **Breaking API change** | Add `/v2`, keep `/v1` for a deprecation window. Product version moves on its own (e.g. `v0.6.0`); the integrator on `/v1` isn't broken. |
+| **First npm publish** — a 3rd-party plugin pins `@openlinker/core` | Flip the publishable packages `private:false`, adopt Changesets (Axis 2). Core then versions via Changesets (`core@0.2.0`) while the product line keeps moving via release-please — disjoint scopes. |
+| **Self-hoster files a bug** | `GET /v1/health` → `{ version: "0.3.0", api: "v1" }`; you know the exact code + contract they ran. |
+| **Demo must preview unreleased work** (conference) | Cut `v0.4.0-rc.1` from a verified commit, point demo at it; prod stays on `v0.3.1`. Still a deliberate tag, never raw `main`. |
+
 ## References
 
 - Related issues: #1277, #1137, #1133, #596, #552, #1127

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -118,5 +118,6 @@ One pointer per section, identical format every time.
 | [ADR-026](./026-country-agnostic-invoicing-domain.md) | Country-agnostic invoicing domain with capability decomposition | Accepted | 2026-06-16 |
 | [ADR-027](./027-order-status-writeback-capability-and-relay.md) | Order status writeback capability (event-as-data) & lifecycle relay | Accepted | 2026-06-22 |
 | [ADR-028](./028-order-cancellation-stock-restore.md) | Order-cancellation-observe hook → marketplace stock-restore | Proposed | 2026-06-22 |
+| [ADR-029](./029-versioning-and-release-strategy.md) | Versioning and release strategy (four axes) | Accepted | 2026-06-30 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*


### PR DESCRIPTION
## What & why

Captures the decided versioning/release strategy as **ADR-029** plus an operational **`RELEASING.md`**. The prior thinking was scattered across `#1137` (product tags + CHANGELOG), `#1133` (API versioning), `#596`/`#552`/`PUBLIC_API.md` (npm SemVer, deferred), and `#1127` (demo mode). This PR gives those a single shared decision record.

**Docs-only.** No tooling install or workflow changes — release-please + first tag land in `#1137`, `/v1` API versioning in `#1133`.

## The decision (four independent axes, kept separate — Grafana precedent)

1. **Product release** — single lockstep `vX.Y.Z` tag + one Keep-a-Changelog `CHANGELOG.md` via **release-please** (Conventional Commits, Release-PR model).
2. **Package npm SemVer** — **Changesets**, scoped to the 7 publishable packages, deferred to first publish. Unchanged from `PUBLIC_API.md`; the ADR reconciles the split (disjoint scope → no contradiction).
3. **HTTP API** — `/v1` URI versioning + a runtime version surface (`GET /v1/health`).
4. **Demo deploy** — runs a **known-good release tag**, never continuously from `main` (green CI ≠ proven-bootable); `-rc.N` tags preview unreleased work.

Branching stays trunk-based/GitHub Flow (already codified); the only follow-up cleanup is dropping the stale `develop` ref from `ci.yml` (in `#1137`).

**Sequencing:** `#1133` → release-please plumbing → cut `v0.1.0` → demo CD from tag → (deferred) Changesets + npm publish.

## Files

- `docs/architecture/adrs/029-versioning-and-release-strategy.md` (new)
- `RELEASING.md` (new, repo root)
- `docs/architecture/adrs/README.md` (index row)

## Testing

- `pnpm check:invariants` — green (incl. `check-repo-urls`).
- Pre-commit gate passed (docs-only → smart-test correctly skipped).

## Follow-ups (separate issues, reference this ADR)

- `#1133` — `/v1` URI versioning + version endpoint (blocks the first tag).
- `#1137` — release-please + `cd.yml` token/trigger + `ci.yml` `develop` cleanup + first `v0.1.0` tag.
- `#552` — Changesets + npm publish (deferred).

Closes #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)