### PR TITLE
fix(erli): stop the inbox poll starving on productsNeedSync events

### DIFF
--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts
@@ -250,6 +250,26 @@ describe('ErliOrderSourceAdapter', () => {
       expect(nextCursor).toBe('00000105');
     });
 
+    it('should advance the cursor past a productsNeedSync event that carries no payload.id at all (real wire shape, #1322 manual E2E)', async () => {
+      const warnSpy = jest
+        .spyOn((adapter as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn')
+        .mockImplementation(() => undefined);
+      client.get.mockResolvedValue(
+        ok([{ id: '00000200', shopId: 99990, created: 'x', read: false, type: 'productsNeedSync' }]),
+      );
+
+      const { items, nextCursor } = await adapter.listOrderFeed(
+        feedInput({ fromCursor: '00000100' }),
+      );
+
+      // No feed item (not an order event), but the cursor must still advance
+      // over it — it must not be dropped as "malformed" just for lacking an
+      // order id it was never going to carry.
+      expect(items).toEqual([]);
+      expect(nextCursor).toBe('00000200');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
     it('should skip a malformed inbox item (missing payload.id) and process the rest', async () => {
       const warnSpy = jest
         .spyOn((adapter as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn')

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-inbox.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-inbox.types.ts
@@ -14,6 +14,10 @@
  *  - Ack is `POST /inbox/mark-read` with `{ lastMessageId }` (mark-up-to-id) —
  *    NOT a per-message `PATCH /inbox/{id}`.
  *  - `type` vocabulary: `orderCreated`, `orderStatusChanged`, `productsNeedSync`.
+ *  - `productsNeedSync` carries NO `payload.id` on the real sandbox (confirmed
+ *    live #1322 manual E2E) — it is a generic "some products need syncing"
+ *    notification, not tied to one order. `payload.id` is only guaranteed
+ *    present on the two order-event types.
  *
  * `ErliInboxMessage` below is the adapter-internal NORMALISED shape (id + the
  * extracted order id + type + timestamp); `validateInboxMessage` maps the raw
@@ -40,11 +44,15 @@ export const ERLI_INBOX_PRODUCTS_NEED_SYNC = 'productsNeedSync';
  * `eventKey`/`eventId` AND the cursor; `orderId` is the Erli-native order id
  * extracted from `payload.id` (becomes `externalOrderId`); `occurredAt` is the
  * wire `created` timestamp.
+ *
+ * `orderId` is optional: it is required (and validated) for the two
+ * order-event types, but absent for non-order types like `productsNeedSync`,
+ * which the real wire never carries a `payload.id` for.
  */
 export interface ErliInboxMessage {
   id: string;
   type: ErliInboxEventType;
-  orderId: string;
+  orderId?: string;
   occurredAt?: string;
   read?: boolean;
 }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-order-source.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-order-source.adapter.ts
@@ -204,8 +204,14 @@ export class ErliOrderSourceAdapter implements OrderSourcePort, OrderStatusWrite
     // pushing real orders off the listing (PR1079-TECH-01).
     const newWave = valid.filter((msg) => fromCursor === null || msg.id > fromCursor);
 
-    // Only the order-event literals become feed items to enqueue.
-    const orderEvents = newWave.filter((msg) => ERLI_ORDER_EVENT_TYPES.has(msg.type));
+    // Only the order-event literals become feed items to enqueue. `orderId` is
+    // guaranteed defined here — `validateInboxMessage` requires `payload.id`
+    // for these two types — the narrowing filter documents that invariant for
+    // the type checker rather than asserting it away.
+    const orderEvents = newWave.filter(
+      (msg): msg is ErliInboxMessage & { orderId: string } =>
+        ERLI_ORDER_EVENT_TYPES.has(msg.type) && msg.orderId !== undefined,
+    );
 
     // Map to neutral feed items, then apply the optional `eventTypes` filter
     // BEFORE dedupe (PR1086 review). Filtering after dedupe can silently drop an
@@ -521,9 +527,18 @@ export class ErliOrderSourceAdapter implements OrderSourcePort, OrderStatusWrite
    * Validate + normalise one raw inbox item. The wire item is
    * `{ id, shopId, created, read, type, payload }` (#992); the order id lives in
    * `payload.id` and the timestamp in `created`. Returns the normalised message
-   * when it carries a string `id`, a non-empty `type`, and a `payload.id`;
-   * otherwise drops it with a warn (id only when available) and returns `null`.
-   * Unknown event types are NOT skipped here (they're filtered later).
+   * when it carries a string `id` and a non-empty `type`; otherwise drops it
+   * with a warn (id only when available) and returns `null`.
+   *
+   * `payload.id` is required ONLY for the two order-event types
+   * (`orderCreated`/`orderStatusChanged`) — those need an order id to become a
+   * feed item. Non-order types (`productsNeedSync` and any future/unknown
+   * type) pass through with `orderId: undefined`: the real wire never carries
+   * a `payload.id` for `productsNeedSync`, and requiring one dropped the
+   * message from `valid` entirely, which stalled `nextCursor` on it forever —
+   * every poll re-fetched and re-warned on the same stuck message (confirmed
+   * live during #1322 manual E2E; see the "no starvation" cursor-advance logic
+   * in `listOrderFeed`, which depends on non-order messages surviving here).
    */
   private validateInboxMessage(candidate: unknown): ErliInboxMessage | null {
     if (typeof candidate !== 'object' || candidate === null) {
@@ -551,7 +566,7 @@ export class ErliOrderSourceAdapter implements OrderSourcePort, OrderStatusWrite
         ? (c.payload as Record<string, unknown>)
         : undefined;
     const orderId = payload && typeof payload.id === 'string' ? payload.id : undefined;
-    if (!orderId) {
+    if (!orderId && ERLI_ORDER_EVENT_TYPES.has(c.type)) {
       this.logger.warn(
         `Skipping malformed Erli inbox message ${id}: missing payload.id (connection: ${this.connectionId})`,
       );


### PR DESCRIPTION
## Summary

- `ErliOrderSourceAdapter.validateInboxMessage` required every inbox item to carry `payload.id` regardless of event type, dropping any item lacking one before it reached the cursor-advance logic in `listOrderFeed`. The real Erli sandbox's `productsNeedSync` event never carries a `payload.id` — confirmed live during manual E2E testing of #1322: the worker re-warned on the same stuck inbox message on every 5-minute `marketplace.orders.poll` cycle for hours, and the cursor never advanced past it.
- `payload.id` is now required only for the two order-event types (`orderCreated`/`orderStatusChanged`); any other type (including `productsNeedSync`) survives validation with `orderId` left `undefined`, restoring `listOrderFeed`'s own documented "no starvation" cursor-advance design.

## Test plan

- [x] `@openlinker/integrations-erli` — 348 tests green (1 new regression test: a `productsNeedSync` event with no `payload` field advances the cursor and logs no warning)
- [x] `tsc --noEmit` / `eslint` clean
- [x] Verified live against the demo stack: rebuilt + redeployed the worker, watched the next poll cycle — cursor advanced past the previously-stuck message id with zero warnings

Closes #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)