### PR TITLE
feat(web/orders): responsive orders table with expandable rows and mobile cards

### DIFF
--- a/apps/web/src/features/orders/components/order-row-detail.test.tsx
+++ b/apps/web/src/features/orders/components/order-row-detail.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * OrderRowDetail tests
+ *
+ * Covers the expandable-row / mobile-card detail panel (#1620): every field
+ * slot renders even when the underlying data is missing (showing "-"), and
+ * populated fields surface the parsed snapshot values.
+ */
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { OrderRowDetail } from './order-row-detail';
+import type { OrderRecord } from '../api/orders.types';
+
+const baseOrder: OrderRecord = {
+  internalOrderId: 'ol_order_bare',
+  customerId: null,
+  sourceConnectionId: 'conn_1',
+  sourceEventId: null,
+  orderSnapshot: {},
+  syncStatus: [],
+  syncAttempts: [],
+  recordStatus: 'ready',
+  createdAt: '2026-01-15T10:00:00.000Z',
+  updatedAt: '2026-01-15T10:00:00.000Z',
+};
+
+function renderDetail(order: OrderRecord): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter>
+      <OrderRowDetail order={order} channelLabel={() => undefined} platformByConnection={new Map()} />
+    </MemoryRouter>,
+  );
+}
+
+describe('OrderRowDetail', () => {
+  afterEach(cleanup);
+
+  it('renders "-" for every field when the snapshot has no data', () => {
+    renderDetail(baseOrder);
+
+    const placeholders = screen.getAllByText('-');
+    // Order reference, items, ship-by, carrier, destination, placed, payment,
+    // shipping address, billing address — every optional slot falls back.
+    expect(placeholders.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it('always renders the internal id and created timestamp', () => {
+    renderDetail(baseOrder);
+
+    expect(screen.getByText('ol_order_bare')).toBeInTheDocument();
+  });
+
+  it('renders parsed snapshot values when present', () => {
+    const order: OrderRecord = {
+      ...baseOrder,
+      orderSnapshot: {
+        orderNumber: 'ALG-1',
+        items: [{ id: 'i1', quantity: 1, price: 10, name: 'Widget' }],
+        paymentStatus: 'paid',
+        shippingAddress: {
+          firstName: 'Anna',
+          lastName: 'Kowalska',
+          address1: 'ul. Testowa 1',
+          city: 'Warszawa',
+          postalCode: '00-001',
+          country: 'PL',
+        },
+      },
+    };
+
+    renderDetail(order);
+
+    expect(screen.getByText('ALG-1')).toBeInTheDocument();
+    expect(screen.getByText('1 item')).toBeInTheDocument();
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+    expect(screen.getByText('Paid')).toBeInTheDocument();
+    const shippingField = screen.getByText('Shipping address').closest('div') as HTMLElement;
+    expect(within(shippingField).getByText('Anna Kowalska')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/orders/components/order-row-detail.tsx
+++ b/apps/web/src/features/orders/components/order-row-detail.tsx
@@ -1,0 +1,119 @@
+/**
+ * OrderRowDetail
+ *
+ * The non-essential order fields moved out of the dense orders-list row into a
+ * shared detail view (#1620). On desktop it fills the expandable-row accordion
+ * panel; on mobile it fills the card body so a collapsed card still shows every
+ * field. Every field is always rendered — missing values show "-" — so the
+ * detail reads the same across both layouts and no data is hidden.
+ *
+ * Pure presentation: all inputs are already-resolved view-model values; no
+ * transport logic at this layer.
+ *
+ * @module features/orders/components
+ */
+import type { ReactElement, ReactNode } from 'react';
+import { TimeDisplay } from '../../../shared/ui/time-display';
+import { parseOrderSnapshot, type ParsedAddress } from '../api/order-snapshot.schema';
+import type { OrderRecord } from '../api/orders.types';
+
+interface OrderRowDetailProps {
+  order: OrderRecord;
+  /** Resolve a source/destination platformType to a human channel label. */
+  channelLabel: (platform: string | undefined) => string | undefined;
+  platformByConnection: Map<string, string>;
+}
+
+const PAYMENT_LABELS: Record<string, string> = {
+  paid: 'Paid',
+  cod: 'Cash on delivery',
+  awaiting: 'Awaiting payment',
+  refunded: 'Refunded',
+};
+
+/** Placeholder for an absent value — keeps every field slot visible. */
+const EMPTY = '-';
+
+function formatAddress(address: ParsedAddress | undefined): ReactNode {
+  if (!address) return EMPTY;
+  const name = [address.firstName, address.lastName].filter(Boolean).join(' ').trim();
+  const lines = [
+    name || address.company || null,
+    address.address1,
+    address.address2 || null,
+    [address.postalCode, address.city].filter(Boolean).join(' ').trim() || null,
+    address.state || null,
+    address.country,
+  ].filter((line): line is string => Boolean(line && line.length > 0));
+  if (lines.length === 0) return EMPTY;
+  return (
+    <span className="orders-detail__address">
+      {lines.map((line, index) => (
+        <span key={index}>{line}</span>
+      ))}
+    </span>
+  );
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }): ReactElement {
+  return (
+    <div className="orders-detail__field">
+      <dt className="orders-detail__label">{label}</dt>
+      <dd className="orders-detail__value">{children}</dd>
+    </div>
+  );
+}
+
+export function OrderRowDetail({
+  order,
+  channelLabel,
+  platformByConnection,
+}: OrderRowDetailProps): ReactElement {
+  const parsed = parseOrderSnapshot(order.orderSnapshot);
+  const itemNames = parsed.items.map((i) => i.name).filter((n): n is string => Boolean(n));
+  const carrier = parsed.shipping?.methodName ?? parsed.pickupPoint?.name ?? null;
+  const destPlatform = order.syncStatus[0]
+    ? platformByConnection.get(order.syncStatus[0].destinationConnectionId)
+    : undefined;
+  const destLabel = channelLabel(destPlatform);
+  const paymentLabel = parsed.paymentStatus ? PAYMENT_LABELS[parsed.paymentStatus] : null;
+
+  return (
+    <dl className="orders-detail">
+      <Field label="Order reference">
+        {parsed.orderNumber ? <span className="mono">{parsed.orderNumber}</span> : EMPTY}
+      </Field>
+      <Field label="Internal ID">
+        <span className="mono">{order.internalOrderId}</span>
+      </Field>
+      <Field label="Items">
+        {parsed.items.length === 0 ? (
+          EMPTY
+        ) : (
+          <span className="orders-detail__items">
+            <span>
+              {parsed.items.length} {parsed.items.length === 1 ? 'item' : 'items'}
+            </span>
+            {itemNames.length > 0 ? (
+              <span className="text-muted">{itemNames.join(', ')}</span>
+            ) : null}
+          </span>
+        )}
+      </Field>
+      <Field label="Ship-by">
+        {order.dispatchByAt ? <TimeDisplay iso={order.dispatchByAt} format="datetime" /> : EMPTY}
+      </Field>
+      <Field label="Carrier">{carrier ?? EMPTY}</Field>
+      <Field label="Destination">{destLabel ?? EMPTY}</Field>
+      <Field label="Created">
+        <TimeDisplay iso={order.createdAt} format="datetime" />
+      </Field>
+      <Field label="Placed">
+        {parsed.placedAt ? <TimeDisplay iso={parsed.placedAt} format="datetime" /> : EMPTY}
+      </Field>
+      <Field label="Payment">{paymentLabel ?? EMPTY}</Field>
+      <Field label="Shipping address">{formatAddress(parsed.shippingAddress)}</Field>
+      <Field label="Billing address">{formatAddress(parsed.billingAddress)}</Field>
+    </dl>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2663,8 +2663,8 @@ textarea,
 
 .data-table__card {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
   gap: 12px;
   padding: 12px 14px;
   border: 1px solid var(--border-default);
@@ -2726,6 +2726,127 @@ textarea,
   color: var(--text-muted);
   border: 1px dashed var(--border-default);
   border-radius: 10px;
+}
+
+/* ── Expandable rows (#1620) ─────────────────────────────────────────── */
+
+.data-table__expand-cell {
+  width: 2.25rem;
+  padding-left: var(--space-2) !important;
+  padding-right: 0 !important;
+  text-align: center;
+}
+
+.data-table__expand-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-xs);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out);
+}
+
+.data-table__expand-toggle:hover {
+  color: var(--text-primary);
+  background: color-mix(in oklab, var(--bg-shell) 70%, transparent);
+}
+
+.data-table__expand-toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.data-table__expand-icon {
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
+.data-table__row--expandable {
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.data-table__row--expandable:hover {
+  background: color-mix(in oklab, var(--bg-shell) 60%, transparent);
+}
+
+.data-table__row--expanded {
+  background: color-mix(in oklab, var(--bg-shell) 45%, transparent);
+}
+
+.data-table__detail-row > .data-table__detail-cell {
+  padding: 0;
+  background: var(--bg-shell);
+  border-top: 0;
+}
+
+.data-table__detail {
+  padding: var(--space-4) var(--space-4) var(--space-4) 2.75rem;
+}
+
+/* Detail field grid — shared by the desktop accordion and the mobile card. */
+.orders-detail {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-3) var(--space-5);
+  margin: 0;
+}
+
+.orders-detail__field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.orders-detail__label {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.orders-detail__value {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.orders-detail__address,
+.orders-detail__items {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+/* ── Mobile card select + detail (#1620) ─────────────────────────────── */
+
+.data-table__card-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+}
+
+.data-table__card-select {
+  flex-shrink: 0;
+  padding-top: 2px;
+}
+
+.data-table__card-detail {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-subtle);
 }
 
 /* DataTableSkeleton — shimmer placeholder that mirrors .data-table shape. */

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -95,6 +95,24 @@ const emptySummary: OrderHealthSummary = {
   awaitingDispatch: 0,
 };
 
+/** Forces the mobile (cardView) breakpoint for the DataTable (#1620). */
+function mockMobileViewport(): { restore: () => void } {
+  const spy = vi.spyOn(window, 'matchMedia').mockImplementation(
+    (query) =>
+      ({
+        matches: query.includes('max-width'),
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList,
+  );
+  return { restore: () => spy.mockRestore() };
+}
+
 describe('OrdersListPage', () => {
   afterEach(cleanup);
 
@@ -233,7 +251,7 @@ describe('OrdersListPage', () => {
     expect(within(row).getByText('Awaiting dispatch')).toBeInTheDocument();
   });
 
-  it('should render customer and item-count columns parsed from the snapshot (#929)', async () => {
+  it('should render customer columns parsed from the snapshot (#929)', async () => {
     const mockApi = createMockApiClient({
       orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
       connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
@@ -245,7 +263,73 @@ describe('OrdersListPage', () => {
     const row = container.querySelector('.data-table__row') as HTMLElement;
     expect(within(row).getByText('Anna Kowalska')).toBeInTheDocument();
     expect(within(row).getByText('Warszawa')).toBeInTheDocument();
-    expect(within(row).getByText('1 item')).toBeInTheDocument();
+  });
+
+  it('should expand the row detail with the item count when the row is clicked (#1620)', async () => {
+    const user = userEvent.setup();
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    expect(container.querySelector('.data-table__detail-row')).toBeNull();
+
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+    await user.click(row);
+
+    const detailRow = container.querySelector('.data-table__detail-row') as HTMLElement;
+    expect(detailRow).not.toBeNull();
+    expect(within(detailRow).getByText('1 item')).toBeInTheDocument();
+    expect(row).toHaveAttribute('class', expect.stringContaining('data-table__row--expanded'));
+
+    await user.click(row);
+    expect(container.querySelector('.data-table__detail-row')).toBeNull();
+  });
+
+  it('should not expand the row when the select checkbox is clicked (#1620)', async () => {
+    const user = userEvent.setup();
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    const checkbox = screen.getByRole('checkbox', { name: 'Select ol_order_synced' });
+    await user.click(checkbox);
+
+    expect(container.querySelector('.data-table__detail-row')).toBeNull();
+    expect(checkbox).toBeChecked();
+  });
+
+  it('should expose a working select checkbox and full field detail in the mobile card view (#1620)', async () => {
+    const viewport = mockMobileViewport();
+    try {
+      const user = userEvent.setup();
+      const mockApi = createMockApiClient({
+        orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
+        connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+      });
+
+      const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+      await screen.findAllByText('ALG-882414');
+      expect(container.querySelector('table')).toBeNull();
+
+      const card = container.querySelector('.data-table__card') as HTMLElement;
+      expect(card).not.toBeNull();
+      expect(within(card).getByText('1 item')).toBeInTheDocument();
+
+      const checkbox = within(card).getByRole('checkbox', { name: 'Select ol_order_synced' });
+      await user.click(checkbox);
+      expect(checkbox).toBeChecked();
+    } finally {
+      viewport.restore();
+    }
   });
 
   it('should render a channel-pill resolved from the connection platformType', async () => {

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -52,6 +52,7 @@ import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.sch
 import { deriveOrderHealth, slaBadge, fulfillmentBadge } from '../../features/orders/lib/order-health';
 import { capSelectionPerSource, sourcesAtCap } from '../../features/orders/lib/dispatch-input';
 import { BulkDispatchDialog } from '../../features/orders/components/bulk-dispatch-dialog';
+import { OrderRowDetail } from '../../features/orders/components/order-row-detail';
 import { BULK_DISPATCH_MAX_ITEMS } from '../../features/shipments';
 import type {
   OrderRecord,
@@ -422,6 +423,37 @@ export function OrdersListPage(): ReactElement {
     setSelectedIds(new Set());
   }
 
+  /**
+   * Per-row selection checkbox (#1109) — shared verbatim by the desktop select
+   * column and the mobile card select slot (#1620) so multi-select behaves
+   * identically in both layouts (already-shipped rows disabled; per-source cap
+   * enforced on add).
+   */
+  function renderSelectCheckbox(order: OrderRecord): ReactElement {
+    if (!isSelectable(order)) {
+      return (
+        <CheckboxCell
+          state="none"
+          disabled
+          onToggle={() => {}}
+          ariaLabel={`${order.internalOrderId} is already shipped`}
+          tooltip="Already shipped"
+        />
+      );
+    }
+    const checked = selectedIds.has(order.internalOrderId);
+    const disabled = !checked && atCapSources.has(order.sourceConnectionId);
+    return (
+      <CheckboxCell
+        state={checked ? 'all' : 'none'}
+        disabled={disabled}
+        onToggle={() => { toggleSelectRow(order); }}
+        ariaLabel={checked ? `Unselect ${order.internalOrderId}` : `Select ${order.internalOrderId}`}
+        tooltip={disabled ? `Max ${BULK_DISPATCH_MAX_ITEMS} per source` : undefined}
+      />
+    );
+  }
+
   const columns: DataTableColumn<OrderRecord>[] = useMemo(
     () => [
       {
@@ -436,30 +468,7 @@ export function OrdersListPage(): ReactElement {
             }
           />
         ),
-        cell: (order) => {
-          if (!isSelectable(order)) {
-            return (
-              <CheckboxCell
-                state="none"
-                disabled
-                onToggle={() => {}}
-                ariaLabel={`${order.internalOrderId} is already shipped`}
-                tooltip="Already shipped"
-              />
-            );
-          }
-          const checked = selectedIds.has(order.internalOrderId);
-          const disabled = !checked && atCapSources.has(order.sourceConnectionId);
-          return (
-            <CheckboxCell
-              state={checked ? 'all' : 'none'}
-              disabled={disabled}
-              onToggle={() => { toggleSelectRow(order); }}
-              ariaLabel={checked ? `Unselect ${order.internalOrderId}` : `Select ${order.internalOrderId}`}
-              tooltip={disabled ? `Max ${BULK_DISPATCH_MAX_ITEMS} per source` : undefined}
-            />
-          );
-        },
+        cell: (order) => renderSelectCheckbox(order),
         align: 'left',
       },
       {
@@ -471,6 +480,7 @@ export function OrdersListPage(): ReactElement {
             <EntityLabel
               id={order.internalOrderId}
               name={formatOrderRef(parsed.orderNumber) || order.internalOrderId}
+              to={order.internalOrderId}
             />
           );
         },
@@ -491,27 +501,6 @@ export function OrdersListPage(): ReactElement {
             </span>
           );
         },
-        hideBelow: 768,
-      },
-      {
-        id: 'items',
-        header: 'Items',
-        sortable: true,
-        cell: (order) => {
-          const parsed = parseOrderSnapshot(order.orderSnapshot);
-          const count = parsed.items.length;
-          if (count === 0) return <span className="text-muted">—</span>;
-          const first = parsed.items[0]?.name;
-          return (
-            <span className="orders-cell-stack">
-              <span>
-                {count} {count === 1 ? 'item' : 'items'}
-              </span>
-              {first ? <span className="text-muted orders-cell-sub">{first}</span> : null}
-            </span>
-          );
-        },
-        hideBelow: 1024,
       },
       {
         id: 'channel',
@@ -532,7 +521,6 @@ export function OrdersListPage(): ReactElement {
             </span>
           );
         },
-        hideBelow: 768,
       },
       {
         id: 'status',
@@ -565,6 +553,7 @@ export function OrdersListPage(): ReactElement {
           // BE-owned SLA bucket drives the badge (#1108) — single source of truth
           // the filter agrees with; the live countdown stays client-side. Falls
           // back to the client-derived urgency for older payloads without slaState.
+          // The exact ship-by date moved to the expandable detail panel (#1620).
           const sla = slaBadge(order.slaState);
           const tone = sla ? sla.tone : SHIP_BY_TONE[view.level];
           const label = sla ? sla.label : view.remaining;
@@ -573,14 +562,12 @@ export function OrdersListPage(): ReactElement {
               <StatusBadge tone={tone} withDot compact>
                 {label}
               </StatusBadge>
-              <span className="text-muted orders-cell-sub mono tabular">
-                {sla ? `${view.remaining} · ` : ''}
-                <TimeDisplay iso={due} format="date" />
-              </span>
+              {sla ? (
+                <span className="text-muted orders-cell-sub mono tabular">{view.remaining}</span>
+              ) : null}
             </span>
           );
         },
-        hideBelow: 768,
       },
       {
         id: 'fulfillment',
@@ -594,19 +581,6 @@ export function OrdersListPage(): ReactElement {
             </StatusBadge>
           );
         },
-        hideBelow: 1024,
-      },
-      {
-        id: 'createdAt',
-        header: 'Created',
-        sortable: true,
-        cell: (order) => <TimeDisplay iso={order.createdAt} format="relative" />,
-      },
-      {
-        id: 'payment',
-        header: 'Payment',
-        cell: () => <span className="orders-ghost" title="Payment status — arrives with #928">soon</span>,
-        hideBelow: 1024,
       },
       {
         id: 'total',
@@ -950,7 +924,20 @@ export function OrdersListPage(): ReactElement {
             columns={columns}
             rows={query.data?.items ?? []}
             rowKey={(order) => order.internalOrderId}
-            rowHref={(order) => order.internalOrderId}
+            expandable={{
+              // Non-essential fields (order ref, items, exact ship-by, carrier,
+              // created, payment, addresses) live in the accordion (#1620); the
+              // row keeps the scannable essentials + status badges.
+              renderDetail: (order) => (
+                <OrderRowDetail
+                  order={order}
+                  channelLabel={channelLabel}
+                  platformByConnection={platformByConnection}
+                />
+              ),
+              toggleLabel: (order, expanded) =>
+                `${expanded ? 'Collapse' : 'Expand'} details for order ${order.internalOrderId}`,
+            }}
             manualSorting
             sort={sortingState}
             onSortChange={(updater) => {
@@ -975,16 +962,28 @@ export function OrdersListPage(): ReactElement {
               });
             }}
             cardView={{
+              // Per-row select stays usable in the mobile card layout (#1109/#1620).
+              select: (order) => renderSelectCheckbox(order),
               title: (order) => {
                 const parsed = parseOrderSnapshot(order.orderSnapshot);
                 return (
                   <EntityLabel
                     id={order.internalOrderId}
                     name={formatOrderRef(parsed.orderNumber) || order.internalOrderId}
+                    to={order.internalOrderId}
                   />
                 );
               },
               subtitle: (order) => <TimeDisplay iso={order.createdAt} format="relative" />,
+              // Full field set below the badges — the mobile counterpart of the
+              // desktop accordion; a collapsed card still shows every field (#1620).
+              detail: (order) => (
+                <OrderRowDetail
+                  order={order}
+                  channelLabel={channelLabel}
+                  platformByConnection={platformByConnection}
+                />
+              ),
               meta: (order) => {
                 const h = deriveOrderHealth(order);
                 const source = channelLabel(platformByConnection.get(order.sourceConnectionId));

--- a/apps/web/src/shared/ui/data-table.test.tsx
+++ b/apps/web/src/shared/ui/data-table.test.tsx
@@ -433,6 +433,37 @@ describe('DataTable', () => {
     expect(screen.getByText('No rows')).toBeInTheDocument();
   });
 
+  it('disables virtualization and warns when expandable and virtualize are both set (#1634)', async () => {
+    const user = userEvent.setup();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { container } = renderWithRouter(
+        <DataTable<TestRow>
+          columns={[{ id: 'name', header: 'Name', cell: (row): string => row.name }]}
+          rowKey={(row): string => row.id}
+          rows={ROWS}
+          virtualize
+          expandable={{
+            renderDetail: (row) => <p>Detail for {row.name}</p>,
+          }}
+        />,
+      );
+
+      // Virtualization is a no-op while expandable is set — every row renders.
+      expect(container.querySelector('.data-table__virtual-scroller')).toBeNull();
+      expect(container.querySelectorAll('tbody tr').length).toBe(ROWS.length);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[DataTable]'));
+
+      // The expand toggle still works correctly (renders detail content), it's
+      // just not virtualized.
+      const toggle = screen.getAllByRole('button', { name: /Expand row details/ })[0];
+      await user.click(toggle);
+      expect(screen.getByText('Detail for Bravo')).toBeInTheDocument();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('does not wrap the table in a scroll container when virtualize is false', () => {
     const { container } = renderWithRouter(
       <DataTable<TestRow>

--- a/apps/web/src/shared/ui/data-table.test.tsx
+++ b/apps/web/src/shared/ui/data-table.test.tsx
@@ -461,6 +461,77 @@ describe('DataTable', () => {
     expect(dataTableContainer).toHaveAttribute('aria-label', 'Invoices (scrollable)');
   });
 
+  it('expands and collapses a row detail panel when the row is clicked (#1620)', async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithRouter(
+      <DataTable<TestRow>
+        columns={[{ id: 'name', header: 'Name', cell: (row): string => row.name }]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        expandable={{
+          renderDetail: (row) => <p>Detail for {row.name}</p>,
+        }}
+      />,
+    );
+
+    expect(container.querySelector('.data-table__detail-row')).toBeNull();
+
+    const firstRow = screen.getAllByRole('row').filter((row) => row.querySelector('td'))[0];
+    await user.click(firstRow);
+
+    expect(screen.getByText('Detail for Bravo')).toBeInTheDocument();
+    expect(firstRow).toHaveClass('data-table__row--expanded');
+
+    await user.click(firstRow);
+    expect(screen.queryByText('Detail for Bravo')).toBeNull();
+  });
+
+  it('toggles the row detail via the toggle button without double-toggling from row bubbling (#1620)', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <DataTable<TestRow>
+        columns={[{ id: 'name', header: 'Name', cell: (row): string => row.name }]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        expandable={{
+          renderDetail: (row) => <p>Detail for {row.name}</p>,
+        }}
+      />,
+    );
+
+    const toggle = screen.getAllByRole('button', { name: /Expand row details/ })[0];
+    await user.click(toggle);
+    expect(screen.getByText('Detail for Bravo')).toBeInTheDocument();
+  });
+
+  it('does not expand the row when a checkbox inside the row is clicked (#1620)', async () => {
+    const onToggle = vi.fn();
+    const user = userEvent.setup();
+    renderWithRouter(
+      <DataTable<TestRow>
+        columns={[
+          {
+            id: 'select',
+            header: 'Select',
+            cell: () => <input type="checkbox" aria-label="select-row" onChange={onToggle} />,
+          },
+          { id: 'name', header: 'Name', cell: (row): string => row.name },
+        ]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        expandable={{
+          renderDetail: (row) => <p>Detail for {row.name}</p>,
+        }}
+      />,
+    );
+
+    const checkbox = screen.getAllByRole('checkbox', { name: 'select-row' })[0];
+    await user.click(checkbox);
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/Detail for/)).toBeNull();
+  });
+
   it('does not mark the container as a scrollable region when rendering mobile cards', () => {
     const { restore } = mockMobileViewport();
     try {

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -10,6 +10,7 @@ import {
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
+  Fragment,
   useCallback,
   useMemo,
   useRef,
@@ -44,6 +45,31 @@ export interface DataTableCardView<Row> {
   meta?: (row: Row) => ReactNode;
   subtitle?: (row: Row) => ReactNode;
   title: (row: Row) => ReactNode;
+  /**
+   * Leading selection slot (e.g. a checkbox), rendered outside the card's
+   * navigation Link so toggling it never navigates. Keeps multi-select usable
+   * in the mobile card layout (#1620).
+   */
+  select?: (row: Row) => ReactNode;
+  /**
+   * Full field set for the card body — the mobile counterpart of the desktop
+   * expandable detail panel. Rendered below the meta row so a card shows every
+   * field without an expand step (#1620).
+   */
+  detail?: (row: Row) => ReactNode;
+}
+
+/**
+ * Per-row expandable detail (#1620). When provided, the desktop table renders a
+ * leading toggle column; clicking a row (or its toggle) reveals `renderDetail`
+ * in an accordion panel beneath the row instead of navigating. Interactive
+ * elements inside the row (links, buttons, checkboxes) still short-circuit the
+ * toggle. Expandable takes precedence over `rowHref` for the row-level click.
+ */
+export interface DataTableExpandable<Row> {
+  renderDetail: (row: Row) => ReactNode;
+  /** aria-label for the per-row toggle button. */
+  toggleLabel?: (row: Row, expanded: boolean) => string;
 }
 
 interface DataTableProps<Row> {
@@ -54,6 +80,8 @@ interface DataTableProps<Row> {
   /** Fixed scroll-container height when virtualize is enabled. Default 560. */
   containerHeight?: number;
   emptyState?: ReactNode;
+  /** Per-row expandable detail panel (desktop accordion). See {@link DataTableExpandable}. */
+  expandable?: DataTableExpandable<Row>;
   /** Per-row height estimate used by the virtualizer. Default 36. */
   estimateRowHeight?: number;
   /**
@@ -98,6 +126,7 @@ export function DataTable<Row>({
   columns,
   containerHeight = 560,
   emptyState,
+  expandable,
   estimateRowHeight = 36,
   manualSorting = false,
   onSortChange,
@@ -121,6 +150,20 @@ export function DataTable<Row>({
   const effectiveOnSortChange = onSortChange ?? setInternalSort;
   const isMobile = useMediaQuery('(max-width: 767.98px)');
   const renderCards = Boolean(cardView) && isMobile;
+
+  // Expansion state (#1620) — keyed by `rowKey`, so it survives re-sorts and
+  // page-data churn as long as the same row stays present.
+  const [expandedKeys, setExpandedKeys] = useState<Set<Key>>(new Set());
+  const toggleExpanded = useCallback((key: Key): void => {
+    setExpandedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+  // Leading toggle column widens the desktop body/header/padding colSpans.
+  const columnCount = columns.length + (expandable ? 1 : 0);
 
   const table = useReactTable<Row>({
     data: rows,
@@ -162,6 +205,15 @@ export function DataTable<Row>({
     [navigate],
   );
 
+  const makeRowExpandHandler = useCallback(
+    (key: Key) =>
+      (event: MouseEvent<HTMLTableRowElement>): void => {
+        if (shouldIgnoreRowClick(event)) return;
+        toggleExpanded(key);
+      },
+    [toggleExpanded],
+  );
+
   const virtualizer = useVirtualizer({
     count: virtualizeActive ? tableRows.length : 0,
     getScrollElement: () => scrollRef.current,
@@ -169,16 +221,54 @@ export function DataTable<Row>({
     overscan: 8,
   });
 
-  const renderBodyRow = (tanstackRow: TanStackRow<Row>, style?: CSSProperties): ReactElement => {
+  const renderBodyRow = (
+    tanstackRow: TanStackRow<Row>,
+    style?: CSSProperties,
+    withDetail = true,
+  ): ReactElement => {
     const row = tanstackRow.original;
+    const key = rowKey(row);
     const href = rowHref?.(row);
-    return (
-      <tr
-        key={rowKey(row)}
-        className={href ? 'data-table__row data-table__row--linked' : 'data-table__row'}
-        onClick={href ? makeRowClickHandler(href) : undefined}
-        style={style}
-      >
+    // Expandable takes precedence over rowHref for the row-level click.
+    const expanded = expandable ? expandedKeys.has(key) : false;
+    // Auto-link the first cell only in pure-navigation mode (no expand toggle).
+    const linkifyFirstCell = Boolean(href) && !expandable;
+    const rowClasses = [
+      'data-table__row',
+      expandable ? 'data-table__row--expandable' : href ? 'data-table__row--linked' : '',
+      expanded ? 'data-table__row--expanded' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    const onClick = expandable
+      ? makeRowExpandHandler(key)
+      : href
+        ? makeRowClickHandler(href)
+        : undefined;
+
+    const bodyRow = (
+      <tr key={key} className={rowClasses} onClick={onClick} style={style}>
+        {expandable ? (
+          <td className="data-table__expand-cell">
+            <button
+              type="button"
+              className="data-table__expand-toggle"
+              aria-expanded={expanded}
+              aria-label={
+                expandable.toggleLabel?.(row, expanded) ??
+                (expanded ? 'Collapse row details' : 'Expand row details')
+              }
+              onClick={(event) => {
+                event.stopPropagation();
+                toggleExpanded(key);
+              }}
+            >
+              <span className="data-table__expand-icon" aria-hidden="true">
+                {expanded ? '▾' : '▸'}
+              </span>
+            </button>
+          </td>
+        ) : null}
         {columns.map((column, index) => {
           const cellClasses = [
             column.align ? `data-table__cell--${column.align}` : '',
@@ -188,7 +278,7 @@ export function DataTable<Row>({
             .join(' ');
 
           const content =
-            href && index === 0 ? (
+            linkifyFirstCell && href && index === 0 ? (
               <Link to={href} className="data-table__row-link">
                 {column.cell(row)}
               </Link>
@@ -204,6 +294,21 @@ export function DataTable<Row>({
         })}
       </tr>
     );
+
+    if (!expandable || !withDetail) return bodyRow;
+
+    return (
+      <Fragment key={key}>
+        {bodyRow}
+        {expanded ? (
+          <tr className="data-table__detail-row">
+            <td className="data-table__detail-cell" colSpan={columnCount}>
+              <div className="data-table__detail">{expandable.renderDetail(row)}</div>
+            </td>
+          </tr>
+        ) : null}
+      </Fragment>
+    );
   };
 
   const renderTable = (): ReactElement => (
@@ -212,6 +317,11 @@ export function DataTable<Row>({
       <thead>
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
+            {expandable ? (
+              <th scope="col" className="data-table__expand-cell">
+                <span className="sr-only">Expand row</span>
+              </th>
+            ) : null}
             {headerGroup.headers.map((header) => {
               const column = columnById.get(header.column.id);
               const canSort = column?.sortable ?? false;
@@ -262,7 +372,7 @@ export function DataTable<Row>({
       <tbody>
         {isEmpty ? (
           <tr className="data-table__empty-row">
-            <td className="data-table__empty-cell" colSpan={columns.length}>
+            <td className="data-table__empty-cell" colSpan={columnCount}>
               {emptyNode}
             </td>
           </tr>
@@ -286,18 +396,20 @@ export function DataTable<Row>({
     if (paddingTop > 0) {
       rows.push(
         <tr key="__padding_top" aria-hidden="true" style={{ height: paddingTop }}>
-          <td colSpan={columns.length} />
+          <td colSpan={columnCount} />
         </tr>,
       );
     }
     for (const virtualItem of virtualItems) {
       const tanstackRow = tableRows[virtualItem.index];
-      rows.push(renderBodyRow(tanstackRow, { height: virtualItem.size }));
+      // Detail panels break fixed-height virtual rows, so they're omitted here;
+      // expandable + virtualize is not a supported combination.
+      rows.push(renderBodyRow(tanstackRow, { height: virtualItem.size }, false));
     }
     if (paddingBottom > 0) {
       rows.push(
         <tr key="__padding_bottom" aria-hidden="true" style={{ height: paddingBottom }}>
-          <td colSpan={columns.length} />
+          <td colSpan={columnCount} />
         </tr>,
       );
     }
@@ -362,15 +474,23 @@ export function DataTable<Row>({
                   }
                   onClick={href ? makeRowClickHandler(href) : undefined}
                 >
-                  {href ? (
-                    <Link to={href} className="data-table__card-main data-table__card-main--link">
-                      {mainContent}
-                    </Link>
-                  ) : (
-                    <div className="data-table__card-main">{mainContent}</div>
-                  )}
-                  {cardView.meta ? (
-                    <div className="data-table__card-meta">{cardView.meta(row)}</div>
+                  <div className="data-table__card-head">
+                    {cardView.select ? (
+                      <div className="data-table__card-select">{cardView.select(row)}</div>
+                    ) : null}
+                    {href ? (
+                      <Link to={href} className="data-table__card-main data-table__card-main--link">
+                        {mainContent}
+                      </Link>
+                    ) : (
+                      <div className="data-table__card-main">{mainContent}</div>
+                    )}
+                    {cardView.meta ? (
+                      <div className="data-table__card-meta">{cardView.meta(row)}</div>
+                    ) : null}
+                  </div>
+                  {cardView.detail ? (
+                    <div className="data-table__card-detail">{cardView.detail(row)}</div>
                   ) : null}
                 </li>
               );

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -65,6 +65,17 @@ export interface DataTableCardView<Row> {
  * in an accordion panel beneath the row instead of navigating. Interactive
  * elements inside the row (links, buttons, checkboxes) still short-circuit the
  * toggle. Expandable takes precedence over `rowHref` for the row-level click.
+ *
+ * **Not supported together with `virtualize`.** The virtualizer forces every
+ * row to a fixed `estimateRowHeight`, which a variable-height detail panel
+ * would break. Rather than silently rendering a toggle that does nothing,
+ * `DataTable` disables virtualization (falls back to rendering every row) for
+ * as long as `expandable` is set, and logs a dev-only console warning so a
+ * future caller who reaches for both on the same table notices immediately
+ * instead of shipping a table whose expand affordance quietly does nothing.
+ * If a future table genuinely needs both at once, teach the virtualizer to
+ * measure dynamic row heights (e.g. `virtualizer.measureElement`) rather than
+ * re-enabling this combination as-is.
  */
 export interface DataTableExpandable<Row> {
   renderDetail: (row: Row) => ReactNode;
@@ -177,9 +188,20 @@ export function DataTable<Row>({
     ...(manualSorting ? {} : { getSortedRowModel: getSortedRowModel() }),
   });
 
+  if (import.meta.env.DEV && expandable && virtualize) {
+    // eslint-disable-next-line no-console -- dev-only guard, see DataTableExpandable JSDoc
+    console.warn(
+      '[DataTable] `expandable` and `virtualize` were both provided; `virtualize` is ' +
+        'ignored while `expandable` is set (a variable-height detail row cannot live ' +
+        'inside a fixed-height virtualized row). See the DataTableExpandable JSDoc in ' +
+        'data-table.tsx.',
+    );
+  }
+
   const tableRows = table.getRowModel().rows;
   const isEmpty = tableRows.length === 0;
-  const virtualizeActive = virtualize && !renderCards && !isEmpty;
+  // `expandable` wins over `virtualize` — see the DataTableExpandable JSDoc.
+  const virtualizeActive = virtualize && !renderCards && !isEmpty && !expandable;
   const containerClasses = [
     'data-table__container',
     cardView ? 'data-table__container--with-cards' : '',
@@ -402,8 +424,9 @@ export function DataTable<Row>({
     }
     for (const virtualItem of virtualItems) {
       const tanstackRow = tableRows[virtualItem.index];
-      // Detail panels break fixed-height virtual rows, so they're omitted here;
-      // expandable + virtualize is not a supported combination.
+      // This path only runs when `expandable` is absent (virtualizeActive is
+      // forced false while `expandable` is set — see the DataTableExpandable
+      // JSDoc), so `withDetail=false` here is defensive, not load-bearing.
       rows.push(renderBodyRow(tanstackRow, { height: virtualItem.size }, false));
     }
     if (paddingBottom > 0) {

--- a/docs/frontend-ui-style-guide.md
+++ b/docs/frontend-ui-style-guide.md
@@ -506,7 +506,7 @@ FE-002 expanded the primitive layer in `apps/web/src/shared/ui`. Every primitive
 
 ### Tables
 
-- `DataTable` — wraps `@tanstack/react-table` for sort/filter/column state. Dense rows (36 px default), row-click navigation, integrated empty state, status badge cells. Pairs with `@tanstack/react-virtual` when row count ≥ 500.
+- `DataTable` — wraps `@tanstack/react-table` for sort/filter/column state. Dense rows (36 px default), row-click navigation, integrated empty state, status badge cells. Pairs with `@tanstack/react-virtual` when row count ≥ 500. `hideBelow` (per-column, breakpoint-gated hiding) and `expandable` (a per-row accordion detail panel, opened via a leading toggle, `#1620`) are two independent, composable strategies for keeping a wide table usable at narrower widths — `hideBelow` drops non-essential columns outright below a breakpoint, `expandable` keeps every column queryable but moves non-essential fields into a click-to-open detail row instead of hiding them. A table can use either, both, or neither; the orders list (`#1620`) uses `expandable` with no `hideBelow` columns, relying on the table's own horizontal scroll at tablet width for anything that doesn't fit. `expandable` is not currently supported together with `virtualize` on the same table — see the `DataTableExpandable` JSDoc in `data-table.tsx`.
 
 ### Status & data surfaces
 
@@ -637,7 +637,7 @@ Parity matrix — what changes across sizes:
 |---|---|---|---|
 | Nav | drawer · hamburger trigger in topbar | drawer *or* persistent rail | persistent 240 px sidebar |
 | Topbar | logo + hamburger + search icon + user | full minus workspace crumb | full |
-| Tables | **card view** (one card per row, key columns stacked) | table with column hiding | full table |
+| Tables | **card view** (one card per row, key columns stacked) | full table, scrolled horizontally within its container as needed | full table |
 | Detail pages | single-column stack | 1-col or 60/40 split | 65/35 grid |
 | KPI strip | 1 × 4 vertical | 2 × 2 grid | 1 × 4 horizontal |
 | `MetricCard` | full width | 2-col grid | 4-col grid |


### PR DESCRIPTION
## Summary

The orders table (`apps/web/src/pages/orders/orders-list-page.tsx`) had 11 columns and overflowed the viewport. This adds expandable-row support to the shared `DataTable` primitive (`apps/web/src/shared/ui/data-table.tsx`) using `@tanstack/react-table` row expansion:

- Desktop rows now show only the essentials + selection checkbox: Order, Customer, Channel, Status, Ship-by, Fulfillment, Total. Clicking a row (or its leading toggle) expands an accordion panel with the remaining fields: order reference, items, exact ship-by date, carrier, destination, created, placed, payment, and shipping/billing addresses. The panel content is rendered by a new shared `OrderRowDetail` component (`apps/web/src/features/orders/components/order-row-detail.tsx`).
- On mobile, the row collapses into a card. The card reuses `OrderRowDetail` so a collapsed card still exposes every field without an extra tap, and gets a dedicated `select` slot (outside the card's navigation `Link`) so multi-select checkboxes still work in the card layout.
- The expand toggle never fires from clicks on links, buttons, or the selection checkbox (existing `INTERACTIVE_SELECTOR` guard in `DataTable`).
- Existing bulk-select + `BulkActionBar` / `BulkDispatchDialog` flows are unchanged and verified working from both the desktop table and the mobile card.
- All previously-visible data/badges are preserved; missing values render as `-` in the detail panel.

## Test plan

- [x] `pnpm --filter @openlinker/web lint` - 0 errors (78 pre-existing warnings, unrelated to this change)
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] `pnpm --filter @openlinker/web test` scoped to `src/pages/orders`, `src/shared/ui/data-table*`, `src/features/orders` - 248 files / 2190 tests passing
- [x] Added: `DataTable` expand/collapse + toggle-button + checkbox-does-not-expand tests
- [x] Added: orders-list-page row-expand, checkbox-does-not-expand, and mobile-card select/detail tests
- [x] Added: dedicated `OrderRowDetail` unit tests (missing-field `-` fallback + populated-field rendering)

Part of #1606
Closes #1620