### PR TITLE
fix(ksef): resolve secretRef/secret credentials mismatch on connection create

### DIFF
--- a/apps/web/src/features/connections/components/ksef-setup-form.tsx
+++ b/apps/web/src/features/connections/components/ksef-setup-form.tsx
@@ -244,7 +244,7 @@ export function KsefSetupForm(): ReactElement {
         label="Context identifier"
         name="contextIdentifier"
         error={form.formState.errors.contextIdentifier?.message}
-        description="Optional KSeF subject/context identifier when issuing on behalf of a sub-unit."
+        description="Optional KSeF subject/context identifier for display and future scoping. Does not affect authentication — sessions always authenticate in the seller NIP context."
       >
         <Input
           {...form.register('contextIdentifier')}

--- a/apps/web/src/features/connections/components/ksef-setup.schema.ts
+++ b/apps/web/src/features/connections/components/ksef-setup.schema.ts
@@ -23,13 +23,15 @@
  *     operator can save incremental progress); the server is the strict gate.
  *   - `config.contextIdentifier` is an FE-additive context field the operator
  *     supplies for display + future scoping; not gated by the C2 config
- *     validator yet (it only requires `env`).
+ *     validator yet (it only requires `env`). It does NOT affect
+ *     authentication — the token-auth session always uses `config.seller.nip`
+ *     as the KSeF context identifier.
  *   - `credentials.authType` → `KsefCredentials.authType`
  *     (`ksef-token` | `qualified-seal`).
  *   - `credentials.secret` carries the write-only secret the operator pastes.
  *     The API persists it in the integration credentials store and assigns a
