### PR TITLE
fix(web): WooCommerce publish wizard dialog overflow/blur, toast z-index, master stock/price prefill

### DIFF
--- a/apps/web/src/features/listings/components/WoocommercePublishWizard.test.tsx
+++ b/apps/web/src/features/listings/components/WoocommercePublishWizard.test.tsx
@@ -272,7 +272,7 @@ describe('WoocommercePublishWizard', () => {
       { apiClient },
     );
 
-    const stockInput = await screen.findByPlaceholderText('0');
+    const stockInput = await screen.findByPlaceholderText('master');
     fireEvent.change(stockInput, { target: { value: '-3' } });
     fireEvent.click(screen.getByRole('button', { name: /^publish$/i }));
 

--- a/apps/web/src/features/listings/components/WoocommercePublishWizard.tsx
+++ b/apps/web/src/features/listings/components/WoocommercePublishWizard.tsx
@@ -33,7 +33,7 @@
  *
  * @module apps/web/src/features/listings/components
  */
-import { useMemo, useRef, useState, type ReactElement } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Alert } from '../../../shared/ui/alert';
@@ -45,6 +45,7 @@ import { StatusBadge } from '../../../shared/ui/status-badge';
 import { useToast } from '../../../shared/ui/toast-provider';
 import { useDebouncedValue } from '../../../shared/hooks/use-debounced-value';
 import type { Connection } from '../../connections';
+import { useInventoryAvailabilityBatchQuery } from '../../inventory';
 import { useProductQuery, useProductsQuery } from '../../products';
 import type { Product, ProductVariant } from '../../products';
 import { useShopPublishMutation } from '../hooks/use-shop-publish-mutation';
