### PR TITLE
feat(infakt): register Infakt plugin in API/worker + wire webhook ingestion

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,6 +43,7 @@
     "@openlinker/integrations-allegro": "workspace:*",
     "@openlinker/integrations-dpd-polska": "workspace:*",
     "@openlinker/integrations-erli": "workspace:*",
+    "@openlinker/integrations-infakt": "workspace:*",
     "@openlinker/integrations-ksef": "workspace:*",
     "@openlinker/integrations-inpost": "workspace:*",
     "@openlinker/integrations-prestashop": "workspace:*",

--- a/apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts
+++ b/apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts
@@ -22,11 +22,11 @@ import { ApiProperty } from '@nestjs/swagger';
 import type {
   InvoiceFailureCode,
   InvoiceFailureMode,
-} from '@openlinker/core/invoicing';
+
+  InvoiceRecord} from '@openlinker/core/invoicing';
 import {
   InvoiceFailureCodeValues,
   InvoiceFailureModeValues,
-  InvoiceRecord,
   InvoiceStatus,
   InvoiceStatusValues,
   RegulatoryStatus,

--- a/apps/api/src/plugins.ts
+++ b/apps/api/src/plugins.ts
@@ -36,6 +36,7 @@ import { WooCommerceIntegrationModule } from '@openlinker/integrations-woocommer
 import { ErliIntegrationModule } from '@openlinker/integrations-erli';
 import { KsefIntegrationModule } from '@openlinker/integrations-ksef';
 import { SubiektIntegrationModule } from '@openlinker/integrations-subiekt';
+import { InfaktIntegrationModule } from '@openlinker/integrations-infakt';
 
 export const apiPlugins: PluginEntry[] = [
   PrestashopIntegrationModule,
@@ -49,4 +50,6 @@ export const apiPlugins: PluginEntry[] = [
   // #753: Subiekt nexo invoicing adapter — registered so the host can resolve
   // the 'Invoicing' capability for subiekt connections.
   SubiektIntegrationModule,
+  // #1281: Infakt accounting invoicing adapter (KSeF submitted via Infakt).
+  InfaktIntegrationModule,
 ];

--- a/apps/api/src/webhooks/application/interfaces/webhook.service.interface.ts
+++ b/apps/api/src/webhooks/application/interfaces/webhook.service.interface.ts
@@ -15,14 +15,18 @@ export interface IWebhookService {
    * Orchestrates the complete webhook processing flow:
    * 1. Resolve the per-provider decoder (default = OL-HMAC + WebhookRequestDto)
    * 2. Connection gate (exists, active, platformType matches)
-   * 3. Verify signature via the decoder; replay-check the normalized timestamp
-   * 4. Decode the body → route | ignore (202, no publish) | reject (400)
-   * 5. Dedup gate → publish event → record delivery
+   * 3. Subscription-verification handshake — if detected, return its echo
+   *    body immediately (no verify/dedup/publish)
+   * 4. Verify signature via the decoder; replay-check the normalized timestamp
+   * 5. Decode the body → route | ignore (202, no publish) | reject (400)
+   * 6. Dedup gate → publish event → record delivery
    *
    * @param provider - Provider identifier (e.g., 'prestashop', 'inpost')
    * @param connectionId - Connection identifier (UUID)
    * @param rawBody - Raw request body bytes (the decoder verifies + parses these)
    * @param headers - Request headers (provider-specific signature/timestamp/topic)
+   * @returns the handshake echo body when the request is a subscription
+   *   verification ping; otherwise resolves with no value
    * @throws WebhookAuthenticationException if signature/connection is invalid (401)
    * @throws WebhookReplayException if timestamp is out of window (401)
    * @throws WebhookDecodeException if the body can't be decoded (400)
@@ -32,5 +36,5 @@ export interface IWebhookService {
     connectionId: string,
     rawBody: Buffer,
     headers: Record<string, string>
-  ): Promise<void>;
+  ): Promise<Record<string, unknown> | void>;
 }

--- a/apps/api/src/webhooks/application/services/webhook.service.spec.ts
+++ b/apps/api/src/webhooks/application/services/webhook.service.spec.ts
@@ -134,6 +134,40 @@ describe('WebhookService (ADR-021 decoder dispatch + #711 dedup/recovery)', () =
     service = module.get(WebhookService);
   });
 
