### PR TITLE
feat(inpost): close shipping adapter feature gaps (#1540)

### DIFF
--- a/apps/api/src/shipping/http/dto/generate-label.dto.spec.ts
+++ b/apps/api/src/shipping/http/dto/generate-label.dto.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * GenerateLabelDto validation spec
+ *
+ * Focused on the optional insured-value block (#1542): the field is absent-safe
+ * and, when present, enforces a positive decimal amount + a non-empty currency
+ * (mirroring the ShipmentCodDto decorators). Uses class-validator against a
+ * plain-to-class instance, the same path Nest's ValidationPipe runs.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { GenerateLabelDto } from './generate-label.dto';
+
+function basePayload(): Record<string, unknown> {
+  return {
+    sourceConnectionId: 'a1111111-1111-4111-8111-111111111111',
+    orderId: 'ol_order_abc',
+    deliveryIntent: 'address',
+    recipient: { email: 'buyer@example.com', phone: '+48123456789' },
+    parcel: { weightGrams: 1000 },
+  };
+}
+
+async function errorsFor(payload: Record<string, unknown>): Promise<string[]> {
+  const dto = plainToInstance(GenerateLabelDto, payload);
+  const errors = await validate(dto, { whitelist: true });
+  // Flatten every constraint key across the (possibly nested) error tree.
+  const collect = (es: typeof errors): string[] =>
+    es.flatMap((e) => [
+      ...Object.keys(e.constraints ?? {}),
+      ...collect(e.children ?? []),
+    ]);
+  return collect(errors);
+}
+
+describe('GenerateLabelDto — insuredValue validation (#1542)', () => {
+  it('should accept a payload with no insuredValue (field is optional)', async () => {
+    expect(await errorsFor(basePayload())).toHaveLength(0);
+  });
+
+  it('should accept a valid insured value (positive decimal amount + currency)', async () => {
+    expect(
+      await errorsFor({ ...basePayload(), insuredValue: { amount: '150.00', currency: 'PLN' } }),
+    ).toHaveLength(0);
+  });
+
+  it('should reject a non-decimal insured amount', async () => {
+    const errors = await errorsFor({
+      ...basePayload(),
+      insuredValue: { amount: 'abc', currency: 'PLN' },
+    });
+    expect(errors).toContain('matches');
+  });
+
+  it('should reject an insured value missing its currency', async () => {
+    const errors = await errorsFor({
+      ...basePayload(),
+      insuredValue: { amount: '150.00' },
+    });
+    expect(errors).toContain('isNotEmpty');
+  });
+});

--- a/apps/api/src/shipping/http/dto/generate-label.dto.ts
+++ b/apps/api/src/shipping/http/dto/generate-label.dto.ts
@@ -142,6 +142,22 @@ class ShipmentCodDto {
   currency!: string;
 }
 
+class ShipmentInsuredValueDto {
+  @ApiProperty({ description: 'Declared value to insure, as a decimal string (e.g. "150.00")' })
+  @IsString()
+  @IsNotEmpty()
+  // Defense-in-depth: the FE gates the decimal shape, but the API has other
+  // potential clients — reject a malformed amount here so it never reaches the
+  // carrier (mirrors ShipmentCodDto, #1542).
+  @Matches(/^\d+(\.\d{1,2})?$/, { message: 'Insured amount must be a decimal string, e.g. "150.00"' })
+  amount!: string;
+
+  @ApiProperty({ description: 'ISO 4217 currency code (e.g. PLN). Carrier validates the supported set.' })
+  @IsString()
+  @IsNotEmpty()
+  currency!: string;
+}
+
 export class GenerateLabelDto {
   @ApiProperty({ description: 'Order-source connection id (the routing rule scope)' })
   @IsUUID()
@@ -208,4 +224,15 @@ export class GenerateLabelDto {
   @ValidateNested()
   @Type(() => ShipmentCodDto)
   cod?: ShipmentCodDto;
+
+  @ApiPropertyOptional({
+    type: ShipmentInsuredValueDto,
+    description:
+      'Declared value to insure the parcel for (operator-supplied, #1542). ' +
+      'Insurance-incapable carriers ignore it; InPost ShipX translates it to its `insurance` object.',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ShipmentInsuredValueDto)
+  insuredValue?: ShipmentInsuredValueDto;
 }

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -280,6 +280,28 @@ describe('ShipmentController', () => {
       expect((dispatch.dispatch.mock.calls[0][0] as { cod?: unknown }).cod).toBeUndefined();
     });
 
+    it('should pass the insured value through to the dispatch input when supplied (#1542)', async () => {
+      dispatch.dispatch.mockResolvedValue({ kind: 'dispatched', shipment: makeShipment() });
+
+      await controller.generateLabel(
+        makeGenerateLabelDto({ insuredValue: { amount: '150.00', currency: 'PLN' } }),
+      );
+
+      expect(dispatch.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ insuredValue: { amount: '150.00', currency: 'PLN' } }),
+      );
+    });
+
+    it('should leave insuredValue undefined on the dispatch input when not supplied (#1542)', async () => {
+      dispatch.dispatch.mockResolvedValue({ kind: 'dispatched', shipment: makeShipment() });
+
+      await controller.generateLabel(makeGenerateLabelDto());
+
+      expect(
+        (dispatch.dispatch.mock.calls[0][0] as { insuredValue?: unknown }).insuredValue,
+      ).toBeUndefined();
+    });
+
     it('should map UndispatchableResolutionException to 422', async () => {
       dispatch.dispatch.mockRejectedValue(new UndispatchableResolutionException('no connection'));
       await expect(controller.generateLabel(makeGenerateLabelDto())).rejects.toBeInstanceOf(

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -637,6 +637,8 @@ describe('ShipmentController', () => {
       ['application/zpl', 'zpl'],
       ['application/x-zpl', 'zpl'],
       ['application/epl', 'epl'],
+      ['application/zip', 'zip'],
+      ['application/zip; charset=binary', 'zip'],
       ['', 'bin'],
       ['application/octet-stream', 'bin'],
     ])('maps %s → %s', (ct, ext) => {

--- a/apps/api/src/shipping/http/shipment.controller.ts
+++ b/apps/api/src/shipping/http/shipment.controller.ts
@@ -217,6 +217,9 @@ export class ShipmentController {
       parcel: dto.parcel,
       // COD pass-through (#966) — caller-supplied; COD-incapable adapters ignore it.
       cod: dto.cod,
+      // Insurance pass-through (#1542) — caller-supplied; insurance-incapable
+      // adapters ignore it, insurance-capable ones (InPost ShipX) translate it.
+      insuredValue: dto.insuredValue,
     };
     try {
       const result = await this.dispatch.dispatch(input);

--- a/apps/api/src/shipping/http/shipment.controller.ts
+++ b/apps/api/src/shipping/http/shipment.controller.ts
@@ -442,8 +442,9 @@ export class ShipmentController {
 /**
  * Map a label document's MIME type to a download-filename extension. The label
  * bytes are NOT always PDF — Allegro returns ZPL/EPL per the seller's "Ship
- * with Allegro" setting and InPost ShipX can return PNG — so the saved file
- * must be labelled by its actual content type, never hardcoded to `.pdf`.
+ * with Allegro" setting, InPost ShipX can return PNG, and a multi-service
+ * dispatch protocol comes back as a ZIP — so the saved file must be labelled
+ * by its actual content type, never hardcoded to `.pdf`.
  * Falls back to `bin` for anything unrecognised so the download never claims a
  * format it isn't.
  */
@@ -461,6 +462,8 @@ export function extensionForContentType(contentType: string): string {
     case 'application/epl':
     case 'application/x-epl':
       return 'epl';
+    case 'application/zip':
+      return 'zip';
     default:
       return 'bin';
   }

--- a/apps/web/src/features/orders/components/generate-label-form.schema.ts
+++ b/apps/web/src/features/orders/components/generate-label-form.schema.ts
@@ -21,6 +21,16 @@ export const COD_CURRENCY_VALUES = ['PLN', 'EUR', 'RON', 'CZK'] as const;
 export type CodCurrency = (typeof COD_CURRENCY_VALUES)[number];
 
 /**
+ * Currencies accepted for declared-value insurance (#1542). InPost ShipX
+ * insurance is a domestic-PL service (`PLN`-only) — the BE mapper rejects any
+ * other value. Kept as its own list (not reusing `COD_CURRENCY_VALUES`) so the
+ * insurance picker only offers what the carrier accepts; widen here if a second
+ * insurance-capable carrier with a broader set ships.
+ */
+export const INSURED_CURRENCY_VALUES = ['PLN'] as const;
+export type InsuredCurrency = (typeof INSURED_CURRENCY_VALUES)[number];
+
+/**
  * InPost locker size templates. A paczkomat shipment is described by a locker
  * size (`parcel.template`), not per-item dimensions — the order carries no
  * reliable dimensions. The BE adapter rejects a paczkomat shipment without it.
@@ -48,6 +58,17 @@ export const generateLabelSchema = z.object({
     ])
     .optional(),
   codCurrency: z.enum(COD_CURRENCY_VALUES).optional(),
+  // Optional declared-value / insurance (operator-supplied, #1542). Empty amount
+  // ⇒ no insurance. Insurance-incapable carriers ignore it server-side; InPost
+  // ShipX translates it to its `insurance` object. Amount accepts a decimal
+  // string (comma or dot) — normalised at submit, mirroring COD.
+  insuredAmount: z
+    .union([
+      z.string().trim().regex(/^\d+([.,]\d{1,2})?$/, 'Enter a valid amount, e.g. 150.00'),
+      z.literal(''),
+    ])
+    .optional(),
+  insuredCurrency: z.enum(INSURED_CURRENCY_VALUES).optional(),
 });
 
 // Two derived types: `Values` is what RHF binds to (Zod's input type — for

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -324,6 +324,51 @@ describe('GenerateLabelForm — happy path', () => {
     expect((generateLabel.mock.calls[0][0] as { cod?: unknown }).cod).toBeUndefined();
   });
 
+  it('should send the insured value and normalise the decimal when supplied (#1542)', async () => {
+    const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
+    const apiClient = createMockApiClient({ shipments: { generateLabel } });
+    renderWithProviders(<GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />, {
+      apiClient,
+    });
+
+    const insuredInput = screen.getByLabelText(/Declared value to insure/i);
+    expect(insuredInput).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+    fireEvent.change(insuredInput, { target: { value: '150,00' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() =>
+      expect(generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ insuredValue: { amount: '150.00', currency: 'PLN' } }),
+      ),
+    );
+  });
+
+  it('should omit the insured value when the amount is left blank (#1542)', async () => {
+    const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
+    const apiClient = createMockApiClient({ shipments: { generateLabel } });
+    renderWithProviders(<GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />, {
+      apiClient,
+    });
+
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() => expect(generateLabel).toHaveBeenCalled());
+    expect(
+      (generateLabel.mock.calls[0][0] as { insuredValue?: unknown }).insuredValue,
+    ).toBeUndefined();
+  });
+
   it('should send parcel.template (locker size, default medium) for a paczkomat order (#1423)', async () => {
     const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
     const apiClient = createMockApiClient({ shipments: { generateLabel } });

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -53,6 +53,7 @@ import {
 } from '../../shipments';
 import {
   COD_CURRENCY_VALUES,
+  INSURED_CURRENCY_VALUES,
   LOCKER_TEMPLATE_VALUES,
   generateLabelSchema,
   type GenerateLabelFormSubmission,
@@ -198,6 +199,9 @@ export function GenerateLabelForm({
       // manual input shown for a COD order with no sourced amount.
       codAmount: '',
       codCurrency: 'PLN',
+      // Declared-value / insurance (#1542) — operator-supplied, blank ⇒ none.
+      insuredAmount: '',
+      insuredCurrency: 'PLN',
     },
     resolver: zodResolver(generateLabelSchema),
   });
@@ -212,6 +216,8 @@ export function GenerateLabelForm({
   const paczkomatRegister = form.register('paczkomatId');
   const codAmountRegister = form.register('codAmount');
   const codCurrencyRegister = form.register('codCurrency');
+  const insuredAmountRegister = form.register('insuredAmount');
+  const insuredCurrencyRegister = form.register('insuredCurrency');
   // Locker size is driven imperatively via a segmented control (#1425). The
   // registration is bound to a hidden input at the control (so RHF holds a real
   // ref and tracks the field); the pressed state is set via `setValue` and read
@@ -273,6 +279,14 @@ export function GenerateLabelForm({
           ? { amount: values.codAmount, currency: values.codCurrency ?? 'PLN' }
           : undefined;
 
+    // Declared-value / insurance (#1542) — operator-supplied, not payment-gated
+    // (unlike COD). Blank amount ⇒ no insurance. The BE mapper re-validates the
+    // amount/currency and rejects a non-PLN insured value.
+    const insuredValue =
+      values.insuredAmount && values.insuredAmount.length > 0
+        ? { amount: values.insuredAmount, currency: values.insuredCurrency ?? 'PLN' }
+        : undefined;
+
     const input: GenerateLabelInput = {
       sourceConnectionId: order.sourceConnectionId,
       ...buildDispatchItem({
@@ -288,6 +302,7 @@ export function GenerateLabelForm({
         },
         paczkomatId: values.paczkomatId,
         cod,
+        insuredValue,
       }),
     };
     try {
@@ -584,6 +599,41 @@ export function GenerateLabelForm({
             )}
           </div>
         ) : null}
+
+        {/* Declared value / insurance (#1542) — operator-supplied, always
+            available (not payment-gated, unlike COD). Blank amount ⇒ no
+            insurance. Insurance-incapable carriers ignore it server-side; InPost
+            ShipX translates it to its `insurance` object. */}
+        <div className="form-field generate-label-form__insured-panel">
+          <div className="generate-label-form__insured-head">
+            <StatusBadge tone="info" withDot>
+              Insurance
+            </StatusBadge>
+          </div>
+          <p className="generate-label-form__insured-note">
+            Declared value to insure the parcel for. Leave blank for the carrier default.
+          </p>
+          <div className="generate-label-form__insured">
+            <Input
+              {...insuredAmountRegister}
+              inputMode="decimal"
+              placeholder="150.00"
+              aria-label="Declared value to insure"
+              invalid={Boolean(form.formState.errors.insuredAmount)}
+            />
+            <Select {...insuredCurrencyRegister} aria-label="Insurance currency">
+              {INSURED_CURRENCY_VALUES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <FieldError
+            id="insured-error"
+            message={form.formState.errors.insuredAmount?.message}
+          />
+        </div>
 
         {showSlowNotice ? (
           <div role="status" aria-live="polite" className="generate-label-form__slow-notice">

--- a/apps/web/src/features/orders/lib/dispatch-input.test.ts
+++ b/apps/web/src/features/orders/lib/dispatch-input.test.ts
@@ -202,6 +202,27 @@ describe('buildDispatchItem', () => {
     });
     expect(item.cod).toEqual({ amount: '129.90', currency: 'PLN' });
   });
+
+  it('normalises a comma decimal in the insured value amount (#1542)', () => {
+    const item = buildDispatchItem({
+      order: order({ snapshot: COURIER_SNAPSHOT }),
+      snapshot: parseOrderSnapshot(COURIER_SNAPSHOT),
+      shippingMethod: 'kurier',
+      parcel: { length: 1, width: 1, height: 1, weightGrams: 1 },
+      insuredValue: { amount: '150,00', currency: 'PLN' },
+    });
+    expect(item.insuredValue).toEqual({ amount: '150.00', currency: 'PLN' });
+  });
+
+  it('omits the insured value when none is supplied (#1542)', () => {
+    const item = buildDispatchItem({
+      order: order({ snapshot: COURIER_SNAPSHOT }),
+      snapshot: parseOrderSnapshot(COURIER_SNAPSHOT),
+      shippingMethod: 'kurier',
+      parcel: { length: 1, width: 1, height: 1, weightGrams: 1 },
+    });
+    expect(item.insuredValue).toBeUndefined();
+  });
 });
 
 describe('groupBy', () => {

--- a/apps/web/src/features/orders/lib/dispatch-input.ts
+++ b/apps/web/src/features/orders/lib/dispatch-input.ts
@@ -110,8 +110,9 @@ export function buildDispatchItem(args: {
   parcel: DispatchParcel;
   paczkomatId?: string;
   cod?: { amount: string; currency: string };
+  insuredValue?: { amount: string; currency: string };
 }): BulkDispatchItem {
-  const { order, snapshot, shippingMethod, parcel, paczkomatId, cod } = args;
+  const { order, snapshot, shippingMethod, parcel, paczkomatId, cod, insuredValue } = args;
   const a = snapshot.shippingAddress;
 
   const address =
@@ -149,6 +150,10 @@ export function buildDispatchItem(args: {
     cod:
       cod && cod.amount.length > 0
         ? { amount: cod.amount.replace(',', '.'), currency: cod.currency }
+        : undefined,
+    insuredValue:
+      insuredValue && insuredValue.amount.length > 0
+        ? { amount: insuredValue.amount.replace(',', '.'), currency: insuredValue.currency }
         : undefined,
   };
 }

--- a/apps/web/src/features/shipments/api/shipments.types.ts
+++ b/apps/web/src/features/shipments/api/shipments.types.ts
@@ -169,6 +169,15 @@ export interface GenerateLabelInput {
     /** ISO 4217 currency code (e.g. PLN). */
     currency: string;
   };
+  /** Optional declared value to insure the parcel for (operator-supplied, #1542).
+   * Insurance-incapable carriers ignore it server-side; InPost ShipX translates
+   * it to its `insurance` object. */
+  insuredValue?: {
+    /** Amount as a decimal string (e.g. "150.00"). */
+    amount: string;
+    /** ISO 4217 currency code (e.g. PLN). */
+    currency: string;
+  };
 }
 
 /** `POST /shipments/generate-label` response — mirrors `DispatchResultResponseDto`. */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9088,6 +9088,36 @@ html[data-density='compact'] .status-badge {
   margin-top: var(--space-2);
 }
 
+/* ── Declared-value / insurance panel (#1542) ───────────────────────────────
+ * Operator-supplied insured value. Mirrors the COD manual-input panel visually
+ * (same neutral recap container + StatusBadge pill) but is always shown and not
+ * payment-gated — insurance is a free operator choice, not a payment mode. */
+.generate-label-form__insured-panel {
+  background: var(--bg-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+}
+
+.generate-label-form__insured-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.generate-label-form__insured-note {
+  margin: var(--space-1) 0 0;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+}
+
+.generate-label-form__insured {
+  display: grid;
+  grid-template-columns: 1fr 7rem;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
 .generate-label-form__slow-notice {
   font-size: 0.8125rem;
   color: var(--text-secondary);

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -411,6 +411,29 @@ describe('ShipmentDispatchService', () => {
       expect(adapter.generateLabel).toHaveBeenCalledWith(expect.objectContaining({ cod: undefined }));
     });
 
+    it('should forward the caller-supplied insured value to the adapter unchanged (#1542)', async () => {
+      primeCodDispatch();
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord('paid'));
+
+      const insuredValue = { amount: '150.00', currency: 'PLN' };
+      await service.dispatch(makeInput({ insuredValue }));
+
+      expect(adapter.generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ insuredValue }),
+      );
+    });
+
+    it('should forward insuredValue as undefined when the caller omits it (#1542)', async () => {
+      primeCodDispatch();
+      orders.getOrderRecord.mockResolvedValue(makeOrderRecord('paid'));
+
+      await service.dispatch(makeInput());
+
+      expect(adapter.generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ insuredValue: undefined }),
+      );
+    });
+
     it('should dispatch source_brokered through the identical path (no rework for #833)', async () => {
       routing.resolve.mockResolvedValue(
         resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.SourceBrokered, processorConnectionId: SOURCE }),

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
@@ -318,6 +318,10 @@ export class ShipmentDispatchService implements IShipmentDispatchService {
         deliveryMethodId: this.resolveProviderDeliveryMethodId(input),
         recipient: input.recipient,
         parcel: input.parcel,
+        // Declared-value / insurance (#1542) — caller-supplied pass-through,
+        // not order-sourced (unlike COD below). Insurance-incapable adapters
+        // ignore it; insurance-capable ones (InPost ShipX) translate it.
+        insuredValue: input.insuredValue,
         // Payment-status-authorized COD (#1435): stripped for non-COD orders,
         // sourced from the order when available, caller amount only as fallback.
         // COD-incapable adapters ignore it; COD-capable ones translate it.

--- a/libs/core/src/shipping/domain/ports/capabilities/dispatch-protocol-reader.capability.ts
+++ b/libs/core/src/shipping/domain/ports/capabilities/dispatch-protocol-reader.capability.ts
@@ -17,9 +17,10 @@
  * inventing a near-identical "ProtocolDocument" type.
  *
  * Carrier-neutral and OPTIONAL: carriers with no handover-manifest concept
- * (e.g. InPost) simply don't implement it, and the bulk-dispatch protocol
- * endpoint reports the gap rather than failing. Allegro Delivery (#831) reuses
- * this exact capability for its dispatch manifest.
+ * simply don't implement it, and the bulk-dispatch protocol endpoint reports
+ * the gap rather than failing. InPost implements it via ShipX
+ * `dispatch_orders/printouts` (#1543); Allegro Delivery (#831) reuses this
+ * exact capability for its dispatch manifest.
  *
  * @module libs/core/src/shipping/domain/ports/capabilities
  */

--- a/libs/core/src/shipping/domain/types/generate-label.types.ts
+++ b/libs/core/src/shipping/domain/types/generate-label.types.ts
@@ -23,6 +23,7 @@ import type { ShippingMethod } from './shipping-method.types';
 import type { ShipmentRecipient } from './shipment-recipient.types';
 import type { ShipmentParcel } from './shipment-parcel.types';
 import type { ShipmentCod } from './shipment-cod.types';
+import type { ShipmentInsuredValue } from './shipment-insured-value.types';
 
 export interface GenerateLabelCommand {
   /** Internal Shipment id (`ol_shipment_*`). */
@@ -59,6 +60,11 @@ export interface GenerateLabelCommand {
    * that don't support COD ignore it; COD-capable adapters (DPD Polska #962)
    * translate it to their provider's wire format. */
   cod?: ShipmentCod;
+  /** Declared value to insure the parcel for. Carrier-neutral and
+   * **caller-supplied** (operator input), not order-sourced — adapters that
+   * don't support insurance ignore it; insurance-capable adapters (InPost ShipX
+   * #1542) translate it to their provider's wire format. */
+  insuredValue?: ShipmentInsuredValue;
 }
 
 export interface GenerateLabelResult {

--- a/libs/core/src/shipping/domain/types/shipment-insured-value.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment-insured-value.types.ts
@@ -1,0 +1,32 @@
+/**
+ * Shipment Insured-Value (Declared-Value / Insurance) Types
+ *
+ * Carrier-neutral declared-value / insurance descriptor for a label-generation
+ * command. Lives in core/shipping so every shipping adapter that supports an
+ * insured value (InPost ShipX #1542, future couriers) maps from one canonical
+ * shape; the adapter translates it to its provider's wire format (e.g. ShipX's
+ * `insurance` object with a numeric `amount` + `currency`).
+ *
+ * Like `ShipmentCod` / `ShipmentRecipient` / `ShipmentParcel`, this is its own
+ * one-shape-per-file type (engineering-standards §"Type Definitions in Separate
+ * Files"); it is referenced as the optional `GenerateLabelCommand.insuredValue`
+ * field.
+ *
+ * **Caller-supplied, not order-sourced.** The insured value is part of the
+ * label payload the dispatch caller owns (operator input), exactly like
+ * `recipient` / `parcel` / `cod` — it is NOT derived from a persisted `Order`
+ * in the dispatch seam.
+ *
+ * `amount` is a decimal **string** (not a number) so the value crosses the
+ * adapter boundary without binary float rounding (`'150.00'`, not `150.0`),
+ * mirroring `ShipmentCod.amount`.
+ *
+ * @module libs/core/src/shipping/domain/types
+ */
+
+export interface ShipmentInsuredValue {
+  /** Declared value to insure, as a decimal string (e.g. `'150.00'`). */
+  amount: string;
+  /** ISO 4217 currency code (e.g. `'PLN'`). Adapter validates carrier support. */
+  currency: string;
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -63,6 +63,7 @@ export type {
   ShipmentDimensions,
 } from './domain/types/shipment-parcel.types';
 export type { ShipmentCod } from './domain/types/shipment-cod.types';
+export type { ShipmentInsuredValue } from './domain/types/shipment-insured-value.types';
 
 export type { TrackingSnapshot, KnownCarrier } from './domain/types/tracking-snapshot.types';
 export { KnownCarrierValues } from './domain/types/tracking-snapshot.types';

--- a/libs/integrations/inpost/src/domain/types/inpost-shipx.types.ts
+++ b/libs/integrations/inpost/src/domain/types/inpost-shipx.types.ts
@@ -58,6 +58,17 @@ export interface ShipXCod {
   currency: string;
 }
 
+/**
+ * ShipX insurance (declared-value) descriptor on a create-shipment request.
+ * `amount` is a JSON number (not the OL decimal string) — the mapper converts.
+ * Present only when the caller declared a value to insure; a shipment without
+ * this object carries InPost's default (non-declared) liability.
+ */
+export interface ShipXInsurance {
+  amount: number;
+  currency: string;
+}
+
 export interface ShipXCreateShipmentRequest {
   sender: ShipXPeer;
   receiver: ShipXPeer;
@@ -67,6 +78,9 @@ export interface ShipXCreateShipmentRequest {
   reference?: string;
   /** Cash-on-delivery to collect. Omitted for prepaid shipments. */
   cod?: ShipXCod;
+  /** Declared value to insure the parcel for. Omitted when the caller
+   * declared none. */
+  insurance?: ShipXInsurance;
   custom_attributes?: {
     sending_method?: string;
     /** Target paczkomat/locker id (e.g. `'BTO02M'`). */

--- a/libs/integrations/inpost/src/domain/types/inpost-shipx.types.ts
+++ b/libs/integrations/inpost/src/domain/types/inpost-shipx.types.ts
@@ -47,6 +47,17 @@ export interface ShipXCourierParcel {
   is_non_standard?: boolean;
 }
 
+/**
+ * ShipX cash-on-delivery descriptor on a create-shipment request. `amount` is
+ * a JSON number (not the OL decimal string) — the mapper converts. Present only
+ * for COD-capable services (courier); a green shipment without this object is a
+ * regular prepaid parcel.
+ */
+export interface ShipXCod {
+  amount: number;
+  currency: string;
+}
+
 export interface ShipXCreateShipmentRequest {
   sender: ShipXPeer;
   receiver: ShipXPeer;
@@ -54,6 +65,8 @@ export interface ShipXCreateShipmentRequest {
   service: ShipXService;
   /** Stamped with the internal `ol_shipment_*` id for traceability. */
   reference?: string;
+  /** Cash-on-delivery to collect. Omitted for prepaid shipments. */
+  cod?: ShipXCod;
   custom_attributes?: {
     sending_method?: string;
     /** Target paczkomat/locker id (e.g. `'BTO02M'`). */

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts
@@ -172,6 +172,36 @@ describe('InpostInboundWebhookDecoderAdapter', () => {
       expect(result.action).toBe('ignore');
     });
 
+    it('should prefer the header timestamp over the body event_ts when both are present', () => {
+      // Both a signed header timestamp and a body `event_ts` are present; the
+      // signed header must win (it is the value the host replay-window checks).
+      const result = decoder.extractEnvelope(realStatusWebhook(), {
+        'x-inpost-timestamp': TIMESTAMP,
+      });
+      expect(result.action).toBe('route');
+      if (result.action === 'route') {
+        expect(result.envelope.occurredAt).toBe(TIMESTAMP);
+        expect(result.envelope.externalId).toBe('49');
+      }
+    });
+
+    it('should decode a combined header + body payload', () => {
+      // Header carries the topic + signed timestamp; body carries the ShipX
+      // event + nested shipment_id. Both halves must be honoured together.
+      const result = decoder.extractEnvelope(realStatusWebhook(), {
+        'x-inpost-topic': 'Shipment.Tracking',
+        'x-inpost-timestamp': TIMESTAMP,
+      });
+      expect(result.action).toBe('route');
+      if (result.action === 'route') {
+        expect(result.envelope.externalId).toBe('49');
+        expect(result.envelope.objectType).toBe('shipment');
+        expect(result.envelope.eventType).toBe('tracking');
+        expect(result.envelope.occurredAt).toBe(TIMESTAMP);
+        expect(result.envelope.eventId).toBeTruthy();
+      }
+    });
+
     it('should prefer payload.shipment_id over a present tracking_number', () => {
       const rawBody = Buffer.from(
         JSON.stringify({

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts
@@ -124,4 +124,79 @@ describe('InpostInboundWebhookDecoderAdapter', () => {
       expect(result.action).toBe('reject');
     });
   });
+
+  // Regression suite pinned to the authoritative ShipX webhook payload shape
+  // (docs page "[1.23.0] Webhooks"): `{ event_ts, event, organization_id,
+  // payload: { shipment_id, status, tracking_number } }`. These lock in that the
+  // decoder extracts the ShipX `shipment_id` (the refresh key for
+  // `GET /v1/shipments/{id}`) — NOT the nested/nullable `tracking_number` — and
+  // classifies the event from the body when no `x-inpost-topic` header is sent.
+  describe('extractEnvelope — real ShipX payload shape', () => {
+    // A `shipment_status_changed` event; `tracking_number` is null early in the
+    // lifecycle, so the refresh cannot rely on it — `shipment_id` is the key.
+    function realStatusWebhook(overrides: Record<string, unknown> = {}): Buffer {
+      return Buffer.from(
+        JSON.stringify({
+          event_ts: '2020-03-20 15:08:42 +0100',
+          event: 'shipment_status_changed',
+          organization_id: 1,
+          payload: { shipment_id: 49, status: 'confirmed', tracking_number: null },
+          ...overrides,
+        }),
+      );
+    }
+
+    it('should route a body-classified status event and extract payload.shipment_id', () => {
+      const result = decoder.extractEnvelope(realStatusWebhook(), {});
+      expect(result.action).toBe('route');
+      if (result.action === 'route') {
+        // The refresh (`GET /v1/shipments/{id}`) consumes this verbatim.
+        expect(result.envelope.externalId).toBe('49');
+        expect(result.envelope.objectType).toBe('shipment');
+        expect(result.envelope.eventType).toBe('tracking');
+        // Falls back to the body `event_ts` when no header timestamp is present.
+        expect(result.envelope.occurredAt).toBe('2020-03-20 15:08:42 +0100');
+      }
+    });
+
+    it('should route a shipment_confirmed event', () => {
+      const result = decoder.extractEnvelope(realStatusWebhook({ event: 'shipment_confirmed' }), {});
+      expect(result.action).toBe('route');
+      if (result.action === 'route') {
+        expect(result.envelope.externalId).toBe('49');
+      }
+    });
+
+    it('should ignore a non-tracking body event (offers_prepared)', () => {
+      const result = decoder.extractEnvelope(realStatusWebhook({ event: 'offers_prepared' }), {});
+      expect(result.action).toBe('ignore');
+    });
+
+    it('should prefer payload.shipment_id over a present tracking_number', () => {
+      const rawBody = Buffer.from(
+        JSON.stringify({
+          event_ts: '2020-03-20 15:08:42 +0100',
+          event: 'shipment_status_changed',
+          payload: { shipment_id: 49, tracking_number: '6200000000001' },
+        }),
+      );
+      const result = decoder.extractEnvelope(rawBody, {});
+      if (result.action === 'route') {
+        expect(result.envelope.externalId).toBe('49');
+      } else {
+        throw new Error('expected route');
+      }
+    });
+
+    it('should reject a status event with no shipment identifier', () => {
+      const rawBody = Buffer.from(
+        JSON.stringify({
+          event_ts: '2020-03-20 15:08:42 +0100',
+          event: 'shipment_status_changed',
+          payload: { status: 'confirmed' },
+        }),
+      );
+      expect(decoder.extractEnvelope(rawBody, {}).action).toBe('reject');
+    });
+  });
 });

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-shipping.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-shipping.adapter.spec.ts
@@ -276,4 +276,53 @@ describe('InpostShippingAdapter', () => {
       expect(result.contentType).toBe('application/pdf');
     });
   });
+
+  describe('generateProtocol', () => {
+    it('should GET the org printouts endpoint with the shipment_ids batch + format=Pdf and return the bytes', async () => {
+      const { adapter, requestBinary } = makeAdapter();
+      const bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+      requestBinary.mockResolvedValueOnce({ body: bytes, contentType: 'application/pdf' });
+
+      const result = await adapter.generateProtocol({ providerShipmentIds: ['11', '22', '33'] });
+
+      expect(requestBinary).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v1/organizations/org-123/dispatch_orders/printouts',
+        query: { shipment_ids: ['11', '22', '33'], format: 'Pdf' },
+      });
+      expect(result).toEqual({ contentType: 'application/pdf', body: bytes });
+    });
+
+    it('should pass a ZIP content type through unchanged (mixed-service batch)', async () => {
+      const { adapter, requestBinary } = makeAdapter();
+      requestBinary.mockResolvedValueOnce({
+        body: new Uint8Array([0x50, 0x4b, 0x03, 0x04]), // PK..
+        contentType: 'application/zip',
+      });
+
+      const result = await adapter.generateProtocol({ providerShipmentIds: ['11', '22'] });
+
+      expect(result.contentType).toBe('application/zip');
+    });
+
+    it('should default to application/pdf when the response carries no content type', async () => {
+      const { adapter, requestBinary } = makeAdapter();
+      requestBinary.mockResolvedValueOnce({ body: new Uint8Array([1]), contentType: '' });
+
+      const result = await adapter.generateProtocol({ providerShipmentIds: ['11'] });
+
+      expect(result.contentType).toBe('application/pdf');
+    });
+
+    it('should reject an empty batch before hitting ShipX', async () => {
+      const { adapter, requestBinary } = makeAdapter();
+
+      await expect(adapter.generateProtocol({ providerShipmentIds: [] })).rejects.toMatchObject({
+        name: 'ShippingProviderRejectionException',
+        providerName: 'inpost',
+        providerCode: 'preflight.empty-protocol-batch',
+      });
+      expect(requestBinary).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts
@@ -168,19 +168,28 @@ export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoder
     return headers[name] ?? headers[name.toLowerCase()] ?? null;
   }
 
+  /**
+   * Walk a key path over the parsed body, returning the leaf value or
+   * `undefined` if any segment is missing or non-traversable. Shared traversal
+   * backing the `firstString` / `firstIdentifier` accessors.
+   */
+  private resolvePath(record: Record<string, unknown>, path: readonly string[]): unknown {
+    let cursor: unknown = record;
+    for (const key of path) {
+      if (typeof cursor !== 'object' || cursor === null) {
+        return undefined;
+      }
+      cursor = (cursor as Record<string, unknown>)[key];
+    }
+    return cursor;
+  }
+
   private firstString(
     record: Record<string, unknown>,
     paths: readonly string[][],
   ): string | null {
     for (const path of paths) {
-      let cursor: unknown = record;
-      for (const key of path) {
-        if (typeof cursor !== 'object' || cursor === null) {
-          cursor = undefined;
-          break;
-        }
-        cursor = (cursor as Record<string, unknown>)[key];
-      }
+      const cursor = this.resolvePath(record, path);
       if (typeof cursor === 'string' && cursor.length > 0) {
         return cursor;
       }
@@ -197,14 +206,7 @@ export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoder
     paths: readonly string[][],
   ): string | null {
     for (const path of paths) {
-      let cursor: unknown = record;
-      for (const key of path) {
-        if (typeof cursor !== 'object' || cursor === null) {
-          cursor = undefined;
-          break;
-        }
-        cursor = (cursor as Record<string, unknown>)[key];
-      }
+      const cursor = this.resolvePath(record, path);
       if (typeof cursor === 'string' && cursor.length > 0) {
         return cursor;
       }

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts
@@ -9,10 +9,20 @@
  * pure transform into the host's neutral envelope.
  *
  * Trigger model (ADR-021): the webhook is a low-latency nudge, never the source
- * of truth. We read ONLY the parcel identifier from the body — never InPost's
- * status enum (sandbox-gated catalogue, OQ-B3) — and route a parcel-targeted
- * refresh that re-reads authoritative status via `getTracking`. So an imperfect
- * payload degrades to a redundant re-read, never wrong state.
+ * of truth. We read ONLY the shipment identifier from the body — never InPost's
+ * status enum — and route a shipment-targeted refresh that re-reads
+ * authoritative status via `getTracking`. So an imperfect payload degrades to a
+ * redundant re-read, never wrong state.
+ *
+ * Payload shape (ShipX Webhooks, docs page "[1.23.0] Webhooks"): a status event
+ * is `{ event_ts, event, organization_id, payload: { shipment_id, status,
+ * tracking_number } }` where `event` is `shipment_status_changed` /
+ * `shipment_confirmed` (and `offers_prepared`, which we ignore). The refresh
+ * re-reads `GET /v1/shipments/{id}`, so the identifier we extract MUST be the
+ * ShipX `shipment_id` (== the `providerShipmentId` OL persists), NOT the
+ * `tracking_number` (which is nested, frequently `null` early in the lifecycle,
+ * and would 404 against the by-id resource). The `x-inpost-*` header form is
+ * kept as a forward-compat fallback but the body `event` field is authoritative.
  *
  * @module libs/integrations/inpost/src/infrastructure/adapters
  */
@@ -29,18 +39,27 @@ const TOPIC_HEADER = 'x-inpost-topic';
 const TRACKING_TOPIC = 'Shipment.Tracking';
 
 /**
- * Candidate body fields carrying the parcel identifier, tried in order. InPost's
- * exact `Shipment.Tracking` payload shape is not public (OQ-B3) — these are the
- * documented-best-guess keys; the live field is confirmed during sandbox
- * onboarding. Isolated here so confirming it is a one-line change, and because
- * the re-read (not the payload) is authoritative the blast radius is a redundant
- * `getTracking`, not incorrect state.
+ * ShipX `event` values that signify a shipment status change worth refreshing.
+ * `offers_prepared` and any other event fall through to ack-and-ignore.
  */
-const PARCEL_ID_CANDIDATE_PATHS: readonly string[][] = [
+const TRACKING_EVENTS: readonly string[] = ['shipment_status_changed', 'shipment_confirmed'];
+
+/**
+ * Candidate body paths carrying the shipment identifier, tried in order. The
+ * authoritative ShipX shape nests it at `payload.shipment_id` (a number); this
+ * is the id the downstream refresh re-reads (`GET /v1/shipments/{id}`), so it
+ * ranks first. The remaining `tracking_number` paths are last-resort fallbacks
+ * for shape-robustness only — they are NOT the refresh key and are kept so a
+ * malformed/legacy payload still routes (a wrong-id re-read 404s and the 30-min
+ * poll heals it, never wrong state).
+ */
+const SHIPMENT_ID_CANDIDATE_PATHS: readonly string[][] = [
+  ['payload', 'shipment_id'],
+  ['shipment_id'],
+  ['payload', 'tracking_number'],
+  ['shipment', 'tracking_number'],
   ['tracking_number'],
   ['trackingNumber'],
-  ['shipment', 'tracking_number'],
-  ['payload', 'tracking_number'],
 ];
 
 export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoderPort {
@@ -75,12 +94,11 @@ export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoder
   }
 
   extractEnvelope(rawBody: Buffer, headers: Record<string, string>): DecodeResult {
-    const topic = this.header(headers, TOPIC_HEADER);
-    if (topic !== TRACKING_TOPIC) {
-      // Well-formed but not a tracking event (other topic / setup ping) —
-      // ack-and-ignore, don't 400 (avoids InPost retry storms on topics we
-      // don't route).
-      return { action: 'ignore', reason: `unhandled topic: ${topic ?? '(none)'}` };
+    const headerTopic = this.header(headers, TOPIC_HEADER);
+    if (headerTopic && headerTopic !== TRACKING_TOPIC) {
+      // A different header topic (setup ping / non-tracking topic) — ack-and-
+      // ignore, don't 400 (avoids InPost retry storms on topics we don't route).
+      return { action: 'ignore', reason: `unhandled topic: ${headerTopic}` };
     }
 
     let body: unknown;
@@ -94,45 +112,55 @@ export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoder
     }
 
     const record = body as Record<string, unknown>;
-    const parcelId = this.firstString(record, PARCEL_ID_CANDIDATE_PATHS);
-    if (!parcelId) {
-      return { action: 'reject', reason: 'no parcel identifier in payload' };
+
+    // Event classification: the authoritative signal is the body `event` field
+    // (ShipX Webhooks); the `x-inpost-topic` header is a forward-compat fallback.
+    const eventName = headerTopic ?? this.firstString(record, [['event']]);
+    const isTrackingEvent =
+      eventName === TRACKING_TOPIC || (eventName !== null && TRACKING_EVENTS.includes(eventName));
+    if (!isTrackingEvent) {
+      return { action: 'ignore', reason: `unhandled event: ${eventName ?? '(none)'}` };
     }
 
-    // A verified request always carries `x-inpost-timestamp` (it's inside the
-    // signed payload), so its absence here means the body reached extract
-    // without passing verify — reject rather than fabricate a timestamp, keeping
-    // this a pure transform.
-    const occurredAt = this.header(headers, TIMESTAMP_HEADER);
+    const shipmentId = this.firstIdentifier(record, SHIPMENT_ID_CANDIDATE_PATHS);
+    if (!shipmentId) {
+      return { action: 'reject', reason: 'no shipment identifier in payload' };
+    }
+
+    // Prefer the signed `x-inpost-timestamp` header; fall back to the body's
+    // `event_ts` (present in the ShipX payload). Reject rather than fabricate a
+    // timestamp, keeping this a pure transform.
+    const occurredAt =
+      this.header(headers, TIMESTAMP_HEADER) ?? this.firstString(record, [['event_ts']]);
     if (!occurredAt) {
-      return { action: 'reject', reason: 'missing x-inpost-timestamp' };
+      return { action: 'reject', reason: 'missing event timestamp' };
     }
     return {
       action: 'route',
       envelope: {
         // Dedup key — use a provider event id if present, else a deterministic
-        // hash of the parcel id + event timestamp so retries collapse and
+        // hash of the shipment id + event timestamp so retries collapse and
         // distinct events don't. Best-effort (the idempotent re-read is the
         // correctness guarantee), so the eventId need only suppress obvious dupes.
-        eventId: this.deriveEventId(record, parcelId, occurredAt),
+        eventId: this.deriveEventId(record, shipmentId, occurredAt),
         eventType: 'tracking',
         occurredAt,
         objectType: 'shipment',
-        externalId: parcelId,
+        externalId: shipmentId,
       },
     };
   }
 
   private deriveEventId(
     record: Record<string, unknown>,
-    parcelId: string,
+    shipmentId: string,
     occurredAt: string | undefined,
   ): string {
     const explicit = this.firstString(record, [['event_id'], ['eventId'], ['id']]);
     if (explicit) {
       return explicit;
     }
-    const basis = `${parcelId}:${occurredAt ?? ''}`;
+    const basis = `${shipmentId}:${occurredAt ?? ''}`;
     return `inpost-${createHash('sha256').update(basis).digest('hex').slice(0, 32)}`;
   }
 
@@ -155,6 +183,33 @@ export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoder
       }
       if (typeof cursor === 'string' && cursor.length > 0) {
         return cursor;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Like `firstString` but also accepts a finite number (ShipX sends
+   * `shipment_id` as a JSON number), coercing it to its string form.
+   */
+  private firstIdentifier(
+    record: Record<string, unknown>,
+    paths: readonly string[][],
+  ): string | null {
+    for (const path of paths) {
+      let cursor: unknown = record;
+      for (const key of path) {
+        if (typeof cursor !== 'object' || cursor === null) {
+          cursor = undefined;
+          break;
+        }
+        cursor = (cursor as Record<string, unknown>)[key];
+      }
+      if (typeof cursor === 'string' && cursor.length > 0) {
+        return cursor;
+      }
+      if (typeof cursor === 'number' && Number.isFinite(cursor)) {
+        return String(cursor);
       }
     }
     return null;

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-shipping.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-shipping.adapter.ts
@@ -20,6 +20,7 @@ import {
   type ShipmentCanceller,
   type PickupPointFinder,
   type LabelDocumentReader,
+  type DispatchProtocolReader,
   type GenerateLabelCommand,
   type GenerateLabelResult,
   type LabelDocument,
@@ -34,6 +35,7 @@ import type { IInpostHttpClient } from '../http/inpost-http-client.interface';
 import {
   buildCreateShipmentRequest,
   buildPointsQuery,
+  buildProtocolQuery,
   mapShipXStatus,
   toGenerateLabelResult,
   toPickupPoint,
@@ -43,7 +45,12 @@ import {
 const SUPPORTED_METHODS: readonly ShippingMethod[] = ['paczkomat', 'kurier'];
 
 export class InpostShippingAdapter
-  implements ShippingProviderManagerPort, ShipmentCanceller, PickupPointFinder, LabelDocumentReader
+  implements
+    ShippingProviderManagerPort,
+    ShipmentCanceller,
+    PickupPointFinder,
+    LabelDocumentReader,
+    DispatchProtocolReader
 {
   private readonly logger = new Logger(InpostShippingAdapter.name);
 
@@ -133,6 +140,22 @@ export class InpostShippingAdapter
       method: 'GET',
       path: `/v1/shipments/${input.providerShipmentId}/label`,
       query: { format: 'pdf' },
+    });
+    return { contentType: contentType || 'application/pdf', body };
+  }
+
+  async generateProtocol(input: { providerShipmentIds: string[] }): Promise<LabelDocument> {
+    // The handover protocol ("protokół odbioru") is a per-batch manifest ShipX
+    // renders from `dispatch_orders/printouts` over already-confirmed shipments,
+    // with or without a courier pickup order. Idempotent read (no carrier side
+    // effect) → shares the client's retry machinery via `requestBinary`. ShipX
+    // returns a single PDF when all shipments share one service and a ZIP when
+    // they span several; the reported content type is forwarded either way and
+    // defaults to PDF only when the header is absent (matches `fetchLabel`).
+    const { body, contentType } = await this.http.requestBinary({
+      method: 'GET',
+      path: `/v1/organizations/${this.config.organizationId}/dispatch_orders/printouts`,
+      query: buildProtocolQuery(input.providerShipmentIds),
     });
     return { contentType: contentType || 'application/pdf', body };
   }

--- a/libs/integrations/inpost/src/infrastructure/http/__tests__/inpost-http-client.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/http/__tests__/inpost-http-client.spec.ts
@@ -79,6 +79,29 @@ describe('InpostHttpClient', () => {
     );
   });
 
+  it('should serialise an array query param as repeated key[]= pairs (ShipX shipment_ids)', async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({ ok: true, status: 200, body: '{"ok":true}' }));
+
+    await client.request({
+      method: 'GET',
+      path: '/v1/organizations/org-1/dispatch_orders/printouts',
+      query: { shipment_ids: ['11', '22'], format: 'Pdf' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('shipment_ids%5B%5D=11'),
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('shipment_ids%5B%5D=22'),
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('format=Pdf'),
+      expect.anything(),
+    );
+  });
+
   it('should resolve undefined for a 204 No Content response', async () => {
     fetchMock.mockResolvedValueOnce(fakeResponse({ ok: true, status: 204 }));
 

--- a/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.interface.ts
+++ b/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.interface.ts
@@ -15,8 +15,12 @@ export interface InpostRequestOptions {
   method: InpostHttpMethod;
   /** Absolute path on the ShipX host, e.g. `/v1/organizations/{org}/shipments`. */
   path: string;
-  /** Query params; `undefined` values are dropped. */
-  query?: Record<string, string | number | boolean | undefined>;
+  /**
+   * Query params; `undefined` values are dropped. An array value is serialised
+   * as repeated `key[]=v` pairs — the Rails-style bracket convention ShipX
+   * expects for list params like `dispatch_orders/printouts?shipment_ids[]=…`.
+   */
+  query?: Record<string, string | number | boolean | readonly (string | number)[] | undefined>;
   /** JSON request body (serialised by the client). */
   body?: unknown;
 }

--- a/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.ts
+++ b/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.ts
@@ -201,7 +201,15 @@ export class InpostHttpClient implements IInpostHttpClient {
     const url = new URL(path, this.baseUrl);
     if (query) {
       for (const [key, value] of Object.entries(query)) {
-        if (value !== undefined) {
+        if (value === undefined) {
+          continue;
+        }
+        if (Array.isArray(value)) {
+          // ShipX list params use the Rails bracket form (`shipment_ids[]=1`).
+          for (const item of value) {
+            url.searchParams.append(`${key}[]`, String(item));
+          }
+        } else {
           url.searchParams.set(key, String(value));
         }
       }

--- a/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
@@ -14,6 +14,7 @@ import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
 import {
   buildCreateShipmentRequest,
   buildPointsQuery,
+  buildProtocolQuery,
   classifyInpostPointType,
   mapShipXStatus,
   toGenerateLabelResult,
@@ -264,6 +265,19 @@ describe('inpost-shipx.mapper', () => {
       expect(
         buildPointsQuery({ city: 'Warszawa', postalCode: '00-001', searchText: 'POZ', limit: 10 }),
       ).toEqual({ city: 'Warszawa', post_code: '00-001', name: 'POZ', per_page: 10 });
+    });
+  });
+
+  describe('buildProtocolQuery', () => {
+    it('should carry the shipment_ids batch and format=Pdf', () => {
+      expect(buildProtocolQuery(['11', '22', '33'])).toEqual({
+        shipment_ids: ['11', '22', '33'],
+        format: 'Pdf',
+      });
+    });
+
+    it('should reject an empty batch with a preflight rejection', () => {
+      expect(() => buildProtocolQuery([])).toThrow(ShippingProviderRejectionException);
     });
   });
 });

--- a/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
@@ -406,5 +406,15 @@ describe('inpost-shipx.mapper', () => {
     it('should reject an empty batch with a preflight rejection', () => {
       expect(() => buildProtocolQuery([])).toThrow(ShippingProviderRejectionException);
     });
+
+    it('should accept a batch of exactly 100 shipments', () => {
+      const ids = Array.from({ length: 100 }, (_, i) => String(i));
+      expect(buildProtocolQuery(ids)).toEqual({ shipment_ids: ids, format: 'Pdf' });
+    });
+
+    it('should reject a batch larger than 100 shipments with a preflight rejection', () => {
+      const ids = Array.from({ length: 101 }, (_, i) => String(i));
+      expect(() => buildProtocolQuery(ids)).toThrow(ShippingProviderRejectionException);
+    });
   });
 });

--- a/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
@@ -154,6 +154,70 @@ describe('inpost-shipx.mapper', () => {
         });
       }
     });
+
+    it('should map cod onto the ShipX request (decimal string → number) for a courier shipment (#1541)', () => {
+      const request = buildCreateShipmentRequest(
+        { ...courierCmd, cod: { amount: '39.99', currency: 'PLN' } },
+        config,
+      );
+      expect(request.cod).toEqual({ amount: 39.99, currency: 'PLN' });
+    });
+
+    it('should omit cod from the ShipX request when the command carries none (#1541)', () => {
+      expect(buildCreateShipmentRequest(courierCmd, config).cod).toBeUndefined();
+      expect(buildCreateShipmentRequest(paczkomatCmd, config).cod).toBeUndefined();
+    });
+
+    it('should throw a typed rejection (preflight.cod-unsupported-method) when COD is requested for a paczkomat shipment (#1541)', () => {
+      const call = (): unknown =>
+        buildCreateShipmentRequest(
+          { ...paczkomatCmd, cod: { amount: '39.99', currency: 'PLN' } },
+          config,
+        );
+      expect(call).toThrow(ShippingProviderRejectionException);
+      try {
+        call();
+      } catch (error) {
+        expect(error).toMatchObject({
+          providerName: 'inpost',
+          providerCode: 'preflight.cod-unsupported-method',
+        });
+      }
+    });
+
+    it('should throw a typed rejection (preflight.cod-amount-invalid) when the COD amount is not a positive number (#1541)', () => {
+      const call = (): unknown =>
+        buildCreateShipmentRequest(
+          { ...courierCmd, cod: { amount: 'abc', currency: 'PLN' } },
+          config,
+        );
+      expect(call).toThrow(ShippingProviderRejectionException);
+      try {
+        call();
+      } catch (error) {
+        expect(error).toMatchObject({
+          providerName: 'inpost',
+          providerCode: 'preflight.cod-amount-invalid',
+        });
+      }
+    });
+
+    it('should throw a typed rejection (preflight.cod-currency-unsupported) when the COD currency is not PLN (#1541)', () => {
+      const call = (): unknown =>
+        buildCreateShipmentRequest(
+          { ...courierCmd, cod: { amount: '39.99', currency: 'EUR' } },
+          config,
+        );
+      expect(call).toThrow(ShippingProviderRejectionException);
+      try {
+        call();
+      } catch (error) {
+        expect(error).toMatchObject({
+          providerName: 'inpost',
+          providerCode: 'preflight.cod-currency-unsupported',
+        });
+      }
+    });
   });
 
   describe('mapShipXStatus', () => {

--- a/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
@@ -168,7 +168,7 @@ describe('inpost-shipx.mapper', () => {
       expect(buildCreateShipmentRequest(paczkomatCmd, config).cod).toBeUndefined();
     });
 
-    it('should throw a typed rejection (preflight.cod-unsupported-method) when COD is requested for a paczkomat shipment (#1541)', () => {
+    it('should throw a typed rejection (preflight.cod-locker-unsupported) when COD is requested for a paczkomat shipment (#1541)', () => {
       const call = (): unknown =>
         buildCreateShipmentRequest(
           { ...paczkomatCmd, cod: { amount: '39.99', currency: 'PLN' } },
@@ -178,29 +178,34 @@ describe('inpost-shipx.mapper', () => {
       try {
         call();
       } catch (error) {
+        // Rejection is a limitation of this v1 adapter (locker COD not modelled
+        // yet, see #1554), not of InPost/ShipX being COD-incapable on lockers.
         expect(error).toMatchObject({
           providerName: 'inpost',
-          providerCode: 'preflight.cod-unsupported-method',
+          providerCode: 'preflight.cod-locker-unsupported',
         });
       }
     });
 
-    it('should throw a typed rejection (preflight.cod-amount-invalid) when the COD amount is not a positive number (#1541)', () => {
-      const call = (): unknown =>
-        buildCreateShipmentRequest(
-          { ...courierCmd, cod: { amount: 'abc', currency: 'PLN' } },
-          config,
-        );
-      expect(call).toThrow(ShippingProviderRejectionException);
-      try {
-        call();
-      } catch (error) {
-        expect(error).toMatchObject({
-          providerName: 'inpost',
-          providerCode: 'preflight.cod-amount-invalid',
-        });
-      }
-    });
+    it.each(['abc', '0', '-5'])(
+      'should throw a typed rejection (preflight.cod-amount-invalid) when the COD amount is not a positive number: %s (#1541)',
+      (amount) => {
+        const call = (): unknown =>
+          buildCreateShipmentRequest(
+            { ...courierCmd, cod: { amount, currency: 'PLN' } },
+            config,
+          );
+        expect(call).toThrow(ShippingProviderRejectionException);
+        try {
+          call();
+        } catch (error) {
+          expect(error).toMatchObject({
+            providerName: 'inpost',
+            providerCode: 'preflight.cod-amount-invalid',
+          });
+        }
+      },
+    );
 
     it('should throw a typed rejection (preflight.cod-currency-unsupported) when the COD currency is not PLN (#1541)', () => {
       const call = (): unknown =>

--- a/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
@@ -224,6 +224,64 @@ describe('inpost-shipx.mapper', () => {
         });
       }
     });
+
+    it('should map insuredValue onto the ShipX request (decimal string → number) for a courier shipment (#1542)', () => {
+      const request = buildCreateShipmentRequest(
+        { ...courierCmd, insuredValue: { amount: '150.00', currency: 'PLN' } },
+        config,
+      );
+      expect(request.insurance).toEqual({ amount: 150, currency: 'PLN' });
+    });
+
+    it('should map insuredValue onto the ShipX request for a paczkomat shipment (insurance IS supported on lockers, unlike COD) (#1542)', () => {
+      const request = buildCreateShipmentRequest(
+        { ...paczkomatCmd, insuredValue: { amount: '150.00', currency: 'PLN' } },
+        config,
+      );
+      expect(request.insurance).toEqual({ amount: 150, currency: 'PLN' });
+    });
+
+    it('should omit insurance from the ShipX request when the command carries none (#1542)', () => {
+      expect(buildCreateShipmentRequest(courierCmd, config).insurance).toBeUndefined();
+      expect(buildCreateShipmentRequest(paczkomatCmd, config).insurance).toBeUndefined();
+    });
+
+    it.each(['abc', '0', '-5'])(
+      'should throw a typed rejection (preflight.insurance-amount-invalid) when the insured amount is not a positive number: %s (#1542)',
+      (amount) => {
+        const call = (): unknown =>
+          buildCreateShipmentRequest(
+            { ...courierCmd, insuredValue: { amount, currency: 'PLN' } },
+            config,
+          );
+        expect(call).toThrow(ShippingProviderRejectionException);
+        try {
+          call();
+        } catch (error) {
+          expect(error).toMatchObject({
+            providerName: 'inpost',
+            providerCode: 'preflight.insurance-amount-invalid',
+          });
+        }
+      },
+    );
+
+    it('should throw a typed rejection (preflight.insurance-currency-unsupported) when the insurance currency is not PLN (#1542)', () => {
+      const call = (): unknown =>
+        buildCreateShipmentRequest(
+          { ...courierCmd, insuredValue: { amount: '150.00', currency: 'EUR' } },
+          config,
+        );
+      expect(call).toThrow(ShippingProviderRejectionException);
+      try {
+        call();
+      } catch (error) {
+        expect(error).toMatchObject({
+          providerName: 'inpost',
+          providerCode: 'preflight.insurance-currency-unsupported',
+        });
+      }
+    });
   });
 
   describe('mapShipXStatus', () => {

--- a/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
@@ -114,13 +114,15 @@ export function buildCreateShipmentRequest(
 
   if (cmd.shippingMethod === 'paczkomat') {
     if (cmd.cod) {
-      // COD to a locker requires a distinct ShipX pass-through/COD service that
-      // the v1 simplified adapter does not model. Fail fast rather than issue a
-      // prepaid label while the operator believes COD was applied (#1541).
+      // InPost lockers DO support COD via a ShipX COD-capable locker service;
+      // the limitation is that this v1 simplified adapter does not model locker
+      // COD yet (not modelled yet by this adapter; see follow-up #1554). Fail
+      // fast rather than issue a prepaid label while the operator believes COD
+      // was applied (#1541).
       throw new ShippingProviderRejectionException(
         'inpost',
-        'preflight.cod-unsupported-method',
-        'InPost paczkomat (locker) shipments do not support COD in this integration; use the kurier method for a cash-on-delivery parcel',
+        'preflight.cod-locker-unsupported',
+        'COD on InPost lockers (paczkomat) is not yet supported by this integration (see #1554); use the kurier method for a cash-on-delivery parcel',
       );
     }
     return buildLockerRequest(cmd, sender);
@@ -318,6 +320,9 @@ function buildCourierRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): Ship
  * A malformed amount or an unsupported currency is a preflight rejection.
  */
 function toShipXCod(cod: ShipmentCod): ShipXCod {
+  // Deliberate decimal-string -> JSON-number boundary: ShipX requires a numeric
+  // `amount`, so `Number()` re-introduces a float here. Safe for 2-decimal PLN
+  // COD values, which round-trip cleanly through IEEE-754.
   const amount = Number(cod.amount);
   if (!Number.isFinite(amount) || amount <= 0) {
     throw new ShippingProviderRejectionException(

--- a/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
@@ -16,6 +16,7 @@ import type {
   GenerateLabelCommand,
   GenerateLabelResult,
   ShipmentCod,
+  ShipmentInsuredValue,
   ShipmentStatus,
   ShipmentAddress,
   TrackingSnapshot,
@@ -30,6 +31,7 @@ import type { InpostConnectionConfig, InpostSenderContact } from '../../domain/t
 import type {
   ShipXAddress,
   ShipXCod,
+  ShipXInsurance,
   ShipXCreateShipmentRequest,
   ShipXPeer,
   ShipXPoint,
@@ -43,6 +45,14 @@ import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
  * preflight rather than silently sent.
  */
 const SHIPX_COD_CURRENCIES: readonly string[] = ['PLN'];
+
+/**
+ * ISO 4217 currencies InPost ShipX accepts for declared-value insurance. Like
+ * COD, InPost insurance is a domestic-PL service, so `PLN` is the only supported
+ * value; a non-PLN insured value is rejected at preflight rather than silently
+ * sent.
+ */
+const SHIPX_INSURANCE_CURRENCIES: readonly string[] = ['PLN'];
 
 /**
  * Full ShipX status → OpenLinker bucket table (verified against the ShipX
@@ -280,7 +290,7 @@ function buildLockerRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): ShipX
       'parcel.template (locker size) is required for a paczkomat shipment',
     );
   }
-  return {
+  const request: ShipXCreateShipmentRequest = {
     sender,
     receiver: toReceiverPeer(cmd, false),
     parcels: { template: cmd.parcel.template },
@@ -292,6 +302,12 @@ function buildLockerRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): ShipX
     // courier pickup-order flow (#1427).
     custom_attributes: { sending_method: 'parcel_locker', target_point: cmd.paczkomatId },
   };
+  // Insurance is supported on locker shipments (unlike COD, which this v1
+  // adapter refuses for lockers — see buildCreateShipmentRequest).
+  if (cmd.insuredValue) {
+    request.insurance = toShipXInsurance(cmd.insuredValue);
+  }
+  return request;
 }
 
 function buildCourierRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): ShipXCreateShipmentRequest {
@@ -332,6 +348,9 @@ function buildCourierRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): Ship
   if (cmd.cod) {
     request.cod = toShipXCod(cmd.cod);
   }
+  if (cmd.insuredValue) {
+    request.insurance = toShipXInsurance(cmd.insuredValue);
+  }
   return request;
 }
 
@@ -361,6 +380,34 @@ function toShipXCod(cod: ShipmentCod): ShipXCod {
     );
   }
   return { amount, currency: cod.currency };
+}
+
+/**
+ * Translate the carrier-neutral insured-value descriptor to the ShipX
+ * `insurance` object. Mirrors `toShipXCod`: OL carries `amount` as a decimal
+ * string (to cross the boundary without float rounding); ShipX expects a JSON
+ * number, so it is parsed here after validation. A malformed amount or an
+ * unsupported currency is a preflight rejection.
+ */
+function toShipXInsurance(insured: ShipmentInsuredValue): ShipXInsurance {
+  // Deliberate decimal-string -> JSON-number boundary (see toShipXCod). Safe for
+  // 2-decimal PLN values, which round-trip cleanly through IEEE-754.
+  const amount = Number(insured.amount);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new ShippingProviderRejectionException(
+      'inpost',
+      'preflight.insurance-amount-invalid',
+      `Insured amount must be a positive number; got '${insured.amount}'`,
+    );
+  }
+  if (!SHIPX_INSURANCE_CURRENCIES.includes(insured.currency)) {
+    throw new ShippingProviderRejectionException(
+      'inpost',
+      'preflight.insurance-currency-unsupported',
+      `InPost insurance currency must be one of ${SHIPX_INSURANCE_CURRENCIES.join(', ')}; got '${insured.currency}'`,
+    );
+  }
+  return { amount, currency: insured.currency };
 }
 
 function toSenderPeer(sender: InpostSenderContact): ShipXPeer {

--- a/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
@@ -220,6 +220,28 @@ export function buildPointsQuery(
   };
 }
 
+/**
+ * Build the query for the handover-protocol printout
+ * (`GET /v1/organizations/:org/dispatch_orders/printouts`). ShipX renders one
+ * manifest PDF over the given already-confirmed shipments — it accepts the
+ * `shipment_ids[]` batch whether or not those shipments carry a dispatch order,
+ * so no courier-pickup order has to be created first. `format` has a single
+ * documented value (`Pdf`); ShipX caps a request at 100 shipments and rejects
+ * the call itself if any id is not `confirmed`, so those stay carrier-enforced.
+ */
+export function buildProtocolQuery(
+  providerShipmentIds: readonly string[],
+): { shipment_ids: readonly string[]; format: 'Pdf' } {
+  if (providerShipmentIds.length === 0) {
+    throw new ShippingProviderRejectionException(
+      'inpost',
+      'preflight.empty-protocol-batch',
+      'At least one shipment id is required to generate a handover protocol',
+    );
+  }
+  return { shipment_ids: providerShipmentIds, format: 'Pdf' };
+}
+
 // --- internals ---------------------------------------------------------------
 
 function buildLockerRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): ShipXCreateShipmentRequest {

--- a/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
@@ -257,9 +257,13 @@ export function buildPointsQuery(
  * manifest PDF over the given already-confirmed shipments — it accepts the
  * `shipment_ids[]` batch whether or not those shipments carry a dispatch order,
  * so no courier-pickup order has to be created first. `format` has a single
- * documented value (`Pdf`); ShipX caps a request at 100 shipments and rejects
- * the call itself if any id is not `confirmed`, so those stay carrier-enforced.
+ * documented value (`Pdf`); ShipX rejects the call itself if any id is not
+ * `confirmed`, so that stays carrier-enforced. The 100-shipment-per-request
+ * cap is preflighted here (mirroring the empty-batch guard) so an oversized
+ * batch fails with a clear domain error instead of a raw carrier rejection.
  */
+export const MAX_PROTOCOL_SHIPMENTS = 100;
+
 export function buildProtocolQuery(
   providerShipmentIds: readonly string[],
 ): { shipment_ids: readonly string[]; format: 'Pdf' } {
@@ -268,6 +272,13 @@ export function buildProtocolQuery(
       'inpost',
       'preflight.empty-protocol-batch',
       'At least one shipment id is required to generate a handover protocol',
+    );
+  }
+  if (providerShipmentIds.length > MAX_PROTOCOL_SHIPMENTS) {
+    throw new ShippingProviderRejectionException(
+      'inpost',
+      'preflight.protocol-batch-too-large',
+      `A handover protocol accepts at most ${MAX_PROTOCOL_SHIPMENTS} shipments per request, got ${providerShipmentIds.length}`,
     );
   }
   return { shipment_ids: providerShipmentIds, format: 'Pdf' };

--- a/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
@@ -15,6 +15,7 @@
 import type {
   GenerateLabelCommand,
   GenerateLabelResult,
+  ShipmentCod,
   ShipmentStatus,
   ShipmentAddress,
   TrackingSnapshot,
@@ -28,12 +29,20 @@ import { PICKUP_POINT_STATUS, PICKUP_POINT_TYPE } from '@openlinker/core/shippin
 import type { InpostConnectionConfig, InpostSenderContact } from '../../domain/types/inpost-config.types';
 import type {
   ShipXAddress,
+  ShipXCod,
   ShipXCreateShipmentRequest,
   ShipXPeer,
   ShipXPoint,
   ShipXShipment,
 } from '../../domain/types/inpost-shipx.types';
 import { ShippingProviderRejectionException } from '@openlinker/core/shipping';
+
+/**
+ * ISO 4217 currencies InPost ShipX accepts for COD. InPost COD is a domestic-PL
+ * service, so `PLN` is the only supported value; a non-PLN COD is rejected at
+ * preflight rather than silently sent.
+ */
+const SHIPX_COD_CURRENCIES: readonly string[] = ['PLN'];
 
 /**
  * Full ShipX status → OpenLinker bucket table (verified against the ShipX
@@ -104,6 +113,16 @@ export function buildCreateShipmentRequest(
   const sender = toSenderPeer(config.senderAddress);
 
   if (cmd.shippingMethod === 'paczkomat') {
+    if (cmd.cod) {
+      // COD to a locker requires a distinct ShipX pass-through/COD service that
+      // the v1 simplified adapter does not model. Fail fast rather than issue a
+      // prepaid label while the operator believes COD was applied (#1541).
+      throw new ShippingProviderRejectionException(
+        'inpost',
+        'preflight.cod-unsupported-method',
+        'InPost paczkomat (locker) shipments do not support COD in this integration; use the kurier method for a cash-on-delivery parcel',
+      );
+    }
     return buildLockerRequest(cmd, sender);
   }
   if (cmd.shippingMethod === 'kurier') {
@@ -267,7 +286,7 @@ function buildCourierRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): Ship
       'parcel.dimensions and parcel.weightGrams are required for a courier shipment',
     );
   }
-  return {
+  const request: ShipXCreateShipmentRequest = {
     sender,
     receiver: toReceiverPeer(cmd, true),
     parcels: [
@@ -286,6 +305,35 @@ function buildCourierRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): Ship
     reference: cmd.shipmentId,
     custom_attributes: { sending_method: 'dispatch_order' },
   };
+  if (cmd.cod) {
+    request.cod = toShipXCod(cmd.cod);
+  }
+  return request;
+}
+
+/**
+ * Translate the carrier-neutral COD descriptor to the ShipX `cod` object. OL
+ * carries `amount` as a decimal string (to cross the boundary without float
+ * rounding); ShipX expects a JSON number, so it is parsed here after validation.
+ * A malformed amount or an unsupported currency is a preflight rejection.
+ */
+function toShipXCod(cod: ShipmentCod): ShipXCod {
+  const amount = Number(cod.amount);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new ShippingProviderRejectionException(
+      'inpost',
+      'preflight.cod-amount-invalid',
+      `COD amount must be a positive number; got '${cod.amount}'`,
+    );
+  }
+  if (!SHIPX_COD_CURRENCIES.includes(cod.currency)) {
+    throw new ShippingProviderRejectionException(
+      'inpost',
+      'preflight.cod-currency-unsupported',
+      `InPost COD currency must be one of ${SHIPX_COD_CURRENCIES.join(', ')}; got '${cod.currency}'`,
+    );
+  }
+  return { amount, currency: cod.currency };
 }
 
 function toSenderPeer(sender: InpostSenderContact): ShipXPeer {

--- a/libs/integrations/inpost/src/testing/__tests__/fake-inpost-shipping.adapter.spec.ts
+++ b/libs/integrations/inpost/src/testing/__tests__/fake-inpost-shipping.adapter.spec.ts
@@ -73,6 +73,19 @@ describe('FakeInpostShippingAdapter', () => {
     await expect(fake.findPickupPoints({ city: 'Poznań' })).resolves.toEqual([point]);
   });
 
+  it('should return a deterministic protocol document for a batch', async () => {
+    const result = await fake.generateProtocol({ providerShipmentIds: ['fake-1', 'fake-2'] });
+    expect(result.contentType).toBe('application/pdf');
+    expect(result.body).toEqual(new Uint8Array([0x25, 0x50, 0x44, 0x46]));
+  });
+
+  it('should reject an empty protocol batch like the real adapter', async () => {
+    await expect(fake.generateProtocol({ providerShipmentIds: [] })).rejects.toMatchObject({
+      name: 'ShippingProviderRejectionException',
+      providerCode: 'preflight.empty-protocol-batch',
+    });
+  });
+
   it('should reset state on clear', async () => {
     await fake.generateLabel(paczkomatCmd);
     fake.clear();

--- a/libs/integrations/inpost/src/testing/fake-inpost-shipping.adapter.ts
+++ b/libs/integrations/inpost/src/testing/fake-inpost-shipping.adapter.ts
@@ -17,6 +17,7 @@ import type {
   ShipmentCanceller,
   PickupPointFinder,
   LabelDocumentReader,
+  DispatchProtocolReader,
   GenerateLabelCommand,
   GenerateLabelResult,
   LabelDocument,
@@ -35,7 +36,8 @@ export class FakeInpostShippingAdapter
     ShippingProviderManagerPort,
     ShipmentCanceller,
     PickupPointFinder,
-    LabelDocumentReader
+    LabelDocumentReader,
+    DispatchProtocolReader
 {
   private counter = 0;
   private seededFailure: Error | null = null;
@@ -103,6 +105,25 @@ export class FakeInpostShippingAdapter
   fetchLabel(_input: { providerShipmentId: string }): Promise<LabelDocument> {
     if (this.seededFailure) {
       return Promise.reject(this.seededFailure);
+    }
+    return Promise.resolve({
+      contentType: 'application/pdf',
+      body: new Uint8Array([0x25, 0x50, 0x44, 0x46]), // %PDF
+    });
+  }
+
+  generateProtocol(input: { providerShipmentIds: string[] }): Promise<LabelDocument> {
+    if (this.seededFailure) {
+      return Promise.reject(this.seededFailure);
+    }
+    if (input.providerShipmentIds.length === 0) {
+      return Promise.reject(
+        new ShippingProviderRejectionException(
+          'inpost',
+          'preflight.empty-protocol-batch',
+          'At least one shipment id is required to generate a handover protocol',
+        ),
+      );
     }
     return Promise.resolve({
       contentType: 'application/pdf',


### PR DESCRIPTION
## What & why

Closes the InPost shipping adapter feature gaps identified in the shipping-integration audit, bringing InPost toward parity with the DPD Polska adapter and the full set of core shipping capabilities.

Closes #1540
Closes #1541
Closes #1542
Closes #1543
Closes #1544

## What landed (per sub-issue)

- **#1541 - COD (pobranie)**: map the carrier-neutral `GenerateLabelCommand.cod` onto the ShipX `cod` object in the InPost mapper. Courier COD is applied; locker COD is fail-fast-rejected with a typed preflight error (this v1 adapter does not model locker COD yet - follow-up #1554). Backend only; command/DTO/FE already carried `cod`.
- **#1542 - Declared-value / insurance**: new optional neutral `insuredValue { amount, currency }` threaded through core `GenerateLabelCommand`, API `GenerateLabelDto`, the InPost ShipX mapper (`insurance` object, courier + locker), and the FE `GenerateLabelForm` - mirroring the COD plumbing. Optional end-to-end (absent => no `insurance` key). DPD wiring deferred (no existing declared-value service in the DPD adapter) - follow-up.
- **#1543 - DispatchProtocolReader**: implement the handover-protocol capability for InPost via ShipX `GET /v1/organizations/{orgId}/dispatch_orders/printouts` (PDF, or ZIP for multi-service batches). Resolved via the `isDispatchProtocolReader` guard (no manifest change), matching the `LabelDocumentReader` precedent. FE bulk-dispatch button was already carrier-agnostic. Also labels ZIP downloads correctly and caps batches at 100 (ShipX limit).
- **#1544 - Webhook field**: the inbound webhook decoder extracted the wrong `tracking_number`; fixed to the authoritative ShipX `payload.shipment_id` (the re-read key used by `getTracking`), plus body-`event` classification and `event_ts` timestamp fallback. Note: a separate concern about the `verify()` HMAC scheme (base64-over-`{ts}.{body}` vs ShipX hex-over-raw-body) is tracked as follow-up #1556 - it needs a live sandbox capture.

## Follow-ups filed

- #1554 - Model InPost locker (paczkomat) COD in the ShipX adapter.
- #1556 - Verify the InPost ShipX webhook HMAC signature scheme against a live sandbox (also covers the non-ISO `occurredAt` note and a real-payload capture).
- #1569 - Scope shipment COD currency options per carrier (FE picker offers PLN/EUR/RON/CZK; InPost courier COD is PLN-only server-side).
- DPD declared-value/insurance wiring (deferred within #1542).

## Testing

Scoped gates green on the final epic HEAD: `@openlinker/integrations-inpost` (122), `@openlinker/api` shipping (49), `@openlinker/core` shipping (202), `@openlinker/web` (2174).

## Notes

Single branch for the whole epic; each sub-issue was reviewed incrementally on this PR (see the per-subtask review + fix + re-review comment threads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)