### PR TITLE
fix(demo): route WooCommerce through the proxy overlay with a scoped X-Forwarded-Proto trust fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,16 @@ OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=
 # Example: shop.example.com
 # PRESTASHOP_DOMAIN=
 
+# Public hostname for WooCommerce. Required for a WooCommerce Connection's
+# siteUrl to authenticate at all (#1416): WooCommerce's REST API rejects
+# Basic-Auth/query-string credentials over plain HTTP (PHP's is_ssl() gate),
+# and OpenLinker's adapter doesn't implement the OAuth 1.0a alternative. This
+# overlay's `woocommerce` service override teaches WordPress to trust
+# Caddy's X-Forwarded-Proto header, so a Connection's siteUrl set to
+# https://<WOOCOMMERCE_DOMAIN> authenticates correctly even though Caddy
+# forwards plain HTTP internally. Example: wc.example.com
+# WOOCOMMERCE_DOMAIN=
+
 # Contact address Let's Encrypt uses for certificate-expiry notices.
 # TLS_EMAIL=
 

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -7,22 +7,25 @@
 #
 # Adds a single Caddy service that terminates TLS (automatic Let's Encrypt
 # certificates, zero manual ACME config) and routes by hostname to the
-# existing web/api/prestashop services. Caddy reaches them over the internal
-# Compose network by SERVICE NAME (web:80, api:3000, prestashop:80) — it does
-# NOT depend on those services publishing host ports, so this overlay works
-# whether or not the loopback-binding hardening from #1400/#1402 has landed,
-# and avoids a redundant hop back out through the host network stack.
+# existing web/api/prestashop/woocommerce services. Caddy reaches them over
+# the internal Compose network by SERVICE NAME (web:80, api:3000,
+# prestashop:80, woocommerce:8080) — it does NOT depend on those services
+# publishing host ports, so this overlay works whether or not the
+# loopback-binding hardening from #1400/#1402 has landed, and avoids a
+# redundant hop back out through the host network stack.
 #
 # This overlay REQUIRES docker-compose.demo.yml (the `web` service only
 # exists there — the bare dev stack has no admin UI to serve).
 #
 # Required .env vars (see .env.example): WEB_DOMAIN, API_DOMAIN,
-# PRESTASHOP_DOMAIN, TLS_EMAIL. See
+# PRESTASHOP_DOMAIN, WOOCOMMERCE_DOMAIN, TLS_EMAIL. See
 # docs/public-domain-demo-deployment-guide.md for the full walkthrough,
 # including local verification without real DNS (CADDYFILE_PATH override).
 #
 # Omitting `-f docker-compose.proxy.yml` reproduces today's plain-HTTP
-# localhost behavior unchanged — this overlay touches no other service.
+# localhost behavior unchanged — this overlay touches no other service
+# EXCEPT the scoped `woocommerce` proxy-trust override below, which only
+# takes effect when this file is included.
 
 services:
   caddy:
@@ -32,6 +35,7 @@ services:
       WEB_DOMAIN: '${WEB_DOMAIN:?set WEB_DOMAIN in .env (see .env.example) - the public hostname for the admin UI}'
       API_DOMAIN: '${API_DOMAIN:?set API_DOMAIN in .env (see .env.example) - the public hostname for the API}'
       PRESTASHOP_DOMAIN: '${PRESTASHOP_DOMAIN:?set PRESTASHOP_DOMAIN in .env (see .env.example) - the public hostname for PrestaShop}'
+      WOOCOMMERCE_DOMAIN: '${WOOCOMMERCE_DOMAIN:?set WOOCOMMERCE_DOMAIN in .env (see .env.example) - the public hostname for WooCommerce}'
       TLS_EMAIL: '${TLS_EMAIL:?set TLS_EMAIL in .env (see .env.example) - required by Lets Encrypt for expiry notices}'
     ports:
       # Unbound (not loopback) by design — this is the public TLS-terminating
@@ -48,6 +52,55 @@ services:
       - web
       - api
       - prestashop
