### PR TITLE
feat(auth): design pass on confirm-email page and HTML confirmation email

### DIFF
--- a/apps/api/src/auth/adapters/mailer.adapter.spec.ts
+++ b/apps/api/src/auth/adapters/mailer.adapter.spec.ts
@@ -52,6 +52,26 @@ describe('SmtpMailerAdapter', () => {
       html: undefined,
     });
   });
+
+  it('forwards an HTML body alongside the plain-text fallback when present', async () => {
+    const transport: jest.Mocked<SmtpTransport> = { sendMail: jest.fn().mockResolvedValue({}) };
+    const adapter = new SmtpMailerAdapter(transport, 'no-reply@openlinker.local');
+
+    await adapter.sendEmail({
+      to: 'a@b.com',
+      subject: 'Hi',
+      text: 'Body',
+      html: '<p>Body</p>',
+    });
+
+    expect(transport.sendMail).toHaveBeenCalledWith({
+      from: 'no-reply@openlinker.local',
+      to: 'a@b.com',
+      subject: 'Hi',
+      text: 'Body',
+      html: '<p>Body</p>',
+    });
+  });
 });
 
 describe('ConsoleMailerAdapter', () => {
@@ -59,6 +79,13 @@ describe('ConsoleMailerAdapter', () => {
     const adapter = new ConsoleMailerAdapter();
     await expect(
       adapter.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'Body' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves without throwing when an HTML body is present (ignored gracefully)', async () => {
+    const adapter = new ConsoleMailerAdapter();
+    await expect(
+      adapter.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'Body', html: '<p>Body</p>' }),
     ).resolves.toBeUndefined();
   });
 });

