### PR TITLE
feat(subiekt): payment method / bank account / cash register per invoice (#1324)

### DIFF
--- a/apps/api/src/integrations/http/dto/subiekt-bank-account-response.dto.ts
+++ b/apps/api/src/integrations/http/dto/subiekt-bank-account-response.dto.ts
@@ -1,0 +1,37 @@
+/**
+ * Subiekt Bank Account Response DTO (#1324)
+ *
+ * Owner-aware bank-account row returned by
+ * `GET /integrations/subiekt/connections/:connectionId/bank-accounts`. Unlike
+ * the neutral capability-generic `BankAccountResponseDto` served by
+ * `InvoicingController`, this Subiekt-specific shape carries the owning seller
+ * Podmiot (`ownerPodmiotId`/`ownerName`) so the FE can group accounts by payer
+ * and surface the >1-owner payer-routing warning (decision 6).
+ *
+ * @module apps/api/src/integrations/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SubiektBankAccountResponseDto {
+  @ApiProperty({ description: 'Bank account id (bridge-native, surfaced as a string)' })
+  id!: string;
+
+  @ApiProperty({ description: 'Account number (IBAN/NRB); empty string when the bridge returns none' })
+  accountNumber!: string;
+
+  @ApiProperty({ description: 'Bank/account display name; empty string when the bridge returns none' })
+  bankName!: string;
+
+  @ApiProperty({ description: "Whether this is the provider's default account" })
+  isDefault!: boolean;
+
+  @ApiProperty({ description: 'Owning seller Podmiot id (used to group accounts by payer)' })
+  ownerPodmiotId!: number;
+
+  @ApiProperty({
+    description: 'Owning seller display name; null when the bridge returns none',
+    nullable: true,
+    type: String,
+  })
+  ownerName!: string | null;
+}

--- a/apps/api/src/integrations/http/dto/subiekt-cash-register-response.dto.ts
+++ b/apps/api/src/integrations/http/dto/subiekt-cash-register-response.dto.ts
@@ -1,0 +1,41 @@
+/**
+ * Subiekt Cash Register Response DTO (#1324)
+ *
+ * One Stanowisko Kasowe (cash register) returned by
+ * `GET /integrations/subiekt/connections/:connectionId/cash-registers`. This is
+ * a Subiekt-local concept with no neutral `libs/core` capability (decision 2) —
+ * inFakt/KSeF have no cash-register notion — so the shape stays Subiekt-only.
+ *
+ * `oddzialId` is an INFORMATIONAL branch tag (a display label): `null` means the
+ * register is unlinked; a non-null value is the register's own branch, NOT a
+ * per-request routing override.
+ *
+ * @module apps/api/src/integrations/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SubiektCashRegisterResponseDto {
+  @ApiProperty({ description: 'Cash-register id (bridge-native number)' })
+  id!: number;
+
+  @ApiProperty({
+    description: 'Cash-register display name; null when the bridge returns none',
+    nullable: true,
+    type: String,
+  })
+  name!: string | null;
+
+  @ApiProperty({
+    description: 'Cash-register symbol; null when the bridge returns none',
+    nullable: true,
+    type: String,
+  })
+  symbol!: string | null;
+
+  @ApiProperty({
+    description: 'Informational branch (Oddział) tag; null when the register is unlinked',
+    nullable: true,
+    type: Number,
+  })
+  oddzialId!: number | null;
+}

--- a/apps/api/src/integrations/http/subiekt.controller.spec.ts
+++ b/apps/api/src/integrations/http/subiekt.controller.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Subiekt Controller Unit Tests (#1324)
+ *
+ * Verifies the owner-aware bank-accounts + cash-registers discovery routes:
+ * mapped output for a Subiekt connection, rejection of a non-Subiekt
+ * connection, and adapter-error propagation.
+ *
+ * @module apps/api/src/integrations/http
+ */
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { SubiektController } from './subiekt.controller';
+import {
+  INTEGRATIONS_SERVICE_TOKEN,
+  type IIntegrationsService,
+} from '@openlinker/core/integrations';
+import type { SubiektInvoicingAdapter } from '@openlinker/integrations-subiekt';
+
+describe('SubiektController', () => {
+  let controller: SubiektController;
+  let integrationsService: jest.Mocked<IIntegrationsService>;
+
+  const bankAccounts = [
+    {
+      id: '5',
+      accountNumber: 'PL61109010140000071219812874',
+      bankName: 'Main account',
+      isDefault: true,
+      ownerPodmiotId: 1,
+      ownerName: 'ACME Sp. z o.o.',
+    },
+    {
+      id: '6',
+      accountNumber: '',
+      bankName: '',
+      isDefault: false,
+      ownerPodmiotId: 2,
+      ownerName: null,
+    },
+  ];
+
+  const cashRegisters = [
+    { id: 100067, name: 'Kasa 1', symbol: 'K1', oddzialId: 100002 },
+    { id: 100068, name: null, symbol: null, oddzialId: null },
+  ];
+
+  // A shaped test double satisfying the controller's structural narrow.
+  const subiektAdapter = {
+    listBankAccountsWithOwner: jest.fn().mockResolvedValue(bankAccounts),
+    listCashRegisters: jest.fn().mockResolvedValue(cashRegisters),
+  } as unknown as jest.Mocked<SubiektInvoicingAdapter>;
+
+  beforeEach(async () => {
+    const mockIntegrationsService = {
+      getCapabilityAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+      getCapabilityAdapters: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SubiektController],
+      providers: [{ provide: INTEGRATIONS_SERVICE_TOKEN, useValue: mockIntegrationsService }],
+    }).compile();
+
+    controller = module.get<SubiektController>(SubiektController);
+    integrationsService = module.get(INTEGRATIONS_SERVICE_TOKEN);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listBankAccounts', () => {
+    it('should return the owner-aware bank-account list for a Subiekt connection', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue(subiektAdapter);
+
+      const result = await controller.listBankAccounts('conn-1');
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith('conn-1', 'Invoicing');
+      expect(subiektAdapter.listBankAccountsWithOwner).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(bankAccounts);
+      // Owner fields are preserved (distinct from the neutral InvoicingController route).
+      expect(result[0].ownerPodmiotId).toBe(1);
+      expect(result[1].ownerName).toBeNull();
+    });
+
+    it('should throw BadRequestException when the connection is not a Subiekt one', async () => {
+      // A non-Subiekt Invoicing adapter lacks the discovery methods.
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        issueInvoice: jest.fn(),
+      } as never);
+
+      await expect(controller.listBankAccounts('conn-x')).rejects.toThrow(BadRequestException);
+      await expect(controller.listBankAccounts('conn-x')).rejects.toThrow(
+        'not a Subiekt Invoicing connection',
+      );
+    });
+
+    it('should propagate adapter errors', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue(subiektAdapter);
+      subiektAdapter.listBankAccountsWithOwner.mockRejectedValueOnce(new Error('bridge unreachable'));
+
+      await expect(controller.listBankAccounts('conn-1')).rejects.toThrow('bridge unreachable');
+    });
+  });
+
+  describe('listCashRegisters', () => {
+    it('should return the cash-register list for a Subiekt connection', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue(subiektAdapter);
+
+      const result = await controller.listCashRegisters('conn-1');
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith('conn-1', 'Invoicing');
+      expect(subiektAdapter.listCashRegisters).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(cashRegisters);
+      // null name/symbol/oddzialId degrade gracefully.
+      expect(result[1].name).toBeNull();
+      expect(result[1].oddzialId).toBeNull();
+    });
+
+    it('should throw BadRequestException when the connection is not a Subiekt one', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        issueInvoice: jest.fn(),
+      } as never);
+
+      await expect(controller.listCashRegisters('conn-x')).rejects.toThrow(BadRequestException);
+    });
+
+    it('should propagate adapter errors', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue(subiektAdapter);
+      subiektAdapter.listCashRegisters.mockRejectedValueOnce(new Error('bridge timeout'));
+
+      await expect(controller.listCashRegisters('conn-1')).rejects.toThrow('bridge timeout');
+    });
+  });
+});

--- a/apps/api/src/integrations/http/subiekt.controller.ts
+++ b/apps/api/src/integrations/http/subiekt.controller.ts
@@ -1,0 +1,136 @@
+/**
+ * Subiekt Integration Controller (#1324)
+ *
+ * Plugin-specific HTTP surface for Subiekt discovery endpoints, mirroring the
+ * `AllegroController` precedent (plugin-scoped controller, capability-adapter
+ * resolution, guard-narrowed to the concrete adapter). DISTINCT from the
+ * capability-generic `InvoicingController`:
+ *   - `InvoicingController` serves the NEUTRAL bank-account shape via the
+ *     `BankAccountsReader` core capability (no owner info).
+ *   - This controller serves the OWNER-AWARE bank-account list
+ *     (`ownerPodmiotId`/`ownerName`) plus the Stanowisko Kasowe (cash-register)
+ *     list — both Subiekt-local shapes with no neutral core capability
+ *     (decisions 2 and 6), so there is no `is*Reader` guard to reuse.
+ *
+ * Narrowing: the two discovery methods are plain public methods on
+ * `SubiektInvoicingAdapter`, not part of any core port. We resolve the
+ * connection's `Invoicing` adapter (same seam as `InvoicingController`) and
+ * narrow it with a small STRUCTURAL guard rather than `instanceof` — this keeps
+ * the concrete adapter as a type-only import (no value-level cross-package
+ * dependency) and makes the guard trivially satisfiable by a shaped test
+ * double. A non-Subiekt connection is rejected with `BadRequestException`,
+ * mirroring how `allegro.controller.ts` rejects an unsupported capability.
+ *
+ * Adapter/bridge errors propagate as-is — the adapter already translates them;
+ * Nest's exception layer maps them (matches `allegro.controller.ts`, which does
+ * not wrap adapter errors).
+ *
+ * @module apps/api/src/integrations/http
+ */
+import { Controller, Get, Param, BadRequestException, Inject } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { Logger } from '@openlinker/shared/logging';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import type { InvoicingPort } from '@openlinker/core/invoicing';
+import type { SubiektInvoicingAdapter } from '@openlinker/integrations-subiekt';
+import { SubiektBankAccountResponseDto } from './dto/subiekt-bank-account-response.dto';
+import { SubiektCashRegisterResponseDto } from './dto/subiekt-cash-register-response.dto';
+
+/**
+ * Structural narrow to the Subiekt adapter. The discovery methods are
+ * Subiekt-local (no core capability), so there is no shared capability guard.
+ * A type-only import + duck-typing keeps apps/api free of a value-level
+ * dependency on the concrete adapter class.
+ */
+function isSubiektInvoicingAdapter(adapter: InvoicingPort): adapter is SubiektInvoicingAdapter {
+  const candidate = adapter as Partial<SubiektInvoicingAdapter>;
+  return (
+    typeof candidate.listBankAccountsWithOwner === 'function' &&
+    typeof candidate.listCashRegisters === 'function'
+  );
+}
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('subiekt')
+@Controller('integrations/subiekt')
+export class SubiektController {
+  private readonly logger = new Logger(SubiektController.name);
+
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+  ) {}
+
+  @Get('connections/:connectionId/bank-accounts')
+  @ApiOperation({
+    summary: "List the Subiekt connection's owner-aware bank accounts",
+    description:
+      "Resolves the connection's Invoicing adapter, narrows to the Subiekt adapter, and returns " +
+      'the OWNER-AWARE bank-account list (with ownerPodmiotId/ownerName) so the FE can group ' +
+      'accounts by payer and show the >1-owner routing warning. Distinct from the neutral ' +
+      "InvoicingController bank-accounts route. 400 when the connection is not a Subiekt one.",
+  })
+  @ApiParam({ name: 'connectionId', description: 'Connection ID' })
+  @ApiResponse({ status: 200, type: [SubiektBankAccountResponseDto] })
+  @ApiResponse({ status: 400, description: 'Connection is not a Subiekt Invoicing connection' })
+  async listBankAccounts(
+    @Param('connectionId') connectionId: string,
+  ): Promise<SubiektBankAccountResponseDto[]> {
+    this.logger.debug(`Listing Subiekt bank accounts (connection: ${connectionId})`);
+    const adapter = await this.resolveSubiektAdapter(connectionId);
+    const accounts = await adapter.listBankAccountsWithOwner();
+    return accounts.map((account) => ({
+      id: account.id,
+      accountNumber: account.accountNumber,
+      bankName: account.bankName,
+      isDefault: account.isDefault,
+      ownerPodmiotId: account.ownerPodmiotId,
+      ownerName: account.ownerName,
+    }));
+  }
+
+  @Get('connections/:connectionId/cash-registers')
+  @ApiOperation({
+    summary: "List the Subiekt connection's cash registers (Stanowiska Kasowe)",
+    description:
+      "Resolves the connection's Invoicing adapter, narrows to the Subiekt adapter, and returns " +
+      'the (unfiltered) cash-register list. oddzialId is an informational branch tag only. ' +
+      '400 when the connection is not a Subiekt one.',
+  })
+  @ApiParam({ name: 'connectionId', description: 'Connection ID' })
+  @ApiResponse({ status: 200, type: [SubiektCashRegisterResponseDto] })
+  @ApiResponse({ status: 400, description: 'Connection is not a Subiekt Invoicing connection' })
+  async listCashRegisters(
+    @Param('connectionId') connectionId: string,
+  ): Promise<SubiektCashRegisterResponseDto[]> {
+    this.logger.debug(`Listing Subiekt cash registers (connection: ${connectionId})`);
+    const adapter = await this.resolveSubiektAdapter(connectionId);
+    const registers = await adapter.listCashRegisters();
+    return registers.map((register) => ({
+      id: register.id,
+      name: register.name,
+      symbol: register.symbol,
+      oddzialId: register.oddzialId,
+    }));
+  }
+
+  /**
+   * Resolve the connection's `Invoicing` adapter and narrow it to the concrete
+   * Subiekt adapter. Throws `BadRequestException` when the connection is not a
+   * Subiekt one (its adapter lacks the Subiekt-local discovery methods).
+   */
+  private async resolveSubiektAdapter(connectionId: string): Promise<SubiektInvoicingAdapter> {
+    const adapter = await this.integrationsService.getCapabilityAdapter<InvoicingPort>(
+      connectionId,
+      'Invoicing',
+    );
+    if (!isSubiektInvoicingAdapter(adapter)) {
+      throw new BadRequestException(
+        `Connection ${connectionId} is not a Subiekt Invoicing connection`,
+      );
+    }
+    return adapter;
+  }
+}

--- a/apps/api/src/integrations/integrations.module.ts
+++ b/apps/api/src/integrations/integrations.module.ts
@@ -22,6 +22,7 @@ import { apiPlugins } from '../plugins';
 import { ConnectionController } from './http/connection.controller';
 import { AdapterController } from './http/adapter.controller';
 import { AllegroController } from './http/allegro.controller';
+import { SubiektController } from './http/subiekt.controller';
 import { ConnectionService } from './application/services/connection.service';
 import { OAuthConnectionService } from './application/services/oauth-connection.service';
 import { OAUTH_CONNECTION_SERVICE_TOKEN } from './application/interfaces/oauth-connection.service.interface';
@@ -34,7 +35,7 @@ import { OAUTH_CONNECTION_SERVICE_TOKEN } from './application/interfaces/oauth-c
     RedisConfigModule, // Required for OAuth state storage
     PluginRegistryModule.forRoot({ plugins: apiPlugins }),
   ],
-  controllers: [ConnectionController, AdapterController, AllegroController],
+  controllers: [ConnectionController, AdapterController, AllegroController, SubiektController],
   providers: [
     ConnectionService,
     // Neutral OAuth orchestration (#859). Allegro's OAuth knowledge (URLs,

--- a/apps/web/src/features/connections/api/connections.api.ts
+++ b/apps/web/src/features/connections/api/connections.api.ts
@@ -6,6 +6,8 @@ import type {
   ConnectionTestResult,
   CreateConnectionInput,
   InstallWebhooksResult,
+  SubiektBankAccount,
+  SubiektCashRegister,
   UpdateConnectionInput,
 } from './connections.types';
 
@@ -13,6 +15,8 @@ export interface ConnectionsApi {
   create: (input: CreateConnectionInput) => Promise<Connection>;
   disable: (connectionId: string) => Promise<Connection>;
   getBankAccounts: (connectionId: string) => Promise<BankAccount[]>;
+  getSubiektBankAccounts: (connectionId: string) => Promise<SubiektBankAccount[]>;
+  getSubiektCashRegisters: (connectionId: string) => Promise<SubiektCashRegister[]>;
   getDiagnostics: (connectionId: string) => Promise<ConnectionDiagnostics>;
   getById: (connectionId: string) => Promise<Connection>;
   installWebhooks: (connectionId: string) => Promise<InstallWebhooksResult>;
@@ -60,6 +64,16 @@ export function createConnectionsApi(request: ApiRequest): ConnectionsApi {
     },
     getBankAccounts(connectionId): Promise<BankAccount[]> {
       return request<BankAccount[]>(`/connections/${connectionId}/bank-accounts`);
+    },
+    getSubiektBankAccounts(connectionId): Promise<SubiektBankAccount[]> {
+      return request<SubiektBankAccount[]>(
+        `/integrations/subiekt/connections/${connectionId}/bank-accounts`,
+      );
+    },
+    getSubiektCashRegisters(connectionId): Promise<SubiektCashRegister[]> {
+      return request<SubiektCashRegister[]>(
+        `/integrations/subiekt/connections/${connectionId}/cash-registers`,
+      );
     },
     setDefaultBankAccount(connectionId, accountId): Promise<void> {
       return request<void>(`/connections/${connectionId}/bank-accounts/${accountId}/default`, {

--- a/apps/web/src/features/connections/api/connections.query-keys.ts
+++ b/apps/web/src/features/connections/api/connections.query-keys.ts
@@ -7,4 +7,8 @@ export const connectionsQueryKeys = {
   detail: (connectionId: string) => ['connections', 'detail', connectionId] as const,
   diagnostics: (connectionId: string) => ['connections', 'diagnostics', connectionId] as const,
   bankAccounts: (connectionId: string) => ['connections', 'bank-accounts', connectionId] as const,
+  subiektBankAccounts: (connectionId: string) =>
+    ['connections', 'subiekt-bank-accounts', connectionId] as const,
+  subiektCashRegisters: (connectionId: string) =>
+    ['connections', 'subiekt-cash-registers', connectionId] as const,
 };

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -119,6 +119,38 @@ export interface BankAccount {
 }
 
 /**
+ * Owner-aware bank account from the Subiekt-specific route
+ * `GET /integrations/subiekt/connections/:id/bank-accounts` (#1324). Distinct
+ * from the neutral {@link BankAccount} served by the capability-generic
+ * InvoicingController: it carries `ownerPodmiotId`/`ownerName` so the Subiekt
+ * FE can group accounts by payer and show the payer-routing warning only when
+ * more than one seller Podmiot is present. Kept Subiekt-local (no core
+ * capability) because no other provider has a multi-payer concept.
+ */
+export interface SubiektBankAccount {
+  id: string;
+  accountNumber: string;
+  bankName: string;
+  isDefault: boolean;
+  ownerPodmiotId: number;
+  ownerName: string | null;
+}
+
+/**
+ * Cash register (Stanowisko Kasowe) from
+ * `GET /integrations/subiekt/connections/:id/cash-registers` (#1324). A real,
+ * working per-document selector. `oddzialId` is an informational branch tag
+ * only — the Oddział axis itself is NOT selectable (it is bound read-only to
+ * the bridge's logged-in Sfera session; see issue #1324 Part B / decision 8b).
+ */
+export interface SubiektCashRegister {
+  id: number;
+  name: string | null;
+  symbol: string | null;
+  oddzialId: number | null;
+}
+
+/**
  * Response from `POST /connections/:id/webhooks/install` (#168). Reports whether
  * the WS push and the synchronous test ping both completed.
  */

--- a/apps/web/src/features/connections/components/infakt-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/infakt-setup-form.test.tsx
@@ -435,7 +435,7 @@ describe('InfaktSetupForm', () => {
       fireEvent.change(select, { target: { value: '2' } });
 
       expect(
-        await findToastTitle('Could not update the inFakt default account'),
+        await findToastTitle('Could not update the default account'),
       ).toBeInTheDocument();
     });
 

--- a/apps/web/src/features/connections/hooks/use-set-default-bank-account-mutation.ts
+++ b/apps/web/src/features/connections/hooks/use-set-default-bank-account-mutation.ts
@@ -9,12 +9,13 @@ interface SetDefaultBankAccountVariables {
 }
 
 /**
- * Marks a bank account as the provider's default (#1303 follow-up) — keeps
- * inFakt's own "default account" setting in sync with the account
+ * Marks a bank account as the invoicing provider's default (#1303 follow-up) —
+ * keeps the provider's own "default account" setting in sync with the account
  * OpenLinker stamps on Transfer invoices, whenever the operator picks one.
+ * Provider-neutral: used by both inFakt (#1310) and Subiekt (#1324).
  *
- * A failed call leaves OL and inFakt disagreeing about the default, so the
- * hook surfaces the failure via a toast — call sites fire-and-forget with
+ * A failed call leaves OL and the provider disagreeing about the default, so
+ * the hook surfaces the failure via a toast — call sites fire-and-forget with
  * `.mutate()` and rely on this single error seam.
  */
 export function useSetDefaultBankAccountMutation(): UseMutationResult<
@@ -30,15 +31,23 @@ export function useSetDefaultBankAccountMutation(): UseMutationResult<
     mutationFn: ({ connectionId, accountId }: SetDefaultBankAccountVariables) =>
       apiClient.connections.setDefaultBankAccount(connectionId, accountId),
     onSuccess: async (_data, { connectionId }) => {
-      await queryClient.invalidateQueries({
-        queryKey: connectionsQueryKeys.bankAccounts(connectionId),
-      });
+      // Invalidate BOTH bank-account list keys: the neutral list (inFakt) and
+      // the owner-aware Subiekt list (#1324). Whichever section is on screen,
+      // its `isDefault` flags refresh after the default flips.
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: connectionsQueryKeys.bankAccounts(connectionId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: connectionsQueryKeys.subiektBankAccounts(connectionId),
+        }),
+      ]);
     },
     onError: (error) => {
       showToast({
         tone: 'error',
-        title: 'Could not update the inFakt default account',
-        description: `The account was saved in OpenLinker but inFakt still shows the previous default. ${error.message}`,
+        title: 'Could not update the default account',
+        description: `The account was saved in OpenLinker but the invoicing provider still shows the previous default. ${error.message}`,
       });
     },
   });

--- a/apps/web/src/features/connections/hooks/use-subiekt-bank-accounts-query.ts
+++ b/apps/web/src/features/connections/hooks/use-subiekt-bank-accounts-query.ts
@@ -1,0 +1,27 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { connectionsQueryKeys } from '../api/connections.query-keys';
+import type { SubiektBankAccount } from '../api/connections.types';
+
+/**
+ * Owner-aware bank-account list for a Subiekt connection (#1324). Unlike the
+ * generic {@link useBankAccountsQuery} (neutral shape, no owner info), this hits
+ * the Subiekt-specific route so the structured section can group accounts by
+ * owning Podmiot and show the payer-routing warning only when >1 owner exists
+ * (decision 6). Only meaningful once the connection exists and Transfer is the
+ * selected payment method — pass `enabled: false` otherwise. Retries disabled:
+ * a failure resolves to the same "no accounts" UI fallback, not a retry loop.
+ */
+export function useSubiektBankAccountsQuery(
+  connectionId: string | undefined,
+  options?: { enabled?: boolean },
+): UseQueryResult<SubiektBankAccount[]> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: connectionsQueryKeys.subiektBankAccounts(connectionId ?? ''),
+    queryFn: () => apiClient.connections.getSubiektBankAccounts(connectionId!),
+    enabled: (options?.enabled ?? true) && connectionId !== undefined && connectionId.length > 0,
+    retry: false,
+  });
+}

--- a/apps/web/src/features/connections/hooks/use-subiekt-cash-registers-query.ts
+++ b/apps/web/src/features/connections/hooks/use-subiekt-cash-registers-query.ts
@@ -1,0 +1,25 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { connectionsQueryKeys } from '../api/connections.query-keys';
+import type { SubiektCashRegister } from '../api/connections.types';
+
+/**
+ * Cash-register (Stanowisko Kasowe) list for a Subiekt connection (#1324) — a
+ * real, working per-document selector. Unfiltered: the Oddział axis is not
+ * selectable (bound to the bridge's Sfera session, decision 8b), so there is
+ * nothing to filter by; each register's `oddzialId` is an informational tag.
+ * Retries disabled — a failure resolves to the "no registers" UI fallback.
+ */
+export function useSubiektCashRegistersQuery(
+  connectionId: string | undefined,
+  options?: { enabled?: boolean },
+): UseQueryResult<SubiektCashRegister[]> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: connectionsQueryKeys.subiektCashRegisters(connectionId ?? ''),
+    queryFn: () => apiClient.connections.getSubiektCashRegisters(connectionId!),
+    enabled: (options?.enabled ?? true) && connectionId !== undefined && connectionId.length > 0,
+    retry: false,
+  });
+}

--- a/apps/web/src/features/connections/index.ts
+++ b/apps/web/src/features/connections/index.ts
@@ -10,6 +10,8 @@
  */
 export type {
   BankAccount,
+  SubiektBankAccount,
+  SubiektCashRegister,
   Connection,
   ConnectionStatus,
   ConnectionFilters,
@@ -33,6 +35,8 @@ export { useUpdateConnectionMutation } from './hooks/use-update-connection-mutat
 export { useBankAccountsQuery } from './hooks/use-bank-accounts-query';
 export { useSetDefaultBankAccountMutation } from './hooks/use-set-default-bank-account-mutation';
 export { usePickBankAccount } from './hooks/use-pick-bank-account';
+export { useSubiektBankAccountsQuery } from './hooks/use-subiekt-bank-accounts-query';
+export { useSubiektCashRegistersQuery } from './hooks/use-subiekt-cash-registers-query';
 
 export {
   INVOICE_TRIGGER_MODEL_VALUES,

--- a/apps/web/src/plugins/infakt/components/infakt-structured-section.test.tsx
+++ b/apps/web/src/plugins/infakt/components/infakt-structured-section.test.tsx
@@ -487,7 +487,7 @@ describe('InfaktStructuredSection', () => {
       fireEvent.change(select, { target: { value: '1' } });
 
       expect(
-        await findToastTitle('Could not update the inFakt default account'),
+        await findToastTitle('Could not update the default account'),
       ).toBeInTheDocument();
     });
   });

--- a/apps/web/src/plugins/subiekt/components/subiekt-structured-section.test.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-structured-section.test.tsx
@@ -1,9 +1,10 @@
 /**
- * SubiektStructuredSection tests (#759)
+ * SubiektStructuredSection tests (#759 + #1324)
  *
  * Renders the plugin-owned structured section the way EditConnectionForm does
  * (via renderWithProviders, so usePlatform('subiekt') resolves the registered
- * plugin and its capabilityDescriptors).
+ * plugin and its capabilityDescriptors). The #1324 payment/bank/cash-register
+ * queries are mocked at the feature-hook boundary so no real HTTP fires.
  *
  * @module plugins/subiekt/components
  */
@@ -13,10 +14,30 @@ import { resolve } from 'node:path';
 import type { ReactElement } from 'react';
 import { cleanup, fireEvent, screen } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders, sampleConnection } from '../../../test/test-utils';
-import type { Connection } from '../../../features/connections';
+import type * as ConnectionsModule from '../../../features/connections';
+import type { Connection, SubiektBankAccount, SubiektCashRegister } from '../../../features/connections';
 import { SubiektStructuredSection } from './subiekt-structured-section';
