### PR TITLE
fix(allegro,web): advertise OfferManager sub-capabilities so bulk wizard shows Allegro category params

### DIFF
--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
@@ -9,7 +9,7 @@
  * dialog are stubbed so the test isolates the modal's own logic from their
  * data dependencies.
  */
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../../../../test/test-utils';
 import { BulkEditModal } from './bulk-edit-modal';
@@ -23,11 +23,19 @@ vi.mock('../CategoryPicker', () => ({
     <div data-testid="category-picker">{value ?? 'none'}</div>
   ),
 }));
+// Mutable so a test can drive the category-parameters query result (#1367).
+let mockCategoryParameters: unknown[] = [];
 vi.mock('../../hooks/use-category-parameters-query', () => ({
-  useCategoryParametersQuery: () => ({ data: [], isLoading: false, error: null }),
+  useCategoryParametersQuery: () => ({
+    data: mockCategoryParameters,
+    isLoading: false,
+    error: null,
+  }),
 }));
 vi.mock('../../../content', () => ({ SuggestionDialog: () => null }));
-vi.mock('../category-parameters-step', () => ({ CategoryParametersStep: () => null }));
+vi.mock('../category-parameters-step', () => ({
+  CategoryParametersStep: () => <div data-testid="category-parameters-step" />,
+}));
 
 const DEFAULTS = { stock: 5, publishImmediately: true, priceAmount: '12.00', priceCurrency: 'PLN' };
 
