### PR TITLE
test(ksef): de-flake aes-cipher wrong-key spec

### DIFF
--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/aes-cipher.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/aes-cipher.spec.ts
@@ -38,12 +38,14 @@ describe('aes-cipher', () => {
     const plaintext = 'secret';
     const ciphertext = encryptAesCbc(plaintext, key, iv);
     const wrongKey = new Uint8Array(randomBytes(KSEF_AES_KEY_BYTES));
+    let result: string | undefined;
     try {
-      const result = decryptAesCbc(ciphertext, wrongKey, iv);
-      expect(result).not.toBe(plaintext);
+      result = decryptAesCbc(ciphertext, wrongKey, iv);
     } catch (err) {
       expect(err).toBeInstanceOf(KsefSessionCryptoException);
+      return;
     }
+    expect(result).not.toBe(plaintext);
   });
 
   it('should throw KsefSessionCryptoException when the ciphertext length is not a multiple of the block size', () => {

--- a/libs/integrations/ksef/src/infrastructure/crypto/__tests__/aes-cipher.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/crypto/__tests__/aes-cipher.spec.ts
@@ -31,9 +31,25 @@ describe('aes-cipher', () => {
     expect(() => encryptAesCbc('x', key, new Uint8Array(8))).toThrow(KsefSessionCryptoException);
   });
 
-  it('should throw KsefSessionCryptoException when decrypting with the wrong key', () => {
-    const ciphertext = encryptAesCbc('secret', key, iv);
+  it('should never recover the plaintext when decrypting with the wrong key', () => {
+    // CBC has no key verification: a wrong key usually fails PKCS#7 padding
+    // validation (throws), but ~0.4% of random keys yield accidentally valid
+    // padding and return garbage instead. Both outcomes are legal (#1538).
+    const plaintext = 'secret';
+    const ciphertext = encryptAesCbc(plaintext, key, iv);
     const wrongKey = new Uint8Array(randomBytes(KSEF_AES_KEY_BYTES));
-    expect(() => decryptAesCbc(ciphertext, wrongKey, iv)).toThrow(KsefSessionCryptoException);
+    try {
+      const result = decryptAesCbc(ciphertext, wrongKey, iv);
+      expect(result).not.toBe(plaintext);
+    } catch (err) {
+      expect(err).toBeInstanceOf(KsefSessionCryptoException);
+    }
+  });
+
+  it('should throw KsefSessionCryptoException when the ciphertext length is not a multiple of the block size', () => {
+    // decipher.final() always throws on a truncated ciphertext, so this covers
+    // the wrapping path of decryptAesCbc deterministically.
+    const truncated = encryptAesCbc('secret', key, iv).slice(0, -1);
+    expect(() => decryptAesCbc(truncated, key, iv)).toThrow(KsefSessionCryptoException);
   });
 });


### PR DESCRIPTION
## What / Why

The KSeF unit test `aes-cipher > should throw KsefSessionCryptoException when decrypting with the wrong key` was inherently flaky (~0.4% of CI runs). AES-256-CBC has no built-in key verification: decrypting with a random wrong key produces pseudo-random bytes that end in accidentally valid PKCS#7 padding with probability ~1/256 (+ smaller contributions from longer paddings), in which case `decryptAesCbc` returns garbage instead of throwing and the `toThrow` assertion failed. Observed on PR #1515 CI run 29322744163, which touched only a workflow file.

Test-only fix, per the issue:

- The wrong-key test now asserts the actual CBC contract: either `decryptAesCbc` throws `KsefSessionCryptoException`, or it returns a value different from the original plaintext (`'secret'`). Both are legal outcomes.
- A new deterministic test covers the `KsefSessionCryptoException` wrapping path: a ciphertext truncated by 1 byte is not a multiple of the AES block size, so `decipher.final()` always throws.

No changes to `aes-cipher.ts`.

## Verification

- `jest --testPathPattern aes-cipher` in `@openlinker/integrations-ksef`: 6/6 tests pass.
- Flake-proof loop driving the real `encryptAesCbc`/`decryptAesCbc` functions directly:
  - 100,000 wrong-key iterations: 99,626 threw `KsefSessionCryptoException`, 374 returned garbage (the ~0.4% case that used to fail CI - now asserted as legal), 0 failures.
  - 10,000 truncated-ciphertext iterations: 10,000/10,000 threw `KsefSessionCryptoException` (deterministic).
- Scoped lint (`eslint` on the spec) and `pnpm --filter @openlinker/integrations-ksef... build` (tsc -b) pass.

Closes #1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)
