### PR TITLE
feat(ksef): derive FA(3) Adnotacje from invoice classification (#1580)

### DIFF
--- a/docs/architecture/adrs/037-neutral-fiscal-annotation-flags.md
+++ b/docs/architecture/adrs/037-neutral-fiscal-annotation-flags.md
@@ -1,0 +1,63 @@
+# ADR-037: Neutral fiscal-annotation flags on the invoicing command
+
+- **Status**: Accepted
+- **Date**: 2026-07-15
+- **Authors**: @norbert-kulus-blockydevs
+
+## Context
+
+[ADR-026](./026-country-agnostic-invoicing-domain.md) keeps the invoicing core
+country-agnostic: no NIP/KSeF/FA vocabulary in `libs/core`, all national
+specifics confined to the provider adapter. The FA(3) `Adnotacje` block carries
+six schema-mandated annotations a Polish invoice may need to declare - cash
+accounting (`P_16`), self-billing (`P_17`), reverse charge (`P_18`), the
+split-payment mechanism (`P_18A`), VAT exemption grounds (`Zwolnienie`/`P_19`),
+triangulation (`P_23`), and the margin scheme (`PMarzy`).
+
+Before #1580 the KSeF builder hard-coded every one of these to its negative
+branch, so a VAT-marża reseller or a reverse-charge/exempt line produced a
+document whose header contradicted its own lines. Fixing it needs some flags the
+neutral command does not carry (they are operator declarations no marketplace
+order expresses), while others are already implied by the per-line tax code.
+
+## Decision
+
+Add a single optional neutral bag `InvoiceAnnotations` to `IssueInvoiceCommand`
+(`cashAccounting`, `selfBilling`, `splitPayment`, `triangulation`,
+`marginScheme`, and a free-text `exemptionLegalBasis`). The names are generic
+commercial/fiscal concepts; the provider adapter maps neutral → its own regime
+(the KSeF adapter maps them to `Adnotacje`). Reverse charge and exemption are
+**deliberately not** boolean flags - the provider derives them from the per-line
+tax codes ([ADR-035](./035-per-line-tax-rate-on-order-item.md)) so the header can
+never contradict the lines. All flags are optional; absent ⇒ the provider's
+"does not apply" default.
+
+## Alternatives considered
+
+- **Per-line-only derivation for everything**: Rejected - cash-basis,
+  self-billing, split-payment and triangulation are invoice-/operator-level
+  declarations with no line signal to derive from.
+- **PL-named fields (`p16`, `pMarzy`, …) on the command**: Rejected - leaks FA(3)
+  vocabulary into `libs/core`, violating ADR-026.
+- **A provider-specific extension map (`Record<string, unknown>`)**: Rejected -
+  untyped, unvalidated, and hides the contract from other adapters.
+
+## Consequences
+
+**Pros:**
+- Header annotations agree with the line-level treatment; margin/exempt/
+  reverse-charge invoices become correct.
+- Core stays country-agnostic; a non-PL provider maps the same neutral flags.
+
+**Cons / trade-offs:**
+- No operator UI yet sets the flags - they thread through defaulting to the
+  negative branch (a documented follow-up).
+- The exemption yes-branch needs a legal-basis text; when a line is exempt but
+  none is supplied, the adapter emits a descriptive placeholder the operator
+  should refine.
+
+## References
+
+- Related issues: #1580, #1586
+- Related ADRs: [ADR-026](./026-country-agnostic-invoicing-domain.md), [ADR-035](./035-per-line-tax-rate-on-order-item.md)
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md) § Invoicing

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -124,5 +124,6 @@ One pointer per section, identical format every time.
 | [ADR-033](./033-openlinker-as-mcp-server.md) | Expose OpenLinker as an MCP server | Proposed | 2026-07-11 |
 | [ADR-034](./034-mcp-authorization-user-issued-pats.md) | MCP authorization — user-issued Personal Access Tokens (Resource Server); OAuth AS deferred | Proposed | 2026-07-12 |
 | [ADR-035](./035-per-line-tax-rate-on-order-item.md) | Per-line tax rate as an opaque neutral code on `OrderItem` (supersedes #1290 accepted-risk) | Accepted | 2026-07-15 |
+| [ADR-037](./037-neutral-fiscal-annotation-flags.md) | Neutral fiscal-annotation flags on the invoicing command (cash-basis/self-billing/split-payment/margin/exemption/triangulation) - provider maps to FA(3) Adnotacje | Accepted | 2026-07-15 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -404,6 +404,39 @@ export interface StoredDocument {
 }
 
 /**
+ * Neutral, operator-supplied fiscal annotation flags on an invoice (#1580,
+ * ADR-037). Country-agnostic (ADR-026): each flag is a generic commercial /
+ * fiscal concept a provider maps to its own regime — a KSeF adapter maps them
+ * to the FA(3) `Adnotacje` block. Every field is optional; an absent flag ⇒ the
+ * provider emits its own "does not apply" default. Core never interprets them.
+ *
+ * Note what is *deliberately absent*: reverse-charge and VAT-exemption are NOT
+ * boolean flags here. A provider derives both from the per-line tax codes it
+ * already receives ({@link InvoiceLine.taxRate}), so re-declaring them at the
+ * header level would risk contradicting the lines. `exemptionLegalBasis` is the
+ * sole exemption-adjacent field — it carries the free-text legal grounds a
+ * provider that annotates exemptions must cite.
+ */
+export interface InvoiceAnnotations {
+  /** Supply settled on a cash basis (KSeF: `P_16`). */
+  cashAccounting?: boolean;
+  /** Buyer issues the invoice on the seller's behalf (KSeF: `P_17`). */
+  selfBilling?: boolean;
+  /** The split-payment mechanism applies (KSeF: `P_18A`). */
+  splitPayment?: boolean;
+  /** Simplified intra-EU triangular transaction (KSeF: `P_23`). */
+  triangulation?: boolean;
+  /** The VAT margin scheme applies (KSeF: `PMarzy` / `P_PMarzy`). */
+  marginScheme?: boolean;
+  /**
+   * Free-text legal grounds for a VAT-exempt sale (KSeF: `Zwolnienie` / `P_19`).
+   * When a provider annotates an exemption (e.g. because a line is exempt), it
+   * cites this text; supplying it also asserts the exemption annotation applies.
+   */
+  exemptionLegalBasis?: string;
+}
+
+/**
  * Command to issue a fiscal document. A pure description of *what* to issue;
  * the port does not decide whether/when/which-type — a future rules layer
  * composes this (ADR-026). `currency` is ISO 4217 (single-currency invoice).
@@ -420,6 +453,8 @@ export interface IssueInvoiceCommand {
   lines: InvoiceLine[];
   /** Neutral document type; well-known values in {@link DocumentTypeValues} (open-world). */
   documentType?: string;
+  /** Operator-supplied fiscal annotation flags (#1580); see {@link InvoiceAnnotations}. */
+  annotations?: InvoiceAnnotations;
   /**
    * Date of supply / sale, ISO 8601 calendar `YYYY-MM-DD` (#1525). Filled from
    * the order's marketplace placement timestamp (`Order.placedAt`) - NEVER from

--- a/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.spec.ts
@@ -140,6 +140,70 @@ describe('buildFa3Xml', () => {
     expect(xml).toContain('<PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>');
   });
 
+  describe('Adnotacje classification (#1580)', () => {
+    it('keeps the all-negative default for a plain standard-rate invoice', () => {
+      const xml = buildFa3Xml(b2bInput());
+      expect(xml).toContain('<P_16>2</P_16>');
+      expect(xml).toContain('<P_18>2</P_18>');
+      expect(xml).toContain('<Zwolnienie><P_19N>1</P_19N></Zwolnienie>');
+      expect(xml).toContain('<PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>');
+      expect(() => validateFa3Xml(buildFa3Xml(b2bInput()))).not.toThrow();
+    });
+
+    it('emits the PMarzy yes-branch (used-goods sub-kind) when marginScheme is set', () => {
+      const xml = buildFa3Xml({ ...b2bInput(), marginScheme: true });
+      expect(xml).toContain('<PMarzy><P_PMarzy>1</P_PMarzy><P_PMarzy_3_1>1</P_PMarzy_3_1></PMarzy>');
+      expect(xml).not.toContain('<P_PMarzyN>');
+      expect(() => validateFa3Xml(buildFa3Xml({ ...b2bInput(), marginScheme: true }))).not.toThrow();
+    });
+
+    it('flips the Zwolnienie group to its yes-branch when a line is VAT-exempt (zw)', () => {
+      const input: Fa3BuilderInput = {
+        ...b2bInput(),
+        lines: [{ name: 'Used book', quantity: 1, unitPriceGross: 50, p12: 'zw' }],
+      };
+      const xml = buildFa3Xml(input);
+      expect(xml).toMatch(/<Zwolnienie><P_19>1<\/P_19><P_19C>[^<]+<\/P_19C><\/Zwolnienie>/);
+      expect(xml).not.toContain('<P_19N>');
+      expect(() => validateFa3Xml(buildFa3Xml(input))).not.toThrow();
+    });
+
+    it('carries the operator exemptionLegalBasis text into P_19C', () => {
+      const xml = buildFa3Xml({
+        ...b2bInput(),
+        lines: [{ name: 'Exempt service', quantity: 1, unitPriceGross: 100, p12: 'zw' }],
+        exemptionLegalBasis: 'art. 43 ust. 1 pkt 1 ustawy o VAT',
+      });
+      expect(xml).toContain('<P_19C>art. 43 ust. 1 pkt 1 ustawy o VAT</P_19C>');
+    });
+
+    it('sets P_18 (reverse charge) from a line carrying the oo band', () => {
+      const input: Fa3BuilderInput = {
+        ...b2bInput(),
+        lines: [{ name: 'Reverse-charge good', quantity: 1, unitPriceGross: 200, p12: 'oo' }],
+      };
+      const xml = buildFa3Xml(input);
+      expect(xml).toContain('<P_18>1</P_18>');
+      expect(() => validateFa3Xml(buildFa3Xml(input))).not.toThrow();
+    });
+
+    it('emits each operator flag on its yes-branch when set (P_16/P_17/P_18A/P_23)', () => {
+      const input: Fa3BuilderInput = {
+        ...b2bInput(),
+        cashAccounting: true,
+        selfBilling: true,
+        splitPayment: true,
+        triangulation: true,
+      };
+      const xml = buildFa3Xml(input);
+      expect(xml).toContain('<P_16>1</P_16>');
+      expect(xml).toContain('<P_17>1</P_17>');
+      expect(xml).toContain('<P_18A>1</P_18A>');
+      expect(xml).toContain('<P_23>1</P_23>');
+      expect(() => validateFa3Xml(buildFa3Xml(input))).not.toThrow();
+    });
+  });
+
   it('should emit Fa children in schema order (P_15 → Adnotacje → RodzajFaktury → FaWiersz)', () => {
     const xml = buildFa3Xml(b2bInput());
     expect(xml).toMatch(/<P_15>[^]*<Adnotacje>[^]*<\/Adnotacje>[^]*<RodzajFaktury>[^]*<FaWiersz/);

--- a/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.ts
@@ -28,6 +28,7 @@ import {
   FA3_RODZAJ_KOREKTA,
   FA3_SCHEMA_VERSION,
   FA3_SYSTEM_CODE,
+  FA3_DEFAULT_EXEMPTION_BASIS,
   FA3_WYBOR_NIE,
   FA3_WYBOR_TAK,
   type Fa3BankAccount,
@@ -374,22 +375,55 @@ function correctionLineNodes(input: Fa3BuilderInput, correction: Fa3CorrectionCo
 }
 
 /**
- * The required `Adnotacje` block (XSD line ~2641) emitted with the "nothing
- * special" defaults for a plain domestic sale: every `etd:TWybor1_2` flag set to
- * "no" (`2`), and each choice group taking its negative branch (`P_19N`, `P_22N`,
- * `P_PMarzyN`, all `etd:TWybor1` = `1`). The schema-mandated child order is
+ * The required `Adnotacje` block (XSD line ~2641), emitted per the invoice's
+ * actual classification (#1580) rather than unconditionally on its negative
+ * branch. The schema-mandated child order (preserved by the object key order) is
  * P_16, P_17, P_18, P_18A, Zwolnienie, NoweSrodkiTransportu, P_23, PMarzy.
+ *
+ * Two sources feed it:
+ *  - **Line-derived** (can never contradict the per-line treatment): `P_18`
+ *    ("odwrotne obciążenie") is `1` when any line carries the reverse-charge
+ *    `p12` band (`oo`); the `Zwolnienie` group takes its yes-branch (`P_19` = `1`
+ *    plus a `P_19C` grounds text) when any line is exempt (`zw`) OR an explicit
+ *    `exemptionLegalBasis` was supplied.
+ *  - **Operator-declared** (neutral `IssueInvoiceCommand.annotations`, absent ⇒
+ *    negative): `P_16` cash-basis, `P_17` self-billing, `P_18A` split-payment,
+ *    `P_23` triangulation, and the `PMarzy` group (yes-branch = `P_PMarzy` = `1`
+ *    with `P_PMarzy_3_1`, the used-goods sub-kind — the secondhand e-commerce
+ *    default; per-kind selection is a follow-up).
+ *
+ * The `Zwolnienie`/`PMarzy` yes-branches are XSD `choice`s whose "applies" arm
+ * is a SEQUENCE requiring a nested child: `Zwolnienie` needs exactly one of
+ * `P_19A`/`P_19B`/`P_19C` after `P_19` (we emit `P_19C`, the open catch-all
+ * grounds), and `PMarzy` needs exactly one of `P_PMarzy_2`/`_3_1`/`_3_2`/`_3_3`
+ * after `P_PMarzy`. `NoweSrodkiTransportu` stays on its negative branch
+ * (`P_22N`) — new-means-of-transport supply is out of scope.
+ *
+ * @param lines the effective lines to derive line-level annotations from — a
+ *   plain invoice's own lines, or a KOR's post-correction ("after") lines.
  */
-function adnotacjeNode(): XmlNodeObject {
+function adnotacjeNode(input: Fa3BuilderInput, lines: Fa3Line[]): XmlNodeObject {
+  const anyReverseCharge = lines.some((line) => line.p12 === 'oo');
+  const exemptionApplies =
+    lines.some((line) => line.p12 === 'zw') || input.exemptionLegalBasis !== undefined;
+
+  const zwolnienie: XmlNodeObject = exemptionApplies
+    ? { P_19: FA3_WYBOR_TAK, P_19C: input.exemptionLegalBasis ?? FA3_DEFAULT_EXEMPTION_BASIS }
+    : { P_19N: FA3_WYBOR_TAK };
+
+  const pMarzy: XmlNodeObject = input.marginScheme
+    ? { P_PMarzy: FA3_WYBOR_TAK, P_PMarzy_3_1: FA3_WYBOR_TAK }
+    : { P_PMarzyN: FA3_WYBOR_TAK };
+
   return {
-    P_16: FA3_WYBOR_NIE,
-    P_17: FA3_WYBOR_NIE,
-    P_18: FA3_WYBOR_NIE,
-    P_18A: FA3_WYBOR_NIE,
-    Zwolnienie: { P_19N: FA3_WYBOR_TAK },
+    P_16: input.cashAccounting ? FA3_WYBOR_TAK : FA3_WYBOR_NIE,
+    P_17: input.selfBilling ? FA3_WYBOR_TAK : FA3_WYBOR_NIE,
+    P_18: anyReverseCharge ? FA3_WYBOR_TAK : FA3_WYBOR_NIE,
+    P_18A: input.splitPayment ? FA3_WYBOR_TAK : FA3_WYBOR_NIE,
+    Zwolnienie: zwolnienie,
     NoweSrodkiTransportu: { P_22N: FA3_WYBOR_TAK },
-    P_23: FA3_WYBOR_NIE,
-    PMarzy: { P_PMarzyN: FA3_WYBOR_TAK },
+    P_23: input.triangulation ? FA3_WYBOR_TAK : FA3_WYBOR_NIE,
+    PMarzy: pMarzy,
   };
 }
 
@@ -486,7 +520,12 @@ function faNode(input: Fa3BuilderInput): XmlNodeObject {
     ...(input.saleDate !== undefined ? { P_6: input.saleDate } : {}),
     ...bands,
     P_15: grandTotal,
-    Adnotacje: adnotacjeNode(),
+    // Header annotations derive from the EFFECTIVE lines: a KOR's post-
+    // correction ("after") lines, else the plain invoice's own lines (#1580).
+    Adnotacje: adnotacjeNode(
+      input,
+      correction !== undefined ? correction.correctedLines : input.lines,
+    ),
     RodzajFaktury: correction !== undefined ? FA3_RODZAJ_KOREKTA : FA3_RODZAJ_FAKTURY_VAT,
   };
   if (correction !== undefined) {

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.ts
@@ -18,6 +18,7 @@
 import type {
   BuyerAddress,
   CorrectionReference,
+  InvoiceAnnotations,
   InvoiceLine,
   IssueInvoiceCommand,
 } from '@openlinker/core/invoicing';
@@ -101,6 +102,10 @@ export function mapToFa3BuilderInput(
     ...(cmd.buyer.isVatGroupMember !== undefined
       ? { buyerIsVatGroupMember: cmd.buyer.isVatGroupMember }
       : {}),
+    // Operator-supplied fiscal annotation flags → the FA(3) Adnotacje block
+    // (#1580). Forwarded only when set; the builder derives reverse-charge /
+    // exemption from the lines' own p12 codes independently of these.
+    ...mapAnnotations(cmd.annotations),
     currency: resolveKodWaluty(cmd.currency),
     issueDate: context.issueDate,
     invoiceNumber: context.invoiceNumber,
@@ -114,6 +119,41 @@ export function mapToFa3BuilderInput(
       : {}),
     ...(context.payment !== undefined ? { payment: context.payment } : {}),
   };
+}
+
+/**
+ * Flatten the neutral {@link InvoiceAnnotations} bag onto the builder input's
+ * flat annotation fields, forwarding only the flags the operator actually set
+ * (each absent flag lets the builder emit its "does not apply" default). Kept as
+ * a conditional copy — mirroring the JST/GV forwarding above — so an undefined
+ * flag never lands as an explicit `undefined` on the builder input.
+ */
+function mapAnnotations(
+  annotations: InvoiceAnnotations | undefined,
+): Partial<Fa3BuilderInput> {
+  if (annotations === undefined) {
+    return {};
+  }
+  const out: Partial<Fa3BuilderInput> = {};
+  if (annotations.cashAccounting !== undefined) {
+    out.cashAccounting = annotations.cashAccounting;
+  }
+  if (annotations.selfBilling !== undefined) {
+    out.selfBilling = annotations.selfBilling;
+  }
+  if (annotations.splitPayment !== undefined) {
+    out.splitPayment = annotations.splitPayment;
+  }
+  if (annotations.triangulation !== undefined) {
+    out.triangulation = annotations.triangulation;
+  }
+  if (annotations.marginScheme !== undefined) {
+    out.marginScheme = annotations.marginScheme;
+  }
+  if (annotations.exemptionLegalBasis !== undefined) {
+    out.exemptionLegalBasis = annotations.exemptionLegalBasis;
+  }
+  return out;
 }
 
 /**

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-xml.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-xml.types.ts
@@ -61,6 +61,16 @@ export const FA3_WYBOR_NIE = '2';
 export const FA3_WYBOR_TAK = '1';
 
 /**
+ * Fallback `Zwolnienie/P_19C` free-text legal grounds emitted when an exempt
+ * (`zw`) line forces the exemption annotation on but the operator supplied no
+ * explicit `exemptionLegalBasis` (#1580). `P_19C` ("inna podstawa prawna" — an
+ * open free-text `TZnakowy`) is the catch-all grounds slot; a descriptive
+ * placeholder keeps the yes-branch schema-valid while flagging that the operator
+ * SHOULD refine it with the precise statutory basis (operator UI is a follow-up).
+ */
+export const FA3_DEFAULT_EXEMPTION_BASIS = 'Zwolnienie z podatku VAT';
+
+/**
  * Seller identity + address — injected into the builder by the adapter (resolved
  * from connection config), never discovered inside the pure builder. `nip` is a
  * required system-configuration value (Podmiot1 always carries a seller NIP).
@@ -271,6 +281,24 @@ export interface Fa3BuilderInput {
    */
   buyerIsPublicSectorEntity?: boolean;
   buyerIsVatGroupMember?: boolean;
+  /**
+   * Operator-supplied / line-derived fiscal annotation flags → the FA(3)
+   * `Adnotacje` block (#1580, ADR-037). The operator declarations
+   * (`cashAccounting` → `P_16`, `selfBilling` → `P_17`, `splitPayment` →
+   * `P_18A`, `triangulation` → `P_23`, `marginScheme` → the `PMarzy` yes-branch)
+   * arrive from the neutral `IssueInvoiceCommand.annotations`; each absent flag
+   * emits its "does not apply" default (`2`, or the group's negative branch).
+   * Reverse-charge (`P_18`) and exemption (`Zwolnienie`) are NOT flags here —
+   * the builder derives them from the lines' own `p12` codes (`oo` / `zw`), so
+   * the header can never contradict the per-line treatment. `exemptionLegalBasis`
+   * supplies the `P_19C` grounds text for the exemption yes-branch.
+   */
+  cashAccounting?: boolean;
+  selfBilling?: boolean;
+  splitPayment?: boolean;
+  triangulation?: boolean;
+  marginScheme?: boolean;
+  exemptionLegalBasis?: string;
   currency: Fa3KodWaluty;
   /**
    * Invoice issue date (`P_1`), ISO-8601 calendar date `YYYY-MM-DD`. Supplied by


### PR DESCRIPTION
## Summary

Part of #1578, addresses #1580 (Adnotacje/margin-scheme half).

`adnotacjeNode()` in the FA(3) builder previously took no arguments and unconditionally emitted every schema-mandated annotation on its negative branch. A VAT-marża reseller got a doubly-wrong document (line taxed at standard rate AND header falsely declaring "no margin scheme"), and any reverse-charge/exempt line produced a header that contradicted its own line-level `P_12` treatment.

## What changed

**Line-derived annotations (agree with the lines by construction):**
- `P_18` (reverse charge / odwrotne obciążenie) = `1` when any effective line carries the `oo` band.
- `Zwolnienie`/`P_19` takes its yes-branch when any line is exempt (`zw`) or an explicit `exemptionLegalBasis` is supplied.

**Operator-declared annotations (no line signal to derive from):**
- New neutral, country-agnostic `InvoiceAnnotations` bag on `IssueInvoiceCommand` (`cashAccounting` → `P_16`, `selfBilling` → `P_17`, `splitPayment` → `P_18A`, `triangulation` → `P_23`, `marginScheme` → `PMarzy`, plus `exemptionLegalBasis`). Threaded through the builder-input mapper; each absent flag defaults to the negative branch. The KSeF adapter maps neutral → FA(3) (ADR-026); no PL vocabulary in `libs/core`.

**XSD yes-branch shapes** (verified against the vendored `schemat_fa3_v1-0e.xsd`): both `Zwolnienie` and `PMarzy` "applies" arms are `choice`/`sequence`s requiring a nested child - `P_19` is followed by one of `P_19A/B/C` (we emit `P_19C`, the open catch-all grounds slot), and `P_PMarzy` by one of `P_PMarzy_2/_3_1/_3_2/_3_3` (we emit `P_PMarzy_3_1`, the used-goods sub-kind - the secondhand e-commerce default). `NoweSrodkiTransportu` stays on its negative branch (out of scope).

**ADR-037** records the neutral annotation-flag vocabulary as an amendment to ADR-026 (append-only; ADR-026 body untouched).

## Tests

Added `Adnotacje classification (#1580)` regression specs in `fa3-xml.builder.spec.ts`: default all-negative still holds, `PMarzy` flips to its yes-branch on `marginScheme`, `Zwolnienie`/`P_19` reflects a `zw` line, `exemptionLegalBasis` reaches `P_19C`, `oo` line sets `P_18`, and each operator flag emits its yes-branch - each validated against `validateFa3Xml` so the nested-child yes-branches stay schema-valid.

## Operator-UI deferrals

No UI yet sets the operator flags - they thread through the command defaulting to the negative branch (documented follow-up). `PMarzy` sub-kind selection (travel/art/collectibles vs used-goods) and the exemption legal-basis picker are follow-ups; a `zw` line with no operator basis emits a descriptive `P_19C` placeholder the operator should refine.

## Quality gate

- `pnpm --filter @openlinker/core build` + `pnpm --filter @openlinker/integrations-ksef build` clean
- builder + mapper specs: 89 passed
- `check-cross-context-imports`, `check-repo-urls`, `check-service-interfaces` all pass
- eslint clean on touched files