### PR TITLE
fix(demo): boot WooCommerce with pnpm demo:up and fix its always-unhealthy healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,11 @@ services:
       # /wp-json/wc/v3/ = WC namespace index, returns 200 without auth once WC is active.
       # NOT /wp-json/wc/v3/system_status (requires consumer key — chicken-and-egg at startup).
       # php, not curl/wget — neither exists in the bitnamilegacy image.
-      test: ['CMD-SHELL', 'php -r ''exit(strpos((string) @file_get_contents("http://localhost:8080/wp-json/wc/v3/"), "wc/v3") === false ? 1 : 0);''']
+      # Needle is "wc\/v3", not "wc/v3": the response body is a JSON string
+      # produced by PHP's json_encode, which escapes "/" as "\/" by default —
+      # the unescaped needle never matches, so the healthcheck always failed
+      # (container ran fine but was permanently reported unhealthy).
+      test: ['CMD-SHELL', 'php -r ''exit(strpos((string) @file_get_contents("http://localhost:8080/wp-json/wc/v3/"), "wc\/v3") === false ? 1 : 0);''']
       interval: 30s
       timeout: 10s
       retries: 10

--- a/docs/one-command-demo-setup-guide.md
+++ b/docs/one-command-demo-setup-guide.md
@@ -37,7 +37,8 @@ tier — API + Worker + admin UI.
   (the whole monorepo is compiled inside the image; the build is from your local
   checkout, not a pre-built registry image).
 - **Free host ports:** `8090` (UI), `3000` (API), `8080` (PrestaShop), `8081`
-  (phpMyAdmin), `5432` (Postgres), `6379` (Redis), `3306` (MySQL).
+  (phpMyAdmin), `8082` (WooCommerce), `5432` (Postgres), `6379` (Redis), `3306`
+  (MySQL), `3307` (WooCommerce MySQL).
 
 > ⚠️ **Shared volumes with the dev stack.** The demo shares the same Compose
 > project (`openlinker`) and data volumes as `pnpm dev:stack:up`. On a machine
@@ -111,13 +112,14 @@ pnpm demo:down      # stop the stack (add -v to also wipe the data volumes)
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d --build \
-  postgres redis mysql phpmyadmin prestashop migrate api worker web
+  postgres redis mysql phpmyadmin woocommerce-mysql woocommerce prestashop migrate api worker web
 ```
 
 Boot order is enforced by `depends_on` (not the CLI service list):
 **Postgres healthy → one-shot `migrate` runs to completion → `api` + `worker`
-start**; PrestaShop auto-installs in parallel; `web` is static (nginx) and needs
-nothing. Migrations run automatically — no manual `migration:run`.
+start**; PrestaShop and WooCommerce auto-install in parallel; `web` is static
+(nginx) and needs nothing. Migrations run automatically — no manual
+`migration:run`.
 
 Wait until the app tier is healthy:
 
@@ -126,8 +128,8 @@ docker compose -f docker-compose.yml -f docker-compose.demo.yml ps
 curl -s http://localhost:3000/v1/health         # expect {"status":"ok",...}
 ```
 
-PrestaShop takes the longest (auto-install + seed); give it a few minutes on the
-first run.
+PrestaShop and WooCommerce take the longest (auto-install + seed / plugin
+download); give them a few minutes on the first run.
 
 ---
 
@@ -140,6 +142,8 @@ first run.
 | PrestaShop storefront | http://localhost:8080 | — |
 | PrestaShop admin | http://localhost:8080/**admin-dev** | `demo@prestashop.com` / `prestashop_demo` |
 | phpMyAdmin | http://localhost:8081 | `root` / `root` |
+| WooCommerce storefront | http://localhost:8082 | — |
+| WooCommerce admin (`wp-admin`) | http://localhost:8082/wp-admin | `admin` / `admin123` |
 
 > The PrestaShop admin folder is `admin-dev` (the post-install step renames the
 > randomized install folder), **not** `/admin`.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "dev:stack:seed-woocommerce": "docker exec openlinker-woocommerce bash /docker-entrypoint-initdb.d/01-seed-wc-data.sh",
     "dev:stack:wc-credentials": "docker exec openlinker-woocommerce cat /bitnami/wordpress/.dev-secrets/woocommerce-credentials.json | jq .",
     "dev:health": "curl -s http://localhost:3000/v1/health/dev-stack | jq . || curl -s http://localhost:3000/v1/health/dev-stack",
-    "demo:up": "docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d --build postgres redis mysql phpmyadmin prestashop migrate api worker web",
+    "demo:up": "docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d --build postgres redis mysql phpmyadmin woocommerce-mysql woocommerce prestashop migrate api worker web",
     "demo:down": "docker compose -f docker-compose.yml -f docker-compose.demo.yml down",
     "demo:logs": "docker compose -f docker-compose.yml -f docker-compose.demo.yml logs -f",
     "prepare": "husky install || true"


### PR DESCRIPTION
## Summary
- `pnpm demo:up` now starts `woocommerce-mysql` + `woocommerce` alongside the existing services, so the one-command demo boots WooCommerce like it already does PrestaShop (no manual service-list override needed).
- `docs/one-command-demo-setup-guide.md` §1/§3/§4 updated to mention WooCommerce's port, boot command, and URL/credentials.
- Bonus fix found while verifying the above live: the `woocommerce` healthcheck in `docker-compose.yml` used the needle `"wc/v3"` against a `file_get_contents` response that's PHP `json_encode` output — which escapes `/` as `\/`. The needle never matched, so the container was permanently reported `unhealthy` even though it worked correctly. Fixed the needle to `"wc\/v3"`. Without this fix there's no way to actually observe "WooCommerce booted healthy" from `docker compose ps`, so it's bundled with this change rather than filed separately.

## Test plan
- [x] Ran the merged compose config (`docker compose -f docker-compose.yml -f docker-compose.demo.yml config --services`) — confirms `woocommerce` / `woocommerce-mysql` resolve correctly with the demo overlay.
- [x] Booted `postgres redis mysql phpmyadmin woocommerce-mysql woocommerce prestashop migrate` (the new `demo:up` list minus the app-tier build step) and watched `woocommerce`'s health status.
- [x] Reproduced the pre-existing healthcheck bug directly inside the container (`strpos($json, "wc/v3")` → `false`, `strpos($json, "wc\/v3")` → `14`), confirmed the fixed test string returns exit `0`.
- [x] After recreating `woocommerce` with the fixed healthcheck, `docker compose ps` shows `woocommerce` `Up ... (healthy)`.
- [x] `curl http://localhost:8082/wp-json/wc/v3/` → `200`, `curl http://localhost:8082/wp-admin/` → `302` (login redirect, as expected) — service is reachable from the host at the documented port.

Closes #1395