### PR TITLE
feat(demo): reverse-proxy/TLS overlay, DB credential overrides, and public-domain deployment guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,3 +98,70 @@ OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=
 # WOOCOMMERCE_HOST_PORT=
 # API_HOST_PORT=
 # WEB_HOST_PORT=
+
+# ---------------------------------------------------------------------------
+# Database / service credentials (#1403) — every value below is a throwaway
+# demo default baked into docker-compose.yml. Rotate all of them before
+# exposing the stack beyond localhost (e.g. behind the reverse-proxy overlay
+# below, or on a host without a host firewall).
+# ---------------------------------------------------------------------------
+
+# Postgres superuser password. Shared by the api/worker/migrate services'
+# DB connection — changing it here changes it everywhere automatically.
+# Default: postgres
+# POSTGRES_PASSWORD=
+
+# PrestaShop-side MySQL instance: root password and the `prestashop` DB
+# user's password. PRESTASHOP_MYSQL_PASSWORD is also used by the prestashop
+# service itself (PS_DB_PASSWD/DB_PASSWD) — always kept in sync.
+# Defaults: root / prestashop
+# PRESTASHOP_MYSQL_ROOT_PASSWORD=
+# PRESTASHOP_MYSQL_PASSWORD=
+
+# WooCommerce-side MySQL instance: root password and the `woocommerce` DB
+# user's password. Independent from the PrestaShop MySQL instance above —
+# the two databases rotate separately. WOOCOMMERCE_MYSQL_PASSWORD is also
+# used by the woocommerce service itself (WORDPRESS_DATABASE_PASSWORD).
+# Defaults: root / woocommerce
+# WOOCOMMERCE_MYSQL_ROOT_PASSWORD=
+# WOOCOMMERCE_MYSQL_PASSWORD=
+
+# Seeded PrestaShop admin login password (paired with ADMIN_MAIL=
+# demo@prestashop.com, not itself overridable). Must not be exposed beyond
+# localhost with the default value.
+# Default: prestashop_demo
+# ADMIN_PASSWD=
+
+# ---------------------------------------------------------------------------
+# Reverse-proxy / TLS overlay (optional, #1403) — only needed when booting
+# with `-f docker-compose.proxy.yml` for a public-domain deployment. See
+# docs/public-domain-demo-deployment-guide.md for the full walkthrough
+# (DNS records, boot command, local verification without real DNS, and the
+# post-deploy verification checklist).
+# ---------------------------------------------------------------------------
+
+# Public hostname for the admin UI. Must resolve (DNS A/AAAA record) to this
+# host before Caddy can obtain a Let's Encrypt certificate for it.
+# Example: app.example.com
+# WEB_DOMAIN=
+
+# Public hostname for the API. Must also be set as VITE_API_BASE_URL above
+# (https://<API_DOMAIN>) so the built UI bundle calls the right origin.
+# Example: api.example.com
+# API_DOMAIN=
+
+# Public hostname for PrestaShop. Should also be set as PS_DOMAIN above so
+# PrestaShop's own generated links match. Internally, OpenLinker always
+# reaches PrestaShop via http://prestashop regardless of this value.
+# Example: shop.example.com
+# PRESTASHOP_DOMAIN=
+
+# Contact address Let's Encrypt uses for certificate-expiry notices.
+# TLS_EMAIL=
+
+# Path to the Caddyfile mounted into the caddy service. Leave unset for the
+# production ACME Caddyfile. Point at ./docker/caddy/Caddyfile.local for
+# local verification without real DNS (uses Caddy's internal CA instead of
+# Let's Encrypt).
+# Default: ./docker/caddy/Caddyfile
+# CADDYFILE_PATH=

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -73,7 +73,8 @@ services:
       DB_HOST: postgres
       DB_PORT: 5432
       DB_USERNAME: postgres
-      DB_PASSWORD: postgres
+      # Must match the base file's postgres service POSTGRES_PASSWORD (#1403).
+      DB_PASSWORD: '${POSTGRES_PASSWORD:-postgres}'
       DB_DATABASE: openlinker
       REDIS_HOST: redis
       REDIS_PORT: 6379
@@ -134,7 +135,8 @@ services:
       DB_HOST: postgres
       DB_PORT: 5432
       DB_USERNAME: postgres
-      DB_PASSWORD: postgres
+      # Must match the base file's postgres service POSTGRES_PASSWORD (#1403).
+      DB_PASSWORD: '${POSTGRES_PASSWORD:-postgres}'
       DB_DATABASE: openlinker
       # migration 1795000000000-encrypt-integration-credentials fails closed
       # under NODE_ENV=production when this is unset, rolling back and exiting 1

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -1,0 +1,54 @@
+# Optional reverse-proxy + TLS overlay for public-domain demo deployments (#1403).
+#
+# Used ON TOP of the base + demo overlays:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.demo.yml -f docker-compose.proxy.yml \
+#     up -d --build postgres redis mysql prestashop migrate api worker web caddy
+#
+# Adds a single Caddy service that terminates TLS (automatic Let's Encrypt
+# certificates, zero manual ACME config) and routes by hostname to the
+# existing web/api/prestashop services. Caddy reaches them over the internal
+# Compose network by SERVICE NAME (web:80, api:3000, prestashop:80) — it does
+# NOT depend on those services publishing host ports, so this overlay works
+# whether or not the loopback-binding hardening from #1400/#1402 has landed,
+# and avoids a redundant hop back out through the host network stack.
+#
+# This overlay REQUIRES docker-compose.demo.yml (the `web` service only
+# exists there — the bare dev stack has no admin UI to serve).
+#
+# Required .env vars (see .env.example): WEB_DOMAIN, API_DOMAIN,
+# PRESTASHOP_DOMAIN, TLS_EMAIL. See
+# docs/public-domain-demo-deployment-guide.md for the full walkthrough,
+# including local verification without real DNS (CADDYFILE_PATH override).
+#
+# Omitting `-f docker-compose.proxy.yml` reproduces today's plain-HTTP
+# localhost behavior unchanged — this overlay touches no other service.
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: openlinker-caddy
+    environment:
+      WEB_DOMAIN: '${WEB_DOMAIN:?set WEB_DOMAIN in .env (see .env.example) - the public hostname for the admin UI}'
+      API_DOMAIN: '${API_DOMAIN:?set API_DOMAIN in .env (see .env.example) - the public hostname for the API}'
+      PRESTASHOP_DOMAIN: '${PRESTASHOP_DOMAIN:?set PRESTASHOP_DOMAIN in .env (see .env.example) - the public hostname for PrestaShop}'
+      TLS_EMAIL: '${TLS_EMAIL:?set TLS_EMAIL in .env (see .env.example) - required by Lets Encrypt for expiry notices}'
+    ports:
+      # Unbound (not loopback) by design — this is the public TLS-terminating
+      # edge; that is the point of the overlay.
+      - '80:80'
+      - '443:443'
+    volumes:
+      # CADDYFILE_PATH lets local verification swap in Caddyfile.local
+      # (tls internal, no real DNS/domain needed) without editing this file.
+      - '${CADDYFILE_PATH:-./docker/caddy/Caddyfile}:/etc/caddy/Caddyfile:ro'
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - web
+      - api
+      - prestashop
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,10 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-postgres
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      # Override in .env for anything beyond local dev/demo use (#1403) — the
+      # default is a throwaway value, not a secret. Every service below that
+      # connects to Postgres references this same var so they never drift.
+      POSTGRES_PASSWORD: '${POSTGRES_PASSWORD:-postgres}'
       POSTGRES_DB: openlinker
     ports:
       - '${OL_BIND_ADDRESS:-127.0.0.1}:${POSTGRES_HOST_PORT:-5432}:5432'
