### PR TITLE
fix(infakt): implement real PDF download via RegulatoryDocumentReader

### DIFF
--- a/apps/web/src/features/invoicing/hooks/use-invoice-rendered-document-download.ts
+++ b/apps/web/src/features/invoicing/hooks/use-invoice-rendered-document-download.ts
@@ -1,0 +1,82 @@
+/**
+ * useInvoiceRenderedDocumentDownload
+ *
+ * One-shot action (NOT a TanStack mutation) that fetches the provider's
+ * server-rendered document (`kind=rendered` — e.g. Infakt's PDF, #1321) via
+ * `apiClient.invoicing.downloadDocument(id, 'rendered')` and triggers a
+ * browser download. Mirrors `useKsefUpoDownload`'s shape exactly; kept as a
+ * separate hook (rather than generalizing `useKsefUpoDownload`) because that
+ * hook is scoped to the dedicated `/upo` route, while this one goes through
+ * the neutral `/document?kind=rendered` route any provider can serve.
+ *
+ * Neutral: keyed on the internal `invoice.id`, never on platform type (ADR-026).
+ * Lives in `features/invoicing/hooks/` so it can use `useApiClient` freely;
+ * per-provider `invoiceDetailSection` slots import it from the
+ * `features/invoicing` barrel (dep direction: plugins/* → features/invoicing
+ * is explicitly allowed).
+ *
+ * @module features/invoicing/hooks
+ */
+import { useCallback, useState } from 'react';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+const EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
+  'application/pdf': 'pdf',
+  'text/html': 'html',
+};
+
+function extensionForBlob(blob: Blob): string {
+  const mime = blob.type.toLowerCase().split(';', 1)[0]?.trim() ?? '';
+  return EXTENSION_BY_MIME[mime] ?? 'bin';
+}
+
+/**
+ * Trigger a browser download for an already-fetched blob via an in-memory
+ * object URL + a programmatic `<a download>` click. Defers `revokeObjectURL`
+ * past the current tick — some engines cancel the in-flight download if the
+ * URL is revoked synchronously after `click()`.
+ */
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+}
+
+interface UseInvoiceRenderedDocumentDownload {
+  /** Fetch + trigger the browser download. Resolves `true` on success, `false`
+   *  when the fetch failed (the error is also exposed via `error`). */
+  download: (invoiceId: string) => Promise<boolean>;
+  isDownloading: boolean;
+  error: Error | null;
+}
+
+export function useInvoiceRenderedDocumentDownload(): UseInvoiceRenderedDocumentDownload {
+  const apiClient = useApiClient();
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const download = useCallback(
+    async (invoiceId: string): Promise<boolean> => {
+      setIsDownloading(true);
+      setError(null);
+      try {
+        const blob = await apiClient.invoicing.downloadDocument(invoiceId, 'rendered');
+        triggerBlobDownload(blob, `ol-invoice-${invoiceId}.${extensionForBlob(blob)}`);
+        return true;
+      } catch (caught) {
+        setError(caught instanceof Error ? caught : new Error(String(caught)));
+        return false;
+      } finally {
+        setIsDownloading(false);
+      }
+    },
+    [apiClient],
+  );
+
+  return { download, isDownloading, error };
+}

--- a/apps/web/src/features/invoicing/index.ts
+++ b/apps/web/src/features/invoicing/index.ts
@@ -31,6 +31,7 @@ export { useKsefUpoPreview } from './hooks/use-ksef-upo-preview';
 export type { UpoPreviewKind } from './hooks/use-ksef-upo-preview';
 export { useKsefUpoDownload } from './hooks/use-ksef-upo-download';
 export { useKsefFa3 } from './hooks/use-ksef-fa3';
