### PR TITLE
fix(listings): allow shop-publish master-catalog config and tolerate missing category read

### DIFF
--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -360,8 +360,14 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   const StructuredSection = plugin?.StructuredConfigSection;
   const ExtraSection = plugin?.ExtraConfigSection;
   const PluginCredentialsPanel = plugin?.CredentialsPanel;
+  // Both marketplace offer connections and shop-publish connections resolve
+  // master-catalog product data (name/description/images/price) through
+  // `masterCatalogConnectionId` — `OfferBuilderService` and
+  // `ProductPublishBuilderService` share the same requirement.
   const isMarketplace = connection.enabledCapabilities.includes('OfferManager');
-  const hasStructuredInputs = StructuredSection !== undefined || isMarketplace;
+  const needsMasterCatalog =
+    isMarketplace || connection.enabledCapabilities.includes('ProductPublisher');
+  const hasStructuredInputs = StructuredSection !== undefined || needsMasterCatalog;
 
   // Tracks whether the raw JSON currently parses. When it doesn't, we lock the
   // structured inputs so typing in them can't silently drop custom keys that
@@ -493,7 +499,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   const autoSelectFiredRef = useRef(false);
   useEffect(() => {
     if (autoSelectFiredRef.current) return;
-    if (!isMarketplace) return;
+    if (!needsMasterCatalog) return;
     if (hasStoredMaster) return;
     if (!localAutoSelectId) return;
     if (connectionsQuery.isLoading) return;
@@ -506,7 +512,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
     localAutoSelectId,
     connectionsQuery.isLoading,
     connectionsQuery.error,
-    isMarketplace,
+    needsMasterCatalog,
     hasStoredMaster,
   ]);
 
@@ -607,7 +613,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
         />
       ) : null}
 
-      {isMarketplace ? (
+      {needsMasterCatalog ? (
         <MarketplaceCatalogPicker
           value={masterCatalogValue}
           candidates={candidates}

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -93,7 +93,12 @@ function ProductCatalogLinkBanner({
   isLoading,
   hasError,
 }: ProductCatalogLinkBannerProps): ReactElement | null {
-  if (!connection.enabledCapabilities.includes('OfferManager')) return null;
+  if (
+    !connection.enabledCapabilities.includes('OfferManager') &&
+    !connection.enabledCapabilities.includes('ProductPublisher')
+  ) {
+    return null;
+  }
 
   const rawMaster = connection.config.masterCatalogConnectionId;
   const explicitMaster = typeof rawMaster === 'string' ? rawMaster : null;

--- a/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
@@ -112,6 +112,17 @@ describe('ProductPublishBuilderService', () => {
     expect(command.parameters).toBeUndefined();
   });
 
+  it('should publish uncategorised when the master cannot report categories', async () => {
+    productMaster.getProductCategories.mockRejectedValue(
+      new Error('Get product categories is not implemented in MVP.')
+    );
+
+    const command = await service.buildPublishProductCommand(baseInput);
+
+    expect(command.destinationCategoryIds).toEqual([]);
+    expect(shopAdapter.provisionCategory).not.toHaveBeenCalled();
+  });
+
   it('should throw when the variant is not found', async () => {
     products.getVariant.mockResolvedValue(null);
     await expect(service.buildPublishProductCommand(baseInput)).rejects.toBeInstanceOf(

--- a/libs/core/src/listings/application/services/product-publish-builder.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-builder.service.ts
@@ -144,7 +144,18 @@ export class ProductPublishBuilderService implements IProductPublishBuilderServi
       return [];
     }
 
-    const categories = await productMaster.getProductCategories(productId);
+    let categories: Category[];
+    try {
+      categories = await productMaster.getProductCategories(productId);
+    } catch (error) {
+      // Best-effort per the class docstring: a master that can't report
+      // categories (e.g. PrestaShop's ProductMaster, not yet implemented)
+      // must not block the publish — it just ships uncategorised.
+      this.logger.warn(
+        `Could not read master categories for product ${productId}; publishing uncategorised: ${(error as Error).message}`
+      );
+      return [];
+    }
     const path = this.toProvisionPath(categories);
     if (path.length === 0) {
       return [];


### PR DESCRIPTION
## Summary
- Widen the `EditConnectionForm`/`connection-detail-page` master-catalog gate from `OfferManager`-only to also cover `ProductPublisher` connections, so a shop-publish connection (e.g. WooCommerce) can have its `masterCatalogConnectionId` set through the UI instead of only via raw JSON.
- Make `ProductPublishBuilderService.provisionCategory` tolerate a master `ProductMasterPort` that doesn't implement `getProductCategories` (e.g. PrestaShop) by falling back to an uncategorised publish instead of hard-failing the `shop.product.publish` job forever — matching the method's own documented best-effort contract.

Closes #1413

## Test plan
- [x] `pnpm --filter @openlinker/core exec tsc --noEmit` — clean
- [x] `pnpm --filter @openlinker/web exec tsc --noEmit` — clean
- [x] `pnpm eslint` on the 4 changed files — clean
- [x] `ProductPublishBuilderService` spec — 7/7 pass, including new case "should publish uncategorised when the master cannot report categories"
- [x] `EditConnectionForm.test.tsx` + `connection-detail-page.test.tsx` — 41/41 pass
- [x] Verified live end-to-end against a local demo stack (WooCommerce destination, PrestaShop master): publish now reaches "Publishing…" instead of failing on `MASTER_CATALOG_NOT_CONFIGURED`, and the worker no longer retries `shop.product.publish` to exhaustion on the category-read error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)