### PR TITLE
feat(ksef): foreign-currency PLN/VAT conversion (art. 106e ust. 11) + Art. 108g number surfacing

### DIFF
--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.test.tsx
@@ -61,6 +61,18 @@ describe('KsefInvoiceDetailSection', () => {
     expect(screen.getByText('KSeF: accepted')).toBeInTheDocument();
   });
 
+  it('surfaces the KSeF number as a copyable value with the Art. 108g payment-title hint', () => {
+    renderWithProviders(
+      <KsefInvoiceDetailSection invoice={makeInvoice()} connection={sampleConnection} />,
+    );
+    // Copyable affordance (CopyableId renders a Copy button labelled with the id).
+    expect(
+      screen.getByRole('button', { name: 'Copy 1234567890-20260625-ABCDEF123456-7F' }),
+    ).toBeInTheDocument();
+    // Art. 108g hint present so the operator knows to paste it into the transfer title.
+    expect(screen.getByText(/Art\. 108g/)).toBeInTheDocument();
+  });
+
   it('returns null when there is no KSeF data', () => {
     renderWithProviders(
       <KsefInvoiceDetailSection

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../../features/invoicing';
 import { KsefFa3View } from './ksef-fa3-view';
 import { Button } from '../../../shared/ui/button';
+import { CopyableId } from '../../../shared/ui/copyable-id';
 import {
   Dialog,
   DialogClose,
@@ -168,9 +169,21 @@ export function KsefInvoiceDetailSection({
             <div className="slot-row__hint">
               {t('invoice.ksef.numberHint', 'Authority-assigned on clearance')}
             </div>
+            {/* Art. 108g (transitional from 2026): a bank transfer paying a KSeF
+                invoice must carry this 35-character KSeF number in the payment
+                title. We surface it copyable so the operator/buyer can paste it
+                into the transfer — OpenLinker does not initiate the transfer. */}
+            {ksefNumber ? (
+              <div className="slot-row__hint">
+                {t(
+                  'invoice.ksef.art108gHint',
+                  'Art. 108g: include this KSeF number in the bank-transfer title when paying this invoice.',
+                )}
+              </div>
+            ) : null}
           </div>
           {ksefNumber ? (
-            <span className="mono-text text-sm">{ksefNumber}</span>
+            <CopyableId id={ksefNumber} label={ksefNumber} />
           ) : (
             <span className="text-muted">
               {t('invoice.ksef.numberPending', 'Pending')}

--- a/libs/integrations/ksef/docs/setup-guide.md
+++ b/libs/integrations/ksef/docs/setup-guide.md
@@ -273,8 +273,32 @@ OpenLinker's KSeF support targets outbound issuance + clearance of FA(3)
   vendored authoritative XSD's required-structure rule set (not a full native
   XSD engine — a deliberate constrained-CI decision). Run the MF example-pack /
   test-environment validation as the authoritative gate before production.
-- **Art. 108g payment-title note.** Carrying the KSeF number on the payment
-  title (Art. 108g) is tracked as future work and is not emitted today.
+- **Foreign-currency PLN/VAT conversion (resolved, #1581).** For a non-PLN
+  invoice (art. 106e ust. 11 ustawy o VAT) OpenLinker now additionally emits the
+  VAT amount expressed in PLN per tax band (`P_14_1W`/`P_14_2W`/`P_14_3W`) and the
+  exchange rate (`KursWaluty`) on each line. The rate source is the **National
+  Bank of Poland (NBP) table A average** (`api.nbp.pl`, a public JSON endpoint —
+  no new dependency), resolved for the **last business day preceding the tax
+  point**. *Resolution timing:* the rate is resolved fresh at issue time keyed to
+  the tax point (`saleDate` ?? issue date); a **correction** re-resolves keyed to
+  the **original** document's issue date, so — because NBP historical rates are
+  immutable — it reuses the exact rate the original was issued at (snapshot-
+  equivalent "as-issued" consistency without persisting the rate in country-
+  agnostic core, ADR-026). *Public-holiday caveat (documented MVP):* NBP returns
+  HTTP 404 on any non-publication day, so the client simply walks back one day at
+  a time (up to ~10 days) until it gets a rate — the same mechanism transparently
+  skips weekends **and** Polish public holidays; there is no separate holiday
+  calendar. If no rate can be resolved (NBP unreachable, or an out-of-range date),
+  issuance **fails** rather than emitting a conversion-less document (compliance
+  over availability). PLN invoices are unaffected (no conversion elements emitted).
+- **Art. 108g payment-title (number surfacing, #1581).** Art. 108g (transitional
+  from 2026) requires a bank transfer paying a KSeF invoice to carry the invoice's
+  35-character KSeF number in the payment title. Because KSeF assigns that number
+  only after clearance, OpenLinker surfaces it in a clearly-labeled, **copyable**
+  form on the invoice detail page (with an Art. 108g hint) so the operator/buyer
+  can paste it into the transfer. OpenLinker does **not** initiate bank transfers,
+  so automated payment-title injection is intentionally out of scope for the
+  invoicing adapter.
 - **MF certificate chain-of-trust (operator action for `prod`).** OpenLinker
   verifies each MF public-key certificate against a pinned MF root CA before using
   it to wrap a session secret. The authoritative Ministerstwo Finansow root CA is

--- a/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
+++ b/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
@@ -32,6 +32,7 @@ import { createKsefHttpClient } from '../../infrastructure/http/ksef-http-client
 import { getSharedKsefRateLimiter } from '../../infrastructure/http/ksef-rate-limiter';
 import { KsefSessionCryptoService } from '../../infrastructure/crypto/ksef-session-crypto.service';
 import { Fa3WithValidationBuilder } from '../../infrastructure/fa3/builders/fa3-with-validation.builder';
+import { NbpExchangeRateClient } from '../../infrastructure/fx/nbp-exchange-rate.client';
 import { DEFAULT_FA3_TAX_RATE } from '../../infrastructure/fa3/domain/fa3-tax-rate.mapper';
 import type { Fa3PaymentInput, SellerProfile } from '../../infrastructure/fa3/domain/fa3-xml.types';
 import type { KsefTokenAuthMaterial } from '../../infrastructure/http/auth/ksef-auth-handshake.service';
@@ -81,6 +82,10 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
     // MF public-key cache as the transport) + the FA(3) build/validate pipeline.
     const sessionCrypto = new KsefSessionCryptoService(publicKeyCache);
     const fa3Builder = new Fa3WithValidationBuilder();
+    // NBP exchange-rate resolver (#1581) — used only when a command's currency is
+    // not PLN (art. 106e ust. 11 PLN/VAT conversion). Native-fetch client, no new
+    // npm dependency; a single shared instance is safe (stateless).
+    const exchangeRateResolver = new NbpExchangeRateClient();
 
     return {
       invoicing: new KsefInvoicingAdapter(
@@ -90,7 +95,7 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
         fa3Builder,
         seller,
         defaultTaxRate,
-        { payment, defaultLineUnit },
+        { payment, defaultLineUnit, exchangeRateResolver },
       ),
     };
   }

--- a/libs/integrations/ksef/src/domain/exceptions/ksef-exchange-rate.exception.ts
+++ b/libs/integrations/ksef/src/domain/exceptions/ksef-exchange-rate.exception.ts
@@ -1,0 +1,23 @@
+/**
+ * KSeF Exchange-Rate Exception
+ *
+ * Raised when the NBP average rate required for the art. 106e ust. 11 PLN/VAT
+ * conversion of a foreign-currency invoice cannot be resolved — a network
+ * failure, a non-404 HTTP error, a malformed NBP response, or no rate published
+ * within the walk-back window. Thrown before any KSeF session is opened, so the
+ * core `InvoiceService` marks the record failed rather than emitting a
+ * non-compliant (conversion-less) foreign-currency document — compliance over
+ * availability. Carries only the neutral currency + reason, never buyer PII or
+ * credential material (ADR-026: PL/KSeF specifics stay in this package).
+ *
+ * @module libs/integrations/ksef/src/domain/exceptions
+ */
+export class KsefExchangeRateException extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'KsefExchangeRateException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, KsefExchangeRateException);
+    }
+  }
+}

--- a/libs/integrations/ksef/src/index.ts
+++ b/libs/integrations/ksef/src/index.ts
@@ -58,6 +58,7 @@ export { KsefSessionCryptoException } from './domain/exceptions/ksef-session-cry
 // Online-session business-failure (zero-valid processed session) — surfaced to
 // the host classifier / core InvoiceService as a terminal failure (#1149 / C5).
 export { KsefSessionException } from './domain/exceptions/ksef-session.exception';
+export { KsefExchangeRateException } from './domain/exceptions/ksef-exchange-rate.exception';
 // Unsupported requested document type — a terminal input error (#1149 / C5).
 export { KsefUnsupportedDocumentTypeException } from './domain/exceptions/ksef-unsupported-document-type.exception';
 // documentType <-> correction command-shape mismatch — a terminal input error (#1151 / C7).

--- a/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-invoicing.adapter.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-invoicing.adapter.spec.ts
@@ -35,6 +35,7 @@ import type {
   RawFa3Xml,
   SellerProfile,
 } from '../../fa3/domain/fa3-xml.types';
+import type { NbpExchangeRateResolverPort } from '../../fx/nbp-exchange-rate.types';
 
 const SELLER: SellerProfile = {
   nip: '1234567890',
@@ -838,6 +839,80 @@ describe('KsefInvoicingAdapter', () => {
       await expect(
         adapter(new FakeKsefHttpClient()).getRegulatoryDocument(record(), 'source'),
       ).rejects.toBeInstanceOf(UnsupportedRegulatoryDocumentKindError);
+    });
+  });
+
+  describe('foreign-currency PLN/VAT conversion (art. 106e ust. 11, #1581)', () => {
+    function fakeResolver(): NbpExchangeRateResolverPort & { resolveRate: jest.Mock } {
+      return {
+        resolveRate: jest
+          .fn()
+          .mockResolvedValue({ rate: 4.5, rateDate: '2026-06-22', table: '119/A/NBP/2026' }),
+      };
+    }
+
+    function adapterWithFx(
+      http: FakeKsefHttpClient,
+      builder: IFa3XmlBuilder,
+      resolver: NbpExchangeRateResolverPort,
+    ): KsefInvoicingAdapter {
+      return new KsefInvoicingAdapter('conn-1', http, fakeCrypto(), builder, SELLER, DEFAULT_TAX_RATE, {
+        now: () => new Date('2026-06-23T10:00:00.000Z'),
+        exchangeRateResolver: resolver,
+      });
+    }
+
+    it('should resolve the NBP rate and thread it onto the builder input for a non-PLN invoice', async () => {
+      const http = new FakeKsefHttpClient();
+      seedHappyPath(http);
+      const { builder, lastInput } = capturingBuilder();
+      const resolver = fakeResolver();
+
+      await adapterWithFx(http, builder, resolver).issueInvoice(command({ currency: 'EUR' }));
+
+      // Tax point for a plain invoice with no saleDate = the issue date (now).
+      expect(resolver.resolveRate).toHaveBeenCalledWith('EUR', '2026-06-23');
+      expect(lastInput()?.exchangeRate).toEqual({
+        rate: 4.5,
+        rateDate: '2026-06-22',
+        table: '119/A/NBP/2026',
+      });
+    });
+
+    it('should key the correction rate to the ORIGINAL issue date (immutable historical rate)', async () => {
+      const http = new FakeKsefHttpClient();
+      seedHappyPath(http);
+      const { builder } = capturingBuilder();
+      const resolver = fakeResolver();
+
+      await adapterWithFx(http, builder, resolver).issueInvoice(
+        command({
+          currency: 'EUR',
+          documentType: 'corrected',
+          correction: {
+            originalClearanceReference: null,
+            originalDocumentNumber: 'FV/2026/05/0042',
+            originalIssueDate: '2026-05-01',
+            reason: 'Return',
+            correctedLines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123.0, taxRate: '23' }],
+          },
+        }),
+      );
+
+      // Not the KOR's own issue date (2026-06-23) — the original document's.
+      expect(resolver.resolveRate).toHaveBeenCalledWith('EUR', '2026-05-01');
+    });
+
+    it('should NOT resolve a rate for a PLN invoice', async () => {
+      const http = new FakeKsefHttpClient();
+      seedHappyPath(http);
+      const { builder, lastInput } = capturingBuilder();
+      const resolver = fakeResolver();
+
+      await adapterWithFx(http, builder, resolver).issueInvoice(command({ currency: 'PLN' }));
+
+      expect(resolver.resolveRate).not.toHaveBeenCalled();
+      expect(lastInput()?.exchangeRate).toBeUndefined();
     });
   });
 });

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing-adapter.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing-adapter.types.ts
@@ -11,6 +11,7 @@
  * @see {@link KsefInvoicingAdapter}
  */
 import type { Fa3PaymentInput } from '../fa3/domain/fa3-xml.types';
