### PR TITLE
feat(shipping): redesign the order-detail shipment panel across all states

### DIFF
--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -179,6 +179,8 @@ describe('GenerateLabelForm — happy path', () => {
     fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
     fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
     fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+    // COD is behind a checkbox (#1425) — reveal the amount input first.
+    fireEvent.click(screen.getByLabelText(/^Cash on delivery$/i));
     // Comma decimal separator → normalised to a dot for the wire shape.
     fireEvent.change(screen.getByLabelText(/COD amount to collect/i), { target: { value: '129,90' } });
 
@@ -231,6 +233,36 @@ describe('GenerateLabelForm — happy path', () => {
       expect(generateLabel).toHaveBeenCalledWith(
         expect.objectContaining({
           parcel: expect.objectContaining({ template: 'medium' }),
+        }),
+      ),
+    );
+  });
+
+  it('should send the selected locker size via the segmented control (#1425)', async () => {
+    const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
+    const apiClient = createMockApiClient({ shipments: { generateLabel } });
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+
+    // Segmented control: pick "large" (was defaulted to medium).
+    const large = screen.getByRole('button', { name: /large/i });
+    fireEvent.click(large);
+    expect(large).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() =>
+      expect(generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parcel: expect.objectContaining({ template: 'large' }),
         }),
       ),
     );

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -253,9 +253,9 @@ describe('GenerateLabelForm — happy path', () => {
     fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
 
     // Segmented control: pick "large" (was defaulted to medium).
-    const large = screen.getByRole('button', { name: /large/i });
+    const large = screen.getByRole('radio', { name: /large/i });
     fireEvent.click(large);
-    expect(large).toHaveAttribute('aria-pressed', 'true');
+    expect(large).toHaveAttribute('aria-checked', 'true');
 
     fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
 

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -55,6 +55,7 @@ import {
   generateLabelSchema,
   type GenerateLabelFormSubmission,
   type GenerateLabelFormValues,
+  type LockerTemplate,
 } from './generate-label-form.schema';
 import {
   buildDispatchItem,
@@ -74,6 +75,17 @@ interface GenerateLabelFormProps {
 }
 
 const SLOW_NOTICE_DELAY_MS = 5_000;
+
+/**
+ * InPost gabaryt (size class) shown as a subtle hint on each locker-size option
+ * (#1425). Small → A, Medium → B, Large → C — the operator-facing shorthand
+ * InPost prints on the locker doors.
+ */
+const LOCKER_TEMPLATE_GABARYT: Record<LockerTemplate, string> = {
+  small: 'A',
+  medium: 'B',
+  large: 'C',
+};
 
 /**
  * Window during which a missing Allegro pickup-point is considered "still
@@ -190,14 +202,22 @@ export function GenerateLabelForm({
   const heightRegister = form.register('height');
   const weightRegister = form.register('weightGrams');
   const paczkomatRegister = form.register('paczkomatId');
-  const lockerTemplateRegister = form.register('lockerTemplate');
   const codAmountRegister = form.register('codAmount');
   const codCurrencyRegister = form.register('codCurrency');
+  // Locker size is driven imperatively via a segmented control (#1425) — keep
+  // the field registered so RHF tracks it, but bind the pressed state through
+  // `watch` + `setValue` rather than spreading a native-input registration.
+  form.register('lockerTemplate');
+  const lockerTemplate = form.watch('lockerTemplate');
 
   // COD orders are flagged by the snapshot's payment status (#928). The COD
   // amount itself isn't persisted (decision A) — the operator enters what to
   // collect here at dispatch.
   const isCodOrder = snapshot.paymentStatus === 'cod';
+  // COD is revealed behind a checkbox (#1425). Pre-checked when the source
+  // order is already flagged cash-on-delivery, otherwise off (prepaid default).
+  const [codEnabled, setCodEnabled] = useState(isCodOrder);
+  const codFieldId = useId();
 
   // Focus first input on mount (a11y — focus enters the inline expansion).
   const firstInputRef = useRef<HTMLInputElement | null>(null);
@@ -233,7 +253,7 @@ export function GenerateLabelForm({
         },
         paczkomatId: values.paczkomatId,
         cod:
-          values.codAmount && values.codAmount.length > 0
+          codEnabled && values.codAmount && values.codAmount.length > 0
             ? { amount: values.codAmount, currency: values.codCurrency ?? 'PLN' }
             : undefined,
       }),
@@ -442,50 +462,98 @@ export function GenerateLabelForm({
           </FormField>
         ) : null}
 
+        {/* Locker size (#1425) — segmented control replacing the Select. Multi
+            child, so it renders the `.form-field` markup directly (like the
+            dimensions composite) rather than through FormField, which clones a
+            single control child. Labelled by the visible label + the group's
+            aria-label; driven imperatively via `setValue`. */}
         {shippingMethod === 'paczkomat' ? (
-          <FormField
-            label="Locker size"
-            name="lockerTemplate"
-            description="InPost parcel template — required for a paczkomat shipment."
-            error={form.formState.errors.lockerTemplate?.message}
-          >
-            <Select {...lockerTemplateRegister} aria-label="Locker size">
-              {LOCKER_TEMPLATE_VALUES.map((t) => (
-                <option key={t} value={t}>
-                  {t}
-                </option>
-              ))}
-            </Select>
-          </FormField>
+          <div className="form-field">
+            <span className="form-field__label">Locker size</span>
+            <p className="form-field__description">
+              InPost parcel template — required for a paczkomat shipment.
+            </p>
+            <div className="segmented-control" role="group" aria-label="Locker size">
+              {LOCKER_TEMPLATE_VALUES.map((t) => {
+                const active = lockerTemplate === t;
+                return (
+                  <button
+                    key={t}
+                    type="button"
+                    className={[
+                      'segmented-control__option',
+                      active ? 'segmented-control__option--active' : '',
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
+                    aria-pressed={active}
+                    onClick={() =>
+                      form.setValue('lockerTemplate', t, { shouldValidate: true })
+                    }
+                  >
+                    <span className="segmented-control__label">{t}</span>
+                    <span className="segmented-control__hint" aria-hidden="true">
+                      {LOCKER_TEMPLATE_GABARYT[t]}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+            <FieldError
+              id="lockerTemplate-error"
+              message={form.formState.errors.lockerTemplate?.message}
+            />
+          </div>
         ) : null}
 
-        {/* Cash on delivery (#966, decision A) — optional, operator-entered.
-            COD-incapable carriers ignore it; DPD translates it to its COD
-            service. Pre-flagged when the order's payment status is COD. */}
+        {/* Cash on delivery (#966, decision A / #1425) — behind a checkbox. The
+            amount + currency reveal only when it's checked; unchecked submits
+            no COD (same as a blank amount). COD-incapable carriers ignore it;
+            DPD translates it to its COD service. Pre-checked when the order's
+            payment status is COD. */}
         <div className="form-field">
-          <p className="form-field__label">Cash on delivery (optional)</p>
+          <label className="generate-label-form__cod-toggle" htmlFor={codFieldId}>
+            <input
+              id={codFieldId}
+              type="checkbox"
+              checked={codEnabled}
+              onChange={(e) => {
+                const enabled = e.target.checked;
+                setCodEnabled(enabled);
+                if (!enabled) {
+                  // Drop any typed amount so the payload can't carry stale COD.
+                  form.setValue('codAmount', '', { shouldValidate: true });
+                }
+              }}
+            />
+            Cash on delivery
+          </label>
           <p className="form-field__description">
             {isCodOrder
               ? 'This order is cash-on-delivery — enter the amount to collect at the door.'
-              : 'Amount to collect on delivery. Leave blank for a prepaid shipment.'}
+              : 'Collect payment when the buyer picks up. Off means a prepaid shipment.'}
           </p>
-          <div className="generate-label-form__cod">
-            <Input
-              {...codAmountRegister}
-              inputMode="decimal"
-              placeholder="129.90"
-              aria-label="COD amount to collect"
-              invalid={Boolean(form.formState.errors.codAmount)}
-            />
-            <Select {...codCurrencyRegister} aria-label="COD currency">
-              {COD_CURRENCY_VALUES.map((c) => (
-                <option key={c} value={c}>
-                  {c}
-                </option>
-              ))}
-            </Select>
-          </div>
-          <FieldError id="cod-error" message={form.formState.errors.codAmount?.message} />
+          {codEnabled ? (
+            <>
+              <div className="generate-label-form__cod">
+                <Input
+                  {...codAmountRegister}
+                  inputMode="decimal"
+                  placeholder="129.90"
+                  aria-label="COD amount to collect"
+                  invalid={Boolean(form.formState.errors.codAmount)}
+                />
+                <Select {...codCurrencyRegister} aria-label="COD currency">
+                  {COD_CURRENCY_VALUES.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+              <FieldError id="cod-error" message={form.formState.errors.codAmount?.message} />
+            </>
+          ) : null}
         </div>
 
         {showSlowNotice ? (

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -35,6 +35,7 @@ import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { KeyValueList, type KeyValueItem } from '../../../shared/ui/key-value-list';
+import { SegmentedControl } from '../../../shared/ui/segmented-control';
 import { Select } from '../../../shared/ui/select';
 import { useToast } from '../../../shared/ui/toast-provider';
 
@@ -204,10 +205,11 @@ export function GenerateLabelForm({
   const paczkomatRegister = form.register('paczkomatId');
   const codAmountRegister = form.register('codAmount');
   const codCurrencyRegister = form.register('codCurrency');
-  // Locker size is driven imperatively via a segmented control (#1425) — keep
-  // the field registered so RHF tracks it, but bind the pressed state through
-  // `watch` + `setValue` rather than spreading a native-input registration.
-  form.register('lockerTemplate');
+  // Locker size is driven imperatively via a segmented control (#1425). The
+  // registration is bound to a hidden input at the control (so RHF holds a real
+  // ref and tracks the field); the pressed state is set via `setValue` and read
+  // via `watch`.
+  const lockerTemplateRegister = form.register('lockerTemplate');
   const lockerTemplate = form.watch('lockerTemplate');
 
   // COD orders are flagged by the snapshot's payment status (#928). The COD
@@ -462,43 +464,35 @@ export function GenerateLabelForm({
           </FormField>
         ) : null}
 
-        {/* Locker size (#1425) — segmented control replacing the Select. Multi
-            child, so it renders the `.form-field` markup directly (like the
-            dimensions composite) rather than through FormField, which clones a
-            single control child. Labelled by the visible label + the group's
-            aria-label; driven imperatively via `setValue`. */}
+        {/* Locker size (#1425) — the shared SegmentedControl replacing the
+            Select. Multi-child, so it renders the `.form-field` markup directly
+            (like the dimensions composite) rather than through FormField, which
+            clones a single control child. The group is labelled by aria-label
+            and wired to its description + error via aria-describedby /
+            aria-errormessage; driven imperatively via `setValue`, with a hidden
+            registered input keeping the field tracked by RHF. */}
         {shippingMethod === 'paczkomat' ? (
           <div className="form-field">
             <span className="form-field__label">Locker size</span>
-            <p className="form-field__description">
+            <p className="form-field__description" id="lockerTemplate-description">
               InPost parcel template — required for a paczkomat shipment.
             </p>
-            <div className="segmented-control" role="group" aria-label="Locker size">
-              {LOCKER_TEMPLATE_VALUES.map((t) => {
-                const active = lockerTemplate === t;
-                return (
-                  <button
-                    key={t}
-                    type="button"
-                    className={[
-                      'segmented-control__option',
-                      active ? 'segmented-control__option--active' : '',
-                    ]
-                      .filter(Boolean)
-                      .join(' ')}
-                    aria-pressed={active}
-                    onClick={() =>
-                      form.setValue('lockerTemplate', t, { shouldValidate: true })
-                    }
-                  >
-                    <span className="segmented-control__label">{t}</span>
-                    <span className="segmented-control__hint" aria-hidden="true">
-                      {LOCKER_TEMPLATE_GABARYT[t]}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
+            <SegmentedControl
+              aria-label="Locker size"
+              aria-describedby="lockerTemplate-description"
+              aria-invalid={form.formState.errors.lockerTemplate ? true : undefined}
+              aria-errormessage={
+                form.formState.errors.lockerTemplate ? 'lockerTemplate-error' : undefined
+              }
+              value={lockerTemplate ?? 'medium'}
+              onChange={(t) => form.setValue('lockerTemplate', t, { shouldValidate: true })}
+              options={LOCKER_TEMPLATE_VALUES.map((t) => ({
+                value: t,
+                label: t,
+                hint: LOCKER_TEMPLATE_GABARYT[t],
+              }))}
+            />
+            <input type="hidden" {...lockerTemplateRegister} />
             <FieldError
               id="lockerTemplate-error"
               message={form.formState.errors.lockerTemplate?.message}

--- a/apps/web/src/features/orders/components/order-shipment-panel.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.tsx
@@ -29,6 +29,7 @@ import type { OrderRecord } from '../api/orders.types';
 import { parseOrderSnapshot, type PaymentStatus } from '../api/order-snapshot.schema';
 import { GenerateLabelForm } from './generate-label-form';
 import { ShipmentActionButtons } from './shipment-action-buttons';
+import { ShipmentLifecycleRail } from './shipment-lifecycle-rail';
 import { ShipmentTrackingLink } from './shipment-tracking-link';
 
 const SHIPPING_CAPABILITY = 'ShippingProviderManager';
@@ -108,12 +109,20 @@ export function OrderShipmentPanel({ order }: OrderShipmentPanelProps): ReactEle
           }
         />
       ) : activeShipment ? (
-        <OrderShipmentPanelBody
-          shipment={activeShipment}
-          shippingPlatformType={shippingConnection?.platformType ?? null}
-          paymentStatus={paymentStatus}
-          mutationError={null /* surfaced via the action-buttons own state */}
-        />
+        <>
+          {/* Lifecycle rail (#1425) — between the header and the facts. Skipped
+              for destination-fulfilled (OMP) shipments, which carry no OL
+              dispatch lifecycle. */}
+          {activeShipment.shippingMethod !== 'omp' ? (
+            <ShipmentLifecycleRail status={activeShipment.status} />
+          ) : null}
+          <OrderShipmentPanelBody
+            shipment={activeShipment}
+            shippingPlatformType={shippingConnection?.platformType ?? null}
+            paymentStatus={paymentStatus}
+            mutationError={null /* surfaced via the action-buttons own state */}
+          />
+        </>
       ) : formOpen ? null : (
         <EmptyState
           title="No shipment yet"

--- a/apps/web/src/features/orders/components/shipment-lifecycle-rail.test.tsx
+++ b/apps/web/src/features/orders/components/shipment-lifecycle-rail.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * ShipmentLifecycleRail — component tests (#1425)
+ *
+ * Covers the stage sequence, the current-node mapping per status, and the
+ * interrupted (failed / cancelled) variants.
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+
+import { ShipmentLifecycleRail } from './shipment-lifecycle-rail';
+import type { ShipmentStatus } from '../../shipments';
+
+afterEach(cleanup);
+
+describe('ShipmentLifecycleRail', () => {
+  it('should render four lifecycle stages', () => {
+    render(<ShipmentLifecycleRail status="generated" />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(4);
+    expect(screen.getByText('Label ready')).toBeInTheDocument();
+    expect(screen.getByText('Dispatched')).toBeInTheDocument();
+    expect(screen.getByText('In transit')).toBeInTheDocument();
+    expect(screen.getByText('Delivered')).toBeInTheDocument();
+  });
+
+  it('should mark the dispatch stage current for a dispatched shipment', () => {
+    render(<ShipmentLifecycleRail status="dispatched" />);
+    const steps = screen.getAllByRole('listitem');
+    expect(steps[0]).toHaveClass('shipment-lifecycle-rail__step--done');
+    expect(steps[1]).toHaveClass('shipment-lifecycle-rail__step--current');
+    expect(steps[1]).toHaveAttribute('aria-current', 'step');
+    expect(steps[1]).toHaveClass('shipment-lifecycle-rail__step--live');
+  });
+
+  it('should mark the delivered stage as both current and done, and not live', () => {
+    render(<ShipmentLifecycleRail status="delivered" />);
+    const steps = screen.getAllByRole('listitem');
+    expect(steps[3]).toHaveClass('shipment-lifecycle-rail__step--current');
+    expect(steps[3]).toHaveClass('shipment-lifecycle-rail__step--done');
+    expect(steps[3]).not.toHaveClass('shipment-lifecycle-rail__step--live');
+  });
+
+  it('should render the interrupted (halted) variant for a failed shipment', () => {
+    const { container } = render(<ShipmentLifecycleRail status="failed" />);
+    expect(container.querySelector('.shipment-lifecycle-rail--halted')).not.toBeNull();
+    expect(screen.getByText('Dispatch failed')).toBeInTheDocument();
+    const steps = screen.getAllByRole('listitem');
+    expect(steps[1]).toHaveClass('shipment-lifecycle-rail__step--halt');
+  });
+
+  it('should render the cancelled variant with a muted halt node', () => {
+    const { container } = render(<ShipmentLifecycleRail status="cancelled" />);
+    expect(container.querySelector('.shipment-lifecycle-rail--cancelled')).not.toBeNull();
+    expect(screen.getByText('Cancelled')).toBeInTheDocument();
+    const steps = screen.getAllByRole('listitem');
+    expect(steps[1]).toHaveClass('shipment-lifecycle-rail__step--halt');
+  });
+
+  it('should handle every shipment status without throwing', () => {
+    const statuses: ShipmentStatus[] = [
+      'draft',
+      'generated',
+      'dispatched',
+      'in-transit',
+      'delivered',
+      'failed',
+      'cancelled',
+    ];
+    for (const status of statuses) {
+      const { unmount } = render(<ShipmentLifecycleRail status={status} />);
+      expect(screen.getAllByRole('listitem')).toHaveLength(4);
+      unmount();
+    }
+  });
+});

--- a/apps/web/src/features/orders/components/shipment-lifecycle-rail.test.tsx
+++ b/apps/web/src/features/orders/components/shipment-lifecycle-rail.test.tsx
@@ -39,12 +39,18 @@ describe('ShipmentLifecycleRail', () => {
     expect(steps[3]).not.toHaveClass('shipment-lifecycle-rail__step--live');
   });
 
-  it('should render the interrupted (halted) variant for a failed shipment', () => {
+  it('should halt a failed shipment at the label stage and leave no stage falsely completed', () => {
     const { container } = render(<ShipmentLifecycleRail status="failed" />);
     expect(container.querySelector('.shipment-lifecycle-rail--halted')).not.toBeNull();
-    expect(screen.getByText('Dispatch failed')).toBeInTheDocument();
+    expect(screen.getByText('Label failed')).toBeInTheDocument();
+    expect(screen.queryByText('Label ready')).not.toBeInTheDocument();
     const steps = screen.getAllByRole('listitem');
-    expect(steps[1]).toHaveClass('shipment-lifecycle-rail__step--halt');
+    // The halt sits at the label stage; no earlier stage is painted as a
+    // completed success, and later stages stay upcoming.
+    expect(steps[0]).toHaveClass('shipment-lifecycle-rail__step--halt');
+    expect(steps.some((step) => step.classList.contains('shipment-lifecycle-rail__step--done'))).toBe(
+      false,
+    );
   });
 
   it('should render the cancelled variant with a muted halt node', () => {

--- a/apps/web/src/features/orders/components/shipment-lifecycle-rail.tsx
+++ b/apps/web/src/features/orders/components/shipment-lifecycle-rail.tsx
@@ -4,8 +4,11 @@
  * Horizontal 4-stage tracker for the order-detail shipment panel:
  * Label ready → Dispatched → In transit → Delivered. Mirrors the buyer-side
  * tracker the marketplace already shows. Maps a persisted `ShipmentStatus`
- * onto the stage sequence; terminal-exception statuses (`failed` / `cancelled`)
- * render an interrupted rail whose halt node sits at the dispatch stage.
+ * onto the stage sequence; terminal-exception statuses render an interrupted
+ * rail whose halt node sits at the stage where progress actually stopped —
+ * `failed` at the label stage (an InPost `failed` is overwhelmingly a
+ * label-generation failure, so no later stage is ever falsely shown complete),
+ * `cancelled` at the dispatch stage (a cancellation presupposes a ready label).
  *
  * Presentational only — no data fetching. Status colour is semantic; the accent
  * is reserved for the current live node.
@@ -19,9 +22,12 @@ import type { ShipmentStatus } from '../../shipments';
 const STAGE_LABELS = ['Label ready', 'Dispatched', 'In transit', 'Delivered'] as const;
 
 /**
- * The stage index each status "lives" at. Terminal-exception statuses halt at
- * the dispatch stage (index 1) — the furthest point a shipment reaches before
- * an operator/carrier rejection or cancellation.
+ * The stage index each status halts / lives at. A halt node must never leave an
+ * earlier stage painted as a completed success (`index < current` renders as
+ * `done`), so each terminal-exception status halts at the stage where progress
+ * actually stopped: `failed` at the label stage (index 0 — label generation is
+ * the dominant InPost failure mode), `cancelled` at the dispatch stage (index 1
+ * — the label was ready before the cancellation).
  */
 const STAGE_INDEX: Record<ShipmentStatus, number> = {
   draft: 0,
@@ -29,7 +35,7 @@ const STAGE_INDEX: Record<ShipmentStatus, number> = {
   dispatched: 1,
   'in-transit': 2,
   delivered: 3,
-  failed: 1,
+  failed: 0,
   cancelled: 1,
 };
 
@@ -56,7 +62,7 @@ interface ShipmentLifecycleRailProps {
 function buildStages(status: ShipmentStatus): RailStage[] {
   const current = STAGE_INDEX[status];
   const halted = status === 'failed' || status === 'cancelled';
-  const haltLabel = status === 'failed' ? 'Dispatch failed' : 'Cancelled';
+  const haltLabel = status === 'failed' ? 'Label failed' : 'Cancelled';
 
   return STAGE_LABELS.map((label, index): RailStage => {
     if (index < current) {

--- a/apps/web/src/features/orders/components/shipment-lifecycle-rail.tsx
+++ b/apps/web/src/features/orders/components/shipment-lifecycle-rail.tsx
@@ -1,0 +1,124 @@
+/**
+ * Shipment Lifecycle Rail (#1425)
+ *
+ * Horizontal 4-stage tracker for the order-detail shipment panel:
+ * Label ready → Dispatched → In transit → Delivered. Mirrors the buyer-side
+ * tracker the marketplace already shows. Maps a persisted `ShipmentStatus`
+ * onto the stage sequence; terminal-exception statuses (`failed` / `cancelled`)
+ * render an interrupted rail whose halt node sits at the dispatch stage.
+ *
+ * Presentational only — no data fetching. Status colour is semantic; the accent
+ * is reserved for the current live node.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import type { ReactElement } from 'react';
+
+import type { ShipmentStatus } from '../../shipments';
+
+const STAGE_LABELS = ['Label ready', 'Dispatched', 'In transit', 'Delivered'] as const;
+
+/**
+ * The stage index each status "lives" at. Terminal-exception statuses halt at
+ * the dispatch stage (index 1) — the furthest point a shipment reaches before
+ * an operator/carrier rejection or cancellation.
+ */
+const STAGE_INDEX: Record<ShipmentStatus, number> = {
+  draft: 0,
+  generated: 0,
+  dispatched: 1,
+  'in-transit': 2,
+  delivered: 3,
+  failed: 1,
+  cancelled: 1,
+};
+
+/** Non-terminal statuses whose current node gently pulses (guarded by reduced-motion). */
+const LIVE_STATUSES: ReadonlySet<ShipmentStatus> = new Set<ShipmentStatus>([
+  'draft',
+  'generated',
+  'dispatched',
+  'in-transit',
+]);
+
+type StageState = 'done' | 'current' | 'upcoming' | 'halt';
+
+interface RailStage {
+  label: string;
+  state: StageState;
+  live: boolean;
+}
+
+interface ShipmentLifecycleRailProps {
+  status: ShipmentStatus;
+}
+
+function buildStages(status: ShipmentStatus): RailStage[] {
+  const current = STAGE_INDEX[status];
+  const halted = status === 'failed' || status === 'cancelled';
+  const haltLabel = status === 'failed' ? 'Dispatch failed' : 'Cancelled';
+
+  return STAGE_LABELS.map((label, index): RailStage => {
+    if (index < current) {
+      return { label, state: 'done', live: false };
+    }
+    if (index === current) {
+      if (halted) {
+        return { label: haltLabel, state: 'halt', live: false };
+      }
+      // `delivered` is the terminal success node: current + done, never live.
+      return { label, state: 'current', live: LIVE_STATUSES.has(status) };
+    }
+    return { label, state: 'upcoming', live: false };
+  });
+}
+
+const STATE_MODIFIER: Record<StageState, string> = {
+  done: 'shipment-lifecycle-rail__step--done',
+  current: 'shipment-lifecycle-rail__step--current',
+  upcoming: '',
+  halt: 'shipment-lifecycle-rail__step--halt shipment-lifecycle-rail__step--current',
+};
+
+export function ShipmentLifecycleRail({ status }: ShipmentLifecycleRailProps): ReactElement {
+  const stages = buildStages(status);
+  const delivered = status === 'delivered';
+
+  const rootClasses = [
+    'shipment-lifecycle-rail',
+    status === 'failed' ? 'shipment-lifecycle-rail--halted' : '',
+    status === 'cancelled' ? 'shipment-lifecycle-rail--cancelled' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <ol className={rootClasses} aria-label="Shipment lifecycle">
+      {stages.map((stage, index) => {
+        const doneModifier =
+          stage.state === 'done' || (delivered && stage.state === 'current')
+            ? 'shipment-lifecycle-rail__step--done'
+            : '';
+        const stepClasses = [
+          'shipment-lifecycle-rail__step',
+          STATE_MODIFIER[stage.state],
+          doneModifier,
+          stage.live ? 'shipment-lifecycle-rail__step--live' : '',
+        ]
+          .filter(Boolean)
+          .join(' ');
+
+        return (
+          <li
+            key={index}
+            className={stepClasses}
+            aria-current={stage.state === 'current' || stage.state === 'halt' ? 'step' : undefined}
+          >
+            <span className="shipment-lifecycle-rail__node" aria-hidden="true" />
+            <span className="shipment-lifecycle-rail__label">{stage.label}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9201,7 +9201,7 @@ html[data-density='compact'] .status-badge {
   font-weight: 600;
 }
 
-/* Segmented locker-size control (replaces the Select). */
+/* Segmented control — shared SegmentedControl primitive (shared/ui). */
 .segmented-control {
   display: inline-flex;
   align-self: flex-start;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9034,6 +9034,259 @@ html[data-density='compact'] .status-badge {
   }
 }
 
+/* ── Shipment lifecycle redesign (#1425) ────────────────────────────────────
+ * Signature lifecycle rail for the order-detail shipment panel + the
+ * segmented locker-size control and checkbox-gated COD reveal in the
+ * generate-label form. Token-only: status hues carry lifecycle meaning; the
+ * signal-orange accent is reserved for the current live node, the pressed
+ * segment, and focus rings.
+ */
+
+/* Lifecycle rail — 4 stages: Label ready → Dispatched → In transit → Delivered */
+.shipment-lifecycle-rail {
+  display: flex;
+  align-items: flex-start;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.shipment-lifecycle-rail__step {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  text-align: center;
+}
+
+/* Connectors: two half-width rules per step so each leg can be tinted by the
+   step that owns it (incoming ::before, outgoing ::after). */
+.shipment-lifecycle-rail__step::before,
+.shipment-lifecycle-rail__step::after {
+  content: '';
+  position: absolute;
+  top: 8px;
+  height: 2px;
+  background: var(--border-default);
+}
+
+.shipment-lifecycle-rail__step::before {
+  left: 0;
+  right: 50%;
+}
+
+.shipment-lifecycle-rail__step::after {
+  left: 50%;
+  right: 0;
+}
+
+.shipment-lifecycle-rail__step:first-child::before,
+.shipment-lifecycle-rail__step:last-child::after {
+  display: none;
+}
+
+.shipment-lifecycle-rail__node {
+  position: relative;
+  z-index: 1;
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  border: 2px solid var(--border-default);
+}
+
+.shipment-lifecycle-rail__label {
+  font-size: 0.75rem;
+  line-height: 1.3;
+  color: var(--text-muted);
+}
+
+/* Done: filled success node + solid success connectors. */
+.shipment-lifecycle-rail__step--done .shipment-lifecycle-rail__node {
+  background: var(--status-success-fg);
+  border-color: var(--status-success-fg);
+}
+
+.shipment-lifecycle-rail__step--done::before,
+.shipment-lifecycle-rail__step--done::after {
+  background: var(--status-success-fg);
+}
+
+.shipment-lifecycle-rail__step--done .shipment-lifecycle-rail__label {
+  color: var(--text-secondary);
+}
+
+/* Current (in-flight): accent node + emphasised label; the incoming leg reads
+   as completed. Excludes the terminal-delivered (also --done) and halt cases. */
+.shipment-lifecycle-rail__step--current:not(.shipment-lifecycle-rail__step--done):not(.shipment-lifecycle-rail__step--halt)::before {
+  background: var(--status-success-fg);
+}
+
+.shipment-lifecycle-rail__step--current:not(.shipment-lifecycle-rail__step--done):not(.shipment-lifecycle-rail__step--halt)
+  .shipment-lifecycle-rail__node {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 4px var(--accent-primary-soft);
+}
+
+.shipment-lifecycle-rail__step--current .shipment-lifecycle-rail__label {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* Terminal delivered: success fill (done) kept, with an accent ring so the node
+   still reads as "you are here". */
+.shipment-lifecycle-rail__step--current.shipment-lifecycle-rail__step--done
+  .shipment-lifecycle-rail__node {
+  box-shadow: 0 0 0 4px var(--accent-primary-soft);
+}
+
+/* Live pulse on a non-terminal current node. */
+.shipment-lifecycle-rail__step--current.shipment-lifecycle-rail__step--live
+  .shipment-lifecycle-rail__node {
+  animation: shipment-lifecycle-rail-pulse 1.8s var(--ease-in-out) infinite;
+}
+
+@keyframes shipment-lifecycle-rail-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 3px var(--accent-primary-soft);
+  }
+  50% {
+    box-shadow: 0 0 0 6px transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shipment-lifecycle-rail__step--live .shipment-lifecycle-rail__node {
+    animation: none;
+  }
+}
+
+/* Interrupted rail — failed: error-tinted halt node at the dispatch stage. */
+.shipment-lifecycle-rail--halted .shipment-lifecycle-rail__step--halt .shipment-lifecycle-rail__node {
+  background: var(--status-error-soft);
+  border-color: var(--status-error-fg);
+}
+
+.shipment-lifecycle-rail--halted .shipment-lifecycle-rail__step--halt::before {
+  background: var(--status-error-fg);
+}
+
+.shipment-lifecycle-rail--halted .shipment-lifecycle-rail__step--halt .shipment-lifecycle-rail__label {
+  color: var(--status-error-fg);
+  font-weight: 600;
+}
+
+/* Interrupted rail — cancelled: dashed, muted halt node. */
+.shipment-lifecycle-rail--cancelled
+  .shipment-lifecycle-rail__step--halt
+  .shipment-lifecycle-rail__node {
+  background: var(--status-disabled-soft);
+  border-color: var(--status-disabled-fg);
+  border-style: dashed;
+}
+
+.shipment-lifecycle-rail--cancelled .shipment-lifecycle-rail__step--halt::before {
+  background: var(--status-disabled-border);
+}
+
+.shipment-lifecycle-rail--cancelled
+  .shipment-lifecycle-rail__step--halt
+  .shipment-lifecycle-rail__label {
+  color: var(--status-disabled-fg);
+  font-weight: 600;
+}
+
+/* Segmented locker-size control (replaces the Select). */
+.segmented-control {
+  display: inline-flex;
+  align-self: flex-start;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+}
+
+.segmented-control__option {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  position: relative;
+  padding: var(--space-2) var(--space-3);
+  border: none;
+  border-right: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 0.8125rem;
+  text-transform: capitalize;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.segmented-control__option:first-child {
+  border-top-left-radius: var(--radius-md);
+  border-bottom-left-radius: var(--radius-md);
+}
+
+.segmented-control__option:last-child {
+  border-right: none;
+  border-top-right-radius: var(--radius-md);
+  border-bottom-right-radius: var(--radius-md);
+}
+
+.segmented-control__option:hover {
+  background: var(--bg-surface-hover);
+}
+
+.segmented-control__option--active {
+  background: var(--accent-primary);
+  color: var(--text-on-primary);
+  font-weight: 600;
+}
+
+.segmented-control__option--active:hover {
+  background: var(--accent-primary-hover);
+}
+
+.segmented-control__option:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  z-index: 1;
+}
+
+.segmented-control__hint {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  opacity: 0.7;
+}
+
+/* COD reveal (#1425) — checkbox toggle; the amount row mounts only when on. */
+.generate-label-form__cod-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.generate-label-form__cod-toggle input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent-primary);
+  cursor: pointer;
+}
+
+.generate-label-form__cod-toggle input[type='checkbox']:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  border-radius: var(--radius-xs);
+}
+
 /* ─────────────────────────────────────────────────────────────────────────
    Order detail redesign (#924)
    Operator cockpit: derived health header + strip, failure banner, pricing,

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -34,6 +34,8 @@ export { Textarea } from './textarea';
 export { Select } from './select';
 export { Combobox } from './combobox';
 export type { ComboboxOption, ComboboxValue } from './combobox';
+export { SegmentedControl } from './segmented-control';
+export type { SegmentedControlOption, SegmentedControlProps } from './segmented-control';
 
 // ── Form composition ───────────────────────────────────────────────
 export { FormField } from './form-field';

--- a/apps/web/src/shared/ui/segmented-control.test.tsx
+++ b/apps/web/src/shared/ui/segmented-control.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+
+import { SegmentedControl, type SegmentedControlOption } from './segmented-control';
+
+afterEach(cleanup);
+
+const options: readonly SegmentedControlOption<'small' | 'medium' | 'large'>[] = [
+  { value: 'small', label: 'small', hint: 'A' },
+  { value: 'medium', label: 'medium', hint: 'B' },
+  { value: 'large', label: 'large', hint: 'C' },
+];
+
+describe('SegmentedControl', () => {
+  it('should render one option button per option', () => {
+    render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={() => {}} />);
+    expect(screen.getAllByRole('button')).toHaveLength(3);
+  });
+
+  it('should mark the active option pressed and the others not', () => {
+    render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: /medium/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /small/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('should call onChange with the option value when clicked', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /large/i }));
+    expect(onChange).toHaveBeenCalledWith('large');
+  });
+
+  it('should hide the decorative hint from the accessible name', () => {
+    render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={() => {}} />);
+    // Accessible name is the label only; the hint is aria-hidden.
+    expect(screen.getByRole('button', { name: 'small' })).toBeInTheDocument();
+  });
+
+  it('should forward the ref and spread aria props onto the group', () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(
+      <SegmentedControl
+        ref={ref}
+        aria-label="Size"
+        aria-describedby="size-desc"
+        options={options}
+        value="small"
+        onChange={() => {}}
+      />,
+    );
+    const group = screen.getByRole('group', { name: 'Size' });
+    expect(group).toHaveAttribute('aria-describedby', 'size-desc');
+    expect(ref.current).toBe(group);
+  });
+
+  it('should merge a custom className with the base class', () => {
+    render(
+      <SegmentedControl
+        aria-label="Size"
+        className="custom"
+        options={options}
+        value="small"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('group', { name: 'Size' })).toHaveClass('segmented-control', 'custom');
+  });
+});

--- a/apps/web/src/shared/ui/segmented-control.test.tsx
+++ b/apps/web/src/shared/ui/segmented-control.test.tsx
@@ -12,31 +12,59 @@ const options: readonly SegmentedControlOption<'small' | 'medium' | 'large'>[] =
 ];
 
 describe('SegmentedControl', () => {
-  it('should render one option button per option', () => {
+  it('should render one radio option per option', () => {
     render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={() => {}} />);
-    expect(screen.getAllByRole('button')).toHaveLength(3);
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
   });
 
-  it('should mark the active option pressed and the others not', () => {
+  it('should mark the active option checked and the others not', () => {
     render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={() => {}} />);
-    expect(screen.getByRole('button', { name: /medium/i })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: /small/i })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('radio', { name: /medium/i })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: /small/i })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('should give the group a single tab stop via a roving tabindex', () => {
+    render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={() => {}} />);
+    expect(screen.getByRole('radio', { name: /medium/i })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('radio', { name: /small/i })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('radio', { name: /large/i })).toHaveAttribute('tabindex', '-1');
   });
 
   it('should call onChange with the option value when clicked', () => {
     const onChange = vi.fn();
     render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={onChange} />);
-    fireEvent.click(screen.getByRole('button', { name: /large/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /large/i }));
     expect(onChange).toHaveBeenCalledWith('large');
+  });
+
+  it('should move selection to the next option on ArrowRight', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('radio', { name: /medium/i }), { key: 'ArrowRight' });
+    expect(onChange).toHaveBeenCalledWith('large');
+  });
+
+  it('should wrap to the first option on ArrowRight from the last', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl aria-label="Size" options={options} value="large" onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('radio', { name: /large/i }), { key: 'ArrowRight' });
+    expect(onChange).toHaveBeenCalledWith('small');
+  });
+
+  it('should move selection to the previous option on ArrowLeft', () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('radio', { name: /medium/i }), { key: 'ArrowLeft' });
+    expect(onChange).toHaveBeenCalledWith('small');
   });
 
   it('should hide the decorative hint from the accessible name', () => {
     render(<SegmentedControl aria-label="Size" options={options} value="medium" onChange={() => {}} />);
     // Accessible name is the label only; the hint is aria-hidden.
-    expect(screen.getByRole('button', { name: 'small' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'small' })).toBeInTheDocument();
   });
 
-  it('should forward the ref and spread aria props onto the group', () => {
+  it('should forward the ref and spread aria props onto the radiogroup', () => {
     const ref = { current: null as HTMLDivElement | null };
     render(
       <SegmentedControl
@@ -48,7 +76,7 @@ describe('SegmentedControl', () => {
         onChange={() => {}}
       />,
     );
-    const group = screen.getByRole('group', { name: 'Size' });
+    const group = screen.getByRole('radiogroup', { name: 'Size' });
     expect(group).toHaveAttribute('aria-describedby', 'size-desc');
     expect(ref.current).toBe(group);
   });
@@ -63,6 +91,6 @@ describe('SegmentedControl', () => {
         onChange={() => {}}
       />,
     );
-    expect(screen.getByRole('group', { name: 'Size' })).toHaveClass('segmented-control', 'custom');
+    expect(screen.getByRole('radiogroup', { name: 'Size' })).toHaveClass('segmented-control', 'custom');
   });
 });

--- a/apps/web/src/shared/ui/segmented-control.tsx
+++ b/apps/web/src/shared/ui/segmented-control.tsx
@@ -1,0 +1,72 @@
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ForwardedRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+
+export interface SegmentedControlOption<T extends string> {
+  value: T;
+  label: ReactNode;
+  /** Optional secondary hint rendered beside the label (decorative — aria-hidden). */
+  hint?: ReactNode;
+}
+
+export interface SegmentedControlProps<T extends string>
+  extends Omit<ComponentPropsWithoutRef<'div'>, 'onChange'> {
+  options: readonly SegmentedControlOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+/**
+ * A single-select segmented toggle (Shopify/Linear-style). Wraps the shared
+ * `.segmented-control` CSS so features don't hand-roll one-off inline controls.
+ * The group is unlabelled by default — pass `aria-label`/`aria-labelledby` (and,
+ * for form use, `aria-describedby`/`aria-invalid`/`aria-errormessage`) via the
+ * spread props so the error/description associate for screen readers.
+ */
+function SegmentedControlInner<T extends string>(
+  { options, value, onChange, className = '', ...rest }: SegmentedControlProps<T>,
+  ref: ForwardedRef<HTMLDivElement>,
+): ReactElement {
+  const classes = ['segmented-control', className].filter(Boolean).join(' ');
+
+  return (
+    <div ref={ref} role="group" className={classes} {...rest}>
+      {options.map((option) => {
+        const active = option.value === value;
+        const optionClasses = [
+          'segmented-control__option',
+          active ? 'segmented-control__option--active' : '',
+        ]
+          .filter(Boolean)
+          .join(' ');
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            className={optionClasses}
+            aria-pressed={active}
+            onClick={() => onChange(option.value)}
+          >
+            <span className="segmented-control__label">{option.label}</span>
+            {option.hint !== undefined && (
+              <span className="segmented-control__hint" aria-hidden="true">
+                {option.hint}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// Generic + forwardRef: cast the wrapped component back to a generic call
+// signature so callers keep full value-type inference on `value`/`onChange`.
+export const SegmentedControl = forwardRef(SegmentedControlInner) as <T extends string>(
+  props: SegmentedControlProps<T> & { ref?: ForwardedRef<HTMLDivElement> },
+) => ReactElement;

--- a/apps/web/src/shared/ui/segmented-control.tsx
+++ b/apps/web/src/shared/ui/segmented-control.tsx
@@ -1,7 +1,9 @@
 import {
   forwardRef,
+  useRef,
   type ComponentPropsWithoutRef,
   type ForwardedRef,
+  type KeyboardEvent,
   type ReactElement,
   type ReactNode,
 } from 'react';
@@ -23,6 +25,14 @@ export interface SegmentedControlProps<T extends string>
 /**
  * A single-select segmented toggle (Shopify/Linear-style). Wraps the shared
  * `.segmented-control` CSS so features don't hand-roll one-off inline controls.
+ *
+ * Uses the ARIA radiogroup idiom (`role="radiogroup"` + `role="radio"` /
+ * `aria-checked`) rather than toggle buttons, because the control is a
+ * single-select "pick one of N" — that communicates the intent precisely to
+ * screen readers. Keyboard: a roving tabindex keeps the group a single tab
+ * stop and Arrow keys move (and select) between options, per the WAI-ARIA
+ * radio-group pattern.
+ *
  * The group is unlabelled by default — pass `aria-label`/`aria-labelledby` (and,
  * for form use, `aria-describedby`/`aria-invalid`/`aria-errormessage`) via the
  * spread props so the error/description associate for screen readers.
@@ -32,10 +42,37 @@ function SegmentedControlInner<T extends string>(
   ref: ForwardedRef<HTMLDivElement>,
 ): ReactElement {
   const classes = ['segmented-control', className].filter(Boolean).join(' ');
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const hasActive = options.some((option) => option.value === value);
+
+  const selectAt = (index: number): void => {
+    const next = options[index];
+    if (next === undefined) return;
+    onChange(next.value);
+    optionRefs.current[index]?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number): void => {
+    const count = options.length;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        event.preventDefault();
+        selectAt((index + 1) % count);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        event.preventDefault();
+        selectAt((index - 1 + count) % count);
+        break;
+      default:
+        break;
+    }
+  };
 
   return (
-    <div ref={ref} role="group" className={classes} {...rest}>
-      {options.map((option) => {
+    <div ref={ref} role="radiogroup" className={classes} {...rest}>
+      {options.map((option, index) => {
         const active = option.value === value;
         const optionClasses = [
           'segmented-control__option',
@@ -47,10 +84,19 @@ function SegmentedControlInner<T extends string>(
         return (
           <button
             key={option.value}
+            ref={(el) => {
+              optionRefs.current[index] = el;
+            }}
             type="button"
+            role="radio"
             className={optionClasses}
-            aria-pressed={active}
+            aria-checked={active}
+            // Roving tabindex: the group is a single tab stop. The checked
+            // option is tabbable; when nothing is checked yet the first option
+            // takes the stop so the group is still keyboard-reachable.
+            tabIndex={active || (!hasActive && index === 0) ? 0 : -1}
             onClick={() => onChange(option.value)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
           >
             <span className="segmented-control__label">{option.label}</span>
             {option.hint !== undefined && (


### PR DESCRIPTION
## What & why

Redesigns the order-detail shipment panel so its state reads at a glance. Replaces the flat `KeyValueList` body with a **lifecycle rail** (Label ready → Dispatched → In transit → Delivered) that mirrors the buyer-side tracker the marketplace already shows the customer; `failed` and `cancelled` render an interrupted rail. Refreshes the generate-label form: **locker size** is now a segmented `small/medium/large` control (with the InPost gabaryt A/B/C hint) and **cash-on-delivery** sits behind a checkbox that reveals the amount only when collecting.

Design mockup (approved) covered every state: empty, generated, dispatched, in-transit, delivered, failed, cancelled, omp-fulfilled, loading.

## Changes (frontend-only)

- `shipment-lifecycle-rail.tsx` (new) + tests — maps every `ShipmentStatus` to a stage; semantic status colour, accent reserved for the current live node; `aria-current`, reduced-motion guard.
- `order-shipment-panel.tsx` — renders the rail for an active shipment (skipped for omp/empty/loading); status badge, facts, actions, empty + OMP paths unchanged.
- `generate-label-form.tsx` — segmented locker-size control (RHF `setValue`/`watch`); COD behind a checkbox; payload shape, gates, decimal normalization unchanged.
- `index.css` — new bounded `#1425` section; **no new tokens** (drift checker passes).

## Quality gate

- eslint (changed files): 0 errors
- `tsc --noEmit` (apps/web): pass
- vitest (`src/features/orders`): 138 pass

## Rebased onto main

#1424 (locker size) is merged into main. This branch has been rebased onto main and now contains ONLY the redesign commits - the locker-size commit is dropped (it lives in main). No longer a draft, no conflicts.

Closes #1425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

