### PR TITLE
docs(demo): clarify Erli requires a public Storefront URL, unlike Allegro

### DIFF
--- a/docs/one-command-demo-setup-guide.md
+++ b/docs/one-command-demo-setup-guide.md
@@ -222,6 +222,26 @@ row + `PS_CANONICAL_REDIRECT=0`, added by a post-install step), so the
 > display base). For the demo, prefer a working image sync over rendered
 > thumbnails.
 
+> **Allegro vs. Erli — the Storefront URL requirement differs.** The guidance
+> above (`http://prestashop`) only holds for **Allegro**: OpenLinker downloads
+> the product image bytes server-side and re-uploads them to Allegro's CDN, so
+> the URL only needs to be **container-reachable**, not public.
+>
+> **Erli does not re-upload images** — its servers fetch the product image URL
+> directly, so for an Erli connection the Storefront URL **must be a real,
+> publicly-reachable HTTPS URL**. `http://prestashop` will silently fail image
+> sync to Erli. For local testing, front PrestaShop with a quick tunnel (e.g.
+> `cloudflared tunnel --url http://localhost:8080`); for a persistent
+> deployment, use the reverse-proxy/public-domain overlay
+> (`docker-compose.proxy.yml`) described in
+> [`docs/public-domain-demo-deployment-guide.md`](./public-domain-demo-deployment-guide.md).
+>
+> `storefrontBaseUrl` is a single, connection-level setting shared by every
+> destination synced from that PrestaShop master. If you're running **both**
+> Allegro and Erli off the same connection, set it to the public HTTPS URL —
+> a public URL also satisfies Allegro's (looser) container-reachability
+> requirement, but a container-internal URL does not satisfy Erli's.
+
 After connecting, OpenLinker syncs the seeded catalog (6 products + variants). See
 them under **Products**.
 


### PR DESCRIPTION
## Summary
- Section 5.2 of `docs/one-command-demo-setup-guide.md` tells operators to set the PrestaShop connection's Storefront URL to `http://prestashop` (container-internal), reasoning that OpenLinker downloads and re-uploads image bytes server-side. That is true for **Allegro** but not for **Erli** — Erli's servers fetch the product image URL directly, so it needs a real, publicly-reachable HTTPS URL. Following the existing guidance verbatim for an Erli-only demo silently breaks image sync.
- Added a callout right after the connection table distinguishing the two cases, with a pointer to a quick tunnel (`cloudflared tunnel --url ...`) or the reverse-proxy/public-domain overlay (`docker-compose.proxy.yml` + `docs/public-domain-demo-deployment-guide.md`) for Erli, and a note on the shared `storefrontBaseUrl` field when both Allegro and Erli point at the same PrestaShop connection.

## Test plan
- [x] Docs-only change; reviewed rendered Markdown for correctness and tone consistency with the rest of the guide.
- [ ] `pnpm lint` was attempted but this worktree has no `node_modules` installed (pre-existing environment issue unrelated to this change — `eslint: not found` on every package). No code was touched, so `pnpm type-check` / `pnpm test` were skipped per the docs-only workflow.

Closes #1417