### PR TITLE
feat(shipping): distinguish InPost paczkomat (APM) from PaczkoPunkt (POP) via point type

### DIFF
--- a/apps/api/src/shipping/http/dto/pickup-point-response.dto.spec.ts
+++ b/apps/api/src/shipping/http/dto/pickup-point-response.dto.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * PickupPointResponseDto Unit Tests
+ *
+ * Tests the fromDomain() projection of the `PickupPoint` domain value,
+ * including the point-type classification fields added in #1433.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import type { PickupPoint } from '@openlinker/core/shipping';
+import { PickupPointResponseDto } from './pickup-point-response.dto';
+
+function baseDomainPoint(overrides: Partial<PickupPoint> = {}): PickupPoint {
+  return {
+    providerId: 'POZ08A',
+    name: 'POZ08A',
+    address: { line1: 'ul. Testowa 1', city: 'Poznań', postalCode: '60-001', country: 'PL' },
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('PickupPointResponseDto', () => {
+  describe('fromDomain', () => {
+    it('should project core fields when mapping a domain pickup point', () => {
+      const dto = PickupPointResponseDto.fromDomain(baseDomainPoint({ lat: 52.4, lon: 16.9 }));
+
+      expect(dto.providerId).toBe('POZ08A');
+      expect(dto.name).toBe('POZ08A');
+      expect(dto.address).toEqual({
+        line1: 'ul. Testowa 1',
+        city: 'Poznań',
+        postalCode: '60-001',
+        country: 'PL',
+      });
+      expect(dto.status).toBe('active');
+      expect(dto.lat).toBe(52.4);
+      expect(dto.lon).toBe(16.9);
+    });
+
+    it('should project pointType and raw type when the domain point classifies as a PaczkoPunkt', () => {
+      const dto = PickupPointResponseDto.fromDomain(
+        baseDomainPoint({ pointType: 'pop', type: ['parcel_locker', 'pop'] }),
+      );
+
+      expect(dto.pointType).toBe('pop');
+      expect(dto.type).toEqual(['parcel_locker', 'pop']);
+    });
+
+    it('should project pointType apm and raw type when the domain point classifies as a Paczkomat', () => {
+      const dto = PickupPointResponseDto.fromDomain(
+        baseDomainPoint({ pointType: 'apm', type: ['parcel_locker'] }),
+      );
+
+      expect(dto.pointType).toBe('apm');
+      expect(dto.type).toEqual(['parcel_locker']);
+    });
+
+    it('should leave pointType and type undefined when the domain point carries no classification', () => {
+      const dto = PickupPointResponseDto.fromDomain(baseDomainPoint());
+
+      expect(dto.pointType).toBeUndefined();
+      expect(dto.type).toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/shipping/http/dto/pickup-point-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/pickup-point-response.dto.ts
@@ -10,10 +10,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   PickupPointStatusValues,
+  PickupPointTypeValues,
   type PickupPoint,
   type PickupPointAddress,
   type PickupPointOpeningHours,
   type PickupPointStatus,
+  type PickupPointType,
 } from '@openlinker/core/shipping';
 
 class PickupPointAddressDto implements PickupPointAddress {
@@ -48,6 +50,18 @@ export class PickupPointResponseDto {
   })
   openingHours?: PickupPointOpeningHours;
 
+  @ApiPropertyOptional({
+    enum: PickupPointTypeValues,
+    description: 'Classified point kind (#1433): apm (Paczkomat) vs pop (PaczkoPunkt)',
+  })
+  pointType?: PickupPointType;
+
+  @ApiPropertyOptional({
+    description: 'Raw provider-reported point-type tokens (e.g. ShipX type list)',
+    type: [String],
+  })
+  type?: readonly string[];
+
   static fromDomain(point: PickupPoint): PickupPointResponseDto {
     const dto = new PickupPointResponseDto();
     dto.providerId = point.providerId;
@@ -57,6 +71,8 @@ export class PickupPointResponseDto {
     dto.lat = point.lat;
     dto.lon = point.lon;
     dto.openingHours = point.openingHours;
+    dto.pointType = point.pointType;
+    dto.type = point.type;
     return dto;
   }
 }

--- a/apps/web/src/features/orders/api/order-snapshot.schema.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.ts
@@ -70,6 +70,14 @@ const orderShippingSchema = z.object({
   methodName: z.string().nullish(),
 });
 
+/**
+ * Pickup-point kind (#1433) — hand-mirrored from the backend
+ * `OrderPickupPointType` union (`@openlinker/core/orders`). `apm` = InPost
+ * Paczkomat, `pop` = PaczkoPunkt. Keep in sync with the core union.
+ */
+export const ParsedOrderPickupPointTypeValues = ['apm', 'pop'] as const;
+export type ParsedOrderPickupPointType = (typeof ParsedOrderPickupPointTypeValues)[number];
+
 const orderPickupPointSchema = z.object({
   /** Bare locker code (e.g. `POZ08A`). */
   id: z.string(),
@@ -77,6 +85,8 @@ const orderPickupPointSchema = z.object({
   name: z.string().nullish(),
   /** Locker-side description (e.g. `Stacja paliw BP`). `.nullish()` — see addressSchema. */
   description: z.string().nullish(),
+  /** Classified point kind (#1433). Absent when the source gave no signal. */
+  pointType: z.enum(ParsedOrderPickupPointTypeValues).nullish(),
 });
 
 export type ParsedOrderItem = z.infer<typeof orderItemSchema>;

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -132,6 +132,30 @@ describe('GenerateLabelForm — happy path', () => {
     expect(screen.queryByText(/Missing recipient data/i)).toBeNull();
   });
 
+  it('should label the pickup field Paczkomat when pointType is absent (#1433)', async () => {
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+    );
+
+    expect(await screen.findByLabelText('Paczkomat')).toBeInTheDocument();
+    expect(screen.queryByLabelText('PaczkoPunkt')).toBeNull();
+  });
+
+  it('should label the pickup field PaczkoPunkt when pointType is pop (#1433)', async () => {
+    const baseSnapshot = makeOrder().orderSnapshot as Record<string, unknown>;
+    const order = makeOrder({
+      orderSnapshot: {
+        ...baseSnapshot,
+        pickupPoint: { id: 'POP-OLS19', name: 'PaczkoPunkt POP-OLS19', pointType: 'pop' },
+      },
+    });
+
+    renderWithProviders(<GenerateLabelForm order={order} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(await screen.findByLabelText('PaczkoPunkt')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Paczkomat')).toBeNull();
+  });
+
   it('should disable submit and switch the label while generation is pending', async () => {
     const resolveRef: { current: ((value: unknown) => void) | null } = { current: null };
     const apiClient = createMockApiClient({

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -104,6 +104,10 @@ export function GenerateLabelForm({
   // or a locker-classified method ⇒ paczkomat flow.
   const methodClass = classifyDeliveryMethod(snapshot.shipping);
   const shippingMethod = resolveShippingMethod(snapshot);
+  // Point-kind label (#1433) — `pop` ⇒ PaczkoPunkt, `apm` or absent ⇒
+  // Paczkomat (mirrors the order-delivery panel mapping; the pickup field only
+  // renders for the paczkomat flow, so absent defaults to Paczkomat here).
+  const pickupFieldLabel = snapshot.pickupPoint?.pointType === 'pop' ? 'PaczkoPunkt' : 'Paczkomat';
   // Clear courier signal: the method is known-courier, or — until the snapshot
   // carries the method (#952) — the order has a full street address but no
   // pickup point. Suppresses the locker retry hint on courier orders that will
@@ -424,12 +428,12 @@ export function GenerateLabelForm({
 
         {shippingMethod === 'paczkomat' ? (
           <FormField
-            label="Paczkomat"
+            label={pickupFieldLabel}
             name="paczkomatId"
             description={
               paczkomatIsBuyerSelected
                 ? 'Buyer-selected via Allegro — read-only.'
-                : 'Type the paczkomat code (e.g. POZ08A). Picker coming in a follow-up.'
+                : `Type the ${pickupFieldLabel} code (e.g. POZ08A). Picker coming in a follow-up.`
             }
             error={form.formState.errors.paczkomatId?.message}
           >

--- a/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
@@ -22,4 +22,24 @@ describe('OrderDeliveryPanel', () => {
     expect(screen.getByText('InPost Paczkomat')).toBeInTheDocument();
     expect(screen.getByText(/operator-selected|buyer-selected/)).toBeInTheDocument();
   });
+
+  it('prefixes the pickup code with the point kind when pointType is present (#1433)', () => {
+    renderWithProviders(
+      <OrderDeliveryPanel
+        pickupPoint={{ id: 'POP-OLS19', pointType: 'pop' }}
+        sourcePlatformType="allegro"
+      />,
+    );
+    expect(screen.getByText(/PaczkoPunkt\s+POP-OLS19/)).toBeInTheDocument();
+  });
+
+  it('labels an apm point as Paczkomat (#1433)', () => {
+    renderWithProviders(
+      <OrderDeliveryPanel
+        pickupPoint={{ id: 'OLS06A', pointType: 'apm' }}
+        sourcePlatformType="allegro"
+      />,
+    );
+    expect(screen.getByText(/Paczkomat\s+OLS06A/)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
@@ -4,12 +4,12 @@ import { renderWithProviders } from '../../../test/test-utils';
 import { OrderDeliveryPanel } from './order-delivery-panel';
 
 describe('OrderDeliveryPanel', () => {
-  it('renders nothing when there is no delivery data', () => {
+  it('should render nothing when there is no delivery data', () => {
     renderWithProviders(<OrderDeliveryPanel />);
     expect(screen.queryByRole('region', { name: 'Delivery' })).toBeNull();
   });
 
-  it('renders the address, method and pickup code when present', () => {
+  it('should render the address, method and pickup code when they are present', () => {
     renderWithProviders(
       <OrderDeliveryPanel
         shippingAddress={{ address1: 'ul. Testowa 1', city: 'Warszawa', postalCode: '00-001', country: 'PL' }}
@@ -23,7 +23,7 @@ describe('OrderDeliveryPanel', () => {
     expect(screen.getByText(/operator-selected|buyer-selected/)).toBeInTheDocument();
   });
 
-  it('prefixes the pickup code with the point kind when pointType is present (#1433)', () => {
+  it('should prefix the pickup code with the point kind when pointType is present (#1433)', () => {
     renderWithProviders(
       <OrderDeliveryPanel
         pickupPoint={{ id: 'POP-OLS19', pointType: 'pop' }}
@@ -33,7 +33,7 @@ describe('OrderDeliveryPanel', () => {
     expect(screen.getByText(/PaczkoPunkt\s+POP-OLS19/)).toBeInTheDocument();
   });
 
-  it('labels an apm point as Paczkomat (#1433)', () => {
+  it('should label the pickup code as Paczkomat when pointType is apm (#1433)', () => {
     renderWithProviders(
       <OrderDeliveryPanel
         pickupPoint={{ id: 'OLS06A', pointType: 'apm' }}

--- a/apps/web/src/features/orders/components/order-delivery-panel.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.tsx
@@ -85,6 +85,15 @@ export function OrderDeliveryPanel({
       ? `buyer-selected via ${sourcePlatform.displayName}`
       : 'operator-selected';
 
+  // Point-kind label (#1433) — Paczkomat (apm) vs PaczkoPunkt (pop). Absent
+  // pointType falls back to no kind label (pre-#1433 behaviour).
+  const pickupKindLabel =
+    pickupPoint?.pointType === 'pop'
+      ? 'PaczkoPunkt'
+      : pickupPoint?.pointType === 'apm'
+        ? 'Paczkomat'
+        : undefined;
+
   return (
     <section className="detail-section order-delivery" aria-label="Delivery">
       <h3 className="detail-section__title">Delivery</h3>
@@ -92,7 +101,10 @@ export function OrderDeliveryPanel({
         {items.length > 0 ? <KeyValueList items={items} /> : null}
         {pickupPoint ? (
           <div className="order-delivery__pickup">
-            <div className="order-delivery__pickup-code mono-text">{pickupPoint.id}</div>
+            <div className="order-delivery__pickup-code mono-text">
+              {pickupKindLabel ? `${pickupKindLabel} ` : ''}
+              {pickupPoint.id}
+            </div>
             <div className="order-delivery__pickup-caption text-muted">
               {pickupPoint.description ? `${pickupPoint.description} · ` : ''}
               {pickupCaption}

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -166,6 +166,17 @@ export interface OrderDispatchWindow {
 }
 
 /**
+ * Pickup-point kind (#1433) carried on a source order — `apm` (InPost
+ * Paczkomat / unattended locker) vs `pop` (PaczkoPunkt / attended partner
+ * point). Defined locally in `orders` rather than reused from
+ * `@openlinker/core/shipping` to avoid an `orders → shipping` cross-context
+ * edge (shipping already depends on orders). Kept value-identical to
+ * `PickupPointType` in shipping.
+ */
+export const OrderPickupPointTypeValues = ['apm', 'pop'] as const;
+export type OrderPickupPointType = (typeof OrderPickupPointTypeValues)[number];
+
+/**
  * Pickup-point reference (InPost Paczkomat locker etc.). `id` is the bare
  * locker code (e.g. `POZ08A`); `name` and `description` are operator-facing
  * labels (`Paczkomat POZ08A` / `Stacja paliw BP`).
@@ -174,6 +185,12 @@ export interface OrderPickupPoint {
   id: string;
   name?: string;
   description?: string;
+  /**
+   * Classified point kind (#1433). For Allegro pickup-point orders the
+   * ingestion adapter infers this from the id/name heuristic (no network
+   * call in the hot path). Absent when no signal is available.
+   */
+  pointType?: OrderPickupPointType;
 }
 
 export interface OrderItem {

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -8,6 +8,8 @@
  *
  * @module libs/core/src/orders/domain/types
  */
+import type { PickupPointType } from '@openlinker/core/shipping';
+
 import type { PaymentStatus } from './payment-status.types';
 
 /**
@@ -168,13 +170,32 @@ export interface OrderDispatchWindow {
 /**
  * Pickup-point kind (#1433) carried on a source order — `apm` (InPost
  * Paczkomat / unattended locker) vs `pop` (PaczkoPunkt / attended partner
- * point). Defined locally in `orders` rather than reused from
- * `@openlinker/core/shipping` to avoid an `orders → shipping` cross-context
- * edge (shipping already depends on orders). Kept value-identical to
- * `PickupPointType` in shipping.
+ * point). Defined locally in `orders` (its own runtime `as const` source of
+ * truth) rather than value-imported from `@openlinker/core/shipping`, to avoid
+ * a runtime `orders → shipping` edge (shipping already depends on orders). Kept
+ * value-identical to `PickupPointType` in shipping — enforced at type-check
+ * time by the `_OrderPickupPointTypeParity` drift guard below (type-only, so it
+ * erases at build time).
  */
 export const OrderPickupPointTypeValues = ['apm', 'pop'] as const;
 export type OrderPickupPointType = (typeof OrderPickupPointTypeValues)[number];
+
+/**
+ * Compile-time drift guard (#1433): `OrderPickupPointType` must stay
+ * value-identical to shipping's `PickupPointType`. The `import type` above
+ * erases at build time, so this adds NO runtime `orders → shipping` edge — the
+ * local `OrderPickupPointTypeValues` remains the runtime source of truth; this
+ * only borrows the shipping type at the type level. If either union gains or
+ * drops a member the two stop being mutually assignable and
+ * `OrderPickupPointTypeParity` fails its `extends true` constraint at
+ * type-check time. Exported (not re-exported from the `orders` barrel) so the
+ * `tsc -b` unused-declaration check counts it as used.
+ */
+type MutuallyAssignable<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type AssertTrue<T extends true> = T;
+export type OrderPickupPointTypeParity = AssertTrue<
+  MutuallyAssignable<OrderPickupPointType, PickupPointType>
+>;
 
 /**
  * Pickup-point reference (InPost Paczkomat locker etc.). `id` is the bare

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -68,8 +68,10 @@ export {
   Address,
   OrderShipping,
   OrderPickupPoint,
+  OrderPickupPointType,
   OrderDispatchWindow,
 } from './domain/types/order.types';
+export { OrderPickupPointTypeValues } from './domain/types/order.types';
 export { PaymentStatusValues, PAYMENT_STATUS } from './domain/types/payment-status.types';
 export type { PaymentStatus } from './domain/types/payment-status.types';
 export { OrderCreate, OrderRef, OrderSourceRef } from './domain/types/order-processor.types';

--- a/libs/core/src/shipping/domain/types/pickup-point.types.ts
+++ b/libs/core/src/shipping/domain/types/pickup-point.types.ts
@@ -23,6 +23,20 @@
 export const PickupPointStatusValues = ['active', 'temporarily-unavailable'] as const;
 export type PickupPointStatus = (typeof PickupPointStatusValues)[number];
 
+/**
+ * Pickup-point kind (#1433). Distinguishes an InPost Paczkomat (`apm` —
+ * unattended parcel locker) from a PaczkoPunkt (`pop` — attended partner
+ * point). Both accept the same locker service, so this is a display /
+ * routing distinction, not a shipping-service discriminator.
+ */
+export const PickupPointTypeValues = ['apm', 'pop'] as const;
+export type PickupPointType = (typeof PickupPointTypeValues)[number];
+
+export const PICKUP_POINT_TYPE = {
+  Automat: 'apm',
+  PartnerPoint: 'pop',
+} as const satisfies Record<'Automat' | 'PartnerPoint', PickupPointType>;
+
 export const PICKUP_POINT_STATUS = {
   Active: 'active',
   TemporarilyUnavailable: 'temporarily-unavailable',
@@ -73,6 +87,17 @@ export interface PickupPoint {
   lat?: number;
   lon?: number;
   openingHours?: PickupPointOpeningHours;
+  /**
+   * Classified point kind (#1433) — `apm` (Paczkomat) vs `pop` (PaczkoPunkt).
+   * Derived from the provider `type` list when present, else a heuristic on
+   * id/name. Absent when the provider gives no signal.
+   */
+  pointType?: PickupPointType;
+  /**
+   * Raw provider-reported point-type tokens (InPost ShipX `type`, e.g.
+   * `['parcel_locker','pop']`). Preserved for auditing / future filtering.
+   */
+  type?: readonly string[];
 }
 
 /**

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -35,6 +35,8 @@ export {
   PICKUP_POINT_STATUS,
   PickupPointDayValues,
   PICKUP_POINT_DAY,
+  PickupPointTypeValues,
+  PICKUP_POINT_TYPE,
 } from './domain/types/pickup-point.types';
 export type {
   PickupPoint,
@@ -43,6 +45,7 @@ export type {
   PickupPointDay,
   PickupPointDayHours,
   PickupPointOpeningHours,
+  PickupPointType,
   FindPickupPointsQuery,
 } from './domain/types/pickup-point.types';
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -803,6 +803,7 @@ describe('AllegroOrderSourceAdapter', () => {
           id: 'POZ08A',
           name: 'Paczkomat POZ08A',
           description: 'Stacja paliw BP',
+          pointType: 'apm',
         });
         // shippingAddress geography comes from the locker; recipient name+phone
         // remain the buyer's (the parcel is collected by the buyer).
@@ -845,11 +846,51 @@ describe('AllegroOrderSourceAdapter', () => {
           id: 'POZ08A',
           name: 'Paczkomat POZ08A',
           description: undefined,
+          pointType: 'apm',
         });
         // Falls back to buyer.address since neither delivery.address nor
         // pickupPoint.address has geography.
         expect(incoming.shippingAddress?.address1).toBe('Profile Street 1');
         expect(incoming.shippingAddress?.city).toBe('BuyerCity');
+      });
+
+      it('should infer pointType pop for a POP- prefixed pickup-point id (#1433)', async () => {
+        const form = baseForm();
+        form.delivery = {
+          address: {},
+          pickupPoint: { id: 'POP-OLS19', name: 'PaczkoPunkt POP-OLS19' },
+        };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.pickupPoint?.pointType).toBe('pop');
+      });
+
+      it('should infer pointType pop from a PaczkoPunkt name without a POP- id (#1433)', async () => {
+        const form = baseForm();
+        form.delivery = {
+          address: {},
+          pickupPoint: { id: 'OLS19X', name: 'InPost PaczkoPunkt at OLS19X' },
+        };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.pickupPoint?.pointType).toBe('pop');
+      });
+
+      it('should infer pointType apm for a plain locker id (#1433)', async () => {
+        const form = baseForm();
+        form.delivery = {
+          address: {},
+          pickupPoint: { id: 'OLS06A', name: 'InPost Paczkomat OLS06A' },
+        };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.pickupPoint?.pointType).toBe('apm');
       });
     });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -803,7 +803,9 @@ describe('AllegroOrderSourceAdapter', () => {
           id: 'POZ08A',
           name: 'Paczkomat POZ08A',
           description: 'Stacja paliw BP',
-          pointType: 'apm',
+          // No POP signal in id/name — Allegro exposes no apm discriminator,
+          // so the classifier stays truthfully undefined (#1433).
+          pointType: undefined,
         });
         // shippingAddress geography comes from the locker; recipient name+phone
         // remain the buyer's (the parcel is collected by the buyer).
@@ -846,7 +848,7 @@ describe('AllegroOrderSourceAdapter', () => {
           id: 'POZ08A',
           name: 'Paczkomat POZ08A',
           description: undefined,
-          pointType: 'apm',
+          pointType: undefined,
         });
         // Falls back to buyer.address since neither delivery.address nor
         // pickupPoint.address has geography.
@@ -880,7 +882,7 @@ describe('AllegroOrderSourceAdapter', () => {
         expect(incoming.pickupPoint?.pointType).toBe('pop');
       });
 
-      it('should infer pointType apm for a plain locker id (#1433)', async () => {
+      it('should leave pointType undefined for a plain locker id with no POP signal (#1433)', async () => {
         const form = baseForm();
         form.delivery = {
           address: {},
@@ -890,7 +892,7 @@ describe('AllegroOrderSourceAdapter', () => {
 
         const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
 
-        expect(incoming.pickupPoint?.pointType).toBe('apm');
+        expect(incoming.pickupPoint?.pointType).toBeUndefined();
       });
     });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -27,6 +27,7 @@ import type {
   IncomingOrderAddress,
   OrderShipping,
   OrderPickupPoint,
+  OrderPickupPointType,
   OrderDispatchWindow,
 } from '@openlinker/core/orders';
 import type { Connection } from '@openlinker/core/identifier-mapping';
@@ -491,7 +492,28 @@ export class AllegroOrderSourceAdapter
     if (!pp?.id) {
       return undefined;
     }
-    return { id: pp.id, name: pp.name, description: pp.description };
+    return {
+      id: pp.id,
+      name: pp.name,
+      description: pp.description,
+      pointType: this.classifyPickupPointType(pp.id, pp.name),
+    };
+  }
+
+  /**
+   * Infer the InPost point kind (#1433) from the id/name only — no network
+   * call in the ingestion hot path. A POP-prefixed id (case-insensitive) or a
+   * "PaczkoPunkt" label ⇒ `pop`, else `apm`. This is the heuristic half of the
+   * authoritative InPost classifier; it is duplicated here as a tiny local
+   * rule rather than imported from `@openlinker/integrations-inpost` to avoid
+   * an integration→integration package dependency (the ShipX `type`-based
+   * authoritative path lives in the InPost mapper, used by the pickup-point
+   * finder where a `/v1/points` lookup already happens).
+   */
+  private classifyPickupPointType(id: string, name?: string): OrderPickupPointType {
+    const idIsPop = id.toLowerCase().startsWith('pop-');
+    const nameIsPop = (name ?? '').toLowerCase().includes('paczkopunkt');
+    return idIsPop || nameIsPop ? 'pop' : 'apm';
   }
 
   /**

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -514,6 +514,11 @@ export class AllegroOrderSourceAdapter
    * package dependency. Keep in sync with `classifyInpostPointType` in the
    * InPost ShipX mapper, whose ShipX `type`-based authoritative path runs where
    * a `/v1/points` lookup already happens (the pickup-point finder).
+   *
+   * The result is therefore best-effort at ingestion time: a `pop` here is a
+   * heuristic match, and it (or the `undefined`) is superseded by the
+   * authoritative ShipX `type`-based classification once the `/v1/points`
+   * path resolves the point.
    */
   private classifyPickupPointType(id: string, name?: string): OrderPickupPointType | undefined {
     const idIsPop = id.toLowerCase().startsWith('pop-');

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -503,17 +503,22 @@ export class AllegroOrderSourceAdapter
   /**
    * Infer the InPost point kind (#1433) from the id/name only — no network
    * call in the ingestion hot path. A POP-prefixed id (case-insensitive) or a
-   * "PaczkoPunkt" label ⇒ `pop`, else `apm`. This is the heuristic half of the
-   * authoritative InPost classifier; it is duplicated here as a tiny local
-   * rule rather than imported from `@openlinker/integrations-inpost` to avoid
-   * an integration→integration package dependency (the ShipX `type`-based
-   * authoritative path lives in the InPost mapper, used by the pickup-point
-   * finder where a `/v1/points` lookup already happens).
+   * "PaczkoPunkt" label ⇒ `pop`. Returns `undefined` when neither a POP signal
+   * nor any other classifiable signal is present: Allegro exposes no locker-vs-
+   * partner-point discriminator here, so absent a POP signal we stay truthful
+   * (`undefined`) rather than confidently guessing `apm`.
+   *
+   * This is the heuristic half of the authoritative InPost classifier; it is
+   * duplicated here as a tiny local rule rather than imported from
+   * `@openlinker/integrations-inpost` to avoid an integration→integration
+   * package dependency. Keep in sync with `classifyInpostPointType` in the
+   * InPost ShipX mapper, whose ShipX `type`-based authoritative path runs where
+   * a `/v1/points` lookup already happens (the pickup-point finder).
    */
-  private classifyPickupPointType(id: string, name?: string): OrderPickupPointType {
+  private classifyPickupPointType(id: string, name?: string): OrderPickupPointType | undefined {
     const idIsPop = id.toLowerCase().startsWith('pop-');
     const nameIsPop = (name ?? '').toLowerCase().includes('paczkopunkt');
-    return idIsPop || nameIsPop ? 'pop' : 'apm';
+    return idIsPop || nameIsPop ? 'pop' : undefined;
   }
 
   /**

--- a/libs/integrations/inpost/src/domain/types/inpost-shipx.types.ts
+++ b/libs/integrations/inpost/src/domain/types/inpost-shipx.types.ts
@@ -83,7 +83,14 @@ export interface ShipXTrackingResponse {
 export interface ShipXPoint {
   /** Locker code (e.g. `'POZ08A'`). */
   name: string;
+  /**
+   * Point-type tokens from `/v1/points` (e.g. `['parcel_locker']` for an
+   * automat, `['parcel_locker','parcel_locker_superpop','pok','pop']` for a
+   * PaczkoPunkt). String form tolerated for defensive parsing.
+   */
   type?: readonly string[] | string;
+  /** Human display name (e.g. `'InPost PaczkoPunkt POP-OLS19'`). */
+  display_name?: string;
   status?: string;
   location?: { latitude: number; longitude: number };
   address?: { line1?: string; line2?: string };

--- a/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
@@ -14,6 +14,7 @@ import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
 import {
   buildCreateShipmentRequest,
   buildPointsQuery,
+  classifyInpostPointType,
   mapShipXStatus,
   toGenerateLabelResult,
   toPickupPoint,
@@ -194,6 +195,64 @@ describe('inpost-shipx.mapper', () => {
       expect(result.status).toBe('active');
       expect(result.address.city).toBe('Poznań');
       expect(result.lat).toBe(52.4);
+    });
+
+    it('should carry pointType and raw type for a parcel_locker automat', () => {
+      const point: ShipXPoint = {
+        name: 'OLS06A',
+        display_name: 'InPost Paczkomat OLS06A',
+        type: ['parcel_locker'],
+      };
+      const result = toPickupPoint(point);
+      expect(result.pointType).toBe('apm');
+      expect(result.type).toEqual(['parcel_locker']);
+    });
+
+    it('should classify a PaczkoPunkt as pop from the type list', () => {
+      const point: ShipXPoint = {
+        name: 'POP-OLS19',
+        display_name: 'InPost PaczkoPunkt POP-OLS19',
+        type: ['parcel_locker', 'parcel_locker_superpop', 'pok', 'pop'],
+      };
+      const result = toPickupPoint(point);
+      expect(result.pointType).toBe('pop');
+      expect(result.type).toEqual(['parcel_locker', 'parcel_locker_superpop', 'pok', 'pop']);
+    });
+
+    it('should leave raw type absent when the point omits it', () => {
+      const result = toPickupPoint({ name: 'POZ08A' });
+      expect(result.type).toBeUndefined();
+      expect(result.pointType).toBe('apm');
+    });
+  });
+
+  describe('classifyInpostPointType', () => {
+    it('should return pop when the type list contains pop (authoritative path)', () => {
+      expect(classifyInpostPointType({ id: 'OLS06A', type: ['parcel_locker', 'pop'] })).toBe('pop');
+    });
+
+    it('should return pop for a parcel_locker_superpop token', () => {
+      expect(
+        classifyInpostPointType({ type: ['parcel_locker', 'parcel_locker_superpop'] }),
+      ).toBe('pop');
+    });
+
+    it('should return apm for a plain parcel_locker type list', () => {
+      expect(classifyInpostPointType({ id: 'POP-OLS19', type: ['parcel_locker'] })).toBe('apm');
+    });
+
+    it('should fall back to the POP- id prefix when type is absent', () => {
+      expect(classifyInpostPointType({ id: 'POP-OLS19' })).toBe('pop');
+      expect(classifyInpostPointType({ id: 'pop-ols19' })).toBe('pop');
+    });
+
+    it('should fall back to the PaczkoPunkt name when type is absent', () => {
+      expect(classifyInpostPointType({ id: 'X', name: 'InPost PaczkoPunkt POP-OLS19' })).toBe('pop');
+    });
+
+    it('should default to apm on the heuristic path when no POP signal is present', () => {
+      expect(classifyInpostPointType({ id: 'OLS06A', name: 'InPost Paczkomat OLS06A' })).toBe('apm');
+      expect(classifyInpostPointType({})).toBe('apm');
     });
   });
 

--- a/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
@@ -21,9 +21,10 @@ import type {
   PickupPoint,
   PickupPointAddress,
   PickupPointStatus,
+  PickupPointType,
   FindPickupPointsQuery,
 } from '@openlinker/core/shipping';
-import { PICKUP_POINT_STATUS } from '@openlinker/core/shipping';
+import { PICKUP_POINT_STATUS, PICKUP_POINT_TYPE } from '@openlinker/core/shipping';
 import type { InpostConnectionConfig, InpostSenderContact } from '../../domain/types/inpost-config.types';
 import type {
   ShipXAddress,
@@ -140,6 +141,7 @@ export function toTrackingSnapshot(status: ShipmentStatus, providerStatus: strin
 
 /** Map a ShipX point to the neutral `PickupPoint`. */
 export function toPickupPoint(point: ShipXPoint): PickupPoint {
+  const type = normalizePointTypeTokens(point.type);
   return {
     providerId: point.name,
     name: point.name,
@@ -147,7 +149,44 @@ export function toPickupPoint(point: ShipXPoint): PickupPoint {
     status: mapPickupPointStatus(point.status),
     lat: point.location?.latitude,
     lon: point.location?.longitude,
+    pointType: classifyInpostPointType({ id: point.name, name: point.display_name, type }),
+    ...(type !== undefined && { type }),
   };
+}
+
+/**
+ * Classify an InPost pickup point as a Paczkomat (`apm`) or a PaczkoPunkt
+ * (`pop`), #1433.
+ *
+ * Authoritative when the ShipX `type` list is present: a list carrying `pop`
+ * or `parcel_locker_superpop` is a PaczkoPunkt, otherwise a Paczkomat (both
+ * carry the shared `parcel_locker` token, so it never discriminates). When
+ * `type` is absent, falls back to a heuristic on the point `id`
+ * (`POP-` prefix, case-insensitive) or display `name` (contains
+ * "PaczkoPunkt"). Pure — no I/O.
+ */
+export function classifyInpostPointType(input: {
+  id?: string;
+  name?: string;
+  type?: readonly string[];
+}): PickupPointType {
+  if (input.type && input.type.length > 0) {
+    const tokens = input.type.map((t) => t.toLowerCase());
+    return tokens.includes('pop') || tokens.includes('parcel_locker_superpop')
+      ? PICKUP_POINT_TYPE.PartnerPoint
+      : PICKUP_POINT_TYPE.Automat;
+  }
+  const idIsPop = (input.id ?? '').toLowerCase().startsWith('pop-');
+  const nameIsPop = (input.name ?? '').toLowerCase().includes('paczkopunkt');
+  return idIsPop || nameIsPop ? PICKUP_POINT_TYPE.PartnerPoint : PICKUP_POINT_TYPE.Automat;
+}
+
+/** Normalize the ShipX `type` (string | string[]) to a token array. */
+function normalizePointTypeTokens(raw?: readonly string[] | string): readonly string[] | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  return typeof raw === 'string' ? [raw] : raw;
 }
 
 /** Build the `GET /v1/points` query string from the neutral finder query. */

--- a/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
@@ -142,7 +142,7 @@ export function toTrackingSnapshot(status: ShipmentStatus, providerStatus: strin
 /** Map a ShipX point to the neutral `PickupPoint`. */
 export function toPickupPoint(point: ShipXPoint): PickupPoint {
   const type = normalizePointTypeTokens(point.type);
-  return {
+  const result: PickupPoint = {
     providerId: point.name,
     name: point.name,
     address: toPickupPointAddress(point),
@@ -150,8 +150,11 @@ export function toPickupPoint(point: ShipXPoint): PickupPoint {
     lat: point.location?.latitude,
     lon: point.location?.longitude,
     pointType: classifyInpostPointType({ id: point.name, name: point.display_name, type }),
-    ...(type !== undefined && { type }),
   };
+  if (type !== undefined) {
+    result.type = type;
+  }
+  return result;
 }
 
 /**
@@ -164,6 +167,11 @@ export function toPickupPoint(point: ShipXPoint): PickupPoint {
  * `type` is absent, falls back to a heuristic on the point `id`
  * (`POP-` prefix, case-insensitive) or display `name` (contains
  * "PaczkoPunkt"). Pure — no I/O.
+ *
+ * The Allegro order-source adapter (`AllegroOrderSourceAdapter.
+ * classifyPickupPointType`) carries a deliberately-duplicated copy of the
+ * fallback branch only (no ShipX `type` list at ingestion). Keep the two in
+ * sync — a change to this heuristic should prompt an equivalent edit there.
  */
 export function classifyInpostPointType(input: {
   id?: string;


### PR DESCRIPTION
## What & why

Allegro's "Allegro Paczkomaty InPost" is one delivery method whose buyer picks either an InPost **Paczkomat (APM automat)** or a **PaczkoPunkt (POP)**. Both arrive with an identical `delivery.method` (id `2488f7b7-...`, name "Allegro Paczkomaty InPost") - verified on two live sandbox orders - so the method carries no signal. OL neither modelled nor read the pickup-point type, collapsing both into one `paczkomat` flow.

Ground truth (public, no-auth `GET https://api-shipx-pl.easypack24.net/v1/points/{id}`):
- automat `OLS06A` → `type: ["parcel_locker"]`
- PaczkoPunkt `POP-OLS19` → `type: ["parcel_locker","parcel_locker_superpop","pok","pop"]`

Both carry `parcel_locker`, so **no ShipX service change is needed** - shipping to a POP via `inpost_locker_standard` + `target_point` is valid for both. This PR only lets OL tell them apart.

## Changes

- `classifyInpostPointType` (inpost mapper): authoritative when the ShipX `type` array is present (`pop` / `parcel_locker_superpop` → `pop`), id/name heuristic (`POP-` prefix, "PaczkoPunkt") as fallback.
- Neutral `PickupPoint` gains `pointType: 'apm'|'pop'` (+ raw `type`); `OrderPickupPoint` gains `pointType`; `ShipXPoint` gains `type`/`display_name`; `toPickupPoint` carries it.
- Allegro `resolvePickupPoint` infers `pointType` from id/name (no network call in the ingestion hot path; the authoritative `type` path is used where the `/v1/points` finder already runs).
- FE: the order delivery panel labels the point "Paczkomat" vs "PaczkoPunkt" (falls back to the current label when absent).

## Design notes

- The `'apm'|'pop'` union is canonical in `shipping`; a value-identical local union in `orders` avoids a new cyclic `orders→shipping` edge (shipping already depends on orders).
- The full classifier lives in the InPost package; Allegro carries only a tiny local id/name heuristic to avoid an integration→integration dependency.

## Quality gate (scoped)

- eslint (changed files): clean
- type-check: core, integrations-inpost, integrations-allegro, web - all pass
- cross-context import invariant: pass
- specs: inpost mapper 25/25 (both classifier paths + `toPickupPoint`), allegro order-source 56/56 (pointType inference), FE order-delivery-panel 4/4

Closes #1433
Independent of the other shipment PRs (branched off main). Complements #1432 (`sending_method`); the sender-handoff axis is orthogonal to the receiver point type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
