### PR TITLE
fix(docker): wire OL_DEMO_MODE + OL_REGISTRATION_ENABLED into the demo compose overlay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,15 @@ OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=
 # Default: true (demo overlay only)
 # OL_DEMO_MODE=
 
+# Gates the self-service registration endpoint itself (RegistrationService.
+# register checks this BEFORE demo mode) — without it, OL_DEMO_MODE=true
+# above has no visible effect, since no visitor can ever reach the
+# auto-activation path it's supposed to gate. Same demo-overlay-only default
+# as OL_DEMO_MODE. Set to false to keep the demo read-only with
+# admin-provisioned accounts only, no public sign-up.
+# Default: true (demo overlay only)
+# OL_REGISTRATION_ENABLED=
+
 # JWT signing secret. The default is a throwaway dev value — rotate before
 # any non-local exposure.
 # Default: development-secret-key-change-in-production

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,17 @@ OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=
 # Default: admin
 # OL_BOOTSTRAP_ADMIN_PASSWORD=
 
+# Demo mode (self-registration auto-activation, read-only banner for viewer
+# sessions, rate-limited registration, scheduled demo-account cleanup — see
+# apps/api/src/auth/demo-mode.service.ts). The demo overlay
+# (docker-compose.demo.yml, i.e. `pnpm demo:up`) defaults this to true —
+# booting the demo overlay IS the signal you want a demo deployment. Set to
+# false to run the full demo container set without the demo-mode
+# restrictions. Has no effect on the plain dev stack (docker-compose.yml
+# alone) — that never wires this variable in.
+# Default: true (demo overlay only)
+# OL_DEMO_MODE=
+
 # JWT signing secret. The default is a throwaway dev value — rotate before
 # any non-local exposure.
 # Default: development-secret-key-change-in-production

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -40,6 +40,14 @@ services:
       # OL_DEMO_MODE=false in .env to run the full demo container set
       # without the demo-mode restrictions.
       OL_DEMO_MODE: '${OL_DEMO_MODE:-true}'
+      # Gates the self-service registration endpoint itself
+      # (RegistrationService.register checks this BEFORE demo mode) - without
+      # it, OL_DEMO_MODE=true above has no visible effect, since no visitor
+      # can ever reach the auto-activation path it's supposed to gate. Same
+      # class of gap as OL_DEMO_MODE (#1499): defaults to enabled only in the
+      # demo overlay. Set to false in .env to keep the demo read-only/
+      # admin-provisioned-accounts-only, with no public sign-up.
+      OL_REGISTRATION_ENABLED: '${OL_REGISTRATION_ENABLED:-true}'
       # CORS allow-list must include the browser origin the web UI is served
       # from (the `web` service publishes :8090), or login fails with a
       # "NetworkError when attempting to fetch resource" (#1368). The API

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -31,6 +31,15 @@ services:
       # production-safe credential.
       NODE_ENV: production
       OL_BOOTSTRAP_ADMIN_PASSWORD: '${OL_BOOTSTRAP_ADMIN_PASSWORD:-admin}'
+      # Booting the demo overlay is itself the operator's signal that they
+      # want a demo deployment (self-registration auto-activation, the
+      # read-only banner, rate-limited registration + account cleanup —
+      # see apps/api/src/auth/demo-mode.service.ts and its consumers).
+      # Previously this had no compose wiring at all, so `pnpm demo:up`
+      # never actually enabled demo mode regardless of .env (#1499). Set
+      # OL_DEMO_MODE=false in .env to run the full demo container set
+      # without the demo-mode restrictions.
+      OL_DEMO_MODE: '${OL_DEMO_MODE:-true}'
       # CORS allow-list must include the browser origin the web UI is served
       # from (the `web` service publishes :8090), or login fails with a
       # "NetworkError when attempting to fetch resource" (#1368). The API


### PR DESCRIPTION
## Summary
- `docker-compose.demo.yml`'s `api` service never referenced `${OL_DEMO_MODE}`, so setting it in `.env` had zero effect — `pnpm demo:up` never actually enabled demo mode.
- Same gap one level deeper: `RegistrationService.register` checks `OL_REGISTRATION_ENABLED` *before* demo mode, and that variable was also never wired anywhere — so even with `OL_DEMO_MODE` fixed, self-registration (and everything gated behind it: auto-activation, the #1469 rate-limiter, the #1469 account-cleanup scheduler) stayed completely unreachable in the demo.
- Adds both `OL_DEMO_MODE: '${OL_DEMO_MODE:-true}'` and `OL_REGISTRATION_ENABLED: '${OL_REGISTRATION_ENABLED:-true}'` to the demo overlay's `api` service only — booting the demo overlay is itself the signal an operator wants a demo deployment. The plain dev stack (`docker-compose.yml` alone) is unaffected by either.
- Documents both new variables in `.env.example`.

Closes #1499

## Test plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.demo.yml config` shows both `OL_DEMO_MODE: "true"` and `OL_REGISTRATION_ENABLED: "true"` by default
- [x] Same command with `OL_DEMO_MODE=false` / `OL_REGISTRATION_ENABLED=false` shows `"false"` for each
- [x] `docker compose -f docker-compose.yml config` (no overlay) has zero references to either variable
- [x] Full `pnpm lint && pnpm type-check` (pre-commit gate) clean on both commits — config-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
