### PR TITLE
fix(demo): harden docker-compose port binding and add multi-instance parametrization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,41 @@ OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=
 # non-local exposure.
 # Default: development-pii-hash-salt-change-in-production
 # OL_PII_HASH_SALT=
+
+# ---------------------------------------------------------------------------
+# SERVER / MULTI-INSTANCE HARDENING (#1400) — every value below has a working
+# localhost-only default baked into docker-compose.yml / docker-compose.demo.yml
+# that reproduces today's exact ports and container names. Leave commented
+# out for a plain local `pnpm demo:up` / `pnpm dev:stack:up`. Set these when
+# running the stack on a shared/public server, or when running a second stack
+# instance alongside an existing one on the same host.
+# ---------------------------------------------------------------------------
+
+# Interface every service's port is published on. Defaults to loopback-only
+# so postgres/redis/mysql/phpMyAdmin/PrestaShop/api are never reachable from
+# outside the host just because a firewall wasn't configured. Only change
+# this if a service genuinely needs to be reachable beyond loopback (normally
+# handled by a reverse proxy in front of `web`/`api` instead).
+# Default: 127.0.0.1
+# OL_BIND_ADDRESS=
+
+# Prefixes the Compose project name and every container_name (e.g.
+# openlinker-postgres becomes ${COMPOSE_PROJECT_NAME}-postgres). Set a
+# distinct value per stack instance to run more than one instance on the
+# same host without container-name collisions.
+# Default: openlinker
+# COMPOSE_PROJECT_NAME=
+
+# Host-side port overrides. Set distinct values (together with a distinct
+# COMPOSE_PROJECT_NAME above) to run a second stack instance alongside an
+# existing one on the same host.
+# Defaults: 5432 / 6379 / 3306 / 8081 / 8080 / 3307 / 8082 / 3000 / 8090
+# POSTGRES_HOST_PORT=
+# REDIS_HOST_PORT=
+# MYSQL_HOST_PORT=
+# PHPMYADMIN_HOST_PORT=
+# PRESTASHOP_HOST_PORT=
+# WOOCOMMERCE_MYSQL_HOST_PORT=
+# WOOCOMMERCE_HOST_PORT=
+# API_HOST_PORT=
+# WEB_HOST_PORT=

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -42,16 +42,18 @@ services:
       # for decrypting connection credentials at runtime. Operator-supplied via
       # .env (see .env.example); `:?` fails the boot with a clear message if unset.
       OPENLINKER_CREDENTIALS_ENCRYPTION_KEY: '${OPENLINKER_CREDENTIALS_ENCRYPTION_KEY:?set OPENLINKER_CREDENTIALS_ENCRYPTION_KEY in .env (see .env.example) - generate with: openssl rand -base64 32}'
-    # Loopback-bound, overriding base's `3000:3000` — the demo image ships
-    # default admin/admin credentials with no redaction, so a multi-homed/LAN
-    # host must not expose it beyond localhost. The browser reaches it at
-    # localhost:3000 regardless (see the `web` service's VITE_API_BASE_URL
-    # below), so this is transparent to the operator.
+    # Overrides base's port publish with the same ${OL_BIND_ADDRESS}/${API_HOST_PORT}
+    # vars (#1400) — kept as an explicit override rather than relying on the
+    # base value because the demo image ships default admin/admin credentials
+    # with no redaction, so this binding must never silently drift from the
+    # base file's. The browser reaches it at localhost:${API_HOST_PORT}
+    # regardless (see the `web` service's VITE_API_BASE_URL below), so this is
+    # transparent to the operator.
     # `!override` (not a plain list, which Compose would merge/append) replaces
-    # base's binding outright — otherwise both the unbound and loopback-bound
-    # publishes would coexist and fail to bind the same host port twice.
+    # base's binding outright — otherwise both publishes would coexist and
+    # fail to bind the same host port twice.
     ports: !override
