### PR TITLE
fix(mappings): relax read endpoints to admin/operator/viewer role

### DIFF
--- a/apps/api/src/mappings/http/__tests__/mapping-roles-guard.spec.ts
+++ b/apps/api/src/mappings/http/__tests__/mapping-roles-guard.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Mapping controllers role-guard coverage (#1652)
+ *
+ * Verifies the demo-viewer-read-access relaxation applied to
+ * `MappingOptionsController` (class-level, every method is a read) and
+ * `MappingsController` (per-method override on exactly the 5 GET handlers,
+ * class-level `@Roles('admin')` default still gating all 6 PUT/DELETE
+ * writes). Exercises the real `RolesGuard` + `Reflector` against the actual
+ * controller prototypes so the test fails if a future edit drifts the role
+ * set on any of these handlers.
+ *
+ * @module apps/api/src/mappings/http/__tests__
+ */
+import type { ExecutionContext } from '@nestjs/common';
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { UserRole } from '@openlinker/core/users';
+
+import { RolesGuard } from '../../../auth/guards/roles.guard';
+import { MappingOptionsController } from '../mapping-options.controller';
+import { MappingsController } from '../mappings.controller';
+
+function createContext(
+  Controller: new (...args: never[]) => unknown,
+  methodName: string,
+  role: UserRole
+): ExecutionContext {
+  const handler = (Controller.prototype as unknown as Record<string, unknown>)[methodName];
+  return {
+    getHandler: () => handler,
+    getClass: () => Controller,
+    switchToHttp: () => ({
+      getRequest: () => ({ user: { role } }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+const MAPPING_OPTIONS_READ_HANDLERS = [
+  'getDestinationCarriers',
+  'getDestinationOrderStatuses',
+  'getDestinationPaymentMethods',
+  'getSourceOrderStatuses',
+  'getSourceDeliveryMethods',
+  'getSourcePaymentMethods',
+  'getDestinationCategories',
+  'getSourceCategories',
+];
+
+const MAPPINGS_READ_HANDLERS = [
+  'getStatusMappings',
+  'getCarrierMappings',
+  'getOrderStateMappings',
+  'getPaymentMappings',
+  'getCategoryMappings',
+];
+
+const MAPPINGS_WRITE_HANDLERS = [
+  'upsertStatusMappings',
+  'upsertCarrierMappings',
+  'upsertOrderStateMappings',
+  'upsertPaymentMappings',
+  'upsertCategoryMapping',
+  'deleteCategoryMapping',
+];
+
+describe('Mapping controllers role-guard coverage (#1652)', () => {
+  let guard: RolesGuard;
+
+  beforeEach(() => {
+    guard = new RolesGuard(new Reflector());
+  });
+
+  describe('MappingOptionsController — every route is a read, class-level relaxed', () => {
+    it.each(MAPPING_OPTIONS_READ_HANDLERS)('%s allows viewer', (methodName) => {
+      const context = createContext(MappingOptionsController, methodName, 'viewer');
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it.each(MAPPING_OPTIONS_READ_HANDLERS)('%s allows operator', (methodName) => {
+      const context = createContext(MappingOptionsController, methodName, 'operator');
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it.each(MAPPING_OPTIONS_READ_HANDLERS)('%s allows admin', (methodName) => {
+      const context = createContext(MappingOptionsController, methodName, 'admin');
+      expect(guard.canActivate(context)).toBe(true);
+    });
+  });
+
+  describe('MappingsController — 5 read handlers relaxed via method-level override', () => {
+    it.each(MAPPINGS_READ_HANDLERS)('%s allows viewer', (methodName) => {
+      const context = createContext(MappingsController, methodName, 'viewer');
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it.each(MAPPINGS_READ_HANDLERS)('%s allows operator', (methodName) => {
+      const context = createContext(MappingsController, methodName, 'operator');
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it.each(MAPPINGS_READ_HANDLERS)('%s allows admin', (methodName) => {
+      const context = createContext(MappingsController, methodName, 'admin');
+      expect(guard.canActivate(context)).toBe(true);
+    });
+  });
+
+  describe('MappingsController — 6 write handlers stay admin-only (class-level fallback)', () => {
+    it.each(MAPPINGS_WRITE_HANDLERS)('%s rejects viewer', (methodName) => {
+      const context = createContext(MappingsController, methodName, 'viewer');
+      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+    });
+
+    it.each(MAPPINGS_WRITE_HANDLERS)('%s rejects operator (unchanged baseline — no operator write access)', (methodName) => {
+      const context = createContext(MappingsController, methodName, 'operator');
+      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+    });
+
+    it.each(MAPPINGS_WRITE_HANDLERS)('%s allows admin', (methodName) => {
+      const context = createContext(MappingsController, methodName, 'admin');
+      expect(guard.canActivate(context)).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/mappings/http/mapping-options.controller.ts
+++ b/apps/api/src/mappings/http/mapping-options.controller.ts
@@ -25,6 +25,11 @@
  * they're already live-data and the cache is the right architecture for
  * tree-structured taxonomies; only the URL changed.
  *
+ * Every route here is a read-only `@Get`, so the class-level `@Roles` is
+ * relaxed to admin/operator/viewer (#1652) — a demo viewer can browse the
+ * bulk-offer-wizard category tree and other mapping-option dropdowns without
+ * a 403.
+ *
  * @module apps/api/src/mappings/http
  */
 
@@ -80,7 +85,7 @@ const PLATFORM_PRESTASHOP = 'prestashop';
 
 type ResolvedSide = 'source' | 'destination';
 
-@Roles('admin')
+@Roles('admin', 'operator', 'viewer')
 @ApiBearerAuth()
 @ApiTags('mappings')
 @Controller('connections/:connectionId/mappings/options')

--- a/apps/api/src/mappings/http/mappings.controller.ts
+++ b/apps/api/src/mappings/http/mappings.controller.ts
@@ -3,7 +3,10 @@
  *
  * HTTP REST API endpoints for connection-scoped mapping configuration.
  * Supports CRUD for status, carrier, and payment mapping types.
- * All endpoints require admin role and JWT authentication.
+ * Write endpoints (PUT/DELETE) require admin role (class-level default);
+ * the 5 read (GET) endpoints are relaxed to admin/operator/viewer via a
+ * per-method override (#1652) so demo viewers can inspect mapping
+ * configuration without a 403.
  *
  * @module apps/api/src/mappings/http
  */
@@ -46,6 +49,7 @@ export class MappingsController {
   // ── Status mappings ──────────────────────────────────────────────────────
 
   @Get('status')
+  @Roles('admin', 'operator', 'viewer')
   @ApiOperation({ summary: 'Get status mappings for a connection' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [StatusMappingResponseDto] })
@@ -75,6 +79,7 @@ export class MappingsController {
   // ── Carrier mappings ─────────────────────────────────────────────────────
 
   @Get('carriers')
+  @Roles('admin', 'operator', 'viewer')
   @ApiOperation({ summary: 'Get carrier mappings for a connection' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [CarrierMappingResponseDto] })
@@ -104,6 +109,7 @@ export class MappingsController {
   // ── Order-state mappings (outbound OL→destination, #862) ──────────────────
 
   @Get('order-states')
+  @Roles('admin', 'operator', 'viewer')
   @ApiOperation({ summary: 'Get OL→destination order-state mappings for a connection' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [OrderStateMappingResponseDto] })
@@ -136,6 +142,7 @@ export class MappingsController {
   // ── Payment mappings ─────────────────────────────────────────────────────
 
   @Get('payments')
+  @Roles('admin', 'operator', 'viewer')
   @ApiOperation({ summary: 'Get payment mappings for a connection' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [PaymentMappingResponseDto] })
@@ -165,6 +172,7 @@ export class MappingsController {
   // ── Category mappings ───────────────────────────────────────────────────
 
   @Get('categories')
+  @Roles('admin', 'operator', 'viewer')
   @ApiOperation({ summary: 'Get category mappings for a connection' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [CategoryMappingResponseDto] })


### PR DESCRIPTION
## Problem

Part of #1606. `MappingOptionsController` (`connections/:connectionId/mappings/options`) and `MappingsController` (`connections/:connectionId/mappings`) both carry a class-level `@Roles('admin')` decorator that gates every method. This blocks demo viewers with a 403 in two places:
- the bulk-create offer wizard's edit-offer step, when browsing the destination/source category tree ("Unable to load categories - Insufficient permissions")
- the connection Mappings tab ("Unable to load mapping configuration - Insufficient permissions")

## Change

- `MappingOptionsController`: relaxed the class-level `@Roles('admin')` to `@Roles('admin', 'operator', 'viewer')`. Verified this controller is 100% read-only (8 `@Get` handlers, zero writes), so a blanket class-level relaxation is safe.
- `MappingsController`: kept the class-level `@Roles('admin')` as the default (so writes stay locked down), and added a per-method `@Roles('admin', 'operator', 'viewer')` override on exactly the 5 read handlers: `GET status`, `GET carriers`, `GET order-states`, `GET payments`, `GET categories`. The 6 write handlers (`PUT status`, `PUT carriers`, `PUT order-states`, `PUT payments`, `PUT categories/:prestashopCategoryId`, `DELETE categories/:prestashopCategoryId`) are untouched and still resolve to admin-only via the class-level fallback.

No changes to `operator` write access anywhere - that's tracked separately (per the issue's own scoping note).

## Tests

Added `apps/api/src/mappings/http/__tests__/mapping-roles-guard.spec.ts`, exercising the real `RolesGuard` + `Reflector` against the actual controller prototypes:
- viewer/operator/admin all pass on all 8 `MappingOptionsController` handlers
- viewer/operator/admin all pass on the 5 `MappingsController` read handlers
- viewer and operator are rejected (403) on all 6 `MappingsController` write handlers; admin passes

Checked `apps/api/src/auth/write-guard-coverage.spec.ts` - it does not currently cover either controller, and adding them would not fit that invariant's opt-in-per-endpoint model (`MappingsController` still relies on a class-level fallback for its writes, which that spec's metadata-only-on-handler check doesn't see), so it was left as-is.

## Quality gate

- `pnpm --filter @openlinker/api lint` - clean on the changed files (one pre-existing, unrelated error in `src/plugins.ts`, confirmed present before this change)
- `pnpm --filter @openlinker/api type-check` - clean (one pre-existing, unrelated failure in `src/auth/registration.service.spec.ts`, confirmed present before this change)
- `pnpm --filter @openlinker/api test -- src/mappings src/auth` - 207 passed (the same pre-existing `registration.service.spec.ts` failure, unrelated to this change)

Closes #1652