### PR TITLE
fix(invoicing): gate invoice issuing behind invoices:write permission

### DIFF
--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -50,7 +50,9 @@ import type { IIntegrationsService } from '@openlinker/core/integrations';
 import { CONNECTION_PORT_TOKEN } from '@openlinker/core/identifier-mapping';
 import type { Connection, ConnectionPort } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
+import 'reflect-metadata';
 import type { AuthenticatedUser } from '../../auth/auth.types';
+import { ROLES_KEY } from '../../auth/decorators/roles.decorator';
 import { InvoicingController } from './invoicing.controller';
 
 const NOW = new Date('2026-06-23T10:00:00.000Z');
@@ -1752,6 +1754,16 @@ describe('InvoicingController', () => {
       expect(markPaid).toHaveBeenCalled();
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('correction document'));
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('issueInvoice permission gate (#1613)', () => {
+    it('carries @Roles(admin) so RolesGuard returns 403 for a non-admin caller', () => {
+      const roles = Reflect.getMetadata(
+        ROLES_KEY,
+        InvoicingController.prototype.issueInvoice,
+      ) as string[] | undefined;
+      expect(roles).toEqual(['admin']);
     });
   });
 });

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.test.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.test.tsx
@@ -15,7 +15,13 @@
 import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
-import { renderWithProviders, createMockApiClient, sampleConnection, findToastDescription } from '../../../test/test-utils';
+import {
+  renderWithProviders,
+  createMockApiClient,
+  sampleConnection,
+  findToastDescription,
+  createAuthenticatedSessionAdapter,
+} from '../../../test/test-utils';
 import { ApiError } from '../../../shared/api/api-error';
 import type { Connection } from '../../connections';
 import type { OrderRecord } from '../../orders';
@@ -26,6 +32,27 @@ afterEach(cleanup);
 
 const ORDER_ID = 'ord_1';
 const CONN_ID = 'conn_inv';
+
+/** Authenticated admin session — holds `invoices:write` (#1613). */
+const adminSession = { sessionAdapter: createAuthenticatedSessionAdapter() };
+
+/** Authenticated viewer session — read-only, no `invoices:write` (#1613). */
+const viewerSession = {
+  sessionAdapter: createAuthenticatedSessionAdapter({
+    id: 'u2',
+    username: 'viewer',
+    email: null,
+    role: 'viewer',
+    permissions: ['orders:read', 'invoices:read'],
+  }),
+};
+
+function demoApiClient(overrides: Parameters<typeof createMockApiClient>[0] = {}): ReturnType<typeof createMockApiClient> {
+  return createMockApiClient({
+    system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+    ...overrides,
+  });
+}
 
 const order: OrderRecord = {
   internalOrderId: ORDER_ID,
@@ -110,6 +137,7 @@ describe('OrderInvoicePanel — capability/toggle gate', () => {
   it('renders when an active connection has Invoicing enabled', async () => {
     renderWithProviders(<OrderInvoicePanel order={order} />, {
       apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()) } }),
+      ...adminSession,
     });
     expect(await screen.findByRole('button', { name: /issue invoice/i })).toBeInTheDocument();
   });
@@ -136,6 +164,7 @@ describe('OrderInvoicePanel — capability/toggle gate', () => {
     const getForOrder = vi.fn().mockRejectedValue(notFound());
     renderWithProviders(<OrderInvoicePanel order={order} />, {
       apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([b, a]) }, invoicing: { getForOrder } }),
+      ...adminSession,
     });
     const picker = await screen.findByRole('combobox', { name: /invoicing connection/i });
     await user.selectOptions(picker, 'conn_zzz');
@@ -148,6 +177,7 @@ describe('OrderInvoicePanel — display states', () => {
   it('not-issued (404) ⇒ "Not issued" badge + enabled Issue button', async () => {
     renderWithProviders(<OrderInvoicePanel order={order} />, {
       apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()) } }),
+      ...adminSession,
     });
     expect(await screen.findByText('Not issued')).toBeInTheDocument();
     expect(await screen.findByRole('button', { name: /issue invoice/i })).toBeEnabled();
