### PR TITLE
test(erli): cover #1146 cancellation stock-restore hook (S7)

### DIFF
--- a/apps/api/test/integration/erli/erli-orders-vertical-slice.int-spec.ts
+++ b/apps/api/test/integration/erli/erli-orders-vertical-slice.int-spec.ts
@@ -470,42 +470,59 @@ describe('Erli Orders Vertical Slice Integration (#998)', () => {
     const jobQueue = harness.getApp().get<SyncJobQueuePort>(SYNC_JOB_QUEUE_TOKEN);
     const enqueueSpy = jest.spyOn(jobQueue, 'enqueue');
 
-    // First sync: purchased → persisted 'processing' (priorStatus becomes 'processing').
-    erli.fake.setRawGet(
-      orderPath(ORDER_CANCEL),
-      buildErliOrder(ORDER_CANCEL, { status: 'purchased', productExternalId: externalProductId }),
-    );
-    await syncTolerateNoDestination(ORDER_CANCEL);
-    expect(enqueueSpy).not.toHaveBeenCalled();
+    // Wrapped in try/finally so the spy on the shared DI-singleton SyncJobQueueService
+    // is always restored, even if an assertion throws (the integration harness does
+    // not reset mocks between tests, so a leaked spy would bleed into later scenarios).
+    try {
+      // First sync: purchased → persisted 'processing' (priorStatus becomes 'processing').
+      erli.fake.setRawGet(
+        orderPath(ORDER_CANCEL),
+        buildErliOrder(ORDER_CANCEL, { status: 'purchased', productExternalId: externalProductId }),
+      );
+      await syncTolerateNoDestination(ORDER_CANCEL);
+      expect(enqueueSpy).not.toHaveBeenCalled();
 
-    // Second sync: cancelled → the #1146 hook fires (transition-gated) and enqueues
-    // the REAL marketplace.offer.stockRestore job via the REAL SyncJobQueueService.
-    erli.fake.setRawGet(
-      orderPath(ORDER_CANCEL),
-      buildErliOrder(ORDER_CANCEL, { status: 'cancelled', productExternalId: externalProductId }),
-    );
-    await syncTolerateNoDestination(ORDER_CANCEL);
+      // Second sync: cancelled → the #1146 hook fires (transition-gated) and enqueues
+      // the REAL marketplace.offer.stockRestore job via the REAL SyncJobQueueService.
+      erli.fake.setRawGet(
+        orderPath(ORDER_CANCEL),
+        buildErliOrder(ORDER_CANCEL, { status: 'cancelled', productExternalId: externalProductId }),
+      );
+      await syncTolerateNoDestination(ORDER_CANCEL);
 
-    const record = await findOrderRecord(ORDER_CANCEL);
-    expect(record).not.toBeNull();
-    expect(record!.orderSnapshot.status).toBe('cancelled');
-    const internalOrderId = record!.internalOrderId;
+      const record = await findOrderRecord(ORDER_CANCEL);
+      expect(record).not.toBeNull();
+      expect(record!.orderSnapshot.status).toBe('cancelled');
+      const internalOrderId = record!.internalOrderId;
 
-    expect(enqueueSpy).toHaveBeenCalledTimes(1);
-    const [enqueueRequest] = enqueueSpy.mock.calls[0];
-    expect(enqueueRequest.type).toBe('marketplace.offer.stockRestore');
-    expect(enqueueRequest.connectionId).toBe(connectionId);
-    expect(enqueueRequest.payload).toMatchObject({ internalOrderId });
-    expect(enqueueRequest.options.dedupeKey).toBe(
-      `marketplace:${connectionId}:stockRestore:${internalOrderId}`,
-    );
+      // syncOrderFromSource has TWO enqueue sites for a resolvable → cancelled
+      // transition — the early-fire hook (incoming.status) and the post-persist hook
+      // (order.status), both transition-gated on priorStatus !== 'cancelled' and both
+      // emitting the IDENTICAL dedupeKey. Redis dedupes them into a single job
+      // ("Job already enqueued (idempotent)"), but the spy counts method invocations,
+      // so it observes 2. Assert the idempotent intent directly: two invocations,
+      // exactly one distinct job.
+      expect(enqueueSpy).toHaveBeenCalledTimes(2);
+      const dedupeKeys = new Set(enqueueSpy.mock.calls.map((c) => c[0].options.dedupeKey));
+      expect(dedupeKeys.size).toBe(1);
 
-    // A re-poll of the already-cancelled order must NOT enqueue a second job
-    // (transition gate — priorStatus === 'cancelled' short-circuits).
-    await syncTolerateNoDestination(ORDER_CANCEL);
-    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+      const [enqueueRequest] = enqueueSpy.mock.calls[0];
+      expect(enqueueRequest.type).toBe('marketplace.offer.stockRestore');
+      expect(enqueueRequest.connectionId).toBe(connectionId);
+      expect(enqueueRequest.payload).toMatchObject({ internalOrderId });
+      expect(enqueueRequest.options.dedupeKey).toBe(
+        `marketplace:${connectionId}:stockRestore:${internalOrderId}`,
+      );
 
-    enqueueSpy.mockRestore();
+      // A re-poll of the already-cancelled order must NOT enqueue any additional job
+      // (transition gate — priorStatus === 'cancelled' short-circuits both hooks), so
+      // the invocation count stays at 2 and the distinct-job count stays at 1.
+      await syncTolerateNoDestination(ORDER_CANCEL);
+      expect(enqueueSpy).toHaveBeenCalledTimes(2);
+      expect(new Set(enqueueSpy.mock.calls.map((c) => c[0].options.dedupeKey)).size).toBe(1);
+    } finally {
+      enqueueSpy.mockRestore();
+    }
   });
 
   // ── S6: lifecycle writeback (DIRECT invocation of OrderStatusWriteback.write) ─

