### PR TITLE
feat(listings,erli,web): operator-selectable responsible producer on offer create (#1531)

### DIFF
--- a/apps/api/src/listings/http/dto/responsible-producers-response.dto.ts
+++ b/apps/api/src/listings/http/dto/responsible-producers-response.dto.ts
@@ -1,0 +1,34 @@
+/**
+ * Responsible Producers Response DTO (#1531)
+ *
+ * Response shape for `GET /listings/connections/:connectionId/responsible-producers`.
+ * Swagger-decorated mirror of `ResponsibleProducerEntry[]` from
+ * `@openlinker/core/listings`, wrapped under `responsibleProducers`.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+import {
+  ResponsibleProducerKindValues,
+  type ResponsibleProducerKind,
+} from '@openlinker/core/listings';
+
+export class ResponsibleProducerDto {
+  @ApiProperty({ description: 'Platform-native responsible-producer id' })
+  id!: string;
+
+  @ApiProperty({ description: 'Responsible-producer name (operator-facing label)' })
+  name!: string;
+
+  @ApiProperty({
+    description: 'EU GPSR classification of the responsible-producer entry',
+    enum: ResponsibleProducerKindValues,
+  })
+  kind!: ResponsibleProducerKind;
+}
+
+export class ResponsibleProducersResponseDto {
+  @ApiProperty({ type: [ResponsibleProducerDto] })
+  responsibleProducers!: ResponsibleProducerDto[];
+}

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -31,11 +31,13 @@ import {
   OFFER_MAPPING_REPOSITORY_TOKEN,
   OfferCreationRecord,
   SELLER_POLICIES_SERVICE_TOKEN,
+  RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
 } from '@openlinker/core/listings';
 import type {
   ICategoryResolutionService,
   IOfferCreationEnqueueService,
   ISellerPoliciesService,
+  IResponsibleProducerService,
   OfferCreationRecordRepositoryPort,
   OfferMappingRepositoryPort,
 } from '@openlinker/core/listings';
@@ -55,6 +57,7 @@ describe('ListingsController', () => {
   let offerCreationRecords: jest.Mocked<OfferCreationRecordRepositoryPort>;
   let offerCreationEnqueue: jest.Mocked<IOfferCreationEnqueueService>;
   let sellerPolicies: jest.Mocked<ISellerPoliciesService>;
+  let responsibleProducers: jest.Mocked<IResponsibleProducerService>;
   let integrationsService: jest.Mocked<IIntegrationsService>;
   let productVariantRepository: jest.Mocked<ProductVariantRepositoryPort>;
   let categoryResolution: jest.Mocked<ICategoryResolutionService>;
@@ -108,6 +111,9 @@ describe('ListingsController', () => {
     sellerPolicies = {
       getSellerPolicies: jest.fn(),
     };
+    responsibleProducers = {
+      listResponsibleProducers: jest.fn(),
+    };
     integrationsService = {
       getCapabilityAdapter: jest.fn(),
     } as unknown as jest.Mocked<IIntegrationsService>;
@@ -134,6 +140,7 @@ describe('ListingsController', () => {
         { provide: OFFER_CREATION_RECORD_REPOSITORY_TOKEN, useValue: offerCreationRecords },
         { provide: OFFER_CREATION_ENQUEUE_SERVICE_TOKEN, useValue: offerCreationEnqueue },
         { provide: SELLER_POLICIES_SERVICE_TOKEN, useValue: sellerPolicies },
+        { provide: RESPONSIBLE_PRODUCER_SERVICE_TOKEN, useValue: responsibleProducers },
         { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
         { provide: PRODUCT_VARIANT_REPOSITORY_TOKEN, useValue: productVariantRepository },
         { provide: CATEGORY_RESOLUTION_SERVICE_TOKEN, useValue: categoryResolution },
@@ -558,6 +565,25 @@ describe('ListingsController', () => {
 
       expect(result).toEqual(policies);
       expect(sellerPolicies.getSellerPolicies).toHaveBeenCalledWith('conn-1');
+    });
+  });
+
+  describe('getResponsibleProducers', () => {
+    it('delegates to the responsible-producer service and wraps the result', async () => {
+      responsibleProducers.listResponsibleProducers.mockResolvedValue([
+        { id: '1', name: 'ACME Sp. z o.o.', kind: 'PRODUCER' },
+        { id: '2', name: 'Importer Ltd', kind: 'PRODUCER' },
+      ]);
+
+      const result = await controller.getResponsibleProducers('conn-1');
+
+      expect(result).toEqual({
+        responsibleProducers: [
+          { id: '1', name: 'ACME Sp. z o.o.', kind: 'PRODUCER' },
+          { id: '2', name: 'Importer Ltd', kind: 'PRODUCER' },
+        ],
+      });
+      expect(responsibleProducers.listResponsibleProducers).toHaveBeenCalledWith('conn-1');
     });
   });
 

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -41,9 +41,11 @@ import {
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
   SELLER_POLICIES_SERVICE_TOKEN,
+  RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
   ICategoryResolutionService,
   IOfferCreationEnqueueService,
   ISellerPoliciesService,
+  IResponsibleProducerService,
   OfferCreationRecordRepositoryPort,
   OfferMappingRepositoryPort,
 } from '@openlinker/core/listings';
@@ -73,6 +75,7 @@ import { CreateOfferDto } from './dto/create-offer.dto';
 import { CreateOfferResponseDto } from './dto/create-offer-response.dto';
 import { OfferCreationStatusResponseDto } from './dto/offer-creation-status-response.dto';
 import { SellerPoliciesResponseDto } from './dto/seller-policies-response.dto';
+import { ResponsibleProducersResponseDto } from './dto/responsible-producers-response.dto';
 import type { CategoryParameterResponseDto } from './dto/category-parameter-response.dto';
 import { CategoryParametersListResponseDto } from './dto/category-parameter-response.dto';
 import { ResolveCategoryRequestDto, ResolveCategoryResponseDto } from './dto/resolve-category.dto';
@@ -102,6 +105,8 @@ export class ListingsController {
     private readonly offerCreationEnqueue: IOfferCreationEnqueueService,
     @Inject(SELLER_POLICIES_SERVICE_TOKEN)
     private readonly sellerPolicies: ISellerPoliciesService,
+    @Inject(RESPONSIBLE_PRODUCER_SERVICE_TOKEN)
+    private readonly responsibleProducers: IResponsibleProducerService,
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrationsService: IIntegrationsService,
     @Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)
@@ -401,6 +406,34 @@ export class ListingsController {
     @Param('connectionId') connectionId: string
   ): Promise<SellerPoliciesResponseDto> {
     return this.sellerPolicies.getSellerPolicies(connectionId);
+  }
+
+  @Roles('admin', 'operator')
+  @Get('connections/:connectionId/responsible-producers')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+  @ApiOperation({
+    summary: 'List seller-configured responsible producers (#1531)',
+    description:
+      'Returns the EU GPSR responsible-producer registry ("producent") configured for the connection, fetched live from the marketplace. The offer-creation wizard renders these so the operator can attach one and the created product is not blocked for a missing producer.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Responsible producers wrapped under `responsibleProducers`.',
+    type: ResponsibleProducersResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Connection not found' })
+  @ApiResponse({ status: 409, description: 'Connection disabled' })
+  @ApiResponse({
+    status: 422,
+    description: 'Adapter does not support responsible-producer listing',
+  })
+  async getResponsibleProducers(
+    @Param('connectionId') connectionId: string
+  ): Promise<ResponsibleProducersResponseDto> {
+    const responsibleProducers =
+      await this.responsibleProducers.listResponsibleProducers(connectionId);
+    return { responsibleProducers };
   }
 
   @Roles('admin', 'operator')

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -24,6 +24,7 @@ import type {
   ResolveCategoryRequest,
   ResolveCategoryResponse,
   SellerPoliciesResponse,
+  ResponsibleProducersResponse,
   ShopPublishRequest,
   ShopPublishResponse,
   ShopPublishStatusResponse,
@@ -96,6 +97,7 @@ export interface ListingsApi {
   /** Read a bulk shop-publish batch + its per-record summary. Used for polling. */
   getBulkShopPublishBatch: (batchId: string) => Promise<BulkShopPublishBatchResponse>;
   getSellerPolicies: (connectionId: string) => Promise<SellerPoliciesResponse>;
+  getResponsibleProducers: (connectionId: string) => Promise<ResponsibleProducersResponse>;
   getCategoryParameters: (
     connectionId: string,
     categoryId: string,
@@ -226,6 +228,11 @@ export function createListingsApi(request: ApiRequest): ListingsApi {
     getSellerPolicies(connectionId): Promise<SellerPoliciesResponse> {
       return request<SellerPoliciesResponse>(
         `/listings/connections/${connectionId}/seller-policies`,
+      );
+    },
+    getResponsibleProducers(connectionId): Promise<ResponsibleProducersResponse> {
+      return request<ResponsibleProducersResponse>(
+        `/listings/connections/${connectionId}/responsible-producers`,
       );
     },
     getCategoryParameters(connectionId, categoryId): Promise<CategoryParametersListResponse> {

--- a/apps/web/src/features/listings/api/listings.query-keys.ts
+++ b/apps/web/src/features/listings/api/listings.query-keys.ts
@@ -13,6 +13,8 @@ export const listingsQueryKeys = {
   offerCreationStatus: (connectionId: string, offerCreationRecordId: string) =>
     ['listings', 'offerCreationStatus', connectionId, offerCreationRecordId] as const,
   sellerPolicies: (connectionId: string) => ['listings', 'sellerPolicies', connectionId] as const,
+  responsibleProducers: (connectionId: string) =>
+    ['listings', 'responsibleProducers', connectionId] as const,
   // The version constant at index 2 cache-busts every browser's in-flight
   // TanStack Query cache when the response shape changes. See #423 + the
   // CATEGORY_PARAMETERS_SCHEMA_VERSION JSDoc in listings.types.ts.

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -362,6 +362,23 @@ export interface SellerPoliciesResponse {
   impliedWarranties: SellerPolicy[];
 }
 
+/** ----- Responsible producers (#1531) -------------------------------------
+ *
+ * A seller-configured EU GPSR responsible-producer ("producent") returned by
+ * `GET /listings/connections/:connectionId/responsible-producers`, fetched live
+ * from the marketplace. The offer-creation wizard renders these so the operator
+ * can attach one and the created product is not blocked for a missing producer.
+ */
+export interface ResponsibleProducer {
+  id: string;
+  name: string;
+  kind: string;
+}
+
+export interface ResponsibleProducersResponse {
+  responsibleProducers: ResponsibleProducer[];
+}
+
 /** ----- Category parameters (#410) ----------------------------------------
  *
  * Marketplace-neutral shape for category parameters returned by

--- a/apps/web/src/features/listings/components/erli/create-erli-offer-request-to-form-values.test.ts
+++ b/apps/web/src/features/listings/components/erli/create-erli-offer-request-to-form-values.test.ts
@@ -46,6 +46,29 @@ describe('createErliOfferRequestToFormValues', () => {
     });
   });
 
+  it('restores the responsible producer from platformParams.producer (#1531)', () => {
+    const values = createErliOfferRequestToFormValues(
+      snapshot({
+        overrides: {
+          title: 'With producer',
+          platformParams: { dispatchTime: { period: 5, unit: 'hour' }, producer: '42' },
+        },
+      }),
+      FALLBACK,
+    );
+
+    expect(values.producer).toBe('42');
+  });
+
+  it('defaults producer to an empty string when the snapshot has none (#1531)', () => {
+    const values = createErliOfferRequestToFormValues(
+      snapshot({ overrides: { title: 'No producer' } }),
+      FALLBACK,
+    );
+
+    expect(values.producer).toBe('');
+  });
+
   it('falls back to the connection default dispatch when the snapshot has none', () => {
     const values = createErliOfferRequestToFormValues(
       snapshot({ overrides: { title: 'No dispatch' } }),

--- a/apps/web/src/features/listings/components/erli/create-erli-offer-request-to-form-values.ts
+++ b/apps/web/src/features/listings/components/erli/create-erli-offer-request-to-form-values.ts
@@ -49,6 +49,14 @@ export function createErliOfferRequestToFormValues(
   const dispatch: ErliDispatchTimeParam = isValidDispatch(dispatchRaw)
     ? { period: dispatchRaw.period, unit: dispatchRaw.unit ?? 'day' }
     : fallbackDispatch;
+  // Responsible producer (#1531) rides `overrides.platformParams.producer`.
+  const producerRaw = overrides?.platformParams?.producer;
+  const producer =
+    typeof producerRaw === 'string'
+      ? producerRaw
+      : typeof producerRaw === 'number'
+        ? String(producerRaw)
+        : '';
 
   return {
     internalVariantId: request.internalVariantId,
@@ -60,6 +68,7 @@ export function createErliOfferRequestToFormValues(
     priceAmount: request.price ? request.price.amount.toFixed(2) : '',
     stock: request.stock,
     description: overrides?.description ?? '',
+    producer,
     publishImmediately: request.publishImmediately,
     dispatchPeriod: dispatch.period,
     dispatchUnit: dispatch.unit,

--- a/apps/web/src/features/listings/components/erli/erli-bulk-config-section.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-bulk-config-section.tsx
@@ -16,6 +16,7 @@ import { useEffect, useMemo, type ReactElement } from 'react';
 
 import type { BulkOfferConfigSectionProps } from '../../../../shared/plugins';
 import { ErliDispatchTimeField } from './erli-dispatch-time-field';
+import { ErliProducerField } from './erli-producer-field';
 import {
   isValidDispatch,
   parseErliConnectionDispatchDefault,
@@ -35,6 +36,9 @@ export function ErliBulkConfigSection({
   const current: ErliDispatchTimeParam = isValidDispatch(platformParams.dispatchTime)
     ? (platformParams.dispatchTime as ErliDispatchTimeParam)
     : connectionDefault;
+  // Batch-default producer (#1531). Applies to every row unless a row overrides
+  // it in the per-row edit modal; empty string = no batch default chosen.
+  const producer = typeof platformParams.producer === 'string' ? platformParams.producer : '';
 
   // Seed the form with the connection default + fix currency to PLN. Keyed on
   // the connection so switching marketplaces re-seeds; `form`/`connectionDefault`
@@ -65,10 +69,22 @@ export function ErliBulkConfigSection({
           );
         }}
       />
+      <ErliProducerField
+        connectionId={connection.id}
+        value={producer}
+        onChange={(next) => {
+          form.setValue(
+            'platformParams',
+            { ...form.getValues('platformParams'), producer: next },
+            { shouldDirty: true },
+          );
+        }}
+      />
       <p className="erli-config__note">
         Erli has no seller/delivery policies — dispatch time stands in for Allegro's policy step.
-        Prices are sent in PLN; images are pulled from each product (Erli requires at least one),
-        and the Resolving step flags any product missing one.
+        The producer applies to every product in this batch (override it per product in the Review
+        step). Prices are sent in PLN; images are pulled from each product (Erli requires at least
+        one), and the Resolving step flags any product missing one.
       </p>
     </div>
   );

--- a/apps/web/src/features/listings/components/erli/erli-bulk-row-section.test.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-bulk-row-section.test.tsx
@@ -1,10 +1,10 @@
 /**
- * ErliBulkRowSection tests (#1096)
+ * ErliBulkRowSection tests (#1096, #1531)
  *
- * The per-row dispatch override is toggle-gated: OFF ⇒ no `dispatchTime` in
- * `platformParams` (the row inherits the batch default at submit); ON ⇒ a
- * `dispatchTime` is emitted. Controlled — assertions are on the `onChange`
- * payload, not internal state.
+ * The per-row dispatch and producer overrides are each toggle-gated: OFF ⇒ no
+ * key in `platformParams` (the row inherits the batch default at submit); ON ⇒
+ * a value is emitted. Controlled — assertions are on the `onChange` payload,
+ * not internal state.
  */
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen } from '@testing-library/react';
@@ -26,6 +26,11 @@ const connection = {
   updatedAt: '2026-01-01T00:00:00.000Z',
 } as Connection;
 
+const dispatchToggle = (): HTMLElement =>
+  screen.getByRole('checkbox', { name: /custom dispatch time/i });
+const producerToggle = (): HTMLElement =>
+  screen.getByRole('checkbox', { name: /custom producer/i });
+
 describe('ErliBulkRowSection', () => {
   it('starts OFF with no override and emits a dispatchTime when toggled on', () => {
     const onChange = vi.fn();
@@ -33,7 +38,7 @@ describe('ErliBulkRowSection', () => {
       <ErliBulkRowSection connection={connection} platformParams={{}} onChange={onChange} />,
     );
 
-    const toggle = screen.getByRole('checkbox');
+    const toggle = dispatchToggle();
     expect(toggle).not.toBeChecked();
 
     fireEvent.click(toggle);
@@ -50,7 +55,7 @@ describe('ErliBulkRowSection', () => {
         onChange={vi.fn()}
       />,
     );
-    expect(screen.getByRole('checkbox')).toBeChecked();
+    expect(dispatchToggle()).toBeChecked();
   });
 
   it('drops dispatchTime when toggled off so the row inherits the batch default', () => {
@@ -63,10 +68,63 @@ describe('ErliBulkRowSection', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(dispatchToggle());
     expect(onChange).toHaveBeenCalledTimes(1);
     const next = onChange.mock.calls[0][0] as Record<string, unknown>;
     expect(next).not.toHaveProperty('dispatchTime');
     expect(next.other).toBe('keep'); // unrelated platformParams preserved
+  });
+
+  describe('producer override (#1531)', () => {
+    it('starts OFF (inherits batch default) with no producer key present', () => {
+      const onChange = vi.fn();
+      renderWithProviders(
+        <ErliBulkRowSection connection={connection} platformParams={{}} onChange={onChange} />,
+      );
+
+      const toggle = producerToggle();
+      expect(toggle).not.toBeChecked();
+      expect(screen.getByText(/uses the batch default producer/i)).toBeInTheDocument();
+    });
+
+    it('emits an empty producer override (opting out of the batch default) when toggled on', () => {
+      const onChange = vi.fn();
+      renderWithProviders(
+        <ErliBulkRowSection connection={connection} platformParams={{}} onChange={onChange} />,
+      );
+
+      fireEvent.click(producerToggle());
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const next = onChange.mock.calls[0][0] as Record<string, unknown>;
+      expect(next).toHaveProperty('producer', '');
+    });
+
+    it('shows the producer toggle ON when the row already carries a producer override', () => {
+      renderWithProviders(
+        <ErliBulkRowSection
+          connection={connection}
+          platformParams={{ producer: '42' }}
+          onChange={vi.fn()}
+        />,
+      );
+      expect(producerToggle()).toBeChecked();
+    });
+
+    it('resets to the batch default (drops the producer key) via the reset affordance', () => {
+      const onChange = vi.fn();
+      renderWithProviders(
+        <ErliBulkRowSection
+          connection={connection}
+          platformParams={{ producer: '42', other: 'keep' }}
+          onChange={onChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /reset to batch default/i }));
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const next = onChange.mock.calls[0][0] as Record<string, unknown>;
+      expect(next).not.toHaveProperty('producer');
+      expect(next.other).toBe('keep'); // unrelated platformParams preserved
+    });
   });
 });

--- a/apps/web/src/features/listings/components/erli/erli-bulk-row-section.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-bulk-row-section.tsx
@@ -1,11 +1,12 @@
 /**
  * ErliBulkRowSection
  *
- * Per-product (per-row) Erli section for the bulk Review edit modal (#1096).
- * Lets the operator override the dispatch time for a single product instead of
- * only batch-wide, behind a toggle: OFF (default) ⇒ the row inherits the batch
- * dispatch time (the submit deep-merges shared `platformParams` under per-row);
- * ON ⇒ a custom dispatch time is written to the row's `platformParams`.
+ * Per-product (per-row) Erli section for the bulk Review edit modal (#1096,
+ * #1531). Lets the operator override the dispatch time and the responsible
+ * producer for a single product instead of only batch-wide, each behind a
+ * toggle: OFF (default) ⇒ the row inherits the batch value (the submit
+ * deep-merges shared `platformParams` under per-row); ON ⇒ a custom value is
+ * written to the row's `platformParams`.
  *
  * Controlled — the host (edit modal) owns the row's `platformParams` (seeded
  * from any existing per-row override) and persists `onChange` output into the
@@ -18,6 +19,7 @@ import { useMemo, type ReactElement } from 'react';
 
 import type { BulkOfferRowSectionProps } from '../../../../shared/plugins';
 import { ErliDispatchTimeField } from './erli-dispatch-time-field';
+import { ErliProducerField } from './erli-producer-field';
 import {
   isValidDispatch,
   parseErliConnectionDispatchDefault,
@@ -39,6 +41,13 @@ export function ErliBulkRowSection({
     ? (platformParams.dispatchTime as ErliDispatchTimeParam)
     : connectionDefault;
 
+  // Producer override (#1531). An absent `producer` key ⇒ this row inherits the
+  // batch-default producer; a present string ⇒ this product overrides it. The
+  // per-row value wins over the batch default at submit (per-row deep-merged
+  // over the shared `platformParams`).
+  const producerOverridden = typeof platformParams.producer === 'string';
+  const producer = producerOverridden ? (platformParams.producer as string) : '';
+
   function toggle(on: boolean): void {
     if (on) {
       onChange({ ...platformParams, dispatchTime: current });
@@ -46,6 +55,18 @@ export function ErliBulkRowSection({
       // Drop the key so the row inherits the batch-wide dispatch at submit.
       const next = { ...platformParams };
       delete next.dispatchTime;
+      onChange(next);
+    }
+  }
+
+  function toggleProducer(on: boolean): void {
+    if (on) {
+      // Start empty; the operator picks a producer for this product only.
+      onChange({ ...platformParams, producer: '' });
+    } else {
+      // Drop the key so the row inherits the batch-default producer at submit.
+      const next = { ...platformParams };
+      delete next.producer;
       onChange(next);
     }
   }
@@ -75,6 +96,40 @@ export function ErliBulkRowSection({
           connectionDefault={connectionDefault}
           onChange={(next) => { onChange({ ...platformParams, dispatchTime: next }); }}
         />
+      ) : null}
+
+      <label
+        className="checkbox-row"
+        style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}
+      >
+        <input
+          type="checkbox"
+          checked={producerOverridden}
+          onChange={(e) => { toggleProducer(e.target.checked); }}
+        />
+        <span>
+          <strong>Custom producer for this product</strong>
+          <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+            Off — this product uses the batch default producer.
+          </small>
+        </span>
+      </label>
+
+      {producerOverridden ? (
+        <>
+          <ErliProducerField
+            connectionId={connection.id}
+            value={producer}
+            onChange={(next) => { onChange({ ...platformParams, producer: next }); }}
+          />
+          <button
+            type="button"
+            className="button button--ghost button--sm"
+            onClick={() => { toggleProducer(false); }}
+          >
+            Reset to batch default
+          </button>
+        </>
       ) : null}
     </div>
   );

--- a/apps/web/src/features/listings/components/erli/erli-create-offer-wizard.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-create-offer-wizard.tsx
@@ -66,6 +66,7 @@ import {
   type ErliCreateOfferValues,
 } from './erli-create-offer.schema';
 import { ErliDispatchTimeField } from './erli-dispatch-time-field';
+import { ErliProducerField } from './erli-producer-field';
 import {
   formatDispatch,
   parseErliConnectionDispatchDefault,
@@ -168,6 +169,7 @@ export function ErliCreateOfferWizard({
       priceAmount: '',
       stock: 0,
       description: '',
+      producer: '',
       publishImmediately: false,
       dispatchPeriod: dispatchDefault.period,
       dispatchUnit: dispatchDefault.unit,
@@ -394,6 +396,7 @@ export function ErliCreateOfferWizard({
         ...(parameters.length > 0 ? { parameters } : {}),
         platformParams: {
           dispatchTime: { period: submitted.dispatchPeriod, unit: submitted.dispatchUnit },
+          ...(submitted.producer ? { producer: submitted.producer } : {}),
         },
       },
     };
@@ -614,6 +617,11 @@ export function ErliCreateOfferWizard({
                   form.setValue('dispatchUnit', next.unit, { shouldDirty: true });
                 }}
                 error={form.formState.errors.dispatchPeriod?.message}
+              />
+              <ErliProducerField
+                connectionId={connection.id}
+                value={form.watch('producer') ?? ''}
+                onChange={(next) => form.setValue('producer', next, { shouldDirty: true })}
               />
               <p className="erli-config__note">
                 Erli has no seller/delivery policies — dispatch time stands in for Allegro's policy

--- a/apps/web/src/features/listings/components/erli/erli-create-offer.schema.ts
+++ b/apps/web/src/features/listings/components/erli/erli-create-offer.schema.ts
@@ -37,6 +37,11 @@ export const erliCreateOfferSchema = z
       .int('Stock must be an integer')
       .min(0, 'Stock must be 0 or greater'),
     description: z.string().optional(),
+    // Responsible-producer id (#1531). Optional at the form level so the wizard
+    // never deadlocks when the Erli account has none; when set it rides to the
+    // adapter on `overrides.platformParams.producer` and clears the created
+    // product's missing-producer block.
+    producer: z.string().optional(),
     publishImmediately: z.boolean(),
     parameters: z.record(z.string(), z.unknown()).default({}),
   })

--- a/apps/web/src/features/listings/components/erli/erli-producer-field.test.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-producer-field.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * ErliProducerField tests (#1531)
+ *
+ * Covers the live per-connection fetch, the empty-state direction copy, the
+ * options render, and the `onChange` contract (selecting by producer id).
+ */
+import { screen, fireEvent, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders, createMockApiClient } from '../../../../test/test-utils';
+import { ErliProducerField } from './erli-producer-field';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ErliProducerField', () => {
+  it('renders the fetched producers as options', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getResponsibleProducers: vi.fn().mockResolvedValue({
+          responsibleProducers: [
+            { id: '1', name: 'ACME Sp. z o.o.', kind: 'PRODUCER' },
+            { id: '42', name: 'Importer Ltd', kind: 'PRODUCER' },
+          ],
+        }),
+      },
+    });
+
+    renderWithProviders(
+      <ErliProducerField connectionId="conn_erli_1" value="" onChange={vi.fn()} />,
+      { apiClient },
+    );
+
+    expect(await screen.findByRole('option', { name: 'ACME Sp. z o.o.' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Importer Ltd' })).toBeInTheDocument();
+  });
+
+  it('shows a directive empty state when the account has no producers', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getResponsibleProducers: vi.fn().mockResolvedValue({ responsibleProducers: [] }),
+      },
+    });
+
+    renderWithProviders(
+      <ErliProducerField connectionId="conn_erli_1" value="" onChange={vi.fn()} />,
+      { apiClient },
+    );
+
+    expect(
+      await screen.findByText(/No producers on this Erli account/i),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onChange with the selected producer id', async () => {
+    const onChange = vi.fn();
+    const apiClient = createMockApiClient({
+      listings: {
+        getResponsibleProducers: vi.fn().mockResolvedValue({
+          responsibleProducers: [{ id: '42', name: 'Importer Ltd', kind: 'PRODUCER' }],
+        }),
+      },
+    });
+
+    renderWithProviders(
+      <ErliProducerField connectionId="conn_erli_1" value="" onChange={onChange} />,
+      { apiClient },
+    );
+
+    const select = await screen.findByRole('combobox');
+    fireEvent.change(select, { target: { value: '42' } });
+
+    expect(onChange).toHaveBeenCalledWith('42');
+  });
+});