@@ -156,6 +186,7 @@ describe('OrderInvoicePanel — display states', () => {
   it('not-issued ⇒ document-type picker fills the row beside a signal-orange primary Issue action (#1622)', async () => {
     const { container } = renderWithProviders(<OrderInvoicePanel order={order} />, {
       apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()) } }),
+      ...adminSession,
     });
     // The picker + primary action share one row (mockup section 02 layout).
     const issue = await screen.findByRole('button', { name: /issue invoice/i });
@@ -192,6 +223,7 @@ describe('OrderInvoicePanel — display states', () => {
         connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) },
         invoicing: { getForOrder: vi.fn().mockResolvedValue(makeInvoice({ status: 'failed', failureMode: 'rejected', failureCode: 'provider-rejected' })) },
       }),
+      ...adminSession,
     });
     // Both the failure copy and the retry hint contain "rejected"
     const msgs = await screen.findAllByText(/rejected/i);
@@ -237,6 +269,7 @@ describe('OrderInvoicePanel — issue flow', () => {
     const issue = vi.fn().mockResolvedValue(makeInvoice());
     renderWithProviders(<OrderInvoicePanel order={order} />, {
       apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()), issue } }),
+      ...adminSession,
     });
     await user.click(await screen.findByRole('button', { name: /issue invoice/i }));
     await waitFor(() => expect(issue).toHaveBeenCalledTimes(1));
@@ -250,6 +283,7 @@ describe('OrderInvoicePanel — issue flow', () => {
     const issue = vi.fn().mockResolvedValue(makeInvoice({ documentType: 'receipt' }));
     renderWithProviders(<OrderInvoicePanel order={order} />, {
       apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()), issue } }),
+      ...adminSession,
     });
     await screen.findByRole('button', { name: /issue invoice/i });
     await user.selectOptions(screen.getByRole('combobox', { name: /document type/i }), 'receipt');
@@ -266,6 +300,7 @@ describe('OrderInvoicePanel — issue flow', () => {
       .mockRejectedValue(new ApiError(leaky, 400, { error: 'CapabilityNotEnabledException', message: leaky }));
     renderWithProviders(<OrderInvoicePanel order={order} />, {
       apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) }, invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()), issue } }),
+      ...adminSession,
     });
     await user.click(await screen.findByRole('button', { name: /issue invoice/i }));
     expect(await findToastDescription(/Invoicing is not enabled for this connection/i)).toBeInTheDocument();
@@ -292,5 +327,56 @@ describe('OrderInvoicePanel — regulatory badge (data gate)', () => {
     });
     await screen.findByRole('link', { name: /invoice pdf/i });
     expect(screen.queryByText(/KSeF:/i)).toBeNull();
