### PR TITLE
feat(invoicing): per-line tax-rate seam on OrderItem + ADR-035 (#1586 Phase 1)

### DIFF
--- a/docs/architecture/adrs/035-per-line-tax-rate-on-order-item.md
+++ b/docs/architecture/adrs/035-per-line-tax-rate-on-order-item.md
@@ -1,0 +1,81 @@
+# ADR-035: Per-line tax rate on the neutral OrderItem contract
+
+- **Status**: Accepted
+- **Date**: 2026-07-15
+- **Authors**: @norbert-kulus-blockydevs
+
+## Context
+
+OpenLinker's neutral `OrderItem` (`libs/core/src/orders`) carries no per-line
+tax rate. When an order is invoiced, `order-to-issue-invoice-command.mapper.ts`
+emits `taxRate: ''` on every `InvoiceLine`, and each provider adapter substitutes
+its connection-level `defaultTaxRate` on every line. Any order that mixes rates
+(23% + 8%/5% — routine for general-merchandise Polish e-commerce) is therefore
+invoiced with a single flat rate on all lines, producing a legally incorrect
+FA(3) tax breakdown (#1586).
+
+This exact gap was raised once before and closed as accepted-risk in #1290, on
+the reasoning that a country-agnostic core (ADR-026) must not carry Polish VAT
+vocabulary. That constraint is real, but it conflated two separate things: naming
+a *country's tax semantics* in core (rightly forbidden) versus carrying an
+*opaque, source-reported rate code* through the neutral pipeline (which does not
+name any country's semantics). #1586 reopens the decision to draw that line
+explicitly.
+
+## Decision
+
+Add an **optional** `taxRate?: string` to the neutral `OrderItem`, carrying a
+source-reported per-line rate as an **opaque neutral string code** reusing the
+vocabulary already established by `InvoiceLine.taxRate` (the provider's own rate
+keys — e.g. KSeF's `FA3_TAX_RATE_MAP` keys `'23' | '8' | '5' | '0' | 'zw' |
+'np'`). `toInvoiceLine()` forwards `item.taxRate ?? ''`. Roll out in phases:
+
+- **Phase 1 (this ADR / #1586 Phase 1)**: add the field + mapper forwarding.
+  Behaviour-preserving — no adapter populates it yet, so every line still falls
+  back to `''` ⇒ the provider's connection-level default (today's behaviour).
+- **Phase 2**: order-source adapters that genuinely expose a per-line rate
+  populate `OrderItem.taxRate`; the provider builder emits the correct per-line
+  band. Scoped to 1–2 live-tested platforms first, the rest documented as
+  follow-ups.
+
+Core still names no country's tax semantics — the code is opaque, produced by the
+source adapter and consumed by the destination provider adapter; ADR-026 holds.
+
+## Alternatives considered
+
+- **Keep the flat per-connection default (status quo / #1290)**: Rejected — it
+  produces a legally wrong tax breakdown for any mixed-rate order, which is a
+  mainstream e-commerce case, not an edge case.
+- **Resolve per-line rate destination-side from the net/gross delta**: Rejected —
+  not all sources report enough to reconstruct the rate reliably, and it buries a
+  fiscal-correctness concern in each provider adapter instead of carrying the
+  source's own asserted rate.
+- **A structured `TaxRate` value object (percentage + scheme enum) in core**:
+  Rejected — that *would* pull tax-scheme semantics into the country-agnostic
+  core, violating ADR-026. An opaque string code keeps core neutral.
+
+## Consequences
+
+**Pros:**
+- Mixed-rate orders can be invoiced with a correct per-line breakdown.
+- Additive + optional ⇒ zero behaviour change until an adapter opts in; no
+  migration, no break to existing single-rate flows.
+- Core stays country-agnostic — the field is an opaque passthrough.
+
+**Cons / trade-offs:**
+- The neutral contract now carries a value whose vocabulary is defined by the
+  provider layer, not core. Accepted: it is opaque to core and documented as
+  such; the alternative (structured VO) is worse for ADR-026.
+- Two-phase rollout means the field sits unused after Phase 1 until adapters fill
+  it — an intentional, documented seam, not dead code.
+
+**Migration path:**
+- None for Phase 1 (additive optional field). Phase 2 is per-adapter and
+  independent; each adapter that populates the field supersedes #1290's
+  accepted-risk framing for the sources it covers.
+
+## References
+
+- Related issues: #1586, supersedes the accepted-risk framing of #1290
+- Related ADRs: [ADR-026](./026-country-agnostic-invoicing-domain.md)
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md) § Invoicing

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -123,5 +123,6 @@ One pointer per section, identical format every time.
 | [ADR-032](./032-demo-only-vendor-neutral-analytics-config-seam.md) | Demo-only, vendor-neutral analytics/integration config seam on `/system/config` | Proposed | 2026-07-08 |
 | [ADR-033](./033-openlinker-as-mcp-server.md) | Expose OpenLinker as an MCP server | Proposed | 2026-07-11 |
 | [ADR-034](./034-mcp-authorization-user-issued-pats.md) | MCP authorization — user-issued Personal Access Tokens (Resource Server); OAuth AS deferred | Proposed | 2026-07-12 |
+| [ADR-035](./035-per-line-tax-rate-on-order-item.md) | Per-line tax rate as an opaque neutral code on `OrderItem` (supersedes #1290 accepted-risk) | Accepted | 2026-07-15 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
@@ -92,6 +92,22 @@ describe('toIssueInvoiceCommand', () => {
     expect(cmd.lines[2].name).toBe('PID-5');
   });
 
+  it('per-line taxRate: forwards OrderItem.taxRate when present, else falls back to empty (#1586 Phase 1)', () => {
+    const order = makeOrder({
+      items: [
+        makeItem({ id: 'a', name: 'Std', taxRate: '23' }),
+        makeItem({ id: 'b', name: 'Reduced', taxRate: '8' }),
+        makeItem({ id: 'c', name: 'Unset' }), // no taxRate -> empty (default path)
+      ],
+    });
+
+    const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
+
+    expect(cmd.lines[0].taxRate).toBe('23');
+    expect(cmd.lines[1].taxRate).toBe('8');
+    expect(cmd.lines[2].taxRate).toBe('');
+  });
+
   it('should fill saleDate from placedAt (ISO YYYY-MM-DD) when the order carries one', () => {
     const cmd = toIssueInvoiceCommand({
       order: makeOrder({ placedAt: new Date('2026-06-20T14:30:00.000Z') }),

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
@@ -191,9 +191,15 @@ function toBuyerAddress(address: Address): BuyerAddress {
 /**
  * Map an {@link OrderItem} onto an {@link InvoiceLine}. `unitPriceGross` is the
  * line price (gross — see treatment guard above). `name` falls back to
- * `sku` then `productId` when the source omitted a label. `taxRate` is left
- * empty here — the provider adapter resolves the regime rate; core never names
- * a tax rate on the order contract.
+ * `sku` then `productId` when the source omitted a label.
+ *
+ * `taxRate` (#1586 Phase 1, ADR-035): forwards the item's genuine per-line rate
+ * when the source populated `OrderItem.taxRate`, else falls back to `''` — the
+ * long-standing "empty ⇒ provider adapter resolves the connection-level default
+ * rate" contract. No order-source adapter fills `OrderItem.taxRate` yet (Phase
+ * 2), so this is behaviour-preserving today: the seam is open, the default path
+ * unchanged. The value stays an opaque neutral code — core never names or
+ * interprets a country/scheme tax rate (ADR-026).
  *
  * Throws {@link InvalidInvoiceLineError} (PII-clean, cites only `orderId`) when
  * the quantity is not a positive finite number - a malformed order snapshot
@@ -210,7 +216,7 @@ function toInvoiceLine(item: OrderItem, orderId: string): InvoiceLine {
     name: item.name?.trim() || item.sku || item.productId,
     quantity: item.quantity,
     unitPriceGross: item.price,
-    taxRate: '',
+    taxRate: item.taxRate ?? '',
   };
 }
 

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -243,6 +243,20 @@ export interface OrderItem {
    * future enrichment — no current adapter sets this on ingestion.
    */
   imageUrl?: string;
+
+  /**
+   * Genuine per-line VAT/tax rate as a neutral string code (#1586, ADR-035),
+   * reusing the same country-agnostic vocabulary as `InvoiceLine.taxRate` (the
+   * KSeF `FA3_TAX_RATE_MAP` keys — e.g. `'23'`, `'8'`, `'5'`, `'0'`, `'zw'`,
+   * `'np'`). Optional and source-uniform: absent means "the source did not
+   * report a per-line rate", and the invoicing pipeline falls back to the
+   * connection-level default (today's behaviour). No order-source adapter
+   * populates this in Phase 1 — the field opens the seam so a mixed-rate order
+   * can carry correct per-line rates once an adapter fills it (Phase 2). The
+   * value is an opaque neutral code; no country/scheme logic lives in core
+   * (ADR-026).
+   */
+  taxRate?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Part of #1578, addresses #1586 (Phase 1 of 2).

Opens the seam for genuine per-line VAT rates so a mixed-rate order (23% + 8%/5%) can eventually be invoiced with a correct FA(3) tax breakdown, and records the cross-context vocabulary decision that #1290 previously closed as accepted-risk.

## Changes

- **`OrderItem.taxRate?: string`** (`libs/core/src/orders/domain/types/order.types.ts`) — optional, opaque neutral rate code reusing the `InvoiceLine.taxRate` vocabulary. Core never interprets it (ADR-026).
- **`toInvoiceLine()`** (`order-to-issue-invoice-command.mapper.ts`) now forwards `item.taxRate ?? ''`. Behaviour-preserving: no order-source adapter populates `OrderItem.taxRate` yet (Phase 2), so every line still falls back to `''` ⇒ the provider's connection-level default rate.
- **ADR-035** documents the opaque-neutral-code choice + phased rollout, and supersedes the accepted-risk framing of #1290. Rejected alternatives (flat default, destination-side derivation, structured `TaxRate` VO) are recorded.

## Scope

Phase 1 is core plumbing only. Phase 2 (cross-border band guard, GTU/Procedura, per-adapter `OrderItem.taxRate` population for 1–2 platforms) is a separate PR later in this epic (Wave C).

## Test plan

- [x] `pnpm --filter @openlinker/core build` — clean
- [x] New mapper test: `OrderItem.taxRate` present ⇒ forwarded; absent ⇒ `''` (default path). 30 mapper tests pass.
- [x] `check-cross-context-imports` + `check-repo-urls` — conform
- [x] ESLint on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)