### PR TITLE
fix(sync): gate platformType-scoped order-poll scheduler tasks by capability

### DIFF
--- a/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
+++ b/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
@@ -287,6 +287,48 @@ describe('SchedulerService', () => {
       expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
     });
 
+    it('should skip a platformType-scoped connection missing requiredCapability (#1452 no-starvation follow-up)', async () => {
+      const withCapability = createConnection('conn-with', 'woocommerce');
+      const withoutCapability = new Connection(
+        'conn-without',
+        'woocommerce',
+        'Test conn-without',
+        'active',
+        {},
+        'cred-ref',
+        new Date(),
+        new Date(),
+        undefined,
+        ['ProductPublisher', 'CategoryProvisioner']
+      );
+      connectionPort.list.mockResolvedValue([withCapability, withoutCapability]);
+      const task = makeTask('woocommerce-orders-poll', {
+        platformType: 'woocommerce',
+        requiredCapability: 'OrderSource',
+      });
+
+      await (
+        service as unknown as { executeTask: (t: SchedulerTaskConfig) => Promise<void> }
+      ).executeTask(task);
+
+      expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(1);
+      expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
+        expect.objectContaining({ connectionId: 'conn-with' })
+      );
+    });
+
+    it('should enqueue for every connection when requiredCapability is absent (backward-compatible default)', async () => {
+      const conn = createConnection('conn-1', 'allegro');
+      connectionPort.list.mockResolvedValue([conn]);
+      const task = makeTask('allegro-orders-poll');
+
+      await (
+        service as unknown as { executeTask: (t: SchedulerTaskConfig) => Promise<void> }
+      ).executeTask(task);
+
+      expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(1);
+    });
+
     it('should not throw when connectionPort.list resolves to undefined', async () => {
       connectionPort.list.mockResolvedValue(undefined as unknown as Connection[]);
       const task: SchedulerTaskConfig = {

--- a/apps/api/src/sync/application/services/scheduler.service.ts
+++ b/apps/api/src/sync/application/services/scheduler.service.ts
@@ -247,6 +247,11 @@ export class SchedulerService implements OnApplicationBootstrap, OnModuleDestroy
           );
         }
         connections = result ?? [];
+        if (task.requiredCapability) {
+          connections = connections.filter((connection) =>
+            connection.enabledCapabilities.includes(task.requiredCapability as string)
+          );
+        }
       } else {
         this.logger.error(
           `Scheduler task ${task.taskId} has neither platformType nor connectionFilter — skipping`

--- a/libs/core/src/sync/domain/types/scheduler-task.types.ts
+++ b/libs/core/src/sync/domain/types/scheduler-task.types.ts
@@ -75,6 +75,23 @@ export interface SchedulerTaskConfig {
   connectionFilter?: () => Promise<Connection[]>;
 
   /**
+   * Optional capability gate applied ON TOP of `platformType`-based lookup
+   * (ignored when `connectionFilter` is set — that callback owns its own
+   * filtering). When present, a connection is only enqueued if
+   * `connection.enabledCapabilities` includes this value.
+   *
+   * Without this, a `platformType`-scoped task (e.g. a per-platform
+   * orders-poll) enqueues for every active connection of that platform
+   * regardless of whether the connection actually has the relevant
+   * capability enabled — a connection with `OrderSource` deliberately
+   * disabled (e.g. a WooCommerce connection used only for product
+   * publishing) still got polled every tick, failed every time with
+   * `CapabilityNotEnabledException`, and spammed ERROR logs forever
+   * (confirmed live during manual E2E testing of #1322).
+   */
+  requiredCapability?: string;
+
+  /**
    * Generate the job payload for a specific connection. Invoked once per
    * tick per active connection.
    */

--- a/libs/integrations/allegro/src/infrastructure/scheduler/allegro-scheduler-tasks.ts
+++ b/libs/integrations/allegro/src/infrastructure/scheduler/allegro-scheduler-tasks.ts
@@ -66,6 +66,7 @@ export function buildAllegroSchedulerTasks(configService: ConfigService): Schedu
     tasks.push({
       taskId: 'allegro-orders-poll',
       platformType: 'allegro',
+      requiredCapability: 'OrderSource',
       jobType: 'marketplace.orders.poll',
       cronExpression,
       enabledEnvVar: 'OL_ALLEGRO_POLL_SCHEDULER_ENABLED',

--- a/libs/integrations/erli/src/infrastructure/scheduler/erli-scheduler-tasks.ts
+++ b/libs/integrations/erli/src/infrastructure/scheduler/erli-scheduler-tasks.ts
@@ -90,6 +90,7 @@ export function buildErliSchedulerTasks(): SchedulerTaskConfig[] {
   tasks.push({
     taskId: 'erli-orders-poll',
     platformType: 'erli',
+    requiredCapability: 'OrderSource',
     jobType: 'marketplace.orders.poll',
     cronExpression: ERLI_ORDERS_POLL_CRON,
     enabledEnvVar: 'OL_ERLI_ORDERS_POLL_SCHEDULER_ENABLED',

--- a/libs/integrations/prestashop/src/infrastructure/scheduler/prestashop-scheduler-tasks.ts
+++ b/libs/integrations/prestashop/src/infrastructure/scheduler/prestashop-scheduler-tasks.ts
@@ -67,6 +67,7 @@ export function buildPrestashopSchedulerTasks(
     tasks.push({
       taskId: 'prestashop-orders-poll',
       platformType: 'prestashop',
+      requiredCapability: 'OrderSource',
       jobType: 'marketplace.orders.poll',
       cronExpression,
       enabledEnvVar: 'OL_PRESTASHOP_POLL_SCHEDULER_ENABLED',

--- a/libs/integrations/woocommerce/src/infrastructure/scheduler/woocommerce-scheduler-tasks.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/scheduler/woocommerce-scheduler-tasks.ts
@@ -15,6 +15,7 @@ export function buildWooCommerceSchedulerTasks(): SchedulerTaskConfig[] {
     {
       taskId: 'woocommerce-orders-poll',
       platformType: 'woocommerce',
+      requiredCapability: 'OrderSource',
       jobType: 'marketplace.orders.poll',
       cronExpression: '*/5 * * * *',
       enabledEnvVar: 'OL_WOOCOMMERCE_POLL_SCHEDULER_ENABLED',


### PR DESCRIPTION
## Summary

- Every `platformType`-scoped scheduler task enqueued a job for every active connection of that platform, with no check of whether the connection actually has the job's relevant capability enabled. Confirmed live: the demo's WooCommerce connection has `OrderSource` deliberately disabled (publishing-only), yet `woocommerce-orders-poll` kept enqueueing `marketplace.orders.poll` for it every 5-minute cycle — each job failed with `CapabilityNotEnabledException`, retried up to 10 attempts, and a new job was enqueued again within seconds, spamming ERROR logs continuously.
- Added an optional `requiredCapability` field to `SchedulerTaskConfig`, applied on top of `platformType`-based lookup (backward compatible — absent means no filtering, unchanged behavior for every other task). Set to `'OrderSource'` on all four `*-orders-poll` tasks (WooCommerce, Allegro, Erli, PrestaShop), which each map 1:1 to that capability.

## Test plan

- [x] `@openlinker/core` — 1456 tests green
- [x] `@openlinker/api` — 695 tests green (2 new regression tests: connection missing the capability is skipped; sibling connection with it enqueues; existing no-`requiredCapability` behavior unchanged)
- [x] `@openlinker/integrations-woocommerce`, `-allegro`, `-erli`, `-prestashop` — all green
- [x] `tsc`/`eslint` clean
- [x] Verified live against the demo stack: rebuilt + redeployed `api`, watched the next tick — `woocommerce-orders-poll` now logs `No active woocommerce connections found for task woocommerce-orders-poll, skipping`, while Allegro/Erli/PrestaShop (which do have `OrderSource` enabled) still enqueue normally

Closes #1454

🤖 Generated with [Claude Code](https://claude.com/claude-code)