### PR TITLE
feat(woocommerce): add inbound webhook support (provisioning + event translation)

### DIFF
--- a/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
+++ b/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
@@ -24,6 +24,7 @@ interface HostStub {
   credentialsRegistry: { register: jest.Mock };
   authFailureRegistry: { register: jest.Mock };
   schedulerRegistry: { register: jest.Mock };
+  translatorRegistry: { register: jest.Mock };
 }
 
 function makeHostStub(): HostStub {
@@ -32,6 +33,7 @@ function makeHostStub(): HostStub {
   const credentialsRegistry = { register: jest.fn() };
   const authFailureRegistry = { register: jest.fn() };
   const schedulerRegistry = { register: jest.fn() };
+  const translatorRegistry = { register: jest.fn() };
 
   const host = {
     connectionTesterRegistry: testerRegistry,
@@ -42,6 +44,7 @@ function makeHostStub(): HostStub {
     authFailureClassifierRegistry: authFailureRegistry,
     schedulerTaskRegistry: schedulerRegistry,
     webhookProvisioningRegistry: { register: jest.fn() },
+    webhookEventTranslatorRegistry: translatorRegistry,
     oauthCompletionRegistry: { register: jest.fn() },
     adapterRegistry: { register: jest.fn() },
     factoryResolver: { registerFactory: jest.fn() },
@@ -55,7 +58,15 @@ function makeHostStub(): HostStub {
     } as unknown as HostServices['credentialsResolver'],
   } as unknown as HostServices;
 
-  return { host, testerRegistry, configRegistry, credentialsRegistry, authFailureRegistry, schedulerRegistry };
+  return {
+    host,
+    testerRegistry,
+    configRegistry,
+    credentialsRegistry,
+    authFailureRegistry,
+    schedulerRegistry,
+    translatorRegistry,
+  };
 }
 
 const mockConnection: Connection = {
@@ -200,6 +211,17 @@ describe('createWooCommercePlugin → register(host) — #876 additions', () => 
     createWooCommercePlugin().register!(host);
     expect(schedulerRegistry.register).toHaveBeenCalledWith(
       expect.objectContaining({ taskId: 'woocommerce-orders-poll' }),
+    );
+  });
+});
+
+describe('createWooCommercePlugin → register(host) — #1548 inbound webhooks', () => {
+  it('should register the webhook event translator at the plugin adapterKey', () => {
+    const { host, translatorRegistry } = makeHostStub();
+    createWooCommercePlugin().register!(host);
+    expect(translatorRegistry.register).toHaveBeenCalledWith(
+      'woocommerce.restapi.v3',
+      expect.objectContaining({ translate: expect.any(Function) }),
     );
   });
 });

