### PR TITLE
fix(invoicing): KSeF correction integrity - reason, rejection detail, buyer override, CAS lease

### DIFF
--- a/apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts
+++ b/apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts
@@ -69,6 +69,14 @@ export class InvoiceRecordResponseDto {
   @ApiProperty({ description: 'Authority-assigned clearance reference', nullable: true })
   clearanceReference!: string | null;
 
+  @ApiProperty({
+    description:
+      'Operator-facing clearance diagnostic (e.g. the authority rejection reason); ' +
+      'null unless a rejection detail was captured (#1582)',
+    nullable: true,
+  })
+  clearanceDetail!: string | null;
+
   @ApiProperty({ description: 'URL of the rendered document PDF', nullable: true })
   pdfUrl!: string | null;
 
@@ -116,6 +124,7 @@ export class InvoiceRecordResponseDto {
     dto.providerInvoiceNumber = record.providerInvoiceNumber;
     dto.regulatoryStatus = record.regulatoryStatus;
     dto.clearanceReference = record.clearanceReference;
+    dto.clearanceDetail = record.clearanceDetail;
     dto.pdfUrl = record.pdfUrl;
     dto.failureMode = record.failureMode;
     dto.failureCode = record.failureCode;

--- a/apps/api/src/invoicing/http/dto/issue-correction-request.dto.spec.ts
+++ b/apps/api/src/invoicing/http/dto/issue-correction-request.dto.spec.ts
@@ -51,4 +51,104 @@ describe('IssueCorrectionRequestDto', () => {
     const nested = errors.flatMap((e) => e.children ?? []);
     expect(JSON.stringify([errors, nested])).toContain('hasCorrectionDelta');
   });
+
+  describe('reason (#1582)', () => {
+    it('should reject a correction with an empty reason', async () => {
+      const dto = plainToInstance(IssueCorrectionRequestDto, {
+        reason: '',
+        lines: [{ originalLineNumber: 1, newQuantity: 2 }],
+      });
+
+      const errors = await validate(dto);
+
+      const reasonError = errors.find((e) => e.property === 'reason');
+      expect(reasonError?.constraints).toHaveProperty('isNotEmpty');
+    });
+
+    it('should reject a correction whose reason is only whitespace (trimmed)', async () => {
+      const dto = plainToInstance(IssueCorrectionRequestDto, {
+        reason: '   ',
+        lines: [{ originalLineNumber: 1, newQuantity: 2 }],
+      });
+
+      const errors = await validate(dto);
+
+      const reasonError = errors.find((e) => e.property === 'reason');
+      expect(reasonError?.constraints).toHaveProperty('isNotEmpty');
+    });
+
+    it('should reject a correction with a missing reason', async () => {
+      const dto = plainToInstance(IssueCorrectionRequestDto, {
+        lines: [{ originalLineNumber: 1, newQuantity: 2 }],
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === 'reason')).toBe(true);
+    });
+
+    it('should trim the reason before it reaches the command', async () => {
+      const dto = plainToInstance(IssueCorrectionRequestDto, {
+        reason: '  wrong NIP  ',
+        lines: [{ originalLineNumber: 1, newQuantity: 2 }],
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.reason).toBe('wrong NIP');
+    });
+  });
+
+  describe('buyerOverride (#1582)', () => {
+    const validBuyer = {
+      name: 'Acme Sp. z o.o.',
+      taxId: { scheme: 'pl-nip', value: '5252248481' },
+      address: {
+        line1: 'ul. Testowa 1',
+        line2: null,
+        city: 'Warszawa',
+        postalCode: '00-001',
+        countryIso2: 'PL',
+      },
+      type: 'company',
+    };
+
+    it('should accept a well-formed buyer override', async () => {
+      const dto = plainToInstance(IssueCorrectionRequestDto, {
+        reason: 'wrong NIP',
+        lines: [{ originalLineNumber: 1, newQuantity: 1 }],
+        buyerOverride: validBuyer,
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject a buyer override with an invalid buyer type', async () => {
+      const dto = plainToInstance(IssueCorrectionRequestDto, {
+        reason: 'wrong NIP',
+        lines: [{ originalLineNumber: 1, newQuantity: 1 }],
+        buyerOverride: { ...validBuyer, type: 'not-a-type' },
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === 'buyerOverride')).toBe(true);
+    });
+
+    it('should reject a buyer override missing the address', async () => {
+      const noAddress = { name: validBuyer.name, taxId: validBuyer.taxId, type: validBuyer.type };
+      const dto = plainToInstance(IssueCorrectionRequestDto, {
+        reason: 'wrong NIP',
+        lines: [{ originalLineNumber: 1, newQuantity: 1 }],
+        buyerOverride: noAddress,
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === 'buyerOverride')).toBe(true);
+    });
+  });
 });

--- a/apps/api/src/invoicing/http/dto/issue-correction-request.dto.ts
+++ b/apps/api/src/invoicing/http/dto/issue-correction-request.dto.ts
@@ -20,10 +20,16 @@ import {
   Min,
   ArrayMinSize,
   Validate,
-  ValidatorConstraint
+  ValidatorConstraint,
+  IsNotEmpty,
+  IsIn,
+  IsBoolean,
+  IsDefined
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Type, Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { BuyerTypeValues } from '@openlinker/core/invoicing';
+import { BuyerTaxIdDto } from './buyer-tax-id.dto';
 
 /**
  * Rejects a correction line that changes neither quantity nor price — a no-op
@@ -90,11 +96,90 @@ class UniqueOriginalLineNumbersConstraint implements ValidatorConstraintInterfac
   }
 }
 
-export class IssueCorrectionRequestDto {
-  @ApiPropertyOptional({ description: 'Free-text reason for correction (e.g. partial return).' })
+/**
+ * Optional buyer-identity override for a correction (#1582). Present only when the
+ * operator is correcting the BUYER on the original document (e.g. a wrong NIP) -
+ * a legally-explicit correction case (art. 106j ust. 1 pkt 5). Neutral: mirrors
+ * the {@link BuyerProfile} shape the mapper already understands. Absent ⇒ the
+ * original document's buyer is reused unchanged.
+ */
+export class CorrectionBuyerAddressDto {
+  @ApiProperty({ description: 'Address line 1' })
   @IsString()
+  @IsNotEmpty()
+  line1!: string;
+
+  @ApiPropertyOptional({ description: 'Address line 2', nullable: true })
   @IsOptional()
-  reason?: string;
+  @IsString()
+  line2?: string | null;
+
+  @ApiProperty({ description: 'City' })
+  @IsString()
+  @IsNotEmpty()
+  city!: string;
+
+  @ApiProperty({ description: 'Postal code' })
+  @IsString()
+  @IsNotEmpty()
+  postalCode!: string;
+
+  @ApiProperty({ description: 'ISO 3166-1 alpha-2 country code' })
+  @IsString()
+  @IsNotEmpty()
+  countryIso2!: string;
+}
+
+export class CorrectionBuyerOverrideDto {
+  @ApiProperty({ description: 'Buyer name' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiPropertyOptional({
+    description: 'Scheme-tagged buyer tax id (e.g. the corrected NIP). Absent for a B2C buyer.',
+    type: BuyerTaxIdDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BuyerTaxIdDto)
+  taxId?: BuyerTaxIdDto;
+
+  @ApiProperty({ type: CorrectionBuyerAddressDto, description: 'Buyer postal address' })
+  @IsDefined()
+  @ValidateNested()
+  @Type(() => CorrectionBuyerAddressDto)
+  address!: CorrectionBuyerAddressDto;
+
+  // Inline literal union (not the imported `BuyerType` alias) so a type-only
+  // import isn't dragged into decorator metadata; kept in lock-step with
+  // `BuyerTypeValues` via the `@IsIn` runtime guard.
+  @ApiProperty({ enum: BuyerTypeValues, description: 'Neutral B2B/B2C axis' })
+  @IsIn(BuyerTypeValues)
+  type!: 'company' | 'private';
+
+  @ApiPropertyOptional({ description: 'Buyer is a public-sector / local-government entity (#1580)' })
+  @IsOptional()
+  @IsBoolean()
+  isPublicSectorEntity?: boolean;
+
+  @ApiPropertyOptional({ description: 'Buyer is a VAT-group member (#1580)' })
+  @IsOptional()
+  @IsBoolean()
+  isVatGroupMember?: boolean;
+}
+
+export class IssueCorrectionRequestDto {
+  @ApiProperty({
+    description:
+      'Free-text reason for the correction (REQUIRED, non-empty; e.g. wrong NIP, ' +
+      'partial return). Legally mandated (art. 106j ust. 2 pkt 5) and required by ' +
+      'the FA(3) XSD (PrzyczynaKorekty minLength=1 when present).',
+  })
+  @IsString()
+  @Transform(({ value }): unknown => (typeof value === 'string' ? value.trim() : value))
+  @IsNotEmpty()
+  reason!: string;
 
   @ApiProperty({ type: [CorrectionLineDto], description: 'Per-line corrections — at least one line must be present.' })
   @IsArray()
@@ -103,6 +188,18 @@ export class IssueCorrectionRequestDto {
   @ValidateNested({ each: true })
   @Type(() => CorrectionLineDto)
   lines!: CorrectionLineDto[];
+
+  @ApiPropertyOptional({
+    description:
+      'Optional buyer-identity override (e.g. a wrong NIP on the original). When ' +
+      'present the correcting document is re-issued with this buyer instead of the ' +
+      "original document's buyer.",
+    type: CorrectionBuyerOverrideDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CorrectionBuyerOverrideDto)
+  buyerOverride?: CorrectionBuyerOverrideDto;
 
   @ApiPropertyOptional({ description: 'Caller-supplied idempotency key for exactly-once issuance.' })
   @IsString()

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -777,6 +777,25 @@ export class InvoicingController {
         })),
         idempotencyKey: dto.idempotencyKey,
         originalDocument,
+        // #1582: optional buyer-identity override (e.g. a wrong NIP on the
+        // original). Re-wrapped into the neutral BuyerProfile the adapter uses
+        // for the KOR; absent ⇒ the original snapshot's buyer is reused.
+        buyerOverride: dto.buyerOverride
+          ? new BuyerProfile(
+              dto.buyerOverride.name,
+              dto.buyerOverride.taxId ?? null,
+              {
+                line1: dto.buyerOverride.address.line1,
+                line2: dto.buyerOverride.address.line2 ?? null,
+                city: dto.buyerOverride.address.city,
+                postalCode: dto.buyerOverride.address.postalCode,
+                countryIso2: dto.buyerOverride.address.countryIso2,
+              },
+              dto.buyerOverride.type,
+              dto.buyerOverride.isPublicSectorEntity,
+              dto.buyerOverride.isVatGroupMember,
+            )
+          : undefined,
       });
     } catch (error) {
       throw this.toHttpException(error);
@@ -1264,6 +1283,7 @@ export class InvoicingController {
       providerInvoiceNumber: record.providerInvoiceNumber,
       regulatoryStatus: record.regulatoryStatus,
       clearanceReference: record.clearanceReference,
+      clearanceDetail: record.clearanceDetail,
       // W1 failure semantics (errorMessage stays omitted — PII).
       failureMode: record.failureMode,
       failureCode: record.failureCode,

--- a/apps/api/src/migrations/1818000000008-add-invoice-clearance-detail.ts
+++ b/apps/api/src/migrations/1818000000008-add-invoice-clearance-detail.ts
@@ -1,0 +1,31 @@
+/**
+ * Add Invoice Clearance Detail Migration
+ *
+ * Adds the nullable `clearanceDetail` text column to `invoice_records` (#1582).
+ * It carries the authority's operator-facing rejection diagnostic (the KSeF
+ * `description`/`details` on a rejected clearance read) so the invoice detail
+ * page can explain WHY a document was rejected, not merely that it was.
+ * Country-agnostic (ADR-026): an opaque free-text blob the adapter fills from
+ * its regime's rejection fields, never interpreted in core. Nullable with no
+ * default - existing rows and non-rejection reads simply carry NULL.
+ *
+ * Generated: 2026-07-15 (synthetic sequential prefix per docs/migrations.md #1013).
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddInvoiceClearanceDetail1818000000008 implements MigrationInterface {
+  name = 'AddInvoiceClearanceDetail1818000000008';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "invoice_records" ADD COLUMN IF NOT EXISTS "clearanceDetail" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "invoice_records" DROP COLUMN IF EXISTS "clearanceDetail"`,
+    );
+  }
+}

--- a/apps/web/src/features/invoicing/api/invoicing.types.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.types.ts
@@ -89,6 +89,11 @@ export interface InvoiceRecord {
   providerInvoiceNumber: string | null;
   regulatoryStatus: RegulatoryStatus;
   clearanceReference: string | null;
+  /** Operator-facing clearance diagnostic (e.g. the authority rejection reason);
+   *  non-null typically only on a `rejected` document (#1582). Optional so
+   *  pre-existing fixtures/records without it stay assignable; the API always
+   *  returns the key (string|null). */
+  clearanceDetail?: string | null;
   pdfUrl: string | null;
   failureMode: FailureMode | null;
   failureCode: FailureCode | null;
@@ -230,10 +235,30 @@ export interface CorrectionLineInput {
   newUnitPriceGross?: number;
 }
 
-/** `POST /invoices/:invoiceId/correct` request body (#1241). Mirrors
- *  `IssueCorrectionCommand` minus the server-resolved fields. */
+/** Optional buyer-identity override on a correction (#1582) - the fix path for a
+ *  wrong buyer NIP/identity on the original. Neutral shape; absent ⇒ the original
+ *  document's buyer is reused. */
+export interface CorrectionBuyerOverrideInput {
+  name: string;
+  taxId?: { scheme: string; value: string };
+  address: {
+    line1: string;
+    line2?: string | null;
+    city: string;
+    postalCode: string;
+    countryIso2: string;
+  };
+  type: 'company' | 'private';
+  isPublicSectorEntity?: boolean;
+  isVatGroupMember?: boolean;
+}
+
+/** `POST /invoices/:invoiceId/correct` request body (#1241, #1582). Mirrors
+ *  `IssueCorrectionCommand` minus the server-resolved fields. `reason` is
+ *  REQUIRED and non-empty (art. 106j ust. 2 pkt 5 / FA(3) XSD minLength=1). */
 export interface IssueCorrectionInput {
-  reason?: string;
+  reason: string;
   lines: CorrectionLineInput[];
   idempotencyKey?: string;
+  buyerOverride?: CorrectionBuyerOverrideInput;
 }

--- a/apps/web/src/features/invoicing/hooks/use-issue-correction-mutation.test.tsx
+++ b/apps/web/src/features/invoicing/hooks/use-issue-correction-mutation.test.tsx
@@ -50,13 +50,14 @@ describe('useIssueCorrectionMutation', () => {
 
     capturedMutation!.mutate({
       invoiceId: 'ol_invoice_1',
-      input: { lines: [{ originalLineNumber: 1, newQuantity: 0 }] },
+      input: { reason: 'partial return', lines: [{ originalLineNumber: 1, newQuantity: 0 }] },
     });
 
     await waitFor(() => expect(capturedMutation!.isSuccess).toBe(true));
 
     expect(capturedMutation!.data).toEqual(correctionRecord);
     expect(issueCorrection).toHaveBeenCalledWith('ol_invoice_1', {
+      reason: 'partial return',
       lines: [{ originalLineNumber: 1, newQuantity: 0 }],
     });
   });
@@ -77,7 +78,7 @@ describe('useIssueCorrectionMutation', () => {
 
     capturedMutation!.mutate({
       invoiceId: 'ol_invoice_1',
-      input: { lines: [] },
+      input: { reason: 'partial return', lines: [] },
     });
 
     await waitFor(() => expect(capturedMutation!.isError).toBe(true));

--- a/apps/web/src/plugins/infakt/components/infakt-invoice-correction-flow.test.tsx
+++ b/apps/web/src/plugins/infakt/components/infakt-invoice-correction-flow.test.tsx
@@ -212,6 +212,10 @@ describe('InfaktInvoiceCorrectionFlow', () => {
     const qtyInputs = await screen.findAllByLabelText(/New qty, line/i);
     fireEvent.change(qtyInputs[0], { target: { value: '3' } });
 
+    fireEvent.change(await screen.findByLabelText(/Reason for correction/i), {
+      target: { value: 'partial return' },
+    });
+
     fireEvent.click(await screen.findByRole('button', { name: /Issue KOR/i }));
 
     await waitFor(() => {

--- a/apps/web/src/plugins/infakt/components/infakt-invoice-correction-flow.tsx
+++ b/apps/web/src/plugins/infakt/components/infakt-invoice-correction-flow.tsx
@@ -78,6 +78,7 @@ export function InfaktInvoiceCorrectionFlow({
   );
 
   const [reason, setReason] = useState('');
+  const [reasonError, setReasonError] = useState<string | null>(null);
   const [lines, setLines] = useState<LineRow[]>([emptyRow()]);
   const [linesError, setLinesError] = useState<string | null>(null);
 
@@ -114,11 +115,22 @@ export function InfaktInvoiceCorrectionFlow({
       return;
     }
     setLinesError(null);
+    // #1582: the correction reason is legally required and must be non-empty
+    // (art. 106j ust. 2 pkt 5 / FA(3) XSD PrzyczynaKorekty minLength=1). Checked
+    // after line validation so a line problem surfaces its own error first.
+    const trimmedReason = reason.trim();
+    if (trimmedReason === '') {
+      setReasonError(
+        t('infakt.correction.reasonRequired', 'A reason for the correction is required.'),
+      );
+      return;
+    }
+    setReasonError(null);
     mutation.mutate(
       {
         invoiceId: invoice.id,
         input: {
-          reason: reason.trim() !== '' ? reason.trim() : undefined,
+          reason: trimmedReason,
           lines: parsedLines,
           idempotencyKey: idempotencyKeyRef.current,
         },
@@ -199,7 +211,13 @@ export function InfaktInvoiceCorrectionFlow({
           onChange={(e) => setReason(e.target.value)}
           disabled={isSubmitting}
           rows={3}
+          aria-invalid={reasonError !== null}
         />
+        {reasonError ? (
+          <p className="error-text" role="alert">
+            {reasonError}
+          </p>
+        ) : null}
       </div>
 
       {/* Line items */}

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-correction-flow.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-correction-flow.test.tsx
@@ -217,6 +217,10 @@ describe('KsefInvoiceCorrectionFlow', () => {
     const qtyInputs = await screen.findAllByLabelText(/New qty, line/i);
     fireEvent.change(qtyInputs[0], { target: { value: '3' } });
 
+    fireEvent.change(await screen.findByLabelText(/Reason for correction/i), {
+      target: { value: 'partial return' },
+    });
+
     fireEvent.click(await screen.findByRole('button', { name: /Issue KOR/i }));
 
     await waitFor(() => {

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-correction-flow.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-correction-flow.tsx
@@ -78,6 +78,7 @@ export function KsefInvoiceCorrectionFlow({
   const [reason, setReason] = useState('');
   const [lines, setLines] = useState<LineRow[]>([emptyRow()]);
   const [linesError, setLinesError] = useState<string | null>(null);
+  const [reasonError, setReasonError] = useState<string | null>(null);
 
   function updateLine(index: number, field: keyof LineRow, value: string): void {
     setLines((prev) => prev.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
@@ -112,11 +113,22 @@ export function KsefInvoiceCorrectionFlow({
       return;
     }
     setLinesError(null);
+    // #1582: the correction reason is legally required and must be non-empty
+    // (art. 106j ust. 2 pkt 5 / FA(3) XSD PrzyczynaKorekty minLength=1). Checked
+    // after line validation so a line problem surfaces its own error first.
+    const trimmedReason = reason.trim();
+    if (trimmedReason === '') {
+      setReasonError(
+        t('ksef.correction.reasonRequired', 'A reason for the correction is required.'),
+      );
+      return;
+    }
+    setReasonError(null);
     mutation.mutate(
       {
         invoiceId: invoice.id,
         input: {
-          reason: reason.trim() !== '' ? reason.trim() : undefined,
+          reason: trimmedReason,
           lines: parsedLines,
           idempotencyKey: idempotencyKeyRef.current,
         },
@@ -197,7 +209,13 @@ export function KsefInvoiceCorrectionFlow({
           onChange={(e) => setReason(e.target.value)}
           disabled={isSubmitting}
           rows={3}
+          aria-invalid={reasonError !== null}
         />
+        {reasonError ? (
+          <p className="error-text" role="alert">
+            {reasonError}
+          </p>
+        ) : null}
       </div>
 
       {/* Line items */}

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.test.tsx
@@ -61,6 +61,27 @@ describe('KsefInvoiceDetailSection', () => {
     expect(screen.getByText('KSeF: accepted')).toBeInTheDocument();
   });
 
+  it('surfaces the rejection detail when a document was rejected (#1582)', () => {
+    renderWithProviders(
+      <KsefInvoiceDetailSection
+        invoice={makeInvoice({
+          regulatoryStatus: 'rejected',
+          clearanceDetail: 'KSeF status 440: buyer NIP invalid',
+        })}
+        connection={sampleConnection}
+      />,
+    );
+    expect(screen.getByText('Rejection detail')).toBeInTheDocument();
+    expect(screen.getByText('KSeF status 440: buyer NIP invalid')).toBeInTheDocument();
+  });
+
+  it('does not render a rejection detail row when the document is not rejected (#1582)', () => {
+    renderWithProviders(
+      <KsefInvoiceDetailSection invoice={makeInvoice()} connection={sampleConnection} />,
+    );
+    expect(screen.queryByText('Rejection detail')).not.toBeInTheDocument();
+  });
+
   it('surfaces the KSeF number as a copyable value with the Art. 108g payment-title hint', () => {
     renderWithProviders(
       <KsefInvoiceDetailSection invoice={makeInvoice()} connection={sampleConnection} />,

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.tsx
@@ -163,6 +163,24 @@ export function KsefInvoiceDetailSection({
           </div>
         ) : null}
 
+        {/* Rejection detail (#1582): when the authority rejected the document,
+            surface its operator-facing diagnostic so the operator can see WHY. */}
+        {invoice.regulatoryStatus === 'rejected' && invoice.clearanceDetail ? (
+          <div className="slot-row">
+            <div>
+              <div className="slot-row__label">
+                {t('invoice.ksef.rejectionDetail', 'Rejection detail')}
+              </div>
+              <div className="slot-row__hint">
+                {t('invoice.ksef.rejectionDetailHint', 'Reported by the authority (KSeF)')}
+              </div>
+            </div>
+            <span className="text-danger" role="status">
+              {invoice.clearanceDetail}
+            </span>
+          </div>
+        ) : null}
+
         <div className="slot-row">
           <div>
             <div className="slot-row__label">{t('invoice.ksef.number', 'KSeF number')}</div>

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.test.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.test.tsx
@@ -167,6 +167,10 @@ describe('SubiektInvoiceCorrectionFlow', () => {
     const lineInputs = await screen.findAllByLabelText(/Line number/i);
     fireEvent.change(lineInputs[0], { target: { value: '2' } });
 
+    fireEvent.change(await screen.findByLabelText(/Reason for correction/i), {
+      target: { value: 'partial return' },
+    });
+
     fireEvent.click(await screen.findByRole('button', { name: /Issue correction/i }));
 
     await waitFor(() => {

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.tsx
@@ -62,6 +62,7 @@ export function SubiektInvoiceCorrectionFlow({
   const mutation = useIssueCorrectionMutation();
 
   const [reason, setReason] = useState('');
+  const [reasonError, setReasonError] = useState<string | null>(null);
   const [lines, setLines] = useState<LineRow[]>([emptyRow()]);
   const [linesError, setLinesError] = useState<string | null>(null);
 
@@ -96,11 +97,22 @@ export function SubiektInvoiceCorrectionFlow({
       return;
     }
     setLinesError(null);
+    // #1582: the correction reason is legally required and must be non-empty
+    // (art. 106j ust. 2 pkt 5 / FA(3) XSD PrzyczynaKorekty minLength=1). Checked
+    // after line validation so a line problem surfaces its own error first.
+    const trimmedReason = reason.trim();
+    if (trimmedReason === '') {
+      setReasonError(
+        t('subiekt.correction.reasonRequired', 'A reason for the correction is required.'),
+      );
+      return;
+    }
+    setReasonError(null);
     mutation.mutate(
       {
         invoiceId: invoice.id,
         input: {
-          reason: reason.trim() !== '' ? reason.trim() : undefined,
+          reason: trimmedReason,
           lines: parsedLines,
           idempotencyKey: idempotencyKeyRef.current,
         },
@@ -181,7 +193,13 @@ export function SubiektInvoiceCorrectionFlow({
           onChange={(e) => setReason(e.target.value)}
           disabled={isSubmitting}
           rows={3}
+          aria-invalid={reasonError !== null}
         />
+        {reasonError ? (
+          <p className="error-text" role="alert">
+            {reasonError}
+          </p>
+        ) : null}
       </div>
 
       {/* Line items */}

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -950,5 +950,93 @@ describe('InvoiceService', () => {
         expect.objectContaining({ documentContent: null }),
       );
     });
+
+    // #1582: single-flight CAS lease for corrections.
+    describe('CAS lease (#1582)', () => {
+      it('claims an atomic lease unconditionally, even when NO idempotencyKey is supplied', async () => {
+        repo.findByIdempotencyKey.mockResolvedValue(null);
+
+        await service.issueCorrection(makeCorrectionCmd({ idempotencyKey: undefined }));
+
+        // The lease is claimed on the freshly-created pending row regardless of key.
+        expect(repo.claimForIssue).toHaveBeenCalledWith('corr-rec', expect.any(Date));
+        expect(correctionAdapter.issueCorrection).toHaveBeenCalledTimes(1);
+      });
+
+      it('backs off WITHOUT calling the provider when the lease claim is contended', async () => {
+        repo.findByIdempotencyKey.mockResolvedValue(null);
+        // A concurrent attempt already holds the slot: claim returns null.
+        repo.claimForIssue.mockResolvedValueOnce(null);
+        const contended = makeRecord({ id: 'corr-rec', status: 'issuing' });
+        repo.findById.mockResolvedValue(contended);
+
+        const result = await service.issueCorrection(makeCorrectionCmd({ idempotencyKey: undefined }));
+
+        expect(correctionAdapter.issueCorrection).not.toHaveBeenCalled();
+        expect(result).toBe(contended);
+      });
+
+      it('resumes an already-issued same-key record without a second provider call', async () => {
+        const issued = makeRecord({ id: 'corr-existing', status: 'issued', documentType: 'corrected' });
+        repo.findByIdempotencyKey.mockResolvedValue(issued);
+
+        const result = await service.issueCorrection(makeCorrectionCmd());
+
+        expect(repo.create).not.toHaveBeenCalled();
+        expect(correctionAdapter.issueCorrection).not.toHaveBeenCalled();
+        expect(result).toBe(issued);
+      });
+    });
+
+    it('snapshots the buyerOverride buyer (not the original) when supplied (#1582)', async () => {
+      const override = new BuyerProfile(
+        'Corrected Buyer',
+        { scheme: 'pl-nip', value: '5252248481' },
+        { line1: 'ul. Nowa 5', line2: null, city: 'Gdansk', postalCode: '80-001', countryIso2: 'PL' },
+        'company',
+      );
+
+      await service.issueCorrection(makeCorrectionCmd({ buyerOverride: override }));
+
+      expect(repo.updateOutcome).toHaveBeenLastCalledWith(
+        'corr-rec',
+        expect.objectContaining({
+          issuedLineSnapshot: expect.objectContaining({ buyer: override }),
+        }),
+      );
+    });
+  });
+
+  describe('applyRegulatoryClearance (#1582)', () => {
+    it('persists the clearanceDetail from the clearance result', async () => {
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'rec-1' }));
+
+      await service.applyRegulatoryClearance('rec-1', {
+        regulatoryStatus: 'rejected',
+        clearanceReference: null,
+        clearanceDetail: 'KSeF status 440: buyer NIP invalid',
+      });
+
+      expect(repo.updateOutcome).toHaveBeenCalledWith('rec-1', {
+        regulatoryStatus: 'rejected',
+        clearanceReference: null,
+        clearanceDetail: 'KSeF status 440: buyer NIP invalid',
+      });
+    });
+
+    it('clears a stale clearanceDetail when the result carries none (e.g. a resend)', async () => {
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'rec-1' }));
+
+      await service.applyRegulatoryClearance('rec-1', {
+        regulatoryStatus: 'submitted',
+        clearanceReference: null,
+      });
+
+      expect(repo.updateOutcome).toHaveBeenCalledWith('rec-1', {
+        regulatoryStatus: 'submitted',
+        clearanceReference: null,
+        clearanceDetail: null,
+      });
+    });
   });
 });

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -488,18 +488,106 @@ export class InvoiceService implements IInvoiceService {
   }
 
   async issueCorrection(cmd: IssueCorrectionCommand): Promise<InvoiceRecord> {
-    // Persist intent before the provider call: `pending` row so a crash leaves
-    // a durable trace. Corrections do not share the idempotency-gate / CAS-lease
-    // of issueInvoice — each correction is a distinct new fiscal document with
-    // its own record; the caller supplies an idempotencyKey for dedup if needed.
-    const pending = await this.repo.create({
-      connectionId: cmd.connectionId,
-      orderId: cmd.orderId,
-      providerType: '',
-      documentType: cmd.documentType ?? 'corrected',
-      status: 'pending',
-      idempotencyKey: cmd.idempotencyKey ?? null,
-    });
+    // Mirrors `issueInvoice`'s single-flight structure (#1582): a supplied
+    // idempotencyKey dedups via the read-gate + create-race resume, and the CAS
+    // lease (`claimForIssue` in `correctWithAdapter`) is claimed UNCONDITIONALLY
+    // - even keyless - so a resumed/contended record can never cross the provider
+    // boundary twice. Each correction is still a DISTINCT new fiscal document
+    // with its own record; keyless calls are never cross-deduplicated (R1), same
+    // as `issueInvoice`.
+    const key = cmd.idempotencyKey;
+    if (key !== undefined) {
+      const existing = await this.repo.findByIdempotencyKey(cmd.connectionId, key);
+      if (existing) {
+        return this.resumeExistingCorrection(cmd, existing);
+      }
+    }
+
+    let pending: InvoiceRecord;
+    try {
+      pending = await this.repo.create({
+        connectionId: cmd.connectionId,
+        orderId: cmd.orderId,
+        providerType: '',
+        documentType: cmd.documentType ?? 'corrected',
+        status: 'pending',
+        idempotencyKey: key ?? null,
+      });
+    } catch (error) {
+      // Create-race: a concurrent same-key call won the dedup guard between our
+      // read-gate and create. Re-read by key and resume the winner under the same
+      // lease gate. Guarded by `key !== undefined` - it cannot fire keyless.
+      if (key !== undefined && error instanceof DuplicateInvoiceRecordException) {
+        const winner = await this.repo.findByIdempotencyKey(cmd.connectionId, key);
+        if (winner) {
+          return this.resumeExistingCorrection(cmd, winner);
+        }
+      }
+      throw error;
+    }
+
+    return this.correctWithAdapter(cmd, pending.id);
+  }
+
+  /**
+   * Decide how to resume an EXISTING same-key correction record, enforcing the
+   * fiscal-safety invariant before any retry re-crosses the provider boundary
+   * (#1582) - the correction-path twin of {@link resumeExisting}:
+   *   - `issued`          -> return verbatim (idempotent replay).
+   *   - live lease        -> return as-is; another attempt holds the slot.
+   *   - in-doubt `failed`  -> return as-is for manual reconciliation.
+   *   - re-attemptable     -> claim the slot atomically and, only on a WIN,
+   *                           re-cross the boundary.
+   */
+  private async resumeExistingCorrection(
+    cmd: IssueCorrectionCommand,
+    existing: InvoiceRecord,
+  ): Promise<InvoiceRecord> {
+    if (existing.status === 'issued') {
+      return existing;
+    }
+    const now = new Date();
+    if (existing.isLeaseLive(now)) {
+      this.logger.warn(
+        `Correction record ${existing.id} is claimed by a live in-flight attempt; not re-attempting`,
+      );
+      return existing;
+    }
+    if (existing.status === 'failed' && !existing.isReattemptableFailure) {
+      this.logger.warn(
+        `Correction record ${existing.id} failed in-doubt (failureMode=${existing.failureMode ?? 'unknown'}); ` +
+          `not auto-re-attempting - surfaced for manual reconciliation`,
+      );
+      return existing;
+    }
+    return this.correctWithAdapter(cmd, existing.id);
+  }
+
+  /**
+   * Atomically CLAIM the in-flight slot (UNCONDITIONALLY - #1582), resolve the
+   * `CorrectionIssuer` adapter, cross the boundary, and patch the outcome. The
+   * CAS claim is the single-flight guard: a contended retry that fails to claim
+   * backs off WITHOUT calling the provider. Mirrors {@link issueWithAdapter}.
+   */
+  private async correctWithAdapter(
+    cmd: IssueCorrectionCommand,
+    recordId: string,
+  ): Promise<InvoiceRecord> {
+    // (1) Atomic claim. A null return means a live attempt already holds the slot
+    // (or the row went terminal): back off WITHOUT crossing the boundary.
+    const leaseExpiresAt = new Date(Date.now() + ISSUING_LEASE_MS);
+    const claimed = await this.repo.claimForIssue(recordId, leaseExpiresAt);
+    if (claimed === null) {
+      this.logger.warn(
+        `Could not claim correction record ${recordId} for issuance ` +
+          `(held by a live attempt or already terminal); not re-attempting`,
+      );
+      const current = await this.repo.findById(recordId);
+      if (current) {
+        return current;
+      }
+      throw new InvoiceRecordNotFoundException(recordId);
+    }
 
     const adapter = await this.integrations.getCapabilityAdapter<InvoicingPort>(
       cmd.connectionId,
@@ -509,7 +597,7 @@ export class InvoiceService implements IInvoiceService {
     if (!isCorrectionIssuer(adapter)) {
       // Adapter resolved but doesn't implement CorrectionIssuer: update the row
       // to failed (in-doubt) and throw so the caller can surface the 422.
-      await this.repo.updateOutcome(pending.id, {
+      await this.repo.updateOutcome(recordId, {
         status: 'failed',
         errorMessage: 'Provider does not support correction issuance.',
         failureMode: 'rejected',
@@ -529,9 +617,9 @@ export class InvoiceService implements IInvoiceService {
       const failureCode = this.classifyFailureCode(error, failureMode);
       const failureReason = this.deriveFailureReason(failureCode);
       this.logger.warn(
-        `Correction issuance failed for record ${pending.id} (failureMode=${failureMode}, failureCode=${failureCode}): ${sanitized}`,
+        `Correction issuance failed for record ${recordId} (failureMode=${failureMode}, failureCode=${failureCode}): ${sanitized}`,
       );
-      await this.repo.updateOutcome(pending.id, {
+      await this.repo.updateOutcome(recordId, {
         status: 'failed',
         errorMessage: sanitized,
         failureMode,
@@ -544,35 +632,41 @@ export class InvoiceService implements IInvoiceService {
 
     const { record: issued, seller, sourceDocument } = issueResult;
 
+    // #1582: the buyer captured on the correction's own snapshot is the OVERRIDE
+    // buyer when one was supplied (a buyer-identity correction), else the original
+    // document's buyer - so a correction-of-correction diffs against the buyer as
+    // actually corrected.
+    const correctionBuyer = cmd.buyerOverride ?? cmd.originalDocument?.buyer;
+
     // #1297: snapshot the correction's OWN post-correction ("after") lines so a
     // correction-of-correction diffs against them, not the live order. Derived
     // from the caller-assembled original snapshot (`cmd.originalDocument.lines`,
     // the "before" state) with the per-line deltas applied. Only when the caller
-    // supplied `originalDocument` (order still resolvable); absent → persist null
+    // supplied `originalDocument` (order still resolvable); absent -> persist null
     // and the next correction falls back to order-derived reconstruction.
     const correctedLines = cmd.originalDocument
       ? applyCorrectionDeltas(cmd.originalDocument.lines, cmd.lines)
       : null;
     const issuedLineSnapshot: IssuedLineSnapshot | null =
-      cmd.originalDocument && correctedLines
+      cmd.originalDocument && correctedLines && correctionBuyer
         ? {
-            buyer: cmd.originalDocument.buyer,
+            buyer: correctionBuyer,
             currency: cmd.originalDocument.currency,
             lines: correctedLines,
           }
         : null;
     // W2/W3 (#1229 follow-up): a correction's displayed content and source
-    // document were previously never persisted at all — every corrected
+    // document were previously never persisted at all - every corrected
     // invoice's "View"/"Preview" 409'd with "no source document available"
     // even when the adapter (KSeF) had built and submitted a real FA(3) XML.
     // Mirrors `issueInvoice`'s persistence exactly, built from the corrected
     // ("after") lines rather than the original ones.
     const documentContent =
-      correctedLines && cmd.originalDocument
+      correctedLines && cmd.originalDocument && correctionBuyer
         ? this.buildContent(
             {
               lines: correctedLines,
-              buyer: cmd.originalDocument.buyer,
+              buyer: correctionBuyer,
               currency: cmd.originalDocument.currency,
             },
             issued,
@@ -580,7 +674,7 @@ export class InvoiceService implements IInvoiceService {
           )
         : null;
 
-    return this.repo.updateOutcome(pending.id, {
+    return this.repo.updateOutcome(recordId, {
       status: 'issued',
       providerType: issued.providerType,
       documentType: issued.documentType,
@@ -637,6 +731,9 @@ export class InvoiceService implements IInvoiceService {
     return this.repo.updateOutcome(invoiceId, {
       regulatoryStatus: result.regulatoryStatus,
       clearanceReference: result.clearanceReference ?? null,
+      // #1582: persist the authority's operator-facing rejection diagnostic (or
+      // clear a stale one when a resend moves the document off `rejected`).
+      clearanceDetail: result.clearanceDetail ?? null,
     });
   }
 

--- a/libs/core/src/invoicing/application/services/regulatory-status-reconciliation.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/regulatory-status-reconciliation.service.spec.ts
@@ -26,6 +26,7 @@ function makeRecord(
     status: 'pending' | 'issued' | 'failed';
     regulatoryStatus: RegulatoryStatus;
     clearanceReference: string | null;
+    clearanceDetail: string | null;
     updatedAt: Date;
   }> = {},
 ): InvoiceRecord {
@@ -46,6 +47,16 @@ function makeRecord(
     null,
     new Date('2026-06-01T10:00:00Z'),
     overrides.updatedAt ?? new Date('2026-06-01T10:00:00Z'),
+    null,
+    null,
+    null,
+    null,
+    false,
+    null,
+    null,
+    null,
+    'unknown',
+    overrides.clearanceDetail ?? null,
   );
 }
 
@@ -156,6 +167,23 @@ describe('RegulatoryStatusReconciliationService', () => {
       await service.reconcile(CONNECTION_ID, { limit: 50 });
 
       expect(repo.updateOutcome).toHaveBeenCalledWith(record.id, { regulatoryStatus: 'rejected' });
+    });
+
+    it('persists the clearanceDetail from a rejected read (#1582)', async () => {
+      const record = makeRecord({ regulatoryStatus: 'submitted', clearanceReference: null });
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        readerAdapter({
+          regulatoryStatus: 'rejected',
+          clearanceReference: null,
+          clearanceDetail: 'KSeF status 440: buyer NIP invalid',
+        }),
+      );
+      repo.findIssuedNonTerminal.mockResolvedValue({ items: [record], total: 1 });
+
+      await service.reconcile(CONNECTION_ID, { limit: 50 });
+
+      const patch = ((repo.updateOutcome as jest.Mock).mock.calls[0] as [unknown, Record<string, unknown>])[1];
+      expect(patch['clearanceDetail']).toBe('KSeF status 440: buyer NIP invalid');
     });
 
     it('defensive-skips a record whose CURRENT status is already terminal (race guard, 8a) and increments skippedTerminal', async () => {

--- a/libs/core/src/invoicing/application/services/regulatory-status-reconciliation.service.ts
+++ b/libs/core/src/invoicing/application/services/regulatory-status-reconciliation.service.ts
@@ -229,6 +229,15 @@ export class RegulatoryStatusReconciliationService
       patch.clearanceReference = read.clearanceReference;
     }
 
+    // (8f #1582) clearanceDetail is the operator-facing rejection diagnostic.
+    // Refresh it when a rejected read carries a new one. Key OMITTED otherwise
+    // so an unrelated read never rewrites it. (A record only ever CARRIES a
+    // detail once rejected, which is terminal and never re-polled here, so
+    // clearing is owned by `applyRegulatoryClearance` on the resend path.)
+    if (read.clearanceDetail != null && read.clearanceDetail !== record.clearanceDetail) {
+      patch.clearanceDetail = read.clearanceDetail;
+    }
+
     return patch;
   }
 

--- a/libs/core/src/invoicing/domain/entities/invoice-record.entity.ts
+++ b/libs/core/src/invoicing/domain/entities/invoice-record.entity.ts
@@ -108,6 +108,14 @@ export class InvoiceRecord {
      * it never asserts "unpaid" for a document OL has simply not polled.
      */
     public readonly paymentStatus: PaymentStatus = 'unknown',
+    /**
+     * Opaque operator-facing clearance diagnostic (#1582) - the authority's
+     * rejection description/details captured by the `RegulatoryStatusReader`
+     * read, so the detail page can explain WHY a document was rejected. Neutral
+     * (ADR-026): a free-text blob, never interpreted in core. `null` until a
+     * read surfaces one (typically only on `rejected`).
+     */
+    public readonly clearanceDetail: string | null = null,
   ) {}
 
   /** Pure derivation: the document was successfully issued by the provider. */

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -121,6 +121,15 @@ export interface RegulatoryClearanceResult {
    * a reference a prior submit could not. `null`/absent until assigned.
    */
   clearanceReference?: string | null;
+  /**
+   * Opaque operator-facing diagnostic the authority returned for the clearance
+   * verdict (#1582) - typically the provider's `description`/`details` on a
+   * `rejected` read, so an operator can see WHY the authority refused the
+   * document rather than only that it was rejected. Country/provider-agnostic
+   * (ADR-026): a free-text blob the adapter fills from its regime's rejection
+   * fields, never interpreted in core. Absent on non-rejection reads.
+   */
+  clearanceDetail?: string | null;
 }
 
 /**
@@ -565,6 +574,17 @@ export interface IssueCorrectionCommand {
   idempotencyKey?: string;
   /** Caller-assembled full original-document snapshot; see {@link OriginalDocumentSnapshot}. */
   originalDocument?: OriginalDocumentSnapshot;
+  /**
+   * OPTIONAL buyer-identity override (#1582). When present, the adapter uses THIS
+   * buyer for the correcting document instead of the buyer captured on
+   * {@link OriginalDocumentSnapshot} - the fix path for a "wrong buyer identity
+   * (e.g. NIP) on the original" correction (a document already cleared by the
+   * authority cannot be deleted, only corrected). Mirrors how `originalDocument`
+   * is a caller-assembled reconstruction; reuses the neutral {@link BuyerProfile}
+   * shape (ADR-026 - no regime/provider vocabulary). Absent ⇒ the original
+   * snapshot's buyer is used unchanged.
+   */
+  buyerOverride?: BuyerProfile;
 }
 
 /**
@@ -718,6 +738,14 @@ export interface InvoiceOutcomePatch {
   providerInvoiceNumber?: string | null;
   regulatoryStatus?: RegulatoryStatus;
   clearanceReference?: string | null;
+  /**
+   * Opaque operator-facing clearance diagnostic (#1582). Set from a
+   * `RegulatoryClearanceResult.clearanceDetail` (typically the authority's
+   * rejection description/details) so the projection can surface WHY a document
+   * was rejected. Country/provider-agnostic (ADR-026); omitted when a patch does
+   * not carry a fresh diagnostic so an unrelated outcome patch never resets it.
+   */
+  clearanceDetail?: string | null;
   /**
    * Neutral payment lifecycle (#1354). Set by the payment-status refresh
    * service from an authoritative `PaymentStatusReader` read; omitted otherwise

--- a/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/entities/invoice-record.orm-entity.ts
@@ -85,6 +85,15 @@ export class InvoiceRecordOrmEntity {
   clearanceReference!: string | null;
 
   /**
+   * Opaque operator-facing clearance diagnostic (#1582) - the authority's
+   * rejection description/details, captured by the reconciliation read so the
+   * detail page can explain a `rejected` verdict. Neutral (ADR-026); `null`
+   * until a read surfaces one.
+   */
+  @Column({ type: 'text', nullable: true })
+  clearanceDetail!: string | null;
+
+  /**
    * Neutral payment lifecycle (#1354) — refreshed from an authoritative
    * `PaymentStatusReader` read triggered by a provider payment webhook. Defaults
    * `unknown` (never asserts "unpaid" for a document OL has not polled).

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
@@ -360,6 +360,7 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
       entity.sourceDocument,
       entity.issuedLineSnapshot,
       entity.paymentStatus,
+      entity.clearanceDetail,
     );
   }
 }

--- a/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-invoicing.adapter.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-invoicing.adapter.spec.ts
@@ -504,6 +504,38 @@ describe('KsefInvoicingAdapter', () => {
       expect(built?.correction?.correctedLines?.[0]?.quantity).toBe(1);
     });
 
+    it('should use the buyerOverride buyer for the KOR when supplied (#1582)', async () => {
+      const http = new FakeKsefHttpClient();
+      seedHappyPath(http);
+      const { builder, lastInput } = capturingBuilder();
+
+      const override = new BuyerProfile(
+        'Corrected Buyer Sp. z o.o.',
+        { scheme: 'pl-nip', value: '5252248481' },
+        { line1: 'ul. Nowa 5', line2: null, city: 'Gdansk', postalCode: '80-001', countryIso2: 'PL' },
+        'company',
+      );
+
+      await adapter(http, builder).issueCorrection(correctionCommand({ buyerOverride: override }));
+
+      const built = lastInput();
+      // The KOR carries the OVERRIDE buyer, not the original snapshot's buyer.
+      expect(built?.buyerName).toBe('Corrected Buyer Sp. z o.o.');
+      expect(built?.buyer).toEqual({ kind: 'nip', nip: '5252248481' });
+    });
+
+    it('should fall back to the original snapshot buyer when no buyerOverride is supplied (#1582)', async () => {
+      const http = new FakeKsefHttpClient();
+      seedHappyPath(http);
+      const { builder, lastInput } = capturingBuilder();
+
+      await adapter(http, builder).issueCorrection(correctionCommand());
+
+      const built = lastInput();
+      expect(built?.buyerName).toBe('Klient Sp. z o.o.');
+      expect(built?.buyer).toEqual({ kind: 'nip', nip: '9876543210' });
+    });
+
     it('should derive distinct P_2 numbers for two corrections of the same order (#1364)', async () => {
       const http = new FakeKsefHttpClient();
       seedHappyPath(http);
@@ -629,6 +661,42 @@ describe('KsefInvoicingAdapter', () => {
 
       expect(result.regulatoryStatus).toBe('submitted');
       expect(result.clearanceReference).toBeNull();
+    });
+
+    it('should capture the authority rejection detail as clearanceDetail (#1582)', async () => {
+      const http = new FakeKsefHttpClient();
+      http.seed('GET', STATUS_PATH, {
+        data: {
+          status: {
+            code: 440,
+            description: 'Weryfikacja negatywna',
+            details: ['NIP nabywcy niepoprawny'],
+          },
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter(http).getClearanceStatus(record());
+
+      expect(result.regulatoryStatus).toBe('rejected');
+      expect(result.clearanceDetail).toContain('440');
+      expect(result.clearanceDetail).toContain('Weryfikacja negatywna');
+      expect(result.clearanceDetail).toContain('NIP nabywcy niepoprawny');
+    });
+
+    it('should not set clearanceDetail on a non-rejection (submitted) read (#1582)', async () => {
+      const http = new FakeKsefHttpClient();
+      http.seed('GET', STATUS_PATH, {
+        data: { status: { code: 150, description: 'W trakcie przetwarzania' } },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter(http).getClearanceStatus(record());
+
+      expect(result.regulatoryStatus).toBe('submitted');
+      expect(result.clearanceDetail ?? null).toBeNull();
     });
 
     it('should return rejected (terminal) on a known business-rejection code (440)', async () => {

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
@@ -115,6 +115,13 @@ const SUPPORTED_DOCUMENT_TYPES: DocumentType[] = ['invoice', 'corrected'];
 /** Content type assumed for a UPO when KSeF omits the response `content-type` (the UPO is XML). */
 const DEFAULT_UPO_CONTENT_TYPE = 'application/xml';
 
+/**
+ * Upper bound on the neutral `clearanceDetail` diagnostic (#1582) persisted to
+ * the projection and shown to operators. Bounds an unexpectedly verbose
+ * authority payload from bloating the row / detail page.
+ */
+const MAX_CLEARANCE_DETAIL_LENGTH = 500;
+
 export class KsefInvoicingAdapter
   implements
     InvoicingPort,
@@ -434,10 +441,14 @@ export class KsefInvoicingAdapter
     // #1364: `issueInvoice` below stamps a distinct P_2 whenever `correction` is
     // present (see `buildCorrectionDocumentNumber`), so delegating with the same
     // `orderId` here no longer collides with the original document's P_2.
+    // #1582: a buyer-identity correction (e.g. a wrong NIP on the original) sends
+    // the OVERRIDE buyer on the KOR instead of the original snapshot's buyer.
+    // Neutral - the adapter just prefers the override when present (ADR-026).
+    const correctionBuyer = cmd.buyerOverride ?? cmd.originalDocument.buyer;
     const issueCmd: IssueInvoiceCommand = {
       connectionId: cmd.connectionId,
       orderId: cmd.orderId,
-      buyer: cmd.originalDocument.buyer,
+      buyer: correctionBuyer,
       currency: cmd.originalDocument.currency,
       // Deliberately the UNMODIFIED original lines, NOT `correctedLines` — per
       // `CorrectionReference`'s contract, the command's top-level `lines` carry
@@ -577,7 +588,14 @@ export class KsefInvoicingAdapter
 
     if (regulatoryStatus !== 'accepted') {
       // Non-terminal (submitted) or terminal-failure (rejected): no KSeF number yet.
-      return { regulatoryStatus, clearanceReference: null };
+      // On a REJECTED read, capture the authority's operator-facing diagnostic
+      // (#1582) so the detail page can explain WHY the document was refused -
+      // opaque to core (ADR-026); no KSeF vocabulary crosses the neutral shape.
+      const clearanceDetail =
+        regulatoryStatus === 'rejected'
+          ? this.formatClearanceDetail(response.data.status)
+          : null;
+      return { regulatoryStatus, clearanceReference: null, clearanceDetail };
     }
 
     return this.buildClearedStatus(response.data, sessionRef, invoiceRef);
@@ -634,6 +652,32 @@ export class KsefInvoicingAdapter
    * for traceability. C8 (UPO download) resolves the UPO document from the
    * `clearanceReference` (KSeF number) the record already carries.
    */
+  /**
+   * Compose the neutral operator-facing rejection diagnostic (#1582) from KSeF's
+   * status block (`description` + optional `details[]`). Bounded and PII-free by
+   * construction on the KSeF side; the code is prefixed so the operator always
+   * has a stable anchor even when the authority omits free text. Returns a plain
+   * opaque string - core never parses it (ADR-026).
+   */
+  private formatClearanceDetail(status: InvoiceStatusResponse['status']): string {
+    const parts: string[] = [];
+    if (typeof status.description === 'string' && status.description.trim().length > 0) {
+      parts.push(status.description.trim());
+    }
+    if (Array.isArray(status.details)) {
+      for (const detail of status.details) {
+        if (typeof detail === 'string' && detail.trim().length > 0) {
+          parts.push(detail.trim());
+        }
+      }
+    }
+    const suffix = parts.length > 0 ? `: ${parts.join('; ')}` : '';
+    const detail = `KSeF status ${status.code}${suffix}`;
+    return detail.length <= MAX_CLEARANCE_DETAIL_LENGTH
+      ? detail
+      : `${detail.slice(0, MAX_CLEARANCE_DETAIL_LENGTH - 3)}...`;
+  }
+
   private async buildClearedStatus(
     data: InvoiceStatusResponse,
     sessionRef: string,

--- a/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.spec.ts
@@ -284,6 +284,30 @@ describe('buildFa3Xml', () => {
       expect(xml).toContain('<PrzyczynaKorekty>Customer returned 1 unit</PrzyczynaKorekty>');
     });
 
+    it('should OMIT PrzyczynaKorekty entirely when the reason is empty (#1582)', () => {
+      // minOccurs=0 + minLength=1: an empty element is invalid, so the builder
+      // omits it rather than emitting `<PrzyczynaKorekty></PrzyczynaKorekty>`.
+      const input = korInput('1111111111-20260501-ABCDEF-01');
+      input.correction!.reason = '';
+      const xml = buildFa3Xml(input);
+      expect(xml).not.toContain('<PrzyczynaKorekty>');
+      expect(xml).not.toContain('<PrzyczynaKorekty/>');
+    });
+
+    it('should OMIT PrzyczynaKorekty when the reason is only whitespace (#1582)', () => {
+      const input = korInput('1111111111-20260501-ABCDEF-01');
+      input.correction!.reason = '   ';
+      const xml = buildFa3Xml(input);
+      expect(xml).not.toContain('<PrzyczynaKorekty>');
+    });
+
+    it('should trim the reason it emits (#1582)', () => {
+      const input = korInput('1111111111-20260501-ABCDEF-01');
+      input.correction!.reason = '  wrong NIP  ';
+      const xml = buildFa3Xml(input);
+      expect(xml).toContain('<PrzyczynaKorekty>wrong NIP</PrzyczynaKorekty>');
+    });
+
     it('should emit the NrKSeF flag + NrKSeFFaKorygowanej pair when the original was a KSeF invoice', () => {
       // XSD (lines ~2910-2928): the KSeF branch of the DaneFaKorygowanej choice is
       // a SEQUENCE — NrKSeF (etd:TWybor1, a FLAG = 1) FOLLOWED BY

--- a/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.ts
@@ -578,7 +578,14 @@ function faNode(input: Fa3BuilderInput): XmlNodeObject {
   if (correction !== undefined) {
     // The KOR correction metadata follows RodzajFaktury in schema order, before
     // the FaWiersz rows.
-    node.PrzyczynaKorekty = correction.reason;
+    // #1582: `PrzyczynaKorekty` is `minOccurs=0` but `minLength=1` when present -
+    // emitting an empty/whitespace element is an XSD content-constraint violation
+    // KSeF rejects at clearance. OMIT the element when the reason is blank
+    // (belt-and-suspenders; the DTO boundary already requires a non-empty reason).
+    const trimmedReason = correction.reason.trim();
+    if (trimmedReason.length > 0) {
+      node.PrzyczynaKorekty = trimmedReason;
+    }
     node.TypKorekty = correction.typKorekty;
     node.DaneFaKorygowanej = correctedInvoiceNode(correction);
   }

--- a/libs/integrations/ksef/src/infrastructure/fa3/validators/fa3-xsd.validator.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/validators/fa3-xsd.validator.spec.ts
@@ -101,6 +101,54 @@ describe('validateFa3Xml', () => {
     }
   });
 
+  it('should reject an empty PrzyczynaKorekty element (#1582)', () => {
+    // minOccurs=0 but minLength=1 when present: an empty text body is a content-
+    // constraint violation that would otherwise only fail at live KSeF clearance.
+    const bad = builtDoc().replace(
+      '</RodzajFaktury>',
+      '</RodzajFaktury><PrzyczynaKorekty></PrzyczynaKorekty>',
+    ) as RawFa3Xml;
+    try {
+      validateFa3Xml(bad);
+      fail('expected Fa3XsdValidationException');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Fa3XsdValidationException);
+      const paths = (error as Fa3XsdValidationException).issues.map((i) => i.path);
+      expect(paths).toContain('/Faktura/Fa/PrzyczynaKorekty');
+    }
+  });
+
+  it('should reject a whitespace-only PrzyczynaKorekty element (#1582)', () => {
+    const bad = builtDoc().replace(
+      '</RodzajFaktury>',
+      '</RodzajFaktury><PrzyczynaKorekty>   </PrzyczynaKorekty>',
+    ) as RawFa3Xml;
+    try {
+      validateFa3Xml(bad);
+      fail('expected Fa3XsdValidationException');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Fa3XsdValidationException);
+      const paths = (error as Fa3XsdValidationException).issues.map((i) => i.path);
+      expect(paths).toContain('/Faktura/Fa/PrzyczynaKorekty');
+    }
+  });
+
+  it('should reject a self-closed empty PrzyczynaKorekty element (#1582)', () => {
+    const bad = builtDoc().replace(
+      '</RodzajFaktury>',
+      '</RodzajFaktury><PrzyczynaKorekty/>',
+    ) as RawFa3Xml;
+    expect(() => validateFa3Xml(bad)).toThrow(Fa3XsdValidationException);
+  });
+
+  it('should accept a non-empty PrzyczynaKorekty element (#1582)', () => {
+    const good = builtDoc().replace(
+      '</RodzajFaktury>',
+      '</RodzajFaktury><PrzyczynaKorekty>wrong NIP</PrzyczynaKorekty>',
+    ) as RawFa3Xml;
+    expect(() => validateFa3Xml(good)).not.toThrow();
+  });
+
   it('should accept the np II token (a valid TStawkaPodatku value)', () => {
     // Swapping the P_12 value for a valid token keeps the document otherwise
     // valid; the token guard must NOT reject `np II`.

--- a/libs/integrations/ksef/src/infrastructure/fa3/validators/fa3-xsd.validator.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/validators/fa3-xsd.validator.ts
@@ -184,6 +184,27 @@ export function validateFa3Xml(xml: RawFa3Xml): void {
     }
   }
 
+  // 4. Content-constraint guard (#1582). `PrzyczynaKorekty` (the KOR correction
+  //    reason) is `minOccurs=0` but `minLength=1` when present, so an empty or
+  //    whitespace-only element is rejected by KSeF at clearance rather than
+  //    locally. Catch both the self-closed form (`<PrzyczynaKorekty/>`) and an
+  //    empty/whitespace text body here, cheaply, at build time. A blank reason
+  //    should be OMITTED entirely (the builder does), never emitted empty.
+  if (/<PrzyczynaKorekty\s*\/>/.test(xml)) {
+    issues.push({
+      path: `${root}/Fa/PrzyczynaKorekty`,
+      message: 'PrzyczynaKorekty must not be empty when present (minLength=1)',
+    });
+  }
+  for (const match of xml.matchAll(/<PrzyczynaKorekty>([^]*?)<\/PrzyczynaKorekty>/g)) {
+    if (match[1].trim().length === 0) {
+      issues.push({
+        path: `${root}/Fa/PrzyczynaKorekty`,
+        message: 'PrzyczynaKorekty must not be empty when present (minLength=1)',
+      });
+    }
+  }
+
   if (issues.length > 0) {
     throw new Fa3XsdValidationException(issues);
   }


### PR DESCRIPTION
Part of #1578, addresses #1582.

Closes the four correction (`issueCorrection`) + rejection-diagnostic integrity gaps.

## 1. Correction reason can be an empty string (XSD violation)
`PrzyczynaKorekty` is `minOccurs=0` but `minLength=1` when present.
- `IssueCorrectionRequestDto.reason` is now **required + non-empty** (trimmed via `@Transform` + `@IsNotEmpty()`) - the legally-stronger fix per art. 106j ust. 2 pkt 5.
- `fa3-xsd.validator.ts` now catches an empty / whitespace / self-closed `PrzyczynaKorekty` locally instead of only at live KSeF clearance.
- The FA(3) builder OMITs the element when the reason is blank (belt-and-suspenders).
- FE correction flows (KSeF/inFakt/Subiekt - the shared DTO changed for all providers) validate a non-empty reason inline, after line validation.

## 2. Rejection diagnostic detail discarded
- Added neutral optional `clearanceDetail?: string | null` to `RegulatoryClearanceResult`, `InvoiceRecord`, `InvoiceOutcomePatch` (+ migration `1818000000008`).
- The KSeF adapter populates it from `status.description`/`status.details` on a `rejected` read (bounded, PL vocabulary stays in the adapter).
- Persisted via the reconcile `buildPatch` and `applyRegulatoryClearance`, exposed on the response DTO, and surfaced as a "Rejection detail" row on the KSeF invoice detail section.

## 3. Buyer NIP/identity cannot be changed via a correction
- Added optional `buyerOverride?: BuyerProfile` to `IssueCorrectionCommand` (mirrors the caller-assembled `originalDocument` pattern), threaded from a new nested `CorrectionBuyerOverrideDto` -> controller -> command.
- When present, the KSeF adapter uses the override buyer for the KOR instead of the original snapshot's buyer; the persisted correction snapshot reflects the override.

## 4. issueCorrection has no single-flight/CAS-lease guard
- `issueCorrection` now mirrors `issueInvoice`: keyed idempotency read-gate + create-race resume, and an **unconditional** `claimForIssue` CAS lease (`correctWithAdapter`) before crossing the provider boundary - independent of a caller-supplied `idempotencyKey`. A contended claim backs off without a provider call.

## Neutrality
All new core fields are opaque/neutral (ADR-026); no KSeF/NIP/FA vocabulary crosses into `libs/core`.

## Tests
- DTO: empty/whitespace/missing reason rejection, reason trimming, buyer-override shape validation.
- Validator + builder: empty `PrzyczynaKorekty` rejection / omission.
- KSeF adapter: `clearanceDetail` capture on rejection (not on submitted), `buyerOverride` used for the KOR.
- Core service: unconditional lease claim without a key, contended-claim back-off, issued-replay, buyer-override snapshot, `applyRegulatoryClearance` detail persist/clear.
- FE: rejection-detail row rendering.

## Quality gate (scoped)
- `@openlinker/core` + `@openlinker/integrations-ksef` build: PASS
- `@openlinker/api` type-check: PASS
- `@openlinker/web` type-check: PASS
- jest (invoice.service, reconcile, adapter, builder, validator, DTO, controller): PASS
- `check-cross-context-imports` + `check-service-interfaces`: PASS
- eslint on touched files: PASS