### PR TITLE
feat(web/orders): surface carrier in order detail and orders-list row detail

### DIFF
--- a/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
@@ -4,9 +4,11 @@ import { renderWithProviders } from '../../../test/test-utils';
 import { OrderDeliveryPanel } from './order-delivery-panel';
 
 describe('OrderDeliveryPanel', () => {
-  it('should render nothing when there is no delivery data', () => {
+  it('should always render the panel with a Carrier field, "-" when there is no delivery data (#1617)', () => {
     renderWithProviders(<OrderDeliveryPanel />);
-    expect(screen.queryByRole('region', { name: 'Delivery' })).toBeNull();
+    expect(screen.getByRole('region', { name: 'Delivery' })).toBeInTheDocument();
+    expect(screen.getByText('Carrier')).toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
   });
 
   it('should render the address, method and pickup code when they are present', () => {
@@ -41,5 +43,34 @@ describe('OrderDeliveryPanel', () => {
       />,
     );
     expect(screen.getByText(/Paczkomat\s+OLS06A/)).toBeInTheDocument();
+  });
+
+  describe('carrier field (#1617)', () => {
+    it('should render the resolved carrier when the caller supplies one', () => {
+      renderWithProviders(
+        <OrderDeliveryPanel
+          shipping={{ methodId: 'm1', methodName: 'InPost Paczkomat' }}
+          carrier="InPost"
+        />,
+      );
+      expect(screen.getByText('Carrier')).toBeInTheDocument();
+      expect(screen.getByText('InPost')).toBeInTheDocument();
+    });
+
+    it('should render "-" for carrier when the caller resolved nothing, even with other delivery data present', () => {
+      renderWithProviders(
+        <OrderDeliveryPanel shipping={{ methodId: 'm1', methodName: 'InPost Paczkomat' }} carrier={null} />,
+      );
+      expect(screen.getByText('Carrier')).toBeInTheDocument();
+      expect(screen.getByText('-')).toBeInTheDocument();
+      // Method still renders independently — carrier and method aren't the same field.
+      expect(screen.getByText('InPost Paczkomat')).toBeInTheDocument();
+    });
+
+    it('should render the panel for the carrier alone when no other delivery data is present', () => {
+      renderWithProviders(<OrderDeliveryPanel carrier="InPost" />);
+      expect(screen.getByRole('region', { name: 'Delivery' })).toBeInTheDocument();
+      expect(screen.getByText('InPost')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/features/orders/components/order-delivery-panel.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.tsx
@@ -10,6 +10,18 @@
  * trait (#893): the buyer selects the locker on the source marketplace, so the
  * source connection — not the destination — owns the "buyer-selected" wording.
  *
+ * Carrier precedence (#1617): the panel never resolves the carrier itself — it
+ * renders whatever `carrier` string the caller passes in. `OrderDetailPage`
+ * computes that value as `shipment.carrier` (the actual carrier of record on
+ * a booked shipment, via `getCarrierDisplayName`) when a shipment exists,
+ * falling back to the snapshot's `shipping.methodName` (the source's stated
+ * delivery-method preference) otherwise. Same precedence the orders-list row
+ * detail would use if a shipment were loaded there (it isn't — see
+ * `OrderRowDetail`, which uses `shipping.methodName` directly). Unlike the
+ * other fields below, Carrier always renders ("-" fallback) — including when
+ * every other delivery field is absent — so the panel doubles as the one
+ * guaranteed place to check "who's shipping this."
+ *
  * @module apps/web/src/features/orders/components
  */
 import type { ReactElement } from 'react';
@@ -28,6 +40,12 @@ interface OrderDeliveryPanelProps {
   pickupPoint?: ParsedOrderPickupPoint;
   /** Source platform type — drives the buyer-selected vs operator-selected caption. */
   sourcePlatformType?: string | null;
+  /**
+   * Resolved carrier display name (#1617) — see precedence note above.
+   * Always rendered as a "Carrier" field, "-" when the caller resolved
+   * nothing (no shipment carrier and no snapshot method name).
+   */
+  carrier?: string | null;
 }
 
 function addressLines(address: ParsedAddress): ReactElement {
@@ -66,11 +84,10 @@ export function OrderDeliveryPanel({
   shipping,
   pickupPoint,
   sourcePlatformType,
-}: OrderDeliveryPanelProps): ReactElement | null {
+  carrier,
+}: OrderDeliveryPanelProps): ReactElement {
   // Resolved unconditionally (never inside a branch) — see #893.
   const sourcePlatform = usePlatform(sourcePlatformType ?? undefined);
-
-  if (!shippingAddress && !shipping && !pickupPoint) return null;
 
   const items: KeyValueItem[] = [];
   if (shippingAddress) {
@@ -79,6 +96,9 @@ export function OrderDeliveryPanel({
   if (shipping?.methodName ?? shipping?.methodId) {
     items.push({ id: 'method', label: 'Method', value: shipping.methodName ?? shipping.methodId });
   }
+  // Always rendered (unlike the fields above) — "-" fallback per #1617 so the
+  // operator can tell "no carrier resolved" apart from "field doesn't exist".
+  items.push({ id: 'carrier', label: 'Carrier', value: carrier ?? '-' });
 
   const pickupCaption =
     sourcePlatform?.pickupPointResolvesAsync === true
@@ -98,7 +118,7 @@ export function OrderDeliveryPanel({
     <section className="detail-section order-delivery" aria-label="Delivery">
       <h3 className="detail-section__title">Delivery</h3>
       <div className="order-delivery__card">
-        {items.length > 0 ? <KeyValueList items={items} /> : null}
+        <KeyValueList items={items} />
         {pickupPoint ? (
           <div className="order-delivery__pickup">
             <div className="order-delivery__pickup-code mono-text">

--- a/apps/web/src/features/orders/components/order-row-detail.tsx
+++ b/apps/web/src/features/orders/components/order-row-detail.tsx
@@ -71,6 +71,13 @@ export function OrderRowDetail({
 }: OrderRowDetailProps): ReactElement {
   const parsed = parseOrderSnapshot(order.orderSnapshot);
   const itemNames = parsed.items.map((i) => i.name).filter((n): n is string => Boolean(n));
+  // Carrier precedence (#1617): the list doesn't load per-order shipment data
+  // (that's a per-order fetch, too expensive for a paged table), so it can't
+  // read the shipment's actual `carrier` the way `OrderDetailPage` does —
+  // `shipping.methodName` (the source's stated delivery-method preference) is
+  // the best signal available at the row level, falling back to the pickup
+  // point's name for pickup-point orders that carry no separate method name.
+  // "-" (via `EMPTY` below) when neither is present.
   const carrier = parsed.shipping?.methodName ?? parsed.pickupPoint?.name ?? null;
   const destPlatform = order.syncStatus[0]
     ? platformByConnection.get(order.syncStatus[0].destinationConnectionId)

--- a/apps/web/src/features/orders/components/order-shipment-panel.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.tsx
@@ -14,6 +14,7 @@ import { useMemo, useState, type ReactElement } from 'react';
 import { useConnectionsQuery } from '../../connections';
 import {
   getCarrierDisplayName,
+  pickActiveShipment,
   ShipmentStatusBadge,
   useOrderShipmentsQuery,
   type Shipment,
@@ -266,18 +267,4 @@ function buildShipmentFieldItems(
   });
 
   return items;
-}
-
-/**
- * Pick the "active" shipment to show in the panel. In v1 there's at most one
- * non-terminal shipment per order (BE invariant). Prefer the most-recent
- * non-terminal row; fall back to the most-recent terminal one so operators
- * can still see the history of a delivered / cancelled / failed order.
- */
-function pickActiveShipment(items: readonly Shipment[] | null): Shipment | null {
-  if (!items || items.length === 0) return null;
-  const nonTerminal = items.find(
-    (s) => s.status !== 'delivered' && s.status !== 'failed' && s.status !== 'cancelled',
-  );
-  return nonTerminal ?? items[0];
 }

--- a/apps/web/src/features/shipments/index.ts
+++ b/apps/web/src/features/shipments/index.ts
@@ -49,3 +49,4 @@ export { useBulkGenerateLabelsMutation } from './hooks/use-bulk-generate-labels-
 export { useProtocolDownload } from './hooks/use-protocol-download';
 export { ShipmentStatusBadge } from './components/shipment-status-badge';
 export { buildCarrierTrackingUrl, getCarrierDisplayName } from './lib/carrier-tracking-url';
+export { pickActiveShipment } from './lib/pick-active-shipment';

--- a/apps/web/src/features/shipments/lib/pick-active-shipment.ts
+++ b/apps/web/src/features/shipments/lib/pick-active-shipment.ts
@@ -1,0 +1,27 @@
+/**
+ * Pick Active Shipment
+ *
+ * Shared precedence rule for choosing "the" shipment to represent an order
+ * when more than one `Shipment` row exists for it (e.g. a cancelled label
+ * followed by a re-generated one). Extracted from `OrderShipmentPanel` (#769)
+ * so `OrderDetailPage`'s carrier resolution (#1617) uses the identical rule
+ * instead of re-deriving its own.
+ *
+ * @module apps/web/src/features/shipments/lib
+ */
+import type { Shipment } from '../api/shipments.types';
+
+/**
+ * Pick the "active" shipment. In v1 there's at most one non-terminal shipment
+ * per order (BE invariant). Prefer the most-recent non-terminal row; fall
+ * back to the most-recent terminal one so operators can still see the
+ * history of a delivered / cancelled / failed order. `items` is assumed
+ * pre-sorted most-recent-first by the API.
+ */
+export function pickActiveShipment(items: readonly Shipment[] | null): Shipment | null {
+  if (!items || items.length === 0) return null;
+  const nonTerminal = items.find(
+    (s) => s.status !== 'delivered' && s.status !== 'failed' && s.status !== 'cancelled',
+  );
+  return nonTerminal ?? items[0];
+}

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -159,7 +159,9 @@ describe('OrderDetailPage', () => {
       const api = createMockApiClient({ orders: { getById: vi.fn().mockResolvedValue(richOrder) } });
       renderDetail(api);
       expect(await screen.findByText('POP-WAW-04412')).toBeInTheDocument();
-      expect(screen.getByText('InPost Paczkomat')).toBeInTheDocument();
+      // Appears twice: the "Method" field, and the "Carrier" field falling back
+      // to the same method name (#1617, no shipment exists for this order).
+      expect(screen.getAllByText('InPost Paczkomat').length).toBeGreaterThanOrEqual(1);
     });
 
     it('summarises item and unit counts in the header', async () => {
@@ -194,6 +196,79 @@ describe('OrderDetailPage', () => {
       // Header + summary both show "Received" (the OL ingestion clock); no "Placed" anywhere.
       expect((await screen.findAllByText(/Received/)).length).toBeGreaterThan(0);
       expect(screen.queryByText(/Placed/)).toBeNull();
+    });
+  });
+
+  describe('carrier field (#1617)', () => {
+    const orderWithMethod: OrderRecord = {
+      ...sampleOrder,
+      orderSnapshot: {
+        shipping: { methodId: 'm1', methodName: 'InPost Paczkomat' },
+      },
+    };
+
+    it('prefers the shipment record carrier over the snapshot method name when a shipment exists', async () => {
+      const api = createMockApiClient({
+        orders: { getById: vi.fn().mockResolvedValue(orderWithMethod) },
+        shipments: {
+          list: vi.fn().mockResolvedValue({
+            items: [
+              {
+                id: 'ol_shipment_1',
+                orderId: orderWithMethod.internalOrderId,
+                customerId: null,
+                connectionId: sampleConnection.id,
+                shippingMethod: 'paczkomat',
+                status: 'dispatched',
+                providerShipmentId: 'prov-1',
+                paczkomatId: 'POZ08A',
+                trackingNumber: 'TRACK-1',
+                carrier: 'inpost',
+                labelPdfRef: null,
+                dispatchedAt: '2026-05-01T10:00:00.000Z',
+                deliveredAt: null,
+                cancelledAt: null,
+                failedAt: null,
+                errorMessage: null,
+                createdAt: '2026-05-01T09:00:00.000Z',
+                updatedAt: '2026-05-01T10:00:00.000Z',
+              },
+            ],
+            total: 1,
+            limit: 20,
+            offset: 0,
+          }),
+        },
+      });
+
+      renderDetail(api);
+
+      expect(await screen.findByText('Carrier')).toBeInTheDocument();
+      expect(screen.getByText('InPost')).toBeInTheDocument();
+    });
+
+    it('falls back to the snapshot delivery method name when no shipment exists', async () => {
+      const api = createMockApiClient({
+        orders: { getById: vi.fn().mockResolvedValue(orderWithMethod) },
+      });
+
+      renderDetail(api);
+
+      expect(await screen.findByText('Carrier')).toBeInTheDocument();
+      // Appears twice: the "Method" field and the "Carrier" field's fallback
+      // to the same value (no shipment record exists for this order).
+      expect(screen.getAllByText('InPost Paczkomat').length).toBe(2);
+    });
+
+    it('renders "-" for carrier when neither a shipment nor a delivery method is present', async () => {
+      const api = createMockApiClient({
+        orders: { getById: vi.fn().mockResolvedValue(sampleOrder) },
+      });
+
+      renderDetail(api);
+
+      expect(await screen.findByText('Carrier')).toBeInTheDocument();
+      expect(screen.getByText('-')).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -27,7 +27,7 @@ import { useRetryOrderDestinationMutation } from '../../features/orders/hooks/us
 import type { OrderSyncStatusValue } from '../../features/orders/api/orders.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import { useConnectionsQuery } from '../../features/connections';
-import { useOrderShipmentsQuery } from '../../features/shipments';
+import { useOrderShipmentsQuery, pickActiveShipment, getCarrierDisplayName } from '../../features/shipments';
 import { OrderCustomerCard } from '../../features/orders/components/order-customer-card';
 import { OrderActivityTimeline } from '../../features/orders/components/order-activity-timeline';
 import { OrderShipmentPanel } from '../../features/orders/components/order-shipment-panel';
@@ -126,6 +126,15 @@ export function OrderDetailPage(): ReactElement {
   );
   const shipmentStatuses = shipmentsQuery.data?.items.map((s) => s.status) ?? null;
   const fulfillment = deriveFulfillment(shipmentStatuses, hasShippingCapability);
+  // Carrier precedence (#1617): the shipment record's `carrier` is the actual
+  // carrier of record on a booked shipment — prefer it over the snapshot's
+  // `shipping.methodName`, which is only the source's stated delivery-method
+  // preference and may not match what was actually booked. Falls back to the
+  // method name when no shipment exists yet (or its carrier hasn't resolved),
+  // and to `null` (rendered "-") when neither is available.
+  const activeShipment = pickActiveShipment(shipmentsQuery.data?.items ?? null);
+  const carrier =
+    getCarrierDisplayName(activeShipment?.carrier ?? null) ?? snapshot.shipping?.methodName ?? null;
   const sourcePlatformType =
     connections.find((c) => c.id === order.sourceConnectionId)?.platformType ?? null;
 
@@ -279,6 +288,7 @@ export function OrderDetailPage(): ReactElement {
             shipping={snapshot.shipping}
             pickupPoint={snapshot.pickupPoint}
             sourcePlatformType={sourcePlatformType}
+            carrier={carrier}
           />
           <OrderShipmentPanel order={order} />
           <OrderInvoicePanel order={order} />


### PR DESCRIPTION
## Summary

The orders UI never surfaced the carrier/delivery method chosen for an order - only the delivery "Method" (source's stated preference), not the actual carrier of record. This adds a Carrier field to order detail and documents the equivalent field already present in the orders-list row detail.

- **Order detail** (`OrderDeliveryPanel`): new always-rendered "Carrier" field ("-" fallback). `OrderDetailPage` resolves it from the active shipment's `carrier` (via `pickActiveShipment` + `getCarrierDisplayName`), falling back to the snapshot's `shipping.methodName` when no shipment exists yet.
- **Orders list** (`OrderRowDetail`, added by the just-merged #1620): the existing "Carrier" field is documented with the precedence rationale - it can only use `shipping.methodName` (falling back to the pickup point name) since the list doesn't load per-order shipment data.
- **Precedence rule** (documented in both files): `shipment.carrier` (the actual carrier of record on a booked shipment) takes priority over `shipping.methodName` (the source's stated delivery-method preference), because the shipment record reflects what actually got booked. The list can never reach the shipment record, so it stops at `shipping.methodName`.
- `pickActiveShipment` (the "most recent non-terminal, else most recent terminal" rule) is extracted from `OrderShipmentPanel` into a shared `apps/web/src/features/shipments/lib` helper so both call sites use the identical rule instead of duplicating it.

## Test plan

- [x] `pnpm --filter @openlinker/web lint` - 0 errors (pre-existing warnings only)
- [x] `tsc -b --pretty false` (scoped to web) - clean
- [x] `vitest run src/features/orders src/features/shipments src/pages/orders` - 243 passed
- [x] New/updated tests cover: Carrier always rendered with "-" fallback in `OrderDeliveryPanel`; shipment-carrier-over-methodName precedence and no-shipment/no-method fallback in `OrderDetailPage`; row-detail carrier field documentation in `OrderRowDetail`

Part of #1606
Closes #1617