### PR TITLE
feat(dashboard): list infra-bearing connections in Infrastructure panel

### DIFF
--- a/apps/api/src/app.controller.spec.ts
+++ b/apps/api/src/app.controller.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * App Controller — Unit Tests
+ *
+ * Covers the `/health/dev-stack` auth gating fix (#1619 review): the route
+ * stays `@Public()`, but the per-connection `name` and diagnostic `message`
+ * fields are redacted for a request without a valid bearer token.
+ *
+ * @module apps/api/src
+ */
+import type { JwtService } from '@nestjs/jwt';
+import { AppController } from './app.controller';
+import type { AppService } from './app.service';
+import type { IDevStackHealthService } from './health/dev-stack-health.service.interface';
+import type { DevStackHealthResponse } from './health/dev-stack-health.types';
+import type { IAppInfoService } from './app-info/app-info.service.interface';
+
+function buildHealthResponse(): DevStackHealthResponse {
+  return {
+    status: 'ok',
+    services: {
+      postgres: { status: 'ok' },
+      redis: { status: 'ok' },
+      prestashop: { status: 'ok' },
+      worker: { status: 'ok' },
+    },
+    connections: [
+      {
+        connectionId: 'conn-1',
+        name: 'My WooCommerce Shop',
+        platformType: 'woocommerce',
+        status: 'error',
+        message: 'WooCommerce authentication failed - check consumer key and secret',
+      },
+    ],
+    timestamp: new Date().toISOString(),
+  };
+}
+
+describe('AppController', () => {
+  let controller: AppController;
+  let devStackHealthService: jest.Mocked<IDevStackHealthService>;
+  let jwtService: jest.Mocked<Pick<JwtService, 'verifyAsync'>>;
+
+  beforeEach(() => {
+    devStackHealthService = {
+      checkInternalHealth: jest.fn(),
+      checkDevStackHealth: jest.fn().mockResolvedValue(buildHealthResponse()),
+    };
+    jwtService = {
+      verifyAsync: jest.fn(),
+    };
+
+    controller = new AppController(
+      {} as AppService,
+      devStackHealthService,
+      { getAppInfo: jest.fn() } as unknown as IAppInfoService,
+      jwtService as unknown as JwtService
+    );
+  });
+
+  function buildRequest(authHeader?: string): { headers: Record<string, string | undefined> } {
+    return { headers: { authorization: authHeader } };
+  }
+
+  describe('getDevStackHealth', () => {
+    it('should return connection name and message when the bearer token is valid', async () => {
+      jwtService.verifyAsync.mockResolvedValue({ sub: 'user-1' });
+
+      const result = await controller.getDevStackHealth(
+        buildRequest('Bearer valid-token') as never
+      );
+
+      expect(result.connections[0]).toEqual({
+        connectionId: 'conn-1',
+        name: 'My WooCommerce Shop',
+        platformType: 'woocommerce',
+        status: 'error',
+        message: 'WooCommerce authentication failed - check consumer key and secret',
+      });
+    });
+
+    it('should redact connection name and message when no bearer token is present', async () => {
+      const result = await controller.getDevStackHealth(buildRequest(undefined) as never);
+
+      expect(result.connections[0]).toEqual({
+        connectionId: 'conn-1',
+        platformType: 'woocommerce',
+        status: 'error',
+      });
+      expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+    });
+
+    it('should redact connection name and message when the bearer token is invalid', async () => {
+      jwtService.verifyAsync.mockRejectedValue(new Error('invalid signature'));
+
+      const result = await controller.getDevStackHealth(
+        buildRequest('Bearer garbage') as never
+      );
+
+      expect(result.connections[0]).toEqual({
+        connectionId: 'conn-1',
+        platformType: 'woocommerce',
+        status: 'error',
+      });
+    });
+  });
+});

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -6,7 +6,9 @@
  *
  * @module apps/api/src
  */
-import { Controller, Get, Inject, VERSION_NEUTRAL, Version } from '@nestjs/common';
+import { Controller, Get, Inject, Req, VERSION_NEUTRAL, Version } from '@nestjs/common';
+import { Request } from 'express';
+import { JwtService } from '@nestjs/jwt';
 import { AppService } from './app.service';
 import { IAppInfoService } from './app-info/app-info.service.interface';
 import { APP_INFO_SERVICE_TOKEN } from './app-info/app-info.module';
@@ -26,7 +28,8 @@ export class AppController {
     @Inject(DEV_STACK_HEALTH_SERVICE_TOKEN)
     private readonly devStackHealthService: IDevStackHealthService,
     @Inject(APP_INFO_SERVICE_TOKEN)
-    private readonly appInfoService: IAppInfoService
+    private readonly appInfoService: IAppInfoService,
+    private readonly jwtService: JwtService
   ) {}
 
   // Root welcome route stays reachable at `/` (no `/v1`) for load-balancer /
@@ -45,8 +48,47 @@ export class AppController {
     return { ...readiness, ...this.appInfoService.getAppInfo() };
   }
 
+  // This route stays @Public() (no login gate) so it keeps working as a
+  // pre-auth readiness probe, but the per-connection `name` and adapter
+  // diagnostic `message` fields are only meaningful to an operator who is
+  // already signed in — an anonymous caller only ever sees the generic
+  // status shape (#1619 review: unauthenticated info disclosure).
   @Get('health/dev-stack')
-  async getDevStackHealth(): Promise<DevStackHealthResponse> {
-    return this.devStackHealthService.checkDevStackHealth();
+  async getDevStackHealth(@Req() request: Request): Promise<DevStackHealthResponse> {
+    const health = await this.devStackHealthService.checkDevStackHealth();
+    if (await this.isAuthenticatedRequest(request)) {
+      return health;
+    }
+    return {
+      ...health,
+      connections: health.connections.map((connection) => ({
+        connectionId: connection.connectionId,
+        platformType: connection.platformType,
+        status: connection.status,
+      })),
+    };
+  }
+
+  /**
+   * Best-effort bearer-token check: verifies signature + expiry via the same
+   * `JwtService` the global `JwtAuthGuard` uses, but never throws or blocks
+   * the (still-public) request — it only decides which response shape to
+   * return.
+   */
+  private async isAuthenticatedRequest(request: Request): Promise<boolean> {
+    const authHeader = request.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) {
+      return false;
+    }
+    const token = authHeader.slice('Bearer '.length).trim();
+    if (!token) {
+      return false;
+    }
+    try {
+      await this.jwtService.verifyAsync(token);
+      return true;
+    } catch {
+      return false;
+    }
   }
 }

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -74,7 +74,10 @@ import { DemoAccountCleanupService } from './demo-account-cleanup.service';
   ],
   // MAILER_TOKEN is exported so sibling modules (#1624 email confirmation,
   // #1626 forgot-password delivery) can inject MailerPort without duplicating
-  // the provider registration.
-  exports: [AuthService, MAILER_TOKEN],
+  // the provider registration. JwtModule is re-exported so modules that
+  // import AuthModule (e.g. AppModule for AppController, #1619) can inject
+  // JwtService to verify a bearer token without enforcing auth on a
+  // @Public() route.
+  exports: [AuthService, MAILER_TOKEN, JwtModule],
 })
 export class AuthModule {}

--- a/apps/api/src/health/connection-infra-health.service.interface.ts
+++ b/apps/api/src/health/connection-infra-health.service.interface.ts
@@ -1,0 +1,21 @@
+/**
+ * Connection Infra Health Service Interface
+ *
+ * Defines the contract for rolling up health of infrastructure-bearing
+ * connections (connections that back a real shop/warehouse system, e.g.
+ * WooCommerce) into the dashboard's Infrastructure panel (#1619).
+ *
+ * @module apps/api/src/health
+ * @see {@link ConnectionInfraHealthService} for the implementation
+ */
+import type { ConnectionHealthEntry } from './dev-stack-health.types';
+
+export interface IConnectionInfraHealthService {
+  /**
+   * Discover active connections whose adapter capabilities mark them as
+   * infrastructure-bearing (`ProductMaster` and/or `InventoryMaster`), probe
+   * each via its registered `ConnectionTesterPort`, and return one health
+   * entry per connection.
+   */
+  checkInfraConnections(): Promise<ConnectionHealthEntry[]>;
+}