+export { useInvoiceRenderedDocumentDownload } from './hooks/use-invoice-rendered-document-download';
 export { invoicingQueryKeys } from './api/invoicing.query-keys';
 export type {
   InvoiceRecord,

--- a/apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.test.tsx
+++ b/apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.test.tsx
@@ -3,9 +3,9 @@
  *
  * @module plugins/infakt/components
  */
-import { cleanup, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
-import { renderWithProviders, sampleConnection } from '../../../test/test-utils';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
 import type { InvoiceRecord } from '../../../features/invoicing/api/invoicing.types';
 import { InfaktInvoiceDetailSection } from './infakt-invoice-detail-section';
 
@@ -120,5 +120,30 @@ describe('InfaktInvoiceDetailSection', () => {
       />,
     );
     expect(await screen.findByText('KSeF rejected this invoice.')).toBeInTheDocument();
+  });
+
+  it('calls downloadDocument with kind=rendered when Download PDF is clicked', async () => {
+    URL.createObjectURL = vi.fn(() => 'blob:mock');
+    URL.revokeObjectURL = vi.fn();
+    const downloadDocument = vi
+      .fn()
+      .mockResolvedValue(new Blob(['%PDF'], { type: 'application/pdf' }));
+    const apiClient = createMockApiClient({ invoicing: { downloadDocument } });
+
+    renderWithProviders(
+      <InfaktInvoiceDetailSection
+        invoice={makeInvoice({
+          regulatoryStatus: 'accepted',
+          clearanceReference: '5260001246-20260625-A1B2-3D',
+        })}
+        connection={infaktConnection}
+      />,
+      { apiClient },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
+    await waitFor(() =>
+      expect(downloadDocument).toHaveBeenCalledWith('ol_invoice_test', 'rendered'),
+    );
   });
 });

