### PR TITLE
fix(inventory): prune stale inventory_items for variants deleted at the master

### DIFF
--- a/apps/api/src/migrations/1818000000007-add-inventory-item-is-stale.ts
+++ b/apps/api/src/migrations/1818000000007-add-inventory-item-is-stale.ts
@@ -1,0 +1,34 @@
+/**
+ * Add Inventory Item isStale Migration
+ *
+ * Adds the `isStale` boolean column to `inventory_items` (#1478). The master
+ * inventory sync soft-marks a row as stale when its variant stops appearing in
+ * the master's `listInventory` response (variant deleted at the master), rather
+ * than hard-deleting it — so debugging history is preserved. Stale rows are
+ * excluded from the variant-availability read the offer flows act on. Defaults
+ * `false` so all existing rows backfill to "live".
+ *
+ * Column name is camelCase (`isStale`) to match TypeORM's default naming — the
+ * repo sets no naming strategy, so ORM property names are the column names
+ * (cf. `availableQuantity`, `productVariantId`, `paymentStatus`).
+ *
+ * Generated: 2026-07-12 (synthetic sequential prefix per docs/migrations.md #1013).
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddInventoryItemIsStale1818000000007 implements MigrationInterface {
+  name = 'AddInventoryItemIsStale1818000000007';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "inventory_items" ADD COLUMN IF NOT EXISTS "isStale" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "inventory_items" DROP COLUMN IF EXISTS "isStale"`,
+    );
+  }
+}

--- a/apps/api/test/integration/inventory-stale-prune.int-spec.ts
+++ b/apps/api/test/integration/inventory-stale-prune.int-spec.ts
@@ -1,0 +1,222 @@
+/**
+ * Inventory Stale-Prune Integration Test (#1478)
+ *
+ * Vertical slice for the soft-delete of orphaned inventory rows. Seeds a product
+ * with per-variant inventory, then drives the public inventory services against
+ * Postgres to assert:
+ * - `pruneStaleVariants` flags rows whose variant is absent from the keep set and
+ *   leaves kept rows live (variant-level and product-level `null`);
+ * - `getAvailabilityByVariantIds` excludes stale rows (zero-fills them);
+ * - a reappearing variant clears its own `isStale` flag through `setInventory`,
+ *   without creating a duplicate row.
+ *
+ * Uses real Postgres via Testcontainers.
+ *
+ * @module apps/api/test/integration
+ */
+import { DataSource, IsNull } from 'typeorm';
+import {
+  ProductOrmEntity,
+  ProductVariantOrmEntity,
+} from '@openlinker/core/products/orm-entities';
+import { InventoryItemOrmEntity } from '@openlinker/core/inventory/orm-entities';
+import {
+  IInventoryService,
+  IInventoryQueryService,
+  InventoryItemEntity,
+  INVENTORY_SERVICE_TOKEN,
+  INVENTORY_QUERY_SERVICE_TOKEN,
+} from '@openlinker/core/inventory';
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+
+interface SeedRow {
+  variantId: string | null;
+  availableQuantity: number;
+}
+
+/** Seeds one product + its variants + one inventory row per spec entry (location null). */
+async function seedProduct(
+  dataSource: DataSource,
+  rows: SeedRow[],
+): Promise<{ productId: string }> {
+  const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+  const productId = `ol_product_stale_${suffix}`;
+
+  const productRepo = dataSource.getRepository(ProductOrmEntity);
+  await productRepo.save(
+    productRepo.create({ id: productId, name: `Stale Test ${suffix}`, sku: null, price: null }),
+  );
+
+  const variantRepo = dataSource.getRepository(ProductVariantOrmEntity);
+  const inventoryRepo = dataSource.getRepository(InventoryItemOrmEntity);
+
+  for (const row of rows) {
+    if (row.variantId !== null) {
+      await variantRepo.save(
+        variantRepo.create({
+          id: row.variantId,
+          productId,
+          sku: null,
+          attributes: null,
+          ean: null,
+          gtin: null,
+        }),
+      );
+    }
+    await inventoryRepo.save(
+      inventoryRepo.create({
+        id: `ol_inventory_${row.variantId ?? 'base'}_${suffix}`,
+        productId,
+        productVariantId: row.variantId,
+        availableQuantity: row.availableQuantity,
+        reservedQuantity: 0,
+        locationId: null,
+      }),
+    );
+  }
+
+  return { productId };
+}
+
+describe('Inventory stale-prune (#1478)', () => {
+  let harness: IntegrationTestHarness;
+  let inventoryService: IInventoryService;
+  let queryService: IInventoryQueryService;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    inventoryService = harness.getApp().get<IInventoryService>(INVENTORY_SERVICE_TOKEN);
+    queryService = harness.getApp().get<IInventoryQueryService>(INVENTORY_QUERY_SERVICE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('marks variant rows absent from the keep set stale and leaves kept rows live', async () => {
+    const dataSource = harness.getDataSource();
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const variantKeep = `ol_variant_keep_${suffix}`;
+    const variantGone = `ol_variant_gone_${suffix}`;
+
+    const { productId } = await seedProduct(dataSource, [
+      { variantId: variantKeep, availableQuantity: 5 },
+      { variantId: variantGone, availableQuantity: 3 },
+    ]);
+
+    const marked = await inventoryService.pruneStaleVariants(productId, [variantKeep]);
+    expect(marked).toBe(1);
+
+    const inventoryRepo = dataSource.getRepository(InventoryItemOrmEntity);
+    const kept = await inventoryRepo.findOneBy({ productId, productVariantId: variantKeep });
+    const gone = await inventoryRepo.findOneBy({ productId, productVariantId: variantGone });
+    expect(kept?.isStale).toBe(false);
+    expect(gone?.isStale).toBe(true);
+  });
+
+  it('excludes stale rows from the variant-availability read', async () => {
+    const dataSource = harness.getDataSource();
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const variantKeep = `ol_variant_keep_${suffix}`;
+    const variantGone = `ol_variant_gone_${suffix}`;
+
+    const { productId } = await seedProduct(dataSource, [
+      { variantId: variantKeep, availableQuantity: 5 },
+      { variantId: variantGone, availableQuantity: 3 },
+    ]);
+    await inventoryService.pruneStaleVariants(productId, [variantKeep]);
+
+    const availability = await queryService.getAvailabilityByVariantIds([variantKeep, variantGone]);
+    const byId = new Map(availability.map((a) => [a.productVariantId, a.totalAvailable]));
+
+    // Kept variant keeps its stock; stale variant is excluded from the aggregate
+    // and therefore zero-filled by the query service.
+    expect(byId.get(variantKeep)).toBe(5);
+    expect(byId.get(variantGone)).toBe(0);
+  });
+
+  it('clears isStale when a variant reappears via setInventory, reusing the same row', async () => {
+    const dataSource = harness.getDataSource();
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const variantKeep = `ol_variant_keep_${suffix}`;
+    const variantGone = `ol_variant_gone_${suffix}`;
+
+    const { productId } = await seedProduct(dataSource, [
+      { variantId: variantKeep, availableQuantity: 5 },
+      { variantId: variantGone, availableQuantity: 3 },
+    ]);
+    await inventoryService.pruneStaleVariants(productId, [variantKeep]);
+
+    // The gone variant reappears at the master — a fresh (live) canonical write.
+    await inventoryService.setInventory(
+      new InventoryItemEntity(
+        `ignored-${suffix}`,
+        productId,
+        variantGone,
+        4,
+        0,
+        null,
+        new Date(),
+        false,
+      ),
+    );
+
+    const inventoryRepo = dataSource.getRepository(InventoryItemOrmEntity);
+    const rows = await inventoryRepo.find({ where: { productId, productVariantId: variantGone } });
+    expect(rows).toHaveLength(1); // no duplicate created
+    expect(rows[0].isStale).toBe(false);
+    expect(rows[0].availableQuantity).toBe(4);
+
+    const availability = await queryService.getAvailabilityByVariantIds([variantGone]);
+    expect(availability.find((a) => a.productVariantId === variantGone)?.totalAvailable).toBe(4);
+  });
+
+  it('marks a product-level (null-variant) row stale when the keep set omits null', async () => {
+    const dataSource = harness.getDataSource();
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const variantKeep = `ol_variant_keep_${suffix}`;
+
+    const { productId } = await seedProduct(dataSource, [
+      { variantId: variantKeep, availableQuantity: 5 },
+      { variantId: null, availableQuantity: 9 },
+    ]);
+
+    const marked = await inventoryService.pruneStaleVariants(productId, [variantKeep]);
+    expect(marked).toBe(1);
+
+    const inventoryRepo = dataSource.getRepository(InventoryItemOrmEntity);
+    const baseRow = await inventoryRepo.findOneBy({ productId, productVariantId: IsNull() });
+    const keptRow = await inventoryRepo.findOneBy({ productId, productVariantId: variantKeep });
+    expect(baseRow?.isStale).toBe(true);
+    expect(keptRow?.isStale).toBe(false);
+  });
+
+  it('keeps a product-level (null-variant) row live when the keep set includes null', async () => {
+    const dataSource = harness.getDataSource();
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const variantGone = `ol_variant_gone_${suffix}`;
+
+    const { productId } = await seedProduct(dataSource, [
+      { variantId: null, availableQuantity: 9 },
+      { variantId: variantGone, availableQuantity: 3 },
+    ]);
+
+    const marked = await inventoryService.pruneStaleVariants(productId, [null]);
+    expect(marked).toBe(1);
+
+    const inventoryRepo = dataSource.getRepository(InventoryItemOrmEntity);
+    const baseRow = await inventoryRepo.findOneBy({ productId, productVariantId: IsNull() });
+    const goneRow = await inventoryRepo.findOneBy({ productId, productVariantId: variantGone });
+    expect(baseRow?.isStale).toBe(false);
+    expect(goneRow?.isStale).toBe(true);
+  });
+});

--- a/docs/plans/analysis/ANALYSIS-implementation-plan-inventory-prune-stale-variants.md
+++ b/docs/plans/analysis/ANALYSIS-implementation-plan-inventory-prune-stale-variants.md
@@ -1,0 +1,41 @@
+# Pre-implement gate — ANALYSIS: Prune stale inventory_items (#1478)
+
+**Verdict: READY** (one must-apply correction recorded below — trivial, no plan restructure needed).
+
+## Reuse findings
+
+| Plan artifact | Status | Evidence |
+|---|---|---|
+| `InventoryItem.isStale` field | **NEW** | No `isStale`/`is_stale` anywhere in `libs`/`apps`. |
+| `inventory_items.isStale` column | **NEW** | Grep clean; ORM entity has no such column. |
+| Migration `1818000000007-add-inventory-item-is-stale` | **NEW** | Tail on `main` = `1818000000006`; `1818000000007` is free + strictly greater. |
+| `InventoryRepositoryPort.markStaleExceptVariants` | **NEW** | No `markStale`/`prune` method exists on the port. |
+| `IInventoryService.pruneStaleVariants` | **NEW** | No such method exists. |
+| Read-side exclusion on `findAvailabilityByVariantIds` | **PARTIAL (extend existing)** | Method exists (`inventory.repository.ts:103`); plan adds one `andWhere`. |
+| Sync wiring in `MasterInventorySyncService` | **PARTIAL (extend existing)** | Adds a post-loop prune call to the existing method. |
+
+No reuse collisions. Every "new" artifact is genuinely absent.
+
+## Backward-compatibility findings
+
+| Surface | Result | Severity |
+|---|---|---|
+| `InventoryRepositoryPort` (add method) | Only **one** implementer — `InventoryRepository` (`inventory.repository.ts:31`). No in-memory/second impl to break. | OK |
+| `IInventoryService` (add method) | Only **one** implementer — `InventoryService` (`inventory.service.ts:22`). | OK |
+| `InventoryItem` ctor (add field) | New param is **last + defaulted `= false`** → all 7 existing `new InventoryItem(...)` call sites compile unchanged. | OK |
+| Top-level barrel `@openlinker/core/inventory` | Only **additions** (no exported symbol removed/renamed). | OK |
+| Response/view surface (`InventoryItemView`) | `InventoryQueryService.compose` maps fields **explicitly** — a new domain field does **not** auto-leak into API responses. `isStale` stays internal (correct for this issue; FE surfacing deferred). | OK |
+| ORM schema change ⇒ migration | Required and planned; additive `NOT NULL DEFAULT false`, self-healing. | Warning (expected) |
+| `check:invariants` | No cross-context import change; the new service method is backed by an existing `implements` clause (`check-service-interfaces` satisfied); migration prefix/class-suffix invariant honoured. | OK |
+
+## Must-apply correction (recorded — gate does not edit the plan)
+
+- **Migration column name is `isStale`, NOT `is_stale`.** `apps/api/src/database/data-source.ts` sets **no** `namingStrategy`, so TypeORM uses property names verbatim as column names — existing columns are camelCase (`availableQuantity`, `reservedQuantity`, `productVariantId`, `locationId`), and the recent `AddInvoicePaymentStatus` migration added `"paymentStatus"`, not `payment_status`. The plan (following the issue text) proposed `is_stale`; that would create a column the ORM entity never reads (`@Column isStale` → column `"isStale"`), yielding a runtime `column "isStale" does not exist`. Implementation must use `ALTER TABLE "inventory_items" ADD COLUMN IF NOT EXISTS "isStale" boolean NOT NULL DEFAULT false`. (The plan already flags "verify actual column name" in step 3 — this resolves it.)
+
+## Open questions
+
+- None blocking. The one design fork (read-side exclusion scope) was resolved with the user: **Option A** — exclude stale only from `findAvailabilityByVariantIds`; leave `findMany` inclusive.
+
+## Summary
+
+Every artifact the plan introduces is confirmed absent from the tree, and each port/service the plan extends has exactly one implementer, so the additive changes break no contract surface. The single correction is the migration column name (`isStale`, camelCase — the repo uses TypeORM default naming), which must be applied at implementation time. Cleared to implement.

--- a/docs/plans/implementation-plan-inventory-prune-stale-variants.md
+++ b/docs/plans/implementation-plan-inventory-prune-stale-variants.md
@@ -1,0 +1,73 @@
+# Implementation Plan — Prune stale `inventory_items` for variants deleted at the master (#1478)
+
+## 1. Understand the task
+
+**Goal.** When a variant is deleted at the inventory master (e.g. a PrestaShop combination is removed), `MasterInventorySyncService.syncFromMasterByExternalId` upserts one row per entry `listInventory` returns but never diffs against what is already stored — so the row for a now-deleted variant lingers forever with stale stock. Close that backend data-integrity gap by **soft-marking** orphaned rows `isStale` and excluding them from the availability read the bulk offer wizard acts on.
+
+**Layer.** CORE — Domain (entity), Application (service + sync orchestration), Infrastructure (ORM entity, repository, migration).
+
+**Non-goals (explicit).**
+- No hard delete — soft `isStale` flag preserves debugging history (per reporter + repo conventions).
+- No FE surfacing of stale rows (a badge on the product page) — deferred.
+- No new variant-deletion detection in the `products` context — the diff is inferred purely from the master's `listInventory` response.
+
+## 2. Research (findings)
+
+- `MasterInventorySyncService.syncFromMasterByExternalId` (`master-inventory-sync.service.ts:43-83`) loops `listInventory` → `toDomainInventoryItem` → `inventoryService.setInventory` (upsert only). No diff/prune step.
+- `InventoryItem` domain entity (`inventory-item.entity.ts`) is a 7-field readonly data holder.
+- `InventoryRepositoryPort` exposes `findByProductAndVariant / upsert / findById / findMany / findAvailabilityByVariantIds` — **no delete/prune**.
+- `IInventoryService` exposes only `setInventory` (upsert) + `getInventory`.
+- `upsert` (`inventory.repository.ts:131`) finds existing by `(productId, productVariantId, locationId)` then `save`s — so a reappearing variant naturally reuses its row **iff** the lookup still finds the stale row.
+- `findAvailabilityByVariantIds` (`inventory.repository.ts:103`) is the aggregate the bulk wizard / product page availability read consumes (`VariantAvailability`).
+- Barrel: domain entity is re-exported as `InventoryItemEntity`; ORM entity via `@openlinker/core/inventory/orm-entities`.
+- Migration convention (`docs/migrations.md` §Ordered/#1013): synthetic sequential prefix, strictly greater than tail. Current tail = `1818000000006` → **use `1818000000007`**. Self-healing `ADD COLUMN IF NOT EXISTS`.
+- Existing tests to touch: `master-inventory-sync.service.spec.ts` (mock needs the new service method), `inventory.service.spec.ts`. Existing int-spec patterns: `inventory-availability.int-spec.ts`, `inventory-multivariant-cleanup.int-spec.ts`.
+
+## 3. Design
+
+### `isStale` flag lifecycle
+- **Mark stale:** after the per-inventory upsert loop, the sync calls `pruneStaleVariants(productId, keptVariantIds)` where `keptVariantIds` = the resolved `productVariantId` of every item written this run (includes `null` for a product-level row). The repo marks every non-stale row for that product whose `productVariantId` is not in the kept set as `isStale = true`. Empty response ⇒ every row for the product is marked stale.
+- **Clear stale (reappear):** the sync always constructs domain items with `isStale = false`; `upsert` maps that through, and because `findByProductAndVariant` (the upsert's existing-row lookup) **does not** filter on `isStale`, the reappearing variant's existing stale row is found by its `(product, variant, location)` key and overwritten `isStale = false` — no duplicate row.
+
+### Read-side exclusion (design fork — see §Open question)
+- **`findAvailabilityByVariantIds` excludes `isStale = true`** — this is the read the bulk wizard *acts on*; it is the actual blast radius of the bug.
+- `findByProductAndVariant` **must stay inclusive** — the upsert reappear-clear path depends on it finding stale rows.
+- `findMany` / `findById` **stay inclusive** — the raw product-page list keeps returning stale rows so a future (deferred) FE badge can surface them; hiding them is an FE concern, not a data-integrity one.
+
+### Data flow
+```
+syncFromMasterByExternalId
+  for each master inventory → build item(isStale=false) → setInventory (upsert, clears stale)
+                                                        → keptVariantIds.push(item.productVariantId)
+  → inventoryService.pruneStaleVariants(productId, keptVariantIds)
+        → repo.markStaleExceptVariants(productId, keptVariantIds)   // UPDATE ... SET is_stale=true
+```
+
+## 4. Step-by-step
+
+1. **Domain entity** `inventory-item.entity.ts` — add `public readonly isStale: boolean = false` as the **last** constructor param (default keeps all existing `new InventoryItem(...)` call sites compiling).
+2. **ORM entity** `inventory-item.orm-entity.ts` — add `@Column({ type: 'boolean', default: false }) isStale!: boolean;`.
+3. **Migration** `apps/api/src/migrations/1818000000007-add-inventory-item-is-stale.ts` — `ALTER TABLE "inventory_items" ADD COLUMN IF NOT EXISTS "is_stale" boolean NOT NULL DEFAULT false` (+ `DROP COLUMN IF EXISTS` down). Class `AddInventoryItemIsStale1818000000007`. *(Column name: confirm TypeORM's default naming maps `isStale` → `isStale`; the ORM entity uses camelCase property names with no naming strategy override — so the DDL column must match whatever the entity resolves to. Verify with `migration:show` / a generate dry-run and align the ALTER to the actual column name.)*
+4. **Repository port** `inventory-repository.port.ts` — add `markStaleExceptVariants(productId: string, keepVariantIds: readonly (string | null)[]): Promise<number>` (returns affected-row count).
+5. **Repository impl** `inventory.repository.ts`:
+   - Implement `markStaleExceptVariants` via an UPDATE query builder: `WHERE productId = :pid AND isStale = false AND (row's variant not in keep set)`, with explicit NULL handling (product-level row kept only if `null ∈ keepVariantIds`; empty keep set ⇒ all rows stale).
+   - Add `.andWhere('inv.isStale = false')` to `findAvailabilityByVariantIds`.
+   - Map `isStale` in `toDomain` and `toOrmEntity`.
+6. **Service interface** `inventory.service.interface.ts` — add `pruneStaleVariants(productId: string, currentVariantIds: readonly (string | null)[]): Promise<number>`.
+7. **Service impl** `inventory.service.ts` — implement `pruneStaleVariants`, delegating to `repo.markStaleExceptVariants` (with a debug log of affected count).
+8. **Wire into sync** `master-inventory-sync.service.ts` — collect `keptVariantIds` in the loop; after the loop call `pruneStaleVariants(internalProductId, keptVariantIds)` unconditionally.
+9. **Tests:**
+   - `master-inventory-sync.service.spec.ts` — add `pruneStaleVariants: jest.fn()` to the `inventoryService` mock (required — the service now calls it); new test: after sync, `pruneStaleVariants` is called with `(internalProductId, [<written variant ids>])`.
+   - `inventory.service.spec.ts` — `pruneStaleVariants` delegates to `markStaleExceptVariants`.
+   - New int-spec `apps/api/test/integration/inventory-stale-prune.int-spec.ts` (real Postgres): (a) variant removed from master response → its row marked stale, surviving variant untouched; (b) reappear → `isStale` cleared, no duplicate row; (c) `findAvailabilityByVariantIds` omits stale rows; (d) product-level `null` row pruned when a simple product's synthetic variant disappears.
+
+## 5. Validate
+
+- **Architecture:** all changes CORE-side; port stays minimal (intent-named `markStaleExceptVariants`, not a generic delete); no CORE↔Integration boundary crossed; no framework leak into domain.
+- **Naming:** matches `docs/engineering-standards.md` (port method intent-named; migration prefix + class-suffix invariant).
+- **Security:** parameterised query builder — no raw SQL interpolation.
+- **Migration:** additive, self-healing, `NOT NULL DEFAULT false` safe for existing rows; `migration:show` clean after generate.
+- **Testing:** unit covers orchestration + delegation; int-spec covers the SQL (mark / clear / exclude / product-level).
+
+## Open question (design fork)
+Read-side exclusion is scoped to **`findAvailabilityByVariantIds` only** (the read the wizard acts on). The product-page list (`findMany`) stays inclusive so a deferred FE badge can surface stale rows. Alternative: also filter `findMany`, hiding stale rows everywhere now. Recommendation: **keep `findMany` inclusive** — matches the issue's "FE surfacing is deferred / out of scope" assumption and avoids silently dropping rows an operator may want to see. Flagging for confirmation.

--- a/libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts
@@ -76,6 +76,7 @@ describe('InventoryQueryService', () => {
       findById: jest.fn(),
       findMany: jest.fn(),
       findAvailabilityByVariantIds: jest.fn(),
+      markStaleExceptVariants: jest.fn(),
     };
 
     productsService = {

--- a/libs/core/src/inventory/application/services/__tests__/inventory.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory.service.spec.ts
@@ -43,6 +43,7 @@ describe('InventoryService', () => {
     inventoryRepository = {
       findByProductAndVariant: jest.fn(),
       upsert: jest.fn(),
+      markStaleExceptVariants: jest.fn().mockResolvedValue(0),
     } as unknown as jest.Mocked<InventoryRepositoryPort>;
 
     jobQueue = {
@@ -176,6 +177,18 @@ describe('InventoryService', () => {
         },
       })
     );
+  });
+
+  it('delegates pruneStaleVariants to the repository and returns the marked count', async () => {
+    (inventoryRepository.markStaleExceptVariants as jest.Mock).mockResolvedValue(3);
+
+    const marked = await service.pruneStaleVariants('product-id', ['ol_variant_a', null]);
+
+    expect(inventoryRepository.markStaleExceptVariants).toHaveBeenCalledWith('product-id', [
+      'ol_variant_a',
+      null,
+    ]);
+    expect(marked).toBe(3);
   });
 
   it('uses persisted updatedAt as write event token', async () => {

--- a/libs/core/src/inventory/application/services/__tests__/master-inventory-sync.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/master-inventory-sync.service.spec.ts
@@ -67,6 +67,7 @@ describe('MasterInventorySyncService', () => {
     inventoryService = {
       setInventory: jest.fn().mockImplementation((item: InventoryItem) => Promise.resolve(item)),
       getInventory: jest.fn().mockResolvedValue(null),
+      pruneStaleVariants: jest.fn().mockResolvedValue(0),
     } as unknown as jest.Mocked<IInventoryService>;
 
     productsService = {
@@ -307,6 +308,69 @@ describe('MasterInventorySyncService', () => {
       await expect(service.syncFromMasterByExternalId(connectionId, externalId)).rejects.toBe(boom);
 
       expect(inventoryService.setInventory).not.toHaveBeenCalled();
+      expect(inventoryService.pruneStaleVariants).not.toHaveBeenCalled();
+    });
+  });
+
+  // Stale-variant pruning (#1478): after writing the current master response,
+  // the sync soft-marks any previously-known variant absent from it as stale.
+  describe('stale-variant pruning', () => {
+    it('prunes with the variant keys just written after the upsert loop', async () => {
+      inventoryAdapter.listInventory.mockResolvedValue([
+        {
+          id: 'inv-a',
+          productId: internalProductId,
+          variantId: 'ol_variant_a',
+          quantity: 10,
+          reserved: 1,
+          available: 9,
+          updatedAt: new Date('2026-05-01T10:00:00Z'),
+        },
+        {
+          id: 'inv-b',
+          productId: internalProductId,
+          variantId: 'ol_variant_b',
+          quantity: 5,
+          reserved: 0,
+          available: 5,
+          updatedAt: new Date('2026-05-01T10:00:00Z'),
+        },
+      ]);
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(inventoryService.pruneStaleVariants).toHaveBeenCalledTimes(1);
+      expect(inventoryService.pruneStaleVariants).toHaveBeenCalledWith(internalProductId, [
+        'ol_variant_a',
+        'ol_variant_b',
+      ]);
+    });
+
+    it('prunes with an empty keep set when the master returns no inventory (product fully removed)', async () => {
+      inventoryAdapter.listInventory.mockResolvedValue([]);
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(inventoryService.setInventory).not.toHaveBeenCalled();
+      expect(inventoryService.pruneStaleVariants).toHaveBeenCalledWith(internalProductId, []);
+    });
+
+    it('prunes with the resolved variant key (null) when the row keys product-level', async () => {
+      inventoryAdapter.listInventory.mockResolvedValue([
+        {
+          id: 'inv-pl',
+          productId: internalProductId,
+          // no variantId — resolveVariantId safety net yields null (zero/many variants)
+          quantity: 5,
+          reserved: 0,
+          available: 5,
+          updatedAt: new Date('2026-05-01T10:00:00Z'),
+        } as unknown as InventoryPortInterface,
+      ]);
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(inventoryService.pruneStaleVariants).toHaveBeenCalledWith(internalProductId, [null]);
     });
   });
 

--- a/libs/core/src/inventory/application/services/inventory.service.interface.ts
+++ b/libs/core/src/inventory/application/services/inventory.service.interface.ts
@@ -43,4 +43,23 @@ export interface IInventoryService {
     productVariantId?: string | null,
     locationId?: string | null
   ): Promise<InventoryItem | null>;
+
+  /**
+   * Prune stale variants after a master sync (#1478).
+   *
+   * Soft-marks every currently-live inventory row for `productId` whose variant
+   * is NOT in `currentVariantIds` (the variant keys present in the master's
+   * latest `listInventory` response, including `null` for a product-level row).
+   * Rows for variants deleted at the master are flagged `isStale` and excluded
+   * from the variant-availability read the offer flows act on. A variant that
+   * reappears clears its own flag via `setInventory`.
+   *
+   * @param productId internal OpenLinker product ID
+   * @param currentVariantIds variant keys still present at the master (may include `null`)
+   * @returns number of rows newly marked stale
+   */
+  pruneStaleVariants(
+    productId: string,
+    currentVariantIds: readonly (string | null)[]
+  ): Promise<number>;
 }

--- a/libs/core/src/inventory/application/services/inventory.service.ts
+++ b/libs/core/src/inventory/application/services/inventory.service.ts
@@ -106,6 +106,22 @@ export class InventoryService implements IInventoryService {
     );
   }
 
+  async pruneStaleVariants(
+    productId: string,
+    currentVariantIds: readonly (string | null)[]
+  ): Promise<number> {
+    const marked = await this.inventoryRepository.markStaleExceptVariants(
+      productId,
+      currentVariantIds
+    );
+    if (marked > 0) {
+      this.logger.debug(
+        `inventory_prune_marked_stale product=${productId} rows=${marked} kept=${currentVariantIds.length}`
+      );
+    }
+    return marked;
+  }
+
   private buildPropagationDedupeKey(item: InventoryItem, writeEventToken: string): string {
     return [
       'inventory:propagate',

--- a/libs/core/src/inventory/application/services/master-inventory-sync.service.ts
+++ b/libs/core/src/inventory/application/services/master-inventory-sync.service.ts
@@ -63,15 +63,25 @@ export class MasterInventorySyncService implements IMasterInventorySyncService {
 
     let availableQuantity = 0;
     let reservedQuantity = 0;
+    const currentVariantIds: (string | null)[] = [];
     for (const inventory of inventories) {
       const inventoryItem = await this.toDomainInventoryItem(inventory, internalProductId);
       await this.inventoryService.setInventory(inventoryItem);
+      currentVariantIds.push(inventoryItem.productVariantId);
       availableQuantity += inventoryItem.availableQuantity;
       reservedQuantity += inventoryItem.reservedQuantity;
     }
 
+    // Soft-mark any previously-known variant absent from this master response as
+    // stale (#1478). Runs unconditionally — an empty response marks every row for
+    // the product stale (product fully removed at the master).
+    const markedStale = await this.inventoryService.pruneStaleVariants(
+      internalProductId,
+      currentVariantIds
+    );
+
     this.logger.debug(
-      `Master inventory sync complete (connection: ${connectionId}, externalId: ${externalId}, internalProductId: ${internalProductId}, itemsWritten=${inventories.length}, available=${availableQuantity}, reserved=${reservedQuantity})`
+      `Master inventory sync complete (connection: ${connectionId}, externalId: ${externalId}, internalProductId: ${internalProductId}, itemsWritten=${inventories.length}, markedStale=${markedStale}, available=${availableQuantity}, reserved=${reservedQuantity})`
     );
 
     return {

--- a/libs/core/src/inventory/domain/entities/inventory-item.entity.ts
+++ b/libs/core/src/inventory/domain/entities/inventory-item.entity.ts
@@ -5,6 +5,12 @@
  * are stored with internal IDs only; external identifiers live in IdentifierMapping.
  * Supports both product-level and variant-level inventory (productVariantId is nullable).
  *
+ * `isStale` soft-marks a row whose variant no longer appears in the master's
+ * `listInventory` response (variant deleted at the master, #1478). Stale rows are
+ * excluded from the variant-availability read the offer flows act on, but kept in
+ * the table for debugging/history rather than hard-deleted. A variant that
+ * reappears clears the flag on its next successful upsert.
+ *
  * @module libs/core/src/inventory/domain/entities
  */
 export class InventoryItem {
@@ -16,6 +22,7 @@ export class InventoryItem {
     public readonly reservedQuantity: number,
     public readonly locationId: string | null,
     public readonly updatedAt: Date,
+    public readonly isStale: boolean = false,
   ) {}
 }
 

--- a/libs/core/src/inventory/domain/ports/inventory-repository.port.ts
+++ b/libs/core/src/inventory/domain/ports/inventory-repository.port.ts
@@ -75,4 +75,31 @@ export interface InventoryRepositoryPort {
   findAvailabilityByVariantIds(
     variantIds: readonly string[]
   ): Promise<readonly VariantAvailability[]>;
+
+  /**
+   * Soft-mark orphaned inventory rows as stale (#1478).
+   *
+   * Marks every currently-live (`isStale = false`) row for `productId` whose
+   * `productVariantId` is NOT in `keepVariantIds` as stale. `keepVariantIds` is
+   * the set of variant keys present in the master's latest `listInventory`
+   * response — including `null` for a product-level row. An empty keep set marks
+   * every row for the product stale (the product was fully removed at the master).
+   *
+   * Does not touch already-stale rows, and does not bump `updatedAt` (a bulk
+   * UPDATE, not a save) — so `updatedAt` keeps reflecting the last real stock
+   * write. A variant that reappears clears its own flag via the upsert path.
+   *
+   * Granularity is per-variant, not per-location: a still-present variant that
+   * the master stops returning at one specific location keeps all its location
+   * rows live (the variant is still in `keepVariantIds`). Multi-location pruning
+   * is out of scope.
+   *
+   * @param productId internal OpenLinker product ID
+   * @param keepVariantIds variant keys to keep live (may include `null`)
+   * @returns number of rows newly marked stale
+   */
+  markStaleExceptVariants(
+    productId: string,
+    keepVariantIds: readonly (string | null)[]
+  ): Promise<number>;
 }

--- a/libs/core/src/inventory/infrastructure/persistence/entities/inventory-item.orm-entity.ts
+++ b/libs/core/src/inventory/infrastructure/persistence/entities/inventory-item.orm-entity.ts
@@ -62,6 +62,12 @@ export class InventoryItemOrmEntity {
   @Column({ type: 'varchar', nullable: true })
   locationId!: string | null;
 
+  // Soft-mark for a row whose variant no longer appears in the master's
+  // listInventory response (#1478). Excluded from the variant-availability read;
+  // cleared when the variant reappears (upsert writes false).
+  @Column({ type: 'boolean', default: false })
+  isStale!: boolean;
+
   @UpdateDateColumn()
   updatedAt!: Date;
 }

--- a/libs/core/src/inventory/infrastructure/persistence/repositories/inventory.repository.ts
+++ b/libs/core/src/inventory/infrastructure/persistence/repositories/inventory.repository.ts
@@ -15,7 +15,7 @@
  */
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Brackets, Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
 import { InventoryItemOrmEntity } from '../entities/inventory-item.orm-entity';
 import type { InventoryRepositoryPort } from '../../../domain/ports/inventory-repository.port';
@@ -111,6 +111,8 @@ export class InventoryRepository implements InventoryRepositoryPort {
       .addSelect('COALESCE(SUM(inv.availableQuantity), 0)', 'totalAvailable')
       .addSelect('COUNT(DISTINCT inv.locationId)', 'locationCount')
       .where('inv.productVariantId IN (:...variantIds)', { variantIds: [...variantIds] })
+      // Exclude soft-deleted rows so offer flows never act on dead stock (#1478).
+      .andWhere('inv.isStale = false')
       .groupBy('inv.productVariantId')
       .getRawMany<{
         productVariantId: string;
@@ -126,6 +128,42 @@ export class InventoryRepository implements InventoryRepositoryPort {
       totalAvailable: Number(row.totalAvailable),
       locationCount: Number(row.locationCount),
     }));
+  }
+
+  async markStaleExceptVariants(
+    productId: string,
+    keepVariantIds: readonly (string | null)[]
+  ): Promise<number> {
+    const nonNullKeep = keepVariantIds.filter((v): v is string => v !== null);
+    const keepNull = keepVariantIds.includes(null);
+
+    const result = await this.repository
+      .createQueryBuilder()
+      .update(InventoryItemOrmEntity)
+      .set({ isStale: true })
+      .where('productId = :productId', { productId })
+      .andWhere('isStale = false')
+      .andWhere(
+        // A row is stale iff its variant is not in the keep set. Each branch
+        // guards its own NULL so the predicate is total (never three-valued),
+        // and NOT IN is only applied to guaranteed-non-null values.
+        new Brackets((qb) => {
+          if (nonNullKeep.length > 0) {
+            qb.where(
+              'productVariantId IS NOT NULL AND productVariantId NOT IN (:...keep)',
+              { keep: nonNullKeep }
+            );
+          } else {
+            qb.where('productVariantId IS NOT NULL');
+          }
+          if (!keepNull) {
+            qb.orWhere('productVariantId IS NULL');
+          }
+        })
+      )
+      .execute();
+
+    return result.affected ?? 0;
   }
 
   async upsert(item: InventoryItem): Promise<InventoryItem> {
@@ -183,7 +221,8 @@ export class InventoryRepository implements InventoryRepositoryPort {
       entity.availableQuantity,
       entity.reservedQuantity,
       entity.locationId,
-      entity.updatedAt
+      entity.updatedAt,
+      entity.isStale
     );
   }
 
@@ -198,6 +237,9 @@ export class InventoryRepository implements InventoryRepositoryPort {
     entity.availableQuantity = item.availableQuantity;
     entity.reservedQuantity = item.reservedQuantity;
     entity.locationId = item.locationId;
+    // A freshly-synced/upserted row is always live — this is what clears a
+    // previously-stale flag when a deleted variant reappears at the master (#1478).
+    entity.isStale = item.isStale;
     entity.updatedAt = item.updatedAt;
     return entity;
   }


### PR DESCRIPTION
## What & why

`MasterInventorySyncService.syncFromMasterByExternalId` upserted one `inventory_items` row per `listInventory` entry but never diffed against what was already stored. When a variant is deleted at the master (e.g. a PrestaShop combination is removed), `listInventory` simply stops returning it — so the orphaned row lingered forever with its last-known stock, and the bulk offer wizard kept sourcing that dead quantity via `getAvailabilityByVariantIds`.

This adds a **soft-delete** pass (mark, don't hard-delete — preserves debugging history per the reporter's ask).

## Changes

- **`InventoryItem.isStale`** (domain, last ctor param, defaulted `false` → no call-site churn) + `isStale` column on `inventory_items` (migration `1818000000007`, additive/self-healing `NOT NULL DEFAULT false`).
  - Column name is camelCase `isStale` (not `is_stale`) — the repo sets no TypeORM naming strategy, so property names are column names (cf. `availableQuantity`, `paymentStatus`).
- **`InventoryRepositoryPort.markStaleExceptVariants`** / **`IInventoryService.pruneStaleVariants`**: mark every live row for a product whose variant is absent from the master's latest response as stale. Handles product-level `NULL` rows; an empty response marks all rows (product fully removed).
- **`MasterInventorySyncService`** calls prune once after the upsert loop (unconditionally).
- **`findAvailabilityByVariantIds`** excludes stale rows — offer flows never act on dead stock. Raw list reads (`findMany`) stay **inclusive** so a future FE badge can surface stale rows (FE surfacing is deferred, out of scope here).

## Design notes

- **Reappear is self-healing**: the sync always writes `isStale = false`, and the upsert's existing-row lookup (`findByProductAndVariant`) stays stale-inclusive — so a re-added variant reuses its existing row and clears the flag rather than duplicating.
- **Transient empty master response** marks rows stale, but it's self-healing (next good sync clears the flag) and never hard-deletes — consistent with the "absence = deletion" premise.
- **Per-variant, not per-location** granularity (documented in the port JSDoc): a still-present variant dropped at one location keeps its other location rows live.

## How to test

```bash
pnpm --filter @openlinker/api exec jest --config test/jest-integration.cjs --testPathPattern='inventory-stale-prune'
```

Unit: prune wiring (incl. empty-response) + service delegation. Integration (real Postgres): mark / availability-exclude / reappear-clear / product-level NULL both directions.

## Quality gate

lint ✓ (0 errors) · type-check ✓ · unit 1474 core + 197 worker ✓ · integration: 5 inventory suites + worker master-inventory-sync e2e ✓

Closes #1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)