### PR TITLE
feat(ksef): cross-border guard + GTU/Procedura + per-line tax rate (#1586 Phase 2)

### DIFF
--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -226,6 +226,24 @@ export interface InvoiceLine {
    * sources that do. Providers without a unit concept ignore it.
    */
   unit?: string;
+  /**
+   * Opaque per-line goods/services classification code (#1586 Phase 2). Neutral
+   * seam carrying an operator-asserted classification the provider maps onto its
+   * regime's line-level marker (a PL adapter maps it onto the FA(3) `GTU_xx`
+   * enumeration for flagged goods categories - fuel, alcohol, tobacco, certain
+   * electronics, scrap, etc.). Country-agnostic: core never interprets the code,
+   * it forwards it verbatim (ADR-026). Optional - absent means "no line-level
+   * classification", the common case; a provider with no such concept ignores it.
+   */
+  gtuCode?: string;
+  /**
+   * Opaque per-line transaction-procedure marker (#1586 Phase 2). Neutral seam
+   * carrying an operator-asserted procedure code the provider maps onto its
+   * regime's line-level procedure marker (a PL adapter maps it onto the FA(3)
+   * `Procedura` enumeration). Country-agnostic: forwarded verbatim, never
+   * interpreted in core (ADR-026). Optional and omitted when absent.
+   */
+  procedureCode?: string;
 }
 
 /**

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -312,6 +312,10 @@ export class OrderIngestionService implements IOrderIngestionService {
           sku: item.sku,
           name: item.name,
           imageUrl: item.imageUrl,
+          // Genuine per-line tax rate when the source adapter reported one
+          // (#1586 Phase 2); absent leaves the invoicing pipeline's
+          // connection-default fallback in place. Opaque neutral code (ADR-026).
+          taxRate: item.taxRate,
         });
       } else {
         unresolvedRefs.push({ itemId: item.id, reason: result.reason });

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -137,6 +137,17 @@ export interface IncomingOrderItem {
   sku?: string;
 
   /**
+   * Genuine per-line VAT/tax rate as a neutral opaque string code (#1586 Phase
+   * 2, ADR-035) - the same country-agnostic vocabulary as `OrderItem.taxRate`
+   * and `InvoiceLine.taxRate` (e.g. `'23'`, `'8'`, `'5'`, `'0'`). Optional and
+   * source-uniform: absent means the source adapter did not report a per-line
+   * rate, and the invoicing pipeline falls back to the connection-level default.
+   * `OrderIngestionService` forwards it verbatim onto the unified `OrderItem`;
+   * core never interprets the code (ADR-026).
+   */
+  taxRate?: string;
+
+  /**
    * Source-reported display label (e.g. Allegro `lineItem.offer.name`).
    * Optional because not every adapter has it — PrestaShop's order-source
    * doesn't expose a free per-line product name and would need catalog

--- a/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
+++ b/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
@@ -65,6 +65,7 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
     const defaultTaxRate = this.resolveDefaultTaxRate(connection);
     const payment = this.resolvePayment(connection);
     const defaultLineUnit = this.resolveDefaultLineUnit(connection);
+    const allowCrossBorder = this.resolveAllowCrossBorder(connection);
 
     const { httpClient, publicKeyCache } = createKsefHttpClient({
       connectionId: connection.id,
@@ -95,7 +96,7 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
         fa3Builder,
         seller,
         defaultTaxRate,
-        { payment, defaultLineUnit, exchangeRateResolver },
+        { payment, defaultLineUnit, exchangeRateResolver, allowCrossBorder },
       ),
     };
   }
@@ -177,6 +178,17 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
     return typeof lineUnit === 'string' && lineUnit.trim().length > 0
       ? lineUnit.trim()
       : undefined;
+  }
+
+  /**
+   * Resolve the interim cross-border escape hatch (#1586) from
+   * `config.allowCrossBorder`. Defaults to `false` (refuse cross-border sales)
+   * for any connection that has not explicitly opted in - only a literal `true`
+   * enables issuance of a sale to a country other than the seller's own.
+   */
+  private resolveAllowCrossBorder(connection: Connection): boolean {
+    const config = connection.config as Partial<KsefConnectionConfig> | undefined;
+    return config?.allowCrossBorder === true;
   }
 
   /**

--- a/libs/integrations/ksef/src/domain/exceptions/ksef-cross-border-unsupported.exception.ts
+++ b/libs/integrations/ksef/src/domain/exceptions/ksef-cross-border-unsupported.exception.ts
@@ -1,0 +1,41 @@
+/**
+ * KSeF Cross-Border Unsupported Exception
+ *
+ * Thrown before any document build/send when a command's buyer country differs
+ * from the seller's own country and the connection has NOT opted into
+ * cross-border handling (`KsefConnectionConfig.allowCrossBorder`). This is the
+ * interim guard for #1586: OpenLinker does not yet select the correct FA(3) tax
+ * band (WDT / export / `np` / OSS) from the buyer country, so rather than
+ * silently emitting a domestic-rate document for a cross-border sale (a legally
+ * wrong invoice), issuance refuses with an actionable, terminal error. A
+ * deterministic input/config fault - never a transient retry: the core
+ * `InvoiceService` marks the record failed. Extends `Error` directly, matching
+ * the other terminal build-fault exceptions in this package
+ * (`KsefUnsupportedDocumentTypeException`, `Fa3BuildException`).
+ *
+ * The escape hatch (`allowCrossBorder: true`) suppresses the throw for an
+ * operator who asserts they have handled banding out of band; the full
+ * per-order band-selection function is a documented follow-up (see
+ * `FA3_IMPLEMENTATION_NOTES.md`).
+ *
+ * Never carries credential material in its message.
+ *
+ * @module libs/integrations/ksef/src/domain/exceptions
+ */
+export class KsefCrossBorderUnsupportedException extends Error {
+  constructor(
+    public readonly sellerCountry: string,
+    public readonly buyerCountry: string,
+  ) {
+    super(
+      `Cross-border sale (seller ${sellerCountry} -> buyer ${buyerCountry}) cannot be issued: ` +
+        `OpenLinker does not yet select the correct FA(3) tax band from the buyer country and ` +
+        `would otherwise emit a silently-wrong domestic-rate document. Set the connection's ` +
+        `allowCrossBorder flag to issue anyway once you have handled the tax banding out of band.`,
+    );
+    this.name = 'KsefCrossBorderUnsupportedException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, KsefCrossBorderUnsupportedException);
+    }
+  }
+}

