### PR TITLE
fix(web): gate trigger-sync jobs by capability, add invoicing reconcile trigger

### DIFF
--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
@@ -73,6 +73,59 @@ describe('TriggerSyncDialog', () => {
       expect(labels).not.toContain('Sync all products'); // requires ProductMaster
     });
 
+    it('should render the Invoicing reconcile trigger for Invoicing-capable connections', () => {
+      const ksefConnection = {
+        ...sampleConnection,
+        platformType: 'ksef' as const,
+        supportedCapabilities: ['Invoicing'],
+        enabledCapabilities: ['Invoicing' as const],
+      };
+      const mockApi = createMockApiClient();
+      renderWithProviders(
+        <TriggerSyncDialog connection={ksefConnection} open onOpenChange={vi.fn()} />,
+        { apiClient: mockApi },
+      );
+      const options = screen.getAllByRole('option');
+      const labels = options.map((o) => o.textContent);
+      expect(labels).toContain('Reconcile regulatory status');
+      // Inventory fan-out job is now gated to InventoryMaster — must not leak here.
+      expect(labels).not.toContain('Propagate inventory to marketplaces');
+      expect(labels).not.toContain('Sync all products');
+    });
+
+    it('should hide the inventory propagation job when the connection lacks InventoryMaster', () => {
+      const invoicingOnlyConnection = {
+        ...sampleConnection,
+        platformType: 'ksef' as const,
+        supportedCapabilities: ['Invoicing'],
+        enabledCapabilities: ['Invoicing' as const],
+      };
+      const mockApi = createMockApiClient();
+      renderWithProviders(
+        <TriggerSyncDialog connection={invoicingOnlyConnection} open onOpenChange={vi.fn()} />,
+        { apiClient: mockApi },
+      );
+      const labels = screen.getAllByRole('option').map((o) => o.textContent);
+      expect(labels).not.toContain('Propagate inventory to marketplaces');
+    });
+
+    it('should render a neutral empty-state and disable submit when no triggers match', () => {
+      const shippingOnlyConnection = {
+        ...sampleConnection,
+        platformType: 'inpost' as const,
+        supportedCapabilities: ['ShippingProviderManager'],
+        enabledCapabilities: [],
+      };
+      const mockApi = createMockApiClient();
+      renderWithProviders(
+        <TriggerSyncDialog connection={shippingOnlyConnection} open onOpenChange={vi.fn()} />,
+        { apiClient: mockApi },
+      );
+      expect(screen.getByText(/no sync triggers available for this connection/i)).toBeInTheDocument();
+      expect(screen.queryByRole('combobox', { name: /job type/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /trigger/i })).toBeDisabled();
+    });
+
     it('should show job description for selected job type', () => {
       renderDialog();
       expect(
@@ -236,6 +289,34 @@ describe('TriggerSyncDialog', () => {
           expect.objectContaining({
             jobType: 'master.product.syncByExternalId',
             payload: { schemaVersion: 1, externalId: 'ext-999', objectType: 'combination' },
+          }),
+        );
+      });
+    });
+
+    it('should enqueue the Invoicing reconcile job with schemaVersion and default limit', async () => {
+      const ksefConnection = {
+        ...sampleConnection,
+        platformType: 'ksef' as const,
+        supportedCapabilities: ['Invoicing'],
+        enabledCapabilities: ['Invoicing' as const],
+      };
+      const mockApi = createMockApiClient();
+      renderWithProviders(
+        <TriggerSyncDialog connection={ksefConnection} open onOpenChange={vi.fn()} />,
+        { apiClient: mockApi },
+      );
+
+      // Reconcile is the only trigger, so it is selected by default. Its optional
+      // limit field pre-fills to 100.
+      fireEvent.click(screen.getByRole('button', { name: /trigger/i }));
+
+      await waitFor(() => {
+        expect(mockApi.syncJobs.enqueue).toHaveBeenCalledWith(
+          expect.objectContaining({
+            connectionId: ksefConnection.id,
+            jobType: 'invoicing.regulatoryStatus.reconcile',
+            payload: { schemaVersion: 1, limit: 100 },
           }),
         );
       });

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
@@ -117,7 +117,25 @@ const ALL_TRIGGERABLE_JOBS: TriggerableJob[] = [
         placeholder: 'ol_product_…',
       },
     ],
-    // No requiredCapability — this is a cross-connection fan-out job, valid for any active connection.
+    // Gated to InventoryMaster (the capability whose inventory it propagates) so it
+    // no longer leaks onto invoicing/shipping-only connections (KSeF, InPost). See #1474.
+    requiredCapability: 'InventoryMaster',
+  },
+  {
+    jobType: 'invoicing.regulatoryStatus.reconcile',
+    label: 'Reconcile regulatory status',
+    description: 'Poll the tax authority for clearance status of submitted invoices.',
+    payloadFields: [
+      {
+        name: 'limit',
+        label: 'Max invoices',
+        required: false,
+        type: 'number',
+        defaultValue: '100',
+        placeholder: '100',
+      },
+    ],
+    requiredCapability: 'Invoicing',
   },
 ];
 
