### PR TITLE
fix(web): correct InPost webhook runbook URL, self-service copy, and HMAC secret step

### DIFF
--- a/apps/web/src/features/connections/api/connections.api.ts
+++ b/apps/web/src/features/connections/api/connections.api.ts
@@ -6,6 +6,7 @@ import type {
   ConnectionTestResult,
   CreateConnectionInput,
   InstallWebhooksResult,
+  RotateWebhookSecretResult,
   SubiektBankAccount,
   SubiektCashRegister,
   UpdateConnectionInput,
@@ -20,6 +21,7 @@ export interface ConnectionsApi {
   getDiagnostics: (connectionId: string) => Promise<ConnectionDiagnostics>;
   getById: (connectionId: string) => Promise<Connection>;
   installWebhooks: (connectionId: string) => Promise<InstallWebhooksResult>;
+  rotateWebhookSecret: (connectionId: string) => Promise<RotateWebhookSecretResult>;
   list: (filters?: ConnectionFilters) => Promise<Connection[]>;
   setDefaultBankAccount: (connectionId: string, accountId: string) => Promise<void>;
   test: (connectionId: string) => Promise<ConnectionTestResult>;
@@ -90,6 +92,12 @@ export function createConnectionsApi(request: ApiRequest): ConnectionsApi {
       return request<InstallWebhooksResult>(`/connections/${connectionId}/webhooks/install`, {
         method: 'POST',
       });
+    },
+    rotateWebhookSecret(connectionId): Promise<RotateWebhookSecretResult> {
+      return request<RotateWebhookSecretResult>(
+        `/connections/${connectionId}/webhooks/secret/rotate`,
+        { method: 'POST' },
+      );
     },
     list(filters): Promise<Connection[]> {
       return request<Connection[]>(`/connections${buildQuery(filters)}`);

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -161,6 +161,17 @@ export interface InstallWebhooksResult {
   warning?: string;
 }
 
+/**
+ * Response from `POST /connections/:id/webhooks/secret/rotate`. The plaintext
+ * secret is revealed exactly once here and is never retrievable again — callers
+ * must surface it immediately for the operator to store.
+ */
+export interface RotateWebhookSecretResult {
+  secret: string;
+  revealedOnce: boolean;
+  warning: string;
+}
+
 export interface ConnectionDiagnostics {
   connectionId: string;
   connectionName: string;

--- a/apps/web/src/features/connections/hooks/use-rotate-webhook-secret-mutation.ts
+++ b/apps/web/src/features/connections/hooks/use-rotate-webhook-secret-mutation.ts
@@ -1,0 +1,25 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import type { RotateWebhookSecretResult } from '../api/connections.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+/**
+ * Rotate the OpenLinker webhook HMAC secret for a connection
+ * (`POST /connections/:id/webhooks/secret/rotate`). Used by the manual webhook
+ * runbooks (e.g. InPost, #1473) where the operator must configure the same
+ * secret on the source platform so signed deliveries verify.
+ *
+ * The plaintext secret is revealed exactly once in the response, so the caller
+ * must surface it immediately. No cache invalidation — the secret is never read
+ * back, only generated.
+ */
+export function useRotateWebhookSecretMutation(): UseMutationResult<
+  RotateWebhookSecretResult,
+  Error,
+  string
+> {
+  const apiClient = useApiClient();
+
+  return useMutation({
+    mutationFn: (connectionId: string) => apiClient.connections.rotateWebhookSecret(connectionId),
+  });
+}

--- a/apps/web/src/features/connections/index.ts
+++ b/apps/web/src/features/connections/index.ts
@@ -19,6 +19,7 @@ export type {
   ConnectionDiagnostics,
   RecentJobSummary,
   InstallWebhooksResult,
+  RotateWebhookSecretResult,
   CreateConnectionInput,
   UpdateConnectionInput,
   PlatformType,
@@ -30,6 +31,7 @@ export { useConnectionsQuery } from './hooks/use-connections-query';
 export { useCreateConnectionMutation } from './hooks/use-create-connection-mutation';
 export { useProductMasterConnections } from './hooks/use-product-master-connections';
 export { useConfigureWebhooksMutation } from './hooks/use-configure-webhooks-mutation';
+export { useRotateWebhookSecretMutation } from './hooks/use-rotate-webhook-secret-mutation';
 export { useUpdateConnectionCredentialsMutation } from './hooks/use-update-connection-credentials-mutation';
 export { useUpdateConnectionMutation } from './hooks/use-update-connection-mutation';
 export { useBankAccountsQuery } from './hooks/use-bank-accounts-query';

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3257,6 +3257,18 @@ textarea,
   border-bottom: none;
 }
 
+/* ── InPost webhook runbook (#1473) ── */
+.action-list__item-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.inpost-webhook-runbook__secret {
+  margin-top: var(--space-3);
+}
+
 /* Diagnostics errors */
 .diagnostics-errors {
   margin-top: 0.5rem;

--- a/apps/web/src/plugins/inpost/components/inpost-structured-section.tsx
+++ b/apps/web/src/plugins/inpost/components/inpost-structured-section.tsx
@@ -6,6 +6,9 @@
  *
  *   - Environment (sandbox / production) → flat `config.environment`
  *   - Organization id → flat `config.organizationId`
+ *   - OpenLinker public API base URL → flat `config.openlinkerCallbackBaseUrl`
+ *     (the host-generic callback field; used by the webhook runbook to build the
+ *     inbound webhook URL InPost delivers to, #1473)
  *   - Sender address (name?, email, phone, street, building number, city,
  *     postcode, country) → whole-object `config.senderAddress`
  *
@@ -84,6 +87,26 @@ export function InpostStructuredSection({
           placeholder="123456"
           disabled={!configIsParseable}
           invalid={Boolean(form.formState.errors.inpostOrganizationId)}
+        />
+      </FormField>
+
+      <FormField
+        label={t('inpost.settings.apiBaseUrl.label', 'OpenLinker public API base URL (optional)')}
+        name="openlinkerCallbackBaseUrl"
+        error={form.formState.errors.openlinkerCallbackBaseUrl?.message}
+        description={t(
+          'inpost.settings.apiBaseUrl.description',
+          "OpenLinker's public API URL that serves inbound webhooks (POST /webhooks) — this is where InPost delivers tracking events, so it must be the API host, not this admin UI. Leave blank only when the API and this UI share one origin (e.g. behind a single reverse proxy); otherwise set the API's public base URL. Drives the webhook URL shown in the setup runbook below.",
+        )}
+      >
+        <Input
+          value={form.watch('openlinkerCallbackBaseUrl') ?? ''}
+          onChange={(event) =>
+            syncStructuredToJson('openlinkerCallbackBaseUrl', event.target.value)
+          }
+          placeholder="https://api.openlinker.example"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.openlinkerCallbackBaseUrl)}
         />
       </FormField>
 

--- a/apps/web/src/plugins/inpost/components/inpost-webhook-runbook.test.tsx
+++ b/apps/web/src/plugins/inpost/components/inpost-webhook-runbook.test.tsx
@@ -1,12 +1,13 @@
 /**
- * InpostWebhookRunbook — component tests (#768)
+ * InpostWebhookRunbook — component tests (#768, #1473)
  *
- * Covers the per-connection webhook URL rendering and the copy-email-template
- * affordance.
+ * Covers the per-connection webhook URL (configured public API base + origin
+ * fallback), the dashboard-first runbook copy, the HMAC secret-rotation step,
+ * and the fallback copy-email-template affordance.
  */
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { renderWithProviders } from '../../../test/test-utils';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
 import type { Connection } from '../../../features/connections';
 import { InpostWebhookRunbook } from './inpost-webhook-runbook';
 
@@ -30,15 +31,75 @@ function makeConnection(overrides: Partial<Connection> = {}): Connection {
 }
 
 describe('InpostWebhookRunbook', () => {
-  it('renders the per-connection webhook endpoint URL', () => {
+  it('builds the webhook URL from the configured public OL API base URL when set', () => {
+    renderWithProviders(
+      <InpostWebhookRunbook
+        connection={makeConnection({
+          config: { openlinkerCallbackBaseUrl: 'https://api.openlinker.example' },
+        })}
+      />,
+    );
+    expect(
+      screen.getByText('https://api.openlinker.example/webhooks/inpost/conn-inpost-1'),
+    ).toBeInTheDocument();
+    // Not the FE origin.
+    expect(
+      screen.queryByText(`${window.location.origin}/webhooks/inpost/conn-inpost-1`),
+    ).not.toBeInTheDocument();
+  });
+
+  it('trims a trailing slash from the configured base URL', () => {
+    renderWithProviders(
+      <InpostWebhookRunbook
+        connection={makeConnection({
+          config: { openlinkerCallbackBaseUrl: 'https://api.openlinker.example/' },
+        })}
+      />,
+    );
+    expect(
+      screen.getByText('https://api.openlinker.example/webhooks/inpost/conn-inpost-1'),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to window.location.origin when no public API base URL is configured', () => {
     renderWithProviders(<InpostWebhookRunbook connection={makeConnection()} />);
     expect(
       screen.getByText(`${window.location.origin}/webhooks/inpost/conn-inpost-1`),
     ).toBeInTheDocument();
-    expect(screen.getByText('integration@inpost.pl')).toBeInTheDocument();
   });
 
-  it('copies an email template containing the endpoint URL on click', async () => {
+  it('presents the InPost Manager dashboard as the primary self-service path', () => {
+    renderWithProviders(<InpostWebhookRunbook connection={makeConnection()} />);
+    expect(screen.getByText(/InPost Manager dashboard/i)).toBeInTheDocument();
+    expect(screen.getByText(/Adresy webhook/i)).toBeInTheDocument();
+    // The old, false "self-service is not offered" claim must be gone.
+    expect(screen.queryByText(/self-service provisioning is not offered/i)).not.toBeInTheDocument();
+  });
+
+  it('rotates the OL webhook secret and reveals it once, noting a 401 on mismatch', async () => {
+    const rotateWebhookSecret = vi.fn().mockResolvedValue({
+      secret: 'whsec_generated_123',
+      revealedOnce: true,
+      warning: 'Store it now.',
+    });
+    const apiClient = createMockApiClient({ connections: { rotateWebhookSecret } });
+
+    renderWithProviders(<InpostWebhookRunbook connection={makeConnection()} />, { apiClient });
+
+    // The runbook warns about the 401 signature failure up front.
+    expect(screen.getByText(/401 Invalid webhook signature/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /generate webhook secret/i }));
+
+    await waitFor(() => expect(rotateWebhookSecret).toHaveBeenCalledWith('conn-inpost-1'));
+    expect(await screen.findByText('whsec_generated_123')).toBeInTheDocument();
+    // Once revealed, the action offers rotation.
+    expect(
+      await screen.findByRole('button', { name: /rotate webhook secret/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('copies an email template containing the endpoint URL as a fallback path', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', {
       value: { writeText },
@@ -52,5 +113,6 @@ describe('InpostWebhookRunbook', () => {
     const copied = writeText.mock.calls[0][0] as string;
     expect(copied).toContain(`${window.location.origin}/webhooks/inpost/conn-inpost-1`);
     expect(copied).toContain('Shipment.Tracking');
+    expect(screen.getByText('integration@inpost.pl')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/plugins/inpost/components/inpost-webhook-runbook.tsx
+++ b/apps/web/src/plugins/inpost/components/inpost-webhook-runbook.tsx
@@ -1,20 +1,32 @@
 /**
  * InPost Webhook Runbook
  *
- * Plugin-owned `ConnectionActions` row for InPost connections (#768). InPost
- * provisions shipment-tracking webhooks **manually** via its integration team
- * (no self-service API), so this is a runbook — not a "configure" button: it
- * surfaces the OL webhook endpoint for this connection + a copy-paste email
- * template the operator sends to InPost. OL authenticates each delivery by HMAC
- * (ADR-021) and refreshes the shipment on every event.
+ * Plugin-owned `ConnectionActions` row for InPost connections (#768, #1473).
+ * InPost's public ShipX API has no webhook-provisioning endpoint, so OpenLinker
+ * cannot auto-register webhooks — hence a runbook, not a "Configure webhooks"
+ * button. The operator registers the endpoint themselves:
+ *
+ *   1. Primary path — the InPost Manager dashboard (Organization settings →
+ *      "Adresy webhook" → "Dodaj do API"), which offers self-service webhook
+ *      registration with a ping-pong verification.
+ *   2. Fallback path — a copy-paste email to the InPost integration team, for
+ *      accounts without dashboard access or during production onboarding.
+ *
+ * OpenLinker authenticates every delivery by HMAC-SHA256 (ADR-021) using a
+ * shared secret OL generates; the same secret must be configured on the InPost
+ * side or OL rejects deliveries with `401 Invalid webhook signature`. This
+ * runbook surfaces the endpoint URL (built from the configured public OL API
+ * base, falling back to the current origin) and a one-click secret rotation.
  *
  * @module plugins/inpost/components
  */
-import { useMemo, type ReactElement } from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
+import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { CopyableId } from '../../../shared/ui/copyable-id';
 import { useToast } from '../../../shared/ui/toast-provider';
 import type { Connection } from '../../../features/connections';
+import { useRotateWebhookSecretMutation } from '../../../features/connections';
 
 const INPOST_INTEGRATION_EMAIL = 'integration@inpost.pl';
 
@@ -22,12 +34,29 @@ interface InpostWebhookRunbookProps {
   connection: Connection;
 }
 
+/**
+ * Resolve the public OpenLinker API base URL that serves inbound webhooks.
+ * Prefers the operator-configured `openlinkerCallbackBaseUrl` (set in the InPost
+ * structured-config section); falls back to `window.location.origin` only when
+ * unset — correct for shared-origin deployments behind one reverse proxy, wrong
+ * for split-origin dev/demo where the FE and API run on different hosts (#1473).
+ */
+function resolveApiBaseUrl(config: Connection['config']): string {
+  const configured = config.openlinkerCallbackBaseUrl;
+  if (typeof configured === 'string' && configured.trim().length > 0) {
+    return configured.trim().replace(/\/+$/, '');
+  }
+  return window.location.origin;
+}
+
 export function InpostWebhookRunbook({ connection }: InpostWebhookRunbookProps): ReactElement {
   const { showToast } = useToast();
+  const rotateSecret = useRotateWebhookSecretMutation();
+  const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
 
   const webhookUrl = useMemo(
-    () => `${window.location.origin}/webhooks/inpost/${connection.id}`,
-    [connection.id],
+    () => `${resolveApiBaseUrl(connection.config)}/webhooks/inpost/${connection.id}`,
+    [connection.config, connection.id],
   );
 
   const emailTemplate = useMemo(
@@ -52,7 +81,7 @@ export function InpostWebhookRunbook({ connection }: InpostWebhookRunbookProps):
       showToast({
         tone: 'success',
         title: 'Email template copied',
-        description: `Send it to ${INPOST_INTEGRATION_EMAIL} to request webhook provisioning.`,
+        description: `Send it to ${INPOST_INTEGRATION_EMAIL} if you can't self-register in the InPost Manager dashboard.`,
       });
     } catch (error) {
       showToast({
@@ -63,21 +92,79 @@ export function InpostWebhookRunbook({ connection }: InpostWebhookRunbookProps):
     }
   }
 
+  async function handleRotateSecret(): Promise<void> {
+    try {
+      const result = await rotateSecret.mutateAsync(connection.id);
+      setRevealedSecret(result.secret);
+      showToast({
+        tone: 'success',
+        title: 'Webhook secret generated',
+        description: 'Copy it now — it is shown only once. Configure the same value in InPost.',
+      });
+    } catch (error) {
+      showToast({
+        tone: 'error',
+        title: 'Could not generate webhook secret',
+        description: (error as Error).message,
+      });
+    }
+  }
+
   return (
     <div className="action-list__item">
       <div>
-        <strong>Webhook setup (manual)</strong>
+        <strong>Webhook setup (runbook)</strong>
         <p className="muted-text">
-          InPost provisions shipment-tracking webhooks manually. Email{' '}
-          <code className="mono-text">{INPOST_INTEGRATION_EMAIL}</code> with the endpoint below;
-          OpenLinker verifies each delivery by HMAC and refreshes the shipment on every event.
-          Self-service provisioning is not offered by InPost today.
+          The ShipX API has no webhook-provisioning endpoint, so OpenLinker can&apos;t register the
+          webhook for you. Register it yourself:
         </p>
+        <ol className="muted-text">
+          <li>
+            <strong>Primary — InPost Manager dashboard.</strong> In Organization settings open{' '}
+            <em>Adresy webhook</em> → <em>Dodaj do API</em> and add the endpoint below (InPost runs
+            a ping-pong verification against it).
+          </li>
+          <li>
+            <strong>Fallback — email the integration team.</strong> If your account has no dashboard
+            access, use the template button to email{' '}
+            <code className="mono-text">{INPOST_INTEGRATION_EMAIL}</code> the same endpoint.
+          </li>
+          <li>
+            <strong>Generate the HMAC secret.</strong> Click <em>Generate webhook secret</em> below
+            and configure the revealed value in InPost so deliveries are signed with it. OpenLinker
+            verifies every delivery by HMAC-SHA256 (ADR-021); a missing or mismatched secret is
+            rejected with <code className="mono-text">401 Invalid webhook signature</code>.
+          </li>
+        </ol>
         <CopyableId id={webhookUrl} />
+        {revealedSecret ? (
+          <Alert
+            tone="warning"
+            title="Webhook secret (shown once)"
+            className="inpost-webhook-runbook__secret"
+          >
+            Store this now — it can&apos;t be retrieved again. Configure it as the webhook signing
+            secret in InPost, then it must match what OpenLinker holds.
+            <CopyableId id={revealedSecret} />
+          </Alert>
+        ) : null}
       </div>
-      <Button tone="secondary" onClick={() => void handleCopyEmail()}>
-        Copy email template
-      </Button>
+      <div className="action-list__item-actions">
+        <Button
+          tone="primary"
+          onClick={() => void handleRotateSecret()}
+          disabled={rotateSecret.isPending}
+        >
+          {rotateSecret.isPending
+            ? 'Generating...'
+            : revealedSecret
+              ? 'Rotate webhook secret'
+              : 'Generate webhook secret'}
+        </Button>
+        <Button tone="secondary" onClick={() => void handleCopyEmail()}>
+          Copy email template
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -137,6 +137,9 @@ export function createMockApiClient(
       test: vi.fn().mockResolvedValue({ success: true, status: 200, message: 'OK', latencyMs: 42 }),
       update: vi.fn().mockResolvedValue(sampleConnection),
       updateCredentials: vi.fn().mockResolvedValue(undefined),
+      rotateWebhookSecret: vi
+        .fn()
+        .mockResolvedValue({ secret: 'whsec_test', revealedOnce: true, warning: 'Store it now.' }),
       ...overrides.connections,
     } as ApiClient['connections'],
     content: {


### PR DESCRIPTION
## What & why

The InPost webhook runbook (`apps/web/src/plugins/inpost/components/inpost-webhook-runbook.tsx`), surfaced as the InPost connection's `ConnectionActions` panel, had three defects that together produced a webhook OpenLinker rejects. All three were hit during manual demo testing on a fresh `main` stack.

1. **Wrong webhook URL origin.** The URL was built from `window.location.origin` (the FE host), but inbound webhooks are served by the OL **API** (`POST /webhooks/:provider/:connectionId`). In any split-origin deployment (dev/demo, or FE and API on separate hosts) this pointed InPost at the FE, which does not serve `/webhooks`. The URL is now derived from the operator-configured public OL API base and falls back to `window.location.origin` only when unset (correct for shared-origin reverse-proxy deployments).

2. **Inaccurate "no self-service" wording.** The doc comment and UI copy falsely claimed "self-service provisioning is not offered by InPost today". The InPost Manager dashboard *does* offer self-service webhook registration (Organization settings -> Adresy webhook). Reworded so the dashboard is the **primary** path and the email template is a documented **fallback**. It stays a runbook (not a button) because the public ShipX API genuinely has no provisioning endpoint.

3. **Missing HMAC shared-secret step.** OL authenticates each delivery by HMAC-SHA256 with a secret OL generates; following the old runbook verbatim yielded `401 Invalid webhook signature`. Added a **Generate/rotate webhook secret** action that reveals the secret once and instructs the operator to configure the same value in InPost, calling out the 401-on-mismatch behaviour.

## How

- Reuse the host-generic `openlinkerCallbackBaseUrl` structured-config field (already wired through the edit-connection schema, merge, and form defaults; PrestaShop/Erli use it too) by rendering an **"OpenLinker public API base URL"** field in `InpostStructuredSection`. The runbook reads `config.openlinkerCallbackBaseUrl` and trims a trailing slash.
- New `useRotateWebhookSecretMutation` + `connections.rotateWebhookSecret` API method hitting the existing `POST /connections/:id/webhooks/secret/rotate` endpoint. The revealed secret is shown once in a warning `Alert` with a `CopyableId`.

**FE-only** - no backend change (the rotate-secret endpoint and the InPost HMAC decoder already exist). InPost's config-shape validator runs with `whitelist: false`, so persisting `config.openlinkerCallbackBaseUrl` needs no adapter change.

## Testing

- `pnpm --filter @openlinker/web type-check` - passes.
- Web unit tests for the changed areas - `src/plugins/inpost` and `src/features/connections`: 27 files / 263 tests pass. Runbook tests now assert the configured-base URL, the origin fallback, trailing-slash trimming, the dashboard-first copy (and absence of the false "self-service is not offered" claim), the secret-rotation step, and the email fallback.

## Files changed

- `apps/web/src/plugins/inpost/components/inpost-webhook-runbook.tsx`
- `apps/web/src/plugins/inpost/components/inpost-webhook-runbook.test.tsx`
- `apps/web/src/plugins/inpost/components/inpost-structured-section.tsx`
- `apps/web/src/features/connections/api/connections.api.ts`
- `apps/web/src/features/connections/api/connections.types.ts`
- `apps/web/src/features/connections/hooks/use-rotate-webhook-secret-mutation.ts` (new)
- `apps/web/src/features/connections/index.ts`
- `apps/web/src/test/test-utils.tsx`
- `apps/web/src/index.css`

Closes #1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)