### PR TITLE
feat(web,erli): add dedicated Callback URL field to Erli's edit-connection form

### DIFF
--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -47,6 +47,7 @@ const HOST_STRUCTURED_FIELDS = [
   'shopId',
   'storefrontBaseUrl',
   'openlinkerCallbackBaseUrl',
+  'callbackBaseUrl',
   'masterCatalogConnectionId',
   'defaultCarrierId',
   'unmanagedStockQuantity',
@@ -309,6 +310,12 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
       // (e.g. http://host.docker.internal:3000) by editing the field.
       openlinkerCallbackBaseUrl:
         readConfigString(connection.config, 'openlinkerCallbackBaseUrl') ||
+        plugin?.getCallbackUrlDefault?.() ||
+        '',
+      // Erli's own callback-URL config key (#1454 follow-up) — same
+      // pre-fill convenience as PrestaShop's `openlinkerCallbackBaseUrl`.
+      callbackBaseUrl:
+        readConfigString(connection.config, 'callbackBaseUrl') ||
         plugin?.getCallbackUrlDefault?.() ||
         '',
       masterCatalogConnectionId: readConfigString(connection.config, 'masterCatalogConnectionId'),

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -160,6 +160,23 @@ export const editConnectionSchema = z
         z.literal(''),
       ])
       .optional(),
+    // Erli-only structured field surfacing `config.callbackBaseUrl` — the
+    // key `ErliWebhookProvisioningAdapter` reads (distinct from PrestaShop's
+    // `openlinkerCallbackBaseUrl`; the two integrations chose different wire
+    // key names before this field existed on the FE, so both are kept
+    // verbatim rather than unified). FE pre-fills from `window.location.origin`
+    // via `getCallbackUrlDefault`, same convenience as PrestaShop's field.
+    callbackBaseUrl: z
+      .union([
+        z
+          .url('Callback URL must be a valid URL')
+          .refine(
+            (value) => value.startsWith('http://') || value.startsWith('https://'),
+            'Callback URL must use http:// or https://',
+          ),
+        z.literal(''),
+      ])
+      .optional(),
     masterCatalogConnectionId: z
       .union([z.string().uuid('Product catalog must be a valid connection ID'), z.literal('')])
       .optional(),
