### PR TITLE
fix(erli): webhook signature verification silently rejects every real delivery

### DIFF
--- a/apps/api/test/integration/erli/erli-webhook-ingestion.int-spec.ts
+++ b/apps/api/test/integration/erli/erli-webhook-ingestion.int-spec.ts
@@ -1,0 +1,151 @@
+/**
+ * Erli Webhook Ingestion Integration Test (#1081 / #1294, ADR-021)
+ *
+ * End-to-end proof of the NATIVE Erli ingress over real HTTP: a genuine
+ * `Authorization: Bearer <secret>` delivery, in Erli's real full-order-resource
+ * body shape, through the registered `ErliInboundWebhookDecoderAdapter`
+ * (verify + extractEnvelope) → dedup → publish → the real
+ * `ErliWebhookEventTranslator` → the real `InboundRoutingPolicy` →
+ * `marketplace.order.sync`. Complements
+ * `erli-orders-vertical-slice.int-spec.ts` S1/S2, which drive the
+ * translator/routing pair directly (the native decoder did not exist when
+ * that file's header was authored) and only prove the fail-closed path over
+ * HTTP — this spec is the one that proves a genuine signature succeeds
+ * through the real host ingress end to end (piotrswierzy's PR #1295 review).
+ *
+ * @module apps/api/test/integration/erli
+ */
+import { randomUUID } from 'crypto';
+import { getTestHarness, resetTestHarness, teardownTestHarness } from '../setup';
+import type { IntegrationTestHarness } from '../setup';
+import { createTestConnection } from '../helpers/test-connection.helper';
+
+/** The real, registered Erli adapterKey (mirrors `erli.constants.ts`'s `ERLI_ADAPTER_KEY`). */
+const ERLI_ADAPTER_KEY = 'erli.shopapi.v1';
+
+/** A real Erli webhook delivery is the full order resource — only `id` is load-bearing. */
+function buildErliOrderWebhookBody(orderId: string, updated: string): Record<string, unknown> {
+  return {
+    id: orderId,
+    status: 'purchased',
+    updated,
+    created: updated,
+  };
+}
+
+describe('Erli Webhook Ingestion Integration (#1081 / #1294)', () => {
+  let harness: IntegrationTestHarness;
+  const webhookSecret = 'erli-native-decoder-test-secret-135790';
+  let priorEnvSecret: string | undefined;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    priorEnvSecret = process.env.OPENLINKER_WEBHOOK_SECRET__ERLI;
+    // Provider-level env fallback (`CredentialsWebhookSecretAdapter`) — same
+    // mechanism the InPost/PrestaShop webhook int-specs use; simplest way to
+    // give the real decoder a secret to verify against without going through
+    // the full provisioning (`ErliWebhookProvisioningAdapter.install`) flow.
+    process.env.OPENLINKER_WEBHOOK_SECRET__ERLI = webhookSecret;
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    if (priorEnvSecret === undefined) {
+      delete process.env.OPENLINKER_WEBHOOK_SECRET__ERLI;
+    } else {
+      process.env.OPENLINKER_WEBHOOK_SECRET__ERLI = priorEnvSecret;
+    }
+    await teardownTestHarness();
+  });
+
+  async function createErliConnection(): Promise<{ id: string }> {
+    return createTestConnection(harness.getDataSource(), {
+      platformType: 'erli',
+      status: 'active',
+      adapterKey: ERLI_ADAPTER_KEY,
+      config: {},
+      enabledCapabilities: ['OrderSource'],
+    });
+  }
+
+  it('verifies a real Bearer-signed Erli order webhook and routes it to a marketplace.order.sync job', async () => {
+    const connection = await createErliConnection();
+    const orderId = `erli-order-${randomUUID()}`;
+    const body = buildErliOrderWebhookBody(orderId, new Date().toISOString());
+
+    await harness
+      .getHttp()
+      .post(`/webhooks/erli/${connection.id}`)
+      .set('Authorization', `Bearer ${webhookSecret}`)
+      .send(body)
+      .expect(202);
+
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    const redisClient = harness.getRedisClient();
+    if (!redisClient) throw new Error('Redis client not available');
+
+    const jobs = await redisClient.xRead([{ key: 'jobs.sync', id: '0' }], { COUNT: 50 });
+    const orderJob = jobs?.[0]?.messages.find((msg) => {
+      if (msg.message.jobType !== 'marketplace.order.sync') return false;
+      if (msg.message.connectionId !== connection.id) return false;
+      try {
+        const payload = JSON.parse(msg.message.payloadJson) as {
+          externalOrderId?: string;
+        };
+        return payload.externalOrderId === orderId;
+      } catch {
+        return false;
+      }
+    });
+    expect(orderJob).toBeDefined();
+
+    // The controller's own 'published' delivery-recording write and the
+    // handler's later 'job_enqueued' write race independently of the job
+    // enqueue itself (both are best-effort, #711) — assert only that a
+    // signature-verified delivery row exists, not its exact terminal status.
+    const deliveryRows: Array<{ signatureValid: boolean }> = await harness.getDataSource().query(
+      `SELECT "signatureValid" FROM webhook_deliveries WHERE provider = 'erli' AND "connectionId" = $1`,
+      [connection.id],
+    );
+    expect(deliveryRows).toHaveLength(1);
+    expect(deliveryRows[0].signatureValid).toBe(true);
+  });
+
+  it('rejects an Erli webhook with a wrong Bearer token (401), records no delivery, enqueues no job', async () => {
+    const connection = await createErliConnection();
+    const orderId = `erli-order-${randomUUID()}`;
+
+    await harness
+      .getHttp()
+      .post(`/webhooks/erli/${connection.id}`)
+      .set('Authorization', 'Bearer not-the-real-secret')
+      .send(buildErliOrderWebhookBody(orderId, new Date().toISOString()))
+      .expect(401);
+
+    const deliveryRows: Array<{ n: number }> = await harness.getDataSource().query(
+      `SELECT count(*)::int AS n FROM webhook_deliveries WHERE provider = 'erli' AND "connectionId" = $1`,
+      [connection.id],
+    );
+    expect(deliveryRows[0].n).toBe(0);
+  });
+
+  it('rejects an Erli webhook with a lowercase "bearer" scheme carrying the wrong token (401)', async () => {
+    const connection = await createErliConnection();
+    const orderId = `erli-order-${randomUUID()}`;
+
+    // Regression guard for the case-sensitivity fix (#1295 round-1 review):
+    // a lowercase scheme must still go through the same case-insensitive
+    // prefix strip, so a WRONG token under that scheme is rejected on its
+    // own merits — not because the scheme match itself broke.
+    await harness
+      .getHttp()
+      .post(`/webhooks/erli/${connection.id}`)
+      .set('Authorization', 'bearer not-the-real-secret')
+      .send(buildErliOrderWebhookBody(orderId, new Date().toISOString()))
+      .expect(401);
+  });
+});

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts
@@ -58,6 +58,15 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
       expect(result.ok).toBe(true);
     });
 