- *     `db:<uuid>` reference (the BE's opaque `secretRef`); the secret value is
- *     never echoed back to the browser.
+ *     `db:<uuid>` reference (stored as the connection's `credentialsRef`); the
+ *     secret value is never echoed back to the browser.
  *
  * @module features/connections/components
  */

--- a/docs/integrations/ksef/setup-guide.md
+++ b/docs/integrations/ksef/setup-guide.md
@@ -64,9 +64,11 @@ A KSeF connection authenticates in one of two modes (`credentials.authType`):
 | `ksef-token` | Static KSeF authorization-token flow (default for server-to-server). |
 | `qualified-seal` | X.509 qualified-seal (pieczęć kwalifikowana) signing flow. |
 
-The concrete secret is **never stored on the connection row**. Credentials carry
-an opaque `secretRef`; the host's `CredentialsResolverPort` resolves the actual
-token / seal material at adapter construction.
+The concrete secret is **never stored on the connection row**. The credentials
+payload (`{ authType, secret }`) is persisted in the encrypted integration
+credentials store under the connection's `credentialsRef` (`db:<uuid>`); the
+host's `CredentialsResolverPort` resolves the actual token / seal material at
+adapter construction.
 
 The handshake (token mode) is: request a **challenge** → **RSA-OAEP(SHA-256)-encrypt**
 the `(token|timestampMs)` blob under the MF **token-encryption** public key → submit it →
@@ -87,8 +89,9 @@ distinct.
    seal certificate (seal mode) for the seller NIP.
 3. Via the wizard, paste the raw secret into the **write-only** `credentials.secret`
    field. The platform persists it in the integration credentials store and assigns
-   the opaque `secretRef` (`db:<uuid>`) itself — you do **not** pre-provision a vault
-   reference. The secret value is never echoed back to the browser.
+   the connection's `credentialsRef` (`db:<uuid>`) itself — you do **not**
+   pre-provision a vault reference. The secret value is never echoed back to the
+   browser.
 
 ---
 
@@ -99,26 +102,21 @@ Non-secret config persisted on the connection row (`KsefConnectionConfig`):
 | Field | Required | Collected by wizard | Description |
 |---|---|---|---|
 | `env` | ✅ | ✅ | `test` \| `demo` \| `prod`. Gated by the config-shape validator at connection create/update. |
+| `seller` | for issuance | ✅ | Seller profile (`Podmiot1`) stamped on every FA(3): `seller.nip`, `seller.name`, `seller.address { line1, line2?, city, postalCode, countryIso2 }`, optional `seller.defaultTaxRate` (neutral fallback tax-rate code, defaults to the PL standard rate). Optional at connection create; a connection without a well-formed `seller` fails fast at adapter construction and cannot issue. |
 
-> **Planned addition (C5) — seller profile.**
-> The issuance path (C4+) will require a `seller` block on the config — the full seller profile
-> (`Podmiot1`) stamped on every FA(3): `seller.nip`, `seller.name`, `seller.address
-> { line1, line2?, city, postalCode, countryIso2 }`. This field does not exist on
-> `KsefConnectionConfig` yet; its shape validation and wizard collection are tracked
-> follow-ups that land alongside the C5 issuance work. Until then, `env` is the only
-> config field the server gates.
+> **Note — `seller.nip` is also the session context.** The token-auth handshake
+> authenticates in the context of `seller.nip` (`<ContextNip>`): KSeF's context
+> NIP is normally the seller's own NIP, and there is no separate secret carrying
+> it. The FE-additive `config.contextIdentifier` field (display / future
+> scoping) does **not** affect authentication.
 
-> **Note:** the seller's tax identifier (NIP) is deliberately not stored on the connection
-> config in C2. Per the config-shape validator's design, it travels with the issued document
-> rather than living on the connection row. The `seller` block (C5) will introduce it as
-> part of a structured seller-profile object, not as a bare `sellerNip` field.
-
-Credentials (`KsefCredentials`, resolved via `CredentialsResolverPort`):
+Credentials (`KsefCredentials`, resolved via `CredentialsResolverPort` from the
+connection's `credentialsRef`):
 
 | Field | Required | Description |
 |---|---|---|
 | `authType` | ✅ | `ksef-token` \| `qualified-seal`. |
-| `secretRef` | ✅ | Opaque reference to the secret in the credential store (never the secret value). Assigned by the platform — see [Obtaining credentials](#obtaining-credentials). |
+| `secret` | ✅ | The raw authentication secret (KSeF authorization token, or a qualified-seal reference), write-only through the wizard. Persisted encrypted in the credential store behind the connection's `credentialsRef` — see [Obtaining credentials](#obtaining-credentials). |
 
 ---
 
@@ -212,7 +210,7 @@ the table below covers both current gaps and explicitly out-of-scope items:
 | Not supported | Rationale |
 |---|---|
 | Issuance / clearance (C2 stub) | The `KsefInvoicingAdapter` is a stub — `issueInvoice`, `upsertCustomer`, and `submitForClearance` throw "not yet implemented". Mechanics land in C4. |
-| Seller profile on connection config | `KsefConnectionConfig` currently only carries `env`. The `seller` block (NIP, name, address) is a C5 addition; without it a connection cannot issue. |
+| Issuance without a seller profile | The `seller` block (NIP, name, address) on `KsefConnectionConfig` is required for issuance and for the token-auth session context; a connection without it fails fast at adapter construction. |
 | Receipts / paragony (B2C fiscal receipts) | KSeF covers structured invoices; receipts are a separate fiscal regime. An invoice to a buyer without a NIP **is** planned (FA(3) `BrakID`) once issuance ships. |
 | Batch (wsadowa) submission pipeline | The online (interactive) session flow is the C4 target; the batch pipeline (`/sessions/batch`) is a separate, deferred path. |
 | Inbound invoice retrieval | OpenLinker is a transmitter, not a KSeF inbox reader; pulling received invoices is out of scope. |

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -94,3 +94,11 @@ When a lesson hardens into a rule, **graduate it** to the canonical doc and leav
 **Rule**: Read the buyer-placed time from `lineItems[].boughtAt`. The PrestaShop equivalent is `date_add`.
 **Applies to**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts`; `libs/core/src/orders/domain/types/incoming-order.types.ts`.
 **Source**: Allegro order-source adapter.
+
+## A credentials/config payload shape shared by FE, shape validator, and adapter factory needs one cross-layer test — per-layer green suites can all pass against divergent assumed shapes
+
+**Context**: KSeF connection create: the FE wizard sent `credentials: { authType, secret }` while the BE shape validator and adapter factory expected `{ authType, secretRef }` plus a second nested credentials lookup — every wizard-created KSeF connection failed at create with a 400.
+**Problem**: Each layer had green unit tests against its *own assumed* payload shape, so the contract drift between FE payload, credentials-shape validator, and adapter factory went unnoticed until a live end-to-end attempt. Nothing type-checks across the FE/BE wire boundary, and the validator + factory each hand-roll their expected shape independently.
+**Rule**: When a wire payload shape (credentials, connection config) is consumed by more than one layer, add at least one test that drives the real FE-produced payload through the BE validator and adapter factory together (or assert all layers against a single shared fixture) — do not rely on per-layer specs that each construct their own payload.
+**Applies to**: connection credentials/config shape validators (`plugin.register` validators), adapter factories in `libs/integrations/**`, FE connection-wizard schemas in `apps/web/src/features/connections/`.
+**Source**: #1318 / PR #1319.

--- a/libs/integrations/ksef/src/application/factories/__tests__/ksef-adapter.factory.spec.ts
+++ b/libs/integrations/ksef/src/application/factories/__tests__/ksef-adapter.factory.spec.ts
@@ -63,11 +63,26 @@ describe('KsefAdapterFactory', () => {
     expect(adapters.invoicing).toBeDefined();
   });
 
-  it('should throw when the seller profile is missing', async () => {
+  it('should throw when the seller profile is missing (context NIP unresolvable)', async () => {
     const factory = new KsefAdapterFactory();
     await expect(
       factory.createAdapters(
         connection({ config: { env: 'test' } }),
+        idMapping,
+        resolver({
+          'ref:ksef': { authType: 'ksef-token', secret: 'super-secret-token' },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(KsefConfigException);
+  });
+
+  it('should throw when the seller profile has a NIP but a malformed address', async () => {
+    // NIP present → resolveContextNip passes; the rejection must come from
+    // resolveSeller's own guard, which runs after the auth material is built.
+    const factory = new KsefAdapterFactory();
+    await expect(
+      factory.createAdapters(
+        connection({ config: { env: 'test', seller: { nip: '1234567890', name: 'Acme Sp. z o.o.' } } }),
         idMapping,
         resolver({
           'ref:ksef': { authType: 'ksef-token', secret: 'super-secret-token' },

--- a/libs/integrations/ksef/src/application/factories/__tests__/ksef-adapter.factory.spec.ts
+++ b/libs/integrations/ksef/src/application/factories/__tests__/ksef-adapter.factory.spec.ts
@@ -57,8 +57,7 @@ describe('KsefAdapterFactory', () => {
       connection(),
       idMapping,
       resolver({
-        'ref:ksef': { authType: 'ksef-token', secretRef: 'ref:secret' },
-        'ref:secret': { token: 'TKN', contextNip: '1234567890' },
+        'ref:ksef': { authType: 'ksef-token', secret: 'super-secret-token' },
       }),
     );
     expect(adapters.invoicing).toBeDefined();
@@ -71,8 +70,7 @@ describe('KsefAdapterFactory', () => {
         connection({ config: { env: 'test' } }),
         idMapping,
         resolver({
-          'ref:ksef': { authType: 'ksef-token', secretRef: 'ref:secret' },
-          'ref:secret': { token: 'TKN', contextNip: '1234567890' },
+          'ref:ksef': { authType: 'ksef-token', secret: 'super-secret-token' },
         }),
       ),
     ).rejects.toBeInstanceOf(KsefConfigException);
@@ -105,7 +103,7 @@ describe('KsefAdapterFactory', () => {
       factory.createAdapters(
         connection(),
         idMapping,
-        resolver({ 'ref:ksef': { authType: 'qualified-seal', secretRef: 'ref:cert' } }),
+        resolver({ 'ref:ksef': { authType: 'qualified-seal', secret: 'ref:cert' } }),
       ),
     ).rejects.toBeInstanceOf(KsefConfigException);
   });

--- a/libs/integrations/ksef/src/application/factories/__tests__/ksef-adapter.factory.spec.ts
+++ b/libs/integrations/ksef/src/application/factories/__tests__/ksef-adapter.factory.spec.ts
@@ -88,7 +88,7 @@ describe('KsefAdapterFactory', () => {
           'ref:ksef': { authType: 'ksef-token', secret: 'super-secret-token' },
         }),
       ),
-    ).rejects.toBeInstanceOf(KsefConfigException);
+    ).rejects.toThrow(/seller profile/);
   });
 
   it('should throw when the environment is missing/invalid', async () => {

--- a/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
+++ b/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
@@ -120,9 +120,11 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
         connection.id,
       );
     }
+    // Trimmed like resolveContextNip — both consumers (the <ContextNip>
+    // handshake and the FA(3) Podmiot1 block) must see one canonical value.
     return {
-      nip: seller.nip,
-      name: seller.name,
+      nip: seller.nip.trim(),
+      name: seller.name.trim(),
       address: {
         line1: address.line1,
         line2: address.line2 ?? null,

--- a/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
+++ b/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
@@ -182,13 +182,15 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
 
   private resolveContextNip(connection: Connection): string {
     const config = connection.config as Partial<KsefConnectionConfig> | undefined;
-    const nip = config?.seller?.nip;
-    if (typeof nip !== 'string' || nip.trim().length === 0) {
+    const nip = config?.seller?.nip?.trim();
+    if (!nip) {
       throw new KsefConfigException(
         'KSeF connection has no seller NIP configured (required as the session context identifier)',
         connection.id,
       );
     }
+    // Trimmed — the value lands verbatim in the <ContextNip> XML element, so a
+    // hand-edited config row with stray whitespace must not leak into the handshake.
     return nip;
   }
 }

--- a/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
+++ b/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
@@ -45,12 +45,6 @@ import type { IKsefAdapterFactory, KsefAdapters } from '../interfaces/ksef-adapt
 
 export type { KsefAdapters };
 
-/** Resolved ksef-token secret shape behind `secretRef` (host-decrypted). */
-interface KsefResolvedTokenSecret {
-  token: string;
-  contextNip: string;
-}
-
 export class KsefAdapterFactory implements IKsefAdapterFactory {
   constructor(private readonly cache?: CachePort) {}
 
@@ -61,7 +55,7 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
   ): Promise<KsefAdapters> {
     const env = this.resolveEnvironment(connection);
     const credentials = await this.resolveCredentials(connection, credentialsResolver);
-    const authMaterial = await this.resolveAuthMaterial(connection, credentials, credentialsResolver);
+    const authMaterial = this.resolveAuthMaterial(connection, credentials);
 
     const seller = this.resolveSeller(connection);
     const defaultTaxRate = this.resolveDefaultTaxRate(connection);
@@ -160,17 +154,21 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
       throw new KsefConfigException('KSeF connection has no credentialsRef', connection.id);
     }
     const credentials = await credentialsResolver.get<KsefCredentials>(connection.credentialsRef);
-    if (!credentials?.authType || !credentials?.secretRef) {
-      throw new KsefConfigException('KSeF credentials missing authType or secretRef', connection.id);
+    if (!credentials?.authType || !credentials?.secret) {
+      throw new KsefConfigException('KSeF credentials missing authType or secret', connection.id);
     }
     return credentials;
   }
 
-  private async resolveAuthMaterial(
-    connection: Connection,
-    credentials: KsefCredentials,
-    credentialsResolver: CredentialsResolverPort,
-  ): Promise<KsefTokenAuthMaterial> {
+  /**
+   * Builds the token auth material from the single resolved credentials
+   * payload. `contextNip` is the KSeF session-context identifier the XML
+   * handshake requires — sourced from the connection's seller profile
+   * (`config.seller.nip`, already collected by the setup wizard) rather than a
+   * second credentials lookup: KSeF's context NIP is normally the seller's own
+   * NIP, and there is no separate secret carrying it.
+   */
+  private resolveAuthMaterial(connection: Connection, credentials: KsefCredentials): KsefTokenAuthMaterial {
     if (credentials.authType !== 'ksef-token') {
       // Qualified-seal needs real X.509/HSM material — deferred to C4.
       throw new KsefConfigException(
@@ -178,10 +176,19 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
         connection.id,
       );
     }
-    const secret = await credentialsResolver.get<KsefResolvedTokenSecret>(credentials.secretRef);
-    if (!secret?.token || !secret?.contextNip) {
-      throw new KsefConfigException('KSeF token secret missing token or contextNip', connection.id);
+    const contextNip = this.resolveContextNip(connection);
+    return { authType: 'ksef-token', token: credentials.secret, contextNip };
+  }
+
+  private resolveContextNip(connection: Connection): string {
+    const config = connection.config as Partial<KsefConnectionConfig> | undefined;
+    const nip = config?.seller?.nip;
+    if (typeof nip !== 'string' || nip.trim().length === 0) {
+      throw new KsefConfigException(
+        'KSeF connection has no seller NIP configured (required as the session context identifier)',
+        connection.id,
+      );
     }
-    return { authType: 'ksef-token', token: secret.token, contextNip: secret.contextNip };
+    return nip;
   }
 }

--- a/libs/integrations/ksef/src/domain/exceptions/ksef-config.exception.ts
+++ b/libs/integrations/ksef/src/domain/exceptions/ksef-config.exception.ts
@@ -2,8 +2,9 @@
  * KSeF Config Exception
  *
  * Thrown for a programmer/config error surfaced before any request leaves the
- * client (C3) — a missing `credentialsRef`, an unresolvable `secretRef`, or an
- * unrecognised environment on a pre-existing connection row. Distinct from
+ * client (C3) — a missing `credentialsRef`, a malformed/empty credential
+ * payload, or an unrecognised environment on a pre-existing connection row.
+ * Distinct from
  * `KsefApiException` (a deterministic HTTP `4xx`) and
  * `KsefAuthenticationException` (a live auth rejection): a config error is not
  * an API response and must not be conflated with retry/auth-failure classifier

--- a/libs/integrations/ksef/src/domain/types/ksef-connection.types.ts
+++ b/libs/integrations/ksef/src/domain/types/ksef-connection.types.ts
@@ -65,8 +65,9 @@ export interface KsefConnectionConfig {
 
 /**
  * Credentials shape resolved via `CredentialsResolverPort` (C3). `secret` is
- * the raw authentication secret (KSeF authorization token, or a qualified-seal
- * reference) the operator supplies through the connection wizard; the host
+ * the raw authentication secret the operator supplies through the connection
+ * wizard — for `ksef-token` the KSeF authorization token; for `qualified-seal`
+ * a placeholder until C4 defines the seal material shape. The host
  * persists it in the integration credentials store behind `connection.credentialsRef`
  * and hands it back verbatim at adapter construction. There is no second,
  * nested credentials indirection — the resolver call on `credentialsRef` is

--- a/libs/integrations/ksef/src/domain/types/ksef-connection.types.ts
+++ b/libs/integrations/ksef/src/domain/types/ksef-connection.types.ts
@@ -4,9 +4,10 @@
  * Per-connection non-secret config + credentials shapes for the KSeF plugin.
  * These are adapter-internal (the only place provider-specific terminology is
  * allowed per ADR-026); core never sees them. The config carries the target
- * KSeF environment; credentials carry the authentication mode plus an opaque
- * `secretRef` the host's `CredentialsResolverPort` resolves at adapter boot
- * (C3) — the secret value itself is never stored on the connection.
+ * KSeF environment; credentials carry the authentication mode plus the raw
+ * `secret` the host's `CredentialsResolverPort` resolves (as the full
+ * credentials payload behind `connection.credentialsRef`) at adapter boot
+ * (C3) — the secret value itself is never stored on the connection row.
  *
  * @module libs/integrations/ksef/src/domain/types
  */
@@ -22,7 +23,7 @@ export type KsefEnvironment = (typeof KsefEnvironmentValues)[number];
 /**
  * Authentication mode for a KSeF connection. `ksef-token` is the static
  * authorization-token flow; `qualified-seal` is the X.509 qualified-seal
- * signing flow. The concrete credential material lives behind `secretRef`,
+ * signing flow. The concrete credential material lives in `KsefCredentials.secret`,
  * resolved at adapter construction (C3) — never on the connection row.
  */
 export const KsefAuthTypeValues = ['ksef-token', 'qualified-seal'] as const;
@@ -63,11 +64,15 @@ export interface KsefConnectionConfig {
 }
 
 /**
- * Credentials shape resolved via `CredentialsResolverPort` (C3). `secretRef` is
- * an opaque reference (e.g. a vault/secret-store key) — never the secret value
- * itself; validators check only that it is a non-empty string.
+ * Credentials shape resolved via `CredentialsResolverPort` (C3). `secret` is
+ * the raw authentication secret (KSeF authorization token, or a qualified-seal
+ * reference) the operator supplies through the connection wizard; the host
+ * persists it in the integration credentials store behind `connection.credentialsRef`
+ * and hands it back verbatim at adapter construction. There is no second,
+ * nested credentials indirection — the resolver call on `credentialsRef` is
+ * the only lookup.
  */
 export interface KsefCredentials {
   authType: KsefAuthType;
-  secretRef: string;
+  secret: string;
 }

--- a/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-connection-credentials-shape-validator.adapter.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-connection-credentials-shape-validator.adapter.spec.ts
@@ -1,7 +1,7 @@
 /**
  * KSeF Connection Credentials Shape Validator — unit tests
  *
- * Verifies the `authType` enum check + non-empty opaque `secretRef`, the
+ * Verifies the `authType` enum check + non-empty `secret`, the
  * `InvalidCredentialsShapeException` rejection path, and that the secret value
  * is never echoed (#1144).
  *
@@ -13,45 +13,45 @@ import { KsefConnectionCredentialsShapeValidatorAdapter } from '../ksef-connecti
 describe('KsefConnectionCredentialsShapeValidatorAdapter', () => {
   const validator = new KsefConnectionCredentialsShapeValidatorAdapter();
 
-  it('should resolve for a ksef-token authType with a non-empty secretRef', async () => {
+  it('should resolve for a ksef-token authType with a non-empty secret', async () => {
     await expect(
-      validator.validate({ authType: 'ksef-token', secretRef: 'vault://ksef/token' }),
+      validator.validate({ authType: 'ksef-token', secret: 'super-secret-token' }),
     ).resolves.toBeUndefined();
   });
 
-  it('should resolve for a qualified-seal authType with a non-empty secretRef', async () => {
+  it('should resolve for a qualified-seal authType with a non-empty secret', async () => {
     await expect(
-      validator.validate({ authType: 'qualified-seal', secretRef: 'vault://ksef/seal' }),
+      validator.validate({ authType: 'qualified-seal', secret: 'super-secret-seal' }),
     ).resolves.toBeUndefined();
   });
 
   it('should reject when authType is missing', async () => {
-    await expect(validator.validate({ secretRef: 'vault://ksef/token' })).rejects.toBeInstanceOf(
+    await expect(validator.validate({ secret: 'super-secret-token' })).rejects.toBeInstanceOf(
       InvalidCredentialsShapeException,
     );
   });
 
   it('should reject when authType is an unknown value', async () => {
     await expect(
-      validator.validate({ authType: 'oauth', secretRef: 'vault://ksef/token' }),
+      validator.validate({ authType: 'oauth', secret: 'super-secret-token' }),
     ).rejects.toBeInstanceOf(InvalidCredentialsShapeException);
   });
 
   it('should reject when authType is not a string', async () => {
     await expect(
-      validator.validate({ authType: 7, secretRef: 'vault://ksef/token' }),
+      validator.validate({ authType: 7, secret: 'super-secret-token' }),
     ).rejects.toBeInstanceOf(InvalidCredentialsShapeException);
   });
 
-  it('should reject when secretRef is missing', async () => {
+  it('should reject when secret is missing', async () => {
     await expect(validator.validate({ authType: 'ksef-token' })).rejects.toBeInstanceOf(
       InvalidCredentialsShapeException,
     );
   });
 
-  it('should reject when secretRef is an empty/whitespace string', async () => {
+  it('should reject when secret is an empty/whitespace string', async () => {
     await expect(
-      validator.validate({ authType: 'ksef-token', secretRef: '   ' }),
+      validator.validate({ authType: 'ksef-token', secret: '   ' }),
     ).rejects.toBeInstanceOf(InvalidCredentialsShapeException);
   });
 
@@ -59,12 +59,12 @@ describe('KsefConnectionCredentialsShapeValidatorAdapter', () => {
     await expect(validator.validate({})).rejects.toMatchObject({ pluginName: 'KSeF' });
   });
 
-  it('should never echo the secretRef value in the error message', async () => {
-    const secret = 'super-secret-ref-value';
-    // authType invalid → rejects before secretRef is even read; assert the
+  it('should never echo the secret value in the error message', async () => {
+    const secret = 'super-secret-value';
+    // authType invalid → rejects before secret is even read; assert the
     // secret never leaks regardless.
     await expect(
-      validator.validate({ authType: 'oauth', secretRef: secret }),
+      validator.validate({ authType: 'oauth', secret }),
     ).rejects.toMatchObject({
       message: expect.not.stringContaining(secret),
     });

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-connection-credentials-shape-validator.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-connection-credentials-shape-validator.adapter.ts
@@ -3,19 +3,21 @@
  *
  * Validates the credentials payload for a KSeF connection: an `authType`
  * selecting the authentication mode (`ksef-token` | `qualified-seal`) and a
- * non-empty opaque `secretRef`. The `secretRef` is a reference resolved at
- * adapter construction (C3) via the host `CredentialsResolverPort` — never the
- * secret value itself, so the validator checks only that it is present and
- * non-empty and NEVER echoes its value. Registered against
- * `ConnectionCredentialsShapeValidatorRegistryService` at `ksef.publicapi.v2`;
- * `ConnectionService` maps the thrown exception to a 400 at the API boundary.
+ * non-empty `secret` — the raw authentication secret the operator pastes into
+ * the connection wizard. The host persists this payload behind
+ * `connection.credentialsRef` and hands it back verbatim at adapter
+ * construction (C3) via the host `CredentialsResolverPort`; the validator
+ * checks only that `secret` is present and non-empty and NEVER echoes its
+ * value. Registered against `ConnectionCredentialsShapeValidatorRegistryService`
+ * at `ksef.publicapi.v2`; `ConnectionService` maps the thrown exception to a
+ * 400 at the API boundary.
  *
  * Validating shape BEFORE persistence keeps malformed credentials out of the
- * DB so a connection can never reach C3 with an unresolvable credential.
+ * DB so a connection can never reach C3 with an unusable credential.
  *
  * Hand-rolled (no class-validator) to stay dependency-light. Error detail uses
  * neutral terminology only (no Polish tax vocabulary) and never includes the
- * `secretRef` value.
+ * `secret` value.
  *
  * @module libs/integrations/ksef/src/infrastructure/adapters
  * @see {@link ConnectionCredentialsShapeValidatorPort}
@@ -40,9 +42,9 @@ export class KsefConnectionCredentialsShapeValidatorAdapter
       return this.reject(`authType must be one of: ${KsefAuthTypeValues.join(', ')}`);
     }
 
-    const secretRef = credentials.secretRef;
-    if (typeof secretRef !== 'string' || secretRef.trim().length === 0) {
-      return this.reject('must include a non-empty `secretRef` string');
+    const secret = credentials.secret;
+    if (typeof secret !== 'string' || secret.trim().length === 0) {
+      return this.reject('must include a non-empty `secret` string');
     }
 
     return Promise.resolve();


### PR DESCRIPTION
## Summary

- KSeF connection creation always failed with `BadRequestException: Invalid KSeF credentials: must include a non-empty \`secretRef\` string` because three layers disagreed on the credentials shape: the FE form sends `{authType, secret}`, the credentials-shape validator required `secretRef`, and the adapter factory assumed an unreachable second credentials indirection that nothing in the system ever populates.
- Renames `KsefCredentials.secretRef` to `secret`, updates the shape validator to match, and removes the dead second-resolver call in `ksef-adapter.factory.ts` - `contextNip` (needed for the KSeF XML handshake) is now sourced from `connection.config.seller.nip`, which the setup form already collects.
- No FE changes needed; `ksef-setup.schema.ts` already sent the correct shape.

Closes #1318

## Test plan

- [x] `pnpm --filter @openlinker/integrations-ksef type-check` - clean
- [x] `pnpm --filter @openlinker/integrations-ksef test` - all 26 suites / 274 tests pass, including an end-to-end factory-creation test exercising `{authType: 'ksef-token', secret: '...'}` through `createAdapters` with no exception thrown
- [x] Confirmed no other package (`apps/api`, `apps/worker`) references `secretRef`/`KsefCredentials`/`KsefResolvedTokenSecret`

## Back-compat note

Wizard-created connections never worked with the old shape, so there is nothing to migrate for them. However, any **hand-provisioned** credential row in the old `{ authType, secretRef }` + nested-secret shape (e.g. rows created during early E2E testing) will now fail at adapter boot with `KsefConfigException: KSeF credentials missing authType or secret`. The fix is to re-save the connection credentials through the wizard (or re-provision the row as `{ authType, secret }`).