--- a/apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.tsx
+++ b/apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.tsx
@@ -4,9 +4,10 @@
  * Per-provider `invoiceDetailSection` slot for inFakt connections (#1282).
  * inFakt submits invoices to KSeF on OpenLinker's behalf and reports back
  * clearance status — OpenLinker only reads the neutral `regulatoryStatus`,
- * it never talks to KSeF directly for this provider (mirrors Subiekt's
- * read-only posture more closely than KSeF's own UPO/FA3-owning section,
- * since inFakt exposes no UPO/FA3 document endpoints of its own).
+ * it never talks to KSeF directly for this provider. inFakt exposes no
+ * UPO/FA3 document endpoints of its own, but it does render a PDF of the
+ * invoice server-side (#1321) — the "Download PDF" action below hits the
+ * neutral `RegulatoryDocumentReader`-backed `/document?kind=rendered` route.
  *
  * Uses the shared `.reg-card` severity-stripe treatment (#1282) directly —
  * inFakt ships with the redesigned look from day one.
@@ -16,19 +17,40 @@
 import type { ReactElement } from 'react';
 import { useTranslation } from '../../../shared/i18n';
 import { CopyableId } from '../../../shared/ui/copyable-id';
+import { Button } from '../../../shared/ui/button';
+import { useToast } from '../../../shared/ui/toast-provider';
 import type { InvoiceDetailSectionProps } from '../../../shared/plugins/plugin.types';
-import { RegulatoryStatusBadge, regCardToneFor } from '../../../features/invoicing';
+import {
+  RegulatoryStatusBadge,
+  regCardToneFor,
+  useInvoiceRenderedDocumentDownload,
+} from '../../../features/invoicing';
 
 export function InfaktInvoiceDetailSection({
   invoice,
 }: InvoiceDetailSectionProps): ReactElement | null {
   const { t } = useTranslation();
+  const pdfDownload = useInvoiceRenderedDocumentDownload();
+  const { showToast } = useToast();
 
   if (invoice.regulatoryStatus === 'not-applicable') {
     return null;
   }
 
   const ksefNumber = invoice.clearanceReference ?? invoice.providerInvoiceNumber ?? null;
+
+  async function handleDownloadPdf(): Promise<void> {
+    const ok = await pdfDownload.download(invoice.id);
+    if (!ok) {
+      showToast({
+        tone: 'error',
+        title: t('infakt.invoice.detail.pdfDownloadFailed', 'PDF download failed'),
+        description:
+          pdfDownload.error?.message ??
+          t('infakt.invoice.detail.pdfDownloadFailedDesc', 'Could not fetch the invoice PDF.'),
+      });
+    }
+  }
 
   return (
     <section className={`invoice-detail-section reg-card ${regCardToneFor(invoice.regulatoryStatus)}`.trim()}>
@@ -60,6 +82,16 @@ export function InfaktInvoiceDetailSection({
               {t('infakt.invoice.detail.numberPending', 'KSeF number pending')}
             </span>
           )}
+          <Button
+            tone="ghost"
+            className="button--sm"
+            onClick={() => void handleDownloadPdf()}
+            disabled={pdfDownload.isDownloading}
+          >
+            {pdfDownload.isDownloading
+              ? t('infakt.invoice.detail.pdfDownloading', 'Downloading…')
+              : t('infakt.invoice.detail.pdfDownload', 'Download PDF')}
+          </Button>
         </div>
       ) : null}
 

--- a/docs/plans/implementation-plan-infakt-pdf-download.md
+++ b/docs/plans/implementation-plan-infakt-pdf-download.md
@@ -1,0 +1,82 @@
+# Implementation Plan — Infakt real PDF download (#1321)
+
+## 1. Task
+
+Fix `InfaktInvoicingAdapter`'s always-null `pdfUrl` by implementing the existing
+`RegulatoryDocumentReader` sub-capability against Infakt's real PDF endpoint
+(`GET /invoices/{uuid}/pdf.json?document_type=original&invoice_type={kind}`,
+verified live against the sandbox). Wire the FE Infakt invoice detail section to
+the already-existing `GET /invoices/:invoiceId/document?kind=rendered` route.
+
+**Layer**: Integration (Infakt adapter) + Frontend (Infakt plugin detail section).
+**Non-goals**: no new sub-capability, no new controller route (the `/document`
+route + `isRegulatoryDocumentReader` dispatch already exist and are unchanged),
+no operator-configurable `document_type` (hardcode `'original'` for v1), no
+change to Subiekt's `pdfUrl` usage (out of scope — Subiekt is FE-only today and
+untouched by this fix).
+
+## 2. Decision: keep `InvoiceRecord.pdfUrl`
+
+Subiekt's FE detail section (`apps/web/src/plugins/subiekt/components/subiekt-invoice-detail-section.tsx`)
+still reads `invoice.pdfUrl` for its own (separate, unverified) PDF link. Removing
+the field core-wide would break that component's types for no benefit to this
+issue's scope. **Decision: keep `pdfUrl` on `InvoiceRecord`, but stop Infakt from
+populating it with a nonexistent field** — pass `null` explicitly at the 3 call
+sites, with a comment explaining Infakt's real PDF path is now
+`RegulatoryDocumentReader.getRegulatoryDocument(record, 'rendered')`, not this
+field. Also drop the dead `print_url` field from the Infakt DTO type (never read).
+
+## 3. Backend changes
+
+1. `libs/integrations/infakt/src/infrastructure/http/infakt-http-client.interface.ts`
+   — add `getBinary(path, query?): Promise<{ data: Uint8Array; contentType: string }>`.
+2. `libs/integrations/infakt/src/infrastructure/http/infakt-http-client.ts`
+   — implement `getBinary` via `fetch` + a capped streaming read (mirrors
+   `KsefHttpClient.readBinaryBodyCapped`'s 10 MB cap — same defense-in-depth
+   rationale: never fully buffer a mendacious/oversized body).
+3. `libs/integrations/infakt/src/domain/types/infakt.types.ts` — remove the dead
+   `pdf_url` / `print_url` fields from `InfaktInvoice`.
+4. `libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts`
+   — add `RegulatoryDocumentReader` to the `implements` clause; implement
+   `getRegulatoryDocument(record, kind)`: throws `UnsupportedRegulatoryDocumentKindError`
+   for any kind other than `'rendered'` (Infakt has no UPO/confirmation of its
+   own — it submits to KSeF natively and OL never touches that document), else
+   calls `getBinary('invoices/{providerInvoiceId}/pdf.json', { document_type: 'original', invoice_type: toInfaktInvoiceType(record.documentType) })`.
+   Replace the 3 `invoice.pdf_url ?? null` call sites with `null` + explanatory comment.
+5. Unit tests: `infakt-invoicing.adapter.spec.ts` — new `getRegulatoryDocument`
+   describe block (happy path returns bytes+contentType; unsupported kind throws).
+   `infakt-http-client.spec.ts` — new `getBinary` test (happy path + oversized-body cap).
+
+## 4. Frontend changes
+
+1. `apps/web/src/features/invoicing/hooks/use-invoice-rendered-document-download.ts`
+   (new) — mirrors `useKsefUpoDownload`'s shape (`{ download, isDownloading, error }`),
+   calling `apiClient.invoicing.downloadDocument(invoiceId, 'rendered')` (already
+   exists on the API client — no client change needed) and triggering a browser
+   download. Neutral (kind-agnostic naming) so any future `rendered`-only
+   provider can reuse it, not just Infakt.
+2. Export it from `features/invoicing/index.ts` barrel.
+3. `apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.tsx`
+   — add a "Download PDF" button gated on `invoice.regulatoryStatus === 'accepted'`
+   (mirrors KSeF's UPO-availability gating), wired to the new hook. Update the
+   file's header comment (currently says Infakt "exposes no UPO/FA3 document
+   endpoints of its own" — still true for confirmation/source, but no longer
+   true for a rendered PDF).
+4. Tests: `infakt-invoice-detail-section.test.tsx` — new case asserting the
+   download button appears when accepted and calls the mocked API client.
+
+## 5. Validation
+
+- `pnpm --filter @openlinker/integrations-infakt test`
+- `pnpm --filter @openlinker/web test -- infakt-invoice-detail-section`
+- `pnpm lint && pnpm type-check` (scoped packages first, full run before PR)
+- Manual: re-verify against the sandbox that `GET /invoices/{uuid}/pdf.json?document_type=original&invoice_type=vat` still returns a valid PDF (already done ad hoc in this session).
+
+## Pre-implement gate: skipped
+
+This is a self-contained fix reusing an existing, unmodified capability
+(`RegulatoryDocumentReader`), an existing, unmodified controller route
+(`GET /invoices/:invoiceId/document`), and an existing, unmodified FE API
+client method (`downloadDocument`). No new port, DI token, ORM entity, or
+contract-surface change is introduced, so there is no reuse-collision or
+contract-break surface for `/pre-implement` to catch.

--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -72,8 +72,6 @@ export interface InfaktInvoice {
   client_id: number | null;
   client_uuid: string | null;
   services: InfaktInvoiceService[];
-  print_url: string | null;
-  pdf_url: string | null;
 }
 
 /** One line item on an Infakt invoice. */

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -11,7 +11,11 @@
  * @module libs/integrations/infakt/src/infrastructure/adapters/__tests__
  */
 import type { LoggerPort } from '@openlinker/shared/logging';
-import { BuyerProfile, InvoiceRecord } from '@openlinker/core/invoicing';
+import {
+  BuyerProfile,
+  InvoiceRecord,
+  UnsupportedRegulatoryDocumentKindError,
+} from '@openlinker/core/invoicing';
 import type { IssueInvoiceCommand, IssueCorrectionCommand } from '@openlinker/core/invoicing';
 import { InfaktInvoicingAdapter, INFAKT_PROVIDER_TYPE } from '../infakt-invoicing.adapter';
 import { InfaktApiError } from '../../../domain/exceptions/infakt-api.error';
@@ -74,8 +78,6 @@ function invoiceFixture(overrides: Partial<InfaktInvoice> = {}): InfaktInvoice {
         group: null,
       },
     ],
-    print_url: null,
-    pdf_url: 'https://infakt.pl/inv-uuid-1.pdf',
     ...overrides,
   };
 }
