### PR TITLE
feat(erli): reuse an existing Allegro connection's credentials for category access (#1387)

### DIFF
--- a/apps/api/src/integrations/application/services/connection.service.spec.ts
+++ b/apps/api/src/integrations/application/services/connection.service.spec.ts
@@ -39,7 +39,11 @@ import {
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionCredentialsShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  ConnectionCredentialsRewriterRegistryService,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+  ConnectionCredentialsRewriteException,
 } from '@openlinker/core/integrations';
+import type { ConnectionCredentialsRewriterPort } from '@openlinker/core/integrations';
 import { AllegroConnectionConfigShapeValidatorAdapter } from '@openlinker/integrations-allegro';
 import {
   PrestashopConnectionConfigShapeValidatorAdapter,
@@ -61,6 +65,7 @@ describe('ConnectionService', () => {
   let mockWebhookProvisioner: jest.Mocked<WebhookProvisioningPort>;
   let configValidatorRegistry: ConnectionConfigShapeValidatorRegistryService;
   let credentialsValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService;
+  let credentialsRewriterRegistry: ConnectionCredentialsRewriterRegistryService;
 
   const mockConnection = new Connection(
     'connection-123',
@@ -171,6 +176,12 @@ describe('ConnectionService', () => {
       new PrestashopConnectionCredentialsShapeValidatorAdapter()
     );
 
+    // Credentials-rewriter registry (#1387, ADR-031). Empty by default so
+    // `updateCredentials` exercises the no-op passthrough for every existing
+    // test; individual tests register a stub rewriter to exercise the
+    // delegation path.
+    credentialsRewriterRegistry = new ConnectionCredentialsRewriterRegistryService();
+
     const mockCredentialsResolver: CredentialsResolverPort = {
       get: jest.fn(),
     } as unknown as CredentialsResolverPort;
@@ -191,6 +202,10 @@ describe('ConnectionService', () => {
         {
           provide: CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
           useValue: credentialsValidatorRegistry,
+        },
+        {
+          provide: CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+          useValue: credentialsRewriterRegistry,
         },
         { provide: CREDENTIALS_RESOLVER_TOKEN, useValue: mockCredentialsResolver },
       ],
@@ -872,6 +887,80 @@ describe('ConnectionService', () => {
         service.updateCredentials('connection-123', { webserviceApiKey: 'NEW' })
       ).rejects.toThrow(/does not have a db-backed/);
       expect(credentials.update).not.toHaveBeenCalled();
+    });
+
+    describe('credentials rewriter dispatch (#1387, ADR-031)', () => {
+      // ConnectionService has zero platform-specific knowledge of what a
+      // rewriter does (that logic — e.g. Erli's Allegro-credentials-reuse
+      // resolution — lives behind `ConnectionCredentialsRewriterPort` in the
+      // owning plugin package and is unit-tested there). These tests only
+      // pin the generic dispatch contract: no-op passthrough when nothing is
+      // registered for the adapterKey, and delegation + error-mapping when a
+      // rewriter is registered.
+      const dbConnection = new Connection(
+        'connection-123',
+        'prestashop',
+        'Test Connection',
+        'active',
+        {},
+        'db:cred-ref-1',
+        new Date(),
+        new Date(),
+        undefined,
+        ['ProductMaster']
+      );
+
+      beforeEach(() => {
+        connectionPort.get.mockResolvedValue(dbConnection);
+        credentials.getByRef.mockResolvedValue({
+          id: 'cred-row-1',
+          ref: 'cred-ref-1',
+          platformType: 'prestashop',
+          credentialsJson: { webserviceApiKey: 'EXISTING' },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        });
+      });
+
+      it('should pass the credentials through unchanged when no rewriter is registered for the adapterKey', async () => {
+        await service.updateCredentials('connection-123', { webserviceApiKey: 'NEW' });
+
+        expect(credentials.update).toHaveBeenCalledWith('cred-ref-1', {
+          credentialsJson: { webserviceApiKey: 'NEW' },
+        });
+      });
+
+      it('should delegate to the registered rewriter and persist its returned payload', async () => {
+        const stubRewriter: jest.Mocked<ConnectionCredentialsRewriterPort> = {
+          rewrite: jest
+            .fn()
+            .mockResolvedValue({ webserviceApiKey: 'REWRITTEN', extraField: 'added-by-rewriter' }),
+        };
+        credentialsRewriterRegistry.register('prestashop.webservice.v1', stubRewriter);
+
+        await service.updateCredentials('connection-123', { webserviceApiKey: 'NEW' });
+
+        expect(stubRewriter.rewrite).toHaveBeenCalledWith({ webserviceApiKey: 'NEW' });
+        expect(credentials.update).toHaveBeenCalledWith('cred-ref-1', {
+          credentialsJson: { webserviceApiKey: 'REWRITTEN', extraField: 'added-by-rewriter' },
+        });
+      });
+
+      it('should map a ConnectionCredentialsRewriteException from the rewriter to BadRequestException', async () => {
+        const stubRewriter: jest.Mocked<ConnectionCredentialsRewriterPort> = {
+          rewrite: jest
+            .fn()
+            .mockRejectedValue(
+              new ConnectionCredentialsRewriteException('Stub', 'source connection is invalid')
+            ),
+        };
+        credentialsRewriterRegistry.register('prestashop.webservice.v1', stubRewriter);
+
+        await expect(
+          service.updateCredentials('connection-123', { webserviceApiKey: 'NEW' })
+        ).rejects.toThrow(BadRequestException);
+        expect(credentials.update).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/apps/api/src/integrations/application/services/connection.service.ts
+++ b/apps/api/src/integrations/application/services/connection.service.ts
@@ -43,8 +43,11 @@ import {
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionCredentialsShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  ConnectionCredentialsRewriterRegistryService,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
   InvalidConnectionConfigException,
   InvalidCredentialsShapeException,
+  ConnectionCredentialsRewriteException,
 } from '@openlinker/core/integrations';
 import type { SyncJobRequest } from '@openlinker/core/sync';
 import { JobEnqueuePort, JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
@@ -72,6 +75,8 @@ export class ConnectionService implements IConnectionService {
     private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
     @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
     private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
+    @Inject(CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN)
+    private readonly connectionCredentialsRewriterRegistry: ConnectionCredentialsRewriterRegistryService,
     @Inject(CREDENTIALS_RESOLVER_TOKEN)
     private readonly credentialsResolver: CredentialsResolverPort
   ) {}
@@ -112,6 +117,32 @@ export class ConnectionService implements IConnectionService {
       await validator.validate(credentials);
     } catch (error) {
       if (error instanceof InvalidCredentialsShapeException) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Run the plugin's credentials rewriter if one is registered for this
+   * adapterKey (#1387, ADR-031). A rewriter transforms the raw credentials
+   * payload BEFORE it is merged onto the existing stored blob and shape-
+   * validated — e.g. Erli resolves `reuseAllegroConnectionId` into a concrete
+   * `allegroClientId`/`allegroClientSecret` pair fetched server-side, so the
+   * raw Allegro `clientSecret` never round-trips through this HTTP layer.
+   * This service has zero platform-specific knowledge of what a rewriter
+   * does — it's a no-op passthrough when nothing is registered.
+   */
+  private async rewriteCredentials(
+    adapterKey: string,
+    credentials: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    const rewriter = this.connectionCredentialsRewriterRegistry.get(adapterKey);
+    if (!rewriter) return credentials;
+    try {
+      return await rewriter.rewrite(credentials);
+    } catch (error) {
+      if (error instanceof ConnectionCredentialsRewriteException) {
         throw new BadRequestException(error.message);
       }
       throw error;
@@ -416,6 +447,7 @@ export class ConnectionService implements IConnectionService {
       platformType: connection.platformType,
       adapterKey: connection.adapterKey,
     });
+    const resolvedCredentials = await this.rewriteCredentials(metadata.adapterKey, credentials);
     const ref = connection.credentialsRef.slice('db:'.length);
     // Merge onto the existing stored credentials rather than replacing the
     // whole blob: callers only send the fields they actually changed (e.g.
@@ -423,7 +455,7 @@ export class ConnectionService implements IConnectionService {
     // other previously-stored field (e.g. Erli's optional Allegro
     // `allegroClientId`/`allegroClientSecret` pair, #1401 review).
     const existing = await this.credentials.getByRef(ref);
-    const mergedCredentials = { ...existing.credentialsJson, ...credentials };
+    const mergedCredentials = { ...existing.credentialsJson, ...resolvedCredentials };
     await this.validateCredentialsShape(metadata.adapterKey, mergedCredentials);
     await this.credentials.update(ref, { credentialsJson: mergedCredentials });
     this.logger.log(`Rotated credentials for connection ${connectionId}`);

--- a/apps/web/src/plugins/erli/components/erli-credentials-panel.test.tsx
+++ b/apps/web/src/plugins/erli/components/erli-credentials-panel.test.tsx
@@ -6,9 +6,11 @@
  * client-side "both or neither" validation for the Client ID/Secret pair,
  * and the sequenced credentials-then-config atomicity write for
  * `allegroCategoryAccessEnabled` (both the enable and disable directions).
+ * Also covers (#1387) the reuse-vs-manual Allegro credential source choice.
  */
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Connection } from '../../../features/connections';
 import {
   createMockApiClient,
   findToastTitle,
@@ -23,6 +25,16 @@ const erliConnectionWithAllegroAccess = {
   config: { ...erliConnection.config, allegroCategoryAccessEnabled: true },
 };
 
+const allegroConnection: Connection = {
+  ...sampleConnection,
+  id: 'conn_allegro_1',
+  name: 'Main Allegro Store',
+  platformType: 'allegro',
+  adapterKey: 'allegro.publicapi.v1',
+  enabledCapabilities: ['OrderSource', 'OfferManager'],
+  supportedCapabilities: ['OrderSource', 'OfferManager'],
+};
+
 describe('ErliCredentialsPanel', () => {
   afterEach(cleanup);
 
@@ -35,7 +47,7 @@ describe('ErliCredentialsPanel', () => {
     const envBacked = { ...erliConnection, credentialsBacked: false };
     renderWithProviders(<ErliCredentialsPanel connection={envBacked} />);
     expect(
-      screen.getByDisplayValue('Environment variable (not editable via UI)'),
+      screen.getByDisplayValue('Environment variable (not editable via UI)')
     ).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /rotate/i })).not.toBeInTheDocument();
   });
@@ -91,15 +103,11 @@ describe('ErliCredentialsPanel', () => {
 
     expect(screen.queryByPlaceholderText('Allegro Client ID')).not.toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getByRole('checkbox', { name: /browse allegro categories/i }),
-    );
+    fireEvent.click(screen.getByRole('checkbox', { name: /browse allegro categories/i }));
     expect(screen.getByPlaceholderText('Allegro Client ID')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Allegro Client Secret')).toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getByRole('checkbox', { name: /browse allegro categories/i }),
-    );
+    fireEvent.click(screen.getByRole('checkbox', { name: /browse allegro categories/i }));
     expect(screen.queryByPlaceholderText('Allegro Client ID')).not.toBeInTheDocument();
   });
 
@@ -114,7 +122,7 @@ describe('ErliCredentialsPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
 
     expect(
-      screen.getByText(/enter both the allegro client id and client secret/i),
+      screen.getByText(/enter both the allegro client id and client secret/i)
     ).toBeInTheDocument();
   });
 
@@ -213,7 +221,7 @@ describe('ErliCredentialsPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
 
     expect(
-      screen.getByText(/enter the allegro client id and client secret to enable/i),
+      screen.getByText(/enter the allegro client id and client secret to enable/i)
     ).toBeInTheDocument();
   });
 
@@ -262,11 +270,125 @@ describe('ErliCredentialsPanel', () => {
       expect(update).toHaveBeenCalledTimes(1);
     });
     expect(
-      await screen.findByText(/category-browsing setting failed to save/i),
+      await screen.findByText(/category-browsing setting failed to save/i)
     ).toBeInTheDocument();
     // Panel stays open (flag write failed, so it never got a chance to reflect the
     // new value anywhere the operator can see) and the fields aren't discarded.
     expect(screen.getByPlaceholderText('Allegro Client ID')).toHaveValue('client-123');
     expect(screen.queryByText('Credentials saved')).not.toBeInTheDocument();
+  });
+
+  describe('reuse an existing Allegro connection (#1387)', () => {
+    it('shows only the manual fields plus a "no connection found" notice when there are zero Allegro connections', async () => {
+      const list = vi.fn().mockResolvedValue([]);
+      const apiClient = createMockApiClient({ connections: { list } });
+      renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />, { apiClient });
+
+      fireEvent.click(screen.getByText('Rotate API key'));
+      fireEvent.click(screen.getByRole('checkbox', { name: /browse allegro categories/i }));
+
+      expect(
+        await screen.findByText(/no allegro connection found on this account/i)
+      ).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Allegro Client ID')).toBeInTheDocument();
+      expect(
+        screen.queryByText(/reuse credentials from an existing allegro connection/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it('defaults to the reuse radio with a connection picker when an Allegro connection exists', async () => {
+      const list = vi.fn().mockResolvedValue([allegroConnection]);
+      const apiClient = createMockApiClient({ connections: { list } });
+      renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />, { apiClient });
+
+      fireEvent.click(screen.getByText('Rotate API key'));
+      fireEvent.click(screen.getByRole('checkbox', { name: /browse allegro categories/i }));
+
+      expect(
+        await screen.findByText(/reuse credentials from an existing allegro connection/i)
+      ).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /reuse credentials/i })).toBeChecked();
+      expect(screen.getByRole('option', { name: allegroConnection.name })).toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('Allegro Client ID')).not.toBeInTheDocument();
+    });
+
+    it('sends reuseAllegroConnectionId (not raw credentials) and patches allegroCategoryAccessEnabled=true', async () => {
+      const list = vi.fn().mockResolvedValue([allegroConnection]);
+      const updateCredentials = vi.fn().mockResolvedValue(undefined);
+      const update = vi.fn().mockResolvedValue(erliConnectionWithAllegroAccess);
+      const apiClient = createMockApiClient({
+        connections: { list, updateCredentials, update },
+      });
+      renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />, { apiClient });
+
+      fireEvent.click(screen.getByText('Rotate API key'));
+      fireEvent.click(screen.getByRole('checkbox', { name: /browse allegro categories/i }));
+      await screen.findByRole('combobox', { name: /allegro connection to reuse/i });
+      fireEvent.change(screen.getByRole('combobox', { name: /allegro connection to reuse/i }), {
+        target: { value: allegroConnection.id },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
+
+      await waitFor(() => {
+        expect(updateCredentials).toHaveBeenCalledWith(erliConnection.id, {
+          reuseAllegroConnectionId: allegroConnection.id,
+        });
+      });
+      await waitFor(() => {
+        expect(update).toHaveBeenCalledWith(erliConnection.id, {
+          config: { ...erliConnection.config, allegroCategoryAccessEnabled: true },
+        });
+      });
+      // The raw Allegro secret is never present anywhere in this flow's payloads.
+      expect(updateCredentials.mock.calls[0][1]).not.toHaveProperty('allegroClientSecret');
+    });
+
+    it('switches to manual fields when "Enter Allegro app credentials manually" is chosen, unaffected by available connections', async () => {
+      const list = vi.fn().mockResolvedValue([allegroConnection]);
+      const updateCredentials = vi.fn().mockResolvedValue(undefined);
+      const update = vi.fn().mockResolvedValue(erliConnectionWithAllegroAccess);
+      const apiClient = createMockApiClient({
+        connections: { list, updateCredentials, update },
+      });
+      renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />, { apiClient });
+
+      fireEvent.click(screen.getByText('Rotate API key'));
+      fireEvent.click(screen.getByRole('checkbox', { name: /browse allegro categories/i }));
+      await screen.findByRole('radio', { name: /enter allegro app credentials manually/i });
+      fireEvent.click(
+        screen.getByRole('radio', { name: /enter allegro app credentials manually/i })
+      );
+
+      expect(screen.getByPlaceholderText('Allegro Client ID')).toBeInTheDocument();
+      fireEvent.change(screen.getByPlaceholderText('Allegro Client ID'), {
+        target: { value: 'client-123' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('Allegro Client Secret'), {
+        target: { value: 'secret-456' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
+
+      await waitFor(() => {
+        expect(updateCredentials).toHaveBeenCalledWith(erliConnection.id, {
+          allegroClientId: 'client-123',
+          allegroClientSecret: 'secret-456',
+        });
+      });
+    });
+
+    it('blocks submit when enabling via reuse without selecting a connection', async () => {
+      const list = vi.fn().mockResolvedValue([allegroConnection]);
+      const apiClient = createMockApiClient({ connections: { list } });
+      renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />, { apiClient });
+
+      fireEvent.click(screen.getByText('Rotate API key'));
+      fireEvent.click(screen.getByRole('checkbox', { name: /browse allegro categories/i }));
+      await screen.findByRole('combobox', { name: /allegro connection to reuse/i });
+      fireEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
+
+      expect(
+        screen.getByText(/select an allegro connection to reuse its credentials/i)
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/plugins/erli/components/erli-credentials-panel.tsx
+++ b/apps/web/src/plugins/erli/components/erli-credentials-panel.tsx
@@ -9,12 +9,24 @@
  * affordance instead.
  *
  * #1384 — also carries the "Browse Allegro categories when creating Erli
- * offers" checkbox. Checking it reveals the Allegro app's Client ID / Client
- * Secret fields (masked, show/hide toggle); saving writes them into the same
+ * offers" checkbox. Checking it reveals the Allegro app credential source
+ * choice (#1387 below); saving writes the resolved credentials into the same
  * `useUpdateConnectionCredentialsMutation` call as `apiKey` (merged, only the
  * fields the operator actually filled), then, in a second sequenced request,
  * patches `connection.config.allegroCategoryAccessEnabled` to match the
  * checkbox.
+ *
+ * #1387 — when the operator has at least one Allegro connection, the panel
+ * defaults to a "Reuse credentials from an existing Allegro connection"
+ * radio (with a `<select>` of that connection's name) alongside "Enter
+ * Allegro app credentials manually". Reuse sends `{ reuseAllegroConnectionId
+ * }` instead of `{ allegroClientId, allegroClientSecret }` — the backend
+ * (`ConnectionService.updateCredentials`, ADR-031) resolves the source
+ * connection's `clientId`/`clientSecret` server-side and writes them into
+ * this connection's own credentials; the raw secret is never sent to, or
+ * returned by, the browser. With zero Allegro connections the radio is
+ * skipped entirely and only the manual fields render (today's #1384
+ * behavior), with a short notice per the approved mockup.
  *
  * Atomicity note (see ADR-031 "Correction" + the PR description): the
  * backend's generic `PUT .../credentials` and `PATCH /connections/:id`
@@ -36,6 +48,7 @@
 import { useState, type FormEvent, type ReactElement } from 'react';
 import type { Connection } from '../../../features/connections';
 import {
+  useConnectionsQuery,
   useUpdateConnectionCredentialsMutation,
   useUpdateConnectionMutation,
 } from '../../../features/connections';
@@ -43,7 +56,10 @@ import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
 import { useToast } from '../../../shared/ui/toast-provider';
+
+type AllegroCredentialSource = 'reuse' | 'manual';
 
 function isAllegroCategoryAccessEnabled(connection: Connection): boolean {
   return connection.config.allegroCategoryAccessEnabled === true;
@@ -53,15 +69,25 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
   const [showRotate, setShowRotate] = useState(false);
   const [apiKey, setApiKey] = useState('');
   const [allegroEnabled, setAllegroEnabled] = useState(() =>
-    isAllegroCategoryAccessEnabled(connection),
+    isAllegroCategoryAccessEnabled(connection)
   );
   const [allegroClientId, setAllegroClientId] = useState('');
   const [allegroClientSecret, setAllegroClientSecret] = useState('');
   const [showSecret, setShowSecret] = useState(false);
+  const [credSource, setCredSource] = useState<AllegroCredentialSource>('reuse');
+  const [selectedAllegroConnectionId, setSelectedAllegroConnectionId] = useState('');
   const [validationError, setValidationError] = useState<string | null>(null);
   const rotate = useUpdateConnectionCredentialsMutation();
   const updateConfig = useUpdateConnectionMutation();
   const { showToast } = useToast();
+  // #1387 — every Allegro connection the operator already has, offered as a
+  // "reuse this app's credentials" pick list. Filtered client-side (not just
+  // trusted from the `platformType` query param) so a mocked/misbehaving
+  // response never renders a non-Allegro connection as a reuse target.
+  const allegroConnectionsQuery = useConnectionsQuery({
+    platformType: 'allegro',
+    status: 'active',
+  });
 
   if (!connection.credentialsBacked) {
     return (
@@ -71,12 +97,24 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
     );
   }
 
+  const allegroConnections = (allegroConnectionsQuery.data ?? []).filter(
+    (c) => c.platformType === 'allegro' && c.status === 'active'
+  );
+  const hasAllegroConnections = allegroConnections.length > 0;
+  // Zero Allegro connections collapses the choice to manual entry regardless
+  // of the radio's own state — there's nothing to reuse.
+  const effectiveCredSource: AllegroCredentialSource = hasAllegroConnections
+    ? credSource
+    : 'manual';
+
   const initialAllegroEnabled = isAllegroCategoryAccessEnabled(connection);
   const idFilled = allegroClientId.trim().length > 0;
   const secretFilled = allegroClientSecret.trim().length > 0;
+  const reuseSelected = selectedAllegroConnectionId.trim().length > 0;
   const canSubmit =
     apiKey.trim().length > 0 ||
-    (allegroEnabled && (idFilled || secretFilled)) ||
+    (allegroEnabled && effectiveCredSource === 'manual' && (idFilled || secretFilled)) ||
+    (allegroEnabled && effectiveCredSource === 'reuse' && reuseSelected) ||
     allegroEnabled !== initialAllegroEnabled;
 
   function openPanel(): void {
@@ -84,6 +122,8 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
     // every time the panel opens — it may have changed since the last open
     // (e.g. another operator, or a prior save in this session).
     setAllegroEnabled(initialAllegroEnabled);
+    setCredSource('reuse');
+    setSelectedAllegroConnectionId('');
     setShowRotate(true);
   }
 
@@ -93,6 +133,8 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
     setAllegroClientId('');
     setAllegroClientSecret('');
     setShowSecret(false);
+    setCredSource('reuse');
+    setSelectedAllegroConnectionId('');
     setValidationError(null);
   }
 
@@ -102,15 +144,22 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
     if (!canSubmit) return;
 
     if (allegroEnabled) {
-      if (idFilled !== secretFilled) {
+      if (effectiveCredSource === 'manual') {
+        if (idFilled !== secretFilled) {
+          setValidationError(
+            'Enter both the Allegro Client ID and Client Secret, or leave both blank.'
+          );
+          return;
+        }
+        if (!idFilled && !secretFilled && !initialAllegroEnabled) {
+          setValidationError(
+            'Enter the Allegro Client ID and Client Secret to enable category browsing.'
+          );
+          return;
+        }
+      } else if (!reuseSelected && !initialAllegroEnabled) {
         setValidationError(
-          'Enter both the Allegro Client ID and Client Secret, or leave both blank.',
-        );
-        return;
-      }
-      if (!idFilled && !secretFilled && !initialAllegroEnabled) {
-        setValidationError(
-          'Enter the Allegro Client ID and Client Secret to enable category browsing.',
+          'Select an Allegro connection to reuse its credentials, or switch to manual entry.'
         );
         return;
       }
@@ -121,9 +170,15 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
     // Both-or-neither is already enforced above; omit both fields entirely
     // (not empty strings) when the checkbox is unchecked, so the backend's
     // shape validator's "both or neither" rule is satisfied by omission.
-    if (allegroEnabled && idFilled && secretFilled) {
+    if (allegroEnabled && effectiveCredSource === 'manual' && idFilled && secretFilled) {
       credentials.allegroClientId = allegroClientId.trim();
       credentials.allegroClientSecret = allegroClientSecret.trim();
+    }
+    // #1387 — server-side copy: the backend resolves this into
+    // allegroClientId/allegroClientSecret from the source connection. The
+    // raw secret never round-trips through this browser.
+    if (allegroEnabled && effectiveCredSource === 'reuse' && reuseSelected) {
+      credentials.reuseAllegroConnectionId = selectedAllegroConnectionId;
     }
 
     try {
@@ -132,10 +187,14 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
       }
       // Second, sequenced request: keep `allegroCategoryAccessEnabled` in
       // sync with the checkbox whenever either changed or new Allegro
-      // credentials were just written. Only reached once the credentials
-      // write above has succeeded (or wasn't needed) — see the module
-      // header for why this ordering fails safe.
-      if (allegroEnabled !== initialAllegroEnabled || 'allegroClientId' in credentials) {
+      // credentials were just written (manual or reused). Only reached once
+      // the credentials write above has succeeded (or wasn't needed) — see
+      // the module header for why this ordering fails safe.
+      if (
+        allegroEnabled !== initialAllegroEnabled ||
+        'allegroClientId' in credentials ||
+        'reuseAllegroConnectionId' in credentials
+      ) {
         await updateConfig.mutateAsync({
           connectionId: connection.id,
           input: {
@@ -196,40 +255,108 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
 
           {allegroEnabled ? (
             <div className="form-grid">
-              <div>
-                <Input
-                  autoComplete="off"
-                  placeholder="Allegro Client ID"
-                  value={allegroClientId}
-                  onChange={(event) => setAllegroClientId(event.target.value)}
-                />
-                <small style={{ display: 'block', color: 'var(--text-muted)' }}>
-                  From an Allegro app you register at apps.developer.allegro.pl. Used only to read
-                  the public category catalog - never to sign in as a seller or place offers.
-                </small>
-              </div>
-              <div>
-                <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
-                  <Input
-                    type={showSecret ? 'text' : 'password'}
-                    autoComplete="off"
-                    placeholder="Allegro Client Secret"
-                    value={allegroClientSecret}
-                    onChange={(event) => setAllegroClientSecret(event.target.value)}
-                  />
-                  <Button
-                    tone="ghost"
-                    type="button"
-                    onClick={() => setShowSecret((v) => !v)}
-                    aria-label={showSecret ? 'Hide Client Secret' : 'Show Client Secret'}
+              {hasAllegroConnections ? (
+                <div>
+                  <label
+                    style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}
                   >
-                    {showSecret ? 'Hide' : 'Show'}
-                  </Button>
+                    <input
+                      type="radio"
+                      name="erli-allegro-cred-source"
+                      checked={effectiveCredSource === 'reuse'}
+                      onChange={() => setCredSource('reuse')}
+                    />
+                    <span>
+                      <strong>Reuse credentials from an existing Allegro connection</strong>
+                      <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                        Recommended - uses the same app credentials already configured on that
+                        connection. Nothing new to register.
+                      </small>
+                    </span>
+                  </label>
+                  {effectiveCredSource === 'reuse' ? (
+                    <div style={{ marginLeft: 'calc(0.875rem + var(--space-2))' }}>
+                      <Select
+                        aria-label="Allegro connection to reuse"
+                        value={selectedAllegroConnectionId}
+                        onChange={(event) => setSelectedAllegroConnectionId(event.target.value)}
+                      >
+                        <option value="">Select an Allegro connection...</option>
+                        {allegroConnections.map((c) => (
+                          <option key={c.id} value={c.id}>
+                            {c.name}
+                          </option>
+                        ))}
+                      </Select>
+                      <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                        Only read access to the public category catalog is used - this
+                        connection&apos;s seller credentials are never touched.
+                      </small>
+                    </div>
+                  ) : null}
+                  <label
+                    style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}
+                  >
+                    <input
+                      type="radio"
+                      name="erli-allegro-cred-source"
+                      checked={effectiveCredSource === 'manual'}
+                      onChange={() => setCredSource('manual')}
+                    />
+                    <span>
+                      <strong>Enter Allegro app credentials manually</strong>
+                      <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                        Use a different Allegro app - e.g. one dedicated just for category browsing.
+                      </small>
+                    </span>
+                  </label>
                 </div>
-                <small style={{ display: 'block', color: 'var(--text-muted)' }}>
-                  Stored encrypted. You won&apos;t see it again after saving.
-                </small>
-              </div>
+              ) : (
+                <Alert tone="info">
+                  No Allegro connection found on this account. Enter your own Allegro app
+                  credentials below to enable category browsing.
+                </Alert>
+              )}
+
+              {effectiveCredSource === 'manual' ? (
+                <div className="form-grid">
+                  <div>
+                    <Input
+                      autoComplete="off"
+                      placeholder="Allegro Client ID"
+                      value={allegroClientId}
+                      onChange={(event) => setAllegroClientId(event.target.value)}
+                    />
+                    <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                      From an Allegro app you register at apps.developer.allegro.pl. Used only to
+                      read the public category catalog - never to sign in as a seller or place
+                      offers.
+                    </small>
+                  </div>
+                  <div>
+                    <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+                      <Input
+                        type={showSecret ? 'text' : 'password'}
+                        autoComplete="off"
+                        placeholder="Allegro Client Secret"
+                        value={allegroClientSecret}
+                        onChange={(event) => setAllegroClientSecret(event.target.value)}
+                      />
+                      <Button
+                        tone="ghost"
+                        type="button"
+                        onClick={() => setShowSecret((v) => !v)}
+                        aria-label={showSecret ? 'Hide Client Secret' : 'Show Client Secret'}
+                      >
+                        {showSecret ? 'Hide' : 'Show'}
+                      </Button>
+                    </div>
+                    <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                      Stored encrypted. You won&apos;t see it again after saving.
+                    </small>
+                  </div>
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -463,7 +463,7 @@ authoring your plugin). Its four fields:
 
 The `HostServices` bag passed into `register` and `createCapabilityAdapter`
 is defined at
-[`libs/plugin-sdk/src/host-services.ts:54-163`](../libs/plugin-sdk/src/host-services.ts#L54-L163).
+[`libs/plugin-sdk/src/host-services.ts:55-178`](../libs/plugin-sdk/src/host-services.ts#L55-L178).
 It splits into two blocks:
 
 - **Read inputs** (use): `logger`, `identifierMapping`,
@@ -473,7 +473,8 @@ It splits into two blocks:
   `emailNormalizerRegistry`, `retryClassifierRegistry`,
   `schedulerTaskRegistry`, `webhookProvisioningRegistry`,
   `connectionConfigShapeValidatorRegistry`,
-  `connectionCredentialsShapeValidatorRegistry`.
+  `connectionCredentialsShapeValidatorRegistry`,
+  `connectionCredentialsRewriterRegistry`.
 
 **Plugin-specific cross-package deps** (your customer-projection
 repository, mapping-config service, etc.) are *not* in the
@@ -1045,7 +1046,7 @@ If you're proposing a new "bulk" capability on a port, that's almost certainly a
   vertical-slice patterns, the PrestaShop opt-in helper.
 - [`libs/plugin-sdk/src/adapter-plugin.ts:42-110`](../libs/plugin-sdk/src/adapter-plugin.ts#L42-L110)
   — the `AdapterPlugin` contract spec, header-comment form.
-- [`libs/plugin-sdk/src/host-services.ts:54-163`](../libs/plugin-sdk/src/host-services.ts#L54-L163)
+- [`libs/plugin-sdk/src/host-services.ts:55-178`](../libs/plugin-sdk/src/host-services.ts#L55-L178)
   — the `HostServices` bag, fields split into read-inputs vs side
   registries.
 

--- a/libs/core/src/integrations/domain/exceptions/connection-credentials-rewrite.exception.ts
+++ b/libs/core/src/integrations/domain/exceptions/connection-credentials-rewrite.exception.ts
@@ -1,0 +1,30 @@
+/**
+ * ConnectionCredentialsRewriteException
+ *
+ * Thrown by `ConnectionCredentialsRewriterPort` implementations when the
+ * submitted credentials payload cannot be rewritten (e.g. a referenced
+ * sibling connection is the wrong kind, or a prerequisite field is missing).
+ * `ConnectionService` catches this at the API boundary and maps it to
+ * `BadRequestException`.
+ *
+ * Sibling of {@link InvalidCredentialsShapeException} — same rationale
+ * (plugins don't depend on NestJS exception types for failure paths). Kept
+ * as a distinct exception type rather than reusing
+ * `InvalidCredentialsShapeException` because a rewrite failure is a
+ * different concern from a shape failure: the payload's *shape* may be
+ * perfectly valid (e.g. `{ reuseAllegroConnectionId: "..." }`) while the
+ * *rewrite* still fails because the referenced id doesn't resolve to a
+ * usable source.
+ *
+ * @module libs/core/src/integrations/domain/exceptions
+ */
+export class ConnectionCredentialsRewriteException extends Error {
+  constructor(
+    public readonly pluginName: string,
+    detail: string
+  ) {
+    super(`Could not rewrite ${pluginName} credentials: ${detail}`);
+    this.name = 'ConnectionCredentialsRewriteException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/integrations/domain/ports/connection-credentials-rewriter.port.ts
+++ b/libs/core/src/integrations/domain/ports/connection-credentials-rewriter.port.ts
@@ -1,0 +1,48 @@
+/**
+ * Connection Credentials Rewriter Port (#1387, ADR-031)
+ *
+ * Contract for per-plugin transformation of a raw `credentials` payload
+ * submitted on connection create / credential rotation, BEFORE it is merged
+ * onto the existing stored blob and shape-validated. Distinct from
+ * {@link ConnectionCredentialsShapeValidatorPort}: a validator only checks
+ * shape and never mutates the payload, while a rewriter is free to replace,
+ * add, or drop fields (e.g. resolving a caller-supplied reference into
+ * concrete secret values fetched server-side).
+ *
+ * Each plugin registers an adapter via
+ * `host.connectionCredentialsRewriterRegistry.register(adapterKey, …)` in
+ * `AdapterPlugin.register(host)` (or, when the rewriter needs a dependency
+ * outside the framework-neutral `HostServices` bag, from a companion NestJS
+ * module that injects `CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN`
+ * directly — mirroring the existing webhook-provisioner pattern). The
+ * registry is keyed by **adapterKey** (consistent with the other host
+ * registries).
+ *
+ * Implementations throw `ConnectionCredentialsRewriteException` (a core
+ * domain exception) on failure. `ConnectionService` catches and maps to
+ * `BadRequestException` at the API boundary.
+ *
+ * The port's contract is deliberately platform-neutral: it says nothing
+ * about *what* a plugin rewrites — only that it may transform the incoming
+ * payload before persistence. Any platform-specific field names or
+ * semantics (e.g. "resolve a sibling Allegro connection's app credentials")
+ * live entirely in the adapter implementation, never in this port.
+ *
+ * @module libs/core/src/integrations/domain/ports
+ * @see {@link ConnectionCredentialsRewriterRegistryService} for the registry
+ * @see {@link ConnectionCredentialsRewriteException} for the failure exception
+ */
+export interface ConnectionCredentialsRewriterPort {
+  /**
+   * Rewrite the raw credentials payload, returning the payload to actually
+   * merge/persist. Implementations that don't need to change anything for a
+   * given payload return it unchanged.
+   *
+   * @param credentials - The raw credential payload, exactly as the operator
+   *   sent it.
+   * @returns The (possibly transformed) credentials payload.
+   * @throws ConnectionCredentialsRewriteException when the payload cannot be
+   *   rewritten.
+   */
+  rewrite(credentials: Record<string, unknown>): Promise<Record<string, unknown>>;
+}

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -19,6 +19,7 @@ export { InboundWebhookDecoderRegistryService } from './infrastructure/adapters/
 export { EmailNormalizerRegistryService } from './infrastructure/adapters/email-normalizer-registry.service';
 export { ConnectionConfigShapeValidatorRegistryService } from './infrastructure/adapters/connection-config-shape-validator-registry.service';
 export { ConnectionCredentialsShapeValidatorRegistryService } from './infrastructure/adapters/connection-credentials-shape-validator-registry.service';
+export { ConnectionCredentialsRewriterRegistryService } from './infrastructure/adapters/connection-credentials-rewriter-registry.service';
 export { OAuthCompletionRegistryService } from './infrastructure/adapters/oauth-completion-registry.service';
 
 // Ports
@@ -32,6 +33,7 @@ export { InboundWebhookDecoderPort } from './domain/ports/inbound-webhook-decode
 export { EmailNormalizerPort } from './domain/ports/email-normalizer.port';
 export { ConnectionConfigShapeValidatorPort } from './domain/ports/connection-config-shape-validator.port';
 export { ConnectionCredentialsShapeValidatorPort } from './domain/ports/connection-credentials-shape-validator.port';
+export { ConnectionCredentialsRewriterPort } from './domain/ports/connection-credentials-rewriter.port';
 export { OAuthCompletionPort } from './domain/ports/oauth-completion.port';
 export {
   WebhookSecretProviderPort,
@@ -83,6 +85,7 @@ export { DuplicateAdapterKeyException } from './domain/exceptions/duplicate-adap
 export { DuplicatePlatformDefaultException } from './domain/exceptions/duplicate-platform-default.exception';
 export { InvalidConnectionConfigException } from './domain/exceptions/invalid-connection-config.exception';
 export { InvalidCredentialsShapeException } from './domain/exceptions/invalid-credentials-shape.exception';
+export { ConnectionCredentialsRewriteException } from './domain/exceptions/connection-credentials-rewrite.exception';
 export { OAuthCodeExchangeException } from './domain/exceptions/oauth-code-exchange.exception';
 export {
   flattenValidationErrors,

--- a/libs/core/src/integrations/infrastructure/adapters/connection-credentials-rewriter-registry.service.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/connection-credentials-rewriter-registry.service.ts
@@ -1,0 +1,33 @@
+/**
+ * Connection Credentials Rewriter Registry Service (#1387, ADR-031)
+ *
+ * Holds `ConnectionCredentialsRewriterPort` implementations keyed by
+ * `adapterKey`. Plugins self-register via
+ * `host.connectionCredentialsRewriterRegistry.register(...)` at boot (or, for
+ * rewriters that need a dependency outside `HostServices`, from a companion
+ * NestJS module injecting this service's token directly). Consumed by
+ * `ConnectionService.updateCredentials` before merge + shape validation.
+ * Sibling of {@link ConnectionCredentialsShapeValidatorRegistryService}.
+ *
+ * @module libs/core/src/integrations/infrastructure/adapters
+ * @see {@link ConnectionCredentialsRewriterPort} for the port interface
+ */
+import { Injectable } from '@nestjs/common';
+import type { ConnectionCredentialsRewriterPort } from '../../domain/ports/connection-credentials-rewriter.port';
+
+@Injectable()
+export class ConnectionCredentialsRewriterRegistryService {
+  private readonly rewriters: Map<string, ConnectionCredentialsRewriterPort> = new Map();
+
+  register(adapterKey: string, rewriter: ConnectionCredentialsRewriterPort): void {
+    this.rewriters.set(adapterKey, rewriter);
+  }
+
+  get(adapterKey: string): ConnectionCredentialsRewriterPort | undefined {
+    return this.rewriters.get(adapterKey);
+  }
+
+  has(adapterKey: string): boolean {
+    return this.rewriters.has(adapterKey);
+  }
+}

--- a/libs/core/src/integrations/integrations.module.ts
+++ b/libs/core/src/integrations/integrations.module.ts
@@ -23,6 +23,7 @@ import { InboundWebhookDecoderRegistryService } from './infrastructure/adapters/
 import { EmailNormalizerRegistryService } from './infrastructure/adapters/email-normalizer-registry.service';
 import { ConnectionConfigShapeValidatorRegistryService } from './infrastructure/adapters/connection-config-shape-validator-registry.service';
 import { ConnectionCredentialsShapeValidatorRegistryService } from './infrastructure/adapters/connection-credentials-shape-validator-registry.service';
+import { ConnectionCredentialsRewriterRegistryService } from './infrastructure/adapters/connection-credentials-rewriter-registry.service';
 import { OAuthCompletionRegistryService } from './infrastructure/adapters/oauth-completion-registry.service';
 import { CredentialsWebhookSecretAdapter } from './infrastructure/adapters/credentials-webhook-secret.adapter';
 import { WebhookSecretService } from './application/services/webhook-secret.service';
@@ -45,6 +46,7 @@ import {
   EMAIL_NORMALIZER_REGISTRY_TOKEN,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
   INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
 } from './integrations.tokens';
 
@@ -65,6 +67,7 @@ export {
   EMAIL_NORMALIZER_REGISTRY_TOKEN,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
   INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
 } from './integrations.tokens';
 
@@ -86,6 +89,7 @@ export {
     EmailNormalizerRegistryService,
     ConnectionConfigShapeValidatorRegistryService,
     ConnectionCredentialsShapeValidatorRegistryService,
+    ConnectionCredentialsRewriterRegistryService,
     OAuthCompletionRegistryService,
     CredentialsWebhookSecretAdapter,
     WebhookSecretService,
@@ -137,6 +141,10 @@ export {
       useExisting: ConnectionCredentialsShapeValidatorRegistryService,
     },
     {
+      provide: CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+      useExisting: ConnectionCredentialsRewriterRegistryService,
+    },
+    {
       provide: INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
       useExisting: OAuthCompletionRegistryService,
     },
@@ -169,6 +177,7 @@ export {
     EMAIL_NORMALIZER_REGISTRY_TOKEN,
     CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
     CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+    CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
     INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
     WEBHOOK_SECRET_PROVIDER_TOKEN,
     WEBHOOK_SECRET_SERVICE_TOKEN,
@@ -184,6 +193,7 @@ export {
     EmailNormalizerRegistryService,
     ConnectionConfigShapeValidatorRegistryService,
     ConnectionCredentialsShapeValidatorRegistryService,
+    ConnectionCredentialsRewriterRegistryService,
     OAuthCompletionRegistryService,
     WebhookSecretService,
   ],

--- a/libs/core/src/integrations/integrations.tokens.ts
+++ b/libs/core/src/integrations/integrations.tokens.ts
@@ -36,4 +36,7 @@ export const CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN = Symbol(
 export const INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN = Symbol(
   'OAuthCompletionRegistryService',
 );
+export const CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN = Symbol(
+  'ConnectionCredentialsRewriterRegistryService',
+);
 

--- a/libs/integrations/allegro/src/allegro-integration.module.ts
+++ b/libs/integrations/allegro/src/allegro-integration.module.ts
@@ -39,6 +39,8 @@ import {
   ConnectionConfigShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionCredentialsShapeValidatorRegistryService,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+  ConnectionCredentialsRewriterRegistryService,
   INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
   OAuthCompletionRegistryService,
   CREDENTIALS_SERVICE_TOKEN,
@@ -129,6 +131,8 @@ export class AllegroIntegrationModule implements OnModuleInit {
     private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
     @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
     private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
+    @Inject(CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN)
+    private readonly connectionCredentialsRewriterRegistry: ConnectionCredentialsRewriterRegistryService,
     @Inject(INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN)
     private readonly oauthCompletionRegistry: OAuthCompletionRegistryService,
     @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
@@ -192,6 +196,7 @@ export class AllegroIntegrationModule implements OnModuleInit {
       inboundWebhookDecoderRegistry: this.inboundWebhookDecoderRegistry,
       connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
       connectionCredentialsShapeValidatorRegistry: this.connectionCredentialsShapeValidatorRegistry,
+      connectionCredentialsRewriterRegistry: this.connectionCredentialsRewriterRegistry,
       oauthCompletionRegistry: this.oauthCompletionRegistry,
     };
 

--- a/libs/integrations/erli/src/erli-credentials-rewriter.module.ts
+++ b/libs/integrations/erli/src/erli-credentials-rewriter.module.ts
@@ -1,0 +1,50 @@
+/**
+ * Erli Credentials Rewriter Module (#1387, ADR-031)
+ *
+ * Companion NestJS module composed into `ErliIntegrationModule`. It exists
+ * because `ErliAllegroCredentialsRewriterAdapter` needs a NestJS-injected
+ * `ConnectionPort` (to resolve the referenced sibling Allegro connection) —
+ * deliberately NOT part of the framework-neutral `HostServices` bag. Rather
+ * than restructure the whole Erli plugin, this small module injects exactly
+ * `ConnectionPort` + `CredentialsResolverPort` + the rewriter registry, and
+ * registers the adapter in `onModuleInit`. Mirrors
+ * `ErliWebhookProvisioningModule`'s shape.
+ *
+ * @module libs/integrations/erli/src
+ */
+import { Inject, Module, type OnModuleInit } from '@nestjs/common';
+import {
+  CredentialsResolverPort,
+  CREDENTIALS_RESOLVER_TOKEN,
+  IntegrationsModule,
+  ConnectionCredentialsRewriterRegistryService,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+} from '@openlinker/core/integrations';
+import {
+  ConnectionPort,
+  CONNECTION_PORT_TOKEN,
+  IdentifierMappingModule,
+} from '@openlinker/core/identifier-mapping';
+import { ERLI_ADAPTER_KEY } from './erli.constants';
+import { ErliAllegroCredentialsRewriterAdapter } from './infrastructure/adapters/erli-allegro-credentials-rewriter.adapter';
+
+@Module({
+  imports: [IntegrationsModule, IdentifierMappingModule],
+})
+export class ErliCredentialsRewriterModule implements OnModuleInit {
+  constructor(
+    @Inject(CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN)
+    private readonly connectionCredentialsRewriterRegistry: ConnectionCredentialsRewriterRegistryService,
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connectionPort: ConnectionPort,
+    @Inject(CREDENTIALS_RESOLVER_TOKEN)
+    private readonly credentialsResolver: CredentialsResolverPort
+  ) {}
+
+  onModuleInit(): void {
+    this.connectionCredentialsRewriterRegistry.register(
+      ERLI_ADAPTER_KEY,
+      new ErliAllegroCredentialsRewriterAdapter(this.connectionPort, this.credentialsResolver)
+    );
+  }
+}

--- a/libs/integrations/erli/src/erli-integration.module.ts
+++ b/libs/integrations/erli/src/erli-integration.module.ts
@@ -34,6 +34,8 @@ import {
   ConnectionConfigShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionCredentialsShapeValidatorRegistryService,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+  ConnectionCredentialsRewriterRegistryService,
   INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
   OAuthCompletionRegistryService,
   CREDENTIALS_RESOLVER_TOKEN,
@@ -64,6 +66,7 @@ import { CACHE_PORT_TOKEN, type CachePort } from '@openlinker/shared';
 import type { HostServices } from '@openlinker/plugin-sdk';
 import { createErliPlugin } from './erli-plugin';
 import { ErliWebhookProvisioningModule } from './erli-webhook-provisioning.module';
+import { ErliCredentialsRewriterModule } from './erli-credentials-rewriter.module';
 
 @Module({
   imports: [
@@ -75,6 +78,11 @@ import { ErliWebhookProvisioningModule } from './erli-webhook-provisioning.modul
     // + IWebhookSecretService (not in HostServices), so it self-registers from
     // this companion module rather than from plugin.register(host).
     ErliWebhookProvisioningModule,
+    // #1387: the Allegro-credentials-reuse rewriter needs NestJS-injected
+    // ConnectionPort (not in HostServices), so it self-registers from this
+    // companion module rather than from plugin.register(host) — same shape
+    // as ErliWebhookProvisioningModule above.
+    ErliCredentialsRewriterModule,
   ],
 })
 export class ErliIntegrationModule implements OnModuleInit {
@@ -99,6 +107,8 @@ export class ErliIntegrationModule implements OnModuleInit {
     private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
     @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
     private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
+    @Inject(CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN)
+    private readonly connectionCredentialsRewriterRegistry: ConnectionCredentialsRewriterRegistryService,
     @Inject(INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN)
     private readonly oauthCompletionRegistry: OAuthCompletionRegistryService,
     @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
@@ -140,6 +150,7 @@ export class ErliIntegrationModule implements OnModuleInit {
       inboundWebhookDecoderRegistry: this.inboundWebhookDecoderRegistry,
       connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
       connectionCredentialsShapeValidatorRegistry: this.connectionCredentialsShapeValidatorRegistry,
+      connectionCredentialsRewriterRegistry: this.connectionCredentialsRewriterRegistry,
       oauthCompletionRegistry: this.oauthCompletionRegistry,
     };
 

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-allegro-credentials-rewriter.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-allegro-credentials-rewriter.adapter.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Erli Allegro-Credentials-Reuse Rewriter Tests (#1387, ADR-031)
+ *
+ * Asserts the `reuseAllegroConnectionId` shape resolves server-side into a
+ * concrete `allegroClientId`/`allegroClientSecret` pair, so the raw Allegro
+ * `clientSecret` is never serialized into an HTTP response body; and that a
+ * payload without `reuseAllegroConnectionId` passes through unchanged.
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
+ */
+import type { Connection, ConnectionPort } from '@openlinker/core/identifier-mapping';
+import { ConnectionNotFoundException } from '@openlinker/core/identifier-mapping';
+import { ConnectionCredentialsRewriteException } from '@openlinker/core/integrations';
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import { ErliAllegroCredentialsRewriterAdapter } from '../erli-allegro-credentials-rewriter.adapter';
+
+function buildAllegroConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'allegro-conn-1',
+    platformType: 'allegro',
+    name: 'Main Allegro Store',
+    status: 'active',
+    config: {},
+    credentialsRef: 'db:allegro-cred-ref-1',
+    ...overrides,
+  } as Connection;
+}
+
+describe('ErliAllegroCredentialsRewriterAdapter', () => {
+  let connectionPort: jest.Mocked<Pick<ConnectionPort, 'get'>>;
+  let credentialsResolver: jest.Mocked<CredentialsResolverPort>;
+  let adapter: ErliAllegroCredentialsRewriterAdapter;
+
+  beforeEach(() => {
+    connectionPort = { get: jest.fn() };
+    credentialsResolver = { get: jest.fn() };
+    adapter = new ErliAllegroCredentialsRewriterAdapter(
+      connectionPort as unknown as ConnectionPort,
+      credentialsResolver
+    );
+  });
+
+  it('should return the credentials unchanged when reuseAllegroConnectionId is absent', async () => {
+    const result = await adapter.rewrite({ apiKey: 'unchanged' });
+
+    expect(result).toEqual({ apiKey: 'unchanged' });
+    expect(connectionPort.get).not.toHaveBeenCalled();
+  });
+
+  it('should copy clientId/clientSecret from the source Allegro connection, dropping reuseAllegroConnectionId', async () => {
+    connectionPort.get.mockResolvedValue(buildAllegroConnection());
+    credentialsResolver.get.mockResolvedValue({
+      clientId: 'reused-client-id',
+      clientSecret: 'reused-client-secret',
+    });
+
+    const result = await adapter.rewrite({
+      apiKey: 'keep-me',
+      reuseAllegroConnectionId: 'allegro-conn-1',
+    });
+
+    expect(connectionPort.get).toHaveBeenCalledWith('allegro-conn-1');
+    expect(credentialsResolver.get).toHaveBeenCalledWith('db:allegro-cred-ref-1');
+    expect(result).toEqual({
+      apiKey: 'keep-me',
+      allegroClientId: 'reused-client-id',
+      allegroClientSecret: 'reused-client-secret',
+    });
+  });
+
+  it('should reject a blank reuseAllegroConnectionId', async () => {
+    await expect(adapter.rewrite({ reuseAllegroConnectionId: '   ' })).rejects.toThrow(
+      ConnectionCredentialsRewriteException
+    );
+    expect(connectionPort.get).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the source connection id does not resolve to an existing connection', async () => {
+    connectionPort.get.mockRejectedValue(new ConnectionNotFoundException('does-not-exist'));
+
+    await expect(
+      adapter.rewrite({ reuseAllegroConnectionId: 'does-not-exist' })
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  it('should reject when the source connection is not an Allegro connection', async () => {
+    connectionPort.get.mockResolvedValue(
+      buildAllegroConnection({ id: 'other-conn-1', platformType: 'prestashop' })
+    );
+
+    await expect(
+      adapter.rewrite({ reuseAllegroConnectionId: 'other-conn-1' })
+    ).rejects.toThrow(/is not an Allegro connection/);
+  });
+
+  it('should reject when the source Allegro connection has no client credentials configured', async () => {
+    connectionPort.get.mockResolvedValue(buildAllegroConnection());
+    credentialsResolver.get.mockResolvedValue({});
+
+    await expect(
+      adapter.rewrite({ reuseAllegroConnectionId: 'allegro-conn-1' })
+    ).rejects.toThrow(/does not have app client credentials/);
+  });
+
+  it('should propagate unexpected errors from ConnectionPort.get unchanged', async () => {
+    const unexpected = new Error('db unavailable');
+    connectionPort.get.mockRejectedValue(unexpected);
+
+    await expect(adapter.rewrite({ reuseAllegroConnectionId: 'allegro-conn-1' })).rejects.toThrow(
+      unexpected
+    );
+  });
+});

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-allegro-credentials-rewriter.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-allegro-credentials-rewriter.adapter.ts
@@ -1,0 +1,106 @@
+/**
+ * Erli Allegro-Credentials-Reuse Rewriter (#1387, ADR-031)
+ *
+ * Implements `ConnectionCredentialsRewriterPort` for the Erli adapter key.
+ * Resolves the `reuseAllegroConnectionId` shape into a concrete
+ * `allegroClientId`/`allegroClientSecret` pair, server-side, so the raw
+ * Allegro `clientSecret` is never serialized into an HTTP response body.
+ * Registered against `ConnectionCredentialsRewriterRegistryService` at
+ * `erli.shopapi.v1` from `ErliCredentialsRewriterModule` (not from
+ * `erli-plugin.ts#register(host)`) because it needs `ConnectionPort` — a
+ * NestJS-injected dependency deliberately kept out of the framework-neutral
+ * `HostServices` bag — mirroring `ErliWebhookProvisioningAdapter`'s wiring.
+ *
+ * "Belongs to the operator's own tenant" (per the issue's acceptance
+ * criteria) has no dedicated model in this codebase today — there is no
+ * `tenantId`/`organizationId` anywhere on `Connection` or `AuthenticatedUser`;
+ * `@Roles('admin')` on the credentials-rotation endpoint is the only access
+ * boundary that exists, and it already applies uniformly to every connection
+ * in the single OpenLinker deployment. The closest enforceable "ownership"
+ * check available is that the source id resolves to a real, existing
+ * connection of `platformType: 'allegro'` in this same instance — anything
+ * else (a missing id, or an id for a non-Allegro connection) is rejected
+ * below.
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters
+ * @see {@link ConnectionCredentialsRewriterPort}
+ */
+import {
+  type ConnectionCredentialsRewriterPort,
+  ConnectionCredentialsRewriteException,
+  type CredentialsResolverPort,
+} from '@openlinker/core/integrations';
+import {
+  type Connection,
+  type ConnectionPort,
+  ConnectionNotFoundException,
+} from '@openlinker/core/identifier-mapping';
+import { Logger } from '@openlinker/shared/logging';
+
+interface AllegroAppCredentials {
+  clientId?: string;
+  clientSecret?: string;
+}
+
+export class ErliAllegroCredentialsRewriterAdapter implements ConnectionCredentialsRewriterPort {
+  private readonly logger = new Logger(ErliAllegroCredentialsRewriterAdapter.name);
+
+  constructor(
+    private readonly connectionPort: ConnectionPort,
+    private readonly credentialsResolver: CredentialsResolverPort,
+    private readonly pluginName: string = 'Erli'
+  ) {}
+
+  async rewrite(credentials: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const { reuseAllegroConnectionId, ...rest } = credentials;
+    if (reuseAllegroConnectionId === undefined) {
+      return credentials;
+    }
+    if (typeof reuseAllegroConnectionId !== 'string' || reuseAllegroConnectionId.trim() === '') {
+      throw new ConnectionCredentialsRewriteException(
+        this.pluginName,
+        '`reuseAllegroConnectionId` must be a non-empty string'
+      );
+    }
+
+    let sourceConnection: Connection;
+    try {
+      sourceConnection = await this.connectionPort.get(reuseAllegroConnectionId);
+    } catch (error) {
+      if (error instanceof ConnectionNotFoundException) {
+        throw new ConnectionCredentialsRewriteException(
+          this.pluginName,
+          `connection ${reuseAllegroConnectionId} does not exist`
+        );
+      }
+      throw error;
+    }
+    if (sourceConnection.platformType !== 'allegro') {
+      throw new ConnectionCredentialsRewriteException(
+        this.pluginName,
+        `connection ${reuseAllegroConnectionId} is not an Allegro connection ` +
+          `(platformType: ${sourceConnection.platformType}); cannot reuse its credentials`
+      );
+    }
+
+    const sourceCredentials = await this.credentialsResolver.get<AllegroAppCredentials>(
+      sourceConnection.credentialsRef
+    );
+    if (!sourceCredentials.clientId || !sourceCredentials.clientSecret) {
+      throw new ConnectionCredentialsRewriteException(
+        this.pluginName,
+        `Allegro connection ${reuseAllegroConnectionId} does not have app client credentials ` +
+          '(clientId/clientSecret) configured to reuse'
+      );
+    }
+
+    this.logger.log(
+      `Reusing Allegro app credentials from connection ${reuseAllegroConnectionId} for credential update`
+    );
+    return {
+      ...rest,
+      allegroClientId: sourceCredentials.clientId,
+      allegroClientSecret: sourceCredentials.clientSecret,
+    };
+  }
+}

--- a/libs/integrations/prestashop/src/prestashop-integration.module.ts
+++ b/libs/integrations/prestashop/src/prestashop-integration.module.ts
@@ -43,6 +43,8 @@ import {
   ConnectionConfigShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionCredentialsShapeValidatorRegistryService,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+  ConnectionCredentialsRewriterRegistryService,
   INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
   OAuthCompletionRegistryService,
   WEBHOOK_SECRET_PROVIDER_TOKEN,
@@ -117,6 +119,8 @@ export class PrestashopIntegrationModule implements OnModuleInit {
     private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
     @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
     private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
+    @Inject(CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN)
+    private readonly connectionCredentialsRewriterRegistry: ConnectionCredentialsRewriterRegistryService,
     @Inject(INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN)
     private readonly oauthCompletionRegistry: OAuthCompletionRegistryService,
     @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
@@ -175,6 +179,7 @@ export class PrestashopIntegrationModule implements OnModuleInit {
       inboundWebhookDecoderRegistry: this.inboundWebhookDecoderRegistry,
       connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
       connectionCredentialsShapeValidatorRegistry: this.connectionCredentialsShapeValidatorRegistry,
+      connectionCredentialsRewriterRegistry: this.connectionCredentialsRewriterRegistry,
       oauthCompletionRegistry: this.oauthCompletionRegistry,
     };
 

--- a/libs/plugin-sdk/src/create-nest-adapter-module.spec.ts
+++ b/libs/plugin-sdk/src/create-nest-adapter-module.spec.ts
@@ -26,6 +26,7 @@ import {
   INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
   CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
   INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
   CREDENTIALS_RESOLVER_TOKEN,
 } from '@openlinker/core/integrations';
@@ -63,6 +64,7 @@ describe('createNestAdapterModule', () => {
     inboundWebhookDecoderRegistry: object;
     connectionConfigShapeValidatorRegistry: object;
     connectionCredentialsShapeValidatorRegistry: object;
+    connectionCredentialsRewriterRegistry: object;
     oauthCompletionRegistry: object;
     retryClassifierRegistry: object;
     authFailureClassifierRegistry: object;
@@ -80,6 +82,7 @@ describe('createNestAdapterModule', () => {
       inboundWebhookDecoderRegistry: {},
       connectionConfigShapeValidatorRegistry: {},
       connectionCredentialsShapeValidatorRegistry: {},
+      connectionCredentialsRewriterRegistry: {},
       oauthCompletionRegistry: {},
       retryClassifierRegistry: {},
       authFailureClassifierRegistry: {},
@@ -121,6 +124,10 @@ describe('createNestAdapterModule', () => {
         {
           provide: CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
           useValue: registries.connectionCredentialsShapeValidatorRegistry,
+        },
+        {
+          provide: CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+          useValue: registries.connectionCredentialsRewriterRegistry,
         },
         {
           provide: INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,

--- a/libs/plugin-sdk/src/create-nest-adapter-module.ts
+++ b/libs/plugin-sdk/src/create-nest-adapter-module.ts
@@ -50,6 +50,8 @@ import {
   ConnectionConfigShapeValidatorRegistryService,
   CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
   ConnectionCredentialsShapeValidatorRegistryService,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+  ConnectionCredentialsRewriterRegistryService,
   INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
   OAuthCompletionRegistryService,
   CREDENTIALS_RESOLVER_TOKEN,
@@ -118,6 +120,8 @@ export function createNestAdapterModule(options: CreateNestAdapterModuleOptions)
       private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
       @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
       private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
+      @Inject(CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN)
+      private readonly connectionCredentialsRewriterRegistry: ConnectionCredentialsRewriterRegistryService,
       @Inject(INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN)
       private readonly oauthCompletionRegistry: OAuthCompletionRegistryService,
       @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
@@ -158,6 +162,7 @@ export function createNestAdapterModule(options: CreateNestAdapterModuleOptions)
         connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
         connectionCredentialsShapeValidatorRegistry:
           this.connectionCredentialsShapeValidatorRegistry,
+        connectionCredentialsRewriterRegistry: this.connectionCredentialsRewriterRegistry,
         oauthCompletionRegistry: this.oauthCompletionRegistry,
       };
 

--- a/libs/plugin-sdk/src/host-services.ts
+++ b/libs/plugin-sdk/src/host-services.ts
@@ -42,6 +42,7 @@ import type {
   InboundWebhookDecoderRegistryService,
   ConnectionConfigShapeValidatorRegistryService,
   ConnectionCredentialsShapeValidatorRegistryService,
+  ConnectionCredentialsRewriterRegistryService,
   OAuthCompletionRegistryService,
   CredentialsResolverPort,
 } from '@openlinker/core/integrations';
@@ -150,6 +151,20 @@ export interface HostServices {
    * `ConnectionTesterPort` against the live API.
    */
   readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService;
+
+  /**
+   * Per-plugin credentials-rewriter registry (#1387, ADR-031). A plugin
+   * registers a `ConnectionCredentialsRewriterPort` here to transform the raw
+   * credentials payload BEFORE it is merged onto the existing stored blob
+   * and shape-validated — e.g. resolving a caller-supplied reference into
+   * concrete secret values fetched server-side. Absence is a deliberate
+   * skip — most plugins persist the submitted payload verbatim. Rewriters
+   * that need a dependency outside this bag (e.g. `ConnectionPort` to
+   * resolve a sibling connection) register from a companion NestJS module
+   * that injects this registry's token directly instead, mirroring the
+   * existing webhook-provisioner pattern.
+   */
+  readonly connectionCredentialsRewriterRegistry: ConnectionCredentialsRewriterRegistryService;
 
   /**
    * Per-plugin OAuth-completion registry (#859). A plugin whose platform uses

--- a/scripts/check-plugin-guide-quotes.mjs
+++ b/scripts/check-plugin-guide-quotes.mjs
@@ -18,7 +18,7 @@
  *      110; the link still resolves but lands on the wrong content.
  *
  *   3. **Boundary check** for the `HostServices` interface at
- *      `libs/plugin-sdk/src/host-services.ts:54-163`. Same shape.
+ *      `libs/plugin-sdk/src/host-services.ts:55-178`. Same shape.
  *
  * Both checks are deliberately strict: when they fire on a benign
  * refactor (e.g., new import above the interface), the human updates
@@ -68,9 +68,9 @@ const BOUNDARY_REFS = [
   {
     label: 'HostServices',
     sourceFile: 'libs/plugin-sdk/src/host-services.ts',
-    sourceStart: 54,
-    sourceEnd: 163,
-    guideLinkSubstring: 'host-services.ts:54-163',
+    sourceStart: 55,
+    sourceEnd: 178,
+    guideLinkSubstring: 'host-services.ts:55-178',
     expectedStart: /^export interface HostServices \{$/,
     expectedEnd: /^\}\s*$/,
   },


### PR DESCRIPTION
Closes #1387. Part of epic #1381 (final sub-task).

## Summary

Extends the #1384 Erli credentials panel (PR #1401) with a reuse-vs-manual choice for the Allegro app credentials used for category-catalog access: when the operator already has an Allegro connection configured, its `clientId`/`clientSecret` can be reused instead of registering a second Allegro app. Matches the approved mockup (both states).

**Security**: the raw Allegro `clientSecret` is resolved and copied entirely server-side — it is never serialized into any HTTP response body, and the frontend never sees it.

## Architecture note

The initial implementation embedded the reuse-resolution logic (with `'allegro'`/`allegroClientId`/`allegroClientSecret` literals) directly inside the generic, cross-platform `ConnectionService.updateCredentials`. That was caught in review as a "platform name leaks into core/host layer" violation and refactored before this PR was opened.

The shipped design instead introduces a new, fully platform-neutral `ConnectionCredentialsRewriterPort` + `ConnectionCredentialsRewriterRegistryService` in `libs/core/src/integrations/`, mirroring the existing `ConnectionConfigShapeValidatorPort`/`ConnectionCredentialsShapeValidatorPort` pair. `ConnectionService.updateCredentials` now just looks up a rewriter by `adapterKey` and no-ops when none is registered — it has zero knowledge of Allegro or Erli.

All Erli/Allegro-specific logic (resolve `reuseAllegroConnectionId` → read the source connection's credentials → validate it's an Allegro connection with client credentials configured) lives in `ErliAllegroCredentialsRewriterAdapter`, registered from a new companion `ErliCredentialsRewriterModule` (mirrors the existing `ErliWebhookProvisioningModule` shape) since the adapter needs a NestJS-injected `ConnectionPort` that's intentionally outside the framework-neutral `HostServices` bag.

## Backend

- `libs/core/src/integrations/domain/ports/connection-credentials-rewriter.port.ts` — new port
- `libs/core/src/integrations/domain/exceptions/connection-credentials-rewrite.exception.ts` — new domain exception
- `libs/core/src/integrations/infrastructure/adapters/connection-credentials-rewriter-registry.service.ts` — new registry
- `apps/api/.../connection.service.ts` — `updateCredentials` now dispatches through the registry (generic, no platform knowledge)
- `libs/integrations/erli/src/infrastructure/adapters/erli-allegro-credentials-rewriter.adapter.ts` — the actual reuse logic
- `libs/integrations/erli/src/erli-credentials-rewriter.module.ts` — registers the adapter
- `HostServices.connectionCredentialsRewriterRegistry` threaded through `libs/plugin-sdk` and all three host-plugin modules (Allegro, PrestaShop, Erli) that build the bag manually

**Tenant/ownership note**: this codebase has no tenant/organization model — there's no `tenantId`/`organizationId` anywhere on `Connection`. `@Roles('admin')` on the credentials endpoint is the only access boundary that exists today, applied uniformly across the single-deployment instance. The closest enforceable check is that the reuse-source id must resolve to a real, existing `platformType: 'allegro'` connection — anything else is rejected. Documented inline in the adapter's JSDoc.

## Frontend

`ErliCredentialsPanel` (`apps/web/src/plugins/erli/components/erli-credentials-panel.tsx`): when ≥1 active Allegro connection exists, shows a "Reuse credentials from an existing Allegro connection" / "Enter Allegro app credentials manually" radio choice with a connection picker, per the approved mockup. Zero Allegro connections falls back to manual-only entry (today's #1384 behavior) with a notice. The reuse path sends `{ reuseAllegroConnectionId }` and follows the same sequenced, fail-safe-ordered write pattern established in #1401 (credentials first, then the `allegroCategoryAccessEnabled` config patch).

## Tests

- `connection.service.spec.ts` — generic passthrough/delegation/error-mapping tests against a stub rewriter (no Allegro-specific cases; those moved out)
- `erli-allegro-credentials-rewriter.adapter.spec.ts` — new, 7 cases (successful reuse, not-found, wrong platform, missing client credentials, blank id, passthrough when absent)
- `erli-credentials-panel.test.tsx` — zero-connections notice, reuse radio + picker, successful reuse submit (asserts payload never contains the raw secret), manual override still works, reuse-without-selection validation

## Quality gate

Full-repo `pnpm lint`, `pnpm check:invariants`, `pnpm type-check`, and `pnpm test` all green (confirmed independently in an isolated worktree before this PR was opened).