--- a/apps/api/test/integration/erli/erli-orders-vertical-slice.int-spec.ts
+++ b/apps/api/test/integration/erli/erli-orders-vertical-slice.int-spec.ts
@@ -64,7 +64,9 @@ import {
 import { OrderRecordOrmEntity } from '@openlinker/core/orders/orm-entities';
 import {
   INBOUND_ROUTING_POLICY_TOKEN,
+  SYNC_JOB_QUEUE_TOKEN,
   type IInboundRoutingPolicyService,
+  type SyncJobQueuePort,
 } from '@openlinker/core/sync';
 import { ErliWebhookEventTranslator } from '@openlinker/integrations-erli/infrastructure/adapters/erli-webhook-event-translator.adapter';
 
@@ -90,6 +92,7 @@ const ORDER_WEBHOOK = 'erli-order-webhook-004';
 const ORDER_DISPATCH_NO_TRACKING = 'erli-order-dispatch-005';
 const ORDER_DISPATCH_WITH_TRACKING = 'erli-order-dispatch-006';
 const ORDER_AWAITING = 'erli-order-awaiting-007';
+const ORDER_CANCEL = 'erli-order-cancel-008';
 
 /** Inbox path the OrderSource adapter requests (literal). */
 const INBOX_PATH = '/inbox';
@@ -452,6 +455,57 @@ describe('Erli Orders Vertical Slice Integration (#998)', () => {
     const record = await findOrderRecord(ORDER_AWAITING);
     expect(record).not.toBeNull();
     expect(record!.recordStatus).toBe('awaiting_mapping');
+  });
+
+  // ── S7: cancellation-observe hook (#1146) — real ingestion → real stockRestore enqueue ─
+  it('S7: an order transitioning to cancelled enqueues a real marketplace.offer.stockRestore job (once)', async () => {
+    const externalProductId = `erli-variant-${ORDER_CANCEL}`;
+    await seedReadyItem(externalProductId);
+
+    // Enqueue is a Redis-stream publish (SyncJobQueueService → JobEnqueuePort), not a
+    // sync_jobs Postgres row — that table is populated by the worker-side stream
+    // consumer, which isn't running in this API-only harness. Spy on the REAL
+    // SyncJobQueueService (resolved from the DI container) to observe the call while
+    // letting it execute for real against Redis.
+    const jobQueue = harness.getApp().get<SyncJobQueuePort>(SYNC_JOB_QUEUE_TOKEN);
+    const enqueueSpy = jest.spyOn(jobQueue, 'enqueue');
+
+    // First sync: purchased → persisted 'processing' (priorStatus becomes 'processing').
+    erli.fake.setRawGet(
+      orderPath(ORDER_CANCEL),
+      buildErliOrder(ORDER_CANCEL, { status: 'purchased', productExternalId: externalProductId }),
+    );
+    await syncTolerateNoDestination(ORDER_CANCEL);
+    expect(enqueueSpy).not.toHaveBeenCalled();
+
+    // Second sync: cancelled → the #1146 hook fires (transition-gated) and enqueues
+    // the REAL marketplace.offer.stockRestore job via the REAL SyncJobQueueService.
+    erli.fake.setRawGet(
+      orderPath(ORDER_CANCEL),
+      buildErliOrder(ORDER_CANCEL, { status: 'cancelled', productExternalId: externalProductId }),
+    );
+    await syncTolerateNoDestination(ORDER_CANCEL);
+
+    const record = await findOrderRecord(ORDER_CANCEL);
+    expect(record).not.toBeNull();
+    expect(record!.orderSnapshot.status).toBe('cancelled');
+    const internalOrderId = record!.internalOrderId;
+
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    const [enqueueRequest] = enqueueSpy.mock.calls[0];
+    expect(enqueueRequest.type).toBe('marketplace.offer.stockRestore');
+    expect(enqueueRequest.connectionId).toBe(connectionId);
+    expect(enqueueRequest.payload).toMatchObject({ internalOrderId });
+    expect(enqueueRequest.options.dedupeKey).toBe(
+      `marketplace:${connectionId}:stockRestore:${internalOrderId}`,
+    );
+
+    // A re-poll of the already-cancelled order must NOT enqueue a second job
+    // (transition gate — priorStatus === 'cancelled' short-circuits).
+    await syncTolerateNoDestination(ORDER_CANCEL);
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+
+    enqueueSpy.mockRestore();
   });
 
   // ── S6: lifecycle writeback (DIRECT invocation of OrderStatusWriteback.write) ─


### PR DESCRIPTION
## What

Integration-test coverage for the #1146 order-cancellation stock-restore hook: an Erli order transitioning to `cancelled` enqueues a real `marketplace.offer.stockRestore` job exactly once, observed via the real `SyncJobQueueService` (not a `sync_jobs` Postgres row, since that table is worker-populated and this harness is API-only).

## Why a standalone PR

Split out of the docs PR #1284 per Piotr's review: this test rode along in an unrelated docs-tree migration commit. Since it's an `apps/api/**/*.int-spec.ts` file, it escapes the `lint`/`type-check` gate that would normally catch this kind of drift, so it's cleaner as its own reviewable, mergeable unit.

## Verification

- `tsc --noEmit` clean.
- Not run locally (requires Docker/Testcontainers per the resource-constrained dev setup) - relies on CI's integration-test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)