### PR TITLE
fix(allegro): detect order cancellation in getOrder (status + fulfillment.status)

### DIFF
--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -21,6 +21,26 @@
  */
 export interface AllegroCheckoutForm {
   id: string;
+  /**
+   * Checkout-form transaction status. `CANCELLED` means the transaction
+   * itself was voided (payment timeout, buyer-initiated cancellation before
+   * a sale completes, etc). Other known values: `BOUGHT`, `FILLED_IN`,
+   * `READY_FOR_PROCESSING`. Optional because older fixtures/mocks predate
+   * this field; absence is treated as not-cancelled.
+   */
+  status?: string;
+  /**
+   * The SELLER's own delivery/fulfillment status — what the "Status
+   * zamówienia" dropdown in Allegro's seller panel sets (`NOWE`,
+   * `W_REALIZACJI`, `WSTRZYMANE`, `DO_WYSLANIA`, `DO_ODBIORU`, `WYSLANE`,
+   * `ODEBRANE`, `ANULOWANE`/`CANCELLED`). `AllegroOrderSourceAdapter.write()`
+   * also SETS this same field when relaying an externally-authored (e.g.
+   * PrestaShop-side) cancellation INTO Allegro — reading it back out here to
+   * detect a seller-initiated cancellation is safe despite that, because the
+   * order-ingestion transition-gate (`priorStatus !== 'cancelled'`) already
+   * suppresses a re-fire once OL's own record is cancelled.
+   */
+  fulfillment?: { status?: string };
   messageToSeller?: string;
   buyer: {
     id: string;

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -357,6 +357,61 @@ describe('AllegroOrderSourceAdapter', () => {
       expect(incoming.paymentStatus).toBe('cod');
     });
 
+    it('should report cancelled status when the checkout-form transaction was voided on Allegro (#1322 manual E2E)', async () => {
+      // Even though payment.finishedAt is set (the order WAS paid before the
+      // buyer/seller cancelled it), status must be 'cancelled', not
+      // 'processing' — this is exactly the live bug: a cancelled-but-paid
+      // order silently kept reporting 'processing' forever.
+      const checkoutForm: AllegroCheckoutForm = {
+        id: 'checkout-3',
+        status: 'CANCELLED',
+        updatedAt: '2024-01-03T00:00:00Z',
+        buyer: { id: 'b3', email: 'b3@example.com', login: 'b3' },
+        lineItems: [
+          {
+            id: 'l1',
+            offer: { id: 'o1', name: 'O1' },
+            quantity: 1,
+            price: { amount: '10.00', currency: 'PLN' },
+          },
+        ],
+        summary: { totalToPay: { amount: '10.00', currency: 'PLN' } },
+        payment: { type: 'ONLINE', finishedAt: '2024-01-03T00:00:00Z' },
+      };
+      httpClient.get.mockResolvedValueOnce({ data: checkoutForm, status: 200, headers: {} });
+
+      const incoming = await adapter.getOrder({ externalOrderId: 'checkout-3' });
+
+      expect(incoming.status).toBe('cancelled');
+    });
+
+    it('should report cancelled status when the seller cancelled via the panel dropdown (fulfillment.status, #1322 manual E2E)', async () => {
+      // The real live bug the manual test hit: the seller used the "Status
+      // zamówienia" dropdown's ANULOWANE option, which sets
+      // fulfillment.status — NOT the transaction-level `status` field.
+      const checkoutForm: AllegroCheckoutForm = {
+        id: 'checkout-4',
+        fulfillment: { status: 'CANCELLED' },
+        updatedAt: '2024-01-04T00:00:00Z',
+        buyer: { id: 'b4', email: 'b4@example.com', login: 'b4' },
+        lineItems: [
+          {
+            id: 'l1',
+            offer: { id: 'o1', name: 'O1' },
+            quantity: 1,
+            price: { amount: '10.00', currency: 'PLN' },
+          },
+        ],
+        summary: { totalToPay: { amount: '10.00', currency: 'PLN' } },
+        payment: { type: 'ONLINE', finishedAt: '2024-01-04T00:00:00Z' },
+      };
+      httpClient.get.mockResolvedValueOnce({ data: checkoutForm, status: 200, headers: {} });
+
+      const incoming = await adapter.getOrder({ externalOrderId: 'checkout-4' });
+
+      expect(incoming.status).toBe('cancelled');
+    });
+
     describe('dispatch time / ship-by (#927)', () => {
       const formWithDelivery = (
         delivery: NonNullable<AllegroCheckoutForm['delivery']>

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -286,7 +286,25 @@ export class AllegroOrderSourceAdapter
 
       const checkoutForm = response.data;
 
-      const status = checkoutForm.payment.finishedAt ? 'processing' : 'pending';
+      // #1160 follow-up: a checkout-form cancelled on Allegro's side — either
+      // the transaction itself voided (`status === 'CANCELLED'`) or the
+      // seller manually cancelling via the panel's "Status zamówienia"
+      // dropdown (`fulfillment.status === 'CANCELLED'`, the ANULOWANE option)
+      // — must surface as 'cancelled' here, or a resync that re-hydrates the
+      // full order (as opposed to reacting to a `/order/events` CANCEL-type
+      // feed entry) silently keeps reporting 'processing' forever, breaking
+      // both the PrestaShop OrderStatusWriteback relay and the marketplace
+      // stock-restore hook, which both key off `incoming.status ===
+      // 'cancelled'`. Confirmed live during manual E2E testing of #1322: a
+      // real Allegro sandbox order cancelled via the seller-panel dropdown
+      // stayed 'processing' in OL after a poll re-synced it.
+      const isCancelled =
+        checkoutForm.status === 'CANCELLED' || checkoutForm.fulfillment?.status === 'CANCELLED';
+      const status = isCancelled
+        ? 'cancelled'
+        : checkoutForm.payment.finishedAt
+          ? 'processing'
+          : 'pending';
       // Allegro's checkout-form carries no order-level created timestamp, so
       // `createdAt` is OpenLinker's ingestion time. The buyer-placed time lives
       // on `lineItems[].boughtAt` and is surfaced separately as `placedAt` (#926).


### PR DESCRIPTION
## Summary

- `AllegroOrderSourceAdapter.getOrder` derived the neutral order status purely from `payment.finishedAt`, ignoring both the checkout-form's own `status` field and the seller-set `fulfillment.status` field (what the seller-panel "Status zamówienia" dropdown writes — the `ANULOWANE` option). Confirmed live: a real Allegro sandbox order cancelled via that dropdown never surfaced as cancelled in OL, silently breaking the `OrderStatusWriteback` relay (PrestaShop never learned about the cancellation) and the `marketplace.offer.stockRestore` hook — both key off `incoming.status === 'cancelled'`.
- `getOrder` now also checks `status === 'CANCELLED'` and `fulfillment.status === 'CANCELLED'` before falling back to the existing `payment.finishedAt`-based processing/pending derivation. Reading `fulfillment.status` back is safe despite the adapter's own `write()` also setting it when relaying an externally-authored cancellation INTO Allegro — `OrderIngestionService`'s transition-gate already suppresses a re-fire once OL's record is cancelled.

## Test plan

- [x] `@openlinker/integrations-allegro` — 522 tests green (2 new regression tests: transaction-level `status` field, seller-panel `fulfillment.status` field)
- [x] `tsc`/`eslint` clean
- [x] Verified live against the demo stack and the real Allegro sandbox: cancelled a real order via the seller-panel dropdown, manually triggered a per-order resync (a seller-only status change doesn't emit a new `/order/events` entry, so the routine poll never re-touches an already-ingested order), confirmed `order_records` flipped to `cancelled`, the PrestaShop `OrderStatusWriteback` relay fired (`PrestashopOrderProcessorManagerAdapter` synced the order with `status=cancelled`), and the OL order-detail page showed `cancelled` — operator-confirmed

Closes #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)