### PR TITLE
fix(web): orders filter bar wraps cleanly on mobile widths

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7674,6 +7674,18 @@ a.kpi-card:focus-visible {
   gap: var(--space-3);
   margin-bottom: var(--space-3);
 }
+/* The `flex-wrap: wrap` above lives on `.orders-toolbar` itself, but its
+   only DOM child is `.toolbar__group` (a nested flex row holding the
+   actual source/date/SLA/fulfillment controls) — a single flex item never
+   wraps. `.toolbar__group` (shared with connections/products/etc.) stays
+   `nowrap` by default because those simpler toolbars fit in one row; the
+   5-control orders bar needs it to wrap so the controls can drop onto
+   their own line(s) instead of shrinking past their native min-content
+   width and overflowing the viewport on mobile (#1669).
+*/
+.orders-toolbar .toolbar__group {
+  flex-wrap: wrap;
+}
 /* Inline date field: small mono-caps label sitting left of the native input. */
 .orders-toolbar__field {
   display: inline-flex;


### PR DESCRIPTION
## Summary

On `/orders` at mobile widths the filter bar (source select, FROM/TO date inputs, SLA select, fulfillment select) overflowed the viewport horizontally instead of wrapping onto its own line(s).

## Root cause

Confirmed via live Playwright inspection at 320/375/414/480px against a running demo stack. The initial hypothesis in the issue (that the date inputs were missing the `.control`/`.control--select` classes targeted by the `@media (max-width: 640px)` override) was **not correct** - the date inputs already carry `className="control"` and are covered by that rule.

The real cause: `.orders-toolbar` has `flex-wrap: wrap`, but its only DOM child is the nested `.toolbar__group` div that actually holds the five filter controls (source select, From/To date fields, SLA select, fulfillment select). A flex container with a single child never wraps, so the five controls stayed forced onto one `nowrap` row inside `.toolbar__group` and shrank down to their native min-content widths (native `<input type="date">` has a browser-enforced minimum around 145px that can't shrink further), pushing the row past the viewport edge - visually clipped rather than triggering page scroll, matching the reported screenshot (TO field and trailing dropdown cut off).

## Fix

Add a scoped rule:

```css
.orders-toolbar .toolbar__group {
  flex-wrap: wrap;
}
```

This lets the nested control row wrap. Combined with the pre-existing `.toolbar .control { width: 100% }` mobile override (which already applied to the date inputs), each control gets a clean full-width row at 320-414px. At 480px+, the From/To date-field pair naturally sits side by side on one row since both fit, giving a tidy two-per-line layout without any extra CSS.

The rule is scoped to `.orders-toolbar .toolbar__group` rather than the shared `.toolbar__group` class, so other `.toolbar` consumers (connections, products, inventory, listings, etc., which only have 1-2 filter controls and already fit on one row) are unaffected - verified no overflow and no visual change at 375px on `/connections`, `/products`, `/inventory`.

## Verification

Live-tested with Playwright against a running demo stack (API on :3000, dev server on :4199) at 320, 375, 414, 480, 768, and 1280px:
- No horizontal overflow at any width (`scrollWidth === clientWidth` on both `.orders-toolbar` and `document.documentElement`).
- 320-414px: all five controls stack one per row, fully visible.
- 480px: From/To pair on one row, other controls stack full-width.
- 768px+: partial wrapping as needed, no overflow.
- 1280px (desktop): unchanged single-row layout.
- Other `.toolbar` pages (connections, products, inventory) unaffected at 375px.

## Test plan

- [x] `pnpm --filter @openlinker/web lint` - 0 errors (pre-existing warnings only)
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] `pnpm exec vitest run src/pages/orders src/features/orders` (from apps/web) - 210/210 passed
- [x] Manual Playwright verification at 320/375/414/480/768/1280px, screenshots reviewed
- [x] Cross-checked connections/products/inventory `.toolbar` pages for regressions

Part of #1606
Closes #1669