### PR TITLE
feat(web): gate AI-suggest and bulk AI-generate-description via useWriteAccess

### DIFF
--- a/apps/web/src/features/content/components/suggestion-dialog.test.tsx
+++ b/apps/web/src/features/content/components/suggestion-dialog.test.tsx
@@ -4,8 +4,9 @@
  * Verifies the generate → apply flow, the "not auto-saved" contract (Apply
  * just calls `onApply(text)` — persistence is the parent's job), that
  * tone/extra inputs are forwarded as part of the suggest request payload,
- * and that the trigger is gated on the `ai:suggest` permission (admin-only)
- * rather than demo mode (#1379 re-scope).
+ * and that the trigger is gated on the `ai:suggest` permission via the
+ * `useWriteAccess` + `ReadOnlyLock` pattern (#1668): visible-but-disabled
+ * for a demo viewer, hidden for a genuinely unauthorized non-demo session.
  */
 import { cleanup, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -17,7 +18,7 @@ import {
   renderWithProviders,
 } from '../../../test/test-utils';
 import { ApiError } from '../../../shared/api/api-error';
-import { AI_SUGGEST_REQUIRES_ADMIN_MESSAGE } from '../../../shared/config/demo-mode';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
 import type { SessionUser } from '../../../shared/auth/session.types';
 import type { SuggestionResponse } from '../api/content.types';
 
@@ -216,43 +217,41 @@ describe('SuggestionDialog', () => {
     });
   });
 
-  describe('permission gating (ai:suggest, #1379 re-scope)', () => {
-    function renderAsViewer() {
+  describe('permission gating (ai:suggest, useWriteAccess + ReadOnlyLock, #1668)', () => {
+    it('hides the trigger entirely for a genuinely unauthorized non-demo session', async () => {
       const suggest = vi.fn();
       const mockApi = createMockApiClient({ content: { suggest } });
       renderWithProviders(
         <SuggestionDialog productId="ol_product_1" channel={null} onApply={vi.fn()} />,
         { apiClient: mockApi, sessionAdapter: createAuthenticatedSessionAdapter(viewerUser) },
       );
-      return { suggest };
-    }
 
-    it('disables the trigger and does not open the dialog for a session without ai:suggest', async () => {
-      const { suggest } = renderAsViewer();
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /Suggest with AI/ })).not.toBeInTheDocument();
+      });
+      expect(suggest).not.toHaveBeenCalled();
+    });
+
+    it('renders the trigger visible-but-disabled with the demo read-only tooltip for a demo viewer', async () => {
+      const suggest = vi.fn();
+      const mockApi = createMockApiClient({
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+        content: { suggest },
+      });
+      renderWithProviders(
+        <SuggestionDialog productId="ol_product_1" channel={null} onApply={vi.fn()} />,
+        { apiClient: mockApi, sessionAdapter: createAuthenticatedSessionAdapter(viewerUser) },
+      );
+
       const user = userEvent.setup();
-
-      // Re-query inside waitFor: the trigger renders locked from the first
-      // paint (session starts anonymous) and stays locked once the viewer
-      // session hydrates — unlike the admin case, there's no flip to enabled.
       await waitFor(() =>
         expect(screen.getByRole('button', { name: /Suggest with AI/ })).toBeDisabled(),
       );
 
       await user.click(screen.getByRole('button', { name: /Suggest with AI/ }));
-
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       expect(suggest).not.toHaveBeenCalled();
-    });
 
-    it('surfaces the requires-admin tooltip on the locked trigger', async () => {
-      renderAsViewer();
-      const user = userEvent.setup();
-
-      await waitFor(() =>
-        expect(screen.getByRole('button', { name: /Suggest with AI/ })).toBeDisabled(),
-      );
-
-      // The tooltip trigger is the focusable span wrapping the disabled button.
       const trigger = screen.getByRole('button', { name: /Suggest with AI/ });
       await user.hover(trigger.parentElement as HTMLElement);
 
@@ -260,14 +259,10 @@ describe('SuggestionDialog', () => {
       // hidden `role="tooltip"` a11y duplicate) — `findByText` would match
       // both and throw. Query the unique `role="tooltip"` node instead.
       const tooltip = await screen.findByRole('tooltip');
-      expect(tooltip).toHaveTextContent(AI_SUGGEST_REQUIRES_ADMIN_MESSAGE);
+      expect(tooltip).toHaveTextContent(DEMO_READ_ONLY_ACTION_MESSAGE);
     });
 
     it('keeps the trigger enabled for an admin session even when the deployment is in demo mode', async () => {
-      // The regression this re-scope fixes: gating on `demoMode` locked the
-      // admin out of the one legitimate use case (demoing AI live to a
-      // prospect from the admin session) while doing nothing for security,
-      // since the backend endpoint is `@Roles('admin')`-gated regardless.
       const suggest = vi.fn().mockResolvedValue(makeSuggestionResponse('ok'));
       const mockApi = createMockApiClient({
         system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },

--- a/apps/web/src/features/content/components/suggestion-dialog.tsx
+++ b/apps/web/src/features/content/components/suggestion-dialog.tsx
@@ -24,10 +24,11 @@ import {
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Textarea } from '../../../shared/ui/textarea';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../../../shared/ui/tooltip';
 import { ApiError } from '../../../shared/api/api-error';
-import { AI_SUGGEST_REQUIRES_ADMIN_MESSAGE } from '../../../shared/config/demo-mode';
-import { usePermission } from '../../../shared/auth/use-permission';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
+import { useWriteAccess } from '../../../shared/auth/use-permission';
+import { useDemoMode } from '../../system';
 import { useSuggestContentMutation } from '../hooks/use-content-mutations';
 import type { PromptTemplateChannel } from '../api/content.types';
 
@@ -69,9 +70,10 @@ export function SuggestionDialog({
   disabled = false,
   onApply,
   scopeWarning,
-}: SuggestionDialogProps): ReactElement {
+}: SuggestionDialogProps): ReactElement | null {
   const mutation = useSuggestContentMutation();
-  const canSuggest = usePermission('ai:suggest');
+  const demoMode = useDemoMode();
+  const write = useWriteAccess('ai:suggest', demoMode);
   const [open, setOpen] = useState(false);
   const [tone, setTone] = useState('');
   const [extra, setExtra] = useState('');
@@ -120,25 +122,24 @@ export function SuggestionDialog({
 
   const channelLabel = channel === null ? 'master' : channel;
 
-  // Gated on the `ai:suggest` permission (admin-only), not demo mode — the
-  // interactive suggest endpoint is `@Roles('admin')`-gated in every
-  // environment, so a non-admin session would otherwise see an enabled
-  // trigger that 403s on click, in both demo and production alike.
-  // Render a locked trigger with an explanatory tooltip instead of mounting
-  // the dialog, so it cannot open. The span wrap is required because a
-  // natively-disabled <button> emits no pointer events for the Radix tooltip.
-  if (!canSuggest) {
+  // `ai:suggest` is admin-only in every environment — invoking the endpoint
+  // triggers a real LLM completion, so it's treated as a direct-write-adjacent
+  // action (like Test-connection/Disable-connection, #1615), not an
+  // open-a-form action (#1668). A demo viewer sees the trigger rendered but
+  // disabled with a read-only tooltip, so the demo advertises the capability
+  // exists; a genuinely unauthorized non-demo session doesn't see the
+  // affordance at all (`write.visible` false).
+  if (!write.visible) {
+    return null;
+  }
+
+  if (write.demoReadOnly) {
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="content-suggestion__locked" tabIndex={0}>
-            <Button type="button" tone="ghost" disabled>
-              🔒 Suggest with AI
-            </Button>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>{AI_SUGGEST_REQUIRES_ADMIN_MESSAGE}</TooltipContent>
-      </Tooltip>
+      <ReadOnlyLock active message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+        <Button type="button" tone="ghost" disabled>
+          ✨ Suggest with AI
+        </Button>
+      </ReadOnlyLock>
     );
   }
 

--- a/apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx
@@ -1245,11 +1245,14 @@ describe('AllegroCreateOfferWizard', () => {
           onCancel={vi.fn()}
           onSubmitted={vi.fn()}
         />,
-        { apiClient: mockApi },
+        // Authenticated (admin) session — the trigger is gated via
+        // `useWriteAccess('ai:suggest', …)` (#1668) and renders nothing for
+        // the default anonymous/noop session.
+        { apiClient: mockApi, sessionAdapter: createAuthenticatedSessionAdapter() },
       );
 
       await advanceToStep2();
-      expect(screen.getByRole('button', { name: /suggest with ai/i })).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: /suggest with ai/i })).toBeInTheDocument();
     });
 
     // Note: this test does not assert the `shouldDirty: true` flag that the

--- a/apps/web/src/features/listings/components/EditOfferDrawer.test.tsx
+++ b/apps/web/src/features/listings/components/EditOfferDrawer.test.tsx
@@ -36,8 +36,8 @@ function renderDrawer(
   renderWithProviders(
     <EditOfferDrawer isOpen={isOpen} onClose={onClose} mapping={mapping} />,
     // Authenticated (admin) session — `SuggestionDialog`'s "Suggest with AI"
-    // trigger is gated on the `ai:suggest` permission (#1379 re-scope), not
-    // demo mode, so the AI-suggest tests below need a permitted session.
+    // trigger is gated on the `ai:suggest` permission via `useWriteAccess`
+    // (#1668), so the AI-suggest tests below need a permitted session.
     { apiClient: mockApi, sessionAdapter: createAuthenticatedSessionAdapter() },
   );
   return { mockApi, onClose };
@@ -147,14 +147,18 @@ describe('EditOfferDrawer', () => {
   });
 
   describe('AI suggest (#485)', () => {
-    it('should render the Suggest button when linkedProductId and platformType resolve to a channel', () => {
+    it('should render the Suggest button when linkedProductId and platformType resolve to a channel', async () => {
       const mappingWithLink: OfferMapping = {
         ...mockMapping,
         linkedProductId: 'ol_product_xyz789',
       };
       renderDrawer(true, {}, undefined, mappingWithLink);
+      // The trigger is gated via `useWriteAccess('ai:suggest', …)` (#1668),
+      // which renders nothing until the session hydrates from anonymous to
+      // the authenticated admin adapter — await it rather than asserting
+      // synchronously.
       expect(
-        screen.getByRole('button', { name: /suggest with ai/i }),
+        await screen.findByRole('button', { name: /suggest with ai/i }),
       ).toBeInTheDocument();
     });
 

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.test.tsx
@@ -4,12 +4,14 @@
  * The Config step builds the batch-wide `BulkWizardConfig` — connection,
  * delivery policy, currency, and the pricing/stock policy objects — and gates
  * "Proceed" on per-mode validation. The AI-generation toggle is gated on the
- * `listings:write` permission (admin + operator), not demo mode (#1379
- * re-scope) — the bulk-create endpoint is `@Roles('admin', 'operator')` in
- * every environment.
+ * `listings:write` permission via the `useWriteAccess` + `ReadOnlyLock`
+ * pattern (#1668): visible-but-disabled for a demo viewer, hidden for a
+ * genuinely unauthorized non-demo session, enabled for anyone holding
+ * `listings:write` (admin + operator) regardless of demo mode.
  */
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   createAuthenticatedSessionAdapter,
   renderWithProviders,
@@ -19,6 +21,7 @@ import { BulkConfigStep } from './bulk-config-step';
 import type { BulkWizardConfig } from './bulk-wizard.types';
 import type { Connection } from '../../../connections';
 import type { SessionUser } from '../../../../shared/auth/session.types';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../../shared/config/demo-mode';
 
 const viewerUser: SessionUser = {
   id: 'user_viewer',
@@ -125,8 +128,8 @@ describe('BulkConfigStep', () => {
     expect(screen.getByRole('button', { name: /Proceed/ })).toBeDisabled();
   }, 15000);
 
-  describe('AI-generation toggle permission gating (listings:write, #1379 re-scope)', () => {
-    it('disables the toggle for a session without listings:write (viewer)', async () => {
+  describe('AI-generation toggle permission gating (listings:write, useWriteAccess + ReadOnlyLock, #1668)', () => {
+    it('hides the toggle entirely for a genuinely unauthorized non-demo session (viewer)', async () => {
       renderWithProviders(
         <BulkConfigStep
           initial={{ generateDescription: true }}
@@ -139,19 +142,55 @@ describe('BulkConfigStep', () => {
         },
       );
 
+      await screen.findByText('Configure batch');
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('checkbox', { name: /Generate AI descriptions by default/ }),
+        ).not.toBeInTheDocument();
+      });
+    }, 15000);
+
+    it('renders the toggle visible-but-disabled with the demo read-only tooltip for a demo viewer', async () => {
+      const apiClient = createMockApiClient({
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+        connections: { list: vi.fn().mockResolvedValue([
+          {
+            id: 'conn-1',
+            name: 'My Allegro',
+            status: 'active',
+            platformType: 'allegro',
+            supportedCapabilities: ['OfferManager', 'OfferCreator'],
+          } as unknown as Connection,
+        ]) },
+        listings: {
+          getSellerPolicies: vi
+            .fn()
+            .mockResolvedValue({ deliveryPolicies: [{ id: 'dp1', name: 'Courier 24h' }] }),
+        },
+      });
+      renderWithProviders(
+        <BulkConfigStep
+          initial={{ generateDescription: true }}
+          onProceed={vi.fn()}
+          onCancel={() => undefined}
+        />,
+        { apiClient, sessionAdapter: createAuthenticatedSessionAdapter(viewerUser) },
+      );
+
       const toggle = await screen.findByRole('checkbox', {
         name: /Generate AI descriptions by default/,
       });
       await waitFor(() => { expect(toggle).toBeDisabled(); }, { timeout: 5000 });
       // Forced off even though `initial.generateDescription` was true.
       expect(toggle).not.toBeChecked();
+
+      const user = userEvent.setup();
+      await user.hover(toggle.closest('.read-only-lock') as HTMLElement);
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip).toHaveTextContent(DEMO_READ_ONLY_ACTION_MESSAGE);
     }, 15000);
 
     it('keeps the toggle enabled for an operator session even when the deployment is in demo mode', async () => {
-      // The regression this re-scope fixes: gating on `demoMode` locked
-      // operators out of a toggle they're backend-authorized to use
-      // (`@Roles('admin', 'operator')` on the bulk-create endpoint), in every
-      // environment including demo.
       const apiClient = createMockApiClient({
         system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
         connections: {

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
@@ -21,9 +21,10 @@ import { Suspense, useEffect, useMemo, useState, type ReactElement } from 'react
 import { useForm } from 'react-hook-form';
 
 import { Alert, Button, FormField, Input, Select } from '../../../../shared/ui';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../shared/ui/tooltip';
-import { BULK_AI_TOGGLE_REQUIRES_WRITE_MESSAGE } from '../../../../shared/config/demo-mode';
-import { usePermission } from '../../../../shared/auth/use-permission';
+import { ReadOnlyLock } from '../../../../shared/ui/read-only-lock';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../../shared/config/demo-mode';
+import { useWriteAccess } from '../../../../shared/auth/use-permission';
+import { useDemoMode } from '../../../system';
 import { useConnectionsQuery } from '../../../connections';
 import type { Connection } from '../../../connections';
 import { usePlatform, usePlatforms, type BulkConfigFormValues } from '../../../../shared/plugins';
@@ -106,7 +107,8 @@ export function BulkConfigStep({
   const section = platform?.bulkOfferConfigSection;
 
   const values = form.watch();
-  const canGenerateDescription = usePermission('listings:write');
+  const demoMode = useDemoMode();
+  const generateDescriptionAccess = useWriteAccess('listings:write', demoMode);
 
   // ---- shared-slice validity (explicit, deterministic — not formState.isValid) ----
   const markupValid =
@@ -336,31 +338,34 @@ export function BulkConfigStep({
         </span>
       </label>
 
-      {(() => {
-        // Gated on `listings:write` (admin + operator), not demo mode — the
+      {generateDescriptionAccess.visible ? (
+        // Direct-write-adjacent action (triggers an LLM completion per row via
+        // the worker), so it follows the `useWriteAccess` + `ReadOnlyLock`
+        // pattern (#1615/#1668): visible-but-disabled for a demo viewer,
+        // hidden entirely for a genuinely unauthorized non-demo session. The
         // bulk-create endpoint is `@Roles('admin', 'operator')`-gated in
-        // every environment, so a viewer session would otherwise see an
-        // enabled toggle that 403s on submit, in both demo and production
-        // alike. Lock it with an explanatory tooltip; the span wrap is
-        // required because a disabled checkbox emits no pointer events.
-        const locked = !canGenerateDescription;
-        const field = (
+        // every environment, so a session without `listings:write` could
+        // never actually have this take effect even if it slipped through.
+        <ReadOnlyLock
+          active={generateDescriptionAccess.demoReadOnly}
+          message={DEMO_READ_ONLY_ACTION_MESSAGE}
+        >
           <label
             style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}
-            aria-disabled={locked}
+            aria-disabled={generateDescriptionAccess.demoReadOnly}
           >
             <input
               type="checkbox"
-              checked={locked ? false : values.generateDescription}
-              disabled={locked}
+              checked={generateDescriptionAccess.demoReadOnly ? false : values.generateDescription}
+              disabled={generateDescriptionAccess.demoReadOnly}
               onChange={(e) => {
-                if (locked) return;
+                if (generateDescriptionAccess.demoReadOnly) return;
                 form.setValue('generateDescription', e.target.checked, { shouldDirty: true });
               }}
             />
             <span>
               <strong>
-                {locked ? (
+                {generateDescriptionAccess.demoReadOnly ? (
                   <span aria-hidden="true" style={{ marginRight: 'var(--space-1)' }}>
                     🔒
                   </span>
@@ -368,24 +373,14 @@ export function BulkConfigStep({
                 Generate AI descriptions by default
               </strong>
               <small style={{ display: 'block', color: 'var(--text-muted)' }}>
-                {locked
-                  ? BULK_AI_TOGGLE_REQUIRES_WRITE_MESSAGE
+                {generateDescriptionAccess.demoReadOnly
+                  ? DEMO_READ_ONLY_ACTION_MESSAGE
                   : 'Worker uses ContentSuggestionService per row. Per-row toggle in the edit modal overrides this.'}
               </small>
             </span>
           </label>
-        );
-        return locked ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span tabIndex={0}>{field}</span>
-            </TooltipTrigger>
-            <TooltipContent>{BULK_AI_TOGGLE_REQUIRES_WRITE_MESSAGE}</TooltipContent>
-          </Tooltip>
-        ) : (
-          field
-        );
-      })()}
+        </ReadOnlyLock>
+      ) : null}
 
       <footer className="bulk-wizard__footer">
         <div className="bulk-wizard__footer-spacer" />

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -14,7 +14,8 @@ import { useNavigate } from 'react-router-dom';
 import { Alert, PageLayout, SetupStepper } from '../../../../shared/ui';
 import { useToast } from '../../../../shared/ui/toast-provider';
 import { usePlatforms, type OfferRowValidationInput } from '../../../../shared/plugins';
-import { usePermission } from '../../../../shared/auth/use-permission';
+import { useWriteAccess } from '../../../../shared/auth/use-permission';
+import { useDemoMode } from '../../../system';
 import { useConnectionsQuery } from '../../../connections';
 import { useBulkSubmitMutation } from '../../hooks/use-bulk-submit-mutation';
 import { useBulkRequiredProductParams } from '../../hooks/use-bulk-required-product-params';
@@ -74,7 +75,14 @@ export function BulkWizard({
   // confirm step submit reuse it; remount mints a fresh one.
   const idempotencyKeyRef = useRef<string>(crypto.randomUUID());
 
-  const canGenerateDescription = usePermission('listings:write');
+  const demoMode = useDemoMode();
+  // Belt-and-suspenders submit-time enforcement (#1668, following the
+  // `useWriteAccess` pattern from bulk-config-step.tsx): only a session that
+  // truly holds `listings:write` can carry `generateDescription: true` into
+  // the request — a demo viewer's `demoReadOnly` toggle in the Config step is
+  // already forced off, but this re-derives from the real permission
+  // regardless of what `config` snapshot reached this point.
+  const canGenerateDescription = useWriteAccess('listings:write', demoMode).canWrite;
   const [step, setStep] = useState<BulkWizardStep>('config');
   const [config, setConfig] = useState<BulkWizardConfig | null>(null);
   const [rows, setRows] = useState<BulkWizardRow[]>(() => seedRows(products));

--- a/apps/web/src/shared/config/demo-mode.ts
+++ b/apps/web/src/shared/config/demo-mode.ts
@@ -1,14 +1,13 @@
 /**
- * Access-control copy constants for AI-generation and demo-mode UI affordances
+ * Access-control copy constants for demo-mode UI affordances
  *
- * `AI_SUGGEST_REQUIRES_ADMIN_MESSAGE` / `BULK_AI_TOGGLE_REQUIRES_WRITE_MESSAGE`
- * are shown when an AI-generation control is disabled because the current
- * session lacks the required permission (`ai:suggest` / `listings:write`).
- * This holds in every environment, not just demo — the underlying
- * `@Roles('admin')` / `@Roles('admin', 'operator')` guards on the backend are
- * permanent. Gating on permission (not `demoMode`) also fixes the pre-existing
- * bug where a non-permitted session saw an enabled control that then 403'd,
- * in both demo and production alike (#1379 re-scope).
+ * The AI-suggest trigger and the bulk wizard's AI-generate-description toggle
+ * (`ai:suggest` / `listings:write`) invoke a real backend call (an LLM
+ * completion), so they're treated as direct-write-adjacent actions — same
+ * `useWriteAccess` + `ReadOnlyLock` pattern as Test-connection /
+ * Disable-connection (#1615/#1668): a demo viewer sees the control rendered
+ * but disabled with `DEMO_READ_ONLY_ACTION_MESSAGE`, while a genuinely
+ * unauthorized non-demo session doesn't see it at all.
  *
  * `NAV_DEMO_RESTRICTED_MESSAGE` remains demo-mode-specific — it's the
  * "visible but locked" tooltip for admin-only nav groups shown to non-admins
@@ -17,14 +16,6 @@
  *
  * @module shared/config
  */
-
-/** Tooltip on the "Suggest with AI" trigger when the session lacks `ai:suggest` (admin-only). */
-export const AI_SUGGEST_REQUIRES_ADMIN_MESSAGE =
-  'AI suggestions require an administrator role.';
-
-/** Tooltip on the bulk "Generate AI descriptions" toggle when the session lacks `listings:write`. */
-export const BULK_AI_TOGGLE_REQUIRES_WRITE_MESSAGE =
-  'Generating AI descriptions requires listings write access.';
 
 /**
  * Tooltip on nav groups shown as "visible but locked" in demo mode. Names the


### PR DESCRIPTION
## Summary

Part of #1606. Two AI-assisted content-generation affordances still used the old plain-permission pattern instead of the established `useWriteAccess` + `ReadOnlyLock` pattern (ConnectionActionsPanel, #1615; listings-list-page, #1663):

- `suggestion-dialog.tsx` - the "Suggest with AI" trigger was gated on `usePermission('ai:suggest')` alone, so it always rendered a locked, disabled button with a "requires administrator" tooltip regardless of demo mode.
- `bulk-config-step.tsx` / `bulk-wizard.tsx` - the bulk wizard's "Generate AI descriptions by default" toggle was gated on `usePermission('listings:write')` alone, same always-locked-when-missing shape.

Both are now built on `useWriteAccess(permission, demoMode)`:
- A session holding the permission sees the control fully enabled, in every environment (unchanged from before).
- A demo viewer (no permission, demo mode) now sees the control rendered but disabled, with the shared `DEMO_READ_ONLY_ACTION_MESSAGE` read-only tooltip, so the demo advertises the capability exists.
- A genuinely unauthorized non-demo session no longer sees the affordance at all (hidden), matching the established convention for direct-write-adjacent actions.

Invoking either action triggers a real backend LLM completion, so both are treated as direct-write actions (like Test-connection/Disable-connection) rather than open-a-form actions - the control itself is disabled, not just its downstream submit.

`AI_SUGGEST_REQUIRES_ADMIN_MESSAGE` and `BULK_AI_TOGGLE_REQUIRES_WRITE_MESSAGE` are removed from `shared/config/demo-mode.ts` since the shared `DEMO_READ_ONLY_ACTION_MESSAGE` now covers both call sites, matching the rest of the pattern.

`bulk-wizard.tsx`'s submit-time safety net (forcing `generateDescription: false` for a session that lacks the real permission) now derives from `useWriteAccess(...).canWrite`, preserving the same enforcement semantics.

## Test plan

- [x] `pnpm --filter @openlinker/web lint` - 0 errors (pre-existing warnings only)
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] Scoped `vitest run` across `src/features/content`, `src/features/listings/components/bulk`, `AllegroCreateOfferWizard.test.tsx`, `EditOfferDrawer.test.tsx`, `src/pages/listings` - all pass, including new/updated coverage for the demo-viewer and hidden states
- [x] Full `apps/web` test suite run for collateral impact - all pass except a pre-existing, unrelated flake in `src/app/app.test.tsx` (confirmed present on the base branch before this change too)