--- a/apps/web/src/features/listings/components/erli/erli-producer-field.tsx
+++ b/apps/web/src/features/listings/components/erli/erli-producer-field.tsx
@@ -1,0 +1,83 @@
+/**
+ * ErliProducerField (#1531)
+ *
+ * Shared, content-only picker for Erli's responsible producer ("producent") —
+ * the selection that clears the missing-producer block on a created product.
+ * Consumed by BOTH `ErliCreateOfferWizard` (single) and `ErliBulkConfigSection`
+ * (bulk batch default) so the field never drifts.
+ *
+ * Options are fetched live from Erli per-connection via
+ * `useResponsibleProducersQuery`. Controlled via `value` + `onChange` (the
+ * producer id) so each host wires it into its own form state. Loading / error /
+ * empty states mirror the Allegro seller-policy picker.
+ *
+ * @module features/listings/components/erli
+ */
+import type { ReactElement } from 'react';
+
+import { Alert } from '../../../../shared/ui/alert';
+import { FormField } from '../../../../shared/ui/form-field';
+import { Input } from '../../../../shared/ui/input';
+import { Select } from '../../../../shared/ui/select';
+import { useResponsibleProducersQuery } from '../../hooks/use-responsible-producers-query';
+
+interface ErliProducerFieldProps {
+  connectionId: string;
+  /** Selected producer id (empty string = none chosen). */
+  value: string;
+  onChange: (producerId: string) => void;
+}
+
+export function ErliProducerField({
+  connectionId,
+  value,
+  onChange,
+}: ErliProducerFieldProps): ReactElement {
+  const query = useResponsibleProducersQuery(connectionId);
+  const producers = query.data?.responsibleProducers ?? [];
+
+  // Matches FormField's `ControlProps` so the single child typechecks in every
+  // branch (Input / Alert / Select all satisfy these optional props).
+  let control: ReactElement<{
+    id?: string;
+    className?: string;
+    'aria-invalid'?: boolean;
+    'aria-describedby'?: string;
+  }>;
+  if (query.isLoading) {
+    control = <Input disabled value="Loading producers…" readOnly />;
+  } else if (query.error) {
+    control = (
+      <Alert tone="error" title="Unable to load producers">
+        {query.error instanceof Error ? query.error.message : 'Please try again.'}
+      </Alert>
+    );
+  } else if (producers.length === 0) {
+    control = (
+      <Alert tone="info" title="No producers found">
+        No producers on this Erli account - add one in Erli, then reload.
+      </Alert>
+    );
+  } else {
+    control = (
+      <Select value={value} onChange={(e) => onChange(e.target.value)}>
+        <option value="">Choose a producer…</option>
+        {producers.map((producer) => (
+          <option key={producer.id} value={producer.id}>
+            {producer.name}
+          </option>
+        ))}
+      </Select>
+    );
+  }
+
+  return (
+    <FormField
+      label="Producer"
+      name="producer"
+      description="Responsible producer shown on the Erli product card. Fetched from Erli."
+    >
+      {control}
+    </FormField>
+  );
+}

