### PR TITLE
feat(erli): operator-selectable delivery price list on offer create (#1530)

### DIFF
--- a/apps/api/src/listings/http/dto/delivery-price-lists-response.dto.ts
+++ b/apps/api/src/listings/http/dto/delivery-price-lists-response.dto.ts
@@ -1,0 +1,23 @@
+/**
+ * Delivery Price Lists Response DTO (#1530)
+ *
+ * Response shape for `GET /listings/connections/:connectionId/delivery-price-lists`.
+ * Swagger-decorated mirror of `DeliveryPriceList[]` from `@openlinker/core/listings`,
+ * wrapped under `deliveryPriceLists`.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeliveryPriceListDto {
+  @ApiProperty({ description: 'Platform-native delivery price list id' })
+  id!: string;
+
+  @ApiProperty({ description: 'Unique delivery price list name (operator-facing label)' })
+  name!: string;
+}
+
+export class DeliveryPriceListsResponseDto {
+  @ApiProperty({ type: [DeliveryPriceListDto] })
+  deliveryPriceLists!: DeliveryPriceListDto[];
+}

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -32,12 +32,14 @@ import {
   OfferCreationRecord,
   SELLER_POLICIES_SERVICE_TOKEN,
   RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
+  DELIVERY_PRICE_LIST_SERVICE_TOKEN,
 } from '@openlinker/core/listings';
 import type {
   ICategoryResolutionService,
   IOfferCreationEnqueueService,
   ISellerPoliciesService,
   IResponsibleProducerService,
+  IDeliveryPriceListService,
   OfferCreationRecordRepositoryPort,
   OfferMappingRepositoryPort,
 } from '@openlinker/core/listings';
@@ -58,6 +60,7 @@ describe('ListingsController', () => {
   let offerCreationEnqueue: jest.Mocked<IOfferCreationEnqueueService>;
   let sellerPolicies: jest.Mocked<ISellerPoliciesService>;
   let responsibleProducers: jest.Mocked<IResponsibleProducerService>;
+  let deliveryPriceLists: jest.Mocked<IDeliveryPriceListService>;
   let integrationsService: jest.Mocked<IIntegrationsService>;
   let productVariantRepository: jest.Mocked<ProductVariantRepositoryPort>;
   let categoryResolution: jest.Mocked<ICategoryResolutionService>;
@@ -108,6 +111,10 @@ describe('ListingsController', () => {
     offerCreationEnqueue = {
       enqueueCreation: jest.fn(),
     };
+    deliveryPriceLists = {
+      listDeliveryPriceLists: jest.fn(),
+    };
+
     sellerPolicies = {
       getSellerPolicies: jest.fn(),
     };
@@ -141,6 +148,7 @@ describe('ListingsController', () => {
         { provide: OFFER_CREATION_ENQUEUE_SERVICE_TOKEN, useValue: offerCreationEnqueue },
         { provide: SELLER_POLICIES_SERVICE_TOKEN, useValue: sellerPolicies },
         { provide: RESPONSIBLE_PRODUCER_SERVICE_TOKEN, useValue: responsibleProducers },
+        { provide: DELIVERY_PRICE_LIST_SERVICE_TOKEN, useValue: deliveryPriceLists },
         { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
         { provide: PRODUCT_VARIANT_REPOSITORY_TOKEN, useValue: productVariantRepository },
         { provide: CATEGORY_RESOLUTION_SERVICE_TOKEN, useValue: categoryResolution },
@@ -584,6 +592,25 @@ describe('ListingsController', () => {
         ],
       });
       expect(responsibleProducers.listResponsibleProducers).toHaveBeenCalledWith('conn-1');
+    });
+  });
+
+  describe('getDeliveryPriceLists', () => {
+    it('delegates to the delivery-price-list service and wraps the result', async () => {
+      deliveryPriceLists.listDeliveryPriceLists.mockResolvedValue([
+        { id: '1', name: '*' },
+        { id: '2', name: 'Kurier' },
+      ]);
+
+      const result = await controller.getDeliveryPriceLists('conn-1');
+
+      expect(result).toEqual({
+        deliveryPriceLists: [
+          { id: '1', name: '*' },
+          { id: '2', name: 'Kurier' },
+        ],
+      });
+      expect(deliveryPriceLists.listDeliveryPriceLists).toHaveBeenCalledWith('conn-1');
     });
   });
 

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -42,10 +42,12 @@ import {
   OFFER_MAPPING_REPOSITORY_TOKEN,
   SELLER_POLICIES_SERVICE_TOKEN,
   RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
+  DELIVERY_PRICE_LIST_SERVICE_TOKEN,
   ICategoryResolutionService,
   IOfferCreationEnqueueService,
   ISellerPoliciesService,
   IResponsibleProducerService,
+  IDeliveryPriceListService,
   OfferCreationRecordRepositoryPort,
   OfferMappingRepositoryPort,
 } from '@openlinker/core/listings';
@@ -76,6 +78,7 @@ import { CreateOfferResponseDto } from './dto/create-offer-response.dto';
 import { OfferCreationStatusResponseDto } from './dto/offer-creation-status-response.dto';
 import { SellerPoliciesResponseDto } from './dto/seller-policies-response.dto';
 import { ResponsibleProducersResponseDto } from './dto/responsible-producers-response.dto';
+import { DeliveryPriceListsResponseDto } from './dto/delivery-price-lists-response.dto';
 import type { CategoryParameterResponseDto } from './dto/category-parameter-response.dto';
 import { CategoryParametersListResponseDto } from './dto/category-parameter-response.dto';
 import { ResolveCategoryRequestDto, ResolveCategoryResponseDto } from './dto/resolve-category.dto';
@@ -107,6 +110,8 @@ export class ListingsController {
     private readonly sellerPolicies: ISellerPoliciesService,
     @Inject(RESPONSIBLE_PRODUCER_SERVICE_TOKEN)
     private readonly responsibleProducers: IResponsibleProducerService,
+    @Inject(DELIVERY_PRICE_LIST_SERVICE_TOKEN)
+    private readonly deliveryPriceLists: IDeliveryPriceListService,
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrationsService: IIntegrationsService,
     @Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)
@@ -434,6 +439,33 @@ export class ListingsController {
     const responsibleProducers =
       await this.responsibleProducers.listResponsibleProducers(connectionId);
     return { responsibleProducers };
+  }
+
+  @Roles('admin', 'operator')
+  @Get('connections/:connectionId/delivery-price-lists')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+  @ApiOperation({
+    summary: 'List seller-configured delivery price lists (#1530)',
+    description:
+      'Returns the delivery price lists ("cennik dostawy") configured for the connection, fetched live from the marketplace. The offer-creation wizard renders these so the operator can attach one and the created offer is buyable.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Delivery price lists wrapped under `deliveryPriceLists`.',
+    type: DeliveryPriceListsResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Connection not found' })
+  @ApiResponse({ status: 409, description: 'Connection disabled' })
+  @ApiResponse({
+    status: 422,
+    description: 'Adapter does not support delivery-price-list listing',
+  })
+  async getDeliveryPriceLists(
+    @Param('connectionId') connectionId: string
+  ): Promise<DeliveryPriceListsResponseDto> {
+    const deliveryPriceLists = await this.deliveryPriceLists.listDeliveryPriceLists(connectionId);
+    return { deliveryPriceLists };
   }
 
   @Roles('admin', 'operator')

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -25,6 +25,7 @@ import type {
   ResolveCategoryResponse,
   SellerPoliciesResponse,
   ResponsibleProducersResponse,
+  DeliveryPriceListsResponse,
   ShopPublishRequest,
   ShopPublishResponse,
   ShopPublishStatusResponse,
@@ -98,6 +99,7 @@ export interface ListingsApi {
   getBulkShopPublishBatch: (batchId: string) => Promise<BulkShopPublishBatchResponse>;
   getSellerPolicies: (connectionId: string) => Promise<SellerPoliciesResponse>;
   getResponsibleProducers: (connectionId: string) => Promise<ResponsibleProducersResponse>;
+  getDeliveryPriceLists: (connectionId: string) => Promise<DeliveryPriceListsResponse>;
   getCategoryParameters: (
     connectionId: string,
     categoryId: string,
@@ -233,6 +235,11 @@ export function createListingsApi(request: ApiRequest): ListingsApi {
     getResponsibleProducers(connectionId): Promise<ResponsibleProducersResponse> {
       return request<ResponsibleProducersResponse>(
         `/listings/connections/${connectionId}/responsible-producers`,
+      );
+    },
+    getDeliveryPriceLists(connectionId): Promise<DeliveryPriceListsResponse> {
+      return request<DeliveryPriceListsResponse>(
+        `/listings/connections/${connectionId}/delivery-price-lists`,
       );
     },
     getCategoryParameters(connectionId, categoryId): Promise<CategoryParametersListResponse> {

--- a/apps/web/src/features/listings/api/listings.query-keys.ts
+++ b/apps/web/src/features/listings/api/listings.query-keys.ts
@@ -15,6 +15,8 @@ export const listingsQueryKeys = {
   sellerPolicies: (connectionId: string) => ['listings', 'sellerPolicies', connectionId] as const,
   responsibleProducers: (connectionId: string) =>
     ['listings', 'responsibleProducers', connectionId] as const,
+  deliveryPriceLists: (connectionId: string) =>
+    ['listings', 'deliveryPriceLists', connectionId] as const,
   // The version constant at index 2 cache-busts every browser's in-flight
   // TanStack Query cache when the response shape changes. See #423 + the
   // CATEGORY_PARAMETERS_SCHEMA_VERSION JSDoc in listings.types.ts.

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -379,6 +379,22 @@ export interface ResponsibleProducersResponse {
   responsibleProducers: ResponsibleProducer[];
 }
 
+/** ----- Delivery price lists (#1530) --------------------------------------
+ *
+ * A seller-configured delivery price list ("cennik dostawy") returned by
+ * `GET /listings/connections/:connectionId/delivery-price-lists`, fetched live
+ * from the marketplace. The offer-creation wizard renders these so the operator
+ * can attach one and the created offer is buyable.
+ */
+export interface DeliveryPriceList {
+  id: string;
+  name: string;
+}
+
+export interface DeliveryPriceListsResponse {
+  deliveryPriceLists: DeliveryPriceList[];
+}
+
 /** ----- Category parameters (#410) ----------------------------------------
  *
  * Marketplace-neutral shape for category parameters returned by

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
@@ -11,7 +11,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { renderWithProviders } from '../../../../test/test-utils';
+import { renderWithProviders, createMockApiClient } from '../../../../test/test-utils';
 import { BulkEditModal } from './bulk-edit-modal';
 import type { BulkWizardRow } from './bulk-wizard.types';
 import type { EanMatchCandidate } from '../../api/listings.types';
@@ -53,6 +53,30 @@ const connection: Connection = {
   createdAt: '2026-01-01T00:00:00.000Z',
   updatedAt: '2026-01-01T00:00:00.000Z',
 };
+
+// Erli connection — advertises DeliveryPriceListReader so the modal renders the
+// per-row delivery-price-list override field (#1530).
+const erliConnection: Connection = {
+  ...connection,
+  id: 'conn_erli',
+  name: 'My Erli',
+  platformType: 'erli',
+  enabledCapabilities: ['OfferManager'],
+  supportedCapabilities: ['OfferManager', 'DeliveryPriceListReader'],
+};
+
+function erliApiClient() {
+  return createMockApiClient({
+    listings: {
+      getDeliveryPriceLists: vi.fn().mockResolvedValue({
+        deliveryPriceLists: [
+          { id: '1', name: '*' },
+          { id: '2', name: 'Kurier' },
+        ],
+      }),
+    },
+  });
+}
 
 function makeRow(opts: {
   name?: string;
@@ -287,5 +311,81 @@ describe('BulkEditModal', () => {
     expect(screen.queryByText('Category parameters')).not.toBeInTheDocument();
     expect(screen.queryByTestId('category-parameters-step')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Allegro category ID')).toBeInTheDocument();
+  });
+
+  // #1530 — per-row delivery-price-list override in the bulk edit modal.
+  describe('delivery price list override (#1530)', () => {
+    it('inherits the batch default and saves no per-row override when left unchanged', async () => {
+      const onSave = vi.fn();
+      renderWithProviders(
+        <BulkEditModal
+          open
+          onOpenChange={() => undefined}
+          row={makeRow()}
+          connection={erliConnection}
+          canBrowseCategories={false}
+          defaults={DEFAULTS}
+          batchDeliveryPriceList="*"
+          onSave={onSave}
+        />,
+        { apiClient: erliApiClient() },
+      );
+
+      // Wait for the live options to load, then assert the field inherits the
+      // batch default value + shows the inherit label.
+      await screen.findByRole('option', { name: 'Kurier' }, { timeout: 4000 });
+      expect(screen.getByLabelText('Delivery price list')).toHaveValue('*');
+      expect(screen.getByText('Batch default')).toBeInTheDocument();
+
+      // Fill the required description so the form passes validation.
+      fireEvent.change(screen.getByLabelText('Description'), {
+        target: { value: 'A fine description' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Save row' }));
+
+      await waitFor(() => { expect(onSave).toHaveBeenCalledTimes(1); });
+      const override = onSave.mock.calls[0][1] as {
+        overrides?: { platformParams?: Record<string, unknown> };
+      };
+      // No per-row override written → the row inherits the batch default at submit.
+      expect(override.overrides?.platformParams?.deliveryPriceList).toBeUndefined();
+    });
+
+    it('writes the per-row override so it wins over the batch default', async () => {
+      const onSave = vi.fn();
+      renderWithProviders(
+        <BulkEditModal
+          open
+          onOpenChange={() => undefined}
+          row={makeRow()}
+          connection={erliConnection}
+          canBrowseCategories={false}
+          defaults={DEFAULTS}
+          batchDeliveryPriceList="*"
+          onSave={onSave}
+        />,
+        { apiClient: erliApiClient() },
+      );
+
+      await screen.findByRole('option', { name: 'Kurier' }, { timeout: 4000 });
+      fireEvent.change(screen.getByLabelText('Delivery price list'), {
+        target: { value: 'Kurier' },
+      });
+
+      // Once changed it reads as overridden with a reset affordance.
+      expect(screen.getByRole('button', { name: 'Reset to batch default' })).toBeInTheDocument();
+
+      // Fill the required description so the form passes validation.
+      fireEvent.change(screen.getByLabelText('Description'), {
+        target: { value: 'A fine description' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Save row' }));
+
+      await waitFor(() => { expect(onSave).toHaveBeenCalledTimes(1); });
+      const override = onSave.mock.calls[0][1] as {
+        overrides?: { platformParams?: Record<string, unknown> };
+      };
+      expect(override.overrides?.platformParams?.deliveryPriceList).toBe('Kurier');
+    });
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -46,6 +46,7 @@ import {
 import { SuggestionDialog } from '../../../content';
 import { CategoryPicker } from '../CategoryPicker';
 import { CategoryParametersStep } from '../category-parameters-step';
+import { ErliDeliveryPriceListOverrideField } from '../erli/erli-delivery-price-list-override-field';
 import { useCategoryParametersQuery } from '../../hooks/use-category-parameters-query';
 import {
   MissingCategoryParameterSectionError,
@@ -89,6 +90,13 @@ interface BulkEditModalProps {
     priceCurrency: string;
   };
   /**
+   * Batch-wide delivery price list picked on the Config step (#1530). Seeds the
+   * per-row delivery-price-list override field so it starts inheriting the batch
+   * default; an empty string means the batch default is "none". Erli-only (the
+   * field renders only when the connection supports `DeliveryPriceListReader`).
+   */
+  batchDeliveryPriceList?: string;
+  /**
    * Save handler — receives the new override block keyed by variant id and
    * the FE-only form-values stash. The wizard stores `editFormValues` on
    * the row so reopening the modal restores entered values; it never gets
@@ -108,6 +116,7 @@ export function BulkEditModal({
   connection,
   canBrowseCategories,
   defaults,
+  batchDeliveryPriceList,
   onSave,
 }: BulkEditModalProps): ReactElement | null {
   if (!row.primaryVariant) return null;
@@ -120,6 +129,7 @@ export function BulkEditModal({
           connection={connection}
           canBrowseCategories={canBrowseCategories}
           defaults={defaults}
+          batchDeliveryPriceList={batchDeliveryPriceList ?? ''}
           onSave={onSave}
           onClose={() => { onOpenChange(false); }}
         />
@@ -133,6 +143,7 @@ interface BulkEditModalFormProps {
   connection: Connection;
   canBrowseCategories: boolean;
   defaults: BulkEditModalProps['defaults'];
+  batchDeliveryPriceList: string;
   onSave: BulkEditModalProps['onSave'];
   onClose: () => void;
 }
@@ -142,6 +153,7 @@ function BulkEditModalForm({
   connection,
   canBrowseCategories,
   defaults,
+  batchDeliveryPriceList,
   onSave,
   onClose,
 }: BulkEditModalFormProps): ReactElement {
@@ -438,6 +450,34 @@ function BulkEditModalForm({
               watchedCategoryId={watchedCategoryId}
               parametersQuery={parametersQuery}
               categoryParameters={categoryParameters}
+            />
+          ) : null}
+
+          {/* Per-row delivery-price-list override (#1530) — Erli-only, gated on
+              the connection's DeliveryPriceListReader capability. Inherits the
+              batch default until the operator overrides it; rides the same
+              `platformParams.deliveryPriceList` escape hatch as the batch default
+              (an absent key means the row inherits at submit). */}
+          {(connection.supportedCapabilities?.includes('DeliveryPriceListReader') ?? false) ? (
+            <ErliDeliveryPriceListOverrideField
+              connectionId={connectionId}
+              value={
+                typeof platformParams.deliveryPriceList === 'string'
+                  ? platformParams.deliveryPriceList
+                  : undefined
+              }
+              batchDefault={batchDeliveryPriceList}
+              onChange={(next) => {
+                setPlatformParams((prev) => {
+                  const copy = { ...prev };
+                  if (next === undefined) {
+                    delete copy.deliveryPriceList;
+                  } else {
+                    copy.deliveryPriceList = next;
+                  }
+                  return copy;
+                });
+              }}
             />
           ) : null}
 

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
@@ -65,6 +65,12 @@ interface BulkReviewStepProps {
    * §3) when false (a `borrows` destination like Erli).
    */
   canBrowseCategories: boolean;
