### PR TITLE
feat(listings,allegro,erli): default marketplace-required condition on offer creation

### DIFF
--- a/apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts
@@ -90,6 +90,10 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
         publishImmediately: payload.publishImmediately,
         price: payload.price,
         overrides,
+        // #1500 — forward the neutral condition end-to-end so a programmatic /
+        // bulk-retry payload's choice reaches the adapter; absent → builder
+        // defaults to 'new'.
+        condition: payload.condition,
         idempotencyKey: payload.idempotencyKey,
         offerCreationRecordId: payload.offerCreationRecordId,
       });

--- a/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
@@ -150,6 +150,8 @@ describe('OfferBuilderService', () => {
           imageUrls: ['https://example.com/img1.jpg', 'https://example.com/img2.jpg'],
         },
         idempotencyKey: undefined,
+        // #1500 — marketplace-required condition defaulted to 'new'.
+        condition: 'new',
         // #431 — barcode threaded through for adapter-side smart-link.
         variantBarcode: '5901234123457',
         // #808 — no pre-resolved card on this input.
@@ -930,6 +932,29 @@ describe('OfferBuilderService', () => {
 
       expect(first.variantGroup?.groupId).toBe('ol_product_456');
       expect(second.variantGroup?.groupId).toBe('ol_product_456');
+    });
+  });
+
+  describe('condition default (#1500)', () => {
+    it('defaults condition to "new" when the operator supplies none', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+      });
+
+      expect(result.condition).toBe('new');
+    });
+
+    it('uses an explicit operator-supplied condition over the default', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+        condition: 'used',
+      });
+
+      expect(result.condition).toBe('used');
     });
   });
 });

--- a/libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts
@@ -179,6 +179,37 @@ describe('OfferCreationExecutionService', () => {
     expect(offerCreationRecord.status).toBe('draft');
   });
 
