### PR TITLE
feat(infakt): resend rejected invoice to KSeF from the UI (#1356)

### DIFF
--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -276,6 +276,7 @@ describe('InvoicingController', () => {
       getInvoice: jest.fn().mockResolvedValue(null),
       getInvoiceById: jest.fn().mockResolvedValue(null),
       listInvoices: jest.fn(),
+      applyRegulatoryClearance: jest.fn(),
     } as unknown as jest.Mocked<IInvoiceService>;
     orders = {
       getOrderRecord: jest.fn(),
@@ -1227,6 +1228,70 @@ describe('InvoicingController', () => {
       await expect(controller.setDefaultBankAccount('conn-infakt-1', '1')).rejects.toBeInstanceOf(
         BadGatewayException,
       );
+    });
+  });
+
+  describe('POST /invoices/:invoiceId/resend-to-ksef (#1356)', () => {
+    it('404 NotFound when the invoice does not exist', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(null);
+      await expect(controller.resendToKsef('inv_missing')).rejects.toBeInstanceOf(NotFoundException);
+      expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('409 Conflict when the invoice is not in a rejected state', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(
+        makeInvoiceRecord({ regulatoryStatus: 'accepted' }),
+      );
+      await expect(controller.resendToKsef('inv_1')).rejects.toBeInstanceOf(ConflictException);
+      // Gate short-circuits before any adapter resolution.
+      expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('501 NotImplemented when the adapter does not implement RegulatoryResubmitter', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(
+        makeInvoiceRecord({ regulatoryStatus: 'rejected' }),
+      );
+      integrations.getCapabilityAdapter.mockResolvedValue({} as InvoicingPort);
+      await expect(controller.resendToKsef('inv_1')).rejects.toBeInstanceOf(NotImplementedException);
+      expect(invoiceService.applyRegulatoryClearance).not.toHaveBeenCalled();
+    });
+
+    it('resubmits and returns the refreshed record when rejected + capability present', async () => {
+      const rejected = makeInvoiceRecord({ regulatoryStatus: 'rejected' });
+      invoiceService.getInvoiceById.mockResolvedValue(rejected);
+      const resubmitForClearance = jest
+        .fn()
+        .mockResolvedValue({ regulatoryStatus: 'submitted', clearanceReference: null });
+      integrations.getCapabilityAdapter.mockResolvedValue({
+        resubmitForClearance,
+      } as unknown as InvoicingPort);
+      const refreshed = makeInvoiceRecord({ regulatoryStatus: 'submitted' });
+      invoiceService.applyRegulatoryClearance.mockResolvedValue(refreshed);
+
+      const result = await controller.resendToKsef('inv_1');
+
+      expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith('conn_1', 'Invoicing');
+      expect(resubmitForClearance).toHaveBeenCalledWith(rejected);
+      expect(invoiceService.applyRegulatoryClearance).toHaveBeenCalledWith('inv_1', {
+        regulatoryStatus: 'submitted',
+        clearanceReference: null,
+      });
+      expect(result.regulatoryStatus).toBe('submitted');
+    });
+
+    it('502 BadGateway with a generic message when the live resend fails', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(
+        makeInvoiceRecord({ regulatoryStatus: 'rejected' }),
+      );
+      integrations.getCapabilityAdapter.mockResolvedValue({
+        resubmitForClearance: jest.fn().mockRejectedValue(new Error('inFakt 500: seller NIP 123')),
+      } as unknown as InvoicingPort);
+
+      const rejection = controller.resendToKsef('inv_1');
+      await expect(rejection).rejects.toBeInstanceOf(BadGatewayException);
+      // Provider error text (incl. any PII) must never be echoed back.
+      await expect(rejection).rejects.not.toThrow(/NIP 123/);
+      expect(invoiceService.applyRegulatoryClearance).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -20,6 +20,7 @@ import type { Response } from 'express';
 import {
   INVOICE_SERVICE_TOKEN,
   InvoiceRecord as InvoiceRecordClass,
+  InvoiceRecordNotFoundException,
   UnsupportedRegulatoryDocumentKindError,
   BuyerProfile,
 } from '@openlinker/core/invoicing';
@@ -1292,6 +1293,26 @@ describe('InvoicingController', () => {
       // Provider error text (incl. any PII) must never be echoed back.
       await expect(rejection).rejects.not.toThrow(/NIP 123/);
       expect(invoiceService.applyRegulatoryClearance).not.toHaveBeenCalled();
+    });
+
+    it('404 NotFound (not 502) when the record is deleted after resend succeeds (TOCTOU)', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(
+        makeInvoiceRecord({ regulatoryStatus: 'rejected' }),
+      );
+      integrations.getCapabilityAdapter.mockResolvedValue({
+        resubmitForClearance: jest
+          .fn()
+          .mockResolvedValue({ regulatoryStatus: 'submitted', clearanceReference: null }),
+      } as unknown as InvoicingPort);
+      // Provider succeeded; the local write-back fails because the row vanished.
+      invoiceService.applyRegulatoryClearance.mockRejectedValue(
+        new InvoiceRecordNotFoundException('inv_1'),
+      );
+
+      const rejection = controller.resendToKsef('inv_1');
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundException);
+      // Must NOT be mislabelled as a provider fault.
+      await expect(rejection).rejects.not.toBeInstanceOf(BadGatewayException);
     });
   });
 });

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -69,6 +69,7 @@ import {
   RegulatoryDocumentKindValues,
   UnsupportedRegulatoryDocumentKindError,
   isRegulatoryDocumentReader,
+  isRegulatoryResubmitter,
   BuyerProfile,
   isBankAccountsReader,
   isBankAccountDefaultSetter,
@@ -540,6 +541,60 @@ export class InvoicingController {
       throw this.toHttpException(error);
     }
     return this.toDto(issued);
+  }
+
+  @Post('invoices/:invoiceId/resend-to-ksef')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Re-send a rejected invoice to the tax authority (KSeF)',
+    description:
+      "Re-triggers transmission of an already-issued document whose clearance ended in " +
+      "'rejected', then refreshes the stored regulatory status. Gated to rejected documents " +
+      '(409 otherwise) to avoid racing an in-flight submission or re-sending a cleared document. ' +
+      'Requires the connection adapter to implement the RegulatoryResubmitter sub-capability ' +
+      '(501 when unsupported). Neutral by design (ADR-026) — the core capability carries no ' +
+      'regime vocabulary; only this operator-facing route name references KSeF, mirroring /upo.',
+  })
+  @ApiResponse({ status: 200, description: 'Resubmitted; refreshed record', type: InvoiceRecordResponseDto })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  @ApiResponse({ status: 409, description: 'Invoice is not in a rejected state' })
+  @ApiResponse({ status: 501, description: 'Adapter does not implement RegulatoryResubmitter' })
+  @ApiResponse({ status: 502, description: 'Invoicing provider unavailable or the resend failed' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async resendToKsef(
+    @Param('invoiceId', invoiceIdPipe()) invoiceId: string,
+  ): Promise<InvoiceRecordResponseDto> {
+    const record = await this.invoiceService.getInvoiceById(invoiceId);
+    if (!record) {
+      throw new NotFoundException(`Invoice not found: ${invoiceId}`);
+    }
+    // Gate: resend ONLY a terminal-rejected document. Re-sending an in-flight
+    // (`submitted`) or already-`accepted` document would race the provider or
+    // duplicate a cleared submission, so anything but `rejected` is a 409.
+    if (record.regulatoryStatus !== 'rejected') {
+      throw new ConflictException(
+        `Invoice ${invoiceId} is not in a rejected state (regulatory status ${record.regulatoryStatus}); ` +
+          'only rejected invoices can be re-sent',
+      );
+    }
+
+    const adapter = await this.resolveInvoicingAdapter(record.connectionId);
+    if (!isRegulatoryResubmitter(adapter)) {
+      throw new NotImplementedException(
+        `Adapter for connection ${record.connectionId} does not implement RegulatoryResubmitter`,
+      );
+    }
+
+    let refreshed: InvoiceRecord;
+    try {
+      const result = await adapter.resubmitForClearance(record);
+      // Refresh the stored regulatory status so the projection reflects the new
+      // (typically `submitted`) state and the reconciliation sweep resumes polling.
+      refreshed = await this.invoiceService.applyRegulatoryClearance(invoiceId, result);
+    } catch (error) {
+      throw this.toProviderBadGateway(error, 'resubmitForClearance');
+    }
+    return this.toDto(refreshed);
   }
 
   @Get('orders/:orderId/invoice')

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -66,6 +66,7 @@ import {
   InvalidBuyerProfileError,
   UnsupportedPriceTreatmentError,
   DuplicateInvoiceRecordException,
+  InvoiceRecordNotFoundException,
   RegulatoryDocumentKindValues,
   UnsupportedRegulatoryDocumentKindError,
   isRegulatoryDocumentReader,
@@ -83,6 +84,7 @@ import type {
   TaxIdentifier,
   InvoicingPort,
   RegulatoryDocumentKind,
+  RegulatoryClearanceResult,
   StoredDocument,
 } from '@openlinker/core/invoicing';
 import {
@@ -585,16 +587,35 @@ export class InvoicingController {
       );
     }
 
-    let refreshed: InvoiceRecord;
+    // No OL-side concurrency lease here (unlike the issue path's CAS lease): two
+    // concurrent admin clicks both read `rejected` and both re-hit the provider.
+    // That is intentional and safe — `resubmitForClearance` only re-sends the SAME
+    // document by `providerInvoiceId` and never re-POSTs `invoices.json`, so it
+    // cannot double-issue; resend relies on provider-side idempotency rather than
+    // an OL lease.
+    let result: RegulatoryClearanceResult;
     try {
-      const result = await adapter.resubmitForClearance(record);
-      // Refresh the stored regulatory status so the projection reflects the new
-      // (typically `submitted`) state and the reconciliation sweep resumes polling.
-      refreshed = await this.invoiceService.applyRegulatoryClearance(invoiceId, result);
+      result = await adapter.resubmitForClearance(record);
     } catch (error) {
+      // Only the provider call is a 502-worthy upstream fault. Keep the local
+      // write outside this catch so a TOCTOU persistence failure isn't mislabelled
+      // as a provider failure.
       throw this.toProviderBadGateway(error, 'resubmitForClearance');
     }
-    return this.toDto(refreshed);
+
+    // Refresh the stored regulatory status so the projection reflects the new
+    // (typically `submitted`) state and the reconciliation sweep resumes polling.
+    // The provider already succeeded; a failure here is a local persistence fault
+    // (e.g. the record was deleted after the read), mapped on its own terms.
+    try {
+      const refreshed = await this.invoiceService.applyRegulatoryClearance(invoiceId, result);
+      return this.toDto(refreshed);
+    } catch (error) {
+      if (error instanceof InvoiceRecordNotFoundException) {
+        throw new NotFoundException(`Invoice not found: ${invoiceId}`);
+      }
+      throw this.toHttpException(error);
+    }
   }
 
   @Get('orders/:orderId/invoice')

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -72,6 +72,7 @@ describe('OrdersController', () => {
       getInvoice: jest.fn(),
       issueCorrection: jest.fn(),
       listInvoices: jest.fn(),
+      applyRegulatoryClearance: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/web/src/features/invoicing/api/invoicing.api.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.api.ts
@@ -42,6 +42,13 @@ export interface InvoicingApi {
   /** `POST /invoices/:invoiceId/correct` — issue a correcting document (#1241). */
   issueCorrection: (invoiceId: string, input: IssueCorrectionInput) => Promise<InvoiceRecord>;
   /**
+   * `POST /invoices/:invoiceId/resend-to-ksef` (#1356) — re-send a rejected
+   * invoice to the tax authority and return the refreshed record. Server gates
+   * to `regulatoryStatus === 'rejected'` (409 otherwise) and to adapters that
+   * implement the neutral RegulatoryResubmitter capability (501 otherwise).
+   */
+  resendToKsef: (invoiceId: string) => Promise<InvoiceRecord>;
+  /**
    * `GET /invoices/:invoiceId/upo` (#1234) — fetch the official UPO confirmation
    * document for a cleared/accepted e-invoice as a Blob. Content type is
    * provider-defined (PDF / XML); the caller derives the kind from `blob.type`.
@@ -117,6 +124,12 @@ export function createInvoicingApi(request: ApiRequest, requestBlob: ApiBlobRequ
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(input),
+      });
+    },
+    resendToKsef(invoiceId): Promise<InvoiceRecord> {
+      return request<InvoiceRecord>(`/invoices/${encodeURIComponent(invoiceId)}/resend-to-ksef`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
       });
     },
     downloadUpo(invoiceId): Promise<Blob> {

--- a/apps/web/src/features/invoicing/hooks/use-resend-to-ksef-mutation.test.tsx
+++ b/apps/web/src/features/invoicing/hooks/use-resend-to-ksef-mutation.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * useResendToKsefMutation tests (#1356)
+ *
+ * @module apps/web/src/features/invoicing/hooks
+ */
+import { waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import type { InvoiceRecord } from '../api/invoicing.types';
+import { useResendToKsefMutation } from './use-resend-to-ksef-mutation';
+
+function makeInvoiceRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
+  return {
+    id: 'ol_invoice_1',
+    connectionId: 'conn_1',
+    orderId: 'ol_order_1',
+    providerType: 'infakt',
+    documentType: 'invoice',
+    status: 'issued',
+    providerInvoiceId: 'inv-uuid-1',
+    providerInvoiceNumber: 'FV 1/2026',
+    regulatoryStatus: 'submitted',
+    clearanceReference: null,
+    pdfUrl: null,
+    failureMode: null,
+    failureCode: null,
+    failureReason: null,
+    issuedAt: null,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('useResendToKsefMutation', () => {
+  it('calls resendToKsef and resolves to the refreshed InvoiceRecord', async () => {
+    const refreshed = makeInvoiceRecord({ regulatoryStatus: 'submitted' });
+    const resendToKsef = vi.fn().mockResolvedValue(refreshed);
+
+    let capturedMutation: ReturnType<typeof useResendToKsefMutation> | undefined;
+
+    function Harness(): null {
+      capturedMutation = useResendToKsefMutation();
+      return null;
+    }
+
+    renderWithProviders(<Harness />, {
+      apiClient: createMockApiClient({ invoicing: { resendToKsef } }),
+    });
+
+    capturedMutation!.mutate('ol_invoice_1');
+
+    await waitFor(() => expect(capturedMutation!.isSuccess).toBe(true));
+
+    expect(capturedMutation!.data).toEqual(refreshed);
+    expect(resendToKsef).toHaveBeenCalledWith('ol_invoice_1');
+  });
+
+  it('surfaces the error when resendToKsef rejects', async () => {
+    const resendToKsef = vi.fn().mockRejectedValue(new Error('KSeF unavailable'));
+
+    let capturedMutation: ReturnType<typeof useResendToKsefMutation> | undefined;
+
+    function Harness(): null {
+      capturedMutation = useResendToKsefMutation();
+      return null;
+    }
+
+    renderWithProviders(<Harness />, {
+      apiClient: createMockApiClient({ invoicing: { resendToKsef } }),
+    });
+
+    capturedMutation!.mutate('ol_invoice_1');
+
+    await waitFor(() => expect(capturedMutation!.isError).toBe(true));
+    expect(capturedMutation!.error?.message).toBe('KSeF unavailable');
+  });
+});

--- a/apps/web/src/features/invoicing/hooks/use-resend-to-ksef-mutation.ts
+++ b/apps/web/src/features/invoicing/hooks/use-resend-to-ksef-mutation.ts
@@ -1,0 +1,27 @@
+/**
+ * useResendToKsefMutation (#1356)
+ *
+ * Mutation hook for `POST /invoices/:invoiceId/resend-to-ksef`. Re-sends a
+ * rejected invoice to KSeF and, on success, invalidates the invoicing query
+ * domain so the refreshed regulatory status (typically `submitted`) appears
+ * immediately. The consumer reads `isPending`/`isSuccess`/`isError` for the
+ * button's loading / success / error states.
+ *
+ * @module apps/web/src/features/invoicing/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { invoicingQueryKeys } from '../api/invoicing.query-keys';
+import type { InvoiceRecord } from '../api/invoicing.types';
+
+export function useResendToKsefMutation(): UseMutationResult<InvoiceRecord, Error, string> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (invoiceId: string) => apiClient.invoicing.resendToKsef(invoiceId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: invoicingQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/invoicing/index.ts
+++ b/apps/web/src/features/invoicing/index.ts
@@ -33,6 +33,7 @@ export {
   useIssueCorrectionMutation,
   type IssueCorrectionVariables,
 } from './hooks/use-issue-correction-mutation';
+export { useResendToKsefMutation } from './hooks/use-resend-to-ksef-mutation';
 export { useKsefUpoPreview } from './hooks/use-ksef-upo-preview';
 export type { UpoPreviewKind } from './hooks/use-ksef-upo-preview';
 export { useKsefUpoDownload } from './hooks/use-ksef-upo-download';

--- a/apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.test.tsx
+++ b/apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.test.tsx
@@ -122,6 +122,40 @@ describe('InfaktInvoiceDetailSection', () => {
     expect(await screen.findByText('KSeF rejected this invoice.')).toBeInTheDocument();
   });
 
+  it('shows a Resend to KSeF button only when rejected', async () => {
+    const { rerender } = renderWithProviders(
+      <InfaktInvoiceDetailSection
+        invoice={makeInvoice({ regulatoryStatus: 'accepted', clearanceReference: 'REF-1' })}
+        connection={infaktConnection}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Resend to KSeF' })).not.toBeInTheDocument();
+
+    rerender(
+      <InfaktInvoiceDetailSection
+        invoice={makeInvoice({ regulatoryStatus: 'rejected', failureReason: 'nope' })}
+        connection={infaktConnection}
+      />,
+    );
+    expect(await screen.findByRole('button', { name: 'Resend to KSeF' })).toBeInTheDocument();
+  });
+
+  it('calls resendToKsef when the Resend button is clicked (rejected)', async () => {
+    const resendToKsef = vi.fn().mockResolvedValue(makeInvoice({ regulatoryStatus: 'submitted' }));
+    const apiClient = createMockApiClient({ invoicing: { resendToKsef } });
+
+    renderWithProviders(
+      <InfaktInvoiceDetailSection
+        invoice={makeInvoice({ regulatoryStatus: 'rejected', failureReason: 'nope' })}
+        connection={infaktConnection}
+      />,
+      { apiClient },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resend to KSeF' }));
+    await waitFor(() => expect(resendToKsef).toHaveBeenCalledWith('ol_invoice_test'));
+  });
+
   it('calls downloadDocument with kind=rendered when Download PDF is clicked', async () => {
     URL.createObjectURL = vi.fn(() => 'blob:mock');
     URL.revokeObjectURL = vi.fn();

--- a/apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.tsx
+++ b/apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.tsx
@@ -24,6 +24,7 @@ import {
   RegulatoryStatusBadge,
   regCardToneFor,
   useInvoiceRenderedDocumentDownload,
+  useResendToKsefMutation,
 } from '../../../features/invoicing';
 
 export function InfaktInvoiceDetailSection({
@@ -31,6 +32,7 @@ export function InfaktInvoiceDetailSection({
 }: InvoiceDetailSectionProps): ReactElement | null {
   const { t } = useTranslation();
   const pdfDownload = useInvoiceRenderedDocumentDownload();
+  const resendToKsef = useResendToKsefMutation();
   const { showToast } = useToast();
 
   if (invoice.regulatoryStatus === 'not-applicable') {
@@ -48,6 +50,28 @@ export function InfaktInvoiceDetailSection({
         description:
           pdfDownload.error?.message ??
           t('infakt.invoice.detail.pdfDownloadFailedDesc', 'Could not fetch the invoice PDF.'),
+      });
+    }
+  }
+
+  async function handleResendToKsef(): Promise<void> {
+    try {
+      await resendToKsef.mutateAsync(invoice.id);
+      showToast({
+        tone: 'success',
+        title: t('infakt.invoice.detail.resendSuccess', 'Re-sent to KSeF'),
+        description: t(
+          'infakt.invoice.detail.resendSuccessDesc',
+          'inFakt is submitting this invoice to KSeF again. Its clearance status will refresh shortly.',
+        ),
+      });
+    } catch (error) {
+      showToast({
+        tone: 'error',
+        title: t('infakt.invoice.detail.resendFailed', 'Re-send failed'),
+        description:
+          (error instanceof Error ? error.message : undefined) ??
+          t('infakt.invoice.detail.resendFailedDesc', 'Could not re-send the invoice to KSeF.'),
       });
     }
   }
@@ -96,10 +120,22 @@ export function InfaktInvoiceDetailSection({
       ) : null}
 
       {invoice.regulatoryStatus === 'rejected' ? (
-        <p className="text-muted reg-card__note">
-          {invoice.failureReason ??
-            t('infakt.invoice.detail.rejectedFallback', 'KSeF rejected this invoice.')}
-        </p>
+        <div className="reg-card__summary">
+          <p className="text-muted reg-card__note">
+            {invoice.failureReason ??
+              t('infakt.invoice.detail.rejectedFallback', 'KSeF rejected this invoice.')}
+          </p>
+          <Button
+            tone="primary"
+            className="button--sm"
+            onClick={() => void handleResendToKsef()}
+            disabled={resendToKsef.isPending}
+          >
+            {resendToKsef.isPending
+              ? t('infakt.invoice.detail.resending', 'Re-sending…')
+              : t('infakt.invoice.detail.resend', 'Resend to KSeF')}
+          </Button>
+        </div>
       ) : null}
     </section>
   );

--- a/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
@@ -71,6 +71,7 @@ describe('InvoicingIssueHandler', () => {
       getLatestInvoiceForOrder: jest.fn(),
       listInvoices: jest.fn(),
       issueCorrection: jest.fn(),
+      applyRegulatoryClearance: jest.fn(),
     };
     handler = new InvoicingIssueHandler(invoiceService as unknown as IInvoiceService);
     warnSpy = jest

--- a/libs/core/src/invoicing/application/services/invoice.service.interface.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.interface.ts
@@ -17,6 +17,7 @@ import type {
   IssueCorrectionCommand,
   IssueInvoiceCommand,
   PaginatedInvoiceRecords,
+  RegulatoryClearanceResult,
 } from '../../domain/types/invoicing.types';
 import type { InvoiceRecord } from '../../domain/entities/invoice-record.entity';
 
@@ -117,4 +118,20 @@ export interface IInvoiceService {
     filter: InvoiceRecordFilters,
     pagination: InvoiceRecordPagination,
   ): Promise<PaginatedInvoiceRecords>;
+
+  /**
+   * Persist a refreshed regulatory-clearance outcome onto an existing record
+   * (#1356). Patches ONLY `regulatoryStatus` + `clearanceReference` — the
+   * issuance lifecycle (`status`, provider ids, line snapshot) is untouched.
+   * Backs the operator "resend to authority" action: after an adapter that
+   * implements `RegulatoryResubmitter` re-triggers transmission, the caller
+   * writes the returned {@link RegulatoryClearanceResult} back so the projection
+   * reflects the new (typically `submitted`) status and the reconciliation sweep
+   * (#1121) resumes polling it. NEVER queries the provider/adapter itself.
+   * Throws `InvoiceRecordNotFoundException` when the id is unknown.
+   */
+  applyRegulatoryClearance(
+    invoiceId: string,
+    result: RegulatoryClearanceResult,
+  ): Promise<InvoiceRecord>;
 }

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -50,6 +50,7 @@ import type {
   IssuedLineSnapshot,
   IssueInvoiceCommand,
   PaginatedInvoiceRecords,
+  RegulatoryClearanceResult,
   TaxBreakdownEntry,
 } from '../../domain/types/invoicing.types';
 
@@ -594,6 +595,22 @@ export class InvoiceService implements IInvoiceService {
     // Cross-context list seam (#1119): the HTTP layer reaches the invoice
     // projection through here, never the repository port. Pure projection read.
     return this.repo.findMany(filter, pagination);
+  }
+
+  async applyRegulatoryClearance(
+    invoiceId: string,
+    result: RegulatoryClearanceResult,
+  ): Promise<InvoiceRecord> {
+    // Write-back of a refreshed clearance outcome (#1356). ONLY the two
+    // regulatory fields are patched — the issuance lifecycle (status, provider
+    // ids, line snapshot, failure fields) is deliberately left untouched, so a
+    // resend never mutates the issued document's own record beyond its clearance
+    // state. `updateOutcome` throws `InvoiceRecordNotFoundException` on an
+    // unknown id.
+    return this.repo.updateOutcome(invoiceId, {
+      regulatoryStatus: result.regulatoryStatus,
+      clearanceReference: result.clearanceReference ?? null,
+    });
   }
 
   /**

--- a/libs/core/src/invoicing/domain/ports/capabilities/regulatory-resubmitter.capability.ts
+++ b/libs/core/src/invoicing/domain/ports/capabilities/regulatory-resubmitter.capability.ts
@@ -23,7 +23,11 @@
  * narrow with `isRegulatoryResubmitter` before invoking — a provider that has no
  * resend concept simply doesn't implement it (the HTTP layer degrades to 501).
  *
- * Neutral-vocabulary litmus (ADR-026): no `nip`/`ksef`/`vat`/`jpk`/`faktura` here.
+ * Neutral-vocabulary litmus (ADR-026): the CONTRACT SURFACE — interface name,
+ * method name, parameter/return types — carries no `nip`/`ksef`/`vat`/`jpk`/
+ * `faktura` vocabulary. The prose above names inFakt/KSeF only as illustrative
+ * examples of a natively-transmitting provider; those are documentation, not part
+ * of the type surface a sibling context binds to.
  *
  * @module libs/core/src/invoicing/domain/ports/capabilities
  * @see {@link RegulatoryStatusReader} for the read-only clearance-poll half

--- a/libs/core/src/invoicing/domain/ports/capabilities/regulatory-resubmitter.capability.ts
+++ b/libs/core/src/invoicing/domain/ports/capabilities/regulatory-resubmitter.capability.ts
@@ -1,0 +1,54 @@
+/**
+ * Regulatory Resubmitter Capability
+ *
+ * Optional sub-capability of `InvoicingPort` (#1356): an invoicing adapter that
+ * can re-trigger transmission of an ALREADY-ISSUED document to the tax authority
+ * declares `implements RegulatoryResubmitter`. It backs the operator "resend"
+ * action for a document whose clearance ended in `rejected` — the adapter kicks
+ * a fresh submission of the SAME provider document and returns the neutral
+ * clearance outcome the resubmit yielded.
+ *
+ * Distinct from {@link RegulatoryTransmitter} on purpose: a transmitter is a
+ * provider OL itself holds the authority session for (OL builds + submits the
+ * document). A resubmitter is a NATIVELY-transmitting provider (e.g. inFakt,
+ * which owns its own KSeF session and builds the fiscal XML) that nonetheless
+ * needs an explicit submission kick from OL — re-sending is that kick, not OL
+ * driving the session. Kept FLAT and independent (it does not `extends`
+ * `RegulatoryStatusReader`): the resubmit returns the post-submit status as data
+ * on its own, and adapters that also poll status implement
+ * `RegulatoryStatusReader` separately — do not cargo-cult `extends` for
+ * orthogonal capabilities.
+ *
+ * Call sites resolve the `Invoicing` capability adapter per-connection, then
+ * narrow with `isRegulatoryResubmitter` before invoking — a provider that has no
+ * resend concept simply doesn't implement it (the HTTP layer degrades to 501).
+ *
+ * Neutral-vocabulary litmus (ADR-026): no `nip`/`ksef`/`vat`/`jpk`/`faktura` here.
+ *
+ * @module libs/core/src/invoicing/domain/ports/capabilities
+ * @see {@link RegulatoryStatusReader} for the read-only clearance-poll half
+ * @see {@link RegulatoryTransmitter} for the OL-holds-the-session submit half
+ */
+import type { InvoiceRecord } from '../../entities/invoice-record.entity';
+import type { RegulatoryClearanceResult } from '../../types/invoicing.types';
+import type { InvoicingPort } from '../invoicing.port';
+
+export interface RegulatoryResubmitter {
+  /**
+   * Re-trigger transmission of an already-issued document to the authority and
+   * return the neutral clearance outcome the resubmit yielded. Operates on the
+   * SAME provider document referenced by `record` (never re-creating it), so it
+   * cannot double-issue a fiscal document. A business verdict (incl. a repeat
+   * `rejected`) is returned as data; a transport/infrastructure failure throws
+   * for the caller to map. `record` is the issued `InvoiceRecord` — the adapter
+   * reads what it needs (`providerInvoiceId`, …) and performs no identifier
+   * mapping.
+   */
+  resubmitForClearance(record: InvoiceRecord): Promise<RegulatoryClearanceResult>;
+}
+
+export function isRegulatoryResubmitter(
+  adapter: InvoicingPort,
+): adapter is InvoicingPort & RegulatoryResubmitter {
+  return typeof (adapter as Partial<RegulatoryResubmitter>).resubmitForClearance === 'function';
+}

--- a/libs/core/src/invoicing/index.ts
+++ b/libs/core/src/invoicing/index.ts
@@ -20,6 +20,7 @@ export * from './domain/ports/invoicing.port';
 // Re-exports both `RegulatoryStatusReader` and `isRegulatoryStatusReader`.
 export * from './domain/ports/capabilities/regulatory-status-reader.capability';
 export * from './domain/ports/capabilities/regulatory-transmitter.capability';
+export * from './domain/ports/capabilities/regulatory-resubmitter.capability';
 export * from './domain/ports/capabilities/correction-issuer.capability';
 export * from './domain/ports/capabilities/regulatory-document-reader.capability';
 export * from './domain/ports/capabilities/bank-accounts-reader.capability';

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -567,6 +567,97 @@ describe('InfaktInvoicingAdapter', () => {
     });
   });
 
+  describe('resubmitForClearance (#1356)', () => {
+    function issuedRecord(): InvoiceRecord {
+      return new InvoiceRecord(
+        'id-1',
+        'conn-1',
+        'order-1',
+        INFAKT_PROVIDER_TYPE,
+        'invoice',
+        'issued',
+        'inv-uuid-1',
+        'FV/1/2026',
+        'rejected',
+        null,
+        null,
+        null,
+        new Date(),
+        null,
+        new Date(),
+        new Date(),
+      );
+    }
+
+    it('re-hits send_to_ksef for the existing document and maps the returned status', async () => {
+      http.seed(
+        'POST',
+        'invoices/inv-uuid-1/send_to_ksef.json',
+        ksefResponseFixture({ status: 'sent' }),
+      );
+
+      const result = await adapter.resubmitForClearance(issuedRecord());
+
+      expect(result).toEqual({ regulatoryStatus: 'submitted', clearanceReference: null });
+      // Never re-POSTs invoices.json (no new draft) — only re-sends the SAME document.
+      expect(http.calls.some((c) => c.method === 'POST' && c.path === 'invoices.json')).toBe(false);
+      expect(
+        http.calls.some(
+          (c) => c.method === 'POST' && c.path === 'invoices/inv-uuid-1/send_to_ksef.json',
+        ),
+      ).toBe(true);
+    });
+
+    it('surfaces a KSeF number once the resend clears', async () => {
+      http.seed(
+        'POST',
+        'invoices/inv-uuid-1/send_to_ksef.json',
+        ksefResponseFixture({ status: 'success', ksef_number: 'KSeF-999' }),
+      );
+
+      const result = await adapter.resubmitForClearance(issuedRecord());
+
+      expect(result).toEqual({ regulatoryStatus: 'accepted', clearanceReference: 'KSeF-999' });
+    });
+
+    it('returns not-applicable defensively when the record has no providerInvoiceId', async () => {
+      const record = new InvoiceRecord(
+        'id-1',
+        'conn-1',
+        'order-1',
+        INFAKT_PROVIDER_TYPE,
+        'invoice',
+        'issued',
+        null,
+        null,
+        'rejected',
+        null,
+        null,
+        null,
+        new Date(),
+        null,
+        new Date(),
+        new Date(),
+      );
+
+      const result = await adapter.resubmitForClearance(record);
+
+      expect(result).toEqual({ regulatoryStatus: 'not-applicable' });
+    });
+
+    it('propagates a transport error (error path)', async () => {
+      http.seedError(
+        'POST',
+        'invoices/inv-uuid-1/send_to_ksef.json',
+        new InfaktApiError('server error', 503, {}),
+      );
+
+      await expect(adapter.resubmitForClearance(issuedRecord())).rejects.toMatchObject({
+        statusCode: 503,
+      });
+    });
+  });
+
   describe('issueCorrection', () => {
     const baseCmd: IssueCorrectionCommand = {
       connectionId: 'conn-1',

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -34,6 +34,7 @@ import type {
   RegulatoryDocument,
   RegulatoryDocumentKind,
   RegulatoryDocumentReader,
+  RegulatoryResubmitter,
   RegulatoryStatus,
   RegulatoryStatusReader,
   UpsertCustomerCommand,
@@ -204,6 +205,7 @@ export class InfaktInvoicingAdapter
   implements
     InvoicingPort,
     RegulatoryStatusReader,
+    RegulatoryResubmitter,
     CorrectionIssuer,
     RegulatoryDocumentReader,
     BankAccountsReader,
@@ -641,6 +643,38 @@ export class InfaktInvoicingAdapter
       `${resource}/${encodeURIComponent(invoiceUuid)}/send_to_ksef.json`,
       {},
     );
+  }
+
+  /**
+   * `RegulatoryResubmitter.resubmitForClearance` (#1356) — re-trigger KSeF
+   * submission of an ALREADY-ISSUED inFakt document, for the operator "resend to
+   * KSeF" action on a rejected invoice.
+   *
+   * Retry-safety (confirms/guards the previously-UNVERIFIED note on repeated
+   * `send_to_ksef` above): unlike `issueInvoice`/`issueCorrection`, this path
+   * does NOT re-POST `invoices.json`, so it can never create a second draft. It
+   * only re-hits `send_to_ksef.json` for the SAME existing document identified by
+   * `record.providerInvoiceId` — a pure re-transmission of a document inFakt
+   * already holds. The caller (the HTTP layer) additionally gates the action to
+   * documents whose clearance ended in `rejected`, so an in-flight or already-
+   * accepted document is never re-sent. Together these make a repeat
+   * `send_to_ksef` a safe re-attempt on one and the same fiscal document — it
+   * cannot double-issue. inFakt's async model returns the fresh submission status
+   * here (typically `pending`/`sent` → neutral `submitted`); OL's reconciliation
+   * sweep (#1121) then polls it to a terminal state.
+   *
+   * `providerInvoiceId` is always present for an issued record; the defensive
+   * `not-applicable` return covers a malformed record rather than a real path.
+   */
+  async resubmitForClearance(record: InvoiceRecord): Promise<RegulatoryClearanceResult> {
+    if (!record.providerInvoiceId) {
+      return { regulatoryStatus: 'not-applicable' };
+    }
+    const ksefResult = await this.sendToKsef(record.providerInvoiceId);
+    return {
+      regulatoryStatus: toRegulatoryStatus(ksefResult.status),
+      clearanceReference: ksefResult.ksef_number ?? null,
+    };
   }
 
   /**


### PR DESCRIPTION
## What changed

Exposes the adapter's existing `sendToKsef` as an operator action so a **KSeF-rejected** invoice can be re-submitted from OpenLinker instead of the inFakt dashboard.

- **CORE** (`libs/core/src/invoicing/`): neutral `RegulatoryResubmitter` capability + `isRegulatoryResubmitter` guard (ADR-026 neutral vocab, no regime terms cross the barrel); `IInvoiceService.applyRegulatoryClearance` patches only `regulatoryStatus` + `clearanceReference`.
- **Integration** (`libs/integrations/infakt`): `InfaktInvoicingAdapter` implements `RegulatoryResubmitter`; `resubmitForClearance` re-hits `send_to_ksef.json` for the existing `providerInvoiceId` and maps to a neutral `RegulatoryClearanceResult`.
- **API** (`apps/api/src/invoicing/http`): `POST invoices/:invoiceId/resend-to-ksef` (admin) - 404 unknown, **409** non-rejected, **501** no capability, 502 provider failure; refreshes stored status on success.
- **Frontend** (`apps/web`): "Resend to KSeF" button in the inFakt detail section's `rejected` branch with loading/success/error states + query invalidation.

## Retry-safety

The previously-UNVERIFIED note concerned duplicate *draft* creation on repeated `issueInvoice` (re-POST of `invoices.json`). The resend path never re-POSTs `invoices.json` (no new draft) - it only re-hits `send_to_ksef.json` for the *same* document by `providerInvoiceId`, and the controller gates to `regulatoryStatus === 'rejected'`, so it cannot race an in-flight submission or double-issue. An adapter test asserts the resend makes no `invoices.json` call.

## How to test

- Unit: `pnpm --filter @openlinker/integrations-infakt test`, `pnpm --filter @openlinker/core test`, `pnpm --filter @openlinker/api test`, plus the FE hook/detail-section tests.
- Manual: on a `rejected` inFakt invoice, click "Resend to KSeF"; confirm the status refreshes and no new draft is created.

## Notes

- Part of the inFakt accounting epic #1279.

Closes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)