-      - '127.0.0.1:3000:3000'
+      - '${OL_BIND_ADDRESS:-127.0.0.1}:${API_HOST_PORT:-3000}:3000'
     # Drop the dev-stack source bind-mounts — the demo runs the built image,
     # not the working tree. (Without !reset, Compose merges volumes by target
     # path and the mounts would survive the override.)
@@ -65,7 +67,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: worker
-    container_name: openlinker-worker
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-worker
     environment:
       NODE_ENV: production
       DB_HOST: postgres
@@ -102,12 +104,13 @@ services:
         # takes effect on the NEXT `--build` (e.g. https://api.example.com
         # for a public-domain deployment), not on a plain `up`/restart.
         VITE_API_BASE_URL: '${VITE_API_BASE_URL:-http://localhost:3000}'
-    container_name: openlinker-web
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-web
     ports:
       # 8080 = PrestaShop, 8081 = phpMyAdmin, 8082 = WooCommerce
-      # Loopback-bound: the demo ships default admin/admin credentials with no
-      # redaction, so a multi-homed/LAN host must not expose it beyond localhost.
-      - '127.0.0.1:8090:80'
+      # Loopback-bound by default (#1400): the demo ships default admin/admin
+      # credentials with no redaction, so a multi-homed/LAN host must not
+      # expose it beyond localhost.
+      - '${OL_BIND_ADDRESS:-127.0.0.1}:${WEB_HOST_PORT:-8090}:80'
     depends_on:
       - api
 
@@ -124,7 +127,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: base
-    container_name: openlinker-migrate
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-migrate
     command: ['pnpm', '--filter', '@openlinker/api', 'migration:run']
     environment:
       NODE_ENV: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,41 @@
-name: openlinker
+# Port binding / naming conventions (#1400):
+#
+# - Every published port binds to ${OL_BIND_ADDRESS:-127.0.0.1} by default —
+#   loopback-only, so a shared/public host doesn't expose postgres/redis/mysql/
+#   phpMyAdmin/PrestaShop/api to the internet just because a firewall wasn't
+#   configured. Override OL_BIND_ADDRESS in .env only when a service genuinely
+#   needs to be reachable beyond loopback (e.g. behind a reverse proxy on its
+#   own host).
+# - Every host-side port is a `${<SERVICE>_HOST_PORT:-<default>}` override —
+#   named with a `_HOST_PORT` suffix (not e.g. plain `REDIS_PORT`) so it can't
+#   be confused with the *container-internal* env vars of the same service
+#   family (api's `REDIS_PORT: 6379` below is the internal Redis port the api
+#   process connects to — always 6379 — and is unrelated to the host-side
+#   publish this section controls).
+# - `${COMPOSE_PROJECT_NAME:-openlinker}` drives both the top-level project
+#   name and every `container_name`, so a second stack instance (different
+#   `.env`: distinct COMPOSE_PROJECT_NAME + shifted *_HOST_PORT values) can
+#   run alongside this one on the same host without name or port collisions.
+#   Defaults reproduce today's exact literal names/ports — nothing changes
+#   for an operator who doesn't set .env overrides, beyond the loopback bind.
+#
+# Volume rule: named Docker volumes (declared at the bottom of this file) are
+# for persistent service data. Bind-mounts into the repo tree are used only
+# where a container needs live repo files it doesn't own as data — PrestaShop
+# module source for fast dev iteration, and one-shot PrestaShop/WooCommerce
+# post-install/init scripts.
+name: ${COMPOSE_PROJECT_NAME:-openlinker}
 
 services:
   postgres:
     image: postgres:16-alpine
-    container_name: openlinker-postgres
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-postgres
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: openlinker
     ports:
-      - '5432:5432'
+      - '${OL_BIND_ADDRESS:-127.0.0.1}:${POSTGRES_HOST_PORT:-5432}:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -20,9 +46,9 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: openlinker-redis
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-redis
     ports:
-      - '6379:6379'
+      - '${OL_BIND_ADDRESS:-127.0.0.1}:${REDIS_HOST_PORT:-6379}:6379'
     volumes:
       - redis_data:/data
     healthcheck:
@@ -33,14 +59,14 @@ services:
 
   mysql:
     image: mysql:8.4.7
-    container_name: openlinker-mysql
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-mysql
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: prestashop
       MYSQL_USER: prestashop
       MYSQL_PASSWORD: prestashop
     ports:
-      - '3306:3306'
+      - '${OL_BIND_ADDRESS:-127.0.0.1}:${MYSQL_HOST_PORT:-3306}:3306'
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
@@ -56,7 +82,7 @@ services:
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:latest
     platform: linux/amd64
-    container_name: openlinker-phpmyadmin
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-phpmyadmin
     environment:
       PMA_HOST: mysql
       PMA_PORT: 3306
@@ -64,7 +90,7 @@ services:
       PMA_PASSWORD: root
       MYSQL_ROOT_PASSWORD: root
     ports:
-      - '8081:80'
+      - '${OL_BIND_ADDRESS:-127.0.0.1}:${PHPMYADMIN_HOST_PORT:-8081}:80'
     depends_on:
       mysql:
         condition: service_healthy
@@ -76,14 +102,14 @@ services:
 
   woocommerce-mysql:
     image: mysql:8.4.7
-    container_name: openlinker-woocommerce-mysql
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-woocommerce-mysql
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: woocommerce
       MYSQL_USER: woocommerce
       MYSQL_PASSWORD: woocommerce
     ports:
-      - '127.0.0.1:3307:3306'
+      - '${OL_BIND_ADDRESS:-127.0.0.1}:${WOOCOMMERCE_MYSQL_HOST_PORT:-3307}:3306'
     volumes:
       - woocommerce_mysql_data:/var/lib/mysql
     healthcheck:
@@ -96,7 +122,7 @@ services:
   woocommerce:
     image: bitnamilegacy/wordpress:6.7.1
     platform: linux/amd64
-    container_name: openlinker-woocommerce
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-woocommerce
     depends_on:
       woocommerce-mysql:
         condition: service_healthy
@@ -116,7 +142,7 @@ services:
       WORDPRESS_PLUGINS: https://downloads.wordpress.org/plugin/woocommerce.10.1.0.zip
     ports:
       # 8082: avoids collision with PrestaShop on 8080
-      - '127.0.0.1:8082:8080'
+      - '${OL_BIND_ADDRESS:-127.0.0.1}:${WOOCOMMERCE_HOST_PORT:-8082}:8080'
     volumes:
       - woocommerce_data:/bitnami/wordpress
       - ./docker/woocommerce:/docker-entrypoint-initdb.d:ro
@@ -136,7 +162,7 @@ services:
 
   prestashop:
     image: prestashop/prestashop:9.0.2-2.0-classic-8.4
-    container_name: openlinker-prestashop
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-prestashop
     # Auto-install + post-install scripts run via the upstream image's
     # /tmp/docker_run.sh (the default CMD). It iterates /tmp/post-install-scripts/
     # alphabetically after the installer completes. Use `pnpm dev:stack:seed-prestashop`
@@ -165,7 +191,7 @@ services:
       ADMIN_MAIL: demo@prestashop.com
       ADMIN_PASSWD: prestashop_demo
     ports:
-      - '8080:80'
+      - '${OL_BIND_ADDRESS:-127.0.0.1}:${PRESTASHOP_HOST_PORT:-8080}:80'
     volumes:
       - prestashop_data:/var/www/html
       # Bind-mount module source for fast dev iteration
@@ -200,7 +226,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: production
-    container_name: openlinker-api
+    container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-api
     environment:
       NODE_ENV: development
       PORT: 3000
@@ -217,7 +243,7 @@ services:
       JWT_EXPIRES_IN: '${JWT_EXPIRES_IN:-1d}'
       OL_PII_HASH_SALT: '${OL_PII_HASH_SALT:-development-pii-hash-salt-change-in-production}'
     ports:
-      - '3000:3000'
+      - '${OL_BIND_ADDRESS:-127.0.0.1}:${API_HOST_PORT:-3000}:3000'
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/one-command-demo-setup-guide.md
+++ b/docs/one-command-demo-setup-guide.md
@@ -25,6 +25,7 @@ tier — API + Worker + admin UI.
 7. [Verify the end-to-end flow](#7-verify-the-end-to-end-flow)
 8. [Troubleshooting](#8-troubleshooting)
 9. [Teardown](#9-teardown)
+10. [Running on a shared server / multiple instances](#10-running-on-a-shared-server--multiple-instances)
 
 ---
 
@@ -272,3 +273,33 @@ pnpm demo:down -v    # stop and WIPE the data volumes (fresh start next time)
 
 Because the demo shares the `openlinker` Compose project with `pnpm dev:stack:up`,
 `-v` wipes volumes shared with the dev stack too — see the warning in section 1.
+
+---
+
+## 10. Running on a shared server / multiple instances
+
+By default every published port binds to `127.0.0.1` and every container name
+is prefixed `openlinker-` — safe on a single-user laptop, but two things to
+know before running this on a shared/public host (#1400):
+
+- **Loopback binding is the default, not an accident.** `postgres` / `redis` /
+  `mysql` / `phpmyadmin` / `prestashop` / `api` all publish on `127.0.0.1` so
+  they're never reachable from outside the host just because a firewall
+  wasn't configured — put a reverse proxy in front of `web` (and `api`, if the
+  browser needs to reach it directly) for anything beyond localhost access.
+  Override the bind interface with `OL_BIND_ADDRESS` in `.env` only if a
+  service genuinely needs to be reachable beyond loopback.
+- **Running a second instance alongside an existing one** (e.g. a per-PR
+  preview environment, or a staging + demo pair on the same host): set a
+  distinct `COMPOSE_PROJECT_NAME` (renames the project and every
+  `container_name`) plus distinct `*_HOST_PORT` overrides
+  (`POSTGRES_HOST_PORT`, `REDIS_HOST_PORT`, `MYSQL_HOST_PORT`,
+  `PHPMYADMIN_HOST_PORT`, `PRESTASHOP_HOST_PORT`,
+  `WOOCOMMERCE_MYSQL_HOST_PORT`, `WOOCOMMERCE_HOST_PORT`, `API_HOST_PORT`,
+  `WEB_HOST_PORT`) in that instance's own `.env` — see `.env.example` for the
+  full list and defaults.
+
+> `pnpm dev:stack:seed-woocommerce` / `pnpm dev:stack:wc-credentials` invoke
+> `docker exec openlinker-woocommerce` directly and don't yet respect a custom
+> `COMPOSE_PROJECT_NAME` — a known limitation when running a second instance,
+> tracked as a documented gap rather than fixed here.

--- a/docs/plans/implementation-plan-1400-docker-demo-compose-hardening.md
+++ b/docs/plans/implementation-plan-1400-docker-demo-compose-hardening.md
@@ -1,0 +1,60 @@
+# Implementation Plan: Docker demo compose hardening (#1400)
+
+## 1. Task
+
+Harden `docker-compose.yml` + `docker-compose.demo.yml` so the one-command demo stack (#1352/#1365/#1397) is safe to run on a shared/public server, per devops feedback: infra services are inconsistently bound (some `0.0.0.0`, some `127.0.0.1`), and nothing is parametrized for running two stack instances side by side.
+
+**Layer**: Infrastructure (docker-compose config only — no application code, no hexagonal layers touched).
+
+**Non-goals** (per issue #1400): TLS/reverse-proxy, secrets management overhaul, CI changes, the non-demo dev-stack's `pnpm dev:stack:*` helper scripts that hardcode container names (`dev:stack:seed-woocommerce`, `dev:stack:wc-credentials` in `package.json`) — those still assume the default project name and are a known limitation when an operator overrides `COMPOSE_PROJECT_NAME`.
+
+## 2. Current state (verified on origin/main @ a964d8bd, WooCommerce already merged via #1397)
+
+- Unbound (`0.0.0.0`) port publishes: `postgres` (5432), `redis` (6379), `mysql` (3306), `phpmyadmin` (8081), `prestashop` (8080), base `api` (3000) — all in `docker-compose.yml`.
+- Already loopback-bound: `woocommerce-mysql` (127.0.0.1:3307), `woocommerce` (127.0.0.1:8082) in `docker-compose.yml`; demo overlay's `api` (127.0.0.1:3000) and `web` (127.0.0.1:8090) in `docker-compose.demo.yml`.
+- Every `container_name` is a hardcoded literal (`openlinker-postgres`, etc.); top-level `name: openlinker` is also a literal.
+- `.env.example` already documents the `${VAR:-default}` override convention (`PS_DOMAIN`, `JWT_SECRET`, `OL_CORS_ORIGIN`, etc.) — this change follows that exact convention, it doesn't invent a new one.
+- Volumes are already consistent: named volumes for persistent data (`postgres_data`, `mysql_data`, ...), bind-mounts only for live repo files the container needs (PrestaShop module source, PrestaShop/WooCommerce post-install/init scripts). No change needed there beyond documenting the rule.
+
+## 3. Design
+
+Single mechanism, applied uniformly (this *is* the fix for "brak konsekwencji"):
+
+1. **Bind address**: one shared `OL_BIND_ADDRESS` var (default `127.0.0.1`) used on every port publish in both compose files. An operator who genuinely wants a service reachable beyond loopback (rare — normally only `web`/`api` sit behind a reverse proxy) overrides this per-deployment via `.env`, or a future per-service override if ever needed — out of scope today, uniform is enough to close the gap.
+2. **Host ports**: one override var per service (`POSTGRES_PORT`, `REDIS_PORT`, `MYSQL_PORT`, `PHPMYADMIN_PORT`, `PRESTASHOP_PORT`, `WOOCOMMERCE_MYSQL_PORT`, `WOOCOMMERCE_PORT`, `API_PORT`, `WEB_PORT`), defaulting to today's literal value — so a second instance overrides these plus `OL_BIND_ADDRESS`/`COMPOSE_PROJECT_NAME` in its own `.env` and coexists with the first.
+3. **Project/container naming**: top-level `name: ${COMPOSE_PROJECT_NAME:-openlinker}` and every `container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-<service>`. Default value reproduces today's exact names (`openlinker-postgres`, ...) so nothing observable changes for an operator who doesn't set `.env` overrides.
+4. **Volume/bind-mount rule**: add a short comment block to `docker-compose.yml` (mirroring the existing header comment already in `docker-compose.demo.yml`) stating the rule explicitly.
+5. **Docs**: update `.env.example` (new vars, same comment style as existing entries) and `docs/one-command-demo-setup-guide.md` (mention override vars + multi-instance capability).
+
+`docker-compose.demo.yml`'s `api`/`web` overrides already use `127.0.0.1` literals — convert them to `${OL_BIND_ADDRESS:-127.0.0.1}` + `${API_PORT:-3000}` / `${WEB_PORT:-8090}` for consistency with the base file, since Compose merges the two files and a mismatched var name between them would silently reintroduce the same inconsistency this issue is about.
+
+## 4. Steps
+
+1. `docker-compose.yml`:
+   - Add header comment documenting bind-address / port / naming override vars and the volume rule.
+   - `name: ${COMPOSE_PROJECT_NAME:-openlinker}`.
+   - `postgres`, `redis`, `mysql`, `phpmyadmin`, `prestashop`, `woocommerce-mysql`, `woocommerce`, `api`: `container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-<service>`; port publish → `'${OL_BIND_ADDRESS:-127.0.0.1}:${<SERVICE>_PORT:-<default>}:<container-port>'`.
+   - **Acceptance**: `docker compose -f docker-compose.yml config` renders identical effective ports/names to today when no `.env` overrides are set (i.e. `0.0.0.0` publishes become `127.0.0.1` — the intended behavior change — everything else identical).
+2. `docker-compose.demo.yml`:
+   - `api` override `ports: !override` → `'${OL_BIND_ADDRESS:-127.0.0.1}:${API_PORT:-3000}:3000'`.
+   - `web` → `'${OL_BIND_ADDRESS:-127.0.0.1}:${WEB_PORT:-8090}:80'`.
+   - `worker`, `migrate` `container_name` → `${COMPOSE_PROJECT_NAME:-openlinker}-<service>`.
+   - **Acceptance**: `docker compose -f docker-compose.yml -f docker-compose.demo.yml config` shows no port/name regressions vs. today's defaults.
+3. `.env.example`: add the new vars (`COMPOSE_PROJECT_NAME`, `OL_BIND_ADDRESS`, `POSTGRES_PORT`, `REDIS_PORT`, `MYSQL_PORT`, `PHPMYADMIN_PORT`, `PRESTASHOP_PORT`, `WOOCOMMERCE_MYSQL_PORT`, `WOOCOMMERCE_PORT`, `API_PORT`, `WEB_PORT`) documented in the existing "OPTIONAL — every value has a working default" block.
+4. `docs/one-command-demo-setup-guide.md`: add a short "Running multiple instances / hardening for a shared server" note pointing at the new vars.
+5. **Verification** (in this worktree, isolated from any other running stack):
+   - Clean boot: only `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` set in `.env`, run `pnpm demo:up`, confirm all services healthy and reachable at the documented `localhost:*` ports, admin/admin login works — i.e. default behavior unchanged except loopback binding.
+   - Second-instance boot: a second `.env` (different project name/prefix + shifted ports) run alongside the first, confirm no port/container-name collisions and both stacks come up healthy.
+   - Tear down both after verification.
+
+## 5. Validation
+
+- No architecture-layer concerns (no TS/core code touched).
+- `pnpm lint` / `pnpm type-check` not expected to be affected — run once as a sanity check since it's cheap.
+- Docker-only verification is the real test here (see step 5 above).
+
+## 6. Risks / open questions
+
+- YAML `${VAR:-default}` interpolation inside `container_name` and `ports` is well-supported by Compose; the existing `PS_DOMAIN` / `JWT_SECRET` precedent in the same files confirms the pattern works in this repo's Compose version.
+- `pnpm dev:stack:seed-woocommerce` / `wc-credentials` hardcode `openlinker-woocommerce` — left as-is (documented non-goal); they still work under the default project name.
+- Not attempting per-service bind-address overrides (only one global `OL_BIND_ADDRESS`) — sufficient to close the "brak konsekwencji" gap without over-engineering; a future need for e.g. `web` reachable on `0.0.0.0` while DB stays loopback can add a per-service var later.


### PR DESCRIPTION
## Summary
- Loopback-bind (`127.0.0.1` by default, overridable via `OL_BIND_ADDRESS`) every previously-unbound port publish in `docker-compose.yml` — postgres, redis, mysql, phpmyadmin, prestashop, api — matching the convention already used for woocommerce/woocommerce-mysql and the demo overlay's api/web.
- Parametrize every host port via `${SERVICE}_HOST_PORT` and every `container_name` (plus the top-level Compose project `name:`) via `${COMPOSE_PROJECT_NAME}`, so a second full stack instance can run alongside the first on the same host with a distinct `.env`.
- Document the volume rule (named volumes for persistent data, bind-mounts only for live repo files the container needs) in a header comment block in `docker-compose.yml`.
- Update `.env.example` and `docs/one-command-demo-setup-guide.md` with the new override variables and a "running on a shared server / multiple instances" section.
- All new variables default to today's exact literal values — a plain `pnpm demo:up` with no `.env` overrides has zero behavior change.

## Test plan
- [x] `docker compose config` structure reviewed post-rebase — no leftover conflict markers, `!override`/`!reset` demo-overlay directives intact.
- [ ] Fresh local boot (`pnpm demo:up`, clean `.env`) — confirm identical ports/behavior to pre-change.
- [ ] Second instance with overridden `COMPOSE_PROJECT_NAME` + `*_HOST_PORT` boots alongside the first without collisions.

Closes #1400

🤖 Generated with [Claude Code](https://claude.com/claude-code)