### PR TITLE
feat(woocommerce): DestinationOptionsReader sub-capability on order-processor adapter

### DIFF
--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
@@ -14,7 +14,8 @@ import {
 } from '../woocommerce-order-processor.adapter';
 import { toPositiveInt } from '../../../utils/woocommerce-utils';
 import { WC_ORDER_STATUS_MAP, WC_ORDER_STATUS_VALUES } from '../woocommerce-order.types';
-import { isOrderStatusWriteback } from '@openlinker/core/orders';
+import { isOrderStatusWriteback, isDestinationOptionsReader } from '@openlinker/core/orders';
+import { WC_ORDER_STATUS_LABELS } from '../woocommerce-options.types';
 import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-client.interface';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
@@ -936,5 +937,112 @@ describe('WooCommerceOrderProcessorAdapter — OrderStatusWriteback', () => {
 
     expect(result.outcome).toBe('rejected');
     expect(result.detail).toBeDefined();
+  });
+});
+
+// ─── DestinationOptionsReader (#472 / #1551) ────────────────────────────────
+
+describe('WooCommerceOrderProcessorAdapter — DestinationOptionsReader', () => {
+  it('should satisfy the isDestinationOptionsReader guard', () => {
+    const adapter = makeAdapter(makeHttpClient(), makeIdentifierMapping());
+    expect(isDestinationOptionsReader(adapter)).toBe(true);
+  });
+
+  describe('listOrderStatuses', () => {
+    it('should return the full WC status vocabulary as neutral options with labels', async () => {
+      const adapter = makeAdapter(makeHttpClient(), makeIdentifierMapping());
+
+      const options = await adapter.listOrderStatuses();
+
+      expect(options.length).toBeGreaterThan(0);
+      expect(options).toContainEqual({ value: 'processing', label: 'Processing' });
+      expect(options).toContainEqual({ value: 'on-hold', label: 'On hold' });
+      // every option carries a non-empty label sourced from the shared label map
+      for (const option of options) {
+        expect(option.label).toBe(
+          WC_ORDER_STATUS_LABELS[option.value as keyof typeof WC_ORDER_STATUS_LABELS],
+        );
+        expect(option.label.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should not hit the network (static vocabulary)', async () => {
+      const httpClient = makeHttpClient();
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      await adapter.listOrderStatuses();
+
+      expect(httpClient.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listPaymentMethods', () => {
+    it('should map GET /payment_gateways rows to neutral options', async () => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue([
+        { id: 'bacs', title: 'Direct bank transfer', enabled: true },
+        { id: 'cod', title: 'Cash on delivery', enabled: false },
+      ]);
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const options = await adapter.listPaymentMethods();
+
+      expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/payment_gateways');
+      expect(options).toEqual([
+        { value: 'bacs', label: 'Direct bank transfer' },
+        { value: 'cod', label: 'Cash on delivery' },
+      ]);
+    });
+
+    it('should fall back to the gateway id when title is missing', async () => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue([{ id: 'paypal' }]);
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const options = await adapter.listPaymentMethods();
+
+      expect(options).toEqual([{ value: 'paypal', label: 'paypal' }]);
+    });
+  });
+
+  describe('listCarriers', () => {
+    it('should map GET /shipping_methods rows to neutral options', async () => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue([
+        { id: 'flat_rate', title: 'Flat rate' },
+        { id: 'free_shipping', title: 'Free shipping' },
+        { id: 'local_pickup', title: 'Local pickup' },
+      ]);
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const options = await adapter.listCarriers();
+
+      expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/shipping_methods');
+      expect(options).toEqual([
+        { value: 'flat_rate', label: 'Flat rate' },
+        { value: 'free_shipping', label: 'Free shipping' },
+        { value: 'local_pickup', label: 'Local pickup' },
+      ]);
+    });
+
+    it('should fall back to the method id when title is missing', async () => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue([{ id: 'flat_rate' }]);
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const options = await adapter.listCarriers();
+
+      expect(options).toEqual([{ value: 'flat_rate', label: 'flat_rate' }]);
+    });
+
+    it('should return an empty list when the store registers no shipping methods', async () => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue([]);
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const options = await adapter.listCarriers();
+
+      expect(options).toEqual([]);
+    });
   });
 });

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-options.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-options.types.ts
@@ -1,0 +1,57 @@
+/**
+ * WooCommerce Destination-Options Types (#1551)
+ *
+ * Response shapes and vocabulary powering `DestinationOptionsReader` on
+ * `WooCommerceOrderProcessorAdapter` — the option lists the connection-mappings
+ * UI renders so operators can build source->destination status / carrier /
+ * payment maps. Only the fields the adapter actually consumes are typed; the WC
+ * REST API returns much more, ignored here to keep the surface tight.
+ *
+ * - Order statuses come from the static WC vocabulary (`WC_ORDER_STATUS_VALUES`)
+ *   decorated with display labels — WC exposes no dedicated status-catalogue
+ *   endpoint, and the core set is fixed by the WC REST API v3 contract.
+ * - Payment methods come from `GET /payment_gateways`.
+ * - Carriers come from `GET /shipping_methods` (see the adapter for the
+ *   rationale on why WC shipping-method *types* stand in for carriers).
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
+ */
+import type { WooCommerceOrderStatus } from './woocommerce-order-status.types';
+
+/**
+ * Human-readable labels for each WC core order status, matching WooCommerce's
+ * own admin wording. Used to decorate the static status vocabulary into neutral
+ * `MappingOption`s.
+ */
+export const WC_ORDER_STATUS_LABELS: Record<WooCommerceOrderStatus, string> = {
+  pending: 'Pending payment',
+  processing: 'Processing',
+  'on-hold': 'On hold',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+  refunded: 'Refunded',
+  failed: 'Failed',
+};
+
+/**
+ * `GET /payment_gateways` row. `id` is the stable gateway code persisted by
+ * mapping config (e.g. `bacs`, `cod`, `cheque`, `paypal`); `title` is the
+ * operator-facing label; `enabled` reflects whether the gateway is active in
+ * the store.
+ */
+export interface WooCommercePaymentGateway {
+  id: string;
+  title?: string;
+  enabled?: boolean;
+}
+
+/**
+ * `GET /shipping_methods` row. WC returns the globally-registered shipping
+ * *method types* (`flat_rate`, `free_shipping`, `local_pickup`, plugin-provided
+ * types), not per-zone carrier instances. `id` is the stable method code;
+ * `title` is the display name.
+ */
+export interface WooCommerceShippingMethod {
+  id: string;
+  title?: string;
+}

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -3,8 +3,10 @@
  *
  * Implements OrderProcessorManagerPort (createOrder), the OrderFulfillmentUpdater
  * sub-capability (updateFulfillment — status updates, cancellations, refund transitions),