+  /**
+   * Batch-wide delivery price list picked on the Config step (#1530). Threaded
+   * into the edit modal so the per-row delivery-price-list override starts
+   * inheriting the batch default. Empty string = the batch default is "none".
+   */
+  batchDeliveryPriceList?: string;
   onUpdateRow: (
     variantId: string,
     override: BulkPerProductOverride,
@@ -97,6 +103,7 @@ export function BulkReviewStep({
   paramsResolving,
   platformBlockerChips,
   canBrowseCategories,
+  batchDeliveryPriceList,
   onUpdateRow,
   onApproveAll,
   onBack,
@@ -312,6 +319,7 @@ export function BulkReviewStep({
             priceAmount: editingPrice.value !== null ? editingPrice.value.toFixed(2) : '',
             priceCurrency: currency,
           }}
+          batchDeliveryPriceList={batchDeliveryPriceList}
           onSave={onUpdateRow}
         />
       ) : null}

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -384,6 +384,11 @@ export function BulkWizard({
               paramsResolving={paramsResolving}
               platformBlockerChips={platformBlockerChips}
               canBrowseCategories={destinationBrowsesCategories}
+              batchDeliveryPriceList={
+                typeof config.platformParams.deliveryPriceList === 'string'
+                  ? config.platformParams.deliveryPriceList
+                  : ''
+              }
               onUpdateRow={handleUpdateRow}
               onApproveAll={() => { setConfirmOpen(true); }}
               onBack={() => { setStep('config'); }}

--- a/apps/web/src/features/listings/components/erli/create-erli-offer-request-to-form-values.ts
+++ b/apps/web/src/features/listings/components/erli/create-erli-offer-request-to-form-values.ts
@@ -57,6 +57,10 @@ export function createErliOfferRequestToFormValues(
       : typeof producerRaw === 'number'
         ? String(producerRaw)
         : '';
+  // Delivery price list (#1530) rides `overrides.platformParams.deliveryPriceList`.
+  const deliveryPriceListRaw = overrides?.platformParams?.deliveryPriceList;
+  const deliveryPriceList =
+    typeof deliveryPriceListRaw === 'string' ? deliveryPriceListRaw : '';
 
   return {
     internalVariantId: request.internalVariantId,
@@ -69,6 +73,7 @@ export function createErliOfferRequestToFormValues(
     stock: request.stock,
     description: overrides?.description ?? '',
     producer,
+    deliveryPriceList,
     publishImmediately: request.publishImmediately,
     dispatchPeriod: dispatch.period,
     dispatchUnit: dispatch.unit,

--- a/apps/web/src/features/listings/components/erli/erli-bulk-config-section.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-bulk-config-section.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useMemo, type ReactElement } from 'react';
 
 import type { BulkOfferConfigSectionProps } from '../../../../shared/plugins';
+import { ErliDeliveryPriceListField } from './erli-delivery-price-list-field';
 import { ErliDispatchTimeField } from './erli-dispatch-time-field';
 import { ErliProducerField } from './erli-producer-field';
 import {
@@ -39,6 +40,8 @@ export function ErliBulkConfigSection({
   // Batch-default producer (#1531). Applies to every row unless a row overrides
   // it in the per-row edit modal; empty string = no batch default chosen.
   const producer = typeof platformParams.producer === 'string' ? platformParams.producer : '';
+  const deliveryPriceList =
+    typeof platformParams.deliveryPriceList === 'string' ? platformParams.deliveryPriceList : '';
 
   // Seed the form with the connection default + fix currency to PLN. Keyed on
   // the connection so switching marketplaces re-seeds; `form`/`connectionDefault`
@@ -76,6 +79,17 @@ export function ErliBulkConfigSection({
           form.setValue(
             'platformParams',
             { ...form.getValues('platformParams'), producer: next },
+            { shouldDirty: true },
+          );
+        }}
+      />
+      <ErliDeliveryPriceListField
+        connectionId={connection.id}
+        value={deliveryPriceList}
+        onChange={(next) => {
+          form.setValue(
+            'platformParams',
+            { ...form.getValues('platformParams'), deliveryPriceList: next },
             { shouldDirty: true },
           );
         }}

--- a/apps/web/src/features/listings/components/erli/erli-create-offer-wizard.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-create-offer-wizard.tsx
@@ -65,6 +65,7 @@ import {
   type ErliCreateOfferSubmission,
   type ErliCreateOfferValues,
 } from './erli-create-offer.schema';
+import { ErliDeliveryPriceListField } from './erli-delivery-price-list-field';
 import { ErliDispatchTimeField } from './erli-dispatch-time-field';
 import { ErliProducerField } from './erli-producer-field';
 import {
@@ -170,6 +171,7 @@ export function ErliCreateOfferWizard({
       stock: 0,
       description: '',
       producer: '',
+      deliveryPriceList: '',
       publishImmediately: false,
       dispatchPeriod: dispatchDefault.period,
       dispatchUnit: dispatchDefault.unit,
@@ -397,6 +399,9 @@ export function ErliCreateOfferWizard({
         platformParams: {
           dispatchTime: { period: submitted.dispatchPeriod, unit: submitted.dispatchUnit },
           ...(submitted.producer ? { producer: submitted.producer } : {}),
+          ...(submitted.deliveryPriceList
+            ? { deliveryPriceList: submitted.deliveryPriceList }
+            : {}),
         },
       },
     };
@@ -622,6 +627,13 @@ export function ErliCreateOfferWizard({
                 connectionId={connection.id}
                 value={form.watch('producer') ?? ''}
                 onChange={(next) => form.setValue('producer', next, { shouldDirty: true })}
+              />
+              <ErliDeliveryPriceListField
+                connectionId={connection.id}
+                value={form.watch('deliveryPriceList') ?? ''}
+                onChange={(next) =>
+                  form.setValue('deliveryPriceList', next, { shouldDirty: true })
+                }
               />
               <p className="erli-config__note">
                 Erli has no seller/delivery policies — dispatch time stands in for Allegro's policy

--- a/apps/web/src/features/listings/components/erli/erli-create-offer.schema.ts
+++ b/apps/web/src/features/listings/components/erli/erli-create-offer.schema.ts
@@ -42,6 +42,11 @@ export const erliCreateOfferSchema = z
     // adapter on `overrides.platformParams.producer` and clears the created
     // product's missing-producer block.
     producer: z.string().optional(),
+    // Delivery price list ("cennik dostawy") name (#1530). Optional at the form
+    // level so the wizard never deadlocks when the Erli account has none; when
+    // set it rides to the adapter on `overrides.platformParams.deliveryPriceList`
+    // and makes the created offer buyable.
+    deliveryPriceList: z.string().optional(),
     publishImmediately: z.boolean(),
     parameters: z.record(z.string(), z.unknown()).default({}),
   })

--- a/apps/web/src/features/listings/components/erli/erli-delivery-price-list-field.test.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-delivery-price-list-field.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * ErliDeliveryPriceListField tests (#1530)
+ *
+ * Covers the live per-connection fetch, the empty-state direction copy, the
+ * options render, and the `onChange` contract (selecting by price-list name).
+ */
+import { screen, fireEvent, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders, createMockApiClient } from '../../../../test/test-utils';
+import { ErliDeliveryPriceListField } from './erli-delivery-price-list-field';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ErliDeliveryPriceListField', () => {
+  it('renders the fetched delivery price lists as options', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getDeliveryPriceLists: vi.fn().mockResolvedValue({
+          deliveryPriceLists: [
+            { id: '1', name: '*' },
+            { id: '2', name: 'Kurier' },
+          ],
+        }),
+      },
+    });
+
+    renderWithProviders(
+      <ErliDeliveryPriceListField connectionId="conn_erli_1" value="" onChange={vi.fn()} />,
+      { apiClient },
+    );
+
+    expect(await screen.findByRole('option', { name: 'Kurier' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '*' })).toBeInTheDocument();
+  });
+
+  it('shows a directive empty state when the account has no delivery price lists', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getDeliveryPriceLists: vi.fn().mockResolvedValue({ deliveryPriceLists: [] }),
+      },
+    });
+
+    renderWithProviders(
+      <ErliDeliveryPriceListField connectionId="conn_erli_1" value="" onChange={vi.fn()} />,
+      { apiClient },
+    );
+
+    expect(await screen.findByText(/No delivery price lists found on this Erli account/i)).toBeInTheDocument();
+  });
+
+  it('calls onChange with the selected price-list name', async () => {
+    const onChange = vi.fn();
+    const apiClient = createMockApiClient({
+      listings: {
+        getDeliveryPriceLists: vi.fn().mockResolvedValue({
+          deliveryPriceLists: [{ id: '2', name: 'Kurier' }],
+        }),
+      },
+    });
+
+    renderWithProviders(
+      <ErliDeliveryPriceListField connectionId="conn_erli_1" value="" onChange={onChange} />,
+      { apiClient },
+    );
+
+    const select = await screen.findByRole('combobox');
+    fireEvent.change(select, { target: { value: 'Kurier' } });
+
+    expect(onChange).toHaveBeenCalledWith('Kurier');
+  });
+});

--- a/apps/web/src/features/listings/components/erli/erli-delivery-price-list-field.test.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-delivery-price-list-field.test.tsx
@@ -51,6 +51,40 @@ describe('ErliDeliveryPriceListField', () => {
     expect(await screen.findByText(/No delivery price lists found on this Erli account/i)).toBeInTheDocument();
   });
 
+  it('refetches when Refresh is clicked in the empty state', async () => {
+    const getDeliveryPriceLists = vi.fn().mockResolvedValue({ deliveryPriceLists: [] });
+    const apiClient = createMockApiClient({ listings: { getDeliveryPriceLists } });
+
+    renderWithProviders(
+      <ErliDeliveryPriceListField connectionId="conn_erli_1" value="" onChange={vi.fn()} />,
+      { apiClient },
+    );
+
+    await screen.findByText(/No delivery price lists found on this Erli account/i);
+    expect(getDeliveryPriceLists).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await vi.waitFor(() => expect(getDeliveryPriceLists).toHaveBeenCalledTimes(2));
+  });
+
+  it('retries when Retry is clicked in the error state', async () => {
+    const getDeliveryPriceLists = vi.fn().mockRejectedValue(new Error('Network error'));
+    const apiClient = createMockApiClient({ listings: { getDeliveryPriceLists } });
+
+    renderWithProviders(
+      <ErliDeliveryPriceListField connectionId="conn_erli_1" value="" onChange={vi.fn()} />,
+      { apiClient },
+    );
+
+    await screen.findByText('Unable to load delivery price lists');
+    expect(getDeliveryPriceLists).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await vi.waitFor(() => expect(getDeliveryPriceLists).toHaveBeenCalledTimes(2));
+  });
+
   it('calls onChange with the selected price-list name', async () => {
     const onChange = vi.fn();
     const apiClient = createMockApiClient({

--- a/apps/web/src/features/listings/components/erli/erli-delivery-price-list-field.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-delivery-price-list-field.tsx
@@ -1,0 +1,83 @@
+/**
+ * ErliDeliveryPriceListField (#1530)
+ *
+ * Shared, content-only picker for Erli's delivery price list ("cennik
+ * dostawy") — the selection that makes a created offer buyable (without it Erli
+ * reports "brak metody dostawy"). Consumed by BOTH `ErliCreateOfferWizard`
+ * (single) and `ErliBulkConfigSection` (bulk) so the field never drifts.
+ *
+ * Options are fetched live from Erli per-connection via
+ * `useDeliveryPriceListsQuery`. Controlled via `value` + `onChange` (the price
+ * list name) so each host wires it into its own form state. Loading / error /
+ * empty states mirror the Allegro seller-policy picker.
+ *
+ * @module features/listings/components/erli
+ */
+import type { ReactElement } from 'react';
+
+import { Alert } from '../../../../shared/ui/alert';
+import { FormField } from '../../../../shared/ui/form-field';
+import { Input } from '../../../../shared/ui/input';
+import { Select } from '../../../../shared/ui/select';
+import { useDeliveryPriceListsQuery } from '../../hooks/use-delivery-price-lists-query';
+
+interface ErliDeliveryPriceListFieldProps {
+  connectionId: string;
+  /** Selected delivery price list name (empty string = none chosen). */
+  value: string;
+  onChange: (name: string) => void;
+}
+
+export function ErliDeliveryPriceListField({
+  connectionId,
+  value,
+  onChange,
+}: ErliDeliveryPriceListFieldProps): ReactElement {
+  const query = useDeliveryPriceListsQuery(connectionId);
+  const priceLists = query.data?.deliveryPriceLists ?? [];
+
+  // Matches FormField's `ControlProps` so the single child typechecks in every
+  // branch (Input / Alert / Select all satisfy these optional props).
+  let control: ReactElement<{
+    id?: string;
+    className?: string;
+    'aria-invalid'?: boolean;
+    'aria-describedby'?: string;
+  }>;
+  if (query.isLoading) {
+    control = <Input disabled value="Loading delivery price lists…" readOnly />;
+  } else if (query.error) {
+    control = (
+      <Alert tone="error" title="Unable to load delivery price lists">
+        {query.error instanceof Error ? query.error.message : 'Please try again.'}
+      </Alert>
+    );
+  } else if (priceLists.length === 0) {
+    control = (
+      <Alert tone="info" title="No delivery price lists found">
+        No delivery price lists found on this Erli account - add one in Erli, then reload.
+      </Alert>
+    );
+  } else {
+    control = (
+      <Select value={value} onChange={(e) => onChange(e.target.value)}>
+        <option value="">Choose a delivery price list…</option>
+        {priceLists.map((list) => (
+          <option key={list.id} value={list.name}>
+            {list.name}
+          </option>
+        ))}
+      </Select>
+    );
+  }
+
+  return (
+    <FormField
+      label="Delivery price list"
+      name="deliveryPriceList"
+      description="Fetched from Erli. Required for buyers to purchase."
+    >
+      {control}
+    </FormField>
+  );
+}

--- a/apps/web/src/features/listings/components/erli/erli-delivery-price-list-field.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-delivery-price-list-field.tsx
@@ -16,6 +16,7 @@
 import type { ReactElement } from 'react';
 
 import { Alert } from '../../../../shared/ui/alert';
+import { Button } from '../../../../shared/ui/button';
 import { FormField } from '../../../../shared/ui/form-field';
 import { Input } from '../../../../shared/ui/input';
 import { Select } from '../../../../shared/ui/select';
@@ -48,14 +49,40 @@ export function ErliDeliveryPriceListField({
     control = <Input disabled value="Loading delivery price lists…" readOnly />;
   } else if (query.error) {
     control = (
-      <Alert tone="error" title="Unable to load delivery price lists">
+      <Alert
+        tone="error"
+        title="Unable to load delivery price lists"
+        action={
+          <Button
+            type="button"
+            tone="ghost"
+            className="button--sm"
+            onClick={() => void query.refetch()}
+          >
+            Retry
+          </Button>
+        }
+      >
         {query.error instanceof Error ? query.error.message : 'Please try again.'}
       </Alert>
     );
   } else if (priceLists.length === 0) {
     control = (
-      <Alert tone="info" title="No delivery price lists found">
-        No delivery price lists found on this Erli account - add one in Erli, then reload.
+      <Alert
+        tone="info"
+        title="No delivery price lists found"
+        action={
+          <Button
+            type="button"
+            tone="ghost"
+            className="button--sm"
+            onClick={() => void query.refetch()}
+          >
+            Refresh
+          </Button>
+        }
+      >
+        No delivery price lists found on this Erli account - add one in Erli, then refresh.
       </Alert>
     );
   } else {

--- a/apps/web/src/features/listings/components/erli/erli-delivery-price-list-override-field.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-delivery-price-list-override-field.tsx
@@ -57,14 +57,40 @@ export function ErliDeliveryPriceListOverrideField({
     control = <Input disabled value="Loading delivery price lists…" readOnly />;
   } else if (query.error) {
     control = (
-      <Alert tone="error" title="Unable to load delivery price lists">
+      <Alert
+        tone="error"
+        title="Unable to load delivery price lists"
+        action={
+          <Button
+            type="button"
+            tone="ghost"
+            className="button--sm"
+            onClick={() => void query.refetch()}
+          >
+            Retry
+          </Button>
+        }
+      >
         {query.error instanceof Error ? query.error.message : 'Please try again.'}
       </Alert>
     );
   } else if (priceLists.length === 0) {
     control = (
-      <Alert tone="info" title="No delivery price lists found">
-        No delivery price lists found on this Erli account - add one in Erli, then reload.
+      <Alert
+        tone="info"
+        title="No delivery price lists found"
+        action={
+          <Button
+            type="button"
+            tone="ghost"
+            className="button--sm"
+            onClick={() => void query.refetch()}
+          >
+            Refresh
+          </Button>
+        }
+      >
+        No delivery price lists found on this Erli account - add one in Erli, then refresh.
       </Alert>
     );
   } else {
@@ -100,23 +126,16 @@ export function ErliDeliveryPriceListOverrideField({
       >
         {control}
       </FormField>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--space-2)',
-          marginTop: 'var(--space-1)',
-        }}
-      >
+      <div className="bulk-edit__delivery-price-list-status">
         {isOverridden ? (
           <>
-            <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>Overridden</span>
+            <span className="bulk-edit__delivery-price-list-status-label">Overridden</span>
             <Button tone="ghost" type="button" onClick={() => onChange(undefined)}>
               Reset to batch default
             </Button>
           </>
         ) : (
-          <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>Batch default</span>
+          <span className="bulk-edit__delivery-price-list-status-label">Batch default</span>
         )}
       </div>
     </div>

--- a/apps/web/src/features/listings/components/erli/erli-delivery-price-list-override-field.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-delivery-price-list-override-field.tsx
@@ -1,0 +1,124 @@
+/**
+ * ErliDeliveryPriceListOverrideField (#1530)
+ *
+ * Per-row delivery-price-list override for the bulk Review edit modal. The field
+ * starts pre-filled with the batch default (the value the operator picked on the
+ * Config step) and reads as inherited ("Batch default"); once changed it reads as
+ * overridden and offers a "Reset to batch default" affordance. Selecting the batch
+ * default value again clears the override so the row inherits again.
+ *
+ * Controlled: `value` is the per-row override (`undefined` = inheriting), the host
+ * (edit modal) persists `onChange` output into the row's
+ * `platformParams.deliveryPriceList`. Options are fetched live per-connection via
+ * `useDeliveryPriceListsQuery`, matching the batch/single wizard picker.
+ *
+ * @module features/listings/components/erli
+ */
+import type { ReactElement } from 'react';
+
+import { Alert } from '../../../../shared/ui/alert';
+import { Button } from '../../../../shared/ui/button';
+import { FormField } from '../../../../shared/ui/form-field';
+import { Input } from '../../../../shared/ui/input';
+import { Select } from '../../../../shared/ui/select';
+import { useDeliveryPriceListsQuery } from '../../hooks/use-delivery-price-lists-query';
+
+interface ErliDeliveryPriceListOverrideFieldProps {
+  connectionId: string;
+  /** Per-row override value; `undefined` means the row inherits the batch default. */
+  value: string | undefined;
+  /** Batch-wide default from the Config step (may be empty = none). */
+  batchDefault: string;
+  onChange: (next: string | undefined) => void;
+}
+
+export function ErliDeliveryPriceListOverrideField({
+  connectionId,
+  value,
+  batchDefault,
+  onChange,
+}: ErliDeliveryPriceListOverrideFieldProps): ReactElement {
+  const query = useDeliveryPriceListsQuery(connectionId);
+  const priceLists = query.data?.deliveryPriceLists ?? [];
+
+  const isOverridden = value !== undefined;
+  const effective = value ?? batchDefault;
+  const batchDefaultLabel = batchDefault ? `"${batchDefault}"` : 'none';
+
+  // Matches FormField's `ControlProps` so the single child typechecks in every
+  // branch (Input / Alert / Select all satisfy these optional props).
+  let control: ReactElement<{
+    id?: string;
+    className?: string;
+    'aria-invalid'?: boolean;
+    'aria-describedby'?: string;
+  }>;
+  if (query.isLoading) {
+    control = <Input disabled value="Loading delivery price lists…" readOnly />;
+  } else if (query.error) {
+    control = (
+      <Alert tone="error" title="Unable to load delivery price lists">
+        {query.error instanceof Error ? query.error.message : 'Please try again.'}
+      </Alert>
+    );
+  } else if (priceLists.length === 0) {
+    control = (
+      <Alert tone="info" title="No delivery price lists found">
+        No delivery price lists found on this Erli account - add one in Erli, then reload.
+      </Alert>
+    );
+  } else {
+    control = (
+      <Select
+        value={effective}
+        onChange={(e) => {
+          const chosen = e.target.value;
+          // Choosing the batch default clears the override so the row inherits.
+          onChange(chosen === batchDefault ? undefined : chosen);
+        }}
+      >
+        <option value="">Choose a delivery price list…</option>
+        {priceLists.map((list) => (
+          <option key={list.id} value={list.name}>
+            {list.name}
+          </option>
+        ))}
+      </Select>
+    );
+  }
+
+  return (
+    <div className="bulk-edit__delivery-price-list">
+      <FormField
+        label="Delivery price list"
+        name="bulk-edit-delivery-price-list"
+        description={
+          isOverridden
+            ? `Overriding the batch default (${batchDefaultLabel}) for this product.`
+            : `Batch default (${batchDefaultLabel}). Change to override this product only.`
+        }
+      >
+        {control}
+      </FormField>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-2)',
+          marginTop: 'var(--space-1)',
+        }}
+      >
+        {isOverridden ? (
+          <>
+            <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>Overridden</span>
+            <Button tone="ghost" type="button" onClick={() => onChange(undefined)}>
+              Reset to batch default
+            </Button>
+          </>
+        ) : (
+          <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>Batch default</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/listings/hooks/use-delivery-price-lists-query.ts
+++ b/apps/web/src/features/listings/hooks/use-delivery-price-lists-query.ts
@@ -1,0 +1,30 @@
+/**
+ * use-delivery-price-lists-query (#1530)
+ *
+ * Fetches the delivery price lists ("cennik dostawy") configured on a
+ * marketplace connection, fetched live from the marketplace. Backs the
+ * delivery-price-list picker in the offer-creation wizard (single + bulk).
+ * Server caches per connection for ~10 minutes; a 5-minute client-side
+ * staleTime keeps repeated wizard opens within a session from re-fetching.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { DeliveryPriceListsResponse } from '../api/listings.types';
+
+export const DELIVERY_PRICE_LISTS_STALE_TIME_MS = 5 * 60 * 1000;
+
+export function useDeliveryPriceListsQuery(
+  connectionId: string,
+): UseQueryResult<DeliveryPriceListsResponse> {
+  const apiClient = useApiClient();
+
+  return useQuery<DeliveryPriceListsResponse>({
+    queryKey: listingsQueryKeys.deliveryPriceLists(connectionId),
+    queryFn: () => apiClient.listings.getDeliveryPriceLists(connectionId),
+    enabled: Boolean(connectionId),
+    staleTime: DELIVERY_PRICE_LISTS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8402,6 +8402,19 @@ html[data-density='compact'] .status-badge {
   text-decoration: underline;
 }
 
+/* ── Bulk edit modal — delivery-price-list override status row (#1530) ── */
+.bulk-edit__delivery-price-list-status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.bulk-edit__delivery-price-list-status-label {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 /* ── Bulk wizard master-pull policies + candidate chips (#792) ──────── */
 .bulk-config__policy {
   display: flex;

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -324,6 +324,10 @@ export function createMockApiClient(
       // #1531 — default to "no producers" so the Erli wizard's producer picker
       // renders its empty state in tests that don't override.
       getResponsibleProducers: vi.fn().mockResolvedValue({ responsibleProducers: [] }),
+      // #1530 — default to "no delivery price lists" so the Erli wizard's
+      // delivery-price-list picker renders its empty state in tests that
+      // don't override.
+      getDeliveryPriceLists: vi.fn().mockResolvedValue({ deliveryPriceLists: [] }),
       // #410 — default to "no parameters" so the wizard's category step
       // renders the friendly empty state in tests that don't override.
       getCategoryParameters: vi.fn().mockResolvedValue({ parameters: [] }),

--- a/libs/core/src/listings/application/interfaces/delivery-price-list.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/delivery-price-list.service.interface.ts
@@ -1,0 +1,33 @@
+/**
+ * Delivery Price List Service Interface (#1530)
+ *
+ * Contract for the core read service that returns a connection's seller-configured
+ * delivery price lists ("cennik dostawy"). Implemented by
+ * `DeliveryPriceListService`; consumed by the HTTP layer so the FE offer-creation
+ * wizard (single + bulk) can populate the delivery-price-list picker without
+ * re-hitting the marketplace API on every render.
+ *
+ * @module libs/core/src/listings/application/interfaces
+ */
+
+import type { DeliveryPriceList } from '@openlinker/core/listings';
+
+export interface IDeliveryPriceListService {
+  /**
+   * Return the delivery price lists for a connection.
+   *
+   * Resolves the connection's `OfferManager` adapter, narrows it to the
+   * `DeliveryPriceListReader` capability, and returns the live options. The
+   * adapter memoises the upstream response per connection so repeated wizard
+   * loads do not hammer the marketplace API.
+   *
+   * Throws:
+   * - `ConnectionNotFoundException` (→ HTTP 404) when the connection does not exist.
+   * - `ConnectionDisabledException` (→ HTTP 409) when the connection is disabled.
+   * - `CapabilityNotSupportedException` (→ HTTP 422) when the connection's
+   *   adapter does not implement `OfferManager` at all.
+   * - `UnprocessableEntityException` (→ HTTP 422) when the adapter supports
+   *   `OfferManager` but does not implement `listDeliveryPriceLists`.
+   */
+  listDeliveryPriceLists(connectionId: string): Promise<DeliveryPriceList[]>;
+}

--- a/libs/core/src/listings/application/services/__tests__/delivery-price-list.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/delivery-price-list.service.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Delivery Price List Service Tests (#1530)
+ *
+ * Unit tests for adapter resolution, capability gating (`DeliveryPriceListReader`),
+ * and error propagation.
+ *
+ * @module libs/core/src/listings/application/services/__tests__
+ */
+
+import { UnprocessableEntityException } from '@nestjs/common';
+
+import type { DeliveryPriceList, OfferManagerPort } from '@openlinker/core/listings';
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+
+import { DeliveryPriceListService } from '../delivery-price-list.service';
+
+describe('DeliveryPriceListService', () => {
+  let service: DeliveryPriceListService;
+  let integrations: jest.Mocked<IIntegrationsService>;
+
+  const connectionId = 'conn-abc';
+  const priceLists: DeliveryPriceList[] = [
+    { id: '1', name: '*' },
+    { id: '2', name: 'Kurier' },
+  ];
+
+  const adapterWith = (listDeliveryPriceLists: jest.Mock | undefined): OfferManagerPort =>
+    ({
+      ...(listDeliveryPriceLists ? { listDeliveryPriceLists } : {}),
+    } as unknown as OfferManagerPort);
+
+  beforeEach(() => {
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+      resolveAdapterMetadata: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    service = new DeliveryPriceListService(integrations);
+  });
+
+  it('returns the delivery price lists from the connection adapter', async () => {
+    const listDeliveryPriceLists = jest.fn().mockResolvedValue(priceLists);
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(listDeliveryPriceLists));
+
+    const result = await service.listDeliveryPriceLists(connectionId);
+
+    expect(result).toBe(priceLists);
+    expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(connectionId, 'OfferManager');
+    expect(listDeliveryPriceLists).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws UnprocessableEntityException when the adapter does not implement listDeliveryPriceLists', async () => {
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(undefined));
+
+    await expect(service.listDeliveryPriceLists(connectionId)).rejects.toThrow(
+      UnprocessableEntityException,
+    );
+  });
+
+  it('propagates exceptions from getCapabilityAdapter (connection not found / disabled)', async () => {
+    integrations.getCapabilityAdapter.mockRejectedValue(new Error('ConnectionNotFoundException'));
+
+    await expect(service.listDeliveryPriceLists(connectionId)).rejects.toThrow(
+      'ConnectionNotFoundException',
+    );
+  });
+});

--- a/libs/core/src/listings/application/services/delivery-price-list.service.ts
+++ b/libs/core/src/listings/application/services/delivery-price-list.service.ts
@@ -1,0 +1,47 @@
+/**
+ * Delivery Price List Service (#1530)
+ *
+ * Read service that returns a connection's seller-configured delivery price
+ * lists ("cennik dostawy") for the offer-creation wizard. Resolves the
+ * connection's `OfferManager` adapter and narrows it to the
+ * `DeliveryPriceListReader` sub-capability; caching of the upstream response
+ * lives in the adapter (per connection), mirroring the category-parameters
+ * read path.
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {IDeliveryPriceListService}
+ * @see {@link IDeliveryPriceListService} for the service contract
+ */
+
+import { Inject, Injectable, UnprocessableEntityException } from '@nestjs/common';
+
+import { isDeliveryPriceListReader } from '@openlinker/core/listings';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import type { DeliveryPriceList, OfferManagerPort } from '@openlinker/core/listings';
+
+import type { IDeliveryPriceListService } from '../interfaces/delivery-price-list.service.interface';
+
+@Injectable()
+export class DeliveryPriceListService implements IDeliveryPriceListService {
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService
+  ) {}
+
+  async listDeliveryPriceLists(connectionId: string): Promise<DeliveryPriceList[]> {
+    // Throws ConnectionNotFoundException (404) / ConnectionDisabledException (409) /
+    // CapabilityNotSupportedException (422) for upstream connection-level issues.
+    const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+      connectionId,
+      'OfferManager'
+    );
+
+    if (!isDeliveryPriceListReader(adapter)) {
+      throw new UnprocessableEntityException(
+        `Adapter for connection ${connectionId} does not support delivery-price-list listing`
+      );
+    }
+
+    return adapter.listDeliveryPriceLists();
+  }
+}

--- a/libs/core/src/listings/domain/ports/capabilities/delivery-price-list-reader.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/delivery-price-list-reader.capability.ts
@@ -1,0 +1,29 @@
+/**
+ * Delivery Price List Reader Capability (#1530)
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that can surface the
+ * seller-configured delivery price lists ("cennik dostawy") required to make an
+ * offer buyable declare `implements DeliveryPriceListReader`. The FE
+ * offer-creation wizard renders these so the operator can attach one via
+ * `CreateOfferCommand.overrides.platformParams`; without a delivery price list
+ * the created offer lands not-buyable ("brak metody dostawy").
+ *
+ * See `seller-policies-reader.capability.ts` for the sibling read-capability
+ * pattern and `offer-lister.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { DeliveryPriceList } from '../../types/delivery-price-list.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface DeliveryPriceListReader {
+  listDeliveryPriceLists(): Promise<DeliveryPriceList[]>;
+}
+
+export function isDeliveryPriceListReader(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & DeliveryPriceListReader {
+  return (
+    typeof (adapter as Partial<DeliveryPriceListReader>).listDeliveryPriceLists === 'function'
+  );
+}

--- a/libs/core/src/listings/domain/types/delivery-price-list.types.ts
+++ b/libs/core/src/listings/domain/types/delivery-price-list.types.ts
@@ -1,0 +1,21 @@
+/**
+ * Delivery Price List Types (#1530)
+ *
+ * Marketplace-neutral shape for a seller-configured delivery price list ("cennik
+ * dostawy") the operator attaches to an offer so buyers can purchase it. Read
+ * live per-connection from the marketplace via the `DeliveryPriceListReader`
+ * capability and rendered in the offer-creation wizard.
+ *
+ * Neutral by construction: `id` is a stable opaque identifier and `name` is the
+ * human label. A destination adapter owns any neutral -> wire mapping (Erli, for
+ * example, references a price list by its unique `name` on product create).
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+export interface DeliveryPriceList {
+  /** Stable opaque identifier of the price list (platform-native id, stringified). */
+  id: string;
+  /** Human-readable, unique price-list name shown in the wizard picker. */
+  name: string;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -133,6 +133,7 @@ export type { OfferBuilderValidationIssue } from './domain/exceptions/offer-buil
 export { MasterCatalogConnectionNotConfiguredException } from './domain/exceptions/master-catalog-connection-not-configured.exception';
 export type { ISellerPoliciesService } from './application/interfaces/seller-policies.service.interface';
 export type { IResponsibleProducerService } from './application/interfaces/responsible-producer.service.interface';
+export type { IDeliveryPriceListService } from './application/interfaces/delivery-price-list.service.interface';
 export type {
   SellerPoliciesCacheRepositoryPort,
   CachedSellerPolicies,
@@ -173,6 +174,7 @@ export type {
 } from './domain/types/offer-create.types';
 export type { OfferParameter } from './domain/types/offer-parameter.types';
 export type { SellerPolicy, SellerPolicies } from './domain/types/seller-policies.types';
+export type { DeliveryPriceList } from './domain/types/delivery-price-list.types';
 export { OfferCreateRejectedException } from './domain/exceptions/offer-create-rejected.exception';
 
 // OfferManagerPort sub-capabilities (#337): optional capabilities extracted into
@@ -275,6 +277,8 @@ export type {
 } from './domain/types/marketplace-offer.types';
 export type { SellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';
 export { isSellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';
+export type { DeliveryPriceListReader } from './domain/ports/capabilities/delivery-price-list-reader.capability';
+export { isDeliveryPriceListReader } from './domain/ports/capabilities/delivery-price-list-reader.capability';
 export type {
   SafetyAttachmentUploader,
   SafetyAttachmentUploadInput,

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -41,6 +41,7 @@ import { SellerPoliciesCacheOrmEntity } from './infrastructure/persistence/entit
 import { SellerPoliciesCacheRepository } from './infrastructure/persistence/repositories/seller-policies-cache.repository';
 import { SellerPoliciesService } from './application/services/seller-policies.service';
 import { ResponsibleProducerService } from './application/services/responsible-producer.service';
+import { DeliveryPriceListService } from './application/services/delivery-price-list.service';
 import { OfferCreationEnqueueService } from './application/services/offer-creation-enqueue.service';
 import { BulkListingSubmitService } from './application/services/bulk-listing-submit.service';
 import { BulkListingRetryService } from './application/services/bulk-listing-retry.service';
@@ -71,6 +72,7 @@ import {
   SELLER_POLICIES_SERVICE_TOKEN,
   SELLER_POLICIES_CACHE_TOKEN,
   RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
+  DELIVERY_PRICE_LIST_SERVICE_TOKEN,
   OFFER_STOCK_RESTORE_SERVICE_TOKEN,
   LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
   PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,
@@ -103,6 +105,7 @@ export {
   SELLER_POLICIES_SERVICE_TOKEN,
   SELLER_POLICIES_CACHE_TOKEN,
   RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
+  DELIVERY_PRICE_LIST_SERVICE_TOKEN,
   OFFER_STOCK_RESTORE_SERVICE_TOKEN,
   LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
   PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,
@@ -166,6 +169,7 @@ export {
     SellerPoliciesCacheRepository,
     SellerPoliciesService,
     ResponsibleProducerService,
+    DeliveryPriceListService,
     OfferStockRestoreService,
     {
       provide: OFFER_LINKING_SERVICE_TOKEN,
@@ -276,6 +280,10 @@ export {
       useExisting: ResponsibleProducerService,
     },
     {
+      provide: DELIVERY_PRICE_LIST_SERVICE_TOKEN,
+      useExisting: DeliveryPriceListService,
+    },
+    {
       provide: OFFER_STOCK_RESTORE_SERVICE_TOKEN,
       useExisting: OfferStockRestoreService,
     },
@@ -300,6 +308,7 @@ export {
     SELLER_POLICIES_SERVICE_TOKEN,
     SELLER_POLICIES_CACHE_TOKEN,
     RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
+    DELIVERY_PRICE_LIST_SERVICE_TOKEN,
     OFFER_STOCK_RESTORE_SERVICE_TOKEN,
     LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
     PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -26,6 +26,8 @@ export const SELLER_POLICIES_SERVICE_TOKEN = Symbol('ISellerPoliciesService');
 export const SELLER_POLICIES_CACHE_TOKEN = Symbol('SellerPoliciesCacheRepositoryPort');
 // Responsible-producer read (#1531)
 export const RESPONSIBLE_PRODUCER_SERVICE_TOKEN = Symbol('IResponsibleProducerService');
+// Delivery price list read (#1530)
+export const DELIVERY_PRICE_LIST_SERVICE_TOKEN = Symbol('IDeliveryPriceListService');
 // Order-cancellation stock-restore (#1146)
 export const OFFER_STOCK_RESTORE_SERVICE_TOKEN = Symbol('IOfferStockRestoreService');
 // Shop publish (#1042, ADR-024)

--- a/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
+++ b/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
@@ -119,6 +119,10 @@ describe('erliAdapterManifest', () => {
     expect(erliAdapterManifest.supportedCapabilities).toContain('ResponsibleProducerReader');
   });
 
+  it('should advertise the DeliveryPriceListReader sub-capability so the FE gates the delivery-price-list picker (#1530)', () => {
+    expect(erliAdapterManifest.supportedCapabilities).toContain('DeliveryPriceListReader');
+  });
+
   it('should be the platform-default adapter', () => {
     expect(erliAdapterManifest.isDefault).toBe(true);
   });

--- a/libs/integrations/erli/src/erli-plugin.ts
+++ b/libs/integrations/erli/src/erli-plugin.ts
@@ -60,15 +60,17 @@ export const erliAdapterManifest: AdapterMetadata = {
   // already implements — advertised (no dispatch entry; callers narrow with
   // `isOfferCreator`) so FE offer-creation flows, gated on `OfferCreator`,
   // keep showing Erli after WooCommerce's quantity-only OfferManager landed.
-  // 'ResponsibleProducerReader' (#1531) is likewise an advertised-without-dispatch
-  // OfferManager sub-capability — the FE gates the producer picker on it; callers
-  // narrow the dispatched OfferManager adapter with `isResponsibleProducerReader`,
-  // never `getCapabilityAdapter('ResponsibleProducerReader')`.
+  // 'ResponsibleProducerReader' (#1531) and 'DeliveryPriceListReader' (#1530) are
+  // likewise advertised-without-dispatch OfferManager sub-capabilities — the FE
+  // gates the producer / delivery-price-list pickers on them; callers narrow the
+  // dispatched OfferManager adapter with `isResponsibleProducerReader` /
+  // `isDeliveryPriceListReader`, never `getCapabilityAdapter('...')`.
   supportedCapabilities: [
     'OfferManager',
     'OrderSource',
     'OfferCreator',
     'ResponsibleProducerReader',
+    'DeliveryPriceListReader',
   ],
   displayName: 'Erli Shop API v1',
   version: '1.0.0',

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -1288,6 +1288,77 @@ describe('ErliOfferManagerAdapter', () => {
     });
   });
 
+  describe('listDeliveryPriceLists (#1530 — DeliveryPriceListReader)', () => {
+    it('maps GET /delivery/priceLists items ({id,name}) to neutral DeliveryPriceList[]', async () => {
+      httpClient.get.mockResolvedValue({
+        status: 200,
+        data: [
+          { id: 1, name: '*' },
+          { id: 42, name: 'Kurier' },
+        ],
+      });
+
+      const result = await adapter.listDeliveryPriceLists();
+
+      expect(httpClient.get).toHaveBeenCalledWith('delivery/priceLists');
+      expect(result).toEqual([
+        { id: '1', name: '*' },
+        { id: '42', name: 'Kurier' },
+      ]);
+    });
+
+    it('drops items without a usable name and tolerates an empty/bodyless response', async () => {
+      httpClient.get.mockResolvedValue({ status: 200, data: undefined });
+
+      await expect(adapter.listDeliveryPriceLists()).resolves.toEqual([]);
+    });
+
+    it('caches the mapped result per connection when a cache is wired', async () => {
+      const cache: jest.Mocked<CachePort> = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+      };
+      const cached = new ErliOfferManagerAdapter(
+        'conn-1',
+        ERLI_ADAPTER_KEY,
+        httpClient,
+        { period: 2, unit: 'day' },
+        cache,
+      );
+      httpClient.get.mockResolvedValue({ status: 200, data: [{ id: 7, name: 'Standard' }] });
+
+      const result = await cached.listDeliveryPriceLists();
+
+      expect(result).toEqual([{ id: '7', name: 'Standard' }]);
+      expect(cache.set).toHaveBeenCalledWith(
+        'erli:delivery-price-lists:conn-1',
+        [{ id: '7', name: 'Standard' }],
+        expect.any(Number),
+      );
+    });
+
+    it('returns the cached value without hitting the API on a cache hit', async () => {
+      const cache: jest.Mocked<CachePort> = {
+        get: jest.fn().mockResolvedValue([{ id: '9', name: 'Cached' }]),
+        set: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+      };
+      const cached = new ErliOfferManagerAdapter(
+        'conn-1',
+        ERLI_ADAPTER_KEY,
+        httpClient,
+        { period: 2, unit: 'day' },
+        cache,
+      );
+
+      const result = await cached.listDeliveryPriceLists();
+
+      expect(result).toEqual([{ id: '9', name: 'Cached' }]);
+      expect(httpClient.get).not.toHaveBeenCalled();
+    });
+  });
+
   describe('create body — responsible producer (#1531)', () => {
     it('stamps the operator-selected producer id onto the create body', async () => {
       await adapter.createOffer(createCmd({ overrides: { platformParams: { producer: '42' } } }));
@@ -1317,6 +1388,33 @@ describe('ErliOfferManagerAdapter', () => {
 
       const body = httpClient.post.mock.calls[0][1] as { producerId?: number };
       expect(body.producerId).toBeUndefined();
+    });
+  });
+
+  describe('create body — delivery price list (#1530)', () => {
+    it('stamps the operator-selected deliveryPriceList onto the create body', async () => {
+      await adapter.createOffer(
+        createCmd({ overrides: { platformParams: { deliveryPriceList: 'Kurier' } } }),
+      );
+
+      const body = httpClient.post.mock.calls[0][1] as { deliveryPriceList?: string };
+      expect(body.deliveryPriceList).toBe('Kurier');
+    });
+
+    it('omits deliveryPriceList when no selection is supplied', async () => {
+      await adapter.createOffer(createCmd());
+
+      const body = httpClient.post.mock.calls[0][1] as { deliveryPriceList?: string };
+      expect(body.deliveryPriceList).toBeUndefined();
+    });
+
+    it('ignores a blank deliveryPriceList selection', async () => {
+      await adapter.createOffer(
+        createCmd({ overrides: { platformParams: { deliveryPriceList: '   ' } } }),
+      );
+
+      const body = httpClient.post.mock.calls[0][1] as { deliveryPriceList?: string };
+      expect(body.deliveryPriceList).toBeUndefined();
     });
   });
 });

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -106,6 +106,8 @@ import {
   type CreateOfferCommand,
   type CreateOfferResult,
   type CreateOfferValidationError,
+  type DeliveryPriceList,
+  type DeliveryPriceListReader,
   type OfferCategory,
   type OfferCondition,
   type OfferCreator,
@@ -133,6 +135,7 @@ import type { ErliDispatchTime } from '../../domain/types/erli-connection.types'
 import type { AllegroCategoryCatalogClient } from '../http/allegro-category-catalog-client';
 import type { IErliHttpClient } from '../http/erli-http-client.interface';
 import type {
+  ErliDeliveryPriceListItem,
   ErliExternalAttribute,
   ErliExternalCategory,
   ErliProductCreateBody,
@@ -203,6 +206,14 @@ export const ERLI_FROZEN_STOCK_CACHE_TTL_SEC = 26 * 60 * 60;
  */
 export const ERLI_RESPONSIBLE_PRODUCERS_CACHE_TTL_SEC = 10 * 60;
 
+/**
+ * Delivery-price-list cache TTL (#1530). The wizard reads this on each offer-create
+ * load; a short TTL keeps repeated loads off the Erli API without letting a
+ * newly-added price list stay hidden for long. Mirrors the ~10-min freshness the
+ * seller-policies read uses.
+ */
+export const ERLI_DELIVERY_PRICE_LISTS_CACHE_TTL_SEC = 10 * 60;
+
 export class ErliOfferManagerAdapter
   implements
     OfferManagerPort,
@@ -211,7 +222,8 @@ export class ErliOfferManagerAdapter
     OfferStatusReader,
     OfferStockRestorer,
     TaxonomyBorrower,
-    ResponsibleProducerReader
+    ResponsibleProducerReader,
+    DeliveryPriceListReader
 {
   private readonly logger = new Logger(ErliOfferManagerAdapter.name);
 
@@ -413,6 +425,49 @@ export class ErliOfferManagerAdapter
       } catch (error) {
         this.logger.debug(
           `Responsible-producer cache write failed (ignored) [connectionId=${this.connectionId}]: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+    return items;
+  }
+
+  /**
+   * DeliveryPriceListReader (#1530). Lists the seller's delivery price lists
+   * ("cennik dostawy") from `GET /delivery/priceLists` so the offer-creation
+   * wizard can render a picker; the operator's choice rides back on
+   * `overrides.platformParams.deliveryPriceList` and is stamped onto the create
+   * body so the offer is buyable. Results are cached per connection for a short
+   * TTL to keep repeated wizard loads off the Erli API; a missing/failing cache
+   * simply falls through to a live read (fail-open).
+   */
+  async listDeliveryPriceLists(): Promise<DeliveryPriceList[]> {
+    const cacheKey = `erli:delivery-price-lists:${this.connectionId}`;
+    if (this.cache) {
+      try {
+        const cached = await this.cache.get<DeliveryPriceList[]>(cacheKey);
+        if (cached) {
+          return cached;
+        }
+      } catch (error) {
+        this.logger.debug(
+          `Delivery-price-list cache read failed (live fetch) [connectionId=${this.connectionId}]: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+    const res = await this.httpClient.get<ErliDeliveryPriceListItem[]>('delivery/priceLists');
+    const items = (res.data ?? [])
+      .filter((item) => typeof item?.name === 'string' && item.name.length > 0)
+      .map((item) => ({ id: String(item.id), name: item.name }));
+    if (this.cache) {
+      try {
+        await this.cache.set(cacheKey, items, ERLI_DELIVERY_PRICE_LISTS_CACHE_TTL_SEC);
+      } catch (error) {
+        this.logger.debug(
+          `Delivery-price-list cache write failed (ignored) [connectionId=${this.connectionId}]: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
@@ -636,6 +691,13 @@ export class ErliOfferManagerAdapter
       images,
       dispatchTime: this.resolveDispatchTime(cmd.overrides?.platformParams),
     };
+    // #1530 — operator-selected delivery price list ("cennik dostawy"). Erli
+    // keys it by unique name; absent ⇒ omit (offer stays not-buyable until the
+    // operator picks one, mirroring the dispatchTime opt-in posture).
+    const deliveryPriceList = readDeliveryPriceListParam(cmd.overrides?.platformParams);
+    if (deliveryPriceList !== undefined) {
+      body.deliveryPriceList = deliveryPriceList;
+    }
     if (cmd.overrides?.description != null) {
       body.description = flattenDescription(cmd.overrides.description);
     }
@@ -897,6 +959,25 @@ function readProducerParam(
   }
   const parsed = Number(trimmed);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * Read a per-offer `deliveryPriceList` selection off the un-modeled
+ * `overrides.platformParams` (#1530). Returns the trimmed price-list name when a
+ * non-empty string is present, else `undefined` (no selection ⇒ the create body
+ * omits the field). A non-string value is ignored rather than thrown — the
+ * picker only ever emits a string, and an offer with no delivery price list is a
+ * valid (if not-yet-buyable) create.
+ */
+function readDeliveryPriceListParam(
+  platformParams: Record<string, unknown> | undefined,
+): string | undefined {
+  const raw = platformParams?.deliveryPriceList;
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -132,6 +132,14 @@ export interface ErliProductCreateBody {
    * the direct and reliable reference here.
    */
   producerId?: number;
+  /**
+   * Delivery price list ("cennik dostawy") the offer references (#1530). Erli
+   * keys a price list by its unique `name` string (the default list is named
+   * `"*"`); without it the created offer lands not-buyable ("brak metody
+   * dostawy"). Supplied when the neutral command carries an operator selection
+   * (`overrides.platformParams.deliveryPriceList`); omitted otherwise.
+   */
+  deliveryPriceList?: string;
   /** Allegro category reuse (#985); omitted when empty. */
   externalCategories?: ErliExternalCategory[];
   /** Allegro parameter reuse (#985); omitted when empty. */
@@ -188,6 +196,18 @@ export type ErliProductStatus = 'accepted' | 'active' | 'inactive' | 'rejected';
  * (`ResponsibleSchema`, "pobierz listę producentów produktu").
  */
 export interface ErliResponsibleProducerItem {
+  id: number;
+  name: string;
+}
+
+/**
+ * One item from `GET /delivery/priceLists` (#1530). Erli returns
+ * `{ id: integer, name: string }`; `name` is the unique delivery-method name
+ * (the default list is `"*"`) that the create body's `deliveryPriceList` field
+ * references. Verified against `docs/architecture/adrs/erli-sandbox-swagger.json`
+ * (`PriceListListItem`).
+ */
+export interface ErliDeliveryPriceListItem {
   id: number;
   name: string;
 }


### PR DESCRIPTION
## What & why

An Erli offer created through OpenLinker landed **not-buyable** ("brak metody dostawy") because it carried no delivery price list ("cennik dostawy"). This adds an operator-selectable **delivery-price-list picker** to the offer-creation wizard, with options **fetched live from Erli per-connection**, and threads the selection onto the Erli offer-create body so the created offer is buyable without manual intervention.

Closes #1530.

## Backend

- New `OfferManager` sub-capability `DeliveryPriceListReader` (+ co-located `isDeliveryPriceListReader` guard) and neutral `DeliveryPriceList` type, mirroring `SellerPoliciesReader`.
- `DeliveryPriceListService` resolves the connection's `OfferManager` adapter, narrows to the capability, and returns the live options. Exposed via `GET /listings/connections/:connectionId/delivery-price-lists` (capability-gated; 422 when unsupported) - never `platformType`.
- The Erli adapter implements `listDeliveryPriceLists` (`GET /delivery/priceLists`, mapping `{id,name}`, cached per connection ~10 min) and stamps the selection onto the create body's `deliveryPriceList` field. Erli keys a price list by its unique **name** (default list is `"*"`), so the picker value is the name. The manifest advertises `DeliveryPriceListReader` (advertised-without-dispatch; resolved by narrowing the `OfferManager` adapter with the guard).

Carriage stays marketplace-neutral: the selection rides the existing `overrides.platformParams.deliveryPriceList` escape hatch (exactly like the sibling `dispatchTime` knob), so it threads through both the single and bulk flows with **no change** to `CreateOfferCommand` / the create-offer DTO / `OfferBuilderService`. The Erli adapter owns the neutral -> wire mapping.

## Frontend

- `use-delivery-price-lists-query` hook + api-client method + response type + query key.
- Shared `ErliDeliveryPriceListField` (existing `FormField` + `Select`; loading / error / empty states matching the Allegro seller-policy picker) rendered on **step 1** of the single Erli wizard and in the **Erli bulk** config section. English labels, sentence case; empty state gives direction ("No delivery price lists found on this Erli account - add one in Erli, then reload.").
- Retry-prefill maps the selection back from the persisted request snapshot.

The field is inherently Erli-only (it lives in the Erli-specific wizard + bulk section); the endpoint is capability-gated.

## How to test

1. Open the Erli create-offer wizard (single or bulk) for an Erli connection - the "Delivery price list" picker appears on the config step, populated live from Erli.
2. Pick a list and create the offer; the Erli product-create body carries `deliveryPriceList` and the offer is buyable on the Erli panel.

## Quality gate

- `pnpm type-check` - pass
- `pnpm lint` (incl. `check:invariants`) - pass
- Scoped tests - pass: core `DeliveryPriceListService` (3), Erli adapter + plugin (119), API listings controller (46), FE field + Erli wizard + bulk components (122).

## Not verified

- The live Erli sandbox was not reached in this run. Wire shapes (`GET /delivery/priceLists` -> `PriceListListItem {id,name}` and the product-create `deliveryPriceList: string` name field) were taken from the committed sandbox OpenAPI (`docs/architecture/adrs/erli-sandbox-swagger.json`); modelled defensively (blank/absent selection omits the field; missing/errored cache falls back to a live read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)