### PR TITLE
feat(demo): demo-only PostHog session recording via server-gated config seam

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -29,6 +29,10 @@ WEB_URL=http://localhost:4173
 OL_REGISTRATION_ENABLED=false
 # true  = enable demo mode
 OL_DEMO_MODE=false
+# Demo-only PostHog session recording (see ADR-032). Only ever surfaced to the
+# frontend when OL_DEMO_MODE=true; unset on normal self-hosted installs.
+# OL_POSTHOG_KEY=
+# OL_POSTHOG_HOST=https://eu.posthog.com
 # --- CORS ---------------------------------------------------------------------
 # Comma-separated list of allowed origins for browser API calls. Required to
 # include the web origin because the API uses `credentials: true` (refresh

--- a/apps/api/src/system/dto/demo-integrations.dto.ts
+++ b/apps/api/src/system/dto/demo-integrations.dto.ts
@@ -10,13 +10,10 @@
  */
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsOptional, ValidateNested } from 'class-validator';
 import { PosthogDemoIntegrationDto } from './posthog-demo-integration.dto';
 
 export class DemoIntegrationsDto {
   @ApiPropertyOptional({ type: PosthogDemoIntegrationDto })
-  @IsOptional()
-  @ValidateNested()
   @Type(() => PosthogDemoIntegrationDto)
   posthog?: PosthogDemoIntegrationDto;
 }

--- a/apps/api/src/system/dto/demo-integrations.dto.ts
+++ b/apps/api/src/system/dto/demo-integrations.dto.ts
@@ -1,0 +1,22 @@
+/**
+ * Demo Integrations DTO
+ *
+ * Vendor-neutral container for demo-only third-party integration config on
+ * GET /system/config. Each provider gets its own namespaced, optional
+ * sub-key (today: `posthog`) so adding a future provider (e.g. support-chat)
+ * is additive rather than a reshape. See ADR-032.
+ *
+ * @module apps/api/src/system/dto
+ */
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsOptional, ValidateNested } from 'class-validator';
+import { PosthogDemoIntegrationDto } from './posthog-demo-integration.dto';
+
+export class DemoIntegrationsDto {
+  @ApiPropertyOptional({ type: PosthogDemoIntegrationDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PosthogDemoIntegrationDto)
+  posthog?: PosthogDemoIntegrationDto;
+}

--- a/apps/api/src/system/dto/posthog-demo-integration.dto.ts
+++ b/apps/api/src/system/dto/posthog-demo-integration.dto.ts
@@ -1,0 +1,18 @@
+/**
+ * PostHog Demo Integration DTO
+ *
+ * Nested response shape for the `demoIntegrations.posthog` block on
+ * GET /system/config. Only ever populated server-side from env vars, never
+ * from user input — see `SystemService.getConfig()`.
+ *
+ * @module apps/api/src/system/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PosthogDemoIntegrationDto {
+  @ApiProperty({ description: 'PostHog project API key (publishable, write-only ingestion key).' })
+  key!: string;
+
+  @ApiProperty({ description: 'PostHog ingestion host, e.g. https://eu.posthog.com.' })
+  host!: string;
+}

--- a/apps/api/src/system/dto/system-config.dto.ts
+++ b/apps/api/src/system/dto/system-config.dto.ts
@@ -6,9 +6,22 @@
  *
  * @module apps/api/src/system/dto
  */
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsOptional, ValidateNested } from 'class-validator';
+import { DemoIntegrationsDto } from './demo-integrations.dto';
 
 export class SystemConfigDto {
   @ApiProperty({ description: 'True when OL_DEMO_MODE=true is set in the environment.' })
   demoMode!: boolean;
+
+  @ApiPropertyOptional({
+    type: DemoIntegrationsDto,
+    description:
+      'Demo-only third-party integration config (e.g. PostHog). Present only when demo mode is active and the provider is configured.',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => DemoIntegrationsDto)
+  demoIntegrations?: DemoIntegrationsDto;
 }

--- a/apps/api/src/system/dto/system-config.dto.ts
+++ b/apps/api/src/system/dto/system-config.dto.ts
@@ -8,7 +8,6 @@
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsOptional, ValidateNested } from 'class-validator';
 import { DemoIntegrationsDto } from './demo-integrations.dto';
 
 export class SystemConfigDto {
@@ -20,8 +19,6 @@ export class SystemConfigDto {
     description:
       'Demo-only third-party integration config (e.g. PostHog). Present only when demo mode is active and the provider is configured.',
   })
-  @IsOptional()
-  @ValidateNested()
   @Type(() => DemoIntegrationsDto)
   demoIntegrations?: DemoIntegrationsDto;
 }

--- a/apps/api/src/system/posthog-config.service.interface.ts
+++ b/apps/api/src/system/posthog-config.service.interface.ts
@@ -1,0 +1,25 @@
+/**
+ * PostHog Config Service Interface
+ *
+ * Contract for reading the demo instance's PostHog analytics configuration
+ * from the environment. Consumed by the system config endpoint to surface
+ * a demo-only, vendor-neutral integration seam (see ADR-032).
+ *
+ * @module apps/api/src/system
+ */
+
+export interface PosthogConfig {
+  key: string;
+  host: string;
+}
+
+export interface IPosthogConfigService {
+  /**
+   * Returns the configured PostHog key/host, or `null` when OL_POSTHOG_KEY
+   * is unset — the caller (SystemService) is responsible for also gating
+   * on demo mode before exposing this to the frontend.
+   */
+  getConfig(): PosthogConfig | null;
+}
+
+export const POSTHOG_CONFIG_SERVICE_TOKEN = Symbol('IPosthogConfigService');

--- a/apps/api/src/system/posthog-config.service.interface.ts
+++ b/apps/api/src/system/posthog-config.service.interface.ts
@@ -7,11 +7,7 @@
  *
  * @module apps/api/src/system
  */
