### PR TITLE
feat(invoicing): NIP mod-11 checksum validation at OL boundaries (#1595)

### DIFF
--- a/apps/api/src/invoicing/http/dto/buyer-tax-id.dto.spec.ts
+++ b/apps/api/src/invoicing/http/dto/buyer-tax-id.dto.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Buyer Tax Id DTO — validation spec (#1595)
+ *
+ * Exercises the scheme-scoped NIP mod-11 checksum constraint: a valid Polish
+ * NIP, an invalid-format value, and a valid-format-but-invalid-checksum value
+ * under `scheme: 'pl-nip'`, plus the pass-through for non-PL schemes.
+ *
+ * @module apps/api/src/invoicing/http/dto
+ */
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+
+import { BuyerTaxIdDto } from './buyer-tax-id.dto';
+
+function buildDto(payload: Record<string, unknown>): BuyerTaxIdDto {
+  return plainToInstance(BuyerTaxIdDto, payload);
+}
+
+// 1189981779 has a correct mod-11 check digit; 1189981770 mutates it.
+const VALID_NIP = '1189981779';
+const INVALID_CHECKSUM_NIP = '1189981770';
+
+describe('BuyerTaxIdDto', () => {
+  it('should pass when scheme is pl-nip and the NIP is checksum-valid', async () => {
+    const errors = await validate(buildDto({ scheme: 'pl-nip', value: VALID_NIP }));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should pass when scheme is pl-nip and the NIP carries separators', async () => {
+    const errors = await validate(buildDto({ scheme: 'pl-nip', value: '11-8998177-9' }));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should reject a pl-nip value with a bad checksum', async () => {
+    const errors = await validate(buildDto({ scheme: 'pl-nip', value: INVALID_CHECKSUM_NIP }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('plNipChecksum');
+  });
+
+  it('should reject an invalid-format pl-nip value', async () => {
+    const errors = await validate(buildDto({ scheme: 'pl-nip', value: '12345' }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('plNipChecksum');
+  });
+
+  it('should NOT checksum-validate a non-PL scheme (eu-vat passes through)', async () => {
+    const errors = await validate(buildDto({ scheme: 'eu-vat', value: 'DE123456789' }));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should still require scheme and value to be non-empty strings', async () => {
+    const errors = await validate(buildDto({ scheme: '', value: '' }));
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/invoicing/http/dto/buyer-tax-id.dto.ts
+++ b/apps/api/src/invoicing/http/dto/buyer-tax-id.dto.ts
@@ -3,13 +3,60 @@
  *
  * Scheme-tagged tax identifier (EN 16931 BT-30 / ISO 6523). PRESENCE on the
  * issue request drives the B2B/B2C axis in the mapper (present => company,
- * absent => private) — there is NO NIP/VAT logic in the API layer; `scheme` is
- * an open string the provider adapter interprets.
+ * absent => private) - there is NO NIP/VAT logic in the API layer beyond the
+ * defensive checksum gate below; `scheme` is an open string the provider adapter
+ * interprets.
+ *
+ * NIP checksum (#1595): when - and only when - the scheme tags the value as a
+ * Polish NIP (`pl-nip`), the mod-11 check digit is validated so a
+ * mistyped-but-well-formed NIP is rejected at the OL boundary instead of
+ * round-tripping to a generic KSeF submission-time rejection. Any other scheme
+ * (e.g. `eu-vat`) is left untouched - the API stays provider-agnostic and does
+ * not reinterpret foreign identifiers as Polish NIPs.
+ *
+ * The mod-11 helper is a deliberate ~10-line local copy (not shared from
+ * `@openlinker/shared` nor imported from the KSeF plugin): the invoicing API is
+ * provider-agnostic and must not depend on a concrete provider package, and the
+ * algorithm is fixed by Polish law and does not drift.
  *
  * @module apps/api/src/invoicing/http/dto
  */
-import { IsString, IsNotEmpty } from 'class-validator';
+import type { ValidationArguments, ValidatorConstraintInterface } from 'class-validator';
+import { IsString, IsNotEmpty, Validate, ValidatorConstraint } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+
+const PL_NIP_SCHEME = 'pl-nip';
+const NIP_CHECKSUM_WEIGHTS = [6, 5, 7, 2, 3, 4, 5, 6, 7];
+
+function isValidNipChecksum(value: string): boolean {
+  if (!/^\d{10}$/.test(value)) return false;
+  const digits = value.split('').map((c) => Number(c));
+  const sum = NIP_CHECKSUM_WEIGHTS.reduce((acc, weight, i) => acc + weight * digits[i], 0);
+  const checkDigit = sum % 11;
+  if (checkDigit === 10) return false;
+  return checkDigit === digits[9];
+}
+
+/**
+ * Rejects a `value` that carries the `pl-nip` scheme but fails the mod-11 check
+ * (or is not a 10-digit NIP once separators are stripped). Non-`pl-nip` schemes
+ * pass unconditionally - the constraint is scheme-scoped by design.
+ */
+@ValidatorConstraint({ name: 'plNipChecksum', async: false })
+class PlNipChecksumConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    const scheme = (args.object as BuyerTaxIdDto).scheme;
+    if (typeof scheme !== 'string' || scheme.trim().toLowerCase() !== PL_NIP_SCHEME) {
+      return true; // not a Polish NIP - out of scope for the checksum gate
+    }
+    if (typeof value !== 'string') return true; // @IsString reports the type error
+    return isValidNipChecksum(value.replace(/[\s-]/g, ''));
+  }
+
+  defaultMessage(): string {
+    return 'value must be a checksum-valid 10-digit Polish NIP when scheme is pl-nip';
+  }
+}
 
 export class BuyerTaxIdDto {
   @ApiProperty({ description: 'Open scheme tag interpreted by the adapter (e.g. pl-nip, eu-vat)' })
@@ -20,5 +67,6 @@ export class BuyerTaxIdDto {
   @ApiProperty({ description: 'The identifier value' })
   @IsString()
   @IsNotEmpty()
+  @Validate(PlNipChecksumConstraint)
   value!: string;
 }

--- a/apps/web/src/plugins/ksef/components/ksef-setup-form.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-setup-form.test.tsx
@@ -78,7 +78,7 @@ describe('KsefSetupForm', () => {
 
     fireEvent.change(screen.getByLabelText('Connection name'), { target: { value: 'KSeF main' } });
     fireEvent.change(screen.getByLabelText('Environment'), { target: { value: 'prod' } });
-    fireEvent.change(screen.getByLabelText('Seller NIP'), { target: { value: '12-3456789-0' } });
+    fireEvent.change(screen.getByLabelText('Seller NIP'), { target: { value: '11-8998177-9' } });
     fireEvent.change(screen.getByLabelText('Authentication type'), {
       target: { value: 'qualified-seal' },
     });
@@ -101,7 +101,7 @@ describe('KsefSetupForm', () => {
     // defaults to PL, so the seller carries an address with just the ISO code.
     expect(payload.config.env).toBe('prod');
     expect(payload.config.seller).toEqual({
-      nip: '1234567890',
+      nip: '1189981779',
       address: { countryIso2: 'PL' },
     });
     // Write-only: secret travels only in credentials, never in config.
@@ -117,7 +117,7 @@ describe('KsefSetupForm', () => {
     renderWithProviders(<KsefSetupForm />, { apiClient });
 
     fireEvent.change(screen.getByLabelText('Connection name'), { target: { value: 'KSeF main' } });
-    fireEvent.change(screen.getByLabelText('Seller NIP'), { target: { value: '1234567890' } });
+    fireEvent.change(screen.getByLabelText('Seller NIP'), { target: { value: '1189981779' } });
     fireEvent.change(screen.getByLabelText('Seller legal name'), {
       target: { value: 'ACME Sp. z o.o.' },
     });
@@ -137,7 +137,7 @@ describe('KsefSetupForm', () => {
     const payload = create.mock.calls[0][0] as { config: Record<string, unknown> };
     // The nested shape `resolveSeller` reads; `line2` is omitted when blank.
     expect(payload.config.seller).toEqual({
-      nip: '1234567890',
+      nip: '1189981779',
       name: 'ACME Sp. z o.o.',
       address: {
         line1: 'ul. Przykładowa 1',

--- a/apps/web/src/plugins/ksef/components/ksef-setup.schema.ts
+++ b/apps/web/src/plugins/ksef/components/ksef-setup.schema.ts
@@ -37,7 +37,7 @@
  */
 import { z } from 'zod';
 import type { CreateConnectionInput } from '../../../features/connections';
-import { normalizeNip } from '../lib/ksef-nip';
+import { normalizeNip, isValidNipChecksum } from '../lib/ksef-nip';
 import { buildKsefSellerConfig } from '../lib/ksef-seller-config';
 export type { KsefSellerProfileInput } from '../lib/ksef-seller-config';
 
@@ -87,7 +87,14 @@ export const ksefSetupSchema = z
           .string()
           .trim()
           .transform(normalizeNip)
-          .pipe(z.string().regex(NIP_DIGITS, 'Seller NIP must be 10 digits')),
+          .pipe(
+            z
+              .string()
+              .regex(NIP_DIGITS, 'Seller NIP must be 10 digits')
+              // mod-11 check digit (#1595) - catches a mistyped-but-well-formed
+              // NIP client-side before it round-trips to KSeF's own rejection.
+              .refine(isValidNipChecksum, 'Seller NIP has an invalid checksum'),
+          ),
         z.literal(''),
       ])
       .optional(),

--- a/apps/web/src/plugins/ksef/ksef-connection-config.ts
+++ b/apps/web/src/plugins/ksef/ksef-connection-config.ts
@@ -28,7 +28,7 @@
 import { z } from 'zod';
 import type { ConnectionConfigContribution } from '../../shared/plugins';
 import { readConfigString, readOptionalConfigString } from '../../shared/plugins';
-import { normalizeNip } from './lib/ksef-nip';
+import { normalizeNip, isValidNipChecksum } from './lib/ksef-nip';
 import { normalizeNrRb } from './lib/ksef-nrb';
 import { applyKsefSellerToConfig, type KsefSellerProfileInput } from './lib/ksef-seller-config';
 import { applyKsefPaymentToConfig, type KsefPaymentInput } from './lib/ksef-payment-config';
@@ -100,6 +100,10 @@ const ksefSchemaShape: ConnectionConfigContribution['schemaShape'] = {
         .transform(normalizeNip)
         .refine((v) => v === '' || /^\d{10}$/.test(v), {
           message: 'Seller NIP must be 10 digits.',
+        })
+        // mod-11 check digit (#1595) - parity with the create wizard.
+        .refine((v) => v === '' || isValidNipChecksum(v), {
+          message: 'Seller NIP has an invalid checksum.',
         }),
       z.literal(''),
     ])

--- a/apps/web/src/plugins/ksef/lib/ksef-nip.test.ts
+++ b/apps/web/src/plugins/ksef/lib/ksef-nip.test.ts
@@ -1,0 +1,64 @@
+/**
+ * KSeF NIP checksum tests (#1595)
+ *
+ * Covers the mod-11 pure validator and the seller-NIP schema gate: a valid NIP,
+ * an invalid-format NIP, and a valid-format-but-invalid-checksum NIP.
+ */
+import { describe, expect, it } from 'vitest';
+import { isValidNipChecksum, normalizeNip } from './ksef-nip';
+import { ksefSetupSchema, KSEF_SETUP_DEFAULT_VALUES } from '../components/ksef-setup.schema';
+
+// 1189981779 has a correct mod-11 check digit (9); 1189981770 mutates it.
+const VALID_NIP = '1189981779';
+const INVALID_CHECKSUM_NIP = '1189981770';
+
+describe('isValidNipChecksum', () => {
+  it('accepts a checksum-valid 10-digit NIP', () => {
+    expect(isValidNipChecksum(VALID_NIP)).toBe(true);
+  });
+
+  it('rejects a valid-format NIP with a wrong check digit', () => {
+    expect(isValidNipChecksum(INVALID_CHECKSUM_NIP)).toBe(false);
+  });
+
+  it('rejects an invalid-format value (wrong length / non-digits)', () => {
+    expect(isValidNipChecksum('12345')).toBe(false);
+    expect(isValidNipChecksum('12345678a0')).toBe(false);
+    expect(isValidNipChecksum('11899817790')).toBe(false);
+  });
+
+  it('rejects a NIP whose mod-11 remainder is 10', () => {
+    // 5272514610 -> first 9 digits sum mod 11 == 10, never a legal check digit.
+    expect(isValidNipChecksum('5272514610')).toBe(false);
+  });
+});
+
+describe('ksefSetupSchema sellerNip checksum gate', () => {
+  const base = { ...KSEF_SETUP_DEFAULT_VALUES, name: 'Conn', secret: 's' };
+
+  it('accepts a checksum-valid seller NIP (separators stripped)', () => {
+    const result = ksefSetupSchema.safeParse({ ...base, sellerNip: '11-8998177-9' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a valid-format seller NIP with a bad checksum', () => {
+    const result = ksefSetupSchema.safeParse({ ...base, sellerNip: INVALID_CHECKSUM_NIP });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid-format seller NIP', () => {
+    const result = ksefSetupSchema.safeParse({ ...base, sellerNip: '12345' });
+    expect(result.success).toBe(false);
+  });
+
+  it('still allows an empty seller NIP (incremental save)', () => {
+    const result = ksefSetupSchema.safeParse({ ...base, sellerNip: '' });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('normalizeNip', () => {
+  it('strips dashes and spaces', () => {
+    expect(normalizeNip('11-8998 177-9')).toBe(VALID_NIP);
+  });
+});

--- a/apps/web/src/plugins/ksef/lib/ksef-nip.ts
+++ b/apps/web/src/plugins/ksef/lib/ksef-nip.ts
@@ -1,5 +1,5 @@
 /**
- * KSeF NIP normalization
+ * KSeF NIP normalization + checksum
  *
  * Single source of truth for stripping the dashes/spaces an operator may paste
  * into a Polish NIP field. Both the create-path (`ksef-setup.schema.ts`) and the
@@ -11,4 +11,28 @@
  */
 export function normalizeNip(value: string): string {
   return value.replace(/[\s-]/g, '');
+}
+
+/**
+ * Validates the Polish NIP mod-11 check digit (#1595).
+ *
+ * The published algorithm: weight the first 9 digits by
+ * `[6,5,7,2,3,4,5,6,7]`, sum the products, take `mod 11`; the result must
+ * equal the 10th (check) digit. A remainder of 10 is not a legal check digit,
+ * so such a NIP is always rejected. The input must already be 10 digits
+ * (normalise + `^\d{10}$`-check first); a non-conforming input returns `false`.
+ *
+ * Pure, static, dependency-free. Co-located here (the FE NIP-util home) rather
+ * than in `@openlinker/shared`: the FE bundle does not consume that package, and
+ * the two backend layers keep their own ~10-line copies to avoid coupling the
+ * provider-agnostic invoicing API and the KSeF plugin through a shared runtime.
+ */
+export function isValidNipChecksum(value: string): boolean {
+  if (!/^\d{10}$/.test(value)) return false;
+  const weights = [6, 5, 7, 2, 3, 4, 5, 6, 7];
+  const digits = value.split('').map((c) => Number(c));
+  const sum = weights.reduce((acc, weight, i) => acc + weight * digits[i], 0);
+  const checkDigit = sum % 11;
+  if (checkDigit === 10) return false;
+  return checkDigit === digits[9];
 }

--- a/libs/integrations/ksef/docs/setup-guide.md
+++ b/libs/integrations/ksef/docs/setup-guide.md
@@ -223,6 +223,7 @@ OpenLinker's KSeF support targets outbound issuance + clearance of FA(3)
 | Batch (wsadowa) submission pipeline | OpenLinker issues via the online (interactive) session flow (`/sessions/online`); the batch pipeline (`/sessions/batch`) is a separate, deferred path. |
 | Inbound invoice retrieval | OpenLinker is a transmitter, not a KSeF inbox reader; pulling received invoices is out of scope. |
 | FA_PEF / PEF documents | Only the FA(3) VAT/KOR schema is planned. |
+| VAT-payer / "biała lista" (MF whitelist) verification | **Deliberately deferred (#1595).** A well-formed, checksum-valid NIP is not necessarily an active VAT-registered entity, but whitelist verification is a seller due-diligence/AML concern, not a KSeF-issuance blocker (issuance succeeds regardless of the buyer's VAT-payer status). If pursued later it belongs as an optional pre-issuance advisory around MF's `wl-api.mf.gov.pl`, not a hard block on the core issuance path. NIP **checksum** (mod-11) validation, by contrast, ships now at the FE + API boundaries. |
 | Auto-generated API reference | See the official OpenAPI at `https://api-test.ksef.mf.gov.pl/docs/v2`. |
 
 ---

--- a/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-connection-config-shape-validator.adapter.spec.ts
@@ -69,7 +69,7 @@ describe('KsefConnectionConfigShapeValidatorAdapter', () => {
 
     it('should resolve when seller.defaultTaxRate is absent', async () => {
       await expect(
-        validator.validate({ env: 'test', seller: { nip: '1234567890' } }),
+        validator.validate({ env: 'test', seller: { nip: '1189981779' } }),
       ).resolves.toBeUndefined();
     });
 
@@ -372,4 +372,35 @@ describe('KsefConnectionConfigShapeValidatorAdapter', () => {
       }
     });
   });
+  describe('seller.nip (#1595)', () => {
+    // 1189981779 has a correct mod-11 check digit; 1189981770 mutates it.
+    it('should resolve when seller.nip is a checksum-valid NIP', async () => {
+      await expect(
+        validator.validate({ env: 'test', seller: { nip: '1189981779' } }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should resolve when seller.nip is absent', async () => {
+      await expect(validator.validate({ env: 'test', seller: {} })).resolves.toBeUndefined();
+    });
+
+    it('should reject a valid-format seller.nip with a bad checksum', async () => {
+      await expect(validator.validate({ env: 'test', seller: { nip: '1189981770' } })).rejects.toMatchObject({
+        errors: [{ path: 'seller.nip', message: 'has an invalid checksum' }],
+      });
+    });
+
+    it('should reject an invalid-format seller.nip', async () => {
+      await expect(validator.validate({ env: 'test', seller: { nip: '12345' } })).rejects.toMatchObject({
+        errors: [{ path: 'seller.nip', message: 'must be a 10-digit Polish NIP' }],
+      });
+    });
+
+    it('should reject a non-string seller.nip', async () => {
+      await expect(
+        validator.validate({ env: 'test', seller: { nip: 1189981779 } }),
+      ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
+    });
+  });
+
 });

--- a/libs/integrations/ksef/src/infrastructure/adapters/__tests__/nip-checksum.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/__tests__/nip-checksum.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * NIP checksum unit tests (#1595)
+ *
+ * Direct coverage of the mod-11 pure validator: a valid NIP, an invalid-format
+ * NIP, a valid-format-but-invalid-checksum NIP, and the illegal mod-11-remainder
+ * -of-10 case.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/adapters/__tests__
+ */
+import { isValidNipChecksum } from '../nip-checksum';
+
+describe('isValidNipChecksum', () => {
+  it('accepts a checksum-valid 10-digit NIP', () => {
+    // 1189981779 -> check digit 9.
+    expect(isValidNipChecksum('1189981779')).toBe(true);
+  });
+
+  it('rejects a valid-format NIP with a wrong check digit', () => {
+    expect(isValidNipChecksum('1189981770')).toBe(false);
+  });
+
+  it('rejects an invalid-format value (wrong length / non-digits)', () => {
+    expect(isValidNipChecksum('12345')).toBe(false);
+    expect(isValidNipChecksum('12345678a0')).toBe(false);
+    expect(isValidNipChecksum('11899817790')).toBe(false);
+  });
+
+  it('rejects a NIP whose mod-11 remainder is 10', () => {
+    expect(isValidNipChecksum('5272514610')).toBe(false);
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-connection-config-shape-validator.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-connection-config-shape-validator.adapter.ts
@@ -19,9 +19,11 @@
  * `skonto.conditions`/`skonto.amount` must both be non-empty when `skonto` is
  * set (a partial skonto is otherwise silently dropped at issuance by the
  * factory's `resolvePayment`, so rejecting it at save time gives the operator
- * a clear error instead). The seller's tax identifier itself (`nip`/`name`/`address`) is intentionally
- * NOT validated here yet — a future pass tightens KSeF connection-shape
- * validation across all seller fields. Registered against
+ * a clear error instead). The seller's `nip`, when present, is checksum-validated
+ * (mod-11, #1595) so a mistyped-but-well-formed NIP is caught at connection-save
+ * time instead of surfacing as a generic KSeF submission-time rejection; the
+ * remaining seller fields (`name`/`address`) are still not validated here - a
+ * future pass tightens KSeF connection-shape validation across them. Registered against
  * `ConnectionConfigShapeValidatorRegistryService` at `ksef.publicapi.v2`;
  * `ConnectionService` maps the thrown exception to a 400 at the API boundary.
  *
@@ -39,6 +41,7 @@ import {
 } from '@openlinker/core/integrations';
 import { KsefEnvironmentValues, KsefFormaPlatnosciValues } from '../../domain/types/ksef-connection.types';
 import { FA3_TAX_RATE_MAP } from '../fa3/domain/fa3-tax-rate.mapper';
+import { isValidNipChecksum } from './nip-checksum';
 
 export class KsefConnectionConfigShapeValidatorAdapter
   implements ConnectionConfigShapeValidatorPort
@@ -72,6 +75,23 @@ export class KsefConnectionConfigShapeValidatorAdapter
             path: 'seller.defaultTaxRate',
             message: `must be one of: ${Object.keys(FA3_TAX_RATE_MAP).join(', ')}`,
           });
+        }
+      }
+
+      // Seller NIP: 10-digit mod-11-valid Polish NIP when present (#1595). The
+      // FE submits digits-only, but a direct API write may include separators,
+      // so normalise before the length/checksum gate.
+      const nip = (seller as Record<string, unknown>).nip;
+      if (nip !== undefined) {
+        if (typeof nip !== 'string' || nip.trim().length === 0) {
+          issues.push({ path: 'seller.nip', message: 'must be a non-empty string' });
+        } else {
+          const normalized = nip.replace(/[\s-]/g, '');
+          if (!/^\d{10}$/.test(normalized)) {
+            issues.push({ path: 'seller.nip', message: 'must be a 10-digit Polish NIP' });
+          } else if (!isValidNipChecksum(normalized)) {
+            issues.push({ path: 'seller.nip', message: 'has an invalid checksum' });
+          }
         }
       }
     }

--- a/libs/integrations/ksef/src/infrastructure/adapters/nip-checksum.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/nip-checksum.ts
@@ -1,0 +1,28 @@
+/**
+ * Polish NIP checksum (#1595)
+ *
+ * Pure, static mod-11 check-digit validator for a 10-digit Polish NIP: weight
+ * the first 9 digits by `[6,5,7,2,3,4,5,6,7]`, sum the products, take `mod 11`;
+ * the result must equal the 10th (check) digit. A remainder of 10 is not a legal
+ * check digit, so such a NIP is always rejected. The caller normalises
+ * (digits-only) and range-checks the length first; a non-10-digit input returns
+ * `false`.
+ *
+ * Deliberately co-located as a ~10-line local copy rather than shared from
+ * `@openlinker/shared`: the provider-agnostic API DTO (`buyer-tax-id.dto.ts`)
+ * keeps its own copy so the generic invoicing layer never imports from a
+ * concrete provider plugin, and this KSeF-plugin copy keeps the plugin
+ * dependency-light. The algorithm is fixed by Polish law and does not drift.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/adapters
+ */
+const NIP_CHECKSUM_WEIGHTS = [6, 5, 7, 2, 3, 4, 5, 6, 7];
+
+export function isValidNipChecksum(value: string): boolean {
+  if (!/^\d{10}$/.test(value)) return false;
+  const digits = value.split('').map((c) => Number(c));
+  const sum = NIP_CHECKSUM_WEIGHTS.reduce((acc, weight, i) => acc + weight * digits[i], 0);
+  const checkDigit = sum % 11;
+  if (checkDigit === 10) return false;
+  return checkDigit === digits[9];
+}


### PR DESCRIPTION
## Summary

Adds Polish NIP checksum (mod-11) validation so a mistyped-but-well-formed 10-digit NIP is rejected at the OpenLinker boundary (FE + API) before it round-trips to KSeF's own submission-time rejection.

### The mod-11 function
Weights `[6,5,7,2,3,4,5,6,7]` over the first 9 digits, `sum mod 11` must equal the 10th check digit; a remainder of 10 is never a legal check digit (rejected). Deliberately co-located as a ~10-line pure copy in each of the three layers rather than shared:
- the FE bundle does not consume `@openlinker/shared`, and
- the provider-agnostic invoicing API must not depend on the concrete KSeF plugin.

The algorithm is fixed by Polish law and does not drift, so duplication is safe and avoids a cross-boundary coupling.

### Wired at both boundaries
- **FE schema** (`ksef-setup.schema.ts` + edit path `ksef-connection-config.ts`): seller-NIP Zod refine using `isValidNipChecksum`. Empty stays allowed for incremental save.
- **KSeF plugin config-shape validator**: `config.seller.nip` is now length + checksum validated (was intentionally unvalidated), emitting the same `InvalidConnectionConfigException` `{ path, message }` shape. `name`/`address` remain a future pass.
- **API `BuyerTaxIdDto`**: a scheme-scoped class-validator constraint checksum-validates `value` only when `scheme === 'pl-nip'`. Other schemes (e.g. `eu-vat`) pass through unchanged, keeping the invoicing API provider-agnostic.

### VAT whitelist (item 2) - deferred
The "biała lista" / MF whitelist verification half is documented as a deliberate scope decision in the KSeF setup-guide Limitations table: it is a seller due-diligence/AML concern, not a KSeF-issuance blocker, and if pursued belongs as an optional pre-issuance advisory around `wl-api.mf.gov.pl`, not a hard block on the core issuance path.

## Tests
- FE (`ksef-nip.test.ts`): pure function + schema gate - valid NIP, invalid format, valid-format-invalid-checksum, mod-11-remainder-of-10, empty-allowed.
- KSeF plugin (`nip-checksum.spec.ts` + validator spec `seller.nip` cases): same coverage at the config-shape boundary.
- API (`buyer-tax-id.dto.spec.ts`): pl-nip valid/invalid/bad-checksum, separator normalization, eu-vat pass-through.
- Updated pre-existing KSeF fixtures that used the checksum-invalid placeholder `1234567890` to a valid `1189981779`.

## Quality gate (scoped)
- `@openlinker/integrations-ksef` build + jest: 64 passed
- `@openlinker/api` type-check + buyer-tax-id jest: 6 passed
- `@openlinker/web` type-check + KSeF vitest: 135 passed
- eslint on touched files: clean
- `scripts/check-cross-context-imports.mjs`: all conform

Part of #1578, addresses #1595