### PR TITLE
fix(orders): stop bulk-dispatch rows exploding into a huge empty gap

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8269,10 +8269,13 @@ html[data-density='compact'] .status-badge {
 }
 
 /* `input.bulk-dispatch__num` (not `.bulk-dispatch__num` alone) is required to
- * out-specificity the base `input[type='number'] { width: 100%; }` rule
- * (attribute selector = higher specificity than a lone class) - otherwise
- * these compact dimension/weight fields silently stretch to share the row's
- * flex space instead of staying at their intended width (#1658). */
+ * out-specificity the base `input[type='number'] { width: 100%; }` rule: that
+ * rule combines an element-type selector with an attribute selector (0,1,1),
+ * which beats a bare class selector (0,1,0) regardless of source order; adding
+ * the `input` element-type selector here brings this rule to the same
+ * specificity tier so it wins on source order instead - otherwise these
+ * compact dimension/weight fields silently stretch to share the row's flex
+ * space instead of staying at their intended width (#1658). */
 input.bulk-dispatch__num {
   width: 52px;
   flex-shrink: 0;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8268,13 +8268,19 @@ html[data-density='compact'] .status-badge {
   color: var(--text-disabled);
 }
 
-.bulk-dispatch__num {
+/* `input.bulk-dispatch__num` (not `.bulk-dispatch__num` alone) is required to
+ * out-specificity the base `input[type='number'] { width: 100%; }` rule
+ * (attribute selector = higher specificity than a lone class) - otherwise
+ * these compact dimension/weight fields silently stretch to share the row's
+ * flex space instead of staying at their intended width (#1658). */
+input.bulk-dispatch__num {
   width: 52px;
+  flex-shrink: 0;
   text-align: center;
   font-variant-numeric: tabular-nums;
 }
 
-.bulk-dispatch__num--wide {
+input.bulk-dispatch__num--wide {
   width: 68px;
 }
 
@@ -8306,7 +8312,7 @@ html[data-density='compact'] .status-badge {
 
 .bulk-dispatch__row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto auto auto;
+  grid-template-columns: minmax(140px, 1fr) auto auto auto auto;
   align-items: center;
   gap: var(--space-3);
   padding: var(--space-3) var(--space-4);
@@ -8319,7 +8325,7 @@ html[data-density='compact'] .status-badge {
 
 .bulk-dispatch__row--ineligible {
   background: var(--bg-canvas);
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(140px, 1fr) auto auto;
 }
 
 .bulk-dispatch__row-id {
@@ -8347,6 +8353,13 @@ html[data-density='compact'] .status-badge {
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
+  /* Without `nowrap`, `overflow-wrap: anywhere` (inherited from `.mono`)
+   * breaks this unbroken internal order id one character per line once its
+   * squeezed grid column runs low on width - inflating the row (and, once
+   * clipped by `.bulk-dispatch__rows`' max-height, the whole dialog) to
+   * hundreds of pixels of apparent empty space (#1658). `nowrap` lets the
+   * already-declared ellipsis truncate it on one line instead. */
+  white-space: nowrap;
 }
 
 .bulk-dispatch__buyer {


### PR DESCRIPTION
## Problem

Part of #1606. In the orders bulk-select "Dispatch N orders" dialog (`apps/web/src/features/orders/components/bulk-dispatch-dialog.tsx`), rows rendered with a huge empty vertical gap between the "N ready" summary and the actual row content (dimensions/weight inputs + status badge), which ended up pushed far down the dialog, mostly out of view.

## Root cause

The order id shown in each row is a long, space-free mono token (e.g. `ol_order_8634d1ea373842bfa1e1e653d9494cb4`). Its grid column (`minmax(0, 1fr)`) could shrink all the way to 0 next to the row's four `auto`-sized columns (source/courier badges, dimension inputs, weight input), and with `overflow-wrap: anywhere` inherited from the shared `.mono` class, the browser wrapped the id one character per line - inflating a single row to 800px+ tall. `.bulk-dispatch__rows` clips its content at `max-height: 46vh`, so this rendered as a large empty area below the summary line, with the row's actual content scrolled far out of view.

A second, related bug made this worse: `input.bulk-dispatch__num` / `--wide` (52px / 68px) were losing the CSS cascade to the base `input[type='number'] { width: 100% }` rule, because an attribute selector (`input[type='number']`) always outranks a lone class selector regardless of source order. This silently stretched every dimension/weight field, squeezing the row-id column even further.

## Fix

- `.bulk-dispatch__row` / `.bulk-dispatch__row--ineligible`: gave the row-id column a `140px` floor (`minmax(140px, 1fr)`) instead of `minmax(0, 1fr)`.
- `.bulk-dispatch__ordid`: added `white-space: nowrap` so the already-declared `overflow: hidden` + `text-overflow: ellipsis` actually engages instead of wrapping.
- `input.bulk-dispatch__num` / `input.bulk-dispatch__num--wide`: bumped selector specificity (element + class) so the declared 52px/68px widths actually win over the base `input[type='number']` rule.

No changes to the per-row dimension/weight input functionality or "Apply to all rows" behaviour - this is a layout/CSS-only fix.

Follows the direction from the approved mockup: https://claude.ai/code/artifact/322bdc65-bc68-4fb1-b2ca-f746ff1b8882

## Verification

Verified live against a running demo stack (local dev server proxying `/v1` to the demo API, logged in as admin) at:
- 1 selected row (single Allegro order) - row renders on one compact line, no gap.
- 3 selected rows in the same source group (Allegro, mixed Courier/Paczkomat) - rows stack tightly.
- 4 selected rows spanning two source groups (Allegro + Erli) - all rows stack tightly with correct per-row source badges.
- Mixed eligible/ineligible selection - the ineligible row (awaiting mapping) still renders correctly with its reason + "dispatch individually" link.
- Narrow/mobile viewport (420px) - existing responsive stacking still holds.

## Quality gate

- `pnpm --filter @openlinker/web lint` - 0 errors (pre-existing warnings only)
- `pnpm --filter @openlinker/web type-check` - clean
- `vitest run src/features/orders src/pages/orders` - 210 passed

Closes #1658