### PR TITLE
fix(prestashop-seed): activate the PL country in the dev/demo shop

### DIFF
--- a/docker/prestashop/post-install-lib/25-activate-country-pl.php
+++ b/docker/prestashop/post-install-lib/25-activate-country-pl.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Activate the Poland (PL) country in the dev shop (#1446).
+ *
+ * PrestaShop ships the PL country row in the default country set but leaves it
+ * inactive. OpenLinker's PrestashopCountryResolver rejects inactive countries,
+ * so a marketplace order for a PL buyer address fails to sync with
+ * "country exists but is not active". Flipping PL active out of the box (the
+ * dev shop already defaults to PLN, #521) makes the demo locale self-consistent
+ * and removes the manual admin step.
+ *
+ * Idempotent: re-runs early-exit when PL is already active.
+ *
+ * Implementation note: legacy bootstrap is intentional — same path bin/console
+ * uses internally for ObjectModel ops. We deliberately do NOT boot the Symfony
+ * kernel: this script only needs Country, a pre-DI ObjectModel class. Mirrors
+ * 20-set-default-currency.php; do not "modernise" without a reason.
+ */
+
+// PrestaShop bootstrap. _PS_ADMIN_DIR_ points at the renamed admin folder
+// from `10-rename-admin.sh` (lexical-order guaranteed to run before us).
+define('_PS_ADMIN_DIR_', '/var/www/html/admin-dev');
+require_once '/var/www/html/config/config.inc.php';
+
+$countryId = (int) Country::getByIso('PL', false);
+
+if ($countryId <= 0) {
+    // The PL row ships with every default install; its absence is unexpected.
+    fwrite(STDERR, "FATAL: PL country row not found in PrestaShop\n");
+    exit(1);
+}
+
+$country = new Country($countryId);
+
+if ((int) $country->active === 1) {
+    echo "* PL country is already active (id={$countryId}); nothing to do\n";
+    exit(0);
+}
+
+$country->active = true;
+
+if (!$country->save()) {
+    fwrite(STDERR, "FATAL: Country::save() failed activating PL (id={$countryId})\n");
+    exit(1);
+}
+
+echo "* PL country activated (id={$countryId})\n";

--- a/docker/prestashop/post-install/25-activate-country-pl.sh
+++ b/docker/prestashop/post-install/25-activate-country-pl.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Activate the Poland (PL) country in the dev shop (#1446).
+# PrestaShop ships PL as a country row but leaves it inactive by default, so
+# order sync for a PL buyer address fails with "country exists but is not
+# active". Thin wrapper that execs the PHP companion — see
+# 25-activate-country-pl.php for the actual ObjectModel-based logic. Idempotent.
+set -e
+
+if ! command -v php >/dev/null 2>&1; then
+    echo "FATAL: php CLI not found in container; cannot run country activation seed" >&2
+    exit 1
+fi
+
+# Run as www-data (matches the install phase on docker_run.sh:89). See
+# 20-set-default-currency.sh for rationale (cache ownership).
+exec runuser -g www-data -u www-data -- php -d memory_limit=256M /tmp/post-install-lib/25-activate-country-pl.php


### PR DESCRIPTION
## Summary
- PrestaShop ships the Poland (PL) country row inactive by default, so `PrestashopCountryResolver` rejects it and marketplace order sync for a PL buyer address fails with "country exists but is not active".
- Adds an idempotent post-install seed (`25-activate-country-pl.sh` + `.php`), mirroring `20-set-default-currency`, that resolves PL by ISO code and flips `active=1` via the Country ObjectModel. Early-exits when already active. Numbered `25-` so it runs after currency and before the product seed.
- The base PrestaShop service mounts are inherited by the demo overlay, so this fixes both the dev stack and the demo image.

Closes #1446

## Test plan
- [x] Verified live in the demo PrestaShop container: PL went `active=0 -> active=1` on first run, second run was a no-op
- [x] `pnpm lint && pnpm type-check` (smart-test scope: none — shell/PHP seed script, no workspace package affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)