### PR TITLE
feat(invoicing): inFakt epic - invoice shipping line + label wiring + webhook integration test

### DIFF
--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -47,6 +47,8 @@ import {
   INTEGRATIONS_SERVICE_TOKEN,
 } from '@openlinker/core/integrations';
 import type { IIntegrationsService } from '@openlinker/core/integrations';
+import { CONNECTION_PORT_TOKEN } from '@openlinker/core/identifier-mapping';
+import type { Connection, ConnectionPort } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
 import type { AuthenticatedUser } from '../../auth/auth.types';
 import { InvoicingController } from './invoicing.controller';
@@ -275,6 +277,7 @@ describe('InvoicingController', () => {
   let orders: jest.Mocked<IOrderRecordService>;
   let integrations: jest.Mocked<IIntegrationsService>;
   let paymentStatusRefreshService: jest.Mocked<IPaymentStatusRefreshService>;
+  let connectionPort: jest.Mocked<Pick<ConnectionPort, 'get'>>;
 
   beforeEach(async () => {
     invoiceService = {
@@ -297,6 +300,12 @@ describe('InvoicingController', () => {
       refreshByExternalId: jest.fn().mockResolvedValue({ outcome: 'updated', paymentStatus: 'paid' }),
     } as unknown as jest.Mocked<IPaymentStatusRefreshService>;
 
+    // Default: a connection with no invoicing shipping-line label configured, so
+    // issuance defaults to the mapper's neutral label (#1562).
+    connectionPort = {
+      get: jest.fn().mockResolvedValue({ id: 'conn_1', config: {} } as unknown as Connection),
+    };
+
     const moduleRef = await Test.createTestingModule({
       controllers: [InvoicingController],
       providers: [
@@ -304,6 +313,7 @@ describe('InvoicingController', () => {
         { provide: ORDER_RECORD_SERVICE_TOKEN, useValue: orders },
         { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: mockIntegrations },
         { provide: PAYMENT_STATUS_REFRESH_SERVICE_TOKEN, useValue: paymentStatusRefreshService },
+        { provide: CONNECTION_PORT_TOKEN, useValue: connectionPort },
       ],
     }).compile();
 
@@ -376,6 +386,61 @@ describe('InvoicingController', () => {
       );
       const cmd = invoiceService.issueInvoice.mock.calls[0][0];
       expect(cmd.idempotencyKey).toBeUndefined();
+    });
+
+    // #1562: the connection's operator-supplied shipping-line label names the
+    // gross shipping line the mapper appends when the order has shipping > 0.
+    const orderWithShipping = (): OrderRecord =>
+      makeOrderRecord({
+        id: 'ol_order_1',
+        status: 'processing',
+        items: [{ id: 'li_1', productId: 'p_1', quantity: 1, price: 100, name: 'Widget' }],
+        totals: { subtotal: 100, tax: 0, shipping: 10, total: 110, currency: 'PLN', taxTreatment: 'inclusive' },
+        billingAddress: {
+          firstName: 'Jan',
+          lastName: 'Kowalski',
+          address1: 'ul. Testowa 1',
+          city: 'Poznań',
+          postalCode: '61-001',
+          country: 'PL',
+        },
+        createdAt: '2026-06-20T08:00:00.000Z',
+        updatedAt: '2026-06-21T09:30:00.000Z',
+      });
+
+    const lastLineName = (): string => {
+      const cmd = invoiceService.issueInvoice.mock.calls[0][0];
+      return cmd.lines[cmd.lines.length - 1].name;
+    };
+
+    it('threads config.invoicing.shippingLineName into the shipping line', async () => {
+      orders.getOrderRecord.mockResolvedValue(orderWithShipping());
+      invoiceService.getInvoice.mockResolvedValue(null);
+      invoiceService.issueInvoice.mockResolvedValue(makeInvoiceRecord());
+      connectionPort.get.mockResolvedValue({
+        id: 'conn_1',
+        config: { invoicing: { shippingLineName: 'Koszt wysyłki' } },
+      } as unknown as Connection);
+      await controller.issueInvoice(dto);
+      expect(connectionPort.get).toHaveBeenCalledWith('conn_1');
+      expect(lastLineName()).toBe('Koszt wysyłki');
+    });
+
+    it('falls back to the neutral default shipping label when none is configured', async () => {
+      orders.getOrderRecord.mockResolvedValue(orderWithShipping());
+      invoiceService.getInvoice.mockResolvedValue(null);
+      invoiceService.issueInvoice.mockResolvedValue(makeInvoiceRecord());
+      await controller.issueInvoice(dto);
+      expect(lastLineName()).toBe('Shipping');
+    });
+
+    it('falls back to the neutral default when the connection lookup fails', async () => {
+      orders.getOrderRecord.mockResolvedValue(orderWithShipping());
+      invoiceService.getInvoice.mockResolvedValue(null);
+      invoiceService.issueInvoice.mockResolvedValue(makeInvoiceRecord());
+      connectionPort.get.mockRejectedValue(new Error('connection gone'));
+      await controller.issueInvoice(dto);
+      expect(lastLineName()).toBe('Shipping');
     });
 
     it('keyless re-issue over a KEYED failed row reuses that row\'s own idempotencyKey', async () => {

--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -434,13 +434,21 @@ describe('InvoicingController', () => {
       expect(lastLineName()).toBe('Shipping');
     });
 
-    it('falls back to the neutral default when the connection lookup fails', async () => {
+    it('falls back to the neutral default when the connection lookup fails, and logs it at debug', async () => {
+      const debugSpy = jest
+        .spyOn(Logger.prototype, 'debug')
+        .mockImplementation(() => undefined);
       orders.getOrderRecord.mockResolvedValue(orderWithShipping());
       invoiceService.getInvoice.mockResolvedValue(null);
       invoiceService.issueInvoice.mockResolvedValue(makeInvoiceRecord());
       connectionPort.get.mockRejectedValue(new Error('connection gone'));
       await controller.issueInvoice(dto);
       expect(lastLineName()).toBe('Shipping');
+      // A swallowed lookup failure must still be observable (#1565 review).
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Shipping-line label lookup failed for connection conn_1'),
+      );
+      debugSpy.mockRestore();
     });
 
     it('keyless re-issue over a KEYED failed row reuses that row\'s own idempotencyKey', async () => {

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -103,6 +103,10 @@ import {
   OrderSnapshotUnavailableError,
 } from '@openlinker/core/orders';
 import type { Order, OrderRecord } from '@openlinker/core/orders';
+import {
+  CONNECTION_PORT_TOKEN,
+  ConnectionPort,
+} from '@openlinker/core/identifier-mapping';
 import { IssueInvoiceRequestDto } from './dto/issue-invoice-request.dto';
 import { IssueCorrectionRequestDto } from './dto/issue-correction-request.dto';
 import { GetInvoiceForOrderQueryDto } from './dto/get-invoice-for-order-query.dto';
@@ -176,6 +180,8 @@ export class InvoicingController {
     private readonly integrationsService: IIntegrationsService,
     @Inject(PAYMENT_STATUS_REFRESH_SERVICE_TOKEN)
     private readonly paymentStatusRefreshService: IPaymentStatusRefreshService,
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connectionPort: ConnectionPort,
   ) {}
 
   @Get('connections/:connectionId/bank-accounts')
@@ -262,6 +268,26 @@ export class InvoicingController {
         throw new BadGatewayException('Invoicing provider is unavailable');
       }
       throw error;
+    }
+  }
+
+  /**
+   * Resolve the connection's optional operator-supplied shipping-line label
+   * (#1562) to thread into `toIssueInvoiceCommand`. Country-agnostic (ADR-026):
+   * core forwards an opaque operator string, never a language it chose, and
+   * never switches on `platformType`. Narrowed to a non-empty string so a
+   * non-string / blank JSONB value defers to the mapper's neutral
+   * `SHIPPING_LINE_NAME` default. Resilient by design: any connection-lookup
+   * failure returns `undefined` (neutral label) rather than breaking issuance -
+   * the adapter resolution downstream is the authoritative connection gate.
+   */
+  private async resolveShippingLineName(connectionId: string): Promise<string | undefined> {
+    try {
+      const connection = await this.connectionPort.get(connectionId);
+      const value = connection.config.invoicing?.shippingLineName;
+      return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+    } catch {
+      return undefined;
     }
   }
 
@@ -353,19 +379,20 @@ export class InvoicingController {
         ? existing.idempotencyKey
         : undefined);
 
+    // #1562: thread the connection's operator-supplied shipping-line label into
+    // the mapper (ADR-026 neutral - core forwards an opaque string). Blank/absent
+    // defers to the mapper's neutral `SHIPPING_LINE_NAME` default.
+    const shippingLineName = await this.resolveShippingLineName(dto.connectionId);
+
     let command: IssueInvoiceCommand;
     try {
-      // `shippingLineName` is intentionally NOT passed here (nor at the other
-      // issuance call sites): there is no locale source at issue time yet, so the
-      // mapper's neutral default label is used. A localized shipping-line label
-      // would be threaded through here once a locale/provider source exists
-      // (follow-up #1562).
       command = toIssueInvoiceCommand({
         order,
         connectionId: dto.connectionId,
         buyerTaxId: this.toTaxIdentifier(dto.buyerTaxId),
         documentType: dto.documentType,
         idempotencyKey,
+        shippingLineName,
       });
     } catch (error) {
       throw this.toHttpException(error);
@@ -469,6 +496,8 @@ export class InvoicingController {
         // Reuse the record's OWN key so the service resumes THIS row rather than
         // starting a fresh attempt (R2/R3, exactly-once dedup).
         idempotencyKey: record.idempotencyKey ?? undefined,
+        // #1562: same operator-supplied shipping-line label as the single-issue path.
+        shippingLineName: await this.resolveShippingLineName(record.connectionId),
       });
       await this.invoiceService.issueInvoice(command);
       return { id: invoiceId, outcome: 'retried' };
@@ -591,6 +620,8 @@ export class InvoicingController {
         // snapshot alone (matches a keyless single re-issue).
         buyerTaxId: null,
         idempotencyKey,
+        // #1562: same operator-supplied shipping-line label as the single-issue path.
+        shippingLineName: await this.resolveShippingLineName(connectionId),
       });
       const issued = await this.invoiceService.issueInvoice(command);
       return { orderId, outcome: 'issued', invoiceId: issued.id };
@@ -698,6 +729,11 @@ export class InvoicingController {
               clearanceReference: original.clearanceReference,
               documentNumber: original.providerInvoiceNumber,
               issuedAt: original.issuedAt,
+              // #1562: same operator-supplied shipping-line label as the issuance
+              // path. Best available approximation for this pre-#1297 rebuild
+              // (which already carries line-fidelity caveats); the current
+              // connection label matches what issuance would render today.
+              shippingLineName: await this.resolveShippingLineName(original.connectionId),
             })
           : undefined;
       }
@@ -1105,15 +1141,24 @@ export class InvoicingController {
     clearanceReference: string | null;
     documentNumber: string;
     issuedAt: Date;
+    shippingLineName?: string;
   }): OriginalDocumentSnapshot {
-    const { orderRecord, connectionId, documentType, clearanceReference, documentNumber, issuedAt } =
-      input;
+    const {
+      orderRecord,
+      connectionId,
+      documentType,
+      clearanceReference,
+      documentNumber,
+      issuedAt,
+      shippingLineName,
+    } = input;
     const order = this.rehydrateOrder(orderRecord.internalOrderId, orderRecord);
     const issueCmd = toIssueInvoiceCommand({
       order,
       connectionId,
       buyerTaxId: null,
       documentType: documentType.length > 0 ? documentType : undefined,
+      shippingLineName,
     });
     return {
       buyer: issueCmd.buyer,

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -355,6 +355,11 @@ export class InvoicingController {
 
     let command: IssueInvoiceCommand;
     try {
+      // `shippingLineName` is intentionally NOT passed here (nor at the other
+      // issuance call sites): there is no locale source at issue time yet, so the
+      // mapper's neutral default label is used. A localized shipping-line label
+      // would be threaded through here once a locale/provider source exists
+      // (follow-up #1562).
       command = toIssueInvoiceCommand({
         order,
         connectionId: dto.connectionId,

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -83,6 +83,7 @@ import {
   isPaymentMarker,
   PAYMENT_STATUS_REFRESH_SERVICE_TOKEN,
   IPaymentStatusRefreshService,
+  normalizeShippingLineName,
 } from '@openlinker/core/invoicing';
 import type {
   InvoiceRecord,
@@ -284,9 +285,18 @@ export class InvoicingController {
   private async resolveShippingLineName(connectionId: string): Promise<string | undefined> {
     try {
       const connection = await this.connectionPort.get(connectionId);
-      const value = connection.config.invoicing?.shippingLineName;
-      return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
-    } catch {
+      // Shared coercion with the core auto-issue reader so the two narrowings
+      // cannot drift (#1565 review).
+      return normalizeShippingLineName(connection.config.invoicing?.shippingLineName);
+    } catch (error) {
+      // Silent fallback is intentional and safe: issuance must never break on a
+      // label lookup (the downstream getCapabilityAdapter is the authoritative
+      // connection gate). Log at debug so an unexpected connection-read failure
+      // is still observable rather than swallowed entirely.
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.debug(
+        `Shipping-line label lookup failed for connection ${connectionId}; using neutral default: ${message}`,
+      );
       return undefined;
     }
   }

--- a/apps/api/src/invoicing/invoicing.module.ts
+++ b/apps/api/src/invoicing/invoicing.module.ts
@@ -18,11 +18,20 @@ import { Module } from '@nestjs/common';
 import { IntegrationsModule as CoreIntegrationsModule } from '@openlinker/core/integrations';
 import { InvoicingModule } from '@openlinker/core/invoicing';
 import { OrdersModule } from '@openlinker/core/orders';
+import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { IntegrationsModule } from '../integrations/integrations.module';
 import { InvoicingController } from './http/invoicing.controller';
 
 @Module({
-  imports: [InvoicingModule, OrdersModule, CoreIntegrationsModule, IntegrationsModule],
+  // IdentifierMappingModule supplies CONNECTION_PORT_TOKEN so the controller can
+  // read the connection's `config.invoicing.shippingLineName` (#1562).
+  imports: [
+    InvoicingModule,
+    OrdersModule,
+    CoreIntegrationsModule,
+    IntegrationsModule,
+    IdentifierMappingModule,
+  ],
   controllers: [InvoicingController],
 })
 export class InvoicingApiModule {}

--- a/apps/api/test/integration/infakt-webhook-ingestion.int-spec.ts
+++ b/apps/api/test/integration/infakt-webhook-ingestion.int-spec.ts
@@ -1,0 +1,248 @@
+/**
+ * Infakt Webhook Ingestion Integration Tests (#1509, #1281 / #1354, ADR-021)
+ *
+ * End-to-end proof of the third-party-native Infakt ingress over real HTTP:
+ * a genuine `X-Infakt-Signature` HMAC-SHA256 delivery, in Infakt's real
+ * `{ event, resource }` body shape, through the registered
+ * `InfaktInboundWebhookDecoderAdapter` (detectHandshake + verify +
+ * extractEnvelope) → dedup → publish → the real
+ * `InfaktWebhookEventTranslatorAdapter` → the real `InboundRoutingPolicy`.
+ *
+ * Complements the existing unit coverage (decoder / event-translator / the
+ * `InfaktWebhookTranslator` HMAC + parse + handshake specs) by exercising the
+ * full receiver stack in CI, mirroring the Erli/InPost/PrestaShop int-specs.
+ *
+ * Covers the two OL-actionable routing branches plus the two auth/handshake
+ * quirks documented on the decoder:
+ *  - `send_to_ksef_success` → `invoicing.regulatoryStatus.reconcile`
+ *  - `invoice_marked_as_paid` → `invoicing.paymentStatus.refreshByExternalId`
+ *  - wrong signature → 401 (no delivery row, no job)
+ *  - subscription-verification handshake → 200 + echoed `verification_code`
+ *    (the documented 200-instead-of-202 quirk verified live against Infakt's
+ *    "Zweryfikuj" button)
+ *
+ * @module apps/api/test/integration
+ */
+import { createHmac, randomUUID } from 'crypto';
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import type { IntegrationTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+
+/** The real, registered Infakt adapterKey (mirrors `infaktAdapterManifest`). */
+const INFAKT_ADAPTER_KEY = 'infakt.accounting.v1';
+
+/** Infakt delivery auth: HMAC-SHA256 hex over the raw body, header `X-Infakt-Signature`. */
+function infaktSign(rawBody: Buffer, secret: string): string {
+  return createHmac('sha256', secret).update(rawBody).digest('hex');
+}
+
+/** Job stream field shape (all values are strings on the Redis stream). */
+type JobFields = { jobType: string; connectionId: string; payloadJson: string };
+
+/**
+ * Ingestion is async (HTTP 202 → event bus → WebhookToJobHandler → enqueue), so
+ * poll the `jobs.sync` stream until a job matching `predicate` appears rather
+ * than relying on a single fixed sleep (which races under full-suite load).
+ */
+async function waitForJob(
+  harness: IntegrationTestHarness,
+  predicate: (fields: JobFields) => boolean,
+  timeoutMs = 5000,
+): Promise<JobFields | undefined> {
+  const redisClient = harness.getRedisClient();
+  if (!redisClient) throw new Error('Redis client not available');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const jobs = await redisClient.xRead([{ key: 'jobs.sync', id: '0' }], { COUNT: 50 });
+    const match = jobs?.[0]?.messages
+      .map((msg) => msg.message as JobFields)
+      .find((fields) => predicate(fields));
+    if (match) return match;
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  return undefined;
+}
+
+describe('Infakt Webhook Ingestion Integration (#1509)', () => {
+  let harness: IntegrationTestHarness;
+  const webhookSecret = 'infakt-native-decoder-test-secret-246810';
+  let priorEnvSecret: string | undefined;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    priorEnvSecret = process.env.OPENLINKER_WEBHOOK_SECRET__INFAKT;
+    // Provider-level env fallback (`CredentialsWebhookSecretAdapter`) — same
+    // mechanism the Erli/InPost webhook int-specs use; the simplest way to give
+    // the real decoder a secret to verify against without provisioning a
+    // per-connection encrypted credentials row.
+    process.env.OPENLINKER_WEBHOOK_SECRET__INFAKT = webhookSecret;
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    if (priorEnvSecret === undefined) {
+      delete process.env.OPENLINKER_WEBHOOK_SECRET__INFAKT;
+    } else {
+      process.env.OPENLINKER_WEBHOOK_SECRET__INFAKT = priorEnvSecret;
+    }
+    await teardownTestHarness();
+  });
+
+  async function createInfaktConnection(): Promise<{ id: string }> {
+    return createTestConnection(harness.getDataSource(), {
+      platformType: 'infakt',
+      status: 'active',
+      adapterKey: INFAKT_ADAPTER_KEY,
+      config: {},
+      enabledCapabilities: ['Invoicing'],
+    });
+  }
+
+  // Both OL-actionable routing branches are asserted in a SINGLE test on
+  // purpose: `resetTestHarness()` flushes Redis (`flushDb`), which destroys the
+  // `webhook-handler` consumer group the handler created at boot — so only the
+  // first pre-reset test can observe a handler-processed enqueue (the same
+  // reason the Erli/InPost webhook int-specs each assert exactly one enqueue).
+  // Firing both signed deliveries here, before any reset, keeps the consumer
+  // group alive across both.
+  it('routes real Infakt-signed KSeF-clearance and payment webhooks to their respective jobs', async () => {
+    const ksefConnection = await createInfaktConnection();
+    const paymentConnection = await createInfaktConnection();
+    const ksefInvoiceUuid = `inv-${randomUUID()}`;
+    const paidInvoiceUuid = `inv-${randomUUID()}`;
+
+    const ksefBody = {
+      event: {
+        uuid: `evt-${randomUUID()}`,
+        name: 'send_to_ksef_success',
+        retry_counter: 0,
+        created_at: new Date().toISOString(),
+      },
+      resource: { status: 'success', invoice_uuid: ksefInvoiceUuid, ksef_number: 'KSeF-INT-1' },
+    };
+    const ksefRawBody = Buffer.from(JSON.stringify(ksefBody));
+
+    const paymentBody = {
+      event: {
+        uuid: `evt-${randomUUID()}`,
+        name: 'invoice_marked_as_paid',
+        retry_counter: 0,
+        created_at: new Date().toISOString(),
+      },
+      // A payment event's resource is the full invoice object → `uuid`, not `invoice_uuid`.
+      resource: { uuid: paidInvoiceUuid, status: 'paid' },
+    };
+    const paymentRawBody = Buffer.from(JSON.stringify(paymentBody));
+
+    await harness
+      .getHttp()
+      .post(`/webhooks/infakt/${ksefConnection.id}`)
+      .set('X-Infakt-Signature', infaktSign(ksefRawBody, webhookSecret))
+      .send(ksefBody)
+      .expect(202);
+
+    await harness
+      .getHttp()
+      .post(`/webhooks/infakt/${paymentConnection.id}`)
+      .set('X-Infakt-Signature', infaktSign(paymentRawBody, webhookSecret))
+      .send(paymentBody)
+      .expect(202);
+
+    // KSeF-clearance event → regulatory-status reconcile (a trigger, not the
+    // source of truth: it nudges the page-scan reconciler; no by-id job exists).
+    const reconcileJob = await waitForJob(
+      harness,
+      (fields) =>
+        fields.jobType === 'invoicing.regulatoryStatus.reconcile' &&
+        fields.connectionId === ksefConnection.id,
+    );
+    expect(reconcileJob).toBeDefined();
+
+    // Payment event → by-id payment-status refresh keyed by the invoice uuid.
+    const paymentJob = await waitForJob(harness, (fields) => {
+      if (fields.jobType !== 'invoicing.paymentStatus.refreshByExternalId') return false;
+      if (fields.connectionId !== paymentConnection.id) return false;
+      try {
+        const payload = JSON.parse(fields.payloadJson) as { externalInvoiceId?: string };
+        return payload.externalInvoiceId === paidInvoiceUuid;
+      } catch {
+        return false;
+      }
+    });
+    expect(paymentJob).toBeDefined();
+
+    // The controller's own 'published' delivery-recording write and the
+    // handler's later 'job_enqueued' write race independently of the enqueue
+    // itself (both best-effort, #711) — assert only that a signature-verified
+    // delivery row exists, not its exact terminal status.
+    const deliveryRows: Array<{ signatureValid: boolean }> = await harness.getDataSource().query(
+      `SELECT "signatureValid" FROM webhook_deliveries WHERE provider = 'infakt' AND "connectionId" = $1`,
+      [ksefConnection.id],
+    );
+    expect(deliveryRows).toHaveLength(1);
+    expect(deliveryRows[0].signatureValid).toBe(true);
+  });
+
+  it('rejects an Infakt webhook with a wrong signature (401), records no delivery, enqueues no job', async () => {
+    const connection = await createInfaktConnection();
+    const body = {
+      event: {
+        uuid: `evt-${randomUUID()}`,
+        name: 'send_to_ksef_success',
+        retry_counter: 0,
+        created_at: new Date().toISOString(),
+      },
+      resource: { status: 'success', invoice_uuid: `inv-${randomUUID()}` },
+    };
+
+    await harness
+      .getHttp()
+      .post(`/webhooks/infakt/${connection.id}`)
+      .set('X-Infakt-Signature', 'deadbeefdeadbeefdeadbeefdeadbeef')
+      .send(body)
+      .expect(401);
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const deliveryRows: Array<{ n: number }> = await harness.getDataSource().query(
+      `SELECT count(*)::int AS n FROM webhook_deliveries WHERE provider = 'infakt' AND "connectionId" = $1`,
+      [connection.id],
+    );
+    expect(deliveryRows[0].n).toBe(0);
+
+    const redisClient = harness.getRedisClient();
+    if (!redisClient) throw new Error('Redis client not available');
+    const jobs = await redisClient.xRead([{ key: 'jobs.sync', id: '0' }], { COUNT: 50 });
+    const infaktJobs =
+      jobs?.[0]?.messages.filter((msg) => msg.message.connectionId === connection.id) ?? [];
+    expect(infaktJobs).toHaveLength(0);
+  });
+
+  it('echoes the verification_code handshake with 200 and enqueues no job', async () => {
+    const connection = await createInfaktConnection();
+    const verificationCode = `vc-${randomUUID()}`;
+
+    // The handshake ping predates any signed traffic and carries no signature;
+    // the controller must echo the same body back with a 200 (not the route's
+    // default 202) to activate the subscription.
+    const response = await harness
+      .getHttp()
+      .post(`/webhooks/infakt/${connection.id}`)
+      .send({ verification_code: verificationCode })
+      .expect(200);
+
+    expect(response.body).toEqual({ verification_code: verificationCode });
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const redisClient = harness.getRedisClient();
+    if (!redisClient) throw new Error('Redis client not available');
+    const jobs = await redisClient.xRead([{ key: 'jobs.sync', id: '0' }], { COUNT: 50 });
+    const infaktJobs =
+      jobs?.[0]?.messages.filter((msg) => msg.message.connectionId === connection.id) ?? [];
+    expect(infaktJobs).toHaveLength(0);
+  });
+});

--- a/apps/api/test/integration/infakt-webhook-ingestion.int-spec.ts
+++ b/apps/api/test/integration/infakt-webhook-ingestion.int-spec.ts
@@ -177,7 +177,10 @@ describe('Infakt Webhook Ingestion Integration (#1509)', () => {
     // The controller's own 'published' delivery-recording write and the
     // handler's later 'job_enqueued' write race independently of the enqueue
     // itself (both best-effort, #711) — assert only that a signature-verified
-    // delivery row exists, not its exact terminal status.
+    // delivery row exists, not its exact terminal status. Dedup/replay is not
+    // re-asserted here: it is provider-agnostic and already covered in
+    // `webhook-ingestion.int-spec.ts` ('should prevent duplicate events' +
+    // 'handler crash/retry with job dedup').
     const deliveryRows: Array<{ signatureValid: boolean }> = await harness.getDataSource().query(
       `SELECT "signatureValid" FROM webhook_deliveries WHERE provider = 'infakt' AND "connectionId" = $1`,
       [ksefConnection.id],
@@ -205,14 +208,25 @@ describe('Infakt Webhook Ingestion Integration (#1509)', () => {
       .send(body)
       .expect(401);
 
+    // Proving the *absence* of an effect can't be polled, so wait a fixed bound
+    // for any (erroneous) downstream enqueue to have surfaced before asserting
+    // none did. The rejection happens pre-publish (401 at the controller), so
+    // this is inherently low-risk; 500 ms is a comfortable margin.
     await new Promise((resolve) => setTimeout(resolve, 500));
 
+    // Load-bearing assertions: the 401 status above + zero `webhook_deliveries`
+    // rows (per #711, a failed-validation delivery inserts no row).
     const deliveryRows: Array<{ n: number }> = await harness.getDataSource().query(
       `SELECT count(*)::int AS n FROM webhook_deliveries WHERE provider = 'infakt' AND "connectionId" = $1`,
       [connection.id],
     );
     expect(deliveryRows[0].n).toBe(0);
 
+    // Corroborating only: `afterEach`'s `resetTestHarness()` flushes Redis and
+    // destroys the `webhook-handler` consumer group, so from the second test
+    // onward there is no live consumer - this no-job check would pass even if
+    // the handler were broken. The real proof is the status code + delivery-row
+    // count above, both of which reject before the publish step.
     const redisClient = harness.getRedisClient();
     if (!redisClient) throw new Error('Redis client not available');
     const jobs = await redisClient.xRead([{ key: 'jobs.sync', id: '0' }], { COUNT: 50 });
@@ -234,10 +248,16 @@ describe('Infakt Webhook Ingestion Integration (#1509)', () => {
       .send({ verification_code: verificationCode })
       .expect(200);
 
+    // Load-bearing: the 200 status + the echoed `verification_code` body above.
     expect(response.body).toEqual({ verification_code: verificationCode });
 
+    // Fixed bound to let any (erroneous) enqueue surface; the handshake
+    // short-circuits before routing, so this is inherently low-risk.
     await new Promise((resolve) => setTimeout(resolve, 500));
 
+    // Corroborating only: Redis was flushed by the prior `resetTestHarness()`,
+    // so the `webhook-handler` consumer group is gone and no job could be
+    // enqueued regardless. The status + echoed body above are the real proof.
     const redisClient = harness.getRedisClient();
     if (!redisClient) throw new Error('Redis client not available');
     const jobs = await redisClient.xRead([{ key: 'jobs.sync', id: '0' }], { COUNT: 50 });

--- a/docs/plans/implementation-plan-wire-shipping-line-label.md
+++ b/docs/plans/implementation-plan-wire-shipping-line-label.md
@@ -1,0 +1,64 @@
+# Implementation Plan: Wire a localized shipping-line label (#1562)
+
+Follow-up to #1517 / PR #1546. PR #1546 added an optional `shippingLineName` to
+`OrderToIssueInvoiceCommandInput` (neutral default `SHIPPING_LINE_NAME = "Shipping"`).
+This issue wires that seam from a source at both issuance entry points.
+
+## Layer
+Interface (API controller) + CORE application (auto-issue trigger) + a one-line CORE type
+extension. No new port, no migration.
+
+## Decision: neutral per-connection `config.invoicing.shippingLineName` (Approach B)
+
+Investigated both directions from the issue:
+
+- **Approach A (provider/adapter-owned label via a new `Invoicing` sub-capability)** is
+  structurally blocked at the auto-issue entry point. `AutoIssueTriggerService` has a
+  deliberate one-way edge (F3): it depends only on `ConnectionPort` + `SyncJobsService` and
+  injects no `IntegrationsService`. It bakes `command.lines` into the `invoicing.issue` job
+  payload, and the worker (`InvoicingIssueHandler`) replays `payload.lines` verbatim (it never
+  re-runs the mapper). Reaching a resolved adapter there would require either breaking F3
+  (adapter resolution in the order-ingestion hot path) or fragile relabel-by-name in the
+  worker. Also, no provider adapter implements such a capability today, so A would be a no-op
+  label everywhere until each adapter adds national wording.
+
+- **Approach B (chosen)** stores an opaque, operator-supplied label on the connection config.
+  Both entry points already hold the `Connection` (auto-issue already reads
+  `config.invoicing.triggerModel`; the controller can `ConnectionPort.get`). The value threads
+  straight into the one mapper both sites use - exactly the wiring point the issue names.
+
+**ADR-026 compliance:** core stores an opaque string; no language is hardcoded in core and no
+`platformType` switch is introduced. The neutral default and the mapper contract are unchanged
+(the mapper still defaults blank/absent to `"Shipping"`).
+
+## Steps
+
+1. **CORE type** - add `shippingLineName?: string` to `ConnectionConfig.invoicing`
+   (`libs/core/src/identifier-mapping/domain/types/connection.types.ts`). Additive JSONB field,
+   round-tripped verbatim by `ConnectionRepository`. **No migration** (matches `triggerModel`).
+
+2. **Auto-issue** (`auto-issue-trigger.service.ts`) - in `onOrderTransition`, read the
+   narrowed `connection.config.invoicing?.shippingLineName` and thread it through
+   `composePayload` into `toIssueInvoiceCommand({ ..., shippingLineName })`.
+
+3. **Controller** (`apps/api/src/invoicing/http/invoicing.controller.ts`) - inject
+   `CONNECTION_PORT_TOKEN`; add a resilient private `resolveShippingLineName(connectionId)`
+   helper (returns `undefined` on any lookup failure so issuance never breaks); pass the value
+   into all four `toIssueInvoiceCommand` calls: `issueInvoice`, `retryOne`, `issueOneForOrder`,
+   and the correction fallback `buildOriginalDocumentSnapshot`.
+
+4. **Tests** - auto-issue spec: label threaded into payload shipping line when configured;
+   neutral default when absent. Controller spec: label threaded into the issued command; default
+   when absent.
+
+## Out of scope / honest boundary
+
+- **No backend DTO validation** - `config.invoicing` is a passthrough JSONB shape with no strict
+  DTO today (`triggerModel` is coerced leniently at read time, not DTO-validated). Adding a
+  strict validator would be new surface unrelated to the wiring; the label is an optional
+  operator string the mapper already trims/defaults.
+- **Dedicated FE field deferred** - the current invoicing-config FE is Subiekt-plugin-coupled
+  (`subiektTriggerModel` in the Subiekt structured section), while `shippingLineName` is
+  provider-generic across all invoicing providers. A clean generic FE input is a larger,
+  separate change. The field is settable today via the connection create/update API (JSONB
+  passthrough), so the backend wiring is fully functional standalone.

--- a/libs/core/src/identifier-mapping/domain/types/connection.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/connection.types.ts
@@ -51,9 +51,18 @@ export interface ConnectionConfig {
    * `AutoIssueTriggerService` and coerced via `parseTriggerModel` (a missing or
    * unrecognized value defaults to `manual`). Typed as `string` here to keep the
    * identifier-mapping context decoupled from the invoicing enum.
+   *
+   * `shippingLineName` (#1562) is the optional, operator-supplied label the
+   * issuance path threads into the neutral order→command mapper's shipping line
+   * (`toIssueInvoiceCommand`). Country-agnostic by construction (ADR-026): core
+   * stores an opaque string, so an operator localizes the buyer-visible label
+   * (e.g. "Koszt wysyłki") without core hardcoding a language or switching on
+   * `platformType`. A missing/blank value falls back to the mapper's neutral
+   * `SHIPPING_LINE_NAME` default.
    */
   invoicing?: {
     triggerModel?: string;
+    shippingLineName?: string;
   };
   [key: string]: unknown;
 }

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
@@ -250,4 +250,61 @@ describe('toIssueInvoiceCommand', () => {
       UnsupportedPriceTreatmentError,
     );
   });
+
+  it('shipping: totals.shipping > 0 -> appends one gross shipping line after the item lines (#1517)', () => {
+    const order = makeOrder({
+      items: [makeItem({ price: 499.99, quantity: 1 })],
+      totals: {
+        subtotal: 499.99,
+        tax: 0,
+        shipping: 10.49,
+        total: 510.48,
+        currency: 'PLN',
+        taxTreatment: 'inclusive',
+      },
+    });
+
+    const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
+
+    expect(cmd.lines).toHaveLength(2);
+    // Product lines come first; the shipping line is appended last.
+    expect(cmd.lines[0].unitPriceGross).toBe(499.99);
+    expect(cmd.lines[1]).toEqual({
+      name: 'Shipping',
+      quantity: 1,
+      unitPriceGross: 10.49,
+      taxRate: '',
+    });
+    // Invoice gross (summed by InvoiceService.buildContent over cmd.lines) now
+    // equals the order total.
+    const gross = cmd.lines.reduce((sum, l) => sum + l.quantity * l.unitPriceGross, 0);
+    expect(gross).toBeCloseTo(order.totals.total, 2);
+  });
+
+  it('shipping: taxRate left empty on the shipping line (provider adapter resolves the regime rate)', () => {
+    const order = makeOrder({
+      totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+    });
+
+    const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
+
+    const shippingLine = cmd.lines.find((l) => l.name === 'Shipping');
+    expect(shippingLine).toBeDefined();
+    expect(shippingLine?.taxRate).toBe('');
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -5],
+  ])('shipping: totals.shipping %s -> no phantom shipping line (#1517)', (_label, shipping) => {
+    const order = makeOrder({
+      items: [makeItem({ price: 100, quantity: 1 })],
+      totals: { subtotal: 100, tax: 0, shipping, total: 100, currency: 'PLN', taxTreatment: 'inclusive' },
+    });
+
+    const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
+
+    expect(cmd.lines).toHaveLength(1);
+    expect(cmd.lines.some((l) => l.name === 'Shipping')).toBe(false);
+  });
 });

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
@@ -296,6 +296,9 @@ describe('toIssueInvoiceCommand', () => {
   it.each([
     ['zero', 0],
     ['negative', -5],
+    ['NaN', Number.NaN],
+    ['+Infinity', Number.POSITIVE_INFINITY],
+    ['-Infinity', Number.NEGATIVE_INFINITY],
   ])('shipping: totals.shipping %s -> no phantom shipping line (#1517)', (_label, shipping) => {
     const order = makeOrder({
       items: [makeItem({ price: 100, quantity: 1 })],
@@ -307,4 +310,38 @@ describe('toIssueInvoiceCommand', () => {
     expect(cmd.lines).toHaveLength(1);
     expect(cmd.lines.some((l) => l.name === 'Shipping')).toBe(false);
   });
+
+  it('shipping: caller-supplied shippingLineName overrides the neutral default label (#1517)', () => {
+    const order = makeOrder({
+      totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+    });
+
+    const cmd = toIssueInvoiceCommand({
+      order,
+      connectionId: 'conn-1',
+      shippingLineName: 'Koszt wysyłki',
+    });
+
+    const shippingLine = cmd.lines.find((l) => l.unitPriceGross === 15 && l.quantity === 1);
+    expect(shippingLine?.name).toBe('Koszt wysyłki');
+    // Neutral English default is not used when an override is supplied.
+    expect(cmd.lines.some((l) => l.name === 'Shipping')).toBe(false);
+  });
+
+  it.each([
+    ['empty', ''],
+    ['whitespace-only', '   '],
+  ])(
+    'shipping: %s shippingLineName override falls back to the neutral default label (#1517)',
+    (_label, shippingLineName) => {
+      const order = makeOrder({
+        totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+      });
+
+      const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1', shippingLineName });
+
+      const shippingLine = cmd.lines.find((l) => l.unitPriceGross === 15 && l.quantity === 1);
+      expect(shippingLine?.name).toBe('Shipping');
+    },
+  );
 });

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
@@ -23,6 +23,9 @@ import { InvalidBuyerProfileError } from './errors/invalid-buyer-profile.error';
 import { InvalidInvoiceLineError } from './errors/invalid-invoice-line.error';
 import { UnsupportedPriceTreatmentError } from './errors/unsupported-price-treatment.error';
 
+/** Carrier-neutral label for the shipping invoice line (#1517). */
+const SHIPPING_LINE_NAME = 'Shipping';
+
 /** Inputs to {@link toIssueInvoiceCommand}. */
 export interface OrderToIssueInvoiceCommandInput {
   order: Order;
@@ -39,7 +42,8 @@ export interface OrderToIssueInvoiceCommandInput {
  * when no address/buyer-name can be derived, `UnsupportedPriceTreatmentError`
  * when the order is net-priced (`taxTreatment === 'exclusive'`), and
  * `InvalidInvoiceLineError` when an item's quantity is not a positive finite
- * number (#1525).
+ * number (#1525). Appends a gross shipping line when `order.totals.shipping > 0`
+ * so the invoice total equals the buyer-paid order total (#1517).
  */
 export function toIssueInvoiceCommand(
   input: OrderToIssueInvoiceCommandInput,
@@ -57,6 +61,15 @@ export function toIssueInvoiceCommand(
 
   const buyer = buildBuyerProfile(order, buyerTaxId ?? null);
   const lines = order.items.map((item) => toInvoiceLine(item, order.id));
+
+  // Buyer-paid shipping is part of the invoice total (invoice gross must equal
+  // order total, #1517). Emit it as a normal gross line so the provider adapter
+  // resolves its tax rate the same way it does for product lines; core never
+  // names a tax rate. Skipped when shipping is 0 (no phantom line).
+  const shippingLine = toShippingLine(order.totals.shipping);
+  if (shippingLine) {
+    lines.push(shippingLine);
+  }
 
   const command: IssueInvoiceCommand = {
     connectionId,
@@ -177,6 +190,25 @@ function toInvoiceLine(item: OrderItem, orderId: string): InvoiceLine {
     name: item.name?.trim() || item.sku || item.productId,
     quantity: item.quantity,
     unitPriceGross: item.price,
+    taxRate: '',
+  };
+}
+
+/**
+ * Compose the shipping {@link InvoiceLine} from the order's gross shipping cost,
+ * or `null` when there is nothing to bill (#1517). A single unit priced at the
+ * gross shipping amount; `taxRate` is left empty (provider adapter resolves the
+ * regime rate, mirroring {@link toInvoiceLine}). Non-positive or non-finite
+ * shipping (0, negative, NaN) yields no line — no phantom shipping line.
+ */
+function toShippingLine(shipping: number): InvoiceLine | null {
+  if (!Number.isFinite(shipping) || shipping <= 0) {
+    return null;
+  }
+  return {
+    name: SHIPPING_LINE_NAME,
+    quantity: 1,
+    unitPriceGross: shipping,
     taxRate: '',
   };
 }

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
@@ -45,6 +45,13 @@ export interface OrderToIssueInvoiceCommandInput {
    * no locale, so a caller that does (or that translates for a target market)
    * can supply a localized name here; when absent the neutral English
    * {@link SHIPPING_LINE_NAME} default is used.
+   *
+   * NOTE: no issuance caller wires this yet (`AutoIssueTriggerService`, the
+   * invoicing controller), so today the neutral default is the only live path
+   * and a PL/KSeF document still renders "Shipping". This is an intentional seam,
+   * not dead code: a localized label needs a locale source that does not exist in
+   * core yet (no per-connection locale setting; the provider is the natural owner
+   * of national wording per ADR-026). Wiring it is tracked as a follow-up (#1562).
    */
   shippingLineName?: string;
 }

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
@@ -23,7 +23,12 @@ import { InvalidBuyerProfileError } from './errors/invalid-buyer-profile.error';
 import { InvalidInvoiceLineError } from './errors/invalid-invoice-line.error';
 import { UnsupportedPriceTreatmentError } from './errors/unsupported-price-treatment.error';
 
-/** Carrier-neutral label for the shipping invoice line (#1517). */
+/**
+ * Default carrier-neutral label for the shipping invoice line (#1517). Core is
+ * language-agnostic and has no locale, so this English default is intentionally
+ * untranslated; a caller that has a locale can override it via
+ * {@link OrderToIssueInvoiceCommandInput.shippingLineName}.
+ */
 const SHIPPING_LINE_NAME = 'Shipping';
 
 /** Inputs to {@link toIssueInvoiceCommand}. */
@@ -35,6 +40,13 @@ export interface OrderToIssueInvoiceCommandInput {
   /** Pass-through ONLY; the adapter derives when absent. */
   documentType?: string;
   idempotencyKey?: string;
+  /**
+   * Optional override for the shipping-line label on a fiscal document. Core has
+   * no locale, so a caller that does (or that translates for a target market)
+   * can supply a localized name here; when absent the neutral English
+   * {@link SHIPPING_LINE_NAME} default is used.
+   */
+  shippingLineName?: string;
 }
 
 /**
@@ -48,7 +60,8 @@ export interface OrderToIssueInvoiceCommandInput {
 export function toIssueInvoiceCommand(
   input: OrderToIssueInvoiceCommandInput,
 ): IssueInvoiceCommand {
-  const { order, connectionId, buyerTaxId, documentType, idempotencyKey } = input;
+  const { order, connectionId, buyerTaxId, documentType, idempotencyKey, shippingLineName } =
+    input;
 
   // GROSS-only MVP: an `exclusive` (net) order would mislabel net as gross.
   // Fail loud rather than corrupt totals. Absent treatment = documented gross
@@ -66,7 +79,7 @@ export function toIssueInvoiceCommand(
   // order total, #1517). Emit it as a normal gross line so the provider adapter
   // resolves its tax rate the same way it does for product lines; core never
   // names a tax rate. Skipped when shipping is 0 (no phantom line).
-  const shippingLine = toShippingLine(order.totals.shipping);
+  const shippingLine = toShippingLine(order.totals.shipping, shippingLineName);
   if (shippingLine) {
     lines.push(shippingLine);
   }
@@ -199,14 +212,16 @@ function toInvoiceLine(item: OrderItem, orderId: string): InvoiceLine {
  * or `null` when there is nothing to bill (#1517). A single unit priced at the
  * gross shipping amount; `taxRate` is left empty (provider adapter resolves the
  * regime rate, mirroring {@link toInvoiceLine}). Non-positive or non-finite
- * shipping (0, negative, NaN) yields no line — no phantom shipping line.
+ * shipping (0, negative, NaN) yields no line — no phantom shipping line. `name`
+ * defaults to the neutral {@link SHIPPING_LINE_NAME} when the caller supplies no
+ * (locale-specific) override.
  */
-function toShippingLine(shipping: number): InvoiceLine | null {
+function toShippingLine(shipping: number, name?: string): InvoiceLine | null {
   if (!Number.isFinite(shipping) || shipping <= 0) {
     return null;
   }
   return {
-    name: SHIPPING_LINE_NAME,
+    name: name?.trim() || SHIPPING_LINE_NAME,
     quantity: 1,
     unitPriceGross: shipping,
     taxRate: '',

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.spec.ts
@@ -243,6 +243,57 @@ describe('AutoIssueTriggerService', () => {
     });
   });
 
+  describe('shipping-line label wiring (#1562)', () => {
+    // Order with a gross shipping cost so the mapper appends a shipping line.
+    const paidShippingOrder = (): Order =>
+      makeOrder({
+        paymentStatus: 'paid',
+        items: [{ id: 'i1', productId: 'p1', quantity: 1, price: 100, name: 'Widget' }],
+        totals: {
+          subtotal: 100,
+          tax: 0,
+          shipping: 10,
+          total: 110,
+          currency: 'PLN',
+          taxTreatment: 'inclusive',
+        },
+      });
+
+    const shippingLineName = (): string => {
+      const lines = (
+        syncJobs.schedule.mock.calls[0][0].payload as { lines: Array<{ name: string }> }
+      ).lines;
+      return lines[lines.length - 1].name;
+    };
+
+    it("threads config.invoicing.shippingLineName into the payload's shipping line", async () => {
+      connectionPort.list.mockResolvedValue([
+        makeConnection('auto-on-paid', {
+          config: { invoicing: { triggerModel: 'auto-on-paid', shippingLineName: 'Koszt wysyłki' } },
+        }),
+      ]);
+      await service.onOrderTransition(paidShippingOrder(), 'src-1');
+      expect(syncJobs.schedule).toHaveBeenCalledTimes(1);
+      expect(shippingLineName()).toBe('Koszt wysyłki');
+    });
+
+    it('falls back to the neutral default label when no shippingLineName is configured', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      await service.onOrderTransition(paidShippingOrder(), 'src-1');
+      expect(shippingLineName()).toBe('Shipping');
+    });
+
+    it('ignores a blank shippingLineName and uses the neutral default', async () => {
+      connectionPort.list.mockResolvedValue([
+        makeConnection('auto-on-paid', {
+          config: { invoicing: { triggerModel: 'auto-on-paid', shippingLineName: '   ' } },
+        }),
+      ]);
+      await service.onOrderTransition(paidShippingOrder(), 'src-1');
+      expect(shippingLineName()).toBe('Shipping');
+    });
+  });
+
   describe('per-connection isolation + PII-safe catch (F9/D11)', () => {
     it('a connection whose composition throws InvalidBuyerProfileError is skipped; others still enqueue', async () => {
       connectionPort.list.mockResolvedValue([

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
@@ -232,6 +232,10 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
   ): InvoicingIssuePayloadV1 {
     // The mapper owns the neutral Order->command rules and may surface
     // InvalidBuyerProfileError / UnsupportedPriceTreatmentError (both PII-clean).
+    // `shippingLineName` is intentionally NOT passed: there is no locale source
+    // here (a Connection carries no locale; config.invoicing holds only
+    // triggerModel), so the mapper's neutral default is used. A localized label
+    // would be threaded here once a locale/provider source exists (#1562).
     const command = toIssueInvoiceCommand({
       order,
       connectionId: invoicingConnectionId,

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
@@ -46,6 +46,7 @@ import { Logger } from '@openlinker/shared/logging';
 import type { IAutoIssueTriggerService } from './auto-issue-trigger.service.interface';
 import type { InvoiceTriggerModel } from '../../domain/types/invoice-trigger.types';
 import { parseTriggerModel } from '../../domain/types/invoice-trigger.types';
+import { normalizeShippingLineName } from '../../domain/types/shipping-line-label.types';
 import { toIssueInvoiceCommand } from '../mappers/order-to-issue-invoice-command.mapper';
 import { BatchedTriggerNotImplementedError } from '../../domain/exceptions/batched-trigger-not-implemented.error';
 import type { InvoicingIssuePayloadV1 } from '@openlinker/core/sync';
@@ -283,13 +284,10 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
 
   /**
    * Read the connection's optional operator-supplied shipping-line label
-   * (#1562). Narrowed to a non-empty string: `config.invoicing` is a passthrough
-   * JSONB shape, so a non-string / blank value defers to the mapper's neutral
-   * default rather than being forwarded. No language / `platformType` logic here
-   * (ADR-026) - the value is whatever the operator stored.
+   * (#1562), narrowed via the shared {@link normalizeShippingLineName} coercion
+   * so this reader and the HTTP controller's cannot drift.
    */
   private readShippingLineName(connection: Connection): string | undefined {
-    const value = connection.config.invoicing?.shippingLineName;
-    return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+    return normalizeShippingLineName(connection.config.invoicing?.shippingLineName);
   }
 }

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
@@ -31,6 +31,7 @@ import {
   ConnectionPort,
   CONNECTION_PORT_TOKEN,
 } from '@openlinker/core/identifier-mapping';
+import type { Connection } from '@openlinker/core/identifier-mapping';
 import {
   ISyncJobsService,
   SYNC_JOBS_SERVICE_TOKEN,
@@ -133,6 +134,7 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
           triggerModel,
           sourceConnectionId,
           sourceEventId,
+          this.readShippingLineName(connection),
         );
 
         await this.syncJobs.schedule({
@@ -229,17 +231,21 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
     triggerModel: InvoiceTriggerModel,
     sourceConnectionId: string,
     sourceEventId?: string,
+    shippingLineName?: string,
   ): InvoicingIssuePayloadV1 {
     // The mapper owns the neutral Order->command rules and may surface
     // InvalidBuyerProfileError / UnsupportedPriceTreatmentError (both PII-clean).
-    // `shippingLineName` is intentionally NOT passed: there is no locale source
-    // here (a Connection carries no locale; config.invoicing holds only
-    // triggerModel), so the mapper's neutral default is used. A localized label
-    // would be threaded here once a locale/provider source exists (#1562).
+    // #1562: thread the operator's per-connection shipping-line label into the
+    // mapper's gross shipping line. Country-agnostic (ADR-026) - core forwards
+    // an opaque operator string, never a language it chose. The worker replays
+    // `payload.lines` verbatim, so the label MUST be baked here, where the
+    // Connection is in hand; a blank/absent value defers to the mapper's neutral
+    // `SHIPPING_LINE_NAME` default.
     const command = toIssueInvoiceCommand({
       order,
       connectionId: invoicingConnectionId,
       idempotencyKey,
+      shippingLineName,
     });
 
     // #12: flatten the BuyerProfile class into the PLAIN, jsonb-safe field-set.
@@ -273,5 +279,17 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
     }
 
     return payload;
+  }
+
+  /**
+   * Read the connection's optional operator-supplied shipping-line label
+   * (#1562). Narrowed to a non-empty string: `config.invoicing` is a passthrough
+   * JSONB shape, so a non-string / blank value defers to the mapper's neutral
+   * default rather than being forwarded. No language / `platformType` logic here
+   * (ADR-026) - the value is whatever the operator stored.
+   */
+  private readShippingLineName(connection: Connection): string | undefined {
+    const value = connection.config.invoicing?.shippingLineName;
+    return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
   }
 }

--- a/libs/core/src/invoicing/domain/types/shipping-line-label.types.spec.ts
+++ b/libs/core/src/invoicing/domain/types/shipping-line-label.types.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Unit tests for {@link normalizeShippingLineName} (#1562 / #1565 review).
+ */
+import { normalizeShippingLineName } from './shipping-line-label.types';
+
+describe('normalizeShippingLineName', () => {
+  it('returns the value when it is a non-empty string', () => {
+    expect(normalizeShippingLineName('Koszt wysyłki')).toBe('Koszt wysyłki');
+  });
+
+  it('preserves the original (untrimmed) value when it has non-blank content', () => {
+    expect(normalizeShippingLineName('  Koszt wysyłki  ')).toBe('  Koszt wysyłki  ');
+  });
+
+  it('returns undefined for a blank / whitespace-only string', () => {
+    expect(normalizeShippingLineName('')).toBeUndefined();
+    expect(normalizeShippingLineName('   ')).toBeUndefined();
+  });
+
+  it('returns undefined for non-string JSONB values', () => {
+    expect(normalizeShippingLineName(undefined)).toBeUndefined();
+    expect(normalizeShippingLineName(null)).toBeUndefined();
+    expect(normalizeShippingLineName(42)).toBeUndefined();
+    expect(normalizeShippingLineName({ label: 'x' })).toBeUndefined();
+  });
+});

--- a/libs/core/src/invoicing/domain/types/shipping-line-label.types.ts
+++ b/libs/core/src/invoicing/domain/types/shipping-line-label.types.ts
@@ -1,0 +1,23 @@
+/**
+ * Shipping-Line Label Coercion
+ *
+ * Single source of truth for narrowing an untrusted per-connection shipping-line
+ * label (`config.invoicing.shippingLineName`, #1562) into an issuance override.
+ * `config.invoicing` is a passthrough JSONB shape, so a non-string / blank value
+ * defers to the mapper's neutral default rather than being forwarded. Shared by
+ * both issuance readers (the auto-issue trigger and the HTTP controller) so the
+ * two narrowings cannot drift. Country-agnostic (ADR-026) — no language /
+ * `platformType` logic; the value is whatever the operator stored.
+ *
+ * @module libs/core/src/invoicing/domain/types
+ */
+
+/**
+ * Narrow an untrusted `config.invoicing.shippingLineName` value to a non-empty
+ * (trimmed) string, or `undefined` when absent / non-string / blank — in which
+ * case the mapper's neutral `SHIPPING_LINE_NAME` default applies. Returns the
+ * original (untrimmed) value; the mapper trims at compose time.
+ */
+export function normalizeShippingLineName(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}

--- a/libs/core/src/invoicing/index.ts
+++ b/libs/core/src/invoicing/index.ts
@@ -14,6 +14,7 @@ export {
   parseTriggerModel,
 } from './domain/types/invoice-trigger.types';
 export type { InvoiceTriggerModel } from './domain/types/invoice-trigger.types';
+export { normalizeShippingLineName } from './domain/types/shipping-line-label.types';
 export * from './domain/entities/buyer-profile.entity';
 export * from './domain/entities/invoice-record.entity';
 export * from './domain/ports/invoicing.port';


### PR DESCRIPTION
## Overview

Integration branch bundling the reviewed invoicing work under the inFakt epic (#1279). Each child PR was merged into `epic/1279-infakt` after two independent review rounds with all findings resolved; this is the single PR that lands the batch on `main`.

## What is included

- **#1517 (fix)** - The order -> `IssueInvoiceCommand` mapper now appends a neutral gross shipping line when `order.totals.shipping > 0`, so the invoice gross total equals the buyer-paid order total. Core-only; provider adapters (inFakt/KSeF/Subiekt) consume `cmd.lines` verbatim. The shipping-line `taxRate` is left empty so the provider resolves the regime rate exactly as it does for product lines.
- **#1562 (feat)** - Wires a neutral, per-connection `config.invoicing.shippingLineName` override at both issuance entry points (`AutoIssueTriggerService` + `InvoicingController`), so the shipping-line label can be operator-supplied without core hardcoding a language (ADR-026 compliant - core forwards an opaque string, no `platformType` switch). The neutral English default is unchanged when no override is set.
- **#1509 (test)** - Adds an inbound-webhook ingestion integration test for the inFakt integration (previously unit-only), driving the real Nest app + Testcontainers Postgres/Redis end-to-end: HMAC verify -> dedup -> publish -> translate -> route, plus wrong-signature rejection and the subscription-verification handshake.

## Review

All three merged PRs (#1546, #1555, #1565) received two independent systematic review rounds and ended at APPROVE with zero open BLOCKING/IMPORTANT/SUGGESTION items. Cross-context import invariants pass; no migration required (the config field is additive JSONB).

Closes #1517
Closes #1509
Closes #1562

Part of #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