+  describe('condition threading (#1500)', () => {
+    it('forwards a programmatic input.condition to the builder and thence to the adapter', async () => {
+      // Echo the neutral condition through the built command so we can assert it
+      // reaches the adapter — proving the orchestrator wires input.condition
+      // end-to-end (builder → createOffer), not just at the builder unit level.
+      builder.buildCreateOfferCommand.mockImplementationOnce(
+        async (input): Promise<CreateOfferCommand> => ({
+          ...builtCommand,
+          condition: input.condition,
+        })
+      );
+
+      await service.executeCreation({ ...baseInput, condition: 'used' });
+
+      expect(builder.buildCreateOfferCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ condition: 'used' })
+      );
+      expect(adapter.createOffer).toHaveBeenCalledWith(
+        expect.objectContaining({ condition: 'used' })
+      );
+    });
+
+    it('forwards an undefined condition unchanged (builder owns the default)', async () => {
+      await service.executeCreation(baseInput);
+
+      expect(builder.buildCreateOfferCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ condition: undefined })
+      );
+    });
+  });
+
   it('persists status=active when adapter returns active', async () => {
     adapter.createOffer.mockResolvedValueOnce({
       externalOfferId: EXTERNAL_OFFER_ID,

--- a/libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts
@@ -185,10 +185,11 @@ describe('OfferCreationExecutionService', () => {
       // reaches the adapter — proving the orchestrator wires input.condition
       // end-to-end (builder → createOffer), not just at the builder unit level.
       builder.buildCreateOfferCommand.mockImplementationOnce(
-        async (input): Promise<CreateOfferCommand> => ({
-          ...builtCommand,
-          condition: input.condition,
-        })
+        (input): Promise<CreateOfferCommand> =>
+          Promise.resolve({
+            ...builtCommand,
+            condition: input.condition,
+          })
       );
 
       await service.executeCreation({ ...baseInput, condition: 'used' });

--- a/libs/core/src/listings/application/services/bulk-listing-retry.service.ts
+++ b/libs/core/src/listings/application/services/bulk-listing-retry.service.ts
@@ -172,6 +172,11 @@ export class BulkListingRetryService implements IBulkListingRetryService {
         generateDescription: aiFlags.generateDescription,
         ...(snapshot.price !== undefined && { price: snapshot.price }),
         ...(snapshot.overrides !== undefined && { overrides: snapshot.overrides }),
+        // #1500 — carry the programmatic condition from the persisted snapshot
+        // so a retry wave rebuilds an identical command. Absent for wizard
+        // submissions (their Stan choice rides on overrides); the builder then
+        // re-applies its 'new' default.
+        ...(snapshot.condition !== undefined && { condition: snapshot.condition }),
         ...(aiFlags.descriptionTone !== undefined && {
           descriptionTone: aiFlags.descriptionTone,
         }),

--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -225,6 +225,11 @@ export class OfferBuilderService implements IOfferBuilderService {
       publishImmediately: input.publishImmediately ?? false,
       overrides: Object.keys(cleanedOverrides).length > 0 ? cleanedOverrides : undefined,
       idempotencyKey: input.idempotencyKey,
+      // #1500 — marketplaces require a condition ("Stan") on offer creation.
+      // Default to 'new' when the operator supplies none so non-UI / borrows
+      // paths never silently omit it; an explicit operator condition wins. The
+      // neutral value stays platform-free — each adapter maps it to its wire id.
+      condition: input.condition ?? 'new',
       ...(sourceCategories.length > 0 ? { sourceCategories } : {}),
       ...(sourceAttributes.length > 0 ? { sourceAttributes } : {}),
       // Neutral parameters (#1039/#1071): projected attributes merged with

--- a/libs/core/src/listings/application/services/offer-creation-enqueue.service.ts
+++ b/libs/core/src/listings/application/services/offer-creation-enqueue.service.ts
@@ -80,6 +80,7 @@ export class OfferCreationEnqueueService implements IOfferCreationEnqueueService
       publishImmediately: input.publishImmediately,
       ...(input.price !== undefined && { price: input.price }),
       ...(input.overrides !== undefined && { overrides: input.overrides }),
+      ...(input.condition !== undefined && { condition: input.condition }),
     };
 
     // 4. Pre-create the record so the HTTP response carries an id clients
@@ -121,6 +122,7 @@ export class OfferCreationEnqueueService implements IOfferCreationEnqueueService
             generateDescription: input.generateDescription ?? false,
             ...(input.price !== undefined && { price: input.price }),
             ...(input.overrides !== undefined && { overrides: input.overrides }),
+            ...(input.condition !== undefined && { condition: input.condition }),
             ...(input.descriptionTone !== undefined && {
               descriptionTone: input.descriptionTone,
             }),
@@ -133,6 +135,7 @@ export class OfferCreationEnqueueService implements IOfferCreationEnqueueService
             offerCreationRecordId: record.id,
             ...(input.price !== undefined && { price: input.price }),
             ...(input.overrides !== undefined && { overrides: input.overrides }),
+            ...(input.condition !== undefined && { condition: input.condition }),
           } satisfies MarketplaceOfferCreatePayloadV1);
 
     // Bulk default idempotency key includes the batchId so the same

--- a/libs/core/src/listings/application/services/offer-creation-execution.service.ts
+++ b/libs/core/src/listings/application/services/offer-creation-execution.service.ts
@@ -98,6 +98,11 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
         publishImmediately: input.publishImmediately,
         price: input.price,
         overrides: input.overrides,
+        // #1500 — forward the neutral condition so a programmatic caller's
+        // choice reaches the builder (and thence the adapter). Omitted →
+        // builder defaults to 'new'. The operator's wizard Stan param still
+        // rides on overrides.parameters independently.
+        condition: input.condition,
         idempotencyKey: input.idempotencyKey,
       });
     } catch (error) {

--- a/libs/core/src/listings/application/types/offer-builder.types.ts
+++ b/libs/core/src/listings/application/types/offer-builder.types.ts
@@ -9,7 +9,7 @@
  * @module libs/core/src/listings/application/types
  */
 
-import type { CreateOfferOverrides } from '@openlinker/core/listings';
+import type { CreateOfferOverrides, OfferCondition } from '@openlinker/core/listings';
 
 export interface BuildCreateOfferCommandInput {
   /** OL internal variant id being listed. */
@@ -30,6 +30,14 @@ export interface BuildCreateOfferCommandInput {
   publishImmediately?: boolean;
   /** Overrides and platform-specific fields passed through to the command. */
   overrides?: CreateOfferOverrides;
+  /**
+   * Optional explicit item condition (#1500). When omitted the builder defaults
+   * to `'new'` so every produced command carries a condition. An operator's
+   * condition parameter picked in the wizard rides on `overrides.parameters`
+   * instead and is honoured by the destination adapter independently of this
+   * field (the adapter never double-sets condition).
+   */
+  condition?: OfferCondition;
   /**
    * Optional idempotency key forwarded to the produced `CreateOfferCommand`.
    * Adapters may use it for unique external references on the marketplace

--- a/libs/core/src/listings/application/types/offer-creation-enqueue.types.ts
+++ b/libs/core/src/listings/application/types/offer-creation-enqueue.types.ts
@@ -14,7 +14,7 @@
  * @module libs/core/src/listings/application/types
  */
 
-import type { CreateOfferOverrides } from '@openlinker/core/listings';
+import type { CreateOfferOverrides, OfferCondition } from '@openlinker/core/listings';
 import type { OfferDescriptionTone } from '@openlinker/core/sync';
 
 import type { OfferCreationRecord } from '../../domain/entities/offer-creation-record.entity';
@@ -32,6 +32,15 @@ export interface EnqueueOfferCreationInput {
   price?: { amount: number; currency: string };
   /** Optional overrides; the builder strips null/undefined on the worker side. */
   overrides?: CreateOfferOverrides;
+  /**
+   * Optional explicit item condition (#1500). Persisted on the record's
+   * `request` snapshot and forwarded on the job payload so it survives the
+   * enqueue → worker → (bulk-)retry round-trip, then defaulted to `'new'` by
+   * the builder when omitted. Programmatic seam only — the operator's wizard
+   * choice rides on `overrides.parameters` (the Stan param) instead. Not
+   * exposed on any HTTP DTO.
+   */
+  condition?: OfferCondition;
   /** Caller-supplied idempotency key; defaults to `offer-create:{record.id}` (per-call-unique). */
   idempotencyKey?: string;
   /**

--- a/libs/core/src/listings/application/types/offer-creation-execution.types.ts
+++ b/libs/core/src/listings/application/types/offer-creation-execution.types.ts
@@ -7,7 +7,7 @@
  * @module libs/core/src/listings/application/types
  */
 
-import type { CreateOfferOverrides } from '@openlinker/core/listings';
+import type { CreateOfferOverrides, OfferCondition } from '@openlinker/core/listings';
 import type { JobOutcome } from '@openlinker/core/sync';
 
 import type { OfferCreationRecord } from '../../domain/entities/offer-creation-record.entity';
@@ -25,6 +25,15 @@ export interface ExecuteOfferCreationInput {
   price?: { amount: number; currency: string };
   /** Optional overrides (title, description, category, images, platformParams). */
   overrides?: CreateOfferOverrides;
+  /**
+   * Optional explicit item condition (#1500). Forwarded verbatim to
+   * `OfferBuilderService.buildCreateOfferCommand`, which defaults it to `'new'`
+   * when omitted so every built command carries the marketplace-required
+   * condition. Programmatic seam only — an operator's wizard choice rides on
+   * `overrides.parameters` (the Stan param) instead, and the destination
+   * adapter never double-sets condition. Not exposed on any HTTP DTO.
+   */
+  condition?: OfferCondition;
   /** Optional idempotency key threaded to the adapter (e.g. Allegro external.id). */
   idempotencyKey?: string;
   /**

--- a/libs/core/src/listings/domain/types/offer-create.types.ts
+++ b/libs/core/src/listings/domain/types/offer-create.types.ts
@@ -13,6 +13,20 @@
 import type { OfferParameter } from './offer-parameter.types';
 
 /**
+ * Marketplace-neutral item condition (#1500).
+ *
+ * A small closed set sufficient for the marketplaces OL targets today (Allegro's
+ * "Stan", Erli's borrowed Allegro taxonomy); richer vocabularies (refurbished,
+ * damaged, …) can extend it later. The neutral value carries no platform id —
+ * each destination adapter owns the neutral → wire mapping (Allegro "Stan" 11323
+ * dictionary value id; Erli `source:"allegro"` 11323). Marketplaces require a
+ * condition on offer creation, so `OfferBuilderService` defaults it to `'new'`
+ * when the operator supplies none.
+ */
+export const OfferConditionValues = ['new', 'used'] as const;
+export type OfferCondition = (typeof OfferConditionValues)[number];
+
+/**
  * A source-shop category reference carried through from the master catalog
  * (#1096). Platform-neutral: a destination that accepts shop-native taxonomy
  * (Erli `source:"shop"`, ADR-025 §3) maps these to its wire shape when no
@@ -194,6 +208,17 @@ export interface CreateOfferCommand {
    * pre-resolution alongside `variantBarcode` / `productCardId`.
    */
   variantGroup?: OfferVariantGroup;
+  /**
+   * Marketplace-neutral item condition (#1500). Defaulted to `'new'` by
+   * `OfferBuilderService` when the operator supplies none, so every core-built
+   * command carries a condition and non-UI / borrows paths no longer silently
+   * omit the marketplace-required condition parameter. Each destination adapter
+   * maps it to its wire shape (Allegro "Stan" 11323 dictionary value; Erli
+   * `source:"allegro"` 11323) and MUST NOT override an operator-supplied
+   * condition parameter already present in `parameters` (operator intent wins,
+   * never double-set). Platform-neutral: no platform id lives in core.
+   */
+  condition?: OfferCondition;
   /**
    * Source-shop category references (master-derived), platform-neutral (#1096).
    * Threaded by `OfferBuilderService` from the master product's categories. A

--- a/libs/core/src/listings/domain/types/offer-creation-request-snapshot.types.ts
+++ b/libs/core/src/listings/domain/types/offer-creation-request-snapshot.types.ts
@@ -14,7 +14,7 @@
  * @module libs/core/src/listings/domain/types
  */
 
-import type { CreateOfferOverrides } from '@openlinker/core/listings';
+import type { CreateOfferOverrides, OfferCondition } from '@openlinker/core/listings';
 
 /**
  * Current snapshot schema version. Bump when the shape changes incompatibly;
@@ -47,4 +47,11 @@ export interface OfferCreationRequestSnapshot {
   publishImmediately: boolean;
   price?: OfferCreationRequestPriceSnapshot;
   overrides?: CreateOfferOverrides;
+  /**
+   * Programmatic item condition captured at submit time (#1500), so a
+   * bulk/single retry rebuild carries it back onto the re-enqueued job. Absent
+   * for wizard submissions — the operator's Stan choice rides on `overrides`
+   * instead — in which case the builder re-applies its `'new'` default.
+   */
+  condition?: OfferCondition;
 }

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -155,13 +155,14 @@ export type {
 } from './domain/types/offer-quantity-update.types';
 export type { UpdateOfferFieldsCommand } from './domain/types/offer-fields-update.types';
 export type { OfferCategory } from './domain/types/category.types';
-export { CreateOfferResultStatusValues } from './domain/types/offer-create.types';
+export { CreateOfferResultStatusValues, OfferConditionValues } from './domain/types/offer-create.types';
 export type {
   CreateOfferCommand,
   CreateOfferOverrides,
   CreateOfferResult,
   CreateOfferResultStatus,
   CreateOfferValidationError,
+  OfferCondition,
   OfferVariantGroup,
   OfferVariantAttribute,
   SourceCategoryRef,

--- a/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
@@ -6,7 +6,7 @@
  * @module libs/core/src/sync/domain/types
  */
 
-import type { CreateOfferOverrides, OfferFieldUpdate } from '@openlinker/core/listings';
+import type { CreateOfferOverrides, OfferCondition, OfferFieldUpdate } from '@openlinker/core/listings';
 import type { OrderFeedEventType } from '@openlinker/core/orders';
 
 export interface MarketplaceOrdersPollPayloadV1 {
@@ -84,6 +84,13 @@ export interface MarketplaceOfferCreatePayloadV1 {
    * expected to carry `null` description/imageUrls.
    */
   overrides?: CreateOfferOverrides;
+  /**
+   * Optional neutral item condition (#1500). Carried so a programmatic caller's
+   * choice survives the enqueue → worker round-trip; the builder defaults it to
+   * `'new'` when absent. The operator's wizard Stan choice rides on `overrides`
+   * instead, so wizard payloads normally omit this.
+   */
+  condition?: OfferCondition;
   /** Optional idempotency key forwarded to the adapter. */
   idempotencyKey?: string;
   /**
@@ -117,6 +124,8 @@ export interface MarketplaceOfferCreatePayloadV2 {
   price?: { amount: number; currency: string };
   /** Optional overrides — same shape as V1. */
   overrides?: CreateOfferOverrides;
+  /** Optional neutral item condition (#1500) — same seam as V1. */
+  condition?: OfferCondition;
   /** Optional idempotency key forwarded to the adapter. */
   idempotencyKey?: string;
   /** Pre-created OfferCreationRecord id — always set for V2 (bulk pre-creates). */

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -1340,6 +1340,61 @@ describe('AllegroOfferManagerAdapter', () => {
       ]);
     });
 
+    it('maps neutral condition "new" to the "Stan" (11323) offer-section parameter (#1500)', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-cond-new', publication: { status: 'INACTIVE' } })
+      );
+
+      await adapter.createOffer({ ...baseCmd, condition: 'new' });
+
+      const body = httpClient.post.mock.calls[0][1] as {
+        parameters?: Array<{ id: string; valuesIds?: string[] }>;
+      };
+      expect(body.parameters).toEqual([{ id: '11323', valuesIds: ['11323_1'] }]);
+    });
+
+    it('maps neutral condition "used" to Stan value 11323_2 (#1500)', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-cond-used', publication: { status: 'INACTIVE' } })
+      );
+
+      await adapter.createOffer({ ...baseCmd, condition: 'used' });
+
+      const body = httpClient.post.mock.calls[0][1] as {
+        parameters?: Array<{ id: string; valuesIds?: string[] }>;
+      };
+      expect(body.parameters).toEqual([{ id: '11323', valuesIds: ['11323_2'] }]);
+    });
+
+    it('does NOT override an operator-supplied Stan (11323) parameter with the default condition (#1500)', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-cond-op', publication: { status: 'INACTIVE' } })
+      );
+
+      await adapter.createOffer({
+        ...baseCmd,
+        condition: 'new',
+        parameters: [{ id: '11323', valuesIds: ['11323_2'], section: 'offer' }],
+      });
+
+      const body = httpClient.post.mock.calls[0][1] as {
+        parameters?: Array<{ id: string; valuesIds?: string[] }>;
+      };
+      // Operator's Stan wins; the default 'new' condition is not double-set.
+      expect(body.parameters).toEqual([{ id: '11323', valuesIds: ['11323_2'] }]);
+    });
+
+    it('does not emit a Stan parameter when condition is absent (#1500)', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-no-cond', publication: { status: 'INACTIVE' } })
+      );
+
+      await adapter.createOffer(baseCmd);
+
+      const body = httpClient.post.mock.calls[0][1] as { parameters?: unknown };
+      expect(body).not.toHaveProperty('parameters');
+    });
+
     it('emits rangeValue from a neutral cmd.parameters entry (#1071)', async () => {
       httpClient.post.mockResolvedValue(
         mockHttpResponse({ id: 'allegro-offer-range', publication: { status: 'INACTIVE' } })

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -1587,6 +1587,13 @@ export class AllegroOfferManagerAdapter
    * offer-section params — operator intent wins and condition is never
    * double-set. `valuesIds` carries the dictionary entry id ("Stan" is a
    * dictionary parameter).
+   *
+   * The operator-wins check inspects only the offer-section params
+   * (`existingOfferParameters`) by design: "Stan" is inherently an
+   * offer-section parameter on Allegro (fixture `describesProduct:false`; the
+   * wizard/mapper always treat it as offer-section), so a product-section Stan
+   * cannot legitimately arise. If that assumption ever breaks, extend the
+   * dedup to scan the product-section params too.
    */
   private buildConditionParameter(
     condition: OfferCondition | undefined,

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -40,6 +40,7 @@ import type {
   UpdateOfferQuantityCommand,
   UpdateOfferFieldsCommand,
   CreateOfferCommand,
+  OfferCondition,
   OfferParameter,
   CreateOfferResult,
   CreateOfferResultStatus,
@@ -108,6 +109,19 @@ import { AllegroQuantityCommand } from '../../index';
 
 /** Adapter key registered for the Allegro marketplace integration. */
 const ALLEGRO_ADAPTER_KEY = 'allegro.publicapi.v1';
+
+/**
+ * Allegro "Stan" (condition) parameter id and its dictionary value ids (#1500).
+ * "Stan" is an offer-section parameter; the adapter owns this neutral → wire
+ * mapping so core carries only the neutral `CreateOfferCommand.condition`. Value
+ * ids are Allegro's stable global dictionary entries (`11323_1` = Nowy / new,
+ * `11323_2` = Używany / used).
+ */
+const ALLEGRO_CONDITION_PARAMETER_ID = '11323';
+const ALLEGRO_CONDITION_VALUE_IDS: Record<OfferCondition, string> = {
+  new: '11323_1',
+  used: '11323_2',
+};
 
 /** Default cache TTL (24h) for `/sale/categories/{id}/parameters` responses. */
 const DEFAULT_CAT_PARAMS_TTL_SEC = 24 * 60 * 60;
@@ -1544,7 +1558,7 @@ export class AllegroOfferManagerAdapter
     // ensures `this.sellerDefaults` is defined by the time we get here).
     body.location = { ...this.sellerDefaults!.location };
 
-    this.applyPlatformParams(body, platformParams, cmd.parameters, cardLinkResult);
+    this.applyPlatformParams(body, platformParams, cmd.parameters, cardLinkResult, cmd.condition);
 
     return body;
   }
@@ -1566,11 +1580,36 @@ export class AllegroOfferManagerAdapter
     }));
   }
 