+
+// --- feature-hook mocks (#1324): keep the real barrel (CapabilityTogglesSection
+// etc.) but override the three Subiekt data hooks so no real query fires. ---
+const bankAccountsResult = { data: [] as SubiektBankAccount[], isLoading: false, isError: false };
+const cashRegistersResult = { data: [] as SubiektCashRegister[], isLoading: false, isError: false };
+// The section fires the default-sync fire-and-forget via `.mutate()` (not
+// `mutateAsync`) so a bridge failure is toasted by the hook, never an unhandled
+// rejection (PR review IMPORTANT #4).
+const setDefaultMutate = vi.fn();
+
+vi.mock('../../../features/connections', async (importOriginal) => {
+  const actual = await importOriginal<typeof ConnectionsModule>();
+  return {
+    ...actual,
+    useSubiektBankAccountsQuery: () => bankAccountsResult,
+    useSubiektCashRegistersQuery: () => cashRegistersResult,
+    useSetDefaultBankAccountMutation: () => ({ mutate: setDefaultMutate }),
+  };
+});
 
 const subiektConnection: Connection = {
   ...sampleConnection,
@@ -42,6 +63,9 @@ function Harness({
     defaultValues: {
       subiektBridgeUrl: '',
       subiektTriggerModel: '',
+      subiektPaymentMethod: '',
+      subiektBankAccountId: '',
+      subiektStanowiskoKasoweId: '',
       subiektCapabilities: {},
       ...defaultValues,
     },
@@ -57,7 +81,28 @@ function Harness({
   );
 }
 
+function account(over: Partial<SubiektBankAccount>): SubiektBankAccount {
+  return {
+    id: '1',
+    accountNumber: '00 0000',
+    bankName: 'Bank',
+    isDefault: false,
+    ownerPodmiotId: 1,
+    ownerName: 'Firma A',
+    ...over,
+  };
+}
+
 describe('SubiektStructuredSection', () => {
+  beforeEach(() => {
+    bankAccountsResult.data = [];
+    bankAccountsResult.isLoading = false;
+    bankAccountsResult.isError = false;
+    cashRegistersResult.data = [];
+    cashRegistersResult.isLoading = false;
+    cashRegistersResult.isError = false;
+    setDefaultMutate.mockClear();
+  });
   afterEach(cleanup);
 
   it('propagates Bridge URL changes via syncStructuredToJson under the subiektBridgeUrl key', () => {
@@ -85,7 +130,7 @@ describe('SubiektStructuredSection', () => {
     const syncStructuredToJson = vi.fn();
     renderWithProviders(<Harness syncStructuredToJson={syncStructuredToJson} />);
 
-    const select = screen.getByRole('combobox');
+    const select = screen.getByLabelText('Invoice trigger');
     fireEvent.change(select, { target: { value: 'auto-on-paid' } });
 
     expect(syncStructuredToJson).toHaveBeenCalledWith('subiektTriggerModel', 'auto-on-paid');
@@ -98,11 +143,9 @@ describe('SubiektStructuredSection', () => {
   });
 
   it('capability label "Show KSeF status badge" comes from the descriptor module (AC-8) and is ABSENT from the shared CapabilityTogglesSection source', () => {
-    // Rendered label is provider-supplied.
     renderWithProviders(<Harness />);
     expect(screen.getByText('Show KSeF status badge')).toBeInTheDocument();
 
-    // ...and the shared component source carries no such literal.
     const sharedSource = readFileSync(
       resolve(process.cwd(), 'src/features/connections/components/CapabilityTogglesSection.tsx'),
       'utf8',
@@ -113,14 +156,125 @@ describe('SubiektStructuredSection', () => {
   it('disables Bridge URL, trigger Select, and toggles when configText is unparseable', () => {
     renderWithProviders(<Harness configIsParseable={false} />);
     expect(screen.getByPlaceholderText('https://localhost:5005')).toBeDisabled();
-    expect(screen.getByRole('combobox')).toBeDisabled();
+    expect(screen.getByLabelText('Invoice trigger')).toBeDisabled();
     expect(screen.getByRole('checkbox')).toBeDisabled();
   });
 
   it('pre-selects the trigger dropdown from the hydrated form value', () => {
+    renderWithProviders(<Harness defaultValues={{ subiektTriggerModel: 'batched' }} />);
+    expect(screen.getByLabelText('Invoice trigger')).toHaveValue('batched');
+  });
+
+  // --- #1324 payment method / bank account ---
+
+  it('routes the payment-method Select change to subiektPaymentMethod', () => {
+    const syncStructuredToJson = vi.fn();
+    renderWithProviders(<Harness syncStructuredToJson={syncStructuredToJson} />);
+
+    fireEvent.change(screen.getByLabelText('Default payment method'), {
+      target: { value: 'transfer' },
+    });
+    expect(syncStructuredToJson).toHaveBeenCalledWith('subiektPaymentMethod', 'transfer');
+  });
+
+  it('offers an explicit "Not set" payment option and hides the bank select when unset (tri-state)', () => {
+    bankAccountsResult.data = [account({})];
+    renderWithProviders(<Harness defaultValues={{ subiektPaymentMethod: '' }} />);
+
+    // The unset option exists and is the current value — no forced "Cash".
+    expect(
+      screen.getByRole('option', { name: 'Not set (Subiekt default)' }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Default payment method')).toHaveValue('');
+    // Bank-account picker is transfer-only, so it stays hidden when unset.
+    expect(screen.queryByLabelText('Bank account for Transfer invoices')).not.toBeInTheDocument();
+  });
+
+  it('hides the bank-account select when payment method is Cash', () => {
+    bankAccountsResult.data = [account({})];
+    renderWithProviders(<Harness defaultValues={{ subiektPaymentMethod: 'cash' }} />);
+    expect(screen.queryByLabelText('Bank account for Transfer invoices')).not.toBeInTheDocument();
+  });
+
+  it('shows a flat bank-account list and NO payer warning for a single-payer install', () => {
+    bankAccountsResult.data = [
+      account({ id: '1', ownerPodmiotId: 7, ownerName: 'Firma A' }),
+      account({ id: '2', ownerPodmiotId: 7, ownerName: 'Firma A' }),
+    ];
+    renderWithProviders(<Harness defaultValues={{ subiektPaymentMethod: 'transfer' }} />);
+
+    expect(screen.getByLabelText('Bank account for Transfer invoices')).toBeInTheDocument();
+    // no optgroup + no multi-payer warning
+    expect(document.querySelector('optgroup')).toBeNull();
+    expect(screen.queryByText(/more than one płatnik/i)).not.toBeInTheDocument();
+  });
+
+  it('groups accounts by owner and shows the payer warning ONLY when >1 payer', () => {
+    bankAccountsResult.data = [
+      account({ id: '1', ownerPodmiotId: 1, ownerName: 'Firma A' }),
+      account({ id: '2', ownerPodmiotId: 2, ownerName: 'Oddział B' }),
+    ];
+    renderWithProviders(<Harness defaultValues={{ subiektPaymentMethod: 'transfer' }} />);
+
+    expect(document.querySelectorAll('optgroup')).toHaveLength(2);
+    expect(screen.getByText(/more than one płatnik/i)).toBeInTheDocument();
+  });
+
+  it('fires the set-default mutation when a non-default account is picked', () => {
+    bankAccountsResult.data = [
+      account({ id: '1', isDefault: true }),
+      account({ id: '2', isDefault: false }),
+    ];
+    const syncStructuredToJson = vi.fn();
     renderWithProviders(
-      <Harness defaultValues={{ subiektTriggerModel: 'batched' }} />,
+      <Harness
+        syncStructuredToJson={syncStructuredToJson}
+        defaultValues={{ subiektPaymentMethod: 'transfer' }}
+      />,
     );
-    expect(screen.getByRole('combobox')).toHaveValue('batched');
+
+    fireEvent.change(screen.getByLabelText('Bank account for Transfer invoices'), {
+      target: { value: '2' },
+    });
+    expect(syncStructuredToJson).toHaveBeenCalledWith('subiektBankAccountId', '2');
+    expect(setDefaultMutate).toHaveBeenCalledWith({ connectionId: 'subiekt_1', accountId: '2' });
+  });
+
+  it('does NOT fire the set-default mutation when the picked account is already default', () => {
+    bankAccountsResult.data = [account({ id: '1', isDefault: true })];
+    renderWithProviders(<Harness defaultValues={{ subiektPaymentMethod: 'transfer' }} />);
+
+    fireEvent.change(screen.getByLabelText('Bank account for Transfer invoices'), {
+      target: { value: '1' },
+    });
+    expect(setDefaultMutate).not.toHaveBeenCalled();
+  });
+
+  // --- #1324 cash register (Stanowisko Kasowe) — NO Oddział selector ---
+
+  it('renders the cash-register select with the Centrala help text and no Oddział field', () => {
+    cashRegistersResult.data = [
+      { id: 100065, name: 'Kasa Centralna', symbol: 'CENTR', oddzialId: 100000 },
+    ];
+    renderWithProviders(<Harness />);
+
+    expect(screen.getByLabelText('Cash register (Stanowisko Kasowe)')).toBeInTheDocument();
+    expect(screen.getByText(/switching Oddział/i)).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Kasa Centralna (CENTR)' })).toBeInTheDocument();
+    // no branch/Oddział selector anywhere
+    expect(screen.queryByLabelText(/Oddział/i)).not.toBeInTheDocument();
+  });
+
+  it('routes the cash-register Select change to subiektStanowiskoKasoweId', () => {
+    cashRegistersResult.data = [
+      { id: 100065, name: 'Kasa Centralna', symbol: 'CENTR', oddzialId: null },
+    ];
+    const syncStructuredToJson = vi.fn();
+    renderWithProviders(<Harness syncStructuredToJson={syncStructuredToJson} />);
+
+    fireEvent.change(screen.getByLabelText('Cash register (Stanowisko Kasowe)'), {
+      target: { value: '100065' },
+    });
+    expect(syncStructuredToJson).toHaveBeenCalledWith('subiektStanowiskoKasoweId', '100065');
   });
 });

--- a/apps/web/src/plugins/subiekt/components/subiekt-structured-section.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-structured-section.tsx
@@ -1,28 +1,41 @@
 /**
- * Subiekt Structured Section (#759)
+ * Subiekt Structured Section (#759 + #1324)
  *
  * Plugin-owned structured-config inputs rendered inside `EditConnectionForm`
  * when the connection's `platformType` is `'subiekt'`. Carries:
  *
  *   - Bridge URL  → flat `config.subiektBridgeUrl` (synced via syncStructuredToJson)
  *   - Trigger Model dropdown (AC-2) → NESTED `config.invoicing.triggerModel`
- *     (synced via syncStructuredToJson — the host's nested merge handler
- *     routes the `subiektTriggerModel` form field to the nested path)
+ *   - Payment / bank / cash-register (#1324) → one `InlineDisclosure`:
+ *       - payment method (cash/transfer) → flat `config.defaultPaymentMethod`
+ *       - bank account (transfer only) → flat `config.bankAccountId`, picked from
+ *         the OWNER-AWARE Subiekt endpoint so options group by płatnik and a
+ *         payer-routing warning shows ONLY when >1 seller Podmiot exists
+ *         (decisions 5/6). On a non-default pick we also flip the provider
+ *         default via the generic set-default mutation.
+ *       - cash register (Stanowisko Kasowe) → flat `config.defaultStanowiskoKasoweId`.
+ *         A real, working per-document selector. There is deliberately NO Oddział
+ *         selector — the branch is bound read-only to the bridge's Sfera session
+ *         and cannot be overridden per request (issue #1324 decision 8b); one
+ *         help line states this.
  *   - Capability toggles → whole-object `config.capabilities` via
- *     `CapabilityTogglesSection` (adapter-provided labels, AC-8)
- *
- * Connection-test is NOT here — the generic `ConnectionActionsPanel` on the
- * detail page already exposes Test for every connection (Decision 8).
+ *     `CapabilityTogglesSection`
  *
  * @module plugins/subiekt/components
  */
-import type { ReactElement } from 'react';
+import { useMemo, type ReactElement } from 'react';
 import { FormField } from '../../../shared/ui/form-field';
+import { InlineDisclosure } from '../../../shared/ui/inline-disclosure';
 import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
 import { useTranslation } from '../../../shared/i18n';
 import { usePlatform } from '../../../shared/plugins';
-import { CapabilityTogglesSection } from '../../../features/connections';
+import {
+  CapabilityTogglesSection,
+  useSetDefaultBankAccountMutation,
+  useSubiektBankAccountsQuery,
+  useSubiektCashRegistersQuery,
+} from '../../../features/connections';
 import type { StructuredConfigSectionProps } from '../../../shared/plugins';
 import {
   SUBIEKT_TRIGGER_MODELS,
@@ -39,6 +52,67 @@ export function SubiektStructuredSection({
   const { t } = useTranslation();
   const plugin = usePlatform(connection.platformType);
   const descriptors = plugin?.capabilityDescriptors ?? {};
+
+  // Human labels for the payment method are routed through the i18n seam so a
+  // future PL catalog localizes them (matches the trigger-model precedent).
+  const paymentMethodLabels: Record<'cash' | 'transfer', string> = {
+    cash: t('subiekt.settings.payment.method.cash', 'Cash'),
+    transfer: t('subiekt.settings.payment.method.transfer', 'Transfer'),
+  };
+  const paymentUnsetLabel = t('subiekt.settings.payment.method.unset', 'Not set (Subiekt default)');
+
+  // Tri-state: '' (unset — send-nothing, bridge keeps its own default) | 'cash' | 'transfer'.
+  const paymentMethod = form.watch('subiektPaymentMethod') ?? '';
+  const isTransfer = paymentMethod === 'transfer';
+  // Summary reflects the real tri-state — an unset method shows "Not set",
+  // never a misleading "Cash" (PR review IMPORTANT #2).
+  const effectiveLabel =
+    paymentMethod === 'cash' || paymentMethod === 'transfer'
+      ? paymentMethodLabels[paymentMethod]
+      : paymentUnsetLabel;
+  const bankAccountId = form.watch('subiektBankAccountId') ?? '';
+  const stanowiskoKasoweId = form.watch('subiektStanowiskoKasoweId') ?? '';
+
+  const bankAccountsQuery = useSubiektBankAccountsQuery(connection.id, { enabled: isTransfer });
+  const cashRegistersQuery = useSubiektCashRegistersQuery(connection.id);
+  const setDefaultBankAccount = useSetDefaultBankAccountMutation();
+
+  const accounts = bankAccountsQuery.data ?? [];
+  // Payer-routing warning shows ONLY when the live list spans more than one
+  // seller Podmiot — on a single-payer install it stays hidden (decision 5/6).
+  const hasMultiplePayers = useMemo(
+    () => new Set(accounts.map((a) => a.ownerPodmiotId)).size > 1,
+    [accounts],
+  );
+  // Group by the stable numeric `ownerPodmiotId` (not the display name) so two
+  // Podmioty sharing a name never merge into one optgroup (PR review). The
+  // group's rendered label still prefers `ownerName`.
+  const accountsByOwner = useMemo(() => {
+    const groups = new Map<number, { label: string; accounts: typeof accounts }>();
+    for (const account of accounts) {
+      const existing = groups.get(account.ownerPodmiotId);
+      if (existing) existing.accounts.push(account);
+      else
+        groups.set(account.ownerPodmiotId, {
+          label: account.ownerName ?? `Podmiot ${account.ownerPodmiotId}`,
+          accounts: [account],
+        });
+    }
+    return groups;
+  }, [accounts]);
+
+  const registers = cashRegistersQuery.data ?? [];
+
+  function onBankAccountChange(accountId: string): void {
+    syncStructuredToJson('subiektBankAccountId', accountId);
+    const account = accounts.find((a) => a.id === accountId);
+    // Keep Subiekt's own "default account" in sync with the operator's pick.
+    // `.mutate()` (not `mutateAsync`) so a bridge failure is handled by the
+    // hook's `onError` toast and never surfaces as an unhandled rejection.
+    if (account && !account.isDefault) {
+      setDefaultBankAccount.mutate({ connectionId: connection.id, accountId });
+    }
+  }
 
   return (
     <>
@@ -75,6 +149,136 @@ export function SubiektStructuredSection({
           ))}
         </Select>
       </FormField>
+
+      <InlineDisclosure
+        label={t('subiekt.settings.payment.summary', 'Payment method for invoice:')}
+        value={effectiveLabel}
+      >
+        <FormField
+          label={t('subiekt.settings.payment.method.label', 'Default payment method')}
+          name="subiektPaymentMethod"
+          error={form.formState.errors.subiektPaymentMethod?.message}
+          description={t(
+            'subiekt.settings.payment.method.help',
+            'Sent on every issued invoice. Leave unset to let Subiekt apply its own default; pick Transfer only when the seller has a bank account configured in Subiekt.',
+          )}
+        >
+          <Select
+            value={paymentMethod}
+            onChange={(event) => syncStructuredToJson('subiektPaymentMethod', event.target.value)}
+            disabled={!configIsParseable}
+            invalid={Boolean(form.formState.errors.subiektPaymentMethod)}
+          >
+            <option value="">{paymentUnsetLabel}</option>
+            <option value="cash">{paymentMethodLabels.cash}</option>
+            <option value="transfer">{paymentMethodLabels.transfer}</option>
+          </Select>
+        </FormField>
+
+        {isTransfer ? (
+          bankAccountsQuery.isLoading ? (
+            <p className="muted-text">
+              {t('subiekt.settings.payment.account.loading', 'Checking Subiekt for bank accounts…')}
+            </p>
+          ) : bankAccountsQuery.isError ? (
+            <p className="muted-text">
+              {t(
+                'subiekt.settings.payment.account.error',
+                "Couldn't check Subiekt for bank accounts — invoices will use whatever was last saved.",
+              )}
+            </p>
+          ) : accounts.length > 0 ? (
+            <>
+              <FormField
+                label={t('subiekt.settings.payment.account.label', 'Bank account for Transfer invoices')}
+                name="subiektBankAccountId"
+              >
+                <Select
+                  value={bankAccountId}
+                  onChange={(event) => onBankAccountChange(event.target.value)}
+                  disabled={!configIsParseable}
+                >
+                  <option value="" disabled>
+                    {t('subiekt.settings.payment.account.placeholder', 'Select a bank account…')}
+                  </option>
+                  {hasMultiplePayers
+                    ? Array.from(accountsByOwner.entries()).map(([ownerPodmiotId, group]) => (
+                        <optgroup key={ownerPodmiotId} label={group.label}>
+                          {group.accounts.map((account) => (
+                            <option key={account.id} value={account.id}>
+                              {account.bankName} — {account.accountNumber}
+                              {account.isDefault ? ' (default in Subiekt)' : ''}
+                            </option>
+                          ))}
+                        </optgroup>
+                      ))
+                    : accounts.map((account) => (
+                        <option key={account.id} value={account.id}>
+                          {account.bankName} — {account.accountNumber}
+                          {account.isDefault ? ' (default in Subiekt)' : ''}
+                        </option>
+                      ))}
+                </Select>
+              </FormField>
+              {hasMultiplePayers ? (
+                <p className="muted-text">
+                  {t(
+                    'subiekt.settings.payment.account.multiPayerWarning',
+                    'This Subiekt install has more than one płatnik. OpenLinker cannot yet confirm which płatnik an invoice is issued under, so the account picked here is not guaranteed to match the issuing payer.',
+                  )}
+                </p>
+              ) : null}
+            </>
+          ) : (
+            <p className="muted-text">
+              {t(
+                'subiekt.settings.payment.account.empty',
+                'No bank account is configured in Subiekt, so Transfer invoices will use whatever form Subiekt applies by default. Add an account under Konfiguracja systemu → Rachunki bankowe, then reload this page.',
+              )}
+            </p>
+          )
+        ) : null}
+
+        <FormField
+          label={t('subiekt.settings.cashRegister.label', 'Cash register (Stanowisko Kasowe)')}
+          name="subiektStanowiskoKasoweId"
+          description={t(
+            'subiekt.settings.cashRegister.help',
+            'Invoices are always issued from the Centrala branch — the bridge does not support switching Oddział.',
+          )}
+        >
+          {cashRegistersQuery.isLoading ? (
+            <p className="muted-text">
+              {t('subiekt.settings.cashRegister.loading', 'Checking Subiekt for cash registers…')}
+            </p>
+          ) : cashRegistersQuery.isError ? (
+            <p className="muted-text">
+              {t(
+                'subiekt.settings.cashRegister.error',
+                "Couldn't check Subiekt for cash registers — invoices will use the default register.",
+              )}
+            </p>
+          ) : (
+            <Select
+              value={stanowiskoKasoweId}
+              onChange={(event) =>
+                syncStructuredToJson('subiektStanowiskoKasoweId', event.target.value)
+              }
+              disabled={!configIsParseable}
+            >
+              <option value="">
+                {t('subiekt.settings.cashRegister.unset', 'Default (Subiekt decides)')}
+              </option>
+              {registers.map((register) => (
+                <option key={register.id} value={String(register.id)}>
+                  {register.name ?? `#${register.id}`}
+                  {register.symbol ? ` (${register.symbol})` : ''}
+                </option>
+              ))}
+            </Select>
+          )}
+        </FormField>
+      </InlineDisclosure>
 
       <CapabilityTogglesSection
         descriptors={descriptors}

--- a/apps/web/src/plugins/subiekt/index.ts
+++ b/apps/web/src/plugins/subiekt/index.ts
@@ -45,6 +45,7 @@ import { SubiektStructuredSection } from './components/subiekt-structured-sectio
 import { SubiektInvoiceDetailSection } from './components/subiekt-invoice-detail-section';
 import { SubiektInvoiceCorrectionFlow } from './components/subiekt-invoice-correction-flow';
 import { SUBIEKT_CAPABILITY_DESCRIPTORS } from './subiekt-capability-descriptors';
+import { subiektConnectionConfig } from './subiekt-connection-config';
 
 export const subiektPlugin: OpenLinkerPlugin = definePlugin({
   id: 'subiekt',
@@ -62,6 +63,7 @@ export const subiektPlugin: OpenLinkerPlugin = definePlugin({
       badge: 'Sfera bridge',
     },
     capabilityDescriptors: SUBIEKT_CAPABILITY_DESCRIPTORS,
+    connectionConfig: subiektConnectionConfig,
     StructuredConfigSection: SubiektStructuredSection,
     CredentialsPanel: SubiektCredentialsPanel,
     invoiceDetailSection: SubiektInvoiceDetailSection,

--- a/apps/web/src/plugins/subiekt/subiekt-connection-config.ts
+++ b/apps/web/src/plugins/subiekt/subiekt-connection-config.ts
@@ -1,0 +1,120 @@
+/**
+ * Subiekt Connection-Config Contribution (#1324, on the #1330 seam)
+ *
+ * The non-render half of Subiekt's per-invoice payment structured-config
+ * editing, plugged into `EditConnectionForm` via
+ * `PlatformContribution.connectionConfig` (the same seam KSeF uses). Owns the
+ * three #1324 fields — payment method, bank account, cash register (Stanowisko
+ * Kasowe) — so they are assembled by the plugin rather than growing the host
+ * `edit-connection.schema.ts` (PR review IMPORTANT #1):
+ *
+ *   - `schemaShape` — the Zod field fragment merged into the edit-connection
+ *     schema when a Subiekt connection is edited.
+ *   - `readConfigToForm` — hydration from flat `config.{defaultPaymentMethod,
+ *     bankAccountId,defaultStanowiskoKasoweId}`. Payment method is tri-state:
+ *     an absent key hydrates to `''` (unset — send-nothing, the bridge keeps
+ *     its own default), NOT a forced `'cash'` (review IMPORTANT #2).
+ *   - `applyToConfig` — per-keystroke partial-patch assembly: flat scalars with
+ *     delete-on-empty; the two id fields parse to the bridge-native `number`.
+ *
+ * The `declare module` block merges the three field names into
+ * `PluginEditConnectionFields` so `form.watch('subiektPaymentMethod')` etc.
+ * stay statically typed in `subiekt-structured-section.tsx`. It enters the TS
+ * import graph through `plugins/subiekt/index.ts` → `plugins/index.ts`.
+ *
+ * The pre-existing Subiekt fields (`subiektBridgeUrl`, `subiektTriggerModel`,
+ * `subiektCapabilities`) remain host-inlined for now — their #1330 migration is
+ * out of scope for #1324.
+ *
+ * @module plugins/subiekt
+ */
+import { z } from 'zod';
+import type { ConnectionConfigContribution } from '../../shared/plugins';
+import { readOptionalConfigString } from '../../shared/plugins';
+
+declare module '../../shared/plugins/plugin.types' {
+  interface PluginEditConnectionFields {
+    /**
+     * #1324 — Subiekt payment method → flat `config.defaultPaymentMethod`
+     * (`'cash' | 'transfer'`). Tri-state: empty string means unset
+     * (send-nothing; the bridge keeps its own default).
+     */
+    subiektPaymentMethod?: string;
+    /**
+     * #1324 — Subiekt bank account → flat `config.bankAccountId` (bridge-native
+     * int). Form holds a string; parsed to a number at serialize, key deleted
+     * when empty.
+     */
+    subiektBankAccountId?: string;
+    /**
+     * #1324 — Subiekt cash register (Stanowisko Kasowe) → flat
+     * `config.defaultStanowiskoKasoweId` (bridge-native int). Form holds a
+     * string; parsed to a number at serialize, deleted when empty. No Oddział
+     * counterpart — that axis is session-bound and not selectable (decision 8b).
+     */
+    subiektStanowiskoKasoweId?: string;
+  }
+}
+
+// The explicit annotation keeps TS's excess-property check live on this
+// separate const (mirrors the KSeF precedent) so a typo'd or never-merged key
+// is a compile error at the contribution literal.
+const subiektSchemaShape: ConnectionConfigContribution['schemaShape'] = {
+  // Tri-state: empty allowed for unset (send-nothing). The bridge only sends a
+  // payment method when one is explicitly configured.
+  subiektPaymentMethod: z.union([z.enum(['cash', 'transfer']), z.literal('')]).optional(),
+  subiektBankAccountId: z.string().optional(),
+  subiektStanowiskoKasoweId: z.string().optional(),
+};
+
+/** Read the tri-state Subiekt payment method out of `config.defaultPaymentMethod`. */
+function readSubiektPaymentMethod(config: Record<string, unknown>): string {
+  return config.defaultPaymentMethod === 'cash' || config.defaultPaymentMethod === 'transfer'
+    ? config.defaultPaymentMethod
+    : '';
+}
+
+/** Read a bridge-native numeric id leaf back as the form's string shape (`''` when absent). */
+function readNumericIdAsString(config: Record<string, unknown>, key: string): string {
+  const value = config[key];
+  return typeof value === 'number' ? String(value) : '';
+}
+
+/**
+ * Merge a PARTIAL Subiekt structured patch into the config — the write side.
+ * All three fields are flat with delete-on-empty; the two id fields parse to
+ * the bridge-native `number`. Only leaves present on the patch are touched, so
+ * per-keystroke single-field patches never drop sibling keys.
+ */
+function applySubiektConfig(
+  config: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...config };
+  const paymentMethod = readOptionalConfigString(patch, 'subiektPaymentMethod');
+  if (paymentMethod !== undefined) {
+    if (paymentMethod.length === 0) delete next.defaultPaymentMethod;
+    else next.defaultPaymentMethod = paymentMethod;
+  }
+  const bankAccountId = readOptionalConfigString(patch, 'subiektBankAccountId');
+  if (bankAccountId !== undefined) {
+    if (bankAccountId.length === 0) delete next.bankAccountId;
+    else next.bankAccountId = Number(bankAccountId);
+  }
+  const stanowiskoKasoweId = readOptionalConfigString(patch, 'subiektStanowiskoKasoweId');
+  if (stanowiskoKasoweId !== undefined) {
+    if (stanowiskoKasoweId.length === 0) delete next.defaultStanowiskoKasoweId;
+    else next.defaultStanowiskoKasoweId = Number(stanowiskoKasoweId);
+  }
+  return next;
+}
+
+export const subiektConnectionConfig: ConnectionConfigContribution = {
+  schemaShape: subiektSchemaShape,
+  readConfigToForm: (config) => ({
+    subiektPaymentMethod: readSubiektPaymentMethod(config),
+    subiektBankAccountId: readNumericIdAsString(config, 'bankAccountId'),
+    subiektStanowiskoKasoweId: readNumericIdAsString(config, 'defaultStanowiskoKasoweId'),
+  }),
+  applyToConfig: applySubiektConfig,
+};

--- a/docs/plans/implementation-plan-subiekt-bank-account-payment-method.md
+++ b/docs/plans/implementation-plan-subiekt-bank-account-payment-method.md
@@ -1,0 +1,556 @@
+# Implementation Plan: Subiekt Bank-Account/Payment-Method + Oddział/Stanowisko Kasowe Per Invoice (Part A + Part B)
+
+**Date**: 2026-07-02 (revised same day after `/grill-me`)
+**Status**: Ready for implementation
+**Estimated Effort**: 3–4 days (implementation, Part A + Part B) + 0.5 day (live verification)
+**Issue**: [#1324](https://github.com/openlinker-project/openlinker/issues/1324)
+
+**Revision note**: this plan originally covered Part A only (payment method + bank account). Following a `/grill-me` session on 2026-07-02, eight decisions were made that fold Part B (Oddział/Stanowisko Kasowe, backed by the now-merged and live-verified `openlinker-subiekt-bridge#5`/PR#6) into this same plan and PR, and correct an internal contradiction discovered during the interview (Part A's original Step 12 planned to reuse the generic `useBankAccountsQuery` hook, but the approved mockup requires owner-aware data that hook doesn't carry). See §0.1 for the full decision log.
+
+---
+
+## 0. Prerequisite State (read this first)
+
+This plan does **not** start from `origin/main`. Three prerequisite PRs are merged **locally only** (no GitHub merge, no push) into two integration worktrees created for this work:
+
+| Repo | Worktree | Branch | Contents |
+|---|---|---|---|
+| `openlinker` (this monorepo) | `.claude/worktrees/1324-prereqs-integration` | `1324-prereqs-integration` | PR #1300 (inFakt FE plugin) + PR #1309 (`defaultPaymentMethod` per-connection) + PR #1310 (`BankAccountsReader`/`BankAccountDefaultSetter` core capabilities + `infakt-structured-section.tsx` pattern). Verified: `pnpm --filter @openlinker/integrations-infakt test` 135/135, `pnpm --filter @openlinker/web test` 1952/1952, both type-check clean. |
+| `openlinker-subiekt-bridge` | `~/projekty/blocky/openlinker-subiekt-bridge` (main clone, branch `3-bank-account-multi-podmiot`) | `3-bank-account-multi-podmiot` | **Updated 2026-07-02**: bridge PR #2 (bank accounts/payment) + PR #4 (multi-Podmiot fix, `openlinker-subiekt-bridge#3`) + PR #6 (Oddział/Stanowisko Kasowe selector, `openlinker-subiekt-bridge#5`) — all three **still open on GitHub** (like the OL prereqs), but the work is present + live-verified on this branch, which is the current tip. `GET /api/branches`, `GET /api/cash-registers`, and `oddzialId`/`stanowiskoKasoweId` on `POST /api/invoices` are verified end-to-end against `Nexo_Demo_1` (real Sfera, via PowerShell-from-WSL, this same machine). Tests green. |
+
+**This plan's implementation branch starts from the openlinker `1324-prereqs-integration` branch**, not `origin/main` — that is the only place `BankAccountsReader`, `BankAccountDefaultSetter`, and the inFakt reference pattern actually exist right now. When #1300/#1309/#1310 eventually merge to `main` for real, this branch should be rebased onto `main` before opening its own PR (the diff will shrink to just the Subiekt-specific commits).
+
+The plan-authoring worktree itself lives at `.claude/worktrees/1324-subiekt-bank-account-plan` (branched from local `1324-prereqs-integration`), carrying only this plan document — implementation happens in a **separate** worktree/branch per the Setup section of `/plan`, also based on `1324-prereqs-integration`.
+
+### 0.1 `/grill-me` Decision Log (2026-07-02)
+
+Eight decisions, made in order, that supersede parts of the original (Part-A-only) plan below. Where a later section still shows the pre-grill reasoning, this log is authoritative.
+
+1. **Part B is folded into this plan and this PR**, not a separate follow-up. Rationale: the approved combined mockup (`subiekt-full-config-section.html`) already presents Part A+B as one section; splitting into two PRs touching the same files would only create merge risk, not reduce it. Bridge PR #6 is merged and live-verified, so there's no dependency reason to wait either.
+2. **No new core capability for Part B.** `listBranches()`/`listCashRegisters()` stay Subiekt-local (on `SubiektBridgeClient` + a Subiekt-specific controller/hook) — inFakt/KSeF have no branch concept, so a `BranchAwareIssuer`-style core port would be a speculative abstraction with one consumer, same reasoning `docs/engineering-standards.md` already argues against.
+3. **New backend file: `apps/api/src/integrations/http/subiekt.controller.ts`**, modeled on the existing plugin-specific-endpoint precedent at `apps/api/src/integrations/http/allegro.controller.ts` (e.g. its `GET integrations/allegro/connections/:id/responsible-producers` route, which is Allegro-only with no core capability behind it — same shape as this issue's need). Routes: `GET integrations/subiekt/connections/:id/branches`, `GET integrations/subiekt/connections/:id/cash-registers`, and (per decision 6) `GET integrations/subiekt/connections/:id/bank-accounts` (owner-aware variant).
+4. **Cash-register filtering by branch is client-side.** The adapter/controller still expose `listCashRegisters()` unfiltered (matching the bridge's full capability); the FE fetches once and filters locally when the operator changes the Oddział select, rather than round-tripping per selection change. Data volume is small (single digits to low tens of registers) and static within one form-edit session.
+5. **Payer-routing limitation gets an explicit, dated sign-off, not a silent doc footnote.** Recorded here: **the user has reviewed and accepted, on 2026-07-02, that OpenLinker cannot guarantee a picked bank account's owning Podmiot matches the invoice's actual issuing payer on a genuinely multi-Podmiot install** (distinct from the Oddział axis, which Part B does close). This is a real fiscal-data-adjacent risk (wrong bank details potentially associated with the wrong legal entity's invoice), accepted as an MVP limitation with the explicit UI mitigation in decision 6 rather than silently shipped.
+6. **Corrects a contradiction found during the interview**: Part A's original Step 12 planned to reuse the generic, cross-plugin `useBankAccountsQuery` hook (core-shaped `InvoicingBankAccount`, no owner field) — but the already-approved mockup groups accounts by owner (`<optgroup label="Moja Firma Sp. z o.o.">`), which that hook cannot supply without widening the neutral core type (rejected, would leak Subiekt vocabulary into `libs/core`, also used by inFakt). **Resolution**: Subiekt's structured section uses its own Subiekt-specific hook (`use-subiekt-bank-accounts-query.ts`) against the new controller's owner-aware endpoint (decision 3), not the generic core-capability hook. The generic `BankAccountsReader`/`BankAccountDefaultSetter` core-capability implementation on the adapter is **still built** (issue's Acceptance Criteria require it, and it's a legitimate seam for any future generic consumer) — it's just not what Subiekt's own FE happens to render from. The FE computes `distinct(ownerPodmiotId).length > 1` from the owner-aware endpoint's response and renders the payer-routing warning **only when true**, not unconditionally on every install.
+7. **Orchestration units re-sequenced** (see §10) to avoid parallel edits to the same files now that Part B touches the same files as Part A, and to reflect the new controller's dependency on the adapter: **A, B parallel → C → E (new controller) → D (FE) → quality gate → E2E**. D is no longer independent of the backend units, since it needs E's endpoints for the new Subiekt-specific hooks.
+8b. **(Added 2026-07-03, mid-implementation) Part B narrows to Stanowisko Kasowe only — the Oddział axis is cut.** A live bridge investigation found that `IKontekstBiznesowy` (the Sfera session's business context) binds **Oddział / Magazyn / StanowiskoKasowe / RachunekBankowy / Podmiot as read-only to the logged-in session** ("Szef" → Oddział=Centrala 100000, Stanowisko=100065, Rachunek=100004, Podmiot=100007). A per-request `oddzialId` cannot override the session's branch — Sfera compares the document's `JednostkaOrganizacyjna`/`StanowiskoKasowe` **entity nav-references** against the session context and rejects a mismatch (both the post-create patch and `ParametryTworzeniaDokumentu`-at-create paths fail identically). To issue under a different Oddział, the bridge would have to log in as a different Subiekt user with a different default workstation — impossible under the current single-fixed-session bridge model. **Consequences, per user direction:**
+   - **Oddział selector is cut entirely** — from the FE (don't even show it read-only, it would only mislead), from `SubiektConnectionConfig` (`defaultOddzialId` removed), from the adapter's `issueInvoice` field-stamping, and from discovery (no `listBranches()`, no `GET .../branches` controller route). OL never sends `oddzialId`.
+   - **Stanowisko Kasowe IS kept as a real, working per-document field.** Unlike Oddział, `stanowiskoKasoweId` alone is accepted by the bridge and genuinely routes the document through that register (this is why bridge PR #6 was narrowed to `stanowiskoKasoweId` as the real field). The FE keeps a functional Stanowisko Kasowe `<Select>`, with one help line: "faktura zawsze wystawiana z oddziału Centrala — most nie obsługuje przełączania oddziału."
+   - **Part A (bank account) is NOT affected** — `RachunekBankowyMojejFirmy` is written as a descriptive `{Nazwa, Numer}` **snapshot** on the document (plain strings, explicitly "not an FK"), not an entity reference matched against the session context. It's a copy, so a different account than the session default writes fine. This is the mechanism issue #1 originally live-verified (transfer with account 100007). Optional: a quick live re-test (transfer with an account ≠ 100004) in the §11 verification would confirm 100%, but the architectural difference (descriptive copy vs. session-matched entity ref) is a strong enough signal to treat Part A as safe.
+   - **Client-side "filter registers by branch" (old decision 4) is moot** — with no Oddział selector there's nothing to filter by; the register picker just lists all registers. Each register's own `oddzialId` tag may still be shown as an informational label.
+
+8. **Live verification is two-track, not one heavyweight PrestaShop flow**: (a) OpenLinker-side screenshots are visual-only (connection edit form renders correctly, live data populates the selects) — no requirement to drive a full order-to-invoice flow through the OL UI; (b) functional proof (payment method / bank account / Oddział / Stanowisko Kasowe actually reach Subiekt and produce the expected document) is done by **calling the bridge API directly** (as already demonstrated this session via PowerShell-from-WSL against `Nexo_Demo_1`), issuing **several real invoices with different configurations** (cash/no-branch; transfer+account; branch+register matching; branch-without-register rejected; mismatched branch/register rejected) and confirming each resulting document's actual payment/branch/register data matches what was configured — not just that the HTTP call returned 200.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Give the Subiekt invoicing adapter the same bank-account/payment-method-per-invoice capability inFakt already has — an operator picks a default payment method (`cash`/`transfer`) and, for transfer, a specific seller bank account, per Subiekt connection. The choice is threaded into every issued invoice.
+
+**Context**: The Subiekt bridge (`openlinker-subiekt-bridge` PR #2) now exposes `GET /api/bank-accounts`, accepts optional `paymentMethod`/`bankAccountId` on `POST /api/invoices`, and exposes `PUT /api/bank-accounts/{id}/default`. OpenLinker's `SubiektInvoicingAdapter` doesn't consume any of it yet. The identical shape was already solved for inFakt (#1303/#1308): two core capabilities (`BankAccountsReader`, `BankAccountDefaultSetter`), capability-generic API endpoints, and an FE structured-config pattern. This work reuses all three verbatim for Subiekt — no new core ports.
+
+**Classification**: Integration (bridge client + adapter) + Frontend (structured-config section). No CORE changes — `BankAccountsReader`/`BankAccountDefaultSetter` already exist in `libs/core/src/invoicing/domain/ports/capabilities/` from #1310.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+
+**Part A — payment method / bank account:**
+- `BridgeIssueInvoiceRequest` gains optional `paymentMethod`/`bankAccountId`.
+- `SubiektBridgeClient` (+ HTTP impl + fake) gains `listBankAccounts()` / `setDefaultBankAccount(id)`.
+- `SubiektConnectionConfig` gains `defaultPaymentMethod?: 'cash' | 'transfer'` and `bankAccountId?: number`.
+- `SubiektInvoicingAdapter implements BankAccountsReader, BankAccountDefaultSetter` (generic core capabilities, built for the API's own capability-generic surface — decision 6) in addition to its existing `InvoicingPort, RegulatoryStatusReader, CorrectionIssuer`.
+- `SubiektInvoicingAdapter.issueInvoice` sends the configured payment fields when set.
+
+**Part B — Oddział (branch) / Stanowisko Kasowe (cash-register station), added after `/grill-me` (decision 1):**
+- `BridgeIssueInvoiceRequest` gains optional `oddzialId`/`stanowiskoKasoweId`.
+- `SubiektBridgeClient` (+ HTTP impl + fake) gains `listBranches()` / `listCashRegisters()` proxying `GET /api/branches` / `GET /api/cash-registers`.
+- `SubiektConnectionConfig` gains `defaultOddzialId?: number` / `defaultStanowiskoKasoweId?: number`.
+- No new core capability (decision 2) — these stay Subiekt-local methods on the adapter, not implementing any `libs/core` port.
+
+**Shared backend + frontend (Part A and B together):**
+- New file `apps/api/src/integrations/http/subiekt.controller.ts` (decision 3) exposing `GET .../branches`, `GET .../cash-registers`, and an owner-aware `GET .../bank-accounts` (decision 6) — none of these are capability-generic, all are Subiekt-only routes resolving the concrete adapter.
+- FE: extend the **existing** `apps/web/src/plugins/subiekt/components/subiekt-structured-section.tsx` with one combined `InlineDisclosure` covering payment method, bank account (grouped by owning Podmiot, with a conditional payer-routing warning per decision 5/6), Oddział, and Stanowisko Kasowe (client-side filtered by Oddział, decision 4) — following the approved `subiekt-full-config-section.html` mockup's five states.
+- New Subiekt-specific FE hooks (`use-subiekt-bank-accounts-query.ts`, `use-subiekt-branches-query.ts`, `use-subiekt-cash-registers-query.ts`) calling the new controller — **not** the generic `useBankAccountsQuery`/`useSetDefaultBankAccountMutation` (decision 6 correction).
+- Tests: adapter unit tests (Part A + B), bridge HTTP client unit tests, fake-adapter parity, new controller unit tests, FE component tests, `subiekt-adapter.factory.spec.ts` config-parsing coverage for all four new config fields.
+- Live verification, two-track per decision 8: OL-side screenshots (visual only) + direct bridge-API functional verification issuing several real invoices with different configurations.
+
+### Out of Scope
+- `SubiektInvoicingAdapter.issueCorrection` does **not** get payment fields — see [§4 Wire-contract correction](#wire-contract-correction-vs-the-issue-text) below: the bridge's korekta endpoint (`POST /api/invoices/{id}/corrections`) does not accept `paymentMethod`/`bankAccountId`/`oddzialId`/`stanowiskoKasoweId` at all (confirmed for Part A's fields against the bridge source; Part B's fields follow the same contract, only added to `CreateInvoiceRequestDto`). Sending them would be silently ignored at best; the plan simply never builds them into the korekta request.
+- No changes to `InvoicingController` (the generic, capability-driven controller) — Part A's `GET/POST .../bank-accounts...` routes there are already capability-generic (added by #1310) and light up automatically. Part B and the owner-aware bank-accounts variant deliberately do NOT go there (decisions 2, 3, 6) — they live on the new Subiekt-only controller instead.
+- No change to `documentType: 'PA'` (paragon) handling — the bridge rejects payment selection for PA, and the current adapter's `issueInvoice` path doesn't special-case PA either; not exercised by this change.
+- Fixing the pre-existing `subiektBridgeUrl` FE/BE config-key mismatch (see Assumptions) — noted, not touched, unrelated to this issue.
+- Merging any of the three openlinker prerequisite PRs (#1300/#1309/#1310) to GitHub — stays purely local per explicit instruction. (Bridge-side PRs #2/#4/#6 are a different repo and are already genuinely merged — see §0.)
+- A full PrestaShop-order-to-invoice E2E flow — decision 8 replaces this with direct bridge-API functional verification; PrestaShop dev-stack is not required for this issue's verification.
+
+### Constraints
+- No new core capability for Part B (decision 2) — `libs/core/**` gains nothing; Part A's use of the two existing capabilities is unchanged.
+- Must follow the inFakt pattern exactly where it applies, and deviate explicitly (with a documented reason) where Subiekt's needs diverge — both the original scalar-vs-snapshot simplification (§7 Alternative 1) and the new generic-hook-vs-Subiekt-specific-hook correction (decision 6) are documented deviations, not oversights.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: Integration (`libs/integrations/subiekt/`) + Frontend (`apps/web/src/plugins/subiekt/`, `apps/web/src/features/connections/`). No CORE, no Infrastructure/persistence, no new Interface-layer code (API controller is unchanged).
+
+**Capabilities Involved**:
+- `InvoicingPort` (existing, unchanged) — `libs/core/src/invoicing/domain/ports/invoicing.port.ts`
+- `BankAccountsReader` (existing, from #1310) — `libs/core/src/invoicing/domain/ports/capabilities/bank-accounts-reader.capability.ts`
+- `BankAccountDefaultSetter` (existing, from #1310) — `libs/core/src/invoicing/domain/ports/capabilities/bank-account-default-setter.capability.ts`
+
+**Existing Services Reused**:
+- `InvoicingController.getBankAccounts` / `.setDefaultBankAccount` (`apps/api/src/invoicing/http/invoicing.controller.ts`) — capability-generic, zero changes needed.
+- `useBankAccountsQuery` / `useSetDefaultBankAccountMutation` (`apps/web/src/features/connections/hooks/`) — connection-generic, zero changes needed.
+- `InlineDisclosure` (`apps/web/src/shared/ui/inline-disclosure.tsx`) — reused as-is.
+- `syncStructuredToJson` (existing prop on `StructuredConfigSectionProps`) — reused for both new scalar fields; **no new whole-object serializer prop needed** (see §7).
+
+**New Components Required**:
+- Four new methods on `SubiektBridgeClient` interface + `SubiektBridgeHttpClient` implementation + `FakeSubiektBridgeAdapter`: `listBankAccounts()`, `setDefaultBankAccount(id)` (Part A), `listBranches()`, `listCashRegisters()` (Part B).
+- Four new optional fields on `BridgeIssueInvoiceRequest` (`subiekt-bridge.types.ts`): `paymentMethod`, `bankAccountId`, `oddzialId`, `stanowiskoKasoweId`.
+- Four new optional fields on `SubiektConnectionConfig` + matching `SubiektConnectionConfigDto` validation: `defaultPaymentMethod`, `bankAccountId`, `defaultOddzialId`, `defaultStanowiskoKasoweId`.
+- `implements BankAccountsReader, BankAccountDefaultSetter` on `SubiektInvoicingAdapter` (Part A, generic core capabilities), plus two new **Subiekt-local, non-core** methods `listBranches()`/`listCashRegisters()` (Part B) and one owner-aware `listBankAccountsWithOwner()` (decision 6) — all behind a 4th constructor parameter (`config: SubiektConnectionConfig`) mirroring `InfaktInvoicingAdapter`.
+- **New file** `apps/api/src/integrations/http/subiekt.controller.ts` (decision 3) — resolves the connection's adapter, narrows to the concrete `SubiektInvoicingAdapter` (no capability guard needed since these aren't core capabilities), exposes `GET connections/:id/branches`, `GET connections/:id/cash-registers`, `GET connections/:id/bank-accounts` (owner-aware variant, distinct route or query param from the generic `InvoicingController` one — see Phase 4 below for the exact path).
+- Three new Subiekt-specific FE hooks (`apps/web/src/plugins/subiekt/hooks/` or co-located with the structured section) replacing the plan's original intent to reuse `useBankAccountsQuery` (decision 6).
+- Form fields threaded through `EditConnectionForm.tsx` + `edit-connection.schema.ts`: `subiektPaymentMethod`, `subiektBankAccountId` (Part A), `subiektOddzialId`, `subiektStanowiskoKasoweId` (Part B) — same shared FE files inFakt's #1303/#1308 touched for its own fields.
+
+**Core vs Integration Justification**: Part A is Integration + Frontend, no new port — `BankAccountsReader`/`BankAccountDefaultSetter` were designed generically in #1310 specifically so a second provider (Subiekt) could adopt them without touching `libs/core`. Part B is Integration + Interface (new controller) + Frontend, **deliberately with no core port** (decision 2) — Oddział/Stanowisko Kasowe has no cross-plugin abstraction to join (inFakt/KSeF have no branch concept), so introducing one now would be a speculative, single-consumer abstraction.
+
+---
+
+## 4. External / Domain Research
+
+### Bridge wire contract (verified against the merged bridge source, not just docs)
+
+Read directly from `~/projekty/blocky/openlinker-subiekt-bridge-1324-integration`:
+
+**`GET /api/bank-accounts`** (`BankAccountsEndpoints.cs`, shape as of bridge PR #4 — see "Multi-payer caveat" below):
+```json
+{
+  "success": true,
+  "data": {
+    "count": 2,
+    "accounts": [
+      { "id": 100004, "name": "Rachunek podstawowy", "number": "00 10101010 1111 1111 1111 1111",
+        "bankNumber": "", "description": "", "currency": "PLN", "isVatAccount": false, "isDefault": true,
+        "ownerPodmiotId": 1, "ownerName": "Moja Firma Sp. z o.o." }
+    ]
+  }
+}
+```
+`ownerPodmiotId`/`ownerName` were added by bridge PR #4 (fixing `openlinker-subiekt-bridge#3`) — the original PR #2 query silently returned only one seller Podmiot's accounts on a multi-payer install (`... = (SELECT TOP 1 Id FROM Podmioty WHERE Typ=2 AND Podtyp=11)`); PR #4 widens it to `IN (...)` and tags each account with its owning Podmiot.
+
+**`PUT /api/bank-accounts/{id}/default`**:
+```json
+{ "success": true, "data": { "bankAccountId": 100007, "isDefault": true } }
+```
+Idempotent — selecting the current default is a no-op success.
+
+**`POST /api/invoices`** — two ADDITIVE optional fields, both absent = unchanged legacy behavior:
+```json
+{ "paymentMethod": "transfer", "bankAccountId": 100007 }
+```
+Strict server-side rules (`PaymentSelection.TryCreate` in `Subiekt.Bridge.Domain/Invoices/PaymentSelection.cs`): `transfer` requires a positive `bankAccountId`; `cash` must not carry one; a bare `bankAccountId` without `paymentMethod` is rejected; not supported for `documentType: "PA"`. Vocabulary errors are 400; combination/account errors are 422.
+
+#### Wire-contract correction vs. the issue text
+
+The GitHub issue's Acceptance Criteria say to thread payment fields into "`issueInvoice`/`issueCorrection`". **Verified against the bridge source, this is only half-true**: `bridge/Subiekt.Bridge.Api/Contracts/InvoiceContracts.cs` shows `PaymentSelection.TryCreate(req.PaymentMethod, req.BankAccountId)` is called **only** inside `InvoiceContractMapper.Build`, which backs `CreateInvoiceRequestDto` (the `POST /api/invoices` issue path). A repo-wide grep for `PaymentMethod`/`BankAccountId` across `bridge/Subiekt.Bridge.Api/`, `bridge/Subiekt.Bridge.Application/`, `bridge/Subiekt.Bridge.Domain/` turns up **no** korekta contract file — the correction endpoint (`POST /api/invoices/{origId}/corrections`, `BridgeKorektaRequest`) has no payment-selection fields at all. **Decision: `BridgeKorektaRequest` is left unchanged; `SubiektInvoicingAdapter.issueCorrection` does not build or send payment fields.** This is a plan-level correction of the issue's proposed solution, made explicit here rather than silently diverging.
+
+#### Multi-payer caveat (bridge issue #3 / PR #4 — read this before implementing Step 1)
+
+The operator's real Subiekt install has **more than one seller Podmiot** (multiple płatnicy/oddziały) — confirmed live, not hypothetical. Bridge PR #2's original bank-account queries used `TOP 1`, silently dropping every payer's accounts except one; bridge PR #4 (`openlinker-subiekt-bridge#3`) fixes the silent-data-loss part by widening to `IN (...)` and tagging each returned account with `ownerPodmiotId`/`ownerName`.
+
+**What PR #4 does NOT fix**: `POST /api/invoices`'s `CreateInvoiceRequestDto` still has no Oddział/Płatnik selector at all — the bridge has no way to route a specific invoice to a specific payer. So even with the corrected account list, OL cannot guarantee that a `bankAccountId` picked in the FE (owned by Payer B) matches whichever payer Subiekt actually issues the resulting document under (Subiekt's own internal default, opaque to the bridge/OL). This is tracked as open, unresolved work on `openlinker-subiekt-bridge#3` and is explicitly **not** blocking for this plan.
+
+**Decisions this plan makes as a result**:
+- `BridgeBankAccount` (Step 1 below) gains `ownerPodmiotId: number` and `ownerName: string | null` fields, matching PR #4's wire shape — captured so the data isn't lost, but **not** propagated into the shared core `InvoicingBankAccount` type (that type is also inFakt's, which has no multi-payer concept — widening it would leak Subiekt-specific vocabulary into `libs/core`, violating the "core stays neutral" invariant this whole capability pattern depends on).
+- `listBankAccounts()` (Step 9) maps the bridge shape to the neutral `InvoicingBankAccount` and **drops** `ownerPodmiotId`/`ownerName` in that mapping — the FE structured section (Step 12) sees a flat list with no owner distinction, same as every other `BankAccountsReader` consumer.
+- **Known MVP limitation, not fixed by this plan**: the FE cannot yet label accounts by payer, and OL cannot verify a picked account's owner matches the invoice's actual issuing payer. Acceptance criteria (§9) call this out explicitly rather than silently shipping a picker that implies a stronger guarantee than the bridge can deliver.
+- **Pre-implementation gate**: bridge PR #2 *and* PR #4 should both be merged before this plan's live E2E verification (§11) runs against the operator's real multi-payer install — verifying against PR #2 alone would reproduce the truncated-account-list bug PR #4 fixes, giving a false-negative E2E result.
+
+### Part B bridge wire contract (`openlinker-subiekt-bridge#5` / PR #6, merged and live-verified)
+
+**`GET /api/branches`**:
+```json
+{ "count": 2, "branches": [{ "id": 100001, "name": "Pachnidło" }, { "id": 100002, "name": "Centrum Handlowe" }] }
+```
+
+**`GET /api/cash-registers`** (optional `?oddzialId=` filter, unused by this plan per decision 4 — always fetched unfiltered, filtered client-side):
+```json
+{ "count": 4, "cashRegisters": [
+  { "id": 100065, "name": "Kasa Centralna", "symbol": "CENTR", "oddzialId": null },
+  { "id": 100066, "name": "Kasa Outlet", "symbol": "OUTLET", "oddzialId": null }
+] }
+```
+`oddzialId: null` means unlinked — per the live probe (`docs/spikes/podmioty-oddzial-stanowisko-probe-findings.md` in the bridge repo), most cash registers on a real install have no branch link at all; only explicitly-linked ones are branch-restricted.
+
+**`POST /api/invoices`** gains `oddzialId?: number` / `stanowiskoKasoweId?: number`, live-verified validation: `oddzialId` alone is rejected (422 — Sfera's implicit register resolution doesn't reach across branches); `stanowiskoKasoweId` alone is accepted (keeps the document's default branch); both together are checked by the bridge itself (register must be linked to the given Oddział, or unlinked) **before** the request ever reaches Sfera.
+
+### Internal pattern (inFakt #1303/#1308, read from the merged worktree)
+
+`InfaktInvoicingAdapter` (`libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts`):
+- Takes a 4th constructor param `config: InfaktConnectionConfig = {}`, derives `this.paymentMethod = config.defaultPaymentMethod ?? 'cash'` and `this.bankAccount = config.bankAccount`.
+- `implements ... BankAccountsReader, BankAccountDefaultSetter`.
+- `listBankAccounts()` — one HTTP GET, maps provider shape → `InvoicingBankAccount[]`.
+- `setDefaultBankAccount(accountId)` — one HTTP PUT/POST.
+- A private `bankAccountFields()` helper returns `{}` unless `paymentMethod === 'transfer'` **and** a bank account is configured; spread into both `issueInvoice` and `issueCorrection` payloads with `...this.bankAccountFields()`.
+
+`infakt-structured-section.tsx` (`apps/web/src/plugins/infakt/components/`): payment-method `<Select>` + conditional bank-account `<Select>`, both inside one `InlineDisclosure`, using `useBankAccountsQuery(connection.id, { enabled: isTransfer })` and `useSetDefaultBankAccountMutation()`. On account pick: `form.setValue('infaktBankAccount', {...}, { shouldDirty: true })` then `syncInfaktBankAccountToJson?.()`, plus a live call to `setDefaultBankAccount.mutateAsync(...)` when the picked account isn't already the provider's default.
+
+**Key structural difference driving this plan's simplification**: `InfaktBankAccountConfig` is a 3-field snapshot object (`{ id, accountNumber, bankName }`) because inFakt's `issueInvoice` payload needs `bank_account`/`bank_name` **strings** at issuance time — the adapter never re-fetches by id. Subiekt's bridge, by contrast, only ever needs the **numeric `bankAccountId`** on the wire (`POST /api/invoices` takes `bankAccountId: number`, not account details) — so `SubiektConnectionConfig.bankAccountId` can be a bare `number`, no snapshot object, no dedicated whole-object FE serializer. See §7 for why this is deliberate, not an oversight.
+
+### Current Subiekt adapter (verified against the merged worktree)
+
+- `SubiektInvoicingAdapter.issueInvoice` (`libs/integrations/subiekt/src/infrastructure/adapters/subiekt-invoicing.adapter.ts:127-139`) builds the bridge request inline: `documentType`, `currency`, `orderId`, `idempotencyKey`, `buyer`, `lines`. This is where `paymentMethod`/`bankAccountId` get spread in.
+- Constructor today: `(bridge, connectionId, logger)` — 3 params, no config. Needs a 4th `config: SubiektConnectionConfig = {}` param, mirroring inFakt exactly.
+- `SubiektAdapterFactory.createAdapters` (`libs/integrations/subiekt/src/application/subiekt-adapter.factory.ts`) already parses `connection.config` into `SubiektConnectionConfig` via `validateAndParseConfig` before constructing the client — the new fields get parsed there and passed into the adapter constructor.
+- `SubiektConnectionConfig` today (`libs/integrations/subiekt/src/domain/types/subiekt-connection-config.types.ts`) has only `bridgeBaseUrl` + `timeoutMs`.
+- `SubiektConnectionConfigDto` (`libs/integrations/subiekt/src/application/dto/subiekt-connection-config.dto.ts`) is the class-validator shape backing the config-shape validator adapter — needs the two new optional fields added with matching decorators.
+- `FakeSubiektBridgeAdapter` (`libs/integrations/subiekt/src/testing/fake-subiekt-bridge.adapter.ts`) is the in-memory `SubiektBridgeClient` double consumed only from `*.spec.ts` (Subiekt nexo is Windows-only, uncontainerizable) — needs the two new methods added with deterministic mock data, mirroring its existing `issueInvoice`/`upsertCustomer` style.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+- None blocking. The bridge wire contract, core capabilities, and FE pattern are all already-shipped, inspectable code — no external API to reverse-engineer.
+
+### Assumptions
+1. **`bankAccountId` is bridge-native, stored verbatim** — a plain `int` from `GET /api/bank-accounts`, not an OL internal id, with no `IdentifierMappingService` involvement. Matches how `InfaktBankAccountConfig.id` stores inFakt's own account id and matches the issue's explicit assumption.
+2. **Connection-level default, not per-invoice** — one payment method + one bank account for every invoice issued through a connection (mirrors inFakt and the KSeF #1311 precedent — OL's order model carries no per-order payment-method signal today).
+3. **`documentType: "PA"` is not exercised** — the current Subiekt adapter's `issueInvoice` path doesn't special-case PA (see `SUPPORTED_DOCUMENT_TYPES` includes `'receipt'`, and the bridge maps neutral → `PA` via `toBridgeDocumentType`). If an operator configures `defaultPaymentMethod: 'transfer'` on a connection that also issues receipts, and a receipt is issued, the bridge will 422 the request (payment selection unsupported for PA). This is accepted as-is (not new to this change — the bridge enforces it, and Subiekt's neutral-doctype derivation already means a given connection mostly issues one doctype family in practice). Flagged for a future adapter-side guard if it proves to bite in real use.
+
+### Documentation Gap Found During Research (not fixed here)
+`apps/web/src/features/connections/components/edit-connection.schema.ts` and `EditConnectionForm.tsx` read/write the Subiekt bridge URL under the **flat JSON key `subiektBridgeUrl`** (`next.subiektBridgeUrl = structured.subiektBridgeUrl`), but `SubiektConnectionConfigDto`/`SubiektConnectionConfig` on the backend expect the key `bridgeBaseUrl`. This looks like a pre-existing FE/BE key-name mismatch from #759, unrelated to bank accounts/payment method. **Not fixed in this plan** (out of scope, would need its own investigation + issue) — flagged so the new `subiektPaymentMethod`/`subiektBankAccountId` fields are deliberately given FE form-field names that map to the **correct, verified** `SubiektConnectionConfig` key names (`defaultPaymentMethod`, `bankAccountId`) rather than copying the existing mismatch pattern.
+
+---
+
+## 6. Proposed Implementation Plan
+
+Phases map onto the orchestration units in §10 (Unit A = Phase 1, Unit B = Phase 2, Unit C = Phase 3, Unit E = Phase 4, Unit D = Phase 5). Part A and Part B fields are implemented **together** in each phase (decision 1) — the phase boundaries are by layer, not by Part.
+
+### Phase 1 (Unit A): Bridge wire types + client (TypeScript)
+
+**Goal**: The TS-side bridge contract can express payment selection, bank-account discovery, AND branch/cash-register discovery.
+
+1. **Extend `BridgeIssueInvoiceRequest` + add discovery response types**
+   - **File**: `libs/integrations/subiekt/src/bridge/subiekt-bridge.types.ts`
+   - **Action**:
+     - Add to `BridgeIssueInvoiceRequest` (after `lines`): `paymentMethod?: 'cash' | 'transfer'; bankAccountId?: number; oddzialId?: number; stanowiskoKasoweId?: number;`.
+     - Part A: `BridgeBankAccount { id: number; name: string | null; number: string | null; bankNumber: string | null; description: string | null; currency: string | null; isVatAccount: boolean; isDefault: boolean; ownerPodmiotId: number; ownerName: string | null }`, `BridgeListBankAccountsResponse { count: number; accounts: BridgeBankAccount[] }`, `BridgeSetDefaultBankAccountResponse { bankAccountId: number; isDefault: boolean }`.
+     - Part B: `BridgeBranch { id: number; name: string | null }`, `BridgeListBranchesResponse { count: number; branches: BridgeBranch[] }`, `BridgeCashRegister { id: number; name: string | null; symbol: string | null; oddzialId: number | null }`, `BridgeListCashRegistersResponse { count: number; cashRegisters: BridgeCashRegister[] }` — matching the PR #6 wire shapes in §4.
+   - **Acceptance**: New types compile; existing `BridgeIssueInvoiceRequest` consumers still compile (all new fields optional).
+
+2. **Extend `SubiektBridgeClient` interface**
+   - **File**: `libs/integrations/subiekt/src/bridge/subiekt-bridge.client.ts`
+   - **Action**: Add four methods with doc comments naming the real routes: `listBankAccounts(): Promise<BridgeListBankAccountsResponse>` (`GET /api/bank-accounts`), `setDefaultBankAccount(bankAccountId: number): Promise<BridgeSetDefaultBankAccountResponse>` (`PUT /api/bank-accounts/{id}/default`), `listBranches(): Promise<BridgeListBranchesResponse>` (`GET /api/branches`), `listCashRegisters(): Promise<BridgeListCashRegistersResponse>` (`GET /api/cash-registers` — always unfiltered per decision 4).
+   - **Acceptance**: Interface compiles; both implementers fail to compile until Steps 3–4 land (TypeScript enforces completeness).
+
+3. **Implement in `SubiektBridgeHttpClient`**
+   - **File**: `libs/integrations/subiekt/src/infrastructure/http/subiekt-bridge-http.client.ts`
+   - **Action**: Add endpoint entries (`listBankAccounts: '/api/bank-accounts'`, `setDefaultBankAccount: (id) => \`/api/bank-accounts/${id}/default\``, `listBranches: '/api/branches'`, `listCashRegisters: '/api/cash-registers'`). Implement the three GETs via the existing private `getJson<T>()`; implement `setDefaultBankAccount` via a new private `putJson<T>()` mirroring `postJson<T>()` (add `'PUT'` to the `request()` method union).
+   - **Acceptance**: All four methods round-trip through the same envelope-unwrap / error-translation path (`SubiektBridgeUnreachableWithPhaseError`, `SubiektRejectedError`, `SubiektBridgeAuthError`) as every other method — no bespoke error handling.
+
+4. **Implement in `FakeSubiektBridgeAdapter`**
+   - **File**: `libs/integrations/subiekt/src/testing/fake-subiekt-bridge.adapter.ts`
+   - **Action**: Add `listBankAccounts()` (2 deterministic accounts, one default, at least one with a distinct `ownerPodmiotId` so multi-payer tests are exercisable), `setDefaultBankAccount(id)` (validates against seeded ids, rejects via `SubiektRejectedError` otherwise, flips in-memory `isDefault`), `listBranches()` (2 branches), `listCashRegisters()` (mix of linked + `oddzialId: null` unlinked registers, matching the real probe data). Add `seed*` helpers + clear new state in `clear()`.
+   - **Acceptance**: `pnpm --filter @openlinker/integrations-subiekt test` green; new cases in `fake-subiekt-bridge.adapter.spec.ts` for all four methods.
+
+### Phase 2 (Unit B): Connection config
+
+**Goal**: `SubiektConnectionConfig` can carry the four defaults; validated at the shape-validator boundary.
+
+5. **Extend `SubiektConnectionConfig`**
+   - **File**: `libs/integrations/subiekt/src/domain/types/subiekt-connection-config.types.ts`
+   - **Action**: Add `export const SubiektPaymentMethodValues = ['cash', 'transfer'] as const; export type SubiektPaymentMethod = (typeof SubiektPaymentMethodValues)[number];` and four new optional fields: `defaultPaymentMethod?: SubiektPaymentMethod; bankAccountId?: number; defaultOddzialId?: number; defaultStanowiskoKasoweId?: number;` — doc comment explaining the bridge-native, no-snapshot rationale (§4) and that Oddział/Stanowisko are stored as bare bridge-native ints too.
+   - **Acceptance**: Type compiles; matches the `as const` + union pattern.
+
+6. **Extend `SubiektConnectionConfigDto`**
+   - **File**: `libs/integrations/subiekt/src/application/dto/subiekt-connection-config.dto.ts`
+   - **Action**: Add `@IsOptional() @IsIn(SubiektPaymentMethodValues) defaultPaymentMethod?`, `@IsOptional() @IsInt() @Min(1) bankAccountId?`, `@IsOptional() @IsInt() @Min(1) defaultOddzialId?`, `@IsOptional() @IsInt() @Min(1) defaultStanowiskoKasoweId?`. No cross-field validation here — bridge is the enforcement authority for Part A (transfer↔account) AND Part B (oddział↔register linkage, oddział-alone-rejected); OL just passes through and surfaces the bridge's rejection.
+   - **Acceptance**: `SubiektConnectionConfigShapeValidatorAdapter`'s existing spec passes; new case asserts `{ bridgeBaseUrl, defaultPaymentMethod: 'transfer', bankAccountId: 5, defaultOddzialId: 100002, defaultStanowiskoKasoweId: 100067 }` passes shape validation.
+
+7. **Thread config into the factory + adapter constructor**
+   - **File**: `libs/integrations/subiekt/src/application/subiekt-adapter.factory.ts`
+   - **Action**: Extend `validateAndParseConfig` to read+validate the four new optional fields (same style as the existing `timeoutMs` block — type/range check, throw `SubiektConfigException` on malformed input) and include them in the returned config. Pass `config` as the adapter's 4th constructor argument.
+   - **Acceptance**: `subiekt-adapter.factory.spec.ts` new cases: valid config parses all four fields; malformed `bankAccountId`/`defaultOddzialId`/`defaultStanowiskoKasoweId` (non-integer, ≤0) throws `SubiektConfigException`.
+
+### Phase 3 (Unit C): Adapter methods
+
+**Goal**: `SubiektInvoicingAdapter` discovers accounts/branches/registers, sets the provider default, and stamps payment + branch/register fields on issuance. Depends on Units A + B.
+
+8. **Add the 4th constructor param + capability interfaces**
+   - **File**: `libs/integrations/subiekt/src/infrastructure/adapters/subiekt-invoicing.adapter.ts`
+   - **Action**: Class signature → `implements InvoicingPort, RegulatoryStatusReader, CorrectionIssuer, BankAccountsReader, BankAccountDefaultSetter` (the two Part-A core capabilities; Part B methods are plain public methods, no core interface — decision 2). Import `BankAccountsReader, BankAccountDefaultSetter, InvoicingBankAccount` from `@openlinker/core/invoicing`. Add constructor param `config: SubiektConnectionConfig = {}` and derive four private readonly fields: `paymentMethod`, `bankAccountId`, `oddzialId`, `stanowiskoKasoweId` from `config`. **Do NOT default `paymentMethod` to `'cash'`** — "unset" means "send nothing" (the true additive/no-regression path), not "force cash".
+   - **Acceptance**: Compiles once Steps 9–11 add method bodies.
+
+9. **Implement the generic core-capability methods (Part A) + the owner-aware + Part B discovery methods**
+   - **File**: same as Step 8.
+   - **Action**:
+     - `listBankAccounts(): Promise<InvoicingBankAccount[]>` — maps the bridge shape to the neutral core type, **dropping** `ownerPodmiotId`/`ownerName` (this is the generic `BankAccountsReader` seam; the API's capability-generic controller uses it — decision 6 keeps it neutral). Comment why the owner fields are dropped here.
+     - `setDefaultBankAccount(accountId: string): Promise<void>` — `await this.bridge.setDefaultBankAccount(Number(accountId))`.
+     - **Owner-aware variant** `listBankAccountsWithOwner(): Promise<SubiektBankAccountView[]>` (Subiekt-local return type, NOT the neutral core type) — returns the full bridge shape incl. `ownerPodmiotId`/`ownerName`, for the new Subiekt controller (Phase 4). Define `SubiektBankAccountView` in the subiekt package's types.
+     - `listBranches(): Promise<SubiektBranchView[]>` and `listCashRegisters(): Promise<SubiektCashRegisterView[]>` — Part B, Subiekt-local return types, map the bridge responses 1:1.
+     - Wrap every bridge call in the existing `try { … } catch (error) { throw this.translateBridgeError(error); }` pattern.
+   - **Acceptance**: New adapter spec cases for all five methods, including `null` name/number/symbol degrading gracefully, and translated errors on bridge failure.
+
+10. **Stamp payment + branch/register fields on `issueInvoice`**
+    - **File**: same as Step 8, inside `issueInvoice`'s request-building block.
+    - **Action**: Extend the request-building with a helper that spreads the configured fields when set:
+      ```ts
+      private paymentFields(): Partial<Pick<BridgeIssueInvoiceRequest, 'paymentMethod' | 'bankAccountId'>> {
+        if (!this.paymentMethod) return {};
+        if (this.paymentMethod === 'transfer' && this.bankAccountId === undefined) return {};
+        return this.paymentMethod === 'transfer'
+          ? { paymentMethod: 'transfer', bankAccountId: this.bankAccountId! }
+          : { paymentMethod: 'cash' };
+      }
+      private branchFields(): Partial<Pick<BridgeIssueInvoiceRequest, 'oddzialId' | 'stanowiskoKasoweId'>> {
+        // Bridge rejects oddzialId-alone (422); mirror that fiscal-safe omission here —
+        // only send oddzialId when a stanowiskoKasoweId is also configured. A
+        // stanowiskoKasoweId alone IS valid (keeps the document's default branch), so
+        // send it whenever set.
+        const out: Partial<Pick<BridgeIssueInvoiceRequest, 'oddzialId' | 'stanowiskoKasoweId'>> = {};
+        if (this.stanowiskoKasoweId !== undefined) out.stanowiskoKasoweId = this.stanowiskoKasoweId;
+        if (this.oddzialId !== undefined && this.stanowiskoKasoweId !== undefined) out.oddzialId = this.oddzialId;
+        return out;
+      }
+      ```
+      Spread `...this.paymentFields(), ...this.branchFields()` into the `bridge.issueInvoice(...)` request. **Do not** touch `issueCorrection` (§4).
+    - **Acceptance**: New adapter spec cases: (a) no config → request byte-identical to today (no new keys); (b) cash → `{ paymentMethod: 'cash' }`; (c) transfer+account → both payment keys; (d) transfer no account → neither payment key; (e) register alone → `{ stanowiskoKasoweId }` only; (f) branch+register → both branch keys; (g) branch alone (no register) → neither branch key (mirrors bridge's oddział-alone-422, omit fiscal-safe).
+
+### Phase 4 (Unit E): Subiekt-specific API controller
+
+**Goal**: Expose the owner-aware bank-accounts, branches, and cash-registers to the FE. New file; depends on Unit C. Follows the plugin-specific-controller precedent (`allegro.controller.ts`), NOT the capability-generic `InvoicingController`.
+
+11. **Create `subiekt.controller.ts` + register it**
+    - **Files**: new `apps/api/src/integrations/http/subiekt.controller.ts`; register in whichever module already declares `AllegroController` (find via `grep -rl "AllegroController" apps/api/src`).
+    - **Action**: `@Controller('integrations/subiekt')`, `@Roles('admin')` (match `allegro.controller.ts`). Three GET routes, each resolving the connection's adapter via `IIntegrationsService.getCapabilityAdapter<InvoicingPort>(connectionId, 'Invoicing')`, then narrowing to the concrete `SubiektInvoicingAdapter` (instanceof, or a small `isSubiektInvoicingAdapter` structural guard — these aren't core capabilities so there's no `is*Reader` guard to reuse; throw `BadRequestException` if the connection isn't Subiekt):
+      - `GET connections/:id/bank-accounts` → `adapter.listBankAccountsWithOwner()` (owner-aware — this is the one the Subiekt FE consumes, distinct from `InvoicingController`'s neutral capability-generic route).
+      - `GET connections/:id/branches` → `adapter.listBranches()`.
+      - `GET connections/:id/cash-registers` → `adapter.listCashRegisters()` (unfiltered; FE filters client-side per decision 4).
+    - Add response DTOs (`SubiektBankAccountResponseDto`, `SubiektBranchResponseDto`, `SubiektCashRegisterResponseDto`) in the controller's `dto/` neighbourhood.
+    - **Acceptance**: `subiekt.controller.spec.ts` — each route returns mapped data for a Subiekt connection; a non-Subiekt connection is rejected; adapter errors propagate as the expected HTTP status. Verify no route collides with `InvoicingController` (different prefix `integrations/subiekt` vs `connections`).
+
+### Phase 5 (Unit D): Frontend
+
+**Goal**: One combined `InlineDisclosure` in the Subiekt structured section covers payment method, bank account (owner-grouped, conditional payer warning), Oddział, and Stanowisko Kasowe — matching the approved `subiekt-full-config-section.html` mockup. Depends on Units C + E (needs the new endpoints).
+
+12. **Add Subiekt-specific FE hooks + API namespace**
+    - **Files**: `apps/web/src/plugins/subiekt/hooks/use-subiekt-bank-accounts-query.ts`, `use-subiekt-branches-query.ts`, `use-subiekt-cash-registers-query.ts` (+ a `setDefaultBankAccount` mutation hook if the FE offers the two-way sync — see note); wire the Subiekt API namespace into the plugin's `apiNamespaces` build contribution (mirror how Allegro's plugin exposes its `responsible-producers` call).
+    - **Action**: Each hook calls the new `integrations/subiekt/connections/:id/{bank-accounts,branches,cash-registers}` endpoints via the plugin API namespace. The bank-accounts hook returns the **owner-aware** shape (with `ownerPodmiotId`/`ownerName`) — this is the decision-6 correction: Subiekt does NOT use the generic `useBankAccountsQuery`.
+    - **Note on two-way default sync**: Part A's inFakt precedent calls `setDefaultBankAccount` when the operator picks a non-default account. Decision 6 routes discovery through the Subiekt controller, but the generic `POST connections/:id/bank-accounts/:accountId/default` route on `InvoicingController` still works for Subiekt (the adapter implements `BankAccountDefaultSetter`). **Keep the two-way sync using the existing generic mutation** (`useSetDefaultBankAccountMutation`) — only the read side needs the owner-aware Subiekt-specific hook; the write side has no owner concern, so reuse the generic mutation rather than adding a redundant Subiekt-specific one.
+    - **Acceptance**: Hook unit tests mock the plugin API namespace; assert correct URL + response typing (owner fields present on the bank-accounts hook).
+
+13. **Extend the shared form contract**
+    - **Files**: `apps/web/src/features/connections/components/edit-connection.schema.ts`, `EditConnectionForm.tsx`
+    - **Action**: Add four flat scalar form fields: `subiektPaymentMethod?`, `subiektBankAccountId?`, `subiektOddzialId?`, `subiektStanowiskoKasoweId?` (all `string` in the form, mirroring `subiektBridgeUrl`/`subiektTriggerModel` — NOT the `infaktBankAccount` whole-object pattern, §7 Alternative 1). Read them in the default-values block from `connection.config` (`defaultPaymentMethod`, `bankAccountId`, `defaultOddzialId`, `defaultStanowiskoKasoweId`, stringified). In the serialize-to-JSON reducer, add four blocks mirroring the existing `subiektBridgeUrl` block: set/delete `next.defaultPaymentMethod` / `next.bankAccountId` / `next.defaultOddzialId` / `next.defaultStanowiskoKasoweId` (numbers parsed back, deleted when empty).
+    - **Acceptance**: `edit-connection.schema.test.ts` round-trip cases for all four fields (set → correct config keys/types; clear → keys deleted).
+
+14. **Extend `SubiektStructuredSection` (the combined section)**
+    - **File**: `apps/web/src/plugins/subiekt/components/subiekt-structured-section.tsx`
+    - **Action**: Add one `InlineDisclosure` after the Trigger-model field, implementing the approved `subiekt-full-config-section.html` mockup's five states:
+      - Payment-method `<Select>` (cash/transfer) via `syncStructuredToJson('subiektPaymentMethod', …)`.
+      - When transfer: bank-account `<Select>` fed by `use-subiekt-bank-accounts-query` (owner-aware). Group options by `ownerName` with `<optgroup>` when >1 distinct `ownerPodmiotId`. Compute `distinct(ownerPodmiotId).length > 1` and render the payer-routing warning callout **only when true** (decision 5/6). On non-default pick, fire the generic `useSetDefaultBankAccountMutation`.
+      - Oddział `<Select>` fed by `use-subiekt-branches-query`, via `syncStructuredToJson('subiektOddzialId', …)`.
+      - Stanowisko Kasowe `<Select>` fed by `use-subiekt-cash-registers-query`, **filtered client-side** to registers with `oddzialId === selectedOddzialId || oddzialId === null` (decision 4). Mismatch prevention: registers linked to a different branch appear disabled (mockup state 04). Branch-set-but-register-empty shows the warning callout (mockup state 05, mirrors the bridge's oddział-alone-422).
+    - **Acceptance**: `subiekt-structured-section.test.tsx` new cases: payment select renders; transfer reveals owner-grouped account select; payer warning shows only with >1 owner; branch select filters the register list client-side; branch-without-register shows the warning; picking a non-default account fires the mutation.
+
+### Phase 6 (Unit F): Cross-cutting verification
+
+15. **Full quality gate**
+    - **Action**: `pnpm lint && pnpm type-check && pnpm test` from the implementation worktree root. No ORM entity changed → no migration (`SubiektConnectionConfig` is a JSONB blob; `pnpm --filter @openlinker/api migration:show` shows nothing new).
+    - **Acceptance**: All green, zero new lint/type errors.
+
+**FE mockups** (design reference for Phase 5): `docs/plans/mockups/subiekt-full-config-section.html` (Part A + Part B combined, 5 states — the approved, authoritative one) and the older `subiekt-bank-account-payment-method.html` (Part A only, kept for reference). Both built against real tokens from `apps/web/src/index.css`.
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Mirror inFakt's whole-object `bankAccount` snapshot exactly
+- **Description**: Give `SubiektConnectionConfig` an `InfaktBankAccountConfig`-shaped `bankAccount?: { id: number; number: string; name: string }` object (snapshotting the account's display fields at selection time, like inFakt does), and add a dedicated `syncSubiektBankAccountToJson` whole-object serializer prop to `StructuredConfigSectionProps`, exactly paralleling `syncInfaktBankAccountToJson`.
+- **Why Rejected**: The Subiekt bridge's `POST /api/invoices` only ever consumes the numeric `bankAccountId` — it has no wire need for the account's display strings at issuance time (unlike inFakt, whose `invoices.json` payload embeds `bank_account`/`bank_name` as strings). Snapshotting a full object OL never sends anywhere is needless state to keep in sync and a wider `StructuredConfigSectionProps` surface (one more optional prop every other plugin ignores) for no behavioral benefit.
+- **Trade-offs**: A pure `bankAccountId: number` is a smaller diff, reuses the existing generic `syncStructuredToJson` scalar-field path already proven for `subiektBridgeUrl`, and is easier to keep correct (nothing can drift between a cached snapshot and the live account). The one thing given up is the FE being able to show the picked account's number/name **without** an extra `useBankAccountsQuery` round-trip on every page load — acceptable, since the structured section already fetches that list live whenever Transfer is selected.
+
+### Alternative 2: Thread payment fields into `issueCorrection` too, matching the issue's literal AC wording
+- **Description**: Follow the GitHub issue text verbatim and add `paymentMethod`/`bankAccountId` to `BridgeKorektaRequest` and `SubiektInvoicingAdapter.issueCorrection`.
+- **Why Rejected**: Verified against the actual merged bridge source (`InvoiceContractMapper.Build`, plus a repo-wide grep for `PaymentMethod`/`BankAccountId`) that the korekta endpoint's contract has no payment-selection fields at all. Adding them client-side would either be silently dropped by the bridge (dead code) or, worse, misleadingly imply a capability the bridge doesn't have.
+- **Trade-offs**: None — this is a correctness fix to the issue's proposed solution, not a real trade-off. If the bridge later grows korekta-side payment selection, it's a small, additive follow-up (extend `BridgeKorektaRequest`, mirror Step 10's helper).
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ No CORE changes; reuses existing `BankAccountsReader`/`BankAccountDefaultSetter` verbatim.
+- ✅ `SubiektInvoicingAdapter` remains DI-friendly (constructor injection, no `new` inside methods).
+- ✅ Ports vs. concrete: adapter still depends only on `SubiektBridgeClient` (interface), never a concrete HTTP class.
+
+### Naming Conventions
+- ✅ `SubiektPaymentMethodValues`/`SubiektPaymentMethod` follow the `as const` + union pattern (engineering-standards.md), matching `InfaktPaymentMethodValues`.
+- ✅ Adapter class name/file unchanged (`SubiektInvoicingAdapter`, `*.adapter.ts`).
+
+### Existing Patterns
+- ✅ Adapter constructor 4th-param config pattern matches `InfaktInvoicingAdapter` exactly.
+- ✅ FE structured-section `InlineDisclosure` + live bank-account query matches `infakt-structured-section.tsx` exactly, modulo the deliberate scalar-vs-object simplification (§7).
+
+### Risks
+- **Bridge/adapter drift if the bridge's korekta endpoint later grows payment fields**: mitigated by the `runSubiektBridgeContractTests` shared suite mentioned in the fake adapter's header comment (out of scope to extend here, but the seam already exists for a future PR to catch this).
+- **`defaultPaymentMethod: 'transfer'` configured without ever confirming a matching bank account exists in Subiekt**: mitigated the same way inFakt handles it — `paymentFields()` omits both fields until a `bankAccountId` is actually configured, so a half-configured connection silently falls back to bridge-default behavior rather than 422ing every invoice.
+- **PA (paragon) + transfer combination**: accepted risk per Assumption 3 — the bridge will 422; not newly introduced by this change, and Subiekt connections issuing receipts are an edge case in current usage.
+
+### Edge Cases
+- Bridge returns zero bank accounts: `listBankAccounts()` returns `[]`; FE section shows the existing "no accounts configured" messaging pattern from `infakt-structured-section.tsx`, adapted for Subiekt wording.
+- `setDefaultBankAccount` called with an id the bridge doesn't recognize: bridge returns 422 → `SubiektRejectedError` → surfaces through the existing mutation's error UI, no special handling needed.
+- Operator switches from Transfer back to Cash: `subiektBankAccountId` stays in `configText` (stale) but `paymentFields()` only reads it when `paymentMethod === 'transfer'`, so a stale id is harmless dead config — matches inFakt's behavior (the config isn't scrubbed on method switch there either).
+
+### Backward Compatibility
+- ✅ Fully additive on every layer (wire, config, DTO, adapter). A connection with none of the new fields set produces byte-identical bridge requests to today (verified by the acceptance criterion in Step 10a).
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `libs/integrations/subiekt/src/infrastructure/adapters/__tests__/subiekt-invoicing.adapter.spec.ts` — new `describe` blocks for `listBankAccounts`, `setDefaultBankAccount`, `listBankAccountsWithOwner`, `listBranches`, `listCashRegisters`, and the seven `paymentFields()`+`branchFields()` scenarios from Phase 3 Step 10.
+- `libs/integrations/subiekt/src/infrastructure/http/__tests__/subiekt-bridge-http.client.spec.ts` — new cases for the four new endpoints, reusing the existing envelope-unwrap / error-translation test harness (including the new `putJson`/`'PUT'` path).
+- `libs/integrations/subiekt/src/testing/__tests__/fake-subiekt-bridge.adapter.spec.ts` — parity cases for the four new fake methods (incl. multi-owner accounts + linked/unlinked registers).
+- `libs/integrations/subiekt/src/application/__tests__/subiekt-adapter.factory.spec.ts` — config parsing + `SubiektConfigException` cases for the four malformed new fields.
+- `libs/integrations/subiekt/src/application/dto/**` shape-validator spec — validation cases for the four new optional fields.
+- `apps/api/src/integrations/http/subiekt.controller.spec.ts` (new) — each of the three routes returns mapped data for a Subiekt connection; non-Subiekt connection rejected; adapter errors propagate.
+- `apps/web/src/plugins/subiekt/hooks/*.test.ts` (new) — the three Subiekt-specific query hooks call the right endpoints with the right response typing.
+- `apps/web/src/plugins/subiekt/components/subiekt-structured-section.test.tsx` — new cases per Phase 5 Step 14's acceptance criteria (payment select, owner-grouped account select, conditional payer warning, client-side register filtering, branch-without-register warning).
+- `apps/web/src/features/connections/components/edit-connection.schema.test.ts` — serializer round-trip cases for all four new form fields.
+
+### Integration Tests
+- None required for the OpenLinker API side beyond the controller unit spec — the new `subiekt.controller.ts` routes are thin adapter-delegation, covered by the controller spec + the adapter specs. No new DB schema. The functional cross-boundary proof (fields actually reaching Subiekt) is the live bridge-API verification in §11, not a Testcontainers integration test (the bridge can't be containerized).
+
+### Mocking Strategy
+- Adapter/bridge-client unit tests mock `SubiektBridgeClient` (the port), never `fetch` directly.
+- Controller spec mocks `IIntegrationsService.getCapabilityAdapter` to return a fake `SubiektInvoicingAdapter`.
+- FE component/hook tests mock the Subiekt plugin API namespace (the new hooks) + the generic `useSetDefaultBankAccountMutation` (reused for the write side, decision 6 note).
+
+### Acceptance Criteria (mirrors the GitHub issue's Part A + Part B checklists, corrected per §4 and the §0.1 decision log)
+
+**Part A:**
+- [ ] `SubiektBridgeClient` (interface + HTTP + fake) exposes `listBankAccounts()` and `setDefaultBankAccount(id)`.
+- [ ] `BridgeIssueInvoiceRequest` carries optional `paymentMethod`/`bankAccountId`; `issueInvoice` populates them from config when set, omits when not; `issueCorrection` untouched (bridge has no korekta-side payment selection).
+- [ ] `SubiektConnectionConfig` gains `defaultPaymentMethod`/`bankAccountId`.
+- [ ] `SubiektInvoicingAdapter implements BankAccountsReader, BankAccountDefaultSetter` (generic core capabilities kept for the capability-generic API surface).
+- [ ] Subiekt structured section renders the payment-method select + owner-grouped bank-account picker.
+
+**Part B:**
+- [ ] `SubiektBridgeClient` exposes `listBranches()` and `listCashRegisters()`.
+- [ ] `BridgeIssueInvoiceRequest` carries optional `oddzialId`/`stanowiskoKasoweId`; `issueInvoice` sends them per the fiscal-safe rules (register-alone OK, branch-alone omitted to mirror the bridge's 422).
+- [ ] `SubiektConnectionConfig` gains `defaultOddzialId`/`defaultStanowiskoKasoweId`.
+- [ ] New `apps/api/src/integrations/http/subiekt.controller.ts` exposes owner-aware `bank-accounts`, `branches`, `cash-registers` routes; no new core capability introduced (decision 2).
+- [ ] Structured section renders the Oddział select + client-side-filtered Stanowisko Kasowe select, with mismatch prevention + branch-without-register warning per the approved mockup.
+
+**Cross-cutting:**
+- [ ] Tests added/updated for every item above; full quality gate green (`pnpm lint && type-check && test`).
+- [ ] No architecture-boundary violations — confirmed by `pnpm lint`'s `check:invariants`.
+- [ ] **Payer-routing limitation (decision 5, user-signed-off 2026-07-02)**: the FE shows the payer-routing warning **only when >1 distinct `ownerPodmiotId`** is detected in the live account list; no copy anywhere implies a guarantee OL can't deliver on a multi-Podmiot install.
+- [ ] Live verification (§11, two-track per decision 8): OL-side screenshots of the rendered section + direct bridge-API functional proof issuing **several** invoices with different configurations, each confirmed to carry the exact payment/branch/register selected. Published as a Claude Artifact.
+
+---
+
+## 10. Orchestration Strategy (how this plan gets executed)
+
+This section is a first-class part of the plan per explicit instruction: implementation work should be broken into small, independently-verifiable units and **delegated to subagents running the Opus model** (not the default model) for the actual code-writing steps, while the orchestrating session stays responsible for sequencing, integration, and final verification.
+
+### Why Opus for subagents here
+The Subiekt package has unusually dense, carefully-reasoned inline documentation (fiscal-safety error translation, retryability phases, idempotency contracts) that a lower-effort model is more likely to silently violate while pattern-matching against the simpler inFakt reference. Opus is worth the cost for the two riskiest units (the adapter capability methods, and the bridge-client + fake-adapter pair) where subtly breaking an existing fiscal-safety invariant is the failure mode to avoid.
+
+### Suggested task decomposition (re-sequenced after `/grill-me`, decision 7)
+
+The pre-grill table had FE (D) running parallel to the backend. That no longer holds: Part B's FE needs the new controller's endpoints (Unit E), and Part B touches the **same files** as Part A (adapter, bridge client, structured section) — so those can't be split across parallel subagents without guaranteed merge conflicts. New dependency chain: **A ∥ B → C → E → D → F(gate) → G(verify)**.
+
+| # | Unit of work | Files touched | Depends on | Delegation |
+|---|---|---|---|---|
+| A | Bridge wire types + client + HTTP impl + fake — Part A **and** Part B methods together (Phase 1) | `subiekt-bridge.types.ts`, `subiekt-bridge.client.ts`, `subiekt-bridge-http.client.ts`, `fake-subiekt-bridge.adapter.ts`, `__tests__` | none | **Opus subagent** — highest risk of breaking the error-translation/retryability contract. |
+| B | Connection config + DTO + factory — all four new fields (Phase 2) | `subiekt-connection-config.types.ts`, `subiekt-connection-config.dto.ts`, `subiekt-adapter.factory.ts`, `__tests__` | none (parallel with A) | **Opus subagent** — touches the fiscal-safe `SubiektConfigException` path. |
+| C | Adapter methods — Part A capabilities + owner-aware + Part B discovery + `issueInvoice` field-stamping (Phase 3) | `subiekt-invoicing.adapter.ts`, its `__tests__` | **A, B** | **Opus subagent** — highest-risk: must not regress `issueInvoice`'s request shape for unconfigured connections (Step 10 case a). |
+| E | New Subiekt API controller + DTOs + module registration (Phase 4) | `apps/api/src/integrations/http/subiekt.controller.ts` (new), its DTOs + spec, the module that declares `AllegroController` | **C** (calls the adapter's new methods) | **Opus subagent** — backend-only, isolated file set, no overlap with D. |
+| D | FE: Subiekt hooks + shared form plumbing + combined structured section (Phase 5) | `apps/web/src/plugins/subiekt/hooks/*` (new), `edit-connection.schema.ts`, `EditConnectionForm.tsx`, `subiekt-structured-section.tsx`, tests | **C, E** (needs the endpoints) | **Opus subagent** — no longer parallel with backend; runs after E. |
+| F | Quality gate + integration | whole worktree | A, B, C, E, D merged | Orchestrating session (not delegated) — reconcile cross-unit seams, run `pnpm lint && type-check && test`. |
+| G | Live verification (two-track) + Artifact | none new (scripts/screenshots) | F green | Orchestrating session — PowerShell-from-WSL bridge calls + OL screenshots + human review. |
+
+**Concurrency**: only A ∥ B run in parallel. C waits on both. E waits on C. D waits on C+E. This is a longer critical path than the pre-grill plan, deliberately — it trades parallelism for zero same-file merge risk (decision 7), which matters more now that Part A and Part B edit the same adapter/client/section files.
+
+**Note on `edit-connection.schema.ts` / `EditConnectionForm.tsx`**: these shared FE files were also touched by the merged inFakt work (#1308) already in the base branch. D is the only unit touching them in this plan, so no intra-plan conflict — but the subagent must be told to *append* the four Subiekt fields next to the existing `subiektBridgeUrl`/`subiektTriggerModel` blocks, not rewrite the file.
+
+---
+
+## 11. Live Verification & Artifact — two-track (decision 8)
+
+The acceptance gate. Not one heavyweight PrestaShop-order flow (decision 8 dropped that — PrestaShop tests nothing new for this issue, the order→invoice trigger is unchanged). Instead two tracks: **(Track 1) OL-side screenshots proving the UI renders + populates from live data**, and **(Track 2) direct bridge-API functional proof that the four selectors actually reach Subiekt and produce documents with exactly the chosen payment/branch/register** — issuing **several** invoices with different configs, as already demonstrated this session against `Nexo_Demo_1`.
+
+### Environment
+
+| Component | Where it runs | How it's started |
+|---|---|---|
+| Subiekt Bridge | Windows-native, reached via `powershell.exe` from WSL | Against `~/projekty/blocky/openlinker-subiekt-bridge` on branch `3-bank-account-multi-podmiot` (tip = PR #6). `dotnet run` the API project, or call `BankAccountProbe`-style scripts directly. Points at `Nexo_Demo_1` (real Sfera). Proven reachable this session. |
+| OpenLinker API + web | WSL/Linux, the implementation worktree | `pnpm start:dev:api` + `pnpm start:dev:web`, connection's `bridgeBaseUrl` pointed at the running bridge. |
+| PrestaShop | **Not required** (decision 8) | — |
+
+### Track 1 — OL-side visual screenshots (UI renders + live data)
+
+1. Subiekt connection edit form, the combined payment/branch section **collapsed** — shows the summary line (payment · branch · register) with real configured values.
+2. Section **expanded, Transfer** — bank-account `<Select>` populated from the live owner-aware endpoint; if the demo DB shows >1 owner, the payer-routing warning is visible (decision 5/6); if single-owner, it is correctly absent.
+3. Section **expanded, branch chosen** — Stanowisko Kasowe select client-side-filtered to that branch's linked + unlinked registers (mockup state 03).
+4. **Branch-without-register** warning state (mockup state 05) and, if reproducible, the mismatch-disabled-option state (mockup state 04).
+
+Screenshots only — no requirement to drive a full order→invoice flow through the OL UI.
+
+### Track 2 — direct bridge-API functional proof (several invoices, different configs)
+
+Issue real documents through the bridge (PowerShell-from-WSL, `Nexo_Demo_1`) and, for each, read the resulting Subiekt document back to confirm the actual payment form / bank account / branch / cash-register match what was sent — not merely that the call returned 200. At minimum these configurations:
+
+| # | Config sent | Expected result on the issued document |
+|---|---|---|
+| 1 | no payment/branch fields (baseline) | Subiekt's own defaults; byte-identical to pre-change behavior |
+| 2 | `paymentMethod: 'cash'` | cash payment form on the document |
+| 3 | `paymentMethod: 'transfer', bankAccountId: <id>` | transfer form + that exact bank account stamped |
+| 4 | `paymentMethod: 'transfer'` with no account | bridge omits / document uses no explicit account (fiscal-safe) |
+| 5 | `stanowiskoKasoweId: <unlinked id>` alone | document issued under that register, default branch |
+| 6 | `oddzialId: <b>, stanowiskoKasoweId: <register linked to b>` | document under branch b + that register |
+| 7 | `oddzialId: <b>` alone (no register) | **422 rejected by the bridge before Sfera** (proves the fiscal-safe guard) |
+| 8 | `oddzialId: <b>, stanowiskoKasoweId: <register linked to a different branch>` | **422 rejected** (proves cross-branch mismatch guard) |
+
+Each row: capture the request + the read-back document's actual payment/branch/register (or the 422 body for rows 7–8) as evidence.
+
+### Artifact
+
+One Claude Artifact (HTML): what was tested, the branch/commit SHAs of both repos at verification time, Track-1 screenshots with captions, and a Track-2 table showing each config → the actual resulting document data (proving the selection genuinely took effect, per the user's explicit requirement). Style mirrors prior inFakt/KSeF E2E artifacts (`infakt-feasibility-poc`, `pr1284-woocommerce-screenshots-fixed`).
+
+---
+
+## 12. Alignment Checklist
+
+- [x] Follows hexagonal architecture — Integration adapter + one new Interface-layer controller (Part B), no CORE touched.
+- [x] Respects CORE vs Integration boundaries — Part A reuses existing `BankAccountsReader`/`BankAccountDefaultSetter`; Part B deliberately adds **no** core port (decision 2), staying Subiekt-local behind a plugin-specific controller (decision 3, precedent: `allegro.controller.ts`).
+- [x] Uses existing patterns (no unnecessary abstractions) — scalar-vs-snapshot simplification (§7 Alt 1); Subiekt-specific-hook-vs-generic-hook correction (decision 6); no speculative single-consumer core capability.
+- [x] Idempotency considered — `setDefaultBankAccount` idempotent per the bridge contract; `issueInvoice`'s `idempotencyKey` untouched; discovery GETs are read-only.
+- [ ] Event-driven patterns — N/A.
+- [x] Rate limits & retries — reuses the existing `SubiektBridgeHttpClient` machinery for all four new endpoints.
+- [x] Error handling comprehensive — new methods route through the same `translateBridgeError` path; controller propagates adapter errors as HTTP.
+- [x] Testing strategy complete — see §9 (Part A + Part B, controller spec, hook specs).
+- [x] Naming conventions followed — see §8.
+- [x] File structure — **new files this plan adds**: `apps/api/src/integrations/http/subiekt.controller.ts` (+ DTOs + spec), three FE hooks under `apps/web/src/plugins/subiekt/hooks/`; everything else edits established locations.
+- [x] Plan is execution-ready — every step names exact files/actions/acceptance, grounded in code read from the merged worktrees + the live-verified bridge PR #6.
+- [x] Plan is saved as a markdown file.
+- [x] No ADR required — Part A reuses an existing pattern; Part B's "plugin-specific controller, no core port" is itself a pre-existing established pattern (`allegro.controller.ts`), not a new architectural decision needing an ADR. The core-capability-vs-Subiekt-local fork was decided in the §0.1 grill log with rationale.
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md) — §14 Invoicing, capability abstractions
+- [Engineering Standards](../engineering-standards.md) — naming, `as const` pattern, Symbol tokens
+- [Testing Guide](../testing-guide.md)
+- [Code Review Guide](../code-review-guide.md)
+- [GitHub issue #1324](https://github.com/openlinker-project/openlinker/issues/1324)
+- Reference implementation: PR #1309 (`1303-infakt-payment-method`), PR #1310 (`1308-infakt-bank-account-picker`) — merged locally into `1324-prereqs-integration`, see §0.
+- Bridge reference: `openlinker-subiekt-bridge` PR #2 (`1-bank-account-payment-method`) — merged locally into the bridge's `1324-prereqs-integration` branch, see §0.

--- a/docs/plans/mockups/subiekt-bank-account-payment-method.html
+++ b/docs/plans/mockups/subiekt-bank-account-payment-method.html
@@ -1,0 +1,416 @@
+<title>Subiekt — payment method &amp; bank account (mockup, #1324)</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  /* ── Tokens, copied verbatim from apps/web/src/index.css (light mode) ──
+     IBM Plex Sans/Mono approximated with the same system-ui fallback stack
+     already declared in --font-sans/--font-mono — the Artifact CSP blocks
+     webfont loading, so this mockup intentionally does not @font-face a
+     substitute rather than risk a silent, less-accurate fallback. */
+  :root {
+    --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+
+    --bg-canvas: oklch(99% 0.003 80);
+    --bg-shell: oklch(97.5% 0.004 80);
+    --bg-surface: #ffffff;
+    --bg-surface-muted: oklch(96% 0.005 80);
+    --bg-surface-hover: oklch(93% 0.006 80);
+
+    --border-subtle: oklch(93.5% 0.006 80);
+    --border-default: oklch(88% 0.008 80);
+    --border-strong: oklch(78% 0.01 80);
+    --border-focus: oklch(68% 0.18 50);
+
+    --text-primary: oklch(20% 0.012 80);
+    --text-secondary: oklch(38% 0.01 80);
+    --text-muted: oklch(52% 0.008 80);
+    --text-disabled: oklch(70% 0.005 80);
+
+    --accent-primary: oklch(68% 0.18 50);
+    --accent-primary-soft: oklch(96% 0.04 60);
+    --accent-primary-border: oklch(85% 0.1 55);
+    --accent-ring: oklch(68% 0.18 50 / 0.3);
+
+    --status-info: oklch(56% 0.14 245);
+    --status-info-soft: oklch(96% 0.03 245);
+    --status-info-border: oklch(85% 0.08 245);
+    --status-info-fg: oklch(40% 0.12 245);
+
+    --status-success: oklch(54% 0.14 150);
+    --status-success-soft: oklch(96% 0.04 150);
+    --status-success-fg: oklch(36% 0.12 150);
+
+    --shadow-xs: 0 1px 2px rgb(15 18 26 / 0.04);
+    --shadow-sm: 0 1px 2px rgb(15 18 26 / 0.04), 0 1px 3px rgb(15 18 26 / 0.06);
+    --shadow-soft: 0 1px 2px rgb(15 18 26 / 0.04), 0 6px 16px rgb(15 18 26 / 0.06);
+    --shadow-focus: 0 0 0 3px var(--accent-ring);
+
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.5rem;
+    --space-6: 2rem;
+    --space-7: 3rem;
+
+    --radius-xs: 4px;
+    --radius-sm: 6px;
+    --radius-md: 8px;
+    --radius-lg: 10px;
+    --radius-pill: 9999px;
+
+    --duration-fast: 120ms;
+    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--bg-shell);
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .page {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: var(--space-7) var(--space-5) var(--space-8);
+    display: grid;
+    gap: var(--space-6);
+  }
+
+  .page-head { display: grid; gap: var(--space-2); }
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 10.5px;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+  h1 { margin: 0; font-size: 1.375rem; font-weight: 650; letter-spacing: -0.012em; text-wrap: balance; }
+  .lede { margin: 0; color: var(--text-secondary); max-width: 62ch; }
+  .lede code { font-family: var(--font-mono); font-size: 0.92em; background: var(--bg-surface-muted); padding: 0.08em 0.35em; border-radius: 4px; }
+
+  /* ── the connection edit-form context the new section lives inside ── */
+  .form-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-soft);
+    overflow: hidden;
+  }
+  .form-card__title {
+    padding: var(--space-4) var(--space-5);
+    border-bottom: 1px solid var(--border-subtle);
+    font-weight: 600;
+    font-size: 0.9rem;
+  }
+  .form-card__body { padding: var(--space-5); display: grid; gap: var(--space-4); }
+
+  .form-field { display: grid; gap: var(--space-2); }
+  .form-field__label { font-size: 0.8125rem; font-weight: 500; color: var(--text-primary); }
+  .form-field__description { margin: 0; color: var(--text-muted); font-size: 0.75rem; }
+
+  .control, select {
+    width: 100%;
+    height: 2rem;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    padding: 0 var(--space-3);
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.8125rem;
+    box-shadow: var(--shadow-xs);
+  }
+  select {
+    appearance: none;
+    padding-right: var(--space-7);
+    background-image:
+      linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%),
+      linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%);
+    background-position: calc(100% - 14px) calc(50% - 2px), calc(100% - 8px) calc(50% - 2px);
+    background-size: 5px 5px, 5px 5px;
+    background-repeat: no-repeat;
+  }
+  select:disabled, .control:disabled { background: var(--bg-surface-muted); color: var(--text-disabled); }
+
+  .capability-row {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: var(--space-2) 0; border-top: 1px solid var(--border-subtle); font-size: 0.8125rem; color: var(--text-secondary);
+  }
+  .capability-row:first-of-type { border-top: none; }
+  .switch { width: 30px; height: 17px; border-radius: var(--radius-pill); background: var(--bg-surface-muted); border: 1px solid var(--border-default); position: relative; flex-shrink: 0; }
+  .switch::after { content: ''; position: absolute; top: 1px; left: 1px; width: 13px; height: 13px; border-radius: 50%; background: #fff; box-shadow: var(--shadow-xs); }
+  .switch--on { background: var(--accent-primary); border-color: var(--accent-primary); }
+  .switch--on::after { left: 15px; }
+
+  /* ── Inline Disclosure — copied verbatim from index.css ── */
+  .inline-disclosure {
+    border: 1px dashed var(--accent-primary-border);
+    background: var(--accent-primary-soft);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+  }
+  .inline-disclosure__summary { cursor: pointer; list-style: none; font-size: 0.85rem; color: var(--text-primary); }
+  .inline-disclosure__summary::-webkit-details-marker { display: none; }
+  .inline-disclosure__summary:focus-visible { outline: none; box-shadow: var(--shadow-focus); border-radius: var(--radius-sm); }
+  .inline-disclosure__label { color: var(--text-secondary); }
+  .inline-disclosure__value { font-family: var(--font-mono); font-weight: 600; color: var(--text-primary); }
+  .inline-disclosure__cta { color: var(--accent-primary); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; font-weight: 600; }
+  .inline-disclosure__panel { margin-top: var(--space-3); display: grid; gap: var(--space-4); }
+
+  .muted-text { margin: 0; color: var(--text-secondary); font-size: 0.8125rem; }
+
+  /* ── skeleton loading row ── */
+  .skeleton-line {
+    height: 2rem; border-radius: var(--radius-md);
+    background: linear-gradient(90deg, var(--bg-surface-muted) 25%, var(--bg-surface-hover) 37%, var(--bg-surface-muted) 63%);
+    background-size: 400% 100%;
+    animation: shimmer 1.4s ease infinite;
+  }
+  @keyframes shimmer { 0% { background-position: 100% 0; } 100% { background-position: -100% 0; } }
+  @media (prefers-reduced-motion: reduce) { .skeleton-line { animation: none; } }
+
+  /* ── multi-payer account option group + caption ── */
+  .account-owner-group { font-weight: 600; font-family: var(--font-sans); font-style: normal; color: var(--text-secondary); }
+
+  .owner-caption {
+    display: flex; align-items: flex-start; gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    background: var(--status-info-soft);
+    border: 1px solid var(--status-info-border);
+    border-radius: var(--radius-sm);
+    color: var(--status-info-fg);
+    font-size: 0.75rem;
+    line-height: 1.45;
+  }
+  .owner-caption__icon {
+    flex-shrink: 0; width: 15px; height: 15px; margin-top: 1px;
+  }
+
+  .picked-account-chip {
+    display: flex; align-items: center; justify-content: space-between; gap: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg-surface-muted);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+  }
+  .picked-account-chip__meta { display: grid; gap: 2px; }
+  .picked-account-chip__number { font-family: var(--font-mono); font-size: 0.8125rem; color: var(--text-primary); }
+  .picked-account-chip__owner { font-size: 0.72rem; color: var(--text-muted); }
+  .payer-pill {
+    font-size: 0.66rem; font-weight: 600; letter-spacing: 0.02em;
+    padding: 2px 8px; border-radius: var(--radius-pill);
+    background: var(--bg-surface); border: 1px solid var(--border-strong); color: var(--text-secondary);
+    white-space: nowrap;
+  }
+
+  /* ── state-sheet scaffolding ── */
+  .state {
+    display: grid; grid-template-columns: 148px 1fr; gap: var(--space-5);
+    padding: var(--space-5) 0;
+    border-top: 1px solid var(--border-subtle);
+  }
+  .state:first-of-type { border-top: none; padding-top: 0; }
+  .state__meta { display: grid; gap: var(--space-2); align-content: start; }
+  .state__index { font-family: var(--font-mono); font-size: 0.7rem; color: var(--text-disabled); }
+  .state__title { font-weight: 600; font-size: 0.8125rem; }
+  .state__note { margin: 0; color: var(--text-muted); font-size: 0.72rem; line-height: 1.5; }
+
+  @media (max-width: 640px) {
+    .state { grid-template-columns: 1fr; }
+    .state__meta { padding-bottom: var(--space-1); }
+  }
+</style>
+
+<div class="page">
+  <header class="page-head">
+    <span class="eyebrow">Connection settings mockup · issue #1324</span>
+    <h1>Subiekt — payment method &amp; bank account</h1>
+    <p class="lede">
+      Five states of the same <code>&lt;InlineDisclosure&gt;</code> block, added to
+      <code>subiekt-structured-section.tsx</code> below the existing "Invoice trigger" field —
+      the identical pattern already shipped for inFakt, extended for Subiekt's multi-payer
+      reality (bridge PR&nbsp;#4 / <code>openlinker-subiekt-bridge#3</code>).
+    </p>
+  </header>
+
+  <section class="form-card">
+    <div class="form-card__title">Edit connection — Magazyn Główny (Subiekt)</div>
+    <div class="form-card__body">
+      <div class="form-field">
+        <div class="form-field__label">Bridge URL</div>
+        <input class="control" value="https://10.20.4.11:5005" disabled />
+      </div>
+
+      <div class="form-field">
+        <div class="form-field__label">Invoice trigger</div>
+        <select disabled><option>On order paid</option></select>
+      </div>
+
+      <!-- ══════════════ STATE 1 — collapsed ══════════════ -->
+      <div class="state">
+        <div class="state__meta">
+          <span class="state__index">01</span>
+          <span class="state__title">Collapsed</span>
+          <p class="state__note">Default rendering — most operators never open this.</p>
+        </div>
+        <details class="inline-disclosure">
+          <summary class="inline-disclosure__summary">
+            <span class="inline-disclosure__label">Payment method for invoice:</span>
+            <span class="inline-disclosure__value">Cash</span>
+            <span class="inline-disclosure__cta">Change →</span>
+          </summary>
+        </details>
+      </div>
+
+      <!-- ══════════════ STATE 2 — expanded, Cash ══════════════ -->
+      <div class="state">
+        <div class="state__meta">
+          <span class="state__index">02</span>
+          <span class="state__title">Expanded — Cash</span>
+          <p class="state__note">No account picker; nothing else to configure.</p>
+        </div>
+        <details class="inline-disclosure" open>
+          <summary class="inline-disclosure__summary">
+            <span class="inline-disclosure__label">Payment method for invoice:</span>
+            <span class="inline-disclosure__value">Cash</span>
+            <span class="inline-disclosure__cta">Change →</span>
+          </summary>
+          <div class="inline-disclosure__panel">
+            <div class="form-field">
+              <div class="form-field__label">Default payment method</div>
+              <select><option selected>Cash</option><option>Transfer</option></select>
+              <p class="form-field__description" style="margin:0;color:var(--text-muted);font-size:0.75rem;">
+                Sent as <code style="font-family:var(--font-mono);">paymentMethod: "cash"</code> on every issued invoice.
+              </p>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <!-- ══════════════ STATE 3 — expanded, Transfer, loading ══════════════ -->
+      <div class="state">
+        <div class="state__meta">
+          <span class="state__index">03</span>
+          <span class="state__title">Transfer — loading</span>
+          <p class="state__note"><code style="font-family:var(--font-mono);">useBankAccountsQuery</code> in flight.</p>
+        </div>
+        <details class="inline-disclosure" open>
+          <summary class="inline-disclosure__summary">
+            <span class="inline-disclosure__label">Payment method for invoice:</span>
+            <span class="inline-disclosure__value">Transfer</span>
+            <span class="inline-disclosure__cta">Change →</span>
+          </summary>
+          <div class="inline-disclosure__panel">
+            <div class="form-field">
+              <div class="form-field__label">Default payment method</div>
+              <select><option>Cash</option><option selected>Transfer</option></select>
+            </div>
+            <div class="form-field">
+              <div class="form-field__label">Bank account for transfer invoices</div>
+              <div class="skeleton-line"></div>
+              <p class="muted-text" style="font-size:0.75rem;color:var(--text-muted);">Checking Subiekt for bank accounts…</p>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <!-- ══════════════ STATE 4 — expanded, Transfer, loaded, multi-payer ══════════════ -->
+      <div class="state">
+        <div class="state__meta">
+          <span class="state__index">04</span>
+          <span class="state__title">Transfer — loaded, multi-payer</span>
+          <p class="state__note">
+            Accounts grouped by owning płatnik (<code style="font-family:var(--font-mono);">ownerName</code>,
+            bridge PR&nbsp;#4). Info caption flags the unresolved routing gap
+            (<code style="font-family:var(--font-mono);">#3</code>) without alarming.
+          </p>
+        </div>
+        <details class="inline-disclosure" open>
+          <summary class="inline-disclosure__summary">
+            <span class="inline-disclosure__label">Payment method for invoice:</span>
+            <span class="inline-disclosure__value">Transfer</span>
+            <span class="inline-disclosure__cta">Change →</span>
+          </summary>
+          <div class="inline-disclosure__panel">
+            <div class="form-field">
+              <div class="form-field__label">Default payment method</div>
+              <select><option>Cash</option><option selected>Transfer</option></select>
+            </div>
+
+            <div class="form-field">
+              <div class="form-field__label">Bank account for transfer invoices</div>
+              <select>
+                <optgroup class="account-owner-group" label="Moja Firma Sp. z o.o.">
+                  <option selected>mBank — 38 2490 •••• 5035 (default in Subiekt)</option>
+                  <option>ING — 12 1050 •••• 8817</option>
+                </optgroup>
+                <optgroup class="account-owner-group" label="Oddział Kraków Sp. z o.o.">
+                  <option>PKO BP — 61 1020 •••• 2461</option>
+                </optgroup>
+              </select>
+            </div>
+
+            <div class="picked-account-chip">
+              <div class="picked-account-chip__meta">
+                <span class="picked-account-chip__number">mBank · 38 2490 0005 7898 4745 0552 5035</span>
+                <span class="picked-account-chip__owner">Owned by Moja Firma Sp. z o.o.</span>
+              </div>
+              <span class="payer-pill">Default in Subiekt</span>
+            </div>
+
+            <div class="owner-caption">
+              <svg class="owner-caption__icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.3" />
+                <path d="M8 7.2v4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+                <circle cx="8" cy="4.9" r="0.9" fill="currentColor" />
+              </svg>
+              <span>
+                Accounts are listed by płatnik because this Subiekt install has more than one.
+                The bridge can't yet confirm which płatnik a given invoice is issued under, so the
+                account shown here isn't guaranteed to match — this will tighten once
+                <code style="font-family:var(--font-mono);">openlinker-subiekt-bridge#3</code> ships an invoice-side selector.
+              </span>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <!-- ══════════════ STATE 5 — expanded, Transfer, empty ══════════════ -->
+      <div class="state">
+        <div class="state__meta">
+          <span class="state__index">05</span>
+          <span class="state__title">Transfer — no accounts</span>
+          <p class="state__note">Zero accounts across every płatnik; falls back to Subiekt's own default form.</p>
+        </div>
+        <details class="inline-disclosure" open>
+          <summary class="inline-disclosure__summary">
+            <span class="inline-disclosure__label">Payment method for invoice:</span>
+            <span class="inline-disclosure__value">Transfer</span>
+            <span class="inline-disclosure__cta">Change →</span>
+          </summary>
+          <div class="inline-disclosure__panel">
+            <div class="form-field">
+              <div class="form-field__label">Default payment method</div>
+              <select><option>Cash</option><option selected>Transfer</option></select>
+            </div>
+            <p class="muted-text" style="font-size:0.8125rem;color:var(--text-secondary);">
+              No bank account is configured in Subiekt for any płatnik, so <strong>Transfer</strong> isn't
+              available to select yet — invoices will use whatever form Subiekt applies by default.
+              Add an account under Konfiguracja systemu → Rachunki bankowe, then reload this page.
+            </p>
+          </div>
+        </details>
+      </div>
+
+      <div class="capability-row"><span>Order sync</span><span class="switch switch--on"></span></div>
+      <div class="capability-row"><span>Invoice regulatory read</span><span class="switch"></span></div>
+    </div>
+  </section>
+</div>

--- a/docs/plans/mockups/subiekt-full-config-section.html
+++ b/docs/plans/mockups/subiekt-full-config-section.html
@@ -1,0 +1,560 @@
+<title>Subiekt — payment, bank account, branch &amp; register (mockup, #1324 Part A+B)</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  /* ── Tokens, copied verbatim from apps/web/src/index.css (light mode) ──
+     IBM Plex Sans/Mono approximated with the same system-ui fallback stack
+     already declared in --font-sans/--font-mono — the Artifact CSP blocks
+     webfont loading, so this mockup intentionally does not @font-face a
+     substitute rather than risk a silent, less-accurate fallback. */
+  :root {
+    --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+
+    --bg-canvas: oklch(99% 0.003 80);
+    --bg-shell: oklch(97.5% 0.004 80);
+    --bg-surface: #ffffff;
+    --bg-surface-muted: oklch(96% 0.005 80);
+    --bg-surface-hover: oklch(93% 0.006 80);
+
+    --border-subtle: oklch(93.5% 0.006 80);
+    --border-default: oklch(88% 0.008 80);
+    --border-strong: oklch(78% 0.01 80);
+    --border-focus: oklch(68% 0.18 50);
+
+    --text-primary: oklch(20% 0.012 80);
+    --text-secondary: oklch(38% 0.01 80);
+    --text-muted: oklch(52% 0.008 80);
+    --text-disabled: oklch(70% 0.005 80);
+
+    --accent-primary: oklch(68% 0.18 50);
+    --accent-primary-soft: oklch(96% 0.04 60);
+    --accent-primary-border: oklch(85% 0.1 55);
+    --accent-ring: oklch(68% 0.18 50 / 0.3);
+
+    --status-info: oklch(56% 0.14 245);
+    --status-info-soft: oklch(96% 0.03 245);
+    --status-info-border: oklch(85% 0.08 245);
+    --status-info-fg: oklch(40% 0.12 245);
+
+    --status-warning: oklch(72% 0.16 85);
+    --status-warning-soft: oklch(96% 0.05 85);
+    --status-warning-border: oklch(85% 0.1 85);
+    --status-warning-fg: oklch(42% 0.12 80);
+
+    --status-error: oklch(58% 0.2 25);
+    --status-error-soft: oklch(96% 0.04 25);
+    --status-error-border: oklch(85% 0.1 25);
+    --status-error-fg: oklch(42% 0.16 25);
+
+    --status-success: oklch(54% 0.14 150);
+    --status-success-soft: oklch(96% 0.04 150);
+    --status-success-fg: oklch(36% 0.12 150);
+
+    --shadow-xs: 0 1px 2px rgb(15 18 26 / 0.04);
+    --shadow-sm: 0 1px 2px rgb(15 18 26 / 0.04), 0 1px 3px rgb(15 18 26 / 0.06);
+    --shadow-soft: 0 1px 2px rgb(15 18 26 / 0.04), 0 6px 16px rgb(15 18 26 / 0.06);
+    --shadow-focus: 0 0 0 3px var(--accent-ring);
+
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.5rem;
+    --space-6: 2rem;
+    --space-7: 3rem;
+
+    --radius-xs: 4px;
+    --radius-sm: 6px;
+    --radius-md: 8px;
+    --radius-lg: 10px;
+    --radius-pill: 9999px;
+
+    --duration-fast: 120ms;
+    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--bg-shell);
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  code { font-family: var(--font-mono); }
+
+  .page {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: var(--space-7) var(--space-5) var(--space-8);
+    display: grid;
+    gap: var(--space-6);
+  }
+
+  .page-head { display: grid; gap: var(--space-2); }
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 10.5px;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+  h1 { margin: 0; font-size: 1.375rem; font-weight: 650; letter-spacing: -0.012em; text-wrap: balance; }
+  .lede { margin: 0; color: var(--text-secondary); max-width: 68ch; }
+  .lede code { font-size: 0.92em; background: var(--bg-surface-muted); padding: 0.08em 0.35em; border-radius: 4px; }
+
+  .part-key {
+    display: flex; gap: var(--space-4); flex-wrap: wrap;
+    padding: var(--space-3) var(--space-4);
+    background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-md);
+    font-size: 0.75rem; color: var(--text-secondary);
+  }
+  .part-key strong { color: var(--text-primary); }
+
+  /* ── the connection edit-form context the new section lives inside ── */
+  .form-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-soft);
+    overflow: hidden;
+  }
+  .form-card__title {
+    padding: var(--space-4) var(--space-5);
+    border-bottom: 1px solid var(--border-subtle);
+    font-weight: 600;
+    font-size: 0.9rem;
+  }
+  .form-card__body { padding: var(--space-5); display: grid; gap: var(--space-4); }
+
+  .form-field { display: grid; gap: var(--space-2); }
+  .form-field__label { font-size: 0.8125rem; font-weight: 500; color: var(--text-primary); }
+  .form-field__description { margin: 0; color: var(--text-muted); font-size: 0.75rem; }
+
+  .control, select {
+    width: 100%;
+    height: 2rem;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    padding: 0 var(--space-3);
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.8125rem;
+    box-shadow: var(--shadow-xs);
+  }
+  select {
+    appearance: none;
+    padding-right: var(--space-7);
+    background-image:
+      linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%),
+      linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%);
+    background-position: calc(100% - 14px) calc(50% - 2px), calc(100% - 8px) calc(50% - 2px);
+    background-size: 5px 5px, 5px 5px;
+    background-repeat: no-repeat;
+  }
+  select:disabled, .control:disabled { background: var(--bg-surface-muted); color: var(--text-disabled); }
+  select[data-invalid] { border-color: var(--status-error); box-shadow: 0 0 0 3px color-mix(in oklab, var(--status-error) 20%, transparent); }
+
+  .capability-row {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: var(--space-2) 0; border-top: 1px solid var(--border-subtle); font-size: 0.8125rem; color: var(--text-secondary);
+  }
+  .capability-row:first-of-type { border-top: none; }
+  .switch { width: 30px; height: 17px; border-radius: var(--radius-pill); background: var(--bg-surface-muted); border: 1px solid var(--border-default); position: relative; flex-shrink: 0; }
+  .switch::after { content: ''; position: absolute; top: 1px; left: 1px; width: 13px; height: 13px; border-radius: 50%; background: #fff; box-shadow: var(--shadow-xs); }
+  .switch--on { background: var(--accent-primary); border-color: var(--accent-primary); }
+  .switch--on::after { left: 15px; }
+
+  /* ── Inline Disclosure — copied verbatim from index.css ── */
+  .inline-disclosure {
+    border: 1px dashed var(--accent-primary-border);
+    background: var(--accent-primary-soft);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+  }
+  .inline-disclosure__summary { cursor: pointer; list-style: none; font-size: 0.85rem; color: var(--text-primary); line-height: 1.6; }
+  .inline-disclosure__summary::-webkit-details-marker { display: none; }
+  .inline-disclosure__summary:focus-visible { outline: none; box-shadow: var(--shadow-focus); border-radius: var(--radius-sm); }
+  .inline-disclosure__label { color: var(--text-secondary); }
+  .inline-disclosure__value { font-family: var(--font-mono); font-weight: 600; color: var(--text-primary); }
+  .inline-disclosure__sep { color: var(--border-strong); padding: 0 2px; }
+  .inline-disclosure__cta { color: var(--accent-primary); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; font-weight: 600; float: right; }
+  .inline-disclosure__panel { margin-top: var(--space-3); display: grid; gap: var(--space-5); }
+
+  /* ── one Part's fieldset inside the shared panel ── */
+  .config-part { display: grid; gap: var(--space-3); }
+  .config-part + .config-part { padding-top: var(--space-4); border-top: 1px solid var(--accent-primary-border); }
+  .config-part__heading {
+    display: flex; align-items: baseline; gap: var(--space-2);
+    font-size: 0.7rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted);
+  }
+  .config-part__heading small { font-weight: 500; text-transform: none; letter-spacing: 0; font-size: 0.72rem; color: var(--text-disabled); }
+
+  .muted-text { margin: 0; color: var(--text-secondary); font-size: 0.8125rem; }
+  .field-hint { margin: 0; color: var(--text-muted); font-size: 0.75rem; }
+
+  /* ── skeleton loading row ── */
+  .skeleton-line {
+    height: 2rem; border-radius: var(--radius-md);
+    background: linear-gradient(90deg, var(--bg-surface-muted) 25%, var(--bg-surface-hover) 37%, var(--bg-surface-muted) 63%);
+    background-size: 400% 100%;
+    animation: shimmer 1.4s ease infinite;
+  }
+  @keyframes shimmer { 0% { background-position: 100% 0; } 100% { background-position: -100% 0; } }
+  @media (prefers-reduced-motion: reduce) { .skeleton-line { animation: none; } }
+
+  /* ── multi-payer account option group + caption ── */
+  .account-owner-group { font-weight: 600; font-family: var(--font-sans); font-style: normal; color: var(--text-secondary); }
+
+  .callout {
+    display: flex; align-items: flex-start; gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-sm);
+    font-size: 0.75rem;
+    line-height: 1.45;
+  }
+  .callout--info { background: var(--status-info-soft); border: 1px solid var(--status-info-border); color: var(--status-info-fg); }
+  .callout--warning { background: var(--status-warning-soft); border: 1px solid var(--status-warning-border); color: var(--status-warning-fg); }
+  .callout--error { background: var(--status-error-soft); border: 1px solid var(--status-error-border); color: var(--status-error-fg); }
+  .callout__icon { flex-shrink: 0; width: 15px; height: 15px; margin-top: 1px; }
+
+  .picked-account-chip {
+    display: flex; align-items: center; justify-content: space-between; gap: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg-surface-muted);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+  }
+  .picked-account-chip__meta { display: grid; gap: 2px; }
+  .picked-account-chip__number { font-family: var(--font-mono); font-size: 0.8125rem; color: var(--text-primary); }
+  .picked-account-chip__owner { font-size: 0.72rem; color: var(--text-muted); }
+  .payer-pill {
+    font-size: 0.66rem; font-weight: 600; letter-spacing: 0.02em;
+    padding: 2px 8px; border-radius: var(--radius-pill);
+    background: var(--bg-surface); border: 1px solid var(--border-strong); color: var(--text-secondary);
+    white-space: nowrap;
+  }
+
+  .field-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
+  @media (max-width: 560px) { .field-row { grid-template-columns: 1fr; } }
+
+  /* ── state-sheet scaffolding ── */
+  .state {
+    display: grid; grid-template-columns: 168px 1fr; gap: var(--space-5);
+    padding: var(--space-6) 0;
+    border-top: 1px solid var(--border-subtle);
+  }
+  .state:first-of-type { border-top: none; padding-top: 0; }
+  .state__meta { display: grid; gap: var(--space-2); align-content: start; }
+  .state__index { font-family: var(--font-mono); font-size: 0.7rem; color: var(--text-disabled); }
+  .state__title { font-weight: 600; font-size: 0.8125rem; }
+  .state__note { margin: 0; color: var(--text-muted); font-size: 0.72rem; line-height: 1.5; }
+
+  @media (max-width: 640px) {
+    .state { grid-template-columns: 1fr; }
+    .state__meta { padding-bottom: var(--space-1); }
+  }
+</style>
+
+<div class="page">
+  <header class="page-head">
+    <span class="eyebrow">Connection settings mockup · issue #1324, Part A + Part B</span>
+    <h1>Subiekt — payment, bank account, branch &amp; cash register</h1>
+    <p class="lede">
+      One combined <code>&lt;InlineDisclosure&gt;</code> section in <code>subiekt-structured-section.tsx</code>,
+      below the existing "Invoice trigger" field. Part A (payment method + bank account) mirrors the shipped
+      inFakt pattern; Part B (branch + cash register) is new, backed by
+      <code>openlinker-subiekt-bridge</code> PR&nbsp;#6.
+    </p>
+    <div class="part-key">
+      <span><strong>Part A</strong> — <code>paymentMethod</code> / <code>bankAccountId</code> · bridge PR&nbsp;#2/#4</span>
+      <span><strong>Part B</strong> — <code>oddzialId</code> / <code>stanowiskoKasoweId</code> · bridge PR&nbsp;#6</span>
+    </div>
+  </header>
+
+  <section class="form-card">
+    <div class="form-card__title">Edit connection — Magazyn Główny (Subiekt)</div>
+    <div class="form-card__body">
+      <div class="form-field">
+        <div class="form-field__label">Bridge URL</div>
+        <input class="control" value="https://10.20.4.11:5005" disabled />
+      </div>
+
+      <div class="form-field">
+        <div class="form-field__label">Invoice trigger</div>
+        <select disabled><option>On order paid</option></select>
+      </div>
+
+      <!-- ══════════════ STATE 1 — collapsed, both parts summarized ══════════════ -->
+      <div class="state">
+        <div class="state__meta">
+          <span class="state__index">01</span>
+          <span class="state__title">Collapsed</span>
+          <p class="state__note">Default rendering. Both parts' current values read as one fact, not two separate rows competing for attention.</p>
+        </div>
+        <details class="inline-disclosure">
+          <summary class="inline-disclosure__summary">
+            <span class="inline-disclosure__cta">Change →</span>
+            <span class="inline-disclosure__label">Payment</span>
+            <span class="inline-disclosure__value">Transfer</span>
+            <span class="inline-disclosure__sep">·</span>
+            <span class="inline-disclosure__label">Branch</span>
+            <span class="inline-disclosure__value">Centrum Handlowe</span>
+            <span class="inline-disclosure__sep">·</span>
+            <span class="inline-disclosure__label">Register</span>
+            <span class="inline-disclosure__value">Kasa Galaxia 1</span>
+          </summary>
+        </details>
+      </div>
+
+      <!-- ══════════════ STATE 2 — expanded, Part A only (Transfer, multi-payer) ══════════════ -->
+      <div class="state">
+        <div class="state__meta">
+          <span class="state__index">02</span>
+          <span class="state__title">Part A — payment</span>
+          <p class="state__note">Same picker as the earlier Part A mockup, now living as the section's first fieldset.</p>
+        </div>
+        <details class="inline-disclosure" open>
+          <summary class="inline-disclosure__summary">
+            <span class="inline-disclosure__cta">Change →</span>
+            <span class="inline-disclosure__label">Payment</span>
+            <span class="inline-disclosure__value">Transfer</span>
+            <span class="inline-disclosure__sep">·</span>
+            <span class="inline-disclosure__label">Branch</span>
+            <span class="inline-disclosure__value">Not set</span>
+            <span class="inline-disclosure__sep">·</span>
+            <span class="inline-disclosure__label">Register</span>
+            <span class="inline-disclosure__value">Not set</span>
+          </summary>
+          <div class="inline-disclosure__panel">
+            <div class="config-part">
+              <div class="config-part__heading">Payment <small>sent as paymentMethod / bankAccountId</small></div>
+              <div class="form-field">
+                <div class="form-field__label">Default payment method</div>
+                <select><option>Cash</option><option selected>Transfer</option></select>
+              </div>
+              <div class="form-field">
+                <div class="form-field__label">Bank account for transfer invoices</div>
+                <select>
+                  <optgroup class="account-owner-group" label="Moja Firma Sp. z o.o.">
+                    <option selected>mBank — 38 2490 •••• 5035 (default in Subiekt)</option>
+                    <option>ING — 12 1050 •••• 8817</option>
+                  </optgroup>
+                  <optgroup class="account-owner-group" label="Oddział Kraków Sp. z o.o.">
+                    <option>PKO BP — 61 1020 •••• 2461</option>
+                  </optgroup>
+                </select>
+              </div>
+              <div class="picked-account-chip">
+                <div class="picked-account-chip__meta">
+                  <span class="picked-account-chip__number">mBank · 38 2490 0005 7898 4745 0552 5035</span>
+                  <span class="picked-account-chip__owner">Owned by Moja Firma Sp. z o.o.</span>
+                </div>
+                <span class="payer-pill">Default in Subiekt</span>
+              </div>
+              <div class="callout callout--info">
+                <svg class="callout__icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.3" />
+                  <path d="M8 7.2v4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+                  <circle cx="8" cy="4.9" r="0.9" fill="currentColor" />
+                </svg>
+                <span>
+                  Accounts are listed by płatnik because this install has more than one. The bridge still can't
+                  confirm which płatnik an invoice is issued under, so the account shown here isn't guaranteed
+                  to match — unaffected by the Branch/Register picker below, which is a separate axis.
+                </span>
+              </div>
+            </div>
+
+            <div class="config-part">
+              <div class="config-part__heading">Branch &amp; cash register <small>sent as oddzialId / stanowiskoKasoweId</small></div>
+              <div class="field-row">
+                <div class="form-field">
+                  <div class="form-field__label">Branch</div>
+                  <select><option selected>Not set (Subiekt's default)</option><option>Pachnidło</option><option>Centrum Handlowe</option></select>
+                </div>
+                <div class="form-field">
+                  <div class="form-field__label">Cash register</div>
+                  <select disabled><option>Not set (Subiekt's default)</option></select>
+                </div>
+              </div>
+              <p class="field-hint">Leave both unset to keep Subiekt's own default branch and register — this is the byte-identical, no-regression state.</p>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <!-- ══════════════ STATE 3 — expanded, Part B filtered by branch ══════════════ -->
+      <div class="state">
+        <div class="state__meta">
+          <span class="state__index">03</span>
+          <span class="state__title">Part B — branch picked</span>
+          <p class="state__note">Picking "Centrum Handlowe" filters the register list to stations linked to it, plus a standing "any unassigned register" group — most registers in the real data have no branch link at all.</p>
+        </div>
+        <details class="inline-disclosure" open>
+          <summary class="inline-disclosure__summary">
+            <span class="inline-disclosure__cta">Change →</span>
+            <span class="inline-disclosure__label">Payment</span>
+            <span class="inline-disclosure__value">Transfer</span>
+            <span class="inline-disclosure__sep">·</span>
+            <span class="inline-disclosure__label">Branch</span>
+            <span class="inline-disclosure__value">Centrum Handlowe</span>
+            <span class="inline-disclosure__sep">·</span>
+            <span class="inline-disclosure__label">Register</span>
+            <span class="inline-disclosure__value">Kasa Galaxia 1</span>
+          </summary>
+          <div class="inline-disclosure__panel">
+            <div class="config-part">
+              <div class="config-part__heading">Branch &amp; cash register <small>sent as oddzialId / stanowiskoKasoweId</small></div>
+              <div class="field-row">
+                <div class="form-field">
+                  <div class="form-field__label">Branch</div>
+                  <select><option>Not set (Subiekt's default)</option><option>Pachnidło</option><option selected>Centrum Handlowe</option></select>
+                </div>
+                <div class="form-field">
+                  <div class="form-field__label">Cash register</div>
+                  <select>
+                    <optgroup class="account-owner-group" label="Linked to Centrum Handlowe">
+                      <option selected>Kasa Galaxia 1</option>
+                      <option>Kasa Galaxia 2 (wielowalutowa)</option>
+                    </optgroup>
+                    <optgroup class="account-owner-group" label="Unassigned — works with any branch">
+                      <option>Kasa Centralna</option>
+                      <option>Kasa Outlet</option>
+                    </optgroup>
+                  </select>
+                </div>
+              </div>
+              <p class="field-hint">Registers linked to a different branch (e.g. Pachnidło's own) aren't offered here — see State 04 for what that looks like when it's not filtered out first.</p>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <!-- ══════════════ STATE 4 — mismatched pair, disabled options ══════════════ -->
+      <div class="state">
+        <div class="state__meta">
+          <span class="state__index">04</span>
+          <span class="state__title">Mismatched pair — caught in the UI</span>
+          <p class="state__note">The bridge rejects an Oddział/Stanowisko pair that don't match before ever touching Sfera (live-verified, PR #6). The picker prevents the mismatch from being selectable at all, rather than letting the operator hit a save-time error.</p>
+        </div>
+        <details class="inline-disclosure" open>
+          <summary class="inline-disclosure__summary">
+            <span class="inline-disclosure__cta">Change →</span>
+            <span class="inline-disclosure__label">Payment</span>
+            <span class="inline-disclosure__value">Transfer</span>
+            <span class="inline-disclosure__sep">·</span>
+            <span class="inline-disclosure__label">Branch</span>
+            <span class="inline-disclosure__value">Pachnidło</span>
+            <span class="inline-disclosure__sep">·</span>
+            <span class="inline-disclosure__label">Register</span>
+            <span class="inline-disclosure__value">Not set</span>
+          </summary>
+          <div class="inline-disclosure__panel">
+            <div class="config-part">
+              <div class="config-part__heading">Branch &amp; cash register <small>sent as oddzialId / stanowiskoKasoweId</small></div>
+              <div class="field-row">
+                <div class="form-field">
+                  <div class="form-field__label">Branch</div>
+                  <select><option>Not set (Subiekt's default)</option><option selected>Pachnidło</option><option>Centrum Handlowe</option></select>
+                </div>
+                <div class="form-field">
+                  <div class="form-field__label">Cash register</div>
+                  <select>
+                    <option value="" selected disabled>Select a register linked to Pachnidło…</option>
+                    <optgroup class="account-owner-group" label="Unassigned — works with any branch">
+                      <option>Kasa Centralna</option>
+                      <option>Kasa Outlet</option>
+                    </optgroup>
+                    <optgroup class="account-owner-group" label="Linked to a different branch">
+                      <option disabled title="Linked to Centrum Handlowe">Kasa Galaxia 1 — linked to Centrum Handlowe</option>
+                      <option disabled title="Linked to Centrum Handlowe">Kasa Galaxia 2 — linked to Centrum Handlowe</option>
+                    </optgroup>
+                  </select>
+                </div>
+              </div>
+              <div class="callout callout--error">
+                <svg class="callout__icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M8 1.5 1.5 13.5h13L8 1.5Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" />
+                  <path d="M8 6.2v3.2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+                  <circle cx="8" cy="11.3" r="0.9" fill="currentColor" />
+                </svg>
+                <span>
+                  Pachnidło has no register of its own that isn't already assigned elsewhere. Pick one of the
+                  unassigned registers above, choose a different branch, or leave the register unset to use
+                  whatever Subiekt defaults to for this branch.
+                </span>
+              </div>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <!-- ══════════════ STATE 5 — branch set, register empty ══════════════ -->
+      <div class="state">
+        <div class="state__meta">
+          <span class="state__index">05</span>
+          <span class="state__title">Branch set, register empty</span>
+          <p class="state__note">The bridge rejects <code>oddzialId</code> alone with a 422 (live-verified) — Subiekt's own implicit register resolution doesn't reach across branches. The warning appears before save, not after a rejected request.</p>
+        </div>
+        <details class="inline-disclosure" open>
+          <summary class="inline-disclosure__summary">
+            <span class="inline-disclosure__cta">Change →</span>
+            <span class="inline-disclosure__label">Payment</span>
+            <span class="inline-disclosure__value">Cash</span>
+            <span class="inline-disclosure__sep">·</span>
+            <span class="inline-disclosure__label">Branch</span>
+            <span class="inline-disclosure__value">Centrum Handlowe</span>
+            <span class="inline-disclosure__sep">·</span>
+            <span class="inline-disclosure__label">Register</span>
+            <span class="inline-disclosure__value" style="color:var(--status-warning-fg);">Missing</span>
+          </summary>
+          <div class="inline-disclosure__panel">
+            <div class="config-part">
+              <div class="config-part__heading">Branch &amp; cash register <small>sent as oddzialId / stanowiskoKasoweId</small></div>
+              <div class="field-row">
+                <div class="form-field">
+                  <div class="form-field__label">Branch</div>
+                  <select><option>Not set (Subiekt's default)</option><option>Pachnidło</option><option selected>Centrum Handlowe</option></select>
+                </div>
+                <div class="form-field">
+                  <div class="form-field__label">Cash register</div>
+                  <select data-invalid>
+                    <option value="" selected>Select a register…</option>
+                    <optgroup class="account-owner-group" label="Linked to Centrum Handlowe">
+                      <option>Kasa Galaxia 1</option>
+                      <option>Kasa Galaxia 2 (wielowalutowa)</option>
+                    </optgroup>
+                    <optgroup class="account-owner-group" label="Unassigned — works with any branch">
+                      <option>Kasa Centralna</option>
+                      <option>Kasa Outlet</option>
+                    </optgroup>
+                  </select>
+                </div>
+              </div>
+              <div class="callout callout--warning">
+                <svg class="callout__icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M8 1.5 1.5 13.5h13L8 1.5Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" />
+                  <path d="M8 6.2v3.2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+                  <circle cx="8" cy="11.3" r="0.9" fill="currentColor" />
+                </svg>
+                <span>
+                  A branch alone isn't enough — Subiekt needs a specific cash register to issue against it.
+                  Pick one above, or clear the branch to fall back to Subiekt's own default.
+                </span>
+              </div>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <div class="capability-row"><span>Order sync</span><span class="switch switch--on"></span></div>
+      <div class="capability-row"><span>Invoice regulatory read</span><span class="switch"></span></div>
+    </div>
+  </section>
+</div>

--- a/libs/integrations/subiekt/src/application/__tests__/subiekt-adapter.factory.spec.ts
+++ b/libs/integrations/subiekt/src/application/__tests__/subiekt-adapter.factory.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Subiekt Adapter Factory — config-parsing unit tests (#1324)
+ *
+ * Exercises `validateAndParseConfig` (via bracket access to the private method)
+ * to cover the four payment/branch config fields added in Unit B. Constructing
+ * the adapter itself is out of scope here (that path lands with Unit C's 4th
+ * constructor param).
+ *
+ * @module libs/integrations/subiekt/src/application/__tests__
+ */
+import { SubiektConfigException } from '../../domain/exceptions/subiekt-config.exception';
+import type { SubiektConnectionConfig } from '../../domain/types/subiekt-connection-config.types';
+import { SubiektAdapterFactory } from '../subiekt-adapter.factory';
+
+type ParseFn = (config: Record<string, unknown>) => SubiektConnectionConfig;
+
+function parse(config: Record<string, unknown>): SubiektConnectionConfig {
+  const factory = new SubiektAdapterFactory();
+  const fn = (factory as unknown as { validateAndParseConfig: ParseFn }).validateAndParseConfig;
+  return fn.call(factory, config);
+}
+
+describe('SubiektAdapterFactory.validateAndParseConfig', () => {
+  it('parses a config with all payment/cash-register fields', () => {
+    const parsed = parse({
+      bridgeBaseUrl: 'http://192.168.1.10:5000',
+      defaultPaymentMethod: 'transfer',
+      bankAccountId: 5,
+      defaultStanowiskoKasoweId: 100067,
+    });
+
+    expect(parsed).toEqual({
+      bridgeBaseUrl: 'http://192.168.1.10:5000',
+      defaultPaymentMethod: 'transfer',
+      bankAccountId: 5,
+      defaultStanowiskoKasoweId: 100067,
+    });
+  });
+
+  it('omits absent optional fields', () => {
+    const parsed = parse({ bridgeBaseUrl: 'http://192.168.1.10' });
+
+    expect(parsed).toEqual({ bridgeBaseUrl: 'http://192.168.1.10' });
+    expect(parsed.defaultPaymentMethod).toBeUndefined();
+    expect(parsed.bankAccountId).toBeUndefined();
+    expect(parsed.defaultStanowiskoKasoweId).toBeUndefined();
+  });
+
+  it('accepts defaultPaymentMethod: cash', () => {
+    expect(
+      parse({ bridgeBaseUrl: 'http://192.168.1.10', defaultPaymentMethod: 'cash' })
+        .defaultPaymentMethod,
+    ).toBe('cash');
+  });
+
+  it('throws SubiektConfigException on an invalid defaultPaymentMethod', () => {
+    expect(() =>
+      parse({ bridgeBaseUrl: 'http://192.168.1.10', defaultPaymentMethod: 'card' }),
+    ).toThrow(SubiektConfigException);
+  });
+
+  it.each([
+    ['bankAccountId', 0],
+    ['bankAccountId', -1],
+    ['bankAccountId', 1.5],
+    ['bankAccountId', 'x'],
+    ['defaultStanowiskoKasoweId', 0],
+    ['defaultStanowiskoKasoweId', -3],
+    ['defaultStanowiskoKasoweId', 3.3],
+  ])('throws SubiektConfigException when %s is %p', (field, value) => {
+    expect(() => parse({ bridgeBaseUrl: 'http://192.168.1.10', [field]: value })).toThrow(
+      SubiektConfigException,
+    );
+  });
+
+  it('still throws for a missing bridgeBaseUrl (existing behavior)', () => {
+    expect(() => parse({})).toThrow(SubiektConfigException);
+  });
+});

--- a/libs/integrations/subiekt/src/application/dto/subiekt-connection-config.dto.ts
+++ b/libs/integrations/subiekt/src/application/dto/subiekt-connection-config.dto.ts
@@ -16,6 +16,7 @@
  */
 import type { ValidatorConstraintInterface } from 'class-validator';
 import {
+  IsIn,
   IsInt,
   IsNotEmpty,
   IsOptional,
@@ -27,6 +28,10 @@ import {
   ValidatorConstraint,
 } from 'class-validator';
 import { isBridgeUrlSafe } from '../../infrastructure/http/subiekt-url-safety';
+import {
+  SubiektPaymentMethodValues,
+  type SubiektPaymentMethod,
+} from '../../domain/types/subiekt-connection-config.types';
 
 @ValidatorConstraint({ name: 'isBridgeUrlSafe', async: false })
 export class IsBridgeUrlSafeConstraint implements ValidatorConstraintInterface {
@@ -51,4 +56,24 @@ export class SubiektConnectionConfigDto {
   @Min(1000)
   @Max(120000)
   timeoutMs?: number;
+
+  // Payment / bank-account / cash-register defaults (#1324). No cross-field
+  // validation here — the bridge is the enforcement authority for
+  // transfer↔account linkage; OL passes through and surfaces the bridge's
+  // rejection. There is no Oddział (branch) field: the Sfera session binds the
+  // branch read-only to the logged-in bridge session, so a per-request override
+  // is impossible.
+  @IsOptional()
+  @IsIn(SubiektPaymentMethodValues)
+  defaultPaymentMethod?: SubiektPaymentMethod;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  bankAccountId?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  defaultStanowiskoKasoweId?: number;
 }

--- a/libs/integrations/subiekt/src/application/subiekt-adapter.factory.ts
+++ b/libs/integrations/subiekt/src/application/subiekt-adapter.factory.ts
@@ -14,7 +14,11 @@
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import type { CredentialsResolverPort } from '@openlinker/core/integrations';
 import type { LoggerPort } from '@openlinker/shared/logging';
-import type { SubiektConnectionConfig } from '../domain/types/subiekt-connection-config.types';
+import type {
+  SubiektConnectionConfig,
+  SubiektPaymentMethod,
+} from '../domain/types/subiekt-connection-config.types';
+import { SubiektPaymentMethodValues } from '../domain/types/subiekt-connection-config.types';
 import type { SubiektBridgeCredentials } from '../domain/types/subiekt-credentials.types';
 import { SubiektConfigException } from '../domain/exceptions/subiekt-config.exception';
 import { SubiektInvoicingAdapter } from '../infrastructure/adapters/subiekt-invoicing.adapter';
@@ -53,14 +57,15 @@ export class SubiektAdapterFactory {
     });
 
     return {
-      invoicing: new SubiektInvoicingAdapter(client, connection.id, logger),
+      invoicing: new SubiektInvoicingAdapter(client, connection.id, logger, config),
     };
   }
 
   /**
    * Validate and parse the raw `connection.config` blob.
-   * @throws SubiektConfigException on a missing / malformed `bridgeBaseUrl` or
-   *   out-of-range `timeoutMs`.
+   * @throws SubiektConfigException on a missing / malformed `bridgeBaseUrl`,
+   *   out-of-range `timeoutMs`, an invalid `defaultPaymentMethod`, or a
+   *   non-positive-integer `bankAccountId` / `defaultStanowiskoKasoweId`.
    */
   private validateAndParseConfig(config: Record<string, unknown>): SubiektConnectionConfig {
     const bridgeBaseUrl = config.bridgeBaseUrl;
@@ -85,6 +90,52 @@ export class SubiektAdapterFactory {
       timeoutMs = raw;
     }
 
-    return timeoutMs !== undefined ? { bridgeBaseUrl, timeoutMs } : { bridgeBaseUrl };
+    let defaultPaymentMethod: SubiektPaymentMethod | undefined;
+    if (config.defaultPaymentMethod !== undefined) {
+      const raw = config.defaultPaymentMethod;
+      if (
+        typeof raw !== 'string' ||
+        !SubiektPaymentMethodValues.includes(raw as SubiektPaymentMethod)
+      ) {
+        throw new SubiektConfigException(
+          `defaultPaymentMethod must be one of: ${SubiektPaymentMethodValues.join(', ')}`,
+          'defaultPaymentMethod',
+          raw,
+        );
+      }
+      defaultPaymentMethod = raw as SubiektPaymentMethod;
+    }
+
+    const bankAccountId = this.parsePositiveIntField(config.bankAccountId, 'bankAccountId');
+    const defaultStanowiskoKasoweId = this.parsePositiveIntField(
+      config.defaultStanowiskoKasoweId,
+      'defaultStanowiskoKasoweId',
+    );
+
+    const parsed: SubiektConnectionConfig = { bridgeBaseUrl };
+    if (timeoutMs !== undefined) parsed.timeoutMs = timeoutMs;
+    if (defaultPaymentMethod !== undefined) parsed.defaultPaymentMethod = defaultPaymentMethod;
+    if (bankAccountId !== undefined) parsed.bankAccountId = bankAccountId;
+    if (defaultStanowiskoKasoweId !== undefined) {
+      parsed.defaultStanowiskoKasoweId = defaultStanowiskoKasoweId;
+    }
+    return parsed;
+  }
+
+  /**
+   * Parse an OPTIONAL bridge-native positive-integer id field. Returns
+   * `undefined` when absent; throws `SubiektConfigException` when present but
+   * not a positive integer.
+   */
+  private parsePositiveIntField(raw: unknown, field: string): number | undefined {
+    if (raw === undefined) return undefined;
+    if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 1) {
+      throw new SubiektConfigException(
+        `${field} must be a positive integer`,
+        field,
+        raw,
+      );
+    }
+    return raw;
   }
 }

--- a/libs/integrations/subiekt/src/bridge/subiekt-bridge.client.ts
+++ b/libs/integrations/subiekt/src/bridge/subiekt-bridge.client.ts
@@ -18,6 +18,9 @@ import type {
   BridgeIssueInvoiceResponse,
   BridgeKorektaRequest,
   BridgeKorektaResponse,
+  BridgeListBankAccountsResponse,
+  BridgeListCashRegistersResponse,
+  BridgeSetDefaultBankAccountResponse,
   BridgeUpsertCustomerRequest,
   BridgeUpsertCustomerResponse,
 } from './subiekt-bridge.types';
@@ -39,4 +42,24 @@ export interface SubiektBridgeClient {
 
   /** Read the current state of a previously-issued document. */
   getInvoiceStatus(req: BridgeInvoiceStatusRequest): Promise<BridgeInvoiceStatusResponse>;
+
+  /**
+   * List the seller's bank accounts (rachunki bankowe), each tagged with its
+   * owning Podmiot on a multi-payer install. The REAL bridge route is
+   * `GET /api/bank-accounts` (#1324).
+   */
+  listBankAccounts(): Promise<BridgeListBankAccountsResponse>;
+
+  /**
+   * Mark a bank account as the seller's default. Idempotent (re-selecting the
+   * current default is a no-op success). The REAL bridge route is
+   * `PUT /api/bank-accounts/{id}/default` (#1324).
+   */
+  setDefaultBankAccount(bankAccountId: number): Promise<BridgeSetDefaultBankAccountResponse>;
+
+  /**
+   * List the seller's Stanowiska Kasowe (cash registers). The REAL bridge route
+   * is `GET /api/cash-registers` (#1324).
+   */
+  listCashRegisters(): Promise<BridgeListCashRegistersResponse>;
 }

--- a/libs/integrations/subiekt/src/bridge/subiekt-bridge.types.ts
+++ b/libs/integrations/subiekt/src/bridge/subiekt-bridge.types.ts
@@ -114,6 +114,25 @@ export interface BridgeIssueInvoiceRequest {
   kontrahentId?: number;
   buyer?: BridgeBuyer;
   lines: BridgeLine[];
+  /**
+   * Payment selection (additive, #1324). Both absent = unchanged legacy
+   * behavior. Bridge-side `PaymentSelection.TryCreate` enforces the rules:
+   * `transfer` requires a positive `bankAccountId`; `cash` must not carry one; a
+   * bare `bankAccountId` without `paymentMethod` is rejected; not supported for
+   * `documentType: "PA"`. Vocabulary errors surface as 400, combination/account
+   * errors as 422 — OL passes through and surfaces the bridge's rejection.
+   */
+  paymentMethod?: 'cash' | 'transfer';
+  /** Numeric bank-account id to bill a `transfer` document against (bridge-native). */
+  bankAccountId?: number;
+  /**
+   * Stanowisko Kasowe (cash register) routing (additive, #1324). The Sfera
+   * session binds Oddział read-only to the logged-in bridge session, so a
+   * per-request branch override is impossible; the cash register is the only
+   * real per-document routing field. Accepted alone (keeps the document's
+   * session-bound branch).
+   */
+  stanowiskoKasoweId?: number;
 }
 
 /**
@@ -212,6 +231,65 @@ export interface BridgeInvoiceStatusRequest {
 export interface BridgeInvoiceStatusResponse {
   state: BridgeInvoiceState;
   regulatoryStatus: BridgeRegulatoryStatus;
+}
+
+/**
+ * One bank account (rachunek bankowy) as the bridge returns it from
+ * `GET /api/bank-accounts` (bridge PR #4). All display fields are nullable —
+ * the bridge returns `""`/`null` for unset Sfera columns, normalized to `null`
+ * on read where applicable. `ownerPodmiotId`/`ownerName` were added by PR #4 to
+ * tag each account with its owning seller Podmiot on a multi-payer install (the
+ * original PR #2 query silently returned only one payer's accounts). These
+ * owner fields are captured here so the data isn't lost, but the neutral core
+ * `InvoicingBankAccount` mapping in the #753 adapter drops them (core stays
+ * marketplace-neutral).
+ */
+export interface BridgeBankAccount {
+  id: number;
+  name: string | null;
+  number: string | null;
+  bankNumber: string | null;
+  description: string | null;
+  currency: string | null;
+  isVatAccount: boolean;
+  isDefault: boolean;
+  ownerPodmiotId: number;
+  ownerName: string | null;
+}
+
+/** `data` payload of `GET /api/bank-accounts`. */
+export interface BridgeListBankAccountsResponse {
+  count: number;
+  accounts: BridgeBankAccount[];
+}
+
+/**
+ * `data` payload of `PUT /api/bank-accounts/{id}/default`. Idempotent — selecting
+ * the current default is a no-op success.
+ */
+export interface BridgeSetDefaultBankAccountResponse {
+  bankAccountId: number;
+  isDefault: boolean;
+}
+
+/**
+ * One Stanowisko Kasowe (cash register) from `GET /api/cash-registers` (bridge
+ * PR #6). `oddzialId: null` means the register is unlinked (not branch-restricted);
+ * per the live probe most registers on a real install are unlinked. `oddzialId`
+ * here is the register's own informational branch tag (a display label), NOT a
+ * per-request routing override.
+ */
+export interface BridgeCashRegister {
+  id: number;
+  name: string | null;
+  symbol: string | null;
+  oddzialId: number | null;
+}
+
+/** `data` payload of `GET /api/cash-registers`. */
+export interface BridgeListCashRegistersResponse {
+  count: number;
+  cashRegisters: BridgeCashRegister[];
 }
 
 /**

--- a/libs/integrations/subiekt/src/domain/types/subiekt-connection-config.types.ts
+++ b/libs/integrations/subiekt/src/domain/types/subiekt-connection-config.types.ts
@@ -10,6 +10,13 @@
  * @module libs/integrations/subiekt/src/domain/types
  */
 
+/**
+ * Payment-method vocabulary the Subiekt bridge accepts on `POST /api/invoices`
+ * (`as const` + union pattern per engineering-standards.md).
+ */
+export const SubiektPaymentMethodValues = ['cash', 'transfer'] as const;
+export type SubiektPaymentMethod = (typeof SubiektPaymentMethodValues)[number];
+
 export interface SubiektConnectionConfig {
   /**
    * Root URL of the local Subiekt bridge (#752). Must include protocol
@@ -21,4 +28,28 @@ export interface SubiektConnectionConfig {
 
   /** Optional per-request timeout in milliseconds. */
   timeoutMs?: number;
+
+  /**
+   * Default payment method threaded onto every issued invoice (#1324). When
+   * UNSET the adapter sends nothing (true additive/no-regression path) — it
+   * does NOT default to `'cash'`. `'transfer'` additionally requires a
+   * `bankAccountId`; the bridge is the enforcement authority.
+   */
+  defaultPaymentMethod?: SubiektPaymentMethod;
+
+  /**
+   * Seller bank-account id used when `defaultPaymentMethod === 'transfer'`.
+   * Bridge-native int from `GET /api/bank-accounts`, stored verbatim — NOT an
+   * OL internal id, no snapshot, no identifier-mapping (see plan §4).
+   */
+  bankAccountId?: number;
+
+  /**
+   * Default Stanowisko Kasowe (cash-register station) id stamped on issued
+   * invoices (#1324). Bridge-native int from `GET /api/cash-registers`, stored
+   * verbatim — no snapshot, no identifier-mapping. The Oddział (branch) axis is
+   * NOT configurable: the Sfera session binds it read-only to the logged-in
+   * bridge session, so a per-request override can only ever be rejected.
+   */
+  defaultStanowiskoKasoweId?: number;
 }

--- a/libs/integrations/subiekt/src/domain/types/subiekt-invoicing-views.types.ts
+++ b/libs/integrations/subiekt/src/domain/types/subiekt-invoicing-views.types.ts
@@ -1,0 +1,43 @@
+/**
+ * Subiekt Invoicing — adapter view types (#1324)
+ *
+ * Subiekt-LOCAL return shapes for the discovery methods that have no neutral
+ * `libs/core` equivalent (decision 2/6 of the #1324 plan): the owner-aware
+ * bank-account view (carries the multi-Podmiot owner tag the neutral
+ * `InvoicingBankAccount` deliberately drops) and the Stanowisko Kasowe view (no
+ * cross-plugin abstraction — inFakt/KSeF have no cash-register concept, so it
+ * stays Subiekt-only). Ids are surfaced as the bridge-native NUMBERs the FE
+ * uses directly (e.g. `SubiektCashRegisterView.id`/`.oddzialId`), NOT
+ * stringified — these views feed the Subiekt-specific controller (#1324 Unit
+ * E), not the neutral core surface.
+ *
+ * @module libs/integrations/subiekt/src/domain/types
+ */
+
+/**
+ * Owner-aware bank-account view — the full bridge shape incl. the owning
+ * seller Podmiot (`ownerPodmiotId`/`ownerName`) that the neutral
+ * `InvoicingBankAccount` mapping drops. Feeds the Subiekt controller so the FE
+ * can group accounts by payer and show the >1-owner payer-routing warning.
+ */
+export interface SubiektBankAccountView {
+  id: string;
+  accountNumber: string;
+  bankName: string;
+  isDefault: boolean;
+  ownerPodmiotId: number;
+  ownerName: string | null;
+}
+
+/**
+ * One Stanowisko Kasowe (cash register), mapped 1:1 from the bridge.
+ * `oddzialId: null` means the register is unlinked; a non-null value is the
+ * register's own informational branch tag (a display label), NOT a per-request
+ * routing override — the branch is bound read-only to the bridge session.
+ */
+export interface SubiektCashRegisterView {
+  id: number;
+  name: string | null;
+  symbol: string | null;
+  oddzialId: number | null;
+}

--- a/libs/integrations/subiekt/src/infrastructure/adapters/__tests__/subiekt-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/subiekt/src/infrastructure/adapters/__tests__/subiekt-connection-config-shape-validator.adapter.spec.ts
@@ -39,4 +39,39 @@ describe('SubiektConnectionConfigShapeValidatorAdapter', () => {
       validator.validate({ bridgeBaseUrl: 'http://192.168.1.10', timeoutMs: 999999 }),
     ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
   });
+
+  it('accepts a valid config with all payment/cash-register fields (#1324)', async () => {
+    await expect(
+      validator.validate({
+        bridgeBaseUrl: 'http://192.168.1.10:5000',
+        defaultPaymentMethod: 'transfer',
+        bankAccountId: 5,
+        defaultStanowiskoKasoweId: 100067,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects an invalid defaultPaymentMethod (#1324)', async () => {
+    await expect(
+      validator.validate({ bridgeBaseUrl: 'http://192.168.1.10', defaultPaymentMethod: 'card' }),
+    ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
+  });
+
+  it('rejects a non-positive-integer bankAccountId (#1324)', async () => {
+    await expect(
+      validator.validate({ bridgeBaseUrl: 'http://192.168.1.10', bankAccountId: 0 }),
+    ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
+    await expect(
+      validator.validate({ bridgeBaseUrl: 'http://192.168.1.10', bankAccountId: 1.5 }),
+    ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
+  });
+
+  it('rejects a non-positive-integer defaultStanowiskoKasoweId (#1324)', async () => {
+    await expect(
+      validator.validate({ bridgeBaseUrl: 'http://192.168.1.10', defaultStanowiskoKasoweId: 0 }),
+    ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
+    await expect(
+      validator.validate({ bridgeBaseUrl: 'http://192.168.1.10', defaultStanowiskoKasoweId: 1.5 }),
+    ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
+  });
 });

--- a/libs/integrations/subiekt/src/infrastructure/adapters/__tests__/subiekt-invoicing.adapter.spec.ts
+++ b/libs/integrations/subiekt/src/infrastructure/adapters/__tests__/subiekt-invoicing.adapter.spec.ts
@@ -10,6 +10,8 @@
 import {
   BuyerProfile,
   InvoiceRecord,
+  isBankAccountDefaultSetter,
+  isBankAccountsReader,
   isCorrectionIssuer,
   isRegulatoryStatusReader,
 } from '@openlinker/core/invoicing';
@@ -20,6 +22,7 @@ import type {
   TaxIdentifier,
 } from '@openlinker/core/invoicing';
 import type { LoggerPort } from '@openlinker/shared/logging';
+import type { SubiektConnectionConfig } from '../../../domain/types/subiekt-connection-config.types';
 import { FakeSubiektBridgeAdapter } from '../../../testing/fake-subiekt-bridge.adapter';
 import {
   SubiektInvoicingAdapter,
@@ -28,6 +31,7 @@ import {
 import { SubiektInvoiceRejectedError } from '../../../domain/exceptions/subiekt-invoice-rejected.exception';
 import { SubiektBridgeTransportError } from '../../../domain/exceptions/subiekt-bridge-transport.exception';
 import { SubiektUnsupportedDocumentTypeError } from '../../../domain/exceptions/subiekt-unsupported-document-type.exception';
+import { SubiektConfigException } from '../../../domain/exceptions/subiekt-config.exception';
 
 const ADDRESS: BuyerAddress = {
   line1: 'ul. Przykładowa 1',
@@ -76,6 +80,24 @@ function makeAdapter(bridge = new FakeSubiektBridgeAdapter()): {
 } {
   const logger = makeLogger();
   const adapter = new SubiektInvoicingAdapter(bridge, 'conn-1', logger);
+  return { adapter, bridge, logger };
+}
+
+const BASE_CONFIG: SubiektConnectionConfig = { bridgeBaseUrl: 'http://localhost:5000' };
+
+function makeConfiguredAdapter(
+  config: Partial<SubiektConnectionConfig>,
+  bridge = new FakeSubiektBridgeAdapter(),
+): {
+  adapter: SubiektInvoicingAdapter;
+  bridge: FakeSubiektBridgeAdapter;
+  logger: LoggerPort;
+} {
+  const logger = makeLogger();
+  const adapter = new SubiektInvoicingAdapter(bridge, 'conn-1', logger, {
+    ...BASE_CONFIG,
+    ...config,
+  });
   return { adapter, bridge, logger };
 }
 
@@ -557,6 +579,246 @@ describe('SubiektInvoicingAdapter', () => {
       await expect(adapter.getClearanceStatus(issued.record)).rejects.toBeInstanceOf(
         SubiektInvoiceRejectedError,
       );
+    });
+  });
+
+  describe('bank-account discovery (#1324)', () => {
+    it('is detected as a BankAccountsReader and BankAccountDefaultSetter', () => {
+      const { adapter } = makeAdapter();
+      expect(isBankAccountsReader(adapter)).toBe(true);
+      expect(isBankAccountDefaultSetter(adapter)).toBe(true);
+    });
+
+    it('listBankAccounts maps the bridge shape to the neutral type and DROPS owner fields', async () => {
+      const { adapter } = makeAdapter();
+      const accounts = await adapter.listBankAccounts();
+      // The fake seeds 3 default accounts (two owner=1, one owner=2).
+      expect(accounts).toEqual([
+        {
+          id: '100004',
+          accountNumber: '00 10101010 1111 1111 1111 1111',
+          bankName: 'Rachunek podstawowy',
+          isDefault: true,
+        },
+        {
+          id: '100007',
+          accountNumber: '00 10101010 2222 2222 2222 2222',
+          bankName: 'Rachunek VAT',
+          isDefault: false,
+        },
+        {
+          id: '100011',
+          accountNumber: '00 10101010 3333 3333 3333 3333',
+          bankName: 'Rachunek oddziału',
+          isDefault: false,
+        },
+      ]);
+      // Owner fields are not part of the neutral shape.
+      expect(accounts[0]).not.toHaveProperty('ownerPodmiotId');
+      expect(accounts[0]).not.toHaveProperty('ownerName');
+    });
+
+    it('listBankAccounts degrades null name/number to empty strings', async () => {
+      const { adapter, bridge } = makeAdapter();
+      bridge.seedBankAccounts([
+        {
+          id: 500,
+          name: null,
+          number: null,
+          bankNumber: null,
+          description: null,
+          currency: null,
+          isVatAccount: false,
+          isDefault: false,
+          ownerPodmiotId: 1,
+          ownerName: null,
+        },
+      ]);
+      const accounts = await adapter.listBankAccounts();
+      expect(accounts).toEqual([
+        { id: '500', accountNumber: '', bankName: '', isDefault: false },
+      ]);
+    });
+
+    it('listBankAccountsWithOwner KEEPS the owner fields', async () => {
+      const { adapter } = makeAdapter();
+      const accounts = await adapter.listBankAccountsWithOwner();
+      expect(accounts).toEqual([
+        {
+          id: '100004',
+          accountNumber: '00 10101010 1111 1111 1111 1111',
+          bankName: 'Rachunek podstawowy',
+          isDefault: true,
+          ownerPodmiotId: 1,
+          ownerName: 'Moja Firma Sp. z o.o.',
+        },
+        {
+          id: '100007',
+          accountNumber: '00 10101010 2222 2222 2222 2222',
+          bankName: 'Rachunek VAT',
+          isDefault: false,
+          ownerPodmiotId: 1,
+          ownerName: 'Moja Firma Sp. z o.o.',
+        },
+        {
+          id: '100011',
+          accountNumber: '00 10101010 3333 3333 3333 3333',
+          bankName: 'Rachunek oddziału',
+          isDefault: false,
+          ownerPodmiotId: 2,
+          ownerName: 'Oddział Handlowy Sp. z o.o.',
+        },
+      ]);
+    });
+
+    it('setDefaultBankAccount calls the bridge with Number(accountId)', async () => {
+      const { adapter, bridge } = makeAdapter();
+      const spy = jest.spyOn(bridge, 'setDefaultBankAccount');
+      await adapter.setDefaultBankAccount('100007');
+      expect(spy).toHaveBeenCalledWith(100007);
+    });
+
+    it('setDefaultBankAccount rejects a non-numeric id before hitting the bridge', async () => {
+      const { adapter, bridge } = makeAdapter();
+      const spy = jest.spyOn(bridge, 'setDefaultBankAccount');
+      await expect(adapter.setDefaultBankAccount('not-a-number')).rejects.toBeInstanceOf(
+        SubiektConfigException,
+      );
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('listBankAccounts propagates a translated transport error', async () => {
+      const { adapter, bridge } = makeAdapter();
+      bridge.seedFailure('bridge-unreachable');
+      await expect(adapter.listBankAccounts()).rejects.toBeInstanceOf(SubiektBridgeTransportError);
+    });
+
+    it('listBankAccountsWithOwner propagates a translated transport error', async () => {
+      const { adapter, bridge } = makeAdapter();
+      bridge.seedFailure('bridge-unreachable');
+      await expect(adapter.listBankAccountsWithOwner()).rejects.toBeInstanceOf(
+        SubiektBridgeTransportError,
+      );
+    });
+
+    it('setDefaultBankAccount translates a subiekt-rejected error (terminal)', async () => {
+      const { adapter, bridge } = makeAdapter();
+      bridge.seedFailure('subiekt-rejected', { reason: 'unknown account' });
+      await expect(adapter.setDefaultBankAccount('999')).rejects.toBeInstanceOf(
+        SubiektInvoiceRejectedError,
+      );
+    });
+  });
+
+  describe('cash-register discovery (#1324)', () => {
+    it('listCashRegisters maps the bridge shape incl. linked + unlinked (null oddzialId)', async () => {
+      const { adapter } = makeAdapter();
+      const registers = await adapter.listCashRegisters();
+      expect(registers).toEqual([
+        { id: 100065, name: 'Kasa Centralna', symbol: 'CENTR', oddzialId: null },
+        { id: 100066, name: 'Kasa Outlet', symbol: 'OUTLET', oddzialId: null },
+        { id: 100067, name: 'Kasa Pachnidło', symbol: 'PACH', oddzialId: 100001 },
+      ]);
+    });
+
+    it('listCashRegisters degrades null name/symbol gracefully', async () => {
+      const { adapter, bridge } = makeAdapter();
+      bridge.seedCashRegisters([{ id: 9, name: null, symbol: null, oddzialId: null }]);
+      const registers = await adapter.listCashRegisters();
+      expect(registers).toEqual([{ id: 9, name: null, symbol: null, oddzialId: null }]);
+    });
+
+    it('listCashRegisters propagates a translated transport error', async () => {
+      const { adapter, bridge } = makeAdapter();
+      bridge.seedFailure('bridge-unreachable');
+      await expect(adapter.listCashRegisters()).rejects.toBeInstanceOf(SubiektBridgeTransportError);
+    });
+  });
+
+  describe('issueInvoice payment + cash-register field stamping (#1324)', () => {
+    async function capturedRequest(
+      config: Partial<SubiektConnectionConfig>,
+    ): Promise<Record<string, unknown>> {
+      const { adapter, bridge } = makeConfiguredAdapter(config);
+      const spy = jest.spyOn(bridge, 'issueInvoice');
+      await adapter.issueInvoice(command());
+      return spy.mock.calls[0][0] as unknown as Record<string, unknown>;
+    }
+
+    it('(a) no config -> request carries NONE of the new keys (no regression)', async () => {
+      // Baseline built from the plain 3-arg adapter — proves an unconfigured
+      // connection sends a byte-identical request to the pre-#1324 behavior.
+      const { adapter, bridge } = makeAdapter();
+      const spy = jest.spyOn(bridge, 'issueInvoice');
+      await adapter.issueInvoice(command());
+      const req = spy.mock.calls[0][0] as unknown as Record<string, unknown>;
+      expect(req).not.toHaveProperty('paymentMethod');
+      expect(req).not.toHaveProperty('bankAccountId');
+      expect(req).not.toHaveProperty('stanowiskoKasoweId');
+    });
+
+    it('(a2) empty config object -> request carries NONE of the new keys', async () => {
+      const req = await capturedRequest({});
+      expect(req).not.toHaveProperty('paymentMethod');
+      expect(req).not.toHaveProperty('bankAccountId');
+      expect(req).not.toHaveProperty('stanowiskoKasoweId');
+    });
+
+    it('(b) cash -> { paymentMethod: cash } only', async () => {
+      const req = await capturedRequest({ defaultPaymentMethod: 'cash' });
+      expect(req.paymentMethod).toBe('cash');
+      expect(req).not.toHaveProperty('bankAccountId');
+    });
+
+    it('(b2) cash ignores a configured bankAccountId', async () => {
+      const req = await capturedRequest({ defaultPaymentMethod: 'cash', bankAccountId: 100007 });
+      expect(req.paymentMethod).toBe('cash');
+      expect(req).not.toHaveProperty('bankAccountId');
+    });
+
+    it('(c) transfer + account -> both payment keys', async () => {
+      const req = await capturedRequest({
+        defaultPaymentMethod: 'transfer',
+        bankAccountId: 100007,
+      });
+      expect(req.paymentMethod).toBe('transfer');
+      expect(req.bankAccountId).toBe(100007);
+    });
+
+    it('(d) transfer without an account -> neither payment key (fiscal-safe)', async () => {
+      const req = await capturedRequest({ defaultPaymentMethod: 'transfer' });
+      expect(req).not.toHaveProperty('paymentMethod');
+      expect(req).not.toHaveProperty('bankAccountId');
+    });
+
+    it('(d2) transfer without an account warns about the half-configured state', async () => {
+      const { adapter, logger } = makeConfiguredAdapter({ defaultPaymentMethod: 'transfer' });
+      await adapter.issueInvoice(command());
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('transfer payment but has no bankAccountId'),
+        expect.objectContaining({ connectionId: 'conn-1' }),
+      );
+    });
+
+    it('(e) register set -> { stanowiskoKasoweId }', async () => {
+      const req = await capturedRequest({ defaultStanowiskoKasoweId: 100067 });
+      expect(req.stanowiskoKasoweId).toBe(100067);
+    });
+
+    it('(f) register unset -> no stanowiskoKasoweId key', async () => {
+      const req = await capturedRequest({ defaultPaymentMethod: 'cash' });
+      expect(req).not.toHaveProperty('stanowiskoKasoweId');
+    });
+
+    it('payment and cash-register fields combine on one request', async () => {
+      const req = await capturedRequest({
+        defaultPaymentMethod: 'transfer',
+        bankAccountId: 100007,
+        defaultStanowiskoKasoweId: 100067,
+      });
+      expect(req.paymentMethod).toBe('transfer');
+      expect(req.bankAccountId).toBe(100007);
+      expect(req.stanowiskoKasoweId).toBe(100067);
     });
   });
 });

--- a/libs/integrations/subiekt/src/infrastructure/adapters/subiekt-invoicing.adapter.ts
+++ b/libs/integrations/subiekt/src/infrastructure/adapters/subiekt-invoicing.adapter.ts
@@ -28,9 +28,12 @@
 import { randomUUID } from 'crypto';
 import type { LoggerPort } from '@openlinker/shared/logging';
 import type {
+  BankAccountDefaultSetter,
+  BankAccountsReader,
   CorrectionIssuer,
   DocumentType,
   GetInvoiceQuery,
+  InvoicingBankAccount,
   InvoicingPort,
   IssueCorrectionCommand,
   IssueInvoiceCommand,
@@ -41,7 +44,16 @@ import type {
   UpsertCustomerResult,
 } from '@openlinker/core/invoicing';
 import { InvoiceRecord } from '@openlinker/core/invoicing';
+import type { BridgeIssueInvoiceRequest } from '../../bridge/subiekt-bridge.types';
 import type { SubiektBridgeClient } from '../../bridge/subiekt-bridge.client';
+import type {
+  SubiektConnectionConfig,
+  SubiektPaymentMethod,
+} from '../../domain/types/subiekt-connection-config.types';
+import type {
+  SubiektBankAccountView,
+  SubiektCashRegisterView,
+} from '../../domain/types/subiekt-invoicing-views.types';
 import {
   SubiektBridgeUnreachableError,
   SubiektRejectedError,
@@ -98,13 +110,38 @@ function readRetryability(error: SubiektBridgeUnreachableError): SubiektTranspor
 }
 
 export class SubiektInvoicingAdapter
-  implements InvoicingPort, RegulatoryStatusReader, CorrectionIssuer
+  implements
+    InvoicingPort,
+    RegulatoryStatusReader,
+    CorrectionIssuer,
+    BankAccountsReader,
+    BankAccountDefaultSetter
 {
+  /**
+   * Connection-level defaults (#1324). All OPTIONAL — an unset field means the
+   * adapter sends nothing for it (the true additive/no-regression path); it is
+   * NOT defaulted to `'cash'`. `paymentFields()`/`cashRegisterFields()` enforce
+   * the fiscal-safe omission rules the bridge would otherwise 422 on. There is
+   * no Oddział (branch) default: the Sfera session binds the branch read-only to
+   * the logged-in bridge session, so a per-request override is impossible.
+   */
+  private readonly paymentMethod?: SubiektPaymentMethod;
+  private readonly bankAccountId?: number;
+  private readonly stanowiskoKasoweId?: number;
+
   constructor(
     private readonly bridge: SubiektBridgeClient,
     private readonly connectionId: string,
     private readonly logger: LoggerPort,
-  ) {}
+    // Only the optional defaults are read here; `bridgeBaseUrl`/`timeoutMs`
+    // are the HTTP client's concern — accept a `Partial` so the `= {}` default
+    // keeps the existing 3-arg call sites (tests) working without a cast.
+    config: Partial<SubiektConnectionConfig> = {},
+  ) {
+    this.paymentMethod = config.defaultPaymentMethod;
+    this.bankAccountId = config.bankAccountId;
+    this.stanowiskoKasoweId = config.defaultStanowiskoKasoweId;
+  }
 
   /**
    * Issue a fiscal document. Derives the neutral doctype (NIP rule) when absent,
@@ -136,6 +173,12 @@ export class SubiektInvoicingAdapter
         // the bridge auto-upserts it and bills it in one unit of work.
         buyer: toBridgeBuyer(cmd.buyer),
         lines: toBridgeLines(cmd.lines),
+        // Connection-level payment + cash-register selection (#1324). Both
+        // helpers return `{}` when unset (or when a combination the bridge would
+        // 422 is only half-configured), so an unconfigured connection produces a
+        // request byte-identical to the pre-#1324 behavior.
+        ...this.paymentFields(),
+        ...this.cashRegisterFields(),
       });
 
       if (response.state === 'failed') {
@@ -382,6 +425,137 @@ export class SubiektInvoicingAdapter
     } catch (error: unknown) {
       throw this.translateBridgeError(error);
     }
+  }
+
+  /**
+   * List the seller's bank accounts as the NEUTRAL `InvoicingBankAccount[]`
+   * (the generic `BankAccountsReader` core-capability seam consumed by the
+   * capability-generic API surface, #1324). Deliberately DROPS the bridge's
+   * `ownerPodmiotId`/`ownerName` — the neutral core type has no owner concept
+   * (it is shared with inFakt/KSeF, which have no multi-Podmiot install), so
+   * surfacing owner data here would leak Subiekt-specific vocabulary into
+   * `libs/core`. Owner-aware consumers use `listBankAccountsWithOwner` instead.
+   */
+  async listBankAccounts(): Promise<InvoicingBankAccount[]> {
+    try {
+      const response = await this.bridge.listBankAccounts();
+      return response.accounts.map((a) => ({
+        id: String(a.id),
+        accountNumber: a.number ?? '',
+        bankName: a.name ?? '',
+        isDefault: a.isDefault,
+      }));
+    } catch (error: unknown) {
+      throw this.translateBridgeError(error);
+    }
+  }
+
+  /** Mark `accountId` as the seller's default bank account with the provider. */
+  async setDefaultBankAccount(accountId: string): Promise<void> {
+    // Guard the string→int coercion: a non-numeric id would otherwise POST to
+    // `/api/bank-accounts/NaN/default`. Fail with the config domain error instead.
+    const numericId = Number(accountId);
+    if (!Number.isInteger(numericId) || numericId < 1) {
+      throw new SubiektConfigException(
+        'bank account id must be a positive integer',
+        'accountId',
+        accountId,
+      );
+    }
+    try {
+      await this.bridge.setDefaultBankAccount(numericId);
+    } catch (error: unknown) {
+      throw this.translateBridgeError(error);
+    }
+  }
+
+  /**
+   * Owner-aware bank-account variant (Subiekt-local, NOT a core capability,
+   * #1324 decision 6). Returns the full bridge shape incl. `ownerPodmiotId`/
+   * `ownerName` so the Subiekt-specific controller/FE can group accounts by
+   * payer and render the >1-owner payer-routing warning. Not exposed on the
+   * neutral `BankAccountsReader` surface.
+   */
+  async listBankAccountsWithOwner(): Promise<SubiektBankAccountView[]> {
+    try {
+      const response = await this.bridge.listBankAccounts();
+      return response.accounts.map((a) => ({
+        id: String(a.id),
+        accountNumber: a.number ?? '',
+        bankName: a.name ?? '',
+        isDefault: a.isDefault,
+        ownerPodmiotId: a.ownerPodmiotId,
+        ownerName: a.ownerName,
+      }));
+    } catch (error: unknown) {
+      throw this.translateBridgeError(error);
+    }
+  }
+
+  /**
+   * List the seller's Stanowiska Kasowe (cash registers) — Subiekt-local, no
+   * core capability (#1324 decision 2). Mapped 1:1 from the bridge; `oddzialId`
+   * stays `number | null` (`null` = unlinked register; a non-null value is the
+   * register's informational branch tag, a display label only).
+   */
+  async listCashRegisters(): Promise<SubiektCashRegisterView[]> {
+    try {
+      const response = await this.bridge.listCashRegisters();
+      return response.cashRegisters.map((c) => ({
+        id: c.id,
+        name: c.name,
+        symbol: c.symbol,
+        oddzialId: c.oddzialId,
+      }));
+    } catch (error: unknown) {
+      throw this.translateBridgeError(error);
+    }
+  }
+
+  /**
+   * Build the additive payment-selection fields for an issue-invoice request
+   * (#1324). Fiscal-safe omission mirrors the bridge's `PaymentSelection`
+   * rules so a half-configured connection never sends a request the bridge
+   * would 422:
+   *   - no `paymentMethod` configured        -> `{}` (send nothing; legacy path)
+   *   - `transfer` without a `bankAccountId`  -> `{}` (never send an incomplete transfer)
+   *   - `transfer` with a `bankAccountId`     -> `{ paymentMethod: 'transfer', bankAccountId }`
+   *   - `cash`                                -> `{ paymentMethod: 'cash' }`
+   */
+  private paymentFields(): Partial<
+    Pick<BridgeIssueInvoiceRequest, 'paymentMethod' | 'bankAccountId'>
+  > {
+    if (!this.paymentMethod) {
+      return {};
+    }
+    if (this.paymentMethod === 'transfer') {
+      if (this.bankAccountId === undefined) {
+        // Observable misconfiguration: nothing prevents saving `transfer` with
+        // no bank account, and the omission silently downgrades to the bridge
+        // default. Warn so the half-configured state is visible in logs.
+        this.logger.warn(
+          'Subiekt connection is configured for transfer payment but has no bankAccountId; omitting payment fields (bridge default applies)',
+          { connectionId: this.connectionId },
+        );
+        return {};
+      }
+      return { paymentMethod: 'transfer', bankAccountId: this.bankAccountId };
+    }
+    return { paymentMethod: 'cash' };
+  }
+
+  /**
+   * Build the additive cash-register field for an issue-invoice request (#1324).
+   * The Oddział (branch) axis was cut: the Sfera session binds the branch
+   * read-only to the logged-in bridge session, so `stanowiskoKasoweId` is the
+   * only real per-document routing field.
+   *   - `stanowiskoKasoweId` configured -> `{ stanowiskoKasoweId }`;
+   *   - unset                           -> `{}` (legacy path).
+   */
+  private cashRegisterFields(): Partial<Pick<BridgeIssueInvoiceRequest, 'stanowiskoKasoweId'>> {
+    return this.stanowiskoKasoweId !== undefined
+      ? { stanowiskoKasoweId: this.stanowiskoKasoweId }
+      : {};
   }
 
   /** Neutral document types this provider issues. */

--- a/libs/integrations/subiekt/src/infrastructure/http/__tests__/subiekt-bridge-http.client.spec.ts
+++ b/libs/integrations/subiekt/src/infrastructure/http/__tests__/subiekt-bridge-http.client.spec.ts
@@ -323,6 +323,97 @@ describe('SubiektBridgeHttpClient', () => {
     });
   });
 
+  describe('listBankAccounts (#1324)', () => {
+    it('issues a GET to /api/bank-accounts and unwraps the envelope', async () => {
+      fetchMock.mockResolvedValue(
+        okResponse({
+          count: 1,
+          accounts: [
+            {
+              id: 100004,
+              name: 'Rachunek podstawowy',
+              number: '00 10101010 1111 1111 1111 1111',
+              bankNumber: null,
+              description: null,
+              currency: 'PLN',
+              isVatAccount: false,
+              isDefault: true,
+              ownerPodmiotId: 1,
+              ownerName: 'Moja Firma Sp. z o.o.',
+            },
+          ],
+        }),
+      );
+      const client = new SubiektBridgeHttpClient(BASE);
+      const res = await client.listBankAccounts();
+      const [url, init] = fetchMock.mock.calls[0] as [string, { method: string }];
+      expect(url).toBe(`${BASE}/api/bank-accounts`);
+      expect(init.method).toBe('GET');
+      expect(res.count).toBe(1);
+      expect(res.accounts[0].ownerPodmiotId).toBe(1);
+    });
+
+    it('translates a transport failure to SubiektBridgeUnreachableError', async () => {
+      fetchMock.mockRejectedValue(fetchError('ECONNREFUSED'));
+      const client = new SubiektBridgeHttpClient(BASE);
+      await expect(client.listBankAccounts()).rejects.toBeInstanceOf(SubiektBridgeUnreachableError);
+    });
+
+    it('translates a 401 to SubiektBridgeAuthError (not a rejection)', async () => {
+      fetchMock.mockResolvedValue(errorResponse(401, {}));
+      const client = new SubiektBridgeHttpClient(BASE);
+      await expect(client.listBankAccounts()).rejects.toBeInstanceOf(SubiektBridgeAuthError);
+    });
+  });
+
+  describe('setDefaultBankAccount (#1324)', () => {
+    it('issues a PUT to the templated /api/bank-accounts/{id}/default path', async () => {
+      fetchMock.mockResolvedValue(okResponse({ bankAccountId: 100007, isDefault: true }));
+      const client = new SubiektBridgeHttpClient(BASE);
+      const res = await client.setDefaultBankAccount(100007);
+      const [url, init] = fetchMock.mock.calls[0] as [
+        string,
+        { method: string; headers: Record<string, string> },
+      ];
+      expect(url).toBe(`${BASE}/api/bank-accounts/100007/default`);
+      expect(init.method).toBe('PUT');
+      expect(init.headers['content-type']).toBe('application/json');
+      expect(res).toEqual({ bankAccountId: 100007, isDefault: true });
+    });
+
+    it('translates a 422 rejection to SubiektRejectedError', async () => {
+      fetchMock.mockResolvedValue(errorResponse(422, envelopeError('Nieznany rachunek.')));
+      const client = new SubiektBridgeHttpClient(BASE);
+      const err = await client
+        .setDefaultBankAccount(999)
+        .then(() => null)
+        .catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(SubiektRejectedError);
+      expect((err as SubiektRejectedError).reason).toBe('Nieznany rachunek.');
+    });
+  });
+
+  describe('listCashRegisters (#1324)', () => {
+    it('issues a GET to /api/cash-registers and unwraps the envelope', async () => {
+      fetchMock.mockResolvedValue(
+        okResponse({
+          count: 2,
+          cashRegisters: [
+            { id: 100065, name: 'Kasa Centralna', symbol: 'CENTR', oddzialId: null },
+            { id: 100067, name: 'Kasa Pachnidło', symbol: 'PACH', oddzialId: 100001 },
+          ],
+        }),
+      );
+      const client = new SubiektBridgeHttpClient(BASE);
+      const res = await client.listCashRegisters();
+      const [url, init] = fetchMock.mock.calls[0] as [string, { method: string }];
+      expect(url).toBe(`${BASE}/api/cash-registers`);
+      expect(init.method).toBe('GET');
+      expect(res.cashRegisters[0].oddzialId).toBeNull();
+      expect(res.cashRegisters[1].oddzialId).toBe(100001);
+    });
+  });
+
   describe('token handling', () => {
     it('attaches the bridge token header when provided', async () => {
       fetchMock.mockResolvedValue(

--- a/libs/integrations/subiekt/src/infrastructure/http/subiekt-bridge-http.client.ts
+++ b/libs/integrations/subiekt/src/infrastructure/http/subiekt-bridge-http.client.ts
@@ -43,8 +43,11 @@ import type {
   BridgeIssueInvoiceResponse,
   BridgeKorektaRequest,
   BridgeKorektaResponse,
+  BridgeListBankAccountsResponse,
+  BridgeListCashRegistersResponse,
   BridgeRegulatoryStatus,
   BridgeResponseEnvelope,
+  BridgeSetDefaultBankAccountResponse,
   BridgeUpsertCustomerRequest,
   BridgeUpsertCustomerResponse,
 } from '../../bridge/subiekt-bridge.types';
@@ -97,6 +100,18 @@ export const SUBIEKT_BRIDGE_ENDPOINTS = {
   /** Templated by `providerInvoiceId`; the bridge route is `GET /api/invoices/{id}/status`. */
   invoiceStatus: (providerInvoiceId: string): string =>
     `/api/invoices/${encodeURIComponent(providerInvoiceId)}/status`,
+  /** Bank-account discovery; the bridge route is `GET /api/bank-accounts` (#1324). */
+  bankAccounts: '/api/bank-accounts',
+  /**
+   * Default bank-account selector, templated by the numeric account id. The
+   * bridge route is `PUT /api/bank-accounts/{id}/default` (#1324).
+   */
+  setDefaultBankAccount: (id: number): string => `/api/bank-accounts/${id}/default`,
+  /**
+   * Stanowisko Kasowe (cash register) discovery. The bridge route is
+   * `GET /api/cash-registers` (#1324).
+   */
+  cashRegisters: '/api/cash-registers',
   health: '/health',
 } as const;
 
@@ -191,6 +206,23 @@ export class SubiektBridgeHttpClient implements SubiektBridgeClient {
     };
   }
 
+  async listBankAccounts(): Promise<BridgeListBankAccountsResponse> {
+    return this.getJson<BridgeListBankAccountsResponse>(SUBIEKT_BRIDGE_ENDPOINTS.bankAccounts);
+  }
+
+  async setDefaultBankAccount(
+    bankAccountId: number,
+  ): Promise<BridgeSetDefaultBankAccountResponse> {
+    return this.putJson<BridgeSetDefaultBankAccountResponse>(
+      SUBIEKT_BRIDGE_ENDPOINTS.setDefaultBankAccount(bankAccountId),
+      {},
+    );
+  }
+
+  async listCashRegisters(): Promise<BridgeListCashRegistersResponse> {
+    return this.getJson<BridgeListCashRegistersResponse>(SUBIEKT_BRIDGE_ENDPOINTS.cashRegisters);
+  }
+
   /**
    * Connectivity probe for the connection tester. Issues `GET /health` and
    * resolves when the bridge is reachable (any non-transport response, incl. a
@@ -229,11 +261,19 @@ export class SubiektBridgeHttpClient implements SubiektBridgeClient {
     return this.request<T>('POST', path, body);
   }
 
+  private async putJson<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>('PUT', path, body);
+  }
+
   private async getJson<T>(path: string): Promise<T> {
     return this.request<T>('GET', path, undefined);
   }
 
-  private async request<T>(method: 'GET' | 'POST', path: string, body: unknown): Promise<T> {
+  private async request<T>(
+    method: 'GET' | 'POST' | 'PUT',
+    path: string,
+    body: unknown,
+  ): Promise<T> {
     const url = `${this.baseUrl}${path}`;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);

--- a/libs/integrations/subiekt/src/testing/__tests__/fake-subiekt-bridge.adapter.spec.ts
+++ b/libs/integrations/subiekt/src/testing/__tests__/fake-subiekt-bridge.adapter.spec.ts
@@ -83,5 +83,71 @@ describe('FakeSubiektBridgeAdapter', () => {
       expect(res.providerInvoiceNumber).toBe('FV-MOCK-001');
       expect(res.regulatoryStatus).toBe('sent');
     });
+
+    describe('discovery methods (#1324)', () => {
+      it('should list >=2 bank accounts, exactly one default, and a distinct ownerPodmiotId', async () => {
+        const res = await fake.listBankAccounts();
+        expect(res.count).toBe(res.accounts.length);
+        expect(res.accounts.length).toBeGreaterThanOrEqual(2);
+        expect(res.accounts.filter((a) => a.isDefault)).toHaveLength(1);
+        const owners = new Set(res.accounts.map((a) => a.ownerPodmiotId));
+        expect(owners.size).toBeGreaterThanOrEqual(2);
+      });
+
+      it('should flip the default when setDefaultBankAccount targets a seeded id', async () => {
+        const before = await fake.listBankAccounts();
+        const nonDefault = before.accounts.find((a) => !a.isDefault);
+        expect(nonDefault).toBeDefined();
+        const res = await fake.setDefaultBankAccount(nonDefault!.id);
+        expect(res).toEqual({ bankAccountId: nonDefault!.id, isDefault: true });
+        const after = await fake.listBankAccounts();
+        expect(after.accounts.filter((a) => a.isDefault)).toHaveLength(1);
+        expect(after.accounts.find((a) => a.isDefault)?.id).toBe(nonDefault!.id);
+      });
+
+      it('should reject setDefaultBankAccount with SubiektRejectedError for an unknown id', async () => {
+        await expect(fake.setDefaultBankAccount(999_999)).rejects.toBeInstanceOf(
+          SubiektRejectedError,
+        );
+      });
+
+      it('should list cash registers with a mix of linked and unlinked (oddzialId: null)', async () => {
+        const res = await fake.listCashRegisters();
+        expect(res.count).toBe(res.cashRegisters.length);
+        expect(res.cashRegisters.some((c) => c.oddzialId === null)).toBe(true);
+        expect(res.cashRegisters.some((c) => c.oddzialId !== null)).toBe(true);
+      });
+
+      it('should reject discovery calls when a bridge-unreachable failure is seeded', async () => {
+        fake.seedFailure('bridge-unreachable');
+        await expect(fake.listBankAccounts()).rejects.toBeInstanceOf(SubiektBridgeUnreachableError);
+        await expect(fake.listCashRegisters()).rejects.toBeInstanceOf(
+          SubiektBridgeUnreachableError,
+        );
+      });
+
+      it('should honour seeded discovery data and reset it on clear()', async () => {
+        fake.seedBankAccounts([
+          {
+            id: 5,
+            name: 'Solo',
+            number: null,
+            bankNumber: null,
+            description: null,
+            currency: 'PLN',
+            isVatAccount: false,
+            isDefault: true,
+            ownerPodmiotId: 1,
+            ownerName: null,
+          },
+        ]);
+        fake.seedCashRegisters([{ id: 9, name: 'Only register', symbol: null, oddzialId: 9 }]);
+        expect((await fake.listBankAccounts()).count).toBe(1);
+        expect((await fake.listCashRegisters()).count).toBe(1);
+        fake.clear();
+        expect((await fake.listBankAccounts()).accounts.length).toBeGreaterThanOrEqual(2);
+        expect((await fake.listCashRegisters()).cashRegisters.length).toBeGreaterThanOrEqual(2);
+      });
+    });
   });
 });

--- a/libs/integrations/subiekt/src/testing/fake-subiekt-bridge.adapter.ts
+++ b/libs/integrations/subiekt/src/testing/fake-subiekt-bridge.adapter.ts
@@ -27,12 +27,17 @@ import {
   SubiektRejectedError,
 } from '../bridge/subiekt-bridge.errors';
 import type {
+  BridgeBankAccount,
+  BridgeCashRegister,
   BridgeInvoiceStatusRequest,
   BridgeInvoiceStatusResponse,
   BridgeIssueInvoiceRequest,
   BridgeIssueInvoiceResponse,
   BridgeKorektaRequest,
   BridgeKorektaResponse,
+  BridgeListBankAccountsResponse,
+  BridgeListCashRegistersResponse,
+  BridgeSetDefaultBankAccountResponse,
   BridgeUpsertCustomerRequest,
   BridgeUpsertCustomerResponse,
 } from '../bridge/subiekt-bridge.types';
@@ -40,6 +45,65 @@ import type {
 type SeededFailure =
   | { kind: 'bridge-unreachable' }
   | { kind: 'subiekt-rejected'; reason: string };
+
+/**
+ * Deterministic default bank accounts. Two accounts, one default, and a THIRD
+ * carrying a distinct `ownerPodmiotId` (2 vs 1) so multi-payer UI/behaviour can
+ * be exercised downstream. Numeric ids mirror the real bridge's `100xxx` space.
+ */
+function defaultBankAccounts(): BridgeBankAccount[] {
+  return [
+    {
+      id: 100004,
+      name: 'Rachunek podstawowy',
+      number: '00 10101010 1111 1111 1111 1111',
+      bankNumber: null,
+      description: null,
+      currency: 'PLN',
+      isVatAccount: false,
+      isDefault: true,
+      ownerPodmiotId: 1,
+      ownerName: 'Moja Firma Sp. z o.o.',
+    },
+    {
+      id: 100007,
+      name: 'Rachunek VAT',
+      number: '00 10101010 2222 2222 2222 2222',
+      bankNumber: null,
+      description: null,
+      currency: 'PLN',
+      isVatAccount: true,
+      isDefault: false,
+      ownerPodmiotId: 1,
+      ownerName: 'Moja Firma Sp. z o.o.',
+    },
+    {
+      id: 100011,
+      name: 'Rachunek oddziału',
+      number: '00 10101010 3333 3333 3333 3333',
+      bankNumber: null,
+      description: null,
+      currency: 'PLN',
+      isVatAccount: false,
+      isDefault: false,
+      ownerPodmiotId: 2,
+      ownerName: 'Oddział Handlowy Sp. z o.o.',
+    },
+  ];
+}
+
+/**
+ * Deterministic default cash registers (Stanowiska Kasowe) — a mix of linked
+ * (`oddzialId` set to an informational branch tag) and unlinked (`oddzialId:
+ * null`), matching the real probe data.
+ */
+function defaultCashRegisters(): BridgeCashRegister[] {
+  return [
+    { id: 100065, name: 'Kasa Centralna', symbol: 'CENTR', oddzialId: null },
+    { id: 100066, name: 'Kasa Outlet', symbol: 'OUTLET', oddzialId: null },
+    { id: 100067, name: 'Kasa Pachnidło', symbol: 'PACH', oddzialId: 100001 },
+  ];
+}
 
 export class FakeSubiektBridgeAdapter implements SubiektBridgeClient {
   private issueCounter = 0;
@@ -51,6 +115,9 @@ export class FakeSubiektBridgeAdapter implements SubiektBridgeClient {
   private readonly issuedById = new Map<string, BridgeIssueInvoiceResponse>();
   /** The most recent korekta request body (for passthrough assertions in tests). */
   private lastKorektaRequest: BridgeKorektaRequest | null = null;
+  /** Discovery state (bank accounts / cash registers), #1324. */
+  private bankAccounts: BridgeBankAccount[] = defaultBankAccounts();
+  private cashRegisters: BridgeCashRegister[] = defaultCashRegisters();
 
   issueInvoice(_req: BridgeIssueInvoiceRequest): Promise<BridgeIssueInvoiceResponse> {
     const failure = this.failureError();
@@ -130,6 +197,41 @@ export class FakeSubiektBridgeAdapter implements SubiektBridgeClient {
     );
   }
 
+  listBankAccounts(): Promise<BridgeListBankAccountsResponse> {
+    const failure = this.failureError();
+    if (failure) {
+      return Promise.reject(failure);
+    }
+    const accounts = this.bankAccounts.map((a) => ({ ...a }));
+    return Promise.resolve({ count: accounts.length, accounts });
+  }
+
+  setDefaultBankAccount(bankAccountId: number): Promise<BridgeSetDefaultBankAccountResponse> {
+    const failure = this.failureError();
+    if (failure) {
+      return Promise.reject(failure);
+    }
+    const target = this.bankAccounts.find((a) => a.id === bankAccountId);
+    if (!target) {
+      // Mirror the real bridge's 422 for an unknown account id.
+      return Promise.reject(new SubiektRejectedError(`Unknown bank account id: ${bankAccountId}`));
+    }
+    // Idempotent flip: the picked account becomes the sole default.
+    for (const account of this.bankAccounts) {
+      account.isDefault = account.id === bankAccountId;
+    }
+    return Promise.resolve({ bankAccountId, isDefault: true });
+  }
+
+  listCashRegisters(): Promise<BridgeListCashRegistersResponse> {
+    const failure = this.failureError();
+    if (failure) {
+      return Promise.reject(failure);
+    }
+    const cashRegisters = this.cashRegisters.map((c) => ({ ...c }));
+    return Promise.resolve({ count: cashRegisters.length, cashRegisters });
+  }
+
   // --- test helpers -----------------------------------------------------------
 
   /**
@@ -156,6 +258,16 @@ export class FakeSubiektBridgeAdapter implements SubiektBridgeClient {
     return this.lastKorektaRequest;
   }
 
+  /** Replace the seeded bank accounts (deep-copied) for `listBankAccounts`/`setDefaultBankAccount`. */
+  seedBankAccounts(accounts: BridgeBankAccount[]): void {
+    this.bankAccounts = accounts.map((a) => ({ ...a }));
+  }
+
+  /** Replace the seeded cash registers (deep-copied) for `listCashRegisters`. */
+  seedCashRegisters(cashRegisters: BridgeCashRegister[]): void {
+    this.cashRegisters = cashRegisters.map((c) => ({ ...c }));
+  }
+
   /** Reset all in-memory state between tests. */
   clear(): void {
     this.issueCounter = 0;
@@ -164,6 +276,8 @@ export class FakeSubiektBridgeAdapter implements SubiektBridgeClient {
     this.issueOverride = null;
     this.issuedById.clear();
     this.lastKorektaRequest = null;
+    this.bankAccounts = defaultBankAccounts();
+    this.cashRegisters = defaultCashRegisters();
   }
 
   private failureError(): Error | null {


### PR DESCRIPTION
## Summary

Adds **payment method / bank account / cash register (Stanowisko Kasowe) per invoice** for the Subiekt nexo invoicing integration, mirroring the inFakt pattern (#1303/#1308) and reusing the existing core capabilities `BankAccountsReader` / `BankAccountDefaultSetter` (no new core ports).

- **Bridge client** (`libs/integrations/subiekt/src/bridge/**`): `listBankAccounts` / `setDefaultBankAccount` / `listCashRegisters`.
- **Connection config** (`SubiektConnectionConfig` + DTO + factory): `defaultPaymentMethod`, `bankAccountId`, `defaultStanowiskoKasoweId`.
- **Adapter** (`subiekt-invoicing.adapter.ts`): implements `BankAccountsReader` / `BankAccountDefaultSetter`; owner-aware `listBankAccountsWithOwner` + `listCashRegisters`; stamps payment / bank-account / cash-register fields onto `issueInvoice`.
- **API** (`apps/api/src/integrations/http/subiekt.controller.ts`): owner-aware `GET .../bank-accounts` + `GET .../cash-registers`.
- **FE** (`apps/web/src/plugins/subiekt/components/subiekt-structured-section.tsx` + `features/connections` hooks/types): payment-method select, owner-grouped bank-account picker with a multi-payer warning, and a Stanowisko Kasowe picker with a Centrala help line. The **Oddział axis is intentionally cut** - it is bound read-only to the bridge's Sfera session and cannot be overridden per invoice (decision 8b).

## ⚠️ Draft - depends on #1310 (must merge first)

This branch is **stacked on the inFakt prerequisite chain**. #1300 and #1309 are already merged to `main`; **#1310 (bank-account picker core capabilities) is still open** and #1324 reuses exactly those capabilities.

**Do not merge until #1310 is merged to `main`.** The current diff is inflated because #1310 (and the surrounding inFakt/KSeF prereq work) are not yet on `main`, so their files show up here. Once #1310 merges, this branch will be rebased onto `main` and the diff will collapse to the **Subiekt-only** delta listed above. Please review only the `libs/integrations/subiekt/**`, `apps/api/src/integrations/http/subiekt.controller.ts`, and `apps/web/src/plugins/subiekt/**` + `features/connections` Subiekt additions here; the inFakt / KSeF churn belongs to the prereq PRs.

## Verification

- Per-package: subiekt 216 tests, api subiekt controller 6/6, web suite green; web `type-check` clean after integrating #1310.
- **Live E2E** against a real `Nexo_Demo_1` Sfera install, both directly through the bridge and full-stack through OpenLinker (Presta-sourced order -> OL -> Subiekt adapter -> bridge -> Sfera): 8 invoices across all payment configs (cash / transfer + bank account / two distinct Stanowiska Kasowe), each confirmed by SQL read-back on the real document. Config-driven, no caching; explicit payment selection correctly requires a faktura (a paragon is rejected 422).

Operator docs (setup guide + tutorial) for this feature are in PR #1284.

Closes #1324
