### PR TITLE
fix(erli,web): reject inactive Allegro credential-reuse source, gate query on rotate panel

### DIFF
--- a/apps/api/src/integrations/application/services/connection.service.spec.ts
+++ b/apps/api/src/integrations/application/services/connection.service.spec.ts
@@ -288,6 +288,51 @@ describe('ConnectionService', () => {
       );
     });
 
+    it('should run the registered rewriter on the create path before persisting credentials (#1405 review)', async () => {
+      connectionPort.create.mockResolvedValue(mockConnection);
+      const stubRewriter: jest.Mocked<ConnectionCredentialsRewriterPort> = {
+        rewrite: jest
+          .fn()
+          .mockResolvedValue({ webserviceApiKey: 'REWRITTEN', extraField: 'added-by-rewriter' }),
+      };
+      credentialsRewriterRegistry.register('prestashop.webservice.v1', stubRewriter);
+
+      await service.create({
+        name: 'Wizard Connection',
+        platformType: 'prestashop',
+        config: { baseUrl: 'https://new.com' },
+        credentials: { webserviceApiKey: 'RAW' },
+      });
+
+      expect(stubRewriter.rewrite).toHaveBeenCalledWith({ webserviceApiKey: 'RAW' });
+      expect(credentials.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credentialsJson: { webserviceApiKey: 'REWRITTEN', extraField: 'added-by-rewriter' },
+        })
+      );
+    });
+
+    it('should map a ConnectionCredentialsRewriteException from the rewriter to BadRequestException on create (#1405 review)', async () => {
+      const stubRewriter: jest.Mocked<ConnectionCredentialsRewriterPort> = {
+        rewrite: jest
+          .fn()
+          .mockRejectedValue(
+            new ConnectionCredentialsRewriteException('Stub', 'source connection is invalid')
+          ),
+      };
+      credentialsRewriterRegistry.register('prestashop.webservice.v1', stubRewriter);
+
+      await expect(
+        service.create({
+          name: 'Wizard Connection',
+          platformType: 'prestashop',
+          config: { baseUrl: 'https://new.com' },
+          credentials: { webserviceApiKey: 'RAW' },
+        })
+      ).rejects.toThrow(BadRequestException);
+      expect(credentials.create).not.toHaveBeenCalled();
+    });
+
     it('should reject PrestaShop credentials missing webserviceApiKey', async () => {
       await expect(
         service.create({

--- a/apps/api/src/integrations/application/services/connection.service.ts
+++ b/apps/api/src/integrations/application/services/connection.service.ts
@@ -248,12 +248,13 @@ export class ConnectionService implements IConnectionService {
       let resolvedCredentialsRef = credentialsRef;
       let createdCredentialRef: string | null = null;
       if (credentials) {
-        await this.validateCredentialsShape(metadata.adapterKey, credentials);
+        const resolvedCredentials = await this.rewriteCredentials(metadata.adapterKey, credentials);
+        await this.validateCredentialsShape(metadata.adapterKey, resolvedCredentials);
         const ref = randomUUID();
         await this.credentials.create({
           ref,
           platformType: rest.platformType,
-          credentialsJson: credentials,
+          credentialsJson: resolvedCredentials,
         });
         createdCredentialRef = ref;
         resolvedCredentialsRef = `db:${ref}`;

--- a/apps/web/src/features/connections/hooks/use-connections-query.ts
+++ b/apps/web/src/features/connections/hooks/use-connections-query.ts
@@ -5,7 +5,7 @@ import { useApiClient } from '../../../app/api/api-client-provider';
 
 export function useConnectionsQuery(
   filters?: ConnectionFilters,
-  options?: { refetchInterval?: number | false },
+  options?: { refetchInterval?: number | false; enabled?: boolean },
 ): UseQueryResult<Connection[]> {
   const apiClient = useApiClient();
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8544,6 +8544,29 @@ html[data-density='compact'] .status-badge {
   margin-top: var(--space-2);
 }
 
+/* Erli credentials panel (#1387 review) — checkbox/radio option rows,
+   hint text, and the reuse-picker indent, extracted from inline styles. */
+.erli-credentials-panel__option-label {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
+.erli-credentials-panel__hint {
+  display: block;
+  color: var(--text-muted);
+}
+
+.erli-credentials-panel__indent {
+  margin-left: calc(0.875rem + var(--space-2));
+}
+
+.erli-credentials-panel__input-row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
 /* Marketplace picker modal (#1096) — shown from Products with 2+ OfferManager connections. */
 .marketplace-picker {
   display: flex;

--- a/apps/web/src/plugins/erli/components/erli-credentials-panel.tsx
+++ b/apps/web/src/plugins/erli/components/erli-credentials-panel.tsx
@@ -100,10 +100,12 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
   // "reuse this app's credentials" pick list. Filtered client-side (not just
   // trusted from the `platformType` query param) so a mocked/misbehaving
   // response never renders a non-Allegro connection as a reuse target.
-  const allegroConnectionsQuery = useConnectionsQuery({
-    platformType: 'allegro',
-    status: 'active',
-  });
+  // Gated on `showRotate` (#1405 review) so the query doesn't fire on every
+  // page render — only when the operator actually opens "Rotate API key".
+  const allegroConnectionsQuery = useConnectionsQuery(
+    { platformType: 'allegro', status: 'active' },
+    { enabled: showRotate }
+  );
 
   if (!connection.credentialsBacked) {
     return (
@@ -117,6 +119,11 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
     (c) => c.platformType === 'allegro' && c.status === 'active'
   );
   const hasAllegroConnections = allegroConnections.length > 0;
+  // The query is gated on `showRotate` (#1405 review), so the first render
+  // after opening the panel is a loading gap — don't render the "no Allegro
+  // connection" empty state during that gap, it would misleadingly suggest
+  // there's nothing to reuse before the fetch has even resolved.
+  const isLoadingAllegroConnections = showRotate && allegroConnectionsQuery.isLoading;
   // Zero Allegro connections collapses the choice to manual entry regardless
   // of the radio's own state — there's nothing to reuse.
   const effectiveCredSource: AllegroCredentialSource = hasAllegroConnections
@@ -279,7 +286,7 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
         description="Stored securely on the server. Rotate to replace the key without restarting the API."
       >
         {showRotate ? (
-          <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+          <div className="erli-credentials-panel__input-row">
             <Input
               type="password"
               autoComplete="off"
@@ -302,7 +309,7 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
        * category-browsing access shouldn't have to open (or fill in) the key
        * rotation flow to reach this. */}
       <div>
-        <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
+        <label className="erli-credentials-panel__option-label">
           <input
             type="checkbox"
             checked={allegroEnabled}
@@ -310,7 +317,7 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
           />
           <span>
             <strong>Browse Allegro categories when creating Erli offers</strong>
-            <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+            <small className="erli-credentials-panel__hint">
               Turn this on to pick categories and fill required parameters from a list, the same
               way you do for Allegro. Leave it off and you&apos;ll enter category IDs by hand.
             </small>
@@ -319,9 +326,11 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
 
         {allegroEnabled ? (
           <div className="form-grid">
-            {hasAllegroConnections ? (
+            {isLoadingAllegroConnections ? (
+              <Alert tone="info">Checking for existing Allegro connections...</Alert>
+            ) : hasAllegroConnections ? (
               <div>
-                <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
+                <label className="erli-credentials-panel__option-label">
                   <input
                     type="radio"
                     name="erli-allegro-cred-source"
@@ -330,14 +339,14 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
                   />
                   <span>
                     <strong>Reuse credentials from an existing Allegro connection</strong>
-                    <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                    <small className="erli-credentials-panel__hint">
                       Recommended - uses the same app credentials already configured on that
                       connection. Nothing new to register.
                     </small>
                   </span>
                 </label>
                 {effectiveCredSource === 'reuse' ? (
-                  <div style={{ marginLeft: 'calc(0.875rem + var(--space-2))' }}>
+                  <div className="erli-credentials-panel__indent">
                     <Select
                       aria-label="Allegro connection to reuse"
                       value={selectedAllegroConnectionId}
@@ -350,18 +359,18 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
                         </option>
                       ))}
                     </Select>
-                    <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                    <small className="erli-credentials-panel__hint">
                       Only read access to the public category catalog is used - this
                       connection&apos;s seller credentials are never touched.
                     </small>
                     {selectedAllegroConnection ? (
-                      <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                      <small className="erli-credentials-panel__hint">
                         Will use that connection&apos;s environment: <strong>{reuseEnvironment}</strong>.
                       </small>
                     ) : null}
                   </div>
                 ) : null}
-                <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
+                <label className="erli-credentials-panel__option-label">
                   <input
                     type="radio"
                     name="erli-allegro-cred-source"
@@ -370,7 +379,7 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
                   />
                   <span>
                     <strong>Enter Allegro app credentials manually</strong>
-                    <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                    <small className="erli-credentials-panel__hint">
                       Use a different Allegro app - e.g. one dedicated just for category browsing.
                     </small>
                   </span>
@@ -396,7 +405,7 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
                     <option value="production">Production</option>
                     <option value="sandbox">Sandbox</option>
                   </Select>
-                  <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                  <small className="erli-credentials-panel__hint">
                     Sandbox and production Allegro apps are registered separately - pick the one
                     this Client ID/Secret belongs to, or category requests will fail
                     authentication.
@@ -409,14 +418,14 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
                     value={allegroClientId}
                     onChange={(event) => setAllegroClientId(event.target.value)}
                   />
-                  <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                  <small className="erli-credentials-panel__hint">
                     From an Allegro app you register at apps.developer.allegro.pl. Used only to
                     read the public category catalog - never to sign in as a seller or place
                     offers.
                   </small>
                 </div>
                 <div>
-                  <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+                  <div className="erli-credentials-panel__input-row">
                     <Input
                       type={showSecret ? 'text' : 'password'}
                       autoComplete="off"
@@ -433,7 +442,7 @@ export function ErliCredentialsPanel({ connection }: { connection: Connection })
                       {showSecret ? 'Hide' : 'Show'}
                     </Button>
                   </div>
-                  <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                  <small className="erli-credentials-panel__hint">
                     Stored encrypted. You won&apos;t see it again after saving.
                   </small>
                 </div>

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-allegro-credentials-rewriter.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-allegro-credentials-rewriter.adapter.spec.ts
@@ -93,6 +93,15 @@ describe('ErliAllegroCredentialsRewriterAdapter', () => {
     ).rejects.toThrow(/is not an Allegro connection/);
   });
 
+  it('should reject when the source Allegro connection is not active', async () => {
+    connectionPort.get.mockResolvedValue(buildAllegroConnection({ status: 'disabled' }));
+
+    await expect(
+      adapter.rewrite({ reuseAllegroConnectionId: 'allegro-conn-1' })
+    ).rejects.toThrow(/is not active/);
+    expect(credentialsResolver.get).not.toHaveBeenCalled();
+  });
+
   it('should reject when the source Allegro connection has no client credentials configured', async () => {
     connectionPort.get.mockResolvedValue(buildAllegroConnection());
     credentialsResolver.get.mockResolvedValue({});

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-allegro-credentials-rewriter.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-allegro-credentials-rewriter.adapter.ts
@@ -82,6 +82,13 @@ export class ErliAllegroCredentialsRewriterAdapter implements ConnectionCredenti
           `(platformType: ${sourceConnection.platformType}); cannot reuse its credentials`
       );
     }
+    if (sourceConnection.status !== 'active') {
+      throw new ConnectionCredentialsRewriteException(
+        this.pluginName,
+        `Allegro connection ${reuseAllegroConnectionId} is not active ` +
+          `(status: ${sourceConnection.status}); cannot reuse its credentials`
+      );
+    }
 
     const sourceCredentials = await this.credentialsResolver.get<AllegroAppCredentials>(
       sourceConnection.credentialsRef


### PR DESCRIPTION
## Summary
- `ErliAllegroCredentialsRewriterAdapter.rewrite` rejects reusing credentials from a source Allegro connection whose status isn't active.
- `ConnectionService.create` now runs the registered credentials rewriter before persisting, matching the existing update path.
- `useConnectionsQuery` gains an `enabled` option; `ErliCredentialsPanel` only queries Allegro connections once "Rotate API key" is open, with a loading state to avoid a misleading empty-state flash.
- Inline styles in the credentials panel replaced with CSS classes.

Closes #1465

## Test plan
- [x] `pnpm --filter @openlinker/integrations-erli test` — new rewriter test passes (8/8)
- [x] `pnpm --filter @openlinker/api test -- connection.service.spec` — new create-path tests pass (72/72)
- [x] Full `pnpm lint && pnpm type-check && pnpm test` (pre-commit gate) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)