### PR TITLE
fix(auth): raise default demo registration rate limit to 100

### DIFF
--- a/apps/api/src/auth/registration.service.ts
+++ b/apps/api/src/auth/registration.service.ts
@@ -108,7 +108,7 @@ export class RegistrationService implements IRegistrationService {
    */
   private async enforceRateLimit(clientIp: string): Promise<void> {
     const limit = Number(
-      this.configService.get<string>('OL_DEMO_REGISTRATION_RATE_LIMIT', '5'),
+      this.configService.get<string>('OL_DEMO_REGISTRATION_RATE_LIMIT', '100'),
     );
     const windowSeconds = Number(
       this.configService.get<string>('OL_DEMO_REGISTRATION_RATE_WINDOW_SECONDS', '3600'),


### PR DESCRIPTION
## Summary

Raises the default value of `OL_DEMO_REGISTRATION_RATE_LIMIT` in `RegistrationService.enforceRateLimit` (`apps/api/src/auth/registration.service.ts`) from `'5'` to `'100'` registrations per IP per hour. The previous default was too restrictive for demo usage. The env-var override mechanism itself is unchanged - operators can still set `OL_DEMO_REGISTRATION_RATE_LIMIT` to any value.

Part of #1606
Closes #1672

## Test plan

- [x] `pnpm --filter @openlinker/api lint` - passes (one pre-existing unrelated error in `src/plugins.ts`, confirmed present before this change too)
- [x] `pnpm --filter @openlinker/api type-check` - passes with no errors
- [x] `pnpm --filter @openlinker/api test -- src/auth/registration.service.spec.ts` - all 11 tests pass (existing rate-limit tests already override the env var explicitly, so no test changes were needed)
- [x] Checked `docs/one-command-demo-setup-guide.md` for mentions of the rate limit default - none found, no doc update needed