--- a/libs/integrations/ksef/src/domain/types/ksef-connection.types.ts
+++ b/libs/integrations/ksef/src/domain/types/ksef-connection.types.ts
@@ -122,6 +122,16 @@ export interface KsefConnectionConfig {
   payment?: KsefPaymentConfig;
   /** Per-line issuance defaults (#1525). Optional. */
   invoiceDefaults?: KsefInvoiceDefaultsConfig;
+  /**
+   * Interim cross-border escape hatch (#1586). When a command's buyer country
+   * differs from the seller's own country, issuance refuses by default (the
+   * pipeline cannot yet select the correct WDT/export/`np`/OSS tax band and
+   * would otherwise emit a silently-wrong domestic-rate document). Setting this
+   * to `true` suppresses that refusal - the operator asserts they have handled
+   * the tax banding out of band. Optional; absent/`false` = refuse cross-border.
+   * Removed once a real per-order band-selection function lands.
+   */
+  allowCrossBorder?: boolean;
 }
 
 /**

--- a/libs/integrations/ksef/src/index.ts
+++ b/libs/integrations/ksef/src/index.ts
@@ -63,6 +63,10 @@ export { KsefExchangeRateException } from './domain/exceptions/ksef-exchange-rat
 export { KsefUnsupportedDocumentTypeException } from './domain/exceptions/ksef-unsupported-document-type.exception';
 // documentType <-> correction command-shape mismatch — a terminal input error (#1151 / C7).
 export { KsefInvalidCorrectionException } from './domain/exceptions/ksef-invalid-correction.exception';
+// Interim cross-border refusal (#1586) — a terminal input/config error: the sale
+// crosses a border the pipeline cannot yet band correctly, unless the connection
+// opted in via `allowCrossBorder`.
+export { KsefCrossBorderUnsupportedException } from './domain/exceptions/ksef-cross-border-unsupported.exception';
 
 // FA(3) build/mapping + structural-validation exceptions (#1148 / C4). Public
 // so the host classifier / persistence layer can pattern-match a deterministic

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing-adapter.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing-adapter.types.ts
@@ -36,4 +36,14 @@ export interface KsefInvoicingAdapterOptions {
    * warning and PLN invoices are unaffected either way.
    */
   exchangeRateResolver?: NbpExchangeRateResolverPort;
+  /**
+   * Interim cross-border escape hatch (#1586). When `true`, issuance skips the
+   * `assertCrossBorderHandled` guard and issues even when the buyer country
+   * differs from the seller country (the operator asserts they have handled tax
+   * banding out of band). Defaults to `false` - cross-border sales are refused
+   * with `KsefCrossBorderUnsupportedException` rather than emitting a
+   * silently-wrong domestic-rate document. Resolved by the factory from
+   * `KsefConnectionConfig.allowCrossBorder`.
+   */
+  allowCrossBorder?: boolean;
 }

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
@@ -90,6 +90,7 @@ import {
   FA3_SYSTEM_CODE,
 } from '../fa3/domain/fa3-xml.types';
 import { mapToFa3BuilderInput } from '../fa3/domain/fa3-builder-input.mapper';
+import { assertCrossBorderHandled } from '../fa3/domain/fa3-cross-border-guard';
 import { KsefNetworkException } from '../../domain/exceptions/ksef-network.exception';
 import { decodeProviderInvoiceId, encodeProviderInvoiceId } from './ksef-provider-invoice-id';
 import { KsefSessionException } from '../../domain/exceptions/ksef-session.exception';