--- a/libs/integrations/woocommerce/src/domain/types/woocommerce-config.types.ts
+++ b/libs/integrations/woocommerce/src/domain/types/woocommerce-config.types.ts
@@ -43,4 +43,18 @@ export interface WooCommerceConnectionConfig {
 
   /** OrderSource capability configuration (#876). */
   orders?: WooCommerceOrdersConfig;
+
+  // Base URL of this OpenLinker instance, where WooCommerce POSTs inbound
+  // webhook deliveries (e.g. http://host.docker.internal:3000 in dev, the
+  // public OL URL in prod). Required before webhook provisioning (#1548) —
+  // WooCommerceWebhookProvisioningAdapter builds each webhook's delivery_url
+  // as `${openlinkerCallbackBaseUrl}/webhooks/woocommerce/${connectionId}`.
+  // Left off the config-shape DTO on purpose: the provisioning adapter is the
+  // single point that validates presence, mirroring the PrestaShop flow.
+  openlinkerCallbackBaseUrl?: string;
+
+  // Set true by WooCommerceWebhookProvisioningAdapter once webhooks are
+  // registered on the store (#1548). Advisory flag surfaced in the FE
+  // connection-actions UI; the reconciliation poll backstops regardless.
+  webhooksConfigured?: boolean;
 }

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-event-translator.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-event-translator.adapter.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * WooCommerce Webhook Event Translator Adapter Unit Tests (#1548)
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/__tests__
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+import { WooCommerceWebhookEventTranslatorAdapter } from '../woocommerce-webhook-event-translator.adapter';
+
+describe('WooCommerceWebhookEventTranslatorAdapter', () => {
+  const translator = new WooCommerceWebhookEventTranslatorAdapter();
+
+  const event = (overrides: Partial<InboundWebhookEvent>): InboundWebhookEvent => ({
+    eventId: 'evt-1',
+    provider: 'woocommerce',
+    connectionId: 'conn-1',
+    eventType: 'order.created',
+    occurredAt: '2026-01-01T00:00:00.000Z',
+    receivedAt: '2026-01-01T00:00:01.000Z',
+    objectType: 'order',
+    externalId: '42',
+    payload: {},
+    ...overrides,
+  });
+
+  it('should translate order.created to the order domain with created', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'order.created' }));
+
+    expect(result).toEqual({
+      domain: 'order',
+      externalId: '42',
+      eventType: 'created',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      payload: {},
+    });
+  });
+
+  it('should map order.updated to updated', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'order.updated' }));
+
+    expect(result?.domain).toBe('order');
+    expect(result?.eventType).toBe('updated');
+  });
+
+  it('should map order.deleted to cancelled', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'order.deleted' }));
+
+    expect(result?.eventType).toBe('cancelled');
+  });
+
+  it('should accept the bare action form (created) without the topic prefix', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'created' }));
+
+    expect(result?.eventType).toBe('created');
+  });
+
+  it('should default an unknown order event type to updated', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'order.weird' }));
+
+    expect(result?.eventType).toBe('updated');
+  });
+
+  it('should be case-insensitive on objectType', () => {
+    const result = translator.translate(event({ objectType: 'ORDER', eventType: 'order.created' }));
+
+    expect(result?.domain).toBe('order');
+  });
+
+  it('should preserve externalId and payload', () => {
+    const result = translator.translate(
+      event({ objectType: 'order', externalId: '777', payload: { id: 777, status: 'processing' } }),
+    );
+
+    expect(result?.externalId).toBe('777');
+    expect(result?.payload).toEqual({ id: 777, status: 'processing' });
+  });
+
+  it('should return null for an unknown object type (undecodable -> dead-letter)', () => {
+    expect(translator.translate(event({ objectType: 'product' }))).toBeNull();
+    expect(translator.translate(event({ objectType: 'coupon' }))).toBeNull();
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-event-translator.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-event-translator.adapter.spec.ts
@@ -41,10 +41,12 @@ describe('WooCommerceWebhookEventTranslatorAdapter', () => {
     expect(result?.eventType).toBe('updated');
   });
 
-  it('should map order.deleted to cancelled', () => {
+  it('should default a non-create order event (e.g. order.deleted) to updated', () => {
+    // Only order.created / order.updated are provisioned, so anything that
+    // isn't a create falls back to a safe re-pull (updated).
     const result = translator.translate(event({ objectType: 'order', eventType: 'order.deleted' }));
 
-    expect(result?.eventType).toBe('cancelled');
+    expect(result?.eventType).toBe('updated');
   });
 
   it('should accept the bare action form (created) without the topic prefix', () => {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-provisioning.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-provisioning.adapter.spec.ts
@@ -146,6 +146,42 @@ describe('WooCommerceWebhookProvisioningAdapter', () => {
       const created = (mockHttpClient.post.mock.calls[0] as unknown[])[1] as { topic: string };
       expect(created.topic).toBe('order.updated');
     });
+
+    it('pages the existing-webhook listing until exhausted so a match past page 1 is not duplicated', async () => {
+      const deliveryUrl = 'https://api.openlinker.example/webhooks/woocommerce/connection-123';
+      // A full first page (100 unrelated rows) forces a second page fetch; the
+      // OL match sits on page 2, so a single-page listing would have missed it.
+      const fullFirstPage = Array.from({ length: 100 }, (_, i) => ({
+        id: 1000 + i,
+        topic: 'product.updated',
+        delivery_url: `https://other.example/${i}`,
+      }));
+      const secondPage = [{ id: 77, topic: 'order.created', delivery_url: deliveryUrl }];
+      mockHttpClient.get
+        .mockResolvedValueOnce(fullFirstPage)
+        .mockResolvedValueOnce(secondPage);
+
+      await adapter.install('connection-123');
+
+      // Two pages read (full page 1 -> keep paging; short page 2 -> stop).
+      expect(mockHttpClient.get).toHaveBeenCalledTimes(2);
+      expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+        1,
+        '/wp-json/wc/v3/webhooks',
+        expect.objectContaining({ page: 1 }),
+      );
+      expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+        2,
+        '/wp-json/wc/v3/webhooks',
+        expect.objectContaining({ page: 2 }),
+      );
+      // The page-2 match is updated (not duplicated); only order.updated is POSTed.
+      expect(mockHttpClient.put).toHaveBeenCalledWith(
+        '/wp-json/wc/v3/webhooks/77',
+        expect.objectContaining({ topic: 'order.created' }),
+      );
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('input validation', () => {
@@ -191,16 +227,22 @@ describe('WooCommerceWebhookProvisioningAdapter', () => {
   });
 
   describe('failure modes', () => {
-    it('throws and does not mark configured when the WC push fails', async () => {
-      mockHttpClient.get.mockRejectedValueOnce(new Error('WC 401'));
+    it('throws and fail-closed resets webhooksConfigured to false when the WC push fails', async () => {
+      mockHttpClient.get.mockRejectedValue(new Error('WC 401'));
 
       await expect(adapter.install('connection-123')).rejects.toThrow(
         /WooCommerce webhook registration failed/,
       );
 
-      // Secret was rotated; connection.update was NOT called (push failed before).
+      // Secret was rotated; the persisted flag is fail-closed reset to false so a
+      // prior `true` doesn't go stale (mirrors the Erli adapter).
       expect(webhookSecretService.rotate).toHaveBeenCalled();
-      expect(connectionPort.update).not.toHaveBeenCalled();
+      expect(connectionPort.update).toHaveBeenCalledWith(
+        'connection-123',
+        expect.objectContaining({
+          config: expect.objectContaining({ webhooksConfigured: false }),
+        }),
+      );
     });
 
     it('returns warning=state-update-failed when connection.update fails after push', async () => {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-provisioning.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-provisioning.adapter.spec.ts
@@ -1,0 +1,216 @@
+/**
+ * WooCommerce Webhook Provisioning Adapter — Unit Tests (#1548)
+ *
+ * Covers the orchestrator branches: happy path (create), idempotent upsert
+ * (update existing), missing callback URL, missing siteUrl, WC push failure,
+ * and state-update failure.
+ *
+ * The WC HTTP client is constructed inside the adapter (not injected), so the
+ * underlying constructor is stubbed via the module path.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/__tests__
+ */
+import { BadRequestException } from '@nestjs/common';
+import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
+import { Connection } from '@openlinker/core/identifier-mapping';
+import type { IWebhookSecretService, CredentialsResolverPort } from '@openlinker/core/integrations';
+import { WooCommerceWebhookProvisioningAdapter } from '../woocommerce-webhook-provisioning.adapter';
+import * as httpClientModule from '../../http/woocommerce-http-client';
+
+describe('WooCommerceWebhookProvisioningAdapter', () => {
+  let adapter: WooCommerceWebhookProvisioningAdapter;
+  let connectionPort: jest.Mocked<ConnectionPort>;
+  let webhookSecretService: jest.Mocked<IWebhookSecretService>;
+  let credentialsResolver: jest.Mocked<CredentialsResolverPort>;
+  let mockHttpClient: {
+    get: jest.Mock;
+    post: jest.Mock;
+    put: jest.Mock;
+    delete: jest.Mock;
+  };
+
+  const baseConnection = new Connection(
+    'connection-123',
+    'woocommerce',
+    'Test Store',
+    'active',
+    {
+      siteUrl: 'https://store.example.com',
+      openlinkerCallbackBaseUrl: 'https://api.openlinker.example',
+    },
+    'db:cred-ref',
+    new Date(),
+    new Date(),
+    undefined,
+    ['OrderSource'],
+  );
+
+  beforeEach(() => {
+    connectionPort = {
+      get: jest.fn().mockResolvedValue(baseConnection),
+      update: jest.fn().mockResolvedValue(baseConnection),
+      list: jest.fn(),
+      create: jest.fn(),
+      disable: jest.fn(),
+    } as unknown as jest.Mocked<ConnectionPort>;
+
+    webhookSecretService = {
+      rotate: jest.fn().mockResolvedValue({ secret: 'rotated-secret-hex' }),
+    } as unknown as jest.Mocked<IWebhookSecretService>;
+
+    credentialsResolver = {
+      get: jest.fn().mockResolvedValue({ consumerKey: 'ck_x', consumerSecret: 'cs_y' }),
+    } as unknown as jest.Mocked<CredentialsResolverPort>;
+
+    mockHttpClient = {
+      // No existing webhooks in the happy path -> adapter falls into POST create.
+      get: jest.fn().mockResolvedValue([]),
+      post: jest.fn().mockResolvedValue({ id: 1 }),
+      put: jest.fn().mockResolvedValue({ id: 1 }),
+      delete: jest.fn(),
+    };
+    jest
+      .spyOn(httpClientModule, 'WooCommerceHttpClient')
+      .mockImplementation(() => mockHttpClient as never);
+
+    adapter = new WooCommerceWebhookProvisioningAdapter(
+      connectionPort,
+      webhookSecretService,
+      credentialsResolver,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('happy path', () => {
+    it('rotates secret, creates order webhooks, marks configured', async () => {
+      const result = await adapter.install('connection-123', 'user-1');
+
+      expect(webhookSecretService.rotate).toHaveBeenCalledWith(
+        'woocommerce',
+        'connection-123',
+        'user-1',
+      );
+
+      // Lists existing once, then POSTs one webhook per order topic.
+      expect(mockHttpClient.get).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(2);
+
+      const topics = mockHttpClient.post.mock.calls.map((c: unknown[]) => {
+        const body = c[1] as { topic: string };
+        return body.topic;
+      });
+      expect(topics).toEqual(['order.created', 'order.updated']);
+
+      // Each webhook targets OL's ingress with the rotated secret + active status.
+      for (const call of mockHttpClient.post.mock.calls as unknown[][]) {
+        const body = call[1] as Record<string, unknown>;
+        expect(body.delivery_url).toBe(
+          'https://api.openlinker.example/webhooks/woocommerce/connection-123',
+        );
+        expect(body.secret).toBe('rotated-secret-hex');
+        expect(body.status).toBe('active');
+      }
+
+      expect(connectionPort.update).toHaveBeenCalledWith(
+        'connection-123',
+        expect.objectContaining({
+          config: expect.objectContaining({ webhooksConfigured: true }),
+        }),
+      );
+
+      // WooCommerce has no synchronous verifiable ping -> false, no warning.
+      expect(result).toEqual({ webhooksConfigured: true, testPingTriggered: false });
+    });
+
+    it('updates an existing webhook (matched by topic + delivery_url) instead of duplicating', async () => {
+      mockHttpClient.get.mockResolvedValue([
+        {
+          id: 55,
+          topic: 'order.created',
+          delivery_url: 'https://api.openlinker.example/webhooks/woocommerce/connection-123',
+        },
+      ]);
+
+      await adapter.install('connection-123');
+
+      expect(mockHttpClient.put).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.put).toHaveBeenCalledWith(
+        '/wp-json/wc/v3/webhooks/55',
+        expect.objectContaining({ topic: 'order.created', status: 'active' }),
+      );
+      // Only the unmatched topic (order.updated) is created.
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+      const created = (mockHttpClient.post.mock.calls[0] as unknown[])[1] as { topic: string };
+      expect(created.topic).toBe('order.updated');
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws BadRequestException when openlinkerCallbackBaseUrl is unset', async () => {
+      connectionPort.get.mockResolvedValue(
+        new Connection(
+          'connection-123',
+          'woocommerce',
+          'Test',
+          'active',
+          { siteUrl: 'https://store.example.com' },
+          'db:cred',
+          new Date(),
+          new Date(),
+          undefined,
+          [],
+        ),
+      );
+
+      await expect(adapter.install('connection-123')).rejects.toThrow(BadRequestException);
+      await expect(adapter.install('connection-123')).rejects.toThrow(/OL callback URL/);
+      expect(webhookSecretService.rotate).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when siteUrl is missing from config', async () => {
+      connectionPort.get.mockResolvedValue(
+        new Connection(
+          'connection-123',
+          'woocommerce',
+          'Test',
+          'active',
+          { openlinkerCallbackBaseUrl: 'https://api.openlinker.example' },
+          'db:cred',
+          new Date(),
+          new Date(),
+          undefined,
+          [],
+        ),
+      );
+
+      await expect(adapter.install('connection-123')).rejects.toThrow(/siteUrl/);
+    });
+  });
+
+  describe('failure modes', () => {
+    it('throws and does not mark configured when the WC push fails', async () => {
+      mockHttpClient.get.mockRejectedValueOnce(new Error('WC 401'));
+
+      await expect(adapter.install('connection-123')).rejects.toThrow(
+        /WooCommerce webhook registration failed/,
+      );
+
+      // Secret was rotated; connection.update was NOT called (push failed before).
+      expect(webhookSecretService.rotate).toHaveBeenCalled();
+      expect(connectionPort.update).not.toHaveBeenCalled();
+    });
+
+    it('returns warning=state-update-failed when connection.update fails after push', async () => {
+      connectionPort.update.mockRejectedValue(new Error('DB write failed'));
+
+      const result = await adapter.install('connection-123');
+
+      expect(result.webhooksConfigured).toBe(false);
+      expect(result.testPingTriggered).toBe(false);
+      expect(result.warning).toBe('state-update-failed');
+    });
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-event-translator.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-event-translator.adapter.ts
@@ -50,19 +50,16 @@ export class WooCommerceWebhookEventTranslatorAdapter implements WebhookEventTra
   /**
    * Map the WooCommerce order event type into the order domain's advisory
    * vocabulary. Accepts both the full WC topic (`order.created`) and its bare
-   * action (`created`). `OrderFeedEventType` has no `status_changed`, so any
-   * update is `updated`; a delete/trash maps to `cancelled`; unknown order
-   * events fall back to `updated` (a safe re-pull).
+   * action (`created`). Only `order.created` / `order.updated` are provisioned
+   * (see `WOOCOMMERCE_ORDER_WEBHOOK_TOPICS`); `OrderFeedEventType` has no
+   * `status_changed`, so anything that isn't a create falls back to `updated`
+   * (a safe re-pull — the authoritative order is fetched downstream).
    */
   private orderEventType(eventType: string): string {
     switch (eventType.toLowerCase()) {
       case 'order.created':
       case 'created':
         return 'created';
-      case 'order.deleted':
-      case 'deleted':
-      case 'trash':
-        return 'cancelled';
       case 'order.updated':
       case 'updated':
       default:

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-event-translator.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-event-translator.adapter.ts
@@ -1,0 +1,72 @@
+/**
+ * WooCommerce Webhook Event Translator Adapter (#1548 / ADR-015)
+ *
+ * Decodes WooCommerce inbound webhook events into neutral
+ * `CanonicalInboundEvent`s. Pure transform — no I/O, no connection state.
+ * WooCommerce delivers topic-based order events (`order.created`,
+ * `order.updated`); the decoder that runs before this translator sets
+ * `objectType = 'order'` and carries the WC topic (or its bare action) as
+ * `eventType`.
+ *
+ * This is the only place that holds WooCommerce's webhook vocabulary — the
+ * core `InboundRoutingPolicy` maps the neutral `domain` -> `jobType`
+ * (order -> `marketplace.order.sync`, gated on the `OrderSource` capability)
+ * with zero platform knowledge. Unknown object types return `null`
+ * (-> dead-letter), keeping the translator total (ADR-015 invariant 5).
+ *
+ * WooCommerce is treated as an order SOURCE over webhooks: the webhook is a
+ * low-latency nudge, never the source of truth. The advisory `eventType` is
+ * coerced by the routing policy to an `OrderFeedEventType`; the authoritative
+ * order is re-pulled by `WooCommerceOrderSourceAdapter.getOrder` downstream.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters
+ * @see {@link CanonicalInboundEvent} for the neutral output contract
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+import type {
+  CanonicalInboundEvent,
+  WebhookEventTranslatorPort,
+} from '@openlinker/core/integrations';
+
+export class WooCommerceWebhookEventTranslatorAdapter implements WebhookEventTranslatorPort {
+  translate(event: InboundWebhookEvent): CanonicalInboundEvent | null {
+    const objectType = event.objectType.toLowerCase();
+
+    switch (objectType) {
+      case 'order':
+        return {
+          domain: 'order',
+          externalId: event.externalId,
+          eventType: this.orderEventType(event.eventType),
+          occurredAt: event.occurredAt,
+          payload: event.payload,
+        };
+      default:
+        // Unknown object type — not decodable by this plugin -> dead-letter.
+        return null;
+    }
+  }
+
+  /**
+   * Map the WooCommerce order event type into the order domain's advisory
+   * vocabulary. Accepts both the full WC topic (`order.created`) and its bare
+   * action (`created`). `OrderFeedEventType` has no `status_changed`, so any
+   * update is `updated`; a delete/trash maps to `cancelled`; unknown order
+   * events fall back to `updated` (a safe re-pull).
+   */
+  private orderEventType(eventType: string): string {
+    switch (eventType.toLowerCase()) {
+      case 'order.created':
+      case 'created':
+        return 'created';
+      case 'order.deleted':
+      case 'deleted':
+      case 'trash':
+        return 'cancelled';
+      case 'order.updated':
+      case 'updated':
+      default:
+        return 'updated';
+    }
+  }
+}

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-provisioning.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-provisioning.adapter.ts
@@ -1,0 +1,212 @@
+/**
+ * WooCommerce Webhook Provisioning Adapter (#1548)
+ *
+ * Implements `WebhookProvisioningPort` for the WooCommerce platform — registers
+ * the store-side order webhooks through WooCommerce REST v3
+ * (`POST /wp-json/wc/v3/webhooks`), each pointing at OpenLinker's inbound
+ * ingress (`/webhooks/woocommerce/:connectionId`). Resolved per-connection by
+ * `ConnectionService.installWebhooks` via `WebhookProvisioningRegistryService`
+ * indexed by `adapterKey`; self-registers from `WooCommerceWebhookProvisioningModule`
+ * (it needs the NestJS-injected `ConnectionPort` + `IWebhookSecretService`, which
+ * are deliberately NOT part of the framework-neutral `HostServices` bag).
+ *
+ * Flow (mirrors the PrestaShop / Erli provisioners):
+ *   1. Validate connection config (callback base URL set, siteUrl set).
+ *   2. Rotate the connection's webhook secret (one-shot plaintext) and hand it
+ *      to WooCommerce as each webhook's `secret` — WC signs every delivery with
+ *      a base64 HMAC-SHA256 of the raw body keyed by this secret.
+ *   3. Upsert one webhook per order topic (`order.created`, `order.updated`),
+ *      idempotently: an existing webhook matching topic + delivery_url is PUT
+ *      (secret rotated, status re-activated); otherwise a new one is POSTed.
+ *   4. Mark `connection.config.webhooksConfigured = true`.
+ *
+ * SIGNATURE VERIFICATION DELTA (#1548 acceptance criterion 4): WooCommerce signs
+ * inbound deliveries with `X-WC-Webhook-Signature: <base64(HMAC-SHA256(rawBody))>`
+ * and sends NO signed timestamp header. The host's default inbound decoder
+ * (`DefaultWebhookDecoder`) expects OpenLinker's own scheme
+ * (`X-OpenLinker-Timestamp` + `X-OpenLinker-Signature = sha256=<hex>` over
+ * `timestamp.body`). The two are incompatible, so end-to-end inbound
+ * authentication requires a WooCommerce-specific `InboundWebhookDecoderPort`
+ * (the ADR-021 seam, exactly like `ErliInboundWebhookDecoderAdapter`) that
+ * verifies the base64 signature and omits the replay-timestamp. That decoder is
+ * a scoped follow-up; this adapter provisions the store side so the decoder can
+ * verify against the same rotated secret when it lands. Until then the
+ * `WooCommerceOrderSourceAdapter` poll remains the reconciliation backstop.
+ *
+ * TEST PING: WooCommerce has no synchronous, verifiable test-ping round-trip
+ * (its own "ping" on webhook creation is delivered asynchronously and cannot be
+ * observed inside this call), so `testPingTriggered` is always `false` by design
+ * — not a degraded state. No warning is attached on the happy path.
+ *
+ * Failure-mode policy: accept-and-surface. Hard validation fails closed
+ * (`BadRequestException`); a partial state after a successful push returns a
+ * `warning`.
+ *
+ * Security: the rotated secret is sent ONLY in the WC request body — never logged.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters
+ * @implements {WebhookProvisioningPort}
+ * @see {@link WooCommerceWebhookEventTranslatorAdapter} for the downstream translator
+ */
+import { BadRequestException } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
+import type {
+  CredentialsResolverPort,
+  IWebhookSecretService,
+  WebhookProvisioningPort,
+  WebhookProvisioningResult,
+} from '@openlinker/core/integrations';
+import type { WooCommerceConnectionConfig } from '../../domain/types/woocommerce-config.types';
+import type { WooCommerceCredentials } from '../../domain/types/woocommerce-credentials.types';
+import { WooCommerceHttpClient } from '../http/woocommerce-http-client';
+import type { IWooCommerceHttpClient } from '../http/woocommerce-http-client.interface';
+import {
+  WOOCOMMERCE_ORDER_WEBHOOK_TOPICS,
+  WOOCOMMERCE_WEBHOOK_PROVIDER,
+  WOOCOMMERCE_WEBHOOKS_PATH,
+  type WooCommerceOrderWebhookTopic,
+  type WooCommerceWebhookResource,
+  type WooCommerceWebhookWriteBody,
+} from './woocommerce-webhook.types';
+
+/** Upper bound on the existing-webhook listing used for idempotent upserts. */
+const WEBHOOK_LIST_PAGE_SIZE = 100;
+
+export class WooCommerceWebhookProvisioningAdapter implements WebhookProvisioningPort {
+  private readonly logger = new Logger(WooCommerceWebhookProvisioningAdapter.name);
+
+  constructor(
+    private readonly connectionPort: ConnectionPort,
+    private readonly webhookSecretService: IWebhookSecretService,
+    private readonly credentialsResolver: CredentialsResolverPort,
+  ) {}
+
+  async install(connectionId: string, actorUserId?: string): Promise<WebhookProvisioningResult> {
+    // Routing by adapterKey guarantees this adapter only sees WooCommerce
+    // connections; the unsupported-platform 400 lives in
+    // `ConnectionService.installWebhooks`.
+    const connection = await this.connectionPort.get(connectionId);
+    const config = (connection.config ?? {}) as Partial<WooCommerceConnectionConfig>;
+
+    const callbackBaseUrl = config.openlinkerCallbackBaseUrl?.trim();
+    if (!callbackBaseUrl) {
+      throw new BadRequestException(
+        'Set the OL callback URL on the connection-edit page before configuring webhooks. ' +
+          'WooCommerce needs to know where to POST events back to OL ' +
+          '(e.g. http://host.docker.internal:3000 in dev, your public OL URL in prod).',
+      );
+    }
+
+    if (!config.siteUrl || typeof config.siteUrl !== 'string') {
+      // Defensive — should be caught by the config-shape DTO at save time.
+      throw new BadRequestException(`Connection ${connectionId} is missing siteUrl in config.`);
+    }
+
+    // Rotate the shared secret (one-shot plaintext). WooCommerce signs each
+    // delivery with it; it is sent only in the WC webhook body below.
+    const { secret } = await this.webhookSecretService.rotate(
+      WOOCOMMERCE_WEBHOOK_PROVIDER,
+      connectionId,
+      actorUserId,
+    );
+
+    const httpClient = await this.createHttpClient(connection.credentialsRef, config.siteUrl);
+    const deliveryUrl = `${callbackBaseUrl.replace(/\/$/, '')}/webhooks/${WOOCOMMERCE_WEBHOOK_PROVIDER}/${connectionId}`;
+
+    try {
+      const existing = await this.listWebhooks(httpClient);
+      for (const topic of WOOCOMMERCE_ORDER_WEBHOOK_TOPICS) {
+        await this.upsertWebhook(httpClient, existing, topic, deliveryUrl, secret, connectionId);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Failed to register WooCommerce webhooks for connection ${connectionId}: ${message}`,
+      );
+      throw new BadRequestException(
+        `WooCommerce webhook registration failed: ${message}. The webhook secret was rotated ` +
+          "on OL's side; re-running install is safe (registration is idempotent).",
+      );
+    }
+
+    // Record success on the connection (best-effort; re-running install is safe).
+    let stateUpdateOk = true;
+    try {
+      await this.connectionPort.update(connectionId, {
+        config: { ...connection.config, webhooksConfigured: true },
+      });
+    } catch (error) {
+      stateUpdateOk = false;
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `WooCommerce webhooks registered but the connection state update failed for ` +
+          `${connectionId}: ${message}. WC has the right config; re-running install is idempotent.`,
+      );
+    }
+
+    this.logger.log(
+      `webhook_install.completed connectionId=${connectionId} provider=woocommerce ` +
+        `webhooksConfigured=${stateUpdateOk} topics=${WOOCOMMERCE_ORDER_WEBHOOK_TOPICS.length} ` +
+        `actor=${actorUserId ?? 'system'}`,
+    );
+
+    // testPingTriggered is always false for WooCommerce (no synchronous,
+    // verifiable ping — see the module doc); it is not a failure, so no warning.
+    return {
+      webhooksConfigured: stateUpdateOk,
+      testPingTriggered: false,
+      ...(stateUpdateOk ? {} : { warning: 'state-update-failed' }),
+    };
+  }
+
+  /**
+   * List the store's existing webhooks (single page — a store legitimately
+   * carrying >100 webhooks is out of scope; the upsert simply creates a new one
+   * if a match isn't on the first page, which WC tolerates).
+   */
+  private async listWebhooks(
+    httpClient: IWooCommerceHttpClient,
+  ): Promise<WooCommerceWebhookResource[]> {
+    return httpClient.get<WooCommerceWebhookResource[]>(WOOCOMMERCE_WEBHOOKS_PATH, {
+      per_page: WEBHOOK_LIST_PAGE_SIZE,
+    });
+  }
+
+  /**
+   * Upsert one webhook by (topic + delivery_url): PUT an existing match (rotates
+   * the secret, re-activates it) or POST a new one. Matching on delivery_url
+   * keeps re-runs from stacking duplicate webhooks on the store.
+   */
+  private async upsertWebhook(
+    httpClient: IWooCommerceHttpClient,
+    existing: WooCommerceWebhookResource[],
+    topic: WooCommerceOrderWebhookTopic,
+    deliveryUrl: string,
+    secret: string,
+    connectionId: string,
+  ): Promise<void> {
+    const body: WooCommerceWebhookWriteBody = {
+      name: `OpenLinker ${topic} (connection ${connectionId})`,
+      topic,
+      delivery_url: deliveryUrl,
+      secret,
+      status: 'active',
+    };
+
+    const match = existing.find((w) => w.topic === topic && w.delivery_url === deliveryUrl);
+    if (match) {
+      await httpClient.put(`${WOOCOMMERCE_WEBHOOKS_PATH}/${match.id}`, body);
+      return;
+    }
+    await httpClient.post(WOOCOMMERCE_WEBHOOKS_PATH, body);
+  }
+
+  private async createHttpClient(
+    credentialsRef: string,
+    siteUrl: string,
+  ): Promise<IWooCommerceHttpClient> {
+    const credentials = await this.credentialsResolver.get<WooCommerceCredentials>(credentialsRef);
+    return new WooCommerceHttpClient(siteUrl, credentials.consumerKey, credentials.consumerSecret);
+  }
+}

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-provisioning.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-provisioning.adapter.ts
@@ -29,9 +29,12 @@
  * authentication requires a WooCommerce-specific `InboundWebhookDecoderPort`
  * (the ADR-021 seam, exactly like `ErliInboundWebhookDecoderAdapter`) that
  * verifies the base64 signature and omits the replay-timestamp. That decoder is
- * a scoped follow-up; this adapter provisions the store side so the decoder can
- * verify against the same rotated secret when it lands. Until then the
- * `WooCommerceOrderSourceAdapter` poll remains the reconciliation backstop.
+ * a scoped follow-up (tracked in #1563); this adapter provisions the store side
+ * so the decoder can verify against the same rotated secret when it lands. Until
+ * then the `WooCommerceOrderSourceAdapter` poll remains the reconciliation
+ * backstop, and inbound deliveries fail host signature verification (WooCommerce
+ * may auto-disable the store-side webhook after repeated failures — re-run
+ * install once #1563 ships).
  *
  * TEST PING: WooCommerce has no synchronous, verifiable test-ping round-trip
  * (its own "ping" on webhook creation is delivered asynchronously and cannot be
@@ -50,7 +53,7 @@
  */
 import { BadRequestException } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
-import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
+import type { Connection, ConnectionPort } from '@openlinker/core/identifier-mapping';
 import type {
   CredentialsResolverPort,
   IWebhookSecretService,
@@ -124,11 +127,30 @@ export class WooCommerceWebhookProvisioningAdapter implements WebhookProvisionin
       this.logger.error(
         `Failed to register WooCommerce webhooks for connection ${connectionId}: ${message}`,
       );
+      // Fail-closed visibility: the secret was already rotated OL-side, but WC may
+      // still hold the old/no secret, so inbound signature verification stays
+      // broken until install is re-run. Best-effort flip the persisted
+      // `webhooksConfigured` flag to false so a prior `true` doesn't go stale and
+      // the connection-actions UI shows webhooks are NOT live. The order-source
+      // poll still backstops order loss.
+      await this.markWebhooksUnconfigured(connectionId, connection.config);
       throw new BadRequestException(
         `WooCommerce webhook registration failed: ${message}. The webhook secret was rotated ` +
           "on OL's side; re-running install is safe (registration is idempotent).",
       );
     }
+
+    // Inbound auth is not yet wired end-to-end: WC signs deliveries with the
+    // base64 `X-WC-Webhook-Signature` scheme the host default decoder cannot
+    // verify, so provisioned deliveries fail verification (and WC may auto-disable
+    // the store-side webhook) until the decoder follow-up (#1563) ships.
+    this.logger.warn(
+      `WooCommerce webhooks registered for connection ${connectionId}, but inbound signature ` +
+        'verification is PENDING the decoder follow-up (#1563): WC signs deliveries with ' +
+        'X-WC-Webhook-Signature, which the host default decoder cannot verify yet, so these ' +
+        'deliveries will fail verification (and WC may auto-disable the webhook). The ' +
+        'order-source poll remains the reconciliation backstop until then.',
+    );
 
     // Record success on the connection (best-effort; re-running install is safe).
     let stateUpdateOk = true;
@@ -161,16 +183,51 @@ export class WooCommerceWebhookProvisioningAdapter implements WebhookProvisionin
   }
 
   /**
-   * List the store's existing webhooks (single page — a store legitimately
-   * carrying >100 webhooks is out of scope; the upsert simply creates a new one
-   * if a match isn't on the first page, which WC tolerates).
+   * List the store's existing webhooks, paging until exhausted. A store can
+   * legitimately carry more than one page of webhooks; if OL's rows aren't on
+   * the first page the upsert would otherwise stack duplicates, so we walk every
+   * page (WC returns fewer than `per_page` items on the last one).
    */
   private async listWebhooks(
     httpClient: IWooCommerceHttpClient,
   ): Promise<WooCommerceWebhookResource[]> {
-    return httpClient.get<WooCommerceWebhookResource[]>(WOOCOMMERCE_WEBHOOKS_PATH, {
-      per_page: WEBHOOK_LIST_PAGE_SIZE,
-    });
+    const all: WooCommerceWebhookResource[] = [];
+    for (let page = 1; ; page += 1) {
+      const batch = await httpClient.get<WooCommerceWebhookResource[]>(WOOCOMMERCE_WEBHOOKS_PATH, {
+        per_page: WEBHOOK_LIST_PAGE_SIZE,
+        page,
+      });
+      if (!Array.isArray(batch) || batch.length === 0) {
+        break;
+      }
+      all.push(...batch);
+      if (batch.length < WEBHOOK_LIST_PAGE_SIZE) {
+        break;
+      }
+    }
+    return all;
+  }
+
+  /**
+   * Best-effort flip of the persisted `webhooksConfigured` flag to false after a
+   * failed registration. Swallows its own errors so it never masks the original
+   * registration failure — the caller still throws the actionable message.
+   */
+  private async markWebhooksUnconfigured(
+    connectionId: string,
+    config: Connection['config'],
+  ): Promise<void> {
+    try {
+      await this.connectionPort.update(connectionId, {
+        config: { ...config, webhooksConfigured: false },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not flag connection ${connectionId} as webhooks-unconfigured after a ` +
+          `registration failure: ${message}. Re-running install is idempotent.`,
+      );
+    }
   }
 
   /**

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook.types.ts
@@ -23,14 +23,6 @@ export const WOOCOMMERCE_WEBHOOK_PROVIDER = 'woocommerce';
 export const WOOCOMMERCE_WEBHOOKS_PATH = '/wp-json/wc/v3/webhooks';
 
 /**
- * WooCommerce delivery signature header (base64 HMAC-SHA256 of the raw body,
- * keyed by the webhook's `secret`). Documented here as the authoritative name
- * for the future inbound decoder (see the provisioning adapter's signature
- * note); the host default OL-HMAC decoder does not read it yet.
- */
-export const WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER = 'x-wc-webhook-signature';
-
-/**
  * Order-relevant WooCommerce webhook topics OL provisions. WooCommerce is used
  * here as an order SOURCE over webhooks (low-latency nudge; the poll reconciles),
  * so only the order lifecycle topics are registered. `order.created` and

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook.types.ts
@@ -1,0 +1,60 @@
+/**
+ * WooCommerce Webhook Types & Constants (#1548)
+ *
+ * Shared vocabulary for the WooCommerce inbound-webhook seam — used by both
+ * `WooCommerceWebhookProvisioningAdapter` (registers the store-side webhooks
+ * via WC REST `/webhooks`) and `WooCommerceWebhookEventTranslatorAdapter`
+ * (decodes a delivered event into a neutral `CanonicalInboundEvent`).
+ *
+ * WooCommerce's own webhook subsystem (WP Admin -> WooCommerce -> Settings ->
+ * Advanced -> Webhooks, or REST `POST /wp-json/wc/v3/webhooks`) delivers a
+ * topic-based event to a `delivery_url`, signed with a base64 HMAC-SHA256 of
+ * the raw body in the `X-WC-Webhook-Signature` header. It sends NO signed
+ * timestamp header. See `docs/architecture-overview.md` (webhook ingestion)
+ * for how the host authenticates inbound deliveries.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters
+ */
+
+/** Webhook-secret provider key + URL `:provider` segment for WooCommerce connections. */
+export const WOOCOMMERCE_WEBHOOK_PROVIDER = 'woocommerce';
+
+/** WooCommerce REST v3 webhooks collection resource. */
+export const WOOCOMMERCE_WEBHOOKS_PATH = '/wp-json/wc/v3/webhooks';
+
+/**
+ * WooCommerce delivery signature header (base64 HMAC-SHA256 of the raw body,
+ * keyed by the webhook's `secret`). Documented here as the authoritative name
+ * for the future inbound decoder (see the provisioning adapter's signature
+ * note); the host default OL-HMAC decoder does not read it yet.
+ */
+export const WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER = 'x-wc-webhook-signature';
+
+/**
+ * Order-relevant WooCommerce webhook topics OL provisions. WooCommerce is used
+ * here as an order SOURCE over webhooks (low-latency nudge; the poll reconciles),
+ * so only the order lifecycle topics are registered. `order.created` and
+ * `order.updated` together cover the "new order" and "status/detail changed"
+ * signals; the authoritative order is always re-pulled downstream.
+ */
+export const WOOCOMMERCE_ORDER_WEBHOOK_TOPICS = ['order.created', 'order.updated'] as const;
+
+export type WooCommerceOrderWebhookTopic = (typeof WOOCOMMERCE_ORDER_WEBHOOK_TOPICS)[number];
+
+/** Body OL sends to WC REST when creating or updating a webhook. */
+export interface WooCommerceWebhookWriteBody {
+  name: string;
+  topic: string;
+  delivery_url: string;
+  secret: string;
+  status: 'active';
+}
+
+/** Subset of the WC webhook resource OL reads back when listing/creating. */
+export interface WooCommerceWebhookResource {
+  id: number;
+  name?: string;
+  status?: string;
+  topic?: string;
+  delivery_url?: string;
+}

--- a/libs/integrations/woocommerce/src/woocommerce-integration.module.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-integration.module.ts
@@ -16,7 +16,12 @@
 import type { DynamicModule } from '@nestjs/common';
 import { createNestAdapterModule } from '@openlinker/plugin-sdk';
 import { createWooCommercePlugin } from './woocommerce-plugin';
+import { WooCommerceWebhookProvisioningModule } from './woocommerce-webhook-provisioning.module';
 
 export const WooCommerceIntegrationModule: DynamicModule = createNestAdapterModule({
   plugin: createWooCommercePlugin(),
+  // The inbound webhook provisioner (#1548) needs NestJS-injected ConnectionPort
+  // + IWebhookSecretService (not in the HostServices bag), so it self-registers
+  // from this companion module rather than from plugin.register(host).
+  imports: [WooCommerceWebhookProvisioningModule],
 });

--- a/libs/integrations/woocommerce/src/woocommerce-plugin.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-plugin.ts
@@ -31,6 +31,7 @@ import { WooCommerceOrderSourceAdapter } from './infrastructure/adapters/woocomm
 import { WooCommerceProductPublisherAdapter } from './infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter';
 import { WooCommerceOfferManagerAdapter } from './infrastructure/adapters/offer-manager/woocommerce-offer-manager.adapter';
 import { WooCommerceAuthFailureClassifierAdapter } from './infrastructure/adapters/woocommerce-auth-failure-classifier.adapter';
+import { WooCommerceWebhookEventTranslatorAdapter } from './infrastructure/adapters/woocommerce-webhook-event-translator.adapter';
 import { buildWooCommerceSchedulerTasks } from './infrastructure/scheduler/woocommerce-scheduler-tasks';
 
 /**
@@ -89,6 +90,15 @@ export function createWooCommercePlugin(): AdapterPlugin {
       host.authFailureClassifierRegistry.register(
         woocommerceAdapterManifest.adapterKey,
         new WooCommerceAuthFailureClassifierAdapter(),
+      );
+      // Inbound webhook-event translator (ADR-015 / #1548) — decodes WC order
+      // webhook events into neutral CanonicalInboundEvents. The webhook
+      // PROVISIONER is registered by `WooCommerceWebhookProvisioningModule`
+      // (it needs NestJS-injected ConnectionPort + IWebhookSecretService, which
+      // are not in the HostServices bag).
+      host.webhookEventTranslatorRegistry.register(
+        woocommerceAdapterManifest.adapterKey,
+        new WooCommerceWebhookEventTranslatorAdapter(),
       );
       for (const task of buildWooCommerceSchedulerTasks()) {
         host.schedulerTaskRegistry.register(task);

--- a/libs/integrations/woocommerce/src/woocommerce-webhook-provisioning.module.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-webhook-provisioning.module.ts
@@ -1,0 +1,61 @@
+/**
+ * WooCommerce Webhook Provisioning Module (#1548)
+ *
+ * Companion NestJS module composed into the WooCommerce plugin via
+ * `createNestAdapterModule({ imports: [WooCommerceWebhookProvisioningModule] })`.
+ * It exists because the automated webhook provisioner needs NestJS-injected
+ * services — `ConnectionPort` (read/patch the connection) and
+ * `IWebhookSecretService` (rotate the shared secret) — that are deliberately
+ * NOT part of the framework-neutral `HostServices` bag. Rather than restructure
+ * the whole WooCommerce plugin onto a custom module, this small module injects
+ * exactly those deps + `CredentialsResolverPort` + the provisioning registry,
+ * and registers `WooCommerceWebhookProvisioningAdapter` in `onModuleInit`.
+ *
+ * Mirrors `ErliWebhookProvisioningModule`.
+ *
+ * @module libs/integrations/woocommerce/src
+ */
+import { Inject, Module, type OnModuleInit } from '@nestjs/common';
+import {
+  CredentialsResolverPort,
+  CREDENTIALS_RESOLVER_TOKEN,
+  IntegrationsModule,
+  IWebhookSecretService,
+  WEBHOOK_SECRET_SERVICE_TOKEN,
+  WebhookProvisioningRegistryService,
+  WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
+} from '@openlinker/core/integrations';
+import {
+  ConnectionPort,
+  CONNECTION_PORT_TOKEN,
+  IdentifierMappingModule,
+} from '@openlinker/core/identifier-mapping';
+import { woocommerceAdapterManifest } from './woocommerce-plugin';
+import { WooCommerceWebhookProvisioningAdapter } from './infrastructure/adapters/woocommerce-webhook-provisioning.adapter';
+
+@Module({
+  imports: [IntegrationsModule, IdentifierMappingModule],
+})
+export class WooCommerceWebhookProvisioningModule implements OnModuleInit {
+  constructor(
+    @Inject(WEBHOOK_PROVISIONING_REGISTRY_TOKEN)
+    private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connectionPort: ConnectionPort,
+    @Inject(WEBHOOK_SECRET_SERVICE_TOKEN)
+    private readonly webhookSecretService: IWebhookSecretService,
+    @Inject(CREDENTIALS_RESOLVER_TOKEN)
+    private readonly credentialsResolver: CredentialsResolverPort,
+  ) {}
+
+  onModuleInit(): void {
+    this.webhookProvisioningRegistry.register(
+      woocommerceAdapterManifest.adapterKey,
+      new WooCommerceWebhookProvisioningAdapter(
+        this.connectionPort,
+        this.webhookSecretService,
+        this.credentialsResolver,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## What changed and why

Brings WooCommerce to parity with PrestaShop on inbound webhooks. Previously WooCommerce ingested orders by polling only; it had neither webhook provisioning nor an event translator, so it could not use the low-latency "webhook = primary path, poll = reconciliation backstop" model.

- **`WooCommerceWebhookProvisioningAdapter`** implements `WebhookProvisioningPort`. It registers the store-side order webhooks (`order.created`, `order.updated`) through WooCommerce REST v3 (`POST /wp-json/wc/v3/webhooks`), each pointing at OpenLinker's `/webhooks/woocommerce/:connectionId` ingress. It rotates the connection's webhook secret (via `IWebhookSecretService`) and hands it to WooCommerce as each webhook's signing secret, upserts idempotently (matched by topic + delivery_url so re-runs do not stack duplicates), and marks `connection.config.webhooksConfigured`. It self-registers from the companion `WooCommerceWebhookProvisioningModule`, which injects the NestJS-provided `ConnectionPort` + `IWebhookSecretService` that are deliberately not in the framework-neutral `HostServices` bag (same pattern as `ErliWebhookProvisioningModule`).
- **`WooCommerceWebhookEventTranslatorAdapter`** implements `WebhookEventTranslatorPort`. It decodes WooCommerce order webhook events into a neutral `CanonicalInboundEvent`, so the existing capability-gated core `InboundRoutingPolicy` maps `order -> marketplace.order.sync` (gated on `OrderSource`). Registered in the plugin's `register(host)`.
- Added `openlinkerCallbackBaseUrl` and `webhooksConfigured` to `WooCommerceConnectionConfig`.

## Signature-verification delta (acceptance criterion 4)

WooCommerce signs each delivery with `X-WC-Webhook-Signature` (a base64 HMAC-SHA256 of the raw body) and sends no signed timestamp header. This is incompatible with the host default inbound decoder (`DefaultWebhookDecoder`), which expects OpenLinker's own `X-OpenLinker-Timestamp` + `X-OpenLinker-Signature` scheme. End-to-end inbound authentication therefore requires a WooCommerce-specific `InboundWebhookDecoderPort` (the ADR-021 seam, exactly like `ErliInboundWebhookDecoderAdapter`) that verifies the base64 signature and omits the replay timestamp. That decoder is a scoped follow-up. This PR provisions the store side against the same rotated secret so the decoder can verify against it when it lands; the `WooCommerceOrderSourceAdapter` poll remains the reconciliation backstop until then. The delta is documented in the provisioning adapter header.

Note: WooCommerce has no synchronous, verifiable test-ping round-trip, so `WebhookProvisioningResult.testPingTriggered` is always `false` by design (not a degraded state); no warning is attached on the happy path.

## How to test

Scoped WooCommerce package checks:

- `pnpm --filter @openlinker/integrations-woocommerce test` - 18 suites, 347 tests pass (includes the new translator and provisioning specs plus the updated plugin-registration spec).
- `pnpm --filter @openlinker/integrations-woocommerce type-check` - passes.
- `pnpm --filter @openlinker/integrations-woocommerce lint` - passes.
- `node scripts/check-cross-context-imports.mjs` - passes (no new violations).

## Related issues

Closes #1548

Follow-up: #1563 - WooCommerce inbound webhook decoder (InboundWebhookDecoderPort, ADR-021 seam). Provisioning ships here; end-to-end inbound signature verification is tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
