### PR TITLE
fix(infakt): parse inFakt v3 list envelope as items/pagination, not entities/metainfo

### DIFF
--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -111,13 +111,15 @@ export interface InfaktClient {
   country: string | null;
 }
 
-/** Paginated list response shape. */
+/** Paginated list response shape (v3 API — verified live 2026-07-07). */
 export interface InfaktListResponse<T> {
-  entities: T[];
-  metainfo: {
-    total_count: number;
-    next: string | null;
-    previous: string | null;
+  items: T[];
+  pagination: {
+    current_page: number;
+    items_on_page: number;
+    limit: number;
+    total_items: number;
+    total_pages: number;
   };
 }
 

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-tester.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-tester.adapter.spec.ts
@@ -33,7 +33,7 @@ function fakeResponse(ok: boolean, status: number): Response {
   return {
     ok,
     status,
-    text: (): Promise<string> => Promise.resolve(ok ? '{"entities":[]}' : '{"error":"unauthorized"}'),
+    text: (): Promise<string> => Promise.resolve(ok ? '{"items":[]}' : '{"error":"unauthorized"}'),
   } as unknown as Response;
 }
 

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -1162,6 +1162,13 @@ describe('InfaktInvoicingAdapter', () => {
       await expect(adapter.listBankAccounts()).resolves.toEqual([]);
     });
 
+    it('should throw a named InfaktApiError instead of an undefined.map() TypeError when the list envelope has no items array (#1373/#1374 regression guard)', async () => {
+      http.seed('GET', 'bank_accounts.json', { entities: [], metainfo: {} });
+
+      await expect(adapter.listBankAccounts()).rejects.toThrow(InfaktApiError);
+      await expect(adapter.listBankAccounts()).rejects.toThrow(/unexpected envelope shape/);
+    });
+
     it('should PUT the account as default in inFakt', async () => {
       http.seed('PUT', 'bank_accounts/54946.json', {
         id: 54946,

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -146,8 +146,8 @@ describe('InfaktInvoicingAdapter', () => {
         country: null,
       };
       http.seed<InfaktListResponse<InfaktClient>>('GET', 'clients.json', {
-        entities: [existing],
-        metainfo: { total_count: 1, next: null, previous: null },
+        items: [existing],
+        pagination: { current_page: 1, items_on_page: 1, limit: 10, total_items: 1, total_pages: 1 },
       });
 
       const result = await adapter.upsertCustomer({
@@ -162,8 +162,8 @@ describe('InfaktInvoicingAdapter', () => {
 
     it('should create a new client when no NIP match exists (happy path)', async () => {
       http.seed<InfaktListResponse<InfaktClient>>('GET', 'clients.json', {
-        entities: [],
-        metainfo: { total_count: 0, next: null, previous: null },
+        items: [],
+        pagination: { current_page: 1, items_on_page: 0, limit: 10, total_items: 0, total_pages: 1 },
       });
       const created: InfaktClient = {
         id: 2,
@@ -234,8 +234,8 @@ describe('InfaktInvoicingAdapter', () => {
     beforeEach(() => {
       // upsertCustomer -> findClientByNip -> none found -> create
       http.seed<InfaktListResponse<InfaktClient>>('GET', 'clients.json', {
-        entities: [],
-        metainfo: { total_count: 0, next: null, previous: null },
+        items: [],
+        pagination: { current_page: 1, items_on_page: 0, limit: 10, total_items: 0, total_pages: 1 },
       });
       http.seed('POST', 'clients.json', {
         id: 1,
@@ -1049,8 +1049,8 @@ describe('InfaktInvoicingAdapter', () => {
 
     function seedIssueFixtures(): void {
       http.seed<InfaktListResponse<InfaktClient>>('GET', 'clients.json', {
-        entities: [],
-        metainfo: { total_count: 0, next: null, previous: null },
+        items: [],
+        pagination: { current_page: 1, items_on_page: 0, limit: 10, total_items: 0, total_pages: 1 },
       });
       http.seed('POST', 'clients.json', {
         id: 1,
@@ -1128,7 +1128,7 @@ describe('InfaktInvoicingAdapter', () => {
   describe('bank accounts (#1303 follow-up)', () => {
     it('should map the bank-accounts list from snake_case to camelCase, including the default flag', async () => {
       http.seed<InfaktListResponse<InfaktBankAccount>>('GET', 'bank_accounts.json', {
-        entities: [
+        items: [
           {
             id: 1,
             account_number: '61 1140 2004 0000 3002 0135 5387',
@@ -1142,7 +1142,7 @@ describe('InfaktInvoicingAdapter', () => {
             default: true,
           },
         ],
-        metainfo: { total_count: 2, next: null, previous: null },
+        pagination: { current_page: 1, items_on_page: 2, limit: 10, total_items: 2, total_pages: 1 },
       });
 
       const accounts = await adapter.listBankAccounts();
@@ -1155,8 +1155,8 @@ describe('InfaktInvoicingAdapter', () => {
 
     it('should return an empty array when inFakt has no bank accounts configured', async () => {
       http.seed<InfaktListResponse<unknown>>('GET', 'bank_accounts.json', {
-        entities: [],
-        metainfo: { total_count: 0, next: null, previous: null },
+        items: [],
+        pagination: { current_page: 1, items_on_page: 0, limit: 10, total_items: 0, total_pages: 1 },
       });
 
       await expect(adapter.listBankAccounts()).resolves.toEqual([]);
@@ -1187,8 +1187,8 @@ describe('InfaktInvoicingAdapter', () => {
 
     function seedIssueFixtures(): void {
       http.seed<InfaktListResponse<InfaktClient>>('GET', 'clients.json', {
-        entities: [],
-        metainfo: { total_count: 0, next: null, previous: null },
+        items: [],
+        pagination: { current_page: 1, items_on_page: 0, limit: 10, total_items: 0, total_pages: 1 },
       });
       http.seed('POST', 'clients.json', {
         id: 1,

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -316,7 +316,7 @@ export class InfaktInvoicingAdapter
     const response = await this.http.get<InfaktListResponse<InfaktBankAccount>>(
       'bank_accounts.json',
     );
-    return response.entities.map((account) => ({
+    return response.items.map((account) => ({
       id: String(account.id),
       accountNumber: account.account_number,
       bankName: account.bank_name,
@@ -838,7 +838,7 @@ export class InfaktInvoicingAdapter
       const list = await this.http.get<InfaktListResponse<InfaktClient>>('clients.json', {
         nip,
       });
-      return list.entities[0] ?? null;
+      return list.items[0] ?? null;
     } catch {
       return null;
     }

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -313,9 +313,7 @@ export class InfaktInvoicingAdapter
    * being stamped) if one ever falls off the page.
    */
   async listBankAccounts(): Promise<InvoicingBankAccount[]> {
-    const response = await this.http.get<InfaktListResponse<InfaktBankAccount>>(
-      'bank_accounts.json',
-    );
+    const response = await this.getListResponse<InfaktBankAccount>('bank_accounts.json');
     return response.items.map((account) => ({
       id: String(account.id),
       accountNumber: account.account_number,
@@ -835,13 +833,37 @@ export class InfaktInvoicingAdapter
 
   private async findClientByNip(nip: string): Promise<InfaktClient | null> {
     try {
-      const list = await this.http.get<InfaktListResponse<InfaktClient>>('clients.json', {
-        nip,
-      });
+      const list = await this.getListResponse<InfaktClient>('clients.json', { nip });
       return list.items[0] ?? null;
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Thin regression guard against a repeat of the #1373/#1374 envelope-shape
+   * drift: `listBankAccounts`/`findClientByNip` both previously read
+   * `response.entities` against a list endpoint that actually returns
+   * `{ items, pagination }`, so a missing `items` array surfaced as an
+   * `undefined.map()` `TypeError` — indistinguishable, once the controller
+   * masks it into a generic 502, from an unreachable provider. Failing loudly
+   * here with a named, path-specific `InfaktApiError` means a FUTURE wire-shape
+   * drift logs a clear cause (`toProviderBadGateway` logs the thrown error's
+   * message) instead of a bare "Cannot read properties of undefined".
+   */
+  private async getListResponse<T>(
+    path: string,
+    query?: Record<string, string>,
+  ): Promise<InfaktListResponse<T>> {
+    const response = await this.http.get<InfaktListResponse<T>>(path, query);
+    if (!response || !Array.isArray(response.items)) {
+      throw new InfaktApiError(
+        `Infakt ${path} returned an unexpected envelope shape (expected { items: [...] })`,
+        502,
+        response,
+      );
+    }
+    return response;
   }
 
   /**


### PR DESCRIPTION
## Summary

- `InfaktListResponse<T>` was typed/consumed as `{ entities, metainfo }`, but the real inFakt v3 API returns `{ items, pagination }` (verified live against the API).
- `InfaktInvoicingAdapter.listBankAccounts()` did `response.entities.map(...)` → `entities` was `undefined` → `TypeError` → caught by `InvoicingController.getBankAccounts` and rewritten into a generic `BadGatewayException`, which the FE renders as "Couldn't check inFakt for bank accounts…" even though the account genuinely has bank accounts configured.
- Same wrong envelope shape was also used by `findClientByNip()` (NIP lookup during `upsertCustomer`).
- Fixed the type + both call sites, updated the unit test fixtures that seeded the old (incorrect) envelope shape.

Closes #1373

## Test plan

- [x] `pnpm --filter @openlinker/integrations-infakt test` — 168/168 pass
- [x] `pnpm --filter @openlinker/integrations-infakt type-check` — clean
- [x] `pnpm eslint` on touched files — clean
- [x] Verified live against the real inFakt API that list endpoints return `{ items, pagination }`, not `{ entities, metainfo }`