+  /**
+   * Build the Allegro "Stan" (condition) offer-section parameter from the neutral
+   * `cmd.condition` (#1500). Returns `undefined` when no condition is set OR when
+   * the operator already supplied a Stan parameter (id 11323) among the
+   * offer-section params — operator intent wins and condition is never
+   * double-set. `valuesIds` carries the dictionary entry id ("Stan" is a
+   * dictionary parameter).
+   */
+  private buildConditionParameter(
+    condition: OfferCondition | undefined,
+    existingOfferParameters: readonly AllegroOfferParameter[]
+  ): AllegroOfferParameter | undefined {
+    if (!condition) {
+      return undefined;
+    }
+    if (existingOfferParameters.some((p) => p.id === ALLEGRO_CONDITION_PARAMETER_ID)) {
+      return undefined;
+    }
+    return {
+      id: ALLEGRO_CONDITION_PARAMETER_ID,
+      valuesIds: [ALLEGRO_CONDITION_VALUE_IDS[condition]],
+    };
+  }
+
   private applyPlatformParams(
     body: AllegroProductOfferCreateRequest,
     platformParams: Record<string, unknown>,
     parameters: readonly OfferParameter[] | undefined,
-    cardLinkResult: ResolveProductCardResult
+    cardLinkResult: ResolveProductCardResult,
+    condition: OfferCondition | undefined
   ): void {
     const deliveryPolicyId = platformParams['deliveryPolicyId'];
     const handlingTime = platformParams['handlingTime'];
@@ -1614,6 +1653,13 @@ export class AllegroOfferManagerAdapter
     const offerParameters = this.toAllegroParameters(
       (parameters ?? []).filter((p) => p.section === 'offer')
     );
+    // #1500 — default marketplace-required condition ("Stan"). Skip when the
+    // operator already supplied a Stan parameter (offer-section id 11323) so
+    // operator intent wins and condition is never double-set.
+    const conditionParameter = this.buildConditionParameter(condition, offerParameters);
+    if (conditionParameter) {
+      offerParameters.push(conditionParameter);
+    }
     if (offerParameters.length > 0) {
       body.parameters = offerParameters;
     }

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -478,6 +478,15 @@ describe('ErliOfferManagerAdapter', () => {
         ]);
       });
 
