### PR TITLE
feat(ksef): implement Test connection via the real ksef-token auth handshake

### DIFF
--- a/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-connection-tester.adapter.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-connection-tester.adapter.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * KSeF connection tester specs — validation branches + handshake delegation.
+ *
+ * The actual `challenge → submit → poll → redeem` sequence (real crypto/HTTP
+ * wiring) is already covered by `ksef-auth-handshake.service.spec.ts` (unit,
+ * `FakeKsefHttpClient`) and `ksef-auth-handshake.int-spec.ts` (real sandbox).
+ * This spec mocks `createKsefHttpClient` so it can focus on the tester's own
+ * logic: config/credential validation short-circuits, and mapping the
+ * handshake's outcome (or thrown exception) onto `ConnectionTestResult`.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/adapters
+ */
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import { Connection } from '@openlinker/core/identifier-mapping';
+import { KsefConnectionTesterAdapter } from '../ksef-connection-tester.adapter';
+import { KsefAuthenticationException } from '../../../domain/exceptions/ksef-authentication.exception';
+import { KsefConfigException } from '../../../domain/exceptions/ksef-config.exception';
+import * as httpClientFactory from '../../http/ksef-http-client.factory';
+
+jest.mock('../../http/ksef-http-client.factory');
+
+const SELLER_CONFIG = {
+  nip: '1234567890',
+  name: 'Acme Sp. z o.o.',
+  address: {
+    line1: 'ul. Testowa 1',
+    city: 'Warszawa',
+    postalCode: '00-001',
+    countryIso2: 'PL',
+  },
+};
+
+function connection(opts: { config?: Record<string, unknown>; credentialsRef?: string } = {}): Connection {
+  return new Connection(
+    'conn-1',
+    'ksef',
+    'KSeF',
+    'active',
+    opts.config ?? { env: 'test', seller: SELLER_CONFIG },
+    opts.credentialsRef ?? 'ref:ksef',
+    new Date(),
+    new Date(),
+    undefined,
+    [],
+  );
+}
+
+function resolver(map: Record<string, unknown>): CredentialsResolverPort {
+  return {
+    get: <T>(ref: string): Promise<T> => {
+      if (!(ref in map)) {
+        return Promise.reject(new Error(`no secret for ${ref}`));
+      }
+      return Promise.resolve(map[ref] as T);
+    },
+  };
+}
+
+describe('KsefConnectionTesterAdapter', () => {
+  const createKsefHttpClientMock = httpClientFactory.createKsefHttpClient as jest.MockedFunction<
+    typeof httpClientFactory.createKsefHttpClient
+  >;
+
+  beforeEach(() => {
+    createKsefHttpClientMock.mockReset();
+  });
+
+  it('should fail fast when the connection has no valid environment', async () => {
+    const adapter = new KsefConnectionTesterAdapter();
+    const result = await adapter.test(
+      connection({ config: { seller: SELLER_CONFIG } }),
+      resolver({ 'ref:ksef': { authType: 'ksef-token', secret: 'tok' } }),
+    );
+    expect(result).toMatchObject({ success: false, message: expect.stringContaining('environment') });
+    expect(createKsefHttpClientMock).not.toHaveBeenCalled();
+  });
+
+  it('should fail fast when the connection has no stored credentials', async () => {
+    const adapter = new KsefConnectionTesterAdapter();
+    const result = await adapter.test(connection({ credentialsRef: '' }), resolver({}));
+    expect(result).toMatchObject({
+      success: false,
+      message: 'Connection has no stored credentials',
+    });
+  });
+
+  it('should fail fast when credentials are missing authType or secret', async () => {
+    const adapter = new KsefConnectionTesterAdapter();
+    const result = await adapter.test(connection(), resolver({ 'ref:ksef': { authType: 'ksef-token' } }));
+    expect(result).toMatchObject({ success: false, message: expect.stringContaining('authType') });
+  });
+
+  it('should report qualified-seal as not yet supported, without attempting a handshake', async () => {
+    const adapter = new KsefConnectionTesterAdapter();
+    const result = await adapter.test(
+      connection(),
+      resolver({ 'ref:ksef': { authType: 'qualified-seal', secret: 'cert-ref' } }),
+    );
+    expect(result).toMatchObject({
+      success: false,
+      message: expect.stringContaining('qualified-seal'),
+    });
+    expect(createKsefHttpClientMock).not.toHaveBeenCalled();
+  });
+
+  it('should fail fast when the seller NIP is missing (no session context identifier)', async () => {
+    const adapter = new KsefConnectionTesterAdapter();
+    const result = await adapter.test(
+      connection({ config: { env: 'test' } }),
+      resolver({ 'ref:ksef': { authType: 'ksef-token', secret: 'tok' } }),
+    );
+    expect(result).toMatchObject({ success: false, message: expect.stringContaining('seller NIP') });
+  });
+
+  it('should report success when the handshake authenticates', async () => {
+    const authenticate = jest.fn().mockResolvedValue({
+      accessToken: 'acc',
+      refreshToken: 'ref',
+      accessTokenExpiresAt: new Date(),
+    });
+    createKsefHttpClientMock.mockReturnValue({
+      httpClient: {} as never,
+      publicKeyCache: {} as never,
+      handshake: { authenticate } as never,
+    });
+
+    const adapter = new KsefConnectionTesterAdapter();
+    const result = await adapter.test(
+      connection(),
+      resolver({ 'ref:ksef': { authType: 'ksef-token', secret: 'super-secret-token' } }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('authenticated');
+    expect(authenticate).toHaveBeenCalledWith({
+      authType: 'ksef-token',
+      token: 'super-secret-token',
+      contextNip: '1234567890',
+    });
+  });
+
+  it('should map a live auth rejection to a failed result carrying the status code', async () => {
+    const authenticate = jest
+      .fn()
+      .mockRejectedValue(new KsefAuthenticationException('KSeF rejected the token', 401));
+    createKsefHttpClientMock.mockReturnValue({
+      httpClient: {} as never,
+      publicKeyCache: {} as never,
+      handshake: { authenticate } as never,
+    });
+
+    const adapter = new KsefConnectionTesterAdapter();
+    const result = await adapter.test(
+      connection(),
+      resolver({ 'ref:ksef': { authType: 'ksef-token', secret: 'tok' } }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      status: 401,
+      message: 'KSeF rejected the token',
+      latencyMs: expect.any(Number),
+    });
+  });
+
+  it('should never leak an unrecognised error into the operator-facing message', async () => {
+    const authenticate = jest.fn().mockRejectedValue(new Error('ECONNRESET at socket level'));
+    createKsefHttpClientMock.mockReturnValue({
+      httpClient: {} as never,
+      publicKeyCache: {} as never,
+      handshake: { authenticate } as never,
+    });
+
+    const adapter = new KsefConnectionTesterAdapter();
+    const result = await adapter.test(
+      connection(),
+      resolver({ 'ref:ksef': { authType: 'ksef-token', secret: 'tok' } }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('KSeF connection test failed');
+  });
+
+  it('should treat a config exception the same as any other test failure', async () => {
+    const authenticate = jest
+      .fn()
+      .mockRejectedValue(new KsefConfigException('KSeF auth handshake used before wiring completed'));
+    createKsefHttpClientMock.mockReturnValue({
+      httpClient: {} as never,
+      publicKeyCache: {} as never,
+      handshake: { authenticate } as never,
+    });
+
+    const adapter = new KsefConnectionTesterAdapter();
+    const result = await adapter.test(
+      connection(),
+      resolver({ 'ref:ksef': { authType: 'ksef-token', secret: 'tok' } }),
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      message: 'KSeF auth handshake used before wiring completed',
+    });
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-connection-tester.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-connection-tester.adapter.ts
@@ -1,0 +1,123 @@
+/**
+ * KSeF Connection Tester
+ *
+ * Probes a live KSeF connection by running the real `ksef-token` auth
+ * handshake (`challenge → submit-token → poll → redeem`) so OL Admin can show
+ * the connection Active (or a clear failure) right after the operator saves
+ * their test token. There is no lighter-weight KSeF endpoint that validates a
+ * token's authenticity — the handshake IS the cheapest proof a `ksef-token`
+ * credential actually authenticates, mirroring `InfaktConnectionTesterAdapter`'s
+ * "one cheap authenticated call" posture as closely as this API model allows.
+ *
+ * Resolves credentials directly and builds a bare `KsefHttpClient` bundle via
+ * `createKsefHttpClient` (mirrors `KsefAdapterFactory.createAdapters`'s
+ * env/credentials/seller-NIP resolution, but skips the invoicing-specific
+ * wiring this probe doesn't need). Registered against
+ * `ConnectionTesterRegistryService` at `ksef.publicapi.v2`.
+ *
+ * `qualified-seal` connections are not constructable until C4 (per
+ * `KsefAdapterFactory.resolveAuthMaterial`) — this returns a clear
+ * not-yet-supported result rather than attempting a handshake that can't
+ * succeed.
+ *
+ * SECURITY: never logs the token, challenge, or any redeemed JWT — same
+ * posture as `KsefAuthHandshakeService` itself.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/adapters
+ * @see {@link ConnectionTesterPort}
+ */
+import type {
+  ConnectionTesterPort,
+  ConnectionTestResult,
+  CredentialsResolverPort,
+} from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { Logger } from '@openlinker/shared/logging';
+import { createKsefHttpClient } from '../http/ksef-http-client.factory';
+import { KsefApiException } from '../../domain/exceptions/ksef-api.exception';
+import { KsefAuthenticationException } from '../../domain/exceptions/ksef-authentication.exception';
+import { KsefConfigException } from '../../domain/exceptions/ksef-config.exception';
+import { KsefEnvironmentValues } from '../../domain/types/ksef-connection.types';
+import type { KsefConnectionConfig, KsefCredentials } from '../../domain/types/ksef-connection.types';
+
+export class KsefConnectionTesterAdapter implements ConnectionTesterPort {
+  private readonly logger = new Logger(KsefConnectionTesterAdapter.name);
+
+  async test(
+    connection: Connection,
+    credentialsResolver: CredentialsResolverPort,
+  ): Promise<ConnectionTestResult> {
+    const startedAt = Date.now();
+    try {
+      const config = connection.config as Partial<KsefConnectionConfig> | undefined;
+      const env = config?.env;
+      if (!env || !KsefEnvironmentValues.includes(env)) {
+        return {
+          success: false,
+          message: 'KSeF connection has no valid environment',
+          latencyMs: Date.now() - startedAt,
+        };
+      }
+
+      if (!connection.credentialsRef) {
+        return {
+          success: false,
+          message: 'Connection has no stored credentials',
+          latencyMs: Date.now() - startedAt,
+        };
+      }
+      const credentials = await credentialsResolver.get<KsefCredentials>(connection.credentialsRef);
+      if (!credentials?.authType || !credentials?.secret) {
+        return {
+          success: false,
+          message: 'KSeF credentials missing authType or secret',
+          latencyMs: Date.now() - startedAt,
+        };
+      }
+      if (credentials.authType !== 'ksef-token') {
+        return {
+          success: false,
+          message: `Connection testing for authType '${credentials.authType}' is not yet supported (qualified-seal deferred)`,
+          latencyMs: Date.now() - startedAt,
+        };
+      }
+
+      const contextNip = config?.seller?.nip?.trim();
+      if (!contextNip) {
+        return {
+          success: false,
+          message: 'KSeF connection has no seller NIP configured',
+          latencyMs: Date.now() - startedAt,
+        };
+      }
+
+      const authMaterial = { authType: 'ksef-token' as const, token: credentials.secret, contextNip };
+      const { handshake } = createKsefHttpClient({ connectionId: connection.id, env, authMaterial });
+      await handshake.authenticate(authMaterial);
+
+      return {
+        success: true,
+        message: 'KSeF token authenticated successfully',
+        latencyMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      return this.toFailure(error, Date.now() - startedAt);
+    }
+  }
+
+  private toFailure(error: unknown, latencyMs: number): ConnectionTestResult {
+    if (
+      error instanceof KsefAuthenticationException ||
+      error instanceof KsefApiException ||
+      error instanceof KsefConfigException
+    ) {
+      const status =
+        error instanceof KsefAuthenticationException || error instanceof KsefApiException
+          ? error.statusCode
+          : undefined;
+      return { success: false, status, message: error.message, latencyMs };
+    }
+    this.logger.debug(`KSeF connection test failed with an unrecognised error: ${String(error)}`);
+    return { success: false, message: 'KSeF connection test failed', latencyMs };
+  }
+}

--- a/libs/integrations/ksef/src/ksef-plugin.ts
+++ b/libs/integrations/ksef/src/ksef-plugin.ts
@@ -7,9 +7,11 @@
  * capabilities its factory can build.
  *
  * Side-registrations land in `register(host)` (`createNestAdapterModule`
- * invokes it): the connection config + credentials shape validators (C2) and
- * the retry classifier (so the worker runner treats terminal KSeF failures as
- * non-retryable instead of defaulting unknown errors to retryable). These
+ * invokes it): the connection config + credentials shape validators (C2), the
+ * retry classifier (so the worker runner treats terminal KSeF failures as
+ * non-retryable instead of defaulting unknown errors to retryable), and the
+ * connection tester (runs the real `ksef-token` auth handshake so "Test
+ * connection" proves the token actually authenticates). The shape validators
  * reject malformed payloads before a connection is persisted, so C3+ never sees
  * a connection with an invalid environment or an unresolvable credential.
  *
@@ -29,6 +31,7 @@ import { KsefAdapterFactory } from './application/factories/ksef-adapter.factory
 import { KSEF_ADAPTER_KEY, KSEF_BRAND } from './ksef.constants';
 import { KsefConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/ksef-connection-config-shape-validator.adapter';
 import { KsefConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/ksef-connection-credentials-shape-validator.adapter';
+import { KsefConnectionTesterAdapter } from './infrastructure/adapters/ksef-connection-tester.adapter';
 import { KsefRetryClassifierAdapter } from './infrastructure/adapters/ksef-retry-classifier.adapter';
 
 /**
@@ -65,6 +68,7 @@ export function createKsefPlugin(): AdapterPlugin {
         new KsefConnectionCredentialsShapeValidatorAdapter(KSEF_BRAND),
       );
       host.retryClassifierRegistry.register(KSEF_ADAPTER_KEY, new KsefRetryClassifierAdapter());
+      host.connectionTesterRegistry.register(KSEF_ADAPTER_KEY, new KsefConnectionTesterAdapter());
     },
 
     async createCapabilityAdapter<T>(


### PR DESCRIPTION
## Summary
KSeF never registered a `ConnectionTesterPort` adapter — unlike every other platform integration (including its sibling invoicing integration Infakt) — so "Test connection" always fell back to the generic "Connection testing is not supported for adapter ksef.publicapi.v2" message.

Added `KsefConnectionTesterAdapter`. There's no lighter-weight KSeF endpoint that validates token authenticity, so it runs the real `ksef-token` auth handshake (`challenge → submit-token → poll → redeem`) via the existing `KsefAuthHandshakeService`/`createKsefHttpClient` — the cheapest possible proof this API model allows, mirroring `InfaktConnectionTesterAdapter`'s "one cheap authenticated call" posture as closely as possible. Validates config/credentials shape before any network call; `qualified-seal` connections get a clear "not yet supported" result instead of an attempted handshake that can't succeed (matches `KsefAdapterFactory`'s existing posture for that authType). Registered against `ConnectionTesterRegistryService` at `ksef.publicapi.v2`.

## Test plan
- [x] `ksef-connection-tester.adapter.spec.ts` — 9 new unit tests (validation short-circuits + handshake success/failure mapping, mocking `createKsefHttpClient` since the handshake's own crypto/HTTP wiring is already covered by `ksef-auth-handshake.service.spec.ts` and the real-sandbox `ksef-auth-handshake.int-spec.ts`)
- [x] Full `@openlinker/integrations-ksef` package suite — 349 tests, all green
- [x] `tsc --noEmit` / `eslint` clean
- [x] Verified live against the real KSeF test environment: 543ms round trip, "KSeF token authenticated successfully"

Closes #1447

🤖 Generated with [Claude Code](https://claude.com/claude-code)