### PR TITLE
feat(web): polish order invoice-generation panel layout

### DIFF
--- a/apps/web/src/features/invoicing/components/document-type-select.tsx
+++ b/apps/web/src/features/invoicing/components/document-type-select.tsx
@@ -28,12 +28,16 @@ interface DocumentTypeSelectProps {
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
+  /** Forwarded to the underlying `<Select>` so the panel can control layout
+   *  (e.g. flex-grow the picker to fill the action row). */
+  className?: string;
 }
 
 export function DocumentTypeSelect({
   value,
   onChange,
   disabled = false,
+  className,
 }: DocumentTypeSelectProps): ReactElement {
   const { t } = useTranslation();
   return (
@@ -41,6 +45,7 @@ export function DocumentTypeSelect({
       value={value}
       disabled={disabled}
       onChange={(event) => onChange(event.target.value)}
+      className={className}
       aria-label={t('invoice.documentType.label', 'Document type')}
     >
       {OPTIONS.map((option) => (

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.test.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.test.tsx
@@ -153,6 +153,18 @@ describe('OrderInvoicePanel — display states', () => {
     expect(await screen.findByRole('button', { name: /issue invoice/i })).toBeEnabled();
   });
 
+  it('not-issued ⇒ document-type picker fills the row beside a signal-orange primary Issue action (#1622)', async () => {
+    const { container } = renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()) } }),
+    });
+    // The picker + primary action share one row (mockup section 02 layout).
+    const issue = await screen.findByRole('button', { name: /issue invoice/i });
+    expect(issue).toHaveClass('button--primary');
+    const picker = screen.getByRole('combobox', { name: /document type/i });
+    expect(picker).toHaveClass('order-invoice-panel__doc-type');
+    expect(container.querySelector('.order-invoice-panel__actions--issue')).not.toBeNull();
+  });
+
   it('issued ⇒ number + safe PDF link + document type, no action button', async () => {
     renderWithProviders(<OrderInvoicePanel order={order} />, {
       apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockResolvedValue(makeInvoice()) } }),

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
@@ -479,13 +479,14 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
         </>
       ) : null}
 
-      {/* ── Not issued: Issue button + DocumentTypeSelect ── */}
+      {/* ── Not issued: DocumentTypeSelect (fills the row) + primary Issue ── */}
       {!requiresConnectionPick && !invoiceQuery.isError && !invoiceQuery.isLoading && displayStatus === 'not-issued' ? (
-        <div className="order-invoice-panel__actions">
+        <div className="order-invoice-panel__actions order-invoice-panel__actions--issue">
           <DocumentTypeSelect
             value={documentType}
             onChange={setDocumentType}
             disabled={issueMutation.isPending}
+            className="order-invoice-panel__doc-type"
           />
           <Button tone="primary" onClick={handleIssue} disabled={issueMutation.isPending}>
             {t('invoice.action.issue', 'Issue invoice')}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10261,6 +10261,33 @@ html[data-density='compact'] .status-badge {
   flex: 1;
 }
 
+/* ─ Not-issued action row (#1622) ─
+   The document-type picker fills the row and the signal-orange primary
+   "Issue invoice" action anchors to the right, matching the panel mockup
+   (demo epic #1606, section 02). `flex-wrap` lets the button drop under a
+   full-width picker on narrow (mobile) panels rather than crushing either. */
+.order-invoice-panel__actions--issue {
+  flex-wrap: wrap;
+}
+
+.order-invoice-panel__doc-type {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.order-invoice-panel__actions--issue .button {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 480px) {
+  .order-invoice-panel__doc-type {
+    flex-basis: 100%;
+  }
+  .order-invoice-panel__actions--issue .button {
+    flex: 1 1 auto;
+  }
+}
+
 /* ─ Skeletons (shared shimmer for panel + detail page) ─ */
 .order-invoice-panel__skeleton,
 .invoice-detail__skeleton {


### PR DESCRIPTION
## Summary
Reworks the not-issued action row in `OrderInvoicePanel` to match the mockup: the document-type picker fills the row and the primary "Issue invoice" action anchors right, using the shared primary-action styling with responsive stacking below 480px. `DocumentTypeSelect` now forwards an optional `className` so the panel can control layout. All existing states (not-issued/issued/failed-retry) and the `useIssueInvoiceMutation` / `useOrderInvoiceQuery` wiring are unchanged.

## Test plan
- [x] `pnpm --filter @openlinker/web lint` - 0 errors
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] Full web test suite passes (247 files, 2182 tests), including a new test locking the polished not-issued layout

Part of #1606
Closes #1622