+import type { NbpExchangeRateResolverPort } from '../fx/nbp-exchange-rate.types';
 
 export interface KsefInvoicingAdapterOptions {
   /**
@@ -27,4 +28,12 @@ export interface KsefInvoicingAdapterOptions {
   defaultLineUnit?: string;
   /** Injected clock so the adapter (and its FA(3) timestamps) stay testable. */
   now?: () => Date;
+  /**
+   * NBP exchange-rate resolver (#1581) for the art. 106e ust. 11 PLN/VAT
+   * conversion of foreign-currency invoices. Injected so specs can fake it;
+   * the factory always wires the concrete {@link NbpExchangeRateClient}. When
+   * absent (bare unit specs), foreign-currency conversion is skipped with a
+   * warning and PLN invoices are unaffected either way.
+   */
+  exchangeRateResolver?: NbpExchangeRateResolverPort;
 }

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
@@ -82,7 +82,8 @@ import type { IKsefHttpClient } from '../http/ksef-http-client.interface';
 import type { KsefSessionCryptoService } from '../crypto/ksef-session-crypto.service';
 import type { SessionCryptoContext } from '../http/ksef-crypto.types';
 import type { IFa3XmlBuilder } from '../fa3/builders/fa3-xml-builder.port';
-import type { Fa3PaymentInput, SellerProfile } from '../fa3/domain/fa3-xml.types';
+import type { Fa3ExchangeRate, Fa3PaymentInput, SellerProfile } from '../fa3/domain/fa3-xml.types';
+import type { NbpExchangeRateResolverPort } from '../fx/nbp-exchange-rate.types';
 import {
   FA3_FORM_CODE,
   FA3_SCHEMA_VERSION,
@@ -138,6 +139,13 @@ export class KsefInvoicingAdapter
   /** Injected clock so the adapter (and its FA(3) timestamps) stay testable. */
   private readonly now: () => Date;
 
+  /**
+   * NBP exchange-rate resolver (#1581) for the art. 106e ust. 11 PLN/VAT
+   * conversion of foreign-currency invoices. `undefined` in bare unit specs;
+   * the factory always wires the concrete client.
+   */
+  private readonly exchangeRateResolver: NbpExchangeRateResolverPort | undefined;
+
   constructor(
     private readonly connectionId: string,
     private readonly httpClient: IKsefHttpClient,
@@ -159,6 +167,7 @@ export class KsefInvoicingAdapter
     this.payment = options.payment;
     this.defaultLineUnit = options.defaultLineUnit;
     this.now = options.now ?? ((): Date => new Date());
+    this.exchangeRateResolver = options.exchangeRateResolver;
   }
 
   async issueInvoice(cmd: IssueInvoiceCommand): Promise<IssueInvoiceResult> {
@@ -198,6 +207,12 @@ export class KsefInvoicingAdapter
     );
     this.warnOnEmptyTaxRateFallback(cmd);
 
+    // Foreign-currency PLN/VAT conversion (art. 106e ust. 11, #1581): resolve the
+    // NBP average rate for the last business day preceding the tax point. Resolved
+    // BEFORE any session opens so a resolution failure fails the record (compliance
+    // over availability) rather than emitting a conversion-less document.
+    const exchangeRate = await this.resolveExchangeRate(cmd, issuedAt);
+
     // 1. neutral → FA(3) (C4). Deterministic build faults throw the mapper's own
     //    typed exceptions; the service maps those to a failed record (no retry).
     const xml = this.fa3Builder.build(
@@ -209,6 +224,7 @@ export class KsefInvoicingAdapter
         defaultTaxRate: this.defaultTaxRate,
         defaultLineUnit: this.defaultLineUnit,
         payment: this.payment,
+        ...(exchangeRate !== undefined ? { exchangeRate } : {}),
       }),
     );
 
