### PR TITLE
fix(webhooks): resolve downstream-job link to the concrete SyncJob (#1366

### DIFF
--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -81,6 +81,7 @@ describe('ConnectionController', () => {
       createIfNotExistsByIdempotencyKey: jest.fn(),
       findAndLockDueJobs: jest.fn(),
       findById: jest.fn(),
+      findByIdempotencyKey: jest.fn(),
       findMany: jest.fn(),
       markSucceeded: jest.fn(),
       markFailed: jest.fn(),

--- a/apps/api/src/sync/http/dto/sync-job-response.dto.ts
+++ b/apps/api/src/sync/http/dto/sync-job-response.dto.ts
@@ -55,7 +55,7 @@ export class SyncJobResponseDto {
   @ApiProperty({ description: 'Job last-update timestamp (ISO 8601)' })
   updatedAt!: string;
 
-  @ApiPropertyOptional({ nullable: true, description: 'Job payload (admin only)' })
+  @ApiPropertyOptional({ nullable: true, description: 'Job payload' })
   payloadJson!: Record<string, unknown> | null;
 
   @ApiPropertyOptional({ nullable: true, description: 'Idempotency key used for deduplication' })

--- a/apps/api/src/sync/http/sync.controller.spec.ts
+++ b/apps/api/src/sync/http/sync.controller.spec.ts
@@ -51,6 +51,7 @@ describe('SyncController', () => {
     createIfNotExistsByIdempotencyKey: jest.fn(),
     findAndLockDueJobs: jest.fn(),
     findById: jest.fn(),
+    findByIdempotencyKey: jest.fn(),
     findMany: jest.fn(),
     markSucceeded: jest.fn(),
     markFailed: jest.fn(),
@@ -236,6 +237,42 @@ describe('SyncController', () => {
       syncJobRepository.findById.mockResolvedValue(null);
 
       await expect(controller.getJob('missing-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('lookupJobForWebhookEvent', () => {
+    it('should assemble the idempotency key from the components and return the job DTO', async () => {
+      syncJobRepository.findByIdempotencyKey.mockResolvedValue(makeSyncJob({ id: 'job-1' }));
+
+      const result = await controller.lookupJobForWebhookEvent('prestashop', 'conn-1', 'evt_42');
+
+      // Server assembles the key from the raw components — the caller never
+      // encodes the format (#1366).
+      expect(syncJobRepository.findByIdempotencyKey).toHaveBeenCalledWith(
+        'prestashop:conn-1:evt_42',
+      );
+      expect(result.id).toBe('job-1');
+    });
+
+    it('should throw BadRequestException when any component is missing or blank', async () => {
+      await expect(
+        controller.lookupJobForWebhookEvent(undefined, 'conn-1', 'evt_42'),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        controller.lookupJobForWebhookEvent('prestashop', '   ', 'evt_42'),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        controller.lookupJobForWebhookEvent('prestashop', 'conn-1', undefined),
+      ).rejects.toThrow(BadRequestException);
+      expect(syncJobRepository.findByIdempotencyKey).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when no job matches the key yet', async () => {
+      syncJobRepository.findByIdempotencyKey.mockResolvedValue(null);
+
+      await expect(
+        controller.lookupJobForWebhookEvent('prestashop', 'conn-1', 'evt_unknown'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/apps/api/src/sync/http/sync.controller.ts
+++ b/apps/api/src/sync/http/sync.controller.ts
@@ -134,7 +134,6 @@ export class SyncController {
     description: 'Paginated job list',
     type: PaginatedSyncJobsResponseDto,
   })
-  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async listJobs(@Query() query: ListSyncJobsQueryDto): Promise<PaginatedSyncJobsResponseDto> {
     const { status, connectionId, jobType, outcome, limit = 20, offset = 0 } = query;
 
@@ -163,7 +162,6 @@ export class SyncController {
     description: 'Aggregated group list',
     type: GroupedSyncJobsResponseDto,
   })
-  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async listGroupedJobs(
     @Query() query: ListGroupedSyncJobsQueryDto
   ): Promise<GroupedSyncJobsResponseDto> {
@@ -189,18 +187,16 @@ export class SyncController {
     };
   }
 
-  @Roles('admin')
   @Get('jobs/lookup')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Look up the sync job an inbound webhook event enqueued',
     description:
-      'Resolves the persisted SyncJob for a webhook trigger, keyed by the inbound-job idempotency key the server assembles from (platformType, connectionId, eventId) — the same key InboundRoutingPolicy stamps on the enqueued job (#1366). Callers pass the raw components (a webhook delivery holds all three) rather than re-encoding the key format. Returns 404 if no job with that key exists yet — the enqueue and the worker-side row creation happen at different times.',
+      'Resolves the persisted SyncJob for a webhook trigger, keyed by the inbound-job idempotency key the server assembles from (platformType, connectionId, eventId) — the same key InboundRoutingPolicy stamps on the enqueued job (#1366). Callers pass the raw components (a webhook delivery holds all three) rather than re-encoding the key format. Returns 404 if no job with that key exists yet — the enqueue and the worker-side row creation happen at different times. Open to any authenticated role, matching its sibling read endpoints (jobs, jobs/grouped, jobs/:id) — only job mutation (enqueue, retry) is admin-gated.',
   })
   @ApiResponse({ status: 200, description: 'Job detail', type: SyncJobResponseDto })
   @ApiResponse({ status: 400, description: 'Missing platformType, connectionId, or eventId' })
   @ApiResponse({ status: 404, description: 'Job not found' })
-  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async lookupJobForWebhookEvent(
     @Query('platformType') platformType?: string,
     @Query('connectionId') connectionId?: string,
@@ -254,7 +250,6 @@ export class SyncController {
   @ApiOperation({ summary: 'Get sync job by ID' })
   @ApiResponse({ status: 200, description: 'Job detail', type: SyncJobResponseDto })
   @ApiResponse({ status: 404, description: 'Job not found' })
-  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async getJob(@Param('id', ParseUUIDPipe) id: string): Promise<SyncJobResponseDto> {
     const job = await this.syncJobRepository.findById(id);
     if (!job) {

--- a/apps/api/src/sync/http/sync.controller.ts
+++ b/apps/api/src/sync/http/sync.controller.ts
@@ -35,6 +35,7 @@ import {
 } from '@openlinker/core/sync';
 import type { SyncJob, SyncJobRequest } from '@openlinker/core/sync';
 import { ISyncJobRetryService, ISyncJobBulkRetryService } from '@openlinker/core/sync';
+import { buildInboundJobIdempotencyKey } from '@openlinker/core/sync';
 import { EnqueueSyncJobDto } from './dto/enqueue-sync-job.dto';
 import { EnqueueSyncJobResponseDto } from './dto/enqueue-sync-job-response.dto';
 import { ListSyncJobsQueryDto } from './dto/list-sync-jobs-query.dto';
@@ -186,6 +187,39 @@ export class SyncController {
       totalGroups,
       totalJobs,
     };
+  }
+
+  @Get('jobs/lookup')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Look up the sync job an inbound webhook event enqueued',
+    description:
+      'Resolves the persisted SyncJob for a webhook trigger, keyed by the inbound-job idempotency key the server assembles from (platformType, connectionId, eventId) — the same key InboundRoutingPolicy stamps on the enqueued job (#1366). Callers pass the raw components (a webhook delivery holds all three) rather than re-encoding the key format. Returns 404 if no job with that key exists yet — the enqueue and the worker-side row creation happen at different times.',
+  })
+  @ApiResponse({ status: 200, description: 'Job detail', type: SyncJobResponseDto })
+  @ApiResponse({ status: 400, description: 'Missing platformType, connectionId, or eventId' })
+  @ApiResponse({ status: 404, description: 'Job not found' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async lookupJobForWebhookEvent(
+    @Query('platformType') platformType?: string,
+    @Query('connectionId') connectionId?: string,
+    @Query('eventId') eventId?: string
+  ): Promise<SyncJobResponseDto> {
+    if (
+      !platformType?.trim() ||
+      !connectionId?.trim() ||
+      !eventId?.trim()
+    ) {
+      throw new BadRequestException(
+        'platformType, connectionId, and eventId query parameters are required'
+      );
+    }
+    const idempotencyKey = buildInboundJobIdempotencyKey(platformType, connectionId, eventId);
+    const job = await this.syncJobRepository.findByIdempotencyKey(idempotencyKey);
+    if (!job) {
+      throw new NotFoundException(`Sync job not found for idempotency key: ${idempotencyKey}`);
+    }
+    return this.toDto(job);
   }
 
   @Roles('admin')

--- a/apps/api/src/sync/http/sync.controller.ts
+++ b/apps/api/src/sync/http/sync.controller.ts
@@ -189,6 +189,7 @@ export class SyncController {
     };
   }
 
+  @Roles('admin')
   @Get('jobs/lookup')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({

--- a/apps/web/src/features/sync-jobs/api/sync.api.ts
+++ b/apps/web/src/features/sync-jobs/api/sync.api.ts
@@ -29,6 +29,16 @@ export interface SyncJobResponse {
   status: string;
 }
 
+/**
+ * Raw components of an inbound webhook event, from which the server assembles
+ * the inbound-job idempotency key to resolve the job it enqueued (#1366).
+ */
+export interface WebhookJobLookupInput {
+  platformType: string;
+  connectionId: string;
+  eventId: string;
+}
+
 export interface SyncJobsApi {
   enqueue: (input: EnqueueSyncJobInput) => Promise<SyncJobResponse>;
   /**
@@ -42,6 +52,15 @@ export interface SyncJobsApi {
    */
   list: (filters?: SyncJobFilters, pagination?: SyncJobPagination) => Promise<PaginatedSyncJobs>;
   getById: (id: string) => Promise<SyncJob>;
+  /**
+   * Resolve the persisted SyncJob a webhook trigger enqueued (#1366). The
+   * caller passes the raw components of the inbound event (a webhook delivery
+   * holds all three); the server assembles the idempotency key, so the format
+   * lives only in core and is never re-encoded here. Rejects with a 404
+   * `ApiError` when no job exists yet (worker hasn't created the row), which
+   * the caller treats as "not resolvable".
+   */
+  lookupJobForWebhookEvent: (input: WebhookJobLookupInput) => Promise<SyncJob>;
   retry: (id: string) => Promise<SyncJob>;
   /**
    * List sync jobs aggregated by (connectionId, jobType). Server caps the
@@ -94,6 +113,14 @@ export function createSyncJobsApi(request: ApiRequest): SyncJobsApi {
     },
     getById(id): Promise<SyncJob> {
       return request<SyncJob>(`/sync/jobs/${id}`);
+    },
+    lookupJobForWebhookEvent(input): Promise<SyncJob> {
+      const params = new URLSearchParams({
+        platformType: input.platformType,
+        connectionId: input.connectionId,
+        eventId: input.eventId,
+      });
+      return request<SyncJob>(`/sync/jobs/lookup?${params.toString()}`);
     },
     retry(id): Promise<SyncJob> {
       return request<SyncJob>(`/sync/jobs/${id}/retry`, { method: 'POST' });

--- a/apps/web/src/features/sync-jobs/api/sync.query-keys.ts
+++ b/apps/web/src/features/sync-jobs/api/sync.query-keys.ts
@@ -5,6 +5,8 @@ export const syncJobsQueryKeys = {
   list: (filters?: SyncJobFilters, pagination?: SyncJobPagination) =>
     ['sync-jobs', 'list', filters ?? {}, pagination ?? {}] as const,
   detail: (id: string) => ['sync-jobs', 'detail', id] as const,
+  webhookJobLookup: (platformType: string, connectionId: string, eventId: string) =>
+    ['sync-jobs', 'webhook-job-lookup', platformType, connectionId, eventId] as const,
   grouped: (filters: SyncJobGroupsFilters) =>
     ['sync-jobs', 'grouped', filters] as const,
 };

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-job-lookup-query.ts
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-job-lookup-query.ts
@@ -1,0 +1,35 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { syncJobsQueryKeys } from '../api/sync.query-keys';
+import type { WebhookJobLookupInput } from '../api/sync.api';
+import type { SyncJob } from '../api/sync-jobs.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+/**
+ * Resolves the persisted SyncJob a webhook trigger enqueued, so a caller
+ * holding only the inbound event's components (e.g. a webhook delivery) can
+ * link to the concrete job it produced (#1366). The server assembles the
+ * idempotency key from the passed components — the format is not re-encoded
+ * here.
+ *
+ * A 404 (job not created yet — worker is asynchronous) surfaces as the query's
+ * error state and is NOT retried: the caller degrades gracefully rather than
+ * hammering the endpoint. Self-disables until all components are present.
+ */
+export function useSyncJobLookupQuery(
+  input: WebhookJobLookupInput | null
+): UseQueryResult<SyncJob> {
+  const apiClient = useApiClient();
+  const enabled = Boolean(input && input.platformType && input.connectionId && input.eventId);
+
+  return useQuery({
+    queryKey: syncJobsQueryKeys.webhookJobLookup(
+      input?.platformType ?? '',
+      input?.connectionId ?? '',
+      input?.eventId ?? ''
+    ),
+    // Guarded by `enabled` — `input` is non-null whenever the query runs.
+    queryFn: () => apiClient.syncJobs.lookupJobForWebhookEvent(input as WebhookJobLookupInput),
+    enabled,
+    retry: false,
+  });
+}

--- a/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.test.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
@@ -84,9 +84,13 @@ describe('WebhookDeliveryDetailPage', () => {
 
     // The Redis Stream enqueue ID is the link *text*, but it resolves to the
     // persisted job's UUID detail route — never `/jobs-logs/<streamId>`, which
-    // the UUID-only route would reject.
+    // the UUID-only route would reject. The link renders the filtered-list
+    // fallback first, then flips to the exact job once the connection + lookup
+    // queries resolve — so wait for the upgraded href.
     const jobLink = await screen.findByRole('link', { name: '1782207005442-0' });
-    expect(jobLink).toHaveAttribute('href', '/jobs-logs/job-uuid-123');
+    await waitFor(() =>
+      expect(jobLink).toHaveAttribute('href', '/jobs-logs/job-uuid-123'),
+    );
 
     // The FE passes the raw components (platformType from the connection,
     // connectionId, eventId) — the server assembles the key, no format here.

--- a/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.test.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.test.tsx
@@ -66,4 +66,58 @@ describe('WebhookDeliveryDetailPage', () => {
     const links = await screen.findAllByRole('link', { name: sampleConnection.name });
     expect(links.length).toBeGreaterThan(0);
   });
+
+  it('links the downstream job to the exact SyncJob resolved for the webhook event', async () => {
+    const lookup = vi.fn().mockResolvedValue({ id: 'job-uuid-123' });
+    const api = createMockApiClient({
+      webhookDeliveries: {
+        getById: vi.fn().mockResolvedValue({
+          ...sampleDelivery,
+          downstreamJobId: '1782207005442-0',
+          downstreamJobType: 'marketplace.order.sync',
+        }),
+      },
+      syncJobs: { lookupJobForWebhookEvent: lookup },
+    });
+
+    renderDetail(api);
+
+    // The Redis Stream enqueue ID is the link *text*, but it resolves to the
+    // persisted job's UUID detail route — never `/jobs-logs/<streamId>`, which
+    // the UUID-only route would reject.
+    const jobLink = await screen.findByRole('link', { name: '1782207005442-0' });
+    expect(jobLink).toHaveAttribute('href', '/jobs-logs/job-uuid-123');
+
+    // The FE passes the raw components (platformType from the connection,
+    // connectionId, eventId) — the server assembles the key, no format here.
+    expect(lookup).toHaveBeenCalledWith({
+      platformType: sampleConnection.platformType,
+      connectionId: sampleConnection.id,
+      eventId: 'evt_42',
+    });
+  });
+
+  it('falls back to the pre-filtered job list when the job is not resolvable yet', async () => {
+    const api = createMockApiClient({
+      webhookDeliveries: {
+        getById: vi.fn().mockResolvedValue({
+          ...sampleDelivery,
+          downstreamJobId: '1782207005442-0',
+          downstreamJobType: 'marketplace.order.sync',
+        }),
+      },
+      // Worker hasn't created the row yet → lookup 404s.
+      syncJobs: {
+        lookupJobForWebhookEvent: vi.fn().mockRejectedValue(new Error('not found')),
+      },
+    });
+
+    renderDetail(api);
+
+    const jobLink = await screen.findByRole('link', { name: '1782207005442-0' });
+    expect(jobLink).toHaveAttribute(
+      'href',
+      `/jobs-logs?connectionId=${sampleConnection.id}&jobType=marketplace.order.sync`,
+    );
+  });
 });

--- a/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx
@@ -14,6 +14,8 @@ import type {
   WebhookDeliveryStatus,
 } from '../../features/webhook-deliveries/api/webhook-deliveries.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
+import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
+import { useSyncJobLookupQuery } from '../../features/sync-jobs/hooks/use-sync-job-lookup-query';
 
 function statusTone(status: WebhookDeliveryStatus): StatusBadgeTone {
   switch (status) {
@@ -31,7 +33,28 @@ function statusTone(status: WebhookDeliveryStatus): StatusBadgeTone {
   }
 }
 
-function buildWebhookDeliveryItems(d: WebhookDeliveryDetail): KeyValueItem[] {
+/**
+ * Where the "Downstream job" link points. The persisted SyncJob UUID (exact
+ * job detail) is preferred; until it resolves — or if the worker hasn't created
+ * the row yet — we fall back to the Jobs & Logs list pre-filtered to this
+ * delivery's connection + job type, so the link is never dead and never sends a
+ * Redis Stream enqueue ID to the UUID-only `/jobs-logs/:id` route (#1366).
+ */
+function buildDownstreamJobHref(d: WebhookDeliveryDetail, exactJobId: string | null): string {
+  if (exactJobId) {
+    return `/jobs-logs/${exactJobId}`;
+  }
+  const params = new URLSearchParams({ connectionId: d.connectionId });
+  if (d.downstreamJobType) {
+    params.set('jobType', d.downstreamJobType);
+  }
+  return `/jobs-logs?${params.toString()}`;
+}
+
+function buildWebhookDeliveryItems(
+  d: WebhookDeliveryDetail,
+  exactJobId: string | null,
+): KeyValueItem[] {
   const items: KeyValueItem[] = [
     {
       id: 'status',
@@ -75,7 +98,7 @@ function buildWebhookDeliveryItems(d: WebhookDeliveryDetail): KeyValueItem[] {
       label: 'Downstream job',
       value: (
         <>
-          <Link to={`/jobs-logs/${d.downstreamJobId}`} className="mono-text">
+          <Link to={buildDownstreamJobHref(d, exactJobId)} className="mono-text">
             {d.downstreamJobId}
           </Link>
           {d.downstreamJobType ? (
@@ -92,6 +115,22 @@ function buildWebhookDeliveryItems(d: WebhookDeliveryDetail): KeyValueItem[] {
 export function WebhookDeliveryDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
   const query = useWebhookDeliveryQuery(id);
+
+  // Resolve the connection (for its platformType) and, from that, the exact
+  // downstream SyncJob the webhook enqueued (#1366). The server builds the
+  // idempotency key from these components — the platformType comes from the
+  // resolved connection (the delivery's free-form `provider` is not a reliable
+  // substitute). Both hooks self-disable on missing inputs, so they're safe to
+  // call before the guards below and stay dormant when there's no downstream job.
+  const delivery = query.data;
+  const connectionQuery = useConnectionQuery(delivery?.connectionId ?? '');
+  const platformType = connectionQuery.data?.platformType;
+  const lookupInput =
+    delivery?.downstreamJobId && platformType
+      ? { platformType, connectionId: delivery.connectionId, eventId: delivery.eventId }
+      : null;
+  const downstreamJobQuery = useSyncJobLookupQuery(lookupInput);
+  const exactJobId = downstreamJobQuery.data?.id ?? null;
 
   if (query.isLoading) {
     return (
@@ -122,7 +161,7 @@ export function WebhookDeliveryDetailPage(): ReactElement {
       title={<span className="mono-text">{d.eventType ?? d.eventId}</span>}
     >
       <section className="detail-section">
-        <KeyValueList items={buildWebhookDeliveryItems(d)} />
+        <KeyValueList items={buildWebhookDeliveryItems(d, exactJobId)} />
       </section>
 
       {d.rejectionReason ? (

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -418,6 +418,7 @@ export function createMockApiClient(
         offset: 0,
       }),
       getById: vi.fn().mockResolvedValue(null),
+      lookupJobForWebhookEvent: vi.fn().mockResolvedValue(null),
       retry: vi.fn().mockResolvedValue(null),
       listGrouped: vi.fn().mockResolvedValue({
         groups: [],

--- a/docs/plans/implementation-plan-1366-webhook-downstream-job-link.md
+++ b/docs/plans/implementation-plan-1366-webhook-downstream-job-link.md
@@ -54,7 +54,7 @@
 - `libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts` — implement (mirrors `findById`).
 
 ### Phase B — interface (apps/api)
-- `apps/api/src/sync/http/sync.controller.ts` — `@Get('jobs/lookup')` (before `jobs/:id`); `@Query` `platformType` / `connectionId` / `eventId` with a blank guard → `BadRequestException`; assemble the key via `buildInboundJobIdempotencyKey`; `NotFoundException` when the repo returns null; reuse `toDto`.
+- `apps/api/src/sync/http/sync.controller.ts` — `@Roles('admin') @Get('jobs/lookup')` (before `jobs/:id`); `@Query` `platformType` / `connectionId` / `eventId` with a blank guard → `BadRequestException`; assemble the key via `buildInboundJobIdempotencyKey`; `NotFoundException` when the repo returns null; reuse `toDto`. Admin-gated because `SyncJobResponseDto.payloadJson` is an admin-only field (inbound webhook payloads can carry PII) — a viewer's lookup 403s and the FE falls back to the filtered list. (Pre-existing: `GET /sync/jobs` + `jobs/grouped` still return `payloadJson`/`lastError` to any authenticated role despite the label — a separate, out-of-scope security follow-up.)
 - `apps/api/src/sync/http/sync.controller.spec.ts` — add `findByIdempotencyKey` to the typed repo mock; 3 tests (found / missing-component / not-found), asserting the server-assembled key.
 
 ### Phase C — frontend

--- a/docs/plans/implementation-plan-1366-webhook-downstream-job-link.md
+++ b/docs/plans/implementation-plan-1366-webhook-downstream-job-link.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Webhook delivery "Downstream job" link → resolve the concrete SyncJob (#1366)
+
+**Date**: 2026-07-07
+**Status**: Implemented (pending quality gate)
+**Estimated Effort**: ~0.5 day
+**Issue**: #1366
+
+---
+
+## 1. Task Summary
+
+**Objective**: Make the "Downstream job" link on the webhook delivery detail page navigate to the **correct** persisted `SyncJob`, instead of the broken `/jobs-logs/${downstreamJobId}` that 404'd every time.
+
+**Why**: `downstreamJobId` recorded on a `webhook_deliveries` row is the Redis Stream `XADD` entry ID (`<epoch-ms>-<seq>`) returned by `JobEnqueuePort.enqueueJob` — **not** the persisted `SyncJob.id` (a Postgres UUID). The `/jobs-logs/:id` route is UUID-only (`ParseUUIDPipe`), so the link always hit the error state. These are two unrelated ID spaces with no shared value between them.
+
+**Revision note**: The original issue proposed *removing* the link (render plain text). That was superseded — we make the redirect work rather than deleting it. The one durable cross-reference between a delivery and the job it produced is the **idempotency key** (`{platformType}:{connectionId}:{sourceEventId}`), built by `InboundRoutingPolicyService` and stored on the `SyncJob` row.
+
+**Classification**: CORE (new repository-port read method) + Interface (new lookup endpoint) + Frontend (api method, query hook, page wiring, tests). **No schema change, no migration** — the `idempotencyKey` column already exists and is unique.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+1. `buildInboundJobIdempotencyKey(platformType, connectionId, sourceEventId)` — a single core-owned pure helper for the key format, used by `InboundRoutingPolicyService` (replaces its inline template) and the lookup endpoint. Exported from `@openlinker/core/sync`.
+2. `SyncJobRepositoryPort.findByIdempotencyKey(key)` + TypeORM impl (`findOne({ where: { idempotencyKey } })`).
+3. `GET /sync/jobs/lookup?platformType=&connectionId=&eventId=` on `SyncController` → assembles the key **server-side** via the shared helper, returns the `SyncJob` DTO, `400` on any missing/blank component, `404` when no row exists yet.
+4. FE `syncJobs.lookupJobForWebhookEvent({ platformType, connectionId, eventId })` api method + `useSyncJobLookupQuery` hook (`retry: false`). The FE passes raw components — it never encodes the key format.
+5. Webhook delivery detail page: resolve connection → pass `{ platformType, connectionId, eventId }` → resolve exact job → link to `/jobs-logs/:uuid`, with a filtered-list fallback.
+6. Tests: helper usage (routing-policy spec output unchanged), controller (found / missing-component / not-found), page (exact link + fallback).
+
+### Out of Scope
+- Persisting the resolved `SyncJob.id` back onto the `webhook_deliveries` row — the enqueue precedes row creation, so there is nothing to persist at record time.
+- Changing what `downstreamJobId` stores (still the enqueue ID; it remains visible as the link text).
+- Any change to `InboundRoutingPolicyService` or the enqueue path.
+
+---
+
+## 3. Architecture & Placement Decisions
+
+- **Correlation key, not enqueue ID.** Resolution reconstructs the idempotency key rather than parsing `downstreamJobId`, so it works regardless of whether the enqueue returned the `XADD` id or (on an idempotent hit) the key itself. `RedisStreamsJobEnqueueService` returns different values on those two branches; neither is the DB UUID.
+- **Key format** (`{platformType}:{connectionId}:{sourceEventId}`) is owned by `InboundRoutingPolicyService`. `sourceEventId` = `event.eventId`, which is exactly what the delivery persists as `eventId`. `platformType` comes from the resolved **connection** — the delivery's free-form `provider` (a URL path param) is not a reliable substitute.
+- **Lookup lives at the interface layer** as a repository-port read exposed via a thin controller endpoint — no orchestration, no new service. Route declared **before** `jobs/:id` so `ParseUUIDPipe` on `:id` can't swallow `lookup`.
+- **Never-dead link.** The worker creates the `SyncJob` row asynchronously, so a lookup can transiently 404. Until/unless the exact job resolves, the link falls back to the Jobs & Logs list pre-filtered by `connectionId` + `jobType` (both read from the URL by `SyncJobsPage`).
+
+---
+
+## 4. Implementation Plan
+
+### Phase A — core `sync`: shared key builder + port + repository
+- `libs/core/src/sync/application/services/inbound-job-idempotency-key.ts` — new `buildInboundJobIdempotencyKey` pure helper; exported from `libs/core/src/sync/index.ts`.
+- `libs/core/src/sync/application/services/inbound-routing-policy.service.ts` — use the helper in `route()` (output byte-identical, existing spec still green).
+- `libs/core/src/sync/domain/ports/sync-job-repository.port.ts` — add `findByIdempotencyKey(idempotencyKey: string): Promise<SyncJob | null>` with JSDoc.
+- `libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts` — implement (mirrors `findById`).
+
+### Phase B — interface (apps/api)
+- `apps/api/src/sync/http/sync.controller.ts` — `@Get('jobs/lookup')` (before `jobs/:id`); `@Query` `platformType` / `connectionId` / `eventId` with a blank guard → `BadRequestException`; assemble the key via `buildInboundJobIdempotencyKey`; `NotFoundException` when the repo returns null; reuse `toDto`.
+- `apps/api/src/sync/http/sync.controller.spec.ts` — add `findByIdempotencyKey` to the typed repo mock; 3 tests (found / missing-component / not-found), asserting the server-assembled key.
+
+### Phase C — frontend
+- `apps/web/src/features/sync-jobs/api/sync.api.ts` — `lookupJobForWebhookEvent({ platformType, connectionId, eventId })` + `WebhookJobLookupInput` type.
+- `apps/web/src/features/sync-jobs/api/sync.query-keys.ts` — `webhookJobLookup(platformType, connectionId, eventId)` key.
+- `apps/web/src/features/sync-jobs/hooks/use-sync-job-lookup-query.ts` — new hook, self-disables until all components present, `retry: false` (a 404 = "not created yet", don't hammer).
+- `apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx` — `buildDownstreamJobHref` helper; call `useConnectionQuery` + `useSyncJobLookupQuery` before the loading/error guards (matches `SyncJobDetailPage` precedent); pass raw components; link exact-job-or-fallback.
+- `apps/web/src/test/test-utils.tsx` — default `syncJobs.lookupJobForWebhookEvent` mock.
+- `apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.test.tsx` — exact-link + fallback tests.
+
+### Phase D — quality gate
+- `pnpm lint && pnpm type-check && pnpm test` (web + api). No migration to show.
+
+---
+
+## 5. Risks & Follow-ups
+
+- **Cross-layer key-format coupling** (tech-review IMPORTANT): **resolved.** The key format now lives in exactly one place — `buildInboundJobIdempotencyKey` in core — used by the routing policy and the lookup endpoint. The endpoint takes the raw `(platformType, connectionId, eventId)` components and assembles the key server-side, so the FE never re-encodes the format and it can evolve in core without silent drift (the `docs/lessons.md` #1318 failure mode no longer applies).
+- **Lookup endpoint validation**: uses raw `@Query` params + a manual guard rather than a class-validator DTO like the sibling list endpoints. Correct and injection-safe (TypeORM parameterizes), but a small DTO would be more idiomatic. **Optional.**
+
+---
+
+## 6. Acceptance Criteria
+
+- [x] "Downstream job" links to the exact `SyncJob` detail (`/jobs-logs/:uuid`) resolved via idempotency key when the job exists.
+- [x] When not yet resolvable (worker hasn't created the row), the link falls back to the pre-filtered Jobs & Logs list — never a broken `/jobs-logs/<streamId>`.
+- [x] New `findByIdempotencyKey` port method + `GET /sync/jobs/lookup` endpoint, with controller tests.
+- [x] `webhook-delivery-detail-page.test.tsx` asserts both the exact-job link and the fallback.
+- [x] No CORE ↔ Integration boundary violations; key format stays owned by core.
+
+---
+
+## Related
+
+- Enqueue ID vs UUID origin: `RedisStreamsJobEnqueueService`, `InboundRoutingPolicyService`, `WebhookToJobHandler`.
+- Fallback target: `SyncJobsPage` URL filters (`connectionId`, `jobType`).
+- Issue #1366 comment thread documents the revised approach.

--- a/libs/core/src/sync/application/services/inbound-job-idempotency-key.ts
+++ b/libs/core/src/sync/application/services/inbound-job-idempotency-key.ts
@@ -1,0 +1,24 @@
+/**
+ * Inbound Job Idempotency Key
+ *
+ * The single authoring site for the idempotency key that ties an inbound
+ * trigger (webhook event) to the sync job it enqueues. `InboundRoutingPolicyService`
+ * stamps this key on every enqueued job; the same value lands on the persisted
+ * `SyncJob` row, so it is the durable cross-reference callers use to resolve a
+ * delivery back to its concrete job (#1366).
+ *
+ * Keeping the format in one exported function means no other layer (the HTTP
+ * lookup endpoint, and transitively the frontend that feeds it) re-encodes the
+ * `{platformType}:{connectionId}:{sourceEventId}` shape — they pass the raw
+ * components and let this helper assemble them, so the format can evolve here
+ * without silent drift across the FE/BE boundary.
+ *
+ * @module application/services
+ */
+export function buildInboundJobIdempotencyKey(
+  platformType: string,
+  connectionId: string,
+  sourceEventId: string
+): string {
+  return `${platformType}:${connectionId}:${sourceEventId}`;
+}

--- a/libs/core/src/sync/application/services/inbound-routing-policy.service.ts
+++ b/libs/core/src/sync/application/services/inbound-routing-policy.service.ts
@@ -27,6 +27,7 @@ import type { IInboundRoutingPolicyService } from '../interfaces/inbound-routing
 import type { RoutingOutcome } from '../types/inbound-routing-policy.types';
 import { JobEnqueuePort } from '../../domain/ports/job-enqueue.port';
 import { JOB_ENQUEUE_TOKEN } from '../../sync.tokens';
+import { buildInboundJobIdempotencyKey } from './inbound-job-idempotency-key';
 import type { JobType, SyncJobRequest } from '../../domain/types/sync-job.types';
 import type {
   MarketplaceOrderSyncPayloadV1,
@@ -95,7 +96,11 @@ export class InboundRoutingPolicyService implements IInboundRoutingPolicyService
       jobType,
       connectionId: connection.id,
       payload,
-      idempotencyKey: `${connection.platformType}:${connection.id}:${sourceEventId}`,
+      idempotencyKey: buildInboundJobIdempotencyKey(
+        connection.platformType,
+        connection.id,
+        sourceEventId
+      ),
     };
     const { jobId } = await this.jobEnqueue.enqueueJob(job);
     this.logger.log(

--- a/libs/core/src/sync/domain/ports/sync-job-repository.port.ts
+++ b/libs/core/src/sync/domain/ports/sync-job-repository.port.ts
@@ -113,6 +113,18 @@ export interface SyncJobRepositoryPort {
   findById(id: string): Promise<SyncJob | null>;
 
   /**
+   * Find a single job by its unique idempotency key. Returns null if not found.
+   *
+   * The idempotency key is the durable cross-reference between an inbound
+   * trigger and the persisted job it produced — the key an enqueuer computes
+   * (e.g. `InboundRoutingPolicyService` uses `{platformType}:{connectionId}:{sourceEventId}`)
+   * is the same one stored on the row. Callers that only hold the enqueue
+   * coordinates (not the DB UUID) use this to resolve the actual `SyncJob` —
+   * e.g. correlating a webhook delivery to the job it triggered (#1366).
+   */
+  findByIdempotencyKey(idempotencyKey: string): Promise<SyncJob | null>;
+
+  /**
    * Requeue stuck jobs (optional helper)
    *
    * Finds jobs stuck in 'running' status longer than lockTimeoutMinutes,

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -120,6 +120,7 @@ export type { ISyncCursorsService } from './application/services/sync-cursors.se
 // Inbound routing policy (ADR-015) — class is value-exported so the API webhooks
 // module can bind it; deps (IIntegrationsService, JobEnqueuePort) resolve there.
 export { InboundRoutingPolicyService } from './application/services/inbound-routing-policy.service';
+export { buildInboundJobIdempotencyKey } from './application/services/inbound-job-idempotency-key';
 export type { IInboundRoutingPolicyService } from './application/interfaces/inbound-routing-policy.service.interface';
 export type { RoutingOutcome } from './application/types/inbound-routing-policy.types';
 

--- a/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
@@ -211,6 +211,11 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
     return entity ? this.toDomain(entity) : null;
   }
 
+  async findByIdempotencyKey(idempotencyKey: string): Promise<SyncJob | null> {
+    const entity = await this.repository.findOne({ where: { idempotencyKey } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
   async findMany(
     filters: SyncJobFilters,
     pagination: SyncJobPagination


### PR DESCRIPTION

<!--
Thank you for contributing to OpenLinker!

Title: use Conventional Commits format — `feat(scope): subject`,
`fix(scope): subject`, `docs:`, `refactor:`, `test:`, `chore:`.
See CONTRIBUTING.md → Commits for the full type list.
-->

## Summary

<!-- 1–3 bullets: what changed and why. Focus on the why. -->

- The webhook delivery detail page linked Downstream job to /jobs-logs/${downstreamJobId}, but downstreamJobId is the Redis Stream enqueue ID (<epoch-ms>-<seq>), not the persisted SyncJob UUID that /jobs-logs/:id (ParseUUIDPipe) resolves — so the link 404'd every time it was populated.
- Resolves the concrete job via the one durable cross-reference between a delivery and the job it enqueued: the inbound-job idempotency key ({platformType}:{connectionId}:{eventId}). The format now lives in a single core helper (buildInboundJobIdempotencyKey) used by both InboundRoutingPolicyService and a new GET /sync/jobs/lookup endpoint that assembles the key server-side from raw components — so the FE never re-encodes the format.
- The link targets the exact /jobs-logs/:uuid, degrading gracefully to the pre-filtered Jobs & Logs list while the worker-created row isn't resolvable yet (async), so it's never dead.


## Related issues

<!-- One `Closes #N` per issue this PR resolves. Issues are closed
     automatically when the PR merges — do not close them manually. -->

Closes #1366

## Test plan

<!-- How a reviewer verifies the change. Commands to run, paths to
     click through, edge cases to confirm. -->

- API unit — pnpm --filter @openlinker/api test sync.controller.spec covers the lookup endpoint: assembles the key server-side (found), 400 on any missing component, 404 when no row exists yet. Existing inbound-routing-policy.service.spec still green (helper output unchanged).
- Web unit — pnpm --filter @openlinker/web test webhook-delivery-detail-page covers: exact-job link (/jobs-logs/:uuid) when resolved, and fallback to /jobs-logs?connectionId=…&jobType=… when the lookup 404s.
- Manual — open a webhook delivery with a populated Downstream job; the link now navigates to the real job detail (or the filtered list until the worker creates the row), never to a broken UUID route

## Quality gate

- [ ] `pnpm lint` passes (zero errors)
- [ ] `pnpm type-check` passes (zero errors)
- [ ] `pnpm test` passes (all unit tests green)
- [ ] *Optional, Docker required:* `pnpm test:integration` passes — needed
      only if you touched `apps/api/test/integration/**` or any plugin's
      `infrastructure/adapters/`.

---

<sub>By submitting this pull request, I confirm that my contributions
are made under the terms of the [Apache License 2.0](../LICENSE), and I
certify the [Developer Certificate of Origin](https://developercertificate.org/)
by signing off my commits.</sub>
