### PR TITLE
feat(woocommerce): implement OrderStatusWriteback sub-capability

### DIFF
--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
@@ -13,7 +13,8 @@ import {
   isValidEmail,
 } from '../woocommerce-order-processor.adapter';
 import { toPositiveInt } from '../../../utils/woocommerce-utils';
-import { WC_ORDER_STATUS_MAP } from '../woocommerce-order.types';
+import { WC_ORDER_STATUS_MAP, WC_ORDER_STATUS_VALUES } from '../woocommerce-order.types';
+import { isOrderStatusWriteback } from '@openlinker/core/orders';
 import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-client.interface';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
@@ -134,6 +135,26 @@ describe('WC_ORDER_STATUS_MAP', () => {
 
   it('should map shipped and delivered both to completed', () => {
     expect(WC_ORDER_STATUS_MAP.shipped).toBe(WC_ORDER_STATUS_MAP.delivered);
+  });
+});
+
+describe('WC_ORDER_STATUS_VALUES', () => {
+  it('should expose the WooCommerce core status vocabulary', () => {
+    expect(WC_ORDER_STATUS_VALUES).toEqual([
+      'pending',
+      'processing',
+      'on-hold',
+      'completed',
+      'cancelled',
+      'refunded',
+      'failed',
+    ]);
+  });
+
+  it('should contain every value produced by the neutral → WC map', () => {
+    for (const wcStatus of Object.values(WC_ORDER_STATUS_MAP)) {
+      expect(WC_ORDER_STATUS_VALUES).toContain(wcStatus);
+    }
   });
 });
 
