### PR TITLE
[EPIC] Integration - WooCommerce integration parity with PrestaShop

### DIFF
--- a/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
+++ b/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
@@ -205,15 +205,13 @@ describe('createWooCommercePlugin → register(host) — #876 additions', () => 
 });
 
 describe('WooCommerceIntegrationModule', () => {
-  // The module is a top-level `DynamicModule` const built by
-  // `createNestAdapterModule({ plugin: createWooCommercePlugin() })`, so merely
-  // importing this spec already exercises the composition — a regression there
-  // throws at module load. These assertions lock the composed shape so the
-  // breakage surfaces at unit speed (#1023; no host bootstrap required).
-  it('composes a DynamicModule (host module class + framework imports)', () => {
-    expect(WooCommerceIntegrationModule.module).toBeDefined();
-    expect(typeof WooCommerceIntegrationModule.module).toBe('function');
-    expect(Array.isArray(WooCommerceIntegrationModule.imports)).toBe(true);
-    expect(WooCommerceIntegrationModule.imports!.length).toBeGreaterThan(0);
+  // Since #1552 the module is a bespoke `@Module` class (Shape A) — it provides
+  // the customer + address provisioners and builds the descriptor with those
+  // plugin-specific deps in `onModuleInit`, mirroring PrestaShop. Importing this
+  // spec exercises the decorator metadata; a class-shape regression surfaces at
+  // unit speed (no host bootstrap required).
+  it('is a NestJS module class implementing onModuleInit', () => {
+    expect(typeof WooCommerceIntegrationModule).toBe('function');
+    expect(typeof WooCommerceIntegrationModule.prototype.onModuleInit).toBe('function');
   });
 });

--- a/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
+++ b/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
@@ -24,6 +24,7 @@ interface HostStub {
   credentialsRegistry: { register: jest.Mock };
   authFailureRegistry: { register: jest.Mock };
   schedulerRegistry: { register: jest.Mock };
+  translatorRegistry: { register: jest.Mock };
 }
 
 function makeHostStub(): HostStub {
@@ -32,6 +33,7 @@ function makeHostStub(): HostStub {
   const credentialsRegistry = { register: jest.fn() };
   const authFailureRegistry = { register: jest.fn() };
   const schedulerRegistry = { register: jest.fn() };
+  const translatorRegistry = { register: jest.fn() };
 
   const host = {
     connectionTesterRegistry: testerRegistry,
@@ -42,6 +44,7 @@ function makeHostStub(): HostStub {
     authFailureClassifierRegistry: authFailureRegistry,
     schedulerTaskRegistry: schedulerRegistry,
     webhookProvisioningRegistry: { register: jest.fn() },
+    webhookEventTranslatorRegistry: translatorRegistry,
     oauthCompletionRegistry: { register: jest.fn() },
     adapterRegistry: { register: jest.fn() },
     factoryResolver: { registerFactory: jest.fn() },
@@ -55,7 +58,15 @@ function makeHostStub(): HostStub {
     } as unknown as HostServices['credentialsResolver'],
   } as unknown as HostServices;
 
-  return { host, testerRegistry, configRegistry, credentialsRegistry, authFailureRegistry, schedulerRegistry };
+  return {
+    host,
+    testerRegistry,
+    configRegistry,
+    credentialsRegistry,
+    authFailureRegistry,
+    schedulerRegistry,
+    translatorRegistry,
+  };
 }
 
 const mockConnection: Connection = {
@@ -200,6 +211,17 @@ describe('createWooCommercePlugin → register(host) — #876 additions', () => 
     createWooCommercePlugin().register!(host);
     expect(schedulerRegistry.register).toHaveBeenCalledWith(
       expect.objectContaining({ taskId: 'woocommerce-orders-poll' }),
+    );
+  });
+});
+
+describe('createWooCommercePlugin → register(host) — #1548 inbound webhooks', () => {
+  it('should register the webhook event translator at the plugin adapterKey', () => {
+    const { host, translatorRegistry } = makeHostStub();
+    createWooCommercePlugin().register!(host);
+    expect(translatorRegistry.register).toHaveBeenCalledWith(
+      'woocommerce.restapi.v3',
+      expect.objectContaining({ translate: expect.any(Function) }),
     );
   });
 });

--- a/libs/integrations/woocommerce/src/domain/types/woocommerce-config.types.ts
+++ b/libs/integrations/woocommerce/src/domain/types/woocommerce-config.types.ts
@@ -43,4 +43,18 @@ export interface WooCommerceConnectionConfig {
 
   /** OrderSource capability configuration (#876). */
   orders?: WooCommerceOrdersConfig;
+
+  // Base URL of this OpenLinker instance, where WooCommerce POSTs inbound
+  // webhook deliveries (e.g. http://host.docker.internal:3000 in dev, the
+  // public OL URL in prod). Required before webhook provisioning (#1548) —
+  // WooCommerceWebhookProvisioningAdapter builds each webhook's delivery_url
+  // as `${openlinkerCallbackBaseUrl}/webhooks/woocommerce/${connectionId}`.
+  // Left off the config-shape DTO on purpose: the provisioning adapter is the
+  // single point that validates presence, mirroring the PrestaShop flow.
+  openlinkerCallbackBaseUrl?: string;
+
+  // Set true by WooCommerceWebhookProvisioningAdapter once webhooks are
+  // registered on the store (#1548). Advisory flag surfaced in the FE
+  // connection-actions UI; the reconciliation poll backstops regardless.
+  webhooksConfigured?: boolean;
 }

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-event-translator.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-event-translator.adapter.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * WooCommerce Webhook Event Translator Adapter Unit Tests (#1548)
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/__tests__
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+import { WooCommerceWebhookEventTranslatorAdapter } from '../woocommerce-webhook-event-translator.adapter';
+
+describe('WooCommerceWebhookEventTranslatorAdapter', () => {
+  const translator = new WooCommerceWebhookEventTranslatorAdapter();
+
+  const event = (overrides: Partial<InboundWebhookEvent>): InboundWebhookEvent => ({
+    eventId: 'evt-1',
+    provider: 'woocommerce',
+    connectionId: 'conn-1',
+    eventType: 'order.created',
+    occurredAt: '2026-01-01T00:00:00.000Z',
+    receivedAt: '2026-01-01T00:00:01.000Z',
+    objectType: 'order',
+    externalId: '42',
+    payload: {},
+    ...overrides,
+  });
+
+  it('should translate order.created to the order domain with created', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'order.created' }));
+
+    expect(result).toEqual({
+      domain: 'order',
+      externalId: '42',
+      eventType: 'created',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      payload: {},
+    });
+  });
+
+  it('should map order.updated to updated', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'order.updated' }));
+
+    expect(result?.domain).toBe('order');
+    expect(result?.eventType).toBe('updated');
+  });
+
+  it('should map order.deleted to cancelled', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'order.deleted' }));
+
+    expect(result?.eventType).toBe('cancelled');
+  });
+
+  it('should accept the bare action form (created) without the topic prefix', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'created' }));
+
+    expect(result?.eventType).toBe('created');
+  });
+
+  it('should default an unknown order event type to updated', () => {
+    const result = translator.translate(event({ objectType: 'order', eventType: 'order.weird' }));
+
+    expect(result?.eventType).toBe('updated');
+  });
+
+  it('should be case-insensitive on objectType', () => {
+    const result = translator.translate(event({ objectType: 'ORDER', eventType: 'order.created' }));
+
+    expect(result?.domain).toBe('order');
+  });
+
+  it('should preserve externalId and payload', () => {
+    const result = translator.translate(
+      event({ objectType: 'order', externalId: '777', payload: { id: 777, status: 'processing' } }),
+    );
+
+    expect(result?.externalId).toBe('777');
+    expect(result?.payload).toEqual({ id: 777, status: 'processing' });
+  });
+
+  it('should return null for an unknown object type (undecodable -> dead-letter)', () => {
+    expect(translator.translate(event({ objectType: 'product' }))).toBeNull();
+    expect(translator.translate(event({ objectType: 'coupon' }))).toBeNull();
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-event-translator.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-event-translator.adapter.spec.ts
@@ -41,10 +41,12 @@ describe('WooCommerceWebhookEventTranslatorAdapter', () => {
     expect(result?.eventType).toBe('updated');
   });
 
-  it('should map order.deleted to cancelled', () => {
+  it('should default a non-create order event (e.g. order.deleted) to updated', () => {
+    // Only order.created / order.updated are provisioned, so anything that
+    // isn't a create falls back to a safe re-pull (updated).
     const result = translator.translate(event({ objectType: 'order', eventType: 'order.deleted' }));
 
-    expect(result?.eventType).toBe('cancelled');
+    expect(result?.eventType).toBe('updated');
   });
 
   it('should accept the bare action form (created) without the topic prefix', () => {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-provisioning.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-provisioning.adapter.spec.ts
@@ -146,6 +146,42 @@ describe('WooCommerceWebhookProvisioningAdapter', () => {
       const created = (mockHttpClient.post.mock.calls[0] as unknown[])[1] as { topic: string };
       expect(created.topic).toBe('order.updated');
     });
+
+    it('pages the existing-webhook listing until exhausted so a match past page 1 is not duplicated', async () => {
+      const deliveryUrl = 'https://api.openlinker.example/webhooks/woocommerce/connection-123';
+      // A full first page (100 unrelated rows) forces a second page fetch; the
+      // OL match sits on page 2, so a single-page listing would have missed it.
+      const fullFirstPage = Array.from({ length: 100 }, (_, i) => ({
+        id: 1000 + i,
+        topic: 'product.updated',
+        delivery_url: `https://other.example/${i}`,
+      }));
+      const secondPage = [{ id: 77, topic: 'order.created', delivery_url: deliveryUrl }];
+      mockHttpClient.get
+        .mockResolvedValueOnce(fullFirstPage)
+        .mockResolvedValueOnce(secondPage);
+
+      await adapter.install('connection-123');
+
+      // Two pages read (full page 1 -> keep paging; short page 2 -> stop).
+      expect(mockHttpClient.get).toHaveBeenCalledTimes(2);
+      expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+        1,
+        '/wp-json/wc/v3/webhooks',
+        expect.objectContaining({ page: 1 }),
+      );
+      expect(mockHttpClient.get).toHaveBeenNthCalledWith(
+        2,
+        '/wp-json/wc/v3/webhooks',
+        expect.objectContaining({ page: 2 }),
+      );
+      // The page-2 match is updated (not duplicated); only order.updated is POSTed.
+      expect(mockHttpClient.put).toHaveBeenCalledWith(
+        '/wp-json/wc/v3/webhooks/77',
+        expect.objectContaining({ topic: 'order.created' }),
+      );
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('input validation', () => {
@@ -191,16 +227,22 @@ describe('WooCommerceWebhookProvisioningAdapter', () => {
   });
 
   describe('failure modes', () => {
-    it('throws and does not mark configured when the WC push fails', async () => {
-      mockHttpClient.get.mockRejectedValueOnce(new Error('WC 401'));
+    it('throws and fail-closed resets webhooksConfigured to false when the WC push fails', async () => {
+      mockHttpClient.get.mockRejectedValue(new Error('WC 401'));
 
       await expect(adapter.install('connection-123')).rejects.toThrow(
         /WooCommerce webhook registration failed/,
       );
 
-      // Secret was rotated; connection.update was NOT called (push failed before).
+      // Secret was rotated; the persisted flag is fail-closed reset to false so a
+      // prior `true` doesn't go stale (mirrors the Erli adapter).
       expect(webhookSecretService.rotate).toHaveBeenCalled();
-      expect(connectionPort.update).not.toHaveBeenCalled();
+      expect(connectionPort.update).toHaveBeenCalledWith(
+        'connection-123',
+        expect.objectContaining({
+          config: expect.objectContaining({ webhooksConfigured: false }),
+        }),
+      );
     });
 
     it('returns warning=state-update-failed when connection.update fails after push', async () => {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-provisioning.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-webhook-provisioning.adapter.spec.ts
@@ -1,0 +1,216 @@
+/**
+ * WooCommerce Webhook Provisioning Adapter — Unit Tests (#1548)
+ *
+ * Covers the orchestrator branches: happy path (create), idempotent upsert
+ * (update existing), missing callback URL, missing siteUrl, WC push failure,
+ * and state-update failure.
+ *
+ * The WC HTTP client is constructed inside the adapter (not injected), so the
+ * underlying constructor is stubbed via the module path.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/__tests__
+ */
+import { BadRequestException } from '@nestjs/common';
+import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
+import { Connection } from '@openlinker/core/identifier-mapping';
+import type { IWebhookSecretService, CredentialsResolverPort } from '@openlinker/core/integrations';
+import { WooCommerceWebhookProvisioningAdapter } from '../woocommerce-webhook-provisioning.adapter';
+import * as httpClientModule from '../../http/woocommerce-http-client';
+
+describe('WooCommerceWebhookProvisioningAdapter', () => {
+  let adapter: WooCommerceWebhookProvisioningAdapter;
+  let connectionPort: jest.Mocked<ConnectionPort>;
+  let webhookSecretService: jest.Mocked<IWebhookSecretService>;
+  let credentialsResolver: jest.Mocked<CredentialsResolverPort>;
+  let mockHttpClient: {
+    get: jest.Mock;
+    post: jest.Mock;
+    put: jest.Mock;
+    delete: jest.Mock;
+  };
+
+  const baseConnection = new Connection(
+    'connection-123',
+    'woocommerce',
+    'Test Store',
+    'active',
+    {
+      siteUrl: 'https://store.example.com',
+      openlinkerCallbackBaseUrl: 'https://api.openlinker.example',
+    },
+    'db:cred-ref',
+    new Date(),
+    new Date(),
+    undefined,
+    ['OrderSource'],
+  );
+
+  beforeEach(() => {
+    connectionPort = {
+      get: jest.fn().mockResolvedValue(baseConnection),
+      update: jest.fn().mockResolvedValue(baseConnection),
+      list: jest.fn(),
+      create: jest.fn(),
+      disable: jest.fn(),
+    } as unknown as jest.Mocked<ConnectionPort>;
+
+    webhookSecretService = {
+      rotate: jest.fn().mockResolvedValue({ secret: 'rotated-secret-hex' }),
+    } as unknown as jest.Mocked<IWebhookSecretService>;
+
+    credentialsResolver = {
+      get: jest.fn().mockResolvedValue({ consumerKey: 'ck_x', consumerSecret: 'cs_y' }),
+    } as unknown as jest.Mocked<CredentialsResolverPort>;
+
+    mockHttpClient = {
+      // No existing webhooks in the happy path -> adapter falls into POST create.
+      get: jest.fn().mockResolvedValue([]),
+      post: jest.fn().mockResolvedValue({ id: 1 }),
+      put: jest.fn().mockResolvedValue({ id: 1 }),
+      delete: jest.fn(),
+    };
+    jest
+      .spyOn(httpClientModule, 'WooCommerceHttpClient')
+      .mockImplementation(() => mockHttpClient as never);
+
+    adapter = new WooCommerceWebhookProvisioningAdapter(
+      connectionPort,
+      webhookSecretService,
+      credentialsResolver,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('happy path', () => {
+    it('rotates secret, creates order webhooks, marks configured', async () => {
+      const result = await adapter.install('connection-123', 'user-1');
+
+      expect(webhookSecretService.rotate).toHaveBeenCalledWith(
+        'woocommerce',
+        'connection-123',
+        'user-1',
+      );
+
+      // Lists existing once, then POSTs one webhook per order topic.
+      expect(mockHttpClient.get).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(2);
+
+      const topics = mockHttpClient.post.mock.calls.map((c: unknown[]) => {
+        const body = c[1] as { topic: string };
+        return body.topic;
+      });
+      expect(topics).toEqual(['order.created', 'order.updated']);
+
+      // Each webhook targets OL's ingress with the rotated secret + active status.
+      for (const call of mockHttpClient.post.mock.calls as unknown[][]) {
+        const body = call[1] as Record<string, unknown>;
+        expect(body.delivery_url).toBe(
+          'https://api.openlinker.example/webhooks/woocommerce/connection-123',
+        );
+        expect(body.secret).toBe('rotated-secret-hex');
+        expect(body.status).toBe('active');
+      }
+
+      expect(connectionPort.update).toHaveBeenCalledWith(
+        'connection-123',
+        expect.objectContaining({
+          config: expect.objectContaining({ webhooksConfigured: true }),
+        }),
+      );
+
+      // WooCommerce has no synchronous verifiable ping -> false, no warning.
+      expect(result).toEqual({ webhooksConfigured: true, testPingTriggered: false });
+    });
+
+    it('updates an existing webhook (matched by topic + delivery_url) instead of duplicating', async () => {
+      mockHttpClient.get.mockResolvedValue([
+        {
+          id: 55,
+          topic: 'order.created',
+          delivery_url: 'https://api.openlinker.example/webhooks/woocommerce/connection-123',
+        },
+      ]);
+
+      await adapter.install('connection-123');
+
+      expect(mockHttpClient.put).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.put).toHaveBeenCalledWith(
+        '/wp-json/wc/v3/webhooks/55',
+        expect.objectContaining({ topic: 'order.created', status: 'active' }),
+      );
+      // Only the unmatched topic (order.updated) is created.
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+      const created = (mockHttpClient.post.mock.calls[0] as unknown[])[1] as { topic: string };
+      expect(created.topic).toBe('order.updated');
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws BadRequestException when openlinkerCallbackBaseUrl is unset', async () => {
+      connectionPort.get.mockResolvedValue(
+        new Connection(
+          'connection-123',
+          'woocommerce',
+          'Test',
+          'active',
+          { siteUrl: 'https://store.example.com' },
+          'db:cred',
+          new Date(),
+          new Date(),
+          undefined,
+          [],
+        ),
+      );
+
+      await expect(adapter.install('connection-123')).rejects.toThrow(BadRequestException);
+      await expect(adapter.install('connection-123')).rejects.toThrow(/OL callback URL/);
+      expect(webhookSecretService.rotate).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when siteUrl is missing from config', async () => {
+      connectionPort.get.mockResolvedValue(
+        new Connection(
+          'connection-123',
+          'woocommerce',
+          'Test',
+          'active',
+          { openlinkerCallbackBaseUrl: 'https://api.openlinker.example' },
+          'db:cred',
+          new Date(),
+          new Date(),
+          undefined,
+          [],
+        ),
+      );
+
+      await expect(adapter.install('connection-123')).rejects.toThrow(/siteUrl/);
+    });
+  });
+
+  describe('failure modes', () => {
+    it('throws and does not mark configured when the WC push fails', async () => {
+      mockHttpClient.get.mockRejectedValueOnce(new Error('WC 401'));
+
+      await expect(adapter.install('connection-123')).rejects.toThrow(
+        /WooCommerce webhook registration failed/,
+      );
+
+      // Secret was rotated; connection.update was NOT called (push failed before).
+      expect(webhookSecretService.rotate).toHaveBeenCalled();
+      expect(connectionPort.update).not.toHaveBeenCalled();
+    });
+
+    it('returns warning=state-update-failed when connection.update fails after push', async () => {
+      connectionPort.update.mockRejectedValue(new Error('DB write failed'));
+
+      const result = await adapter.install('connection-123');
+
+      expect(result.webhooksConfigured).toBe(false);
+      expect(result.testPingTriggered).toBe(false);
+      expect(result.warning).toBe('state-update-failed');
+    });
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/inventory-master/woocommerce-inventory-master.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/inventory-master/woocommerce-inventory-master.adapter.ts
@@ -27,6 +27,7 @@ import { WooCommerceResourceNotFoundException } from '../../../domain/exceptions
 import { WooCommerceNotSupportedException } from '../../../domain/exceptions/woocommerce-not-supported.exception';
 import { WooCommerceInvalidIdentifierException } from '../../../domain/exceptions/woocommerce-invalid-identifier.exception';
 import { fetchAllPages, toPositiveInt } from '../../utils/woocommerce-utils';
+import { buildSyntheticVariantExternalId } from '../../mappers/woocommerce-variant-id';
 import {
   DEFAULT_UNMANAGED_STOCK_QUANTITY,
   type WooCommerceConnectionConfig,
@@ -192,7 +193,7 @@ export class WooCommerceInventoryMasterAdapter implements InventoryMasterPort {
     wcId: number,
     product: WooCommerceProduct,
   ): Promise<Inventory[]> {
-    const syntheticExternalId = `product:${wcId}`;
+    const syntheticExternalId = buildSyntheticVariantExternalId(wcId);
     const variantId = await this.identifierMapping.getOrCreateInternalId(
       CORE_ENTITY_TYPE.ProductVariant,
       syntheticExternalId,
@@ -281,7 +282,7 @@ export class WooCommerceInventoryMasterAdapter implements InventoryMasterPort {
     const [variantId, inventoryId] = await Promise.all([
       this.identifierMapping.getOrCreateInternalId(
         CORE_ENTITY_TYPE.ProductVariant,
-        `product:${wcId}`,
+        buildSyntheticVariantExternalId(wcId),
         this.connection.id,
         { parentEntityType: CORE_ENTITY_TYPE.Product, parentInternalId: adjustment.productId },
       ),

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-fulfillment-status.mapper.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-fulfillment-status.mapper.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * WooCommerce Fulfillment Status Mapper — unit tests
+ *
+ * Pure-function coverage of the WC → neutral fulfillment status mapping
+ * (#1550). No adapter or HTTP client instantiation needed.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__
+ */
+import {
+  mapWooCommerceStatus,
+  mapToFulfillmentStatusSnapshot,
+  WC_FULFILLMENT_STATUS_MAP,
+} from '../woocommerce-fulfillment-status.mapper';
+import { WC_ORDER_STATUS_VALUES } from '../woocommerce-order-status.types';
+import { FULFILLMENT_STATUS } from '@openlinker/core/orders';
+
+describe('WooCommerceFulfillmentStatusMapper', () => {
+  describe('mapWooCommerceStatus', () => {
+    it.each([
+      ['pending', null],
+      ['processing', null],
+      ['on-hold', null],
+      ['failed', null],
+      ['completed', FULFILLMENT_STATUS.Delivered],
+      ['cancelled', FULFILLMENT_STATUS.Cancelled],
+      ['refunded', FULFILLMENT_STATUS.Cancelled],
+    ] as const)('should map WC status "%s" to neutral %s', (wcStatus, expected) => {
+      expect(mapWooCommerceStatus(wcStatus)).toBe(expected);
+    });
+
+    it('should map an unknown status to null', () => {
+      expect(mapWooCommerceStatus('checkout-draft')).toBeNull();
+    });
+
+    it('should map an absent status to null', () => {
+      expect(mapWooCommerceStatus(undefined)).toBeNull();
+    });
+
+    it('should have a mapping entry for every WC status in the shared vocabulary', () => {
+      for (const status of WC_ORDER_STATUS_VALUES) {
+        expect(WC_FULFILLMENT_STATUS_MAP).toHaveProperty(status);
+      }
+    });
+  });
+
+  describe('mapToFulfillmentStatusSnapshot', () => {
+    it('should return delivered with deliveredAt from date_completed_gmt for a completed order', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({
+        id: 1,
+        status: 'completed',
+        date_completed_gmt: '2026-07-14T10:30:00',
+      });
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Delivered);
+      expect(snapshot.trackingNumber).toBeNull();
+      expect(snapshot.deliveredAt).toEqual(new Date('2026-07-14T10:30:00Z'));
+    });
+
+    it('should fall back to date_modified_gmt for deliveredAt when date_completed_gmt is absent', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({
+        id: 1,
+        status: 'completed',
+        date_modified_gmt: '2026-07-13T08:00:00',
+      });
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Delivered);
+      expect(snapshot.deliveredAt).toEqual(new Date('2026-07-13T08:00:00Z'));
+    });
+
+    it('should return delivered with null deliveredAt when no completion timestamp is present', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({ id: 1, status: 'completed' });
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Delivered);
+      expect(snapshot.deliveredAt).toBeNull();
+    });
+
+    it('should return cancelled with null deliveredAt for a cancelled order', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({ id: 1, status: 'cancelled' });
+
+      expect(snapshot).toEqual({
+        status: FULFILLMENT_STATUS.Cancelled,
+        trackingNumber: null,
+        deliveredAt: null,
+      });
+    });
+
+    it('should return cancelled for a refunded order', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({ id: 1, status: 'refunded' });
+
+      expect(snapshot.status).toBe(FULFILLMENT_STATUS.Cancelled);
+      expect(snapshot.deliveredAt).toBeNull();
+    });
+
+    it('should return null status for a pre-fulfillment (processing) order', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({ id: 1, status: 'processing' });
+
+      expect(snapshot).toEqual({ status: null, trackingNumber: null, deliveredAt: null });
+    });
+
+    it('should not populate deliveredAt for a non-delivered status even when a timestamp exists', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({
+        id: 1,
+        status: 'cancelled',
+        date_modified_gmt: '2026-07-14T10:30:00',
+      });
+
+      expect(snapshot.deliveredAt).toBeNull();
+    });
+
+    it('should honour an explicit timezone offset on the completion timestamp', () => {
+      const snapshot = mapToFulfillmentStatusSnapshot({
+        id: 1,
+        status: 'completed',
+        date_completed_gmt: '2026-07-14T12:30:00+02:00',
+      });
+
+      expect(snapshot.deliveredAt).toEqual(new Date('2026-07-14T10:30:00Z'));
+    });
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
@@ -13,7 +13,8 @@ import {
   isValidEmail,
 } from '../woocommerce-order-processor.adapter';
 import { toPositiveInt } from '../../../utils/woocommerce-utils';
-import { WC_ORDER_STATUS_MAP } from '../woocommerce-order.types';
+import { WC_ORDER_STATUS_MAP, WC_ORDER_STATUS_VALUES } from '../woocommerce-order.types';
+import { isOrderStatusWriteback } from '@openlinker/core/orders';
 import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-client.interface';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
@@ -134,6 +135,26 @@ describe('WC_ORDER_STATUS_MAP', () => {
 
   it('should map shipped and delivered both to completed', () => {
     expect(WC_ORDER_STATUS_MAP.shipped).toBe(WC_ORDER_STATUS_MAP.delivered);
+  });
+});
+
+describe('WC_ORDER_STATUS_VALUES', () => {
+  it('should expose the WooCommerce core status vocabulary', () => {
+    expect(WC_ORDER_STATUS_VALUES).toEqual([
+      'pending',
+      'processing',
+      'on-hold',
+      'completed',
+      'cancelled',
+      'refunded',
+      'failed',
+    ]);
+  });
+
+  it('should contain every value produced by the neutral → WC map', () => {
+    for (const wcStatus of Object.values(WC_ORDER_STATUS_MAP)) {
+      expect(WC_ORDER_STATUS_VALUES).toContain(wcStatus);
+    }
   });
 });
 
@@ -806,5 +827,114 @@ describe('WooCommerceOrderProcessorAdapter — updateFulfillment', () => {
     ).resolves.toBeUndefined();
     const [, payload] = httpClient.put.mock.calls[0];
     expect(payload).not.toHaveProperty('tracking_number');
+  });
+});
+
+// ─── OrderStatusWriteback (write) ────────────────────────────────────────────
+
+describe('WooCommerceOrderProcessorAdapter — OrderStatusWriteback', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should be detected by the isOrderStatusWriteback guard', () => {
+    const adapter = makeAdapter(makeHttpClient(), makeIdentifierMapping());
+    expect(isOrderStatusWriteback(adapter)).toBe(true);
+  });
+
+  // ── dispatched ──
+
+  it('should PUT status completed for a dispatched event', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.put.mockResolvedValue({ id: 55, status: 'completed' });
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({ type: 'dispatched', externalOrderId: '55' });
+
+    expect(httpClient.put).toHaveBeenCalledWith('/wp-json/wc/v3/orders/55', { status: 'completed' });
+    expect(result).toEqual({ outcome: 'applied' });
+  });
+
+  it('should accept a trackingNumber on a dispatched event without failing', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.put.mockResolvedValue({ id: 55, status: 'completed' });
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({
+      type: 'dispatched',
+      externalOrderId: '55',
+      trackingNumber: 'TRACK123',
+    });
+
+    expect(result).toEqual({ outcome: 'applied' });
+    const [, payload] = httpClient.put.mock.calls[0];
+    expect(payload).not.toHaveProperty('tracking_number');
+  });
+
+  // ── cancelled ──
+
+  it('should read the order then PUT status cancelled for a cancelled event', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: 55, status: 'processing' });
+    httpClient.put.mockResolvedValue({ id: 55, status: 'cancelled' });
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({ type: 'cancelled', externalOrderId: '55' });
+
+    expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/orders/55');
+    expect(httpClient.put).toHaveBeenCalledWith('/wp-json/wc/v3/orders/55', { status: 'cancelled' });
+    expect(result).toEqual({ outcome: 'applied' });
+  });
+
+  it.each(['completed', 'refunded'])(
+    'should reject a cancel writeback when WC is already %s (no PUT)',
+    async (currentStatus) => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue({ id: 55, status: currentStatus });
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const result = await adapter.write({ type: 'cancelled', externalOrderId: '55' });
+
+      expect(result.outcome).toBe('rejected');
+      expect(result.detail).toContain(currentStatus);
+      expect(httpClient.put).not.toHaveBeenCalled();
+    },
+  );
+
+  it('should treat a cancel writeback as an idempotent no-op when already cancelled (no PUT)', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: 55, status: 'cancelled' });
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({ type: 'cancelled', externalOrderId: '55' });
+
+    expect(result).toEqual({ outcome: 'applied' });
+    expect(httpClient.put).not.toHaveBeenCalled();
+  });
+
+  // ── failure / validation ──
+
+  it.each(['1/refunds', 'abc', '', '-1'])(
+    'should reject (not throw) a non-numeric externalOrderId "%s"',
+    async (id) => {
+      const httpClient = makeHttpClient();
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const result = await adapter.write({ type: 'cancelled', externalOrderId: id });
+
+      expect(result.outcome).toBe('rejected');
+      expect(httpClient.get).not.toHaveBeenCalled();
+      expect(httpClient.put).not.toHaveBeenCalled();
+    },
+  );
+
+  it('should return rejected (never throw) when the WC PUT fails', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: 55, status: 'processing' });
+    httpClient.put.mockRejectedValue(new WooCommerceHttpResponseException(500, 'server error'));
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({ type: 'cancelled', externalOrderId: '55' });
+
+    expect(result.outcome).toBe('rejected');
+    expect(result.detail).toBeDefined();
   });
 });

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
@@ -14,7 +14,8 @@ import {
 } from '../woocommerce-order-processor.adapter';
 import { toPositiveInt } from '../../../utils/woocommerce-utils';
 import { WC_ORDER_STATUS_MAP, WC_ORDER_STATUS_VALUES } from '../woocommerce-order.types';
-import { isOrderStatusWriteback } from '@openlinker/core/orders';
+import { isOrderStatusWriteback, isDestinationOptionsReader } from '@openlinker/core/orders';
+import { WC_ORDER_STATUS_LABELS } from '../woocommerce-options.types';
 import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-client.interface';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
@@ -936,5 +937,112 @@ describe('WooCommerceOrderProcessorAdapter — OrderStatusWriteback', () => {
 
     expect(result.outcome).toBe('rejected');
     expect(result.detail).toBeDefined();
+  });
+});
+
+// ─── DestinationOptionsReader (#472 / #1551) ────────────────────────────────
+
+describe('WooCommerceOrderProcessorAdapter — DestinationOptionsReader', () => {
+  it('should satisfy the isDestinationOptionsReader guard', () => {
+    const adapter = makeAdapter(makeHttpClient(), makeIdentifierMapping());
+    expect(isDestinationOptionsReader(adapter)).toBe(true);
+  });
+
+  describe('listOrderStatuses', () => {
+    it('should return the full WC status vocabulary as neutral options with labels', async () => {
+      const adapter = makeAdapter(makeHttpClient(), makeIdentifierMapping());
+
+      const options = await adapter.listOrderStatuses();
+
+      expect(options.length).toBeGreaterThan(0);
+      expect(options).toContainEqual({ value: 'processing', label: 'Processing' });
+      expect(options).toContainEqual({ value: 'on-hold', label: 'On hold' });
+      // every option carries a non-empty label sourced from the shared label map
+      for (const option of options) {
+        expect(option.label).toBe(
+          WC_ORDER_STATUS_LABELS[option.value as keyof typeof WC_ORDER_STATUS_LABELS],
+        );
+        expect(option.label.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should not hit the network (static vocabulary)', async () => {
+      const httpClient = makeHttpClient();
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      await adapter.listOrderStatuses();
+
+      expect(httpClient.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listPaymentMethods', () => {
+    it('should map GET /payment_gateways rows to neutral options', async () => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue([
+        { id: 'bacs', title: 'Direct bank transfer', enabled: true },
+        { id: 'cod', title: 'Cash on delivery', enabled: false },
+      ]);
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const options = await adapter.listPaymentMethods();
+
+      expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/payment_gateways');
+      expect(options).toEqual([
+        { value: 'bacs', label: 'Direct bank transfer' },
+        { value: 'cod', label: 'Cash on delivery' },
+      ]);
+    });
+
+    it('should fall back to the gateway id when title is missing', async () => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue([{ id: 'paypal' }]);
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const options = await adapter.listPaymentMethods();
+
+      expect(options).toEqual([{ value: 'paypal', label: 'paypal' }]);
+    });
+  });
+
+  describe('listCarriers', () => {
+    it('should map GET /shipping_methods rows to neutral options', async () => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue([
+        { id: 'flat_rate', title: 'Flat rate' },
+        { id: 'free_shipping', title: 'Free shipping' },
+        { id: 'local_pickup', title: 'Local pickup' },
+      ]);
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const options = await adapter.listCarriers();
+
+      expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/shipping_methods');
+      expect(options).toEqual([
+        { value: 'flat_rate', label: 'Flat rate' },
+        { value: 'free_shipping', label: 'Free shipping' },
+        { value: 'local_pickup', label: 'Local pickup' },
+      ]);
+    });
+
+    it('should fall back to the method id when title is missing', async () => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue([{ id: 'flat_rate' }]);
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const options = await adapter.listCarriers();
+
+      expect(options).toEqual([{ value: 'flat_rate', label: 'flat_rate' }]);
+    });
+
+    it('should return an empty list when the store registers no shipping methods', async () => {
+      const httpClient = makeHttpClient();
+      httpClient.get.mockResolvedValue([]);
+      const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+      const options = await adapter.listCarriers();
+
+      expect(options).toEqual([]);
+    });
   });
 });

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
@@ -19,6 +19,11 @@ import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-clie
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
 import type { OrderCreate, OrderItem, OrderStatus } from '@openlinker/core/orders';
+import type { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
+import { DestinationAddressMapping } from '@openlinker/core/customers';
+import type { SyncLockPort } from '@openlinker/core/sync';
+import { WooCommerceCustomerProvisioner } from '../../../provisioners/woocommerce-customer-provisioner';
+import { WooCommerceAddressProvisioner } from '../../../provisioners/woocommerce-address-provisioner';
 import { WooCommerceResourceNotFoundException } from '../../../../domain/exceptions/woocommerce-resource-not-found.exception';
 import { WooCommerceInvalidIdentifierException } from '../../../../domain/exceptions/woocommerce-invalid-identifier.exception';
 import { WooCommerceOrderProcessingException } from '../../../../domain/exceptions/woocommerce-order-processing.exception';
@@ -30,6 +35,16 @@ import { WooCommerceUnauthorizedException } from '../../../../domain/exceptions/
 // ─── Test fixtures ─────────────────────────────────────────────────────────
 
 const CONNECTION_ID = 'conn-wc-001';
+
+// Address reuse tracking hashes the address (getPiiConfig requires a salt).
+const originalPiiHashSalt = process.env.OL_PII_HASH_SALT;
+beforeAll(() => {
+  process.env.OL_PII_HASH_SALT = 'test-salt-for-hashing';
+});
+afterAll(() => {
+  if (originalPiiHashSalt === undefined) delete process.env.OL_PII_HASH_SALT;
+  else process.env.OL_PII_HASH_SALT = originalPiiHashSalt;
+});
 
 const mockConnection: Connection = {
   id: CONNECTION_ID,
@@ -66,11 +81,62 @@ function makeIdentifierMapping(): jest.Mocked<IdentifierMappingPort> {
   };
 }
 
+/** In-memory SyncLockPort — single-holder-per-key, enough for the adapter tests. */
+function makeSyncLock(): SyncLockPort {
+  const locks = new Map<string, string>();
+  return {
+    acquire: jest.fn((key: string) => {
+      if (locks.has(key)) return Promise.resolve(null);
+      const token = `tok-${Math.random().toString(36).slice(2)}`;
+      locks.set(key, token);
+      return Promise.resolve(token);
+    }),
+    release: jest.fn((key: string, token: string) => {
+      if (locks.get(key) === token) {
+        locks.delete(key);
+        return Promise.resolve(true);
+      }
+      return Promise.resolve(false);
+    }),
+  };
+}
+
+/**
+ * Stub customer-projection repository. `findDestinationAddressMapping` returns a
+ * reuse HIT by default so the address provisioner short-circuits and adds no HTTP
+ * calls — these createOrder tests focus on customer + order-payload behaviour,
+ * not address reuse (that has its own dedicated provisioner spec).
+ */
+function makeProjectionRepo(): jest.Mocked<CustomerProjectionRepositoryPort> {
+  return {
+    findById: jest.fn(),
+    findByEmailHash: jest.fn(),
+    findMany: jest.fn(),
+    upsert: jest.fn(),
+    findAddressesByCustomerId: jest.fn(),
+    upsertAddress: jest.fn(),
+    findDestinationAddressMapping: jest.fn(() =>
+      Promise.resolve(
+        new DestinationAddressMapping('ol-cust-1', CONNECTION_ID, 'hash', 'billing', '7', new Date(), new Date()),
+      ),
+    ),
+    upsertDestinationAddressMapping: jest.fn((m) => Promise.resolve(m)),
+  } as unknown as jest.Mocked<CustomerProjectionRepositoryPort>;
+}
+
 function makeAdapter(
   httpClient: jest.Mocked<IWooCommerceHttpClient>,
   identifierMapping: jest.Mocked<IdentifierMappingPort>,
 ): WooCommerceOrderProcessorAdapter {
-  return new WooCommerceOrderProcessorAdapter(httpClient, identifierMapping, mockConnection);
+  const syncLock = makeSyncLock();
+  return new WooCommerceOrderProcessorAdapter(
+    httpClient,
+    identifierMapping,
+    mockConnection,
+    new WooCommerceCustomerProvisioner(syncLock),
+    new WooCommerceAddressProvisioner(syncLock),
+    makeProjectionRepo(),
+  );
 }
 
 function makeOrder(overrides: Partial<OrderCreate> = {}): OrderCreate {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.fulfillment-status.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.fulfillment-status.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * WooCommerce Order Processor Adapter — FulfillmentStatusReader unit tests
+ *
+ * Covers the getFulfillmentStatus read path (#1550): the isFulfillmentStatusReader
+ * guard, the GET /orders/{id} call + mapping, id validation, and 404 handling.
+ * Mocks IWooCommerceHttpClient and IdentifierMappingPort.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__
+ */
+import { WooCommerceOrderProcessorAdapter } from '../woocommerce-order-processor.adapter';
+import { isFulfillmentStatusReader, FULFILLMENT_STATUS } from '@openlinker/core/orders';
+import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-client.interface';
+import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
+import { WooCommerceResourceNotFoundException } from '../../../../domain/exceptions/woocommerce-resource-not-found.exception';
+import { WooCommerceInvalidArgumentException } from '../../../../domain/exceptions/woocommerce-invalid-argument.exception';
+import { WooCommerceHttpResponseException } from '../../../http/woocommerce-http-response.exception';
+
+const CONNECTION_ID = 'conn-wc-001';
+
+const mockConnection: Connection = {
+  id: CONNECTION_ID,
+  platformType: 'woocommerce',
+  name: 'Test WC Store',
+  status: 'active',
+  config: { siteUrl: 'https://myshop.com' } as Record<string, unknown>,
+  credentialsRef: 'cred-ref-001',
+  adapterKey: 'woocommerce.restapi.v3',
+  enabledCapabilities: ['OrderProcessorManager'],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function makeHttpClient(): jest.Mocked<IWooCommerceHttpClient> {
+  return {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  };
+}
+
+function makeIdentifierMapping(): jest.Mocked<IdentifierMappingPort> {
+  return {
+    getOrCreateInternalId: jest.fn(),
+    getOrCreateExactMapping: jest.fn(),
+    getInternalId: jest.fn(),
+    getExternalIds: jest.fn(),
+    createMapping: jest.fn(),
+    batchGetOrCreateInternalIds: jest.fn(),
+    deleteMapping: jest.fn(),
+    listExternalIdsByConnection: jest.fn(),
+  };
+}
+
+function makeAdapter(
+  httpClient: jest.Mocked<IWooCommerceHttpClient>,
+): WooCommerceOrderProcessorAdapter {
+  return new WooCommerceOrderProcessorAdapter(httpClient, makeIdentifierMapping(), mockConnection);
+}
+
+describe('WooCommerceOrderProcessorAdapter — FulfillmentStatusReader', () => {
+  it('should pass the isFulfillmentStatusReader guard', () => {
+    const adapter = makeAdapter(makeHttpClient());
+    expect(isFulfillmentStatusReader(adapter)).toBe(true);
+  });
+
+  it('should GET the order and return the mapped fulfillment snapshot', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({
+      id: 123,
+      status: 'completed',
+      date_completed_gmt: '2026-07-14T10:30:00',
+    });
+    const adapter = makeAdapter(httpClient);
+
+    const snapshot = await adapter.getFulfillmentStatus({ externalOrderId: '123' });
+
+    expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/orders/123');
+    expect(snapshot).toEqual({
+      status: FULFILLMENT_STATUS.Delivered,
+      trackingNumber: null,
+      deliveredAt: new Date('2026-07-14T10:30:00Z'),
+    });
+  });
+
+  it('should return a null-status snapshot for a pre-fulfillment order', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: 5, status: 'processing' });
+    const adapter = makeAdapter(httpClient);
+
+    const snapshot = await adapter.getFulfillmentStatus({ externalOrderId: '5' });
+
+    expect(snapshot.status).toBeNull();
+    expect(snapshot.deliveredAt).toBeNull();
+  });
+
+  it('should reject a non-integer externalOrderId before any HTTP call', async () => {
+    const httpClient = makeHttpClient();
+    const adapter = makeAdapter(httpClient);
+
+    await expect(
+      adapter.getFulfillmentStatus({ externalOrderId: '12/../../etc' }),
+    ).rejects.toBeInstanceOf(WooCommerceInvalidArgumentException);
+    expect(httpClient.get).not.toHaveBeenCalled();
+  });
+
+  it('should throw WooCommerceResourceNotFoundException on a 404', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.get.mockRejectedValue(new WooCommerceHttpResponseException(404, 'Not Found'));
+    const adapter = makeAdapter(httpClient);
+
+    await expect(
+      adapter.getFulfillmentStatus({ externalOrderId: '999' }),
+    ).rejects.toBeInstanceOf(WooCommerceResourceNotFoundException);
+  });
+
+  it('should propagate non-404 errors unchanged', async () => {
+    const httpClient = makeHttpClient();
+    const err = new WooCommerceHttpResponseException(500, 'Server Error');
+    httpClient.get.mockRejectedValue(err);
+    const adapter = makeAdapter(httpClient);
+
+    await expect(adapter.getFulfillmentStatus({ externalOrderId: '7' })).rejects.toBe(err);
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.fulfillment-status.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.fulfillment-status.spec.ts
@@ -11,6 +11,10 @@ import { WooCommerceOrderProcessorAdapter } from '../woocommerce-order-processor
 import { isFulfillmentStatusReader, FULFILLMENT_STATUS } from '@openlinker/core/orders';
 import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-client.interface';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
+import type { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
+import type { SyncLockPort } from '@openlinker/core/sync';
+import { WooCommerceCustomerProvisioner } from '../../../provisioners/woocommerce-customer-provisioner';
+import { WooCommerceAddressProvisioner } from '../../../provisioners/woocommerce-address-provisioner';
 import { WooCommerceResourceNotFoundException } from '../../../../domain/exceptions/woocommerce-resource-not-found.exception';
 import { WooCommerceInvalidArgumentException } from '../../../../domain/exceptions/woocommerce-invalid-argument.exception';
 import { WooCommerceHttpResponseException } from '../../../http/woocommerce-http-response.exception';
@@ -52,10 +56,38 @@ function makeIdentifierMapping(): jest.Mocked<IdentifierMappingPort> {
   };
 }
 
+function makeSyncLock(): SyncLockPort {
+  return {
+    acquire: jest.fn(() => Promise.resolve('tok')),
+    release: jest.fn(() => Promise.resolve(true)),
+  };
+}
+
+function makeProjectionRepo(): jest.Mocked<CustomerProjectionRepositoryPort> {
+  return {
+    findById: jest.fn(),
+    findByEmailHash: jest.fn(),
+    findMany: jest.fn(),
+    upsert: jest.fn(),
+    findAddressesByCustomerId: jest.fn(),
+    upsertAddress: jest.fn(),
+    findDestinationAddressMapping: jest.fn(),
+    upsertDestinationAddressMapping: jest.fn(),
+  } as unknown as jest.Mocked<CustomerProjectionRepositoryPort>;
+}
+
 function makeAdapter(
   httpClient: jest.Mocked<IWooCommerceHttpClient>,
 ): WooCommerceOrderProcessorAdapter {
-  return new WooCommerceOrderProcessorAdapter(httpClient, makeIdentifierMapping(), mockConnection);
+  const syncLock = makeSyncLock();
+  return new WooCommerceOrderProcessorAdapter(
+    httpClient,
+    makeIdentifierMapping(),
+    mockConnection,
+    new WooCommerceCustomerProvisioner(syncLock),
+    new WooCommerceAddressProvisioner(syncLock),
+    makeProjectionRepo(),
+  );
 }
 
 describe('WooCommerceOrderProcessorAdapter — FulfillmentStatusReader', () => {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-fulfillment-status.mapper.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-fulfillment-status.mapper.ts
@@ -1,0 +1,102 @@
+/**
+ * WooCommerce Fulfillment Status Mapper
+ *
+ * Pure mapper from a WooCommerce order's `status` field to the neutral
+ * `FulfillmentStatusSnapshot` (#834 / #1550) — the WC → neutral read direction,
+ * counterpart to the neutral → WC write direction owned by
+ * {@link WC_ORDER_STATUS_MAP}. Reuses the shared WC status vocabulary from
+ * `woocommerce-order-status.types.ts` (#1549) — there is a single source of
+ * truth for the WooCommerce status set across every order sub-capability.
+ *
+ * **Status mapping rules** (conservative v1):
+ *
+ * - `completed` → `delivered`. WC has no distinct shipped/in-transit/delivered
+ *   states — `completed` is the terminal fulfilled state and never transitions
+ *   further, so it projects to the terminal neutral `delivered` (+ `deliveredAt`
+ *   read from `date_completed_gmt`, falling back to `date_modified_gmt`).
+ * - `cancelled` → `cancelled`.
+ * - `refunded` → `cancelled`. A refund is a terminal reversal of the order; the
+ *   writeback (#1549) already treats `refunded` as terminal alongside
+ *   `completed`, so the read side mirrors it onto the only neutral terminal-
+ *   reversal value available.
+ * - `pending` / `processing` / `on-hold` / `failed` → `null`. The shop has not
+ *   yet fulfilled the order (awaiting payment, processing, on hold, or a failed
+ *   payment) — projection-only skip.
+ * - An unknown / absent status → `null` (defensive: treat as not-yet-acted).
+ *
+ * **Tracking**: always `null`. WooCommerce core has no order-level tracking
+ * field (it lives in the third-party Shipment Tracking plugin's meta_data),
+ * mirroring the same limitation `updateFulfillment` documents on the write side.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
+ */
+import type { FulfillmentStatus, FulfillmentStatusSnapshot } from '@openlinker/core/orders';
+import { FULFILLMENT_STATUS } from '@openlinker/core/orders';
+
+import type { WooCommerceOrderResponse } from './woocommerce-order.types';
+import { WC_ORDER_STATUS_VALUES, type WooCommerceOrderStatus } from './woocommerce-order-status.types';
+
+/**
+ * WooCommerce status → neutral `FulfillmentStatus`. Keyed off the shared
+ * {@link WooCommerceOrderStatus} vocabulary so a new WC status can't be added in
+ * one place without the compiler flagging the missing branch here. `null` marks
+ * the pre-fulfillment states the sync service skips (projection-only semantics).
+ */
+export const WC_FULFILLMENT_STATUS_MAP: Record<WooCommerceOrderStatus, FulfillmentStatus | null> = {
+  pending: null,
+  processing: null,
+  'on-hold': null,
+  completed: FULFILLMENT_STATUS.Delivered,
+  cancelled: FULFILLMENT_STATUS.Cancelled,
+  refunded: FULFILLMENT_STATUS.Cancelled,
+  failed: null,
+};
+
+/**
+ * Map a raw WooCommerce order `status` string to the neutral fulfillment status.
+ * Returns `null` for pre-fulfillment states and for any unknown / absent value.
+ */
+export function mapWooCommerceStatus(status: string | undefined): FulfillmentStatus | null {
+  if (status === undefined || !isKnownWooCommerceStatus(status)) {
+    return null;
+  }
+  return WC_FULFILLMENT_STATUS_MAP[status];
+}
+
+/**
+ * Project a WooCommerce order response onto the neutral fulfillment snapshot.
+ * `deliveredAt` is populated only on the `delivered` transition, read from the
+ * order's completion timestamp.
+ */
+export function mapToFulfillmentStatusSnapshot(
+  order: WooCommerceOrderResponse,
+): FulfillmentStatusSnapshot {
+  const status = mapWooCommerceStatus(order.status);
+  const deliveredAt =
+    status === FULFILLMENT_STATUS.Delivered
+      ? parseDate(order.date_completed_gmt ?? order.date_modified_gmt)
+      : null;
+
+  return {
+    status,
+    trackingNumber: null,
+    deliveredAt,
+  };
+}
+
+function isKnownWooCommerceStatus(status: string): status is WooCommerceOrderStatus {
+  return (WC_ORDER_STATUS_VALUES as readonly string[]).includes(status);
+}
+
+/**
+ * WooCommerce serialises GMT timestamps without a zone suffix (e.g.
+ * `2026-07-14T10:30:00`). Append `Z` when no explicit offset is present so it
+ * parses as UTC rather than local time. Returns `null` for absent / unparseable
+ * values.
+ */
+function parseDate(value: string | undefined): Date | null {
+  if (!value) return null;
+  const normalised = /[zZ]|[+-]\d{2}:?\d{2}$/.test(value) ? value : `${value}Z`;
+  const parsed = new Date(normalised);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-options.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-options.types.ts
@@ -1,0 +1,57 @@
+/**
+ * WooCommerce Destination-Options Types (#1551)
+ *
+ * Response shapes and vocabulary powering `DestinationOptionsReader` on
+ * `WooCommerceOrderProcessorAdapter` — the option lists the connection-mappings
+ * UI renders so operators can build source->destination status / carrier /
+ * payment maps. Only the fields the adapter actually consumes are typed; the WC
+ * REST API returns much more, ignored here to keep the surface tight.
+ *
+ * - Order statuses come from the static WC vocabulary (`WC_ORDER_STATUS_VALUES`)
+ *   decorated with display labels — WC exposes no dedicated status-catalogue
+ *   endpoint, and the core set is fixed by the WC REST API v3 contract.
+ * - Payment methods come from `GET /payment_gateways`.
+ * - Carriers come from `GET /shipping_methods` (see the adapter for the
+ *   rationale on why WC shipping-method *types* stand in for carriers).
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
+ */
+import type { WooCommerceOrderStatus } from './woocommerce-order-status.types';
+
+/**
+ * Human-readable labels for each WC core order status, matching WooCommerce's
+ * own admin wording. Used to decorate the static status vocabulary into neutral
+ * `MappingOption`s.
+ */
+export const WC_ORDER_STATUS_LABELS: Record<WooCommerceOrderStatus, string> = {
+  pending: 'Pending payment',
+  processing: 'Processing',
+  'on-hold': 'On hold',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+  refunded: 'Refunded',
+  failed: 'Failed',
+};
+
+/**
+ * `GET /payment_gateways` row. `id` is the stable gateway code persisted by
+ * mapping config (e.g. `bacs`, `cod`, `cheque`, `paypal`); `title` is the
+ * operator-facing label; `enabled` reflects whether the gateway is active in
+ * the store.
+ */
+export interface WooCommercePaymentGateway {
+  id: string;
+  title?: string;
+  enabled?: boolean;
+}
+
+/**
+ * `GET /shipping_methods` row. WC returns the globally-registered shipping
+ * *method types* (`flat_rate`, `free_shipping`, `local_pickup`, plugin-provided
+ * types), not per-zone carrier instances. `id` is the stable method code;
+ * `title` is the display name.
+ */
+export interface WooCommerceShippingMethod {
+  id: string;
+  title?: string;
+}

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -3,8 +3,10 @@
  *
  * Implements OrderProcessorManagerPort (createOrder), the OrderFulfillmentUpdater
  * sub-capability (updateFulfillment — status updates, cancellations, refund transitions),
- * and the OrderStatusWriteback sub-capability (write — the #1157 / ADR-027 lifecycle
- * relay contract) for WooCommerce REST API v3.
+ * the OrderStatusWriteback sub-capability (write — the #1157 / ADR-027 lifecycle
+ * relay contract), and the DestinationOptionsReader sub-capability (listCarriers /
+ * listOrderStatuses / listPaymentMethods — the #472 / #1551 mapping-UI option
+ * vocabulary) for WooCommerce REST API v3.
  *
  * Key design decisions:
  * - createOrder: the adapter does NOT dedup. It POSTs to WC and returns the
@@ -29,6 +31,7 @@
  * @implements {OrderProcessorManagerPort}
  * @implements {OrderFulfillmentUpdater}
  * @implements {OrderStatusWriteback}
+ * @implements {DestinationOptionsReader}
  */
 import type {
   OrderProcessorManagerPort,
@@ -43,6 +46,8 @@ import type {
   OrderStatusWriteback,
   OrderLifecycleEvent,
   OrderWritebackResult,
+  DestinationOptionsReader,
+  MappingOption,
 } from '@openlinker/core/orders';
 import type { IdentifierMappingPort, Connection, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
@@ -66,7 +71,12 @@ import type {
   WooCommerceCustomerCreateRequest,
   WooCommerceCustomerResponse,
 } from './woocommerce-order.types';
-import { WC_ORDER_STATUS_MAP } from './woocommerce-order.types';
+import { WC_ORDER_STATUS_MAP, WC_ORDER_STATUS_VALUES } from './woocommerce-order.types';
+import {
+  WC_ORDER_STATUS_LABELS,
+  type WooCommercePaymentGateway,
+  type WooCommerceShippingMethod,
+} from './woocommerce-options.types';
 
 // ─── Module-level pure helpers ────────────────────────────────────────────────
 // Pure functions with no dependency on adapter state — independently testable.
@@ -82,7 +92,11 @@ export function isValidEmail(value: unknown): value is string {
 // ─── Adapter ──────────────────────────────────────────────────────────────────
 
 export class WooCommerceOrderProcessorAdapter
-  implements OrderProcessorManagerPort, OrderFulfillmentUpdater, OrderStatusWriteback
+  implements
+    OrderProcessorManagerPort,
+    OrderFulfillmentUpdater,
+    OrderStatusWriteback,
+    DestinationOptionsReader
 {
   private readonly logger = new Logger(WooCommerceOrderProcessorAdapter.name);
 
@@ -289,6 +303,65 @@ export class WooCommerceOrderProcessorAdapter
       );
       return { outcome: 'rejected', detail };
     }
+  }
+
+  // ─── DestinationOptionsReader (#472 / #1551) ──────────────────────────────
+  //
+  // Live option vocabulary powering the connection-mappings UI dropdowns. Each
+  // method returns the neutral `MappingOption` shape ({ value, label }); `value`
+  // is the stable identifier persisted by mapping config, `label` is the
+  // operator-facing string.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * WooCommerce core has no first-class carrier entity — shipping is modelled as
+   * method *types* (`flat_rate`, `free_shipping`, `local_pickup`, plus any
+   * plugin-provided types) attached to shipping zones, not named carriers.
+   * `GET /shipping_methods` returns those globally-registered method types, which
+   * is the closest live analogue to a carrier list and gives the mapping UI a
+   * non-empty, stable set to map onto (rather than an empty dropdown). `value` is
+   * the WC method id — the same code createOrder emits as `shipping_lines.method_id`.
+   */
+  async listCarriers(): Promise<MappingOption[]> {
+    const rows = await this.httpClient.get<WooCommerceShippingMethod[]>(
+      '/wp-json/wc/v3/shipping_methods',
+    );
+    return rows.map((row) => ({
+      value: String(row.id),
+      label: row.title ?? String(row.id),
+    }));
+  }
+
+  /**
+   * WooCommerce exposes no dedicated order-status catalogue endpoint — the core
+   * status set is fixed by the WC REST API v3 contract. Enumerate the shared
+   * vocabulary (`WC_ORDER_STATUS_VALUES`) decorated with display labels; `value`
+   * is the WC status slug persisted by mapping config.
+   */
+  listOrderStatuses(): Promise<MappingOption[]> {
+    return Promise.resolve(
+      WC_ORDER_STATUS_VALUES.map((slug) => ({
+        value: slug,
+        label: WC_ORDER_STATUS_LABELS[slug],
+      })),
+    );
+  }
+
+  /**
+   * `GET /payment_gateways` lists every payment gateway registered in the store.
+   * `value` is the gateway code (`bacs`, `cod`, `paypal`, …) persisted by mapping
+   * config; `label` is the operator-facing title. All registered gateways are
+   * returned regardless of `enabled` — an operator may legitimately map a source
+   * payment method onto a currently-disabled destination gateway.
+   */
+  async listPaymentMethods(): Promise<MappingOption[]> {
+    const rows = await this.httpClient.get<WooCommercePaymentGateway[]>(
+      '/wp-json/wc/v3/payment_gateways',
+    );
+    return rows.map((row) => ({
+      value: String(row.id),
+      label: row.title ?? String(row.id),
+    }));
   }
 
   // ─── Private helpers ──────────────────────────────────────────────────────

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -49,6 +49,7 @@ import { WooCommerceOrderProcessingException } from '../../../domain/exceptions/
 import { WooCommerceInvalidArgumentException } from '../../../domain/exceptions/woocommerce-invalid-argument.exception';
 import { WooCommerceInvalidIdentifierException } from '../../../domain/exceptions/woocommerce-invalid-identifier.exception';
 import { toPositiveInt } from '../../utils/woocommerce-utils';
+import { isSyntheticVariantExternalId } from '../../mappers/woocommerce-variant-id';
 import type {
   WooCommerceOrderCreateRequest,
   WooCommerceOrderUpdateRequest,
@@ -396,7 +397,7 @@ export class WooCommerceOrderProcessorAdapter
             this.connection.id,
           );
         }
-        if (variantMapping.externalId.startsWith('product:')) {
+        if (isSyntheticVariantExternalId(variantMapping.externalId)) {
           // Synthetic variant of a simple product (`product:{wcId}` — same
           // convention as PrestaShop; the inventory adapter strips this
           // prefix too). Simple products have no WC variation — the line

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -13,17 +13,20 @@
  *   without an extension, so it cannot be read back as a skip-check). Real
  *   idempotency is core-owned: OrderSyncService's per-(order,destination) lock
  *   (#906) + update-or-create mapping check (#909).
- * - Customer provisioning: POST /customers with email when available.
- *   auth failures (401/403) propagate as WooCommerceAuthFailureException — they
- *   are NOT swallowed into guest-order creation (#877).
+ * - Customer provisioning: delegated to WooCommerceCustomerProvisioner
+ *   (resolve-or-create under a distributed lock; #1552). Auth failures (401/403)
+ *   propagate as WooCommerceAuthFailureException — they are NOT swallowed into
+ *   guest-order creation (#877).
  * - buyerEmail: WooCommerce adapter reads buyer email from order.metadata?.buyerEmail,
  *   which OrderSyncService populates from the source order's customerEmail (#948).
  *   When absent (hash-only PII mode, or a source without an email), customer
  *   provisioning degrades to guest (customer_id = 0).
- * - destination_address_mappings: not applicable — WC has no address entities; addresses
- *   are embedded inline in the order payload.
- * - DuplicateIdentifierMappingError: not applicable here — mapping writes are in
- *   OrderSyncService.
+ * - Address reuse: delegated to WooCommerceAddressProvisioner (#1552). WC has no
+ *   standalone address resource — the provisioner writes the customer's inline
+ *   billing/shipping address at most once per (customer, addressHash, type) using
+ *   destination_address_mappings, guarded by the same distributed lock. Best-effort:
+ *   a provisioning failure is logged and never aborts order creation. The order
+ *   payload always carries the inline address regardless.
  *
  * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
  * @implements {OrderProcessorManagerPort}
@@ -45,17 +48,18 @@ import type {
   OrderWritebackResult,
 } from '@openlinker/core/orders';
 import type { IdentifierMappingPort, Connection, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
-import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
+import type { CustomerProjectionRepositoryPort, AddressType } from '@openlinker/core/customers';
 import { Logger } from '@openlinker/shared/logging';
 import type { IWooCommerceHttpClient } from '../../http/woocommerce-http-client.interface';
 import { WooCommerceHttpResponseException } from '../../http/woocommerce-http-response.exception';
-import { WooCommerceUnauthorizedException } from '../../../domain/exceptions/woocommerce-unauthorized.exception';
-import { WooCommerceAuthFailureException } from '../../../domain/exceptions/woocommerce-auth-failure.exception';
 import { WooCommerceResourceNotFoundException } from '../../../domain/exceptions/woocommerce-resource-not-found.exception';
 import { WooCommerceOrderProcessingException } from '../../../domain/exceptions/woocommerce-order-processing.exception';
 import { WooCommerceInvalidArgumentException } from '../../../domain/exceptions/woocommerce-invalid-argument.exception';
 import { WooCommerceInvalidIdentifierException } from '../../../domain/exceptions/woocommerce-invalid-identifier.exception';
 import { toPositiveInt } from '../../utils/woocommerce-utils';
+import type { WooCommerceCustomerProvisioner } from '../../provisioners/woocommerce-customer-provisioner';
+import type { WooCommerceAddressProvisioner } from '../../provisioners/woocommerce-address-provisioner';
 import type {
   WooCommerceOrderCreateRequest,
   WooCommerceOrderUpdateRequest,
@@ -63,8 +67,6 @@ import type {
   WooCommerceOrderAddress,
   WooCommerceLineItemRequest,
   WooCommerceShippingLineRequest,
-  WooCommerceCustomerCreateRequest,
-  WooCommerceCustomerResponse,
 } from './woocommerce-order.types';
 import { WC_ORDER_STATUS_MAP } from './woocommerce-order.types';
 
@@ -90,6 +92,9 @@ export class WooCommerceOrderProcessorAdapter
     private readonly httpClient: IWooCommerceHttpClient,
     private readonly identifierMapping: IdentifierMappingPort,
     private readonly connection: Connection,
+    private readonly customerProvisioner: WooCommerceCustomerProvisioner,
+    private readonly addressProvisioner: WooCommerceAddressProvisioner,
+    private readonly customerProjectionRepository: CustomerProjectionRepositoryPort,
   ) {}
 
   // ─── OrderProcessorManagerPort ────────────────────────────────────────────
@@ -110,8 +115,26 @@ export class WooCommerceOrderProcessorAdapter
       );
     }
 
-    // Step 2 — resolve or provision WC customer
-    const customerId = await this.resolveCustomerId(order, buyerEmail);
+    // Step 2 — resolve or provision WC customer (delegated to the provisioner,
+    // which serializes concurrent provisioning for the same buyer under a lock).
+    const firstName = order.billingAddress?.firstName ?? order.shippingAddress?.firstName ?? '';
+    const lastName = order.billingAddress?.lastName ?? order.shippingAddress?.lastName ?? '';
+    const customerId = await this.customerProvisioner.resolveOrCreateCustomer({
+      internalCustomerId: order.customerId,
+      buyerEmail,
+      firstName,
+      lastName,
+      connectionId: this.connection.id,
+      httpClient: this.httpClient,
+      identifierMapping: this.identifierMapping,
+    });
+
+    // Step 2b — reuse-tracked address provisioning (best-effort; #1552). Records
+    // the WC customer's inline billing/shipping address for reuse without ever
+    // aborting order creation. Skipped for guest orders (customer_id = 0).
+    if (customerId > 0 && order.customerId) {
+      await this.provisionAddresses(order, order.customerId, customerId);
+    }
 
     // Step 3 — resolve line items (throws on any unresolvable or corrupted mapping)
     const lineItems = await this.resolveLineItems(order.items);
@@ -294,128 +317,39 @@ export class WooCommerceOrderProcessorAdapter
   // ─── Private helpers ──────────────────────────────────────────────────────
 
   /**
-   * Resolves or provisions a WC customer account for the given OL internal customer.
-   * Degrades to guest (customer_id = 0) on non-auth, non-critical failure.
-   * Auth failures (401/403) are NOT swallowed — they propagate as
-   * WooCommerceAuthFailureException so the sync runner can flag the connection
-   * for re-authentication (#877 I1).
+   * Best-effort reuse-tracked provisioning of the WC customer's inline billing
+   * and shipping addresses (#1552). Delegates to WooCommerceAddressProvisioner
+   * per address type. Failures are logged and swallowed — address reuse tracking
+   * is auxiliary and must never abort order creation.
    */
-  private async resolveCustomerId(
+  private async provisionAddresses(
     order: OrderCreate,
-    buyerEmail: string | undefined,
-  ): Promise<number> {
-    const { customerId } = order;
-    if (!customerId) return 0;
+    internalCustomerId: string,
+    wcCustomerId: number,
+  ): Promise<void> {
+    const targets: Array<{ address: Address | undefined; type: AddressType }> = [
+      { address: order.billingAddress, type: 'billing' },
+      { address: order.shippingAddress, type: 'shipping' },
+    ];
 
-    // 1. Look up existing WC customer mapping
-    const externalIds = await this.identifierMapping.getExternalIds(
-      CORE_ENTITY_TYPE.Customer,
-      customerId,
-    );
-    const mapping = externalIds.find((e: ExternalIdMapping) => e.connectionId === this.connection.id);
-    if (mapping) {
-      const n = Number(mapping.externalId);
-      if (!Number.isInteger(n) || n <= 0) {
+    for (const { address, type } of targets) {
+      if (!address) continue;
+      try {
+        await this.addressProvisioner.resolveOrCreateAddress({
+          internalCustomerId,
+          wcCustomerId,
+          address,
+          addressType: type,
+          connectionId: this.connection.id,
+          httpClient: this.httpClient,
+          customerProjectionRepository: this.customerProjectionRepository,
+        });
+      } catch (err) {
         this.logger.warn(
-          `resolveCustomerId: corrupted mapping "${mapping.externalId}" for customer ${customerId} — guest order`,
+          `provisionAddresses: ${type} address reuse tracking failed for customer ${internalCustomerId} — continuing: ${String(err)}`,
         );
-        return 0;
-      }
-      return n;
-    }
-
-    // 2. No existing mapping — provision WC customer if email is available
-    if (!buyerEmail) {
-      this.logger.warn(
-        `resolveCustomerId: no WC mapping and no buyerEmail for customer ${customerId} — guest order`,
-      );
-      return 0;
-    }
-
-    const firstName = order.billingAddress?.firstName ?? order.shippingAddress?.firstName ?? '';
-    const lastName = order.billingAddress?.lastName ?? order.shippingAddress?.lastName ?? '';
-
-    let wcCustomerId: number;
-    try {
-      const created = await this.httpClient.post<WooCommerceCustomerResponse>(
-        '/wp-json/wc/v3/customers',
-        {
-          email: buyerEmail,
-          first_name: firstName,
-          last_name: lastName,
-        } satisfies WooCommerceCustomerCreateRequest,
-      );
-      if (!created.id) {
-        this.logger.warn(
-          `resolveCustomerId: WC customer POST returned no id for ${customerId} — guest order`,
-        );
-        return 0;
-      }
-      wcCustomerId = created.id;
-    } catch (err) {
-      // Auth failures must propagate — invalid credentials require re-authentication.
-      // Swallowing a 401/403 into a guest order masks a broken connection (#877 I1).
-      if (err instanceof WooCommerceUnauthorizedException) {
-        throw new WooCommerceAuthFailureException(
-          `WooCommerce auth failure provisioning customer ${customerId} on connection ${this.connection.id}: ${String(err)}`,
-          this.connection.id,
-        );
-      }
-      if (err instanceof WooCommerceHttpResponseException && err.statusCode === 400) {
-        // WC returns 400 + code 'registration-error-email-exists' for duplicate emails —
-        // look up the existing customer account by email
-        const existing = await this.httpClient.get<WooCommerceCustomerResponse[]>(
-          '/wp-json/wc/v3/customers',
-          { email: buyerEmail },
-        );
-        const match = existing.find((c) => c.email === buyerEmail);
-        if (!match?.id) {
-          this.logger.warn(
-            `resolveCustomerId: duplicate email ${buyerEmail} but no matching WC customer — guest order`,
-          );
-          return 0;
-        }
-        wcCustomerId = match.id;
-      } else {
-        // Non-auth, non-400 failure (network, rate-limit, etc.) — degrade to guest,
-        // do not abort order creation.
-        this.logger.warn(
-          `resolveCustomerId: WC customer API error for ${customerId} — guest order: ${String(err)}`,
-        );
-        return 0;
       }
     }
-
-    // 3. Store Customer mapping with concurrent-duplicate handler
-    try {
-      await this.identifierMapping.createMapping(
-        CORE_ENTITY_TYPE.Customer,
-        String(wcCustomerId),
-        this.connection.id,
-        customerId,
-      );
-    } catch (err) {
-      if (err instanceof DuplicateIdentifierMappingError) {
-        // Concurrent retry stored it first — look up winner and return its id
-        const winners = await this.identifierMapping.getExternalIds(
-          CORE_ENTITY_TYPE.Customer,
-          customerId,
-        );
-        const winner = winners.find((e: ExternalIdMapping) => e.connectionId === this.connection.id);
-        if (winner) {
-          const n = Number(winner.externalId);
-          return Number.isInteger(n) && n > 0 ? n : 0;
-        }
-        // Transient — fall back to guest (do not fail the order)
-        this.logger.warn(
-          `resolveCustomerId: concurrent duplicate but no winner for ${customerId} — guest order`,
-        );
-        return 0;
-      }
-      throw err;
-    }
-
-    return wcCustomerId;
   }
 
   /**

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -1,9 +1,10 @@
 /**
  * WooCommerce Order Processor Adapter
  *
- * Implements OrderProcessorManagerPort (createOrder) and the OrderFulfillmentUpdater
- * sub-capability (updateFulfillment — status updates, cancellations, refund transitions)
- * for WooCommerce REST API v3.
+ * Implements OrderProcessorManagerPort (createOrder), the OrderFulfillmentUpdater
+ * sub-capability (updateFulfillment — status updates, cancellations, refund transitions),
+ * and the OrderStatusWriteback sub-capability (write — the #1157 / ADR-027 lifecycle
+ * relay contract) for WooCommerce REST API v3.
  *
  * Key design decisions:
  * - createOrder: the adapter does NOT dedup. It POSTs to WC and returns the
@@ -27,6 +28,7 @@
  * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
  * @implements {OrderProcessorManagerPort}
  * @implements {OrderFulfillmentUpdater}
+ * @implements {OrderStatusWriteback}
  */
 import type {
   OrderProcessorManagerPort,
@@ -36,7 +38,12 @@ import type {
   Address,
   OrderStatus,
 } from '@openlinker/core/orders';
-import type { OrderFulfillmentUpdater } from '@openlinker/core/orders';
+import type {
+  OrderFulfillmentUpdater,
+  OrderStatusWriteback,
+  OrderLifecycleEvent,
+  OrderWritebackResult,
+} from '@openlinker/core/orders';
 import type { IdentifierMappingPort, Connection, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
@@ -75,7 +82,7 @@ export function isValidEmail(value: unknown): value is string {
 // ─── Adapter ──────────────────────────────────────────────────────────────────
 
 export class WooCommerceOrderProcessorAdapter
-  implements OrderProcessorManagerPort, OrderFulfillmentUpdater
+  implements OrderProcessorManagerPort, OrderFulfillmentUpdater, OrderStatusWriteback
 {
   private readonly logger = new Logger(WooCommerceOrderProcessorAdapter.name);
 
@@ -207,6 +214,80 @@ export class WooCommerceOrderProcessorAdapter
       this.logger.debug(
         `updateFulfillment: trackingNumber "${input.trackingNumber}" accepted but not persisted (WC has no core tracking field)`,
       );
+    }
+  }
+
+  // ─── OrderStatusWriteback ─────────────────────────────────────────────────
+
+  /**
+   * `OrderStatusWriteback` (#1157 / ADR-027): the single event-as-data writeback
+   * the lifecycle relay dispatches through. Maps each neutral lifecycle event
+   * onto WooCommerce's order status and PUTs it via `PUT /orders/{id}`.
+   *
+   * Never throws — the outcome is reported via `OrderWritebackResult`:
+   * - `dispatched` → set WC status `completed` (delegates to `updateFulfillment`,
+   *   the same neutral-`shipped` → WC-`completed` mapping). `applied`.
+   * - `cancelled`  → refuse (`rejected`) if WC has already reached a terminal
+   *   fulfilled state (`completed` / `refunded`) — the shop is authoritative for
+   *   its own live state, so we surface the conflict rather than force a
+   *   regressive transition. Idempotent when already `cancelled`. Otherwise PUT
+   *   `cancelled`. `applied`.
+   */
+  async write(event: OrderLifecycleEvent): Promise<OrderWritebackResult> {
+    try {
+      if (!/^\d+$/.test(event.externalOrderId)) {
+        return {
+          outcome: 'rejected',
+          detail: `Invalid externalOrderId "${event.externalOrderId}" — expected a WC integer ID`,
+        };
+      }
+
+      if (event.type === 'dispatched') {
+        await this.updateFulfillment({
+          externalOrderId: event.externalOrderId,
+          status: 'shipped',
+          trackingNumber: event.trackingNumber,
+        });
+        return { outcome: 'applied' };
+      }
+
+      // event.type === 'cancelled' — one read to honour the shop's authoritative
+      // live state before forcing a regressive transition.
+      const order = await this.httpClient.get<WooCommerceOrderResponse>(
+        `/wp-json/wc/v3/orders/${event.externalOrderId}`,
+      );
+      const currentStatus = order.status;
+
+      if (currentStatus === 'completed' || currentStatus === 'refunded') {
+        this.logger.warn(
+          `WooCommerce order ${event.externalOrderId} already in terminal state ` +
+            `'${currentStatus}' — refusing cancel writeback (connection: ${this.connection.id})`,
+        );
+        return { outcome: 'rejected', detail: `order already ${currentStatus}` };
+      }
+
+      if (currentStatus === 'cancelled') {
+        this.logger.debug(
+          `WooCommerce order ${event.externalOrderId} already cancelled — cancel writeback is a no-op ` +
+            `(connection: ${this.connection.id})`,
+        );
+        return { outcome: 'applied' };
+      }
+
+      const wcStatus = WC_ORDER_STATUS_MAP.cancelled;
+      await this.httpClient.put<WooCommerceOrderUpdateRequest>(
+        `/wp-json/wc/v3/orders/${event.externalOrderId}`,
+        { status: wcStatus } satisfies WooCommerceOrderUpdateRequest,
+      );
+      return { outcome: 'applied' };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `OrderStatusWriteback '${event.type}' failed for WooCommerce order ` +
+          `${event.externalOrderId}: ${detail} (connection: ${this.connection.id})`,
+        error instanceof Error ? error.stack : undefined,
+      );
+      return { outcome: 'rejected', detail };
     }
   }
 

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -3,8 +3,10 @@
  *
  * Implements OrderProcessorManagerPort (createOrder), the OrderFulfillmentUpdater
  * sub-capability (updateFulfillment — status updates, cancellations, refund transitions),
- * and the OrderStatusWriteback sub-capability (write — the #1157 / ADR-027 lifecycle
- * relay contract) for WooCommerce REST API v3.
+ * the OrderStatusWriteback sub-capability (write — the #1157 / ADR-027 lifecycle
+ * relay contract), and the FulfillmentStatusReader sub-capability (getFulfillmentStatus
+ * — the #834 / #1550 read-back of the shop's fulfillment view) for WooCommerce REST
+ * API v3.
  *
  * Key design decisions:
  * - createOrder: the adapter does NOT dedup. It POSTs to WC and returns the
@@ -29,6 +31,7 @@
  * @implements {OrderProcessorManagerPort}
  * @implements {OrderFulfillmentUpdater}
  * @implements {OrderStatusWriteback}
+ * @implements {FulfillmentStatusReader}
  */
 import type {
   OrderProcessorManagerPort,
@@ -43,6 +46,8 @@ import type {
   OrderStatusWriteback,
   OrderLifecycleEvent,
   OrderWritebackResult,
+  FulfillmentStatusReader,
+  FulfillmentStatusSnapshot,
 } from '@openlinker/core/orders';
 import type { IdentifierMappingPort, Connection, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
@@ -67,6 +72,7 @@ import type {
   WooCommerceCustomerResponse,
 } from './woocommerce-order.types';
 import { WC_ORDER_STATUS_MAP } from './woocommerce-order.types';
+import { mapToFulfillmentStatusSnapshot } from './woocommerce-fulfillment-status.mapper';
 
 // ─── Module-level pure helpers ────────────────────────────────────────────────
 // Pure functions with no dependency on adapter state — independently testable.
@@ -82,7 +88,11 @@ export function isValidEmail(value: unknown): value is string {
 // ─── Adapter ──────────────────────────────────────────────────────────────────
 
 export class WooCommerceOrderProcessorAdapter
-  implements OrderProcessorManagerPort, OrderFulfillmentUpdater, OrderStatusWriteback
+  implements
+    OrderProcessorManagerPort,
+    OrderFulfillmentUpdater,
+    OrderStatusWriteback,
+    FulfillmentStatusReader
 {
   private readonly logger = new Logger(WooCommerceOrderProcessorAdapter.name);
 
@@ -288,6 +298,52 @@ export class WooCommerceOrderProcessorAdapter
         error instanceof Error ? error.stack : undefined,
       );
       return { outcome: 'rejected', detail };
+    }
+  }
+
+  // ─── FulfillmentStatusReader ──────────────────────────────────────────────
+
+  /**
+   * `FulfillmentStatusReader` (#834 / #1550): read the shop's view of an
+   * order's fulfillment progress. GETs `/orders/{id}`, reads the WC `status`,
+   * and maps it to the neutral `FulfillmentStatusSnapshot` via
+   * {@link mapToFulfillmentStatusSnapshot}.
+   *
+   * `status` is `null` when the shop has not yet fulfilled the order
+   * (`pending` / `processing` / `on-hold` / `failed`) — the branch-1 sync
+   * service treats that as "no shipment to project, skip this pass".
+   * `trackingNumber` is always `null` (WC core carries no order-level tracking
+   * field). `externalOrderId` is the WC-native numeric order id.
+   */
+  async getFulfillmentStatus(input: {
+    externalOrderId: string;
+  }): Promise<FulfillmentStatusSnapshot> {
+    this.logger.debug(
+      `getFulfillmentStatus: externalOrderId=${input.externalOrderId} (connection: ${this.connection.id})`,
+    );
+
+    // Path-traversal defence — externalOrderId must be a bare positive integer string.
+    if (!/^\d+$/.test(input.externalOrderId)) {
+      throw new WooCommerceInvalidArgumentException(
+        `Invalid externalOrderId "${input.externalOrderId}" — expected a WC integer ID`,
+      );
+    }
+
+    try {
+      const order = await this.httpClient.get<WooCommerceOrderResponse>(
+        `/wp-json/wc/v3/orders/${input.externalOrderId}`,
+      );
+      return mapToFulfillmentStatusSnapshot(order);
+    } catch (err) {
+      if (err instanceof WooCommerceHttpResponseException && err.statusCode === 404) {
+        throw new WooCommerceResourceNotFoundException(
+          `WooCommerce order ${input.externalOrderId} not found`,
+          CORE_ENTITY_TYPE.Order,
+          input.externalOrderId,
+          this.connection.id,
+        );
+      }
+      throw err;
     }
   }
 

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-status.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-status.types.ts
@@ -1,0 +1,51 @@
+/**
+ * WooCommerce Order Status Vocabulary and Mapping
+ *
+ * The shared, single source of truth for translating between OpenLinker's
+ * neutral `OrderStatus` and WooCommerce's own order-status vocabulary. Kept in a
+ * dedicated `*.types.ts` module (per the `as const` convention) so every
+ * WooCommerce order sub-capability reuses the same map and vocabulary without
+ * duplication:
+ * - `OrderStatusWriteback` / `OrderFulfillmentUpdater` / `createOrder` (#1549) —
+ *   neutral → WC direction via {@link WC_ORDER_STATUS_MAP}.
+ * - `FulfillmentStatusReader` (#1550) — WC → neutral direction, keyed off
+ *   {@link WooCommerceOrderStatus}.
+ * - `DestinationOptionsReader` (#1551) — enumerates the WC status vocabulary via
+ *   {@link WC_ORDER_STATUS_VALUES}.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
+ */
+import type { OrderStatus } from '@openlinker/core/orders';
+
+/**
+ * The WooCommerce core order-status vocabulary (WC REST API v3). Declared as a
+ * runtime array so consumers can enumerate it (option pickers, validation)
+ * without an enum runtime artifact.
+ */
+export const WC_ORDER_STATUS_VALUES = [
+  'pending',
+  'processing',
+  'on-hold',
+  'completed',
+  'cancelled',
+  'refunded',
+  'failed',
+] as const;
+
+/** A WooCommerce core order status. */
+export type WooCommerceOrderStatus = (typeof WC_ORDER_STATUS_VALUES)[number];
+
+/**
+ * Neutral `OrderStatus` → WooCommerce status. Lossy best-effort: WC has no
+ * distinct `shipped` state, so both `shipped` and `delivered` collapse onto
+ * `completed`. Exported so tests and sibling sub-capabilities verify it without
+ * instantiating an adapter.
+ */
+export const WC_ORDER_STATUS_MAP: Record<OrderStatus, WooCommerceOrderStatus> = {
+  pending: 'pending',
+  processing: 'processing',
+  shipped: 'completed',
+  delivered: 'completed',
+  cancelled: 'cancelled',
+  refunded: 'refunded',
+};

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order.types.ts
@@ -75,6 +75,10 @@ export interface WooCommerceOrderResponse {
   id?: number;
   number?: string;
   status?: string;
+  /** GMT timestamp WC stamps when an order transitions to `completed`. */
+  date_completed_gmt?: string;
+  /** GMT timestamp of the order's last modification — `deliveredAt` fallback. */
+  date_modified_gmt?: string;
 }
 
 // ─── Customer shapes ──────────────────────────────────────────────────────────

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order.types.ts
@@ -2,26 +2,21 @@
  * WooCommerce Order Adapter Types
  *
  * Request and response shapes for WooCommerce REST API v3 order and customer
- * operations, plus the OL OrderStatus → WC status mapping constant.
+ * operations.
  *
  * All response fields are declared optional where the WC API may omit them.
  *
+ * The OL `OrderStatus` → WC status map and the WC status vocabulary live in the
+ * dedicated `woocommerce-order-status.types.ts` module (shared across the order
+ * sub-capabilities); they are re-exported here for import-path stability.
+ *
  * @module libs/integrations/woocommerce/src/infrastructure/adapters/order-processor
  */
-import type { OrderStatus } from '@openlinker/core/orders';
 
-// ─── Status map ───────────────────────────────────────────────────────────────
-// Exported as a constant so tests can import and verify it without instantiating
-// the adapter (DRY, single source of truth for the WC status mapping).
+// ─── Status map (re-exported from the dedicated status module) ──────────────────
 
-export const WC_ORDER_STATUS_MAP: Record<OrderStatus, string> = {
-  pending:    'pending',
-  processing: 'processing',
-  shipped:    'completed',
-  delivered:  'completed',
-  cancelled:  'cancelled',
-  refunded:   'refunded',
-};
+export { WC_ORDER_STATUS_MAP, WC_ORDER_STATUS_VALUES } from './woocommerce-order-status.types';
+export type { WooCommerceOrderStatus } from './woocommerce-order-status.types';
 
 // ─── Order shapes ─────────────────────────────────────────────────────────────
 

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/woocommerce-product-master.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/woocommerce-product-master.adapter.ts
@@ -36,6 +36,7 @@ import { Logger } from '@openlinker/shared/logging';
 import type { IWooCommerceHttpClient } from '../../http/woocommerce-http-client.interface';
 import { WooCommerceHttpResponseException } from '../../http/woocommerce-http-response.exception';
 import type { IWooCommerceProductMapper } from '../../mappers/woocommerce-product.mapper.interface';
+import { buildSyntheticVariantExternalId } from '../../mappers/woocommerce-variant-id';
 import { WooCommerceResourceNotFoundException } from '../../../domain/exceptions/woocommerce-resource-not-found.exception';
 import { WooCommerceDuplicateSkuException } from '../../../domain/exceptions/woocommerce-duplicate-sku.exception';
 import type {
@@ -180,7 +181,7 @@ export class WooCommerceProductMasterAdapter implements ProductMasterPort {
 
     if (product.type !== 'variable' || !product.variations?.length) {
       // Simple product — deterministic synthetic variant (same convention as PrestaShop)
-      const syntheticExternalId = `product:${wcId}`;
+      const syntheticExternalId = buildSyntheticVariantExternalId(wcId);
       const internalVariantId = await this.identifierMapping.getOrCreateInternalId(
         CORE_ENTITY_TYPE.ProductVariant,
         syntheticExternalId,
@@ -209,7 +210,7 @@ export class WooCommerceProductMasterAdapter implements ProductMasterPort {
     // Variable product — delete stale synthetic (safe no-op if absent)
     await this.identifierMapping.deleteMapping(
       CORE_ENTITY_TYPE.ProductVariant,
-      `product:${wcId}`,
+      buildSyntheticVariantExternalId(wcId),
       this.connection.id,
     );
 

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-event-translator.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-event-translator.adapter.ts
@@ -50,19 +50,16 @@ export class WooCommerceWebhookEventTranslatorAdapter implements WebhookEventTra
   /**
    * Map the WooCommerce order event type into the order domain's advisory
    * vocabulary. Accepts both the full WC topic (`order.created`) and its bare
-   * action (`created`). `OrderFeedEventType` has no `status_changed`, so any
-   * update is `updated`; a delete/trash maps to `cancelled`; unknown order
-   * events fall back to `updated` (a safe re-pull).
+   * action (`created`). Only `order.created` / `order.updated` are provisioned
+   * (see `WOOCOMMERCE_ORDER_WEBHOOK_TOPICS`); `OrderFeedEventType` has no
+   * `status_changed`, so anything that isn't a create falls back to `updated`
+   * (a safe re-pull — the authoritative order is fetched downstream).
    */
   private orderEventType(eventType: string): string {
     switch (eventType.toLowerCase()) {
       case 'order.created':
       case 'created':
         return 'created';
-      case 'order.deleted':
-      case 'deleted':
-      case 'trash':
-        return 'cancelled';
       case 'order.updated':
       case 'updated':
       default:

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-event-translator.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-event-translator.adapter.ts
@@ -1,0 +1,72 @@
+/**
+ * WooCommerce Webhook Event Translator Adapter (#1548 / ADR-015)
+ *
+ * Decodes WooCommerce inbound webhook events into neutral
+ * `CanonicalInboundEvent`s. Pure transform — no I/O, no connection state.
+ * WooCommerce delivers topic-based order events (`order.created`,
+ * `order.updated`); the decoder that runs before this translator sets
+ * `objectType = 'order'` and carries the WC topic (or its bare action) as
+ * `eventType`.
+ *
+ * This is the only place that holds WooCommerce's webhook vocabulary — the
+ * core `InboundRoutingPolicy` maps the neutral `domain` -> `jobType`
+ * (order -> `marketplace.order.sync`, gated on the `OrderSource` capability)
+ * with zero platform knowledge. Unknown object types return `null`
+ * (-> dead-letter), keeping the translator total (ADR-015 invariant 5).
+ *
+ * WooCommerce is treated as an order SOURCE over webhooks: the webhook is a
+ * low-latency nudge, never the source of truth. The advisory `eventType` is
+ * coerced by the routing policy to an `OrderFeedEventType`; the authoritative
+ * order is re-pulled by `WooCommerceOrderSourceAdapter.getOrder` downstream.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters
+ * @see {@link CanonicalInboundEvent} for the neutral output contract
+ */
+import type { InboundWebhookEvent } from '@openlinker/core/events';
+import type {
+  CanonicalInboundEvent,
+  WebhookEventTranslatorPort,
+} from '@openlinker/core/integrations';
+
+export class WooCommerceWebhookEventTranslatorAdapter implements WebhookEventTranslatorPort {
+  translate(event: InboundWebhookEvent): CanonicalInboundEvent | null {
+    const objectType = event.objectType.toLowerCase();
+
+    switch (objectType) {
+      case 'order':
+        return {
+          domain: 'order',
+          externalId: event.externalId,
+          eventType: this.orderEventType(event.eventType),
+          occurredAt: event.occurredAt,
+          payload: event.payload,
+        };
+      default:
+        // Unknown object type — not decodable by this plugin -> dead-letter.
+        return null;
+    }
+  }
+
+  /**
+   * Map the WooCommerce order event type into the order domain's advisory
+   * vocabulary. Accepts both the full WC topic (`order.created`) and its bare
+   * action (`created`). `OrderFeedEventType` has no `status_changed`, so any
+   * update is `updated`; a delete/trash maps to `cancelled`; unknown order
+   * events fall back to `updated` (a safe re-pull).
+   */
+  private orderEventType(eventType: string): string {
+    switch (eventType.toLowerCase()) {
+      case 'order.created':
+      case 'created':
+        return 'created';
+      case 'order.deleted':
+      case 'deleted':
+      case 'trash':
+        return 'cancelled';
+      case 'order.updated':
+      case 'updated':
+      default:
+        return 'updated';
+    }
+  }
+}

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-provisioning.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-provisioning.adapter.ts
@@ -1,0 +1,212 @@
+/**
+ * WooCommerce Webhook Provisioning Adapter (#1548)
+ *
+ * Implements `WebhookProvisioningPort` for the WooCommerce platform — registers
+ * the store-side order webhooks through WooCommerce REST v3
+ * (`POST /wp-json/wc/v3/webhooks`), each pointing at OpenLinker's inbound
+ * ingress (`/webhooks/woocommerce/:connectionId`). Resolved per-connection by
+ * `ConnectionService.installWebhooks` via `WebhookProvisioningRegistryService`
+ * indexed by `adapterKey`; self-registers from `WooCommerceWebhookProvisioningModule`
+ * (it needs the NestJS-injected `ConnectionPort` + `IWebhookSecretService`, which
+ * are deliberately NOT part of the framework-neutral `HostServices` bag).
+ *
+ * Flow (mirrors the PrestaShop / Erli provisioners):
+ *   1. Validate connection config (callback base URL set, siteUrl set).
+ *   2. Rotate the connection's webhook secret (one-shot plaintext) and hand it
+ *      to WooCommerce as each webhook's `secret` — WC signs every delivery with
+ *      a base64 HMAC-SHA256 of the raw body keyed by this secret.
+ *   3. Upsert one webhook per order topic (`order.created`, `order.updated`),
+ *      idempotently: an existing webhook matching topic + delivery_url is PUT
+ *      (secret rotated, status re-activated); otherwise a new one is POSTed.
+ *   4. Mark `connection.config.webhooksConfigured = true`.
+ *
+ * SIGNATURE VERIFICATION DELTA (#1548 acceptance criterion 4): WooCommerce signs
+ * inbound deliveries with `X-WC-Webhook-Signature: <base64(HMAC-SHA256(rawBody))>`
+ * and sends NO signed timestamp header. The host's default inbound decoder
+ * (`DefaultWebhookDecoder`) expects OpenLinker's own scheme
+ * (`X-OpenLinker-Timestamp` + `X-OpenLinker-Signature = sha256=<hex>` over
+ * `timestamp.body`). The two are incompatible, so end-to-end inbound
+ * authentication requires a WooCommerce-specific `InboundWebhookDecoderPort`
+ * (the ADR-021 seam, exactly like `ErliInboundWebhookDecoderAdapter`) that
+ * verifies the base64 signature and omits the replay-timestamp. That decoder is
+ * a scoped follow-up; this adapter provisions the store side so the decoder can
+ * verify against the same rotated secret when it lands. Until then the
+ * `WooCommerceOrderSourceAdapter` poll remains the reconciliation backstop.
+ *
+ * TEST PING: WooCommerce has no synchronous, verifiable test-ping round-trip
+ * (its own "ping" on webhook creation is delivered asynchronously and cannot be
+ * observed inside this call), so `testPingTriggered` is always `false` by design
+ * — not a degraded state. No warning is attached on the happy path.
+ *
+ * Failure-mode policy: accept-and-surface. Hard validation fails closed
+ * (`BadRequestException`); a partial state after a successful push returns a
+ * `warning`.
+ *
+ * Security: the rotated secret is sent ONLY in the WC request body — never logged.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters
+ * @implements {WebhookProvisioningPort}
+ * @see {@link WooCommerceWebhookEventTranslatorAdapter} for the downstream translator
+ */
+import { BadRequestException } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
+import type {
+  CredentialsResolverPort,
+  IWebhookSecretService,
+  WebhookProvisioningPort,
+  WebhookProvisioningResult,
+} from '@openlinker/core/integrations';
+import type { WooCommerceConnectionConfig } from '../../domain/types/woocommerce-config.types';
+import type { WooCommerceCredentials } from '../../domain/types/woocommerce-credentials.types';
+import { WooCommerceHttpClient } from '../http/woocommerce-http-client';
+import type { IWooCommerceHttpClient } from '../http/woocommerce-http-client.interface';
+import {
+  WOOCOMMERCE_ORDER_WEBHOOK_TOPICS,
+  WOOCOMMERCE_WEBHOOK_PROVIDER,
+  WOOCOMMERCE_WEBHOOKS_PATH,
+  type WooCommerceOrderWebhookTopic,
+  type WooCommerceWebhookResource,
+  type WooCommerceWebhookWriteBody,
+} from './woocommerce-webhook.types';
+
+/** Upper bound on the existing-webhook listing used for idempotent upserts. */
+const WEBHOOK_LIST_PAGE_SIZE = 100;
+
+export class WooCommerceWebhookProvisioningAdapter implements WebhookProvisioningPort {
+  private readonly logger = new Logger(WooCommerceWebhookProvisioningAdapter.name);
+
+  constructor(
+    private readonly connectionPort: ConnectionPort,
+    private readonly webhookSecretService: IWebhookSecretService,
+    private readonly credentialsResolver: CredentialsResolverPort,
+  ) {}
+
+  async install(connectionId: string, actorUserId?: string): Promise<WebhookProvisioningResult> {
+    // Routing by adapterKey guarantees this adapter only sees WooCommerce
+    // connections; the unsupported-platform 400 lives in
+    // `ConnectionService.installWebhooks`.
+    const connection = await this.connectionPort.get(connectionId);
+    const config = (connection.config ?? {}) as Partial<WooCommerceConnectionConfig>;
+
+    const callbackBaseUrl = config.openlinkerCallbackBaseUrl?.trim();
+    if (!callbackBaseUrl) {
+      throw new BadRequestException(
+        'Set the OL callback URL on the connection-edit page before configuring webhooks. ' +
+          'WooCommerce needs to know where to POST events back to OL ' +
+          '(e.g. http://host.docker.internal:3000 in dev, your public OL URL in prod).',
+      );
+    }
+
+    if (!config.siteUrl || typeof config.siteUrl !== 'string') {
+      // Defensive — should be caught by the config-shape DTO at save time.
+      throw new BadRequestException(`Connection ${connectionId} is missing siteUrl in config.`);
+    }
+
+    // Rotate the shared secret (one-shot plaintext). WooCommerce signs each
+    // delivery with it; it is sent only in the WC webhook body below.
+    const { secret } = await this.webhookSecretService.rotate(
+      WOOCOMMERCE_WEBHOOK_PROVIDER,
+      connectionId,
+      actorUserId,
+    );
+
+    const httpClient = await this.createHttpClient(connection.credentialsRef, config.siteUrl);
+    const deliveryUrl = `${callbackBaseUrl.replace(/\/$/, '')}/webhooks/${WOOCOMMERCE_WEBHOOK_PROVIDER}/${connectionId}`;
+
+    try {
+      const existing = await this.listWebhooks(httpClient);
+      for (const topic of WOOCOMMERCE_ORDER_WEBHOOK_TOPICS) {
+        await this.upsertWebhook(httpClient, existing, topic, deliveryUrl, secret, connectionId);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Failed to register WooCommerce webhooks for connection ${connectionId}: ${message}`,
+      );
+      throw new BadRequestException(
+        `WooCommerce webhook registration failed: ${message}. The webhook secret was rotated ` +
+          "on OL's side; re-running install is safe (registration is idempotent).",
+      );
+    }
+
+    // Record success on the connection (best-effort; re-running install is safe).
+    let stateUpdateOk = true;
+    try {
+      await this.connectionPort.update(connectionId, {
+        config: { ...connection.config, webhooksConfigured: true },
+      });
+    } catch (error) {
+      stateUpdateOk = false;
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `WooCommerce webhooks registered but the connection state update failed for ` +
+          `${connectionId}: ${message}. WC has the right config; re-running install is idempotent.`,
+      );
+    }
+
+    this.logger.log(
+      `webhook_install.completed connectionId=${connectionId} provider=woocommerce ` +
+        `webhooksConfigured=${stateUpdateOk} topics=${WOOCOMMERCE_ORDER_WEBHOOK_TOPICS.length} ` +
+        `actor=${actorUserId ?? 'system'}`,
+    );
+
+    // testPingTriggered is always false for WooCommerce (no synchronous,
+    // verifiable ping — see the module doc); it is not a failure, so no warning.
+    return {
+      webhooksConfigured: stateUpdateOk,
+      testPingTriggered: false,
+      ...(stateUpdateOk ? {} : { warning: 'state-update-failed' }),
+    };
+  }
+
+  /**
+   * List the store's existing webhooks (single page — a store legitimately
+   * carrying >100 webhooks is out of scope; the upsert simply creates a new one
+   * if a match isn't on the first page, which WC tolerates).
+   */
+  private async listWebhooks(
+    httpClient: IWooCommerceHttpClient,
+  ): Promise<WooCommerceWebhookResource[]> {
+    return httpClient.get<WooCommerceWebhookResource[]>(WOOCOMMERCE_WEBHOOKS_PATH, {
+      per_page: WEBHOOK_LIST_PAGE_SIZE,
+    });
+  }
+
+  /**
+   * Upsert one webhook by (topic + delivery_url): PUT an existing match (rotates
+   * the secret, re-activates it) or POST a new one. Matching on delivery_url
+   * keeps re-runs from stacking duplicate webhooks on the store.
+   */
+  private async upsertWebhook(
+    httpClient: IWooCommerceHttpClient,
+    existing: WooCommerceWebhookResource[],
+    topic: WooCommerceOrderWebhookTopic,
+    deliveryUrl: string,
+    secret: string,
+    connectionId: string,
+  ): Promise<void> {
+    const body: WooCommerceWebhookWriteBody = {
+      name: `OpenLinker ${topic} (connection ${connectionId})`,
+      topic,
+      delivery_url: deliveryUrl,
+      secret,
+      status: 'active',
+    };
+
+    const match = existing.find((w) => w.topic === topic && w.delivery_url === deliveryUrl);
+    if (match) {
+      await httpClient.put(`${WOOCOMMERCE_WEBHOOKS_PATH}/${match.id}`, body);
+      return;
+    }
+    await httpClient.post(WOOCOMMERCE_WEBHOOKS_PATH, body);
+  }
+
+  private async createHttpClient(
+    credentialsRef: string,
+    siteUrl: string,
+  ): Promise<IWooCommerceHttpClient> {
+    const credentials = await this.credentialsResolver.get<WooCommerceCredentials>(credentialsRef);
+    return new WooCommerceHttpClient(siteUrl, credentials.consumerKey, credentials.consumerSecret);
+  }
+}

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-provisioning.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-provisioning.adapter.ts
@@ -29,9 +29,12 @@
  * authentication requires a WooCommerce-specific `InboundWebhookDecoderPort`
  * (the ADR-021 seam, exactly like `ErliInboundWebhookDecoderAdapter`) that
  * verifies the base64 signature and omits the replay-timestamp. That decoder is
- * a scoped follow-up; this adapter provisions the store side so the decoder can
- * verify against the same rotated secret when it lands. Until then the
- * `WooCommerceOrderSourceAdapter` poll remains the reconciliation backstop.
+ * a scoped follow-up (tracked in #1563); this adapter provisions the store side
+ * so the decoder can verify against the same rotated secret when it lands. Until
+ * then the `WooCommerceOrderSourceAdapter` poll remains the reconciliation
+ * backstop, and inbound deliveries fail host signature verification (WooCommerce
+ * may auto-disable the store-side webhook after repeated failures — re-run
+ * install once #1563 ships).
  *
  * TEST PING: WooCommerce has no synchronous, verifiable test-ping round-trip
  * (its own "ping" on webhook creation is delivered asynchronously and cannot be
@@ -50,7 +53,7 @@
  */
 import { BadRequestException } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
-import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
+import type { Connection, ConnectionPort } from '@openlinker/core/identifier-mapping';
 import type {
   CredentialsResolverPort,
   IWebhookSecretService,
@@ -124,11 +127,30 @@ export class WooCommerceWebhookProvisioningAdapter implements WebhookProvisionin
       this.logger.error(
         `Failed to register WooCommerce webhooks for connection ${connectionId}: ${message}`,
       );
+      // Fail-closed visibility: the secret was already rotated OL-side, but WC may
+      // still hold the old/no secret, so inbound signature verification stays
+      // broken until install is re-run. Best-effort flip the persisted
+      // `webhooksConfigured` flag to false so a prior `true` doesn't go stale and
+      // the connection-actions UI shows webhooks are NOT live. The order-source
+      // poll still backstops order loss.
+      await this.markWebhooksUnconfigured(connectionId, connection.config);
       throw new BadRequestException(
         `WooCommerce webhook registration failed: ${message}. The webhook secret was rotated ` +
           "on OL's side; re-running install is safe (registration is idempotent).",
       );
     }
+
+    // Inbound auth is not yet wired end-to-end: WC signs deliveries with the
+    // base64 `X-WC-Webhook-Signature` scheme the host default decoder cannot
+    // verify, so provisioned deliveries fail verification (and WC may auto-disable
+    // the store-side webhook) until the decoder follow-up (#1563) ships.
+    this.logger.warn(
+      `WooCommerce webhooks registered for connection ${connectionId}, but inbound signature ` +
+        'verification is PENDING the decoder follow-up (#1563): WC signs deliveries with ' +
+        'X-WC-Webhook-Signature, which the host default decoder cannot verify yet, so these ' +
+        'deliveries will fail verification (and WC may auto-disable the webhook). The ' +
+        'order-source poll remains the reconciliation backstop until then.',
+    );
 
     // Record success on the connection (best-effort; re-running install is safe).
     let stateUpdateOk = true;
@@ -161,16 +183,51 @@ export class WooCommerceWebhookProvisioningAdapter implements WebhookProvisionin
   }
 
   /**
-   * List the store's existing webhooks (single page — a store legitimately
-   * carrying >100 webhooks is out of scope; the upsert simply creates a new one
-   * if a match isn't on the first page, which WC tolerates).
+   * List the store's existing webhooks, paging until exhausted. A store can
+   * legitimately carry more than one page of webhooks; if OL's rows aren't on
+   * the first page the upsert would otherwise stack duplicates, so we walk every
+   * page (WC returns fewer than `per_page` items on the last one).
    */
   private async listWebhooks(
     httpClient: IWooCommerceHttpClient,
   ): Promise<WooCommerceWebhookResource[]> {
-    return httpClient.get<WooCommerceWebhookResource[]>(WOOCOMMERCE_WEBHOOKS_PATH, {
-      per_page: WEBHOOK_LIST_PAGE_SIZE,
-    });
+    const all: WooCommerceWebhookResource[] = [];
+    for (let page = 1; ; page += 1) {
+      const batch = await httpClient.get<WooCommerceWebhookResource[]>(WOOCOMMERCE_WEBHOOKS_PATH, {
+        per_page: WEBHOOK_LIST_PAGE_SIZE,
+        page,
+      });
+      if (!Array.isArray(batch) || batch.length === 0) {
+        break;
+      }
+      all.push(...batch);
+      if (batch.length < WEBHOOK_LIST_PAGE_SIZE) {
+        break;
+      }
+    }
+    return all;
+  }
+
+  /**
+   * Best-effort flip of the persisted `webhooksConfigured` flag to false after a
+   * failed registration. Swallows its own errors so it never masks the original
+   * registration failure — the caller still throws the actionable message.
+   */
+  private async markWebhooksUnconfigured(
+    connectionId: string,
+    config: Connection['config'],
+  ): Promise<void> {
+    try {
+      await this.connectionPort.update(connectionId, {
+        config: { ...config, webhooksConfigured: false },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not flag connection ${connectionId} as webhooks-unconfigured after a ` +
+          `registration failure: ${message}. Re-running install is idempotent.`,
+      );
+    }
   }
 
   /**

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook.types.ts
@@ -23,14 +23,6 @@ export const WOOCOMMERCE_WEBHOOK_PROVIDER = 'woocommerce';
 export const WOOCOMMERCE_WEBHOOKS_PATH = '/wp-json/wc/v3/webhooks';
 
 /**
- * WooCommerce delivery signature header (base64 HMAC-SHA256 of the raw body,
- * keyed by the webhook's `secret`). Documented here as the authoritative name
- * for the future inbound decoder (see the provisioning adapter's signature
- * note); the host default OL-HMAC decoder does not read it yet.
- */
-export const WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER = 'x-wc-webhook-signature';
-
-/**
  * Order-relevant WooCommerce webhook topics OL provisions. WooCommerce is used
  * here as an order SOURCE over webhooks (low-latency nudge; the poll reconciles),
  * so only the order lifecycle topics are registered. `order.created` and

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook.types.ts
@@ -1,0 +1,60 @@
+/**
+ * WooCommerce Webhook Types & Constants (#1548)
+ *
+ * Shared vocabulary for the WooCommerce inbound-webhook seam — used by both
+ * `WooCommerceWebhookProvisioningAdapter` (registers the store-side webhooks
+ * via WC REST `/webhooks`) and `WooCommerceWebhookEventTranslatorAdapter`
+ * (decodes a delivered event into a neutral `CanonicalInboundEvent`).
+ *
+ * WooCommerce's own webhook subsystem (WP Admin -> WooCommerce -> Settings ->
+ * Advanced -> Webhooks, or REST `POST /wp-json/wc/v3/webhooks`) delivers a
+ * topic-based event to a `delivery_url`, signed with a base64 HMAC-SHA256 of
+ * the raw body in the `X-WC-Webhook-Signature` header. It sends NO signed
+ * timestamp header. See `docs/architecture-overview.md` (webhook ingestion)
+ * for how the host authenticates inbound deliveries.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters
+ */
+
+/** Webhook-secret provider key + URL `:provider` segment for WooCommerce connections. */
+export const WOOCOMMERCE_WEBHOOK_PROVIDER = 'woocommerce';
+
+/** WooCommerce REST v3 webhooks collection resource. */
+export const WOOCOMMERCE_WEBHOOKS_PATH = '/wp-json/wc/v3/webhooks';
+
+/**
+ * WooCommerce delivery signature header (base64 HMAC-SHA256 of the raw body,
+ * keyed by the webhook's `secret`). Documented here as the authoritative name
+ * for the future inbound decoder (see the provisioning adapter's signature
+ * note); the host default OL-HMAC decoder does not read it yet.
+ */
+export const WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER = 'x-wc-webhook-signature';
+
+/**
+ * Order-relevant WooCommerce webhook topics OL provisions. WooCommerce is used
+ * here as an order SOURCE over webhooks (low-latency nudge; the poll reconciles),
+ * so only the order lifecycle topics are registered. `order.created` and
+ * `order.updated` together cover the "new order" and "status/detail changed"
+ * signals; the authoritative order is always re-pulled downstream.
+ */
+export const WOOCOMMERCE_ORDER_WEBHOOK_TOPICS = ['order.created', 'order.updated'] as const;
+
+export type WooCommerceOrderWebhookTopic = (typeof WOOCOMMERCE_ORDER_WEBHOOK_TOPICS)[number];
+
+/** Body OL sends to WC REST when creating or updating a webhook. */
+export interface WooCommerceWebhookWriteBody {
+  name: string;
+  topic: string;
+  delivery_url: string;
+  secret: string;
+  status: 'active';
+}
+
+/** Subset of the WC webhook resource OL reads back when listing/creating. */
+export interface WooCommerceWebhookResource {
+  id: number;
+  name?: string;
+  status?: string;
+  topic?: string;
+  delivery_url?: string;
+}

--- a/libs/integrations/woocommerce/src/infrastructure/mappers/__tests__/woocommerce-variant-id.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/mappers/__tests__/woocommerce-variant-id.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the WooCommerce variant-id helpers.
+ *
+ * Locks the synthetic-variant marker contract relied on by the product-master,
+ * inventory-master, and order-processor adapters: a simple product maps to a
+ * deterministic `product:{wcId}` external id, and every call site agrees on how
+ * to build and detect it (mirrors prestashop-variant-id.spec.ts).
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/mappers
+ */
+import {
+  WOOCOMMERCE_SYNTHETIC_VARIANT_PREFIX,
+  buildSyntheticVariantExternalId,
+  isSyntheticVariantExternalId,
+} from '../woocommerce-variant-id';
+
+describe('woocommerce-variant-id', () => {
+  describe('buildSyntheticVariantExternalId', () => {
+    it('should build a product:{wcId} marker from a numeric WC product id', () => {
+      expect(buildSyntheticVariantExternalId(25)).toBe('product:25');
+    });
+
+    it('should build a product:{wcId} marker from a string WC product id', () => {
+      expect(buildSyntheticVariantExternalId('460')).toBe('product:460');
+    });
+
+    it('should be deterministic — the same product id yields the same marker', () => {
+      expect(buildSyntheticVariantExternalId(7)).toBe(buildSyntheticVariantExternalId(7));
+    });
+
+    it('should use the shared prefix constant', () => {
+      expect(buildSyntheticVariantExternalId(1)).toBe(
+        `${WOOCOMMERCE_SYNTHETIC_VARIANT_PREFIX}1`,
+      );
+    });
+  });
+
+  describe('isSyntheticVariantExternalId', () => {
+    it('should return true for a synthetic marker', () => {
+      expect(isSyntheticVariantExternalId('product:25')).toBe(true);
+    });
+
+    it('should return true for a marker built by buildSyntheticVariantExternalId', () => {
+      expect(isSyntheticVariantExternalId(buildSyntheticVariantExternalId(99))).toBe(true);
+    });
+
+    it('should return false for a real numeric WC variation id', () => {
+      expect(isSyntheticVariantExternalId('460')).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(isSyntheticVariantExternalId(undefined)).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      expect(isSyntheticVariantExternalId(null)).toBe(false);
+    });
+
+    it('should return false for an empty string', () => {
+      expect(isSyntheticVariantExternalId('')).toBe(false);
+    });
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/mappers/woocommerce-variant-id.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/mappers/woocommerce-variant-id.ts
@@ -1,0 +1,39 @@
+/**
+ * WooCommerce variant-id helpers
+ *
+ * Centralizes the synthetic-variant marker convention shared by the
+ * product-master, inventory-master, and order-processor adapters. A WooCommerce
+ * "simple product" has no WC variation, so OpenLinker maps it to a deterministic
+ * synthetic ProductVariant whose external id is `product:{wcProductId}` (matching
+ * the PrestaShop precedent). A "variable product" maps each WC variation to a
+ * variant keyed by the numeric WC variation id.
+ *
+ * Extracted so the marker literal cannot drift between the call sites that build
+ * or detect it — the same rationale behind prestashop-variant-id.ts. Before this
+ * was extracted, the `product:{wcId}` string was hand-written in three adapters,
+ * and the order-processor duplicated the `startsWith('product:')` detection
+ * inline.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/mappers
+ * @see prestashop-variant-id for the PrestaShop precedent
+ */
+
+/** Prefix marking a synthetic variant of a WooCommerce simple product. */
+export const WOOCOMMERCE_SYNTHETIC_VARIANT_PREFIX = 'product:';
+
+/**
+ * Builds the deterministic synthetic-variant external id for a simple product.
+ * Stable per WC product id, so repeat syncs resolve the same OpenLinker variant.
+ */
+export function buildSyntheticVariantExternalId(wcProductId: number | string): string {
+  return `${WOOCOMMERCE_SYNTHETIC_VARIANT_PREFIX}${wcProductId}`;
+}
+
+/**
+ * True when an external variant id is a synthetic simple-product marker rather
+ * than a real WC variation id. Callers skip variation-id coercion for these — a
+ * simple product's line item is the product itself, with no `variation_id`.
+ */
+export function isSyntheticVariantExternalId(raw: string | null | undefined): boolean {
+  return typeof raw === 'string' && raw.startsWith(WOOCOMMERCE_SYNTHETIC_VARIANT_PREFIX);
+}

--- a/libs/integrations/woocommerce/src/infrastructure/mappers/woocommerce-variant.mapper.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/mappers/woocommerce-variant.mapper.ts
@@ -1,0 +1,11 @@
+/**
+ * WooCommerce Variant Mapper
+ *
+ * Maps WooCommerce product-variation data to the OpenLinker ProductVariant
+ * schema. The mapping logic lives on WooCommerceProductMapper (mapVariation);
+ * this alias mirrors the PrestaShop layout (prestashop-variant.mapper.ts) so the
+ * variant-mapping seam has a named home.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/mappers
+ */
+export { WooCommerceProductMapper as WooCommerceVariantMapper } from './woocommerce-product.mapper';

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-address-provisioner.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-address-provisioner.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * WooCommerce Address Provisioner — unit tests
+ *
+ * Covers guest skip, reuse hit (mapping table), reuse miss (write inline address
+ * + record mapping), hash-match recovery (existing WC address), and a concurrency
+ * test proving the distributed lock prevents duplicate address writes.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__
+ */
+import { WooCommerceAddressProvisioner } from '../woocommerce-address-provisioner';
+import type { IWooCommerceHttpClient } from '../../http/woocommerce-http-client.interface';
+import type { SyncLockPort } from '@openlinker/core/sync';
+import type { CustomerProjectionRepositoryPort, AddressType } from '@openlinker/core/customers';
+import { DestinationAddressMapping } from '@openlinker/core/customers';
+import type { Address } from '@openlinker/core/orders';
+
+const CONNECTION_ID = 'conn-wc-1';
+const INTERNAL_CUSTOMER_ID = 'ol-cust-1';
+const WC_CUSTOMER_ID = 7;
+
+const originalPiiHashSalt = process.env.OL_PII_HASH_SALT;
+beforeAll(() => {
+  process.env.OL_PII_HASH_SALT = 'test-salt-for-hashing';
+});
+afterAll(() => {
+  if (originalPiiHashSalt === undefined) delete process.env.OL_PII_HASH_SALT;
+  else process.env.OL_PII_HASH_SALT = originalPiiHashSalt;
+});
+
+const ADDRESS: Address = {
+  firstName: 'Jan',
+  lastName: 'Kowalski',
+  address1: 'ul. Kwiatowa 1',
+  city: 'Warszawa',
+  postalCode: '00-001',
+  country: 'PL',
+};
+
+function makeHttpClient(): jest.Mocked<IWooCommerceHttpClient> {
+  return { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() };
+}
+
+function makeSyncLock(): SyncLockPort {
+  const locks = new Map<string, string>();
+  return {
+    acquire: jest.fn((key: string) => {
+      if (locks.has(key)) return Promise.resolve(null);
+      const token = `tok-${Math.random().toString(36).slice(2)}`;
+      locks.set(key, token);
+      return Promise.resolve(token);
+    }),
+    release: jest.fn((key: string, token: string) => {
+      if (locks.get(key) === token) {
+        locks.delete(key);
+        return Promise.resolve(true);
+      }
+      return Promise.resolve(false);
+    }),
+  };
+}
+
+/** Stateful destination-address-mapping fake. */
+function makeProjectionRepo(): jest.Mocked<CustomerProjectionRepositoryPort> {
+  const store = new Map<string, DestinationAddressMapping>();
+  const key = (i: string, c: string, h: string, t: AddressType): string => `${i}|${c}|${h}|${t}`;
+  return {
+    findById: jest.fn(),
+    findByEmailHash: jest.fn(),
+    findMany: jest.fn(),
+    upsert: jest.fn(),
+    findAddressesByCustomerId: jest.fn(),
+    upsertAddress: jest.fn(),
+    findDestinationAddressMapping: jest.fn((i: string, c: string, h: string, t: AddressType) =>
+      Promise.resolve(store.get(key(i, c, h, t)) ?? null),
+    ),
+    upsertDestinationAddressMapping: jest.fn((m: DestinationAddressMapping) => {
+      store.set(key(m.internalCustomerId, m.destinationConnectionId, m.addressHash, m.addressType), m);
+      return Promise.resolve(m);
+    }),
+  } as unknown as jest.Mocked<CustomerProjectionRepositoryPort>;
+}
+
+function input(overrides: Partial<Record<string, unknown>> = {}): {
+  internalCustomerId: string;
+  wcCustomerId: number;
+  address: Address | undefined;
+  addressType: AddressType;
+  connectionId: string;
+  httpClient: jest.Mocked<IWooCommerceHttpClient>;
+  customerProjectionRepository: jest.Mocked<CustomerProjectionRepositoryPort>;
+} {
+  return {
+    internalCustomerId: INTERNAL_CUSTOMER_ID,
+    wcCustomerId: WC_CUSTOMER_ID,
+    address: ADDRESS,
+    addressType: 'billing',
+    connectionId: CONNECTION_ID,
+    httpClient: makeHttpClient(),
+    customerProjectionRepository: makeProjectionRepo(),
+    ...overrides,
+  } as never;
+}
+
+describe('WooCommerceAddressProvisioner', () => {
+  it('should skip (return null) for a guest order (wcCustomerId <= 0)', async () => {
+    const httpClient = makeHttpClient();
+    const provisioner = new WooCommerceAddressProvisioner(makeSyncLock());
+    const result = await provisioner.resolveOrCreateAddress(input({ wcCustomerId: 0, httpClient }));
+    expect(result).toBeNull();
+    expect(httpClient.get).not.toHaveBeenCalled();
+    expect(httpClient.put).not.toHaveBeenCalled();
+  });
+
+  it('should skip (return null) when there is no address', async () => {
+    const httpClient = makeHttpClient();
+    const provisioner = new WooCommerceAddressProvisioner(makeSyncLock());
+    const result = await provisioner.resolveOrCreateAddress(input({ address: undefined, httpClient }));
+    expect(result).toBeNull();
+    expect(httpClient.put).not.toHaveBeenCalled();
+  });
+
+  it('should reuse an existing mapping without any API call (reuse hit)', async () => {
+    const repo = makeProjectionRepo();
+    (repo.findDestinationAddressMapping as jest.Mock).mockResolvedValueOnce(
+      new DestinationAddressMapping(INTERNAL_CUSTOMER_ID, CONNECTION_ID, 'h', 'billing', '7', new Date(), new Date()),
+    );
+    const httpClient = makeHttpClient();
+    const provisioner = new WooCommerceAddressProvisioner(makeSyncLock());
+
+    const result = await provisioner.resolveOrCreateAddress(
+      input({ customerProjectionRepository: repo, httpClient }),
+    );
+
+    expect(result).toBe('7');
+    expect(httpClient.get).not.toHaveBeenCalled();
+    expect(httpClient.put).not.toHaveBeenCalled();
+  });
+
+  it('should write the inline address and record the mapping (reuse miss)', async () => {
+    const repo = makeProjectionRepo();
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: WC_CUSTOMER_ID }); // no billing → no hash match
+    httpClient.put.mockResolvedValue({ id: WC_CUSTOMER_ID });
+    const provisioner = new WooCommerceAddressProvisioner(makeSyncLock());
+
+    const result = await provisioner.resolveOrCreateAddress(
+      input({ customerProjectionRepository: repo, httpClient }),
+    );
+
+    expect(result).toBe(String(WC_CUSTOMER_ID));
+    expect(httpClient.put).toHaveBeenCalledWith(
+      `/wp-json/wc/v3/customers/${WC_CUSTOMER_ID}`,
+      expect.objectContaining({ billing: expect.objectContaining({ address_1: 'ul. Kwiatowa 1', country: 'PL' }) }),
+    );
+    expect(repo.upsertDestinationAddressMapping).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reuse an address already present on the WC customer without a PUT (hash-match recovery)', async () => {
+    const repo = makeProjectionRepo();
+    const httpClient = makeHttpClient();
+    // WC customer already carries the same billing address → hashes match.
+    httpClient.get.mockResolvedValue({
+      id: WC_CUSTOMER_ID,
+      billing: { address_1: 'ul. Kwiatowa 1', city: 'Warszawa', postcode: '00-001', country: 'PL' },
+    });
+    const provisioner = new WooCommerceAddressProvisioner(makeSyncLock());
+
+    const result = await provisioner.resolveOrCreateAddress(
+      input({ customerProjectionRepository: repo, httpClient }),
+    );
+
+    expect(result).toBe(String(WC_CUSTOMER_ID));
+    expect(httpClient.put).not.toHaveBeenCalled();
+    expect(repo.upsertDestinationAddressMapping).toHaveBeenCalledTimes(1);
+  });
+
+  it('should NOT write a duplicate address under concurrent provisioning (lock serializes)', async () => {
+    const repo = makeProjectionRepo();
+    const httpClient = makeHttpClient();
+    httpClient.get.mockResolvedValue({ id: WC_CUSTOMER_ID }); // no match → would PUT
+    httpClient.put.mockResolvedValue({ id: WC_CUSTOMER_ID });
+    const syncLock = makeSyncLock();
+    const provisioner = new WooCommerceAddressProvisioner(syncLock);
+
+    const [a, b] = await Promise.all([
+      provisioner.resolveOrCreateAddress(input({ customerProjectionRepository: repo, httpClient })),
+      provisioner.resolveOrCreateAddress(input({ customerProjectionRepository: repo, httpClient })),
+    ]);
+
+    expect(a).toBe(String(WC_CUSTOMER_ID));
+    expect(b).toBe(String(WC_CUSTOMER_ID));
+    // Exactly one PUT — the second caller reused the mapping recorded by the first.
+    expect(httpClient.put).toHaveBeenCalledTimes(1);
+    expect(repo.upsertDestinationAddressMapping).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-customer-provisioner.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-customer-provisioner.spec.ts
@@ -222,4 +222,36 @@ describe('WooCommerceCustomerProvisioner', () => {
     expect(httpClient.post).toHaveBeenCalledTimes(1);
     expect(port.createMapping).toHaveBeenCalledTimes(1);
   });
+
+  it('should serialize case/whitespace email variants on the same lock key (normalized)', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.post.mockResolvedValue({ id: 88 });
+    const syncLock = makeSyncLock();
+    const provisioner = new WooCommerceCustomerProvisioner(syncLock);
+
+    // Two distinct internal customers so neither takes the mapping fast path;
+    // both provision under a lock keyed off the (normalized) email.
+    await provisioner.resolveOrCreateCustomer(
+      baseInput({
+        internalCustomerId: 'ol-cust-a',
+        buyerEmail: 'Buyer@Example.com',
+        identifierMapping: makeStatefulMapping().port,
+        httpClient,
+      }),
+    );
+    await provisioner.resolveOrCreateCustomer(
+      baseInput({
+        internalCustomerId: 'ol-cust-b',
+        buyerEmail: '  buyer@example.com  ',
+        identifierMapping: makeStatefulMapping().port,
+        httpClient,
+      }),
+    );
+
+    const acquireMock = syncLock.acquire as jest.Mock<Promise<string | null>, [string, number]>;
+    expect(acquireMock).toHaveBeenCalledTimes(2);
+    const [firstKey] = acquireMock.mock.calls[0];
+    const [secondKey] = acquireMock.mock.calls[1];
+    expect(firstKey).toBe(secondKey);
+  });
 });

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-customer-provisioner.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-customer-provisioner.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * WooCommerce Customer Provisioner — unit tests
+ *
+ * Covers resolve-or-create, guest fallback, duplicate-email recovery, auth-failure
+ * propagation, concurrent-duplicate mapping handling, and a concurrency test that
+ * proves the distributed lock prevents duplicate customer creation.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__
+ */
+import { WooCommerceCustomerProvisioner } from '../woocommerce-customer-provisioner';
+import type { IWooCommerceHttpClient } from '../../http/woocommerce-http-client.interface';
+import type { IdentifierMappingPort, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
+import type { SyncLockPort } from '@openlinker/core/sync';
+import { WooCommerceHttpResponseException } from '../../http/woocommerce-http-response.exception';
+import { WooCommerceUnauthorizedException } from '../../../domain/exceptions/woocommerce-unauthorized.exception';
+import { WooCommerceAuthFailureException } from '../../../domain/exceptions/woocommerce-auth-failure.exception';
+
+const CONNECTION_ID = 'conn-wc-1';
+const INTERNAL_CUSTOMER_ID = 'ol-cust-1';
+const EMAIL = 'buyer@example.com';
+
+function makeHttpClient(): jest.Mocked<IWooCommerceHttpClient> {
+  return { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() };
+}
+
+/** In-memory SyncLockPort — single holder per key. */
+function makeSyncLock(): SyncLockPort {
+  const locks = new Map<string, string>();
+  return {
+    acquire: jest.fn((key: string) => {
+      if (locks.has(key)) return Promise.resolve(null);
+      const token = `tok-${Math.random().toString(36).slice(2)}`;
+      locks.set(key, token);
+      return Promise.resolve(token);
+    }),
+    release: jest.fn((key: string, token: string) => {
+      if (locks.get(key) === token) {
+        locks.delete(key);
+        return Promise.resolve(true);
+      }
+      return Promise.resolve(false);
+    }),
+  };
+}
+
+/** Stateful identifier-mapping fake scoped to the Customer entity on one connection. */
+function makeStatefulMapping(): {
+  port: jest.Mocked<IdentifierMappingPort>;
+  seed(internalId: string, externalId: string): void;
+} {
+  const store = new Map<string, string>(); // internalId -> externalId
+  const port = {
+    getOrCreateInternalId: jest.fn(),
+    getOrCreateExactMapping: jest.fn(),
+    getInternalId: jest.fn(),
+    getExternalIds: jest.fn((entityType: string, internalId: string) => {
+      const externalId = store.get(internalId);
+      if (entityType !== CORE_ENTITY_TYPE.Customer || externalId === undefined) {
+        return Promise.resolve([] as ExternalIdMapping[]);
+      }
+      return Promise.resolve([
+        { externalId, connectionId: CONNECTION_ID, platformType: 'woocommerce', entityType },
+      ]);
+    }),
+    createMapping: jest.fn((_entityType: string, externalId: string, _connId: string, internalId: string) => {
+      if (store.has(internalId)) {
+        return Promise.reject(
+          new DuplicateIdentifierMappingError(CORE_ENTITY_TYPE.Customer, externalId, 'woocommerce', CONNECTION_ID),
+        );
+      }
+      store.set(internalId, externalId);
+      return Promise.resolve();
+    }),
+    batchGetOrCreateInternalIds: jest.fn(),
+    deleteMapping: jest.fn(),
+    listExternalIdsByConnection: jest.fn(),
+  } as unknown as jest.Mocked<IdentifierMappingPort>;
+  return { port, seed: (internalId, externalId) => store.set(internalId, externalId) };
+}
+
+function baseInput(overrides: Record<string, unknown> = {}): {
+  internalCustomerId: string | undefined;
+  buyerEmail: string | undefined;
+  firstName: string;
+  lastName: string;
+  connectionId: string;
+  httpClient: jest.Mocked<IWooCommerceHttpClient>;
+  identifierMapping: jest.Mocked<IdentifierMappingPort>;
+} {
+  return {
+    internalCustomerId: INTERNAL_CUSTOMER_ID,
+    buyerEmail: EMAIL,
+    firstName: 'Jan',
+    lastName: 'Kowalski',
+    connectionId: CONNECTION_ID,
+    httpClient: makeHttpClient(),
+    identifierMapping: makeStatefulMapping().port,
+    ...overrides,
+  } as never;
+}
+
+describe('WooCommerceCustomerProvisioner', () => {
+  it('should return the mapped WC customer id without any API call (resolve — existing mapping)', async () => {
+    const { port, seed } = makeStatefulMapping();
+    seed(INTERNAL_CUSTOMER_ID, '7');
+    const httpClient = makeHttpClient();
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+
+    const id = await provisioner.resolveOrCreateCustomer(
+      baseInput({ identifierMapping: port, httpClient }),
+    );
+
+    expect(id).toBe(7);
+    expect(httpClient.post).not.toHaveBeenCalled();
+  });
+
+  it('should create a WC customer and record the mapping (create — no existing mapping)', async () => {
+    const { port } = makeStatefulMapping();
+    const httpClient = makeHttpClient();
+    httpClient.post.mockResolvedValue({ id: 42 });
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+
+    const id = await provisioner.resolveOrCreateCustomer(
+      baseInput({ identifierMapping: port, httpClient }),
+    );
+
+    expect(id).toBe(42);
+    expect(httpClient.post).toHaveBeenCalledWith(
+      '/wp-json/wc/v3/customers',
+      expect.objectContaining({ email: EMAIL }),
+    );
+    expect(port.createMapping).toHaveBeenCalledWith(CORE_ENTITY_TYPE.Customer, '42', CONNECTION_ID, INTERNAL_CUSTOMER_ID);
+  });
+
+  it('should return guest (0) when there is no internal customer id', async () => {
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ internalCustomerId: undefined }));
+    expect(id).toBe(0);
+  });
+
+  it('should return guest (0) when no mapping exists and no buyer email is available', async () => {
+    const httpClient = makeHttpClient();
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ buyerEmail: undefined, httpClient }));
+    expect(id).toBe(0);
+    expect(httpClient.post).not.toHaveBeenCalled();
+  });
+
+  it('should return guest (0) when the existing mapping is corrupted (non positive-integer)', async () => {
+    const { port, seed } = makeStatefulMapping();
+    seed(INTERNAL_CUSTOMER_ID, 'not-a-number');
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ identifierMapping: port }));
+    expect(id).toBe(0);
+  });
+
+  it('should recover the existing customer by email on WC duplicate-email 400', async () => {
+    const { port } = makeStatefulMapping();
+    const httpClient = makeHttpClient();
+    httpClient.post.mockRejectedValue(new WooCommerceHttpResponseException(400, 'email exists'));
+    httpClient.get.mockResolvedValue([{ id: 99, email: EMAIL }]);
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ identifierMapping: port, httpClient }));
+
+    expect(id).toBe(99);
+    expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/customers', { email: EMAIL });
+    expect(port.createMapping).toHaveBeenCalledWith(CORE_ENTITY_TYPE.Customer, '99', CONNECTION_ID, INTERNAL_CUSTOMER_ID);
+  });
+
+  it('should propagate auth failures as WooCommerceAuthFailureException (not swallowed to guest)', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.post.mockRejectedValue(new WooCommerceUnauthorizedException('401'));
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+
+    await expect(
+      provisioner.resolveOrCreateCustomer(baseInput({ httpClient })),
+    ).rejects.toBeInstanceOf(WooCommerceAuthFailureException);
+  });
+
+  it('should degrade to guest (0) on a non-auth, non-400 API error', async () => {
+    const httpClient = makeHttpClient();
+    httpClient.post.mockRejectedValue(new WooCommerceHttpResponseException(500, 'server error'));
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ httpClient }));
+    expect(id).toBe(0);
+  });
+
+  it('should resolve the winning mapping when createMapping races (concurrent duplicate)', async () => {
+    const { port, seed } = makeStatefulMapping();
+    const httpClient = makeHttpClient();
+    httpClient.post.mockResolvedValue({ id: 55 });
+    // createMapping rejects with a duplicate, and the winner is already stored.
+    port.createMapping.mockImplementationOnce(() => {
+      seed(INTERNAL_CUSTOMER_ID, '55');
+      return Promise.reject(
+        new DuplicateIdentifierMappingError(CORE_ENTITY_TYPE.Customer, '55', 'woocommerce', CONNECTION_ID),
+      );
+    });
+    const provisioner = new WooCommerceCustomerProvisioner(makeSyncLock());
+
+    const id = await provisioner.resolveOrCreateCustomer(baseInput({ identifierMapping: port, httpClient }));
+    expect(id).toBe(55);
+  });
+
+  it('should NOT create a duplicate customer under concurrent provisioning (lock serializes)', async () => {
+    const { port } = makeStatefulMapping();
+    const httpClient = makeHttpClient();
+    httpClient.post.mockResolvedValue({ id: 77 });
+    const syncLock = makeSyncLock();
+    const provisioner = new WooCommerceCustomerProvisioner(syncLock);
+
+    const [a, b] = await Promise.all([
+      provisioner.resolveOrCreateCustomer(baseInput({ identifierMapping: port, httpClient })),
+      provisioner.resolveOrCreateCustomer(baseInput({ identifierMapping: port, httpClient })),
+    ]);
+
+    expect(a).toBe(77);
+    expect(b).toBe(77);
+    // Exactly one POST /customers — the second caller reused the mapping after the lock.
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    expect(port.createMapping).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-address-provisioner.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-address-provisioner.ts
@@ -1,0 +1,215 @@
+/**
+ * WooCommerce Address Provisioner
+ *
+ * WooCommerce has no standalone address resource — billing / shipping addresses
+ * live INLINE on the customer (and on each order). This provisioner therefore
+ * implements address REUSE, not address creation: it keys off the address hash
+ * (`address1`, `address2`, `city`, `postcode`, `countryIso2`) and the
+ * `destination_address_mappings` table so a repeat order for the same buyer +
+ * address writes the WC customer's inline address at most once. Provisioning
+ * for a given (customer, addressHash, type) is serialized with the host
+ * `SyncLockPort` (Redis) to prevent duplicate writes under concurrency.
+ *
+ * Resolution order (mirrors `PrestashopAddressProvisioner`):
+ *   1. Primary reuse: `destination_address_mappings` lookup (fast path).
+ *   2. Acquire lock, re-check mapping.
+ *   3. Recovery: read the WC customer's inline address, match by hash.
+ *   4. Otherwise write the address onto the WC customer (`PUT /customers/{id}`).
+ *   5. Record the reuse mapping (idempotent under concurrent duplicates).
+ *
+ * Guest orders (`customer_id: 0`) have no customer account to attach an address
+ * to, so provisioning is skipped and returns `null` — the order payload still
+ * carries the inline address regardless.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners
+ */
+import { Injectable, Inject } from '@nestjs/common';
+import { SYNC_LOCK_TOKEN, type SyncLockPort } from '@openlinker/core/sync';
+import type { CustomerProjectionRepositoryPort, AddressType } from '@openlinker/core/customers';
+import { DestinationAddressMapping } from '@openlinker/core/customers';
+import type { Address } from '@openlinker/core/orders';
+import { Logger } from '@openlinker/shared/logging';
+import type { IWooCommerceHttpClient } from '../http/woocommerce-http-client.interface';
+import type {
+  WooCommerceCustomerWithAddressesResponse,
+  WooCommerceCustomerAddressUpdateRequest,
+} from './woocommerce-provisioner.types';
+import {
+  acquireLockWithWait,
+  computeAddressHash,
+  computeWcAddressHash,
+  toWcCustomerAddress,
+} from './woocommerce-provisioner.helpers';
+
+export interface ResolveOrCreateAddressInput {
+  readonly internalCustomerId: string;
+  /** The resolved WC customer id. Guest (`<= 0`) short-circuits with `null`. */
+  readonly wcCustomerId: number;
+  readonly address: Address | undefined;
+  readonly addressType: AddressType;
+  readonly connectionId: string;
+  readonly httpClient: IWooCommerceHttpClient;
+  readonly customerProjectionRepository: CustomerProjectionRepositoryPort;
+}
+
+@Injectable()
+export class WooCommerceAddressProvisioner {
+  private readonly logger = new Logger(WooCommerceAddressProvisioner.name);
+
+  constructor(
+    @Inject(SYNC_LOCK_TOKEN)
+    private readonly syncLock: SyncLockPort,
+  ) {}
+
+  private lockKey(
+    connectionId: string,
+    wcCustomerId: number,
+    addressHash: string,
+    addressType: AddressType,
+  ): string {
+    return `woocommerce:address-provision:${connectionId}:${wcCustomerId}:${addressHash}:${addressType}`;
+  }
+
+  /**
+   * Resolve (reuse) or write the WC customer's inline address, returning the
+   * destination address id recorded for reuse (the WC customer id, as that is
+   * where the address lives), or `null` when provisioning is skipped (guest, or
+   * a best-effort failure that must not abort order creation).
+   */
+  async resolveOrCreateAddress(input: ResolveOrCreateAddressInput): Promise<string | null> {
+    const {
+      internalCustomerId,
+      wcCustomerId,
+      address,
+      addressType,
+      connectionId,
+      httpClient,
+      customerProjectionRepository,
+    } = input;
+
+    if (!address || wcCustomerId <= 0) return null;
+
+    const addressHash = computeAddressHash(address);
+
+    // Step 1 — primary reuse: mapping table
+    const existing = await customerProjectionRepository.findDestinationAddressMapping(
+      internalCustomerId,
+      connectionId,
+      addressHash,
+      addressType,
+    );
+    if (existing) {
+      this.logger.debug(
+        `Address reuse hit: ${internalCustomerId} → ${existing.destinationAddressId} (${addressType})`,
+      );
+      return existing.destinationAddressId;
+    }
+
+    // Step 2 — serialize under the distributed lock
+    const key = this.lockKey(connectionId, wcCustomerId, addressHash, addressType);
+    const token = await acquireLockWithWait(this.syncLock, key);
+
+    try {
+      // Step 3 — re-check the mapping under the lock
+      const postLock = await customerProjectionRepository.findDestinationAddressMapping(
+        internalCustomerId,
+        connectionId,
+        addressHash,
+        addressType,
+      );
+      if (postLock) {
+        this.logger.debug(
+          `Address reuse hit after lock: ${internalCustomerId} → ${postLock.destinationAddressId} (${addressType})`,
+        );
+        return postLock.destinationAddressId;
+      }
+
+      // Step 4 — recovery: does the WC customer already carry this address?
+      const alreadyPresent = await this.matchesExistingWcAddress(
+        wcCustomerId,
+        addressType,
+        addressHash,
+        httpClient,
+      );
+
+      // Step 5 — otherwise write the inline address onto the WC customer
+      if (!alreadyPresent) {
+        const body: WooCommerceCustomerAddressUpdateRequest =
+          addressType === 'billing'
+            ? { billing: toWcCustomerAddress(address) }
+            : { shipping: toWcCustomerAddress(address) };
+        await httpClient.put<WooCommerceCustomerWithAddressesResponse>(
+          `/wp-json/wc/v3/customers/${wcCustomerId}`,
+          body,
+        );
+        this.logger.debug(
+          `Wrote ${addressType} address onto WC customer ${wcCustomerId} (connection: ${connectionId})`,
+        );
+      }
+
+      // Step 6 — record the reuse mapping (idempotent under concurrent duplicates)
+      const destinationAddressId = String(wcCustomerId);
+      await this.recordMapping(
+        internalCustomerId,
+        connectionId,
+        addressHash,
+        addressType,
+        destinationAddressId,
+        customerProjectionRepository,
+      );
+      return destinationAddressId;
+    } finally {
+      if (token) await this.syncLock.release(key, token);
+    }
+  }
+
+  private async matchesExistingWcAddress(
+    wcCustomerId: number,
+    addressType: AddressType,
+    addressHash: string,
+    httpClient: IWooCommerceHttpClient,
+  ): Promise<boolean> {
+    try {
+      const customer = await httpClient.get<WooCommerceCustomerWithAddressesResponse>(
+        `/wp-json/wc/v3/customers/${wcCustomerId}`,
+      );
+      const wcAddress = addressType === 'billing' ? customer.billing : customer.shipping;
+      return computeWcAddressHash(wcAddress) === addressHash;
+    } catch (err) {
+      // Recovery read is best-effort — if it fails we fall through to a write.
+      this.logger.debug(
+        `Address recovery read failed for WC customer ${wcCustomerId} — will write: ${String(err)}`,
+      );
+      return false;
+    }
+  }
+
+  private async recordMapping(
+    internalCustomerId: string,
+    connectionId: string,
+    addressHash: string,
+    addressType: AddressType,
+    destinationAddressId: string,
+    customerProjectionRepository: CustomerProjectionRepositoryPort,
+  ): Promise<void> {
+    try {
+      const now = new Date();
+      await customerProjectionRepository.upsertDestinationAddressMapping(
+        new DestinationAddressMapping(
+          internalCustomerId,
+          connectionId,
+          addressHash,
+          addressType,
+          destinationAddressId,
+          now,
+          now,
+        ),
+      );
+    } catch (err) {
+      // A concurrent writer may have recorded it first — tolerate and move on.
+      this.logger.debug(
+        `Address mapping upsert raced for ${internalCustomerId} (${addressType}): ${String(err)}`,
+      );
+    }
+  }
+}

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-address-provisioner.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-address-provisioner.ts
@@ -27,12 +27,12 @@ import { Injectable, Inject } from '@nestjs/common';
 import { SYNC_LOCK_TOKEN, type SyncLockPort } from '@openlinker/core/sync';
 import type { CustomerProjectionRepositoryPort, AddressType } from '@openlinker/core/customers';
 import { DestinationAddressMapping } from '@openlinker/core/customers';
-import type { Address } from '@openlinker/core/orders';
 import { Logger } from '@openlinker/shared/logging';
 import type { IWooCommerceHttpClient } from '../http/woocommerce-http-client.interface';
 import type {
   WooCommerceCustomerWithAddressesResponse,
   WooCommerceCustomerAddressUpdateRequest,
+  ResolveOrCreateAddressInput,
 } from './woocommerce-provisioner.types';
 import {
   acquireLockWithWait,
@@ -40,17 +40,6 @@ import {
   computeWcAddressHash,
   toWcCustomerAddress,
 } from './woocommerce-provisioner.helpers';
-
-export interface ResolveOrCreateAddressInput {
-  readonly internalCustomerId: string;
-  /** The resolved WC customer id. Guest (`<= 0`) short-circuits with `null`. */
-  readonly wcCustomerId: number;
-  readonly address: Address | undefined;
-  readonly addressType: AddressType;
-  readonly connectionId: string;
-  readonly httpClient: IWooCommerceHttpClient;
-  readonly customerProjectionRepository: CustomerProjectionRepositoryPort;
-}
 
 @Injectable()
 export class WooCommerceAddressProvisioner {
@@ -108,6 +97,17 @@ export class WooCommerceAddressProvisioner {
     // Step 2 — serialize under the distributed lock
     const key = this.lockKey(connectionId, wcCustomerId, addressHash, addressType);
     const token = await acquireLockWithWait(this.syncLock, key);
+    if (!token) {
+      // The lock could not be acquired within the wait budget (e.g. a Redis
+      // outage or heavy contention). Proceeding UNSERIALIZED is safe here —
+      // unlike PrestaShop, which throws — because writing the inline address is
+      // an idempotent `PUT /customers/{id}` (a racing writer sets the same
+      // fields) and the reuse mapping upsert tolerates a concurrent duplicate.
+      // We log the degradation so a defeated lock stays observable.
+      this.logger.warn(
+        `resolveOrCreateAddress: could not acquire provisioning lock for customer ${internalCustomerId} (${addressType}) within budget — proceeding unserialized (idempotent PUT keeps this safe)`,
+      );
+    }
 
     try {
       // Step 3 — re-check the mapping under the lock

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-customer-provisioner.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-customer-provisioner.ts
@@ -1,0 +1,241 @@
+/**
+ * WooCommerce Customer Provisioner
+ *
+ * Resolve-or-create a WooCommerce customer for an internal OL customer, with a
+ * distributed lock (host `SyncLockPort`, Redis-backed) that serializes
+ * concurrent provisioning for the same buyer so simultaneous orders don't
+ * create duplicate customers. Mirrors `PrestashopCustomerProvisioner`, adapted
+ * to WooCommerce's REST `GET/POST /customers` model.
+ *
+ * Resolution order:
+ *   1. Existing external↔internal mapping (fast path).
+ *   2. Acquire lock, re-check mapping.
+ *   3. Create WC customer (`POST /customers`); on WC's duplicate-email 400,
+ *      look the existing account up by email (`GET /customers?email=`).
+ *   4. Record the identifier mapping (with concurrent-duplicate handling).
+ *
+ * Degrades to guest (customer id `0`) when creation is impossible (no internal
+ * customer, no buyer email, corrupted mapping, or a non-auth API error). Auth
+ * failures (401/403) are NOT swallowed — they propagate as
+ * `WooCommerceAuthFailureException` so the connection can be flagged for
+ * re-authentication (#877 I1).
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners
+ */
+import { Injectable, Inject } from '@nestjs/common';
+import type { IdentifierMappingPort, ExternalIdMapping } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
+import { SYNC_LOCK_TOKEN, type SyncLockPort } from '@openlinker/core/sync';
+import { Logger } from '@openlinker/shared/logging';
+import type { IWooCommerceHttpClient } from '../http/woocommerce-http-client.interface';
+import { WooCommerceHttpResponseException } from '../http/woocommerce-http-response.exception';
+import { WooCommerceUnauthorizedException } from '../../domain/exceptions/woocommerce-unauthorized.exception';
+import { WooCommerceAuthFailureException } from '../../domain/exceptions/woocommerce-auth-failure.exception';
+import type {
+  WooCommerceCustomerCreateRequest,
+  WooCommerceCustomerResponse,
+} from '../adapters/order-processor/woocommerce-order.types';
+import { acquireLockWithWait, lockKeyToken } from './woocommerce-provisioner.helpers';
+
+/** The WooCommerce guest sentinel — orders with `customer_id: 0` are guest orders. */
+const WC_GUEST_CUSTOMER_ID = 0;
+
+export interface ResolveOrCreateCustomerInput {
+  /** Internal OL customer id (undefined for a guest source order). */
+  readonly internalCustomerId: string | undefined;
+  /** Validated buyer email (undefined when unavailable — forces guest). */
+  readonly buyerEmail: string | undefined;
+  readonly firstName: string;
+  readonly lastName: string;
+  readonly connectionId: string;
+  readonly httpClient: IWooCommerceHttpClient;
+  readonly identifierMapping: IdentifierMappingPort;
+}
+
+@Injectable()
+export class WooCommerceCustomerProvisioner {
+  private readonly logger = new Logger(WooCommerceCustomerProvisioner.name);
+
+  constructor(
+    @Inject(SYNC_LOCK_TOKEN)
+    private readonly syncLock: SyncLockPort,
+  ) {}
+
+  private lockKey(connectionId: string, emailHash: string): string {
+    return `woocommerce:customer-provision:${connectionId}:${emailHash}`;
+  }
+
+  /**
+   * Find the WC customer id mapped to this internal customer on this connection.
+   * Returns a positive integer id, `0` when the mapping is corrupted (non
+   * positive-integer external id), or `null` when there is no mapping.
+   */
+  private async findMappedCustomerId(
+    internalCustomerId: string,
+    connectionId: string,
+    identifierMapping: IdentifierMappingPort,
+  ): Promise<number | null> {
+    const externalIds = await identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.Customer,
+      internalCustomerId,
+    );
+    const mapping = externalIds.find((e: ExternalIdMapping) => e.connectionId === connectionId);
+    if (!mapping) return null;
+    const n = Number(mapping.externalId);
+    if (!Number.isInteger(n) || n <= 0) {
+      this.logger.warn(
+        `resolveOrCreateCustomer: corrupted mapping "${mapping.externalId}" for customer ${internalCustomerId} — guest order`,
+      );
+      return WC_GUEST_CUSTOMER_ID;
+    }
+    return n;
+  }
+
+  async resolveOrCreateCustomer(input: ResolveOrCreateCustomerInput): Promise<number> {
+    const {
+      internalCustomerId,
+      buyerEmail,
+      firstName,
+      lastName,
+      connectionId,
+      httpClient,
+      identifierMapping,
+    } = input;
+
+    if (!internalCustomerId) return WC_GUEST_CUSTOMER_ID;
+
+    // Step 1 — existing mapping (fast path)
+    const mapped = await this.findMappedCustomerId(internalCustomerId, connectionId, identifierMapping);
+    if (mapped !== null) return mapped;
+
+    // Step 2 — no mapping; provisioning needs an email
+    if (!buyerEmail) {
+      this.logger.warn(
+        `resolveOrCreateCustomer: no WC mapping and no buyerEmail for customer ${internalCustomerId} — guest order`,
+      );
+      return WC_GUEST_CUSTOMER_ID;
+    }
+
+    // Step 3 — serialize provisioning for this buyer under a distributed lock
+    const key = this.lockKey(connectionId, lockKeyToken(buyerEmail));
+    const token = await acquireLockWithWait(this.syncLock, key);
+
+    try {
+      // Step 4 — re-check the mapping now that we hold (or waited for) the lock
+      const postLock = await this.findMappedCustomerId(
+        internalCustomerId,
+        connectionId,
+        identifierMapping,
+      );
+      if (postLock !== null) return postLock;
+
+      // Step 5 — create the WC customer (or recover an existing one by email)
+      const wcCustomerId = await this.createOrRecoverCustomer(
+        internalCustomerId,
+        buyerEmail,
+        firstName,
+        lastName,
+        connectionId,
+        httpClient,
+      );
+      if (wcCustomerId <= 0) return WC_GUEST_CUSTOMER_ID;
+
+      // Step 6 — record the mapping (idempotent under concurrent duplicates)
+      return await this.recordMapping(
+        internalCustomerId,
+        wcCustomerId,
+        connectionId,
+        identifierMapping,
+      );
+    } finally {
+      if (token) await this.syncLock.release(key, token);
+    }
+  }
+
+  private async createOrRecoverCustomer(
+    internalCustomerId: string,
+    buyerEmail: string,
+    firstName: string,
+    lastName: string,
+    connectionId: string,
+    httpClient: IWooCommerceHttpClient,
+  ): Promise<number> {
+    try {
+      const created = await httpClient.post<WooCommerceCustomerResponse>(
+        '/wp-json/wc/v3/customers',
+        {
+          email: buyerEmail,
+          first_name: firstName,
+          last_name: lastName,
+        } satisfies WooCommerceCustomerCreateRequest,
+      );
+      if (!created.id) {
+        this.logger.warn(
+          `resolveOrCreateCustomer: WC customer POST returned no id for ${internalCustomerId} — guest order`,
+        );
+        return WC_GUEST_CUSTOMER_ID;
+      }
+      return created.id;
+    } catch (err) {
+      // Auth failures must propagate — invalid credentials require re-auth.
+      if (err instanceof WooCommerceUnauthorizedException) {
+        throw new WooCommerceAuthFailureException(
+          `WooCommerce auth failure provisioning customer ${internalCustomerId} on connection ${connectionId}: ${String(err)}`,
+          connectionId,
+        );
+      }
+      // WC returns 400 (code 'registration-error-email-exists') for a duplicate
+      // email — look the existing account up by email.
+      if (err instanceof WooCommerceHttpResponseException && err.statusCode === 400) {
+        const existing = await httpClient.get<WooCommerceCustomerResponse[]>(
+          '/wp-json/wc/v3/customers',
+          { email: buyerEmail },
+        );
+        const match = existing.find((c) => c.email === buyerEmail);
+        if (!match?.id) {
+          this.logger.warn(
+            `resolveOrCreateCustomer: duplicate email ${buyerEmail} but no matching WC customer — guest order`,
+          );
+          return WC_GUEST_CUSTOMER_ID;
+        }
+        return match.id;
+      }
+      // Non-auth, non-400 (network, rate-limit, server) — degrade to guest.
+      this.logger.warn(
+        `resolveOrCreateCustomer: WC customer API error for ${internalCustomerId} — guest order: ${String(err)}`,
+      );
+      return WC_GUEST_CUSTOMER_ID;
+    }
+  }
+
+  private async recordMapping(
+    internalCustomerId: string,
+    wcCustomerId: number,
+    connectionId: string,
+    identifierMapping: IdentifierMappingPort,
+  ): Promise<number> {
+    try {
+      await identifierMapping.createMapping(
+        CORE_ENTITY_TYPE.Customer,
+        String(wcCustomerId),
+        connectionId,
+        internalCustomerId,
+      );
+    } catch (err) {
+      if (err instanceof DuplicateIdentifierMappingError) {
+        const winner = await this.findMappedCustomerId(
+          internalCustomerId,
+          connectionId,
+          identifierMapping,
+        );
+        if (winner !== null && winner > 0) return winner;
+        this.logger.warn(
+          `resolveOrCreateCustomer: concurrent duplicate but no winner for ${internalCustomerId} — guest order`,
+        );
+        return WC_GUEST_CUSTOMER_ID;
+      }
+      throw err;
+    }
+    return wcCustomerId;
+  }
+}

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-customer-provisioner.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-customer-provisioner.ts
@@ -36,21 +36,10 @@ import type {
   WooCommerceCustomerResponse,
 } from '../adapters/order-processor/woocommerce-order.types';
 import { acquireLockWithWait, lockKeyToken } from './woocommerce-provisioner.helpers';
+import type { ResolveOrCreateCustomerInput } from './woocommerce-provisioner.types';
 
 /** The WooCommerce guest sentinel — orders with `customer_id: 0` are guest orders. */
 const WC_GUEST_CUSTOMER_ID = 0;
-
-export interface ResolveOrCreateCustomerInput {
-  /** Internal OL customer id (undefined for a guest source order). */
-  readonly internalCustomerId: string | undefined;
-  /** Validated buyer email (undefined when unavailable — forces guest). */
-  readonly buyerEmail: string | undefined;
-  readonly firstName: string;
-  readonly lastName: string;
-  readonly connectionId: string;
-  readonly httpClient: IWooCommerceHttpClient;
-  readonly identifierMapping: IdentifierMappingPort;
-}
 
 @Injectable()
 export class WooCommerceCustomerProvisioner {
@@ -116,9 +105,23 @@ export class WooCommerceCustomerProvisioner {
       return WC_GUEST_CUSTOMER_ID;
     }
 
-    // Step 3 — serialize provisioning for this buyer under a distributed lock
-    const key = this.lockKey(connectionId, lockKeyToken(buyerEmail));
+    // Step 3 — serialize provisioning for this buyer under a distributed lock.
+    // Normalize the email (trim + lowercase) before hashing so case/whitespace
+    // variants of the same address serialize against the same lock key.
+    const key = this.lockKey(connectionId, lockKeyToken(buyerEmail.trim().toLowerCase()));
     const token = await acquireLockWithWait(this.syncLock, key);
+    if (!token) {
+      // The lock could not be acquired within the wait budget (e.g. a Redis
+      // outage or heavy contention). Proceeding UNSERIALIZED is safe here —
+      // unlike PrestaShop, which throws — because the WC customer path is
+      // backstopped by WC's email-uniqueness constraint + the duplicate-email
+      // 400 recovery below, so a racing writer converges on one account rather
+      // than creating a duplicate. We log the degradation so a defeated lock
+      // (which is otherwise invisible) stays observable.
+      this.logger.warn(
+        `resolveOrCreateCustomer: could not acquire provisioning lock for customer ${internalCustomerId} within budget — proceeding unserialized (WC email-uniqueness + 400 recovery keep this safe)`,
+      );
+    }
 
     try {
       // Step 4 — re-check the mapping now that we hold (or waited for) the lock

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.helpers.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.helpers.ts
@@ -2,9 +2,9 @@
  * WooCommerce Provisioner Helpers
  *
  * Pure helpers shared by the WooCommerce customer + address provisioners:
- * country / currency normalization (WooCommerce's model is flat — there is no
- * separate resolver layer, so these live alongside the provisioners), address
- * hashing, OL-Address → WC-address mapping, and a bounded-wait distributed-lock
+ * country normalization (WooCommerce's model is flat — there is no separate
+ * resolver layer, so this lives alongside the provisioners), address hashing,
+ * OL-Address → WC-address mapping, and a bounded-wait distributed-lock
  * acquisition built on the host `SyncLockPort`.
  *
  * @module libs/integrations/woocommerce/src/infrastructure/provisioners
@@ -14,7 +14,7 @@ import type { SyncLockPort, SyncLockToken } from '@openlinker/core/sync';
 import type { Address } from '@openlinker/core/orders';
 import type { NormalizedAddress } from '@openlinker/shared/config';
 import { hashAddress } from '@openlinker/shared/config';
-import type { WooCommerceCustomerAddress } from './woocommerce-provisioner.types';
+import type { WooCommerceOrderAddress } from '../adapters/order-processor/woocommerce-order.types';
 
 /** Lock TTL in milliseconds — 30 s is ample for the WC customer API round-trips. */
 export const PROVISIONER_LOCK_TTL_MS = 30_000;
@@ -44,13 +44,6 @@ export function normalizeCountryCode(country: string | null | undefined): string
 }
 
 /**
- * Normalize a currency code to an upper-case ISO-4217 value.
- */
-export function normalizeCurrencyCode(currency: string | null | undefined): string {
-  return (currency ?? '').trim().toUpperCase();
-}
-
-/**
  * Compute the address-reuse hash for an OL order address. Mirrors the component
  * set used across the platform (`address1`, `address2`, `city`, `postcode`,
  * `countryIso2`), with the country normalized so a reuse lookup matches the
@@ -72,7 +65,7 @@ export function computeAddressHash(address: Address): string {
  * the mapping table has no row but the WC customer already carries a matching
  * address). Returns null when the WC address lacks the fields needed to hash.
  */
-export function computeWcAddressHash(address: WooCommerceCustomerAddress | undefined): string | null {
+export function computeWcAddressHash(address: WooCommerceOrderAddress | undefined): string | null {
   if (!address || !address.address_1 || !address.city || !address.postcode) {
     return null;
   }
@@ -90,10 +83,17 @@ export function computeWcAddressHash(address: WooCommerceCustomerAddress | undef
  * Map an OL Address to a WooCommerce inline customer address, omitting nullish
  * fields (WC REST rejects `null` on string-typed address properties) and
  * normalizing the country code.
+ *
+ * Shares the `WooCommerceOrderAddress` wire type with the order-processor
+ * adapter's private `mapAddress`, but stays a separate function on purpose: it
+ * normalizes `country` (upper-case ISO2) so the value written to the WC customer
+ * matches the value fed into the reuse hash (`computeAddressHash`). The adapter's
+ * `mapAddress` deliberately passes `country` through verbatim for the order
+ * payload, so the two are not interchangeable.
  */
-export function toWcCustomerAddress(address: Address): WooCommerceCustomerAddress {
-  const mapped: WooCommerceCustomerAddress = {};
-  const assign = (key: keyof WooCommerceCustomerAddress, value: string | null | undefined): void => {
+export function toWcCustomerAddress(address: Address): WooCommerceOrderAddress {
+  const mapped: WooCommerceOrderAddress = {};
+  const assign = (key: keyof WooCommerceOrderAddress, value: string | null | undefined): void => {
     if (value !== null && value !== undefined) mapped[key] = value;
   };
   assign('first_name', address.firstName);

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.helpers.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.helpers.ts
@@ -1,0 +1,137 @@
+/**
+ * WooCommerce Provisioner Helpers
+ *
+ * Pure helpers shared by the WooCommerce customer + address provisioners:
+ * country / currency normalization (WooCommerce's model is flat — there is no
+ * separate resolver layer, so these live alongside the provisioners), address
+ * hashing, OL-Address → WC-address mapping, and a bounded-wait distributed-lock
+ * acquisition built on the host `SyncLockPort`.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners
+ */
+import { createHash } from 'crypto';
+import type { SyncLockPort, SyncLockToken } from '@openlinker/core/sync';
+import type { Address } from '@openlinker/core/orders';
+import type { NormalizedAddress } from '@openlinker/shared/config';
+import { hashAddress } from '@openlinker/shared/config';
+import type { WooCommerceCustomerAddress } from './woocommerce-provisioner.types';
+
+/** Lock TTL in milliseconds — 30 s is ample for the WC customer API round-trips. */
+export const PROVISIONER_LOCK_TTL_MS = 30_000;
+
+/** Default bounded-wait parameters for lock acquisition. */
+const DEFAULT_MAX_ACQUIRE_ATTEMPTS = 20;
+const DEFAULT_ACQUIRE_DELAY_MS = 100;
+
+/**
+ * Derive a stable, non-reversible token from a value for use inside a Redis
+ * lock key — keeps raw PII (e.g. buyer email) out of the key space. This is a
+ * plain SHA-256, deliberately independent of the org-level PII salt (a lock key
+ * is ephemeral and never persisted), so it works in any runtime without PII
+ * config wiring.
+ */
+export function lockKeyToken(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+/**
+ * Normalize a country code to an upper-case ISO-3166 alpha-2 value. WooCommerce
+ * expects upper-case ISO2 in address `country`; normalizing here keeps the value
+ * we hash for reuse consistent with the value we write.
+ */
+export function normalizeCountryCode(country: string | null | undefined): string {
+  return (country ?? '').trim().toUpperCase();
+}
+
+/**
+ * Normalize a currency code to an upper-case ISO-4217 value.
+ */
+export function normalizeCurrencyCode(currency: string | null | undefined): string {
+  return (currency ?? '').trim().toUpperCase();
+}
+
+/**
+ * Compute the address-reuse hash for an OL order address. Mirrors the component
+ * set used across the platform (`address1`, `address2`, `city`, `postcode`,
+ * `countryIso2`), with the country normalized so a reuse lookup matches the
+ * value written to WooCommerce.
+ */
+export function computeAddressHash(address: Address): string {
+  const normalized: NormalizedAddress = {
+    address1: address.address1,
+    address2: address.address2,
+    city: address.city,
+    postcode: address.postalCode,
+    countryIso2: normalizeCountryCode(address.country),
+  };
+  return hashAddress(normalized);
+}
+
+/**
+ * Compute the reuse hash of a WooCommerce inline address (recovery path — when
+ * the mapping table has no row but the WC customer already carries a matching
+ * address). Returns null when the WC address lacks the fields needed to hash.
+ */
+export function computeWcAddressHash(address: WooCommerceCustomerAddress | undefined): string | null {
+  if (!address || !address.address_1 || !address.city || !address.postcode) {
+    return null;
+  }
+  const normalized: NormalizedAddress = {
+    address1: address.address_1,
+    address2: address.address_2,
+    city: address.city,
+    postcode: address.postcode,
+    countryIso2: normalizeCountryCode(address.country),
+  };
+  return hashAddress(normalized);
+}
+
+/**
+ * Map an OL Address to a WooCommerce inline customer address, omitting nullish
+ * fields (WC REST rejects `null` on string-typed address properties) and
+ * normalizing the country code.
+ */
+export function toWcCustomerAddress(address: Address): WooCommerceCustomerAddress {
+  const mapped: WooCommerceCustomerAddress = {};
+  const assign = (key: keyof WooCommerceCustomerAddress, value: string | null | undefined): void => {
+    if (value !== null && value !== undefined) mapped[key] = value;
+  };
+  assign('first_name', address.firstName);
+  assign('last_name', address.lastName);
+  assign('company', address.company);
+  assign('address_1', address.address1);
+  assign('address_2', address.address2);
+  assign('city', address.city);
+  assign('state', address.state);
+  assign('postcode', address.postalCode);
+  assign('country', normalizeCountryCode(address.country));
+  assign('phone', address.phone);
+  return mapped;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Acquire a distributed lock with a bounded wait. Retries `acquire` until it
+ * succeeds or the attempt budget is exhausted, so a second caller for the same
+ * key serializes behind the first holder rather than racing it.
+ *
+ * @returns the lock token on success, or `null` if the lock could not be
+ *   acquired within the budget (caller must re-check state and degrade safely).
+ */
+export async function acquireLockWithWait(
+  syncLock: SyncLockPort,
+  key: string,
+  ttlMs: number = PROVISIONER_LOCK_TTL_MS,
+  maxAttempts: number = DEFAULT_MAX_ACQUIRE_ATTEMPTS,
+  delayMs: number = DEFAULT_ACQUIRE_DELAY_MS,
+): Promise<SyncLockToken | null> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const token = await syncLock.acquire(key, ttlMs);
+    if (token) return token;
+    await sleep(delayMs);
+  }
+  return null;
+}

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.types.ts
@@ -1,0 +1,52 @@
+/**
+ * WooCommerce Provisioner Types
+ *
+ * Wire shapes for the WooCommerce customer + address provisioners. WooCommerce
+ * stores billing / shipping addresses INLINE on the customer resource (no
+ * standalone address entity), so the "address" shapes here are the nested
+ * `billing` / `shipping` objects of a WC customer, and the update request is a
+ * partial customer PUT carrying one or both of them.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/provisioners
+ */
+
+/**
+ * A WooCommerce customer billing / shipping address object. All fields are
+ * optional because a source order may omit them; nullish fields are OMITTED
+ * from the wire payload (WC REST type-checks address properties as strings).
+ */
+export interface WooCommerceCustomerAddress {
+  first_name?: string;
+  last_name?: string;
+  company?: string;
+  address_1?: string;
+  address_2?: string;
+  city?: string;
+  state?: string;
+  postcode?: string;
+  country?: string;
+  phone?: string;
+  email?: string;
+}
+
+/**
+ * A WooCommerce customer resource as returned by `GET /customers/{id}`,
+ * including its inline billing / shipping addresses (used by the address
+ * provisioner's hash-match recovery path).
+ */
+export interface WooCommerceCustomerWithAddressesResponse {
+  id?: number;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  billing?: WooCommerceCustomerAddress;
+  shipping?: WooCommerceCustomerAddress;
+}
+
+/**
+ * Partial customer PUT body carrying one or both inline addresses.
+ */
+export interface WooCommerceCustomerAddressUpdateRequest {
+  billing?: WooCommerceCustomerAddress;
+  shipping?: WooCommerceCustomerAddress;
+}

--- a/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.types.ts
@@ -1,33 +1,20 @@
 /**
  * WooCommerce Provisioner Types
  *
- * Wire shapes for the WooCommerce customer + address provisioners. WooCommerce
- * stores billing / shipping addresses INLINE on the customer resource (no
- * standalone address entity), so the "address" shapes here are the nested
- * `billing` / `shipping` objects of a WC customer, and the update request is a
- * partial customer PUT carrying one or both of them.
+ * Wire shapes and method-input contracts for the WooCommerce customer + address
+ * provisioners. WooCommerce stores billing / shipping addresses INLINE on the
+ * customer resource (no standalone address entity), so the "address" shapes here
+ * reuse the adapter's `WooCommerceOrderAddress` (the same nested billing /
+ * shipping object), and the update request is a partial customer PUT carrying
+ * one or both of them.
  *
  * @module libs/integrations/woocommerce/src/infrastructure/provisioners
  */
-
-/**
- * A WooCommerce customer billing / shipping address object. All fields are
- * optional because a source order may omit them; nullish fields are OMITTED
- * from the wire payload (WC REST type-checks address properties as strings).
- */
-export interface WooCommerceCustomerAddress {
-  first_name?: string;
-  last_name?: string;
-  company?: string;
-  address_1?: string;
-  address_2?: string;
-  city?: string;
-  state?: string;
-  postcode?: string;
-  country?: string;
-  phone?: string;
-  email?: string;
-}
+import type { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import type { Address } from '@openlinker/core/orders';
+import type { AddressType, CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
+import type { WooCommerceOrderAddress } from '../adapters/order-processor/woocommerce-order.types';
+import type { IWooCommerceHttpClient } from '../http/woocommerce-http-client.interface';
 
 /**
  * A WooCommerce customer resource as returned by `GET /customers/{id}`,
@@ -39,14 +26,43 @@ export interface WooCommerceCustomerWithAddressesResponse {
   email?: string;
   first_name?: string;
   last_name?: string;
-  billing?: WooCommerceCustomerAddress;
-  shipping?: WooCommerceCustomerAddress;
+  billing?: WooCommerceOrderAddress;
+  shipping?: WooCommerceOrderAddress;
 }
 
 /**
  * Partial customer PUT body carrying one or both inline addresses.
  */
 export interface WooCommerceCustomerAddressUpdateRequest {
-  billing?: WooCommerceCustomerAddress;
-  shipping?: WooCommerceCustomerAddress;
+  billing?: WooCommerceOrderAddress;
+  shipping?: WooCommerceOrderAddress;
+}
+
+/**
+ * Input for {@link WooCommerceCustomerProvisioner.resolveOrCreateCustomer}.
+ */
+export interface ResolveOrCreateCustomerInput {
+  /** Internal OL customer id (undefined for a guest source order). */
+  readonly internalCustomerId: string | undefined;
+  /** Validated buyer email (undefined when unavailable — forces guest). */
+  readonly buyerEmail: string | undefined;
+  readonly firstName: string;
+  readonly lastName: string;
+  readonly connectionId: string;
+  readonly httpClient: IWooCommerceHttpClient;
+  readonly identifierMapping: IdentifierMappingPort;
+}
+
+/**
+ * Input for {@link WooCommerceAddressProvisioner.resolveOrCreateAddress}.
+ */
+export interface ResolveOrCreateAddressInput {
+  readonly internalCustomerId: string;
+  /** The resolved WC customer id. Guest (`<= 0`) short-circuits with `null`. */
+  readonly wcCustomerId: number;
+  readonly address: Address | undefined;
+  readonly addressType: AddressType;
+  readonly connectionId: string;
+  readonly httpClient: IWooCommerceHttpClient;
+  readonly customerProjectionRepository: CustomerProjectionRepositoryPort;
 }

--- a/libs/integrations/woocommerce/src/woocommerce-integration.module.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-integration.module.ts
@@ -1,22 +1,173 @@
 /**
  * WooCommerce Integration Module
  *
- * Host wiring for the WooCommerce REST API v3 plugin. WooCommerce has no
- * plugin-specific NestJS providers (no TypeORM repository, no token-refresh
- * service), so it uses the SDK's `createNestAdapterModule` directly: the
- * helper imports the integrations/sync/identifier-mapping modules, builds
- * the `HostServices` bag from DI, registers the manifest + factory, and
- * calls `plugin.register(host)` for the connection tester and validators.
+ * NestJS host wrapper for the WooCommerce plugin descriptor
+ * (`createWooCommercePlugin`). WooCommerce's customer + address provisioners
+ * (#1552) depend on the host `SyncLockPort` and `CustomerProjectionRepositoryPort`,
+ * which are NOT part of the curated `HostServices` bag — so the plugin can no
+ * longer be wired with the bare `createNestAdapterModule` helper. This module
+ * mirrors the PrestaShop pattern (Shape A, #593): it provides the provisioners,
+ * builds the descriptor with those plugin-specific deps in `onModuleInit`,
+ * assembles a `HostServices` bag from injected host fields, and routes manifest
+ * + factory + side registrations through the descriptor.
  *
- * Added to `apps/api/src/plugins.ts` and `apps/worker/src/plugins.ts` as
- * the single edit point that enables the plugin in both hosts.
+ * Added to `apps/api/src/plugins.ts` and `apps/worker/src/plugins.ts` as the
+ * single edit point that enables the plugin in both hosts.
  *
  * @module libs/integrations/woocommerce/src
  */
-import type { DynamicModule } from '@nestjs/common';
-import { createNestAdapterModule } from '@openlinker/plugin-sdk';
+import type { OnModuleInit } from '@nestjs/common';
+import { Module, Inject } from '@nestjs/common';
+import {
+  IdentifierMappingModule,
+  IDENTIFIER_MAPPING_PORT_TOKEN,
+  IdentifierMappingPort,
+  type Connection,
+} from '@openlinker/core/identifier-mapping';
+import type { AdapterFactoryPort } from '@openlinker/core/integrations';
+import {
+  IntegrationsModule,
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  AdapterFactoryResolverService,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterRegistryPort,
+  CONNECTION_TESTER_REGISTRY_TOKEN,
+  ConnectionTesterRegistryService,
+  EMAIL_NORMALIZER_REGISTRY_TOKEN,
+  EmailNormalizerRegistryService,
+  WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
+  WebhookProvisioningRegistryService,
+  WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN,
+  WebhookEventTranslatorRegistryService,
+  INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN,
+  InboundWebhookDecoderRegistryService,
+  CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  ConnectionConfigShapeValidatorRegistryService,
+  CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN,
+  ConnectionCredentialsShapeValidatorRegistryService,
+  CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN,
+  ConnectionCredentialsRewriterRegistryService,
+  INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN,
+  OAuthCompletionRegistryService,
+  CREDENTIALS_RESOLVER_TOKEN,
+  CredentialsResolverPort,
+} from '@openlinker/core/integrations';
+import {
+  SyncModule,
+  RETRY_CLASSIFIER_REGISTRY_TOKEN,
+  RetryClassifierRegistryService,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+  AuthFailureClassifierRegistryService,
+  SCHEDULER_TASK_REGISTRY_TOKEN,
+  SchedulerTaskRegistryService,
+} from '@openlinker/core/sync';
+import {
+  CustomersModule,
+  CUSTOMER_PROJECTION_REPOSITORY_TOKEN,
+  CustomerProjectionRepositoryPort,
+} from '@openlinker/core/customers';
+import { Logger } from '@openlinker/shared/logging';
+import { CACHE_PORT_TOKEN, type CachePort } from '@openlinker/shared';
+import type { HostServices } from '@openlinker/plugin-sdk';
+import { WooCommerceCustomerProvisioner } from './infrastructure/provisioners/woocommerce-customer-provisioner';
+import { WooCommerceAddressProvisioner } from './infrastructure/provisioners/woocommerce-address-provisioner';
 import { createWooCommercePlugin } from './woocommerce-plugin';
 
-export const WooCommerceIntegrationModule: DynamicModule = createNestAdapterModule({
-  plugin: createWooCommercePlugin(),
-});
+@Module({
+  imports: [IntegrationsModule, SyncModule, IdentifierMappingModule, CustomersModule],
+  providers: [WooCommerceCustomerProvisioner, WooCommerceAddressProvisioner],
+})
+export class WooCommerceIntegrationModule implements OnModuleInit {
+  private readonly logger = new Logger(WooCommerceIntegrationModule.name);
+
+  constructor(
+    @Inject(ADAPTER_REGISTRY_TOKEN)
+    private readonly adapterRegistry: AdapterRegistryPort,
+    @Inject(ADAPTER_FACTORY_RESOLVER_TOKEN)
+    private readonly factoryResolver: AdapterFactoryResolverService,
+    @Inject(CONNECTION_TESTER_REGISTRY_TOKEN)
+    private readonly connectionTesterRegistry: ConnectionTesterRegistryService,
+    @Inject(EMAIL_NORMALIZER_REGISTRY_TOKEN)
+    private readonly emailNormalizerRegistry: EmailNormalizerRegistryService,
+    @Inject(WEBHOOK_PROVISIONING_REGISTRY_TOKEN)
+    private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
+    @Inject(WEBHOOK_EVENT_TRANSLATOR_REGISTRY_TOKEN)
+    private readonly webhookEventTranslatorRegistry: WebhookEventTranslatorRegistryService,
+    @Inject(INBOUND_WEBHOOK_DECODER_REGISTRY_TOKEN)
+    private readonly inboundWebhookDecoderRegistry: InboundWebhookDecoderRegistryService,
+    @Inject(CONNECTION_CONFIG_SHAPE_VALIDATOR_REGISTRY_TOKEN)
+    private readonly connectionConfigShapeValidatorRegistry: ConnectionConfigShapeValidatorRegistryService,
+    @Inject(CONNECTION_CREDENTIALS_SHAPE_VALIDATOR_REGISTRY_TOKEN)
+    private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
+    @Inject(CONNECTION_CREDENTIALS_REWRITER_REGISTRY_TOKEN)
+    private readonly connectionCredentialsRewriterRegistry: ConnectionCredentialsRewriterRegistryService,
+    @Inject(INTEGRATIONS_OAUTH_COMPLETION_REGISTRY_TOKEN)
+    private readonly oauthCompletionRegistry: OAuthCompletionRegistryService,
+    @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly retryClassifierRegistry: RetryClassifierRegistryService,
+    @Inject(AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly authFailureClassifierRegistry: AuthFailureClassifierRegistryService,
+    @Inject(SCHEDULER_TASK_REGISTRY_TOKEN)
+    private readonly schedulerTaskRegistry: SchedulerTaskRegistryService,
+    @Inject(IDENTIFIER_MAPPING_PORT_TOKEN)
+    private readonly identifierMapping: IdentifierMappingPort,
+    @Inject(CREDENTIALS_RESOLVER_TOKEN)
+    private readonly credentialsResolver: CredentialsResolverPort,
+    private readonly customerProvisioner: WooCommerceCustomerProvisioner,
+    private readonly addressProvisioner: WooCommerceAddressProvisioner,
+    @Inject(CUSTOMER_PROJECTION_REPOSITORY_TOKEN)
+    private readonly customerProjectionRepository: CustomerProjectionRepositoryPort,
+    @Inject(CACHE_PORT_TOKEN)
+    private readonly cache?: CachePort,
+  ) {}
+
+  onModuleInit(): void {
+    this.logger.log('Registering WooCommerce plugin (manifest + factory + side registries)...');
+
+    const plugin = createWooCommercePlugin({
+      customerProvisioner: this.customerProvisioner,
+      addressProvisioner: this.addressProvisioner,
+      customerProjectionRepository: this.customerProjectionRepository,
+    });
+
+    const host: HostServices = {
+      logger: (context: string) => new Logger(context),
+      identifierMapping: this.identifierMapping,
+      credentialsResolver: this.credentialsResolver,
+      cache: this.cache,
+      adapterRegistry: this.adapterRegistry,
+      factoryResolver: this.factoryResolver,
+      connectionTesterRegistry: this.connectionTesterRegistry,
+      emailNormalizerRegistry: this.emailNormalizerRegistry,
+      retryClassifierRegistry: this.retryClassifierRegistry,
+      authFailureClassifierRegistry: this.authFailureClassifierRegistry,
+      schedulerTaskRegistry: this.schedulerTaskRegistry,
+      webhookProvisioningRegistry: this.webhookProvisioningRegistry,
+      webhookEventTranslatorRegistry: this.webhookEventTranslatorRegistry,
+      inboundWebhookDecoderRegistry: this.inboundWebhookDecoderRegistry,
+      connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,
+      connectionCredentialsShapeValidatorRegistry: this.connectionCredentialsShapeValidatorRegistry,
+      connectionCredentialsRewriterRegistry: this.connectionCredentialsRewriterRegistry,
+      oauthCompletionRegistry: this.oauthCompletionRegistry,
+    };
+
+    host.adapterRegistry.register(plugin.manifest);
+    const factoryAdapter: AdapterFactoryPort = {
+      createCapabilityAdapter: <T>(
+        conn: Connection,
+        cap: string,
+        idMap: IdentifierMappingPort,
+        credRes: CredentialsResolverPort,
+      ): Promise<T> =>
+        plugin.createCapabilityAdapter<T>(conn, cap, {
+          ...host,
+          identifierMapping: idMap,
+          credentialsResolver: credRes,
+        }),
+    };
+    host.factoryResolver.registerFactory(plugin.manifest.adapterKey, factoryAdapter);
+    plugin.register?.(host);
+
+    this.logger.log('WooCommerce plugin registered successfully');
+  }
+}

--- a/libs/integrations/woocommerce/src/woocommerce-integration.module.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-integration.module.ts
@@ -16,7 +16,12 @@
 import type { DynamicModule } from '@nestjs/common';
 import { createNestAdapterModule } from '@openlinker/plugin-sdk';
 import { createWooCommercePlugin } from './woocommerce-plugin';
+import { WooCommerceWebhookProvisioningModule } from './woocommerce-webhook-provisioning.module';
 
 export const WooCommerceIntegrationModule: DynamicModule = createNestAdapterModule({
   plugin: createWooCommercePlugin(),
+  // The inbound webhook provisioner (#1548) needs NestJS-injected ConnectionPort
+  // + IWebhookSecretService (not in the HostServices bag), so it self-registers
+  // from this companion module rather than from plugin.register(host).
+  imports: [WooCommerceWebhookProvisioningModule],
 });

--- a/libs/integrations/woocommerce/src/woocommerce-plugin.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-plugin.ts
@@ -16,6 +16,9 @@
 import { dispatchCapability, type AdapterPlugin, type HostServices } from '@openlinker/plugin-sdk';
 import type { AdapterMetadata } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
+import type { WooCommerceCustomerProvisioner } from './infrastructure/provisioners/woocommerce-customer-provisioner';
+import type { WooCommerceAddressProvisioner } from './infrastructure/provisioners/woocommerce-address-provisioner';
 import { WooCommerceConnectionTesterAdapter } from './infrastructure/adapters/woocommerce-connection-tester.adapter';
 import { WooCommerceConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/woocommerce-connection-config-shape-validator.adapter';
 import { WooCommerceConnectionCredentialsShapeValidatorAdapter } from './infrastructure/adapters/woocommerce-connection-credentials-shape-validator.adapter';
@@ -69,7 +72,25 @@ export const woocommerceAdapterManifest: AdapterMetadata = {
 /** Short brand label for domain-exception prefixes (manifest.displayName is too long). */
 const WOOCOMMERCE_BRAND = 'WooCommerce';
 
-export function createWooCommercePlugin(): AdapterPlugin {
+/**
+ * Plugin-specific cross-package deps for the WooCommerce descriptor (#1552).
+ * The customer + address provisioners and the customer-projection repository
+ * are NOT part of the curated `HostServices` bag (they need `SyncLockPort` and
+ * `CustomerProjectionRepositoryPort`), so they're injected via the companion
+ * NestJS module (`WooCommerceIntegrationModule`) and passed through here — the
+ * same pattern PrestaShop uses for its provisioners.
+ *
+ * Optional so the static / unit-test path (`createWooCommercePlugin()`) keeps
+ * working; the OrderProcessorManager capability throws a descriptive error when
+ * they're absent.
+ */
+export interface CreateWooCommercePluginDeps {
+  readonly customerProvisioner: WooCommerceCustomerProvisioner;
+  readonly addressProvisioner: WooCommerceAddressProvisioner;
+  readonly customerProjectionRepository: CustomerProjectionRepositoryPort;
+}
+
+export function createWooCommercePlugin(deps?: CreateWooCommercePluginDeps): AdapterPlugin {
   return {
     manifest: woocommerceAdapterManifest,
 
@@ -137,12 +158,23 @@ export function createWooCommercePlugin(): AdapterPlugin {
                   host.identifierMapping,
                   connection,
                 ),
-              OrderProcessorManager: () =>
-                new WooCommerceOrderProcessorAdapter(
+              OrderProcessorManager: () => {
+                if (!deps) {
+                  throw new Error(
+                    `${WOOCOMMERCE_BRAND} OrderProcessorManager requires customer + address ` +
+                      `provisioners — resolve this capability through WooCommerceIntegrationModule, ` +
+                      `not a bare createWooCommercePlugin().`,
+                  );
+                }
+                return new WooCommerceOrderProcessorAdapter(
                   httpClient,
                   host.identifierMapping,
                   connection,
-                ),
+                  deps.customerProvisioner,
+                  deps.addressProvisioner,
+                  deps.customerProjectionRepository,
+                );
+              },
               OrderSource: () => new WooCommerceOrderSourceAdapter(httpClient, connection),
               // ProductPublisher + CategoryProvisioner are the same instance —
               // CategoryProvisioner is a sub-capability of ShopProductManagerPort,

--- a/libs/integrations/woocommerce/src/woocommerce-plugin.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-plugin.ts
@@ -31,6 +31,7 @@ import { WooCommerceOrderSourceAdapter } from './infrastructure/adapters/woocomm
 import { WooCommerceProductPublisherAdapter } from './infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter';
 import { WooCommerceOfferManagerAdapter } from './infrastructure/adapters/offer-manager/woocommerce-offer-manager.adapter';
 import { WooCommerceAuthFailureClassifierAdapter } from './infrastructure/adapters/woocommerce-auth-failure-classifier.adapter';
+import { WooCommerceWebhookEventTranslatorAdapter } from './infrastructure/adapters/woocommerce-webhook-event-translator.adapter';
 import { buildWooCommerceSchedulerTasks } from './infrastructure/scheduler/woocommerce-scheduler-tasks';
 
 /**
@@ -89,6 +90,15 @@ export function createWooCommercePlugin(): AdapterPlugin {
       host.authFailureClassifierRegistry.register(
         woocommerceAdapterManifest.adapterKey,
         new WooCommerceAuthFailureClassifierAdapter(),
+      );
+      // Inbound webhook-event translator (ADR-015 / #1548) — decodes WC order
+      // webhook events into neutral CanonicalInboundEvents. The webhook
+      // PROVISIONER is registered by `WooCommerceWebhookProvisioningModule`
+      // (it needs NestJS-injected ConnectionPort + IWebhookSecretService, which
+      // are not in the HostServices bag).
+      host.webhookEventTranslatorRegistry.register(
+        woocommerceAdapterManifest.adapterKey,
+        new WooCommerceWebhookEventTranslatorAdapter(),
       );
       for (const task of buildWooCommerceSchedulerTasks()) {
         host.schedulerTaskRegistry.register(task);

--- a/libs/integrations/woocommerce/src/woocommerce-webhook-provisioning.module.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-webhook-provisioning.module.ts
@@ -1,0 +1,61 @@
+/**
+ * WooCommerce Webhook Provisioning Module (#1548)
+ *
+ * Companion NestJS module composed into the WooCommerce plugin via
+ * `createNestAdapterModule({ imports: [WooCommerceWebhookProvisioningModule] })`.
+ * It exists because the automated webhook provisioner needs NestJS-injected
+ * services — `ConnectionPort` (read/patch the connection) and
+ * `IWebhookSecretService` (rotate the shared secret) — that are deliberately
+ * NOT part of the framework-neutral `HostServices` bag. Rather than restructure
+ * the whole WooCommerce plugin onto a custom module, this small module injects
+ * exactly those deps + `CredentialsResolverPort` + the provisioning registry,
+ * and registers `WooCommerceWebhookProvisioningAdapter` in `onModuleInit`.
+ *
+ * Mirrors `ErliWebhookProvisioningModule`.
+ *
+ * @module libs/integrations/woocommerce/src
+ */
+import { Inject, Module, type OnModuleInit } from '@nestjs/common';
+import {
+  CredentialsResolverPort,
+  CREDENTIALS_RESOLVER_TOKEN,
+  IntegrationsModule,
+  IWebhookSecretService,
+  WEBHOOK_SECRET_SERVICE_TOKEN,
+  WebhookProvisioningRegistryService,
+  WEBHOOK_PROVISIONING_REGISTRY_TOKEN,
+} from '@openlinker/core/integrations';
+import {
+  ConnectionPort,
+  CONNECTION_PORT_TOKEN,
+  IdentifierMappingModule,
+} from '@openlinker/core/identifier-mapping';
+import { woocommerceAdapterManifest } from './woocommerce-plugin';
+import { WooCommerceWebhookProvisioningAdapter } from './infrastructure/adapters/woocommerce-webhook-provisioning.adapter';
+
+@Module({
+  imports: [IntegrationsModule, IdentifierMappingModule],
+})
+export class WooCommerceWebhookProvisioningModule implements OnModuleInit {
+  constructor(
+    @Inject(WEBHOOK_PROVISIONING_REGISTRY_TOKEN)
+    private readonly webhookProvisioningRegistry: WebhookProvisioningRegistryService,
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connectionPort: ConnectionPort,
+    @Inject(WEBHOOK_SECRET_SERVICE_TOKEN)
+    private readonly webhookSecretService: IWebhookSecretService,
+    @Inject(CREDENTIALS_RESOLVER_TOKEN)
+    private readonly credentialsResolver: CredentialsResolverPort,
+  ) {}
+
+  onModuleInit(): void {
+    this.webhookProvisioningRegistry.register(
+      woocommerceAdapterManifest.adapterKey,
+      new WooCommerceWebhookProvisioningAdapter(
+        this.connectionPort,
+        this.webhookSecretService,
+        this.credentialsResolver,
+      ),
+    );
+  }
+}

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -344,6 +344,10 @@ const ALLOW_LIST = new Map([
     new Set(['CustomerProjectionRepositoryPort']),
   ],
   [
+    'libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-provisioner.types.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
     'libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-address-provisioner.spec.ts',
     new Set(['CustomerProjectionRepositoryPort']),
   ],

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -325,6 +325,32 @@ const ALLOW_LIST = new Map([
     'libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-address-provisioner.ts',
     new Set(['CustomerProjectionRepositoryPort']),
   ],
+  // WooCommerce customer + address provisioning (#1552) — mirrors PrestaShop;
+  // rewire via ICustomersService alongside the PS entries (#722).
+  [
+    'libs/integrations/woocommerce/src/woocommerce-plugin.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
+    'libs/integrations/woocommerce/src/woocommerce-integration.module.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
+    'libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
+    'libs/integrations/woocommerce/src/infrastructure/provisioners/woocommerce-address-provisioner.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
+    'libs/integrations/woocommerce/src/infrastructure/provisioners/__tests__/woocommerce-address-provisioner.spec.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
+    'libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
   [
     'libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-address-provisioner.spec.ts',
     new Set(['CustomerProjectionRepositoryPort']),

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -356,6 +356,10 @@ const ALLOW_LIST = new Map([
     new Set(['CustomerProjectionRepositoryPort']),
   ],
   [
+    'libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.fulfillment-status.spec.ts',
+    new Set(['CustomerProjectionRepositoryPort']),
+  ],
+  [
     'libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-address-provisioner.spec.ts',
     new Set(['CustomerProjectionRepositoryPort']),
   ],


### PR DESCRIPTION
## Summary

This epic brings the WooCommerce integration to parity with PrestaShop by
integrating six independently reviewed feature branches into a single
delivery. Each capability was developed and reviewed on its own branch, then
unioned here on top of the shared order-processor adapter.

## Capabilities delivered

- **Inbound webhooks (#1548)** - webhook provisioning on the WooCommerce side
  plus a webhook event translator that maps WC notifications into OpenLinker's
  neutral canonical inbound events.
- **OrderStatusWriteback (#1549)** - relay-based, source-bound order-status
  round-trip that pushes a status change back to the originating marketplace
  (ADR-027). Owns the shared `woocommerce-order-status.types.ts` module reused
  across the cluster.
- **FulfillmentStatusReader (#1550)** - reads a WooCommerce order's current
  fulfillment status and maps it to the neutral fulfillment snapshot.
- **DestinationOptionsReader (#1551)** - discovers the shop's live option
  vocabulary (carriers, order statuses, payment methods) that powers the
  connection-mapping UI dropdowns.
- **Customer + address provisioning (#1552)** - dedicated customer and address
  provisioners with reuse tracking and distributed locking, mirroring the
  PrestaShop pattern. Expands the order-processor adapter to delegate customer
  resolution and best-effort address reuse.
- **Variant mapping (#1553)** - variant mapper and synthetic-variant-id helpers
  mirroring PrestaShop, so multi-variant WooCommerce products resolve to the
  correct OpenLinker variants.

After the integration the `WooCommerceOrderProcessorAdapter` implements
`OrderProcessorManagerPort`, `OrderFulfillmentUpdater`, `OrderStatusWriteback`,
`DestinationOptionsReader`, and `FulfillmentStatusReader`.

## Review and follow-up

Each of the six branches passed review individually before integration. The
inbound webhook decoder is intentionally out of scope here and is tracked as a
deferred follow-up in #1563.

## Verification

Scoped checks on `@openlinker/integrations-woocommerce` all pass: type-check,
lint, and 421 unit tests across 23 suites. The cross-context import invariant
check passes.

Closes #1547 #1548 #1549 #1550 #1551 #1552 #1553
