### PR TITLE
feat(shipping): source COD amount from Allegro and gate cash-on-delivery on payment status

### DIFF
--- a/apps/web/src/features/orders/api/order-snapshot.schema.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.ts
@@ -79,11 +79,24 @@ const orderPickupPointSchema = z.object({
   description: z.string().nullish(),
 });
 
+/**
+ * Marketplace-sourced cash-on-delivery collect amount (#1435). Persisted onto
+ * the snapshot by the backend for a COD order whose source exposes the amount
+ * (Allegro `summary.totalToPay`). Absent for prepaid orders and legacy /
+ * non-Allegro COD. `amount` is a decimal string (money crosses the boundary as
+ * a string to avoid float drift), currency an ISO 4217 code.
+ */
+const codToCollectSchema = z.object({
+  amount: z.string(),
+  currency: z.string(),
+});
+
 export type ParsedOrderItem = z.infer<typeof orderItemSchema>;
 export type ParsedAddress = z.infer<typeof addressSchema>;
 export type ParsedOrderTotals = z.infer<typeof orderTotalsSchema>;
 export type ParsedOrderShipping = z.infer<typeof orderShippingSchema>;
 export type ParsedOrderPickupPoint = z.infer<typeof orderPickupPointSchema>;
+export type ParsedCodToCollect = z.infer<typeof codToCollectSchema>;
 
 export interface ParseWarning {
   field: string;
@@ -136,6 +149,12 @@ export interface ParsedOrderSnapshot {
   pickupPoint?: ParsedOrderPickupPoint;
   /** Source-reported payment status (#928); absent when the source didn't report it. */
   paymentStatus?: PaymentStatus;
+  /**
+   * Marketplace-sourced COD collect amount (#1435). Present only for a COD order
+   * whose source exposed the amount; drives the read-only "from Allegro" COD
+   * panel on the Generate-label form. Absent ⇒ the operator-typed COD fallback.
+   */
+  codToCollect?: ParsedCodToCollect;
   parseWarnings: ParseWarning[];
 }
 
@@ -283,6 +302,22 @@ export function parseOrderSnapshot(snapshot: Record<string, unknown>): ParsedOrd
     }
   }
 
+  // Sourced COD collect amount (#1435) — optional (COD orders with a sourced amount).
+  let codToCollect: ParsedCodToCollect | undefined;
+  if (snapshot.codToCollect !== undefined && snapshot.codToCollect !== null) {
+    const candidate = asRecord(snapshot.codToCollect);
+    if (candidate === null) {
+      warnings.push({ field: 'codToCollect', message: 'expected an object' });
+    } else {
+      const result = codToCollectSchema.safeParse(candidate);
+      if (result.success) {
+        codToCollect = result.data;
+      } else {
+        warnings.push({ field: 'codToCollect', message: firstZodMessage(result.error) });
+      }
+    }
+  }
+
   return {
     id,
     orderNumber,
@@ -296,6 +331,7 @@ export function parseOrderSnapshot(snapshot: Record<string, unknown>): ParsedOrd
     shipping,
     pickupPoint,
     paymentStatus: readPaymentStatus(snapshot.paymentStatus, warnings),
+    codToCollect,
     parseWarnings: warnings,
   };
 }

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -166,21 +166,86 @@ describe('GenerateLabelForm — happy path', () => {
     resolveRef.current?.({ kind: 'dispatched', shipment: null });
   });
 
