### PR TITLE
fix(web): add spacing under section titles

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1966,6 +1966,11 @@ textarea,
 
 .panel__header {
   justify-content: space-between;
+  /* Breathing room below the eyebrow + section-title block so panel titles
+     don't sit flush against their content. Single shared rule so every panel
+     header (dashboard sections, connection config, etc.) stays consistent;
+     eyebrow -> title stays tight (both margin: 0), the gap is title -> content. */
+  margin-bottom: var(--space-3);
 }
 
 .activity-list__item,


### PR DESCRIPTION
## Summary
Adds `margin-bottom: var(--space-3)` to `.panel__header`, the shared markup used by every dashboard section and the connection Config tab (`.panel__header > div > (.eyebrow + .section-title)`), so title content no longer sits flush against the following panel body. Eyebrow-to-title spacing is unchanged; verified against every other `.section-title` usage in the app to confirm no double-spacing or misalignment.

## Test plan
- [x] Design-token drift check passes (`--space-3` declared in both `index.css` and `tokens.ts`)
- [x] `pnpm --filter @openlinker/web lint` - 0 errors
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] Manually verified every `.section-title` usage in the app (dashboard, connection Config, settings, mappings, connection diagnostics/actions/capabilities, prompt-template history) for regressions

Part of #1606
Closes #1618