@@ -259,7 +261,9 @@ describe('InfaktInvoicingAdapter', () => {
       expect(record.providerInvoiceNumber).toBe('FV/1/2026');
       expect(record.status).toBe('issued');
       expect(record.idempotencyKey).toBe('idem-1');
-      expect(record.pdfUrl).toBe('https://infakt.pl/inv-uuid-1.pdf');
+      // Infakt's invoice resource carries no `pdf_url` field (#1321) — the
+      // real PDF is served via `RegulatoryDocumentReader.getRegulatoryDocument`.
+      expect(record.pdfUrl).toBeNull();
       // KSeF submission is inline now — the record reflects the send_to_ksef
       // response, not the (necessarily stale, pre-submission) invoice payload.
       expect(record.regulatoryStatus).toBe('submitted');
@@ -616,6 +620,70 @@ describe('InfaktInvoicingAdapter', () => {
         failureMode: 'in-doubt',
         statusCode: 500,
       });
+    });
+  });
+
+  describe('getRegulatoryDocument', () => {
+    function recordFixture(): InvoiceRecord {
+      const now = new Date('2026-07-01T12:00:00Z');
+      return new InvoiceRecord(
+        'record-1',
+        'conn-1',
+        'order-1',
+        INFAKT_PROVIDER_TYPE,
+        'invoice',
+        'issued',
+        'inv-uuid-1',
+        'FV/1/2026',
+        'accepted',
+        'ksef-number-1',
+        'idem-1',
+        null,
+        now,
+        null,
+        now,
+        now,
+      );
+    }
+
+    it('should fetch the PDF via the dedicated pdf.json endpoint (happy path)', async () => {
+      const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // "%PDF"
+      http.seedBinary('invoices/inv-uuid-1/pdf.json', {
+        data: pdfBytes,
+        contentType: 'application/pdf',
+      });
+
+      const document = await adapter.getRegulatoryDocument(recordFixture(), 'rendered');
+
+      expect(document.content).toBe(pdfBytes);
+      expect(document.contentType).toBe('application/pdf');
+      const call = http.calls.find(
+        (c) => c.method === 'GET_BINARY' && c.path === 'invoices/inv-uuid-1/pdf.json',
+      );
+      expect(call?.query).toEqual({ document_type: 'original', invoice_type: 'vat' });
+    });
+
+    it('should default to application/pdf when Infakt reports no content type', async () => {
+      http.seedBinary('invoices/inv-uuid-1/pdf.json', {
+        data: new Uint8Array([1, 2, 3]),
+        contentType: '',
+      });
+
+      const document = await adapter.getRegulatoryDocument(recordFixture(), 'rendered');
+
+      expect(document.contentType).toBe('application/pdf');
+    });
+
+    it('should throw UnsupportedRegulatoryDocumentKindError for confirmation (Infakt has no UPO of its own)', async () => {
+      await expect(
+        adapter.getRegulatoryDocument(recordFixture(), 'confirmation'),
+      ).rejects.toBeInstanceOf(UnsupportedRegulatoryDocumentKindError);
+    });
+
+    it('should throw UnsupportedRegulatoryDocumentKindError for source', async () => {
+      await expect(
+        adapter.getRegulatoryDocument(recordFixture(), 'source'),
+      ).rejects.toBeInstanceOf(UnsupportedRegulatoryDocumentKindError);
     });
   });
 });

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -28,12 +28,15 @@ import type {
   IssueInvoiceResult,
   InvoicingPort,
   RegulatoryClearanceResult,
+  RegulatoryDocument,
+  RegulatoryDocumentKind,
+  RegulatoryDocumentReader,
   RegulatoryStatus,
   RegulatoryStatusReader,
   UpsertCustomerCommand,
   UpsertCustomerResult,
 } from '@openlinker/core/invoicing';
