### PR TITLE
feat(woocommerce): implement FulfillmentStatusReader sub-capability

### DIFF
--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-fulfillment-status.mapper.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-fulfillment-status.mapper.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * WooCommerce Fulfillment Status Mapper — unit tests
+ *
+ * Pure-function coverage of the WC → neutral fulfillment status mapping
+ * (#1550). No adapter or HTTP client instantiation needed.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__
+ */
+import {
+  mapWooCommerceStatus,
+  mapToFulfillmentStatusSnapshot,
+  WC_FULFILLMENT_STATUS_MAP,
+} from '../woocommerce-fulfillment-status.mapper';
+import { WC_ORDER_STATUS_VALUES } from '../woocommerce-order-status.types';
+import { FULFILLMENT_STATUS } from '@openlinker/core/orders';
+
+describe('WooCommerceFulfillmentStatusMapper', () => {
+  describe('mapWooCommerceStatus', () => {
+    it.each([
+      ['pending', null],
+      ['processing', null],
+      ['on-hold', null],
+      ['failed', null],
+      ['completed', FULFILLMENT_STATUS.Delivered],
+      ['cancelled', FULFILLMENT_STATUS.Cancelled],
+      ['refunded', FULFILLMENT_STATUS.Cancelled],
+    ] as const)('should map WC status "%s" to neutral %s', (wcStatus, expected) => {
+      expect(mapWooCommerceStatus(wcStatus)).toBe(expected);
+    });
+
+    it('should map an unknown status to null', () => {
+      expect(mapWooCommerceStatus('checkout-draft')).toBeNull();
+    });
+
+    it('should map an absent status to null', () => {
+      expect(mapWooCommerceStatus(undefined)).toBeNull();
+    });
+
+    it('should have a mapping entry for every WC status in the shared vocabulary', () => {
+      for (const status of WC_ORDER_STATUS_VALUES) {
+        expect(WC_FULFILLMENT_STATUS_MAP).toHaveProperty(status);
+      }
+    });
+  });
+
+  describe('mapToFulfillmentStatusSnapshot', () => {
+    it('should return delivered with deliveredAt from date_completed_gmt for a completed order', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({
+        id: 1,
+        status: 'completed',
+        date_completed_gmt: '2026-07-14T10:30:00',
+      });
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Delivered);
+      expect(snapshot.trackingNumber).toBeNull();
+      expect(snapshot.deliveredAt).toEqual(new Date('2026-07-14T10:30:00Z'));
+    });
+
+    it('should fall back to date_modified_gmt for deliveredAt when date_completed_gmt is absent', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({
+        id: 1,
+        status: 'completed',
+        date_modified_gmt: '2026-07-13T08:00:00',
+      });
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Delivered);
+      expect(snapshot.deliveredAt).toEqual(new Date('2026-07-13T08:00:00Z'));
+    });
+
+    it('should return delivered with null deliveredAt when no completion timestamp is present', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({ id: 1, status: 'completed' });
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Delivered);
+      expect(snapshot.deliveredAt).toBeNull();
+    });
+
+    it('should return cancelled with null deliveredAt for a cancelled order', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({ id: 1, status: 'cancelled' });
+
+      expect(snapshot).toEqual({
+        status: FULFILLMENT_STATUS.Cancelled,
+        trackingNumber: null,
+        deliveredAt: null,
+      });
+    });
+
+    it('should return cancelled for a refunded order', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({ id: 1, status: 'refunded' });
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Cancelled);
+      expect(snapshot.deliveredAt).toBeNull();
+    });
+
+    it('should return null status for a pre-fulfillment (processing) order', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({ id: 1, status: 'processing' });
+
+      expect(snapshot).toEqual({ status: null, trackingNumber: null, deliveredAt: null });
+    });
+
+    it('should not populate deliveredAt for a non-delivered status even when a timestamp exists', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({
+        id: 1,
+        status: 'cancelled',
+        date_modified_gmt: '2026-07-14T10:30:00',
+      });
+
+      expect(snapshot.deliveredAt).toBeNull();
+    });
+
+    it('should honour an explicit timezone offset on the completion timestamp', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({
+        id: 1,
+        status: 'completed',
+        date_completed_gmt: '2026-07-14T12:30:00+02:00',
+      });
+
+      expect(snapshot.deliveredAt).toEqual(new Date('2026-07-14T10:30:00Z'));
+    });
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.fulfillment-status.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.fulfillment-status.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * WooCommerce Order Processor Adapter — FulfillmentStatusReader unit tests
+ *
+ * Covers the getFulfillmentStatus read path (#1550): the isFulfillmentStatusReader
+ * guard, the GET /orders/{id} call + mapping, id validation, and 404 handling.
+ * Mocks IWooCommerceHttpClient and IdentifierMappingPort.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__
+ */
+import { WooCommerceOrderProcessorAdapter } from '../woocommerce-order-processor.adapter';
+import { isFulfillmentStatusReader, FULFILLMENT_STATUS } from '@openlinker/core/orders';
+import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-client.interface';
+import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
+import { WooCommerceResourceNotFoundException } from '../../../../domain/exceptions/woocommerce-resource-not-found.exception';
+import { WooCommerceInvalidArgumentException } from '../../../../domain/exceptions/woocommerce-invalid-argument.exception';
+import { WooCommerceHttpResponseException } from '../../../http/woocommerce-http-response.exception';
+
+const CONNECTION_ID = 'conn-wc-001';
+
+const mockConnection: Connection = {
+  id: CONNECTION_ID,
+  platformType: 'woocommerce',
+  name: 'Test WC Store',
+  status: 'active',
+  config: { siteUrl: 'https://myshop.com' } as Record<string, unknown>,
+  credentialsRef: 'cred-ref-001',
+  adapterKey: 'woocommerce.restapi.v3',
+  enabledCapabilities: ['OrderProcessorManager'],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function makeHttpClient(): jest.Mocked<IWooCommerceHttpClient> {
+  return {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  };
+}
+
+function makeIdentifierMapping(): jest.Mocked<IdentifierMappingPort> {
+  return {
+    getOrCreateInternalId: jest.fn(),
+    getOrCreateExactMapping: jest.fn(),
+    getInternalId: jest.fn(),
+    getExternalIds: jest.fn(),
+    createMapping: jest.fn(),
+    batchGetOrCreateInternalIds: jest.fn(),
+    deleteMapping: jest.fn(),
+    listExternalIdsByConnection: jest.fn(),
+  };
+}
+
+function makeAdapter(
+  httpClient: jest.Mocked<IWooCommerceHttpClient>,
+): WooCommerceOrderProcessorAdapter {
+  return new WooCommerceOrderProcessorAdapter(httpClient, makeIdentifierMapping(), mockConnection);
+}
+
+describe('WooCommerceOrderProcessorAdapter — FulfillmentStatusReader', () => {
+  it('should pass the isFulfillmentStatusReader guard', () => {
+    const adapter = makeAdapter(makeHttpClient());
+    expect(isFulfillmentStatusReader(adapter)).toBe(true);
+  });
+
+  it('should GET the order and return the mapped fulfillment snapshot', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({
+      id: 123,
+      status: 'completed',
+      date_completed_gmt: '2026-07-14T10:30:00',
+    });
+    const adapter = makeAdapter(httpClient);
+
+    const snapshot = await adapter.getFulfillmentStatus({ externalOrderId: '123' });
+
+    expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/orders/123');
+    expect(snapshot).toEqual({
+      status: FULFILLMENT_STATUS.Delivered,
+      trackingNumber: null,
+      deliveredAt: new Date('2026-07-14T10:30:00Z'),
+    });
+  });
+
+  it('should return a null-status snapshot for a pre-fulfillment order', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: 5, status: 'processing' });
+    const adapter = makeAdapter(httpClient);
+
+    const snapshot = await adapter.getFulfillmentStatus({ externalOrderId: '5' });
+
+    expect(snapshot.status).toBeNull();
+    expect(snapshot.deliveredAt).toBeNull();
+  });
+
+  it('should reject a non-integer externalOrderId before any HTTP call', async () => {
+    const httpClient = makeHttpClient();
+    const adapter = makeAdapter(httpClient);
+
+    await expect(
+      adapter.getFulfillmentStatus({ externalOrderId: '12/../../etc' }),
+    ).rejects.toBeInstanceOf(WooCommerceInvalidArgumentException);
+    expect(httpClient.get).not.toHaveBeenCalled();
+  });
+
+  it('should throw WooCommerceResourceNotFoundException on a 404', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockRejectedValue(new WooCommerceHttpResponseException(404, 'Not Found'));
+    const adapter = makeAdapter(httpClient);
+
+    await expect(
+      adapter.getFulfillmentStatus({ externalOrderId: '999' }),
+    ).rejects.toBeInstanceOf(WooCommerceResourceNotFoundException);
+  });
+
+  it('should propagate non-404 errors unchanged', async () => {
+    const httpClient = makeHttpClient();
+    const err = new WooCommerceHttpResponseException(500, 'Server Error');
+    httpClient.get.mockRejectedValue(err);
+    const adapter = makeAdapter(httpClient);
+
+    await expect(adapter.getFulfillmentStatus({ externalOrderId: '7' })).rejects.toBe(err);
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-fulfillment-status.mapper.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-fulfillment-status.mapper.ts
@@ -1,0 +1,102 @@
+/**
+ * WooCommerce Fulfillment Status Mapper
+ *
+ * Pure mapper from a WooCommerce order's `status` field to the neutral
+ * `FulfillmentStatusSnapshot` (#834 / #1550) — the WC → neutral read direction,
+ * counterpart to the neutral → WC write direction owned by
+ * {@link WC_ORDER_STATUS_MAP}. Reuses the shared WC status vocabulary from
+ * `woocommerce-order-status.types.ts` (#1549) — there is a single source of
+ * truth for the WooCommerce status set across every order sub-capability.
+ *
+ * **Status mapping rules** (conservative v1):
+ *
+ * - `completed` → `delivered`. WC has no distinct shipped/in-transit/delivered
+ *   states — `completed` is the terminal fulfilled state and never transitions
+ *   further, so it projects to the terminal neutral `delivered` (+ `deliveredAt`
+ *   read from `date_completed_gmt`, falling back to `date_modified_gmt`).
+ * - `cancelled` → `cancelled`.
+ * - `refunded` → `cancelled`. A refund is a terminal reversal of the order; the
+ *   writeback (#1549) already treats `refunded` as terminal alongside
+ *   `completed`, so the read side mirrors it onto the only neutral terminal-
+ *   reversal value available.
+ * - `pending` / `processing` / `on-hold` / `failed` → `null`. The shop has not
+ *   yet fulfilled the order (awaiting payment, processing, on hold, or a failed
+ *   payment) — projection-only skip.
+ * - An unknown / absent status → `null` (defensive: treat as not-yet-acted).
+ *
+ * **Tracking**: always `null`. WooCommerce core has no order-level tracking
+ * field (it lives in the third-party Shipment Tracking plugin's meta_data),
+ * mirroring the same limitation `updateFulfillment` documents on the write side.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
+ */
+import type { FulfillmentStatus, FulfillmentStatusSnapshot } from '@openlinker/core/orders';
+import { FULFILLMENT_STATUS } from '@openlinker/core/orders';
+
+import type { WooCommerceOrderResponse } from './woocommerce-order.types';
+import { WC_ORDER_STATUS_VALUES, type WooCommerceOrderStatus } from './woocommerce-order-status.types';
+
+/**
+ * WooCommerce status → neutral `FulfillmentStatus`. Keyed off the shared
+ * {@link WooCommerceOrderStatus} vocabulary so a new WC status can't be added in
+ * one place without the compiler flagging the missing branch here. `null` marks
+ * the pre-fulfillment states the sync service skips (projection-only semantics).
+ */
+export const WC_FULFILLMENT_STATUS_MAP: Record<WooCommerceOrderStatus, FulfillmentStatus | null> = {
+  pending: null,
+  processing: null,
+  'on-hold': null,
+  completed: FULFILLMENT_STATUS.Delivered,
+  cancelled: FULFILLMENT_STATUS.Cancelled,
+  refunded: FULFILLMENT_STATUS.Cancelled,
+  failed: null,
+};
+
+/**
+ * Map a raw WooCommerce order `status` string to the neutral fulfillment status.
+ * Returns `null` for pre-fulfillment states and for any unknown / absent value.
+ */
+export function mapWooCommerceStatus(status: string | undefined): FulfillmentStatus | null {
+  if (status === undefined || !isKnownWooCommerceStatus(status)) {
+    return null;
+  }
+  return WC_FULFILLMENT_STATUS_MAP[status];
+}
+
+/**
+ * Project a WooCommerce order response onto the neutral fulfillment snapshot.
+ * `deliveredAt` is populated only on the `delivered` transition, read from the
+ * order's completion timestamp.
+ */
+export function mapToFulfillmentStatusSnapshot(
+  order: WooCommerceOrderResponse,
+): FulfillmentStatusSnapshot {
+  const status = mapWooCommerceStatus(order.status);
+  const deliveredAt =
+    status === FULFILLMENT_STATUS.Delivered
+      ? parseDate(order.date_completed_gmt ?? order.date_modified_gmt)
+      : null;
+
+  return {
+    status,
+    trackingNumber: null,
+    deliveredAt,
+  };
+}
+
+function isKnownWooCommerceStatus(status: string): status is WooCommerceOrderStatus {
+  return (WC_ORDER_STATUS_VALUES as readonly string[]).includes(status);
+}
+
+/**
+ * WooCommerce serialises GMT timestamps without a zone suffix (e.g.
+ * `2026-07-14T10:30:00`). Append `Z` when no explicit offset is present so it
+ * parses as UTC rather than local time. Returns `null` for absent / unparseable
+ * values.
+ */
+function parseDate(value: string | undefined): Date | null {
+  if (!value) return null;
+  const normalised = /[zZ]|[+-]\d{2}:?\d{2}$/.test(value) ? value : `${value}Z`;
+  const parsed = new Date(normalised);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -3,8 +3,10 @@
  *
  * Implements OrderProcessorManagerPort (createOrder), the OrderFulfillmentUpdater
  * sub-capability (updateFulfillment — status updates, cancellations, refund transitions),
- * and the OrderStatusWriteback sub-capability (write — the #1157 / ADR-027 lifecycle
- * relay contract) for WooCommerce REST API v3.
+ * the OrderStatusWriteback sub-capability (write — the #1157 / ADR-027 lifecycle
+ * relay contract), and the FulfillmentStatusReader sub-capability (getFulfillmentStatus
+ * — the #834 / #1550 read-back of the shop's fulfillment view) for WooCommerce REST
+ * API v3.
  *
  * Key design decisions:
  * - createOrder: the adapter does NOT dedup. It POSTs to WC and returns the
@@ -29,6 +31,7 @@
  * @implements {OrderProcessorManagerPort}
  * @implements {OrderFulfillmentUpdater}
  * @implements {OrderStatusWriteback}
+ * @implements {FulfillmentStatusReader}
  */
 import type {
   OrderProcessorManagerPort,
@@ -43,6 +46,8 @@ import type {
   OrderStatusWriteback,
   OrderLifecycleEvent,
   OrderWritebackResult,
+  FulfillmentStatusReader,
+  FulfillmentStatusSnapshot,
 } from '@openlinker/core/orders';
 import type { IdentifierMappingPort, Connection, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
@@ -67,6 +72,7 @@ import type {
   WooCommerceCustomerResponse,
 } from './woocommerce-order.types';
 import { WC_ORDER_STATUS_MAP } from './woocommerce-order.types';
+import { mapToFulfillmentStatusSnapshot } from './woocommerce-fulfillment-status.mapper';
 
 // ─── Module-level pure helpers ────────────────────────────────────────────────
 // Pure functions with no dependency on adapter state — independently testable.
@@ -82,7 +88,11 @@ export function isValidEmail(value: unknown): value is string {
 // ─── Adapter ──────────────────────────────────────────────────────────────────
 
 export class WooCommerceOrderProcessorAdapter
-  implements OrderProcessorManagerPort, OrderFulfillmentUpdater, OrderStatusWriteback
+  implements
+    OrderProcessorManagerPort,
+    OrderFulfillmentUpdater,
+    OrderStatusWriteback,
+    FulfillmentStatusReader
 {
   private readonly logger = new Logger(WooCommerceOrderProcessorAdapter.name);
 
@@ -288,6 +298,52 @@ export class WooCommerceOrderProcessorAdapter
         error instanceof Error ? error.stack : undefined,
       );
       return { outcome: 'rejected', detail };
+    }
+  }
+
+  // ─── FulfillmentStatusReader ──────────────────────────────────────────────
+
+  /**
+   * `FulfillmentStatusReader` (#834 / #1550): read the shop's view of an
+   * order's fulfillment progress. GETs `/orders/{id}`, reads the WC `status`,
+   * and maps it to the neutral `FulfillmentStatusSnapshot` via
+   * {@link mapToFulfillmentStatusSnapshot}.
+   *
+   * `status` is `null` when the shop has not yet fulfilled the order
+   * (`pending` / `processing` / `on-hold` / `failed`) — the branch-1 sync
+   * service treats that as "no shipment to project, skip this pass".
+   * `trackingNumber` is always `null` (WC core carries no order-level tracking
+   * field). `externalOrderId` is the WC-native numeric order id.
+   */
+  async getFulfillmentStatus(input: {
+    externalOrderId: string;
+  }): Promise<FulfillmentStatusSnapshot> {
+    this.logger.debug(
+      `getFulfillmentStatus: externalOrderId=${input.externalOrderId} (connection: ${this.connection.id})`,
+    );
+
+    // Path-traversal defence — externalOrderId must be a bare positive integer string.
+    if (!/^\d+$/.test(input.externalOrderId)) {
+      throw new WooCommerceInvalidArgumentException(
+        `Invalid externalOrderId "${input.externalOrderId}" — expected a WC integer ID`,
+      );
+    }
+
+    try {
+      const order = await this.httpClient.get<WooCommerceOrderResponse>(
+        `/wp-json/wc/v3/orders/${input.externalOrderId}`,
+      );
+      return mapToFulfillmentStatusSnapshot(order);
+    } catch (err) {
+      if (err instanceof WooCommerceHttpResponseException && err.statusCode === 404) {
+        throw new WooCommerceResourceNotFoundException(
+          `WooCommerce order ${input.externalOrderId} not found`,
+          CORE_ENTITY_TYPE.Order,
+          input.externalOrderId,
+          this.connection.id,
+        );
+      }
+      throw err;
     }
   }
 

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order.types.ts
@@ -75,6 +75,10 @@ export interface WooCommerceOrderResponse {
   id?: number;
   number?: string;
   status?: string;
+  /** GMT timestamp WC stamps when an order transitions to `completed`. */
+  date_completed_gmt?: string;
+  /** GMT timestamp of the order's last modification — `deliveredAt` fallback. */
+  date_modified_gmt?: string;
 }
 
 // ─── Customer shapes ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Part of #1547 (WooCommerce parity with PrestaShop). Adds the `FulfillmentStatusReader` sub-capability (#834) to `WooCommerceOrderProcessorAdapter`, so OpenLinker can read back the shop's view of an order's fulfillment progress - the counterpart to the `OrderFulfillmentUpdater` write path.

## Changes

- `WooCommerceOrderProcessorAdapter` now additionally `implements FulfillmentStatusReader` and passes the `isFulfillmentStatusReader` guard.
- `getFulfillmentStatus({ externalOrderId })` GETs `/orders/{id}`, reads the WooCommerce order `status`, and maps it to the neutral `FulfillmentStatusSnapshot`.
- New `woocommerce-fulfillment-status.mapper.ts` (WC -> neutral read direction) reuses the shared neutral<->WooCommerce status vocabulary from `woocommerce-order-status.types.ts` (introduced by #1549) as the single source of truth - it does not duplicate the map. `WC_FULFILLMENT_STATUS_MAP` is keyed off `WooCommerceOrderStatus` so a new WC status cannot be added without the compiler flagging the missing branch.

## Mapping (conservative v1)

- `completed` -> `delivered` (WC's terminal fulfilled state; `deliveredAt` read from `date_completed_gmt`, falling back to `date_modified_gmt`).
- `cancelled` -> `cancelled`; `refunded` -> `cancelled` (terminal reversal, mirroring how the writeback treats `refunded` as terminal alongside `completed`).
- `pending` / `processing` / `on-hold` / `failed` -> `null` (pre-fulfillment; the branch-1 sync service skips projection).
- unknown / absent status -> `null` (defensive).
- `trackingNumber` is always `null` - WooCommerce core has no order-level tracking field.

`externalOrderId` is validated as a bare integer before any HTTP call (path-traversal defence); a 404 surfaces as `WooCommerceResourceNotFoundException`.

## Testing

- New `woocommerce-fulfillment-status.mapper.spec.ts` covers the mapping for every WC status plus timestamp handling.
- New `woocommerce-order-processor.fulfillment-status.spec.ts` covers the guard, GET + mapping, id validation, and 404 handling.
- Scoped `@openlinker/integrations-woocommerce` type-check, lint, and test all pass (99 order-processor tests green).

## Basing

Stacked on the #1549 branch to reuse its shared status-types module. GitHub will auto-retarget this PR to `main` once #1549 merges.

Closes #1550