### PR TITLE
ci(release): dispatch product-release to website repo on cut release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,6 +36,33 @@ jobs:
       # Pinned by commit SHA (not the mutable v4 tag) because this workflow holds
       # contents+pull-requests write — supply-chain hygiene for third-party actions.
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # openlinker.io/changelog renders this repo's GitHub Releases at build time.
+      # A tag pushed by release-please's default GITHUB_TOKEN can't re-trigger a
+      # separate workflow (RELEASING.md § CD trigger caveat), so poke the website
+      # repo directly — but only when a Release was actually cut (the Release PR
+      # merged), not on the every-push Release-PR refresh.
+      - name: Notify website of new release
+        if: ${{ steps.release.outputs.release_created }}
+        # Best-effort: the tag + GitHub Release are already created by the step
+        # above, so a failed dispatch (expired PAT, website repo down) must not
+        # red-X an otherwise-successful release. --fail-with-body still logs the
+        # error for debugging, and the changelog refreshes on the next site deploy.
+        continue-on-error: true
+        env:
+          TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::notice::WEBSITE_DISPATCH_TOKEN not set — skipping website redeploy dispatch"
+            exit 0
+          fi
+          curl -sS --fail-with-body -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/openlinker-project/openlinker-website/dispatches \
+            -d "{\"event_type\":\"product-release\",\"client_payload\":{\"tag\":\"$TAG\"}}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -109,6 +109,15 @@ the tag + GitHub Release. You never hand-tag again.
   baseline is hand-formatted, so eyeball the first insertion) before merging.
 - Per-package changelogs do not exist yet — they arrive with npm publishing
   (Changesets), as separate files for a different audience (plugin authors).
+- **openlinker.io/changelog** renders this repo's GitHub Releases at build time.
+  On a cut release (`steps.release.outputs.release_created`), `release-please.yml`
+  fires a `repository_dispatch` (`event_type: product-release`) to
+  `openlinker-project/openlinker-website` so its `deploy.yml` redeploys prod with
+  the new notes. This needs a repo Actions secret **`WEBSITE_DISPATCH_TOKEN`** — a
+  fine-grained PAT scoped to `openlinker-website` with **Contents: read & write**
+  (the `POST /dispatches` endpoint rides the contents permission). The step
+  skips with a `::notice::` if the secret is absent, so the workflow is safe to
+  run before the secret is provisioned.
 
 ## Demo deployments
 


### PR DESCRIPTION
## What

Wires `release-please.yml` to notify the website repo when a release is actually cut, so `openlinker.io/changelog` (which renders this repo's GitHub Releases at build time) redeploys automatically instead of only refreshing on the next unrelated site deploy.

- Gives the `release-please-action` step an `id: release`.
- Adds a `Notify website of new release` step, gated `if: ${{ steps.release.outputs.release_created }}` so it fires **only when the Release PR merges** (a tag + GitHub Release is cut) — not on the every-push Release-PR refresh.
- The step `POST`s a `repository_dispatch` (`event_type: product-release`, `client_payload.tag`) to `openlinker-project/openlinker-website`, whose `deploy.yml` listens for that event.

## Why this shape

release-please cuts the tag with the default `GITHUB_TOKEN`, which **cannot** re-trigger a separate workflow (`RELEASING.md § CD trigger caveat`). Running the dispatch in the same job, gated on `release_created`, is exactly the pattern that caveat prescribes. Using in-runner `curl` (vs a third-party `repository-dispatch` action) keeps the supply-chain surface minimal alongside the SHA-pinned release-please action.

## Safety

- **Graceful skip**: if `WEBSITE_DISPATCH_TOKEN` is absent the step emits a `::notice::` and exits 0 — so this PR is safe to merge **before** the secret is provisioned.
- **`continue-on-error: true`**: the tag + GitHub Release are created by the step *above* this one, so a failed downstream dispatch (expired PAT, website repo down) must not red-X an already-successful release. `--fail-with-body` still surfaces the error in the logs; the changelog also self-heals on the next site deploy.
- Secret is passed via `env:` (never interpolated into the command → not log-exposed); the dispatch rides the scoped PAT, not `GITHUB_TOKEN`, so the job's existing permissions are unchanged.

## Prerequisite (maintainer-only, manual)

Create a fine-grained PAT scoped to `openlinker-project/openlinker-website` with **Contents: read & write**, and add it to this repo's Actions secrets as **`WEBSITE_DISPATCH_TOKEN`**. Documented inline in the workflow and in `RELEASING.md`. Merging before the secret exists is safe (graceful skip).

## Verification

- YAML parses; all 15 `check:invariants` guards pass (incl. repo-URL drift).
- Pre-commit hook green (lint + type-check; smart-test correctly skipped — no workspace package touched).
- True end-to-end (a real tag → website prod deploy) can only be observed on the next release merge with the secret provisioned.

## Files

- `.github/workflows/release-please.yml` — the `id` + notify step.
- `RELEASING.md` — documents the dispatch wiring + the `WEBSITE_DISPATCH_TOKEN` prerequisite under the CHANGELOG section.

Closes #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)