### PR TITLE
feat(demo): parameterize domain/secret env vars via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,48 @@
 # Generate a fresh value with:
 #   openssl rand -base64 32
 OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=
+
+# ---------------------------------------------------------------------------
+# OPTIONAL — every value below has a working localhost-only default baked
+# into docker-compose.yml / docker-compose.demo.yml. Leave commented out for
+# a plain local `pnpm demo:up`. Uncomment and set when deploying behind a
+# real domain (reverse proxy + TLS) instead of localhost, or when hardening
+# beyond local evaluation — none of the defaults are production-safe.
+# ---------------------------------------------------------------------------
+
+# Public browser-facing origin the UI is served from. Must match exactly
+# (scheme + host) or the API rejects the browser's requests with a CORS
+# error. Default: http://localhost:8090
+# OL_CORS_ORIGIN=https://app.example.com
+
+# API origin reachable from the operator's BROWSER — baked into the web
+# bundle at IMAGE BUILD TIME (Vite), not read at container start. Changing
+# this requires `--build` on the web image, not just a restart.
+# Default: http://localhost:3000
+# VITE_API_BASE_URL=https://api.example.com
+
+# Canonical PrestaShop shop domain, baked into generated links/redirects.
+# This is the PUBLIC domain the operator's browser opens — it is unrelated
+# to how the api/worker containers reach PrestaShop internally, which is
+# always the compose service name (http://prestashop) regardless of this
+# value. Default: localhost:8080
+# PS_DOMAIN=shop.example.com
+
+# Seeded admin password (api's OL_BOOTSTRAP_ADMIN_PASSWORD). The default
+# admin/admin login must not be exposed beyond localhost.
+# Default: admin
+# OL_BOOTSTRAP_ADMIN_PASSWORD=
+
+# JWT signing secret. The default is a throwaway dev value — rotate before
+# any non-local exposure.
+# Default: development-secret-key-change-in-production
+# JWT_SECRET=
+
+# Access-token lifetime (e.g. 15m, 1h, 1d). Default: 1d
+# JWT_EXPIRES_IN=
+
+# Salt used to hash customer PII during order ingestion (api + worker share
+# this value). The default is a throwaway dev value — rotate before any
+# non-local exposure.
+# Default: development-pii-hash-salt-change-in-production
+# OL_PII_HASH_SALT=

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -26,14 +26,18 @@ services:
       # predictable admin/admin because OL_BOOTSTRAP_ADMIN_PASSWORD is set
       # explicitly — under NODE_ENV=production BootstrapAdminService would
       # otherwise generate a random password (apps/api/src/auth/
-      # bootstrap-admin.service.ts).
+      # bootstrap-admin.service.ts). Override in .env before exposing this
+      # beyond localhost — admin/admin is a throwaway demo default, not a
+      # production-safe credential.
       NODE_ENV: production
-      OL_BOOTSTRAP_ADMIN_PASSWORD: admin
+      OL_BOOTSTRAP_ADMIN_PASSWORD: '${OL_BOOTSTRAP_ADMIN_PASSWORD:-admin}'
       # CORS allow-list must include the browser origin the web UI is served
       # from (the `web` service publishes :8090), or login fails with a
       # "NetworkError when attempting to fetch resource" (#1368). The API
-      # default is only http://localhost:4173 (apps/api/src/main.ts).
-      OL_CORS_ORIGIN: http://localhost:8090
+      # default is only http://localhost:4173 (apps/api/src/main.ts). Override
+      # in .env with the real public origin (e.g. https://app.example.com)
+      # when serving the UI from a domain other than localhost:8090.
+      OL_CORS_ORIGIN: '${OL_CORS_ORIGIN:-http://localhost:8090}'
       # Required by migration 1795000000000-encrypt-integration-credentials and
       # for decrypting connection credentials at runtime. Operator-supplied via
       # .env (see .env.example); `:?` fails the boot with a clear message if unset.
