### PR TITLE
fix(demo): pass WEB_URL through to the api container tracking WEB_HOST_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,6 +279,14 @@ services:
       JWT_SECRET: '${JWT_SECRET:-development-secret-key-change-in-production}'
       JWT_EXPIRES_IN: '${JWT_EXPIRES_IN:-1d}'
       OL_PII_HASH_SALT: '${OL_PII_HASH_SALT:-development-pii-hash-salt-change-in-production}'
+      # Base URL used to build confirm-email/reset-password links emailed to
+      # users (EmailConfirmationService, MailerPasswordResetNotifierAdapter).
+      # Defaults to the demo web service's own published port (WEB_HOST_PORT,
+      # docker-compose.demo.yml) rather than a second, unrelated hardcoded
+      # default — so the two stay in sync automatically instead of drifting
+      # like the Vite-preview-port default (4173) that neither compose file
+      # ever overrode (#1647).
+      WEB_URL: '${WEB_URL:-http://localhost:${WEB_HOST_PORT:-8090}}'
     ports:
       - '${OL_BIND_ADDRESS:-127.0.0.1}:${API_HOST_PORT:-3000}:3000'
     depends_on:

--- a/docs/one-command-demo-setup-guide.md
+++ b/docs/one-command-demo-setup-guide.md
@@ -95,6 +95,7 @@ demo-safe values. Listed here so you know what's in play if you want to override
 | `NODE_ENV` | `production` | Production posture for the app tier. |
 | `OL_BOOTSTRAP_ADMIN_PASSWORD` | `admin` | Keeps the seeded admin login `admin` / `admin` under `NODE_ENV=production`. |
 | `OL_CORS_ORIGIN` | `http://localhost:8090` | API CORS allow-list — must match the UI origin or login fails with a CORS "NetworkError". |
+| `WEB_URL` | `http://localhost:8090` (tracks `WEB_HOST_PORT`) | Base URL used to build confirm-email / reset-password links emailed to users - stays in sync with the `web` service's published port instead of a second hardcoded default. |
 | `VITE_API_BASE_URL` | `http://localhost:3000` | Baked into the UI bundle **at build time** — the browser-reachable API origin. |
 | `DB_*` / `REDIS_*` | `postgres` / `redis` (service names) | App tier reaches Postgres/Redis over the Compose network. |
 | `JWT_SECRET`, `JWT_EXPIRES_IN` | dev values | Auth token signing. |


### PR DESCRIPTION
## Problem

`EmailConfirmationService.sendConfirmation` and `MailerPasswordResetNotifierAdapter` (used by the forgot-password flow) both build the emailed link from `configService.get('WEB_URL', 'http://localhost:4173')`. Neither `docker-compose.yml` nor the demo overlay declared a `WEB_URL` entry for the `api` service, so this always fell back to the hardcoded `http://localhost:4173` default - the Vite preview port, not the port the demo's `web` service is actually published on (`WEB_HOST_PORT`, default `8090`).

Confirmed live: registering on a demo stack with `WEB_HOST_PORT=8090` produced a confirmation email linking to an unreachable `http://localhost:4173/confirm-email/{token}`.

## Fix

Added a `WEB_URL` entry to the `api` service's `environment` block in `docker-compose.yml`, defaulting to `http://localhost:${WEB_HOST_PORT:-8090}` so it tracks whatever port the `web` service is actually published on instead of introducing a second, independent hardcoded default. Verified with `docker compose config` that the nested variable substitution resolves correctly (both with and without a `WEB_HOST_PORT` override), and that the demo overlay's environment merge doesn't clobber it.

Also documented the baked-in default in `docs/one-command-demo-setup-guide.md`'s "Already set for you" table.

## Scope confirmation

- `docker-compose.demo.yml`'s `api.environment` block is a dictionary that Compose *merges* with the base file's (not an `!override`/`!reset` list), so declaring `WEB_URL` once in `docker-compose.yml` is sufficient for both `pnpm dev:stack:up` and `pnpm demo:up` - no change needed in the demo overlay itself.
- Both `EmailConfirmationService` (confirmation emails) and `MailerPasswordResetNotifierAdapter` (password-reset emails) read the exact same `WEB_URL` config key with the same `http://localhost:4173` fallback, so this fix benefits both flows.

## Test plan

- [x] `docker compose -f docker-compose.yml -f docker-compose.demo.yml config` with a dummy `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` shows `WEB_URL: http://localhost:8090` for the `api` service
- [x] Same command with `WEB_HOST_PORT=9999` shows `WEB_URL: http://localhost:9999`, confirming it tracks the override
- [x] `docker compose -f docker-compose.yml config` (base file alone) also resolves `WEB_URL` correctly

Part of #1606
Closes #1647