### PR TITLE
feat(web): mailer/SMTP settings tile + edit modal on /settings

### DIFF
--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -36,6 +36,10 @@ import { createHealthApi, type HealthApi } from '../../features/health/api/healt
 import { createInventoryApi, type InventoryApi } from '../../features/inventory/api/inventory.api';
 import { createInvoicingApi, type InvoicingApi } from '../../features/invoicing/api/invoicing.api';
 import { createListingsApi, type ListingsApi } from '../../features/listings/api/listings.api';
+import {
+  createMailerSettingsApi,
+  type MailerSettingsApi,
+} from '../../features/mailer-settings/api/mailer-settings.api';
 import { createOrdersApi, type OrdersApi } from '../../features/orders/api/orders.api';
 import { createProductsApi, type ProductsApi } from '../../features/products/api/products.api';
 import { createShipmentsApi, type ShipmentsApi } from '../../features/shipments/api/shipments.api';
@@ -102,6 +106,7 @@ export interface CoreApiClient {
   inventory: InventoryApi;
   invoicing: InvoicingApi;
   listings: ListingsApi;
+  mailerSettings: MailerSettingsApi;
   orders: OrdersApi;
   products: ProductsApi;
   promptTemplates: PromptTemplatesApi;
@@ -253,6 +258,7 @@ export function createApiClient({
     inventory: createInventoryApi(request),
     invoicing: createInvoicingApi(request, requestBlob),
     listings: createListingsApi(request),
+    mailerSettings: createMailerSettingsApi(request),
     mappings: createMappingsApi(request),
     orders: createOrdersApi(request),
     products: createProductsApi(request),

--- a/apps/web/src/features/mailer-settings/api/mailer-settings.api.ts
+++ b/apps/web/src/features/mailer-settings/api/mailer-settings.api.ts
@@ -1,0 +1,48 @@
+/**
+ * Mailer Settings API Client
+ *
+ * Thin HTTP adapter over the admin-only `/mailer-settings` endpoints. The
+ * SMTP password is write-only — `setCredentials` / `clearCredentials` never
+ * receive or return the actual password value.
+ *
+ * @module apps/web/src/features/mailer-settings/api
+ */
+import type {
+  MailerSettingsView,
+  SetMailerCredentialsInput,
+  UpdateMailerSettingsInput,
+} from './mailer-settings.types';
+
+export interface MailerSettingsApi {
+  get: () => Promise<MailerSettingsView>;
+  update: (input: UpdateMailerSettingsInput) => Promise<void>;
+  setCredentials: (input: SetMailerCredentialsInput) => Promise<void>;
+  clearCredentials: () => Promise<void>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+export function createMailerSettingsApi(request: ApiRequest): MailerSettingsApi {
+  return {
+    get(): Promise<MailerSettingsView> {
+      return request<MailerSettingsView>('/mailer-settings');
+    },
+    async update(input): Promise<void> {
+      await request<void>('/mailer-settings', {
+        method: 'PUT',
+        body: JSON.stringify(input),
+      });
+    },
+    async setCredentials(input): Promise<void> {
+      await request<void>('/mailer-settings/credentials', {
+        method: 'PUT',
+        body: JSON.stringify(input),
+      });
+    },
+    async clearCredentials(): Promise<void> {
+      await request<void>('/mailer-settings/credentials', { method: 'DELETE' });
+    },
+  };
+}

--- a/apps/web/src/features/mailer-settings/api/mailer-settings.query-keys.ts
+++ b/apps/web/src/features/mailer-settings/api/mailer-settings.query-keys.ts
@@ -1,0 +1,13 @@
+/**
+ * Mailer Settings — Query Key Factory
+ *
+ * Singular resource (one row server-side) so `current()` is the only key.
+ * The `all` key is the invalidation root used by mutation hooks.
+ *
+ * @module apps/web/src/features/mailer-settings/api
+ */
+
+export const mailerSettingsQueryKeys = {
+  all: ['mailer-settings'] as const,
+  current: () => ['mailer-settings', 'current'] as const,
+};

--- a/apps/web/src/features/mailer-settings/api/mailer-settings.types.ts
+++ b/apps/web/src/features/mailer-settings/api/mailer-settings.types.ts
@@ -1,0 +1,41 @@
+/**
+ * Mailer Settings — Frontend Types
+ *
+ * Hand-written wire types mirroring the backend DTOs in
+ * `apps/api/src/mailer/http/dto/*.ts`. Kept FE-local so the web bundle stays
+ * independent of NestJS / core imports.
+ *
+ * @module apps/web/src/features/mailer-settings/api
+ */
+
+export const MailerTransportValues = ['console', 'smtp'] as const;
+export type MailerTransport = (typeof MailerTransportValues)[number];
+
+/**
+ * Response shape for `GET /mailer-settings`. Never includes the SMTP
+ * password — only whether one is currently configured (DB or env).
+ */
+export interface MailerSettingsView {
+  transport: MailerTransport;
+  smtpHost: string | null;
+  smtpPort: number | null;
+  smtpSecure: boolean;
+  fromAddress: string | null;
+  smtpPasswordConfigured: boolean;
+  updatedAt: string | null;
+  updatedBy: string | null;
+}
+
+/** Body for `PUT /mailer-settings`. The SMTP password is written separately. */
+export interface UpdateMailerSettingsInput {
+  transport: MailerTransport;
+  smtpHost: string | null;
+  smtpPort: number | null;
+  smtpSecure: boolean;
+  fromAddress: string | null;
+}
+
+/** Body for `PUT /mailer-settings/credentials`. Server trims `password`. */
+export interface SetMailerCredentialsInput {
+  password: string;
+}

--- a/apps/web/src/features/mailer-settings/components/mailer-settings-dialog.test.tsx
+++ b/apps/web/src/features/mailer-settings/components/mailer-settings-dialog.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Mailer Settings Dialog — Tests
+ *
+ * Covers prefill (non-secret fields only — password stays blank even when
+ * `smtpPasswordConfigured` is true), submit wiring (update, plus a
+ * conditional credentials rotation only when a password was typed), and the
+ * explicit "Clear stored password" action.
+ *
+ * @module apps/web/src/features/mailer-settings/components
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import type { MailerSettingsView } from '../api/mailer-settings.types';
+import { MailerSettingsDialog } from './mailer-settings-dialog';
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+afterEach(cleanup);
+
+const smtpView: MailerSettingsView = {
+  transport: 'smtp',
+  smtpHost: 'smtp.example.com',
+  smtpPort: 587,
+  smtpSecure: true,
+  fromAddress: 'orders@example.com',
+  smtpPasswordConfigured: true,
+  updatedAt: '2026-07-01T00:00:00.000Z',
+  updatedBy: 'admin',
+};
+
+describe('MailerSettingsDialog', () => {
+  it('prefills the non-secret fields and leaves the password blank', () => {
+    renderWithProviders(<MailerSettingsDialog open view={smtpView} onClose={() => undefined} />);
+
+    expect(screen.getByLabelText(/smtp host/i)).toHaveValue('smtp.example.com');
+    expect(screen.getByLabelText(/smtp port/i)).toHaveValue('587');
+    expect(screen.getByLabelText(/from address/i)).toHaveValue('orders@example.com');
+    expect(screen.getByLabelText(/smtp password/i)).toHaveValue('');
+    expect(screen.getByText(/Password configured\. Leave blank to keep it/)).toBeInTheDocument();
+  });
+
+  it('submits the update mutation with the current form values', async () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ mailerSettings: { update } });
+    const onClose = vi.fn();
+
+    renderWithProviders(
+      <MailerSettingsDialog open view={smtpView} onClose={onClose} />,
+      { apiClient },
+    );
+
+    fireEvent.change(screen.getByLabelText(/smtp host/i), {
+      target: { value: 'smtp2.example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledWith({
+        transport: 'smtp',
+        smtpHost: 'smtp2.example.com',
+        smtpPort: 587,
+        smtpSecure: true,
+        fromAddress: 'orders@example.com',
+      });
+    });
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('rotates the password only when a new value was typed', async () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const setCredentials = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ mailerSettings: { update, setCredentials } });
+
+    renderWithProviders(
+      <MailerSettingsDialog open view={smtpView} onClose={() => undefined} />,
+      { apiClient },
+    );
+
+    fireEvent.change(screen.getByLabelText(/smtp password/i), {
+      target: { value: 'new-secret-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(setCredentials).toHaveBeenCalledWith({ password: 'new-secret-password' });
+    });
+  });
+
+  it('does not rotate the password when the field is left blank', async () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const setCredentials = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ mailerSettings: { update, setCredentials } });
+
+    renderWithProviders(
+      <MailerSettingsDialog open view={smtpView} onClose={() => undefined} />,
+      { apiClient },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalled();
+    });
+    expect(setCredentials).not.toHaveBeenCalled();
+  });
+
+  it('clears the stored password when "Clear stored password" is clicked', async () => {
+    const clearCredentials = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ mailerSettings: { clearCredentials } });
+
+    renderWithProviders(
+      <MailerSettingsDialog open view={smtpView} onClose={() => undefined} />,
+      { apiClient },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /clear stored password/i }));
+
+    await waitFor(() => {
+      expect(clearCredentials).toHaveBeenCalled();
+    });
+  });
+
+  it('hides smtp fields and the password control when transport is console', () => {
+    renderWithProviders(
+      <MailerSettingsDialog
+        open
+        view={{ ...smtpView, transport: 'console' }}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByLabelText(/smtp host/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/smtp password/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/mailer-settings/components/mailer-settings-dialog.tsx
+++ b/apps/web/src/features/mailer-settings/components/mailer-settings-dialog.tsx
@@ -1,0 +1,268 @@
+/**
+ * Mailer Settings Dialog
+ *
+ * Edit modal for the DB-backed mailer/SMTP settings. Wraps the Dialog
+ * primitive + React Hook Form / Zod, mirroring
+ * `ai-provider-settings/components/ai-provider-key-dialog.tsx`. Submitting
+ * the form updates the non-secret transport fields and — only when a new
+ * password was typed — rotates the SMTP password in a second request. The
+ * password field is never pre-filled; `smtpPasswordConfigured` drives the
+ * "Password configured" / "No password set" hint instead.
+ *
+ * @module apps/web/src/features/mailer-settings/components
+ */
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect, type ReactElement } from 'react';
+import { useForm } from 'react-hook-form';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '../../../shared/ui/dialog';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { MailerTransportValues, type MailerSettingsView } from '../api/mailer-settings.types';
+import { useClearMailerCredentialsMutation } from '../hooks/use-clear-mailer-credentials-mutation';
+import { useSetMailerCredentialsMutation } from '../hooks/use-set-mailer-credentials-mutation';
+import { useUpdateMailerSettingsMutation } from '../hooks/use-update-mailer-settings-mutation';
+import {
+  mailerSettingsFormSchema,
+  type MailerSettingsFormSubmission,
+  type MailerSettingsFormValues,
+} from './mailer-settings-form.schema';
+
+interface MailerSettingsDialogProps {
+  open: boolean;
+  view: MailerSettingsView;
+  onClose: () => void;
+}
+
+const TRANSPORT_LABEL: Record<(typeof MailerTransportValues)[number], string> = {
+  console: 'Console (log only, no email sent)',
+  smtp: 'SMTP',
+};
+
+function toFormValues(view: MailerSettingsView): MailerSettingsFormValues {
+  return {
+    transport: view.transport,
+    smtpHost: view.smtpHost ?? '',
+    smtpPort: view.smtpPort !== null ? String(view.smtpPort) : '',
+    smtpSecure: view.smtpSecure,
+    fromAddress: view.fromAddress ?? '',
+    password: '',
+  };
+}
+
+export function MailerSettingsDialog({
+  open,
+  view,
+  onClose,
+}: MailerSettingsDialogProps): ReactElement {
+  const { showToast } = useToast();
+  const updateMutation = useUpdateMailerSettingsMutation();
+  const setCredentialsMutation = useSetMailerCredentialsMutation();
+  const clearCredentialsMutation = useClearMailerCredentialsMutation();
+
+  const form = useForm<MailerSettingsFormValues, undefined, MailerSettingsFormSubmission>({
+    defaultValues: toFormValues(view),
+    resolver: zodResolver(mailerSettingsFormSchema),
+  });
+
+  // Reset the form (and any prior mutation error) whenever the dialog opens —
+  // matches the #478 fix in ai-provider-key-dialog.tsx: depend on the
+  // destructured stable methods, not the wrapping `form` / mutation objects,
+  // which get a fresh identity every render and would loop the effect.
+  const { reset: resetForm } = form;
+  const { reset: resetUpdateMutation } = updateMutation;
+  const { reset: resetCredentialsMutation } = setCredentialsMutation;
+  useEffect(() => {
+    if (open) {
+      resetForm(toFormValues(view));
+      resetUpdateMutation();
+      resetCredentialsMutation();
+    }
+    // `view` is intentionally excluded: resetting on every background
+    // refetch (not just on open) would clobber an in-progress edit.
+  }, [open, resetForm, resetUpdateMutation, resetCredentialsMutation]);
+
+  const transport = form.watch('transport');
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      await updateMutation.mutateAsync({
+        transport: values.transport,
+        smtpHost: values.transport === 'smtp' ? values.smtpHost : null,
+        smtpPort: values.transport === 'smtp' ? Number(values.smtpPort) : null,
+        smtpSecure: values.smtpSecure,
+        fromAddress: values.transport === 'smtp' ? values.fromAddress : null,
+      });
+
+      if (values.password.length > 0) {
+        await setCredentialsMutation.mutateAsync({ password: values.password });
+      }
+
+      showToast({
+        tone: 'success',
+        title: 'Mailer settings saved',
+        description: 'Outbound mail will use the updated configuration.',
+      });
+      onClose();
+    } catch {
+      // Surfaced via mutationError → <Alert> below.
+    }
+  });
+
+  const handleClearPassword = async (): Promise<void> => {
+    try {
+      await clearCredentialsMutation.mutateAsync();
+      form.setValue('password', '');
+      showToast({
+        tone: 'success',
+        title: 'SMTP password cleared',
+        description: 'The server falls back to env or none until a new password is set.',
+      });
+    } catch (error) {
+      showToast({
+        tone: 'error',
+        title: 'Could not clear the password',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+
+  const validationMessages = Object.values(form.formState.errors)
+    .map((entry) => entry?.message)
+    .filter((message): message is string => typeof message === 'string');
+
+  const showValidationSummary = form.formState.submitCount > 0 && validationMessages.length > 0;
+
+  const mutationError = updateMutation.error ?? setCredentialsMutation.error;
+  const isSaving = updateMutation.isPending || setCredentialsMutation.isPending;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose();
+      }}
+    >
+      <DialogContent>
+        <DialogTitle>Edit mailer settings</DialogTitle>
+        <DialogDescription>
+          Choose how outbound mail is sent. The SMTP password is write-only — it is never returned by
+          the API.
+        </DialogDescription>
+
+        {mutationError ? (
+          <Alert tone="error" title="Could not save mailer settings">
+            {mutationError.message}
+          </Alert>
+        ) : null}
+
+        <form
+          onSubmit={(event) => {
+            void onSubmit(event);
+          }}
+          noValidate
+        >
+          {showValidationSummary ? <FormErrorSummary errors={validationMessages} /> : null}
+
+          <FormField label="Transport" name="transport">
+            <Select {...form.register('transport')}>
+              {MailerTransportValues.map((value) => (
+                <option key={value} value={value}>
+                  {TRANSPORT_LABEL[value]}
+                </option>
+              ))}
+            </Select>
+          </FormField>
+
+          {transport === 'smtp' ? (
+            <>
+              <FormField
+                label="SMTP host"
+                name="smtpHost"
+                error={form.formState.errors.smtpHost?.message}
+              >
+                <Input placeholder="smtp.example.com" {...form.register('smtpHost')} />
+              </FormField>
+
+              <FormField
+                label="SMTP port"
+                name="smtpPort"
+                error={form.formState.errors.smtpPort?.message}
+              >
+                <Input inputMode="numeric" placeholder="587" {...form.register('smtpPort')} />
+              </FormField>
+
+              <label className="mailer-settings-checkbox">
+                <input type="checkbox" {...form.register('smtpSecure')} />
+                <span>Use implicit TLS (leave unchecked for STARTTLS/plain)</span>
+              </label>
+
+              <FormField
+                label="From address"
+                name="fromAddress"
+                error={form.formState.errors.fromAddress?.message}
+              >
+                <Input type="email" placeholder="orders@example.com" {...form.register('fromAddress')} />
+              </FormField>
+
+              <FormField
+                label="SMTP password"
+                name="password"
+                description={
+                  view.smtpPasswordConfigured
+                    ? 'Password configured. Leave blank to keep it, or enter a new value to rotate it.'
+                    : 'No password set. Enter a value to configure one.'
+                }
+                error={form.formState.errors.password?.message}
+              >
+                <Input
+                  type="password"
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="Leave blank to keep current password"
+                  {...form.register('password')}
+                />
+              </FormField>
+
+              {view.smtpPasswordConfigured ? (
+                <Button
+                  type="button"
+                  tone="ghost"
+                  className="button--sm"
+                  disabled={clearCredentialsMutation.isPending}
+                  onClick={() => {
+                    void handleClearPassword();
+                  }}
+                >
+                  {clearCredentialsMutation.isPending ? 'Clearing…' : 'Clear stored password'}
+                </Button>
+              ) : null}
+            </>
+          ) : null}
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" tone="ghost">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? 'Saving…' : 'Save changes'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/mailer-settings/components/mailer-settings-form.schema.ts
+++ b/apps/web/src/features/mailer-settings/components/mailer-settings-form.schema.ts
@@ -1,0 +1,85 @@
+/**
+ * Mailer Settings Form — Zod Schema
+ *
+ * Port/host/from-address are represented as plain strings in the form (the
+ * port field is a text input so an empty value can be distinguished from
+ * `0`) and only required when `transport === 'smtp'` — mirrors the backend
+ * DTO comment ("the controller does not cross-validate this... trusting the
+ * admin form"), so this is exactly where that validation belongs. The
+ * password field is always optional: leaving it blank keeps whatever is
+ * already stored server-side (write-only, never pre-filled).
+ *
+ * @module apps/web/src/features/mailer-settings/components
+ */
+import { z } from 'zod';
+import { MailerTransportValues } from '../api/mailer-settings.types';
+
+export const MAX_HOST_LENGTH = 255;
+export const MAX_FROM_ADDRESS_LENGTH = 320;
+export const MAX_PASSWORD_LENGTH = 512;
+const MIN_PORT = 1;
+const MAX_PORT = 65535;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const mailerSettingsFormSchema = z
+  .object({
+    transport: z.enum(MailerTransportValues),
+    smtpHost: z.string().trim().max(MAX_HOST_LENGTH, `Host is too long (max ${MAX_HOST_LENGTH} characters)`),
+    smtpPort: z.string().trim(),
+    smtpSecure: z.boolean(),
+    fromAddress: z
+      .string()
+      .trim()
+      .max(MAX_FROM_ADDRESS_LENGTH, `From address is too long (max ${MAX_FROM_ADDRESS_LENGTH} characters)`),
+    password: z
+      .string()
+      .trim()
+      .max(MAX_PASSWORD_LENGTH, `Password is too long (max ${MAX_PASSWORD_LENGTH} characters)`),
+  })
+  .superRefine((values, ctx) => {
+    if (values.transport !== 'smtp') {
+      return;
+    }
+
+    if (values.smtpHost.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['smtpHost'],
+        message: 'Host is required for SMTP transport',
+      });
+    }
+
+    if (values.smtpPort.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['smtpPort'],
+        message: 'Port is required for SMTP transport',
+      });
+    } else {
+      const port = Number(values.smtpPort);
+      if (!Number.isInteger(port) || port < MIN_PORT || port > MAX_PORT) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['smtpPort'],
+          message: `Port must be an integer between ${MIN_PORT} and ${MAX_PORT}`,
+        });
+      }
+    }
+
+    if (values.fromAddress.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['fromAddress'],
+        message: 'From address is required for SMTP transport',
+      });
+    } else if (!EMAIL_PATTERN.test(values.fromAddress)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['fromAddress'],
+        message: 'Enter a valid email address',
+      });
+    }
+  });
+
+export type MailerSettingsFormValues = z.input<typeof mailerSettingsFormSchema>;
+export type MailerSettingsFormSubmission = z.output<typeof mailerSettingsFormSchema>;