--- a/apps/web/src/features/listings/hooks/use-responsible-producers-query.ts
+++ b/apps/web/src/features/listings/hooks/use-responsible-producers-query.ts
@@ -1,0 +1,30 @@
+/**
+ * use-responsible-producers-query (#1531)
+ *
+ * Fetches the EU GPSR responsible producers ("producent") configured on a
+ * marketplace connection, fetched live from the marketplace. Backs the producer
+ * picker in the offer-creation wizard (single + bulk). Server caches per
+ * connection for ~10 minutes; a 5-minute client-side staleTime keeps repeated
+ * wizard opens within a session from re-fetching.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { ResponsibleProducersResponse } from '../api/listings.types';
+
+export const RESPONSIBLE_PRODUCERS_STALE_TIME_MS = 5 * 60 * 1000;
+
+export function useResponsibleProducersQuery(
+  connectionId: string,
+): UseQueryResult<ResponsibleProducersResponse> {
+  const apiClient = useApiClient();
+
+  return useQuery<ResponsibleProducersResponse>({
+    queryKey: listingsQueryKeys.responsibleProducers(connectionId),
+    queryFn: () => apiClient.listings.getResponsibleProducers(connectionId),
+    enabled: Boolean(connectionId),
+    staleTime: RESPONSIBLE_PRODUCERS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -321,6 +321,9 @@ export function createMockApiClient(
         warranties: [],
         impliedWarranties: [],
       }),
+      // #1531 — default to "no producers" so the Erli wizard's producer picker
+      // renders its empty state in tests that don't override.
+      getResponsibleProducers: vi.fn().mockResolvedValue({ responsibleProducers: [] }),
       // #410 — default to "no parameters" so the wizard's category step
       // renders the friendly empty state in tests that don't override.
       getCategoryParameters: vi.fn().mockResolvedValue({ parameters: [] }),

--- a/libs/core/src/listings/application/interfaces/responsible-producer.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/responsible-producer.service.interface.ts
@@ -1,0 +1,33 @@
+/**
+ * Responsible Producer Service Interface (#1531)
+ *
+ * Contract for the core read service that returns a connection's EU GPSR
+ * responsible-producer registry ("producent" / responsible person). Implemented
+ * by `ResponsibleProducerService`; consumed by the HTTP layer so the FE
+ * offer-creation wizard (single + bulk) can populate the producer picker
+ * without re-hitting the marketplace API on every render.
+ *
+ * @module libs/core/src/listings/application/interfaces
+ */
+
+import type { ResponsibleProducerEntry } from '@openlinker/core/listings';
+
+export interface IResponsibleProducerService {
+  /**
+   * Return the responsible-producer entries for a connection.
+   *
+   * Resolves the connection's `OfferManager` adapter, narrows it to the
+   * `ResponsibleProducerReader` capability, and returns the live options. The
+   * adapter memoises the upstream response per connection so repeated wizard
+   * loads do not hammer the marketplace API.
+   *
+   * Throws:
+   * - `ConnectionNotFoundException` (→ HTTP 404) when the connection does not exist.
+   * - `ConnectionDisabledException` (→ HTTP 409) when the connection is disabled.
+   * - `CapabilityNotSupportedException` (→ HTTP 422) when the connection's
+   *   adapter does not implement `OfferManager` at all.
+   * - `UnprocessableEntityException` (→ HTTP 422) when the adapter supports
+   *   `OfferManager` but does not implement `fetchResponsibleProducers`.
+   */
+  listResponsibleProducers(connectionId: string): Promise<ResponsibleProducerEntry[]>;
+}