+    it('should accept a lowercase "bearer" auth scheme', () => {
+      const result = decoder.verify({
+        rawBody: makeBody(),
+        headers: { authorization: `bearer ${SECRET}` },
+        secret: SECRET,
+      });
+      expect(result.ok).toBe(true);
+    });
+
     it('should reject a tampered (wrong) access token', () => {
       const result = decoder.verify({
         rawBody: makeBody(),
@@ -111,6 +120,19 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
     it('should produce a deterministic eventId for the same orderId + updated timestamp', () => {
       const a = decoder.extractEnvelope(makeBody({ updated: '2026-07-01T11:20:17.415Z' }), {});
       const b = decoder.extractEnvelope(makeBody({ updated: '2026-07-01T11:20:17.415Z' }), {});
+      expect(a.action).toBe('route');
+      expect(b.action).toBe('route');
+      if (a.action !== 'route' || b.action !== 'route') return;
+      expect(a.envelope.eventId).toBe(b.envelope.eventId);
+    });
+
+    it('should produce a deterministic eventId across retried deliveries of a timestamp-less body', () => {
+      // Guards against the eventId hash basis absorbing the decode-time "now"
+      // fallback used for the envelope's advisory occurredAt — that value must
+      // stay out of the dedup hash or every retry would mint a fresh eventId
+      // and defeat the Postgres eventId-dedup gate.
+      const a = decoder.extractEnvelope(makeBody(), {});
+      const b = decoder.extractEnvelope(makeBody(), {});
       expect(a.action).toBe('route');
       expect(b.action).toBe('route');
       if (a.action !== 'route' || b.action !== 'route') return;

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts
@@ -162,6 +162,27 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
       expect(created.envelope.eventId).not.toBe(cancelled.envelope.eventId);
     });
 
+    it('should produce distinct eventIds for a status change even when the body carries no timestamp', () => {
+      // Regression: a timestamp-less body used to hash on orderId alone, so
+      // the dedup gate would drop a later real status change for the same
+      // order. status is now folded into the hash basis too.
+      const created = decoder.extractEnvelope(makeBody({ status: 'purchased' }), {});
+      const cancelled = decoder.extractEnvelope(makeBody({ status: 'cancelled' }), {});
+      expect(created.action).toBe('route');
+      expect(cancelled.action).toBe('route');
+      if (created.action !== 'route' || cancelled.action !== 'route') return;
+      expect(created.envelope.eventId).not.toBe(cancelled.envelope.eventId);
+    });
+
+    it('should produce the same eventId for a retried delivery of an identical timestamp-less body', () => {
+      const a = decoder.extractEnvelope(makeBody({ status: 'purchased' }), {});
+      const b = decoder.extractEnvelope(makeBody({ status: 'purchased' }), {});
+      expect(a.action).toBe('route');
+      expect(b.action).toBe('route');
+      if (a.action !== 'route' || b.action !== 'route') return;
+      expect(a.envelope.eventId).toBe(b.envelope.eventId);
+    });
+
     it('should reject malformed JSON', () => {
       const result = decoder.extractEnvelope(Buffer.from('not json'), {});
       expect(result.action).toBe('reject');

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-inbound-webhook-decoder.adapter.spec.ts
@@ -1,10 +1,12 @@
 /**
  * Unit tests for ErliInboundWebhookDecoderAdapter (#1081, ADR-021).
  *
- * All wire constants are provisional (#992); tests are deliberately written
- * against the named constants (`ERLI_WEBHOOK_ACCESS_TOKEN_HEADER`, etc.) so
- * that updating the constants in `erli-webhook.types.ts` cascades through
- * without touching these assertions.
+ * Wire shapes are confirmed against the live sandbox (#992, 2026-07-01): the
+ * body is the full order resource (no `type` discriminator), keyed by `id`;
+ * the access token arrives on the standard `Authorization: Bearer <token>`
+ * header. Tests are written against the named constants
+ * (`ERLI_WEBHOOK_ACCESS_TOKEN_HEADER`, etc.) so future wire reconciliations
+ * cascade through without touching these assertions.
  */
 import { ErliInboundWebhookDecoderAdapter } from '../erli-inbound-webhook-decoder.adapter';
 
@@ -13,7 +15,7 @@ const ORDER_ID = 'erli-order-fake-123';
 
 function makeBody(overrides: Record<string, unknown> = {}): Buffer {
   return Buffer.from(
-    JSON.stringify({ type: 'orderCreated', orderId: ORDER_ID, ...overrides }),
+    JSON.stringify({ id: ORDER_ID, status: 'purchased', ...overrides }),
   );
 }
 
@@ -29,10 +31,19 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
   // ---------------------------------------------------------------------------
 
   describe('verify', () => {
-    it('should accept a correctly-matched access token', () => {
+    it('should accept a correctly-matched Bearer access token', () => {
       const result = decoder.verify({
         rawBody: makeBody(),
-        headers: { 'x-access-token': SECRET },
+        headers: { authorization: `Bearer ${SECRET}` },
+        secret: SECRET,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('should accept a bare (non-Bearer-prefixed) access token', () => {
+      const result = decoder.verify({
+        rawBody: makeBody(),
+        headers: { authorization: SECRET },
         secret: SECRET,
       });
       expect(result.ok).toBe(true);
@@ -41,7 +52,7 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
     it('should accept the header in any casing', () => {
       const result = decoder.verify({
         rawBody: makeBody(),
-        headers: { 'X-Access-Token': SECRET },
+        headers: { Authorization: `Bearer ${SECRET}` },
         secret: SECRET,
       });
       expect(result.ok).toBe(true);
@@ -50,13 +61,13 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
     it('should reject a tampered (wrong) access token', () => {
       const result = decoder.verify({
         rawBody: makeBody(),
-        headers: { 'x-access-token': 'wrong-token' },
+        headers: { authorization: 'Bearer wrong-token' },
         secret: SECRET,
       });
       expect(result.ok).toBe(false);
     });
 
-    it('should reject when the access-token header is absent', () => {
+    it('should reject when the Authorization header is absent', () => {
       const result = decoder.verify({
         rawBody: makeBody(),
         headers: {},
@@ -65,10 +76,10 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
       expect(result.ok).toBe(false);
     });
 
-    it('should not return timestampMs (provisional: no signed timestamp from Erli)', () => {
+    it('should not return timestampMs (Erli sends no signed delivery timestamp)', () => {
       const result = decoder.verify({
         rawBody: makeBody(),
-        headers: { 'x-access-token': SECRET },
+        headers: { authorization: `Bearer ${SECRET}` },
         secret: SECRET,
       });
       expect(result).not.toHaveProperty('timestampMs');
@@ -80,23 +91,13 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
   // ---------------------------------------------------------------------------
 
   describe('extractEnvelope', () => {
-    it('should route an orderCreated event with the orderId as externalId', () => {
+    it('should route the full-order-resource body with id as externalId', () => {
       const result = decoder.extractEnvelope(makeBody(), {});
       expect(result.action).toBe('route');
       if (result.action !== 'route') return;
       expect(result.envelope.externalId).toBe(ORDER_ID);
-      expect(result.envelope.eventType).toBe('orderCreated');
-      expect(result.envelope.objectType).toBe('order');
-    });
-
-    it('should route an orderStatusChanged event', () => {
-      const result = decoder.extractEnvelope(
-        makeBody({ type: 'orderStatusChanged' }),
-        {},
-      );
-      expect(result.action).toBe('route');
-      if (result.action !== 'route') return;
       expect(result.envelope.eventType).toBe('orderStatusChanged');
+      expect(result.envelope.objectType).toBe('order');
     });
 
     it('should include a non-empty eventId', () => {
@@ -107,9 +108,9 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
       expect(result.envelope.eventId.length).toBeGreaterThan(0);
     });
 
-    it('should produce a deterministic eventId for the same orderId + eventType', () => {
-      const a = decoder.extractEnvelope(makeBody(), {});
-      const b = decoder.extractEnvelope(makeBody(), {});
+    it('should produce a deterministic eventId for the same orderId + updated timestamp', () => {
+      const a = decoder.extractEnvelope(makeBody({ updated: '2026-07-01T11:20:17.415Z' }), {});
+      const b = decoder.extractEnvelope(makeBody({ updated: '2026-07-01T11:20:17.415Z' }), {});
       expect(a.action).toBe('route');
       expect(b.action).toBe('route');
       if (a.action !== 'route' || b.action !== 'route') return;
@@ -124,18 +125,19 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
       expect(result.envelope.eventId).toBe(explicitId);
     });
 
-    it('should produce distinct eventIds for the same orderId but different eventTypes', () => {
-      const created = decoder.extractEnvelope(makeBody({ type: 'orderCreated' }), {});
-      const changed = decoder.extractEnvelope(makeBody({ type: 'orderStatusChanged' }), {});
+    it('should produce distinct eventIds for successive deliveries of the same order (create, then cancel)', () => {
+      const created = decoder.extractEnvelope(
+        makeBody({ updated: '2026-07-01T11:20:17.415Z' }),
+        {},
+      );
+      const cancelled = decoder.extractEnvelope(
+        makeBody({ status: 'cancelled', updated: '2026-07-01T11:37:02.000Z' }),
+        {},
+      );
       expect(created.action).toBe('route');
-      expect(changed.action).toBe('route');
-      if (created.action !== 'route' || changed.action !== 'route') return;
-      expect(created.envelope.eventId).not.toBe(changed.envelope.eventId);
-    });
-
-    it('should ignore (not reject) an unknown event type', () => {
-      const result = decoder.extractEnvelope(makeBody({ type: 'unknownEvent' }), {});
-      expect(result.action).toBe('ignore');
+      expect(cancelled.action).toBe('route');
+      if (created.action !== 'route' || cancelled.action !== 'route') return;
+      expect(created.envelope.eventId).not.toBe(cancelled.envelope.eventId);
     });
 
     it('should reject malformed JSON', () => {
@@ -143,33 +145,27 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
       expect(result.action).toBe('reject');
     });
 
-    it('should reject a body with a missing orderId', () => {
-      const body = Buffer.from(JSON.stringify({ type: 'orderCreated' }));
+    it('should reject a body with a missing id', () => {
+      const body = Buffer.from(JSON.stringify({ status: 'purchased' }));
       const result = decoder.extractEnvelope(body, {});
       expect(result.action).toBe('reject');
     });
 
-    it('should reject a body with a blank orderId', () => {
-      const result = decoder.extractEnvelope(makeBody({ orderId: '   ' }), {});
+    it('should reject a body with a blank id', () => {
+      const result = decoder.extractEnvelope(makeBody({ id: '   ' }), {});
       expect(result.action).toBe('reject');
     });
 
-    it('should reject a body with a non-string orderId', () => {
-      const result = decoder.extractEnvelope(makeBody({ orderId: 42 }), {});
+    it('should reject a body with a non-string id', () => {
+      const result = decoder.extractEnvelope(makeBody({ id: 42 }), {});
       expect(result.action).toBe('reject');
     });
 
-    it('should reject a body missing the event type field', () => {
-      const body = Buffer.from(JSON.stringify({ orderId: ORDER_ID }));
-      const result = decoder.extractEnvelope(body, {});
-      expect(result.action).toBe('reject');
-    });
-
-    it('should include the orderId in the envelope payload', () => {
+    it('should include the order id in the envelope payload', () => {
       const result = decoder.extractEnvelope(makeBody(), {});
       expect(result.action).toBe('route');
       if (result.action !== 'route') return;
-      expect(result.envelope.payload).toMatchObject({ orderId: ORDER_ID });
+      expect(result.envelope.payload).toMatchObject({ id: ORDER_ID });
     });
 
     it('should fall back to a non-empty occurredAt when the body has no timestamp', () => {
@@ -180,9 +176,9 @@ describe('ErliInboundWebhookDecoderAdapter', () => {
       expect(result.envelope.occurredAt.length).toBeGreaterThan(0);
     });
 
-    it('should prefer occurredAt body field when present', () => {
+    it('should prefer the updated body field for occurredAt when present', () => {
       const ts = '2026-01-15T10:00:00.000Z';
-      const result = decoder.extractEnvelope(makeBody({ occurredAt: ts }), {});
+      const result = decoder.extractEnvelope(makeBody({ updated: ts }), {});
       expect(result.action).toBe('route');
       if (result.action !== 'route') return;
       expect(result.envelope.occurredAt).toBe(ts);

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-webhook-event-translator.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-webhook-event-translator.adapter.spec.ts
@@ -21,7 +21,7 @@ function makeEvent(overrides: Partial<InboundWebhookEvent> = {}): InboundWebhook
     receivedAt: '2026-06-16T10:00:01.000Z',
     objectType: 'order',
     externalId: 'erli-order-fake-123',
-    payload: { orderId: 'erli-order-fake-123' },
+    payload: { id: 'erli-order-fake-123' },
     ...overrides,
   };
 }
@@ -41,7 +41,7 @@ describe('ErliWebhookEventTranslator', () => {
       externalId: 'erli-order-fake-123',
       eventType: 'created',
       occurredAt: '2026-06-16T10:00:00.000Z',
-      payload: { orderId: 'erli-order-fake-123' },
+      payload: { id: 'erli-order-fake-123' },
     });
   });
 
@@ -53,7 +53,7 @@ describe('ErliWebhookEventTranslator', () => {
 
   it('should fall back to the payload order-id field when externalId is empty', () => {
     const result = translator.translate(
-      makeEvent({ externalId: '', payload: { orderId: 'erli-order-fake-999' } }),
+      makeEvent({ externalId: '', payload: { id: 'erli-order-fake-999' } }),
     );
 
     expect(result).toMatchObject({ domain: 'order', externalId: 'erli-order-fake-999' });
@@ -61,11 +61,11 @@ describe('ErliWebhookEventTranslator', () => {
 
   it('should pass occurredAt and payload through unchanged', () => {
     const result = translator.translate(
-      makeEvent({ occurredAt: '2026-01-01T00:00:00.000Z', payload: { orderId: 'x-1', extra: 7 } }),
+      makeEvent({ occurredAt: '2026-01-01T00:00:00.000Z', payload: { id: 'x-1', extra: 7 } }),
     );
 
     expect(result?.occurredAt).toBe('2026-01-01T00:00:00.000Z');
-    expect(result?.payload).toEqual({ orderId: 'x-1', extra: 7 });
+    expect(result?.payload).toEqual({ id: 'x-1', extra: 7 });
   });
 
   it('should return null for an unknown event type without throwing', () => {
@@ -82,7 +82,7 @@ describe('ErliWebhookEventTranslator', () => {
   });
 
   it('should return null when the order id is a blank / whitespace string', () => {
-    const result = translator.translate(makeEvent({ externalId: '   ', payload: { orderId: '  ' } }));
+    const result = translator.translate(makeEvent({ externalId: '   ', payload: { id: '  ' } }));
 
     expect(result).toBeNull();
   });
@@ -91,7 +91,7 @@ describe('ErliWebhookEventTranslator', () => {
     const result = translator.translate(
       makeEvent({
         externalId: '',
-        payload: { orderId: 42 as unknown as string },
+        payload: { id: 42 as unknown as string },
       }),
     );
 

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-webhook-provisioning.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-webhook-provisioning.adapter.spec.ts
@@ -112,8 +112,16 @@ describe('ErliWebhookProvisioningAdapter', () => {
       );
     });
 
-    it('should report testPingTriggered=true when the ingress accepts the signature (non-401)', async () => {
+    it('should report testPingTriggered=true when the ingress accepts the signature (400, body rejected)', async () => {
       fetchSpy.mockResolvedValue({ status: 400 } as Response);
+
+      const result = await adapter.install(CONNECTION_ID);
+
+      expect(result.testPingTriggered).toBe(true);
+    });
+
+    it('should report testPingTriggered=true when the ingress accepts the signature (2xx)', async () => {
+      fetchSpy.mockResolvedValue({ status: 202 } as Response);
 
       const result = await adapter.install(CONNECTION_ID);
 
@@ -122,6 +130,14 @@ describe('ErliWebhookProvisioningAdapter', () => {
 
     it('should report testPingTriggered=false when the ingress rejects the signature (401)', async () => {
       fetchSpy.mockResolvedValue({ status: 401 } as Response);
+
+      const result = await adapter.install(CONNECTION_ID);
+
+      expect(result.testPingTriggered).toBe(false);
+    });
+
+    it('should report testPingTriggered=false on a transient ingress error (5xx) rather than mistaking it for an accepted signature', async () => {
+      fetchSpy.mockResolvedValue({ status: 500 } as Response);
 
       const result = await adapter.install(CONNECTION_ID);
 

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-webhook-provisioning.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-webhook-provisioning.adapter.spec.ts
@@ -137,6 +137,35 @@ describe('ErliWebhookProvisioningAdapter', () => {
       expect(result.testPingTriggered).toBe(false);
     });
 
+    it('should abort and report testPingTriggered=false (not hang install) when OL\'s own ingress never responds', async () => {
+      jest.useFakeTimers();
+      fetchSpy.mockImplementation(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            const signal = (init as RequestInit)?.signal;
+            signal?.addEventListener('abort', () => {
+              const err = new Error('The operation was aborted');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          }),
+      );
+
+      const installPromise = adapter.install(CONNECTION_ID);
+      // Flush the microtask queue between each timer advance so the aborted
+      // fetch's rejection has a chance to propagate before the next tick.
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+        jest.advanceTimersByTime(1_000);
+      }
+      const result = await installPromise;
+
+      expect(result.webhooksConfigured).toBe(true);
+      expect(result.testPingTriggered).toBe(false);
+
+      jest.useRealTimers();
+    });
+
     it('should NEVER log the secret while self-testing', async () => {
       const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-webhook-provisioning.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-webhook-provisioning.adapter.spec.ts
@@ -42,6 +42,8 @@ describe('ErliWebhookProvisioningAdapter', () => {
   let credentialsResolver: { get: jest.Mock };
   let adapter: ErliWebhookProvisioningAdapter;
 
+  let fetchSpy: jest.SpiedFunction<typeof fetch>;
+
   beforeEach(() => {
     httpClient = {
       get: jest.fn(),
@@ -62,6 +64,16 @@ describe('ErliWebhookProvisioningAdapter', () => {
       credentialsResolver as never,
       factory as never,
     );
+    // Self-test ping (round-trips the secret against OL's own ingress) — default
+    // to a 400 (signature accepted, body rejected downstream), the same
+    // "authenticated but undecodable" shape a real empty-body self-test produces.
+    fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({ status: 400 } as Response);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
   });
 
   it('should register both order hooks via PUT /hooks/{name} with the callback url + secret', async () => {
@@ -83,7 +95,62 @@ describe('ErliWebhookProvisioningAdapter', () => {
       { hookName: 'orderStatusChanged', url, accessToken: SECRET },
       { idempotent: true },
     );
-    expect(result).toEqual({ webhooksConfigured: true, testPingTriggered: false });
+    expect(result).toEqual({ webhooksConfigured: true, testPingTriggered: true });
+  });
+
+  describe('self-test ping', () => {
+    it('should round-trip the freshly-rotated secret against OL\'s own webhook ingress', async () => {
+      await adapter.install(CONNECTION_ID);
+
+      const url = `http://host.docker.internal:3000/webhooks/erli/${CONNECTION_ID}`;
+      expect(fetchSpy).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ Authorization: `Bearer ${SECRET}` }),
+        }),
+      );
+    });
+
+    it('should report testPingTriggered=true when the ingress accepts the signature (non-401)', async () => {
+      fetchSpy.mockResolvedValue({ status: 400 } as Response);
+
+      const result = await adapter.install(CONNECTION_ID);
+
+      expect(result.testPingTriggered).toBe(true);
+    });
+
+    it('should report testPingTriggered=false when the ingress rejects the signature (401)', async () => {
+      fetchSpy.mockResolvedValue({ status: 401 } as Response);
+
+      const result = await adapter.install(CONNECTION_ID);
+
+      expect(result.testPingTriggered).toBe(false);
+    });
+
+    it('should report testPingTriggered=false (non-fatal) when the self-test request itself fails', async () => {
+      fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const result = await adapter.install(CONNECTION_ID);
+
+      expect(result.webhooksConfigured).toBe(true);
+      expect(result.testPingTriggered).toBe(false);
+    });
+
+    it('should NEVER log the secret while self-testing', async () => {
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      await adapter.install(CONNECTION_ID);
+
+      const allLogged = [logSpy, warnSpy]
+        .flatMap((spy) => spy.mock.calls)
+        .flatMap((call) => call.map((arg) => String(arg)))
+        .join('\n');
+      expect(allLogged).not.toContain(SECRET);
+
+      jest.restoreAllMocks();
+    });
   });
 
   it('should mark the connection webhooksConfigured', async () => {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-inbound-webhook-decoder.adapter.ts
@@ -3,14 +3,15 @@
  *
  * Authenticates + decodes Erli inbound order webhooks at the host ingress,
  * keyed by `provider = 'erli'`. The verify half checks the `accessToken` Erli
- * echoes back in the `ERLI_WEBHOOK_ACCESS_TOKEN_HEADER` header against the
- * per-connection shared secret stored OL-side by `IWebhookSecretService`
- * (provisioned by `ErliWebhookProvisioningAdapter`, #996).
+ * echoes back on the `ERLI_WEBHOOK_ACCESS_TOKEN_HEADER` (`Authorization`)
+ * header against the per-connection shared secret stored OL-side by
+ * `IWebhookSecretService` (provisioned by `ErliWebhookProvisioningAdapter`, #996).
  *
- * PROVISIONAL (#992): the header name, body field paths, and the presence of a
- * delivery timestamp are all unconfirmed until the sandbox spike. All wire
- * assumptions are isolated in `erli-webhook.types.ts` — when #992 lands,
- * that file is the single reconciliation point.
+ * CONFIRMED (#992 sandbox spike, 2026-07-01): the body is the full order
+ * resource with no event-type discriminator (see `erli-webhook.types.ts`), so
+ * `extractEnvelope` always emits a generic `'orderStatusChanged'` envelope
+ * eventType — every delivery is treated as "go re-fetch this order", which is
+ * both hooks' only decodable signal. Erli sends no signed delivery timestamp.
  *
  * Trigger model (ADR-025): webhook is a low-latency nudge, never the source
  * of truth. We read only the order id from the body; the authoritative order
@@ -30,9 +31,8 @@ import type {
 } from '@openlinker/core/integrations';
 import {
   ERLI_WEBHOOK_ACCESS_TOKEN_HEADER,
-  ERLI_WEBHOOK_EVENT_TYPE_FIELD,
+  ERLI_WEBHOOK_AUTH_HEADER_PREFIX,
   ERLI_WEBHOOK_ORDER_ID_FIELD,
-  ErliWebhookEventTypeValues,
 } from './erli-webhook.types';
 
 export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPort {
@@ -41,10 +41,13 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
     headers: Record<string, string>;
     secret: string;
   }): WebhookVerifyResult {
-    const token = this.header(input.headers, ERLI_WEBHOOK_ACCESS_TOKEN_HEADER);
-    if (!token) {
+    const header = this.header(input.headers, ERLI_WEBHOOK_ACCESS_TOKEN_HEADER);
+    if (!header) {
       return { ok: false };
     }
+    const token = header.startsWith(ERLI_WEBHOOK_AUTH_HEADER_PREFIX)
+      ? header.slice(ERLI_WEBHOOK_AUTH_HEADER_PREFIX.length)
+      : header;
     const provided = Buffer.from(token);
     const expected = Buffer.from(input.secret);
     if (provided.length !== expected.length) {
@@ -53,9 +56,9 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
     if (!timingSafeEqual(provided, expected)) {
       return { ok: false };
     }
-    // PROVISIONAL (#992): Erli does not send a signed timestamp header, so
-    // `timestampMs` is omitted intentionally — the host's replay-window check
-    // only fires when the field is present.
+    // Erli does not send a signed timestamp header, so `timestampMs` is
+    // omitted intentionally — the host's replay-window check only fires when
+    // the field is present.
     return { ok: true };
   }
 
@@ -71,30 +74,28 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
     }
     const record = body as Record<string, unknown>;
 
-    const rawEventType = this.asNonEmptyString(record[ERLI_WEBHOOK_EVENT_TYPE_FIELD]);
-    if (!rawEventType) {
-      return { action: 'reject', reason: 'missing or empty event type field' };
-    }
-    if (
-      !ErliWebhookEventTypeValues.includes(
-        rawEventType as (typeof ErliWebhookEventTypeValues)[number],
-      )
-    ) {
-      return { action: 'ignore', reason: `unhandled event type: ${rawEventType}` };
-    }
-    const eventType = rawEventType;
-
     const orderId = this.asNonEmptyString(record[ERLI_WEBHOOK_ORDER_ID_FIELD]);
     if (!orderId) {
-      return { action: 'reject', reason: 'missing or empty orderId field' };
+      return { action: 'reject', reason: 'missing or empty order id field' };
     }
+
+    // No body discriminator exists (see module doc) — every delivery decodes
+    // to the same generic "order changed" signal.
+    const eventType = 'orderStatusChanged';
+    const occurredAt = this.resolveOccurredAt(record);
 
     return {
       action: 'route',
       envelope: {
-        eventId: this.deriveEventId(record, orderId, eventType),
+        // `occurredAt` (Erli's own `updated` timestamp) is load-bearing here,
+        // not just advisory: it is what makes eventIds for the SAME order's
+        // successive deliveries (create, then cancel, …) distinct. Without it
+        // every delivery would hash to `${orderId}:orderStatusChanged` and the
+        // Postgres eventId-dedup gate would silently drop every delivery after
+        // the first for a given order.
+        eventId: this.deriveEventId(record, orderId, occurredAt),
         eventType,
-        occurredAt: this.resolveOccurredAt(record),
+        occurredAt,
         objectType: 'order',
         externalId: orderId,
         payload: { [ERLI_WEBHOOK_ORDER_ID_FIELD]: orderId },
@@ -102,27 +103,24 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
     };
   }
 
-  private deriveEventId(
-    record: Record<string, unknown>,
-    orderId: string,
-    eventType: string,
-  ): string {
-    const explicit =
-      this.asNonEmptyString(record['eventId']) ?? this.asNonEmptyString(record['id']);
+  private deriveEventId(record: Record<string, unknown>, orderId: string, occurredAt: string): string {
+    const explicit = this.asNonEmptyString(record['eventId']);
     if (explicit) {
       return explicit;
     }
-    const basis = `${orderId}:${eventType}`;
+    const basis = `${orderId}:${occurredAt}`;
     return `erli-${createHash('sha256').update(basis).digest('hex').slice(0, 32)}`;
   }
 
   private resolveOccurredAt(record: Record<string, unknown>): string {
     const fromBody =
+      this.asNonEmptyString(record['updated']) ??
       this.asNonEmptyString(record['occurredAt']) ??
       this.asNonEmptyString(record['timestamp']) ??
-      this.asNonEmptyString(record['createdAt']);
-    // Advisory only — authoritative timestamp comes from the downstream order
-    // fetch (ADR-025 trigger-not-truth model).
+      this.asNonEmptyString(record['created']);
+    // Falls back to "now" only when the body carries no timestamp at all —
+    // advisory either way, since the authoritative status always comes from
+    // the downstream order fetch (ADR-025 trigger-not-truth model).
     return fromBody ?? new Date().toISOString();
   }
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-inbound-webhook-decoder.adapter.ts
@@ -12,6 +12,9 @@
  * `extractEnvelope` always emits a generic `'orderStatusChanged'` envelope
  * eventType — every delivery is treated as "go re-fetch this order", which is
  * both hooks' only decodable signal. Erli sends no signed delivery timestamp.
+ * `ErliWebhookEventTranslator` still special-cases a hypothetical
+ * `orderCreated` discriminator for forward-compat — this decoder never emits
+ * it today, so don't go looking for it here if that branch looks dead.
  *
  * Trigger model (ADR-025): webhook is a low-latency nudge, never the source
  * of truth. We read only the order id from the body; the authoritative order
@@ -45,7 +48,11 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
     if (!header) {
       return { ok: false };
     }
-    const token = header.startsWith(ERLI_WEBHOOK_AUTH_HEADER_PREFIX)
+    // Scheme match is case-insensitive: RFC 7235 doesn't mandate a case for
+    // the auth-scheme token, and a lowercase `bearer ` from Erli or an
+    // intermediary proxy must not fall through to a raw-header comparison
+    // that always fails the length check.
+    const token = header.toLowerCase().startsWith(ERLI_WEBHOOK_AUTH_HEADER_PREFIX.toLowerCase())
       ? header.slice(ERLI_WEBHOOK_AUTH_HEADER_PREFIX.length)
       : header;
     const provided = Buffer.from(token);
@@ -82,7 +89,8 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
     // No body discriminator exists (see module doc) — every delivery decodes
     // to the same generic "order changed" signal.
     const eventType = 'orderStatusChanged';
-    const occurredAt = this.resolveOccurredAt(record);
+    const bodyTimestamp = this.resolveBodyTimestamp(record);
+    const occurredAt = bodyTimestamp ?? new Date().toISOString();
 
     return {
       action: 'route',
@@ -93,7 +101,7 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
         // every delivery would hash to `${orderId}:orderStatusChanged` and the
         // Postgres eventId-dedup gate would silently drop every delivery after
         // the first for a given order.
-        eventId: this.deriveEventId(record, orderId, occurredAt),
+        eventId: this.deriveEventId(record, orderId, bodyTimestamp),
         eventType,
         occurredAt,
         objectType: 'order',
@@ -103,25 +111,35 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
     };
   }
 
-  private deriveEventId(record: Record<string, unknown>, orderId: string, occurredAt: string): string {
+  private deriveEventId(
+    record: Record<string, unknown>,
+    orderId: string,
+    bodyTimestamp: string | null,
+  ): string {
     const explicit = this.asNonEmptyString(record['eventId']);
     if (explicit) {
       return explicit;
     }
-    const basis = `${orderId}:${occurredAt}`;
+    // The hash basis intentionally never includes the "now" fallback used for
+    // the envelope's advisory `occurredAt` — that value is decode-time and
+    // non-deterministic, so hashing it would produce a fresh eventId on every
+    // retried delivery and defeat the Postgres eventId-dedup gate. A body
+    // that carries no timestamp at all hashes on `orderId` alone: deliberately
+    // deterministic (retries of the same timestamp-less delivery dedupe
+    // together) at the cost of collapsing distinct timestamp-less events for
+    // the same order — an accepted, documented trade-off, not the silent
+    // regression a "now" basis would cause.
+    const basis = bodyTimestamp ? `${orderId}:${bodyTimestamp}` : orderId;
     return `erli-${createHash('sha256').update(basis).digest('hex').slice(0, 32)}`;
   }
 
-  private resolveOccurredAt(record: Record<string, unknown>): string {
-    const fromBody =
+  private resolveBodyTimestamp(record: Record<string, unknown>): string | null {
+    return (
       this.asNonEmptyString(record['updated']) ??
       this.asNonEmptyString(record['occurredAt']) ??
       this.asNonEmptyString(record['timestamp']) ??
-      this.asNonEmptyString(record['created']);
-    // Falls back to "now" only when the body carries no timestamp at all —
-    // advisory either way, since the authoritative status always comes from
-    // the downstream order fetch (ADR-025 trigger-not-truth model).
-    return fromBody ?? new Date().toISOString();
+      this.asNonEmptyString(record['created'])
+    );
   }
 
   private header(headers: Record<string, string>, name: string): string | null {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-inbound-webhook-decoder.adapter.ts
@@ -96,11 +96,12 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
       action: 'route',
       envelope: {
         // `occurredAt` (Erli's own `updated` timestamp) is load-bearing here,
-        // not just advisory: it is what makes eventIds for the SAME order's
-        // successive deliveries (create, then cancel, …) distinct. Without it
-        // every delivery would hash to `${orderId}:orderStatusChanged` and the
-        // Postgres eventId-dedup gate would silently drop every delivery after
-        // the first for a given order.
+        // not just advisory: it is one of the fields (alongside `status`,
+        // see `deriveEventId`) that makes eventIds for the SAME order's
+        // successive deliveries (create, then cancel, ...) distinct. Without
+        // it every delivery would hash to `${orderId}:${status}:no-timestamp`
+        // and the Postgres eventId-dedup gate would collapse same-status
+        // repeats together.
         eventId: this.deriveEventId(record, orderId, bodyTimestamp),
         eventType,
         occurredAt,
@@ -121,15 +122,19 @@ export class ErliInboundWebhookDecoderAdapter implements InboundWebhookDecoderPo
       return explicit;
     }
     // The hash basis intentionally never includes the "now" fallback used for
-    // the envelope's advisory `occurredAt` — that value is decode-time and
+    // the envelope's advisory `occurredAt` - that value is decode-time and
     // non-deterministic, so hashing it would produce a fresh eventId on every
-    // retried delivery and defeat the Postgres eventId-dedup gate. A body
-    // that carries no timestamp at all hashes on `orderId` alone: deliberately
-    // deterministic (retries of the same timestamp-less delivery dedupe
-    // together) at the cost of collapsing distinct timestamp-less events for
-    // the same order — an accepted, documented trade-off, not the silent
-    // regression a "now" basis would cause.
-    const basis = bodyTimestamp ? `${orderId}:${bodyTimestamp}` : orderId;
+    // retried delivery and defeat the Postgres eventId-dedup gate. `status` is
+    // folded in alongside the timestamp so a timestamp-less body still gets
+    // distinct eventIds across a real status change (e.g. created -> paid),
+    // rather than collapsing every timestamp-less delivery for the same order
+    // onto one eventId and relying solely on the reconciliation poll to catch
+    // the dropped ones. Retried deliveries of the identical body still hash
+    // to the same eventId (id + status + timestamp are all unchanged), so the
+    // dedup gate still catches true retries.
+    const status = this.asNonEmptyString(record['status']) ?? 'no-status';
+    const timestamp = bodyTimestamp ?? 'no-timestamp';
+    const basis = `${orderId}:${status}:${timestamp}`;
     return `erli-${createHash('sha256').update(basis).digest('hex').slice(0, 32)}`;
   }
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-webhook-event-translator.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-webhook-event-translator.adapter.ts
@@ -1,13 +1,13 @@
 /**
  * Erli Webhook Event Translator Adapter (#996 / ADR-015)
  *
- * Decodes Erli's id-only inbound webhook events into neutral
- * `CanonicalInboundEvent`s. Pure transform — no I/O, no connection state, no DI.
- * `ErliInboundWebhookDecoderAdapter` always emits `orderStatusChanged` (#992
- * sandbox spike — the real body carries no event-type discriminator to tell
- * `orderCreated` apart), mapped below to canonical `updated`. The `orderCreated`
+ * Decodes Erli's inbound webhook events into neutral `CanonicalInboundEvent`s.
+ * Pure transform — no I/O, no connection state, no DI. `ErliInboundWebhookDecoderAdapter`
+ * (#1081, native decoder — confirmed against the live sandbox, #992) always emits
+ * `orderStatusChanged`, since the real body carries no event-type discriminator to tell
+ * `orderCreated` apart, mapped below to canonical `updated`. The `orderCreated`
  * branch is kept for defensiveness / forward-compat if a future decoder
- * revision recovers a real discriminator:
+ * revision recovers a real discriminator — it is NOT reachable from today's decoder:
  *   - `orderCreated`       → canonical `{ domain: 'order', eventType: 'created' }`
  *   - `orderStatusChanged` → canonical `{ domain: 'order', eventType: 'updated' }`
  *
@@ -17,12 +17,12 @@
  * it NEVER throws (ADR-015 invariant 5).
  *
  * The order id is narrowed DEFENSIVELY from `unknown`: it originates from an
- * untrusted webhook body (especially in the future native-decoder path, the
- * load-bearing #992 follow-up), so anything that is not a non-empty string
- * yields `null` rather than a malformed event.
+ * untrusted webhook body, so anything that is not a non-empty string yields
+ * `null` rather than a malformed event.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  * @see {@link WebhookEventTranslatorPort} for the port interface
+ * @see {@link ErliInboundWebhookDecoderAdapter} for the decoder this translator consumes
  */
 import type { InboundWebhookEvent } from '@openlinker/core/events';
 import type {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-webhook-event-translator.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-webhook-event-translator.adapter.ts
@@ -3,8 +3,11 @@
  *
  * Decodes Erli's id-only inbound webhook events into neutral
  * `CanonicalInboundEvent`s. Pure transform — no I/O, no connection state, no DI.
- * Erli emits these order event types (#992-PROVISIONAL, isolated in
- * `erli-webhook.types.ts`):
+ * `ErliInboundWebhookDecoderAdapter` always emits `orderStatusChanged` (#992
+ * sandbox spike — the real body carries no event-type discriminator to tell
+ * `orderCreated` apart), mapped below to canonical `updated`. The `orderCreated`
+ * branch is kept for defensiveness / forward-compat if a future decoder
+ * revision recovers a real discriminator:
  *   - `orderCreated`       → canonical `{ domain: 'order', eventType: 'created' }`
  *   - `orderStatusChanged` → canonical `{ domain: 'order', eventType: 'updated' }`
  *

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-webhook-provisioning.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-webhook-provisioning.adapter.ts
@@ -129,11 +129,54 @@ export class ErliWebhookProvisioningAdapter implements WebhookProvisioningPort {
         `(${ErliWebhookEventTypeValues.length} hooks${stateUpdateOk ? '' : '; state update pending'}).`,
     );
 
+    const testPingTriggered = await this.selfTestPing(url, secret, connectionId);
+
     return {
       webhooksConfigured: true,
-      testPingTriggered: false,
+      testPingTriggered,
       ...(stateUpdateOk ? {} : { warning: 'state-update-failed' }),
     };
+  }
+
+  /**
+   * Round-trips the just-registered secret against OL's OWN webhook endpoint,
+   * in the exact shape Erli uses (`Authorization: Bearer <secret>`) — proving
+   * the ingress accepts it without waiting for Erli to actually deliver
+   * anything (Erli's own delivery latency in the sandbox has been observed
+   * to range from seconds to 15+ minutes with no visible pattern, which makes
+   * "did the fix work" otherwise unanswerable on any predictable timeline).
+   *
+   * The body is intentionally empty: an authentic signature always reaches
+   * `extractEnvelope`, which then rejects it (400, missing order id) — so a
+   * successful self-test never enqueues a real `marketplace.order.sync` job.
+   * Only a genuine signature failure (401) counts as "not triggered"; the
+   * secret is never logged, only used in-memory for this one request.
+   */
+  private async selfTestPing(
+    url: string,
+    secret: string,
+    connectionId: string,
+  ): Promise<boolean> {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${secret}`, 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      const ok = response.status !== 401;
+      this.logger.log(
+        `Erli webhook self-test ping for connection ${connectionId}: HTTP ${response.status} ` +
+          `(signature ${ok ? 'accepted' : 'REJECTED'}).`,
+      );
+      return ok;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Erli webhook self-test ping failed for connection ${connectionId} (non-fatal — ` +
+          `install already succeeded): ${message}`,
+      );
+      return false;
+    }
   }
 
   /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-webhook-provisioning.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-webhook-provisioning.adapter.ts
@@ -154,8 +154,12 @@ export class ErliWebhookProvisioningAdapter implements WebhookProvisioningPort {
    * The body is intentionally empty: an authentic signature always reaches
    * `extractEnvelope`, which then rejects it (400, missing order id) — so a
    * successful self-test never enqueues a real `marketplace.order.sync` job.
-   * Only a genuine signature failure (401) counts as "not triggered"; the
-   * secret is never logged, only used in-memory for this one request.
+   * Only 2xx or 400 count as "signature accepted" — those are the only two
+   * outcomes reachable once `verify()` passes (route, or reject on the empty
+   * body); any other status (401 = signature rejected, 5xx = ingress error,
+   * a timeout, …) is treated as "not triggered" rather than mistaking a
+   * transient failure for a working signature. The secret is never logged,
+   * only used in-memory for this one request.
    *
    * Bounded by `SELF_TEST_TIMEOUT_MS`: a hung or unreachable OL ingress must
    * degrade to `testPingTriggered: false`, never block the caller — `install()`
@@ -176,7 +180,7 @@ export class ErliWebhookProvisioningAdapter implements WebhookProvisioningPort {
         body: '{}',
         signal: controller.signal,
       });
-      const ok = response.status !== 401;
+      const ok = response.status === 400 || (response.status >= 200 && response.status < 300);
       this.logger.log(
         `Erli webhook self-test ping for connection ${connectionId}: HTTP ${response.status} ` +
           `(signature ${ok ? 'accepted' : 'REJECTED'}).`,

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-webhook-provisioning.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-webhook-provisioning.adapter.ts
@@ -43,6 +43,11 @@ import { erliHookPath, type ErliHookRegistrationBody } from './erli-webhook.type
 /** Webhook-secret provider key for Erli connections. */
 const ERLI_WEBHOOK_PROVIDER = 'erli';
 
+// Same-process loopback call to OL's own ingress — a short bound is enough,
+// and it keeps a hung self-test from blocking the admin-facing `install()`
+// call (mirrors the AbortController timeout pattern in `erli-http-client.ts`).
+const SELF_TEST_TIMEOUT_MS = 5_000;
+
 export class ErliWebhookProvisioningAdapter implements WebhookProvisioningPort {
   private readonly logger = new Logger(ErliWebhookProvisioningAdapter.name);
 
@@ -151,17 +156,25 @@ export class ErliWebhookProvisioningAdapter implements WebhookProvisioningPort {
    * successful self-test never enqueues a real `marketplace.order.sync` job.
    * Only a genuine signature failure (401) counts as "not triggered"; the
    * secret is never logged, only used in-memory for this one request.
+   *
+   * Bounded by `SELF_TEST_TIMEOUT_MS`: a hung or unreachable OL ingress must
+   * degrade to `testPingTriggered: false`, never block the caller — `install()`
+   * already succeeded by the time this runs, and the docstring's "non-fatal"
+   * promise only holds if a stalled request can't stall the response too.
    */
   private async selfTestPing(
     url: string,
     secret: string,
     connectionId: string,
   ): Promise<boolean> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), SELF_TEST_TIMEOUT_MS);
     try {
       const response = await fetch(url, {
         method: 'POST',
         headers: { Authorization: `Bearer ${secret}`, 'Content-Type': 'application/json' },
         body: '{}',
+        signal: controller.signal,
       });
       const ok = response.status !== 401;
       this.logger.log(
@@ -170,12 +183,19 @@ export class ErliWebhookProvisioningAdapter implements WebhookProvisioningPort {
       );
       return ok;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const timedOut = controller.signal.aborted || (error as Error)?.name === 'AbortError';
+      const message = timedOut
+        ? `timed out after ${SELF_TEST_TIMEOUT_MS}ms`
+        : error instanceof Error
+          ? error.message
+          : String(error);
       this.logger.warn(
         `Erli webhook self-test ping failed for connection ${connectionId} (non-fatal — ` +
           `install already succeeded): ${message}`,
       );
       return false;
+    } finally {
+      clearTimeout(timeout);
     }
   }
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-webhook.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-webhook.types.ts
@@ -1,31 +1,31 @@
 /**
  * Erli Webhook Wire Types
  *
- * Provisional shapes for Erli's inbound *webhook* bodies — the low-latency
- * trigger path (#996) that complements the mandatory inbox poll (#993). Models
- * the two order-relevant event literals and the id-only webhook body shape.
+ * Confirmed shapes for Erli's inbound *webhook* bodies (#992 sandbox spike,
+ * 2026-07-01) — the low-latency trigger path (#996) that complements the
+ * mandatory inbox poll (#993).
  *
- * PROVISIONAL (#992): the webhook body shape, the field that carries the order
- * id, the event-type discriminator vocabulary (`orderCreated` /
- * `orderStatusChanged`), and the signature/header scheme are ALL UNCONFIRMED
- * until the sandbox spike. This file is the SINGLE reconciliation point for
- * every webhook wire assumption — `ErliWebhookEventTranslator` (and the future
- * native `InboundWebhookDecoderPort`, the load-bearing #992 follow-up) read
- * webhook shapes only from here, so confirming the spike is a one-file edit.
- *
- * When #992 lands, these symbols flip:
- *   - `ErliWebhookEventTypeValues` — the literal discriminator strings.
- *   - `ERLI_WEBHOOK_ORDER_ID_FIELD` — the body field carrying the order id.
- *   - `ErliWebhookBody` — the full provisional body shape.
- * (The webhook event-type vocabulary is intentionally mirrored against the
- * inbox vocabulary in `erli-inbox.types.ts`; they are distinct wire surfaces
- * that #992 may reconcile to a single source.)
+ * CONFIRMED AGAINST THE LIVE SANDBOX (#992): unlike the original provisional
+ * assumption, Erli's webhook body is **not** an id-only `{ type, orderId }`
+ * envelope — it is the **full order resource** (the same shape `GET
+ * /orders/{id}` returns: `id`, `status`, `user`, `items`, `delivery`, …), and
+ * carries **no event-type discriminator field**. Both the `orderCreated` and
+ * `orderStatusChanged` hooks POST this same shape to the same callback URL, so
+ * OL cannot distinguish "created" from "status changed" from the body alone —
+ * the decoder treats every delivery as a generic "go re-fetch this order"
+ * trigger (ADR-025 trigger-not-truth: the real status always comes from the
+ * downstream `ErliOrderSourceAdapter.getOrder` call, never the webhook body).
+ * The access token Erli echoes back arrives on the standard `Authorization`
+ * header (`Bearer <token>`), not a custom `x-access-token` header.
  *
  * @module libs/integrations/erli/src/infrastructure/adapters
  */
 
 /**
- * Order-relevant webhook event-type discriminators (#992-PROVISIONAL).
+ * Order-relevant webhook event-type discriminators.
+ *
+ * Used only for hook **registration** (`PUT /hooks/{hookName}`) — the webhook
+ * *body* carries no equivalent discriminator (see module doc above).
  *
  * `as const` + union per engineering standards — no runtime enum.
  */
@@ -34,41 +34,33 @@ export const ErliWebhookEventTypeValues = ['orderCreated', 'orderStatusChanged']
 export type ErliWebhookEventType = (typeof ErliWebhookEventTypeValues)[number];
 
 /**
- * The body field carrying the external order id (#992-PROVISIONAL).
+ * The body field carrying the external order id (#992-confirmed).
  *
- * Erli webhooks are id-only triggers (ADR-015 trigger-not-truth): the body
- * carries the order id, not the full order, which is pulled downstream by the
- * `marketplace.order.sync` job via `ErliOrderSourceAdapter.getOrder`.
+ * The webhook body is the full order resource; `id` is its top-level order
+ * id, the same field `ErliOrder` (`GET /orders/{id}`) uses.
  */
-export const ERLI_WEBHOOK_ORDER_ID_FIELD = 'orderId';
+export const ERLI_WEBHOOK_ORDER_ID_FIELD = 'id';
 
 /**
- * Provisional id-only Erli webhook body (#992-PROVISIONAL).
- *
- * Modelled as a generic record because the exact field set is unconfirmed; the
- * translator narrows it defensively from `unknown` rather than trusting the
- * declared shape (the id originates from an untrusted body in the future
- * native-decoder path).
+ * Confirmed Erli webhook body (#992) — the full order resource. Modelled as a
+ * generic record because only `id` is load-bearing for the decoder (the rest
+ * is ignored — ADR-025 trigger-not-truth); the translator narrows `id`
+ * defensively from `unknown` since it originates from an untrusted body.
  */
 export interface ErliWebhookBody {
-  /** External Erli order id — field name provisional (`ERLI_WEBHOOK_ORDER_ID_FIELD`). */
+  /** External Erli order id (`ERLI_WEBHOOK_ORDER_ID_FIELD`). */
   [ERLI_WEBHOOK_ORDER_ID_FIELD]: string;
 }
 
 /**
  * Request header Erli sends on each delivery carrying the access token for
- * signature verification (#992-PROVISIONAL — exact header unconfirmed).
- * Isolated here so #992 confirmation is a one-line edit; the decoder reads
- * only this constant.
+ * signature verification (#992-confirmed: the standard `Authorization`
+ * header, value `Bearer <token>` — not a custom `x-access-token` header).
  */
-export const ERLI_WEBHOOK_ACCESS_TOKEN_HEADER = 'x-access-token';
+export const ERLI_WEBHOOK_ACCESS_TOKEN_HEADER = 'authorization';
 
-/**
- * Body field carrying the Erli event-type discriminator (#992-PROVISIONAL).
- * Currently modelled as the `type` field; may differ from the inbox feed's
- * `status` field — #992 confirms or reconciles.
- */
-export const ERLI_WEBHOOK_EVENT_TYPE_FIELD = 'type';
+/** Prefix Erli prepends to the echoed access token on the `Authorization` header. */
+export const ERLI_WEBHOOK_AUTH_HEADER_PREFIX = 'Bearer ';
 
 /**
  * Webhook registration (#996), verified against the live Erli Shop API (#992).


### PR DESCRIPTION
## Summary
- Erli sends `Authorization: Bearer <secret>` and a body shaped `{ id, status, updated }` — the decoder was checking `X-Access-Token` and an `orderId` field that doesn't exist, so every real webhook from Erli failed signature verification and was silently rejected.
- `eventId` dedup key now hashes `id:updated` (Erli's own timestamp) instead of `id:eventType`, removing a collision risk between successive status changes for the same order.
- Implements the previously-stubbed self-test ping on webhook install (`WebhookProvisioningResult.testPingTriggered`), so a bad secret/callback URL surfaces immediately at setup time.

## Verification
- Updated unit tests (wire shape, self-test ping) — all green, `pnpm --filter @openlinker/integrations-erli test/lint/type-check` clean.
- Live E2E on the Erli sandbox, twice: real order placed on the storefront → real webhook received + signature-verified → `marketplace.order.sync` enqueued → order synced to the PrestaShop destination. Second run was one clean automatic pass end to end (Erli order `260701x10018` → OL `ol_order_7a38ca72b9c24dc1985600e1a693b8ff` → PrestaShop order `#10`), confirmed via API/worker logs, DB rows, the OpenLinker order-detail UI, and the PrestaShop admin order page.

Closes #1294

## Test plan
- [x] `pnpm --filter @openlinker/integrations-erli test` — 282/282 passing
- [x] `pnpm --filter @openlinker/integrations-erli lint` / `type-check` — clean
- [x] Live E2E against Erli sandbox (order → webhook → OL → PrestaShop), confirmed twice