### PR TITLE
feat(listings): let viewer role reach bulk-create wizard step 4

### DIFF
--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -3,9 +3,12 @@
  *
  * @module apps/api/src/listings/http
  */
+import 'reflect-metadata';
 import { NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
+
+import { ROLES_KEY } from '../../auth/decorators/roles.decorator';
 
 import type {
   CatalogProduct,
@@ -1048,6 +1051,42 @@ describe('ListingsController', () => {
 
         await expect(controller.getCatalogProduct('conn-1', 'p1')).rejects.toThrow('upstream-503');
       });
+    });
+  });
+
+  // ─── @Roles metadata (#1608) ────────────────────────────────────────────────
+  //
+  // Demo-mode `viewer` accounts must reach step 4 (Confirm) of the bulk-create
+  // offer wizard: all read-only lookups it drives must include 'viewer' in
+  // their @Roles set, while every write/submit endpoint stays admin+operator
+  // only. Reads decorator metadata directly (no HTTP layer / DB needed) so
+  // this stays in the fast unit-test tier; the end-to-end guard behaviour is
+  // covered by viewer-role-authz.int-spec.ts.
+  describe('@Roles metadata (#1608 — viewer wizard-read access)', () => {
+    const READ_LOOKUP_METHODS = [
+      'getSellerPolicies',
+      'getResponsibleProducers',
+      'getDeliveryPriceLists',
+      'getCategoryParameters',
+      'resolveCategory',
+      'resolveCategoriesBatch',
+      'findProductsByBarcode',
+      'getCatalogProduct',
+    ] as const;
+
+    const WRITE_METHODS = ['updateOfferFields', 'autoMatchVariants', 'createOffer'] as const;
+
+    function rolesOf(methodName: string): string[] | undefined {
+      const proto = ListingsController.prototype as unknown as Record<string, unknown>;
+      return Reflect.getMetadata(ROLES_KEY, proto[methodName] as object) as string[] | undefined;
+    }
+
+    it.each(READ_LOOKUP_METHODS)('%s includes admin, operator, and viewer', (methodName) => {
+      expect(rolesOf(methodName)).toEqual(['admin', 'operator', 'viewer']);
+    });
+
+    it.each(WRITE_METHODS)('%s stays restricted to admin and operator (no viewer)', (methodName) => {
+      expect(rolesOf(methodName)).toEqual(['admin', 'operator']);
     });
   });
 });

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -394,7 +394,7 @@ export class ListingsController {
     return this.toOfferCreationStatusDto(record);
   }
 
-  @Roles('admin', 'operator')
+  @Roles('admin', 'operator', 'viewer')
   @Get('connections/:connectionId/seller-policies')
   @HttpCode(HttpStatus.OK)
   @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
@@ -413,7 +413,7 @@ export class ListingsController {
     return this.sellerPolicies.getSellerPolicies(connectionId);
   }
 
-  @Roles('admin', 'operator')
+  @Roles('admin', 'operator', 'viewer')
   @Get('connections/:connectionId/responsible-producers')
   @HttpCode(HttpStatus.OK)
   @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
@@ -441,7 +441,7 @@ export class ListingsController {
     return { responsibleProducers };
   }
 
-  @Roles('admin', 'operator')
+  @Roles('admin', 'operator', 'viewer')
   @Get('connections/:connectionId/delivery-price-lists')
   @HttpCode(HttpStatus.OK)
   @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
@@ -468,7 +468,7 @@ export class ListingsController {
     return { deliveryPriceLists };
   }
 
-  @Roles('admin', 'operator')
+  @Roles('admin', 'operator', 'viewer')
   @Get('connections/:connectionId/categories/:categoryId/parameters')
   @HttpCode(HttpStatus.OK)
   @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
@@ -524,7 +524,7 @@ export class ListingsController {
     return { parameters: parameters.map((p) => this.toCategoryParameterResponseDto(p)) };
   }
 
-  @Roles('admin', 'operator')
+  @Roles('admin', 'operator', 'viewer')
   @Post('connections/:connectionId/categories/resolve')
   @HttpCode(HttpStatus.OK)
   @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
@@ -575,7 +575,7 @@ export class ListingsController {
     };
   }
 
-  @Roles('admin', 'operator')
+  @Roles('admin', 'operator', 'viewer')
   @Post('connections/:connectionId/categories/resolve-batch')
   @HttpCode(HttpStatus.OK)
   @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