-
-export interface PosthogConfig {
-  key: string;
-  host: string;
-}
+import type { PosthogConfig } from './posthog-config.types';
 
 export interface IPosthogConfigService {
   /**

--- a/apps/api/src/system/posthog-config.service.spec.ts
+++ b/apps/api/src/system/posthog-config.service.spec.ts
@@ -1,0 +1,35 @@
+import type { ConfigService } from '@nestjs/config';
+import { PosthogConfigService } from './posthog-config.service';
+
+describe('PosthogConfigService', () => {
+  function makeService(env: Record<string, string>): PosthogConfigService {
+    const configService = {
+      get: <T>(key: string, defaultValue?: T): T => (env[key] as T) ?? (defaultValue as T),
+    } as unknown as ConfigService;
+    return new PosthogConfigService(configService);
+  }
+
+  it('should return null when OL_POSTHOG_KEY is unset', () => {
+    expect(makeService({}).getConfig()).toBeNull();
+  });
+
+  it('should return null when OL_POSTHOG_KEY is blank', () => {
+    expect(makeService({ OL_POSTHOG_KEY: '   ' }).getConfig()).toBeNull();
+  });
+
+  it('should default the host to eu.posthog.com when only the key is set', () => {
+    expect(makeService({ OL_POSTHOG_KEY: 'phc_abc123' }).getConfig()).toEqual({
+      key: 'phc_abc123',
+      host: 'https://eu.posthog.com',
+    });
+  });
+
+  it('should use the configured host when both key and host are set', () => {
+    expect(
+      makeService({
+        OL_POSTHOG_KEY: 'phc_abc123',
+        OL_POSTHOG_HOST: 'https://us.posthog.com',
+      }).getConfig(),
+    ).toEqual({ key: 'phc_abc123', host: 'https://us.posthog.com' });
+  });
+});

--- a/apps/api/src/system/posthog-config.service.ts
+++ b/apps/api/src/system/posthog-config.service.ts
@@ -1,0 +1,30 @@
+/**
+ * PostHog Config Service
+ *
+ * Reads OL_POSTHOG_KEY / OL_POSTHOG_HOST from the environment. Returns null
+ * when no key is configured, so the demo-only analytics seam is deny-by-
+ * default even on a demo-mode instance that hasn't opted into PostHog.
+ *
+ * @module apps/api/src/system
+ * @implements {IPosthogConfigService}
+ */
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { IPosthogConfigService, PosthogConfig } from './posthog-config.service.interface';
+
+const DEFAULT_POSTHOG_HOST = 'https://eu.posthog.com';
+
+@Injectable()
+export class PosthogConfigService implements IPosthogConfigService {
+  constructor(private readonly configService: ConfigService) {}
+
+  getConfig(): PosthogConfig | null {
+    const key = this.configService.get<string>('OL_POSTHOG_KEY', '').trim();
+    if (!key) {
+      return null;
+    }
+
+    const host = this.configService.get<string>('OL_POSTHOG_HOST', DEFAULT_POSTHOG_HOST).trim();
+    return { key, host: host || DEFAULT_POSTHOG_HOST };
+  }
+}

--- a/apps/api/src/system/posthog-config.service.ts
+++ b/apps/api/src/system/posthog-config.service.ts
@@ -10,7 +10,8 @@
  */
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import type { IPosthogConfigService, PosthogConfig } from './posthog-config.service.interface';
+import type { IPosthogConfigService } from './posthog-config.service.interface';
+import type { PosthogConfig } from './posthog-config.types';
 
 const DEFAULT_POSTHOG_HOST = 'https://eu.posthog.com';
 

--- a/apps/api/src/system/posthog-config.types.ts
+++ b/apps/api/src/system/posthog-config.types.ts
@@ -1,0 +1,12 @@
+/**
+ * PostHog Config Types
+ *
+ * Value shape returned by `IPosthogConfigService.getConfig()`.
+ *
+ * @module apps/api/src/system
+ */
+
+export interface PosthogConfig {
+  key: string;
+  host: string;
+}

--- a/apps/api/src/system/system.module.ts
+++ b/apps/api/src/system/system.module.ts
@@ -10,6 +10,8 @@
 import { Module } from '@nestjs/common';
 import { DemoModeService } from '../auth/demo-mode.service';
 import { DEMO_MODE_SERVICE_TOKEN } from '../auth/demo-mode.service.interface';
+import { PosthogConfigService } from './posthog-config.service';
+import { POSTHOG_CONFIG_SERVICE_TOKEN } from './posthog-config.service.interface';
 import { SystemService } from './system.service';
 import { SYSTEM_SERVICE_TOKEN } from './system.service.interface';
 import { SystemController } from './system.controller';
@@ -19,6 +21,8 @@ import { SystemController } from './system.controller';
   providers: [
     DemoModeService,
     { provide: DEMO_MODE_SERVICE_TOKEN, useExisting: DemoModeService },
+    PosthogConfigService,
+    { provide: POSTHOG_CONFIG_SERVICE_TOKEN, useExisting: PosthogConfigService },
     SystemService,
     { provide: SYSTEM_SERVICE_TOKEN, useExisting: SystemService },
   ],

--- a/apps/api/src/system/system.service.spec.ts
+++ b/apps/api/src/system/system.service.spec.ts
@@ -1,12 +1,19 @@
 import type { IDemoModeService } from '../auth/demo-mode.service.interface';
+import type { IPosthogConfigService, PosthogConfig } from './posthog-config.service.interface';
 import { SystemService } from './system.service';
 
 describe('SystemService', () => {
-  function makeService(demoMode: boolean): SystemService {
+  function makeService(
+    demoMode: boolean,
+    posthogConfig: PosthogConfig | null = null,
+  ): SystemService {
     const demoModeService: IDemoModeService = {
       isDemoModeEnabled: () => demoMode,
     };
-    return new SystemService(demoModeService);
+    const posthogConfigService: IPosthogConfigService = {
+      getConfig: () => posthogConfig,
+    };
+    return new SystemService(demoModeService, posthogConfigService);
   }
 
   it('should return demoMode: true when demo mode is enabled', () => {
@@ -15,5 +22,23 @@ describe('SystemService', () => {
 
   it('should return demoMode: false when demo mode is disabled', () => {
     expect(makeService(false).getConfig()).toEqual({ demoMode: false });
+  });
+
+  it('should not include demoIntegrations when demo mode is off, even if PostHog is configured', () => {
+    expect(
+      makeService(false, { key: 'phc_abc', host: 'https://eu.posthog.com' }).getConfig(),
+    ).toEqual({ demoMode: false });
+  });
+
+  it('should not include demoIntegrations when demo mode is on but PostHog is unconfigured', () => {
+    expect(makeService(true, null).getConfig()).toEqual({ demoMode: true });
+  });
+
+  it('should include demoIntegrations.posthog when demo mode is on and PostHog is configured', () => {
+    const posthogConfig: PosthogConfig = { key: 'phc_abc', host: 'https://eu.posthog.com' };
+    expect(makeService(true, posthogConfig).getConfig()).toEqual({
+      demoMode: true,
+      demoIntegrations: { posthog: posthogConfig },
+    });
   });
 });

--- a/apps/api/src/system/system.service.spec.ts
+++ b/apps/api/src/system/system.service.spec.ts
@@ -1,5 +1,6 @@
 import type { IDemoModeService } from '../auth/demo-mode.service.interface';
-import type { IPosthogConfigService, PosthogConfig } from './posthog-config.service.interface';
+import type { IPosthogConfigService } from './posthog-config.service.interface';
+import type { PosthogConfig } from './posthog-config.types';
 import { SystemService } from './system.service';
 
 describe('SystemService', () => {

--- a/apps/api/src/system/system.service.ts
+++ b/apps/api/src/system/system.service.ts
@@ -12,6 +12,10 @@ import {
   DEMO_MODE_SERVICE_TOKEN,
   type IDemoModeService,
 } from '../auth/demo-mode.service.interface';
+import {
+  POSTHOG_CONFIG_SERVICE_TOKEN,
+  type IPosthogConfigService,
+} from './posthog-config.service.interface';
 import type { ISystemService } from './system.service.interface';
 import type { SystemConfigDto } from './dto/system-config.dto';
 
@@ -20,9 +24,21 @@ export class SystemService implements ISystemService {
   constructor(
     @Inject(DEMO_MODE_SERVICE_TOKEN)
     private readonly demoModeService: IDemoModeService,
+    @Inject(POSTHOG_CONFIG_SERVICE_TOKEN)
+    private readonly posthogConfigService: IPosthogConfigService,
   ) {}
 
   getConfig(): SystemConfigDto {
-    return { demoMode: this.demoModeService.isDemoModeEnabled() };
+    const demoMode = this.demoModeService.isDemoModeEnabled();
+    if (!demoMode) {
+      return { demoMode };
+    }
+
+    const posthog = this.posthogConfigService.getConfig();
+    if (!posthog) {
+      return { demoMode };
+    }
+
+    return { demoMode, demoIntegrations: { posthog } };
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,10 +29,10 @@
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.24",
     "cmdk": "^1.1.1",
+    "posthog-js": "^1.398.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.2",
-    "posthog-js": "^1.398.3",
     "react-router-dom": "^7.13.1",
     "zod": "^4.3.6"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.2",
+    "posthog-js": "^1.398.3",
     "react-router-dom": "^7.13.1",
     "zod": "^4.3.6"
   },

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -46,6 +46,7 @@ import { CommandPaletteTrigger } from '../shared/ui/command-palette';
 import { DemoBanner } from '../shared/ui/demo-banner';
 import { useSystemConfigQuery } from '../features/system';
 import {
+  disableDemoAnalytics,
   getDemoAnalyticsConsent,
   initDemoIntegrations,
   setDemoAnalyticsConsent,
@@ -268,6 +269,9 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
   const handleAnalyticsConsentChange = useCallback((consent: DemoAnalyticsConsent): void => {
     setDemoAnalyticsConsent(consent);
     setAnalyticsConsent(consent);
+    if (consent === 'declined') {
+      disableDemoAnalytics();
+    }
   }, []);
 
   const crumbs = resolveCrumbFromMatches(matches);
@@ -350,6 +354,7 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
         {demoMode ? (
           <DemoBanner
             consentPending={Boolean(posthogConfig?.key) && analyticsConsent === null}
+            consentAccepted={Boolean(posthogConfig?.key) && analyticsConsent === 'accepted'}
             onConsentChange={handleAnalyticsConsentChange}
           />
         ) : null}

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -17,6 +17,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
   type PropsWithChildren,
   type ReactElement,
 } from 'react';
@@ -44,6 +45,12 @@ import { CommandPaletteProvider, useCommandPalette } from './command-palette-pro
 import { CommandPaletteTrigger } from '../shared/ui/command-palette';
 import { DemoBanner } from '../shared/ui/demo-banner';
 import { useSystemConfigQuery } from '../features/system';
+import {
+  getDemoAnalyticsConsent,
+  initDemoIntegrations,
+  setDemoAnalyticsConsent,
+  type DemoAnalyticsConsent,
+} from '../features/demo';
 
 interface SidebarNavProps {
   ariaLabel: string;
@@ -204,6 +211,11 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
   const { showToast } = useToast();
   const systemConfigQuery = useSystemConfigQuery();
   const demoMode = systemConfigQuery.data?.demoMode ?? false;
+  const posthogConfig = systemConfigQuery.data?.demoIntegrations?.posthog;
+  const [analyticsConsent, setAnalyticsConsent] = useState<DemoAnalyticsConsent | null>(() =>
+    getDemoAnalyticsConsent(),
+  );
+  const hasInitializedAnalyticsRef = useRef(false);
   const location = useLocation();
   const drawerRef = useRef<HTMLDialogElement>(null);
   // Initialize density at boot so <html data-density="..."> is set before
@@ -237,6 +249,26 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
       showToast({ tone: 'info', description: 'You have been logged out.' });
     })();
   }, [clearSession, showToast]);
+
+  // Demo-only analytics (#1301) — attempt init once the config query has
+  // settled and again whenever the visitor grants consent. The loader's own
+  // guards (demoMode, config presence, consent) make repeat calls a no-op,
+  // but hasInitializedAnalyticsRef avoids a redundant dynamic import.
+  useEffect(() => {
+    if (!systemConfigQuery.isSuccess || hasInitializedAnalyticsRef.current) {
+      return;
+    }
+    if (analyticsConsent !== 'accepted') {
+      return;
+    }
+    hasInitializedAnalyticsRef.current = true;
+    void initDemoIntegrations(systemConfigQuery.data);
+  }, [systemConfigQuery.isSuccess, systemConfigQuery.data, analyticsConsent]);
+
+  const handleAnalyticsConsentChange = useCallback((consent: DemoAnalyticsConsent): void => {
+    setDemoAnalyticsConsent(consent);
+    setAnalyticsConsent(consent);
+  }, []);
 
   const crumbs = resolveCrumbFromMatches(matches);
 
@@ -315,7 +347,12 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
           ) : null}
         </header>
 
-        {demoMode ? <DemoBanner /> : null}
+        {demoMode ? (
+          <DemoBanner
+            consentPending={Boolean(posthogConfig?.key) && analyticsConsent === null}
+            onConsentChange={handleAnalyticsConsentChange}
+          />
+        ) : null}
 
         {/* `key={location.pathname}` retriggers the .shell-content
             cross-fade animation on every route change (#775). */}

--- a/apps/web/src/features/demo/demo.types.ts
+++ b/apps/web/src/features/demo/demo.types.ts
@@ -1,0 +1,12 @@
+/**
+ * Demo Types
+ *
+ * Visitor consent for demo-only analytics (PostHog session recording) is a
+ * client-owned preference persisted to localStorage, mirroring the theme
+ * preference in `shared/theme/theme.types.ts`.
+ */
+
+export const DEMO_ANALYTICS_CONSENT_STORAGE_KEY = 'openlinker.demoAnalyticsConsent';
+
+export const DemoAnalyticsConsentValues = ['accepted', 'declined'] as const;
+export type DemoAnalyticsConsent = (typeof DemoAnalyticsConsentValues)[number];

--- a/apps/web/src/features/demo/index.ts
+++ b/apps/web/src/features/demo/index.ts
@@ -1,0 +1,3 @@
+export { initDemoIntegrations } from './lib/init-demo-integrations';
+export { getDemoAnalyticsConsent, setDemoAnalyticsConsent } from './lib/demo-analytics-consent';
+export type { DemoAnalyticsConsent } from './demo.types';

--- a/apps/web/src/features/demo/index.ts
+++ b/apps/web/src/features/demo/index.ts
@@ -1,3 +1,3 @@
-export { initDemoIntegrations } from './lib/init-demo-integrations';
+export { disableDemoAnalytics, initDemoIntegrations } from './lib/init-demo-integrations';
 export { getDemoAnalyticsConsent, setDemoAnalyticsConsent } from './lib/demo-analytics-consent';
 export type { DemoAnalyticsConsent } from './demo.types';

--- a/apps/web/src/features/demo/lib/demo-analytics-consent.test.ts
+++ b/apps/web/src/features/demo/lib/demo-analytics-consent.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEMO_ANALYTICS_CONSENT_STORAGE_KEY } from '../demo.types';
+import { getDemoAnalyticsConsent, setDemoAnalyticsConsent } from './demo-analytics-consent';
+
+describe('demo-analytics-consent', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('should return null when no consent is stored', () => {
+    expect(getDemoAnalyticsConsent()).toBeNull();
+  });
+
+  it('should round-trip an accepted consent', () => {
+    setDemoAnalyticsConsent('accepted');
+    expect(getDemoAnalyticsConsent()).toBe('accepted');
+  });
+
+  it('should round-trip a declined consent', () => {
+    setDemoAnalyticsConsent('declined');
+    expect(getDemoAnalyticsConsent()).toBe('declined');
+  });
+
+  it('should return null for an invalid stored value', () => {
+    window.localStorage.setItem(DEMO_ANALYTICS_CONSENT_STORAGE_KEY, 'not-a-real-value');
+    expect(getDemoAnalyticsConsent()).toBeNull();
+  });
+
+  it('should not throw and should return null when localStorage.getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    expect(() => getDemoAnalyticsConsent()).not.toThrow();
+    expect(getDemoAnalyticsConsent()).toBeNull();
+  });
+
+  it('should not throw when localStorage.setItem throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    expect(() => setDemoAnalyticsConsent('accepted')).not.toThrow();
+  });
+});