-import { InvoiceRecord } from '@openlinker/core/invoicing';
+import { InvoiceRecord, UnsupportedRegulatoryDocumentKindError } from '@openlinker/core/invoicing';
 import type { IInfaktHttpClient } from '../http/infakt-http-client.interface';
 import { InfaktApiError } from '../../domain/exceptions/infakt-api.error';
 import type {
@@ -167,7 +170,7 @@ function fromGroszy(amountGroszy: number): number {
 }
 
 export class InfaktInvoicingAdapter
-  implements InvoicingPort, RegulatoryStatusReader, CorrectionIssuer
+  implements InvoicingPort, RegulatoryStatusReader, CorrectionIssuer, RegulatoryDocumentReader
 {
   constructor(
     private readonly connectionId: string,
@@ -286,7 +289,11 @@ export class InfaktInvoicingAdapter
       toRegulatoryStatus(ksefResult.status),
       ksefResult.ksef_number,
       idempotencyKey ?? null,
-      invoice.pdf_url ?? null,
+      // Infakt's invoice resource carries no `pdf_url` field (verified live
+      // against the sandbox, #1321) — the real PDF path is
+      // `RegulatoryDocumentReader.getRegulatoryDocument(record, 'rendered')`
+      // below, which hits the dedicated `pdf.json` endpoint.
+      null,
       now,
       null,
       now,
@@ -328,7 +335,11 @@ export class InfaktInvoicingAdapter
           toRegulatoryStatus(invoice.ksef_data?.status ?? null),
           invoice.ksef_data?.ksef_number ?? null,
           null,
-          invoice.pdf_url ?? null,
+          // Infakt's invoice resource carries no `pdf_url` field (verified live
+          // against the sandbox, #1321) — the real PDF path is
+          // `RegulatoryDocumentReader.getRegulatoryDocument(record, 'rendered')`
+          // below, which hits the dedicated `pdf.json` endpoint.
+          null,
           invoice.invoice_date ? new Date(invoice.invoice_date) : now,
           null,
           now,
@@ -453,7 +464,11 @@ export class InfaktInvoicingAdapter
       toRegulatoryStatus(ksefResult.status),
       ksefResult.ksef_number,
       idempotencyKey ?? null,
-      invoice.pdf_url ?? null,
+      // Infakt's invoice resource carries no `pdf_url` field (verified live
+      // against the sandbox, #1321) — the real PDF path is
+      // `RegulatoryDocumentReader.getRegulatoryDocument(record, 'rendered')`
+      // below, which hits the dedicated `pdf.json` endpoint.
+      null,
       now,
       null,
       now,
@@ -472,6 +487,34 @@ export class InfaktInvoicingAdapter
       `invoices/${invoiceUuid}/send_to_ksef.json`,
       {},
     );
+  }
+
+  /**
+   * `RegulatoryDocumentReader.getRegulatoryDocument` (#1321) — fetch the
+   * invoice PDF as neutral bytes. Infakt has no `pdf_url` field on the
+   * invoice resource (verified live against the sandbox); the real path is
+   * the dedicated `GET /invoices/{uuid}/pdf.json` endpoint, which returns the
+   * PDF binary directly. Infakt submits to KSeF natively and OL never builds
+   * or holds a KSeF confirmation (UPO) for this provider, so only `rendered`
+   * is supported — `confirmation`/`source` are soft 409s via
+   * `UnsupportedRegulatoryDocumentKindError`, mirroring KSeF's own adapter
+   * rejecting `rendered` the other way around.
+   */
+  async getRegulatoryDocument(
+    record: InvoiceRecord,
+    kind: RegulatoryDocumentKind = 'confirmation',
+  ): Promise<RegulatoryDocument> {
+    if (kind !== 'rendered') {
+      throw new UnsupportedRegulatoryDocumentKindError(kind);
+    }
+    const response = await this.http.getBinary(`invoices/${record.providerInvoiceId}/pdf.json`, {
+      document_type: 'original',
+      invoice_type: toInfaktInvoiceType(record.documentType),
+    });
+    return {
+      content: response.data,
+      contentType: response.contentType.length > 0 ? response.contentType : 'application/pdf',
+    };
   }
 
   // --- helpers ---

--- a/libs/integrations/infakt/src/infrastructure/http/__tests__/infakt-http-client.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/http/__tests__/infakt-http-client.spec.ts
@@ -19,6 +19,30 @@ function fakeResponse(status: number, body: string): Response {
   } as unknown as Response;
 }
 
