### PR TITLE
fix(auth): address PR #1655 review findings (rate limit, dead code, cross-context gate)

### DIFF
--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -18,12 +18,12 @@ import type { IAuthService } from './auth.service.interface';
 import { LoginDto } from './dto/login.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
 import {
+  EmailConfirmationRateLimitedException,
   EmailNotConfirmedException,
   InvalidEmailConfirmationTokenException,
   InvalidPasswordResetTokenException,
   RefreshTokenReuseDetectedException,
   User,
-  UserNotPendingConfirmationException,
 } from '@openlinker/core/users';
 import type { IPasswordResetService } from './password-reset.service.interface';
 import { PASSWORD_RESET_SERVICE_TOKEN } from './password-reset.service.interface';
@@ -357,8 +357,15 @@ describe('AuthController', () => {
     });
 
     it('returns a generic message and never leaks the internal user id (finding 1)', async () => {
+      // EmailConfirmationService.confirmEmail already remaps
+      // UserNotPendingConfirmationException to
+      // InvalidEmailConfirmationTokenException internally before it ever
+      // reaches the controller — asserted directly in
+      // email-confirmation.service.spec.ts. This test exercises the
+      // controller's own generic-message mapping on the exception it
+      // actually receives.
       emailConfirmationService.confirmEmail.mockRejectedValue(
-        new UserNotPendingConfirmationException('ol_user_super-secret-internal-uuid'),
+        new InvalidEmailConfirmationTokenException(),
       );
 
       await expect(controller.confirmEmail(dto)).rejects.toMatchObject({
@@ -370,26 +377,37 @@ describe('AuthController', () => {
         message: expect.stringContaining('ol_user_super-secret-internal-uuid'),
       });
     });
-
-    it('converts UserNotPendingConfirmationException to the same generic 400', async () => {
-      emailConfirmationService.confirmEmail.mockRejectedValue(
-        new UserNotPendingConfirmationException('some-user-id'),
-      );
-      await expect(controller.confirmEmail(dto)).rejects.toThrow(BadRequestException);
-    });
   });
 
   describe('POST /auth/resend-confirmation', () => {
+    const makeIpReq = (ip = '203.0.113.7'): Request => ({ ip }) as unknown as Request;
+
     it('always returns 200 and delegates to the service', async () => {
       emailConfirmationService.resendConfirmation.mockResolvedValue();
       const dto: ResendConfirmationDto = Object.assign(new ResendConfirmationDto(), {
         email: 'demo@test.com',
       });
 
-      const result = await controller.resendConfirmation(dto);
+      const result = await controller.resendConfirmation(dto, makeIpReq());
 
       expect(result).toEqual({ ok: true });
-      expect(emailConfirmationService.resendConfirmation).toHaveBeenCalledWith('demo@test.com');
+      expect(emailConfirmationService.resendConfirmation).toHaveBeenCalledWith(
+        'demo@test.com',
+        '203.0.113.7',
+      );
+    });
+
+    it('converts EmailConfirmationRateLimitedException to 429 (review finding 2)', async () => {
+      emailConfirmationService.resendConfirmation.mockRejectedValue(
+        new EmailConfirmationRateLimitedException(),
+      );
+      const dto: ResendConfirmationDto = Object.assign(new ResendConfirmationDto(), {
+        email: 'demo@test.com',
+      });
+
+      await expect(controller.resendConfirmation(dto, makeIpReq())).rejects.toMatchObject({
+        status: 429,
+      });
     });
   });
 

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -34,6 +34,7 @@ import { Request, Response } from 'express';
 import { Logger } from '@openlinker/shared/logging';
 import type { User } from '@openlinker/core/users';
 import {
+  EmailConfirmationRateLimitedException,
   EmailNotConfirmedException,
   InvalidEmailConfirmationTokenException,
   InvalidPasswordResetTokenException,
@@ -41,7 +42,6 @@ import {
   RegistrationRateLimitedException,
   RefreshTokenReuseDetectedException,
   UserAlreadyExistsException,
-  UserNotPendingConfirmationException,
   WeakPasswordException,
 } from '@openlinker/core/users';
 import { AUTH_SERVICE_TOKEN, IAuthService } from './auth.service.interface';
@@ -174,15 +174,15 @@ export class AuthController {
     try {
       await this.emailConfirmationService.confirmEmail(dto.token);
     } catch (error) {
-      if (
-        error instanceof InvalidEmailConfirmationTokenException ||
-        error instanceof UserNotPendingConfirmationException
-      ) {
-        // Never surface `error.message` from these domain exceptions on this
-        // public, unauthenticated endpoint — some (e.g.
-        // UserNotPendingConfirmationException) carry an internal user id.
-        // Log the specific reason server-side and return one generic,
-        // non-identifying message regardless of which exception fired.
+      // EmailConfirmationService.confirmEmail already catches
+      // UserNotPendingConfirmationException / UserNotFoundException
+      // internally and remaps them to InvalidEmailConfirmationTokenException
+      // before they ever reach this controller (see its own catch block),
+      // so this only ever needs to handle the one exception type.
+      if (error instanceof InvalidEmailConfirmationTokenException) {
+        // Never surface `error.message` on this public, unauthenticated
+        // endpoint. Log the specific reason server-side and return one
+        // generic, non-identifying message.
         this.logger.warn(`Email confirmation failed: ${(error as Error).message}`);
         throw new BadRequestException('This confirmation link is invalid or has expired.');
       }
@@ -203,8 +203,19 @@ export class AuthController {
     description: 'Request accepted (regardless of account existence or status)',
     type: OkResponseDto,
   })
-  async resendConfirmation(@Body() dto: ResendConfirmationDto): Promise<OkResponseDto> {
-    await this.emailConfirmationService.resendConfirmation(dto.email);
+  @ApiResponse({ status: 429, description: 'Too many resend requests from this IP' })
+  async resendConfirmation(
+    @Body() dto: ResendConfirmationDto,
+    @Req() req: Request,
+  ): Promise<OkResponseDto> {
+    try {
+      await this.emailConfirmationService.resendConfirmation(dto.email, req.ip);
+    } catch (error) {
+      if (error instanceof EmailConfirmationRateLimitedException) {
+        throw new HttpException(error.message, HttpStatus.TOO_MANY_REQUESTS);
+      }
+      throw error;
+    }
     return { ok: true };
   }
 

--- a/apps/api/src/auth/email-confirmation.service.interface.ts
+++ b/apps/api/src/auth/email-confirmation.service.interface.ts
@@ -31,8 +31,13 @@ export interface IEmailConfirmationService {
    * email or an account that isn't `pending_confirmation` — the caller
    * always returns a generic 200, mirroring `PasswordResetService.requestReset`'s
    * enumeration-safe posture.
+   *
+   * When demo mode is enabled and `clientIp` is provided, enforces the same
+   * IP-keyed fixed-window rate limit shape as `RegistrationService.register`
+   * (#1655 review finding) — throws `EmailConfirmationRateLimitedException`
+   * when the requesting IP exceeds the configured limit.
    */
-  resendConfirmation(email: string): Promise<void>;
+  resendConfirmation(email: string, clientIp?: string): Promise<void>;
 }
 
 export const EMAIL_CONFIRMATION_SERVICE_TOKEN = Symbol('IEmailConfirmationService');

--- a/apps/api/src/auth/email-confirmation.service.spec.ts
+++ b/apps/api/src/auth/email-confirmation.service.spec.ts
@@ -5,6 +5,7 @@
  */
 import type { ConfigService } from '@nestjs/config';
 import {
+  EmailConfirmationRateLimitedException,
   EmailConfirmationToken,
   InvalidEmailConfirmationTokenException,
   User,
@@ -14,8 +15,10 @@ import {
   type MailerPort,
   type UserRepositoryPort,
 } from '@openlinker/core/users';
+import type { CachePort } from '@openlinker/shared/cache';
 import { EmailConfirmationService } from './email-confirmation.service';
 import type { IUserManagementService } from '../users/user-management.service.interface';
+import type { IDemoModeService } from './demo-mode.service.interface';
 
 const makeUser = (
   email: string | null = 'demo@test.com',
@@ -46,6 +49,16 @@ const makeUserManagementService = (): jest.Mocked<IUserManagementService> => ({
   reactivateUser: jest.fn(),
   deleteUser: jest.fn(),
   confirmEmail: jest.fn(),
+});
+
+const makeDemoModeService = (enabled = false): jest.Mocked<IDemoModeService> => ({
+  isDemoModeEnabled: jest.fn(() => enabled),
+});
+
+const makeCache = (): jest.Mocked<CachePort> => ({
+  get: jest.fn(),
+  set: jest.fn(),
+  delete: jest.fn(),
 });
 
 const makeUserRepo = (): jest.Mocked<UserRepositoryPort> => ({
@@ -79,6 +92,8 @@ describe('EmailConfirmationService', () => {
         mailer,
         userManagementService,
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({ WEB_URL: 'https://app.example.com' }),
       );
 
@@ -105,6 +120,8 @@ describe('EmailConfirmationService', () => {
         mailer,
         makeUserManagementService(),
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -126,6 +143,8 @@ describe('EmailConfirmationService', () => {
         mailer,
         makeUserManagementService(),
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -141,6 +160,8 @@ describe('EmailConfirmationService', () => {
         mailer,
         makeUserManagementService(),
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -160,6 +181,8 @@ describe('EmailConfirmationService', () => {
         makeMailer(),
         userManagementService,
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -178,6 +201,8 @@ describe('EmailConfirmationService', () => {
         makeMailer(),
         userManagementService,
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -194,6 +219,8 @@ describe('EmailConfirmationService', () => {
         makeMailer(),
         makeUserManagementService(),
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -214,6 +241,8 @@ describe('EmailConfirmationService', () => {
         makeMailer(),
         userManagementService,
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -234,6 +263,8 @@ describe('EmailConfirmationService', () => {
         makeMailer(),
         userManagementService,
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -254,6 +285,8 @@ describe('EmailConfirmationService', () => {
         makeMailer(),
         userManagementService,
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
       const warnSpy = jest.spyOn(
@@ -283,6 +316,8 @@ describe('EmailConfirmationService', () => {
         makeMailer(),
         userManagementService,
         makeUserRepo(),
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -312,6 +347,8 @@ describe('EmailConfirmationService', () => {
         mailer,
         makeUserManagementService(),
         userRepo,
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({ WEB_URL: 'https://app.example.com' }),
       );
 
@@ -331,6 +368,8 @@ describe('EmailConfirmationService', () => {
         makeMailer(),
         makeUserManagementService(),
         userRepo,
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -349,6 +388,8 @@ describe('EmailConfirmationService', () => {
         makeMailer(),
         makeUserManagementService(),
         userRepo,
+        makeDemoModeService(),
+        makeCache(),
         makeConfig({}),
       );
 
@@ -356,6 +397,97 @@ describe('EmailConfirmationService', () => {
 
       expect(tokenRepo.invalidateActiveForUser).not.toHaveBeenCalled();
       expect(tokenRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('does not rate-limit when demo mode is disabled (review finding 2)', async () => {
+      const tokenRepo = makeTokenRepo();
+      const userRepo = makeUserRepo();
+      const cache = makeCache();
+      userRepo.findByEmail.mockResolvedValue(makeUser());
+      const service = new EmailConfirmationService(
+        tokenRepo,
+        makeMailer(),
+        makeUserManagementService(),
+        userRepo,
+        makeDemoModeService(false),
+        cache,
+        makeConfig({}),
+      );
+
+      await service.resendConfirmation('demo@test.com', '1.2.3.4');
+
+      expect(cache.get).not.toHaveBeenCalled();
+      expect(cache.set).not.toHaveBeenCalled();
+    });
+
+    it('does not rate-limit when no clientIp is provided, even in demo mode', async () => {
+      const tokenRepo = makeTokenRepo();
+      const userRepo = makeUserRepo();
+      const cache = makeCache();
+      userRepo.findByEmail.mockResolvedValue(makeUser());
+      const service = new EmailConfirmationService(
+        tokenRepo,
+        makeMailer(),
+        makeUserManagementService(),
+        userRepo,
+        makeDemoModeService(true),
+        cache,
+        makeConfig({}),
+      );
+
+      await service.resendConfirmation('demo@test.com');
+
+      expect(cache.get).not.toHaveBeenCalled();
+      expect(cache.set).not.toHaveBeenCalled();
+    });
+
+    it('increments the per-IP counter under the configured limit and proceeds (review finding 2)', async () => {
+      const tokenRepo = makeTokenRepo();
+      const userRepo = makeUserRepo();
+      const cache = makeCache();
+      cache.get.mockResolvedValue(2);
+      userRepo.findByEmail.mockResolvedValue(makeUser());
+      const service = new EmailConfirmationService(
+        tokenRepo,
+        makeMailer(),
+        makeUserManagementService(),
+        userRepo,
+        makeDemoModeService(true),
+        cache,
+        makeConfig({
+          OL_DEMO_RESEND_CONFIRMATION_RATE_LIMIT: '5',
+          OL_DEMO_RESEND_CONFIRMATION_RATE_WINDOW_SECONDS: '3600',
+        }),
+      );
+
+      await service.resendConfirmation('demo@test.com', '1.2.3.4');
+
+      expect(cache.get).toHaveBeenCalledWith('demo:resend-confirmation:1.2.3.4');
+      expect(cache.set).toHaveBeenCalledWith('demo:resend-confirmation:1.2.3.4', 3, 3600);
+      expect(tokenRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws EmailConfirmationRateLimitedException once the per-IP limit is reached (review finding 2)', async () => {
+      const tokenRepo = makeTokenRepo();
+      const userRepo = makeUserRepo();
+      const cache = makeCache();
+      cache.get.mockResolvedValue(5);
+      const service = new EmailConfirmationService(
+        tokenRepo,
+        makeMailer(),
+        makeUserManagementService(),
+        userRepo,
+        makeDemoModeService(true),
+        cache,
+        makeConfig({ OL_DEMO_RESEND_CONFIRMATION_RATE_LIMIT: '5' }),
+      );
+
+      await expect(
+        service.resendConfirmation('demo@test.com', '1.2.3.4'),
+      ).rejects.toThrow(EmailConfirmationRateLimitedException);
+
+      expect(cache.set).not.toHaveBeenCalled();
+      expect(userRepo.findByEmail).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/auth/email-confirmation.service.ts
+++ b/apps/api/src/auth/email-confirmation.service.ts
@@ -15,8 +15,10 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { randomBytes, createHash } from 'crypto';
 import { Logger } from '@openlinker/shared/logging';
+import { CACHE_PORT_TOKEN, type CachePort } from '@openlinker/shared/cache';
 import {
   EMAIL_CONFIRMATION_TOKEN_REPOSITORY_TOKEN,
+  EmailConfirmationRateLimitedException,
   InvalidEmailConfirmationTokenException,
   MAILER_TOKEN,
   USER_REPOSITORY_TOKEN,
@@ -32,6 +34,7 @@ import {
   IUserManagementService,
   USER_MANAGEMENT_SERVICE_TOKEN,
 } from '../users/user-management.service.interface';
+import { DEMO_MODE_SERVICE_TOKEN, type IDemoModeService } from './demo-mode.service.interface';
 import { renderConfirmationEmailHtml } from './templates/confirmation-email.template';
 
 const DEFAULT_TTL_MINUTES = 24 * 60;
@@ -55,6 +58,10 @@ export class EmailConfirmationService implements IEmailConfirmationService {
     private readonly userManagementService: IUserManagementService,
     @Inject(USER_REPOSITORY_TOKEN)
     private readonly userRepository: UserRepositoryPort,
+    @Inject(DEMO_MODE_SERVICE_TOKEN)
+    private readonly demoModeService: IDemoModeService,
+    @Inject(CACHE_PORT_TOKEN)
+    private readonly cache: CachePort,
     private readonly configService: ConfigService
   ) {
     this.ttlMinutes = Number(
@@ -167,7 +174,12 @@ export class EmailConfirmationService implements IEmailConfirmationService {
     }
   }
 
-  async resendConfirmation(email: string): Promise<void> {
+  async resendConfirmation(email: string, clientIp?: string): Promise<void> {
+    const demoMode = this.demoModeService.isDemoModeEnabled();
+    if (demoMode && clientIp) {
+      await this.enforceRateLimit(clientIp);
+    }
+
     const user = await this.userRepository.findByEmail(email);
     if (!user || user.status !== 'pending_confirmation') {
       // No-op for an unknown email or an account not awaiting confirmation
@@ -189,5 +201,29 @@ export class EmailConfirmationService implements IEmailConfirmationService {
 
   private hashToken(rawToken: string): string {
     return createHash('sha256').update(rawToken).digest('hex');
+  }
+
+  /**
+   * Fixed-window counter keyed by client IP — same shape as
+   * `RegistrationService.enforceRateLimit` (#1469), applied here to close
+   * the review finding that `POST /auth/resend-confirmation` had no abuse
+   * deterrence (an unauthenticated caller could otherwise email-bomb any
+   * pending-confirmation address). Best-effort, not atomic — acceptable for
+   * demo-mode abuse deterrence, not a hard security boundary.
+   */
+  private async enforceRateLimit(clientIp: string): Promise<void> {
+    const limit = Number(
+      this.configService.get<string>('OL_DEMO_RESEND_CONFIRMATION_RATE_LIMIT', '5')
+    );
+    const windowSeconds = Number(
+      this.configService.get<string>('OL_DEMO_RESEND_CONFIRMATION_RATE_WINDOW_SECONDS', '3600')
+    );
+    const key = `demo:resend-confirmation:${clientIp}`;
+    const count = (await this.cache.get<number>(key)) ?? 0;
+    if (count >= limit) {
+      this.logger.warn(`Resend-confirmation rate limit exceeded for IP ${clientIp}`);
+      throw new EmailConfirmationRateLimitedException();
+    }
+    await this.cache.set(key, count + 1, windowSeconds);
   }
 }

--- a/libs/core/src/users/domain/exceptions/email-confirmation-rate-limited.exception.ts
+++ b/libs/core/src/users/domain/exceptions/email-confirmation-rate-limited.exception.ts
@@ -1,0 +1,18 @@
+/**
+ * Email Confirmation Rate Limited Exception
+ *
+ * Thrown when a resend-confirmation request exceeds the configured rate
+ * limit for the requesting IP while demo mode is enabled (#1655 review
+ * finding — mirrors RegistrationRateLimitedException's rationale and
+ * enforcement shape for the sibling resend-confirmation endpoint).
+ *
+ * @module libs/core/src/users/domain/exceptions
+ */
+
+export class EmailConfirmationRateLimitedException extends Error {
+  constructor() {
+    super('Too many confirmation email requests. Please try again later.');
+    this.name = 'EmailConfirmationRateLimitedException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/users/index.ts
+++ b/libs/core/src/users/index.ts
@@ -26,6 +26,7 @@ export { CannotSelfModifyException } from './domain/exceptions/cannot-self-modif
 export { LastAdminException } from './domain/exceptions/last-admin.exception';
 export { RegistrationDisabledException } from './domain/exceptions/registration-disabled.exception';
 export { RegistrationRateLimitedException } from './domain/exceptions/registration-rate-limited.exception';
+export { EmailConfirmationRateLimitedException } from './domain/exceptions/email-confirmation-rate-limited.exception';
 export { InvalidPasswordResetTokenException } from './domain/exceptions/invalid-password-reset-token.exception';
 export { InvalidEmailConfirmationTokenException } from './domain/exceptions/invalid-email-confirmation-token.exception';
 export { EmailNotConfirmedException } from './domain/exceptions/email-not-confirmed.exception';

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -172,15 +172,20 @@ const ALLOW_LIST = new Map([
   ['apps/api/src/auth/refresh-token.service.ts', new Set(['RefreshTokenRepositoryPort'])],
   ['apps/api/src/auth/refresh-token.service.spec.ts', new Set(['RefreshTokenRepositoryPort'])],
 
-  // apps → users.EmailConfirmationTokenRepositoryPort — rewire via IUsersService
-  // (#1624, mirrors the pre-existing PasswordResetTokenRepositoryPort entry above)
+  // apps → users.EmailConfirmationTokenRepositoryPort + UserRepositoryPort — rewire via IUsersService
+  // (#1624, mirrors the pre-existing PasswordResetTokenRepositoryPort entry above;
+  // #1649 added the direct UserRepositoryPort lookup used to unstick pending accounts)
   [
     'apps/api/src/auth/email-confirmation.service.ts',
-    new Set(['EmailConfirmationTokenRepositoryPort']),
+    new Set(['EmailConfirmationTokenRepositoryPort', 'UserRepositoryPort']),
   ],
   [
     'apps/api/src/auth/email-confirmation.service.spec.ts',
-    new Set(['EmailConfirmationTokenRepositoryPort']),
+    new Set(['EmailConfirmationTokenRepositoryPort', 'UserRepositoryPort']),
+  ],
+  [
+    'apps/api/test/integration/email-confirmation.int-spec.ts',
+    new Set(['EmailConfirmationTokenRepositoryPort', 'UserRepositoryPort']),
   ],
 
   // apps + worker → sync.SyncJobRepositoryPort — rewire via ISyncJobsService


### PR DESCRIPTION
## Summary

PR #1655 merged into `1606-demo-mode-improvements` before its own review comments (posted a couple minutes before the merge) could be addressed. This is a follow-up that fixes all three findings from https://github.com/openlinker-project/openlinker/pull/1655#issuecomment-4981749747:

1. **BLOCKING - 4 new check-cross-context-imports.mjs violations**: the allow-list gate is per-symbol, not per-file. `email-confirmation.service.ts` / `.spec.ts` were already allow-listed for `EmailConfirmationTokenRepositoryPort` but not for the newly-added `UserRepositoryPort` import, and the new `email-confirmation.int-spec.ts` had no entry at all. Added the matching allow-list entries, mirroring the existing `password-reset.service.ts` shape. `node scripts/check-cross-context-imports.mjs` is back down to the same 3 pre-existing baseline violations that exist on the base branch.

2. **IMPORTANT - no rate limiting on POST /auth/resend-confirmation**: added an IP-keyed fixed-window rate limit to `EmailConfirmationService.resendConfirmation`, mirroring `RegistrationService.enforceRateLimit`'s pattern exactly (same `CachePort` mechanism), but with its own config vars and Redis key prefix scoped to this endpoint: `OL_DEMO_RESEND_CONFIRMATION_RATE_LIMIT` / `OL_DEMO_RESEND_CONFIRMATION_RATE_WINDOW_SECONDS`, key `demo:resend-confirmation:{clientIp}`. Only gated in demo mode, matching the existing pattern. Exceeding the limit throws a new `EmailConfirmationRateLimitedException`, mapped to HTTP 429 in the controller (mirrors `RegistrationRateLimitedException`'s controller mapping).

3. **IMPORTANT - dead code in AuthController.confirmEmail**: the `UserNotPendingConfirmationException` catch branch was unreachable, since `EmailConfirmationService.confirmEmail` already catches and remaps that exception (and `UserNotFoundException`) internally before it ever reaches the controller. Removed the dead branch and its now-unused import, and updated the corresponding controller spec test to exercise the exception the controller actually receives (`InvalidEmailConfirmationTokenException`).

## Test plan

- [x] `node scripts/check-cross-context-imports.mjs` — 3 violations (pre-existing baseline, unchanged from base branch)
- [x] `pnpm --filter @openlinker/api lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm --filter @openlinker/api type-check` — clean
- [x] `pnpm --filter @openlinker/core build` — clean (new exception export)
- [x] `pnpm --filter @openlinker/api test -- src/auth` — 148/148 passing, including new rate-limit tests in `email-confirmation.service.spec.ts` and the 429-mapping test in `auth.controller.spec.ts`
- [x] `pnpm --filter @openlinker/core test -- barrel-purity` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)