### PR TITLE
feat(web/connections): show demo-viewer actions disabled instead of hidden

### DIFF
--- a/apps/web/src/features/connections/components/ConnectionActionsPanel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionActionsPanel.test.tsx
@@ -1,6 +1,11 @@
-import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { renderWithProviders, sampleConnection, createAuthenticatedSessionAdapter } from '../../../test/test-utils';
+import {
+  createMockApiClient,
+  renderWithProviders,
+  sampleConnection,
+  createAuthenticatedSessionAdapter,
+} from '../../../test/test-utils';
 import { ConnectionActionsPanel } from './ConnectionActionsPanel';
 
 // jsdom does not implement showModal/close — stub them on HTMLDialogElement
@@ -78,5 +83,57 @@ describe('ConnectionActionsPanel', () => {
 
     // Dialog is now open — job type select should be visible
     expect(screen.getByRole('combobox', { name: /job type/i })).toBeInTheDocument();
+  });
+
+  describe('demo read-only viewer (#1615)', () => {
+    const viewerSession = { sessionAdapter: createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: null,
+      role: 'viewer',
+      permissions: ['connections:read', 'sync:read'],
+    }) };
+
+    function demoApiClient() {
+      return createMockApiClient({ system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) } });
+    }
+
+    it('renders every action visible-but-disabled instead of hiding them', async () => {
+      renderWithProviders(<ConnectionActionsPanel connection={sampleConnection} />, {
+        apiClient: demoApiClient(),
+        ...viewerSession,
+      });
+
+      expect(await screen.findByRole('button', { name: 'Test connection' })).toBeDisabled();
+      expect(screen.getByRole('link', { name: 'Edit' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /trigger sync/i })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Disable' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /configure webhooks/i })).toBeDisabled();
+    });
+
+    it('opens the TriggerSyncDialog with an enabled job type select but a disabled Trigger submit', async () => {
+      renderWithProviders(<ConnectionActionsPanel connection={sampleConnection} />, {
+        apiClient: demoApiClient(),
+        ...viewerSession,
+      });
+
+      fireEvent.click(await screen.findByRole('button', { name: /trigger sync/i }));
+
+      const jobTypeSelect = screen.getByRole('combobox', { name: /job type/i });
+      expect(jobTypeSelect).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: /^trigger$/i })).toBeDisabled();
+    });
+
+    it('keeps the existing hide-when-missing behaviour for an unauthorized non-demo viewer', async () => {
+      renderWithProviders(<ConnectionActionsPanel connection={sampleConnection} />, viewerSession);
+
+      // Wait for the session to hydrate before asserting absence.
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: 'Test connection' })).not.toBeInTheDocument();
+      });
+      expect(screen.queryByRole('link', { name: 'Edit' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /trigger sync/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Disable' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/features/connections/components/ConnectionActionsPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionActionsPanel.tsx
@@ -9,7 +9,10 @@ import { Button } from '../../../shared/ui/button';
 import { ConfirmDialog } from '../../../shared/ui/confirm-dialog';
 import { Alert } from '../../../shared/ui/alert';
 import { useToast } from '../../../shared/ui/toast-provider';
-import { usePermission } from '../../../shared/auth/use-permission';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
+import { useDemoMode } from '../../system';
 
 interface ConnectionActionsPanelProps {
   connection: Connection;
@@ -24,8 +27,9 @@ export function ConnectionActionsPanel({ connection }: ConnectionActionsPanelPro
   const plugin = usePlatform(connection.platformType);
   const PluginActions = plugin?.ConnectionActions;
 
-  const canWrite = usePermission('connections:write');
-  const canSync = usePermission('sync:write');
+  const demoMode = useDemoMode();
+  const write = useWriteAccess('connections:write', demoMode);
+  const sync = useWriteAccess('sync:write', demoMode);
 
   const isDisabled = connection.status === 'disabled';
 
@@ -69,7 +73,7 @@ export function ConnectionActionsPanel({ connection }: ConnectionActionsPanelPro
       ) : null}
 
       <div className="action-list">
-        {canWrite ? (
+        {write.visible ? (
           <div className="action-list__item">
             <div>
               <strong>Test connection</strong>
@@ -78,17 +82,19 @@ export function ConnectionActionsPanel({ connection }: ConnectionActionsPanelPro
                 stored credentials.
               </p>
             </div>
-            <Button
-              tone="secondary"
-              disabled={testConnection.isPending}
-              onClick={() => void handleTest()}
-            >
-              {testConnection.isPending ? 'Testing...' : 'Test connection'}
-            </Button>
+            <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+              <Button
+                tone="secondary"
+                disabled={testConnection.isPending || write.demoReadOnly}
+                onClick={() => void handleTest()}
+              >
+                {testConnection.isPending ? 'Testing...' : 'Test connection'}
+              </Button>
+            </ReadOnlyLock>
           </div>
         ) : null}
 
-        {canWrite ? (
+        {write.visible ? (
           <div className="action-list__item">
             <div>
               <strong>Edit connection</strong>
@@ -100,9 +106,11 @@ export function ConnectionActionsPanel({ connection }: ConnectionActionsPanelPro
           </div>
         ) : null}
 
-        {canWrite && PluginActions ? <PluginActions connection={connection} /> : null}
+        {write.visible && PluginActions ? (
+          <PluginActions connection={connection} readOnly={write.demoReadOnly} />
+        ) : null}
 
-        {canSync && !isDisabled ? (
+        {sync.visible && !isDisabled ? (
           <div className="action-list__item">
             <div>
               <strong>Trigger sync</strong>
@@ -120,19 +128,21 @@ export function ConnectionActionsPanel({ connection }: ConnectionActionsPanelPro
           </div>
         ) : null}
 
-        {canWrite && !isDisabled ? (
+        {write.visible && !isDisabled ? (
           <div className="action-list__item">
             <div>
               <strong>Disable connection</strong>
               <p className="muted-text">Stop all sync activity for this connection. This can be reversed by re-enabling.</p>
             </div>
-            <Button
-              tone="danger"
-              onClick={() => setIsDisableDialogOpen(true)}
-              disabled={disableConnection.isPending}
-            >
-              {disableConnection.isPending ? 'Disabling...' : 'Disable'}
-            </Button>
+            <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+              <Button
+                tone="danger"
+                onClick={() => setIsDisableDialogOpen(true)}
+                disabled={disableConnection.isPending || write.demoReadOnly}
+              >
+                {disableConnection.isPending ? 'Disabling...' : 'Disable'}
+              </Button>
+            </ReadOnlyLock>
           </div>
         ) : null}
       </div>
@@ -141,6 +151,7 @@ export function ConnectionActionsPanel({ connection }: ConnectionActionsPanelPro
         connection={connection}
         open={isTriggerDialogOpen}
         onOpenChange={setIsTriggerDialogOpen}
+        submitDisabled={sync.demoReadOnly}
       />
 
       <ConfirmDialog

--- a/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
@@ -1,6 +1,11 @@
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+  sampleConnection,
+} from '../../../test/test-utils';
 import type { Connection } from '../api/connections.types';
 import { EditConnectionForm } from './EditConnectionForm';
 
@@ -644,6 +649,44 @@ describe('EditConnectionForm', () => {
         environment: 'sandbox',
         masterCatalogConnectionId: '',
       });
+    });
+  });
+
+  describe('demo read-only viewer (#1615)', () => {
+    const viewerAdapter = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: null,
+      role: 'viewer',
+      permissions: ['connections:read'],
+    });
+
+    it('opens with editable inputs but disables the final submit', async () => {
+      const apiClient = createMockApiClient({
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      });
+      renderWithProviders(<EditConnectionForm connection={sampleConnection} />, {
+        apiClient,
+        sessionAdapter: viewerAdapter,
+      });
+
+      const nameInput = await screen.findByDisplayValue(sampleConnection.name);
+      expect(nameInput).not.toBeDisabled();
+      fireEvent.change(nameInput, { target: { value: 'Should not persist' } });
+      expect(nameInput).toHaveValue('Should not persist');
+
+      const submit = await screen.findByRole('button', { name: 'Save changes' });
+      expect(submit).toBeDisabled();
+    });
+
+    it('keeps the submit enabled for an admin session even in demo mode', async () => {
+      const apiClient = createMockApiClient({
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      });
+      renderWithProviders(<EditConnectionForm connection={sampleConnection} />, { apiClient });
+
+      const submit = await screen.findByRole('button', { name: 'Save changes' });
+      expect(submit).not.toBeDisabled();
     });
   });
 });

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -21,6 +21,10 @@ import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
 import { Textarea } from '../../../shared/ui/textarea';
 import { useToast } from '../../../shared/ui/toast-provider';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
+import { useDemoMode } from '../../system';
 import {
   usePlatform,
   readConfigString,
@@ -284,6 +288,8 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   const updateConnection = useUpdateConnectionMutation();
   const { showToast } = useToast();
   const navigate = useNavigate();
+  const demoMode = useDemoMode();
+  const write = useWriteAccess('connections:write', demoMode);
   const [showRawJson, setShowRawJson] = useState(false);
   const plugin = usePlatform(connection.platformType);
   // #1330 — the platform's non-render structured-config half: Zod schema
@@ -682,9 +688,11 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
       ) : null}
 
       <div className="form-actions">
-        <Button type="submit" disabled={updateConnection.isPending}>
-          {updateConnection.isPending ? 'Saving...' : 'Save changes'}
-        </Button>
+        <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+          <Button type="submit" disabled={updateConnection.isPending || write.demoReadOnly}>
+            {updateConnection.isPending ? 'Saving...' : 'Save changes'}
+          </Button>
+        </ReadOnlyLock>
         <Button tone="secondary" onClick={() => void navigate(`/connections/${connection.id}`)}>
           Cancel
         </Button>

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
@@ -30,10 +30,20 @@ beforeAll(() => {
 
 afterEach(cleanup);
 
-function renderDialog(open = true, onOpenChange = vi.fn(), apiOverrides = {}) {
+function renderDialog(
+  open = true,
+  onOpenChange = vi.fn(),
+  apiOverrides = {},
+  submitDisabled = false,
+) {
   const mockApi = createMockApiClient(apiOverrides);
   renderWithProviders(
-    <TriggerSyncDialog connection={sampleConnection} open={open} onOpenChange={onOpenChange} />,
+    <TriggerSyncDialog
+      connection={sampleConnection}
+      open={open}
+      onOpenChange={onOpenChange}
+      submitDisabled={submitDisabled}
+    />,
     { apiClient: mockApi },
   );
   return { mockApi, onOpenChange };
@@ -494,6 +504,25 @@ describe('TriggerSyncDialog', () => {
       const firstSuffix = firstKey.split(':').at(-1);
       const secondSuffix = secondKey.split(':').at(-1);
       expect(firstSuffix).toBe(secondSuffix);
+    });
+  });
+
+  describe('submitDisabled (demo read-only viewer, #1615)', () => {
+    it('renders the job type and payload inputs editable while disabling only the Trigger submit', () => {
+      renderDialog(true, vi.fn(), {}, true);
+
+      const select = screen.getByRole('combobox', { name: /job type/i });
+      expect(select).not.toBeDisabled();
+      fireEvent.change(select, { target: { value: 'master.product.syncByExternalId' } });
+      expect(select).toHaveValue('master.product.syncByExternalId');
+
+      expect(screen.getByRole('button', { name: /trigger/i })).toBeDisabled();
+    });
+
+    it('keeps the Trigger submit enabled when submitDisabled is not set', () => {
+      renderDialog();
+
+      expect(screen.getByRole('button', { name: /trigger/i })).not.toBeDisabled();
     });
   });
 });

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
@@ -23,6 +23,8 @@ import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
 import { useToast } from '../../../shared/ui/toast-provider';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
 import type { PayloadField, TriggerableJob, TriggerSyncDialogProps } from './trigger-sync-dialog.types';
 
 const ALL_TRIGGERABLE_JOBS: TriggerableJob[] = [
@@ -165,6 +167,7 @@ export function TriggerSyncDialog({
   connection,
   open,
   onOpenChange,
+  submitDisabled = false,
 }: TriggerSyncDialogProps): ReactElement {
   const triggerableJobs = useMemo(
     () =>
@@ -323,13 +326,17 @@ export function TriggerSyncDialog({
           <Button tone="secondary" onClick={() => onOpenChange(false)} disabled={enqueueSyncJob.isPending}>
             Cancel
           </Button>
-          <Button
-            tone="primary"
-            onClick={() => void handleSubmit()}
-            disabled={enqueueSyncJob.isPending || intentKey === null || !hasTriggers}
-          >
-            {enqueueSyncJob.isPending ? 'Enqueuing…' : 'Trigger'}
-          </Button>
+          <ReadOnlyLock active={submitDisabled} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+            <Button
+              tone="primary"
+              onClick={() => void handleSubmit()}
+              disabled={
+                enqueueSyncJob.isPending || intentKey === null || !hasTriggers || submitDisabled
+              }
+            >
+              {enqueueSyncJob.isPending ? 'Enqueuing…' : 'Trigger'}
+            </Button>
+          </ReadOnlyLock>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/features/sync-jobs/components/trigger-sync-dialog.types.ts
+++ b/apps/web/src/features/sync-jobs/components/trigger-sync-dialog.types.ts
@@ -44,4 +44,9 @@ export interface TriggerSyncDialogProps {
   connection: Connection;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /**
+   * Demo read-only viewer (#1615): the dialog opens with editable inputs, but
+   * the final "Trigger" submit renders disabled with a read-only tooltip.
+   */
+  submitDisabled?: boolean;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3257,6 +3257,12 @@ textarea,
   border-bottom: none;
 }
 
+/* Keeps a disabled write button wrapped by ReadOnlyLock (#1615) aligned with
+   the un-wrapped variant inside flex action rows and form action bars. */
+.read-only-lock {
+  display: inline-flex;
+}
+
 /* ── InPost webhook runbook (#1473) ── */
 .action-list__item-actions {
   display: flex;

--- a/apps/web/src/plugins/erli/components/erli-connection-actions.test.tsx
+++ b/apps/web/src/plugins/erli/components/erli-connection-actions.test.tsx
@@ -91,4 +91,16 @@ describe('ErliConnectionActions', () => {
 
     resolve({ webhooksConfigured: true, testPingTriggered: true });
   });
+
+  it('renders the Configure webhooks button disabled when readOnly is set (demo viewer, #1615)', () => {
+    renderWithProviders(<ErliConnectionActions connection={withCallbackUrl} readOnly />);
+
+    expect(screen.getByRole('button', { name: 'Configure webhooks' })).toBeDisabled();
+  });
+
+  it('keeps the button enabled when readOnly is not set', () => {
+    renderWithProviders(<ErliConnectionActions connection={withCallbackUrl} />);
+
+    expect(screen.getByRole('button', { name: 'Configure webhooks' })).not.toBeDisabled();
+  });
 });

--- a/apps/web/src/plugins/erli/components/erli-connection-actions.tsx
+++ b/apps/web/src/plugins/erli/components/erli-connection-actions.tsx
@@ -15,14 +15,18 @@ import type { ReactElement } from 'react';
 import type { Connection } from '../../../features/connections';
 import { useConfigureWebhooksMutation } from '../../../features/connections';
 import { Button } from '../../../shared/ui/button';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
 import { useToast } from '../../../shared/ui/toast-provider';
 
 interface ErliConnectionActionsProps {
   connection: Connection;
+  readOnly?: boolean;
 }
 
 export function ErliConnectionActions({
   connection,
+  readOnly = false,
 }: ErliConnectionActionsProps): ReactElement {
   const configureWebhooks = useConfigureWebhooksMutation();
   const { showToast } = useToast();
@@ -87,17 +91,19 @@ export function ErliConnectionActions({
         )}
       </div>
       {hasCallbackBaseUrl && (
-        <Button
-          tone={webhooksConfigured ? 'secondary' : 'primary'}
-          disabled={configureWebhooks.isPending}
-          onClick={() => void handleConfigureWebhooks()}
-        >
-          {configureWebhooks.isPending
-            ? 'Configuring...'
-            : webhooksConfigured
-              ? 'Re-configure webhooks'
-              : 'Configure webhooks'}
-        </Button>
+        <ReadOnlyLock active={readOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+          <Button
+            tone={webhooksConfigured ? 'secondary' : 'primary'}
+            disabled={configureWebhooks.isPending || readOnly}
+            onClick={() => void handleConfigureWebhooks()}
+          >
+            {configureWebhooks.isPending
+              ? 'Configuring...'
+              : webhooksConfigured
+                ? 'Re-configure webhooks'
+                : 'Configure webhooks'}
+          </Button>
+        </ReadOnlyLock>
       )}
     </div>
   );

--- a/apps/web/src/plugins/prestashop/components/prestashop-connection-actions.tsx
+++ b/apps/web/src/plugins/prestashop/components/prestashop-connection-actions.tsx
@@ -10,16 +10,20 @@
  */
 import type { ReactElement } from 'react';
 import { Button } from '../../../shared/ui/button';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
 import { useToast } from '../../../shared/ui/toast-provider';
 import { useConfigureWebhooksMutation } from '../../../features/connections';
 import type { Connection } from '../../../features/connections';
 
 interface PrestashopConnectionActionsProps {
   connection: Connection;
+  readOnly?: boolean;
 }
 
 export function PrestashopConnectionActions({
   connection,
+  readOnly = false,
 }: PrestashopConnectionActionsProps): ReactElement {
   const configureWebhooks = useConfigureWebhooksMutation();
   const { showToast } = useToast();
@@ -71,17 +75,19 @@ export function PrestashopConnectionActions({
           {webhooksConfigured ? ' Currently configured ✓' : ''}
         </p>
       </div>
-      <Button
-        tone={webhooksConfigured ? 'secondary' : 'primary'}
-        disabled={configureWebhooks.isPending}
-        onClick={() => void handleConfigureWebhooks()}
-      >
-        {configureWebhooks.isPending
-          ? 'Configuring...'
-          : webhooksConfigured
-            ? 'Re-configure webhooks'
-            : 'Configure webhooks'}
-      </Button>
+      <ReadOnlyLock active={readOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+        <Button
+          tone={webhooksConfigured ? 'secondary' : 'primary'}
+          disabled={configureWebhooks.isPending || readOnly}
+          onClick={() => void handleConfigureWebhooks()}
+        >
+          {configureWebhooks.isPending
+            ? 'Configuring...'
+            : webhooksConfigured
+              ? 'Re-configure webhooks'
+              : 'Configure webhooks'}
+        </Button>
+      </ReadOnlyLock>
     </div>
   );
 }

--- a/apps/web/src/shared/auth/use-permission.test.ts
+++ b/apps/web/src/shared/auth/use-permission.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { createElement } from 'react';
-import { usePermission } from './use-permission';
+import { usePermission, useWriteAccess } from './use-permission';
 import { SessionProvider } from './session-provider';
 import type { SessionAdapter } from './session-adapter';
 import type { Session } from './session.types';
@@ -110,5 +110,34 @@ describe('usePermission', () => {
       wrapper: makeWrapper(adminSession),
     });
     await waitFor(() => expect(result.current).toBe(false));
+  });
+});
+
+describe('useWriteAccess', () => {
+  it('grants full write access when the session holds the permission, regardless of demo mode', async () => {
+    const { result } = renderHook(() => useWriteAccess('connections:write', true), {
+      wrapper: makeWrapper(adminSession),
+    });
+    await waitFor(() =>
+      expect(result.current).toEqual({ canWrite: true, demoReadOnly: false, visible: true }),
+    );
+  });
+
+  it('marks a viewer without the permission as demo-read-only when demo mode is on (#1615)', async () => {
+    const { result } = renderHook(() => useWriteAccess('connections:write', true), {
+      wrapper: makeWrapper(viewerSession),
+    });
+    await waitFor(() =>
+      expect(result.current).toEqual({ canWrite: false, demoReadOnly: true, visible: true }),
+    );
+  });
+
+  it('hides the affordance for a viewer without the permission outside demo mode (unchanged)', async () => {
+    const { result } = renderHook(() => useWriteAccess('connections:write', false), {
+      wrapper: makeWrapper(viewerSession),
+    });
+    await waitFor(() =>
+      expect(result.current).toEqual({ canWrite: false, demoReadOnly: false, visible: false }),
+    );
   });
 });

--- a/apps/web/src/shared/auth/use-permission.ts
+++ b/apps/web/src/shared/auth/use-permission.ts
@@ -21,3 +21,41 @@ export function usePermission(permission: Permission): boolean {
   const { session } = useSession();
   return session.user?.permissions.includes(permission) ?? false;
 }
+
+/**
+ * Write-access decision for a permission-gated affordance, aware of demo mode.
+ *
+ * Splits the two "can't write" cases that used to collapse into a single
+ * hidden control (#1615):
+ *
+ * - `canWrite` — the session holds the permission; render enabled.
+ * - `demoReadOnly` — the session lacks the permission **but** the deployment is
+ *   a public demo, so the affordance still renders (disabled, with a read-only
+ *   tooltip) to advertise that the capability exists. This is the relaxation
+ *   scoped to demo read-only viewers.
+ * - neither — genuinely unauthorized non-demo session; `visible` is false and
+ *   the caller keeps the existing hide-when-missing behaviour.
+ *
+ * `demoMode` is passed in (rather than read here) so this hook stays in the
+ * `shared` layer without importing the `features/system` demo-mode hook — call
+ * sites resolve it via `useDemoMode()`.
+ *
+ * @example
+ * const demoMode = useDemoMode();
+ * const write = useWriteAccess('connections:write', demoMode);
+ * // {write.visible && <Button disabled={write.demoReadOnly}>Disable</Button>}
+ */
+export interface WriteAccess {
+  /** Session holds the permission — full write access. */
+  canWrite: boolean;
+  /** Write blocked, but the control still renders (disabled) — demo viewer. */
+  demoReadOnly: boolean;
+  /** Whether the write affordance should render at all. */
+  visible: boolean;
+}
+
+export function useWriteAccess(permission: Permission, demoMode: boolean): WriteAccess {
+  const canWrite = usePermission(permission);
+  const demoReadOnly = !canWrite && demoMode;
+  return { canWrite, demoReadOnly, visible: canWrite || demoReadOnly };
+}

--- a/apps/web/src/shared/config/demo-mode.ts
+++ b/apps/web/src/shared/config/demo-mode.ts
@@ -33,3 +33,12 @@ export const BULK_AI_TOGGLE_REQUIRES_WRITE_MESSAGE =
  */
 export const NAV_DEMO_RESTRICTED_MESSAGE =
   'Requires an administrator role.';
+
+/**
+ * Tooltip on a write action a demo read-only viewer sees rendered-but-disabled.
+ * The action stays visible so the demo advertises the capability exists; the
+ * final write submit is locked because the deployment is read-only in demo
+ * mode. Only shown to demo viewers — genuinely unauthorized non-demo sessions
+ * keep the existing hide-when-missing behaviour (see `useWriteAccess`).
+ */
+export const DEMO_READ_ONLY_ACTION_MESSAGE = 'Read-only in demo mode.';

--- a/apps/web/src/shared/plugins/plugin.types.ts
+++ b/apps/web/src/shared/plugins/plugin.types.ts
@@ -522,8 +522,12 @@ export interface PlatformContribution {
    * Connection-detail: contribute extra platform-specific actions to the
    * actions panel. Rendered as a sub-tree below the generic actions; the
    * component owns its mutation hooks and toast feedback.
+   *
+   * `readOnly` is set when the panel is shown to a demo read-only viewer
+   * (#1615): the action stays visible but its write buttons render disabled
+   * with a read-only tooltip.
    */
-  ConnectionActions?: ComponentType<{ connection: Connection }>;
+  ConnectionActions?: ComponentType<{ connection: Connection; readOnly?: boolean }>;
   /** Listing-detail: gate the "Edit offer" button on `ListingDetailPage`. */
   supportsListingEdit?: boolean;
   /**

--- a/apps/web/src/shared/ui/read-only-lock.tsx
+++ b/apps/web/src/shared/ui/read-only-lock.tsx
@@ -1,0 +1,41 @@
+/**
+ * ReadOnlyLock
+ *
+ * Wraps a disabled write affordance with a tooltip explaining why it is locked.
+ * When `active` is false it renders its children untouched, so call sites can
+ * always mount the same subtree and only opt into the lock treatment for demo
+ * read-only viewers (#1615).
+ *
+ * The `<span>` wrapper is required because a natively-disabled `<button>` emits
+ * no pointer events, so the Radix tooltip would never trigger without it (same
+ * pattern as the AI-suggest locked trigger in `suggestion-dialog.tsx`).
+ *
+ * @module shared/ui
+ */
+import type { ReactElement, ReactNode } from 'react';
+import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip';
+
+interface ReadOnlyLockProps {
+  /** When true, wrap children with the locked tooltip; otherwise pass through. */
+  active: boolean;
+  /** Tooltip copy explaining why the affordance is disabled. */
+  message: string;
+  children: ReactNode;
+}
+
+export function ReadOnlyLock({ active, message, children }: ReadOnlyLockProps): ReactElement {
+  if (!active) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="read-only-lock" tabIndex={0}>
+          {children}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{message}</TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Summary

On a connection's Actions tab, write-gated action rows (Test connection, Edit connection, Trigger sync, Disable connection, plugin actions) were fully hidden from any session lacking the permission - including demo read-only viewers. This meant a public demo deployment couldn't show what the platform can actually do.

This PR splits the "can't write" case into two, via a new `useWriteAccess(permission, demoMode)` hook in `shared/auth/use-permission.ts`:
- **demo viewer** (lacks the permission, deployment is in demo mode): the action still renders, but the write affordance is disabled with a "Read-only in demo mode" tooltip (new `ReadOnlyLock` component at `shared/ui/read-only-lock.tsx`).
- **genuinely unauthorized, non-demo**: unchanged - the row is hidden entirely.

Behavior per action:
- **Test connection** / **Disable connection**: button renders, disabled, tooltip.
- **Edit connection** / **Trigger sync**: the row/link still opens the edit form or dialog with fully editable inputs; only the final submit button (`Save changes` / `Trigger`) is disabled.
- **Plugin actions** (`ConnectionActions` contribution): the panel now passes a `readOnly` prop; Erli's and PrestaShop's "Configure webhooks" render disabled with the same tooltip.

Authorized operators/admins are unaffected; unauthorized non-demo sessions keep the current hide-when-missing behavior.

This also covers the shared demo-viewer connections nav/route access relaxation this issue carries for siblings #1614/#1616 - the Connections nav group and its routes already have no admin-only gate, so no separate change was needed there.

## Test plan

- [x] `pnpm --filter @openlinker/web lint` - 0 errors (pre-existing warnings only)
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] `pnpm --filter @openlinker/web test` - all 2193 tests pass, including new coverage:
  - `use-permission.test.ts`: `useWriteAccess` admin / demo-viewer / non-demo-unauthorized matrix
  - `ConnectionActionsPanel.test.tsx`: demo viewer sees all actions disabled-not-hidden, Trigger sync dialog opens with editable job-type select and disabled submit, non-demo unauthorized viewer keeps hide behavior
  - `EditConnectionForm.test.tsx`: demo viewer can edit fields but submit is disabled; admin submit stays enabled in demo mode
  - `TriggerSyncDialog.test.tsx`: `submitDisabled` prop locks only the Trigger button
  - `erli-connection-actions.test.tsx`: `readOnly` prop disables Configure webhooks

Part of #1606
Closes #1615