### PR TITLE
feat(connections): Erli setup wizard environment select (Production/Sandbox)

### DIFF
--- a/apps/web/src/features/connections/components/erli-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.test.tsx
@@ -21,7 +21,7 @@ describe('ErliSetupForm', () => {
     renderWithProviders(<ErliSetupForm />);
     expect(screen.getByLabelText('Connection name')).toBeInTheDocument();
     expect(screen.getByLabelText('API key')).toBeInTheDocument();
-    expect(screen.getByLabelText('Base URL (optional)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Environment')).toBeInTheDocument();
   });
 
   it('requires connection name to be non-empty', async () => {
@@ -45,25 +45,12 @@ describe('ErliSetupForm', () => {
     });
   });
 
-  it('rejects a non-HTTPS base URL override', async () => {
+  it('defaults the environment select to Production', () => {
     renderWithProviders(<ErliSetupForm />);
-    fireEvent.change(screen.getByLabelText('Connection name'), {
-      target: { value: 'My Erli Store' },
-    });
-    fireEvent.change(screen.getByLabelText('API key'), {
-      target: { value: 'sk_test_123' },
-    });
-    fireEvent.change(screen.getByLabelText('Base URL (optional)'), {
-      target: { value: 'http://api.erli.pl' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
-
-    await waitFor(() => {
-      expect(screen.getAllByText('Base URL must use HTTPS')[0]).toBeInTheDocument();
-    });
+    expect(screen.getByLabelText('Environment')).toHaveValue('production');
   });
 
-  it('submits the API key and omits config when no base URL is given', async () => {
+  it('submits the API key and omits config when Production is selected', async () => {
     const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Erli Store' });
     const apiClient = createMockApiClient({ connections: { create } });
 
@@ -91,7 +78,7 @@ describe('ErliSetupForm', () => {
     expect(await findToastTitle('Connection created')).toBeInTheDocument();
   });
 
-  it('includes baseUrl in config when supplied', async () => {
+  it('includes the sandbox baseUrl in config when Sandbox is selected', async () => {
     const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Erli Store' });
     const apiClient = createMockApiClient({ connections: { create } });
 
@@ -103,15 +90,15 @@ describe('ErliSetupForm', () => {
     fireEvent.change(screen.getByLabelText('API key'), {
       target: { value: 'sk_test_123' },
     });
-    fireEvent.change(screen.getByLabelText('Base URL (optional)'), {
-      target: { value: 'https://api.erli.pl' },
+    fireEvent.change(screen.getByLabelText('Environment'), {
+      target: { value: 'sandbox' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
 
     await waitFor(() => {
       expect(create).toHaveBeenCalledWith(
         expect.objectContaining({
-          config: { baseUrl: 'https://api.erli.pl' },
+          config: { baseUrl: 'https://sandbox.erli.dev/svc/shop-api' },
         }),
       );
     });

--- a/apps/web/src/features/connections/components/erli-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.test.tsx
@@ -50,7 +50,7 @@ describe('ErliSetupForm', () => {
     expect(screen.getByLabelText('Environment')).toHaveValue('sandbox');
   });
 
-  it('submits the API key and omits config when Production is selected', async () => {
+  it('submits the neutral production environment in config when Production is selected', async () => {
     const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Erli Store' });
     const apiClient = createMockApiClient({ connections: { create } });
 
@@ -73,7 +73,7 @@ describe('ErliSetupForm', () => {
           name: 'My Erli Store',
           platformType: 'erli',
           adapterKey: 'erli.shopapi.v1',
-          config: {},
+          config: { environment: 'production' },
           credentials: { apiKey: 'sk_test_123' },
         }),
       );
@@ -81,7 +81,7 @@ describe('ErliSetupForm', () => {
     expect(await findToastTitle('Connection created')).toBeInTheDocument();
   });
 
-  it('includes the sandbox baseUrl in config when Sandbox is selected', async () => {
+  it('submits the neutral sandbox environment in config when Sandbox is selected', async () => {
     const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Erli Store' });
     const apiClient = createMockApiClient({ connections: { create } });
 
@@ -101,7 +101,7 @@ describe('ErliSetupForm', () => {
     await waitFor(() => {
       expect(create).toHaveBeenCalledWith(
         expect.objectContaining({
-          config: { baseUrl: 'https://sandbox.erli.dev/svc/shop-api' },
+          config: { environment: 'sandbox' },
         }),
       );
     });

--- a/apps/web/src/features/connections/components/erli-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.test.tsx
@@ -45,9 +45,9 @@ describe('ErliSetupForm', () => {
     });
   });
 
-  it('defaults the environment select to Production', () => {
+  it('defaults the environment select to Sandbox', () => {
     renderWithProviders(<ErliSetupForm />);
-    expect(screen.getByLabelText('Environment')).toHaveValue('production');
+    expect(screen.getByLabelText('Environment')).toHaveValue('sandbox');
   });
 
   it('submits the API key and omits config when Production is selected', async () => {
@@ -61,6 +61,9 @@ describe('ErliSetupForm', () => {
     });
     fireEvent.change(screen.getByLabelText('API key'), {
       target: { value: 'sk_test_123' },
+    });
+    fireEvent.change(screen.getByLabelText('Environment'), {
+      target: { value: 'production' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Connect Erli' }));
 

--- a/apps/web/src/features/connections/components/erli-setup-form.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.tsx
@@ -4,7 +4,8 @@
  * Single-step wizard for creating an Erli connection. Collects:
  *   - Connection name
  *   - Shop API key (the only credential — sent as a Bearer token by the BE)
- *   - Environment (Production/Sandbox, #1377) — maps to a base URL config override
+ *   - Environment (Production/Sandbox, #1377) — persisted as the neutral
+ *     `config.environment` choice; the BE resolves it to a base URL
  *
  * Simpler than the WooCommerce form — one credential, no capabilities step
  * (capabilities default silently to the adapter manifest's supported set on
@@ -150,10 +151,7 @@ export function ErliSetupForm(): ReactElement {
         error={form.formState.errors.environment?.message}
         description="Choose Sandbox to test against Erli's sandbox before switching to production."
       >
-        <Select
-          {...form.register('environment')}
-          invalid={Boolean(form.formState.errors.environment)}
-        >
+        <Select {...form.register('environment')}>
           <option value="sandbox">Sandbox - https://sandbox.erli.dev</option>
           <option value="production">Production - https://erli.pl</option>
         </Select>

--- a/apps/web/src/features/connections/components/erli-setup-form.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.tsx
@@ -154,8 +154,8 @@ export function ErliSetupForm(): ReactElement {
           {...form.register('environment')}
           invalid={Boolean(form.formState.errors.environment)}
         >
-          <option value="production">Production — https://erli.pl</option>
-          <option value="sandbox">Sandbox — https://sandbox.erli.dev</option>
+          <option value="sandbox">Sandbox - https://sandbox.erli.dev</option>
+          <option value="production">Production - https://erli.pl</option>
         </Select>
       </FormField>
 

--- a/apps/web/src/features/connections/components/erli-setup-form.tsx
+++ b/apps/web/src/features/connections/components/erli-setup-form.tsx
@@ -4,7 +4,7 @@
  * Single-step wizard for creating an Erli connection. Collects:
  *   - Connection name
  *   - Shop API key (the only credential — sent as a Bearer token by the BE)
- *   - Optional advanced base URL override (config)
+ *   - Environment (Production/Sandbox, #1377) — maps to a base URL config override
  *
  * Simpler than the WooCommerce form — one credential, no capabilities step
  * (capabilities default silently to the adapter manifest's supported set on
@@ -35,6 +35,7 @@ import { Button } from '../../../shared/ui/button';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
 import { useToast } from '../../../shared/ui/toast-provider';
 
 export function ErliSetupForm(): ReactElement {
@@ -144,18 +145,18 @@ export function ErliSetupForm(): ReactElement {
       </FormField>
 
       <FormField
-        label="Base URL (optional)"
-        name="baseUrl"
-        error={form.formState.errors.baseUrl?.message}
-        description="Advanced — override the default Erli API base URL. Must use HTTPS. Leave blank to use the default."
+        label="Environment"
+        name="environment"
+        error={form.formState.errors.environment?.message}
+        description="Choose Sandbox to test against Erli's sandbox before switching to production."
       >
-        <Input
-          {...form.register('baseUrl')}
-          className="mono-text"
-          placeholder="https://api.erli.pl"
-          autoComplete="off"
-          invalid={Boolean(form.formState.errors.baseUrl)}
-        />
+        <Select
+          {...form.register('environment')}
+          invalid={Boolean(form.formState.errors.environment)}
+        >
+          <option value="production">Production — https://erli.pl</option>
+          <option value="sandbox">Sandbox — https://sandbox.erli.dev</option>
+        </Select>
       </FormField>
 
       {createdConnectionId ? (

--- a/apps/web/src/features/connections/components/erli-setup.schema.ts
+++ b/apps/web/src/features/connections/components/erli-setup.schema.ts
@@ -22,7 +22,7 @@ export const ERLI_ADAPTER_KEY = 'erli.shopapi.v1';
 // path alias into libs/integrations/* packages.
 export const ERLI_SANDBOX_BASE_URL = 'https://sandbox.erli.dev/svc/shop-api';
 
-export const ErliEnvironmentValues = ['production', 'sandbox'] as const;
+export const ErliEnvironmentValues = ['sandbox', 'production'] as const;
 export type ErliEnvironment = (typeof ErliEnvironmentValues)[number];
 
 export const erliSetupSchema = z.object({
@@ -37,7 +37,7 @@ export type ErliSetupFormSubmission = z.output<typeof erliSetupSchema>;
 export const ERLI_SETUP_DEFAULT_VALUES: ErliSetupFormValues = {
   name: '',
   apiKey: '',
-  environment: 'production',
+  environment: 'sandbox',
 };
 
 export function toCreateConnectionInput(values: ErliSetupFormSubmission): CreateConnectionInput {

--- a/apps/web/src/features/connections/components/erli-setup.schema.ts
+++ b/apps/web/src/features/connections/components/erli-setup.schema.ts
@@ -5,10 +5,13 @@
  * wizard. Erli is a marketplace authenticated with a single Shop API key
  * (sent as a Bearer token by the BE adapter, #981). The form collects a
  * connection name, the required `apiKey` credential, and an `environment`
- * select (Production/Sandbox, #1377) that maps to an optional `baseUrl`
- * config override. `enabledCapabilities` is intentionally omitted from the
- * payload so the API defaults it to the adapter manifest's supported set
- * (#984/#993 ship `OfferManager` / `OrderSource`).
+ * select (Production/Sandbox, #1377). The payload persists the neutral
+ * `config.environment` choice — the BE adapter factory resolves it to the
+ * concrete Shop API base URL — so no sandbox-URL literal is duplicated on the
+ * FE and a future URL change never leaves a stale literal in stored
+ * connections. `enabledCapabilities` is intentionally omitted from the payload
+ * so the API defaults it to the adapter manifest's supported set (#984/#993
+ * ship `OfferManager` / `OrderSource`).
  *
  * @module features/connections/components
  */
@@ -17,13 +20,7 @@ import type { CreateConnectionInput } from '../api/connections.types';
 
 export const ERLI_ADAPTER_KEY = 'erli.shopapi.v1';
 
-// Mirrors the BE source of truth (libs/integrations/erli/src/domain/types
-// /erli-connection.types.ts) — duplicated as a literal since apps/web has no
-// path alias into libs/integrations/* packages.
-export const ERLI_SANDBOX_BASE_URL = 'https://sandbox.erli.dev/svc/shop-api';
-
 export const ErliEnvironmentValues = ['sandbox', 'production'] as const;
-export type ErliEnvironment = (typeof ErliEnvironmentValues)[number];
 
 export const erliSetupSchema = z.object({
   name: z.string().trim().min(1, 'Connection name is required'),
@@ -41,17 +38,15 @@ export const ERLI_SETUP_DEFAULT_VALUES: ErliSetupFormValues = {
 };
 
 export function toCreateConnectionInput(values: ErliSetupFormSubmission): CreateConnectionInput {
-  const config: Record<string, unknown> = {};
-  if (values.environment === 'sandbox') {
-    config.baseUrl = ERLI_SANDBOX_BASE_URL;
-  }
-
   return {
     name: values.name,
     platformType: 'erli',
     adapterKey: ERLI_ADAPTER_KEY,
     credentials: { apiKey: values.apiKey },
-    config,
+    // Persist the neutral choice, not a derived URL: the BE adapter factory
+    // maps `environment` → the concrete Shop API base URL, so a future
+    // sandbox-URL change can't leave a stale literal in this connection's config.
+    config: { environment: values.environment },
     // enabledCapabilities is OMITTED on purpose: on the omitted path
     // `ConnectionService.create` defaults to the adapter manifest's supported
     // set (`rest.enabledCapabilities ?? [...metadata.supportedCapabilities]`),

--- a/apps/web/src/features/connections/components/erli-setup.schema.ts
+++ b/apps/web/src/features/connections/components/erli-setup.schema.ts
@@ -4,10 +4,11 @@
  * Zod schema + form → API payload mapping for the guided Erli connection
  * wizard. Erli is a marketplace authenticated with a single Shop API key
  * (sent as a Bearer token by the BE adapter, #981). The form collects a
- * connection name, the required `apiKey` credential, and an optional advanced
- * `baseUrl` config override. `enabledCapabilities` is intentionally omitted
- * from the payload so the API defaults it to the adapter manifest's supported
- * set (#984/#993 ship `OfferManager` / `OrderSource`).
+ * connection name, the required `apiKey` credential, and an `environment`
+ * select (Production/Sandbox, #1377) that maps to an optional `baseUrl`
+ * config override. `enabledCapabilities` is intentionally omitted from the
+ * payload so the API defaults it to the adapter manifest's supported set
+ * (#984/#993 ship `OfferManager` / `OrderSource`).
  *
  * @module features/connections/components
  */
@@ -16,22 +17,18 @@ import type { CreateConnectionInput } from '../api/connections.types';
 
 export const ERLI_ADAPTER_KEY = 'erli.shopapi.v1';
 
-// Mirrors the BE config DTO posture (optional https-only base URL override).
-const isHttps = (value: string): boolean => value.startsWith('https://');
+// Mirrors the BE source of truth (libs/integrations/erli/src/domain/types
+// /erli-connection.types.ts) — duplicated as a literal since apps/web has no
+// path alias into libs/integrations/* packages.
+export const ERLI_SANDBOX_BASE_URL = 'https://sandbox.erli.dev/svc/shop-api';
+
+export const ErliEnvironmentValues = ['production', 'sandbox'] as const;
+export type ErliEnvironment = (typeof ErliEnvironmentValues)[number];
 
 export const erliSetupSchema = z.object({
   name: z.string().trim().min(1, 'Connection name is required'),
   apiKey: z.string().trim().min(1, 'API key is required'),
-  baseUrl: z
-    .union([
-      z
-        .string()
-        .trim()
-        .url('Base URL must be a valid URL (e.g. https://api.erli.pl)')
-        .refine(isHttps, 'Base URL must use HTTPS'),
-      z.literal(''),
-    ])
-    .optional(),
+  environment: z.enum(ErliEnvironmentValues),
 });
 
 export type ErliSetupFormValues = z.input<typeof erliSetupSchema>;
@@ -40,13 +37,13 @@ export type ErliSetupFormSubmission = z.output<typeof erliSetupSchema>;
 export const ERLI_SETUP_DEFAULT_VALUES: ErliSetupFormValues = {
   name: '',
   apiKey: '',
-  baseUrl: '',
+  environment: 'production',
 };
 
 export function toCreateConnectionInput(values: ErliSetupFormSubmission): CreateConnectionInput {
   const config: Record<string, unknown> = {};
-  if (values.baseUrl && values.baseUrl.length > 0) {
-    config.baseUrl = values.baseUrl;
+  if (values.environment === 'sandbox') {
+    config.baseUrl = ERLI_SANDBOX_BASE_URL;
   }
 
   return {

--- a/apps/web/src/features/connections/components/infakt-setup.schema.ts
+++ b/apps/web/src/features/connections/components/infakt-setup.schema.ts
@@ -4,8 +4,8 @@
  * Zod schema + form → API payload mapping for the guided inFakt connection
  * wizard. inFakt is a Polish accounting platform authenticated with a single
  * API key (#1280/#1282). The form collects a connection name, the required
- * `apiKey` credential, and an optional advanced `baseUrl` config override
- * (sandbox vs. production). Mirrors `erli-setup.schema.ts`.
+ * `apiKey` credential, and an optional advanced free-text `baseUrl` config
+ * override (sandbox vs. production).
  *
  * @module features/connections/components
  */

--- a/docs/plans/implementation-plan-1377-erli-setup-environment-select.md
+++ b/docs/plans/implementation-plan-1377-erli-setup-environment-select.md
@@ -1,0 +1,40 @@
+# Implementation Plan — Erli setup wizard: environment select instead of free-text Base URL (#1377)
+
+## 1. Task
+
+Replace the free-text "Base URL (optional)" input in the Erli connection wizard with a two-option `Select` (Production / Sandbox), since only two valid base URLs exist and both are already enforced server-side by `ERLI_ALLOWED_BASE_URL_HOSTS`.
+
+**Layer**: Frontend (Interface: FE form/schema) + small Integration constant export (Domain types).
+**Non-goals**: no change to `erli-base-url.policy.ts` / validation, no change to the edit-connection flow (create-wizard only, per issue's own scoping).
+
+## 2. Existing patterns reused
+
+- `inpost-setup-form.tsx` / `inpost-setup.schema.ts` already use `environment: z.enum(['sandbox', 'production'])` + `<Select>` — same shape, copied directly.
+- `apps/web` has no path alias into `libs/integrations/*`, so the sandbox URL literal is duplicated in the FE schema with a comment cross-referencing the BE constant (per the issue's own fallback instruction).
+
+## 3. Steps
+
+1. **`libs/integrations/erli/src/domain/types/erli-connection.types.ts`** — add `export const ERLI_SANDBOX_BASE_URL = 'https://sandbox.erli.dev/svc/shop-api';` next to `ERLI_DEFAULT_BASE_URL`.
+2. **`apps/web/src/features/connections/components/erli-setup.schema.ts`**:
+   - Replace `baseUrl` union field with `environment: z.enum(['production', 'sandbox'])` (`as const` values array).
+   - Update `ERLI_SETUP_DEFAULT_VALUES` → `environment: 'production'`.
+   - Update `toCreateConnectionInput`: `sandbox` → `config.baseUrl = ERLI_SANDBOX_BASE_URL_LITERAL` (local literal + comment pointing at `erli-connection.types.ts`); `production` → omit `config.baseUrl`.
+3. **`apps/web/src/features/connections/components/erli-setup-form.tsx`** — replace the `<Input>` block (Base URL) with a `<Select>` with two `<option>`s ("Production — https://erli.pl", "Sandbox — https://sandbox.erli.dev").
+4. **`apps/web/src/features/connections/components/erli-setup-form.test.tsx`** — update:
+   - "renders the required form fields" → assert Environment select instead of Base URL input.
+   - Remove the HTTPS-rejection test (field no longer free-text).
+   - "omits config when no base URL is given" → default (production) submit path, `config: {}`.
+   - "includes baseUrl in config when supplied" → select Sandbox, assert `config: { baseUrl: 'https://sandbox.erli.dev/svc/shop-api' }`.
+
+## 4. Acceptance criteria (from issue)
+
+- [ ] Select with exactly two options, Production default-selected, no free-text URL field.
+- [ ] Production submit → no `baseUrl` key in `config`.
+- [ ] Sandbox submit → `config.baseUrl = 'https://sandbox.erli.dev/svc/shop-api'`.
+- [ ] `ERLI_SANDBOX_BASE_URL` constant added next to `ERLI_DEFAULT_BASE_URL`.
+- [ ] Tests updated for the select interaction and both submit paths.
+- [ ] No architecture boundary violations.
+
+## 5. Risk / validation
+
+Trivial, single-context (FE) change with one BE constant addition — no cross-context contract surface touched, no DI/tokens/migrations involved. Pre-implement gate skipped as unnecessary for a change this size and this well-specified (issue already enumerates every touched file).

--- a/libs/integrations/erli/src/application/__tests__/erli-adapter.factory.spec.ts
+++ b/libs/integrations/erli/src/application/__tests__/erli-adapter.factory.spec.ts
@@ -87,6 +87,41 @@ describe('ErliAdapterFactory', () => {
     expect(lastFetchHeaders().Authorization).toBe('Bearer k-123');
   });
 
+  it('should resolve the sandbox base URL when config.environment is sandbox (#1377)', async () => {
+    const client = await factory.createHttpClient(
+      connection({ config: { environment: 'sandbox' } }),
+      resolverFor({ apiKey: 'k-123' }),
+    );
+    await client.get('/probe');
+
+    expect(lastFetchUrl()).toBe('https://sandbox.erli.dev/svc/shop-api/probe');
+  });
+
+  it('should resolve the default prod base URL when config.environment is production (#1377)', async () => {
+    const client = await factory.createHttpClient(
+      connection({ config: { environment: 'production' } }),
+      resolverFor({ apiKey: 'k-123' }),
+    );
+    await client.get('/probe');
+
+    expect(lastFetchUrl()).toBe('https://erli.pl/svc/shop-api/probe');
+  });
+
+  it('should let an explicit legacy config.baseUrl win over config.environment (backward compat, #1377)', async () => {
+    // Connections created before the environment select persisted the derived
+    // sandbox URL directly on config.baseUrl (with no config.environment). That
+    // explicit override must still resolve the same host.
+    const client = await factory.createHttpClient(
+      connection({
+        config: { baseUrl: 'https://sandbox.erli.dev/svc/shop-api', environment: 'production' },
+      }),
+      resolverFor({ apiKey: 'k-123' }),
+    );
+    await client.get('/probe');
+
+    expect(lastFetchUrl()).toBe('https://sandbox.erli.dev/svc/shop-api/probe');
+  });
+
   it('should honour a config.baseUrl override', async () => {
     const client = await factory.createHttpClient(
       connection({ config: { baseUrl: 'https://sandbox.erli.dev/svc/shop-api' } }),

--- a/libs/integrations/erli/src/application/erli-adapter.factory.ts
+++ b/libs/integrations/erli/src/application/erli-adapter.factory.ts
@@ -30,6 +30,7 @@ import { ErliConfigException } from '../domain/exceptions/erli-config.exception'
 import { isAllowedErliBaseUrl } from '../domain/policies/erli-base-url.policy';
 import {
   ERLI_DEFAULT_BASE_URL,
+  ERLI_SANDBOX_BASE_URL,
   type ErliConnectionConfig,
   type ErliCredentials,
 } from '../domain/types/erli-connection.types';
@@ -177,23 +178,33 @@ export class ErliAdapterFactory implements IErliAdapterFactory {
     );
   }
 
+  /**
+   * Resolve the Shop API base URL. Precedence (#1377):
+   *   1. Explicit `config.baseUrl` — honoured for backward compatibility, since
+   *      connections created before the environment select persisted the derived
+   *      sandbox URL here. Re-validated through the SSRF/cleartext allowlist.
+   *   2. `config.environment` — the neutral choice the FE now persists:
+   *      `'sandbox'` → the sandbox host, anything else → the prod default. These
+   *      constants are trusted (not operator-supplied), so no allowlist re-check.
+   *   3. Default prod base URL.
+   */
   private resolveBaseUrl(connection: Connection): string {
     const config = (connection.config ?? {}) as ErliConnectionConfig;
     const override = config.baseUrl?.trim();
-    if (!override || override.length === 0) {
-      return ERLI_DEFAULT_BASE_URL;
+    if (override && override.length > 0) {
+      // Defense-in-depth: the config-shape validator enforces the https + Erli-host
+      // allowlist at create/update, but a pre-existing or externally-written row
+      // could carry a plain-http or off-host baseUrl — which would send the bearer
+      // key over cleartext or to an attacker-controlled host (SSRF). Re-check here
+      // so the property doesn't rest solely on create-time validation (PR1057-TECH-03).
+      if (!isAllowedErliBaseUrl(override)) {
+        throw new ErliConfigException(
+          `Erli connection ${connection.id} has a disallowed baseUrl (must be https and an Erli-owned host)`,
+          connection.id,
+        );
+      }
+      return override;
     }
-    // Defense-in-depth: the config-shape validator enforces the https + Erli-host
-    // allowlist at create/update, but a pre-existing or externally-written row
-    // could carry a plain-http or off-host baseUrl — which would send the bearer
-    // key over cleartext or to an attacker-controlled host (SSRF). Re-check here
-    // so the property doesn't rest solely on create-time validation (PR1057-TECH-03).
-    if (!isAllowedErliBaseUrl(override)) {
-      throw new ErliConfigException(
-        `Erli connection ${connection.id} has a disallowed baseUrl (must be https and an Erli-owned host)`,
-        connection.id,
-      );
-    }
-    return override;
+    return config.environment === 'sandbox' ? ERLI_SANDBOX_BASE_URL : ERLI_DEFAULT_BASE_URL;
   }
 }

--- a/libs/integrations/erli/src/domain/types/erli-connection.types.ts
+++ b/libs/integrations/erli/src/domain/types/erli-connection.types.ts
@@ -104,3 +104,10 @@ export interface ErliConnectionConfig {
  * Erli allowlist — see `domain/policies/erli-base-url.policy.ts`.
  */
 export const ERLI_DEFAULT_BASE_URL = 'https://erli.pl/svc/shop-api';
+
+/**
+ * Sandbox Erli Shop API base URL (confirmed by the #992 spike). Named source of
+ * truth for the FE create-wizard's Production/Sandbox environment select (#1377)
+ * — previously only referenced in the doc comment above.
+ */
+export const ERLI_SANDBOX_BASE_URL = 'https://sandbox.erli.dev/svc/shop-api';

--- a/libs/integrations/erli/src/domain/types/erli-connection.types.ts
+++ b/libs/integrations/erli/src/domain/types/erli-connection.types.ts
@@ -33,6 +33,16 @@
 export const AllegroCatalogEnvironmentValues = ['sandbox', 'production'] as const;
 export type AllegroCatalogEnvironment = (typeof AllegroCatalogEnvironmentValues)[number];
 
+/**
+ * Erli Shop API environment (#1377). The neutral choice the FE create-wizard
+ * persists on `connection.config.environment`; the adapter factory maps it to
+ * the concrete base URL ({@link ERLI_SANDBOX_BASE_URL} / {@link ERLI_DEFAULT_BASE_URL}).
+ * Persisting the choice rather than a derived URL means a future base-URL change
+ * never leaves a stale literal in an existing connection's config.
+ */
+export const ErliEnvironmentValues = ['sandbox', 'production'] as const;
+export type ErliEnvironment = (typeof ErliEnvironmentValues)[number];
+
 /** Encrypted credentials for an Erli connection (resolved via host.credentialsResolver). */
 export interface ErliCredentials {
   apiKey: string;
@@ -56,7 +66,21 @@ export interface ErliDispatchTime {
 
 /** Non-secret per-connection config stored on `connection.config`. */
 export interface ErliConnectionConfig {
-  /** Optional Shop API base URL override; defaults to {@link ERLI_DEFAULT_BASE_URL}. */
+  /**
+   * Neutral Shop API environment choice (#1377) the FE create-wizard persists.
+   * The factory maps `'sandbox'` → {@link ERLI_SANDBOX_BASE_URL} and anything
+   * else → {@link ERLI_DEFAULT_BASE_URL}. Superseded by an explicit
+   * {@link ErliConnectionConfig.baseUrl} when both are present (legacy
+   * connections stored the derived URL directly).
+   */
+  environment?: ErliEnvironment;
+  /**
+   * Optional explicit Shop API base URL override; defaults to
+   * {@link ERLI_DEFAULT_BASE_URL}. Takes precedence over
+   * {@link ErliConnectionConfig.environment} so connections created before
+   * #1377 (which persisted the resolved sandbox URL here) keep resolving the
+   * same host.
+   */
   baseUrl?: string;
   /**
    * Shop-wide default dispatch time applied to every created offer when the
@@ -106,8 +130,8 @@ export interface ErliConnectionConfig {
 export const ERLI_DEFAULT_BASE_URL = 'https://erli.pl/svc/shop-api';
 
 /**
- * Sandbox Erli Shop API base URL (confirmed by the #992 spike). Named source of
- * truth for the FE create-wizard's Production/Sandbox environment select (#1377)
- * — previously only referenced in the doc comment above.
+ * Sandbox Erli Shop API base URL (confirmed by the #992 spike). The adapter
+ * factory resolves it when `connection.config.environment === 'sandbox'` (#1377)
+ * — the single source of truth for the sandbox host, no longer duplicated on the FE.
  */
 export const ERLI_SANDBOX_BASE_URL = 'https://sandbox.erli.dev/svc/shop-api';

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-config-shape-validator.adapter.spec.ts
@@ -109,6 +109,32 @@ describe('ErliConnectionConfigShapeValidatorAdapter', () => {
     });
   });
 
+  describe('environment (#1377)', () => {
+    it('should resolve when environment is absent', async () => {
+      await expect(validator.validate({})).resolves.toBeUndefined();
+    });
+
+    it('should resolve when environment is "sandbox"', async () => {
+      await expect(validator.validate({ environment: 'sandbox' })).resolves.toBeUndefined();
+    });
+
+    it('should resolve when environment is "production"', async () => {
+      await expect(validator.validate({ environment: 'production' })).resolves.toBeUndefined();
+    });
+
+    it('should reject an unknown environment value', async () => {
+      await expect(validator.validate({ environment: 'staging' })).rejects.toMatchObject({
+        errors: [{ path: 'environment', message: expect.any(String) }],
+      });
+    });
+
+    it('should reject a non-string environment value', async () => {
+      await expect(validator.validate({ environment: 123 })).rejects.toMatchObject({
+        errors: [{ path: 'environment', message: expect.any(String) }],
+      });
+    });
+  });
+
   describe('allegroEnvironment (#1382/#1383, ADR-031)', () => {
     it('should resolve when allegroEnvironment is absent', async () => {
       await expect(validator.validate({})).resolves.toBeUndefined();

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts
@@ -26,7 +26,10 @@ import {
   InvalidConnectionConfigException,
 } from '@openlinker/core/integrations';
 import { ERLI_ALLOWED_BASE_URL_HOSTS, isAllowedErliHost } from '../../domain/policies/erli-base-url.policy';
-import { AllegroCatalogEnvironmentValues } from '../../domain/types/erli-connection.types';
+import {
+  AllegroCatalogEnvironmentValues,
+  ErliEnvironmentValues,
+} from '../../domain/types/erli-connection.types';
 
 export class ErliConnectionConfigShapeValidatorAdapter
   implements ConnectionConfigShapeValidatorPort
@@ -53,6 +56,7 @@ export class ErliConnectionConfigShapeValidatorAdapter
       }
     }
 
+    this.validateEnvironment(config.environment, issues);
     this.validateDispatchTime(config.defaultDispatchTime, issues);
     this.validateAllegroEnvironment(config.allegroEnvironment, issues);
     this.validateAllegroCategoryAccessEnabled(config.allegroCategoryAccessEnabled, issues);
@@ -115,6 +119,24 @@ export class ErliConnectionConfigShapeValidatorAdapter
       issues.push({
         path: 'defaultDispatchTime.unit',
         message: "must be 'hour', 'day', or 'month'",
+      });
+    }
+  }
+
+  /**
+   * `environment` (#1377), when present, must be exactly `'sandbox'` or
+   * `'production'` — the neutral Shop API environment choice the factory maps to
+   * a base URL. Absent is valid (legacy connections used `baseUrl` directly, and
+   * the factory falls back to the prod default).
+   */
+  private validateEnvironment(value: unknown, issues: FlatValidationIssue[]): void {
+    if (value === undefined) {
+      return;
+    }
+    if (typeof value !== 'string' || !(ErliEnvironmentValues as readonly string[]).includes(value)) {
+      issues.push({
+        path: 'environment',
+        message: `must be one of: ${ErliEnvironmentValues.join(', ')}`,
       });
     }
   }


### PR DESCRIPTION
## Summary
- Replace the Erli connection wizard's free-text "Base URL (optional)" input with a two-option `Select` (Production / Sandbox) — only two valid base URLs exist and both are already enforced server-side by `ERLI_ALLOWED_BASE_URL_HOSTS`.
- Export `ERLI_SANDBOX_BASE_URL` as a named constant in `libs/integrations/erli/src/domain/types/erli-connection.types.ts`, next to `ERLI_DEFAULT_BASE_URL`.
- Mirrors the existing InPost setup form's `environment` select pattern.

## Test plan
- [x] `pnpm build` / `pnpm type-check` clean across the monorepo
- [x] `pnpm --filter @openlinker/integrations-erli lint` / `test` — 0 errors, 347/347 passed
- [x] `pnpm --filter @openlinker/web lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm --filter @openlinker/web test` — 2086/2087 passed (1 pre-existing, unrelated failure in `settings-page.test.tsx` caused by local VITE env vars, last touched in an unrelated commit)
- [x] Updated `erli-setup-form.test.tsx`: select renders with Production default, Production submit omits `config.baseUrl`, Sandbox submit sets `config.baseUrl` to the sandbox URL

Closes #1377