### PR TITLE
feat(web/orders): items preview in collapsed row + fix a narrow-width card overflow

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1874,6 +1874,20 @@ textarea,
   gap: 0.75rem;
 }
 
+/* `.page-section` gets no `grid-template-columns` above, so its single
+   implicit column uses the default `auto` track-sizing function — which
+   sizes to the MAX-CONTENT of the widest descendant across every row, not
+   the container's own width (#1646). A wide-enough child (e.g. the orders
+   page's 5-segment health-summary row) can blow that column out past the
+   page's actual width; downstream `.shell-content`'s `overflow-x: hidden`
+   then clips the excess invisibly instead of showing a scrollbar, so the
+   card silently loses its right edge at narrow viewports. `minmax(0, 1fr)`
+   makes the column a real stretchy track capped at the container's width,
+   which every `.page-section` consumer needs regardless of what it renders. */
+.page-section {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .page-header {
   gap: 0.45rem;
 }
@@ -7490,12 +7504,22 @@ a.kpi-card:focus-visible {
 .orders-segment {
   display: block;
   width: 100%;
+  min-width: 0;
   padding: 0;
   border: none;
   background: none;
   text-align: left;
   cursor: pointer;
   border-radius: var(--radius-lg);
+  /* Undo the global `button { white-space: nowrap }` (#1646) — it inherits
+     into `.metric-card__label`, forcing labels like "Awaiting mapping" onto
+     one unbreakable line. At narrow widths the bare `1fr` grid-column
+     fallback (≤480px) has no `minmax(0, …)` floor, so the track grows to fit
+     that unbroken label and the whole segment card silently overflows past
+     the viewport — clipped invisibly by `.shell-content`'s `overflow-x:
+     hidden` rather than producing a scrollbar. Restoring wrap here lets the
+     label break across lines instead. */
+  white-space: normal;
 }
 .orders-segment > .metric-card { height: 100%; }
 .orders-segment:focus-visible {
@@ -7514,6 +7538,15 @@ a.kpi-card:focus-visible {
   font-size: 0.6875rem;
   color: var(--status-error-strong);
   max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Items preview under the Order cell (#1646) — a glance at contents before
+   expanding the row; truncates long/multi-item snapshots on one line. */
+.orders-items-preview {
+  max-width: 240px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -618,4 +618,62 @@ describe('OrdersListPage', () => {
     const row = container.querySelector('.data-table__row') as HTMLElement;
     expect(within(row).getByText('buyer@allegromail.pl')).toBeInTheDocument();
   });
+
+  it('should preview the single item name in the collapsed row (#1646)', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+    expect(within(row).getByText('Filtr kubełkowy AquaPro')).toBeInTheDocument();
+    // Collapsed — the full "N item(s)" detail summary isn't rendered yet.
+    expect(container.querySelector('.data-table__detail-row')).toBeNull();
+  });
+
+  it('should preview the first item name plus a "+N more" suffix for multi-item orders (#1646)', async () => {
+    const multiItemOrder: OrderRecord = {
+      ...syncedOrder,
+      internalOrderId: 'ol_order_multi',
+      orderSnapshot: {
+        ...syncedOrder.orderSnapshot,
+        items: [
+          { id: 'i1', quantity: 1, price: 40, name: 'Filtr kubełkowy AquaPro' },
+          { id: 'i2', quantity: 2, price: 22.1, name: 'Wkład węglowy' },
+          { id: 'i3', quantity: 1, price: 22.1, name: 'Uszczelka' },
+        ],
+      },
+    };
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([multiItemOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+    expect(within(row).getByText('Filtr kubełkowy AquaPro +2 more')).toBeInTheDocument();
+  });
+
+  it('should not render an items preview line when the snapshot has no named items (#1646)', async () => {
+    const noItemsOrder: OrderRecord = {
+      ...syncedOrder,
+      internalOrderId: 'ol_order_noitems',
+      orderSnapshot: { ...syncedOrder.orderSnapshot, items: [] },
+    };
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([noItemsOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+    expect(within(row).queryByText(/more$/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -234,6 +234,21 @@ function customerName(parsed: ReturnType<typeof parseOrderSnapshot>): string | n
 }
 
 /**
+ * Compact items preview for the collapsed row (#1646). Live feedback: the
+ * order's contents were only visible after expanding the accordion — this
+ * gives an at-a-glance signal in the Order cell without duplicating the full
+ * per-line quantities/prices, which stay in `OrderRowDetail`. First item name
+ * plus a "+N more" suffix when the order has more than one line; `null` when
+ * the snapshot carries no named items (parse failure or genuinely empty).
+ */
+function itemsPreview(parsed: ReturnType<typeof parseOrderSnapshot>): string | null {
+  const names = parsed.items.map((i) => i.name).filter((n): n is string => Boolean(n));
+  if (names.length === 0) return null;
+  const [first, ...rest] = names;
+  return rest.length > 0 ? `${first} +${rest.length} more` : first;
+}
+
+/**
  * Cockpit "data freshness" line — freshest `updatedAt` across visible rows,
  * rendered as a locale-aware HH:MM. Same locale-resolution path as
  * `formatCurrency` so the i18n seam stays single-source-of-truth.
@@ -476,12 +491,20 @@ export function OrdersListPage(): ReactElement {
         header: 'Order',
         cell: (order) => {
           const parsed = parseOrderSnapshot(order.orderSnapshot);
+          const preview = itemsPreview(parsed);
           return (
-            <EntityLabel
-              id={order.internalOrderId}
-              name={formatOrderRef(parsed.orderNumber) || order.internalOrderId}
-              to={order.internalOrderId}
-            />
+            <span className="orders-cell-stack">
+              <EntityLabel
+                id={order.internalOrderId}
+                name={formatOrderRef(parsed.orderNumber) || order.internalOrderId}
+                to={order.internalOrderId}
+              />
+              {preview ? (
+                <span className="text-muted orders-cell-sub orders-items-preview" title={preview}>
+                  {preview}
+                </span>
+              ) : null}
+            </span>
           );
         },
       },


### PR DESCRIPTION
## Summary

Two changes to the orders list page, from live user feedback on the #1620 responsive-table redesign.

**1. Items preview before expand.** The order's contents were only visible after expanding the row's accordion. The Order cell now shows a compact preview under the order reference - the first item name, plus a "+N more" suffix for multi-item orders (e.g. "Bosch Professional GSR 12V-15 Cordless Drill +2 more"). This mirrors the existing two-line cell pattern already used by Customer, Channel, Status, and Ship-by in the same row, so it reads as part of the established design language rather than a new visual element. The full per-line item list with quantities/prices is unchanged - it stays in the expandable detail panel (desktop) and the mobile card body (already shown unconditionally there, per #1620).

**2. Fixed a real card-overflow bug found while auditing shrink behavior.** Resizing the browser down to ~480px and below silently clipped the right edge of the 5-segment health-summary cards (All orders / Needs attention / Awaiting mapping / Awaiting dispatch / Synced) - no scrollbar appeared because `.shell-content` has `overflow-x: hidden`, so the cut-off edge was easy to miss.

Root cause: `.page-section` (the shared wrapper every page uses via `PageLayout`) is `display: grid` with no `grid-template-columns`, so its single implicit column falls back to the default `auto` track-sizing function. That sizes the column to the *max-content* width of the widest descendant, not the container's own width. The orders page's 5-card segment row was wide enough (in its own natural/unwrapped layout) to blow that column out past the page's real width at narrow viewports, and the excess got clipped invisibly instead of scrolling.

Fix: constrain `.page-section`'s implicit column to `minmax(0, 1fr)` so it's a real stretchy track capped at the container's width - this protects every page that uses `PageLayout`, not just orders. Also removed the inherited global `button { white-space: nowrap }` from `.orders-segment` so long labels like "Awaiting mapping" can wrap instead of forcing an unbreakable line (a secondary contributor to the same overflow).

## Verification

Audited `/orders` at 1440, 1200, 1024, 900, 768, 767, 640, 480, 375px using a headless-browser script against a local dev server proxied to the demo stack's live data:
- No `document.body.scrollWidth` > `document.documentElement.clientWidth` at any width, before or after the fix (the overflow here was invisible/clipped, not scrollable - confirmed by comparing `.orders-segments` width against its `.page-section` parent width, which matched exactly after the fix at every breakpoint).
- Screenshots before the fix show the segment cards' right border cut off at 480px and 375px; after the fix all five cards render fully within the viewport at every tested width.
- Desktop table <-> mobile card transition (767/768px boundary) shows no overlapping text, cut-off badges, or misaligned columns.
- The expand/accordion toggle and the new items-preview line both remain usable and don't overflow at narrow widths (verified via screenshot at 600px card view + row-click at 1280px table view).

## Test plan

- [x] `pnpm --filter @openlinker/web lint` - 0 errors (pre-existing warnings only, none touching new code)
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] `pnpm --filter @openlinker/web test` scoped to `orders-list-page.test.tsx`, `data-table.test.tsx`, `order-row-detail.test.tsx` - 57/57 passing, including 3 new tests for the items preview (single item, multi-item "+N more", no-items case)
- [x] Manual verification against live demo-stack data via headless browser at 9 viewport widths

Part of #1606