-  it('should include COD in the dispatch payload when an amount is entered, normalising the decimal (#966)', async () => {
+  it('should send the read-only sourced Allegro amount for a COD order with codToCollect (#1435)', async () => {
     const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
     const apiClient = createMockApiClient({ shipments: { generateLabel } });
+    const order = makeOrder({
+      orderSnapshot: {
+        ...makeOrder().orderSnapshot,
+        paymentStatus: 'cod',
+        codToCollect: { amount: '510.94', currency: 'PLN' },
+      },
+    });
 
-    renderWithProviders(
-      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
-      { apiClient },
+    renderWithProviders(<GenerateLabelForm order={order} onSuccess={vi.fn()} onCancel={vi.fn()} />, {
+      apiClient,
+    });
+
+    // Read-only "from Allegro" panel: amount shown, no manual input rendered.
+    expect(screen.getByText(/from Allegro/i)).toBeInTheDocument();
+    expect(screen.getByText(/510\.94/)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/COD amount to collect/i)).toBeNull();
+
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() =>
+      expect(generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ cod: { amount: '510.94', currency: 'PLN' } }),
+      ),
     );
+  });
+
+  it('should render no COD UI and send no cod for a prepaid order (#1435)', async () => {
+    const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
+    const apiClient = createMockApiClient({ shipments: { generateLabel } });
+    const order = makeOrder({
+      orderSnapshot: { ...makeOrder().orderSnapshot, paymentStatus: 'paid' },
+    });
+
+    renderWithProviders(<GenerateLabelForm order={order} onSuccess={vi.fn()} onCancel={vi.fn()} />, {
+      apiClient,
+    });
+
+    expect(screen.queryByText(/Cash on delivery/i)).toBeNull();
+    expect(screen.queryByLabelText(/COD amount to collect/i)).toBeNull();
+
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() => expect(generateLabel).toHaveBeenCalled());
+    expect((generateLabel.mock.calls[0][0] as { cod?: unknown }).cod).toBeUndefined();
+  });
+
+  it('should show the fallback manual COD input for a COD order with no sourced amount and send it, normalising the decimal (#1435)', async () => {
+    const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
+    const apiClient = createMockApiClient({ shipments: { generateLabel } });
+    const order = makeOrder({
+      orderSnapshot: { ...makeOrder().orderSnapshot, paymentStatus: 'cod' },
+    });
+
+    renderWithProviders(<GenerateLabelForm order={order} onSuccess={vi.fn()} onCancel={vi.fn()} />, {
+      apiClient,
+    });
+
+    // Fallback: a manual amount input is the only typed case.
+    const codInput = screen.getByLabelText(/COD amount to collect/i);
+    expect(codInput).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
     fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
     fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
     fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
     // Comma decimal separator → normalised to a dot for the wire shape.
-    fireEvent.change(screen.getByLabelText(/COD amount to collect/i), { target: { value: '129,90' } });
+    fireEvent.change(codInput, { target: { value: '129,90' } });
 
     fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
 
@@ -191,14 +256,38 @@ describe('GenerateLabelForm — happy path', () => {
     );
   });
 
-  it('should omit COD from the payload when no amount is entered', async () => {
+  it('should allow manual COD for an order with no reported payment status (DPD/PrestaShop) and send it (#1435 regression)', async () => {
     const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
     const apiClient = createMockApiClient({ shipments: { generateLabel } });
+    // Default makeOrder() has no paymentStatus — the non-marketplace path.
+    renderWithProviders(<GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />, {
+      apiClient,
+    });
 
-    renderWithProviders(
-      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
-      { apiClient },
+    const codInput = screen.getByLabelText(/COD amount to collect/i);
+    expect(codInput).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+    fireEvent.change(codInput, { target: { value: '129.90' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() =>
+      expect(generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ cod: { amount: '129.90', currency: 'PLN' } }),
+      ),
     );
+  });
+
+  it('should omit COD when an unknown-payment order leaves the amount blank (#1435)', async () => {
+    const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
+    const apiClient = createMockApiClient({ shipments: { generateLabel } });
+    renderWithProviders(<GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />, {
+      apiClient,
+    });
 
     fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
     fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -36,6 +36,7 @@ import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { KeyValueList, type KeyValueItem } from '../../../shared/ui/key-value-list';
 import { Select } from '../../../shared/ui/select';
+import { StatusBadge } from '../../../shared/ui/status-badge';
 import { useToast } from '../../../shared/ui/toast-provider';
 
 import type { OrderRecord } from '../api/orders.types';
@@ -175,7 +176,9 @@ export function GenerateLabelForm({
       paczkomatId: snapshot.pickupPoint?.id ?? '',
       // Locker size — required by the BE for paczkomat shipments (#764).
       lockerTemplate: 'medium',
-      // COD (#966, decision A) — operator-entered at dispatch; not order-sourced.
+      // COD (#1435) — payment-status-driven. The amount is sourced from the
+      // order (Allegro) for a COD order; these fields back only the fallback
+      // manual input shown for a COD order with no sourced amount.
       codAmount: '',
       codCurrency: 'PLN',
     },
@@ -194,10 +197,27 @@ export function GenerateLabelForm({
   const codAmountRegister = form.register('codAmount');
   const codCurrencyRegister = form.register('codCurrency');
 
-  // COD orders are flagged by the snapshot's payment status (#928). The COD
-  // amount itself isn't persisted (decision A) — the operator enters what to
-  // collect here at dispatch.
-  const isCodOrder = snapshot.paymentStatus === 'cod';
+  // COD is driven by the order's payment status + the marketplace-sourced
+  // amount (#1435). The gate is a block-list on the one prepaid status, not an
+  // allow-list, so sources that don't report payment (PrestaShop / WooCommerce /
+  // DPD) keep the manual-COD path (#966). States:
+  //   - COD + sourced amount            → read-only "from Allegro" panel; submit
+  //                                       sends the sourced amount.
+  //   - COD + no sourced amount         → fallback manual input.
+  //   - unknown / unreported payment    → fallback manual input (DPD/PrestaShop
+  //                                       operator-typed COD, as before).
+  //   - explicitly prepaid (`paid`) /   → NO COD UI, submit sends no cod.
+  //     dispatch-blocked (awaiting/refunded, already blocked upstream)
+  const paymentStatus = snapshot.paymentStatus;
+  const sourcedCod = snapshot.codToCollect;
+  const isCodOrder = paymentStatus === 'cod';
+  // COD surface is allowed unless the order is explicitly prepaid or otherwise
+  // payment-blocked (awaiting/refunded never dispatch, but stay defensive here).
+  const codAllowed =
+    paymentStatus !== 'paid' && paymentStatus !== 'awaiting' && paymentStatus !== 'refunded';
+  // The read-only "from Allegro" panel only applies to a marketplace COD order
+  // that carried a sourced amount; every other allowed state uses the input.
+  const showSourcedCod = isCodOrder && sourcedCod !== undefined;
 
   // Focus first input on mount (a11y — focus enters the inline expansion).
   const firstInputRef = useRef<HTMLInputElement | null>(null);
@@ -218,6 +238,19 @@ export function GenerateLabelForm({
   }, [mutation.isPending]);
 
   const onSubmit: SubmitHandler<GenerateLabelFormSubmission> = async (values) => {
+    // COD payload by state (#1435). Prepaid / blocked orders never send COD; a
+    // marketplace-sourced amount is sent verbatim; otherwise the operator-typed
+    // amount is honoured (COD-unsourced marketplace order, or an unreported-
+    // payment source like PrestaShop/DPD). The BE re-enforces the gate — the FE
+    // is not authorization — but sending the right shape keeps the two aligned.
+    const cod = !codAllowed
+      ? undefined
+      : showSourcedCod && sourcedCod
+        ? { amount: sourcedCod.amount, currency: sourcedCod.currency }
+        : values.codAmount && values.codAmount.length > 0
+          ? { amount: values.codAmount, currency: values.codCurrency ?? 'PLN' }
+          : undefined;
+
     const input: GenerateLabelInput = {
       sourceConnectionId: order.sourceConnectionId,
       ...buildDispatchItem({
@@ -232,10 +265,7 @@ export function GenerateLabelForm({
           template: shippingMethod === 'paczkomat' ? values.lockerTemplate : undefined,
         },
         paczkomatId: values.paczkomatId,
-        cod:
-          values.codAmount && values.codAmount.length > 0
-            ? { amount: values.codAmount, currency: values.codCurrency ?? 'PLN' }
-            : undefined,
+        cod,
       }),
     };
     try {
@@ -459,34 +489,60 @@ export function GenerateLabelForm({
           </FormField>
         ) : null}
 
-        {/* Cash on delivery (#966, decision A) — optional, operator-entered.
-            COD-incapable carriers ignore it; DPD translates it to its COD
-            service. Pre-flagged when the order's payment status is COD. */}
-        <div className="form-field">
-          <p className="form-field__label">Cash on delivery (optional)</p>
-          <p className="form-field__description">
-            {isCodOrder
-              ? 'This order is cash-on-delivery — enter the amount to collect at the door.'
-              : 'Amount to collect on delivery. Leave blank for a prepaid shipment.'}
-          </p>
-          <div className="generate-label-form__cod">
-            <Input
-              {...codAmountRegister}
-              inputMode="decimal"
-              placeholder="129.90"
-              aria-label="COD amount to collect"
-              invalid={Boolean(form.formState.errors.codAmount)}
-            />
-            <Select {...codCurrencyRegister} aria-label="COD currency">
-              {COD_CURRENCY_VALUES.map((c) => (
-                <option key={c} value={c}>
-                  {c}
-                </option>
-              ))}
-            </Select>
+        {/* Cash on delivery (#1435) — payment-status-driven. Explicitly prepaid
+            (and dispatch-blocked) orders render nothing. A marketplace COD order
+            shows the read-only sourced amount ("from Allegro"); a COD order with
+            no sourced amount, or a source that doesn't report payment
+            (PrestaShop / DPD / legacy), shows a manual input (the operator-typed
+            path, #966). */}
+        {codAllowed ? (
+          <div className="form-field generate-label-form__cod-panel">
+            <div className="generate-label-form__cod-head">
+              <StatusBadge tone="warning" withDot>
+                Cash on delivery
+              </StatusBadge>
+              {showSourcedCod ? (
+                <span className="generate-label-form__cod-source">from Allegro</span>
+              ) : null}
+            </div>
+
+            {showSourcedCod && sourcedCod ? (
+              <>
+                <p className="generate-label-form__cod-amount tabular">
+                  {sourcedCod.amount} {sourcedCod.currency}
+                </p>
+                <p className="generate-label-form__cod-note">
+                  Collected on delivery — set by the order, not editable here.
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="generate-label-form__cod-note">
+                  {isCodOrder
+                    ? "This order is cash-on-delivery, but the collect amount didn't come from the source (non-Allegro or missing). Enter the amount to collect."
+                    : 'Amount to collect on delivery. Leave blank for a prepaid shipment.'}
+                </p>
+                <div className="generate-label-form__cod">
+                  <Input
+                    {...codAmountRegister}
+                    inputMode="decimal"
+                    placeholder="129.90"
+                    aria-label="COD amount to collect"
+                    invalid={Boolean(form.formState.errors.codAmount)}
+                  />
+                  <Select {...codCurrencyRegister} aria-label="COD currency">
+                    {COD_CURRENCY_VALUES.map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+                <FieldError id="cod-error" message={form.formState.errors.codAmount?.message} />
+              </>
+            )}
           </div>
-          <FieldError id="cod-error" message={form.formState.errors.codAmount?.message} />
-        </div>
+        ) : null}
 
         {showSlowNotice ? (
           <div role="status" aria-live="polite" className="generate-label-form__slow-notice">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8987,6 +8987,46 @@ html[data-density='compact'] .status-badge {
   gap: var(--space-2);
 }
 
+/* ── COD payment panel (#1435) ──────────────────────────────────────────────
+ * Payment-status-driven COD surface. Neutral recap container shared by the
+ * read-only "from Allegro" amount and the fallback manual input, so both read
+ * as siblings; the status is carried by a StatusBadge pill (reused, not a new
+ * hue). No heavy tone-filled panel. */
+.generate-label-form__cod-panel {
+  background: var(--bg-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+}
+
+.generate-label-form__cod-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.generate-label-form__cod-source {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.generate-label-form__cod-amount {
+  margin: var(--space-2) 0 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.generate-label-form__cod-note {
+  margin: var(--space-1) 0 0;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+}
+
+.generate-label-form__cod-panel .generate-label-form__cod {
+  margin-top: var(--space-2);
+}
+
 .generate-label-form__slow-notice {
   font-size: 0.8125rem;
   color: var(--text-secondary);

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -591,6 +591,7 @@ export class OrderIngestionService implements IOrderIngestionService {
       pickupPoint: incoming.pickupPoint,
       deliverySmart: incoming.deliverySmart,
       paymentStatus: incoming.paymentStatus,
+      codToCollect: incoming.codToCollect,
       dispatchTime: incoming.dispatchTime,
       placedAt: incoming.placedAt ? new Date(incoming.placedAt) : undefined,
       createdAt: new Date(incoming.createdAt),

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -90,6 +90,10 @@ export class OrderRecordService implements IOrderRecordService {
       // reported" from "Smart explicitly false".
       ...(order.deliverySmart !== undefined && { deliverySmart: order.deliverySmart }),
       ...(order.paymentStatus !== undefined && { paymentStatus: order.paymentStatus }),
+      // Marketplace-sourced COD collect amount (#1435) — present-only, like
+      // paymentStatus. Read back by `OrderRecord.codToCollect` for the dispatch
+      // COD gate; absent for prepaid orders and sources that don't expose it.
+      ...(order.codToCollect !== undefined && { codToCollect: order.codToCollect }),
       // Dispatch (ship-by) window carried through for fidelity; the scalar
       // deadline is denormalized to the `dispatchByAt` column below (#927).
       ...(order.dispatchTime !== undefined && { dispatchTime: order.dispatchTime }),
@@ -172,6 +176,8 @@ export class OrderRecordService implements IOrderRecordService {
       // See `persistOrder` above for the absent-vs-false rationale.
       ...(incoming.deliverySmart !== undefined && { deliverySmart: incoming.deliverySmart }),
       ...(incoming.paymentStatus !== undefined && { paymentStatus: incoming.paymentStatus }),
+      // Marketplace-sourced COD collect amount (#1435) — see persistOrder.
+      ...(incoming.codToCollect !== undefined && { codToCollect: incoming.codToCollect }),
       ...(incoming.dispatchTime !== undefined && { dispatchTime: incoming.dispatchTime }),
       // Buyer-placed-on-marketplace time (#926) — ISO string passed through verbatim.
       ...(incoming.placedAt !== undefined && { placedAt: incoming.placedAt }),

--- a/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
@@ -43,3 +43,26 @@ describe('OrderRecord.paymentStatus', () => {
     expect(makeRecord({ paymentStatus: null }).paymentStatus).toBeUndefined();
   });
 });
+
+describe('OrderRecord.codToCollect (#1435)', () => {
+  it('returns the sourced amount when the snapshot carries a well-formed pair', () => {
+    expect(makeRecord({ codToCollect: { amount: '510.94', currency: 'PLN' } }).codToCollect).toEqual({
+      amount: '510.94',
+      currency: 'PLN',
+    });
+  });
+
+  it('returns undefined when the snapshot has no codToCollect key', () => {
+    expect(makeRecord({}).codToCollect).toBeUndefined();
+  });
+
+  it('returns undefined when the value is not an object', () => {
+    expect(makeRecord({ codToCollect: '510.94' }).codToCollect).toBeUndefined();
+    expect(makeRecord({ codToCollect: null }).codToCollect).toBeUndefined();
+  });
+
+  it('returns undefined when amount or currency is missing / non-string', () => {
+    expect(makeRecord({ codToCollect: { amount: '510.94' } }).codToCollect).toBeUndefined();
+    expect(makeRecord({ codToCollect: { amount: 510.94, currency: 'PLN' } }).codToCollect).toBeUndefined();
+  });
+});

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -11,6 +11,7 @@ import type { OrderRecordStatus } from '../types/order-record.types';
 import type { OrderSyncStatus, SyncAttempt } from '../types/order-sync.types';
 import { PaymentStatusValues } from '../types/payment-status.types';
 import type { PaymentStatus } from '../types/payment-status.types';
+import type { CodToCollect } from '../types/cod-to-collect.types';
 import type { FulfillmentRollupState } from '../types/order-fulfillment.types';
 
 export type { OrderSyncStatus, SyncAttempt } from '../types/order-sync.types';
@@ -72,6 +73,26 @@ export class OrderRecord {
     const value = this.orderSnapshot.paymentStatus;
     return typeof value === 'string' && (PaymentStatusValues as readonly string[]).includes(value)
       ? (value as PaymentStatus)
+      : undefined;
+  }
+
+  /**
+   * Typed, fail-safe read of the marketplace-sourced COD collect amount (#1435)
+   * from the snapshot. Pure derivation of an already-loaded field (ADR-011): no
+   * I/O, no mutation. Mirrors the {@link paymentStatus} getter — centralises the
+   * `orderSnapshot.codToCollect` key + narrowing so the shipping dispatch gate
+   * binds to a typed contract, not the JSON layout. Returns `undefined` when the
+   * source didn't supply it (prepaid orders, legacy/non-Allegro COD) or the
+   * stored value isn't a well-formed `{ amount, currency }` pair.
+   */
+  get codToCollect(): CodToCollect | undefined {
+    const value = this.orderSnapshot.codToCollect;
+    if (typeof value !== 'object' || value === null) {
+      return undefined;
+    }
+    const { amount, currency } = value as Record<string, unknown>;
+    return typeof amount === 'string' && typeof currency === 'string'
+      ? { amount, currency }
       : undefined;
   }
 }

--- a/libs/core/src/orders/domain/types/cod-to-collect.types.ts
+++ b/libs/core/src/orders/domain/types/cod-to-collect.types.ts
@@ -1,0 +1,28 @@
+/**
+ * Cash-on-Delivery Collect Amount (#1435)
+ *
+ * Source-derived amount the buyer pays on delivery for a cash-on-delivery
+ * order. Carried on the neutral order model (`IncomingOrder` / `Order` +
+ * persisted snapshot) so the shipment-dispatch gate can prefer the
+ * marketplace-sourced amount over an operator-typed value, and gate COD on the
+ * order's payment status rather than trusting FE input.
+ *
+ * Its own one-shape-per-file type (engineering-standards §"Type Definitions in
+ * Separate Files"), mirroring the shipping-context `ShipmentCod` shape — but
+ * owned by the orders context so no cross-context dependency on shipping is
+ * introduced (orders never depends on shipping).
+ *
+ * `amount` is a decimal **string** (not a number) so the value crosses the
+ * adapter/persistence boundary without binary float rounding (`'510.94'`,
+ * not `510.94`) — matching how source adapters (Allegro `summary.totalToPay`)
+ * express money.
+ *
+ * @module libs/core/src/orders/domain/types
+ */
+
+export interface CodToCollect {
+  /** Amount to collect on delivery, as a decimal string (e.g. `'510.94'`). */
+  amount: string;
+  /** ISO 4217 currency code (e.g. `'PLN'`). */
+  currency: string;
+}

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -17,6 +17,7 @@ import type {
   PriceTaxTreatment,
 } from './order.types';
 import type { PaymentStatus } from './payment-status.types';
+import type { CodToCollect } from './cod-to-collect.types';
 
 export interface IncomingOrder {
   /**
@@ -80,6 +81,14 @@ export interface IncomingOrder {
   deliverySmart?: boolean;
   /** Source-reported payment status (#928); absent when the source did not report it. */
   paymentStatus?: PaymentStatus;
+
+  /**
+   * Marketplace-sourced cash-on-delivery collect amount (#1435). Set by the
+   * source adapter only for a cash-on-delivery order (Allegro maps
+   * `summary.totalToPay` — the buyer pays the full order total on delivery).
+   * Absent for prepaid orders and for sources that don't expose it.
+   */
+  codToCollect?: CodToCollect;
 
   /**
    * Marketplace dispatch (ship-by) commitment window (#927). The SLA deadline

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -9,6 +9,7 @@
  * @module libs/core/src/orders/domain/types
  */
 import type { PaymentStatus } from './payment-status.types';
+import type { CodToCollect } from './cod-to-collect.types';
 
 /**
  * Order status values
@@ -121,6 +122,14 @@ export interface Order {
   deliverySmart?: boolean;
   /** Source-reported payment status (#928); absent when the source did not report it. */
   paymentStatus?: PaymentStatus;
+  /**
+   * Marketplace-sourced cash-on-delivery collect amount (#1435). Present only
+   * for a cash-on-delivery order whose source exposes the collectable amount
+   * (Allegro `summary.totalToPay`). Absent for prepaid orders and for sources
+   * that don't surface it (legacy / non-Allegro COD → operator-typed fallback).
+   * The dispatch gate prefers this over the operator-supplied dispatch amount.
+   */
+  codToCollect?: CodToCollect;
   /**
    * When the buyer placed the order on the source marketplace (#926). Distinct
    * from `createdAt`/`updatedAt`, which are OpenLinker's ingestion clocks — this

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -72,6 +72,7 @@ export {
 } from './domain/types/order.types';
 export { PaymentStatusValues, PAYMENT_STATUS } from './domain/types/payment-status.types';
 export type { PaymentStatus } from './domain/types/payment-status.types';
+export type { CodToCollect } from './domain/types/cod-to-collect.types';
 export { OrderCreate, OrderRef, OrderSourceRef } from './domain/types/order-processor.types';
 export {
   IncomingOrder,

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -26,14 +26,23 @@ import { OrderNotDispatchablePaymentStatusException } from '../../domain/excepti
 import { ShippingProviderRejectionException } from '../../domain/exceptions/shipping-provider-rejection.exception';
 import { Logger } from '@openlinker/shared/logging';
 
-/** Build an OrderRecord whose snapshot carries the given payment status (or none). */
-function makeOrderRecord(paymentStatus?: PaymentStatus): OrderRecord {
+/**
+ * Build an OrderRecord whose snapshot carries the given payment status (or none)
+ * and, optionally, a marketplace-sourced COD collect amount (#1435).
+ */
+function makeOrderRecord(
+  paymentStatus?: PaymentStatus,
+  codToCollect?: { amount: string; currency: string },
+): OrderRecord {
+  const snapshot: Record<string, unknown> = {};
+  if (paymentStatus !== undefined) snapshot.paymentStatus = paymentStatus;
+  if (codToCollect !== undefined) snapshot.codToCollect = codToCollect;
   return new OrderRecord(
     'ol_order_1',
     'ol_customer_1',
     SOURCE,
     null,
-    paymentStatus === undefined ? {} : { paymentStatus },
+    snapshot,
     [],
     'ready',
     new Date(),
@@ -315,7 +324,8 @@ describe('ShipmentDispatchService', () => {
       expect(result).toEqual({ kind: 'dispatched', shipment: generated });
     });
 
-    it('should forward caller-supplied COD verbatim to generateLabel (#962)', async () => {
+    /** Shared happy-path routing + repo mocks for the COD gate tests (#1435). */
+    function primeCodDispatch(): void {
       routing.resolve.mockResolvedValue(
         resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier, processorConnectionId: INPOST }),
       );
@@ -327,6 +337,59 @@ describe('ShipmentDispatchService', () => {
         labelPdfRef: 'dpd-1',
       });
       repository.update.mockResolvedValue(makeShipment({ status: 'generated' }));
+    }
+
+    it('should apply the order-sourced COD amount for a cod order, ignoring the caller amount (#1435)', async () => {
+      primeCodDispatch();
+      orders.getOrderRecord.mockResolvedValue(
+        makeOrderRecord('cod', { amount: '510.94', currency: 'PLN' }),
+      );
+
+      await service.dispatch(makeInput({ cod: { amount: '1.00', currency: 'PLN' } }));
+
+      expect(adapter.generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ cod: { amount: '510.94', currency: 'PLN' } }),
+      );
+    });
+
+    it('should fall back to the caller COD amount for a cod order with no sourced amount (#1435)', async () => {
+      primeCodDispatch();
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord('cod'));
+
+      const cod = { amount: '39.99', currency: 'PLN' };
+      await service.dispatch(makeInput({ cod }));
+
+      expect(adapter.generateLabel).toHaveBeenCalledWith(expect.objectContaining({ cod }));
+    });
+
+    it('should strip caller-supplied COD for an explicitly prepaid (paid) order (#1435)', async () => {
+      primeCodDispatch();
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord('paid'));
+
+      await service.dispatch(makeInput({ cod: { amount: '39.99', currency: 'PLN' } }));
+
+      expect(adapter.generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ cod: undefined }),
+      );
+    });
+
+    // Regression guard (#1435): non-marketplace sources (PrestaShop / WooCommerce)
+    // don't report payment status, so an operator-typed COD (DPD, #966) must pass
+    // through when the status is unknown — the gate is a `paid`-only block-list,
+    // NOT an allow-list.
+    it('should keep caller-supplied COD when there is no order record (#1435)', async () => {
+      primeCodDispatch();
+      orders.getOrderRecord.mockResolvedValue(null);
+
+      const cod = { amount: '39.99', currency: 'PLN' };
+      await service.dispatch(makeInput({ cod }));
+
+      expect(adapter.generateLabel).toHaveBeenCalledWith(expect.objectContaining({ cod }));
+    });
+
+    it('should keep caller-supplied COD when the order reports no payment status (DPD/PrestaShop) (#1435)', async () => {
+      primeCodDispatch();
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord(undefined));
 
       const cod = { amount: '39.99', currency: 'PLN' };
       await service.dispatch(makeInput({ cod }));
@@ -335,17 +398,13 @@ describe('ShipmentDispatchService', () => {
     });
 
     it('should forward cod as undefined when the caller omits it', async () => {
-      routing.resolve.mockResolvedValue(
-        resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier, processorConnectionId: INPOST }),
-      );
-      repository.findActiveByOrderId.mockResolvedValue(null);
-      repository.create.mockResolvedValue(makeShipment({ status: 'draft' }));
+      primeCodDispatch();
       adapter.generateLabel.mockResolvedValue({
         providerShipmentId: 'shipx-1',
         trackingNumber: null,
         labelPdfRef: 'shipx:label:shipx-1',
       });
-      repository.update.mockResolvedValue(makeShipment({ status: 'generated' }));
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord('cod'));
 
       await service.dispatch(makeInput());
 

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
@@ -32,8 +32,11 @@ import {
 import {
   type IOrderRecordService,
   type PaymentStatus,
+  type CodToCollect,
+  PAYMENT_STATUS,
   ORDER_RECORD_SERVICE_TOKEN,
 } from '@openlinker/core/orders';
+import type { OrderRecord } from '@openlinker/core/orders';
 
 import type { IShipmentDispatchService } from '../interfaces/shipment-dispatch.service.interface';
 import { IOrderFulfillmentProjectionService } from '../interfaces/order-fulfillment-projection.service.interface';
@@ -109,6 +112,11 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
       throw new OrderNotDispatchablePaymentStatusException(input.orderId, paymentStatus);
     }
 
+    // COD authorization gate (#1435): the FE is not authorization
+    // (frontend-architecture § App Boundary), so COD is decided server-side from
+    // the order's payment status — mirroring the #938 payment gate above.
+    const cod = this.resolveEffectiveCod(order, input.cod);
+
     switch (resolution.processorKind) {
       case FULFILLMENT_PROCESSOR_KIND.OmpFulfilled:
         // Branch-1: the OMP ships via its own carrier setup — OL generates no
@@ -121,6 +129,7 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
         const shipment = await this.dispatchViaShippingProvider(
           input,
           resolution.processorConnectionId,
+          cod,
         );
         return { kind: 'dispatched', shipment };
       }
@@ -151,9 +160,50 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
     return input.sourceDeliveryMethodId ?? undefined;
   }
 
+  /**
+   * Resolve the COD to actually apply at the carrier (#1435). COD is authorized
+   * by the order's payment status, never blindly by the dispatch caller (FE
+   * input is not authorization) — but the gate is a block-list on the one status
+   * that must never carry COD, not an allow-list, so sources that don't report
+   * payment (PrestaShop / WooCommerce / DPD / legacy) keep their operator-typed
+   * COD:
+   * - `paymentStatus === 'paid'` → strip COD, even if the caller passed one
+   *   (prevents double-charging a prepaid order via a crafted API call).
+   * - `paymentStatus === 'cod'` → prefer the marketplace-sourced `codToCollect`;
+   *   fall back to the caller-supplied amount when the source didn't provide one
+   *   (legacy / non-Allegro COD).
+   * - otherwise (`undefined` / unrecognised, or no order record) → pass the
+   *   caller amount through unchanged. Non-marketplace sources don't express
+   *   payment status, so operator-supplied COD (#966) stays authoritative here.
+   *   (`awaiting` / `refunded` never reach this point — the #938 gate blocks
+   *   dispatch entirely for them.)
+   */
+  private resolveEffectiveCod(
+    order: OrderRecord | null,
+    inputCod: CodToCollect | undefined,
+  ): CodToCollect | undefined {
+    const paymentStatus = order?.paymentStatus;
+    if (paymentStatus === PAYMENT_STATUS.Paid) {
+      if (inputCod !== undefined) {
+        this.logger.warn(
+          `Stripping COD from dispatch of order ${order?.internalOrderId ?? '(unknown)'}: ` +
+            `order is prepaid (payment status 'paid')`,
+        );
+      }
+      return undefined;
+    }
+    if (paymentStatus === PAYMENT_STATUS.Cod) {
+      return order?.codToCollect ?? inputCod;
+    }
+    // Unknown / unreported payment (non-marketplace sources) — preserve the
+    // caller-supplied COD (the pre-#1435 behavior for PrestaShop / DPD).
+    return inputCod;
+  }
+
   private async dispatchViaShippingProvider(
     input: ShipmentDispatchInput,
     processorConnectionId: string | null,
+    cod: CodToCollect | undefined,
   ): Promise<Shipment> {
     if (!processorConnectionId) {
       // A label-generating rule always carries a processor connection (it can't
@@ -255,9 +305,10 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
         deliveryMethodId: this.resolveProviderDeliveryMethodId(input),
         recipient: input.recipient,
         parcel: input.parcel,
-        // Caller-supplied COD (#962) — pass through verbatim; COD-incapable
-        // adapters ignore it, COD-capable ones translate it to their wire shape.
-        cod: input.cod,
+        // Payment-status-authorized COD (#1435): stripped for non-COD orders,
+        // sourced from the order when available, caller amount only as fallback.
+        // COD-incapable adapters ignore it; COD-capable ones translate it.
+        cod,
       });
 
       const generated = await this.shipments.update(shipment.id, {

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
@@ -33,10 +33,10 @@ import {
   type IOrderRecordService,
   type PaymentStatus,
   type CodToCollect,
+  type OrderRecord,
   PAYMENT_STATUS,
   ORDER_RECORD_SERVICE_TOKEN,
 } from '@openlinker/core/orders';
-import type { OrderRecord } from '@openlinker/core/orders';
 
 import type { IShipmentDispatchService } from '../interfaces/shipment-dispatch.service.interface';
 import { IOrderFulfillmentProjectionService } from '../interfaces/order-fulfillment-projection.service.interface';
@@ -112,11 +112,6 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
       throw new OrderNotDispatchablePaymentStatusException(input.orderId, paymentStatus);
     }
 
-    // COD authorization gate (#1435): the FE is not authorization
-    // (frontend-architecture § App Boundary), so COD is decided server-side from
-    // the order's payment status — mirroring the #938 payment gate above.
-    const cod = this.resolveEffectiveCod(order, input.cod);
-
     switch (resolution.processorKind) {
       case FULFILLMENT_PROCESSOR_KIND.OmpFulfilled:
         // Branch-1: the OMP ships via its own carrier setup — OL generates no
@@ -126,6 +121,12 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
 
       case FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier:
       case FULFILLMENT_PROCESSOR_KIND.SourceBrokered: {
+        // COD authorization gate (#1435): the FE is not authorization
+        // (frontend-architecture § App Boundary), so COD is decided server-side
+        // from the order's payment status — mirroring the #938 payment gate
+        // above. Resolved only on the label-generating path, so an OMP-fulfilled
+        // order never computes (and discards) a COD or logs a spurious strip.
+        const cod = this.resolveEffectiveCod(order, input.cod, input.orderId);
         const shipment = await this.dispatchViaShippingProvider(
           input,
           resolution.processorConnectionId,
@@ -181,19 +182,31 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
   private resolveEffectiveCod(
     order: OrderRecord | null,
     inputCod: CodToCollect | undefined,
+    orderId: string,
   ): CodToCollect | undefined {
     const paymentStatus = order?.paymentStatus;
     if (paymentStatus === PAYMENT_STATUS.Paid) {
       if (inputCod !== undefined) {
         this.logger.warn(
-          `Stripping COD from dispatch of order ${order?.internalOrderId ?? '(unknown)'}: ` +
+          `Stripping COD from dispatch of order ${orderId}: ` +
             `order is prepaid (payment status 'paid')`,
         );
       }
       return undefined;
     }
     if (paymentStatus === PAYMENT_STATUS.Cod) {
-      return order?.codToCollect ?? inputCod;
+      const resolved = order?.codToCollect ?? inputCod;
+      if (resolved === undefined) {
+        // Likely operator mistake: a COD order is being dispatched with no
+        // amount from either the marketplace source or the caller, so it would
+        // ship COD with nothing to collect. Surface it; the value is unchanged.
+        this.logger.warn(
+          `COD order ${orderId} resolved to no COD amount ` +
+            `(no marketplace-sourced amount and no caller-supplied amount): ` +
+            `it will ship without a collectable amount`,
+        );
+      }
+      return resolved;
     }
     // Unknown / unreported payment (non-marketplace sources) — preserve the
     // caller-supplied COD (the pre-#1435 behavior for PrestaShop / DPD).

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -329,6 +329,8 @@ describe('AllegroOrderSourceAdapter', () => {
       expect(incoming.shippingAddress?.city).toBe('Warsaw');
       // #928 — prepaid ONLINE order with finishedAt → paid (dispatch permitted).
       expect(incoming.paymentStatus).toBe('paid');
+      // #1435 — a prepaid (non-COD) order carries no sourced COD amount.
+      expect(incoming.codToCollect).toBeUndefined();
     });
 
     it('should report pending status when the buyer has not yet completed payment', async () => {
@@ -355,6 +357,9 @@ describe('AllegroOrderSourceAdapter', () => {
       // #928 — CASH_ON_DELIVERY → cod regardless of order-lifecycle status
       // (dispatch is permitted for COD; the order ships and is paid on receipt).
       expect(incoming.paymentStatus).toBe('cod');
+      // #1435 — a COD order carries the sourced collect amount (the full
+      // order total the buyer pays on delivery) from summary.totalToPay.
+      expect(incoming.codToCollect).toEqual({ amount: '10.00', currency: 'PLN' });
     });
 
     describe('dispatch time / ship-by (#927)', () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -10,6 +10,7 @@
  * @implements {OrderSourcePort}
  */
 
+import { PAYMENT_STATUS } from '@openlinker/core/orders';
 import type {
   OrderSourcePort,
   SourceOptionsReader,
@@ -306,6 +307,20 @@ export class AllegroOrderSourceAdapter
         ? Number.parseFloat(checkoutForm.delivery.cost.amount)
         : Math.max(0, total - subtotal);
 
+      // #1435 — for a cash-on-delivery order the buyer pays the full order total
+      // on delivery, so the collectable amount is `summary.totalToPay` verbatim
+      // (decimal string preserved, no float round-trip). Keyed off the neutral
+      // payment status (reusing `deriveAllegroPaymentStatus`, not a duplicate
+      // COD-type compare); absent for prepaid / awaiting orders.
+      const paymentStatus = deriveAllegroPaymentStatus(checkoutForm.payment);
+      const codToCollect =
+        paymentStatus === PAYMENT_STATUS.Cod
+          ? {
+              amount: checkoutForm.summary.totalToPay.amount,
+              currency: checkoutForm.summary.totalToPay.currency,
+            }
+          : undefined;
+
       return {
         externalOrderId: checkoutFormId,
         orderNumber: checkoutFormId,
@@ -340,7 +355,8 @@ export class AllegroOrderSourceAdapter
         shipping: this.resolveShipping(checkoutForm),
         pickupPoint: this.resolvePickupPoint(checkoutForm),
         deliverySmart: checkoutForm.delivery?.smart,
-        paymentStatus: deriveAllegroPaymentStatus(checkoutForm.payment),
+        paymentStatus,
+        codToCollect,
         dispatchTime: this.resolveDispatchTime(checkoutForm),
         placedAt,
         createdAt,


### PR DESCRIPTION
## What & why

OL already derived `paymentStatus: 'cod'` from Allegro (`payment.type === 'CASH_ON_DELIVERY'`) but (1) never sourced the collect amount and (2) never enforced the status - the COD field was an optional operator-typed input. So COD could be applied to a prepaid order, a COD order could ship uncollected, and the amount was hand-typed. This sources the amount from Allegro and gates COD - without regressing DPD.

## Changes

- **Allegro** (`allegro-order-source.adapter.ts`): when the payment is COD, set a neutral `codToCollect { amount, currency }` from `summary.totalToPay`; undefined otherwise.
- **Core** (`orders` types + `order-record` entity/service + ingestion): carry/persist `codToCollect` (new orders-owned `CodToCollect` type - orders must not depend on shipping).
- **Dispatch gate** (`shipment-dispatch.service.ts`): COD is a **PAID-only block-list** - an explicitly `paid` order strips COD; `cod` prefers the sourced amount (else the caller's); **unknown/absent payment status passes the caller amount through** (preserves manual COD for PrestaShop/WooCommerce/DPD - no DPD regression). `awaiting`/`refunded` are already blocked by the #938 gate.
- **FE** (`generate-label-form.tsx` + schema + dispatch-input + order-snapshot.schema, `index.css`): payment-driven COD - sourced marketplace COD → read-only "from Allegro" amount; cod-unsourced or unknown-payment → manual fallback input; explicitly paid/blocked → no COD UI. Matches the approved mockup (payment panels reuse the neutral recap container + status pill).

## DPD regression guard

DPD is the COD-capable carrier and its orders come from PrestaShop, which does not report payment status (`paymentStatus === undefined`). An earlier allow-list gate would have stripped COD from every DPD order; the block-list fix keeps it. Tests assert: an order with no payment status keeps operator COD through dispatch; a `paid` order strips it.

## Quality gate (scoped)

- eslint (changed files): 0 errors
- type-check: `@openlinker/core`, `@openlinker/web` pass
- tests: core dispatch 38 pass (incl. DPD-regression guards), FE generate-label + dispatch-input 42 pass, Allegro adapter 53 pass

Closes #1435
Independent of the other shipment PRs (off main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