+      - woocommerce
+
+  # Scoped WordPress proxy-trust override (#1416). WooCommerce's REST API
+  # (WC_REST_Authentication::authenticate()) only accepts Basic-Auth /
+  # query-string consumer key+secret when PHP's is_ssl() is true; over plain
+  # HTTP it demands OAuth 1.0a instead, which OpenLinker's adapter doesn't
+  # implement. Caddy terminates real TLS at the edge above but forwards
+  # plain HTTP internally to woocommerce:8080, so WordPress's own is_ssl()
+  # would still see plain HTTP unless told to trust Caddy's
+  # X-Forwarded-Proto header.
+  #
+  # This override is defined ONLY in this optional overlay file — the base
+  # (docker-compose.yml) and demo (docker-compose.demo.yml) compose files
+  # never set WORDPRESS_EXTRA_WP_CONFIG_CONTENT, so a plain `pnpm demo:up`
+  # or bare dev-stack boot (no Caddy in front) never trusts this header from
+  # anyone. It is intentionally NOT a blanket "always HTTPS" bypass (unlike
+  # an earlier, rejected mu-plugin approach that unconditionally set
+  # $_SERVER['HTTPS']='on'): it only flips HTTPS on when the specific
+  # request already carries X-Forwarded-Proto: https, which for any request
+  # arriving from the public internet can only originate from Caddy's own
+  # genuine TLS termination — ports 80/443 are the only unbound (public)
+  # entry point this overlay adds.
+  #
+  # KNOWN RESIDUAL RISK (verified, not fixed here — out of scope per #1416's
+  # safety note): the woocommerce service's own port 8082 host-port mapping
+  # is loopback-bound by default (#1400/#1402) but still reachable by any
+  # process on the SAME host, which can set X-Forwarded-Proto itself and
+  # bypass the HTTPS gate for that direct request. This is the same trust
+  # boundary already accepted for every other loopback-bound service in
+  # this demo stack (anyone who can run code on the host can already reach
+  # Postgres/Redis/MySQL directly) — it does not extend that boundary to
+  # the public internet, which is the actual threat the is_ssl() gate
+  # exists to close.
+  woocommerce:
+    environment:
+      # $$ escapes Compose's own ${VAR} interpolation — the literal string
+      # written into wp-config.php must keep a single $.
+      #
+      # No `&&` here (nested ifs instead): bitnami's wordpress_conf_append
+      # inserts this value as a sed REPLACEMENT string, where `&` means
+      # "the whole matched line" — a literal `&&` in the PHP would silently
+      # corrupt wp-config.php (verified: it crashes `wp core install` with
+      # no error output) rather than write the intended condition.
+      WORDPRESS_EXTRA_WP_CONFIG_CONTENT: |
+        if (!empty($$_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+            if ($$_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+                $$_SERVER['HTTPS'] = 'on';
+            }
+        }
 
 volumes:
   caddy_data:

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -24,3 +24,7 @@
 {$PRESTASHOP_DOMAIN} {
 	reverse_proxy prestashop:80
 }
+
+{$WOOCOMMERCE_DOMAIN} {
+	reverse_proxy woocommerce:8080
+}

--- a/docker/caddy/Caddyfile.local
+++ b/docker/caddy/Caddyfile.local
@@ -28,3 +28,8 @@
 	tls internal
 	reverse_proxy prestashop:80
 }
+
+{$WOOCOMMERCE_DOMAIN} {
+	tls internal
+	reverse_proxy woocommerce:8080
+}

--- a/docs/public-domain-demo-deployment-guide.md
+++ b/docs/public-domain-demo-deployment-guide.md
@@ -51,9 +51,15 @@ hostnames at the server's public IP:
 | `app.example.com` | server IP | OpenLinker admin UI (`web`) |
 | `api.example.com` | server IP | OpenLinker API (`api`) |
 | `shop.example.com` | server IP | PrestaShop |
+| `wc.example.com` | server IP | WooCommerce |
 
 `worker` needs **no DNS record** — it's a background process with no
