### PR TITLE
fix(integrations): allow viewer/operator role on connection diagnostics

### DIFF
--- a/apps/api/src/integrations/http/connection.controller.ts
+++ b/apps/api/src/integrations/http/connection.controller.ts
@@ -179,7 +179,7 @@ export class ConnectionController {
     return this.toResponse(connection, user);
   }
 
-  @Roles('admin')
+  @Roles('admin', 'operator', 'viewer')
   @Get(':id/diagnostics')
   @ApiOperation({ summary: 'Get connection diagnostics and activity summary' })
   @ApiResponse({

--- a/apps/api/test/integration/operator-role-authz.int-spec.ts
+++ b/apps/api/test/integration/operator-role-authz.int-spec.ts
@@ -145,6 +145,20 @@ describe('Operator Role Authorization', () => {
         .set('Authorization', `Bearer ${operatorToken}`)
         .expect(200);
     });
+
+    it('GET /connections/:id/diagnostics → 200 (opened to operator/viewer by #1645)', async () => {
+      const { http, adminToken, operatorToken } = await seeds();
+      const dto = createPrestashopConnectionDto();
+      const { body: conn } = await http
+        .post('/v1/connections')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(dto)
+        .expect(201);
+      await http
+        .get(`/v1/connections/${conn.id as string}/diagnostics`)
+        .set('Authorization', `Bearer ${operatorToken}`)
+        .expect(200);
+    });
   });
 
   // ─── administrative writes — operator gets 403 ──────────────────────────────
@@ -219,20 +233,6 @@ describe('Operator Role Authorization', () => {
         .post('/v1/sync/jobs/retry-grouped')
         .set('Authorization', `Bearer ${operatorToken}`)
         .send({ connectionId: '00000000-0000-4000-8000-000000000001', jobType: 'marketplace.orders.poll' })
-        .expect(403);
-    });
-
-    it('GET /connections/:id/diagnostics → 403 (admin-only GET)', async () => {
-      const { http, adminToken, operatorToken } = await seeds();
-      const dto = createPrestashopConnectionDto();
-      const { body: conn } = await http
-        .post('/v1/connections')
-        .set('Authorization', `Bearer ${adminToken}`)
-        .send(dto)
-        .expect(201);
-      await http
-        .get(`/v1/connections/${conn.id as string}/diagnostics`)
-        .set('Authorization', `Bearer ${operatorToken}`)
         .expect(403);
     });
 

--- a/apps/api/test/integration/viewer-role-authz.int-spec.ts
+++ b/apps/api/test/integration/viewer-role-authz.int-spec.ts
@@ -60,6 +60,20 @@ describe('Viewer Role Authorization', () => {
         .expect(200);
     });
 
+    it('GET /connections/:id/diagnostics (#1645 - read stays viewer-accessible)', async () => {
+      const { http, adminToken, viewerToken } = await seeds();
+      const dto = createPrestashopConnectionDto();
+      const { body: conn } = await http
+        .post('/v1/connections')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(dto)
+        .expect(201);
+      await http
+        .get(`/v1/connections/${conn.id as string}/diagnostics`)
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .expect(200);
+    });
+
     it('GET /orders', async () => {
       const { http, viewerToken } = await seeds();
       await http
@@ -324,20 +338,6 @@ describe('Viewer Role Authorization', () => {
         .post('/v1/sync/jobs/retry-grouped')
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({ connectionId: '00000000-0000-4000-8000-000000000001', jobType: 'marketplace.orders.poll' })
-        .expect(403);
-    });
-
-    it('GET /connections/:id/diagnostics', async () => {
-      const { http, adminToken, viewerToken } = await seeds();
-      const dto = createPrestashopConnectionDto();
-      const { body: conn } = await http
-        .post('/v1/connections')
-        .set('Authorization', `Bearer ${adminToken}`)
-        .send(dto)
-        .expect(201);
-      await http
-        .get(`/v1/connections/${conn.id as string}/diagnostics`)
-        .set('Authorization', `Bearer ${viewerToken}`)
         .expect(403);
     });
 


### PR DESCRIPTION
## Summary

`GET /connections/:id/diagnostics` was still gated to `admin` only via `@Roles('admin')` in `apps/api/src/integrations/http/connection.controller.ts`. This was a follow-up gap left by #1614, which relaxed the frontend's access to the connection Health tab but did not update the backend guard - a demo viewer opening the Health tab hit a 403 "Insufficient permissions" on this endpoint.

This PR extends the guard to `@Roles('admin', 'operator', 'viewer')`, matching the read-only access pattern already established for other GET endpoints on connections and listings (see the #1608 precedent in `listings.controller.ts`, and the fact that `GET /connections` / `GET /connections/:id` already have no role restriction).

No other endpoint in `connection.controller.ts` was touched - create, update, test, credentials, webhooks, and disable all remain `admin`-only exactly as before.

Verified the diagnostics response (`ConnectionDiagnosticsResponseDto.fromDomain`) exposes only connection id/name/status and a recent-sync-job summary (id, jobType, status, attempts, timestamps, lastError) - no credentials, config, or other secrets - so opening it to viewer/operator carries no data-leak risk (same care as the #1616 config-leak review).

## Test plan

- [x] Updated `apps/api/test/integration/viewer-role-authz.int-spec.ts`: moved the diagnostics assertion from "writes - viewer gets 403" to "reads - viewer gets 200".
- [x] Updated `apps/api/test/integration/operator-role-authz.int-spec.ts`: moved the diagnostics assertion from "administrative writes - operator gets 403" to "operational writes - operator NOT blocked", now expecting 200.
- [x] `pnpm --filter @openlinker/api lint` - no new errors introduced (one pre-existing unrelated error in `plugins.ts`).
- [x] `pnpm --filter @openlinker/api type-check` - clean.
- [x] `pnpm --filter @openlinker/api test -- src/integrations src/auth` - 22 suites / 264 tests passing, including `write-guard-coverage.spec.ts` (unaffected, only checks write handlers).

Part of #1606
Closes #1645