### PR TITLE
fix(demo): use curl instead of PHP file_get_contents for PrestaShop healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,11 @@ services:
       mysql:
         condition: service_healthy
     healthcheck:
-      test: ['CMD-SHELL', 'php -r "exit(@file_get_contents(\"http://localhost:80\") ? 0 : 1);"']
+      # PS_DOMAIN redirects "/" to http://localhost:8080/ (the host-mapped port),
+      # which isn't reachable from inside this container. `curl` without `-L`
+      # accepts the 302 as proof Apache is up; PHP's file_get_contents() follows
+      # redirects by default and fails with "Connection refused" on :8080 (#1392).
+      test: ['CMD', 'curl', '-fsS', '-o', '/dev/null', 'http://localhost:80']
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary
- The `prestashop` service healthcheck reported `unhealthy` even when Apache/PrestaShop was serving fine, because `PS_DOMAIN` redirects `/` to the host-mapped port (`localhost:8080`), and PHP's `file_get_contents()` follows that redirect by default and fails with `Connection refused` from inside the container.
- Replaced with `curl -fsS -o /dev/null http://localhost:80` (no `-L`), which accepts the 302 as proof the server is up, plus a comment explaining why `-L` must stay off.

## Test plan
- [x] Confirmed root cause live on a running `openlinker-prestashop` container (`curl -L` reproduces `Failed to connect to localhost port 8080`, `file_get_contents` returns the same `Connection refused`)
- [x] Verified the new healthcheck command exits 0 against the live container
- [ ] `pnpm dev:stack:up` (or `docker compose up -d prestashop`) reaches `healthy` status on a fresh container recreate

Closes #1392