+      it('does not emit a Stan attribute when condition is absent', async () => {
+        // Mirrors the Allegro "absent -> no Stan param" coverage: with no
+        // condition and no operator params, no Stan (11323) attribute is added.
+        await adapter.createOffer(createCmd());
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toBeUndefined();
+      });
+
       it('appends condition before variant-group axes so group index refs stay valid', async () => {
         const groupId = `ol_product_${'c'.repeat(32)}`;
         await adapter.createOffer(
@@ -499,6 +508,38 @@ describe('ErliOfferManagerAdapter', () => {
           type: 'dictionary',
           values: [{ id: '11323_1' }],
         });
+        expect(body.externalAttributes?.[1]).toMatchObject({
+          source: 'shop',
+          name: 'Color',
+          values: ['Red'],
+          index: 1,
+        });
+        expect(body.externalVariantGroup?.attributes).toEqual([1]);
+      });
+
+      it('keeps operator-Stan dedup and variant-group index integrity together', async () => {
+        const groupId = `ol_product_${'d'.repeat(32)}`;
+        await adapter.createOffer(
+          createCmd({
+            // Default condition 'new' plus an operator-supplied Stan param: the
+            // operator wins (no double-set), and the appended group axis still
+            // references its own absolute index after the operator attribute.
+            condition: 'new',
+            parameters: [{ id: '11323', valuesIds: ['11323_2'], section: 'offer' }],
+            variantGroup: { groupId, attributes: [{ name: 'Color', value: 'Red' }] },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as {
+          externalAttributes?: Array<{ id: string; index?: number }>;
+          externalVariantGroup?: { attributes?: number[] };
+        };
+        // Exactly one Stan attribute — the operator's (11323_2), not the default.
+        const stanAttrs = (body.externalAttributes ?? []).filter((a) => a.id === '11323');
+        expect(stanAttrs).toEqual([
+          { source: 'allegro', id: '11323', type: 'dictionary', values: [{ id: '11323_2' }] },
+        ]);
+        // The group axis follows the single param attribute at index 1.
         expect(body.externalAttributes?.[1]).toMatchObject({
           source: 'shop',
           name: 'Color',

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -444,6 +444,71 @@ describe('ErliOfferManagerAdapter', () => {
       });
     });
 
+    describe('condition default (#1500)', () => {
+      it('maps neutral condition "new" to a source:"allegro" Stan (11323_1) attribute', async () => {
+        await adapter.createOffer(createCmd({ condition: 'new' }));
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '11323', type: 'dictionary', values: [{ id: '11323_1' }] },
+        ]);
+      });
+
+      it('maps neutral condition "used" to Stan value 11323_2', async () => {
+        await adapter.createOffer(createCmd({ condition: 'used' }));
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '11323', type: 'dictionary', values: [{ id: '11323_2' }] },
+        ]);
+      });
+
+      it('does NOT double-set condition when the operator already supplied a Stan (11323) param', async () => {
+        await adapter.createOffer(
+          createCmd({
+            condition: 'new',
+            parameters: [{ id: '11323', valuesIds: ['11323_2'], section: 'offer' }],
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as { externalAttributes?: unknown };
+        // Operator's Stan wins; the default 'new' condition is not appended.
+        expect(body.externalAttributes).toEqual([
+          { source: 'allegro', id: '11323', type: 'dictionary', values: [{ id: '11323_2' }] },
+        ]);
+      });
+
+      it('appends condition before variant-group axes so group index refs stay valid', async () => {
+        const groupId = `ol_product_${'c'.repeat(32)}`;
+        await adapter.createOffer(
+          createCmd({
+            condition: 'new',
+            variantGroup: { groupId, attributes: [{ name: 'Color', value: 'Red' }] },
+          }),
+        );
+
+        const body = httpClient.post.mock.calls[0][1] as {
+          externalAttributes?: Array<{ id: string; index?: number }>;
+          externalVariantGroup?: { attributes?: number[] };
+        };
+        // Condition attribute precedes the group axis; the group references the
+        // axis by its absolute index (1), unaffected by the prepended condition.
+        expect(body.externalAttributes?.[0]).toEqual({
+          source: 'allegro',
+          id: '11323',
+          type: 'dictionary',
+          values: [{ id: '11323_1' }],
+        });
+        expect(body.externalAttributes?.[1]).toMatchObject({
+          source: 'shop',
+          name: 'Color',
+          values: ['Red'],
+          index: 1,
+        });
+        expect(body.externalVariantGroup?.attributes).toEqual([1]);
+      });
+    });
+
     describe('variant grouping (#986/#1065)', () => {
       const GROUP_ID = `ol_product_${'b'.repeat(32)}`;
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -107,6 +107,7 @@ import {
   type CreateOfferResult,
   type CreateOfferValidationError,
   type OfferCategory,
+  type OfferCondition,
   type OfferCreator,
   type OfferDescriptionUpdate,
   type OfferFieldUpdate,
@@ -166,6 +167,19 @@ const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, 
  * different name, this is the single change point alongside that map.
  */
 const ERLI_FROZEN_STOCK_FIELD = 'stock';
+
+/**
+ * Erli condition ("Stan") parameter id and its dictionary value ids (#1500).
+ * Erli borrows Allegro's taxonomy (ADR-025 §3), so condition rides as the Allegro
+ * "Stan" parameter (`11323`) with the same dictionary value id (`11323_1` = new,
+ * `11323_2` = used), emitted `source:"allegro"`. The adapter owns this neutral →
+ * wire mapping; core carries only the neutral `CreateOfferCommand.condition`.
+ */
+const ERLI_CONDITION_PARAMETER_ID = '11323';
+const ERLI_CONDITION_VALUE_IDS: Record<OfferCondition, string> = {
+  new: '11323_1',
+  used: '11323_2',
+};
 
 /**
  * Frozen-stock cache TTL (#1066). Sized for the WORST-case reconciliation cadence
@@ -585,6 +599,17 @@ export class ErliOfferManagerAdapter
       );
     }
 
+    // #1500 — default marketplace-required condition ("Stan"). Erli borrows
+    // Allegro's taxonomy, so condition rides as a source:"allegro" dictionary
+    // attribute. Appended to the Allegro-param attributes BEFORE the variant-group
+    // index calc below so the group's index refs (which point at the axes that
+    // come after) stay valid. Skipped when the operator already supplied a Stan
+    // parameter in cmd.parameters (operator intent wins, never double-set).
+    const conditionAttribute = buildConditionAttribute(cmd);
+    if (conditionAttribute) {
+      paramAttributes.push(conditionAttribute);
+    }
+
     // #986/#1065: explicit multi-variant grouping. A sibling's distinguishing
     // axes become shop-source `externalAttributes` entries, and the group
     // references them by **index** — Erli's verified wire shape. There is NO
@@ -872,6 +897,30 @@ function buildExternalAttributes(cmd: CreateOfferCommand): {
     }
   }
   return { attributes, droppedParamIds };
+}
+
+/**
+ * Build the Erli condition ("Stan") attribute from the neutral `cmd.condition`
+ * (#1500). Erli borrows Allegro's taxonomy (ADR-025 §3), so condition is emitted
+ * as a `source:"allegro"` dictionary attribute (parameter id `11323`, value id
+ * `11323_1`/`11323_2`). Returns `undefined` when no condition is set OR when the
+ * operator already supplied a Stan parameter in `cmd.parameters` — operator
+ * intent wins and condition is never double-set.
+ */
+function buildConditionAttribute(cmd: CreateOfferCommand): ErliExternalAttribute | undefined {
+  const condition = cmd.condition;
+  if (!condition) {
+    return undefined;
+  }
+  if ((cmd.parameters ?? []).some((p) => p.id === ERLI_CONDITION_PARAMETER_ID)) {
+    return undefined;
+  }
+  return {
+    source: 'allegro',
+    id: ERLI_CONDITION_PARAMETER_ID,
+    type: 'dictionary',
+    values: [{ id: ERLI_CONDITION_VALUE_IDS[condition] }],
+  };
 }
 
 /**


### PR DESCRIPTION
## What & why

Marketplace listings require a **condition** parameter (Allegro "Stan" id `11323`; Erli `11323_1`), but OpenLinker core never supplied one. The value only ever reached the wire through the UI wizard's category-parameter step, so any path that does not collect it from the operator silently omitted the required parameter and hit an opaque marketplace-side rejection:

- **Erli** borrows/open projection branch (no Allegro category reader wired) - the real motivating case from golden-path E2E.
- **Programmatic / API** offer creation (no UI).

This adds a first-class, marketplace-neutral `condition` (default `"new"`) to the core command, so bulk, programmatic, and Erli paths all get a condition uniformly. It does **not** touch the FE wizard (Allegro UI already collects "Stan" post-#1367).

## Changes

- **Core (`libs/core/listings`)**
  - New neutral `OfferCondition` (`'new' | 'used'`) + `OfferConditionValues` in `offer-create.types.ts`; exported from the listings barrel.
  - `CreateOfferCommand.condition?` and `BuildCreateOfferCommandInput.condition?` added.
  - `OfferBuilderService` stamps `command.condition = input.condition ?? 'new'` - the single default source. An explicit operator-supplied condition wins.
- **Allegro adapter** - maps `cmd.condition` to the offer-section "Stan" parameter (`id 11323`, `valuesIds` `11323_1` new / `11323_2` used). Skipped when the operator already supplied a Stan (11323) param, so it is never double-set.
- **Erli adapter** - maps `cmd.condition` to a `source:"allegro"` dictionary attribute (`11323` -> `11323_1`/`11323_2`), matching Erli's borrowed-Allegro-taxonomy shape. Appended before the variant-group axes so the group's index refs stay valid. Same operator-wins dedup.

No platform literal strings leak into core - the neutral field follows the existing `variantGroup` precedent (adapters own the neutral -> wire mapping). CORE <-> Integration boundary respected.

## Design decisions

- **Closed set `'new' | 'used'`** - sufficient for Allegro/Erli today; extensible later (documented on the type).
- **Default lives in the builder only** (not duplicated in adapters). Every real offer-creation path routes through `OfferBuilderService`, so this covers bulk, programmatic, and Erli uniformly; adapters map whatever `cmd.condition` is present.
- **Operator override precedence** - a programmatic caller uses `input.condition`; a wizard operator's explicit "Stan" pick rides on `overrides.parameters` and is honoured by each adapter's dedup (operator's platform param wins over the default).
- `11323_1`=Nowy / `11323_2`=Używany verified against the Allegro category-parameters fixture.

## How tested

Scoped per touched package (type-check + unit tests):

- `@openlinker/core` - type-check clean; 1477 tests pass (2 new builder tests: default applied, operator override).
- `@openlinker/integrations-allegro` - type-check clean; 530 tests pass (4 new: new->11323_1, used->11323_2, operator-Stan-wins, absent->no param).
- `@openlinker/integrations-erli` - type-check clean; 361 tests pass (4 new: new->11323_1, used->11323_2, operator-wins dedup, group-index integrity).

ESLint clean on all changed files.

Closes #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)