### PR TITLE
fix(core): propagate master-side product/variant deletion (#1599)

### DIFF
--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -136,6 +136,7 @@ describe('ListingsController', () => {
       upsert: jest.fn(),
       upsertMany: jest.fn(),
       findMany: jest.fn(),
+      markStaleExceptVariants: jest.fn(),
     };
     categoryResolution = {
       resolveCategory: jest.fn(),

--- a/apps/api/src/migrations/1819000000001-add-product-variant-is-stale.ts
+++ b/apps/api/src/migrations/1819000000001-add-product-variant-is-stale.ts
@@ -1,0 +1,47 @@
+/**
+ * Add Product Variant isStale Migration
+ *
+ * Adds `isStale` (boolean) + `staleAt` (timestamptz) to `product_variants`
+ * (#1599). The master product sync soft-marks a variant stale when it stops
+ * appearing in the master's `getProductVariants` response, or when the product
+ * itself 404s at the master — the products-context counterpart of
+ * `inventory_items.isStale` (#1478). Order-item resolution consults `isStale`
+ * to fail early instead of passing a deleted ("zombie") variant downstream.
+ * Soft-mark, never a delete, so mappings and historical orders keep resolving.
+ * `isStale` defaults `false` so all existing rows backfill to "live".
+ *
+ * `staleAt` is `timestamptz` (not bare `timestamp`) so the `NOW()` write — which
+ * yields `timestamptz` — is stored without a silent tz coercion, matching the
+ * #1296 correction applied to `invoice_records`.
+ *
+ * Column names are camelCase to match TypeORM's default naming (the repo sets no
+ * naming strategy) — cf. `inventory_items.isStale` and the sibling columns here
+ * (`productId`, `createdAt`).
+ *
+ * Generated: 2026-07-16 (synthetic sequential prefix per docs/migrations.md
+ * #1013 — sorts strictly after the current `main` tail `1819000000000`).
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductVariantIsStale1819000000001 implements MigrationInterface {
+  name = 'AddProductVariantIsStale1819000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "product_variants" ADD COLUMN IF NOT EXISTS "isStale" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "product_variants" ADD COLUMN IF NOT EXISTS "staleAt" TIMESTAMP WITH TIME ZONE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "product_variants" DROP COLUMN IF EXISTS "staleAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "product_variants" DROP COLUMN IF EXISTS "isStale"`,
+    );
+  }
+}

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -55,6 +55,7 @@ function createMockProductsService(): jest.Mocked<IProductsService> {
     getVariantsByBarcodes: jest.fn(),
     listProducts: jest.fn(),
     listVariants: jest.fn(),
+    markVariantsStaleExcept: jest.fn(),
   };
 }
 

--- a/apps/api/test/integration/inventory-stale-prune.int-spec.ts
+++ b/apps/api/test/integration/inventory-stale-prune.int-spec.ts
@@ -114,7 +114,10 @@ describe('Inventory stale-prune (#1478)', () => {
     ]);
 
     const marked = await inventoryService.pruneStaleVariants(productId, [variantKeep]);
-    expect(marked).toBe(1);
+    expect(marked.markedCount).toBe(1);
+    // The `UPDATE … RETURNING "productVariantId"` extraction surfaces the exact
+    // flagged variant id (real-Postgres coverage for the RETURNING path, #1599).
+    expect(marked.variantIds).toEqual([variantGone]);
 
     const inventoryRepo = dataSource.getRepository(InventoryItemOrmEntity);
     const kept = await inventoryRepo.findOneBy({ productId, productVariantId: variantKeep });
@@ -191,7 +194,7 @@ describe('Inventory stale-prune (#1478)', () => {
     ]);
 
     const marked = await inventoryService.pruneStaleVariants(productId, [variantKeep]);
-    expect(marked).toBe(1);
+    expect(marked.markedCount).toBe(1);
 
     const inventoryRepo = dataSource.getRepository(InventoryItemOrmEntity);
     const baseRow = await inventoryRepo.findOneBy({ productId, productVariantId: IsNull() });
@@ -211,7 +214,7 @@ describe('Inventory stale-prune (#1478)', () => {
     ]);
 
     const marked = await inventoryService.pruneStaleVariants(productId, [null]);
-    expect(marked).toBe(1);
+    expect(marked.markedCount).toBe(1);
 
     const inventoryRepo = dataSource.getRepository(InventoryItemOrmEntity);
     const baseRow = await inventoryRepo.findOneBy({ productId, productVariantId: IsNull() });

--- a/apps/api/test/integration/product-variant-stale-prune.int-spec.ts
+++ b/apps/api/test/integration/product-variant-stale-prune.int-spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Product Variant Stale-Prune Integration Test (#1599)
+ *
+ * Vertical slice for the products-context soft-delete of variants deleted at the
+ * master. Seeds a product with variants, then drives the public products service
+ * against Postgres to assert:
+ * - `markVariantsStaleExcept` flags variants absent from the keep set (setting
+ *   `staleAt`) and leaves kept variants live, returning the flagged ids;
+ * - an empty keep-set marks EVERY live variant stale (the 404 whole-product path);
+ * - `upsertVariants` clears a reappearing variant's `isStale`/`staleAt` flags.
+ *
+ * Uses real Postgres via Testcontainers — exercises the `UPDATE … RETURNING` and
+ * empty-keep branch that a mocked unit test can't.
+ *
+ * @module apps/api/test/integration
+ */
+import { DataSource } from 'typeorm';
+import { ProductOrmEntity, ProductVariantOrmEntity } from '@openlinker/core/products/orm-entities';
+import { IProductsService, PRODUCTS_SERVICE_TOKEN } from '@openlinker/core/products';
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+
+async function seedProduct(
+  dataSource: DataSource,
+  variantIds: string[],
+): Promise<{ productId: string }> {
+  const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+  const productId = `ol_product_vstale_${suffix}`;
+
+  const productRepo = dataSource.getRepository(ProductOrmEntity);
+  await productRepo.save(
+    productRepo.create({ id: productId, name: `VStale ${suffix}`, sku: null, price: null }),
+  );
+
+  const variantRepo = dataSource.getRepository(ProductVariantOrmEntity);
+  for (const id of variantIds) {
+    await variantRepo.save(
+      variantRepo.create({ id, productId, sku: null, attributes: null, ean: null, gtin: null }),
+    );
+  }
+
+  return { productId };
+}
+
+describe('Product variant stale-prune (#1599)', () => {
+  let harness: IntegrationTestHarness;
+  let productsService: IProductsService;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    productsService = harness.getApp().get<IProductsService>(PRODUCTS_SERVICE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('marks variants absent from the keep set stale (with staleAt) and leaves kept variants live', async () => {
+    const dataSource = harness.getDataSource();
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const keep = `ol_variant_keep_${suffix}`;
+    const gone = `ol_variant_gone_${suffix}`;
+
+    const { productId } = await seedProduct(dataSource, [keep, gone]);
+
+    const marked = await productsService.markVariantsStaleExcept(productId, [keep]);
+    expect(marked).toEqual([gone]);
+
+    const variantRepo = dataSource.getRepository(ProductVariantOrmEntity);
+    const keptRow = await variantRepo.findOneBy({ id: keep });
+    const goneRow = await variantRepo.findOneBy({ id: gone });
+    expect(keptRow?.isStale).toBe(false);
+    expect(keptRow?.staleAt).toBeNull();
+    expect(goneRow?.isStale).toBe(true);
+    expect(goneRow?.staleAt).toBeInstanceOf(Date);
+  });
+
+  it('marks every live variant stale when the keep set is empty (product fully removed / 404)', async () => {
+    const dataSource = harness.getDataSource();
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const a = `ol_variant_a_${suffix}`;
+    const b = `ol_variant_b_${suffix}`;
+
+    const { productId } = await seedProduct(dataSource, [a, b]);
+
+    const marked = await productsService.markVariantsStaleExcept(productId, []);
+    expect(marked.sort()).toEqual([a, b].sort());
+
+    const variantRepo = dataSource.getRepository(ProductVariantOrmEntity);
+    const rows = await variantRepo.findBy({ productId });
+    expect(rows.every((r) => r.isStale)).toBe(true);
+  });
+
+  it('does not re-flag an already-stale variant (idempotent — returns only newly flagged)', async () => {
+    const dataSource = harness.getDataSource();
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const gone = `ol_variant_gone_${suffix}`;
+
+    const { productId } = await seedProduct(dataSource, [gone]);
+
+    const first = await productsService.markVariantsStaleExcept(productId, []);
+    expect(first).toEqual([gone]);
+    const second = await productsService.markVariantsStaleExcept(productId, []);
+    expect(second).toEqual([]);
+  });
+
+  it('clears isStale/staleAt when a stale variant reappears via upsertVariants', async () => {
+    const dataSource = harness.getDataSource();
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const variantId = `ol_variant_back_${suffix}`;
+
+    const { productId } = await seedProduct(dataSource, [variantId]);
+    await productsService.markVariantsStaleExcept(productId, []);
+
+    await productsService.upsertVariants(productId, [
+      { id: variantId, productId, sku: null, attributes: null, ean: null, gtin: null },
+    ]);
+
+    const variantRepo = dataSource.getRepository(ProductVariantOrmEntity);
+    const row = await variantRepo.findOneBy({ id: variantId });
+    expect(row?.isStale).toBe(false);
+    expect(row?.staleAt).toBeNull();
+  });
+});

--- a/apps/worker/src/sync/handlers/__tests__/master-product-sync.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/master-product-sync.handler.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Master Product Sync Handler Tests
+ *
+ * Covers the ADR-007 status/outcome mapping added in #1599: a master-side
+ * deletion (`masterDeleted: true`) yields a terminal `business_failure`
+ * (not retried), a normal sync yields `ok`, and a transient service error
+ * still wraps in a retryable `SyncJobExecutionError`.
+ *
+ * @module apps/worker/src/sync/handlers/__tests__
+ */
+import { MasterProductSyncHandler } from '../master-product-sync.handler';
+import type { IMasterProductSyncService, MasterProductSyncResult } from '@openlinker/core/products';
+import type { SyncJobEntity as SyncJob } from '@openlinker/core/sync';
+import { SyncJobExecutionError } from '@openlinker/core/sync';
+
+describe('MasterProductSyncHandler', () => {
+  let handler: MasterProductSyncHandler;
+  let masterProductSync: jest.Mocked<IMasterProductSyncService>;
+
+  beforeEach(() => {
+    masterProductSync = {
+      syncFromMasterByExternalId: jest.fn(),
+    };
+    handler = new MasterProductSyncHandler(masterProductSync);
+  });
+
+  const createJob = (): SyncJob =>
+    ({
+      id: 'job-1',
+      jobType: 'master.product.syncByExternalId',
+      connectionId: 'conn-1',
+      payload: { schemaVersion: 1, externalId: 'ext-9', objectType: 'Product' },
+      idempotencyKey: 'key',
+      status: 'queued',
+      attempts: 0,
+      maxAttempts: 3,
+      nextRunAt: new Date(),
+      lockedAt: null,
+      lockedBy: null,
+      lastError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }) as unknown as SyncJob;
+
+  const result = (masterDeleted: boolean): MasterProductSyncResult => ({
+    internalProductId: 'ol_product_abc',
+    variantsUpserted: masterDeleted ? 0 : 2,
+    masterDeleted,
+  });
+
+  it('returns outcome=ok for a normal sync', async () => {
+    masterProductSync.syncFromMasterByExternalId.mockResolvedValueOnce(result(false));
+
+    await expect(handler.execute(createJob())).resolves.toEqual({ outcome: 'ok' });
+  });
+
+  it('returns outcome=business_failure when the product was deleted at the master', async () => {
+    masterProductSync.syncFromMasterByExternalId.mockResolvedValueOnce(result(true));
+
+    await expect(handler.execute(createJob())).resolves.toEqual({ outcome: 'business_failure' });
+  });
+
+  it('wraps a transient service error in a retryable SyncJobExecutionError', async () => {
+    masterProductSync.syncFromMasterByExternalId.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+    await expect(handler.execute(createJob())).rejects.toBeInstanceOf(SyncJobExecutionError);
+  });
+});

--- a/apps/worker/src/sync/handlers/master-product-sync.handler.ts
+++ b/apps/worker/src/sync/handlers/master-product-sync.handler.ts
@@ -50,7 +50,20 @@ export class MasterProductSyncHandler implements SyncJobHandler {
     );
 
     try {
-      await this.masterProductSync.syncFromMasterByExternalId(job.connectionId, payload.externalId);
+      const result = await this.masterProductSync.syncFromMasterByExternalId(
+        job.connectionId,
+        payload.externalId
+      );
+
+      // A product deleted at the master is a terminal business outcome, not a
+      // transient failure — return business_failure so the runner does NOT retry
+      // a permanent condition (#1599, ADR-007). The variants were marked stale.
+      if (result.masterDeleted) {
+        this.logger.warn(
+          `Master product sync: product deleted at master (job ${job.id}, connection: ${job.connectionId}, externalId: ${String(payload.externalId)})`
+        );
+        return { outcome: 'business_failure' };
+      }
 
       return { outcome: 'ok' };
     } catch (error) {

--- a/docs/plans/analysis/ANALYSIS-master-deletion-propagation.md
+++ b/docs/plans/analysis/ANALYSIS-master-deletion-propagation.md
@@ -1,0 +1,45 @@
+# Pre-implement Gate — Master-deletion propagation (#1599)
+
+**Plan:** `docs/plans/implementation-plan-master-deletion-propagation.md`
+**Date:** 2026-07-15
+**Verdict:** ✅ **READY** (no Critical findings; several in-PR mechanical Warnings)
+
+---
+
+## Reuse audit (does it already exist?)
+
+| Plan artifact | Class | Evidence |
+|---|---|---|
+| `product_variants.isStale` / `staleAt` columns | **NEW** | No `isStale`/`staleAt` anywhere under `libs/core/src/products/` |
+| `ProductVariantRepositoryPort.markStaleExceptVariants` | **NEW** | Port has `findById/findByProductId/…/upsert/upsertMany/findMany` only |
+| `IProductsService.markVariantsStaleExcept` | **NEW** | Absent from interface |
+| `MasterProductNotFoundError` | **NEW** | grep empty; no `products/domain/exceptions/` dir yet |
+| `StaleOrderItemError` | **NEW** | grep empty |
+| Event names `master.variant.stale` / `master.product.stale`, stream `events.master.deletion` | **NEW** | grep empty |
+| `MasterProductSyncResult.masterDeleted` | **PARTIAL (extend)** | Current shape `{ internalProductId, variantsUpserted }` — add field |
+| Stale-column pattern / `markStaleExceptVariants` query / `pruneStaleVariants` / event-publish shape | **REUSE** | `inventory-item.orm-entity.ts`, `inventory.repository.ts:133`, `master-inventory-sync.service.ts:78`, `sync-job-bulk-retry.service.ts:54`, migration `…007-add-inventory-item-is-stale.ts` |
+
+No reuse collisions — every proposed new artifact is confirmed absent.
+
+## Backward-compatibility checklist
+
+| Surface | Finding | Severity | Migration path |
+|---|---|---|---|
+| `product_variants` ORM schema | 2 new columns | **Warning (expected)** | Migration `1818000000008-add-product-variant-is-stale.ts` (next sequential prefix; latest is `…007`) |
+| `IProductsService` (barrel-exported) | **Add** `markVariantsStaleExcept` (additive method) | **Warning** | Purely additive to the contract. Breaks 1 typed mock literal: `products.controller.spec.ts:46 createMockProductsService()` (`jest.Mocked<IProductsService>` requires all keys) → add `markVariantsStaleExcept: jest.fn()`. The worker handler mock (`marketplace-offer-create.handler.spec.ts:71`) uses `as unknown as` cast → unaffected. |
+| `ProductVariantRepositoryPort` (barrel-exported) | **Add** `markStaleExceptVariants` | **Warning** | Additive. Update 2 typed mock literals: `products.service.spec.ts:57`, `listings.controller.spec.ts:65`. |
+| `IInventoryService.pruneStaleVariants` (barrel-exported) | **Change return** `Promise<number>` → `Promise<{ markedCount; variantIds }>` | **Warning** | Only in-context production caller is `master-inventory-sync.service.ts:78`. Update return type + these tests: `master-inventory-sync.service.spec.ts:70` (`mockResolvedValue(0)`), `inventory.service.spec.ts:182`, `inventory-stale-prune.int-spec.ts` (assert on `.markedCount`). No external method consumers. |
+| `ProductMasterPort.getProduct` thrown type | Adapters translate platform 404 → neutral `MasterProductNotFoundError` (signature unchanged) | **None** | The 4 `productMaster.getProduct(...)` callers are all **core** services (`master-product-sync`, `product-publish-builder`, `offer-builder`, `content-suggestion`) — none can `instanceof` a platform exception (cross-boundary ban), so none break; `master-product-sync` gains an explicit catch. Net improvement. Verify no adapter-internal caller of product-master `getProduct` catches the platform type (low risk — the existing PS catchers are in the order-processor adapter, a different file). |
+| `MasterProductSyncResult` (barrel-exported) | Add required `masterDeleted` | **Warning-low** | Return type; sole consumer is the worker handler (updated in-PR). All producer paths set it. |
+| Top-level barrels | New exports added (`MasterProductNotFoundError`, event constants/types); none removed/renamed | **None** | Additive |
+| Symbol tokens | None changed | **None** | |
+| `check:invariants` (cross-context) | `inventory → products` (import event constants) already an allowed edge; `products → events` and `inventory → events` land on the allowed infrastructure spine; all via top-level barrels; event constants are `UPPER_SNAKE_CASE as const` (allowed cross-context shape) | **None** | Should pass |
+
+## Open questions / notes for implementation
+
+1. **`markStaleExceptVariants` RETURNING** — use `.returning('id')` (products) / `.returning('productVariantId')` (inventory) to return the marked ids for event payloads. Confirm the driver returns `raw` rows; map to `string[]` (filter nulls on the inventory side).
+2. **Migration authoring** — hand-author `1818000000008-…` with the synthetic sequential prefix (per `docs/migrations.md` #1013) rather than relying on a generated timestamp prefix; verify `migration:show` is clean.
+3. **Test-mock fan-out** — the three typed `jest.Mocked<…>` literals above (2 for the added port/service methods, plus the inventory return-type ripple) must be updated in the same PR or `type-check`/`pnpm test` fails. This is expected mechanical churn, not a design problem.
+4. **`domain/exceptions/` dir** is created fresh in the products context (none exists today).
+
+**Bottom line:** the plan reinvents nothing and breaks no published contract. All Warnings are additive-method mock updates, one low-blast-radius return-type widening, and the expected migration — all contained within this PR. Proceed.

--- a/docs/plans/implementation-plan-master-deletion-propagation.md
+++ b/docs/plans/implementation-plan-master-deletion-propagation.md
@@ -1,0 +1,164 @@
+# Implementation Plan — Master-side product/variant deletion propagation (#1599)
+
+**Issue:** [#1599](https://github.com/openlinker-project/openlinker/issues/1599) — `[BUG] CORE — master-side product/variant deletion never propagates beyond inventory_items.isStale`
+**Branch:** `1599-master-variant-deletion-propagation`
+**Date:** 2026-07-15
+**Type:** CORE (Domain / Application / Infrastructure + migration) + thin Integration (adapter error translation)
+
+---
+
+## 1. Understand the task
+
+When a product/variant is **deleted at the master** (any `ProductMaster`/`InventoryMaster`), the only signal OpenLinker records today is `inventory_items.isStale` (#1478) — confined to the inventory context. Consequences:
+
+- **Zombie variants** — `product_variants` has no staleness marker; canonical variants of a deleted product live forever as valid rows.
+- **Orders fail late & opaquely** — `OrderItemRefResolverService` resolves a deleted variant to a normal order line; it only fails downstream at the destination adapter (e.g. PS `validateOrder`), producing a perpetually-retried job with a misleading error.
+- **No signal** — marking stale is a bare `UPDATE` + `logger.debug`; no domain event, nothing an operator can observe.
+- **404 dead-end** — a master `getProduct()` 404 is not distinguished from a transient error; the permanent condition is retried forever.
+
+**Goal:** make master-side deletion a first-class, master-agnostic signal in `libs/core` — mark stale in the products context, distinguish 404 from transient failure, guard order resolution early, and emit a domain event.
+
+**Layer classification:** CORE (products + orders + inventory + events) with a **thin, mechanical Integration touch** (two adapters translate their platform 404 exception to one neutral core error at the port boundary — the standard error-conversion pattern, no domain logic).
+
+**Explicit non-goals (per issue):**
+- No UI / notification consumers of the new event (follow-ups) — this issue only guarantees the event *exists*.
+- No row deletion — staleness is a **soft mark** (consistent with #1478); mappings + historical orders keep resolving.
+- The dead-code/retry observation in `prestashop-order-processor-manager.adapter.ts:605-673` is out of scope (separate adapter finding).
+- Staleness lives on **variants only** (see §3, Decision D1) — not a new `products.isStale` column.
+
+---
+
+## 2. Research — existing patterns to reuse
+
+| Concern | Reference (reuse verbatim where possible) |
+|---|---|
+| Stale column + soft-mark | `inventory-item.orm-entity.ts:68` `@Column({ type: 'boolean', default: false }) isStale`; migration `1818000000007-add-inventory-item-is-stale.ts` |
+| Bulk "mark stale except keep-set" | `inventory.repository.ts:133 markStaleExceptVariants` — NULL-safe `Brackets`, `.andWhere('isStale = false')` |
+| Unconditional prune after sync write | `master-inventory-sync.service.ts:66-81` (collect `currentVariantIds`, prune) |
+| Variant repo mappers | `product-variant.repository.ts` `toDomain:223` / `toOrmEntity:240`, `upsert`/`upsertMany` |
+| Cross-context variant read | `IProductsService.getVariant` (`products.service.interface.ts:62`), consumed by orders resolver |
+| Order resolution seam | `order-item-ref-resolver.service.ts` `tryResolve → {resolved:false, reason}` + `MissingOrderItemMappingError` |
+| Status/outcome split (ADR-007) | `SyncJobHandlerResult { outcome: 'ok' \| 'business_failure' }` (`sync-job.types.ts:98-118`); example `invoicing-issue.handler.ts:59-94` |
+| Domain event publish | `sync-job-bulk-retry.service.ts:54-68` — `publish(STREAM, {eventId, eventType, payloadJson, metadataJson, occurredAt, publishedAt})`; wire via `EventsModule` + `EVENT_PUBLISHER_TOKEN` (`sync.module.ts:12,59`) |
+| Platform 404 exceptions | `PrestashopResourceNotFoundException` (PS `getResource` 404, client:650) / `WooCommerceResourceNotFoundException` (Woo 404, adapter:100) — both extend bare `Error`, no shared base |
+
+**Key deltas from the #1478 template:**
+- `product_variants` is an **interface** (structural), not a class — new fields go on the interface + repo mappers, no constructor.
+- `staleAt` is **net-new** (inventory has only `isStale`).
+- Products/inventory modules do **not** yet import `EventsModule` — event wiring is part of the work.
+
+---
+
+## 3. Design
+
+### Data flow (after the change)
+
+```
+marketplace/shop deletes product
+   │
+   ├─ marketplace.product.sync job ──► MasterProductSyncService.syncFromMasterByExternalId
+   │      ProductMaster.getProduct(id)
+   │        ├─ 200 + getProductVariants → upsert (clears isStale) + markVariantsStaleExcept(currentIds)
+   │        │        └─ if any marked → emit master.variant.stale
+   │        └─ 404 → adapter throws neutral MasterProductNotFoundError
+   │                 → markVariantsStaleExcept(productId, [])  (mark ALL stale)
+   │                 → emit master.product.stale
+   │                 → return { masterDeleted:true } → handler outcome:'business_failure' (NOT retried)
+   │
+   ├─ inventory sync ──► MasterInventorySyncService (unchanged prune) → emit master.variant.stale
+   │
+   └─ later, order arrives referencing the deleted variant
+          OrderItemRefResolverService.resolve → getVariant → variant.isStale === true
+             → throw StaleOrderItemError → tryResolve → {resolved:false, reason:"…deleted at master…"}
+             (early, actionable — no opaque destination rejection)
+```
+
+### Decisions
+- **D1 — variants-only staleness.** Every product has ≥1 variant (simple products get a deterministic synthetic variant), so "all variants of product P are stale" *is* the product-deleted signal. Avoids a second table/column. The 404 path marks all variants stale and emits `master.product.stale`.
+- **D2 — adapter translates 404 at the port boundary.** Both adapters wrap `getProduct` to catch their own platform not-found and rethrow the neutral core `MasterProductNotFoundError`. Keeps platform strings out of core (ADR-boundary compliant) and the platform exception internal to the adapter. Only `getProduct` is wrapped — other methods and other catchers of the platform exception are untouched.
+- **D3 — `getVariant`/`findById` do NOT filter stale.** The resolver must *see* the stale variant to raise the rich reason; filtering would degrade it to the generic `variant-missing`. (Contrast inventory's availability read, which filters — different use case.)
+- **D4 — un-stale on reappearance is automatic** via `upsertMany`: `toOrmEntity` writes `isStale = variant.isStale ?? false`, `staleAt = variant.staleAt ?? null`; the sync-built domain variant has neither set → clears the flag.
+- **D5 — dedicated `StaleOrderItemError`** (not overloading `MissingOrderItemMappingError`) — distinct name + message-rich; caught alongside the existing error in `tryResolve` so downstream handling is identical.
+
+---
+
+## 4. Step-by-step implementation
+
+### A — Products-context staleness marker
+
+1. **`libs/core/src/products/infrastructure/persistence/entities/product-variant.orm-entity.ts`** — add:
+   ```ts
+   @Column({ type: 'boolean', default: false })
+   isStale!: boolean;
+
+   @Column({ type: 'timestamp', nullable: true })
+   staleAt!: Date | null;
+   ```
+2. **`libs/core/src/products/domain/entities/product-variant.entity.ts`** — add interface fields `isStale?: boolean;` and `staleAt?: Date | null;` (documented as master-deletion soft-mark).
+3. **`product-variant.repository.ts`** —
+   - `toDomain` (:223): `isStale: entity.isStale, staleAt: entity.staleAt`.
+   - `toOrmEntity` (:240): `entity.isStale = variant.isStale ?? false; entity.staleAt = variant.staleAt ?? null;` (D4).
+   - New method `markStaleExceptVariants(productId, keepVariantIds): Promise<string[]>`. **Do NOT clone inventory's nullable-`Brackets` query** (review IMPORTANT): `product_variants` is keyed by a non-null `id` PK, so no three-valued NULL handling is needed. Shape: `.update().set({ isStale: true, staleAt: () => 'NOW()' }).where('productId = :pid AND isStale = false')` + **only when `keepVariantIds` is non-empty** append `.andWhere('id NOT IN (:...keep)')` — an empty keep-set (the 404 whole-product path) marks every live row, and `id NOT IN ()` is invalid SQL. Use `.returning('id')` and narrow the raw result explicitly: `(result.raw as { id: string }[]).map((r) => r.id)` — **no `any`** (review IMPORTANT).
+4. **`product-variant-repository.port.ts`** — add `markStaleExceptVariants(productId: string, keepVariantIds: readonly string[]): Promise<string[]>` with JSDoc.
+5. **`products.service.interface.ts` + `products.service.ts`** — add `markVariantsStaleExcept(productId, keepVariantIds): Promise<string[]>` delegating to the repo.
+
+### B — Neutral not-found + business-failure outcome
+
+6. **New `libs/core/src/products/domain/exceptions/master-product-not-found.error.ts`** — `MasterProductNotFoundError extends Error` with `(productId, connectionId, cause?)`, `name` set, `captureStackTrace`. Export from `libs/core/src/products/index.ts`.
+7. **Adapters translate (D2):**
+   - `prestashop-product-master.adapter.ts` `getProduct` — wrap body; `catch (e) { if (e instanceof PrestashopResourceNotFoundException) throw new MasterProductNotFoundError(productId, this.connection.id, e); throw e; }`.
+   - `woocommerce-product-master.adapter.ts` `getProduct` — same, catching `WooCommerceResourceNotFoundException`.
+   - (Import `MasterProductNotFoundError` from `@openlinker/core/products` — integrations already depend on the core barrel.)
+8. **`master-product-sync.service.ts` `syncFromMasterByExternalId`** —
+   - Collect `currentVariantIds` from the master `variants`, call `productsService.markVariantsStaleExcept(internalProductId, currentVariantIds)` unconditionally after upsert; emit `master.variant.stale` if the returned id list is non-empty (§D).
+   - Wrap `getProduct`/`getProductVariants` in try/catch: on `MasterProductNotFoundError`, call `markVariantsStaleExcept(internalProductId, [])`, emit `master.product.stale`, and return `{ internalProductId, variantsUpserted: 0, masterDeleted: true }` (do **not** rethrow). Transient errors rethrow unchanged.
+   - Extend `MasterProductSyncResult` with `masterDeleted: boolean` (default `false` on the success path).
+9. **`apps/worker/src/sync/handlers/master-product-sync.handler.ts`** — return `{ outcome: result.masterDeleted ? 'business_failure' : 'ok' }`. Transient throws still wrap in `SyncJobExecutionError` (retryable) unchanged.
+
+### C — Order-item resolution guard
+
+10. **New `libs/core/src/orders/domain/exceptions/stale-order-item.error.ts`** — `StaleOrderItemError extends Error(connectionId, productRef, internalVariantId)` with a message naming "variant deleted at the master".
+11. **`order-item-ref-resolver.service.ts`** — after each `getVariant` (`offer`, `variant`, `sku` branches), `if (variant.isStale) throw new StaleOrderItemError(...)`. Add `|| error instanceof StaleOrderItemError` to the `tryResolve` catch so it maps to `{ resolved:false, productRef, reason: error.message }`.
+
+### D — Event emission
+
+12. **New `libs/core/src/products/domain/types/master-deletion-events.types.ts`** — `MASTER_DELETION_EVENT_STREAM = 'events.master.deletion'`, `MASTER_VARIANT_STALE_EVENT = 'master.variant.stale'`, `MASTER_PRODUCT_STALE_EVENT = 'master.product.stale'`, and a `MasterDeletionEventPayload { connectionId; internalProductId; variantIds: string[] }` type. Export from products barrel.
+13. **`master-product-sync.service.ts`** — inject `EventPublisherPort` (`EVENT_PUBLISHER_TOKEN`); publish on both prune paths (variant prune + 404). Upgrade the prune `logger.debug` → `logger.warn`.
+14. **`master-inventory-sync.service.ts`** — extend `InventoryService.pruneStaleVariants` to return `{ markedCount: number; variantIds: string[] }` (change `markStaleExceptVariants` in `inventory.repository.ts` to `.returning('productVariantId')`, narrow `result.raw` explicitly and **filter nulls** — product-level rows carry `productVariantId = NULL`; ripple through `inventory.service(.interface).ts` return type). This is a change to the barrel-exported `IInventoryService` (review IMPORTANT): update all consumers/mocks in the same PR — `master-inventory-sync.service.spec.ts:70` (`mockResolvedValue({ markedCount: 0, variantIds: [] })`), `inventory.service.spec.ts:182`, `inventory-stale-prune.int-spec.ts` (assert on `.markedCount`). Inject the publisher, emit `master.variant.stale` when ids are non-empty; upgrade the prune log `debug → warn`.
+
+    > **Edge (review SUGGESTION):** `getProductVariants` is not translated to `MasterProductNotFoundError` — only `getProduct` is. Since `getProduct` is called first in the sync, a deleted product 404s there; a 404 surfacing only from `getProductVariants` stays a generic retryable error. Acceptable for MVP.
+15. **Module wiring** — add `EventsModule` to `imports` and inject `EVENT_PUBLISHER_TOKEN` in `products.module.ts` and `inventory.module.ts` (mirror `sync.module.ts`).
+
+### Migration
+
+16. `pnpm --filter @openlinker/api migration:generate -- src/migrations/AddProductVariantIsStale` (or hand-author a `18180000000NN-...` sequential-prefix migration per `docs/migrations.md`) adding `isStale boolean NOT NULL DEFAULT false` + `staleAt timestamp NULL` to `product_variants`. Verify `migration:show` reports no pending drift.
+
+### Cross-cutting (review IMPORTANT)
+
+- **File headers** — every new `.ts` (both exception classes, `master-deletion-events.types.ts`) gets the JSDoc header block per engineering-standards §File Headers.
+
+### Tests (unit — colocated `*.spec.ts`)
+
+- `product-variant.repository.spec` — `markStaleExceptVariants` marks the absent set, keeps the keep-set, returns ids; **empty keep-set marks every live row** (the 404 whole-product branch); `toDomain`/`toOrmEntity` round-trip isStale/staleAt.
+- **Products prune int-spec (review SUGGESTION)** — add `apps/api/test/integration/product-variant-stale-prune.int-spec.ts` mirroring `inventory-stale-prune.int-spec.ts` (real-Postgres `UPDATE ... RETURNING`, empty-keep branch).
+- `master-product-sync.service.spec` — (a) prune marks absent variants + un-stales on reappearance; (b) 404 → all-stale + `masterDeleted:true` + `master.product.stale` published; (c) `master.variant.stale` published on partial prune.
+- `master-product-sync.handler.spec` — `masterDeleted → business_failure`; transient error → throws (retryable).
+- `order-item-ref-resolver.service.spec` — stale variant → `{resolved:false, reason}` for `offer`, `variant`, `sku` branches.
+- `master-inventory-sync.service.spec` — event published when rows marked stale.
+- Adapter specs (PS + Woo) — `getProduct` 404 → `MasterProductNotFoundError`.
+
+---
+
+## 5. Validate
+
+- **Architecture:** all domain logic in `libs/core`; adapters only translate their own exception (no domain logic, no platform string in core). Cross-context reads (orders→products, inventory→products events) via barrels — `pnpm check:invariants` must pass. Event types live in the products context (owner of variant staleness); inventory already depends on products.
+- **Naming:** `*.error.ts` exceptions, `*.types.ts` for event constants, `markVariantsStaleExcept` mirrors `pruneStaleVariants`.
+- **Security:** no new external input surface; event payloads carry only internal ids.
+- **Migration:** required (schema change), `migration:show` clean gate.
+- **Testing:** unit-first; the concurrency/real-DB angle of the stale marking is covered by the existing #1478 inventory pattern — no new integration test strictly required, but a products int-spec may be added if time permits.
+
+## Risks / open questions
+
+- **PR size.** Touches 4 core contexts + 2 adapters + worker + migration. Recommendation: **one cohesive PR** (A+B+C+D) — shipping A+B alone leaves the headline symptom (orders resolving deleted variants) unfixed. Fallback split available per the issue if review prefers.
+- **Double-emission** — product sync and inventory sync each emit on their own prune for the same deletion. Accepted: distinct context signals; consumers dedupe. Documented in the event type JSDoc.
+- **Inventory return-shape change** — `pruneStaleVariants` gains a variant-id list; single caller, low blast radius.

--- a/libs/core/src/inventory/application/services/__tests__/inventory.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory.service.spec.ts
@@ -179,16 +179,19 @@ describe('InventoryService', () => {
     );
   });
 
-  it('delegates pruneStaleVariants to the repository and returns the marked count', async () => {
-    (inventoryRepository.markStaleExceptVariants as jest.Mock).mockResolvedValue(3);
+  it('delegates pruneStaleVariants to the repository and returns the prune result', async () => {
+    (inventoryRepository.markStaleExceptVariants as jest.Mock).mockResolvedValue({
+      markedCount: 3,
+      variantIds: ['ol_variant_b'],
+    });
 
-    const marked = await service.pruneStaleVariants('product-id', ['ol_variant_a', null]);
+    const result = await service.pruneStaleVariants('product-id', ['ol_variant_a', null]);
 
     expect(inventoryRepository.markStaleExceptVariants).toHaveBeenCalledWith('product-id', [
       'ol_variant_a',
       null,
     ]);
-    expect(marked).toBe(3);
+    expect(result).toEqual({ markedCount: 3, variantIds: ['ol_variant_b'] });
   });
 
   it('uses persisted updatedAt as write event token', async () => {

--- a/libs/core/src/inventory/application/services/__tests__/master-inventory-sync.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/master-inventory-sync.service.spec.ts
@@ -24,6 +24,7 @@ import type {
 } from '@openlinker/core/inventory';
 import { InventoryItemEntity as InventoryItem } from '@openlinker/core/inventory';
 import type { IProductsService, ProductVariant } from '@openlinker/core/products';
+import type { EventPublisherPort } from '@openlinker/core/events';
 
 describe('MasterInventorySyncService', () => {
   let service: MasterInventorySyncService;
@@ -32,6 +33,7 @@ describe('MasterInventorySyncService', () => {
   let inventoryService: jest.Mocked<IInventoryService>;
   let inventoryAdapter: jest.Mocked<InventoryMasterPort>;
   let productsService: jest.Mocked<Pick<IProductsService, 'getVariantsByProductId'>>;
+  let eventPublisher: jest.Mocked<EventPublisherPort>;
 
   const connectionId = 'connection-123';
   const externalId = 'ext-product-9';
@@ -67,7 +69,7 @@ describe('MasterInventorySyncService', () => {
     inventoryService = {
       setInventory: jest.fn().mockImplementation((item: InventoryItem) => Promise.resolve(item)),
       getInventory: jest.fn().mockResolvedValue(null),
-      pruneStaleVariants: jest.fn().mockResolvedValue(0),
+      pruneStaleVariants: jest.fn().mockResolvedValue({ markedCount: 0, variantIds: [] }),
     } as unknown as jest.Mocked<IInventoryService>;
 
     productsService = {
@@ -76,11 +78,16 @@ describe('MasterInventorySyncService', () => {
       getVariantsByProductId: jest.fn().mockResolvedValue([]),
     };
 
+    eventPublisher = {
+      publish: jest.fn().mockResolvedValue('msg-1'),
+    } as unknown as jest.Mocked<EventPublisherPort>;
+
     service = new MasterInventorySyncService(
       integrationsService,
       identifierMapping,
       inventoryService,
-      productsService as unknown as IProductsService
+      productsService as unknown as IProductsService,
+      eventPublisher
     );
   });
 
@@ -371,6 +378,40 @@ describe('MasterInventorySyncService', () => {
       await service.syncFromMasterByExternalId(connectionId, externalId);
 
       expect(inventoryService.pruneStaleVariants).toHaveBeenCalledWith(internalProductId, [null]);
+    });
+
+    it('publishes master.variant.stale when the prune flags variant rows (#1599)', async () => {
+      inventoryAdapter.listInventory.mockResolvedValue([]);
+      (inventoryService.pruneStaleVariants as jest.Mock).mockResolvedValueOnce({
+        markedCount: 2,
+        variantIds: ['ol_variant_gone'],
+      });
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(eventPublisher.publish).toHaveBeenCalledWith(
+        'events.master.deletion',
+        expect.objectContaining({
+          eventType: 'master.variant.stale',
+          payloadJson: JSON.stringify({
+            connectionId,
+            internalProductId,
+            variantIds: ['ol_variant_gone'],
+          }),
+        })
+      );
+    });
+
+    it('does not publish when the prune flags no variant rows', async () => {
+      inventoryAdapter.listInventory.mockResolvedValue([]);
+      (inventoryService.pruneStaleVariants as jest.Mock).mockResolvedValueOnce({
+        markedCount: 0,
+        variantIds: [],
+      });
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(eventPublisher.publish).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/core/src/inventory/application/services/inventory.service.interface.ts
+++ b/libs/core/src/inventory/application/services/inventory.service.interface.ts
@@ -8,6 +8,7 @@
  * @see {@link InventoryService} for the implementation
  */
 import type { InventoryItem } from '../../domain/entities/inventory-item.entity';
+import type { PruneStaleVariantsResult } from '../../domain/types/inventory.types';
 
 /**
  * Inventory Service Interface
@@ -56,10 +57,12 @@ export interface IInventoryService {
    *
    * @param productId internal OpenLinker product ID
    * @param currentVariantIds variant keys still present at the master (may include `null`)
-   * @returns number of rows newly marked stale
+   * @returns rows newly marked stale (`markedCount`) + the distinct non-null
+   *   variant ids flagged (`variantIds`), so the caller can emit a
+   *   master-deletion event (#1599)
    */
   pruneStaleVariants(
     productId: string,
     currentVariantIds: readonly (string | null)[]
-  ): Promise<number>;
+  ): Promise<PruneStaleVariantsResult>;
 }

--- a/libs/core/src/inventory/application/services/inventory.service.ts
+++ b/libs/core/src/inventory/application/services/inventory.service.ts
@@ -14,6 +14,7 @@ import { Injectable, Inject } from '@nestjs/common';
 import type { IInventoryService } from './inventory.service.interface';
 import { InventoryRepositoryPort } from '../../domain/ports/inventory-repository.port';
 import type { InventoryItem } from '../../domain/entities/inventory-item.entity';
+import type { PruneStaleVariantsResult } from '../../domain/types/inventory.types';
 import { Logger } from '@openlinker/shared/logging';
 import { INVENTORY_REPOSITORY_TOKEN } from '../../inventory.tokens';
 import { SyncJobQueuePort, SYNC_JOB_QUEUE_TOKEN } from '@openlinker/core/sync';
@@ -109,17 +110,17 @@ export class InventoryService implements IInventoryService {
   async pruneStaleVariants(
     productId: string,
     currentVariantIds: readonly (string | null)[]
-  ): Promise<number> {
-    const marked = await this.inventoryRepository.markStaleExceptVariants(
+  ): Promise<PruneStaleVariantsResult> {
+    const result = await this.inventoryRepository.markStaleExceptVariants(
       productId,
       currentVariantIds
     );
-    if (marked > 0) {
-      this.logger.debug(
-        `inventory_prune_marked_stale product=${productId} rows=${marked} kept=${currentVariantIds.length}`
+    if (result.markedCount > 0) {
+      this.logger.warn(
+        `inventory_prune_marked_stale product=${productId} rows=${result.markedCount} variants=${result.variantIds.length} kept=${currentVariantIds.length}`
       );
     }
-    return marked;
+    return result;
   }
 
   private buildPropagationDedupeKey(item: InventoryItem, writeEventToken: string): string {

--- a/libs/core/src/inventory/application/services/master-inventory-sync.service.ts
+++ b/libs/core/src/inventory/application/services/master-inventory-sync.service.ts
@@ -11,7 +11,14 @@ import { Injectable, Inject } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
-import { IProductsService, PRODUCTS_SERVICE_TOKEN } from '@openlinker/core/products';
+import {
+  IProductsService,
+  PRODUCTS_SERVICE_TOKEN,
+  MASTER_DELETION_EVENT_STREAM,
+  MASTER_DELETION_EVENT_SCHEMA_VERSION,
+  MASTER_VARIANT_STALE_EVENT,
+} from '@openlinker/core/products';
+import { EventPublisherPort, EVENT_PUBLISHER_TOKEN } from '@openlinker/core/events';
 import { INVENTORY_SERVICE_TOKEN } from '../../inventory.tokens';
 import { IInventoryService } from './inventory.service.interface';
 import type {
@@ -37,7 +44,9 @@ export class MasterInventorySyncService implements IMasterInventorySyncService {
     @Inject(INVENTORY_SERVICE_TOKEN)
     private readonly inventoryService: IInventoryService,
     @Inject(PRODUCTS_SERVICE_TOKEN)
-    private readonly productsService: IProductsService
+    private readonly productsService: IProductsService,
+    @Inject(EVENT_PUBLISHER_TOKEN)
+    private readonly eventPublisher: EventPublisherPort
   ) {}
 
   async syncFromMasterByExternalId(
@@ -75,13 +84,32 @@ export class MasterInventorySyncService implements IMasterInventorySyncService {
     // Soft-mark any previously-known variant absent from this master response as
     // stale (#1478). Runs unconditionally — an empty response marks every row for
     // the product stale (product fully removed at the master).
-    const markedStale = await this.inventoryService.pruneStaleVariants(
+    const pruneResult = await this.inventoryService.pruneStaleVariants(
       internalProductId,
       currentVariantIds
     );
 
+    // Emit the master-deletion signal from the inventory prune path too (#1599).
+    // Disjoint from the product-sync emission — a full deletion produces one from
+    // each sync path; consumers dedupe by (productId, variantIds) as needed.
+    if (pruneResult.variantIds.length > 0) {
+      const now = new Date().toISOString();
+      await this.eventPublisher.publish(MASTER_DELETION_EVENT_STREAM, {
+        eventId: randomUUID(),
+        eventType: MASTER_VARIANT_STALE_EVENT,
+        payloadJson: JSON.stringify({
+          connectionId,
+          internalProductId,
+          variantIds: pruneResult.variantIds,
+        }),
+        metadataJson: JSON.stringify({ schemaVersion: MASTER_DELETION_EVENT_SCHEMA_VERSION }),
+        occurredAt: now,
+        publishedAt: now,
+      });
+    }
+
     this.logger.debug(
-      `Master inventory sync complete (connection: ${connectionId}, externalId: ${externalId}, internalProductId: ${internalProductId}, itemsWritten=${inventories.length}, markedStale=${markedStale}, available=${availableQuantity}, reserved=${reservedQuantity})`
+      `Master inventory sync complete (connection: ${connectionId}, externalId: ${externalId}, internalProductId: ${internalProductId}, itemsWritten=${inventories.length}, markedStale=${pruneResult.markedCount}, available=${availableQuantity}, reserved=${reservedQuantity})`
     );
 
     return {

--- a/libs/core/src/inventory/domain/ports/inventory-repository.port.ts
+++ b/libs/core/src/inventory/domain/ports/inventory-repository.port.ts
@@ -15,6 +15,7 @@ import type {
   InventoryPagination,
   PaginatedInventoryItems,
   VariantAvailability,
+  PruneStaleVariantsResult,
 } from '../types/inventory.types';
 
 /**
@@ -96,10 +97,11 @@ export interface InventoryRepositoryPort {
    *
    * @param productId internal OpenLinker product ID
    * @param keepVariantIds variant keys to keep live (may include `null`)
-   * @returns number of rows newly marked stale
+   * @returns rows newly marked stale (`markedCount`) + the distinct non-null
+   *   variant ids flagged (`variantIds`, for the master-deletion event)
    */
   markStaleExceptVariants(
     productId: string,
     keepVariantIds: readonly (string | null)[]
-  ): Promise<number>;
+  ): Promise<PruneStaleVariantsResult>;
 }

--- a/libs/core/src/inventory/domain/types/inventory.types.ts
+++ b/libs/core/src/inventory/domain/types/inventory.types.ts
@@ -88,6 +88,18 @@ export interface VariantAvailability {
   locationCount: number;
 }
 
+/**
+ * Result of a stale-marking prune (#1478 / #1599). `markedCount` is the total
+ * rows newly flagged (may exceed `variantIds.length` — multiple location rows
+ * per variant); `variantIds` is the distinct set of non-null variant ids
+ * flagged, used to emit the master-deletion event. Product-level rows
+ * (`productVariantId = NULL`) contribute to `markedCount` but not `variantIds`.
+ */
+export interface PruneStaleVariantsResult {
+  markedCount: number;
+  variantIds: string[];
+}
+
 
 
 

--- a/libs/core/src/inventory/index.ts
+++ b/libs/core/src/inventory/index.ts
@@ -44,6 +44,7 @@ export {
   InventoryPagination,
   PaginatedInventoryItems,
   VariantAvailability,
+  PruneStaleVariantsResult,
 } from './domain/types/inventory.types';
 
 // ORM entities are exposed on the host-only `@openlinker/core/inventory/orm-entities`

--- a/libs/core/src/inventory/infrastructure/persistence/repositories/inventory.repository.ts
+++ b/libs/core/src/inventory/infrastructure/persistence/repositories/inventory.repository.ts
@@ -25,6 +25,7 @@ import type {
   InventoryPagination,
   PaginatedInventoryItems,
   VariantAvailability,
+  PruneStaleVariantsResult,
 } from '../../../domain/types/inventory.types';
 
 @Injectable()
@@ -133,7 +134,7 @@ export class InventoryRepository implements InventoryRepositoryPort {
   async markStaleExceptVariants(
     productId: string,
     keepVariantIds: readonly (string | null)[]
-  ): Promise<number> {
+  ): Promise<PruneStaleVariantsResult> {
     const nonNullKeep = keepVariantIds.filter((v): v is string => v !== null);
     const keepNull = keepVariantIds.includes(null);
 
@@ -161,9 +162,17 @@ export class InventoryRepository implements InventoryRepositoryPort {
           }
         })
       )
+      .returning(['productVariantId'])
       .execute();
 
-    return result.affected ?? 0;
+    // RETURNING yields one raw row per flagged inventory row; distinct non-null
+    // variant ids feed the master-deletion event payload (#1599). Product-level
+    // rows carry a NULL variant id and are counted but not surfaced as ids.
+    const raw = result.raw as { productVariantId: string | null }[];
+    const variantIds = [
+      ...new Set(raw.map((r) => r.productVariantId).filter((v): v is string => v !== null)),
+    ];
+    return { markedCount: result.affected ?? raw.length, variantIds };
   }
 
   async upsert(item: InventoryItem): Promise<InventoryItem> {

--- a/libs/core/src/inventory/inventory.module.ts
+++ b/libs/core/src/inventory/inventory.module.ts
@@ -26,6 +26,7 @@ import { ProductsModule } from '@openlinker/core/products';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { SyncModule } from '@openlinker/core/sync';
+import { EventsModule } from '@openlinker/core/events';
 
 // Re-export tokens for convenience
 export {
@@ -43,6 +44,7 @@ export {
     IntegrationsModule, // Required for INTEGRATIONS_SERVICE_TOKEN (marketplace adapter resolution)
     IdentifierMappingModule, // Required for IDENTIFIER_MAPPING_SERVICE_TOKEN
     SyncModule, // Required for SYNC_JOB_QUEUE_TOKEN (inventory propagation enqueue)
+    EventsModule, // Required for EVENT_PUBLISHER_TOKEN (master-deletion event, #1599)
   ],
   providers: [
     // Provide classes directly first

--- a/libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts
@@ -1,6 +1,7 @@
 import { OrderItemRefResolverService } from '../order-item-ref-resolver.service';
 import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
 import { MissingOrderItemMappingError } from '../../../domain/exceptions/missing-order-item-mapping.error';
+import { StaleOrderItemError } from '../../../domain/exceptions/stale-order-item.error';
 import type { IProductsService, ProductVariant } from '@openlinker/core/products';
 
 function makeVariant(id: string, productId: string): ProductVariant {
@@ -14,6 +15,10 @@ function makeVariant(id: string, productId: string): ProductVariant {
     createdAt: new Date(),
     updatedAt: new Date(),
   };
+}
+
+function makeStaleVariant(id: string, productId: string): ProductVariant {
+  return { ...makeVariant(id, productId), isStale: true, staleAt: new Date() };
 }
 
 describe('OrderItemRefResolverService', () => {
@@ -111,6 +116,57 @@ describe('OrderItemRefResolverService', () => {
     await expect(
       service.resolve(connectionId, { type: 'sku', externalId: 'SKU-2' })
     ).resolves.toEqual({ internalProductId: 'ol_product_1' });
+  });
+
+  describe('stale variant guard (#1599)', () => {
+    it('throws StaleOrderItemError when an offer resolves to a stale variant', async () => {
+      identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
+      productsService.getVariant.mockResolvedValueOnce(
+        makeStaleVariant('ol_variant_1', 'ol_product_1')
+      );
+
+      await expect(
+        service.resolve(connectionId, { type: 'offer', externalId: 'offer-1' })
+      ).rejects.toBeInstanceOf(StaleOrderItemError);
+    });
+
+    it('throws StaleOrderItemError when a variant ref resolves to a stale variant', async () => {
+      identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
+      productsService.getVariant.mockResolvedValueOnce(
+        makeStaleVariant('ol_variant_1', 'ol_product_1')
+      );
+
+      await expect(
+        service.resolve(connectionId, { type: 'variant', externalId: 'v-1' })
+      ).rejects.toBeInstanceOf(StaleOrderItemError);
+    });
+
+    it('throws StaleOrderItemError when a sku resolves to a stale variant', async () => {
+      identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
+      productsService.getVariant.mockResolvedValueOnce(
+        makeStaleVariant('ol_variant_1', 'ol_product_1')
+      );
+
+      await expect(
+        service.resolve(connectionId, { type: 'sku', externalId: 'SKU-1' })
+      ).rejects.toBeInstanceOf(StaleOrderItemError);
+    });
+
+    it('tryResolve surfaces a stale variant as resolved=false with a message-rich reason', async () => {
+      identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
+      productsService.getVariant.mockResolvedValueOnce(
+        makeStaleVariant('ol_variant_1', 'ol_product_1')
+      );
+
+      const productRef = { type: 'offer' as const, externalId: 'offer-1' };
+      const result = await service.tryResolve(connectionId, productRef);
+
+      expect(result.resolved).toBe(false);
+      if (!result.resolved) {
+        expect(result.productRef).toEqual(productRef);
+        expect(result.reason).toContain('deleted at the master');
+      }
+    });
   });
 
   describe('tryResolve', () => {

--- a/libs/core/src/orders/application/services/order-item-ref-resolver.service.ts
+++ b/libs/core/src/orders/application/services/order-item-ref-resolver.service.ts
@@ -11,6 +11,7 @@ import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTIT
 import { IProductsService, PRODUCTS_SERVICE_TOKEN } from '@openlinker/core/products';
 import type { IncomingOrderItemRef } from '../../domain/types/incoming-order.types';
 import { MissingOrderItemMappingError } from '../../domain/exceptions/missing-order-item-mapping.error';
+import { StaleOrderItemError } from '../../domain/exceptions/stale-order-item.error';
 import type { IOrderItemRefResolverService } from '../interfaces/order-item-ref-resolver.service.interface';
 import type {
   ItemResolutionResult,
@@ -36,7 +37,10 @@ export class OrderItemRefResolverService implements IOrderItemRefResolverService
       const result = await this.resolve(connectionId, productRef);
       return { resolved: true, ...result };
     } catch (error) {
-      if (error instanceof MissingOrderItemMappingError) {
+      if (
+        error instanceof MissingOrderItemMappingError ||
+        error instanceof StaleOrderItemError
+      ) {
         return { resolved: false, productRef, reason: error.message };
       }
       throw error;
@@ -68,6 +72,9 @@ export class OrderItemRefResolverService implements IOrderItemRefResolverService
             productRef,
             'identifier_mappings:Offer:variant-missing'
           );
+        }
+        if (variant.isStale) {
+          throw new StaleOrderItemError(connectionId, productRef, variant.id);
         }
         return { internalProductId: variant.productId, internalVariantId: variant.id };
       }
@@ -107,6 +114,9 @@ export class OrderItemRefResolverService implements IOrderItemRefResolverService
             'identifier_mappings:ProductVariant:variant-missing'
           );
         }
+        if (variant.isStale) {
+          throw new StaleOrderItemError(connectionId, productRef, variant.id);
+        }
         return { internalProductId: variant.productId, internalVariantId: variant.id };
       }
       case 'sku': {
@@ -124,6 +134,9 @@ export class OrderItemRefResolverService implements IOrderItemRefResolverService
         }
         const variant = await this.productsService.getVariant(internalId);
         if (variant) {
+          if (variant.isStale) {
+            throw new StaleOrderItemError(connectionId, productRef, variant.id);
+          }
           return { internalProductId: variant.productId, internalVariantId: variant.id };
         }
         return { internalProductId: internalId };

--- a/libs/core/src/orders/domain/exceptions/stale-order-item.error.ts
+++ b/libs/core/src/orders/domain/exceptions/stale-order-item.error.ts
@@ -1,0 +1,33 @@
+/**
+ * Stale Order Item Error
+ *
+ * Thrown when an incoming order item resolves to a canonical variant that was
+ * deleted at the master (`ProductVariant.isStale === true`, #1599). Distinct
+ * from `MissingOrderItemMappingError`: the mapping and the variant row exist —
+ * the variant is a zombie. Surfacing this early (at resolution time) yields an
+ * actionable reason instead of an opaque destination-shop rejection later.
+ *
+ * Non-retryable until the variant is restored (un-staled) at the master. Caught
+ * by `OrderItemRefResolverService.tryResolve` and mapped to the same
+ * `{ resolved: false, reason }` seam as a missing mapping.
+ *
+ * @module libs/core/src/orders/domain/exceptions
+ */
+import type { IncomingOrderItemRef } from '../types/incoming-order.types';
+
+export class StaleOrderItemError extends Error {
+  constructor(
+    public readonly connectionId: string,
+    public readonly productRef: IncomingOrderItemRef,
+    public readonly internalVariantId: string,
+  ) {
+    super(
+      `Order item resolves to a variant deleted at the master (connectionId=${connectionId}, type=${productRef.type}, externalId=${productRef.externalId}, variantId=${internalVariantId})`,
+    );
+    this.name = 'StaleOrderItemError';
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, StaleOrderItemError);
+    }
+  }
+}

--- a/libs/core/src/products/application/services/__tests__/master-product-sync.service.spec.ts
+++ b/libs/core/src/products/application/services/__tests__/master-product-sync.service.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Master Product Sync Service Tests
+ *
+ * Covers the master-deletion propagation added in #1599: the unconditional
+ * variant-prune after a successful pull (emitting `master.variant.stale`), the
+ * 404 branch (neutral `MasterProductNotFoundError` → mark all variants stale,
+ * emit `master.product.stale`, `masterDeleted: true`, no upsert), and that a
+ * transient failure rethrows unchanged.
+ *
+ * @module libs/core/src/products/application/services/__tests__
+ */
+import { MasterProductSyncService } from '../master-product-sync.service';
+import { MasterProductNotFoundError } from '../../../domain/exceptions/master-product-not-found.error';
+import {
+  MASTER_DELETION_EVENT_STREAM,
+  MASTER_PRODUCT_STALE_EVENT,
+  MASTER_VARIANT_STALE_EVENT,
+} from '../../../domain/types/master-deletion-events.types';
+import type { IProductsService } from '../products.service.interface';
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
+import type { EventPublisherPort } from '@openlinker/core/events';
+import type { Product } from '../../../domain/entities/product.entity';
+import type { ProductVariant } from '../../../domain/entities/product-variant.entity';
+import type { ProductMasterPort } from '../../../domain/ports/product-master.port';
+
+const connectionId = 'connection-1';
+const externalId = 'ext-9';
+const internalProductId = 'ol_product_abc';
+
+function makeProduct(): Product {
+  return { id: internalProductId, name: 'P', sku: null } as unknown as Product;
+}
+
+function makeVariant(id: string): ProductVariant {
+  return { id, productId: internalProductId, sku: null, attributes: null, ean: null, gtin: null };
+}
+
+describe('MasterProductSyncService', () => {
+  let integrationsService: jest.Mocked<IIntegrationsService>;
+  let identifierMapping: jest.Mocked<IIdentifierMappingService>;
+  let productsService: jest.Mocked<
+    Pick<IProductsService, 'upsertProduct' | 'upsertVariants' | 'markVariantsStaleExcept'>
+  >;
+  let eventPublisher: jest.Mocked<EventPublisherPort>;
+  let adapter: jest.Mocked<Pick<ProductMasterPort, 'getProduct' | 'getProductVariants'>>;
+  let service: MasterProductSyncService;
+
+  beforeEach(() => {
+    adapter = {
+      getProduct: jest.fn().mockResolvedValue(makeProduct()),
+      getProductVariants: jest.fn().mockResolvedValue([makeVariant('ol_variant_1')]),
+    };
+
+    integrationsService = {
+      getCapabilityAdapter: jest.fn().mockResolvedValue(adapter),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    identifierMapping = {
+      getOrCreateInternalId: jest.fn().mockResolvedValue(internalProductId),
+    } as unknown as jest.Mocked<IIdentifierMappingService>;
+
+    productsService = {
+      upsertProduct: jest.fn().mockResolvedValue(makeProduct()),
+      upsertVariants: jest.fn().mockResolvedValue(undefined),
+      markVariantsStaleExcept: jest.fn().mockResolvedValue([]),
+    };
+
+    eventPublisher = {
+      publish: jest.fn().mockResolvedValue('msg-1'),
+    } as unknown as jest.Mocked<EventPublisherPort>;
+
+    service = new MasterProductSyncService(
+      integrationsService,
+      identifierMapping,
+      productsService as unknown as IProductsService,
+      eventPublisher
+    );
+  });
+
+  it('prunes absent variants and emits master.variant.stale on a successful pull', async () => {
+    productsService.markVariantsStaleExcept.mockResolvedValueOnce(['ol_variant_gone']);
+
+    const result = await service.syncFromMasterByExternalId(connectionId, externalId);
+
+    expect(productsService.markVariantsStaleExcept).toHaveBeenCalledWith(internalProductId, [
+      'ol_variant_1',
+    ]);
+    expect(eventPublisher.publish).toHaveBeenCalledWith(
+      MASTER_DELETION_EVENT_STREAM,
+      expect.objectContaining({ eventType: MASTER_VARIANT_STALE_EVENT })
+    );
+    expect(result).toEqual({ internalProductId, variantsUpserted: 1, masterDeleted: false });
+  });
+
+  it('does not emit when nothing was newly marked stale', async () => {
+    productsService.markVariantsStaleExcept.mockResolvedValueOnce([]);
+
+    await service.syncFromMasterByExternalId(connectionId, externalId);
+
+    expect(eventPublisher.publish).not.toHaveBeenCalled();
+  });
+
+  it('skips the prune on a successful pull that returns zero variants (avoids staling all on a flaky empty response)', async () => {
+    adapter.getProductVariants.mockResolvedValueOnce([]);
+
+    const result = await service.syncFromMasterByExternalId(connectionId, externalId);
+
+    // A genuine full deletion arrives as MasterProductNotFoundError, not an
+    // empty 200 — so an empty variant list must NOT prune (would stale everything).
+    expect(productsService.markVariantsStaleExcept).not.toHaveBeenCalled();
+    expect(eventPublisher.publish).not.toHaveBeenCalled();
+    expect(result).toEqual({ internalProductId, variantsUpserted: 0, masterDeleted: false });
+  });
+
+  it('marks all variants stale, emits master.product.stale and reports masterDeleted on a 404', async () => {
+    adapter.getProduct.mockRejectedValueOnce(
+      new MasterProductNotFoundError(internalProductId, connectionId)
+    );
+    productsService.markVariantsStaleExcept.mockResolvedValueOnce(['ol_variant_1', 'ol_variant_2']);
+
+    const result = await service.syncFromMasterByExternalId(connectionId, externalId);
+
+    // Empty keep-set ⇒ mark every variant of the product stale.
+    expect(productsService.markVariantsStaleExcept).toHaveBeenCalledWith(internalProductId, []);
+    expect(productsService.upsertProduct).not.toHaveBeenCalled();
+    expect(productsService.upsertVariants).not.toHaveBeenCalled();
+    expect(eventPublisher.publish).toHaveBeenCalledWith(
+      MASTER_DELETION_EVENT_STREAM,
+      expect.objectContaining({ eventType: MASTER_PRODUCT_STALE_EVENT })
+    );
+    expect(result).toEqual({ internalProductId, variantsUpserted: 0, masterDeleted: true });
+  });
+
+  it('rethrows a transient (non-not-found) adapter error unchanged', async () => {
+    adapter.getProduct.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+    await expect(
+      service.syncFromMasterByExternalId(connectionId, externalId)
+    ).rejects.toThrow('ECONNRESET');
+    expect(productsService.markVariantsStaleExcept).not.toHaveBeenCalled();
+    expect(eventPublisher.publish).not.toHaveBeenCalled();
+  });
+});

--- a/libs/core/src/products/application/services/master-product-sync.service.interface.ts
+++ b/libs/core/src/products/application/services/master-product-sync.service.interface.ts
@@ -10,6 +10,13 @@
 export interface MasterProductSyncResult {
   internalProductId: string;
   variantsUpserted: number;
+  /**
+   * True when the product was found deleted at the master (neutral
+   * `MasterProductNotFoundError`) — all its variants were marked stale and no
+   * upsert ran (#1599). The worker handler maps this to a terminal
+   * `outcome: 'business_failure'` (ADR-007) instead of a retryable throw.
+   */
+  masterDeleted: boolean;
 }
 
 export interface IMasterProductSyncService {

--- a/libs/core/src/products/application/services/master-product-sync.service.ts
+++ b/libs/core/src/products/application/services/master-product-sync.service.ts
@@ -7,14 +7,24 @@
  * @module libs/core/src/products/application/services
  */
 
+import { randomUUID } from 'node:crypto';
 import { Injectable, Inject } from '@nestjs/common';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
+import { EventPublisherPort, EVENT_PUBLISHER_TOKEN } from '@openlinker/core/events';
 import { PRODUCTS_SERVICE_TOKEN } from '../../products.tokens';
 import { IProductsService } from './products.service.interface';
 import type { ProductMasterPort } from '../../domain/ports/product-master.port';
 import type { Product } from '../../domain/entities/product.entity';
 import type { ProductVariant } from '../../domain/entities/product-variant.entity';
+import { MasterProductNotFoundError } from '../../domain/exceptions/master-product-not-found.error';
+import {
+  MASTER_DELETION_EVENT_STREAM,
+  MASTER_DELETION_EVENT_SCHEMA_VERSION,
+  MASTER_PRODUCT_STALE_EVENT,
+  MASTER_VARIANT_STALE_EVENT,
+  type MasterDeletionEventPayload,
+} from '../../domain/types/master-deletion-events.types';
 import { normalizeBarcode, normalizeToEan13 } from '../../domain/utils/barcode-normalization';
 import type {
   IMasterProductSyncService,
@@ -32,7 +42,9 @@ export class MasterProductSyncService implements IMasterProductSyncService {
     @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
     private readonly identifierMapping: IIdentifierMappingService,
     @Inject(PRODUCTS_SERVICE_TOKEN)
-    private readonly productsService: IProductsService
+    private readonly productsService: IProductsService,
+    @Inject(EVENT_PUBLISHER_TOKEN)
+    private readonly eventPublisher: EventPublisherPort
   ) {}
 
   async syncFromMasterByExternalId(
@@ -52,28 +64,112 @@ export class MasterProductSyncService implements IMasterProductSyncService {
       'ProductMaster'
     );
 
-    // Pull product and variants from adapter
-    const productFromAdapter = await productAdapter.getProduct(internalProductId);
-    const variantsFromAdapter = await productAdapter.getProductVariants(internalProductId);
+    // Pull product and variants from adapter. A master-side deletion surfaces
+    // as the neutral MasterProductNotFoundError (adapters translate their 404 at
+    // the port boundary, #1599) — distinct from a transient failure, which
+    // rethrows unchanged so the job stays retryable.
+    let productFromAdapter: Product;
+    let variantsFromAdapter: ProductVariant[];
+    try {
+      productFromAdapter = await productAdapter.getProduct(internalProductId);
+      variantsFromAdapter = await productAdapter.getProductVariants(internalProductId);
+    } catch (error) {
+      if (error instanceof MasterProductNotFoundError) {
+        return this.handleMasterDeletion(connectionId, externalId, internalProductId);
+      }
+      throw error;
+    }
 
     // Convert port -> domain entities
     const product = this.toDomainProduct(productFromAdapter);
     const variants = variantsFromAdapter.map((v) => this.toDomainVariant(v, internalProductId));
 
-    // Upsert into canonical storage
+    // Upsert into canonical storage (upsert clears any prior staleness on the
+    // reappearing variants — see repository toOrmEntity).
     await this.productsService.upsertProduct(product);
     if (variants.length > 0) {
       await this.productsService.upsertVariants(internalProductId, variants);
     }
 
+    // Soft-mark any previously-known variant absent from this master response as
+    // stale (#1599 — the products-context counterpart of the inventory prune).
+    // Guarded against a false positive: a successful pull returning ZERO variants
+    // is ambiguous (a genuinely emptied product vs. a flaky master response), and
+    // pruning against an empty keep-set would stale every variant. A real full
+    // deletion arrives as MasterProductNotFoundError (handleMasterDeletion) — the
+    // authoritative signal — so here we only prune when the master actually
+    // enumerated variants, and skip (with a warning) on an empty response.
+    let markedStale: string[] = [];
+    if (variants.length > 0) {
+      markedStale = await this.productsService.markVariantsStaleExcept(
+        internalProductId,
+        variants.map((v) => v.id)
+      );
+      if (markedStale.length > 0) {
+        await this.publishDeletionEvent(MASTER_VARIANT_STALE_EVENT, {
+          connectionId,
+          internalProductId,
+          variantIds: markedStale,
+        });
+      }
+    } else {
+      this.logger.warn(
+        `Master product sync returned 0 variants for an existing product — skipping prune to avoid staling all variants on a possibly-transient empty response (connection: ${connectionId}, externalId: ${externalId}, internalProductId: ${internalProductId})`
+      );
+    }
+
     this.logger.debug(
-      `Master product sync complete (connection: ${connectionId}, externalId: ${externalId}, internalProductId: ${internalProductId}, variants: ${variants.length})`
+      `Master product sync complete (connection: ${connectionId}, externalId: ${externalId}, internalProductId: ${internalProductId}, variants: ${variants.length}, markedStale=${markedStale.length})`
     );
 
     return {
       internalProductId,
       variantsUpserted: variants.length,
+      masterDeleted: false,
     };
+  }
+
+  /**
+   * Product deleted at the master: mark every one of its variants stale (empty
+   * keep-set), emit `master.product.stale`, and signal a business failure so
+   * the handler does NOT retry a permanent condition (#1599, ADR-007).
+   */
+  private async handleMasterDeletion(
+    connectionId: string,
+    externalId: string,
+    internalProductId: string
+  ): Promise<MasterProductSyncResult> {
+    const markedStale = await this.productsService.markVariantsStaleExcept(internalProductId, []);
+    if (markedStale.length > 0) {
+      await this.publishDeletionEvent(MASTER_PRODUCT_STALE_EVENT, {
+        connectionId,
+        internalProductId,
+        variantIds: markedStale,
+      });
+    }
+    this.logger.warn(
+      `Master product deleted — marked variants stale (connection: ${connectionId}, externalId: ${externalId}, internalProductId: ${internalProductId}, markedStale=${markedStale.length})`
+    );
+    return {
+      internalProductId,
+      variantsUpserted: 0,
+      masterDeleted: true,
+    };
+  }
+
+  private async publishDeletionEvent(
+    eventType: typeof MASTER_VARIANT_STALE_EVENT | typeof MASTER_PRODUCT_STALE_EVENT,
+    payload: MasterDeletionEventPayload
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    await this.eventPublisher.publish(MASTER_DELETION_EVENT_STREAM, {
+      eventId: randomUUID(),
+      eventType,
+      payloadJson: JSON.stringify(payload),
+      metadataJson: JSON.stringify({ schemaVersion: MASTER_DELETION_EVENT_SCHEMA_VERSION }),
+      occurredAt: now,
+      publishedAt: now,
+    });
   }
 
   /**

--- a/libs/core/src/products/application/services/products.service.interface.ts
+++ b/libs/core/src/products/application/services/products.service.interface.ts
@@ -104,4 +104,13 @@ export interface IProductsService {
     filters: ProductVariantListFilters,
     pagination: ProductPagination
   ): Promise<PaginatedProductVariants>;
+
+  /**
+   * Soft-mark every live variant of `productId` NOT in `keepVariantIds` as
+   * stale — deleted at the master (#1599). An empty keep-set marks all live
+   * variants (product fully removed / 404). Returns the ids newly flipped so
+   * the caller can emit a master-deletion event. Un-staling happens implicitly
+   * on the next successful upsert of a reappearing variant.
+   */
+  markVariantsStaleExcept(productId: string, keepVariantIds: readonly string[]): Promise<string[]>;
 }

--- a/libs/core/src/products/application/services/products.service.spec.ts
+++ b/libs/core/src/products/application/services/products.service.spec.ts
@@ -63,6 +63,7 @@ describe('ProductsService', () => {
     upsert: jest.fn(),
     upsertMany: jest.fn(),
     findMany: jest.fn(),
+    markStaleExceptVariants: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -233,6 +234,19 @@ describe('ProductsService', () => {
         { search: '1234567890123' },
         { limit: 20, offset: 0 }
       );
+    });
+  });
+
+  describe('markVariantsStaleExcept', () => {
+    it('delegates to the repository and returns the flagged variant ids (#1599)', async () => {
+      variantRepo.markStaleExceptVariants.mockResolvedValue(['ol_variant_gone']);
+
+      const marked = await service.markVariantsStaleExcept('ol_product_1', ['ol_variant_keep']);
+
+      expect(variantRepo.markStaleExceptVariants).toHaveBeenCalledWith('ol_product_1', [
+        'ol_variant_keep',
+      ]);
+      expect(marked).toEqual(['ol_variant_gone']);
     });
   });
 });

--- a/libs/core/src/products/application/services/products.service.ts
+++ b/libs/core/src/products/application/services/products.service.ts
@@ -112,4 +112,17 @@ export class ProductsService implements IProductsService {
   ): Promise<PaginatedProductVariants> {
     return this.variantRepository.findMany(filters, pagination);
   }
+
+  async markVariantsStaleExcept(
+    productId: string,
+    keepVariantIds: readonly string[]
+  ): Promise<string[]> {
+    const marked = await this.variantRepository.markStaleExceptVariants(productId, keepVariantIds);
+    if (marked.length > 0) {
+      this.logger.warn(
+        `products_prune_marked_stale (productId: ${productId}, markedStale=${marked.length}, kept=${keepVariantIds.length})`
+      );
+    }
+    return marked;
+  }
 }

--- a/libs/core/src/products/domain/entities/product-variant.entity.ts
+++ b/libs/core/src/products/domain/entities/product-variant.entity.ts
@@ -36,4 +36,15 @@ export interface ProductVariant {
   price?: number;
   /** Master-derived, not persisted on the variants table. */
   weight?: number;
+  /**
+   * Soft-mark set when the variant is deleted at the master — absent from the
+   * master's `getProductVariants` response, or the product itself 404s (#1599).
+   * Optional at the domain level so adapter drafts and test factories may omit
+   * it; the repository normalises `undefined → false` on write. Order-item
+   * resolution consults this to fail early instead of passing a zombie variant
+   * downstream. Cleared on the variant's reappearance via upsert.
+   */
+  isStale?: boolean;
+  /** Timestamp of the most recent stale-marking; `null`/absent when live. */
+  staleAt?: Date | null;
 }

--- a/libs/core/src/products/domain/exceptions/master-product-not-found.error.ts
+++ b/libs/core/src/products/domain/exceptions/master-product-not-found.error.ts
@@ -1,0 +1,30 @@
+/**
+ * Master Product Not Found Error
+ *
+ * Neutral, platform-agnostic domain error meaning "this product no longer
+ * resolves at its master" (#1599). Master `ProductMaster` adapters translate
+ * their own platform not-found exception (PrestaShop / WooCommerce 404, or a
+ * missing external-id mapping) into this single core-visible shape at the
+ * `getProduct` port boundary — the repository-error-conversion pattern from
+ * `docs/engineering-standards.md § Error Handling`. Core services catch THIS
+ * (never a platform exception) to distinguish a permanent master-side deletion
+ * from a transient failure and mark the product's variants stale.
+ *
+ * @module libs/core/src/products/domain/exceptions
+ */
+export class MasterProductNotFoundError extends Error {
+  constructor(
+    public readonly productId: string,
+    public readonly connectionId: string,
+    cause?: unknown,
+  ) {
+    super(`Product not found at master (productId=${productId}, connectionId=${connectionId})`, {
+      cause,
+    });
+    this.name = 'MasterProductNotFoundError';
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MasterProductNotFoundError);
+    }
+  }
+}

--- a/libs/core/src/products/domain/ports/product-variant-repository.port.ts
+++ b/libs/core/src/products/domain/ports/product-variant-repository.port.ts
@@ -98,4 +98,19 @@ export interface ProductVariantRepositoryPort {
     filters: ProductVariantListFilters,
     pagination: ProductPagination
   ): Promise<PaginatedProductVariants>;
+
+  /**
+   * Soft-mark every live variant of `productId` NOT in `keepVariantIds` as
+   * stale (#1599 — deleted at the master). An empty keep-set marks all live
+   * variants (the product-fully-deleted / 404 path). Returns the ids actually
+   * flipped (already-stale rows are skipped, preserving their `staleAt`).
+   *
+   * @param productId - Internal OpenLinker product ID
+   * @param keepVariantIds - Variant ids present in the current master response
+   * @returns Ids of the variants newly marked stale
+   */
+  markStaleExceptVariants(
+    productId: string,
+    keepVariantIds: readonly string[]
+  ): Promise<string[]>;
 }

--- a/libs/core/src/products/domain/types/master-deletion-events.types.ts
+++ b/libs/core/src/products/domain/types/master-deletion-events.types.ts
@@ -1,0 +1,46 @@
+/**
+ * Master-Deletion Event Types
+ *
+ * Platform-neutral domain-event contract published when a product/variant is
+ * detected as deleted at its master (#1599). The observability seam: UI /
+ * notification consumers are follow-ups, but the event must exist so they can
+ * be built without touching the sync services again.
+ *
+ * Owned by the products context (canonical owner of variant identity) and
+ * consumed cross-context by the inventory master-sync prune path — a value
+ * import of `UPPER_SNAKE_CASE as const` constants, the permitted cross-context
+ * shape. Published as an `EventEnvelope` (inline `eventType`), matching the
+ * codebase's runtime event pattern rather than a `*.event.ts` class.
+ *
+ * Delivery is **at-most-once**: the event is published *after* the stale-mark
+ * commits, so a publish failure loses the event and the next sync will NOT
+ * re-emit it (the rows are already stale, so the prune returns no new ids). The
+ * authoritative state is the persisted `isStale` flag, not the event; a future
+ * consumer that needs guaranteed delivery should reconcile against the flag (or
+ * this should move to a transactional outbox). Matches the existing
+ * fire-after-commit publisher precedent (e.g. `SyncJobBulkRetryService`).
+ *
+ * @module libs/core/src/products/domain/types
+ */
+
+/** Redis stream the master-deletion events are published to. */
+export const MASTER_DELETION_EVENT_STREAM = 'events.master.deletion';
+
+/** Emitted when specific variants are marked stale (partial prune). */
+export const MASTER_VARIANT_STALE_EVENT = 'master.variant.stale';
+
+/** Emitted when a whole product 404s at the master (all variants marked stale). */
+export const MASTER_PRODUCT_STALE_EVENT = 'master.product.stale';
+
+/** Schema version stamped into the event envelope metadata. */
+export const MASTER_DELETION_EVENT_SCHEMA_VERSION = '1';
+
+/**
+ * Payload carried by both master-deletion events. `variantIds` are the internal
+ * OpenLinker variant ids newly marked stale.
+ */
+export interface MasterDeletionEventPayload {
+  connectionId: string;
+  internalProductId: string;
+  variantIds: string[];
+}

--- a/libs/core/src/products/index.ts
+++ b/libs/core/src/products/index.ts
@@ -25,6 +25,18 @@ export { ProductVariantRepositoryPort } from './domain/ports/product-variant-rep
 export { Product } from './domain/entities/product.entity';
 export { ProductVariant } from './domain/entities/product-variant.entity';
 
+// Domain Exceptions
+export { MasterProductNotFoundError } from './domain/exceptions/master-product-not-found.error';
+
+// Master-deletion event contract (#1599)
+export {
+  MASTER_DELETION_EVENT_STREAM,
+  MASTER_VARIANT_STALE_EVENT,
+  MASTER_PRODUCT_STALE_EVENT,
+  MASTER_DELETION_EVENT_SCHEMA_VERSION,
+  MasterDeletionEventPayload,
+} from './domain/types/master-deletion-events.types';
+
 // Domain Utils
 export { normalizeBarcode, normalizeToEan13 } from './domain/utils/barcode-normalization';
 export { coverImageUrl } from './domain/utils/product-cover-image';

--- a/libs/core/src/products/infrastructure/persistence/entities/product-variant.orm-entity.ts
+++ b/libs/core/src/products/infrastructure/persistence/entities/product-variant.orm-entity.ts
@@ -45,6 +45,20 @@ export class ProductVariantOrmEntity {
   @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
   price!: number | null;
 
+  // Soft-mark for a variant that no longer appears in the master's
+  // getProductVariants response, or whose product 404s at the master
+  // (#1599 — the products-context counterpart of inventory_items.isStale,
+  // #1478). Excluded from nothing at the persistence layer; consulted by
+  // order-item resolution to fail early. Cleared (false, staleAt=null) when
+  // the variant reappears via upsert.
+  @Column({ type: 'boolean', default: false })
+  isStale!: boolean;
+
+  // `timestamptz` (not bare `timestamp`) so the `NOW()` write is stored without a
+  // silent tz coercion — the #1296 correction applied to invoice_records (#1599).
+  @Column({ type: 'timestamptz', nullable: true })
+  staleAt!: Date | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
@@ -172,6 +172,40 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
     return { items: entities.map((e) => this.toDomain(e)), total };
   }
 
+  /**
+   * Soft-mark every live variant of `productId` that is NOT in `keepVariantIds`
+   * as stale (#1599), returning the ids actually flipped. Mirrors the inventory
+   * `markStaleExceptVariants` intent, but `product_variants` is keyed by a
+   * non-null `id` PK, so no three-valued NULL handling is needed. An empty
+   * keep-set marks EVERY live row (the product-fully-deleted / 404 path) — the
+   * `NOT IN` clause is only appended when there is something to keep, because
+   * `id NOT IN ()` is invalid SQL. Already-stale rows are skipped so `staleAt`
+   * keeps the first-marked timestamp.
+   */
+  async markStaleExceptVariants(
+    productId: string,
+    keepVariantIds: readonly string[]
+  ): Promise<string[]> {
+    const qb = this.repository
+      .createQueryBuilder()
+      .update(ProductVariantOrmEntity)
+      .set({ isStale: true, staleAt: () => 'NOW()' })
+      .where('productId = :productId', { productId })
+      .andWhere('isStale = false');
+
+    if (keepVariantIds.length > 0) {
+      qb.andWhere('id NOT IN (:...keep)', { keep: [...keepVariantIds] });
+    }
+
+    // Array form of `.returning(...)` — resolves column metadata and emits a
+    // quoted identifier. (The string form produces the same quoted SQL in
+    // TypeORM 0.3.17's UpdateQueryBuilder, but the array form is the documented,
+    // version-robust way and matches the sibling inventory repository.)
+    const result = await qb.returning(['id']).execute();
+    const raw = result.raw as { id: string }[];
+    return raw.map((row) => row.id);
+  }
+
   async upsert(variant: ProductVariant): Promise<ProductVariant> {
     const entity = this.toOrmEntity(variant);
     const saved = await this.repository.save(entity);
@@ -229,6 +263,8 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
       ean: entity.ean,
       gtin: entity.gtin,
       price: entity.price !== null ? Number(entity.price) : undefined,
+      isStale: entity.isStale,
+      staleAt: entity.staleAt,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
     };
@@ -246,6 +282,11 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
     entity.ean = variant.ean;
     entity.gtin = variant.gtin;
     entity.price = variant.price ?? null;
+    // Un-stale on reappearance: a master re-sync builds the domain variant
+    // without staleness set, so upsert clears the flag (#1599). Callers that
+    // intend to mark stale use markStaleExceptVariants, not upsert.
+    entity.isStale = variant.isStale ?? false;
+    entity.staleAt = variant.staleAt ?? null;
     // Adapters may omit timestamps on first insert; TypeORM's @CreateDateColumn
     // and @UpdateDateColumn populate them in that case.
     if (variant.createdAt) entity.createdAt = variant.createdAt;

--- a/libs/core/src/products/products.module.ts
+++ b/libs/core/src/products/products.module.ts
@@ -25,6 +25,7 @@ import {
 } from './products.tokens';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
+import { EventsModule } from '@openlinker/core/events';
 
 // Re-export tokens for convenience
 export {
@@ -39,6 +40,7 @@ export {
     TypeOrmModule.forFeature([ProductOrmEntity, ProductVariantOrmEntity]),
     IntegrationsModule,
     IdentifierMappingModule,
+    EventsModule,
   ],
   providers: [
     // Provide classes directly first

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
@@ -19,6 +19,7 @@ import {
   PrestashopResourceNotFoundException,
   PrestashopNotSupportedException,
 } from '@openlinker/integrations-prestashop';
+import { MasterProductNotFoundError } from '@openlinker/core/products';
 import type {
   PrestashopProduct,
   PrestashopCombination,
@@ -73,19 +74,17 @@ describe('PrestashopProductMasterAdapter', () => {
       expect(result.sku).toBe('TEST-001');
     });
 
-    it('should throw PrestashopResourceNotFoundException when no external ID mapping exists', async () => {
+    it('should throw MasterProductNotFoundError when no external ID mapping exists (#1599)', async () => {
       const internalId = 'internal-product-123';
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- test mock: narrowing dynamic spy / fixture / response shape
       mockIdentifierMapping.getExternalIds = jest.fn().mockResolvedValue([]);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- test mock: narrowing dynamic spy / fixture / response shape
-      await expect(adapter.getProduct(internalId)).rejects.toThrow(
-        PrestashopResourceNotFoundException
-      );
+      await expect(adapter.getProduct(internalId)).rejects.toThrow(MasterProductNotFoundError);
     });
 
-    it('should throw PrestashopResourceNotFoundException when external ID not found for this connection', async () => {
+    it('should throw MasterProductNotFoundError when external ID not found for this connection (#1599)', async () => {
       const internalId = 'internal-product-123';
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- test mock: narrowing dynamic spy / fixture / response shape
@@ -98,9 +97,7 @@ describe('PrestashopProductMasterAdapter', () => {
       ]);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- test mock: narrowing dynamic spy / fixture / response shape
-      await expect(adapter.getProduct(internalId)).rejects.toThrow(
-        PrestashopResourceNotFoundException
-      );
+      await expect(adapter.getProduct(internalId)).rejects.toThrow(MasterProductNotFoundError);
     });
 
     it('should use connection langId from config', async () => {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
@@ -17,7 +17,7 @@ import type {
   ProductVariantCreate,
   Category,
 } from '@openlinker/core/products';
-import { normalizeBarcode, normalizeToEan13 } from '@openlinker/core/products';
+import { normalizeBarcode, normalizeToEan13, MasterProductNotFoundError } from '@openlinker/core/products';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
@@ -68,51 +68,61 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
   async getProduct(productId: string): Promise<Product> {
     this.logger.debug(`Getting product: ${productId} (connection: ${this.connection.id})`);
 
-    // Resolve internal ID → external ID
-    const externalIds = await this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Product, productId);
-    const prestashopId = externalIds.find(
-      (e: { connectionId: string }) => e.connectionId === this.connection.id
-    );
-
-    if (!prestashopId) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
-      const error = new PrestashopResourceNotFoundException(
-        `Product not found: ${productId} (no external ID mapping for connection ${this.connection.id})`,
-        CORE_ENTITY_TYPE.Product,
-        productId,
-        this.connection.id
+    try {
+      // Resolve internal ID → external ID
+      const externalIds = await this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Product, productId);
+      const prestashopId = externalIds.find(
+        (e: { connectionId: string }) => e.connectionId === this.connection.id
       );
+
+      if (!prestashopId) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
+        const error = new PrestashopResourceNotFoundException(
+          `Product not found: ${productId} (no external ID mapping for connection ${this.connection.id})`,
+          CORE_ENTITY_TYPE.Product,
+          productId,
+          this.connection.id
+        );
+        throw error;
+      }
+
+      // Fetch from PrestaShop
+      const prestashopProduct = await this.httpClient.getResource<PrestashopProduct>(
+        'products',
+        prestashopId.externalId
+      );
+
+      // Map to OpenLinker schema
+      const langIdValue: number = this.resolveLangId();
+
+      const mapped = this.productMapper.mapProduct(prestashopProduct, langIdValue);
+
+      // #1096 F2/F3 — enrich with shop-native features and a full category path so
+      // a borrows destination (Erli) can emit `source:"shop"` taxonomy. Both are
+      // best-effort: a resolver failure leaves the field empty/unset and never
+      // breaks product sync.
+      const features = await this.resolveFeatures(prestashopProduct, langIdValue);
+      const categoryBreadcrumb = await this.resolveCategoryBreadcrumb(
+        prestashopProduct,
+        langIdValue
+      );
+
+      // Return with internal ID
+      return {
+        ...mapped,
+        id: productId,
+        ...(features.length > 0 ? { features } : {}),
+        ...(categoryBreadcrumb.length > 0 ? { categoryBreadcrumb } : {}),
+      };
+    } catch (error) {
+      // Translate the platform not-found (missing mapping OR a 404 from the
+      // webservice, i.e. deleted at the master) into the neutral core error so
+      // core services can distinguish deletion from a transient failure (#1599).
+      if (error instanceof PrestashopResourceNotFoundException) {
+        throw new MasterProductNotFoundError(productId, this.connection.id, error);
+      }
       throw error;
     }
-
-    // Fetch from PrestaShop
-    const prestashopProduct = await this.httpClient.getResource<PrestashopProduct>(
-      'products',
-      prestashopId.externalId
-    );
-
-    // Map to OpenLinker schema
-    const langIdValue: number = this.resolveLangId();
-
-    const mapped = this.productMapper.mapProduct(prestashopProduct, langIdValue);
-
-    // #1096 F2/F3 — enrich with shop-native features and a full category path so
-    // a borrows destination (Erli) can emit `source:"shop"` taxonomy. Both are
-    // best-effort: a resolver failure leaves the field empty/unset and never
-    // breaks product sync.
-    const features = await this.resolveFeatures(prestashopProduct, langIdValue);
-    const categoryBreadcrumb = await this.resolveCategoryBreadcrumb(
-      prestashopProduct,
-      langIdValue
-    );
-
-    // Return with internal ID
-    return {
-      ...mapped,
-      id: productId,
-      ...(features.length > 0 ? { features } : {}),
-      ...(categoryBreadcrumb.length > 0 ? { categoryBreadcrumb } : {}),
-    };
   }
 
   /**

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/__tests__/woocommerce-product-master.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/__tests__/woocommerce-product-master.adapter.spec.ts
@@ -12,6 +12,7 @@ import type { IWooCommerceProductMapper } from '../../../mappers/woocommerce-pro
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { WooCommerceResourceNotFoundException } from '../../../../domain/exceptions/woocommerce-resource-not-found.exception';
+import { MasterProductNotFoundError } from '@openlinker/core/products';
 import { WooCommerceDuplicateSkuException } from '../../../../domain/exceptions/woocommerce-duplicate-sku.exception';
 import { WooCommerceHttpResponseException } from '../../../http/woocommerce-http-response.exception';
 import type { WooCommerceProduct, WooCommerceProductVariation } from '../woocommerce-product.types';
@@ -135,18 +136,18 @@ describe('WooCommerceProductMasterAdapter', () => {
       expect(httpClient.get).toHaveBeenCalledWith('/wp-json/wc/v3/products/42');
     });
 
-    it('should throw WooCommerceResourceNotFoundException when no mapping exists', async () => {
+    it('should throw MasterProductNotFoundError when no mapping exists (#1599)', async () => {
       const httpClient = makeHttpClient();
       const identifierMapping = makeIdentifierMapping();
       identifierMapping.getExternalIds.mockResolvedValue([]);
       const adapter = makeAdapter(httpClient, identifierMapping, makeMapper());
       await expect(adapter.getProduct('prod-missing')).rejects.toBeInstanceOf(
-        WooCommerceResourceNotFoundException,
+        MasterProductNotFoundError,
       );
       expect(httpClient.get).not.toHaveBeenCalled();
     });
 
-    it('should convert WooCommerceHttpResponseException(404) to WooCommerceResourceNotFoundException', async () => {
+    it('should translate a WooCommerceHttpResponseException(404) to MasterProductNotFoundError (#1599)', async () => {
       const httpClient = makeHttpClient();
       httpClient.get.mockRejectedValue(
         new WooCommerceHttpResponseException(404, 'Not found'),
@@ -157,7 +158,7 @@ describe('WooCommerceProductMasterAdapter', () => {
       ]);
       const adapter = makeAdapter(httpClient, identifierMapping, makeMapper());
       await expect(adapter.getProduct('prod-deleted')).rejects.toBeInstanceOf(
-        WooCommerceResourceNotFoundException,
+        MasterProductNotFoundError,
       );
     });
   });

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/woocommerce-product-master.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/woocommerce-product-master.adapter.ts
@@ -30,6 +30,7 @@ import type {
   ProductVariantCreate,
   Category,
 } from '@openlinker/core/products';
+import { MasterProductNotFoundError } from '@openlinker/core/products';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
@@ -78,36 +79,46 @@ export class WooCommerceProductMasterAdapter implements ProductMasterPort {
 
   async getProduct(productId: string): Promise<Product> {
     this.logger.debug(`Getting product: ${productId} (connection: ${this.connection.id})`);
-    const externalIds = await this.identifierMapping.getExternalIds(
-      CORE_ENTITY_TYPE.Product,
-      productId,
-    );
-    const mapping = externalIds.find((e) => e.connectionId === this.connection.id);
-    if (!mapping) {
-      throw new WooCommerceResourceNotFoundException(
-        `Product not found: ${productId} (no mapping for connection ${this.connection.id})`,
+    try {
+      const externalIds = await this.identifierMapping.getExternalIds(
         CORE_ENTITY_TYPE.Product,
         productId,
-        this.connection.id,
       );
-    }
-    let p: WooCommerceProduct;
-    try {
-      p = await this.httpClient.get<WooCommerceProduct>(
-        `/wp-json/wc/v3/products/${mapping.externalId}`,
-      );
-    } catch (err) {
-      if (err instanceof WooCommerceHttpResponseException && err.statusCode === 404) {
+      const mapping = externalIds.find((e) => e.connectionId === this.connection.id);
+      if (!mapping) {
         throw new WooCommerceResourceNotFoundException(
-          `WooCommerce product ${mapping.externalId} not found (deleted?)`,
+          `Product not found: ${productId} (no mapping for connection ${this.connection.id})`,
           CORE_ENTITY_TYPE.Product,
           productId,
           this.connection.id,
         );
       }
-      throw err;
+      let p: WooCommerceProduct;
+      try {
+        p = await this.httpClient.get<WooCommerceProduct>(
+          `/wp-json/wc/v3/products/${mapping.externalId}`,
+        );
+      } catch (err) {
+        if (err instanceof WooCommerceHttpResponseException && err.statusCode === 404) {
+          throw new WooCommerceResourceNotFoundException(
+            `WooCommerce product ${mapping.externalId} not found (deleted?)`,
+            CORE_ENTITY_TYPE.Product,
+            productId,
+            this.connection.id,
+          );
+        }
+        throw err;
+      }
+      return { ...this.mapper.mapProduct(p), id: productId };
+    } catch (error) {
+      // Translate the platform not-found (missing mapping OR a 404, i.e. deleted
+      // at the master) into the neutral core error so core services can
+      // distinguish deletion from a transient failure (#1599).
+      if (error instanceof WooCommerceResourceNotFoundException) {
+        throw new MasterProductNotFoundError(productId, this.connection.id, error);
+      }
+      throw error;
     }
-    return { ...this.mapper.mapProduct(p), id: productId };
   }
 
   async getProducts(filters?: ProductFilters): Promise<Product[]> {


### PR DESCRIPTION
Closes #1599

## What & why

When a product/variant is deleted at the master (any `ProductMaster`/`InventoryMaster` — PrestaShop, WooCommerce, or a future master), the only signal OpenLinker recorded was `inventory_items.isStale` (#1478), confined to the inventory context. Consequences: zombie variants persisted in the canonical store, order ingestion resolved them and failed **late & opaquely** at the destination (a perpetually-retried job with a misleading error), and nothing was ever emitted for an operator to observe.

This fixes it master-agnostically, entirely in `libs/core` — the two adapters only translate their own platform 404 into a neutral core error at the port boundary (the documented error-conversion pattern; no domain logic leaks into integrations).

## Changes (the issue's A/B/C/D)

- **A — products-context staleness.** `product_variants` gains `isStale` + `staleAt` (migration `1818000000008`). `MasterProductSyncService` prunes variants absent from the master's `getProductVariants` response and **un-stales them on reappearance** via upsert. New `ProductVariantRepositoryPort.markStaleExceptVariants` (non-null-PK query, empty-keep-set marks all, `UPDATE … RETURNING` typed explicitly).
- **B — neutral 404 vs transient.** New `MasterProductNotFoundError`; PrestaShop + WooCommerce `getProduct` translate their platform 404 to it. On a master-side deletion the sync marks all variants stale and the worker handler returns `outcome: 'business_failure'` (ADR-007) instead of retrying a permanent condition forever.
- **C — order-item guard.** New `StaleOrderItemError`; `OrderItemRefResolverService` fails **early** with a message-rich reason (through the existing `tryResolve → { resolved: false, reason }` seam) for the `offer` / `variant` / `sku` branches — no more opaque destination rejection.
- **D — domain event.** `master.variant.stale` / `master.product.stale` published from **both** the product-sync and inventory-sync prune paths (observability seam for future UI/notification consumers); prune logs upgraded `debug → warn`.

## How to test

- `pnpm test` — unit specs across core / api / worker / prestashop / woocommerce (all green; new specs cover the prune, the 404 → business-failure + event, the resolver stale-guard for all three ref types, the inventory-sync event, and both adapters' 404 translation).
- `pnpm test:integration` (Docker) — `product-variant-stale-prune.int-spec.ts` (new) + `inventory-stale-prune.int-spec.ts` exercise the real-Postgres `UPDATE … RETURNING`, the empty-keep branch, and un-stale-on-reappearance. The migration applies cleanly on a fresh Testcontainers DB.
- `pnpm lint` (incl. `check:invariants`) + `pnpm type-check` — clean.

## Notes

- Staleness is a **soft mark** (consistent with #1478) — mappings and historical orders keep resolving.
- The domain event is the observability seam only; UI/notification consumers are follow-ups.
- Plan + pre-implement analysis included under `docs/plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)