### PR TITLE
feat(api): version the HTTP API under /v1 + runtime version surface (#1133)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,8 +6,8 @@ npm-package contract lives in [PUBLIC_API.md](./PUBLIC_API.md). This document is
 the operational how-to.
 
 > **Status:** the product release line described here is the agreed target.
-> Tooling (release-please) and the first tag land in #1137; `/v1` API
-> versioning lands in #1133. Until those merge, there are no tags yet.
+> `/v1` API versioning has shipped (#1133). Tooling (release-please) and the
+> first tag land in #1137; until that merges, there are no tags yet.
 
 ## The four version axes
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -180,3 +180,13 @@ OL_PII_HASH_SALT=your-org-level-salt-change-in-production
 # Uncomment to override defaults if ports conflict locally.
 # WOOCOMMERCE_MYSQL_HOST_PORT=3307   # default: 127.0.0.1:3307 (separate from PS MySQL on 3306)
 # WOOCOMMERCE_HOST_PORT=8082         # default: 127.0.0.1:8082 (PS uses 8080)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Product version surface (#1133 / ADR-029)
+# ─────────────────────────────────────────────────────────────────────────────
+# Reported by GET /v1/health as `version` and by the Swagger doc. Set this to
+# the release tag in deploys (the compiled `node dist/main.js` process has no
+# npm_package_version). Resolution: OL_PRODUCT_VERSION → npm_package_version →
+# 0.0.0-dev. Release wiring is owned by #1137 (release-please).
+# OL_PRODUCT_VERSION=0.1.0

--- a/apps/api/src/app-info/app-info.module.ts
+++ b/apps/api/src/app-info/app-info.module.ts
@@ -1,0 +1,24 @@
+/**
+ * App Info Module
+ *
+ * Exposes the `AppInfoService` (product + API version resolution) behind a
+ * Symbol token for injection into the root controller's version surface.
+ *
+ * @module apps/api/src/app-info
+ */
+import { Module } from '@nestjs/common';
+import { AppInfoService } from './app-info.service';
+
+export const APP_INFO_SERVICE_TOKEN = Symbol('IAppInfoService');
+
+@Module({
+  providers: [
+    AppInfoService,
+    {
+      provide: APP_INFO_SERVICE_TOKEN,
+      useExisting: AppInfoService,
+    },
+  ],
+  exports: [APP_INFO_SERVICE_TOKEN],
+})
+export class AppInfoModule {}

--- a/apps/api/src/app-info/app-info.service.interface.ts
+++ b/apps/api/src/app-info/app-info.service.interface.ts
@@ -1,0 +1,18 @@
+/**
+ * App Info Service Interface
+ *
+ * Contract for resolving the running process's product + API version, used by
+ * the runtime version surface (`GET /v1/health`) and the Swagger document.
+ *
+ * @module apps/api/src/app-info
+ */
+import type { AppInfo } from './app-info.types';
+
+export interface IAppInfoService {
+  /** Product (release) version, resolved from env with a dev fallback. */
+  getProductVersion(): string;
+  /** HTTP API version label (e.g. `v1`). */
+  getApiVersion(): string;
+  /** Combined identity for the version surface. */
+  getAppInfo(): AppInfo;
+}

--- a/apps/api/src/app-info/app-info.service.spec.ts
+++ b/apps/api/src/app-info/app-info.service.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * App Info Service Unit Tests
+ *
+ * Covers the product-version resolution chain
+ * (OL_PRODUCT_VERSION → npm_package_version → dev fallback) and the API-version
+ * constant surface.
+ *
+ * @module apps/api/src/app-info
+ */
+import type { ConfigService } from '@nestjs/config';
+import { AppInfoService } from './app-info.service';
+import { API_VERSION_LABEL } from './app-info.types';
+
+describe('AppInfoService', () => {
+  const originalNpmVersion = process.env.npm_package_version;
+
+  function makeService(configValue?: string): AppInfoService {
+    const configService = {
+      get: jest.fn().mockReturnValue(configValue),
+    } as unknown as ConfigService;
+    return new AppInfoService(configService);
+  }
+
+  afterEach(() => {
+    if (originalNpmVersion === undefined) {
+      delete process.env.npm_package_version;
+    } else {
+      process.env.npm_package_version = originalNpmVersion;
+    }
+  });
+
+  describe('getProductVersion', () => {
+    it('should return OL_PRODUCT_VERSION when set', () => {
+      delete process.env.npm_package_version;
+      const service = makeService('1.4.2');
+
+      expect(service.getProductVersion()).toBe('1.4.2');
+    });
+
+    it('should trim whitespace from OL_PRODUCT_VERSION', () => {
+      const service = makeService('  2.0.0  ');
+
+      expect(service.getProductVersion()).toBe('2.0.0');
+    });
+
+    it('should fall back to npm_package_version when OL_PRODUCT_VERSION is unset', () => {
+      process.env.npm_package_version = '0.9.1';
+      const service = makeService(undefined);
+
+      expect(service.getProductVersion()).toBe('0.9.1');
+    });
+
+    it('should fall back to the dev sentinel when nothing is set', () => {
+      delete process.env.npm_package_version;
+      const service = makeService(undefined);
+
+      expect(service.getProductVersion()).toBe('0.0.0-dev');
+    });
+
+    it('should prefer OL_PRODUCT_VERSION over npm_package_version', () => {
+      process.env.npm_package_version = '0.9.1';
+      const service = makeService('3.1.0');
+
+      expect(service.getProductVersion()).toBe('3.1.0');
+    });
+
+    it('should ignore an empty OL_PRODUCT_VERSION and fall through', () => {
+      delete process.env.npm_package_version;
+      const service = makeService('   ');
+
+      expect(service.getProductVersion()).toBe('0.0.0-dev');
+    });
+  });
+
+  describe('getApiVersion', () => {
+    it('should return the shared API version label', () => {
+      const service = makeService('1.0.0');
+
+      expect(service.getApiVersion()).toBe(API_VERSION_LABEL);
+      expect(service.getApiVersion()).toBe('v1');
+    });
+  });
+
+  describe('getAppInfo', () => {
+    it('should combine product and API versions', () => {
+      delete process.env.npm_package_version;
+      const service = makeService('1.2.3');
+
+      expect(service.getAppInfo()).toEqual({ version: '1.2.3', api: 'v1' });
+    });
+  });
+});

--- a/apps/api/src/app-info/app-info.service.ts
+++ b/apps/api/src/app-info/app-info.service.ts
@@ -1,0 +1,47 @@
+/**
+ * App Info Service
+ *
+ * Resolves the running process's product version from a single, deploy-friendly
+ * chain: `OL_PRODUCT_VERSION` (set by the deploy to the release tag) →
+ * `npm_package_version` (present under a `pnpm`-run dev process) → `0.0.0-dev`
+ * fallback. The API version is a compile-time constant (`API_VERSION_LABEL`)
+ * shared with the URI-versioning config so the routed prefix and the reported
+ * `api` value stay in lockstep. See ADR-029 (Axis 3).
+ *
+ * @module apps/api/src/app-info
+ * @implements {IAppInfoService}
+ */
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { IAppInfoService } from './app-info.service.interface';
+import { API_VERSION_LABEL, type AppInfo } from './app-info.types';
+
+const DEV_VERSION_FALLBACK = '0.0.0-dev';
+
+@Injectable()
+export class AppInfoService implements IAppInfoService {
+  constructor(private readonly configService: ConfigService) {}
+
+  getProductVersion(): string {
+    const explicit = this.configService.get<string>('OL_PRODUCT_VERSION');
+    if (explicit && explicit.trim().length > 0) {
+      return explicit.trim();
+    }
+    const npmVersion = process.env.npm_package_version;
+    if (npmVersion && npmVersion.trim().length > 0) {
+      return npmVersion.trim();
+    }
+    return DEV_VERSION_FALLBACK;
+  }
+
+  getApiVersion(): string {
+    return API_VERSION_LABEL;
+  }
+
+  getAppInfo(): AppInfo {
+    return {
+      version: this.getProductVersion(),
+      api: this.getApiVersion(),
+    };
+  }
+}

--- a/apps/api/src/app-info/app-info.types.ts
+++ b/apps/api/src/app-info/app-info.types.ts
@@ -1,0 +1,24 @@
+/**
+ * App Info Types & API Version Constants
+ *
+ * Single source of truth for the HTTP API version. `API_VERSION` feeds the
+ * NestJS URI-versioning config in `main.ts` (`defaultVersion`) AND the runtime
+ * version surface (`GET /v1/health`), so the routed prefix and the reported
+ * `api` field can never drift. See ADR-029 (Axis 3) / RELEASING.md.
+ *
+ * @module apps/api/src/app-info
+ */
+
+/** Bare API version fed to NestJS `enableVersioning({ defaultVersion })`. */
+export const API_VERSION = '1';
+
+/** URI-prefixed label (`v1`) reported by the version surface. */
+export const API_VERSION_LABEL = `v${API_VERSION}`;
+
+/** Resolved runtime identity of the running process. */
+export interface AppInfo {
+  /** Product (release) version — the `vX.Y.Z` tag the artifact was built from. */
+  version: string;
+  /** HTTP API version label (e.g. `v1`). */
+  api: string;
+}

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -6,8 +6,10 @@
  *
  * @module apps/api/src
  */
-import { Controller, Get, Inject } from '@nestjs/common';
+import { Controller, Get, Inject, VERSION_NEUTRAL, Version } from '@nestjs/common';
 import { AppService } from './app.service';
+import { IAppInfoService } from './app-info/app-info.service.interface';
+import { APP_INFO_SERVICE_TOKEN } from './app-info/app-info.module';
 import { Public } from './auth/decorators/public.decorator';
 import { IDevStackHealthService } from './health/dev-stack-health.service.interface';
 import type {
@@ -22,9 +24,14 @@ export class AppController {
   constructor(
     private readonly appService: AppService,
     @Inject(DEV_STACK_HEALTH_SERVICE_TOKEN)
-    private readonly devStackHealthService: IDevStackHealthService
+    private readonly devStackHealthService: IDevStackHealthService,
+    @Inject(APP_INFO_SERVICE_TOKEN)
+    private readonly appInfoService: IAppInfoService
   ) {}
 
+  // Root welcome route stays reachable at `/` (no `/v1`) for load-balancer /
+  // uptime probes that hit the bare origin (#1133).
+  @Version(VERSION_NEUTRAL)
   @Get()
   getHello(): string {
     return this.appService.getHello();
@@ -32,7 +39,10 @@ export class AppController {
 
   @Get('health')
   async getHealth(): Promise<InternalHealthResponse> {
-    return this.devStackHealthService.checkInternalHealth();
+    const readiness = await this.devStackHealthService.checkInternalHealth();
+    // App-info spread last so version/api stay authoritative even if the
+    // readiness shape ever grows a colliding field.
+    return { ...readiness, ...this.appInfoService.getAppInfo() };
   }
 
   @Get('health/dev-stack')

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AppInfoModule } from './app-info/app-info.module';
 import { DatabaseModule } from '@openlinker/shared/database';
 import { RedisConfigModule } from '@openlinker/shared/redis';
 import { CacheModule } from '@openlinker/shared/cache';
@@ -48,6 +49,7 @@ import { UsersApiModule } from './users/users.module';
     DatabaseModule,
     RedisConfigModule,
     CacheModule,
+    AppInfoModule, // Runtime product + API version surface for GET /v1/health (#1133)
     HealthModule,
     AuthModule,
     IdentifierMappingModule,

--- a/apps/api/src/health/dev-stack-health.service.interface.ts
+++ b/apps/api/src/health/dev-stack-health.service.interface.ts
@@ -8,9 +8,9 @@
  *
  * @module apps/api/src/health
  */
-import type { InternalHealthResponse, DevStackHealthResponse } from './dev-stack-health.types';
+import type { InternalHealthReadiness, DevStackHealthResponse } from './dev-stack-health.types';
 
 export interface IDevStackHealthService {
-  checkInternalHealth(): Promise<InternalHealthResponse>;
+  checkInternalHealth(): Promise<InternalHealthReadiness>;
   checkDevStackHealth(): Promise<DevStackHealthResponse>;
 }

--- a/apps/api/src/health/dev-stack-health.service.ts
+++ b/apps/api/src/health/dev-stack-health.service.ts
@@ -19,7 +19,7 @@ import { RedisClientType } from 'redis';
 import type { IDevStackHealthService } from './dev-stack-health.service.interface';
 import { WORKER_HEARTBEAT_REDIS_KEY } from '@openlinker/shared/worker/worker-health.constants';
 import type {
-  InternalHealthResponse,
+  InternalHealthReadiness,
   DevStackHealthResponse,
   ServiceHealth,
   ServiceStatus,
@@ -42,7 +42,7 @@ export class DevStackHealthService implements IDevStackHealthService {
     private readonly configService: ConfigService
   ) {}
 
-  async checkInternalHealth(): Promise<InternalHealthResponse> {
+  async checkInternalHealth(): Promise<InternalHealthReadiness> {
     const services = {
       postgres: await this.checkPostgres(),
       redis: await this.checkRedis(),

--- a/apps/api/src/health/dev-stack-health.types.ts
+++ b/apps/api/src/health/dev-stack-health.types.ts
@@ -14,12 +14,23 @@ export interface ServiceHealth {
 
 export interface InternalHealthResponse {
   status: 'ok' | 'error';
+  /** Product (release) version of the running process (#1133). */
+  version: string;
+  /** HTTP API version label, e.g. `v1` (#1133). */
+  api: string;
   services: {
     postgres: ServiceHealth;
     redis: ServiceHealth;
   };
   timestamp: string;
 }
+
+/**
+ * Readiness half of the internal health response — the DB/Redis probe result
+ * the health service owns. The root controller overlays the version surface
+ * (`version` + `api`, #1133) onto this to build the full `InternalHealthResponse`.
+ */
+export type InternalHealthReadiness = Omit<InternalHealthResponse, 'version' | 'api'>;
 
 export interface DevStackHealthResponse {
   status: 'ok' | 'degraded' | 'error';

--- a/apps/api/src/integrations/http/allegro.controller.ts
+++ b/apps/api/src/integrations/http/allegro.controller.ts
@@ -145,6 +145,11 @@ export class AllegroController {
   }
 
   @Public()
+  // Versioned under /v1 like the rest of the API (#1133). This is an internal
+  // JSON endpoint the FE callback page calls with the auth code — NOT the
+  // browser redirect target. The Allegro-whitelisted redirect URI is the FE
+  // route `/integrations/allegro/connect/callback` (window.location.origin),
+  // which is unaffected by API versioning.
   @Get('oauth/callback')
   @ApiOperation({ summary: 'Handle Allegro OAuth callback' })
   @ApiQuery({ name: 'code', description: 'OAuth authorization code', required: true })

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -8,13 +8,16 @@
  * @module apps/api/src
  */
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
 import * as express from 'express';
 import { installNestLogger } from '@openlinker/shared/logging/nest';
 import { AppModule } from './app.module';
+import { APP_INFO_SERVICE_TOKEN } from './app-info/app-info.module';
+import type { IAppInfoService } from './app-info/app-info.service.interface';
+import { API_VERSION } from './app-info/app-info.types';
 import { CapabilityNotSupportedFilter } from './common/filters/capability-not-supported.filter';
 import { ConnectionExceptionFilter } from './common/filters/connection-exception.filter';
 
@@ -80,11 +83,25 @@ async function bootstrap(): Promise<void> {
   // exception types, so registration order is irrelevant.
   app.useGlobalFilters(new CapabilityNotSupportedFilter(), new ConnectionExceptionFilter());
 
+  // HTTP API URI versioning (#1133 / ADR-029 Axis 3) — every route is served
+  // under `/v1` by default. The inbound `/webhooks` ingress opts out via
+  // `VERSION_NEUTRAL` (externally-provisioned URL); the root `/` welcome route
+  // stays neutral too. Must run before Swagger's createDocument so operations
+  // render `/v1/...`.
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: API_VERSION,
+  });
+
+  // Single-source the product version reported by the version surface + Swagger.
+  const appInfoService = app.get<IAppInfoService>(APP_INFO_SERVICE_TOKEN);
+  const productVersion = appInfoService.getProductVersion();
+
   // Swagger API documentation
   const config = new DocumentBuilder()
     .setTitle('OpenLinker API')
     .setDescription('Open-source, modular, API-first e-commerce orchestration platform')
-    .setVersion('1.0')
+    .setVersion(productVersion)
     .addBearerAuth()
     .addTag('auth', 'Authentication endpoints')
     .addTag('connections', 'Connection management endpoints')

--- a/apps/api/src/webhooks/http/webhook.controller.ts
+++ b/apps/api/src/webhooks/http/webhook.controller.ts
@@ -19,6 +19,7 @@ import {
   UnauthorizedException,
   NotFoundException,
   PayloadTooLargeException,
+  VERSION_NEUTRAL,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiHeader } from '@nestjs/swagger';
 import { Public } from '../../auth/decorators/public.decorator';
@@ -31,7 +32,10 @@ import { Logger } from '@openlinker/shared/logging';
 
 @Public()
 @ApiTags('webhooks')
-@Controller('webhooks')
+// Version-neutral (#1133): external platforms provision `/webhooks/...` URLs and
+// the raw-body middleware is keyed on the literal `/webhooks` path — this ingress
+// must stay reachable without the `/v1` prefix.
+@Controller({ path: 'webhooks', version: VERSION_NEUTRAL })
 export class WebhookController {
   private readonly logger = new Logger(WebhookController.name);
   private readonly MAX_BODY_SIZE = 256 * 1024; // 256KB

--- a/apps/api/test/integration/ai-provider-settings.int-spec.ts
+++ b/apps/api/test/integration/ai-provider-settings.int-spec.ts
@@ -39,7 +39,7 @@ async function loginAsViewer(
     [username, `${username}@example.com`, passwordHash],
   );
   const response = await harness.getHttp()
-    .post('/auth/login')
+    .post('/v1/auth/login')
     .send({ username, password: 'viewer-pass' })
     .expect(200);
   return response.body.access_token as string;
@@ -66,7 +66,7 @@ describe('AI Provider Settings Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       const res = await http
-        .get('/ai-provider-settings')
+        .get('/v1/ai-provider-settings')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -88,7 +88,7 @@ describe('AI Provider Settings Integration', () => {
       const viewerToken = await loginAsViewer(harness);
 
       await http
-        .get('/ai-provider-settings')
+        .get('/v1/ai-provider-settings')
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(403);
     });
@@ -100,14 +100,14 @@ describe('AI Provider Settings Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       await http
-        .put('/ai-provider-settings/keys/anthropic')
+        .put('/v1/ai-provider-settings/keys/anthropic')
         .set('Authorization', `Bearer ${token}`)
         .send({ apiKey: 'sk-ant-pretend-key-1234567890' })
         .expect(204);
 
       // GET reflects the new state — anthropic is configured from db.
       const res = await http
-        .get('/ai-provider-settings')
+        .get('/v1/ai-provider-settings')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       const anthropicRow = (res.body.providers as Array<{ provider: string }>).find(
@@ -125,7 +125,7 @@ describe('AI Provider Settings Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       const res = await http
-        .put('/ai-provider-settings/keys/fake')
+        .put('/v1/ai-provider-settings/keys/fake')
         .set('Authorization', `Bearer ${token}`)
         .send({ apiKey: 'sk-anything-pretend-1234567890' })
         .expect(400);
@@ -138,7 +138,7 @@ describe('AI Provider Settings Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       await http
-        .put('/ai-provider-settings/keys/cohere')
+        .put('/v1/ai-provider-settings/keys/cohere')
         .set('Authorization', `Bearer ${token}`)
         .send({ apiKey: 'sk-cohere-pretend-1234567890' })
         .expect(404);
@@ -149,13 +149,13 @@ describe('AI Provider Settings Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       await http
-        .put('/ai-provider-settings/keys/anthropic')
+        .put('/v1/ai-provider-settings/keys/anthropic')
         .set('Authorization', `Bearer ${token}`)
         .send({ apiKey: '' })
         .expect(400);
 
       await http
-        .put('/ai-provider-settings/keys/anthropic')
+        .put('/v1/ai-provider-settings/keys/anthropic')
         .set('Authorization', `Bearer ${token}`)
         .send({ apiKey: 'short' })
         .expect(400);
@@ -166,7 +166,7 @@ describe('AI Provider Settings Integration', () => {
       const viewerToken = await loginAsViewer(harness);
 
       await http
-        .put('/ai-provider-settings/keys/anthropic')
+        .put('/v1/ai-provider-settings/keys/anthropic')
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({ apiKey: 'sk-ant-pretend-1234567890' })
         .expect(403);
@@ -179,7 +179,7 @@ describe('AI Provider Settings Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       const res = await http
-        .delete('/ai-provider-settings/keys/fake')
+        .delete('/v1/ai-provider-settings/keys/fake')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
 
@@ -191,7 +191,7 @@ describe('AI Provider Settings Integration', () => {
       const viewerToken = await loginAsViewer(harness);
 
       await http
-        .delete('/ai-provider-settings/keys/anthropic')
+        .delete('/v1/ai-provider-settings/keys/anthropic')
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(403);
     });
@@ -203,7 +203,7 @@ describe('AI Provider Settings Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       const res = await http
-        .put('/ai-provider-settings/active')
+        .put('/v1/ai-provider-settings/active')
         .set('Authorization', `Bearer ${token}`)
         .send({ provider: 'anthropic' })
         .expect(422);
@@ -217,21 +217,21 @@ describe('AI Provider Settings Integration', () => {
 
       // Seed: store a key for openai.
       await http
-        .put('/ai-provider-settings/keys/openai')
+        .put('/v1/ai-provider-settings/keys/openai')
         .set('Authorization', `Bearer ${token}`)
         .send({ apiKey: 'sk-openai-pretend-1234567890' })
         .expect(204);
 
       // Activate openai.
       await http
-        .put('/ai-provider-settings/active')
+        .put('/v1/ai-provider-settings/active')
         .set('Authorization', `Bearer ${token}`)
         .send({ provider: 'openai' })
         .expect(204);
 
       // GET reflects the change + the activeUpdated{At,By} fields are populated.
       const res = await http
-        .get('/ai-provider-settings')
+        .get('/v1/ai-provider-settings')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(res.body.activeProvider).toBe('openai');
@@ -247,13 +247,13 @@ describe('AI Provider Settings Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       await http
-        .put('/ai-provider-settings/active')
+        .put('/v1/ai-provider-settings/active')
         .set('Authorization', `Bearer ${token}`)
         .send({ provider: 'fake' })
         .expect(204);
 
       const res = await http
-        .get('/ai-provider-settings')
+        .get('/v1/ai-provider-settings')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(res.body.activeProvider).toBe('fake');
@@ -264,7 +264,7 @@ describe('AI Provider Settings Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       await http
-        .put('/ai-provider-settings/active')
+        .put('/v1/ai-provider-settings/active')
         .set('Authorization', `Bearer ${token}`)
         .send({ provider: 'cohere' })
         .expect(400);
@@ -275,7 +275,7 @@ describe('AI Provider Settings Integration', () => {
       const viewerToken = await loginAsViewer(harness);
 
       await http
-        .put('/ai-provider-settings/active')
+        .put('/v1/ai-provider-settings/active')
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({ provider: 'fake' })
         .expect(403);

--- a/apps/api/test/integration/api-versioning.int-spec.ts
+++ b/apps/api/test/integration/api-versioning.int-spec.ts
@@ -1,0 +1,91 @@
+/**
+ * HTTP API Versioning Integration Test (#1133 / ADR-029 Axis 3)
+ *
+ * Vertical slice covering the URI-versioning contract:
+ * - `GET /v1/health` exposes the runtime version surface (product + api).
+ * - Versioned routes are served ONLY under `/v1` (unversioned → 404).
+ * - The inbound-webhook ingress stays version-neutral (externally-provisioned
+ *   URL): reachable without `/v1`, absent under `/v1`.
+ * - The Allegro OAuth callback is a normal versioned API endpoint (the FE
+ *   callback page calls it with the auth code) — served under `/v1`, not neutral.
+ *
+ * @module apps/api/test/integration
+ */
+import { getTestHarness, IntegrationTestHarness, teardownTestHarness } from './setup';
+
+describe('HTTP API versioning (#1133)', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  describe('runtime version surface', () => {
+    it('should expose product + api version at GET /v1/health', async () => {
+      const http = harness.getHttp();
+
+      const response = await http.get('/v1/health').expect(200);
+
+      expect(response.body).toMatchObject({
+        status: expect.stringMatching(/^(ok|error)$/),
+        api: 'v1',
+        version: expect.any(String),
+      });
+      expect(response.body.version.length).toBeGreaterThan(0);
+      expect(response.body.services).toBeDefined();
+    });
+  });
+
+  describe('versioned routes are served only under /v1', () => {
+    it('should route a versioned resource under /v1 (auth-gated, not 404)', async () => {
+      const http = harness.getHttp();
+
+      // No token → 401 proves the route EXISTS under /v1 (guard ran).
+      await http.get('/v1/orders').expect(401);
+    });
+
+    it('should 404 the same resource without the /v1 prefix', async () => {
+      const http = harness.getHttp();
+
+      await http.get('/orders').expect(404);
+    });
+  });
+
+  describe('version-neutral carve-out — inbound webhook ingress', () => {
+    // An uppercase provider trips the handler's "lowercase letters only" format
+    // check → 400. That status is produced ONLY when the route is reached, so it
+    // is unambiguous proof of routing (unlike a handler 404 for an unknown
+    // connection, which a plain routing miss also returns).
+    const NEUTRAL_PROBE = '/webhooks/INVALID/not-a-uuid';
+
+    it('should serve the webhook ingress without /v1 (reaches the handler → 400)', async () => {
+      const http = harness.getHttp();
+
+      await http.post(NEUTRAL_PROBE).send({}).expect(400);
+    });
+
+    it('should NOT serve the webhook ingress under /v1', async () => {
+      const http = harness.getHttp();
+
+      await http.post(`/v1${NEUTRAL_PROBE}`).send({}).expect(404);
+    });
+  });
+
+  describe('the Allegro OAuth callback is versioned (internal API, not a redirect target)', () => {
+    it('should route the callback under /v1 (400 on missing params, not 404)', async () => {
+      const http = harness.getHttp();
+
+      await http.get('/v1/integrations/allegro/oauth/callback').expect(400);
+    });
+
+    it('should 404 the callback without the /v1 prefix', async () => {
+      const http = harness.getHttp();
+
+      await http.get('/integrations/allegro/oauth/callback').expect(404);
+    });
+  });
+});

--- a/apps/api/test/integration/app-boot.int-spec.ts
+++ b/apps/api/test/integration/app-boot.int-spec.ts
@@ -46,7 +46,7 @@ describe('App Boot Integration', () => {
   it('should respond to health endpoint', async () => {
     const http = harness.getHttp();
 
-    const response = await http.get('/health').expect(200);
+    const response = await http.get('/v1/health').expect(200);
 
     expect(response.body).toBeDefined();
   });

--- a/apps/api/test/integration/auth-refresh.int-spec.ts
+++ b/apps/api/test/integration/auth-refresh.int-spec.ts
@@ -48,7 +48,7 @@ async function seedAdminAndLogin(harness: IntegrationTestHarness, username = 'ad
 
   const response = await harness
     .getHttp()
-    .post('/auth/login')
+    .post('/v1/auth/login')
     .send({ username, password: 'test-password' })
     .expect(200);
 
@@ -94,7 +94,7 @@ describe('Auth Refresh Integration (#710)', () => {
 
       const response = await harness
         .getHttp()
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ username: 'admin', password: 'test-password' })
         .expect(200);
 
@@ -137,7 +137,7 @@ describe('Auth Refresh Integration (#710)', () => {
 
       const refreshResponse = await harness
         .getHttp()
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .set('Cookie', initial.cookieHeader)
         .set('X-CSRF-Token', initial.csrfValue)
         .expect(200);
@@ -160,7 +160,7 @@ describe('Auth Refresh Integration (#710)', () => {
 
       await harness
         .getHttp()
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .set('Cookie', initial.cookieHeader)
         // no X-CSRF-Token header
         .expect(403);
@@ -171,7 +171,7 @@ describe('Auth Refresh Integration (#710)', () => {
 
       await harness
         .getHttp()
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .set('Cookie', initial.cookieHeader)
         .set('X-CSRF-Token', 'tampered-value')
         .expect(403);
@@ -183,7 +183,7 @@ describe('Auth Refresh Integration (#710)', () => {
       // Rotate once — this revokes `initial.refreshCookie` with reason `rotated`.
       await harness
         .getHttp()
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .set('Cookie', initial.cookieHeader)
         .set('X-CSRF-Token', initial.csrfValue)
         .expect(200);
@@ -191,7 +191,7 @@ describe('Auth Refresh Integration (#710)', () => {
       // Now replay the OLD cookie — should trip reuse-detection.
       await harness
         .getHttp()
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .set('Cookie', initial.cookieHeader)
         .set('X-CSRF-Token', initial.csrfValue)
         .expect(401);
@@ -216,7 +216,7 @@ describe('Auth Refresh Integration (#710)', () => {
       // Send only the CSRF cookie/header, no ol_refresh.
       await harness
         .getHttp()
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .set('Cookie', `${COOKIE_CSRF}=${initial.csrfValue}`)
         .set('X-CSRF-Token', initial.csrfValue)
         .expect(401);
@@ -229,7 +229,7 @@ describe('Auth Refresh Integration (#710)', () => {
 
       await harness
         .getHttp()
-        .post('/auth/logout')
+        .post('/v1/auth/logout')
         .set('Cookie', initial.cookieHeader)
         .set('X-CSRF-Token', initial.csrfValue)
         .expect(204);
@@ -238,7 +238,7 @@ describe('Auth Refresh Integration (#710)', () => {
       // (or returns 401 directly because it's revoked).
       await harness
         .getHttp()
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .set('Cookie', initial.cookieHeader)
         .set('X-CSRF-Token', initial.csrfValue)
         .expect(401);
@@ -255,7 +255,7 @@ describe('Auth Refresh Integration (#710)', () => {
       const initial = await seedAdminAndLogin(harness);
       await harness
         .getHttp()
-        .post('/auth/logout')
+        .post('/v1/auth/logout')
         .set('Cookie', initial.cookieHeader)
         .expect(403);
     });

--- a/apps/api/test/integration/auth.int-spec.ts
+++ b/apps/api/test/integration/auth.int-spec.ts
@@ -56,7 +56,7 @@ describe('Auth Integration', () => {
       await seedUser(dataSource, 'testuser', 'correct-password');
 
       const response = await http
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ username: 'testuser', password: 'correct-password' })
         .expect(200);
 
@@ -72,7 +72,7 @@ describe('Auth Integration', () => {
       await seedUser(dataSource, 'testuser', 'correct-password');
 
       await http
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ username: 'testuser', password: 'wrong-password' })
         .expect(401);
     });
@@ -80,7 +80,7 @@ describe('Auth Integration', () => {
     it('should return 401 when user does not exist', async () => {
       const http = harness.getHttp();
 
-      await http.post('/auth/login').send({ username: 'ghost', password: 'any' }).expect(401);
+      await http.post('/v1/auth/login').send({ username: 'ghost', password: 'any' }).expect(401);
     });
   });
 
@@ -93,7 +93,7 @@ describe('Auth Integration', () => {
 
       // Login to get token
       const loginResponse = await http
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ username: 'meuser', password: 'password123' })
         .expect(200);
 
@@ -101,7 +101,7 @@ describe('Auth Integration', () => {
 
       // Use token to fetch current user
       const meResponse = await http
-        .get('/auth/me')
+        .get('/v1/auth/me')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -115,13 +115,13 @@ describe('Auth Integration', () => {
     it('should return 401 when no token is provided', async () => {
       const http = harness.getHttp();
 
-      await http.get('/auth/me').expect(401);
+      await http.get('/v1/auth/me').expect(401);
     });
 
     it('should return 401 when token is invalid', async () => {
       const http = harness.getHttp();
 
-      await http.get('/auth/me').set('Authorization', 'Bearer this.is.not.valid').expect(401);
+      await http.get('/v1/auth/me').set('Authorization', 'Bearer this.is.not.valid').expect(401);
     });
   });
 });

--- a/apps/api/test/integration/connection-capabilities.int-spec.ts
+++ b/apps/api/test/integration/connection-capabilities.int-spec.ts
@@ -43,7 +43,7 @@ describe('Connection Capabilities Integration', () => {
     const dataSource = harness.getDataSource();
     const authToken = token ?? (await loginAsAdmin(http, dataSource));
     const response = await http
-      .post('/connections')
+      .post('/v1/connections')
       .set('Authorization', `Bearer ${authToken}`)
       .send(body)
       .expect(201);
@@ -85,7 +85,7 @@ describe('Connection Capabilities Integration', () => {
       enabledCapabilities: ['ProductMaster', 'OfferManager'], // Marketplace not supported by prestashop.webservice.v1
     } as Record<string, unknown>);
 
-    await http.post('/connections').set('Authorization', `Bearer ${token}`).send(dto).expect(400);
+    await http.post('/v1/connections').set('Authorization', `Bearer ${token}`).send(dto).expect(400);
   });
 
   it('allows PATCH to narrow enabledCapabilities', async () => {
@@ -99,7 +99,7 @@ describe('Connection Capabilities Integration', () => {
     );
 
     const updated = await http
-      .patch(`/connections/${created.id}`)
+      .patch(`/v1/connections/${created.id}`)
       .set('Authorization', `Bearer ${token}`)
       .send({ enabledCapabilities: ['ProductMaster'] })
       .expect(200);
@@ -126,7 +126,7 @@ describe('Connection Capabilities Integration', () => {
     );
 
     await http
-      .patch(`/connections/${created.id}`)
+      .patch(`/v1/connections/${created.id}`)
       .set('Authorization', `Bearer ${token}`)
       .send({ adapterKey: 'prestashop.webservice.v2' })
       .expect(400);
@@ -143,7 +143,7 @@ describe('Connection Capabilities Integration', () => {
     );
 
     await http
-      .patch(`/connections/${created.id}`)
+      .patch(`/v1/connections/${created.id}`)
       .set('Authorization', `Bearer ${token}`)
       .send({ enabledCapabilities: ['OfferManager'] })
       .expect(400);

--- a/apps/api/test/integration/connection-credentials.int-spec.ts
+++ b/apps/api/test/integration/connection-credentials.int-spec.ts
@@ -54,7 +54,7 @@ describe('Connection Credentials Integration', () => {
       const dto = createPrestashopWizardConnectionDto({ name: 'Wizard Store' });
 
       const response = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send(dto)
         .expect(201);
@@ -89,7 +89,7 @@ describe('Connection Credentials Integration', () => {
       });
 
       await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send(dto)
         .expect(400);
@@ -105,7 +105,7 @@ describe('Connection Credentials Integration', () => {
       });
 
       await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send(dto)
         .expect(400);
@@ -121,7 +121,7 @@ describe('Connection Credentials Integration', () => {
       });
 
       await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send(dto)
         .expect(400);
@@ -135,7 +135,7 @@ describe('Connection Credentials Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       const created = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send(createPrestashopWizardConnectionDto())
         .expect(201);
@@ -144,7 +144,7 @@ describe('Connection Credentials Integration', () => {
       const refBefore = before!.credentialsRef;
 
       await http
-        .put(`/connections/${created.body.id}/credentials`)
+        .put(`/v1/connections/${created.body.id}/credentials`)
         .set('Authorization', `Bearer ${token}`)
         .send({ credentials: { webserviceApiKey: 'ROTATED_KEY' } })
         .expect(204);
@@ -170,7 +170,7 @@ describe('Connection Credentials Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       const created = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send(createPrestashopConnectionDto({ credentialsRef: 'db:explicit-ref' }))
         .expect(201);
@@ -182,7 +182,7 @@ describe('Connection Credentials Integration', () => {
         .update({ id: created.body.id }, { credentialsRef: 'LEGACY_RAW_KEY' });
 
       await http
-        .put(`/connections/${created.body.id}/credentials`)
+        .put(`/v1/connections/${created.body.id}/credentials`)
         .set('Authorization', `Bearer ${token}`)
         .send({ credentials: { webserviceApiKey: 'X' } })
         .expect(400);

--- a/apps/api/test/integration/connection-crud.int-spec.ts
+++ b/apps/api/test/integration/connection-crud.int-spec.ts
@@ -39,7 +39,7 @@ describe('Connection CRUD Integration', () => {
 
       // Create connection via HTTP
       const response = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send(dto)
         .expect(201);
@@ -72,7 +72,7 @@ describe('Connection CRUD Integration', () => {
 
       // Missing required fields
       await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send({})
         .expect(400);
@@ -80,7 +80,7 @@ describe('Connection CRUD Integration', () => {
 
     it('should return 401 without token', async () => {
       const http = harness.getHttp();
-      await http.post('/connections').send({}).expect(401);
+      await http.post('/v1/connections').send({}).expect(401);
     });
   });
 
@@ -93,7 +93,7 @@ describe('Connection CRUD Integration', () => {
       // Create connection via HTTP
       const dto = createPrestashopConnectionDto();
       const createResponse = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send(dto)
         .expect(201);
@@ -101,7 +101,7 @@ describe('Connection CRUD Integration', () => {
 
       // Retrieve connection via HTTP
       const getResponse = await http
-        .get(`/connections/${connectionId}`)
+        .get(`/v1/connections/${connectionId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -121,14 +121,14 @@ describe('Connection CRUD Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get('/connections/00000000-0000-4000-8000-000000000000')
+        .get('/v1/connections/00000000-0000-4000-8000-000000000000')
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
 
     it('should return 401 without token', async () => {
       const http = harness.getHttp();
-      await http.get('/connections/00000000-0000-4000-8000-000000000000').expect(401);
+      await http.get('/v1/connections/00000000-0000-4000-8000-000000000000').expect(401);
     });
   });
 
@@ -142,12 +142,12 @@ describe('Connection CRUD Integration', () => {
       const dto1 = createPrestashopConnectionDto({ name: 'Store 1' });
       const dto2 = createPrestashopConnectionDto({ name: 'Store 2' });
 
-      await http.post('/connections').set('Authorization', `Bearer ${token}`).send(dto1).expect(201);
-      await http.post('/connections').set('Authorization', `Bearer ${token}`).send(dto2).expect(201);
+      await http.post('/v1/connections').set('Authorization', `Bearer ${token}`).send(dto1).expect(201);
+      await http.post('/v1/connections').set('Authorization', `Bearer ${token}`).send(dto2).expect(201);
 
       // List connections
       const response = await http
-        .get('/connections')
+        .get('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -168,14 +168,14 @@ describe('Connection CRUD Integration', () => {
       // Create connections with different platform types
       const prestashopDto = createPrestashopConnectionDto({ name: 'PrestaShop Store' });
       await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send(prestashopDto)
         .expect(201);
 
       // Filter by platformType
       const response = await http
-        .get('/connections')
+        .get('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .query({ platformType: 'prestashop' })
         .expect(200);
@@ -197,7 +197,7 @@ describe('Connection CRUD Integration', () => {
       // Create connection
       const dto = createPrestashopConnectionDto();
       const createResponse = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${token}`)
         .send(dto)
         .expect(201);
@@ -210,7 +210,7 @@ describe('Connection CRUD Integration', () => {
       };
 
       const updateResponse = await http
-        .patch(`/connections/${connectionId}`)
+        .patch(`/v1/connections/${connectionId}`)
         .set('Authorization', `Bearer ${token}`)
         .send(updateDto)
         .expect(200);

--- a/apps/api/test/integration/connection-diagnostics.int-spec.ts
+++ b/apps/api/test/integration/connection-diagnostics.int-spec.ts
@@ -42,7 +42,7 @@ describe('Connection Diagnostics API Integration', () => {
       const connection = await createTestConnection(dataSource);
 
       const response = await http
-        .get(`/connections/${connection.id}/diagnostics`)
+        .get(`/v1/connections/${connection.id}/diagnostics`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -73,7 +73,7 @@ describe('Connection Diagnostics API Integration', () => {
       });
 
       const response = await http
-        .get(`/connections/${connection.id}/diagnostics`)
+        .get(`/v1/connections/${connection.id}/diagnostics`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -93,14 +93,14 @@ describe('Connection Diagnostics API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get('/connections/00000000-0000-4000-8000-000000000000/diagnostics')
+        .get('/v1/connections/00000000-0000-4000-8000-000000000000/diagnostics')
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
 
     it('should return 401 without token', async () => {
       const http = harness.getHttp();
-      await http.get('/connections/00000000-0000-4000-8000-000000000000/diagnostics').expect(401);
+      await http.get('/v1/connections/00000000-0000-4000-8000-000000000000/diagnostics').expect(401);
     });
   });
 });

--- a/apps/api/test/integration/content-editor-and-suggest.int-spec.ts
+++ b/apps/api/test/integration/content-editor-and-suggest.int-spec.ts
@@ -37,7 +37,7 @@ async function loginAsViewer(
     [username, `${username}@example.com`, passwordHash],
   );
   const response = await harness.getHttp()
-    .post('/auth/login')
+    .post('/v1/auth/login')
     .send({ username, password: 'viewer-pass' })
     .expect(200);
   return response.body.access_token as string;
@@ -80,7 +80,7 @@ describe('Content Editor + AI Suggest Integration', () => {
       const productId = await seedProduct(dataSource, 'get-empty');
 
       const response = await http
-        .get(`/products/${productId}/content`)
+        .get(`/v1/products/${productId}/content`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -104,7 +104,7 @@ describe('Content Editor + AI Suggest Integration', () => {
       const productId = await seedProduct(dataSource, 'draft-1');
 
       const saved = await http
-        .post(`/products/${productId}/content/draft`)
+        .post(`/v1/products/${productId}/content/draft`)
         .set('Authorization', `Bearer ${token}`)
         .send({ connectionId: null, fieldKey: 'description', value: 'my draft' })
         .expect(200);
@@ -115,19 +115,19 @@ describe('Content Editor + AI Suggest Integration', () => {
 
       // The state endpoint now reflects the draft.
       const state = await http
-        .get(`/products/${productId}/content`)
+        .get(`/v1/products/${productId}/content`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(state.body.master.draftValue).toBe('my draft');
 
       await http
-        .post(`/products/${productId}/content/discard`)
+        .post(`/v1/products/${productId}/content/discard`)
         .set('Authorization', `Bearer ${token}`)
         .send({ connectionId: null, fieldKey: 'description' })
         .expect(204);
 
       const after = await http
-        .get(`/products/${productId}/content`)
+        .get(`/v1/products/${productId}/content`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(after.body.master.draftValue).toBeNull();
@@ -141,7 +141,7 @@ describe('Content Editor + AI Suggest Integration', () => {
 
       const oversized = 'x'.repeat(65537);
       await http
-        .post(`/products/${productId}/content/draft`)
+        .post(`/v1/products/${productId}/content/draft`)
         .set('Authorization', `Bearer ${token}`)
         .send({ connectionId: null, fieldKey: 'description', value: oversized })
         .expect(400);
@@ -166,7 +166,7 @@ describe('Content Editor + AI Suggest Integration', () => {
       // with a live PrestaShop adapter is covered by manual QA + the existing
       // integration-test pattern (live-creds gap).
       const response = await http
-        .post(`/products/${productId}/content/suggest`)
+        .post(`/v1/products/${productId}/content/suggest`)
         .set('Authorization', `Bearer ${token}`)
         .send({ channel: 'allegro', tone: 'casual' });
 
@@ -183,7 +183,7 @@ describe('Content Editor + AI Suggest Integration', () => {
       const productId = await seedProduct(dataSource, 'suggest-tone-cap');
 
       await http
-        .post(`/products/${productId}/content/suggest`)
+        .post(`/v1/products/${productId}/content/suggest`)
         .set('Authorization', `Bearer ${token}`)
         .send({ channel: 'allegro', tone: 'x'.repeat(65) })
         .expect(400);
@@ -196,7 +196,7 @@ describe('Content Editor + AI Suggest Integration', () => {
       const productId = await seedProduct(dataSource, 'suggest-instr-cap');
 
       await http
-        .post(`/products/${productId}/content/suggest`)
+        .post(`/v1/products/${productId}/content/suggest`)
         .set('Authorization', `Bearer ${token}`)
         .send({ channel: 'allegro', extraInstructions: 'x'.repeat(1025) })
         .expect(400);
@@ -211,7 +211,7 @@ describe('Content Editor + AI Suggest Integration', () => {
       const productId = await seedProduct(dataSource, 'publish-missing');
 
       await http
-        .post(`/products/${productId}/content/publish`)
+        .post(`/v1/products/${productId}/content/publish`)
         .set('Authorization', `Bearer ${token}`)
         .send({ connectionId: null, fieldKey: 'description' })
         .expect(404);
@@ -226,30 +226,30 @@ describe('Content Editor + AI Suggest Integration', () => {
       const viewerToken = await loginAsViewer(harness);
 
       await http
-        .get(`/products/${productId}/content`)
+        .get(`/v1/products/${productId}/content`)
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(403);
 
       await http
-        .post(`/products/${productId}/content/draft`)
+        .post(`/v1/products/${productId}/content/draft`)
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({ connectionId: null, fieldKey: 'description', value: 'x' })
         .expect(403);
 
       await http
-        .post(`/products/${productId}/content/discard`)
+        .post(`/v1/products/${productId}/content/discard`)
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({ connectionId: null, fieldKey: 'description' })
         .expect(403);
 
       await http
-        .post(`/products/${productId}/content/publish`)
+        .post(`/v1/products/${productId}/content/publish`)
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({ connectionId: null, fieldKey: 'description' })
         .expect(403);
 
       await http
-        .post(`/products/${productId}/content/suggest`)
+        .post(`/v1/products/${productId}/content/suggest`)
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({ channel: 'allegro' })
         .expect(403);

--- a/apps/api/test/integration/helpers/test-auth.helper.ts
+++ b/apps/api/test/integration/helpers/test-auth.helper.ts
@@ -35,7 +35,7 @@ export async function loginAs(
   );
 
   const response = await http
-    .post('/auth/login')
+    .post('/v1/auth/login')
     .send({ username, password })
     .expect(200);
 

--- a/apps/api/test/integration/inventory-availability.int-spec.ts
+++ b/apps/api/test/integration/inventory-availability.int-spec.ts
@@ -136,7 +136,7 @@ describe('GET /inventory/availability (#792 PR 2)', () => {
     });
 
     const response = await http
-      .get(`/inventory/availability?${params.toString()}`)
+      .get(`/v1/inventory/availability?${params.toString()}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -169,7 +169,7 @@ describe('GET /inventory/availability (#792 PR 2)', () => {
     const token = await loginAsAdmin(http, dataSource);
 
     await http
-      .get('/inventory/availability?productVariantIds=')
+      .get('/v1/inventory/availability?productVariantIds=')
       .set('Authorization', `Bearer ${token}`)
       .expect(400);
   });
@@ -182,14 +182,14 @@ describe('GET /inventory/availability (#792 PR 2)', () => {
     const ids = Array.from({ length: 201 }, (_, i) => `ol_variant_${i.toString()}`).join(',');
 
     await http
-      .get(`/inventory/availability?productVariantIds=${ids}`)
+      .get(`/v1/inventory/availability?productVariantIds=${ids}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(400);
   });
 
   it('returns 401 without an auth token', async () => {
     const http = harness.getHttp();
-    await http.get('/inventory/availability?productVariantIds=ol_variant_x').expect(401);
+    await http.get('/v1/inventory/availability?productVariantIds=ol_variant_x').expect(401);
   });
 
   it('preserves input order in the response items[]', async () => {
@@ -214,7 +214,7 @@ describe('GET /inventory/availability (#792 PR 2)', () => {
     });
 
     const response = await http
-      .get(`/inventory/availability?${params.toString()}`)
+      .get(`/v1/inventory/availability?${params.toString()}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 

--- a/apps/api/test/integration/inventory-read.int-spec.ts
+++ b/apps/api/test/integration/inventory-read.int-spec.ts
@@ -40,7 +40,7 @@ describe('Inventory Read API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       const response = await http
-        .get('/inventory')
+        .get('/v1/inventory')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -59,7 +59,7 @@ describe('Inventory Read API Integration', () => {
       });
 
       const response = await http
-        .get('/inventory')
+        .get('/v1/inventory')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -83,7 +83,7 @@ describe('Inventory Read API Integration', () => {
       await createTestInventoryItem(dataSource);
 
       const response = await http
-        .get(`/inventory?productId=${item1.productId}`)
+        .get(`/v1/inventory?productId=${item1.productId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -100,7 +100,7 @@ describe('Inventory Read API Integration', () => {
       await createTestInventoryItem(dataSource, { locationId: 'warehouse-b' });
 
       const response = await http
-        .get('/inventory?locationId=warehouse-a')
+        .get('/v1/inventory?locationId=warehouse-a')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -118,7 +118,7 @@ describe('Inventory Read API Integration', () => {
       }
 
       const page1 = await http
-        .get('/inventory?limit=2&offset=0')
+        .get('/v1/inventory?limit=2&offset=0')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -128,7 +128,7 @@ describe('Inventory Read API Integration', () => {
       expect(page1.body.offset).toBe(0);
 
       const page2 = await http
-        .get('/inventory?limit=2&offset=2')
+        .get('/v1/inventory?limit=2&offset=2')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -143,7 +143,7 @@ describe('Inventory Read API Integration', () => {
 
     it('should return 401 without token', async () => {
       const http = harness.getHttp();
-      await http.get('/inventory').expect(401);
+      await http.get('/v1/inventory').expect(401);
     });
 
     it('should surface the cover image URL from the parent product', async () => {
@@ -159,7 +159,7 @@ describe('Inventory Read API Integration', () => {
       });
 
       const response = await http
-        .get('/inventory')
+        .get('/v1/inventory')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -176,7 +176,7 @@ describe('Inventory Read API Integration', () => {
       const item = await createTestInventoryItem(dataSource, undefined, { images: null });
 
       const response = await http
-        .get('/inventory')
+        .get('/v1/inventory')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -195,7 +195,7 @@ describe('Inventory Read API Integration', () => {
       const item = await createTestInventoryItem(dataSource, { availableQuantity: 7 });
 
       const response = await http
-        .get(`/inventory/${item.id}`)
+        .get(`/v1/inventory/${item.id}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -209,14 +209,14 @@ describe('Inventory Read API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get('/inventory/ol_inventory_nonexistent')
+        .get('/v1/inventory/ol_inventory_nonexistent')
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
 
     it('should return 401 without token', async () => {
       const http = harness.getHttp();
-      await http.get('/inventory/ol_inventory_nonexistent').expect(401);
+      await http.get('/v1/inventory/ol_inventory_nonexistent').expect(401);
     });
   });
 });

--- a/apps/api/test/integration/invoicing-list.int-spec.ts
+++ b/apps/api/test/integration/invoicing-list.int-spec.ts
@@ -85,7 +85,7 @@ describe('Invoicing list (integration)', () => {
     const token = await loginAsAdmin(http, dataSource);
 
     const response = await http
-      .get('/invoices')
+      .get('/v1/invoices')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -96,7 +96,7 @@ describe('Invoicing list (integration)', () => {
 
   it('rejects an unauthenticated request', async () => {
     const http = harness.getHttp();
-    await http.get('/invoices').expect(401);
+    await http.get('/v1/invoices').expect(401);
   });
 
   it('filters by status', async () => {
@@ -108,7 +108,7 @@ describe('Invoicing list (integration)', () => {
     await seedInvoice(ds, { status: 'pending' });
 
     const response = await http
-      .get('/invoices?status=failed')
+      .get('/v1/invoices?status=failed')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -126,7 +126,7 @@ describe('Invoicing list (integration)', () => {
     await seedInvoice(ds, { connectionId: CONN_B });
 
     const response = await http
-      .get(`/invoices?connectionId=${CONN_B}`)
+      .get(`/v1/invoices?connectionId=${CONN_B}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -142,7 +142,7 @@ describe('Invoicing list (integration)', () => {
     await seedInvoice(ds, { regulatoryStatus: 'not-applicable' });
 
     const response = await http
-      .get('/invoices?regulatoryStatus=cleared')
+      .get('/v1/invoices?regulatoryStatus=cleared')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -159,7 +159,7 @@ describe('Invoicing list (integration)', () => {
     await seedInvoice(ds, { issuedAt: new Date('2026-07-15T00:00:00.000Z') });
 
     const response = await http
-      .get('/invoices?issuedFrom=2026-06-01T00:00:00.000Z&issuedTo=2026-06-30T00:00:00.000Z')
+      .get('/v1/invoices?issuedFrom=2026-06-01T00:00:00.000Z&issuedTo=2026-06-30T00:00:00.000Z')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -176,7 +176,7 @@ describe('Invoicing list (integration)', () => {
     }
 
     const response = await http
-      .get('/invoices?limit=2&offset=0')
+      .get('/v1/invoices?limit=2&offset=0')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -186,7 +186,7 @@ describe('Invoicing list (integration)', () => {
     expect(response.body.offset).toBe(0);
 
     const page2 = await http
-      .get('/invoices?limit=2&offset=2')
+      .get('/v1/invoices?limit=2&offset=2')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
     expect(page2.body.items).toHaveLength(1);
@@ -202,7 +202,7 @@ describe('Invoicing list (integration)', () => {
     });
 
     const response = await http
-      .get('/invoices')
+      .get('/v1/invoices')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -222,7 +222,7 @@ describe('Invoicing list (integration)', () => {
     // rejects it with a 400 rather than accepting-and-ignoring it (which would
     // mislead a caller into thinking results were filtered).
     await http
-      .get('/invoices?hasTaxId=true')
+      .get('/v1/invoices?hasTaxId=true')
       .set('Authorization', `Bearer ${token}`)
       .expect(400);
   });
@@ -260,7 +260,7 @@ describe('GET /orders/:orderId/invoice (integration)', () => {
     });
 
     const found = await http
-      .get(`/orders/${order.internalOrderId}/invoice?connectionId=${INVOICING_CONN}`)
+      .get(`/v1/orders/${order.internalOrderId}/invoice?connectionId=${INVOICING_CONN}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
     expect(found.body.orderId).toBe(order.internalOrderId);
@@ -268,7 +268,7 @@ describe('GET /orders/:orderId/invoice (integration)', () => {
 
     // Keying off the (wrong) source connection finds nothing.
     await http
-      .get(`/orders/${order.internalOrderId}/invoice?connectionId=${SOURCE_CONN}`)
+      .get(`/v1/orders/${order.internalOrderId}/invoice?connectionId=${SOURCE_CONN}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(404);
   });
@@ -280,7 +280,7 @@ describe('GET /orders/:orderId/invoice (integration)', () => {
     const order = await createTestOrderRecord(ds, { sourceConnectionId: SOURCE_CONN });
 
     await http
-      .get(`/orders/${order.internalOrderId}/invoice`)
+      .get(`/v1/orders/${order.internalOrderId}/invoice`)
       .set('Authorization', `Bearer ${token}`)
       .expect(400);
   });
@@ -291,7 +291,7 @@ describe('GET /orders/:orderId/invoice (integration)', () => {
     const token = await loginAsAdmin(http, ds);
 
     await http
-      .get(`/orders/ol_order_missing/invoice?connectionId=${INVOICING_CONN}`)
+      .get(`/v1/orders/ol_order_missing/invoice?connectionId=${INVOICING_CONN}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(404);
   });

--- a/apps/api/test/integration/invoicing/invoicing-upo-download.int-spec.ts
+++ b/apps/api/test/integration/invoicing/invoicing-upo-download.int-spec.ts
@@ -89,7 +89,7 @@ async function loginAsViewer(harness: IntegrationTestHarness): Promise<string> {
     ]);
   const response = await harness
     .getHttp()
-    .post('/auth/login')
+    .post('/v1/auth/login')
     .send({ username: 'viewer', password: 'viewer-pass' })
     .expect(200);
   return (response.body as { access_token: string }).access_token;
@@ -142,7 +142,7 @@ describe('Invoicing UPO Download Integration (#1224)', () => {
     const record = await seedInvoiceRecord(dataSource, { connectionId: connection.id });
 
     const res = await http
-      .get(`/invoices/${record.id}/upo`)
+      .get(`/v1/invoices/${record.id}/upo`)
       .set('Authorization', `Bearer ${token}`)
       .buffer(true)
       .parse((response, callback) => {
@@ -162,7 +162,7 @@ describe('Invoicing UPO Download Integration (#1224)', () => {
     const token = await loginAsAdmin(http, harness.getDataSource());
 
     await http
-      .get('/invoices/11111111-1111-1111-1111-111111111111/upo')
+      .get('/v1/invoices/11111111-1111-1111-1111-111111111111/upo')
       .set('Authorization', `Bearer ${token}`)
       .expect(404);
   });
@@ -183,7 +183,7 @@ describe('Invoicing UPO Download Integration (#1224)', () => {
     });
 
     await http
-      .get(`/invoices/${record.id}/upo`)
+      .get(`/v1/invoices/${record.id}/upo`)
       .set('Authorization', `Bearer ${token}`)
       .expect(409);
   });
@@ -200,7 +200,7 @@ describe('Invoicing UPO Download Integration (#1224)', () => {
     const viewerToken = await loginAsViewer(harness);
 
     await http
-      .get(`/invoices/${record.id}/upo`)
+      .get(`/v1/invoices/${record.id}/upo`)
       .set('Authorization', `Bearer ${viewerToken}`)
       .expect(403);
   });

--- a/apps/api/test/integration/listings-bulk-offer-creation-retry-failed.int-spec.ts
+++ b/apps/api/test/integration/listings-bulk-offer-creation-retry-failed.int-spec.ts
@@ -282,7 +282,7 @@ describe('Listings Bulk Offer-Creation Retry-Failed API Integration', () => {
       const streamLenBefore = await redis.xLen('jobs.sync').catch(() => 0);
 
       const response = await http
-        .post(`/listings/bulk-create/${batchId}/retry-failed`)
+        .post(`/v1/listings/bulk-create/${batchId}/retry-failed`)
         .set('Authorization', `Bearer ${token}`)
         .expect(202);
 
@@ -339,7 +339,7 @@ describe('Listings Bulk Offer-Creation Retry-Failed API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .post(`/listings/bulk-create/${UNKNOWN_BATCH_ID}/retry-failed`)
+        .post(`/v1/listings/bulk-create/${UNKNOWN_BATCH_ID}/retry-failed`)
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
@@ -357,7 +357,7 @@ describe('Listings Bulk Offer-Creation Retry-Failed API Integration', () => {
       });
 
       await http
-        .post(`/listings/bulk-create/${batchId}/retry-failed`)
+        .post(`/v1/listings/bulk-create/${batchId}/retry-failed`)
         .set('Authorization', `Bearer ${token}`)
         .expect(409);
     });
@@ -368,7 +368,7 @@ describe('Listings Bulk Offer-Creation Retry-Failed API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .post('/listings/bulk-create/not-a-uuid/retry-failed')
+        .post('/v1/listings/bulk-create/not-a-uuid/retry-failed')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
@@ -377,7 +377,7 @@ describe('Listings Bulk Offer-Creation Retry-Failed API Integration', () => {
       const http = harness.getHttp();
       const batchId = randomUUID();
 
-      await http.post(`/listings/bulk-create/${batchId}/retry-failed`).expect(401);
+      await http.post(`/v1/listings/bulk-create/${batchId}/retry-failed`).expect(401);
     });
   });
 
@@ -496,7 +496,7 @@ describe('Listings Bulk Offer-Creation Retry-Failed API Integration', () => {
 
       // POST retry-failed.
       const retryResponse = await http
-        .post(`/listings/bulk-create/${batchId}/retry-failed`)
+        .post(`/v1/listings/bulk-create/${batchId}/retry-failed`)
         .set('Authorization', `Bearer ${token}`)
         .expect(202);
 

--- a/apps/api/test/integration/listings-bulk-offer-creation.int-spec.ts
+++ b/apps/api/test/integration/listings-bulk-offer-creation.int-spec.ts
@@ -119,7 +119,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .post('/listings/bulk-create')
+        .post('/v1/listings/bulk-create')
         .set('Authorization', `Bearer ${token}`)
         .send({
           connectionId: CONN_A,
@@ -137,7 +137,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       const productIds = Array.from({ length: 101 }, (_, i) => `ol_variant_${i}`);
 
       await http
-        .post('/listings/bulk-create')
+        .post('/v1/listings/bulk-create')
         .set('Authorization', `Bearer ${token}`)
         .send({
           connectionId: CONN_A,
@@ -153,7 +153,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .post('/listings/bulk-create')
+        .post('/v1/listings/bulk-create')
         .set('Authorization', `Bearer ${token}`)
         .send({
           connectionId: 'not-a-uuid',
@@ -174,7 +174,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .post('/listings/bulk-create')
+        .post('/v1/listings/bulk-create')
         .set('Authorization', `Bearer ${token}`)
         .send({
           connectionId: CONN_A, // valid UUID, no such connection seeded
@@ -188,7 +188,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       const http = harness.getHttp();
 
       await http
-        .post('/listings/bulk-create')
+        .post('/v1/listings/bulk-create')
         .send({
           connectionId: CONN_A,
           productIds: ['ol_variant_a'],
@@ -224,7 +224,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       });
 
       const response = await http
-        .get(`/listings/bulk-create/${batchId}`)
+        .get(`/v1/listings/bulk-create/${batchId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -260,7 +260,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       });
 
       const response = await http
-        .get(`/listings/bulk-create/${batchId}`)
+        .get(`/v1/listings/bulk-create/${batchId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -283,7 +283,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       });
 
       const response = await http
-        .get(`/listings/bulk-create/${batchId}`)
+        .get(`/v1/listings/bulk-create/${batchId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -298,7 +298,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get(`/listings/bulk-create/${UNKNOWN_BATCH_ID}`)
+        .get(`/v1/listings/bulk-create/${UNKNOWN_BATCH_ID}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
@@ -309,7 +309,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get('/listings/bulk-create/not-a-uuid')
+        .get('/v1/listings/bulk-create/not-a-uuid')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
@@ -317,7 +317,7 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
     it('returns 401 without a bearer token', async () => {
       const http = harness.getHttp();
 
-      await http.get(`/listings/bulk-create/${UNKNOWN_BATCH_ID}`).expect(401);
+      await http.get(`/v1/listings/bulk-create/${UNKNOWN_BATCH_ID}`).expect(401);
     });
   });
 });

--- a/apps/api/test/integration/listings-create-offer.int-spec.ts
+++ b/apps/api/test/integration/listings-create-offer.int-spec.ts
@@ -56,7 +56,7 @@ describe('Listings Create-Offer API Integration', () => {
       });
 
       const response = await http
-        .get(`/listings/connections/${CONN_A}/offers/creation/${recordId}`)
+        .get(`/v1/listings/connections/${CONN_A}/offers/creation/${recordId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -77,7 +77,7 @@ describe('Listings Create-Offer API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get(`/listings/connections/${CONN_A}/offers/creation/00000000-0000-4000-8000-000000000000`)
+        .get(`/v1/listings/connections/${CONN_A}/offers/creation/00000000-0000-4000-8000-000000000000`)
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
@@ -108,7 +108,7 @@ describe('Listings Create-Offer API Integration', () => {
       });
 
       const response = await http
-        .get(`/listings/connections/${CONN_A}/offers/creation/${recordId}`)
+        .get(`/v1/listings/connections/${CONN_A}/offers/creation/${recordId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -126,7 +126,7 @@ describe('Listings Create-Offer API Integration', () => {
       });
 
       const response = await http
-        .get(`/listings/connections/${CONN_A}/offers/creation/${recordId}`)
+        .get(`/v1/listings/connections/${CONN_A}/offers/creation/${recordId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -141,7 +141,7 @@ describe('Listings Create-Offer API Integration', () => {
       const recordId = await createTestOfferCreationRecord(dataSource, { connectionId: CONN_B });
 
       await http
-        .get(`/listings/connections/${CONN_A}/offers/creation/${recordId}`)
+        .get(`/v1/listings/connections/${CONN_A}/offers/creation/${recordId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });

--- a/apps/api/test/integration/listings-seller-policies.int-spec.ts
+++ b/apps/api/test/integration/listings-seller-policies.int-spec.ts
@@ -55,7 +55,7 @@ describe('Listings Seller-Policies API Integration', () => {
     await createTestSellerPoliciesCache(dataSource, { connectionId: CONN, policies });
 
     const response = await http
-      .get(`/listings/connections/${CONN}/seller-policies`)
+      .get(`/v1/listings/connections/${CONN}/seller-policies`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 

--- a/apps/api/test/integration/oauth-connection.int-spec.ts
+++ b/apps/api/test/integration/oauth-connection.int-spec.ts
@@ -128,7 +128,7 @@ describe('OAuth Connection (integration)', () => {
   ): Promise<string> {
     const res = await harness
       .getHttp()
-      .post('/integrations/allegro/oauth/connect')
+      .post('/v1/integrations/allegro/oauth/connect')
       .set('Authorization', `Bearer ${token}`)
       .send({
         clientId: 'client-1',
@@ -148,7 +148,7 @@ describe('OAuth Connection (integration)', () => {
     installFetchStub();
     const res = await harness
       .getHttp()
-      .get('/integrations/allegro/oauth/callback')
+      .get('/v1/integrations/allegro/oauth/callback')
       .query({ code: 'auth-code-1', state })
       .expect(200);
 
@@ -179,7 +179,7 @@ describe('OAuth Connection (integration)', () => {
     installFetchStub();
     const first = await harness
       .getHttp()
-      .get('/integrations/allegro/oauth/callback')
+      .get('/v1/integrations/allegro/oauth/callback')
       .query({ code: 'auth-code-1', state })
       .expect(200);
 
@@ -187,7 +187,7 @@ describe('OAuth Connection (integration)', () => {
     // completed-marker path and returns the same connection without re-running.
     const replay = await harness
       .getHttp()
-      .get('/integrations/allegro/oauth/callback')
+      .get('/v1/integrations/allegro/oauth/callback')
       .query({ code: 'auth-code-1', state })
       .expect(200);
 
@@ -203,7 +203,7 @@ describe('OAuth Connection (integration)', () => {
     const state1 = await connect(token, { connectionName: 'Store' });
     const created = await harness
       .getHttp()
-      .get('/integrations/allegro/oauth/callback')
+      .get('/v1/integrations/allegro/oauth/callback')
       .query({ code: 'code-1', state: state1 })
       .expect(200);
     const connectionId = created.body.connectionId as string;
@@ -212,7 +212,7 @@ describe('OAuth Connection (integration)', () => {
     const state2 = await connect(token, { connectionId });
     const reauth = await harness
       .getHttp()
-      .get('/integrations/allegro/oauth/callback')
+      .get('/v1/integrations/allegro/oauth/callback')
       .query({ code: 'code-2', state: state2 })
       .expect(200);
 
@@ -230,7 +230,7 @@ describe('OAuth Connection (integration)', () => {
     const state1 = await connect(token, { connectionName: 'Store' });
     const created = await harness
       .getHttp()
-      .get('/integrations/allegro/oauth/callback')
+      .get('/v1/integrations/allegro/oauth/callback')
       .query({ code: 'code-1', state: state1 })
       .expect(200);
     const connectionId = created.body.connectionId as string;
@@ -241,7 +241,7 @@ describe('OAuth Connection (integration)', () => {
     const state2 = await connect(token, { connectionId });
     const res = await harness
       .getHttp()
-      .get('/integrations/allegro/oauth/callback')
+      .get('/v1/integrations/allegro/oauth/callback')
       .query({ code: 'code-2', state: state2 })
       .expect(400);
     expect(res.body.code).toBe('OAUTH_ACCOUNT_MISMATCH');
@@ -261,7 +261,7 @@ describe('OAuth Connection (integration)', () => {
     tokenOk = false; // provider rejects the code → OAuthCodeExchangeException → 400
     await harness
       .getHttp()
-      .get('/integrations/allegro/oauth/callback')
+      .get('/v1/integrations/allegro/oauth/callback')
       .query({ code: 'bad-code', state })
       .expect(400);
 

--- a/apps/api/test/integration/operator-role-authz.int-spec.ts
+++ b/apps/api/test/integration/operator-role-authz.int-spec.ts
@@ -54,7 +54,7 @@ describe('Operator Role Authorization', () => {
     it('POST /orders/:id/destinations/:connectionId/retry → 404 (guard passes; order unknown)', async () => {
       const { http, operatorToken } = await seeds();
       await http
-        .post('/orders/fake-order-id/destinations/00000000-0000-4000-8000-000000000001/retry')
+        .post('/v1/orders/fake-order-id/destinations/00000000-0000-4000-8000-000000000001/retry')
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect((res) => {
           expect(res.status).not.toBe(403);
@@ -64,7 +64,7 @@ describe('Operator Role Authorization', () => {
     it('POST /listings/connections/:connectionId/offers → not 403 (guard passes; handler validates)', async () => {
       const { http, operatorToken } = await seeds();
       const res = await http
-        .post('/listings/connections/00000000-0000-4000-8000-000000000001/offers')
+        .post('/v1/listings/connections/00000000-0000-4000-8000-000000000001/offers')
         .set('Authorization', `Bearer ${operatorToken}`)
         .send({});
       expect(res.status).not.toBe(403);
@@ -73,7 +73,7 @@ describe('Operator Role Authorization', () => {
     it('POST /listings/bulk-create → not 403 (guard passes; handler validates body)', async () => {
       const { http, operatorToken } = await seeds();
       const res = await http
-        .post('/listings/bulk-create')
+        .post('/v1/listings/bulk-create')
         .set('Authorization', `Bearer ${operatorToken}`)
         .send({});
       expect(res.status).not.toBe(403);
@@ -82,7 +82,7 @@ describe('Operator Role Authorization', () => {
     it('POST /listings/bulk-shop-publish → not 403 (guard passes; handler validates body)', async () => {
       const { http, operatorToken } = await seeds();
       const res = await http
-        .post('/listings/bulk-shop-publish')
+        .post('/v1/listings/bulk-shop-publish')
         .set('Authorization', `Bearer ${operatorToken}`)
         .send({});
       expect(res.status).not.toBe(403);
@@ -91,7 +91,7 @@ describe('Operator Role Authorization', () => {
     it('GET /listings/connections/:connectionId/seller-policies → not 403 (guard passes; connection unknown)', async () => {
       const { http, operatorToken } = await seeds();
       const res = await http
-        .get('/listings/connections/00000000-0000-4000-8000-000000000001/seller-policies')
+        .get('/v1/listings/connections/00000000-0000-4000-8000-000000000001/seller-policies')
         .set('Authorization', `Bearer ${operatorToken}`);
       expect(res.status).not.toBe(403);
     });
@@ -99,7 +99,7 @@ describe('Operator Role Authorization', () => {
     it('GET /shipments → 200 (operator has full shipment access)', async () => {
       const { http, operatorToken } = await seeds();
       await http
-        .get('/shipments')
+        .get('/v1/shipments')
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect(200);
     });
@@ -107,7 +107,7 @@ describe('Operator Role Authorization', () => {
     it('GET /pickup-points → not 403 (operator has pickup-point access; connectionId required so 400 without params)', async () => {
       const { http, operatorToken } = await seeds();
       const res = await http
-        .get('/pickup-points')
+        .get('/v1/pickup-points')
         .set('Authorization', `Bearer ${operatorToken}`);
       expect(res.status).not.toBe(403);
     });
@@ -120,7 +120,7 @@ describe('Operator Role Authorization', () => {
       const { http, operatorToken } = await seeds();
       const dto = createPrestashopConnectionDto();
       await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${operatorToken}`)
         .send(dto)
         .expect(403);
@@ -130,12 +130,12 @@ describe('Operator Role Authorization', () => {
       const { http, adminToken, operatorToken } = await seeds();
       const dto = createPrestashopConnectionDto();
       const { body: conn } = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${adminToken}`)
         .send(dto)
         .expect(201);
       await http
-        .patch(`/connections/${conn.id as string}`)
+        .patch(`/v1/connections/${conn.id as string}`)
         .set('Authorization', `Bearer ${operatorToken}`)
         .send({ name: 'should-be-blocked' })
         .expect(403);
@@ -145,12 +145,12 @@ describe('Operator Role Authorization', () => {
       const { http, adminToken, operatorToken } = await seeds();
       const dto = createPrestashopConnectionDto();
       const { body: conn } = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${adminToken}`)
         .send(dto)
         .expect(201);
       await http
-        .put(`/connections/${conn.id as string}/credentials`)
+        .put(`/v1/connections/${conn.id as string}/credentials`)
         .set('Authorization', `Bearer ${operatorToken}`)
         .send({ credentials: {} })
         .expect(403);
@@ -160,12 +160,12 @@ describe('Operator Role Authorization', () => {
       const { http, adminToken, operatorToken } = await seeds();
       const dto = createPrestashopConnectionDto();
       const { body: conn } = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${adminToken}`)
         .send(dto)
         .expect(201);
       await http
-        .post(`/connections/${conn.id as string}/webhooks/install`)
+        .post(`/v1/connections/${conn.id as string}/webhooks/install`)
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect(403);
     });
@@ -173,7 +173,7 @@ describe('Operator Role Authorization', () => {
     it('POST /sync/jobs → 403', async () => {
       const { http, operatorToken } = await seeds();
       await http
-        .post('/sync/jobs')
+        .post('/v1/sync/jobs')
         .set('Authorization', `Bearer ${operatorToken}`)
         .send({ jobType: 'marketplace.orders.poll', connectionId: '00000000-0000-4000-8000-000000000001' })
         .expect(403);
@@ -182,7 +182,7 @@ describe('Operator Role Authorization', () => {
     it('POST /sync/jobs/retry-grouped → 403', async () => {
       const { http, operatorToken } = await seeds();
       await http
-        .post('/sync/jobs/retry-grouped')
+        .post('/v1/sync/jobs/retry-grouped')
         .set('Authorization', `Bearer ${operatorToken}`)
         .send({ connectionId: '00000000-0000-4000-8000-000000000001', jobType: 'marketplace.orders.poll' })
         .expect(403);
@@ -192,12 +192,12 @@ describe('Operator Role Authorization', () => {
       const { http, adminToken, operatorToken } = await seeds();
       const dto = createPrestashopConnectionDto();
       const { body: conn } = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${adminToken}`)
         .send(dto)
         .expect(201);
       await http
-        .get(`/connections/${conn.id as string}/diagnostics`)
+        .get(`/v1/connections/${conn.id as string}/diagnostics`)
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect(403);
     });
@@ -205,7 +205,7 @@ describe('Operator Role Authorization', () => {
     it('GET /prompt-templates → 403 (entire controller admin-only)', async () => {
       const { http, operatorToken } = await seeds();
       await http
-        .get('/prompt-templates')
+        .get('/v1/prompt-templates')
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect(403);
     });
@@ -213,7 +213,7 @@ describe('Operator Role Authorization', () => {
     it('PUT /ai-provider-settings/active → 403 (entire controller admin-only)', async () => {
       const { http, operatorToken } = await seeds();
       await http
-        .put('/ai-provider-settings/active')
+        .put('/v1/ai-provider-settings/active')
         .set('Authorization', `Bearer ${operatorToken}`)
         .send({ provider: 'anthropic' })
         .expect(403);
@@ -222,7 +222,7 @@ describe('Operator Role Authorization', () => {
     it('GET /webhook-deliveries → 403 (entire controller admin-only)', async () => {
       const { http, operatorToken } = await seeds();
       await http
-        .get('/webhook-deliveries')
+        .get('/v1/webhook-deliveries')
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect(403);
     });
@@ -230,7 +230,7 @@ describe('Operator Role Authorization', () => {
     it('GET /cursors → 403 (entire controller admin-only)', async () => {
       const { http, operatorToken } = await seeds();
       await http
-        .get('/cursors')
+        .get('/v1/cursors')
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect(403);
     });
@@ -238,7 +238,7 @@ describe('Operator Role Authorization', () => {
     it('GET /users → 403 (entire controller admin-only)', async () => {
       const { http, operatorToken } = await seeds();
       await http
-        .get('/users')
+        .get('/v1/users')
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect(403);
     });
@@ -256,13 +256,13 @@ describe('Operator Role Authorization', () => {
       });
 
       const { body: conn } = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${adminToken}`)
         .send(dto)
         .expect(201);
 
       const operatorGet = await http
-        .get(`/connections/${conn.id as string}`)
+        .get(`/v1/connections/${conn.id as string}`)
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect(200);
 
@@ -275,10 +275,10 @@ describe('Operator Role Authorization', () => {
       const { http, adminToken, operatorToken } = await seeds();
 
       const dto1 = createPrestashopConnectionDto({ name: 'Store A' });
-      await http.post('/connections').set('Authorization', `Bearer ${adminToken}`).send(dto1).expect(201);
+      await http.post('/v1/connections').set('Authorization', `Bearer ${adminToken}`).send(dto1).expect(201);
 
       const { body: list } = await http
-        .get('/connections')
+        .get('/v1/connections')
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect(200);
 

--- a/apps/api/test/integration/order-destination-retry.int-spec.ts
+++ b/apps/api/test/integration/order-destination-retry.int-spec.ts
@@ -76,7 +76,7 @@ describe('Order Destination Retry Integration', () => {
     );
 
     const response = await http
-      .post(`/orders/${orderRecord.internalOrderId}/destinations/${destConnection.id}/retry`)
+      .post(`/v1/orders/${orderRecord.internalOrderId}/destinations/${destConnection.id}/retry`)
       .set('Authorization', `Bearer ${token}`)
       .expect(202);
 
@@ -98,7 +98,7 @@ describe('Order Destination Retry Integration', () => {
 
     // Order row's destination flipped from 'failed' → 'pending'
     const detail = await http
-      .get(`/orders/${orderRecord.internalOrderId}`)
+      .get(`/v1/orders/${orderRecord.internalOrderId}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
     const row = detail.body.syncStatus.find(
@@ -137,7 +137,7 @@ describe('Order Destination Retry Integration', () => {
     });
 
     await http
-      .post(`/orders/${orderRecord.internalOrderId}/destinations/${destConnection.id}/retry`)
+      .post(`/v1/orders/${orderRecord.internalOrderId}/destinations/${destConnection.id}/retry`)
       .set('Authorization', `Bearer ${token}`)
       .expect(409);
 
@@ -154,7 +154,7 @@ describe('Order Destination Retry Integration', () => {
     const unknownConnectionId = '99999999-9999-4999-8999-999999999999';
 
     await http
-      .post(`/orders/ol_order_does_not_exist/destinations/${unknownConnectionId}/retry`)
+      .post(`/v1/orders/ol_order_does_not_exist/destinations/${unknownConnectionId}/retry`)
       .set('Authorization', `Bearer ${token}`)
       .expect(404);
   });
@@ -163,6 +163,6 @@ describe('Order Destination Retry Integration', () => {
     const http = harness.getHttp();
     const unknownConnectionId = '99999999-9999-4999-8999-999999999999';
 
-    await http.post(`/orders/ol_order_x/destinations/${unknownConnectionId}/retry`).expect(401);
+    await http.post(`/v1/orders/ol_order_x/destinations/${unknownConnectionId}/retry`).expect(401);
   });
 });

--- a/apps/api/test/integration/orders-read.int-spec.ts
+++ b/apps/api/test/integration/orders-read.int-spec.ts
@@ -40,7 +40,7 @@ describe('Orders Read API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       const response = await http
-        .get('/orders')
+        .get('/v1/orders')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -56,7 +56,7 @@ describe('Orders Read API Integration', () => {
       const order = await createTestOrderRecord(dataSource);
 
       const response = await http
-        .get('/orders')
+        .get('/v1/orders')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -82,7 +82,7 @@ describe('Orders Read API Integration', () => {
       await createTestOrderRecord(dataSource, { sourceConnectionId: otherConnectionId });
 
       const response = await http
-        .get(`/orders?sourceConnectionId=${targetConnectionId}`)
+        .get(`/v1/orders?sourceConnectionId=${targetConnectionId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -107,7 +107,7 @@ describe('Orders Read API Integration', () => {
       });
 
       const response = await http
-        .get('/orders?syncStatus=synced')
+        .get('/v1/orders?syncStatus=synced')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -124,7 +124,7 @@ describe('Orders Read API Integration', () => {
       }
 
       const page1 = await http
-        .get('/orders?limit=2&offset=0')
+        .get('/v1/orders?limit=2&offset=0')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -134,7 +134,7 @@ describe('Orders Read API Integration', () => {
       expect(page1.body.offset).toBe(0);
 
       const page2 = await http
-        .get('/orders?limit=2&offset=2')
+        .get('/v1/orders?limit=2&offset=2')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -153,7 +153,7 @@ describe('Orders Read API Integration', () => {
 
     it('should return 401 without token', async () => {
       const http = harness.getHttp();
-      await http.get('/orders').expect(401);
+      await http.get('/v1/orders').expect(401);
     });
   });
 
@@ -169,7 +169,7 @@ describe('Orders Read API Integration', () => {
       await createTestOrderRecord(dataSource, { dispatchByAt: new Date(Date.now() - 60_000) });
 
       const response = await http
-        .get('/orders')
+        .get('/v1/orders')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -191,7 +191,7 @@ describe('Orders Read API Integration', () => {
       });
 
       const response = await http
-        .get('/orders')
+        .get('/v1/orders')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -208,14 +208,14 @@ describe('Orders Read API Integration', () => {
       await createTestOrderRecord(dataSource, { fulfillmentState: 'dispatched' });
 
       const overdue = await http
-        .get('/orders?slaState=overdue')
+        .get('/v1/orders?slaState=overdue')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(overdue.body.total).toBe(1);
       expect(overdue.body.items[0].slaState).toBe('overdue');
 
       const dispatched = await http
-        .get('/orders?fulfillmentState=dispatched')
+        .get('/v1/orders?fulfillmentState=dispatched')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(dispatched.body.total).toBe(1);
@@ -223,7 +223,7 @@ describe('Orders Read API Integration', () => {
 
       // not-shipped also matches NULL-column rows.
       const notShipped = await http
-        .get('/orders?fulfillmentState=not-shipped')
+        .get('/v1/orders?fulfillmentState=not-shipped')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(notShipped.body.total).toBe(1);
@@ -239,7 +239,7 @@ describe('Orders Read API Integration', () => {
       await createTestOrderRecord(dataSource, {});
 
       const response = await http
-        .get('/orders/sla-summary')
+        .get('/v1/orders/sla-summary')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -265,7 +265,7 @@ describe('Orders Read API Integration', () => {
       const order = await createTestOrderRecord(dataSource);
 
       const response = await http
-        .get(`/orders/${order.internalOrderId}`)
+        .get(`/v1/orders/${order.internalOrderId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -279,14 +279,14 @@ describe('Orders Read API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get('/orders/ol_order_nonexistent')
+        .get('/v1/orders/ol_order_nonexistent')
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
 
     it('should return 401 without token', async () => {
       const http = harness.getHttp();
-      await http.get('/orders/ol_order_nonexistent').expect(401);
+      await http.get('/v1/orders/ol_order_nonexistent').expect(401);
     });
   });
 });

--- a/apps/api/test/integration/products-read.int-spec.ts
+++ b/apps/api/test/integration/products-read.int-spec.ts
@@ -107,7 +107,7 @@ describe('Products Read API Integration — currency persistence', () => {
     const seeded = await seedProduct(dataSource, { currency: 'PLN' });
 
     const response = await http
-      .get('/products')
+      .get('/v1/products')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -126,7 +126,7 @@ describe('Products Read API Integration — currency persistence', () => {
     const seeded = await seedProduct(dataSource, { currency: null });
 
     const response = await http
-      .get('/products')
+      .get('/v1/products')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -146,7 +146,7 @@ describe('Products Read API Integration — currency persistence', () => {
     await seedVariant(dataSource, { productId: product.id, price: 19.99 });
 
     const response = await http
-      .get(`/products/${product.id}`)
+      .get(`/v1/products/${product.id}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -163,7 +163,7 @@ describe('Products Read API Integration — currency persistence', () => {
     await seedVariant(dataSource, { productId: product.id, price: null });
 
     const response = await http
-      .get(`/products/${product.id}`)
+      .get(`/v1/products/${product.id}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -192,7 +192,7 @@ describe('Products Read API Integration — currency persistence', () => {
     await repo.upsert(domainProduct);
 
     const response = await http
-      .get('/products')
+      .get('/v1/products')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 

--- a/apps/api/test/integration/prompt-templates-crud.int-spec.ts
+++ b/apps/api/test/integration/prompt-templates-crud.int-spec.ts
@@ -24,7 +24,7 @@ async function loginAsViewer(
     [username, `${username}@example.com`, passwordHash],
   );
   const response = await harness.getHttp()
-    .post('/auth/login')
+    .post('/v1/auth/login')
     .send({ username, password: 'viewer-pass' })
     .expect(200);
   return response.body.access_token as string;
@@ -59,7 +59,7 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // Create v1 draft
     const createRes = await http
-      .post('/prompt-templates')
+      .post('/v1/prompt-templates')
       .set('Authorization', `Bearer ${token}`)
       .send(createPayload)
       .expect(201);
@@ -71,7 +71,7 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // Update the draft
     const updateRes = await http
-      .patch(`/prompt-templates/${v1Id}`)
+      .patch(`/v1/prompt-templates/${v1Id}`)
       .set('Authorization', `Bearer ${token}`)
       .send({ systemPrompt: 'Sys v1 edited {{product.name}}' })
       .expect(200);
@@ -81,7 +81,7 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // Publish v1
     const publishV1Res = await http
-      .post(`/prompt-templates/${v1Id}/publish`)
+      .post(`/v1/prompt-templates/${v1Id}/publish`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -90,7 +90,7 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // Start v2 draft
     const v2CreateRes = await http
-      .post('/prompt-templates')
+      .post('/v1/prompt-templates')
       .set('Authorization', `Bearer ${token}`)
       .send({ ...createPayload, systemPrompt: 'Sys v2 {{product.name}}' })
       .expect(201);
@@ -100,7 +100,7 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // Publish v2 — asserts v1 gets archived
     const publishV2Res = await http
-      .post(`/prompt-templates/${v2Id}/publish`)
+      .post(`/v1/prompt-templates/${v2Id}/publish`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -108,14 +108,14 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // v1 should now be archived
     const v1AfterRes = await http
-      .get(`/prompt-templates/${v1Id}`)
+      .get(`/v1/prompt-templates/${v1Id}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
     expect(v1AfterRes.body.state).toBe('archived');
 
     // Latest published is v2
     const latestRes = await http
-      .get('/prompt-templates/latest')
+      .get('/v1/prompt-templates/latest')
       .query({ key: 'test.template', channel: 'allegro' })
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
@@ -124,7 +124,7 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // Version history returns both, newest first
     const versionsRes = await http
-      .get('/prompt-templates/versions')
+      .get('/v1/prompt-templates/versions')
       .query({ key: 'test.template', channel: 'allegro' })
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
@@ -134,7 +134,7 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // Revert to v1 — produces a new draft at v3
     const revertRes = await http
-      .post('/prompt-templates/revert')
+      .post('/v1/prompt-templates/revert')
       .set('Authorization', `Bearer ${token}`)
       .send({ key: 'test.template', channel: 'allegro', version: 1 })
       .expect(201);
@@ -145,7 +145,7 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // List shows the latest (v3 draft) with hasDraft=true and publishedVersion=2
     const listRes = await http
-      .get('/prompt-templates')
+      .get('/v1/prompt-templates')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
     expect(listRes.body).toHaveLength(1);
@@ -164,7 +164,7 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // Create + publish a row
     const createRes = await http
-      .post('/prompt-templates')
+      .post('/v1/prompt-templates')
       .set('Authorization', `Bearer ${token}`)
       .send({
         key: 'state.guard',
@@ -175,13 +175,13 @@ describe('Prompt Templates CRUD Integration', () => {
       })
       .expect(201);
     await http
-      .post(`/prompt-templates/${createRes.body.id}/publish`)
+      .post(`/v1/prompt-templates/${createRes.body.id}/publish`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
     // Patch on a published row → 400
     await http
-      .patch(`/prompt-templates/${createRes.body.id}`)
+      .patch(`/v1/prompt-templates/${createRes.body.id}`)
       .set('Authorization', `Bearer ${token}`)
       .send({ systemPrompt: 'should-fail' })
       .expect(400);
@@ -192,7 +192,7 @@ describe('Prompt Templates CRUD Integration', () => {
     const token = await loginAsAdmin(http, harness.getDataSource());
 
     const createRes = await http
-      .post('/prompt-templates')
+      .post('/v1/prompt-templates')
       .set('Authorization', `Bearer ${token}`)
       .send({
         key: 'render.test',
@@ -207,7 +207,7 @@ describe('Prompt Templates CRUD Integration', () => {
       .expect(201);
 
     const renderRes = await http
-      .post(`/prompt-templates/${createRes.body.id}/render`)
+      .post(`/v1/prompt-templates/${createRes.body.id}/render`)
       .set('Authorization', `Bearer ${token}`)
       .send({ values: { name: 'Ada', item: 'cap' } })
       .expect(200);
@@ -223,7 +223,7 @@ describe('Prompt Templates CRUD Integration', () => {
     const token = await loginAsAdmin(http, harness.getDataSource());
 
     const createRes = await http
-      .post('/prompt-templates')
+      .post('/v1/prompt-templates')
       .set('Authorization', `Bearer ${token}`)
       .send({
         key: 'render.missing',
@@ -235,7 +235,7 @@ describe('Prompt Templates CRUD Integration', () => {
       .expect(201);
 
     await http
-      .post(`/prompt-templates/${createRes.body.id}/render`)
+      .post(`/v1/prompt-templates/${createRes.body.id}/render`)
       .set('Authorization', `Bearer ${token}`)
       .send({ values: {} })
       .expect(422);
@@ -246,12 +246,12 @@ describe('Prompt Templates CRUD Integration', () => {
     const viewerToken = await loginAsViewer(harness);
 
     await http
-      .get('/prompt-templates')
+      .get('/v1/prompt-templates')
       .set('Authorization', `Bearer ${viewerToken}`)
       .expect(403);
 
     await http
-      .post('/prompt-templates')
+      .post('/v1/prompt-templates')
       .set('Authorization', `Bearer ${viewerToken}`)
       .send({
         key: 'role.guard',
@@ -268,7 +268,7 @@ describe('Prompt Templates CRUD Integration', () => {
     const token = await loginAsAdmin(http, harness.getDataSource());
 
     await http
-      .get('/prompt-templates/00000000-0000-0000-0000-000000000000')
+      .get('/v1/prompt-templates/00000000-0000-0000-0000-000000000000')
       .set('Authorization', `Bearer ${token}`)
       .expect(404);
   });
@@ -281,7 +281,7 @@ describe('Prompt Templates CRUD Integration', () => {
     // value reaches the service verbatim and matches against the DB. No
     // rows are seeded for `'not-a-channel'`, so the response is 200 + [].
     const res = await http
-      .get('/prompt-templates')
+      .get('/v1/prompt-templates')
       .query({ channel: 'not-a-channel' })
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
@@ -296,7 +296,7 @@ describe('Prompt Templates CRUD Integration', () => {
 
     // Two rows for the same key but different channels can both be published.
     const prestaRes = await http
-      .post('/prompt-templates')
+      .post('/v1/prompt-templates')
       .set('Authorization', `Bearer ${token}`)
       .send({
         key: 'multi.channel',
@@ -307,12 +307,12 @@ describe('Prompt Templates CRUD Integration', () => {
       })
       .expect(201);
     await http
-      .post(`/prompt-templates/${prestaRes.body.id}/publish`)
+      .post(`/v1/prompt-templates/${prestaRes.body.id}/publish`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
     const allegroRes = await http
-      .post('/prompt-templates')
+      .post('/v1/prompt-templates')
       .set('Authorization', `Bearer ${token}`)
       .send({
         key: 'multi.channel',
@@ -323,13 +323,13 @@ describe('Prompt Templates CRUD Integration', () => {
       })
       .expect(201);
     await http
-      .post(`/prompt-templates/${allegroRes.body.id}/publish`)
+      .post(`/v1/prompt-templates/${allegroRes.body.id}/publish`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
     // List shows both pairs, each with its own published row.
     const listRes = await http
-      .get('/prompt-templates')
+      .get('/v1/prompt-templates')
       .query({ key: 'multi.channel' })
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
@@ -343,7 +343,7 @@ describe('Prompt Templates CRUD Integration', () => {
     const token = await loginAsAdmin(http, harness.getDataSource());
 
     const createRes = await http
-      .post('/prompt-templates')
+      .post('/v1/prompt-templates')
       .set('Authorization', `Bearer ${token}`)
       .send({
         key: 'delete.test',
@@ -355,12 +355,12 @@ describe('Prompt Templates CRUD Integration', () => {
       .expect(201);
 
     await http
-      .delete(`/prompt-templates/${createRes.body.id}`)
+      .delete(`/v1/prompt-templates/${createRes.body.id}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(204);
 
     await http
-      .get(`/prompt-templates/${createRes.body.id}`)
+      .get(`/v1/prompt-templates/${createRes.body.id}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(404);
   });

--- a/apps/api/test/integration/routing-rules.int-spec.ts
+++ b/apps/api/test/integration/routing-rules.int-spec.ts
@@ -75,7 +75,7 @@ describe('Fulfillment Routing HTTP Integration', () => {
     );
     const response = await harness
       .getHttp()
-      .post('/auth/login')
+      .post('/v1/auth/login')
       .send({ username, password: 'viewer-pass' })
       .expect(200);
     return response.body.access_token as string;
@@ -88,13 +88,13 @@ describe('Fulfillment Routing HTTP Integration', () => {
 
     // Empty before any write.
     const initial = await http
-      .get(`/connections/${sourceId}/routing-rules`)
+      .get(`/v1/connections/${sourceId}/routing-rules`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
     expect(initial.body).toEqual([]);
 
     const putRes = await http
-      .put(`/connections/${sourceId}/routing-rules`)
+      .put(`/v1/connections/${sourceId}/routing-rules`)
       .set('Authorization', `Bearer ${token}`)
       .send({
         items: [
@@ -114,7 +114,7 @@ describe('Fulfillment Routing HTTP Integration', () => {
     expect(putRes.body).toHaveLength(2);
 
     const getRes = await http
-      .get(`/connections/${sourceId}/routing-rules`)
+      .get(`/v1/connections/${sourceId}/routing-rules`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -139,7 +139,7 @@ describe('Fulfillment Routing HTTP Integration', () => {
     const { sourceId, prestashopId, inpostId } = await seedConnections();
 
     const res = await http
-      .get(`/connections/${sourceId}/routing-rules/candidates`)
+      .get(`/v1/connections/${sourceId}/routing-rules/candidates`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
@@ -166,7 +166,7 @@ describe('Fulfillment Routing HTTP Integration', () => {
     // Routing an OMP rule at the Allegro source itself — Allegro does not
     // declare OrderProcessorManager.
     await http
-      .put(`/connections/${sourceId}/routing-rules`)
+      .put(`/v1/connections/${sourceId}/routing-rules`)
       .set('Authorization', `Bearer ${token}`)
       .send({
         items: [
@@ -185,7 +185,7 @@ describe('Fulfillment Routing HTTP Integration', () => {
     const token = await loginAsAdmin(http, harness.getDataSource());
 
     await http
-      .get('/connections/ol_connection_does_not_exist/routing-rules/candidates')
+      .get('/v1/connections/ol_connection_does_not_exist/routing-rules/candidates')
       .set('Authorization', `Bearer ${token}`)
       .expect(404);
   });
@@ -196,7 +196,7 @@ describe('Fulfillment Routing HTTP Integration', () => {
     const viewerToken = await loginAsViewer();
 
     await http
-      .get(`/connections/${sourceId}/routing-rules`)
+      .get(`/v1/connections/${sourceId}/routing-rules`)
       .set('Authorization', `Bearer ${viewerToken}`)
       .expect(403);
   });

--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -15,8 +15,10 @@
  */
 import express from 'express';
 import cookieParser from 'cookie-parser';
+import { VersioningType } from '@nestjs/common';
 import { createIntegrationTestHarness } from '@openlinker/test-kit';
 import { AppModule } from '../../src/app.module';
+import { API_VERSION } from '../../src/app-info/app-info.types';
 import { CapabilityNotSupportedFilter } from '../../src/common/filters/capability-not-supported.filter';
 import { ConnectionExceptionFilter } from '../../src/common/filters/connection-exception.filter';
 
@@ -27,6 +29,10 @@ const harness = createIntegrationTestHarness({
   // rather than a default 500).
   configureApp: (app) => {
     app.useGlobalFilters(new CapabilityNotSupportedFilter(), new ConnectionExceptionFilter());
+    // Mirror main.ts's URI versioning (#1133) so int-specs exercise the same
+    // `/v1` routing prod serves. Version-neutral routes (/webhooks, the Allegro
+    // OAuth callback) stay reachable without the prefix.
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: API_VERSION });
   },
   configureBodyParser: (app) => {
     // 1) /webhooks: JSON parser with a `verify` hook that captures the raw

--- a/apps/api/test/integration/shipment-dispatch-notification.int-spec.ts
+++ b/apps/api/test/integration/shipment-dispatch-notification.int-spec.ts
@@ -263,7 +263,7 @@ describe('Shipment Dispatch Notification Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       const response = await http
-        .post(`/shipments/${shipmentId}/notify-dispatched`)
+        .post(`/v1/shipments/${shipmentId}/notify-dispatched`)
         .set('Authorization', `Bearer ${token}`);
 
       expect(response.status).toBe(200);
@@ -289,13 +289,13 @@ describe('Shipment Dispatch Notification Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       const first = await http
-        .post(`/shipments/${shipmentId}/notify-dispatched`)
+        .post(`/v1/shipments/${shipmentId}/notify-dispatched`)
         .set('Authorization', `Bearer ${token}`);
       expect(first.status).toBe(200);
       expect(first.body.outcome).toBe('notified');
 
       const second = await http
-        .post(`/shipments/${shipmentId}/notify-dispatched`)
+        .post(`/v1/shipments/${shipmentId}/notify-dispatched`)
         .set('Authorization', `Bearer ${token}`);
       expect(second.status).toBe(200);
       expect(second.body).toEqual({
@@ -315,7 +315,7 @@ describe('Shipment Dispatch Notification Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       const response = await http
-        .post('/shipments/ol_shipment_nonexistent/notify-dispatched')
+        .post('/v1/shipments/ol_shipment_nonexistent/notify-dispatched')
         .set('Authorization', `Bearer ${token}`);
 
       expect(response.status).toBe(404);

--- a/apps/api/test/integration/shipment-label-download.int-spec.ts
+++ b/apps/api/test/integration/shipment-label-download.int-spec.ts
@@ -96,7 +96,7 @@ describe('Shipment Label Download API Integration', () => {
   ): Promise<string> {
     const { sourceId } = await seedRoute();
     const created = await http
-      .post('/shipments/generate-label')
+      .post('/v1/shipments/generate-label')
       .set('Authorization', `Bearer ${token}`)
       .send({
         sourceConnectionId: sourceId,
@@ -117,7 +117,7 @@ describe('Shipment Label Download API Integration', () => {
       const id = await seedShipment(http, token, 'ol_order_label_1');
 
       const res = await http
-        .get(`/shipments/${id}/label`)
+        .get(`/v1/shipments/${id}/label`)
         .set('Authorization', `Bearer ${token}`)
         .buffer(true)
         .parse((response, cb) => {
@@ -139,13 +139,13 @@ describe('Shipment Label Download API Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       await http
-        .get('/shipments/ol_shipment_missing/label')
+        .get('/v1/shipments/ol_shipment_missing/label')
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
 
     it('should 401 without auth', async () => {
-      await harness.getHttp().get('/shipments/ol_shipment_x/label').expect(401);
+      await harness.getHttp().get('/v1/shipments/ol_shipment_x/label').expect(401);
     });
   });
 });

--- a/apps/api/test/integration/shipments-read.int-spec.ts
+++ b/apps/api/test/integration/shipments-read.int-spec.ts
@@ -100,7 +100,7 @@ describe('Shipments Read + Command API Integration', () => {
     deliveryMethodId: string = METHOD,
   ): request.Test {
     return http
-      .post('/shipments/generate-label')
+      .post('/v1/shipments/generate-label')
       .set('Authorization', `Bearer ${token}`)
       .send({
         sourceConnectionId: sourceId,
@@ -145,7 +145,7 @@ describe('Shipments Read + Command API Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       await http
-        .post('/shipments/generate-label')
+        .post('/v1/shipments/generate-label')
         .set('Authorization', `Bearer ${token}`)
         .send({ sourceConnectionId: 'not-a-uuid', orderId: '', shippingMethod: 'pigeon' })
         .expect(400);
@@ -157,7 +157,7 @@ describe('Shipments Read + Command API Integration', () => {
       const http = harness.getHttp();
       const token = await loginAsAdmin(http, harness.getDataSource());
 
-      const res = await http.get('/shipments').set('Authorization', `Bearer ${token}`).expect(200);
+      const res = await http.get('/v1/shipments').set('Authorization', `Bearer ${token}`).expect(200);
 
       expect(res.body).toMatchObject({ items: [], total: 0, limit: 20, offset: 0 });
     });
@@ -168,24 +168,24 @@ describe('Shipments Read + Command API Integration', () => {
       const { sourceId, carrierId } = await seedRoute();
       await generateLabel(http, token, sourceId, 'ol_order_list_1').expect(200);
 
-      const all = await http.get('/shipments').set('Authorization', `Bearer ${token}`).expect(200);
+      const all = await http.get('/v1/shipments').set('Authorization', `Bearer ${token}`).expect(200);
       expect(all.body.total).toBe(1);
       expect(all.body.items[0].orderId).toBe('ol_order_list_1');
 
       const byStatus = await http
-        .get('/shipments?status=generated')
+        .get('/v1/shipments?status=generated')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(byStatus.body.total).toBe(1);
 
       const byConn = await http
-        .get(`/shipments?connectionId=${carrierId}`)
+        .get(`/v1/shipments?connectionId=${carrierId}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(byConn.body.total).toBe(1);
 
       const otherConn = await http
-        .get('/shipments?connectionId=00000000-0000-4000-8000-000000000000')
+        .get('/v1/shipments?connectionId=00000000-0000-4000-8000-000000000000')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(otherConn.body.total).toBe(0);
@@ -201,13 +201,13 @@ describe('Shipments Read + Command API Integration', () => {
       await generateLabel(http, token, sourceId, 'ol_order_tracking').expect(200);
 
       const withoutTracking = await http
-        .get('/shipments?hasTracking=false')
+        .get('/v1/shipments?hasTracking=false')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(withoutTracking.body.total).toBe(1);
 
       const withTracking = await http
-        .get('/shipments?hasTracking=true')
+        .get('/v1/shipments?hasTracking=true')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(withTracking.body.total).toBe(0);
@@ -221,7 +221,7 @@ describe('Shipments Read + Command API Integration', () => {
       await generateLabel(http, token, sourceId, 'ol_order_p2').expect(200);
 
       const page = await http
-        .get('/shipments?limit=1&offset=0')
+        .get('/v1/shipments?limit=1&offset=0')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -240,23 +240,23 @@ describe('Shipments Read + Command API Integration', () => {
       const id = created.body.shipment.id as string;
 
       const byId = await http
-        .get(`/shipments/${id}`)
+        .get(`/v1/shipments/${id}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(byId.body.id).toBe(id);
 
       const active = await http
-        .get('/shipments/active?orderId=ol_order_read')
+        .get('/v1/shipments/active?orderId=ol_order_read')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(active.body.id).toBe(id);
 
       await http
-        .get('/shipments/ol_shipment_missing')
+        .get('/v1/shipments/ol_shipment_missing')
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
       await http
-        .get('/shipments/active?orderId=ol_order_none')
+        .get('/v1/shipments/active?orderId=ol_order_none')
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
@@ -271,7 +271,7 @@ describe('Shipments Read + Command API Integration', () => {
       const id = created.body.shipment.id as string;
 
       const cancelled = await http
-        .post(`/shipments/${id}/cancel`)
+        .post(`/v1/shipments/${id}/cancel`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(cancelled.body.status).toBe('cancelled');
@@ -279,13 +279,13 @@ describe('Shipments Read + Command API Integration', () => {
 
       // Now terminal: no active shipment for the order.
       await http
-        .get('/shipments/active?orderId=ol_order_cancel')
+        .get('/v1/shipments/active?orderId=ol_order_cancel')
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
 
       // Idempotent re-cancel.
       const again = await http
-        .post(`/shipments/${id}/cancel`)
+        .post(`/v1/shipments/${id}/cancel`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
       expect(again.body.status).toBe('cancelled');
@@ -296,7 +296,7 @@ describe('Shipments Read + Command API Integration', () => {
       const token = await loginAsAdmin(http, harness.getDataSource());
 
       await http
-        .post('/shipments/ol_shipment_missing/cancel')
+        .post('/v1/shipments/ol_shipment_missing/cancel')
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });

--- a/apps/api/test/integration/sync-jobs-grouped.int-spec.ts
+++ b/apps/api/test/integration/sync-jobs-grouped.int-spec.ts
@@ -36,7 +36,7 @@ describe('Sync Jobs Grouped API Integration', () => {
   describe('GET /sync/jobs/grouped', () => {
     it('should require authentication', async () => {
       const http = harness.getHttp();
-      await http.get('/sync/jobs/grouped?status=dead').expect(401);
+      await http.get('/v1/sync/jobs/grouped?status=dead').expect(401);
     });
 
     it('should return empty groups when no matching jobs exist', async () => {
@@ -45,7 +45,7 @@ describe('Sync Jobs Grouped API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       const response = await http
-        .get('/sync/jobs/grouped?status=dead')
+        .get('/v1/sync/jobs/grouped?status=dead')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -78,7 +78,7 @@ describe('Sync Jobs Grouped API Integration', () => {
       });
 
       const response = await http
-        .get('/sync/jobs/grouped?status=dead')
+        .get('/v1/sync/jobs/grouped?status=dead')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -124,7 +124,7 @@ describe('Sync Jobs Grouped API Integration', () => {
       });
 
       const response = await http
-        .get('/sync/jobs/grouped?status=dead')
+        .get('/v1/sync/jobs/grouped?status=dead')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -152,7 +152,7 @@ describe('Sync Jobs Grouped API Integration', () => {
       });
 
       const response = await http
-        .get(`/sync/jobs/grouped?status=dead&connectionId=${CONNECTION_A}`)
+        .get(`/v1/sync/jobs/grouped?status=dead&connectionId=${CONNECTION_A}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -178,7 +178,7 @@ describe('Sync Jobs Grouped API Integration', () => {
       });
 
       const response = await http
-        .get('/sync/jobs/grouped?status=dead')
+        .get('/v1/sync/jobs/grouped?status=dead')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 

--- a/apps/api/test/integration/sync-jobs-read.int-spec.ts
+++ b/apps/api/test/integration/sync-jobs-read.int-spec.ts
@@ -45,7 +45,7 @@ describe('Sync Jobs Read API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       const response = await http
-        .get('/sync/jobs')
+        .get('/v1/sync/jobs')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -64,7 +64,7 @@ describe('Sync Jobs Read API Integration', () => {
       });
 
       const response = await http
-        .get('/sync/jobs')
+        .get('/v1/sync/jobs')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -90,7 +90,7 @@ describe('Sync Jobs Read API Integration', () => {
       await createTestSyncJob(dataSource, { status: 'dead' });
 
       const response = await http
-        .get('/sync/jobs?status=queued')
+        .get('/v1/sync/jobs?status=queued')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -107,7 +107,7 @@ describe('Sync Jobs Read API Integration', () => {
       await createTestSyncJob(dataSource, { connectionId: OTHER_CONNECTION_ID });
 
       const response = await http
-        .get(`/sync/jobs?connectionId=${TARGET_CONNECTION_ID}`)
+        .get(`/v1/sync/jobs?connectionId=${TARGET_CONNECTION_ID}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -124,7 +124,7 @@ describe('Sync Jobs Read API Integration', () => {
       await createTestSyncJob(dataSource, { jobType: 'marketplace.offers.sync' });
 
       const response = await http
-        .get('/sync/jobs?jobType=master.inventory.syncByExternalId')
+        .get('/v1/sync/jobs?jobType=master.inventory.syncByExternalId')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -142,7 +142,7 @@ describe('Sync Jobs Read API Integration', () => {
       }
 
       const page1 = await http
-        .get('/sync/jobs?limit=2&offset=0')
+        .get('/v1/sync/jobs?limit=2&offset=0')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -152,7 +152,7 @@ describe('Sync Jobs Read API Integration', () => {
       expect(page1.body.offset).toBe(0);
 
       const page2 = await http
-        .get('/sync/jobs?limit=2&offset=2')
+        .get('/v1/sync/jobs?limit=2&offset=2')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -167,7 +167,7 @@ describe('Sync Jobs Read API Integration', () => {
 
     it('should return 401 without token', async () => {
       const http = harness.getHttp();
-      await http.get('/sync/jobs').expect(401);
+      await http.get('/v1/sync/jobs').expect(401);
     });
 
     // Issue #400 — Plan B for #391: outcome field on sync_jobs.
@@ -184,7 +184,7 @@ describe('Sync Jobs Read API Integration', () => {
         });
 
         const response = await http
-          .get('/sync/jobs')
+          .get('/v1/sync/jobs')
           .set('Authorization', `Bearer ${token}`)
           .expect(200);
 
@@ -201,7 +201,7 @@ describe('Sync Jobs Read API Integration', () => {
         await createTestSyncJob(dataSource, { status: 'dead' });
 
         const response = await http
-          .get('/sync/jobs')
+          .get('/v1/sync/jobs')
           .set('Authorization', `Bearer ${token}`)
           .expect(200);
 
@@ -229,7 +229,7 @@ describe('Sync Jobs Read API Integration', () => {
         await createTestSyncJob(dataSource, { status: 'queued', outcome: null });
 
         const response = await http
-          .get('/sync/jobs?outcome=business_failure')
+          .get('/v1/sync/jobs?outcome=business_failure')
           .set('Authorization', `Bearer ${token}`)
           .expect(200);
 
@@ -244,7 +244,7 @@ describe('Sync Jobs Read API Integration', () => {
         const token = await loginAsAdmin(http, dataSource);
 
         await http
-          .get('/sync/jobs?outcome=garbage')
+          .get('/v1/sync/jobs?outcome=garbage')
           .set('Authorization', `Bearer ${token}`)
           .expect(400);
       });
@@ -262,7 +262,7 @@ describe('Sync Jobs Read API Integration', () => {
       });
 
       const response = await http
-        .get(`/sync/jobs/${job.id}`)
+        .get(`/v1/sync/jobs/${job.id}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -277,14 +277,14 @@ describe('Sync Jobs Read API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get(`/sync/jobs/${NONEXISTENT_ID}`)
+        .get(`/v1/sync/jobs/${NONEXISTENT_ID}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
 
     it('should return 401 without token', async () => {
       const http = harness.getHttp();
-      await http.get(`/sync/jobs/${NONEXISTENT_ID}`).expect(401);
+      await http.get(`/v1/sync/jobs/${NONEXISTENT_ID}`).expect(401);
     });
   });
 });

--- a/apps/api/test/integration/sync-jobs-retry-grouped.int-spec.ts
+++ b/apps/api/test/integration/sync-jobs-retry-grouped.int-spec.ts
@@ -39,7 +39,7 @@ describe('Sync Jobs Retry Grouped API Integration', () => {
     it('should require authentication', async () => {
       const http = harness.getHttp();
       await http
-        .post('/sync/jobs/retry-grouped')
+        .post('/v1/sync/jobs/retry-grouped')
         .send({ connectionId: CONNECTION_A, jobType: 'master.inventory.syncByExternalId' })
         .expect(401);
     });
@@ -50,7 +50,7 @@ describe('Sync Jobs Retry Grouped API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .post('/sync/jobs/retry-grouped')
+        .post('/v1/sync/jobs/retry-grouped')
         .set('Authorization', `Bearer ${token}`)
         .send({ connectionId: CONNECTION_A })
         .expect(400);
@@ -62,7 +62,7 @@ describe('Sync Jobs Retry Grouped API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .post('/sync/jobs/retry-grouped')
+        .post('/v1/sync/jobs/retry-grouped')
         .set('Authorization', `Bearer ${token}`)
         .send({ connectionId: CONNECTION_A, jobType: 'not.a.real.job.type' })
         .expect(400);
@@ -97,7 +97,7 @@ describe('Sync Jobs Retry Grouped API Integration', () => {
       });
 
       const response = await http
-        .post('/sync/jobs/retry-grouped')
+        .post('/v1/sync/jobs/retry-grouped')
         .set('Authorization', `Bearer ${token}`)
         .send({ connectionId: CONNECTION_A, jobType: 'master.inventory.syncByExternalId' })
         .expect(200);
@@ -129,7 +129,7 @@ describe('Sync Jobs Retry Grouped API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       const response = await http
-        .post('/sync/jobs/retry-grouped')
+        .post('/v1/sync/jobs/retry-grouped')
         .set('Authorization', `Bearer ${token}`)
         .send({ connectionId: CONNECTION_A, jobType: 'master.inventory.syncByExternalId' })
         .expect(200);
@@ -156,7 +156,7 @@ describe('Sync Jobs Retry Grouped API Integration', () => {
       });
 
       const response = await http
-        .post('/sync/jobs/retry-grouped')
+        .post('/v1/sync/jobs/retry-grouped')
         .set('Authorization', `Bearer ${token}`)
         .send({ connectionId: CONNECTION_A, jobType: 'master.inventory.syncByExternalId' })
         .expect(200);

--- a/apps/api/test/integration/viewer-role-authz.int-spec.ts
+++ b/apps/api/test/integration/viewer-role-authz.int-spec.ts
@@ -54,7 +54,7 @@ describe('Viewer Role Authorization', () => {
     it('GET /connections', async () => {
       const { http, viewerToken } = await seeds();
       await http
-        .get('/connections')
+        .get('/v1/connections')
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(200);
     });
@@ -62,7 +62,7 @@ describe('Viewer Role Authorization', () => {
     it('GET /orders', async () => {
       const { http, viewerToken } = await seeds();
       await http
-        .get('/orders')
+        .get('/v1/orders')
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(200);
     });
@@ -70,7 +70,7 @@ describe('Viewer Role Authorization', () => {
     it('GET /sync/jobs', async () => {
       const { http, viewerToken } = await seeds();
       await http
-        .get('/sync/jobs')
+        .get('/v1/sync/jobs')
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(200);
     });
@@ -78,7 +78,7 @@ describe('Viewer Role Authorization', () => {
     it('GET /products', async () => {
       const { http, viewerToken } = await seeds();
       await http
-        .get('/products')
+        .get('/v1/products')
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(200);
     });
@@ -86,7 +86,7 @@ describe('Viewer Role Authorization', () => {
     it('GET /inventory', async () => {
       const { http, viewerToken } = await seeds();
       await http
-        .get('/inventory')
+        .get('/v1/inventory')
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(200);
     });
@@ -94,7 +94,7 @@ describe('Viewer Role Authorization', () => {
     it('GET /listings', async () => {
       const { http, viewerToken } = await seeds();
       await http
-        .get('/listings')
+        .get('/v1/listings')
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(200);
     });
@@ -110,7 +110,7 @@ describe('Viewer Role Authorization', () => {
       const { http, viewerToken } = await seeds();
       const dto = createPrestashopConnectionDto();
       await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${viewerToken}`)
         .send(dto)
         .expect(403);
@@ -121,12 +121,12 @@ describe('Viewer Role Authorization', () => {
       // Admin creates the connection; viewer is blocked on the update
       const dto = createPrestashopConnectionDto();
       const { body: conn } = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${adminToken}`)
         .send(dto)
         .expect(201);
       await http
-        .patch(`/connections/${conn.id as string}`)
+        .patch(`/v1/connections/${conn.id as string}`)
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({ name: 'should-be-blocked' })
         .expect(403);
@@ -135,7 +135,7 @@ describe('Viewer Role Authorization', () => {
     it('POST /sync/jobs', async () => {
       const { http, viewerToken } = await seeds();
       await http
-        .post('/sync/jobs')
+        .post('/v1/sync/jobs')
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({ jobType: 'marketplace.orders.poll', connectionId: '00000000-0000-4000-8000-000000000001' })
         .expect(403);
@@ -145,7 +145,7 @@ describe('Viewer Role Authorization', () => {
       const { http, viewerToken } = await seeds();
       // Guard fires before the service lookup, so no order needs to exist
       await http
-        .post('/orders/fake-order-id/destinations/00000000-0000-4000-8000-000000000001/retry')
+        .post('/v1/orders/fake-order-id/destinations/00000000-0000-4000-8000-000000000001/retry')
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(403);
     });
@@ -153,7 +153,7 @@ describe('Viewer Role Authorization', () => {
     it('POST /listings/connections/:connectionId/offers', async () => {
       const { http, viewerToken } = await seeds();
       await http
-        .post('/listings/connections/00000000-0000-4000-8000-000000000001/offers')
+        .post('/v1/listings/connections/00000000-0000-4000-8000-000000000001/offers')
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({})
         .expect(403);
@@ -162,7 +162,7 @@ describe('Viewer Role Authorization', () => {
     it('POST /sync/jobs/retry-grouped', async () => {
       const { http, viewerToken } = await seeds();
       await http
-        .post('/sync/jobs/retry-grouped')
+        .post('/v1/sync/jobs/retry-grouped')
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({ connectionId: '00000000-0000-4000-8000-000000000001', jobType: 'marketplace.orders.poll' })
         .expect(403);
@@ -172,12 +172,12 @@ describe('Viewer Role Authorization', () => {
       const { http, adminToken, viewerToken } = await seeds();
       const dto = createPrestashopConnectionDto();
       const { body: conn } = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${adminToken}`)
         .send(dto)
         .expect(201);
       await http
-        .get(`/connections/${conn.id as string}/diagnostics`)
+        .get(`/v1/connections/${conn.id as string}/diagnostics`)
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(403);
     });
@@ -193,21 +193,21 @@ describe('Viewer Role Authorization', () => {
       });
 
       const { body: conn } = await http
-        .post('/connections')
+        .post('/v1/connections')
         .set('Authorization', `Bearer ${adminToken}`)
         .send(dto)
         .expect(201);
 
       // Admin sees the raw config
       const adminGet = await http
-        .get(`/connections/${conn.id as string}`)
+        .get(`/v1/connections/${conn.id as string}`)
         .set('Authorization', `Bearer ${adminToken}`)
         .expect(200);
       expect(adminGet.body.config).toEqual(dto.config);
 
       // Viewer gets an empty object
       const viewerGet = await http
-        .get(`/connections/${conn.id as string}`)
+        .get(`/v1/connections/${conn.id as string}`)
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(200);
       expect(viewerGet.body.config).toEqual({});
@@ -222,11 +222,11 @@ describe('Viewer Role Authorization', () => {
 
       const dto1 = createPrestashopConnectionDto({ name: 'Store A' });
       const dto2 = createPrestashopConnectionDto({ name: 'Store B' });
-      await http.post('/connections').set('Authorization', `Bearer ${adminToken}`).send(dto1).expect(201);
-      await http.post('/connections').set('Authorization', `Bearer ${adminToken}`).send(dto2).expect(201);
+      await http.post('/v1/connections').set('Authorization', `Bearer ${adminToken}`).send(dto1).expect(201);
+      await http.post('/v1/connections').set('Authorization', `Bearer ${adminToken}`).send(dto2).expect(201);
 
       const { body: list } = await http
-        .get('/connections')
+        .get('/v1/connections')
         .set('Authorization', `Bearer ${viewerToken}`)
         .expect(200);
 

--- a/apps/api/test/integration/woocommerce/woocommerce-bulk-wizard-smoke.int-spec.ts
+++ b/apps/api/test/integration/woocommerce/woocommerce-bulk-wizard-smoke.int-spec.ts
@@ -167,7 +167,7 @@ const SKIP_WC_INTEGRATION =
     // POST /listings/bulk-create — returns 202 ACCEPTED per the controller spec.
     // connectionId = Allegro destination; productIds = OL internal variant IDs.
     const submitRes = await http
-      .post('/listings/bulk-create')
+      .post('/v1/listings/bulk-create')
       .set('Authorization', `Bearer ${authToken}`)
       .send({
         connectionId: allegroConnectionId,
@@ -196,7 +196,7 @@ const SKIP_WC_INTEGRATION =
     // Submit the S variant as the primary; the submit service expands it to
     // both S and M offers (multi-variant fan-out, #824). totalCount = 2.
     const submitRes = await http
-      .post('/listings/bulk-create')
+      .post('/v1/listings/bulk-create')
       .set('Authorization', `Bearer ${authToken}`)
       .send({
         connectionId: allegroConnectionId,

--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -18,6 +18,7 @@
  * @module app/api
  * @see apps/web/src/shared/plugins/plugin.types.ts — the OpenLinkerPlugin contract (#702)
  */
+import { withApiVersion } from '../../shared/config/api-version';
 import { createAdaptersApi, type AdaptersApi } from '../../features/adapters/api/adapters.api';
 import {
   createAiProviderSettingsApi,
@@ -115,7 +116,9 @@ export interface CoreApiClient {
 export type ApiClient = CoreApiClient & PluginApiNamespaces;
 
 function buildUrl(baseUrl: string, path: string): string {
-  return new URL(path, `${baseUrl.replace(/\/$/, '')}/`).toString();
+  // Root-absolute paths intentionally resolve against the base ORIGIN, so the
+  // `/v1` version segment (#1133) must live in the path, not the base URL.
+  return new URL(withApiVersion(path), `${baseUrl.replace(/\/$/, '')}/`).toString();
 }
 
 async function readResponseBody(response: Response): Promise<unknown> {

--- a/apps/web/src/shared/auth/jwt-bearer-session-adapter.test.ts
+++ b/apps/web/src/shared/auth/jwt-bearer-session-adapter.test.ts
@@ -223,7 +223,7 @@ describe('JwtBearerSessionAdapter', () => {
       await adapter.clearSession();
 
       const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
-      expect(url).toBe('http://localhost:3000/auth/logout');
+      expect(url).toBe('http://localhost:3000/v1/auth/logout');
       expect(init.method).toBe('POST');
       expect(init.credentials).toBe('include');
 

--- a/apps/web/src/shared/auth/jwt-bearer-session-adapter.ts
+++ b/apps/web/src/shared/auth/jwt-bearer-session-adapter.ts
@@ -17,6 +17,7 @@
  * request (refresh, logout). See `auth.cookies.ts` server-side for
  * the contract.
  */
+import { withApiVersion } from '../config/api-version';
 import type { SessionAdapter } from './session-adapter';
 import {
   ANONYMOUS_SESSION,
@@ -33,7 +34,9 @@ interface JwtBearerSessionAdapterConfig {
 }
 
 function buildUrl(baseUrl: string, path: string): string {
-  return `${baseUrl.replace(/\/$/, '')}${path}`;
+  // The auth endpoints (`/auth/refresh`, `/auth/me`, `/auth/logout`) are served
+  // under `/v1` (#1133) — pin the same major via the shared prefix helper.
+  return `${baseUrl.replace(/\/$/, '')}${withApiVersion(path)}`;
 }
 
 function readCsrfCookie(): string | null {

--- a/apps/web/src/shared/config/api-version.ts
+++ b/apps/web/src/shared/config/api-version.ts
@@ -1,0 +1,26 @@
+/**
+ * HTTP API version the frontend speaks (#1133 / ADR-029 Axis 3).
+ *
+ * The backend serves every route under `/v1`; the client pins the API major it
+ * targets. Single source for both URL builders (the api-client and the JWT
+ * session adapter) so they can never drift when a future `/v2` ships. Backend
+ * version-neutral routes (inbound webhooks, the Allegro OAuth callback) are not
+ * called through the FE client, so a blanket prefix is safe.
+ *
+ * @module apps/web/src/shared/config
+ */
+
+/** URI version segment prepended to every API path (leading slash, no trailing). */
+export const API_VERSION_PREFIX = '/v1';
+
+/**
+ * Prepend the version segment to a path unless it is already versioned.
+ * Normalizes a missing leading slash so callers can pass `orders` or `/orders`.
+ */
+export function withApiVersion(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  if (normalizedPath === API_VERSION_PREFIX || normalizedPath.startsWith(`${API_VERSION_PREFIX}/`)) {
+    return normalizedPath;
+  }
+  return `${API_VERSION_PREFIX}${normalizedPath}`;
+}

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -144,12 +144,16 @@ pnpm dev:stack:up
 
 OpenLinker provides two health check endpoints:
 
-1. **`GET /health`** - Internal dependencies only
-   - Checks: PostgreSQL, Redis
-   - Used by: Monitoring, PM2, Kubernetes
-   - Returns: `{ status: 'ok' }` when internal services are healthy
+The API is versioned under `/v1` (#1133 / ADR-029 Axis 3), so both health
+endpoints live under that prefix.
 
-2. **`GET /health/dev-stack`** - Development stack (internal + external)
+1. **`GET /v1/health`** - Internal dependencies + runtime version surface
+   - Checks: PostgreSQL, Redis
+   - Reports: running product `version` + API `api` version (#1133)
+   - Used by: Monitoring, PM2, Kubernetes
+   - Returns: `{ status: 'ok', version, api, services, timestamp }`
+
+2. **`GET /v1/health/dev-stack`** - Development stack (internal + external)
    - Checks: PostgreSQL, Redis, PrestaShop
    - Used by: Local development troubleshooting
    - Returns: Detailed status for each service
@@ -157,26 +161,28 @@ OpenLinker provides two health check endpoints:
 ### Using Health Checks
 
 ```bash
-# Check internal health
-curl http://localhost:3000/health
+# Check internal health + version surface
+curl http://localhost:3000/v1/health
 
 # Check dev stack health (with PrestaShop)
 pnpm dev:health
 
 # Or manually
-curl http://localhost:3000/health/dev-stack
+curl http://localhost:3000/v1/health/dev-stack
 ```
 
 ### Expected Responses
 
-**Internal Health (`/health`):**
+**Internal Health (`/v1/health`):**
 ```json
 {
-  "status": "ok"
+  "status": "ok",
+  "version": "0.1.0",
+  "api": "v1"
 }
 ```
 
-**Dev Stack Health (`/health/dev-stack`):**
+**Dev Stack Health (`/v1/health/dev-stack`):**
 ```json
 {
   "status": "ok",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,7 @@ pnpm start:dev:worker    # background sync jobs
 Health check:
 
 ```bash
-curl -s http://localhost:3000/health/dev-stack | jq .
+curl -s http://localhost:3000/v1/health/dev-stack | jq .
 ```
 
 Once the worker is running (`pnpm start:dev:worker`), the **System Health** panel at **http://localhost:4173** (dashboard) will show four tiles: PostgreSQL, Redis, PrestaShop, and Worker. The Worker tile confirms the background sync worker is alive; if it remains red after the worker starts, check the worker logs for errors.

--- a/docs/integrations/allegro/runbook.md
+++ b/docs/integrations/allegro/runbook.md
@@ -32,10 +32,10 @@ Resetting a cursor allows you to replay data from an earlier point.
 
 ```bash
 # Delete orders cursor for a connection
-curl -X DELETE http://localhost:3000/integrations/allegro/connections/{connectionId}/cursors/allegro.orders.lastEventId
+curl -X DELETE http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/cursors/allegro.orders.lastEventId
 
 # Delete offers cursor for a connection
-curl -X DELETE http://localhost:3000/integrations/allegro/connections/{connectionId}/cursors/allegro.offers.lastEventId
+curl -X DELETE http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/cursors/allegro.offers.lastEventId
 ```
 
 **Option 2: Direct database update**
@@ -74,10 +74,10 @@ WHERE connection_id = 'your-connection-id'
 
 ```bash
 # Check orders cursor value
-curl http://localhost:3000/integrations/allegro/connections/{connectionId}/cursors?cursorKey=allegro.orders.lastEventId
+curl http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/cursors?cursorKey=allegro.orders.lastEventId
 
 # Check offers cursor value
-curl http://localhost:3000/integrations/allegro/connections/{connectionId}/cursors?cursorKey=allegro.offers.lastEventId
+curl http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/cursors?cursorKey=allegro.offers.lastEventId
 ```
 
 **Response**:
@@ -110,7 +110,7 @@ Allegro API has rate limits. When exceeded, requests return HTTP 429 (Too Many R
 
 ```bash
 # Get failed jobs for a connection
-curl http://localhost:3000/integrations/allegro/connections/{connectionId}/commands?status=failed
+curl http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/commands?status=failed
 ```
 
 **Option 2: Check application logs**
@@ -146,7 +146,7 @@ Quantity update commands can fail for various reasons. Failed commands are persi
 
 ```bash
 # Get all failed commands for a connection
-curl http://localhost:3000/integrations/allegro/connections/{connectionId}/commands/failed
+curl http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/commands/failed
 ```
 
 **Response**:
@@ -169,7 +169,7 @@ curl http://localhost:3000/integrations/allegro/connections/{connectionId}/comma
 
 ```bash
 # Get command by ID
-curl http://localhost:3000/integrations/allegro/connections/{connectionId}/commands/{commandId}
+curl http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/commands/{commandId}
 ```
 
 ### Query Failed Commands in Database
@@ -214,7 +214,7 @@ Offer mappings link Allegro offers to internal OpenLinker products and variants.
 ### Create Mapping
 
 ```bash
-curl -X POST http://localhost:3000/integrations/offer-mappings \
+curl -X POST http://localhost:3000/v1/integrations/offer-mappings \
   -H "Content-Type: application/json" \
   -d '{
     "connectionId": "your-connection-id",
@@ -243,16 +243,16 @@ curl -X POST http://localhost:3000/integrations/offer-mappings \
 
 ```bash
 # List mappings for a connection
-curl http://localhost:3000/integrations/offer-mappings?connectionId={connectionId}
+curl http://localhost:3000/v1/integrations/offer-mappings?connectionId={connectionId}
 
 # List mappings for a product
-curl http://localhost:3000/integrations/offer-mappings?productId={productId}
+curl http://localhost:3000/v1/integrations/offer-mappings?productId={productId}
 ```
 
 ### Update Mapping
 
 ```bash
-curl -X PATCH http://localhost:3000/integrations/offer-mappings/{mappingId} \
+curl -X PATCH http://localhost:3000/v1/integrations/offer-mappings/{mappingId} \
   -H "Content-Type: application/json" \
   -d '{
     "internalProductId": "new-product-id",
@@ -263,7 +263,7 @@ curl -X PATCH http://localhost:3000/integrations/offer-mappings/{mappingId} \
 ### Delete Mapping
 
 ```bash
-curl -X DELETE http://localhost:3000/integrations/offer-mappings/{mappingId}
+curl -X DELETE http://localhost:3000/v1/integrations/offer-mappings/{mappingId}
 ```
 
 ### Query Mappings in Database
@@ -365,14 +365,14 @@ ORDER BY updated_at DESC;
 
 ```bash
 # Get poll jobs
-curl http://localhost:3000/sync/jobs?connectionId={connectionId}&jobType=marketplace.orders.poll
+curl http://localhost:3000/v1/sync/jobs?connectionId={connectionId}&jobType=marketplace.orders.poll
 ```
 
 **Step 2: Check order sync jobs**
 
 ```bash
 # Get order sync jobs
-curl http://localhost:3000/sync/jobs?connectionId={connectionId}&jobType=marketplace.order.sync
+curl http://localhost:3000/v1/sync/jobs?connectionId={connectionId}&jobType=marketplace.order.sync
 ```
 
 **Step 3: Check application logs**
@@ -390,12 +390,12 @@ Quantity update commands go through several states: `queued`, `accepted`, `rejec
 
 ```bash
 # Get all commands for a connection
-curl http://localhost:3000/integrations/allegro/connections/{connectionId}/commands
+curl http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/commands
 
 # Get commands by status
-curl http://localhost:3000/integrations/allegro/connections/{connectionId}/commands?status=queued
-curl http://localhost:3000/integrations/allegro/connections/{connectionId}/commands?status=accepted
-curl http://localhost:3000/integrations/allegro/connections/{connectionId}/commands?status=failed
+curl http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/commands?status=queued
+curl http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/commands?status=accepted
+curl http://localhost:3000/v1/integrations/allegro/connections/{connectionId}/commands?status=failed
 ```
 
 ### Command Status Meanings

--- a/docs/plans/analysis/ANALYSIS-http-api-versioning.md
+++ b/docs/plans/analysis/ANALYSIS-http-api-versioning.md
@@ -1,0 +1,60 @@
+# Pre-implement analysis — HTTP API versioning (`/v1`) (#1133)
+
+- **Plan**: `docs/plans/implementation-plan-http-api-versioning.md` (Design A / hard `/v1`)
+- **Gate run**: read-only against the live tree at `1133-http-api-versioning`
+- **Verdict**: **READY** — with one **required carve-out decision** to fold in before coding (Allegro OAuth callback). No Critical contract break, no reuse collision.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `AppInfoService` / `IAppInfoService` | **NEW** (absent) | no `*app-info*`/`*version*service*` under `apps/api/src`; no `getProductVersion`/`AppInfoService` symbol anywhere |
+| `api-version.const.ts` (`API_VERSION`, `API_VERSION_LABEL`) | **NEW** | no `API_VERSION` symbol in `apps/api/src` |
+| `enableVersioning` / `VERSION_NEUTRAL` config | **NEW** | confirmed unused in `apps/api` + `apps/worker` |
+| `version`/`api` on `InternalHealthResponse` | **PARTIAL — extend** | `dev-stack-health.types.ts` owns it; consumed only by `app.controller.ts` + `dev-stack-health.service*.ts` (all apps/api) |
+| Version-neutral webhook route | **PARTIAL — extend** | single `webhook.controller.ts` (`@Controller('webhooks')`) → one `@Version(VERSION_NEUTRAL)` |
+| Runtime version endpoint | **NEW** | no app/product-version endpoint exists (root `/` returns a string) |
+
+## Backward-compat findings
+
+| Surface | Result | Severity |
+|---|---|---|
+| Top-level barrels (`@openlinker/core/*`) | untouched (apps/api-only change) | — |
+| Port method signatures | none changed | — |
+| DTO / response shapes | `InternalHealthResponse` gains **optional** `version`/`api` — additive | none |
+| Symbol tokens | none removed; may **add** `APP_INFO_SERVICE_TOKEN` | none |
+| ORM schema | no entity change → **no migration** | none |
+| `check:invariants` | no cross-context import; apps/api service not covered by `check-service-interfaces.mjs` (libs/core-only) | none |
+| OpenAPI snapshot tests | none exist → no contract-snapshot break | none |
+| **Allegro OAuth callback** `/integrations/allegro/oauth/callback` | **external URL not in the plan's neutral set** | **Warning (external contract)** |
+
+> **⚠️ Superseded during tech-review.** The analysis below recommended keeping the
+> Allegro OAuth callback version-neutral. That was **wrong** — the Allegro-whitelisted
+> redirect URI is the **FE route** `/integrations/allegro/connect/callback`
+> (`window.location.origin`), not this backend endpoint. The backend
+> `/integrations/allegro/oauth/callback` is an internal JSON API the FE callback page
+> calls through the versioned api-client, so it MUST be versioned (`/v1`). Marking it
+> neutral 404s that call and breaks OAuth completion. Final neutral set is
+> `{ /webhooks, / }` only. Kept below for provenance.
+
+### The Allegro OAuth callback (must decide before coding)
+
+`AllegroOauthConnectDto.redirectUri` is **client-supplied** and documented as *"must match Allegro app configuration"* (`allegro-oauth-connect.dto.ts:38`). It is an operator-whitelisted redirect URI in Allegro's developer console — a genuine external URL, same class as `/webhooks`. Under hard `/v1` the callback route becomes `/v1/integrations/allegro/oauth/callback`, so any operator who whitelisted the unversioned URL must re-register it.
+
+Two acceptable resolutions (pick one at implementation; not a replan):
+- **(a) Carve it out** — mark the callback route `@Version(VERSION_NEUTRAL)` (mirrors the `/webhooks` treatment). Zero operator churn; the OAuth surface stays outside the versioned contract. **Recommended** — the callback is an integration handshake, not part of the app's REST contract, and there is no cost to leaving it stable.
+- **(b) Version it + document** — let it move to `/v1`, update the FE-supplied `redirectUri` default + the DTO example + a RELEASING/setup note telling operators to re-whitelist. Consistent "everything is /v1" story, at the cost of an operator migration step.
+
+Because there are **zero external deployments today**, either is safe; (a) is strictly lower-risk and one decorator.
+
+## Open questions / minor notes (non-blocking)
+
+1. **Root `/` (`getHello`)** moves to `/v1` under the default → bare `GET /` returns 404. No known consumer; optionally keep neutral for LB probes. Trivial.
+2. **Where to populate `version`/`api`** — controller overlay (keeps `DevStackHealthService` focused on DB/redis readiness) vs. inject `AppInfoService` into the health service. Prefer the controller overlay; impl detail.
+3. **Ordering in `main.ts`** — call `enableVersioning(...)` **before** `SwaggerModule.createDocument(...)` so Swagger operations render `/v1/...`.
+4. **FE test** `apps/web/src/app/api/api-client.test.ts:137` calls `request('/health')` — will need updating alongside the FE base-path change.
+5. **`/webhooks` raw-body middleware** in `main.ts` stays keyed on `/webhooks`; the neutral webhook route keeps that path, so no mismatch.
+
+## Bottom line
+
+No reuse collision, no Critical contract break, no migration. Proceed — but **explicitly decide the Allegro OAuth-callback carve-out** (recommend `VERSION_NEUTRAL`) so the neutral set is `{ /webhooks, /integrations/allegro/oauth/callback }`, not just `/webhooks`.

--- a/docs/plans/implementation-plan-http-api-versioning.md
+++ b/docs/plans/implementation-plan-http-api-versioning.md
@@ -1,0 +1,133 @@
+# Implementation Plan — HTTP API versioning (`/v1`) + runtime version surface (#1133)
+
+- **Issue**: #1133 (Axis 3 of ADR-029)
+- **Layer**: Interface / DX (apps/api bootstrap + FE api-client base path + docs)
+- **Branch**: `1133-http-api-versioning`
+
+## 1. Goal
+
+Move the flat, unversioned HTTP API onto an explicit **URI versioning** scheme
+(`/v1/...`) using NestJS `enableVersioning`, and add a **runtime version
+surface** (`GET /v1/health` reporting product version + API version) so the tag,
+the Release, the CHANGELOG, and the live process agree. Decided by
+[ADR-029](../architecture/adrs/029-versioning-and-release-strategy.md) §Axis 3 and
+[RELEASING.md](../../RELEASING.md) §"HTTP API versioning". Blocks the first
+`v0.1.0` product tag (#1137).
+
+**Non-goals** (explicitly deferred):
+- No `/v2`, no actual breaking change — only the `/v1` scaffold + the
+  deprecation *policy text*.
+- Product-release tooling (release-please, CHANGELOG, first tag) is #1137.
+- npm package SemVer (Changesets) stays deferred (#552 / PUBLIC_API.md).
+- Making `package.json` the enforced single origin of the product version is
+  coordinated with #1137 (which owns tagging); #1133 ships a sane resolution
+  chain + the endpoint.
+
+## 2. Decided design
+
+### 2.1 Versioning
+- `app.enableVersioning({ type: VersioningType.URI, defaultVersion: API_VERSION })`
+  in `apps/api/src/main.ts`, where `API_VERSION = '1'` (prefix defaults to `v` →
+  `/v1`). Sourced from one shared constant reused by the version endpoint.
+- **Version-neutral routes** (served WITHOUT `/v1`):
+  - `@Controller('webhooks')` — external platforms have `/webhooks/:provider/:connectionId`
+    provisioned, and `main.ts` keys raw-body middleware on the literal `/webhooks` path.
+  - the root `/` welcome route — kept neutral for load-balancer / uptime probes
+    that hit the bare origin.
+- **Correction (post-review):** the Allegro OAuth callback
+  `/integrations/allegro/oauth/callback` is **versioned** (`/v1`), NOT neutral.
+  The pre-implement analysis conflated it with the Allegro-whitelisted redirect
+  URI — but that whitelisted URL is the **FE route**
+  `/integrations/allegro/connect/callback` (`window.location.origin`). The backend
+  endpoint is an internal JSON API the FE callback page calls via the versioned
+  api-client (`request('/integrations/allegro/oauth/callback?...')` → `/v1/...`);
+  marking it neutral would 404 that call and break OAuth completion.
+- Everything else (auth, orders, connections, sync, products, health, both
+  Allegro OAuth endpoints, …) moves under `/v1` via the default.
+
+### 2.2 Runtime version surface
+- Enrich the existing internal health response so `GET /v1/health` returns
+  `{ status, version, api, services, timestamp }` (reuses `AppController` +
+  `DevStackHealthService.checkInternalHealth()` — no new controller).
+  - `api`: the `v1` string, from the shared `API_VERSION` constant.
+  - `version`: product version, resolved by a small `AppInfoService`
+    (`IAppInfoService`) as `OL_PRODUCT_VERSION ?? npm_package_version ?? '0.0.0-dev'`.
+    Deploy sets `OL_PRODUCT_VERSION` to the release tag (documented; #1137 wires
+    it from package.json/release-please). `npm_package_version` covers `pnpm`-run
+    dev.
+- `GET /v1/health/dev-stack` (existing dev diagnostics) rides along under `/v1`.
+
+### 2.3 Swagger
+- Keep the Swagger UI at `/api` (middleware, unaffected by route versioning).
+- Set `DocumentBuilder().setVersion(productVersion)` from the same resolved
+  product version (was hardcoded `'1.0'`). Operation paths auto-render `/v1/...`.
+
+### 2.4 Frontend
+- Append `/v1` to the API base. Chosen approach: **`buildUrl()`** in
+  `apps/web/src/app/api/api-client.ts` prepends `/v1` to non-neutral paths, OR
+  simpler — bake `/v1` into the base and special-case the two health calls.
+  Final choice pinned in step list after reading `buildUrl`. FE calls
+  `/health/dev-stack`, which is version-neutral-sensitive — see §3 decision.
+
+### 2.5 Deprecation/support policy
+- Add a short "HTTP API versioning" section to `docs/` (or extend RELEASING.md
+  reference): `/v1` is current; a breaking change ships as `/v2` with `/v1`
+  supported for a documented window; product version moves independently.
+
+## 3. Open decision (needs user) — enforcement strictness vs. test churn
+
+NestJS URI versioning supports `defaultVersion: ['1', VERSION_NEUTRAL]`
+(type-verified), which serves **both** `/v1/x` and `/x`. This is the fork:
+
+- **Design A — hard `/v1`** (`defaultVersion: '1'`). Unversioned → 404.
+  Faithful to "decide before adoption". Cost: mirror versioning in the int-test
+  harness + update ~100–185 non-webhook int-spec paths to `/v1/...` (67 files),
+  large mechanical diff, heavier/flakier int-suite verification.
+- **Design B — dual-serve** (`['1', VERSION_NEUTRAL]`). Both paths resolve.
+  Zero test churn; FE/Swagger/docs advertise `/v1`. Softer: unversioned stays
+  reachable (transitional). 
+- **Design C — hard `/v1` in main.ts only**, harness stays unversioned + one
+  dedicated `api-versioning.int-spec.ts`. Low churn but harness diverges from
+  main.ts (which it otherwise mirrors).
+
+**Recommendation: Design A** — #1133's whole point is to make `/v1` the surface
+before integrators build against the unversioned one; dual-serve leaves the
+unversioned surface adoptable and undercuts that. The churn is mechanical and
+scriptable. If the large diff / int-suite flakiness is the bigger concern,
+Design B is the safe fallback.
+
+## 4. Step-by-step
+
+1. **`apps/api/src/app-info/`** — `IAppInfoService` (`getProductVersion()`,
+   `getApiVersion()`), `AppInfoService` impl, `api-version.const.ts`
+   (`API_VERSION = '1'`, `API_VERSION_LABEL = 'v1'`). Unit spec for the
+   resolution chain.
+2. **`apps/api/src/main.ts`** — `enableVersioning({ type: URI, defaultVersion })`;
+   `.setVersion(productVersion)` in Swagger; keep `/webhooks` middleware + `/api`.
+3. **`webhook.controller.ts`** — add `@Version(VERSION_NEUTRAL)`.
+4. **`app.controller.ts` + `dev-stack-health.types.ts`** — add `version` + `api`
+   to `InternalHealthResponse`; inject `AppInfoService`; populate in
+   `checkInternalHealth()` (or map in controller). Update the health unit/int spec.
+5. **Test harness** (`apps/api/test/integration/setup.ts` `configureApp`) — under
+   Design A only: `app.enableVersioning(...)` mirroring main.ts; update non-webhook
+   int-spec paths to `/v1/...` (webhook + neutral paths unchanged). Under Design B:
+   no harness change; add `api-versioning.int-spec.ts` asserting `/v1/health`
+   surface + `/webhooks` neutral + a representative `/v1/orders` route.
+6. **Frontend** — `apps/web/src/app/api/api-client.ts` (+ `env.ts` / `.env.example`):
+   route non-neutral calls through `/v1`; keep `/health*` reachable.
+7. **Docs** — deprecation/support policy note; update `dev-environment.md` /
+   `getting-started.md` health curls if paths change.
+8. **Quality gate** — `pnpm lint`, `pnpm type-check`, `pnpm test`; targeted
+   int-spec run for the versioning + health slices.
+
+## 5. Validation / risks
+- **Arch compliance**: interface-layer only; `AppInfoService` implements an
+  interface (standards §Service Interface). No core/domain changes, no migration.
+- **Risk — webhook breakage**: mitigated by `@Version(VERSION_NEUTRAL)` +
+  unchanged raw-body middleware path. Covered by existing webhook int-specs.
+- **Risk — FE health 404**: `/health/dev-stack` must stay reachable from the FE;
+  handled in step 6.
+- **Risk — version source in Docker**: `npm_package_version` unset under
+  `node dist/main.js`; `OL_PRODUCT_VERSION` fallback + doc note.
+- **Risk — int-suite churn/flakiness (Design A)**: large diff; verify with
+  targeted patterns, prune Docker between heavy runs.

--- a/docs/prestashop-module-testing-guide.md
+++ b/docs/prestashop-module-testing-guide.md
@@ -220,7 +220,7 @@ Now create a connection in OpenLinker using the `credentialsRef` you configured:
 
 ```bash
 # Create connection (use the credentialsRef you set up above)
-curl -X POST http://localhost:3000/connections \
+curl -X POST http://localhost:3000/v1/connections \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Test PrestaShop Store",
@@ -301,7 +301,7 @@ export OPENLINKER_WEBHOOK_SECRET__PRESTASHOP=test-secret-key-12345
    - Check diagnostics: pending count should decrease, delivered count should increase
 
 3. **If Failed**:
-   - Check OpenLinker API is running: `curl http://localhost:3000/health`
+   - Check OpenLinker API is running: `curl http://localhost:3000/v1/health`
    - Check network connectivity: `docker exec openlinker-prestashop curl -v http://host.docker.internal:3000`
    - Verify webhook secret matches exactly
    - Check OpenLinker logs for signature verification errors

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "dev:stack:seed-prestashop": "docker compose exec prestashop sh -c 'for f in /tmp/post-install-scripts/*.sh; do echo \"--- $f ---\"; sh \"$f\" || exit $?; done'",
     "dev:stack:seed-woocommerce": "docker exec openlinker-woocommerce bash /docker-entrypoint-initdb.d/01-seed-wc-data.sh",
     "dev:stack:wc-credentials": "docker exec openlinker-woocommerce cat /bitnami/wordpress/.dev-secrets/woocommerce-credentials.json | jq .",
-    "dev:health": "curl -s http://localhost:3000/health/dev-stack | jq . || curl -s http://localhost:3000/health/dev-stack",
+    "dev:health": "curl -s http://localhost:3000/v1/health/dev-stack | jq . || curl -s http://localhost:3000/v1/health/dev-stack",
     "prepare": "husky install || true"
   },
   "devDependencies": {


### PR DESCRIPTION
## What & why

Adopts explicit **HTTP API URI versioning** (`/v1`) via NestJS `enableVersioning({ type: VersioningType.URI, defaultVersion: '1' })`, and adds a **runtime version surface** at `GET /v1/health`. This is **Axis 3 of [ADR-029](../blob/main/docs/architecture/adrs/029-versioning-and-release-strategy.md)** and blocks the first `v0.1.0` product tag (#1137) — the first release should advertise a versioned API before external integrators build against the flat, unversioned surface.

Closes #1133

## Version-neutral set (deliberately minimal)

Only genuinely-external / origin routes opt out of `/v1`:

| Route | Why neutral |
|---|---|
| `POST /webhooks/:provider/:connectionId` | Externally-provisioned URLs; the raw-body middleware is keyed on the literal `/webhooks` path. |
| `GET /` | Welcome route kept reachable at the bare origin for LB / uptime probes. |

**The Allegro OAuth callback is versioned** (`/v1/integrations/allegro/oauth/callback`), **not** neutral. It is an internal JSON endpoint the FE callback page calls with the auth code — *not* the browser redirect target. The Allegro-whitelisted redirect URI is the **FE route** `/integrations/allegro/connect/callback` (`window.location.origin`), which API versioning doesn't touch. (An earlier draft mistakenly carved this out; caught in review — see the plan/analysis docs.)

## Runtime version surface

`GET /v1/health` → `{ status, version, api, services, timestamp }`.
- `api` — the `v1` label.
- `version` — product version resolved `OL_PRODUCT_VERSION → npm_package_version → 0.0.0-dev`. Deploys set `OL_PRODUCT_VERSION` to the release tag (documented in `apps/api/.env.example`; release wiring owned by #1137).
- `API_VERSION` is **one shared constant** reused by `enableVersioning`, the health response, and the Swagger doc version, so the routed prefix and the reported `api` can't drift. Swagger operations render `/v1/...` automatically (`@nestjs/swagger` reads the versioning config).

## Frontend

Both API-URL builders (the api-client and the JWT session adapter — `auth/refresh|me|logout`) pin the same major via a single shared `withApiVersion()` helper in `shared/config/api-version.ts`.

## Changes

- **New** `apps/api/src/app-info/` module — `AppInfoService` + `IAppInfoService` + types (version resolution).
- Enrich `InternalHealthResponse`; the controller overlays `version`/`api` onto the readiness result (health service stays readiness-only).
- Mirror versioning in the integration harness; migrate int-spec paths to `/v1`.
- New `api-versioning.int-spec.ts` — asserts the version surface, hard `/v1` enforcement (unversioned → 404), webhook neutrality, and the versioned OAuth callback.
- Docs: `dev-environment` / `getting-started` / Allegro runbook / PS-module-testing-guide curls, the `dev:health` script, `RELEASING.md` status, and `OL_PRODUCT_VERSION` in `.env.example`.

## How to test

```bash
pnpm --filter @openlinker/api start:dev
curl -s localhost:3000/v1/health | jq       # { status, version, api: "v1", services, timestamp }
curl -s -o /dev/null -w '%{http_code}\n' localhost:3000/orders     # 404 (unversioned)
curl -s -o /dev/null -w '%{http_code}\n' localhost:3000/v1/orders  # 401 (routed, auth-gated)
```

## Verification

- `pnpm type-check` ✅ · `pnpm lint` + `check:invariants` ✅ (0 errors)
- Unit (backend + FE) ✅ incl. new `AppInfoService` spec + FE URL-builder specs
- **Integration: 70/70 suites green** (rebased on current `main`). `allegro-prestashop-carrier-mapping` intermittently times out under Docker contention in the full run but passes in isolation (4/4) — a known Testcontainers-contention flake, unrelated to this change.

## Follow-up (not blocking)

Deploy wiring of `OL_PRODUCT_VERSION` → release tag is owned by **#1137** (release-please). Until then, a Docker `node dist/main.js` process reports `0.0.0-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)