### PR TITLE
feat(mailer): DB-backed mailer/SMTP settings with admin controller

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -22,6 +22,7 @@ import { CustomersModule } from '@openlinker/core/customers';
 import { ContentModule } from '@openlinker/core/content';
 import { InvoicingModule } from '@openlinker/core/invoicing';
 import { AiModule as CoreAiModule } from '@openlinker/core/ai';
+import { MailerModule as CoreMailerModule } from '@openlinker/core/mailer';
 import { AuthModule } from './auth/auth.module';
 import { IntegrationsModule } from './integrations/integrations.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
@@ -39,6 +40,7 @@ import { ShippingApiModule } from './shipping/shipping.module';
 import { InvoicingApiModule } from './invoicing/invoicing.module';
 import { UsersApiModule } from './users/users.module';
 import { SystemModule } from './system/system.module';
+import { MailerApiModule } from './mailer/mailer.module';
 
 @Module({
   imports: [
@@ -69,6 +71,8 @@ import { SystemModule } from './system/system.module';
     InvoicingModule, // Invoicing domain foundation — port + record + repo (#751, ADR-026)
     CoreAiModule, // Editable prompt-template storage + render service (#341)
     AiApiModule, // REST surface for prompt templates (#341)
+    CoreMailerModule, // DB-backed mailer/SMTP settings resolution (#1643)
+    MailerApiModule, // Admin REST surface for mailer/SMTP settings (#1643)
     ContentApiModule, // REST surface for product content editor + AI suggest (#339 + #342)
     ShippingApiModule, // Shipment read + command HTTP API (#846); imports core ShippingModule (#763/#835)
     UsersApiModule, // User management: list, approve/reject pending, role + status ops (#1125)
@@ -79,4 +83,3 @@ import { SystemModule } from './system/system.module';
   providers: [AppService],
 })
 export class AppModule {}
-

--- a/apps/api/src/auth/adapters/db-backed-mailer.adapter.ts
+++ b/apps/api/src/auth/adapters/db-backed-mailer.adapter.ts
@@ -1,0 +1,62 @@
+/**
+ * DB-Backed Mailer Adapter
+ *
+ * Bound to `MAILER_TOKEN`. On every `sendEmail()` call, reads the
+ * effective transport configuration through `IMailerSettingsService`
+ * (DB row → env var fallback → console default) and delegates to a
+ * freshly-built `ConsoleMailerAdapter` or `SmtpMailerAdapter`.
+ *
+ * **No cache.** Mirrors `MultiProviderAiCompletionAdapter`'s read-through
+ * model: the settings lookup is a singleton-row PK query (plus, for SMTP,
+ * one encrypted-credential lookup) — sub-millisecond, dwarfed by the actual
+ * SMTP round-trip. Read-through buys instant cross-process visibility of an
+ * admin settings change with no TTL window and no invalidator port.
+ *
+ * @module apps/api/src/auth/adapters
+ */
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { createTransport } from 'nodemailer';
+import {
+  MAILER_SETTINGS_SERVICE_TOKEN,
+  type IMailerSettingsService,
+} from '@openlinker/core/mailer';
+import type { EmailMessage, MailerPort } from '@openlinker/core/users';
+import { ConsoleMailerAdapter } from './console-mailer.adapter';
+import { SmtpMailerAdapter, type SmtpTransport } from './smtp-mailer.adapter';
+
+@Injectable()
+export class DbBackedMailerAdapter implements MailerPort {
+  private readonly logger = new Logger(DbBackedMailerAdapter.name);
+
+  constructor(
+    @Inject(MAILER_SETTINGS_SERVICE_TOKEN)
+    private readonly settings: IMailerSettingsService
+  ) {}
+
+  async sendEmail(message: EmailMessage): Promise<void> {
+    const config = await this.settings.resolveTransportConfig();
+
+    if (config.transport !== 'smtp' || !config.smtpHost) {
+      await new ConsoleMailerAdapter().sendEmail(message);
+      return;
+    }
+
+    const transporter = createTransport({
+      host: config.smtpHost,
+      port: config.smtpPort,
+      secure: config.smtpSecure,
+      auth: config.smtpUser
+        ? { user: config.smtpUser, pass: config.smtpPassword ?? undefined }
+        : undefined,
+    });
+    const adapter = new SmtpMailerAdapter(
+      transporter as unknown as SmtpTransport,
+      config.fromAddress
+    );
+
+    this.logger.debug(
+      `[mail] route host=${config.smtpHost} port=${config.smtpPort} secure=${config.smtpSecure}`
+    );
+    await adapter.sendEmail(message);
+  }
+}

--- a/apps/api/src/auth/adapters/mailer.adapter.spec.ts
+++ b/apps/api/src/auth/adapters/mailer.adapter.spec.ts
@@ -1,41 +1,27 @@
 /**
- * Mailer infrastructure unit tests: transport selection by config, the
- * console + SMTP adapter contracts, and the password-reset notifier that
- * composes MailerPort.
+ * Mailer infrastructure unit tests: the console + SMTP adapter contracts,
+ * the DB-backed router adapter that resolves the effective transport per
+ * send (#1643), and the password-reset notifier that composes MailerPort.
  */
 import type { ConfigService } from '@nestjs/config';
 import { User, type MailerPort } from '@openlinker/core/users';
+import type { IMailerSettingsService } from '@openlinker/core/mailer';
 import { ConsoleMailerAdapter } from './console-mailer.adapter';
 import { SmtpMailerAdapter, type SmtpTransport } from './smtp-mailer.adapter';
-import { createMailer } from './mailer.provider';
 import { MailerPasswordResetNotifierAdapter } from './mailer-password-reset-notifier.adapter';
+import { DbBackedMailerAdapter } from './db-backed-mailer.adapter';
+
+const sendMailMock = jest.fn().mockResolvedValue({});
+const createTransportMock = jest.fn((..._args: unknown[]) => ({ sendMail: sendMailMock }));
+jest.mock('nodemailer', () => ({
+  createTransport: (...args: unknown[]) => createTransportMock(...args),
+}));
 
 function makeConfig(values: Record<string, string>): ConfigService {
   return {
     get: jest.fn((key: string, fallback?: string) => values[key] ?? fallback),
   } as unknown as ConfigService;
 }
-
-describe('createMailer (transport selection)', () => {
-  it('defaults to the console adapter when no SMTP host is configured', () => {
-    const mailer = createMailer(makeConfig({}));
-    expect(mailer).toBeInstanceOf(ConsoleMailerAdapter);
-  });
-
-  it('uses the console adapter when MAIL_TRANSPORT=console even if a host is set', () => {
-    const mailer = createMailer(makeConfig({ MAIL_TRANSPORT: 'console', MAIL_SMTP_HOST: 'smtp.x' }));
-    expect(mailer).toBeInstanceOf(ConsoleMailerAdapter);
-  });
-
-  it('uses the SMTP adapter when a host is configured', () => {
-    const mailer = createMailer(makeConfig({ MAIL_SMTP_HOST: 'smtp.example.com' }));
-    expect(mailer).toBeInstanceOf(SmtpMailerAdapter);
-  });
-
-  it('throws when MAIL_TRANSPORT=smtp but no host is set', () => {
-    expect(() => createMailer(makeConfig({ MAIL_TRANSPORT: 'smtp' }))).toThrow(/MAIL_SMTP_HOST/);
-  });
-});
 
 describe('SmtpMailerAdapter', () => {
   it('forwards the message to the underlying transport with the From address', async () => {
@@ -58,8 +44,109 @@ describe('ConsoleMailerAdapter', () => {
   it('resolves without throwing (logs only)', async () => {
     const adapter = new ConsoleMailerAdapter();
     await expect(
-      adapter.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'Body' }),
+      adapter.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'Body' })
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('DbBackedMailerAdapter', () => {
+  const buildSettings = (
+    resolved: Awaited<ReturnType<IMailerSettingsService['resolveTransportConfig']>>
+  ): jest.Mocked<IMailerSettingsService> => ({
+    getSettings: jest.fn(),
+    updateSettings: jest.fn(),
+    setSmtpPassword: jest.fn(),
+    clearSmtpPassword: jest.fn(),
+    resolveTransportConfig: jest.fn().mockResolvedValue(resolved),
+  });
+
+  beforeEach(() => {
+    sendMailMock.mockClear();
+    createTransportMock.mockClear();
+  });
+
+  it('sends via the console adapter when the resolved transport is console', async () => {
+    const settings = buildSettings({
+      transport: 'console',
+      smtpHost: null,
+      smtpPort: 587,
+      smtpSecure: false,
+      smtpUser: null,
+      smtpPassword: null,
+      fromAddress: 'no-reply@openlinker.local',
+    });
+    const consoleSpy = jest.spyOn(ConsoleMailerAdapter.prototype, 'sendEmail');
+    const adapter = new DbBackedMailerAdapter(settings);
+
+    await adapter.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'Body' });
+
+    expect(consoleSpy).toHaveBeenCalledWith({ to: 'a@b.com', subject: 'Hi', text: 'Body' });
+    expect(createTransportMock).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('falls back to console when transport is smtp but no host is resolved (defensive)', async () => {
+    const settings = buildSettings({
+      transport: 'smtp',
+      smtpHost: null,
+      smtpPort: 587,
+      smtpSecure: false,
+      smtpUser: null,
+      smtpPassword: null,
+      fromAddress: 'no-reply@openlinker.local',
+    });
+    const adapter = new DbBackedMailerAdapter(settings);
+
+    await expect(
+      adapter.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'Body' })
+    ).resolves.toBeUndefined();
+    expect(createTransportMock).not.toHaveBeenCalled();
+  });
+
+  it('builds an SMTP transporter from the resolved config and sends through it', async () => {
+    const settings = buildSettings({
+      transport: 'smtp',
+      smtpHost: 'smtp.example.com',
+      smtpPort: 587,
+      smtpSecure: false,
+      smtpUser: 'user',
+      smtpPassword: 'pass',
+      fromAddress: 'no-reply@openlinker.local',
+    });
+    const adapter = new DbBackedMailerAdapter(settings);
+
+    await adapter.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'Body' });
+
+    expect(createTransportMock).toHaveBeenCalledWith({
+      host: 'smtp.example.com',
+      port: 587,
+      secure: false,
+      auth: { user: 'user', pass: 'pass' },
+    });
+    expect(sendMailMock).toHaveBeenCalledWith({
+      from: 'no-reply@openlinker.local',
+      to: 'a@b.com',
+      subject: 'Hi',
+      text: 'Body',
+      html: undefined,
+    });
+  });
+
+  it('omits auth when no SMTP user is resolved', async () => {
+    const settings = buildSettings({
+      transport: 'smtp',
+      smtpHost: 'smtp.example.com',
+      smtpPort: 587,
+      smtpSecure: false,
+      smtpUser: null,
+      smtpPassword: null,
+      fromAddress: 'no-reply@openlinker.local',
+    });
+    const adapter = new DbBackedMailerAdapter(settings);
+
+    await adapter.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'Body' });
+
+    expect(createTransportMock).toHaveBeenCalledWith(expect.objectContaining({ auth: undefined }));
   });
 });
 