+  });
+});
+
+describe('OrderInvoicePanel — write-access gating (#1613, mirrors #1615)', () => {
+  it('demo read-only viewer sees the Issue button visible-but-disabled', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: demoApiClient({
+        connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) },
+        invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()) },
+      }),
+      ...viewerSession,
+    });
+    expect(await screen.findByRole('button', { name: /issue invoice/i })).toBeDisabled();
+  });
+
+  it('demo read-only viewer sees the Retry button visible-but-disabled', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: demoApiClient({
+        connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) },
+        invoicing: {
+          getForOrder: vi.fn().mockResolvedValue(
+            makeInvoice({ status: 'failed', failureMode: 'rejected', failureCode: 'provider-rejected' }),
+          ),
+        },
+      }),
+      ...viewerSession,
+    });
+    expect(await screen.findByRole('button', { name: /retry/i })).toBeDisabled();
+  });
+
+  it('keeps the existing hide-when-missing behaviour for an unauthorized non-demo viewer', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) },
+        invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()) },
+      }),
+      ...viewerSession,
+    });
+    await screen.findByText('Not issued');
+    expect(screen.queryByRole('button', { name: /issue invoice/i })).not.toBeInTheDocument();
+  });
+
+  it('operator/admin session issuing is unaffected — Issue button renders enabled outside demo mode', async () => {
+    renderWithProviders(<OrderInvoicePanel order={order} />, {
+      apiClient: createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([invoicingConnection]) },
+        invoicing: { getForOrder: vi.fn().mockRejectedValue(notFound()) },
+      }),
+      ...adminSession,
+    });
+    expect(await screen.findByRole('button', { name: /issue invoice/i })).toBeEnabled();
   });
 });

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
@@ -16,6 +16,14 @@
  *   - canRetryInvoice() is the single gate (failed+rejected only)
  *   - in-doubt shows "Check {provider}"/"Mark resolved" (no-op for Wave A)
  *