--- a/apps/api/src/health/connection-infra-health.service.spec.ts
+++ b/apps/api/src/health/connection-infra-health.service.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Connection Infra Health Service — Unit Tests
+ *
+ * Covers #1619: the dashboard Infrastructure panel must list every
+ * infra-bearing connection (ProductMaster/InventoryMaster capability),
+ * skipping marketplace-only connections and connections with no registered
+ * tester.
+ *
+ * @module apps/api/src/health
+ */
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import { ConnectionInfraHealthService } from './connection-infra-health.service';
+import type { IConnectionService } from '../integrations/application/interfaces/connection.service.interface';
+
+function buildConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn-1',
+    name: 'My WooCommerce Shop',
+    platformType: 'woocommerce',
+    status: 'active',
+    config: {},
+    credentialsBacked: true,
+    adapterKey: 'woocommerce.restapi.v3',
+    enabledCapabilities: [],
+    supportedCapabilities: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Connection;
+}
+
+describe('ConnectionInfraHealthService', () => {
+  let service: ConnectionInfraHealthService;
+  let connectionService: jest.Mocked<Pick<IConnectionService, 'list' | 'testConnection'>>;
+  let integrationsService: jest.Mocked<Pick<IIntegrationsService, 'resolveAdapterMetadata'>>;
+
+  beforeEach(() => {
+    connectionService = {
+      list: jest.fn(),
+      testConnection: jest.fn(),
+    };
+    integrationsService = {
+      resolveAdapterMetadata: jest.fn(),
+    };
+
+    service = new ConnectionInfraHealthService(
+      connectionService as unknown as IConnectionService,
+      integrationsService as unknown as IIntegrationsService
+    );
+  });
+
+  it('should return an empty array when there are no active connections', async () => {
+    connectionService.list.mockResolvedValue([]);
+
+    const result = await service.checkInfraConnections();
+
+    expect(result).toEqual([]);
+    expect(integrationsService.resolveAdapterMetadata).not.toHaveBeenCalled();
+  });
+
+  it('should include an infra-bearing connection (ProductMaster/InventoryMaster) and probe it', async () => {
+    const connection = buildConnection();
+    connectionService.list.mockResolvedValue([connection]);
+    integrationsService.resolveAdapterMetadata.mockResolvedValue({
+      adapterKey: 'woocommerce.restapi.v3',
+      platformType: 'woocommerce',
+      supportedCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderProcessorManager'],
+      displayName: 'WooCommerce REST API v3',
+      version: '1.0.0',
+    });
+    connectionService.testConnection.mockResolvedValue({
+      success: true,
+      latencyMs: 42,
+      message: 'OK',
+    });
+
+    const result = await service.checkInfraConnections();
+
+    expect(result).toEqual([
+      {
+        connectionId: 'conn-1',
+        name: 'My WooCommerce Shop',
+        platformType: 'woocommerce',
+        status: 'ok',
+        message: undefined,
+      },
+    ]);
+    expect(connectionService.testConnection).toHaveBeenCalledWith('conn-1');
+  });
+
+  it('should exclude a marketplace-only connection (no ProductMaster/InventoryMaster)', async () => {
+    const connection = buildConnection({ id: 'conn-2', platformType: 'allegro' });
+    connectionService.list.mockResolvedValue([connection]);
+    integrationsService.resolveAdapterMetadata.mockResolvedValue({
+      adapterKey: 'allegro.publicapi.v1',
+      platformType: 'allegro',
+      supportedCapabilities: ['OrderSource', 'OfferManager'],
+      displayName: 'Allegro Public API v1',
+      version: '1.0.0',
+    });
+
+    const result = await service.checkInfraConnections();
+
+    expect(result).toEqual([]);
+    expect(connectionService.testConnection).not.toHaveBeenCalled();
+  });
+
+  it('should report an error entry when the connection probe fails', async () => {
+    const connection = buildConnection();
+    connectionService.list.mockResolvedValue([connection]);
+    integrationsService.resolveAdapterMetadata.mockResolvedValue({
+      adapterKey: 'woocommerce.restapi.v3',
+      platformType: 'woocommerce',
+      supportedCapabilities: ['ProductMaster', 'InventoryMaster'],
+      displayName: 'WooCommerce REST API v3',
+      version: '1.0.0',
+    });
+    connectionService.testConnection.mockResolvedValue({
+      success: false,
+      latencyMs: 12,
+      message: 'Unauthorized (401)',
+    });
+
+    const result = await service.checkInfraConnections();
+
+    expect(result).toEqual([
+      {
+        connectionId: 'conn-1',
+        name: 'My WooCommerce Shop',
+        platformType: 'woocommerce',
+        status: 'error',
+        message: 'Unauthorized (401)',
+      },
+    ]);
+  });
+
+  it('should report a warning entry when the probe itself throws (e.g. unsupported adapter)', async () => {
+    const connection = buildConnection();
+    connectionService.list.mockResolvedValue([connection]);
+    integrationsService.resolveAdapterMetadata.mockResolvedValue({
+      adapterKey: 'woocommerce.restapi.v3',
+      platformType: 'woocommerce',
+      supportedCapabilities: ['ProductMaster', 'InventoryMaster'],
+      displayName: 'WooCommerce REST API v3',
+      version: '1.0.0',
+    });
+    connectionService.testConnection.mockRejectedValue(
+      new Error('Connection testing is not supported for adapter woocommerce.restapi.v3')
+    );
+
+    const result = await service.checkInfraConnections();
+
+    expect(result).toEqual([
+      {
+        connectionId: 'conn-1',
+        name: 'My WooCommerce Shop',
+        platformType: 'woocommerce',
+        status: 'warning',
+        message: 'Connection testing is not supported for adapter woocommerce.restapi.v3',
+      },
+    ]);
+  });
+
+  it('should skip a connection whose adapter metadata cannot be resolved', async () => {
+    const connection = buildConnection();
+    connectionService.list.mockResolvedValue([connection]);
+    integrationsService.resolveAdapterMetadata.mockRejectedValue(new Error('adapter not found'));
+
+    const result = await service.checkInfraConnections();
+
+    expect(result).toEqual([]);
+    expect(connectionService.testConnection).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/health/connection-infra-health.service.spec.ts
+++ b/apps/api/src/health/connection-infra-health.service.spec.ts
@@ -3,8 +3,12 @@
  *
  * Covers #1619: the dashboard Infrastructure panel must list every
  * infra-bearing connection (ProductMaster/InventoryMaster capability),
- * skipping marketplace-only connections and connections with no registered
- * tester.
+ * skipping marketplace-only connections and connections with the
+ * capability disabled via `enabledCapabilities`. Discovery goes through
+ * `listCapabilityAdapters` (same seam as every other core consumer) rather
+ * than a hand-rolled `metadata.supportedCapabilities` check, so these tests
+ * mock that method directly instead of `resolveAdapterMetadata` +
+ * `connectionService.list`.
  *
  * @module apps/api/src/health
  */
@@ -22,7 +26,7 @@ function buildConnection(overrides: Partial<Connection> = {}): Connection {
     config: {},
     credentialsBacked: true,
     adapterKey: 'woocommerce.restapi.v3',
-    enabledCapabilities: [],
+    enabledCapabilities: ['ProductMaster', 'InventoryMaster'],
     supportedCapabilities: [],
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -30,18 +34,48 @@ function buildConnection(overrides: Partial<Connection> = {}): Connection {
   } as Connection;
 }
 
+type CapabilityAdapterEntry = {
+  connectionId: string;
+  connection: Connection;
+  adapter: unknown;
+  metadata: unknown;
+};
+
+/** Builds the `listCapabilityAdapters` mock implementation for a fixed connection→capabilities map. */
+function mockCapabilityAdapters(
+  integrationsService: jest.Mocked<Pick<IIntegrationsService, 'listCapabilityAdapters'>>,
+  connectionsByCapability: Record<string, Connection[]>
+): void {
+  integrationsService.listCapabilityAdapters.mockImplementation(
+    <T>(filters: { capability: string }) => {
+      const connections = connectionsByCapability[filters.capability] ?? [];
+      return Promise.resolve(
+        connections.map(
+          (connection): CapabilityAdapterEntry => ({
+            connectionId: connection.id,
+            connection,
+            adapter: {} as T,
+            metadata: {},
+          })
+        )
+      ) as unknown as ReturnType<IIntegrationsService['listCapabilityAdapters']>;
+    }
+  );
+}
+
 describe('ConnectionInfraHealthService', () => {
   let service: ConnectionInfraHealthService;
   let connectionService: jest.Mocked<Pick<IConnectionService, 'list' | 'testConnection'>>;
-  let integrationsService: jest.Mocked<Pick<IIntegrationsService, 'resolveAdapterMetadata'>>;
+  let integrationsService: jest.Mocked<Pick<IIntegrationsService, 'listCapabilityAdapters'>>;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     connectionService = {
       list: jest.fn(),
       testConnection: jest.fn(),
     };
     integrationsService = {
-      resolveAdapterMetadata: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
     };
 
     service = new ConnectionInfraHealthService(
@@ -50,24 +84,29 @@ describe('ConnectionInfraHealthService', () => {
     );
   });
 
-  it('should return an empty array when there are no active connections', async () => {
-    connectionService.list.mockResolvedValue([]);
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should return an empty array when no connection has an infra capability', async () => {
+    mockCapabilityAdapters(integrationsService, {});
 
     const result = await service.checkInfraConnections();
 
     expect(result).toEqual([]);
-    expect(integrationsService.resolveAdapterMetadata).not.toHaveBeenCalled();
+    expect(integrationsService.listCapabilityAdapters).toHaveBeenCalledWith(
+      expect.objectContaining({ capability: 'ProductMaster', lazy: true })
+    );
+    expect(integrationsService.listCapabilityAdapters).toHaveBeenCalledWith(
+      expect.objectContaining({ capability: 'InventoryMaster', lazy: true })
+    );
   });
 
   it('should include an infra-bearing connection (ProductMaster/InventoryMaster) and probe it', async () => {
     const connection = buildConnection();
-    connectionService.list.mockResolvedValue([connection]);
-    integrationsService.resolveAdapterMetadata.mockResolvedValue({
-      adapterKey: 'woocommerce.restapi.v3',
-      platformType: 'woocommerce',
-      supportedCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderProcessorManager'],
-      displayName: 'WooCommerce REST API v3',
-      version: '1.0.0',
+    mockCapabilityAdapters(integrationsService, {
+      ProductMaster: [connection],
+      InventoryMaster: [connection],
     });
     connectionService.testConnection.mockResolvedValue({
       success: true,
@@ -86,19 +125,26 @@ describe('ConnectionInfraHealthService', () => {
         message: undefined,
       },
     ]);
+    // Deduped: appears in both capability lists but probed exactly once.
+    expect(connectionService.testConnection).toHaveBeenCalledTimes(1);
     expect(connectionService.testConnection).toHaveBeenCalledWith('conn-1');
   });
 
+  it('should exclude a connection whose adapter supports the capability but has it disabled via enabledCapabilities', async () => {
+    // listCapabilityAdapters itself intersects supportedCapabilities with
+    // enabledCapabilities, so a connection with InventoryMaster disabled
+    // (e.g. WooCommerce's OfferManager/InventoryMaster mutual exclusion)
+    // never appears in the entries this service receives.
+    mockCapabilityAdapters(integrationsService, {});
+
+    const result = await service.checkInfraConnections();
+
+    expect(result).toEqual([]);
+    expect(connectionService.testConnection).not.toHaveBeenCalled();
+  });
+
   it('should exclude a marketplace-only connection (no ProductMaster/InventoryMaster)', async () => {
-    const connection = buildConnection({ id: 'conn-2', platformType: 'allegro' });
-    connectionService.list.mockResolvedValue([connection]);
-    integrationsService.resolveAdapterMetadata.mockResolvedValue({
-      adapterKey: 'allegro.publicapi.v1',
-      platformType: 'allegro',
-      supportedCapabilities: ['OrderSource', 'OfferManager'],
-      displayName: 'Allegro Public API v1',
-      version: '1.0.0',
-    });
+    mockCapabilityAdapters(integrationsService, {});
 
     const result = await service.checkInfraConnections();
 
@@ -108,14 +154,7 @@ describe('ConnectionInfraHealthService', () => {
 
   it('should report an error entry when the connection probe fails', async () => {
     const connection = buildConnection();
-    connectionService.list.mockResolvedValue([connection]);
-    integrationsService.resolveAdapterMetadata.mockResolvedValue({
-      adapterKey: 'woocommerce.restapi.v3',
-      platformType: 'woocommerce',
-      supportedCapabilities: ['ProductMaster', 'InventoryMaster'],
-      displayName: 'WooCommerce REST API v3',
-      version: '1.0.0',
-    });
+    mockCapabilityAdapters(integrationsService, { ProductMaster: [connection] });
     connectionService.testConnection.mockResolvedValue({
       success: false,
       latencyMs: 12,
@@ -137,14 +176,7 @@ describe('ConnectionInfraHealthService', () => {
 
   it('should report a warning entry when the probe itself throws (e.g. unsupported adapter)', async () => {
     const connection = buildConnection();
-    connectionService.list.mockResolvedValue([connection]);
-    integrationsService.resolveAdapterMetadata.mockResolvedValue({
-      adapterKey: 'woocommerce.restapi.v3',
-      platformType: 'woocommerce',
-      supportedCapabilities: ['ProductMaster', 'InventoryMaster'],
-      displayName: 'WooCommerce REST API v3',
-      version: '1.0.0',
-    });
+    mockCapabilityAdapters(integrationsService, { ProductMaster: [connection] });
     connectionService.testConnection.mockRejectedValue(
       new Error('Connection testing is not supported for adapter woocommerce.restapi.v3')
     );
@@ -162,14 +194,23 @@ describe('ConnectionInfraHealthService', () => {
     ]);
   });
 
-  it('should skip a connection whose adapter metadata cannot be resolved', async () => {
+  it('should report an error entry with a timed-out message when the probe hangs past the timeout budget', async () => {
     const connection = buildConnection();
-    connectionService.list.mockResolvedValue([connection]);
-    integrationsService.resolveAdapterMetadata.mockRejectedValue(new Error('adapter not found'));
+    mockCapabilityAdapters(integrationsService, { ProductMaster: [connection] });
+    connectionService.testConnection.mockImplementation(() => new Promise(() => undefined));
 
-    const result = await service.checkInfraConnections();
+    const resultPromise = service.checkInfraConnections();
+    await jest.advanceTimersByTimeAsync(5000);
+    const result = await resultPromise;
 
-    expect(result).toEqual([]);
-    expect(connectionService.testConnection).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        connectionId: 'conn-1',
+        name: 'My WooCommerce Shop',
+        platformType: 'woocommerce',
+        status: 'error',
+        message: expect.stringContaining('timed out'),
+      },
+    ]);
   });
 });

--- a/apps/api/src/health/connection-infra-health.service.ts
+++ b/apps/api/src/health/connection-infra-health.service.ts
@@ -1,0 +1,97 @@
+/**
+ * Connection Infra Health Service
+ *
+ * Rolls up the health of infrastructure-bearing connections (connections
+ * that back a real shop/warehouse system, e.g. WooCommerce) into the
+ * dashboard's Infrastructure panel (#1619). "Infrastructure-bearing" is
+ * defined by capability, not by platform name — any adapter advertising
+ * `ProductMaster` and/or `InventoryMaster` qualifies, so a future adapter
+ * with the same capability shape is picked up automatically. Marketplace
+ * adapters (Allegro, Erli, …) never qualify and are left to the existing
+ * "Connection health" panel.
+ *
+ * @module apps/api/src/health
+ * @implements {IConnectionInfraHealthService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { IIntegrationsService } from '@openlinker/core/integrations';
+import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import { IConnectionService } from '../integrations/application/interfaces/connection.service.interface';
+import { CONNECTION_SERVICE_TOKEN } from '../integrations/application/interfaces/connection.service.interface';
+import type { IConnectionInfraHealthService } from './connection-infra-health.service.interface';
+import type { ConnectionHealthEntry, ServiceStatus } from './dev-stack-health.types';
+
+const INFRA_CAPABILITIES = ['ProductMaster', 'InventoryMaster'];
+
+@Injectable()
+export class ConnectionInfraHealthService implements IConnectionInfraHealthService {
+  private readonly logger = new Logger(ConnectionInfraHealthService.name);
+
+  constructor(
+    @Inject(CONNECTION_SERVICE_TOKEN)
+    private readonly connectionService: IConnectionService,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService
+  ) {}
+
+  async checkInfraConnections(): Promise<ConnectionHealthEntry[]> {
+    const connections = await this.connectionService.list({ status: 'active' });
+    if (connections.length === 0) {
+      return [];
+    }
+
+    const infraConnections = await this.filterInfraBearing(connections);
+    return Promise.all(infraConnections.map((connection) => this.checkConnection(connection)));
+  }
+
+  private async filterInfraBearing(connections: Connection[]): Promise<Connection[]> {
+    const flags = await Promise.all(
+      connections.map(async (connection) => {
+        try {
+          const metadata = await this.integrationsService.resolveAdapterMetadata({
+            platformType: connection.platformType,
+            adapterKey: connection.adapterKey,
+          });
+          return metadata.supportedCapabilities.some((capability) =>
+            INFRA_CAPABILITIES.includes(capability)
+          );
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+          this.logger.warn(
+            `Could not resolve adapter metadata for connection ${connection.id}: ${errorMessage}`
+          );
+          return false;
+        }
+      })
+    );
+    return connections.filter((_, index) => flags[index]);
+  }
+
+  private async checkConnection(connection: Connection): Promise<ConnectionHealthEntry> {
+    try {
+      const result = await this.connectionService.testConnection(connection.id);
+      const status: ServiceStatus = result.success ? 'ok' : 'error';
+      return {
+        connectionId: connection.id,
+        name: connection.name,
+        platformType: connection.platformType,
+        status,
+        message: result.success ? undefined : result.message,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(
+        `Infra connection health check failed for ${connection.id}: ${errorMessage}`
+      );
+      return {
+        connectionId: connection.id,
+        name: connection.name,
+        platformType: connection.platformType,
+        status: 'warning',
+        message: errorMessage,
+      };
+    }
+  }
+}

--- a/apps/api/src/health/connection-infra-health.service.ts
+++ b/apps/api/src/health/connection-infra-health.service.ts
@@ -10,6 +10,14 @@
  * adapters (Allegro, Erli, …) never qualify and are left to the existing
  * "Connection health" panel.
  *
+ * Discovery goes through `IIntegrationsService.listCapabilityAdapters` (the
+ * same seam `OrderSyncService` and every other core consumer uses) rather
+ * than hand-rolling a `metadata.supportedCapabilities` check, so a
+ * connection with the capability disabled via `enabledCapabilities` (e.g. a
+ * WooCommerce connection with `InventoryMaster` turned off in favor of
+ * `OfferManager` — see the mutual-exclusion note in
+ * docs/architecture-overview.md) is correctly excluded here too.
+ *
  * @module apps/api/src/health
  * @implements {IConnectionInfraHealthService}
  */
@@ -22,8 +30,10 @@ import { IConnectionService } from '../integrations/application/interfaces/conne
 import { CONNECTION_SERVICE_TOKEN } from '../integrations/application/interfaces/connection.service.interface';
 import type { IConnectionInfraHealthService } from './connection-infra-health.service.interface';
 import type { ConnectionHealthEntry, ServiceStatus } from './dev-stack-health.types';
+import { HealthCheckTimeoutError, withTimeout } from './with-timeout.util';
 
 const INFRA_CAPABILITIES = ['ProductMaster', 'InventoryMaster'];
+const CHECK_TIMEOUT_MS = 5000;
 
 @Injectable()
 export class ConnectionInfraHealthService implements IConnectionInfraHealthService {
@@ -37,41 +47,46 @@ export class ConnectionInfraHealthService implements IConnectionInfraHealthServi
   ) {}
 
   async checkInfraConnections(): Promise<ConnectionHealthEntry[]> {
-    const connections = await this.connectionService.list({ status: 'active' });
-    if (connections.length === 0) {
+    const infraConnections = await this.discoverInfraBearingConnections();
+    if (infraConnections.length === 0) {
       return [];
     }
 
-    const infraConnections = await this.filterInfraBearing(connections);
     return Promise.all(infraConnections.map((connection) => this.checkConnection(connection)));
   }
 
-  private async filterInfraBearing(connections: Connection[]): Promise<Connection[]> {
-    const flags = await Promise.all(
-      connections.map(async (connection) => {
-        try {
-          const metadata = await this.integrationsService.resolveAdapterMetadata({
-            platformType: connection.platformType,
-            adapterKey: connection.adapterKey,
-          });
-          return metadata.supportedCapabilities.some((capability) =>
-            INFRA_CAPABILITIES.includes(capability)
-          );
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-          this.logger.warn(
-            `Could not resolve adapter metadata for connection ${connection.id}: ${errorMessage}`
-          );
-          return false;
-        }
-      })
-    );
-    return connections.filter((_, index) => flags[index]);
+  /**
+   * Discover active connections that both (a) have an adapter advertising an
+   * infra-bearing capability and (b) have that capability enabled on the
+   * connection itself. `listCapabilityAdapters` already intersects
+   * `metadata.supportedCapabilities` with `connection.enabledCapabilities`
+   * per capability (#1619 review) — called once per infra capability since
+   * the port only takes a single capability, then deduped by connection id
+   * (a connection may qualify via both `ProductMaster` and `InventoryMaster`).
+   */
+  private async discoverInfraBearingConnections(): Promise<Connection[]> {
+    const byConnectionId = new Map<string, Connection>();
+
+    for (const capability of INFRA_CAPABILITIES) {
+      const entries = await this.integrationsService.listCapabilityAdapters<unknown>({
+        capability,
+        lazy: true,
+      });
+      for (const entry of entries) {
+        byConnectionId.set(entry.connectionId, entry.connection);
+      }
+    }
+
+    return Array.from(byConnectionId.values());
   }
 
   private async checkConnection(connection: Connection): Promise<ConnectionHealthEntry> {
     try {
-      const result = await this.connectionService.testConnection(connection.id);
+      const result = await withTimeout(
+        this.connectionService.testConnection(connection.id),
+        `Infra connection health check timed out after ${CHECK_TIMEOUT_MS}ms`,
+        CHECK_TIMEOUT_MS
+      );
       const status: ServiceStatus = result.success ? 'ok' : 'error';
       return {
         connectionId: connection.id,
@@ -82,6 +97,18 @@ export class ConnectionInfraHealthService implements IConnectionInfraHealthServi
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      if (error instanceof HealthCheckTimeoutError) {
+        this.logger.warn(
+          `Infra connection health check timed out for ${connection.id}: ${errorMessage}`
+        );
+        return {
+          connectionId: connection.id,
+          name: connection.name,
+          platformType: connection.platformType,
+          status: 'error',
+          message: errorMessage,
+        };
+      }
       this.logger.warn(
         `Infra connection health check failed for ${connection.id}: ${errorMessage}`
       );

--- a/apps/api/src/health/dev-stack-health.service.spec.ts
+++ b/apps/api/src/health/dev-stack-health.service.spec.ts
@@ -13,6 +13,7 @@ import type { ConfigService } from '@nestjs/config';
 import type { RedisClientType } from 'redis';
 import { of, throwError } from 'rxjs';
 import { DevStackHealthService } from './dev-stack-health.service';
+import type { IConnectionInfraHealthService } from './connection-infra-health.service.interface';
 
 describe('DevStackHealthService', () => {
   let service: DevStackHealthService;
@@ -20,6 +21,7 @@ describe('DevStackHealthService', () => {
   let redisClient: jest.Mocked<Pick<RedisClientType, 'ping' | 'xAdd' | 'get'>>;
   let httpService: jest.Mocked<Pick<HttpService, 'get'>>;
   let configService: jest.Mocked<Pick<ConfigService, 'get'>>;
+  let connectionInfraHealthService: jest.Mocked<IConnectionInfraHealthService>;
 
   beforeEach(() => {
     dataSource = { query: jest.fn().mockResolvedValue([{ '?column?': 1 }]) };
@@ -30,12 +32,14 @@ describe('DevStackHealthService', () => {
     };
     httpService = { get: jest.fn().mockReturnValue(of({ status: 200 })) };
     configService = { get: jest.fn().mockReturnValue('http://localhost:8080') };
+    connectionInfraHealthService = { checkInfraConnections: jest.fn().mockResolvedValue([]) };
 
     service = new DevStackHealthService(
       dataSource as unknown as DataSource,
       redisClient as unknown as RedisClientType,
       httpService as unknown as HttpService,
-      configService as unknown as ConfigService
+      configService as unknown as ConfigService,
+      connectionInfraHealthService
     );
   });
 
@@ -98,6 +102,57 @@ describe('DevStackHealthService', () => {
 
       expect(result.services.worker).toBeDefined();
       expect(result.services.worker.status).toBe('ok');
+    });
+
+    it('should include infra-bearing connections in dev stack health', async () => {
+      connectionInfraHealthService.checkInfraConnections.mockResolvedValueOnce([
+        {
+          connectionId: 'conn-1',
+          name: 'My WooCommerce Shop',
+          platformType: 'woocommerce',
+          status: 'ok',
+        },
+      ]);
+
+      const result = await service.checkDevStackHealth();
+
+      expect(result.connections).toEqual([
+        {
+          connectionId: 'conn-1',
+          name: 'My WooCommerce Shop',
+          platformType: 'woocommerce',
+          status: 'ok',
+        },
+      ]);
+      expect(result.status).toBe('ok');
+    });
+
+    it('should report degraded when an infra-bearing connection is unhealthy but internals are ok', async () => {
+      connectionInfraHealthService.checkInfraConnections.mockResolvedValueOnce([
+        {
+          connectionId: 'conn-1',
+          name: 'My WooCommerce Shop',
+          platformType: 'woocommerce',
+          status: 'error',
+          message: 'Unauthorized',
+        },
+      ]);
+
+      const result = await service.checkDevStackHealth();
+
+      expect(result.status).toBe('degraded');
+      expect(result.connections[0].status).toBe('error');
+    });
+
+    it('should report empty connections and not fail when the infra rollup throws', async () => {
+      connectionInfraHealthService.checkInfraConnections.mockRejectedValueOnce(
+        new Error('registry unavailable')
+      );
+
+      const result = await service.checkDevStackHealth();
+
+      expect(result.connections).toEqual([]);
+      expect(result.status).toBe('ok');
     });
 
     it('should report degraded when worker is stale but internals are ok', async () => {

--- a/apps/api/src/health/dev-stack-health.service.ts
+++ b/apps/api/src/health/dev-stack-health.service.ts
@@ -20,6 +20,7 @@ import { WORKER_HEARTBEAT_REDIS_KEY } from '@openlinker/shared/worker';
 import type { IDevStackHealthService } from './dev-stack-health.service.interface';
 import { IConnectionInfraHealthService } from './connection-infra-health.service.interface';
 import { CONNECTION_INFRA_HEALTH_SERVICE_TOKEN } from './health.tokens';
+import { withTimeout } from './with-timeout.util';
 import type {
   InternalHealthReadiness,
   DevStackHealthResponse,
@@ -122,7 +123,11 @@ export class DevStackHealthService implements IDevStackHealthService {
 
   private async checkPostgres(): Promise<ServiceHealth> {
     try {
-      await this.withTimeout(this.dataSource.query('SELECT 1'), 'PostgreSQL health check timeout');
+      await withTimeout(
+        this.dataSource.query('SELECT 1'),
+        'PostgreSQL health check timeout',
+        this.CHECK_TIMEOUT_MS
+      );
       return { status: 'ok' as ServiceStatus };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -134,32 +139,18 @@ export class DevStackHealthService implements IDevStackHealthService {
     }
   }
 
-  private async withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
-    let timeoutId: NodeJS.Timeout | undefined;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(() => reject(new Error(message)), this.CHECK_TIMEOUT_MS);
-    });
-    try {
-      return await Promise.race([promise, timeoutPromise]);
-    } finally {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    }
-  }
-
   private async checkRedis(): Promise<ServiceHealth> {
     try {
       const streamKey = this.HEALTHCHECK_STREAM;
       const timestamp = Date.now().toString();
 
-      await this.withTimeout(this.redisClient.ping(), 'Redis ping timeout');
+      await withTimeout(this.redisClient.ping(), 'Redis ping timeout', this.CHECK_TIMEOUT_MS);
 
       // Exercise Redis Streams with a non-blocking write. XADD succeeds iff
       // the server supports Streams and accepts writes; no read-back needed,
       // which avoids false positives on cold boot when consumer groups or
       // stream entries are not yet initialized.
-      await this.withTimeout(
+      await withTimeout(
         this.redisClient.xAdd(
           streamKey,
           '*',
@@ -172,7 +163,8 @@ export class DevStackHealthService implements IDevStackHealthService {
             },
           }
         ),
-        'Redis xAdd timeout'
+        'Redis xAdd timeout',
+        this.CHECK_TIMEOUT_MS
       );
 
       return { status: 'ok' as ServiceStatus };
@@ -233,9 +225,10 @@ export class DevStackHealthService implements IDevStackHealthService {
 
   private async checkWorker(): Promise<ServiceHealth> {
     try {
-      const heartbeat = await this.withTimeout(
+      const heartbeat = await withTimeout(
         this.redisClient.get(WORKER_HEARTBEAT_REDIS_KEY),
-        'Worker heartbeat check timeout'
+        'Worker heartbeat check timeout',
+        this.CHECK_TIMEOUT_MS
       );
 
       if (!heartbeat) {

--- a/apps/api/src/health/dev-stack-health.service.ts
+++ b/apps/api/src/health/dev-stack-health.service.ts
@@ -18,9 +18,12 @@ import { firstValueFrom, timeout } from 'rxjs';
 import { RedisClientType } from 'redis';
 import { WORKER_HEARTBEAT_REDIS_KEY } from '@openlinker/shared/worker';
 import type { IDevStackHealthService } from './dev-stack-health.service.interface';
+import { IConnectionInfraHealthService } from './connection-infra-health.service.interface';
+import { CONNECTION_INFRA_HEALTH_SERVICE_TOKEN } from './health.tokens';
 import type {
   InternalHealthReadiness,
   DevStackHealthResponse,
+  ConnectionHealthEntry,
   ServiceHealth,
   ServiceStatus,
 } from './dev-stack-health.types';
@@ -39,7 +42,9 @@ export class DevStackHealthService implements IDevStackHealthService {
     @Inject('REDIS_CLIENT')
     private readonly redisClient: RedisClientType,
     private readonly httpService: HttpService,
-    private readonly configService: ConfigService
+    private readonly configService: ConfigService,
+    @Inject(CONNECTION_INFRA_HEALTH_SERVICE_TOKEN)
+    private readonly connectionInfraHealthService: IConnectionInfraHealthService
   ) {}
 
   async checkInternalHealth(): Promise<InternalHealthReadiness> {
@@ -63,11 +68,12 @@ export class DevStackHealthService implements IDevStackHealthService {
   async checkDevStackHealth(): Promise<DevStackHealthResponse> {
     // Run all checks in parallel so checkWorker()'s GET reaches Redis before
     // checkRedis()'s xAdd is queued, preventing pipeline blocking.
-    const [postgres, redis, prestashop, worker] = await Promise.all([
+    const [postgres, redis, prestashop, worker, connections] = await Promise.all([
       this.checkPostgres(),
       this.checkRedis(),
       this.checkPrestaShop(),
       this.checkWorker(),
+      this.checkInfraConnections(),
     ]);
     const services = { postgres, redis, prestashop, worker };
 
@@ -78,14 +84,18 @@ export class DevStackHealthService implements IDevStackHealthService {
     const hasExternalError =
       services.prestashop.status === 'error' ||
       services.worker.status === 'error' ||
-      services.worker.status === 'warning';
+      services.worker.status === 'warning' ||
+      connections.some(
+        (connection) => connection.status === 'error' || connection.status === 'warning'
+      );
 
     let status: 'ok' | 'degraded' | 'error';
     if (hasInternalError) {
       // Internal services (PostgreSQL, Redis) are down - critical error
       status = 'error';
     } else if (hasExternalError) {
-      // Internal services are healthy, but external (PrestaShop/worker) is down/slow - degraded
+      // Internal services are healthy, but an external dependency (PrestaShop,
+      // worker, or an infra-bearing connection) is down/slow - degraded
       status = 'degraded';
     } else {
       // All services (internal + external) are healthy
@@ -95,8 +105,19 @@ export class DevStackHealthService implements IDevStackHealthService {
     return {
       status,
       services,
+      connections,
       timestamp: new Date().toISOString(),
     };
+  }
+
+  private async checkInfraConnections(): Promise<ConnectionHealthEntry[]> {
+    try {
+      return await this.connectionInfraHealthService.checkInfraConnections();
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Infra connection health rollup failed: ${errorMessage}`, error);
+      return [];
+    }
   }
 
   private async checkPostgres(): Promise<ServiceHealth> {

--- a/apps/api/src/health/dev-stack-health.types.ts
+++ b/apps/api/src/health/dev-stack-health.types.ts
@@ -40,10 +40,18 @@ export type InternalHealthReadiness = Omit<InternalHealthResponse, 'version' | '
  * `InventoryMaster`) rather than being a marketplace listing channel. Today
  * this surfaces WooCommerce; it generalizes to any future adapter with the
  * same capability shape without further changes here.
+ *
+ * `name` (the operator-chosen connection label) and `message` (adapter
+ * diagnostic text, which can describe *why* auth failed) are optional
+ * because the `@Public()` `GET /health/dev-stack` endpoint only includes
+ * them for authenticated callers — an anonymous request gets the generic
+ * `connectionId` / `platformType` / `status` shape (#1619 review: this is
+ * real user/diagnostic detail, unlike the fixed-name postgres/redis/worker
+ * rows, which never needed gating).
  */
 export interface ConnectionHealthEntry {
   connectionId: string;
-  name: string;
+  name?: string;
   platformType: string;
   status: ServiceStatus;
   message?: string;

--- a/apps/api/src/health/dev-stack-health.types.ts
+++ b/apps/api/src/health/dev-stack-health.types.ts
@@ -32,6 +32,23 @@ export interface InternalHealthResponse {
  */
 export type InternalHealthReadiness = Omit<InternalHealthResponse, 'version' | 'api'>;
 
+/**
+ * Health entry for a single infrastructure-bearing connection (#1619).
+ *
+ * A connection is infrastructure-bearing when its adapter's capabilities
+ * indicate it backs a real shop/warehouse system (`ProductMaster` and/or
+ * `InventoryMaster`) rather than being a marketplace listing channel. Today
+ * this surfaces WooCommerce; it generalizes to any future adapter with the
+ * same capability shape without further changes here.
+ */
+export interface ConnectionHealthEntry {
+  connectionId: string;
+  name: string;
+  platformType: string;
+  status: ServiceStatus;
+  message?: string;
+}
+
 export interface DevStackHealthResponse {
   status: 'ok' | 'degraded' | 'error';
   services: {
@@ -40,6 +57,11 @@ export interface DevStackHealthResponse {
     prestashop: ServiceHealth;
     worker: ServiceHealth;
   };
+  /**
+   * Infra-bearing connections (e.g. a connected WooCommerce shop) discovered
+   * at request time and probed via their `ConnectionTesterPort` adapter.
+   * Empty when no such connections are configured.
+   */
+  connections: ConnectionHealthEntry[];
   timestamp: string;
 }
-

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -2,8 +2,9 @@
  * Health Module
  *
  * Provides health checking capabilities for the development stack. Includes
- * checks for internal dependencies (PostgreSQL, Redis) and external
- * dependencies (PrestaShop).
+ * checks for internal dependencies (PostgreSQL, Redis), external dependencies
+ * (PrestaShop), and infrastructure-bearing connections (e.g. a connected
+ * WooCommerce shop, #1619).
  *
  * @module apps/api/src/health
  */
@@ -12,19 +13,37 @@ import { HttpModule } from '@nestjs/axios';
 import { DatabaseModule } from '@openlinker/shared/database';
 import { RedisConfigModule } from '@openlinker/shared/redis';
 import { DevStackHealthService } from './dev-stack-health.service';
+import { ConnectionInfraHealthService } from './connection-infra-health.service';
+import { IntegrationsModule } from '../integrations/integrations.module';
+import {
+  DEV_STACK_HEALTH_SERVICE_TOKEN,
+  CONNECTION_INFRA_HEALTH_SERVICE_TOKEN,
+} from './health.tokens';
 
-export const DEV_STACK_HEALTH_SERVICE_TOKEN = Symbol('IDevStackHealthService');
+export { DEV_STACK_HEALTH_SERVICE_TOKEN, CONNECTION_INFRA_HEALTH_SERVICE_TOKEN };
 
 @Module({
-  imports: [HttpModule, DatabaseModule, RedisConfigModule],
+  imports: [
+    HttpModule,
+    DatabaseModule,
+    RedisConfigModule,
+    // For CONNECTION_SERVICE_TOKEN + (re-exported) INTEGRATIONS_SERVICE_TOKEN,
+    // used by ConnectionInfraHealthService to discover + probe infra-bearing
+    // connections (#1619).
+    IntegrationsModule,
+  ],
   providers: [
     DevStackHealthService,
     {
       provide: DEV_STACK_HEALTH_SERVICE_TOKEN,
       useExisting: DevStackHealthService,
     },
+    ConnectionInfraHealthService,
+    {
+      provide: CONNECTION_INFRA_HEALTH_SERVICE_TOKEN,
+      useExisting: ConnectionInfraHealthService,
+    },
   ],
   exports: [DEV_STACK_HEALTH_SERVICE_TOKEN],
 })
 export class HealthModule {}
-

--- a/apps/api/src/health/health.tokens.ts
+++ b/apps/api/src/health/health.tokens.ts
@@ -1,0 +1,7 @@
+/**
+ * Health Module DI Tokens
+ *
+ * @module apps/api/src/health
+ */
+export const DEV_STACK_HEALTH_SERVICE_TOKEN = Symbol('IDevStackHealthService');
+export const CONNECTION_INFRA_HEALTH_SERVICE_TOKEN = Symbol('IConnectionInfraHealthService');

--- a/apps/api/src/health/with-timeout.util.ts
+++ b/apps/api/src/health/with-timeout.util.ts
@@ -1,0 +1,49 @@
+/**
+ * Health Check Timeout Utility
+ *
+ * Shared timeout wrapper for health-check probes (#1619 review follow-up).
+ * Every probe that reaches an external dependency (PostgreSQL, Redis,
+ * PrestaShop, an infra-bearing connection's `ConnectionTesterPort`, …) must
+ * race against a bounded timeout so a slow/hanging dependency can't stall
+ * the whole health rollup. Extracted from `DevStackHealthService` so
+ * `ConnectionInfraHealthService` shares the exact same behavior instead of
+ * hand-rolling its own.
+ *
+ * @module apps/api/src/health
+ */
+
+/**
+ * Thrown when a wrapped promise does not settle within the given timeout.
+ * Callers can distinguish a genuine timeout from an ordinary probe failure
+ * (e.g. "unsupported adapter") to report a more specific health status.
+ */
+export class HealthCheckTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HealthCheckTimeoutError';
+  }
+}
+
+export const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = 5000;
+
+/**
+ * Races `promise` against a timer; rejects with {@link HealthCheckTimeoutError}
+ * if the timer wins first. Always clears the timer, whichever wins.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  message: string,
+  timeoutMs: number = DEFAULT_HEALTH_CHECK_TIMEOUT_MS
+): Promise<T> {
+  let timeoutId: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new HealthCheckTimeoutError(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/apps/api/src/integrations/application/interfaces/connection.service.interface.ts
+++ b/apps/api/src/integrations/application/interfaces/connection.service.interface.ts
@@ -20,6 +20,8 @@ import type { ConnectionCreateInput } from './connection.service.types';
 
 export type { ConnectionCreateInput };
 
+export const CONNECTION_SERVICE_TOKEN = Symbol('IConnectionService');
+
 export interface IConnectionService {
   /**
    * Create a new connection

--- a/apps/api/src/integrations/integrations.module.ts
+++ b/apps/api/src/integrations/integrations.module.ts
@@ -24,6 +24,7 @@ import { AdapterController } from './http/adapter.controller';
 import { AllegroController } from './http/allegro.controller';
 import { SubiektController } from './http/subiekt.controller';
 import { ConnectionService } from './application/services/connection.service';
+import { CONNECTION_SERVICE_TOKEN } from './application/interfaces/connection.service.interface';
 import { OAuthConnectionService } from './application/services/oauth-connection.service';
 import { OAUTH_CONNECTION_SERVICE_TOKEN } from './application/interfaces/oauth-connection.service.interface';
 import { DemoModeService } from '../auth/demo-mode.service';
@@ -40,6 +41,7 @@ import { DEMO_MODE_SERVICE_TOKEN } from '../auth/demo-mode.service.interface';
   controllers: [ConnectionController, AdapterController, AllegroController, SubiektController],
   providers: [
     ConnectionService,
+    { provide: CONNECTION_SERVICE_TOKEN, useExisting: ConnectionService },
     // Neutral OAuth orchestration (#859). Allegro's OAuth knowledge (URLs,
     // token exchange, `/me`) now lives in the plugin behind OAuthCompletionPort,
     // resolved at runtime via OAuthCompletionRegistryService — so the host no
@@ -52,6 +54,10 @@ import { DEMO_MODE_SERVICE_TOKEN } from '../auth/demo-mode.service.interface';
     DemoModeService,
     { provide: DEMO_MODE_SERVICE_TOKEN, useExisting: DemoModeService },
   ],
-  exports: [PluginRegistryModule],
+  // CoreIntegrationsModule is re-exported so downstream modules (e.g. HealthModule,
+  // for the infra-connection health rollup, #1619) can inject INTEGRATIONS_SERVICE_TOKEN
+  // via this module without re-importing CoreIntegrationsModule directly.
+  // (NestJS dedupes the singleton instance, so plugin-registered testers stay intact.)
+  exports: [PluginRegistryModule, CoreIntegrationsModule, CONNECTION_SERVICE_TOKEN],
 })
 export class IntegrationsModule {}

--- a/apps/web/src/features/health/api/health.types.ts
+++ b/apps/web/src/features/health/api/health.types.ts
@@ -10,10 +10,16 @@ export interface ServiceHealth {
  * Health entry for a single infrastructure-bearing connection (#1619) - a
  * connection whose adapter backs a real shop/warehouse system (e.g. a
  * connected WooCommerce shop) rather than a marketplace listing channel.
+ *
+ * `name` and `message` are optional because the backend only includes them
+ * for an authenticated request - an anonymous caller of the (still public)
+ * `/health/dev-stack` endpoint gets the generic status-only shape. The
+ * dashboard is behind login, so in practice this widget always sees them,
+ * but the type has to reflect what the wire contract actually allows.
  */
 export interface ConnectionHealthEntry {
   connectionId: string;
-  name: string;
+  name?: string;
   platformType: string;
   status: ServiceStatus;
   message?: string;

--- a/apps/web/src/features/health/api/health.types.ts
+++ b/apps/web/src/features/health/api/health.types.ts
@@ -6,6 +6,19 @@ export interface ServiceHealth {
   message?: string;
 }
 
+/**
+ * Health entry for a single infrastructure-bearing connection (#1619) - a
+ * connection whose adapter backs a real shop/warehouse system (e.g. a
+ * connected WooCommerce shop) rather than a marketplace listing channel.
+ */
+export interface ConnectionHealthEntry {
+  connectionId: string;
+  name: string;
+  platformType: string;
+  status: ServiceStatus;
+  message?: string;
+}
+
 export interface DevStackHealth {
   status: OverallStatus;
   services: {
@@ -14,5 +27,11 @@ export interface DevStackHealth {
     prestashop: ServiceHealth;
     worker?: ServiceHealth;
   };
+  /**
+   * Infra-bearing connections (e.g. a connected WooCommerce shop) discovered
+   * and probed alongside the fixed core services. Empty when none exist.
+   * Optional for backward compatibility with cached/older responses.
+   */
+  connections?: ConnectionHealthEntry[];
   timestamp: string;
 }

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -63,7 +63,7 @@ function groupsResponse(groups: SyncJobGroup[]): SyncJobGroupsResponse {
 
 function findCardByLabel(container: HTMLElement, label: string): HTMLElement {
   const labels = Array.from(
-    container.querySelectorAll<HTMLElement>('.kpi-card__label-text'),
+    container.querySelectorAll<HTMLElement>('.kpi-card__label-text')
   ).filter((el) => el.textContent === label);
   if (labels.length !== 1) {
     throw new Error(`Expected one .kpi-card__label-text "${label}", found ${labels.length}`);
@@ -86,10 +86,17 @@ describe('DashboardPage', () => {
   it('shows real connection count from API', async () => {
     const apiClient = createMockApiClient({
       connections: {
-        list: vi.fn().mockResolvedValue([
-          makeConnection({ id: 'c1', name: 'Store A', status: 'active', platformType: 'prestashop' }),
-          makeConnection({ id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro' }),
-        ]),
+        list: vi
+          .fn()
+          .mockResolvedValue([
+            makeConnection({
+              id: 'c1',
+              name: 'Store A',
+              status: 'active',
+              platformType: 'prestashop',
+            }),
+            makeConnection({ id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro' }),
+          ]),
       },
     });
     renderWithProviders(<DashboardPage />, { apiClient });
@@ -105,6 +112,105 @@ describe('DashboardPage', () => {
     expect(await within(container).findByText('PostgreSQL')).toBeInTheDocument();
     expect(within(container).getByText('Redis')).toBeInTheDocument();
     expect(within(container).getByText('PrestaShop')).toBeInTheDocument();
+  });
+
+  it('lists an infra-bearing connection (e.g. WooCommerce) in the Infrastructure panel (#1619)', async () => {
+    const apiClient = createMockApiClient({
+      health: {
+        getDevStackHealth: vi.fn().mockResolvedValue({
+          status: 'ok',
+          services: {
+            postgres: { status: 'ok' },
+            redis: { status: 'ok' },
+            prestashop: { status: 'ok' },
+            worker: { status: 'ok' },
+          },
+          connections: [
+            {
+              connectionId: 'conn-woo-1',
+              name: 'My WooCommerce Shop',
+              platformType: 'woocommerce',
+              status: 'ok',
+            },
+          ],
+          timestamp: '2026-04-06T00:00:00.000Z',
+        }),
+      },
+    });
+    const { container } = renderWithProviders(<DashboardPage />, { apiClient });
+
+    expect(
+      await within(container).findByText('WooCommerce — My WooCommerce Shop')
+    ).toBeInTheDocument();
+    // Fixed core services still render alongside the connection row.
+    expect(within(container).getByText('PostgreSQL')).toBeInTheDocument();
+    expect(within(container).getByText('Redis')).toBeInTheDocument();
+    expect(within(container).getByText('PrestaShop')).toBeInTheDocument();
+    expect(within(container).getByText('Worker')).toBeInTheDocument();
+  });
+
+  it('surfaces an unhealthy infra-bearing connection with its message', async () => {
+    const apiClient = createMockApiClient({
+      health: {
+        getDevStackHealth: vi.fn().mockResolvedValue({
+          status: 'degraded',
+          services: {
+            postgres: { status: 'ok' },
+            redis: { status: 'ok' },
+            prestashop: { status: 'ok' },
+            worker: { status: 'ok' },
+          },
+          connections: [
+            {
+              connectionId: 'conn-woo-1',
+              name: 'My WooCommerce Shop',
+              platformType: 'woocommerce',
+              status: 'error',
+              message: 'Unauthorized (401)',
+            },
+          ],
+          timestamp: '2026-04-06T00:00:00.000Z',
+        }),
+      },
+    });
+    renderWithProviders(<DashboardPage />, { apiClient });
+
+    expect(await screen.findByText('Unauthorized (401)')).toBeInTheDocument();
+  });
+
+  it('reflects the real node set (not a fixed string) in the System health KPI description', async () => {
+    const apiClient = createMockApiClient({
+      health: {
+        getDevStackHealth: vi.fn().mockResolvedValue({
+          status: 'ok',
+          services: {
+            postgres: { status: 'ok' },
+            redis: { status: 'ok' },
+            prestashop: { status: 'ok' },
+            worker: { status: 'ok' },
+          },
+          connections: [
+            {
+              connectionId: 'conn-woo-1',
+              name: 'My WooCommerce Shop',
+              platformType: 'woocommerce',
+              status: 'ok',
+            },
+          ],
+          timestamp: '2026-04-06T00:00:00.000Z',
+        }),
+      },
+    });
+    const { container } = renderWithProviders(<DashboardPage />, { apiClient });
+
+    await waitFor(() => {
+      const card = findCardByLabel(container, 'System health');
+      expect(
+        within(card).getByText(
+          'Postgres · Redis · PrestaShop · Worker · WooCommerce (My WooCommerce Shop)'
+        )
+      ).toBeInTheDocument();
+    });
   });
 
   it('shows error message when a service is degraded', async () => {
@@ -144,7 +250,9 @@ describe('DashboardPage', () => {
     });
     renderWithProviders(<DashboardPage />, { apiClient });
 
-    expect(await screen.findByRole('heading', { name: 'Health check failed' }, { timeout: 10000 })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: 'Health check failed' }, { timeout: 10000 })
+    ).toBeInTheDocument();
   }, 15000);
 
   it('shows recent sync jobs in a table', async () => {
@@ -171,11 +279,9 @@ describe('DashboardPage', () => {
   it('shows failed jobs count in metric card', async () => {
     const apiClient = createMockApiClient({
       syncJobs: {
-        listGrouped: vi.fn().mockResolvedValue(
-          groupsResponse([
-            makeGroup({ count: 1, lastError: 'Timeout' }),
-          ]),
-        ),
+        listGrouped: vi
+          .fn()
+          .mockResolvedValue(groupsResponse([makeGroup({ count: 1, lastError: 'Timeout' })])),
       },
     });
     renderWithProviders(<DashboardPage />, { apiClient });
@@ -186,9 +292,9 @@ describe('DashboardPage', () => {
   it('tints the Failed jobs card red and links to /jobs-logs?status=dead when there are failures', async () => {
     const apiClient = createMockApiClient({
       syncJobs: {
-        listGrouped: vi.fn().mockResolvedValue(
-          groupsResponse([makeGroup({ count: 3, lastError: 'Timeout' })]),
-        ),
+        listGrouped: vi
+          .fn()
+          .mockResolvedValue(groupsResponse([makeGroup({ count: 3, lastError: 'Timeout' })])),
       },
     });
 
@@ -216,10 +322,17 @@ describe('DashboardPage', () => {
   it('tints the Integration health card warning when a connection is in error', async () => {
     const apiClient = createMockApiClient({
       connections: {
-        list: vi.fn().mockResolvedValue([
-          makeConnection({ id: 'c1', name: 'Store A', status: 'active', platformType: 'prestashop' }),
-          makeConnection({ id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro' }),
-        ]),
+        list: vi
+          .fn()
+          .mockResolvedValue([
+            makeConnection({
+              id: 'c1',
+              name: 'Store A',
+              status: 'active',
+              platformType: 'prestashop',
+            }),
+            makeConnection({ id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro' }),
+          ]),
       },
     });
 
@@ -242,7 +355,7 @@ describe('DashboardPage', () => {
     renderWithProviders(<DashboardPage />, { apiClient });
 
     expect(
-      await screen.findByRole('heading', { name: 'Unable to load sync jobs' }, { timeout: 5000 }),
+      await screen.findByRole('heading', { name: 'Unable to load sync jobs' }, { timeout: 5000 })
     ).toBeInTheDocument();
   });
 
@@ -280,14 +393,14 @@ describe('DashboardPage', () => {
                 count: 3,
                 lastError: 'FK violation',
               }),
-            ]),
+            ])
           ),
         },
       });
       renderWithProviders(<DashboardPage />, { apiClient });
 
       expect(
-        await screen.findByRole('heading', { name: /What’s broken right now/ }),
+        await screen.findByRole('heading', { name: /What’s broken right now/ })
       ).toBeInTheDocument();
       expect(await screen.findByText('master › inventory › syncByExternalId')).toBeInTheDocument();
       expect(screen.getByText('1 unique signature · 3 total failures')).toBeInTheDocument();
@@ -308,15 +421,13 @@ describe('DashboardPage', () => {
                 jobType: 'marketplace.orders.poll' as JobType,
                 count: 1,
               }),
-            ]),
+            ])
           ),
         },
       });
       renderWithProviders(<DashboardPage />, { apiClient });
 
-      expect(
-        await screen.findByText('2 unique signatures · 3 total failures'),
-      ).toBeInTheDocument();
+      expect(await screen.findByText('2 unique signatures · 3 total failures')).toBeInTheDocument();
     });
 
     it('calls retryGrouped with the group selector when Retry is clicked', async () => {
@@ -334,7 +445,7 @@ describe('DashboardPage', () => {
                 jobType: 'some.failing.job' as JobType,
                 count: 1,
               }),
-            ]),
+            ])
           ),
           retryGrouped,
         },
@@ -370,7 +481,7 @@ describe('DashboardPage', () => {
                 jobType: 'bulk.failing.job' as JobType,
                 count: 3,
               }),
-            ]),
+            ])
           ),
           retryGrouped,
         },
@@ -400,7 +511,7 @@ describe('DashboardPage', () => {
                 jobType: 'partial.retry.job' as JobType,
                 count: 3,
               }),
-            ]),
+            ])
           ),
           retryGrouped,
         },
@@ -432,7 +543,7 @@ describe('DashboardPage', () => {
                 jobType: 'racy.job' as JobType,
                 count: 3,
               }),
-            ]),
+            ])
           ),
           retryGrouped,
         },
@@ -471,7 +582,7 @@ describe('DashboardPage', () => {
                 jobType: 'some.job' as JobType,
                 count: 2,
               }),
-            ]),
+            ])
           ),
         },
       });
@@ -490,7 +601,7 @@ describe('DashboardPage', () => {
       const failingJobsLink = screen.getByRole('link', { name: /2 failing jobs/ });
       expect(failingJobsLink).toHaveAttribute(
         'href',
-        '/jobs-logs?status=dead&connectionId=conn_failing',
+        '/jobs-logs?status=dead&connectionId=conn_failing'
       );
     });
   });

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -126,7 +126,7 @@ function buildInfraNodeLabels(
     const platformLabel =
       platformDisplayNames.get(connection.platformType) ??
       fallbackPlatformLabel(connection.platformType);
-    labels.push(`${platformLabel} (${connection.name})`);
+    labels.push(connection.name ? `${platformLabel} (${connection.name})` : platformLabel);
   }
   return labels;
 }
@@ -647,7 +647,12 @@ export function DashboardPage(): ReactElement {
               {infraConnections.map((connection) => (
                 <ServiceHealthRow
                   key={connection.connectionId}
-                  name={`${platformDisplayNames.get(connection.platformType) ?? fallbackPlatformLabel(connection.platformType)} — ${connection.name}`}
+                  name={
+                    connection.name
+                      ? `${platformDisplayNames.get(connection.platformType) ?? fallbackPlatformLabel(connection.platformType)} — ${connection.name}`
+                      : (platformDisplayNames.get(connection.platformType) ??
+                        fallbackPlatformLabel(connection.platformType))
+                  }
                   health={{ status: connection.status, message: connection.message }}
                 />
               ))}

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -14,13 +14,22 @@ import { useDevStackHealthQuery } from '../../features/health/hooks/use-dev-stac
 import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
 import { useFailedJobGroupsQuery } from '../../features/sync-jobs/hooks/use-failed-job-groups-query';
 import { useRetryGroupedSyncJobsMutation } from '../../features/sync-jobs/hooks/use-retry-grouped-sync-jobs-mutation';
+import { usePlatforms } from '../../shared/plugins';
 import type {
+  DevStackHealth,
   ServiceHealth,
   ServiceStatus,
   OverallStatus,
 } from '../../features/health/api/health.types';
-import type { Connection, ConnectionStatus } from '../../features/connections/api/connections.types';
-import type { JobStatus, SyncJob, SyncJobGroup } from '../../features/sync-jobs/api/sync-jobs.types';
+import type {
+  Connection,
+  ConnectionStatus,
+} from '../../features/connections/api/connections.types';
+import type {
+  JobStatus,
+  SyncJob,
+  SyncJobGroup,
+} from '../../features/sync-jobs/api/sync-jobs.types';
 import { DASHBOARD_HEALTH_INTERVAL_MS, DASHBOARD_JOBS_INTERVAL_MS } from './intervals';
 import { Button } from '../../shared/ui/button';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
@@ -47,7 +56,7 @@ function toRowStatusTone(status: ConnectionStatus | JobStatus): DashboardTone {
 
 function mapHealthTone(
   status: ServiceStatus | OverallStatus | undefined,
-  hasError: boolean,
+  hasError: boolean
 ): DashboardTone {
   if (hasError || status === 'error') return 'error';
   if (status === 'warning' || status === 'degraded') return 'warning';
@@ -69,7 +78,7 @@ function formatJobType(jobType: string): string {
 function renderHealthValue(
   status: OverallStatus | undefined,
   isLoading: boolean,
-  hasError: boolean,
+  hasError: boolean
 ): string {
   if (isLoading) return '—';
   if (hasError) return 'Unreachable';
@@ -84,6 +93,42 @@ function ServiceHealthRow({ name, health }: { name: string; health: ServiceHealt
       {health.message ? <span className="muted-text">{health.message}</span> : null}
     </li>
   );
+}
+
+/**
+ * Capitalizes a bare platform-type key (e.g. `woocommerce` → `Woocommerce`)
+ * for when no plugin-contributed display name is registered. This is only a
+ * fallback — the dashboard prefers `usePlatforms()` display names.
+ */
+function fallbackPlatformLabel(platformType: string): string {
+  return platformType.length > 0
+    ? platformType[0].toUpperCase() + platformType.slice(1)
+    : platformType;
+}
+
+/**
+ * Builds the ordered list of infrastructure node labels backing both the
+ * Infrastructure panel and the KPI-strip summary (#1619). Core services are
+ * always listed first, followed by one entry per infra-bearing connection
+ * (e.g. a connected WooCommerce shop) — so the summary always reflects the
+ * real node set instead of a fixed string.
+ */
+function buildInfraNodeLabels(
+  data: DevStackHealth | undefined,
+  platformDisplayNames: Map<string, string>
+): string[] {
+  if (!data) return [];
+  const labels = ['Postgres', 'Redis', 'PrestaShop'];
+  if (data.services.worker) {
+    labels.push('Worker');
+  }
+  for (const connection of data.connections ?? []) {
+    const platformLabel =
+      platformDisplayNames.get(connection.platformType) ??
+      fallbackPlatformLabel(connection.platformType);
+    labels.push(`${platformLabel} (${connection.name})`);
+  }
+  return labels;
 }
 
 interface ConnectionFailureSignal {
@@ -103,7 +148,7 @@ interface RolledUpConnection {
  * per-connection total is `sum(group.count) where group.connectionId = C`.
  */
 function summarizeFailuresByConnection(
-  groups: SyncJobGroup[],
+  groups: SyncJobGroup[]
 ): Map<string, ConnectionFailureSignal> {
   const byConnection = new Map<string, ConnectionFailureSignal>();
   for (const group of groups) {
@@ -122,7 +167,7 @@ function summarizeFailuresByConnection(
 
 function rollUpConnectionHealth(
   connections: Connection[],
-  failureSignals: Map<string, ConnectionFailureSignal>,
+  failureSignals: Map<string, ConnectionFailureSignal>
 ): RolledUpConnection[] {
   return connections.map((connection) => {
     const deadJobCount = failureSignals.get(connection.id)?.deadJobCount ?? 0;
@@ -141,8 +186,7 @@ function ConnectionHealthList({ rows }: { rows: RolledUpConnection[] }): ReactEl
   if (rows.length === 0) {
     return (
       <p className="muted-text">
-        No connections configured.{' '}
-        <Link to="/connections/new">Add the first connection.</Link>
+        No connections configured. <Link to="/connections/new">Add the first connection.</Link>
       </p>
     );
   }
@@ -169,13 +213,23 @@ function ConnectionHealthList({ rows }: { rows: RolledUpConnection[] }): ReactEl
 }
 
 export function DashboardPage(): ReactElement {
-  const connectionsQuery = useConnectionsQuery(undefined, { refetchInterval: DASHBOARD_HEALTH_INTERVAL_MS });
+  const connectionsQuery = useConnectionsQuery(undefined, {
+    refetchInterval: DASHBOARD_HEALTH_INTERVAL_MS,
+  });
   const healthQuery = useDevStackHealthQuery({ refetchInterval: DASHBOARD_HEALTH_INTERVAL_MS });
-  const recentJobsQuery = useSyncJobsQuery(undefined, { limit: 5 }, { refetchInterval: DASHBOARD_JOBS_INTERVAL_MS });
-  const queuedJobsQuery = useSyncJobsQuery({ status: 'queued' }, { limit: 1 }, { refetchInterval: DASHBOARD_JOBS_INTERVAL_MS });
+  const recentJobsQuery = useSyncJobsQuery(
+    undefined,
+    { limit: 5 },
+    { refetchInterval: DASHBOARD_JOBS_INTERVAL_MS }
+  );
+  const queuedJobsQuery = useSyncJobsQuery(
+    { status: 'queued' },
+    { limit: 1 },
+    { refetchInterval: DASHBOARD_JOBS_INTERVAL_MS }
+  );
   const deadGroupsQuery = useFailedJobGroupsQuery(
     { status: 'dead' },
-    { refetchInterval: DASHBOARD_JOBS_INTERVAL_MS },
+    { refetchInterval: DASHBOARD_JOBS_INTERVAL_MS }
   );
   const retryGrouped = useRetryGroupedSyncJobsMutation();
   const { showToast } = useToast();
@@ -187,16 +241,32 @@ export function DashboardPage(): ReactElement {
   const connections = connectionsQuery.data ?? [];
   const failedGroups = useMemo<SyncJobGroup[]>(
     () => deadGroupsQuery.data?.groups ?? [],
-    [deadGroupsQuery.data],
+    [deadGroupsQuery.data]
   );
-  const failureSignals = useMemo(
-    () => summarizeFailuresByConnection(failedGroups),
-    [failedGroups],
-  );
+  const failureSignals = useMemo(() => summarizeFailuresByConnection(failedGroups), [failedGroups]);
   const rolledUpConnections = useMemo(
     () => rollUpConnectionHealth(connections, failureSignals),
-    [connections, failureSignals],
+    [connections, failureSignals]
   );
+
+  const platforms = usePlatforms();
+  const platformDisplayNames = useMemo(
+    () =>
+      new Map<string, string>(
+        platforms.map((platform): [string, string] => [platform.platformType, platform.displayName])
+      ),
+    [platforms]
+  );
+  const infraConnections = healthQuery.data?.connections ?? [];
+  const infraNodeLabels = useMemo(
+    () => buildInfraNodeLabels(healthQuery.data, platformDisplayNames),
+    [healthQuery.data, platformDisplayNames]
+  );
+  const systemHealthDescription = healthQuery.isLoading
+    ? 'Checking dependencies…'
+    : infraNodeLabels.length > 0
+      ? infraNodeLabels.join(' · ')
+      : 'No infrastructure nodes detected';
 
   const activeCount = connections.filter((c) => c.status === 'active').length;
   const errorCount = connections.filter((c) => c.status === 'error').length;
@@ -275,7 +345,7 @@ export function DashboardPage(): ReactElement {
         setPendingGroupKey((current) => (current === key ? null : current));
       }
     },
-    [retryGrouped, showToast],
+    [retryGrouped, showToast]
   );
 
   const failedGroupColumns: DataTableColumn<SyncJobGroup>[] = useMemo(
@@ -356,7 +426,7 @@ export function DashboardPage(): ReactElement {
         },
       },
     ],
-    [connectionNameById, handleRetryGroup, pendingGroupKey],
+    [connectionNameById, handleRetryGroup, pendingGroupKey]
   );
 
   const recentJobColumns: DataTableColumn<SyncJob>[] = useMemo(
@@ -386,12 +456,10 @@ export function DashboardPage(): ReactElement {
         id: 'updatedAt',
         header: 'Updated',
         align: 'right',
-        cell: (job) => (
-          <TimeDisplay iso={job.updatedAt} format="relative" className="muted-text" />
-        ),
+        cell: (job) => <TimeDisplay iso={job.updatedAt} format="relative" className="muted-text" />,
       },
     ],
-    [],
+    []
   );
 
   return (
@@ -419,10 +487,10 @@ export function DashboardPage(): ReactElement {
           value={renderHealthValue(
             healthQuery.data?.status,
             healthQuery.isLoading,
-            Boolean(healthQuery.error),
+            Boolean(healthQuery.error)
           )}
           tone={mapHealthTone(healthQuery.data?.status, Boolean(healthQuery.error))}
-          description="Postgres · Redis · PrestaShop · Worker"
+          description={systemHealthDescription}
         />
 
         {deadTotal > 0 ? (
@@ -491,13 +559,11 @@ export function DashboardPage(): ReactElement {
             rows={failedGroups}
             rowKey={(group) => groupKey(group)}
             cardView={{
-              title: (group) => (
-                <span className="mono-text">{formatJobType(group.jobType)}</span>
-              ),
+              title: (group) => <span className="mono-text">{formatJobType(group.jobType)}</span>,
               subtitle: (group) => (
                 <span>
-                  {connectionNameById.get(group.connectionId) ?? group.connectionId} ·{' '}
-                  {group.count} failure{group.count === 1 ? '' : 's'}
+                  {connectionNameById.get(group.connectionId) ?? group.connectionId} · {group.count}{' '}
+                  failure{group.count === 1 ? '' : 's'}
                 </span>
               ),
               meta: (group) => (
@@ -506,9 +572,7 @@ export function DashboardPage(): ReactElement {
                 </StatusBadge>
               ),
             }}
-            emptyState={
-              <p className="muted-text">No failed jobs. All clear.</p>
-            }
+            emptyState={<p className="muted-text">No failed jobs. All clear.</p>}
           />
         )}
       </article>
@@ -527,7 +591,11 @@ export function DashboardPage(): ReactElement {
           </div>
 
           {connectionsQuery.isLoading && (
-            <LoadingState title="Loading connections" message="Fetching connection status…" liveRegion="off" />
+            <LoadingState
+              title="Loading connections"
+              message="Fetching connection status…"
+              liveRegion="off"
+            />
           )}
           {connectionsQuery.error && (
             <ErrorState
@@ -555,7 +623,11 @@ export function DashboardPage(): ReactElement {
           </div>
 
           {healthQuery.isLoading && (
-            <LoadingState title="Checking system health" message="Pinging dependencies…" liveRegion="off" />
+            <LoadingState
+              title="Checking system health"
+              message="Pinging dependencies…"
+              liveRegion="off"
+            />
           )}
           {healthQuery.error && (
             <ErrorState
@@ -572,6 +644,13 @@ export function DashboardPage(): ReactElement {
               {healthQuery.data.services.worker && (
                 <ServiceHealthRow name="Worker" health={healthQuery.data.services.worker} />
               )}
+              {infraConnections.map((connection) => (
+                <ServiceHealthRow
+                  key={connection.connectionId}
+                  name={`${platformDisplayNames.get(connection.platformType) ?? fallbackPlatformLabel(connection.platformType)} — ${connection.name}`}
+                  health={{ status: connection.status, message: connection.message }}
+                />
+              ))}
             </ul>
           )}
         </article>
@@ -590,7 +669,11 @@ export function DashboardPage(): ReactElement {
         </div>
 
         {recentJobsQuery.isLoading && (
-          <LoadingState title="Loading sync jobs" message="Fetching recent activity…" liveRegion="off" />
+          <LoadingState
+            title="Loading sync jobs"
+            message="Fetching recent activity…"
+            liveRegion="off"
+          />
         )}
         {recentJobsQuery.error && (
           <ErrorState


### PR DESCRIPTION
## Summary

Part of #1606
Closes #1619

The dashboard "Infrastructure / System health" panel only listed the four hardcoded core services (Postgres, Redis, PrestaShop, Worker), fed by a fixed-shape `/health/dev-stack` response. A connection that carries its own infrastructure (e.g. a connected WooCommerce shop) never appeared there, even though it was already visible under "Connection health".

- Added `ConnectionInfraHealthService` (`apps/api/src/health/connection-infra-health.service.ts`) which discovers active connections whose adapter capabilities include `ProductMaster` and/or `InventoryMaster` - this is capability-driven, not a WooCommerce-specific hardcode, so any future adapter with the same capability shape is picked up automatically. Each qualifying connection is probed via its existing `ConnectionTesterPort` (already implemented by WooCommerce, PrestaShop, Allegro, etc. and reused via `IConnectionService.testConnection`).
- `DevStackHealthService.checkDevStackHealth()` now runs this rollup alongside the existing Postgres/Redis/PrestaShop/worker checks and returns a new `connections: ConnectionHealthEntry[]` array on `DevStackHealthResponse`. An unhealthy infra-bearing connection degrades the overall status the same way PrestaShop/worker already do.
- To wire this without violating the CORE/Integration boundary, `ConnectionService` is now exposed from the api-layer `IntegrationsModule` behind a `CONNECTION_SERVICE_TOKEN` Symbol (mirroring the existing DI-token conventions), and `HealthModule` imports `IntegrationsModule` to resolve it plus the re-exported `INTEGRATIONS_SERVICE_TOKEN`.
- On the frontend, `apps/web/src/features/health/api/health.types.ts` gained a `ConnectionHealthEntry` type and an optional `connections` field on `DevStackHealth`. The dashboard page renders one `ServiceHealthRow` per infra-bearing connection alongside the fixed core rows (using `usePlatforms()` for the platform display name, e.g. "WooCommerce").
- The KPI-strip "System health" card no longer hardcodes "Postgres · Redis · PrestaShop · Worker" - the description is now built from the real node set (core services plus any connected infra-bearing connections), so it grows automatically as connections are added.

## Test plan

- [x] `pnpm --filter @openlinker/api type-check` - passes
- [x] `pnpm --filter @openlinker/api lint` - passes (0 errors)
- [x] `pnpm --filter @openlinker/api` unit tests for `src/health` and `src/integrations` - 147 passed
- [x] `pnpm --filter @openlinker/web type-check` - passes
- [x] `pnpm --filter @openlinker/web lint` - passes (0 errors)
- [x] `apps/web` dashboard-page tests (incl. new WooCommerce infra-connection cases) - 24 passed
- [x] `node scripts/check-cross-context-imports.mjs` and `check-service-interfaces.mjs` - both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)