@@ -134,7 +135,12 @@ export function WoocommercePublishWizard({
 
   // Multi-select tray state — only used during the selection step. Map
   // preserves insertion order, matching the tray's expected chip order.
-  const [selectedVariants, setSelectedVariants] = useState<Map<string, string>>(new Map());
+  // Carries master price alongside the label so Configure can prefill the
+  // price override field with the real current value instead of leaving it
+  // blank behind a "master" placeholder (#1414 follow-up).
+  const [selectedVariants, setSelectedVariants] = useState<
+    Map<string, { label: string; price: number | null }>
+  >(new Map());
   // null while the operator is still picking (selection step showing);
   // locked in once "Continue" is pressed, or immediately when props already
   // supplied ids.
@@ -157,11 +163,16 @@ export function WoocommercePublishWizard({
   );
   const productDetailQuery = useProductQuery(selectedProductId ?? '');
 
-  function toggleVariant(variantId: string, label: string, checked: boolean): void {
+  function toggleVariant(
+    variantId: string,
+    label: string,
+    price: number | null,
+    checked: boolean,
+  ): void {
     setSelectedVariants((prev) => {
       const next = new Map(prev);
       if (checked) {
-        next.set(variantId, label);
+        next.set(variantId, { label, price });
       } else {
         next.delete(variantId);
       }
@@ -219,25 +230,29 @@ export function WoocommercePublishWizard({
     if (chosen.length > 1) {
       form.reset({
         ...WOOCOMMERCE_PUBLISH_BULK_DEFAULTS,
-        items: chosen.map(([variantId, label]) => ({
+        items: chosen.map(([variantId, { label, price }]) => ({
           variantId,
           label,
           stock: '',
-          priceAmount: '',
+          priceAmount: price !== null ? String(price) : '',
         })),
       });
       setFinalMode('bulk');
     } else {
-      const [[variantId, label]] = chosen;
+      const [[variantId, { label, price }]] = chosen;
       setSingleVariantId(variantId);
       setSingleVariantLabel(label);
-      form.reset(WOOCOMMERCE_PUBLISH_SINGLE_DEFAULTS);
+      form.reset({
+        ...WOOCOMMERCE_PUBLISH_SINGLE_DEFAULTS,
+        priceAmount: price !== null ? String(price) : '',
+      });
       setFinalMode('single');
     }
   }
 
   function handleVariantPick(product: Product, variant: ProductVariant, checked: boolean): void {
-    toggleVariant(variant.id, variantLabel(product, variant), checked);
+    const price = variant.price ?? product.price ?? null;
+    toggleVariant(variant.id, variantLabel(product, variant), price, checked);
   }
 
   const mode = finalMode;
@@ -251,10 +266,76 @@ export function WoocommercePublishWizard({
 
   const singleId = !needsVariantPicker ? propsIds[0] : singleVariantId;
 
+  // Master stock, fetched once per row set so Configure can prefill the
+  // stock field with the real current value instead of leaving it blank
+  // behind a "master" placeholder (#1414 follow-up — mirrors the price
+  // prefill, which comes from the picker's already-loaded Product/Variant
+  // instead of a dedicated query).
+  const relevantVariantIds = useMemo(() => {
+    if (mode === 'bulk') return itemsFieldArray.fields.map((f) => f.variantId);
+    if (mode === 'single' && singleId) return [singleId];
+    return [];
+  }, [mode, itemsFieldArray.fields, singleId]);
+  const availabilityQuery = useInventoryAvailabilityBatchQuery(relevantVariantIds, {
+    enabled: mode !== null && relevantVariantIds.length > 0,
+  });
+  const masterStockByVariantId = useMemo(
+    () => new Map((availabilityQuery.data?.items ?? []).map((i) => [i.productVariantId, i.totalAvailable])),
+    [availabilityQuery.data],
+  );
+  const priceByVariantId = useMemo(
+    () => new Map(Array.from(selectedVariants.entries()).map(([id, v]) => [id, v.price])),
+    [selectedVariants],
+  );
+
+  // Prefill stock once master availability resolves — only for fields the
+  // operator hasn't already touched, so a slow/refetching query never
+  // clobbers a manual edit.
+  useEffect(() => {
+    if (masterStockByVariantId.size === 0) return;
+    if (mode === 'bulk') {
+      itemsFieldArray.fields.forEach((row, index) => {
+        if (form.getValues(`items.${index}.stock`) !== '') return;
+        const avail = masterStockByVariantId.get(row.variantId);
+        if (avail !== undefined) form.setValue(`items.${index}.stock`, String(avail));
+      });
+    } else if (mode === 'single' && singleId) {
+      if (form.getValues('stock') !== '') return;
+      const avail = masterStockByVariantId.get(singleId);
+      if (avail !== undefined) form.setValue('stock', String(avail));
+    }
+  }, [masterStockByVariantId, mode, singleId, itemsFieldArray.fields, form]);
+
   function resetColumn(field: 'stock' | 'priceAmount'): void {
-    itemsFieldArray.fields.forEach((_, index) => {
-      form.setValue(`items.${index}.${field}`, '', { shouldDirty: true });
+    itemsFieldArray.fields.forEach((row, index) => {
+      if (field === 'stock') {
+        const avail = masterStockByVariantId.get(row.variantId);
+        form.setValue(`items.${index}.stock`, avail !== undefined ? String(avail) : '', {
+          shouldDirty: true,
+        });
+      } else {
+        const price = priceByVariantId.get(row.variantId);
+        form.setValue(
+          `items.${index}.priceAmount`,
+          price !== undefined && price !== null ? String(price) : '',
+          { shouldDirty: true },
+        );
+      }
     });
+    showToast({
+      tone: 'success',
+      description:
+        field === 'stock'
+          ? "Stock reset to each product's current master stock."
+          : "Price reset to each product's current master price.",
+    });
+  }
+
+  function backToSelection(): void {
+    setSingleVariantId(null);
+    setSingleVariantLabel(null);
+    setSelectedVariants(new Map());
+    setFinalMode(null);
   }
 
   const submit = form.handleSubmit(async (values) => {
@@ -479,7 +560,7 @@ export function WoocommercePublishWizard({
           </div>
           {selectedList.length > 0 ? (
             <div className="shop-publish-tray__chips">
-              {selectedList.map(([variantId, label]) => (
+              {selectedList.map(([variantId, { label }]) => (
                 <span key={variantId} className="shop-publish-chip shop-publish-chip--removable">
                   <span title={label}>{label}</span>
                   <button
@@ -690,17 +771,7 @@ export function WoocommercePublishWizard({
                 {singleId}
               </span>
               {needsVariantPicker ? (
-                <Button
-                  type="button"
-                  tone="ghost"
-                  className="button--sm"
-                  onClick={() => {
-                    setSingleVariantId(null);
-                    setSingleVariantLabel(null);
-                    setSelectedVariants(new Map());
-                    setFinalMode(null);
-                  }}
-                >
+                <Button type="button" tone="ghost" className="button--sm" onClick={backToSelection}>
                   Change
                 </Button>
               ) : null}
@@ -712,7 +783,7 @@ export function WoocommercePublishWizard({
               <Input
                 inputMode="numeric"
                 className="input--mono"
-                placeholder="0"
+                placeholder="master"
                 {...form.register('stock')}
               />
             </FormField>
@@ -757,6 +828,11 @@ export function WoocommercePublishWizard({
 
       <div className="wizard-actions">
         <div className="wizard-actions__group">
+          {needsVariantPicker ? (
+            <Button type="button" tone="ghost" onClick={backToSelection}>
+              ← Back
+            </Button>
+          ) : null}
           <Button type="button" tone="ghost" onClick={onCancel}>
             Cancel
           </Button>

--- a/apps/web/src/features/listings/components/woocommerce-publish-wizard.schema.ts
+++ b/apps/web/src/features/listings/components/woocommerce-publish-wizard.schema.ts
@@ -57,7 +57,7 @@ export const WOOCOMMERCE_PUBLISH_DEFAULT_CURRENCY = 'PLN';
 
 export const WOOCOMMERCE_PUBLISH_SINGLE_DEFAULTS: WoocommercePublishWizardValues = {
   status: 'published',
-  stock: '0',
+  stock: '',
   priceAmount: '',
   priceCurrency: WOOCOMMERCE_PUBLISH_DEFAULT_CURRENCY,
   items: [],

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -292,7 +292,7 @@
   --shadow-soft: 0 1px 2px rgb(15 18 26 / 0.04), 0 6px 16px rgb(15 18 26 / 0.06);
   --shadow-soft-hover: 0 2px 4px rgb(15 18 26 / 0.04), 0 12px 28px rgb(15 18 26 / 0.10);
   --shadow-overlay: 0 24px 48px rgb(15 18 26 / 0.16), 0 8px 16px rgb(15 18 26 / 0.08);
-  --overlay-scrim: rgb(15 18 26 / 0.40);
+  --overlay-scrim: rgb(15 18 26 / 0.55);
 
   --shadow-xs: 0 1px 2px rgb(15 18 26 / 0.04);
   --shadow-sm: 0 1px 2px rgb(15 18 26 / 0.04), 0 1px 3px rgb(15 18 26 / 0.06);
@@ -461,7 +461,7 @@ html[data-theme='dark'] {
   --shadow-lg: 0 6px 12px rgb(0 0 0 / 0.42), 0 16px 32px rgb(0 0 0 / 0.40);
   --shadow-focus: 0 0 0 3px var(--accent-ring);
   --shadow-inset-top: inset 0 1px 0 rgb(255 255 255 / 0.04);
-  --overlay-scrim: rgb(0 0 0 / 0.60);
+  --overlay-scrim: rgb(0 0 0 / 0.72);
 }
 
 * {
@@ -2985,7 +2985,7 @@ textarea,
   display: grid;
   gap: 0.75rem;
   width: min(24rem, calc(100vw - 2rem));
-  z-index: 40;
+  z-index: 60;
 }
 
 /* ── Toast (#775) ───────────────────────────────────────────────────
@@ -4172,6 +4172,8 @@ a.kpi-card:focus-visible {
   position: fixed;
   inset: 0;
   background: var(--overlay-scrim);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   animation: dialog-fade-in var(--duration-fast) var(--ease-out);
   z-index: 40;
 }
@@ -4183,6 +4185,7 @@ a.kpi-card:focus-visible {
   transform: translate(-50%, -50%);
   width: min(520px, 92vw);
   max-height: min(90vh, 720px);
+  overflow-x: hidden;
   overflow-y: auto;
   background: var(--bg-surface-elevated);
   border: 1px solid var(--border-subtle);
@@ -5115,6 +5118,7 @@ a.kpi-card:focus-visible {
   background: var(--bg-surface);
   box-shadow: var(--shadow-soft);
   max-width: 100%;
+  min-width: 0;
 }
 
 /* Catalog Product Match Panel (#635) — rendered above Step 2's parameter list. */
@@ -5672,6 +5676,8 @@ a.kpi-card:focus-visible {
   display: grid;
   gap: 0.5rem;
   max-height: 260px;
+  min-width: 0;
+  overflow-x: hidden;
   overflow-y: auto;
   border: 1px solid var(--border-subtle);
   border-radius: 0.375rem;
@@ -5685,6 +5691,11 @@ a.kpi-card:focus-visible {
   padding: 0;
   display: grid;
   gap: 0.25rem;
+  min-width: 0;
+}
+
+.create-offer-variant-picker__product {
+  min-width: 0;
 }
 
 .create-offer-variant-picker__product-row {
@@ -5693,6 +5704,7 @@ a.kpi-card:focus-visible {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
+  min-width: 0;
   padding: 0.5rem 0.625rem;
   background: transparent;
   border: 1px solid transparent;
@@ -5715,6 +5727,7 @@ a.kpi-card:focus-visible {
   padding: 0 0 0 0.75rem;
   display: grid;
   gap: 0.25rem;
+  min-width: 0;
   border-left: 2px solid var(--border-subtle);
 }
 
@@ -9489,6 +9502,8 @@ html[data-density='compact'] .status-badge {
 .shop-publish-affix__pre {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
+  white-space: nowrap;
   padding: 0 var(--space-3);
   font-size: 0.75rem;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- Backdrop-blur the dialog overlay (`.dialog__overlay`) so background page content is visually obscured, not just dimmed
- Fix the CSS Grid picker list so long SKU/EAN rows can no longer overflow past the dialog's rounded border (`min-width: 0` + `overflow-x: hidden` through the whole chain)
- Bump `.toast-region` above `.dialog__content` so toasts render on top of an open dialog instead of underneath it
- WooCommerce publish wizard's Configure step now prefills Stock/Price with the real current master values (price from the loaded product/variant, stock via `useInventoryAvailabilityBatchQuery`) instead of a blank input behind a misleading "master" placeholder that silently submitted `stock: 0`
- "Use master stock/price for all" now re-fills from master instead of clearing to blank
- Added a "← Back" button to the Configure step (only when opened via the top-level product picker)

All bugs found and fixed during manual E2E testing of the demo stack.

## Test plan
- [x] `WoocommercePublishWizard.test.tsx` — existing suite + 1 updated placeholder-text assertion, all green
- [x] Verified live in a running demo stack: dialog blur, no overflow, toasts visible over dialogs, stock/price prefilled with real master values

Closes #1439

🤖 Generated with [Claude Code](https://claude.com/claude-code)