### PR TITLE
feat(shipping): surface carrier-rejection details in the log and 502 body

### DIFF
--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -296,13 +296,21 @@ describe('ShipmentController', () => {
       );
     });
 
-    it('should map ShippingProviderRejectionException to 502', async () => {
+    it('should map ShippingProviderRejectionException to a 502 carrying the structured provider details (#1428)', async () => {
       dispatch.dispatch.mockRejectedValue(
-        new ShippingProviderRejectionException('inpost', 'PARCEL_TOO_LARGE', 'parcel exceeds size'),
+        new ShippingProviderRejectionException('inpost', 'target_point', 'validation errors', {
+          fieldErrors: { custom_attributes: [{ target_point: ['does_not_exist'] }] },
+        }),
       );
-      await expect(controller.generateLabel(makeGenerateLabelDto())).rejects.toBeInstanceOf(
-        BadGatewayException,
-      );
+
+      const err = await controller.generateLabel(makeGenerateLabelDto()).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(BadGatewayException);
+      expect((err as BadGatewayException).getResponse()).toEqual({
+        message: 'validation errors',
+        providerCode: 'target_point',
+        details: { fieldErrors: { custom_attributes: [{ target_point: ['does_not_exist'] }] } },
+      });
     });
 
     it('should map a ShippingProviderAuthException (carrier 401/403) to 502, not the 500 "Unclassified" path', async () => {

--- a/apps/api/src/shipping/http/shipment.controller.ts
+++ b/apps/api/src/shipping/http/shipment.controller.ts
@@ -415,7 +415,15 @@ export class ShipmentController {
       return new BadGatewayException(error.message);
     }
     if (error instanceof ShippingProviderRejectionException) {
-      return new BadGatewayException(error.message);
+      // Surface the carrier's structured rejection so the client sees WHICH
+      // field the provider rejected, not just a generic message (#1428). The
+      // provider-details payload is field-error metadata by convention — never
+      // credentials. `providerCode` gives callers a stable discriminator.
+      return new BadGatewayException({
+        message: error.message,
+        providerCode: error.providerCode,
+        details: error.providerDetails,
+      });
     }
     if (error instanceof Error) {
       this.logger.error(

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -23,6 +23,8 @@ import type { ShipmentRepositoryPort } from '../../domain/ports/shipment-reposit
 import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
 import { UndispatchableResolutionException } from '../../domain/exceptions/undispatchable-resolution.exception';
 import { OrderNotDispatchablePaymentStatusException } from '../../domain/exceptions/order-not-dispatchable-payment-status.exception';
+import { ShippingProviderRejectionException } from '../../domain/exceptions/shipping-provider-rejection.exception';
+import { Logger } from '@openlinker/shared/logging';
 
 /** Build an OrderRecord whose snapshot carries the given payment status (or none). */
 function makeOrderRecord(paymentStatus?: PaymentStatus): OrderRecord {
@@ -454,6 +456,28 @@ describe('ShipmentDispatchService', () => {
         draft.id,
         expect.objectContaining({ status: 'failed', errorMessage: 'paczkomat unavailable' }),
       );
+    });
+
+    it('should log the provider rejection code + details, not just the message (#1428)', async () => {
+      routing.resolve.mockResolvedValue(resolution());
+      repository.findActiveByOrderId.mockResolvedValue(null);
+      repository.create.mockResolvedValue(makeShipment({ status: 'draft' }));
+      repository.update.mockResolvedValue(makeShipment({ status: 'failed' }));
+      const rejection = new ShippingProviderRejectionException(
+        'inpost',
+        'target_point',
+        'validation errors',
+        { fieldErrors: { custom_attributes: [{ target_point: ['does_not_exist'] }] } },
+      );
+      adapter.generateLabel.mockRejectedValue(rejection);
+      const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+      await expect(service.dispatch(makeInput())).rejects.toBe(rejection);
+
+      const logged = warn.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(logged).toContain('code=target_point');
+      expect(logged).toContain('does_not_exist');
+      warn.mockRestore();
     });
   });
 

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
@@ -48,6 +48,7 @@ import {
 } from '../../domain/delivery-intent-resolution';
 import { UndispatchableResolutionException } from '../../domain/exceptions/undispatchable-resolution.exception';
 import { OrderNotDispatchablePaymentStatusException } from '../../domain/exceptions/order-not-dispatchable-payment-status.exception';
+import { ShippingProviderRejectionException } from '../../domain/exceptions/shipping-provider-rejection.exception';
 import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
 import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
 import { SHIPMENT_STATUS } from '../../domain/types/shipment-status.types';
@@ -271,8 +272,17 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
       return generated;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      // Surface the carrier's structured rejection (code + field errors) in the
+      // log — the top-level message alone is often a generic "validation error"
+      // that hides which field the provider rejected (#1428).
+      const rejectionDetail =
+        error instanceof ShippingProviderRejectionException
+          ? ` [provider=${error.providerName} code=${error.providerCode ?? 'null'} details=${JSON.stringify(
+              error.providerDetails ?? null,
+            )}]`
+          : '';
       this.logger.warn(
-        `generateLabel failed for shipment ${shipment.id} (order ${input.orderId}): ${message}`,
+        `generateLabel failed for shipment ${shipment.id} (order ${input.orderId}): ${message}${rejectionDetail}`,
       );
       // Persist the visible failure (surfaces in /shipments + enables retry),
       // then propagate the domain error so the caller can render it.

--- a/libs/core/src/shipping/domain/exceptions/shipping-provider-rejection.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/shipping-provider-rejection.exception.ts
@@ -40,6 +40,16 @@
  *     - Allegro command errors: `{ errors: AllegroShipmentCommandError[] }`
  *   Optional — undefined when there's nothing structured to carry.
  *
+ *   **Contract (not just convention) — this is a data-exposure boundary.**
+ *   The HTTP controller forwards `providerDetails` verbatim into the 502
+ *   response body AND logs it via `JSON.stringify`. Adapters MUST therefore
+ *   populate it with narrow, deliberately-mapped field-error / discriminator
+ *   metadata only. It MUST NOT carry secrets, credentials, buyer PII, echoed
+ *   request payloads, or a raw upstream error body — doing so would surface
+ *   that data in an API response and in logs, violating the "never return
+ *   secrets in API responses" security baseline. Map to an explicit shape;
+ *   never spread an unfiltered provider response into this field.
+ *
  * `message` is operator-readable verbatim — no prefix. The structured
  * `providerName` already carries the provider context for logs.
  *


### PR DESCRIPTION
## What & why

When a carrier rejects a label, `ShippingProviderRejectionException` carries structured `providerDetails` (e.g. ShipX `{ fieldErrors: { custom_attributes: [{ target_point: ['does_not_exist'] }] } }`) and a `providerCode` - but both were dropped before anyone could see them:
- `ShipmentDispatchService.generateLabel` logged only `error.message`.
- `ShipmentController.toHttpException` mapped the exception to `BadGatewayException(error.message)`.

So a real InPost failure surfaced only as the generic `"There are some validation errors. Check details object for more info."` in both the log and the 502 body - the actual field errors (which field the provider rejected) were invisible without hot-patching.

## Changes

- `shipment-dispatch.service.ts` - the dispatch-failure warn log now appends `[provider=… code=… details=…]` when the error is a `ShippingProviderRejectionException`.
- `shipment.controller.ts` - the rejection maps to a 502 whose body is `{ message, providerCode, details }`, not just `message`. Provider-details is field-error metadata by convention (never credentials).
- Tests: service logs the code + details; controller 502 body carries the structured details.

## Quality gate

- `pnpm --filter @openlinker/core type-check`: pass
- `pnpm --filter @openlinker/api type-check`: pass (after a workspace rebuild of plugin-sdk/core to refresh stale `.d.ts` drift from recent main - unrelated to this change)
- eslint (changed files): 0 errors
- jest: core dispatch-service 34 pass, api shipment.controller 45 pass

Closes #1428
Independent of #1423 / #1425 / #1426 (branched off main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
