### PR TITLE
feat(woocommerce): customer + address provisioning with reuse and locking

### DIFF
--- a/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
+++ b/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
@@ -205,15 +205,13 @@ describe('createWooCommercePlugin → register(host) — #876 additions', () => 
 });
 
 describe('WooCommerceIntegrationModule', () => {
-  // The module is a top-level `DynamicModule` const built by
-  // `createNestAdapterModule({ plugin: createWooCommercePlugin() })`, so merely
-  // importing this spec already exercises the composition — a regression there
-  // throws at module load. These assertions lock the composed shape so the
-  // breakage surfaces at unit speed (#1023; no host bootstrap required).
-  it('composes a DynamicModule (host module class + framework imports)', () => {
-    expect(WooCommerceIntegrationModule.module).toBeDefined();
-    expect(typeof WooCommerceIntegrationModule.module).toBe('function');
-    expect(Array.isArray(WooCommerceIntegrationModule.imports)).toBe(true);
-    expect(WooCommerceIntegrationModule.imports!.length).toBeGreaterThan(0);
+  // Since #1552 the module is a bespoke `@Module` class (Shape A) — it provides
+  // the customer + address provisioners and builds the descriptor with those
+  // plugin-specific deps in `onModuleInit`, mirroring PrestaShop. Importing this
+  // spec exercises the decorator metadata; a class-shape regression surfaces at
+  // unit speed (no host bootstrap required).
+  it('is a NestJS module class implementing onModuleInit', () => {
+    expect(typeof WooCommerceIntegrationModule).toBe('function');
+    expect(typeof WooCommerceIntegrationModule.prototype.onModuleInit).toBe('function');
   });
 });

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
@@ -19,6 +19,11 @@ import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-clie
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
 import type { OrderCreate, OrderItem, OrderStatus } from '@openlinker/core/orders';
+import type { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
+import { DestinationAddressMapping } from '@openlinker/core/customers';
+import type { SyncLockPort } from '@openlinker/core/sync';
+import { WooCommerceCustomerProvisioner } from '../../../provisioners/woocommerce-customer-provisioner';
+import { WooCommerceAddressProvisioner } from '../../../provisioners/woocommerce-address-provisioner';
 import { WooCommerceResourceNotFoundException } from '../../../../domain/exceptions/woocommerce-resource-not-found.exception';
 import { WooCommerceInvalidIdentifierException } from '../../../../domain/exceptions/woocommerce-invalid-identifier.exception';
 import { WooCommerceOrderProcessingException } from '../../../../domain/exceptions/woocommerce-order-processing.exception';
@@ -30,6 +35,16 @@ import { WooCommerceUnauthorizedException } from '../../../../domain/exceptions/
 // ─── Test fixtures ─────────────────────────────────────────────────────────
 
 const CONNECTION_ID = 'conn-wc-001';
+
+// Address reuse tracking hashes the address (getPiiConfig requires a salt).
+const originalPiiHashSalt = process.env.OL_PII_HASH_SALT;
+beforeAll(() => {
+  process.env.OL_PII_HASH_SALT = 'test-salt-for-hashing';
+});
+afterAll(() => {
+  if (originalPiiHashSalt === undefined) delete process.env.OL_PII_HASH_SALT;
+  else process.env.OL_PII_HASH_SALT = originalPiiHashSalt;
+});
 
 const mockConnection: Connection = {
   id: CONNECTION_ID,
@@ -66,11 +81,62 @@ function makeIdentifierMapping(): jest.Mocked<IdentifierMappingPort> {
   };
 }
 
+/** In-memory SyncLockPort — single-holder-per-key, enough for the adapter tests. */
+function makeSyncLock(): SyncLockPort {
+  const locks = new Map<string, string>();
+  return {
+    acquire: jest.fn((key: string) => {
+      if (locks.has(key)) return Promise.resolve(null);
+      const token = `tok-${Math.random().toString(36).slice(2)}`;
+      locks.set(key, token);
+      return Promise.resolve(token);
+    }),
+    release: jest.fn((key: string, token: string) => {
+      if (locks.get(key) === token) {
+        locks.delete(key);
+        return Promise.resolve(true);
+      }
+      return Promise.resolve(false);
+    }),
+  };
+}
+
+/**
+ * Stub customer-projection repository. `findDestinationAddressMapping` returns a
+ * reuse HIT by default so the address provisioner short-circuits and adds no HTTP
+ * calls — these createOrder tests focus on customer + order-payload behaviour,
+ * not address reuse (that has its own dedicated provisioner spec).
+ */
+function makeProjectionRepo(): jest.Mocked<CustomerProjectionRepositoryPort> {
+  return {
+    findById: jest.fn(),
+    findByEmailHash: jest.fn(),
+    findMany: jest.fn(),
+    upsert: jest.fn(),
+    findAddressesByCustomerId: jest.fn(),
+    upsertAddress: jest.fn(),
+    findDestinationAddressMapping: jest.fn(() =>
+      Promise.resolve(
+        new DestinationAddressMapping('ol-cust-1', CONNECTION_ID, 'hash', 'billing', '7', new Date(), new Date()),
+      ),
+    ),
+    upsertDestinationAddressMapping: jest.fn((m) => Promise.resolve(m)),
+  } as unknown as jest.Mocked<CustomerProjectionRepositoryPort>;
+}
+
 function makeAdapter(
   httpClient: jest.Mocked<IWooCommerceHttpClient>,
   identifierMapping: jest.Mocked<IdentifierMappingPort>,
 ): WooCommerceOrderProcessorAdapter {
-  return new WooCommerceOrderProcessorAdapter(httpClient, identifierMapping, mockConnection);
+  const syncLock = makeSyncLock();
+  return new WooCommerceOrderProcessorAdapter(
+    httpClient,
+    identifierMapping,
+    mockConnection,
+    new WooCommerceCustomerProvisioner(syncLock),
+    new WooCommerceAddressProvisioner(syncLock),
+    makeProjectionRepo(),
+  );
 }
 
 function makeOrder(overrides: Partial<OrderCreate> = {}): OrderCreate {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -13,17 +13,20 @@
  *   without an extension, so it cannot be read back as a skip-check). Real
  *   idempotency is core-owned: OrderSyncService's per-(order,destination) lock
  *   (#906) + update-or-create mapping check (#909).
- * - Customer provisioning: POST /customers with email when available.
- *   auth failures (401/403) propagate as WooCommerceAuthFailureException — they
- *   are NOT swallowed into guest-order creation (#877).
+ * - Customer provisioning: delegated to WooCommerceCustomerProvisioner
+ *   (resolve-or-create under a distributed lock; #1552). Auth failures (401/403)
+ *   propagate as WooCommerceAuthFailureException — they are NOT swallowed into
+ *   guest-order creation (#877).
  * - buyerEmail: WooCommerce adapter reads buyer email from order.metadata?.buyerEmail,
  *   which OrderSyncService populates from the source order's customerEmail (#948).
  *   When absent (hash-only PII mode, or a source without an email), customer
  *   provisioning degrades to guest (customer_id = 0).
- * - destination_address_mappings: not applicable — WC has no address entities; addresses
- *   are embedded inline in the order payload.
- * - DuplicateIdentifierMappingError: not applicable here — mapping writes are in
- *   OrderSyncService.
+ * - Address reuse: delegated to WooCommerceAddressProvisioner (#1552). WC has no
+ *   standalone address resource — the provisioner writes the customer's inline
+ *   billing/shipping address at most once per (customer, addressHash, type) using
+ *   destination_address_mappings, guarded by the same distributed lock. Best-effort:
+ *   a provisioning failure is logged and never aborts order creation. The order
+ *   payload always carries the inline address regardless.
  *
  * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
  * @implements {OrderProcessorManagerPort}
@@ -45,17 +48,18 @@ import type {
   OrderWritebackResult,
 } from '@openlinker/core/orders';
 import type { IdentifierMappingPort, Connection, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
-import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
+import type { CustomerProjectionRepositoryPort, AddressType } from '@openlinker/core/customers';
 import { Logger } from '@openlinker/shared/logging';
 import type { IWooCommerceHttpClient } from '../../http/woocommerce-http-client.interface';
 import { WooCommerceHttpResponseException } from '../../http/woocommerce-http-response.exception';
-import { WooCommerceUnauthorizedException } from '../../../domain/exceptions/woocommerce-unauthorized.exception';
-import { WooCommerceAuthFailureException } from '../../../domain/exceptions/woocommerce-auth-failure.exception';
 import { WooCommerceResourceNotFoundException } from '../../../domain/exceptions/woocommerce-resource-not-found.exception';
 import { WooCommerceOrderProcessingException } from '../../../domain/exceptions/woocommerce-order-processing.exception';
 import { WooCommerceInvalidArgumentException } from '../../../domain/exceptions/woocommerce-invalid-argument.exception';
 import { WooCommerceInvalidIdentifierException } from '../../../domain/exceptions/woocommerce-invalid-identifier.exception';
 import { toPositiveInt } from '../../utils/woocommerce-utils';
+import type { WooCommerceCustomerProvisioner } from '../../provisioners/woocommerce-customer-provisioner';
+import type { WooCommerceAddressProvisioner } from '../../provisioners/woocommerce-address-provisioner';
 import type {
   WooCommerceOrderCreateRequest,
   WooCommerceOrderUpdateRequest,
@@ -63,8 +67,6 @@ import type {
   WooCommerceOrderAddress,
   WooCommerceLineItemRequest,
   WooCommerceShippingLineRequest,
-  WooCommerceCustomerCreateRequest,
-  WooCommerceCustomerResponse,
 } from './woocommerce-order.types';
 import { WC_ORDER_STATUS_MAP } from './woocommerce-order.types';
 
@@ -90,6 +92,9 @@ export class WooCommerceOrderProcessorAdapter
     private readonly httpClient: IWooCommerceHttpClient,
     private readonly identifierMapping: IdentifierMappingPort,
     private readonly connection: Connection,
+    private readonly customerProvisioner: WooCommerceCustomerProvisioner,
+    private readonly addressProvisioner: WooCommerceAddressProvisioner,
+    private readonly customerProjectionRepository: CustomerProjectionRepositoryPort,
   ) {}
 
   // ─── OrderProcessorManagerPort ────────────────────────────────────────────
@@ -110,8 +115,26 @@ export class WooCommerceOrderProcessorAdapter
       );
     }
 
-    // Step 2 — resolve or provision WC customer
-    const customerId = await this.resolveCustomerId(order, buyerEmail);
+    // Step 2 — resolve or provision WC customer (delegated to the provisioner,
+    // which serializes concurrent provisioning for the same buyer under a lock).
+    const firstName = order.billingAddress?.firstName ?? order.shippingAddress?.firstName ?? '';
+    const lastName = order.billingAddress?.lastName ?? order.shippingAddress?.lastName ?? '';
+    const customerId = await this.customerProvisioner.resolveOrCreateCustomer({
+      internalCustomerId: order.customerId,
+      buyerEmail,
+      firstName,
+      lastName,
+      connectionId: this.connection.id,
+      httpClient: this.httpClient,
+      identifierMapping: this.identifierMapping,
+    });
+
+    // Step 2b — reuse-tracked address provisioning (best-effort; #1552). Records
+    // the WC customer's inline billing/shipping address for reuse without ever
+    // aborting order creation. Skipped for guest orders (customer_id = 0).
+    if (customerId > 0 && order.customerId) {
+      await this.provisionAddresses(order, order.customerId, customerId);
+    }
 
     // Step 3 — resolve line items (throws on any unresolvable or corrupted mapping)
     const lineItems = await this.resolveLineItems(order.items);
@@ -294,128 +317,39 @@ export class WooCommerceOrderProcessorAdapter
   // ─── Private helpers ──────────────────────────────────────────────────────
 
   /**
-   * Resolves or provisions a WC customer account for the given OL internal customer.
-   * Degrades to guest (customer_id = 0) on non-auth, non-critical failure.
-   * Auth failures (401/403) are NOT swallowed — they propagate as
-   * WooCommerceAuthFailureException so the sync runner can flag the connection
-   * for re-authentication (#877 I1).
+   * Best-effort reuse-tracked provisioning of the WC customer's inline billing
+   * and shipping addresses (#1552). Delegates to WooCommerceAddressProvisioner
+   * per address type. Failures are logged and swallowed — address reuse tracking
+   * is auxiliary and must never abort order creation.
    */
-  private async resolveCustomerId(
+  private async provisionAddresses(
     order: OrderCreate,
-    buyerEmail: string | undefined,
-  ): Promise<number> {
-    const { customerId } = order;
-    if (!customerId) return 0;
+    internalCustomerId: string,
+    wcCustomerId: number,
+  ): Promise<void> {
+    const targets: Array<{ address: Address | undefined; type: AddressType }> = [
+      { address: order.billingAddress, type: 'billing' },
+      { address: order.shippingAddress, type: 'shipping' },
+    ];
 
-    // 1. Look up existing WC customer mapping
-    const externalIds = await this.identifierMapping.getExternalIds(
-      CORE_ENTITY_TYPE.Customer,
-      customerId,
-    );
-    const mapping = externalIds.find((e: ExternalIdMapping) => e.connectionId === this.connection.id);
-    if (mapping) {
-      const n = Number(mapping.externalId);
-      if (!Number.isInteger(n) || n <= 0) {
+    for (const { address, type } of targets) {
+      if (!address) continue;
+      try {
+        await this.addressProvisioner.resolveOrCreateAddress({
+          internalCustomerId,
+          wcCustomerId,
+          address,
+          addressType: type,
+          connectionId: this.connection.id,
+          httpClient: this.httpClient,
+          customerProjectionRepository: this.customerProjectionRepository,
+        });
+      } catch (err) {
         this.logger.warn(
-          `resolveCustomerId: corrupted mapping "${mapping.externalId}" for customer ${customerId} — guest order`,
+          `provisionAddresses: ${type} address reuse tracking failed for customer ${internalCustomerId} — continuing: ${String(err)}`,
         );
-        return 0;
-      }
-      return n;
-    }
-
-    // 2. No existing mapping — provision WC customer if email is available
-    if (!buyerEmail) {
-      this.logger.warn(
-        `resolveCustomerId: no WC mapping and no buyerEmail for customer ${customerId} — guest order`,
-      );
-      return 0;
-    }
-
-    const firstName = order.billingAddress?.firstName ?? order.shippingAddress?.firstName ?? '';
-    const lastName = order.billingAddress?.lastName ?? order.shippingAddress?.lastName ?? '';
-
-    let wcCustomerId: number;
-    try {
-      const created = await this.httpClient.post<WooCommerceCustomerResponse>(
-        '/wp-json/wc/v3/customers',
-        {
-          email: buyerEmail,
-          first_name: firstName,
-          last_name: lastName,
-        } satisfies WooCommerceCustomerCreateRequest,
-      );
-      if (!created.id) {
-        this.logger.warn(
-          `resolveCustomerId: WC customer POST returned no id for ${customerId} — guest order`,
-        );
-        return 0;
-      }
-      wcCustomerId = created.id;
-    } catch (err) {
-      // Auth failures must propagate — invalid credentials require re-authentication.
-      // Swallowing a 401/403 into a guest order masks a broken connection (#877 I1).
-      if (err instanceof WooCommerceUnauthorizedException) {
-        throw new WooCommerceAuthFailureException(
-          `WooCommerce auth failure provisioning customer ${customerId} on connection ${this.connection.id}: ${String(err)}`,
-          this.connection.id,
-        );
-      }
-      if (err instanceof WooCommerceHttpResponseException && err.statusCode === 400) {
-        // WC returns 400 + code 'registration-error-email-exists' for duplicate emails —
-        // look up the existing customer account by email
-        const existing = await this.httpClient.get<WooCommerceCustomerResponse[]>(
-          '/wp-json/wc/v3/customers',
-          { email: buyerEmail },
-        );
-        const match = existing.find((c) => c.email === buyerEmail);
-        if (!match?.id) {
-          this.logger.warn(
-            `resolveCustomerId: duplicate email ${buyerEmail} but no matching WC customer — guest order`,
-          );
-          return 0;
-        }
-        wcCustomerId = match.id;
-      } else {
-        // Non-auth, non-400 failure (network, rate-limit, etc.) — degrade to guest,
-        // do not abort order creation.
-        this.logger.warn(
-          `resolveCustomerId: WC customer API error for ${customerId} — guest order: ${String(err)}`,
-        );
-        return 0;
       }
     }
-
-    // 3. Store Customer mapping with concurrent-duplicate handler
-    try {
-      await this.identifierMapping.createMapping(
-        CORE_ENTITY_TYPE.Customer,
-        String(wcCustomerId),
-        this.connection.id,
-        customerId,
-      );
-    } catch (err) {
-      if (err instanceof DuplicateIdentifierMappingError) {
-        // Concurrent retry stored it first — look up winner and return its id
-        const winners = await this.identifierMapping.getExternalIds(
-          CORE_ENTITY_TYPE.Customer,
-          customerId,
-        );
-        const winner = winners.find((e: ExternalIdMapping) => e.connectionId === this.connection.id);
-        if (winner) {
-          const n = Number(winner.externalId);
-          return Number.isInteger(n) && n > 0 ? n : 0;
-        }
-        // Transient — fall back to guest (do not fail the order)
-        this.logger.warn(
-          `resolveCustomerId: concurrent duplicate but no winner for ${customerId} — guest order`,
-        );
-        return 0;
-      }
-      throw err;
-    }
-
-    return wcCustomerId;
   }
 
   /**

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-address-provisioner.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-address-provisioner.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * WooCommerce Address Provisioner — unit tests
+ *
+ * Covers guest skip, reuse hit (mapping table), reuse miss (write inline address
+ * + record mapping), hash-match recovery (existing WC address), and a concurrency
+ * test proving the distributed lock prevents duplicate address writes.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__
+ */
+import { WooCommerceAddressProvisioner } from '../woocommerce-address-provisioner';
+import type { IWooCommerceHttpClient } from '../../http/woocommerce-http-client.interface';
+import type { SyncLockPort } from '@openlinker/core/sync';
+import type { CustomerProjectionRepositoryPort, AddressType } from '@openlinker/core/customers';
+import { DestinationAddressMapping } from '@openlinker/core/customers';
+import type { Address } from '@openlinker/core/orders';
+
+const CONNECTION_ID = 'conn-wc-1';
+const INTERNAL_CUSTOMER_ID = 'ol-cust-1';
+const WC_CUSTOMER_ID = 7;
+
+const originalPiiHashSalt = process.env.OL_PII_HASH_SALT;
+beforeAll(() => {
+  process.env.OL_PII_HASH_SALT = 'test-salt-for-hashing';
+});
+afterAll(() => {
+  if (originalPiiHashSalt === undefined) delete process.env.OL_PII_HASH_SALT;
+  else process.env.OL_PII_HASH_SALT = originalPiiHashSalt;
+});
+
+const ADDRESS: Address = {
+  firstName: 'Jan',
+  lastName: 'Kowalski',
+  address1: 'ul. Kwiatowa 1',
+  city: 'Warszawa',
+  postalCode: '00-001',
+  country: 'PL',
+};
+
+function makeHttpClient(): jest.Mocked<IWooCommerceHttpClient> {
+  return { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() };
+}
+
+function makeSyncLock(): SyncLockPort {
+  const locks = new Map<string, string>();
+  return {
+    acquire: jest.fn((key: string) => {
+      if (locks.has(key)) return Promise.resolve(null);
+      const token = `tok-${Math.random().toString(36).slice(2)}`;
+      locks.set(key, token);
+      return Promise.resolve(token);
+    }),
+    release: jest.fn((key: string, token: string) => {
+      if (locks.get(key) === token) {
+        locks.delete(key);
+        return Promise.resolve(true);
+      }
+      return Promise.resolve(false);
+    }),
+  };
+}
+
+/** Stateful destination-address-mapping fake. */
+function makeProjectionRepo(): jest.Mocked<CustomerProjectionRepositoryPort> {
+  const store = new Map<string, DestinationAddressMapping>();
+  const key = (i: string, c: string, h: string, t: AddressType): string => `${i}|${c}|${h}|${t}`;
+  return {
+    findById: jest.fn(),
+    findByEmailHash: jest.fn(),
+    findMany: jest.fn(),
+    upsert: jest.fn(),
+    findAddressesByCustomerId: jest.fn(),
+    upsertAddress: jest.fn(),
+    findDestinationAddressMapping: jest.fn((i: string, c: string, h: string, t: AddressType) =>
+      Promise.resolve(store.get(key(i, c, h, t)) ?? null),
+    ),
+    upsertDestinationAddressMapping: jest.fn((m: DestinationAddressMapping) => {
+      store.set(key(m.internalCustomerId, m.destinationConnectionId, m.addressHash, m.addressType), m);
+      return Promise.resolve(m);
+    }),
+  } as unknown as jest.Mocked<CustomerProjectionRepositoryPort>;
+}
+
+function input(overrides: Partial<Record<string, unknown>> = {}): {
+  internalCustomerId: string;
+  wcCustomerId: number;
+  address: Address | undefined;
+  addressType: AddressType;
+  connectionId: string;
+  httpClient: jest.Mocked<IWooCommerceHttpClient>;
+  customerProjectionRepository: jest.Mocked<CustomerProjectionRepositoryPort>;
+} {
+  return {
+    internalCustomerId: INTERNAL_CUSTOMER_ID,
+    wcCustomerId: WC_CUSTOMER_ID,
+    address: ADDRESS,
+    addressType: 'billing',
+    connectionId: CONNECTION_ID,
+    httpClient: makeHttpClient(),
+    customerProjectionRepository: makeProjectionRepo(),
+    ...overrides,
+  } as never;
+}
+
+describe('WooCommerceAddressProvisioner', () => {
+  it('should skip (return null) for a guest order (wcCustomerId <= 0)', async () => {
+    const httpClient = makeHttpClient();
+    const provisioner = new WooCommerceAddressProvisioner(makeSyncLock());
+    const result = await provisioner.resolveOrCreateAddress(input({ wcCustomerId: 0, httpClient }));
+    expect(result).toBeNull();
+    expect(httpClient.get).not.toHaveBeenCalled();
+    expect(httpClient.put).not.toHaveBeenCalled();
+  });
+
+  it('should skip (return null) when there is no address', async () => {
+    const httpClient = makeHttpClient();
+    const provisioner = new WooCommerceAddressProvisioner(makeSyncLock());
+    const result = await provisioner.resolveOrCreateAddress(input({ address: undefined, httpClient }));
+    expect(result).toBeNull();
+    expect(httpClient.put).not.toHaveBeenCalled();
+  });
+
+  it('should reuse an existing mapping without any API call (reuse hit)', async () => {
+    const repo = makeProjectionRepo();
+    (repo.findDestinationAddressMapping as jest.Mock).mockResolvedValueOnce(
+      new DestinationAddressMapping(INTERNAL_CUSTOMER_ID, CONNECTION_ID, 'h', 'billing', '7', new Date(), new Date()),
+    );
+    const httpClient = makeHttpClient();
+    const provisioner = new WooCommerceAddressProvisioner(makeSyncLock());
+
+    const result = await provisioner.resolveOrCreateAddress(
+      input({ customerProjectionRepository: repo, httpClient }),
+    );
+
+    expect(result).toBe('7');
+    expect(httpClient.get).not.toHaveBeenCalled();
+    expect(httpClient.put).not.toHaveBeenCalled();
+  });
+
+  it('should write the inline address and record the mapping (reuse miss)', async () => {
+    const repo = makeProjectionRepo();
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: WC_CUSTOMER_ID }); // no billing → no hash match
+    httpClient.put.mockResolvedValue({ id: WC_CUSTOMER_ID });
+    const provisioner = new WooCommerceAddressProvisioner(makeSyncLock());
+
+    const result = await provisioner.resolveOrCreateAddress(
+      input({ customerProjectionRepository: repo, httpClient }),
+    );
+
+    expect(result).toBe(String(WC_CUSTOMER_ID));
+    expect(httpClient.put).toHaveBeenCalledWith(
+      `/wp-json/wc/v3/customers/${WC_CUSTOMER_ID}`,
+      expect.objectContaining({ billing: expect.objectContaining({ address_1: 'ul. Kwiatowa 1', country: 'PL' }) }),
+    );
+    expect(repo.upsertDestinationAddressMapping).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reuse an address already present on the WC customer without a PUT (hash-match recovery)', async () => {
+    const repo = makeProjectionRepo();
+    const httpClient = makeHttpClient();
+    // WC customer already carries the same billing address → hashes match.
+    httpClient.get.mockResolvedValue({
+      id: WC_CUSTOMER_ID,
+      billing: { address_1: 'ul. Kwiatowa 1', city: 'Warszawa', postcode: '00-001', country: 'PL' },
+    });
+    const provisioner = new WooCommerceAddressProvisioner(makeSyncLock());
+
+    const result = await provisioner.resolveOrCreateAddress(
+      input({ customerProjectionRepository: repo, httpClient }),
+    );
+
+    expect(result).toBe(String(WC_CUSTOMER_ID));
+    expect(httpClient.put).not.toHaveBeenCalled();
+    expect(repo.upsertDestinationAddressMapping).toHaveBeenCalledTimes(1);
+  });
+
+  it('should NOT write a duplicate address under concurrent provisioning (lock serializes)', async () => {
+    const repo = makeProjectionRepo();
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: WC_CUSTOMER_ID }); // no match → would PUT
+    httpClient.put.mockResolvedValue({ id: WC_CUSTOMER_ID });
+    const syncLock = makeSyncLock();
+    const provisioner = new WooCommerceAddressProvisioner(syncLock);
+
+    const [a, b] = await Promise.all([
+      provisioner.resolveOrCreateAddress(input({ customerProjectionRepository: repo, httpClient })),
+      provisioner.resolveOrCreateAddress(input({ customerProjectionRepository: repo, httpClient })),
+    ]);
+
+    expect(a).toBe(String(WC_CUSTOMER_ID));
+    expect(b).toBe(String(WC_CUSTOMER_ID));
+    // Exactly one PUT — the second caller reused the mapping recorded by the first.
+    expect(httpClient.put).toHaveBeenCalledTimes(1);
+    expect(repo.upsertDestinationAddressMapping).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-customer-provisioner.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-customer-provisioner.spec.ts
@@ -222,4 +222,36 @@ describe('WooCommerceCustomerProvisioner', () => {
     expect(httpClient.post).toHaveBeenCalledTimes(1);
     expect(port.createMapping).toHaveBeenCalledTimes(1);
   });
+
+  it('should serialize case/whitespace email variants on the same lock key (normalized)', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.post.mockResolvedValue({ id: 88 });
+    const syncLock = makeSyncLock();
+    const provisioner = new WooCommerceCustomerProvisioner(syncLock);
+
+    // Two distinct internal customers so neither takes the mapping fast path;
+    // both provision under a lock keyed off the (normalized) email.
+    await provisioner.resolveOrCreateCustomer(
+      baseInput({
+        internalCustomerId: 'ol-cust-a',
+        buyerEmail: 'Buyer@Example.com',
+        identifierMapping: makeStatefulMapping().port,
+        httpClient,
+      }),
+    );
+    await provisioner.resolveOrCreateCustomer(
+      baseInput({
+        internalCustomerId: 'ol-cust-b',
+        buyerEmail: '  buyer@example.com  ',
+        identifierMapping: makeStatefulMapping().port,
+        httpClient,
+      }),
+    );
+
+    const acquireMock = syncLock.acquire as jest.Mock<Promise<string | null>, [string, number]>;
+    expect(acquireMock).toHaveBeenCalledTimes(2);
+    const [firstKey] = acquireMock.mock.calls[0];
+    const [secondKey] = acquireMock.mock.calls[1];
+    expect(firstKey).toBe(secondKey);
+  });
 });

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-customer-provisioner.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-customer-provisioner.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * WooCommerce Customer Provisioner — unit tests
+ *
+ * Covers resolve-or-create, guest fallback, duplicate-email recovery, auth-failure
+ * propagation, concurrent-duplicate mapping handling, and a concurrency test that
+ * proves the distributed lock prevents duplicate customer creation.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__
+ */
+import { WooCommerceCustomerProvisioner } from '../woocommerce-customer-provisioner';
+import type { IWooCommerceHttpClient } from '../../http/woocommerce-http-client.interface';
+import type { IdentifierMappingPort, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
+import type { SyncLockPort } from '@openlinker/core/sync';
+import { WooCommerceHttpResponseException } from '../../http/woocommerce-http-response.exception';
+import { WooCommerceUnauthorizedException } from '../../../domain/exceptions/woocommerce-unauthorized.exception';
+import { WooCommerceAuthFailureException } from '../../../domain/exceptions/woocommerce-auth-failure.exception';
+
+const CONNECTION_ID = 'conn-wc-1';
+const INTERNAL_CUSTOMER_ID = 'ol-cust-1';
+const EMAIL = 'buyer@example.com';
+
+function makeHttpClient(): jest.Mocked<IWooCommerceHttpClient> {
+  return { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() };
+}
+
+/** In-memory SyncLockPort — single holder per key. */
+function makeSyncLock(): SyncLockPort {
+  const locks = new Map<string, string>();
+  return {
+    acquire: jest.fn((key: string) => {
+      if (locks.has(key)) return Promise.resolve(null);
+      const token = `tok-${Math.random().toString(36).slice(2)}`;
+      locks.set(key, token);
+      return Promise.resolve(token);
+    }),
+    release: jest.fn((key: string, token: string) => {
+      if (locks.get(key) === token) {
+        locks.delete(key);
+        return Promise.resolve(true);
+      }
+      return Promise.resolve(false);
+    }),
+  };
+}
+
+/** Stateful identifier-mapping fake scoped to the Customer entity on one connection. */
+function makeStatefulMapping(): {
+  port: jest.Mocked<IdentifierMappingPort>;
+  seed(internalId: string, externalId: string): void;
+} {
+  const store = new Map<string, string>(); // internalId -> externalId
+  const port = {
+    getOrCreateInternalId: jest.fn(),
+    getOrCreateExactMapping: jest.fn(),
+    getInternalId: jest.fn(),
+    getExternalIds: jest.fn((entityType: string, internalId: string) => {
+      const externalId = store.get(internalId);
+      if (entityType !== CORE_ENTITY_TYPE.Customer || externalId === undefined) {
+        return Promise.resolve([] as ExternalIdMapping[]);
+      }
+      return Promise.resolve([
+        { externalId, connectionId: CONNECTION_ID, platformType: 'woocommerce', entityType },
+      ]);
+    }),
+    createMapping: jest.fn((_entityType: string, externalId: string, _connId: string, internalId: string) => {
+      if (store.has(internalId)) {
+        return Promise.reject(
+          new DuplicateIdentifierMappingError(CORE_ENTITY_TYPE.Customer, externalId, 'woocommerce', CONNECTION_ID),
+        );
+      }
+      store.set(internalId, externalId);
+      return Promise.resolve();
+    }),
+    batchGetOrCreateInternalIds: jest.fn(),
+    deleteMapping: jest.fn(),
+    listExternalIdsByConnection: jest.fn(),
+  } as unknown as jest.Mocked<IdentifierMappingPort>;
+  return { port, seed: (internalId, externalId) => store.set(internalId, externalId) };
+}
+
+function baseInput(overrides: Record<string, unknown> = {}): {
+  internalCustomerId: string | undefined;
+  buyerEmail: string | undefined;
+  firstName: string;
+  lastName: string;
+  connectionId: string;
+  httpClient: jest.Mocked<IWooCommerceHttpClient>;
+  identifierMapping: jest.Mocked<IdentifierMappingPort>;
+} {
+  return {
+    internalCustomerId: INTERNAL_CUSTOMER_ID,
+    buyerEmail: EMAIL,
+    firstName: 'Jan',
+    lastName: 'Kowalski',
+    connectionId: CONNECTION_ID,
+    httpClient: makeHttpClient(),
+    identifierMapping: makeStatefulMapping().port,
+    ...overrides,
+  } as never;
+}
+
+describe('WooCommerceCustomerProvisioner', () => {
+  it('should return the mapped WC customer id without any API call (resolve — existing mapping)', async () => {
+    const { port, seed } = makeStatefulMapping();
+    seed(INTERNAL_CUSTOMER_ID, '7');
+    const httpClient = makeHttpClient();
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+
+    const id = await provisioner.resolveOrCreateCustomer(
+      baseInput({ identifierMapping: port, httpClient }),
+    );
+
+    expect(id).toBe(7);
+    expect(httpClient.post).not.toHaveBeenCalled();
+  });
+
+  it('should create a WC customer and record the mapping (create — no existing mapping)', async () => {
+    const { port } = makeStatefulMapping();
+    const httpClient = makeHttpClient();
+    httpClient.post.mockResolvedValue({ id: 42 });
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+
+    const id = await provisioner.resolveOrCreateCustomer(
+      baseInput({ identifierMapping: port, httpClient }),
+    );
+
+    expect(id).toBe(42);
+    expect(httpClient.post).toHaveBeenCalledWith(
+      '/wp-json/wc/v3/customers',
+      expect.objectContaining({ email: EMAIL }),
+    );
+    expect(port.createMapping).toHaveBeenCalledWith(CORE_ENTITY_TYPE.Customer, '42', CONNECTION_ID, INTERNAL_CUSTOMER_ID);
+  });
+
+  it('should return guest (0) when there is no internal customer id', async () => {
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ internalCustomerId: undefined }));
+    expect(id).toBe(0);
+  });
+
+  it('should return guest (0) when no mapping exists and no buyer email is available', async () => {
+    const httpClient = makeHttpClient();
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ buyerEmail: undefined, httpClient }));
+    expect(id).toBe(0);
+    expect(httpClient.post).not.toHaveBeenCalled();
+  });
+
+  it('should return guest (0) when the existing mapping is corrupted (non positive-integer)', async () => {
+    const { port, seed } = makeStatefulMapping();
+    seed(INTERNAL_CUSTOMER_ID, 'not-a-number');
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ identifierMapping: port }));
+    expect(id).toBe(0);
+  });
+
+  it('should recover the existing customer by email on WC duplicate-email 400', async () => {
+    const { port } = makeStatefulMapping();
+    const httpClient = makeHttpClient();
+    httpClient.post.mockRejectedValue(new WooCommerceHttpResponseException(400, 'email exists'));
+    httpClient.get.mockResolvedValue([{ id: 99, email: EMAIL }]);
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ identifierMapping: port, httpClient }));
+
+    expect(id).toBe(99);
+    expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/customers', { email: EMAIL });
+    expect(port.createMapping).toHaveBeenCalledWith(CORE_ENTITY_TYPE.Customer, '99', CONNECTION_ID, INTERNAL_CUSTOMER_ID);
+  });
+
+  it('should propagate auth failures as WooCommerceAuthFailureException (not swallowed to guest)', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.post.mockRejectedValue(new WooCommerceUnauthorizedException('401'));
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+
+    await expect(
+      provisioner.resolveOrCreateCustomer(baseInput({ httpClient })),
+    ).rejects.toBeInstanceOf(WooCommerceAuthFailureException);
+  });
+
+  it('should degrade to guest (0) on a non-auth, non-400 API error', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.post.mockRejectedValue(new WooCommerceHttpResponseException(500, 'server error'));
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ httpClient }));
+    expect(id).toBe(0);
+  });
+
+  it('should resolve the winning mapping when createMapping races (concurrent duplicate)', async () => {
+    const { port, seed } = makeStatefulMapping();
+    const httpClient = makeHttpClient();
+    httpClient.post.mockResolvedValue({ id: 55 });
+    // createMapping rejects with a duplicate, and the winner is already stored.
+    port.createMapping.mockImplementationOnce(() => {
+      seed(INTERNAL_CUSTOMER_ID, '55');
+      return Promise.reject(
+        new DuplicateIdentifierMappingError(CORE_ENTITY_TYPE.Customer, '55', 'woocommerce', CONNECTION_ID),
+      );
+    });
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ identifierMapping: port, httpClient }));
+    expect(id).toBe(55);
+  });
+
+  it('should NOT create a duplicate customer under concurrent provisioning (lock serializes)', async () => {
+    const { port } = makeStatefulMapping();
+    const httpClient = makeHttpClient();
+    httpClient.post.mockResolvedValue({ id: 77 });
+    const syncLock = makeSyncLock();
+    const provisioner = new WooCommerceCustomerProvisioner(syncLock);
+
+    const [a, b] = await Promise.all([
+      provisioner.resolveOrCreateCustomer(baseInput({ identifierMapping: port, httpClient })),
+      provisioner.resolveOrCreateCustomer(baseInput({ identifierMapping: port, httpClient })),
+    ]);
+
+    expect(a).toBe(77);
+    expect(b).toBe(77);
+    // Exactly one POST /customers — the second caller reused the mapping after the lock.
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    expect(port.createMapping).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-address-provisioner.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-address-provisioner.ts
@@ -1,0 +1,215 @@
+/**
+ * WooCommerce Address Provisioner
+ *
+ * WooCommerce has no standalone address resource — billing / shipping addresses
+ * live INLINE on the customer (and on each order). This provisioner therefore
+ * implements address REUSE, not address creation: it keys off the address hash
+ * (`address1`, `address2`, `city`, `postcode`, `countryIso2`) and the
+ * `destination_address_mappings` table so a repeat order for the same buyer +
+ * address writes the WC customer's inline address at most once. Provisioning
+ * for a given (customer, addressHash, type) is serialized with the host
+ * `SyncLockPort` (Redis) to prevent duplicate writes under concurrency.
+ *
+ * Resolution order (mirrors `PrestashopAddressProvisioner`):
+ *   1. Primary reuse: `destination_address_mappings` lookup (fast path).
+ *   2. Acquire lock, re-check mapping.
+ *   3. Recovery: read the WC customer's inline address, match by hash.
+ *   4. Otherwise write the address onto the WC customer (`PUT /customers/{id}`).
+ *   5. Record the reuse mapping (idempotent under concurrent duplicates).
+ *
+ * Guest orders (`customer_id: 0`) have no customer account to attach an address
+ * to, so provisioning is skipped and returns `null` — the order payload still
+ * carries the inline address regardless.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners
+ */
+import { Injectable, Inject } from '@nestjs/common';
+import { SYNC_LOCK_TOKEN, type SyncLockPort } from '@openlinker/core/sync';
+import type { CustomerProjectionRepositoryPort, AddressType } from '@openlinker/core/customers';
+import { DestinationAddressMapping } from '@openlinker/core/customers';
+import type { Address } from '@openlinker/core/orders';
+import { Logger } from '@openlinker/shared/logging';
+import type { IWooCommerceHttpClient } from '../http/woocommerce-http-client.interface';
+import type {
+  WooCommerceCustomerWithAddressesResponse,
+  WooCommerceCustomerAddressUpdateRequest,
+} from './woocommerce-provisioner.types';
+import {
+  acquireLockWithWait,
+  computeAddressHash,
+  computeWcAddressHash,
+  toWcCustomerAddress,
+} from './woocommerce-provisioner.helpers';
+
+export interface ResolveOrCreateAddressInput {
+  readonly internalCustomerId: string;
+  /** The resolved WC customer id. Guest (`<= 0`) short-circuits with `null`. */
+  readonly wcCustomerId: number;
+  readonly address: Address | undefined;
+  readonly addressType: AddressType;
+  readonly connectionId: string;
+  readonly httpClient: IWooCommerceHttpClient;
+  readonly customerProjectionRepository: CustomerProjectionRepositoryPort;
+}
+
+@Injectable()
+export class WooCommerceAddressProvisioner {
+  private readonly logger = new Logger(WooCommerceAddressProvisioner.name);
+
+  constructor(
+    @Inject(SYNC_LOCK_TOKEN)
+    private readonly syncLock: SyncLockPort,
+  ) {}
+
+  private lockKey(
+    connectionId: string,
+    wcCustomerId: number,
+    addressHash: string,
+    addressType: AddressType,
+  ): string {
+    return `woocommerce:address-provision:${connectionId}:${wcCustomerId}:${addressHash}:${addressType}`;
+  }
+
+  /**
+   * Resolve (reuse) or write the WC customer's inline address, returning the
+   * destination address id recorded for reuse (the WC customer id, as that is
+   * where the address lives), or `null` when provisioning is skipped (guest, or
+   * a best-effort failure that must not abort order creation).
+   */
+  async resolveOrCreateAddress(input: ResolveOrCreateAddressInput): Promise<string | null> {
+    const {
+      internalCustomerId,
+      wcCustomerId,
+      address,
+      addressType,
+      connectionId,
+      httpClient,
+      customerProjectionRepository,
+    } = input;
+
+    if (!address || wcCustomerId <= 0) return null;
+
+    const addressHash = computeAddressHash(address);
+
+    // Step 1 — primary reuse: mapping table
+    const existing = await customerProjectionRepository.findDestinationAddressMapping(
+      internalCustomerId,
+      connectionId,
+      addressHash,
+      addressType,
+    );
+    if (existing) {
+      this.logger.debug(
+        `Address reuse hit: ${internalCustomerId} → ${existing.destinationAddressId} (${addressType})`,
+      );
+      return existing.destinationAddressId;
+    }
+
+    // Step 2 — serialize under the distributed lock
+    const key = this.lockKey(connectionId, wcCustomerId, addressHash, addressType);
+    const token = await acquireLockWithWait(this.syncLock, key);
+
+    try {
+      // Step 3 — re-check the mapping under the lock
+      const postLock = await customerProjectionRepository.findDestinationAddressMapping(
+        internalCustomerId,
+        connectionId,
+        addressHash,
+        addressType,
+      );
+      if (postLock) {
+        this.logger.debug(
+          `Address reuse hit after lock: ${internalCustomerId} → ${postLock.destinationAddressId} (${addressType})`,
+        );
+        return postLock.destinationAddressId;
+      }
+
+      // Step 4 — recovery: does the WC customer already carry this address?
+      const alreadyPresent = await this.matchesExistingWcAddress(
+        wcCustomerId,
+        addressType,
+        addressHash,
+        httpClient,
+      );
+
+      // Step 5 — otherwise write the inline address onto the WC customer
+      if (!alreadyPresent) {
+        const body: WooCommerceCustomerAddressUpdateRequest =
+          addressType === 'billing'
+            ? { billing: toWcCustomerAddress(address) }
+            : { shipping: toWcCustomerAddress(address) };
+        await httpClient.put<WooCommerceCustomerWithAddressesResponse>(
+          `/wp-json/wc/v3/customers/${wcCustomerId}`,
+          body,
+        );
+        this.logger.debug(
+          `Wrote ${addressType} address onto WC customer ${wcCustomerId} (connection: ${connectionId})`,
+        );
+      }
+
+      // Step 6 — record the reuse mapping (idempotent under concurrent duplicates)
+      const destinationAddressId = String(wcCustomerId);
+      await this.recordMapping(
+        internalCustomerId,
+        connectionId,
+        addressHash,
+        addressType,
+        destinationAddressId,
+        customerProjectionRepository,
+      );
+      return destinationAddressId;
+    } finally {
+      if (token) await this.syncLock.release(key, token);
+    }
+  }
+
+  private async matchesExistingWcAddress(
+    wcCustomerId: number,
+    addressType: AddressType,
+    addressHash: string,
+    httpClient: IWooCommerceHttpClient,
+  ): Promise<boolean> {
+    try {
+      const customer = await httpClient.get<WooCommerceCustomerWithAddressesResponse>(
+        `/wp-json/wc/v3/customers/${wcCustomerId}`,
+      );
+      const wcAddress = addressType === 'billing' ? customer.billing : customer.shipping;
+      return computeWcAddressHash(wcAddress) === addressHash;
+    } catch (err) {
+      // Recovery read is best-effort — if it fails we fall through to a write.
+      this.logger.debug(
+        `Address recovery read failed for WC customer ${wcCustomerId} — will write: ${String(err)}`,
+      );
+      return false;
+    }
+  }
+
+  private async recordMapping(
+    internalCustomerId: string,
+    connectionId: string,
+    addressHash: string,
+    addressType: AddressType,
+    destinationAddressId: string,
+    customerProjectionRepository: CustomerProjectionRepositoryPort,
+  ): Promise<void> {
+    try {
+      const now = new Date();
+      await customerProjectionRepository.upsertDestinationAddressMapping(
+        new DestinationAddressMapping(
+          internalCustomerId,
+          connectionId,
+          addressHash,
+          addressType,
+          destinationAddressId,
+          now,
+          now,
+        ),
+      );
+    } catch (err) {
+      // A concurrent writer may have recorded it first — tolerate and move on.
+      this.logger.debug(
+        `Address mapping upsert raced for ${internalCustomerId} (${addressType}): ${String(err)}`,
+      );
+    }
+  }
+}

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-address-provisioner.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-address-provisioner.ts
@@ -27,12 +27,12 @@ import { Injectable, Inject } from '@nestjs/common';
 import { SYNC_LOCK_TOKEN, type SyncLockPort } from '@openlinker/core/sync';
 import type { CustomerProjectionRepositoryPort, AddressType } from '@openlinker/core/customers';
 import { DestinationAddressMapping } from '@openlinker/core/customers';
-import type { Address } from '@openlinker/core/orders';
 import { Logger } from '@openlinker/shared/logging';
 import type { IWooCommerceHttpClient } from '../http/woocommerce-http-client.interface';
 import type {
   WooCommerceCustomerWithAddressesResponse,
   WooCommerceCustomerAddressUpdateRequest,
+  ResolveOrCreateAddressInput,
 } from './woocommerce-provisioner.types';
 import {
   acquireLockWithWait,
@@ -40,17 +40,6 @@ import {
   computeWcAddressHash,
   toWcCustomerAddress,
 } from './woocommerce-provisioner.helpers';
-
-export interface ResolveOrCreateAddressInput {
-  readonly internalCustomerId: string;
-  /** The resolved WC customer id. Guest (`<= 0`) short-circuits with `null`. */
-  readonly wcCustomerId: number;
-  readonly address: Address | undefined;
-  readonly addressType: AddressType;
-  readonly connectionId: string;
-  readonly httpClient: IWooCommerceHttpClient;
-  readonly customerProjectionRepository: CustomerProjectionRepositoryPort;
-}
 
 @Injectable()
 export class WooCommerceAddressProvisioner {
@@ -108,6 +97,17 @@ export class WooCommerceAddressProvisioner {
     // Step 2 — serialize under the distributed lock
     const key = this.lockKey(connectionId, wcCustomerId, addressHash, addressType);
     const token = await acquireLockWithWait(this.syncLock, key);
+    if (!token) {
+      // The lock could not be acquired within the wait budget (e.g. a Redis
+      // outage or heavy contention). Proceeding UNSERIALIZED is safe here —
+      // unlike PrestaShop, which throws — because writing the inline address is
+      // an idempotent `PUT /customers/{id}` (a racing writer sets the same
+      // fields) and the reuse mapping upsert tolerates a concurrent duplicate.
+      // We log the degradation so a defeated lock stays observable.
+      this.logger.warn(
+        `resolveOrCreateAddress: could not acquire provisioning lock for customer ${internalCustomerId} (${addressType}) within budget — proceeding unserialized (idempotent PUT keeps this safe)`,
+      );
+    }
 
     try {
       // Step 3 — re-check the mapping under the lock

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-customer-provisioner.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-customer-provisioner.ts
@@ -1,0 +1,241 @@
+/**
+ * WooCommerce Customer Provisioner
+ *
+ * Resolve-or-create a WooCommerce customer for an internal OL customer, with a
+ * distributed lock (host `SyncLockPort`, Redis-backed) that serializes
+ * concurrent provisioning for the same buyer so simultaneous orders don't
+ * create duplicate customers. Mirrors `PrestashopCustomerProvisioner`, adapted
+ * to WooCommerce's REST `GET/POST /customers` model.
+ *
+ * Resolution order:
+ *   1. Existing external↔internal mapping (fast path).
+ *   2. Acquire lock, re-check mapping.
+ *   3. Create WC customer (`POST /customers`); on WC's duplicate-email 400,
+ *      look the existing account up by email (`GET /customers?email=`).
+ *   4. Record the identifier mapping (with concurrent-duplicate handling).
+ *
+ * Degrades to guest (customer id `0`) when creation is impossible (no internal
+ * customer, no buyer email, corrupted mapping, or a non-auth API error). Auth
+ * failures (401/403) are NOT swallowed — they propagate as
+ * `WooCommerceAuthFailureException` so the connection can be flagged for
+ * re-authentication (#877 I1).
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners
+ */
+import { Injectable, Inject } from '@nestjs/common';
+import type { IdentifierMappingPort, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
+import { SYNC_LOCK_TOKEN, type SyncLockPort } from '@openlinker/core/sync';
+import { Logger } from '@openlinker/shared/logging';
+import type { IWooCommerceHttpClient } from '../http/woocommerce-http-client.interface';
+import { WooCommerceHttpResponseException } from '../http/woocommerce-http-response.exception';
+import { WooCommerceUnauthorizedException } from '../../domain/exceptions/woocommerce-unauthorized.exception';
+import { WooCommerceAuthFailureException } from '../../domain/exceptions/woocommerce-auth-failure.exception';
+import type {
+  WooCommerceCustomerCreateRequest,
+  WooCommerceCustomerResponse,
+} from '../adapters/order-processor/woocommerce-order.types';
+import { acquireLockWithWait, lockKeyToken } from './woocommerce-provisioner.helpers';
+
+/** The WooCommerce guest sentinel — orders with `customer_id: 0` are guest orders. */
+const WC_GUEST_CUSTOMER_ID = 0;
+
+export interface ResolveOrCreateCustomerInput {
+  /** Internal OL customer id (undefined for a guest source order). */
+  readonly internalCustomerId: string | undefined;
+  /** Validated buyer email (undefined when unavailable — forces guest). */
+  readonly buyerEmail: string | undefined;
+  readonly firstName: string;
+  readonly lastName: string;
+  readonly connectionId: string;
+  readonly httpClient: IWooCommerceHttpClient;
+  readonly identifierMapping: IdentifierMappingPort;
+}
+
+@Injectable()
+export class WooCommerceCustomerProvisioner {
+  private readonly logger = new Logger(WooCommerceCustomerProvisioner.name);
+
+  constructor(
+    @Inject(SYNC_LOCK_TOKEN)
+    private readonly syncLock: SyncLockPort,
+  ) {}
+
+  private lockKey(connectionId: string, emailHash: string): string {
+    return `woocommerce:customer-provision:${connectionId}:${emailHash}`;
+  }
+
+  /**
+   * Find the WC customer id mapped to this internal customer on this connection.
+   * Returns a positive integer id, `0` when the mapping is corrupted (non
+   * positive-integer external id), or `null` when there is no mapping.
+   */
+  private async findMappedCustomerId(
+    internalCustomerId: string,
+    connectionId: string,
+    identifierMapping: IdentifierMappingPort,
+  ): Promise<number | null> {
+    const externalIds = await identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.Customer,
+      internalCustomerId,
+    );
+    const mapping = externalIds.find((e: ExternalIdMapping) => e.connectionId === connectionId);
+    if (!mapping) return null;
+    const n = Number(mapping.externalId);
+    if (!Number.isInteger(n) || n <= 0) {
+      this.logger.warn(
+        `resolveOrCreateCustomer: corrupted mapping "${mapping.externalId}" for customer ${internalCustomerId} — guest order`,
+      );
+      return WC_GUEST_CUSTOMER_ID;
+    }
+    return n;
+  }
+
+  async resolveOrCreateCustomer(input: ResolveOrCreateCustomerInput): Promise<number> {
+    const {
+      internalCustomerId,
+      buyerEmail,
+      firstName,
+      lastName,
+      connectionId,
+      httpClient,
+      identifierMapping,
+    } = input;
+
+    if (!internalCustomerId) return WC_GUEST_CUSTOMER_ID;
+
+    // Step 1 — existing mapping (fast path)
+    const mapped = await this.findMappedCustomerId(internalCustomerId, connectionId, identifierMapping);
+    if (mapped !== null) return mapped;
+
+    // Step 2 — no mapping; provisioning needs an email
+    if (!buyerEmail) {
+      this.logger.warn(
+        `resolveOrCreateCustomer: no WC mapping and no buyerEmail for customer ${internalCustomerId} — guest order`,
+      );
+      return WC_GUEST_CUSTOMER_ID;
+    }
+
+    // Step 3 — serialize provisioning for this buyer under a distributed lock
+    const key = this.lockKey(connectionId, lockKeyToken(buyerEmail));
+    const token = await acquireLockWithWait(this.syncLock, key);
+
+    try {
+      // Step 4 — re-check the mapping now that we hold (or waited for) the lock
+      const postLock = await this.findMappedCustomerId(
+        internalCustomerId,
+        connectionId,
+        identifierMapping,
+      );
+      if (postLock !== null) return postLock;
+
+      // Step 5 — create the WC customer (or recover an existing one by email)
+      const wcCustomerId = await this.createOrRecoverCustomer(
+        internalCustomerId,
+        buyerEmail,
+        firstName,
+        lastName,
+        connectionId,
+        httpClient,
+      );
+      if (wcCustomerId <= 0) return WC_GUEST_CUSTOMER_ID;
+
+      // Step 6 — record the mapping (idempotent under concurrent duplicates)
+      return await this.recordMapping(
+        internalCustomerId,
+        wcCustomerId,
+        connectionId,
+        identifierMapping,
+      );
+    } finally {
+      if (token) await this.syncLock.release(key, token);
+    }
+  }
+
+  private async createOrRecoverCustomer(
+    internalCustomerId: string,
+    buyerEmail: string,
+    firstName: string,
+    lastName: string,
+    connectionId: string,
+    httpClient: IWooCommerceHttpClient,
+  ): Promise<number> {
+    try {
+      const created = await httpClient.post<WooCommerceCustomerResponse>(
+        '/wp-json/wc/v3/customers',
+        {
+          email: buyerEmail,
+          first_name: firstName,
+          last_name: lastName,
+        } satisfies WooCommerceCustomerCreateRequest,
+      );
+      if (!created.id) {
+        this.logger.warn(
+          `resolveOrCreateCustomer: WC customer POST returned no id for ${internalCustomerId} — guest order`,
+        );
+        return WC_GUEST_CUSTOMER_ID;
+      }
+      return created.id;
+    } catch (err) {
+      // Auth failures must propagate — invalid credentials require re-auth.
+      if (err instanceof WooCommerceUnauthorizedException) {
+        throw new WooCommerceAuthFailureException(
+          `WooCommerce auth failure provisioning customer ${internalCustomerId} on connection ${connectionId}: ${String(err)}`,
+          connectionId,
+        );
+      }
+      // WC returns 400 (code 'registration-error-email-exists') for a duplicate
+      // email — look the existing account up by email.
+      if (err instanceof WooCommerceHttpResponseException && err.statusCode === 400) {
+        const existing = await httpClient.get<WooCommerceCustomerResponse[]>(
+          '/wp-json/wc/v3/customers',
+          { email: buyerEmail },
+        );
+        const match = existing.find((c) => c.email === buyerEmail);
+        if (!match?.id) {
+          this.logger.warn(
+            `resolveOrCreateCustomer: duplicate email ${buyerEmail} but no matching WC customer — guest order`,
+          );
+          return WC_GUEST_CUSTOMER_ID;
+        }
+        return match.id;
+      }
+      // Non-auth, non-400 (network, rate-limit, server) — degrade to guest.
+      this.logger.warn(
+        `resolveOrCreateCustomer: WC customer API error for ${internalCustomerId} — guest order: ${String(err)}`,
+      );
+      return WC_GUEST_CUSTOMER_ID;
+    }
+  }
+
+  private async recordMapping(
+    internalCustomerId: string,
+    wcCustomerId: number,
+    connectionId: string,
+    identifierMapping: IdentifierMappingPort,
+  ): Promise<number> {
+    try {
+      await identifierMapping.createMapping(
+        CORE_ENTITY_TYPE.Customer,
+        String(wcCustomerId),
+        connectionId,
+        internalCustomerId,
+      );
+    } catch (err) {
+      if (err instanceof DuplicateIdentifierMappingError) {
+        const winner = await this.findMappedCustomerId(
+          internalCustomerId,
+          connectionId,
+          identifierMapping,
+        );
+        if (winner !== null && winner > 0) return winner;
+        this.logger.warn(
+          `resolveOrCreateCustomer: concurrent duplicate but no winner for ${internalCustomerId} — guest order`,
+        );
+        return WC_GUEST_CUSTOMER_ID;
+      }
+      throw err;
+    }
+    return wcCustomerId;
+  }
+}

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-customer-provisioner.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-customer-provisioner.ts
@@ -36,21 +36,10 @@ import type {
   WooCommerceCustomerResponse,
 } from '../adapters/order-processor/woocommerce-order.types';
 import { acquireLockWithWait, lockKeyToken } from './woocommerce-provisioner.helpers';
+import type { ResolveOrCreateCustomerInput } from './woocommerce-provisioner.types';
 
 /** The WooCommerce guest sentinel — orders with `customer_id: 0` are guest orders. */
 const WC_GUEST_CUSTOMER_ID = 0;
-
-export interface ResolveOrCreateCustomerInput {
-  /** Internal OL customer id (undefined for a guest source order). */
-  readonly internalCustomerId: string | undefined;
-  /** Validated buyer email (undefined when unavailable — forces guest). */
-  readonly buyerEmail: string | undefined;
-  readonly firstName: string;
-  readonly lastName: string;
-  readonly connectionId: string;
-  readonly httpClient: IWooCommerceHttpClient;
-  readonly identifierMapping: IdentifierMappingPort;
-}
 
 @Injectable()
 export class WooCommerceCustomerProvisioner {
@@ -116,9 +105,23 @@ export class WooCommerceCustomerProvisioner {
       return WC_GUEST_CUSTOMER_ID;
     }
 
-    // Step 3 — serialize provisioning for this buyer under a distributed lock
-    const key = this.lockKey(connectionId, lockKeyToken(buyerEmail));
+    // Step 3 — serialize provisioning for this buyer under a distributed lock.
+    // Normalize the email (trim + lowercase) before hashing so case/whitespace
+    // variants of the same address serialize against the same lock key.
+    const key = this.lockKey(connectionId, lockKeyToken(buyerEmail.trim().toLowerCase()));
     const token = await acquireLockWithWait(this.syncLock, key);
+    if (!token) {
+      // The lock could not be acquired within the wait budget (e.g. a Redis
+      // outage or heavy contention). Proceeding UNSERIALIZED is safe here —
+      // unlike PrestaShop, which throws — because the WC customer path is
+      // backstopped by WC's email-uniqueness constraint + the duplicate-email
+      // 400 recovery below, so a racing writer converges on one account rather
+      // than creating a duplicate. We log the degradation so a defeated lock
+      // (which is otherwise invisible) stays observable.
+      this.logger.warn(
+        `resolveOrCreateCustomer: could not acquire provisioning lock for customer ${internalCustomerId} within budget — proceeding unserialized (WC email-uniqueness + 400 recovery keep this safe)`,
+      );
+    }
 
     try {
       // Step 4 — re-check the mapping now that we hold (or waited for) the lock

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.helpers.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.helpers.ts
@@ -2,9 +2,9 @@
  * WooCommerce Provisioner Helpers
  *
  * Pure helpers shared by the WooCommerce customer + address provisioners:
- * country / currency normalization (WooCommerce's model is flat — there is no
- * separate resolver layer, so these live alongside the provisioners), address
- * hashing, OL-Address → WC-address mapping, and a bounded-wait distributed-lock
+ * country normalization (WooCommerce's model is flat — there is no separate
+ * resolver layer, so this lives alongside the provisioners), address hashing,
+ * OL-Address → WC-address mapping, and a bounded-wait distributed-lock
  * acquisition built on the host `SyncLockPort`.
  *
  * @module libs/integrations/woocommerce/src/infrastructure/provisioners
@@ -14,7 +14,7 @@ import type { SyncLockPort, SyncLockToken } from '@openlinker/core/sync';
 import type { Address } from '@openlinker/core/orders';
 import type { NormalizedAddress } from '@openlinker/shared/config';
 import { hashAddress } from '@openlinker/shared/config';
-import type { WooCommerceCustomerAddress } from './woocommerce-provisioner.types';
+import type { WooCommerceOrderAddress } from '../adapters/order-processor/woocommerce-order.types';
 
 /** Lock TTL in milliseconds — 30 s is ample for the WC customer API round-trips. */
 export const PROVISIONER_LOCK_TTL_MS = 30_000;
@@ -44,13 +44,6 @@ export function normalizeCountryCode(country: string | null | undefined): string
 }
 
 /**
- * Normalize a currency code to an upper-case ISO-4217 value.
- */
-export function normalizeCurrencyCode(currency: string | null | undefined): string {
-  return (currency ?? '').trim().toUpperCase();
-}
-
-/**
  * Compute the address-reuse hash for an OL order address. Mirrors the component
  * set used across the platform (`address1`, `address2`, `city`, `postcode`,
  * `countryIso2`), with the country normalized so a reuse lookup matches the
@@ -72,7 +65,7 @@ export function computeAddressHash(address: Address): string {
  * the mapping table has no row but the WC customer already carries a matching
  * address). Returns null when the WC address lacks the fields needed to hash.
  */
-export function computeWcAddressHash(address: WooCommerceCustomerAddress | undefined): string | null {
+export function computeWcAddressHash(address: WooCommerceOrderAddress | undefined): string | null {
   if (!address || !address.address_1 || !address.city || !address.postcode) {
     return null;
   }
@@ -90,10 +83,17 @@ export function computeWcAddressHash(address: WooCommerceCustomerAddress | undef
  * Map an OL Address to a WooCommerce inline customer address, omitting nullish
  * fields (WC REST rejects `null` on string-typed address properties) and
  * normalizing the country code.
+ *
+ * Shares the `WooCommerceOrderAddress` wire type with the order-processor
+ * adapter's private `mapAddress`, but stays a separate function on purpose: it
+ * normalizes `country` (upper-case ISO2) so the value written to the WC customer
+ * matches the value fed into the reuse hash (`computeAddressHash`). The adapter's
+ * `mapAddress` deliberately passes `country` through verbatim for the order
+ * payload, so the two are not interchangeable.
  */
-export function toWcCustomerAddress(address: Address): WooCommerceCustomerAddress {
-  const mapped: WooCommerceCustomerAddress = {};
-  const assign = (key: keyof WooCommerceCustomerAddress, value: string | null | undefined): void => {
+export function toWcCustomerAddress(address: Address): WooCommerceOrderAddress {
+  const mapped: WooCommerceOrderAddress = {};
+  const assign = (key: keyof WooCommerceOrderAddress, value: string | null | undefined): void => {
     if (value !== null && value !== undefined) mapped[key] = value;
   };
   assign('first_name', address.firstName);

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.helpers.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.helpers.ts
@@ -1,0 +1,137 @@
+/**
+ * WooCommerce Provisioner Helpers
+ *
+ * Pure helpers shared by the WooCommerce customer + address provisioners:
+ * country / currency normalization (WooCommerce's model is flat — there is no
+ * separate resolver layer, so these live alongside the provisioners), address
+ * hashing, OL-Address → WC-address mapping, and a bounded-wait distributed-lock
+ * acquisition built on the host `SyncLockPort`.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners
+ */
+import { createHash } from 'crypto';
+import type { SyncLockPort, SyncLockToken } from '@openlinker/core/sync';
+import type { Address } from '@openlinker/core/orders';
+import type { NormalizedAddress } from '@openlinker/shared/config';
+import { hashAddress } from '@openlinker/shared/config';
+import type { WooCommerceCustomerAddress } from './woocommerce-provisioner.types';
+
+/** Lock TTL in milliseconds — 30 s is ample for the WC customer API round-trips. */
+export const PROVISIONER_LOCK_TTL_MS = 30_000;
+
+/** Default bounded-wait parameters for lock acquisition. */
+const DEFAULT_MAX_ACQUIRE_ATTEMPTS = 20;
+const DEFAULT_ACQUIRE_DELAY_MS = 100;
+
+/**
+ * Derive a stable, non-reversible token from a value for use inside a Redis
+ * lock key — keeps raw PII (e.g. buyer email) out of the key space. This is a
+ * plain SHA-256, deliberately independent of the org-level PII salt (a lock key
+ * is ephemeral and never persisted), so it works in any runtime without PII
+ * config wiring.
+ */
+export function lockKeyToken(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+/**
+ * Normalize a country code to an upper-case ISO-3166 alpha-2 value. WooCommerce
+ * expects upper-case ISO2 in address `country`; normalizing here keeps the value
+ * we hash for reuse consistent with the value we write.
+ */
+export function normalizeCountryCode(country: string | null | undefined): string {
+  return (country ?? '').trim().toUpperCase();
+}
+
+/**
+ * Normalize a currency code to an upper-case ISO-4217 value.
+ */
+export function normalizeCurrencyCode(currency: string | null | undefined): string {
+  return (currency ?? '').trim().toUpperCase();
+}
+
+/**
+ * Compute the address-reuse hash for an OL order address. Mirrors the component
+ * set used across the platform (`address1`, `address2`, `city`, `postcode`,
+ * `countryIso2`), with the country normalized so a reuse lookup matches the
+ * value written to WooCommerce.
+ */
+export function computeAddressHash(address: Address): string {
+  const normalized: NormalizedAddress = {
+    address1: address.address1,
+    address2: address.address2,
+    city: address.city,
+    postcode: address.postalCode,
+    countryIso2: normalizeCountryCode(address.country),
+  };
+  return hashAddress(normalized);
+}
+
+/**
+ * Compute the reuse hash of a WooCommerce inline address (recovery path — when
+ * the mapping table has no row but the WC customer already carries a matching
+ * address). Returns null when the WC address lacks the fields needed to hash.
+ */
+export function computeWcAddressHash(address: WooCommerceCustomerAddress | undefined): string | null {
+  if (!address || !address.address_1 || !address.city || !address.postcode) {
+    return null;
+  }
+  const normalized: NormalizedAddress = {
+    address1: address.address_1,
+    address2: address.address_2,
+    city: address.city,
+    postcode: address.postcode,
+    countryIso2: normalizeCountryCode(address.country),
+  };
+  return hashAddress(normalized);
+}
+
+/**
+ * Map an OL Address to a WooCommerce inline customer address, omitting nullish
+ * fields (WC REST rejects `null` on string-typed address properties) and
+ * normalizing the country code.
+ */
+export function toWcCustomerAddress(address: Address): WooCommerceCustomerAddress {
+  const mapped: WooCommerceCustomerAddress = {};
+  const assign = (key: keyof WooCommerceCustomerAddress, value: string | null | undefined): void => {
+    if (value !== null && value !== undefined) mapped[key] = value;
+  };
+  assign('first_name', address.firstName);
+  assign('last_name', address.lastName);
+  assign('company', address.company);
+  assign('address_1', address.address1);
+  assign('address_2', address.address2);
+  assign('city', address.city);
+  assign('state', address.state);
+  assign('postcode', address.postalCode);
+  assign('country', normalizeCountryCode(address.country));
+  assign('phone', address.phone);
+  return mapped;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Acquire a distributed lock with a bounded wait. Retries `acquire` until it
+ * succeeds or the attempt budget is exhausted, so a second caller for the same
+ * key serializes behind the first holder rather than racing it.
+ *
+ * @returns the lock token on success, or `null` if the lock could not be
+ *   acquired within the budget (caller must re-check state and degrade safely).
+ */
+export async function acquireLockWithWait(
+  syncLock: SyncLockPort,
+  key: string,
+  ttlMs: number = PROVISIONER_LOCK_TTL_MS,
+  maxAttempts: number = DEFAULT_MAX_ACQUIRE_ATTEMPTS,
+  delayMs: number = DEFAULT_ACQUIRE_DELAY_MS,
+): Promise<SyncLockToken | null> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const token = await syncLock.acquire(key, ttlMs);
+    if (token) return token;
+    await sleep(delayMs);
+  }
+  return null;
+}

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.types.ts
@@ -1,0 +1,52 @@
+/**
+ * WooCommerce Provisioner Types
+ *
+ * Wire shapes for the WooCommerce customer + address provisioners. WooCommerce
+ * stores billing / shipping addresses INLINE on the customer resource (no
+ * standalone address entity), so the "address" shapes here are the nested
+ * `billing` / `shipping` objects of a WC customer, and the update request is a
+ * partial customer PUT carrying one or both of them.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners
+ */
+
+/**
+ * A WooCommerce customer billing / shipping address object. All fields are
+ * optional because a source order may omit them; nullish fields are OMITTED
+ * from the wire payload (WC REST type-checks address properties as strings).
+ */
+export interface WooCommerceCustomerAddress {
+  first_name?: string;
+  last_name?: string;
+  company?: string;
+  address_1?: string;
+  address_2?: string;
+  city?: string;
+  state?: string;
+  postcode?: string;
+  country?: string;
+  phone?: string;
+  email?: string;
+}
+
+/**
+ * A WooCommerce customer resource as returned by `GET /customers/{id}`,
+ * including its inline billing / shipping addresses (used by the address
+ * provisioner's hash-match recovery path).
+ */
+export interface WooCommerceCustomerWithAddressesResponse {
+  id?: number;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  billing?: WooCommerceCustomerAddress;
+  shipping?: WooCommerceCustomerAddress;
+}
+
+/**
+ * Partial customer PUT body carrying one or both inline addresses.
+ */
+export interface WooCommerceCustomerAddressUpdateRequest {
+  billing?: WooCommerceCustomerAddress;
+  shipping?: WooCommerceCustomerAddress;
+}

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.types.ts
@@ -1,33 +1,20 @@
 /**
  * WooCommerce Provisioner Types
  *
- * Wire shapes for the WooCommerce customer + address provisioners. WooCommerce
- * stores billing / shipping addresses INLINE on the customer resource (no
- * standalone address entity), so the "address" shapes here are the nested
- * `billing` / `shipping` objects of a WC customer, and the update request is a
- * partial customer PUT carrying one or both of them.
+ * Wire shapes and method-input contracts for the WooCommerce customer + address
+ * provisioners. WooCommerce stores billing / shipping addresses INLINE on the
+ * customer resource (no standalone address entity), so the "address" shapes here
+ * reuse the adapter's `WooCommerceOrderAddress` (the same nested billing /
+ * shipping object), and the update request is a partial customer PUT carrying
+ * one or both of them.
  *
  * @module libs/integrations/woocommerce/src/infrastructure/provisioners
  */
-
-/**
- * A WooCommerce customer billing / shipping address object. All fields are
- * optional because a source order may omit them; nullish fields are OMITTED
- * from the wire payload (WC REST type-checks address properties as strings).
- */
-export interface WooCommerceCustomerAddress {
-  first_name?: string;
-  last_name?: string;
-  company?: string;
-  address_1?: string;
-  address_2?: string;
-  city?: string;
-  state?: string;
-  postcode?: string;
-  country?: string;
-  phone?: string;
-  email?: string;
-}
+import type { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import type { Address } from '@openlinker/core/orders';
+import type { AddressType, CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
+import type { WooCommerceOrderAddress } from '../adapters/order-processor/woocommerce-order.types';
+import type { IWooCommerceHttpClient } from '../http/woocommerce-http-client.interface';
 
 /**
  * A WooCommerce customer resource as returned by `GET /customers/{id}`,
@@ -39,14 +26,43 @@ export interface WooCommerceCustomerWithAddressesResponse {
   email?: string;
   first_name?: string;
   last_name?: string;
-  billing?: WooCommerceCustomerAddress;
-  shipping?: WooCommerceCustomerAddress;
+  billing?: WooCommerceOrderAddress;
+  shipping?: WooCommerceOrderAddress;
 }
 
 /**
  * Partial customer PUT body carrying one or both inline addresses.
  */
 export interface WooCommerceCustomerAddressUpdateRequest {
-  billing?: WooCommerceCustomerAddress;
-  shipping?: WooCommerceCustomerAddress;
+  billing?: WooCommerceOrderAddress;
+  shipping?: WooCommerceOrderAddress;
+}
+
+/**
+ * Input for {@link WooCommerceCustomerProvisioner.resolveOrCreateCustomer}.
+ */
+export interface ResolveOrCreateCustomerInput {
+  /** Internal OL customer id (undefined for a guest source order). */
+  readonly internalCustomerId: string | undefined;
+  /** Validated buyer email (undefined when unavailable — forces guest). */
+  readonly buyerEmail: string | undefined;
+  readonly firstName: string;
+  readonly lastName: string;
+  readonly connectionId: string;
+  readonly httpClient: IWooCommerceHttpClient;
+  readonly identifierMapping: IdentifierMappingPort;
+}
+
+/**
+ * Input for {@link WooCommerceAddressProvisioner.resolveOrCreateAddress}.
+ */
+export interface ResolveOrCreateAddressInput {
+  readonly internalCustomerId: string;
+  /** The resolved WC customer id. Guest (`<= 0`) short-circuits with `null`. */
+  readonly wcCustomerId: number;
+  readonly address: Address | undefined;
+  readonly addressType: AddressType;
+  readonly connectionId: string;
+  readonly httpClient: IWooCommerceHttpClient;
+  readonly customerProjectionRepository: CustomerProjectionRepositoryPort;
 }

--- a/libs/integrations/woocommerce/src/woocommerce-integration.module.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-integration.module.ts
@@ -1,22 +1,173 @@
 /**
  * WooCommerce Integration Module
  *
- * Host wiring for the WooCommerce REST API v3 plugin. WooCommerce has no
- * plugin-specific NestJS providers (no TypeORM repository, no token-refresh
- * service), so it uses the SDK's `createNestAdapterModule` directly: the
- * helper imports the integrations/sync/identifier-mapping modules, builds
- * the `HostServices` bag from DI, registers the manifest + factory, and
- * calls `plugin.register(host)` for the connection tester and validators.
+ * NestJS host wrapper for the WooCommerce plugin descriptor
+ * (`createWooCommercePlugin`). WooCommerce's customer + address provisioners
+ * (#1552) depend on the host `SyncLockPort` and `CustomerProjectionRepositoryPort`,
+ * which are NOT part of the curated `HostServices` bag — so the plugin can no
+ * longer be wired with the bare `createNestAdapterModule` helper. This module
+ * mirrors the PrestaShop pattern (Shape A, #593): it provides the provisioners,
+ * builds the descriptor with those plugin-specific deps in `onModuleInit`,
+ * assembles a `HostServices` bag from injected host fields, and routes manifest
+ * + factory + side registrations through the descriptor.
  *
- * Added to `apps/api/src/plugins.ts` and `apps/worker/src/plugins.ts` as
- * the single edit point that enables the plugin in both hosts.
+ * Added to `apps/api/src/plugins.ts` and `apps/worker/src/plugins.ts` as the
+ * single edit point that enables the plugin in both hosts.
  *
  * @module libs/integrations/woocommerce/src
  */
-import type { DynamicModule } from '@nestjs/common';
-import { createNestAdapterModule } from '@openlinker/plugin-sdk';
+import type { OnModuleInit } from '@nestjs/common';
+import { Module, Inject } from '@nestjs/common';
+import {
+  IdentifierMappingModule,
+  IDENTIFIER_MAPPING_PORT_TOKEN,
+  IdentifierMappingPort,
+  type Connection,
+} from '@openlinker/core/identifier-mapping';
+import type { AdapterFactoryPort } from '@openlinker/core/integrations';
+import {
+  IntegrationsModule,
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  AdapterFactoryResolverService,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterRegistryPort,
+  CONNECTION_TESTER_REGISTRY_TOKEN,
+  ConnectionTesterRegistryService,
+  EMAIL_NORMALIZER_REGISTRY_TOKEN,
+  EmailNormalizerRegistryService,
+  WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
+  WebhookProvisioningRegistryService,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  WebhookEventTranslatorRegistryService,
+  INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
+  InboundWebhookDecoderRegistryService,
+  CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  ConnectionConfigShapeValidatorRegistryService,
+  CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  ConnectionCredentialsShapeValidatorRegistryService,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+  ConnectionCredentialsRewriterRegistryService,
+  INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
+  OAuthCompletionRegistryService,
+  CREDENTIALS_RESOLVER_TOKEN,
+  CredentialsResolverPort,
+} from '@openlinker/core/integrations';
+import {
+  SyncModule,
+  RETRY_CLASSIFIER_REGISTRY_TOKEN,
+  RetryClassifierRegistryService,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+  AuthFailureClassifierRegistryService,
+  SCHEDULER_TASK_REGISTRY_TOKEN,
+  SchedulerTaskRegistryService,
+} from '@openlinker/core/sync';
+import {
+  CustomersModule,
+  CUSTOMER_PROJECTION_REPOSITORY_TOKEN,
+  CustomerProjectionRepositoryPort,
+} from '@openlinker/core/customers';
+import { Logger } from '@openlinker/shared/logging';
+import { CACHE_PORT_TOKEN, type CachePort } from '@openlinker/shared';
+import type { HostServices } from '@openlinker/plugin-sdk';
+import { WooCommerceCustomerProvisioner } from './infrastructure/provisioners/woocommerce-customer-provisioner';
+import { WooCommerceAddressProvisioner } from './infrastructure/provisioners/woocommerce-address-provisioner';
 import { createWooCommercePlugin } from './woocommerce-plugin';
 
-export const WooCommerceIntegrationModule: DynamicModule = createNestAdapterModule({
-  plugin: createWooCommercePlugin(),
-});
+@Module({
+  imports: [IntegrationsModule, SyncModule, IdentifierMappingModule, CustomersModule],
+  providers: [WooCommerceCustomerProvisioner, WooCommerceAddressProvisioner],
+})
+export class WooCommerceIntegrationModule implements OnModuleInit {
+  private readonly logger = new Logger(WooCommerceIntegrationModule.name);
+
+  constructor(
+    @Inject(ADAPTER_REGISTRY_TOKEN)
+    private readonly adapterRegistry: AdapterRegistryPort,
+    @Inject(ADAPTER_FACTORY_RESOLVER_TOKEN)
+    private readonly factoryResolver: AdapterFactoryResolverService,
+    @Inject(CONNECTION_TESTER_REGISTRY_TOKEN)
+    private readonly connectionTesterRegistry: ConnectionTesterRegistryService,
+    @Inject(EMAIL_NORMALIZER_REGISTRY_TOKEN)
+    private readonly emailNormalizerRegistry: EmailNormalizerRegistryService,
+    @Inject(WEBHOOK_PROVISIONING_REGISTRY_TOKEN)
+    private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
+    @Inject(WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN)
+    private readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService,
+    @Inject(INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN)
+    private readonly inboundWebhookDecoderRegistry: InboundWebhookDecoderRegistryService,
+    @Inject(CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN)
+    private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
+    @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
+    private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
+    @Inject(CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN)
+    private readonly connectionCredentialsRewriterRegistry: ConnectionCredentialsRewriterRegistryService,
+    @Inject(INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN)
+    private readonly oauthCompletionRegistry: OAuthCompletionRegistryService,
+    @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly retryClassifierRegistry: RetryClassifierRegistryService,
+    @Inject(AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly authFailureClassifierRegistry: AuthFailureClassifierRegistryService,
+    @Inject(SCHEDULER_TASK_REGISTRY_TOKEN)
+    private readonly schedulerTaskRegistry: SchedulerTaskRegistryService,
+    @Inject(IDENTIFIER_MAPPING_PORT_TOKEN)
+    private readonly identifierMapping: IdentifierMappingPort,
+    @Inject(CREDENTIALS_RESOLVER_TOKEN)
+    private readonly credentialsResolver: CredentialsResolverPort,
+    private readonly customerProvisioner: WooCommerceCustomerProvisioner,
+    private readonly addressProvisioner: WooCommerceAddressProvisioner,
+    @Inject(CUSTOMER_PROJECTION_REPOSITORY_TOKEN)
+    private readonly customerProjectionRepository: CustomerProjectionRepositoryPort,
+    @Inject(CACHE_PORT_TOKEN)
+    private readonly cache?: CachePort,
+  ) {}
+
+  onModuleInit(): void {
+    this.logger.log('Registering WooCommerce plugin (manifest + factory + side registries)...');
+
+    const plugin = createWooCommercePlugin({
+      customerProvisioner: this.customerProvisioner,
+      addressProvisioner: this.addressProvisioner,
+      customerProjectionRepository: this.customerProjectionRepository,
+    });
+
+    const host: HostServices = {
+      logger: (context: string) => new Logger(context),
+      identifierMapping: this.identifierMapping,
+      credentialsResolver: this.credentialsResolver,
+      cache: this.cache,
+      adapterRegistry: this.adapterRegistry,
+      factoryResolver: this.factoryResolver,
+      connectionTesterRegistry: this.connectionTesterRegistry,
+      emailNormalizerRegistry: this.emailNormalizerRegistry,
+      retryClassifierRegistry: this.retryClassifierRegistry,
+      authFailureClassifierRegistry: this.authFailureClassifierRegistry,
+      schedulerTaskRegistry: this.schedulerTaskRegistry,
+      webhookProvisioningRegistry: this.webhookProvisioningRegistry,
+      webhookEventTranslatorRegistry: this.webhookEventTranslatorRegistry,
+      inboundWebhookDecoderRegistry: this.inboundWebhookDecoderRegistry,
+      connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
+      connectionCredentialsShapeValidatorRegistry: this.connectionCredentialsShapeValidatorRegistry,
+      connectionCredentialsRewriterRegistry: this.connectionCredentialsRewriterRegistry,
+      oauthCompletionRegistry: this.oauthCompletionRegistry,
+    };
+
+    host.adapterRegistry.register(plugin.manifest);
+    const factoryAdapter: AdapterFactoryPort = {
+      createCapabilityAdapter: <T>(
+        conn: Connection,
+        cap: string,
+        idMap: IdentifierMappingPort,
+        credRes: CredentialsResolverPort,
+      ): Promise<T> =>
+        plugin.createCapabilityAdapter<T>(conn, cap, {
+          ...host,
+          identifierMapping: idMap,
+          credentialsResolver: credRes,
+        }),
+    };
+    host.factoryResolver.registerFactory(plugin.manifest.adapterKey, factoryAdapter);
+    plugin.register?.(host);
+
+    this.logger.log('WooCommerce plugin registered successfully');
+  }
+}

--- a/libs/integrations/woocommerce/src/woocommerce-plugin.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-plugin.ts
@@ -16,6 +16,9 @@
 import { dispatchCapability, type AdapterPlugin, type HostServices } from '@openlinker/plugin-sdk';
 import type { AdapterMetadata } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
+import type { WooCommerceCustomerProvisioner } from './infrastructure/provisioners/woocommerce-customer-provisioner';
+import type { WooCommerceAddressProvisioner } from './infrastructure/provisioners/woocommerce-address-provisioner';
 import { WooCommerceConnectionTesterAdapter } from './infrastructure/adapters/woocommerce-connection-tester.adapter';
 import { WooCommerceConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/woocommerce-connection-config-shape-validator.adapter';
 import { WooCommerceConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/woocommerce-connection-credentials-shape-validator.adapter';
@@ -69,7 +72,25 @@ export const woocommerceAdapterManifest: AdapterMetadata = {
 /** Short brand label for domain-exception prefixes (manifest.displayName is too long). */
 const WOOCOMMERCE_BRAND = 'WooCommerce';
 
-export function createWooCommercePlugin(): AdapterPlugin {
+/**
+ * Plugin-specific cross-package deps for the WooCommerce descriptor (#1552).
+ * The customer + address provisioners and the customer-projection repository
+ * are NOT part of the curated `HostServices` bag (they need `SyncLockPort` and
+ * `CustomerProjectionRepositoryPort`), so they're injected via the companion
+ * NestJS module (`WooCommerceIntegrationModule`) and passed through here — the
+ * same pattern PrestaShop uses for its provisioners.
+ *
+ * Optional so the static / unit-test path (`createWooCommercePlugin()`) keeps
+ * working; the OrderProcessorManager capability throws a descriptive error when
+ * they're absent.
+ */
+export interface CreateWooCommercePluginDeps {
+  readonly customerProvisioner: WooCommerceCustomerProvisioner;
+  readonly addressProvisioner: WooCommerceAddressProvisioner;
+  readonly customerProjectionRepository: CustomerProjectionRepositoryPort;
+}
+
+export function createWooCommercePlugin(deps?: CreateWooCommercePluginDeps): AdapterPlugin {
   return {
     manifest: woocommerceAdapterManifest,
 
@@ -137,12 +158,23 @@ export function createWooCommercePlugin(): AdapterPlugin {
                   host.identifierMapping,
                   connection,
                 ),
-              OrderProcessorManager: () =>
-                new WooCommerceOrderProcessorAdapter(
+              OrderProcessorManager: () => {
+                if (!deps) {
+                  throw new Error(
+                    `${WOOCOMMERCE_BRAND} OrderProcessorManager requires customer + address ` +
+                      `provisioners — resolve this capability through WooCommerceIntegrationModule, ` +
+                      `not a bare createWooCommercePlugin().`,
+                  );
+                }
+                return new WooCommerceOrderProcessorAdapter(
                   httpClient,
                   host.identifierMapping,
                   connection,
-                ),
+                  deps.customerProvisioner,
+                  deps.addressProvisioner,
+                  deps.customerProjectionRepository,
+                );
+              },
               OrderSource: () => new WooCommerceOrderSourceAdapter(httpClient, connection),
               // ProductPublisher + CategoryProvisioner are the same instance —
               // CategoryProvisioner is a sub-capability of ShopProductManagerPort,

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -344,6 +344,10 @@ const ALLOW_LIST = new Map([
     new Set(['CustomerProjectionRepositoryPort']),
   ],
   [
+    'libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.types.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
     'libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-address-provisioner.spec.ts',
     new Set(['CustomerProjectionRepositoryPort']),
   ],

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -325,6 +325,32 @@ const ALLOW_LIST = new Map([
     'libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-address-provisioner.ts',
     new Set(['CustomerProjectionRepositoryPort']),
   ],
+  // WooCommerce customer + address provisioning (#1552) — mirrors PrestaShop;
+  // rewire via ICustomersService alongside the PS entries (#722).
+  [
+    'libs/integrations/woocommerce/src/woocommerce-plugin.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
+    'libs/integrations/woocommerce/src/woocommerce-integration.module.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
+    'libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
+    'libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-address-provisioner.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
+    'libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-address-provisioner.spec.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
+    'libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
   [
     'libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-address-provisioner.spec.ts',
     new Set(['CustomerProjectionRepositoryPort']),


### PR DESCRIPTION
## What & why

Part of #1547 (WooCommerce parity with PrestaShop). WooCommerce did only inline, best-effort customer provisioning inside `createOrder` and had no address reuse. This adds dedicated provisioners mirroring PrestaShop's `PrestashopCustomerProvisioner` / `PrestashopAddressProvisioner`, so WooCommerce participates in the destination-owned customer model (Model A) and address-reuse tracking (Model C).

## Changes

- **`WooCommerceCustomerProvisioner`** - resolve-or-create a WC customer (`GET/POST /customers`), records the external<->internal mapping via the host `IdentifierMapping` service, recovers the existing account on WC's duplicate-email `400`, and serializes concurrent provisioning per buyer under the host `SyncLockPort` (Redis). Guest fallback (`customer_id=0`) only when creation is impossible; `401/403` propagate as `WooCommerceAuthFailureException` (not swallowed).
- **`WooCommerceAddressProvisioner`** - WooCommerce has no standalone address entity, so reuse keys off the address hash (`address1`, `address2`, `city`, `postcode`, `countryIso2`) and the `destination_address_mappings` table, with a hash-match recovery read against the WC customer's inline address. Writes the inline billing/shipping address onto the WC customer at most once per hash, serialized per `(customer, addressHash, type)` under the `SyncLockPort`.
- Country/currency normalization + address-hashing helpers live alongside the provisioners (WC's model is flat, no resolver layer).
- Wired as first-class injected services via a new bespoke `WooCommerceIntegrationModule` (Shape A, replacing `createNestAdapterModule`), passed through the plugin descriptor into the order-processor adapter. `createOrder` now consumes the provisioners in place of the inline path (address provisioning is best-effort and never aborts order creation).
- Allow-listed the new plugin `CustomerProjectionRepositoryPort` imports alongside the PrestaShop entries (#722).

## Tests

Dedicated provisioner specs cover: resolve-or-create, reuse hit, reuse miss, guest fallback, duplicate-email/auth-failure/concurrent-duplicate paths, and a concurrency test per provisioner proving the lock prevents duplicate customer/address creation. Existing order-processor + plugin specs updated for the new wiring.

Scoped checks for `@openlinker/integrations-woocommerce`: type-check, lint, and test (18 suites / 362 tests) all pass. Cross-context invariant check passes.

## Basing

Stacked on #1549's branch (`1549-woocommerce-order-status-writeback`) to reduce conflict surface on the shared order-processor adapter. GitHub will auto-retarget to `main` after #1549 merges.

Closes #1552

🤖 Generated with [Claude Code](https://claude.com/claude-code)