### PR TITLE
fix(invoicing): stamp a distinct KSeF document number per correction

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10657,6 +10657,22 @@ html[data-density='compact'] .status-badge {
 }
 .ksef-fa3-view__lineitems tbody tr:last-child td { border-bottom: none; }
 
+/* ── KOR "before correction" lines (#1364 follow-up) ──────────────────
+ * A correction document's pre-correction rows are collapsed by default —
+ * kept out of the main lines/totals table, but reachable for audit.
+ */
+.ksef-fa3-view__before-correction { margin-top: var(--space-3, 0.75rem); }
+.ksef-fa3-view__before-correction summary {
+  cursor: pointer;
+  list-style: none;
+}
+.ksef-fa3-view__before-correction summary::-webkit-details-marker { display: none; }
+.ksef-fa3-view__before-correction summary:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  border-radius: var(--radius-sm);
+}
+
 /* ── Inline Disclosure (#1303) ───────────────────────────────────────
  * Native <details>/<summary> "collapsed value + Change affordance"
  * pattern. First use: Infakt's default-payment-method field, which

--- a/apps/web/src/plugins/ksef/components/ksef-fa3-view.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-fa3-view.test.tsx
@@ -50,6 +50,7 @@ function buildXml({
     netUnitPrice: string;
     netTotal: string;
     vatRate: string;
+    isBeforeCorrection?: boolean;
   }>;
   vatNet23?: string | null;
   vatTax23?: string | null;
@@ -67,6 +68,7 @@ function buildXml({
       <P_9A>${l.netUnitPrice}</P_9A>
       <P_11>${l.netTotal}</P_11>
       <P_12>${l.vatRate}</P_12>
+      ${l.isBeforeCorrection ? '<StanPrzed>1</StanPrzed>' : ''}
     </FaWiersz>`,
     )
     .join('');
@@ -148,6 +150,48 @@ describe('KsefFa3View', () => {
     expect(screen.getAllByText('1000.00').length).toBeGreaterThanOrEqual(1);
     // 100.00 appears as netTotal for line 2 and netUnitPrice for line 1
     expect(screen.getAllByText('100.00').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should render only the "after" line in the main table for a KOR correction, with the "before" line collapsed separately (#1364 follow-up)', () => {
+    renderWithProviders(
+      <KsefFa3View
+        xmlText={buildXml({
+          lines: [
+            {
+              lineNo: '1',
+              description: 'Widget A',
+              unit: 'pcs',
+              quantity: '10',
+              netUnitPrice: '100.00',
+              netTotal: '1000.00',
+              vatRate: '23',
+              isBeforeCorrection: true,
+            },
+            {
+              lineNo: '1',
+              description: 'Widget A',
+              unit: 'pcs',
+              quantity: '5',
+              netUnitPrice: '100.00',
+              netTotal: '500.00',
+              vatRate: '23',
+            },
+          ],
+        })}
+      />,
+    );
+
+    // Main table renders the "after" line only.
+    const mainTable = document.querySelector('.ksef-fa3-view__lines .ksef-fa3-view__lineitems');
+    expect(mainTable?.textContent).toContain('500.00');
+    expect(mainTable?.textContent).not.toContain('1000.00');
+
+    // The "before" line is present, but only inside the collapsed disclosure.
+    expect(screen.getByText('Lines before correction')).toBeInTheDocument();
+    const beforeTable = document.querySelector(
+      '.ksef-fa3-view__before-correction .ksef-fa3-view__lineitems',
+    );
+    expect(beforeTable?.textContent).toContain('1000.00');
   });
 
   it('should show grand total when present in XML', () => {

--- a/apps/web/src/plugins/ksef/components/ksef-fa3-view.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-fa3-view.tsx
@@ -8,7 +8,9 @@
  *   - Seller identity (name + NIP)
  *   - Buyer identity (name + NIP)
  *   - Invoice number and issue date
- *   - Invoice lines table (line#, description, unit, qty, net price, net total, VAT rate)
+ *   - Invoice lines table (line#, description, unit, qty, net price, net total, VAT rate) —
+ *     current ("after") lines only; a KOR correction's `StanPrzed=1` "before" rows render in
+ *     a separate collapsed section so they never mix into the main table/totals (#1364 follow-up)
  *   - VAT band summary (23%, 8%, 5%, 0%)
  *   - Grand total
  *   - KSeF assigned number (if present)
@@ -83,6 +85,7 @@ function parseFa3Xml(xmlText: string): FaData | null {
     netUnitPrice: getText(el, 'P_9A'),
     netTotal: getText(el, 'P_11'),
     vatRate: getText(el, 'P_12'),
+    isBeforeCorrection: getText(el, 'StanPrzed') === '1',
   }));
 
   const vatNet23 = fa ? getText(fa, 'P_13_1') : null;
@@ -130,6 +133,14 @@ export function KsefFa3View({ xmlText }: KsefFa3ViewProps): ReactElement | null 
     data.vatNet8 !== null ||
     data.vatNet5 !== null ||
     data.vatNet0 !== null;
+
+  // A KOR correction emits one "before" row (StanPrzed=1) per changed line
+  // plus every current "after" line. The VAT summary / grand total below
+  // already reflect only the "after" state, so the main table must too —
+  // otherwise line counts and totals double up (#1364 follow-up). The
+  // "before" rows are still shown, but in a separate, clearly labeled set.
+  const currentLines = data.lines.filter((line) => !line.isBeforeCorrection);
+  const beforeCorrectionLines = data.lines.filter((line) => line.isBeforeCorrection);
 
   return (
     <div className="ksef-fa3-view">
@@ -188,8 +199,8 @@ export function KsefFa3View({ xmlText }: KsefFa3ViewProps): ReactElement | null 
         </div>
       ) : null}
 
-      {/* Line items */}
-      {data.lines.length > 0 ? (
+      {/* Line items (current / "after" state) */}
+      {currentLines.length > 0 ? (
         <div className="ksef-fa3-view__lines">
           <div className="slot-row__label ksef-fa3-view__lines-title">
             {t('invoice.ksef.fa3Lines', 'Invoice lines')}
@@ -208,7 +219,7 @@ export function KsefFa3View({ xmlText }: KsefFa3ViewProps): ReactElement | null 
                 </tr>
               </thead>
               <tbody>
-                {data.lines.map((line, idx) => (
+                {currentLines.map((line, idx) => (
                   <tr key={line.lineNo ?? idx}>
                     <td>{line.lineNo ?? String(idx + 1)}</td>
                     <td>{line.description ?? '—'}</td>
@@ -223,6 +234,44 @@ export function KsefFa3View({ xmlText }: KsefFa3ViewProps): ReactElement | null 
             </table>
           </div>
         </div>
+      ) : null}
+
+      {/* KOR "before correction" lines — shown separately so they never mix
+          into the current-state table/totals above. */}
+      {beforeCorrectionLines.length > 0 ? (
+        <details className="ksef-fa3-view__before-correction">
+          <summary className="slot-row__label ksef-fa3-view__lines-title">
+            {t('invoice.ksef.fa3LinesBefore', 'Lines before correction')}
+          </summary>
+          <div className="ksef-fa3-view__lines-table-wrap">
+            <table className="ksef-fa3-view__lineitems">
+              <thead>
+                <tr>
+                  <th>{t('invoice.ksef.fa3LineNo', '#')}</th>
+                  <th>{t('invoice.ksef.fa3LineDesc', 'Description')}</th>
+                  <th>{t('invoice.ksef.fa3LineUnit', 'Unit')}</th>
+                  <th>{t('invoice.ksef.fa3LineQty', 'Qty')}</th>
+                  <th>{t('invoice.ksef.fa3LineNetPrice', 'Net price')}</th>
+                  <th>{t('invoice.ksef.fa3LineNetTotal', 'Net total')}</th>
+                  <th>{t('invoice.ksef.fa3LineVat', 'VAT')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {beforeCorrectionLines.map((line, idx) => (
+                  <tr key={line.lineNo ?? idx}>
+                    <td>{line.lineNo ?? String(idx + 1)}</td>
+                    <td>{line.description ?? '—'}</td>
+                    <td>{line.unit ?? '—'}</td>
+                    <td>{line.quantity ?? '—'}</td>
+                    <td>{line.netUnitPrice ?? '—'}</td>
+                    <td>{line.netTotal ?? '—'}</td>
+                    <td>{line.vatRate ?? '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </details>
       ) : null}
 
       {/* VAT bands */}

--- a/apps/web/src/plugins/ksef/components/ksef-fa3-view.types.ts
+++ b/apps/web/src/plugins/ksef/components/ksef-fa3-view.types.ts
@@ -12,6 +12,14 @@ export interface FaLine {
   netUnitPrice: string | null;
   netTotal: string | null;
   vatRate: string | null;
+  /**
+   * FA(3) KOR before/after correction model: `true` when this row carries
+   * `<StanPrzed>1</StanPrzed>` (the pre-correction "before" state). A
+   * correction document emits one before row per changed line plus every
+   * current ("after") line — they must be rendered as two distinct sets, not
+   * flattened into one table, or line counts/totals double up (#1364 follow-up).
+   */
+  isBeforeCorrection: boolean;
 }
 
 export interface FaData {

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -823,9 +823,9 @@ describe('InvoiceService', () => {
         getInvoice: jest.fn(),
         upsertCustomer: jest.fn(),
         getSupportedDocumentTypes: jest.fn(),
-        issueCorrection: jest.fn().mockResolvedValue(
-          makeRecord({ id: 'corr-rec', status: 'issued', documentType: 'corrected' }),
-        ),
+        issueCorrection: jest.fn().mockResolvedValue({
+          record: makeRecord({ id: 'corr-rec', status: 'issued', documentType: 'corrected' }),
+        }),
       };
       integrations.getCapabilityAdapter.mockResolvedValue(correctionAdapter);
       repo.create.mockResolvedValue(
@@ -894,6 +894,60 @@ describe('InvoiceService', () => {
       expect(repo.updateOutcome).toHaveBeenLastCalledWith(
         'corr-rec',
         expect.objectContaining({ issuedLineSnapshot: null }),
+      );
+    });
+
+    // #1229 follow-up regression: a correction's source document (e.g. KSeF's
+    // FA(3) XML) was previously discarded entirely — `issueCorrection` never
+    // persisted `documentContent`/`sourceDocument` at all, so a corrected
+    // invoice's "View"/"Preview" always 409'd with "no source document
+    // available" even when the adapter had built and submitted a real one.
+    it('persists the adapter-supplied source document for a correction, same as issueInvoice', async () => {
+      const sourceDocument = {
+        contentType: 'application/xml',
+        contentBase64: 'PEZha3R1cmE+a29yZWtjamE8L0Zha3R1cmE+',
+      };
+      correctionAdapter.issueCorrection.mockResolvedValue({
+        record: makeRecord({ id: 'corr-rec', status: 'issued', documentType: 'corrected' }),
+        sourceDocument,
+      });
+
+      await service.issueCorrection(makeCorrectionCmd());
+
+      expect(repo.updateOutcome).toHaveBeenLastCalledWith(
+        'corr-rec',
+        expect.objectContaining({ sourceDocument }),
+      );
+    });
+
+    it('persists sourceDocument:null for a correction when the adapter surfaces none', async () => {
+      await service.issueCorrection(makeCorrectionCmd());
+
+      expect(repo.updateOutcome).toHaveBeenLastCalledWith(
+        'corr-rec',
+        expect.objectContaining({ sourceDocument: null }),
+      );
+    });
+
+    it('snapshots documentContent from the corrected ("after") lines, not the original', async () => {
+      await service.issueCorrection(
+        makeCorrectionCmd({ lines: [{ originalLineNumber: 1, newUnitPriceGross: 90 }] }),
+      );
+
+      const [, patch] = repo.updateOutcome.mock.calls.at(-1) as [string, Record<string, unknown>];
+      const content = patch['documentContent'] as { lines: { unitNet: number }[] } | null;
+      expect(content).not.toBeNull();
+      // Line 1's price was corrected 100 -> 90 gross; documentContent must
+      // reflect the corrected value, not the original document's 100.
+      expect(content?.lines[0].unitNet).toBeCloseTo(90 / 1.23, 2);
+    });
+
+    it('persists documentContent:null for a correction when the caller supplied no originalDocument', async () => {
+      await service.issueCorrection(makeCorrectionCmd({ originalDocument: undefined }));
+
+      expect(repo.updateOutcome).toHaveBeenLastCalledWith(
+        'corr-rec',
+        expect.objectContaining({ documentContent: null }),
       );
     });
   });

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -49,6 +49,7 @@ import type {
   IssuedDocumentSeller,
   IssuedLineSnapshot,
   IssueInvoiceCommand,
+  IssueInvoiceResult,
   PaginatedInvoiceRecords,
   RegulatoryClearanceResult,
   TaxBreakdownEntry,
@@ -519,9 +520,9 @@ export class InvoiceService implements IInvoiceService {
       throw new CapabilityNotSupportedException(cmd.connectionId, 'CorrectionIssuer');
     }
 
-    let issued: InvoiceRecord;
+    let issueResult: IssueInvoiceResult;
     try {
-      issued = await adapter.issueCorrection(cmd);
+      issueResult = await adapter.issueCorrection(cmd);
     } catch (error) {
       const sanitized = this.sanitizeError(error);
       const failureMode = this.classifyFailure(error);
@@ -541,19 +542,43 @@ export class InvoiceService implements IInvoiceService {
       throw error;
     }
 
+    const { record: issued, seller, sourceDocument } = issueResult;
+
     // #1297: snapshot the correction's OWN post-correction ("after") lines so a
     // correction-of-correction diffs against them, not the live order. Derived
     // from the caller-assembled original snapshot (`cmd.originalDocument.lines`,
     // the "before" state) with the per-line deltas applied. Only when the caller
     // supplied `originalDocument` (order still resolvable); absent → persist null
     // and the next correction falls back to order-derived reconstruction.
-    const issuedLineSnapshot: IssuedLineSnapshot | null = cmd.originalDocument
-      ? {
-          buyer: cmd.originalDocument.buyer,
-          currency: cmd.originalDocument.currency,
-          lines: applyCorrectionDeltas(cmd.originalDocument.lines, cmd.lines),
-        }
+    const correctedLines = cmd.originalDocument
+      ? applyCorrectionDeltas(cmd.originalDocument.lines, cmd.lines)
       : null;
+    const issuedLineSnapshot: IssuedLineSnapshot | null =
+      cmd.originalDocument && correctedLines
+        ? {
+            buyer: cmd.originalDocument.buyer,
+            currency: cmd.originalDocument.currency,
+            lines: correctedLines,
+          }
+        : null;
+    // W2/W3 (#1229 follow-up): a correction's displayed content and source
+    // document were previously never persisted at all — every corrected
+    // invoice's "View"/"Preview" 409'd with "no source document available"
+    // even when the adapter (KSeF) had built and submitted a real FA(3) XML.
+    // Mirrors `issueInvoice`'s persistence exactly, built from the corrected
+    // ("after") lines rather than the original ones.
+    const documentContent =
+      correctedLines && cmd.originalDocument
+        ? this.buildContent(
+            {
+              lines: correctedLines,
+              buyer: cmd.originalDocument.buyer,
+              currency: cmd.originalDocument.currency,
+            },
+            issued,
+            seller ?? null,
+          )
+        : null;
 
     return this.repo.updateOutcome(pending.id, {
       status: 'issued',
@@ -571,6 +596,8 @@ export class InvoiceService implements IInvoiceService {
       failureReason: null,
       leaseExpiresAt: null,
       issuedLineSnapshot,
+      documentContent,
+      sourceDocument: sourceDocument ?? null,
     });
   }
 
@@ -647,7 +674,7 @@ export class InvoiceService implements IInvoiceService {
    * revision rather than relying on this recomputation.
    */
   private buildContent(
-    cmd: IssueInvoiceCommand,
+    cmd: Pick<IssueInvoiceCommand, 'lines' | 'buyer' | 'currency'>,
     record: InvoiceRecord,
     seller: IssuedDocumentSeller | null,
   ): IssuedDocumentContent {

--- a/libs/core/src/invoicing/domain/ports/capabilities/correction-issuer.capability.ts
+++ b/libs/core/src/invoicing/domain/ports/capabilities/correction-issuer.capability.ts
@@ -19,18 +19,21 @@
  *
  * @module libs/core/src/invoicing/domain/ports/capabilities
  */
-import type { InvoiceRecord } from '../../entities/invoice-record.entity';
-import type { IssueCorrectionCommand } from '../../types/invoicing.types';
+import type { IssueCorrectionCommand, IssueInvoiceResult } from '../../types/invoicing.types';
 import type { InvoicingPort } from '../invoicing.port';
 
 export interface CorrectionIssuer {
   /**
-   * Issue a correction of an already-issued document. Returns a transient issued
-   * `InvoiceRecord` (the core service persists). A business rejection throws a
-   * terminal error; a transport/infrastructure failure throws for the caller to
-   * retry. Performs no identifier mapping.
+   * Issue a correction of an already-issued document. Returns the same
+   * {@link IssueInvoiceResult} shape `issueInvoice` does (transient issued
+   * `record` the core service persists, plus the optional `seller`/
+   * `sourceDocument` an adapter that builds its own machine-readable document
+   * — e.g. KSeF's FA(3) XML — surfaces so `GET .../document?kind=source`
+   * works for corrections too, #1229 follow-up). A business rejection throws
+   * a terminal error; a transport/infrastructure failure throws for the
+   * caller to retry. Performs no identifier mapping.
    */
-  issueCorrection(cmd: IssueCorrectionCommand): Promise<InvoiceRecord>;
+  issueCorrection(cmd: IssueCorrectionCommand): Promise<IssueInvoiceResult>;
 }
 
 export function isCorrectionIssuer(

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -763,7 +763,7 @@ describe('InfaktInvoicingAdapter', () => {
       // uuids; verified live, 2026-07-03).
       http.seed('POST', 'corrective_invoices/corr-uuid-1/send_to_ksef.json', ksefResponseFixture());
 
-      const record = await adapter.issueCorrection(baseCmd);
+      const { record } = await adapter.issueCorrection(baseCmd);
 
       expect(record).toBeInstanceOf(InvoiceRecord);
       expect(record.providerInvoiceId).toBe('corr-uuid-1');

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -561,7 +561,7 @@ export class InfaktInvoicingAdapter
     return { paymentStatus: toPaymentStatus(invoice) };
   }
 
-  async issueCorrection(cmd: IssueCorrectionCommand): Promise<InvoiceRecord> {
+  async issueCorrection(cmd: IssueCorrectionCommand): Promise<IssueInvoiceResult> {
     const { originalProviderInvoiceId, reason, lines, documentType, idempotencyKey, orderId } =
       cmd;
 
@@ -679,28 +679,33 @@ export class InfaktInvoicingAdapter
     const ksefResult = await this.sendToKsef(invoice.uuid, 'corrective_invoices');
 
     const now = new Date();
-    return new InvoiceRecord(
-      randomUUID(),
-      this.connectionId,
-      orderId,
-      INFAKT_PROVIDER_TYPE,
-      documentType ?? 'corrected',
-      'issued',
-      invoice.uuid,
-      invoice.number ?? null,
-      toRegulatoryStatus(ksefResult.status),
-      ksefResult.ksef_number,
-      idempotencyKey ?? null,
-      // Infakt's invoice resource carries no `pdf_url` field (verified live
-      // against the sandbox, #1321) — the real PDF path is
-      // `RegulatoryDocumentReader.getRegulatoryDocument(record, 'rendered')`
-      // below, which hits the dedicated `pdf.json` endpoint.
-      null,
-      now,
-      null,
-      now,
-      now,
-    );
+    return {
+      record: new InvoiceRecord(
+        randomUUID(),
+        this.connectionId,
+        orderId,
+        INFAKT_PROVIDER_TYPE,
+        documentType ?? 'corrected',
+        'issued',
+        invoice.uuid,
+        invoice.number ?? null,
+        toRegulatoryStatus(ksefResult.status),
+        ksefResult.ksef_number,
+        idempotencyKey ?? null,
+        // Infakt's invoice resource carries no `pdf_url` field (verified live
+        // against the sandbox, #1321) — the real PDF path is
+        // `RegulatoryDocumentReader.getRegulatoryDocument(record, 'rendered')`
+        // below, which hits the dedicated `pdf.json` endpoint.
+        null,
+        now,
+        null,
+        now,
+        now,
+      ),
+      // Infakt builds and owns its own FA(3)/KSeF session server-side (see the
+      // module docstring) — there is no machine-readable document for OL to
+      // capture, same as issueInvoice.
+    };
   }
 
   // --- Infakt-specific: trigger KSeF submission ---

--- a/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
+++ b/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
@@ -4,10 +4,10 @@
  * Single per-connection construction seam for the KSeF plugin. Resolves the
  * connection's credentials via the host `CredentialsResolverPort`, validates
  * the config + credential shape, and builds the concrete `KsefHttpClient` (auth
- * header injection, retry/backoff, token lifecycle) wired to the per-connection
- * capability adapters. C4 wires the issuance mechanics onto the same client.
- * Routing all construction through here keeps credential + environment
- * resolution in one place (the Allegro/Erli precedent).
+ * header injection, retry/backoff, token lifecycle) wired to the FA(3)
+ * issuance + clearance mechanics on the same client. Routing all construction
+ * through here keeps credential + environment resolution in one place (the
+ * Allegro/Erli precedent).
  *
  * Not `@Injectable` — a plain class; the client it builds closes over one
  * connection's resolved secret, never a DI singleton.
@@ -17,9 +17,10 @@
  * malformed credential shape fails fast with `KsefConfigException` before any
  * request leaves the client (ADR-003).
  *
- * Qualified-seal (X.509) connections are not constructable until C4 — they
- * throw `KsefConfigException` here so the connection fails loudly rather than
- * half-wiring an unusable client.
+ * Qualified-seal (X.509) connections need real X.509/HSM signing material this
+ * package does not yet implement — they throw `KsefConfigException` here so
+ * the connection fails loudly rather than half-wiring an unusable client. See
+ * `KsefAuthXmlBuilder.signXades` for the deferred signing implementation.
  *
  * @module libs/integrations/ksef/src/application/factories
  */
@@ -233,9 +234,9 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
    */
   private resolveAuthMaterial(connection: Connection, credentials: KsefCredentials): KsefTokenAuthMaterial {
     if (credentials.authType !== 'ksef-token') {
-      // Qualified-seal needs real X.509/HSM material — deferred to C4.
+      // Qualified-seal needs real X.509/HSM signing material — not yet implemented.
       throw new KsefConfigException(
-        `KSeF authType '${credentials.authType}' is not constructable until C4 (qualified-seal)`,
+        `KSeF authType '${credentials.authType}' is not yet supported (qualified-seal signing is not implemented)`,
         connection.id,
       );
     }

--- a/libs/integrations/ksef/src/application/interfaces/ksef-adapter.factory.interface.ts
+++ b/libs/integrations/ksef/src/application/interfaces/ksef-adapter.factory.interface.ts
@@ -7,9 +7,8 @@
  * precedent so consumers depend on the abstraction rather than the concrete
  * factory class.
  *
- * C2 builds only the `Invoicing` capability (stub). C3 adds the concrete HTTP
- * client; C4 fills in the issuance mechanics. The signature stays stable across
- * those phases.
+ * Builds the `Invoicing` capability adapter (FA(3) issuance + clearance,
+ * `KsefInvoicingAdapter`) — the only capability KSeF's manifest declares.
  *
  * @module libs/integrations/ksef/src/application/interfaces
  */
@@ -24,10 +23,10 @@ export interface KsefAdapters {
 
 export interface IKsefAdapterFactory {
   /**
-   * Build the per-connection capability adapters. `identifierMapping` is kept on
-   * the signature (unused by the C2 stub) so later phases extend behaviour
-   * without churning this contract or the plugin's dispatch call site — mirrors
-   * the Allegro/Erli precedent.
+   * Build the per-connection capability adapters. `identifierMapping` is kept
+   * on the signature — unused today (KSeF has no identifier-mapping need) —
+   * so a future capability can be added without churning this contract or the
+   * plugin's dispatch call site. Mirrors the Allegro/Erli precedent.
    */
   createAdapters(
     connection: Connection,

--- a/libs/integrations/ksef/src/index.ts
+++ b/libs/integrations/ksef/src/index.ts
@@ -1,14 +1,17 @@
 /**
  * @openlinker/integrations-ksef — Public Barrel
  *
- * KSeF Public API v2 invoicing/clearance adapter plugin (#1144 / C2 skeleton).
- * The runtime entry the host composes is `KsefIntegrationModule`; this barrel
- * also exports the static `ksefAdapterManifest` (#575 pattern) and the plugin
- * factory. C2 ships the plugin skeleton + manifest + connection config/
- * credentials shape validators + the stub `Invoicing` capability adapter. The
- * HTTP client (C3), issuance mechanics (C4), and `RegulatoryTransmitter`
- * clearance sub-capability land in the follow-up KSeF issues; see ADR-026 for
- * the country-agnostic invoicing decisions they build on.
+ * KSeF Public API v2 invoicing/clearance adapter plugin (#1144). The runtime
+ * entry the host composes is `KsefIntegrationModule`; this barrel also
+ * exports the static `ksefAdapterManifest` (#575 pattern) and the plugin
+ * factory. Shipped: the HTTP client, connection config/credentials shape
+ * validators, connection tester, the `Invoicing` capability adapter (FA(3)
+ * `VAT`/`KOR` issuance via the async submit → poll → UPO flow), and the
+ * `RegulatoryTransmitter` clearance sub-capability. See
+ * `libs/integrations/ksef/docs/setup-guide.md` for the full flow, current
+ * limitations, and compliance caveats, and ADR-026 for the country-agnostic
+ * invoicing decisions this package builds on. `qualified-seal` auth (X.509
+ * signing) remains a documented deferred stub — see `KsefAuthXmlBuilder`.
  *
  * @module libs/integrations/ksef/src
  */

--- a/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-invoicing.adapter.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-invoicing.adapter.spec.ts
@@ -474,7 +474,7 @@ describe('KsefInvoicingAdapter', () => {
       seedHappyPath(http);
       const { builder, lastInput } = capturingBuilder();
 
-      const record = await adapter(http, builder).issueCorrection(correctionCommand());
+      const { record } = await adapter(http, builder).issueCorrection(correctionCommand());
 
       const paths = http.calls.map((c) => `${c.method} ${c.path}`);
       expect(paths).toEqual([
@@ -489,7 +489,10 @@ describe('KsefInvoicingAdapter', () => {
       // The KOR's own P_2 must land on the correction record too — the
       // correction path is the primary consumer of the #1289 precondition
       // this unblocks, so guard it explicitly, not just via delegation (#1338).
-      expect(record.providerInvoiceNumber).toBe('ol_order_123');
+      // #1364: a correction's P_2 must be DISTINCT from the original document's
+      // P_2 (`orderId`) or KSeF rejects the second submission as a duplicate.
+      expect(record.providerInvoiceNumber).not.toBe('ol_order_123');
+      expect(record.providerInvoiceNumber).toMatch(/^ol_order_123-KOR-/);
 
       const built = lastInput();
       expect(built?.correction).toBeDefined();
@@ -498,6 +501,36 @@ describe('KsefInvoicingAdapter', () => {
       // The delta (newQuantity: 1) was applied onto the original line (qty 2).
       expect(built?.correction?.correctedLines).toHaveLength(1);
       expect(built?.correction?.correctedLines?.[0]?.quantity).toBe(1);
+    });
+
+    it('should derive distinct P_2 numbers for two corrections of the same order (#1364)', async () => {
+      const http = new FakeKsefHttpClient();
+      seedHappyPath(http);
+
+      const { record: first } = await adapter(http).issueCorrection(
+        correctionCommand({ idempotencyKey: 'retry-key-a' }),
+      );
+      const { record: second } = await adapter(http).issueCorrection(
+        correctionCommand({ idempotencyKey: 'retry-key-b' }),
+      );
+
+      expect(first.providerInvoiceNumber).not.toBe(second.providerInvoiceNumber);
+      expect(first.providerInvoiceNumber).not.toBe('ol_order_123');
+      expect(second.providerInvoiceNumber).not.toBe('ol_order_123');
+    });
+
+    it('should derive the same P_2 for repeated calls with the same idempotencyKey (#1364)', async () => {
+      const http = new FakeKsefHttpClient();
+      seedHappyPath(http);
+
+      const { record: first } = await adapter(http).issueCorrection(
+        correctionCommand({ idempotencyKey: 'stable-retry-key' }),
+      );
+      const { record: retry } = await adapter(http).issueCorrection(
+        correctionCommand({ idempotencyKey: 'stable-retry-key' }),
+      );
+
+      expect(retry.providerInvoiceNumber).toBe(first.providerInvoiceNumber);
     });
 
     it('should apply newUnitPriceGross deltas while keeping name/taxRate from the original line', async () => {

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
@@ -175,7 +175,17 @@ export class KsefInvoicingAdapter
     // FA(3) invoice-number source (P_2 must be a unique invoice number, not an
     // order id) before prod. Owned by the core InvoiceService numbering
     // follow-up (#1118), not the C6 clearance-read (#1150).
-    const documentNumber = cmd.orderId;
+    //
+    // #1364 interim fix: a correction MUST NOT reuse the original document's
+    // P_2 — KSeF rejects it live with "Duplikat faktury" (confirmed against
+    // the real test environment) once the same order is corrected a second
+    // time. Give every correction a distinct suffix so it never collides with
+    // the document it corrects (or an earlier correction of the same order).
+    // Not the real sequential-numbering source #1364 ultimately wants — just
+    // enough to stop the collision until that lands.
+    const documentNumber = cmd.correction
+      ? this.buildCorrectionDocumentNumber(cmd.orderId, cmd.idempotencyKey, issuedAt)
+      : cmd.orderId;
     this.logger.log(
       `Issuing KSeF document (connection ${this.connectionId}, order ${cmd.orderId}, lines ${cmd.lines.length})`,
     );
@@ -264,6 +274,24 @@ export class KsefInvoicingAdapter
     return { record, seller: this.toNeutralSeller(), sourceDocument: this.toSourceDocument(xml) };
   }
 
+  /**
+   * #1364 interim fix: derive a P_2 for a correction that is distinct from the
+   * original document's P_2 (`orderId`) and from any earlier correction of the
+   * same order. Keyed off `idempotencyKey` when the caller supplied one (stable
+   * across retries of the SAME correction attempt — a retry must reuse the same
+   * P_2, not mint a new one), else falls back to the issue timestamp. Not the
+   * real per-seller sequential FA(3) numbering source #1364 ultimately wants —
+   * just enough to stop the live "Duplikat faktury" collision until that lands.
+   */
+  private buildCorrectionDocumentNumber(
+    orderId: string,
+    idempotencyKey: string | undefined,
+    issuedAt: Date,
+  ): string {
+    const suffix = idempotencyKey ? idempotencyKey.slice(0, 16) : issuedAt.getTime().toString(36);
+    return `${orderId}-KOR-${suffix}`;
+  }
+
   /** Wrap the built FA(3) XML as a neutral, jsonb-persistable {@link StoredDocument}. */
   private toSourceDocument(xml: string): StoredDocument {
     return {
@@ -309,7 +337,7 @@ export class KsefInvoicingAdapter
    * stays on the base `IssueCorrectionCommand` for adapters (e.g. Subiekt)
    * whose provider-native id IS the correction target.
    */
-  async issueCorrection(cmd: IssueCorrectionCommand): Promise<InvoiceRecordType> {
+  async issueCorrection(cmd: IssueCorrectionCommand): Promise<IssueInvoiceResult> {
     if (!cmd.originalDocument) {
       throw new KsefInvalidCorrectionException(
         `Cannot issue a KSeF correction for order ${cmd.orderId}: the original invoice ` +
@@ -317,15 +345,9 @@ export class KsefInvoicingAdapter
       );
     }
     const correctedLines = this.applyCorrectionDeltas(cmd.originalDocument.lines, cmd.lines);
-    // NOTE (#1338 review follow-up, tracked in #1364): delegating to issueInvoice
-    // with the SAME `orderId` means a KOR stamps P_2 = the original document's
-    // P_2 — the correction and the invoice it corrects share a document number,
-    // which is wrong for FA(3) (P_2 must be unique per document). Pre-existing
-    // (the orderId-as-P_2 placeholder predates this fix); now more visible
-    // because `providerInvoiceNumber` is actually persisted and consumed by the
-    // correction precondition. Must be resolved together with the real
-    // per-seller sequential FA(3) numbering source (see the `documentNumber`
-    // TODO in issueInvoice above) — a correction needs its own distinct number.
+    // #1364: `issueInvoice` below stamps a distinct P_2 whenever `correction` is
+    // present (see `buildCorrectionDocumentNumber`), so delegating with the same
+    // `orderId` here no longer collides with the original document's P_2.
     const issueCmd: IssueInvoiceCommand = {
       connectionId: cmd.connectionId,
       orderId: cmd.orderId,
@@ -346,11 +368,12 @@ export class KsefInvoicingAdapter
       },
       idempotencyKey: cmd.idempotencyKey,
     };
-    // `CorrectionIssuer.issueCorrection` returns the plain neutral `InvoiceRecord`
-    // (unlike `issueInvoice`, which wraps it in `IssueInvoiceResult` alongside the
-    // optional seller/sourceDocument the UPO/document-retrieval flow needs).
-    const { record } = await this.issueInvoice(issueCmd);
-    return record;
+    // `CorrectionIssuer.issueCorrection` now returns the full `IssueInvoiceResult`
+    // (record + seller + sourceDocument), same as `issueInvoice` — a KOR's FA(3)
+    // XML must be persisted and re-servable just like the original invoice's
+    // (#1229 follow-up: the source document was previously discarded here,
+    // leaving every correction's "View"/"Preview" with nothing to render).
+    return this.issueInvoice(issueCmd);
   }
 
   /**

--- a/libs/integrations/subiekt/src/infrastructure/adapters/__tests__/subiekt-invoicing.adapter.spec.ts
+++ b/libs/integrations/subiekt/src/infrastructure/adapters/__tests__/subiekt-invoicing.adapter.spec.ts
@@ -313,7 +313,7 @@ describe('SubiektInvoicingAdapter', () => {
     it('issues a quantity-only correction via the bridge correction endpoint', async () => {
       const { adapter, bridge } = makeAdapter();
       const correctionSpy = jest.spyOn(bridge, 'issueCorrection');
-      const record = await adapter.issueCorrection(
+      const { record } = await adapter.issueCorrection(
         correctionCommand({ lines: [{ originalLineNumber: 1, newQuantity: 5 }] }),
       );
       // origId path arg parsed from originalProviderInvoiceId; body carries only nowaIlosc.
@@ -364,7 +364,7 @@ describe('SubiektInvoicingAdapter', () => {
 
     it('echoes the command idempotencyKey onto the returned record', async () => {
       const { adapter } = makeAdapter();
-      const record = await adapter.issueCorrection(correctionCommand({ idempotencyKey: 'idem-kor' }));
+      const { record } = await adapter.issueCorrection(correctionCommand({ idempotencyKey: 'idem-kor' }));
       expect(record.idempotencyKey).toBe('idem-kor');
     });
 
@@ -398,9 +398,9 @@ describe('SubiektInvoicingAdapter', () => {
 
     it("defaults documentType to 'corrected' when the command omits it, honours an explicit one", async () => {
       const { adapter } = makeAdapter();
-      const def = await adapter.issueCorrection(correctionCommand());
+      const { record: def } = await adapter.issueCorrection(correctionCommand());
       expect(def.documentType).toBe('corrected');
-      const explicit = await adapter.issueCorrection(
+      const { record: explicit } = await adapter.issueCorrection(
         correctionCommand({ documentType: 'credit-note' }),
       );
       expect(explicit.documentType).toBe('credit-note');
@@ -408,7 +408,7 @@ describe('SubiektInvoicingAdapter', () => {
 
     it("defaults regulatoryStatus to 'submitted' (the korekta response carries none)", async () => {
       const { adapter } = makeAdapter();
-      const record = await adapter.issueCorrection(correctionCommand());
+      const { record } = await adapter.issueCorrection(correctionCommand());
       expect(record.regulatoryStatus).toBe('submitted');
       expect(record.pdfUrl).toBeNull();
     });

--- a/libs/integrations/subiekt/src/infrastructure/adapters/subiekt-invoicing.adapter.ts
+++ b/libs/integrations/subiekt/src/infrastructure/adapters/subiekt-invoicing.adapter.ts
@@ -243,7 +243,7 @@ export class SubiektInvoicingAdapter
    * A non-positive-integer `originalProviderInvoiceId` is a terminal, fiscal-safe
    * rejection (we cannot route the correction) — `SubiektInvoiceRejectedError`.
    */
-  async issueCorrection(cmd: IssueCorrectionCommand): Promise<InvoiceRecord> {
+  async issueCorrection(cmd: IssueCorrectionCommand): Promise<IssueInvoiceResult> {
     const origId = Number(cmd.originalProviderInvoiceId);
     if (!Number.isInteger(origId) || origId <= 0) {
       throw new SubiektInvoiceRejectedError(
@@ -277,30 +277,34 @@ export class SubiektInvoicingAdapter
       }
 
       const now = new Date();
-      return new InvoiceRecord(
-        // Transient id — the core InvoiceService persists and may overwrite it.
-        randomUUID(),
-        this.connectionId,
-        cmd.orderId,
-        SUBIEKT_PROVIDER_TYPE,
-        documentType,
-        'issued',
-        String(response.providerInvoiceId),
-        response.providerInvoiceNumber,
-        // The korekta response carries no regulatory status; default to the
-        // non-terminal 'submitted' so the #1230 reconcile refreshes it later.
-        'submitted',
-        // clearanceReference — populated by a later RegulatoryStatusReader read.
-        null,
-        idempotencyKey ?? null,
-        // The korekta response carries no pdfUrl.
-        null,
-        now,
-        // errorMessage
-        null,
-        now,
-        now,
-      );
+      return {
+        record: new InvoiceRecord(
+          // Transient id — the core InvoiceService persists and may overwrite it.
+          randomUUID(),
+          this.connectionId,
+          cmd.orderId,
+          SUBIEKT_PROVIDER_TYPE,
+          documentType,
+          'issued',
+          String(response.providerInvoiceId),
+          response.providerInvoiceNumber,
+          // The korekta response carries no regulatory status; default to the
+          // non-terminal 'submitted' so the #1230 reconcile refreshes it later.
+          'submitted',
+          // clearanceReference — populated by a later RegulatoryStatusReader read.
+          null,
+          idempotencyKey ?? null,
+          // The korekta response carries no pdfUrl.
+          null,
+          now,
+          // errorMessage
+          null,
+          now,
+          now,
+        ),
+        // The Subiekt bridge builds and submits the korekta document itself —
+        // no machine-readable document for OL to capture, same as issueInvoice.
+      };
     } catch (error: unknown) {
       throw this.translateBridgeError(error);
     }


### PR DESCRIPTION
## Summary

- KSeF was rejecting the second correction of the same order with "Duplikat faktury" — `KsefInvoicingAdapter.issueInvoice` always stamped the FA(3) `P_2` document number as `cmd.orderId`, reused verbatim for the original invoice and every correction of it. Fixed by giving corrections a distinct `P_2` (`{orderId}-KOR-{suffix}`), the suffix derived from `idempotencyKey` when present (stable across retries of the same correction attempt) or the issue timestamp otherwise. Confirmed live end-to-end: 3 consecutive corrections of the same order, each cleared as `accepted` by the real KSeF test environment with its own KSeF-assigned clearance number.
- Threaded the full `IssueInvoiceResult` (record + seller + `sourceDocument`) through `CorrectionIssuer.issueCorrection` across all 3 invoicing adapters (KSeF, inFakt, Subiekt) — `KsefInvoicingAdapter` was discarding the built FA(3) XML on the correction path, so a correction's "View"/"Preview" always failed with "No source document is available". `InvoiceService.issueCorrection` now persists `documentContent` (snapshotted from the corrected "after" lines) and `sourceDocument` for corrections, same as the original-issue path.
- Fixed the FA(3) preview panel (`KsefFa3View`): it parsed every `<FaWiersz>` unconditionally, so a KOR's `StanPrzed=1` "before" row and the current "after" row rendered as two unlabeled lines in one table, with totals that didn't reconcile against the VAT summary below. The main table now shows only the current state; "before" lines move into a separate collapsed "Lines before correction" disclosure.
- Housekeeping: dropped stale "C2 stub" / "C4 fills in issuance mechanics" doc-header language from the KSeF package barrel, adapter-factory, and adapter-factory-interface files — FA(3) issuance, clearance, and corrections have been fully wired for a while; only `qualified-seal` auth remains genuinely unimplemented, and its rejection message no longer references a stale phase label.

## Test plan

- [x] `@openlinker/core` — tests green (incl. 4 new regression tests for correction `sourceDocument`/`documentContent` persistence)
- [x] `@openlinker/integrations-ksef` — 351 tests green (incl. 2 new regression tests for distinct/stable P_2 numbering)
- [x] `@openlinker/integrations-infakt` — tests green
- [x] `@openlinker/integrations-subiekt` — tests green
- [x] `apps/web` — `ksef-fa3-view.test.tsx` 9 tests green (incl. new KOR before/after split regression test)
- [x] `tsc --noEmit` / `eslint` clean on all touched packages
- [x] Verified live against the demo stack + real KSeF test environment: issued a correction, manually reconciled, confirmed `regulatoryStatus: accepted` with a real KSeF clearance reference — repeated 3x on the same order, each with a distinct document number and no "Duplikat faktury"
- [x] Verified the FA(3) preview now shows one current-state line per corrected item with correct totals, plus a collapsed "before" section

Closes #1364
Closes #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)