### PR TITLE
fix(shipping): add locker-size field to the generate-label form

### DIFF
--- a/apps/web/src/features/orders/components/generate-label-form.schema.ts
+++ b/apps/web/src/features/orders/components/generate-label-form.schema.ts
@@ -20,12 +20,24 @@ import { z } from 'zod';
 export const COD_CURRENCY_VALUES = ['PLN', 'EUR', 'RON', 'CZK'] as const;
 export type CodCurrency = (typeof COD_CURRENCY_VALUES)[number];
 
+/**
+ * InPost locker size templates. A paczkomat shipment is described by a locker
+ * size (`parcel.template`), not per-item dimensions — the order carries no
+ * reliable dimensions. The BE adapter rejects a paczkomat shipment without it.
+ */
+export const LOCKER_TEMPLATE_VALUES = ['small', 'medium', 'large'] as const;
+export type LockerTemplate = (typeof LOCKER_TEMPLATE_VALUES)[number];
+
 export const generateLabelSchema = z.object({
   length: z.coerce.number().int().positive('Length must be a positive integer'),
   width: z.coerce.number().int().positive('Width must be a positive integer'),
   height: z.coerce.number().int().positive('Height must be a positive integer'),
   weightGrams: z.coerce.number().int().positive('Weight must be a positive integer'),
   paczkomatId: z.string().trim().optional(),
+  // Locker size for paczkomat shipments (#764 InPost). Optional at the schema
+  // level (courier shipments don't use it); the form defaults it and only
+  // surfaces the picker for the paczkomat flow.
+  lockerTemplate: z.enum(LOCKER_TEMPLATE_VALUES).optional(),
   // Optional cash-on-delivery (operator-supplied, #966). Empty amount ⇒ no COD.
   // COD-incapable carriers ignore it server-side; DPD translates it to the COD
   // service. Amount accepts a decimal string (comma or dot) — normalised at submit.

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -211,6 +211,31 @@ describe('GenerateLabelForm — happy path', () => {
     expect((generateLabel.mock.calls[0][0] as { cod?: unknown }).cod).toBeUndefined();
   });
 
+  it('should send parcel.template (locker size, default medium) for a paczkomat order (#1423)', async () => {
+    const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
+    const apiClient = createMockApiClient({ shipments: { generateLabel } });
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() =>
+      expect(generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parcel: expect.objectContaining({ template: 'medium' }),
+        }),
+      ),
+    );
+  });
+
   it('should send deliveryIntent pickup_point for an order with a pickup point (#979)', async () => {
     const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
     const apiClient = createMockApiClient({ shipments: { generateLabel } });

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -51,6 +51,7 @@ import {
 } from '../../shipments';
 import {
   COD_CURRENCY_VALUES,
+  LOCKER_TEMPLATE_VALUES,
   generateLabelSchema,
   type GenerateLabelFormSubmission,
   type GenerateLabelFormValues,
@@ -172,6 +173,8 @@ export function GenerateLabelForm({
       // Allegro flow: paczkomatId is pre-filled buyer-selected; InPost flow:
       // operator types (picker deferred per plan).
       paczkomatId: snapshot.pickupPoint?.id ?? '',
+      // Locker size — required by the BE for paczkomat shipments (#764).
+      lockerTemplate: 'medium',
       // COD (#966, decision A) — operator-entered at dispatch; not order-sourced.
       codAmount: '',
       codCurrency: 'PLN',
@@ -187,6 +190,7 @@ export function GenerateLabelForm({
   const heightRegister = form.register('height');
   const weightRegister = form.register('weightGrams');
   const paczkomatRegister = form.register('paczkomatId');
+  const lockerTemplateRegister = form.register('lockerTemplate');
   const codAmountRegister = form.register('codAmount');
   const codCurrencyRegister = form.register('codCurrency');
 
@@ -225,6 +229,7 @@ export function GenerateLabelForm({
           width: values.width,
           height: values.height,
           weightGrams: values.weightGrams,
+          template: shippingMethod === 'paczkomat' ? values.lockerTemplate : undefined,
         },
         paczkomatId: values.paczkomatId,
         cod:
@@ -434,6 +439,23 @@ export function GenerateLabelForm({
               aria-readonly={paczkomatIsBuyerSelected ? 'true' : undefined}
               placeholder={paczkomatIsBuyerSelected ? undefined : 'POZ08A'}
             />
+          </FormField>
+        ) : null}
+
+        {shippingMethod === 'paczkomat' ? (
+          <FormField
+            label="Locker size"
+            name="lockerTemplate"
+            description="InPost parcel template — required for a paczkomat shipment."
+            error={form.formState.errors.lockerTemplate?.message}
+          >
+            <Select {...lockerTemplateRegister} aria-label="Locker size">
+              {LOCKER_TEMPLATE_VALUES.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </Select>
           </FormField>
         ) : null}
 

--- a/apps/web/src/features/orders/lib/dispatch-input.test.ts
+++ b/apps/web/src/features/orders/lib/dispatch-input.test.ts
@@ -170,6 +170,28 @@ describe('buildDispatchItem', () => {
     expect(item.recipient.address).toBeUndefined();
   });
 
+  it('forwards the locker-size template when supplied', () => {
+    const item = buildDispatchItem({
+      order: order({ snapshot: PACZKOMAT_SNAPSHOT }),
+      snapshot: parseOrderSnapshot(PACZKOMAT_SNAPSHOT),
+      shippingMethod: 'paczkomat',
+      parcel: { length: 300, width: 200, height: 100, weightGrams: 500, template: 'medium' },
+      paczkomatId: 'POZ08A',
+    });
+    expect(item.parcel.template).toBe('medium');
+  });
+
+  it('omits parcel.template when no locker size is supplied', () => {
+    const item = buildDispatchItem({
+      order: order({ snapshot: PACZKOMAT_SNAPSHOT }),
+      snapshot: parseOrderSnapshot(PACZKOMAT_SNAPSHOT),
+      shippingMethod: 'paczkomat',
+      parcel: { length: 300, width: 200, height: 100, weightGrams: 500 },
+      paczkomatId: 'POZ08A',
+    });
+    expect(item.parcel.template).toBeUndefined();
+  });
+
   it('normalises a comma decimal in the COD amount', () => {
     const item = buildDispatchItem({
       order: order({ snapshot: COURIER_SNAPSHOT }),

--- a/apps/web/src/features/orders/lib/dispatch-input.ts
+++ b/apps/web/src/features/orders/lib/dispatch-input.ts
@@ -91,6 +91,9 @@ export interface DispatchParcel {
   width: number;
   height: number;
   weightGrams: number;
+  /** Locker size code for paczkomat shipments (InPost `small|medium|large`).
+   *  Required by the BE for a paczkomat shipment; absent for courier. */
+  template?: string;
 }
 
 /**
@@ -137,6 +140,9 @@ export function buildDispatchItem(args: {
       address,
     },
     parcel: {
+      // Locker size is authoritative for paczkomat shipments; dimensions are
+      // carried too but ignored by locker adapters.
+      ...(parcel.template ? { template: parcel.template } : {}),
       dimensions: { length: parcel.length, width: parcel.width, height: parcel.height },
       weightGrams: parcel.weightGrams,
     },


### PR DESCRIPTION
## What & why

Generating an InPost paczkomat label always failed at ShipX with HTTP 502 and `parcel.template (locker size) is required for a paczkomat shipment`. The InPost adapter's `buildLockerRequest` requires `cmd.parcel.template`, and the neutral `ShipmentParcel.template` / `GenerateLabelInput.parcel.template` contracts already existed - but the Generate-label form only collected dimensions + weight and never a locker size, so `parcel.template` was always undefined and every paczkomat dispatch was dead on arrival.

Verified end-to-end against the InPost ShipX sandbox: with a locker size supplied, the same order dispatches (`status: confirmed`, offer bought) and produces a real label PDF.

## Changes (frontend-only - BE contract already carries the field)

- `generate-label-form.schema.ts` - add `lockerTemplate` (`small | medium | large`) with a runtime `LOCKER_TEMPLATE_VALUES` const (follows the existing `COD_CURRENCY_VALUES` as-const pattern).
- `generate-label-form.tsx` - render a locker-size selector, shown only for the paczkomat method (mirrors the paczkomat-only `paczkomatId` field), default `medium`.
- `lib/dispatch-input.ts` - thread it through `buildDispatchItem` into `parcel.template`, so the single-order form and the bulk dispatch dialog stay identical.
- Tests: form sends `parcel.template` for a paczkomat order; `buildDispatchItem` forwards / omits the template correctly.

## Quality gate

- `eslint` (changed files): 0 errors
- `tsc --noEmit` (apps/web): pass
- `vitest` (orders feature): 39 pass

Closes #1423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