--- a/apps/api/src/auth/email-confirmation.service.spec.ts
+++ b/apps/api/src/auth/email-confirmation.service.spec.ts
@@ -71,6 +71,8 @@ describe('EmailConfirmationService', () => {
       const message = mailer.sendEmail.mock.calls[0][0];
       expect(message.to).toBe('demo@test.com');
       expect(message.text).toContain('https://app.example.com/confirm-email/');
+      expect(message.html).toContain('https://app.example.com/confirm-email/');
+      expect(message.html).toContain('Confirm your email address');
     });
 
     it('does not send when the user has no email', async () => {

--- a/apps/api/src/auth/email-confirmation.service.ts
+++ b/apps/api/src/auth/email-confirmation.service.ts
@@ -30,6 +30,7 @@ import {
   IUserManagementService,
   USER_MANAGEMENT_SERVICE_TOKEN,
 } from '../users/user-management.service.interface';
+import { renderConfirmationEmailHtml } from './templates/confirmation-email.template';
 
 const DEFAULT_TTL_MINUTES = 24 * 60;
 
@@ -81,12 +82,15 @@ export class EmailConfirmationService implements IEmailConfirmationService {
 
       const base = this.configService.get<string>('WEB_URL', 'http://localhost:4173');
       const link = `${base.replace(/\/$/, '')}/confirm-email/${rawToken}`;
-      const text = `Hello ${user.username},\n\nThanks for signing up for OpenLinker. Confirm your email address to activate your account:\n\n${link}\n\nThis link expires in ${Math.round(this.ttlMinutes / 60)} hours. If you did not create this account, you can ignore this email.`;
+      const ttlHours = Math.round(this.ttlMinutes / 60);
+      const text = `Hello ${user.username},\n\nThanks for signing up for OpenLinker. Confirm your email address to activate your account:\n\n${link}\n\nThis link expires in ${ttlHours} hours. If you did not create this account, you can ignore this email.`;
+      const html = renderConfirmationEmailHtml({ username: user.username, link, ttlHours });
 
       await this.mailer.sendEmail({
         to: user.email,
         subject: 'Confirm your OpenLinker account',
         text,
+        html,
       });
     } catch (error) {
       // Never let a token-persistence or transport failure (e.g. DB hiccup,

--- a/apps/api/src/auth/templates/confirmation-email.template.spec.ts
+++ b/apps/api/src/auth/templates/confirmation-email.template.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * ConfirmationEmailTemplate Unit Tests
+ *
+ * @module apps/api/src/auth/templates
+ */
+import { renderConfirmationEmailHtml } from './confirmation-email.template';
+
+describe('renderConfirmationEmailHtml', () => {
+  it('renders the confirmation link as the CTA href and as a plain fallback link', () => {
+    const html = renderConfirmationEmailHtml({
+      username: 'demo_user',
+      link: 'https://app.example.com/confirm-email/raw-token',
+      ttlHours: 24,
+    });
+
+    expect(html).toContain('href="https://app.example.com/confirm-email/raw-token"');
+    expect(html).toContain('Confirm your email');
+    expect(html).toContain('OpenLinker');
+    expect(html).toContain('expires in 24 hours');
+  });
+
+  it('greets the user by username', () => {
+    const html = renderConfirmationEmailHtml({
+      username: 'demo_user',
+      link: 'https://app.example.com/confirm-email/raw-token',
+      ttlHours: 24,
+    });
+
+    expect(html).toContain('Hello demo_user');
+  });
+
+  it('escapes HTML-significant characters in the username', () => {
+    const html = renderConfirmationEmailHtml({
+      username: '<script>alert(1)</script>',
+      link: 'https://app.example.com/confirm-email/raw-token',
+      ttlHours: 24,
+    });
+
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});

--- a/apps/api/src/auth/templates/confirmation-email.template.ts
+++ b/apps/api/src/auth/templates/confirmation-email.template.ts
@@ -1,0 +1,107 @@
+/**
+ * Confirmation Email HTML Template
+ *
+ * Renders the branded HTML body for the email-confirmation message
+ * (#1650). Deliberately separate from the app's design-tokens-based web
+ * CSS system: email clients don't load external stylesheets or support
+ * most modern CSS, so every rule here is inlined on the element it
+ * affects, and the layout uses table-friendly, widely-supported
+ * properties only. Kept in `apps/api` (not `libs/core`) — this is a
+ * rendering detail of one mailer call, not a domain concern.
+ *
+ * @module apps/api/src/auth/templates
+ */
+
+export interface ConfirmationEmailTemplateInput {
+  username: string;
+  link: string;
+  ttlHours: number;
+}
+
+const BRAND_COLOR = '#4f46e5';
+const TEXT_COLOR = '#1f2430';
+const MUTED_COLOR = '#6b7280';
+const BORDER_COLOR = '#e5e7eb';
+const SURFACE_COLOR = '#f4f5f7';
+
+/**
+ * Escapes the handful of characters that matter when interpolating
+ * user-controlled text (the username) into an HTML body.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function renderConfirmationEmailHtml({
+  username,
+  link,
+  ttlHours,
+}: ConfirmationEmailTemplateInput): string {
+  const safeUsername = escapeHtml(username);
+  const safeLink = escapeHtml(link);
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Confirm your OpenLinker account</title>
+  </head>
+  <body style="margin:0; padding:0; background-color:${SURFACE_COLOR}; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${SURFACE_COLOR}; padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px; background-color:#ffffff; border:1px solid ${BORDER_COLOR}; border-radius:8px; overflow:hidden;">
+            <tr>
+              <td style="padding:32px 32px 0 32px;">
+                <span style="font-size:18px; font-weight:700; color:${TEXT_COLOR}; letter-spacing:-0.01em;">OpenLinker</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:24px 32px 0 32px;">
+                <h1 style="margin:0 0 12px 0; font-size:20px; line-height:1.3; font-weight:600; color:${TEXT_COLOR};">Confirm your email address</h1>
+                <p style="margin:0 0 20px 0; font-size:14px; line-height:1.6; color:${TEXT_COLOR};">
+                  Hello ${safeUsername}, thanks for signing up for OpenLinker. Confirm your email address to activate your account.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 32px;">
+                <table role="presentation" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td style="border-radius:6px; background-color:${BRAND_COLOR};">
+                      <a href="${safeLink}" style="display:inline-block; padding:12px 24px; font-size:14px; font-weight:600; color:#ffffff; text-decoration:none; border-radius:6px;">
+                        Confirm your email
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:24px 32px 8px 32px;">
+                <p style="margin:0; font-size:12px; line-height:1.6; color:${MUTED_COLOR};">
+                  Or paste this link into your browser:<br />
+                  <a href="${safeLink}" style="color:${BRAND_COLOR}; word-break:break-all;">${safeLink}</a>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 32px 32px 32px; border-top:1px solid ${BORDER_COLOR};">
+                <p style="margin:16px 0 0 0; font-size:12px; line-height:1.6; color:${MUTED_COLOR};">
+                  This link expires in ${ttlHours} hours. If you did not create this account, you can safely ignore this email.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}

--- a/apps/web/src/features/auth/components/ConfirmEmailStatus.test.tsx
+++ b/apps/web/src/features/auth/components/ConfirmEmailStatus.test.tsx
@@ -23,29 +23,35 @@ describe('ConfirmEmailStatus', () => {
 
     renderWithProviders(<ConfirmEmailStatus token="raw-token" />, { apiClient });
 
+    expect(await screen.findByText(/you're all set/i)).toBeInTheDocument();
     expect(
-      await screen.findByText(/your email is confirmed and your account is now active/i),
+      screen.getByText(/your email is confirmed and your account is now active/i),
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /sign in now/i })).toHaveAttribute('href', '/login');
+    expect(screen.getByRole('link', { name: /continue to sign in/i })).toHaveAttribute(
+      'href',
+      '/login',
+    );
   });
 
-  it('shows an error state with a retry option when confirmation fails', async () => {
+  it('shows an error state with a retry option and a way back to sign-in when confirmation fails', async () => {
     const confirmEmail = vi.fn().mockRejectedValue(new Error('Invalid or expired token'));
     const apiClient = createMockApiClient({ auth: { confirmEmail } });
 
     renderWithProviders(<ConfirmEmailStatus token="raw-token" />, { apiClient });
 
-    expect(await screen.findByText('Confirmation failed')).toBeInTheDocument();
+    expect(await screen.findByText(/we couldn't confirm this link/i)).toBeInTheDocument();
     expect(screen.getByText('Invalid or expired token')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /back to sign in/i })).toHaveAttribute(
+      'href',
+      '/login',
+    );
     expect(confirmEmail).toHaveBeenCalledWith({ token: 'raw-token' });
     expect(confirmEmail).toHaveBeenCalledTimes(1);
 
     confirmEmail.mockResolvedValueOnce({ ok: true });
     screen.getByRole('button', { name: /try again/i }).click();
 
-    expect(
-      await screen.findByText(/your email is confirmed and your account is now active/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/you're all set/i)).toBeInTheDocument();
     expect(confirmEmail).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/web/src/features/auth/components/ConfirmEmailStatus.tsx
+++ b/apps/web/src/features/auth/components/ConfirmEmailStatus.tsx
@@ -12,6 +12,16 @@
  * same scenario `useHandleAllegroCallback` documents as unreliable for
  * TanStack Query's mutation observer re-renders.
  *
+ * Visual design (#1650): each state gets a small "seal" glyph (a filled
+ * circle in the state's status color) as a fast, at-a-glance signal, on top
+ * of the existing text. Success stays light-touch (no bordered box — a
+ * confirmed account is good news, not something that needs a heavy
+ * container); error stays boxed in an `Alert` with `role="alert"`, because
+ * the error message is dynamic (server-supplied) and deserves the stronger,
+ * accessible treatment. The action area (`.confirm-email__actions`) is a
+ * plain vertical stack so a future "Resend confirmation email" affordance
+ * (pending #1649's backend endpoint) can slot in without a redesign.
+ *
  * @module features/auth/components
  */
 import type { ReactElement } from 'react';
@@ -19,6 +29,7 @@ import { Link } from 'react-router-dom';
 import { useConfirmEmail } from '../hooks/use-confirm-email';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
+import { StatusBadge } from '../../../shared/ui/status-badge';
 
 interface ConfirmEmailStatusProps {
   token: string;
@@ -33,28 +44,49 @@ export function ConfirmEmailStatus({ token }: ConfirmEmailStatusProps): ReactEle
 
   if (state.status === 'success') {
     return (
-      <div className="guest-page__success">
-        <p>Your email is confirmed and your account is now active.</p>
-        <Link to="/login">Sign in now</Link>
+      <div className="confirm-email" aria-live="polite">
+        <span className="confirm-email__seal confirm-email__seal--success" aria-hidden="true">
+          ✓
+        </span>
+        <h2 className="confirm-email__heading">You&apos;re all set</h2>
+        <p className="confirm-email__message">
+          Your email is confirmed and your account is now active.
+        </p>
+        <div className="confirm-email__actions">
+          <Link className="button" to="/login">
+            Continue to sign in
+          </Link>
+        </div>
       </div>
     );
   }
 
   if (state.status === 'error') {
     return (
-      <div className="guest-form__demo-callout">
-        <Alert tone="error" title="Confirmation failed">
-          {getErrorMessage(state.error)}
-        </Alert>
-        <Button type="button" tone="secondary" onClick={retry}>
-          Try again
-        </Button>
-        <p className="guest-form__footer-link">
-          <Link to="/login">Back to sign in</Link>
-        </p>
+      <div className="confirm-email" aria-live="polite">
+        <span className="confirm-email__seal confirm-email__seal--error" aria-hidden="true">
+          ✕
+        </span>
+        <h2 className="confirm-email__heading">We couldn&apos;t confirm this link</h2>
+        <Alert tone="error">{getErrorMessage(state.error)}</Alert>
+        <div className="confirm-email__actions">
+          <Link className="button" to="/login">
+            Back to sign in
+          </Link>
+          <Button type="button" tone="ghost" onClick={retry}>
+            Try again
+          </Button>
+        </div>
       </div>
     );
   }
 
-  return <p>Confirming your email…</p>;
+  return (
+    <div className="confirm-email confirm-email--pending" aria-live="polite">
+      <StatusBadge tone="info" pulse>
+        Confirming
+      </StatusBadge>
+      <p className="confirm-email__message">Confirming your email — this only takes a moment.</p>
+    </div>
+  );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3357,6 +3357,81 @@ textarea,
   text-decoration: underline;
 }
 
+/*
+ * Confirm-email states (#1650) — pending / success / error outcomes of
+ * consuming a single-use email-confirmation token. A small tone-colored
+ * "seal" glyph gives each outcome an at-a-glance signal above the text;
+ * success stays unboxed (light touch — good news needs no container),
+ * error stays boxed in `.alert` (dynamic, server-supplied message gets the
+ * stronger, accessible treatment). `.confirm-email__actions` is a plain
+ * vertical stack, deliberately generic, so a future "Resend confirmation
+ * email" action can slot in below the existing two without a redesign.
+ */
+.confirm-email {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  text-align: center;
+}
+
+.confirm-email--pending {
+  padding: var(--space-4) 0;
+}
+
+.confirm-email__seal {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.confirm-email__seal--success {
+  background: var(--status-success-soft);
+  border-color: var(--status-success-border);
+  color: var(--status-success-fg);
+}
+
+.confirm-email__seal--error {
+  background: var(--status-error-soft);
+  border-color: var(--status-error-border);
+  color: var(--status-error-fg);
+}
+
+.confirm-email__heading {
+  margin: 0;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.confirm-email__message {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.confirm-email .alert {
+  width: 100%;
+  text-align: left;
+}
+
+.confirm-email__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.confirm-email__actions .button {
+  width: 100%;
+}
+
 /* Badge group (inline badge list) */
 .badge-group {
   display: flex;


### PR DESCRIPTION
## Summary

Part of #1606. Two related surfaces from #1624 (email-confirmation activation) get a design pass:

1. `ConfirmEmailStatus.tsx` (the pending/success/error states rendered on `/confirm-email/:token`) - previously baseline text and a class name reused from an unrelated component (`guest-form__demo-callout`, meant for the register page's demo-mode info banner), which also mis-laid-out the error state (its default flex-row direction placed the Alert and buttons side by side).
2. `EmailConfirmationService.sendConfirmation`'s emailed message - previously plain-text only.

## Design choices (confirm-email page)

Invoked the `frontend-design` skill before making layout/visual decisions. This is a polish pass inside an already-established design system (tokens, `Alert`, `Button`, `StatusBadge` already exist in `index.css` / `shared/ui`), so the brief here was disciplined reuse plus one deliberate new element, not a fresh visual identity:

- **State signaling**: each outcome gets a small tone-colored "seal" glyph (a filled circle using the same `--status-success-*` / `--status-error-*` tokens as `Alert`'s left border) above the heading, so the state reads before the text does. This is the one new, purpose-built element for this page.
- **Weight asymmetry between success and error is intentional**: success stays unboxed (light touch - good news doesn't need a heavy container), error stays boxed in the existing `Alert` component with `role="alert"` (the message is dynamic/server-supplied and deserves the stronger, accessible treatment). Using the same primitive for both would have flattened that distinction.
- **CTA weighting**: "Back to sign in" is the reliable, always-works action, so it's the primary (filled) button; "Try again" is a plain-ghost secondary button, since retrying replays the same single-use token and is unlikely to change the outcome except in a genuine transient-failure case.
- **Pending state** reuses the existing `StatusBadge` `pulse` treatment (already used elsewhere in the app for "live" states) instead of inventing a new spinner - one less pattern in the codebase, not more.
- **Actions container is a plain vertical stack** (`.confirm-email__actions`), deliberately generic so a future "Resend confirmation email" button (pending #1649's backend endpoint) can slot in without a redesign.
- Copy follows the interface-voice guidance in `docs/frontend-ui-style-guide.md`: specific, active-voice headings ("We couldn't confirm this link", "You're all set") instead of generic labels, in the same conversational register as the rest of the auth flow.
- All colors/spacing/radii come from existing design tokens (`--status-*`, `--space-*`, `--radius-*`); no new hex values or one-off styling. Verified in both themes since the tokens already carry light/dark pairs.

## Email template

- Checked `MailerPort`'s `EmailMessage` (`libs/core/src/users/domain/ports/mailer.port.ts`) first - it already declares an optional `html?: string` field, and both current implementers already handle it correctly: `SmtpMailerAdapter` passes `html` straight through to nodemailer alongside `text`, and `ConsoleMailerAdapter` ignores it gracefully (no crash, dev-time logging stays text-only). **No port or adapter changes were needed** - only test coverage confirming both behaviors, including the new HTML-present case.
- Added `apps/api/src/auth/templates/confirmation-email.template.ts`: a small, self-contained `renderConfirmationEmailHtml()` function producing an inline-styled, table-based HTML email (logo/wordmark, heading, short body, one prominent CTA button, plain-link fallback, expiry footer note). Deliberately kept separate from the web app's design-tokens CSS system - email clients don't load external stylesheets or support most modern CSS, so every rule is inlined per the style guide's own carve-out for this case. User-controlled text (username) is HTML-escaped before interpolation.
- Wired into `EmailConfirmationService.sendConfirmation` - both `text` and `html` are now set on the same `EmailMessage` so any mail client picks whichever it supports.

## Scope notes

- This branch was built in parallel with #1649 (the confirm-email stuck-account bug fix, not yet merged as of this PR). #1649's scope is entirely `apps/api` with no FE files, so it should not touch anything this PR changes - but this branch may need a rebase once #1649 merges into #1606.
- A "Resend confirmation email" UI affordance is intentionally **out of scope** here: #1649's resend endpoint doesn't exist yet and has no FE wiring on this branch, so there is nothing to design against. The action area is shaped to accept it later without rework.

## Test plan

- [x] `pnpm --filter @openlinker/web lint` - 0 errors (pre-existing warnings only, none in touched files)
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] `npx vitest run src/features/auth` - 16/16 passing
- [x] `pnpm --filter @openlinker/api lint` (scoped eslint run on touched files) - 0 errors/warnings
- [x] `pnpm --filter @openlinker/api type-check` (after a full `pnpm build` to clear a pre-existing stale cross-package `.d.ts` issue unrelated to this branch) - only one pre-existing, untouched-file error remains (`registration.service.spec.ts`)
- [x] `npx jest src/auth/email-confirmation.service.spec.ts src/auth/templates src/auth/adapters/mailer.adapter.spec.ts` - 23/23 passing