@@ -72,8 +76,10 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       # Required by shared PII config (libs/shared/src/config/pii-config.ts) —
-      # order-ingestion jobs hash customer identifiers in the worker.
-      OL_PII_HASH_SALT: development-pii-hash-salt-change-in-production
+      # order-ingestion jobs hash customer identifiers in the worker. Same
+      # variable as the api service's (docker-compose.yml) — override once in
+      # .env to keep both in sync.
+      OL_PII_HASH_SALT: '${OL_PII_HASH_SALT:-development-pii-hash-salt-change-in-production}'
       # Same encryption key the api/migrate services use — the worker decrypts
       # connection credentials when running sync jobs (#1368).
       OPENLINKER_CREDENTIALS_ENCRYPTION_KEY: '${OPENLINKER_CREDENTIALS_ENCRYPTION_KEY:?set OPENLINKER_CREDENTIALS_ENCRYPTION_KEY in .env (see .env.example) - generate with: openssl rand -base64 32}'
@@ -92,7 +98,10 @@ services:
       args:
         # Build-time (Vite) — must be the API origin reachable from the
         # operator's BROWSER, hence localhost, not the compose service name.
-        VITE_API_BASE_URL: http://localhost:3000
+        # Baked into the bundle at build time: overriding this in .env only
+        # takes effect on the NEXT `--build` (e.g. https://api.example.com
+        # for a public-domain deployment), not on a plain `up`/restart.
+        VITE_API_BASE_URL: '${VITE_API_BASE_URL:-http://localhost:3000}'
     container_name: openlinker-web
     ports:
       # 8080 = PrestaShop, 8081 = phpMyAdmin, 8082 = WooCommerce

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,9 @@ services:
     # alphabetically after the installer completes. Use `pnpm dev:stack:seed-prestashop`
     # to re-run them mid-development without recreating the volume.
     environment:
-      PS_DOMAIN: localhost:8080
+      # Canonical shop domain PrestaShop bakes into generated links/redirects.
+      # Override in .env for a public-domain deployment (e.g. shop.example.com).
+      PS_DOMAIN: '${PS_DOMAIN:-localhost:8080}'
       PS_FOLDER_ADMIN: admin
       PS_COUNTRY: US
       PS_LANGUAGE: en
@@ -201,9 +203,11 @@ services:
       DB_DATABASE: openlinker
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      JWT_SECRET: development-secret-key-change-in-production
-      JWT_EXPIRES_IN: 1d
-      OL_PII_HASH_SALT: development-pii-hash-salt-change-in-production
+      # Override every one of these in .env for anything beyond local
+      # dev/demo use — the defaults are throwaway values, not secrets.
+      JWT_SECRET: '${JWT_SECRET:-development-secret-key-change-in-production}'
+      JWT_EXPIRES_IN: '${JWT_EXPIRES_IN:-1d}'
+      OL_PII_HASH_SALT: '${OL_PII_HASH_SALT:-development-pii-hash-salt-change-in-production}'
     ports:
       - '3000:3000'
     depends_on:


### PR DESCRIPTION
## Summary

Follow-up to the demo boot fixes (#1369/#1372). Makes the demo devops-ready for a real public-domain deployment (reverse proxy + TLS instead of localhost) by wiring the following through `${VAR:-default}` interpolation instead of hardcoded literals:

- `OL_CORS_ORIGIN` — browser origin the UI is served from (api)
- `VITE_API_BASE_URL` — API origin baked into the web bundle at build time
- `PS_DOMAIN` — PrestaShop's public canonical domain
- `OL_BOOTSTRAP_ADMIN_PASSWORD` — seeded admin password
- `JWT_SECRET`, `JWT_EXPIRES_IN` — token signing
- `OL_PII_HASH_SALT` — customer-identifier hashing salt (api + worker)

Every default is today's exact literal value, so `pnpm demo:up` / `pnpm dev:stack:up` with no `.env` changes has **zero behavior change**. Unlike `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` (`${VAR:?required}` — no safe default exists for an encryption key), all of these have a working local default and are optional overrides.

`.env.example` gains a clearly-separated, commented-out **OPTIONAL** section documenting each variable's purpose, default, and (for `VITE_API_BASE_URL`) the build-time caveat.

Also documents that `PS_DOMAIN` is the *public browser-facing* domain only — it's independent of how `api`/`worker` reach PrestaShop internally (always the compose service name, `http://prestashop`), which is a common point of confusion when moving from localhost to a real domain.

## Test plan

Verified both ends of the interpolation with `docker compose config`:
- With only `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` set (no other env) → every parameterized value renders as today's exact default (`http://localhost:8090`, `http://localhost:3000`, `localhost:8080`, `admin`, `development-secret-key-change-in-production`, `1d`, `development-pii-hash-salt-change-in-production`).
- With all seven env vars set to example override values → every one renders as the overridden value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)