### PR TITLE
feat(users): enforce case-insensitive unique email on registration

### DIFF
--- a/apps/api/src/auth/password-reset.service.spec.ts
+++ b/apps/api/src/auth/password-reset.service.spec.ts
@@ -85,6 +85,26 @@ describe('PasswordResetService', () => {
       // Notifier receives the raw token; storage keeps only its sha256 hash
       expect(saved.tokenHash).toBe(createHash('sha256').update(rawToken).digest('hex'));
     });
+
+    it('resolves a mixed-case email lookup and notifies the matched user (#1625)', async () => {
+      // Mirrors what the real UserRepository.findByEmail does — it
+      // normalizes the lookup internally, so a caller passing a mixed-case
+      // email still resolves the existing lowercase-stored user.
+      const { userRepo, tokenRepo, notifier } = makeMocks();
+      const user = makeUser();
+      userRepo.findByEmail.mockResolvedValue(user);
+      tokenRepo.save.mockImplementation((t) =>
+        Promise.resolve(
+          new PasswordResetToken('t-1', t.userId, t.tokenHash, t.expiresAt, null, new Date())
+        )
+      );
+      const service = new PasswordResetService(userRepo, tokenRepo, notifier, makeConfig(60));
+
+      await service.requestReset('Admin@Example.COM');
+
+      expect(userRepo.findByEmail).toHaveBeenCalledWith('Admin@Example.COM');
+      expect(notifier.notifyResetRequested).toHaveBeenCalledWith(user, expect.any(String));
+    });
   });
 
   describe('resetPassword', () => {

--- a/apps/api/src/auth/registration.service.spec.ts
+++ b/apps/api/src/auth/registration.service.spec.ts
@@ -79,6 +79,22 @@ describe('RegistrationService', () => {
     expect(repo.save).not.toHaveBeenCalled();
   });
 
+  it('should throw UserAlreadyExistsException for a case-variant duplicate email (#1625)', async () => {
+    // Mirrors what the real UserRepository.findByEmail does — it normalizes
+    // the lookup internally, so a caller passing a mixed-case email still
+    // resolves the existing lowercase-stored user.
+    const repo = makeRepo();
+    repo.findByUsername.mockResolvedValue(null);
+    repo.findByEmail.mockResolvedValue(makeUser('foo'));
+    const service = new RegistrationService(repo, makeConfig({ OL_REGISTRATION_ENABLED: 'true' }), makeDemoService(false), new InMemoryCacheAdapter());
+
+    await expect(service.register('user2', 'FOO@EXAMPLE.COM', 'pass123')).rejects.toThrow(
+      UserAlreadyExistsException
+    );
+    expect(repo.findByEmail).toHaveBeenCalledWith('FOO@EXAMPLE.COM');
+    expect(repo.save).not.toHaveBeenCalled();
+  });
+
   it('should save user in pending status with viewer role when demo mode is off', async () => {
     const repo = makeRepo();
     repo.findByUsername.mockResolvedValue(null);

--- a/apps/api/src/migrations/1819000000000-normalize-user-emails.ts
+++ b/apps/api/src/migrations/1819000000000-normalize-user-emails.ts
@@ -1,0 +1,40 @@
+/**
+ * Normalize User Emails Migration
+ *
+ * Backfills `users.email` to trimmed-lowercase so the existing
+ * `UQ_users_email` constraint enforces uniqueness case-insensitively (#1625).
+ * `UserRepository.save`/`findByEmail` normalize on every future write/read;
+ * this migration corrects any row written before that normalization existed.
+ *
+ * If two existing rows normalize to the same value, this UPDATE fails with a
+ * Postgres 23505 unique-violation instead of silently merging the accounts —
+ * that is intentional. An operator must resolve the collision (rename or
+ * deactivate one of the accounts) before re-running the migration.
+ *
+ * Idempotent: the WHERE clause only touches rows that aren't already
+ * normalized, so re-running after a partial or full success is a no-op.
+ *
+ * down() is intentionally irreversible — original casing is not preserved,
+ * mirroring other data-normalizing migrations in this repo.
+ *
+ * Generated: 2026-07-15 (synthetic sequential prefix per docs/migrations.md #1013).
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NormalizeUserEmails1819000000000 implements MigrationInterface {
+  name = 'NormalizeUserEmails1819000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "users"
+         SET "email" = LOWER(TRIM("email"))
+       WHERE "email" IS NOT NULL
+         AND "email" <> LOWER(TRIM("email"))`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // intentionally irreversible — original casing is not preserved
+  }
+}

--- a/apps/api/test/integration/user-email-uniqueness.int-spec.ts
+++ b/apps/api/test/integration/user-email-uniqueness.int-spec.ts
@@ -1,0 +1,90 @@
+/**
+ * User Email Uniqueness Integration Test
+ *
+ * Proves the case-insensitive unique-email guarantee (#1625) against a REAL
+ * Postgres instance, not a mocked `QueryFailedError`. `UserRepository.save`
+ * normalizes email to trimmed-lowercase before INSERT and converts a `23505`
+ * unique-violation on `UQ_users_email` into `UserAlreadyExistsException`; the
+ * unit test in `user.repository.spec.ts` proves that catch-logic against a
+ * hand-constructed error on a mocked ORM repository, but never exercises the
+ * actual DB constraint. This test resolves the real `UserRepositoryPort`
+ * from the app's DI container and calls `save()` directly twice — bypassing
+ * `RegistrationService`'s `findByEmail` pre-check entirely — so the second
+ * call is the only thing standing between two case-variant emails and a
+ * silent duplicate row.
+ *
+ * @module apps/api/test/integration
+ */
+import { UserAlreadyExistsException, USER_REPOSITORY_TOKEN, type UserRepositoryPort } from '@openlinker/core/users';
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { IntegrationTestHarness } from './setup';
+
+describe('User Email Uniqueness (real Postgres)', () => {
+  let harness: IntegrationTestHarness;
+  let userRepository: UserRepositoryPort;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    userRepository = harness.getApp().get<UserRepositoryPort>(USER_REPOSITORY_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('should genuinely violate the DB unique constraint for a case-variant duplicate email', async () => {
+    await userRepository.save({
+      username: 'alice',
+      email: 'user@test.com',
+      passwordHash: 'hash-1',
+      role: 'viewer',
+      status: 'pending',
+    });
+
+    // Different username and different email casing — RegistrationService's
+    // findByEmail pre-check would already catch this via case-insensitive
+    // lookup, so calling save() directly is the only way to reach the real
+    // constraint on the normalized (lowercased) column value.
+    await expect(
+      userRepository.save({
+        username: 'bob',
+        email: 'User@Test.com',
+        passwordHash: 'hash-2',
+        role: 'viewer',
+        status: 'pending',
+      })
+    ).rejects.toThrow(UserAlreadyExistsException);
+
+    // Confirm no duplicate row was actually persisted.
+    const dataSource = harness.getDataSource();
+    const rows = await dataSource.query<{ count: string }[]>(
+      `SELECT count(*)::text as count FROM users WHERE email = $1`,
+      ['user@test.com']
+    );
+    expect(rows[0].count).toBe('1');
+  });
+
+  it('should allow two users with genuinely distinct emails', async () => {
+    await userRepository.save({
+      username: 'carol',
+      email: 'carol@test.com',
+      passwordHash: 'hash-1',
+      role: 'viewer',
+      status: 'pending',
+    });
+
+    await expect(
+      userRepository.save({
+        username: 'dave',
+        email: 'dave@test.com',
+        passwordHash: 'hash-2',
+        role: 'viewer',
+        status: 'pending',
+      })
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/web/src/features/users/components/register-form.test.tsx
+++ b/apps/web/src/features/users/components/register-form.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
+import { ApiError } from '../../../shared/api/api-error';
 import { RegisterForm } from './register-form';
 
 describe('RegisterForm', () => {
@@ -70,6 +71,25 @@ describe('RegisterForm', () => {
     await userEvent.click(screen.getByRole('button', { name: /request access/i }));
 
     expect(await screen.findByText('Username already taken')).toBeInTheDocument();
+  });
+
+  it('should show a dedicated message when registration fails with a 409 (#1625)', async () => {
+    const mockApi = createMockApiClient({
+      auth: {
+        register: vi
+          .fn()
+          .mockRejectedValue(new ApiError('Email already registered', 409, null)),
+      },
+    });
+    renderWithProviders(<RegisterForm />, { apiClient: mockApi });
+
+    await userEvent.type(screen.getByLabelText(/username/i), 'alice');
+    await userEvent.type(screen.getByLabelText(/email/i), 'alice@test.com');
+    await userEvent.type(screen.getByLabelText('Password'), 'password123');
+    await userEvent.type(screen.getByLabelText('Confirm password'), 'password123');
+    await userEvent.click(screen.getByRole('button', { name: /request access/i }));
+
+    expect(await screen.findByText('This email is already registered.')).toBeInTheDocument();
   });
 
   describe('demo mode', () => {

--- a/apps/web/src/features/users/components/register-form.tsx
+++ b/apps/web/src/features/users/components/register-form.tsx
@@ -14,6 +14,7 @@ import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 import { useRegisterMutation } from '../hooks/use-register-mutation';
 import { registerFormSchema, type RegisterFormValues } from './register-form.schema';
+import { ApiError } from '../../../shared/api/api-error';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
@@ -76,7 +77,9 @@ export function RegisterForm({ demoMode = false }: RegisterFormProps): ReactElem
       {form.formState.submitCount > 0 ? <FormErrorSummary errors={validationMessages} /> : null}
       {register.error ? (
         <Alert tone="error" title="Registration failed">
-          {register.error.message}
+          {register.error instanceof ApiError && register.error.isConflict()
+            ? 'This email is already registered.'
+            : register.error.message}
         </Alert>
       ) : null}
 

--- a/apps/web/src/features/users/hooks/use-register-mutation.ts
+++ b/apps/web/src/features/users/hooks/use-register-mutation.ts
@@ -1,9 +1,10 @@
 import { useMutation, type UseMutationResult } from '@tanstack/react-query';
 import { useApiClient } from '../../../app/api/api-client-provider';
+import type { ApiError } from '../../../shared/api/api-error';
 import type { RegisterRequest } from '../../auth/api/auth.types';
 import type { OkResponse } from '../../auth/api/auth.types';
 
-export function useRegisterMutation(): UseMutationResult<OkResponse, Error, RegisterRequest> {
+export function useRegisterMutation(): UseMutationResult<OkResponse, ApiError, RegisterRequest> {
   const apiClient = useApiClient();
 
   return useMutation({

--- a/apps/web/src/shared/api/api-error.test.ts
+++ b/apps/web/src/shared/api/api-error.test.ts
@@ -1,0 +1,17 @@
+/**
+ * ApiError status-helper tests (#1625 — isConflict()).
+ */
+import { describe, expect, it } from 'vitest';
+import { ApiError } from './api-error';
+
+describe('ApiError', () => {
+  describe('isConflict', () => {
+    it('returns true for a 409 status', () => {
+      expect(new ApiError('Email already registered', 409, null).isConflict()).toBe(true);
+    });
+
+    it('returns false for a non-409 status', () => {
+      expect(new ApiError('Not found', 404, null).isConflict()).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/shared/api/api-error.ts
+++ b/apps/web/src/shared/api/api-error.ts
@@ -21,6 +21,10 @@ export class ApiError extends Error {
     return this.status === 404;
   }
 
+  isConflict(): boolean {
+    return this.status === 409;
+  }
+
   isServerError(): boolean {
     return this.status >= 500;
   }

--- a/docs/plans/analysis/ANALYSIS-unique-email-enforcement.md
+++ b/docs/plans/analysis/ANALYSIS-unique-email-enforcement.md
@@ -1,0 +1,47 @@
+# Pre-Implementation Readiness Gate: Unique-Email Enforcement (#1625)
+
+**Plan**: `docs/plans/implementation-plan-unique-email-enforcement.md`
+**Date**: 2026-07-15
+**Verdict**: ✅ **READY**
+
+---
+
+## Reuse Findings
+
+| Plan Artifact | Classification | Evidence |
+|---|---|---|
+| `normalizeEmail()` private helper in `UserRepository` | **NEW (confirmed absent)** | `grep -rn "normalizeEmail\|toLowerCase\|LOWER(" libs/core/src/users` matches nothing in `users` domain/infrastructure — the only `.toLowerCase()` hits in `apps/api/src/auth` are unrelated boolean-flag parsing (`registration.service.ts:51`, `demo-mode.service.ts:21`, `bootstrap-admin.service.ts:49`). No existing email-normalization utility anywhere in the repo to reuse instead. |
+| Migration `1819000000000-normalize-user-emails.ts` | **NEW** | Current tip on this checkout is `1818000000007-add-inventory-item-is-stale.ts`; `1819000000000` is strictly greater, satisfying the ordering invariant in `docs/migrations.md`. No existing migration touches `users.email` casing. |
+| `ApiError.isConflict()` | **NEW (confirmed absent)** | `apps/web/src/shared/api/api-error.ts` has `isUnauthorized()` (401), `isForbidden()` (403), `isNotFound()` (404), `isServerError()` (≥500), `isNetworkError()` (0) — no `isConflict()`. Adding it at 409 follows the exact same one-line pattern as its siblings. |
+| `register-form.tsx` conflict branch | **NEW** | Confirmed current file (lines 77-81) renders `register.error.message` verbatim inside a generic `<Alert>` with no status branching — matches the plan's stated gap exactly. |
+| `libs/core/src/users/infrastructure/persistence/repositories/user.repository.spec.ts` | **NEW file** | `find libs/core/src/users -iname "*repository*spec*"` returns nothing — the plan's "create if absent" branch applies; no existing spec to extend. |
+| `UserAlreadyExistsException`, `UserRepositoryPort`, `findByEmail`, repository's `23505` catch | **ALREADY EXISTS → reuse, unchanged** | Confirmed in prior research pass (`user.repository.ts:35-38,91-115`, `domain/exceptions/user-already-exists.exception.ts`). Plan correctly reuses these without modification. |
+
+No collisions. Nothing the plan proposes to add already exists elsewhere under a different name.
+
+---
+
+## Backward-Compatibility Findings
+
+| Surface | Check | Result |
+|---|---|---|
+| `UserRepositoryPort` signature | `findByEmail`/`save` signatures unchanged — normalization is internal to the method body | ✅ No break |
+| Top-level barrel `@openlinker/core/users` | No export added/removed/renamed | ✅ No break |
+| Symbol tokens | None touched | ✅ No break |
+| DTOs (`RegisterDto`, register API request/response shapes) | Unchanged | ✅ No break |
+| ORM schema | No column/table added; migration is data-only (`UPDATE ... SET email = LOWER(TRIM(email))`), existing `UQ_users_email` constraint retained | ⚠️ **Warning (expected, planned)**: a pre-existing case-colliding pair of rows will cause the migration to fail with `23505` rather than silently merge — this is the plan's documented, intentional behavior (Phase 6 Step 2, Risks section). Flagging only so the human running the migration is prepared for it, not as a defect.
+| `check:invariants` | Migration timestamp ordering (`scripts/check-migration-timestamps.mjs`) | ✅ `1819000000000` sorts after the confirmed tip `1818000000007` — passes rule 3 (strictly greater than `origin/main`'s newest). No cross-context import added, so `check-cross-context-imports` is unaffected. No new service file requiring the `check-service-interfaces` interface rule (the repository already `implements UserRepositoryPort`). |
+
+No Critical items. One expected Warning, already accounted for in the plan's own risk section.
+
+---
+
+## Open Questions
+
+None blocking. The plan's own "Open Questions" section (production case-collision unknowable without a live query) is accepted as-is — the migration's fail-loud behavior is the correct mitigation and doesn't require resolving before implementation starts.
+
+---
+
+## Summary
+
+The plan is ready to implement as written: every artifact it proposes to add (`normalizeEmail` helper, the backfill migration, `ApiError.isConflict()`, the register-form conflict branch, and a new `user.repository.spec.ts`) was confirmed absent from the live tree, so there is no reuse collision to resolve. Nothing it changes breaks a published contract — `UserRepositoryPort`'s signature, the `@openlinker/core/users` barrel, DI tokens, and DTOs are all untouched, and the one schema-adjacent risk (the backfill migration failing loudly on a genuine pre-existing case collision) is both expected and already documented as intentional in the plan itself. No revision needed before moving to implementation.

--- a/docs/plans/implementation-plan-unique-email-enforcement.md
+++ b/docs/plans/implementation-plan-unique-email-enforcement.md
@@ -1,0 +1,214 @@
+# Implementation Plan: Unique-Email Enforcement on Registration (#1625)
+
+**Date**: 2026-07-15
+**Status**: Draft
+**Estimated Effort**: 4-6 hours
+**Issue**: https://github.com/openlinker-project/openlinker/issues/1625 (part of epic #1606)
+
+---
+
+## 1. Task Summary
+
+**Objective**: Guarantee that a given email address maps to exactly one account, closing the one real gap left in an otherwise-already-implemented uniqueness path: case-insensitive collisions (`Foo@Example.com` registering alongside an existing `foo@example.com`).
+
+**Context**: Issue #1625 assumed uniqueness enforcement didn't exist yet. Codebase research (this plan's Phase 0) found it mostly does:
+- DB-level `UNIQUE (email)` constraint since the original users-table migration (`apps/api/src/migrations/1775000000000-add-users-table.ts:25`).
+- Service-level pre-check in `RegistrationService.register` (`apps/api/src/auth/registration.service.ts:60-70`) throwing `UserAlreadyExistsException`.
+- Repository-level backstop in `UserRepository.save` (`libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts:101-114`) catching Postgres `23505` and converting it to the same domain exception — closes the pre-check race window.
+- Controller mapping to HTTP 409 (`apps/api/src/auth/auth.controller.ts:114-135`, `ConflictException`).
+
+What's missing is **normalization**: the `email` column is plain `varchar` with no case folding anywhere in the read or write path (verified: no `citext`, no `lower()` index, no `.toLowerCase()` in `UserRepository` or `RegistrationService`). Two accounts can exist today for the same mailbox differing only by case, and login-by-email in `password-reset.service.ts` would only ever find whichever exact-case row was queried.
+
+**Classification**: CORE (domain exception unchanged) + Infrastructure (migration, repository) + Interface (frontend error UX). No new port or capability.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- Normalize email to a canonical case (lowercase) at every write and read path so the existing `UNIQUE (email)` constraint becomes effectively case-insensitive.
+- Backfill migration to lowercase existing `users.email` values before... actually alongside declaring the invariant, so pre-existing mixed-case duplicates don't silently violate the constraint mid-deploy.
+- Add a focused unit test for the concurrent-registration race (two `save()` calls for the same normalized email, second must surface `UserAlreadyExistsException` via the `23505` catch path, not just the pre-check).
+- Add a `isConflict()` helper to `ApiError` and a dedicated "email already in use" inline error on the registration form's email field (frontend UX gap identified in research).
+
+### Out of Scope
+- Building an email-confirmation flow — this repo uses an admin-approval model (`pending → active`), not email confirmation; the issue's mention of "unconfirmed duplicate signup" does not apply here and is treated as a no-op non-goal.
+- Any change to the `UserAlreadyExistsException` shape or the existing pre-check/backstop pattern — both are correct as-is and are reused, not replaced.
+- Normalizing `username` casing — out of scope; the issue is scoped to email only.
+- Internationalized email normalization (IDN, Unicode case folding) — plain ASCII `.toLowerCase()` is the accepted default; documented as an assumption below.
+
+### Constraints
+- Must not require a new capability port — this stays entirely inside the `users` bounded context.
+- Must not break the two existing `findByEmail` callers: `RegistrationService.register` and `PasswordResetService` (`apps/api/src/auth/password-reset.service.ts:50`) — both must query with the same normalization the write path uses, or lookups silently stop matching.
+- Migration ordering: current tip on this checkout is `1818000000007` (confirmed via `pnpm --filter @openlinker/api migration:show`); the new migration must use a synthetic timestamp strictly after that, e.g. `1819000000000`.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**:
+- Infrastructure: `libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts` (normalize before every query/insert), `apps/api/src/migrations/` (backfill + rely on existing unique constraint).
+- Application (host): `apps/api/src/auth/registration.service.ts`, `apps/api/src/auth/password-reset.service.ts` — pass email through unchanged; normalization is centralized in the repository so every caller benefits without remembering to normalize.
+- Interface (frontend): `apps/web/src/shared/api/api-error.ts`, `apps/web/src/features/users/components/register-form.tsx`.
+
+**Capabilities Involved**: None new. `UserRepositoryPort` (`libs/core/src/users/domain/ports/user-repository.port.ts`) keeps its existing signature — normalization is an implementation detail of the adapter, not a contract change.
+
+**Existing Services Reused**: `RegistrationService`, `PasswordResetService`, `UserRepository`, `UserAlreadyExistsException`, `ConflictException` mapping in `AuthController`.
+
+**New Components Required**: none (no new entity, port, or exception — this is a hardening pass on existing components).
+
+**Core vs Integration Justification**: This is CORE domain infrastructure (persistence adapter for the `users` context), not an integration — email uniqueness is a platform-wide invariant, not something that varies per external system.
+
+---
+
+## 4. External / Domain Research
+
+### Internal Patterns
+- **Repository-catches-infra-error-and-throws-domain-error** is the established pattern (`docs/engineering-standards.md § Error Handling`) and is already correctly applied in `UserRepository.save` — the normalization work extends this same method, it doesn't introduce a new pattern.
+- **Self-healing migration pattern** for landing a constraint/backfill safely (see `docs/migrations.md § Recovery: duplicate migration timestamp` and `#1013`) — not strictly needed here since we're not renaming a migration, but the backfill migration should still be idempotent (`UPDATE ... WHERE email <> LOWER(email)`, safe to re-run).
+- No existing `citext` usage anywhere in the schema — introducing it here would be a one-off pattern deviation; plain `.toLowerCase()` normalization at the application boundary is simpler and consistent with the rest of the codebase (no other unique text column in this repo uses `citext` or a functional index).
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+- Should normalization also trim leading/trailing whitespace? Assumed yes (safe default, near-zero risk) — see Assumptions.
+- Are there any existing production rows with case-colliding emails today? Cannot verify without querying production; the backfill migration is written to be safe either way (see Phase 2, Step 2 — it aborts loudly on a genuine post-backfill collision rather than silently dropping a row).
+
+### Assumptions
+- **Lowercase, not `citext`**: normalize to lowercase ASCII at the repository boundary and keep the plain `varchar` + `UNIQUE (email)` constraint. Rejected `citext` because it would be the first use of that extension in the schema and adds an operational dependency (`CREATE EXTENSION citext`) for no behavioral benefit over normalize-on-write.
+- **No email-confirmation flow exists or is planned** in this repo (verified: `RegistrationService` goes straight to `pending`/`active` status, no token/confirmation entity found) — the issue's confirmation-flow caveat is treated as not applicable.
+- Trimming whitespace is included in the same normalization step since it's a near-zero-risk, standard practice alongside case folding.
+
+### Documentation Gaps
+- None — `docs/lessons.md` has no prior entries on email/user uniqueness to reconcile with.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1: Backend normalization
+**Goal**: Make `foo@example.com` and `Foo@Example.com` collide everywhere email is written or read.
+
+**Steps**:
+1. **Add a normalization helper**
+   - **File**: `libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts`
+   - **Action**: Add a private `normalizeEmail(email: string | null): string | null` (`email?.trim().toLowerCase() ?? null`). Apply it in `findByEmail` (normalize the query argument) and in `save` (normalize `user.email` before `ormRepository.create`).
+   - **Acceptance**: `findByEmail('Foo@Example.com')` finds a row stored as `foo@example.com`; `save({ email: 'Foo@Example.com', ... })` persists `foo@example.com`.
+   - **Dependencies**: none.
+
+2. **Backfill migration**
+   - **File**: `apps/api/src/migrations/1819000000000-normalize-user-emails.ts`
+   - **Action**: `up()` runs `UPDATE users SET email = LOWER(TRIM(email)) WHERE email IS NOT NULL AND email <> LOWER(TRIM(email))`. Wrap in a pre-check: if this update would violate the existing `UQ_users_email` constraint (i.e. two rows normalize to the same value), the `UPDATE` fails naturally with `23505` — that is the desired behavior (surface the conflict loudly for manual resolution rather than silently merging/deleting a row). `down()` is a no-op (`// intentionally irreversible — original casing is not preserved`), consistent with other data-normalizing migrations in this repo having asymmetric down migrations where restoring original data isn't meaningful.
+   - **Acceptance**: `pnpm --filter @openlinker/api migration:run` succeeds against a fresh DB and against a DB with pre-existing mixed-case rows that don't collide; fails loudly (documented, expected) if two existing rows do collide after normalization.
+   - **Dependencies**: Step 1 (so no new mixed-case rows are written between the migration running and app restart — deploy migration and code together, as is already the norm for this repo).
+
+3. **Verify `PasswordResetService` still matches**
+   - **File**: `apps/api/src/auth/password-reset.service.ts:50`
+   - **Action**: No code change expected — `findByEmail` now normalizes internally, so the caller's raw-case input still resolves correctly. Add a regression assertion in its existing spec (see Testing Strategy) rather than modifying the service.
+   - **Acceptance**: `password-reset.service.spec.ts` passes with a mixed-case lookup.
+
+### Phase 2: Frontend error UX
+**Goal**: Registering with a duplicate (or case-variant duplicate) email shows an unambiguous, field-attributed error instead of a generic alert.
+
+**Steps**:
+1. **Add `isConflict()` to `ApiError`**
+   - **File**: `apps/web/src/shared/api/api-error.ts`
+   - **Action**: Add `isConflict(): boolean { return this.status === 409; }`, mirroring the existing `isUnauthorized()/isForbidden()/isNotFound()` helpers.
+   - **Acceptance**: Unit test asserts `new ApiError({ status: 409, ... }).isConflict() === true`.
+
+2. **Surface a dedicated message in `register-form.tsx`**
+   - **File**: `apps/web/src/features/users/components/register-form.tsx`
+   - **Action**: In the existing error-render branch (around line 77-81), branch on `register.error.isConflict?.()` to render `"This email is already registered."` instead of the raw backend message, keeping the existing generic `Alert` as the fallback for all other error types. Do not add field-level validation wiring beyond this (React Hook Form's async server-error mapping for a single top-level alert is consistent with how other forms in this codebase already surface server errors — no new pattern needed).
+   - **Acceptance**: Manually triggering a 409 (e.g. registering the same email twice in dev) shows the dedicated copy.
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Postgres `citext` column type
+- **Description**: Change `email` to `citext`, drop the manual normalization.
+- **Why Rejected**: First use of the extension in this schema; requires `CREATE EXTENSION citext` privilege in every environment (including CI Testcontainers image) and a type-level migration touching TypeORM's column mapping. Normalize-on-write achieves the identical guarantee with zero new infrastructure dependencies.
+- **Trade-offs**: `citext` is slightly more defensive against a future direct-SQL write bypassing the repository; deemed unnecessary since all writes already go through `UserRepository.save`.
+
+### Alternative 2: Functional unique index `UNIQUE (LOWER(email))`, keep stored casing
+- **Description**: Preserve the user's original casing on display, enforce uniqueness via a functional index instead of normalizing storage.
+- **Why Rejected**: `findByEmail` would then need `WHERE LOWER(email) = LOWER($1)` instead of an exact match, and the existing `UQ_users_email` constraint would need dropping in favor of the functional index — more migration surface for a benefit (preserved display casing) nobody has asked for; email isn't rendered back to the user anywhere in this codebase today.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ No port signature change; normalization is a private implementation detail of `UserRepository`, consistent with `docs/architecture-overview.md § Repository Ports Pattern`.
+- ✅ No CORE↔Integration boundary touched — everything stays inside `libs/core/src/users` and its host callers in `apps/api/src/auth`.
+
+### Naming Conventions
+- ✅ Migration filename/class follow `docs/migrations.md` timestamp convention (`1819000000000`, class suffix matches).
+
+### Existing Patterns
+- ✅ Reuses the established repository error-conversion pattern; reuses the established `ApiError.isX()` helper family on the frontend.
+
+### Risks
+- **Pre-existing case-colliding rows in a real deployment**: the backfill migration fails loudly instead of silently merging accounts — intentional (data-loss-avoidant), but means this migration is not silently zero-touch in an environment with actual collisions. Mitigation: document the failure mode in the migration's file header so an operator knows to manually resolve (rename or deactivate one account) before retrying.
+- **Missed normalization call site**: if a future write path bypasses `UserRepository.save` (e.g. a raw SQL admin script), the invariant could be violated again. Mitigation: the DB-level `UNIQUE (email)` constraint remains the ultimate backstop regardless of case — a raw insert of `Foo@Example.com` when `foo@example.com` already exists would not be blocked by the DB constraint (case-sensitive), but this is accepted as an existing, unrelated gap in "someone bypasses the repository" scenarios generally, not something this plan can fully close without `citext` (Alternative 1, rejected).
+
+### Edge Cases
+- **Null email**: `UserOrmEntity.email` is nullable; `normalizeEmail(null)` must return `null`, not throw or produce `"null"`.
+- **Already-lowercase input**: normalization must be idempotent — registering with `foo@example.com` twice must still hit the pre-check/backstop path unchanged.
+
+### Backward Compatibility
+- ✅ No breaking change to `UserRepositoryPort` or any consumer signature. The migration is additive/corrective data-only.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `libs/core/src/users/infrastructure/persistence/repositories/user.repository.spec.ts` (create if absent, or extend): assert `findByEmail` normalizes its input and `save` normalizes before persisting.
+- `apps/api/src/auth/registration.service.spec.ts`: extend existing duplicate-email cases with a case-variant case (`register('user2', 'FOO@EXAMPLE.COM', ...)` after `foo@example.com` exists → `UserAlreadyExistsException`).
+- New test: concurrent-registration race — two `save()` invocations for the same normalized email where the pre-check passes for both (simulate by calling `save` directly, bypassing the service's pre-check), second call must throw `UserAlreadyExistsException` via the `23505` catch path in `UserRepository.save`.
+- `apps/api/src/auth/password-reset.service.spec.ts`: add a mixed-case lookup regression case.
+- `apps/web/src/shared/api/api-error.spec.ts` (or wherever `ApiError` is tested): `isConflict()` returns true only for status 409.
+
+### Integration Tests
+- Not required for this change — the unit-level Postgres-error-conversion path is already exercised at the unit level per this repo's existing test for `UserAlreadyExistsException`; a full `*.int-spec.ts` would duplicate that coverage against a real Testcontainers Postgres without adding meaningfully to confidence. If reviewers want a live-DB confirmation, add one assertion to an existing `test/integration/**/users*.int-spec.ts` if one exists — otherwise skip, per proportionality.
+
+### Mocking Strategy
+- Repository unit tests use a real in-memory-backed `Repository<UserOrmEntity>` mock or the existing `jest.Mocked<UserRepositoryPort>` pattern already used in `registration.service.spec.ts` — no new mocking pattern needed.
+
+### Acceptance Criteria
+- [ ] `foo@example.com` and `Foo@Example.com` cannot both register successfully.
+- [ ] Existing duplicate-email (same-case) behavior is unchanged (still 409 via `UserAlreadyExistsException`).
+- [ ] `PasswordResetService` still resolves a user regardless of the casing used at registration vs. the casing used to request a reset.
+- [ ] Migration `1819000000000-normalize-user-emails.ts` runs cleanly on a fresh DB (`pnpm --filter @openlinker/api migration:run`) and `migration:show` reflects it as applied.
+- [ ] Frontend registration form shows a dedicated "This email is already registered." message on a 409.
+- [ ] `pnpm lint && pnpm type-check && pnpm test` pass.
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture
+- [x] Respects CORE vs Integration boundaries
+- [x] Uses existing patterns (no unnecessary abstractions) — no new port, no new exception type
+- [x] Idempotency considered — normalization and backfill are both idempotent
+- [x] Event-driven patterns used where applicable — n/a, no event involved
+- [x] Rate limits & retries addressed — unaffected, existing demo-mode rate limit untouched
+- [x] Error handling comprehensive — reuses existing `UserAlreadyExistsException` → 409 mapping
+- [x] Testing strategy complete
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready
+- [x] Plan is saved as markdown file
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md)
+- [Engineering Standards](../engineering-standards.md)
+- [Testing Guide](../testing-guide.md)
+- [Migrations Guide](../migrations.md)
+- [Code Review Guide](../code-review-guide.md)

--- a/libs/core/src/users/infrastructure/persistence/repositories/user.repository.spec.ts
+++ b/libs/core/src/users/infrastructure/persistence/repositories/user.repository.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * User Repository — Unit Tests
+ *
+ * Verifies email normalization (#1625) and the Postgres unique-violation →
+ * domain-exception conversion path in UserRepository.save.
+ *
+ * @module libs/core/src/users/infrastructure/persistence/repositories
+ */
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import type { Repository } from 'typeorm';
+import { QueryFailedError } from 'typeorm';
+
+import { UserAlreadyExistsException } from '../../../domain/exceptions/user-already-exists.exception';
+import { UserOrmEntity } from '../entities/user.orm-entity';
+import { UserRepository } from './user.repository';
+
+describe('UserRepository', () => {
+  let repository: UserRepository;
+  let ormRepository: jest.Mocked<Repository<UserOrmEntity>>;
+
+  const now = new Date('2026-07-15T10:00:00Z');
+
+  const buildOrm = (overrides: Partial<UserOrmEntity> = {}): UserOrmEntity => ({
+    id: 'user-uuid',
+    username: 'alice',
+    email: 'alice@example.com',
+    passwordHash: 'hash',
+    role: 'viewer',
+    status: 'pending',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    const mockOrmRepo = {
+      findOne: jest.fn(),
+      create: jest.fn((entityLike: Partial<UserOrmEntity>) => entityLike as UserOrmEntity),
+      save: jest.fn(),
+    } as unknown as jest.Mocked<Repository<UserOrmEntity>>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserRepository,
+        {
+          provide: getRepositoryToken(UserOrmEntity),
+          useValue: mockOrmRepo,
+        },
+      ],
+    }).compile();
+
+    repository = module.get<UserRepository>(UserRepository);
+    ormRepository = module.get(getRepositoryToken(UserOrmEntity));
+  });
+
+  describe('findByEmail', () => {
+    it('should normalize a mixed-case email before querying', async () => {
+      ormRepository.findOne.mockResolvedValue(buildOrm());
+
+      await repository.findByEmail('Alice@Example.com');
+
+      expect(ormRepository.findOne).toHaveBeenCalledWith({
+        where: { email: 'alice@example.com' },
+      });
+    });
+
+    it('should trim surrounding whitespace before querying', async () => {
+      ormRepository.findOne.mockResolvedValue(null);
+
+      await repository.findByEmail('  alice@example.com  ');
+
+      expect(ormRepository.findOne).toHaveBeenCalledWith({
+        where: { email: 'alice@example.com' },
+      });
+    });
+  });
+
+  describe('save', () => {
+    it('should persist the email lowercased and trimmed', async () => {
+      ormRepository.save.mockResolvedValue(buildOrm({ email: 'alice@example.com' }));
+
+      await repository.save({
+        username: 'alice',
+        email: 'Alice@Example.com',
+        passwordHash: 'hash',
+        role: 'viewer',
+        status: 'pending',
+      });
+
+      expect(ormRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'alice@example.com' })
+      );
+    });
+
+    it('should pass through a null email unchanged', async () => {
+      ormRepository.save.mockResolvedValue(buildOrm({ email: null }));
+
+      await repository.save({
+        username: 'alice',
+        email: null,
+        passwordHash: 'hash',
+        role: 'viewer',
+        status: 'pending',
+      });
+
+      expect(ormRepository.create).toHaveBeenCalledWith(expect.objectContaining({ email: null }));
+    });
+
+    it('should convert a Postgres unique-violation on the normalized email into UserAlreadyExistsException', async () => {
+      // Simulates the pre-check-race window: two concurrent registrations for
+      // case-variant emails both pass RegistrationService's findByEmail
+      // pre-check, and the second save() call hits the DB constraint.
+      const error = new QueryFailedError('duplicate key value violates unique constraint', [], '');
+      (error as QueryFailedError & { code?: string; detail?: string }).code = '23505';
+      (error as QueryFailedError & { code?: string; detail?: string }).detail =
+        'Key (email)=(alice@example.com) already exists.';
+      ormRepository.save.mockRejectedValue(error);
+
+      await expect(
+        repository.save({
+          username: 'alice2',
+          email: 'ALICE@EXAMPLE.COM',
+          passwordHash: 'hash',
+          role: 'viewer',
+          status: 'pending',
+        })
+      ).rejects.toThrow(UserAlreadyExistsException);
+    });
+
+    it('should re-throw a QueryFailedError that is not a unique-violation', async () => {
+      const error = new QueryFailedError('connection terminated', [], '');
+      (error as QueryFailedError & { code?: string }).code = '57P01';
+      ormRepository.save.mockRejectedValue(error);
+
+      await expect(
+        repository.save({
+          username: 'alice',
+          email: 'alice@example.com',
+          passwordHash: 'hash',
+          role: 'viewer',
+          status: 'pending',
+        })
+      ).rejects.toBe(error);
+    });
+  });
+});

--- a/libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts
+++ b/libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts
@@ -33,7 +33,9 @@ export class UserRepository implements UserRepositoryPort {
   }
 
   async findByEmail(email: string): Promise<User | null> {
-    const entity = await this.ormRepository.findOne({ where: { email } });
+    const entity = await this.ormRepository.findOne({
+      where: { email: email.trim().toLowerCase() },
+    });
     return entity ? this.toDomain(entity) : null;
   }
 
@@ -91,9 +93,10 @@ export class UserRepository implements UserRepositoryPort {
   async save(
     user: Pick<User, 'username' | 'email' | 'passwordHash' | 'role' | 'status'>
   ): Promise<User> {
+    const normalizedEmail = this.normalizeEmail(user.email);
     const entity = this.ormRepository.create({
       username: user.username,
-      email: user.email,
+      email: normalizedEmail,
       passwordHash: user.passwordHash,
       role: user.role,
       status: user.status,
@@ -106,7 +109,7 @@ export class UserRepository implements UserRepositoryPort {
         const pgErr = error as QueryFailedError & { code?: string; detail?: string };
         if (pgErr.code === '23505') {
           const detail = pgErr.detail ?? '';
-          const identifier = detail.includes('(email)') ? (user.email ?? 'email') : user.username;
+          const identifier = detail.includes('(email)') ? (normalizedEmail ?? 'email') : user.username;
           throw new UserAlreadyExistsException(identifier);
         }
       }
@@ -144,6 +147,14 @@ export class UserRepository implements UserRepositoryPort {
       [userId],
     ) as [unknown, number];
     return { deleted: result[1] > 0 };
+  }
+
+  /**
+   * Trims and lowercases an email so `foo@example.com` and `Foo@Example.com`
+   * collide against the same `UQ_users_email` constraint row (#1625).
+   */
+  private normalizeEmail(email: string | null): string | null {
+    return email ? email.trim().toLowerCase() : null;
   }
 
   private toDomain(entity: UserOrmEntity): User {


### PR DESCRIPTION
Normalizes email (trim + lowercase) in UserRepository.findByEmail/save so foo@example.com and Foo@Example.com collide against the same UQ_users_email constraint, backfills existing rows via a new migration, and surfaces a dedicated "This email is already registered." message on the register form for 409 responses.


<!--
Thank you for contributing to OpenLinker!

Title: use Conventional Commits format — `feat(scope): subject`,
`fix(scope): subject`, `docs:`, `refactor:`, `test:`, `chore:`.
See CONTRIBUTING.md → Commits for the full type list.
-->

## Summary
- Normalizes `users.email` to trimmed-lowercase in `UserRepository.findByEmail`/`save` so `foo@example.com` and `Foo@Example.com` collide against the existing `UQ_users_email` constraint instead of creating two accounts.
- Adds migration `1819000000000-normalize-user-emails.ts` to backfill any pre-existing mixed-case rows (idempotent; fails loudly on a genuine pre-existing collision rather than silently merging accounts).
- Adds `ApiError.isConflict()` and surfaces a dedicated "This email is already registered." message on the register form for 409 responses, instead of the raw backend error string.
- The DB unique constraint, service-level pre-check, and repository-level 409 mapping already existed prior to this change — this PR closes the one real gap (case sensitivity).



## Related issues

<!-- One `Closes #N` per issue this PR resolves. Issues are closed
     automatically when the PR merges — do not close them manually. -->

Part of #1606
Closes #1625

## Test plan
- [x] `pnpm --filter @openlinker/core test -- user.repository.spec.ts` — normalization + concurrent-registration-race path (Postgres `23505` → `UserAlreadyExistsException`)
- [x] `pnpm --filter @openlinker/api test -- registration.service.spec.ts password-reset.service.spec.ts` — existing duplicate-email/username paths unaffected
- [ ] `pnpm --filter @openlinker/web test -- register-form api-error` — FE conflict-message + `isConflict()` unit tests
- [ ] `pnpm --filter @openlinker/api migration:run` against a fresh DB
- [ ] Manual: register `test@example.com`, then `Test@Example.com` → expect "This email is already registered."

## Quality gate

- [ ] `pnpm lint` passes (zero errors)
- [ ] `pnpm type-check` passes (zero errors)
- [ ] `pnpm test` passes (all unit tests green)
- [ ] *Optional, Docker required:* `pnpm test:integration` passes — needed
      only if you touched `apps/api/test/integration/**` or any plugin's
      `infrastructure/adapters/`.

## Migrations

- [ ] If this PR changes an ORM entity, a migration is included under
      `apps/api/src/migrations/` (or the plugin package), `pnpm --filter
      @openlinker/api migration:show` confirms it's listed, and both
      `up()` and `down()` were tested locally. See
      [`docs/migrations.md`](../docs/migrations.md). Tick this box for
      PRs that don't touch schemas too — it's trivially satisfied.
- Adds migration `1819000000000-normalize-user-emails.ts` to backfill any pre-existing mixed-case rows (idempotent; fails loudly on a genuine pre-existing collision rather than silently merging accounts).
- 


---

<sub>By submitting this pull request, I confirm that my contributions
are made under the terms of the [Apache License 2.0](../LICENSE), and I
certify the [Developer Certificate of Origin](https://developercertificate.org/)
by signing off my commits.</sub>