--- a/apps/web/src/features/demo/lib/demo-analytics-consent.ts
+++ b/apps/web/src/features/demo/lib/demo-analytics-consent.ts
@@ -1,0 +1,37 @@
+/**
+ * Demo Analytics Consent
+ *
+ * Reads/writes the visitor's opt-in choice for demo-only analytics (PostHog
+ * session recording) to localStorage. Fails safe: if storage is unavailable
+ * (private browsing, strict cookie policy), consent reads as unset so the
+ * visitor is re-prompted rather than silently enabling recording.
+ */
+import {
+  DEMO_ANALYTICS_CONSENT_STORAGE_KEY,
+  DemoAnalyticsConsentValues,
+  type DemoAnalyticsConsent,
+} from '../demo.types';
+
+function isDemoAnalyticsConsent(value: unknown): value is DemoAnalyticsConsent {
+  return (
+    typeof value === 'string' && DemoAnalyticsConsentValues.includes(value as DemoAnalyticsConsent)
+  );
+}
+
+export function getDemoAnalyticsConsent(): DemoAnalyticsConsent | null {
+  try {
+    const raw = window.localStorage.getItem(DEMO_ANALYTICS_CONSENT_STORAGE_KEY);
+    return isDemoAnalyticsConsent(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setDemoAnalyticsConsent(value: DemoAnalyticsConsent): void {
+  try {
+    window.localStorage.setItem(DEMO_ANALYTICS_CONSENT_STORAGE_KEY, value);
+  } catch {
+    // localStorage may be disabled — the visitor will simply be re-prompted
+    // next time; no functional impact beyond that.
+  }
+}

--- a/apps/web/src/features/demo/lib/init-demo-integrations.test.ts
+++ b/apps/web/src/features/demo/lib/init-demo-integrations.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SystemConfig } from '../../system';
+import { initDemoIntegrations } from './init-demo-integrations';
+
+const posthogInit = vi.fn();
+vi.mock('posthog-js', () => ({
+  default: { init: posthogInit },
+}));
+
+const getDemoAnalyticsConsent = vi.fn();
+vi.mock('./demo-analytics-consent', () => ({
+  getDemoAnalyticsConsent: (): unknown => getDemoAnalyticsConsent(),
+}));
+
+const configuredPosthog: SystemConfig = {
+  demoMode: true,
+  demoIntegrations: { posthog: { key: 'phc_abc', host: 'https://eu.posthog.com' } },
+};
+
+describe('initDemoIntegrations', () => {
+  beforeEach(() => {
+    posthogInit.mockClear();
+    getDemoAnalyticsConsent.mockReset();
+  });
+
+  it('should not init when demoMode is false', async () => {
+    getDemoAnalyticsConsent.mockReturnValue('accepted');
+    await initDemoIntegrations({ ...configuredPosthog, demoMode: false });
+    expect(posthogInit).not.toHaveBeenCalled();
+  });
+
+  it('should not init when demoMode is true but no posthog key is configured', async () => {
+    getDemoAnalyticsConsent.mockReturnValue('accepted');
+    await initDemoIntegrations({ demoMode: true });
+    expect(posthogInit).not.toHaveBeenCalled();
+  });
+
+  it('should not init when config is present but consent is not accepted', async () => {
+    getDemoAnalyticsConsent.mockReturnValue(null);
+    await initDemoIntegrations(configuredPosthog);
+    expect(posthogInit).not.toHaveBeenCalled();
+
+    getDemoAnalyticsConsent.mockReturnValue('declined');
+    await initDemoIntegrations(configuredPosthog);
+    expect(posthogInit).not.toHaveBeenCalled();
+  });
+
+  it('should not init when config is undefined', async () => {
+    getDemoAnalyticsConsent.mockReturnValue('accepted');
+    await initDemoIntegrations(undefined);
+    expect(posthogInit).not.toHaveBeenCalled();
+  });
+
+  it('should init with masking options when all gates pass', async () => {
+    getDemoAnalyticsConsent.mockReturnValue('accepted');
+    await initDemoIntegrations(configuredPosthog);
+    expect(posthogInit).toHaveBeenCalledWith('phc_abc', {
+      api_host: 'https://eu.posthog.com',
+      person_profiles: 'identified_only',
+      session_recording: {
+        maskAllInputs: true,
+        maskTextSelector: '[data-ph-mask]',
+      },
+    });
+  });
+});

--- a/apps/web/src/features/demo/lib/init-demo-integrations.test.ts
+++ b/apps/web/src/features/demo/lib/init-demo-integrations.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SystemConfig } from '../../system';
-import { initDemoIntegrations } from './init-demo-integrations';
+import { disableDemoAnalytics, initDemoIntegrations } from './init-demo-integrations';
 
 const posthogInit = vi.fn();
+const posthogOptOut = vi.fn();
 vi.mock('posthog-js', () => ({
-  default: { init: posthogInit },
+  default: { init: posthogInit, opt_out_capturing: posthogOptOut },
 }));
 
 const getDemoAnalyticsConsent = vi.fn();
@@ -20,6 +21,7 @@ const configuredPosthog: SystemConfig = {
 describe('initDemoIntegrations', () => {
   beforeEach(() => {
     posthogInit.mockClear();
+    posthogOptOut.mockClear();
     getDemoAnalyticsConsent.mockReset();
   });
 
@@ -57,10 +59,29 @@ describe('initDemoIntegrations', () => {
     expect(posthogInit).toHaveBeenCalledWith('phc_abc', {
       api_host: 'https://eu.posthog.com',
       person_profiles: 'identified_only',
+      autocapture: false,
+      capture_pageview: true,
       session_recording: {
         maskAllInputs: true,
-        maskTextSelector: '[data-ph-mask]',
+        maskTextSelector: '*',
       },
     });
+  });
+});
+
+describe('disableDemoAnalytics', () => {
+  beforeEach(() => {
+    posthogInit.mockClear();
+    posthogOptOut.mockClear();
+    getDemoAnalyticsConsent.mockReset();
+  });
+
+  it('should opt the visitor out of capture after PostHog was initialized', async () => {
+    getDemoAnalyticsConsent.mockReturnValue('accepted');
+    await initDemoIntegrations(configuredPosthog);
+
+    disableDemoAnalytics();
+
+    expect(posthogOptOut).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/features/demo/lib/init-demo-integrations.ts
+++ b/apps/web/src/features/demo/lib/init-demo-integrations.ts
@@ -5,9 +5,19 @@
  * session recording). `posthog-js` is dynamically imported so it is never
  * fetched on a normal (non-demo) install — the three synchronous guards
  * (demo mode, config presence, visitor consent) all run before the import.
+ *
+ * Masking is opt-out (`maskTextSelector: '*'` masks every rendered text
+ * node), not opt-in by selector: demo mode must only ever run against
+ * synthetic seed data (see docs/one-command-demo-setup-guide.md), but rrweb
+ * records every rendered DOM text node by default, so an operator who points
+ * a demo instance at real data would otherwise ship buyer PII to PostHog
+ * cloud.
  */
+import type { PostHog } from 'posthog-js';
 import type { SystemConfig } from '../../system';
 import { getDemoAnalyticsConsent } from './demo-analytics-consent';
+
+let posthogInstance: PostHog | null = null;
 
 export async function initDemoIntegrations(config: SystemConfig | undefined): Promise<void> {
   const posthogConfig = config?.demoMode ? config.demoIntegrations?.posthog : undefined;
@@ -20,12 +30,24 @@ export async function initDemoIntegrations(config: SystemConfig | undefined): Pr
   }
 
   const { default: posthog } = await import('posthog-js');
+  posthogInstance = posthog;
   posthog.init(posthogConfig.key, {
     api_host: posthogConfig.host,
     person_profiles: 'identified_only',
+    autocapture: false,
+    capture_pageview: true,
     session_recording: {
       maskAllInputs: true,
-      maskTextSelector: '[data-ph-mask]',
+      maskTextSelector: '*',
     },
   });
+}
+
+/**
+ * Opts the current visitor out of PostHog capture without a page reload, so
+ * the in-banner "disable" affordance takes effect immediately. A no-op when
+ * PostHog was never initialized (consent was never accepted this session).
+ */
+export function disableDemoAnalytics(): void {
+  posthogInstance?.opt_out_capturing();
 }

--- a/apps/web/src/features/demo/lib/init-demo-integrations.ts
+++ b/apps/web/src/features/demo/lib/init-demo-integrations.ts
@@ -1,0 +1,31 @@
+/**
+ * Init Demo Integrations
+ *
+ * Gated loader for demo-only third-party integrations (today: PostHog
+ * session recording). `posthog-js` is dynamically imported so it is never
+ * fetched on a normal (non-demo) install — the three synchronous guards
+ * (demo mode, config presence, visitor consent) all run before the import.
+ */
+import type { SystemConfig } from '../../system';
+import { getDemoAnalyticsConsent } from './demo-analytics-consent';
+
+export async function initDemoIntegrations(config: SystemConfig | undefined): Promise<void> {
+  const posthogConfig = config?.demoMode ? config.demoIntegrations?.posthog : undefined;
+  if (!posthogConfig?.key) {
+    return;
+  }
+
+  if (getDemoAnalyticsConsent() !== 'accepted') {
+    return;
+  }
+
+  const { default: posthog } = await import('posthog-js');
+  posthog.init(posthogConfig.key, {
+    api_host: posthogConfig.host,
+    person_profiles: 'identified_only',
+    session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: '[data-ph-mask]',
+    },
+  });
+}

--- a/apps/web/src/features/system/api/system.types.ts
+++ b/apps/web/src/features/system/api/system.types.ts
@@ -1,3 +1,13 @@
+export interface PosthogDemoIntegration {
+  key: string;
+  host: string;
+}
+
+export interface DemoIntegrations {
+  posthog?: PosthogDemoIntegration;
+}
+
 export interface SystemConfig {
   demoMode: boolean;
+  demoIntegrations?: DemoIntegrations;
 }

--- a/apps/web/src/features/system/index.ts
+++ b/apps/web/src/features/system/index.ts
@@ -1,3 +1,7 @@
-export type { SystemConfig } from './api/system.types';
+export type {
+  SystemConfig,
+  DemoIntegrations,
+  PosthogDemoIntegration,
+} from './api/system.types';
 export { systemQueryKeys } from './api/system.query-keys';
 export { useSystemConfigQuery } from './hooks/use-system-config-query';

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10295,6 +10295,16 @@ html[data-density='compact'] .status-badge {
   line-height: 1;
 }
 
+/* Analytics-consent CTA (#1301) — appended to the demo banner only when a
+   demo-only integration (e.g. PostHog) is configured and unconsented. */
+.demo-banner__consent {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
 /* Login / register page: info bar at top of the form-card. */
 .guest-form__demo-bar {
   display: flex;

--- a/apps/web/src/shared/ui/demo-banner.test.tsx
+++ b/apps/web/src/shared/ui/demo-banner.test.tsx
@@ -1,6 +1,7 @@
 import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 import { DemoBanner } from './demo-banner';
 
 describe('DemoBanner', () => {
@@ -25,5 +26,30 @@ describe('DemoBanner', () => {
     const ref = createRef<HTMLDivElement>();
     render(<DemoBanner ref={ref} />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('should not render the consent CTA when consentPending is false', () => {
+    render(<DemoBanner consentPending={false} />);
+    expect(screen.queryByText(/accept analytics/i)).not.toBeInTheDocument();
+  });
+
+  it('should render the consent CTA when consentPending is true', () => {
+    render(<DemoBanner consentPending />);
+    expect(screen.getByText(/accept analytics/i)).toBeInTheDocument();
+    expect(screen.getByText(/decline/i)).toBeInTheDocument();
+  });
+
+  it('should call onConsentChange with "accepted" when Accept is clicked', async () => {
+    const onConsentChange = vi.fn();
+    render(<DemoBanner consentPending onConsentChange={onConsentChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /accept analytics/i }));
+    expect(onConsentChange).toHaveBeenCalledWith('accepted');
+  });
+
+  it('should call onConsentChange with "declined" when Decline is clicked', async () => {
+    const onConsentChange = vi.fn();
+    render(<DemoBanner consentPending onConsentChange={onConsentChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /decline/i }));
+    expect(onConsentChange).toHaveBeenCalledWith('declined');
   });
 });

--- a/apps/web/src/shared/ui/demo-banner.test.tsx
+++ b/apps/web/src/shared/ui/demo-banner.test.tsx
@@ -52,4 +52,22 @@ describe('DemoBanner', () => {
     await userEvent.click(screen.getByRole('button', { name: /decline/i }));
     expect(onConsentChange).toHaveBeenCalledWith('declined');
   });
+
+  it('should not render the revoke affordance when consentAccepted is false', () => {
+    render(<DemoBanner consentAccepted={false} />);
+    expect(screen.queryByText(/analytics on/i)).not.toBeInTheDocument();
+  });
+
+  it('should render the revoke affordance when consentAccepted is true', () => {
+    render(<DemoBanner consentAccepted />);
+    expect(screen.getByText(/analytics on/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /disable/i })).toBeInTheDocument();
+  });
+
+  it('should call onConsentChange with "declined" when Disable is clicked', async () => {
+    const onConsentChange = vi.fn();
+    render(<DemoBanner consentAccepted onConsentChange={onConsentChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /disable/i }));
+    expect(onConsentChange).toHaveBeenCalledWith('declined');
+  });
 });

--- a/apps/web/src/shared/ui/demo-banner.tsx
+++ b/apps/web/src/shared/ui/demo-banner.tsx
@@ -6,8 +6,9 @@
  * persists for the session as a constant visual reminder.
  *
  * Optionally renders an analytics-consent CTA (#1301) when the host passes
- * `consentPending`. This component stays feature-agnostic — it does not read
- * or write consent storage itself (that lives in `features/demo`, which
+ * `consentPending`, or a compact revoke affordance when the host passes
+ * `consentAccepted`. This component stays feature-agnostic — it does not
+ * read or write consent storage itself (that lives in `features/demo`, which
  * `shared/ui` must not import) — the host wires `onConsentChange`.
  */
 import { forwardRef, type ComponentPropsWithoutRef } from 'react';
@@ -16,12 +17,14 @@ import { Button } from './button';
 export interface DemoBannerProps extends ComponentPropsWithoutRef<'div'> {
   /** True when the visitor hasn't yet accepted or declined demo analytics. */
   consentPending?: boolean;
-  /** Called with the visitor's choice when the consent CTA is used. */
+  /** True when the visitor has already accepted demo analytics (shows a revoke affordance). */
+  consentAccepted?: boolean;
+  /** Called with the visitor's choice when the consent CTA or revoke affordance is used. */
   onConsentChange?: (consent: 'accepted' | 'declined') => void;
 }
 
 export const DemoBanner = forwardRef<HTMLDivElement, DemoBannerProps>(function DemoBanner(
-  { className = '', consentPending = false, onConsentChange, ...props },
+  { className = '', consentPending = false, consentAccepted = false, onConsentChange, ...props },
   ref,
 ) {
   const classes = ['demo-banner', className].filter(Boolean).join(' ');
@@ -48,6 +51,18 @@ export const DemoBanner = forwardRef<HTMLDivElement, DemoBannerProps>(function D
             onClick={() => onConsentChange?.('declined')}
           >
             Decline
+          </Button>
+        </span>
+      ) : null}
+      {consentAccepted ? (
+        <span className="demo-banner__consent">
+          <span>Analytics on.</span>
+          <Button
+            className="button--xs"
+            tone="ghost"
+            onClick={() => onConsentChange?.('declined')}
+          >
+            Disable
           </Button>
         </span>
       ) : null}

--- a/apps/web/src/shared/ui/demo-banner.tsx
+++ b/apps/web/src/shared/ui/demo-banner.tsx
@@ -4,20 +4,53 @@
  * Full-width info bar rendered below the topbar in AppShell when the
  * deployment is running in demo mode (OL_DEMO_MODE=true). Not dismissible —
  * persists for the session as a constant visual reminder.
+ *
+ * Optionally renders an analytics-consent CTA (#1301) when the host passes
+ * `consentPending`. This component stays feature-agnostic — it does not read
+ * or write consent storage itself (that lives in `features/demo`, which
+ * `shared/ui` must not import) — the host wires `onConsentChange`.
  */
 import { forwardRef, type ComponentPropsWithoutRef } from 'react';
+import { Button } from './button';
 
-export const DemoBanner = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
-  function DemoBanner({ className = '', ...props }, ref) {
-    const classes = ['demo-banner', className].filter(Boolean).join(' ');
-    return (
-      <div ref={ref} className={classes} role="note" aria-label="Demo mode notice" {...props}>
-        <span className="demo-banner__icon" aria-hidden="true">🔒</span>
-        <span>
-          <strong>Demo mode — read-only.</strong> You can explore all data; write actions are
-          disabled.
+export interface DemoBannerProps extends ComponentPropsWithoutRef<'div'> {
+  /** True when the visitor hasn't yet accepted or declined demo analytics. */
+  consentPending?: boolean;
+  /** Called with the visitor's choice when the consent CTA is used. */
+  onConsentChange?: (consent: 'accepted' | 'declined') => void;
+}
+
+export const DemoBanner = forwardRef<HTMLDivElement, DemoBannerProps>(function DemoBanner(
+  { className = '', consentPending = false, onConsentChange, ...props },
+  ref,
+) {
+  const classes = ['demo-banner', className].filter(Boolean).join(' ');
+  return (
+    <div ref={ref} className={classes} role="note" aria-label="Demo mode notice" {...props}>
+      <span className="demo-banner__icon" aria-hidden="true">🔒</span>
+      <span>
+        <strong>Demo mode — read-only.</strong> You can explore all data; write actions are
+        disabled.
+      </span>
+      {consentPending ? (
+        <span className="demo-banner__consent">
+          <span>This demo uses session recording to improve the product.</span>
+          <Button
+            className="button--xs"
+            tone="secondary"
+            onClick={() => onConsentChange?.('accepted')}
+          >
+            Accept analytics
+          </Button>
+          <Button
+            className="button--xs"
+            tone="ghost"
+            onClick={() => onConsentChange?.('declined')}
+          >
+            Decline
+          </Button>
         </span>
-      </div>
-    );
-  },
-);
+      ) : null}
+    </div>
+  );
+});

--- a/docs/one-command-demo-setup-guide.md
+++ b/docs/one-command-demo-setup-guide.md
@@ -119,7 +119,18 @@ in the demo banner.
 | `OL_POSTHOG_KEY` | PostHog project API key (publishable, write-only ingestion key — never a personal/private key). Unset by default. |
 | `OL_POSTHOG_HOST` | PostHog ingestion host. Defaults to `https://eu.posthog.com` when `OL_POSTHOG_KEY` is set. |
 
-See [ADR-032](./architecture/adrs/032-demo-only-vendor-neutral-analytics-config-seam.md) for the design rationale.
+**Only run session recording against synthetic seed data.** Recording masks
+all form inputs and all rendered text (`maskAllInputs` + a mask-everything
+text selector), but a demo instance pointed at real shop data would still
+expose non-text signal (order IDs in URLs, image content, layout) to
+PostHog cloud. Session recording is intended for the seeded demo dataset
+only — never enable `OL_POSTHOG_KEY` on an instance connected to a live
+PrestaShop/Allegro/Erli store with real customer data.
+
+A visitor who accepted the consent prompt can revoke it at any time from
+the demo banner ("Disable" next to "Analytics on").
+
+See ADR-032 (`docs/architecture/adrs/032-demo-only-vendor-neutral-analytics-config-seam.md`, merging via #1410) for the design rationale.
 
 ---
 

--- a/docs/one-command-demo-setup-guide.md
+++ b/docs/one-command-demo-setup-guide.md
@@ -103,6 +103,24 @@ demo-safe values. Listed here so you know what's in play if you want to override
 > `VITE_API_BASE_URL` is a **build-time** input — changing it requires rebuilding
 > the `web` image (`pnpm demo:up` rebuilds when the arg changes).
 
+### Optional: session recording on a public demo instance
+
+**OpenLinker ships no telemetry by default.** Session recording (PostHog)
+only activates on an instance where the operator has both set
+`OL_DEMO_MODE=true` and explicitly configured `OL_POSTHOG_KEY` — a self-hosted
+install or a local `pnpm demo:up` run never contacts PostHog. When both are
+set, `GET /system/config` surfaces a `demoIntegrations.posthog` block that the
+frontend uses to load `posthog-js` (dynamically, so it never ships in the
+default bundle) — and only after the visitor accepts the consent prompt shown
+in the demo banner.
+
+| Variable | Purpose |
+|---|---|
+| `OL_POSTHOG_KEY` | PostHog project API key (publishable, write-only ingestion key — never a personal/private key). Unset by default. |
+| `OL_POSTHOG_HOST` | PostHog ingestion host. Defaults to `https://eu.posthog.com` when `OL_POSTHOG_KEY` is set. |
+
+See [ADR-032](./architecture/adrs/032-demo-only-vendor-neutral-analytics-config-seam.md) for the design rationale.
+
 ---
 
 ## 3. Boot the stack

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      posthog-js:
+        specifier: ^1.398.3
+        version: 1.398.3
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1851,6 +1854,12 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@posthog/core@1.39.6':
+    resolution: {integrity: sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==}
+
+  '@posthog/types@1.392.1':
+    resolution: {integrity: sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -2642,6 +2651,9 @@ packages:
   '@types/supertest@6.0.2':
     resolution: {integrity: sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
 
@@ -3369,6 +3381,9 @@ packages:
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -3544,6 +3559,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
@@ -3827,6 +3845,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -5073,6 +5094,12 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-js@1.398.3:
+    resolution: {integrity: sha512-sOHenPjkkQBEd3GwoRXr6/kctrFBrcArg+MkNbj0blv1ruDOYxku0B6lntI/TimFcbATKmgGMTINRcb47pjAGw==}
+
+  preact@10.29.6:
+    resolution: {integrity: sha512-/UzLXnc1jrAS2uHi89XsSECqXVHYzV1VUL1L3esxrmPRmDvKFWtmbabE2a4QQ5a3bLgBivubRCEOt4GGmncPBQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5140,6 +5167,9 @@ packages:
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -6105,6 +6135,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -7146,6 +7179,12 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
+  '@posthog/core@1.39.6':
+    dependencies:
+      '@posthog/types': 1.392.1
+
+  '@posthog/types@1.392.1': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -7951,6 +7990,9 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/validator@13.15.10': {}
 
@@ -8797,6 +8839,8 @@ snapshots:
 
   cookiejar@2.1.4: {}
 
+  core-js@3.49.0: {}
+
   core-util-is@1.0.3: {}
 
   cors@2.8.5:
@@ -8972,6 +9016,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv-expand@10.0.0: {}
 
@@ -9316,6 +9364,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.4.8: {}
 
   figures@3.2.0:
     dependencies:
@@ -10756,6 +10806,19 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  posthog-js@1.398.3:
+    dependencies:
+      '@posthog/core': 1.39.6
+      '@posthog/types': 1.392.1
+      core-js: 3.49.0
+      dompurify: 3.4.11
+      fflate: 0.4.8
+      preact: 10.29.6
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
+  preact@10.29.6: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.0:
@@ -10833,6 +10896,8 @@ snapshots:
   qs@6.13.0:
     dependencies:
       side-channel: 1.1.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -11808,6 +11873,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Summary
- Extends `GET /system/config` with an optional, per-provider-namespaced `demoIntegrations.posthog` block, populated by `SystemService` only when `OL_DEMO_MODE=true` and `OL_POSTHOG_KEY` is configured. New `IPosthogConfigService` mirrors the existing `IDemoModeService` composition pattern.
- Frontend `features/demo` hosts a gated loader (`initDemoIntegrations`) that dynamically imports `posthog-js` only once demo mode, the config block, and explicit visitor consent (persisted in `localStorage`, mirroring the theme-preference pattern) are all present — verified via a prod build that the SDK (`posthog-js`, ~210KB chunk) is **not** in any eagerly-loaded `<script>` tag, only reachable via dynamic `import()`.
- `DemoBanner` gains an optional consent CTA (Accept/Decline); `shared/ui` stays feature-agnostic — `AppShell` owns the `features/demo` wiring per dependency-direction rules.
- Documented in `docs/one-command-demo-setup-guide.md` (explicit "ships no telemetry by default" statement) and `apps/api/.env.example`.

**Dependency**: references `ADR-032` (design rationale for the vendor-neutral, per-provider-namespaced config seam), which currently lives only in the not-yet-merged plan PR #1410. That PR should merge before or alongside this one so the ADR link resolves on `main`.

Implements the plan in #1410 (docs/plans/implementation-plan-demo-posthog-session-recording.md).

## Test plan
- [x] `apps/api` unit tests: `posthog-config.service.spec.ts` (new), `system.service.spec.ts` (extended) — all passing.
- [x] `apps/web` unit tests: `demo-analytics-consent.test.ts`, `init-demo-integrations.test.ts` (new), `demo-banner.test.tsx` (extended) — all passing.
- [x] `pnpm --filter @openlinker/api exec tsc` and `pnpm --filter @openlinker/web exec tsc -b` both clean.
- [x] `pnpm --filter @openlinker/api exec eslint` and `pnpm --filter @openlinker/web exec eslint` — 0 errors (pre-existing warnings only, unrelated to this diff).
- [x] Full `apps/api` suite (689 tests) green. Full `apps/web` suite: 1 pre-existing, unrelated failure (`settings-page.test.tsx`, confirmed present on `origin/main` before this change) — everything else (2064 tests) green.
- [x] Verified via `vite build` that `posthog-js` ships in its own dynamically-loaded chunk, absent from `dist/index.html`'s eager `<script>` tags.

Closes #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpsVFTpKZ1HoowEUKzbnWu