--- a/libs/core/src/listings/application/services/__tests__/responsible-producer.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/responsible-producer.service.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Responsible Producer Service Tests (#1531)
+ *
+ * Unit tests for adapter resolution, capability gating (`ResponsibleProducerReader`),
+ * and error propagation.
+ *
+ * @module libs/core/src/listings/application/services/__tests__
+ */
+
+import { UnprocessableEntityException } from '@nestjs/common';
+
+import type { OfferManagerPort, ResponsibleProducerEntry } from '@openlinker/core/listings';
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+
+import { ResponsibleProducerService } from '../responsible-producer.service';
+
+describe('ResponsibleProducerService', () => {
+  let service: ResponsibleProducerService;
+  let integrations: jest.Mocked<IIntegrationsService>;
+
+  const connectionId = 'conn-abc';
+  const producers: ResponsibleProducerEntry[] = [
+    { id: '1', name: 'ACME Sp. z o.o.', kind: 'PRODUCER' },
+    { id: '2', name: 'Importer Ltd', kind: 'PRODUCER' },
+  ];
+
+  const adapterWith = (fetchResponsibleProducers: jest.Mock | undefined): OfferManagerPort =>
+    ({
+      ...(fetchResponsibleProducers ? { fetchResponsibleProducers } : {}),
+    } as unknown as OfferManagerPort);
+
+  beforeEach(() => {
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+      resolveAdapterMetadata: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    service = new ResponsibleProducerService(integrations);
+  });
+
+  it('returns the responsible producers from the connection adapter', async () => {
+    const fetchResponsibleProducers = jest.fn().mockResolvedValue(producers);
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(fetchResponsibleProducers));
+
+    const result = await service.listResponsibleProducers(connectionId);
+
+    expect(result).toBe(producers);
+    expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(connectionId, 'OfferManager');
+    expect(fetchResponsibleProducers).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws UnprocessableEntityException when the adapter does not implement fetchResponsibleProducers', async () => {
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(undefined));
+
+    await expect(service.listResponsibleProducers(connectionId)).rejects.toThrow(
+      UnprocessableEntityException,
+    );
+  });
+
+  it('propagates exceptions from getCapabilityAdapter (connection not found / disabled)', async () => {
+    integrations.getCapabilityAdapter.mockRejectedValue(new Error('ConnectionNotFoundException'));
+
+    await expect(service.listResponsibleProducers(connectionId)).rejects.toThrow(
+      'ConnectionNotFoundException',
+    );
+  });
+});

