### PR TITLE
feat(prestashop): implement getProductCategories on ProductMaster adapter

### DIFF
--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
@@ -689,11 +689,92 @@ describe('PrestashopProductMasterAdapter', () => {
         PrestashopNotSupportedException
       );
     });
+  });
 
-    it('should throw PrestashopNotSupportedException for getProductCategories', async () => {
+  describe('getProductCategories (#1502)', () => {
+    const internalId = 'internal-product-123';
+    const externalId = '42';
+
+    function mapExternalId(): void {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- test mock: narrowing dynamic spy / fixture / response shape
+      mockIdentifierMapping.getExternalIds = jest
+        .fn()
+        .mockResolvedValue([{ connectionId: connection.id, externalId, entityType: 'Product' }]);
+    }
+
+    it('returns the product category tree root→leaf with depth when a path resolver is wired', async () => {
+      mapExternalId();
+      const productWithCategory: PrestashopProduct = {
+        ...samplePrestashopProduct,
+        id_category_default: '12',
+      };
+      const categories: Record<string, { id: string; name: string; id_parent: string }> = {
+        '5': { id: '5', name: 'Home & Garden', id_parent: '2' },
+        '12': { id: '12', name: 'Mugs', id_parent: '5' },
+      };
+      mockHttpClient.getResource = jest.fn((resource: string, id: string | number) => {
+        if (resource === 'categories') return Promise.resolve(categories[String(id)]);
+        return Promise.resolve(productWithCategory);
+      }) as unknown as jest.Mocked<IPrestashopWebserviceClient>['getResource'];
+
+      const adapterWithResolver = new PrestashopProductMasterAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        productMapper,
+        connection,
+        new PrestashopAttributeResolver(),
+        new PrestashopFeatureResolver(),
+        new PrestashopCategoryPathResolver()
+      );
+
+      const result = await adapterWithResolver.getProductCategories(internalId);
+
+      expect(result).toEqual([
+        { id: '5', name: 'Home & Garden', depth: 0 },
+        { id: '12', name: 'Mugs', depth: 1 },
+      ]);
+    });
+
+    it('returns an empty list when the product has no default category (tolerated)', async () => {
+      mapExternalId();
+      mockHttpClient.getResource = jest.fn().mockResolvedValue({
+        ...samplePrestashopProduct,
+        id_category_default: undefined,
+      });
+
+      const adapterWithResolver = new PrestashopProductMasterAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        productMapper,
+        connection,
+        new PrestashopAttributeResolver(),
+        new PrestashopFeatureResolver(),
+        new PrestashopCategoryPathResolver()
+      );
+
+      const result = await adapterWithResolver.getProductCategories(internalId);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns an empty list when no path resolver is wired (tolerated)', async () => {
+      mapExternalId();
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ ...samplePrestashopProduct, id_category_default: '12' });
+
+      const result = await adapter.getProductCategories(internalId);
+
+      expect(result).toEqual([]);
+    });
+
+    it('throws PrestashopResourceNotFoundException when no external ID mapping exists', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- test mock: narrowing dynamic spy / fixture / response shape
+      mockIdentifierMapping.getExternalIds = jest.fn().mockResolvedValue([]);
+
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- test mock: narrowing dynamic spy / fixture / response shape
-      await expect(adapter.getProductCategories('product-id')).rejects.toThrow(
-        PrestashopNotSupportedException
+      await expect(adapter.getProductCategories(internalId)).rejects.toThrow(
+        PrestashopResourceNotFoundException
       );
     });
   });

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
@@ -549,8 +549,22 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
    * breadcrumb), which excludes the Root/Home pseudo-categories. `depth` is
    * stamped from the root→leaf index so the builder's depth-ordered provision
    * path is deterministic. Best-effort by design: no path resolver wired, no
-   * default leaf, or an unresolvable walk yields `[]` (publish uncategorised) —
+   * default leaf, or an unresolvable walk yields `[]` (publish uncategorised) -
    * the builder tolerates an empty list.