--- a/apps/web/src/features/mailer-settings/components/mailer-settings-tile.test.tsx
+++ b/apps/web/src/features/mailer-settings/components/mailer-settings-tile.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Mailer Settings Tile — Tests
+ *
+ * Covers the tile's loading/error/success (console default + smtp-configured)
+ * states. Rendered under an admin session throughout — non-admin visibility
+ * is asserted at the page level in `settings-page.test.tsx`, since gating
+ * lives there, not in this component.
+ *
+ * @module apps/web/src/features/mailer-settings/components
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+} from '../../../test/test-utils';
+import type { MailerSettingsView } from '../api/mailer-settings.types';
+import { MailerSettingsTile } from './mailer-settings-tile';
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+afterEach(cleanup);
+
+const adminSessionAdapter = createAuthenticatedSessionAdapter();
+
+const consoleView: MailerSettingsView = {
+  transport: 'console',
+  smtpHost: null,
+  smtpPort: null,
+  smtpSecure: false,
+  fromAddress: null,
+  smtpPasswordConfigured: false,
+  updatedAt: null,
+  updatedBy: null,
+};
+
+const smtpView: MailerSettingsView = {
+  transport: 'smtp',
+  smtpHost: 'smtp.example.com',
+  smtpPort: 587,
+  smtpSecure: false,
+  fromAddress: 'orders@example.com',
+  smtpPasswordConfigured: true,
+  updatedAt: '2026-07-01T00:00:00.000Z',
+  updatedBy: 'admin',
+};
+
+describe('MailerSettingsTile', () => {
+  it('shows a loading state while the settings query is in flight', async () => {
+    const apiClient = createMockApiClient({
+      mailerSettings: { get: vi.fn(() => new Promise<MailerSettingsView>(() => {})) },
+    });
+    renderWithProviders(<MailerSettingsTile />, { sessionAdapter: adminSessionAdapter, apiClient });
+
+    // Query is gated on session readiness (isAdmin), which resolves
+    // asynchronously — wait for it before asserting the loading state.
+    expect(await screen.findByText('Loading mailer settings…')).toBeInTheDocument();
+  });
+
+  it('shows an error state when the settings query fails', async () => {
+    const apiClient = createMockApiClient({
+      mailerSettings: { get: vi.fn().mockRejectedValue(new Error('Network down')) },
+    });
+    renderWithProviders(<MailerSettingsTile />, { sessionAdapter: adminSessionAdapter, apiClient });
+
+    expect(
+      await screen.findByText(/Could not load mailer settings: Network down/),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the console default with no smtp fields', async () => {
+    const apiClient = createMockApiClient({
+      mailerSettings: { get: vi.fn().mockResolvedValue(consoleView) },
+    });
+    renderWithProviders(<MailerSettingsTile />, { sessionAdapter: adminSessionAdapter, apiClient });
+
+    expect(await screen.findByText('Console')).toBeInTheDocument();
+    expect(screen.queryByText('Host')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+  });
+
+  it('shows the smtp host/port/from/password summary when configured', async () => {
+    const apiClient = createMockApiClient({
+      mailerSettings: { get: vi.fn().mockResolvedValue(smtpView) },
+    });
+    renderWithProviders(<MailerSettingsTile />, { sessionAdapter: adminSessionAdapter, apiClient });
+
+    expect(await screen.findByText('SMTP')).toBeInTheDocument();
+    expect(screen.getByText('smtp.example.com')).toBeInTheDocument();
+    expect(screen.getByText('587')).toBeInTheDocument();
+    expect(screen.getByText('orders@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Configured')).toBeInTheDocument();
+  });
+
+  it('opens the edit dialog when Edit is clicked', async () => {
+    const apiClient = createMockApiClient({
+      mailerSettings: { get: vi.fn().mockResolvedValue(smtpView) },
+    });
+    renderWithProviders(<MailerSettingsTile />, { sessionAdapter: adminSessionAdapter, apiClient });
+
+    const editButton = await screen.findByRole('button', { name: 'Edit' });
+    fireEvent.click(editButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit mailer settings')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/features/mailer-settings/components/mailer-settings-tile.tsx
+++ b/apps/web/src/features/mailer-settings/components/mailer-settings-tile.tsx
@@ -1,0 +1,98 @@
+/**
+ * Mailer Settings Tile
+ *
+ * Read-only summary of the current mailer/SMTP transport, rendered on
+ * `/settings` next to the Environment and Account tiles. Admin-only — the
+ * caller (`settings-page.tsx`) mounts this component only for an
+ * authenticated admin session, so a non-admin never even triggers the
+ * `GET /mailer-settings` request.
+ *
+ * @module apps/web/src/features/mailer-settings/components
+ */
+import { useState, type ReactElement } from 'react';
+import { Button } from '../../../shared/ui/button';
+import { useMailerSettingsQuery } from '../hooks/use-mailer-settings-query';
+import { MailerSettingsDialog } from './mailer-settings-dialog';
+
+const TRANSPORT_LABEL: Record<'console' | 'smtp', string> = {
+  console: 'Console',
+  smtp: 'SMTP',
+};
+
+export function MailerSettingsTile(): ReactElement {
+  const query = useMailerSettingsQuery();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <article className="panel panel--dense">
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">Outbound mail</p>
+          <h3 className="section-title">Mailer</h3>
+        </div>
+        <span className="panel__meta">Admin only</span>
+      </div>
+
+      {query.isLoading ? (
+        <p className="muted-text" aria-live="polite">
+          Loading mailer settings…
+        </p>
+      ) : null}
+
+      {query.isError ? (
+        <p className="muted-text" role="alert">
+          Could not load mailer settings: {query.error.message}
+        </p>
+      ) : null}
+
+      {query.data ? (
+        <>
+          <dl className="definition-list">
+            <div>
+              <dt>Transport</dt>
+              <dd>{TRANSPORT_LABEL[query.data.transport]}</dd>
+            </div>
+            {query.data.transport === 'smtp' ? (
+              <>
+                <div>
+                  <dt>Host</dt>
+                  <dd className="mono-text">{query.data.smtpHost ?? '—'}</dd>
+                </div>
+                <div>
+                  <dt>Port</dt>
+                  <dd className="mono-text">{query.data.smtpPort ?? '—'}</dd>
+                </div>
+                <div>
+                  <dt>From address</dt>
+                  <dd className="mono-text">{query.data.fromAddress ?? '—'}</dd>
+                </div>
+                <div>
+                  <dt>SMTP password</dt>
+                  <dd>{query.data.smtpPasswordConfigured ? 'Configured' : 'Not set'}</dd>
+                </div>
+              </>
+            ) : null}
+          </dl>
+
+          <Button
+            tone="secondary"
+            className="button--sm"
+            onClick={() => {
+              setDialogOpen(true);
+            }}
+          >
+            Edit
+          </Button>
+
+          <MailerSettingsDialog
+            open={dialogOpen}
+            view={query.data}
+            onClose={() => {
+              setDialogOpen(false);
+            }}
+          />
+        </>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/src/features/mailer-settings/hooks/use-clear-mailer-credentials-mutation.ts
+++ b/apps/web/src/features/mailer-settings/hooks/use-clear-mailer-credentials-mutation.ts
@@ -1,0 +1,24 @@
+/**
+ * Clear Mailer Credentials Mutation
+ *
+ * Removes the stored SMTP password. After success the resolved transport
+ * config falls back to the env var (if set) or reports no password
+ * configured. Invalidates the settings query so the dialog/tile reflect the
+ * new state.
+ *
+ * @module apps/web/src/features/mailer-settings/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { mailerSettingsQueryKeys } from '../api/mailer-settings.query-keys';
+
+export function useClearMailerCredentialsMutation(): UseMutationResult<void, Error, void> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => apiClient.mailerSettings.clearCredentials(),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: mailerSettingsQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/mailer-settings/hooks/use-mailer-settings-query.ts
+++ b/apps/web/src/features/mailer-settings/hooks/use-mailer-settings-query.ts
@@ -1,0 +1,27 @@
+/**
+ * Mailer Settings Query Hook
+ *
+ * Reads the mailer/SMTP settings view. Gated on admin role so non-admin
+ * sessions don't trigger a 403 round-trip — the tile isn't rendered for
+ * them at all (see `settings-page.tsx`), but the hook stays defensively
+ * gated to match the `ai-provider-settings` precedent.
+ *
+ * @module apps/web/src/features/mailer-settings/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { useSession } from '../../../shared/auth/use-session';
+import { mailerSettingsQueryKeys } from '../api/mailer-settings.query-keys';
+import type { MailerSettingsView } from '../api/mailer-settings.types';
+
+export function useMailerSettingsQuery(): UseQueryResult<MailerSettingsView> {
+  const apiClient = useApiClient();
+  const { session } = useSession();
+  const isAdmin = session.status === 'authenticated' && session.user?.role === 'admin';
+
+  return useQuery({
+    queryKey: mailerSettingsQueryKeys.current(),
+    queryFn: () => apiClient.mailerSettings.get(),
+    enabled: isAdmin,
+  });
+}

--- a/apps/web/src/features/mailer-settings/hooks/use-set-mailer-credentials-mutation.ts
+++ b/apps/web/src/features/mailer-settings/hooks/use-set-mailer-credentials-mutation.ts
@@ -1,0 +1,27 @@
+/**
+ * Set Mailer Credentials Mutation
+ *
+ * Persists a new SMTP password. Write-only — the value is never echoed back.
+ * Invalidates the settings query so `smtpPasswordConfigured` flips to `true`.
+ *
+ * @module apps/web/src/features/mailer-settings/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { mailerSettingsQueryKeys } from '../api/mailer-settings.query-keys';
+import type { SetMailerCredentialsInput } from '../api/mailer-settings.types';
+
+export function useSetMailerCredentialsMutation(): UseMutationResult<
+  void,
+  Error,
+  SetMailerCredentialsInput
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input) => apiClient.mailerSettings.setCredentials(input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: mailerSettingsQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/mailer-settings/hooks/use-update-mailer-settings-mutation.ts
+++ b/apps/web/src/features/mailer-settings/hooks/use-update-mailer-settings-mutation.ts
@@ -1,0 +1,27 @@
+/**
+ * Update Mailer Settings Mutation
+ *
+ * Persists the non-secret transport/host/port/secure/from fields. Invalidates
+ * the settings query on success so the tile + dialog refetch the new state.
+ *
+ * @module apps/web/src/features/mailer-settings/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { mailerSettingsQueryKeys } from '../api/mailer-settings.query-keys';
+import type { UpdateMailerSettingsInput } from '../api/mailer-settings.types';
+
+export function useUpdateMailerSettingsMutation(): UseMutationResult<
+  void,
+  Error,
+  UpdateMailerSettingsInput
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input) => apiClient.mailerSettings.update(input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: mailerSettingsQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5905,6 +5905,20 @@ a.kpi-card:focus-visible {
   color: var(--text-primary);
 }
 
+/*
+ * ── Mailer Settings (#1644) ─────────────────────────────────────────
+ * The dialog renders inside the shared `Dialog` primitive; this covers the
+ * SMTP-secure checkbox label, same shape as `.create-offer-checkbox`.
+ */
+.mailer-settings-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  margin: 0.75rem 0;
+}
+
 .create-offer-variant-picker {
   display: grid;
   gap: 0.5rem;

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -56,4 +56,31 @@ describe('SettingsPage', () => {
     expect(headingNames).toContain('Organization');
     expect(headingNames).toContain('Preferences');
   });
+
+  it('shows the Mailer tile for an admin session', async () => {
+    renderWithProviders(<SettingsPage />, {
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Mailer' })).toBeInTheDocument();
+    expect(screen.getByText('Mailer', { selector: '.toolbar-chip' })).toBeInTheDocument();
+  });
+
+  it('never renders the Mailer tile for a non-admin session', async () => {
+    renderWithProviders(<SettingsPage />, {
+      sessionAdapter: createAuthenticatedSessionAdapter({
+        id: 'user_2',
+        username: 'viewer',
+        email: 'viewer@example.com',
+        role: 'viewer',
+        permissions: [],
+      }),
+    });
+
+    // Wait for the authenticated Account tile to confirm session resolution,
+    // then assert the Mailer tile is fully absent — not disabled, not present.
+    expect(await screen.findByText('viewer@example.com')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Mailer' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Mailer', { selector: '.toolbar-chip' })).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -1,10 +1,12 @@
 import type { ReactElement } from 'react';
 import { env } from '../../shared/config/env';
 import { useSession } from '../../shared/auth/use-session';
+import { MailerSettingsTile } from '../../features/mailer-settings/components/mailer-settings-tile';
 import { PageLayout } from '../../shared/ui/page-layout';
 
 export function SettingsPage(): ReactElement {
   const { isReady, session } = useSession();
+  const isAdmin = isReady && session.status === 'authenticated' && session.user?.role === 'admin';
 
   return (
     <PageLayout
@@ -15,6 +17,7 @@ export function SettingsPage(): ReactElement {
         <div className="toolbar__group">
           <span className="toolbar-chip">Environment</span>
           <span className="toolbar-chip">Account</span>
+          {isAdmin ? <span className="toolbar-chip">Mailer</span> : null}
           <span className="toolbar-chip">Upcoming</span>
         </div>
       }
@@ -78,6 +81,9 @@ export function SettingsPage(): ReactElement {
             </dl>
           )}
         </article>
+
+        {/* ── Mailer (admin-only) ──────────────────────────────────── */}
+        {isAdmin ? <MailerSettingsTile /> : null}
 
         {/* ── Notifications (planned) ───────────────────────────────── */}
         <article className="panel panel--dense">

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -353,6 +353,22 @@ export function createMockApiClient(
       }),
       ...overrides.listings,
     } as ApiClient['listings'],
+    mailerSettings: {
+      get: vi.fn().mockResolvedValue({
+        transport: 'console',
+        smtpHost: null,
+        smtpPort: null,
+        smtpSecure: false,
+        fromAddress: null,
+        smtpPasswordConfigured: false,
+        updatedAt: null,
+        updatedBy: null,
+      }),
+      update: vi.fn().mockResolvedValue(undefined),
+      setCredentials: vi.fn().mockResolvedValue(undefined),
+      clearCredentials: vi.fn().mockResolvedValue(undefined),
+      ...overrides.mailerSettings,
+    } as ApiClient['mailerSettings'],
     products: {
       list: vi.fn().mockResolvedValue({
         items: [],


### PR DESCRIPTION
## Summary

Adds the frontend half of mailer/SMTP settings management (backend landed in #1643). Admin sessions now see a third tile on `/settings`, next to Environment and Account, following the existing `panel panel--dense` markup:

- Read-only summary of the current transport (`console` | `smtp`) and, for `smtp`, the host/port/from address plus whether an SMTP password is configured - the password value itself is never displayed or returned by the API.
- An "Edit" action opens a modal (`shared/ui/dialog.tsx`) with a React Hook Form + Zod form to update transport/host/port/secure/from-address and set/rotate/clear the SMTP password. The password field is always blank on open (write-only) regardless of `smtpPasswordConfigured`.
- New feature slice `apps/web/src/features/mailer-settings/` (api client, query-key factory, hooks, form schema, tile + dialog components), modeled directly on `apps/web/src/features/ai-provider-settings/`.
- Admin-only visibility: the tile is gated on `session.user.role === 'admin'` in `settings-page.tsx` - the same check used by the app shell and the prompt-templates page. A non-admin session never mounts `MailerSettingsTile`, so it never issues the `GET /mailer-settings` request and the tile is fully absent, not just disabled.
- No new route: the modal lives on the existing `/settings` page, per the issue's explicit design choice.

## Test plan

- [x] `pnpm --filter @openlinker/web lint` - 0 errors (79 pre-existing warnings unrelated to this change)
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] `pnpm --filter @openlinker/web test` scoped to `src/features/mailer-settings` and `src/pages/settings/settings-page.test.tsx` - 18/18 passing, covering tile loading/error/console-default/smtp-configured states, dialog prefill (password always blank), submit wiring, conditional password rotation, clear-password action, and admin-only tile visibility at the page level
- [ ] Manual verification against a live admin session at `http://localhost:8090/settings`

Part of #1606
Closes #1644