@@ -280,6 +296,48 @@ export class KsefInvoicingAdapter
     // Persist the FA(3) source XML as a neutral opaque blob so the core service can
     // re-serve `GET .../document?kind=source` without a KSeF round-trip (#1224 W3).
     return { record, seller: this.toNeutralSeller(), sourceDocument: this.toSourceDocument(xml) };
+  }
+
+  /**
+   * Resolve the foreign-currency exchange rate for the art. 106e ust. 11 PLN/VAT
+   * conversion (#1581). Returns `undefined` for a PLN invoice (no conversion
+   * needed) or when no resolver is wired (bare unit specs).
+   *
+   * RATE TIMING (snapshot-vs-fresh decision): the rate is resolved FRESH at issue
+   * time, keyed to the document's tax point. For a plain invoice the tax point is
+   * `saleDate ?? issueDate`; for a CORRECTION it is deliberately the ORIGINAL
+   * document's issue date, NOT the KOR's own (later) issue date. Because NBP
+   * publishes immutable historical rates, re-resolving a correction against the
+   * original tax point returns the exact same rate the original was issued at —
+   * giving snapshot-equivalent "as issued" consistency (#1297 philosophy) WITHOUT
+   * persisting the rate on the country-agnostic core snapshot (ADR-026 keeps all
+   * NBP/PLN vocabulary inside this package).
+   */
+  private async resolveExchangeRate(
+    cmd: IssueInvoiceCommand,
+    issuedAt: Date,
+  ): Promise<Fa3ExchangeRate | undefined> {
+    const currency = cmd.currency.trim().toUpperCase();
+    if (currency === 'PLN') {
+      return undefined;
+    }
+    if (!this.exchangeRateResolver) {
+      this.logger.warn(
+        `KSeF document (connection ${this.connectionId}, order ${cmd.orderId}) is in ${currency} ` +
+          'but no NBP exchange-rate resolver is wired — skipping the art. 106e ust. 11 PLN/VAT ' +
+          'conversion (KursWaluty / P_14_xW will be absent).',
+      );
+      return undefined;
+    }
+    const taxPoint = cmd.correction
+      ? cmd.correction.originalIssueDate
+      : cmd.saleDate ?? this.toIsoDate(issuedAt);
+    const resolved = await this.exchangeRateResolver.resolveRate(currency, taxPoint);
+    this.logger.log(
+      `Resolved NBP rate ${resolved.rate} for ${currency} (table ${resolved.table}, ` +
+        `${resolved.rateDate}; tax point ${taxPoint}) for connection ${this.connectionId}`,
+    );
+    return { rate: resolved.rate, rateDate: resolved.rateDate, table: resolved.table };
   }
 
   /**

--- a/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.spec.ts
@@ -722,4 +722,75 @@ describe('buildFa3Xml', () => {
       expect(() => validateFa3Xml(buildFa3Xml(input))).not.toThrow();
     });
   });
+
+  describe('foreign-currency PLN/VAT conversion (art. 106e ust. 11, #1581)', () => {
+    function eurMultiBandInput(): Fa3BuilderInput {
+      return {
+        ...b2bInput(),
+        currency: 'EUR',
+        saleDate: '2026-06-20',
+        lines: [
+          { name: 'Standard widget', quantity: 1, unitPriceGross: 123.0, p12: '23' },
+          { name: 'Reduced book', quantity: 2, unitPriceGross: 54.0, p12: '8' },
+          { name: 'Super-reduced food', quantity: 1, unitPriceGross: 21.0, p12: '5' },
+        ],
+        exchangeRate: { rate: 4.321, rateDate: '2026-06-19', table: '117/A/NBP/2026' },
+      };
+    }
+
+    it('should emit KursWaluty (4dp) on every FaWiersz line for a non-PLN invoice', () => {
+      const xml = buildFa3Xml(eurMultiBandInput());
+      // 3 lines → 3 KursWaluty elements, each the resolved NBP rate at 4dp.
+      expect(xml.match(/<KursWaluty>4\.3210<\/KursWaluty>/g)?.length).toBe(3);
+    });
+
+    it('should emit the per-band PLN-converted VAT amounts (P_14_xW)', () => {
+      const xml = buildFa3Xml(eurMultiBandInput());
+      // 23%: VAT 23.00 EUR × 4.3210 = 99.383 → 99.38 PLN
+      expect(xml).toContain('<P_14_1>23.00</P_14_1><P_14_1W>99.38</P_14_1W>');
+      // 8%: VAT 8.00 EUR × 4.3210 = 34.568 → 34.57 PLN
+      expect(xml).toContain('<P_14_2>8.00</P_14_2><P_14_2W>34.57</P_14_2W>');
+      // 5%: VAT 1.00 EUR × 4.3210 = 4.321 → 4.32 PLN
+      expect(xml).toContain('<P_14_3>1.00</P_14_3><P_14_3W>4.32</P_14_3W>');
+    });
+
+    it('should place each P_14_xW immediately after its P_14_x (XSD band order)', () => {
+      const xml = buildFa3Xml(eurMultiBandInput());
+      expect(xml).toMatch(
+        /<P_13_1>[^<]*<\/P_13_1><P_14_1>[^<]*<\/P_14_1><P_14_1W>[^<]*<\/P_14_1W>/,
+      );
+    });
+
+    it('should pass the structural FA(3) validator for a multi-band non-PLN invoice', () => {
+      expect(() => validateFa3Xml(buildFa3Xml(eurMultiBandInput()))).not.toThrow();
+    });
+
+    it('should emit KursWaluty + P_14_xW on a foreign-currency correction (converted difference)', () => {
+      const input = eurMultiBandInput();
+      input.correction = {
+        typKorekty: '2',
+        reason: 'Return',
+        originalIssueDate: '2026-06-20',
+        originalInvoiceNumber: 'FV/2026/06/0001',
+        originalKsefNumber: null,
+        // After: the 23% line quantity drops to 0 (full return of that line).
+        correctedLines: [
+          { name: 'Standard widget', quantity: 0, unitPriceGross: 123.0, p12: '23' },
+          { name: 'Reduced book', quantity: 2, unitPriceGross: 54.0, p12: '8' },
+          { name: 'Super-reduced food', quantity: 1, unitPriceGross: 21.0, p12: '5' },
+        ],
+      };
+      const xml = buildFa3Xml(input);
+      // 23% band VAT difference: 0 − 23.00 = −23.00 EUR × 4.3210 = −99.38 PLN.
+      expect(xml).toContain('<P_14_1>-23.00</P_14_1><P_14_1W>-99.38</P_14_1W>');
+      expect(xml).toContain('<KursWaluty>4.3210</KursWaluty>');
+      expect(() => validateFa3Xml(xml)).not.toThrow();
+    });
+
+    it('should NOT emit KursWaluty or P_14_xW for a PLN invoice', () => {
+      const xml = buildFa3Xml(b2bInput());
+      expect(xml).not.toContain('<KursWaluty>');
+      expect(xml).not.toContain('P_14_1W');
+    });
+  });
 });

--- a/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.ts
@@ -34,6 +34,7 @@ import {
   type Fa3BankAccount,
   type Fa3BuilderInput,
   type Fa3CorrectionContext,
+  type Fa3ExchangeRate,
   type Fa3Line,
   type Fa3PaymentInput,
   type RawFa3Xml,
@@ -118,6 +119,17 @@ function money(value: number): string {
 }
 
 /**
+ * Render an exchange rate (`KursWaluty`, type `TIlosci` — decimal, ≤6 fraction
+ * digits). NBP table-A rates are published to 4 decimal places, so 4dp is the
+ * exact source precision and stays comfortably inside `TIlosci`'s 6-digit
+ * fraction limit. The `TIlosci` pattern rejects `-0`; a resolved NBP rate is
+ * always positive so no `-0` normalisation is needed here (unlike `money`).
+ */
+function rate(value: number): string {
+  return value.toFixed(4);
+}
+
+/**
  * Per-line net (`P_11` = "wartość sprzedaży NETTO"). For a positive-rate band
  * the gross line is divided out (`net = gross / (1 + rate)`); zero-rate / exempt
  * / reverse-charge bands carry net = gross (no embedded VAT). This is the single
@@ -188,7 +200,12 @@ function buyerIdentificationNode(buyer: BuyerIdentity): XmlNodeObject {
  * "before" rows carry `StanPrzed=1` (the FA(3) before/after correction model);
  * a plain invoice and the KOR "after" rows omit it.
  */
