### PR TITLE
fix(demo): unblock one-command Docker demo boot + PrestaShop networking (#1368)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# One-command demo environment (#1352 / #1368)
+#
+# Docker Compose auto-loads a root `.env` file for ${VAR} interpolation.
+# Copy this file to `.env` and fill in the required values before `pnpm demo:up`:
+#
+#   cp .env.example .env
+#
+# `.env` is gitignored — never commit real secrets.
+
+# REQUIRED. Encryption key for the integration_credentials store. Migration
+# 1795000000000-encrypt-integration-credentials fails closed (and aborts the
+# whole demo boot) under NODE_ENV=production if this is unset, and the api /
+# worker need it to decrypt connection credentials at runtime.
+#
+# Generate a fresh value with:
+#   openssl rand -base64 32
+OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=

--- a/README.md
+++ b/README.md
@@ -231,10 +231,17 @@ Want to click through OpenLinker without setting up a dev environment? The demo 
 ```bash
 git clone https://github.com/openlinker-project/openlinker.git
 cd openlinker
+
+# Required pre-step: provide the credentials encryption key (not committable).
+cp .env.example .env
+echo "OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=$(openssl rand -base64 32)" >> .env
+
 pnpm demo:up        # builds the images and starts everything (first run takes a while)
 pnpm demo:logs      # follow the logs
 pnpm demo:down      # stop the stack (add -v to also wipe the data volumes)
 ```
+
+> **Required:** `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` must be set (via the root `.env`) before `pnpm demo:up`. The credentials-encryption migration fails closed without it and aborts the boot. Generate one with `openssl rand -base64 32`. See [`.env.example`](./.env.example).
 
 Database migrations run automatically (one-shot `migrate` container) before the API and Worker start — no manual `migration:run` needed.
 
@@ -243,14 +250,18 @@ Database migrations run automatically (one-shot `migrate` container) before the 
 | OpenLinker admin UI | http://localhost:8090 | `admin` / `admin` |
 | OpenLinker API | http://localhost:3000 | — |
 | PrestaShop storefront | http://localhost:8080 | — |
-| PrestaShop admin | http://localhost:8080/admin | `demo@prestashop.com` / `prestashop_demo` |
+| PrestaShop admin | http://localhost:8080/admin-dev | `demo@prestashop.com` / `prestashop_demo` |
 | phpMyAdmin (PrestaShop MySQL) | http://localhost:8081 | `root` / `root` |
 
 PrestaShop auto-installs with a seeded catalog and the OpenLinker module pre-mounted. The PrestaShop ↔ OpenLinker **connection itself is configured manually** in the admin UI (`Connections → New`) — see the [Operator Guide](./docs/user-guide/README.md).
 
+**Configuring the PrestaShop connection (container networking):** the API and Worker containers reach PrestaShop over the Compose network by its **service name**, not `localhost`. When creating the connection, set both the **Shop URL** and the **Storefront URL** to `http://prestashop` (not `http://localhost:8080`) — `localhost` from inside a container resolves to the container itself. The demo pre-configures PrestaShop for this (a `prestashop`-domain shop URL plus disabled canonical redirect) via a post-install step, so webservice calls and server-side product-image downloads (OpenLinker fetches image bytes itself, then re-uploads them to the marketplace CDN) resolve correctly.
+
+> **Known limitation (follow-up):** with the Storefront URL set to `http://prestashop`, product-image *download* works from the app tier, but the operator's **browser** can't resolve `prestashop`, so product thumbnails in the OpenLinker UI won't render. Decoupling the server-side download base from the browser display base is a tracked follow-up — for the demo, prefer a working image sync over rendered thumbnails.
+
 Notes:
 
-- The demo shares the same Compose project (and data volumes) as `pnpm dev:stack:up`, so don't run both flows expecting isolated data. Requires Docker Compose ≥ 2.24.
+- ⚠️ **Shared volumes:** the demo shares the same Compose project (`openlinker`) and data volumes as `pnpm dev:stack:up`. On a machine with an existing local dev stack, running the demo **reuses and can clobber that data** — the two flows are *not* isolated. Stop and, if needed, wipe one before running the other (`pnpm dev:stack:down` / `pnpm demo:down -v`). Requires Docker Compose ≥ 2.24.
 - `VITE_API_BASE_URL` is baked into the UI bundle at image build time (default `http://localhost:3000`); rebuild the `web` image to change it.
 - Demo credentials are intentionally not production-safe — this stack is for local evaluation only.
 

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -29,6 +29,15 @@ services:
       # bootstrap-admin.service.ts).
       NODE_ENV: production
       OL_BOOTSTRAP_ADMIN_PASSWORD: admin
+      # CORS allow-list must include the browser origin the web UI is served
+      # from (the `web` service publishes :8090), or login fails with a
+      # "NetworkError when attempting to fetch resource" (#1368). The API
+      # default is only http://localhost:4173 (apps/api/src/main.ts).
+      OL_CORS_ORIGIN: http://localhost:8090
+      # Required by migration 1795000000000-encrypt-integration-credentials and
+      # for decrypting connection credentials at runtime. Operator-supplied via
+      # .env (see .env.example); `:?` fails the boot with a clear message if unset.
+      OPENLINKER_CREDENTIALS_ENCRYPTION_KEY: '${OPENLINKER_CREDENTIALS_ENCRYPTION_KEY:?set OPENLINKER_CREDENTIALS_ENCRYPTION_KEY in .env (see .env.example) - generate with: openssl rand -base64 32}'
     # Drop the dev-stack source bind-mounts — the demo runs the built image,
     # not the working tree. (Without !reset, Compose merges volumes by target
     # path and the mounts would survive the override.)
@@ -55,6 +64,9 @@ services:
       # Required by shared PII config (libs/shared/src/config/pii-config.ts) —
       # order-ingestion jobs hash customer identifiers in the worker.
       OL_PII_HASH_SALT: development-pii-hash-salt-change-in-production
+      # Same encryption key the api/migrate services use — the worker decrypts
+      # connection credentials when running sync jobs (#1368).
+      OPENLINKER_CREDENTIALS_ENCRYPTION_KEY: '${OPENLINKER_CREDENTIALS_ENCRYPTION_KEY:?set OPENLINKER_CREDENTIALS_ENCRYPTION_KEY in .env (see .env.example) - generate with: openssl rand -base64 32}'
     depends_on:
       postgres:
         condition: service_healthy
@@ -100,6 +112,10 @@ services:
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
       DB_DATABASE: openlinker
+      # migration 1795000000000-encrypt-integration-credentials fails closed
+      # under NODE_ENV=production when this is unset, rolling back and exiting 1
+      # — which blocks the gated api/worker and aborts the whole demo (#1368).
+      OPENLINKER_CREDENTIALS_ENCRYPTION_KEY: '${OPENLINKER_CREDENTIALS_ENCRYPTION_KEY:?set OPENLINKER_CREDENTIALS_ENCRYPTION_KEY in .env (see .env.example) - generate with: openssl rand -base64 32}'
     restart: 'no'
     depends_on:
       postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      # First-boot init (~60s: creates the prestashop db/user) must not be
+      # counted against the retry window, or a slower host marks MySQL
+      # unhealthy and aborts the dependent prestashop/phpmyadmin services (#1368).
+      start_period: 180s
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:latest

--- a/docker/prestashop/post-install-lib/40-configure-container-network.php
+++ b/docker/prestashop/post-install-lib/40-configure-container-network.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Make the shop reachable from the app-tier containers on the compose network (#1368).
+ *
+ * From inside a container, `localhost:8080` is the container itself, not
+ * PrestaShop — the app tier must reach the shop by its compose service name
+ * (`prestashop`). Two things break that out of the box:
+ *
+ *   1. No ps_shop_url row matches the `prestashop` Host, so PrestaShop can't
+ *      resolve a shop for the request.
+ *   2. When the request Host doesn't match the main shop domain, PrestaShop
+ *      301-redirects to its canonical domain — breaking webservice GET /api/...
+ *
+ * This script (idempotently):
+ *   - registers a second, non-main ps_shop_url row with domain/domain_ssl =
+ *     `prestashop` for the main shop, and
+ *   - sets PS_CANONICAL_REDIRECT=0 so no canonical 301 is issued.
+ *
+ * Legacy bootstrap only — ShopUrl + Configuration are pre-DI ObjectModel
+ * classes (mirrors 20-set-default-currency.php); no Symfony kernel needed.
+ */
+
+// _PS_ADMIN_DIR_ points at the renamed admin folder from `10-rename-admin.sh`
+// (lexical-order guaranteed to run before us).
+define('_PS_ADMIN_DIR_', '/var/www/html/admin-dev');
+require_once '/var/www/html/config/config.inc.php';
+
+const CONTAINER_DOMAIN = 'prestashop';
+
+$mainShopId = (int) Configuration::get('PS_SHOP_DEFAULT');
+if ($mainShopId <= 0) {
+    $mainShopId = 1;
+}
+
+// 1. Disable canonical redirect (0 = no redirect, 1 = 302, 2 = 301).
+if ((int) Configuration::get('PS_CANONICAL_REDIRECT') !== 0) {
+    if (!Configuration::updateValue('PS_CANONICAL_REDIRECT', 0)) {
+        fwrite(STDERR, "FATAL: Configuration::updateValue(PS_CANONICAL_REDIRECT) failed\n");
+        exit(1);
+    }
+    echo "* PS_CANONICAL_REDIRECT set to 0 (no canonical redirect)\n";
+} else {
+    echo "* PS_CANONICAL_REDIRECT already 0; nothing to do\n";
+}
+
+// 2. Register a container-reachable shop_url row (idempotent).
+$existing = ShopUrl::getShopUrls($mainShopId);
+$alreadyPresent = false;
+if ($existing) {
+    foreach ($existing as $row) {
+        if ($row['domain'] === CONTAINER_DOMAIN || $row['domain_ssl'] === CONTAINER_DOMAIN) {
+            $alreadyPresent = true;
+            break;
+        }
+    }
+}
+
+if ($alreadyPresent) {
+    echo "* ShopUrl for domain '" . CONTAINER_DOMAIN . "' already exists; nothing to do\n";
+    exit(0);
+}
+
+$shopUrl = new ShopUrl();
+$shopUrl->id_shop = $mainShopId;
+$shopUrl->domain = CONTAINER_DOMAIN;
+$shopUrl->domain_ssl = CONTAINER_DOMAIN;
+$shopUrl->physical_uri = '/';
+$shopUrl->virtual_uri = '';
+// Non-main: keep the operator's localhost URL as the shop's main URL so the
+// storefront/admin the operator opens in their browser is unaffected.
+$shopUrl->main = false;
+$shopUrl->active = true;
+
+if (!$shopUrl->add()) {
+    fwrite(STDERR, "FATAL: ShopUrl::add() failed for domain '" . CONTAINER_DOMAIN . "'\n");
+    exit(1);
+}
+
+echo "* ShopUrl added for domain '" . CONTAINER_DOMAIN . "' (id_shop={$mainShopId})\n";
+echo "* App-tier containers can now reach the shop at http://prestashop\n";

--- a/docker/prestashop/post-install/40-configure-container-network.sh
+++ b/docker/prestashop/post-install/40-configure-container-network.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Make the shop reachable from the app-tier containers on the compose network (#1368).
+# Thin wrapper that execs the PHP companion — see 40-configure-container-network.php
+# for the actual ObjectModel-based logic. Idempotent.
+set -e
+
+if ! command -v php >/dev/null 2>&1; then
+    echo "FATAL: php CLI not found in container; cannot run container-network config" >&2
+    exit 1
+fi
+
+# Run as www-data (matches the install phase on docker_run.sh:89). See
+# 20-set-default-currency.sh for rationale (cache ownership).
+exec runuser -g www-data -u www-data -- php -d memory_limit=256M /tmp/post-install-lib/40-configure-container-network.php


### PR DESCRIPTION
## Summary

Fixes the clean-checkout boot blockers and PrestaShop connection networking gaps found while booting the one-command Docker demo (#1352) end-to-end. **Infra + docs only — no domain code.** Stacks on PR #1365 (base = `1352-docker-demo-environment`).

| Item | What | Code-fixed / Documented |
|---|---|---|
| **A2** | `mysql` healthcheck gains `start_period: 180s` in `docker-compose.yml` so first-boot init (~60s) is not counted against the retry window on slower hosts. | Code-fixed |
| **A3** | Demo `api` service sets `OL_CORS_ORIGIN=http://localhost:8090` (the origin the `web` service publishes), so UI login no longer fails with a CORS `NetworkError`. | Code-fixed |
| **A1** | `migrate` / `api` / `worker` now source `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` from the environment (Compose auto-loads root `.env`) with a required-var `:?` guard that aborts the boot with a clear message if unset. New root `.env.example` + README pre-step document it (generation hint `openssl rand -base64 32`). No secret committed. | Code-fixed + Documented |
| **B1** | New PrestaShop post-install step `40-configure-container-network.{sh,php}` registers a second `ps_shop_url` row with `domain`/`domain_ssl = prestashop` for the main shop and sets `PS_CANONICAL_REDIRECT=0`, so the app-tier containers can reach the shop by its compose service name. README also documents entering `http://prestashop` as the Shop URL. | Code-fixed + Documented |
| **B2** | README documents that the connection's Storefront URL must be container-reachable (`http://prestashop`) for server-side offer image upload, with the browser-thumbnail trade-off noted. The deeper download-base/display-base decoupling is called out as a tracked follow-up (not attempted here). | Documented (follow-up flagged) |
| **Doc** | Corrected PrestaShop admin path `/admin` → `/admin-dev` (the post-install rename). | Documented |
| **Doc** | Louder ⚠️ warning that the demo shares the `openlinker` Compose project + data volumes with `pnpm dev:stack:up` (kept the shared project rather than risk breaking the existing `dev:stack` flow). | Documented |

## Files changed

- `docker-compose.yml` — mysql healthcheck `start_period`
- `docker-compose.demo.yml` — `OL_CORS_ORIGIN` on api; `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` on migrate/api/worker
- `.env.example` (new) — documents the required encryption key
- `docker/prestashop/post-install/40-configure-container-network.sh` (new)
- `docker/prestashop/post-install-lib/40-configure-container-network.php` (new)
- `README.md` — demo pre-step, admin path fix, connection networking + shared-volume warning

## Test plan

A reviewer can verify without a full boot:

1. **Merged compose is valid YAML**
   - `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=x docker compose -f docker-compose.yml -f docker-compose.demo.yml config >/dev/null` → succeeds.
   - `docker compose -f docker-compose.yml config >/dev/null` → base still valid.
2. **Required-var guard fires with a clear message**
   - `docker compose -f docker-compose.yml -f docker-compose.demo.yml config` (var unset) → exits non-zero with `required variable OPENLINKER_CREDENTIALS_ENCRYPTION_KEY is missing a value: set … generate with: openssl rand -base64 32`.
3. **Shell script syntax** — `bash -n docker/prestashop/post-install/40-configure-container-network.sh`.
4. **Full E2E (optional)** — `cp .env.example .env && echo "OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=$(openssl rand -base64 32)" >> .env && pnpm demo:up`; confirm migrations complete, UI logs in at :8090 without CORS error, admin reachable at `/admin-dev`, and a PrestaShop connection created with Shop/Storefront URL `http://prestashop` reaches the webservice and syncs product images.

> Note: the PHP companion (`40-configure-container-network.php`) follows the existing `20-set-default-currency.php` legacy-bootstrap conventions; it was not runtime-linted locally (no PHP CLI in the dev box) but mirrors a shipping script.

Closes #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
