### PR TITLE
fix(auth): fix stuck email-confirmation accounts, add resend + diagnostic logging

### DIFF
--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -30,6 +30,7 @@ import { PASSWORD_RESET_SERVICE_TOKEN } from './password-reset.service.interface
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { ConfirmEmailDto } from './dto/confirm-email.dto';
+import { ResendConfirmationDto } from './dto/resend-confirmation.dto';
 import type { IRefreshTokenService } from './refresh-token.service.interface';
 import { REFRESH_TOKEN_SERVICE_TOKEN } from './refresh-token.tokens';
 import type { IRegistrationService } from './registration.service.interface';
@@ -82,6 +83,7 @@ describe('AuthController', () => {
     const mockEmailConfirmationService: jest.Mocked<IEmailConfirmationService> = {
       sendConfirmation: jest.fn(),
       confirmEmail: jest.fn(),
+      resendConfirmation: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -374,6 +376,20 @@ describe('AuthController', () => {
         new UserNotPendingConfirmationException('some-user-id'),
       );
       await expect(controller.confirmEmail(dto)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('POST /auth/resend-confirmation', () => {
+    it('always returns 200 and delegates to the service', async () => {
+      emailConfirmationService.resendConfirmation.mockResolvedValue();
+      const dto: ResendConfirmationDto = Object.assign(new ResendConfirmationDto(), {
+        email: 'demo@test.com',
+      });
+
+      const result = await controller.resendConfirmation(dto);
+
+      expect(result).toEqual({ ok: true });
+      expect(emailConfirmationService.resendConfirmation).toHaveBeenCalledWith('demo@test.com');
     });
   });
 

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -56,6 +56,7 @@ import { ResetPasswordDto } from './dto/reset-password.dto';
 import { OkResponseDto } from './dto/ok-response.dto';
 import { RegisterDto } from './dto/register.dto';
 import { ConfirmEmailDto } from './dto/confirm-email.dto';
+import { ResendConfirmationDto } from './dto/resend-confirmation.dto';
 import { AuthenticatedUser } from './auth.types';
 import {
   IPasswordResetService,
@@ -187,6 +188,23 @@ export class AuthController {
       }
       throw error;
     }
+    return { ok: true };
+  }
+
+  @Public()
+  @Post('resend-confirmation')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Resend the email confirmation link for a pending account. Always returns 200 to prevent user enumeration.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Request accepted (regardless of account existence or status)',
+    type: OkResponseDto,
+  })
+  async resendConfirmation(@Body() dto: ResendConfirmationDto): Promise<OkResponseDto> {
+    await this.emailConfirmationService.resendConfirmation(dto.email);
     return { ok: true };
   }
 

--- a/apps/api/src/auth/dto/resend-confirmation.dto.ts
+++ b/apps/api/src/auth/dto/resend-confirmation.dto.ts
@@ -1,0 +1,15 @@
+/**
+ * Resend Confirmation DTO
+ *
+ * Request body for POST /auth/resend-confirmation.
+ *
+ * @module apps/api/src/auth/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail } from 'class-validator';
+
+export class ResendConfirmationDto {
+  @ApiProperty({ description: 'Email associated with the pending account', example: 'demo@example.com' })
+  @IsEmail()
+  email!: string;
+}

--- a/apps/api/src/auth/email-confirmation.service.interface.ts
+++ b/apps/api/src/auth/email-confirmation.service.interface.ts
@@ -23,6 +23,16 @@ export interface IEmailConfirmationService {
    * unknown/expired/used token.
    */
   confirmEmail(token: string): Promise<void>;
+
+  /**
+   * Issues a fresh confirmation token and resends the confirmation email for
+   * the account matching `email`, invalidating any previously-issued
+   * unconsumed token first (#1649). No-ops (never throws) for an unknown
+   * email or an account that isn't `pending_confirmation` — the caller
+   * always returns a generic 200, mirroring `PasswordResetService.requestReset`'s
+   * enumeration-safe posture.
+   */
+  resendConfirmation(email: string): Promise<void>;
 }
 
 export const EMAIL_CONFIRMATION_SERVICE_TOKEN = Symbol('IEmailConfirmationService');

--- a/apps/api/src/auth/email-confirmation.service.spec.ts
+++ b/apps/api/src/auth/email-confirmation.service.spec.ts
@@ -12,12 +12,15 @@ import {
   UserNotPendingConfirmationException,
   type EmailConfirmationTokenRepositoryPort,
   type MailerPort,
+  type UserRepositoryPort,
 } from '@openlinker/core/users';
 import { EmailConfirmationService } from './email-confirmation.service';
 import type { IUserManagementService } from '../users/user-management.service.interface';
 
-const makeUser = (email: string | null = 'demo@test.com'): User =>
-  new User('user-1', 'demo_user', email, 'hash', 'viewer', 'pending_confirmation', new Date(), new Date());
+const makeUser = (
+  email: string | null = 'demo@test.com',
+  status: User['status'] = 'pending_confirmation',
+): User => new User('user-1', 'demo_user', email, 'hash', 'viewer', status, new Date(), new Date());
 
 const makeConfig = (overrides: Record<string, string> = {}): ConfigService =>
   ({
@@ -27,6 +30,7 @@ const makeConfig = (overrides: Record<string, string> = {}): ConfigService =>
 const makeTokenRepo = (): jest.Mocked<EmailConfirmationTokenRepositoryPort> => ({
   save: jest.fn(),
   consumeToken: jest.fn(),
+  invalidateActiveForUser: jest.fn(),
 });
 
 const makeMailer = (): jest.Mocked<MailerPort> => ({
@@ -44,6 +48,23 @@ const makeUserManagementService = (): jest.Mocked<IUserManagementService> => ({
   confirmEmail: jest.fn(),
 });
 
+const makeUserRepo = (): jest.Mocked<UserRepositoryPort> => ({
+  findByUsername: jest.fn(),
+  findByEmail: jest.fn(),
+  findById: jest.fn(),
+  findAll: jest.fn(),
+  updatePasswordHash: jest.fn(),
+  updateStatus: jest.fn(),
+  updateRole: jest.fn(),
+  approveUser: jest.fn(),
+  deleteById: jest.fn(),
+  findStaleViewerAccounts: jest.fn(),
+  save: jest.fn(),
+  deactivateAdminAtomically: jest.fn(),
+  updateAdminRoleAtomically: jest.fn(),
+  deleteAdminAtomically: jest.fn(),
+});
+
 describe('EmailConfirmationService', () => {
   describe('sendConfirmation', () => {
     it('saves a hashed token and emails the confirmation link', async () => {
@@ -57,6 +78,7 @@ describe('EmailConfirmationService', () => {
         tokenRepo,
         mailer,
         userManagementService,
+        makeUserRepo(),
         makeConfig({ WEB_URL: 'https://app.example.com' }),
       );
 
@@ -80,6 +102,7 @@ describe('EmailConfirmationService', () => {
         tokenRepo,
         mailer,
         makeUserManagementService(),
+        makeUserRepo(),
         makeConfig({}),
       );
 
@@ -100,6 +123,7 @@ describe('EmailConfirmationService', () => {
         tokenRepo,
         mailer,
         makeUserManagementService(),
+        makeUserRepo(),
         makeConfig({}),
       );
 
@@ -114,6 +138,7 @@ describe('EmailConfirmationService', () => {
         tokenRepo,
         mailer,
         makeUserManagementService(),
+        makeUserRepo(),
         makeConfig({}),
       );
 
@@ -132,6 +157,7 @@ describe('EmailConfirmationService', () => {
         tokenRepo,
         makeMailer(),
         userManagementService,
+        makeUserRepo(),
         makeConfig({}),
       );
 
@@ -149,6 +175,7 @@ describe('EmailConfirmationService', () => {
         tokenRepo,
         makeMailer(),
         userManagementService,
+        makeUserRepo(),
         makeConfig({}),
       );
 
@@ -164,6 +191,7 @@ describe('EmailConfirmationService', () => {
         makeTokenRepo(),
         makeMailer(),
         makeUserManagementService(),
+        makeUserRepo(),
         makeConfig({}),
       );
 
@@ -183,6 +211,7 @@ describe('EmailConfirmationService', () => {
         tokenRepo,
         makeMailer(),
         userManagementService,
+        makeUserRepo(),
         makeConfig({}),
       );
 
@@ -202,12 +231,44 @@ describe('EmailConfirmationService', () => {
         tokenRepo,
         makeMailer(),
         userManagementService,
+        makeUserRepo(),
         makeConfig({}),
       );
 
       await expect(service.confirmEmail('raw-token')).rejects.toThrow(
         InvalidEmailConfirmationTokenException,
       );
+    });
+
+    it('logs the original exception constructor name (not its message) before remapping (#1649)', async () => {
+      const tokenRepo = makeTokenRepo();
+      tokenRepo.consumeToken.mockResolvedValue('user-1');
+      const userManagementService = makeUserManagementService();
+      userManagementService.confirmEmail.mockRejectedValue(
+        new UserNotPendingConfirmationException('user-1'),
+      );
+      const service = new EmailConfirmationService(
+        tokenRepo,
+        makeMailer(),
+        userManagementService,
+        makeUserRepo(),
+        makeConfig({}),
+      );
+      const warnSpy = jest.spyOn(
+        (service as unknown as { logger: { warn: (msg: string) => void } }).logger,
+        'warn',
+      );
+
+      await expect(service.confirmEmail('raw-token')).rejects.toThrow(
+        InvalidEmailConfirmationTokenException,
+      );
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('UserNotPendingConfirmationException'),
+      );
+      // The raw exception message carries the internal user id — must never
+      // be logged.
+      expect(warnSpy.mock.calls.some((call) => String(call[0]).includes('user-1'))).toBe(false);
     });
 
     it('does not consume the token twice for two concurrent calls with the same raw token (finding 2)', async () => {
@@ -219,6 +280,7 @@ describe('EmailConfirmationService', () => {
         tokenRepo,
         makeMailer(),
         userManagementService,
+        makeUserRepo(),
         makeConfig({}),
       );
 
@@ -230,6 +292,68 @@ describe('EmailConfirmationService', () => {
       expect(first.status).toBe('fulfilled');
       expect(second.status).toBe('rejected');
       expect(userManagementService.confirmEmail).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('resendConfirmation', () => {
+    it('invalidates the existing token and sends a fresh one for a pending_confirmation account', async () => {
+      const tokenRepo = makeTokenRepo();
+      const mailer = makeMailer();
+      const userRepo = makeUserRepo();
+      const user = makeUser();
+      userRepo.findByEmail.mockResolvedValue(user);
+      tokenRepo.save.mockResolvedValue(
+        new EmailConfirmationToken('t2', 'user-1', 'hash', new Date(), null, new Date()),
+      );
+      const service = new EmailConfirmationService(
+        tokenRepo,
+        mailer,
+        makeUserManagementService(),
+        userRepo,
+        makeConfig({ WEB_URL: 'https://app.example.com' }),
+      );
+
+      await service.resendConfirmation('demo@test.com');
+
+      expect(tokenRepo.invalidateActiveForUser).toHaveBeenCalledWith('user-1', expect.any(Date));
+      expect(tokenRepo.save).toHaveBeenCalledTimes(1);
+      expect(mailer.sendEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('no-ops for an unknown email (enumeration-safe)', async () => {
+      const tokenRepo = makeTokenRepo();
+      const userRepo = makeUserRepo();
+      userRepo.findByEmail.mockResolvedValue(null);
+      const service = new EmailConfirmationService(
+        tokenRepo,
+        makeMailer(),
+        makeUserManagementService(),
+        userRepo,
+        makeConfig({}),
+      );
+
+      await expect(service.resendConfirmation('ghost@test.com')).resolves.toBeUndefined();
+
+      expect(tokenRepo.invalidateActiveForUser).not.toHaveBeenCalled();
+      expect(tokenRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('no-ops for an account that is not pending_confirmation (enumeration-safe)', async () => {
+      const tokenRepo = makeTokenRepo();
+      const userRepo = makeUserRepo();
+      userRepo.findByEmail.mockResolvedValue(makeUser('demo@test.com', 'active'));
+      const service = new EmailConfirmationService(
+        tokenRepo,
+        makeMailer(),
+        makeUserManagementService(),
+        userRepo,
+        makeConfig({}),
+      );
+
+      await expect(service.resendConfirmation('demo@test.com')).resolves.toBeUndefined();
+
+      expect(tokenRepo.invalidateActiveForUser).not.toHaveBeenCalled();
+      expect(tokenRepo.save).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/auth/email-confirmation.service.ts
+++ b/apps/api/src/auth/email-confirmation.service.ts
@@ -19,11 +19,13 @@ import {
   EMAIL_CONFIRMATION_TOKEN_REPOSITORY_TOKEN,
   InvalidEmailConfirmationTokenException,
   MAILER_TOKEN,
+  USER_REPOSITORY_TOKEN,
   UserNotFoundException,
   UserNotPendingConfirmationException,
   type EmailConfirmationTokenRepositoryPort,
   type MailerPort,
   type User,
+  type UserRepositoryPort,
 } from '@openlinker/core/users';
 import type { IEmailConfirmationService } from './email-confirmation.service.interface';
 import {
@@ -50,6 +52,8 @@ export class EmailConfirmationService implements IEmailConfirmationService {
     private readonly mailer: MailerPort,
     @Inject(USER_MANAGEMENT_SERVICE_TOKEN)
     private readonly userManagementService: IUserManagementService,
+    @Inject(USER_REPOSITORY_TOKEN)
+    private readonly userRepository: UserRepositoryPort,
     private readonly configService: ConfigService
   ) {
     this.ttlMinutes = Number(
@@ -120,11 +124,17 @@ export class EmailConfirmationService implements IEmailConfirmationService {
     const now = new Date();
     const userId = await this.tokenRepository.consumeToken(tokenHash, now);
     if (!userId) {
+      // Distinct failure mode from the catch block below: no row matched
+      // the atomic consume — the token itself is unknown, expired, or
+      // already used. Logged so ops can tell this apart from "token was
+      // consumed fine, activation itself failed" (#1649).
+      this.logger.warn('Email confirmation failed: no matching unconsumed token');
       throw new InvalidEmailConfirmationTokenException();
     }
 
     try {
       await this.userManagementService.confirmEmail(userId);
+      this.logger.log(`Email confirmed and account activated: ${userId}`);
     } catch (error) {
       if (
         error instanceof UserNotPendingConfirmationException ||
@@ -135,13 +145,42 @@ export class EmailConfirmationService implements IEmailConfirmationService {
         // another path) or no longer exists (e.g. removed by the demo
         // account cleanup job in the window between consumeToken and this
         // call). Both exceptions carry the internal user id in their
-        // message — always remap to the same generic invalid-token error
-        // the public endpoint already returns for every other invalid-token
-        // case, regardless of which exception fired.
+        // message — never let that reach the HTTP layer or the log, so we
+        // remap to the same generic invalid-token error the public endpoint
+        // already returns for every other invalid-token case. The original
+        // exception's constructor name (never its message — that's the
+        // part carrying the user id) is logged server-side BEFORE the
+        // remap, so ops can distinguish "token fine, activation failed for
+        // an unrelated reason" from a genuinely bad token (#1649) — the
+        // regression this closes is that the previous remap discarded this
+        // distinction before `AuthController`'s own logging ever saw it.
+        this.logger.warn(
+          `Email confirmation token was consumed but activation failed: ${error.constructor.name}`
+        );
         throw new InvalidEmailConfirmationTokenException();
       }
       throw error;
     }
+  }
+
+  async resendConfirmation(email: string): Promise<void> {
+    const user = await this.userRepository.findByEmail(email);
+    if (!user || user.status !== 'pending_confirmation') {
+      // No-op for an unknown email or an account not awaiting confirmation
+      // (already active, deactivated, etc.) — mirrors
+      // PasswordResetService.requestReset's enumeration-safe posture. The
+      // caller always returns the same generic 200 regardless.
+      this.logger.debug('Resend confirmation requested for a non-pending-confirmation account');
+      return;
+    }
+
+    const now = new Date();
+    // Invalidate any previously-issued, still-unconsumed token first so a
+    // stale link from an earlier email can no longer be used once the new
+    // one is sent (#1649) — mirrors
+    // PasswordResetTokenRepositoryPort.invalidateActiveForUser.
+    await this.tokenRepository.invalidateActiveForUser(user.id, now);
+    await this.sendConfirmation(user);
   }
 
   private hashToken(rawToken: string): string {

--- a/apps/api/src/auth/registration.service.spec.ts
+++ b/apps/api/src/auth/registration.service.spec.ts
@@ -23,6 +23,7 @@ const makeUser = (username: string, status: UserStatus = 'pending'): User =>
 const makeEmailConfirmationService = (): jest.Mocked<IEmailConfirmationService> => ({
   sendConfirmation: jest.fn(),
   confirmEmail: jest.fn(),
+  resendConfirmation: jest.fn(),
 });
 
 const makeConfig = (overrides: Record<string, string> = {}): ConfigService =>
@@ -93,7 +94,7 @@ describe('RegistrationService', () => {
     const repo = makeRepo();
     repo.findByUsername.mockResolvedValue(null);
     repo.findByEmail.mockResolvedValue(makeUser('foo'));
-    const service = new RegistrationService(repo, makeConfig({ OL_REGISTRATION_ENABLED: 'true' }), makeDemoService(false), new InMemoryCacheAdapter());
+    const service = new RegistrationService(repo, makeConfig({ OL_REGISTRATION_ENABLED: 'true' }), makeDemoService(false), new InMemoryCacheAdapter(), makeEmailConfirmationService());
 
     await expect(service.register('user2', 'FOO@EXAMPLE.COM', 'pass123')).rejects.toThrow(
       UserAlreadyExistsException

--- a/apps/api/test/integration/email-confirmation.int-spec.ts
+++ b/apps/api/test/integration/email-confirmation.int-spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Email Confirmation Integration Test
+ *
+ * Regression coverage for #1649: a freshly self-registered `pending_confirmation`
+ * account got permanently stuck because `EmailConfirmationTokenRepository.consumeToken`
+ * passed the raw DB column name (`user_id`) to TypeORM's QueryBuilder#returning
+ * instead of the entity property name (`userId`). TypeORM resolves `.returning()`
+ * entries against column metadata keyed by property name, so it silently emitted
+ * no RETURNING output for the unrecognized name — the UPDATE still ran
+ * (`affected: 1`, `used_at` correctly set) but `result.raw` came back empty,
+ * so `consumeToken` always returned `null` even for a perfectly valid,
+ * unexpired, first-and-only-use token. `EmailConfirmationService.confirmEmail`
+ * then always threw `InvalidEmailConfirmationTokenException` on the very
+ * first, uncontended call — no race or double-fire needed to reproduce.
+ *
+ * Only a mock-based unit test existed for `EmailConfirmationService` before
+ * this — the token repository itself had no real-Postgres coverage, which is
+ * why a `.returning()` argument that TypeORM resolves silently (no runtime
+ * error, no type error) went unnoticed.
+ *
+ * @module apps/api/test/integration
+ */
+import { createHash } from 'crypto';
+import {
+  USER_REPOSITORY_TOKEN,
+  EMAIL_CONFIRMATION_TOKEN_REPOSITORY_TOKEN,
+  InvalidEmailConfirmationTokenException,
+  type UserRepositoryPort,
+  type EmailConfirmationTokenRepositoryPort,
+} from '@openlinker/core/users';
+import {
+  EMAIL_CONFIRMATION_SERVICE_TOKEN,
+  type IEmailConfirmationService,
+} from '../../src/auth/email-confirmation.service.interface';
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { IntegrationTestHarness } from './setup';
+
+function hashToken(rawToken: string): string {
+  return createHash('sha256').update(rawToken).digest('hex');
+}
+
+describe('Email Confirmation Integration (real Postgres)', () => {
+  let harness: IntegrationTestHarness;
+  let userRepository: UserRepositoryPort;
+  let tokenRepository: EmailConfirmationTokenRepositoryPort;
+  let emailConfirmationService: IEmailConfirmationService;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    userRepository = harness.getApp().get<UserRepositoryPort>(USER_REPOSITORY_TOKEN);
+    tokenRepository = harness
+      .getApp()
+      .get<EmailConfirmationTokenRepositoryPort>(EMAIL_CONFIRMATION_TOKEN_REPOSITORY_TOKEN);
+    emailConfirmationService = harness
+      .getApp()
+      .get<IEmailConfirmationService>(EMAIL_CONFIRMATION_SERVICE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('activates a freshly registered pending_confirmation user on a single, uncontended confirmEmail call', async () => {
+    const user = await userRepository.save({
+      username: 'demo_user_1649',
+      email: 'demo1649@test.com',
+      passwordHash: 'hash',
+      role: 'viewer',
+      status: 'pending_confirmation',
+    });
+
+    const rawToken = 'a'.repeat(64);
+    await tokenRepository.save({
+      userId: user.id,
+      tokenHash: hashToken(rawToken),
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    await emailConfirmationService.confirmEmail(rawToken);
+
+    const reloaded = await userRepository.findById(user.id);
+    expect(reloaded?.status).toBe('active');
+  });
+
+  it('still rejects an unknown/already-used token (guards against an always-succeeds regression)', async () => {
+    await expect(emailConfirmationService.confirmEmail('never-issued-token')).rejects.toThrow(
+      InvalidEmailConfirmationTokenException,
+    );
+  });
+
+  it('rejects a token that has already been consumed once', async () => {
+    const user = await userRepository.save({
+      username: 'demo_user_1649b',
+      email: 'demo1649b@test.com',
+      passwordHash: 'hash',
+      role: 'viewer',
+      status: 'pending_confirmation',
+    });
+    const rawToken = 'b'.repeat(64);
+    await tokenRepository.save({
+      userId: user.id,
+      tokenHash: hashToken(rawToken),
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    await emailConfirmationService.confirmEmail(rawToken);
+
+    await expect(emailConfirmationService.confirmEmail(rawToken)).rejects.toThrow(
+      InvalidEmailConfirmationTokenException,
+    );
+  });
+
+  describe('resendConfirmation', () => {
+    it('invalidates the previous unconsumed token so only the newest link works', async () => {
+      const user = await userRepository.save({
+        username: 'demo_user_1649c',
+        email: 'demo1649c@test.com',
+        passwordHash: 'hash',
+        role: 'viewer',
+        status: 'pending_confirmation',
+      });
+      const staleRawToken = 'c'.repeat(64);
+      await tokenRepository.save({
+        userId: user.id,
+        tokenHash: hashToken(staleRawToken),
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      });
+
+      await emailConfirmationService.resendConfirmation('demo1649c@test.com');
+
+      // The stale link from before the resend must no longer work.
+      await expect(emailConfirmationService.confirmEmail(staleRawToken)).rejects.toThrow(
+        InvalidEmailConfirmationTokenException,
+      );
+
+      const reloaded = await userRepository.findById(user.id);
+      expect(reloaded?.status).toBe('pending_confirmation');
+    });
+
+    it('does not throw for an unknown email (enumeration-safe)', async () => {
+      await expect(
+        emailConfirmationService.resendConfirmation('no-such-account@test.com'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does not throw and does not affect an already-active account', async () => {
+      const user = await userRepository.save({
+        username: 'demo_user_1649d',
+        email: 'demo1649d@test.com',
+        passwordHash: 'hash',
+        role: 'viewer',
+        status: 'active',
+      });
+
+      await expect(
+        emailConfirmationService.resendConfirmation('demo1649d@test.com'),
+      ).resolves.toBeUndefined();
+
+      const reloaded = await userRepository.findById(user.id);
+      expect(reloaded?.status).toBe('active');
+    });
+  });
+});

--- a/libs/core/src/users/domain/ports/email-confirmation-token-repository.port.ts
+++ b/libs/core/src/users/domain/ports/email-confirmation-token-repository.port.ts
@@ -23,4 +23,12 @@ export interface EmailConfirmationTokenRepositoryPort {
    * result for a given token.
    */
   consumeToken(tokenHash: string, now: Date): Promise<string | null>;
+
+  /**
+   * Marks every still-unconsumed token for `userId` as used as of `now`.
+   * Called before issuing a fresh token (resend, #1649) so a stale link
+   * from an earlier email can no longer be used once a newer one has been
+   * sent — mirrors `PasswordResetTokenRepositoryPort.invalidateActiveForUser`.
+   */
+  invalidateActiveForUser(userId: string, now: Date): Promise<void>;
 }

--- a/libs/core/src/users/infrastructure/persistence/repositories/email-confirmation-token.repository.spec.ts
+++ b/libs/core/src/users/infrastructure/persistence/repositories/email-confirmation-token.repository.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Email Confirmation Token Repository — Unit Tests
+ *
+ * Regression guard for #1649: `consumeToken`'s `.returning()` call must pass
+ * the entity PROPERTY name (`userId`), not the raw DB column name
+ * (`user_id`). TypeORM's QueryBuilder#returning resolves entries against
+ * column metadata keyed by property name and silently produces no RETURNING
+ * output for a name it can't match — the UPDATE still runs and `used_at`
+ * still gets set, but `result.raw` comes back empty, so `consumeToken`
+ * always returned `null` even for a valid, unexpired, first-use token. This
+ * test only asserts the call shape (a mocked query builder can't reproduce
+ * TypeORM's real column-metadata resolution) — the real-Postgres regression
+ * coverage lives in
+ * `apps/api/test/integration/email-confirmation.int-spec.ts`.
+ *
+ * @module libs/core/src/users/infrastructure/persistence/repositories
+ */
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import type { Repository } from 'typeorm';
+import { EmailConfirmationTokenOrmEntity } from '../entities/email-confirmation-token.orm-entity';
+import { EmailConfirmationTokenRepository } from './email-confirmation-token.repository';
+
+describe('EmailConfirmationTokenRepository', () => {
+  let repository: EmailConfirmationTokenRepository;
+
+  const buildUpdateQueryBuilder = (rawRows: Array<{ user_id: string }>) => {
+    const qb = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      returning: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue({ raw: rawRows, affected: rawRows.length, generatedMaps: [] }),
+    };
+    return qb;
+  };
+
+  const setup = async (qb: ReturnType<typeof buildUpdateQueryBuilder>): Promise<void> => {
+    const mockOrmRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+      update: jest.fn(),
+    } as unknown as jest.Mocked<Repository<EmailConfirmationTokenOrmEntity>>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailConfirmationTokenRepository,
+        { provide: getRepositoryToken(EmailConfirmationTokenOrmEntity), useValue: mockOrmRepository },
+      ],
+    }).compile();
+
+    repository = module.get<EmailConfirmationTokenRepository>(EmailConfirmationTokenRepository);
+  };
+
+  describe('consumeToken', () => {
+    it('requests RETURNING by the entity property name, not the raw DB column name', async () => {
+      const qb = buildUpdateQueryBuilder([{ user_id: 'user-1' }]);
+      await setup(qb);
+
+      const userId = await repository.consumeToken('hash', new Date());
+
+      // The regression: passing 'user_id' (raw column) here made TypeORM
+      // silently return an empty RETURNING result even though the UPDATE
+      // matched a row.
+      expect(qb.returning).toHaveBeenCalledWith(['userId']);
+      expect(userId).toBe('user-1');
+    });
+
+    it('returns null when no row matches (unknown/expired/already-used token)', async () => {
+      const qb = buildUpdateQueryBuilder([]);
+      await setup(qb);
+
+      const userId = await repository.consumeToken('hash', new Date());
+
+      expect(userId).toBeNull();
+    });
+  });
+});

--- a/libs/core/src/users/infrastructure/persistence/repositories/email-confirmation-token.repository.ts
+++ b/libs/core/src/users/infrastructure/persistence/repositories/email-confirmation-token.repository.ts
@@ -8,7 +8,7 @@
  */
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { EmailConfirmationToken } from '../../../domain/entities/email-confirmation-token.entity';
 import type { EmailConfirmationTokenRepositoryPort } from '../../../domain/ports/email-confirmation-token-repository.port';
 import { EmailConfirmationTokenOrmEntity } from '../entities/email-confirmation-token.orm-entity';
@@ -41,11 +41,22 @@ export class EmailConfirmationTokenRepository implements EmailConfirmationTokenR
       .where('token_hash = :tokenHash', { tokenHash })
       .andWhere('used_at IS NULL')
       .andWhere('expires_at > :now', { now })
-      .returning(['user_id'])
+      // Entity PROPERTY name ('userId'), not the raw DB column name
+      // ('user_id') — TypeORM's QueryBuilder#returning resolves entries
+      // against column metadata keyed by property name and silently emits
+      // no RETURNING output for a name it can't match (#1649: `affected: 1`
+      // but `raw: []`, so this always returned null even though the token
+      // was correctly consumed — the account got permanently stuck in
+      // `pending_confirmation` with a burned, unusable token).
+      .returning(['userId'])
       .execute();
 
     const row = (result.raw as Array<{ user_id: string }>)[0];
     return row ? row.user_id : null;
+  }
+
+  async invalidateActiveForUser(userId: string, now: Date): Promise<void> {
+    await this.ormRepository.update({ userId, usedAt: IsNull() }, { usedAt: now });
   }
 
   private toDomain(entity: EmailConfirmationTokenOrmEntity): EmailConfirmationToken {


### PR DESCRIPTION
Part of #1606.
Closes #1649.

## Root cause

`EmailConfirmationTokenRepository.consumeToken` called TypeORM's QueryBuilder `.returning(['user_id'])` using the raw DB column name instead of the entity property name (`userId`). TypeORM resolves `.returning()` entries against column metadata keyed by property name, so it silently produced no RETURNING output for a name it couldn't match: the atomic `UPDATE ... SET used_at = ...` still ran and matched the row (`affected: 1`, `used_at` correctly set), but `result.raw` came back as an empty array. `consumeToken` read `result.raw[0]` and, finding nothing, returned `null` even though the token was completely valid and had just been consumed.

`EmailConfirmationService.confirmEmail` treats a `null` return from `consumeToken` as "unknown/expired/used token" and throws `InvalidEmailConfirmationTokenException`. This means every single confirmation attempt failed on the very first, uncontended call - no race condition or double-fire (e.g. link-prefetching) was needed to reproduce it. The account was left permanently stuck in `pending_confirmation` with a burned, single-use token that could never be replayed.

This was caught with a real-Postgres integration test that seeds a `pending_confirmation` user, saves a valid token via the real repository, and calls the real `EmailConfirmationService.confirmEmail` once - it reproduced the bug immediately. No integration test previously existed for the token repository; the existing coverage was entirely mock-based, which is why a `.returning()` argument that TypeORM resolves silently (no runtime error, no type error) went unnoticed.

## Changes

1. **Root-cause fix**: `consumeToken` now calls `.returning(['userId'])` (entity property name). The RETURNING output is still keyed by the raw column name (`user_id`) in the driver's result, so the existing `row.user_id` read is unchanged.
2. **Diagnostic-logging fix**: `EmailConfirmationService.confirmEmail` now logs a non-identifying discriminant server-side before remapping `UserNotPendingConfirmationException` / `UserNotFoundException` to the generic `InvalidEmailConfirmationTokenException` - the original exception's constructor name (never its message, which carries the internal user id). A separate log line also distinguishes the "no matching unconsumed token" case (bad/expired/already-used token) from "token consumed fine, activation itself failed". `AuthController`'s client-facing message stays generic and unchanged.
3. **Resend-confirmation endpoint**: `POST /auth/resend-confirmation` accepts an email and always returns a generic 200, mirroring `PasswordResetService.requestReset`'s enumeration-safe posture. It no-ops for an unknown email or an account that isn't `pending_confirmation`. For a matching pending account it invalidates any previously-issued unconsumed token (new `EmailConfirmationTokenRepositoryPort.invalidateActiveForUser`, mirroring the password-reset token repository) before issuing and sending a fresh one, so a stale link from an earlier email stops working once a new one is sent.

## Tests

- `apps/api/test/integration/email-confirmation.int-spec.ts` (new, real Postgres via Testcontainers): reproduces the original bug end to end (single confirmEmail call on a freshly seeded pending_confirmation user + valid token now succeeds), guards against an always-succeeds regression (unknown and already-consumed tokens are still rejected), and covers the resend flow (old token invalidated, unknown-email no-op, already-active no-op).
- `libs/core/.../email-confirmation-token.repository.spec.ts` (new, unit): asserts `consumeToken` calls `.returning(['userId'])`, guarding the exact regression shape at the source level.
- `apps/api/src/auth/email-confirmation.service.spec.ts`: updated for the new `userRepository` dependency, plus new tests for the diagnostic log and `resendConfirmation`.
- `apps/api/src/auth/auth.controller.spec.ts`: new test for the resend-confirmation endpoint.
- Fixed a pre-existing missing-argument bug in `registration.service.spec.ts` (unrelated to this bug, caught by type-check while touching the file).

## Quality gate

- `pnpm --filter @openlinker/core build`: pass
- `pnpm --filter @openlinker/core lint`: pass (0 errors, pre-existing warnings only)
- `pnpm --filter @openlinker/api lint`: pass (0 errors, pre-existing warnings only)
- `pnpm --filter @openlinker/core type-check`: pass
- `pnpm --filter @openlinker/api type-check`: pass
- `pnpm --filter @openlinker/core test -- users`: 22/22 pass
- `pnpm --filter @openlinker/api test -- src/auth src/users`: 186/186 pass
- `pnpm --filter @openlinker/api test` (full unit suite): 816/816 pass
- `pnpm --filter @openlinker/api test:integration -- email-confirmation` (real Postgres via Testcontainers): 6/6 pass
- No ORM entity/schema changes, so no migration needed.