+  describe('subscription-verification handshake', () => {
+    it('returns the handshake echo body and short-circuits before verify/dedup/publish', async () => {
+      const handshakeDecoder: jest.Mocked<InboundWebhookDecoderPort> = {
+        ...decoder,
+        detectHandshake: jest.fn().mockReturnValue({ verification_code: 'abc123' }),
+      };
+      decoderRegistry.get.mockReturnValue(handshakeDecoder);
+
+      const result = await service.processWebhook(provider, connectionId, rawBody, headers);
+
+      expect(result).toEqual({ verification_code: 'abc123' });
+      expect(handshakeDecoder.verify).not.toHaveBeenCalled();
+      expect(deliveryRepository.insertIfNew).not.toHaveBeenCalled();
+      expect(eventPublisher.publishInboundWebhook).not.toHaveBeenCalled();
+    });
+
+    it('proceeds to verify when detectHandshake returns null', async () => {
+      const nonHandshakeDecoder: jest.Mocked<InboundWebhookDecoderPort> = {
+        ...decoder,
+        detectHandshake: jest.fn().mockReturnValue(null),
+      };
+      decoderRegistry.get.mockReturnValue(nonHandshakeDecoder);
+      deliveryRepository.insertIfNew.mockResolvedValue({
+        isNew: true,
+        delivery: makeDelivery({ eventId: 'e1', provider, connectionId }),
+      });
+
+      const result = await service.processWebhook(provider, connectionId, rawBody, headers);
+
+      expect(result).toBeUndefined();
+      expect(nonHandshakeDecoder.verify).toHaveBeenCalled();
+    });
+  });
+
   describe('decoder dispatch + three-state decode', () => {
     it('publishes a routed event when the decoder verifies + routes and the row is new', async () => {
       deliveryRepository.insertIfNew.mockResolvedValue({

--- a/apps/api/src/webhooks/application/services/webhook.service.ts
+++ b/apps/api/src/webhooks/application/services/webhook.service.ts
@@ -17,6 +17,7 @@ import { DefaultWebhookDecoder } from '../decoders/default-webhook-decoder';
 import { WebhookAuthenticationException } from '../errors/webhook-authentication.exception';
 import { WebhookDecodeException } from '../errors/webhook-decode.exception';
 import type { InboundWebhookEvent } from '@openlinker/core/events';
+import type { InboundWebhookDecoderPort } from '@openlinker/core/integrations';
 import {
   InboundWebhookDecoderRegistryService,
   INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
@@ -58,13 +59,24 @@ export class WebhookService implements IWebhookService {
     connectionId: string,
     rawBody: Buffer,
     headers: Record<string, string>
-  ): Promise<void> {
+  ): Promise<Record<string, unknown> | void> {
     // Resolve the provider's decoder (ADR-021); fall back to the host's
     // OL-HMAC + WebhookRequestDto default for OL-module providers.
-    const decoder = this.decoderRegistry.get(provider) ?? this.defaultDecoder;
+    const decoder: InboundWebhookDecoderPort =
+      this.decoderRegistry.get(provider) ?? this.defaultDecoder;
 
     // Connection gate (provider-agnostic): exists, active, platformType matches.
     await this.authService.assertConnectionUsable(provider, connectionId);
+
+    // Subscription-verification handshake (e.g. Infakt's `verification_code`
+    // echo) — runs BEFORE signature verification: the ping precedes any
+    // signed traffic. Short-circuits with the exact body to echo; no
+    // verify/dedup/publish for a handshake request.
+    const handshakeBody = decoder.detectHandshake?.(rawBody, headers);
+    if (handshakeBody) {
+      this.logger.log(`Webhook handshake detected: provider=${provider}, connectionId=${connectionId}`);
+      return handshakeBody;
+    }
 
     // Verify the signature via the decoder (host supplies the per-connection
     // secret). Then replay-check the decoder-normalized timestamp. Order is

--- a/apps/api/src/webhooks/http/webhook.controller.ts
+++ b/apps/api/src/webhooks/http/webhook.controller.ts
@@ -70,6 +70,10 @@ export class WebhookController {
     @Param('connectionId') connectionId: string,
     @Headers() headers: Record<string, string>,
     @Req() req: RequestWithRawBody,
+    // Only usage of the raw Response object in this controller — needed to
+    // override the route's default 202 with 200 on the handshake-echo path
+    // (see the res.status(HttpStatus.OK) call below). Passthrough mode still
+    // lets Nest serialize the returned body as normal.
     @Res({ passthrough: true }) res: Response,
   ): Promise<Record<string, unknown> | void> {
     // No `@Body() WebhookRequestDto` — the body shape is the provider's, not

--- a/apps/api/src/webhooks/http/webhook.controller.ts
+++ b/apps/api/src/webhooks/http/webhook.controller.ts
@@ -67,7 +67,7 @@ export class WebhookController {
     @Param('connectionId') connectionId: string,
     @Headers() headers: Record<string, string>,
     @Req() req: RequestWithRawBody,
-  ): Promise<void> {
+  ): Promise<Record<string, unknown> | void> {
     // No `@Body() WebhookRequestDto` — the body shape is the provider's, not
     // OL's (ADR-021). The per-provider decoder (resolved in WebhookService)
     // verifies + parses the raw bytes; the host OL-module default decoder still
@@ -100,7 +100,7 @@ export class WebhookController {
     }
 
     try {
-      await this.webhookService.processWebhook(provider, connectionId, rawBody, headers);
+      return await this.webhookService.processWebhook(provider, connectionId, rawBody, headers);
     } catch (error) {
       // Map domain exceptions to HTTP exceptions
       if (error instanceof WebhookDecodeException) {

--- a/apps/api/src/webhooks/http/webhook.controller.ts
+++ b/apps/api/src/webhooks/http/webhook.controller.ts
@@ -13,6 +13,7 @@ import {
   Param,
   Headers,
   Req,
+  Res,
   HttpCode,
   HttpStatus,
   BadRequestException,
@@ -20,6 +21,7 @@ import {
   NotFoundException,
   PayloadTooLargeException,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiHeader } from '@nestjs/swagger';
 import { Public } from '../../auth/decorators/public.decorator';
 import { WebhookService } from '../application/services/webhook.service';
@@ -57,6 +59,7 @@ export class WebhookController {
       'Provider-specific webhook signature. OL-module providers send `sha256=<hex>`; third-party providers use their own scheme + header (e.g. InPost `x-inpost-signature`, base64 HMAC). Resolved per-provider by the registered decoder.',
     required: false,
   })
+  @ApiResponse({ status: 200, description: 'Subscription-verification handshake echoed back' })
   @ApiResponse({ status: 202, description: 'Webhook accepted and queued for processing' })
   @ApiResponse({ status: 400, description: 'Invalid request payload or malformed data' })
   @ApiResponse({ status: 401, description: 'Invalid signature or timestamp out of window' })
@@ -67,6 +70,7 @@ export class WebhookController {
     @Param('connectionId') connectionId: string,
     @Headers() headers: Record<string, string>,
     @Req() req: RequestWithRawBody,
+    @Res({ passthrough: true }) res: Response,
   ): Promise<Record<string, unknown> | void> {
     // No `@Body() WebhookRequestDto` — the body shape is the provider's, not
     // OL's (ADR-021). The per-provider decoder (resolved in WebhookService)
@@ -100,7 +104,15 @@ export class WebhookController {
     }
 
     try {
-      return await this.webhookService.processWebhook(provider, connectionId, rawBody, headers);
+      const result = await this.webhookService.processWebhook(provider, connectionId, rawBody, headers);
+      if (result !== undefined) {
+        // Handshake echo — verified live against Infakt's own "Zweryfikuj"
+        // button (2026-07-01): it reports "could not verify" on our default
+        // 202, but accepts 200. Every other outcome (route/ignore) keeps the
+        // route's default 202 via @HttpCode above.
+        res.status(HttpStatus.OK);
+      }
+      return result;
     } catch (error) {
       // Map domain exceptions to HTTP exceptions
       if (error instanceof WebhookDecodeException) {

--- a/apps/api/test/jest-integration.cjs
+++ b/apps/api/test/jest-integration.cjs
@@ -105,6 +105,14 @@ module.exports = {
       __dirname,
       '../../../libs/integrations/dpd-polska/src/$1',
     ),
+    '^@openlinker/integrations-infakt$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/infakt/src/index.ts',
+    ),
+    '^@openlinker/integrations-infakt/(.*)$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/infakt/src/$1',
+    ),
     '^@openlinker/test-kit$': path.resolve(__dirname, '../../../libs/test-kit/src/index.ts'),
     '^@openlinker/test-kit/(.*)$': path.resolve(__dirname, '../../../libs/test-kit/src/$1'),
   },

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -28,6 +28,7 @@
     "@openlinker/integrations-allegro": "workspace:*",
     "@openlinker/integrations-dpd-polska": "workspace:*",
     "@openlinker/integrations-erli": "workspace:*",
+    "@openlinker/integrations-infakt": "workspace:*",
     "@openlinker/integrations-ksef": "workspace:*",
     "@openlinker/integrations-inpost": "workspace:*",
     "@openlinker/integrations-prestashop": "workspace:*",

--- a/apps/worker/src/plugins.ts
+++ b/apps/worker/src/plugins.ts
@@ -37,6 +37,7 @@ import { DpdIntegrationModule } from '@openlinker/integrations-dpd-polska';
 import { ErliIntegrationModule } from '@openlinker/integrations-erli';
 import { KsefIntegrationModule } from '@openlinker/integrations-ksef';
 import { SubiektIntegrationModule } from '@openlinker/integrations-subiekt';
+import { InfaktIntegrationModule } from '@openlinker/integrations-infakt';
 
 export const workerPlugins: PluginEntry[] = [
   PrestashopIntegrationModule,
@@ -53,4 +54,7 @@ export const workerPlugins: PluginEntry[] = [
   // #753: resolve the Subiekt 'Invoicing' capability when issuance is driven
   // from the worker (mirrors WooCommerce/InPost dual registration).
   SubiektIntegrationModule,
+  // #1281: resolve the Infakt 'Invoicing' capability when issuance/reconcile
+  // jobs run from the worker (mirrors Subiekt/KSeF dual registration).
+  InfaktIntegrationModule,
 ];

--- a/apps/worker/test/jest-integration.cjs
+++ b/apps/worker/test/jest-integration.cjs
@@ -101,5 +101,13 @@ module.exports = {
       __dirname,
       '../../../libs/integrations/dpd-polska/src/$1',
     ),
+    '^@openlinker/integrations-infakt$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/infakt/src/index.ts',
+    ),
+    '^@openlinker/integrations-infakt/(.*)$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/infakt/src/$1',
+    ),
   },
 };

--- a/docs/plans/implementation-plan-infakt-registration-webhook-routing.md
+++ b/docs/plans/implementation-plan-infakt-registration-webhook-routing.md
@@ -1,0 +1,114 @@
+# Implementation Plan — Infakt plugin registration + webhook routing (#1281)
+
+## 1. Goal / non-goals
+
+Wire the already-hardened Infakt plugin (#1280, PR #1292, not yet merged — this
+branch is stacked on `1280-infakt-plugin-hardening-tests`) into the running API,
+and connect Infakt's inbound webhooks (KSeF clearance notifications relayed by
+Infakt) to OL's webhook ingestion pipeline.
+
+Non-goals: `WebhookProvisioningPort` (Infakt webhook setup is UI-only, per
+issue scope), FE plugin (#1282), docs/ADR (#1283).
+
+## 2. Layer classification
+
+Integration (`libs/integrations/infakt`) + thin core extension
+(`libs/core/src/integrations`, `libs/core/src/sync` — additive domain value +
+routing case) + host wiring (`apps/api`).
+
+## 3. Key finding from research
+
+- `libs/integrations/infakt` only exists on `1280-infakt-plugin-hardening-tests`
+  (unmerged). This branch is based on it per user instruction; PR opens
+  against `main` as **draft** and will show #1280's diff until #1292 merges.
+- Registering a `WebhookEventTranslatorPort` alone is not enough: Infakt's
+  webhook is **not** OL-enveloped and uses its own HMAC scheme + a
+  verification handshake (`{"verification_code":...}` echo) — this is exactly
+  the third-party-native case ADR-021's `InboundWebhookDecoderPort` exists for
+  (see InPost as the precedent).
+- The existing `InboundEventDomainValues` closed union
+  (`order | inventory | product | shipment`) has no `invoicing` value, and
+  `InboundRoutingPolicyService` has no case for it. Reconciling clearance
+  status already has a job: `invoicing.regulatoryStatus.reconcile`
+  (page-scan over non-terminal invoices, no target-id payload) — a webhook
+  is a **trigger, not the source of truth** (matches the InPost/webhook
+  philosophy already documented in `architecture-overview.md`), so routing
+  the Infakt event to this existing reconcile job (rather than inventing a
+  by-id job) is the smallest correct change.
+- No existing mechanism lets a decoder produce a custom response body
+  (needed for the verification-code echo). Adding one optional method to
+  `InboundWebhookDecoderPort` is the minimal extension; it's additive so
+  `DefaultWebhookDecoder` / InPost's decoder need no change (default to
+  no-op via `?.()`).
+
+## 4. Steps
+
+1. **Dependency wiring**
+   - `apps/api/package.json`, `apps/worker/package.json`: add
+     `"@openlinker/integrations-infakt": "workspace:*"`.
+   - `apps/api/src/plugins.ts`: import + append `InfaktIntegrationModule`.
+   - `apps/api/test/jest-integration.cjs`: add the two moduleNameMapper
+     entries (mirrors the ksef block).
+
+2. **Handshake extension (core, additive)**
+   - `libs/core/src/integrations/domain/ports/inbound-webhook-decoder.port.ts`:
+     add optional `detectHandshake?(rawBody: Buffer, headers: Record<string,
+     string>): Record<string, unknown> | null` — runs before signature
+     verification (a subscription-verification ping predates any real
+     traffic and isn't itself required to be signed by Infakt's documented
+     flow).
+   - `apps/api/src/webhooks/application/services/webhook.service.ts`: after
+     the connection gate, call `decoder.detectHandshake?.(rawBody, headers)`;
+     if it returns non-null, return it immediately (no verify/dedup/publish).
+   - `IWebhookService.processWebhook` return type: `Promise<Record<string,
+     unknown> | void>`.
+   - `WebhookController.receiveWebhook`: return type updated to match;
+     NestJS serializes the returned object as the JSON body under the
+     existing `@HttpCode(ACCEPTED)`.
+
+3. **`invoicing` inbound domain (core, additive)**
+   - `libs/core/src/integrations/domain/types/canonical-inbound-event.types.ts`:
+     add `'invoicing'` to `InboundEventDomainValues`.
+   - `libs/core/src/sync/application/services/inbound-routing-policy.service.ts`:
+     add a `case 'invoicing':` → `{ jobType: 'invoicing.regulatoryStatus.reconcile',
+     requiredCapability: 'Invoicing', payload: { schemaVersion: 1, limit: 50 }
+     satisfies RegulatoryStatusReconcilePayloadV1 }`.
+
+4. **Infakt decoder + translator** (`libs/integrations/infakt/src/infrastructure/adapters/`)
+   - `infakt-inbound-webhook-decoder.adapter.ts` —
+     `InfaktInboundWebhookDecoderAdapter implements InboundWebhookDecoderPort`:
+     wraps the existing `InfaktWebhookTranslator` (verify via HMAC-SHA256 hex
+     over raw body per its `verifySignature`; `detectHandshake` via its
+     `getVerificationEcho`; `extractEnvelope` via its `parse`, mapping to
+     `{eventId: event.uuid, eventType: event.name, occurredAt:
+     event.created_at, objectType: 'invoice', externalId:
+     resource.invoice_uuid ?? event.uuid, payload: resource}`).
+   - `infakt-webhook-event-translator.adapter.ts` —
+     `InfaktWebhookEventTranslatorAdapter implements WebhookEventTranslatorPort`:
+     `translate` returns `{domain: 'invoicing', externalId, eventType,
+     occurredAt, payload}` for `objectType === 'invoice'`, else `null`.
+   - Register both in `infakt-plugin.ts`'s `register(host)`:
+     `host.inboundWebhookDecoderRegistry.register(platformType, decoder)`,
+     `host.webhookEventTranslatorRegistry.register(adapterKey, translator)`.
+
+5. **Tests**
+   - Unit specs for the two new adapters (happy path + malformed/unsigned
+     rejection + handshake echo).
+   - Extend `inbound-routing-policy.service.spec.ts` with the new
+     `'invoicing'` case.
+   - Extend `webhook.service.spec.ts` with a handshake-short-circuit case.
+
+6. **Quality gate**: `pnpm lint && pnpm type-check && pnpm test`
+   (scoped to affected packages given resource constraints; full run before
+   PR).
+
+## 5. Risks / open questions
+
+- Exact HTTP status Infakt expects for the verification echo is unconfirmed
+  (POC never shipped a controller for it) — using the existing `202` path.
+  Flagged in the PR description as a manual-verification item, consistent
+  with #1292's own test-plan checkboxes.
+- `invoicing.regulatoryStatus.reconcile`'s `limit: 50` on webhook-triggered
+  runs is a nudge, not a guarantee the specific invoice is within that page —
+  acceptable because the scheduled reconcile already drains the full
+  frontier; the webhook only shortens latency.

--- a/libs/core/src/integrations/domain/ports/inbound-webhook-decoder.port.ts
+++ b/libs/core/src/integrations/domain/ports/inbound-webhook-decoder.port.ts
@@ -42,4 +42,15 @@ export interface InboundWebhookDecoderPort {
    * (malformed). Must be total — never throw unbounded.
    */
   extractEnvelope(rawBody: Buffer, headers: Record<string, string>): DecodeResult;
+
+  /**
+   * Detect a provider-native subscription-verification handshake (e.g.
+   * Infakt's `{"verification_code": "..."}` ping the endpoint must echo back
+   * to activate the webhook) and return the exact JSON body to echo, or
+   * `null` if this isn't a handshake request. Runs BEFORE `verify` — a
+   * handshake ping precedes any signed traffic and predates a rotated
+   * secret being meaningful. Optional: providers without a handshake step
+   * omit it, and the host skips straight to `verify`.
+   */
+  detectHandshake?(rawBody: Buffer, headers: Record<string, string>): Record<string, unknown> | null;
 }

--- a/libs/core/src/integrations/domain/types/canonical-inbound-event.types.ts
+++ b/libs/core/src/integrations/domain/types/canonical-inbound-event.types.ts
@@ -17,7 +17,13 @@
  * @module libs/core/src/integrations/domain/types
  */
 
-export const InboundEventDomainValues = ['order', 'inventory', 'product', 'shipment'] as const;
+export const InboundEventDomainValues = [
+  'order',
+  'inventory',
+  'product',
+  'shipment',
+  'invoicing',
+] as const;
 
 export type InboundEventDomain = (typeof InboundEventDomainValues)[number];
 

--- a/libs/core/src/sync/application/services/__tests__/inbound-routing-policy.service.spec.ts
+++ b/libs/core/src/sync/application/services/__tests__/inbound-routing-policy.service.spec.ts
@@ -119,6 +119,35 @@ describe('InboundRoutingPolicyService', () => {
     );
   });
 
+  it('should route an invoicing event to invoicing.regulatoryStatus.reconcile gated on Invoicing', async () => {
+    const outcome = await service.route(
+      event({ domain: 'invoicing', eventType: 'send_to_ksef_success', externalId: 'inv-1' }),
+      connection(['Invoicing']),
+      ['Invoicing'],
+      'evt-9'
+    );
+
+    expect(outcome.status).toBe('enqueued');
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobType: 'invoicing.regulatoryStatus.reconcile',
+        payload: { schemaVersion: 1, limit: 50 },
+      })
+    );
+  });
+
+  it('should not enqueue an invoicing event when Invoicing is not enabled', async () => {
+    const outcome = await service.route(
+      event({ domain: 'invoicing', eventType: 'send_to_ksef_success' }),
+      connection([]),
+      ['Invoicing'],
+      'evt-9'
+    );
+
+    expect(outcome).toEqual({ status: 'ungated', domain: 'invoicing', requiredCapability: 'Invoicing' });
+    expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+  });
+
   it('should not enqueue a shipment event when ShippingProviderManager is not enabled', async () => {
     const outcome = await service.route(
       event({ domain: 'shipment', eventType: 'tracking' }),

--- a/libs/core/src/sync/application/services/inbound-routing-policy.service.ts
+++ b/libs/core/src/sync/application/services/inbound-routing-policy.service.ts
@@ -39,6 +39,15 @@ import type {
   MasterInventorySyncByExternalIdPayloadV1,
   MasterProductSyncByExternalIdPayloadV1,
 } from '../../domain/types/master-job-payloads.types';
+import type { RegulatoryStatusReconcilePayloadV1 } from '../../domain/types/invoicing-job-payloads.types';
+
+/**
+ * Page size for the reconcile job a webhook-triggered `invoicing` event
+ * enqueues. The webhook is a trigger, not the source of truth (#1281,
+ * mirrors the InPost/webhook philosophy): it only shortens the latency
+ * until the next scheduled reconcile drains the full non-terminal frontier.
+ */
+const INVOICING_WEBHOOK_RECONCILE_LIMIT = 50;
 
 /**
  * Local mirror of the order-domain event vocabulary. `OrderFeedEventType` is
@@ -151,6 +160,20 @@ export class InboundRoutingPolicyService implements IInboundRoutingPolicyService
             schemaVersion: 1,
             externalId: event.externalId,
           } satisfies MarketplaceShipmentSyncByExternalIdPayloadV1,
+        };
+      case 'invoicing':
+        // No by-id job exists (or is needed) — a clearance-status webhook
+        // (e.g. Infakt relaying a KSeF update) is a trigger, not the source
+        // of truth. It nudges the existing page-scan reconciler rather than
+        // inventing a by-id job; the scheduled run still drains the full
+        // non-terminal frontier regardless.
+        return {
+          jobType: 'invoicing.regulatoryStatus.reconcile',
+          requiredCapability: 'Invoicing',
+          payload: {
+            schemaVersion: 1,
+            limit: INVOICING_WEBHOOK_RECONCILE_LIMIT,
+          } satisfies RegulatoryStatusReconcilePayloadV1,
         };
       default: {
         // Exhaustive — `domain` is a closed union; this guards future additions.

--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -47,11 +47,18 @@ export interface InfaktInvoice {
   number: string | null;
   kind: InfaktInvoiceKind;
   status: string;
-  // Infakt returns monetary fields as "amount currency" strings (e.g. "123.00 PLN"),
-  // never plain numbers — confirmed against the v3 vat_invoice schema (#1292 review).
-  gross_price: string;
-  net_price: string;
-  tax_price: string;
+  // Infakt's public API represents every monetary field as a PLAIN INTEGER
+  // count of groszy (1 PLN = 100 grosze) — confirmed both live against the
+  // real sandbox (a 349.00 PLN order landed as gross_price=348, i.e. 3.48 PLN,
+  // when this adapter previously sent "amount currency" decimal strings) and
+  // against the official MCP-exposed API schema (`unit_net_price`/`net_price`/
+  // `gross_price` are `integer`, described as "w groszach"). The earlier
+  // "amount currency" string assumption (#1292 review) was wrong and caused
+  // every issued invoice to understate its legal/KSeF amount ~100x (#1293
+  // review, live E2E finding).
+  gross_price: number;
+  net_price: number;
+  tax_price: number;
   payment_method: string;
   invoice_date: string | null;
   sale_date: string | null;
@@ -75,11 +82,11 @@ export interface InfaktInvoiceService {
   tax_symbol: string;
   quantity: number;
   unit: string | null;
-  // Same "amount currency" string format as InfaktInvoice's top-level totals.
-  unit_net_price: string;
-  net_price: string;
-  tax_price: string;
-  gross_price: string;
+  // Same plain-integer-groszy format as InfaktInvoice's top-level totals.
+  unit_net_price: number;
+  net_price: number;
+  tax_price: number;
+  gross_price: number;
   correction: boolean | null;
   group: number | null;
 }

--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -84,16 +84,20 @@ export interface InfaktInvoiceService {
   group: number | null;
 }
 
-/** Client (buyer) from GET /clients/{uuid}.json or POST /clients.json */
+/**
+ * Client (buyer) from GET /clients/{uuid}.json or POST /clients.json.
+ * Field names verified live against the sandbox response (2026-07-01) —
+ * `company_name` / `postal_code`, not `name` / `post_code`.
+ */
 export interface InfaktClient {
   id: number;
   uuid: string;
-  name: string;
+  company_name: string;
   nip: string | null;
   email: string | null;
   city: string | null;
   street: string | null;
-  post_code: string | null;
+  postal_code: string | null;
   country: string | null;
 }
 

--- a/libs/integrations/infakt/src/index.ts
+++ b/libs/integrations/infakt/src/index.ts
@@ -16,3 +16,8 @@ export type { InfaktInvoice, InfaktClient, InfaktKsefData, InfaktKsefStatus } fr
 export { InfaktConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/infakt-connection-config-shape-validator.adapter';
 export { InfaktConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/infakt-connection-credentials-shape-validator.adapter';
 export { InfaktRetryClassifierAdapter } from './infrastructure/adapters/infakt-retry-classifier.adapter';
+
+// Webhook ingress (#1281, ADR-021/ADR-015) — exported so host-side tests can
+// register the real adapters.
+export { InfaktInboundWebhookDecoderAdapter } from './infrastructure/adapters/infakt-inbound-webhook-decoder.adapter';
+export { InfaktWebhookEventTranslatorAdapter } from './infrastructure/adapters/infakt-webhook-event-translator.adapter';

--- a/libs/integrations/infakt/src/infakt-integration.module.ts
+++ b/libs/integrations/infakt/src/infakt-integration.module.ts
@@ -6,10 +6,10 @@
  * `createNestAdapterModule` directly: the helper imports the
  * integrations/sync/identifier-mapping modules, builds the `HostServices`
  * bag from DI, and registers the manifest + factory + the descriptor's
- * side-registrations (config/credentials validators, retry classifier).
+ * side-registrations (config/credentials validators, retry classifier,
+ * inbound webhook decoder + translator — #1281).
  *
- * Not yet wired into `apps/api/src/plugins.ts` / `apps/worker/src/plugins.ts`
- * — that registration + webhook routing is #1281.
+ * Wired into `apps/api/src/plugins.ts` and `apps/worker/src/plugins.ts`.
  *
  * @module libs/integrations/infakt/src
  */

--- a/libs/integrations/infakt/src/infakt-plugin.ts
+++ b/libs/integrations/infakt/src/infakt-plugin.ts
@@ -27,6 +27,8 @@ import { InfaktAdapterFactory } from './application/infakt-adapter.factory';
 import { InfaktConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/infakt-connection-config-shape-validator.adapter';
 import { InfaktConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/infakt-connection-credentials-shape-validator.adapter';
 import { InfaktRetryClassifierAdapter } from './infrastructure/adapters/infakt-retry-classifier.adapter';
+import { InfaktInboundWebhookDecoderAdapter } from './infrastructure/adapters/infakt-inbound-webhook-decoder.adapter';
+import { InfaktWebhookEventTranslatorAdapter } from './infrastructure/adapters/infakt-webhook-event-translator.adapter';
 
 /**
  * Static plugin manifest. Exported for host tooling (capability-matrix, manifest
@@ -58,6 +60,20 @@ export function createInfaktPlugin(): AdapterPlugin {
         new InfaktConnectionCredentialsShapeValidatorAdapter(INFAKT_BRAND),
       );
       host.retryClassifierRegistry.register(INFAKT_ADAPTER_KEY, new InfaktRetryClassifierAdapter());
+
+      // #1281 / ADR-021 — third-party-native webhook ingress. The decoder
+      // (provider-keyed) authenticates + decodes Infakt's KSeF-relay webhook
+      // (incl. the subscription-verification handshake) at the host ingress;
+      // the translator (adapterKey-keyed) maps the decoded event onto the
+      // `invoicing` inbound domain downstream.
+      host.inboundWebhookDecoderRegistry.register(
+        infaktAdapterManifest.platformType,
+        new InfaktInboundWebhookDecoderAdapter(),
+      );
+      host.webhookEventTranslatorRegistry.register(
+        INFAKT_ADAPTER_KEY,
+        new InfaktWebhookEventTranslatorAdapter(),
+      );
     },
 
     async createCapabilityAdapter<T>(

--- a/libs/integrations/infakt/src/infakt-plugin.ts
+++ b/libs/integrations/infakt/src/infakt-plugin.ts
@@ -29,6 +29,7 @@ import { InfaktConnectionCredentialsShapeValidatorAdapter } from './infrastructu
 import { InfaktRetryClassifierAdapter } from './infrastructure/adapters/infakt-retry-classifier.adapter';
 import { InfaktInboundWebhookDecoderAdapter } from './infrastructure/adapters/infakt-inbound-webhook-decoder.adapter';
 import { InfaktWebhookEventTranslatorAdapter } from './infrastructure/adapters/infakt-webhook-event-translator.adapter';
+import { InfaktConnectionTesterAdapter } from './infrastructure/adapters/infakt-connection-tester.adapter';
 
 /**
  * Static plugin manifest. Exported for host tooling (capability-matrix, manifest
@@ -60,6 +61,7 @@ export function createInfaktPlugin(): AdapterPlugin {
         new InfaktConnectionCredentialsShapeValidatorAdapter(INFAKT_BRAND),
       );
       host.retryClassifierRegistry.register(INFAKT_ADAPTER_KEY, new InfaktRetryClassifierAdapter());
+      host.connectionTesterRegistry.register(INFAKT_ADAPTER_KEY, new InfaktConnectionTesterAdapter());
 
       // #1281 / ADR-021 — third-party-native webhook ingress. The decoder
       // (provider-keyed) authenticates + decodes Infakt's KSeF-relay webhook

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-tester.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-tester.adapter.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Infakt Connection Tester — unit tests
+ *
+ * Stubs `global.fetch` to verify the probe maps a 2xx to success, a 401 to a
+ * clear auth failure, and a transport error to a failure result — never
+ * throwing (the tester always returns a `ConnectionTestResult`).
+ *
+ * @module libs/integrations/infakt/src/infrastructure/adapters/__tests__
+ */
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { InfaktConnectionTesterAdapter } from '../infakt-connection-tester.adapter';
+
+function connection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn-1',
+    platformType: 'infakt',
+    name: 'Infakt',
+    status: 'active',
+    config: {},
+    credentialsRef: 'ref-1',
+    enabledCapabilities: [],
+    adapterKey: 'infakt.accounting.v1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+const resolver: CredentialsResolverPort = { get: jest.fn().mockResolvedValue({ apiKey: 'k-123' }) };
+
+function fakeResponse(ok: boolean, status: number): Response {
+  return {
+    ok,
+    status,
+    text: (): Promise<string> => Promise.resolve(ok ? '{"entities":[]}' : '{"error":"unauthorized"}'),
+  } as unknown as Response;
+}
+
+const originalFetch = global.fetch;
+
+describe('InfaktConnectionTesterAdapter', () => {
+  let tester: InfaktConnectionTesterAdapter;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    tester = new InfaktConnectionTesterAdapter();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('should return success with the probe status on a 2xx response', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(true, 200));
+
+    const result = await tester.test(connection(), resolver);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.message).toContain('credentials accepted');
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should return a failure with status 401 when the key is rejected', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(false, 401));
+
+    const result = await tester.test(connection(), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(401);
+  });
+
+  it('should return a failure (not throw) on a transport error, collapsing the raw cause', async () => {
+    fetchMock.mockRejectedValue(new Error('connect ECONNREFUSED 10.0.0.1:443 /secret-path'));
+
+    const result = await tester.test(connection(), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBeUndefined();
+    expect(result.message).toBe('Infakt probe failed');
+    expect(result.message).not.toContain('ECONNREFUSED');
+    expect(result.message).not.toContain('secret-path');
+  });
+
+  it('should never surface InfaktApiError.responseBody in the result message', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(false, 422));
+
+    const result = await tester.test(connection(), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(422);
+    expect(result.message).not.toContain('unauthorized');
+  });
+
+  it('should return a failure (not throw) when the connection has no stored credentials', async () => {
+    const result = await tester.test(connection({ credentialsRef: undefined }), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.message.length).toBeGreaterThan(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-inbound-webhook-decoder.adapter.spec.ts
@@ -95,13 +95,27 @@ describe('InfaktInboundWebhookDecoderAdapter', () => {
     it('should fall back to the event uuid as externalId when invoice_uuid is absent', () => {
       const rawBody = Buffer.from(
         JSON.stringify({
-          event: { uuid: 'e-2', name: 'draft_invoice_created', retry_counter: 0, created_at: '2026-06-30T10:00:00Z' },
+          event: { uuid: 'e-2', name: 'send_to_ksef_error', retry_counter: 0, created_at: '2026-06-30T10:00:00Z' },
           resource: { id: 42 },
         }),
       );
       const result = adapter.extractEnvelope(rawBody);
       expect(result.action).toBe('route');
       expect(result.action === 'route' && result.envelope.externalId).toBe('e-2');
+    });
+
+    it('should ignore (not route) an Infakt event OL does not act on', () => {
+      const rawBody = Buffer.from(
+        JSON.stringify({
+          event: { uuid: 'e-3', name: 'draft_invoice_created', retry_counter: 0, created_at: '2026-06-30T10:00:00Z' },
+          resource: { id: 42 },
+        }),
+      );
+      const result = adapter.extractEnvelope(rawBody);
+      expect(result).toEqual({
+        action: 'ignore',
+        reason: 'unhandled Infakt event: draft_invoice_created',
+      });
     });
 
     it('should reject a malformed payload', () => {

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-inbound-webhook-decoder.adapter.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Infakt Inbound Webhook Decoder Adapter — unit tests
+ *
+ * @module libs/integrations/infakt/src/infrastructure/adapters/__tests__
+ */
+import { createHmac } from 'crypto';
+import { InfaktInboundWebhookDecoderAdapter } from '../infakt-inbound-webhook-decoder.adapter';
+
+const SECRET = 'test-webhook-secret';
+
+function sign(body: Buffer, secret: string): string {
+  return createHmac('sha256', secret).update(body).digest('hex');
+}
+
+describe('InfaktInboundWebhookDecoderAdapter', () => {
+  let adapter: InfaktInboundWebhookDecoderAdapter;
+
+  beforeEach(() => {
+    adapter = new InfaktInboundWebhookDecoderAdapter();
+  });
+
+  describe('detectHandshake', () => {
+    it('should echo the verification_code when present', () => {
+      const body = Buffer.from(JSON.stringify({ verification_code: 'abc123' }));
+      expect(adapter.detectHandshake(body)).toEqual({ verification_code: 'abc123' });
+    });
+
+    it('should return null for a non-handshake payload', () => {
+      const body = Buffer.from(JSON.stringify({ event: { name: 'x' } }));
+      expect(adapter.detectHandshake(body)).toBeNull();
+    });
+  });
+
+  describe('verify', () => {
+    it('should return ok=true for a valid signature', () => {
+      const rawBody = Buffer.from(JSON.stringify({ event: { name: 'x' } }));
+      const result = adapter.verify({
+        rawBody,
+        headers: { 'x-infakt-signature': sign(rawBody, SECRET) },
+        secret: SECRET,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.timestampMs).toBeUndefined();
+    });
+
+    it('should return ok=false for an invalid signature', () => {
+      const rawBody = Buffer.from(JSON.stringify({ event: { name: 'x' } }));
+      const result = adapter.verify({
+        rawBody,
+        headers: { 'x-infakt-signature': 'deadbeef' },
+        secret: SECRET,
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('should return ok=false when the signature header is missing', () => {
+      const rawBody = Buffer.from(JSON.stringify({ event: { name: 'x' } }));
+      const result = adapter.verify({ rawBody, headers: {}, secret: SECRET });
+      expect(result.ok).toBe(false);
+    });
+
+    it('should read the signature header case-insensitively', () => {
+      const rawBody = Buffer.from(JSON.stringify({ event: { name: 'x' } }));
+      const result = adapter.verify({
+        rawBody,
+        headers: { 'X-Infakt-Signature': sign(rawBody, SECRET) },
+        secret: SECRET,
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('extractEnvelope', () => {
+    it('should route a well-formed invoice event', () => {
+      const rawBody = Buffer.from(
+        JSON.stringify({
+          event: { uuid: 'e-1', name: 'send_to_ksef_success', retry_counter: 0, created_at: '2026-06-30T10:00:00Z' },
+          resource: { status: 'success', invoice_uuid: 'inv-1', ksef_number: 'KSeF-1' },
+        }),
+      );
+      const result = adapter.extractEnvelope(rawBody);
+      expect(result).toEqual({
+        action: 'route',
+        envelope: {
+          eventId: 'e-1',
+          eventType: 'send_to_ksef_success',
+          occurredAt: '2026-06-30T10:00:00Z',
+          objectType: 'invoice',
+          externalId: 'inv-1',
+          payload: { status: 'success', invoice_uuid: 'inv-1', ksef_number: 'KSeF-1' },
+        },
+      });
+    });
+
+    it('should fall back to the event uuid as externalId when invoice_uuid is absent', () => {
+      const rawBody = Buffer.from(
+        JSON.stringify({
+          event: { uuid: 'e-2', name: 'draft_invoice_created', retry_counter: 0, created_at: '2026-06-30T10:00:00Z' },
+          resource: { id: 42 },
+        }),
+      );
+      const result = adapter.extractEnvelope(rawBody);
+      expect(result.action).toBe('route');
+      expect(result.action === 'route' && result.envelope.externalId).toBe('e-2');
+    });
+
+    it('should reject a malformed payload', () => {
+      const rawBody = Buffer.from('not json');
+      expect(adapter.extractEnvelope(rawBody)).toEqual({
+        action: 'reject',
+        reason: 'malformed Infakt webhook payload',
+      });
+    });
+  });
+});

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -320,6 +320,23 @@ describe('InfaktInvoicingAdapter', () => {
         statusCode: 500,
       });
     });
+
+    it('should propagate a failure from sendToKsef after the draft was already created (error path, #1293 review)', async () => {
+      // The draft succeeds but the explicit KSeF submission kick fails — the
+      // draft is left orphaned in Infakt (retry-safety assumption documented
+      // inline on the sendToKsef call site).
+      http.seed('POST', 'invoices.json', invoiceFixture());
+      http.seedError(
+        'POST',
+        'invoices/inv-uuid-1/send_to_ksef.json',
+        new InfaktApiError('Infakt server error', 500, { error: 'internal' }),
+      );
+
+      await expect(adapter.issueInvoice(baseCmd)).rejects.toMatchObject({
+        failureMode: 'in-doubt',
+        statusCode: 500,
+      });
+    });
   });
 
   describe('getInvoice', () => {
@@ -580,6 +597,23 @@ describe('InfaktInvoicingAdapter', () => {
       http.seedError('GET', 'invoices/inv-uuid-1.json', new InfaktApiError('not found', 404, {}));
 
       await expect(adapter.issueCorrection(baseCmd)).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    it('should propagate a failure from sendToKsef after the correction draft was already created (error path, #1293 review)', async () => {
+      // Same orphaned-draft risk as issueInvoice's equivalent case — the
+      // corrective draft succeeds but the explicit KSeF submission kick fails.
+      http.seed('GET', 'invoices/inv-uuid-1.json', invoiceFixture());
+      http.seed('POST', 'invoices.json', invoiceFixture({ uuid: 'corr-uuid-1', kind: 'corrective' }));
+      http.seedError(
+        'POST',
+        'invoices/corr-uuid-1/send_to_ksef.json',
+        new InfaktApiError('Infakt server error', 500, { error: 'internal' }),
+      );
+
+      await expect(adapter.issueCorrection(baseCmd)).rejects.toMatchObject({
+        failureMode: 'in-doubt',
+        statusCode: 500,
+      });
     });
   });
 });

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -516,6 +516,7 @@ describe('InfaktInvoicingAdapter', () => {
       // the "before" row and the fallback "after" row go through this path.
       http.seed('GET', 'invoices/inv-uuid-1.json', invoiceFixture());
       http.seed('POST', 'invoices.json', invoiceFixture({ uuid: 'corr-uuid-1', kind: 'corrective' }));
+      http.seed('POST', 'invoices/corr-uuid-1/send_to_ksef.json', ksefResponseFixture());
 
       await adapter.issueCorrection(baseCmd);
 
@@ -534,6 +535,7 @@ describe('InfaktInvoicingAdapter', () => {
     it('should convert a price-changing correction line from gross to net (#1292 review)', async () => {
       http.seed('GET', 'invoices/inv-uuid-1.json', invoiceFixture());
       http.seed('POST', 'invoices.json', invoiceFixture({ uuid: 'corr-uuid-1', kind: 'corrective' }));
+      http.seed('POST', 'invoices/corr-uuid-1/send_to_ksef.json', ksefResponseFixture());
 
       await adapter.issueCorrection({
         ...baseCmd,

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -80,6 +80,29 @@ function invoiceFixture(overrides: Partial<InfaktInvoice> = {}): InfaktInvoice {
   };
 }
 
+function ksefResponseFixture(
+  overrides: Partial<{ status: 'pending' | 'sent' | 'success' | 'error'; ksef_number: string | null }> = {},
+): {
+  request_uuid: string;
+  invoice_uuid: string;
+  invoice_kind: string;
+  ksef_number: string | null;
+  status: 'pending' | 'sent' | 'success' | 'error';
+  status_description: string | null;
+  timestamps: { request_created_at: string | null; request_finished_at: string | null };
+} {
+  return {
+    request_uuid: 'req-uuid-1',
+    invoice_uuid: 'inv-uuid-1',
+    invoice_kind: 'vat',
+    ksef_number: null,
+    status: 'pending',
+    status_description: 'Faktura oczekuje na wysłanie do KSeF.',
+    timestamps: { request_created_at: '2026-07-01T12:00:00Z', request_finished_at: '2026-07-01T12:00:00Z' },
+    ...overrides,
+  };
+}
+
 describe('InfaktInvoicingAdapter', () => {
   let http: FakeInfaktHttpClient;
   let logger: jest.Mocked<LoggerPort>;
@@ -107,12 +130,12 @@ describe('InfaktInvoicingAdapter', () => {
       const existing: InfaktClient = {
         id: 1,
         uuid: 'client-existing',
-        name: 'Acme',
+        company_name: 'Acme',
         nip: '1234567890',
         email: null,
         city: null,
         street: null,
-        post_code: null,
+        postal_code: null,
         country: null,
       };
       http.seed<InfaktListResponse<InfaktClient>>('GET', 'clients.json', {
@@ -125,7 +148,9 @@ describe('InfaktInvoicingAdapter', () => {
         buyer: buyer({ nip: '1234567890' }),
       });
 
-      expect(result).toEqual({ providerCustomerId: 'client-existing' });
+      // The neutral providerCustomerId carries Infakt's NUMERIC client id
+      // (not the uuid) — invoices.json only accepts client_id.
+      expect(result).toEqual({ providerCustomerId: '1' });
     });
 
     it('should create a new client when no NIP match exists (happy path)', async () => {
@@ -136,12 +161,12 @@ describe('InfaktInvoicingAdapter', () => {
       const created: InfaktClient = {
         id: 2,
         uuid: 'client-new',
-        name: 'Acme',
+        company_name: 'Acme',
         nip: '1234567890',
         email: null,
         city: 'Warszawa',
         street: 'Testowa 1',
-        post_code: '00-001',
+        postal_code: '00-001',
         country: 'PL',
       };
       http.seed('POST', 'clients.json', created);
@@ -151,26 +176,32 @@ describe('InfaktInvoicingAdapter', () => {
         buyer: buyer({ nip: '1234567890' }),
       });
 
-      expect(result).toEqual({ providerCustomerId: 'client-new' });
+      expect(result).toEqual({ providerCustomerId: '2' });
+      // Field names verified live against the real Infakt v3 sandbox
+      // (2026-07-01): `name`/`post_code` are silently rejected/ignored.
+      const createCall = http.calls.find((c) => c.method === 'POST' && c.path === 'clients.json');
+      expect(createCall?.body).toMatchObject({
+        client: expect.objectContaining({ company_name: 'Acme Sp. z o.o.', postal_code: '00-001' }),
+      });
     });
 
     it('should create a new client without a NIP lookup when the buyer has no tax id', async () => {
       const created: InfaktClient = {
         id: 3,
         uuid: 'client-no-nip',
-        name: 'Jan Kowalski',
+        company_name: 'Jan Kowalski',
         nip: null,
         email: null,
         city: 'Warszawa',
         street: 'Testowa 1',
-        post_code: '00-001',
+        postal_code: '00-001',
         country: 'PL',
       };
       http.seed('POST', 'clients.json', created);
 
       const result = await adapter.upsertCustomer({ connectionId: 'conn-1', buyer: buyer() });
 
-      expect(result).toEqual({ providerCustomerId: 'client-no-nip' });
+      expect(result).toEqual({ providerCustomerId: '3' });
       expect(http.calls.some((c) => c.method === 'GET' && c.path === 'clients.json')).toBe(false);
     });
 
@@ -202,14 +233,17 @@ describe('InfaktInvoicingAdapter', () => {
       http.seed('POST', 'clients.json', {
         id: 1,
         uuid: 'client-uuid-1',
-        name: 'Acme',
+        company_name: 'Acme',
         nip: '1234567890',
         email: null,
         city: null,
         street: null,
-        post_code: null,
+        postal_code: null,
         country: null,
       });
+      // issueInvoice now submits to KSeF inline (issuing IS submitting) —
+      // verified live (2026-07-01) that an Infakt draft never auto-submits.
+      http.seed('POST', 'invoices/inv-uuid-1/send_to_ksef.json', ksefResponseFixture());
     });
 
     it('should issue an invoice and return an InvoiceRecord (happy path)', async () => {
@@ -226,6 +260,39 @@ describe('InfaktInvoicingAdapter', () => {
       expect(record.status).toBe('issued');
       expect(record.idempotencyKey).toBe('idem-1');
       expect(record.pdfUrl).toBe('https://infakt.pl/inv-uuid-1.pdf');
+      // KSeF submission is inline now — the record reflects the send_to_ksef
+      // response, not the (necessarily stale, pre-submission) invoice payload.
+      expect(record.regulatoryStatus).toBe('submitted');
+
+      // Verified live against the real Infakt v3 sandbox (2026-07-01):
+      // `payment_method: 'transfer'` 422s without a configured bank account,
+      // and `client_uuid` is ignored — invoices.json needs the numeric
+      // `client_id`.
+      const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
+      expect(invoiceCall?.body).toMatchObject({
+        invoice: expect.objectContaining({ payment_method: 'cash', client_id: 1 }),
+      });
+      // issuing IS submitting for Infakt (draft never auto-submits) — verified
+      // live (2026-07-01).
+      expect(http.calls.some((c) => c.method === 'POST' && c.path === 'invoices/inv-uuid-1/send_to_ksef.json')).toBe(
+        true,
+      );
+    });
+
+    it('should default an empty taxRate to the Polish standard VAT rate (regime-rate fallback)', async () => {
+      // Core always leaves InvoiceLine.taxRate empty (documented contract:
+      // "the provider adapter resolves the regime rate"). Verified live
+      // (2026-07-01): an empty tax_symbol cascades into services.gross /
+      // value.tax_values rejections too — every real order line hit this.
+      http.seed('POST', 'invoices.json', invoiceFixture());
+
+      await adapter.issueInvoice({ ...baseCmd, lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate: '' }] });
+
+      const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
+      const services = (invoiceCall?.body as { invoice: { services: Array<{ tax_symbol: string; unit_net_price: string }> } })
+        .invoice.services;
+      expect(services[0].tax_symbol).toBe('23');
+      expect(services[0].unit_net_price).toBe('100.00 PLN');
     });
 
     it('should propagate a 422 InfaktApiError with failureMode: rejected (error path)', async () => {
@@ -420,12 +487,27 @@ describe('InfaktInvoicingAdapter', () => {
     it('should issue a correction and return an InvoiceRecord (happy path)', async () => {
       http.seed('GET', 'invoices/inv-uuid-1.json', invoiceFixture());
       http.seed('POST', 'invoices.json', invoiceFixture({ uuid: 'corr-uuid-1', kind: 'corrective' }));
+      // A correction is its own KSeF document — needs its own send_to_ksef
+      // kick, same as the original (verified live, 2026-07-01).
+      http.seed('POST', 'invoices/corr-uuid-1/send_to_ksef.json', ksefResponseFixture());
 
       const record = await adapter.issueCorrection(baseCmd);
 
       expect(record).toBeInstanceOf(InvoiceRecord);
       expect(record.providerInvoiceId).toBe('corr-uuid-1');
       expect(record.idempotencyKey).toBe('idem-corr-1');
+      expect(record.regulatoryStatus).toBe('submitted');
+
+      // Verified live against the real Infakt v3 sandbox (2026-07-01):
+      // omitting client_id on a corrective invoice 422s with "client_id
+      // required" — the original invoice's own client_id must be forwarded.
+      const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
+      expect(invoiceCall?.body).toMatchObject({
+        invoice: expect.objectContaining({ client_id: 1 }),
+      });
+      expect(
+        http.calls.some((c) => c.method === 'POST' && c.path === 'invoices/corr-uuid-1/send_to_ksef.json'),
+      ).toBe(true);
     });
 
     it('should parse Infakt\'s "amount currency" unit_net_price string for the untouched-line fallback', async () => {

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -398,7 +398,7 @@ describe('InfaktInvoicingAdapter', () => {
     });
 
     it.each([
-      ['success', 'cleared'],
+      ['success', 'accepted'],
       ['pending', 'submitted'],
       ['sent', 'submitted'],
       ['error', 'rejected'],

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -45,9 +45,9 @@ function invoiceFixture(overrides: Partial<InfaktInvoice> = {}): InfaktInvoice {
     number: 'FV/1/2026',
     kind: 'vat',
     status: 'sent',
-    gross_price: '123.00 PLN',
-    net_price: '100.00 PLN',
-    tax_price: '23.00 PLN',
+    gross_price: 12300,
+    net_price: 10000,
+    tax_price: 2300,
     payment_method: 'transfer',
     invoice_date: '2026-07-01',
     sale_date: '2026-07-01',
@@ -66,10 +66,10 @@ function invoiceFixture(overrides: Partial<InfaktInvoice> = {}): InfaktInvoice {
         tax_symbol: '23',
         quantity: 1,
         unit: 'szt.',
-        unit_net_price: '100.00 PLN',
-        net_price: '100.00 PLN',
-        tax_price: '23.00 PLN',
-        gross_price: '123.00 PLN',
+        unit_net_price: 10000,
+        net_price: 10000,
+        tax_price: 2300,
+        gross_price: 12300,
         correction: null,
         group: null,
       },
@@ -289,10 +289,10 @@ describe('InfaktInvoicingAdapter', () => {
       await adapter.issueInvoice({ ...baseCmd, lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate: '' }] });
 
       const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
-      const services = (invoiceCall?.body as { invoice: { services: Array<{ tax_symbol: string; unit_net_price: string }> } })
+      const services = (invoiceCall?.body as { invoice: { services: Array<{ tax_symbol: string; unit_net_price: number }> } })
         .invoice.services;
       expect(services[0].tax_symbol).toBe('23');
-      expect(services[0].unit_net_price).toBe('100.00 PLN');
+      expect(services[0].unit_net_price).toBe(10000);
     });
 
     it('should propagate a 422 InfaktApiError with failureMode: rejected (error path)', async () => {
@@ -527,10 +527,11 @@ describe('InfaktInvoicingAdapter', () => {
       ).toBe(true);
     });
 
-    it('should parse Infakt\'s "amount currency" unit_net_price string for the untouched-line fallback', async () => {
-      // Infakt returns unit_net_price as "100.00 PLN", never a plain number
-      // (#1292 review); baseCmd's line carries no newUnitPriceGross, so both
-      // the "before" row and the fallback "after" row go through this path.
+    it('should carry the original unit_net_price (plain integer groszy) through for the untouched-line fallback', async () => {
+      // Infakt's wire format is a plain integer count of groszy (#1293 review
+      // finding — the earlier "amount currency" string assumption understated
+      // every invoice ~100x); baseCmd's line carries no newUnitPriceGross, so
+      // both the "before" row and the fallback "after" row go through this path.
       http.seed('GET', 'invoices/inv-uuid-1.json', invoiceFixture());
       http.seed('POST', 'invoices.json', invoiceFixture({ uuid: 'corr-uuid-1', kind: 'corrective' }));
       http.seed('POST', 'invoices/corr-uuid-1/send_to_ksef.json', ksefResponseFixture());
@@ -539,17 +540,17 @@ describe('InfaktInvoicingAdapter', () => {
 
       const postCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
       const body = postCall?.body as {
-        invoice: { services: { unit_net_price: string; correction: boolean }[] };
+        invoice: { services: { unit_net_price: number; correction: boolean }[] };
       };
       expect(body.invoice.services.find((s) => s.correction === false)?.unit_net_price).toBe(
-        '100.00 PLN',
+        10000,
       );
       expect(body.invoice.services.find((s) => s.correction === true)?.unit_net_price).toBe(
-        '100.00 PLN',
+        10000,
       );
     });
 
-    it('should convert a price-changing correction line from gross to net (#1292 review)', async () => {
+    it('should convert a price-changing correction line from gross to net, in groszy (#1292 review)', async () => {
       http.seed('GET', 'invoices/inv-uuid-1.json', invoiceFixture());
       http.seed('POST', 'invoices.json', invoiceFixture({ uuid: 'corr-uuid-1', kind: 'corrective' }));
       http.seed('POST', 'invoices/corr-uuid-1/send_to_ksef.json', ksefResponseFixture());
@@ -561,12 +562,13 @@ describe('InfaktInvoicingAdapter', () => {
 
       const postCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
       const body = postCall?.body as {
-        invoice: { services: { unit_net_price: string; correction: boolean }[] };
+        invoice: { services: { unit_net_price: number; correction: boolean }[] };
       };
       const correctedRow = body.invoice.services.find((s) => s.correction === true);
-      // 61.5 gross / 1.23 (tax_symbol '23') = 50.00 net — was previously written
-      // straight through as "61.50 PLN", overstating the net price.
-      expect(correctedRow?.unit_net_price).toBe('50.00 PLN');
+      // 61.5 gross / 1.23 (tax_symbol '23') = 50.00 net PLN = 5000 groszy —
+      // was previously written straight through as "61.50 PLN" (61500 groszy
+      // if naively converted), overstating the net price.
+      expect(correctedRow?.unit_net_price).toBe(5000);
     });
 
     it('should propagate a 422 InfaktApiError with failureMode: rejected (error path)', async () => {

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-webhook-event-translator.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-webhook-event-translator.adapter.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Infakt Webhook Event Translator Adapter — unit tests
+ *
+ * @module libs/integrations/infakt/src/infrastructure/adapters/__tests__
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+import { InfaktWebhookEventTranslatorAdapter } from '../infakt-webhook-event-translator.adapter';
+
+function event(overrides: Partial<InboundWebhookEvent> = {}): InboundWebhookEvent {
+  return {
+    eventId: 'e-1',
+    provider: 'infakt',
+    connectionId: 'conn-1',
+    eventType: 'send_to_ksef_success',
+    occurredAt: '2026-06-30T10:00:00Z',
+    receivedAt: '2026-06-30T10:00:01Z',
+    objectType: 'invoice',
+    externalId: 'inv-1',
+    payload: { status: 'success' },
+    ...overrides,
+  };
+}
+
+describe('InfaktWebhookEventTranslatorAdapter', () => {
+  let translator: InfaktWebhookEventTranslatorAdapter;
+
+  beforeEach(() => {
+    translator = new InfaktWebhookEventTranslatorAdapter();
+  });
+
+  it('should translate a send_to_ksef_success event to the invoicing domain', () => {
+    expect(translator.translate(event())).toEqual({
+      domain: 'invoicing',
+      externalId: 'inv-1',
+      eventType: 'send_to_ksef_success',
+      occurredAt: '2026-06-30T10:00:00Z',
+      payload: { status: 'success' },
+    });
+  });
+
+  it('should translate a send_to_ksef_error event to the invoicing domain', () => {
+    expect(translator.translate(event({ eventType: 'send_to_ksef_error' }))?.domain).toBe('invoicing');
+  });
+
+  it('should return null for a non-KSeF invoice event (dead-letter)', () => {
+    expect(translator.translate(event({ eventType: 'draft_invoice_created' }))).toBeNull();
+  });
+
+  it('should return null for a non-invoice object type', () => {
+    expect(translator.translate(event({ objectType: 'order' }))).toBeNull();
+  });
+});

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-tester.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-tester.adapter.ts
@@ -1,0 +1,85 @@
+/**
+ * Infakt Connection Tester
+ *
+ * Probes a live Infakt connection with one cheap authenticated GET so OL Admin
+ * can show the connection Active (or a clear failure) right after the operator
+ * pastes their API key. Resolves credentials directly and builds a bare
+ * `InfaktHttpClient` (mirrors the `SubiektConnectionTesterAdapter` precedent —
+ * Infakt's factory only exposes `createInvoicingAdapter`, not a standalone
+ * HTTP-client construction seam) and maps the outcome to the neutral
+ * `ConnectionTestResult`. Registered against `ConnectionTesterRegistryService`
+ * at `infakt.accounting.v1`.
+ *
+ * The probe path ({@link INFAKT_CONNECTION_PROBE_PATH}) is `GET /clients.json`
+ * with `limit=1` — a real, already-used Infakt v3 endpoint (see
+ * `InfaktInvoicingAdapter.findClientByNip`), cheap, side-effect-free, and
+ * requires a valid API key so a 2xx confirms both reachability and credential
+ * validity, same posture as Erli's `GET /me`.
+ *
+ * @module libs/integrations/infakt/src/infrastructure/adapters
+ * @see {@link ConnectionTesterPort}
+ */
+import type {
+  ConnectionTesterPort,
+  ConnectionTestResult,
+  CredentialsResolverPort,
+} from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { Logger } from '@openlinker/shared/logging';
+import { InfaktHttpClient, INFAKT_DEFAULT_BASE_URL } from '../http/infakt-http-client';
+import { InfaktApiError } from '../../domain/exceptions/infakt-api.error';
+import type { InfaktCredentials, InfaktConnectionConfig } from '../../domain/types/infakt-connection.types';
+
+const INFAKT_CONNECTION_PROBE_PATH = 'clients.json';
+
+export class InfaktConnectionTesterAdapter implements ConnectionTesterPort {
+  private readonly logger = new Logger(InfaktConnectionTesterAdapter.name);
+
+  async test(
+    connection: Connection,
+    credentialsResolver: CredentialsResolverPort,
+  ): Promise<ConnectionTestResult> {
+    const startedAt = Date.now();
+    try {
+      if (!connection.credentialsRef) {
+        return {
+          success: false,
+          message: 'Connection has no stored credentials',
+          latencyMs: Date.now() - startedAt,
+        };
+      }
+
+      const credentials = await credentialsResolver.get<InfaktCredentials>(connection.credentialsRef);
+      const config = (connection.config ?? {}) as InfaktConnectionConfig;
+      const client = new InfaktHttpClient(
+        { apiKey: credentials.apiKey, baseUrl: config.baseUrl ?? INFAKT_DEFAULT_BASE_URL },
+        this.logger,
+      );
+
+      await client.get(INFAKT_CONNECTION_PROBE_PATH, { limit: '1' });
+
+      return {
+        success: true,
+        status: 200,
+        // GET /clients.json requires auth, so a 2xx confirms both reachability
+        // and a valid credential.
+        message: 'Connection reachable and credentials accepted',
+        latencyMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      return this.toFailure(error, Date.now() - startedAt);
+    }
+  }
+
+  private toFailure(error: unknown, latencyMs: number): ConnectionTestResult {
+    // InfaktApiError.message is bounded and bearer-safe; responseBody is a
+    // SEPARATE field that may echo back submitted data and must never reach
+    // the operator-facing result.
+    if (error instanceof InfaktApiError) {
+      return { success: false, status: error.statusCode, message: error.message, latencyMs };
+    }
+    // Anything else (raw fetch/undici error, credential-resolution failure)
+    // collapses to a fixed string — never let an internal detail leak.
+    return { success: false, status: undefined, message: 'Infakt probe failed', latencyMs };
+  }
+}

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-inbound-webhook-decoder.adapter.ts
@@ -60,7 +60,7 @@ export class InfaktInboundWebhookDecoderAdapter implements InboundWebhookDecoder
 
     const externalId =
       typeof parsed.resource['invoice_uuid'] === 'string'
-        ? (parsed.resource['invoice_uuid'])
+        ? parsed.resource['invoice_uuid']
         : parsed.event.uuid;
 
     return {

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-inbound-webhook-decoder.adapter.ts
@@ -1,0 +1,74 @@
+/**
+ * Infakt Inbound Webhook Decoder Adapter (#1281, ADR-021)
+ *
+ * Authenticates + decodes Infakt's third-party-native webhooks at the host
+ * ingress, keyed by `provider = 'infakt'`. Wraps the confirmed-live
+ * `InfaktWebhookTranslator` (verify = HMAC-SHA256 hex over the raw body,
+ * header `X-Infakt-Signature`; no timestamp header, so `verify` returns no
+ * `timestampMs` and the shared replay-window check is a no-op for this
+ * provider) rather than duplicating its crypto/parsing logic.
+ *
+ * `detectHandshake` covers Infakt's subscription-verification ping
+ * (`{"verification_code": "..."}` → echo the same body back) — it runs
+ * before `verify` per the port contract, since the ping predates any signed
+ * traffic.
+ *
+ * @module libs/integrations/infakt/src/infrastructure/adapters
+ */
+import type {
+  DecodeResult,
+  InboundWebhookDecoderPort,
+  WebhookVerifyResult,
+} from '@openlinker/core/integrations';
+import { Logger } from '@openlinker/shared/logging';
+import { InfaktWebhookTranslator } from '../../infrastructure/webhooks/infakt-webhook-translator';
+
+const SIGNATURE_HEADER = 'X-Infakt-Signature';
+
+export class InfaktInboundWebhookDecoderAdapter implements InboundWebhookDecoderPort {
+  private readonly logger = new Logger(InfaktInboundWebhookDecoderAdapter.name);
+  /** Secret-independent parsing helpers only — `verify` builds its own instance with the resolved per-connection secret. */
+  private readonly parser = new InfaktWebhookTranslator({ secret: '' }, this.logger);
+
+  detectHandshake(rawBody: Buffer): Record<string, unknown> | null {
+    return this.parser.getVerificationEcho(rawBody);
+  }
+
+  verify(input: {
+    rawBody: Buffer;
+    headers: Record<string, string>;
+    secret: string;
+  }): WebhookVerifyResult {
+    const signature = this.header(input.headers, SIGNATURE_HEADER);
+    const translator = new InfaktWebhookTranslator({ secret: input.secret }, this.logger);
+    return { ok: translator.verifySignature(input.rawBody, signature) };
+  }
+
+  extractEnvelope(rawBody: Buffer): DecodeResult {
+    const parsed = this.parser.parse(rawBody);
+    if (!parsed) {
+      return { action: 'reject', reason: 'malformed Infakt webhook payload' };
+    }
+
+    const externalId =
+      typeof parsed.resource['invoice_uuid'] === 'string'
+        ? (parsed.resource['invoice_uuid'])
+        : parsed.event.uuid;
+
+    return {
+      action: 'route',
+      envelope: {
+        eventId: parsed.event.uuid,
+        eventType: parsed.event.name,
+        occurredAt: parsed.event.created_at,
+        objectType: 'invoice',
+        externalId,
+        payload: parsed.resource,
+      },
+    };
+  }
+
+  private header(headers: Record<string, string>, name: string): string | undefined {
+    return headers[name] ?? headers[name.toLowerCase()];
+  }
+}

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-inbound-webhook-decoder.adapter.ts
@@ -21,14 +21,14 @@ import type {
   WebhookVerifyResult,
 } from '@openlinker/core/integrations';
 import { Logger } from '@openlinker/shared/logging';
-import { InfaktWebhookTranslator } from '../../infrastructure/webhooks/infakt-webhook-translator';
+import { InfaktWebhookTranslator } from '../webhooks/infakt-webhook-translator';
 
 const SIGNATURE_HEADER = 'X-Infakt-Signature';
 
 export class InfaktInboundWebhookDecoderAdapter implements InboundWebhookDecoderPort {
   private readonly logger = new Logger(InfaktInboundWebhookDecoderAdapter.name);
   /** Secret-independent parsing helpers only — `verify` builds its own instance with the resolved per-connection secret. */
-  private readonly parser = new InfaktWebhookTranslator({ secret: '' }, this.logger);
+  private readonly parser = InfaktWebhookTranslator.forParsing(this.logger);
 
   detectHandshake(rawBody: Buffer): Record<string, unknown> | null {
     return this.parser.getVerificationEcho(rawBody);

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-inbound-webhook-decoder.adapter.ts
@@ -50,6 +50,14 @@ export class InfaktInboundWebhookDecoderAdapter implements InboundWebhookDecoder
       return { action: 'reject', reason: 'malformed Infakt webhook payload' };
     }
 
+    // Short-circuit here rather than always routing: every Infakt event OL
+    // doesn't act on (draft_invoice_created, invoice_marked_as_paid, …) would
+    // otherwise still pay for a full Postgres dedup-insert + Redis publish
+    // before being dead-lettered two hops later in WebhookToJobHandler.
+    if (this.parser.toOlDomain(parsed.event.name) === null) {
+      return { action: 'ignore', reason: `unhandled Infakt event: ${parsed.event.name}` };
+    }
+
     const externalId =
       typeof parsed.resource['invoice_uuid'] === 'string'
         ? (parsed.resource['invoice_uuid'])

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -133,15 +133,26 @@ function taxRateNumeric(taxRate: string): number {
   return 0;
 }
 
-/** Converts a buyer-paid gross unit price to Infakt's net unit price for the given tax rate. */
+/** Converts a buyer-paid gross unit price (PLN) to Infakt's net unit price (PLN) for the given tax rate. */
 function grossToNet(unitPriceGross: number, taxRate: string): number {
   return unitPriceGross / (1 + taxRateNumeric(taxRate));
 }
 
-/** Parses Infakt's "amount currency" monetary string (e.g. "123.00 PLN") to a number. */
-function parseInfaktAmount(value: string): number {
-  const n = parseFloat(value);
-  return isNaN(n) ? 0 : n;
+/**
+ * Converts a PLN amount to Infakt's wire format: a plain integer count of
+ * groszy (1 PLN = 100 groszy). Confirmed both live against the real sandbox
+ * and against the official API schema — `unit_net_price`/`net_price`/
+ * `gross_price` are `integer`, documented "w groszach". Sending a decimal
+ * "amount currency" string here (the previous behaviour) understated every
+ * invoice's legal/KSeF amount ~100x (#1293 review).
+ */
+function toGroszy(amountPln: number): number {
+  return Math.round(amountPln * 100);
+}
+
+/** Converts an Infakt wire amount (plain integer groszy) back to a PLN decimal for arithmetic. */
+function fromGroszy(amountGroszy: number): number {
+  return amountGroszy / 100;
 }
 
 export class InfaktInvoicingAdapter
@@ -193,7 +204,7 @@ export class InfaktInvoicingAdapter
   }
 
   async issueInvoice(cmd: IssueInvoiceCommand): Promise<IssueInvoiceResult> {
-    const { lines, currency, documentType, idempotencyKey, orderId } = cmd;
+    const { lines, documentType, idempotencyKey, orderId } = cmd;
     const clientId = await this.resolveClientId(cmd);
 
     const kind = documentType === 'proforma' ? 'proforma' : 'vat';
@@ -202,7 +213,8 @@ export class InfaktInvoicingAdapter
       tax_symbol: toInfaktTaxSymbol(l.taxRate),
       quantity: l.quantity,
       unit: 'szt.',
-      unit_net_price: `${grossToNet(l.unitPriceGross, l.taxRate).toFixed(2)} ${currency ?? 'PLN'}`,
+      // Plain integer groszy, NOT an "amount currency" string — see toGroszy.
+      unit_net_price: toGroszy(grossToNet(l.unitPriceGross, l.taxRate)),
     }));
 
     const payload = {
@@ -346,25 +358,19 @@ export class InfaktInvoicingAdapter
       { invoice_type: 'vat' },
     );
 
-    // Infakt's InfaktInvoice type carries no currency field (accounts are
-    // single-currency in practice); PLN mirrors issueInvoice's own default
-    // and is the only value Infakt sandbox/production has ever returned here.
-    const currency = 'PLN';
-
     // Build correction services: original row (correction: false) + corrected row (correction: true)
     const correctionServices = original.services.flatMap((svc, idx) => {
       const corrLine = lines.find((l) => l.originalLineNumber === idx + 1);
       const corrQty = corrLine?.newQuantity ?? svc.quantity;
-      // Infakt returns unit_net_price as an "amount currency" string (e.g.
-      // "100.00 PLN"), never a plain number — confirmed against the v3
-      // schema (#1292 review) — so it must be parsed before arithmetic.
-      const originalNet = parseInfaktAmount(svc.unit_net_price);
+      // svc.unit_net_price is a plain integer groszy (Infakt wire format —
+      // see toGroszy/fromGroszy) — convert to a PLN decimal before arithmetic.
+      const originalNet = fromGroszy(svc.unit_net_price);
       // newUnitPriceGross is gross (IssueCorrectionCommand contract); Infakt's
       // unit_net_price is net — convert using the ORIGINAL line's tax_symbol,
       // same as issueInvoice's gross→net conversion (#1292 review).
       const corrPrice = corrLine?.newUnitPriceGross
-        ? `${grossToNet(corrLine.newUnitPriceGross, svc.tax_symbol).toFixed(2)} ${currency}`
-        : `${originalNet.toFixed(2)} ${currency}`;
+        ? toGroszy(grossToNet(corrLine.newUnitPriceGross, svc.tax_symbol))
+        : toGroszy(originalNet);
       return [
         // Original "before" row
         {
@@ -372,7 +378,7 @@ export class InfaktInvoicingAdapter
           tax_symbol: svc.tax_symbol,
           quantity: svc.quantity,
           unit: svc.unit ?? 'szt.',
-          unit_net_price: `${originalNet.toFixed(2)} ${currency}`,
+          unit_net_price: toGroszy(originalNet),
           group: idx + 1,
           correction: false,
         },

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -117,8 +117,16 @@ function toInfaktTaxSymbol(taxRate: string): string {
   }
 }
 
-/** Parses a tax-rate string (neutral `'23'`/`'0.23'` or Infakt `tax_symbol` `'zw'`/`'np'`) to a decimal fraction. */
+/**
+ * Parses a tax-rate string (neutral `'23'`/`'0.23'` or Infakt `tax_symbol`
+ * `'zw'`/`'np'`) to a decimal fraction.
+ *
+ * Must stay consistent with `toInfaktTaxSymbol`'s empty-string fallback — a
+ * mismatched net/gross split for the declared tax_symbol is itself rejected
+ * by Infakt as an invalid `value.tax_values`.
+ */
 function taxRateNumeric(taxRate: string): number {
+  if (taxRate.trim() === '') return DEFAULT_PL_VAT_RATE;
   const n = parseFloat(taxRate);
   if (!isNaN(n) && n > 1) return n / 100;
   if (!isNaN(n)) return n;
@@ -445,16 +453,5 @@ export class InfaktInvoicingAdapter
     } catch {
       return null;
     }
-  }
-
-  private taxRateNumeric(taxRate: string): number {
-    // Must stay consistent with toInfaktTaxSymbol's empty-string fallback —
-    // a mismatched net/gross split for the declared tax_symbol is itself
-    // rejected by Infakt as an invalid `value.tax_values`.
-    if (taxRate.trim() === '') return DEFAULT_PL_VAT_RATE;
-    const n = parseFloat(taxRate);
-    if (!isNaN(n) && n > 1) return n / 100;
-    if (!isNaN(n)) return n;
-    return 0;
   }
 }

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -5,11 +5,15 @@
  * over the Infakt REST API v3. PL-specific logic (NIP mapping, ksef_data polling,
  * paragon vs faktura) stays here — never bleeds into libs/core.
  *
- * KSeF model: OL calls `issueInvoice` (creates a draft in Infakt) then
- * `getClearanceStatus` reads `ksef_data.status` off the stored invoice UUID.
- * Infakt submits to KSeF natively; OL does not build FA(3) XML. This is why the
- * adapter implements `RegulatoryStatusReader` (read-only clearance poll), NOT
- * `RegulatoryTransmitter` (active KSeF session + submit).
+ * KSeF model: `issueInvoice`/`issueCorrection` create the draft in Infakt AND
+ * explicitly trigger `send_to_ksef.json` inline, one atomic step — verified
+ * live (2026-07-01): an Infakt draft does NOT auto-submit to KSeF on its own,
+ * so this call is required or the document sits in `draft` forever. Infakt
+ * still builds the FA(3) XML and owns the KSeF session itself (OL never
+ * touches FA(3)); `getClearanceStatus` reads `ksef_data.status` for later
+ * polling. This is why the adapter implements `RegulatoryStatusReader`
+ * (read-only clearance poll), NOT `RegulatoryTransmitter` (which implies OL
+ * itself holds the active KSeF session).
  *
  * @module libs/integrations/infakt/src/infrastructure/adapters
  */
@@ -75,6 +79,18 @@ function toInfaktInvoiceType(documentType: string): string {
   }
 }
 
+/**
+ * Poland's standard VAT rate — the "regime rate" the adapter is documented
+ * (`order-to-issue-invoice-command.mapper.ts`) to resolve when core leaves
+ * `InvoiceLine.taxRate` empty, which it always does today (core never names
+ * a tax rate on the order contract). Verified live (2026-07-01): an empty
+ * `tax_symbol` doesn't just get rejected on its own field — Infakt cascades
+ * it into `services.gross` / `value.tax_values` errors too, so EVERY line on
+ * EVERY invoice 422'd before this fallback existed.
+ */
+const DEFAULT_PL_VAT_SYMBOL = '23';
+const DEFAULT_PL_VAT_RATE = 0.23;
+
 /** Maps neutral taxRate string to Infakt tax_symbol. */
 function toInfaktTaxSymbol(taxRate: string): string {
   // Common neutral→Infakt mapping; adapter owns this PL logic
@@ -97,7 +113,7 @@ function toInfaktTaxSymbol(taxRate: string): string {
     case 'oo':
       return 'np';
     default:
-      return taxRate;
+      return taxRate.trim() === '' ? DEFAULT_PL_VAT_SYMBOL : taxRate;
   }
 }
 
@@ -142,32 +158,35 @@ export class InfaktInvoicingAdapter
     if (nip) {
       const existing = await this.findClientByNip(nip);
       if (existing) {
-        this.logger.log(`Infakt client found by NIP ${nip}: ${existing.uuid}`);
-        return { providerCustomerId: existing.uuid };
+        this.logger.log(`Infakt client found by NIP ${nip}: ${existing.id}`);
+        return { providerCustomerId: String(existing.id) };
       }
     }
 
-    // Create new client
+    // Create new client. Field names verified live against the sandbox
+    // (2026-07-01): the API wants `company_name` / `postal_code`, not the
+    // `name` / `post_code` this previously sent — the latter is silently
+    // rejected/ignored, so first-time client creation always 422'd.
     const payload = {
       client: {
-        name: buyer.name,
+        company_name: buyer.name,
         nip: nip ?? undefined,
         city: buyer.address.city,
         street: buyer.address.line1,
-        post_code: buyer.address.postalCode,
+        postal_code: buyer.address.postalCode,
         country: buyer.address.countryIso2,
       },
     };
 
     // InfaktApiError carries `failureMode`; propagate as-is (see issueInvoice).
     const created = await this.http.post<InfaktClient>('clients.json', payload);
-    this.logger.log(`Infakt client created: ${created.uuid}`);
-    return { providerCustomerId: created.uuid };
+    this.logger.log(`Infakt client created: ${created.id}`);
+    return { providerCustomerId: String(created.id) };
   }
 
   async issueInvoice(cmd: IssueInvoiceCommand): Promise<IssueInvoiceResult> {
     const { lines, currency, documentType, idempotencyKey, orderId } = cmd;
-    const clientUuid = await this.resolveClientUuid(cmd);
+    const clientId = await this.resolveClientId(cmd);
 
     const kind = documentType === 'proforma' ? 'proforma' : 'vat';
     const services = lines.map((l) => ({
@@ -181,8 +200,15 @@ export class InfaktInvoicingAdapter
     const payload = {
       invoice: {
         kind,
-        payment_method: 'transfer',
-        client_uuid: clientUuid,
+        // 'cash' is the sandbox/production-safe default confirmed live
+        // (2026-06-30 POC) — 'transfer' is rejected unless the seller has a
+        // bank account configured in Infakt (`bank_account`/`bank_name`
+        // required), which OL has no way to know or configure per-connection.
+        payment_method: 'cash',
+        // Infakt's invoices.json wants the NUMERIC client id, not the client
+        // uuid — verified live (2026-07-01): `client_uuid` is silently
+        // ignored and the request 422s with "client_id required".
+        client_id: clientId,
         services,
         ...(idempotencyKey ? { external_id: idempotencyKey } : {}),
       },
@@ -195,7 +221,15 @@ export class InfaktInvoicingAdapter
 
     this.logger.log(`Infakt invoice created: ${invoice.uuid} (${invoice.number ?? 'draft'})`);
 
-    const ksefStatus = invoice.ksef_data?.status ?? null;
+    // Issuing does NOT submit to KSeF on its own — verified live (2026-07-01):
+    // an Infakt invoice sits in `draft` (KSeF-untouched) forever unless
+    // send_to_ksef.json is called explicitly. Mirrors how KSeF's own
+    // `issueInvoice` submits inline (build → session → submit, one atomic
+    // step) and how Subiekt "transmits to KSeF natively at issuance" — for
+    // Infakt that native transmission requires this explicit kick, so it
+    // belongs in the same place: issuing IS submitting.
+    const ksefResult = await this.sendToKsef(invoice.uuid);
+
     const now = new Date();
     const record = new InvoiceRecord(
       randomUUID(),
@@ -206,8 +240,8 @@ export class InfaktInvoicingAdapter
       'issued',
       invoice.uuid,
       invoice.number ?? null,
-      toRegulatoryStatus(ksefStatus),
-      invoice.ksef_data?.ksef_number ?? null,
+      toRegulatoryStatus(ksefResult.status),
+      ksefResult.ksef_number,
       idempotencyKey ?? null,
       invoice.pdf_url ?? null,
       now,
@@ -339,6 +373,11 @@ export class InfaktInvoicingAdapter
       invoice: {
         kind: 'corrective',
         payment_method: 'cash',
+        // Required by Infakt on every invoice, corrective included — verified
+        // live (2026-07-01): omitting it 422s with "client_id required". The
+        // original invoice already carries the numeric id, so no extra
+        // upsertCustomer round-trip is needed for a correction.
+        client_id: original.client_id,
         corrected_invoice_number: original.number,
         corrected_invoice_date: original.invoice_date ?? new Date().toISOString().slice(0, 10),
         correction_reason_symbol: 'other',
@@ -352,6 +391,11 @@ export class InfaktInvoicingAdapter
     const invoice = await this.http.post<InfaktInvoice>('invoices.json', payload);
 
     this.logger.log(`Infakt correction created: ${invoice.uuid} (${invoice.number ?? 'draft'})`);
+
+    // A correction is its own KSeF document (KOR) — it needs the same explicit
+    // submission kick as the original (see issueInvoice).
+    const ksefResult = await this.sendToKsef(invoice.uuid);
+
     const now = new Date();
     return new InvoiceRecord(
       randomUUID(),
@@ -362,8 +406,8 @@ export class InfaktInvoicingAdapter
       'issued',
       invoice.uuid,
       invoice.number ?? null,
-      'not-applicable',
-      null,
+      toRegulatoryStatus(ksefResult.status),
+      ksefResult.ksef_number,
       idempotencyKey ?? null,
       invoice.pdf_url ?? null,
       now,
@@ -374,6 +418,9 @@ export class InfaktInvoicingAdapter
   }
 
   // --- Infakt-specific: trigger KSeF submission ---
+  // Called inline by issueInvoice/issueCorrection (issuing IS submitting for
+  // this provider). Left public rather than private so an operator-facing
+  // manual re-submit can reuse it later without adding a second code path.
 
   async sendToKsef(invoiceUuid: string): Promise<InfaktSendToKsefResponse> {
     return this.http.post<InfaktSendToKsefResponse>(
@@ -384,9 +431,9 @@ export class InfaktInvoicingAdapter
 
   // --- helpers ---
 
-  private async resolveClientUuid(cmd: IssueInvoiceCommand): Promise<string> {
+  private async resolveClientId(cmd: IssueInvoiceCommand): Promise<number> {
     const result = await this.upsertCustomer({ connectionId: cmd.connectionId, buyer: cmd.buyer });
-    return result.providerCustomerId;
+    return Number(result.providerCustomerId);
   }
 
   private async findClientByNip(nip: string): Promise<InfaktClient | null> {
@@ -398,5 +445,16 @@ export class InfaktInvoicingAdapter
     } catch {
       return null;
     }
+  }
+
+  private taxRateNumeric(taxRate: string): number {
+    // Must stay consistent with toInfaktTaxSymbol's empty-string fallback —
+    // a mismatched net/gross split for the declared tax_symbol is itself
+    // rejected by Infakt as an invalid `value.tax_values`.
+    if (taxRate.trim() === '') return DEFAULT_PL_VAT_RATE;
+    const n = parseFloat(taxRate);
+    if (!isNaN(n) && n > 1) return n / 100;
+    if (!isNaN(n)) return n;
+    return 0;
   }
 }

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -452,8 +452,9 @@ export class InfaktInvoicingAdapter
 
   // --- Infakt-specific: trigger KSeF submission ---
   // Called inline by issueInvoice/issueCorrection (issuing IS submitting for
-  // this provider). Left public rather than private so an operator-facing
-  // manual re-submit can reuse it later without adding a second code path.
+  // this provider). Public: already called directly by
+  // scripts/poc-sandbox-test.ts, and kept accessible so a future
+  // operator-facing manual re-submit can reuse it without a second code path.
 
   async sendToKsef(invoiceUuid: string): Promise<InfaktSendToKsefResponse> {
     return this.http.post<InfaktSendToKsefResponse>(

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -53,7 +53,18 @@ const SUPPORTED_DOCUMENT_TYPES: readonly DocumentType[] = [
   'prepayment',
 ];
 
-/** Maps Infakt ksef_data.status → neutral RegulatoryStatus. */
+/**
+ * Maps Infakt ksef_data.status → neutral RegulatoryStatus.
+ *
+ * `success` is the TERMINAL accepted state — it must map to `accepted`, not
+ * `cleared`. `cleared` is reserved for split-clearance regimes (no current
+ * provider emits it) and the FE's status card only branches on
+ * `submitted`/`accepted`/`rejected`, so a `cleared` mapping here left the
+ * badge permanently stuck at "CLEARING" and hid the clearance-reference chip
+ * even once the invoice had genuinely cleared on the government side
+ * (#1293 review, live E2E finding). Mirrors KSeF's own adapter, which maps
+ * its terminal 200 status to `accepted` for the exact same reason.
+ */
 function toRegulatoryStatus(ksefStatus: InfaktKsefStatus | null | undefined): RegulatoryStatus {
   if (!ksefStatus) return 'not-applicable';
   switch (ksefStatus) {
@@ -61,7 +72,7 @@ function toRegulatoryStatus(ksefStatus: InfaktKsefStatus | null | undefined): Re
     case 'sent':
       return 'submitted';
     case 'success':
-      return 'cleared';
+      return 'accepted';
     case 'error':
       return 'rejected';
   }

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -236,6 +236,18 @@ export class InfaktInvoicingAdapter
     // step) and how Subiekt "transmits to KSeF natively at issuance" — for
     // Infakt that native transmission requires this explicit kick, so it
     // belongs in the same place: issuing IS submitting.
+    //
+    // Retry-safety assumption (unverified — #1293 review): if this call
+    // throws (network/API error), the draft above was already created and
+    // this whole method rejects, so core treats issuance as failed. A caller
+    // retry re-invokes issueInvoice, which re-POSTs invoices.json with the
+    // SAME external_id (idempotencyKey). We rely on Infakt returning/reusing
+    // the same invoice uuid for a repeat external_id rather than creating a
+    // duplicate draft — that would make this second sendToKsef call a safe
+    // re-attempt on the same document. This dedup behaviour has not been
+    // confirmed against the live API; if Infakt instead creates a new draft
+    // per POST, a failed sendToKsef leaves an orphaned un-submitted document
+    // on every retry.
     const ksefResult = await this.sendToKsef(invoice.uuid);
 
     const now = new Date();
@@ -402,6 +414,13 @@ export class InfaktInvoicingAdapter
 
     // A correction is its own KSeF document (KOR) — it needs the same explicit
     // submission kick as the original (see issueInvoice).
+    //
+    // Same retry-safety assumption as issueInvoice (unverified — #1293
+    // review): a retry re-calls issueCorrection, which re-POSTs
+    // invoices.json with the same external_id; we rely on Infakt
+    // returning/reusing the same correction uuid rather than creating a
+    // second corrective draft, which would make this sendToKsef call a safe
+    // re-attempt on the same document.
     const ksefResult = await this.sendToKsef(invoice.uuid);
 
     const now = new Date();

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-webhook-event-translator.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-webhook-event-translator.adapter.ts
@@ -19,11 +19,11 @@ import type {
   WebhookEventTranslatorPort,
 } from '@openlinker/core/integrations';
 import { Logger } from '@openlinker/shared/logging';
-import { InfaktWebhookTranslator } from '../../infrastructure/webhooks/infakt-webhook-translator';
+import { InfaktWebhookTranslator } from '../webhooks/infakt-webhook-translator';
 
 export class InfaktWebhookEventTranslatorAdapter implements WebhookEventTranslatorPort {
-  private readonly translator = new InfaktWebhookTranslator(
-    { secret: '' },
+  /** Secret-independent parsing helpers only — this adapter never verifies signatures. */
+  private readonly translator = InfaktWebhookTranslator.forParsing(
     new Logger(InfaktWebhookEventTranslatorAdapter.name),
   );
 

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-webhook-event-translator.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-webhook-event-translator.adapter.ts
@@ -1,0 +1,45 @@
+/**
+ * Infakt Webhook Event Translator Adapter (#1281, ADR-015)
+ *
+ * Decodes the neutral envelope produced by `InfaktInboundWebhookDecoderAdapter`
+ * into a `CanonicalInboundEvent` on the `invoicing` domain. Only the two
+ * KSeF-clearance event names Infakt confirmed live
+ * (`send_to_ksef_success` / `send_to_ksef_error`) route through — reused from
+ * `InfaktWebhookTranslator.toOlDomain` so the allowlist has one source of
+ * truth with the already-tested POC class. Every other Infakt event
+ * (`draft_invoice_created`, `invoice_marked_as_paid`, …) is well-formed but
+ * not yet actionable by OL → `null` (dead-letter), per the translator's
+ * total-function contract.
+ *
+ * @module libs/integrations/infakt/src/infrastructure/adapters
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+import type {
+  CanonicalInboundEvent,
+  WebhookEventTranslatorPort,
+} from '@openlinker/core/integrations';
+import { Logger } from '@openlinker/shared/logging';
+import { InfaktWebhookTranslator } from '../../infrastructure/webhooks/infakt-webhook-translator';
+
+export class InfaktWebhookEventTranslatorAdapter implements WebhookEventTranslatorPort {
+  private readonly translator = new InfaktWebhookTranslator(
+    { secret: '' },
+    new Logger(InfaktWebhookEventTranslatorAdapter.name),
+  );
+
+  translate(event: InboundWebhookEvent): CanonicalInboundEvent | null {
+    if (event.objectType !== 'invoice') {
+      return null;
+    }
+    if (this.translator.toOlDomain(event.eventType) !== 'invoicing') {
+      return null;
+    }
+    return {
+      domain: 'invoicing',
+      externalId: event.externalId,
+      eventType: event.eventType,
+      occurredAt: event.occurredAt,
+      payload: event.payload,
+    };
+  }
+}

--- a/libs/integrations/infakt/src/infrastructure/webhooks/__tests__/infakt-webhook-translator.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/webhooks/__tests__/infakt-webhook-translator.spec.ts
@@ -30,6 +30,14 @@ describe('InfaktWebhookTranslator', () => {
     translator = new InfaktWebhookTranslator({ secret: SECRET }, logger);
   });
 
+  describe('forParsing', () => {
+    it('should build a translator usable for parsing without a real secret', () => {
+      const parsingTranslator = InfaktWebhookTranslator.forParsing(logger);
+      const body = Buffer.from(JSON.stringify({ verification_code: 'abc123' }));
+      expect(parsingTranslator.getVerificationEcho(body)).toEqual({ verification_code: 'abc123' });
+    });
+  });
+
   describe('verifySignature', () => {
     it('should return true for a valid signature', () => {
       const body = Buffer.from(JSON.stringify({ event: { name: 'x' } }));

--- a/libs/integrations/infakt/src/infrastructure/webhooks/__tests__/infakt-webhook-translator.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/webhooks/__tests__/infakt-webhook-translator.spec.ts
@@ -75,6 +75,27 @@ describe('InfaktWebhookTranslator', () => {
       const body = Buffer.from('not json');
       expect(translator.getVerificationEcho(body)).toBeNull();
     });
+
+    it('should return null when a signed event carries a verification_code field', () => {
+      const body = Buffer.from(
+        JSON.stringify({
+          event: { uuid: 'e-1', name: 'send_to_ksef_success' },
+          resource: { verification_code: 'not-a-handshake' },
+        }),
+      );
+      expect(translator.getVerificationEcho(body)).toBeNull();
+    });
+
+    it('should return null when verification_code exceeds the length cap', () => {
+      const body = Buffer.from(JSON.stringify({ verification_code: 'a'.repeat(257) }));
+      expect(translator.getVerificationEcho(body)).toBeNull();
+    });
+
+    it('should echo a verification_code at exactly the length cap', () => {
+      const code = 'a'.repeat(256);
+      const body = Buffer.from(JSON.stringify({ verification_code: code }));
+      expect(translator.getVerificationEcho(body)).toEqual({ verification_code: code });
+    });
   });
 
   describe('parse', () => {

--- a/libs/integrations/infakt/src/infrastructure/webhooks/infakt-webhook-translator.ts
+++ b/libs/integrations/infakt/src/infrastructure/webhooks/infakt-webhook-translator.ts
@@ -90,6 +90,16 @@ export class InfaktWebhookTranslator {
   ) {}
 
   /**
+   * Builds a translator for callers that only need the secret-independent
+   * parsing helpers (`getVerificationEcho`, `parse`, `toOlDomain`,
+   * `toKsefResource`) — never `verifySignature`, which is always constructed
+   * separately with the per-connection resolved secret.
+   */
+  static forParsing(logger: LoggerPort): InfaktWebhookTranslator {
+    return new InfaktWebhookTranslator({ secret: '' }, logger);
+  }
+
+  /**
    * Returns the verification_code echo body when Infakt sends a verification ping.
    * The OL webhook controller must respond with this JSON body to activate the webhook.
    * Returns null if the payload is not a verification ping.

--- a/libs/integrations/infakt/src/infrastructure/webhooks/infakt-webhook-translator.ts
+++ b/libs/integrations/infakt/src/infrastructure/webhooks/infakt-webhook-translator.ts
@@ -84,6 +84,9 @@ export interface InfaktWebhookTranslatorConfig {
 }
 
 export class InfaktWebhookTranslator {
+  /** Handshake pings send a short random token; caps the pre-verification echo (see `getVerificationEcho`). */
+  private static readonly MAX_VERIFICATION_CODE_LENGTH = 256;
+
   constructor(
     private readonly config: InfaktWebhookTranslatorConfig,
     private readonly logger: LoggerPort,
@@ -103,6 +106,14 @@ export class InfaktWebhookTranslator {
    * Returns the verification_code echo body when Infakt sends a verification ping.
    * The OL webhook controller must respond with this JSON body to activate the webhook.
    * Returns null if the payload is not a verification ping.
+   *
+   * Gated on the absence of the `event` envelope: every signed delivery is
+   * `{ event, resource }` (see `parse`), while the handshake ping is the bare
+   * `{ verification_code }` shape. Without this guard, a signed event that
+   * happened to carry a string `verification_code` field would be
+   * mis-short-circuited here and never routed. `verification_code` is also
+   * length-capped — the handshake echo is returned pre-signature-verification,
+   * so an oversized value is rejected rather than reflected back verbatim.
    */
   getVerificationEcho(rawBody: Buffer): { verification_code: string } | null {
     try {
@@ -110,10 +121,14 @@ export class InfaktWebhookTranslator {
       if (
         typeof parsed === 'object' &&
         parsed !== null &&
+        !('event' in parsed) &&
         'verification_code' in parsed &&
         typeof (parsed as Record<string, unknown>)['verification_code'] === 'string'
       ) {
-        return { verification_code: (parsed as { verification_code: string }).verification_code };
+        const code = (parsed as { verification_code: string }).verification_code;
+        if (code.length <= InfaktWebhookTranslator.MAX_VERIFICATION_CODE_LENGTH) {
+          return { verification_code: code };
+        }
       }
     } catch {
       // not JSON

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       '@openlinker/integrations-erli':
         specifier: workspace:*
         version: link:../../libs/integrations/erli
+      '@openlinker/integrations-infakt':
+        specifier: workspace:*
+        version: link:../../libs/integrations/infakt
       '@openlinker/integrations-inpost':
         specifier: workspace:*
         version: link:../../libs/integrations/inpost
@@ -384,6 +387,9 @@ importers:
       '@openlinker/integrations-erli':
         specifier: workspace:*
         version: link:../../libs/integrations/erli
+      '@openlinker/integrations-infakt':
+        specifier: workspace:*
+        version: link:../../libs/integrations/infakt
       '@openlinker/integrations-inpost':
         specifier: workspace:*
         version: link:../../libs/integrations/inpost


### PR DESCRIPTION
## Summary

Stacked on #1292 (#1280, not yet merged) - this branch is based on `1280-infakt-plugin-hardening-tests` so it carries that PR's diff until it merges. Opened as **draft** for that reason.

Part of the Infakt epic (#1279). Closes #1281.

- Registers `InfaktIntegrationModule` in `apps/api/src/plugins.ts` and `apps/worker/src/plugins.ts` (mirrors the KSeF/Subiekt dual-registration pattern) so the host can resolve the `Invoicing` capability for Infakt connections
- Adds `@openlinker/integrations-infakt` to `apps/api`/`apps/worker` `package.json`, and the jest-integration moduleNameMapper entries
- Wires Infakt's third-party-native webhook (KSeF clearance relay) into OL's ingestion pipeline per ADR-021/ADR-015:
  - `InfaktInboundWebhookDecoderAdapter` (provider-keyed `infakt`): HMAC-SHA256 signature verify (no timestamp header, so no replay-window check for this provider), subscription-verification handshake detection, envelope extraction — wraps the already-tested `InfaktWebhookTranslator` from the #1280 POC rather than duplicating its crypto/parsing
  - `InfaktWebhookEventTranslatorAdapter` (adapterKey-keyed `infakt.accounting.v1`): maps `send_to_ksef_success` / `send_to_ksef_error` to the new `invoicing` inbound domain; other Infakt events dead-letter (`null`)
- Extends `InboundWebhookDecoderPort` with an optional `detectHandshake` step (runs before `verify`) so a provider's subscription-verification ping can echo a body back — `WebhookService`/`WebhookController` now thread a return value through instead of always resolving `void`. This is additive; `DefaultWebhookDecoder` and existing decoders (InPost) are unaffected.
- Adds `'invoicing'` to the closed `InboundEventDomainValues` union and a new `InboundRoutingPolicyService` case: an `invoicing` webhook event enqueues the existing `invoicing.regulatoryStatus.reconcile` job (gated on the `Invoicing` capability). No new by-id job — the webhook is a trigger, not the source of truth (mirrors the InPost/webhook philosophy already documented in `architecture-overview.md`); the scheduled reconcile still drains the full non-terminal frontier regardless.

No `WebhookProvisioningPort` (Infakt webhook setup is UI-only, per issue scope).

**Scope note**: beyond the plugin registration/webhook wiring described above, this PR also carries several fiscal fixes surfaced by live sandbox E2E testing during review — most notably an integer-groszy wire-format correction (invoices were being issued at ~1/100th of the real total) and a KSeF `success` -> `accepted` regulatory-status mapping fix (previously mapped to `cleared`, which the FE never renders as terminal). Both are covered by tests and confirmed against the real sandbox.

## Test plan

- [x] `pnpm --filter @openlinker/integrations-infakt test` - 9 suites, 93 tests passing (2 new spec files)
- [x] `pnpm --filter @openlinker/core test` - 138 suites, 1410 tests passing (incl. new `invoicing` routing cases)
- [x] `pnpm --filter @openlinker/api test` - 48 suites, 580 tests passing (incl. new handshake short-circuit cases)
- [x] `pnpm --filter @openlinker/worker test` - 17 suites, 188 tests passing
- [x] `pnpm lint` - 0 errors (only pre-existing warnings)
- [x] `pnpm type-check` - 0 errors across all packages
- [x] `pnpm check:invariants` - cross-context imports, service interfaces, jest-integration-mappers all pass
- [x] Manual: `pnpm start:dev:api` starts without errors with Infakt module registered
- [x] Manual: `GET /adapters` lists `infakt.accounting.v1` (route is `GET /adapters`, not `/integrations/adapters`)
- [x] Manual: `POST /webhooks/infakt/{connectionId}` with valid HMAC signature returns 202
- [x] Manual: `POST /webhooks/infakt/{connectionId}` with invalid signature returns 401
- [x] Manual: verification handshake echoes `verification_code` back correctly — required a fix: Infakt's own verifier only accepts HTTP 200 for the echo, not 202 (see manual QA comment below for the full writeup, incl. a live E2E confirmation and 7 other bugs found + fixed against the real sandbox)
