### PR TITLE
fix(web): keep demo-mode banner sticky while scrolling

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11016,6 +11016,13 @@ html[data-density='compact'] .status-badge {
   color: var(--status-info-fg);
   font-size: 12px;
   flex-shrink: 0;
+  /* Stick directly below the sticky topbar (height: 52px) so the demo-mode
+     reminder stays visible while shell content scrolls. z-index sits above
+     scrolled .shell-content but below the topbar (z-index: 10) so the two
+     header blocks never overlap. */
+  position: sticky;
+  top: 52px;
+  z-index: 9;
 }
 
 .demo-banner__icon {


### PR DESCRIPTION
## Summary
Pins `.demo-banner` with `position: sticky` under the sticky topbar (`top: 52px`, `z-index: 9`) so it stays visible while shell content scrolls, instead of scrolling away as a plain in-flow flex item. Only renders for demo viewers, so non-viewer/non-demo sessions are visually unaffected.

## Test plan
- [x] `pnpm --filter @openlinker/web lint` - 0 errors
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] Existing demo-banner and app-shell tests pass (31/31)
- [x] Verified light/dark themes and mobile widths do not regress

Part of #1606
Closes #1612