### PR TITLE
fix(invoicing): include order shipping cost as an invoice line

### DIFF
--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -355,6 +355,11 @@ export class InvoicingController {
 
     let command: IssueInvoiceCommand;
     try {
+      // `shippingLineName` is intentionally NOT passed here (nor at the other
+      // issuance call sites): there is no locale source at issue time yet, so the
+      // mapper's neutral default label is used. A localized shipping-line label
+      // would be threaded through here once a locale/provider source exists
+      // (follow-up #1562).
       command = toIssueInvoiceCommand({
         order,
         connectionId: dto.connectionId,

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
@@ -250,4 +250,61 @@ describe('toIssueInvoiceCommand', () => {
       UnsupportedPriceTreatmentError,
     );
   });
+
+  it('shipping: totals.shipping > 0 -> appends one gross shipping line after the item lines (#1517)', () => {
+    const order = makeOrder({
+      items: [makeItem({ price: 499.99, quantity: 1 })],
+      totals: {
+        subtotal: 499.99,
+        tax: 0,
+        shipping: 10.49,
+        total: 510.48,
+        currency: 'PLN',
+        taxTreatment: 'inclusive',
+      },
+    });
+
+    const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
+
+    expect(cmd.lines).toHaveLength(2);
+    // Product lines come first; the shipping line is appended last.
+    expect(cmd.lines[0].unitPriceGross).toBe(499.99);
+    expect(cmd.lines[1]).toEqual({
+      name: 'Shipping',
+      quantity: 1,
+      unitPriceGross: 10.49,
+      taxRate: '',
+    });
+    // Invoice gross (summed by InvoiceService.buildContent over cmd.lines) now
+    // equals the order total.
+    const gross = cmd.lines.reduce((sum, l) => sum + l.quantity * l.unitPriceGross, 0);
+    expect(gross).toBeCloseTo(order.totals.total, 2);
+  });
+
+  it('shipping: taxRate left empty on the shipping line (provider adapter resolves the regime rate)', () => {
+    const order = makeOrder({
+      totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+    });
+
+    const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
+
+    const shippingLine = cmd.lines.find((l) => l.name === 'Shipping');
+    expect(shippingLine).toBeDefined();
+    expect(shippingLine?.taxRate).toBe('');
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -5],
+  ])('shipping: totals.shipping %s -> no phantom shipping line (#1517)', (_label, shipping) => {
+    const order = makeOrder({
+      items: [makeItem({ price: 100, quantity: 1 })],
+      totals: { subtotal: 100, tax: 0, shipping, total: 100, currency: 'PLN', taxTreatment: 'inclusive' },
+    });
+
+    const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
+
+    expect(cmd.lines).toHaveLength(1);
+    expect(cmd.lines.some((l) => l.name === 'Shipping')).toBe(false);
+  });
 });

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
@@ -296,6 +296,9 @@ describe('toIssueInvoiceCommand', () => {
   it.each([
     ['zero', 0],
     ['negative', -5],
+    ['NaN', Number.NaN],
+    ['+Infinity', Number.POSITIVE_INFINITY],
+    ['-Infinity', Number.NEGATIVE_INFINITY],
   ])('shipping: totals.shipping %s -> no phantom shipping line (#1517)', (_label, shipping) => {
     const order = makeOrder({
       items: [makeItem({ price: 100, quantity: 1 })],
@@ -307,4 +310,38 @@ describe('toIssueInvoiceCommand', () => {
     expect(cmd.lines).toHaveLength(1);
     expect(cmd.lines.some((l) => l.name === 'Shipping')).toBe(false);
   });
+
+  it('shipping: caller-supplied shippingLineName overrides the neutral default label (#1517)', () => {
+    const order = makeOrder({
+      totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+    });
+
+    const cmd = toIssueInvoiceCommand({
+      order,
+      connectionId: 'conn-1',
+      shippingLineName: 'Koszt wysyłki',
+    });
+
+    const shippingLine = cmd.lines.find((l) => l.unitPriceGross === 15 && l.quantity === 1);
+    expect(shippingLine?.name).toBe('Koszt wysyłki');
+    // Neutral English default is not used when an override is supplied.
+    expect(cmd.lines.some((l) => l.name === 'Shipping')).toBe(false);
+  });
+
+  it.each([
+    ['empty', ''],
+    ['whitespace-only', '   '],
+  ])(
+    'shipping: %s shippingLineName override falls back to the neutral default label (#1517)',
+    (_label, shippingLineName) => {
+      const order = makeOrder({
+        totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+      });
+
+      const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1', shippingLineName });
+
+      const shippingLine = cmd.lines.find((l) => l.unitPriceGross === 15 && l.quantity === 1);
+      expect(shippingLine?.name).toBe('Shipping');
+    },
+  );
 });

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
@@ -23,6 +23,9 @@ import { InvalidBuyerProfileError } from './errors/invalid-buyer-profile.error';
 import { InvalidInvoiceLineError } from './errors/invalid-invoice-line.error';
 import { UnsupportedPriceTreatmentError } from './errors/unsupported-price-treatment.error';
 
+/** Carrier-neutral label for the shipping invoice line (#1517). */
+const SHIPPING_LINE_NAME = 'Shipping';
+
 /** Inputs to {@link toIssueInvoiceCommand}. */
 export interface OrderToIssueInvoiceCommandInput {
   order: Order;
@@ -39,7 +42,8 @@ export interface OrderToIssueInvoiceCommandInput {
  * when no address/buyer-name can be derived, `UnsupportedPriceTreatmentError`
  * when the order is net-priced (`taxTreatment === 'exclusive'`), and
  * `InvalidInvoiceLineError` when an item's quantity is not a positive finite
- * number (#1525).
+ * number (#1525). Appends a gross shipping line when `order.totals.shipping > 0`
+ * so the invoice total equals the buyer-paid order total (#1517).
  */
 export function toIssueInvoiceCommand(
   input: OrderToIssueInvoiceCommandInput,
@@ -57,6 +61,15 @@ export function toIssueInvoiceCommand(
 
   const buyer = buildBuyerProfile(order, buyerTaxId ?? null);
   const lines = order.items.map((item) => toInvoiceLine(item, order.id));
+
+  // Buyer-paid shipping is part of the invoice total (invoice gross must equal
+  // order total, #1517). Emit it as a normal gross line so the provider adapter
+  // resolves its tax rate the same way it does for product lines; core never
+  // names a tax rate. Skipped when shipping is 0 (no phantom line).
+  const shippingLine = toShippingLine(order.totals.shipping);
+  if (shippingLine) {
+    lines.push(shippingLine);
+  }
 
   const command: IssueInvoiceCommand = {
     connectionId,
@@ -177,6 +190,25 @@ function toInvoiceLine(item: OrderItem, orderId: string): InvoiceLine {
     name: item.name?.trim() || item.sku || item.productId,
     quantity: item.quantity,
     unitPriceGross: item.price,
+    taxRate: '',
+  };
+}
+
+/**
+ * Compose the shipping {@link InvoiceLine} from the order's gross shipping cost,
+ * or `null` when there is nothing to bill (#1517). A single unit priced at the
+ * gross shipping amount; `taxRate` is left empty (provider adapter resolves the
+ * regime rate, mirroring {@link toInvoiceLine}). Non-positive or non-finite
+ * shipping (0, negative, NaN) yields no line — no phantom shipping line.
+ */
+function toShippingLine(shipping: number): InvoiceLine | null {
+  if (!Number.isFinite(shipping) || shipping <= 0) {
+    return null;
+  }
+  return {
+    name: SHIPPING_LINE_NAME,
+    quantity: 1,
+    unitPriceGross: shipping,
     taxRate: '',
   };
 }

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
@@ -45,6 +45,13 @@ export interface OrderToIssueInvoiceCommandInput {
    * no locale, so a caller that does (or that translates for a target market)
    * can supply a localized name here; when absent the neutral English
    * {@link SHIPPING_LINE_NAME} default is used.
+   *
+   * NOTE: no issuance caller wires this yet (`AutoIssueTriggerService`, the
+   * invoicing controller), so today the neutral default is the only live path
+   * and a PL/KSeF document still renders "Shipping". This is an intentional seam,
+   * not dead code: a localized label needs a locale source that does not exist in
+   * core yet (no per-connection locale setting; the provider is the natural owner
+   * of national wording per ADR-026). Wiring it is tracked as a follow-up (#1562).
    */
   shippingLineName?: string;
 }

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
@@ -23,7 +23,12 @@ import { InvalidBuyerProfileError } from './errors/invalid-buyer-profile.error';
 import { InvalidInvoiceLineError } from './errors/invalid-invoice-line.error';
 import { UnsupportedPriceTreatmentError } from './errors/unsupported-price-treatment.error';
 
-/** Carrier-neutral label for the shipping invoice line (#1517). */
+/**
+ * Default carrier-neutral label for the shipping invoice line (#1517). Core is
+ * language-agnostic and has no locale, so this English default is intentionally
+ * untranslated; a caller that has a locale can override it via
+ * {@link OrderToIssueInvoiceCommandInput.shippingLineName}.
+ */
 const SHIPPING_LINE_NAME = 'Shipping';
 
 /** Inputs to {@link toIssueInvoiceCommand}. */
@@ -35,6 +40,13 @@ export interface OrderToIssueInvoiceCommandInput {
   /** Pass-through ONLY; the adapter derives when absent. */
   documentType?: string;
   idempotencyKey?: string;
+  /**
+   * Optional override for the shipping-line label on a fiscal document. Core has
+   * no locale, so a caller that does (or that translates for a target market)
+   * can supply a localized name here; when absent the neutral English
+   * {@link SHIPPING_LINE_NAME} default is used.
+   */
+  shippingLineName?: string;
 }
 
 /**
@@ -48,7 +60,8 @@ export interface OrderToIssueInvoiceCommandInput {
 export function toIssueInvoiceCommand(
   input: OrderToIssueInvoiceCommandInput,
 ): IssueInvoiceCommand {
-  const { order, connectionId, buyerTaxId, documentType, idempotencyKey } = input;
+  const { order, connectionId, buyerTaxId, documentType, idempotencyKey, shippingLineName } =
+    input;
 
   // GROSS-only MVP: an `exclusive` (net) order would mislabel net as gross.
   // Fail loud rather than corrupt totals. Absent treatment = documented gross
@@ -66,7 +79,7 @@ export function toIssueInvoiceCommand(
   // order total, #1517). Emit it as a normal gross line so the provider adapter
   // resolves its tax rate the same way it does for product lines; core never
   // names a tax rate. Skipped when shipping is 0 (no phantom line).
-  const shippingLine = toShippingLine(order.totals.shipping);
+  const shippingLine = toShippingLine(order.totals.shipping, shippingLineName);
   if (shippingLine) {
     lines.push(shippingLine);
   }
@@ -199,14 +212,16 @@ function toInvoiceLine(item: OrderItem, orderId: string): InvoiceLine {
  * or `null` when there is nothing to bill (#1517). A single unit priced at the
  * gross shipping amount; `taxRate` is left empty (provider adapter resolves the
  * regime rate, mirroring {@link toInvoiceLine}). Non-positive or non-finite
- * shipping (0, negative, NaN) yields no line — no phantom shipping line.
+ * shipping (0, negative, NaN) yields no line — no phantom shipping line. `name`
+ * defaults to the neutral {@link SHIPPING_LINE_NAME} when the caller supplies no
+ * (locale-specific) override.
  */
-function toShippingLine(shipping: number): InvoiceLine | null {
+function toShippingLine(shipping: number, name?: string): InvoiceLine | null {
   if (!Number.isFinite(shipping) || shipping <= 0) {
     return null;
   }
   return {
-    name: SHIPPING_LINE_NAME,
+    name: name?.trim() || SHIPPING_LINE_NAME,
     quantity: 1,
     unitPriceGross: shipping,
     taxRate: '',

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
@@ -232,6 +232,10 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
   ): InvoicingIssuePayloadV1 {
     // The mapper owns the neutral Order->command rules and may surface
     // InvalidBuyerProfileError / UnsupportedPriceTreatmentError (both PII-clean).
+    // `shippingLineName` is intentionally NOT passed: there is no locale source
+    // here (a Connection carries no locale; config.invoicing holds only
+    // triggerModel), so the mapper's neutral default is used. A localized label
+    // would be threaded here once a locale/provider source exists (#1562).
     const command = toIssueInvoiceCommand({
       order,
       connectionId: invoicingConnectionId,


### PR DESCRIPTION
## Problem

The issued invoice omitted the order's shipping cost, so the invoice total did not equal the amount the buyer paid. Observed on a live golden-path run: an Erli order (1x @ 499.99 PLN + 10.49 shipping, order total 510.48) produced a KSeF invoice with a single 499.99 product line, gross 499.99, and no shipping line - invoice gross != order total.

## Root cause

The order -> `IssueInvoiceCommand` mapper (`libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts`) built `command.lines` from `order.items` only and never turned `order.totals.shipping` into a line. `InvoiceService.buildContent` sums `cmd.lines` for net/tax/gross, so the missing line dropped shipping from the totals and the tax breakdown.

## Fix

In the pure mapper, append one neutral gross shipping line when `order.totals.shipping > 0`:
- quantity 1, `unitPriceGross = order.totals.shipping`, carrier-neutral name (`Shipping`), and empty `taxRate` - mirroring the product-line contract so the provider adapter resolves the regime rate. Core never names a tax rate.
- No phantom line when shipping is 0 (also guards non-finite / negative).

Because both issuance entry points (`AutoIssueTriggerService` and the HTTP controller) compose the command through this mapper, the fix is uniform and needs no adapter change. `InvoiceService` picks up the extra line automatically - shipping now flows into the totals and tax breakdown, and invoice gross equals the order total.

No CORE <-> Integration boundary change; no document-type / tax-scheme vocabulary added to core.

## Tests

Added unit tests on the mapper: shipping line appended (and ordered after item lines) when `shipping > 0`, gross sum equals order total, `taxRate` left empty, and no phantom line for zero/negative shipping. Scoped `pnpm --filter @openlinker/core test` for the mapper (23 passing) and `invoice.service` (42 passing) green; core `type-check` clean.

Closes #1517

🤖 Generated with [Claude Code](https://claude.com/claude-code)