### PR TITLE
docs(mcp): ADR-033 + phased implementation plan for OpenLinker as an MCP server

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -517,6 +517,8 @@ Each is an independent interface + co-located `is{Capability}(adapter)` type gua
 
 **Capability is open at the registry boundary** (#576). The well-known set lives in `CoreCapabilityValues` as the closed `CoreCapability` type; adapter metadata (`AdapterMetadata.supportedCapabilities`), the `IntegrationsService` resolution methods, and the connection entity's `enabledCapabilities` accept `CoreCapability | string`. Plugin adapters can register new capability names without a core PR — the runtime gate at `IntegrationsService.getCapabilityAdapter` validates against `metadata.supportedCapabilities`. The HTTP request DTOs remain strict on `CoreCapabilityValues` until a runtime-aware DTO validator follow-up lands.
 
+This same `getCapabilityAdapter` seam — with its per-connection gating and encrypted credential isolation sitting below it — is the mount point for exposing OpenLinker as an **MCP server** (agents drive OL), where MCP tools become a new Interface-layer adapter over the existing application services and `tools/list` is dynamic and capability-declared (each tool declares a required capability/sub-capability and is registered iff an in-scope connection supports it — a base port backs several tools, a decomposed port one per sub-capability; `connectionId` as an argument, via the `is{Capability}` guards). See [ADR-033](./architecture/adrs/033-openlinker-as-mcp-server.md) for the decision, security model, and phased plan, and [ADR-034](./architecture/adrs/034-mcp-authorization-user-issued-pats.md) for the auth layer (OL as an OAuth 2.1 Resource Server validating user-issued Personal Access Tokens; an OAuth Authorization Server is a deferred optional upgrade).
+
 ---
 
 ## Identifier Mapping Service

--- a/docs/architecture/adrs/033-openlinker-as-mcp-server.md
+++ b/docs/architecture/adrs/033-openlinker-as-mcp-server.md
@@ -1,0 +1,55 @@
+# ADR-033: Expose OpenLinker as an MCP server
+
+- **Status**: Proposed
+- **Date**: 2026-07-11
+- **Authors**: @piotrswierzy
+
+## Context
+
+AI agents (Claude, ChatGPT, etc.) increasingly drive back-office software directly. MCP (Model Context Protocol) is the emerging standard for that: a governed open standard (governance moved Dec 2025 to the Linux Foundation's Agentic AI Foundation, with a formal SEP process and a 12-month deprecation-to-removal lifecycle), with 10,000+ production servers. Shopify already ships an official Storefront MCP server; no evidence that BaseLinker / Linnworks / ChannelEngine / Pipe17 do — so there is a real, time-boxed early-mover window for a mid-market multichannel orchestrator.
+
+The question this ADR settles: **should OpenLinker expose itself as an MCP _server_** (agents drive OL), and if so, under what security and architectural model — *before* any runtime code is written. OL-as-MCP-_client_ is explicitly out of scope.
+
+Two facts make the fit unusually clean. First, every adapter call in OL already funnels through one seam — `IIntegrationsService.getCapabilityAdapter<T>(connectionId, capability)` (`libs/core/src/integrations/application/interfaces/integrations.service.interface.ts:48`), with per-connection gating enforced below it (`integrations.service.ts:100,108` throws `CapabilityNotSupportedException` / `CapabilityNotEnabledException`), and credential isolation below _that_ (AES-256-GCM `integration_credentials`, `credentialsRef`, `CredentialsResolverPort` — [ADR-006](./006-credentials-encryption-at-rest.md)). MCP tools bolt onto this seam and inherit isolation for free. Second, secure agent-assisted setup is spec-native: MCP's 2025-11-25 spec adds **URL-mode elicitation** (secrets go browser→server, never through the model) and **bans** form-mode / tool-argument secret entry (also OWASP MCP01) — and OL already has the matching plumbing (`OAuthConnectionService` + `AllegroOAuthCompletionAdapter` + the public `GET /integrations/allegro/oauth/callback`, [ADR-013](./013-neutral-oauth-completion-port.md)).
+
+Countervailing forces: protocol churn (the ~28 Jul 2026 revision is the largest since launch, with breaking changes and a stable TS SDK v2); the security exposure of a write-capable multi-tenant commerce backend (OWASP MCP Top 10; Unit 42's 78.3% cross-server-attack finding); and unproven merchant _demand_ — the case is supply-side + first-mover, not pull.
+
+## Decision
+
+**Conditional yes (medium-high confidence).** Expose OL as an MCP server, as a **new Interface-layer adapter over existing application services** — no CORE ↔ Integration contract changes. Constraints that make it conditional:
+
+1. **Ship on the stable MCP TypeScript SDK v2 (~post-28 Jul 2026)** to avoid the breaking-change window. ADR + plan are authored now; code waits for the stable SDK.
+2. **No credential-argument tools, ever.** Secrets enter only via URL-mode elicitation / out-of-band browser entry (reusing the OAuth flow; one net-new OL-hosted key-entry page for API-key platforms). A `save_api_key(key)` tool is permanently out of scope.
+3. **`tools/list` is dynamic and capability-declared** — never a static catalog. Each tool declares the capability (or sub-capability) it requires and is registered iff ≥1 in-scope connection supports+enables it (via `listCapabilityAdapters` + the `is{Capability}` guards) — a base read port backs several tools (`ProductMaster` → `search_catalog` + `get_product`), a decomposed port maps one tool per sub-capability (`OfferCreator` → `create_offer`). `connectionId` is a validated argument (stable tool names, bounded list); `notifications/tools/list_changed` on change — so an agent sees only capabilities some connection actually supports and has enabled.
+4. **Every write/config tool is admin-scoped and audit-logged.** v1 human-in-the-loop relies on the MCP client's tool-approval UX + the coarse consent implied when the operator minted + installed an admin-scoped MCP token; per-action server-enforced confirmation is a deliberately deferred hardening for the demand-gated Phase 3 write surface (not silently assumed — a named residual risk in the plan).
+5. **A net-new client↔server auth layer is required — OL is an OAuth 2.1 Resource Server that validates OpenLinker-issued Personal Access Tokens.** OL has JWT-bearer + `RolesGuard` only today (`apps/api/src/auth/`, no token issuance to third parties; it is an OAuth *client* to Allegro, never an OAuth server). MCP authorization is **optional** (the OAuth profile is a conditional `SHOULD`, not a `MUST`), so Phase 0 does **not** stand up an Authorization Server: the operator generates a scoped, revocable **MCP token** (GitHub-PAT style) and pastes it into their MCP client, and OL validates it as a Resource Server — matching how GitHub / Atlassian / Sentry ship. An OAuth 2.1 AS (embedded or external IdP) is a **deferred, optional upgrade** behind the same RS seam. This is Phase 0 and gates every later phase. **See [ADR-034](./034-mcp-authorization-user-issued-pats.md) for the full decision, alternatives, and rationale.** The MCP token's `sub` maps to an existing OL user and **inherits that user's flat RBAC role** (admin/operator/viewer). OL is **single-tenant per deployment** — `connections` has no owner/tenant column and any authenticated user already sees every connection — so there is no per-user "allowed connections" concept to reuse; per-connection `enabledCapabilities` continues to gate *capabilities* (not *which connections* a principal may touch). Restricting an agent token to a subset of connections is net-new scope, deferred to a **Phase 3 (write) prerequisite** — the higher-blast-radius surface — not a Phase 0/1 concern.
+
+**Wiring**: a NestJS feature module `apps/api/src/mcp/` inside the existing API app (reuses the running HTTP server, global guards, `@Public()`/`VERSION_NEUTRAL` primitives, and the composed plugin/DB/Redis DI graph) — not a standalone third app. Phase the surface as read-only domain tools (P1) → mapping assistant (P2, highest ROI, no secrets) → secure setup (P3), treating P1–P2 as a low-regret spike and gating write-heavy work behind demand evidence.
+
+## Alternatives considered
+
+- **Do nothing.** Rejected: forgoes a credible, closing early-mover window when the architecture fit is unusually low-cost. Reversible later, but the differentiation is time-boxed.
+- **MCP-client only** (OL consumes external MCP servers). Rejected: solves a different problem (enriching OL's own automation), doesn't deliver the "agents drive OL" adoption/differentiation thesis. Not mutually exclusive — can follow later.
+- **Full read-write tool surface now, on the current SDK.** Rejected: maximizes blast radius (multi-tenant writes) exactly when the protocol and its security guidance are most in flux, and before any demand signal. The phased, demand-gated rollout dominates.
+- **Standalone third app** (mirror `apps/worker/`). Rejected for v1: forces a duplicated package, a third hand-synced plugin list, and a fresh HTTP bootstrap for no benefit while MCP shares the API's auth, plugins, and domain services. Revisit only if MCP must scale/deploy independently.
+
+## Consequences
+
+**Pros:**
+- Tools inherit per-connection capability gating + encrypted credential isolation for free from the existing seam.
+- Spec-native secret handling maps directly onto OL's existing OAuth flow; only one net-new key-entry page.
+- Phased, in-API rollout keeps blast radius and effort low; P1/P2 are independently valuable.
+
+**Cons / trade-offs:**
+- The auth layer (Phase 0) is security-critical but small — an OAuth 2.1 **Resource Server** validating OL-issued Personal Access Tokens ([ADR-034](./034-mcp-authorization-user-issued-pats.md)); the trade-off is a long-lived bearer token (OWASP MCP01), mitigated by PAT hardening + admin-scope + audit, with the short-lived-token OAuth upgrade deferred.
+- New dependency (`@modelcontextprotocol/sdk`) tied to a protocol in active revision; churn risk mitigated by the SDK-timing constraint and the lifecycle policy.
+- Multi-tenant write exposure demands sustained HITL + audit discipline; demand remains unproven.
+
+**Migration path:** none for existing behavior — purely additive. The MCP module is opt-in and inert until Phase 0 auth ships.
+
+## References
+
+- Related issues: #1350 (this EPIC), #1036 / [ADR-023](./023-cross-platform-category-and-attribute-projection.md) (neutral mapping shapes)
+- Related ADRs: [ADR-002](./002-capability-ports-with-sub-capabilities.md) (capability ports + `is{X}` guards), [ADR-006](./006-credentials-encryption-at-rest.md) (credential encryption), [ADR-013](./013-neutral-oauth-completion-port.md) (neutral OAuth-completion port), [ADR-034](./034-mcp-authorization-user-issued-pats.md) (the MCP auth layer — user-issued PATs, RS)
+- Implementation plan: [docs/plans/implementation-plan-mcp-server.md](../../plans/implementation-plan-mcp-server.md)
+- Primary doc section: [docs/architecture-overview.md § Capability Abstractions](../../architecture-overview.md#capability-abstractions-business-roles)

--- a/docs/architecture/adrs/034-mcp-authorization-user-issued-pats.md
+++ b/docs/architecture/adrs/034-mcp-authorization-user-issued-pats.md
@@ -1,0 +1,60 @@
+# ADR-034: MCP authorization — user-issued Personal Access Tokens (Resource Server); OAuth Authorization Server deferred
+
+- **Status**: Proposed
+- **Date**: 2026-07-12
+- **Authors**: @piotrswierzy
+
+## Context
+
+[ADR-033](./033-openlinker-as-mcp-server.md) committed OL to expose an MCP server and named the net-new client↔server auth layer as the gating Phase 0. Two rounds of investigation refined it:
+
+1. **First pass** established that the MCP spec makes the server an OAuth 2.1 **Resource Server** and puts the Authorization Server out of scope, and that the official TS SDK v2 removed its AS helpers (RS-only). That pointed at "RS + a pluggable/embedded AS (`node-oidc-provider`)."
+2. **Second pass** (this ADR) asked whether OL needs an AS *at all*, and found it does not for v1. **MCP authorization is OPTIONAL** — the OAuth profile is a conditional `SHOULD`, not a `MUST`. A **user-issued Personal Access Token (PAT)** that OL validates as a Resource Server is spec-permissible (undocumented, not banned), and is exactly what real production remote MCP servers already ship: **GitHub** (`Bearer` PAT — the self-hosted server's *primary* method), **Atlassian Rovo** (API token, *mandatory* for Jira Service Management + Bitbucket), **Sentry** (`Sentry-Bearer`). The one OAuth-only counter-example, **Notion**, is OAuth-only *because it is a multi-tenant SaaS* needing per-user delegated consent — a driver a **single-tenant, self-hosted** OL does not share: the operator mints a token for an agent they run themselves.
+
+## Decision
+
+OL's MCP auth layer is an **OAuth 2.1 Resource Server that validates OpenLinker-issued Personal Access Tokens** — **no Authorization Server in v1**:
+
+- The operator **generates an MCP token** from a settings/API surface (GitHub-PAT style), scoped and revocable, and pastes it into their MCP client's config (`Authorization: Bearer …`).
+- OL **validates the token on every MCP request** (a bearer guard over the existing user/credential machinery). RFC 9728 Protected Resource Metadata, DCR, and authorize+consent are **not required** — those exist to route a client to an external AS, and OL issues + validates its own tokens. (OL still returns a minimal `WWW-Authenticate: Bearer` on 401, per RFC 6750, so a client can discover that auth is needed rather than see a bare 401.)
+- **Scope floor:** at minimum a **read-only vs read-write** scope, so a leaked read-only token can't drive writes; finer per-capability / per-connection scoping is deferred (the Phase 3 per-token connection allow-list is one such refinement).
+- **PAT hardening is mandatory:** hash-at-rest, one-time reveal, expiry, per-token revocation, audience binding, rotation.
+- **Single-tenant assumption:** this design assumes **one organisation per deployment** (the operator mints a token for an agent they run). A future multi-tenant / multi-user model would reopen the decision — that is when the deferred OAuth AS (per-user delegated consent) earns its keep.
+- **The OAuth 2.1 Authorization Server (embedded `node-oidc-provider` or an external IdP) is deferred, not rejected.** A future OAuth token and today's PAT are validated by the **same Resource-Server seam**, so adding OAuth later is *additive*. It buys per-action consent, inherently short-lived tokens, and delegation to distinct client apps — an **optional upgrade gated on demand** (e.g. an enterprise operator wanting short-lived tokens, or a future multi-user model).
+
+## Alternatives considered
+
+- **Embedded / pluggable OAuth 2.1 AS now (`node-oidc-provider`)** — the prior framing. **Deferred, not chosen:** heaviest option (account/consent/persistence integration with OL's existing login), the spec doesn't require an AS, and the PAT model already matches shipping prior art. Retained as the documented upgrade path.
+- **Standalone IdP sidecar (Keycloak / Ory Hydra / Zitadel / Logto).** Rejected for v1: a second container + its own user store every self-hoster inherits, to solve a problem (delegated third-party consent) single-tenant OL doesn't have.
+- **Require an external IdP for every deployment.** Rejected: unrealistic operator burden for self-hosted OSS. Available via the same RS seam for operators who want it.
+- **No auth / local-stdio only.** Rejected: OL is a remote HTTP server over a write-capable commerce backend; unauthenticated is a non-starter.
+
+## Consequences
+
+**Pros:**
+- Radically smaller Phase 0 — a token-mint surface + a bearer guard, reusing OL's existing hashed-token precedent; no AS, DCR, consent screen, or `node-oidc-provider`.
+- Matches shipping prior art (GitHub / Atlassian / Sentry) and fits the single-tenant operator model exactly.
+- The RS seam is shared, so OAuth is a clean later addition — nothing thrown away.
+
+**Cons / trade-offs:**
+- A long-lived bearer PAT is **OWASP MCP01 (Token Mismanagement)** — the #1 MCP risk. The **concrete exposure**: the operator pastes the token into a third-party client's config (e.g. Claude Desktop's `claude_desktop_config.json`), which typically sits **in plaintext on disk** — exactly OWASP MCP01's "tokens hard-coded in client configs." Mitigated (not eliminated) by the scope floor + hardening above + audit + HITL-on-writes + the single-tenant/operator-controlled context (the operator authorises their *own* agent). It cannot fully satisfy the spec's "short-lived token" guidance — that is what the deferred OAuth upgrade is for.
+- Gives up per-action consent, inherently short-lived tokens, and per-client delegation vs OAuth.
+- **Client compatibility is the load-bearing risk** — see Open questions.
+
+**Migration path:** none — additive, inert until Phase 0 ships. Adding OAuth later reuses the RS seam.
+
+## Open questions
+
+- **Client compatibility (validate before Phase 0 code).** Do OL's target MCP clients (Claude Desktop, Claude.ai web, ChatGPT, Cursor…) accept a manual `Authorization` header for a *remote* Streamable-HTTP server? Confirmed at the server/vendor/framework level (GitHub/Atlassian/Sentry/FastMCP), **not** exhaustively per GUI client. A ~1-hour stub test against the actual target client settles it; a client that refuses manual headers forces the OAuth upgrade sooner.
+- **Token format:** opaque random string (hash-compared, GitHub-style — trivial revocation, one DB hit per call) vs signed JWT (self-validating claims incl. audience, no DB hit, but harder to revoke). Opaque is the leaning default (revocation matters more than a DB hit for a single-tenant admin surface); decide in Phase 0.
+- **Token store:** extend the existing `refresh_tokens` hashing precedent, or a dedicated `mcp_tokens` table? (Distinct audience + scopes argue for a dedicated store.)
+
+## References
+
+- Refines/replaces the auth framing in [ADR-033](./033-openlinker-as-mcp-server.md) Decision #5 (which points here). **ADR-033 itself is not superseded** — it remains the umbrella "expose OL as an MCP server" decision; only its one-line auth framing is replaced here.
+- MCP Authorization spec — 2025-06-18 (authorization is OPTIONAL; OAuth is a conditional `SHOULD`) + 2026-07-28 RC (`modelcontextprotocol.io`).
+- Prior art: GitHub, Atlassian Rovo, and Sentry MCP servers (config-pasted PAT); FastMCP static-bearer client auth.
+- OWASP MCP Top 10 — MCP01 Token Mismanagement (long-lived-token risk + mitigations); RFC 6750 (Bearer), RFC 8707 (resource/audience).
+- Deep-research verification passes: 2026-07-11 (spec/SDK, 23/25 confirmed) and 2026-07-12 (PAT viability, 24/25 confirmed) via 3-vote adversarial verification.
+- Related issues: #1486 (Phase 0), #1350 (EPIC).
+- Implementation plan: [docs/plans/implementation-plan-mcp-server.md](../../plans/implementation-plan-mcp-server.md)

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -121,5 +121,7 @@ One pointer per section, identical format every time.
 | [ADR-029](./029-versioning-and-release-strategy.md) | Versioning and release strategy (four axes) | Accepted | 2026-06-30 |
 | [ADR-031](./031-erli-allegro-category-catalog-via-client-credentials.md) | Erli category/parameter browsing via an Erli-owned Allegro client-credentials token | Proposed | 2026-07-07 |
 | [ADR-032](./032-demo-only-vendor-neutral-analytics-config-seam.md) | Demo-only, vendor-neutral analytics/integration config seam on `/system/config` | Proposed | 2026-07-08 |
+| [ADR-033](./033-openlinker-as-mcp-server.md) | Expose OpenLinker as an MCP server | Proposed | 2026-07-11 |
+| [ADR-034](./034-mcp-authorization-user-issued-pats.md) | MCP authorization — user-issued Personal Access Tokens (Resource Server); OAuth AS deferred | Proposed | 2026-07-12 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-mcp-server.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-mcp-server.md
@@ -1,0 +1,53 @@
+# Pre-Implement Analysis: implementation-plan-mcp-server.md
+
+**Gate date**: 2026-07-11
+**Plan**: [docs/plans/implementation-plan-mcp-server.md](../implementation-plan-mcp-server.md)
+**Issue**: #1350 (EPIC — MCP server ADR + plan)
+**Reviewer**: OpenLinker Tech Lead (read-only readiness gate)
+
+---
+
+## Verdict: **READY** (with one accuracy correction)
+
+The plan is greenfield and implementable — every artifact it proposes to create is confirmed absent, and it changes no published contract surface (the only edit to existing code is one additive `imports[]` line in `app.module.ts` + a new npm dependency). **One reuse claim is inaccurate** (the rate-limiter "reuse") and should be corrected to "net-new, patterned on X" so the effort estimate and implementation aren't misled — but it is not a collision or a contract break, so it does not gate.
+
+---
+
+## Reuse findings (does it already exist?)
+
+| Plan artifact | Class | Evidence |
+|---|---|---|
+| `apps/api/src/mcp/` module, `McpModule`, mcp tokens/controllers | **NEW** | ABSENT — no `mcp` source dir anywhere; only the plan/ADR docs match `mcp` |
+| `@modelcontextprotocol/sdk` dependency | **NEW** | ABSENT in all 20 workspace `package.json`s — no version collision |
+| OAuth 2.1 **Authorization Server** (`/authorize`, `/token`, DCR RFC 7591, `.well-known/oauth-*`, consent) | **NEW** | ABSENT as an AS. OL's `OAuthConnectionService` (`oauth-connection.service.ts:69`) is an OAuth *client* to Allegro — distinct, no collision. `auth/registration.service.ts` is user-account registration, **not** RFC 7591 DCR |
+| `sub` → OL-user mapping store | **NEW** | No external-identity/SSO/api-key/PAT table exists. `refresh_tokens` (`migrations/1796000000000-add-refresh-tokens.ts:18`) maps an OL-issued token hash → user (login sessions), **not** an external subject — prior-art *pattern* only, do not reuse verbatim |
+| Dynamic, sub-capability-keyed `tools/list` via `listCapabilityAdapters` + `is{X}` guards | **REUSE (seam exists)** | `IIntegrationsService.listCapabilityAdapters` (`integrations.service.interface.ts:82`), `getCapabilityAdapter` (`:48`); `is{X}` guards in `listings`/`orders` `domain/ports/capabilities/**` |
+| Read/mapping/setup tools over existing services | **REUSE (seams exist)** | `ConnectionService` (create/update/updateCredentials/installWebhooks/testConnection), `OAuthConnectionService`, `IMappingConfigService`/`ICategoryResolutionService`/`IAttributeProjectionService` — all confirmed in the research phase |
+| Per-token **rate limit + concurrency cap** | **NEW (plan overstated reuse)** | ⚠️ The claimed "existing rolling-window limiter (shipping dispatch)" **does not exist**. The shipping ZSET (`redis-pickup-point-query-stats.adapter.ts:40`) is query-popularity ranking (#849), not a limiter. No `@nestjs/throttler`, no generic `RateLimiter`/`TokenBucket`; `CachePort` has no atomic increment. Effectively net-new |
+
+## Backward-compatibility findings
+
+| Surface | Assessment |
+|---|---|
+| Top-level barrels (`@openlinker/core/<ctx>`) | **No change** — MCP consumes existing barrel exports; adds none |
+| Port method signatures | **No change** — reuses `getCapabilityAdapter`/`listCapabilityAdapters` as-is |
+| DTO shapes | **No change** to existing DTOs; MCP tool schemas are new |
+| Symbol tokens | **No change** — new `mcp` tokens only; no existing token removed/renamed |
+| ORM schema | **New tables only** (`sub`→user store, optional client-registration) ⇒ standard forward migration per `docs/migrations.md`. **No change to existing tables.** Warning-level only in that migrations must be authored in the Phase 0 child issue |
+| `check:invariants` | **No expected trip** — MCP lives in `apps/api` (not a `libs/core` cross-context path); no deep-barrel imports planned; repo-URL guard already passes on the docs |
+| `app.module.ts` | Additive `imports: [McpModule]` — non-breaking |
+
+## Open questions (from the plan, unchanged by this gate)
+
+- **Q1 (resolved — superseded by two post-gate deep-research passes → ADR-034)**: OL is an OAuth 2.1 **Resource Server that validates its own user-issued Personal Access Tokens** — **no Authorization Server in v1** (MCP auth is optional; PAT matches GitHub/Atlassian/Sentry prior art). This supersedes both the in-grill "OL is its own AS" framing and the interim "RS + embedded AS (node-oidc-provider)" framing; the OAuth AS is a deferred optional upgrade. Net effect on this gate: Phase 0 shrinks (no AS/DCR/consent), and the "AS greenfield" backward-compat row above becomes moot for v1. See [ADR-034](../../architecture/adrs/034-mcp-authorization-user-issued-pats.md).
+- **Q2 (resolved)**: `sub` → OL user; inherit RBAC role; no per-user connection scoping (single-tenant).
+- **Q5**: per-token connection scoping for writes — net-new, Phase 3 prerequisite.
+- **Q6**: PII in order-read tools — consciously deferred.
+- **Machine-token signing**: reusing `JwtService`/`JWT_SECRET` (HS256, 15m, `{sub,username,role}`) verbatim would conflate login JWTs with long-lived machine tokens — Phase 0 should use a distinct audience/key/expiry for MCP tokens.
+
+## Recommended correction before implementation
+
+1. **Fix the rate-limiter reuse claim** in the plan's *Abuse invariant* and Phase 1 step 4: change "reuses the existing Redis/Valkey rolling-window limiter (as used in shipping dispatch)" → "**net-new** per-token limiter on the raw `REDIS_CLIENT`, patterned on the ZSET rolling-window mechanics in `redis-pickup-point-query-stats.adapter.ts` and the Lua-atomic `RedisSyncLockService`; `CachePort` cannot do atomic increments." Effort +~1 d.
+2. (Phase 0 note) Author MCP-token signing with a distinct audience/key from login JWTs — don't reuse `JWT_SECRET`/`refresh_tokens` verbatim.
+
+Neither is a contract break or a reuse collision; the plan is **READY** once the wording is corrected.

--- a/docs/plans/implementation-plan-mcp-server.md
+++ b/docs/plans/implementation-plan-mcp-server.md
@@ -1,0 +1,268 @@
+# Implementation Plan: Expose OpenLinker as an MCP Server
+
+**Date**: 2026-07-11
+**Status**: Ready for Review
+**Estimated Effort**: Planning only (this EPIC). Implementation ≈ Phase 0: 3–5 d (RS bearer guard + PAT mint/store/hardening + admin token-management settings UI — see Q1 / Q4 / ADR-034; no Authorization Server in v1) · Phase 1: 3–5 d · Phase 2: 5–8 d · Phase 3: 5–7 d (per-token connection scoping added — Q5). Each a separate child issue, shipped post-stable-SDK ~28 Jul 2026.
+
+> Decision rationale, security model, and alternatives live in [ADR-033](../architecture/adrs/033-openlinker-as-mcp-server.md). This plan is the *what* and *how*; the ADR is the *why*.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Expose OpenLinker as an **MCP (Model Context Protocol) server** so AI agents (Claude, ChatGPT, …) can query and drive OL's capabilities, as a new Interface-layer adapter over existing application services — **no CORE ↔ Integration contract changes**.
+
+**Context**: MCP is a governed open standard with an open early-mover window for multichannel orchestrators (see ADR-033 § Context). OL's architecture fits unusually cleanly: every adapter call already funnels through one gated seam (`IIntegrationsService.getCapabilityAdapter`), and spec-native secret handling (URL-mode elicitation) maps onto OL's existing OAuth flow.
+
+**Classification**: **Interface** (new MCP adapter over existing application services), with a net-new auth slice (Phase 0) and small Frontend slices (Phase 0 token-management settings UI + Phase 3 key-entry page). No domain/core contract changes.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- ADR-033 (done, this EPIC), this plan (this EPIC), and the four phased child issues (this EPIC).
+- Phase 0–3 **implementation** ships as the child issues, not here.
+
+### Out of Scope
+- **Any runtime code in this EPIC** — docs/planning only.
+- **OL-as-MCP-client** (OL consuming external MCP servers) — different problem, deferred.
+- **Any credential-argument tool** (`save_api_key(key)`, secrets in tool args or returns) — *permanently* out of scope (ADR-033 decision #2; OWASP MCP01).
+- CORE ↔ Integration boundary changes; new capability ports; DB schema changes to existing tables.
+
+### Constraints
+- **SDK timing**: implement on the **stable MCP TypeScript SDK v2 (~28 Jul 2026)**; the ~28 Jul 2026 revision carries breaking changes. Author now, code after.
+- **Phase 0 gates Phases 1–3** — no domain/config tool ships before the client↔server auth layer.
+- New dependency: `@modelcontextprotocol/sdk` (MCP protocol server + RS bearer primitives) — none present today. **No `node-oidc-provider`** in v1 (no AS — ADR-034); it becomes a dependency only if/when the deferred OAuth upgrade ships. Node ≥18 / NestJS 10.3 / TS 5.4 / Express — compatible.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: **App / Interface** — new NestJS feature module `apps/api/src/mcp/` inside the existing API app (ADR-033 § wiring). Reuses the running HTTP server + Express transport, the global `JwtAuthGuard`/`RolesGuard` (`apps/api/src/auth/auth.module.ts:70-71`), the `@Public()` + `VERSION_NEUTRAL` primitives (`apps/api/src/auth/decorators/public.decorator.ts`, used by `webhook.controller.ts:40` and `allegro.controller.ts:147`), and the composed `PluginRegistryModule` / DB / Redis DI graph. **No** standalone third app (rejected — see ADR-033 § Alternatives).
+
+**The one seam everything mounts on**:
+- `IIntegrationsService.getCapabilityAdapter<T>(connectionId, capability)` — `libs/core/src/integrations/application/interfaces/integrations.service.interface.ts:48`; token `INTEGRATIONS_SERVICE_TOKEN` (`libs/core/src/integrations/integrations.tokens.ts:13`).
+- `listCapabilityAdapters<T>({ capability, platformType?, lazy? })` — same interface, line 82 (drives multi-connection tools + per-connection `tools/list`).
+- Runtime two-tier gate (inherited for free): `integrations.service.ts:100` (adapter supports capability → else `CapabilityNotSupportedException`) and `:108` (connection has it enabled → else `CapabilityNotEnabledException`).
+- Credential isolation below the seam: `credentialsRef` + `enabledCapabilities` on `connections` (`connection.orm-entity.ts:41,47`), AES-256-GCM `integration_credentials` (ADR-006), `CredentialsResolverPort` (`CREDENTIALS_RESOLVER_TOKEN`).
+
+**Capabilities involved** (read via `is{X}` guards, never a static catalog):
+- `ProductMaster`, `InventoryMaster`, `OrderSource` (Phase 1 reads).
+- Options readers `DestinationOptionsReader` / `SourceOptionsReader` (`libs/core/src/orders/domain/ports/capabilities/*`), `CategoryBarcodeMatcher` / `EanCategoryMatcher` (`libs/core/src/listings/domain/ports/capabilities/*`) (Phase 2).
+
+**Existing services reused (Phase 2/3 — bind to neutral core interfaces, NOT legacy HTTP DTOs)**:
+- `IMappingConfigService` — `MAPPING_CONFIG_SERVICE_TOKEN` (`libs/core/src/mappings/mappings.tokens.ts:9`). Neutral `CategoryMappingInput` (`mappings/domain/types/mapping.types.ts:36`). ⚠️ status/carrier/payment inputs are still `allegro*`/`prestashop*`-named in the domain type (partial neutralization, ADR-023); the MCP layer must not re-import the legacy HTTP DTOs (`apps/api/src/mappings/http/dto/*` still expose `allegroCategoryId` etc.).
+- `ICategoryResolutionService` — `CATEGORY_RESOLUTION_SERVICE_TOKEN` (`listings.tokens.ts:16`); `resolveCategory(CategoryResolutionInput)`.
+- `IAttributeProjectionService` — `ATTRIBUTE_PROJECTION_SERVICE_TOKEN` (`listings.tokens.ts:7`); `project(AttributeProjectionInput)`.
+- `ConnectionService` (`apps/api/src/integrations/application/services/connection.service.ts`) — `create` (:201), `update` (:368, = set-config + enable-capability), `updateCredentials` (:436), `installWebhooks` (:152), `testConnection` (:177), `disable` (:465).
+- `OAuthConnectionService` (`oauth-connection.service.ts`) — `generateAuthorizationUrl` (:69), `validateState` (:105), `completeAuthorization` (:129), `checkCompletedState` (:197); public callback `GET /integrations/allegro/oauth/callback` (`allegro.controller.ts:147`).
+
+**New components required**: the `apps/api/src/mcp/` module (transport wiring, per-connection tool registry, the MCP↔OL auth bridge), an admin-only MCP-token-management settings page (Phase 0, FE), plus one net-new OL-hosted branded key-entry page (Phase 3, FE). No new domain entities/ports.
+
+**Core vs Integration justification**: This is a pure Interface adapter. It calls only published application-service interfaces and capability ports through the barrels; it introduces no domain logic and no platform knowledge (platform specifics stay behind the capability guards and the OAuth-completion registry). Nothing here belongs in CORE or in a plugin.
+
+---
+
+## 4. External / Domain Research
+
+### External System — MCP
+- **Governance/lifecycle**: Linux Foundation Agentic AI Foundation (Dec 2025); formal SEP process; 12-month deprecation-to-removal policy caps churn.
+- **Auth (client↔server)** — verified via two deep-research passes (see [ADR-034](../architecture/adrs/034-mcp-authorization-user-issued-pats.md)): MCP authorization is **OPTIONAL** (the OAuth profile is a conditional `SHOULD`, not a `MUST`), and a **user-issued PAT validated by OL as a Resource Server** is spec-permissible and is how GitHub / Atlassian / Sentry ship. So v1 needs **no Authorization Server** — OL mints its own scoped bearer tokens and validates them. (RFC 9728 PRM / DCR / authorize+consent are only required when routing to an external AS.) **OL has none of this today** (`apps/api/src/auth/` is stateless JWT-bearer + `RolesGuard`; no token issuance to third parties). Trade-off: a long-lived bearer PAT is OWASP MCP01 — mitigated by hardening; the short-lived-token OAuth AS is a deferred upgrade.
+- **Secret handling**: 2025-11-25 spec adds **URL-mode elicitation** (browser→server, never through the model) and **bans** form-mode / tool-argument secrets (OWASP MCP01).
+- **Security surface**: OWASP MCP Top 10; Unit 42's 78.3% cross-server-attack finding → HITL + audit on every write is non-negotiable.
+- **SDK / transport**: official `@modelcontextprotocol/sdk` (stable TS v2 ≈ 28 Jul 2026) over **Streamable HTTP** transport, behind a thin Nest `@Public()`/`VERSION_NEUTRAL` controller. No community NestJS wrapper (Q3). Note the v2 SDK ships **only resource-server** auth primitives (`requireBearerAuth`, `mcpAuthMetadataRouter`, `hostHeaderValidation`) — the AS is OL's (embedded library), not the SDK's.
+
+### Internal Patterns
+- **Per-connection capability narrowing**: `MappingOptionsController` (`apps/api/src/mappings/http/mapping-options.controller.ts`) already resolves an adapter and returns 501 when a capability is absent — the exact shape `tools/list` reuses.
+- **Public + version-neutral routes**: `@Public()` + `VERSION_NEUTRAL` (webhooks, Allegro callback) — the pattern for MCP `.well-known` + OAuth endpoints that must sit at fixed unauthenticated URLs.
+- **Neutral OAuth-completion**: ADR-013's `OAuthCompletionPort` + registry means the "start_connection → URL elicitation" tool is platform-agnostic for OAuth platforms.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+- **Q1 — MCP token model (RESOLVED — see [ADR-034](../architecture/adrs/034-mcp-authorization-user-issued-pats.md)).** OL is an OAuth 2.1 **Resource Server that validates its own user-issued Personal Access Tokens** — **no Authorization Server in v1**. The operator mints a scoped, revocable MCP token from settings (GitHub-PAT style) and pastes it into the MCP client; OL validates it with a bearer guard. MCP authorization is optional per spec, and this matches GitHub/Atlassian/Sentry prior art. *Deferred (not rejected):* an embedded/external OAuth AS for short-lived tokens + consent, behind the same RS seam. *Rejected for v1:* an IdP sidecar, and requiring an external IdP for every deployment.
+- **Q2 — `sub` → OL user mapping store.** How does an MCP token `sub` resolve to an OL user? *Default (resolved):* map `sub` → an existing OL user and inherit its flat RBAC role; there is **no per-user connection scoping** (OL is single-tenant; all connections are already globally visible). A thin `sub`→userId mapping is all Phase 0 needs; per-connection `enabledCapabilities` gates capabilities as today. Any per-token connection restriction is Phase 3 scope (Q5), not this store.
+- **Q3 — Library + transport (RESOLVED).** Use the official `@modelcontextprotocol/sdk` directly behind a thin `@Public()`/`VERSION_NEUTRAL` transport controller over **Streamable HTTP** (OL is a hosted server, not a stdio subprocess). No community NestJS-MCP wrapper: it adds a second dependency tracking a churning protocol with no lifecycle guarantee, and its value is static `@Tool()` decorators — which fight our dynamic, capability-driven registration (Q4/§6). Revisit only if a *governed* wrapper emerges.
+- **Q4 — Do the FE slices warrant separate FE issues? (RESOLVED — fold both.)** Two small FE surfaces exist: the **Phase 0** admin MCP-token-management settings page (generate / one-time-reveal / list / revoke) and the **Phase 3** branded key-entry page + "connected via agent" affordance. Both are BE-dominant slices tightly coupled to their phase's API. *Decision:* fold each into its own phase's child issue with an explicit FE checklist (per `docs/frontend-architecture.md`), rather than spinning separate FE issues — so #1486 carries the token-UI checklist and #1489 the key-entry-page checklist.
+- **Q5 — Per-token connection scoping for writes (Phase 3).** Before write/config tools ship, should an agent token be restrictable to a subset of connections (net-new, since OL has none today)? *Default:* yes — introduce an additive per-token connection allow-list as a Phase 3 write prerequisite (the higher-blast-radius surface); reads (P1) and mapping suggestions (P2) run at the user's existing global scope.
+- **Q6 — PII in order-read tools (deferred).** `OrderSource` reads carry buyer PII, which the agent's LLM provider would receive as a de-facto sub-processor. Consciously **deferred for now** — not designed into Phase 1. Flag to revisit before order-read tools ship (options if/when: default PII-minimized reads + explicit opt-in tool; honor `OL_STORE_PII` as a floor).
+- **Q7 — MCP client accepts a manual bearer header? (validate before Phase 0 code — the one thing that could kill the PAT model).** The PAT approach requires the target MCP client to accept a static `Authorization` header for a *remote* Streamable-HTTP server. Confirmed at the server/vendor/framework level (GitHub/Atlassian/Sentry/FastMCP), **not** exhaustively per GUI client. *Default:* run a ~1-hour stub-server header check against the actual target (Claude Desktop, etc.) before committing Phase 0. A client that refuses manual headers pulls the deferred OAuth AS forward.
+
+### Assumptions
+- "Create the ADR and plan the implementation" = this EPIC produces **ADR + plan + child-issue breakdown only**; runtime code ships as Phase 0–3 children.
+- Demand is unproven → P1 (+P2) treated as a **low-regret spike**; write-heavy P3 gated behind demand evidence.
+- Node ≥18 / NestJS 10 / TS 5.4 remain MCP-SDK-compatible at implementation time (re-verify against the stable v2 SDK).
+
+### Documentation Gaps
+- No existing OL doc covers a resource-server auth model; the Phase 0 child issue should add one (or an ADR addendum) when the token model is chosen.
+
+---
+
+## 6. Proposed Implementation Plan
+
+> **Cross-cutting invariants (apply to every phase)**
+> - **Dynamic, capability-declared `tools/list`**: never a static catalog. **Each tool declares the capability (or sub-capability) it requires** and is registered iff **at least one** of the calling principal's in-scope connections supports *and* has enabled it — computed via `listCapabilityAdapters({ capability, lazy: true })` (`lazy` avoids constructing adapters just to list). A **base read port backs several tools** (`ProductMaster` → `search_catalog` + `get_product`); a **decomposed port maps one tool per sub-capability** (`OfferCreator` → `create_offer`, `CategoryBrowser` → `browse_categories`, … across the ~34 sub-capabilities in `docs/capabilities.md`). `connectionId` is a **validated tool argument** (not baked into the tool name — names stay stable: `create_offer`, not `create_offer__allegro-main`); a `list_connections` tool tells the agent which connections back which tool. Call-time `connectionId`→capability validation is enforced by the existing `getCapabilityAdapter` gate (throws `CapabilityNotSupported`/`NotEnabled`). The list mutates with connection/capability state and is republished via `notifications/tools/list_changed`. Bounded by the capability surface (not N connections × M capabilities), with stable, cacheable tool names.
+> - **Secret invariant**: no credential-argument tools; secrets only via URL-mode elicitation / out-of-band browser entry. No tool returns a secret.
+> - **Write/config invariant (v1)**: every write/config tool is **admin-scoped** (maps to `@Roles('admin')`) and **audit-logged** (`{ actorSub, olUserId, connectionId, tool, args-minus-secrets, timestamp }`). Human-in-the-loop for v1 relies on the **MCP client's tool-approval UX** plus the **coarse consent implied when the operator minted + installed an admin-scoped MCP token** (Phase 0) — not per-action server-side enforcement. Deliberate, bounded choice: admin-scope + audit cap the blast radius, and Phase 3 (the write-heavy phase) is demand-gated and ships last. **Deferred hardening (revisit at Phase 3):** server-enforced two-phase confirmation (a write tool returns a *pending action* + an out-of-band browser confirmation the model can't self-approve) for config/destructive tools, if the write surface warrants it — recorded as a named residual risk (§ 8), not silently assumed.
+> - **Abuse invariant**: MCP tool calls carry a **per-token (per-principal) rate limit + concurrency cap**, distinct from adapter-level rate-limit backoff. Adapter backoff protects the downstream marketplace API from OL; this cap protects **OL's own sync-job fairness** (the agent and the scheduler share a connection's upstream quota) and the connection's upstream standing from an autonomous agent that loops. **This limiter is net-new** — the repo has no generic rate-limiter or semaphore to reuse (no `@nestjs/throttler`; `CachePort` has no atomic increment; the shipping ZSET is query-popularity ranking, not a limiter). Build it on the raw `REDIS_CLIENT`, patterned on the ZSET rolling-window mechanics in `redis-pickup-point-query-stats.adapter.ts` and the Lua-atomic `RedisSyncLockService`. The audit log supplies the usage signal to tune limits.
+
+### Phase 0 — Client↔server MCP auth (gating prerequisite, net-new)
+**Goal**: OL is an OAuth 2.1 **Resource Server that validates OpenLinker-issued Personal Access Tokens** (Q1 / [ADR-034](../architecture/adrs/034-mcp-authorization-user-issued-pats.md)) — **no Authorization Server in v1**. The operator mints a scoped MCP token from settings, pastes it into the MCP client (`Authorization: Bearer …`), and OL validates it. Maps the token → OL user (inheriting its RBAC role; no per-user connection scoping — Q2). Adversarially reviewed against the OWASP MCP Top 10 before any tool ships.
+
+> **Validate first (Q7, ~1 h):** before building, confirm the target MCP client (Claude Desktop, etc.) accepts a manual `Authorization` header for a *remote* Streamable-HTTP server — a stub-server header check. A client that refuses manual headers forces the deferred OAuth upgrade sooner. See ADR-034 § Open questions.
+
+**Steps**:
+1. **MCP token mint + store (API)** — admin-scoped mint/list/revoke endpoints (`@Roles('admin')`) that generate a scoped, revocable MCP token (GitHub-PAT style), plus a store (extend the `refresh_tokens` hashing precedent, or a dedicated `mcp_tokens` table — Q2). The settings UI that drives these is step 5. **Token format** (decide here): opaque random string, hash-compared (leaning default — trivial revocation) vs signed JWT (ADR-034 § Open questions). **Scope floor:** at minimum a **read-only vs read-write** scope so a leaked read-only token can't drive writes. **Hardening (mandatory):** hash-at-rest, one-time reveal, expiry, per-token revocation, audience binding, rotation. *Acceptance*: an admin mints a token (with a scope) shown once; it is stored hashed; revoke/expiry work; a read-only token is refused on a write; the raw token never re-appears in any read.
+2. **Resource-Server bearer guard** — `apps/api/src/mcp/auth/mcp-token.guard.ts`: validates the presented bearer against the store (hash compare), checks scope + expiry + revocation, and rejects otherwise (401 with a minimal `WWW-Authenticate: Bearer`, per RFC 6750, for client discovery). **Token-passthrough prohibition**: OL only accepts its own tokens and never forwards the client's token to upstream marketplace APIs (Allegro/PrestaShop) — OL holds its own upstream credentials separately. *Acceptance*: valid token → authorized; expired/revoked/unknown/wrong-scope → 401; a passthrough (non-OL) token is refused; unit-tested against crafted tokens.
+3. **Token → OL principal mapping** — resolve the token to its owning OL user and **inherit that user's flat RBAC role** (admin/operator/viewer). OL is single-tenant per deployment (no owner/tenant column on `connections`; any authenticated user already sees every connection), so **all connections are in scope exactly as a human session sees them today** — there is no per-user "allowed connections" concept. Per-connection `enabledCapabilities` continues to gate *capabilities*, not *which connections*. *Acceptance*: resolves an OL user + role; unknown token → 401. **Per-token connection scoping is out of scope here — deferred to Phase 3 (§ Phase 3).**
+4. **Wire the module** — add `McpModule` to `apps/api/src/app.module.ts` imports; MCP routes sit behind the bearer guard. *Acceptance*: API boots; existing routes unaffected.
+5. **MCP-token management UI (FE, net-new — folded per Q4)** — an admin-only settings page in `apps/web` (e.g. `/settings/mcp-tokens`): a *Generate token* form (name + scope + expiry), a **one-time-reveal modal** (shows the raw token once with a copy button, then never again — the UX half of step 1's one-time-reveal hardening), an active-token list (name / scope / created / last-used / expiry, no raw value), and a revoke action with confirm. Server state via TanStack Query, form via RHF + Zod, driven by the step-1 endpoints; nothing secret persisted client-side. *Acceptance*: an admin generates a token and sees the raw value exactly once; copy works; the list shows active tokens without the raw value; revoke removes a token; FE checklist per `docs/frontend-architecture.md` (loading/empty/error states, `app→pages→features→shared` direction, no raw `fetch`).
+
+**Deferred (optional upgrade, not v1 — ADR-034):** an OAuth 2.1 Authorization Server (embedded `node-oidc-provider` or external IdP) for short-lived tokens / per-action consent / delegation. It plugs into the **same RS bearer seam** (step 2), so it's additive when demand warrants (enterprise/multi-user).
+
+**Dependencies**: none (net-new). **Gates**: Phases 1–3.
+
+### Phase 1 — Read-only domain tools (low-regret spike)
+**Goal**: Highest-utility, lowest-blast-radius tools: catalog search + `getProduct` (`ProductMaster`), availability reads (`InventoryMaster`), order-status reads (`OrderSource`).
+
+**Steps**:
+1. **Capability-gated tool registry** — `apps/api/src/mcp/tools/tool-registry.service.ts` — builds `tools/list` for the calling principal: each tool declares a required capability and is registered iff ≥1 in-scope connection supports+enables it (`listCapabilityAdapters({ capability, lazy: true })`). A base read port backs several tools (`ProductMaster` → `search_catalog` + `get_product`); `connectionId` is a validated argument; plus a `list_connections` tool. Emits `notifications/tools/list_changed` when the capability inventory changes. *Acceptance*: a capability no in-scope connection supports has all its tools absent from `tools/list`; a call naming a `connectionId` that lacks the capability is rejected by the `getCapabilityAdapter` gate; adding/removing a connection republishes the list.
+2. **Read tools** — `apps/api/src/mcp/tools/read/*.tool.ts` — each resolves its adapter via `getCapabilityAdapter` and returns neutral read models. *Acceptance*: tool calls succeed for capable connections, return the capability-not-enabled error shape otherwise.
+3. **Audit log (reads)** — lightweight structured log per call (no HITL needed for reads). *Acceptance*: every call logged with principal + connection + tool.
+4. **Per-token rate/concurrency cap** — enforce the abuse invariant with a **net-new** limiter on the raw `REDIS_CLIENT` (no reusable primitive exists — see the invariant). *Acceptance*: a token exceeding its call-rate or concurrency ceiling is throttled (429-equivalent MCP error) without starving the scheduler's share of the connection's upstream quota.
+
+**Dependencies**: Phase 0.
+
+### Phase 2 — Mapping assistant (highest ROI; no secrets, correctable mistakes)
+**Goal**: Read/discovery + suggestion tools over the neutral mapping/resolution seams; write tools HITL-gated. Ship a `configure-mappings` Skill.
+
+**Steps**:
+1. **Discovery tools** — options via `DestinationOptionsReader`/`SourceOptionsReader`; category suggestions via `ICategoryResolutionService.resolveCategory` + `EanCategoryMatcher`; attribute projections via `IAttributeProjectionService.project`. *Acceptance*: read-only; bind to neutral core interfaces (⚠️ not legacy `allegro*` HTTP DTOs).
+2. **Write tools** — `upsertCategoryMapping` etc. via `IMappingConfigService`, using neutral `CategoryMappingInput`. *Acceptance*: admin-scoped, audit-logged; human approval via the MCP client's tool-approval UX (v1 model — these writes are correctable/no-secrets, so client-trust is appropriate here).
+3. **Skill** — `configure-mappings` procedure doc. *Acceptance*: encodes the discover→suggest→confirm→write loop.
+
+**Dependencies**: Phase 0 (Phase 1 helpful, not required).
+
+### Phase 3 — Secure connection setup (Skills + MCP + out-of-band)
+**Goal**: `start_connection` returns a URL-mode elicitation; OAuth platforms reuse the existing flow; API-key platforms use one net-new branded key-entry page. Non-secret orchestration tools for status/test/webhooks/config/capability.
+
+**Steps**:
+1. **`start_connection` tool** — returns a URL-mode elicitation; OAuth path calls `OAuthConnectionService.generateAuthorizationUrl`; API-key path returns the new key-entry page URL. *Acceptance*: never accepts a secret as a tool arg.
+2. **Branded key-entry page (FE, net-new)** — posts to `PUT /connections/:id/credentials` (`ConnectionService.updateCredentials`). *Acceptance*: secret goes browser→server only; page is the sole API-key entry surface for agent-assisted setup. (Per Q4, folded into this issue with an FE checklist.)
+3. **Orchestration tools (writes)** — `check_connection_status` / `test_connection` (`testConnection`), `install_webhooks` (`installWebhooks`), `set_connection_config` + `enable_capability` (`update`). *Acceptance*: all admin-scoped, audit-logged; **never** a `save_api_key(key)` tool. **Phase 3 is where the deferred HITL-hardening decision is made** (server-enforced two-phase confirmation vs. continued client-trust) — these are the higher-blast-radius, less-reversible writes; default recommendation is server-enforced two-phase for the config/destructive subset.
+4. **Per-token connection scoping (net-new, Q5)** — introduce an additive per-token connection allow-list so a write-capable agent token can be restricted to a subset of connections (OL has no such scoping today; §3 read/suggestion tools run at the user's existing global scope). *Acceptance*: a write/config tool call against a connection outside the token's allow-list is refused; default (no allow-list) preserves current global behavior for backward compatibility.
+
+**Dependencies**: Phase 0.
+
+### Configuration Changes
+- New dependency in `apps/api/package.json`: `@modelcontextprotocol/sdk` (see ADR-034). No `node-oidc-provider` in v1.
+- Env: MCP resource identifier / expected audience (names decided in Phase 0).
+
+### Database Migrations
+- Only the Phase 0 **MCP-token store** (`mcp_tokens`, or an extension of `refresh_tokens` — Q2): hashed token, owner user id, scopes, audience, expiry, revoked-at. **New table only — no changes to existing tables.** (No OAuth client-registration table — no AS in v1.)
+- Each new migration must follow the **synthetic sequential timestamp** convention (`migrations.md § Timestamp uniqueness invariant`) — re-prefix the `migration:generate` output to the next free synthetic timestamp, don't ship a raw `Date.now()` prefix (the ordering guard fails `pnpm lint` otherwise). Author it in the Phase 0 child issue (#1486).
+
+### File-naming note (for the child issues)
+- The MCP tool files (`tools/**/*.tool.ts`) introduce a `.tool.ts` suffix not yet in `engineering-standards.md § Files and Folders` — decide/register the convention in the Phase 1 issue (#1487) before code.
+- The Phase 0 MCP-token service + `tool-registry.service.ts` (Phase 1) follow the service-interface rule (an `implements` clause on an `I*Service` or a `*Port`). The `check-service-interfaces` invariant only scans `libs/core/src`, so `apps/api` won't fail the build, but the standard still applies.
+
+### Events / Error Handling
+- No new domain events. Reuse `CapabilityNotSupportedException` / `CapabilityNotEnabledException` (map to the MCP capability-not-available error shape). Auth failures → 401/403 via the Phase 0 guard.
+
+---
+
+## 7. Alternatives Considered
+
+*(Full treatment in [ADR-033](../architecture/adrs/033-openlinker-as-mcp-server.md) § Alternatives.)*
+
+- **Standalone third app** (mirror `apps/worker/`) — rejected: duplicated package + a third hand-synced plugin list (`apps/worker/src/plugins.ts` is already a maintained divergence) + a fresh HTTP bootstrap, for no benefit while MCP shares the API's auth/plugins/domain DI. Revisit only if MCP must scale/deploy independently.
+- **Full read-write surface now, on the current SDK** — rejected: maximizes blast radius during the protocol's most volatile window and before any demand signal.
+- **Static `tools/list`** — rejected: would advertise tools a connection can't service, breaking the capability contract and leaking a misleading surface to agents.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Pure Interface adapter over published application-service interfaces + capability ports; no CORE ↔ Integration change; no new domain logic. (ADR-033; `docs/architecture-overview.md § Capability Abstractions`.)
+
+### Naming Conventions
+- ✅ `*.controller.ts` / `*.service.ts` / `*.guard.ts` / `*.tool.ts` under `apps/api/src/mcp/`; Symbol DI tokens per `engineering-standards.md § Symbol DI Token Re-export Convention`.
+
+### Existing Patterns
+- ✅ Reuses `@Public()`/`VERSION_NEUTRAL`, `getCapabilityAdapter`, `is{X}` guards, `OAuthConnectionService`, `ConnectionService` — no new abstraction invented.
+
+### Risks
+- **Protocol churn** → mitigated by the stable-SDK-timing constraint + the 12-month lifecycle policy.
+- **Write exposure via an agent token** (OL is single-tenant, so this is blast-radius within one org, not cross-tenant) → mitigated by admin-scope + audit on every write, coarse consent at OAuth-grant time, and demand-gating Phase 3.
+- **Residual risk — v1 relies on the MCP client's tool-approval UX for per-action HITL** (an auto-approving or prompt-injected client can invoke a write without a fresh human confirmation). Accepted for v1 because reads (P1) need no gate and P2 writes are correctable/no-secrets; the named trigger to revisit is Phase 3's config/destructive writes, where server-enforced two-phase confirmation is the recommended hardening. Mapped to OWASP MCP (missing server-side authorization on state-changing operations).
+- **The MCP auth layer is net-new & security-critical** (RS validating user-issued PATs, ADR-034) → isolated as Phase 0, adversarially reviewed (OWASP MCP Top 10 checklist) before any tool ships.
+- **Long-lived bearer PAT = OWASP MCP01 (Token Mismanagement)** → mitigated (not eliminated) by hash-at-rest, expiry, scopes, one-time reveal, revocation, audience binding, rotation, plus admin-scope + audit + HITL-on-writes + the single-tenant/operator-controlled context. The short-lived-token OAuth AS is the deferred upgrade if this trade-off ever proves insufficient.
+- **Client-compatibility (load-bearing)** → a target MCP client that refuses a manual `Authorization` header would break the PAT model; validate per Q7 (~1 h) *before* Phase 0 code. **Spec is mid-transition** — re-verify against the ratified 2026-07-28 revision before code freeze.
+- **Partial mapping-shape neutralization (ADR-023)** → MCP binds to neutral core service interfaces, never the legacy `allegro*`/`prestashop*` HTTP DTOs.
+
+### Backward Compatibility
+- ✅ Purely additive; the MCP module is opt-in and inert until Phase 0 ships. No existing behavior changes.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+*(For the child issues — this EPIC ships no code and needs no tests.)*
+
+### Unit Tests
+- Phase 0: token validation (audience/issuer/resource/PKCE), `sub`→principal mapping, `.well-known` shape.
+- Phase 1: `tool-registry` per-connection narrowing (capable vs. not-enabled vs. not-supported).
+- Phase 2/3: HITL gate (rejected confirmation → no write), audit-log emission, the no-secret-in-args/returns invariant.
+
+### Integration Tests
+- One vertical slice per phase against Testcontainers (auth handshake → `tools/list` → a read tool; a HITL write round-trip).
+
+### Acceptance Criteria (this EPIC)
+- [x] ADR authored at `docs/architecture/adrs/033-openlinker-as-mcp-server.md` per the README template (decision, confidence, alternatives, capability-port→tool mapping, spec-native secret model, net-new auth gap, SDK-timing constraint).
+- [x] ADR registered in `docs/architecture/adrs/README.md` and cross-linked from `docs/architecture-overview.md § Capability Abstractions`.
+- [x] Implementation plan at `docs/plans/implementation-plan-mcp-server.md` covering all four phases, exact seams/services per phase, and the chosen wiring (`apps/api/src/mcp/` module vs standalone app).
+- [x] Plan documents the per-connection dynamic `tools/list` requirement (runtime `is{X}` guards) and the HITL-gating + audit-logging model for every write/config tool.
+- [x] Child issues drafted for Phase 0–3 and linked from EPIC #1350 as sub-issues: #1486 (P0), #1487 (P1), #1488 (P2), #1489 (P3) — Phases 1–3 declare a blocked-by-#1486 dependency (§ 11).
+- [x] Security model states the "no credential-argument tools; URL-mode elicitation / out-of-band entry only" invariant, mapped to OWASP MCP Top 10 + the MCP auth spec.
+- [x] No runtime code changes in this EPIC; no architecture boundary changes.
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture (Interface adapter over application services)
+- [x] Respects CORE vs Integration boundaries (no change to either)
+- [x] Uses existing patterns (no unnecessary abstractions)
+- [x] Idempotency considered (reuses idempotent connection/OAuth seams; reads are safe)
+- [x] Event-driven patterns used where applicable (n/a — no new events)
+- [x] Rate limits & retries addressed (inherited from adapters below the seam)
+- [x] Error handling comprehensive (reuses capability exceptions; auth 401/403)
+- [x] Testing strategy complete (per-phase, above)
+- [x] Naming conventions followed
+- [x] File structure matches standards (`apps/api/src/mcp/`)
+- [x] Plan is execution-ready (per phase, seam-precise)
+- [x] Plan is saved as markdown file
+
+---
+
+## 11. Child-Issue Breakdown (to create + link from EPIC #1350 on ship)
+
+Each is a sub-issue of #1350; Phases 1–3 declare a **blocked-by Phase 0** dependency.
+
+1. **Phase 0 — `[MCP] Client↔server OAuth 2.1 resource-server auth layer`** (CORE/Interface + security). Deliver: `.well-known/oauth-protected-resource`, token validation (PKCE/RFC 8707/RFC 9207/audience), `sub`→OL-principal mapping (+ store), `McpModule` wired into `app.module.ts`. **Gates all others.** Labels: `enhancement`, `security`.
+2. **Phase 1 — `[MCP] Read-only domain tools (ProductMaster / InventoryMaster / OrderSource)`** (Interface). Deliver: per-connection dynamic `tools/list`, read tools over `getCapabilityAdapter`, read audit log. Blocked-by Phase 0. Labels: `enhancement`.
+3. **Phase 2 — `[MCP] Mapping assistant tools + configure-mappings Skill`** (Interface). Deliver: discovery/suggestion tools over neutral `IMappingConfigService`/`ICategoryResolutionService`/`IAttributeProjectionService`/options-readers/EAN matcher; HITL write tools; Skill. Bind to neutral core interfaces (not legacy HTTP DTOs). Blocked-by Phase 0. Labels: `enhancement`.
+4. **Phase 3 — `[MCP] Secure connection setup (URL-mode elicitation + branded key-entry page)`** (Interface + small Frontend). Deliver: `start_connection` (OAuth reuse + API-key page), the net-new key-entry page → `PUT /connections/:id/credentials`, non-secret orchestration tools (status/test/webhooks/config/capability), all HITL for writes. Blocked-by Phase 0. Labels: `enhancement`, `security`.
+
+---
+
+## Related Documentation
+- [ADR-033: Expose OpenLinker as an MCP server](../architecture/adrs/033-openlinker-as-mcp-server.md)
+- [Architecture Overview](../architecture-overview.md)
+- [Engineering Standards](../engineering-standards.md)
+- [Testing Guide](../testing-guide.md)
+- [Code Review Guide](../code-review-guide.md)


### PR DESCRIPTION
## What & why

Planning-only deliverable for EPIC #1350 — **no runtime code**. Turns the "should OL expose itself as an MCP server?" research into a committed decision + phased plan + child issues, before any code is written.

## Deliverables

- **ADR-033** (`docs/architecture/adrs/033-openlinker-as-mcp-server.md`, Proposed) — conditional-yes to expose OL as an MCP **server**, as a pure Interface-layer adapter over existing application services (**no CORE↔Integration change**). Records the capability-port→tool mapping onto the `getCapabilityAdapter` seam, the dynamic capability-declared `tools/list`, the spec-native secret model (URL-mode elicitation / out-of-band entry, **no credential-argument tools**; OWASP MCP01), the net-new auth gap (see ADR-034), the SDK-timing constraint (stable TS SDK v2, ~post-28 Jul 2026), and the in-API `apps/api/src/mcp/` wiring choice over a standalone app. Registered in the ADR index; cross-linked from `architecture-overview.md § Capability Abstractions`.
- **ADR-034** (`docs/architecture/adrs/034-mcp-authorization-user-issued-pats.md`, Proposed) — the MCP auth layer. **OL is an OAuth 2.1 Resource Server that validates its own user-issued Personal Access Tokens (GitHub-PAT style) — no Authorization Server in v1.** Two deep-research passes established that MCP authorization is **OPTIONAL** (the OAuth profile is a conditional `SHOULD`, not a `MUST`) and that a user-pasted `Authorization: Bearer <PAT>` is exactly how **GitHub / Atlassian Rovo / Sentry** ship remote MCP servers; the one OAuth-only counter-example (Notion) is driven by multi-tenancy, which single-tenant self-hosted OL does not share. An embedded/external OAuth AS is a **deferred optional upgrade** behind the same RS seam.
- **Implementation plan** (`docs/plans/implementation-plan-mcp-server.md`) — 4 phases (Phase 0 RS/PAT auth gate → P1 read tools → P2 mapping assistant → P3 secure setup), each naming the exact services/seams it calls into, the dynamic capability-declared `tools/list`, and the write/config safety model.
- **Pre-implement gate verdict** (`docs/plans/analysis/`) — **READY**; greenfield confirmed; corrected one over-optimistic reuse claim (no reusable rate limiter exists — the per-token cap is net-new).

## Design refined via `/grill-me` + two deep-research passes + `/pre-implement` + `/tech-review`

- **Auth moved to the simplest viable shape.** The decision walked own-AS → RS + embedded AS (`node-oidc-provider`) → **RS validating user-issued PATs, no AS** — each simpler, driven by "MCP auth is optional + PAT is how the incumbents ship + OL is single-tenant so needs no delegated consent." Phase 0 shrank from ~6–10 d to ~2–4 d (bearer guard + PAT mint/store/hardening; no AS/DCR/consent). Trade-off recorded: a long-lived bearer PAT is **OWASP MCP01** (concrete exposure = the token in plaintext in the client's config file), mitigated by a **read/write scope floor** + hardening + admin-scope + audit + the single-tenant context. **Load-bearing risk:** the target MCP client must accept a manual `Authorization` header for a remote server — validate ~1 h before Phase 0 code.
- `sub` → OL user **inherits its RBAC role**; OL is **single-tenant**, so there is **no per-user connection scoping** (corrected a wrong "allowed connectionIds" assumption). Per-token connection scoping is deferred to Phase 3 (writes), as a refinement of the ADR-034 scope model.
- v1 HITL **trusts the MCP client's tool-approval UX** + the coarse consent implied when the operator mints + installs an admin-scoped token, bounded by admin-scope + audit; server-enforced two-phase confirmation is a named, deferred Phase-3 hardening.
- `tools/list` is **dynamic and capability-declared** (each tool declares a required capability; a base port backs several tools, a decomposed port one per sub-capability; `connectionId` as an argument; `list_changed` on change).
- Official `@modelcontextprotocol/sdk` + Streamable HTTP, **no** NestJS wrapper.
- Added a **per-token rate/concurrency cap** (net-new) as an abuse invariant.

## Child issues (created + linked as sub-issues of the EPIC; Phases 1–3 blocked-by Phase 0)

- #1486 — Phase 0: Resource-Server auth via user-issued Personal Access Tokens (MCP tokens)
- #1487 — Phase 1: read-only domain tools
- #1488 — Phase 2: mapping assistant + Skill
- #1489 — Phase 3: secure connection setup

## Test plan

Docs-only — no code, no new tests. Verified: `check-repo-urls` passes; all ADR cross-links resolve; both ADRs follow the README template + numbering (033/034, with 031/032 confirmed on main); pre-commit `smart-test` classifies it as docs-only (no affected packages).

Closes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)