- * and the OrderStatusWriteback sub-capability (write — the #1157 / ADR-027 lifecycle
- * relay contract) for WooCommerce REST API v3.
+ * the OrderStatusWriteback sub-capability (write — the #1157 / ADR-027 lifecycle
+ * relay contract), and the DestinationOptionsReader sub-capability (listCarriers /
+ * listOrderStatuses / listPaymentMethods — the #472 / #1551 mapping-UI option
+ * vocabulary) for WooCommerce REST API v3.
  *
  * Key design decisions:
  * - createOrder: the adapter does NOT dedup. It POSTs to WC and returns the
@@ -29,6 +31,7 @@
  * @implements {OrderProcessorManagerPort}
  * @implements {OrderFulfillmentUpdater}
  * @implements {OrderStatusWriteback}
+ * @implements {DestinationOptionsReader}
  */
 import type {
   OrderProcessorManagerPort,
@@ -43,6 +46,8 @@ import type {
   OrderStatusWriteback,
   OrderLifecycleEvent,
   OrderWritebackResult,
+  DestinationOptionsReader,
+  MappingOption,
 } from '@openlinker/core/orders';
 import type { IdentifierMappingPort, Connection, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
@@ -66,7 +71,12 @@ import type {
   WooCommerceCustomerCreateRequest,
   WooCommerceCustomerResponse,
 } from './woocommerce-order.types';
-import { WC_ORDER_STATUS_MAP } from './woocommerce-order.types';
+import { WC_ORDER_STATUS_MAP, WC_ORDER_STATUS_VALUES } from './woocommerce-order.types';
+import {
+  WC_ORDER_STATUS_LABELS,
+  type WooCommercePaymentGateway,
+  type WooCommerceShippingMethod,
+} from './woocommerce-options.types';
 
 // ─── Module-level pure helpers ────────────────────────────────────────────────
 // Pure functions with no dependency on adapter state — independently testable.
@@ -82,7 +92,11 @@ export function isValidEmail(value: unknown): value is string {
 // ─── Adapter ──────────────────────────────────────────────────────────────────
 
 export class WooCommerceOrderProcessorAdapter
-  implements OrderProcessorManagerPort, OrderFulfillmentUpdater, OrderStatusWriteback
+  implements
+    OrderProcessorManagerPort,
+    OrderFulfillmentUpdater,
+    OrderStatusWriteback,
+    DestinationOptionsReader
 {
   private readonly logger = new Logger(WooCommerceOrderProcessorAdapter.name);
 
@@ -289,6 +303,65 @@ export class WooCommerceOrderProcessorAdapter
       );
       return { outcome: 'rejected', detail };
     }
+  }
+
+  // ─── DestinationOptionsReader (#472 / #1551) ──────────────────────────────
+  //
+  // Live option vocabulary powering the connection-mappings UI dropdowns. Each
+  // method returns the neutral `MappingOption` shape ({ value, label }); `value`
+  // is the stable identifier persisted by mapping config, `label` is the
+  // operator-facing string.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * WooCommerce core has no first-class carrier entity — shipping is modelled as
+   * method *types* (`flat_rate`, `free_shipping`, `local_pickup`, plus any
+   * plugin-provided types) attached to shipping zones, not named carriers.
+   * `GET /shipping_methods` returns those globally-registered method types, which
+   * is the closest live analogue to a carrier list and gives the mapping UI a
+   * non-empty, stable set to map onto (rather than an empty dropdown). `value` is
+   * the WC method id — the same code createOrder emits as `shipping_lines.method_id`.
+   */
+  async listCarriers(): Promise<MappingOption[]> {
+    const rows = await this.httpClient.get<WooCommerceShippingMethod[]>(
+      '/wp-json/wc/v3/shipping_methods',
+    );
+    return rows.map((row) => ({
+      value: String(row.id),
+      label: row.title ?? String(row.id),
+    }));
+  }
+
+  /**
+   * WooCommerce exposes no dedicated order-status catalogue endpoint — the core
+   * status set is fixed by the WC REST API v3 contract. Enumerate the shared
+   * vocabulary (`WC_ORDER_STATUS_VALUES`) decorated with display labels; `value`
+   * is the WC status slug persisted by mapping config.
+   */
+  listOrderStatuses(): Promise<MappingOption[]> {
+    return Promise.resolve(
+      WC_ORDER_STATUS_VALUES.map((slug) => ({
+        value: slug,
+        label: WC_ORDER_STATUS_LABELS[slug],
+      })),
+    );
+  }
+
+  /**
+   * `GET /payment_gateways` lists every payment gateway registered in the store.
+   * `value` is the gateway code (`bacs`, `cod`, `paypal`, …) persisted by mapping
+   * config; `label` is the operator-facing title. All registered gateways are
+   * returned regardless of `enabled` — an operator may legitimately map a source
+   * payment method onto a currently-disabled destination gateway.
+   */
+  async listPaymentMethods(): Promise<MappingOption[]> {
+    const rows = await this.httpClient.get<WooCommercePaymentGateway[]>(
+      '/wp-json/wc/v3/payment_gateways',
+    );
+    return rows.map((row) => ({
+      value: String(row.id),
+      label: row.title ?? String(row.id),
+    }));
   }
 
   // ─── Private helpers ──────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed and why

Implements the `DestinationOptionsReader` sub-capability (#472) on `WooCommerceOrderProcessorAdapter`, bringing WooCommerce to parity with PrestaShop (#472/#473). The connection-mappings UI (`MappingOptionsController`) resolves the destination `OrderProcessorManager` adapter, narrows it with `isDestinationOptionsReader`, and calls the three list methods to populate the status / carrier / payment dropdowns operators use to build source->destination maps. Before this change WooCommerce failed that guard and the dropdowns came back empty.

The adapter now `implements DestinationOptionsReader` and adds:

- `listOrderStatuses()` - enumerates the shared WC status vocabulary (`WC_ORDER_STATUS_VALUES`, from #1549's module) decorated with display labels. WooCommerce exposes no status-catalogue endpoint; the core set is fixed by the WC REST API v3 contract, so this is a static, network-free list.
- `listPaymentMethods()` - `GET /payment_gateways`, mapped to the neutral `MappingOption` shape (`value` = gateway code, `label` = title). All registered gateways are returned regardless of `enabled` so an operator can map onto a currently-disabled gateway.
- `listCarriers()` - `GET /shipping_methods`. **Decision:** WooCommerce core has no first-class carrier entity - shipping is modelled as method *types* (`flat_rate`, `free_shipping`, `local_pickup`, plus plugin-provided types) attached to zones, not named carriers. Returning those globally-registered method types is the closest live analogue and gives the mapping UI a non-empty, stable set to map onto, rather than an empty dropdown. `value` is the WC method id - the same code `createOrder` already emits as `shipping_lines.method_id`.

New `woocommerce-options.types.ts` holds the two response shapes plus the status-label map. All three methods return the neutral `MappingOption` shape PrestaShop returns.

## Basing

Stacked on `1549-woocommerce-order-status-writeback` to reuse the shared `WC_ORDER_STATUS_VALUES` vocabulary and avoid conflicting on the adapter class beyond the `implements` line. GitHub will auto-retarget this PR to `main` once #1549 merges.

## How to test

Scoped WooCommerce package checks:

```
pnpm --filter @openlinker/integrations-woocommerce type-check   # pass
pnpm --filter @openlinker/integrations-woocommerce lint         # pass
pnpm --filter @openlinker/integrations-woocommerce test         # 354 passed, 16 suites
```

New unit tests cover the `isDestinationOptionsReader` guard and all three methods (mapping, id fallback when title is missing, empty-list carriers, and static-vocabulary statuses making no network call).

## Acceptance criteria

- [x] Adapter implements `DestinationOptionsReader` and passes the `isDestinationOptionsReader` guard.
- [x] `listOrderStatuses()` and `listPaymentMethods()` return non-empty neutral option lists.
- [x] `listCarriers()` behaviour (shipping methods) implemented and documented inline.
- [x] Unit tests cover the three methods.
- [x] No CORE <-> Integration boundary violations (adapter imports only the `MappingOption` type + `DestinationOptionsReader` interface from the `@openlinker/core/orders` barrel).

Closes #1551