-function lineNode(line: Fa3Line, ordinal: number, stanPrzed = false): XmlNodeObject {
+function lineNode(
+  line: Fa3Line,
+  ordinal: number,
+  stanPrzed = false,
+  exchangeRate?: Fa3ExchangeRate,
+): XmlNodeObject {
   const node: XmlNodeObject = {
     NrWierszaFa: ordinal,
     P_7: line.name,
@@ -214,6 +231,13 @@ function lineNode(line: Fa3Line, ordinal: number, stanPrzed = false): XmlNodeObj
     P_11: money(lineNet(line)),
     P_12: line.p12,
   };
+  // KursWaluty (per-line dział-VI conversion rate, art. 106e ust. 11) sits after
+  // P_12 and before StanPrzed (XSD FaWiersz sequence). Emitted only for a
+  // foreign-currency invoice; the same single invoice-level rate is stamped on
+  // every line (#1581).
+  if (exchangeRate !== undefined) {
+    node.KursWaluty = rate(exchangeRate.rate);
+  }
   if (stanPrzed) {
     node.StanPrzed = 1;
   }
@@ -259,7 +283,10 @@ function aggregateBands(lines: Fa3Line[]): BandAggregate {
  * by *either* side of a correction (so a band reduced to zero by the correction
  * still surfaces its zero/negative difference).
  */
-function formatTotals(agg: BandAggregate): { bands: XmlNodeObject; grandTotal: string } {
+function formatTotals(
+  agg: BandAggregate,
+  exchangeRate?: Fa3ExchangeRate,
+): { bands: XmlNodeObject; grandTotal: string } {
   const bands: XmlNodeObject = {};
   for (const p12 of BAND_EMIT_ORDER) {
     const net = agg.netByBand.get(p12);
@@ -269,7 +296,16 @@ function formatTotals(agg: BandAggregate): { bands: XmlNodeObject; grandTotal: s
     const target = VAT_BANDS[p12];
     bands[target.net] = money(net);
     if (target.vat !== undefined) {
-      bands[target.vat] = money(agg.vatByBand.get(p12) ?? 0);
+      const vat = agg.vatByBand.get(p12) ?? 0;
+      bands[target.vat] = money(vat);
+      // P_14_xW: the same band's VAT expressed in PLN (art. 106e ust. 11), only
+      // for a foreign-currency invoice. Emitted immediately after its P_14_x so
+      // the XSD band sequence (P_13_x, P_14_x, P_14_xW) holds. On a correction
+      // `vat` is already the after−before difference, so the converted amount is
+      // the converted difference (#1581).
+      if (exchangeRate !== undefined) {
+        bands[`${target.vat}W`] = money(vat * exchangeRate.rate);
+      }
     }
   }
   return { bands, grandTotal: money(agg.grandTotal) };
@@ -367,9 +403,9 @@ function correctedInvoiceNode(correction: Fa3CorrectionContext): XmlNodeObject {
  * continuously across both blocks.
  */
 function correctionLineNodes(input: Fa3BuilderInput, correction: Fa3CorrectionContext): XmlNode {
-  const before = input.lines.map((line, idx) => lineNode(line, idx + 1, true));
+  const before = input.lines.map((line, idx) => lineNode(line, idx + 1, true, input.exchangeRate));
   const after = correction.correctedLines.map((line, idx) =>
-    lineNode(line, input.lines.length + idx + 1),
+    lineNode(line, input.lines.length + idx + 1, false, input.exchangeRate),
   );
   return [...before, ...after];
 }
@@ -503,12 +539,13 @@ function faNode(input: Fa3BuilderInput): XmlNodeObject {
             aggregateBands(correction.correctedLines),
             aggregateBands(input.lines),
           ),
+          input.exchangeRate,
         )
-      : formatTotals(aggregateBands(input.lines));
+      : formatTotals(aggregateBands(input.lines), input.exchangeRate);
   const wiersze: XmlNode =
     correction !== undefined
       ? correctionLineNodes(input, correction)
-      : input.lines.map((line, idx) => lineNode(line, idx + 1));
+      : input.lines.map((line, idx) => lineNode(line, idx + 1, false, input.exchangeRate));
 
   const node: XmlNodeObject = {
     KodWaluty: input.currency,

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.ts
@@ -25,6 +25,7 @@ import type {
 import type {
   Fa3BuilderInput,
   Fa3CorrectionContext,
+  Fa3ExchangeRate,
   Fa3Line,
   Fa3PaymentInput,
   SellerProfile,
@@ -73,6 +74,13 @@ export interface Fa3MappingContext {
    * `Platnosc` entirely.
    */
   payment?: Fa3PaymentInput;
+  /**
+   * Resolved foreign-currency exchange rate (#1581) — supplied by the adapter
+   * ONLY when the command currency is not PLN (the adapter resolves the NBP
+   * table-A average for the last business day preceding the tax point). Absent
+   * for PLN invoices; forwarded verbatim so the mapper stays pure.
+   */
+  exchangeRate?: Fa3ExchangeRate;
 }
 
 /**
@@ -118,6 +126,7 @@ export function mapToFa3BuilderInput(
       ? { correction: mapCorrection(cmd.correction, context) }
       : {}),
     ...(context.payment !== undefined ? { payment: context.payment } : {}),
+    ...(context.exchangeRate !== undefined ? { exchangeRate: context.exchangeRate } : {}),
   };
 }
 

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-xml.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-xml.types.ts
@@ -208,7 +208,9 @@ export const FA3_RACHUNEK_BANKOWY_CHILD_ORDER = [
  * restricted to the elements the builder can emit (#1525 review). Notably `P_6`
  * (the optional sale-date choice) sits between `P_2` and the `P_13_x`/`P_14_x`
  * band aggregates - a position regression fails the local validator instead of
- * KSeF clearance. Same flat first-occurrence caveat as the other order lists:
+ * KSeF clearance. Each foreign-currency PLN-converted VAT element (`P_14_xW`,
+ * art. 106e ust. 11, #1581) sits immediately after its own `P_14_x` inside the
+ * same band sequence. Same flat first-occurrence caveat as the other order lists:
  * none of these names may also occur nested inside another listed element's
  * subtree (true for the builder's output - FaWiersz children are `P_7`/`P_8A`/
  * `P_8B`/`P_9A`/`P_11`/`P_12`, disjoint from this list).
@@ -220,10 +222,13 @@ export const FA3_FA_CHILD_ORDER = [
   'P_6',
   'P_13_1',
   'P_14_1',
+  'P_14_1W',
   'P_13_2',
   'P_14_2',
+  'P_14_2W',
   'P_13_3',
   'P_14_3',
+  'P_14_3W',
   'P_13_6_1',
   'P_13_6_2',
   'P_13_6_3',
@@ -245,8 +250,9 @@ export const FA3_FA_CHILD_ORDER = [
  * XSD-mandated child order of the `FaWiersz` sequence (FA(3) v1-0E, XSD line
  * ~3080), restricted to the elements the builder can emit (#1525). Notably
  * `P_8A` (unit of measure) comes immediately before `P_8B` (quantity), and
- * `P_9A` (net unit price) immediately after `P_8B`; the `StanPrzed` KOR flag
- * closes the sequence. Absent optional elements are simply skipped.
+ * `P_9A` (net unit price) immediately after `P_8B`; the per-line foreign-currency rate `KursWaluty`
+ * (art. 106e ust. 11 / dział VI, #1581) sits after `P_12`, and the `StanPrzed`
+ * KOR flag closes the sequence. Absent optional elements are simply skipped.
  */
 export const FA3_FA_WIERSZ_CHILD_ORDER = [
   'NrWierszaFa',
@@ -256,8 +262,24 @@ export const FA3_FA_WIERSZ_CHILD_ORDER = [
   'P_9A',
   'P_11',
   'P_12',
+  'KursWaluty',
   'StanPrzed',
 ] as const;
+
+/**
+ * Resolved foreign-currency exchange rate for the art. 106e ust. 11 PLN/VAT
+ * conversion (#1581). Present on {@link Fa3BuilderInput} ONLY when the invoice
+ * currency is not PLN; the adapter resolves it (NBP table-A average for the last
+ * business day preceding the tax point) and threads it through the mapper. The
+ * builder then emits `KursWaluty` on each `FaWiersz` line and the PLN-converted
+ * VAT amounts `P_14_xW` in the tax-summary band section. `rate` is PLN per 1 unit
+ * of the invoice currency; `rateDate`/`table` are carried for audit only.
+ */
+export interface Fa3ExchangeRate {
+  rate: number;
+  rateDate: string;
+  table: string;
+}
 
 /**
  * Fully-mapped builder input. The adapter produces this from a neutral
@@ -332,6 +354,13 @@ export interface Fa3BuilderInput {
    * in that case, so existing connections keep byte-identical output.
    */
   payment?: Fa3PaymentInput;
+  /**
+   * Resolved foreign-currency exchange rate (#1581). Present ONLY for a non-PLN
+   * invoice; when set the builder emits `KursWaluty` per line and the
+   * PLN-converted VAT `P_14_xW` band amounts. Absent for PLN invoices, which
+   * keep byte-identical output.
+   */
+  exchangeRate?: Fa3ExchangeRate;
 }
 
 /**

--- a/libs/integrations/ksef/src/infrastructure/fx/__tests__/nbp-exchange-rate.client.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fx/__tests__/nbp-exchange-rate.client.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * NBP Exchange-Rate Client — Unit Specs
+ *
+ * Exercises the weekend/holiday walk-back, the tax-point−1 start rule, response
+ * parsing, and failure modes with an INJECTED fake fetch — never the network.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/fx
+ */
+import { KsefExchangeRateException } from '../../../domain/exceptions/ksef-exchange-rate.exception';
+import { NbpExchangeRateClient } from '../nbp-exchange-rate.client';
+import type { NbpFetch, NbpFetchResponse } from '../nbp-exchange-rate.types';
+
+/** A 200 response carrying one NBP table-A rate row. */
+function ok(mid: number, effectiveDate: string, no = '047/A/NBP/2026'): NbpFetchResponse {
+  return {
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({ table: 'A', currency: 'euro', code: 'EUR', rates: [{ no, effectiveDate, mid }] }),
+  };
+}
+
+/** A 404 (non-publication day). */
+function notFound(): NbpFetchResponse {
+  return { ok: false, status: 404, json: () => Promise.resolve({}) };
+}
+
+/** Extract the `YYYY-MM-DD` date segment from a requested NBP URL. */
+function dateOf(url: string): string {
+  const match = url.match(/\/a\/[a-z]+\/(\d{4}-\d{2}-\d{2})\//);
+  if (!match) {
+    throw new Error(`unexpected NBP url: ${url}`);
+  }
+  return match[1];
+}
+
+describe('NbpExchangeRateClient', () => {
+  it('should query the day before the tax point and return the parsed rate', async () => {
+    const seen: string[] = [];
+    const fetchImpl: NbpFetch = (url) => {
+      seen.push(url);
+      return Promise.resolve(ok(4.321, '2026-03-10'));
+    };
+    const client = new NbpExchangeRateClient({ fetchImpl });
+
+    const result = await client.resolveRate('EUR', '2026-03-11');
+
+    expect(result).toEqual({ rate: 4.321, rateDate: '2026-03-10', table: '047/A/NBP/2026' });
+    // Tax point 2026-03-11 → first lookup is the preceding day 2026-03-10.
+    expect(dateOf(seen[0])).toBe('2026-03-10');
+    expect(seen[0]).toContain('/a/eur/');
+    expect(seen[0]).toContain('format=json');
+  });
+
+  it('should walk back across a weekend when NBP 404s the non-publication days', async () => {
+    // Tax point Monday 2026-03-09 → preceding day Sunday 03-08 (404),
+    // Saturday 03-07 (404), Friday 03-06 (published).
+    const seen: string[] = [];
+    const fetchImpl: NbpFetch = (url) => {
+      const date = dateOf(url);
+      seen.push(date);
+      if (date === '2026-03-06') {
+        return Promise.resolve(ok(4.3, '2026-03-06'));
+      }
+      return Promise.resolve(notFound());
+    };
+    const client = new NbpExchangeRateClient({ fetchImpl });
+
+    const result = await client.resolveRate('EUR', '2026-03-09');
+
+    expect(result.rate).toBe(4.3);
+    expect(result.rateDate).toBe('2026-03-06');
+    expect(seen).toEqual(['2026-03-08', '2026-03-07', '2026-03-06']);
+  });
+
+  it('should walk back across a multi-day holiday cluster (also 404s, same mechanism)', async () => {
+    // Simulate a long holiday gap: only 2025-12-24 is published; 12-25..01-01 404.
+    const fetchImpl: NbpFetch = (url) => {
+      const date = dateOf(url);
+      return Promise.resolve(date === '2025-12-24' ? ok(4.25, '2025-12-24') : notFound());
+    };
+    const client = new NbpExchangeRateClient({ fetchImpl });
+
+    const result = await client.resolveRate('EUR', '2026-01-02');
+
+    expect(result.rateDate).toBe('2025-12-24');
+  });
+
+  it('should throw when no rate is published within the look-back window', async () => {
+    const fetchImpl: NbpFetch = () => Promise.resolve(notFound());
+    const client = new NbpExchangeRateClient({ fetchImpl, maxLookbackDays: 3 });
+
+    await expect(client.resolveRate('EUR', '2026-03-11')).rejects.toBeInstanceOf(
+      KsefExchangeRateException,
+    );
+  });
+
+  it('should throw on a non-404 HTTP error', async () => {
+    const fetchImpl: NbpFetch = () =>
+      Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) });
+    const client = new NbpExchangeRateClient({ fetchImpl });
+
+    await expect(client.resolveRate('EUR', '2026-03-11')).rejects.toBeInstanceOf(
+      KsefExchangeRateException,
+    );
+  });
+
+  it('should throw on a network failure from fetch', async () => {
+    const fetchImpl: NbpFetch = () => Promise.reject(new Error('ECONNRESET'));
+    const client = new NbpExchangeRateClient({ fetchImpl });
+
+    await expect(client.resolveRate('EUR', '2026-03-11')).rejects.toBeInstanceOf(
+      KsefExchangeRateException,
+    );
+  });
+
+  it('should throw on a malformed / non-positive rate payload', async () => {
+    const fetchImpl: NbpFetch = () =>
+      Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ rates: [{ mid: 0 }] }) });
+    const client = new NbpExchangeRateClient({ fetchImpl });
+
+    await expect(client.resolveRate('EUR', '2026-03-11')).rejects.toBeInstanceOf(
+      KsefExchangeRateException,
+    );
+  });
+
+  it('should reject a non-ISO tax point date', async () => {
+    const fetchImpl: NbpFetch = () => Promise.resolve(ok(4.3, '2026-03-10'));
+    const client = new NbpExchangeRateClient({ fetchImpl });
+
+    await expect(client.resolveRate('EUR', '11/03/2026')).rejects.toBeInstanceOf(
+      KsefExchangeRateException,
+    );
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/fx/nbp-exchange-rate.client.ts
+++ b/libs/integrations/ksef/src/infrastructure/fx/nbp-exchange-rate.client.ts
@@ -1,0 +1,176 @@
+/**
+ * NBP Exchange-Rate Client
+ *
+ * Resolves the National Bank of Poland (NBP) table-A average rate for a
+ * foreign currency on the last business day PRECEDING a tax point, satisfying
+ * art. 106e ust. 11 ustawy o VAT (a foreign-currency invoice must additionally
+ * express the VAT amount in PLN at that rate). Uses the public NBP JSON endpoint
+ * (`https://api.nbp.pl/api/exchangerates/rates/a/{code}/{date}/?format=json`)
+ * via native `fetch` — NO new npm dependency, mirroring the `KsefHttpClient` /
+ * `AllegroHttpClient` native-fetch precedent (no axios, no SDK).
+ *
+ * WEEKEND / HOLIDAY WALK-BACK: NBP publishes rates only on business days and
+ * returns HTTP 404 for any non-publication date. The client starts at
+ * `(taxPoint − 1 day)` and walks back one day at a time until it gets a 200,
+ * up to {@link NBP_MAX_LOOKBACK_DAYS}. Because NBP 404s weekends AND public
+ * holidays identically, the single walk-back covers both — there is no separate
+ * Polish holiday calendar (the accepted, documented MVP mechanism).
+ *
+ * TESTABILITY: `fetch` is injected (defaults to a timeout-wrapped global
+ * `fetch`) so specs exercise the walk-back with a fake and never hit the
+ * network. Time-independent: the search date is derived from the passed
+ * `taxPointDate`, so no clock is needed.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/fx
+ * @implements {NbpExchangeRateResolverPort}
+ */
+import { Logger } from '@openlinker/shared/logging';
+import { KsefExchangeRateException } from '../../domain/exceptions/ksef-exchange-rate.exception';
+import {
+  NBP_MAX_LOOKBACK_DAYS,
+  NBP_REQUEST_TIMEOUT_MS,
+  NBP_TABLE_A_BASE,
+  type NbpExchangeRateResolverPort,
+  type NbpFetch,
+  type NbpResolvedRate,
+} from './nbp-exchange-rate.types';
+
+/** One NBP table-A rate row (subset of the documented JSON response we read). */
+interface NbpRateRow {
+  no?: unknown;
+  effectiveDate?: unknown;
+  mid?: unknown;
+}
+
+/** The NBP table-A single-currency response envelope (subset). */
+interface NbpRatesResponse {
+  rates?: unknown;
+}
+
+export interface NbpExchangeRateClientOptions {
+  /** Injected `fetch` (specs); defaults to a timeout-wrapped global `fetch`. */
+  fetchImpl?: NbpFetch;
+  /** Override the walk-back window (specs); defaults to {@link NBP_MAX_LOOKBACK_DAYS}. */
+  maxLookbackDays?: number;
+}
+
+export class NbpExchangeRateClient implements NbpExchangeRateResolverPort {
+  private readonly logger = new Logger(NbpExchangeRateClient.name);
+  private readonly fetchImpl: NbpFetch;
+  private readonly maxLookbackDays: number;
+
+  constructor(options: NbpExchangeRateClientOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? defaultNbpFetch;
+    this.maxLookbackDays = options.maxLookbackDays ?? NBP_MAX_LOOKBACK_DAYS;
+  }
+
+  async resolveRate(currencyCode: string, taxPointDate: string): Promise<NbpResolvedRate> {
+    const code = currencyCode.trim().toLowerCase();
+    if (code.length === 0) {
+      throw new KsefExchangeRateException('NBP rate lookup requires a non-empty currency code');
+    }
+    const taxPoint = parseIsoDate(taxPointDate);
+    if (taxPoint === null) {
+      throw new KsefExchangeRateException(
+        `NBP rate lookup requires an ISO YYYY-MM-DD tax point, got "${taxPointDate}"`,
+      );
+    }
+
+    // Art. 106e ust. 11: last business day PRECEDING the tax point → start the
+    // day before and walk back over weekends/holidays (which NBP 404s).
+    let cursor = addUtcDays(taxPoint, -1);
+    for (let attempt = 0; attempt < this.maxLookbackDays; attempt++) {
+      const dateStr = toIsoDate(cursor);
+      const url = `${NBP_TABLE_A_BASE}/${encodeURIComponent(code)}/${dateStr}/?format=json`;
+
+      let response;
+      try {
+        response = await this.fetchImpl(url);
+      } catch (error) {
+        throw new KsefExchangeRateException(
+          `NBP rate lookup failed (network) for ${code.toUpperCase()} at ${dateStr}: ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      if (response.status === 404) {
+        // Non-publication day (weekend or holiday) — step back one day.
+        cursor = addUtcDays(cursor, -1);
+        continue;
+      }
+      if (!response.ok) {
+        throw new KsefExchangeRateException(
+          `NBP rate lookup returned HTTP ${response.status} for ${code.toUpperCase()} at ${dateStr}`,
+        );
+      }
+
+      const body = (await response.json()) as NbpRatesResponse;
+      const resolved = parseNbpRate(body);
+      if (resolved === null) {
+        throw new KsefExchangeRateException(
+          `NBP rate response for ${code.toUpperCase()} at ${dateStr} was malformed or non-positive`,
+        );
+      }
+      this.logger.debug(
+        `Resolved NBP rate for ${code.toUpperCase()}: ${resolved.rate} (table ${resolved.table}, ${resolved.rateDate})`,
+      );
+      return resolved;
+    }
+
+    throw new KsefExchangeRateException(
+      `No NBP table-A rate published for ${code.toUpperCase()} within ${this.maxLookbackDays} ` +
+        `day(s) before ${taxPointDate}`,
+    );
+  }
+}
+
+/** Parse the first NBP rate row into a validated {@link NbpResolvedRate} (or null). */
+function parseNbpRate(body: NbpRatesResponse): NbpResolvedRate | null {
+  const rows = Array.isArray(body.rates) ? (body.rates as NbpRateRow[]) : [];
+  const row = rows[0];
+  if (!row) {
+    return null;
+  }
+  const rate = typeof row.mid === 'number' ? row.mid : Number(row.mid);
+  const table = typeof row.no === 'string' ? row.no : '';
+  const rateDate = typeof row.effectiveDate === 'string' ? row.effectiveDate : '';
+  if (!Number.isFinite(rate) || rate <= 0 || table.length === 0 || rateDate.length === 0) {
+    return null;
+  }
+  return { rate, rateDate, table };
+}
+
+/** Parse a strict ISO `YYYY-MM-DD` into a UTC-midnight Date, or null. */
+function parseIsoDate(value: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const ms = Date.parse(`${value}T00:00:00Z`);
+  return Number.isNaN(ms) ? null : new Date(ms);
+}
+
+/** Add `days` (may be negative) to a UTC date, returning a new Date. */
+function addUtcDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+/** Render a Date's UTC calendar day as ISO `YYYY-MM-DD`. */
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Production `fetch` wrapper: native `fetch` with an AbortController timeout so a
+ * hung NBP request never stalls issuance indefinitely. Kept module-private; the
+ * client injects a fake in specs.
+ */
+const defaultNbpFetch: NbpFetch = async (url) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), NBP_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    return { ok: response.ok, status: response.status, json: () => response.json() };
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/libs/integrations/ksef/src/infrastructure/fx/nbp-exchange-rate.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/fx/nbp-exchange-rate.types.ts
@@ -1,0 +1,79 @@
+/**
+ * NBP Exchange-Rate Client Types
+ *
+ * Neutral (FA(3)-agnostic) contract for resolving the National Bank of Poland
+ * (NBP) average exchange rate used to satisfy art. 106e ust. 11 ustawy o VAT:
+ * a foreign-currency invoice must additionally express the VAT amount in PLN,
+ * converted at the NBP table-A average rate for the last business day PRECEDING
+ * the tax point. PL/KSeF specifics stay in this package (ADR-026) — no NBP/PLN
+ * vocabulary ever crosses back into `libs/core`.
+ *
+ * The `fetch` implementation is injectable so specs never touch the network.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/fx
+ */
+
+/** NBP table A public rates base URL (public JSON endpoint, no SDK / npm dep). */
+export const NBP_TABLE_A_BASE = 'https://api.nbp.pl/api/exchangerates/rates/a';
+
+/**
+ * How many days to walk back from (tax point − 1 day) looking for a published
+ * rate. NBP returns HTTP 404 on non-publication days (weekends AND public
+ * holidays), so the same walk-back that skips weekends also skips holidays —
+ * there is no separate holiday calendar (documented MVP mechanism). 10 days
+ * comfortably clears the longest Polish holiday cluster (e.g. the Christmas /
+ * New-Year window).
+ */
+export const NBP_MAX_LOOKBACK_DAYS = 10;
+
+/** Default per-request network timeout for the production fetch wrapper. */
+export const NBP_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * A resolved NBP rate. `rateDate` is the NBP publication date actually used
+ * (the walked-back business day, not the tax point), and `table` is the NBP
+ * table reference (`rates[0].no`, e.g. `"047/A/NBP/2026"`) for audit.
+ */
+export interface NbpResolvedRate {
+  /** PLN per 1 unit of the foreign currency (NBP `mid`, > 0). */
+  rate: number;
+  /** Publication date of the rate used, ISO `YYYY-MM-DD`. */
+  rateDate: string;
+  /** NBP table reference (`rates[0].no`). */
+  table: string;
+}
+
+/**
+ * Minimal `fetch` surface the client depends on — a subset of the DOM/undici
+ * `Response`, so the global `fetch` satisfies it directly and a test fake is a
+ * one-liner. Kept intentionally narrow (no headers/body) to keep fakes trivial.
+ */
+export interface NbpFetchResponse {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}
+
+/** Injectable `fetch` shape. Production wires the global `fetch`; specs a fake. */
+export type NbpFetch = (url: string) => Promise<NbpFetchResponse>;
+
+/**
+ * Resolver contract consumed by the KSeF invoicing adapter. Implemented by
+ * {@link NbpExchangeRateClient}; the adapter depends on this interface (not the
+ * concrete class) so it can be faked in unit specs.
+ */
+export interface NbpExchangeRateResolverPort {
+  /**
+   * Resolve the NBP table-A average rate for `currencyCode` (ISO-4217) on the
+   * last publication day on-or-before `(taxPointDate − 1 day)` — i.e. the last
+   * business day PRECEDING the tax point, per art. 106e ust. 11.
+   *
+   * @param currencyCode ISO-4217 code (case-insensitive), e.g. `"EUR"`.
+   * @param taxPointDate ISO `YYYY-MM-DD` — the tax point (moment obowiązku
+   *   podatkowego); the search starts the day before it.
+   * @throws {KsefExchangeRateException} on a network failure, a non-404 HTTP
+   *   error, a malformed response, or when no rate is published within the
+   *   look-back window.
+   */
+  resolveRate(currencyCode: string, taxPointDate: string): Promise<NbpResolvedRate>;
+}


### PR DESCRIPTION
Part of #1578, addresses #1581

## What & why

Two financial/payment-compliance gaps on the issued KSeF document.

### 1. Foreign-currency PLN/VAT conversion (art. 106e ust. 11)
A non-PLN invoice must additionally express the VAT amount in PLN at the NBP average rate for the last business day preceding the tax point. Previously the currency mapper only validated the ISO-4217 code and the builder emitted neither the rate nor the converted amounts.

- **NBP exchange-rate client** (`infrastructure/fx/nbp-exchange-rate.client.ts`): resolves the NBP **table A** average rate; walks back from `tax point - 1 day` over non-publication days (NBP returns 404 on weekends AND holidays, so one walk-back covers both). `fetch` is injected for testability.
- **`Fa3BuilderInput.exchangeRate`** (optional): the adapter populates it **only** for non-PLN invoices.
- **Builder**: emits `KursWaluty` per `FaWiersz` line and per-band PLN-converted VAT `P_14_1W`/`P_14_2W`/`P_14_3W`, in XSD-mandated positions.
- **Rate-timing decision**: resolved **fresh at issue time** keyed to the tax point (`saleDate ?? issueDate`); a **correction** re-resolves keyed to the **original** document's issue date. Because NBP historical rates are immutable, that yields snapshot-equivalent "as-issued" consistency (#1297 philosophy) **without** persisting the rate in country-agnostic core (ADR-026).

### 2. Art. 108g (make the KSeF number obtainable, not automate transfers)
Art. 108g (transitional from 2026) requires a bank transfer paying a KSeF invoice to carry the 35-char KSeF number in the payment title. The KSeF invoice detail page now surfaces the number as a **copyable** value (shared `CopyableId`) with an Art. 108g hint. OpenLinker does not initiate transfers, so automated payment-title injection is intentionally out of scope.

## New external integration

This adds an outbound call to the **NBP public exchange-rate API** (`api.nbp.pl`) as the legally-mandated PLN-conversion rate source (art. 106e ust. 11). It is a public JSON endpoint reached via native `fetch` — **NO new npm dependency** (mirrors the existing `KsefHttpClient`/`AllegroHttpClient` native-fetch pattern). Called only when a command's currency is not PLN. On resolution failure issuance fails (compliance over availability) rather than emitting a conversion-less document.

## XSD element/position decisions
- `P_14_xW` are children of each rate band's sequence (XSD lines ~2510/2530/2550), emitted immediately after the band's own `P_14_x` (`P_13_x, P_14_x, P_14_xW`).
- The only `Fa`-level rate element (`KursWalutyZ`, after `P_15`) is advance-invoice specific, so the per-line `KursWaluty` (XSD line ~3199, "dział VI" conversion rate, after `P_12`, before `StanPrzed`) is the correct home for a plain sale; the single invoice-level rate is stamped on every line.
- `KursWaluty` → `TIlosci` (rendered 4dp, NBP table-A precision); `P_14_xW` → `TKwotowy` (2dp, existing `money()` helper).

## Boundary
All FX logic lives inside the KSeF plugin. No NBP/PLN vocabulary added to `libs/core` (ADR-026). `check-cross-context-imports` passes.

## Tests / gate
- `pnpm --filter @openlinker/integrations-ksef build` — pass.
- Full KSeF unit suite: **33 suites / 444 tests pass** (new NBP client weekend/holiday walk-back with injected fake fetch — no network; multi-band non-PLN builder specs asserting `KursWaluty` + `P_14_xW` validated by `validateFa3Xml`; adapter FX threading + PLN skip + correction-keyed-to-original-date specs).
- `node scripts/check-cross-context-imports.mjs` — pass.
- `eslint` on all touched files — clean.

> ⚠️ FE `pnpm --filter @openlinker/web type-check` / vitest could not be run in this environment: `qrcode-generator` is declared in `apps/web/package.json` but is **absent from the lockfile and the pnpm store** on the epic branch (an untouched QR file, unrelated to this change), which blocks the whole web package's type-check/test load. The FE diff here is minimal (swap a plain span for the existing `CopyableId` + an Art. 108g hint, mirroring the shipped inFakt section) and is type-clean apart from that pre-existing missing-dependency error. The epic owner should run `pnpm install` to lock `qrcode-generator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)