--- a/libs/core/src/listings/application/services/responsible-producer.service.ts
+++ b/libs/core/src/listings/application/services/responsible-producer.service.ts
@@ -1,0 +1,47 @@
+/**
+ * Responsible Producer Service (#1531)
+ *
+ * Read service that returns a connection's EU GPSR responsible-producer
+ * registry ("producent" / responsible person) for the offer-creation wizard.
+ * Resolves the connection's `OfferManager` adapter and narrows it to the
+ * `ResponsibleProducerReader` sub-capability; caching of the upstream response
+ * lives in the adapter (per connection), mirroring the seller-policies and
+ * category-parameters read paths.
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {IResponsibleProducerService}
+ * @see {@link IResponsibleProducerService} for the service contract
+ */
+
+import { Inject, Injectable, UnprocessableEntityException } from '@nestjs/common';
+
+import { isResponsibleProducerReader } from '@openlinker/core/listings';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import type { OfferManagerPort, ResponsibleProducerEntry } from '@openlinker/core/listings';
+
+import type { IResponsibleProducerService } from '../interfaces/responsible-producer.service.interface';
+
+@Injectable()
+export class ResponsibleProducerService implements IResponsibleProducerService {
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService
+  ) {}
+
+  async listResponsibleProducers(connectionId: string): Promise<ResponsibleProducerEntry[]> {
+    // Throws ConnectionNotFoundException (404) / ConnectionDisabledException (409) /
+    // CapabilityNotSupportedException (422) for upstream connection-level issues.
+    const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+      connectionId,
+      'OfferManager'
+    );
+
+    if (!isResponsibleProducerReader(adapter)) {
+      throw new UnprocessableEntityException(
+        `Adapter for connection ${connectionId} does not support responsible-producer listing`
+      );
+    }
+
+    return adapter.fetchResponsibleProducers();
+  }
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -130,6 +130,7 @@ export { OfferBuilderValidationException } from './domain/exceptions/offer-build
 export type { OfferBuilderValidationIssue } from './domain/exceptions/offer-builder-validation.exception';
 export { MasterCatalogConnectionNotConfiguredException } from './domain/exceptions/master-catalog-connection-not-configured.exception';
 export type { ISellerPoliciesService } from './application/interfaces/seller-policies.service.interface';
