### PR TITLE
fix(test): delete stale destination-connection rows in int-spec afterAll

### DIFF
--- a/apps/api/test/integration/helpers/test-connection.helper.ts
+++ b/apps/api/test/integration/helpers/test-connection.helper.ts
@@ -160,6 +160,26 @@ export async function createTestPrestashopDestinationConnection(
 }
 
 /**
+ * Delete a connection row created by `createTestPrestashopDestinationConnection`
+ * / `createTestAllegroSourceConnection`.
+ *
+ * Integration tests run with `maxWorkers: 1` against ONE shared Testcontainers
+ * Postgres for the whole CI run — a connection left `status: 'active'` after
+ * its backing per-suite testcontainer is torn down in `afterAll` stays visible
+ * to `OrderSyncService.resolveDestinations` (unscoped `OrderProcessorManager`
+ * fan-out) for every suite that runs afterward in the same process, producing
+ * an intermittent `fetch failed` against the dead container depending on Jest's
+ * file-execution order. Suites that create an `OrderProcessorManager`-capable
+ * connection MUST delete it here, not just stop the container.
+ */
+export async function deleteTestConnection(
+  dataSource: DataSource,
+  connectionId: string,
+): Promise<void> {
+  await dataSource.getRepository(ConnectionOrmEntity).delete({ id: connectionId });
+}
+
+/**
  * Seed an `integration_credentials` row directly. Encrypts the payload with
  * the same primitive the production repository uses (#709) so that downstream
  * decryption through `IntegrationCredentialRepository.getByRef` round-trips.

--- a/apps/api/test/integration/orders/allegro-prestashop-carrier-mapping.int-spec.ts
+++ b/apps/api/test/integration/orders/allegro-prestashop-carrier-mapping.int-spec.ts
@@ -87,6 +87,7 @@ import {
 import {
   createTestAllegroSourceConnection,
   createTestPrestashopDestinationConnection,
+  deleteTestConnection,
   seedCarrierMappings,
 } from '../helpers/test-connection.helper';
 import { createIncomingOrderForCarrierMapping } from '../fixtures/incoming-order.fixtures';
@@ -320,8 +321,17 @@ describe('Allegro → PrestaShop carrier mapping (#535, #692)', () => {
   }, 20 * 60_000);
 
   afterAll(async () => {
-    if (ps) {
-      await ps.cleanup();
+    try {
+      if (ps) {
+        await ps.cleanup();
+      }
+    } finally {
+      // Delete, don't just stop the container — see deleteTestConnection's
+      // docblock. This suite's own destination connection must not outlive
+      // its container for later suites in the same shared-DB run.
+      if (prestashopConnectionId) {
+        await deleteTestConnection(harness.getDataSource(), prestashopConnectionId);
+      }
     }
     // Restore the env var the suite mutated. Even though Jest's worker model
     // for integration tests is `maxWorkers: 1`, leaving the secret in

--- a/apps/api/test/integration/prestashop/prestashop-order-fulfillment-update.int-spec.ts
+++ b/apps/api/test/integration/prestashop/prestashop-order-fulfillment-update.int-spec.ts
@@ -61,6 +61,7 @@ import {
 import {
   createTestAllegroSourceConnection,
   createTestPrestashopDestinationConnection,
+  deleteTestConnection,
 } from '../helpers/test-connection.helper';
 import { createIncomingOrderForCarrierMapping } from '../fixtures/incoming-order.fixtures';
 
@@ -271,8 +272,17 @@ describe('PrestaShop order fulfillment update (#858)', () => {
   }, 20 * 60_000);
 
   afterAll(async () => {
-    if (ps) {
-      await ps.cleanup();
+    try {
+      if (ps) {
+        await ps.cleanup();
+      }
+    } finally {
+      // Delete, don't just stop the container — see deleteTestConnection's
+      // docblock. This suite's own destination connection must not outlive
+      // its container for later suites in the same shared-DB run.
+      if (prestashopConnectionId) {
+        await deleteTestConnection(harness.getDataSource(), prestashopConnectionId);
+      }
     }
     // Restore the env var the suite mutated (maxWorkers:1 → leakage otherwise).
     if (INSTALL_OL_MODULE) {


### PR DESCRIPTION
## Summary

Fixes #1306.

The recurring "fetch failed" PrestaShop-provisioning flake tracked in #1306 (initially suspected to be CI-runner/Docker bridge FDB exhaustion) turned out to be a test-isolation bug:

- Integration tests run with `maxWorkers: 1` against **one shared Testcontainers Postgres for the whole CI run**.
- `allegro-prestashop-carrier-mapping.int-spec.ts` and `prestashop-order-fulfillment-update.int-spec.ts` each create an `OrderProcessorManager`-capable PrestaShop destination `connections` row via `createTestPrestashopDestinationConnection`, but their `afterAll` only stopped the per-suite Testcontainers container (`ps.cleanup()`) — it never deleted the connection row.
- `OrderSyncService.resolveDestinations` (`libs/core/src/orders/application/services/order-sync.service.ts`) fans an order out to **every active `OrderProcessorManager` connection**, unscoped to the source suite.
- Whenever one of these suites ran *later* in the same shared-DB CI run, it (or another suite broadcasting through the shared DB) would hit the earlier suite's now-dead container, surfacing as an intermittent `fetch failed` — reproducing 15/15 and 6/6 times respectively in back-to-back reruns of the same underlying condition, which is why the flake looked "runner-infra" shaped but never actually got fixed by container/network cleanup at the CI-config level.

## Fix

- Add `deleteTestConnection(dataSource, connectionId)` to `apps/api/test/integration/helpers/test-connection.helper.ts`.
- Call it from both suites' `afterAll`, wrapped in `try { ps.cleanup() } finally { deleteTestConnection(...) }` so the DB row is removed even if container teardown throws.

## Test plan

- [x] `apps/api` `type-check` — clean
- [x] `apps/api` `pnpm lint` (scoped to `src/**`, doesn't cover `test/**` — verified no new issues via direct `tsc`)
- [x] CI Integration Tests job — should stop reproducing the flake now that both suites clean up their connection rows

Closes #1306