### PR TITLE
chore(infra): swap Redis for Valkey in dev stack and integration tests

### DIFF
--- a/apps/worker/test/integration/harness.ts
+++ b/apps/worker/test/integration/harness.ts
@@ -39,7 +39,9 @@ export async function startHarness(): Promise<void> {
     .start();
 
   // Start Redis container
-  const redis = await new RedisContainer('redis:7-alpine').withLabels(ciRunIdLabels()).start();
+  const redis = await new RedisContainer('valkey/valkey:8-alpine')
+    .withLabels(ciRunIdLabels())
+    .start();
 
   // Provide connection info to tests via env vars
   process.env.DB_HOST = postgres.getHost();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,14 +19,14 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:8-alpine
     container_name: openlinker-redis
     ports:
       - '6379:6379'
     volumes:
       - redis_data:/data
     healthcheck:
-      test: ['CMD', 'redis-cli', 'ping']
+      test: ['CMD', 'valkey-cli', 'ping']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -171,7 +171,7 @@ async setup(): Promise<void> {
     .start();
 
   // 2. Start Redis container
-  this.redisContainer = await new RedisContainer('redis:7-alpine').start();
+  this.redisContainer = await new RedisContainer('valkey/valkey:8-alpine').start();
 
   // 3. Override environment variables with container ports
   process.env.DB_HOST = this.postgresContainer.getHost();
@@ -215,7 +215,7 @@ async setup(): Promise<void> {
 ### Container Images
 
 - **PostgreSQL**: `postgres:16-alpine` (lightweight, production-like)
-- **Redis**: `redis:7-alpine` (lightweight, production-like)
+- **Redis**: `valkey/valkey:8-alpine` (lightweight, production-like)
 
 ---
 
@@ -900,7 +900,7 @@ pnpm test && pnpm test:integration
 ### Testcontainers
 
 - **PostgreSQL**: `postgres:16-alpine` (ephemeral container)
-- **Redis**: `redis:7-alpine` (ephemeral container)
+- **Redis**: `valkey/valkey:8-alpine` (ephemeral container)
 - **Lifecycle**: Auto-started before tests, auto-stopped after tests
 
 ---

--- a/libs/test-kit/src/containers.ts
+++ b/libs/test-kit/src/containers.ts
@@ -26,7 +26,7 @@ declare global {
 }
 
 const DEFAULT_POSTGRES_IMAGE = 'postgres:16-alpine';
-const DEFAULT_REDIS_IMAGE = 'redis:7-alpine';
+const DEFAULT_REDIS_IMAGE = 'valkey/valkey:8-alpine';
 const DEFAULT_DB_NAME = 'openlinker_test';
 const DEFAULT_DB_USER = 'postgres';
 const DEFAULT_DB_PASSWORD = 'postgres';

--- a/libs/test-kit/src/types.ts
+++ b/libs/test-kit/src/types.ts
@@ -176,7 +176,7 @@ export interface ContainerConfig {
   postgresImage?: string;
 
   /**
-   * Redis image tag. Defaults to `redis:7-alpine`.
+   * Redis-compatible image tag. Defaults to `valkey/valkey:8-alpine`.
    */
   redisImage?: string;
 


### PR DESCRIPTION
## Summary
- Retags the pinned `redis:7-alpine` image to `valkey/valkey:8-alpine` in `docker-compose.yml` (dev stack), `libs/test-kit/src/containers.ts` (shared Testcontainers harness default), and `apps/worker/test/integration/harness.ts` (worker-local Testcontainers harness).
- Switches the `docker-compose.yml` healthcheck from `redis-cli ping` to `valkey-cli ping`.
- No production deployment manifests exist in this repo, so this covers the full in-repo scope.

## Why
DevOps asked whether Redis 7 can be swapped for Valkey (the open-source BSD fork). A compatibility audit of this codebase's actual Redis usage found no blockers: no Redis Stack modules (RedisJSON/RediSearch/TimeSeries/Bloom), no post-fork Redis 7.4+/8.0+-exclusive commands, full Streams (`XADD`/`XGROUP`/`XREADGROUP`/`XACK`) parity since the fork, and the one Lua script (compare-and-delete lock in `redis-sync-lock.service.ts`) uses only plain `EVAL`/`GET`/`DEL`.

Closes #1394

## Test plan
- [x] `pnpm lint` — zero errors (pre-existing warnings unrelated to this change)
- [x] `pnpm type-check` — zero errors
- [x] `pnpm test` — unit suite passes (one pre-existing, unrelated failure in `apps/web/src/pages/settings/settings-page.test.tsx` reproduces identically on `origin/main`, confirmed via stash)
- [x] `docker pull valkey/valkey:8-alpine` succeeds locally
- [ ] `pnpm test:integration` (Testcontainers-backed: event-bus Streams, sync-lock Lua script, shipping rolling-window sorted sets) — deferred to CI, not run locally in this session