### PR TITLE
feat(auth): rate-limit demo self-registration + scheduled cleanup of demo accounts

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -20,6 +20,7 @@ import {
   ForbiddenException,
   Get,
   HttpCode,
+  HttpException,
   HttpStatus,
   Inject,
   Post,
@@ -33,6 +34,7 @@ import { Request, Response } from 'express';
 import {
   InvalidPasswordResetTokenException,
   RegistrationDisabledException,
+  RegistrationRateLimitedException,
   RefreshTokenReuseDetectedException,
   UserAlreadyExistsException,
   WeakPasswordException,
@@ -117,15 +119,19 @@ export class AuthController {
   @ApiResponse({ status: 201, description: 'Registration submitted — awaiting admin approval', type: OkResponseDto })
   @ApiResponse({ status: 403, description: 'Registration is disabled for this installation' })
   @ApiResponse({ status: 409, description: 'Username or email already taken' })
-  async register(@Body() dto: RegisterDto): Promise<OkResponseDto> {
+  @ApiResponse({ status: 429, description: 'Too many registration attempts from this IP' })
+  async register(@Body() dto: RegisterDto, @Req() req: Request): Promise<OkResponseDto> {
     try {
-      await this.registrationService.register(dto.username, dto.email, dto.password);
+      await this.registrationService.register(dto.username, dto.email, dto.password, req.ip);
     } catch (error) {
       if (error instanceof RegistrationDisabledException) {
         throw new ForbiddenException(error.message);
       }
       if (error instanceof UserAlreadyExistsException) {
         throw new ConflictException(error.message);
+      }
+      if (error instanceof RegistrationRateLimitedException) {
+        throw new HttpException(error.message, HttpStatus.TOO_MANY_REQUESTS);
       }
       throw error;
     }

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -30,6 +30,7 @@ import { RegistrationService } from './registration.service';
 import { REGISTRATION_SERVICE_TOKEN } from './registration.service.interface';
 import { DemoModeService } from './demo-mode.service';
 import { DEMO_MODE_SERVICE_TOKEN } from './demo-mode.service.interface';
+import { DemoAccountCleanupService } from './demo-account-cleanup.service';
 
 @Module({
   imports: [
@@ -65,6 +66,7 @@ import { DEMO_MODE_SERVICE_TOKEN } from './demo-mode.service.interface';
     { provide: REGISTRATION_SERVICE_TOKEN, useExisting: RegistrationService },
     DemoModeService,
     { provide: DEMO_MODE_SERVICE_TOKEN, useExisting: DemoModeService },
+    DemoAccountCleanupService,
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: RolesGuard },
   ],

--- a/apps/api/src/auth/bootstrap-admin.service.spec.ts
+++ b/apps/api/src/auth/bootstrap-admin.service.spec.ts
@@ -39,6 +39,7 @@ const makeRepo = (): jest.Mocked<UserRepositoryPort> => ({
   deactivateAdminAtomically: jest.fn(),
   updateAdminRoleAtomically: jest.fn(),
   deleteAdminAtomically: jest.fn(),
+  findStaleViewerAccounts: jest.fn(),
 });
 
 describe('BootstrapAdminService', () => {

--- a/apps/api/src/auth/demo-account-cleanup.service.spec.ts
+++ b/apps/api/src/auth/demo-account-cleanup.service.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * DemoAccountCleanupService Unit Tests
+ *
+ * @module apps/api/src/auth
+ */
+import type { ConfigService } from '@nestjs/config';
+import { DemoAccountCleanupService } from './demo-account-cleanup.service';
+import type { IDemoModeService } from './demo-mode.service.interface';
+import { User, type UserRepositoryPort } from '@openlinker/core/users';
+
+const makeUser = (id: string): User =>
+  new User(id, `user-${id}`, `${id}@test.com`, 'hash', 'viewer', 'active', new Date(), new Date());
+
+const makeConfig = (overrides: Record<string, string> = {}): ConfigService =>
+  ({
+    get: jest.fn((key: string, defaultValue?: string) => overrides[key] ?? defaultValue),
+  }) as unknown as ConfigService;
+
+const makeDemoService = (enabled: boolean): IDemoModeService => ({
+  isDemoModeEnabled: () => enabled,
+});
+
+const makeRepo = (): jest.Mocked<UserRepositoryPort> => ({
+  findByUsername: jest.fn(),
+  findByEmail: jest.fn(),
+  findById: jest.fn(),
+  findAll: jest.fn(),
+  save: jest.fn(),
+  updatePasswordHash: jest.fn(),
+  updateStatus: jest.fn(),
+  updateRole: jest.fn(),
+  approveUser: jest.fn(),
+  deleteById: jest.fn(),
+  deactivateAdminAtomically: jest.fn(),
+  updateAdminRoleAtomically: jest.fn(),
+  deleteAdminAtomically: jest.fn(),
+  findStaleViewerAccounts: jest.fn(),
+});
+
+describe('DemoAccountCleanupService', () => {
+  it('should do nothing when demo mode is off', async () => {
+    const repo = makeRepo();
+    const service = new DemoAccountCleanupService(repo, makeDemoService(false), makeConfig());
+
+    await service.cleanup();
+
+    expect(repo.findStaleViewerAccounts).not.toHaveBeenCalled();
+    expect(repo.deleteById).not.toHaveBeenCalled();
+  });
+
+  it('should delete every stale viewer account when demo mode is on', async () => {
+    const repo = makeRepo();
+    repo.findStaleViewerAccounts.mockResolvedValue([makeUser('u1'), makeUser('u2')]);
+    const service = new DemoAccountCleanupService(
+      repo,
+      makeDemoService(true),
+      makeConfig({ OL_DEMO_ACCOUNT_RETENTION_HOURS: '24' }),
+    );
+
+    await service.cleanup();
+
+    expect(repo.deleteById).toHaveBeenCalledTimes(2);
+    expect(repo.deleteById).toHaveBeenCalledWith('u1');
+    expect(repo.deleteById).toHaveBeenCalledWith('u2');
+  });
+
+  it('should query with a cutoff derived from the configured retention window', async () => {
+    const repo = makeRepo();
+    repo.findStaleViewerAccounts.mockResolvedValue([]);
+    const now = new Date('2026-01-02T00:00:00.000Z');
+    jest.useFakeTimers().setSystemTime(now);
+    const service = new DemoAccountCleanupService(
+      repo,
+      makeDemoService(true),
+      makeConfig({ OL_DEMO_ACCOUNT_RETENTION_HOURS: '24' }),
+    );
+
+    await service.cleanup();
+
+    const cutoff = repo.findStaleViewerAccounts.mock.calls[0][0];
+    expect(cutoff.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+    jest.useRealTimers();
+  });
+
+  it('should not delete anything when no accounts are stale', async () => {
+    const repo = makeRepo();
+    repo.findStaleViewerAccounts.mockResolvedValue([]);
+    const service = new DemoAccountCleanupService(repo, makeDemoService(true), makeConfig());
+
+    await service.cleanup();
+
+    expect(repo.deleteById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/auth/demo-account-cleanup.service.ts
+++ b/apps/api/src/auth/demo-account-cleanup.service.ts
@@ -1,0 +1,62 @@
+/**
+ * Demo Account Cleanup Service
+ *
+ * Periodically deletes self-registered demo accounts once they exceed a
+ * configurable retention window (#1469). Only acts when OL_DEMO_MODE is
+ * enabled — a non-demo deployment (registration usually disabled anyway)
+ * never has this task do anything.
+ *
+ * Scope: `role: 'viewer'` + `status: 'active'` + `createdAt` older than the
+ * retention window, per `UserRepositoryPort.findStaleViewerAccounts`. This
+ * is the exact shape `RegistrationService.register` produces for a demo
+ * account — an operator-created persistent viewer account is
+ * indistinguishable from a demo one and would also be swept up. Acceptable
+ * for a public/unattended demo; out of scope to add a distinguishing column
+ * for a single supervised deployment.
+ *
+ * @module apps/api/src/auth
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@openlinker/shared/logging';
+import { UserRepositoryPort, USER_REPOSITORY_TOKEN } from '@openlinker/core/users';
+import { DEMO_MODE_SERVICE_TOKEN, type IDemoModeService } from './demo-mode.service.interface';
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+@Injectable()
+export class DemoAccountCleanupService {
+  private readonly logger = new Logger(DemoAccountCleanupService.name);
+
+  constructor(
+    @Inject(USER_REPOSITORY_TOKEN)
+    private readonly userRepository: UserRepositoryPort,
+    @Inject(DEMO_MODE_SERVICE_TOKEN)
+    private readonly demoModeService: IDemoModeService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async cleanup(): Promise<void> {
+    if (!this.demoModeService.isDemoModeEnabled()) {
+      return;
+    }
+
+    const retentionHours = Number(
+      this.configService.get<string>('OL_DEMO_ACCOUNT_RETENTION_HOURS', '24'),
+    );
+    const olderThan = new Date(Date.now() - retentionHours * MS_PER_HOUR);
+    const staleAccounts = await this.userRepository.findStaleViewerAccounts(olderThan);
+
+    for (const account of staleAccounts) {
+      await this.userRepository.deleteById(account.id);
+    }
+
+    if (staleAccounts.length > 0) {
+      this.logger.log(
+        `Demo account cleanup: removed ${staleAccounts.length} account(s) older than ${retentionHours}h`,
+      );
+    }
+  }
+}

--- a/apps/api/src/auth/password-reset.service.spec.ts
+++ b/apps/api/src/auth/password-reset.service.spec.ts
@@ -35,6 +35,7 @@ function makeMocks() {
     deactivateAdminAtomically: jest.fn(),
     updateAdminRoleAtomically: jest.fn(),
     deleteAdminAtomically: jest.fn(),
+    findStaleViewerAccounts: jest.fn(),
   };
   const tokenRepo: jest.Mocked<PasswordResetTokenRepositoryPort> = {
     save: jest.fn(),

--- a/apps/api/src/auth/registration.service.interface.ts
+++ b/apps/api/src/auth/registration.service.interface.ts
@@ -10,7 +10,11 @@
  */
 
 export interface IRegistrationService {
-  register(username: string, email: string, password: string): Promise<void>;
+  /**
+   * `clientIp` is only consulted when demo mode is enabled, to key the
+   * per-IP registration rate limit (#1469). Omit it for non-demo callers.
+   */
+  register(username: string, email: string, password: string, clientIp?: string): Promise<void>;
 }
 
 export const REGISTRATION_SERVICE_TOKEN = Symbol('IRegistrationService');

--- a/apps/api/src/auth/registration.service.spec.ts
+++ b/apps/api/src/auth/registration.service.spec.ts
@@ -4,10 +4,12 @@
  * @module apps/api/src/auth
  */
 import type { ConfigService } from '@nestjs/config';
+import { InMemoryCacheAdapter } from '@openlinker/shared/cache/testing';
 import { RegistrationService } from './registration.service';
 import type { IDemoModeService } from './demo-mode.service.interface';
 import {
   RegistrationDisabledException,
+  RegistrationRateLimitedException,
   UserAlreadyExistsException,
   User,
   type UserRepositoryPort,
@@ -16,11 +18,9 @@ import {
 const makeUser = (username: string): User =>
   new User('id', username, `${username}@test.com`, 'hash', 'viewer', 'pending', new Date(), new Date());
 
-const makeConfig = (enabled: string): ConfigService =>
+const makeConfig = (overrides: Record<string, string> = {}): ConfigService =>
   ({
-    get: jest.fn((key: string, defaultValue?: string) =>
-      key === 'OL_REGISTRATION_ENABLED' ? enabled : defaultValue
-    ),
+    get: jest.fn((key: string, defaultValue?: string) => overrides[key] ?? defaultValue),
   }) as unknown as ConfigService;
 
 const makeDemoService = (enabled: boolean): IDemoModeService => ({
@@ -41,12 +41,13 @@ const makeRepo = (): jest.Mocked<UserRepositoryPort> => ({
   deactivateAdminAtomically: jest.fn(),
   updateAdminRoleAtomically: jest.fn(),
   deleteAdminAtomically: jest.fn(),
+  findStaleViewerAccounts: jest.fn(),
 });
 
 describe('RegistrationService', () => {
   it('should throw RegistrationDisabledException when registration is disabled', async () => {
     const repo = makeRepo();
-    const service = new RegistrationService(repo, makeConfig('false'), makeDemoService(false));
+    const service = new RegistrationService(repo, makeConfig({ OL_REGISTRATION_ENABLED: 'false' }), makeDemoService(false), new InMemoryCacheAdapter());
 
     await expect(service.register('alice', 'alice@test.com', 'pass123')).rejects.toThrow(
       RegistrationDisabledException
@@ -58,7 +59,7 @@ describe('RegistrationService', () => {
     const repo = makeRepo();
     repo.findByUsername.mockResolvedValue(makeUser('alice'));
     repo.findByEmail.mockResolvedValue(null);
-    const service = new RegistrationService(repo, makeConfig('true'), makeDemoService(false));
+    const service = new RegistrationService(repo, makeConfig({ OL_REGISTRATION_ENABLED: 'true' }), makeDemoService(false), new InMemoryCacheAdapter());
 
     await expect(service.register('alice', 'newemail@test.com', 'pass123')).rejects.toThrow(
       UserAlreadyExistsException
@@ -70,7 +71,7 @@ describe('RegistrationService', () => {
     const repo = makeRepo();
     repo.findByUsername.mockResolvedValue(null);
     repo.findByEmail.mockResolvedValue(makeUser('bob'));
-    const service = new RegistrationService(repo, makeConfig('true'), makeDemoService(false));
+    const service = new RegistrationService(repo, makeConfig({ OL_REGISTRATION_ENABLED: 'true' }), makeDemoService(false), new InMemoryCacheAdapter());
 
     await expect(service.register('alice', 'bob@test.com', 'pass123')).rejects.toThrow(
       UserAlreadyExistsException
@@ -83,7 +84,7 @@ describe('RegistrationService', () => {
     repo.findByUsername.mockResolvedValue(null);
     repo.findByEmail.mockResolvedValue(null);
     repo.save.mockImplementation((u) => Promise.resolve(makeUser(u.username)));
-    const service = new RegistrationService(repo, makeConfig('true'), makeDemoService(false));
+    const service = new RegistrationService(repo, makeConfig({ OL_REGISTRATION_ENABLED: 'true' }), makeDemoService(false), new InMemoryCacheAdapter());
 
     await service.register('alice', 'alice@test.com', 'pass123');
 
@@ -101,7 +102,7 @@ describe('RegistrationService', () => {
     repo.findByUsername.mockResolvedValue(null);
     repo.findByEmail.mockResolvedValue(null);
     repo.save.mockImplementation((u) => Promise.resolve(makeUser(u.username)));
-    const service = new RegistrationService(repo, makeConfig('true'), makeDemoService(true));
+    const service = new RegistrationService(repo, makeConfig({ OL_REGISTRATION_ENABLED: 'true' }), makeDemoService(true), new InMemoryCacheAdapter());
 
     await service.register('demo_user', 'demo@test.com', 'pass123');
 
@@ -109,5 +110,86 @@ describe('RegistrationService', () => {
     const saved = repo.save.mock.calls[0][0];
     expect(saved.status).toBe('active');
     expect(saved.role).toBe('viewer');
+  });
+
+  describe('rate limiting (#1469)', () => {
+    it('should throw RegistrationRateLimitedException after the configured limit is reached', async () => {
+      const repo = makeRepo();
+      repo.findByUsername.mockResolvedValue(null);
+      repo.findByEmail.mockResolvedValue(null);
+      repo.save.mockImplementation((u) => Promise.resolve(makeUser(u.username)));
+      const cache = new InMemoryCacheAdapter();
+      const service = new RegistrationService(
+        repo,
+        makeConfig({ OL_REGISTRATION_ENABLED: 'true', OL_DEMO_REGISTRATION_RATE_LIMIT: '2' }),
+        makeDemoService(true),
+        cache,
+      );
+
+      await service.register('user1', 'user1@test.com', 'pass123', '1.2.3.4');
+      await service.register('user2', 'user2@test.com', 'pass123', '1.2.3.4');
+
+      await expect(
+        service.register('user3', 'user3@test.com', 'pass123', '1.2.3.4'),
+      ).rejects.toThrow(RegistrationRateLimitedException);
+      expect(repo.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('should track separate IPs independently', async () => {
+      const repo = makeRepo();
+      repo.findByUsername.mockResolvedValue(null);
+      repo.findByEmail.mockResolvedValue(null);
+      repo.save.mockImplementation((u) => Promise.resolve(makeUser(u.username)));
+      const cache = new InMemoryCacheAdapter();
+      const service = new RegistrationService(
+        repo,
+        makeConfig({ OL_REGISTRATION_ENABLED: 'true', OL_DEMO_REGISTRATION_RATE_LIMIT: '1' }),
+        makeDemoService(true),
+        cache,
+      );
+
+      await service.register('user1', 'user1@test.com', 'pass123', '1.1.1.1');
+      await service.register('user2', 'user2@test.com', 'pass123', '2.2.2.2');
+
+      expect(repo.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not rate-limit when demo mode is off, even with a clientIp', async () => {
+      const repo = makeRepo();
+      repo.findByUsername.mockResolvedValue(null);
+      repo.findByEmail.mockResolvedValue(null);
+      repo.save.mockImplementation((u) => Promise.resolve(makeUser(u.username)));
+      const cache = new InMemoryCacheAdapter();
+      const service = new RegistrationService(
+        repo,
+        makeConfig({ OL_REGISTRATION_ENABLED: 'true', OL_DEMO_REGISTRATION_RATE_LIMIT: '1' }),
+        makeDemoService(false),
+        cache,
+      );
+
+      await service.register('user1', 'user1@test.com', 'pass123', '1.2.3.4');
+      await service.register('user2', 'user2@test.com', 'pass123', '1.2.3.4');
+
+      expect(repo.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not rate-limit when no clientIp is provided', async () => {
+      const repo = makeRepo();
+      repo.findByUsername.mockResolvedValue(null);
+      repo.findByEmail.mockResolvedValue(null);
+      repo.save.mockImplementation((u) => Promise.resolve(makeUser(u.username)));
+      const cache = new InMemoryCacheAdapter();
+      const service = new RegistrationService(
+        repo,
+        makeConfig({ OL_REGISTRATION_ENABLED: 'true', OL_DEMO_REGISTRATION_RATE_LIMIT: '1' }),
+        makeDemoService(true),
+        cache,
+      );
+
+      await service.register('user1', 'user1@test.com', 'pass123');
+      await service.register('user2', 'user2@test.com', 'pass123');
+
+      expect(repo.save).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/apps/api/src/auth/registration.service.ts
+++ b/apps/api/src/auth/registration.service.ts
@@ -14,8 +14,10 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcryptjs';
 import { Logger } from '@openlinker/shared/logging';
+import { CACHE_PORT_TOKEN, type CachePort } from '@openlinker/shared/cache';
 import {
   RegistrationDisabledException,
+  RegistrationRateLimitedException,
   UserAlreadyExistsException,
   UserRepositoryPort,
   USER_REPOSITORY_TOKEN,
@@ -35,12 +37,24 @@ export class RegistrationService implements IRegistrationService {
     private readonly configService: ConfigService,
     @Inject(DEMO_MODE_SERVICE_TOKEN)
     private readonly demoModeService: IDemoModeService,
+    @Inject(CACHE_PORT_TOKEN)
+    private readonly cache: CachePort,
   ) {}
 
-  async register(username: string, email: string, password: string): Promise<void> {
+  async register(
+    username: string,
+    email: string,
+    password: string,
+    clientIp?: string,
+  ): Promise<void> {
     const enabled = this.configService.get<string>('OL_REGISTRATION_ENABLED', 'false');
     if (enabled.trim().toLowerCase() !== 'true') {
       throw new RegistrationDisabledException();
+    }
+
+    const demoMode = this.demoModeService.isDemoModeEnabled();
+    if (demoMode && clientIp) {
+      await this.enforceRateLimit(clientIp);
     }
 
     const [existingByUsername, existingByEmail] = await Promise.all([
@@ -56,7 +70,6 @@ export class RegistrationService implements IRegistrationService {
     }
 
     const passwordHash = await bcrypt.hash(password, BCRYPT_COST);
-    const demoMode = this.demoModeService.isDemoModeEnabled();
     await this.userRepository.save({
       username,
       email,
@@ -72,5 +85,28 @@ export class RegistrationService implements IRegistrationService {
     } else {
       this.logger.log(`New user registered and pending approval: ${username}`);
     }
+  }
+
+  /**
+   * Fixed-window counter keyed by client IP (#1469). Best-effort, not
+   * atomic — `CachePort` exposes only get/set/delete, so a race between two
+   * concurrent requests from the same IP can both read the pre-increment
+   * count. Acceptable here: this is abuse deterrence for a public demo, not
+   * a hard security boundary.
+   */
+  private async enforceRateLimit(clientIp: string): Promise<void> {
+    const limit = Number(
+      this.configService.get<string>('OL_DEMO_REGISTRATION_RATE_LIMIT', '5'),
+    );
+    const windowSeconds = Number(
+      this.configService.get<string>('OL_DEMO_REGISTRATION_RATE_WINDOW_SECONDS', '3600'),
+    );
+    const key = `demo:register:${clientIp}`;
+    const count = (await this.cache.get<number>(key)) ?? 0;
+    if (count >= limit) {
+      this.logger.warn(`Registration rate limit exceeded for IP ${clientIp}`);
+      throw new RegistrationRateLimitedException();
+    }
+    await this.cache.set(key, count + 1, windowSeconds);
   }
 }

--- a/apps/api/src/users/user-management.service.spec.ts
+++ b/apps/api/src/users/user-management.service.spec.ts
@@ -35,6 +35,7 @@ const makeRepo = (): jest.Mocked<UserRepositoryPort> => ({
   deactivateAdminAtomically: jest.fn(),
   updateAdminRoleAtomically: jest.fn(),
   deleteAdminAtomically: jest.fn(),
+  findStaleViewerAccounts: jest.fn(),
 });
 
 describe('UserManagementService', () => {

--- a/libs/core/src/users/domain/exceptions/registration-rate-limited.exception.ts
+++ b/libs/core/src/users/domain/exceptions/registration-rate-limited.exception.ts
@@ -1,0 +1,16 @@
+/**
+ * Registration Rate Limited Exception
+ *
+ * Thrown when a registration attempt exceeds the configured rate limit for
+ * the requesting IP while demo mode is enabled (#1469).
+ *
+ * @module libs/core/src/users/domain/exceptions
+ */
+
+export class RegistrationRateLimitedException extends Error {
+  constructor() {
+    super('Too many registration attempts. Please try again later.');
+    this.name = 'RegistrationRateLimitedException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/users/domain/ports/user-repository.port.ts
+++ b/libs/core/src/users/domain/ports/user-repository.port.ts
@@ -23,6 +23,15 @@ export interface UserRepositoryPort {
   deleteById(userId: string): Promise<void>;
 
   /**
+   * Active viewer-role accounts created before `olderThan` — the
+   * self-registration shape (#1469's demo-account cleanup). Scoped to
+   * `role: 'viewer'` because `RegistrationService.register` always creates
+   * viewer accounts; an operator-created persistent viewer account is
+   * indistinguishable from a demo one by this query (documented limitation).
+   */
+  findStaleViewerAccounts(olderThan: Date): Promise<User[]>;
+
+  /**
    * Atomically deactivates an admin only when 2+ active admins exist.
    * Returns { updated: true } on success; { updated: false } when the user
    * is the sole active admin (guard fired). The caller decides the meaning.

--- a/libs/core/src/users/index.ts
+++ b/libs/core/src/users/index.ts
@@ -21,6 +21,7 @@ export { UserNotDeactivatedException } from './domain/exceptions/user-not-deacti
 export { CannotSelfModifyException } from './domain/exceptions/cannot-self-modify.exception';
 export { LastAdminException } from './domain/exceptions/last-admin.exception';
 export { RegistrationDisabledException } from './domain/exceptions/registration-disabled.exception';
+export { RegistrationRateLimitedException } from './domain/exceptions/registration-rate-limited.exception';
 export { InvalidPasswordResetTokenException } from './domain/exceptions/invalid-password-reset-token.exception';
 export { WeakPasswordException } from './domain/exceptions/weak-password.exception';
 export { RefreshTokenReuseDetectedException } from './domain/exceptions/refresh-token-reuse-detected.exception';

--- a/libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts
+++ b/libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts
@@ -10,7 +10,7 @@
  */
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { QueryFailedError, Repository } from 'typeorm';
+import { LessThan, QueryFailedError, Repository } from 'typeorm';
 import { User } from '../../../domain/entities/user.entity';
 import { UserAlreadyExistsException } from '../../../domain/exceptions/user-already-exists.exception';
 import type { UserRepositoryPort } from '../../../domain/ports/user-repository.port';
@@ -79,6 +79,13 @@ export class UserRepository implements UserRepositoryPort {
 
   async deleteById(userId: string): Promise<void> {
     await this.ormRepository.delete({ id: userId });
+  }
+
+  async findStaleViewerAccounts(olderThan: Date): Promise<User[]> {
+    const entities = await this.ormRepository.find({
+      where: { role: 'viewer', status: 'active', createdAt: LessThan(olderThan) },
+    });
+    return entities.map((entity) => this.toDomain(entity));
   }
 
   async save(

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -407,6 +407,14 @@ const ALLOW_LIST = new Map([
     'apps/api/src/users/user-management.service.spec.ts',
     new Set(['UserRepositoryPort']),
   ],
+  [
+    'apps/api/src/auth/demo-account-cleanup.service.ts',
+    new Set(['UserRepositoryPort']),
+  ],
+  [
+    'apps/api/src/auth/demo-account-cleanup.service.spec.ts',
+    new Set(['UserRepositoryPort']),
+  ],
 ]);
 
 const DENY_PATTERNS = [


### PR DESCRIPTION
## Summary
- `POST /auth/register` had no rate limiting, and demo mode auto-activates every self-registered account — a public unattended demo could accumulate unlimited viewer accounts with no cleanup mechanism.
- `RegistrationService` now enforces a per-IP fixed-window counter via the existing `CachePort` (Redis-backed), active only when demo mode is on. Limit/window are env-configurable (`OL_DEMO_REGISTRATION_RATE_LIMIT`, `OL_DEMO_REGISTRATION_RATE_WINDOW_SECONDS`, defaults 5/hour). Exceeding it maps to HTTP 429.
- New `DemoAccountCleanupService` runs hourly and, only when demo mode is on, deletes viewer/active accounts older than a configurable retention window (`OL_DEMO_ACCOUNT_RETENTION_HOURS`, default 24h) via a new `UserRepositoryPort.findStaleViewerAccounts` query.
- `demo-account-cleanup.service.ts`'s direct `UserRepositoryPort` import is allow-listed in `check-cross-context-imports.mjs`, mirroring the existing `registration.service.ts` entry (no `IUsersService` cross-context seam exists yet for the users context — documented follow-up).

Closes #1469

## Test plan
- [x] New unit tests for the rate limiter (limit reached, per-IP isolation, no-op outside demo mode, no-op without a client IP)
- [x] New unit tests for the cleanup service (no-op outside demo mode, deletes stale accounts, cutoff derived from retention window, no-op when nothing is stale)
- [x] `pnpm --filter @openlinker/api test` — 58/58 suites, 708/708 tests green
- [x] `pnpm lint && pnpm type-check` (full monorepo) clean
- [x] Pre-commit smart-test: 1 pre-existing unrelated failure (`apps/web` `settings-page.test.tsx` "shows environment info") — fails identically on `main`, unrelated to this change (no `apps/web` files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)