@@ -806,5 +827,114 @@ describe('WooCommerceOrderProcessorAdapter — updateFulfillment', () => {
     ).resolves.toBeUndefined();
     const [, payload] = httpClient.put.mock.calls[0];
     expect(payload).not.toHaveProperty('tracking_number');
+  });
+});
+
+// ─── OrderStatusWriteback (write) ────────────────────────────────────────────
+
+describe('WooCommerceOrderProcessorAdapter — OrderStatusWriteback', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should be detected by the isOrderStatusWriteback guard', () => {
+    const adapter = makeAdapter(makeHttpClient(), makeIdentifierMapping());
+    expect(isOrderStatusWriteback(adapter)).toBe(true);
+  });
+
+  // ── dispatched ──
+
+  it('should PUT status completed for a dispatched event', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.put.mockResolvedValue({ id: 55, status: 'completed' });
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({ type: 'dispatched', externalOrderId: '55' });
+
+    expect(httpClient.put).toHaveBeenCalledWith('/wp-json/wc/v3/orders/55', { status: 'completed' });
+    expect(result).toEqual({ outcome: 'applied' });
+  });
+
+  it('should accept a trackingNumber on a dispatched event without failing', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.put.mockResolvedValue({ id: 55, status: 'completed' });
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({
+      type: 'dispatched',
+      externalOrderId: '55',
+      trackingNumber: 'TRACK123',
+    });
+
+    expect(result).toEqual({ outcome: 'applied' });
+    const [, payload] = httpClient.put.mock.calls[0];
+    expect(payload).not.toHaveProperty('tracking_number');
+  });
+
+  // ── cancelled ──
+
+  it('should read the order then PUT status cancelled for a cancelled event', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: 55, status: 'processing' });
+    httpClient.put.mockResolvedValue({ id: 55, status: 'cancelled' });
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({ type: 'cancelled', externalOrderId: '55' });
+
+    expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/orders/55');
+    expect(httpClient.put).toHaveBeenCalledWith('/wp-json/wc/v3/orders/55', { status: 'cancelled' });
+    expect(result).toEqual({ outcome: 'applied' });
+  });
+
+  it.each(['completed', 'refunded'])(
+    'should reject a cancel writeback when WC is already %s (no PUT)',
+    async (currentStatus) => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue({ id: 55, status: currentStatus });
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const result = await adapter.write({ type: 'cancelled', externalOrderId: '55' });
+
+      expect(result.outcome).toBe('rejected');
+      expect(result.detail).toContain(currentStatus);
+      expect(httpClient.put).not.toHaveBeenCalled();
+    },
+  );
+
+  it('should treat a cancel writeback as an idempotent no-op when already cancelled (no PUT)', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: 55, status: 'cancelled' });
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({ type: 'cancelled', externalOrderId: '55' });
+
+    expect(result).toEqual({ outcome: 'applied' });
+    expect(httpClient.put).not.toHaveBeenCalled();
+  });
+
+  // ── failure / validation ──
+
+  it.each(['1/refunds', 'abc', '', '-1'])(
+    'should reject (not throw) a non-numeric externalOrderId "%s"',
+    async (id) => {
+      const httpClient = makeHttpClient();
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const result = await adapter.write({ type: 'cancelled', externalOrderId: id });
+
+      expect(result.outcome).toBe('rejected');
+      expect(httpClient.get).not.toHaveBeenCalled();
+      expect(httpClient.put).not.toHaveBeenCalled();
+    },
+  );
+
+  it('should return rejected (never throw) when the WC PUT fails', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: 55, status: 'processing' });
+    httpClient.put.mockRejectedValue(new WooCommerceHttpResponseException(500, 'server error'));
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({ type: 'cancelled', externalOrderId: '55' });
+
+    expect(result.outcome).toBe('rejected');
+    expect(result.detail).toBeDefined();
   });
 });

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -1,9 +1,10 @@
 /**
  * WooCommerce Order Processor Adapter
  *
- * Implements OrderProcessorManagerPort (createOrder) and the OrderFulfillmentUpdater
- * sub-capability (updateFulfillment — status updates, cancellations, refund transitions)
- * for WooCommerce REST API v3.
+ * Implements OrderProcessorManagerPort (createOrder), the OrderFulfillmentUpdater
+ * sub-capability (updateFulfillment — status updates, cancellations, refund transitions),
+ * and the OrderStatusWriteback sub-capability (write — the #1157 / ADR-027 lifecycle
+ * relay contract) for WooCommerce REST API v3.
  *
  * Key design decisions:
  * - createOrder: the adapter does NOT dedup. It POSTs to WC and returns the
@@ -27,6 +28,7 @@
  * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
  * @implements {OrderProcessorManagerPort}
  * @implements {OrderFulfillmentUpdater}
+ * @implements {OrderStatusWriteback}
  */
 import type {
   OrderProcessorManagerPort,
@@ -36,7 +38,12 @@ import type {
   Address,
   OrderStatus,
 } from '@openlinker/core/orders';
-import type { OrderFulfillmentUpdater } from '@openlinker/core/orders';
+import type {
+  OrderFulfillmentUpdater,
+  OrderStatusWriteback,
+  OrderLifecycleEvent,
+  OrderWritebackResult,
+} from '@openlinker/core/orders';
 import type { IdentifierMappingPort, Connection, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
@@ -75,7 +82,7 @@ export function isValidEmail(value: unknown): value is string {
 // ─── Adapter ──────────────────────────────────────────────────────────────────
 
 export class WooCommerceOrderProcessorAdapter
-  implements OrderProcessorManagerPort, OrderFulfillmentUpdater
+  implements OrderProcessorManagerPort, OrderFulfillmentUpdater, OrderStatusWriteback
 {
   private readonly logger = new Logger(WooCommerceOrderProcessorAdapter.name);
 
@@ -207,6 +214,80 @@ export class WooCommerceOrderProcessorAdapter
       this.logger.debug(
         `updateFulfillment: trackingNumber "${input.trackingNumber}" accepted but not persisted (WC has no core tracking field)`,
       );
+    }
+  }
+
+  // ─── OrderStatusWriteback ─────────────────────────────────────────────────
+
+  /**
+   * `OrderStatusWriteback` (#1157 / ADR-027): the single event-as-data writeback
+   * the lifecycle relay dispatches through. Maps each neutral lifecycle event
+   * onto WooCommerce's order status and PUTs it via `PUT /orders/{id}`.
+   *
+   * Never throws — the outcome is reported via `OrderWritebackResult`:
+   * - `dispatched` → set WC status `completed` (delegates to `updateFulfillment`,
+   *   the same neutral-`shipped` → WC-`completed` mapping). `applied`.
+   * - `cancelled`  → refuse (`rejected`) if WC has already reached a terminal
+   *   fulfilled state (`completed` / `refunded`) — the shop is authoritative for
+   *   its own live state, so we surface the conflict rather than force a
+   *   regressive transition. Idempotent when already `cancelled`. Otherwise PUT
+   *   `cancelled`. `applied`.
+   */
+  async write(event: OrderLifecycleEvent): Promise<OrderWritebackResult> {
+    try {
+      if (!/^\d+$/.test(event.externalOrderId)) {
+        return {
+          outcome: 'rejected',
+          detail: `Invalid externalOrderId "${event.externalOrderId}" — expected a WC integer ID`,
+        };
+      }
+
+      if (event.type === 'dispatched') {
+        await this.updateFulfillment({
+          externalOrderId: event.externalOrderId,
+          status: 'shipped',
+          trackingNumber: event.trackingNumber,
+        });
+        return { outcome: 'applied' };
+      }
+
+      // event.type === 'cancelled' — one read to honour the shop's authoritative
+      // live state before forcing a regressive transition.
+      const order = await this.httpClient.get<WooCommerceOrderResponse>(
+        `/wp-json/wc/v3/orders/${event.externalOrderId}`,
+      );
+      const currentStatus = order.status;
+
+      if (currentStatus === 'completed' || currentStatus === 'refunded') {
+        this.logger.warn(
+          `WooCommerce order ${event.externalOrderId} already in terminal state ` +
+            `'${currentStatus}' — refusing cancel writeback (connection: ${this.connection.id})`,
+        );
+        return { outcome: 'rejected', detail: `order already ${currentStatus}` };
+      }
+
+      if (currentStatus === 'cancelled') {
+        this.logger.debug(
+          `WooCommerce order ${event.externalOrderId} already cancelled — cancel writeback is a no-op ` +
+            `(connection: ${this.connection.id})`,
+        );
+        return { outcome: 'applied' };
+      }
+
+      const wcStatus = WC_ORDER_STATUS_MAP.cancelled;
+      await this.httpClient.put<WooCommerceOrderUpdateRequest>(
+        `/wp-json/wc/v3/orders/${event.externalOrderId}`,
+        { status: wcStatus } satisfies WooCommerceOrderUpdateRequest,
+      );
+      return { outcome: 'applied' };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `OrderStatusWriteback '${event.type}' failed for WooCommerce order ` +
+          `${event.externalOrderId}: ${detail} (connection: ${this.connection.id})`,
+        error instanceof Error ? error.stack : undefined,
+      );
+      return { outcome: 'rejected', detail };
     }
   }
 

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-status.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-status.types.ts
@@ -1,0 +1,51 @@
+/**
+ * WooCommerce Order Status Vocabulary and Mapping
+ *
+ * The shared, single source of truth for translating between OpenLinker's
+ * neutral `OrderStatus` and WooCommerce's own order-status vocabulary. Kept in a
+ * dedicated `*.types.ts` module (per the `as const` convention) so every
+ * WooCommerce order sub-capability reuses the same map and vocabulary without
+ * duplication:
+ * - `OrderStatusWriteback` / `OrderFulfillmentUpdater` / `createOrder` (#1549) —
+ *   neutral → WC direction via {@link WC_ORDER_STATUS_MAP}.
+ * - `FulfillmentStatusReader` (#1550) — WC → neutral direction, keyed off
+ *   {@link WooCommerceOrderStatus}.
+ * - `DestinationOptionsReader` (#1551) — enumerates the WC status vocabulary via
+ *   {@link WC_ORDER_STATUS_VALUES}.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
+ */
+import type { OrderStatus } from '@openlinker/core/orders';
+
+/**
+ * The WooCommerce core order-status vocabulary (WC REST API v3). Declared as a
+ * runtime array so consumers can enumerate it (option pickers, validation)
+ * without an enum runtime artifact.
+ */
+export const WC_ORDER_STATUS_VALUES = [
+  'pending',
+  'processing',
+  'on-hold',
+  'completed',
+  'cancelled',
+  'refunded',
+  'failed',
+] as const;
+
+/** A WooCommerce core order status. */
+export type WooCommerceOrderStatus = (typeof WC_ORDER_STATUS_VALUES)[number];
+
+/**
+ * Neutral `OrderStatus` → WooCommerce status. Lossy best-effort: WC has no
+ * distinct `shipped` state, so both `shipped` and `delivered` collapse onto
+ * `completed`. Exported so tests and sibling sub-capabilities verify it without
+ * instantiating an adapter.
+ */
+export const WC_ORDER_STATUS_MAP: Record<OrderStatus, WooCommerceOrderStatus> = {
+  pending: 'pending',
+  processing: 'processing',
+  shipped: 'completed',
+  delivered: 'completed',
+  cancelled: 'cancelled',
+  refunded: 'refunded',
+};

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order.types.ts
@@ -2,26 +2,21 @@
  * WooCommerce Order Adapter Types
  *
  * Request and response shapes for WooCommerce REST API v3 order and customer
- * operations, plus the OL OrderStatus → WC status mapping constant.
+ * operations.
  *
  * All response fields are declared optional where the WC API may omit them.
  *
+ * The OL `OrderStatus` → WC status map and the WC status vocabulary live in the
+ * dedicated `woocommerce-order-status.types.ts` module (shared across the order
+ * sub-capabilities); they are re-exported here for import-path stability.
+ *
  * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
  */
-import type { OrderStatus } from '@openlinker/core/orders';
 
-// ─── Status map ───────────────────────────────────────────────────────────────
-// Exported as a constant so tests can import and verify it without instantiating
-// the adapter (DRY, single source of truth for the WC status mapping).
+// ─── Status map (re-exported from the dedicated status module) ──────────────────
 
-export const WC_ORDER_STATUS_MAP: Record<OrderStatus, string> = {
-  pending:    'pending',
-  processing: 'processing',
-  shipped:    'completed',
-  delivered:  'completed',
-  cancelled:  'cancelled',
-  refunded:   'refunded',
-};
+export { WC_ORDER_STATUS_MAP, WC_ORDER_STATUS_VALUES } from './woocommerce-order-status.types';
+export type { WooCommerceOrderStatus } from './woocommerce-order-status.types';
 
 // ─── Order shapes ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What changed and why

Part of #1547 (WooCommerce parity with PrestaShop).

`WooCommerceOrderProcessorAdapter` previously implemented only `OrderProcessorManagerPort` and `OrderFulfillmentUpdater`, so it could not relay a lifecycle status change back to an order's participant. This change has it additionally implement the `OrderStatusWriteback` sub-capability (#1157 / ADR-027) - the single `write(event)` contract the Posture-A lifecycle relay dispatches through, mirroring PrestaShop's implementation.

### `write(event)`

Maps each neutral `OrderLifecycleEvent` onto WooCommerce's order-status vocabulary and PUTs it via REST `PUT /orders/{id}`:

- `dispatched` -> WC `completed` (neutral `shipped`), delegating to the existing `updateFulfillment` path. Outcome `applied`.
- `cancelled` -> reads the order first; refuses (`rejected`) when WC has already reached a terminal fulfilled state (`completed` / `refunded`), since the shop is authoritative for its own live state; idempotent no-op when already `cancelled`; otherwise PUTs `cancelled`. Outcome `applied`.

`write` never throws - every failure and conflict is surfaced via `OrderWritebackResult` (`applied` / `rejected`), consistent with ADR-027 and the PrestaShop reference.

### Shared status module

Extracted the neutral<->WooCommerce order-status vocabulary and map into a dedicated `woocommerce-order-status.types.ts` module following the `as const` convention. It exposes `WC_ORDER_STATUS_VALUES` (the WC vocabulary), `WooCommerceOrderStatus`, and `WC_ORDER_STATUS_MAP` (neutral -> WC). This is the single source of truth reused by the sibling `FulfillmentStatusReader` (#1550) and `DestinationOptionsReader` (#1551) sub-capabilities. `WC_ORDER_STATUS_MAP` is re-exported from `woocommerce-order.types.ts` for import-path stability.

No plugin-manifest change is needed: `OrderStatusWriteback` is guard-detected on the resolved adapter via `isOrderStatusWriteback`, not declared as a registry capability.

## How to test

Scoped to the WooCommerce package:

```
pnpm --filter @openlinker/integrations-woocommerce type-check
pnpm --filter @openlinker/integrations-woocommerce lint
pnpm --filter @openlinker/integrations-woocommerce test
```

New unit tests cover the `isOrderStatusWriteback` guard, the dispatched and cancelled paths, the terminal-state refusal, the idempotent no-op, non-numeric id rejection, PUT-failure handling, and the status vocabulary constant. All 346 package tests pass.

## Related issues

Closes #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)