-`EXPOSE`'d port and is never proxied.
+`EXPOSE`'d port and is never proxied. `WOOCOMMERCE_DOMAIN` is required by
+the overlay the same way the other three domains are (fails closed if
+unset, see § 5) because `docker-compose.yml` always starts the
+`woocommerce` service — point it at a real record even if you don't
+currently use a WooCommerce Connection; Caddy only requests a certificate
+for it lazily, on first real traffic.
 
 Wait for DNS propagation (`dig +short app.example.com` should return the
 server IP) before booting the proxy overlay — Caddy's automatic HTTPS will
@@ -72,6 +78,7 @@ the most common point of confusion:
 | `WEB_DOMAIN` | `OL_CORS_ORIGIN` = `https://<WEB_DOMAIN>` | The API's CORS allow-list must match the browser origin the UI is served from, or login fails with a CORS `NetworkError`. |
 | `API_DOMAIN` | `VITE_API_BASE_URL` = `https://<API_DOMAIN>` | Baked into the UI bundle at **build time** — changing it requires `--build` on the `web` image, not just a restart. |
 | `PRESTASHOP_DOMAIN` | `PS_DOMAIN` = `<PRESTASHOP_DOMAIN>` | The domain PrestaShop bakes into its own generated links/redirects. |
+| `WOOCOMMERCE_DOMAIN` | (nothing else — see the callout below) | Unlike the other three, this is not just cosmetic: it's the **only** `siteUrl` a WooCommerce Connection can actually authenticate against (#1416). |
 
 Worked example, given the DNS records above:
 
@@ -80,6 +87,7 @@ Worked example, given the DNS records above:
 WEB_DOMAIN=app.example.com
 API_DOMAIN=api.example.com
 PRESTASHOP_DOMAIN=shop.example.com
+WOOCOMMERCE_DOMAIN=wc.example.com
 TLS_EMAIL=ops@example.com
 
 # Must line up with the domains above (scheme included)
@@ -95,6 +103,21 @@ PS_DOMAIN=shop.example.com
 > **internal**, container-to-container address — never the public
 > `PRESTASHOP_DOMAIN`. The API/Worker containers never resolve the public
 > domain; only the operator's browser does.