+/** Fake `Response` exposing a streaming `.body.getReader()` for `getBinary`. */
+function fakeBinaryResponse(status: number, contentType: string, chunks: Uint8Array[]): Response {
+  let index = 0;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: (): Promise<string> => Promise.resolve(''),
+    headers: { get: (name: string): string | null => (name === 'content-type' ? contentType : null) },
+    body: {
+      getReader: () => ({
+        read: (): Promise<{ done: boolean; value?: Uint8Array }> => {
+          if (index < chunks.length) {
+            const value = chunks[index];
+            index += 1;
+            return Promise.resolve({ done: false, value });
+          }
+          return Promise.resolve({ done: true });
+        },
+        cancel: (): Promise<void> => Promise.resolve(),
+      }),
+    },
+  } as unknown as Response;
+}
+
 function fakeLogger(): jest.Mocked<LoggerPort> {
   return {
     log: jest.fn(),
@@ -150,6 +174,38 @@ describe('InfaktHttpClient', () => {
       fetchMock.mockResolvedValue(fakeResponse(404, '{"error":"not found"}'));
       await expect(client.get('invoices/missing.json')).rejects.toBeInstanceOf(InfaktApiError);
       expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('getBinary', () => {
+    it('should stream the response body and report the content type (happy path)', async () => {
+      const chunk1 = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // "%PDF"
+      const chunk2 = new Uint8Array([0x2d, 0x31, 0x2e, 0x34]); // "-1.4"
+      fetchMock.mockResolvedValue(fakeBinaryResponse(200, 'application/pdf', [chunk1, chunk2]));
+
+      const result = await client.getBinary('invoices/abc/pdf.json', { document_type: 'original' });
+
+      expect(result.contentType).toBe('application/pdf');
+      expect(Array.from(result.data)).toEqual([...chunk1, ...chunk2]);
+      const [url] = fetchMock.mock.calls[0] as [string];
+      expect(url).toBe(`${INFAKT_DEFAULT_BASE_URL}/invoices/abc/pdf.json?document_type=original`);
+    });
+
+    it('should throw InfaktApiError on a non-2xx response', async () => {
+      fetchMock.mockResolvedValue(fakeResponse(404, '{"error":"not found"}'));
+      await expect(client.getBinary('invoices/missing/pdf.json')).rejects.toBeInstanceOf(
+        InfaktApiError,
+      );
+    });
+
+    it('should cap the response and throw InfaktApiError past the byte cap', async () => {
+      // Exceeds the client's 10 MB streaming cap in a single oversized chunk.
+      const oversized = new Uint8Array(10 * 1024 * 1024 + 1);
+      fetchMock.mockResolvedValue(fakeBinaryResponse(200, 'application/pdf', [oversized]));
+
+      await expect(client.getBinary('invoices/huge/pdf.json')).rejects.toMatchObject({
+        statusCode: 200,
+      });
     });
   });
 });

--- a/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.interface.ts
+++ b/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.interface.ts
@@ -12,7 +12,15 @@
  *
  * @module libs/integrations/infakt/src/infrastructure/http
  */
+/** Raw bytes + provider-reported content type for a binary (non-JSON) response. */
+export interface InfaktBinaryResponse {
+  data: Uint8Array;
+  contentType: string;
+}
+
 export interface IInfaktHttpClient {
   get<T>(path: string, query?: Record<string, string>): Promise<T>;
   post<T>(path: string, body: unknown): Promise<T>;
+  /** Fetch a binary response (e.g. a PDF) rather than parsing JSON. */
+  getBinary(path: string, query?: Record<string, string>): Promise<InfaktBinaryResponse>;
 }

--- a/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.ts
+++ b/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.ts
@@ -10,7 +10,7 @@
  */
 import type { LoggerPort } from '@openlinker/shared/logging';
 import { InfaktApiError } from '../../domain/exceptions/infakt-api.error';
-import type { IInfaktHttpClient } from './infakt-http-client.interface';
+import type { IInfaktHttpClient, InfaktBinaryResponse } from './infakt-http-client.interface';
 
 export interface InfaktHttpClientConfig {
   apiKey: string;
@@ -18,6 +18,14 @@ export interface InfaktHttpClientConfig {
 }
 
 export const INFAKT_DEFAULT_BASE_URL = 'https://api.infakt.pl/api/v3';
+
+/**
+ * Cap on a binary response body (e.g. an invoice PDF). Mirrors the KSeF HTTP
+ * client's `MAX_BINARY_RESPONSE_BYTES` — the running total is enforced as
+ * chunks stream in, so an oversized or mendacious `Content-Length` can't
+ * drive an unbounded buffered read into memory.
+ */
+const MAX_BINARY_RESPONSE_BYTES = 10 * 1024 * 1024;
 
 export class InfaktHttpClient implements IInfaktHttpClient {
   private readonly baseUrl: string;
@@ -43,6 +51,53 @@ export class InfaktHttpClient implements IInfaktHttpClient {
       body: JSON.stringify(body),
     });
     return this.parse<T>(res, 'POST', path);
+  }
+
+  async getBinary(path: string, query?: Record<string, string>): Promise<InfaktBinaryResponse> {
+    const url = this.buildUrl(path, query);
+    const res = await fetch(url, { headers: this.headers() });
+    if (!res.ok) {
+      const text = await res.text();
+      this.logger.warn(`Infakt API GET ${path} → ${res.status}`);
+      throw new InfaktApiError(
+        `Infakt API GET ${path} failed with status ${res.status}`,
+        res.status,
+        text,
+      );
+    }
+    const data = await this.readBinaryBodyCapped(res, url);
+    return { data, contentType: res.headers.get('content-type') ?? '' };
+  }
+
+  private async readBinaryBodyCapped(res: Response, url: string): Promise<Uint8Array> {
+    const body = res.body;
+    if (!body) {
+      return new Uint8Array(0);
+    }
+    const reader = body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_BINARY_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new InfaktApiError(
+          `Infakt binary response for ${url} exceeds the ${MAX_BINARY_RESPONSE_BYTES}-byte cap`,
+          res.status,
+          null,
+        );
+      }
+      chunks.push(value);
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return bytes;
   }
 
   private buildUrl(path: string, query?: Record<string, string>): string {

--- a/libs/integrations/infakt/src/testing/fake-infakt-http-client.ts
+++ b/libs/integrations/infakt/src/testing/fake-infakt-http-client.ts
@@ -10,10 +10,15 @@
  *
  * @module libs/integrations/infakt/src/testing
  */
-import type { IInfaktHttpClient } from '../infrastructure/http/infakt-http-client.interface';
+import type {
+  IInfaktHttpClient,
+  InfaktBinaryResponse,
+} from '../infrastructure/http/infakt-http-client.interface';
+
+type CallMethod = 'GET' | 'POST' | 'GET_BINARY';
 
 interface RecordedCall {
-  method: 'GET' | 'POST';
+  method: CallMethod;
   path: string;
   query?: Record<string, string>;
   body?: unknown;
@@ -31,8 +36,14 @@ export class FakeInfaktHttpClient implements IInfaktHttpClient {
     return this;
   }
 
-  /** Seed a rejection (e.g. `InfaktApiError`) for `GET path` / `POST path`. */
-  seedError(method: 'GET' | 'POST', path: string, error: Error): this {
+  /** Seed a successful binary response for `getBinary(path)`. */
+  seedBinary(path: string, value: InfaktBinaryResponse): this {
+    this.responses.set(this.key('GET_BINARY', path), { kind: 'resolve', value });
+    return this;
+  }
+
+  /** Seed a rejection (e.g. `InfaktApiError`) for `GET path` / `POST path` / `getBinary(path)`. */
+  seedError(method: CallMethod, path: string, error: Error): this {
     this.responses.set(this.key(method, path), { kind: 'reject', error });
     return this;
   }
@@ -52,7 +63,12 @@ export class FakeInfaktHttpClient implements IInfaktHttpClient {
     return this.resolve<T>('POST', path);
   }
 
-  private resolve<T>(method: 'GET' | 'POST', path: string): Promise<T> {
+  getBinary(path: string, query?: Record<string, string>): Promise<InfaktBinaryResponse> {
+    this.calls.push({ method: 'GET_BINARY', path, query });
+    return this.resolve<InfaktBinaryResponse>('GET_BINARY', path);
+  }
+
+  private resolve<T>(method: CallMethod, path: string): Promise<T> {
     const seeded = this.responses.get(this.key(method, path));
     if (!seeded) {
       return Promise.reject(
@@ -62,7 +78,7 @@ export class FakeInfaktHttpClient implements IInfaktHttpClient {
     return seeded.kind === 'resolve' ? Promise.resolve(seeded.value as T) : Promise.reject(seeded.error);
   }
 
-  private key(method: 'GET' | 'POST', path: string): string {
+  private key(method: CallMethod, path: string): string {
     return `${method} ${path}`;
   }
 }


### PR DESCRIPTION
## Summary
- `InfaktInvoicingAdapter` read a `pdf_url` field that does not exist on Infakt's invoice resource (verified live against the sandbox), so `InvoiceRecord.pdfUrl` was always `null` and the "download PDF" affordance never worked for Infakt connections.
- The adapter now implements `RegulatoryDocumentReader.getRegulatoryDocument` for `kind: 'rendered'`, calling the real `GET /invoices/{uuid}/pdf.json?document_type=original&invoice_type={kind}` endpoint (confirmed live: returns a valid PDF binary directly).
- The dead `pdf_url` / `print_url` fields are removed from the Infakt wire type; `InvoiceRecord.pdfUrl` stays on core (Subiekt's FE still reads it) but Infakt no longer fakes it — it's `null` now, with the real path routed through the existing `GET /invoices/:invoiceId/document?kind=rendered` controller route (unchanged, already supports this).
- FE: new `useInvoiceRenderedDocumentDownload` hook + a working "Download PDF" button in the Infakt invoice detail section.

Base branch is `1282-infakt-fe-plugin` (PR #1300, still open) because the touched FE component (`infakt-invoice-detail-section.tsx`) only exists on that branch — will retarget to `main` once it merges, matching PR #1307's precedent.

## Test plan
- [x] `pnpm --filter @openlinker/integrations-infakt build/lint/test` — 115/115 passing, new `getRegulatoryDocument` + `getBinary` coverage (happy path, no-content-type fallback, unsupported kind, oversized-body cap)
- [x] `pnpm --filter @openlinker/web type-check` clean
- [x] New FE test: clicking "Download PDF" calls `apiClient.invoicing.downloadDocument(id, 'rendered')`
- [x] `pnpm check:invariants` clean (no cross-context/service-interface violations)
- [x] Live sandbox verification of the real PDF endpoint before implementation (see issue #1321)

Closes #1321