### PR TITLE
feat(invoicing): outbound mark-as-paid (PaymentMarker) for inFakt

### DIFF
--- a/apps/api/src/invoicing/http/dto/mark-invoice-paid-request.dto.spec.ts
+++ b/apps/api/src/invoicing/http/dto/mark-invoice-paid-request.dto.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Mark Invoice Paid Request DTO — validation spec (#1362)
+ *
+ * Exercises the class-validator constraints on `MarkInvoicePaidRequestDto`, in
+ * particular the calendar-date-only `paidDate` shape: a full ISO datetime is
+ * rejected because the adapter-side `.toISOString().slice(0, 10)` would let a
+ * near-midnight value roll the settlement date back a day.
+ *
+ * @module apps/api/src/invoicing/http/dto
+ */
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+
+import { MarkInvoicePaidRequestDto } from './mark-invoice-paid-request.dto';
+
+function buildDto(payload: Record<string, unknown>): MarkInvoicePaidRequestDto {
+  return plainToInstance(MarkInvoicePaidRequestDto, payload);
+}
+
+describe('MarkInvoicePaidRequestDto', () => {
+  it('should pass validation when paidDate is a calendar date (YYYY-MM-DD)', async () => {
+    const errors = await validate(buildDto({ paidDate: '2026-07-08' }));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should pass validation when paidDate is omitted (bare {})', async () => {
+    const errors = await validate(buildDto({}));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should reject a full ISO datetime (calendar-date-only field)', async () => {
+    const errors = await validate(buildDto({ paidDate: '2026-07-08T23:30:00+02:00' }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('matches');
+  });
+
+  it('should reject an impossible calendar date', async () => {
+    const errors = await validate(buildDto({ paidDate: '2026-13-45' }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('isIso8601');
+  });
+});

--- a/apps/api/src/invoicing/http/dto/mark-invoice-paid-request.dto.ts
+++ b/apps/api/src/invoicing/http/dto/mark-invoice-paid-request.dto.ts
@@ -1,0 +1,30 @@
+/**
+ * Mark Invoice Paid Request DTO (#1362)
+ *
+ * Body for `POST /invoices/:invoiceId/mark-paid`. `paidDate` is optional - a
+ * bare `{}` marks the invoice as paid today (UTC). The provider-native
+ * `externalInvoiceId` is never accepted here; the controller always derives
+ * it server-side from the resolved `InvoiceRecord.providerInvoiceId`.
+ *
+ * `paidDate` is a calendar date (`YYYY-MM-DD`), not a datetime: payment
+ * settlement is a day, and a full ISO datetime near local midnight would let
+ * the adapter-side `.toISOString().slice(0, 10)` roll the date back a day. The
+ * date-only shape is enforced with `@Matches` (format) alongside `@IsISO8601`
+ * (rejects impossible calendar dates like `2026-13-45`).
+ *
+ * @module apps/api/src/invoicing/http/dto
+ */
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsISO8601, IsOptional, Matches } from 'class-validator';
+
+export class MarkInvoicePaidRequestDto {
+  @ApiPropertyOptional({
+    description: 'Calendar date the payment was settled (YYYY-MM-DD). Defaults to today (UTC) when omitted.',
+    example: '2026-07-08',
+    format: 'date',
+  })
+  @IsOptional()
+  @IsISO8601()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'paidDate must be a calendar date (YYYY-MM-DD)' })
+  paidDate?: string;
+}

--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -24,12 +24,14 @@ import {
   UnsupportedRegulatoryDocumentKindError,
   DuplicateInvoiceRecordException,
   BuyerProfile,
+  PAYMENT_STATUS_REFRESH_SERVICE_TOKEN,
 } from '@openlinker/core/invoicing';
 import type {
   IInvoiceService,
   InvoiceRecord,
   InvoicingPort,
   IssuedDocumentContent,
+  IPaymentStatusRefreshService,
   RegulatoryDocument,
   StoredDocument,
 } from '@openlinker/core/invoicing';
@@ -46,6 +48,7 @@ import {
 } from '@openlinker/core/integrations';
 import type { IIntegrationsService } from '@openlinker/core/integrations';
 import { Logger } from '@openlinker/shared/logging';
+import type { AuthenticatedUser } from '../../auth/auth.types';
 import { InvoicingController } from './invoicing.controller';
 
 const NOW = new Date('2026-06-23T10:00:00.000Z');
@@ -271,6 +274,7 @@ describe('InvoicingController', () => {
   let invoiceService: jest.Mocked<IInvoiceService>;
   let orders: jest.Mocked<IOrderRecordService>;
   let integrations: jest.Mocked<IIntegrationsService>;
+  let paymentStatusRefreshService: jest.Mocked<IPaymentStatusRefreshService>;
 
   beforeEach(async () => {
     invoiceService = {
@@ -289,12 +293,17 @@ describe('InvoicingController', () => {
       getCapabilityAdapter: jest.fn(),
     } as unknown as jest.Mocked<IIntegrationsService>;
 
+    paymentStatusRefreshService = {
+      refreshByExternalId: jest.fn().mockResolvedValue({ outcome: 'updated', paymentStatus: 'paid' }),
+    } as unknown as jest.Mocked<IPaymentStatusRefreshService>;
+
     const moduleRef = await Test.createTestingModule({
       controllers: [InvoicingController],
       providers: [
         { provide: INVOICE_SERVICE_TOKEN, useValue: invoiceService },
         { provide: ORDER_RECORD_SERVICE_TOKEN, useValue: orders },
         { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: mockIntegrations },
+        { provide: PAYMENT_STATUS_REFRESH_SERVICE_TOKEN, useValue: paymentStatusRefreshService },
       ],
     }).compile();
 
@@ -1520,6 +1529,155 @@ describe('InvoicingController', () => {
 
       expect(warnSpy).toHaveBeenCalledWith(expect.not.stringContaining('bob+invoices@secret.pl'));
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[redacted-email]'));
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('POST /invoices/:invoiceId/mark-paid (#1362)', () => {
+    const actor: AuthenticatedUser = { id: 'user_1', username: 'admin', role: 'admin' };
+
+    it('should mark paid with the record providerInvoiceId and return the refreshed record', async () => {
+      invoiceService.getInvoiceById
+        .mockResolvedValueOnce(makeInvoiceRecord({ providerInvoiceId: 'inv-uuid-9' }))
+        .mockResolvedValueOnce(makeInvoiceRecord({ providerInvoiceId: 'inv-uuid-9' }));
+      const markPaid = jest.fn().mockResolvedValue(undefined);
+      integrations.getCapabilityAdapter.mockResolvedValue({ markPaid } as unknown as InvoicingPort);
+
+      const result = await controller.markInvoicePaid(
+        'inv_1',
+        { paidDate: '2026-07-08' },
+        actor,
+      );
+
+      expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith('conn_1', 'Invoicing');
+      expect(markPaid).toHaveBeenCalledWith({
+        externalInvoiceId: 'inv-uuid-9',
+        paidDate: new Date('2026-07-08'),
+      });
+      expect(paymentStatusRefreshService.refreshByExternalId).toHaveBeenCalledWith(
+        'conn_1',
+        'inv-uuid-9',
+      );
+      // 'updated' outcome (beforeEach default) re-reads the projection: once for
+      // validation, once for the fresh DTO.
+      expect(invoiceService.getInvoiceById).toHaveBeenCalledTimes(2);
+      expect(result.id).toBe('inv_1');
+    });
+
+    it('should default paidDate to today when omitted', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(
+        makeInvoiceRecord({ providerInvoiceId: 'inv-uuid-9' }),
+      );
+      const markPaid = jest.fn().mockResolvedValue(undefined);
+      integrations.getCapabilityAdapter.mockResolvedValue({ markPaid } as unknown as InvoicingPort);
+      jest.useFakeTimers().setSystemTime(new Date('2026-07-08T12:00:00Z'));
+
+      await controller.markInvoicePaid('inv_1', {}, actor);
+
+      expect(markPaid).toHaveBeenCalledWith({
+        externalInvoiceId: 'inv-uuid-9',
+        paidDate: new Date('2026-07-08T12:00:00Z'),
+      });
+      jest.useRealTimers();
+    });
+
+    it('should 404 when the invoice id is unknown', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(null);
+
+      await expect(controller.markInvoicePaid('missing', {}, actor)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('should 422 when the invoice has no provider invoice id', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(makeInvoiceRecord({ providerInvoiceId: null }));
+
+      await expect(controller.markInvoicePaid('inv_1', {}, actor)).rejects.toBeInstanceOf(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('should 501 when the adapter does not implement PaymentMarker', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(makeInvoiceRecord());
+      integrations.getCapabilityAdapter.mockResolvedValue({} as InvoicingPort);
+
+      await expect(controller.markInvoicePaid('inv_1', {}, actor)).rejects.toBeInstanceOf(
+        NotImplementedException,
+      );
+      expect(paymentStatusRefreshService.refreshByExternalId).not.toHaveBeenCalled();
+    });
+
+    it('should 502 when the live markPaid call fails', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(makeInvoiceRecord());
+      const markPaid = jest.fn().mockRejectedValue(new Error('inFakt 404'));
+      integrations.getCapabilityAdapter.mockResolvedValue({ markPaid } as unknown as InvoicingPort);
+
+      await expect(controller.markInvoicePaid('inv_1', {}, actor)).rejects.toBeInstanceOf(
+        BadGatewayException,
+      );
+      expect(paymentStatusRefreshService.refreshByExternalId).not.toHaveBeenCalled();
+    });
+
+    it('should still return 200 when the post-mark refresh outcome is "unchanged" (not an error)', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(makeInvoiceRecord());
+      const markPaid = jest.fn().mockResolvedValue(undefined);
+      integrations.getCapabilityAdapter.mockResolvedValue({ markPaid } as unknown as InvoicingPort);
+      paymentStatusRefreshService.refreshByExternalId.mockResolvedValue({
+        outcome: 'unchanged',
+        paymentStatus: 'unpaid',
+      });
+
+      const result = await controller.markInvoicePaid('inv_1', {}, actor);
+
+      expect(result).toBeDefined();
+      expect(markPaid).toHaveBeenCalled();
+      // No redundant re-read: 'unchanged' means the projection is already current.
+      expect(invoiceService.getInvoiceById).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still return 200 when the post-mark refresh throws (best-effort, swallowed)', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(makeInvoiceRecord());
+      const markPaid = jest.fn().mockResolvedValue(undefined);
+      integrations.getCapabilityAdapter.mockResolvedValue({ markPaid } as unknown as InvoicingPort);
+      paymentStatusRefreshService.refreshByExternalId.mockRejectedValue(new Error('transport error'));
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+      const result = await controller.markInvoicePaid('inv_1', {}, actor);
+
+      expect(result).toBeDefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('inv_1'));
+      // A swallowed refresh failure leaves the projection untouched - no re-read.
+      expect(invoiceService.getInvoiceById).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+
+    it('should warn (not block) when the local payment status is already paid', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(makeInvoiceRecord({ paymentStatus: 'paid' }));
+      const markPaid = jest.fn().mockResolvedValue(undefined);
+      integrations.getCapabilityAdapter.mockResolvedValue({ markPaid } as unknown as InvoicingPort);
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+      const result = await controller.markInvoicePaid('inv_1', {}, actor);
+
+      expect(result).toBeDefined();
+      expect(markPaid).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("already 'paid'"));
+      warnSpy.mockRestore();
+    });
+
+    it('should warn (not block) when marking a correction document as paid', async () => {
+      invoiceService.getInvoiceById.mockResolvedValue(
+        makeInvoiceRecord({ documentType: 'corrected' }),
+      );
+      const markPaid = jest.fn().mockResolvedValue(undefined);
+      integrations.getCapabilityAdapter.mockResolvedValue({ markPaid } as unknown as InvoicingPort);
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+      const result = await controller.markInvoicePaid('inv_1', {}, actor);
+
+      expect(result).toBeDefined();
+      expect(markPaid).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('correction document'));
       warnSpy.mockRestore();
     });
   });

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -54,6 +54,8 @@ import { ApiBearerAuth, ApiTags, ApiOperation, ApiProduces, ApiQuery, ApiRespons
 import { Response } from 'express';
 import { Logger } from '@openlinker/shared/logging';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { AuthenticatedUser } from '../../auth/auth.types';
 import {
   IIntegrationsService,
   INTEGRATIONS_SERVICE_TOKEN,
@@ -77,6 +79,9 @@ import {
   isBankAccountsReader,
   isBankAccountDefaultSetter,
   isInvoiceEmailSender,
+  isPaymentMarker,
+  PAYMENT_STATUS_REFRESH_SERVICE_TOKEN,
+  IPaymentStatusRefreshService,
 } from '@openlinker/core/invoicing';
 import type {
   InvoiceRecord,
@@ -113,6 +118,7 @@ import type { BulkIssueInvoiceResultDto } from './dto/bulk-issue-invoices-respon
 import { BankAccountResponseDto } from './dto/bank-account-response.dto';
 import { SendInvoiceEmailRequestDto } from './dto/send-invoice-email-request.dto';
 import { SendInvoiceEmailResponseDto } from './dto/send-invoice-email-response.dto';
+import { MarkInvoicePaidRequestDto } from './dto/mark-invoice-paid-request.dto';
 
 /** MIME → download-filename extension; the UPO is labelled by its real content type. */
 const EXTENSION_BY_CONTENT_TYPE: Readonly<Record<string, string>> = {
@@ -167,6 +173,8 @@ export class InvoicingController {
     private readonly orders: IOrderRecordService,
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrationsService: IIntegrationsService,
+    @Inject(PAYMENT_STATUS_REFRESH_SERVICE_TOKEN)
+    private readonly paymentStatusRefreshService: IPaymentStatusRefreshService,
   ) {}
 
   @Get('connections/:connectionId/bank-accounts')
@@ -829,6 +837,102 @@ export class InvoicingController {
     } catch (error) {
       throw this.toProviderBadGateway(error, 'sendByEmail', invoiceId);
     }
+  }
+
+  @Roles('admin')
+  @Post('invoices/:invoiceId/mark-paid')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Push an authoritative "paid" state to the provider (#1362)',
+    description:
+      'Marks an already-issued document as paid with the connection\'s Invoicing provider - ' +
+      'the outbound counterpart to the payment-status webhook (#1354). Useful for orders ' +
+      'settled before/outside the invoice itself (e.g. a marketplace order the buyer already ' +
+      'paid the marketplace for), which a provider has no bank statement to auto-match ' +
+      'against. After the provider accepts the mark, OL best-effort re-reads the payment ' +
+      'status to refresh its own projection; the returned `paymentStatus` reflects that ' +
+      'immediate re-read and may not yet show `paid` if the provider\'s own processing ' +
+      'hasn\'t completed - this is not a failure. 501 when the resolved adapter does not ' +
+      'implement PaymentMarker.',
+  })
+  @ApiResponse({ status: 200, description: 'Provider accepted the mark', type: InvoiceRecordResponseDto })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  @ApiResponse({ status: 422, description: 'Invoice not fully issued (no provider invoice id)' })
+  @ApiResponse({ status: 501, description: 'Adapter does not implement PaymentMarker' })
+  @ApiResponse({ status: 502, description: 'Invoicing provider unavailable or the mark failed' })
+  async markInvoicePaid(
+    @Param('invoiceId', invoiceIdPipe()) invoiceId: string,
+    @Body() dto: MarkInvoicePaidRequestDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<InvoiceRecordResponseDto> {
+    const record = await this.invoiceService.getInvoiceById(invoiceId);
+    if (!record) {
+      throw new NotFoundException(`Invoice not found: ${invoiceId}`);
+    }
+    if (!record.providerInvoiceId) {
+      throw new UnprocessableEntityException(
+        `Invoice ${invoiceId} has no provider invoice id - it may not be fully issued yet`,
+      );
+    }
+
+    const adapter = await this.resolveInvoicingAdapter(record.connectionId);
+    if (!isPaymentMarker(adapter)) {
+      throw new NotImplementedException(
+        `Adapter for invoice ${invoiceId} does not implement PaymentMarker`,
+      );
+    }
+
+    // Proportionate sanity warnings (not hard blocks): the operator may be
+    // asserting a financial fact that contradicts OL's own projection, so
+    // surface it in the log rather than silently marking. Payment is normally
+    // tracked on the original invoice, not on a correction document.
+    if (record.documentType === 'corrected') {
+      this.logger.warn(
+        `Marking a correction document (invoice ${invoiceId}) as paid; payment is normally tracked on the original invoice, not its correction`,
+      );
+    }
+    if (record.paymentStatus === 'paid' || record.paymentStatus === 'partially-paid') {
+      this.logger.warn(
+        `Invoice ${invoiceId} local payment status is already '${record.paymentStatus}' before marking paid; proceeding at operator request`,
+      );
+    }
+
+    this.logger.log(
+      `Marking invoice ${invoiceId} (connection=${record.connectionId}) as paid, requested by user ${user.id}`,
+    );
+
+    const paidDate = dto.paidDate ? new Date(dto.paidDate) : new Date();
+    try {
+      await adapter.markPaid({ externalInvoiceId: record.providerInvoiceId, paidDate });
+    } catch (error) {
+      throw this.toProviderBadGateway(error, 'markPaid', invoiceId);
+    }
+
+    // Best-effort refresh: the provider mark already succeeded above, so a
+    // hiccup here (throw, or a non-throwing 'unchanged' outcome because the
+    // provider's own async processing hasn't completed yet) must never fail
+    // the request - there is no reconciliation sweep for payment status
+    // today, so this immediate re-read is the only automatic attempt to
+    // update OL's local projection.
+    let projectionChanged = false;
+    try {
+      const result = await this.paymentStatusRefreshService.refreshByExternalId(
+        record.connectionId,
+        record.providerInvoiceId,
+      );
+      projectionChanged = result.outcome === 'updated';
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Post-markPaid payment status refresh failed for invoice ${invoiceId}: ${message}`);
+    }
+
+    // Only re-read when the refresh actually wrote a new status; on 'unchanged'
+    // / 'not-found' / 'unsupported' / a swallowed failure, `record` is already
+    // current so a second query would be redundant.
+    const refreshed = projectionChanged
+      ? await this.invoiceService.getInvoiceById(invoiceId)
+      : null;
+    return this.toDto(refreshed ?? record);
   }
 
   @Get('orders/:orderId/invoice')

--- a/apps/api/test/integration/operator-role-authz.int-spec.ts
+++ b/apps/api/test/integration/operator-role-authz.int-spec.ts
@@ -245,6 +245,16 @@ describe('Operator Role Authorization', () => {
         .expect(403);
     });
 
+    it('POST /invoices/:invoiceId/mark-paid → 403 (invoicing writes remain admin-only, #1362)', async () => {
+      const { http, operatorToken } = await seeds();
+      // Guard fires before the handler, so a fake id still yields 403 (not 404).
+      await http
+        .post('/v1/invoices/00000000-0000-4000-8000-000000000009/mark-paid')
+        .set('Authorization', `Bearer ${operatorToken}`)
+        .send({})
+        .expect(403);
+    });
+
     it('GET /prompt-templates → 403 (entire controller admin-only)', async () => {
       const { http, operatorToken } = await seeds();
       await http

--- a/apps/api/test/integration/viewer-role-authz.int-spec.ts
+++ b/apps/api/test/integration/viewer-role-authz.int-spec.ts
@@ -252,6 +252,16 @@ describe('Viewer Role Authorization', () => {
         .expect(403);
     });
 
+    it('POST /invoices/:invoiceId/mark-paid (#1362)', async () => {
+      const { http, viewerToken } = await seeds();
+      // Guard fires before the handler, so a fake id still yields 403 (not 404).
+      await http
+        .post('/v1/invoices/00000000-0000-4000-8000-000000000009/mark-paid')
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .send({})
+        .expect(403);
+    });
+
     it('POST /shipments/generate-label', async () => {
       const { http, viewerToken } = await seeds();
       await http

--- a/docs/plans/implementation-plan-infakt-invoice-payment-marker.md
+++ b/docs/plans/implementation-plan-infakt-invoice-payment-marker.md
@@ -1,0 +1,372 @@
+# Implementation Plan: Outbound Invoice Payment Marking (#1362)
+
+> Revised after TWO rounds of tech-lead + security review (both run as
+> subagents each round). Round 1 caught a factual error and naming/type-
+> placement issues (fixed). Round 2 verified all round-1 fixes against the
+> live tree and found no BLOCKING/IMPORTANT issues - only the two polish
+> items folded in below. See "Review corrections" callouts inline.
+
+## 1. Understand the task
+
+**Goal**: Give OpenLinker a way to push a "paid" state to an invoicing provider
+(starting with inFakt) when a marketplace/prepaid order is already settled on
+OL's side but the provider has no bank statement to auto-match against (e.g.
+Allegro/Erli orders - the buyer paid the marketplace, not the seller's bank
+account directly). Without this, such invoices sit as `unpaid` in the
+provider's own bookkeeping forever.
+
+This is the **outbound** counterpart to #1354 (already shipped, PR #1361),
+which consumes inFakt's `invoice_marked_as_paid` webhook and re-reads
+authoritative state via `PaymentStatusReader`. #1362 is the reverse
+direction: OL → provider.
+
+**Layer**: CORE (new sub-capability) + Integration (inFakt adapter) +
+Interface (HTTP endpoint). No FE, no DB migration.
+
+**Non-goals** (explicitly deferred, per issue's "OR" phrasing):
+- Automatic order-paid → mark-paid trigger. No such trigger currently exists
+  in `orders`/`sync` for any capability; wiring one is a separate, larger
+  piece of work. v1 ships a manual/operator-triggered HTTP endpoint only.
+- FE "Mark as paid" button - marked optional in the issue; skipped for v1.
+- A dedicated async task-status poll for inFakt's `paid.json` task reference.
+  See §7 for the honest risk framing of this decision (**corrected** - the
+  first draft over-claimed here).
+
+## 2. Feasibility (verified live against inFakt sandbox, 2026-07-08)
+
+`POST /async/invoices/{uuid}/paid.json` with body `{"invoice":{"paid_date":"YYYY-MM-DD"}}`:
+- Returns `201` with an async task envelope (`processing_code: 100`, "Zlecenie przyjęte" - i.e. "task accepted", NOT "task completed").
+- Immediate re-read of `GET /invoices/{uuid}.json` shows `status: 'paid'` and
+  `paid_date` set to the given date - confirmed on two separate sandbox
+  invoices, each with a ~2-3s gap between mark and re-read.
+- Re-marking an already-paid invoice is safe (still 201, no error) -
+  idempotent from OL's perspective. This was tested against real production
+  load characteristics of exactly one request each time, on an
+  otherwise-idle sandbox - see §7 for why this doesn't fully retire the
+  concurrent-double-mark question.
+- Invalid uuid → 404 with `{"error": "..."}"` - maps to the adapter's existing
+  `InfaktApiError` pattern.
+- `left_to_pay`/`paid_price` do not zero out via this call (provider-side
+  ledger quirk, not blocking - `toPaymentStatus()` in the adapter already
+  reads `status`/`paid_date`, not `left_to_pay`).
+
+## 3. Research - existing patterns to reuse
+
+- **Capability pattern**: `libs/core/src/invoicing/domain/ports/capabilities/invoice-email-sender.capability.ts`
+  is a template for the file shape (single-method optional sub-capability,
+  co-located `is*` guard, neutral vocabulary per ADR-026). **Correction from
+  tech review**: `InvoiceEmailSender` is the *minority* pattern for where its
+  command type lives (inline in the capability file). The majority pattern -
+  and the one that matters here because it's the capability's own read-side
+  sibling - is `PaymentStatusReader` → `PaymentStatusResult`, which lives in
+  `domain/types/invoicing.types.ts`. See §4 for the corrected type placement.
+- **Adapter pattern**: `InfaktInvoicingAdapter.sendByEmail` (`libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts`)
+  - thin `this.http.post(path, payload)` + a log line, with
+  `encodeURIComponent` around the caller-supplied id. `markPaid` follows the
+  same shape.
+- **Controller pattern**: `POST invoices/:invoiceId/send-email` (no
+  local-record refresh) and `POST invoices/:invoiceId/resend-to-ksef`
+  (persists the returned outcome back onto the record via
+  `IInvoiceService.applyRegulatoryClearance`). Our endpoint follows the
+  resend-to-ksef shape but refreshes via the **existing** `PaymentStatusRefreshService`
+  (#1354) rather than adding a new `IInvoiceService` mutation method - no new
+  core service surface needed. **Tech review flagged this trade-off
+  explicitly** - see §4 and §7.
+- **Manifest check (confirmed, no change needed)**: `infaktAdapterManifest`
+  (`libs/integrations/infakt/src/infakt-plugin.ts`) only declares the base
+  `'Invoicing'` capability; every prior sub-capability addition
+  (`PaymentStatusReader`, `InvoiceEmailSender`, `BankAccountsReader`, …) was
+  added without touching the manifest, because sub-capabilities are
+  runtime-narrowed via `is*` guards at call sites, not declared statically.
+  `markPaid` follows the same convention - **no manifest edit**.
+
+## 4. Design
+
+### CORE - `libs/core/src/invoicing`
+
+**Naming correction (tech review)**: the plan originally named this
+`InvoicePaymentMarker`/`isInvoicePaymentMarker`. The plan's own framing calls
+this capability "the outbound counterpart to `PaymentStatusReader`" - but
+`PaymentStatusReader` carries no `Invoice` prefix, so `InvoicePaymentMarker`
+breaks that stated pairing. Renamed to **`PaymentMarker`/`isPaymentMarker`**
+for symmetry (mirrors the `RegulatoryStatusReader` ↔ `RegulatoryResubmitter`/
+`RegulatoryTransmitter` pairs, none of which are inconsistently prefixed
+within a pair).
+
+**Type placement correction (tech review)**: `MarkInvoicePaidCommand` moves
+into `domain/types/invoicing.types.ts` alongside its read-side sibling
+`PaymentStatusResult`, rather than living inline in the capability file. This
+is closer to the engineering-standards.md "types live in separate files"
+rule and matches the majority precedent (`RegulatoryResubmitter`,
+`RegulatoryStatusReader`, `RegulatoryTransmitter`, `CorrectionIssuer` all do
+this; only `InvoiceEmailSender`/`BankAccountsReader` keep types inline).
+
+**Edit**: `domain/types/invoicing.types.ts` - add, next to `PaymentStatusResult`:
+
+```typescript
+/**
+ * Command to push an authoritative "paid" state to the provider for an
+ * already-issued document (#1362, the outbound counterpart to
+ * PaymentStatusReader). `externalInvoiceId` is always the provider-native id
+ * from a previously-issued InvoiceRecord - never client-supplied directly.
+ */
+export interface MarkInvoicePaidCommand {
+  externalInvoiceId: string;
+  paidDate: Date;
+}
+```
+
+**Round-2 note (shape asymmetry, non-blocking)**: `getPaymentStatus` (the
+read-side sibling) takes the whole `InvoiceRecord`, so it has `documentType`
+available even though it doesn't branch on it today. `MarkInvoicePaidCommand`
+only carries the two primitives - if a future fix wants `markPaid` to branch
+on `documentType` for correction records, this shape would need to widen
+(a breaking change), unlike `getPaymentStatus` where the record is already
+there. Flagged as a known asymmetry, not fixed for v1 - passing the raw
+`externalInvoiceId` keeps this capability's contract minimal and matches
+what the issue actually asked for.
+
+**New file**: `domain/ports/capabilities/payment-marker.capability.ts`
+
+```typescript
+import type { MarkInvoicePaidCommand } from '../../types/invoicing.types';
+import type { InvoicingPort } from '../invoicing.port';
+
+export interface PaymentMarker {
+  /** Push an authoritative "paid" state to the provider for an already-issued document. */
+  markPaid(cmd: MarkInvoicePaidCommand): Promise<void>;
+}
+
+export function isPaymentMarker(
+  adapter: InvoicingPort,
+): adapter is InvoicingPort & PaymentMarker { ... }
+```
+
+Doc comment mirrors `payment-status-reader.capability.ts`: neutral vocabulary
+litmus, explains this is the outbound counterpart to `PaymentStatusReader`
+(#1354), and is explicit that OL still re-reads via `PaymentStatusReader`
+afterward for confirmation - while being honest that this confirmation is
+**best-effort**, not guaranteed (see §7 - no reconciliation sweep exists for
+payment status today, unlike regulatory status).
+
+**Barrel**: add `export * from './domain/ports/capabilities/payment-marker.capability';`
+to `libs/core/src/invoicing/index.ts` (alongside the other capability
+exports). `MarkInvoicePaidCommand` is already exported via the existing
+`export * from './domain/types/invoicing.types';` line - no separate export
+needed.
+
+### Integration - `libs/integrations/infakt`
+
+**Edit**: `infakt-invoicing.adapter.ts`
+- Add `PaymentMarker` to the `implements` clause.
+- New method (the real code - no `.replace()` trick; the first draft's
+  illustrative snippet was misleading and is dropped):
+  ```typescript
+  async markPaid(cmd: MarkInvoicePaidCommand): Promise<void> {
+    await this.http.post(`async/invoices/${encodeURIComponent(cmd.externalInvoiceId)}/paid.json`, {
+      invoice: { paid_date: cmd.paidDate.toISOString().slice(0, 10) },
+    });
+    this.logger.log(`Infakt invoice ${cmd.externalInvoiceId} marked as paid`);
+  }
+  ```
+  Path and payload verified live against the sandbox in §2.
+- Date formatting: `YYYY-MM-DD` via `toISOString().slice(0, 10)`, matching
+  the verified wire format.
+- **Correction records** (noted per tech review): like the existing
+  `getPaymentStatus`, `markPaid` takes no `documentType`/kind context, so the
+  adapter cannot branch for a `'corrected'` record the way `getClearanceStatus`
+  does. Marking a correction as "paid" is likely not a meaningful operator
+  action (a correction adjusts amounts; payment tracking belongs on the
+  original invoice). Rather than a hard block (which could break a legitimate
+  flow), the controller now emits a proportionate soft-warning log when
+  `record.documentType === 'corrected'` and still proceeds - see the Interface
+  section. The adapter itself stays kind-agnostic, matching `getPaymentStatus`.
+
+**Test**: `__tests__/infakt-invoicing.adapter.spec.ts` - new `describe('markPaid', ...)`
+block asserting the adapter POSTs to `async/invoices/{id}/paid.json` with the
+correctly-formatted date.
+
+### Interface - `apps/api/src/invoicing/http`
+
+**New DTO**: `dto/mark-invoice-paid-request.dto.ts`
+```typescript
+export class MarkInvoicePaidRequestDto {
+  @IsOptional()
+  @IsISO8601()
+  paidDate?: string; // defaults to "today" (UTC) when omitted
+}
+```
+`@IsISO8601()` confirmed consistent with local precedent - `list-invoices-query.dto.ts`
+in this same module already uses `@IsOptional() @IsISO8601()` for
+`issuedFrom`/`issuedTo`.
+
+**Controller** (`invoicing.controller.ts`):
+- Inject `PAYMENT_STATUS_REFRESH_SERVICE_TOKEN` / `IPaymentStatusRefreshService`
+  in the constructor (new 4th dependency).
+- New endpoint:
+  ```
+  @Roles('admin')
+  @Post('invoices/:invoiceId/mark-paid')
+  @HttpCode(HttpStatus.OK)
+  async markInvoicePaid(
+    @Param('invoiceId', invoiceIdPipe()) invoiceId: string,
+    @Body() dto: MarkInvoicePaidRequestDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<InvoiceRecordResponseDto>
+  ```
+  Flow (mirrors `sendInvoiceEmail` + `resendToKsef`):
+  1. `getInvoiceById` → 404 if missing.
+  2. `record.providerInvoiceId` missing → 422 (not fully issued).
+  3. Resolve adapter via existing `resolveInvoicingAdapter`.
+  4. `isPaymentMarker` guard → 501 if unsupported.
+  5. **Security-review addition**: log the action at `log()` level (not
+     `warn`) BEFORE calling the provider, carrying the acting admin's
+     identity - `` `Marking invoice ${invoiceId} (connection=${record.connectionId}) as paid, requested by user ${user.id}` ``.
+     Log **only** `user.id` (a UUID, not PII) - never interpolate the whole
+     `user` object into the log line, in case `AuthenticatedUser` grows a
+     PII field later without this call site being revisited.
+     This is the controller's first write that asserts a financial fact to a
+     third party with zero automatic verification against the order's real
+     settlement state, so - unlike `resendToKsef`/`sendByEmail`, which only
+     log the operation - this one logs the actor too.
+     **Round-2 correction on framing**: this is NOT introducing a wholly new
+     repo-wide pattern - `ai-provider-settings.controller.ts` and
+     `content.controller.ts` already thread `@CurrentUser()` into their
+     service calls for a *persisted*, queryable actor record (stronger than
+     a log line). `InvoiceRecord` has no actor/audit column today, so this
+     endpoint falls back to log-only rather than a persisted actor id - that
+     richer pattern isn't available here without a migration, which is out
+     of scope for this issue.
+  6. `adapter.markPaid({ externalInvoiceId: record.providerInvoiceId, paidDate: dto.paidDate ? new Date(dto.paidDate) : new Date() })`,
+     provider failure → `toProviderBadGateway` (502).
+  7. Best-effort refresh: call `paymentStatusRefreshService.refreshByExternalId(record.connectionId, record.providerInvoiceId)`.
+     - If this **throws**, log a warning and swallow - the provider-side mark
+       already succeeded (step 6), so the request must not fail on a
+       local-projection read-back hiccup.
+     - If it returns normally with `outcome: 'unchanged'` (a **non-throwing**,
+       perfectly normal return when the async task hasn't completed yet -
+       this is NOT an error case and must be tested separately from the
+       throw case), that is expected and not a bug; the response still
+       reflects the pre-mark `paymentStatus` in that case. This is the
+       **accepted, documented behavior** (see §7) - not a defect, since
+       there is no reconciliation sweep to self-heal it later, but a
+       correctly-marked provider invoice is never lost, only the local
+       projection may lag until inFakt fires its own webhook or an operator
+       re-triggers a read.
+  8. Return `getInvoiceById(invoiceId)` (fresh read) mapped through `toDto`.
+- Swagger docs (`@ApiOperation`/`@ApiResponse`) mirroring `resend-to-ksef`'s
+  block: 200/404/422/501/502/403. The 200 description explicitly states:
+  "The provider mark succeeded; the returned `paymentStatus` reflects OL's
+  best-effort immediate re-read and may not yet show `paid` if the
+  provider's own processing hasn't completed - this is not a failure."
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `libs/core/src/invoicing/domain/types/invoicing.types.ts` | +`MarkInvoicePaidCommand` |
+| `libs/core/src/invoicing/domain/ports/capabilities/payment-marker.capability.ts` | new |
+| `libs/core/src/invoicing/index.ts` | +1 export line (capability; the type is already covered by the existing types-barrel export) |
+| `libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts` | +implements, +method |
+| `libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts` | +tests |
+| `apps/api/src/invoicing/http/dto/mark-invoice-paid-request.dto.ts` | new |
+| `apps/api/src/invoicing/http/invoicing.controller.ts` | +import, +DI, +endpoint |
+| `apps/api/src/invoicing/http/invoicing.controller.spec.ts` | +tests |
+
+No ORM/migration changes - `InvoiceRecord.paymentStatus` already exists
+(#1354). No module-wiring changes needed - `PaymentStatusRefreshService` is
+already provided by the core `InvoicingModule`, already imported into
+`InvoicingApiModule`. `infakt-plugin.ts` manifest is confirmed unchanged
+(§3).
+
+## 5. Testing
+
+- Adapter unit test: `markPaid` posts to the right path with the right body
+  (`__tests__/infakt-invoicing.adapter.spec.ts`).
+- Controller unit tests (`invoicing.controller.spec.ts`), `describe('markInvoicePaid', ...)`:
+  - success path, refresh returns `outcome: 'updated'` → 200, refreshed record.
+  - success path, refresh returns `outcome: 'unchanged'` → 200, record
+    reflects pre-mark state, **not treated as an error** (tech-review
+    addition - this branch is easy to conflate with the throw case if not
+    tested separately).
+  - `paidDate` omitted from the request → adapter called with today's date
+    (tech-review addition - the default-date branch deserves its own
+    assertion, not just incidental coverage from the success-path test).
+  - 404 - invoice not found.
+  - 422 - no `providerInvoiceId` (not fully issued).
+  - 501 - adapter doesn't implement `PaymentMarker`.
+  - 502 - `adapter.markPaid` throws.
+  - refresh service throws - request still returns 200 (best-effort refresh
+    doesn't fail the whole call).
+
+## 6. Validation
+
+- Architecture: capability lives in `domain/ports/capabilities/`, its command
+  type lives in `domain/types/invoicing.types.ts` (majority precedent), the
+  adapter implements it in infra, the controller stays thin (delegates to
+  `IInvoiceService`/`IPaymentStatusRefreshService`/capability adapter - never
+  a repository port). No cross-context barrel violations.
+- Naming: `PaymentMarker`/`isPaymentMarker`, symmetric with its read-side
+  sibling `PaymentStatusReader`/`isPaymentStatusReader`. File name
+  `payment-marker.capability.ts` matches the `*.capability.ts` convention.
+- No `any`, no `console.log`, no secrets, no new credential handling.
+- Quality gate: `pnpm lint && pnpm type-check && pnpm test` (scoped to
+  `@openlinker/core`, `@openlinker/integrations-infakt`, `@openlinker/api`
+  packages primarily).
+
+## 7. Risks / open questions (revised after review)
+
+- **No reconciliation sweep for payment status (corrected claim).** The
+  first draft of this plan claimed "the existing PaymentStatusReader /
+  reconciliation infra already provides eventual-consistency correction."
+  This is **false** - verified against the live tree: unlike
+  `RegulatoryStatusReconciliationService` (which `SchedulerService` runs
+  every 30 min via `invoicing.regulatoryStatus.reconcile`), there is **no**
+  `invoicing.paymentStatus.*` scheduled task. `PaymentStatusRefreshService`
+  is invoked in production from exactly one place today: the inbound
+  webhook path, triggered only when inFakt fires its own
+  `invoice_marked_as_paid` webhook. If our immediate post-`markPaid` refresh
+  doesn't observe the new state (async task still queued) AND inFakt never
+  separately webhooks back for an OL-triggered mark (plausible - that
+  webhook may only fire for provider-detected bank-statement matches), the
+  local `paymentStatus` projection can stay stale indefinitely even though
+  the provider-side mark succeeded and is durable. **Accepted risk for v1**:
+  the provider is the source of truth and is correctly updated regardless;
+  only OL's own read-model cache of that fact may lag. A fast-follow issue
+  for a `invoicing.paymentStatus.reconcile` sweep (mirroring the regulatory
+  one) is a reasonable enhancement but explicitly out of scope here.
+- **Async-mark concurrency (double-click) is verified idempotent, but only
+  under light-load manual testing.** Re-marking an already-paid sandbox
+  invoice returned 201 twice with no error, across two manual sandbox calls.
+  This is not the same as verifying provider-side behavior under a genuine
+  race (two near-simultaneous marks against the same still-in-flight async
+  task). No idempotency guard is added on OL's side regardless, because
+  `markPaid` never creates a new fiscal document the way `issueInvoice`
+  does - it is a repeatable state-set operation, and even a double-fired
+  provider task converges on the same terminal state (`paid`). This is a
+  reasonable inference, not a fully load-tested guarantee.
+- **Pre-check against local `paymentStatus` (implemented as a soft-warn).**
+  The endpoint does not hard-block when `record.paymentStatus` is already
+  `'paid'`/`'partially-paid'` before allowing the mark (no automatic
+  order-paid verification exists yet, so blocking would be premature), but it
+  now emits a proportionate warning log in that case and proceeds at operator
+  request - so an admin marking an order paid that OL's own projection
+  disagrees with is at least surfaced in the log. Full automatic verification
+  against the order's real settlement state remains a v1 non-goal.
+- **Financial-write audit trail**: addressed in §4 step 5 - this endpoint
+  now logs the acting admin's identity (`user.id` only, never the whole user
+  object) before the provider call. None of the other invoicing write
+  endpoints do even this log-only version today; not retrofitted here. Note
+  this is a *weaker* control than the persisted-actor pattern already used
+  by `ai-provider-settings`/`content` controllers (queryable, durable) -
+  log-only is the fallback because `InvoiceRecord` has no actor column and
+  adding one is a migration, out of scope for this issue.
+- **Stale local `paymentStatus` cannot cause an incorrect authorization
+  decision elsewhere (confirmed, round 2).** `InvoiceRecord.paymentStatus`
+  (this context) and `OrderRecord.paymentStatus` (the `orders` context,
+  which gates `ShipmentDispatchService`'s dispatch-blocking check) are
+  fully independent fields with independent `PaymentStatus` union types -
+  no shared code path reads `InvoiceRecord.paymentStatus`/`isPaid` outside
+  this endpoint and the existing webhook refresh path. So the staleness risk
+  above is a pure UX/reporting concern, never a security or business-logic
+  one.

--- a/libs/core/src/invoicing/domain/ports/capabilities/payment-marker.capability.spec.ts
+++ b/libs/core/src/invoicing/domain/ports/capabilities/payment-marker.capability.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Payment Marker capability guard — unit tests (#1362)
+ *
+ * @module libs/core/src/invoicing/domain/ports/capabilities
+ */
+import type { InvoicingPort } from '../invoicing.port';
+import { type PaymentMarker, isPaymentMarker } from './payment-marker.capability';
+
+const base: InvoicingPort = {
+  issueInvoice: jest.fn(),
+  getInvoice: jest.fn(),
+  upsertCustomer: jest.fn(),
+  getSupportedDocumentTypes: jest.fn(),
+};
+
+describe('isPaymentMarker', () => {
+  it('returns true when the adapter implements markPaid', () => {
+    const marker: InvoicingPort & PaymentMarker = {
+      ...base,
+      markPaid: jest.fn(),
+    };
+    expect(isPaymentMarker(marker)).toBe(true);
+  });
+
+  it('returns false on a base InvoicingPort without outbound payment marking', () => {
+    expect(isPaymentMarker(base)).toBe(false);
+  });
+});

--- a/libs/core/src/invoicing/domain/ports/capabilities/payment-marker.capability.ts
+++ b/libs/core/src/invoicing/domain/ports/capabilities/payment-marker.capability.ts
@@ -1,0 +1,47 @@
+/**
+ * Payment Marker Capability (#1362)
+ *
+ * The WRITE half of the payment-status seam (ADR-002 sub-capability pattern,
+ * ADR-026 country-agnostic) - the outbound counterpart to `PaymentStatusReader`
+ * (#1354). An optional sub-capability of `InvoicingPort`: an invoicing adapter
+ * that can push an authoritative "paid" state to the provider for an
+ * already-issued document declares `implements PaymentMarker`.
+ *
+ * Why this exists: some orders are already settled before the invoice is ever
+ * issued (e.g. a marketplace order - the buyer paid the marketplace, not the
+ * seller's bank account directly). A provider with no bank statement to
+ * auto-match against would otherwise show such an invoice as unpaid forever.
+ *
+ * `markPaid` is a fire-and-confirm write, not a query - a caller that wants
+ * OL's own `InvoiceRecord.paymentStatus` projection updated afterward should
+ * separately invoke `PaymentStatusReader.getPaymentStatus` (or the
+ * `PaymentStatusRefreshService` that wraps it). There is currently no
+ * scheduled reconciliation sweep for payment status (unlike regulatory
+ * status), so that follow-up read is best-effort, not guaranteed.
+ *
+ * Call sites resolve the `Invoicing` capability adapter per-connection, then
+ * narrow with `isPaymentMarker` before invoking - a provider without an
+ * outbound payment-marking concept simply doesn't implement it.
+ *
+ * Neutral-vocabulary litmus (ADR-026): no `paid_date`/`left_to_pay`/`faktura` here.
+ *
+ * @module libs/core/src/invoicing/domain/ports/capabilities
+ */
+import type { MarkInvoicePaidCommand } from '../../types/invoicing.types';
+import type { InvoicingPort } from '../invoicing.port';
+
+export interface PaymentMarker {
+  /**
+   * Push an authoritative "paid" state to the provider for an already-issued
+   * document. A transport/infrastructure failure throws for the caller to
+   * handle; a successful call means the provider accepted the mark (which may
+   * itself be processed asynchronously provider-side).
+   */
+  markPaid(cmd: MarkInvoicePaidCommand): Promise<void>;
+}
+
+export function isPaymentMarker(
+  adapter: InvoicingPort,
+): adapter is InvoicingPort & PaymentMarker {
+  return typeof (adapter as Partial<PaymentMarker>).markPaid === 'function';
+}

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -171,6 +171,20 @@ export interface PaymentStatusResult {
   paymentStatus: PaymentStatus;
 }
 
+/**
+ * Command to push an authoritative "paid" state to the provider for an
+ * already-issued document (#1362) - the OUTBOUND counterpart to
+ * `PaymentStatusReader`. `externalInvoiceId` is always the provider-native id
+ * read from a previously-issued `InvoiceRecord.providerInvoiceId` - never
+ * client-supplied directly. Country/provider-agnostic: no `paid_date`
+ * vocabulary here - the adapter formats `paidDate` in whatever wire shape its
+ * provider expects.
+ */
+export interface MarkInvoicePaidCommand {
+  externalInvoiceId: string;
+  paidDate: Date;
+}
+
 /** Neutral B2B/B2C axis. Drives document-type policy in a future rules layer, not here. */
 export const BuyerTypeValues = ['company', 'private'] as const;
 export type BuyerType = (typeof BuyerTypeValues)[number];

--- a/libs/core/src/invoicing/index.ts
+++ b/libs/core/src/invoicing/index.ts
@@ -21,6 +21,8 @@ export * from './domain/ports/invoicing.port';
 export * from './domain/ports/capabilities/regulatory-status-reader.capability';
 // Re-exports both `PaymentStatusReader` and `isPaymentStatusReader` (#1354).
 export * from './domain/ports/capabilities/payment-status-reader.capability';
+// Re-exports both `PaymentMarker` and `isPaymentMarker` (#1362).
+export * from './domain/ports/capabilities/payment-marker.capability';
 export * from './domain/ports/capabilities/regulatory-transmitter.capability';
 export * from './domain/ports/capabilities/regulatory-resubmitter.capability';
 export * from './domain/ports/capabilities/correction-issuer.capability';

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -647,6 +647,46 @@ describe('InfaktInvoicingAdapter', () => {
     });
   });
 
+  describe('markPaid (#1362)', () => {
+    it('should POST the mark-paid task with the formatted date', async () => {
+      http.seed('POST', 'async/invoices/inv-uuid-1/paid.json', {});
+
+      await adapter.markPaid({
+        externalInvoiceId: 'inv-uuid-1',
+        paidDate: new Date('2026-07-08T12:34:56Z'),
+      });
+
+      expect(http.calls).toContainEqual({
+        method: 'POST',
+        path: 'async/invoices/inv-uuid-1/paid.json',
+        body: { invoice: { paid_date: '2026-07-08' } },
+      });
+    });
+
+    it('should URL-encode the external invoice id', async () => {
+      http.seed('POST', 'async/invoices/inv%2Fuuid/paid.json', {});
+
+      await adapter.markPaid({
+        externalInvoiceId: 'inv/uuid',
+        paidDate: new Date('2026-07-08T00:00:00Z'),
+      });
+
+      expect(http.calls[0]?.path).toBe('async/invoices/inv%2Fuuid/paid.json');
+    });
+
+    it('should propagate a transport error', async () => {
+      http.seedError(
+        'POST',
+        'async/invoices/inv-uuid-1/paid.json',
+        new InfaktApiError('not found', 404, {}),
+      );
+
+      await expect(
+        adapter.markPaid({ externalInvoiceId: 'inv-uuid-1', paidDate: new Date('2026-07-08') }),
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+  });
+
   describe('resubmitForClearance (#1356)', () => {
     function issuedRecord(): InvoiceRecord {
       return new InvoiceRecord(

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -32,6 +32,8 @@ import type {
   IssueInvoiceCommand,
   IssueInvoiceResult,
   InvoicingPort,
+  MarkInvoicePaidCommand,
+  PaymentMarker,
   PaymentStatus,
   PaymentStatusReader,
   PaymentStatusResult,
@@ -267,6 +269,7 @@ export class InfaktInvoicingAdapter
     InvoicingPort,
     RegulatoryStatusReader,
     PaymentStatusReader,
+    PaymentMarker,
     RegulatoryResubmitter,
     CorrectionIssuer,
     RegulatoryDocumentReader,
@@ -559,6 +562,30 @@ export class InfaktInvoicingAdapter
     );
 
     return { paymentStatus: toPaymentStatus(invoice) };
+  }
+
+  /**
+   * `PaymentMarker.markPaid` (#1362) - the outbound counterpart to
+   * `getPaymentStatus`: push an authoritative "paid" state to inFakt for an
+   * order settled elsewhere (e.g. a marketplace order - the buyer paid the
+   * marketplace, not the seller's bank account, so inFakt has no bank
+   * statement to auto-match against). Verified live against the sandbox
+   * (2026-07-08): `POST /async/invoices/{uuid}/paid.json` returns 201 with an
+   * async task envelope (`processing_code: 100`, "task accepted" - not
+   * "completed"), and an immediate re-read shows `status: 'paid'` /
+   * `paid_date` set. Re-marking an already-paid invoice is safe (still 201,
+   * no error).
+   *
+   * Async on inFakt's side: the caller is responsible for re-reading via
+   * `getPaymentStatus` afterward if it needs OL's own projection updated -
+   * this method only confirms the provider ACCEPTED the mark, not that its
+   * processing has finished.
+   */
+  async markPaid(cmd: MarkInvoicePaidCommand): Promise<void> {
+    await this.http.post(`async/invoices/${encodeURIComponent(cmd.externalInvoiceId)}/paid.json`, {
+      invoice: { paid_date: cmd.paidDate.toISOString().slice(0, 10) },
+    });
+    this.logger.log(`Infakt invoice ${cmd.externalInvoiceId} marked as paid`);
   }
 
   async issueCorrection(cmd: IssueCorrectionCommand): Promise<IssueInvoiceResult> {


### PR DESCRIPTION
## What & why

Closes #1362.

Adds the **outbound** half of payment-status sync as the write-half counterpart to the `PaymentStatusReader` shipped in #1354 (epic #1279). OpenLinker can now push an authoritative "paid" state to the invoicing provider for a document that was settled elsewhere (e.g. a marketplace order the buyer already paid the marketplace for), which a provider with no matching bank statement would otherwise show as unpaid forever.

## Changes

- **CORE**: new `PaymentMarker` sub-capability (`markPaid(cmd)`) + co-located `isPaymentMarker` guard in `libs/core/src/invoicing/domain/ports/capabilities/`; neutral `MarkInvoicePaidCommand` in `invoicing.types.ts`; barrel export. Country-agnostic per ADR-026 (no provider vocabulary in core).
- **Integration**: `InfaktInvoicingAdapter` implements `PaymentMarker` against `POST /async/invoices/{uuid}/paid.json` (verified live against the inFakt sandbox 2026-07-08).
- **Interface**: `POST /invoices/:invoiceId/mark-paid` (`@Roles('admin')`), capability-gated with 501 when the resolved adapter doesn't implement `PaymentMarker`. `externalInvoiceId` is always derived server-side from `InvoiceRecord.providerInvoiceId`, never client-supplied. After the provider accepts the mark, OL does a best-effort re-read of payment status to refresh its own projection (a hiccup there never fails the request).

## Naming note

The issue AC names the capability `InvoicePaymentMarker` / `isInvoicePaymentMarker`. I shipped `PaymentMarker` / `isPaymentMarker` instead, to mirror its direct read-half counterpart `PaymentStatusReader` / `isPaymentStatusReader` in the same directory. This keeps the write/read pair symmetric.

## Tests

- Controller unit spec: 10 cases (happy path, default-today date, 404 / 422 / 501 / 502, best-effort refresh `unchanged` + thrown, warn-not-block on already-paid and on a correction document).
- Capability guard unit spec (mirrors the `invoice-email-sender` guard spec).
- DTO validation spec: `paidDate` constrained to a calendar date (`YYYY-MM-DD`) so a full ISO datetime near local midnight can't roll the settlement date back a day via the adapter's UTC slice.
- Adapter spec: mark-paid POST wire shape, external-id URL encoding, transport-error propagation.
- Authz int-specs (`viewer` + `operator`): the new write endpoint returns 403 for non-admin roles, alongside the existing invoicing writes.

## Quality gate

`pnpm type-check` (core + api), unit tests, and the two authz int-specs all pass locally. Integration suite requires Docker (CI covers the rest).
