### PR TITLE
docs(readme): add self-updating version badge, de-stale alpha prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenLinker
 
 [![CI](https://github.com/openlinker-project/openlinker/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openlinker-project/openlinker/actions/workflows/ci.yml)
+[![Version](https://img.shields.io/github/package-json/v/openlinker-project/openlinker?label=version)](./CHANGELOG.md)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](https://github.com/openlinker-project/openlinker/issues/670)
 
@@ -10,7 +11,7 @@
 
 If you sell on your own shop *and* on marketplaces like Allegro, you've already lived the pain: orders coming in from multiple places, inventory drifting between channels, manually rewriting product descriptions for every listing, customer data scattered across systems. The usual answers are SaaS channel managers (you pay forever and your data lives on their servers) or custom scripts (fragile and yours to maintain alone). OpenLinker is the third option: a self-hosted, open-source orchestration platform that does the same job, on your servers, with your data, with code you can read and extend.
 
-> **Status: alpha, pre-1.0.** First public release is in progress. Expect rough edges; report them.
+> **Status: alpha, pre-1.0.** Expect rough edges; report them.
 
 <p align="center">
   <picture>


### PR DESCRIPTION
## What & why

The README badge block (CI / License / Status) had **no version badge** — a reader couldn't tell which release OpenLinker is on. Hardcoding `v0.1.0` would be the wrong fix: it'd go stale the instant the next release cuts and the README is the one place nobody remembers to update (the exact drift class we closed with the release-please work in #1332).

This adds a **dynamic** shields.io badge that reads the version from the single canonical source, so it can't drift:

```markdown
[![Version](https://img.shields.io/github/package-json/v/openlinker-project/openlinker?label=version)](./CHANGELOG.md)
```

- **`github/package-json/v`** reads `version` from the root `package.json` — which release-please bumps only when a Release PR merges. So the badge tracks the release line (`0.1.0` today; `0.1.1` the moment #1345 merges) with **zero README edits and no hardcoded number** in the markdown.
- Chose `package-json/v` over `github/v/release` so it renders correctly **right now**, independent of when the `v0.1.0` GitHub Release is published (the `v/release` variant shows "no releases" until then).

Two axes handled by churn rate:
- **Version (high-churn)** → dynamic badge (above).
- **Maturity (low-churn)** → the `Status: alpha` badge is left **untouched** — it changes ~twice in the project's life and is correctly hardcoded.

Also **de-staled the prose** at line 13 — dropped "First public release is in progress" (`v0.1.0` is now tagged) and kept it maturity-only/version-agnostic so it can't re-drift.

## Diff

`README.md` only, +2/−1: one new badge line + one prose trim. No app code, no tests, no migration.

## Test plan

- [x] `pnpm check:invariants` green — incl. `scripts/check-repo-urls.mjs` (the new shields URL uses the canonical `openlinker-project/openlinker` slug and trips no repo-URL guard).
- [x] `Status: alpha` badge + its `#670` link unchanged.
- [x] No hardcoded version number in the markdown source — the number appears only inside the shields URL, resolved at render time from `package.json`.
- [x] Auto-reflects a bump: the badge URL reads root `package.json`, which release-please updates on Release-PR merge — verify after #1345 merges (→ `0.1.1`) with no README change.

Closes #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)