### PR TITLE
fix(api): version listings invalid-path-id int-spec paths under /v1

### DIFF
--- a/apps/api/test/integration/listings-invalid-path-id.int-spec.ts
+++ b/apps/api/test/integration/listings-invalid-path-id.int-spec.ts
@@ -46,7 +46,7 @@ describe('Listings Invalid Path-Id API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get(`/listings/${NON_UUID_ID}`)
+        .get(`/v1/listings/${NON_UUID_ID}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
@@ -57,7 +57,7 @@ describe('Listings Invalid Path-Id API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get(`/listings/${VALID_ABSENT_UUID}`)
+        .get(`/v1/listings/${VALID_ABSENT_UUID}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
@@ -70,7 +70,7 @@ describe('Listings Invalid Path-Id API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get(`/listings/${NON_UUID_ID}/offer`)
+        .get(`/v1/listings/${NON_UUID_ID}/offer`)
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
@@ -83,7 +83,7 @@ describe('Listings Invalid Path-Id API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get(`/listings/connections/${VALID_CONNECTION_UUID}/offers/creation/${NON_UUID_ID}`)
+        .get(`/v1/listings/connections/${VALID_CONNECTION_UUID}/offers/creation/${NON_UUID_ID}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
@@ -94,7 +94,7 @@ describe('Listings Invalid Path-Id API Integration', () => {
       const token = await loginAsAdmin(http, dataSource);
 
       await http
-        .get(`/listings/connections/${NON_UUID_ID}/offers/creation/${VALID_ABSENT_UUID}`)
+        .get(`/v1/listings/connections/${NON_UUID_ID}/offers/creation/${VALID_ABSENT_UUID}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });


### PR DESCRIPTION
## What

Main's `Integration Tests` job has been red since #1316 and #1313 merged next to each other - a semantic merge conflict:

- #1316 (f7d11048) enabled URI versioning with a global `/v1` default, so every listings route is now mounted at `/v1/listings/...`.
- #1313 (f745d384) added `listings-invalid-path-id.int-spec.ts` written pre-versioning, calling unprefixed `/listings/...`.

Result: every request in the spec hit the router-level 404 (`Cannot GET /listings/...`). The three `expect(400)` ParseUUIDPipe assertions failed, and the `expect(404)` assertions passed vacuously (Express default 404, not the controller's NotFoundException).

This also fails the Integration Tests job on every open PR based on current main (e.g. #1309, #1317).

## Fix

Prefix the five request paths with `/v1`, matching every other listings int-spec.

## Testing

Ran the suite against the real Testcontainers harness locally: 5/5 pass (including the previously-vacuous 404 assertions, which now exercise the controller for real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)