### PR TITLE
fix(listings,woocommerce): publish carries the variant SKU (#1485)

### DIFF
--- a/docs/plans/analysis/ANALYSIS-implementation-plan-publish-product-sku.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-publish-product-sku.md
@@ -1,0 +1,48 @@
+# Pre-Implement Analysis: implementation-plan-publish-product-sku.md
+
+**Gate date**: 2026-07-12
+**Plan**: [docs/plans/implementation-plan-publish-product-sku.md](../implementation-plan-publish-product-sku.md)
+**Issue**: #1485 (BUG — shop product publish drops the SKU)
+**Reviewer**: OpenLinker Tech Lead (read-only readiness gate)
+
+---
+
+## Verdict: **READY** (one scope note to record, not a blocker)
+
+The plan is a purely additive, optional-field change. Every assumption verified against `origin/main`: the field is genuinely new, the neutral command has exactly one construction site, and no published contract surface is broken. **The one thing the plan/issue under-stated — a *second* `ShopProductManagerPort` implementor (PrestaShop) exists — turns out to *reinforce* the plan rather than break it**, but the reason is subtle enough to record before coding.
+
+---
+
+## Reuse findings (does it already exist?)
+
+| Plan artifact | Class | Evidence |
+|---|---|---|
+| `PublishProductCommand.sku?` | **NEW** | `git show origin/main:…/product-publish.types.ts` → no `sku` (grep exit 1). Confirmed absent. |
+| Variant SKU source | **REUSE** | `ProductVariant.sku: string \| null` (`libs/core/src/products/domain/entities/product-variant.entity.ts:20`); already fetched at builder line 70 via `IProductsService.getVariant`. |
+| Command construction site | **REUSE (single)** | `git grep "PublishProductCommand = {"` on `origin/main` → only `product-publish-builder.service.ts:108`. `ProductPublishExecutionService` (single + bulk) calls the builder — no other literal. Fixing the builder covers all publish paths. |
+| `WooCommerceProductPublishRequest.sku?` | **NEW** | Wire type had no `sku`; WC `products` resource natively supports it. |
+| WC adapter mapping | **PARTIAL (extend)** | `buildProductBody` exists; add one `if (cmd.sku != null) …` line. |
+
+## Backward-compatibility findings
+
+| Surface | Assessment |
+|---|---|
+| Top-level barrel `@openlinker/core/listings` | **No break** — `PublishProductCommand` is exported (`index.ts:303` block); adding an **optional** field is additive. No consumer constructs it except the builder. |
+| Port signatures | **No change** — `ShopProductManagerPort.publishProduct(cmd)` unchanged; `cmd` shape widened additively. |
+| DTO shapes | **N/A** — no HTTP request/response DTO touched. |
+| Symbol tokens | **No change.** |
+| ORM schema | **No change → no migration.** SKU is read from the existing `ProductVariant`; nothing persisted. |
+| `check:invariants` | **No expected trip** — no cross-context deep import (WC already imports the type from the barrel), builder still `implements IProductPublishBuilderService`, no repo-URL change. |
+
+## Open questions (record before/at implementation)
+
+1. **A second `ShopProductManagerPort` implementor exists — PrestaShop — and must be left untouched, deliberately.** `PrestashopProductPublisherAdapter.buildProductBody` (`…/prestashop-product-publisher.adapter.ts:191`) already sets **`reference: cmd.internalVariantId`** and uses that same `reference` as its **idempotency / orphan-recovery key** (`findExistingByReference`, lines 96/101/234, #1107). So:
+   - PrestaShop's `reference` is intentionally the **internal variant id**, *not* the human SKU. Naively mapping the new `cmd.sku → reference` would **break** #1107 idempotent upsert.
+   - The plan's "optional field; publishers that don't map it are unaffected" is therefore **correct and important** — PrestaShop correctly ignores `cmd.sku` and keeps its reference-as-idempotency-key contract.
+   - Net effect: the "publish drops the SKU" symptom is **WooCommerce-specific**; PrestaShop already carries a stable identifier (just not the human SKU). **Whether PrestaShop should *additionally* surface the human SKU (e.g. in a different PS field) is a separate design question — out of scope for #1485, worth a follow-up issue.**
+
+2. **Bulk publish** rides the same builder via `ProductPublishExecutionService`, so it inherits the fix with no extra work — confirmed, not an open risk.
+
+## Recommendation
+
+Proceed as planned. **Do not** extend the change to the PrestaShop publisher in this issue — its `reference` field is a deliberate idempotency key, not the SKU. Add a one-line note in the PR body that PrestaShop is intentionally out of scope for the reason above, and (optionally) file a follow-up for "PrestaShop publish: surface the human SKU alongside the reference-as-idempotency-key" if that's wanted.

--- a/docs/plans/implementation-plan-publish-product-sku.md
+++ b/docs/plans/implementation-plan-publish-product-sku.md
@@ -1,0 +1,56 @@
+# Implementation Plan — Publish carries the variant SKU (#1485)
+
+## 1. Understand the task
+
+**Goal:** a product published to a shop must carry its OL variant SKU. Today the neutral `PublishProductCommand` has no `sku` field, so `WooCommerceProductPublisherAdapter` sets nothing and every published WooCommerce product comes out with `sku: ""` — breaking SKU-keyed reconciliation / inventory / automation on the shop side.
+
+**Classification:** CORE (domain type + application builder) + Integration (WooCommerce adapter). No new ports, no schema/ORM change, no migration.
+
+**Non-goals (explicitly out of scope):**
+- Category-on-publish (`getProductCategories` MVP deferral) — tracked elsewhere.
+- Variable-product / variations grouping.
+- Threading SKU into marketplace `createOffer` (offer side already carries identifiers via its own path).
+- **The PrestaShop `ProductPublisher` is intentionally NOT modified.** It already sets `reference = internalVariantId` and uses that `reference` as its idempotency / orphan-recovery key (`prestashop-product-publisher.adapter.ts:191`, #1107). Mapping the new `cmd.sku → reference` would break PS upsert — the optional field correctly leaves PS untouched (it ignores `cmd.sku`). Whether PS should *additionally* surface the human SKU in a separate field is a **separate follow-up**, not this issue. (See the pre-implement analysis for the full rationale.)
+
+## 2. Research (established facts)
+
+- `PublishProductCommand` — `libs/core/src/listings/domain/types/product-publish.types.ts`. Optional-field convention already in use (`content?`, `parameters?`, `externalProductId?`).
+- **Sole construction site:** `ProductPublishBuilderService.buildPublishProductCommand` (`libs/core/src/listings/application/services/product-publish-builder.service.ts:108`). `ProductPublishExecutionService` (single **and** bulk) calls the builder — no other literal builds the command. Fixing the builder covers all publish paths.
+- The builder already fetches the variant at line 70: `const variant = await this.productsService.getVariant(input.internalVariantId)`. `IProductsService.getVariant → ProductVariant | null`; `ProductVariant.sku: string | null` (`libs/core/src/products/domain/entities/product-variant.entity.ts:20`).
+- WooCommerce wire type `WooCommerceProductPublishRequest` — `.../product-publisher/woocommerce-product-publish.types.ts`. `buildProductBody` (`woocommerce-product-publisher.adapter.ts:110`) assembles the sparse body (spreads `platformParams` first so modelled fields win). WooCommerce product resource natively has a `sku` string field.
+- Existing specs to mirror: `product-publish-builder.service.spec.ts` (mocks `getVariant` returning `{ …, sku: null }`) and `.../product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts` (`baseCommand()` + body `toMatchObject`).
+
+## 3. Design
+
+Additive, optional, neutral field threaded variant → command → adapter. No platform vocabulary in core (`sku` is a neutral variant field).
+
+```
+ProductVariant.sku ──(builder)──▶ PublishProductCommand.sku? ──(WC adapter)──▶ WC products.sku
+     string|null        omit when null/empty        string?         set when present
+```
+
+## 4. Steps
+
+1. **Domain type** — `product-publish.types.ts`: add `sku?: string` to `PublishProductCommand` with a doc comment (variant-level identifier; publishers that support a SKU field map it, others ignore; absent ⇒ unchanged).
+   *AC:* type compiles; field optional.
+
+2. **Builder** — `product-publish-builder.service.ts` (~line 116): add `...(variant.sku ? { sku: variant.sku } : {})` to the command literal. `variant.sku` is `string | null` → only set when a non-empty string (spread-omit convention, matching `content`/`parameters`).
+   *AC:* variant SKU threads into the command; `null`/empty variant SKU ⇒ field absent.
+
+3. **WC wire type** — `woocommerce-product-publish.types.ts`: add `sku?: string` to `WooCommerceProductPublishRequest`.
+   *AC:* type compiles.
+
+4. **WC adapter** — `woocommerce-product-publisher.adapter.ts` `buildProductBody`: `if (cmd.sku != null) typed.sku = cmd.sku;` (applies to both create + upsert, which share `buildProductBody`).
+   *AC:* `sku` written to body when present; omitted when absent.
+
+5. **Tests**
+   - Builder spec: add a case with `getVariant` returning a non-null `sku` → asserts `command.sku` equals it; keep/assert the existing `sku: null` mock path yields **no** `sku` key.
+   - WC adapter spec: `baseCommand({ sku: 'SKU-1' })` → body `toMatchObject({ sku: 'SKU-1' })` (create); assert `baseCommand()` (no sku) → body has **no** `sku` key; one upsert (PUT) assertion that `sku` is present.
+   *AC:* both present + absent branches covered on builder and adapter.
+
+## 5. Validate
+
+- **Architecture:** neutral field in core; adapter maps neutral→wire — no platform term leaks into core. Optional field ⇒ no publisher behavior change (PrestaShop/Shopify publishers, if any, ignore it).
+- **Contract surface:** additive optional field on a published domain type — **not** a break (no removed/renamed/newly-required field). No barrel/token/DTO/ORM change ⇒ no migration, no `check:invariants` trip.
+- **Testing:** unit only (no vertical slice added). Builder + adapter specs cover present/absent.
+- **Pre-implement gate:** **unnecessary** — purely additive optional field, single known builder construction site verified, one adapter, no schema/contract change. Documented here rather than a separate analysis file.

--- a/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
@@ -99,6 +99,24 @@ describe('ProductPublishBuilderService', () => {
       expect.objectContaining({ title: 'Widget', description: 'A widget', imageUrls: ['http://img'] })
     );
     expect(command.status).toBe('published');
+    // Default mock variant has sku: null ⇒ the key is spread-omitted entirely
+    // (not merely set to undefined).
+    expect(command).not.toHaveProperty('sku');
+  });
+
+  it('should thread the variant SKU into the command when the variant has one', async () => {
+    products.getVariant.mockResolvedValue({
+      id: VARIANT,
+      productId: 'prod-1',
+      attributes: { Brand: 'Acme' },
+      ean: null,
+      gtin: null,
+      sku: 'SKU-123',
+    });
+
+    const command = await service.buildPublishProductCommand(baseInput);
+
+    expect(command.sku).toBe('SKU-123');
   });
 
   it('should publish uncategorised when the shop adapter is not a CategoryProvisioner', async () => {

--- a/libs/core/src/listings/application/services/product-publish-builder.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-builder.service.ts
@@ -113,6 +113,10 @@ export class ProductPublishBuilderService implements IProductPublishBuilderServi
       price: price as { amount: number; currency: string },
       stock: input.stock,
       status: input.status,
+      // Thread the variant SKU so shop products publish with a reference the
+      // shop can key on (reconciliation, inventory-by-SKU). Omitted when the
+      // variant has no SKU, matching the spread-omit convention below.
+      ...(variant.sku ? { sku: variant.sku } : {}),
       ...(content ? { content } : {}),
       ...(parameters.length > 0 ? { parameters } : {}),
       ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),

--- a/libs/core/src/listings/domain/types/product-publish.types.ts
+++ b/libs/core/src/listings/domain/types/product-publish.types.ts
@@ -66,6 +66,13 @@ export interface PublishProductContent {
 export interface PublishProductCommand {
   /** OL internal variant id being published. */
   internalVariantId: string;
+  /**
+   * Variant SKU / reference (OL variants own the SKU). Populated from
+   * `ProductVariant.sku` by the publish builder. Optional: publishers that
+   * expose a SKU field map it; those that don't simply ignore it. Absent ⇒ the
+   * publisher does not set a SKU (created without one / left unchanged on update).
+   */
+  sku?: string;
   /** Target shop connection id. */
   connectionId: string;
   /**

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
@@ -80,7 +80,30 @@ describe('WooCommerceProductPublisherAdapter', () => {
         categories: [{ id: 12 }],
         attributes: [{ name: 'Color', options: ['Red'], visible: true }],
       });
+      // baseCommand carries no sku ⇒ the key must be absent. `toMatchObject`
+      // above ignores missing keys, so this negative assertion is what guards
+      // against the field being silently dropped again (#1485).
+      expect(body).not.toHaveProperty('sku');
       expect(result).toEqual({ externalProductId: '100', status: 'published' });
+    });
+
+    it('should write the SKU to the body when the command carries one (create + upsert)', async () => {
+      http.post.mockResolvedValue({ id: 5, status: 'publish' });
+      http.put.mockResolvedValue({ id: 5, status: 'publish' });
+
+      await adapter.publishProduct(baseCommand({ sku: 'SKU-1' }));
+      expect(http.post.mock.calls[0][1]).toMatchObject({ sku: 'SKU-1' });
+
+      await adapter.publishProduct(baseCommand({ sku: 'SKU-1', externalProductId: '5' }));
+      expect(http.put.mock.calls[0][1]).toMatchObject({ sku: 'SKU-1' });
+    });
+
+    it('should omit the SKU key when the command has none', async () => {
+      http.post.mockResolvedValue({ id: 6, status: 'publish' });
+
+      await adapter.publishProduct(baseCommand());
+
+      expect(http.post.mock.calls[0][1]).not.toHaveProperty('sku');
     });
 
     it('should PUT to the product id on upsert (externalProductId present)', async () => {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publish.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publish.types.ts
@@ -21,6 +21,8 @@ export type WooCommerceProductStatus = 'publish' | 'draft' | 'pending' | 'privat
  */
 export interface WooCommerceProductPublishRequest {
   name?: string;
+  /** Product SKU / reference. Maps the neutral `PublishProductCommand.sku`. */
+  sku?: string;
   type?: 'simple';
   status?: WooCommerceProductStatus;
   regular_price?: string;

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
@@ -117,6 +117,10 @@ export class WooCommerceProductPublisherAdapter
       stock_quantity: cmd.stock,
     };
 
+    // Truthy (not `!= null`) so an empty string is treated as absent, matching
+    // the builder's spread-omit and avoiding an empty `sku` clearing the WC
+    // product's SKU on upsert.
+    if (cmd.sku) typed.sku = cmd.sku;
     if (content?.title != null) typed.name = content.title;
     if (content?.description != null) typed.description = content.description;
     if (content?.imageUrls != null) typed.images = content.imageUrls.map((src) => ({ src }));


### PR DESCRIPTION
## What & why

Publishing a product to a shop dropped the SKU. The neutral `PublishProductCommand` carried no `sku` field, so `WooCommerceProductPublisherAdapter` had nothing to set and every published WooCommerce product came out with `sku: ""` — breaking SKU-keyed reconciliation, inventory-by-SKU, and any downstream SKU-keyed automation on the shop side. It's a CORE contract gap, not just a WooCommerce oversight (verified end-to-end on the demo stack; the golden-path E2E #1481 had to match the WC product by *name* because the SKU lookup never resolved).

## Change (neutral optional field, threaded core → adapter)

- **Domain type** (`product-publish.types.ts`) — add optional `sku?: string` to `PublishProductCommand`. Optional so publishers that don't expose a SKU field ignore it; nothing breaks.
- **Builder** (`product-publish-builder.service.ts`) — thread `ProductVariant.sku` into the command (spread-omit when the variant has no SKU). This is the **sole** command construction site; single- **and** bulk-publish both flow through it via `ProductPublishExecutionService`, so all publish paths are covered.
- **WooCommerce adapter** (`buildProductBody`) — map `cmd.sku` → WooCommerce `sku` on create **and** upsert; add the field to the WC wire type. Uses a truthy guard so an empty SKU is treated as absent (never clears an existing WC SKU on upsert).
- **Tests** — builder threads/omits (`not.toHaveProperty` proves omission); WC adapter writes on create+upsert and omits when absent, incl. a negative `not.toHaveProperty('sku')` assertion that closes the `toMatchObject` blind spot which let the bug ship.

## Scope notes

- **PrestaShop's `ProductPublisher` is intentionally NOT modified.** It already sets `reference = internalVariantId` and uses that `reference` as its idempotency / orphan-recovery key (#1107); mapping `sku → reference` would break PS upsert. The optional field correctly leaves PS untouched (it ignores `cmd.sku`). Whether PS should *additionally* surface the human SKU in a separate field is a **separate follow-up**.
- **Behavioral consequence:** WooCommerce rejects duplicate SKUs (`product_invalid_sku`, 400). A variant whose SKU collides with an existing WC product — previously published fine with a blank SKU — will now be rejected. This is correct behavior and is handled gracefully (the adapter already maps WC 4xx → `ProductPublishRejectedException` = `business_failure`, not a crash). Flagging so operators aren't surprised by newly-failing publishes on colliding SKUs.

## No schema change / no migration

SKU is read from the existing `ProductVariant` — nothing persisted.

## Test plan

- `pnpm type-check` — clean (repo-wide)
- `pnpm lint` — clean (all 12 `check:invariants` pass)
- `@openlinker/core` unit — 1471 passed; `@openlinker/integrations-woocommerce` unit — 314 passed
- New unit coverage: builder present/absent, WC adapter present (create+upsert)/absent

## Process

Planned + gated before coding: `/pre-implement` (READY — surfaced the PrestaShop second-publisher nuance) and `/tech-review` on the plan, then a deep `/tech-review` on the code (all suggestions applied). Plan + analysis under `docs/plans/`.

Closes #1485

🤖 Generated with [Claude Code](https://claude.com/claude-code)