+   *
+   * Single-branch by design (#1502 MVP scope): only `id_category_default` is
+   * followed, so exactly one root->leaf path is returned. A product's
+   * `associations.categories` (a product may sit in several categories) is
+   * intentionally ignored - a product whose intended placement lives in a
+   * non-default category, or whose default is Home, publishes
+   * uncategorised/mis-placed. Multi-branch placement is deferred, matching
+   * `toProvisionPath`'s documented single-branch assumption.
+   *
+   * NOTE: `depth` here is a RELATIVE breadcrumb index (0 = first non-excluded
+   * ancestor after Root/Home), unlike sibling `getCategories()`, which reports
+   * PrestaShop's ABSOLUTE `level_depth`. The builder only uses `depth` for
+   * relative ordering within a single path, so the relative index is sufficient
+   * and the two meanings never mix.
    */
   async getProductCategories(productId: string): Promise<Category[]> {
     this.logger.debug(
@@ -566,7 +580,6 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     );
 
     if (!prestashopId) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
       const error = new PrestashopResourceNotFoundException(
         `Product not found: ${productId} (no external ID mapping for connection ${this.connection.id})`,
         CORE_ENTITY_TYPE.Product,
@@ -583,6 +596,8 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
 
     const path = await this.resolveCategoryBreadcrumb(prestashopProduct, this.resolveLangId());
 
+    // `depth` is the RELATIVE root->leaf index (0-based), not PrestaShop's
+    // absolute `level_depth` used by `getCategories()` - see the method note.
     return path.map((node, index) => ({ id: node.id, name: node.name, depth: index }));
   }
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
@@ -537,14 +537,53 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     return Promise.reject(error);
   }
 
-  getProductCategories(_productId: string): Promise<Category[]> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
-    const error = new PrestashopNotSupportedException(
-      'Get product categories is not implemented in MVP.',
-      'getProductCategories',
-      'Future implementation'
+  /**
+   * Return the product's category placement as a neutral `Category[]` ordered
+   * root→leaf, so the publish provisioner + builder chain places a
+   * PrestaShop-mastered product in the mapped/provisioned destination category
+   * instead of "Uncategorized" (#1502).
+   *
+   * PrestaShop has no product→path endpoint, so the path is reconstructed from
+   * the product's `id_category_default` by the shared
+   * `PrestashopCategoryPathResolver` (reusing the same walk as the #1096 F3
+   * breadcrumb), which excludes the Root/Home pseudo-categories. `depth` is
+   * stamped from the root→leaf index so the builder's depth-ordered provision
+   * path is deterministic. Best-effort by design: no path resolver wired, no
+   * default leaf, or an unresolvable walk yields `[]` (publish uncategorised) —
+   * the builder tolerates an empty list.
+   */
+  async getProductCategories(productId: string): Promise<Category[]> {
+    this.logger.debug(
+      `Getting categories for product: ${productId} (connection: ${this.connection.id})`
     );
-    return Promise.reject(error);
+
+    const externalIds = await this.identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.Product,
+      productId
+    );
+    const prestashopId = externalIds.find(
+      (e: { connectionId: string }) => e.connectionId === this.connection.id
+    );
+
+    if (!prestashopId) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
+      const error = new PrestashopResourceNotFoundException(
+        `Product not found: ${productId} (no external ID mapping for connection ${this.connection.id})`,
+        CORE_ENTITY_TYPE.Product,
+        productId,
+        this.connection.id
+      );
+      throw error;
+    }
+
+    const prestashopProduct = await this.httpClient.getResource<PrestashopProduct>(
+      'products',
+      prestashopId.externalId
+    );
+
+    const path = await this.resolveCategoryBreadcrumb(prestashopProduct, this.resolveLangId());
+
+    return path.map((node, index) => ({ id: node.id, name: node.name, depth: index }));
   }
 
   assignCategories(_productId: string, _categoryIds: string[]): Promise<void> {


### PR DESCRIPTION
## What

Implements `PrestashopProductMasterAdapter.getProductCategories(productId)`, which was a throwing MVP stub (`PrestashopNotSupportedException`).

It now returns the product's category placement as a neutral `Category[]` ordered root->leaf:

- Resolves the internal product id to its PrestaShop external id (mirroring `getProduct`); throws `PrestashopResourceNotFoundException` when there is no external mapping for the connection.
- Reconstructs the category path from the product's `id_category_default` using the already-wired `PrestashopCategoryPathResolver` (PrestaShop has no product->path endpoint). This reuses the exact walk behind the #1096 F3 breadcrumb, which excludes the Root/Home pseudo-categories.
- Stamps `depth` from the root->leaf index so the publish builder's depth-ordered provision path is deterministic.

## Why

When PrestaShop is the master catalog, publishing a product to a destination shop (e.g. WooCommerce) landed it in "Uncategorized". The destination publisher and the core `ProductPublishBuilderService` already handle categories correctly - the only gap was that this adapter method threw, so the builder (which tolerates the throw by design) shipped the product uncategorised. With this method implemented, the existing provisioner + builder chain now places the product in the mapped/provisioned destination category. No change was needed to the core builder or the WooCommerce publisher.

Modeled on the WooCommerce master analogue (`woocommerce-product-master.adapter.ts` `getProductCategories`), adapted to PrestaShop's tree-walk model.

## Assumptions / notes

- The path is derived from `id_category_default` (single root->leaf branch), which is the shape the builder's `toProvisionPath` expects. Best-effort by design: no path resolver wired, no default leaf, or an unresolvable walk yields `[]` (publish uncategorised) - the builder tolerates an empty list, preserving the previous non-blocking behavior.

## How tested

- Extended the adapter unit spec (`prestashop-product-master.adapter.spec.ts`) with a dedicated `getProductCategories` block: returns the tree root->leaf with `depth` when a path resolver is wired; returns `[]` when the product has no default category; returns `[]` when no resolver is wired; throws `PrestashopResourceNotFoundException` when there is no external mapping. Removed the now-obsolete "throws NotSupported" test.
- `pnpm --filter @openlinker/integrations-prestashop type-check` - passes.
- `pnpm --filter @openlinker/integrations-prestashop test` - 32 suites / 487 tests pass.
- ESLint on both touched files - clean.

Closes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)