@@ -639,7 +639,7 @@ export class ListingsController {
   // appears (e.g. a future bulk-prefill worker), promote to a service.
   // -----------------------------------------------------------------
 
-  @Roles('admin', 'operator')
+  @Roles('admin', 'operator', 'viewer')
   @Post('connections/:connectionId/products/find-by-barcode')
   @HttpCode(HttpStatus.OK)
   @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
@@ -692,7 +692,7 @@ export class ListingsController {
     return { kind: 'no_match' };
   }
 
-  @Roles('admin', 'operator')
+  @Roles('admin', 'operator', 'viewer')
   @Get('connections/:connectionId/products/:productId')
   @HttpCode(HttpStatus.OK)
   @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })

--- a/apps/api/test/integration/viewer-role-authz.int-spec.ts
+++ b/apps/api/test/integration/viewer-role-authz.int-spec.ts
@@ -152,6 +152,84 @@ describe('Viewer Role Authorization', () => {
     });
   });
 
+  // ─── #1608: bulk-create wizard read-lookups — viewer NOT blocked ───────────
+  //
+  // A demo-mode viewer must be able to walk the bulk-create offer wizard to
+  // step 4 (Confirm): every read-only lookup it drives must pass the guard.
+  // The connection id is fake so the handler itself 404s/409s/422s past the
+  // guard — the assertion is only that RolesGuard does not fire (not 403).
+
+  describe('#1608 — wizard read-lookups, viewer gets past the guard (not 403)', () => {
+    const FAKE_CONNECTION_ID = '00000000-0000-4000-8000-000000000001';
+
+    it('GET /listings/connections/:connectionId/seller-policies', async () => {
+      const { http, viewerToken } = await seeds();
+      const res = await http
+        .get(`/v1/listings/connections/${FAKE_CONNECTION_ID}/seller-policies`)
+        .set('Authorization', `Bearer ${viewerToken}`);
+      expect(res.status).not.toBe(403);
+    });
+
+    it('GET /listings/connections/:connectionId/responsible-producers', async () => {
+      const { http, viewerToken } = await seeds();
+      const res = await http
+        .get(`/v1/listings/connections/${FAKE_CONNECTION_ID}/responsible-producers`)
+        .set('Authorization', `Bearer ${viewerToken}`);
+      expect(res.status).not.toBe(403);
+    });
+
+    it('GET /listings/connections/:connectionId/delivery-price-lists', async () => {
+      const { http, viewerToken } = await seeds();
+      const res = await http
+        .get(`/v1/listings/connections/${FAKE_CONNECTION_ID}/delivery-price-lists`)
+        .set('Authorization', `Bearer ${viewerToken}`);
+      expect(res.status).not.toBe(403);
+    });
+
+    it('GET /listings/connections/:connectionId/categories/:categoryId/parameters', async () => {
+      const { http, viewerToken } = await seeds();
+      const res = await http
+        .get(`/v1/listings/connections/${FAKE_CONNECTION_ID}/categories/123/parameters`)
+        .set('Authorization', `Bearer ${viewerToken}`);
+      expect(res.status).not.toBe(403);
+    });
+
+    it('POST /listings/connections/:connectionId/categories/resolve', async () => {
+      const { http, viewerToken } = await seeds();
+      const res = await http
+        .post(`/v1/listings/connections/${FAKE_CONNECTION_ID}/categories/resolve`)
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .send({});
+      expect(res.status).not.toBe(403);
+    });
+
+    it('POST /listings/connections/:connectionId/categories/resolve-batch', async () => {
+      const { http, viewerToken } = await seeds();
+      const res = await http
+        .post(`/v1/listings/connections/${FAKE_CONNECTION_ID}/categories/resolve-batch`)
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .send({ items: [] });
+      expect(res.status).not.toBe(403);
+    });
+
+    it('POST /listings/connections/:connectionId/products/find-by-barcode', async () => {
+      const { http, viewerToken } = await seeds();
+      const res = await http
+        .post(`/v1/listings/connections/${FAKE_CONNECTION_ID}/products/find-by-barcode`)
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .send({ barcode: '5901234123457' });
+      expect(res.status).not.toBe(403);
+    });
+
+    it('GET /listings/connections/:connectionId/products/:productId', async () => {
+      const { http, viewerToken } = await seeds();
+      const res = await http
+        .get(`/v1/listings/connections/${FAKE_CONNECTION_ID}/products/p1`)
+        .set('Authorization', `Bearer ${viewerToken}`);
+      expect(res.status).not.toBe(403);
+    });
+  });
+
   // ─── writes: viewer gets 403 ────────────────────────────────────────────────
   //
   // RolesGuard fires before the handler body, so these 403s arrive even with