@@ -312,6 +329,8 @@ export type StructuredConfigPatch = {
   shopId?: string;
   storefrontBaseUrl?: string;
   openlinkerCallbackBaseUrl?: string;
+  /** Erli webhook callback URL — `config.callbackBaseUrl` (#1454 follow-up). */
+  callbackBaseUrl?: string;
   masterCatalogConnectionId?: string;
   /**
    * PrestaShop fallback carrier id (#517). Empty string clears the key;
@@ -461,6 +480,13 @@ export function mergeStructuredIntoConfig(
       delete next.openlinkerCallbackBaseUrl;
     } else {
       next.openlinkerCallbackBaseUrl = structured.openlinkerCallbackBaseUrl;
+    }
+  }
+  if (structured.callbackBaseUrl !== undefined) {
+    if (structured.callbackBaseUrl.length === 0) {
+      delete next.callbackBaseUrl;
+    } else {
+      next.callbackBaseUrl = structured.callbackBaseUrl;
     }
   }
   // Unlike baseUrl/shopId, masterCatalogConnectionId uses `""` as an explicit

--- a/apps/web/src/plugins/erli/components/erli-connection-actions.tsx
+++ b/apps/web/src/plugins/erli/components/erli-connection-actions.tsx
@@ -5,7 +5,9 @@
  * Erli connections. Exposes the "Configure webhooks" action (#1216) — guards
  * against a missing `config.callbackBaseUrl` (required by the backend before
  * it can register Erli webhook subscriptions) with an instructional message
- * instead of surfacing a raw 400.
+ * instead of surfacing a raw 400. The hint now points at the dedicated
+ * "Callback URL" field (`ErliStructuredSection`, #1454 follow-up) rather than
+ * the raw-JSON config block.
  *
  * @module plugins/erli/components
  */
@@ -78,9 +80,9 @@ export function ErliConnectionActions({
           </p>
         ) : (
           <p className="muted-text">
-            Set <code>callbackBaseUrl</code> on this connection before configuring webhooks. Open{' '}
-            <strong>Edit connection</strong>, add <code>callbackBaseUrl</code> (the public
-            OpenLinker URL Erli posts webhooks to), then return here.
+            Set the <strong>Callback URL</strong> field on this connection before configuring
+            webhooks. Open <strong>Edit connection</strong>, fill in the Callback URL (the public
+            OpenLinker URL Erli posts webhooks to), save, then return here.
           </p>
         )}
       </div>

--- a/apps/web/src/plugins/erli/components/erli-structured-section.test.tsx
+++ b/apps/web/src/plugins/erli/components/erli-structured-section.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * ErliStructuredSection Tests
+ *
+ * Coverage for the Callback URL editor field shown in EditConnectionForm
+ * for Erli connections (#1454 follow-up). The bound config key is
+ * `callbackBaseUrl` — the key `ErliWebhookProvisioningAdapter` expects.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any -- test component mocking requires flexible types */
+import type { ReactElement } from 'react';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../test/test-utils';
+import { ErliStructuredSection } from './erli-structured-section';
+
+describe('ErliStructuredSection', () => {
+  afterEach(cleanup);
+
+  it('renders the callbackBaseUrl field for editing', () => {
+    const TestComponent = (): ReactElement => {
+      const form = useForm<any>({
+        defaultValues: { callbackBaseUrl: 'https://api.example.com' },
+      });
+      return (
+        <ErliStructuredSection
+          connection={{ id: '1' } as any}
+          form={form as any}
+          configIsParseable={true}
+          syncStructuredToJson={vi.fn()}
+        />
+      );
+    };
+    renderWithProviders(<TestComponent />);
+    expect(screen.getByDisplayValue('https://api.example.com')).toBeInTheDocument();
+  });
+
+  it('calls syncStructuredToJson with the callbackBaseUrl config key when the value changes', () => {
+    const syncStructuredToJson = vi.fn();
+    const TestComponent = (): ReactElement => {
+      const form = useForm<any>({
+        defaultValues: { callbackBaseUrl: 'https://api.example.com' },
+      });
+      return (
+        <ErliStructuredSection
+          connection={{ id: '1' } as any}
+          form={form as any}
+          configIsParseable={true}
+          syncStructuredToJson={syncStructuredToJson}
+        />
+      );
+    };
+    renderWithProviders(<TestComponent />);
+
+    const input = screen.getByDisplayValue('https://api.example.com');
+    fireEvent.change(input, { target: { value: 'https://newapi.example.com' } });
+
+    expect(syncStructuredToJson).toHaveBeenCalledWith(
+      'callbackBaseUrl',
+      'https://newapi.example.com'
+    );
+  });
+
+  it('disables input when configIsParseable is false', () => {
+    const TestComponent = (): ReactElement => {
+      const form = useForm<any>({
+        defaultValues: { callbackBaseUrl: 'https://api.example.com' },
+      });
+      return (
+        <ErliStructuredSection
+          connection={{ id: '1' } as any}
+          form={form as any}
+          configIsParseable={false}
+          syncStructuredToJson={vi.fn()}
+        />
+      );
+    };
+    renderWithProviders(<TestComponent />);
+
+    const input = screen.getByDisplayValue('https://api.example.com');
+    expect(input).toBeDisabled();
+  });
+
+  it('shows form error message when callbackBaseUrl has a validation error', () => {
+    const TestComponent = (): ReactElement => {
+      const form = useForm<any>({
+        defaultValues: { callbackBaseUrl: '' },
+      });
+      form.formState.errors.callbackBaseUrl = {
+        message: 'Callback URL must use http:// or https://',
+        type: 'manual',
+      };
+      return (
+        <ErliStructuredSection
+          connection={{ id: '1' } as any}
+          form={form as any}
+          configIsParseable={true}
+          syncStructuredToJson={vi.fn()}
+        />
+      );
+    };
+    renderWithProviders(<TestComponent />);
+
+    expect(screen.getByText('Callback URL must use http:// or https://')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/plugins/erli/components/erli-structured-section.tsx
+++ b/apps/web/src/plugins/erli/components/erli-structured-section.tsx
@@ -1,0 +1,42 @@
+/**
+ * Erli Structured Section
+ *
+ * Plugin-owned structured-config input rendered inside `EditConnectionForm`
+ * when the connection's `platformType` is `'erli'`. Carries:
+ *
+ *   - Callback URL — `config.callbackBaseUrl`, the public OL URL Erli posts
+ *     webhook events to (read by `ErliWebhookProvisioningAdapter`). Before
+ *     this section existed, the field could only be set via the raw-JSON
+ *     config block, which the "Configure webhooks" action's own hint text
+ *     pointed operators at without a dedicated place to enter it (#1454
+ *     follow-up UX gap, confirmed live during manual E2E testing of #1322).
+ *
+ * @module plugins/erli/components
+ */
+import type { ReactElement } from 'react';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import type { StructuredConfigSectionProps } from '../../../shared/plugins';
+
+export function ErliStructuredSection({
+  form,
+  configIsParseable,
+  syncStructuredToJson,
+}: StructuredConfigSectionProps): ReactElement {
+  return (
+    <FormField
+      label="Callback URL"
+      name="callbackBaseUrl"
+      error={form.formState.errors.callbackBaseUrl?.message}
+      description="The public OpenLinker URL Erli posts webhook events to (e.g. https://api.example.com)."
+    >
+      <Input
+        value={form.watch('callbackBaseUrl') ?? ''}
+        onChange={(event) => syncStructuredToJson('callbackBaseUrl', event.target.value)}
+        placeholder="https://api.example.com"
+        disabled={!configIsParseable}
+        invalid={Boolean(form.formState.errors.callbackBaseUrl)}
+      />
+    </FormField>
+  );
+}

--- a/apps/web/src/plugins/erli/erli.test.ts
+++ b/apps/web/src/plugins/erli/erli.test.ts
@@ -49,8 +49,11 @@ describe('erliPlugin', () => {
     it('contributes a credentials panel', () => {
       expect(erliPlugin.platform?.CredentialsPanel).toBeDefined();
     });
-    it('does NOT contribute a structured-config edit slot', () => {
-      expect(erliPlugin.platform?.StructuredConfigSection).toBeUndefined();
+    it('contributes a structured-config edit slot for the callback URL (#1454 follow-up)', () => {
+      expect(erliPlugin.platform?.StructuredConfigSection).toBeDefined();
+    });
+    it('contributes a getCallbackUrlDefault matching the PrestaShop precedent', () => {
+      expect(erliPlugin.platform?.getCallbackUrlDefault).toBeInstanceOf(Function);
     });
     it('contributes a ConnectionActions component for webhook install (#1216)', () => {
       expect(erliPlugin.platform?.ConnectionActions).toBeDefined();

--- a/apps/web/src/plugins/erli/index.ts
+++ b/apps/web/src/plugins/erli/index.ts
@@ -7,10 +7,12 @@
  * bearer token by the BE adapter, #981), so the only credential the operator
  * supplies is `apiKey`; `baseUrl` is an optional advanced config override.
  *
- * Structured config *editing* is intentionally not contributed — the only
- * config field is the optional `baseUrl`, set at create time via the guided
- * wizard; the edit form falls back to the generic raw-JSON config block for
- * the rare post-create change.
+ * Structured config editing contributes exactly one field: `callbackBaseUrl`
+ * (#1454 follow-up) — the public OL URL Erli posts webhook events to, needed
+ * before "Configure webhooks" can do anything. Every other config field
+ * (`baseUrl`, `masterCatalogConnectionId`, `allegroCategoryAccessEnabled`) is
+ * either set at create time via the guided wizard or rare enough that the
+ * generic raw-JSON config block remains the right place to edit it.
  *
  * @module plugins/erli
  */
@@ -21,6 +23,7 @@ import type { OpenLinkerPlugin } from '../../shared/plugins';
 import { definePlugin } from '../define-plugin';
 import { ErliConnectionActions } from './components/erli-connection-actions';
 import { ErliCredentialsPanel } from './components/erli-credentials-panel';
+import { ErliStructuredSection } from './components/erli-structured-section';
 import { erliSetupRoute } from './erli-setup.route';
 
 // Lazy-loaded so adding marketplaces doesn't bloat the main bundle (#1096).
@@ -57,6 +60,9 @@ export const erliPlugin: OpenLinkerPlugin = definePlugin({
       to: '/connections/new/erli',
       badge: 'API key',
     },
+    getCallbackUrlDefault: () =>
+      typeof window !== 'undefined' ? window.location.origin : undefined,
+    StructuredConfigSection: ErliStructuredSection,
     CredentialsPanel: ErliCredentialsPanel,
     ConnectionActions: ErliConnectionActions,
     // Bulk offer creation (#1096): dispatch time, no policies, PLN-only.


### PR DESCRIPTION
## Summary

- Erli's "Configure webhooks" action was gated on `config.callbackBaseUrl` being set, with a hint pointing operators at Edit connection to add it — but there was no dedicated field, only the raw-JSON config textarea. Confirmed live during manual E2E testing of #1322: no way to discover where to actually set it.
- Added `callbackBaseUrl` to the host's structured-field set (`EditConnectionForm.tsx`, `edit-connection.schema.ts`), mirroring the existing `openlinkerCallbackBaseUrl` (PrestaShop) pattern — same validation shape, same `window.location.origin` pre-fill convenience via `getCallbackUrlDefault`.
- New minimal `ErliStructuredSection` component (one labeled "Callback URL" input), wired into the Erli plugin descriptor. Updated the connection-actions hint text to point at the new field.

## Test plan

- [x] `@openlinker/web` — all touched suites green (`erli.test.ts`, new `erli-structured-section.test.tsx`, `EditConnectionForm.test.tsx`)
- [x] `tsc`/`eslint` clean
- [x] Verified live against the demo stack: rebuilt + redeployed `web`, the "Callback URL" field appeared on the Erli connection edit form, saved a real tunnel URL, and "Configure webhooks" succeeded — confirmed by the operator via a "registered and verified by a test ping" toast

Closes #1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)