### PR TITLE
fix(web): hide demo-mode banner from admin/operator sessions

### DIFF
--- a/apps/web/src/app/app-shell.test.tsx
+++ b/apps/web/src/app/app-shell.test.tsx
@@ -212,6 +212,36 @@ describe('AppShell', () => {
     expect(promptTemplates.closest('a')).toHaveAttribute('href', '/ai/prompt-templates');
   });
 
+  it('shows the demo banner for a viewer session in demo mode (#1468)', async () => {
+    const viewerAdapter = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: 'viewer@example.com',
+      role: 'viewer',
+      permissions: [],
+    });
+    const demoApiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+    });
+    renderShell({ pathname: '/', apiClient: demoApiClient, sessionAdapter: viewerAdapter });
+
+    expect(await screen.findByRole('note', { name: 'Demo mode notice' })).toBeInTheDocument();
+  });
+
+  it('hides the demo banner for an admin session in demo mode (#1468)', async () => {
+    const demoApiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+    });
+    renderShell({ pathname: '/', apiClient: demoApiClient });
+
+    // Wait for the demo-mode config to resolve (same signal the sibling
+    // nav-lock tests use) before asserting the banner's absence. Scoped to
+    // the primary nav — desktop + mobile drawer both render the label.
+    const primary = screen.getByRole('navigation', { name: 'Primary' });
+    await within(primary).findByText('Prompt templates');
+    expect(screen.queryByRole('note', { name: 'Demo mode notice' })).toBeNull();
+  });
+
   it('uses "Connections" as the nav label (not "Integrations")', () => {
     renderShell({ pathname: '/' });
     const primary = screen.getByRole('navigation', { name: 'Primary' });

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -249,6 +249,12 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
   const counts = useNavCounts();
   const isAdmin =
     isReady && session.status === 'authenticated' && session.user?.role === 'admin';
+  // Demo mode's "write actions are disabled" claim is only true for a
+  // viewer-role session — RolesGuard lets admin/operator write fine, so
+  // showing the banner to them is actively misleading during a live
+  // walkthrough (#1468).
+  const isViewerOnly =
+    isReady && session.status === 'authenticated' && session.user?.role === 'viewer';
   const groups = useMemo(() => buildNavGroups({ isAdmin, demoMode }), [isAdmin, demoMode]);
   const matches = useMatches();
 
@@ -371,7 +377,7 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
           ) : null}
         </header>
 
-        {demoMode ? (
+        {demoMode && isViewerOnly ? (
           <DemoBanner
             consentPending={Boolean(posthogConfig?.key) && analyticsConsent === null}
             consentAccepted={Boolean(posthogConfig?.key) && analyticsConsent === 'accepted'}


### PR DESCRIPTION
## Summary
- `AppShell` rendered the "write actions are disabled" demo-mode banner for every authenticated session, regardless of role.
- `RolesGuard` only restricts the `viewer` role — `admin`/`operator` accounts can write fine in demo mode, so showing them the banner falsely claims writes are disabled during a live walkthrough.
- Gates the banner render on the session role (mirrors the existing `isAdmin` computation) — only shown for a `viewer` session now.

Closes #1468

## Test plan
- [x] New test: demo banner shown for a viewer session in demo mode
- [x] New test: demo banner hidden for an admin session in demo mode
- [x] `pnpm --filter @openlinker/web test` — 244/245 passing (1 pre-existing unrelated failure: `settings-page.test.tsx` "shows environment info", fails identically on `main`)
- [x] `pnpm --filter @openlinker/web lint && type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)