+
+> **WooCommerce is the opposite: the Connection's `siteUrl` MUST be the
+> public `https://<WOOCOMMERCE_DOMAIN>`, never `http://woocommerce:8080`.**
+> WooCommerce's REST API only accepts Basic-Auth/query-string credentials
+> when PHP's `is_ssl()` is true, and OpenLinker's adapter doesn't implement
+> the OAuth 1.0a alternative required over plain HTTP. Pointing the
+> Connection at the internal address (as PrestaShop's guidance above would
+> suggest) always fails with `401 woocommerce_rest_cannot_view`, regardless
+> of credentials. `https://<WOOCOMMERCE_DOMAIN>` works because Caddy
+> genuinely terminates TLS there **and** the `woocommerce` service override
+> in `docker-compose.proxy.yml` teaches WordPress to trust Caddy's
+> `X-Forwarded-Proto` header for the hop back to plain-HTTP
+> `woocommerce:8080` — see the [WooCommerce setup
+> guide](../libs/integrations/woocommerce/docs/setup-guide.md) for the full
+> explanation and the local-dev-without-a-domain alternative (a tunnel).
 
 The full variable reference (base demo vars + this guide's additions) is in
 [`.env.example`](../.env.example) — every override lives there with an
@@ -128,16 +151,21 @@ anything twice — one `.env` line per variable is enough.
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.demo.yml -f docker-compose.proxy.yml \
-  up -d --build postgres redis mysql prestashop migrate api worker web caddy
+  up -d --build postgres redis mysql woocommerce-mysql prestashop woocommerce migrate api worker web caddy
 ```
 
 The proxy overlay (`docker-compose.proxy.yml`) adds one service, `caddy`,
 which:
-- reaches `web` / `api` / `prestashop` **over the internal Compose network**
-  by service name and container port — it does not depend on those
-  services' host-published ports at all;
-- terminates TLS for the three domains configured in step 3;
+- reaches `web` / `api` / `prestashop` / `woocommerce` **over the internal
+  Compose network** by service name and container port — it does not depend
+  on those services' host-published ports at all;
+- terminates TLS for the four domains configured in step 3;
 - publishes host ports `80` and `443` (unbound — this is the public edge).
+
+It also adds a scoped override to the `woocommerce` service itself
+(`WORDPRESS_EXTRA_WP_CONFIG_CONTENT`) so WordPress trusts Caddy's
+`X-Forwarded-Proto: https` header — see the callout in step 3 for why this
+is required for a WooCommerce Connection to authenticate at all.
 
 Confirm it's up:
 
@@ -156,13 +184,15 @@ demo exactly as documented in the [base setup guide](./one-command-demo-setup-gu
 To verify the proxy overlay boots and routes correctly **before** you have
 real DNS/domains, or in a local sandbox:
 
-1. Pick three test hostnames (e.g. `app.local.test`, `api.local.test`,
-   `shop.local.test`) and add them to `/etc/hosts` pointing at `127.0.0.1`.
+1. Pick four test hostnames (e.g. `app.local.test`, `api.local.test`,
+   `shop.local.test`, `wc.local.test`) and add them to `/etc/hosts` pointing
+   at `127.0.0.1`.
 2. Set `.env`:
    ```dotenv
    WEB_DOMAIN=app.local.test
    API_DOMAIN=api.local.test
    PRESTASHOP_DOMAIN=shop.local.test
+   WOOCOMMERCE_DOMAIN=wc.local.test
    TLS_EMAIL=test@example.com
    CADDYFILE_PATH=./docker/caddy/Caddyfile.local
    ```
@@ -202,6 +232,12 @@ Run through this after every deployment (initial or credential rotation):
   ```
 - [ ] **PrestaShop reachable at its own domain**: `https://<PRESTASHOP_DOMAIN>`
   loads the storefront.
+- [ ] **WooCommerce Connection authenticates**: create/edit a WooCommerce
+  Connection with `siteUrl: https://<WOOCOMMERCE_DOMAIN>` and run
+  **Test Connection** — expects `{ success: true, latencyMs: ... }`, not a
+  `401 woocommerce_rest_cannot_view`. This is the concrete verification that
+  the `X-Forwarded-Proto` trust override actually round-trips end to end,
+  not just that `https://<WOOCOMMERCE_DOMAIN>/wp-admin` loads in a browser.
 - [ ] **Database ports unreachable from outside the host** — run from a
   *different* machine (not the server itself):
   ```bash
@@ -230,8 +266,10 @@ Run through this after every deployment (initial or credential rotation):
 | Browser shows a certificate warning even with the production Caddyfile | `CADDYFILE_PATH` is still pointed at `Caddyfile.local` | Unset `CADDYFILE_PATH` (or point it back at `./docker/caddy/Caddyfile`) and restart the `caddy` service |
 | Login fails with a CORS `NetworkError` after switching to a public domain | `OL_CORS_ORIGIN` doesn't match `https://<WEB_DOMAIN>` exactly (scheme/host) | Fix `OL_CORS_ORIGIN` in `.env`, restart `api` |
 | UI calls the wrong API origin / mixed-content errors | `VITE_API_BASE_URL` wasn't set before the `web` image was built | Set it in `.env`, rebuild: `docker compose ... up -d --build web` |
-| `docker compose up` with the proxy overlay fails immediately citing a missing var | One of `WEB_DOMAIN`/`API_DOMAIN`/`PRESTASHOP_DOMAIN`/`TLS_EMAIL` is unset | Set all four in `.env` — the overlay fails closed by design (`${VAR:?...}`) rather than booting half-configured |
-| `caddy` service can't reach `web`/`api`/`prestashop` | Booted without `-f docker-compose.demo.yml` (no `web` service exists) | Always use the 3-file invocation from § 5 |
+| WooCommerce Connection still returns `401 woocommerce_rest_cannot_view` through `https://<WOOCOMMERCE_DOMAIN>` | The `woocommerce` service booted before `docker-compose.proxy.yml` was in the `-f` list (env only applies at container creation), or WordPress's config cache still has the old `wp-config.php` | Recreate the container with all three `-f` flags: `docker compose -f docker-compose.yml -f docker-compose.demo.yml -f docker-compose.proxy.yml up -d --force-recreate woocommerce` |
+| Connection Test fails with an HTTPS/protocol validation error instead of 401 | `siteUrl` was set to `http://woocommerce:8080` or `http://<WOOCOMMERCE_DOMAIN>` | This is the connection-config validator working as intended (#1416) — WooCommerce `siteUrl` must be `https://`; use `https://<WOOCOMMERCE_DOMAIN>` |
+| `docker compose up` with the proxy overlay fails immediately citing a missing var | One of `WEB_DOMAIN`/`API_DOMAIN`/`PRESTASHOP_DOMAIN`/`WOOCOMMERCE_DOMAIN`/`TLS_EMAIL` is unset | Set all five in `.env` — the overlay fails closed by design (`${VAR:?...}`) rather than booting half-configured |
+| `caddy` service can't reach `web`/`api`/`prestashop`/`woocommerce` | Booted without `-f docker-compose.demo.yml` (no `web` service exists), or without `woocommerce` in the service list | Always use the 3-file invocation from § 5, including `woocommerce-mysql woocommerce` in the service list |
 
 For everything else (PrestaShop admin folder, seller-defaults, offer
 creation, etc.), see the [base demo setup guide's troubleshooting

--- a/libs/integrations/woocommerce/docs/setup-guide.md
+++ b/libs/integrations/woocommerce/docs/setup-guide.md
@@ -7,9 +7,74 @@ with catalog sync, inventory propagation, order ingest, and offer creation.
 
 - WooCommerce 8.x or later
 - **HPOS enabled** — WooCommerce → Settings → Advanced → Features → Order Storage: "High-Performance Order Storage"
-- WooCommerce REST API v3 accessible over **HTTPS** (HTTP is blocked — Basic Auth credentials must not travel in cleartext)
+- WooCommerce REST API v3 accessible over **HTTPS**, terminated by a genuine TLS endpoint the
+  Connection's `siteUrl` actually resolves to (see "The `is_ssl()` gotcha" below — this is
+  stricter than it looks)
 - Consumer key + secret with **read_write** scope (see Step 1)
 - OpenLinker API server running
+
+## The `is_ssl()` gotcha (read this before choosing a `siteUrl`)
+
+WooCommerce's REST API (`WC_REST_Authentication::authenticate()`) only accepts Basic-Auth or
+query-string `consumer_key`/`consumer_secret` credentials when PHP's `is_ssl()` returns `true`.
+Over plain HTTP it demands OAuth 1.0a request signing instead — which OpenLinker's WooCommerce
+adapter does not implement (#1416). Practically, this means:
+
+- **A `siteUrl` that is plain HTTP always fails.** OpenLinker's own connection-config validator
+  already rejects `http://` outright (`@IsUrl({ protocols: ['https'] })` on
+  `WooCommerceConnectionConfigDto.siteUrl`) — you'll get a clear validation error at save-time,
+  not a mysterious `401`.
+- **A `siteUrl` that is HTTPS at the edge but plain HTTP behind a reverse proxy still fails**,
+  unless the proxy's `X-Forwarded-Proto: https` header is explicitly trusted by WordPress. This
+  is the scenario that bites the internal Docker addresses below (`http://woocommerce:8080`,
+  `http://localhost:8082`) — they have no TLS anywhere in the path, so there's no fixing them;
+  you need a `siteUrl` that terminates real (or locally-trusted) TLS. See the three options below.
+
+Do **not** work around this by forcing WordPress to always believe `is_ssl()` is true
+(e.g. an mu-plugin unconditionally setting `$_SERVER['HTTPS'] = 'on'`) — that makes WordPress
+trust the header from *any* request, including ones that never touched TLS, which defeats the
+whole point of the HTTPS gate (Basic Auth credentials would then happily travel over the
+unencrypted hop). The only safe pattern is trusting `X-Forwarded-Proto` when it is set by a
+proxy you actually control and that genuinely terminates TLS in front of WordPress — see Option 3.
+
+### Option 1 — tunnel (fastest, any local dev)
+
+Point a tunnel at whichever WooCommerce port you're running (`8082` for the dev stack, or the
+demo's WooCommerce container's published port), then use the tunnel's `https://` URL as `siteUrl`:
+
+```bash
+cloudflared tunnel --url http://localhost:8082
+# → prints something like https://random-words-1234.trycloudflare.com
+```
+
+No account needed for `cloudflared`'s quick tunnels; the URL rotates on every run, so re-run
+`Test Connection` after restarting the tunnel.
+
+### Option 2 — public-domain deployment via the proxy overlay (Docker demo)
+
+If you're running the [Docker demo](../../../../docs/one-command-demo-setup-guide.md) on a real
+server, the [public-domain deployment guide](../../../../docs/public-domain-demo-deployment-guide.md)'s
+reverse-proxy/TLS overlay (`docker-compose.proxy.yml`) routes `WOOCOMMERCE_DOMAIN` to the
+`woocommerce` service and includes a scoped `WORDPRESS_EXTRA_WP_CONFIG_CONTENT` override that
+makes WordPress trust `X-Forwarded-Proto` **from Caddy specifically** (Caddy is the only thing
+that can reach `woocommerce:8080` and set that header while also being the one place TLS is
+genuinely terminated). This override only exists when `docker-compose.proxy.yml` is included —
+a plain `pnpm demo:up` never enables it. Use `siteUrl: https://<WOOCOMMERCE_DOMAIN>`.
+
+### Option 3 — self-signed cert on your own reverse proxy (advanced, no public domain)
+
+If you're not using the demo's Caddy overlay but do have your own TLS-terminating reverse proxy
+in front of WooCommerce (nginx, Caddy standalone, Traefik, …), apply the same
+`X-Forwarded-Proto` trust pattern via `wp-config.php`:
+
+```php
+if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+    $_SERVER['HTTPS'] = 'on';
+}
+```
+
+Only add this if you control the network path such that nothing but your own proxy can reach
+WordPress directly — otherwise a client could set the header itself and spoof `is_ssl()`.
 
 ## 1. Generate WC REST API credentials
 
@@ -22,13 +87,15 @@ with catalog sync, inventory propagation, order ingest, and offer creation.
 7. Copy the **Consumer Key** (`ck_...`) and **Consumer Secret** (`cs_...`) — shown only once
 
 > **HTTPS required.** OpenLinker enforces HTTPS to protect Basic Auth credentials in transit.
-> For local development you can use a self-signed certificate or the local dev stack (see below).
+> Pick one of the three options above for local/demo development.
 
 ## 2. Create a WooCommerce connection in OpenLinker
 
 1. Open OL Admin → Integrations → Connections → **New Connection**
 2. Platform: **WooCommerce**
-3. Site URL: `https://your-shop.com` — **HTTPS is required** (the config validator rejects `http://`, even for local dev; use a self-signed cert on your local dev stack, e.g. `https://localhost:8443`)
+3. Site URL: `https://your-shop.com` — **HTTPS is required** (the config validator rejects
+   `http://` outright, even for local dev — see "The `is_ssl()` gotcha" above for a working
+   `siteUrl` in local/demo contexts)
 4. Consumer Key / Consumer Secret: paste from Step 1
 5. Click **Test Connection** — expects `{ success: true, latencyMs: ... }`
 6. Click **Save**
@@ -81,6 +148,14 @@ pnpm dev:stack:seed-woocommerce
 | WC REST API | http://localhost:8082/wp-json/wc/v3/ |
 | Consumer key | generated — run `pnpm dev:stack:wc-credentials` |
 
+> **`http://localhost:8082` cannot be used as the Connection's `siteUrl` directly** — it's plain
+> HTTP, and the config validator rejects it. The dev stack itself is unaffected (the seed script
+> uses `wp eval` to call WC's PHP API directly, bypassing HTTP auth entirely — see
+> `docker/woocommerce/01-seed-wc-data.sh`), but a real OpenLinker↔WooCommerce Connection needs
+> Option 1 above: `cloudflared tunnel --url http://localhost:8082`, then use the printed
+> `https://…trycloudflare.com` URL as `siteUrl` with the credentials from
+> `pnpm dev:stack:wc-credentials`.
+
 **Seed data** (available after `pnpm dev:stack:up`):
 
 | SKU | Type | Stock |
@@ -94,7 +169,8 @@ pnpm dev:stack:seed-woocommerce
 | Symptom | Cause | Fix |
 |---|---|---|
 | Connection test fails with "SSRF blocked" | Site URL resolves to RFC-1918 address (10.x, 192.168.x, 172.16.x) | Use a publicly routable URL or loopback (127.0.0.1) for local dev |
-| Connection test fails with "HTTPS required" | HTTP URL provided | Change site URL to `https://` |
+| Connection test fails with "HTTPS required" | HTTP URL provided | Change site URL to `https://` — see "The `is_ssl()` gotcha" above for a working option |
+| `401 woocommerce_rest_cannot_view` even with valid consumer key/secret | `siteUrl` is HTTPS at the edge but the request reaches WordPress over plain HTTP behind a reverse proxy that isn't trusted (`is_ssl()` still false) | Use the proxy overlay's `WOOCOMMERCE_DOMAIN` (Option 2) which already wires the `X-Forwarded-Proto` trust, or apply the `wp-config.php` snippet from Option 3 for a custom proxy |
 | Orders not appearing in OL | `OL_WOOCOMMERCE_POLL_SCHEDULER_ENABLED=false` | Set to `true` in worker env and restart |
 | Stock not propagating to Allegro | `InventoryMaster` capability not enabled on the connection | Enable in OL Admin → connection settings |
 | WC product sync returns empty | HPOS not enabled | Enable HPOS in WooCommerce → Settings → Advanced → Features |


### PR DESCRIPTION
## Summary

WooCommerce's REST API (`WC_REST_Authentication::authenticate()`) only accepts Basic-Auth or query-string `consumer_key`/`consumer_secret` credentials when PHP's `is_ssl()` returns `true`; over plain HTTP it requires OAuth 1.0a signing instead, which OpenLinker's WooCommerce adapter does not implement. This addresses two of #1416's three deployment contexts:

1. **Docker demo / public-domain deployment (fixed)**: adds `WOOCOMMERCE_DOMAIN` routing to the reverse-proxy/TLS overlay (`docker-compose.proxy.yml`, `docker/caddy/Caddyfile`, `docker/caddy/Caddyfile.local`), plus a `woocommerce` service override — scoped **only** to this optional overlay file — that sets `WORDPRESS_EXTRA_WP_CONFIG_CONTENT` to trust Caddy's `X-Forwarded-Proto: https` header. A WooCommerce Connection with `siteUrl: https://<WOOCOMMERCE_DOMAIN>` now authenticates end-to-end.
2. **Local non-Docker dev / bare Docker internal address (documented, not fixed)**: `http://localhost:8082` / `http://woocommerce:8080` have no TLS anywhere in the path and cannot be made to work without a proxy in front. Documented the tunnel workaround (`cloudflared tunnel --url http://localhost:8082`) in the WooCommerce setup guide, per the issue's explicitly-allowed fallback.
3. **Clear error instead of a generic 401 (already true on `main`, unrelated to this PR)**: `WooCommerceConnectionConfigDto.siteUrl` already has `@IsUrl({ protocols: ['https'] })`, so a plain-HTTP `siteUrl` is rejected at save-time with a validation error, not a mysterious `401`. Confirmed no change was needed here; documented it explicitly instead.

### Why this is safe (the security constraint called out in the issue)

An earlier approach that unconditionally set `$_SERVER['HTTPS'] = 'on'` via an mu-plugin was correctly rejected as a blanket SSL-verification bypass. This PR does **not** do that:

- The trust override lives **only** in `docker-compose.proxy.yml` — the base and demo compose files never set `WORDPRESS_EXTRA_WP_CONFIG_CONTENT`, so a plain `pnpm demo:up` or bare dev-stack boot never trusts the header from anyone.
- It only flips `is_ssl()` on when the specific request already carries `X-Forwarded-Proto: https`, which — for any request arriving from the public internet — can only originate from Caddy's own genuine TLS termination (ports 80/443 are the only unbound entry point the overlay adds).
- **Documented, bounded residual risk** (verified, not silently glossed over): the `woocommerce` service's own host-port mapping (`8082` by default) is loopback-bound per #1400/#1402, but any process on the *same host* can still reach it directly and spoof the header. This is the same trust boundary already accepted for every other loopback-bound service in this demo stack — it doesn't extend to the public internet, which is the actual threat the `is_ssl()` gate exists to close.

### A real bug found + fixed during verification

Bitnami's `wordpress_conf_append` (which reads `WORDPRESS_EXTRA_WP_CONFIG_CONTENT`) inserts the value as a `sed` **replacement string** — a literal `&&` in my first draft of the PHP snippet was silently corrupting `wp-config.php` (sed interprets `&` as "the whole matched line"), crashing `wp core install` with no visible error. Fixed by rewriting the condition as nested `if`s instead of `&&`. Documented this gotcha in a code comment so nobody re-introduces it.

## What was verified live (Docker available in this environment)

Booted an isolated stack (`-p wc1416test`, unique host ports) with `docker-compose.yml` + `docker-compose.demo.yml` + `docker-compose.proxy.yml` (`CADDYFILE_PATH=Caddyfile.local` for local TLS since no real DNS was available):

- WordPress/WooCommerce installs cleanly with the override in place (confirmed the `&&`/sed bug above by first reproducing the silent crash, then fixing it).
- `wp-config.php` contains the expected trust snippet.
- **Through Caddy** (`https://wc.local.test`, genuine local TLS): WC REST API with query-string consumer key/secret → `200`, real JSON response.
- **Direct to the container over plain HTTP** (bypassing Caddy): same credentials → `401`, proving the fix isn't a blanket bypass.
- **Direct to the container with a spoofed `X-Forwarded-Proto: https` header** (no real TLS): → `200`, confirming and documenting the residual same-host risk described above.

Not run: `pnpm test:integration` (not needed — no TypeScript changed). `pnpm lint`/`pnpm type-check` are not applicable (no TS/JS touched); ran the relevant `check-repo-urls.mjs` invariant script directly (passes) since it's the only checker in `pnpm lint` that could plausibly flag new doc links.

## Files changed

- `docker-compose.proxy.yml` — `WOOCOMMERCE_DOMAIN` required env var + `woocommerce` service override
- `docker/caddy/Caddyfile`, `docker/caddy/Caddyfile.local` — WooCommerce site block
- `.env.example` — `WOOCOMMERCE_DOMAIN` documented
- `docs/public-domain-demo-deployment-guide.md` — DNS record, var table, worked example, boot command, local-verification steps, checklist item, troubleshooting entries, and a callout that WooCommerce's `siteUrl` rule is the *opposite* of PrestaShop's (must be the public domain, not the internal address)
- `libs/integrations/woocommerce/docs/setup-guide.md` (pre-existing file, extended — this repo's established location for integration setup guides, e.g. KSeF/Erli/Allegro all live at `libs/integrations/<pkg>/docs/setup-guide.md`, not under a `docs/integrations/` path) — the `is_ssl()` gotcha explained explicitly, three working `siteUrl` options, corrected the previous (untested, and as far as I can tell non-functional) `https://localhost:8443` local-dev suggestion to the verified tunnel workaround, and new troubleshooting rows

## Test plan

- [x] Live-verified the proxy overlay end-to-end (see above)
- [x] `docker compose config` validates the merged compose files
- [ ] Reviewer: confirm the residual-risk framing (same-host header spoofing) is an acceptable trade-off for a demo/eval deployment, not something that needs a stricter mitigation (e.g. source-IP allowlisting) before merge

## Scope note (partial fix, not closing #1416)

This PR does not fully close #1416: the local-dev flow (`pnpm dev:stack:up`) is addressed with documentation (tunnel) rather than "a working alternative" in the stronger sense the issue's acceptance criteria leaves open, and I did not attempt source-IP-scoped header trust (would be over-engineering for a demo overlay, and the loopback-binding precedent already accepted elsewhere in this stack covers the same risk class). Suggest the issue stays open for maintainer sign-off on the residual-risk framing, or a narrow follow-up if stricter trust-boundary enforcement is wanted.

Does not touch #1415 or #1417's files (`docker-compose.demo.yml`'s `PRESTASHOP_BASE_URL`, `one-command-demo-setup-guide.md`'s Erli callout) — separate, parallel work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)