@@ -71,7 +158,7 @@ describe('MailerPasswordResetNotifierAdapter', () => {
     const mailer: jest.Mocked<MailerPort> = { sendEmail: jest.fn().mockResolvedValue(undefined) };
     const notifier = new MailerPasswordResetNotifierAdapter(
       mailer,
-      makeConfig({ WEB_URL: 'https://app.example.com' }),
+      makeConfig({ WEB_URL: 'https://app.example.com' })
     );
 
     await notifier.notifyResetRequested(makeUser('user@example.com'), 'raw-token-123');

--- a/apps/api/src/auth/adapters/mailer.provider.ts
+++ b/apps/api/src/auth/adapters/mailer.provider.ts
@@ -1,53 +1,20 @@
 /**
  * Mailer Provider
  *
- * Selects the MailerPort implementation at boot from configuration. When
- * MAIL_SMTP_HOST is set (and MAIL_TRANSPORT is not forced to "console"), a
- * real nodemailer SMTP transport is used; otherwise the console adapter is
- * the default so offline development works without a mail server.
+ * Binds `MAILER_TOKEN` to `DbBackedMailerAdapter`, which resolves the
+ * effective transport (console vs SMTP) through `IMailerSettingsService` on
+ * every send: DB row → env var fallback → console default (#1643). This
+ * closes the loop on #1623's env-var-only mailer infrastructure by making
+ * the transport operator-editable at runtime via `PUT /mailer-settings`,
+ * without a redeploy.
  *
  * @module apps/api/src/auth/adapters
  */
-import { Logger, type Provider } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { createTransport } from 'nodemailer';
-import { MAILER_TOKEN, type MailerPort } from '@openlinker/core/users';
-import { ConsoleMailerAdapter } from './console-mailer.adapter';
-import { SmtpMailerAdapter } from './smtp-mailer.adapter';
-
-const logger = new Logger('MailerProvider');
-
-export function createMailer(configService: ConfigService): MailerPort {
-  const transport = configService.get<string>('MAIL_TRANSPORT', '').toLowerCase();
-  const host = configService.get<string>('MAIL_SMTP_HOST');
-
-  if (transport === 'console' || (!host && transport !== 'smtp')) {
-    logger.log('Using console mailer transport (dev default)');
-    return new ConsoleMailerAdapter();
-  }
-
-  if (!host) {
-    throw new Error('MAIL_TRANSPORT=smtp requires MAIL_SMTP_HOST to be set');
-  }
-
-  const port = Number(configService.get<string>('MAIL_SMTP_PORT', '587'));
-  const secure = configService.get<string>('MAIL_SMTP_SECURE', 'false') === 'true';
-  const user = configService.get<string>('MAIL_SMTP_USER');
-  const pass = configService.get<string>('MAIL_SMTP_PASSWORD');
-
-  const transporter = createTransport({
-    host,
-    port,
-    secure,
-    auth: user ? { user, pass } : undefined,
-  });
-
-  logger.log(`Using SMTP mailer transport host=${host} port=${port} secure=${secure}`);
-  return SmtpMailerAdapter.fromConfig(configService, transporter);
-}
+import type { Provider } from '@nestjs/common';
+import { MAILER_TOKEN } from '@openlinker/core/users';
+import { DbBackedMailerAdapter } from './db-backed-mailer.adapter';
 
 export const MAILER_PROVIDER: Provider = {
   provide: MAILER_TOKEN,
-  useFactory: createMailer,
-  inject: [ConfigService],
+  useClass: DbBackedMailerAdapter,
 };

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -14,6 +14,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MAILER_TOKEN, PASSWORD_RESET_NOTIFIER_TOKEN, UsersModule } from '@openlinker/core/users';
+import { MailerModule as CoreMailerModule } from '@openlinker/core/mailer';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { AuthService } from './auth.service';
 import { AUTH_SERVICE_TOKEN } from './auth.service.interface';
@@ -40,6 +41,9 @@ import { UsersApiModule } from '../users/users.module';
   imports: [
     UsersModule,
     UsersApiModule,
+    // For MAILER_SETTINGS_SERVICE_TOKEN, consumed by DbBackedMailerAdapter
+    // (#1643) to resolve the DB-backed transport at send time.
+    CoreMailerModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/apps/api/src/auth/write-guard-coverage.spec.ts
+++ b/apps/api/src/auth/write-guard-coverage.spec.ts
@@ -47,6 +47,7 @@ import { WebhookDeliveryController } from '../webhooks/http/webhook-delivery.con
 import { AiProviderSettingsController } from '../ai/http/ai-provider-settings.controller';
 import { PromptTemplatesController } from '../ai/http/prompt-templates.controller';
 import { ContentController } from '../content/http/content.controller';
+import { MailerSettingsController } from '../mailer/http/mailer-settings.controller';
 
 const METHOD_METADATA = 'method';
 
@@ -78,6 +79,7 @@ const CONTROLLERS = [
   AiProviderSettingsController,
   PromptTemplatesController,
   ContentController,
+  MailerSettingsController,
 ];
 
 describe('Write-guard coverage invariant (#1124 / #1126 / #1357)', () => {
@@ -92,22 +94,16 @@ describe('Write-guard coverage invariant (#1124 / #1126 / #1357)', () => {
 
         const fn = proto[methodName] as object;
 
-        const httpMethod = Reflect.getMetadata(
-          METHOD_METADATA,
-          fn,
-        ) as RequestMethod | undefined;
+        const httpMethod = Reflect.getMetadata(METHOD_METADATA, fn) as RequestMethod | undefined;
 
         if (httpMethod === undefined) continue;
         if (!WRITE_METHODS.has(httpMethod)) continue;
 
-        const roles = Reflect.getMetadata(
-          ROLES_KEY,
-          fn,
-        ) as unknown[] | undefined;
+        const roles = Reflect.getMetadata(ROLES_KEY, fn) as unknown[] | undefined;
 
         if (!roles || roles.length === 0) {
           unguarded.push(
-            `${Controller.name}.${methodName} (HTTP method ${RequestMethod[httpMethod]}) is missing @Roles`,
+            `${Controller.name}.${methodName} (HTTP method ${RequestMethod[httpMethod]}) is missing @Roles`
           );
         }
       }

--- a/apps/api/src/mailer/http/dto/mailer-settings-response.dto.ts
+++ b/apps/api/src/mailer/http/dto/mailer-settings-response.dto.ts
@@ -1,0 +1,62 @@
+/**
+ * Mailer Settings Response DTO
+ *
+ * Response body for `GET /mailer-settings`. Reports the non-secret
+ * transport fields plus whether an SMTP password is currently configured
+ * (DB or env) — the password value itself never leaves the server.
+ *
+ * @module apps/api/src/mailer/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  MailerTransport,
+  MailerTransportValues,
+  type MailerSettingsView,
+} from '@openlinker/core/mailer';
+
+export class MailerSettingsResponseDto {
+  @ApiProperty({ enum: MailerTransportValues })
+  transport!: MailerTransport;
+
+  @ApiProperty({ type: String, nullable: true })
+  smtpHost!: string | null;
+
+  @ApiProperty({ type: Number, nullable: true })
+  smtpPort!: number | null;
+
+  @ApiProperty()
+  smtpSecure!: boolean;
+
+  @ApiProperty({ type: String, nullable: true })
+  fromAddress!: string | null;
+
+  @ApiProperty({ description: 'True when an SMTP password is currently resolvable (DB or env).' })
+  smtpPasswordConfigured!: boolean;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: 'When the settings were last changed. `null` when no row exists yet.',
+  })
+  updatedAt!: string | null;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: 'Who last changed the settings. `null` when no row exists yet.',
+  })
+  updatedBy!: string | null;
+
+  static fromView(view: MailerSettingsView): MailerSettingsResponseDto {
+    const dto = new MailerSettingsResponseDto();
+    dto.transport = view.transport;
+    dto.smtpHost = view.smtpHost;
+    dto.smtpPort = view.smtpPort;
+    dto.smtpSecure = view.smtpSecure;
+    dto.fromAddress = view.fromAddress;
+    dto.smtpPasswordConfigured = view.smtpPasswordConfigured;
+    dto.updatedAt = view.updatedAt ? view.updatedAt.toISOString() : null;
+    dto.updatedBy = view.updatedBy;
+    return dto;
+  }
+}

--- a/apps/api/src/mailer/http/dto/set-mailer-credentials.dto.ts
+++ b/apps/api/src/mailer/http/dto/set-mailer-credentials.dto.ts
@@ -1,0 +1,29 @@
+/**
+ * Set Mailer Credentials DTO
+ *
+ * Request body for `PUT /mailer-settings/credentials`. Write-only — the
+ * password is never echoed back in any response.
+ *
+ * @module apps/api/src/mailer/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+const MIN_PASSWORD_LENGTH = 1;
+const MAX_PASSWORD_LENGTH = 512;
+
+export class SetMailerCredentialsDto {
+  @ApiProperty({
+    description:
+      'SMTP password. Stored encrypted; never returned in any response body. Surrounding whitespace is trimmed.',
+    minLength: MIN_PASSWORD_LENGTH,
+    maxLength: MAX_PASSWORD_LENGTH,
+  })
+  @Transform(({ value }: { value: unknown }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(MIN_PASSWORD_LENGTH)
+  @MaxLength(MAX_PASSWORD_LENGTH)
+  password!: string;
+}

--- a/apps/api/src/mailer/http/dto/update-mailer-settings.dto.ts
+++ b/apps/api/src/mailer/http/dto/update-mailer-settings.dto.ts
@@ -1,0 +1,48 @@
+/**
+ * Update Mailer Settings DTO
+ *
+ * Request body for `PUT /mailer-settings`. Non-secret transport fields only
+ * — the SMTP password is written separately via
+ * `PUT /mailer-settings/credentials`. `smtpHost`/`smtpPort` are required
+ * when `transport === 'smtp'`; the controller does not cross-validate this
+ * (matching the AI settings precedent of trusting the admin form) so an
+ * operator can stage a partial SMTP config before switching transport.
+ *
+ * @module apps/api/src/mailer/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsBoolean, IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { MailerTransport, MailerTransportValues } from '@openlinker/core/mailer';
+
+export class UpdateMailerSettingsDto {
+  @ApiProperty({ enum: MailerTransportValues })
+  @IsIn(MailerTransportValues as unknown as string[])
+  transport!: MailerTransport;
+
+  @ApiProperty({ type: String, nullable: true, description: 'SMTP server host.' })
+  @IsOptional()
+  @IsString()
+  smtpHost?: string | null;
+
+  @ApiProperty({ type: Number, nullable: true, description: 'SMTP server port.' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(65535)
+  smtpPort?: number | null;
+
+  @ApiProperty({ description: 'Use implicit TLS (true) vs STARTTLS/plain (false).' })
+  @IsBoolean()
+  smtpSecure!: boolean;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: 'Default From address for outbound mail.',
+  })
+  @IsOptional()
+  @IsString()
+  fromAddress?: string | null;
+}

--- a/apps/api/src/mailer/http/mailer-settings.controller.spec.ts
+++ b/apps/api/src/mailer/http/mailer-settings.controller.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Mailer Settings Controller — Unit Tests
+ *
+ * Mocks `IMailerSettingsService`. Asserts: every handler is gated with
+ * `@Roles('admin')` (including the read endpoint — mailer settings surface
+ * SMTP topology, which is operator-sensitive), the GET response never
+ * carries the password (only `smtpPasswordConfigured`), and each handler
+ * delegates to the correct service method with the current actor's id.
+ *
+ * @module apps/api/src/mailer/http
+ */
+import 'reflect-metadata';
+import type { Response } from 'express';
+import type { IMailerSettingsService } from '@openlinker/core/mailer';
+import { ROLES_KEY } from '../../auth/decorators/roles.decorator';
+import type { AuthenticatedUser } from '../../auth/auth.types';
+import { MailerSettingsController } from './mailer-settings.controller';
+import type { UpdateMailerSettingsDto } from './dto/update-mailer-settings.dto';
+import type { SetMailerCredentialsDto } from './dto/set-mailer-credentials.dto';
+
+describe('MailerSettingsController', () => {
+  let settings: jest.Mocked<IMailerSettingsService>;
+  let controller: MailerSettingsController;
+  let res: jest.Mocked<Pick<Response, 'setHeader'>>;
+  const user = { id: 'admin-1' } as AuthenticatedUser;
+
+  beforeEach(() => {
+    settings = {
+      getSettings: jest.fn(),
+      updateSettings: jest.fn(),
+      setSmtpPassword: jest.fn(),
+      clearSmtpPassword: jest.fn(),
+      resolveTransportConfig: jest.fn(),
+    };
+    res = { setHeader: jest.fn() };
+    controller = new MailerSettingsController(settings);
+  });
+
+  describe('role gating', () => {
+    const methods: Array<keyof MailerSettingsController> = [
+      'get',
+      'update',
+      'setCredentials',
+      'clearCredentials',
+    ];
+
+    it.each(methods)('%s carries @Roles(admin)', (methodName) => {
+      const proto = MailerSettingsController.prototype as unknown as Record<string, object>;
+      const roles = Reflect.getMetadata(ROLES_KEY, proto[methodName]) as string[] | undefined;
+      expect(roles).toEqual(['admin']);
+    });
+  });
+
+  describe('get', () => {
+    it('returns the non-secret view and never leaks the password', async () => {
+      settings.getSettings.mockResolvedValue({
+        transport: 'smtp',
+        smtpHost: 'smtp.example.com',
+        smtpPort: 587,
+        smtpSecure: true,
+        fromAddress: 'noreply@x.com',
+        smtpPasswordConfigured: true,
+        updatedAt: new Date('2026-05-01T00:00:00Z'),
+        updatedBy: 'admin-1',
+      });
+
+      const dto = await controller.get(res as unknown as Response);
+
+      expect(dto.smtpPasswordConfigured).toBe(true);
+      expect(Object.keys(dto)).not.toContain('password');
+      expect(Object.keys(dto)).not.toContain('smtpPassword');
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+    });
+  });
+
+  describe('update', () => {
+    it('delegates to updateSettings with the resolved input and actor id', async () => {
+      const dto: UpdateMailerSettingsDto = {
+        transport: 'smtp',
+        smtpHost: 'smtp.example.com',
+        smtpPort: 587,
+        smtpSecure: false,
+        fromAddress: 'noreply@x.com',
+      };
+
+      await controller.update(dto, user, res as unknown as Response);
+
+      expect(settings.updateSettings).toHaveBeenCalledWith(
+        {
+          transport: 'smtp',
+          smtpHost: 'smtp.example.com',
+          smtpPort: 587,
+          smtpSecure: false,
+          fromAddress: 'noreply@x.com',
+        },
+        'admin-1'
+      );
+    });
+
+    it('normalizes omitted optional fields to null', async () => {
+      const dto: UpdateMailerSettingsDto = { transport: 'console', smtpSecure: false };
+
+      await controller.update(dto, user, res as unknown as Response);
+
+      expect(settings.updateSettings).toHaveBeenCalledWith(
+        {
+          transport: 'console',
+          smtpHost: null,
+          smtpPort: null,
+          smtpSecure: false,
+          fromAddress: null,
+        },
+        'admin-1'
+      );
+    });
+  });
+
+  describe('setCredentials', () => {
+    it('delegates to setSmtpPassword', async () => {
+      const dto: SetMailerCredentialsDto = { password: 'super-secret' };
+
+      await controller.setCredentials(dto, user, res as unknown as Response);
+
+      expect(settings.setSmtpPassword).toHaveBeenCalledWith('super-secret', 'admin-1');
+    });
+  });
+
+  describe('clearCredentials', () => {
+    it('delegates to clearSmtpPassword', async () => {
+      await controller.clearCredentials(user, res as unknown as Response);
+
+      expect(settings.clearSmtpPassword).toHaveBeenCalledWith('admin-1');
+    });
+  });
+});

--- a/apps/api/src/mailer/http/mailer-settings.controller.ts
+++ b/apps/api/src/mailer/http/mailer-settings.controller.ts
@@ -1,0 +1,115 @@
+/**
+ * Mailer Settings Controller
+ *
+ * Admin-only REST surface for the DB-backed mailer/SMTP settings.
+ * Mirrors `AiProviderSettingsController` one-for-one: non-secret settings
+ * are readable/writable via `GET`/`PUT /mailer-settings`, and the SMTP
+ * password is write-only via a separate `PUT`/`DELETE /mailer-settings/credentials`
+ * pair so it never round-trips through a response body.
+ *
+ * Endpoints:
+ *
+ *   GET    /mailer-settings              — non-secret settings view
+ *   PUT    /mailer-settings              — update transport/host/port/secure/from
+ *   PUT    /mailer-settings/credentials  — set/rotate the SMTP password
+ *   DELETE /mailer-settings/credentials  — clear the SMTP password
+ *
+ * @module apps/api/src/mailer/http
+ */
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Put,
+  Res,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import {
+  MAILER_SETTINGS_SERVICE_TOKEN,
+  type IMailerSettingsService,
+} from '@openlinker/core/mailer';
+import { AuthenticatedUser } from '../../auth/auth.types';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { MailerSettingsResponseDto } from './dto/mailer-settings-response.dto';
+import { SetMailerCredentialsDto } from './dto/set-mailer-credentials.dto';
+import { UpdateMailerSettingsDto } from './dto/update-mailer-settings.dto';
+
+@ApiBearerAuth()
+@ApiTags('mailer-settings')
+@Controller('mailer-settings')
+export class MailerSettingsController {
+  constructor(
+    @Inject(MAILER_SETTINGS_SERVICE_TOKEN)
+    private readonly settings: IMailerSettingsService
+  ) {}
+
+  @Roles('admin')
+  @Get()
+  @ApiOperation({ summary: 'Read the mailer/SMTP settings (never returns the password)' })
+  @ApiResponse({ status: 200, type: MailerSettingsResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async get(@Res({ passthrough: true }) res: Response): Promise<MailerSettingsResponseDto> {
+    res.setHeader('Cache-Control', 'no-store');
+    const view = await this.settings.getSettings();
+    return MailerSettingsResponseDto.fromView(view);
+  }
+
+  @Roles('admin')
+  @Put()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Update the non-secret transport/host/port/secure/from settings' })
+  @ApiResponse({ status: 204, description: 'Settings updated' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async update(
+    @Body() dto: UpdateMailerSettingsDto,
+    @CurrentUser() user: AuthenticatedUser,
+    @Res({ passthrough: true }) res: Response
+  ): Promise<void> {
+    res.setHeader('Cache-Control', 'no-store');
+    await this.settings.updateSettings(
+      {
+        transport: dto.transport,
+        smtpHost: dto.smtpHost ?? null,
+        smtpPort: dto.smtpPort ?? null,
+        smtpSecure: dto.smtpSecure,
+        fromAddress: dto.fromAddress ?? null,
+      },
+      user?.id
+    );
+  }
+
+  @Roles('admin')
+  @Put('credentials')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Set or rotate the SMTP password' })
+  @ApiResponse({ status: 204, description: 'Password stored encrypted' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async setCredentials(
+    @Body() dto: SetMailerCredentialsDto,
+    @CurrentUser() user: AuthenticatedUser,
+    @Res({ passthrough: true }) res: Response
+  ): Promise<void> {
+    res.setHeader('Cache-Control', 'no-store');
+    await this.settings.setSmtpPassword(dto.password, user?.id);
+  }
+
+  @Roles('admin')
+  @Delete('credentials')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Clear the stored SMTP password (falls back to env or none)' })
+  @ApiResponse({ status: 204, description: 'Password cleared' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async clearCredentials(
+    @CurrentUser() user: AuthenticatedUser,
+    @Res({ passthrough: true }) res: Response
+  ): Promise<void> {
+    res.setHeader('Cache-Control', 'no-store');
+    await this.settings.clearSmtpPassword(user?.id);
+  }
+}

--- a/apps/api/src/mailer/mailer.module.ts
+++ b/apps/api/src/mailer/mailer.module.ts
@@ -1,0 +1,22 @@
+/**
+ * Mailer API Module
+ *
+ * NestJS module owning the HTTP surface for the mailer bounded context.
+ * The controller resolves its dependency from core `MailerModule` — the
+ * settings service — so this module's only responsibility is mounting the
+ * controller and importing the core module.
+ *
+ * Follows the `{domain}.module.ts` + `{Domain}ApiModule` pattern already
+ * used by `AiApiModule`.
+ *
+ * @module apps/api/src/mailer
+ */
+import { Module } from '@nestjs/common';
+import { MailerModule as CoreMailerModule } from '@openlinker/core/mailer';
+import { MailerSettingsController } from './http/mailer-settings.controller';
+
+@Module({
+  imports: [CoreMailerModule],
+  controllers: [MailerSettingsController],
+})
+export class MailerApiModule {}

--- a/apps/api/src/migrations/1818000000009-add-mailer-settings.ts
+++ b/apps/api/src/migrations/1818000000009-add-mailer-settings.ts
@@ -1,0 +1,25 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMailerSettings1818000000009 implements MigrationInterface {
+  name = 'AddMailerSettings1818000000009';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "mailer_settings" (
+        "id" text NOT NULL,
+        "transport" text NOT NULL,
+        "smtp_host" text,
+        "smtp_port" integer,
+        "smtp_secure" boolean NOT NULL DEFAULT false,
+        "from_address" text,
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updated_by" text,
+        CONSTRAINT "PK_mailer_settings" PRIMARY KEY ("id")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "mailer_settings"`);
+  }
+}

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1194,6 +1194,7 @@ graph LR
   integrations --> identifier-mapping
   shipping --> integrations
   shipping --> mappings
+  mailer --> integrations
 ```
 
 `identifier-mapping`, `integrations`, and `events` form the most-depended-upon "infrastructure spine" (each used by 5+ siblings). `users`, `webhooks`, and `mappings` have minimal outbound coupling.

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -158,6 +158,11 @@
       "types": "./dist/invoicing/orm-entities.d.ts",
       "require": "./dist/invoicing/orm-entities.js",
       "default": "./dist/invoicing/orm-entities.js"
+    },
+    "./mailer": {
+      "types": "./dist/mailer/index.d.ts",
+      "require": "./dist/mailer/index.js",
+      "default": "./dist/mailer/index.js"
     }
   },
   "files": [

--- a/libs/core/src/mailer/application/services/mailer-settings.service.interface.ts
+++ b/libs/core/src/mailer/application/services/mailer-settings.service.interface.ts
@@ -1,0 +1,40 @@
+/**
+ * Mailer Settings Service Interface
+ *
+ * Application-layer contract for reading/writing the DB-backed mailer/SMTP
+ * settings and for resolving the fully-effective runtime transport
+ * configuration consumed by the mailer adapter. Mirrors
+ * `IAiProviderActiveSettingsService`.
+ *
+ * @module libs/core/src/mailer/application/services
+ */
+import type {
+  MailerSettingsInput,
+  MailerSettingsView,
+  ResolvedMailerTransportConfig,
+} from '../../domain/types/mailer-settings.types';
+
+export interface IMailerSettingsService {
+  /**
+   * Composite read used by the admin `GET /mailer-settings` endpoint. Never
+   * includes the SMTP password — only whether one is currently configured.
+   */
+  getSettings(): Promise<MailerSettingsView>;
+
+  /** Persist the non-secret settings fields (transport/host/port/secure/from). */
+  updateSettings(input: MailerSettingsInput, actorUserId?: string): Promise<void>;
+
+  /** Set or rotate the SMTP password (encrypted at rest). */
+  setSmtpPassword(password: string, actorUserId?: string): Promise<void>;
+
+  /** Clear the stored SMTP password. */
+  clearSmtpPassword(actorUserId?: string): Promise<void>;
+
+  /**
+   * Resolve the fully-effective runtime transport configuration: DB row →
+   * env var fallback → console default. Read-through on every call — no
+   * in-process cache beyond the singleton-row lookup cost (matches the AI
+   * active-provider router's resolution model).
+   */
+  resolveTransportConfig(): Promise<ResolvedMailerTransportConfig>;
+}

--- a/libs/core/src/mailer/application/services/mailer-settings.service.spec.ts
+++ b/libs/core/src/mailer/application/services/mailer-settings.service.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * Mailer Settings Service — Unit Tests
+ *
+ * Mocks the settings repo + `ICredentialsService` + `ConfigService`.
+ * Asserts: GET view never carries the password; DB row wins over env when
+ * present; env-only fallback reproduces the pre-#1643 `createMailer`
+ * resolution when no row exists; console default when neither DB nor env
+ * are set; credential write/clear delegate correctly, including the
+ * create-on-missing-ref fallback.
+ *
+ * @module libs/core/src/mailer/application/services
+ */
+import type { ConfigService } from '@nestjs/config';
+import { Logger as SharedLogger } from '@openlinker/shared/logging';
+import {
+  CredentialNotFoundException,
+  IntegrationCredential,
+  type ICredentialsService,
+} from '@openlinker/core/integrations';
+import { MailerSettings } from '../../domain/entities/mailer-settings.entity';
+import type { MailerSettingsRepositoryPort } from '../../domain/ports/mailer-settings-repository.port';
+import { MAILER_SMTP_CREDENTIALS_REF } from '../../domain/types/mailer-credentials.types';
+import { MailerSettingsService } from './mailer-settings.service';
+
+const buildConfigService = (overrides: Record<string, string | undefined> = {}): ConfigService =>
+  ({
+    get: <T = string>(key: string, fallback?: T): T | undefined =>
+      (overrides[key] as T | undefined) ?? fallback,
+  }) as unknown as ConfigService;
+
+const buildCredential = (password: string): IntegrationCredential =>
+  new IntegrationCredential(
+    'cred-1',
+    MAILER_SMTP_CREDENTIALS_REF,
+    'mailer',
+    { password },
+    new Date(),
+    new Date()
+  );
+
+describe('MailerSettingsService', () => {
+  let repository: jest.Mocked<MailerSettingsRepositoryPort>;
+  let credentials: jest.Mocked<ICredentialsService>;
+  let logSpy: jest.SpyInstance;
+
+  const buildService = (config: ConfigService = buildConfigService()): MailerSettingsService =>
+    new MailerSettingsService(repository, credentials, config);
+
+  beforeEach(() => {
+    repository = {
+      findSettings: jest.fn(),
+      upsertSettings: jest.fn(),
+    };
+    credentials = {
+      getByRef: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+    logSpy = jest.spyOn(SharedLogger.prototype, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  describe('getSettings', () => {
+    it('returns console defaults with no timestamps when no row exists', async () => {
+      repository.findSettings.mockResolvedValue(null);
+      credentials.getByRef.mockRejectedValue(
+        new CredentialNotFoundException(MAILER_SMTP_CREDENTIALS_REF)
+      );
+
+      const view = await buildService().getSettings();
+
+      expect(view).toEqual({
+        transport: 'console',
+        smtpHost: null,
+        smtpPort: null,
+        smtpSecure: false,
+        fromAddress: null,
+        smtpPasswordConfigured: false,
+        updatedAt: null,
+        updatedBy: null,
+      });
+    });
+
+    it('never includes the password, only whether one is configured', async () => {
+      const updatedAt = new Date('2026-05-01T00:00:00Z');
+      repository.findSettings.mockResolvedValue(
+        new MailerSettings(
+          'smtp',
+          'smtp.example.com',
+          587,
+          true,
+          'noreply@x.com',
+          updatedAt,
+          'admin'
+        )
+      );
+      credentials.getByRef.mockResolvedValue(buildCredential('super-secret'));
+
+      const view = await buildService().getSettings();
+
+      expect(view).toEqual({
+        transport: 'smtp',
+        smtpHost: 'smtp.example.com',
+        smtpPort: 587,
+        smtpSecure: true,
+        fromAddress: 'noreply@x.com',
+        smtpPasswordConfigured: true,
+        updatedAt,
+        updatedBy: 'admin',
+      });
+      expect(JSON.stringify(view)).not.toContain('super-secret');
+    });
+
+    it('reports smtpPasswordConfigured=true from env when no DB credential exists', async () => {
+      repository.findSettings.mockResolvedValue(null);
+      credentials.getByRef.mockRejectedValue(
+        new CredentialNotFoundException(MAILER_SMTP_CREDENTIALS_REF)
+      );
+      const service = buildService(buildConfigService({ MAIL_SMTP_PASSWORD: 'env-secret' }));
+
+      const view = await service.getSettings();
+
+      expect(view.smtpPasswordConfigured).toBe(true);
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('delegates to the repository and logs the transport', async () => {
+      repository.upsertSettings.mockResolvedValue(
+        new MailerSettings('smtp', 'smtp.x', 587, false, 'a@b.com', new Date(), 'admin')
+      );
+
+      await buildService().updateSettings(
+        {
+          transport: 'smtp',
+          smtpHost: 'smtp.x',
+          smtpPort: 587,
+          smtpSecure: false,
+          fromAddress: 'a@b.com',
+        },
+        'admin'
+      );
+
+      expect(repository.upsertSettings).toHaveBeenCalledWith(
+        {
+          transport: 'smtp',
+          smtpHost: 'smtp.x',
+          smtpPort: 587,
+          smtpSecure: false,
+          fromAddress: 'a@b.com',
+        },
+        'admin'
+      );
+    });
+  });
+
+  describe('setSmtpPassword / clearSmtpPassword', () => {
+    it('updates the existing credential when present', async () => {
+      credentials.update.mockResolvedValue(buildCredential('new-pass'));
+
+      await buildService().setSmtpPassword('new-pass', 'admin');
+
+      expect(credentials.update).toHaveBeenCalledWith(MAILER_SMTP_CREDENTIALS_REF, {
+        credentialsJson: { password: 'new-pass' },
+      });
+      expect(credentials.create).not.toHaveBeenCalled();
+    });
+
+    it('creates the credential when the ref does not exist yet', async () => {
+      credentials.update.mockRejectedValue(
+        new CredentialNotFoundException(MAILER_SMTP_CREDENTIALS_REF)
+      );
+      credentials.create.mockResolvedValue(buildCredential('new-pass'));
+
+      await buildService().setSmtpPassword('new-pass', 'admin');
+
+      expect(credentials.create).toHaveBeenCalledWith({
+        ref: MAILER_SMTP_CREDENTIALS_REF,
+        platformType: 'mailer',
+        credentialsJson: { password: 'new-pass' },
+      });
+    });
+
+    it('clears the credential', async () => {
+      credentials.delete.mockResolvedValue(true);
+
+      await buildService().clearSmtpPassword('admin');
+
+      expect(credentials.delete).toHaveBeenCalledWith(MAILER_SMTP_CREDENTIALS_REF);
+    });
+  });
+
+  describe('resolveTransportConfig', () => {
+    it('resolves console default when no DB row and no env are set', async () => {
+      repository.findSettings.mockResolvedValue(null);
+
+      const config = await buildService().resolveTransportConfig();
+
+      expect(config).toEqual({
+        transport: 'console',
+        smtpHost: null,
+        smtpPort: 587,
+        smtpSecure: false,
+        smtpUser: null,
+        smtpPassword: null,
+        fromAddress: 'no-reply@openlinker.local',
+      });
+    });
+
+    it('falls back to env vars when no DB row exists (pre-#1643 behavior)', async () => {
+      repository.findSettings.mockResolvedValue(null);
+      const service = buildService(
+        buildConfigService({
+          MAIL_SMTP_HOST: 'smtp.env.com',
+          MAIL_SMTP_PORT: '2525',
+          MAIL_SMTP_SECURE: 'true',
+          MAIL_SMTP_USER: 'env-user',
+          MAIL_SMTP_PASSWORD: 'env-pass',
+          MAIL_FROM: 'env@x.com',
+        })
+      );
+
+      const config = await service.resolveTransportConfig();
+
+      expect(config).toEqual({
+        transport: 'smtp',
+        smtpHost: 'smtp.env.com',
+        smtpPort: 2525,
+        smtpSecure: true,
+        smtpUser: 'env-user',
+        smtpPassword: 'env-pass',
+        fromAddress: 'env@x.com',
+      });
+    });
+
+    it('DB row wins over env vars when a row exists', async () => {
+      repository.findSettings.mockResolvedValue(
+        new MailerSettings('smtp', 'smtp.db.com', 465, true, 'db@x.com', new Date(), 'admin')
+      );
+      credentials.getByRef.mockResolvedValue(buildCredential('db-pass'));
+      const service = buildService(
+        buildConfigService({ MAIL_SMTP_HOST: 'smtp.env.com', MAIL_SMTP_PASSWORD: 'env-pass' })
+      );
+
+      const config = await service.resolveTransportConfig();
+
+      expect(config).toEqual({
+        transport: 'smtp',
+        smtpHost: 'smtp.db.com',
+        smtpPort: 465,
+        smtpSecure: true,
+        smtpUser: null,
+        smtpPassword: 'db-pass',
+        fromAddress: 'db@x.com',
+      });
+    });
+
+    it('returns console transport when the DB row transport is console, ignoring smtp env vars', async () => {
+      repository.findSettings.mockResolvedValue(
+        new MailerSettings('console', null, null, false, null, new Date(), 'admin')
+      );
+      const service = buildService(buildConfigService({ MAIL_SMTP_HOST: 'smtp.env.com' }));
+
+      const config = await service.resolveTransportConfig();
+
+      expect(config.transport).toBe('console');
+      expect(config.smtpHost).toBeNull();
+    });
+
+    it('falls back to the env password when the DB row is smtp but no credential row exists', async () => {
+      repository.findSettings.mockResolvedValue(
+        new MailerSettings('smtp', 'smtp.db.com', 465, true, 'db@x.com', new Date(), 'admin')
+      );
+      credentials.getByRef.mockRejectedValue(
+        new CredentialNotFoundException(MAILER_SMTP_CREDENTIALS_REF)
+      );
+      const service = buildService(buildConfigService({ MAIL_SMTP_PASSWORD: 'env-pass' }));
+
+      const config = await service.resolveTransportConfig();
+
+      expect(config.smtpPassword).toBe('env-pass');
+    });
+  });
+});

--- a/libs/core/src/mailer/application/services/mailer-settings.service.ts
+++ b/libs/core/src/mailer/application/services/mailer-settings.service.ts
@@ -1,0 +1,232 @@
+/**
+ * Mailer Settings Service
+ *
+ * Implements `IMailerSettingsService`. Non-secret settings (transport, host,
+ * port, secure, from address) live in the singleton `mailer_settings` table;
+ * the SMTP password is stored separately as an encrypted credential (
+ * `ref = 'mailer:smtp-password'`) via `ICredentialsService`
+ * (`@openlinker/core/integrations`).
+ *
+ * Read-through model: `resolveTransportConfig()` hits the repository (and,
+ * for SMTP, the credentials store) on every call — no in-process cache.
+ * The cost is a singleton-row PK lookup plus (for SMTP) one credential
+ * lookup, both sub-millisecond, dwarfed by the actual SMTP round-trip. This
+ * mirrors `AiProviderActiveSettingsService` / `MultiProviderAiCompletionAdapter`'s
+ * resolution model (docs/architecture-overview.md § AI).
+ *
+ * Resolution order when no DB row exists yet (first boot): fall back to the
+ * legacy env vars `MAIL_TRANSPORT` / `MAIL_SMTP_HOST` / `MAIL_SMTP_PORT` /
+ * `MAIL_SMTP_SECURE` / `MAIL_SMTP_USER` / `MAIL_SMTP_PASSWORD` / `MAIL_FROM`
+ * (#1623), finally defaulting to the console transport so offline dev keeps
+ * working with zero configuration. `MAIL_SMTP_USER` is always read from env
+ * even once a DB row exists — it isn't yet one of the admin-editable fields
+ * (out of scope for #1643; see `ResolvedMailerTransportConfig.smtpUser`).
+ *
+ * @module libs/core/src/mailer/application/services
+ * @implements {IMailerSettingsService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@openlinker/shared/logging';
+import {
+  CREDENTIALS_SERVICE_TOKEN,
+  CredentialNotFoundException,
+  type ICredentialsService,
+} from '@openlinker/core/integrations';
+import { MAILER_SETTINGS_REPOSITORY_TOKEN } from '../../mailer.tokens';
+import type { MailerSettings } from '../../domain/entities/mailer-settings.entity';
+import { MailerSettingsRepositoryPort } from '../../domain/ports/mailer-settings-repository.port';
+import { MAILER_SMTP_CREDENTIALS_REF } from '../../domain/types/mailer-credentials.types';
+import type {
+  MailerSettingsInput,
+  MailerSettingsView,
+  ResolvedMailerTransportConfig,
+} from '../../domain/types/mailer-settings.types';
+import type { IMailerSettingsService } from './mailer-settings.service.interface';
+
+const DEFAULT_FROM_ADDRESS = 'no-reply@openlinker.local';
+const DEFAULT_SMTP_PORT = 587;
+
+@Injectable()
+export class MailerSettingsService implements IMailerSettingsService {
+  private readonly logger = new Logger(MailerSettingsService.name);
+
+  constructor(
+    @Inject(MAILER_SETTINGS_REPOSITORY_TOKEN)
+    private readonly repository: MailerSettingsRepositoryPort,
+    @Inject(CREDENTIALS_SERVICE_TOKEN)
+    private readonly credentials: ICredentialsService,
+    private readonly configService: ConfigService
+  ) {}
+
+  async getSettings(): Promise<MailerSettingsView> {
+    const row = await this.repository.findSettings();
+    const smtpPasswordConfigured = await this.isSmtpPasswordConfigured();
+
+    if (!row) {
+      return {
+        transport: 'console',
+        smtpHost: null,
+        smtpPort: null,
+        smtpSecure: false,
+        fromAddress: null,
+        smtpPasswordConfigured,
+        updatedAt: null,
+        updatedBy: null,
+      };
+    }
+
+    return {
+      transport: row.transport,
+      smtpHost: row.smtpHost,
+      smtpPort: row.smtpPort,
+      smtpSecure: row.smtpSecure,
+      fromAddress: row.fromAddress,
+      smtpPasswordConfigured,
+      updatedAt: row.updatedAt,
+      updatedBy: row.updatedBy,
+    };
+  }
+
+  async updateSettings(input: MailerSettingsInput, actorUserId?: string): Promise<void> {
+    await this.repository.upsertSettings(input, actorUserId ?? null);
+    this.logger.log('mailer_settings.update', {
+      transport: input.transport,
+      actor: actorUserId ?? 'system',
+    });
+  }
+
+  async setSmtpPassword(password: string, actorUserId?: string): Promise<void> {
+    try {
+      await this.credentials.update(MAILER_SMTP_CREDENTIALS_REF, {
+        credentialsJson: { password },
+      });
+    } catch (error) {
+      if (error instanceof CredentialNotFoundException) {
+        await this.credentials.create({
+          ref: MAILER_SMTP_CREDENTIALS_REF,
+          platformType: 'mailer',
+          credentialsJson: { password },
+        });
+      } else {
+        throw error;
+      }
+    }
+    this.logger.log('mailer_settings.set_credentials', { actor: actorUserId ?? 'system' });
+  }
+
+  async clearSmtpPassword(actorUserId?: string): Promise<void> {
+    await this.credentials.delete(MAILER_SMTP_CREDENTIALS_REF);
+    this.logger.log('mailer_settings.clear_credentials', { actor: actorUserId ?? 'system' });
+  }
+
+  async resolveTransportConfig(): Promise<ResolvedMailerTransportConfig> {
+    const row = await this.repository.findSettings();
+    if (row) {
+      return this.resolveFromRow(row);
+    }
+    return this.resolveFromEnv();
+  }
+
+  private async resolveFromRow(row: MailerSettings): Promise<ResolvedMailerTransportConfig> {
+    const fromAddress = row.fromAddress ?? DEFAULT_FROM_ADDRESS;
+
+    if (row.transport !== 'smtp') {
+      return {
+        transport: 'console',
+        smtpHost: null,
+        smtpPort: DEFAULT_SMTP_PORT,
+        smtpSecure: false,
+        smtpUser: null,
+        smtpPassword: null,
+        fromAddress,
+      };
+    }
+
+    const smtpPassword = await this.readSmtpPassword();
+    return {
+      transport: 'smtp',
+      smtpHost: row.smtpHost,
+      smtpPort: row.smtpPort ?? DEFAULT_SMTP_PORT,
+      smtpSecure: row.smtpSecure,
+      smtpUser: this.configService.get<string>('MAIL_SMTP_USER') ?? null,
+      smtpPassword,
+      fromAddress,
+    };
+  }
+
+  /**
+   * First-boot fallback when no DB row exists yet — reproduces the
+   * env-var-only resolution `MailerProvider` used before this change (#1623),
+   * so operators on env-only configuration keep working unchanged.
+   */
+  private resolveFromEnv(): ResolvedMailerTransportConfig {
+    const transportEnv = this.configService.get<string>('MAIL_TRANSPORT', '').toLowerCase();
+    const host = this.configService.get<string>('MAIL_SMTP_HOST');
+    const fromAddress = this.configService.get<string>('MAIL_FROM', DEFAULT_FROM_ADDRESS);
+
+    if (transportEnv === 'console' || (!host && transportEnv !== 'smtp')) {
+      return {
+        transport: 'console',
+        smtpHost: null,
+        smtpPort: DEFAULT_SMTP_PORT,
+        smtpSecure: false,
+        smtpUser: null,
+        smtpPassword: null,
+        fromAddress,
+      };
+    }
+
+    if (!host) {
+      throw new Error('MAIL_TRANSPORT=smtp requires MAIL_SMTP_HOST to be set');
+    }
+
+    const smtpPort = Number(
+      this.configService.get<string>('MAIL_SMTP_PORT', String(DEFAULT_SMTP_PORT))
+    );
+    const smtpSecure = this.configService.get<string>('MAIL_SMTP_SECURE', 'false') === 'true';
+    const smtpUser = this.configService.get<string>('MAIL_SMTP_USER') ?? null;
+    const smtpPassword = this.configService.get<string>('MAIL_SMTP_PASSWORD') ?? null;
+
+    return {
+      transport: 'smtp',
+      smtpHost: host,
+      smtpPort,
+      smtpSecure,
+      smtpUser,
+      smtpPassword,
+      fromAddress,
+    };
+  }
+
+  private async readSmtpPassword(): Promise<string | null> {
+    try {
+      const credential = await this.credentials.getByRef(MAILER_SMTP_CREDENTIALS_REF);
+      const password = credential.credentialsJson?.password;
+      if (typeof password !== 'string') {
+        this.logger.error(
+          `Mailer credential ${MAILER_SMTP_CREDENTIALS_REF} is missing a password field`
+        );
+        return null;
+      }
+      return password;
+    } catch (error) {
+      if (error instanceof CredentialNotFoundException) {
+        return this.configService.get<string>('MAIL_SMTP_PASSWORD') ?? null;
+      }
+      throw error;
+    }
+  }
+
+  private async isSmtpPasswordConfigured(): Promise<boolean> {
+    try {
+      await this.credentials.getByRef(MAILER_SMTP_CREDENTIALS_REF);
+      return true;
+    } catch (error) {
+      if (error instanceof CredentialNotFoundException) {
+        return Boolean(this.configService.get<string>('MAIL_SMTP_PASSWORD'));
+      }
+      throw error;
+    }
+  }
+}

--- a/libs/core/src/mailer/domain/entities/mailer-settings.entity.ts
+++ b/libs/core/src/mailer/domain/entities/mailer-settings.entity.ts
@@ -1,0 +1,27 @@
+/**
+ * Mailer Settings Domain Entity
+ *
+ * Singleton-row representation of the DB-backed mailer/SMTP settings
+ * (transport, host, port, secure, from address). Modeled on
+ * `AiProviderActiveSetting` — the SMTP password is intentionally NOT a
+ * field here; it lives in the encrypted `integration_credentials` store at
+ * `ref = 'mailer:smtp-password'` and is resolved separately by
+ * `MailerSettingsService`.
+ *
+ * @module libs/core/src/mailer/domain/entities
+ */
+import type { MailerTransport } from '../types/mailer-settings.types';
+
+export const MAILER_SETTINGS_SINGLETON_ID = 'singleton';
+
+export class MailerSettings {
+  constructor(
+    public readonly transport: MailerTransport,
+    public readonly smtpHost: string | null,
+    public readonly smtpPort: number | null,
+    public readonly smtpSecure: boolean,
+    public readonly fromAddress: string | null,
+    public readonly updatedAt: Date,
+    public readonly updatedBy: string | null
+  ) {}
+}

--- a/libs/core/src/mailer/domain/ports/mailer-settings-repository.port.ts
+++ b/libs/core/src/mailer/domain/ports/mailer-settings-repository.port.ts
@@ -1,0 +1,27 @@
+/**
+ * Mailer Settings Repository Port
+ *
+ * Persistence contract for the singleton-row `mailer_settings` table.
+ * Implemented by `MailerSettingsRepository` in the infrastructure layer;
+ * consumed by `MailerSettingsService`. Mirrors
+ * `AiProviderActiveSettingRepositoryPort`.
+ *
+ * @module libs/core/src/mailer/domain/ports
+ */
+import type { MailerSettings } from '../entities/mailer-settings.entity';
+import type { MailerSettingsInput } from '../types/mailer-settings.types';
+
+export interface MailerSettingsRepositoryPort {
+  /**
+   * Read the singleton row. Returns `null` when no row exists yet — callers
+   * are expected to fall back to env-var resolution and create the row on
+   * first admin write.
+   */
+  findSettings(): Promise<MailerSettings | null>;
+
+  /**
+   * Idempotently upsert the non-secret settings fields on the singleton row.
+   * Creates the row if absent.
+   */
+  upsertSettings(input: MailerSettingsInput, updatedBy: string | null): Promise<MailerSettings>;
+}

--- a/libs/core/src/mailer/domain/types/mailer-credentials.types.ts
+++ b/libs/core/src/mailer/domain/types/mailer-credentials.types.ts
@@ -1,0 +1,14 @@
+/**
+ * Mailer Credentials Types
+ *
+ * The SMTP password is stored as a single credential row in the shared,
+ * encrypted `integration_credentials` store (via `ICredentialsService`,
+ * `@openlinker/core/integrations`) rather than as a plaintext column on
+ * `mailer_settings`. Single fixed `ref` — unlike the AI provider keys there
+ * is only one mailer transport active at a time, so no per-provider
+ * parameterization is needed.
+ *
+ * @module libs/core/src/mailer/domain/types
+ */
+
+export const MAILER_SMTP_CREDENTIALS_REF = 'mailer:smtp-password';

--- a/libs/core/src/mailer/domain/types/mailer-settings.types.ts
+++ b/libs/core/src/mailer/domain/types/mailer-settings.types.ts
@@ -1,0 +1,63 @@
+/**
+ * Mailer Settings Types
+ *
+ * Value types for the DB-backed mailer/SMTP settings. `transport` mirrors
+ * the two transports `MailerProvider` already supported via env vars
+ * (`MAIL_TRANSPORT=console|smtp`, #1623) — the DB row makes the choice
+ * operator-editable at runtime instead of requiring a redeploy.
+ *
+ * @module libs/core/src/mailer/domain/types
+ */
+
+export const MailerTransportValues = ['console', 'smtp'] as const;
+export type MailerTransport = (typeof MailerTransportValues)[number];
+
+/**
+ * Non-secret settings fields, as written by `PUT /mailer-settings`. The SMTP
+ * password is deliberately absent — it is written separately via
+ * `PUT /mailer-settings/credentials` into the encrypted credentials store.
+ */
+export interface MailerSettingsInput {
+  transport: MailerTransport;
+  smtpHost: string | null;
+  smtpPort: number | null;
+  smtpSecure: boolean;
+  fromAddress: string | null;
+}
+
+/**
+ * Read view returned by `GET /mailer-settings`. Never carries the SMTP
+ * password — only whether one is currently configured.
+ */
+export interface MailerSettingsView {
+  transport: MailerTransport;
+  smtpHost: string | null;
+  smtpPort: number | null;
+  smtpSecure: boolean;
+  fromAddress: string | null;
+  smtpPasswordConfigured: boolean;
+  updatedAt: Date | null;
+  updatedBy: string | null;
+}
+
+/**
+ * Fully-resolved runtime transport configuration consumed by the mailer
+ * adapter to actually send an email. Resolution order: DB row → env var
+ * fallback → console default (see `IMailerSettingsService.resolveTransportConfig`).
+ */
+export interface ResolvedMailerTransportConfig {
+  transport: MailerTransport;
+  smtpHost: string | null;
+  smtpPort: number;
+  smtpSecure: boolean;
+  /**
+   * SMTP auth username. Not yet an admin-editable field (out of scope for
+   * #1643, which only covers transport/host/port/secure/from as non-secret
+   * fields plus the password as the one secret) — always sourced from the
+   * legacy `MAIL_SMTP_USER` env var. A future issue can promote it to a
+   * DB-backed field alongside the password.
+   */
+  smtpUser: string | null;
+  smtpPassword: string | null;
+  fromAddress: string;
+}

--- a/libs/core/src/mailer/index.ts
+++ b/libs/core/src/mailer/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Mailer Module Public API
+ *
+ * Exports domain entities, ports, types, application service interfaces,
+ * and the NestJS module for the mailer bounded context (DB-backed
+ * mailer/SMTP settings — #1643, mirrors the AI Provider Settings pattern).
+ *
+ * @module libs/core/src/mailer
+ */
+export {
+  MailerSettings,
+  MAILER_SETTINGS_SINGLETON_ID,
+} from './domain/entities/mailer-settings.entity';
+export type { MailerSettingsRepositoryPort } from './domain/ports/mailer-settings-repository.port';
+export { MailerTransportValues } from './domain/types/mailer-settings.types';
+export type {
+  MailerTransport,
+  MailerSettingsInput,
+  MailerSettingsView,
+  ResolvedMailerTransportConfig,
+} from './domain/types/mailer-settings.types';
+export { MAILER_SMTP_CREDENTIALS_REF } from './domain/types/mailer-credentials.types';
+export type { IMailerSettingsService } from './application/services/mailer-settings.service.interface';
+export { MailerModule } from './mailer.module';
+export * from './mailer.tokens';

--- a/libs/core/src/mailer/infrastructure/persistence/entities/mailer-settings.orm-entity.ts
+++ b/libs/core/src/mailer/infrastructure/persistence/entities/mailer-settings.orm-entity.ts
@@ -1,0 +1,39 @@
+/**
+ * Mailer Settings ORM Entity
+ *
+ * TypeORM mapping for the `mailer_settings` singleton-row table. The `id`
+ * column is always `'singleton'` (literal); the row is upserted by
+ * `MailerSettingsRepository.upsertSettings`. Production gets the schema via
+ * the DDL migration; integration-test harness materialises it via
+ * `synchronize: true`.
+ *
+ * @module libs/core/src/mailer/infrastructure/persistence/entities
+ */
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('mailer_settings')
+export class MailerSettingsOrmEntity {
+  @PrimaryColumn({ type: 'text', name: 'id' })
+  id!: string;
+
+  @Column({ type: 'text', name: 'transport' })
+  transport!: string;
+
+  @Column({ type: 'text', name: 'smtp_host', nullable: true })
+  smtpHost!: string | null;
+
+  @Column({ type: 'integer', name: 'smtp_port', nullable: true })
+  smtpPort!: number | null;
+
+  @Column({ type: 'boolean', name: 'smtp_secure', default: false })
+  smtpSecure!: boolean;
+
+  @Column({ type: 'text', name: 'from_address', nullable: true })
+  fromAddress!: string | null;
+
+  @UpdateDateColumn({ type: 'timestamptz', name: 'updated_at' })
+  updatedAt!: Date;
+
+  @Column({ type: 'text', name: 'updated_by', nullable: true })
+  updatedBy!: string | null;
+}

--- a/libs/core/src/mailer/infrastructure/persistence/repositories/mailer-settings.repository.spec.ts
+++ b/libs/core/src/mailer/infrastructure/persistence/repositories/mailer-settings.repository.spec.ts
@@ -94,10 +94,60 @@ describe('MailerSettingsRepository', () => {
           smtpSecure: false,
           fromAddress: null,
           updatedBy: 'admin',
+          updatedAt: expect.any(Date),
         },
         { conflictPaths: ['id'] }
       );
       expect(result.transport).toBe('console');
+    });
+
+    it('refreshes updated_at on every successive call, not just the initial insert', async () => {
+      ormRepo.upsert.mockResolvedValue({} as never);
+
+      const firstUpdatedAt = new Date('2026-05-01T00:00:00Z');
+      ormRepo.findOneOrFail.mockResolvedValueOnce(ormRow({ updatedAt: firstUpdatedAt }));
+      const first = await subject.upsertSettings(
+        {
+          transport: 'smtp',
+          smtpHost: 'smtp.example.com',
+          smtpPort: 587,
+          smtpSecure: false,
+          fromAddress: 'noreply@example.com',
+        },
+        'admin'
+      );
+
+      const secondUpdatedAt = new Date('2026-05-02T00:00:00Z');
+      ormRepo.findOneOrFail.mockResolvedValueOnce(ormRow({ updatedAt: secondUpdatedAt }));
+      const second = await subject.upsertSettings(
+        {
+          transport: 'smtp',
+          smtpHost: 'smtp.example.com',
+          smtpPort: 587,
+          smtpSecure: false,
+          fromAddress: 'noreply@example.com',
+        },
+        'admin'
+      );
+
+      expect(second.updatedAt.getTime()).not.toBe(first.updatedAt.getTime());
+      expect(ormRepo.upsert).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ updatedAt: expect.any(Date) }),
+        { conflictPaths: ['id'] }
+      );
+      expect(ormRepo.upsert).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ updatedAt: expect.any(Date) }),
+        { conflictPaths: ['id'] }
+      );
+      const firstCallUpdatedAt = (
+        ormRepo.upsert.mock.calls[0][0] as MailerSettingsOrmEntity
+      ).updatedAt;
+      const secondCallUpdatedAt = (
+        ormRepo.upsert.mock.calls[1][0] as MailerSettingsOrmEntity
+      ).updatedAt;
+      expect(secondCallUpdatedAt.getTime()).toBeGreaterThanOrEqual(firstCallUpdatedAt.getTime());
     });
   });
 });

--- a/libs/core/src/mailer/infrastructure/persistence/repositories/mailer-settings.repository.spec.ts
+++ b/libs/core/src/mailer/infrastructure/persistence/repositories/mailer-settings.repository.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Mailer Settings Repository — Unit Tests
+ *
+ * Mocks the TypeORM repository so the spec is fast and independent of
+ * Postgres. Pins: singleton-id upsert (`ON CONFLICT (id) DO UPDATE` via
+ * `.upsert`), ORM ↔ domain mapping, and the defensive throw on an unknown
+ * `transport` value read back from the row.
+ *
+ * @module libs/core/src/mailer/infrastructure/persistence/repositories
+ */
+import type { Repository } from 'typeorm';
+import { MailerSettingsRepository } from './mailer-settings.repository';
+import type { MailerSettingsOrmEntity } from '../entities/mailer-settings.orm-entity';
+
+describe('MailerSettingsRepository', () => {
+  let ormRepo: jest.Mocked<
+    Pick<Repository<MailerSettingsOrmEntity>, 'findOne' | 'findOneOrFail' | 'upsert'>
+  >;
+  let subject: MailerSettingsRepository;
+
+  const ormRow = (overrides: Partial<MailerSettingsOrmEntity> = {}): MailerSettingsOrmEntity => ({
+    id: 'singleton',
+    transport: 'smtp',
+    smtpHost: 'smtp.example.com',
+    smtpPort: 587,
+    smtpSecure: false,
+    fromAddress: 'noreply@example.com',
+    updatedAt: new Date('2026-05-01T00:00:00Z'),
+    updatedBy: 'admin',
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    ormRepo = {
+      findOne: jest.fn(),
+      findOneOrFail: jest.fn(),
+      upsert: jest.fn(),
+    };
+    subject = new MailerSettingsRepository(
+      ormRepo as unknown as Repository<MailerSettingsOrmEntity>
+    );
+  });
+
+  describe('findSettings', () => {
+    it('returns null when no row exists', async () => {
+      ormRepo.findOne.mockResolvedValue(null);
+      expect(await subject.findSettings()).toBeNull();
+    });
+
+    it('maps the row to the domain entity', async () => {
+      ormRepo.findOne.mockResolvedValue(ormRow());
+
+      const settings = await subject.findSettings();
+
+      expect(settings).toMatchObject({
+        transport: 'smtp',
+        smtpHost: 'smtp.example.com',
+        smtpPort: 587,
+        smtpSecure: false,
+        fromAddress: 'noreply@example.com',
+        updatedBy: 'admin',
+      });
+      expect(ormRepo.findOne).toHaveBeenCalledWith({ where: { id: 'singleton' } });
+    });
+
+    it('throws when the persisted transport value is unrecognized', async () => {
+      ormRepo.findOne.mockResolvedValue(ormRow({ transport: 'sendgrid' }));
+      await expect(subject.findSettings()).rejects.toThrow(/unknown value/);
+    });
+  });
+
+  describe('upsertSettings', () => {
+    it('upserts on the singleton id and returns the saved row', async () => {
+      ormRepo.upsert.mockResolvedValue({} as never);
+      ormRepo.findOneOrFail.mockResolvedValue(ormRow({ transport: 'console', smtpHost: null }));
+
+      const result = await subject.upsertSettings(
+        {
+          transport: 'console',
+          smtpHost: null,
+          smtpPort: null,
+          smtpSecure: false,
+          fromAddress: null,
+        },
+        'admin'
+      );
+
+      expect(ormRepo.upsert).toHaveBeenCalledWith(
+        {
+          id: 'singleton',
+          transport: 'console',
+          smtpHost: null,
+          smtpPort: null,
+          smtpSecure: false,
+          fromAddress: null,
+          updatedBy: 'admin',
+        },
+        { conflictPaths: ['id'] }
+      );
+      expect(result.transport).toBe('console');
+    });
+  });
+});

--- a/libs/core/src/mailer/infrastructure/persistence/repositories/mailer-settings.repository.ts
+++ b/libs/core/src/mailer/infrastructure/persistence/repositories/mailer-settings.repository.ts
@@ -54,6 +54,12 @@ export class MailerSettingsRepository implements MailerSettingsRepositoryPort {
         smtpSecure: input.smtpSecure,
         fromAddress: input.fromAddress,
         updatedBy,
+        // TypeORM's upsert() only includes explicitly-passed columns in the
+        // ON CONFLICT DO UPDATE SET clause — @UpdateDateColumn()'s auto-touch
+        // behavior applies only to .save(), so updatedAt must be set here
+        // explicitly or every update after the initial insert would leave it
+        // frozen at its creation value.
+        updatedAt: new Date(),
       },
       { conflictPaths: ['id'] }
     );

--- a/libs/core/src/mailer/infrastructure/persistence/repositories/mailer-settings.repository.ts
+++ b/libs/core/src/mailer/infrastructure/persistence/repositories/mailer-settings.repository.ts
@@ -1,0 +1,84 @@
+/**
+ * Mailer Settings Repository
+ *
+ * TypeORM-backed implementation of `MailerSettingsRepositoryPort`. Operates
+ * on a single fixed-id row (`id = 'singleton'`); `upsertSettings` uses an
+ * `ON CONFLICT (id) DO UPDATE` to keep both the create and update paths
+ * atomic without a separate `findOne` round-trip. ORM ↔ domain mapping is
+ * private to this class. Mirrors `AiProviderActiveSettingRepository`.
+ *
+ * @module libs/core/src/mailer/infrastructure/persistence/repositories
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  MAILER_SETTINGS_SINGLETON_ID,
+  MailerSettings,
+} from '../../../domain/entities/mailer-settings.entity';
+import type { MailerSettingsRepositoryPort } from '../../../domain/ports/mailer-settings-repository.port';
+import {
+  MailerTransportValues,
+  type MailerSettingsInput,
+  type MailerTransport,
+} from '../../../domain/types/mailer-settings.types';
+import { MailerSettingsOrmEntity } from '../entities/mailer-settings.orm-entity';
+
+const isMailerTransport = (value: string): value is MailerTransport =>
+  (MailerTransportValues as readonly string[]).includes(value);
+
+@Injectable()
+export class MailerSettingsRepository implements MailerSettingsRepositoryPort {
+  constructor(
+    @InjectRepository(MailerSettingsOrmEntity)
+    private readonly ormRepository: Repository<MailerSettingsOrmEntity>
+  ) {}
+
+  async findSettings(): Promise<MailerSettings | null> {
+    const row = await this.ormRepository.findOne({
+      where: { id: MAILER_SETTINGS_SINGLETON_ID },
+    });
+    return row ? this.toDomain(row) : null;
+  }
+
+  async upsertSettings(
+    input: MailerSettingsInput,
+    updatedBy: string | null
+  ): Promise<MailerSettings> {
+    await this.ormRepository.upsert(
+      {
+        id: MAILER_SETTINGS_SINGLETON_ID,
+        transport: input.transport,
+        smtpHost: input.smtpHost,
+        smtpPort: input.smtpPort,
+        smtpSecure: input.smtpSecure,
+        fromAddress: input.fromAddress,
+        updatedBy,
+      },
+      { conflictPaths: ['id'] }
+    );
+    const saved = await this.ormRepository.findOneOrFail({
+      where: { id: MAILER_SETTINGS_SINGLETON_ID },
+    });
+    return this.toDomain(saved);
+  }
+
+  private toDomain(entity: MailerSettingsOrmEntity): MailerSettings {
+    if (!isMailerTransport(entity.transport)) {
+      // Defensive: a row with an unknown transport should not exist (the
+      // service-layer write path validates), but if a manual DB edit or a
+      // value drift from a future code change leaves the row in a state we
+      // can't represent, surface it loudly rather than coerce silently.
+      throw new Error(`mailer_settings.transport has an unknown value '${entity.transport}'`);
+    }
+    return new MailerSettings(
+      entity.transport,
+      entity.smtpHost,
+      entity.smtpPort,
+      entity.smtpSecure,
+      entity.fromAddress,
+      entity.updatedAt,
+      entity.updatedBy
+    );
+  }
+}

--- a/libs/core/src/mailer/mailer.module.ts
+++ b/libs/core/src/mailer/mailer.module.ts
@@ -1,0 +1,44 @@
+/**
+ * Mailer Module (core)
+ *
+ * NestJS module for the mailer bounded context. Wires the singleton
+ * `mailer_settings` repository and `MailerSettingsService`, which resolves
+ * the effective outbound-email transport configuration (console vs SMTP)
+ * at runtime: DB row → env var fallback → console default. The SMTP
+ * password is stored via the shared encrypted `integration_credentials`
+ * store (`CoreIntegrationsModule`), not on this module's own table.
+ *
+ * The concrete `MailerPort` adapter (console/SMTP transport + nodemailer)
+ * lives in `apps/api/src/auth/adapters/` — this module only owns settings
+ * persistence + resolution, mirroring how `AiModule` owns AI provider
+ * settings while the Vercel completion adapters live in
+ * `libs/integrations/ai/`.
+ *
+ * @module libs/core/src/mailer
+ */
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { IntegrationsModule as CoreIntegrationsModule } from '../integrations/integrations.module';
+import { MAILER_SETTINGS_REPOSITORY_TOKEN, MAILER_SETTINGS_SERVICE_TOKEN } from './mailer.tokens';
+import { MailerSettingsService } from './application/services/mailer-settings.service';
+import { MailerSettingsOrmEntity } from './infrastructure/persistence/entities/mailer-settings.orm-entity';
+import { MailerSettingsRepository } from './infrastructure/persistence/repositories/mailer-settings.repository';
+
+@Module({
+  imports: [
+    ConfigModule,
+    // For CREDENTIALS_SERVICE_TOKEN, consumed by MailerSettingsService to
+    // store/resolve the SMTP password.
+    CoreIntegrationsModule,
+    TypeOrmModule.forFeature([MailerSettingsOrmEntity]),
+  ],
+  providers: [
+    MailerSettingsRepository,
+    { provide: MAILER_SETTINGS_REPOSITORY_TOKEN, useExisting: MailerSettingsRepository },
+    MailerSettingsService,
+    { provide: MAILER_SETTINGS_SERVICE_TOKEN, useExisting: MailerSettingsService },
+  ],
+  exports: [MAILER_SETTINGS_REPOSITORY_TOKEN, MAILER_SETTINGS_SERVICE_TOKEN],
+})
+export class MailerModule {}

--- a/libs/core/src/mailer/mailer.module.ts
+++ b/libs/core/src/mailer/mailer.module.ts
@@ -19,7 +19,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { IntegrationsModule as CoreIntegrationsModule } from '../integrations/integrations.module';
+import { IntegrationsModule as CoreIntegrationsModule } from '@openlinker/core/integrations';
 import { MAILER_SETTINGS_REPOSITORY_TOKEN, MAILER_SETTINGS_SERVICE_TOKEN } from './mailer.tokens';
 import { MailerSettingsService } from './application/services/mailer-settings.service';
 import { MailerSettingsOrmEntity } from './infrastructure/persistence/entities/mailer-settings.orm-entity';

--- a/libs/core/src/mailer/mailer.tokens.ts
+++ b/libs/core/src/mailer/mailer.tokens.ts
@@ -1,0 +1,10 @@
+/**
+ * Mailer Module Dependency Injection Tokens
+ *
+ * Symbol tokens for dependency injection in the mailer bounded context.
+ *
+ * @module libs/core/src/mailer
+ */
+
+export const MAILER_SETTINGS_REPOSITORY_TOKEN = Symbol('MailerSettingsRepositoryPort');
+export const MAILER_SETTINGS_SERVICE_TOKEN = Symbol('IMailerSettingsService');


### PR DESCRIPTION
## Summary

Part of #1606
Closes #1643

Mirrors the existing AI Provider Settings pattern end to end so the mailer transport (console vs SMTP) becomes admin-editable at runtime instead of only configurable via env vars (#1623).

- New `libs/core/src/mailer` bounded context (mirrors `libs/core/src/ai`): domain entity `MailerSettings` (singleton row), `MailerSettingsRepositoryPort` + TypeORM repository, `MailerSettingsService` implementing `IMailerSettingsService`.
- New migration `1818000000009-add-mailer-settings.ts` creating the singleton `mailer_settings` table (transport, smtp_host, smtp_port, smtp_secure, from_address, updated_at, updated_by).
- The SMTP password is stored via the existing encrypted `integration_credentials` store (`ICredentialsService`) at `ref = mailer:smtp-password`, never as a plaintext column, and is never returned by `GET`.
- Resolution order in `MailerSettingsService.resolveTransportConfig()`: DB row -> legacy env vars (`MAIL_TRANSPORT`/`MAIL_SMTP_*`/`MAIL_FROM`) -> console default. Read-through on every call, no in-process cache, matching the AI active-provider router's model.
- New admin-only `MailerSettingsController` (`apps/api/src/mailer/http/mailer-settings.controller.ts`): `GET /mailer-settings` (non-secret fields only), `PUT /mailer-settings` (transport/host/port/secure/from), `PUT /mailer-settings/credentials` (set/rotate the SMTP password, write-only), `DELETE /mailer-settings/credentials`. All gated with `@Roles('admin')`.
- `MailerProvider` (`apps/api/src/auth/adapters/mailer.provider.ts`) now binds `MAILER_TOKEN` to a new `DbBackedMailerAdapter`, which resolves the effective transport on every `sendEmail()` call and delegates to a freshly-built `ConsoleMailerAdapter` or `SmtpMailerAdapter` - so a settings change takes effect immediately, with no restart.
- `AuthModule` now imports core `MailerModule` for the settings service token; `app.module.ts` registers the new core `MailerModule` and `MailerApiModule`.

## Test plan

- [x] `pnpm --filter @openlinker/core build` (rebuilt first to avoid stale cross-package `.d.ts` drift)
- [x] `pnpm --filter @openlinker/core lint` / `pnpm --filter @openlinker/api lint` - zero new errors (2 pre-existing unrelated errors in `apps/api/src/plugins.ts` / `apps/worker/src/plugins.ts` confirmed present on the base branch too)
- [x] `pnpm --filter @openlinker/core type-check` and `pnpm --filter @openlinker/api type-check` - clean
- [x] `pnpm --filter @openlinker/core test` - 150 suites / 1536 tests pass
- [x] `pnpm --filter @openlinker/api test` - 817 tests pass (1 pre-existing failure in `app.controller.spec.ts` due to an unbuilt sibling package in this environment, confirmed present on the base branch too)
- [x] New unit tests: `mailer-settings.service.spec.ts`, `mailer-settings.repository.spec.ts` (core), `mailer-settings.controller.spec.ts`, updated `mailer.adapter.spec.ts` (api) - cover the repository, the settings service (DB/env/console resolution precedence, credential write/clear), and the controller's `@Roles('admin')` gating on every handler
- [x] `check-cross-context-imports` / `check-service-interfaces` / `check-migration-timestamps` invariants pass with no new violations
- [ ] `pnpm --filter @openlinker/api migration:show` - not run (no local Postgres in this environment); migration follows the exact DDL shape of the reference `1792000000000-add-ai-provider-active-setting.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)