@@ -206,6 +284,35 @@ describe('Viewer Role Authorization', () => {
       const { http, viewerToken } = await seeds();
       await http
         .post('/v1/listings/connections/00000000-0000-4000-8000-000000000001/offers')
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .send({})
+        .expect(403);
+    });
+
+    it('POST /listings/connections/:connectionId/offers/:offerId/fields (#1608 — write stays admin/operator)', async () => {
+      const { http, viewerToken } = await seeds();
+      await http
+        .post(
+          '/v1/listings/connections/00000000-0000-4000-8000-000000000001/offers/00000000-0000-4000-8000-000000000002/fields'
+        )
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .send({ price: '10.00' })
+        .expect(403);
+    });
+
+    it('POST /listings/connections/:connectionId/sync/auto-match-variants (#1608 — write stays admin/operator)', async () => {
+      const { http, viewerToken } = await seeds();
+      await http
+        .post('/v1/listings/connections/00000000-0000-4000-8000-000000000001/sync/auto-match-variants')
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .send({})
+        .expect(403);
+    });
+
+    it('POST /listings/bulk-create (#1608 — bulk submit stays admin/operator)', async () => {
+      const { http, viewerToken } = await seeds();
+      await http
+        .post('/v1/listings/bulk-create')
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({})
         .expect(403);


### PR DESCRIPTION
## Summary

Part of #1606

In demo mode a self-registered account gets role `viewer`. Opening the bulk-create offer wizard, a viewer hit 403 "Insufficient permissions" on read-only lookups (Erli seller/delivery policies, responsible producers, category parameters, category resolution, catalog product lookups), which blocked the wizard mid-flow and made it impossible to ever reach step 4 (Confirm).

`RolesGuard` throws when a handler's `@Roles(...)` set excludes the caller's role. The wizard's read-lookup endpoints in `ListingsController` were decorated `@Roles('admin', 'operator')`, excluding `viewer`.

This PR adds `'viewer'` to the `@Roles` decorator on exactly the 8 read-lookup handlers the wizard calls:

1. `GET connections/:connectionId/seller-policies`
2. `GET connections/:connectionId/responsible-producers`
3. `GET connections/:connectionId/delivery-price-lists`
4. `GET connections/:connectionId/categories/:categoryId/parameters`
5. `POST connections/:connectionId/categories/resolve`
6. `POST connections/:connectionId/categories/resolve-batch`
7. `POST connections/:connectionId/products/find-by-barcode`
8. `GET connections/:connectionId/products/:productId`

Write/submit endpoints are untouched and stay `@Roles('admin', 'operator')`:
- `POST connections/:connectionId/offers/:offerId/fields`
- `POST connections/:connectionId/sync/auto-match-variants`
- `POST connections/:connectionId/offers`
- `POST /listings/bulk-create` and other bulk-flow write endpoints (different controller, not modified)

## Tests

- New unit test block in `listings.controller.spec.ts` asserting the `@Roles` metadata split directly: the 8 read endpoints include `admin`, `operator`, `viewer`; the 3 write endpoints stay `admin`, `operator` only.
- Extended `viewer-role-authz.int-spec.ts` with end-to-end guard checks: a viewer JWT is not blocked (not 403) on the 8 read endpoints, and still gets 403 on the offer-fields-update, auto-match-variants, and bulk-create-submit write endpoints.
- `write-guard-coverage.spec.ts` needed no change — it only asserts every write handler carries non-empty `@Roles` metadata, which remains true.

## Test plan

- [x] `pnpm --filter @openlinker/api lint` (scoped to changed files — clean; one pre-existing unrelated error in `plugins.ts`)
- [x] `pnpm --filter @openlinker/api type-check` (clean, after `pnpm build`)
- [x] `pnpm --filter @openlinker/api test -- src/listings src/auth` (21 suites, 216 tests passed)

Closes #1608