### PR TITLE
fix(erli): sandbox category auth, missing bulk picker, and rejected dictionary attributes

### DIFF
--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -151,7 +151,10 @@ export function BulkWizard({
     ? !batchConnection.supportedCapabilities.includes('EanCategoryMatcher')
     : false;
   const destinationBrowsesCategories =
-    batchConnection?.supportedCapabilities.includes('CategoryBrowser') ?? false;
+    (batchConnection?.supportedCapabilities.includes('CategoryBrowser') ?? false) ||
+    (batchConnection
+      ? (batchPlatform?.bulkCategoryBrowsingEnabled?.(batchConnection) ?? false)
+      : false);
 
   // Reconcile the `needs-product-parameters` blocker whenever a category's
   // schema resolves (it loads after the operator picks the category, so it

--- a/apps/web/src/plugins/erli/components/erli-credentials-panel.test.tsx
+++ b/apps/web/src/plugins/erli/components/erli-credentials-panel.test.tsx
@@ -43,6 +43,15 @@ describe('ErliCredentialsPanel', () => {
     expect(screen.getByText('Rotate API key')).toBeInTheDocument();
   });
 
+  it('shows the Allegro category-browsing checkbox without opening "Rotate API key"', () => {
+    renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />);
+    expect(
+      screen.getByRole('checkbox', { name: /browse allegro categories/i })
+    ).toBeInTheDocument();
+    // The API key input itself must stay closed until explicitly opened.
+    expect(screen.queryByPlaceholderText('New API key')).not.toBeInTheDocument();
+  });
+
   it('falls back to the env-var disabled input when credentialsBacked=false', () => {
     const envBacked = { ...erliConnection, credentialsBacked: false };
     renderWithProviders(<ErliCredentialsPanel connection={envBacked} />);
@@ -166,7 +175,11 @@ describe('ErliCredentialsPanel', () => {
     });
     await waitFor(() => {
       expect(update).toHaveBeenCalledWith(erliConnection.id, {
-        config: { ...erliConnection.config, allegroCategoryAccessEnabled: true },
+        config: {
+          ...erliConnection.config,
+          allegroCategoryAccessEnabled: true,
+          allegroEnvironment: 'production',
+        },
       });
     });
     // Ordering: credentials write resolves strictly before the config patch fires.
@@ -336,11 +349,52 @@ describe('ErliCredentialsPanel', () => {
       });
       await waitFor(() => {
         expect(update).toHaveBeenCalledWith(erliConnection.id, {
-          config: { ...erliConnection.config, allegroCategoryAccessEnabled: true },
+          config: {
+            ...erliConnection.config,
+            allegroCategoryAccessEnabled: true,
+            allegroEnvironment: 'production',
+          },
         });
       });
       // The raw Allegro secret is never present anywhere in this flow's payloads.
       expect(updateCredentials.mock.calls[0][1]).not.toHaveProperty('allegroClientSecret');
+    });
+
+    it('infers allegroEnvironment from the reused connection instead of always defaulting to production', async () => {
+      const sandboxAllegroConnection: Connection = {
+        ...allegroConnection,
+        id: 'conn_allegro_sandbox',
+        name: 'Sandbox Allegro Store',
+        config: { ...allegroConnection.config, environment: 'sandbox' },
+      };
+      const list = vi.fn().mockResolvedValue([sandboxAllegroConnection]);
+      const updateCredentials = vi.fn().mockResolvedValue(undefined);
+      const update = vi.fn().mockResolvedValue(erliConnectionWithAllegroAccess);
+      const apiClient = createMockApiClient({
+        connections: { list, updateCredentials, update },
+      });
+      renderWithProviders(<ErliCredentialsPanel connection={erliConnection} />, { apiClient });
+
+      fireEvent.click(screen.getByText('Rotate API key'));
+      fireEvent.click(screen.getByRole('checkbox', { name: /browse allegro categories/i }));
+      await screen.findByRole('combobox', { name: /allegro connection to reuse/i });
+      fireEvent.change(screen.getByRole('combobox', { name: /allegro connection to reuse/i }), {
+        target: { value: sandboxAllegroConnection.id },
+      });
+      expect(await screen.findByText(/will use that connection's environment/i)).toHaveTextContent(
+        'sandbox'
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
+
+      await waitFor(() => {
+        expect(update).toHaveBeenCalledWith(erliConnection.id, {
+          config: {
+            ...erliConnection.config,
+            allegroCategoryAccessEnabled: true,
+            allegroEnvironment: 'sandbox',
+          },
+        });
+      });
     });
 
     it('switches to manual fields when "Enter Allegro app credentials manually" is chosen, unaffected by available connections', async () => {

--- a/apps/web/src/plugins/erli/components/erli-credentials-panel.tsx
+++ b/apps/web/src/plugins/erli/components/erli-credentials-panel.tsx
@@ -45,7 +45,7 @@
  *
  * @module plugins/erli/components
  */
-import { useState, type FormEvent, type ReactElement } from 'react';
+import { useEffect, useState, type FormEvent, type ReactElement } from 'react';
 import type { Connection } from '../../../features/connections';
 import {
   useConnectionsQuery,
@@ -60,9 +60,24 @@ import { Select } from '../../../shared/ui/select';
 import { useToast } from '../../../shared/ui/toast-provider';
 
 type AllegroCredentialSource = 'reuse' | 'manual';
+type AllegroCatalogEnvironment = 'sandbox' | 'production';
 
 function isAllegroCategoryAccessEnabled(connection: Connection): boolean {
   return connection.config.allegroCategoryAccessEnabled === true;
+}
+
+/**
+ * `config.environment` on an Allegro connection (sandbox/production) — read
+ * here so the "reuse" path can infer the category-catalog client's target
+ * environment from the *same* connection it's borrowing app credentials
+ * from. Without this, `ErliAdapterFactory` defaults to `'production'`
+ * (erli-adapter.factory.ts) regardless of the source connection's actual
+ * environment, so reusing a sandbox Allegro app's credentials always fails
+ * category-catalog auth with a 401 `invalid_client` — the sandbox app was
+ * never registered against Allegro's production token endpoint.
+ */
+function readAllegroEnvironment(connection: Connection): AllegroCatalogEnvironment {
+  return connection.config.environment === 'sandbox' ? 'sandbox' : 'production';
 }
 
 export function ErliCredentialsPanel({ connection }: { connection: Connection }): ReactElement {
@@ -76,6 +91,7 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
   const [showSecret, setShowSecret] = useState(false);
   const [credSource, setCredSource] = useState<AllegroCredentialSource>('reuse');
   const [selectedAllegroConnectionId, setSelectedAllegroConnectionId] = useState('');
+  const [manualEnvironment, setManualEnvironment] = useState<AllegroCatalogEnvironment>('production');
   const [validationError, setValidationError] = useState<string | null>(null);
   const rotate = useUpdateConnectionCredentialsMutation();
   const updateConfig = useUpdateConnectionMutation();
@@ -106,8 +122,21 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
   const effectiveCredSource: AllegroCredentialSource = hasAllegroConnections
     ? credSource
     : 'manual';
+  const selectedAllegroConnection = allegroConnections.find(
+    (c) => c.id === selectedAllegroConnectionId
+  );
+  const reuseEnvironment = selectedAllegroConnection
+    ? readAllegroEnvironment(selectedAllegroConnection)
+    : undefined;
 
   const initialAllegroEnabled = isAllegroCategoryAccessEnabled(connection);
+  // Resync when the connection's server-confirmed state changes (e.g. after
+  // this panel's own save invalidates the query) — the Allegro section is
+  // always mounted now (not gated behind "Rotate API key"), so there's no
+  // open/close moment to reseed it from otherwise.
+  useEffect(() => {
+    setAllegroEnabled(initialAllegroEnabled);
+  }, [initialAllegroEnabled]);
   const idFilled = allegroClientId.trim().length > 0;
   const secretFilled = allegroClientSecret.trim().length > 0;
   const reuseSelected = selectedAllegroConnectionId.trim().length > 0;
@@ -117,24 +146,26 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
     (allegroEnabled && effectiveCredSource === 'reuse' && reuseSelected) ||
     allegroEnabled !== initialAllegroEnabled;
 
-  function openPanel(): void {
-    // Seed the checkbox from the connection's current server-confirmed state
-    // every time the panel opens — it may have changed since the last open
-    // (e.g. another operator, or a prior save in this session).
-    setAllegroEnabled(initialAllegroEnabled);
-    setCredSource('reuse');
-    setSelectedAllegroConnectionId('');
+  function openApiKeyInput(): void {
+    setApiKey('');
     setShowRotate(true);
   }
 
-  function closePanel(): void {
+  function closeApiKeyInput(): void {
     setShowRotate(false);
     setApiKey('');
+    setValidationError(null);
+  }
+
+  /** Clears only the one-shot manual-entry secret fields after a successful
+   *  save — `allegroEnabled`/`credSource`/`selectedAllegroConnectionId`/
+   *  `manualEnvironment` are sticky UI state now that this section is always
+   *  visible (not a collapse/reopen flow), so they're left as the operator
+   *  set them. */
+  function resetAllegroTransientFields(): void {
     setAllegroClientId('');
     setAllegroClientSecret('');
     setShowSecret(false);
-    setCredSource('reuse');
-    setSelectedAllegroConnectionId('');
     setValidationError(null);
   }
 
@@ -195,10 +226,26 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
         'allegroClientId' in credentials ||
         'reuseAllegroConnectionId' in credentials
       ) {
+        // `allegroEnvironment` drives which Allegro OAuth/REST host the
+        // category-catalog client targets (erli-adapter.factory.ts defaults
+        // to 'production' when absent). Reuse infers it from the source
+        // connection so a sandbox Allegro app's credentials aren't sent to
+        // Allegro's production token endpoint (always a 401 invalid_client);
+        // manual entry uses the operator's explicit pick since there's no
+        // source connection to infer it from.
+        const allegroEnvironment: AllegroCatalogEnvironment | undefined = allegroEnabled
+          ? effectiveCredSource === 'reuse'
+            ? reuseEnvironment
+            : manualEnvironment
+          : undefined;
         await updateConfig.mutateAsync({
           connectionId: connection.id,
           input: {
-            config: { ...connection.config, allegroCategoryAccessEnabled: allegroEnabled },
+            config: {
+              ...connection.config,
+              allegroCategoryAccessEnabled: allegroEnabled,
+              ...(allegroEnvironment ? { allegroEnvironment } : {}),
+            },
           },
         });
       }
@@ -207,7 +254,8 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
         title: 'Credentials saved',
         description: 'Erli connection credentials are now in use.',
       });
-      closePanel();
+      closeApiKeyInput();
+      resetAllegroTransientFields();
     } catch {
       // Surfaced via rotate.error / updateConfig.error below. Fields are
       // deliberately NOT cleared on failure so a retry can resend them.
@@ -215,169 +263,195 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
   };
 
   return (
-    <FormField
-      label="API Key"
-      name="credentials"
-      description="Stored securely on the server. Rotate to replace the key without restarting the API."
-    >
-      {showRotate ? (
-        <div className="form-grid">
-          {rotate.error ? <Alert tone="error">{rotate.error.message}</Alert> : null}
-          {updateConfig.error ? (
-            <Alert tone="error">
-              Category-browsing setting failed to save: {updateConfig.error.message}. Click Save
-              again to retry.
-            </Alert>
-          ) : null}
-          {validationError ? <Alert tone="error">{validationError}</Alert> : null}
-          <Input
-            type="password"
-            autoComplete="off"
-            placeholder="New API key"
-            value={apiKey}
-            onChange={(event) => setApiKey(event.target.value)}
-          />
+    <div className="form-grid">
+      {rotate.error ? <Alert tone="error">{rotate.error.message}</Alert> : null}
+      {updateConfig.error ? (
+        <Alert tone="error">
+          Category-browsing setting failed to save: {updateConfig.error.message}. Click Save again
+          to retry.
+        </Alert>
+      ) : null}
+      {validationError ? <Alert tone="error">{validationError}</Alert> : null}
 
-          <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
-            <input
-              type="checkbox"
-              checked={allegroEnabled}
-              onChange={(event) => setAllegroEnabled(event.target.checked)}
+      <FormField
+        label="API Key"
+        name="credentials"
+        description="Stored securely on the server. Rotate to replace the key without restarting the API."
+      >
+        {showRotate ? (
+          <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+            <Input
+              type="password"
+              autoComplete="off"
+              placeholder="New API key"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
             />
-            <span>
-              <strong>Browse Allegro categories when creating Erli offers</strong>
-              <small style={{ display: 'block', color: 'var(--text-muted)' }}>
-                Turn this on to pick categories and fill required parameters from a list, the same
-                way you do for Allegro. Leave it off and you&apos;ll enter category IDs by hand.
-              </small>
-            </span>
-          </label>
-
-          {allegroEnabled ? (
-            <div className="form-grid">
-              {hasAllegroConnections ? (
-                <div>
-                  <label
-                    style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}
-                  >
-                    <input
-                      type="radio"
-                      name="erli-allegro-cred-source"
-                      checked={effectiveCredSource === 'reuse'}
-                      onChange={() => setCredSource('reuse')}
-                    />
-                    <span>
-                      <strong>Reuse credentials from an existing Allegro connection</strong>
-                      <small style={{ display: 'block', color: 'var(--text-muted)' }}>
-                        Recommended - uses the same app credentials already configured on that
-                        connection. Nothing new to register.
-                      </small>
-                    </span>
-                  </label>
-                  {effectiveCredSource === 'reuse' ? (
-                    <div style={{ marginLeft: 'calc(0.875rem + var(--space-2))' }}>
-                      <Select
-                        aria-label="Allegro connection to reuse"
-                        value={selectedAllegroConnectionId}
-                        onChange={(event) => setSelectedAllegroConnectionId(event.target.value)}
-                      >
-                        <option value="">Select an Allegro connection...</option>
-                        {allegroConnections.map((c) => (
-                          <option key={c.id} value={c.id}>
-                            {c.name}
-                          </option>
-                        ))}
-                      </Select>
-                      <small style={{ display: 'block', color: 'var(--text-muted)' }}>
-                        Only read access to the public category catalog is used - this
-                        connection&apos;s seller credentials are never touched.
-                      </small>
-                    </div>
-                  ) : null}
-                  <label
-                    style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}
-                  >
-                    <input
-                      type="radio"
-                      name="erli-allegro-cred-source"
-                      checked={effectiveCredSource === 'manual'}
-                      onChange={() => setCredSource('manual')}
-                    />
-                    <span>
-                      <strong>Enter Allegro app credentials manually</strong>
-                      <small style={{ display: 'block', color: 'var(--text-muted)' }}>
-                        Use a different Allegro app - e.g. one dedicated just for category browsing.
-                      </small>
-                    </span>
-                  </label>
-                </div>
-              ) : (
-                <Alert tone="info">
-                  No Allegro connection found on this account. Enter your own Allegro app
-                  credentials below to enable category browsing.
-                </Alert>
-              )}
-
-              {effectiveCredSource === 'manual' ? (
-                <div className="form-grid">
-                  <div>
-                    <Input
-                      autoComplete="off"
-                      placeholder="Allegro Client ID"
-                      value={allegroClientId}
-                      onChange={(event) => setAllegroClientId(event.target.value)}
-                    />
-                    <small style={{ display: 'block', color: 'var(--text-muted)' }}>
-                      From an Allegro app you register at apps.developer.allegro.pl. Used only to
-                      read the public category catalog - never to sign in as a seller or place
-                      offers.
-                    </small>
-                  </div>
-                  <div>
-                    <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
-                      <Input
-                        type={showSecret ? 'text' : 'password'}
-                        autoComplete="off"
-                        placeholder="Allegro Client Secret"
-                        value={allegroClientSecret}
-                        onChange={(event) => setAllegroClientSecret(event.target.value)}
-                      />
-                      <Button
-                        tone="ghost"
-                        type="button"
-                        onClick={() => setShowSecret((v) => !v)}
-                        aria-label={showSecret ? 'Hide Client Secret' : 'Show Client Secret'}
-                      >
-                        {showSecret ? 'Hide' : 'Show'}
-                      </Button>
-                    </div>
-                    <small style={{ display: 'block', color: 'var(--text-muted)' }}>
-                      Stored encrypted. You won&apos;t see it again after saving.
-                    </small>
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          ) : null}
-
-          <div className="form-actions">
-            <Button
-              type="button"
-              onClick={(event) => void onSave(event)}
-              disabled={rotate.isPending || updateConfig.isPending || !canSubmit}
-            >
-              {rotate.isPending || updateConfig.isPending ? 'Saving...' : 'Save credentials'}
-            </Button>
-            <Button tone="secondary" type="button" onClick={closePanel}>
+            <Button tone="ghost" type="button" onClick={closeApiKeyInput}>
               Cancel
             </Button>
           </div>
-        </div>
-      ) : (
-        <Button tone="secondary" type="button" onClick={openPanel}>
-          Rotate API key
+        ) : (
+          <Button tone="secondary" type="button" onClick={openApiKeyInput}>
+            Rotate API key
+          </Button>
+        )}
+      </FormField>
+
+      {/* Independent of the API key rotation above — an operator managing
+       * category-browsing access shouldn't have to open (or fill in) the key
+       * rotation flow to reach this. */}
+      <div>
+        <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
+          <input
+            type="checkbox"
+            checked={allegroEnabled}
+            onChange={(event) => setAllegroEnabled(event.target.checked)}
+          />
+          <span>
+            <strong>Browse Allegro categories when creating Erli offers</strong>
+            <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+              Turn this on to pick categories and fill required parameters from a list, the same
+              way you do for Allegro. Leave it off and you&apos;ll enter category IDs by hand.
+            </small>
+          </span>
+        </label>
+
+        {allegroEnabled ? (
+          <div className="form-grid">
+            {hasAllegroConnections ? (
+              <div>
+                <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
+                  <input
+                    type="radio"
+                    name="erli-allegro-cred-source"
+                    checked={effectiveCredSource === 'reuse'}
+                    onChange={() => setCredSource('reuse')}
+                  />
+                  <span>
+                    <strong>Reuse credentials from an existing Allegro connection</strong>
+                    <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                      Recommended - uses the same app credentials already configured on that
+                      connection. Nothing new to register.
+                    </small>
+                  </span>
+                </label>
+                {effectiveCredSource === 'reuse' ? (
+                  <div style={{ marginLeft: 'calc(0.875rem + var(--space-2))' }}>
+                    <Select
+                      aria-label="Allegro connection to reuse"
+                      value={selectedAllegroConnectionId}
+                      onChange={(event) => setSelectedAllegroConnectionId(event.target.value)}
+                    >
+                      <option value="">Select an Allegro connection...</option>
+                      {allegroConnections.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.name}
+                        </option>
+                      ))}
+                    </Select>
+                    <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                      Only read access to the public category catalog is used - this
+                      connection&apos;s seller credentials are never touched.
+                    </small>
+                    {selectedAllegroConnection ? (
+                      <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                        Will use that connection&apos;s environment: <strong>{reuseEnvironment}</strong>.
+                      </small>
+                    ) : null}
+                  </div>
+                ) : null}
+                <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
+                  <input
+                    type="radio"
+                    name="erli-allegro-cred-source"
+                    checked={effectiveCredSource === 'manual'}
+                    onChange={() => setCredSource('manual')}
+                  />
+                  <span>
+                    <strong>Enter Allegro app credentials manually</strong>
+                    <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                      Use a different Allegro app - e.g. one dedicated just for category browsing.
+                    </small>
+                  </span>
+                </label>
+              </div>
+            ) : (
+              <Alert tone="info">
+                No Allegro connection found on this account. Enter your own Allegro app
+                credentials below to enable category browsing.
+              </Alert>
+            )}
+
+            {effectiveCredSource === 'manual' ? (
+              <div className="form-grid">
+                <div>
+                  <Select
+                    aria-label="Allegro app environment"
+                    value={manualEnvironment}
+                    onChange={(event) =>
+                      setManualEnvironment(event.target.value as AllegroCatalogEnvironment)
+                    }
+                  >
+                    <option value="production">Production</option>
+                    <option value="sandbox">Sandbox</option>
+                  </Select>
+                  <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                    Sandbox and production Allegro apps are registered separately - pick the one
+                    this Client ID/Secret belongs to, or category requests will fail
+                    authentication.
+                  </small>
+                </div>
+                <div>
+                  <Input
+                    autoComplete="off"
+                    placeholder="Allegro Client ID"
+                    value={allegroClientId}
+                    onChange={(event) => setAllegroClientId(event.target.value)}
+                  />
+                  <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                    From an Allegro app you register at apps.developer.allegro.pl. Used only to
+                    read the public category catalog - never to sign in as a seller or place
+                    offers.
+                  </small>
+                </div>
+                <div>
+                  <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+                    <Input
+                      type={showSecret ? 'text' : 'password'}
+                      autoComplete="off"
+                      placeholder="Allegro Client Secret"
+                      value={allegroClientSecret}
+                      onChange={(event) => setAllegroClientSecret(event.target.value)}
+                    />
+                    <Button
+                      tone="ghost"
+                      type="button"
+                      onClick={() => setShowSecret((v) => !v)}
+                      aria-label={showSecret ? 'Hide Client Secret' : 'Show Client Secret'}
+                    >
+                      {showSecret ? 'Hide' : 'Show'}
+                    </Button>
+                  </div>
+                  <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                    Stored encrypted. You won&apos;t see it again after saving.
+                  </small>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="form-actions">
+        <Button
+          type="button"
+          onClick={(event) => void onSave(event)}
+          disabled={rotate.isPending || updateConfig.isPending || !canSubmit}
+        >
+          {rotate.isPending || updateConfig.isPending ? 'Saving...' : 'Save credentials'}
         </Button>
-      )}
-    </FormField>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/plugins/erli/index.ts
+++ b/apps/web/src/plugins/erli/index.ts
@@ -68,6 +68,17 @@ export const erliPlugin: OpenLinkerPlugin = definePlugin({
     bulkOfferRowSection: ErliBulkRowSectionLazy,
     // Shared single+bulk blocker: Erli requires ≥1 image (declared once).
     offerValidation: erliOfferValidation,
+    // Bulk Review edit modal: Erli's category browsing is a dynamic
+    // per-connection toggle (`allegroCategoryAccessEnabled`, set via the
+    // credentials panel), not a static adapter capability — the manifest
+    // deliberately never declares `CategoryBrowser` (most Erli connections
+    // don't have Allegro category access configured). Without this, the
+    // bulk edit modal always falls back to the manual Allegro-category-id
+    // input even when the operator *has* configured category access; the
+    // single-offer `ErliCreateOfferWizard` already reads the same config
+    // flag directly.
+    bulkCategoryBrowsingEnabled: (connection) =>
+      connection.config.allegroCategoryAccessEnabled === true,
     // Listing-detail: opt into the generic "Edit offer" drawer (#1215). The BE
     // adapter already implements OfferFieldUpdater; this exposes the FE button.
     supportsListingEdit: true,

--- a/apps/web/src/shared/plugins/plugin.types.ts
+++ b/apps/web/src/shared/plugins/plugin.types.ts
@@ -569,6 +569,24 @@ export interface PlatformContribution {
    */
   bulkOfferRowSection?: ComponentType<BulkOfferRowSectionProps>;
   /**
+   * Bulk offer creation: per-connection override for whether the Review edit
+   * modal shows the browsable category tree (`CategoryPicker` +
+   * category-parameters step) instead of the manual Allegro-category-id
+   * input. The default signal (`connection.supportedCapabilities.includes
+   * ('CategoryBrowser')`) is a static, manifest-level flag — it can never be
+   * true for a `borrows`-taxonomy destination like Erli, whose category
+   * browsing is a *dynamic per-connection* toggle
+   * (`config.allegroCategoryAccessEnabled`, set via the credentials panel),
+   * not a capability the adapter always has. The single-offer
+   * `ErliCreateOfferWizard` already reads this config flag directly; this
+   * slot lets the bulk flow reach the same per-connection signal without a
+   * `platformType ===` check in the shared bulk components. ORed with the
+   * static capability check, never replacing it — a real `CategoryBrowser`
+   * adapter (Allegro) keeps working with no contribution needed. Absent ⇒
+   * only the static capability decides.
+   */
+  bulkCategoryBrowsingEnabled?: (connection: Connection) => boolean;
+  /**
    * Offer creation: declare the platform's blocker chips + row validator once
    * (#1096), consumed by BOTH the bulk Review step and the single-offer wizard.
    * Resolved via `usePlatform(platformType)`. Absent ⇒ only the host-neutral

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -344,7 +344,7 @@ describe('ErliOfferManagerAdapter', () => {
 
         const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
         expect(body.externalAttributes).toEqual([
-          { source: 'allegro', id: '11323', type: 'dictionary', values: ['11323_1'] },
+          { source: 'allegro', id: '11323', type: 'dictionary', values: [{ id: '11323_1' }] },
         ]);
       });
 
@@ -373,7 +373,7 @@ describe('ErliOfferManagerAdapter', () => {
 
         const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
         expect(body.externalAttributes).toEqual([
-          { source: 'allegro', id: '11323', type: 'dictionary', values: ['11323_1'] },
+          { source: 'allegro', id: '11323', type: 'dictionary', values: [{ id: '11323_1' }] },
           { source: 'allegro', id: '224017', type: 'string', values: ['Acme'] },
         ]);
       });
@@ -421,7 +421,7 @@ describe('ErliOfferManagerAdapter', () => {
 
         const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
         expect(body.externalAttributes).toEqual([
-          { source: 'allegro', id: '11323', type: 'dictionary', values: ['11323_1'] },
+          { source: 'allegro', id: '11323', type: 'dictionary', values: [{ id: '11323_1' }] },
         ]);
       });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -853,7 +853,15 @@ function buildExternalAttributes(cmd: CreateOfferCommand): {
       continue;
     }
     if (param.valuesIds !== undefined && param.valuesIds.length > 0) {
-      attributes.push({ source: 'allegro', id: param.id, type: 'dictionary', values: param.valuesIds });
+      // Erli's `dictionary` type requires `values` as `{ id }` objects, not
+      // bare ids — a bare string/id array is rejected wire-side with
+      // `values[N] must be of type object` (confirmed live, #1384 follow-up).
+      attributes.push({
+        source: 'allegro',
+        id: param.id,
+        type: 'dictionary',
+        values: param.valuesIds.map((id) => ({ id })),
+      });
     } else if (param.values !== undefined && param.values.length > 0) {
       attributes.push({ source: 'allegro', id: param.id, type: 'string', values: param.values });
     } else {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -55,19 +55,35 @@ export interface ErliExternalCategory {
 }
 
 /**
+ * A single `dictionary`-type attribute value — Erli's Shop API rejects a bare
+ * string/id here (`externalAttributes[N].values[M] must be of type object`,
+ * confirmed live against the sandbox, #1384 follow-up); `name` is optional
+ * (`additionalProperties: false`, only `id` is required per
+ * `docs/architecture/adrs/erli-sandbox-swagger.json`).
+ */
+export interface ErliDictionaryAttributeValue {
+  id: string | number;
+  name?: string;
+}
+
+/**
  * Attribute entry in `externalAttributes`. `source:"allegro"` reuses an
  * OL-resolved Allegro parameter id (#985); `source:"shop"` carries a shop-native
  * attribute — used to express a variant's distinguishing axes for grouping
  * (#986), since Erli's `externalVariantGroup.attributes` references entries here
  * by `index` (verified against the Shop API). `index` defaults to the array
  * position; set explicitly when a grouping ref must point at a specific entry.
+ *
+ * `values`' element shape is keyed by `type` per the verified sandbox schema:
+ * `string` → plain strings, `dictionary` → `{ id, name? }` objects. `number`/
+ * `range` types exist in the schema but this adapter never emits them today.
  */
 export interface ErliExternalAttribute {
   source: 'allegro' | 'shop';
   id: string;
   name?: string;
   type: ErliExternalAttributeType;
-  values: string[];
+  values: string[] | ErliDictionaryAttributeValue[];
   index?: number;
   unit?: string;
 }


### PR DESCRIPTION
## Summary
- Infer the reused Allegro connection's environment (sandbox/production) into `config.allegroEnvironment` instead of always defaulting to production (`erli-adapter.factory.ts:175`) — reusing a sandbox Allegro app's credentials always 401'd `invalid_client` otherwise. Added an explicit environment picker for the manual-credential-entry path.
- Added a `bulkCategoryBrowsingEnabled` `PlatformContribution` slot so the bulk offer wizard's Review/Edit modal reaches the same dynamic per-connection `config.allegroCategoryAccessEnabled` signal the single-offer `ErliCreateOfferWizard` already used — previously it only checked the static `CategoryBrowser` manifest capability, which Erli correctly never declares, so the tree picker never appeared in bulk mode even with category access configured.
- Mapped dictionary-type category parameter values to Erli's real wire shape (`{ id, name? }` objects, not bare strings) — confirmed against the live sandbox schema (`docs/architecture/adrs/erli-sandbox-swagger.json`) after every dictionary-parameter offer was rejected with `externalAttributes[N].values[0] must be of type object`.
- Moved the "Browse Allegro categories" checkbox out from under the collapsed "Rotate API key" toggle so it's reachable without opening API-key rotation.

All bugs found and fixed during a live manual E2E test against the real Erli + Allegro sandboxes.

## Test plan
- [x] `erli-credentials-panel.test.tsx` — 21 tests (2 new: environment inference, checkbox visibility without opening rotate)
- [x] `erli-offer-manager.adapter.spec.ts` — 82 tests (3 updated for the object-shape fix)
- [x] Full `@openlinker/integrations-erli` package suite — 347 tests, all green
- [x] Verified live end-to-end: 3/3 offers created via the bulk wizard with real category picker + dictionary parameters, confirmed correct on the live Erli sandbox storefront (name/price/image)

Closes #1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)