### PR TITLE
fix(auth): scope refresh cookie to versioned /v1/auth path

### DIFF
--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -30,7 +30,9 @@ import type { IRefreshTokenService } from './refresh-token.service.interface';
 import { REFRESH_TOKEN_SERVICE_TOKEN } from './refresh-token.tokens';
 import type { IRegistrationService } from './registration.service.interface';
 import { REGISTRATION_SERVICE_TOKEN } from './registration.service.interface';
-import { REFRESH_COOKIE_NAME } from './auth.cookies';
+import { PATH_METADATA } from '@nestjs/common/constants';
+import { API_VERSION_LABEL } from '../app-info/app-info.types';
+import { REFRESH_COOKIE_NAME, REFRESH_COOKIE_PATH } from './auth.cookies';
 
 const makeUser = (): User =>
   new User('user-uuid-123', 'admin', null, '$2a$10$hash', 'admin', 'active', new Date(), new Date());
@@ -87,6 +89,19 @@ describe('AuthController', () => {
     refreshTokenService = module.get(REFRESH_TOKEN_SERVICE_TOKEN);
   });
 
+  describe('refresh cookie path drift guard (#1327)', () => {
+    it('scopes the refresh cookie to the versioned mount point of AuthController', () => {
+      // RFC 6265 §5.1.4: the browser only sends ol_refresh when its Path
+      // prefixes the request path on / boundaries. Under URI versioning the
+      // controller is mounted at /{API_VERSION_LABEL}/{controller path}, so
+      // the cookie path must be derived from the same two sources — a future
+      // controller-prefix change fails here; a version bump self-heals.
+      const controllerPath = Reflect.getMetadata(PATH_METADATA, AuthController) as string;
+      expect(controllerPath).toBe('auth'); // guard against a silent undefined metadata read
+      expect(REFRESH_COOKIE_PATH).toBe(`/${API_VERSION_LABEL}/${controllerPath}`);
+    });
+  });
+
   describe('POST /auth/login', () => {
     const dto: LoginDto = Object.assign(new LoginDto(), {
       username: 'admin',
@@ -115,10 +130,19 @@ describe('AuthController', () => {
       const cookieNames = res.cookie.mock.calls.map((call) => call[0]);
       expect(cookieNames).toContain(REFRESH_COOKIE_NAME);
       expect(cookieNames).toContain('ol_csrf');
-      // setCsrfCookie proactively clears the stale /auth-scoped ol_csrf (#748)
-      // before re-issuing the /-scoped one, so users from the buggy window
-      // recover on their next login without needing to clear cookies manually.
+      // Refresh cookie must be issued at the versioned path or the browser
+      // never sends it back to /v1/auth/refresh (#1327).
+      expect(res.cookie).toHaveBeenCalledWith(
+        REFRESH_COOKIE_NAME,
+        'raw-refresh-token',
+        expect.objectContaining({ path: REFRESH_COOKIE_PATH }),
+      );
+      // Migration cleanups proactively clear the stale /auth-scoped copies —
+      // ol_csrf from the pre-#748 window, ol_refresh from the pre-#1327
+      // window — so users from the buggy windows recover on their next
+      // login without needing to clear cookies manually.
       expect(res.clearCookie).toHaveBeenCalledWith('ol_csrf', { path: '/auth' });
+      expect(res.clearCookie).toHaveBeenCalledWith(REFRESH_COOKIE_NAME, { path: '/auth' });
     });
 
     it('throws UnauthorizedException when credentials are invalid and skips cookie set', async () => {
@@ -159,8 +183,9 @@ describe('AuthController', () => {
       expect(refreshTokenService.rotate).toHaveBeenCalledWith('presented-token');
       expect(result.access_token).toBe('test-jwt-token');
       expect(res.cookie).toHaveBeenCalledTimes(2);
-      // Migration cleanup also fires on every successful refresh (#748).
+      // Migration cleanups also fire on every successful refresh (#748/#1327).
       expect(res.clearCookie).toHaveBeenCalledWith('ol_csrf', { path: '/auth' });
+      expect(res.clearCookie).toHaveBeenCalledWith(REFRESH_COOKIE_NAME, { path: '/auth' });
     });
 
     it('throws 401 when the cookie is missing', async () => {
@@ -186,8 +211,15 @@ describe('AuthController', () => {
           res as unknown as Response,
         ),
       ).rejects.toThrow(UnauthorizedException);
-      // 3 = ol_refresh @ /auth, ol_csrf @ /, ol_csrf @ /auth migration cleanup (#748).
-      expect(res.clearCookie).toHaveBeenCalledTimes(3);
+      // 4 = ol_refresh @ /v1/auth, ol_csrf @ /, plus the /auth migration
+      // cleanups for ol_csrf (#748) and ol_refresh (#1327). The wrong-path
+      // failure mode matters: a clear that misses the set path leaves a live
+      // HttpOnly refresh token in the jar, so assert WHICH cookie is deleted.
+      expect(res.clearCookie).toHaveBeenCalledTimes(4);
+      expect(res.clearCookie).toHaveBeenCalledWith(REFRESH_COOKIE_NAME, {
+        path: REFRESH_COOKIE_PATH,
+      });
+      expect(res.clearCookie).toHaveBeenCalledWith(REFRESH_COOKIE_NAME, { path: '/auth' });
     });
 
     it('revokes the orphan + clears cookies when getMe fails after a successful rotation', async () => {
@@ -209,7 +241,7 @@ describe('AuthController', () => {
       ).rejects.toThrow(UnauthorizedException);
 
       expect(refreshTokenService.revoke).toHaveBeenCalledWith('orphan-successor');
-      expect(res.clearCookie).toHaveBeenCalledTimes(3);
+      expect(res.clearCookie).toHaveBeenCalledTimes(4);
       // Cookies must NOT be set when the user is gone — the browser would
       // otherwise store a refresh cookie pointing at a useless DB row.
       expect(res.cookie).not.toHaveBeenCalled();
@@ -226,7 +258,14 @@ describe('AuthController', () => {
       await controller.logout(req, res as unknown as Response);
 
       expect(refreshTokenService.revoke).toHaveBeenCalledWith('token-to-revoke');
-      expect(res.clearCookie).toHaveBeenCalledTimes(3);
+      expect(res.clearCookie).toHaveBeenCalledTimes(4);
+      // Logout must delete the cookie that was actually set (versioned path)
+      // AND the pre-#1327 legacy copy — a clear at the wrong path leaves a
+      // live HttpOnly refresh token behind after logout.
+      expect(res.clearCookie).toHaveBeenCalledWith(REFRESH_COOKIE_NAME, {
+        path: REFRESH_COOKIE_PATH,
+      });
+      expect(res.clearCookie).toHaveBeenCalledWith(REFRESH_COOKIE_NAME, { path: '/auth' });
     });
 
     it('does not invoke revoke when no cookie is present, still clears cookies', async () => {
@@ -238,7 +277,7 @@ describe('AuthController', () => {
       await controller.logout(req, res as unknown as Response);
 
       expect(refreshTokenService.revoke).not.toHaveBeenCalled();
-      expect(res.clearCookie).toHaveBeenCalledTimes(3);
+      expect(res.clearCookie).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/apps/api/src/auth/auth.cookies.ts
+++ b/apps/api/src/auth/auth.cookies.ts
@@ -1,8 +1,8 @@
 /**
  * Auth Cookie Helpers
  *
- * Shapes the refresh + CSRF cookies set on `/auth/login`, rotated on
- * `/auth/refresh`, and cleared on `/auth/logout`. The single source
+ * Shapes the refresh + CSRF cookies set on `/v1/auth/login`, rotated on
+ * `/v1/auth/refresh`, and cleared on `/v1/auth/logout`. The single source
  * of truth for cookie names, paths, and SameSite mode — controllers
  * and tests both consume these constants so the contract drift would
  * be visible in the diff.
@@ -11,15 +11,26 @@
  */
 import { randomBytes } from 'crypto';
 import type { CookieOptions, Response } from 'express';
+import { API_VERSION_LABEL } from '../app-info/app-info.types';
 import { REFRESH_TOKEN_TTL_SECONDS } from './refresh-token.types';
 
 export const REFRESH_COOKIE_NAME = 'ol_refresh';
 export const CSRF_COOKIE_NAME = 'ol_csrf';
 export const CSRF_HEADER_NAME = 'x-csrf-token';
 
-// Refresh cookie is HttpOnly and only consumed by /auth/refresh + /auth/logout,
-// so scoping it to /auth keeps it out of every unrelated request.
-const REFRESH_COOKIE_PATH = '/auth';
+// Refresh cookie is HttpOnly and only consumed by /v1/auth/refresh +
+// /v1/auth/logout, so scoping it to the versioned auth subtree keeps it out
+// of every unrelated request. Derived from API_VERSION_LABEL — the same
+// source main.ts feeds enableVersioning() — because RFC 6265 §5.1.4 only
+// sends a cookie when its Path prefixes the request path on / boundaries:
+// a literal '/auth' is NOT a prefix of '/v1/auth/refresh', so the browser
+// silently dropped the cookie from every refresh after the /v1 migration
+// (#1133) and each page reload logged the user out. See #1327.
+export const REFRESH_COOKIE_PATH = `/${API_VERSION_LABEL}/auth`;
+
+// Pre-versioning scope: ol_refresh lived here until #1327, and ol_csrf until
+// #748. Only used to clear those stale copies out of returning browsers.
+const LEGACY_AUTH_COOKIE_PATH = '/auth';
 
 // CSRF cookie is non-HttpOnly so the SPA can read it via document.cookie and
 // mirror it into X-CSRF-Token. document.cookie only exposes cookies whose
@@ -67,6 +78,13 @@ function csrfCookieOptions(): CookieOptions {
 }
 
 export function setRefreshCookie(res: Response, rawToken: string): void {
+  // Migration cleanup: drop the stale ol_refresh left at /auth from the
+  // pre-#1327 window before issuing the /v1/auth-scoped one. The stale copy
+  // is never sent to /v1/auth/* (that was the bug), but it holds a live,
+  // unrevoked token that would otherwise sit in the jar for its full TTL.
+  // Has to run on every login/refresh — affected users never reach logout
+  // while they're being silently bounced to /auth/login.
+  res.clearCookie(REFRESH_COOKIE_NAME, { path: LEGACY_AUTH_COOKIE_PATH });
   res.cookie(REFRESH_COOKIE_NAME, rawToken, refreshCookieOptions());
 }
 
@@ -80,7 +98,7 @@ export function setCsrfCookie(res: Response): string {
   // to run on every successful login/refresh — clearAuthCookies (logout
   // only) isn't enough because affected users never reach logout while
   // they're being silently bounced to /auth/login.
-  res.clearCookie(CSRF_COOKIE_NAME, { path: REFRESH_COOKIE_PATH });
+  res.clearCookie(CSRF_COOKIE_NAME, { path: LEGACY_AUTH_COOKIE_PATH });
   res.cookie(CSRF_COOKIE_NAME, csrf, csrfCookieOptions());
   return csrf;
 }
@@ -88,7 +106,9 @@ export function setCsrfCookie(res: Response): string {
 export function clearAuthCookies(res: Response): void {
   res.clearCookie(REFRESH_COOKIE_NAME, { path: REFRESH_COOKIE_PATH });
   res.clearCookie(CSRF_COOKIE_NAME, { path: CSRF_COOKIE_PATH });
-  // Migration cleanup: ol_csrf was previously set at /auth (#748). Clear that
-  // copy too so stale cookies from the buggy window don't shadow the new one.
-  res.clearCookie(CSRF_COOKIE_NAME, { path: REFRESH_COOKIE_PATH });
+  // Migration cleanup: ol_csrf was previously set at /auth (#748), ol_refresh
+  // until #1327. Clear those copies too so stale cookies from the buggy
+  // windows don't linger (csrf could even shadow the new /-scoped value).
+  res.clearCookie(CSRF_COOKIE_NAME, { path: LEGACY_AUTH_COOKIE_PATH });
+  res.clearCookie(REFRESH_COOKIE_NAME, { path: LEGACY_AUTH_COOKIE_PATH });
 }

--- a/apps/api/src/auth/demo-mode.service.spec.ts
+++ b/apps/api/src/auth/demo-mode.service.spec.ts
@@ -1,4 +1,4 @@
-import { ConfigService } from '@nestjs/config';
+import type { ConfigService } from '@nestjs/config';
 import { DemoModeService } from './demo-mode.service';
 
 describe('DemoModeService', () => {

--- a/apps/api/test/integration/auth-refresh.int-spec.ts
+++ b/apps/api/test/integration/auth-refresh.int-spec.ts
@@ -107,19 +107,28 @@ describe('Auth Refresh Integration (#710)', () => {
           ? [String(rawHeader)]
           : [];
       expect(rawCookies.length).toBeGreaterThan(0);
-      const refreshLine = rawCookies.find((c) => c.startsWith(`${COOKIE_REFRESH}=`));
-      // Skip the migration-cleanup Set-Cookie that `setCsrfCookie` emits at
-      // `Path=/auth` to drop the pre-#748 stale copy. That header looks like
-      // `ol_csrf=; Path=/auth; Expires=Thu, 01 Jan 1970 …` — it precedes the
-      // real issuance so a plain `.find()` would match the clearing line
-      // first and the `Path=/` assertions below would all fail.
+      // Skip the migration-cleanup Set-Cookie lines that precede the real
+      // issuance: `setCsrfCookie` clears the pre-#748 ol_csrf at `Path=/auth`,
+      // `setRefreshCookie` clears the pre-#1327 ol_refresh at `Path=/auth`.
+      // Those headers look like `ol_…=; Path=/auth; Expires=Thu, 01 Jan 1970 …`
+      // — a plain `.find()` would match the clearing line first and the Path
+      // assertions below would all fail.
+      const refreshLine = rawCookies.find(
+        (c) => c.startsWith(`${COOKIE_REFRESH}=`) && !/Expires=Thu, 01 Jan 1970/.test(c),
+      );
       const csrfLine = rawCookies.find(
         (c) => c.startsWith(`${COOKIE_CSRF}=`) && !/Expires=Thu, 01 Jan 1970/.test(c),
       );
 
       expect(refreshLine).toMatch(/HttpOnly/i);
       expect(refreshLine).toMatch(/SameSite=Lax/i); // dev/test mode
-      expect(refreshLine).toMatch(/Path=\/auth/);
+      // ol_refresh MUST be scoped to the versioned mount point. The literal
+      // /v1/auth here is deliberate — it pairs with the literal request path
+      // `.post('/v1/auth/login')` above, witnessing the RFC 6265 §5.1.4
+      // prefix-match the browser performs. Deriving it from API_VERSION_LABEL
+      // would make the assertion true by construction and blind to
+      // mount-vs-cookie drift (#1327).
+      expect(refreshLine).toMatch(/Path=\/v1\/auth(;|$)/);
       expect(csrfLine).toBeDefined();
       expect(csrfLine).not.toMatch(/HttpOnly/i); // SPA must read this
       // ol_csrf MUST be at Path=/ — document.cookie only exposes cookies whose

--- a/docs/operations/auth-cookies.md
+++ b/docs/operations/auth-cookies.md
@@ -18,14 +18,27 @@ Two cookies are set at login and rotated at every refresh:
 | `ol_refresh` | yes      | The refresh-token value itself.                           |
 | `ol_csrf`    | no       | Mirror for the double-submit CSRF check.                  |
 
-Both cookies share the same `Path=/auth` so a single `Set-Cookie`
-round-trip covers `/auth/refresh` and `/auth/logout`. They are not
-sent to non-auth routes, but they ARE sent to `/auth/me`,
-`/auth/forgot-password`, and `/auth/reset-password` (broader path
-in exchange for one cookie pair instead of two). The cookies remain
-`HttpOnly` (`ol_refresh`) and `SameSite=Strict` (production), so the
-broader path widens the exfiltration surface only marginally — see
-#710 review for the documented trade-off.
+The two cookies carry different `Path` scopes:
+
+- `ol_refresh` is scoped to the **versioned auth subtree** —
+  `Path=/v1/auth`, derived in code from `API_VERSION_LABEL` so it
+  always matches the actual mount point of `AuthController` under
+  URI versioning (#1133/#1327). It is not sent to non-auth routes,
+  but it IS sent to `/v1/auth/me`, `/v1/auth/forgot-password`, and
+  `/v1/auth/reset-password` (broader path in exchange for a single
+  cookie; it stays `HttpOnly` and `SameSite=Strict` in production,
+  so the wider path widens the exfiltration surface only marginally
+  — see #710 review for the documented trade-off).
+- `ol_csrf` is scoped to `Path=/` (#748): the SPA must read it via
+  `document.cookie` from any route, and `document.cookie` only
+  exposes cookies whose Path prefixes the current document URL.
+
+Historical note: both cookies originally shared `Path=/auth`. That
+scope broke `ol_csrf` reads outside `/auth/*` (#748) and, after the
+`/v1` API-versioning migration, stopped `ol_refresh` from ever being
+sent to `/v1/auth/refresh` — logging users out on every page reload
+(#1327). Login/refresh/logout proactively clear stale copies at the
+legacy `/auth` path, so returning browsers self-heal.
 
 ## SameSite policy
 
@@ -47,7 +60,7 @@ to production.
 `SameSite=Strict` is incompatible with deployments where the FE and
 API live on different origins (e.g. `app.example.com` →
 `api.example.com`): the browser drops the cookie on every
-cross-origin fetch, so `/auth/refresh` never receives `ol_refresh`
+cross-origin fetch, so `/v1/auth/refresh` never receives `ol_refresh`
 and silently fails. If your prod deploy is cross-origin, set
 `OL_COOKIE_SAMESITE=lax` explicitly. Defense-in-depth in that
 configuration leans on the CSRF double-submit guard and the
@@ -97,7 +110,7 @@ What the flow does **not** protect:
   control. Password-reset rate-limiting + MFA are the relevant
   defenses.
 - **CSRF on non-cookie endpoints**. The `CsrfGuard` runs only on
-  `/auth/refresh` and `/auth/logout`. State-mutating endpoints that
+  `/v1/auth/refresh` and `/v1/auth/logout`. State-mutating endpoints that
   rely on `Authorization: Bearer …` aren't CSRF-exposed because the
   bearer header is not auto-attached by the browser.
 - **Server compromise**. If the API host is rooted, every active

--- a/docs/plans/analysis/ANALYSIS-refresh-cookie-path-v1.md
+++ b/docs/plans/analysis/ANALYSIS-refresh-cookie-path-v1.md
@@ -1,0 +1,42 @@
+# Pre-implement Analysis — refresh-cookie-path-v1 (#1327)
+
+**Gate run**: 2026-07-03, against worktree `1327-refresh-cookie-path-v1` @ `e6298374`.
+**Plan**: `docs/plans/implementation-plan-refresh-cookie-path-v1.md`
+
+## Verdict: READY
+
+No Critical findings. One Warning (stale operator doc the plan doesn't touch) — fold into the
+same PR; it does not require re-planning.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `REFRESH_COOKIE_PATH` (re-derive + export) | PARTIAL (extend existing) | Exists module-private at `apps/api/src/auth/auth.cookies.ts:22`; sole definition in the tree. Export is additive — the file header already declares constants as test-consumable, and `REFRESH_COOKIE_NAME` is exported from the same file as precedent. |
+| `LEGACY_AUTH_COOKIE_PATH` (new const) | NEW (confirmed absent) | No existing constant names the legacy `'/auth'` scope; the #748 cleanups at `auth.cookies.ts:83,93` borrow `REFRESH_COOKIE_PATH` for it — exactly the coupling the plan unwinds. |
+| `API_VERSION_LABEL` (consume) | ALREADY EXISTS → reuse | `apps/api/src/app-info/app-info.types.ts:16`; existing consumers `app-info.service.ts:17` and `main.ts` (via `API_VERSION`). No new definition needed. |
+| Drift-guard unit test (`PATH_METADATA`) | NEW | No prior `PATH_METADATA` / `@nestjs/common/constants` usage in the repo — this is a first use, not a collision. Keep the plan's `'auth'` sanity guard so an undefined metadata read fails loudly. |
+| Int-spec `Path=/v1/auth` assertion | PARTIAL (flip existing) | `apps/api/test/integration/auth-refresh.int-spec.ts:122` currently asserts the buggy `Path=\/auth`; the epoch-expiry filter to extend exists at `:116-118`. |
+
+Consumer sweep (`ol_refresh` / `REFRESH_COOKIE` / `path: '/auth'` across `apps/` + `libs/`):
+every hit is either `auth.cookies.ts` itself, its two spec files, `auth.controller.ts`
+(name-only, no path), comment references (`main.ts:53`, `setup.ts:57`), or the FE's
+`no-localstorage-jwt.test.ts` (name-only). **No hidden consumer binds to the path value.**
+`csrf.guard.ts` carries no path logic.
+
+## Backward-compat findings
+
+| Surface | Finding | Severity |
+|---|---|---|
+| Top-level barrels | Not touched — change is entirely in `apps/api` (no `@openlinker/*` package surface). | — |
+| Port signatures / DTOs / Symbol tokens / ORM schema | None touched; no migration needed. | — |
+| Set-Cookie wire contract | `Path` attribute changes `/auth` → `/v1/auth`. Not a published contract (issue's stated assumption: no proxy/CDN pins the literal). Stale browser cookies are handled by the plan's legacy-path clears. | OK (documented assumption) |
+| `check:invariants` | `auth → app-info` is a same-app relative import (`../app-info/…`, depth ≤ `../..`); no cross-context walker scope (`apps/**` walker only guards `@openlinker/core/*` deep paths). No rule fires. | — |
+| **`docs/operations/auth-cookies.md`** | **Warning**: states "Both cookies share the same `Path=/auth`" (`:21-24`) — already stale post-#748 (csrf is `/`), and doubly stale after this fix. Plan does not list it. | Warning |
+
+## Open questions
+
+None blocking. One addition for the implementation step list: update
+`docs/operations/auth-cookies.md`'s cookie-path paragraph (`:21-24`, and the `/auth/refresh`
+route mentions) to the versioned reality in the same PR — it is the operator-facing statement
+of exactly the contract this fix changes.

--- a/docs/plans/implementation-plan-refresh-cookie-path-v1.md
+++ b/docs/plans/implementation-plan-refresh-cookie-path-v1.md
@@ -1,0 +1,101 @@
+# Implementation Plan — Refresh-token cookie Path fix after /v1 API versioning (#1327)
+
+## 1. Understanding
+
+**Goal**: `apps/api/src/auth/auth.cookies.ts` scopes the HttpOnly `ol_refresh` cookie to
+`Path=/auth`, but since the URI-versioning migration (#1133/#1316) `AuthController` is mounted at
+`/v1/auth/*`. Per RFC 6265 §5.1.4 the browser never sends the cookie to `POST /v1/auth/refresh`,
+so every cold page reload 401s and logs the user out despite a valid refresh token.
+
+**Layer**: Interface (HTTP auth cookies). No domain/application/persistence change, no migration.
+
+**Non-goals**:
+- `CSRF_COOKIE_PATH` stays `'/'` (correct since #748).
+- No FE change — `ol_refresh` is HttpOnly; the SPA never reads it.
+- No change to token issuance/rotation logic.
+
+## 2. Research
+
+- `REFRESH_COOKIE_PATH` is consumed in exactly one file: `auth.cookies.ts` (set at :53, three
+  `clearCookie` sites at :83/:89/:93).
+- **Trap found**: the two CSRF *migration-cleanup* clears (`:83`, `:93`, from #748) reuse
+  `REFRESH_COOKIE_PATH` as a stand-in for the **legacy `'/auth'`** CSRF path. Blindly re-pointing
+  the constant to `/v1/auth` would silently retarget those cleanups and break the #748 recovery
+  semantics. They need their own literal.
+- `API_VERSION` / `API_VERSION_LABEL` (`apps/api/src/app-info/app-info.types.ts`) is the declared
+  single source of truth for the version prefix — `main.ts:91` and the integration harness
+  (`test/integration/setup.ts:35`) both feed it to `enableVersioning`. Deriving the cookie path
+  from it satisfies the issue's "don't hardcode `/v1` a second time" criterion.
+- `auth-refresh.int-spec.ts:122` currently asserts the **buggy** `Path=/auth` — it passes because
+  supertest replays the `Cookie` header manually, bypassing browser path-matching. That assertion
+  must flip to the versioned path.
+
+## 3. Design
+
+```
+apps/api/src/auth/auth.cookies.ts
+  import { API_VERSION_LABEL } from '../app-info/app-info.types';
+  export const REFRESH_COOKIE_PATH = `/${API_VERSION_LABEL}/auth`;   // now exported for tests
+  const LEGACY_AUTH_COOKIE_PATH = '/auth';                            // pre-#1327 refresh + pre-#748 csrf scope
+```
+
+- `setRefreshCookie()` additionally clears the stale `ol_refresh` at the legacy `'/auth'` path
+  before setting the new one (same rationale and mechanism as the #748 CSRF cleanup already in
+  this file: browsers from the buggy window otherwise carry a live-but-unreachable refresh token
+  for its full TTL).
+- The two CSRF migration-cleanup clears switch from `REFRESH_COOKIE_PATH` to
+  `LEGACY_AUTH_COOKIE_PATH` (behavior-preserving).
+- `clearAuthCookies()` clears `ol_refresh` at both the versioned and legacy paths.
+
+**Drift guard (AC 2)**: unit test asserts
+`REFRESH_COOKIE_PATH === '/' + API_VERSION_LABEL + '/' + Reflect.getMetadata(PATH_METADATA, AuthController)`
+using the `PATH_METADATA` constant from `@nestjs/common/constants` (not the raw `'path'`
+literal, so a Nest-internal key rename fails at import time instead of returning `undefined`),
+plus an explicit guard that the resolved controller path is exactly `'auth'` so a silent
+`undefined` can't make the assertion vacuous. A future controller-prefix change fails the
+build; a future `API_VERSION` bump self-heals because the path is derived.
+
+**Test-tautology guard (review finding)**: the int-spec must NOT derive its expected cookie
+path from `API_VERSION_LABEL` — the implementation computes the path from that same constant,
+so a derived assertion is true by construction and blind to mount-vs-cookie drift (e.g.
+versioning removed while the constant still says `v1`). The int-spec's request paths are
+literal (`.post('/v1/auth/login')`); assert the **literal** `Path=/v1/auth` against that
+literal request path (RFC 6265 §5.1.4 prefix-match is then witnessed by the pair of literals).
+
+## 4. Steps
+
+1. **`apps/api/src/auth/auth.cookies.ts`** — derive + export `REFRESH_COOKIE_PATH`, add
+   `LEGACY_AUTH_COOKIE_PATH`, add legacy-refresh cleanup in `setRefreshCookie` and
+   `clearAuthCookies`, retarget the two CSRF cleanups to the legacy literal.
+   Style constraints (mirror the in-file #748 precedent exactly): clear **before** set,
+   options limited to `{ path: LEGACY_AUTH_COOKIE_PATH }`, *why* comment citing #1327 with the
+   "affected users never reach logout" rationale; update the file header's `/auth/*` route
+   references to the versioned paths.
+   *Accept*: `Set-Cookie: ol_refresh=…; Path=/v1/auth` on login/refresh; clears cover both paths.
+2. **`apps/api/src/auth/auth.controller.spec.ts`** — add drift-guard test (path derivation vs
+   `PATH_METADATA` controller metadata); assert **which cookie gets deleted, not just how many
+   times**: explicit `toHaveBeenCalledWith(REFRESH_COOKIE_NAME, { path: REFRESH_COOKIE_PATH })`
+   and `toHaveBeenCalledWith(REFRESH_COOKIE_NAME, { path: '/auth' })` on the logout/reuse paths
+   (a clear at the wrong path leaves a live HttpOnly refresh token after logout — call counts
+   alone can't catch that); update `clearCookie` call-count expectations (login/refresh now also
+   clear legacy `ol_refresh`; reuse/logout paths clear 4, not 3); keep `'/auth'` literals for the
+   migration-cleanup assertions.
+3. **`apps/api/test/integration/auth-refresh.int-spec.ts`** — assert the **literal**
+   `Path=/v1/auth` on the refresh cookie line (no `API_VERSION_LABEL` import — see
+   test-tautology guard above); extend the "skip epoch-expired clearing lines" filter (already
+   used for csrf) to the refresh cookie lookup.
+4. **`docs/operations/auth-cookies.md`** (pre-implement gate finding) — fix the stale
+   "Both cookies share the same `Path=/auth`" paragraph (`:21-24`; csrf has been `/` since
+   #748) and the `/auth/*` route mentions to the versioned reality.
+5. Quality gate: `pnpm lint`, `pnpm type-check`, `pnpm test`, plus the relevant int-spec via
+   Testcontainers:
+   `pnpm --filter @openlinker/api exec jest --config test/jest-integration.cjs --testPathPattern=auth-refresh`.
+
+## 5. Validation
+
+- **Architecture**: interface-layer only; no boundary crossings; import direction
+  `auth → app-info` already exists in the app layer (both under `apps/api/src`).
+- **Security**: fix restores refresh-token delivery; legacy cleanup removes a lingering
+  (path-orphaned) credential from browser jars. No secrets, no new surface.
+- **Assumption carried from the issue**: no deployment pins proxy/CDN rules to the literal
+  `/auth` cookie path.


### PR DESCRIPTION
## Summary

Since the `/v1` URI-versioning migration (#1133/#1316), `AuthController` is mounted at `/v1/auth/*` but the HttpOnly `ol_refresh` cookie was still issued with `Path=/auth`. Per RFC 6265 §5.1.4 the browser never attached it to `POST /v1/auth/refresh`, so **every full page reload received a 401 and logged the user out** despite a valid, unexpired refresh token sitting in the (never-sent) cookie.

## Changes

- **`apps/api/src/auth/auth.cookies.ts`**
  - `REFRESH_COOKIE_PATH` is now derived as `` `/${API_VERSION_LABEL}/auth` `` (→ `/v1/auth`) from the same source `main.ts` feeds `enableVersioning()`, and exported for tests — no second hardcoded `/v1` literal, so a future API-version bump self-heals.
  - New `LEGACY_AUTH_COOKIE_PATH = '/auth'` takes over the #748 CSRF migration-cleanup clears, which previously **borrowed `REFRESH_COOKIE_PATH` as that literal** — changing the constant naively would have silently retargeted the #748 recovery.
  - Login/refresh/logout additionally clear the stale pre-fix `ol_refresh` at the legacy `/auth` path (mirrors the #748 cleanup precedent in the same file), so returning browsers don't carry a live-but-unreachable refresh token for its full TTL.
- **`apps/api/src/auth/auth.controller.spec.ts`** — drift-guard test asserting `REFRESH_COOKIE_PATH === '/' + API_VERSION_LABEL + '/' + <AuthController route metadata>` (a future controller-prefix change fails the build), plus explicit which-cookie-deleted-at-which-path assertions on the logout/reuse paths — a clear at the wrong path would leave a live HttpOnly refresh token after logout, which bare call counts can't catch.
- **`apps/api/test/integration/auth-refresh.int-spec.ts`** — flips the assertion that previously *asserted the bug* (`Path=/auth`; it passed because supertest replays the Cookie header manually, bypassing browser path-matching — exactly why #1133 didn't catch this). Now asserts the **literal** `Path=/v1/auth` paired with the literal request path, deliberately not derived from `API_VERSION_LABEL` to avoid a tautological assertion blind to mount-vs-cookie drift.
- **`docs/operations/auth-cookies.md`** — the cookie-path section claimed "Both cookies share the same `Path=/auth`", stale since #748 and doubly stale after this fix; rewritten to the versioned reality with the historical note.
- `demo-mode.service.spec.ts` carries a 1-line `import type` autofix produced by the repo's own `lint --fix` — unrelated to the fix, kept because the tooling reapplies it.
- Plan + pre-implement analysis docs under `docs/plans/`.

## Test plan

- [x] `pnpm lint` (incl. `check:invariants`) — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — full unit suite green (api 632, worker 188, all packages)
- [x] `apps/api/test/integration/auth-refresh.int-spec.ts` via Testcontainers — 8/8, including cookie-jar login → refresh (the issue's AC-3)
- [x] Fix independently confirmed live during the 2026-07-03 inFakt/KSeF E2E run (see issue comment): `Set-Cookie` carries `Path=/v1/auth` and silent refresh returns 200

Closes #1327

🤖 Generated with [Claude Code](https://claude.com/claude-code)