+ * Write-access gating (#1613): the Issue/Retry affordances are gated behind
+ * the `invoices:write` permission via `useWriteAccess`, reusing the SAME
+ * visible-but-disabled-with-a-tooltip pattern as `ConnectionActionsPanel`
+ * (#1615) rather than only reacting to the resulting 403 after the fact. A
+ * demo read-only viewer still sees the action (disabled, `ReadOnlyLock`
+ * tooltip); a genuinely unauthorized non-demo session keeps the pre-existing
+ * hide-when-missing behaviour.
+ *
  * @module apps/web/src/features/invoicing/components
  */
 import { useMemo, useState, type ReactElement } from 'react';
@@ -35,6 +43,10 @@ import { Select } from '../../../shared/ui/select';
 import { KeyValueList, type KeyValueItem } from '../../../shared/ui/key-value-list';
 import { ApiError } from '../../../shared/api/api-error';
 import { usePlatform } from '../../../shared/plugins';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
+import { useDemoMode } from '../../system';
 
 import type { OrderRecord } from '../../orders';
 import type { InvoiceRecord } from '../api/invoicing.types';
@@ -173,6 +185,9 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
 
   const invoiceQuery = useOrderInvoiceQuery(order.internalOrderId, invoicingConnectionId);
   const issueMutation = useIssueInvoiceMutation();
+
+  const demoMode = useDemoMode();
+  const write = useWriteAccess('invoices:write', demoMode);
 
   // Per-provider plugin slots (resolved via platformType — ZERO literal strings here)
   const platform = usePlatform(invoicingConnection?.platformType);
@@ -405,7 +420,7 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
               </span>
             </div>
           </div>
-          {canRetryInvoice(invoice) ? (
+          {canRetryInvoice(invoice) && write.visible ? (
             <div className="order-invoice-panel__actions">
               <span className="text-muted" style={{ fontSize: '11.5px' }}>
                 {t(
@@ -414,13 +429,15 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
                 )}
               </span>
               <span className="spacer" />
-              <Button
-                tone="secondary"
-                onClick={handleIssue}
-                disabled={issueMutation.isPending}
-              >
-                {t('invoice.action.retry', 'Retry')}
-              </Button>
+              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                <Button
+                  tone="secondary"
+                  onClick={handleIssue}
+                  disabled={issueMutation.isPending || write.demoReadOnly}
+                >
+                  {t('invoice.action.retry', 'Retry')}
+                </Button>
+              </ReadOnlyLock>
             </div>
           ) : null}
         </>
@@ -480,17 +497,19 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
       ) : null}
 
       {/* ── Not issued: DocumentTypeSelect (fills the row) + primary Issue ── */}
-      {!requiresConnectionPick && !invoiceQuery.isError && !invoiceQuery.isLoading && displayStatus === 'not-issued' ? (
+      {!requiresConnectionPick && !invoiceQuery.isError && !invoiceQuery.isLoading && displayStatus === 'not-issued' && write.visible ? (
         <div className="order-invoice-panel__actions order-invoice-panel__actions--issue">
           <DocumentTypeSelect
             value={documentType}
             onChange={setDocumentType}
-            disabled={issueMutation.isPending}
+            disabled={issueMutation.isPending || write.demoReadOnly}
             className="order-invoice-panel__doc-type"
           />
-          <Button tone="primary" onClick={handleIssue} disabled={issueMutation.isPending}>
-            {t('invoice.action.issue', 'Issue invoice')}
-          </Button>
+          <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+            <Button tone="primary" onClick={handleIssue} disabled={issueMutation.isPending || write.demoReadOnly}>
+              {t('invoice.action.issue', 'Issue invoice')}
+            </Button>
+          </ReadOnlyLock>
         </div>
       ) : null}
     </section>

--- a/apps/web/src/features/invoicing/lib/issue-error-message.test.ts
+++ b/apps/web/src/features/invoicing/lib/issue-error-message.test.ts
@@ -49,6 +49,15 @@ describe('resolveIssueErrorMessage', () => {
     expect(resolveIssueErrorMessage(error, t)).toBe(msg);
   });
 
+  it('403 ⇒ permission-specific fixed copy (#1613), no error.message echo', () => {
+    const error = new ApiError('Forbidden resource', 403, { message: 'Forbidden resource' });
+    const result = resolveIssueErrorMessage(error, t);
+    expect(result).toBe(
+      "Can't issue invoices in demo mode - demo accounts are read-only; issuing an invoice needs an operator account.",
+    );
+    expect(result).not.toContain('Forbidden resource');
+  });
+
   it('409 ⇒ already-issued fixed copy', () => {
     const error = new ApiError('Invoice already issued for order: o1', 409, {});
     expect(resolveIssueErrorMessage(error, t)).toBe('This order already has an issued invoice.');

--- a/apps/web/src/features/invoicing/lib/issue-error-message.ts
+++ b/apps/web/src/features/invoicing/lib/issue-error-message.ts
@@ -12,11 +12,15 @@
  *      verbatim (controller correlationId string, PII-clean).
  *   3. Other HTTP 400 (buyer-profile / price-treatment) → surface
  *      `error.message` (PII-clean mapper text, operator-actionable).
- *   4. Defensive 409 → already-issued fixed string.
- *   5. Fallback → generic fixed string.
+ *   4. Insufficient permissions (HTTP 403) → a FIXED, permission-specific
+ *      string (#1613). The FE gates the Issue/Retry affordances behind
+ *      `invoices:write` (`useWriteAccess`), so this is normally a defensive
+ *      fallback for a stale session — never echo `error.message`.
+ *   5. Defensive 409 → already-issued fixed string.
+ *   6. Fallback → generic fixed string.
  *
  * Security invariant: only branches 2 and 3 surface `error.message`; the
- * capability branch and fallback emit FIXED strings.
+ * capability branch, the 403 branch, and the fallback emit FIXED strings.
  *
  * @module apps/web/src/features/invoicing/lib
  */
@@ -57,6 +61,12 @@ export function resolveIssueErrorMessage(error: unknown, t: Translate): string {
     // the BE sent. Keep this in lockstep with the controller's 400 vocabulary.
     if (error.status === 422 || error.status === 400) {
       return error.message;
+    }
+    if (error.status === 403) {
+      return t(
+        'invoice.error.forbidden',
+        "Can't issue invoices in demo mode - demo accounts are read-only; issuing an invoice needs an operator account.",
+      );
     }
     if (error.status === 409) {
       return t('invoice.error.alreadyIssued', 'This order already has an issued invoice.');

--- a/apps/web/src/shared/auth/session.types.ts
+++ b/apps/web/src/shared/auth/session.types.ts
@@ -24,6 +24,7 @@ export const PermissionValues = [
   'customers:read',
   'shipments:read',
   'invoices:read',
+  'invoices:write',
   'webhooks:read',
   'ai:suggest',
 ] as const;

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -510,6 +510,7 @@ const DEFAULT_TEST_USER: SessionUser = {
     'inventory:read', 'inventory:write',
     'listings:read', 'listings:write',
     'ai:suggest',
+    'invoices:read', 'invoices:write',
   ],
 };
 

--- a/libs/core/src/users/domain/types/role.types.ts
+++ b/libs/core/src/users/domain/types/role.types.ts
@@ -48,6 +48,7 @@ export const PermissionValues = [
   'customers:read',
   'shipments:read',
   'invoices:read',
+  'invoices:write',
   'webhooks:read',
   'ai:suggest',
 ] as const;


### PR DESCRIPTION
## Summary

Part of #1606
Closes #1613

A demo viewer clicking "Issue invoice" on the order detail page got a generic, misleading toast ("Could not issue invoice - Please try again") instead of a clear permission message. Root cause: invoice issuing was never permission-gated on the FE, so `OrderInvoicePanel` rendered the Issue/Retry buttons for any authenticated user and only found out about the missing permission when the backend's `RolesGuard` rejected the request.

- Added `invoices:write` to the shared `Permission` union on both sides (`apps/web/src/shared/auth/session.types.ts` and `libs/core/src/users/domain/types/role.types.ts`). It is granted to `admin` only, matching the existing `@Roles('admin')` guard on `POST /invoices` (verified - no backend change was needed there, it already rejects with a 403).
- `OrderInvoicePanel` now gates the Issue (not-issued state) and Retry (failed/rejected state) buttons behind `useWriteAccess('invoices:write', demoMode)`, reusing the exact same visible-but-disabled `ReadOnlyLock` pattern `ConnectionActionsPanel` uses for demo read-only viewers (#1615): a demo viewer still sees the button, disabled, with a "Read-only in demo mode" tooltip; a genuinely unauthorized non-demo session keeps the existing hide-when-missing behaviour; an admin/operator session with the permission is unaffected.
- `resolveIssueErrorMessage` now maps an HTTP 403 to a fixed, permission-specific message ("Can't issue invoices in demo mode - demo accounts are read-only; issuing an invoice needs an operator account.") instead of falling through to the generic copy. This is now a defensive fallback (the button is disabled before a request is even made), but keeps the error path honest if a session goes stale mid-visit.
- Added a targeted spec test asserting `InvoicingController.issueInvoice` carries `@Roles('admin')` metadata (on top of the existing generic `write-guard-coverage.spec.ts` invariant that was already passing).

## Test plan

- [x] `resolveIssueErrorMessage` unit test for the new 403 branch
- [x] `OrderInvoicePanel` tests: demo viewer sees Issue/Retry disabled-with-tooltip; unauthorized non-demo viewer still gets hide-when-missing; admin/operator issuing unaffected
- [x] Existing `OrderInvoicePanel` tests updated to render under an authenticated admin session (previously relied on no gating existing at all)
- [x] Backend: new spec asserting `@Roles('admin')` on `issueInvoice`; existing `RolesGuard` + `write-guard-coverage.spec.ts` suites still pass
- [x] `pnpm --filter @openlinker/web lint` / `pnpm --filter @openlinker/api lint` / `pnpm --filter @openlinker/core lint` - 0 errors (pre-existing warnings only)
- [x] `pnpm --filter @openlinker/web type-check` / `pnpm --filter @openlinker/api type-check` (after building `libs/**`) - clean, aside from one pre-existing unrelated failure in `registration.service.spec.ts` (confirmed via `git stash`, present before this change)
- [x] `pnpm --filter @openlinker/web test src/features/invoicing` - 92/92 passing
- [x] `pnpm --filter @openlinker/api test -- invoicing.controller.spec.ts` - 105/105 passing