### PR TITLE
docs(api): correct stale "OAuth callback is version-neutral" comments (#1133 follow-up)

### DIFF
--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -30,8 +30,8 @@ const harness = createIntegrationTestHarness({
   configureApp: (app) => {
     app.useGlobalFilters(new CapabilityNotSupportedFilter(), new ConnectionExceptionFilter());
     // Mirror main.ts's URI versioning (#1133) so int-specs exercise the same
-    // `/v1` routing prod serves. Version-neutral routes (/webhooks, the Allegro
-    // OAuth callback) stay reachable without the prefix.
+    // `/v1` routing prod serves. Only the version-neutral routes (the `/webhooks`
+    // ingress and the root `/`) stay reachable without the prefix.
     app.enableVersioning({ type: VersioningType.URI, defaultVersion: API_VERSION });
   },
   configureBodyParser: (app) => {

--- a/apps/web/src/shared/config/api-version.ts
+++ b/apps/web/src/shared/config/api-version.ts
@@ -3,9 +3,10 @@
  *
  * The backend serves every route under `/v1`; the client pins the API major it
  * targets. Single source for both URL builders (the api-client and the JWT
- * session adapter) so they can never drift when a future `/v2` ships. Backend
- * version-neutral routes (inbound webhooks, the Allegro OAuth callback) are not
- * called through the FE client, so a blanket prefix is safe.
+ * session adapter) so they can never drift when a future `/v2` ships. The one
+ * backend version-neutral route (the inbound `/webhooks` ingress) is never
+ * called through the FE client, so a blanket prefix is safe. (The Allegro OAuth
+ * callback IS versioned and IS called through this client — hence the prefix.)
  *
  * @module apps/web/src/shared/config
  */


### PR DESCRIPTION
## What

Comment-only follow-up to #1316 (`Closes #1133`). Two code comments still describe the Allegro OAuth callback as **version-neutral** — a stale claim from an early draft of that PR.

The callback endpoint itself was corrected to be **versioned** (`/v1`) before #1316 merged, but these two comment fixes were made *after* the squash-merge and never landed on `main`. Left as-is they re-encode the exact wrong mental model (callback neutral + not called through the FE client) that caused the original bug this feature had to fix.

## Changes (comment-only, zero behavior change)

- **`apps/web/src/shared/config/api-version.ts`** — the callback **is** versioned and **is** called through the FE api-client (`allegro.api.ts` `handleCallback`); only the `/webhooks` ingress is neutral.
- **`apps/api/test/integration/setup.ts`** — only `/webhooks` and the root `/` are version-neutral.

## Verification

- Pre-commit `smart-test` ✅ (3 changed files, all selected tests passed).
- No runtime/behavior change — corrects misleading comments only.

## Context

Housekeeping: the fixes were force-pushed to the already-merged #1316 branch and stranded there; this lands them on `main` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)