### PR TITLE
fix(web): convert remaining hide-when-missing write gates to demo read-only

### DIFF
--- a/apps/web/src/features/connections/components/create-connection-form.test.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.test.tsx
@@ -1,9 +1,10 @@
 import type { ReactElement } from 'react';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { useLocation } from 'react-router-dom';
 import { CreateConnectionForm } from './create-connection-form';
 import {
+  createAuthenticatedSessionAdapter,
   createMockApiClient,
   findToastDescription,
   findToastTitle,
@@ -120,5 +121,50 @@ describe('CreateConnectionForm', () => {
 
     expect(await screen.findByText('Unable to create connection')).toBeInTheDocument();
     expect(screen.getByText('API create failed')).toBeInTheDocument();
+  });
+
+  describe('demo read-only viewer (#1667)', () => {
+    const viewerSession = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: null,
+      role: 'viewer',
+      permissions: ['connections:read'],
+    });
+
+    function demoApiClient(): ReturnType<typeof createMockApiClient> {
+      return createMockApiClient({
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      });
+    }
+
+    it('opens with editable inputs but disables the final submit', async () => {
+      const view = renderWithProviders(<CreateConnectionForm />, {
+        apiClient: demoApiClient(),
+        sessionAdapter: viewerSession,
+      });
+
+      const nameInput = await within(view.container).findByLabelText('Connection name');
+      expect(nameInput).not.toBeDisabled();
+      fireEvent.change(nameInput, { target: { value: 'Should not persist' } });
+      expect(nameInput).toHaveValue('Should not persist');
+
+      const submit = within(view.container).getByRole('button', { name: 'Create connection' });
+      await waitFor(() => {
+        expect(submit).toBeDisabled();
+      });
+    });
+
+    it('keeps the submit enabled for an admin session even in demo mode', async () => {
+      const view = renderWithProviders(<CreateConnectionForm />, {
+        apiClient: demoApiClient(),
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      const submit = await within(view.container).findByRole('button', { name: 'Create connection' });
+      await waitFor(() => {
+        expect(submit).not.toBeDisabled();
+      });
+    });
   });
 });

--- a/apps/web/src/features/connections/components/create-connection-form.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.tsx
@@ -20,6 +20,10 @@ import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
 import { Textarea } from '../../../shared/ui/textarea';
 import { useToast } from '../../../shared/ui/toast-provider';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
+import { useDemoMode } from '../../system';
 
 const DEFAULT_CONFIG = JSON.stringify(
   {
@@ -45,6 +49,11 @@ export function CreateConnectionForm(): ReactElement {
   const navigate = useNavigate();
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
   const plugins = usePlatforms();
+  const demoMode = useDemoMode();
+  // The page-level "New connection" CTA that opens this form stays enabled
+  // for a demo viewer (#1667); only this form's own final submit is locked,
+  // matching EditConnectionForm's "Save changes" treatment (#1615).
+  const write = useWriteAccess('connections:write', demoMode);
   const platformOptions = plugins.map((p) => ({ value: p.platformType, label: p.displayName }));
   const form = useForm<CreateConnectionFormValues, undefined, CreateConnectionFormSubmission>({
     defaultValues: DEFAULT_VALUES,
@@ -206,9 +215,11 @@ export function CreateConnectionForm(): ReactElement {
 
         {requiresExternalAuthRedirect ? null : (
           <div className="form-actions">
-            <Button type="submit" disabled={createConnection.isPending}>
-              {createConnection.isPending ? 'Creating...' : 'Create connection'}
-            </Button>
+            <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+              <Button type="submit" disabled={createConnection.isPending || write.demoReadOnly}>
+                {createConnection.isPending ? 'Creating...' : 'Create connection'}
+              </Button>
+            </ReadOnlyLock>
             <Button tone="secondary" onClick={() => setIsResetDialogOpen(true)} disabled={createConnection.isPending}>
               Reset draft
             </Button>

--- a/apps/web/src/pages/connections/connections-list-page.test.tsx
+++ b/apps/web/src/pages/connections/connections-list-page.test.tsx
@@ -68,4 +68,53 @@ describe('ConnectionsListPage', () => {
     expect(screen.getByRole('combobox', { name: 'Filter by platform' })).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: 'Filter by status' })).toBeInTheDocument();
   });
+
+  describe('demo read-only viewer (#1667)', () => {
+    const viewerSession = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: null,
+      role: 'viewer',
+      permissions: ['connections:read'],
+    });
+
+    function demoApiClient(
+      overrides: Parameters<typeof createMockApiClient>[0] = {},
+    ): ReturnType<typeof createMockApiClient> {
+      return createMockApiClient({
+        ...overrides,
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      });
+    }
+
+    it('renders "New connection" visible and enabled for a demo viewer', async () => {
+      renderWithProviders(<ConnectionsListPage />, {
+        apiClient: demoApiClient({ connections: { list: vi.fn().mockResolvedValue([sampleConnection]) } }),
+        sessionAdapter: viewerSession,
+      });
+
+      const cta = await screen.findByRole('link', { name: 'New connection' });
+      expect(cta).toHaveAttribute('href', '/connections/new');
+    });
+
+    it('renders "Add the first connection" visible and enabled for a demo viewer on the empty state', async () => {
+      renderWithProviders(<ConnectionsListPage />, {
+        apiClient: demoApiClient({ connections: { list: vi.fn().mockResolvedValue([]) } }),
+        sessionAdapter: viewerSession,
+      });
+
+      const cta = await screen.findByRole('link', { name: 'Add the first connection' });
+      expect(cta).toHaveAttribute('href', '/connections/new');
+    });
+
+    it('hides "New connection" for a genuinely unauthorized non-demo viewer', async () => {
+      renderWithProviders(<ConnectionsListPage />, {
+        apiClient: createMockApiClient({ connections: { list: vi.fn().mockResolvedValue([sampleConnection]) } }),
+        sessionAdapter: viewerSession,
+      });
+
+      await screen.findByText(sampleConnection.name);
+      expect(screen.queryByRole('link', { name: 'New connection' })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/pages/connections/connections-list-page.tsx
+++ b/apps/web/src/pages/connections/connections-list-page.tsx
@@ -10,7 +10,8 @@ import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge'
 import { Button } from '../../shared/ui/button';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { Select } from '../../shared/ui/select';
-import { usePermission } from '../../shared/auth/use-permission';
+import { useWriteAccess } from '../../shared/auth/use-permission';
+import { useDemoMode } from '../../features/system';
 
 const CONNECTION_STATUSES = ['active', 'disabled', 'error', 'needs_reauth'] as const;
 
@@ -69,7 +70,11 @@ export function ConnectionsListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const { sort, setSort } = useTableSort([{ id: 'name', desc: false }]);
   const plugins = usePlatforms();
-  const canWrite = usePermission('connections:write');
+  const demoMode = useDemoMode();
+  // "New connection" opens the create-connection form (an "open a form"
+  // action, #1615 precedent) - stays visible AND enabled for a demo viewer;
+  // only the form's own final submit gets locked (create-connection-form.tsx).
+  const write = useWriteAccess('connections:write', demoMode);
 
   const platformType = searchParams.get('platformType') ?? '';
   const status = searchParams.get('status') ?? '';
@@ -111,7 +116,7 @@ export function ConnectionsListPage(): ReactElement {
       title="Connections"
       description="All configured integration connections — filter by platform or status."
       actions={
-        canWrite ? (
+        write.visible ? (
           <Link className="button" to="/connections/new">
             New connection
           </Link>
@@ -169,7 +174,7 @@ export function ConnectionsListPage(): ReactElement {
           action={
             filtersActive ? (
               <Button onClick={clearFilters}>Clear filters</Button>
-            ) : canWrite ? (
+            ) : write.visible ? (
               <Link className="button button--primary" to="/connections/new">
                 Add the first connection
               </Link>

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -634,6 +634,61 @@ describe('OrdersListPage', () => {
     expect(container.querySelector('.data-table__detail-row')).toBeNull();
   });
 
+  describe('demo read-only viewer (#1667)', () => {
+    const viewerSession = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: null,
+      role: 'viewer',
+      permissions: ['orders:read'],
+    });
+
+    it('renders the per-row Retry visible but disabled with a read-only tooltip for a demo viewer', async () => {
+      const mockApi = createMockApiClient({
+        orders: { list: vi.fn().mockResolvedValue(paginated([failedOrder])) },
+        connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      });
+
+      renderWithProviders(<OrdersListPage />, { apiClient: mockApi, sessionAdapter: viewerSession });
+
+      await screen.findByText('ALG-FAIL');
+      const retryButton = await screen.findByRole('button', { name: 'Retry' });
+      expect(retryButton).toBeDisabled();
+    });
+
+    it('renders the mobile card Retry visible but disabled for a demo viewer', async () => {
+      const viewport = mockMobileViewport();
+      try {
+        const mockApi = createMockApiClient({
+          orders: { list: vi.fn().mockResolvedValue(paginated([failedOrder])) },
+          connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+          system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+        });
+
+        renderWithProviders(<OrdersListPage />, { apiClient: mockApi, sessionAdapter: viewerSession });
+
+        await screen.findAllByText('ALG-FAIL');
+        const retryButton = await screen.findByRole('button', { name: 'Retry' });
+        expect(retryButton).toBeDisabled();
+      } finally {
+        viewport.restore();
+      }
+    });
+
+    it('keeps the existing hide-when-missing behaviour for an unauthorized non-demo viewer', async () => {
+      const mockApi = createMockApiClient({
+        orders: { list: vi.fn().mockResolvedValue(paginated([failedOrder])) },
+        connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+      });
+
+      renderWithProviders(<OrdersListPage />, { apiClient: mockApi, sessionAdapter: viewerSession });
+
+      await screen.findByText('ALG-FAIL');
+      expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+    });
+  });
+
   it('should preview the first item name plus a "+N more" suffix for multi-item orders (#1646)', async () => {
     const multiItemOrder: OrderRecord = {
       ...syncedOrder,

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -47,7 +47,10 @@ import { useOrdersQuery } from '../../features/orders/hooks/use-orders-query';
 import { useOrderStatusSummaryQuery } from '../../features/orders/hooks/use-order-status-summary-query';
 import { useOrderSlaSummaryQuery } from '../../features/orders/hooks/use-order-sla-summary-query';
 import { useRetryOrderDestinationMutation } from '../../features/orders/hooks/use-retry-order-destination-mutation';
-import { usePermission } from '../../shared/auth/use-permission';
+import { ReadOnlyLock } from '../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../shared/config/demo-mode';
+import { useDemoMode } from '../../features/system';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
 import { deriveOrderHealth, slaBadge, fulfillmentBadge } from '../../features/orders/lib/order-health';
 import { capSelectionPerSource, sourcesAtCap } from '../../features/orders/lib/dispatch-input';
@@ -339,7 +342,11 @@ export function OrdersListPage(): ReactElement {
   const slaSummary = slaSummaryQuery.data;
 
   const retryMutation = useRetryOrderDestinationMutation();
-  const canRetryOrder = usePermission('orders:write');
+  const demoMode = useDemoMode();
+  // Per-row "Retry" fires the retry mutation immediately (a direct-write
+  // action, no intermediate form) - visible-but-disabled with a read-only
+  // tooltip for a demo viewer, per the #1615 precedent.
+  const retryWrite = useWriteAccess('orders:write', demoMode);
 
   // Channel lookup: connectionId → platformType, cached app-wide via TanStack.
   const connectionsQuery = useConnectionsQuery();
@@ -626,19 +633,21 @@ export function OrdersListPage(): ReactElement {
         align: 'right',
         cell: (order) => {
           const failed = order.syncStatus.find((s) => s.status === 'failed');
-          if (order.recordStatus === 'awaiting_mapping' || !failed || !canRetryOrder) return null;
+          if (order.recordStatus === 'awaiting_mapping' || !failed || !retryWrite.visible) return null;
           const isRetrying =
             retryMutation.isPending &&
             retryMutation.variables?.internalOrderId === order.internalOrderId;
           return (
-            <Button
-              tone="ghost"
-              className="button--sm"
-              disabled={isRetrying}
-              onClick={() => { handleRetry(order.internalOrderId, failed.destinationConnectionId); }}
-            >
-              {isRetrying ? 'Retrying…' : 'Retry'}
-            </Button>
+            <ReadOnlyLock active={retryWrite.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+              <Button
+                tone="ghost"
+                className="button--sm"
+                disabled={isRetrying || retryWrite.demoReadOnly}
+                onClick={() => { handleRetry(order.internalOrderId, failed.destinationConnectionId); }}
+              >
+                {isRetrying ? 'Retrying…' : 'Retry'}
+              </Button>
+            </ReadOnlyLock>
           );
         },
       },
@@ -652,6 +661,8 @@ export function OrdersListPage(): ReactElement {
       platformByConnection,
       retryMutation.isPending,
       retryMutation.variables,
+      retryWrite.visible,
+      retryWrite.demoReadOnly,
       // Selection state — the select column re-renders as checkboxes toggle (#1109).
       selectedIds,
       atCapSources,
@@ -1042,15 +1053,20 @@ export function OrdersListPage(): ReactElement {
                         {shipBy.remaining}
                       </StatusBadge>
                     ) : null}
-                    {failed && order.recordStatus !== 'awaiting_mapping' && canRetryOrder ? (
-                      <Button
-                        tone="ghost"
-                        className="button--sm"
-                        disabled={isRetrying}
-                        onClick={() => { handleRetry(order.internalOrderId, failed.destinationConnectionId); }}
+                    {failed && order.recordStatus !== 'awaiting_mapping' && retryWrite.visible ? (
+                      <ReadOnlyLock
+                        active={retryWrite.demoReadOnly}
+                        message={DEMO_READ_ONLY_ACTION_MESSAGE}
                       >
-                        {isRetrying ? 'Retrying…' : 'Retry'}
-                      </Button>
+                        <Button
+                          tone="ghost"
+                          className="button--sm"
+                          disabled={isRetrying || retryWrite.demoReadOnly}
+                          onClick={() => { handleRetry(order.internalOrderId, failed.destinationConnectionId); }}
+                        >
+                          {isRetrying ? 'Retrying…' : 'Retry'}
+                        </Button>
+                      </ReadOnlyLock>
                     ) : null}
                   </span>
                 );

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
@@ -241,4 +241,62 @@ describe('SyncJobDetailPage', () => {
       expect(getOfferCreationStatus).not.toHaveBeenCalled();
     });
   });
+
+  describe('demo read-only viewer (#1667)', () => {
+    const viewerSession = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: null,
+      role: 'viewer',
+      permissions: ['sync:read'],
+    });
+
+    const deadJob: SyncJob = {
+      ...sampleJob,
+      status: 'dead',
+      attempts: 3,
+      lastError: 'timeout',
+    };
+
+    it('renders Retry visible but disabled with a read-only tooltip for a demo viewer', async () => {
+      const mockApi = createMockApiClient({
+        syncJobs: { getById: vi.fn().mockResolvedValue(deadJob) },
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      });
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/sync-jobs/:id" element={<SyncJobDetailPage />} />
+        </Routes>,
+        {
+          apiClient: mockApi,
+          route: '/sync-jobs/job_abc12345-1111-2222-3333-444444444444',
+          sessionAdapter: viewerSession,
+        },
+      );
+
+      const retryButton = await screen.findByRole('button', { name: 'Retry' });
+      expect(retryButton).toBeDisabled();
+    });
+
+    it('keeps the existing hide-when-missing behaviour for an unauthorized non-demo viewer', async () => {
+      const mockApi = createMockApiClient({
+        syncJobs: { getById: vi.fn().mockResolvedValue(deadJob) },
+      });
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/sync-jobs/:id" element={<SyncJobDetailPage />} />
+        </Routes>,
+        {
+          apiClient: mockApi,
+          route: '/sync-jobs/job_abc12345-1111-2222-3333-444444444444',
+          sessionAdapter: viewerSession,
+        },
+      );
+
+      await screen.findByText('Job failed after 3 attempts');
+      expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
@@ -15,7 +15,10 @@ import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
 import { OfferCreationTracker } from '../../features/listings/components/OfferCreationTracker';
-import { usePermission } from '../../shared/auth/use-permission';
+import { ReadOnlyLock } from '../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../shared/config/demo-mode';
+import { useDemoMode } from '../../features/system';
 
 /**
  * Extracts the offer-creation record ID from a `marketplace.offer.create`
@@ -77,7 +80,11 @@ export function SyncJobDetailPage(): ReactElement {
   // before the loading/error guards below.
   const connectionQuery = useConnectionQuery(query.data?.connectionId ?? '');
   const retry = useRetrySyncJobMutation();
-  const canRetry = usePermission('sync:write');
+  const demoMode = useDemoMode();
+  // "Retry" fires the retry mutation immediately (a direct-write action, no
+  // intermediate form) - visible-but-disabled with a read-only tooltip for a
+  // demo viewer, per the #1615 Test connection/Disable connection precedent.
+  const write = useWriteAccess('sync:write', demoMode);
   const { showToast } = useToast();
 
   if (query.isLoading) {
@@ -132,10 +139,12 @@ export function SyncJobDetailPage(): ReactElement {
           tone="error"
           title={`Job failed after ${job.attempts} attempt${job.attempts === 1 ? '' : 's'}`}
           action={
-            canRetry ? (
-              <Button onClick={handleRetry} disabled={retry.isPending}>
-                {retry.isPending ? 'Retrying…' : 'Retry'}
-              </Button>
+            write.visible ? (
+              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                <Button onClick={handleRetry} disabled={retry.isPending || write.demoReadOnly}>
+                  {retry.isPending ? 'Retrying…' : 'Retry'}
+                </Button>
+              </ReadOnlyLock>
             ) : null
           }
         >


### PR DESCRIPTION
## Summary

Three write-gated affordances still used the old hide-when-missing permission pattern (`usePermission(...) ? (...) : null`) instead of the established `useWriteAccess` + `ReadOnlyLock` visible-but-disabled pattern from #1615/#1613/#1663.

- `connections-list-page.tsx`: "New connection" (header CTA) and "Add the first connection" (empty-state CTA) are an open-a-form action - both stay visible and enabled for a demo viewer. `create-connection-form.tsx` locks only its own final submit button, matching `EditConnectionForm`'s "Save changes" treatment.
- `sync-job-detail-page.tsx`: "Retry" is a direct-write action (fires the retry mutation immediately) - stays visible but disabled with a read-only tooltip for a demo viewer.
- `orders-list-page.tsx`: the per-row "Retry" (both the desktop table column and the mobile card meta row) gets the same direct-write treatment.

Genuinely unauthorized non-demo sessions keep the existing hide-when-missing behavior in all three places - only demo mode relaxes hidden to visible-but-disabled/enabled-with-locked-submit.

Part of #1606

## Test plan

- [x] `pnpm --filter @openlinker/web lint` - 0 errors (79 pre-existing style warnings, unchanged baseline)
- [x] `pnpm --filter @openlinker/web type-check` - passes clean
- [x] Scoped unit tests for all four touched files (73 tests) - all passing, including new demo-viewer and unauthorized-non-demo-viewer cases
- [x] Manual review against reference implementations: `ConnectionActionsPanel.tsx` (#1615), `listings-list-page.tsx` (#1663)

Closes #1667