### PR TITLE
fix(shipping): use parcel_locker sending method for InPost paczkomat shipments

### DIFF
--- a/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
@@ -75,7 +75,8 @@ describe('inpost-shipx.mapper', () => {
       expect(request.service).toBe('inpost_locker_standard');
       expect(request.reference).toBe('ol_shipment_abc');
       expect(request.custom_attributes?.target_point).toBe('POZ08A');
-      expect(request.custom_attributes?.sending_method).toBe('dispatch_order');
+      // Locker self-drop → parcel_locker, not the courier-collection dispatch_order (#1427).
+      expect(request.custom_attributes?.sending_method).toBe('parcel_locker');
       expect((request.parcels as ShipXLockerParcel).template).toBe('small');
       // Locker receiver carries no address (addressed by the locker).
       expect(request.receiver.address).toBeUndefined();
@@ -91,6 +92,8 @@ describe('inpost-shipx.mapper', () => {
       expect(parcel.dimensions).toEqual({ length: '80', width: '360', height: '640', unit: 'mm' });
       expect(parcel.weight).toEqual({ amount: '2.50', unit: 'kg' });
       expect(request.receiver.address?.post_code).toBe('02-677');
+      // Courier keeps dispatch_order (courier collects from the sender) (#1427).
+      expect(request.custom_attributes?.sending_method).toBe('dispatch_order');
     });
 
     it('should throw a typed rejection (preflight.missing-paczkomat-id) when paczkomat shipment lacks paczkomatId (#885)', () => {

--- a/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
@@ -185,7 +185,11 @@ function buildLockerRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): ShipX
     parcels: { template: cmd.parcel.template },
     service: 'inpost_locker_standard',
     reference: cmd.shipmentId,
-    custom_attributes: { sending_method: 'dispatch_order', target_point: cmd.paczkomatId },
+    // Paczkomat is a sender self-drop at a locker → `parcel_locker` is the ShipX
+    // sending method documented for `inpost_locker_standard`. `dispatch_order`
+    // (courier collects from the sender) routed locker shipments into the
+    // courier pickup-order flow (#1427).
+    custom_attributes: { sending_method: 'parcel_locker', target_point: cmd.paczkomatId },
   };
 }
 


### PR DESCRIPTION
## What & why

`buildLockerRequest` hardcoded `custom_attributes.sending_method: 'dispatch_order'` for paczkomat shipments. In ShipX, `sending_method` describes how the **sender** hands the parcel to InPost: `dispatch_order` = a courier collects it from the sender; `parcel_locker` = the sender drops it at a locker. Forcing `dispatch_order` on a locker service routes a self-drop paczkomat shipment into the courier pickup-order flow.

Per the ShipX "Sending method" compatibility table, **`parcel_locker` is the documented sending method for `inpost_locker_standard`** (and `dispatch_order` for `inpost_courier_standard`). Switch the locker path to `parcel_locker`; keep `dispatch_order` for courier.

## Changes

- `inpost-shipx.mapper.ts` - `buildLockerRequest` now sends `sending_method: 'parcel_locker'`; `buildCourierRequest` unchanged (`dispatch_order`).
- Mapper spec - assert `parcel_locker` for the locker path and `dispatch_order` for the courier path.

## Confirmation (issue AC)

Value confirmed against ShipX docs - the "Sending method" service↔method compatibility table (`parcel_locker → inpost_locker_standard`):
- https://dokumentacja-inpost.atlassian.net/wiki/spaces/PL/pages/28639234
- https://dokumentacja-inpost.atlassian.net/wiki/spaces/PL/pages/18153491

`target_point` (the receiver locker, already set) remains the required locker field. Docs also show `dispatch_order` is *accepted* with a locker service, so this switch is low-risk on creation; a sandbox create smoke-test is recommended as a final pre-merge check.

## Quality gate

- `pnpm --filter @openlinker/integrations-inpost type-check`: pass
- eslint (changed files): 0 errors
- jest (inpost mapper): 16 pass

Closes #1427
Independent of #1423 / #1425 / #1426 / #1428 (branched off main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
