### PR TITLE
feat(ksef): QR verification code (KOD I) on out-of-KSeF invoices

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "@tanstack/react-virtual": "^3.13.24",
     "cmdk": "^1.1.1",
     "posthog-js": "^1.398.3",
+    "qrcode-generator": "^1.5.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.2",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10949,6 +10949,41 @@ html[data-density='compact'] .status-badge {
   gap: var(--space-1);
 }
 
+/* ── KSeF verification (QR) code (#1579) ─────────────────────────────
+ * KOD I verification-code footer: the QR (dark-on-light, kept theme-fixed
+ * for scannability) plus the KSeF number caption. Sits at the bottom of
+ * the rendered FA(3) document.
+ */
+.ksef-fa3-view__verification {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.ksef-fa3-view__verification-qr {
+  flex: 0 0 auto;
+  /* The QR SVG carries its own white background; frame it so it stays
+     readable on any theme surface. */
+  padding: var(--space-2);
+  background: #ffffff;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.ksef-fa3-view__verification-meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: 0.8125rem;
+}
+
+.ksef-fa3-view__verification-hint {
+  color: var(--text-secondary);
+  max-width: 32ch;
+}
+
 /* ── Inline Disclosure (#1303) ───────────────────────────────────────
  * Native <details>/<summary> "collapsed value + Change affordance"
  * pattern. First use: Infakt's default-payment-method field, which

--- a/apps/web/src/plugins/ksef/components/ksef-fa3-view.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-fa3-view.test.tsx
@@ -197,6 +197,35 @@ describe('KsefFa3View', () => {
       expect(screen.getByText('ul. Kupiecka 7')).toBeInTheDocument();
     });
 
+    it('should render the KOD I verification QR code with the KSeF number caption (#1579)', async () => {
+      renderWithProviders(
+        <KsefFa3View
+          xmlText={buildXml({ issueDate: '2026-07-01' })}
+          ksefNumber="1234567890-20260701-ABCDEF-000001"
+          environment="test"
+        />,
+      );
+
+      // The QR URL is computed via an async Web Crypto SHA-256, so it lands
+      // after an effect tick - query with findBy*.
+      const qr = await screen.findByRole('img', { name: /verification QR code/i });
+      expect(qr).toBeInTheDocument();
+      expect(qr.tagName.toLowerCase()).toBe('svg');
+      // KSeF number is shown as the caption below the QR (and also in the
+      // header), so it appears twice.
+      const captionEl = qr.closest('.ksef-fa3-view__verification');
+      expect(captionEl?.textContent).toContain('1234567890-20260701-ABCDEF-000001');
+    });
+
+    it('should not render a verification QR when the seller NIP is absent (#1579)', () => {
+      // A document with no Podmiot1 NIP cannot form a valid verification URL.
+      const xmlWithoutNip = buildXml()
+        .replace('<NIP>1234567890</NIP>', '')
+        .replace('<NIP>0987654321</NIP>', '');
+      renderWithProviders(<KsefFa3View xmlText={xmlWithoutNip} environment="prod" />);
+      expect(screen.queryByRole('img', { name: /verification QR code/i })).not.toBeInTheDocument();
+    });
+
     it('should render sale date, currency, and the "Standard invoice" subtitle', () => {
       renderWithProviders(<KsefFa3View xmlText={buildXml({ saleDate: '2026-06-28' })} />);
 

--- a/apps/web/src/plugins/ksef/components/ksef-fa3-view.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-fa3-view.tsx
@@ -20,6 +20,11 @@
  *     payment term (date or descriptive TerminOpis), bank account, skonto
  *   - KOR: correction reason + corrected-invoice number; `StanPrzed=1`
  *     "before" rows stay in a separate collapsed section (#1364 follow-up)
+ *   - KOD I verification QR code (#1579): the legally-required verification
+ *     code (kod weryfikacyjny) for invoices handed to buyers outside KSeF,
+ *     with the KSeF number as caption. Computed client-side from the seller
+ *     NIP + issue date + SHA-256 of the exact submitted XML (see
+ *     `../lib/ksef-verification`).
  *
  * Skipped by design: Adnotacje (P_16-P_23), WZ, amount-in-words, footer.
  *
@@ -33,12 +38,14 @@
  *
  * @module plugins/ksef/components
  */
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { ReactElement } from 'react';
 import { useTranslation } from '../../../shared/i18n';
 import { KSEF_FORMA_PLATNOSCI_VALUES } from './ksef-setup.schema';
 import type { KsefFormaPlatnosci } from './ksef-setup.schema';
 import type { FaData, FaLine, FaParty, FaPayment, FaVatBand } from './ksef-fa3-view.types';
+import { buildKsefVerificationUrl } from '../lib/ksef-verification';
+import { QrCode } from '../../../shared/ui/qr-code';
 
 interface KsefFa3ViewProps {
   xmlText: string;
@@ -48,6 +55,13 @@ interface KsefFa3ViewProps {
    * authority AFTER the document is built - so the parent passes it in.
    */
   ksefNumber?: string | null;
+  /**
+   * KSeF target environment of the connection ('test' | 'demo' | 'prod'),
+   * threaded from `connection.config.env` by the parent section. Selects the
+   * verification-code (QR) host: prod -> ksef.mf.gov.pl, otherwise the test
+   * portal. Absent/unknown falls back to the test host (never prod).
+   */
+  environment?: string | null;
   /**
    * Notifies the parent when `xmlText` cannot be parsed (or is missing
    * required fields), so it can fall through to its placeholder/error copy
@@ -391,6 +405,7 @@ function PartyBlock({ label, party }: PartyBlockProps): ReactElement {
 export function KsefFa3View({
   xmlText,
   ksefNumber,
+  environment,
   onParseError,
 }: KsefFa3ViewProps): ReactElement | null {
   const { t } = useTranslation();
@@ -400,6 +415,27 @@ export function KsefFa3View({
   useEffect(() => {
     if (!data) onParseError?.();
   }, [data, onParseError]);
+
+  // KOD I verification code (legally required on invoices handed to buyers
+  // outside KSeF, since 1 Feb 2026). Deterministic from public data - seller
+  // NIP + issue date + SHA-256 of the exact submitted XML - so it is computed
+  // fully client-side; no signing key or server round-trip. SHA-256 is async
+  // (Web Crypto), so it lands via state rather than useMemo. Hooks stay
+  // unconditional (before the early return); the effect no-ops when `data` is
+  // null or a required field is missing.
+  const [verificationUrl, setVerificationUrl] = useState<string | null>(null);
+  const sellerNip = data?.seller.nip ?? null;
+  const issueDateIso = data?.issueDate ?? null;
+  useEffect(() => {
+    let cancelled = false;
+    void buildKsefVerificationUrl({ environment, sellerNip, issueDateIso, xmlText }).then((url) => {
+      if (!cancelled) setVerificationUrl(url);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [environment, sellerNip, issueDateIso, xmlText]);
+
   if (!data) return null;
 
   const isCorrection = data.invoiceType === 'KOR';
@@ -624,6 +660,34 @@ export function KsefFa3View({
                 .join(' - ')}
             </div>
           ) : null}
+        </section>
+      ) : null}
+
+      {/* KOD I verification code (kod weryfikacyjny) - legally required on any
+          copy of a KSeF-cleared invoice handed to the buyer outside KSeF. The
+          KSeF number is shown as the caption below the QR. */}
+      {verificationUrl !== null ? (
+        <section className="ksef-fa3-view__verification">
+          <QrCode
+            value={verificationUrl}
+            size={148}
+            ariaLabel={t('invoice.ksef.fa3VerificationQrAlt', 'KSeF invoice verification QR code')}
+            className="ksef-fa3-view__verification-qr"
+          />
+          <div className="ksef-fa3-view__verification-meta">
+            <div className="ksef-fa3-view__field-label">
+              {t('invoice.ksef.fa3VerificationLabel', 'Verification code')}
+            </div>
+            {displayKsefNumber !== null && displayKsefNumber !== undefined ? (
+              <div className="mono-text text-sm">{displayKsefNumber}</div>
+            ) : null}
+            <div className="ksef-fa3-view__verification-hint">
+              {t(
+                'invoice.ksef.fa3VerificationHint',
+                'Scan to verify this invoice against the KSeF system.',
+              )}
+            </div>
+          </div>
         </section>
       ) : null}
     </div>

--- a/apps/web/src/plugins/ksef/components/ksef-fa3-view.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-fa3-view.tsx
@@ -45,7 +45,7 @@ import { KSEF_FORMA_PLATNOSCI_VALUES } from './ksef-setup.schema';
 import type { KsefFormaPlatnosci } from './ksef-setup.schema';
 import type { FaData, FaLine, FaParty, FaPayment, FaVatBand } from './ksef-fa3-view.types';
 import { buildKsefVerificationUrl } from '../lib/ksef-verification';
-import { QrCode } from '../../../shared/ui/qr-code';
+import { QrCode } from '../../../shared/ui';
 
 interface KsefFa3ViewProps {
   xmlText: string;

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
@@ -54,6 +54,7 @@ function resolveKsefNumber(
 
 export function KsefInvoiceDetailSection({
   invoice,
+  connection,
 }: InvoiceDetailSectionProps): ReactElement | null {
   const { t } = useTranslation();
   const upoDownload = useKsefUpoDownload();
@@ -67,6 +68,12 @@ export function KsefInvoiceDetailSection({
   const handleFa3ParseError = useCallback(() => setViewParseFailed(true), []);
 
   const ksefNumber = resolveKsefNumber(invoice.clearanceReference, invoice.providerInvoiceNumber);
+  // KSeF target environment for this connection ('test' | 'demo' | 'prod'),
+  // used to pick the verification-code (QR) host (prod vs test portal). The FE
+  // Connection config is untyped, so narrow defensively; absence falls back to
+  // the test verification host in the lib, never prod.
+  const ksefEnvironment =
+    typeof connection.config.env === 'string' ? connection.config.env : undefined;
   const hasRegulatoryData = invoice.regulatoryStatus !== 'not-applicable';
 
   if (!hasRegulatoryData && !ksefNumber) {
@@ -255,6 +262,7 @@ export function KsefInvoiceDetailSection({
                 <KsefFa3View
                   xmlText={fa3.viewText}
                   ksefNumber={ksefNumber}
+                  environment={ksefEnvironment}
                   onParseError={handleFa3ParseError}
                 />
               ) : (

--- a/apps/web/src/plugins/ksef/lib/ksef-verification.test.ts
+++ b/apps/web/src/plugins/ksef/lib/ksef-verification.test.ts
@@ -1,0 +1,119 @@
+/**
+ * KSeF verification-code URL assembly tests (#1579)
+ *
+ * Locks the KOD I construction: host selection (prod vs test), the ISO ->
+ * DD-MM-RRRR date reformat, Base64URL SHA-256 hashing of the exact XML bytes,
+ * and the full URL shape. The hash fixture uses a fixed XML byte string with a
+ * pre-computed expected digest so any change to the hashing/encoding is caught.
+ *
+ * @module plugins/ksef/lib
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  bytesToBase64Url,
+  buildKsefVerificationUrl,
+  formatIssueDateForVerification,
+  resolveKsefVerificationHost,
+  sha256Base64Url,
+} from './ksef-verification';
+
+// SHA-256 of the UTF-8 bytes of this exact string, Base64URL-encoded (padding
+// stripped). Pre-computed with Node's crypto so the test is self-contained.
+const FIXTURE_XML = '<Faktura>test-fixture</Faktura>';
+const FIXTURE_XML_HASH = 'NcIQCHZs-My4vFFE_t-x3y2M2XcBkkftWgYEEJA-Ts0';
+
+describe('resolveKsefVerificationHost', () => {
+  it('should resolve prod to the production verification host', () => {
+    expect(resolveKsefVerificationHost('prod')).toBe('ksef.mf.gov.pl');
+  });
+
+  it('should resolve test and demo to the test verification host', () => {
+    expect(resolveKsefVerificationHost('test')).toBe('qr-test.ksef.mf.gov.pl');
+    expect(resolveKsefVerificationHost('demo')).toBe('qr-test.ksef.mf.gov.pl');
+  });
+
+  it('should fall back to the test host for unknown/missing environments (never prod)', () => {
+    expect(resolveKsefVerificationHost(undefined)).toBe('qr-test.ksef.mf.gov.pl');
+    expect(resolveKsefVerificationHost(null)).toBe('qr-test.ksef.mf.gov.pl');
+    expect(resolveKsefVerificationHost('production')).toBe('qr-test.ksef.mf.gov.pl');
+    expect(resolveKsefVerificationHost('')).toBe('qr-test.ksef.mf.gov.pl');
+  });
+});
+
+describe('formatIssueDateForVerification', () => {
+  it('should reformat ISO YYYY-MM-DD to DD-MM-RRRR', () => {
+    expect(formatIssueDateForVerification('2026-07-01')).toBe('01-07-2026');
+    expect(formatIssueDateForVerification('2026-12-31')).toBe('31-12-2026');
+  });
+
+  it('should return null for non-ISO or missing dates', () => {
+    expect(formatIssueDateForVerification(null)).toBeNull();
+    expect(formatIssueDateForVerification(undefined)).toBeNull();
+    expect(formatIssueDateForVerification('')).toBeNull();
+    expect(formatIssueDateForVerification('01-07-2026')).toBeNull();
+    expect(formatIssueDateForVerification('2026/07/01')).toBeNull();
+    expect(formatIssueDateForVerification('2026-07-01T00:00:00Z')).toBeNull();
+  });
+});
+
+describe('bytesToBase64Url', () => {
+  it('should use the URL-safe alphabet and strip padding', () => {
+    // 0xFF 0xFF 0xFE -> std base64 "///+" -> URL-safe "___-" ('/'->'_', '+'->'-').
+    expect(bytesToBase64Url(new Uint8Array([0xff, 0xff, 0xfe]))).toBe('___-');
+    // Single byte 0x00 -> std "AA==" -> padding stripped.
+    expect(bytesToBase64Url(new Uint8Array([0x00]))).toBe('AA');
+  });
+});
+
+describe('sha256Base64Url', () => {
+  it('should hash exact UTF-8 bytes and Base64URL-encode the digest', async () => {
+    await expect(sha256Base64Url(FIXTURE_XML)).resolves.toBe(FIXTURE_XML_HASH);
+  });
+});
+
+describe('buildKsefVerificationUrl', () => {
+  it('should assemble the full verification URL for a prod connection', async () => {
+    const url = await buildKsefVerificationUrl({
+      environment: 'prod',
+      sellerNip: '1234567890',
+      issueDateIso: '2026-07-01',
+      xmlText: FIXTURE_XML,
+    });
+    expect(url).toBe(`https://ksef.mf.gov.pl/invoice/1234567890/01-07-2026/${FIXTURE_XML_HASH}`);
+  });
+
+  it('should use the test host for a test connection', async () => {
+    const url = await buildKsefVerificationUrl({
+      environment: 'test',
+      sellerNip: '1234567890',
+      issueDateIso: '2026-07-01',
+      xmlText: FIXTURE_XML,
+    });
+    expect(url).toBe(
+      `https://qr-test.ksef.mf.gov.pl/invoice/1234567890/01-07-2026/${FIXTURE_XML_HASH}`,
+    );
+  });
+
+  it('should normalize a NIP that carries dashes/spaces', async () => {
+    const url = await buildKsefVerificationUrl({
+      environment: 'prod',
+      sellerNip: '123-456-78-90',
+      issueDateIso: '2026-07-01',
+      xmlText: FIXTURE_XML,
+    });
+    expect(url).toContain('/invoice/1234567890/');
+  });
+
+  it('should return null when a required input is missing/malformed', async () => {
+    const base = {
+      environment: 'prod',
+      sellerNip: '1234567890',
+      issueDateIso: '2026-07-01',
+      xmlText: FIXTURE_XML,
+    };
+    await expect(buildKsefVerificationUrl({ ...base, sellerNip: null })).resolves.toBeNull();
+    await expect(buildKsefVerificationUrl({ ...base, sellerNip: '' })).resolves.toBeNull();
+    await expect(buildKsefVerificationUrl({ ...base, issueDateIso: 'nope' })).resolves.toBeNull();
+    await expect(buildKsefVerificationUrl({ ...base, xmlText: '' })).resolves.toBeNull();
+  });
+});

--- a/apps/web/src/plugins/ksef/lib/ksef-verification.ts
+++ b/apps/web/src/plugins/ksef/lib/ksef-verification.ts
@@ -1,0 +1,115 @@
+/**
+ * KSeF verification-code (kod weryfikacyjny) URL assembly
+ *
+ * Since 1 Feb 2026 any structured invoice handed to a buyer OUTSIDE the KSeF
+ * system (PDF / email / on-screen preview) must carry a QR verification code so
+ * the recipient can confirm the document against the authority. OpenLinker is
+ * always online, so it only ever needs KOD I - the online-cleared verification
+ * code, which is purely deterministic from PUBLIC data and needs NO signing key
+ * or certificate (that is KOD II, the offline certificate-signed code, which is
+ * explicitly out of scope - OL never issues offline).
+ *
+ * KOD I encodes this verification URL:
+ *
+ *   https://{host}/invoice/{NIP}/{DD-MM-RRRR}/{Base64URL(SHA256(rawXmlBytes))}
+ *
+ *   - `host`       : the environment's KSeF verification host (prod vs test).
+ *   - `NIP`        : seller NIP (digits only).
+ *   - `DD-MM-RRRR` : the invoice issue date, day-month-year hyphen-separated
+ *                    (OL stores it ISO `YYYY-MM-DD`, so it is reformatted here).
+ *   - hash         : SHA-256 over the EXACT raw, unencrypted FA(3) XML bytes as
+ *                    submitted to KSeF, Base64URL-encoded (URL-safe alphabet,
+ *                    padding stripped) - NOT standard Base64, NOT re-serialized.
+ *
+ * The hash input MUST be the byte-exact submitted document. In OpenLinker that
+ * is the persisted `sourceDocument` snapshot (the FA(3) `xml` string the adapter
+ * submitted verbatim; see `KsefInvoicingAdapter.toSourceDocument`), which the FE
+ * loads via `?kind=source` and passes as `xmlText`. Encoding that string back to
+ * UTF-8 bytes round-trips the original bytes exactly.
+ *
+ * @module plugins/ksef/lib
+ */
+import type { KsefEnvironment } from '../components/ksef-setup.schema';
+
+/**
+ * KSeF verification (QR) hosts per environment. Production resolves to the live
+ * verification portal; every non-prod tier (test / demo) resolves to the test
+ * verification host. Never defaults to prod for an unknown environment.
+ */
+const KSEF_VERIFICATION_HOSTS: Readonly<Record<KsefEnvironment, string>> = {
+  prod: 'ksef.mf.gov.pl',
+  test: 'qr-test.ksef.mf.gov.pl',
+  demo: 'qr-test.ksef.mf.gov.pl',
+};
+
+const TEST_VERIFICATION_HOST = KSEF_VERIFICATION_HOSTS.test;
+
+/**
+ * Resolve the KSeF verification host for a connection environment. Only the
+ * explicit `prod` value maps to the production host; any other (or unknown)
+ * value falls back to the test host so a mis-set environment can never leak a
+ * production verification URL onto a sandbox document.
+ */
+export function resolveKsefVerificationHost(environment: string | null | undefined): string {
+  return environment === 'prod' ? KSEF_VERIFICATION_HOSTS.prod : TEST_VERIFICATION_HOST;
+}
+
+/**
+ * Reformat an ISO `YYYY-MM-DD` issue date to the `DD-MM-RRRR` form the KSeF
+ * verification URL requires. Returns null for anything that is not a plain
+ * ISO date (the caller then omits the QR rather than emit a malformed URL).
+ */
+export function formatIssueDateForVerification(isoDate: string | null | undefined): string | null {
+  if (!isoDate) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate.trim());
+  if (!match) return null;
+  const [, year, month, day] = match;
+  return `${day}-${month}-${year}`;
+}
+
+/** Base64URL-encode raw bytes: standard Base64 with `+`->`-`, `/`->`_`, padding stripped. */
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * SHA-256 over UTF-8 bytes of `xmlText`, Base64URL-encoded. Uses Web Crypto
+ * (`crypto.subtle`) - available in every supported browser and in the test
+ * runtime - so no hashing dependency is pulled in.
+ */
+export async function sha256Base64Url(xmlText: string): Promise<string> {
+  const bytes = new TextEncoder().encode(xmlText);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return bytesToBase64Url(new Uint8Array(digest));
+}
+
+export interface KsefVerificationUrlInput {
+  environment: string | null | undefined;
+  sellerNip: string | null | undefined;
+  /** Issue date in ISO `YYYY-MM-DD` (FA(3) `P_1`). */
+  issueDateIso: string | null | undefined;
+  /** The exact raw FA(3) XML submitted to KSeF (the persisted source document). */
+  xmlText: string;
+}
+
+/**
+ * Assemble the full KSeF KOD I verification URL. Returns null when any required
+ * input is missing/malformed (no NIP, unparseable issue date, empty XML) so the
+ * caller can skip the QR rather than render a broken code.
+ */
+export async function buildKsefVerificationUrl(
+  input: KsefVerificationUrlInput,
+): Promise<string | null> {
+  const nip = input.sellerNip?.replace(/[\s-]/g, '') ?? '';
+  const issueDate = formatIssueDateForVerification(input.issueDateIso);
+  if (nip.length === 0 || issueDate === null || input.xmlText.length === 0) {
+    return null;
+  }
+  const host = resolveKsefVerificationHost(input.environment);
+  const hash = await sha256Base64Url(input.xmlText);
+  return `https://${host}/invoice/${nip}/${issueDate}/${hash}`;
+}

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -82,3 +82,7 @@ export type { CheckboxCellProps } from './checkbox-cell';
 // ── Disclosure (#1303) ───────────────────────────────────────────────
 export { InlineDisclosure } from './inline-disclosure';
 export type { InlineDisclosureProps } from './inline-disclosure';
+
+// ── QR verification code (#1579) ────────────────────────────
+export { QrCode } from './qr-code';
+export type { QrCodeErrorCorrectionLevel } from './qr-code';

--- a/apps/web/src/shared/ui/qr-code.test.tsx
+++ b/apps/web/src/shared/ui/qr-code.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * QrCode tests
+ *
+ * Verifies the headless QR-logic library produces a real, non-empty module
+ * matrix rendered as inline SVG, that colours stay theme-fixed (dark-on-light
+ * for scannability), and that an empty value renders nothing.
+ *
+ * @module shared/ui
+ */
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { QrCode } from './qr-code';
+
+describe('QrCode', () => {
+  it('should render an inline SVG with dark modules on a white background', () => {
+    const { container } = render(
+      <QrCode value="https://ksef.mf.gov.pl/invoice/1234567890/01-07-2026/abc" ariaLabel="QR" />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute('role')).toBe('img');
+    expect(svg?.getAttribute('aria-label')).toBe('QR');
+    // White background rect + a non-empty dark module path.
+    expect(container.querySelector('rect')?.getAttribute('fill')).toBe('#ffffff');
+    const path = container.querySelector('path');
+    expect(path?.getAttribute('fill')).toBe('#000000');
+    expect((path?.getAttribute('d') ?? '').length).toBeGreaterThan(0);
+  });
+
+  it('should render nothing for an empty value', () => {
+    const { container } = render(<QrCode value="" />);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+});

--- a/apps/web/src/shared/ui/qr-code.tsx
+++ b/apps/web/src/shared/ui/qr-code.tsx
@@ -1,0 +1,88 @@
+/**
+ * QrCode
+ *
+ * Renders a QR code as inline, self-contained SVG - no <img>, no network, no
+ * canvas. Uses `qrcode-generator` (a mature, zero-runtime-dependency, MIT
+ * headless QR-*logic* library) purely to compute the module matrix; the SVG
+ * markup (a single `<path>` of the dark modules over a light background) is
+ * built here so the visual stays under our control and design system.
+ *
+ * QR codes must stay dark-on-light to remain scannable, so the colours are
+ * FIXED (dark modules on a white background) and intentionally do NOT follow
+ * the light/dark theme - a phone camera has to read this off a screen or a
+ * printed page. A quiet zone (margin) of 4 modules is included per the QR spec.
+ *
+ * @module shared/ui
+ */
+import { useMemo } from 'react';
+import type { ReactElement } from 'react';
+import qrcode from 'qrcode-generator';
+
+export type QrCodeErrorCorrectionLevel = 'L' | 'M' | 'Q' | 'H';
+
+interface QrCodeProps {
+  /** The string to encode (for KSeF: the verification URL). */
+  value: string;
+  /** Rendered size in px (width = height). Defaults to 160. */
+  size?: number;
+  /**
+   * Error-correction level. `M` (~15% recovery) is the sensible default for a
+   * clean on-screen / PDF verification code.
+   */
+  errorCorrectionLevel?: QrCodeErrorCorrectionLevel;
+  /** Accessible label; when absent the SVG is treated as decorative. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+/** Quiet-zone width in modules, per the QR Code specification. */
+const QUIET_ZONE_MODULES = 4;
+
+export function QrCode({
+  value,
+  size = 160,
+  errorCorrectionLevel = 'M',
+  ariaLabel,
+  className = '',
+}: QrCodeProps): ReactElement | null {
+  const model = useMemo(() => {
+    if (value.length === 0) return null;
+    // typeNumber 0 = auto-select the smallest version that fits `value`.
+    const qr = qrcode(0, errorCorrectionLevel);
+    qr.addData(value);
+    qr.make();
+    const count = qr.getModuleCount();
+    const total = count + QUIET_ZONE_MODULES * 2;
+    // One path command per dark module, offset by the quiet zone.
+    const segments: string[] = [];
+    for (let row = 0; row < count; row += 1) {
+      for (let col = 0; col < count; col += 1) {
+        if (qr.isDark(row, col)) {
+          segments.push(`M${col + QUIET_ZONE_MODULES} ${row + QUIET_ZONE_MODULES}h1v1h-1z`);
+        }
+      }
+    }
+    return { total, path: segments.join('') };
+  }, [value, errorCorrectionLevel]);
+
+  if (!model) return null;
+
+  const classes = ['qr-code', className].filter(Boolean).join(' ');
+
+  return (
+    <svg
+      className={classes}
+      width={size}
+      height={size}
+      viewBox={`0 0 ${model.total} ${model.total}`}
+      shapeRendering="crispEdges"
+      role={ariaLabel ? 'img' : 'presentation'}
+      aria-label={ariaLabel}
+      aria-hidden={ariaLabel ? undefined : true}
+      focusable="false"
+    >
+      <rect width={model.total} height={model.total} fill="#ffffff" />
+      <path d={model.path} fill="#000000" />
+    </svg>
+  );
+}

--- a/docs/frontend-ui-style-guide.md
+++ b/docs/frontend-ui-style-guide.md
@@ -597,6 +597,7 @@ Adopted (FE-002):
 | `@radix-ui/react-popover` | portal + positioning | `Popover` |
 | `@radix-ui/react-toast` | queue + focus management | `Toast` |
 | `@radix-ui/react-tabs` | roving tabindex | `Tabs` |
+| `qrcode-generator` | QR module-matrix computation (KOD I invoice verification, #1579) | `QrCode` |
 
 **Adding a library requires:** (1) a written rationale in the PR description explaining why the behavior can't be built from native HTML, (2) a wrapping primitive under `shared/ui/` with its own CSS, (3) an update to this section.
 

--- a/libs/integrations/ksef/docs/setup-guide.md
+++ b/libs/integrations/ksef/docs/setup-guide.md
@@ -212,6 +212,39 @@ path, with its `buyerTaxId: null` and line-fidelity caveats).
 
 ---
 
+## Verification code (QR / kod weryfikacyjny)
+
+Since **1 Feb 2026**, any structured invoice handed to a buyer **outside** the
+KSeF system - a PDF, an email attachment, or an on-screen copy - must carry a QR
+**verification code** (*kod weryfikacyjny*) when the buyer has no KSeF access.
+This explicitly includes B2C consumers, buyers with no NIP, VAT-exempt buyers,
+and foreign buyers - i.e. OpenLinker's dominant e-commerce scenario.
+
+**OpenLinker emits KOD I (the online verification code).** Because OL always
+issues invoices online (submit -> clear -> UPO), KOD I is all that is required.
+KOD I is purely deterministic from **public** data and needs **no signing key or
+certificate**. The FA(3) invoice preview renders it as a QR encoding:
+
+```
+https://{host}/invoice/{sellerNIP}/{DD-MM-RRRR}/{Base64URL(SHA256(rawInvoiceXml))}
+```
+
+- `host` - `ksef.mf.gov.pl` for `prod` connections, `qr-test.ksef.mf.gov.pl`
+  for `test` / `demo` connections (taken from the connection's environment).
+- `DD-MM-RRRR` - the invoice issue date.
+- the hash - SHA-256 of the **exact submitted FA(3) XML bytes** (the persisted
+  source document), Base64URL-encoded.
+
+The KSeF number is shown as a caption beneath the QR. The code is generated
+client-side in the invoice preview (`ksef-fa3-view`), so no additional
+configuration is needed - it appears automatically once an invoice is cleared.
+
+> **KOD II (the offline, certificate-signed verification code) is out of scope.**
+> KOD II is only required for invoices issued in KSeF *offline* mode, which
+> OpenLinker never uses. It is deliberately not implemented.
+
+---
+
 ## Limitations
 
 OpenLinker's KSeF support targets outbound issuance + clearance of FA(3)

--- a/libs/integrations/ksef/src/infrastructure/fa3/FA3_IMPLEMENTATION_NOTES.md
+++ b/libs/integrations/ksef/src/infrastructure/fa3/FA3_IMPLEMENTATION_NOTES.md
@@ -175,6 +175,46 @@ blank for a new invoice — not a connection default). See
 [#1311](https://github.com/openlinker-project/openlinker/issues/1311) for the
 full field-scope audit and design mockup.
 
+## Verification code (QR / kod weryfikacyjny - #1579)
+
+Since 1 Feb 2026 any structured invoice handed to a buyer **outside** KSeF
+(PDF / email / on-screen copy) must carry a QR verification code so the
+recipient can confirm the document against the authority. This is OpenLinker's
+dominant scenario - e-commerce orders issued to consumers, no-NIP buyers,
+VAT-exempt or foreign buyers - so it is not optional.
+
+**What OL emits: KOD I (online verification code).** KOD I is purely
+deterministic from **public** data and needs no signing key or certificate. It
+encodes the URL:
+
+```
+https://{host}/invoice/{NIP}/{DD-MM-RRRR}/{Base64URL(SHA256(rawXmlBytes))}
+```
+
+- `host` - `ksef.mf.gov.pl` on `prod`; `qr-test.ksef.mf.gov.pl` on every
+  non-prod tier (`test` / `demo`). Threaded from the connection's `config.env`.
+- `NIP` - seller NIP (digits only).
+- `DD-MM-RRRR` - the invoice issue date (FA(3) `P_1`, stored ISO `YYYY-MM-DD`,
+  reformatted day-month-year).
+- hash - SHA-256 over the **exact raw, unencrypted FA(3) XML bytes as
+  submitted** (the persisted `sourceDocument` snapshot - NOT re-serialized /
+  pretty-printed), **Base64URL**-encoded (URL-safe alphabet, padding stripped -
+  not standard Base64).
+
+**Where:** generated entirely in the frontend from the already-loaded source XML
+(`apps/web/src/plugins/ksef/lib/ksef-verification.ts` + `shared/ui/qr-code.tsx`,
+rendered by `ksef-fa3-view.tsx`). No backend/adapter change is required because
+the byte-exact submitted document is the persisted `sourceDocument`
+(`KsefInvoicingAdapter.toSourceDocument` base64-encodes the same `xml` string it
+submits), served verbatim via `GET /invoices/:id/document?kind=source`. Encoding
+that text back to UTF-8 bytes round-trips the submitted bytes exactly, so the
+hash matches what KSeF computed. The KSeF number is shown as the QR caption.
+
+**KOD II (offline certificate-signed code) is explicitly OUT OF SCOPE.** KOD II
+is only required for documents issued in KSeF *offline* mode and is signed with
+the seller's KSeF certificate private key. OpenLinker always issues online
+(submit -> clear -> UPO), so KOD II never applies.
+
 ## Known limitations / deferred work
 
 - ⏸ Reconcile the neutral tax-rate code set (UNCL 5305 vs OpenLinker-custom) —

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,9 @@ importers:
       posthog-js:
         specifier: ^1.398.3
         version: 1.398.3
+      qrcode-generator:
+        specifier: ^1.5.2
+        version: 1.5.2
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -5159,6 +5162,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qrcode-generator@1.5.2:
+    resolution: {integrity: sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw==}
 
   qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
@@ -10888,6 +10894,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  qrcode-generator@1.5.2: {}
 
   qs@6.11.0:
     dependencies:


### PR DESCRIPTION
Part of #1578, addresses #1579

## What & why

Since 1 Feb 2026 any KSeF-cleared structured invoice handed to a buyer **outside** KSeF (PDF / email / on-screen copy) must carry a QR **verification code** (*kod weryfikacyjny*) when the buyer has no KSeF access - B2C consumers, no-NIP buyers, VAT-exempt and foreign buyers. That is OpenLinker's dominant scenario, and the invoice preview previously rendered no QR at all.

This renders **KOD I** (the online verification code) on the FA(3) invoice preview. KOD I is purely deterministic from **public** data and needs **no signing key or certificate**:

```
https://{host}/invoice/{sellerNIP}/{DD-MM-RRRR}/{Base64URL(SHA256(rawInvoiceXml))}
```

- `host` - `ksef.mf.gov.pl` (prod) vs `qr-test.ksef.mf.gov.pl` (test/demo), threaded from the connection's `config.env` (never hardcoded prod).
- issue date reformatted from ISO `YYYY-MM-DD` to `DD-MM-RRRR`.
- hash = SHA-256 over the exact submitted XML bytes, **Base64URL** (URL-safe alphabet, padding stripped) - not standard Base64.
- The KSeF number is shown as the caption below the QR.

**KOD II** (the offline, certificate-signed code) is explicitly **out of scope** - OL always issues online, so it never applies.

## Implementation shape: FE-only (no backend/port change)

The hash must cover the byte-exact submitted document. In OL that is the persisted `sourceDocument` snapshot: `KsefInvoicingAdapter.toSourceDocument` base64-encodes the same `xml` string it submits to KSeF, and the controller serves it verbatim via `GET /invoices/:id/document?kind=source`. The preview already loads that text (`useKsefFa3` -> `blob.text()`), so encoding it back to UTF-8 bytes round-trips the submitted bytes exactly and the hash matches what KSeF computed. No adapter/`RegulatoryDocumentReader` change was needed.

- `apps/web/src/plugins/ksef/lib/ksef-verification.ts` - host selection, ISO->DD-MM-RRRR, SHA-256 -> Base64URL, URL assembly (pure + async, fully unit-tested).
- `apps/web/src/shared/ui/qr-code.tsx` - shared inline-SVG QR primitive.
- `ksef-fa3-view.tsx` - computes the URL client-side (Web Crypto) and renders the QR + caption; `ksef-invoice-detail-section.tsx` threads `connection.config.env`.

## Dependency rationale (per FE UI style guide)

Added **`qrcode-generator@^1.5.2`** (MIT, zero runtime dependencies, ships its own types) as a **headless QR-*logic* library** - it computes the module matrix only; the SVG markup (dark-on-light for scannability, theme-fixed) is built by our own `QrCode` component, so no styled UI library is introduced. Correct QR encoding (Reed-Solomon EC across versions, masking) is non-trivial and error-prone to hand-roll for a legally-required feature, so a small vetted library is the safer choice.

## Tests

- `ksef-verification.test.ts` - host prod/test/demo/unknown, date reformat, Base64URL alphabet + padding, SHA-256 against a fixed XML-bytes fixture with a pre-computed digest, full URL shape (prod + test), NIP normalization, null-on-missing-input.
- `qr-code.test.tsx` - renders non-empty dark-on-light SVG; nothing for empty value.
- `ksef-fa3-view.test.tsx` - QR + KSeF-number caption render for a cleared invoice; no QR when seller NIP is absent.

## Docs

Updated `libs/integrations/ksef/docs/setup-guide.md` and `FA3_IMPLEMENTATION_NOTES.md` documenting the requirement, KOD I construction, and KOD II being out of scope.

## Quality gate (scoped)

- `pnpm --filter @openlinker/web type-check` - pass
- `pnpm --filter @openlinker/web test <touched files>` - 56 passed
- `eslint` on touched files - clean