+export type { IResponsibleProducerService } from './application/interfaces/responsible-producer.service.interface';
 export type {
   SellerPoliciesCacheRepositoryPort,
   CachedSellerPolicies,

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -40,6 +40,7 @@ import { BulkShopPublishSubmitService } from './application/services/bulk-shop-p
 import { SellerPoliciesCacheOrmEntity } from './infrastructure/persistence/entities/seller-policies-cache.orm-entity';
 import { SellerPoliciesCacheRepository } from './infrastructure/persistence/repositories/seller-policies-cache.repository';
 import { SellerPoliciesService } from './application/services/seller-policies.service';
+import { ResponsibleProducerService } from './application/services/responsible-producer.service';
 import { OfferCreationEnqueueService } from './application/services/offer-creation-enqueue.service';
 import { BulkListingSubmitService } from './application/services/bulk-listing-submit.service';
 import { BulkListingRetryService } from './application/services/bulk-listing-retry.service';
@@ -69,6 +70,7 @@ import {
   OFFER_STATUS_SNAPSHOT_REPOSITORY_TOKEN,
   SELLER_POLICIES_SERVICE_TOKEN,
   SELLER_POLICIES_CACHE_TOKEN,
+  RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
   OFFER_STOCK_RESTORE_SERVICE_TOKEN,
   LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
   PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,
@@ -100,6 +102,7 @@ export {
   OFFER_STATUS_SNAPSHOT_REPOSITORY_TOKEN,
   SELLER_POLICIES_SERVICE_TOKEN,
   SELLER_POLICIES_CACHE_TOKEN,
+  RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
   OFFER_STOCK_RESTORE_SERVICE_TOKEN,
   LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
   PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,
@@ -162,6 +165,7 @@ export {
     OfferStatusSnapshotRepository,
     SellerPoliciesCacheRepository,
     SellerPoliciesService,
+    ResponsibleProducerService,
     OfferStockRestoreService,
     {
       provide: OFFER_LINKING_SERVICE_TOKEN,
@@ -268,6 +272,10 @@ export {
       useExisting: SellerPoliciesService,
     },
     {
+      provide: RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
+      useExisting: ResponsibleProducerService,
+    },
+    {
       provide: OFFER_STOCK_RESTORE_SERVICE_TOKEN,
       useExisting: OfferStockRestoreService,
     },
@@ -291,6 +299,7 @@ export {
     OFFER_STATUS_SYNC_SERVICE_TOKEN,
     SELLER_POLICIES_SERVICE_TOKEN,
     SELLER_POLICIES_CACHE_TOKEN,
+    RESPONSIBLE_PRODUCER_SERVICE_TOKEN,
     OFFER_STOCK_RESTORE_SERVICE_TOKEN,
     LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
     PRODUCT_PUBLISH_BUILDER_SERVICE_TOKEN,

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -24,6 +24,8 @@ export const OFFER_STATUS_SYNC_SERVICE_TOKEN = Symbol('IOfferStatusSyncService')
 export const OFFER_STATUS_SNAPSHOT_REPOSITORY_TOKEN = Symbol('OfferStatusSnapshotRepositoryPort');
 export const SELLER_POLICIES_SERVICE_TOKEN = Symbol('ISellerPoliciesService');
 export const SELLER_POLICIES_CACHE_TOKEN = Symbol('SellerPoliciesCacheRepositoryPort');
+// Responsible-producer read (#1531)
+export const RESPONSIBLE_PRODUCER_SERVICE_TOKEN = Symbol('IResponsibleProducerService');
 // Order-cancellation stock-restore (#1146)
 export const OFFER_STOCK_RESTORE_SERVICE_TOKEN = Symbol('IOfferStockRestoreService');
 // Shop publish (#1042, ADR-024)

--- a/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
+++ b/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
@@ -10,7 +10,11 @@
  * @module libs/integrations/erli/src/__tests__
  */
 import type { Connection } from '@openlinker/core/identifier-mapping';
-import { isOfferCreator, type OfferManagerPort } from '@openlinker/core/listings';
+import {
+  isOfferCreator,
+  isResponsibleProducerReader,
+  type OfferManagerPort,
+} from '@openlinker/core/listings';
 import type { OrderSourcePort } from '@openlinker/core/orders';
 import type { HostServices } from '@openlinker/plugin-sdk';
 import { createErliPlugin, erliAdapterManifest, ErliIntegrationModule } from '../index';
@@ -109,6 +113,10 @@ describe('erliAdapterManifest', () => {
     expect(erliAdapterManifest.supportedCapabilities).toContain('OfferCreator');
     // Erli has no offer-event journal — the offers-sync trigger stays hidden.
     expect(erliAdapterManifest.supportedCapabilities).not.toContain('OfferEventReader');
+  });
+
+  it('should advertise the ResponsibleProducerReader sub-capability so the wizard producer picker shows for Erli (#1531)', () => {
+    expect(erliAdapterManifest.supportedCapabilities).toContain('ResponsibleProducerReader');
   });
 
   it('should be the platform-default adapter', () => {
@@ -276,6 +284,16 @@ describe('createErliPlugin', () => {
       );
 
       expect(isOfferCreator(adapter)).toBe(true);
+    });
+
+    it('should resolve OfferManager to a responsible-producer-reader adapter (#1531)', async () => {
+      const adapter = await createErliPlugin().createCapabilityAdapter<OfferManagerPort>(
+        connection,
+        'OfferManager',
+        makeDispatchHost(),
+      );
+
+      expect(isResponsibleProducerReader(adapter)).toBe(true);
     });
 
     it('should resolve OrderSource to an order-source adapter (#993)', async () => {

--- a/libs/integrations/erli/src/erli-plugin.ts
+++ b/libs/integrations/erli/src/erli-plugin.ts
@@ -60,7 +60,16 @@ export const erliAdapterManifest: AdapterMetadata = {
   // already implements — advertised (no dispatch entry; callers narrow with
   // `isOfferCreator`) so FE offer-creation flows, gated on `OfferCreator`,
   // keep showing Erli after WooCommerce's quantity-only OfferManager landed.
-  supportedCapabilities: ['OfferManager', 'OrderSource', 'OfferCreator'],
+  // 'ResponsibleProducerReader' (#1531) is likewise an advertised-without-dispatch
+  // OfferManager sub-capability — the FE gates the producer picker on it; callers
+  // narrow the dispatched OfferManager adapter with `isResponsibleProducerReader`,
+  // never `getCapabilityAdapter('ResponsibleProducerReader')`.
+  supportedCapabilities: [
+    'OfferManager',
+    'OrderSource',
+    'OfferCreator',
+    'ResponsibleProducerReader',
+  ],
   displayName: 'Erli Shop API v1',
   version: '1.0.0',
   isDefault: true,

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -33,6 +33,7 @@ import type { IErliHttpClient } from '../../http/erli-http-client.interface';
 import {
   ErliOfferManagerAdapter,
   ERLI_FROZEN_STOCK_CACHE_TTL_SEC,
+  ERLI_RESPONSIBLE_PRODUCERS_CACHE_TTL_SEC,
 } from '../erli-offer-manager.adapter';
 
 const VALID_ID = `ol_variant_${'a'.repeat(32)}`;
@@ -1213,6 +1214,109 @@ describe('ErliOfferManagerAdapter', () => {
       await adapter.restoreStockOnCancellation([]);
 
       expect(httpClient.patch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchResponsibleProducers (#1531 — ResponsibleProducerReader)', () => {
+    it('maps GET /dictionaries/responsibleProducers items to neutral ResponsibleProducerEntry[]', async () => {
+      httpClient.get.mockResolvedValue({
+        status: 200,
+        data: [
+          { id: 1, name: 'ACME Sp. z o.o.' },
+          { id: 42, name: 'Importer Ltd' },
+        ],
+      });
+
+      const result = await adapter.fetchResponsibleProducers();
+
+      expect(httpClient.get).toHaveBeenCalledWith('dictionaries/responsibleProducers');
+      expect(result).toEqual([
+        { id: '1', name: 'ACME Sp. z o.o.', kind: 'PRODUCER' },
+        { id: '42', name: 'Importer Ltd', kind: 'PRODUCER' },
+      ]);
+    });
+
+    it('drops items without a usable name and tolerates an empty/bodyless response', async () => {
+      httpClient.get.mockResolvedValue({ status: 200, data: undefined });
+
+      await expect(adapter.fetchResponsibleProducers()).resolves.toEqual([]);
+    });
+
+    it('caches the mapped result per connection when a cache is wired', async () => {
+      const cache: jest.Mocked<CachePort> = {
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+      };
+      const cached = new ErliOfferManagerAdapter(
+        'conn-1',
+        ERLI_ADAPTER_KEY,
+        httpClient,
+        { period: 2, unit: 'day' },
+        cache,
+      );
+      httpClient.get.mockResolvedValue({ status: 200, data: [{ id: 7, name: 'Producent' }] });
+
+      const result = await cached.fetchResponsibleProducers();
+
+      expect(result).toEqual([{ id: '7', name: 'Producent', kind: 'PRODUCER' }]);
+      expect(cache.set).toHaveBeenCalledWith(
+        'erli:responsible-producers:conn-1',
+        [{ id: '7', name: 'Producent', kind: 'PRODUCER' }],
+        ERLI_RESPONSIBLE_PRODUCERS_CACHE_TTL_SEC,
+      );
+    });
+
+    it('returns the cached value without hitting the API on a cache hit', async () => {
+      const cache: jest.Mocked<CachePort> = {
+        get: jest.fn().mockResolvedValue([{ id: '9', name: 'Cached', kind: 'PRODUCER' }]),
+        set: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+      };
+      const cached = new ErliOfferManagerAdapter(
+        'conn-1',
+        ERLI_ADAPTER_KEY,
+        httpClient,
+        { period: 2, unit: 'day' },
+        cache,
+      );
+
+      const result = await cached.fetchResponsibleProducers();
+
+      expect(result).toEqual([{ id: '9', name: 'Cached', kind: 'PRODUCER' }]);
+      expect(httpClient.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('create body — responsible producer (#1531)', () => {
+    it('stamps the operator-selected producer id onto the create body', async () => {
+      await adapter.createOffer(createCmd({ overrides: { platformParams: { producer: '42' } } }));
+
+      const body = httpClient.post.mock.calls[0][1] as { producerId?: number };
+      expect(body.producerId).toBe(42);
+    });
+
+    it('accepts a numeric producer selection', async () => {
+      await adapter.createOffer(createCmd({ overrides: { platformParams: { producer: 7 } } }));
+
+      const body = httpClient.post.mock.calls[0][1] as { producerId?: number };
+      expect(body.producerId).toBe(7);
+    });
+
+    it('omits producerId when no selection is supplied', async () => {
+      await adapter.createOffer(createCmd());
+
+      const body = httpClient.post.mock.calls[0][1] as { producerId?: number };
+      expect(body.producerId).toBeUndefined();
+    });
+
+    it('ignores a blank or non-numeric producer selection', async () => {
+      await adapter.createOffer(
+        createCmd({ overrides: { platformParams: { producer: '   ' } } }),
+      );
+
+      const body = httpClient.post.mock.calls[0][1] as { producerId?: number };
+      expect(body.producerId).toBeUndefined();
     });
   });
 });

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -117,6 +117,8 @@ import {
   type OfferStatusReader,
   type OfferStockRestorer,
   type OfferStockRestoreTarget,
+  type ResponsibleProducerEntry,
+  type ResponsibleProducerReader,
   type TaxonomyBorrower,
   type TaxonomyOwner,
   type UpdateOfferFieldsCommand,
@@ -137,6 +139,7 @@ import type {
   ErliProductImage,
   ErliProductPatchBody,
   ErliProductResource,
+  ErliResponsibleProducerItem,
 } from './erli-product.types';
 
 /**
@@ -192,6 +195,14 @@ const ERLI_CONDITION_VALUE_IDS: Record<OfferCondition, string> = {
  */
 export const ERLI_FROZEN_STOCK_CACHE_TTL_SEC = 26 * 60 * 60;
 
+/**
+ * Responsible-producer cache TTL (#1531). The wizard reads this on each
+ * offer-create load; a short TTL keeps repeated loads off the Erli API without
+ * letting a newly-added producer stay hidden for long. Mirrors the ~10-min
+ * freshness the seller-policies read uses.
+ */
+export const ERLI_RESPONSIBLE_PRODUCERS_CACHE_TTL_SEC = 10 * 60;
+
 export class ErliOfferManagerAdapter
   implements
     OfferManagerPort,
@@ -199,7 +210,8 @@ export class ErliOfferManagerAdapter
     OfferFieldUpdater,
     OfferStatusReader,
     OfferStockRestorer,
-    TaxonomyBorrower
+    TaxonomyBorrower,
+    ResponsibleProducerReader
 {
   private readonly logger = new Logger(ErliOfferManagerAdapter.name);
 
@@ -359,6 +371,54 @@ export class ErliOfferManagerAdapter
     // (handled above → OfferNotFoundOnMarketplaceException) never reaches here.
     await this.writeFrozenStockFlag(externalOfferId, product.frozenFields);
     return mapErliStatusToReadResult(product);
+  }
+
+  /**
+   * ResponsibleProducerReader (#1531). Lists the seller's EU GPSR
+   * responsible-producer registry ("producent") from
+   * `GET /dictionaries/responsibleProducers` so the offer-creation wizard can
+   * render a picker; the operator's choice rides back on
+   * `overrides.platformParams.producer` and is stamped onto the create body so
+   * the created product is not blocked for a missing producer. Erli's dictionary
+   * carries no GPSR classification, so every entry maps to `'PRODUCER'`. Results
+   * are cached per connection for a short TTL to keep repeated wizard loads off
+   * the Erli API; a missing/failing cache simply falls through to a live read
+   * (fail-open).
+   */
+  async fetchResponsibleProducers(): Promise<ResponsibleProducerEntry[]> {
+    const cacheKey = `erli:responsible-producers:${this.connectionId}`;
+    if (this.cache) {
+      try {
+        const cached = await this.cache.get<ResponsibleProducerEntry[]>(cacheKey);
+        if (cached) {
+          return cached;
+        }
+      } catch (error) {
+        this.logger.debug(
+          `Responsible-producer cache read failed (live fetch) [connectionId=${this.connectionId}]: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+    const res = await this.httpClient.get<ErliResponsibleProducerItem[]>(
+      'dictionaries/responsibleProducers',
+    );
+    const items: ResponsibleProducerEntry[] = (res.data ?? [])
+      .filter((item) => typeof item?.name === 'string' && item.name.length > 0)
+      .map((item) => ({ id: String(item.id), name: item.name, kind: 'PRODUCER' as const }));
+    if (this.cache) {
+      try {
+        await this.cache.set(cacheKey, items, ERLI_RESPONSIBLE_PRODUCERS_CACHE_TTL_SEC);
+      } catch (error) {
+        this.logger.debug(
+          `Responsible-producer cache write failed (ignored) [connectionId=${this.connectionId}]: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+    return items;
   }
 
   /**
@@ -578,6 +638,14 @@ export class ErliOfferManagerAdapter
     };
     if (cmd.overrides?.description != null) {
       body.description = flattenDescription(cmd.overrides.description);
+    }
+    // #1531 — operator-selected responsible producer ("producent"). Erli keys it
+    // by the numeric dictionary id (`producerId`); absent ⇒ omit (the product
+    // stays blocked for a missing producer until the operator picks one,
+    // mirroring the dispatchTime/deliveryPriceList opt-in posture).
+    const producerId = readProducerParam(cmd.overrides?.platformParams);
+    if (producerId !== undefined) {
+      body.producerId = producerId;
     }
     if (cmd.variantBarcode != null) {
       body.ean = cmd.variantBarcode;
@@ -802,6 +870,33 @@ function readDispatchTimeParam(
   return candidate.unit === undefined
     ? { period }
     : { period, unit: candidate.unit as ErliDispatchTime['unit'] };
+}
+
+/**
+ * Read a per-offer `producer` selection off the un-modeled
+ * `overrides.platformParams` (#1531). The wizard carries the numeric Erli
+ * responsible-producer dictionary id as a string; this returns it as a positive
+ * integer for `body.producerId`, or `undefined` when absent/blank (no selection
+ * ⇒ the create body omits the field). A non-numeric value is ignored rather than
+ * thrown — the picker only ever emits a dictionary id, and a product with no
+ * producer is a valid (if blocked-until-set) create.
+ */
+function readProducerParam(
+  platformParams: Record<string, unknown> | undefined,
+): number | undefined {
+  const raw = platformParams?.producer;
+  if (typeof raw === 'number') {
+    return Number.isInteger(raw) && raw > 0 ? raw : undefined;
+  }
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  const parsed = Number(trimmed);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -120,6 +120,18 @@ export interface ErliProductCreateBody {
   ean?: string;
   sku?: string;
   dispatchTime?: ErliDispatchTime;
+  /**
+   * Responsible producer ("producent") the product references (#1531). Erli
+   * keys it by the numeric responsible-producer dictionary id
+   * (`GET /dictionaries/responsibleProducers`); without it the created product
+   * is blocked for a missing producer. Supplied when the neutral command carries
+   * an operator selection (`overrides.platformParams.producer`); omitted
+   * otherwise. Erli's schema documents `producerId` as deprecated in favour of
+   * the `externalResponsibleProducer` `{ externalId, source }` array, but the
+   * numeric id maps 1:1 to a dictionary entry (which the picker reads), so it is
+   * the direct and reliable reference here.
+   */
+  producerId?: number;
   /** Allegro category reuse (#985); omitted when empty. */
   externalCategories?: ErliExternalCategory[];
   /** Allegro parameter reuse (#985); omitted when empty. */
@@ -167,6 +179,18 @@ export type ErliProductPatchBody = Pick<
  * neutral closed `OfferPublicationStatus` union.
  */
 export type ErliProductStatus = 'accepted' | 'active' | 'inactive' | 'rejected';
+
+/**
+ * One item from `GET /dictionaries/responsibleProducers` (#1531). Erli returns
+ * the `ResponsibleSchema` shape (`{ id: integer, name: string, ... }`); only the
+ * `id` (referenced by the create body's `producerId`) and `name` (picker label)
+ * are consumed. Verified against `docs/architecture/adrs/erli-sandbox-swagger.json`
+ * (`ResponsibleSchema`, "pobierz listę producentów produktu").
+ */
+export interface ErliResponsibleProducerItem {
+  id: number;
+  name: string;
+}
 
 export interface ErliProductResource {
   /**


### PR DESCRIPTION
## What & why

An Erli product/offer created through OpenLinker is blocked for a missing **producer ("producent") / responsible person** until one is set manually in Erli. This adds an operator-selectable **producer picker** to the offer-creation wizard, with options **fetched live from Erli** (never hardcoded), and threads the selection into the Erli product-create body so the created product carries its producer.

Built as the direct sibling of the delivery-price-list flow (#1530), reusing the EU GPSR `ResponsibleProducerReader` capability that already exists in core (#430, previously only surfaced on the Allegro connection-settings page).

## Vertical slice

- **core (`listings`)** - `ResponsibleProducerService` + `IResponsibleProducerService` + `RESPONSIBLE_PRODUCER_SERVICE_TOKEN`. Resolves the connection's `OfferManager` adapter and narrows it to the existing `ResponsibleProducerReader` sub-capability (returns the neutral `ResponsibleProducerEntry { id, name, kind }[]`). Capability + types are reused as-is; no new capability file.
- **api** - `GET /listings/connections/:connectionId/responsible-producers` (sibling of `.../seller-policies`), wrapping the result under `responsibleProducers`. New `ResponsibleProducersResponseDto`.
- **erli plugin** - `ErliOfferManagerAdapter` now `implements ResponsibleProducerReader`: `fetchResponsibleProducers()` reads `GET /dictionaries/responsibleProducers` (cached per connection, fail-open), and `buildCreateBody` maps the neutral `overrides.platformParams.producer` selection onto `producerId`. Manifest advertises `ResponsibleProducerReader` (narrow-only via `isResponsibleProducerReader`, no dispatch-table entry - same posture as `OfferCreator`).
- **web (`features/listings`)** - `useResponsibleProducersQuery` + shared `ErliProducerField`, wired into:
  - the **single** wizard (a Producer picker among product details);
  - the **bulk config** step (batch default applied to every row);
  - the **bulk per-row edit modal** (`erli-bulk-row-section`) - a per-product override that inherits the batch default by default and offers a "Reset to batch default" affordance; per-row wins over the batch default at submit.
  - English label "Producer", helper "Responsible producer shown on the Erli product card. Fetched from Erli.", empty state "No producers on this Erli account - add one in Erli, then reload." Only shown for an Erli connection.

## Carry-through (marketplace-neutral)

The selection rides the neutral `overrides.platformParams.producer` escape hatch (batch default + per-row override, per-row wins), so core stays platform-agnostic and the Erli adapter owns the neutral->wire mapping. **No change to `CreateOfferCommand` or the create-offer DTO.**

## Erli API / wire shape

Modelled from the committed sandbox OpenAPI (`docs/architecture/adrs/erli-sandbox-swagger.json`):
- read: `GET /dictionaries/responsibleProducers` -> `ResponsibleSchema[]` (`{ id: integer, name, ... }`, summary "pobierz listę producentów produktu"). Erli's schema has no GPSR classification, so every entry maps to `kind: 'PRODUCER'`.
- write: `ProductCreate.producerId` (integer, the direct 1:1 reference to the dictionary `id` the picker reads). The swagger documents `producerId` as deprecated in favour of the `externalResponsibleProducer` `{ externalId, source }` array, but that path needs a `source` we cannot reliably derive for a dictionary-picked producer, whereas `producerId` maps cleanly to the option the operator selected. Flagged here as the one assumption to confirm against live Erli.

## Tests

- core: `responsible-producer.service.spec.ts` (adapter resolution, capability gating, error propagation).
- api: `getResponsibleProducers` controller test.
- erli: adapter `fetchResponsibleProducers` (mapping, empty/bodyless tolerance, per-connection cache hit/miss) + create-body `producerId` mapping (string/number/blank/absent); plugin manifest + `isResponsibleProducerReader` narrowing.
- web: `ErliProducerField` (fetch, options, empty state, onChange); `ErliBulkRowSection` per-row inherit/override/reset; request-to-form-values producer round-trip.

## Quality gate

`pnpm type-check` (core, erli, api, web) and `pnpm lint` (incl. `check:invariants` - cross-context imports + service-interfaces) pass with zero errors. Scoped unit tests for every touched package pass. (One unrelated pre-existing web failure, `settings-page.test.tsx`, is an env-default assertion untouched by this branch.)

Closes #1531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZPSZVQQeFiDEJVG41c1nE