### PR TITLE
fix(web/listings): stop hiding Create offer / Publish to shop from demo viewers

### DIFF
--- a/apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx
@@ -1508,4 +1508,41 @@ describe('AllegroCreateOfferWizard', () => {
       expect(screen.queryByText(/Matched from/i)).not.toBeInTheDocument();
     });
   });
+
+  describe('demo read-only viewer (#1663)', () => {
+    it('reaches the Review step with every field editable but disables the final Create offer submit', async () => {
+      const createOffer = vi.fn();
+      const mockApi = defaultMocks({
+        listings: { createOffer, getSellerPolicies: vi.fn().mockResolvedValue(policies) },
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      });
+
+      renderWithProviders(
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await advanceToStep2();
+      await pickFirstLeafCategory();
+      fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
+      fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      await advanceThroughEmptyParameters();
+
+      const deliverySelect = await screen.findByLabelText(/delivery policy/i);
+      fireEvent.change(deliverySelect, { target: { value: 'del-1' } });
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+      // Review step reached — the wizard was fully walkable in demo mode.
+      const submitButton = await screen.findByRole('button', { name: /create offer/i });
+      expect(submitButton).toBeDisabled();
+
+      fireEvent.click(submitButton);
+      expect(createOffer).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx
@@ -44,6 +44,10 @@ import { Select } from '../../../shared/ui/select';
 import { SetupStepper } from '../../../shared/ui/setup-stepper';
 import { Textarea } from '../../../shared/ui/textarea';
 import { useToast } from '../../../shared/ui/toast-provider';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
+import { useDemoMode } from '../../system';
 import { useDebouncedValue } from '../../../shared/hooks/use-debounced-value';
 import type { Connection } from '../../connections';
 import { SuggestionDialog } from '../../content';
@@ -237,6 +241,12 @@ export function AllegroCreateOfferWizard({
   // Fresh idempotency key per mount. Re-mount = launcher close+reopen =
   // a new key naturally (#307 acceptance preserved).
   const idempotencyKeyRef = useRef<string>(crypto.randomUUID());
+
+  // A demo viewer can walk the whole wizard (all steps stay editable); only
+  // the final "Create offer" submit is gated (#1663), mirroring the
+  // visible-but-disabled pattern from ConnectionActionsPanel (#1615).
+  const demoMode = useDemoMode();
+  const write = useWriteAccess('listings:write', demoMode);
 
   const form = useForm<CreateOfferFieldsValues, undefined, CreateOfferFieldsSubmission>({
     // Connection id is fixed by the launcher's pick. Variant defaults to
@@ -1314,9 +1324,15 @@ export function AllegroCreateOfferWizard({
               Next
             </Button>
           ) : (
-            <Button type="submit" form="create-offer-form" disabled={mutation.isPending}>
-              {mutation.isPending ? 'Submitting…' : 'Create offer'}
-            </Button>
+            <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+              <Button
+                type="submit"
+                form="create-offer-form"
+                disabled={mutation.isPending || write.demoReadOnly}
+              >
+                {mutation.isPending ? 'Submitting…' : 'Create offer'}
+              </Button>
+            </ReadOnlyLock>
           )}
         </div>
       </div>

--- a/apps/web/src/features/listings/components/WoocommercePublishWizard.test.tsx
+++ b/apps/web/src/features/listings/components/WoocommercePublishWizard.test.tsx
@@ -280,4 +280,59 @@ describe('WoocommercePublishWizard', () => {
     expect((await screen.findAllByText(/whole number/i)).length).toBeGreaterThan(0);
     expect(shopPublish).not.toHaveBeenCalled();
   });
+
+  describe('demo read-only viewer (#1663)', () => {
+    it('lets a demo viewer edit the Configure step but disables the final Publish submit', async () => {
+      const shopPublish = vi.fn();
+      const apiClient = createMockApiClient({
+        listings: { shopPublish },
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      });
+
+      renderWithProviders(
+        <WoocommercePublishWizard
+          connection={wooConnection}
+          defaultVariantId="ol_variant_1"
+          onCancel={vi.fn()}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient },
+      );
+
+      const stockInput = await screen.findByPlaceholderText('master');
+      fireEvent.change(stockInput, { target: { value: '5' } });
+      expect(stockInput).not.toBeDisabled();
+
+      const submitButton = screen.getByRole('button', { name: /^publish$/i });
+      expect(submitButton).toBeDisabled();
+      fireEvent.click(submitButton);
+      expect(shopPublish).not.toHaveBeenCalled();
+    });
+
+    it('lets a demo viewer reach the single-mode Review step but disables Confirm & publish', async () => {
+      const shopPublish = vi.fn();
+      const apiClient = createMockApiClient({
+        listings: { shopPublish },
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      });
+
+      renderWithProviders(
+        <WoocommercePublishWizard
+          connection={wooConnection}
+          defaultVariantId="ol_variant_1"
+          onCancel={vi.fn()}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient },
+      );
+
+      await screen.findByPlaceholderText('master');
+      fireEvent.click(screen.getByRole('button', { name: /^review$/i }));
+
+      const confirmButton = await screen.findByRole('button', { name: /confirm & publish/i });
+      expect(confirmButton).toBeDisabled();
+      fireEvent.click(confirmButton);
+      expect(shopPublish).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/web/src/features/listings/components/WoocommercePublishWizard.tsx
+++ b/apps/web/src/features/listings/components/WoocommercePublishWizard.tsx
@@ -43,6 +43,10 @@ import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { StatusBadge } from '../../../shared/ui/status-badge';
 import { useToast } from '../../../shared/ui/toast-provider';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
+import { useDemoMode } from '../../system';
 import { useDebouncedValue } from '../../../shared/hooks/use-debounced-value';
 import type { Connection } from '../../connections';
 import { useInventoryAvailabilityBatchQuery } from '../../inventory';
@@ -192,6 +196,13 @@ export function WoocommercePublishWizard({
   const bulkMutation = useBulkShopPublishMutation();
   const { showToast } = useToast();
   const idempotencyKeyRef = useRef<string>(crypto.randomUUID());
+
+  // A demo viewer can walk the whole wizard (selection, Configure, Review
+  // all stay editable); only the final publish submit is gated (#1663),
+  // mirroring the visible-but-disabled pattern from ConnectionActionsPanel
+  // (#1615).
+  const demoMode = useDemoMode();
+  const write = useWriteAccess('listings:write', demoMode);
 
   const [reviewing, setReviewing] = useState(false);
 
@@ -648,9 +659,11 @@ export function WoocommercePublishWizard({
             </Button>
           </div>
           <div className="wizard-actions__group">
-            <Button type="submit" disabled={isPending}>
-              {isPending ? 'Publishing…' : 'Confirm & publish'}
-            </Button>
+            <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+              <Button type="submit" disabled={isPending || write.demoReadOnly}>
+                {isPending ? 'Publishing…' : 'Confirm & publish'}
+              </Button>
+            </ReadOnlyLock>
           </div>
         </div>
       </form>
@@ -852,18 +865,22 @@ export function WoocommercePublishWizard({
               Review
             </Button>
           ) : null}
-          <Button
-            type="submit"
-            disabled={
-              isPending || (mode === 'bulk' ? itemsFieldArray.fields.length === 0 : !singleId)
-            }
-          >
-            {isPending
-              ? 'Publishing…'
-              : mode === 'bulk'
-                ? `Publish ${itemsFieldArray.fields.length} products`
-                : 'Publish'}
-          </Button>
+          <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+            <Button
+              type="submit"
+              disabled={
+                isPending ||
+                write.demoReadOnly ||
+                (mode === 'bulk' ? itemsFieldArray.fields.length === 0 : !singleId)
+              }
+            >
+              {isPending
+                ? 'Publishing…'
+                : mode === 'bulk'
+                  ? `Publish ${itemsFieldArray.fields.length} products`
+                  : 'Publish'}
+            </Button>
+          </ReadOnlyLock>
         </div>
       </div>
     </form>

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -290,4 +290,78 @@ describe('ListingsListPage', () => {
 
     expect(await screen.findByRole('button', { name: /publish to shop/i })).toBeInTheDocument();
   });
+
+  describe('demo read-only viewer (#1663)', () => {
+    const viewerSession = {
+      sessionAdapter: createAuthenticatedSessionAdapter({
+        id: 'u2',
+        username: 'viewer',
+        email: null,
+        role: 'viewer',
+        permissions: ['listings:read'],
+      }),
+    };
+
+    function demoApiClient(): ReturnType<typeof createMockApiClient> {
+      return createMockApiClient({
+        listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+        connections: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 'conn_woo_1',
+              name: 'Main WooCommerce store',
+              platformType: 'woocommerce',
+              status: 'active',
+              config: {},
+              credentialsBacked: true,
+              adapterKey: 'woocommerce.restapi.v3',
+              enabledCapabilities: ['ProductPublisher'],
+              supportedCapabilities: ['ProductPublisher'],
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-01T00:00:00Z',
+            },
+          ]),
+        },
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      });
+    }
+
+    it('shows both Create offer and Publish to shop enabled instead of hiding them', async () => {
+      renderWithProviders(<ListingsListPage />, { apiClient: demoApiClient(), ...viewerSession });
+
+      const createOffer = await screen.findByRole('button', { name: /create offer/i });
+      expect(createOffer).not.toBeDisabled();
+      const publishToShop = screen.getByRole('button', { name: /publish to shop/i });
+      expect(publishToShop).not.toBeDisabled();
+    });
+
+    it('keeps the existing hide-when-missing behaviour for an unauthorized non-demo viewer', async () => {
+      const mockApi = createMockApiClient({
+        listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+        connections: {
+          list: vi.fn().mockResolvedValue([
+            {
+              id: 'conn_woo_1',
+              name: 'Main WooCommerce store',
+              platformType: 'woocommerce',
+              status: 'active',
+              config: {},
+              credentialsBacked: true,
+              adapterKey: 'woocommerce.restapi.v3',
+              enabledCapabilities: ['ProductPublisher'],
+              supportedCapabilities: ['ProductPublisher'],
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-01T00:00:00Z',
+            },
+          ]),
+        },
+      });
+
+      renderWithProviders(<ListingsListPage />, { apiClient: mockApi, ...viewerSession });
+
+      await screen.findByText('allegro-offer-999');
+      expect(screen.queryByRole('button', { name: /create offer/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /publish to shop/i })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -17,7 +17,8 @@ import {
   selectShopPublishConnections,
 } from '../../features/listings/components/ShopPublishLauncher';
 import { useConnectionsQuery } from '../../features/connections';
-import { usePermission } from '../../shared/auth/use-permission';
+import { useWriteAccess } from '../../shared/auth/use-permission';
+import { useDemoMode } from '../../features/system';
 import type {
   CreateOfferRequest,
   ListingsFilters,
@@ -152,7 +153,11 @@ export function ListingsListPage(): ReactElement {
   const connectionsQuery = useConnectionsQuery();
   const shopPublishConnections = selectShopPublishConnections(connectionsQuery.data ?? []);
   const canPublishToShop = shopPublishConnections.length > 0;
-  const canWrite = usePermission('listings:write');
+  const demoMode = useDemoMode();
+  // "Create offer" and "Publish to shop" both open a wizard first — visible
+  // (enabled) for a demo viewer per the useWriteAccess + ReadOnlyLock pattern
+  // (#1615/#1613); the wizards themselves gate their own final submit (#1663).
+  const write = useWriteAccess('listings:write', demoMode);
 
   const [isWizardOpen, setIsWizardOpen] = useState(false);
   const [isShopPublishOpen, setIsShopPublishOpen] = useState(false);
@@ -206,7 +211,7 @@ export function ListingsListPage(): ReactElement {
       title="Listings"
       description="Offer mapping workbench — browse offer-to-variant identifier mappings across platforms."
       actions={
-        canWrite ? (
+        write.visible ? (
           <>
             <Button onClick={() => setIsWizardOpen(true)}>Create offer</Button>
             {canPublishToShop ? (


### PR DESCRIPTION
## Problem

`ListingsListPage` gated both the "Create offer" button (opens the single-offer `AllegroCreateOfferWizard`) and the "Publish to shop" button (opens `ShopPublishLauncher` / `WoocommercePublishWizard`) behind a single `canWrite` check that rendered the whole actions block as `null` when missing. A demo viewer never saw either button, so could never reach either wizard's Confirm step, even though the wizards' internal read endpoints are already viewer-accessible (#1608).

## Change

Reuses the established `useWriteAccess(permission, demoMode)` + `ReadOnlyLock` pattern from `ConnectionActionsPanel` (#1615) and `OrderInvoicePanel` (#1613) instead of inventing a new mechanism:

- `listings-list-page.tsx`: replaced the `canWrite ? (...) : null` hide-gate with `write.visible` (`useWriteAccess('listings:write', demoMode)`). Both entry buttons only *open* a wizard, so they stay enabled for a demo viewer (mirrors the "Edit connection" / "Trigger sync" open-a-form buttons in `ConnectionActionsPanel`, which are not wrapped in `ReadOnlyLock`). Genuinely unauthorized non-demo sessions keep the existing hide behaviour.
- `AllegroCreateOfferWizard.tsx`: the final Step-5 "Create offer" submit is now wrapped in `ReadOnlyLock` and disabled for a demo viewer (`write.demoReadOnly`). Every other step stays fully editable.
- `WoocommercePublishWizard.tsx`: the same treatment on both final-submit paths - the Configure step's "Publish" / "Publish N products" button and the single-mode Review step's "Confirm & publish" button.

## Tests

- `listings-list-page.test.tsx`: demo viewer sees both entry buttons enabled (not hidden); a genuinely unauthorized non-demo viewer still gets the hide behaviour.
- `AllegroCreateOfferWizard.test.tsx`: demo viewer can walk the wizard to the Review step with all fields editable; the final submit is disabled and clicking it never calls the create-offer API.
- `WoocommercePublishWizard.test.tsx`: demo viewer can edit the Configure step and reach the single-mode Review step; both final-submit buttons are disabled and never call the publish API.

Verified the single-offer wizard's internal read-lookup hooks (`useSellerPoliciesQuery`, `useCategoryParametersQuery`, `useResolveCategoryQuery`, `useCatalogProductMatchQuery`, `useCatalogProductQuery`) render correctly for a demo viewer once the entry button is reachable - no new backend gap found; this confirms #1608's fix already covers them.

## Quality gate

- `pnpm --filter @openlinker/web lint` - 0 errors (pre-existing warnings only, none introduced by this change)
- `pnpm --filter @openlinker/web type-check` - clean
- Scoped Vitest run (listings feature + listings pages + the two reference demo-mode panels) - 397 passed

Part of #1606
Closes #1663