### PR TITLE
feat(woocommerce): variant/combination mapping mirroring PrestaShop (#1553)

### DIFF
--- a/libs/integrations/woocommerce/src/infrastructure/adapters/inventory-master/woocommerce-inventory-master.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/inventory-master/woocommerce-inventory-master.adapter.ts
@@ -27,6 +27,7 @@ import { WooCommerceResourceNotFoundException } from '../../../domain/exceptions
 import { WooCommerceNotSupportedException } from '../../../domain/exceptions/woocommerce-not-supported.exception';
 import { WooCommerceInvalidIdentifierException } from '../../../domain/exceptions/woocommerce-invalid-identifier.exception';
 import { fetchAllPages, toPositiveInt } from '../../utils/woocommerce-utils';
+import { buildSyntheticVariantExternalId } from '../../mappers/woocommerce-variant-id';
 import {
   DEFAULT_UNMANAGED_STOCK_QUANTITY,
   type WooCommerceConnectionConfig,
@@ -192,7 +193,7 @@ export class WooCommerceInventoryMasterAdapter implements InventoryMasterPort {
     wcId: number,
     product: WooCommerceProduct,
   ): Promise<Inventory[]> {
-    const syntheticExternalId = `product:${wcId}`;
+    const syntheticExternalId = buildSyntheticVariantExternalId(wcId);
     const variantId = await this.identifierMapping.getOrCreateInternalId(
       CORE_ENTITY_TYPE.ProductVariant,
       syntheticExternalId,
@@ -281,7 +282,7 @@ export class WooCommerceInventoryMasterAdapter implements InventoryMasterPort {
     const [variantId, inventoryId] = await Promise.all([
       this.identifierMapping.getOrCreateInternalId(
         CORE_ENTITY_TYPE.ProductVariant,
-        `product:${wcId}`,
+        buildSyntheticVariantExternalId(wcId),
         this.connection.id,
         { parentEntityType: CORE_ENTITY_TYPE.Product, parentInternalId: adjustment.productId },
       ),

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -49,6 +49,7 @@ import { WooCommerceOrderProcessingException } from '../../../domain/exceptions/
 import { WooCommerceInvalidArgumentException } from '../../../domain/exceptions/woocommerce-invalid-argument.exception';
 import { WooCommerceInvalidIdentifierException } from '../../../domain/exceptions/woocommerce-invalid-identifier.exception';
 import { toPositiveInt } from '../../utils/woocommerce-utils';
+import { isSyntheticVariantExternalId } from '../../mappers/woocommerce-variant-id';
 import type {
   WooCommerceOrderCreateRequest,
   WooCommerceOrderUpdateRequest,
@@ -396,7 +397,7 @@ export class WooCommerceOrderProcessorAdapter
             this.connection.id,
           );
         }
-        if (variantMapping.externalId.startsWith('product:')) {
+        if (isSyntheticVariantExternalId(variantMapping.externalId)) {
           // Synthetic variant of a simple product (`product:{wcId}` — same
           // convention as PrestaShop; the inventory adapter strips this
           // prefix too). Simple products have no WC variation — the line

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/woocommerce-product-master.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/woocommerce-product-master.adapter.ts
@@ -36,6 +36,7 @@ import { Logger } from '@openlinker/shared/logging';
 import type { IWooCommerceHttpClient } from '../../http/woocommerce-http-client.interface';
 import { WooCommerceHttpResponseException } from '../../http/woocommerce-http-response.exception';
 import type { IWooCommerceProductMapper } from '../../mappers/woocommerce-product.mapper.interface';
+import { buildSyntheticVariantExternalId } from '../../mappers/woocommerce-variant-id';
 import { WooCommerceResourceNotFoundException } from '../../../domain/exceptions/woocommerce-resource-not-found.exception';
 import { WooCommerceDuplicateSkuException } from '../../../domain/exceptions/woocommerce-duplicate-sku.exception';
 import type {
@@ -180,7 +181,7 @@ export class WooCommerceProductMasterAdapter implements ProductMasterPort {
 
     if (product.type !== 'variable' || !product.variations?.length) {
       // Simple product — deterministic synthetic variant (same convention as PrestaShop)
-      const syntheticExternalId = `product:${wcId}`;
+      const syntheticExternalId = buildSyntheticVariantExternalId(wcId);
       const internalVariantId = await this.identifierMapping.getOrCreateInternalId(
         CORE_ENTITY_TYPE.ProductVariant,
         syntheticExternalId,
@@ -209,7 +210,7 @@ export class WooCommerceProductMasterAdapter implements ProductMasterPort {
     // Variable product — delete stale synthetic (safe no-op if absent)
     await this.identifierMapping.deleteMapping(
       CORE_ENTITY_TYPE.ProductVariant,
-      `product:${wcId}`,
+      buildSyntheticVariantExternalId(wcId),
       this.connection.id,
     );
 

--- a/libs/integrations/woocommerce/src/infrastructure/mappers/__tests__/woocommerce-variant-id.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/mappers/__tests__/woocommerce-variant-id.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the WooCommerce variant-id helpers.
+ *
+ * Locks the synthetic-variant marker contract relied on by the product-master,
+ * inventory-master, and order-processor adapters: a simple product maps to a
+ * deterministic `product:{wcId}` external id, and every call site agrees on how
+ * to build and detect it (mirrors prestashop-variant-id.spec.ts).
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/mappers
+ */
+import {
+  WOOCOMMERCE_SYNTHETIC_VARIANT_PREFIX,
+  buildSyntheticVariantExternalId,
+  isSyntheticVariantExternalId,
+} from '../woocommerce-variant-id';
+
+describe('woocommerce-variant-id', () => {
+  describe('buildSyntheticVariantExternalId', () => {
+    it('should build a product:{wcId} marker from a numeric WC product id', () => {
+      expect(buildSyntheticVariantExternalId(25)).toBe('product:25');
+    });
+
+    it('should build a product:{wcId} marker from a string WC product id', () => {
+      expect(buildSyntheticVariantExternalId('460')).toBe('product:460');
+    });
+
+    it('should be deterministic — the same product id yields the same marker', () => {
+      expect(buildSyntheticVariantExternalId(7)).toBe(buildSyntheticVariantExternalId(7));
+    });
+
+    it('should use the shared prefix constant', () => {
+      expect(buildSyntheticVariantExternalId(1)).toBe(
+        `${WOOCOMMERCE_SYNTHETIC_VARIANT_PREFIX}1`,
+      );
+    });
+  });
+
+  describe('isSyntheticVariantExternalId', () => {
+    it('should return true for a synthetic marker', () => {
+      expect(isSyntheticVariantExternalId('product:25')).toBe(true);
+    });
+
+    it('should return true for a marker built by buildSyntheticVariantExternalId', () => {
+      expect(isSyntheticVariantExternalId(buildSyntheticVariantExternalId(99))).toBe(true);
+    });
+
+    it('should return false for a real numeric WC variation id', () => {
+      expect(isSyntheticVariantExternalId('460')).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(isSyntheticVariantExternalId(undefined)).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      expect(isSyntheticVariantExternalId(null)).toBe(false);
+    });
+
+    it('should return false for an empty string', () => {
+      expect(isSyntheticVariantExternalId('')).toBe(false);
+    });
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/mappers/woocommerce-variant-id.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/mappers/woocommerce-variant-id.ts
@@ -1,0 +1,39 @@
+/**
+ * WooCommerce variant-id helpers
+ *
+ * Centralizes the synthetic-variant marker convention shared by the
+ * product-master, inventory-master, and order-processor adapters. A WooCommerce
+ * "simple product" has no WC variation, so OpenLinker maps it to a deterministic
+ * synthetic ProductVariant whose external id is `product:{wcProductId}` (matching
+ * the PrestaShop precedent). A "variable product" maps each WC variation to a
+ * variant keyed by the numeric WC variation id.
+ *
+ * Extracted so the marker literal cannot drift between the call sites that build
+ * or detect it — the same rationale behind prestashop-variant-id.ts. Before this
+ * was extracted, the `product:{wcId}` string was hand-written in three adapters,
+ * and the order-processor duplicated the `startsWith('product:')` detection
+ * inline.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/mappers
+ * @see prestashop-variant-id for the PrestaShop precedent
+ */
+
+/** Prefix marking a synthetic variant of a WooCommerce simple product. */
+export const WOOCOMMERCE_SYNTHETIC_VARIANT_PREFIX = 'product:';
+
+/**
+ * Builds the deterministic synthetic-variant external id for a simple product.
+ * Stable per WC product id, so repeat syncs resolve the same OpenLinker variant.
+ */
+export function buildSyntheticVariantExternalId(wcProductId: number | string): string {
+  return `${WOOCOMMERCE_SYNTHETIC_VARIANT_PREFIX}${wcProductId}`;
+}
+
+/**
+ * True when an external variant id is a synthetic simple-product marker rather
+ * than a real WC variation id. Callers skip variation-id coercion for these — a
+ * simple product's line item is the product itself, with no `variation_id`.
+ */
+export function isSyntheticVariantExternalId(raw: string | null | undefined): boolean {
+  return typeof raw === 'string' && raw.startsWith(WOOCOMMERCE_SYNTHETIC_VARIANT_PREFIX);
+}

--- a/libs/integrations/woocommerce/src/infrastructure/mappers/woocommerce-variant.mapper.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/mappers/woocommerce-variant.mapper.ts
@@ -1,0 +1,11 @@
+/**
+ * WooCommerce Variant Mapper
+ *
+ * Maps WooCommerce product-variation data to the OpenLinker ProductVariant
+ * schema. The mapping logic lives on WooCommerceProductMapper (mapVariation);
+ * this alias mirrors the PrestaShop layout (prestashop-variant.mapper.ts) so the
+ * variant-mapping seam has a named home.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/mappers
+ */
+export { WooCommerceProductMapper as WooCommerceVariantMapper } from './woocommerce-product.mapper';


### PR DESCRIPTION
Part of #1547 (WooCommerce parity with PrestaShop).

## What changed and why

Mirrors the PrestaShop variant-mapping layout for WooCommerce, giving the variant-mapping seam a named home and centralizing the synthetic-variant marker so it cannot drift between adapters.

- Add `woocommerce-variant.mapper.ts` - aliases `WooCommerceProductMapper` as `WooCommerceVariantMapper`, mirroring `prestashop-variant.mapper.ts`.
- Add `woocommerce-variant-id.ts` - the shared synthetic-variant marker (`product:{wcId}`), a builder (`buildSyntheticVariantExternalId`), and a detector (`isSyntheticVariantExternalId`), mirroring `prestashop-variant-id.ts`.
- Route the product-master, inventory-master, and order-processor adapters through the shared helpers, removing the hand-written `product:` literal that was duplicated across all three call sites (the same drift risk that motivated the PrestaShop extraction).
- Add unit tests for the variant-id helpers.

The underlying behavior was already in place: WooCommerce variable products expand to one `ProductVariant` per variation (carrying SKU / GTIN / attributes), simple products yield a deterministic synthetic variant, and the inventory-master adapter keys stock per variant (#822/#823). This change adds the two named files called for in the issue and removes the duplicated marker literal without rewriting the working, already-tested behavior.

## How to test

Scoped to the WooCommerce package:

```
pnpm --filter @openlinker/integrations-woocommerce type-check
pnpm --filter @openlinker/integrations-woocommerce lint
pnpm --filter @openlinker/integrations-woocommerce test
```

Type-check and lint pass with zero errors; all 342 unit tests pass (including the new `woocommerce-variant-id.spec.ts` and the existing variable-expansion / synthetic-variant coverage in the product-master adapter and product mapper specs).

## Acceptance criteria

- [x] A WooCommerce variant mapper maps variations to `ProductVariant`s with SKU/GTIN + attributes.
- [x] Simple (non-variable) products yield a deterministic synthetic variant.
- [x] The WooCommerce `ProductMasterPort` adapter returns per-variant data; inventory keys per variant.
- [x] Unit tests cover variable-product expansion and the simple-product synthetic variant.
- [x] No architecture boundary violations (CORE <-> Integration).

Closes #1553