### PR TITLE
feat(integrations): validate masterCatalogConnectionId shape on WooCommerce + Erli config

### DIFF
--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-config-shape-validator.adapter.spec.ts
@@ -198,6 +198,16 @@ describe('ErliConnectionConfigShapeValidatorAdapter', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('should resolve when masterCatalogConnectionId is an empty string (blank = not configured / opt-out)', async () => {
+      await expect(validator.validate({ masterCatalogConnectionId: '' })).resolves.toBeUndefined();
+    });
+
+    it('should resolve when masterCatalogConnectionId is null (treated as not configured)', async () => {
+      await expect(
+        validator.validate({ masterCatalogConnectionId: null }),
+      ).resolves.toBeUndefined();
+    });
+
     it('should reject a malformed masterCatalogConnectionId', async () => {
       await expect(
         validator.validate({ masterCatalogConnectionId: 'not-a-uuid' }),

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-connection-config-shape-validator.adapter.spec.ts
@@ -186,4 +186,30 @@ describe('ErliConnectionConfigShapeValidatorAdapter', () => {
       });
     });
   });
+
+  describe('masterCatalogConnectionId (#1501)', () => {
+    it('should resolve when masterCatalogConnectionId is absent (ingestion-only connection)', async () => {
+      await expect(validator.validate({})).resolves.toBeUndefined();
+    });
+
+    it('should resolve when masterCatalogConnectionId is a valid UUID', async () => {
+      await expect(
+        validator.validate({ masterCatalogConnectionId: '3f7c1e2a-9b4d-4c6e-8a1f-2d5e6f7a8b9c' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should reject a malformed masterCatalogConnectionId', async () => {
+      await expect(
+        validator.validate({ masterCatalogConnectionId: 'not-a-uuid' }),
+      ).rejects.toMatchObject({
+        errors: [{ path: 'masterCatalogConnectionId', message: expect.any(String) }],
+      });
+    });
+
+    it('should reject a non-string masterCatalogConnectionId', async () => {
+      await expect(validator.validate({ masterCatalogConnectionId: 123 })).rejects.toMatchObject({
+        errors: [{ path: 'masterCatalogConnectionId', message: expect.any(String) }],
+      });
+    });
+  });
 });

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts
@@ -194,10 +194,17 @@ export class ErliConnectionConfigShapeValidatorAdapter
    * of the connection whose catalog offers/publishes source from (#1501).
    * Shape-only: an absent value is valid so order-ingestion-only connections are
    * not blocked (presence is a capability-gated follow-up, not enforced here).
-   * Mirrors Allegro's `@IsOptional() @IsUUID('4')` posture.
+   *
+   * An absent-or-blank value (`undefined`, `null`, or `''`) is treated as "not
+   * configured", not rejected: core reads a blank id as unset (offer-builder /
+   * product-publish-builder coerce '' to null) and, in offer-mapping-sync, as
+   * the explicit opt-out from barcode auto-resolve — so a cleared field must
+   * save rather than 400. The UUID check runs only on a non-empty value. This
+   * mirrors Allegro's / WooCommerce's `@IsOptional() @IsUUID('4')` posture,
+   * which likewise skips null/undefined.
    */
   private validateMasterCatalogConnectionId(value: unknown, issues: FlatValidationIssue[]): void {
-    if (value === undefined) {
+    if (value === undefined || value === null || value === '') {
       return;
     }
     if (typeof value !== 'string' || !UUID_V4_PATTERN.test(value)) {

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-connection-config-shape-validator.adapter.ts
@@ -31,6 +31,14 @@ import {
   ErliEnvironmentValues,
 } from '../../domain/types/erli-connection.types';
 
+/**
+ * UUID v4 shape, mirroring `class-validator`'s `isUUID('4')` predicate so the
+ * Erli check stays consistent with Allegro's `@IsUUID('4')` posture without
+ * pulling class-validator into this dependency-light hand-rolled validator.
+ */
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export class ErliConnectionConfigShapeValidatorAdapter
   implements ConnectionConfigShapeValidatorPort
 {
@@ -60,6 +68,7 @@ export class ErliConnectionConfigShapeValidatorAdapter
     this.validateDispatchTime(config.defaultDispatchTime, issues);
     this.validateAllegroEnvironment(config.allegroEnvironment, issues);
     this.validateAllegroCategoryAccessEnabled(config.allegroCategoryAccessEnabled, issues);
+    this.validateMasterCatalogConnectionId(config.masterCatalogConnectionId, issues);
 
     const callbackBaseUrl = config.callbackBaseUrl;
     if (callbackBaseUrl !== undefined) {
@@ -176,6 +185,25 @@ export class ErliConnectionConfigShapeValidatorAdapter
       issues.push({
         path: 'allegroCategoryAccessEnabled',
         message: 'must be a boolean when provided',
+      });
+    }
+  }
+
+  /**
+   * `masterCatalogConnectionId`, when present, must be a valid UUID v4 — the id
+   * of the connection whose catalog offers/publishes source from (#1501).
+   * Shape-only: an absent value is valid so order-ingestion-only connections are
+   * not blocked (presence is a capability-gated follow-up, not enforced here).
+   * Mirrors Allegro's `@IsOptional() @IsUUID('4')` posture.
+   */
+  private validateMasterCatalogConnectionId(value: unknown, issues: FlatValidationIssue[]): void {
+    if (value === undefined) {
+      return;
+    }
+    if (typeof value !== 'string' || !UUID_V4_PATTERN.test(value)) {
+      issues.push({
+        path: 'masterCatalogConnectionId',
+        message: 'must be a valid UUID',
       });
     }
   }

--- a/libs/integrations/woocommerce/src/application/dto/woocommerce-connection-config.dto.ts
+++ b/libs/integrations/woocommerce/src/application/dto/woocommerce-connection-config.dto.ts
@@ -40,6 +40,7 @@ import {
   IsInt,
   IsOptional,
   IsUrl,
+  IsUUID,
   Min,
   ValidateNested,
   Validate,
@@ -80,6 +81,14 @@ export class WooCommerceConnectionConfigDto {
   @IsUrl({ require_tld: false, require_protocol: true, protocols: ['https'] })
   @Validate(IsSsrfSafeUrlConstraint)
   siteUrl!: string;
+
+  // Shape-only when present: a malformed catalog-connection id is caught at
+  // save time rather than surfacing as a late offer/publish business_failure
+  // (#1501). Presence is NOT enforced here — order-ingestion-only connections
+  // legitimately omit it; requiring it is a capability-gated follow-up.
+  @IsUUID('4', { message: 'masterCatalogConnectionId must be a valid UUID' })
+  @IsOptional()
+  masterCatalogConnectionId?: string;
 
   @IsOptional()
   @ValidateNested()

--- a/libs/integrations/woocommerce/src/application/dto/woocommerce-connection-config.dto.ts
+++ b/libs/integrations/woocommerce/src/application/dto/woocommerce-connection-config.dto.ts
@@ -42,6 +42,7 @@ import {
   IsUrl,
   IsUUID,
   Min,
+  ValidateIf,
   ValidateNested,
   Validate,
   ValidatorConstraint,
@@ -86,8 +87,16 @@ export class WooCommerceConnectionConfigDto {
   // save time rather than surfacing as a late offer/publish business_failure
   // (#1501). Presence is NOT enforced here — order-ingestion-only connections
   // legitimately omit it; requiring it is a capability-gated follow-up.
-  @IsUUID('4', { message: 'masterCatalogConnectionId must be a valid UUID' })
+  //
+  // An empty string is treated as "absent", not rejected: core reads a blank
+  // masterCatalogConnectionId as "not configured" (offer-builder /
+  // product-publish-builder coerce '' to null) and, in offer-mapping-sync, as
+  // the explicit opt-out from barcode auto-resolve. `@IsOptional()` already
+  // skips null/undefined; `@ValidateIf` also skips '', so a cleared field saves
+  // instead of 400-ing while the UUID check still runs on any non-empty value.
   @IsOptional()
+  @ValidateIf((_o, v) => v !== '')
+  @IsUUID('4', { message: 'masterCatalogConnectionId must be a valid UUID' })
   masterCatalogConnectionId?: string;
 
   @IsOptional()

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-connection-config-shape-validator.adapter.spec.ts
@@ -111,4 +111,30 @@ describe('WooCommerceConnectionConfigShapeValidatorAdapter', () => {
       validator.validate({ siteUrl: 'https://127.0.0.1' }),
     ).resolves.toBeUndefined();
   });
+
+  // ── masterCatalogConnectionId shape (#1501) ────────────────────────────────
+
+  it('should pass when masterCatalogConnectionId is a valid UUID', async () => {
+    await expect(
+      validator.validate({
+        siteUrl: 'https://myshop.com',
+        masterCatalogConnectionId: '3f7c1e2a-9b4d-4c6e-8a1f-2d5e6f7a8b9c',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should pass when masterCatalogConnectionId is absent (ingestion-only connection)', async () => {
+    await expect(
+      validator.validate({ siteUrl: 'https://myshop.com' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should throw when masterCatalogConnectionId is a malformed UUID', async () => {
+    await expect(
+      validator.validate({
+        siteUrl: 'https://myshop.com',
+        masterCatalogConnectionId: 'not-a-uuid',
+      }),
+    ).rejects.toThrow(InvalidConnectionConfigException);
+  });
 });

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-connection-config-shape-validator.adapter.spec.ts
@@ -129,11 +129,32 @@ describe('WooCommerceConnectionConfigShapeValidatorAdapter', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('should pass when masterCatalogConnectionId is an empty string (blank = not configured / opt-out)', async () => {
+    await expect(
+      validator.validate({ siteUrl: 'https://myshop.com', masterCatalogConnectionId: '' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should pass when masterCatalogConnectionId is null (treated as not configured)', async () => {
+    await expect(
+      validator.validate({ siteUrl: 'https://myshop.com', masterCatalogConnectionId: null }),
+    ).resolves.toBeUndefined();
+  });
+
   it('should throw when masterCatalogConnectionId is a malformed UUID', async () => {
     await expect(
       validator.validate({
         siteUrl: 'https://myshop.com',
         masterCatalogConnectionId: 'not-a-uuid',
+      }),
+    ).rejects.toThrow(InvalidConnectionConfigException);
+  });
+
+  it('should throw when masterCatalogConnectionId is a non-string value', async () => {
+    await expect(
+      validator.validate({
+        siteUrl: 'https://myshop.com',
+        masterCatalogConnectionId: 123,
       }),
     ).rejects.toThrow(InvalidConnectionConfigException);
   });


### PR DESCRIPTION
## What

Add an OPTIONAL-UUID (v4) shape check for `masterCatalogConnectionId` to the WooCommerce and Erli connection config-shape validators, matching Allegro's existing `@IsOptional() @IsUUID('4')` posture.

- **WooCommerce** (`woocommerce-connection-config.dto.ts`): new `masterCatalogConnectionId?` field decorated with `@IsOptional() @IsUUID('4')`. The validator adapter already runs with `whitelist: false`, so the key is now inspected instead of passing through un-checked.
- **Erli** (`erli-connection-config-shape-validator.adapter.ts`): a hand-rolled UUID-v4 check in the dependency-light validator (no class-validator dependency), emitting the same flat `{ path, message }` issue via `InvalidConnectionConfigException` as its sibling checks.

## Why

A connection that creates offers or publishes products reads `masterCatalogConnectionId` from its config and throws `MasterCatalogConnectionNotConfiguredException` when it is absent or malformed. Neither the WooCommerce nor Erli validator checked this field at all, so a typo'd/malformed value was only discovered at the **first offer-create / publish attempt** - surfacing as a terminal `business_failure` record rather than at connection save time. This moves the feedback to save time.

## Scope

Shape-only-when-present. A well-formed UUID or an absent value still saves successfully - order-ingestion-only connections are intentionally **not** blocked. Presence enforcement is explicitly OUT of scope (a capability-gated follow-up, gated on the connection actually enabling an offer-creating capability).

No architecture-boundary changes: plugins still do not depend on `@nestjs/common`; the validators throw the existing core domain exception.

## How tested

- Added unit specs to both validator adapter specs covering: malformed UUID rejected, valid UUID accepted, absent value accepted (plus a non-string case for Erli).
- Scoped quality gate (both touched packages):
  - `pnpm --filter @openlinker/integrations-woocommerce type-check` - pass
  - `pnpm --filter @openlinker/integrations-woocommerce test` - 317 passed
  - `pnpm --filter @openlinker/integrations-erli type-check` - pass
  - `pnpm --filter @openlinker/integrations-erli test` - 361 passed

Closes #1501

🤖 Generated with [Claude Code](https://claude.com/claude-code)