### PR TITLE
feat(ksef): bulk-issue rate-limit pacing + shared-NIP bucket warning (#1594)

### DIFF
--- a/apps/api/src/integrations/application/interfaces/connection.service.interface.ts
+++ b/apps/api/src/integrations/application/interfaces/connection.service.interface.ts
@@ -51,6 +51,16 @@ export interface IConnectionService {
   update(connectionId: string, patch: ConnectionUpdate): Promise<Connection>;
 
   /**
+   * Advisory (#1594): return non-blocking warnings about a connection sharing a
+   * provider-side rate-limit bucket with another active connection (same adapter
+   * + same seller tax id). Empty when there is no collision. Never throws.
+   *
+   * @param connection - The just-created/updated connection to check
+   * @returns Zero or more operator-facing warning strings
+   */
+  findSharedRateLimitBucketWarnings(connection: Connection): Promise<string[]>;
+
+  /**
    * Rotate the credentials stored for a connection. Writes to the credential
    * row referenced by `credentialsRef`; the connection row is not modified.
    *

--- a/apps/api/src/integrations/application/services/connection.service.spec.ts
+++ b/apps/api/src/integrations/application/services/connection.service.spec.ts
@@ -1237,4 +1237,67 @@ describe('ConnectionService', () => {
       await expect(service.disable('connection-123')).rejects.toThrow(NotFoundException);
     });
   });
+  describe('findSharedRateLimitBucketWarnings (#1594)', () => {
+    function ksefConnection(
+      id: string,
+      name: string,
+      nip: string | undefined,
+      adapterKey = 'ksef.publicapi.v2',
+      status: 'active' | 'disabled' = 'active'
+    ): Connection {
+      return new Connection(
+        id,
+        'ksef',
+        name,
+        status,
+        nip ? { env: 'test', seller: { nip } } : { env: 'test' },
+        'cred_x',
+        new Date(),
+        new Date(),
+        adapterKey,
+        ['Invoicing']
+      );
+    }
+
+    it('returns no warning when the connection carries no seller tax id', async () => {
+      const conn = ksefConnection('c1', 'A', undefined);
+      const warnings = await service.findSharedRateLimitBucketWarnings(conn);
+      expect(warnings).toEqual([]);
+      expect(connectionPort.list).not.toHaveBeenCalled();
+    });
+
+    it('warns when another active connection shares adapter + seller tax id', async () => {
+      const subject = ksefConnection('c1', 'Channel A', '1234567890');
+      const sibling = ksefConnection('c2', 'Channel B', '1234567890');
+      connectionPort.list.mockResolvedValue([subject, sibling]);
+
+      const warnings = await service.findSharedRateLimitBucketWarnings(subject);
+
+      expect(connectionPort.list).toHaveBeenCalledWith({ status: 'active' });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('Channel B');
+      expect(warnings[0]).toContain('1234567890');
+    });
+
+    it('does not warn about itself', async () => {
+      const subject = ksefConnection('c1', 'Channel A', '1234567890');
+      connectionPort.list.mockResolvedValue([subject]);
+      const warnings = await service.findSharedRateLimitBucketWarnings(subject);
+      expect(warnings).toEqual([]);
+    });
+
+    it('does not warn when the shared NIP is on a different adapter', async () => {
+      const subject = ksefConnection('c1', 'Channel A', '1234567890', 'ksef.publicapi.v2');
+      const other = ksefConnection('c2', 'Infakt B', '1234567890', 'infakt.accounting.v1');
+      connectionPort.list.mockResolvedValue([subject, other]);
+      const warnings = await service.findSharedRateLimitBucketWarnings(subject);
+      expect(warnings).toEqual([]);
+    });
+
+    it('is advisory: a list failure yields no warning rather than throwing', async () => {
+      const subject = ksefConnection('c1', 'Channel A', '1234567890');
+      connectionPort.list.mockRejectedValue(new Error('db down'));
+      await expect(service.findSharedRateLimitBucketWarnings(subject)).resolves.toEqual([]);
+    });
+  });
 });

--- a/apps/api/src/integrations/application/services/connection.service.ts
+++ b/apps/api/src/integrations/application/services/connection.service.ts
@@ -107,6 +107,75 @@ export class ConnectionService implements IConnectionService {
   }
 
   /**
+   * Advisory shared-rate-limit-bucket detection (#1594). Some invoicing
+   * providers (e.g. KSeF) bucket their per-hour request ceilings by the seller's
+   * tax id: two OL connections configured against the SAME seller tax id on the
+   * same adapter, egressing from the same deployment IP, therefore share ONE
+   * provider-side rate-limit budget. A bulk run on one can then throttle the
+   * other in ways that look like an unrelated flake.
+   *
+   * This surfaces a NON-BLOCKING warning at connection create/edit time when a
+   * new/updated connection's `config.seller.nip` matches another ACTIVE
+   * connection on the same adapter. Platform-neutral: it reads the generic
+   * `config.seller.nip` shape (no KSeF vocabulary) and only fires for adapters
+   * that carry a seller tax id. Never throws — advisory only; a lookup failure
+   * yields no warning rather than failing the operation.
+   */
+  async findSharedRateLimitBucketWarnings(connection: Connection): Promise<string[]> {
+    const nip = this.extractSellerTaxId(connection.config);
+    if (!nip || !connection.adapterKey) {
+      return [];
+    }
+    let candidates: Connection[];
+    try {
+      candidates = await this.connectionPort.list({ status: 'active' });
+    } catch (error) {
+      this.logger.warn(
+        `Shared-rate-limit-bucket check skipped for connection ${connection.id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return [];
+    }
+    const colliding = candidates.filter(
+      (c) =>
+        c.id !== connection.id &&
+        c.adapterKey === connection.adapterKey &&
+        this.extractSellerTaxId(c.config) === nip
+    );
+    if (colliding.length === 0) {
+      return [];
+    }
+    const names = colliding.map((c) => c.name).join(', ');
+    this.logger.warn(
+      `Connection ${connection.id} shares seller tax id ${nip} on adapter ` +
+        `${connection.adapterKey} with active connection(s): ${names} — shared provider rate-limit bucket.`
+    );
+    return [
+      `Another active connection (${names}) uses the same adapter and seller tax id (${nip}). ` +
+        `They share the provider's per-seller rate-limit bucket, so heavy activity on one ` +
+        `(e.g. a bulk invoice run) can throttle the other. This is a warning, not a block.`,
+    ];
+  }
+
+  /**
+   * Extract a normalized seller tax id from a connection config, or `null` when
+   * the config carries none. Reads only the generic `seller.nip` shape so no
+   * provider vocabulary leaks into this platform-agnostic service.
+   */
+  private extractSellerTaxId(config: unknown): string | null {
+    if (!config || typeof config !== 'object') {
+      return null;
+    }
+    const seller = (config as Record<string, unknown>).seller;
+    if (!seller || typeof seller !== 'object') {
+      return null;
+    }
+    const nip = (seller as Record<string, unknown>).nip;
+    return typeof nip === 'string' && nip.trim().length > 0 ? nip.trim() : null;
+  }
+
+  /**
    * Run the plugin's config / credentials shape validators if registered.
    * The registries are keyed by adapterKey; the domain exception payload
    * is re-thrown as `BadRequestException` so the HTTP layer surfaces a

--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -65,6 +65,7 @@ describe('ConnectionController', () => {
   beforeEach(async () => {
     const mockService = {
       create: jest.fn(),
+      findSharedRateLimitBucketWarnings: jest.fn().mockResolvedValue([]),
       list: jest.fn(),
       get: jest.fn(),
       update: jest.fn(),

--- a/apps/api/src/integrations/http/connection.controller.ts
+++ b/apps/api/src/integrations/http/connection.controller.ts
@@ -64,7 +64,8 @@ export class ConnectionController {
 
   private async toResponse(
     connection: Connection,
-    user?: AuthenticatedUser
+    user?: AuthenticatedUser,
+    warnings?: string[]
   ): Promise<ConnectionResponseDto> {
     let supported: string[] = [];
     try {
@@ -83,7 +84,7 @@ export class ConnectionController {
       );
       supported = [];
     }
-    return ConnectionResponseDto.fromDomain(connection, supported, user?.role);
+    return ConnectionResponseDto.fromDomain(connection, supported, user?.role, warnings);
   }
 
   @Roles('admin')
@@ -102,7 +103,8 @@ export class ConnectionController {
     @CurrentUser() user: AuthenticatedUser
   ): Promise<ConnectionResponseDto> {
     const connection = await this.connectionService.create(dto);
-    return this.toResponse(connection, user);
+    const warnings = await this.connectionService.findSharedRateLimitBucketWarnings(connection);
+    return this.toResponse(connection, user, warnings);
   }
 
   @Get()
@@ -165,7 +167,8 @@ export class ConnectionController {
       }),
     };
     const connection = await this.connectionService.update(id, patch);
-    return this.toResponse(connection, user);
+    const warnings = await this.connectionService.findSharedRateLimitBucketWarnings(connection);
+    return this.toResponse(connection, user, warnings);
   }
 
   @Roles('admin')

--- a/apps/api/src/integrations/http/dto/connection-response.dto.ts
+++ b/apps/api/src/integrations/http/dto/connection-response.dto.ts
@@ -69,10 +69,20 @@ export class ConnectionResponseDto {
   @ApiProperty({ description: 'Last update timestamp' })
   updatedAt!: Date;
 
+  @ApiPropertyOptional({
+    description:
+      'Non-blocking advisory warnings about this connection (#1594), e.g. it shares a ' +
+      'provider-side rate-limit bucket with another active connection on the same seller ' +
+      'tax id. Present only on create/update responses that detected one; never a hard error.',
+    type: [String],
+  })
+  warnings?: string[];
+
   static fromDomain(
     connection: Connection,
     supportedCapabilities: string[],
-    role?: UserRole
+    role?: UserRole,
+    warnings?: string[]
   ): ConnectionResponseDto {
     const dto = new ConnectionResponseDto();
     dto.id = connection.id;
@@ -89,6 +99,9 @@ export class ConnectionResponseDto {
     dto.supportedCapabilities = supportedCapabilities;
     dto.createdAt = connection.createdAt;
     dto.updatedAt = connection.updatedAt;
+    if (warnings && warnings.length > 0) {
+      dto.warnings = warnings;
+    }
     return dto;
   }
 }

--- a/apps/api/src/invoicing/http/dto/bulk-issue-invoices-response.dto.ts
+++ b/apps/api/src/invoicing/http/dto/bulk-issue-invoices-response.dto.ts
@@ -12,6 +12,13 @@
  *   - `failed`  — the order was missing / not invoiceable, or the provider
  *                 rejected the request; carries a neutral, PII-free `reason`.
  *
+ * Partial-completion (#1594): this is the operator's completion feedback for a
+ * bulk run — the endpoint processes every id and reports each outcome, so a
+ * failure on one order never aborts the rest and the caller sees exactly what
+ * happened per id. It remains a single synchronous request; live streaming /
+ * async-job progress for very large batches is a documented follow-up (the
+ * batch is capped at 100 ids, which bounds the call duration in the meantime).
+ *
  * Neutral — no provider vocabulary, never the raw provider rejection text.
  *
  * @module apps/api/src/invoicing/http/dto
@@ -45,6 +52,13 @@ export class BulkIssueInvoiceResultDto {
 }
 
 export class BulkIssueInvoicesResponseDto {
+  @ApiProperty({
+    description:
+      'Total number of distinct orders processed in this batch (issued + skipped + failed). ' +
+      'Equals the de-duplicated `orderIds` count — a progress denominator for the operator UI.',
+  })
+  total!: number;
+
   @ApiProperty({ description: 'Number of invoices issued.' })
   issued!: number;
 

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -543,7 +543,10 @@ export class InvoicingController {
       'deterministic key `invoice:{connectionId}:{orderId}` (same key the auto-issue ' +
       'trigger uses), so a re-submitted batch does not double-issue. Orders already ' +
       'issued / in progress are skipped; a per-order failure is captured without ' +
-      'aborting the rest. At most 100 order ids per request. Returns a per-id summary.',
+      'aborting the rest. At most 100 order ids per request. Returns a per-id summary ' +
+      '(partial-completion feedback). The provider adapter self-paces its own per-hour ' +
+      'rate-limit ceilings (#1594), so a large batch throttles itself rather than ' +
+      'relying solely on reactive backoff.',
   })
   @ApiResponse({ status: 200, description: 'Per-id issue summary', type: BulkIssueInvoicesResponseDto })
   @ApiResponse({ status: 400, description: 'Validation error (empty array, blank ids, or batch > 100)' })
@@ -563,7 +566,17 @@ export class InvoicingController {
 
     const issued = results.filter((r) => r.outcome === 'issued').length;
     const skipped = results.filter((r) => r.outcome === 'skipped').length;
-    return { issued, skipped, failed: results.length - issued - skipped, results };
+    // Partial-completion feedback (#1594): every id is processed and reported
+    // per-outcome (no all-or-nothing), with `total` as the progress denominator.
+    // Live streaming progress for very large batches is a documented follow-up;
+    // the max-100 cap bounds the synchronous call duration until then.
+    return {
+      total: results.length,
+      issued,
+      skipped,
+      failed: results.length - issued - skipped,
+      results,
+    };
   }
 
   /**

--- a/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
+++ b/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
@@ -29,6 +29,7 @@ import type { CredentialsResolverPort } from '@openlinker/core/integrations';
 import type { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { KsefInvoicingAdapter } from '../../infrastructure/adapters/ksef-invoicing.adapter';
 import { createKsefHttpClient } from '../../infrastructure/http/ksef-http-client.factory';
+import { getSharedKsefRateLimiter } from '../../infrastructure/http/ksef-rate-limiter';
 import { KsefSessionCryptoService } from '../../infrastructure/crypto/ksef-session-crypto.service';
 import { Fa3WithValidationBuilder } from '../../infrastructure/fa3/builders/fa3-with-validation.builder';
 import { DEFAULT_FA3_TAX_RATE } from '../../infrastructure/fa3/domain/fa3-tax-rate.mapper';
@@ -69,6 +70,11 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
       env,
       authMaterial,
       cache: this.cache,
+      // #1594: proactive per-hour pacing keyed on the seller NIP (KSeF buckets by
+      // NIP), shared process-wide so sibling connections on the same NIP throttle
+      // against one bucket rather than each other.
+      rateLimiter: getSharedKsefRateLimiter(),
+      rateLimitBucketKey: seller.nip,
     });
 
     // C5 issuance dependencies: the session-crypto service (shares the same

--- a/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-http-client.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-http-client.spec.ts
@@ -12,6 +12,7 @@ import type { KsefAuthenticationToken } from '../ksef-http-client.types';
 import { KsefAuthenticationException } from '../../../domain/exceptions/ksef-authentication.exception';
 import { KsefApiException } from '../../../domain/exceptions/ksef-api.exception';
 import { KsefNetworkException } from '../../../domain/exceptions/ksef-network.exception';
+import type { KsefRateLimiter } from '../ksef-rate-limiter';
 
 function token(expiresInMs = 3_600_000, accessToken = 'access-token'): KsefAuthenticationToken {
   return {
@@ -350,6 +351,70 @@ describe('KsefHttpClient', () => {
       const client = new KsefHttpClient('conn-1', baseUrl, lifecycle);
 
       await expect(client.get('/sessions/online')).rejects.toBeInstanceOf(KsefApiException);
+    });
+  });
+
+  describe('proactive rate-limit pacing (#1594)', () => {
+    function stubLimiter(): { limiter: KsefRateLimiter; acquire: jest.Mock } {
+      const acquire = jest.fn().mockResolvedValue(undefined);
+      return { limiter: { acquire } as unknown as KsefRateLimiter, acquire };
+    }
+
+    it('acquires a session-open permit before POST /sessions/online', async () => {
+      fetchMock.mockResolvedValue(jsonResponse(200, { referenceNumber: 'r' }));
+      const { limiter, acquire } = stubLimiter();
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle, undefined, {
+        rateLimiter: limiter,
+        bucketKey: 'nip-123',
+      });
+
+      await client.post('/sessions/online', { x: 1 });
+
+      expect(acquire).toHaveBeenCalledWith('nip-123', 'session-open');
+    });
+
+    it('classifies the invoice-submit and session-close endpoints', async () => {
+      // Fresh Response per call — a Response body can only be read once.
+      fetchMock.mockImplementation(() =>
+        Promise.resolve(jsonResponse(200, { referenceNumber: 'r' })),
+      );
+      const { limiter, acquire } = stubLimiter();
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle, undefined, {
+        rateLimiter: limiter,
+        bucketKey: 'nip-123',
+      });
+
+      await client.post('/sessions/online/session-ref-1/invoices', { x: 1 });
+      await client.post('/sessions/online/session-ref-1/close', undefined, { idempotent: true });
+
+      expect(acquire).toHaveBeenNthCalledWith(1, 'nip-123', 'invoice-submit');
+      expect(acquire).toHaveBeenNthCalledWith(2, 'nip-123', 'session-close');
+    });
+
+    it('does not pace reads or non-session writes', async () => {
+      fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(200, { ok: true })));
+      const { limiter, acquire } = stubLimiter();
+      const client = new KsefHttpClient('conn-1', baseUrl, lifecycle, undefined, {
+        rateLimiter: limiter,
+        bucketKey: 'nip-123',
+      });
+
+      await client.get('/sessions/session-ref-1'); // status read
+      await client.post('/auth/challenge', undefined, { idempotent: true, skipAuth: true });
+
+      expect(acquire).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the connection id as the bucket key when none is supplied', async () => {
+      fetchMock.mockResolvedValue(jsonResponse(200, { referenceNumber: 'r' }));
+      const { limiter, acquire } = stubLimiter();
+      const client = new KsefHttpClient('conn-99', baseUrl, lifecycle, undefined, {
+        rateLimiter: limiter,
+      });
+
+      await client.post('/sessions/online', { x: 1 });
+
+      expect(acquire).toHaveBeenCalledWith('conn-99', 'session-open');
     });
   });
 });

--- a/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-rate-limiter.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/__tests__/ksef-rate-limiter.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * KSeF Rate Limiter unit specs (#1594)
+ *
+ * Exercises the token-bucket pacer under a SIMULATED rate-limit ceiling using an
+ * injected fake clock whose `sleep` advances virtual time — so pacing is
+ * asserted deterministically with zero real waiting.
+ */
+import {
+  KsefRateLimiter,
+  buildDefaultKsefRateLimiterConfig,
+  getSharedKsefRateLimiter,
+  KSEF_DOCUMENTED_CEILINGS,
+  DEFAULT_KSEF_UTILIZATION_FACTOR,
+} from '../ksef-rate-limiter';
+import type { KsefRateLimiterClock } from '../ksef-rate-limiter.types';
+
+/** Virtual clock: `sleep` fast-forwards `now`, so refill accrues without real time. */
+class FakeClock implements KsefRateLimiterClock {
+  private t = 0;
+  now(): number {
+    return this.t;
+  }
+  sleep(ms: number): Promise<void> {
+    this.t += ms;
+    return Promise.resolve();
+  }
+  advance(ms: number): void {
+    this.t += ms;
+  }
+}
+
+const MS_PER_HOUR = 3_600_000;
+
+describe('KsefRateLimiter', () => {
+  it('admits a burst up to the configured ceiling with no wait', async () => {
+    const clock = new FakeClock();
+    const limiter = new KsefRateLimiter({ 'session-open': { perHour: 3 } }, clock);
+
+    await limiter.acquire('nip-1', 'session-open');
+    await limiter.acquire('nip-1', 'session-open');
+    await limiter.acquire('nip-1', 'session-open');
+
+    // Bucket started full (capacity 3) → three immediate grants, no time passed.
+    expect(clock.now()).toBe(0);
+  });
+
+  it('paces the next request once the burst capacity is exhausted', async () => {
+    const clock = new FakeClock();
+    const limiter = new KsefRateLimiter({ 'session-open': { perHour: 2 } }, clock);
+
+    await limiter.acquire('nip-1', 'session-open'); // 2 -> 1
+    await limiter.acquire('nip-1', 'session-open'); // 1 -> 0
+    expect(clock.now()).toBe(0);
+
+    await limiter.acquire('nip-1', 'session-open'); // waits for 1 token
+    // One token accrues in perHour^-1 of an hour: 3_600_000 / 2 = 1_800_000 ms.
+    expect(clock.now()).toBe(MS_PER_HOUR / 2);
+  });
+
+  it('paces a bulk run of N requests under a low ceiling', async () => {
+    const clock = new FakeClock();
+    const ceiling = 5;
+    const limiter = new KsefRateLimiter({ 'invoice-submit': { perHour: ceiling } }, clock);
+
+    const total = 8; // 5 burst + 3 paced
+    for (let i = 0; i < total; i++) {
+      await limiter.acquire('nip-bulk', 'invoice-submit');
+    }
+
+    // After the initial `ceiling` burst, each further grant costs one refill
+    // interval (MS_PER_HOUR / ceiling). 3 paced grants → 3 intervals of elapsed
+    // virtual time.
+    const pacedGrants = total - ceiling;
+    expect(clock.now()).toBe(pacedGrants * (MS_PER_HOUR / ceiling));
+  });
+
+  it('keeps categories independent (one exhausted bucket never blocks another)', async () => {
+    const clock = new FakeClock();
+    const limiter = new KsefRateLimiter(
+      { 'session-open': { perHour: 1 }, 'invoice-submit': { perHour: 1 } },
+      clock,
+    );
+
+    await limiter.acquire('nip-1', 'session-open'); // drains session-open
+    await limiter.acquire('nip-1', 'invoice-submit'); // independent bucket, immediate
+
+    expect(clock.now()).toBe(0);
+  });
+
+  it('keeps bucket keys (seller NIPs) independent', async () => {
+    const clock = new FakeClock();
+    const limiter = new KsefRateLimiter({ 'session-open': { perHour: 1 } }, clock);
+
+    await limiter.acquire('nip-A', 'session-open'); // drains A
+    await limiter.acquire('nip-B', 'session-open'); // separate bucket, immediate
+
+    expect(clock.now()).toBe(0);
+  });
+
+  it('does not pace a category configured to a non-positive ceiling', async () => {
+    const clock = new FakeClock();
+    const limiter = new KsefRateLimiter({ 'session-close': { perHour: 0 } }, clock);
+
+    for (let i = 0; i < 50; i++) {
+      await limiter.acquire('nip-1', 'session-close');
+    }
+    expect(clock.now()).toBe(0);
+  });
+
+  it('refills continuously so waiting real time restores tokens', async () => {
+    const clock = new FakeClock();
+    const limiter = new KsefRateLimiter({ 'session-open': { perHour: 2 } }, clock);
+
+    await limiter.acquire('nip-1', 'session-open'); // 2 -> 1
+    await limiter.acquire('nip-1', 'session-open'); // 1 -> 0
+
+    // Advance a full refill interval out-of-band → one token should be back.
+    clock.advance(MS_PER_HOUR / 2);
+    await limiter.acquire('nip-1', 'session-open'); // consumes the refilled token, no wait
+    expect(clock.now()).toBe(MS_PER_HOUR / 2);
+  });
+
+  describe('default config', () => {
+    it('scales documented ceilings by the headroom factor', () => {
+      const cfg = buildDefaultKsefRateLimiterConfig();
+      expect(cfg['session-open'].perHour).toBe(
+        Math.floor(KSEF_DOCUMENTED_CEILINGS['session-open'] * DEFAULT_KSEF_UTILIZATION_FACTOR),
+      );
+      expect(cfg['invoice-submit'].perHour).toBe(
+        Math.floor(KSEF_DOCUMENTED_CEILINGS['invoice-submit'] * DEFAULT_KSEF_UTILIZATION_FACTOR),
+      );
+      // 0.9 * 120 = 108 > 100 (max bulk batch), so a full 100-order batch still
+      // bursts through without pacing while reserving ~10% headroom.
+      expect(cfg['session-open'].perHour).toBeGreaterThan(100);
+    });
+  });
+
+  describe('getSharedKsefRateLimiter', () => {
+    it('returns a stable process-wide singleton', () => {
+      expect(getSharedKsefRateLimiter()).toBe(getSharedKsefRateLimiter());
+    });
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.factory.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.factory.ts
@@ -22,6 +22,7 @@ import type { CachePort } from '@openlinker/shared/cache';
 import type { KsefEnvironment } from '../../domain/types/ksef-connection.types';
 import type { KsefAuthenticationToken } from './ksef-http-client.types';
 import { KsefHttpClient, type KsefTokenLifecycle } from './ksef-http-client';
+import type { KsefRateLimiter } from './ksef-rate-limiter';
 import { resolveKsefBaseUrl } from './ksef-hosts';
 import { MfPublicKeyCacheService } from '../crypto/mf-public-key-cache.service';
 import { KsefTokenEncryptor } from './auth/ksef-token-encryptor.service';
@@ -37,6 +38,19 @@ export interface CreateKsefHttpClientInput {
   /** Resolved ksef-token material. Qualified-seal wiring is deferred to C4. */
   authMaterial: KsefTokenAuthMaterial;
   cache?: CachePort;
+  /**
+   * Proactive per-hour rate-limit pacer (#1594) shared across connections. When
+   * present, the client throttles the three online-session write endpoints
+   * against KSeF's documented ceilings. Omitted by callers (e.g. the connection
+   * tester) that never issue documents.
+   */
+  rateLimiter?: KsefRateLimiter;
+  /**
+   * Rate-limit bucket key — the seller NIP (KSeF buckets by NIP), so sibling
+   * connections on the same NIP share one bucket. Falls back to `connectionId`
+   * inside the client when absent.
+   */
+  rateLimitBucketKey?: string;
 }
 
 export interface KsefHttpClientBundle {
@@ -70,7 +84,10 @@ export function createKsefHttpClient(input: CreateKsefHttpClientInput): KsefHttp
   };
 
   // 1. Client first (its unauthenticated endpoints bootstrap the services).
-  const httpClient = new KsefHttpClient(input.connectionId, baseUrl, lifecycle);
+  const httpClient = new KsefHttpClient(input.connectionId, baseUrl, lifecycle, undefined, {
+    rateLimiter: input.rateLimiter,
+    bucketKey: input.rateLimitBucketKey,
+  });
 
   // 2. Services share the one client instance.
   const publicKeyCache = new MfPublicKeyCacheService(input.connectionId, httpClient, input.cache);

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-http-client.ts
@@ -44,6 +44,8 @@ import type {
 import { KsefApiException } from '../../domain/exceptions/ksef-api.exception';
 import { KsefAuthenticationException } from '../../domain/exceptions/ksef-authentication.exception';
 import { KsefNetworkException } from '../../domain/exceptions/ksef-network.exception';
+import type { KsefRateLimiter } from './ksef-rate-limiter';
+import type { KsefRateLimitCategory } from './ksef-rate-limiter.types';
 
 /** Refresh proactively within this window of the access-token expiry. */
 const TOKEN_REFRESH_WINDOW_MS = 60_000;
@@ -92,14 +94,30 @@ export class KsefHttpClient implements IKsefHttpClient {
   private token: KsefAuthenticationToken | null = null;
   private refreshInFlight: Promise<void> | null = null;
 
+  /**
+   * Proactive per-hour pacer (#1594) for the three rate-limited online-session
+   * write endpoints, shared across every client instance keyed to the same
+   * bucket. `null` disables pacing (the pre-#1594 behaviour) so unit specs and
+   * callers that don't wire one keep working.
+   */
+  private readonly rateLimiter: KsefRateLimiter | null;
+  /**
+   * The pacing bucket key — the seller NIP when supplied (KSeF buckets by NIP),
+   * else the connection id as a safe per-connection fallback.
+   */
+  private readonly rateLimitBucketKey: string;
+
   constructor(
     private readonly connectionId: string,
     baseUrl: string,
     private readonly lifecycle: KsefTokenLifecycle,
     retryConfig?: Partial<KsefRetryConfig>,
+    pacing?: { rateLimiter?: KsefRateLimiter; bucketKey?: string },
   ) {
     this.baseUrl = baseUrl.replace(/\/$/, '');
     this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+    this.rateLimiter = pacing?.rateLimiter ?? null;
+    this.rateLimitBucketKey = pacing?.bucketKey ?? connectionId;
   }
 
   async get<T = unknown>(path: string, options?: KsefHttpRequestOptions): Promise<KsefHttpResponse<T>> {
@@ -161,6 +179,13 @@ export class KsefHttpClient implements IKsefHttpClient {
     idempotent: boolean,
     expectBinary = false,
   ): Promise<KsefHttpResponse<T>> {
+    // Proactive pacing (#1594): block until a per-hour token is free BEFORE the
+    // first attempt, so a bulk run self-throttles under KSeF's documented
+    // ceilings rather than firing all requests and relying on reactive 429s.
+    // Acquired once per logical request (not per retry attempt); reactive 429
+    // backoff below remains the backstop for anything the pacer under-estimates.
+    await this.acquireRateLimitPermit(method, path);
+
     let lastError: Error | null = null;
     let delay = this.retryConfig.initialDelayMs;
 
@@ -208,6 +233,40 @@ export class KsefHttpClient implements IKsefHttpClient {
       }
     }
     throw lastError ?? new Error('KSeF request failed after retries');
+  }
+
+  /**
+   * Acquire a proactive rate-limit token for a rate-limited write endpoint.
+   * No-op when no limiter is wired or the call is not one of the three paced
+   * POSTs (reads, auth, and everything else pass through unthrottled).
+   */
+  private async acquireRateLimitPermit(method: 'GET' | 'POST', path: string): Promise<void> {
+    if (!this.rateLimiter || method !== 'POST') {
+      return;
+    }
+    const category = this.classifyRateLimitCategory(path);
+    if (!category) {
+      return;
+    }
+    await this.rateLimiter.acquire(this.rateLimitBucketKey, category);
+  }
+
+  /**
+   * Map a KSeF path to its rate-limit category, or `null` when the endpoint is
+   * not one of the three documented per-hour-capped online-session writes.
+   */
+  private classifyRateLimitCategory(path: string): KsefRateLimitCategory | null {
+    const normalized = path.replace(/^\//, '').split('?')[0]?.replace(/\/$/, '') ?? '';
+    if (normalized === 'sessions/online') {
+      return 'session-open';
+    }
+    if (/^sessions\/online\/[^/]+\/invoices$/.test(normalized)) {
+      return 'invoice-submit';
+    }
+    if (/^sessions\/online\/[^/]+\/close$/.test(normalized)) {
+      return 'session-close';
+    }
+    return null;
   }
 
   private async executeRequest<T>(

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-rate-limiter.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-rate-limiter.ts
@@ -1,0 +1,174 @@
+/**
+ * KSeF Rate Limiter (#1594)
+ *
+ * Proactive, client-side token-bucket pacer for the three rate-limited KSeF
+ * online-session write endpoints. KSeF 2.0 enforces per-context
+ * `(seller NIP, source IP)` per-hour ceilings:
+ *   - `POST /sessions/online`            (session-open)   = 120/hour
+ *   - `POST /sessions/online/{ref}/invoices` (invoice-submit) = 180/hour
+ *   - `POST /sessions/online/{ref}/close`    (session-close)  = 120/hour
+ *
+ * A 100-order bulk-issue run fans out to ~100 opens + 100 submits + 100 closes
+ * on ONE connection, landing within a few points of the open/close ceiling and
+ * leaving no headroom for auto-issue / retries / a second bulk call in the same
+ * rolling hour. This limiter self-throttles that run against the documented
+ * ceilings so the reactive 429/Retry-After path (which only fires AFTER KSeF
+ * rejects) becomes a backstop rather than the primary control.
+ *
+ * Design:
+ *  - One token bucket per `(bucketKey, category)`. `bucketKey` is the seller NIP
+ *    (KSeF buckets by NIP), so multiple OL connections on the same NIP + the
+ *    same egress IP share one bucket — matching KSeF's own edge accounting.
+ *    A single OL deployment egresses from one IP, so keying on NIP alone is a
+ *    faithful proxy for KSeF's `(NIP, IP)` context here.
+ *  - Bucket capacity == `perHour`; refill accrues continuously at
+ *    `perHour / 3_600_000` tokens per ms. A burst up to `perHour` is admitted
+ *    immediately; steady-state then paces at the sustained rate.
+ *  - `acquire` consumes one token, awaiting (via the injected clock) until a
+ *    token is available. The injected clock keeps the pacer testable with a fake
+ *    time source — no real sleeps in specs.
+ *
+ * This is a process-local pacer (a shared singleton via
+ * `getSharedKsefRateLimiter`), NOT a cross-process/distributed limiter: it
+ * bounds THIS deployment's own outbound rate. Cross-instance coordination (if OL
+ * ever runs multiple issuing replicas against one NIP) is a documented follow-up.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+import { Logger } from '@openlinker/shared/logging';
+import type {
+  KsefRateLimitCategory,
+  KsefRateLimiterClock,
+  KsefRateLimiterConfig,
+} from './ksef-rate-limiter.types';
+
+const MS_PER_HOUR = 3_600_000;
+
+/**
+ * Absorbs IEEE-754 drift when a refill computes a token count a hair below a
+ * whole token (e.g. 0.9999999 instead of 1). Without it a bucket that has
+ * mathematically accrued exactly one token would spin one extra 1ms wait.
+ */
+const TOKEN_EPSILON = 1e-6;
+
+/**
+ * Documented KSeF per-hour ceilings (per `(NIP, IP)` context). Re-confirm
+ * against the live CIRFMF documentation periodically — MF may adjust these.
+ */
+export const KSEF_DOCUMENTED_CEILINGS: Record<KsefRateLimitCategory, number> = {
+  'session-open': 120,
+  'invoice-submit': 180,
+  'session-close': 120,
+};
+
+/**
+ * Fraction of each documented ceiling the pacer will actually spend, reserving
+ * the remainder as headroom for concurrent activity (auto-issue trigger, manual
+ * retries, a second bulk call) on the same context. 0.9 keeps a 100-order bulk
+ * run well under the burst capacity (0.9 * 120 = 108 > 100) while still leaving
+ * ~10% for everything else.
+ */
+export const DEFAULT_KSEF_UTILIZATION_FACTOR = 0.9;
+
+/** Build the default limiter config from the documented ceilings + headroom factor. */
+export function buildDefaultKsefRateLimiterConfig(
+  utilizationFactor: number = DEFAULT_KSEF_UTILIZATION_FACTOR,
+): KsefRateLimiterConfig {
+  const scale = (ceiling: number): number => Math.max(1, Math.floor(ceiling * utilizationFactor));
+  return {
+    'session-open': { perHour: scale(KSEF_DOCUMENTED_CEILINGS['session-open']) },
+    'invoice-submit': { perHour: scale(KSEF_DOCUMENTED_CEILINGS['invoice-submit']) },
+    'session-close': { perHour: scale(KSEF_DOCUMENTED_CEILINGS['session-close']) },
+  };
+}
+
+/** Default clock: real wall-clock time + real (cancellable-free) sleep. */
+const REAL_CLOCK: KsefRateLimiterClock = {
+  now: () => Date.now(),
+  sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+interface TokenBucket {
+  tokens: number;
+  lastRefillMs: number;
+}
+
+export class KsefRateLimiter {
+  private readonly logger = new Logger(KsefRateLimiter.name);
+  private readonly config: KsefRateLimiterConfig;
+  private readonly clock: KsefRateLimiterClock;
+  private readonly buckets = new Map<string, TokenBucket>();
+
+  constructor(config?: Partial<KsefRateLimiterConfig>, clock: KsefRateLimiterClock = REAL_CLOCK) {
+    this.config = { ...buildDefaultKsefRateLimiterConfig(), ...config };
+    this.clock = clock;
+  }
+
+  /**
+   * Consume one token for `(bucketKey, category)`, awaiting until one is
+   * available. Serialises acquisitions per bucket so concurrent callers can't
+   * both read the same pre-refill token count and over-draw the bucket.
+   */
+  async acquire(bucketKey: string, category: KsefRateLimitCategory): Promise<void> {
+    const perHour = this.config[category]?.perHour;
+    if (!perHour || perHour <= 0) {
+      return; // Unconfigured / disabled category — no pacing.
+    }
+    const refillPerMs = perHour / MS_PER_HOUR;
+    const key = `${bucketKey}:${category}`;
+
+    for (;;) {
+      const bucket = this.getBucket(key, perHour);
+      this.refill(bucket, perHour, refillPerMs);
+      if (bucket.tokens + TOKEN_EPSILON >= 1) {
+        bucket.tokens = Math.max(0, bucket.tokens - 1);
+        return;
+      }
+      // Not enough credit yet — wait for exactly one token to accrue, then loop
+      // and re-check (another waiter may have consumed it first).
+      // Compute via `perHour` (not `refillPerMs`) so the tiny divisor doesn't
+      // amplify float error into a spurious extra millisecond of wait.
+      const waitMs = Math.ceil(((1 - bucket.tokens) * MS_PER_HOUR) / perHour);
+      this.logger.debug(
+        `Pacing KSeF ${category} on bucket ${bucketKey}: waiting ${waitMs}ms for a rate-limit token`,
+      );
+      await this.clock.sleep(waitMs);
+    }
+  }
+
+  private getBucket(key: string, capacity: number): TokenBucket {
+    let bucket = this.buckets.get(key);
+    if (!bucket) {
+      // Start full: the first burst up to the ceiling is admitted immediately.
+      bucket = { tokens: capacity, lastRefillMs: this.clock.now() };
+      this.buckets.set(key, bucket);
+    }
+    return bucket;
+  }
+
+  private refill(bucket: TokenBucket, capacity: number, refillPerMs: number): void {
+    const now = this.clock.now();
+    const elapsed = now - bucket.lastRefillMs;
+    if (elapsed <= 0) {
+      return;
+    }
+    bucket.tokens = Math.min(capacity, bucket.tokens + elapsed * refillPerMs);
+    bucket.lastRefillMs = now;
+  }
+}
+
+let sharedInstance: KsefRateLimiter | null = null;
+
+/**
+ * Process-wide shared limiter so every per-connection KSeF HTTP client paces
+ * against the SAME buckets — the point of keying on NIP is defeated if each
+ * short-lived adapter instance got its own limiter. Constructed lazily with the
+ * default (documented-ceiling) config; tests construct their own instance
+ * directly rather than touching this singleton.
+ */
+export function getSharedKsefRateLimiter(): KsefRateLimiter {
+  if (!sharedInstance) {
+    sharedInstance = new KsefRateLimiter();
+  }
+  return sharedInstance;
+}

--- a/libs/integrations/ksef/src/infrastructure/http/ksef-rate-limiter.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/http/ksef-rate-limiter.types.ts
@@ -1,0 +1,49 @@
+/**
+ * KSeF Rate Limiter Types
+ *
+ * Type surface for the proactive, client-side request pacer (#1594). KSeF 2.0
+ * enforces per-context `(seller NIP, source IP)` per-hour ceilings on the three
+ * online-session write endpoints; the pacer self-throttles a bulk run against
+ * those documented ceilings rather than relying solely on reactive
+ * 429/Retry-After backoff.
+ *
+ * Kept in a dedicated `.types.ts` file per engineering-standards "Type
+ * Definitions in Separate Files"; the `as const` + union pattern (no enums) is
+ * the project default for enumerated values.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/http
+ */
+
+/**
+ * The three rate-limited KSeF online-session write endpoints, keyed by neutral
+ * category. Reads (`GET /sessions/{ref}`, status/UPO polls) and the auth
+ * handshake are NOT in the documented ceilings and are never paced.
+ */
+export const KsefRateLimitCategoryValues = [
+  'session-open', // POST /sessions/online
+  'invoice-submit', // POST /sessions/online/{ref}/invoices
+  'session-close', // POST /sessions/online/{ref}/close
+] as const;
+
+export type KsefRateLimitCategory = (typeof KsefRateLimitCategoryValues)[number];
+
+/**
+ * Per-category configured ceiling. `perHour` is the effective sustained rate the
+ * pacer enforces (documented KSeF ceiling minus reserved headroom); it doubles
+ * as the token-bucket capacity, so a burst up to `perHour` requests is admitted
+ * immediately and steady-state traffic then paces at `perHour` per rolling hour.
+ */
+export interface KsefRateLimitConfig {
+  perHour: number;
+}
+
+export type KsefRateLimiterConfig = Record<KsefRateLimitCategory, KsefRateLimitConfig>;
+
+/**
+ * Injectable time source so pacing is deterministic under test (no real sleeps).
+ * `now` returns epoch milliseconds; `sleep` resolves after the given delay.
+ */
+export interface KsefRateLimiterClock {
+  now(): number;
+  sleep(ms: number): Promise<void>;
+}


### PR DESCRIPTION
Part of #1578, addresses #1594.

## Problem
KSeF 2.0 enforces per-context `(seller NIP, source IP)` per-hour ceilings on the three online-session write endpoints: `POST /sessions/online` (open) 120/h, `POST /sessions/online/{ref}/invoices` (submit) 180/h, `POST /sessions/online/{ref}/close` 120/h. A 100-order bulk-issue run opens one online session per invoice (~100 opens + 100 submits + 100 closes on one connection), landing within a few points of the open/close ceiling with no headroom - and only reactive 429/Retry-After backoff existed, never proactive pacing.

## What this delivers

### 1. Proactive client-side pacing (KSeF plugin / infrastructure)
- New `KsefRateLimiter` (`ksef-rate-limiter.ts`): a token-bucket pacer keyed per `(bucketKey, category)`. `bucketKey` is the **seller NIP** (KSeF buckets by NIP), so sibling OL connections on the same NIP share ONE bucket - matching KSeF's own edge accounting for a single-egress-IP deployment. Bucket capacity == effective per-hour ceiling (documented ceiling x 0.9, reserving ~10% headroom for auto-issue / retries / a second bulk call); tokens refill continuously. An **injected clock/sleep** makes pacing deterministic under test - no real sleeps. Exposed as a process-wide shared singleton so short-lived per-connection adapters pace against the same buckets.
- `KsefHttpClient` acquires a permit before the three paced POSTs (classified by path); reads, auth, and everything else pass through unthrottled. Wired through the client factory + adapter factory (bucket key = `seller.nip`). Reactive 429 backoff stays as the backstop.

### 2. Progress / partial-completion (API) - MVP + documented follow-up
- The bulk-issue endpoint already reports per-id outcomes (issued/skipped/failed) and never aborts the batch on one failure - that is the operator's partial-completion feedback. Added an explicit `total` denominator for a progress UI and documented the contract.
- **Deferred (documented):** live streaming / async-job progress for very large batches. The batch stays capped at 100 ids, which bounds the synchronous call duration in the meantime. A full async-job/SSE redesign was intentionally out of scope.

### 3. Cross-connection NIP-collision warning (API)
- `ConnectionService.findSharedRateLimitBucketWarnings`: at connection create/edit time, detect when a connection's seller tax id matches another **active** connection on the **same adapter**, and surface a **non-blocking** warning (they share the provider's per-seller rate-limit bucket) on the connection response (`ConnectionResponseDto.warnings`). Advisory only - never a hard block, never throws (a lookup failure yields no warning). Platform-neutral: reads the generic `config.seller.nip` shape, no KSeF vocabulary in the platform-agnostic service.

## Architecture
- Pacing lives entirely in the KSeF plugin (infrastructure); no rate-limit logic leaks into core.
- Progress/orchestration stays in the API layer.
- The NIP-collision check lives where connection validation lives (`ConnectionService`), platform-neutral.
- `check-cross-context-imports` and `check-service-interfaces` invariants pass.

## Tests
- `KsefRateLimiter`: pacing under a simulated low ceiling with a fake clock, burst admission, per-category and per-NIP independence, headroom-factor config (9 specs).
- `KsefHttpClient`: permit acquisition + endpoint classification for the three paced POSTs, no pacing for reads/auth, connection-id bucket fallback (4 specs).
- `ConnectionService`: collision detected / self-excluded / different-adapter ignored / no-seller no-op / advisory-on-list-failure (5 specs).

## Quality gate (scoped)
- `@openlinker/integrations-ksef` build: pass
- `@openlinker/api` type-check: pass
- Scoped jest: KSeF rate-limiter 9/9, KSeF http+factory 68/68, connection.service 83/83
- eslint on all touched files: clean
- cross-context + service-interface invariants: pass

Note: `connection-response.dto.spec` and `invoicing.controller.spec` fail to load in this worktree due to a pre-existing `@nestjs/swagger` vs `@nestjs/core` version mismatch in the shared node_modules (`Cannot find module @nestjs/core/router/legacy-route-converter`) - confirmed identical with these changes stashed, i.e. environmental, not from this PR.