### PR TITLE
fix(listings): make bulk-wizard category resolve mapping-aware (#1522)

### DIFF
--- a/apps/api/src/listings/http/dto/resolve-category-batch.dto.ts
+++ b/apps/api/src/listings/http/dto/resolve-category-batch.dto.ts
@@ -38,6 +38,19 @@ export class ResolveCategoryBatchItemDto {
   @IsString()
   @MaxLength(64)
   ean?: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      "Source-platform category ids for this variant's product, ordered deepest-first. " +
+      'When the EAN yields no catalogue match, the batch falls back to the configured ' +
+      'per-source-category mapping to resolve the destination category (#1522). ' +
+      'Omit for EAN-only resolution.',
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  sourceCategoryIds?: string[];
 }
 
 export class ResolveCategoryBatchRequestDto {

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -818,6 +818,39 @@ describe('ListingsController', () => {
       });
     });
 
+    it('forwards sourceCategoryIds and surfaces a category_mapping result (#1522)', async () => {
+      const serviceResult = new Map<string, EanMatchResult>([
+        [
+          'v1',
+          {
+            kind: 'matched',
+            allegroCategoryId: '89508',
+            productCardId: '',
+            method: 'category_mapping',
+          },
+        ],
+      ]);
+      categoryResolution.resolveCategoriesBatch.mockResolvedValue(serviceResult);
+
+      const result = await controller.resolveCategoriesBatch('conn-1', {
+        items: [{ variantId: 'v1', ean: '5901234567890', sourceCategoryIds: ['ps-cat-42'] }],
+      });
+
+      expect(categoryResolution.resolveCategoriesBatch).toHaveBeenCalledWith('conn-1', {
+        items: [{ variantId: 'v1', ean: '5901234567890', sourceCategoryIds: ['ps-cat-42'] }],
+      });
+      expect(result).toEqual({
+        results: {
+          v1: {
+            kind: 'matched',
+            allegroCategoryId: '89508',
+            productCardId: '',
+            method: 'category_mapping',
+          },
+        },
+      });
+    });
+
     it('maps AdapterCapabilityNotSupportedException to 422', async () => {
       categoryResolution.resolveCategoriesBatch.mockRejectedValue(
         new AdapterCapabilityNotSupportedException('conn-1', 'EanCategoryMatcher')

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -548,13 +548,15 @@ export class ListingsController {
   @HttpCode(HttpStatus.OK)
   @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
   @ApiOperation({
-    summary: 'Batch-resolve marketplace categories by variant EAN (#795)',
+    summary: 'Batch-resolve marketplace categories by variant EAN, with mapping fallback (#795 / #1522)',
     description:
-      'Resolves up to 200 variant EANs to marketplace categories in one call via the ' +
-      'connection adapter’s EanCategoryMatcher sub-capability (#735). EAN-only — no ' +
-      'mapping fallback. Drives the bulk-listing wizard Resolve step, replacing the ' +
-      'previous one-HTTP-call-per-row loop. Results are keyed by variantId; every input ' +
-      'item gets exactly one entry.',
+      'Resolves up to 200 variants to marketplace categories in one call. EAN catalogue ' +
+      'match (via the connection adapter’s EanCategoryMatcher sub-capability, #735) is the ' +
+      'primary path; when the EAN yields no match and the item supplies sourceCategoryIds, ' +
+      'the batch falls back to the operator’s configured per-source-category mapping (#1522), ' +
+      'returning method="category_mapping". Drives the bulk-listing wizard Resolve step, ' +
+      'replacing the previous one-HTTP-call-per-row loop. Results are keyed by variantId; ' +
+      'every input item gets exactly one entry.',
   })
   @ApiResponse({
     status: 200,
@@ -573,7 +575,13 @@ export class ListingsController {
   ): Promise<ResolveCategoryBatchResponseDto> {
     try {
       const results = await this.categoryResolution.resolveCategoriesBatch(connectionId, {
-        items: dto.items.map((item) => ({ variantId: item.variantId, ean: item.ean ?? null })),
+        items: dto.items.map((item) => ({
+          variantId: item.variantId,
+          ean: item.ean ?? null,
+          ...(item.sourceCategoryIds && item.sourceCategoryIds.length > 0
+            ? { sourceCategoryIds: item.sourceCategoryIds }
+            : {}),
+        })),
       });
       return { results: Object.fromEntries(results) };
     } catch (error) {

--- a/apps/api/src/products/http/dto/product-response.dto.ts
+++ b/apps/api/src/products/http/dto/product-response.dto.ts
@@ -36,6 +36,16 @@ export class ProductResponseDto {
   @ApiPropertyOptional({ nullable: true, description: 'Product image URLs' })
   images!: string[] | null;
 
+  @ApiPropertyOptional({
+    nullable: true,
+    type: [String],
+    description:
+      'Source-platform external category ids (#1034), populated at product sync. ' +
+      'Drives the per-source-category mapping fallback in the bulk-offer wizard (#1522). ' +
+      'Null until a sync populates it.',
+  })
+  categories!: string[] | null;
+
   @ApiProperty({ description: 'Creation timestamp (ISO 8601)' })
   createdAt!: string;
 

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -218,6 +218,7 @@ export class ProductsController {
       currency: product.currency ?? null,
       description: product.description,
       images: product.images,
+      categories: product.categories ?? null,
       createdAt: product.createdAt!.toISOString(),
       updatedAt: product.updatedAt!.toISOString(),
     };

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -574,18 +574,26 @@ export interface EanMatchCandidate {
   name?: string;
 }
 
+/**
+ * How a `matched` batch result was resolved (#1522). Absent ⇒ `auto_detect`
+ * (an EAN catalogue match). `category_mapping` marks a result produced by the
+ * configured per-source-category mapping fallback (no catalogue card).
+ */
+export type EanMatchMethod = 'auto_detect' | 'category_mapping';
+
 export type EanMatchResult =
-  | { kind: 'matched'; allegroCategoryId: string; productCardId: string }
+  | { kind: 'matched'; allegroCategoryId: string; productCardId: string; method?: EanMatchMethod }
   | { kind: 'multi-match'; candidates: EanMatchCandidate[] }
   | { kind: 'no-ean' }
   | { kind: 'no-match' };
 
 /**
  * Request body for `POST /listings/connections/:connectionId/categories/resolve-batch`
- * (#795). One result entry per item, keyed by `variantId`.
+ * (#795). One result entry per item, keyed by `variantId`. `sourceCategoryIds`
+ * (#1522) enables the configured-mapping fallback when the EAN yields no match.
  */
 export interface ResolveCategoriesBatchRequest {
-  items: Array<{ variantId: string; ean: string | null }>;
+  items: Array<{ variantId: string; ean: string | null; sourceCategoryIds?: string[] }>;
 }
 
 /** Response from the batch resolve route (#795). Keyed by `variantId`. */

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
@@ -204,6 +204,52 @@ describe('BulkResolveStep', () => {
     expect(out.categoryCandidates).toHaveLength(1);
   });
 
+  it('threads source categories and resolves a mapped category (EAN no-match) without blocking the row', async () => {
+    const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
+    // EAN misses Allegro's catalogue, but the operator's PS→Allegro category
+    // mapping resolves the destination category server-side (#1522).
+    const apiClient = mockClient({
+      results: {
+        var_prod_a: {
+          kind: 'matched',
+          allegroCategoryId: 'cat-mapped',
+          productCardId: '',
+          method: 'category_mapping',
+        },
+      },
+      availability: [{ productVariantId: 'var_prod_a', totalAvailable: 5, locationCount: 1 }],
+    });
+
+    renderWithProviders(
+      <BulkResolveStep
+        rows={[makeRow('prod_a', { ean: '5901111111111' }, { categories: ['ps-cat-42'] })]}
+        connectionId="conn_1"
+        pricingPolicy={{ mode: 'use-master' }}
+        stockPolicy={{ mode: 'use-master' }}
+        currency="PLN"
+        onComplete={onComplete}
+      />,
+      { apiClient },
+    );
+
+    await waitFor(() => { expect(onComplete).toHaveBeenCalledTimes(1); });
+
+    // The row's source category is threaded into the batch request.
+    expect(apiClient.listings.resolveCategoriesBatch).toHaveBeenCalledWith('conn_1', {
+      items: [{ variantId: 'var_prod_a', ean: '5901111111111', sourceCategoryIds: ['ps-cat-42'] }],
+    });
+
+    const out = onComplete.mock.calls[0][0][0];
+    // Mapping-resolved rows are NOT blocked and carry no category blocker.
+    expect(out.blockers).not.toContain('no-match');
+    expect(out.blockers).not.toContain('no-ean');
+    expect(out).toMatchObject({
+      resolvedCategoryId: 'cat-mapped',
+      resolvedProductCardId: null,
+      resolutionMethod: 'category_mapping',
+    });
+  });
+
   it('shows a Retry affordance and does not advance when the batch call fails', async () => {
     const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
     const apiClient = mockClient({ categoryRejects: true });

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
@@ -65,6 +65,11 @@ function barcodeOf(row: BulkWizardRow): string | null {
   return raw && raw.trim() !== '' ? raw : null;
 }
 
+/** Non-empty source-platform category ids for the row's product (#1522). */
+function sourceCategoriesOf(row: BulkWizardRow): string[] {
+  return (row.product?.categories ?? []).filter((c) => typeof c === 'string' && c.trim() !== '');
+}
+
 export function BulkResolveStep({
   rows,
   connectionId,
@@ -79,20 +84,30 @@ export function BulkResolveStep({
 
   const variantRows = rows.filter((r) => r.primaryVariant !== null);
   const variantIds = variantRows.map((r) => r.primaryVariant!.id);
-  const barcodeItems = variantRows
-    .map((r) => ({ variantId: r.primaryVariant!.id, ean: barcodeOf(r) }))
-    .filter((i): i is { variantId: string; ean: string } => i.ean !== null);
-  const barcodeVariantIds = barcodeItems.map((i) => i.variantId);
+  // Resolve any row that carries an EAN (primary catalogue-match path) OR a
+  // source category (mapping-fallback path, #1522). A row with neither can't
+  // resolve server-side and is synthesized as no-ean below without a call.
+  const resolveItems = variantRows
+    .map((r) => {
+      const cats = sourceCategoriesOf(r);
+      return {
+        variantId: r.primaryVariant!.id,
+        ean: barcodeOf(r),
+        ...(cats.length > 0 ? { sourceCategoryIds: cats } : {}),
+      };
+    })
+    .filter((i) => i.ean !== null || (i.sourceCategoryIds?.length ?? 0) > 0);
+  const resolveVariantIds = resolveItems.map((i) => i.variantId);
 
   const categoryQuery = useQuery({
-    queryKey: listingsQueryKeys.resolveCategoryBatch(connectionId, barcodeVariantIds),
-    queryFn: () => apiClient.listings.resolveCategoriesBatch(connectionId, { items: barcodeItems }),
-    enabled: barcodeItems.length > 0,
+    queryKey: listingsQueryKeys.resolveCategoryBatch(connectionId, resolveVariantIds),
+    queryFn: () => apiClient.listings.resolveCategoriesBatch(connectionId, { items: resolveItems }),
+    enabled: resolveItems.length > 0,
   });
 
   const availabilityQuery = useInventoryAvailabilityBatchQuery(variantIds);
 
-  const categoryReady = barcodeItems.length === 0 || categoryQuery.isSuccess;
+  const categoryReady = resolveItems.length === 0 || categoryQuery.isSuccess;
   const availabilityReady = variantIds.length === 0 || availabilityQuery.isSuccess;
   const hasError = categoryQuery.isError || availabilityQuery.isError;
   const settled = categoryReady && availabilityReady && !hasError;
@@ -119,10 +134,13 @@ export function BulkResolveStep({
         };
       }
 
+      // Prefer the batch verdict (which now covers both the EAN-match and the
+      // mapping-fallback paths, #1522). Only synthesize when the row was never
+      // sent — a row with neither an EAN nor a source category (no-ean), or a
+      // sent EAN row the batch somehow omitted (defensive no-match).
       const categoryResult: EanMatchResult =
-        barcodeOf(row) !== null
-          ? categoryResults[variant.id] ?? { kind: 'no-match' }
-          : { kind: 'no-ean' };
+        categoryResults[variant.id] ??
+        (barcodeOf(row) !== null ? { kind: 'no-match' } : { kind: 'no-ean' });
       const masterPrice = variant.price;
       const masterCurrency = row.product?.currency ?? null;
       const masterStock = availabilityMap.has(variant.id)
@@ -149,9 +167,18 @@ export function BulkResolveStep({
         blockers,
         resolvedCategoryId:
           categoryResult.kind === 'matched' ? categoryResult.allegroCategoryId : null,
+        // Empty on the mapping-fallback path (no catalogue card) — normalize to
+        // null so `selectBulkProductCardId` never threads an empty card (#1522).
         resolvedProductCardId:
-          categoryResult.kind === 'matched' ? categoryResult.productCardId : null,
-        resolutionMethod: categoryResult.kind === 'matched' ? 'auto_detect' : null,
+          categoryResult.kind === 'matched' && categoryResult.productCardId !== ''
+            ? categoryResult.productCardId
+            : null,
+        // Carry the BE-reported method so a mapping-resolved row reads as
+        // `category_mapping` rather than `auto_detect` (#1522).
+        resolutionMethod:
+          categoryResult.kind === 'matched'
+            ? categoryResult.method ?? 'auto_detect'
+            : null,
         masterPrice,
         masterStock,
         masterCurrency,

--- a/apps/web/src/features/products/api/products.types.ts
+++ b/apps/web/src/features/products/api/products.types.ts
@@ -40,6 +40,13 @@ export interface Product {
   currency: string | null;
   description: string | null;
   images: string[] | null;
+  /**
+   * Source-platform external category ids (#1034), populated at product sync.
+   * Threaded into the bulk-offer wizard's Resolve step so an EAN-no-match row
+   * can still resolve its destination category via the configured
+   * per-source-category mapping (#1522). Null/absent until a sync populates it.
+   */
+  categories?: string[] | null;
   createdAt: string;
   updatedAt: string;
   variants?: ProductVariant[];

--- a/libs/core/src/listings/application/interfaces/category-resolution.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/category-resolution.service.interface.ts
@@ -8,11 +8,9 @@
  * @module libs/core/src/listings/application/interfaces
  */
 
+import type { EanMatchResult } from '@openlinker/core/listings';
 import type {
-  BatchCategoryByEanInput,
-  EanMatchResult,
-} from '@openlinker/core/listings';
-import type {
+  BatchCategoryResolveInput,
   CategoryResolutionInput,
   CategoryResolutionResult,
 } from '../types/category-resolution.types';
@@ -33,19 +31,29 @@ export interface ICategoryResolutionService {
   resolveCategory(input: CategoryResolutionInput): Promise<CategoryResolutionResult>;
 
   /**
-   * Resolve marketplace categories for N variant EANs in one batch (#795).
+   * Resolve marketplace categories for N variants in one batch (#795), EAN
+   * first with a configured-mapping fallback (#1522).
    *
-   * Thin pass-through to the connection's `EanCategoryMatcher` sub-capability
-   * (#735) — EAN-only, no mapping fallback. Drives the bulk-listing wizard's
-   * Resolve step (#792 PR 3), collapsing the previous one-call-per-row loop
-   * into a single call.
+   * Primary path is the connection's `EanCategoryMatcher` sub-capability (#735).
+   * When the EAN yields no catalogue match (or the variant carries no EAN) and
+   * the item supplies `sourceCategoryIds`, the service consults the operator's
+   * per-source-category mapping — the same mapping `OfferBuilderService` honours
+   * at offer-build time — and returns a `matched` result with
+   * `method: 'category_mapping'` (empty `productCardId`). This keeps the wizard
+   * Resolve preview in agreement with build-time resolution.
    *
-   * Throws `AdapterCapabilityNotSupportedException` when the resolved
-   * `OfferManager` adapter does not implement `EanCategoryMatcher`.
-   * Returned map is keyed by `variantId`; every input item has one entry.
+   * Drives the bulk-listing wizard's Resolve step (#792 PR 3), collapsing the
+   * previous one-call-per-row loop into a single call.
+   *
+   * A destination that cannot batch-match EANs (a `borrows`-taxonomy
+   * destination, e.g. Erli) degrades every item to `no-match` — it resolves the
+   * category server-side at submit instead. Throws
+   * `AdapterCapabilityNotSupportedException` when the resolved connection is not
+   * an `OfferManager` marketplace at all. Returned map is keyed by `variantId`;
+   * every input item has one entry.
    */
   resolveCategoriesBatch(
     connectionId: string,
-    input: BatchCategoryByEanInput,
+    input: BatchCategoryResolveInput,
   ): Promise<Map<string, EanMatchResult>>;
 }

--- a/libs/core/src/listings/application/services/category-resolution.service.spec.ts
+++ b/libs/core/src/listings/application/services/category-resolution.service.spec.ts
@@ -172,8 +172,113 @@ describe('CategoryResolutionService', () => {
         CONNECTION_ID,
         'OfferManager'
       );
-      expect(resolveCategoriesForBatchByEan).toHaveBeenCalledWith(input);
-      expect(result).toBe(adapterResult);
+      // The adapter receives only the EAN-only shape (`sourceCategoryIds` is a
+      // core-owned fallback input, never forwarded to the adapter).
+      expect(resolveCategoriesForBatchByEan).toHaveBeenCalledWith({
+        items: [
+          { variantId: 'v1', ean: '590111' },
+          { variantId: 'v2', ean: null },
+        ],
+      });
+      // Returns one entry per input item, carrying the adapter's verdict when no
+      // mapping fallback applies (no `sourceCategoryIds` on these items).
+      expect(result.get('v1')).toEqual({
+        kind: 'matched',
+        allegroCategoryId: 'cat-1',
+        productCardId: 'card-1',
+      });
+      expect(result.get('v2')).toEqual({ kind: 'no-ean' });
+      expect(result.size).toBe(2);
+    });
+
+    it('should keep the EAN catalogue match when the EAN hits, ignoring the mapping', async () => {
+      const resolveCategoriesForBatchByEan = jest.fn().mockResolvedValue(
+        new Map<string, EanMatchResult>([
+          ['v1', { kind: 'matched', allegroCategoryId: 'cat-ean', productCardId: 'card-1' }],
+        ])
+      );
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        resolveCategoriesForBatchByEan,
+      });
+
+      const result = await service.resolveCategoriesBatch(CONNECTION_ID, {
+        items: [{ variantId: 'v1', ean: '590111', sourceCategoryIds: ['src-1'] }],
+      });
+
+      expect(result.get('v1')).toEqual({
+        kind: 'matched',
+        allegroCategoryId: 'cat-ean',
+        productCardId: 'card-1',
+      });
+      // EAN won — the mapping was never consulted.
+      expect(mappingConfig.resolveDestinationCategory).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to category_mapping when the EAN misses but a source-category mapping exists', async () => {
+      const resolveCategoriesForBatchByEan = jest.fn().mockResolvedValue(
+        new Map<string, EanMatchResult>([['v1', { kind: 'no-match' }]])
+      );
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        resolveCategoriesForBatchByEan,
+      });
+      mappingConfig.resolveDestinationCategory.mockResolvedValue('cat-mapped');
+
+      const result = await service.resolveCategoriesBatch(CONNECTION_ID, {
+        items: [{ variantId: 'v1', ean: '590111', sourceCategoryIds: ['src-deep', 'src-root'] }],
+      });
+
+      expect(result.get('v1')).toEqual({
+        kind: 'matched',
+        allegroCategoryId: 'cat-mapped',
+        productCardId: '',
+        method: 'category_mapping',
+      });
+      expect(mappingConfig.resolveDestinationCategory).toHaveBeenCalledWith(
+        CONNECTION_ID,
+        'src-deep'
+      );
+    });
+
+    it('should fall back to category_mapping for a variant with no EAN but a mapped source category', async () => {
+      const resolveCategoriesForBatchByEan = jest.fn().mockResolvedValue(
+        new Map<string, EanMatchResult>([['v1', { kind: 'no-ean' }]])
+      );
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        resolveCategoriesForBatchByEan,
+      });
+      mappingConfig.resolveDestinationCategory.mockResolvedValue('cat-mapped');
+
+      const result = await service.resolveCategoriesBatch(CONNECTION_ID, {
+        items: [{ variantId: 'v1', ean: null, sourceCategoryIds: ['src-1'] }],
+      });
+
+      expect(result.get('v1')).toEqual({
+        kind: 'matched',
+        allegroCategoryId: 'cat-mapped',
+        productCardId: '',
+        method: 'category_mapping',
+      });
+    });
+
+    it('should stay no-match when the EAN misses and no source-category mapping resolves', async () => {
+      const resolveCategoriesForBatchByEan = jest.fn().mockResolvedValue(
+        new Map<string, EanMatchResult>([['v1', { kind: 'no-match' }]])
+      );
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        resolveCategoriesForBatchByEan,
+      });
+      mappingConfig.resolveDestinationCategory.mockResolvedValue(null);
+
+      const result = await service.resolveCategoriesBatch(CONNECTION_ID, {
+        items: [{ variantId: 'v1', ean: '590111', sourceCategoryIds: ['src-1'] }],
+      });
+
+      expect(result.get('v1')).toEqual({ kind: 'no-match' });
+      expect(mappingConfig.resolveDestinationCategory).toHaveBeenCalledWith(CONNECTION_ID, 'src-1');
     });
 
     it('should degrade to no-match for every variant when the adapter cannot batch-resolve', async () => {

--- a/libs/core/src/listings/application/services/category-resolution.service.ts
+++ b/libs/core/src/listings/application/services/category-resolution.service.ts
@@ -156,6 +156,16 @@ export class CategoryResolutionService implements ICategoryResolutionService {
         item.sourceCategoryIds &&
         item.sourceCategoryIds.length > 0
       ) {
+        // Empty opts (no `sourceConnectionId`/`borrowedTaxonomy`) is safe today:
+        // this loop only runs past the `isEanCategoryMatcher` gate above, and
+        // every current EanCategoryMatcher (Allegro) *owns* its taxonomy, so
+        // `resolveDestinationCategory` resolves entirely via its step-1
+        // `findBySourceCategory` lookup, which consults neither opt. The
+        // transport also has no `sourceConnectionId` to carry. If a future
+        // destination is ever both an EanCategoryMatcher *and* a
+        // borrows-taxonomy destination, this batch preview would need to
+        // thread `sourceConnectionId`/`borrowedTaxonomy` here too, or it would
+        // silently diverge from `OfferBuilderService.resolveCategory`.
         const mapped = await this.tryCategoryMapping(connectionId, item.sourceCategoryIds, {});
         if (mapped) {
           this.logger.debug(

--- a/libs/core/src/listings/application/services/category-resolution.service.ts
+++ b/libs/core/src/listings/application/services/category-resolution.service.ts
@@ -21,7 +21,6 @@ import { Injectable, Inject } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
 import type {
   OfferManagerPort,
-  BatchCategoryByEanInput,
   EanMatchResult,
 } from '@openlinker/core/listings';
 import {
@@ -34,6 +33,7 @@ import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/co
 import { IMappingConfigService, MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
 import type { ICategoryResolutionService } from '../interfaces/category-resolution.service.interface';
 import type {
+  BatchCategoryResolveInput,
   CategoryProvenance,
   CategoryResolutionInput,
   CategoryResolutionResult,
@@ -108,7 +108,7 @@ export class CategoryResolutionService implements ICategoryResolutionService {
 
   async resolveCategoriesBatch(
     connectionId: string,
-    input: BatchCategoryByEanInput
+    input: BatchCategoryResolveInput
   ): Promise<Map<string, EanMatchResult>> {
     // Resolving the OfferManager adapter validates the connection up front:
     // unknown/disabled connections surface as 404/409, and a non-marketplace
@@ -120,10 +120,10 @@ export class CategoryResolutionService implements ICategoryResolutionService {
     // A destination that can't batch-match EANs (it `borrows` its taxonomy, e.g.
     // Erli per ADR-025 §3 — reuses already-resolved Allegro ids, has no catalog
     // of its own) degrades to `no-match` for every variant rather than aborting
-    // the whole batch. The operator then supplies the category per row in Review
-    // (manual / configured mapping). This mirrors the single-resolve chain's
-    // graceful fall-through and the per-item no-throw contract — "can't match →
-    // no-match" — and is gated on the declared capability, never `platformType`.
+    // the whole batch. It resolves the category server-side at submit instead
+    // (the wizard suppresses the pre-flight blocker for it). This mirrors the
+    // single-resolve chain's graceful fall-through and the per-item no-throw
+    // contract, and is gated on the declared capability, never `platformType`.
     if (!isEanCategoryMatcher(adapter)) {
       this.logger.debug(
         `Adapter lacks EanCategoryMatcher; degrading ${input.items.length} variant(s) to no-match ` +
@@ -136,7 +136,43 @@ export class CategoryResolutionService implements ICategoryResolutionService {
     this.logger.debug(
       `Batch-resolving ${input.items.length} variant EAN(s) (connection=${connectionId})`
     );
-    return adapter.resolveCategoriesForBatchByEan(input);
+    // EAN catalogue match stays the PRIMARY path — the adapter only needs
+    // `{ variantId, ean }`; `sourceCategoryIds` is a core-owned fallback input.
+    const eanResults = await adapter.resolveCategoriesForBatchByEan({
+      items: input.items.map((item) => ({ variantId: item.variantId, ean: item.ean })),
+    });
+
+    // #1522 — mapping fallback. When the EAN yields no catalogue match (or the
+    // variant has no EAN) and the item supplies source categories, consult the
+    // operator's configured per-source-category mapping — the same mapping
+    // `OfferBuilderService` honours at offer-build time — so the wizard preview
+    // agrees with the build. A hit resolves to a `matched` result with no
+    // catalogue card (the offer self-links by barcode at build time).
+    const resolved = new Map<string, EanMatchResult>();
+    for (const item of input.items) {
+      const eanResult = eanResults.get(item.variantId) ?? { kind: 'no-match' };
+      if (
+        (eanResult.kind === 'no-match' || eanResult.kind === 'no-ean') &&
+        item.sourceCategoryIds &&
+        item.sourceCategoryIds.length > 0
+      ) {
+        const mapped = await this.tryCategoryMapping(connectionId, item.sourceCategoryIds, {});
+        if (mapped) {
+          this.logger.debug(
+            `Variant ${item.variantId} resolved via category_mapping (connection=${connectionId}, categoryId=${mapped})`
+          );
+          resolved.set(item.variantId, {
+            kind: 'matched',
+            allegroCategoryId: mapped,
+            productCardId: '',
+            method: 'category_mapping',
+          });
+          continue;
+        }
+      }
+      resolved.set(item.variantId, eanResult);
+    }
+    return resolved;
   }
 
   /**

--- a/libs/core/src/listings/application/types/category-resolution.types.ts
+++ b/libs/core/src/listings/application/types/category-resolution.types.ts
@@ -75,6 +75,30 @@ export interface CategoryResolutionInput {
   sourceConnectionId?: string;
 }
 
+/**
+ * One variant's input to the bulk Resolve batch (#795, mapping-aware #1522).
+ * `sourceCategoryIds` is the per-source-category mapping fallback input —
+ * ordered deepest-first — consulted when the EAN yields no catalogue match
+ * (mirrors `CategoryResolutionInput.sourceCategoryIds` on the single-resolve
+ * chain). Absent/empty ⇒ EAN-only for that item (legacy behaviour).
+ */
+export interface BatchCategoryResolveItem {
+  variantId: string;
+  ean: string | null;
+  sourceCategoryIds?: string[];
+}
+
+/**
+ * Batch input for `ICategoryResolutionService.resolveCategoriesBatch` (#1522).
+ * A superset of the adapter-facing `BatchCategoryByEanInput`: each item may
+ * additionally carry `sourceCategoryIds` so the service can fall back to the
+ * configured mapping on an EAN no-match. The adapter still receives only
+ * `{ variantId, ean }` — the mapping fallback is a core concern.
+ */
+export interface BatchCategoryResolveInput {
+  items: BatchCategoryResolveItem[];
+}
+
 export interface CategoryResolutionResult {
   /** Resolved destination category ID, or null if manual pick is needed */
   destinationCategoryId: string | null;

--- a/libs/core/src/listings/domain/types/ean-category-match.types.ts
+++ b/libs/core/src/listings/domain/types/ean-category-match.types.ts
@@ -29,13 +29,31 @@ export const EanMatchResultKindValues = [
 export type EanMatchResultKind = (typeof EanMatchResultKindValues)[number];
 
 /**
+ * How a `matched` batch result was resolved (#1522).
+ *
+ * - `auto_detect`: unique product card found in the marketplace catalogue by
+ *   EAN (the adapter's `EanCategoryMatcher` path). This is the default and the
+ *   only value adapters ever produce — the field is absent on their results.
+ * - `category_mapping`: no catalogue match for the EAN, but the operator's
+ *   configured per-source-category mapping resolved the destination category.
+ *   Set only by `CategoryResolutionService.resolveCategoriesBatch` on the
+ *   mapping-fallback path; carries no catalogue card (`productCardId` is empty).
+ */
+export const EanMatchMethodValues = ['auto_detect', 'category_mapping'] as const;
+
+export type EanMatchMethod = (typeof EanMatchMethodValues)[number];
+
+/**
  * Per-EAN outcome of a batch category match call.
  *
- * - `matched`: unique product card found in Allegro's catalogue with this EAN;
- *   `allegroCategoryId` is the category-id reported on that card, ready to
- *   pre-fill the review-table row. `productCardId` is the Allegro
- *   product-card UUID — passed through to `productSet[0].product.id` at
- *   offer-create time so the offer smart-links to the catalogue card.
+ * - `matched`: a destination category was resolved for this variant.
+ *   `allegroCategoryId` is the resolved category-id, ready to pre-fill the
+ *   review-table row. `productCardId` is the marketplace product-card UUID
+ *   (Allegro) — passed through to `productSet[0].product.id` at offer-create
+ *   time so the offer smart-links to the catalogue card; it is empty on the
+ *   `category_mapping` fallback path (no catalogue card, #1522). `method`
+ *   distinguishes an EAN catalogue match (`auto_detect`, the default when the
+ *   field is absent) from the configured-mapping fallback (`category_mapping`).
  * - `multi-match`: more than one product card matched the EAN (rare but
  *   real — duplicate cards exist on Allegro's catalogue). Caller MUST surface
  *   candidate selection UX (#740). Ordering preserves Allegro's relevance
@@ -47,7 +65,7 @@ export type EanMatchResultKind = (typeof EanMatchResultKindValues)[number];
  *   no-throw contract).
  */
 export type EanMatchResult =
-  | { kind: 'matched'; allegroCategoryId: string; productCardId: string }
+  | { kind: 'matched'; allegroCategoryId: string; productCardId: string; method?: EanMatchMethod }
   | { kind: 'multi-match'; candidates: EanMatchCandidate[] }
   | { kind: 'no-ean' }
   | { kind: 'no-match' };

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -32,6 +32,8 @@ export type {
   CategoryResolutionResult,
   CategoryResolutionMethod,
   CategoryProvenance,
+  BatchCategoryResolveItem,
+  BatchCategoryResolveInput,
 } from './application/types/category-resolution.types';
 export {
   CategoryResolutionMethodValues,
@@ -200,9 +202,10 @@ export type {
   SmartClassificationReport,
   SmartClassificationCondition,
 } from './domain/types/smart-classification.types';
-export { EanMatchResultKindValues } from './domain/types/ean-category-match.types';
+export { EanMatchResultKindValues, EanMatchMethodValues } from './domain/types/ean-category-match.types';
 export type {
   EanMatchResultKind,
+  EanMatchMethod,
   EanMatchResult,
   EanMatchCandidate,
   BatchCategoryByEanInput,


### PR DESCRIPTION
## What & why

The bulk-offer wizard's **Resolve step** resolved the destination (Allegro) category **by EAN catalogue-match only** and ignored the operator's configured PS -> Allegro category mapping. A product whose EAN is not in Allegro's catalogue but whose source category **is** mapped was blocked in the wizard (empty category picker, review row "needs attention"), even though `OfferBuilderService` builds the offer correctly server-side using that same mapping. The wizard preview and build-time resolution disagreed.

This makes the batch Resolve step **mapping-aware** so the two agree.

## Approach — mapping-aware resolve (the real fix)

Chosen over the FE-blocker-suppression fallback because the source category ids are already available end-to-end: OL persists them (`products.categories`, #1034) and the domain `Product` carries them; they were simply not exposed on the transport. Threading them lets the wizard **show** the resolved category, mirroring `OfferBuilderService`, rather than merely suppressing the blocker.

- **Core** — `CategoryResolutionService.resolveCategoriesBatch` keeps EAN catalogue match as the **primary** path. On an EAN `no-match` (or a variant with no EAN) it consults the operator's configured per-source-category mapping via the same `IMappingConfigService.resolveDestinationCategory` (`findBySourceCategory`) that `OfferBuilderService` uses, when the item supplies `sourceCategoryIds`. A hit returns a `matched` result with `method: 'category_mapping'` and an empty `productCardId` (the offer self-links by barcode at build time). Borrows-taxonomy destinations (Erli) are unchanged — they degrade to `no-match` and resolve server-side at submit.
- **Transport** — batch request item gains `sourceCategoryIds`; `EanMatchResult.matched` gains an optional `method`; `ProductResponseDto` / FE `Product` expose the persisted source category ids.
- **FE** — the Resolve step attaches each row's `product.categories`, prefers the batch verdict (now covering both EAN and mapping paths), reports `category_mapping`, and normalizes the empty mapping card id to `null`.

EAN match stays primary; mapping is the fallback only on `no-match` / `no-ean`. No CORE<->Integration boundary crossings; capability-gated, no `platformType` checks.

## How tested

- **Core** unit tests (`category-resolution.service.spec.ts`): EAN hit still wins (mapping not consulted); EAN no-match + source-category mapping -> resolves via `category_mapping`; no-EAN + mapping -> `category_mapping`; EAN no-match + no mapping -> stays `no-match`.
- **API** controller test: `sourceCategoryIds` forwarded to the service and a `category_mapping` result surfaced.
- **FE** (`bulk-resolve-step.test.tsx`): a mapped-category row (EAN no-match) is no longer blocked and carries `resolutionMethod: category_mapping`.
- Scoped gates green: `@openlinker/core` type-check + tests, `@openlinker/api` type-check + affected controller specs, `@openlinker/web` type-check + full test suite (one pre-existing, unrelated `settings-page.test.tsx` env-default failure). `pnpm check:invariants` passes.

Closes #1522

🤖 Generated with [Claude Code](https://claude.com/claude-code)