@@ -166,6 +184,7 @@ export function TriggerSyncDialog({
   const { showToast } = useToast();
 
   const selectedJob = triggerableJobs.find((j) => j.jobType === selectedJobType);
+  const hasTriggers = triggerableJobs.length > 0;
 
   useEffect(() => {
     if (open) {
@@ -248,19 +267,27 @@ export function TriggerSyncDialog({
             </Alert>
           ) : null}
 
-          <FormField label="Job type" name="jobType">
-            <Select
-              value={selectedJobType}
-              onChange={(e) => handleJobTypeChange(e.target.value)}
-              disabled={enqueueSyncJob.isPending}
-            >
-              {triggerableJobs.map((job) => (
-                <option key={job.jobType} value={job.jobType}>
-                  {job.label}
-                </option>
-              ))}
-            </Select>
-          </FormField>
+          {!hasTriggers ? (
+            <p className="trigger-sync-dialog__description muted-text" role="status">
+              No sync triggers available for this connection.
+            </p>
+          ) : null}
+
+          {hasTriggers ? (
+            <FormField label="Job type" name="jobType">
+              <Select
+                value={selectedJobType}
+                onChange={(e) => handleJobTypeChange(e.target.value)}
+                disabled={enqueueSyncJob.isPending}
+              >
+                {triggerableJobs.map((job) => (
+                  <option key={job.jobType} value={job.jobType}>
+                    {job.label}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+          ) : null}
 
           {selectedJob?.description ? (
             <p className="trigger-sync-dialog__description muted-text">{selectedJob.description}</p>
@@ -293,7 +320,7 @@ export function TriggerSyncDialog({
           <Button
             tone="primary"
             onClick={() => void handleSubmit()}
-            disabled={enqueueSyncJob.isPending || intentKey === null}
+            disabled={enqueueSyncJob.isPending || intentKey === null || !hasTriggers}
           >
             {enqueueSyncJob.isPending ? 'Enqueuing…' : 'Trigger'}
           </Button>


### PR DESCRIPTION
## What & why

The connection-level "Trigger sync" dialog (`apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx`) showed the wrong (and only) trigger for capability-specialized connections. On a KSeF connection (`supportedCapabilities: ['Invoicing']`) the sole option offered was "Propagate inventory to marketplaces", which is meaningless for an invoicing connection; the same leak hit shipping-only InPost. There was also no UI trigger for the `Invoicing` capability at all.

## Changes (FE-only)

1. **Add an Invoicing trigger** to `ALL_TRIGGERABLE_JOBS`: `invoicing.regulatoryStatus.reconcile` (label "Reconcile regulatory status", `requiredCapability: 'Invoicing'`) with one optional number field `limit` (default 100). The dialog already injects `{ schemaVersion: 1 }`, so no special-casing is needed. The backend handler already exists and is connection-scoped.
2. **Gate `inventory.propagateToMarketplaces`** with `requiredCapability: 'InventoryMaster'` so it stops appearing on invoicing/shipping-only connections (KSeF, InPost).
3. **Empty-state**: when a connection has no matching triggers (e.g. InPost `ShippingProviderManager`), render a neutral "No sync triggers available for this connection" message and disable submit instead of showing an empty select.

## How to test

- KSeF (`Invoicing`) connection: shows "Reconcile regulatory status"; enqueues `invoicing.regulatoryStatus.reconcile` with `{ schemaVersion: 1, limit }`; the inventory job is not listed.
- InPost (`ShippingProviderManager`) connection: neutral empty-state, submit disabled.
- Inventory-capable connections still show the propagation job.

`TriggerSyncDialog.test.tsx` updated with coverage for the Invoicing trigger, the hidden inventory job, the empty-state, and the reconcile enqueue payload.

## Checks

- `apps/web` type-check: pass
- `TriggerSyncDialog.test.tsx` (vitest): 23 passed
- eslint on changed files: 0 errors

Closes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)