@@ -61,16 +64,29 @@ services:
     image: mysql:8.4.7
     container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-mysql
     environment:
-      MYSQL_ROOT_PASSWORD: root
+      # Overridable in .env (#1403) — both default to today's literal values.
+      # PRESTASHOP_MYSQL_PASSWORD must match the prestashop service's
+      # PS_DB_PASSWD/DB_PASSWD below (same var referenced at both sites).
+      MYSQL_ROOT_PASSWORD: '${PRESTASHOP_MYSQL_ROOT_PASSWORD:-root}'
       MYSQL_DATABASE: prestashop
       MYSQL_USER: prestashop
-      MYSQL_PASSWORD: prestashop
+      MYSQL_PASSWORD: '${PRESTASHOP_MYSQL_PASSWORD:-prestashop}'
     ports:
       - '${OL_BIND_ADDRESS:-127.0.0.1}:${MYSQL_HOST_PORT:-3306}:3306'
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
-      test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost', '-u', 'root', '-proot']
+      test:
+        [
+          'CMD',
+          'mysqladmin',
+          'ping',
+          '-h',
+          'localhost',
+          '-u',
+          'root',
+          '-p${PRESTASHOP_MYSQL_ROOT_PASSWORD:-root}',
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -87,8 +103,10 @@ services:
       PMA_HOST: mysql
       PMA_PORT: 3306
       PMA_USER: root
-      PMA_PASSWORD: root
-      MYSQL_ROOT_PASSWORD: root
+      # Mirrors the mysql service's root password (#1403) — phpMyAdmin only
+      # ever talks to the PrestaShop-side MySQL instance.
+      PMA_PASSWORD: '${PRESTASHOP_MYSQL_ROOT_PASSWORD:-root}'
+      MYSQL_ROOT_PASSWORD: '${PRESTASHOP_MYSQL_ROOT_PASSWORD:-root}'
     ports:
       - '${OL_BIND_ADDRESS:-127.0.0.1}:${PHPMYADMIN_HOST_PORT:-8081}:80'
     depends_on:
@@ -104,17 +122,31 @@ services:
     image: mysql:8.4.7
     container_name: ${COMPOSE_PROJECT_NAME:-openlinker}-woocommerce-mysql
     environment:
-      MYSQL_ROOT_PASSWORD: root
+      # Overridable in .env (#1403), separate from the PrestaShop MySQL
+      # instance's vars — these two databases rotate independently.
+      # WOOCOMMERCE_MYSQL_PASSWORD must match the woocommerce service's
+      # WORDPRESS_DATABASE_PASSWORD below (same var referenced at both sites).
+      MYSQL_ROOT_PASSWORD: '${WOOCOMMERCE_MYSQL_ROOT_PASSWORD:-root}'
       MYSQL_DATABASE: woocommerce
       MYSQL_USER: woocommerce
-      MYSQL_PASSWORD: woocommerce
+      MYSQL_PASSWORD: '${WOOCOMMERCE_MYSQL_PASSWORD:-woocommerce}'
     ports:
       - '${OL_BIND_ADDRESS:-127.0.0.1}:${WOOCOMMERCE_MYSQL_HOST_PORT:-3307}:3306'
     volumes:
       - woocommerce_mysql_data:/var/lib/mysql
     healthcheck:
-      # -proot: no space between flag and password (matches MYSQL_ROOT_PASSWORD: root)
-      test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost', '-u', 'root', '-proot']
+      # -p<password>: no space between flag and password.
+      test:
+        [
+          'CMD',
+          'mysqladmin',
+          'ping',
+          '-h',
+          'localhost',
+          '-u',
+          'root',
+          '-p${WOOCOMMERCE_MYSQL_ROOT_PASSWORD:-root}',
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -131,7 +163,8 @@ services:
       WORDPRESS_DATABASE_PORT_NUMBER: 3306
       WORDPRESS_DATABASE_NAME: woocommerce
       WORDPRESS_DATABASE_USER: woocommerce
-      WORDPRESS_DATABASE_PASSWORD: woocommerce
+      # Must match woocommerce-mysql's MYSQL_PASSWORD above (#1403).
+      WORDPRESS_DATABASE_PASSWORD: '${WOOCOMMERCE_MYSQL_PASSWORD:-woocommerce}'
       WORDPRESS_USERNAME: admin
       WORDPRESS_PASSWORD: admin123
       WORDPRESS_EMAIL: admin@openlinker.local
@@ -177,7 +210,8 @@ services:
       PS_DB_SERVER: mysql
       PS_DB_NAME: prestashop
       PS_DB_USER: prestashop
-      PS_DB_PASSWD: prestashop
+      # Must match the mysql service's MYSQL_PASSWORD (#1403).
+      PS_DB_PASSWD: '${PRESTASHOP_MYSQL_PASSWORD:-prestashop}'
       PS_DB_PREFIX: ps_
       PS_ENABLE_SSL: 0
       PS_DEMO_MODE: 0
@@ -186,10 +220,12 @@ services:
       DB_SERVER: mysql
       DB_NAME: prestashop
       DB_USER: prestashop
-      DB_PASSWD: prestashop
+      DB_PASSWD: '${PRESTASHOP_MYSQL_PASSWORD:-prestashop}'
       DB_PREFIX: ps_
       ADMIN_MAIL: demo@prestashop.com
-      ADMIN_PASSWD: prestashop_demo
+      # The seeded PrestaShop admin login password (#1403) — override before
+      # exposing this beyond localhost, same as OL_BOOTSTRAP_ADMIN_PASSWORD.
+      ADMIN_PASSWD: '${ADMIN_PASSWD:-prestashop_demo}'
     ports:
       - '${OL_BIND_ADDRESS:-127.0.0.1}:${PRESTASHOP_HOST_PORT:-8080}:80'
     volumes:
@@ -233,7 +269,8 @@ services:
       DB_HOST: postgres
       DB_PORT: 5432
       DB_USERNAME: postgres
-      DB_PASSWORD: postgres
+      # Must match the postgres service's POSTGRES_PASSWORD above (#1403).
+      DB_PASSWORD: '${POSTGRES_PASSWORD:-postgres}'
       DB_DATABASE: openlinker
       REDIS_HOST: redis
       REDIS_PORT: 6379

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,0 +1,26 @@
+# Production Caddyfile for the public-domain demo proxy overlay (#1403).
+#
+# Automatic HTTPS via Let's Encrypt — Caddy issues and renews a certificate
+# per site block the first time it observes real, publicly-resolvable DNS
+# for that hostname (HTTP-01 challenge on port 80, then serves over 443).
+#
+# See docs/public-domain-demo-deployment-guide.md for prerequisites (DNS
+# records, port 80/443 reachability) and the post-deploy verification
+# checklist. For local verification without real DNS, use Caddyfile.local
+# instead (set CADDYFILE_PATH=./docker/caddy/Caddyfile.local in .env).
+
+{
+	email {$TLS_EMAIL}
+}
+
+{$WEB_DOMAIN} {
+	reverse_proxy web:80
+}
+
+{$API_DOMAIN} {
+	reverse_proxy api:3000
+}
+
+{$PRESTASHOP_DOMAIN} {
+	reverse_proxy prestashop:80
+}

--- a/docker/caddy/Caddyfile.local
+++ b/docker/caddy/Caddyfile.local
@@ -1,0 +1,30 @@
+# Local-verification variant of the Caddyfile (#1403) — no real DNS/domain,
+# no Let's Encrypt, no mkcert dependency.
+#
+# `tls internal` makes Caddy mint certificates from its own local CA instead
+# of requesting one from Let's Encrypt. Use this together with /etc/hosts
+# entries pointing your three test hostnames at 127.0.0.1 — see
+# docs/public-domain-demo-deployment-guide.md § Local verification.
+#
+# Select this file via .env:
+#   CADDYFILE_PATH=./docker/caddy/Caddyfile.local
+#
+# The browser will show a certificate warning unless you additionally trust
+# Caddy's local root CA (`docker compose exec caddy caddy trust` — see the
+# guide); accepting the warning is sufficient to verify routing + TLS
+# termination without doing that.
+
+{$WEB_DOMAIN} {
+	tls internal
+	reverse_proxy web:80
+}
+
+{$API_DOMAIN} {
+	tls internal
+	reverse_proxy api:3000
+}
+
+{$PRESTASHOP_DOMAIN} {
+	tls internal
+	reverse_proxy prestashop:80
+}

--- a/docs/one-command-demo-setup-guide.md
+++ b/docs/one-command-demo-setup-guide.md
@@ -11,6 +11,10 @@ tier — API + Worker + admin UI.
 
 > **Local evaluation only.** Credentials are intentionally not production-safe and
 > the stack is not hardened (no TLS, default passwords). Do not expose it publicly.
+>
+> Need to make the demo reachable under a real domain instead (reverse proxy +
+> TLS, rotated credentials, DNS)? See the
+> [public-domain demo deployment guide](./public-domain-demo-deployment-guide.md).
 
 ---
 

--- a/docs/plans/implementation-plan-demo-proxy-tls-credentials.md
+++ b/docs/plans/implementation-plan-demo-proxy-tls-credentials.md
@@ -1,0 +1,231 @@
+# Implementation Plan: Reverse-Proxy/TLS Overlay, DB Credential Overrides, and Public-Domain Deployment Guide
+
+**Issue**: #1403
+**Branch**: `1403-demo-proxy-tls-credentials`
+**Layer**: DX / Infrastructure (docker-compose + docs, no application code)
+
+## 1. Understand the task
+
+**Goal.** The demo stack (#1352/#1365) already carries the env-var seams to serve
+under a real domain (`VITE_API_BASE_URL` / `OL_CORS_ORIGIN` / `PS_DOMAIN`, #1375)
+and #1400/#1402 harden port binding. What's still missing for an operator to
+actually deploy the demo behind a public domain:
+
+1. A reverse-proxy + TLS compose overlay (Caddy — automatic HTTPS, minimal ACME
+   config) that routes by hostname to `web` / `api` / `prestashop`.
+2. Non-default, `.env`-overridable database/service credentials
+   (`POSTGRES_PASSWORD`, `MYSQL_ROOT_PASSWORD`, `MYSQL_PASSWORD` for both MySQL
+   instances, PrestaShop `ADMIN_PASSWD`) — today these are hardcoded literals.
+3. A deployment guide covering DNS, the proxy overlay, the full env-var list,
+   and a post-deploy verification checklist.
+
+**Non-goals** (explicit, from the issue): CI/CD pipeline changes, container
+orchestration beyond docker-compose (no Kubernetes), a general secrets-vaulting
+overhaul beyond the four named credentials, and a hardened production topology
+(load balancing, WAF). This stays "demo/evaluation reachable under a real
+domain," not production-grade.
+
+**Dependency note.** PR #1402 (port-binding hardening, closes #1400) is **still
+open**, not merged, as of this session. Per orchestrator instruction, this
+branch is cut from current `origin/main` (pre-#1402) rather than waiting. The
+proxy design below is deliberately **independent of whether #1402's
+loopback-binding has landed** — see §3.1.
+
+## 2. Research the codebase
+
+- `docker-compose.yml` (base): postgres/redis/mysql/phpmyadmin/woocommerce-mysql/
+  woocommerce/prestashop/api services. Hardcoded credentials today:
+  `POSTGRES_PASSWORD: postgres`, `MYSQL_ROOT_PASSWORD: root` (both `mysql` and
+  `woocommerce-mysql`), `MYSQL_PASSWORD: prestashop` (mysql→prestashop user) /
+  `MYSQL_PASSWORD: woocommerce` (woocommerce-mysql→woocommerce user),
+  `ADMIN_PASSWD: prestashop_demo` (prestashop service). `PS_DOMAIN` is already
+  `${VAR:-default}` (#1375) — the pattern to replicate.
+- `docker-compose.demo.yml` (overlay): adds `worker`, `web`, `migrate`, reshapes
+  `api` to production posture. `OL_BOOTSTRAP_ADMIN_PASSWORD`, `OL_CORS_ORIGIN`,
+  `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` already follow the `${VAR:-default}` /
+  `${VAR:?message}` pattern this issue extends.
+- `.env.example`: one REQUIRED var (`OPENLINKER_CREDENTIALS_ENCRYPTION_KEY`),
+  then an "OPTIONAL" block per #1375 var with a comment explaining why/when to
+  set it. New vars follow this exact section shape.
+- `docs/one-command-demo-setup-guide.md`: the existing demo runbook — gets a
+  cross-reference to the new guide, not a rewrite.
+- Prior art for Caddy in this repo: `libs/integrations/woocommerce/docs/
+  master-shop-setup-guide.md` already documents an ad-hoc local Caddy
+  reverse-proxy for HTTPS (`caddy reverse-proxy`, `NODE_EXTRA_CA_CERTS` for the
+  API/worker to trust Caddy's local CA). Useful reference for the "local
+  verification" section of the new guide, not directly reusable code.
+- `apps/web/Dockerfile` confirms `web` serves on container port 80 (nginx);
+  `api` listens on 3000; `prestashop` on container port 80. No service other
+  than `web`/`api`/`prestashop` needs a public hostname — `worker` has no
+  `EXPOSE` (issue confirms this explicitly).
+
+## 3. Design
+
+### 3.1 Reverse-proxy/TLS overlay — network-based routing, not port-based
+
+**Key design decision:** the new `docker-compose.proxy.yml` overlay's `caddy`
+service joins the same Compose network as every other service and reverse-proxies
+to them **by service DNS name and container port** (`web:80`, `api:3000`,
+`prestashop:80`) — it does **not** route through the host-published ports at
+all. This makes the overlay correct regardless of whether #1402's loopback-bind
+changes have landed on `main` yet, and is also simply the more robust pattern
+(no double-hop through the host network stack). Operators can keep or drop the
+host port publishes independently — this overlay doesn't care.
+
+`docker-compose.proxy.yml`:
+```yaml
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: openlinker-caddy
+    ports:
+      - '80:80'
+      - '443:443'
+    environment:
+      WEB_DOMAIN: '${WEB_DOMAIN:?...}'
+      API_DOMAIN: '${API_DOMAIN:?...}'
+      PRESTASHOP_DOMAIN: '${PRESTASHOP_DOMAIN:?...}'
+      TLS_EMAIL: '${TLS_EMAIL:?...}'
+    volumes:
+      - '${CADDYFILE_PATH:-./docker/caddy/Caddyfile}:/etc/caddy/Caddyfile:ro'
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on: [web, api, prestashop]
+
+volumes:
+  caddy_data:
+  caddy_config:
+```
+
+`depends_on: [web, ...]` means this overlay **must always be combined with
+`docker-compose.demo.yml`** (the bare dev stack has no `web` service) — the
+guide states this explicitly with the 3-file compose invocation.
+
+Two Caddyfiles ship under `docker/caddy/`:
+- `Caddyfile` (default, mounted via `CADDYFILE_PATH` default) — production
+  ACME (Let's Encrypt) automatic HTTPS, one site block per domain.
+- `Caddyfile.local` — `tls internal` variant for local verification without a
+  real domain/DNS (self-signed, Caddy's internal CA), selected via
+  `CADDYFILE_PATH=./docker/caddy/Caddyfile.local` in `.env`.
+
+`80:443` are published unbound (not loopback) by design — this is the public
+TLS-terminating edge; that's the point of the overlay.
+
+### 3.2 Credential parametrization
+
+Follow the exact `${VAR:-default}` pattern #1375 established (defaults =
+today's literal values, so a plain `pnpm demo:up` / `dev:stack:up` is
+byte-identical in behavior). **Decision (human, post-plan-review): 6 separate,
+instance-specific var names** — not shared names across the two MySQL
+instances. This supersedes the plan's original draft (which proposed reusing
+one var name across both instances to literally match the issue's 4-name
+list); the human confirmed 6 distinct vars is the intended design.
+
+| Var | Used in | Default | Notes |
+|---|---|---|---|
+| `POSTGRES_PASSWORD` | `postgres` service | `postgres` | Single instance, single var. |
+| `PRESTASHOP_MYSQL_ROOT_PASSWORD` | `mysql` service (root), `phpmyadmin` (`PMA_PASSWORD` + `MYSQL_ROOT_PASSWORD` — phpMyAdmin only ever talks to the `mysql`/PrestaShop instance), `mysql` healthcheck | `root` | Instance-specific: the PrestaShop-side MySQL container. |
+| `PRESTASHOP_MYSQL_PASSWORD` | `mysql` service (prestashop DB user) + `prestashop` service (`PS_DB_PASSWD`/`DB_PASSWD`, must match) | `prestashop` | Both call sites must resolve to the same value — same var, referenced twice. |
+| `WOOCOMMERCE_MYSQL_ROOT_PASSWORD` | `woocommerce-mysql` service (root), its healthcheck | `root` | Instance-specific: the WooCommerce-side MySQL container. |
+| `WOOCOMMERCE_MYSQL_PASSWORD` | `woocommerce-mysql` service (woocommerce DB user) + `woocommerce` service (`WORDPRESS_DATABASE_PASSWORD`, must match) | `woocommerce` | Same var referenced at both call sites. |
+| `ADMIN_PASSWD` | `prestashop` service (`ADMIN_PASSWD`) | `prestashop_demo` | Matches the literal PrestaShop-image env var name, same convention as `PS_DOMAIN`. |
+
+Healthcheck arrays need the password baked into a single token
+(`-p${PRESTASHOP_MYSQL_ROOT_PASSWORD:-root}` / `-p${WOOCOMMERCE_MYSQL_ROOT_PASSWORD:-root}`
+replacing the current literal `-proot`) — docker compose interpolates `${...}`
+in the compose YAML itself before handing the config to the Docker Engine, so
+this resolves correctly with no shell quoting issues inside the container.
+
+### 3.3 `.env.example` additions
+
+Extend the existing "OPTIONAL" block (same section, same comment style) with
+the four new vars, each documented with: what it guards, today's default, and
+an explicit "rotate before non-loopback exposure" callout — mirroring the
+existing `OL_BOOTSTRAP_ADMIN_PASSWORD` / `JWT_SECRET` entries. Also add a
+"Reverse-proxy / public-domain overlay (optional)" sub-block for
+`WEB_DOMAIN`, `API_DOMAIN`, `PRESTASHOP_DOMAIN`, `TLS_EMAIL`,
+`CADDYFILE_PATH` — cross-referencing the new deployment guide instead of
+duplicating the full explanation inline.
+
+### 3.4 Deployment guide
+
+New `docs/public-domain-demo-deployment-guide.md`:
+1. Scope/framing — extends, doesn't replace, the "local evaluation only" demo;
+   still not a hardened production topology.
+2. Prerequisites — DNS A/AAAA records for the three hostnames (web/api/
+   prestashop — no worker record), ports 80/443 open on the host firewall for
+   ACME HTTP-01 + traffic, Docker Compose ≥ 2.24.
+3. Env-var reference — the full list from #1375 (`OL_CORS_ORIGIN`,
+   `VITE_API_BASE_URL`, `PS_DOMAIN`) **plus** this issue's new vars, with an
+   explicit worked example showing how `WEB_DOMAIN`/`API_DOMAIN`/
+   `PRESTASHOP_DOMAIN` must line up with `OL_CORS_ORIGIN`/`VITE_API_BASE_URL`/
+   `PS_DOMAIN` (a common point of confusion per the issue).
+4. Credential rotation — the four new vars, generation tips
+   (`openssl rand -base64 24` etc.), explicit warning these must change before
+   public exposure.
+5. Boot command — the 3-file compose invocation.
+6. Local verification path — `Caddyfile.local` + `/etc/hosts` override (no
+   real DNS/domain needed), referencing the existing woocommerce doc's Caddy
+   pattern for trust-store/NODE_EXTRA_CA_CERTS nuances where relevant.
+7. Post-deploy verification checklist — TLS cert validity, login with no CORS
+   console errors, `GET /v1/health` → 200, DB ports (5432/3306/6379) unreachable
+   from outside the host (`nmap`/`curl --connect-timeout`), PrestaShop reachable
+   at its own domain, and the repeated reminder that the **internal** PrestaShop
+   connection URL in OpenLinker is always `http://prestashop`, never the public
+   domain.
+8. Troubleshooting — ACME challenge failures (DNS not propagated / port 80
+   blocked), mixed-content/CORS symptoms, cert renewal.
+
+`docs/one-command-demo-setup-guide.md` gets one short new subsection /
+cross-reference pointing to the new guide (not a rewrite).
+
+## 4. Step-by-step implementation
+
+1. **`docker-compose.yml`** — parametrize the 4 credentials + 2 healthchecks
+   (§3.2). Acceptance: `docker compose -f docker-compose.yml config` with no
+   `.env` shows identical literal values to today; with a test `.env` setting
+   all 4 vars, `config` shows the overridden values propagated to every
+   dependent field (mysql user password ⟷ prestashop DB_PASSWD, etc.).
+2. **`docker/caddy/Caddyfile`** and **`docker/caddy/Caddyfile.local`** (new) —
+   per §3.1.
+3. **`docker-compose.proxy.yml`** (new) — per §3.1.
+4. **`.env.example`** — add the 4 credential vars + 5 proxy-overlay vars
+   (§3.3).
+5. **`docs/public-domain-demo-deployment-guide.md`** (new) — per §3.4.
+6. **`docs/one-command-demo-setup-guide.md`** — add cross-reference subsection.
+7. **Local verification** (per AC): boot
+   `docker compose -f docker-compose.yml -f docker-compose.demo.yml -f docker-compose.proxy.yml up -d --build ...`
+   with `CADDYFILE_PATH=./docker/caddy/Caddyfile.local` + `/etc/hosts` entries
+   for the three test hostnames pointed at `127.0.0.1`; confirm Caddy issues
+   its internal cert and routes each hostname to the right upstream, and that
+   plain `pnpm demo:up` (no `.env`, no proxy overlay) is unaffected.
+
+## 5. Validation
+
+- **Architecture compliance**: no application code touched — pure
+  docker-compose + docs change, consistent with the issue's declared layer.
+- **Naming**: new compose file follows the `docker-compose.<purpose>.yml`
+  convention already established (`docker-compose.demo.yml`); new doc follows
+  the existing `docs/*-guide.md` naming.
+- **Testing strategy**: no unit/integration tests apply (infra/docs only).
+  Validation is the local Docker Compose boot + `docker compose config`
+  diffing described in step 7, plus running the existing quality gate
+  (`pnpm lint` / `pnpm type-check` / `pnpm test`) to confirm zero regressions
+  from files outside the TS/JS toolchain's purview (should be a no-op, but run
+  it per the standard process).
+- **Security**: this is explicitly a security-labeled issue — the whole point
+  is making the previously-implicit "don't expose this" caveat enforceable via
+  `.env` overrides + a documented verification checklist. No new secrets are
+  hardcoded; `.env` stays gitignored.
+- **Backward compatibility**: acceptance criterion "plain `pnpm demo:up` /
+  `pnpm dev:stack:up` (no `.env` overrides, no proxy overlay) behavior is
+  unchanged" is the hard constraint validated in step 1 and step 7.
+
+## Decisions confirmed (human, post-plan-review)
+
+1. **6 distinct, instance-specific credential var names** (§3.2) — confirmed,
+   supersedes the plan's original 4-shared-name draft.
+2. **#1402 not yet merged** — proceed on `origin/main`; a small rebase conflict
+   later is acceptable.
+3. **Local verification**: `Caddyfile.local` + `tls internal` (no `mkcert`
+   dependency) — confirmed.

--- a/docs/public-domain-demo-deployment-guide.md
+++ b/docs/public-domain-demo-deployment-guide.md
@@ -1,0 +1,238 @@
+# Public-Domain Demo Deployment Guide
+
+This guide extends the [one-command demo setup guide](./one-command-demo-setup-guide.md)
+for the specific case of standing the demo up **reachable under a real domain**
+instead of `localhost` — e.g. for a shared evaluation server or a demo you want
+to hand a link to. It covers DNS, the optional reverse-proxy/TLS overlay,
+the full set of environment-variable overrides, and a post-deploy
+verification checklist.
+
+> **Still a demo, not a hardened production topology.** This guide makes the
+> demo stack safe(r) to expose on a real domain — TLS, non-default
+> credentials, a verification checklist. It does not add load balancing, a
+> WAF, secrets vaulting, or a production-grade order-lifecycle SLA. See the
+> [demo setup guide](./one-command-demo-setup-guide.md)'s "Local evaluation
+> only" framing — this guide extends that scope, it doesn't replace it.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [DNS records](#2-dns-records)
+3. [Environment variables](#3-environment-variables)
+4. [Credential rotation](#4-credential-rotation)
+5. [Boot the stack with the proxy overlay](#5-boot-the-stack-with-the-proxy-overlay)
+6. [Local verification (no real DNS needed)](#6-local-verification-no-real-dns-needed)
+7. [Post-deploy verification checklist](#7-post-deploy-verification-checklist)
+8. [Troubleshooting](#8-troubleshooting)
+
+---
+
+## 1. Prerequisites
+
+Everything from the [demo setup guide's prerequisites](./one-command-demo-setup-guide.md#1-prerequisites),
+plus:
+
+- A **domain you control**, with the ability to add DNS records.
+- **Ports 80 and 443 reachable from the internet** on the host — Caddy uses
+  port 80 for the ACME HTTP-01 challenge (issuing/renewing certificates) and
+  serves HTTPS on 443. If the host is behind a cloud firewall / security
+  group, open both.
+- Docker Compose ≥ 2.24 (same requirement as the base demo).
+
+## 2. DNS records
+
+Create an **A** (or **AAAA**) record pointing each of the following
+hostnames at the server's public IP:
+
+| Hostname (example) | Points to | Serves |
+|---|---|---|
+| `app.example.com` | server IP | OpenLinker admin UI (`web`) |
+| `api.example.com` | server IP | OpenLinker API (`api`) |
+| `shop.example.com` | server IP | PrestaShop |
+
+`worker` needs **no DNS record** — it's a background process with no
+`EXPOSE`'d port and is never proxied.
+
+Wait for DNS propagation (`dig +short app.example.com` should return the
+server IP) before booting the proxy overlay — Caddy's automatic HTTPS will
+retry on failure, but a certificate can't issue until the hostname resolves
+publicly.
+
+## 3. Environment variables
+
+Two groups of variables are relevant here: the domain/CORS seams from #1375
+(already documented in [`.env.example`](../.env.example)) and this guide's
+new proxy + credential variables. They must be **kept consistent** — this is
+the most common point of confusion:
+
+| This guide's proxy var | Must match | Why |
+|---|---|---|
+| `WEB_DOMAIN` | `OL_CORS_ORIGIN` = `https://<WEB_DOMAIN>` | The API's CORS allow-list must match the browser origin the UI is served from, or login fails with a CORS `NetworkError`. |
+| `API_DOMAIN` | `VITE_API_BASE_URL` = `https://<API_DOMAIN>` | Baked into the UI bundle at **build time** — changing it requires `--build` on the `web` image, not just a restart. |
+| `PRESTASHOP_DOMAIN` | `PS_DOMAIN` = `<PRESTASHOP_DOMAIN>` | The domain PrestaShop bakes into its own generated links/redirects. |
+
+Worked example, given the DNS records above:
+
+```dotenv
+# Proxy overlay
+WEB_DOMAIN=app.example.com
+API_DOMAIN=api.example.com
+PRESTASHOP_DOMAIN=shop.example.com
+TLS_EMAIL=ops@example.com
+
+# Must line up with the domains above (scheme included)
+OL_CORS_ORIGIN=https://app.example.com
+VITE_API_BASE_URL=https://api.example.com
+PS_DOMAIN=shop.example.com
+```
+
+> **The internal PrestaShop connection URL is unaffected by any of this.**
+> When wiring the PrestaShop connection in OpenLinker (see the [demo setup
+> guide § 5.2](./one-command-demo-setup-guide.md#52-create-the-connection-in-openlinker)),
+> the Shop URL / Storefront URL are still `http://prestashop` — the
+> **internal**, container-to-container address — never the public
+> `PRESTASHOP_DOMAIN`. The API/Worker containers never resolve the public
+> domain; only the operator's browser does.
+
+The full variable reference (base demo vars + this guide's additions) is in
+[`.env.example`](../.env.example) — every override lives there with an
+explanation and default.
+
+## 4. Credential rotation
+
+Before exposing the stack beyond localhost, rotate every credential
+`.env.example` lists under "Database / service credentials": `POSTGRES_PASSWORD`,
+`PRESTASHOP_MYSQL_ROOT_PASSWORD`, `PRESTASHOP_MYSQL_PASSWORD`,
+`WOOCOMMERCE_MYSQL_ROOT_PASSWORD`, `WOOCOMMERCE_MYSQL_PASSWORD`, `ADMIN_PASSWD`
+— plus the pre-existing `OL_BOOTSTRAP_ADMIN_PASSWORD` and `JWT_SECRET` from
+the base demo guide. None of the shipped defaults are production-safe; they
+exist only so a plain local `pnpm demo:up` works with zero configuration.
+
+Generate strong values, e.g.:
+
+```bash
+openssl rand -base64 24   # for each *_PASSWORD / *_PASSWD variable
+```
+
+Two credential pairs must stay in sync **because they're read by two
+different services** — set them once in `.env` and both sides pick up the
+same value automatically (see `docker-compose.yml` comments for the exact
+pairing): `PRESTASHOP_MYSQL_PASSWORD` (mysql user password ⟷ PrestaShop's
+`PS_DB_PASSWD`), `WOOCOMMERCE_MYSQL_PASSWORD` (woocommerce-mysql user
+password ⟷ WordPress's `WORDPRESS_DATABASE_PASSWORD`). You don't need to set
+anything twice — one `.env` line per variable is enough.
+
+## 5. Boot the stack with the proxy overlay
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.demo.yml -f docker-compose.proxy.yml \
+  up -d --build postgres redis mysql prestashop migrate api worker web caddy
+```
+
+The proxy overlay (`docker-compose.proxy.yml`) adds one service, `caddy`,
+which:
+- reaches `web` / `api` / `prestashop` **over the internal Compose network**
+  by service name and container port — it does not depend on those
+  services' host-published ports at all;
+- terminates TLS for the three domains configured in step 3;
+- publishes host ports `80` and `443` (unbound — this is the public edge).
+
+Confirm it's up:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.demo.yml -f docker-compose.proxy.yml logs -f caddy
+```
+
+Look for `certificate obtained successfully` per domain in the log output.
+
+Omitting `-f docker-compose.proxy.yml` reproduces the plain-HTTP localhost
+demo exactly as documented in the [base setup guide](./one-command-demo-setup-guide.md)
+— this overlay changes nothing else.
+
+## 6. Local verification (no real DNS needed)
+
+To verify the proxy overlay boots and routes correctly **before** you have
+real DNS/domains, or in a local sandbox:
+
+1. Pick three test hostnames (e.g. `app.local.test`, `api.local.test`,
+   `shop.local.test`) and add them to `/etc/hosts` pointing at `127.0.0.1`.
+2. Set `.env`:
+   ```dotenv
+   WEB_DOMAIN=app.local.test
+   API_DOMAIN=api.local.test
+   PRESTASHOP_DOMAIN=shop.local.test
+   TLS_EMAIL=test@example.com
+   CADDYFILE_PATH=./docker/caddy/Caddyfile.local
+   ```
+   `Caddyfile.local` uses `tls internal` — Caddy mints certificates from its
+   own local CA instead of requesting one from Let's Encrypt, so no real
+   DNS/domain or `mkcert` dependency is needed.
+3. Boot with the same command as step 5.
+4. Your browser will show a certificate warning (the cert is signed by
+   Caddy's local CA, not a public one) — accept it to verify routing/TLS
+   termination. To remove the warning entirely, trust Caddy's local root CA:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.demo.yml -f docker-compose.proxy.yml \
+     exec caddy caddy trust
+   ```
+   (installs the CA inside the container only; for the *browser* to stop
+   warning you'd additionally need to extract and trust that CA on the host
+   — out of scope for a quick verification pass.)
+
+Switch `CADDYFILE_PATH` back to the default (or unset it) to return to the
+production ACME Caddyfile.
+
+## 7. Post-deploy verification checklist
+
+Run through this after every deployment (initial or credential rotation):
+
+- [ ] **TLS certificate valid** for each domain:
+  ```bash
+  curl -vI https://app.example.com 2>&1 | grep -i "SSL certificate verify ok"
+  ```
+  or check the padlock in a browser.
+- [ ] **Login works with no CORS console errors** — open the browser dev
+  console while logging in at `https://<WEB_DOMAIN>`; no
+  `NetworkError`/CORS messages.
+- [ ] **API health check returns 200**:
+  ```bash
+  curl -s -o /dev/null -w '%{http_code}\n' https://api.example.com/v1/health
+  ```
+- [ ] **PrestaShop reachable at its own domain**: `https://<PRESTASHOP_DOMAIN>`
+  loads the storefront.
+- [ ] **Database ports unreachable from outside the host** — run from a
+  *different* machine (not the server itself):
+  ```bash
+  nmap -p 5432,3306,3307,6379 <server-public-ip>
+  # or, per port:
+  curl --connect-timeout 3 <server-public-ip>:5432
+  ```
+  All should report closed/filtered/refused. If any is open, check the host
+  firewall — the compose files publish these ports for local dev convenience;
+  a public-facing host needs a firewall rule blocking them (or the
+  `${OL_BIND_ADDRESS}` loopback-binding hardening from #1400/#1402, once
+  merged, which binds them to `127.0.0.1` by default at the compose level).
+- [ ] **Internal PrestaShop connection URL is still `http://prestashop`** —
+  re-confirm the OpenLinker↔PrestaShop connection's Shop URL/Storefront URL
+  fields were **not** accidentally set to the public `PRESTASHOP_DOMAIN`
+  (see § 3 callout above).
+- [ ] **Credentials rotated** — `POSTGRES_PASSWORD`, both MySQL instance
+  password pairs, `ADMIN_PASSWD`, `OL_BOOTSTRAP_ADMIN_PASSWORD`, `JWT_SECRET`
+  are all non-default values in `.env`.
+
+## 8. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Caddy log shows `challenge failed` / certificate never issues | DNS hasn't propagated yet, or port 80 is blocked by a firewall/security group | `dig +short <domain>` to confirm propagation; confirm port 80 (not just 443) is open — Let's Encrypt's HTTP-01 challenge needs it |
+| Browser shows a certificate warning even with the production Caddyfile | `CADDYFILE_PATH` is still pointed at `Caddyfile.local` | Unset `CADDYFILE_PATH` (or point it back at `./docker/caddy/Caddyfile`) and restart the `caddy` service |
+| Login fails with a CORS `NetworkError` after switching to a public domain | `OL_CORS_ORIGIN` doesn't match `https://<WEB_DOMAIN>` exactly (scheme/host) | Fix `OL_CORS_ORIGIN` in `.env`, restart `api` |
+| UI calls the wrong API origin / mixed-content errors | `VITE_API_BASE_URL` wasn't set before the `web` image was built | Set it in `.env`, rebuild: `docker compose ... up -d --build web` |
+| `docker compose up` with the proxy overlay fails immediately citing a missing var | One of `WEB_DOMAIN`/`API_DOMAIN`/`PRESTASHOP_DOMAIN`/`TLS_EMAIL` is unset | Set all four in `.env` — the overlay fails closed by design (`${VAR:?...}`) rather than booting half-configured |
+| `caddy` service can't reach `web`/`api`/`prestashop` | Booted without `-f docker-compose.demo.yml` (no `web` service exists) | Always use the 3-file invocation from § 5 |
+
+For everything else (PrestaShop admin folder, seller-defaults, offer
+creation, etc.), see the [base demo setup guide's troubleshooting
+table](./one-command-demo-setup-guide.md#8-troubleshooting).


### PR DESCRIPTION
## Summary

- Adds `docker-compose.proxy.yml`, an optional Caddy overlay that terminates TLS (automatic Let's Encrypt) and routes by hostname to `web`/`api`/`prestashop`. Caddy reaches those services **over the internal Compose network by service name/port**, not through host-published ports — independent of #1402's loopback-binding hardening (now merged), and avoids a redundant hop through the host network stack. Ships with two Caddyfiles: `docker/caddy/Caddyfile` (production ACME) and `docker/caddy/Caddyfile.local` (`tls internal`, for local verification with no real DNS/domain and no `mkcert` dependency).
- Parametrizes `POSTGRES_PASSWORD`, `PRESTASHOP_MYSQL_ROOT_PASSWORD`, `PRESTASHOP_MYSQL_PASSWORD`, `WOOCOMMERCE_MYSQL_ROOT_PASSWORD`, `WOOCOMMERCE_MYSQL_PASSWORD`, and PrestaShop `ADMIN_PASSWD` via `${VAR:-default}` in `docker-compose.yml`, following the exact pattern #1375 established for `OL_BOOTSTRAP_ADMIN_PASSWORD`/`JWT_SECRET`. All defaults are unchanged, so a plain `pnpm demo:up` / `pnpm dev:stack:up` with no `.env` is byte-identical to today.
  - 6 separate, instance-specific variable names (not shared across the two MySQL instances) — confirmed design decision during planning.
  - Also fixes a latent gap the issue didn't call out explicitly but is required for correctness: `api`/`worker`/`migrate`'s `DB_PASSWORD` was hardcoded to `postgres` **independently** of the `postgres` service's password — overriding `POSTGRES_PASSWORD` alone would have broken every app-tier DB connection. Now all four reference the same var.
- Adds `docs/public-domain-demo-deployment-guide.md`: DNS records needed per component, the full env-var list (the #1375 domain/CORS vars + this PR's new credential/proxy vars, with a worked example showing how they must line up), credential rotation guidance, the 3-file boot command, local verification steps, and a post-deploy verification checklist (TLS validity, CORS-clean login, `/v1/health` 200, DB ports unreachable externally, PrestaShop reachable at its own domain, and the recurring "internal PrestaShop connection URL is always `http://prestashop`" reminder).
- Updates `.env.example` with all new vars in the existing comment style, and cross-references the new guide from `docs/one-command-demo-setup-guide.md`.
- Rebased onto `main` after #1402 merged (both touched `docker-compose.yml`); resolved a straightforward `.env.example` section-ordering conflict, no logic conflicts.

## Live verification (done, on the final rebased/merged state)

Booted the full stack + proxy overlay locally with Docker — first against this PR's changes alone, then again against the final state rebased on top of #1402 (loopback-binding hardening) to confirm both features compose correctly together:

- All containers (postgres, redis, mysql, prestashop, migrate, api, worker, web, caddy) started healthy.
- Caddy obtained internal-CA TLS certificates for all three hostnames on boot (`tls.obtain … certificate obtained successfully`, confirmed in container logs).
- `https://web.local.test/` → `200`
- `https://api.local.test/v1/health` → `200` with `{"status":"ok","services":{"postgres":{"status":"ok"},"redis":{"status":"ok"}}}` — confirms the reverse-proxy path AND the `POSTGRES_PASSWORD`/`DB_PASSWORD` wiring fix.
- `https://shop.local.test/` → `302` (expected PrestaShop redirect behavior).
- Confirmed `api`/`web`/`postgres` publish on `127.0.0.1` by default post-#1402-merge (`docker port` output), i.e. #1400/#1402's hardening and #1403's changes don't regress each other.

Verification was run in an isolated manner (stopped/removed only what this session started; pre-existing dev-stack containers/volumes were left untouched).

## Test plan

- [x] `pnpm lint` — zero errors, `check:invariants` all green
- [x] `pnpm type-check` — zero errors
- [x] `pnpm test` — all packages pass (2030 web / 1453 core / 675 api / 197 worker tests, etc.)
- [x] `docker compose config` structure validated via YAML parsing (custom-tag-aware) — no syntax errors, `!override`/`!reset` directives intact
- [x] Manually traced every credential var reference for "must match" consistency across services
- [x] **Live boot of the proxy overlay** — confirmed Caddy issues certificates and routes `web`/`api`/`prestashop` correctly, re-verified after rebasing on #1402
- [x] Plain `pnpm demo:up` (no `.env`, no proxy overlay) behavior is unchanged — all new vars default to today's literal values

Closes #1403

🤖 Generated with [Claude Code](https://claude.com/claude-code)