### PR TITLE
fix(shipping): backfill the InPost tracking number from getTracking

### DIFF
--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-shipping.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-shipping.adapter.spec.ts
@@ -162,7 +162,34 @@ describe('InpostShippingAdapter', () => {
       const snapshot = await adapter.getTracking({ providerShipmentId: '1' });
 
       expect(request).toHaveBeenCalledWith({ method: 'GET', path: '/v1/shipments/1' });
-      expect(snapshot).toEqual({ status: 'delivered', providerStatus: 'delivered', carrier: 'inpost' });
+      expect(snapshot).toEqual({
+        status: 'delivered',
+        providerStatus: 'delivered',
+        carrier: 'inpost',
+        trackingNumber: 'X',
+      });
+    });
+
+    it('should carry the ShipX tracking number into the snapshot so it backfills (#1426)', async () => {
+      const { adapter, request } = makeAdapter();
+      request.mockResolvedValueOnce({
+        id: 1,
+        status: 'confirmed',
+        tracking_number: '602222118600000022831478',
+      });
+
+      const snapshot = await adapter.getTracking({ providerShipmentId: '1' });
+
+      expect(snapshot.trackingNumber).toBe('602222118600000022831478');
+    });
+
+    it('should omit trackingNumber when ShipX has not minted one yet', async () => {
+      const { adapter, request } = makeAdapter();
+      request.mockResolvedValueOnce({ id: 1, status: 'created', tracking_number: null });
+
+      const snapshot = await adapter.getTracking({ providerShipmentId: '1' });
+
+      expect(snapshot.trackingNumber).toBeUndefined();
     });
 
     it('should fall back to in-transit for an unknown ShipX status', async () => {

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-shipping.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-shipping.adapter.ts
@@ -96,13 +96,14 @@ export class InpostShippingAdapter
       path: `/v1/shipments/${input.providerShipmentId}`,
     });
     const mapped = mapShipXStatus(shipment.status);
+    const trackingNumber = shipment.tracking_number ?? undefined;
     if (mapped === null) {
       this.logger.warn(
         `Unknown ShipX status '${shipment.status}' for shipment ${input.providerShipmentId}; treating as in-transit`,
       );
-      return toTrackingSnapshot('in-transit', shipment.status);
+      return toTrackingSnapshot('in-transit', shipment.status, trackingNumber);
     }
-    return toTrackingSnapshot(mapped, shipment.status);
+    return toTrackingSnapshot(mapped, shipment.status, trackingNumber);
   }
 
   async cancelShipment(input: { providerShipmentId: string }): Promise<void> {

--- a/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
@@ -134,8 +134,19 @@ export function toGenerateLabelResult(shipment: ShipXShipment): GenerateLabelRes
  * shipments; no brokerage layer to disambiguate, unlike Allegro Delivery —
  * see `KnownCarrierValues` in core).
  */
-export function toTrackingSnapshot(status: ShipmentStatus, providerStatus: string): TrackingSnapshot {
-  return { status, providerStatus, carrier: 'inpost' };
+export function toTrackingSnapshot(
+  status: ShipmentStatus,
+  providerStatus: string,
+  trackingNumber?: string,
+): TrackingSnapshot {
+  // Backfill the waybill once ShipX mints it at confirmation — the status-sync
+  // service diffs this onto `Shipment.trackingNumber` (never overwrites).
+  return {
+    status,
+    providerStatus,
+    carrier: 'inpost',
+    ...(trackingNumber ? { trackingNumber } : {}),
+  };
 }
 
 /** Map a ShipX point to the neutral `PickupPoint`. */


### PR DESCRIPTION
## What & why

The order-detail panel showed Tracking `—` even after ShipX had minted a waybill. `InpostShippingAdapter.getTracking` fetches the ShipX shipment (whose body carries `tracking_number` once `confirmed`) but `toTrackingSnapshot` returned only `{ status, providerStatus, carrier }`, dropping the number. `TrackingSnapshot` already has an optional `trackingNumber` and `ShipmentStatusSyncService` backfills `Shipment.trackingNumber` from it - but the adapter never populated it, so the backfill never fired.

Verified against the ShipX sandbox: `GET /v1/shipments/{id}` returns e.g. `tracking_number: "602222118600000022831478"` while OL kept `trackingNumber = null`; after this fix the `marketplace.shipment.statusSync` poll backfills it and the panel shows the waybill.

## Changes

- `inpost-shipx.mapper.ts` - `toTrackingSnapshot` gains an optional `trackingNumber` and includes it when present.
- `inpost-shipping.adapter.ts` - `getTracking` passes `shipment.tracking_number ?? undefined` in both the mapped and unknown-status branches.
- Adapter spec - assert the tracking number is carried through, and omitted when ShipX hasn't minted one.

## Quality gate

- `pnpm --filter @openlinker/integrations-inpost type-check`: pass
- eslint (changed files): 0 errors
- jest (inpost adapter + mapper): 38 pass

Closes #1426
Independent of #1423 / #1425 (branched off main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
