### PR TITLE
fix(invoicing): re-check live order status before KSeF auto-issuance

### DIFF
--- a/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
@@ -9,6 +9,7 @@ import { InvoicingIssueHandler, MAX_INVOICE_LINES } from '../invoicing-issue.han
 import { BuyerProfile } from '@openlinker/core/invoicing';
 import { SyncJobExecutionError } from '@openlinker/core/sync';
 import type { IInvoiceService } from '@openlinker/core/invoicing';
+import type { IOrderRecordService, OrderRecord } from '@openlinker/core/orders';
 import type {
   InvoicingIssuePayloadV1,
   SyncJob as SyncJobEntity,
@@ -58,8 +59,14 @@ function makeJob(payload: unknown): SyncJobEntity {
   } as SyncJobEntity;
 }
 
+function makeOrderRecord(status: string | undefined): OrderRecord | null {
+  if (status === undefined) return null;
+  return { status } as unknown as OrderRecord;
+}
+
 describe('InvoicingIssueHandler', () => {
   let invoiceService: jest.Mocked<IInvoiceService>;
+  let orderRecordService: jest.Mocked<IOrderRecordService>;
   let handler: InvoicingIssueHandler;
   let warnSpy: jest.SpyInstance<void, [message: string]>;
 
@@ -73,7 +80,18 @@ describe('InvoicingIssueHandler', () => {
       issueCorrection: jest.fn(),
       applyRegulatoryClearance: jest.fn(),
     };
-    handler = new InvoicingIssueHandler(invoiceService as unknown as IInvoiceService);
+    orderRecordService = {
+      persistOrder: jest.fn(),
+      updateSyncStatus: jest.fn(),
+      persistIncomingSnapshot: jest.fn(),
+      getOrderRecord: jest.fn().mockResolvedValue(null),
+      findMany: jest.fn(),
+      updateFulfillmentState: jest.fn(),
+    } as unknown as jest.Mocked<IOrderRecordService>;
+    handler = new InvoicingIssueHandler(
+      invoiceService as unknown as IInvoiceService,
+      orderRecordService,
+    );
     warnSpy = jest
       .spyOn(
         (handler as unknown as { logger: { warn: (m: string) => void } }).logger,
@@ -172,6 +190,42 @@ describe('InvoicingIssueHandler', () => {
         expect(msg).not.toContain(BUYER_SENTINEL);
         expect(msg).not.toContain('ul. Testowa');
       }
+    });
+  });
+
+  describe('live order-status gate (#1596)', () => {
+    it('skips issuance when the live order status is cancelled', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(makeOrderRecord('cancelled'));
+      const result = await handler.execute(makeJob(makePayload()));
+      expect(result).toEqual({ outcome: 'business_failure' });
+      expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
+      expect(warnSpy.mock.calls[0][0]).toContain("status is 'cancelled'");
+    });
+
+    it('skips issuance when the live order status is refunded', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(makeOrderRecord('refunded'));
+      const result = await handler.execute(makeJob(makePayload()));
+      expect(result).toEqual({ outcome: 'business_failure' });
+      expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
+    });
+
+    it('proceeds with issuance when the live order status is still eligible (e.g. processing)', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(makeOrderRecord('processing'));
+      const result = await handler.execute(makeJob(makePayload()));
+      expect(result).toEqual({ outcome: 'ok' });
+      expect(invoiceService.issueInvoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('proceeds with issuance when the order record is absent (graceful degradation)', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(null);
+      const result = await handler.execute(makeJob(makePayload()));
+      expect(result).toEqual({ outcome: 'ok' });
+      expect(invoiceService.issueInvoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-checks the order by payload.orderId', async () => {
+      await handler.execute(makeJob(makePayload({ orderId: 'order-42' })));
+      expect(orderRecordService.getOrderRecord).toHaveBeenCalledWith('order-42');
     });
   });
 

--- a/apps/worker/src/sync/handlers/invoicing-issue.handler.ts
+++ b/apps/worker/src/sync/handlers/invoicing-issue.handler.ts
@@ -5,10 +5,10 @@
  * The policy service (`AutoIssueTriggerService`) has already composed the
  * issuance command into the job payload, so this handler:
  *  1. Casts + DEEP-validates the payload (F5).
- *  2. Re-checks the order's LIVE status via `IOrderRecordService` (#1596) —
+ *  2. Reconstructs `new BuyerProfile(...)` from the PLAIN payload buyer (#12).
+ *  3. Re-checks the order's LIVE status via `IOrderRecordService` (#1596) —
  *     the payload was snapshotted at trigger time and can be stale by the time
  *     this job runs; a cancelled/refunded order must never clear an invoice.
- *  3. Reconstructs `new BuyerProfile(...)` from the PLAIN payload buyer (#12).
  *  4. Calls `invoiceService.issueInvoice(command)` with the command idempotency
  *     key equal to `payload.idempotencyKey` (the SAME string as the job row, F4).
  *
@@ -72,39 +72,41 @@ export class InvoicingIssueHandler implements SyncJobHandler {
       return { outcome: 'business_failure' };
     }
 
-    // #1596: the payload was snapshotted at trigger time (order-ingestion.service.ts),
-    // which can be arbitrarily stale by the time this job actually runs (retry
-    // backoff, queue backlog, worker restart). Re-check the order's LIVE status
-    // immediately before issuing — a cancelled/refunded order must never clear a
-    // fiscal invoice. Mirrors the #938 shipping-dispatch live re-check
-    // (ShipmentDispatchService): an absent/unknown live status (record null, or
-    // an unrecognised status) falls through to normal issuance — graceful
-    // degradation for sources that don't report status — this gate only BLOCKS
-    // on a positively-confirmed cancelled/refunded status.
-    const record = await this.orderRecords.getOrderRecord(payload.orderId);
-    if (record?.status === 'cancelled' || record?.status === 'refunded') {
-      this.logger.warn(
-        `invoicing.issue skipped: order status is '${record.status}' orderId=${payload.orderId} connectionId=${payload.connectionId}`,
-      );
-      return { outcome: 'business_failure' };
-    }
-
     const command = this.toCommand(payload);
 
     try {
+      // #1596: re-check the order's LIVE status immediately before issuing. This
+      // read sits INSIDE the retryable try so a transient repository failure is
+      // wrapped as a retryable SyncJobExecutionError (fail-closed — never issue
+      // on an unresolved read), consistent with the file's two documented
+      // failure paths rather than propagating raw. Mirrors the #938
+      // shipping-dispatch live re-check (ShipmentDispatchService): an
+      // absent/unknown live status (record null, or an unrecognised status)
+      // falls through to normal issuance — graceful degradation for sources that
+      // don't report status — this gate only BLOCKS on a positively-confirmed
+      // cancelled/refunded status (a terminal business_failure, not a retry).
+      const record = await this.orderRecords.getOrderRecord(payload.orderId);
+      if (record?.status === 'cancelled' || record?.status === 'refunded') {
+        this.logger.warn(
+          `invoicing.issue skipped: order status is '${record.status}' orderId=${payload.orderId} connectionId=${payload.connectionId}`,
+        );
+        return { outcome: 'business_failure' };
+      }
+
       // F4: command idempotencyKey === payload.idempotencyKey === job row key.
       // The service's `issued`-only exactly-once gate makes duplicate events /
       // retries a no-op against the same key.
       await this.invoiceService.issueInvoice(command);
       return { outcome: 'ok' };
     } catch (error) {
-      // ANY issueInvoice failure (transport/bridge-unreachable AND any provider
-      // error that escapes the SVC) is wrapped as retryable here — the deep
-      // pre-validation above has already rejected statically-malformed payloads
-      // as business_failure, and the SVC's `issued`-only exactly-once gate makes
-      // every retry a no-op against the same key, so re-crossing the provider
-      // boundary cannot double-issue. PII discipline: the message carries ONLY
-      // error.name + orderId + connectionId — never payload/buyer.
+      // ANY issueInvoice / live-status-read failure (transport/bridge-unreachable
+      // AND any provider error that escapes the SVC) is wrapped as retryable
+      // here — the deep pre-validation above has already rejected
+      // statically-malformed payloads as business_failure, and the SVC's
+      // `issued`-only exactly-once gate makes every retry a no-op against the
+      // same key, so re-crossing the provider boundary cannot double-issue. PII
+      // discipline: the message carries ONLY error.name + orderId + connectionId
+      // — never payload/buyer.
       const errorName = error instanceof Error ? error.name : 'UnknownError';
       throw new SyncJobExecutionError(
         `invoicing.issue failed: error=${errorName} orderId=${payload.orderId} connectionId=${payload.connectionId}`,

--- a/apps/worker/src/sync/handlers/invoicing-issue.handler.ts
+++ b/apps/worker/src/sync/handlers/invoicing-issue.handler.ts
@@ -5,8 +5,11 @@
  * The policy service (`AutoIssueTriggerService`) has already composed the
  * issuance command into the job payload, so this handler:
  *  1. Casts + DEEP-validates the payload (F5).
- *  2. Reconstructs `new BuyerProfile(...)` from the PLAIN payload buyer (#12).
- *  3. Calls `invoiceService.issueInvoice(command)` with the command idempotency
+ *  2. Re-checks the order's LIVE status via `IOrderRecordService` (#1596) —
+ *     the payload was snapshotted at trigger time and can be stale by the time
+ *     this job runs; a cancelled/refunded order must never clear an invoice.
+ *  3. Reconstructs `new BuyerProfile(...)` from the PLAIN payload buyer (#12).
+ *  4. Calls `invoiceService.issueInvoice(command)` with the command idempotency
  *     key equal to `payload.idempotencyKey` (the SAME string as the job row, F4).
  *
  * PII DISCIPLINE (F-validate-PII / D11): the payload carries real buyer PII.
@@ -37,6 +40,7 @@ import {
   BuyerTypeValues,
 } from '@openlinker/core/invoicing';
 import type { IssueInvoiceCommand } from '@openlinker/core/invoicing';
+import { IOrderRecordService, ORDER_RECORD_SERVICE_TOKEN } from '@openlinker/core/orders';
 import { Logger } from '@openlinker/shared/logging';
 
 type SyncJob = SyncJobEntity;
@@ -54,6 +58,8 @@ export class InvoicingIssueHandler implements SyncJobHandler {
   constructor(
     @Inject(INVOICE_SERVICE_TOKEN)
     private readonly invoiceService: IInvoiceService,
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecords: IOrderRecordService,
   ) {}
 
   async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
@@ -63,6 +69,23 @@ export class InvoicingIssueHandler implements SyncJobHandler {
     // + ids (no payload/buyer/lines).
     const payload = this.validatePayload(job);
     if (payload === null) {
+      return { outcome: 'business_failure' };
+    }
+
+    // #1596: the payload was snapshotted at trigger time (order-ingestion.service.ts),
+    // which can be arbitrarily stale by the time this job actually runs (retry
+    // backoff, queue backlog, worker restart). Re-check the order's LIVE status
+    // immediately before issuing — a cancelled/refunded order must never clear a
+    // fiscal invoice. Mirrors the #938 shipping-dispatch live re-check
+    // (ShipmentDispatchService): an absent/unknown live status (record null, or
+    // an unrecognised status) falls through to normal issuance — graceful
+    // degradation for sources that don't report status — this gate only BLOCKS
+    // on a positively-confirmed cancelled/refunded status.
+    const record = await this.orderRecords.getOrderRecord(payload.orderId);
+    if (record?.status === 'cancelled' || record?.status === 'refunded') {
+      this.logger.warn(
+        `invoicing.issue skipped: order status is '${record.status}' orderId=${payload.orderId} connectionId=${payload.connectionId}`,
+      );
       return { outcome: 'business_failure' };
     }
 

--- a/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
@@ -44,6 +44,28 @@ describe('OrderRecord.paymentStatus', () => {
   });
 });
 
+describe('OrderRecord.status (#1596)', () => {
+  it.each(['pending', 'processing', 'shipped', 'delivered', 'cancelled', 'refunded'])(
+    'returns the recognised order status %s from the snapshot',
+    (status) => {
+      expect(makeRecord({ status }).status).toBe(status);
+    },
+  );
+
+  it('returns undefined when the snapshot has no status key', () => {
+    expect(makeRecord({}).status).toBeUndefined();
+  });
+
+  it('returns undefined when status is an unrecognised string', () => {
+    expect(makeRecord({ status: 'archived' }).status).toBeUndefined();
+  });
+
+  it('returns undefined when status is a non-string value', () => {
+    expect(makeRecord({ status: 42 }).status).toBeUndefined();
+    expect(makeRecord({ status: null }).status).toBeUndefined();
+  });
+});
+
 describe('OrderRecord.codToCollect (#1435)', () => {
   it('returns the sourced amount when the snapshot carries a well-formed pair', () => {
     expect(makeRecord({ codToCollect: { amount: '510.94', currency: 'PLN' } }).codToCollect).toEqual({

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -13,6 +13,8 @@ import { PaymentStatusValues } from '../types/payment-status.types';
 import type { PaymentStatus } from '../types/payment-status.types';
 import type { CodToCollect } from '../types/cod-to-collect.types';
 import type { FulfillmentRollupState } from '../types/order-fulfillment.types';
+import { OrderStatusValues } from '../types/order.types';
+import type { OrderStatus } from '../types/order.types';
 
 export type { OrderSyncStatus, SyncAttempt } from '../types/order-sync.types';
 
@@ -93,6 +95,22 @@ export class OrderRecord {
     const { amount, currency } = value as Record<string, unknown>;
     return typeof amount === 'string' && typeof currency === 'string'
       ? { amount, currency }
+      : undefined;
+  }
+
+  /**
+   * Typed, fail-safe read of the order's neutral lifecycle status (#1596) from
+   * the snapshot. Pure derivation of an already-loaded field (ADR-011): no I/O,
+   * no mutation. Mirrors {@link paymentStatus} — lets the #1596 auto-issuance
+   * race gate re-check the order's LIVE status against a typed contract rather
+   * than the snapshot's internal JSON layout. Returns `undefined` when the
+   * source didn't populate status or the stored value isn't a recognised
+   * `OrderStatus`.
+   */
+  get status(): OrderStatus | undefined {
+    const value = this.orderSnapshot.status;
+    return typeof value === 'string' && (OrderStatusValues as readonly string[]).includes(value)
+      ? (value as OrderStatus)
       : undefined;
   }
 }


### PR DESCRIPTION
## Summary

Part of #1578, addresses #1596.

`AutoIssueTriggerService` snapshots the order into the `invoicing.issue` job payload at trigger time. `InvoicingIssueHandler` never re-validated that snapshot against the order's *current* state before calling `issueInvoice`. A cancel/refund arriving after the job is scheduled but before it actually runs (retry backoff, queue backlog, worker restart) let a fiscal KSeF invoice be issued and cleared against an order that is no longer eligible.

## Changes

- Added a `status` getter to `OrderRecord` (`libs/core/src/orders/domain/entities/order-record.entity.ts`), mirroring the existing `paymentStatus` getter pattern — a pure, typed derivation of the snapshot's `status` field, narrowed via `OrderStatusValues`.
- `InvoicingIssueHandler.execute` (`apps/worker/src/sync/handlers/invoicing-issue.handler.ts`) now injects `IOrderRecordService` and re-reads the order's live status immediately before calling `issueInvoice`, mirroring the existing `#938` shipping-dispatch live re-check pattern (`ShipmentDispatchService`). An absent/unrecognised live status falls through to normal issuance (graceful degradation for sources that don't report status) — only a positively-confirmed `cancelled`/`refunded` status blocks issuance, returning `{ outcome: 'business_failure' }`.

## Test plan

- [x] `pnpm --filter @openlinker/core build` — clean
- [x] `pnpm --filter @openlinker/worker build` — clean
- [x] New unit tests in `invoicing-issue.handler.spec.ts` cover: cancelled → business_failure (no issueInvoice call), refunded → business_failure, still-eligible status → normal issuance, absent order record → normal issuance (graceful degradation), and that the live re-check queries by `payload.orderId`
- [x] New unit tests in `order-record.entity.spec.ts` cover the new `status` getter (all recognised values, missing key, unrecognised string, non-string value)
- [x] `pnpm lint` (scoped ESLint run on touched files) — clean
- [x] `node scripts/check-cross-context-imports.mjs` / `check-service-interfaces.mjs` — no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)