### PR TITLE
feat(listings): expose filled parameter values and productSet linkage in MarketplaceOffer

### DIFF
--- a/apps/api/src/listings/http/dto/marketplace-offer-response.dto.spec.ts
+++ b/apps/api/src/listings/http/dto/marketplace-offer-response.dto.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * MarketplaceOfferResponseDto mapping tests (#1482) - verifies the
+ * `fromDomain` passthrough of the filled-parameter values and productSet
+ * linkage, and that adapters without parameter data keep the previous shape
+ * (fields absent).
+ */
+import type { MarketplaceOffer } from '@openlinker/core/listings';
+
+import { MarketplaceOfferResponseDto } from './marketplace-offer-response.dto';
+
+const baseOffer: MarketplaceOffer = {
+  externalId: '7781562863',
+  title: 'Vintage Camera Lens 50mm f/1.4',
+  description: 'Mint condition lens.',
+  imageUrl: 'https://a.allegroimg.com/lens-1.jpg',
+  price: { amount: '249.00', currency: 'PLN' },
+  availableQuantity: 3,
+  status: 'ACTIVE',
+  category: { id: '12345', name: 'Lenses' },
+  marketplaceUrl: 'https://allegro.pl/oferta/7781562863',
+  endsAt: '2026-05-15T12:00:00Z',
+};
+
+describe('MarketplaceOfferResponseDto.fromDomain (#1482)', () => {
+  it('should pass filled parameters and productSet linkage through when present', () => {
+    const dto = MarketplaceOfferResponseDto.fromDomain({
+      ...baseOffer,
+      parameters: [
+        {
+          id: '11323',
+          name: 'Stan',
+          values: ['Nowy'],
+          valuesIds: ['11323_1'],
+          section: 'offer',
+        },
+        {
+          id: '224017',
+          values: [],
+          rangeValue: { from: '10', to: '20' },
+          section: 'offer',
+        },
+        {
+          id: '17448',
+          name: 'Marka',
+          values: ['Canon'],
+          valuesIds: ['17448_2'],
+          section: 'product',
+        },
+      ],
+      productSet: [{ productId: 'product-card-1', quantity: 1 }],
+    });
+
+    expect(dto.parameters).toEqual([
+      {
+        id: '11323',
+        name: 'Stan',
+        values: ['Nowy'],
+        valuesIds: ['11323_1'],
+        rangeValue: undefined,
+        section: 'offer',
+      },
+      {
+        id: '224017',
+        name: undefined,
+        values: [],
+        valuesIds: undefined,
+        rangeValue: { from: '10', to: '20' },
+        section: 'offer',
+      },
+      {
+        id: '17448',
+        name: 'Marka',
+        values: ['Canon'],
+        valuesIds: ['17448_2'],
+        rangeValue: undefined,
+        section: 'product',
+      },
+    ]);
+    expect(dto.productSet).toEqual([{ productId: 'product-card-1', quantity: 1 }]);
+  });
+
+  it('should leave parameters and productSet absent when the domain offer carries neither', () => {
+    const dto = MarketplaceOfferResponseDto.fromDomain(baseOffer);
+
+    expect(dto.parameters).toBeUndefined();
+    expect(dto.productSet).toBeUndefined();
+    // Previous shape untouched — existing consumers unaffected.
+    expect(dto).toMatchObject({
+      externalId: '7781562863',
+      title: 'Vintage Camera Lens 50mm f/1.4',
+      price: { amount: '249.00', currency: 'PLN' },
+      availableQuantity: 3,
+      status: 'ACTIVE',
+      category: { id: '12345', name: 'Lenses' },
+    });
+  });
+});

--- a/apps/api/src/listings/http/dto/marketplace-offer-response.dto.ts
+++ b/apps/api/src/listings/http/dto/marketplace-offer-response.dto.ts
@@ -9,6 +9,7 @@
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { MarketplaceOffer } from '@openlinker/core/listings';
+import { CategoryParameterSectionValues } from '@openlinker/core/listings';
 
 class MarketplaceOfferPriceDto {
   @ApiProperty({ description: 'Decimal string preserving precision', example: '99.99' })
@@ -24,6 +25,46 @@ class MarketplaceOfferCategoryDto {
 
   @ApiPropertyOptional()
   name?: string;
+}
+
+class MarketplaceOfferParameterRangeDto {
+  @ApiProperty()
+  from!: string;
+
+  @ApiProperty()
+  to!: string;
+}
+
+class MarketplaceOfferParameterDto {
+  @ApiProperty({ description: 'Marketplace-native parameter id' })
+  id!: string;
+
+  @ApiPropertyOptional({
+    description: 'Human-readable label; absent when the marketplace omits it on reads',
+  })
+  name?: string;
+
+  @ApiProperty({ type: [String], description: 'Human-readable values when provided' })
+  values!: string[];
+
+  @ApiPropertyOptional({ type: [String], description: 'Dictionary value ids when provided' })
+  valuesIds?: string[];
+
+  @ApiPropertyOptional({ type: MarketplaceOfferParameterRangeDto })
+  rangeValue?: MarketplaceOfferParameterRangeDto;
+
+  @ApiProperty({ enum: CategoryParameterSectionValues })
+  section!: (typeof CategoryParameterSectionValues)[number];
+}
+
+class MarketplaceOfferProductSetItemDto {
+  @ApiPropertyOptional({
+    description: 'Marketplace catalog product id (absent for inline products)',
+  })
+  productId?: string;
+
+  @ApiPropertyOptional({ description: 'Units of the catalog product per offer item' })
+  quantity?: number;
 }
 
 export class MarketplaceOfferResponseDto {
@@ -59,9 +100,22 @@ export class MarketplaceOfferResponseDto {
 
   @ApiPropertyOptional({
     description:
-      'ISO 8601 — when the offer\'s marketplace-side validity ends (Allegro: publication.endingAt). Optional; not every marketplace publishes a fixed end date.',
+      "ISO 8601 — when the offer's marketplace-side validity ends (Allegro: publication.endingAt). Optional; not every marketplace publishes a fixed end date.",
   })
   endsAt?: string;
+
+  @ApiPropertyOptional({
+    type: [MarketplaceOfferParameterDto],
+    description:
+      'Filled category-parameter values (#1482). Absent for adapters whose native read carries no parameter data.',
+  })
+  parameters?: MarketplaceOfferParameterDto[];
+
+  @ApiPropertyOptional({
+    type: [MarketplaceOfferProductSetItemDto],
+    description: 'Product-set linkage for catalog-grouped offers (#1482).',
+  })
+  productSet?: MarketplaceOfferProductSetItemDto[];
 
   static fromDomain(offer: MarketplaceOffer): MarketplaceOfferResponseDto {
     return {
@@ -75,6 +129,20 @@ export class MarketplaceOfferResponseDto {
       category: offer.category ? { id: offer.category.id, name: offer.category.name } : undefined,
       marketplaceUrl: offer.marketplaceUrl,
       endsAt: offer.endsAt,
+      parameters: offer.parameters?.map((parameter) => ({
+        id: parameter.id,
+        name: parameter.name,
+        values: parameter.values,
+        valuesIds: parameter.valuesIds,
+        rangeValue: parameter.rangeValue
+          ? { from: parameter.rangeValue.from, to: parameter.rangeValue.to }
+          : undefined,
+        section: parameter.section,
+      })),
+      productSet: offer.productSet?.map((entry) => ({
+        productId: entry.productId,
+        quantity: entry.quantity,
+      })),
     };
   }
 }

--- a/libs/core/src/listings/domain/types/marketplace-offer.types.ts
+++ b/libs/core/src/listings/domain/types/marketplace-offer.types.ts
@@ -13,6 +13,7 @@
  *
  * @module libs/core/src/listings/domain/types
  */
+import type { CategoryParameterSection } from './category-parameter.types';
 
 export interface MarketplaceOfferPrice {
   /** Decimal string, e.g. `"99.99"` — keep precision intact across the wire. */
@@ -29,6 +30,37 @@ export interface MarketplaceOfferCategory {
    * this undefined and the FE shows the id only.
    */
   name?: string;
+}
+
+/**
+ * One filled category-parameter value on a live offer (#1482).
+ *
+ * Reuses the neutral section vocabulary from `CategoryParameterSection`
+ * (#415/#419): `'offer'` for offer-section parameters, `'product'` for
+ * product-section ones (Brand, Model, manufacturer code, ...). `name` stays
+ * optional - some marketplaces omit it on reads and consumers fall back to
+ * the id. `values` carries human-readable values when provided; `valuesIds`
+ * carries dictionary value ids; `rangeValue` carries integer/float range
+ * parameters as a neutral string pair.
+ */
+export interface MarketplaceOfferParameter {
+  id: string;
+  name?: string;
+  values: string[];
+  valuesIds?: string[];
+  rangeValue?: { from: string; to: string };
+  section: CategoryParameterSection;
+}
+
+/**
+ * Product-set linkage entry for catalog-grouped offers (#1482) - e.g.
+ * Allegro's auto-grouping links each offer to a catalog product card.
+ * Both fields are optional because inline (non-linked) entries carry no
+ * stable product id and some marketplaces don't report a quantity.
+ */
+export interface MarketplaceOfferProductSetItem {
+  productId?: string;
+  quantity?: number;
 }
 
 export interface MarketplaceOffer {
@@ -52,4 +84,12 @@ export interface MarketplaceOffer {
    * see on the detail page.
    */
   endsAt?: string;
+  /**
+   * Filled category-parameter values (#1482). Absent when the adapter's
+   * native read carries no parameter data - existing consumers are
+   * unaffected.
+   */
+  parameters?: MarketplaceOfferParameter[];
+  /** Product-set linkage for catalog-grouped offers (#1482). */
+  productSet?: MarketplaceOfferProductSetItem[];
 }

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -265,6 +265,8 @@ export type {
   MarketplaceOffer,
   MarketplaceOfferPrice,
   MarketplaceOfferCategory,
+  MarketplaceOfferParameter,
+  MarketplaceOfferProductSetItem,
 } from './domain/types/marketplace-offer.types';
 export type { SellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';
 export { isSellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -315,6 +315,13 @@ export interface AllegroProductSetEntry {
     images?: string[];
   };
   /**
+   * How many units of the catalog product one offer item contains
+   * (`quantity.value`, default 1 - Allegro uses it for bundles/sets).
+   * Read-side field consumed by `getOffer` (#1482); the create path never
+   * sets it.
+   */
+  quantity?: { value?: number };
+  /**
    * EU GPSR (Reg. 2023/988) responsible-producer reference. Required by
    * Allegro on every `productSet[]` entry when the entry creates an inline
    * product (no `product.id`). Smart-linked entries inherit this from the
@@ -798,7 +805,6 @@ export interface AllegroWarrantiesResponse {
 export interface AllegroImpliedWarrantiesResponse {
   impliedWarranties: AllegroSellerPolicyEntry[];
 }
-
 
 /**
  * Response from `GET /sale/offers/{offerId}/smart` (#737) — Allegro Smart!

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -723,14 +723,11 @@ describe('AllegroOfferManagerAdapter', () => {
     // tests assert the public boundary contract (categoryId | null) plus the
     // outgoing endpoint shape. Cache + multi-match nuances are covered by
     // the batch util's own spec.
-    type ProductCardFixture = Pick<
-      AllegroProductCardSummary,
-      'id' | 'category' | 'parameters'
-    >;
+    type ProductCardFixture = Pick<AllegroProductCardSummary, 'id' | 'category' | 'parameters'>;
     function buildProductCard(
       ean: string,
       categoryId: string,
-      productId = 'prod-id',
+      productId = 'prod-id'
     ): ProductCardFixture {
       return {
         id: productId,
@@ -930,6 +927,105 @@ describe('AllegroOfferManagerAdapter', () => {
         marketplaceUrl: 'https://allegro.pl/oferta/7781562864',
         endsAt: undefined,
       });
+    });
+
+    it('should map offer-section and product-section parameters with productSet linkage (#1482)', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: '7781562865',
+          name: 'Parameterised Offer',
+          sellingMode: { price: { amount: '99.00', currency: 'PLN' } },
+          stock: { available: 2 },
+          publication: { status: 'ACTIVE' },
+          parameters: [
+            { id: '11323', name: 'Stan', values: ['Nowy'], valuesIds: ['11323_1'] },
+            // Range parameter with no name - Allegro may omit `name` on reads.
+            { id: '224017', rangeValue: { from: '10', to: '20' } },
+          ],
+          productSet: [
+            {
+              product: {
+                id: 'product-card-1',
+                parameters: [
+                  { id: '17448', name: 'Marka', values: ['Canon'], valuesIds: ['17448_2'] },
+                ],
+              },
+              quantity: { value: 1 },
+            },
+          ],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.getOffer({ externalId: '7781562865' });
+
+      expect(result.parameters).toEqual([
+        {
+          id: '11323',
+          name: 'Stan',
+          values: ['Nowy'],
+          valuesIds: ['11323_1'],
+          rangeValue: undefined,
+          section: 'offer',
+        },
+        {
+          id: '224017',
+          name: undefined,
+          values: [],
+          valuesIds: undefined,
+          rangeValue: { from: '10', to: '20' },
+          section: 'offer',
+        },
+        {
+          id: '17448',
+          name: 'Marka',
+          values: ['Canon'],
+          valuesIds: ['17448_2'],
+          rangeValue: undefined,
+          section: 'product',
+        },
+      ]);
+      expect(result.productSet).toEqual([{ productId: 'product-card-1', quantity: 1 }]);
+    });
+
+    it('should map inline productSet entries (no product.id) with productId absent (#1482)', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: '7781562866',
+          name: 'Inline Product Offer',
+          sellingMode: { price: { amount: '15.00', currency: 'PLN' } },
+          stock: { available: 1 },
+          publication: { status: 'ACTIVE' },
+          productSet: [{ product: { name: 'Inline Product' } }],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.getOffer({ externalId: '7781562866' });
+
+      expect(result.parameters).toBeUndefined();
+      expect(result.productSet).toEqual([{ productId: undefined, quantity: undefined }]);
+    });
+
+    it('should leave parameters and productSet absent when the response carries neither (#1482)', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: '7781562867',
+          name: 'No Params Offer',
+          sellingMode: { price: { amount: '20.00', currency: 'PLN' } },
+          stock: { available: 4 },
+          publication: { status: 'ACTIVE' },
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.getOffer({ externalId: '7781562867' });
+
+      expect(result.parameters).toBeUndefined();
+      expect(result.productSet).toBeUndefined();
     });
 
     it('should omit marketplaceUrl when storefrontBaseUrl is unset', async () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -46,7 +46,10 @@ import type {
   CreateOfferValidationError,
   OfferCategory,
   CategoryParameter,
+  CategoryParameterSection,
   MarketplaceOffer,
+  MarketplaceOfferParameter,
+  MarketplaceOfferProductSetItem,
   SellerPolicies,
   SafetyAttachmentUploader,
   SafetyAttachmentUploadInput,
@@ -686,7 +689,67 @@ export class AllegroOfferManagerAdapter
       category: offer.category ? { id: offer.category.id } : undefined,
       marketplaceUrl: this.buildMarketplaceUrl(offer.id),
       endsAt: offer.publication?.endingAt,
+      parameters: this.mapOfferParameters(offer),
+      productSet: this.mapOfferProductSet(offer),
     };
+  }
+
+  /**
+   * Collect the offer's filled parameter values into the neutral shape
+   * (#1482). Offer-section values come from `offer.parameters`; product-
+   * section values (Brand, Model, manufacturer code, ...) come from each
+   * `productSet[].product.parameters` - both already present on the
+   * `GET /sale/product-offers/{offerId}` response, so no extra API call.
+   * Returns undefined when the response carries no parameter data at all,
+   * keeping the previous DTO shape for sparse offers.
+   */
+  private mapOfferParameters(offer: AllegroProductOffer): MarketplaceOfferParameter[] | undefined {
+    const mapped: MarketplaceOfferParameter[] = [];
+    for (const parameter of offer.parameters ?? []) {
+      mapped.push(this.toMarketplaceOfferParameter(parameter, 'offer'));
+    }
+    for (const entry of offer.productSet ?? []) {
+      for (const parameter of entry.product?.parameters ?? []) {
+        mapped.push(this.toMarketplaceOfferParameter(parameter, 'product'));
+      }
+    }
+    return mapped.length > 0 ? mapped : undefined;
+  }
+
+  private toMarketplaceOfferParameter(
+    parameter: AllegroOfferParameter,
+    section: CategoryParameterSection
+  ): MarketplaceOfferParameter {
+    return {
+      id: parameter.id,
+      name: parameter.name,
+      values: parameter.values ?? [],
+      valuesIds: parameter.valuesIds,
+      rangeValue: parameter.rangeValue
+        ? { from: parameter.rangeValue.from, to: parameter.rangeValue.to }
+        : undefined,
+      section,
+    };
+  }
+
+  /**
+   * Map `productSet[]` into the neutral catalog-linkage shape (#1482).
+   * `product.id` is only present on smart-linked entries (inline products
+   * carry no card id); `quantity.value` is Allegro's per-item unit count.
+   * Returns undefined when the offer has no product set so adapters without
+   * catalog linkage keep the previous shape.
+   */
+  private mapOfferProductSet(
+    offer: AllegroProductOffer
+  ): MarketplaceOfferProductSetItem[] | undefined {
+    const entries = offer.productSet ?? [];
+    if (entries.length === 0) {
+      return undefined;
+    }
+    return entries.map((entry) => ({
+      productId: entry.product?.id,
+      quantity: entry.quantity?.value,
+    }));
   }
 
   /**
@@ -838,7 +901,7 @@ export class AllegroOfferManagerAdapter
    * failure.
    */
   async resolveCategoriesForBatchByEan(
-    input: BatchCategoryByEanInput,
+    input: BatchCategoryByEanInput
   ): Promise<Map<string, EanMatchResult>> {
     return resolveCategoriesForBatchByEan(this.httpClient, this.cache, this.connectionId, input);
   }


### PR DESCRIPTION
## What & why

The neutral offer read model `MarketplaceOffer` dropped the filled category-parameter values and productSet linkage that the Allegro adapter already fetches on every `getOffer` call (`GET /sale/product-offers/{offerId}` carries `parameters[]` and `productSet[].product.parameters[]`). This blocked value-level parameter assertions in the golden-path E2E (#1481) and kept the listing-detail page from ever showing an offer's actual parameters.

This PR extends the read model and maps what the adapter already has - zero extra API calls:

- **Neutral type** (`libs/core/src/listings/domain/types/marketplace-offer.types.ts`): new optional `parameters?: MarketplaceOfferParameter[]` (`id`, `name?`, `values`, `valuesIds?`, `rangeValue? { from, to }`, `section`) reusing the existing `CategoryParameterSection` vocabulary (#415/#419), plus optional `productSet?: MarketplaceOfferProductSetItem[]` (`productId?`, `quantity?`). Both exported from the `@openlinker/core/listings` barrel.
- **Allegro adapter** (`allegro-offer-manager.adapter.ts` `getOffer`): maps `offer.parameters` with `section: 'offer'` and each `productSet[].product.parameters` with `section: 'product'`; maps `productSet[].product.id` + `quantity.value` into the linkage field. Added the documented read-side `quantity?: { value?: number }` field to the `AllegroProductSetEntry` wire type (the create path never sets it).
- **HTTP DTO** (`marketplace-offer-response.dto.ts`): passes the new optional fields through on `GET /listings/:id/offer`, with Swagger-typed nested DTOs.

Backward compatible: both fields are optional and absent when an adapter's native read carries no parameter data - existing consumers (listing-detail FE) are unaffected. Erli is out of scope (no `OfferReader`); FE rendering is deferred per the issue - the API surface is the deliverable.

## How to test

- `pnpm --filter @openlinker/integrations-allegro test -- allegro-offer-manager` - new `getOffer (#1482)` cases cover offer+product sections, `rangeValue`, missing `name`, inline productSet entries (no `product.id`), and the fields-absent path (120 tests pass).
- `pnpm --filter @openlinker/api test -- "marketplace-offer-response|listings.controller.spec"` - DTO passthrough spec + existing controller spec (47 tests pass).
- Against a stack with a mapped Allegro sandbox offer: `GET /v1/listings/:mappingId/offer` returns `parameters[]` / `productSet[]` for offers that have filled parameters; sparse offers keep the previous shape.

## Related issues

Closes #1482

🤖 Generated with [Claude Code](https://claude.com/claude-code)
