### PR TITLE
feat(listings): redesign publish-to-shop dialog and make batch stock/price per-product

### DIFF
--- a/apps/api/src/listings/http/bulk-shop-publish.controller.ts
+++ b/apps/api/src/listings/http/bulk-shop-publish.controller.ts
@@ -74,10 +74,12 @@ export class BulkShopPublishController {
       const { batchId, items } = await this.bulkSubmit.submit({
         connectionId: dto.connectionId,
         initiatedBy: user.id,
-        internalVariantIds: dto.internalVariantIds,
+        items: dto.items.map((item) => ({
+          internalVariantId: item.internalVariantId,
+          stock: item.stock,
+          ...(item.price !== undefined && { price: item.price }),
+        })),
         status: dto.status,
-        stock: dto.stock,
-        ...(dto.price !== undefined && { price: dto.price }),
         ...(dto.content !== undefined && { content: dto.content }),
       });
       return { batchId, items };

--- a/apps/api/src/listings/http/dto/publish-product.dto.ts
+++ b/apps/api/src/listings/http/dto/publish-product.dto.ts
@@ -110,34 +110,52 @@ export class PublishProductRequestDto {
   content?: PublishContentDto;
 }
 
+export class BulkPublishItemDto {
+  @ApiProperty({
+    description: 'OpenLinker internal variant id',
+    example: 'ol_variant_a1b2c3d4e5f6',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(VARIANT_ID_PATTERN, { message: `internalVariantId ${VARIANT_ID_MESSAGE}` })
+  internalVariantId!: string;
+
+  @ApiProperty({ example: 7, minimum: 0, description: "This product's own stock." })
+  @IsInt()
+  @Min(0)
+  stock!: number;
+
+  @ApiPropertyOptional({
+    type: PublishPriceDto,
+    description: "This product's own price override; omitted ⇒ master price.",
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PublishPriceDto)
+  price?: PublishPriceDto;
+}
+
 export class BulkPublishProductRequestDto {
   @ApiProperty({ description: 'Target shop connection id (uuid).' })
   @IsString()
   @IsNotEmpty()
   connectionId!: string;
 
-  @ApiProperty({ isArray: true, type: String, description: 'Internal variant ids (1..100).' })
+  @ApiProperty({
+    isArray: true,
+    type: BulkPublishItemDto,
+    description: 'One entry per product (1..100), each with its own stock/price.',
+  })
   @IsArray()
   @ArrayNotEmpty()
   @ArrayMaxSize(100)
-  @IsString({ each: true })
-  @Matches(VARIANT_ID_PATTERN, { each: true, message: `internalVariantIds ${VARIANT_ID_MESSAGE}` })
-  internalVariantIds!: string[];
+  @ValidateNested({ each: true })
+  @Type(() => BulkPublishItemDto)
+  items!: BulkPublishItemDto[];
 
   @ApiProperty({ enum: PublishProductStatusValues, example: 'published' })
   @IsIn(PublishProductStatusValues)
   status!: PublishProductStatus;
-
-  @ApiProperty({ example: 7, minimum: 0, description: 'Shared stock applied to every variant.' })
-  @IsInt()
-  @Min(0)
-  stock!: number;
-
-  @ApiPropertyOptional({ type: PublishPriceDto, description: 'Shared price override.' })
-  @IsOptional()
-  @ValidateNested()
-  @Type(() => PublishPriceDto)
-  price?: PublishPriceDto;
 
   @ApiPropertyOptional({ type: PublishContentDto, description: 'Shared content overrides.' })
   @IsOptional()

--- a/apps/api/src/listings/http/shop-publish.controller.spec.ts
+++ b/apps/api/src/listings/http/shop-publish.controller.spec.ts
@@ -92,13 +92,15 @@ describe('BulkShopPublishController', () => {
     controller = new BulkShopPublishController(bulkSubmit as never);
   });
 
-  it('should submit a bulk batch stamping initiatedBy from the session', async () => {
+  it('should submit a bulk batch stamping initiatedBy from the session, with each item keeping its own stock', async () => {
     const result = await controller.submit(
       {
         connectionId: CONN,
-        internalVariantIds: ['ol_variant_a'],
+        items: [
+          { internalVariantId: 'ol_variant_a', stock: 1 },
+          { internalVariantId: 'ol_variant_b', stock: 4 },
+        ],
         status: 'draft',
-        stock: 1,
       } as never,
       USER,
     );
@@ -106,7 +108,10 @@ describe('BulkShopPublishController', () => {
       expect.objectContaining({
         connectionId: CONN,
         initiatedBy: 'user-1',
-        internalVariantIds: ['ol_variant_a'],
+        items: [
+          { internalVariantId: 'ol_variant_a', stock: 1 },
+          { internalVariantId: 'ol_variant_b', stock: 4 },
+        ],
       }),
     );
     expect(result).toEqual({ batchId: 'batch-1', items: [] });
@@ -115,10 +120,7 @@ describe('BulkShopPublishController', () => {
   it('should map EmptyBulkSubmissionException to 400', async () => {
     bulkSubmit.submit.mockRejectedValue(new EmptyBulkSubmissionException());
     await expect(
-      controller.submit(
-        { connectionId: CONN, internalVariantIds: [], status: 'draft', stock: 1 } as never,
-        USER,
-      ),
+      controller.submit({ connectionId: CONN, items: [], status: 'draft' } as never, USER),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 

--- a/apps/api/test/integration/listings/bulk-shop-publish.int-spec.ts
+++ b/apps/api/test/integration/listings/bulk-shop-publish.int-spec.ts
@@ -84,9 +84,11 @@ describe('Bulk Shop Publish Integration (#1044)', () => {
     const result = await submitService().submit({
       connectionId: shopConnectionId,
       initiatedBy: 'user-int',
-      internalVariantIds: [VARIANT_A, VARIANT_B],
+      items: [
+        { internalVariantId: VARIANT_A, stock: 4 },
+        { internalVariantId: VARIANT_B, stock: 4 },
+      ],
       status: 'published',
-      stock: 4,
     });
 
     expect(result.items).toHaveLength(2);
@@ -117,9 +119,11 @@ describe('Bulk Shop Publish Integration (#1044)', () => {
     const { batchId, items } = await submitService().submit({
       connectionId: shopConnectionId,
       initiatedBy: 'user-int',
-      internalVariantIds: [VARIANT_A, VARIANT_B],
+      items: [
+        { internalVariantId: VARIANT_A, stock: 1 },
+        { internalVariantId: VARIANT_B, stock: 1 },
+      ],
       status: 'published',
-      stock: 1,
     });
     const [childA, childB] = items;
     const progress = progressService();
@@ -155,9 +159,11 @@ describe('Bulk Shop Publish Integration (#1044)', () => {
     const { batchId, items } = await submitService().submit({
       connectionId: shopConnectionId,
       initiatedBy: 'user-int',
-      internalVariantIds: [VARIANT_A, VARIANT_B],
+      items: [
+        { internalVariantId: VARIANT_A, stock: 1 },
+        { internalVariantId: VARIANT_B, stock: 1 },
+      ],
       status: 'published',
-      stock: 1,
     });
     const [childA] = items;
     const progress = progressService();

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -299,12 +299,16 @@ export interface ShopPublishStatusResponse {
   updatedAt: string;
 }
 
-export interface BulkShopPublishRequest {
-  connectionId: string;
-  internalVariantIds: string[];
-  status: 'draft' | 'published';
+export interface BulkShopPublishItemRequest {
+  internalVariantId: string;
   stock: number;
   price?: ShopPublishPrice;
+}
+
+export interface BulkShopPublishRequest {
+  connectionId: string;
+  items: BulkShopPublishItemRequest[];
+  status: 'draft' | 'published';
   content?: ShopPublishContent;
 }
 

--- a/apps/web/src/features/listings/components/ShopPublishLauncher.tsx
+++ b/apps/web/src/features/listings/components/ShopPublishLauncher.tsx
@@ -235,7 +235,7 @@ export function ShopPublishLauncher({
         if (!next) close();
       }}
     >
-      <DialogContent>
+      <DialogContent className="dialog__content--publish">
         <DialogTitle>{title}</DialogTitle>
         {description !== null ? (
           <DialogDescription className="mono-text">{description}</DialogDescription>

--- a/apps/web/src/features/listings/components/WoocommercePublishWizard.test.tsx
+++ b/apps/web/src/features/listings/components/WoocommercePublishWizard.test.tsx
@@ -94,7 +94,11 @@ describe('WoocommercePublishWizard', () => {
     const [body] = shopPublishBulk.mock.calls[0];
     expect(body).toMatchObject({
       connectionId: 'conn_woo_1',
-      internalVariantIds: ['ol_variant_1', 'ol_variant_2', 'ol_variant_3'],
+      items: [
+        { internalVariantId: 'ol_variant_1', stock: 0 },
+        { internalVariantId: 'ol_variant_2', stock: 0 },
+        { internalVariantId: 'ol_variant_3', stock: 0 },
+      ],
       status: 'draft',
     });
     await waitFor(() => {
@@ -102,7 +106,63 @@ describe('WoocommercePublishWizard', () => {
     });
   });
 
-  it('shows a searchable variant picker and lets the operator pick one when opened without a default variant', async () => {
+  it('gives each product its own stock/price row in bulk Configure, independent of the others (#1414)', async () => {
+    const shopPublishBulk = vi.fn().mockResolvedValue({ batchId: 'batch-7', items: [] });
+    const apiClient = createMockApiClient({ listings: { shopPublishBulk } });
+
+    renderWithProviders(
+      <WoocommercePublishWizard
+        connection={wooConnection}
+        defaultVariantIds={['ol_variant_1', 'ol_variant_2']}
+        onCancel={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    const stockInputs = await screen.findAllByPlaceholderText('master');
+    // 2 products × (stock, price) = 4 inputs; stock inputs are the even ones.
+    fireEvent.change(stockInputs[0], { target: { value: '12' } });
+
+    fireEvent.click(await screen.findByRole('button', { name: /publish 2 products/i }));
+
+    await waitFor(() => {
+      expect(shopPublishBulk).toHaveBeenCalledTimes(1);
+    });
+    const [body] = shopPublishBulk.mock.calls[0];
+    expect(body.items).toEqual([
+      { internalVariantId: 'ol_variant_1', stock: 12 },
+      { internalVariantId: 'ol_variant_2', stock: 0 },
+    ]);
+  });
+
+  it('removes a product from the batch via its row remove button', async () => {
+    const shopPublishBulk = vi.fn().mockResolvedValue({ batchId: 'batch-7', items: [] });
+    const apiClient = createMockApiClient({ listings: { shopPublishBulk } });
+
+    renderWithProviders(
+      <WoocommercePublishWizard
+        connection={wooConnection}
+        defaultVariantIds={['ol_variant_1', 'ol_variant_2']}
+        onCancel={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    await screen.findByRole('button', { name: /publish 2 products/i });
+    fireEvent.click((await screen.findAllByRole('button', { name: /remove.*from batch/i }))[0]);
+
+    fireEvent.click(await screen.findByRole('button', { name: /publish 1 product/i }));
+
+    await waitFor(() => {
+      expect(shopPublishBulk).toHaveBeenCalledTimes(1);
+    });
+    const [body] = shopPublishBulk.mock.calls[0];
+    expect(body.items).toEqual([{ internalVariantId: 'ol_variant_2', stock: 0 }]);
+  });
+
+  it('shows a searchable multi-select picker and lets the operator check one or more variants when opened without a default variant', async () => {
     const shopPublish = vi
       .fn()
       .mockResolvedValue({ jobId: 'job-1', listingCreationRecordId: 'rec-9' });
@@ -135,14 +195,19 @@ describe('WoocommercePublishWizard', () => {
       { apiClient },
     );
 
-    // Publish is disabled until a variant is picked.
-    expect(await screen.findByRole('button', { name: /^publish$/i })).toBeDisabled();
+    // Continue is disabled until at least one variant is checked.
+    expect(
+      await screen.findByRole('button', { name: /continue with 0 products/i }),
+    ).toBeDisabled();
 
     fireEvent.click(await screen.findByText('Red Shirt'));
-    fireEvent.click(await screen.findByRole('radio'));
+    fireEvent.click(await screen.findByRole('checkbox'));
+
+    const continueButton = await screen.findByRole('button', { name: /continue with 1 product/i });
+    expect(continueButton).not.toBeDisabled();
+    fireEvent.click(continueButton);
 
     const publishButton = await screen.findByRole('button', { name: /^publish$/i });
-    expect(publishButton).not.toBeDisabled();
     fireEvent.click(publishButton);
 
     await waitFor(() => {
@@ -150,6 +215,47 @@ describe('WoocommercePublishWizard', () => {
     });
     const [, body] = shopPublish.mock.calls[0];
     expect(body).toMatchObject({ internalVariantId: 'ol_variant_9' });
+  });
+
+  it('removes a checked variant from the selection tray before continuing', async () => {
+    const products = {
+      list: vi.fn().mockResolvedValue({
+        items: [{ id: 'prod_1', name: 'Red Shirt', sku: 'RS-1', price: 19.99, currency: 'PLN' }],
+        total: 1,
+        limit: 10,
+        offset: 0,
+      }),
+      getById: vi.fn().mockResolvedValue({
+        id: 'prod_1',
+        name: 'Red Shirt',
+        sku: 'RS-1',
+        price: 19.99,
+        currency: 'PLN',
+        variants: [
+          { id: 'ol_variant_9', productId: 'prod_1', sku: 'RS-1-M', ean: null, gtin: null, price: 19.99 },
+        ],
+      }),
+    };
+    const apiClient = createMockApiClient({ listings: {}, products });
+
+    renderWithProviders(
+      <WoocommercePublishWizard
+        connection={wooConnection}
+        onCancel={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    fireEvent.click(await screen.findByText('Red Shirt'));
+    fireEvent.click(await screen.findByRole('checkbox'));
+    await screen.findByRole('button', { name: /continue with 1 product/i });
+
+    fireEvent.click(await screen.findByRole('button', { name: /remove.*from batch/i }));
+
+    expect(
+      await screen.findByRole('button', { name: /continue with 0 products/i }),
+    ).toBeDisabled();
   });
 
   it('rejects a negative stock value and does not call the API', async () => {

--- a/apps/web/src/features/listings/components/WoocommercePublishWizard.tsx
+++ b/apps/web/src/features/listings/components/WoocommercePublishWizard.tsx
@@ -6,12 +6,20 @@
  * this component receives the resolved `Connection` as a prop and renders
  * wizard body + footer actions directly.
  *
- * Two modes, driven by props:
- *   - **single** — `defaultVariantId` set: one product. Optional Review step
- *     before submit. Submits via `useShopPublishMutation`, reports
- *     `{ recordId }`.
- *   - **bulk** — `defaultVariantIds` (>1): one product per variant. Submits
- *     via `useBulkShopPublishMutation`, reports `{ batchId }`.
+ * Two modes, resolved from props OR from the in-dialog picker when the
+ * top-level "Publish to shop" CTA opens with no variant context at all:
+ *   - **single** — one product. Optional Review step before submit. Submits
+ *     via `useShopPublishMutation`, reports `{ recordId }`.
+ *   - **bulk** — 2+ products, one per variant. Each product gets its own
+ *     Stock + Price override row in Configure (#1414 — these are independent
+ *     publish decisions, not one shared value for the batch). Submits via
+ *     `useBulkShopPublishMutation`, reports `{ batchId }`.
+ *
+ * When entered with no `defaultVariantId(s)` (the top-level CTA), the wizard
+ * runs a **selection step** first: search + checkbox multi-select collecting
+ * into a persistent tray, then "Continue" locks in single vs. bulk mode based
+ * on how many variants were checked. Entering with props already set
+ * (row-level "Publish"/bulk actions) skips straight to Configure, unchanged.
  *
  * Category placement, attributes, and images are resolved server-side from
  * the master product at publish time (the #1042 builder), so the wizard is
@@ -26,7 +34,7 @@
  * @module apps/web/src/features/listings/components
  */
 import { useMemo, useRef, useState, type ReactElement } from 'react';
-import { useForm } from 'react-hook-form';
+import { useFieldArray, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
@@ -42,6 +50,7 @@ import type { Product, ProductVariant } from '../../products';
 import { useShopPublishMutation } from '../hooks/use-shop-publish-mutation';
 import { useBulkShopPublishMutation } from '../hooks/use-bulk-shop-publish-mutation';
 import type {
+  BulkShopPublishItemRequest,
   BulkShopPublishRequest,
   ShopPublishContent,
   ShopPublishPrice,
@@ -63,6 +72,8 @@ interface WoocommercePublishWizardProps {
   onSubmitted: (result: { recordId?: string; batchId?: string }, connectionId: string) => void;
 }
 
+type PublishMode = 'single' | 'bulk';
+
 const VARIANT_SEARCH_DEBOUNCE_MS = 300;
 const VARIANT_PICKER_PAGE_SIZE = 10;
 
@@ -77,25 +88,25 @@ function variantLabel(product: Product, variant: ProductVariant): string {
   return product.name;
 }
 
-/** Whole-flow mode derived from the props the launcher passes. Bulk wins
- *  when more than one id is supplied; otherwise single. */
-function resolveVariantIds(
-  defaultVariantId?: string,
-  defaultVariantIds?: string[],
-): { ids: string[]; mode: 'single' | 'bulk' } {
+/** Ids supplied directly by props (row-level "Publish"/bulk actions). Empty
+ *  when the top-level CTA opened with no variant context — the operator picks
+ *  via the in-dialog selection step instead. */
+function resolvePropsIds(defaultVariantId?: string, defaultVariantIds?: string[]): string[] {
   const bulkIds = (defaultVariantIds ?? []).filter(Boolean);
-  if (bulkIds.length > 1) {
-    return { ids: bulkIds, mode: 'bulk' };
-  }
-  if (bulkIds.length === 1) {
-    return { ids: bulkIds, mode: 'single' };
-  }
-  return { ids: defaultVariantId ? [defaultVariantId] : [], mode: 'single' };
+  if (bulkIds.length > 0) return bulkIds;
+  return defaultVariantId ? [defaultVariantId] : [];
 }
 
-function buildPrice(values: WoocommercePublishWizardSubmission): ShopPublishPrice | undefined {
-  if (values.priceAmount === '') return undefined;
-  return { amount: Number(values.priceAmount), currency: values.priceCurrency };
+function modeForIds(ids: string[]): PublishMode {
+  return ids.length > 1 ? 'bulk' : 'single';
+}
+
+function buildPrice(
+  priceAmount: string,
+  priceCurrency: string,
+): ShopPublishPrice | undefined {
+  if (priceAmount === '') return undefined;
+  return { amount: Number(priceAmount), currency: priceCurrency };
 }
 
 function buildContent(): ShopPublishContent | undefined {
@@ -111,18 +122,30 @@ export function WoocommercePublishWizard({
   onCancel,
   onSubmitted,
 }: WoocommercePublishWizardProps): ReactElement {
-  const { ids, mode } = useMemo(
-    () => resolveVariantIds(defaultVariantId, defaultVariantIds),
+  const propsIds = useMemo(
+    () => resolvePropsIds(defaultVariantId, defaultVariantIds),
     [defaultVariantId, defaultVariantIds],
   );
   // The top-level "Publish to shop" CTA opens this wizard with no variant
   // context at all (no row/product to publish from). In that case the
-  // operator has to search and pick one here instead of the field silently
+  // operator runs the selection step below instead of the field silently
   // rendering blank.
-  const needsVariantPicker = mode === 'single' && ids.length === 0;
+  const needsVariantPicker = propsIds.length === 0;
 
-  const [pickedVariantId, setPickedVariantId] = useState<string | null>(null);
-  const [pickedVariantLabel, setPickedVariantLabel] = useState<string | null>(null);
+  // Multi-select tray state — only used during the selection step. Map
+  // preserves insertion order, matching the tray's expected chip order.
+  const [selectedVariants, setSelectedVariants] = useState<Map<string, string>>(new Map());
+  // null while the operator is still picking (selection step showing);
+  // locked in once "Continue" is pressed, or immediately when props already
+  // supplied ids.
+  const [finalMode, setFinalMode] = useState<PublishMode | null>(
+    needsVariantPicker ? null : modeForIds(propsIds),
+  );
+  const [singleVariantId, setSingleVariantId] = useState<string | null>(
+    !needsVariantPicker && propsIds.length === 1 ? propsIds[0] : null,
+  );
+  const [singleVariantLabel, setSingleVariantLabel] = useState<string | null>(null);
+
   const [productSearchInput, setProductSearchInput] = useState('');
   const [productOffset, setProductOffset] = useState(0);
   const [selectedProductId, setSelectedProductId] = useState<string | null>(null);
@@ -134,11 +157,24 @@ export function WoocommercePublishWizard({
   );
   const productDetailQuery = useProductQuery(selectedProductId ?? '');
 
-  const effectiveIds = ids.length > 0 ? ids : pickedVariantId ? [pickedVariantId] : [];
+  function toggleVariant(variantId: string, label: string, checked: boolean): void {
+    setSelectedVariants((prev) => {
+      const next = new Map(prev);
+      if (checked) {
+        next.set(variantId, label);
+      } else {
+        next.delete(variantId);
+      }
+      return next;
+    });
+  }
 
-  function handleVariantPick(product: Product, variant: ProductVariant): void {
-    setPickedVariantId(variant.id);
-    setPickedVariantLabel(variantLabel(product, variant));
+  function removeFromTray(variantId: string): void {
+    setSelectedVariants((prev) => {
+      const next = new Map(prev);
+      next.delete(variantId);
+      return next;
+    });
   }
 
   const singleMutation = useShopPublishMutation();
@@ -148,50 +184,110 @@ export function WoocommercePublishWizard({
 
   const [reviewing, setReviewing] = useState(false);
 
+  // Initial defaultValues cover both non-picker entry points synchronously
+  // (props ids are stable and known at mount); the picker path starts from
+  // the single-mode shape as a placeholder and is fully reset once the
+  // operator hits "Continue" (see handleContinue below).
+  const initialDefaults: WoocommercePublishWizardValues =
+    !needsVariantPicker && propsIds.length > 1
+      ? {
+          ...WOOCOMMERCE_PUBLISH_BULK_DEFAULTS,
+          items: propsIds.map((variantId) => ({
+            variantId,
+            label: variantId,
+            stock: '',
+            priceAmount: '',
+          })),
+        }
+      : WOOCOMMERCE_PUBLISH_SINGLE_DEFAULTS;
+
   const form = useForm<
     WoocommercePublishWizardValues,
     undefined,
     WoocommercePublishWizardSubmission
   >({
-    defaultValues:
-      mode === 'bulk' ? WOOCOMMERCE_PUBLISH_BULK_DEFAULTS : WOOCOMMERCE_PUBLISH_SINGLE_DEFAULTS,
+    defaultValues: initialDefaults,
     resolver: zodResolver(woocommercePublishWizardSchema),
     mode: 'onBlur',
   });
 
+  const itemsFieldArray = useFieldArray({ control: form.control, name: 'items' });
+
+  function handleContinue(): void {
+    const chosen = Array.from(selectedVariants.entries());
+    if (chosen.length === 0) return;
+    if (chosen.length > 1) {
+      form.reset({
+        ...WOOCOMMERCE_PUBLISH_BULK_DEFAULTS,
+        items: chosen.map(([variantId, label]) => ({
+          variantId,
+          label,
+          stock: '',
+          priceAmount: '',
+        })),
+      });
+      setFinalMode('bulk');
+    } else {
+      const [[variantId, label]] = chosen;
+      setSingleVariantId(variantId);
+      setSingleVariantLabel(label);
+      form.reset(WOOCOMMERCE_PUBLISH_SINGLE_DEFAULTS);
+      setFinalMode('single');
+    }
+  }
+
+  function handleVariantPick(product: Product, variant: ProductVariant, checked: boolean): void {
+    toggleVariant(variant.id, variantLabel(product, variant), checked);
+  }
+
+  const mode = finalMode;
   const status = form.watch('status');
   const mutationError = mode === 'bulk' ? bulkMutation.error : singleMutation.error;
   const isPending = singleMutation.isPending || bulkMutation.isPending;
 
   const validationMessages = Object.values(form.formState.errors)
-    .map((e) => e?.message)
+    .map((e) => (Array.isArray(e) ? undefined : e?.message))
     .filter((m): m is string => typeof m === 'string');
 
+  const singleId = !needsVariantPicker ? propsIds[0] : singleVariantId;
+
+  function resetColumn(field: 'stock' | 'priceAmount'): void {
+    itemsFieldArray.fields.forEach((_, index) => {
+      form.setValue(`items.${index}.${field}`, '', { shouldDirty: true });
+    });
+  }
+
   const submit = form.handleSubmit(async (values) => {
-    const stockValue = values.stock === '' ? 0 : Number(values.stock);
-    const price = buildPrice(values);
     const content = buildContent();
 
     try {
       if (mode === 'bulk') {
+        const items: BulkShopPublishItemRequest[] = values.items.map((item) => {
+          const price = buildPrice(item.priceAmount, values.priceCurrency);
+          return {
+            internalVariantId: item.variantId,
+            stock: item.stock === '' ? 0 : Number(item.stock),
+            ...(price ? { price } : {}),
+          };
+        });
         const request: BulkShopPublishRequest = {
           connectionId: connection.id,
-          internalVariantIds: effectiveIds,
+          items,
           status: values.status,
-          stock: stockValue,
-          ...(price ? { price } : {}),
           ...(content ? { content } : {}),
         };
         const result = await bulkMutation.mutateAsync({ request });
         showToast({
           tone: 'success',
           title: 'Bulk publish started',
-          description: `Publishing ${effectiveIds.length} products to ${connection.name}.`,
+          description: `Publishing ${items.length} products to ${connection.name}.`,
         });
         onSubmitted({ batchId: result.batchId }, connection.id);
       } else {
+        const stockValue = values.stock === '' ? 0 : Number(values.stock);
+        const price = buildPrice(values.priceAmount, values.priceCurrency);
         const request: ShopPublishRequest = {
-          internalVariantId: effectiveIds[0],
+          internalVariantId: singleId ?? '',
           status: values.status,
           stock: stockValue,
           ...(price ? { price } : {}),
@@ -239,6 +335,186 @@ export function WoocommercePublishWizard({
     </div>
   );
 
+  // ── Selection step (top-level CTA, no props ids yet) ──────────────────
+  if (needsVariantPicker && mode === null) {
+    const selectedList = Array.from(selectedVariants.entries());
+    return (
+      <div className="wizard-card">
+        <FormField
+          label="Search products"
+          name="productSearch"
+          description="Search by product name, SKU, or EAN. Check one or more variants — they all publish together."
+        >
+          <Input
+            value={productSearchInput}
+            onChange={(e) => {
+              setProductSearchInput(e.target.value);
+              setProductOffset(0);
+            }}
+            placeholder="e.g. T-shirt, SKU-123, 5901234567890"
+          />
+        </FormField>
+
+        <div className="shop-publish-picker">
+          {productsQuery.isLoading ? (
+            <p className="muted-text">Loading products…</p>
+          ) : (productsQuery.data?.items.length ?? 0) === 0 ? (
+            <p className="muted-text">No products match.</p>
+          ) : (
+            <ul className="create-offer-variant-picker__list">
+              {(productsQuery.data?.items ?? []).map((product) => {
+                const isExpanded = selectedProductId === product.id;
+                return (
+                  <li key={product.id} className="create-offer-variant-picker__product">
+                    <button
+                      type="button"
+                      className="create-offer-variant-picker__product-row"
+                      onClick={() => setSelectedProductId(isExpanded ? null : product.id)}
+                      aria-expanded={isExpanded}
+                    >
+                      <span className="shop-publish-picker__product-name" title={product.name}>
+                        {product.name}
+                      </span>
+                      <span className="mono-text muted-text shop-publish-picker__code">
+                        {product.sku ?? '-'}
+                      </span>
+                    </button>
+
+                    {isExpanded ? (
+                      <ul className="create-offer-variant-picker__variants">
+                        {productDetailQuery.isLoading ? (
+                          <li className="muted-text">Loading variants…</li>
+                        ) : (productDetailQuery.data?.variants ?? []).length === 0 ? (
+                          <li className="muted-text">No variants on this product.</li>
+                        ) : (
+                          (productDetailQuery.data?.variants ?? []).map((variant) => {
+                            const label = variantLabel(productDetailQuery.data ?? product, variant);
+                            const checked = selectedVariants.has(variant.id);
+                            return (
+                              <li key={variant.id}>
+                                <label className="create-offer-variant-picker__variant">
+                                  <input
+                                    type="checkbox"
+                                    checked={checked}
+                                    onChange={(e) =>
+                                      handleVariantPick(
+                                        productDetailQuery.data ?? product,
+                                        variant,
+                                        e.target.checked,
+                                      )
+                                    }
+                                  />
+                                  <span
+                                    className="create-offer-variant-picker__variant-name shop-publish-picker__variant-name"
+                                    title={label}
+                                  >
+                                    {label}
+                                  </span>
+                                  <span className="mono-text muted-text shop-publish-picker__code">
+                                    SKU {variant.sku ?? '-'} · EAN {variant.ean ?? '-'}
+                                  </span>
+                                </label>
+                              </li>
+                            );
+                          })
+                        )}
+                      </ul>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          {(() => {
+            const total = productsQuery.data?.total ?? 0;
+            if (total <= VARIANT_PICKER_PAGE_SIZE) return null;
+            const pageEnd = Math.min(productOffset + VARIANT_PICKER_PAGE_SIZE, total);
+            return (
+              <div className="create-offer-variant-picker__pagination">
+                <span className="muted-text">
+                  {productOffset + 1}-{pageEnd} of {total}
+                </span>
+                <div className="create-offer-variant-picker__pagination-actions">
+                  <Button
+                    tone="secondary"
+                    type="button"
+                    aria-label="Previous page of products"
+                    disabled={productOffset === 0}
+                    onClick={() =>
+                      setProductOffset((o) => Math.max(0, o - VARIANT_PICKER_PAGE_SIZE))
+                    }
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    tone="secondary"
+                    type="button"
+                    aria-label="Next page of products"
+                    disabled={productOffset + VARIANT_PICKER_PAGE_SIZE >= total}
+                    onClick={() => setProductOffset((o) => o + VARIANT_PICKER_PAGE_SIZE)}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            );
+          })()}
+        </div>
+
+        <div className="shop-publish-tray">
+          <div className="shop-publish-tray__head">
+            <span className="shop-publish-tray__count">
+              Selected for this batch: <span className="mono-text">{selectedList.length}</span>
+            </span>
+            {selectedList.length > 0 ? (
+              <Button
+                tone="ghost"
+                type="button"
+                className="button--sm"
+                onClick={() => setSelectedVariants(new Map())}
+              >
+                Clear all
+              </Button>
+            ) : null}
+          </div>
+          {selectedList.length > 0 ? (
+            <div className="shop-publish-tray__chips">
+              {selectedList.map(([variantId, label]) => (
+                <span key={variantId} className="shop-publish-chip shop-publish-chip--removable">
+                  <span title={label}>{label}</span>
+                  <button
+                    type="button"
+                    aria-label={`Remove ${label} from batch`}
+                    onClick={() => removeFromTray(variantId)}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="shop-publish-tray__empty-hint muted-text">
+              Check one or more variants above to add them here.
+            </p>
+          )}
+        </div>
+
+        <div className="wizard-actions">
+          <div className="wizard-actions__group">
+            <Button type="button" tone="ghost" onClick={onCancel}>
+              Cancel
+            </Button>
+          </div>
+          <div className="wizard-actions__group">
+            <Button type="button" disabled={selectedList.length === 0} onClick={handleContinue}>
+              Continue with {selectedList.length} product{selectedList.length === 1 ? '' : 's'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // ── Single-mode Review step ───────────────────────────────────────────
   if (mode === 'single' && reviewing) {
     const values = form.getValues();
@@ -263,8 +539,8 @@ export function WoocommercePublishWizard({
           <div className="shop-publish-kv__row">
             <dt>Variant</dt>
             <dd>
-              {pickedVariantLabel ? <div>{pickedVariantLabel}</div> : null}
-              <span className="mono-text muted-text">{effectiveIds[0]}</span>
+              {singleVariantLabel ? <div>{singleVariantLabel}</div> : null}
+              <span className="mono-text muted-text">{singleId}</span>
             </dd>
           </div>
           <div className="shop-publish-kv__row">
@@ -300,161 +576,13 @@ export function WoocommercePublishWizard({
     );
   }
 
-  // ── Form step (single + bulk share the field layout) ──────────────────
+  // ── Configure step (single + bulk share the field layout) ─────────────
   return (
     <form onSubmit={(e) => void submit(e)} noValidate className="wizard-card">
       {mutationError ? <Alert tone="error">{mutationError.message}</Alert> : null}
       {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
         <FormErrorSummary errors={validationMessages} />
       ) : null}
-
-      {mode === 'bulk' ? (
-        <div className="form-field">
-          <span className="form-field__label">
-            Variants <span className="shop-publish-hint">{effectiveIds.length} selected</span>
-          </span>
-          <div className="shop-publish-chips">
-            {effectiveIds.map((id) => (
-              <span key={id} className="shop-publish-chip mono-text" title={id}>
-                {id}
-              </span>
-            ))}
-          </div>
-        </div>
-      ) : needsVariantPicker && pickedVariantId === null ? (
-        <div className="form-field">
-          <FormField
-            label="Search products"
-            name="productSearch"
-            description="Search by product name, SKU, or EAN."
-          >
-            <Input
-              value={productSearchInput}
-              onChange={(e) => {
-                setProductSearchInput(e.target.value);
-                setProductOffset(0);
-              }}
-              placeholder="e.g. T-shirt, SKU-123, 5901234567890"
-            />
-          </FormField>
-
-          <div className="create-offer-variant-picker">
-            {productsQuery.isLoading ? (
-              <p className="muted-text">Loading products…</p>
-            ) : (productsQuery.data?.items.length ?? 0) === 0 ? (
-              <p className="muted-text">No products match.</p>
-            ) : (
-              <ul className="create-offer-variant-picker__list">
-                {(productsQuery.data?.items ?? []).map((product) => {
-                  const isExpanded = selectedProductId === product.id;
-                  return (
-                    <li key={product.id} className="create-offer-variant-picker__product">
-                      <button
-                        type="button"
-                        className="create-offer-variant-picker__product-row"
-                        onClick={() => setSelectedProductId(isExpanded ? null : product.id)}
-                        aria-expanded={isExpanded}
-                      >
-                        <span>{product.name}</span>
-                        <span className="mono-text muted-text">{product.sku ?? '-'}</span>
-                      </button>
-
-                      {isExpanded ? (
-                        <ul className="create-offer-variant-picker__variants">
-                          {productDetailQuery.isLoading ? (
-                            <li className="muted-text">Loading variants…</li>
-                          ) : (productDetailQuery.data?.variants ?? []).length === 0 ? (
-                            <li className="muted-text">No variants on this product.</li>
-                          ) : (
-                            (productDetailQuery.data?.variants ?? []).map((variant) => (
-                              <li key={variant.id}>
-                                <label className="create-offer-variant-picker__variant">
-                                  <input
-                                    type="radio"
-                                    name="wooPublishVariantId"
-                                    value={variant.id}
-                                    checked={false}
-                                    onChange={() =>
-                                      handleVariantPick(productDetailQuery.data ?? product, variant)
-                                    }
-                                  />
-                                  <span className="create-offer-variant-picker__variant-name">
-                                    {variantLabel(productDetailQuery.data ?? product, variant)}
-                                  </span>
-                                  <span className="mono-text muted-text">
-                                    SKU {variant.sku ?? '-'} · EAN {variant.ean ?? '-'}
-                                  </span>
-                                </label>
-                              </li>
-                            ))
-                          )}
-                        </ul>
-                      ) : null}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            {(() => {
-              const total = productsQuery.data?.total ?? 0;
-              if (total <= VARIANT_PICKER_PAGE_SIZE) return null;
-              const pageEnd = Math.min(productOffset + VARIANT_PICKER_PAGE_SIZE, total);
-              return (
-                <div className="create-offer-variant-picker__pagination">
-                  <span className="muted-text">
-                    {productOffset + 1}-{pageEnd} of {total}
-                  </span>
-                  <div className="create-offer-variant-picker__pagination-actions">
-                    <Button
-                      tone="secondary"
-                      type="button"
-                      aria-label="Previous page of products"
-                      disabled={productOffset === 0}
-                      onClick={() =>
-                        setProductOffset((o) => Math.max(0, o - VARIANT_PICKER_PAGE_SIZE))
-                      }
-                    >
-                      Previous
-                    </Button>
-                    <Button
-                      tone="secondary"
-                      type="button"
-                      aria-label="Next page of products"
-                      disabled={productOffset + VARIANT_PICKER_PAGE_SIZE >= total}
-                      onClick={() => setProductOffset((o) => o + VARIANT_PICKER_PAGE_SIZE)}
-                    >
-                      Next
-                    </Button>
-                  </div>
-                </div>
-              );
-            })()}
-          </div>
-        </div>
-      ) : (
-        <div className="form-field">
-          <span className="form-field__label">Variant</span>
-          <div className="shop-publish-variant-line">
-            {pickedVariantLabel ? <span>{pickedVariantLabel}</span> : null}
-            <span className="mono-text muted-text" title={effectiveIds[0]}>
-              {effectiveIds[0]}
-            </span>
-            {needsVariantPicker ? (
-              <Button
-                type="button"
-                tone="ghost"
-                className="button--sm"
-                onClick={() => {
-                  setPickedVariantId(null);
-                  setPickedVariantLabel(null);
-                }}
-              >
-                Change
-              </Button>
-            ) : null}
-          </div>
-        </div>
-      )}
 
       <div className="form-field">
         <span className="form-field__label">
@@ -469,51 +597,155 @@ export function WoocommercePublishWizard({
         ) : null}
       </div>
 
-      <div className="shop-publish-field-row">
-        <FormField
-          label={
-            <>
-              Stock{' '}
-              {mode === 'bulk' ? (
-                <span className="shop-publish-hint">per master if blank</span>
-              ) : null}
-            </>
-          }
-          name="stock"
-          error={form.formState.errors.stock?.message}
-        >
-          <Input
-            inputMode="numeric"
-            className="input--mono"
-            placeholder={mode === 'bulk' ? 'from master' : '0'}
-            {...form.register('stock')}
-          />
-        </FormField>
-        <FormField
-          label={
-            <>
-              Price override <span className="shop-publish-hint">optional</span>
-            </>
-          }
-          name="priceAmount"
-          error={form.formState.errors.priceAmount?.message}
-        >
-          <div className="shop-publish-affix">
-            <span className="shop-publish-affix__pre mono-text">{form.watch('priceCurrency')}</span>
-            <Input
-              inputMode="decimal"
-              className="input--mono shop-publish-affix__input"
-              placeholder="from master"
-              {...form.register('priceAmount')}
-            />
+      {mode === 'bulk' ? (
+        <div className="form-field">
+          <span className="form-field__label">
+            Products{' '}
+            <span className="shop-publish-hint">{itemsFieldArray.fields.length} selected</span>{' '}
+            <span className="shop-publish-hint">— stock &amp; price set per product</span>
+          </span>
+          <div className="shop-publish-config-table">
+            <div className="shop-publish-config-table__body">
+              {itemsFieldArray.fields.map((field, index) => (
+                <div key={field.id} className="shop-publish-config-row">
+                  <div className="shop-publish-config-row__top">
+                    <span className="shop-publish-config-row__name" title={field.label}>
+                      {field.label}
+                    </span>
+                    <button
+                      type="button"
+                      className="shop-publish-config-row__remove"
+                      aria-label={`Remove ${field.label} from batch`}
+                      onClick={() => itemsFieldArray.remove(index)}
+                    >
+                      ×
+                    </button>
+                  </div>
+                  <div className="shop-publish-config-row__fields">
+                    <FormField
+                      label="Stock"
+                      name={`items.${index}.stock`}
+                      error={form.formState.errors.items?.[index]?.stock?.message}
+                    >
+                      <Input
+                        inputMode="numeric"
+                        className="input--mono"
+                        placeholder="master"
+                        {...form.register(`items.${index}.stock`)}
+                      />
+                    </FormField>
+                    <FormField
+                      label="Price override"
+                      name={`items.${index}.priceAmount`}
+                      error={form.formState.errors.items?.[index]?.priceAmount?.message}
+                    >
+                      <div className="shop-publish-affix">
+                        <span className="shop-publish-affix__pre mono-text">
+                          {form.watch('priceCurrency')}
+                        </span>
+                        <Input
+                          inputMode="decimal"
+                          className="input--mono shop-publish-affix__input"
+                          placeholder="master"
+                          {...form.register(`items.${index}.priceAmount`)}
+                        />
+                      </div>
+                    </FormField>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="shop-publish-config-table__foot">
+              <span className="form-field__description">
+                Blank stock/price falls back to the master product's value at publish time.
+              </span>
+              <div className="shop-publish-config-table__foot-actions">
+                <Button
+                  tone="ghost"
+                  type="button"
+                  className="button--sm"
+                  onClick={() => resetColumn('stock')}
+                >
+                  Use master stock for all
+                </Button>
+                <Button
+                  tone="ghost"
+                  type="button"
+                  className="button--sm"
+                  onClick={() => resetColumn('priceAmount')}
+                >
+                  Use master price for all
+                </Button>
+              </div>
+            </div>
           </div>
-        </FormField>
-      </div>
+        </div>
+      ) : (
+        <>
+          <div className="form-field">
+            <span className="form-field__label">Variant</span>
+            <div className="shop-publish-variant-line">
+              {singleVariantLabel ? <span>{singleVariantLabel}</span> : null}
+              <span className="mono-text muted-text" title={singleId ?? ''}>
+                {singleId}
+              </span>
+              {needsVariantPicker ? (
+                <Button
+                  type="button"
+                  tone="ghost"
+                  className="button--sm"
+                  onClick={() => {
+                    setSingleVariantId(null);
+                    setSingleVariantLabel(null);
+                    setSelectedVariants(new Map());
+                    setFinalMode(null);
+                  }}
+                >
+                  Change
+                </Button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="shop-publish-field-row">
+            <FormField label="Stock" name="stock" error={form.formState.errors.stock?.message}>
+              <Input
+                inputMode="numeric"
+                className="input--mono"
+                placeholder="0"
+                {...form.register('stock')}
+              />
+            </FormField>
+            <FormField
+              label={
+                <>
+                  Price override <span className="shop-publish-hint">optional</span>
+                </>
+              }
+              name="priceAmount"
+              error={form.formState.errors.priceAmount?.message}
+            >
+              <div className="shop-publish-affix">
+                <span className="shop-publish-affix__pre mono-text">
+                  {form.watch('priceCurrency')}
+                </span>
+                <Input
+                  inputMode="decimal"
+                  className="input--mono shop-publish-affix__input"
+                  placeholder="from master"
+                  {...form.register('priceAmount')}
+                />
+              </div>
+            </FormField>
+          </div>
+        </>
+      )}
 
       {mode === 'bulk' ? (
         <Alert tone="info">
-          Each variant publishes as its own simple WooCommerce product. Out-of-stock variants list
-          with their master stock (0 is honored).
+          Each product publishes independently — one can list at a different price or stock level
+          than the rest of the batch. Out-of-stock variants list with their master stock (0 is
+          honored).
         </Alert>
       ) : (
         <div className="shop-publish-callout">
@@ -534,7 +766,7 @@ export function WoocommercePublishWizard({
             <Button
               type="button"
               tone="secondary"
-              disabled={isPending || effectiveIds.length === 0}
+              disabled={isPending || !singleId}
               onClick={() => {
                 void form.trigger().then((ok) => {
                   if (ok) setReviewing(true);
@@ -544,11 +776,16 @@ export function WoocommercePublishWizard({
               Review
             </Button>
           ) : null}
-          <Button type="submit" disabled={isPending || effectiveIds.length === 0}>
+          <Button
+            type="submit"
+            disabled={
+              isPending || (mode === 'bulk' ? itemsFieldArray.fields.length === 0 : !singleId)
+            }
+          >
             {isPending
               ? 'Publishing…'
               : mode === 'bulk'
-                ? `Publish ${effectiveIds.length} products`
+                ? `Publish ${itemsFieldArray.fields.length} products`
                 : 'Publish'}
           </Button>
         </div>

--- a/apps/web/src/features/listings/components/woocommerce-publish-wizard.schema.ts
+++ b/apps/web/src/features/listings/components/woocommerce-publish-wizard.schema.ts
@@ -1,10 +1,12 @@
 /**
- * WooCommerce publish wizard schema (#1044)
+ * WooCommerce publish wizard schema (#1044, per-product stock/price #1414)
  *
- * Zod schema for the shop-publish wizard form. Shared by single and bulk
- * modes — the variant ids come from props (not the form), so the form only
- * carries the operator-editable knobs: visibility, stock, and an optional
- * price override.
+ * Zod schema for the shop-publish wizard form. **Single** mode carries a top-
+ * level `stock`/`priceAmount` (variant id comes from props, not the form).
+ * **Bulk** mode carries one `items[]` row per selected variant — stock and
+ * price are per-product, not one shared value for the whole batch — plus a
+ * shared `status`/`priceCurrency`. Visibility isn't a per-item concern, so it
+ * stays a single top-level field in both modes.
  *
  * `priceAmount` is a string in the form (empty = "use master price") and is
  * coerced to a number at submit time by the component. The schema validates
@@ -16,26 +18,40 @@ import { z } from 'zod';
 
 export const ShopPublishVisibilityValues = ['draft', 'published'] as const;
 
+const stockFieldSchema = z
+  .string()
+  .trim()
+  .refine((v) => v === '' || /^\d+$/.test(v), 'Stock must be a whole number ≥ 0');
+
+const priceAmountFieldSchema = z
+  .string()
+  .trim()
+  .refine(
+    (v) => v === '' || (/^\d+(\.\d{1,2})?$/.test(v) && Number(v) > 0),
+    'Price must be a positive number',
+  );
+
+const bulkItemSchema = z.object({
+  variantId: z.string().trim().min(1),
+  label: z.string(),
+  stock: stockFieldSchema,
+  priceAmount: priceAmountFieldSchema,
+});
+
 export const woocommercePublishWizardSchema = z.object({
   status: z.enum(ShopPublishVisibilityValues),
-  // Stock is an integer >= 0. Empty string in bulk mode means "use master
-  // stock" — handled by the optional union below.
-  stock: z
-    .string()
-    .trim()
-    .refine((v) => v === '' || /^\d+$/.test(v), 'Stock must be a whole number ≥ 0'),
-  priceAmount: z
-    .string()
-    .trim()
-    .refine(
-      (v) => v === '' || (/^\d+(\.\d{1,2})?$/.test(v) && Number(v) > 0),
-      'Price must be a positive number',
-    ),
+  // Single-mode only — ignored by the bulk submit path.
+  stock: stockFieldSchema,
+  priceAmount: priceAmountFieldSchema,
   priceCurrency: z.string().trim().min(1),
+  // Bulk-mode only — one row per selected variant, seeded when the operator
+  // finishes picking. Ignored by the single-publish submit path.
+  items: z.array(bulkItemSchema),
 });
 
 export type WoocommercePublishWizardValues = z.input<typeof woocommercePublishWizardSchema>;
 export type WoocommercePublishWizardSubmission = z.output<typeof woocommercePublishWizardSchema>;
+export type WoocommercePublishWizardItem = z.output<typeof bulkItemSchema>;
 
 export const WOOCOMMERCE_PUBLISH_DEFAULT_CURRENCY = 'PLN';
 
@@ -44,6 +60,7 @@ export const WOOCOMMERCE_PUBLISH_SINGLE_DEFAULTS: WoocommercePublishWizardValues
   stock: '0',
   priceAmount: '',
   priceCurrency: WOOCOMMERCE_PUBLISH_DEFAULT_CURRENCY,
+  items: [],
 };
 
 export const WOOCOMMERCE_PUBLISH_BULK_DEFAULTS: WoocommercePublishWizardValues = {
@@ -51,4 +68,5 @@ export const WOOCOMMERCE_PUBLISH_BULK_DEFAULTS: WoocommercePublishWizardValues =
   stock: '',
   priceAmount: '',
   priceCurrency: WOOCOMMERCE_PUBLISH_DEFAULT_CURRENCY,
+  items: [],
 };

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9431,6 +9431,31 @@ html[data-density='compact'] .status-badge {
   white-space: nowrap;
 }
 
+/* Removable chip variant — selection tray + configure-step summary (#1414) */
+.shop-publish-chip--removable {
+  gap: var(--space-1);
+  max-width: 220px;
+}
+.shop-publish-chip--removable span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.shop-publish-chip--removable button {
+  flex: none;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+  line-height: 1;
+  padding: 0 0 0 var(--space-1);
+  border-radius: var(--radius-pill);
+}
+.shop-publish-chip--removable button:hover {
+  color: var(--status-error-fg);
+}
+
 /* Stock + price-override two-column row */
 .shop-publish-field-row {
   display: grid;
@@ -9477,6 +9502,141 @@ html[data-density='compact'] .status-badge {
   border: 1px dashed var(--border-default);
   border-radius: var(--radius-md);
   padding: var(--space-3);
+}
+
+/* ── Publish-to-shop dialog: width, truncation, tray, config table (#1414) ── */
+
+/* Wider than the 520px dialog default — enough room for the config table's
+ * 2-column Stock/Price fields without wrapping, and for real product names
+ * to have space to truncate gracefully instead of overflowing at 520px. */
+.dialog__content--publish {
+  width: min(680px, 94vw);
+  max-height: min(90vh, 800px);
+}
+
+/* Product/variant name truncation in the search picker — names spilled past
+ * the dialog edge and pushed the SKU/EAN column off-canvas before this. */
+.shop-publish-picker {
+  display: grid;
+  gap: var(--space-2);
+}
+.shop-publish-picker__product-name,
+.shop-publish-picker__variant-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.shop-publish-picker__code {
+  flex: none;
+  white-space: nowrap;
+}
+
+/* Selection tray — accumulates checked variants across searches before
+ * "Continue" locks in single vs. bulk mode. */
+.shop-publish-tray {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border-top: 1px solid var(--border-subtle);
+  padding-top: var(--space-3);
+}
+.shop-publish-tray__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.75rem;
+}
+.shop-publish-tray__count {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.shop-publish-tray__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  max-height: 4.5rem;
+  overflow-y: auto;
+}
+.shop-publish-tray__empty-hint {
+  font-size: 0.75rem;
+  font-style: italic;
+  margin: 0;
+}
+
+/* Per-product configure table — stock/price are per-product (#1414), not one
+ * shared field for the whole batch. */
+.shop-publish-config-table {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.shop-publish-config-table__body {
+  max-height: 320px;
+  overflow-y: auto;
+}
+.shop-publish-config-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+}
+.shop-publish-config-row + .shop-publish-config-row {
+  border-top: 1px solid var(--border-subtle);
+}
+.shop-publish-config-row__top {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.shop-publish-config-row__name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+}
+.shop-publish-config-row__remove {
+  flex: none;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+}
+.shop-publish-config-row__remove:hover {
+  color: var(--status-error-fg);
+  background: var(--status-error-soft);
+}
+.shop-publish-config-row__fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+@media (max-width: 480px) {
+  .shop-publish-config-row__fields {
+    grid-template-columns: 1fr;
+  }
+}
+.shop-publish-config-table__foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-shell);
+  border-top: 1px solid var(--border-subtle);
+}
+.shop-publish-config-table__foot-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
 }
 
 /* Review key-value list (also reused by the single tracker) */

--- a/docs/plans/implementation-plan-publish-to-shop-dialog-redesign.md
+++ b/docs/plans/implementation-plan-publish-to-shop-dialog-redesign.md
@@ -1,0 +1,122 @@
+# Implementation Plan: Publish-to-shop dialog redesign (#1414)
+
+## 1. Task
+
+Frontend-only. Fix three UI defects in the "Publish to shop" flow and add real batch
+multi-select from the top-level entry point, per the approved mock
+(https://claude.ai/code/artifact/d14dfe42-6554-4457-a6ce-6800829daf03):
+
+1. Dialog too narrow (520px) → widen.
+2. Product/variant names + SKU overflow instead of truncating.
+3. Picker is single-select (`type="radio"`) with no way to batch-publish from the
+   top-level "Publish to shop" CTA → checkboxes + selection tray.
+4. Configure step: Stock/Price become per-product rows (not one shared field),
+   each with an independent "use master for all" reset, plus a per-row remove.
+
+Non-goals (explicitly out of scope, tracked separately): per-product destination
+category (needs a new BE capability, separate epic).
+
+## 2. Research
+
+- `ShopPublishLauncher.tsx` owns the `<Dialog>` chrome; `WoocommercePublishWizard.tsx`
+  owns the picker + form body. Only the wizard needs picker/form changes;
+  the launcher only needs the wide-dialog class.
+- `.dialog__content--wide` (920px) already exists in `index.css`, used by the KSeF
+  UPO dialog. Publish-to-shop needs something narrower (~680px is enough for a
+  3-column config row) — add a new `.dialog__content--publish` modifier rather
+  than reusing `--wide` verbatim (different target width, same pattern).
+- Existing multi-select precedent: `apps/web/src/pages/products/products-list-page.tsx`
+  uses `CheckboxCell` + `BulkActionBar` (`shared/ui/`). Reuse `BulkActionBar` isn't a
+  fit here (it's a page-level sticky bar); the mock's in-dialog "selection tray"
+  (chips + count + Clear all) is a new small local pattern, not a shared primitive
+  (single consumer today).
+- `woocommerce-publish-wizard.schema.ts` currently has one shared `stock`/`priceAmount`
+  for both modes. Needs a per-item shape for bulk.
+- `resolveVariantIds` currently returns a fixed `ids` array from props; the "remove
+  from batch" action needs a **stateful** selected-id list, not just props passthrough.
+
+## 3. Design
+
+### 3.1 CSS (`apps/web/src/index.css`)
+New section `/* ── Publish-to-shop dialog (#1414) ── */`:
+- `.dialog__content--publish { width: min(680px, 94vw); max-height: min(90vh, 800px); }`
+- `.shop-publish-picker__product-name`, `.shop-publish-picker__variant-name`:
+  `min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap` (+ `title` attr in JSX).
+- `.shop-publish-picker__code` — fixed-width mono column for SKU/EAN (`flex:none`).
+- `.shop-publish-tray`, `.shop-publish-tray__chips`, `.shop-publish-chip` — selection tray
+  (reuses the existing `.shop-publish-chip` class already defined for the read-only bulk
+  chips row — extend it with a remove `<button>` variant, don't duplicate).
+- `.shop-publish-config-row`, `.shop-publish-config-row__fields` — per-product config row
+  (2-line: name+remove, then Stock/Price mini-grid).
+
+### 3.2 Picker → checkbox multi-select (`WoocommercePublishWizard.tsx`)
+- Replace `pickedVariantId: string | null` with `selectedVariants: Map<string, { label, productId }>`
+  (ordered by insertion — `Map` preserves insertion order, matches the tray's expected order).
+- Checkbox `onChange` toggles membership in the map instead of single-picking.
+- Tray renders `Array.from(selectedVariants.entries())` as chips with a remove `×`.
+- `effectiveIds` becomes `ids.length > 0 ? ids : Array.from(selectedVariants.keys())`.
+- Continuing with 1 selected → `mode: 'single'` (unchanged path); 2+ → `mode: 'bulk'`
+  (`resolveVariantIds`'s existing `bulkIds.length > 1` branch already does this once fed
+  the right array — no change needed there, only the *source* of the array changes from
+  "always props" to "props OR local selection").
+- This only applies to the `needsVariantPicker` (top-level entry, no `defaultVariantId(s)`)
+  branch — row-level single/bulk entry points (`defaultVariantId`/`defaultVariantIds` set)
+  are unaffected.
+
+### 3.3 Configure step — per-product Stock/Price (bulk mode)
+- Schema: add `items: { variantId: string; stock: string; priceAmount: string }[]` to
+  `woocommercePublishWizardSchema`, validated with the same per-field rules as today's
+  top-level `stock`/`priceAmount`. Keep the top-level `stock`/`priceAmount` fields for
+  **single** mode (unchanged) — bulk mode ignores them and uses `items` instead.
+- Seed `items` from `effectiveIds` via `useFieldArray` (`control`, `name: 'items'`) when
+  entering bulk mode (on mode transition / mount), one row per variant, `stock: ''`,
+  `priceAmount: ''`, `priceCurrency` stays a single shared field (only stock+price are
+  per-product per the request — currency isn't).
+- Per-row remove button calls `remove(index)` (from `useFieldArray`) — this is the same
+  action as un-checking the variant in the picker, so it should also sync back
+  `selectedVariants` if the operator navigates back (acceptable to leave picker state
+  independent for v1: removing in Configure only removes from the batch being submitted,
+  matching the mock's behavior — no back-sync required, documented as a follow-up if
+  raised in review).
+- Two reset buttons: "Use master stock for all" → `items.forEach((_, i) => setValue(items.${i}.stock, ''))`;
+  same for price. Independent, no "copy row 1" semantics.
+- Submit: `BulkShopPublishRequest` needs per-item stock/price. Check
+  `apps/web/src/features/listings/api/listings.types.ts` — if `BulkShopPublishRequest`
+  is currently `{ connectionId, internalVariantIds, status, stock, price? }` (batch-shared),
+  it needs to become `{ connectionId, status, items: { internalVariantId, stock, price? }[] }`
+  or similar — **this is a BE contract touch-point**, not pure FE. Confirmed in step 4 below.
+
+### 3.4 `ShopPublishLauncher.tsx`
+- Apply `dialog__content--publish` className to `<DialogContent>`.
+
+## 4. Contract check (pre-implement gate focus)
+
+`BulkShopPublishRequest` / the bulk-publish endpoint DTO must be checked before writing
+FE code that assumes per-item stock/price — if the backend only accepts one shared
+stock/price for the whole batch today, per-product overrides need a backend change too
+(new scope, likely its own follow-up issue) OR the FE ships per-row UI but sends the
+*first* row's values / an average, which would misrepresent the feature. This plan
+assumes the check comes back "needs backend change" and scopes accordingly — resolved
+in the pre-implement pass before touching the request-building code.
+
+## 5. Steps
+
+1. `apps/web/src/index.css` — new CSS section (dialog width, truncation, tray, config-row).
+2. `woocommerce-publish-wizard.schema.ts` — add `items` field + defaults; keep single-mode
+   fields unchanged.
+3. `WoocommercePublishWizard.tsx` — checkbox multi-select + tray (picker), `useFieldArray`
+   for the bulk Configure table, two reset actions, remove-row action.
+4. `apps/web/src/features/listings/api/listings.types.ts` + bulk-publish API/mutation —
+   extend `BulkShopPublishRequest` for per-item stock/price (BE contract — flag if this
+   requires a backend PR; if so, ship FE behind the extended contract in the same PR only
+   if the BE change is small and self-contained, otherwise split and note the follow-up).
+5. `WoocommercePublishWizard.test.tsx` — update/add cases: multi-select accumulation,
+   remove chip, per-row independence, two reset actions, submit payload shape.
+6. `ShopPublishLauncher.tsx` — apply the new dialog width class.
+
+## 6. Validation
+
+- `pnpm --filter @openlinker/web exec tsc --noEmit`
+- `pnpm eslint` on changed files
+- `pnpm --filter @openlinker/web exec vitest run` on the wizard + launcher test files
+- Manual check against the mock states (loading/empty/error/results, tray, config table).

--- a/libs/core/src/listings/application/interfaces/bulk-shop-publish-submit.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/bulk-shop-publish-submit.service.interface.ts
@@ -27,9 +27,9 @@ export interface IBulkShopPublishSubmitService {
    *
    * Throws `ConnectionNotFoundException` (→ 404), `ConnectionDisabledException`
    * (→ 409), `CapabilityNotSupportedException` (→ 422) for the connection/capability
-   * cascade, and `EmptyBulkSubmissionException` (→ 400) when `internalVariantIds`
-   * is empty. On partial enqueue failure the batch is marked `failed` best-effort
-   * and the error re-thrown.
+   * cascade, and `EmptyBulkSubmissionException` (→ 400) when `items` is empty. On
+   * partial enqueue failure the batch is marked `failed` best-effort and the
+   * error re-thrown.
    */
   submit(input: BulkShopPublishSubmitInput): Promise<BulkShopPublishSubmitResult>;
 

--- a/libs/core/src/listings/application/services/__tests__/bulk-shop-publish-submit.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/bulk-shop-publish-submit.service.spec.ts
@@ -24,9 +24,11 @@ describe('BulkShopPublishSubmitService', () => {
   const input = {
     connectionId: CONN,
     initiatedBy: USER,
-    internalVariantIds: ['v1', 'v2'],
+    items: [
+      { internalVariantId: 'v1', stock: 3 },
+      { internalVariantId: 'v2', stock: 5 },
+    ],
     status: 'published' as const,
-    stock: 3,
   };
 
   beforeEach(() => {
@@ -58,13 +60,13 @@ describe('BulkShopPublishSubmitService', () => {
   });
 
   it('should reject an empty submission', async () => {
-    await expect(service.submit({ ...input, internalVariantIds: [] })).rejects.toBeInstanceOf(
+    await expect(service.submit({ ...input, items: [] })).rejects.toBeInstanceOf(
       EmptyBulkSubmissionException,
     );
     expect(batchRepo.create).not.toHaveBeenCalled();
   });
 
-  it('should persist the batch, fan out one publish per variant with bulkBatchId, and flip to running', async () => {
+  it('should persist the batch, fan out one publish per variant with bulkBatchId and its own stock, and flip to running', async () => {
     const result = await service.submit(input);
 
     expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(CONN, 'ProductPublisher');
@@ -74,6 +76,9 @@ describe('BulkShopPublishSubmitService', () => {
     expect(enqueue.enqueuePublish).toHaveBeenCalledTimes(2);
     expect(enqueue.enqueuePublish).toHaveBeenCalledWith(
       expect.objectContaining({ internalVariantId: 'v1', bulkBatchId: 'batch-1', stock: 3 }),
+    );
+    expect(enqueue.enqueuePublish).toHaveBeenCalledWith(
+      expect.objectContaining({ internalVariantId: 'v2', bulkBatchId: 'batch-1', stock: 5 }),
     );
     expect(batchRepo.updateStatus).toHaveBeenCalledWith('batch-1', 'running');
     expect(result).toEqual({

--- a/libs/core/src/listings/application/services/bulk-shop-publish-submit.service.ts
+++ b/libs/core/src/listings/application/services/bulk-shop-publish-submit.service.ts
@@ -53,7 +53,7 @@ export class BulkShopPublishSubmitService implements IBulkShopPublishSubmitServi
   ) {}
 
   async submit(input: BulkShopPublishSubmitInput): Promise<BulkShopPublishSubmitResult> {
-    if (input.internalVariantIds.length === 0) {
+    if (input.items.length === 0) {
       throw new EmptyBulkSubmissionException();
     }
 
@@ -66,15 +66,14 @@ export class BulkShopPublishSubmitService implements IBulkShopPublishSubmitServi
 
     // 2. Persist the parent batch. totalCount = fan-out width (no multi-variant
     //    expansion — each submitted id is its own publish; #1042 model is
-    //    variant-keyed).
+    //    variant-keyed). Stock/price are per-item (#1414), so sharedConfig only
+    //    carries what's genuinely shared across every child.
     const batch = await this.bulkBatchRepository.create({
       connectionId: input.connectionId,
       initiatedBy: input.initiatedBy,
-      totalCount: input.internalVariantIds.length,
+      totalCount: input.items.length,
       sharedConfig: {
         status: input.status,
-        stock: input.stock,
-        ...(input.price !== undefined && { price: input.price }),
         ...(input.content !== undefined && { content: input.content }),
       },
     });
@@ -83,21 +82,25 @@ export class BulkShopPublishSubmitService implements IBulkShopPublishSubmitServi
     //    marks the batch failed and re-throws (mirrors BulkListingSubmitService).
     const items: BulkShopPublishItem[] = [];
     try {
-      for (const internalVariantId of input.internalVariantIds) {
+      for (const item of input.items) {
         const { jobId, listingCreationRecord } = await this.enqueue.enqueuePublish({
           connectionId: input.connectionId,
-          internalVariantId,
+          internalVariantId: item.internalVariantId,
           status: input.status,
-          stock: input.stock,
+          stock: item.stock,
           bulkBatchId: batch.id,
-          ...(input.price !== undefined && { price: input.price }),
+          ...(item.price !== undefined && { price: item.price }),
           ...(input.content !== undefined && { content: input.content }),
         });
-        items.push({ internalVariantId, jobId, listingCreationRecordId: listingCreationRecord.id });
+        items.push({
+          internalVariantId: item.internalVariantId,
+          jobId,
+          listingCreationRecordId: listingCreationRecord.id,
+        });
       }
     } catch (error) {
       this.logger.warn(
-        `Bulk publish batch ${batch.id} enqueue failed after ${items.length}/${input.internalVariantIds.length} jobs: ${(error as Error).message}`,
+        `Bulk publish batch ${batch.id} enqueue failed after ${items.length}/${input.items.length} jobs: ${(error as Error).message}`,
       );
       await this.bulkBatchRepository.updateStatus(batch.id, BULK_BATCH_STATUS.Failed);
       throw error;

--- a/libs/core/src/listings/application/types/bulk-shop-publish-submit.types.ts
+++ b/libs/core/src/listings/application/types/bulk-shop-publish-submit.types.ts
@@ -16,19 +16,28 @@ import type {
   PublishProductStatus,
 } from '../../domain/types/product-publish.types';
 
+/**
+ * One child publish within a bulk submission — variant id plus its own stock
+ * and optional price override (#1414: stock/price are per-product, not
+ * batch-shared; a bulk publish is N independent publish decisions that happen
+ * to share a connection, status, and content).
+ */
+export interface BulkShopPublishSubmitItemInput {
+  internalVariantId: string;
+  stock: number;
+  /** Omitted ⇒ this child falls back to its master product's price. */
+  price?: { amount: number; currency: string };
+}
+
 export interface BulkShopPublishSubmitInput {
   /** Target shop connection id. */
   connectionId: string;
   /** Operator user id that submitted the bulk request. */
   initiatedBy: string;
-  /** Internal variant ids to publish — one child publish each. */
-  internalVariantIds: string[];
+  /** One child publish (variant + own stock/price) each. */
+  items: BulkShopPublishSubmitItemInput[];
   /** Shared target publication state applied to every child. */
   status: PublishProductStatus;
-  /** Shared stock applied to every child. */
-  stock: number;
-  /** Optional shared price override; omitted ⇒ each child falls back to its master product. */
-  price?: { amount: number; currency: string };
   /** Optional shared content overrides applied to every child. */
   content?: PublishProductContent;
 }

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -340,6 +340,7 @@ export type { IListingCreationQueryService } from './application/interfaces/list
 export type { IBulkShopPublishSubmitService } from './application/interfaces/bulk-shop-publish-submit.service.interface';
 export type {
   BulkShopPublishSubmitInput,
+  BulkShopPublishSubmitItemInput,
   BulkShopPublishSubmitResult,
   BulkShopPublishItem,
   BulkShopPublishBatchSummary,


### PR DESCRIPTION
## Summary
- Widen the "Publish to shop" dialog (`.dialog__content--publish`, 680px) instead of the shared 520px default that clipped connection names and variant rows.
- Truncate product/variant names with ellipsis + `title` tooltip instead of letting them overflow and push SKU/EAN off-canvas.
- Replace the single-select radio picker with checkbox multi-select + a persistent selection tray (chips, count, remove), so the top-level "Publish to shop" CTA can actually start a batch publish — this was previously unreachable since nothing passed pre-selected variant ids in.
- **Per-product stock/price** (was one shared value for the whole batch): `BulkShopPublishSubmitInput` (core), `BulkPublishProductRequestDto` (API), and the FE Configure step all move to `items: { internalVariantId, stock, price? }[]`. Each product gets its own row with independent "Use master stock/price for all" resets (never copies one row onto the rest).
- Explicitly excludes per-product destination category selection — needs a new `ShopProductManagerPort` sub-capability, tracked as a separate epic.

Closes #1414

Design reference: https://claude.ai/code/artifact/d14dfe42-6554-4457-a6ce-6800829daf03

## Test plan
- [x] `pnpm -r --filter "./libs/**" build` — clean
- [x] `pnpm --filter @openlinker/core exec tsc --noEmit` — clean
- [x] `pnpm --filter @openlinker/api type-check` — clean
- [x] `pnpm --filter @openlinker/worker type-check` — clean
- [x] `pnpm --filter @openlinker/web exec tsc --noEmit` — clean
- [x] `pnpm eslint` on all changed files — clean (2 pre-existing unrelated lint findings confirmed via `git stash` diff, not regressions)
- [x] `check-design-tokens` / `check-cross-context-imports` / `check-service-interfaces` invariants — all pass
- [x] `BulkShopPublishSubmitService` spec — updated + passing (per-item stock assertions)
- [x] `ShopPublishController`/`BulkShopPublishController` spec — updated + passing
- [x] `bulk-shop-publish.int-spec.ts` — updated to the new `items` shape
- [x] `WoocommercePublishWizard.test.tsx` — 7/7 passing, incl. 4 new cases: per-row stock independence, row removal, checkbox multi-select accumulation, tray removal
- [x] `ShopPublishLauncher.test.tsx` — 4/4 passing
- [x] Full `apps/web` vitest run — 2071/2072 passing (1 pre-existing unrelated failure in `settings-page.test.tsx`, confirmed present on `main`)
- [x] Full `libs/core` listings jest run — 350/350 passing
- [x] Full `apps/api` listings jest run — 69/69 passing

No migration needed — `sharedConfig` is an untyped JSONB blob, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)