@@ -140,6 +141,12 @@ export class KsefInvoicingAdapter
   private readonly now: () => Date;
 
   /**
+   * Interim cross-border escape hatch (#1586). `true` skips the
+   * `assertCrossBorderHandled` guard; defaults to `false` (refuse cross-border).
+   */
+  private readonly allowCrossBorder: boolean;
+
+  /**
    * NBP exchange-rate resolver (#1581) for the art. 106e ust. 11 PLN/VAT
    * conversion of foreign-currency invoices. `undefined` in bare unit specs;
    * the factory always wires the concrete client.
@@ -168,6 +175,7 @@ export class KsefInvoicingAdapter
     this.defaultLineUnit = options.defaultLineUnit;
     this.now = options.now ?? ((): Date => new Date());
     this.exchangeRateResolver = options.exchangeRateResolver;
+    this.allowCrossBorder = options.allowCrossBorder ?? false;
   }
 
   async issueInvoice(cmd: IssueInvoiceCommand): Promise<IssueInvoiceResult> {
@@ -181,6 +189,18 @@ export class KsefInvoicingAdapter
     // correction, or a correction without the corrected type) would silently emit
     // the wrong document. Assert the two agree, terminally, before any build/send.
     this.assertCorrectionConsistency(cmd);
+    // Interim cross-border guard (#1586): refuse a sale to a country other than
+    // the seller's own before any build/send, unless the connection opted in.
+    // The pipeline cannot yet select the correct WDT/export/`np`/OSS tax band
+    // from the buyer country, so issuing would emit a silently-wrong
+    // domestic-rate document. A terminal fault - the service marks the record
+    // failed (no retry). See FA3_IMPLEMENTATION_NOTES.md for the deferred
+    // per-order band-selection follow-up.
+    assertCrossBorderHandled(
+      this.seller.address.countryIso2,
+      cmd.buyer.address.countryIso2,
+      this.allowCrossBorder,
+    );
 
     const issuedAt = this.now();
     // The FA(3) P_2 document number. Single source for BOTH the XML builder's

--- a/libs/integrations/ksef/src/infrastructure/fa3/FA3_IMPLEMENTATION_NOTES.md
+++ b/libs/integrations/ksef/src/infrastructure/fa3/FA3_IMPLEMENTATION_NOTES.md
@@ -75,10 +75,18 @@ Unknown codes throw `UnmappedTaxRateException` (no silent default).
 > `taxRate` *before* calling `resolveP12` — `resolveP12` itself is unchanged
 > and still throws on a genuinely unmapped non-empty code. This is a flat
 > per-connection default, not a real per-line VAT rate: an order mixing
-> goods at different rates (23%/8%/0%) will mis-tax every line at the
-> connection default until `OrderItem` carries a real per-item tax rate
-> end-to-end — a larger, separate follow-up spanning every order-source
-> adapter, intentionally out of scope for #1290.
+> goods at different rates (23%/8%/0%) mis-taxes every line at the connection
+> default *only when the source adapter did not report per-line rates*.
+>
+> **UPDATE (#1586 Phase 2):** `OrderItem` / `InvoiceLine` now carry an optional
+> neutral per-line `taxRate` (ADR-035), and an order-source adapter that reports
+> a genuine per-line rate populates it end-to-end. **PrestaShop** does so today —
+> `PrestashopOrderSourceAdapter` derives the whole-percent rate from each
+> `order_details` row's tax-inclusive/exclusive unit prices and maps it to the
+> neutral vocabulary. A populated mixed-rate order now produces a correctly-split
+> FA(3) band breakdown. ⏸ Deferred (documented follow-ups): **WooCommerce**
+> (line_items expose only a `taxes`/`tax_class` delta, not a clean per-line rate —
+> left on the flat-default fallback), plus Allegro/Erli.
 
 > **OPEN:** the canonical neutral tax-rate code set (UNCL 5305 vs OpenLinker
 > custom) is being settled upstream; the keys above are provisional and must be
@@ -228,7 +236,12 @@ the seller's KSeF certificate private key. OpenLinker always issues online
   (`1` = effects in the period of the original, `3` = on terms set by separate
   regulations) are not yet caller-selectable; the neutral `CorrectionReference`
   carries no `typKorekty` field. Deferred until a caller needs a non-default variant.
-- ⏸ Per-line GTU / Procedura codes (not in the neutral `InvoiceLine`; sourcing TBD).
+- ✅ Per-line GTU / Procedura codes (#1586 Phase 2): the neutral `InvoiceLine`
+  now carries optional opaque `gtuCode` / `procedureCode`, threaded through
+  `Fa3Line` and emitted as `FaWiersz/GTU` (`TGTU` enum) + `FaWiersz/Procedura`
+  (`TOznaczenieProcedury`), positioned after `P_12` and before `KursWaluty`
+  per the XSD, omitted when absent. ⏸ Deferred: a category→GTU
+  operator-configurable mapping UI (codes must be supplied on the command today).
 - ⏸ `Podmiot2` `JST` / `GV` flags are hard-coded to `2` ("no") in `buyerNode`.
   Both elements are required by the XSD, and `2` is correct for the common
   buyer — but a buyer that actually *is* a local-government (JST) subsidiary
@@ -247,5 +260,12 @@ the seller's KSeF certificate private key. OpenLinker always issues online
   bounded (ciphertext travels only over TLS to MF; the FA(3) header prefix is
   public structure) and cannot be fixed client-side without breaking
   server-side decryption (the observed status-430 rejection of per-document IVs).
+- ⏸ Cross-border tax-band SELECTION (#1586): an interim guard
+  (`fa3-cross-border-guard.ts`) now REFUSES a sale whose buyer country differs
+  from the seller's own country (throwing `KsefCrossBorderUnsupportedException`
+  before build/send) unless the connection sets `allowCrossBorder`. The full
+  per-order band-selection function (choose WDT / export / `np I`/`np II` / OSS
+  from the buyer country + EU membership) is the deferred follow-up that
+  promotes this guard into real banding.
 - ⏸ Money rounding rule + decimal-place contract (to finalise with the builder).
 - ⏸ Emitting OL variant attributes as explicit distinguishing parameters.

--- a/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.spec.ts
@@ -793,4 +793,50 @@ describe('buildFa3Xml', () => {
       expect(xml).not.toContain('P_14_1W');
     });
   });
+  describe('per-line GTU / Procedura markers (#1586)', () => {
+    it('should emit GTU and Procedura on a line when present', () => {
+      const input = b2bInput();
+      input.lines = [
+        { name: 'Flagged goods', quantity: 1, unitPriceGross: 123, p12: '23', gtuCode: 'GTU_01', procedureCode: 'SW' },
+      ];
+      const xml = buildFa3Xml(input);
+      expect(xml).toContain('<GTU>GTU_01</GTU>');
+      expect(xml).toContain('<Procedura>SW</Procedura>');
+    });
+
+    it('should omit GTU and Procedura when absent', () => {
+      const xml = buildFa3Xml(b2bInput());
+      expect(xml).not.toContain('<GTU>');
+      expect(xml).not.toContain('<Procedura>');
+    });
+
+    it('should position GTU/Procedura after P_12 and before KursWaluty (XSD order)', () => {
+      const input = b2bInput();
+      input.currency = 'EUR';
+      input.exchangeRate = { rate: 4.321, rateDate: '2026-06-20', table: 'A/120/2026' };
+      input.lines = [
+        { name: 'Flagged goods', quantity: 1, unitPriceGross: 123, p12: '23', gtuCode: 'GTU_01', procedureCode: 'SW' },
+      ];
+      const xml = buildFa3Xml(input);
+      const p12 = xml.indexOf('<P_12>');
+      const gtu = xml.indexOf('<GTU>');
+      const proc = xml.indexOf('<Procedura>');
+      const kurs = xml.indexOf('<KursWaluty>');
+      expect(p12).toBeLessThan(gtu);
+      expect(gtu).toBeLessThan(proc);
+      expect(proc).toBeLessThan(kurs);
+      // Structural validator agrees the FaWiersz child order is XSD-legal.
+      expect(() => validateFa3Xml(xml)).not.toThrow();
+    });
+
+    it('should keep a validatable document with only GTU set', () => {
+      const input = b2bInput();
+      input.lines = [{ name: 'Widget', quantity: 1, unitPriceGross: 123, p12: '23', gtuCode: 'GTU_07' }];
+      const xml = buildFa3Xml(input);
+      expect(xml).toContain('<GTU>GTU_07</GTU>');
+      expect(xml).not.toContain('<Procedura>');
+      expect(() => validateFa3Xml(xml)).not.toThrow();
+    });
+  });
+
 });

--- a/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.ts
@@ -231,6 +231,16 @@ function lineNode(
     P_11: money(lineNet(line)),
     P_12: line.p12,
   };
+  // GTU / Procedura (per-line goods & procedure markers, #1586) sit after P_12
+  // and before KursWaluty in the FaWiersz sequence (XSD lines ~3189/~3194).
+  // Already precedence-resolved by the mapper (absent = omitted); forwarded as
+  // opaque tokens - an out-of-enum value is caught by KSeF at clearance.
+  if (line.gtuCode !== undefined) {
+    node.GTU = line.gtuCode;
+  }
+  if (line.procedureCode !== undefined) {
+    node.Procedura = line.procedureCode;
+  }
   // KursWaluty (per-line dział-VI conversion rate, art. 106e ust. 11) sits after
   // P_12 and before StanPrzed (XSD FaWiersz sequence). Emitted only for a
   // foreign-currency invoice; the same single invoice-level rate is stamped on

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.spec.ts
@@ -14,6 +14,8 @@ import {
   UnsupportedCountryCodeException,
 } from '../../../domain/exceptions/fa3-builder.exception';
 import { mapToFa3BuilderInput, type Fa3MappingContext } from './fa3-builder-input.mapper';
+import { buildFa3Xml } from '../builders/fa3-xml.builder';
+import { validateFa3Xml } from '../validators/fa3-xsd.validator';
 import type { SellerProfile } from './fa3-xml.types';
 
 const SELLER: SellerProfile = {
@@ -180,5 +182,72 @@ describe('mapToFa3BuilderInput - line unit P_8A precedence (#1525)', () => {
     };
     const result = mapToFa3BuilderInput(cmd, { ...CONTEXT, defaultLineUnit: 'szt.' });
     expect(result.correction?.correctedLines[0].unit).toBe('szt.');
+  });
+});
+
+describe('mapToFa3BuilderInput - per-line GTU / Procedura (#1586)', () => {
+  it('should forward gtuCode and procedureCode onto the mapped line', () => {
+    const cmd = baseCommand('23');
+    cmd.lines = [
+      { name: 'Widget', quantity: 1, unitPriceGross: 100, taxRate: '23', gtuCode: 'GTU_01', procedureCode: 'SW' },
+    ];
+    const result = mapToFa3BuilderInput(cmd, CONTEXT);
+    expect(result.lines[0].gtuCode).toBe('GTU_01');
+    expect(result.lines[0].procedureCode).toBe('SW');
+  });
+
+  it('should omit both when the neutral line carries neither', () => {
+    const result = mapToFa3BuilderInput(baseCommand('23'), CONTEXT);
+    expect('gtuCode' in result.lines[0]).toBe(false);
+    expect('procedureCode' in result.lines[0]).toBe(false);
+  });
+
+  it('should treat empty/whitespace codes as absent (no connection default)', () => {
+    const cmd = baseCommand('23');
+    cmd.lines = [
+      { name: 'Widget', quantity: 1, unitPriceGross: 100, taxRate: '23', gtuCode: '  ', procedureCode: '' },
+    ];
+    const result = mapToFa3BuilderInput(cmd, CONTEXT);
+    expect('gtuCode' in result.lines[0]).toBe(false);
+    expect('procedureCode' in result.lines[0]).toBe(false);
+  });
+
+  it('should forward the codes onto correction lines too', () => {
+    const cmd = baseCommand('23');
+    cmd.correction = {
+      originalClearanceReference: null,
+      originalDocumentNumber: 'FA/2026/06/0001',
+      originalIssueDate: '2026-06-01',
+      reason: 'Return',
+      correctedLines: [
+        { name: 'Widget', quantity: 1, unitPriceGross: 90, taxRate: '23', gtuCode: 'GTU_07' },
+      ],
+    };
+    const result = mapToFa3BuilderInput(cmd, CONTEXT);
+    expect(result.correction?.correctedLines[0].gtuCode).toBe('GTU_07');
+  });
+});
+
+describe('mixed-rate order -> correctly-split FA(3) band breakdown (#1586 acceptance)', () => {
+  it('should flow distinct per-line neutral rates through to the P_13/P_14 band split', () => {
+    const cmd = baseCommand('23');
+    // Two lines at different genuine per-line rates (23% + 8%) - the exact
+    // mixed-rate case that a single flat connection default would mis-tax.
+    cmd.lines = [
+      { name: 'Standard-rate good', quantity: 1, unitPriceGross: 123, taxRate: '23' },
+      { name: 'Reduced-rate good', quantity: 1, unitPriceGross: 108, taxRate: '8' },
+    ];
+    const mapped = mapToFa3BuilderInput(cmd, CONTEXT);
+    // Mapping seam: each line resolves to its OWN P_12, not the connection default.
+    expect(mapped.lines.map((l) => l.p12)).toEqual(['23', '8']);
+
+    const xml = buildFa3Xml(mapped);
+    // 23% line: net 100.00 -> P_13_1, VAT 23.00 -> P_14_1.
+    expect(xml).toContain('<P_13_1>100.00</P_13_1>');
+    expect(xml).toContain('<P_14_1>23.00</P_14_1>');
+    // 8% line: net 100.00 -> P_13_2, VAT 8.00 -> P_14_2.
+    expect(xml).toContain('<P_13_2>100.00</P_13_2>');
+    expect(xml).toContain('<P_14_2>8.00</P_14_2>');
+    expect(() => validateFa3Xml(xml)).not.toThrow();
   });
 });

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.ts
@@ -189,12 +189,19 @@ function mapLine(line: InvoiceLine, context: Fa3MappingContext): Fa3Line {
   // configured default, else the element is omitted (empty/whitespace counts
   // as absent so a hollow value never reaches the wire).
   const unit = line.unit?.trim() || context.defaultLineUnit?.trim() || undefined;
+  // Per-line GTU/Procedura markers (#1586) — opaque neutral codes forwarded
+  // verbatim; empty/whitespace counts as absent so a hollow value never reaches
+  // the wire (mirrors the P_8A precedence above). No connection-level default.
+  const gtuCode = line.gtuCode?.trim() || undefined;
+  const procedureCode = line.procedureCode?.trim() || undefined;
   return {
     name: line.name,
     quantity: line.quantity,
     unitPriceGross: line.unitPriceGross,
     p12: resolveP12(line.taxRate || context.defaultTaxRate),
     ...(unit !== undefined ? { unit } : {}),
+    ...(gtuCode !== undefined ? { gtuCode } : {}),
+    ...(procedureCode !== undefined ? { procedureCode } : {}),
   };
 }
 

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-cross-border-guard.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-cross-border-guard.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * FA(3) Cross-Border Guard — Unit Specs
+ *
+ * Pins the interim #1586 guard: domestic sales pass, cross-border sales are
+ * refused with `KsefCrossBorderUnsupportedException` unless `allowCrossBorder`
+ * is set, and country comparison is case/whitespace-insensitive so a lowercase
+ * source ISO code never trips a false refusal.
+ *
+ * @module libs/integrations/ksef/src/infrastructure/fa3/domain
+ */
+import { assertCrossBorderHandled } from './fa3-cross-border-guard';
+import { KsefCrossBorderUnsupportedException } from '../../../domain/exceptions/ksef-cross-border-unsupported.exception';
+
+describe('assertCrossBorderHandled', () => {
+  it('should pass for a domestic sale (same country)', () => {
+    expect(() => assertCrossBorderHandled('PL', 'PL', false)).not.toThrow();
+  });
+
+  it('should pass domestic regardless of case/whitespace', () => {
+    expect(() => assertCrossBorderHandled('PL', ' pl ', false)).not.toThrow();
+  });
+
+  it('should throw for a cross-border sale when not opted in', () => {
+    expect(() => assertCrossBorderHandled('PL', 'DE', false)).toThrow(
+      KsefCrossBorderUnsupportedException,
+    );
+  });
+
+  it('should carry the seller and buyer countries on the exception', () => {
+    try {
+      assertCrossBorderHandled('PL', 'de', false);
+      fail('expected throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(KsefCrossBorderUnsupportedException);
+      const ex = error as KsefCrossBorderUnsupportedException;
+      expect(ex.sellerCountry).toBe('PL');
+      expect(ex.buyerCountry).toBe('DE');
+    }
+  });
+
+  it('should suppress the throw when the connection opted into cross-border', () => {
+    expect(() => assertCrossBorderHandled('PL', 'DE', true)).not.toThrow();
+  });
+
+  it('should not treat an empty/absent buyer country as cross-border', () => {
+    expect(() => assertCrossBorderHandled('PL', '', false)).not.toThrow();
+  });
+});

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-cross-border-guard.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-cross-border-guard.ts
@@ -1,0 +1,51 @@
+/**
+ * FA(3) Cross-Border Interim Guard
+ *
+ * Refuses issuance of a cross-border sale until OpenLinker can select the
+ * correct FA(3) tax band (WDT / export / `np` / OSS) from the buyer country
+ * (#1586). Today the pipeline applies the connection's domestic default rate to
+ * every line regardless of `buyer.address.countryIso2`; for a sale shipped to a
+ * different country that produces a silently-wrong domestic-rate document. This
+ * pure guard is the interim safety net: when the buyer's country differs from
+ * the seller's own country AND the connection has not opted into cross-border
+ * handling, it throws a clear terminal exception instead. The per-connection
+ * `allowCrossBorder` override suppresses the throw (the operator asserts they
+ * have handled banding out of band).
+ *
+ * Pure and synchronous (no I/O, no clock) - country codes are compared
+ * case-insensitively and trimmed so a lowercase source ISO code and an
+ * uppercase seller-config code never trigger a false cross-border refusal.
+ * The full per-order band-selection function is a documented follow-up
+ * (see FA3_IMPLEMENTATION_NOTES.md).
+ *
+ * @module libs/integrations/ksef/src/infrastructure/fa3/domain
+ */
+import { KsefCrossBorderUnsupportedException } from '../../../domain/exceptions/ksef-cross-border-unsupported.exception';
+
+/**
+ * Assert a sale is either domestic or explicitly opted into cross-border
+ * handling. Throws {@link KsefCrossBorderUnsupportedException} when the buyer
+ * country differs from the seller country and `allowCrossBorder` is not set.
+ *
+ * @param sellerCountry Seller's own ISO 3166-1 alpha-2 country (Podmiot1).
+ * @param buyerCountry  Buyer's ISO 3166-1 alpha-2 country (from the command).
+ * @param allowCrossBorder Interim escape hatch - `true` suppresses the throw.
+ */
+export function assertCrossBorderHandled(
+  sellerCountry: string,
+  buyerCountry: string,
+  allowCrossBorder: boolean,
+): void {
+  if (allowCrossBorder) {
+    return;
+  }
+  const seller = sellerCountry.trim().toUpperCase();
+  const buyer = buyerCountry.trim().toUpperCase();
+  // An empty/absent buyer country is not a cross-border signal on its own - the
+  // downstream KodKraju resolver already rejects a genuinely-invalid code. Only
+  // a present, different country trips the guard.
+  if (buyer.length === 0 || buyer === seller) {
+    return;
+  }
+  throw new KsefCrossBorderUnsupportedException(seller, buyer);
+}

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-xml.types.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-xml.types.ts
@@ -97,6 +97,21 @@ export interface Fa3Line {
    * connection's `invoiceDefaults.lineUnit` -> absent (element omitted).
    */
   unit?: string;
+  /**
+   * FA(3) `GTU` goods/services marker (`TGTU` enum: `GTU_01`..`GTU_13`, XSD line
+   * ~1997), sits after `P_12`(+variants) and before `Procedura` in the FaWiersz
+   * sequence (#1586). Opaque here - the builder-input mapper forwards the neutral
+   * `InvoiceLine.gtuCode` verbatim; an out-of-enum value is rejected by KSeF at
+   * clearance (the local validator only pins element order). Omitted when absent.
+   */
+  gtuCode?: string;
+  /**
+   * FA(3) `Procedura` transaction-procedure marker (`TOznaczenieProcedury` enum,
+   * XSD line ~3194), sits after `GTU` and before `KursWaluty` in the FaWiersz
+   * sequence (#1586). Opaque - forwarded verbatim from `InvoiceLine.procedureCode`.
+   * Omitted when absent.
+   */
+  procedureCode?: string;
 }
 
 /**
@@ -250,8 +265,10 @@ export const FA3_FA_CHILD_ORDER = [
  * XSD-mandated child order of the `FaWiersz` sequence (FA(3) v1-0E, XSD line
  * ~3080), restricted to the elements the builder can emit (#1525). Notably
  * `P_8A` (unit of measure) comes immediately before `P_8B` (quantity), and
- * `P_9A` (net unit price) immediately after `P_8B`; the per-line foreign-currency rate `KursWaluty`
- * (art. 106e ust. 11 / dział VI, #1581) sits after `P_12`, and the `StanPrzed`
+ * `P_9A` (net unit price) immediately after `P_8B`; the optional per-line `GTU`
+ * (goods/services marker) and `Procedura` (procedure marker) sit after `P_12`
+ * (#1586), then the per-line foreign-currency rate `KursWaluty`
+ * (art. 106e ust. 11 / dział VI, #1581), and the `StanPrzed`
  * KOR flag closes the sequence. Absent optional elements are simply skipped.
  */
 export const FA3_FA_WIERSZ_CHILD_ORDER = [
@@ -262,6 +279,8 @@ export const FA3_FA_WIERSZ_CHILD_ORDER = [
   'P_9A',
   'P_11',
   'P_12',
+  'GTU',
+  'Procedura',
   'KursWaluty',
   'StanPrzed',
 ] as const;

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
@@ -288,6 +288,85 @@ describe('PrestashopOrderSourceAdapter', () => {
       expect(incoming.items[0].productRef).toEqual({ type: 'product', externalId: '5' });
     });
 
+    it('should derive a genuine per-line taxRate from tax-incl/excl unit prices (#1586)', async () => {
+      const prestashopOrder: PrestashopOrder = {
+        id: '43',
+        reference: 'ORDER-043',
+        id_customer: '7',
+        current_state: '2',
+        total_paid: '231.00',
+        total_paid_tax_incl: '231.00',
+        total_paid_tax_excl: '200.00',
+        total_shipping: '0',
+        date_add: '2024-01-01 10:00:00',
+        date_upd: '2024-01-01 12:00:00',
+      };
+      const orderRows: PrestashopOrderRow[] = [
+        {
+          id: '100',
+          product_id: '5',
+          product_attribute_id: '0',
+          product_quantity: '1',
+          product_price: '100.00',
+          product_reference: 'SKU-5',
+          unit_price_tax_incl: '123.00',
+          unit_price_tax_excl: '100.00',
+        },
+        {
+          id: '101',
+          product_id: '6',
+          product_attribute_id: '0',
+          product_quantity: '1',
+          product_price: '100.00',
+          product_reference: 'SKU-6',
+          unit_price_tax_incl: '108.00',
+          unit_price_tax_excl: '100.00',
+        },
+      ];
+
+      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce(prestashopOrder);
+      mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(orderRows);
+
+      const incoming = await adapter.getOrder({ externalOrderId: '43' });
+
+      // Mixed-rate order: 23% and 8% derived per line from incl/excl.
+      expect(incoming.items[0].taxRate).toBe('23');
+      expect(incoming.items[1].taxRate).toBe('8');
+    });
+
+    it('should omit taxRate when the row lacks tax-incl/excl prices (#1586)', async () => {
+      const prestashopOrder: PrestashopOrder = {
+        id: '44',
+        reference: 'ORDER-044',
+        id_customer: '7',
+        current_state: '2',
+        total_paid: '99.99',
+        total_paid_tax_incl: '99.99',
+        total_paid_tax_excl: '99.99',
+        total_shipping: '0',
+        date_add: '2024-01-01 10:00:00',
+        date_upd: '2024-01-01 12:00:00',
+      };
+      const orderRows: PrestashopOrderRow[] = [
+        {
+          id: '100',
+          product_id: '5',
+          product_attribute_id: '0',
+          product_quantity: '1',
+          product_price: '99.99',
+          product_reference: 'SKU-5',
+        },
+      ];
+
+      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce(prestashopOrder);
+      mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(orderRows);
+
+      const incoming = await adapter.getOrder({ externalOrderId: '44' });
+
+      expect(incoming.items[0].taxRate).toBeUndefined();
+      expect('taxRate' in incoming.items[0]).toBe(false);
+    });
+
     it('should translate a 404 from the webservice client into PrestashopResourceNotFoundException', async () => {
       mockHttpClient.getResource = jest
         .fn()

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
@@ -203,12 +203,20 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
           : row?.product_id
             ? 'product'
             : 'sku';
+      // Genuine per-line VAT rate (#1586 Phase 2): PrestaShop's `order_details`
+      // resource exposes no direct rate percentage, but it does carry the per-row
+      // tax-inclusive/exclusive unit prices, from which the effective whole-percent
+      // rate is derived and mapped to the neutral code vocabulary. Absent/unmatched
+      // leaves `taxRate` undefined so the invoicing pipeline keeps its
+      // connection-default fallback.
+      const taxRate = PrestashopOrderSourceAdapter.deriveNeutralTaxRate(row);
       return {
         id: item.id,
         productRef: { type: refType, externalId },
         quantity: item.quantity,
         price: item.price,
         sku: item.sku,
+        ...(taxRate !== undefined ? { taxRate } : {}),
       };
     });
 
@@ -247,6 +255,39 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
    * (e.g. POZ08A, WAW124, KRK05). Case-insensitive match; result is uppercased.
    */
   private static readonly PACZKOMAT_CODE_RE = /^[A-Z]{3}\d{2,4}[A-Z]?$/i;
+
+  /**
+   * Neutral per-line VAT-rate codes PrestaShop lines can resolve to (#1586
+   * Phase 2) - the whole-percent PL rates, mapped as the opaque neutral string
+   * codes the invoicing pipeline forwards (ADR-026; no country logic in core).
+   * A derived rate outside this set is treated as "unknown" and dropped so a
+   * mis-derived value never silently overrides the connection default.
+   */
+  private static readonly NEUTRAL_TAX_RATE_CODES = new Set(['23', '8', '5', '0']);
+
+  /**
+   * Derive a genuine per-line VAT rate from a PrestaShop `order_details` row's
+   * tax-inclusive/exclusive unit prices and map it to the neutral code
+   * vocabulary. Returns `undefined` when the row lacks usable prices, the net
+   * price is non-positive, or the derived whole-percent rate is not a known PL
+   * rate - in every such case the caller omits `taxRate` and the invoicing
+   * pipeline falls back to the connection-level default.
+   */
+  private static deriveNeutralTaxRate(row: PrestashopOrderRow | undefined): string | undefined {
+    if (!row) {
+      return undefined;
+    }
+    const incl = Number(row.unit_price_tax_incl);
+    const excl = Number(row.unit_price_tax_excl);
+    if (!Number.isFinite(incl) || !Number.isFinite(excl) || excl <= 0) {
+      return undefined;
+    }
+    // Round to the nearest whole percent - PS stores prices at 6dp, so a 23%
+    // line can surface as e.g. 22.9998%; the rate vocabulary is whole-percent.
+    const ratePercent = Math.round(((incl - excl) / excl) * 100);
+    const code = String(ratePercent);
+    return PrestashopOrderSourceAdapter.NEUTRAL_TAX_RATE_CODES.has(code) ? code : undefined;
+  }
 
   /**
    * Returns pickupPoint when the connection declares official_inpost module and

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
@@ -116,6 +116,15 @@ export interface PrestashopOrderRow {
   product_quantity?: string | number;
   product_price?: string | number;
   product_reference?: string;
+  /**
+   * Per-line unit price INCLUDING tax (`ps_order_detail.unit_price_tax_incl`).
+   * Paired with `unit_price_tax_excl` to derive the genuine per-line VAT rate
+   * for `IncomingOrderItem.taxRate` (#1586 Phase 2) - PrestaShop exposes no
+   * direct per-row rate percentage on the `order_details` resource.
+   */
+  unit_price_tax_incl?: string | number;
+  /** Per-line unit price EXCLUDING tax (`ps_order_detail.unit_price_tax_excl`). */
+  unit_price_tax_excl?: string | number;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Part of #1578, addresses #1586 (Phase 2 — completes the issue). Builds on Phase 1's neutral `OrderItem.taxRate` seam (PR #1604 / ADR-035).

## Part A — Cross-border tax-band interim guard
`assertCrossBorderHandled(sellerCountry, buyerCountry, allowCrossBorder)` (pure, case/whitespace-insensitive) throws the terminal `KsefCrossBorderUnsupportedException` when the buyer country differs from the seller country and the connection hasn't opted into cross-border handling — instead of silently emitting the domestic band for a WDT/export/OSS sale. Optional per-connection `allowCrossBorder` override is the interim escape hatch (operator asserts they've handled banding). The guard runs in `issueInvoice` before build/send. Full per-order band selection is a documented follow-up.

## Part B — GTU / Procedura emission (plumbing only)
Neutral opaque `gtuCode?` / `procedureCode?` on `InvoiceLine`, threaded `Fa3Line` → `mapLine` → `lineNode`, emitted as the FA(3) `FaWiersz` `GTU` / `Procedura` elements (positioned after `P_12`, before `KursWaluty`; verified against `schemat_fa3_v1-0e.xsd` and `validateFa3Xml`), omitted when absent. No category→GTU mapping UI — that's an explicitly deferred, separately-scoped follow-up.

## Part C — per-line tax rate populated for PrestaShop (WooCommerce deferred)
`PrestashopOrderSourceAdapter` derives the whole-percent neutral rate from each `order_details` row's tax-incl/tax-excl unit prices, maps to `{23,8,5,0}`, and threads it to `OrderItem.taxRate` (Phase 1 forwards to the invoice line) — so a mixed-rate order produces a correctly-split FA(3) `P_13`/`P_14` breakdown. **WooCommerce/Allegro/Erli deferred** (documented in `FA3_IMPLEMENTATION_NOTES.md`): WC line items expose only a tax delta, not a clean per-line rate percentage.

## Test plan
- [x] `pnpm --filter @openlinker/core build`, `--filter @openlinker/integrations-ksef build`, `--filter @openlinker/integrations-prestashop build` — clean
- [x] Mixed-rate 23%+8% acceptance test proves per-line rates reach the P_13/P_14 band split; GTU/Procedura emission+omission+XSD-order (validateFa3Xml); cross-border guard (domestic pass / cross-border throw / override / empty-country / case-insensitive); PrestaShop derive+omit. 110 KSeF + 30 PrestaShop + 71 core affected tests pass.
- [x] `check-cross-context-imports` + `check-service-interfaces` — conform; ESLint on ~20 touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)