@@ -89,6 +97,10 @@ function makeRow(opts: {
 }
 
 describe('BulkEditModal', () => {
+  beforeEach(() => {
+    mockCategoryParameters = [];
+  });
+
   it('renders a suggested-category chip per multi-match candidate, falling back to the id', () => {
     renderWithProviders(
       <BulkEditModal
@@ -234,5 +246,46 @@ describe('BulkEditModal', () => {
     await waitFor(() => { expect(onSave).toHaveBeenCalledTimes(1); });
     const override = onSave.mock.calls[0][1] as { overrides?: { categoryId?: string } };
     expect(override.overrides?.categoryId).toBeUndefined();
+  });
+
+  // #1367 — a browsable-taxonomy destination (Allegro, whose manifest advertises
+  // the `CategoryBrowser` sub-capability) must render the per-category parameter
+  // step so required offer params like "Stan" can be set; a borrows-taxonomy
+  // destination (Erli) must not.
+  it('renders the category-parameter step for a browsable destination once a category is resolved (#1367)', () => {
+    mockCategoryParameters = [{ id: '11323', name: 'Stan', type: 'dictionary', required: true }];
+    renderWithProviders(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={{ ...makeRow(), resolvedCategoryId: 'cat-1' }}
+        connection={connection}
+        canBrowseCategories={true}
+        defaults={DEFAULTS}
+        onSave={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText('Category parameters')).toBeInTheDocument();
+    expect(screen.getByTestId('category-parameters-step')).toBeInTheDocument();
+  });
+
+  it('hides the category-parameter step for a borrows destination even with required params (#1367)', () => {
+    mockCategoryParameters = [{ id: '11323', name: 'Stan', type: 'dictionary', required: true }];
+    renderWithProviders(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={{ ...makeRow(), resolvedCategoryId: 'cat-1' }}
+        connection={connection}
+        canBrowseCategories={false}
+        defaults={DEFAULTS}
+        onSave={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByText('Category parameters')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('category-parameters-step')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Allegro category ID')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -138,6 +138,13 @@ export function BulkWizard({
   // resolves the category server-side at submit (#1096 / ADR-025 §3), so a
   // pre-flight non-match must not block it; one without a browsable category tree
   // needs manual Allegro-id entry in the edit modal rather than the tree picker.
+  //
+  // `EanCategoryMatcher` and `CategoryBrowser` are `OfferManager` sub-capabilities
+  // advertised on the connection payload's `supportedCapabilities` (Allegro's
+  // manifest declares them, Erli does not — #1367). Keep them in the manifest; the
+  // response `supportedCapabilities` mirrors the live manifest, so dropping either
+  // silently regresses Allegro to the borrows-taxonomy branch (no parameter step,
+  // required "Stan" unsettable → PARAMETER_REQUIRED at submit).
   const destinationResolvesCategoryAtSubmit = batchConnection
     ? !batchConnection.supportedCapabilities.includes('EanCategoryMatcher')
     : false;

--- a/libs/integrations/allegro/src/__tests__/allegro-plugin.spec.ts
+++ b/libs/integrations/allegro/src/__tests__/allegro-plugin.spec.ts
@@ -20,6 +20,17 @@ describe('allegroAdapterManifest', () => {
       expect.arrayContaining(['OrderSource', 'OfferManager', 'ShippingProviderManager']),
     );
   });
+
+  it('advertises the CategoryBrowser + EanCategoryMatcher OfferManager sub-capabilities so the bulk wizard renders the category-parameter step for a browsable taxonomy (#1367)', () => {
+    // These drive the FE browsable-vs-borrows split on the connection response's
+    // `supportedCapabilities`. The adapter implements both (guard-verified in
+    // allegro-offer-manager.adapter.spec.ts); the manifest must advertise them
+    // or the coarse list is silently missing them and Allegro is treated as a
+    // borrows-taxonomy destination (no "Stan" parameter → PARAMETER_REQUIRED).
+    expect(allegroAdapterManifest.supportedCapabilities).toEqual(
+      expect.arrayContaining(['CategoryBrowser', 'EanCategoryMatcher']),
+    );
+  });
 });
 
 describe('createAllegroPlugin → register(host)', () => {

--- a/libs/integrations/allegro/src/allegro-plugin.ts
+++ b/libs/integrations/allegro/src/allegro-plugin.ts
@@ -74,7 +74,23 @@ export interface CreateAllegroPluginDeps {
 export const allegroAdapterManifest: AdapterMetadata = {
   adapterKey: 'allegro.publicapi.v1',
   platformType: 'allegro',
-  supportedCapabilities: ['OrderSource', 'OfferManager', 'ShippingProviderManager'],
+  // `CategoryBrowser` + `EanCategoryMatcher` are `OfferManager` sub-capabilities
+  // that `AllegroOfferManagerAdapter` implements. They are advertised here — the
+  // same way PrestaShop advertises `ProductPublisher` / `CategoryProvisioner`
+  // (#1367) — so host-side discovery (the connection response's
+  // `supportedCapabilities`) can tell a browsable-taxonomy destination (Allegro:
+  // category tree + per-category parameters) from a borrows-taxonomy one (Erli:
+  // manual category id, no parameter step). Runtime dispatch is unaffected:
+  // both sub-capabilities are resolved by narrowing the `OfferManager` adapter
+  // with `isCategoryBrowser` / `isEanCategoryMatcher`, never via
+  // `getCapabilityAdapter('CategoryBrowser')`, so no dispatch-table entry is needed.
+  supportedCapabilities: [
+    'OrderSource',
+    'OfferManager',
+    'ShippingProviderManager',
+    'CategoryBrowser',
+    'EanCategoryMatcher',
+  ],
   displayName: 'Allegro Public API v1',
   version: '1.0.0',
   isDefault: true,

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -23,6 +23,7 @@ import {
   OfferCreateRejectedException,
   OfferNotFoundOnMarketplaceException,
   isCatalogProductReader,
+  isCategoryBrowser,
   isEanCategoryMatcher,
   isOfferSmartClassificationReader,
   isOfferStatusReader,
@@ -796,6 +797,13 @@ describe('AllegroOfferManagerAdapter', () => {
       // Lock the capability-guard contract: future #736 application service
       // narrows on isEanCategoryMatcher(adapter) to discover this method.
       expect(isEanCategoryMatcher(adapter)).toBe(true);
+    });
+
+    it('declares the CategoryBrowser capability via the runtime guard (#1367)', () => {
+      // Drift-guard for the manifest's advertised `CategoryBrowser` sub-capability
+      // (allegro-plugin.spec.ts): the bulk wizard's browsable-taxonomy signal
+      // trusts the manifest, so the adapter must actually implement fetchCategories.
+      expect(isCategoryBrowser(adapter)).toBe(true);
     });
 
     it('forwards batch input through to the util via the adapter cache + http client', async () => {


### PR DESCRIPTION
## Summary

Bulk offer creation to **Allegro** hid the category-parameter step, so required offer params like `Stan`/Condition could not be set and every offer failed at submit with `PARAMETER_REQUIRED  parameters.Stan`. The single-offer wizard was unaffected — the bug was specific to the bulk flow.

### Root cause

`bulk-wizard.tsx` derived the browsable-vs-borrows split from `.includes()` on the connection's **coarse** `supportedCapabilities` list:

- `destinationBrowsesCategories` (:145) ← `.includes('CategoryBrowser')`
- `destinationResolvesCategoryAtSubmit` (:141) ← `!.includes('EanCategoryMatcher')`

`CategoryBrowser` and `EanCategoryMatcher` are `OfferManager` **sub-capabilities**, and Allegro's manifest never advertised them (`['OrderSource','OfferManager','ShippingProviderManager']`). So `destinationBrowsesCategories` was always `false` for Allegro → `bulk-edit-modal.tsx` took the Erli borrows-taxonomy branch (manual category-id, `ParameterSection` gated out) → no `Stan` field → `OfferBuilderValidationException` at submit.

### Chosen fix (and why)

**Align the Allegro manifest to advertise the OfferManager sub-capabilities its adapter actually implements** (`CategoryBrowser`, `EanCategoryMatcher`).

This is the most convention-consistent fix: PrestaShop and WooCommerce already advertise sub-capability-like entries (`ProductPublisher`, `CategoryProvisioner`) in `supportedCapabilities` for exactly this kind of host-side discovery. The connection response's `supportedCapabilities` is populated straight from the live manifest (`connection.controller.ts:75` → `metadata.supportedCapabilities`), so:

- Both FE `.includes()` checks become correct with **no DB/DTO/migration change** and take effect immediately for existing Allegro connections.
- **Erli stays a borrows destination** — it declares neither sub-capability, so its manual category-id / no-parameter-step branch is unchanged.
- **No `platformType` literal dispatch** is introduced; the discriminator is the declared capability, verified against the adapter's guards.

**Runtime dispatch verified safe:** `CategoryBrowser` / `EanCategoryMatcher` are only ever resolved by resolving `OfferManager` via `getCapabilityAdapter` and narrowing with `isCategoryBrowser` / `isEanCategoryMatcher` (e.g. `categories-cache.service.ts`, `category-resolution.service.ts`, `offer-builder.service.ts`). Nothing calls `getCapabilityAdapter('CategoryBrowser')`, so the `getCapabilityAdapter` gate (`metadata.supportedCapabilities.includes(capability)`) is never hit with these names and **no dispatch-table entry is required**.

> Note on the issue's proposed `taxonomyMode` backend field: that alternative also works, but it adds a new response-DTO field + backend derivation for a signal the manifest already expresses truthfully. The manifest-alignment approach fixes both FE checks at the source with a far smaller surface and matches the established precedent, so the FE keeps reading `supportedCapabilities` — which is now correct rather than always-false.

### Files changed

- `libs/integrations/allegro/src/allegro-plugin.ts` — manifest advertises `CategoryBrowser` + `EanCategoryMatcher`
- `libs/integrations/allegro/src/__tests__/allegro-plugin.spec.ts` — asserts the manifest advertises the pair
- `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts` — drift-guard: adapter implements `isCategoryBrowser` (mirrors existing `isEanCategoryMatcher` lock)
- `apps/web/src/features/listings/components/bulk/bulk-wizard.tsx` — comment documenting the manifest dependency (no logic change needed; the `.includes()` checks are now correct)
- `apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx` — parameter step renders for a browsable destination, hidden for a borrows destination

## Test plan

- Bulk offer to Allegro: pick/resolve a category that requires `Stan` → the category-parameter step renders (matching the single-offer wizard); set `Stan` → offer submits with no `PARAMETER_REQUIRED`.
- Bulk offer to Erli: still shows the manual "Allegro category ID" branch with no parameter step.

## Quality gate

- [x] `pnpm --filter @openlinker/web type-check` — pass (0 errors)
- [x] `pnpm --filter @openlinker/web` bulk tests (`bulk-edit-modal`, `bulk-wizard`) — 21/21 pass
- [x] `pnpm --filter @openlinker/integrations-allegro test` (`allegro-plugin`, `allegro-offer-manager.adapter`) — 122/122 pass
- [x] ESLint on all touched files — 0 errors (only pre-existing `explicit-function-return-type` warnings on test mocks)

Skipped / unrelated: the full `@openlinker/web` vitest run has one pre-existing failure in `settings-page.test.tsx` (asserts an `env.ts` default `http://localhost:3000`), unrelated to this change. Package-scoped `tsc --noEmit` for `@openlinker/integrations-allegro` reports `TS6305` "output not built from source" for upstream `libs/core`/`libs/shared` dist in this fresh worktree — a pre-existing build-state artifact, not introduced here; the jest suites (which resolve from source) pass.

Closes #1367

🤖 Generated with [Claude Code](https://claude.com/claude-code)
