### PR TITLE
fix(erli): map buyer-selected pickup point onto neutral IncomingOrder (#1519)

### DIFF
--- a/apps/web/src/features/listings/components/WoocommercePublishWizard.test.tsx
+++ b/apps/web/src/features/listings/components/WoocommercePublishWizard.test.tsx
@@ -304,7 +304,10 @@ describe('WoocommercePublishWizard', () => {
       expect(stockInput).not.toBeDisabled();
 
       const submitButton = screen.getByRole('button', { name: /^publish$/i });
-      expect(submitButton).toBeDisabled();
+      // `demoMode` resolves from the async `useDemoMode()` config query, which
+      // may settle after the stock input renders — wait for the disabled state
+      // rather than asserting it synchronously (flaked in CI, #1519/#1518).
+      await waitFor(() => expect(submitButton).toBeDisabled());
       fireEvent.click(submitButton);
       expect(shopPublish).not.toHaveBeenCalled();
     });
@@ -330,7 +333,7 @@ describe('WoocommercePublishWizard', () => {
       fireEvent.click(screen.getByRole('button', { name: /^review$/i }));
 
       const confirmButton = await screen.findByRole('button', { name: /confirm & publish/i });
-      expect(confirmButton).toBeDisabled();
+      await waitFor(() => expect(confirmButton).toBeDisabled());
       fireEvent.click(confirmButton);
       expect(shopPublish).not.toHaveBeenCalled();
     });

--- a/apps/web/src/features/listings/components/WoocommercePublishWizard.test.tsx
+++ b/apps/web/src/features/listings/components/WoocommercePublishWizard.test.tsx
@@ -303,12 +303,14 @@ describe('WoocommercePublishWizard', () => {
       fireEvent.change(stockInput, { target: { value: '5' } });
       expect(stockInput).not.toBeDisabled();
 
-      const submitButton = screen.getByRole('button', { name: /^publish$/i });
-      // `demoMode` resolves from the async `useDemoMode()` config query, which
-      // may settle after the stock input renders — wait for the disabled state
-      // rather than asserting it synchronously (flaked in CI, #1519/#1518).
-      await waitFor(() => expect(submitButton).toBeDisabled());
-      fireEvent.click(submitButton);
+      // `demoMode` resolves from the async `useDemoMode()` config query; once it
+      // settles the submit button is re-wrapped in a read-only lock (a new DOM
+      // node), so re-query inside waitFor rather than holding a stale reference
+      // to the pre-wrap button (flaked in CI, #1519/#1518).
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /^publish$/i })).toBeDisabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: /^publish$/i }));
       expect(shopPublish).not.toHaveBeenCalled();
     });
 
@@ -332,9 +334,11 @@ describe('WoocommercePublishWizard', () => {
       await screen.findByPlaceholderText('master');
       fireEvent.click(screen.getByRole('button', { name: /^review$/i }));
 
-      const confirmButton = await screen.findByRole('button', { name: /confirm & publish/i });
-      await waitFor(() => expect(confirmButton).toBeDisabled());
-      fireEvent.click(confirmButton);
+      await screen.findByRole('button', { name: /confirm & publish/i });
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /confirm & publish/i })).toBeDisabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: /confirm & publish/i }));
       expect(shopPublish).not.toHaveBeenCalled();
     });
   });

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order.mapper.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order.mapper.spec.ts
@@ -230,6 +230,78 @@ describe('mapErliOrderToIncomingOrder', () => {
     expect(result.billingAddress).toBeUndefined();
   });
 
+  it('should project delivery.pickupPlace onto the neutral pickupPoint (#1519)', () => {
+    const result = mapErliOrderToIncomingOrder(
+      buildErliOrder({
+        delivery: {
+          cod: false,
+          price: 1000,
+          pickupPlace: {
+            id: 42,
+            externalId: 'POZ08A',
+            type: 'paczkomat',
+            provider: 'inpost',
+            name: 'Paczkomat POZ08A',
+            address: 'ul. Testowa 1',
+            city: 'Testowo',
+            zip: '00-001',
+          },
+        },
+      }),
+    );
+
+    expect(result.pickupPoint).toEqual({
+      id: 'POZ08A',
+      name: 'Paczkomat POZ08A',
+      description: 'ul. Testowa 1',
+      pointType: 'apm',
+    });
+  });
+
+  it('should fall back to the numeric pickupPlace id when externalId is absent (#1519)', () => {
+    const result = mapErliOrderToIncomingOrder(
+      buildErliOrder({
+        delivery: { cod: false, price: 1000, pickupPlace: { id: 42 } },
+      }),
+    );
+
+    expect(result.pickupPoint?.id).toBe('42');
+    expect(result.pickupPoint?.pointType).toBeUndefined();
+  });
+
+  it('should classify a PaczkoPunkt pickup point as pop (#1519)', () => {
+    const result = mapErliOrderToIncomingOrder(
+      buildErliOrder({
+        delivery: {
+          cod: false,
+          price: 1000,
+          pickupPlace: { externalId: 'POP-123', type: 'paczkopunkt', name: 'PaczkoPunkt' },
+        },
+      }),
+    );
+
+    expect(result.pickupPoint?.id).toBe('POP-123');
+    expect(result.pickupPoint?.pointType).toBe('pop');
+  });
+
+  it('should leave pickupPoint undefined for a courier / home-delivery order (#1519)', () => {
+    const result = mapErliOrderToIncomingOrder(
+      buildErliOrder({ delivery: { name: 'Kurier', typeId: 'courier', price: 1000, cod: true } }),
+    );
+
+    expect(result.pickupPoint).toBeUndefined();
+  });
+
+  it('should leave pickupPoint undefined when pickupPlace carries no resolvable id (#1519)', () => {
+    const result = mapErliOrderToIncomingOrder(
+      buildErliOrder({
+        delivery: { cod: false, price: 1000, pickupPlace: { name: 'Some point', type: 'apm' } },
+      }),
+    );
+
+    expect(result.pickupPoint).toBeUndefined();
+  });
+
   it('should never emit an internal ol_ id anywhere in the output (the #995 identity boundary)', () => {
     const result = mapErliOrderToIncomingOrder(buildErliOrder());
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-order.mapper.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-order.mapper.ts
@@ -34,6 +34,8 @@ import type {
   IncomingOrderAddress,
   IncomingOrderItem,
   IncomingOrderTotals,
+  OrderPickupPoint,
+  OrderPickupPointType,
   OrderStatus,
   PaymentStatus,
 } from '@openlinker/core/orders';
@@ -42,6 +44,7 @@ import type {
   ErliOrder,
   ErliOrderAddress,
   ErliOrderItem,
+  ErliOrderPickupPlace,
   ErliOrderStatus,
 } from './erli-order.types';
 
@@ -69,6 +72,7 @@ export function mapErliOrderToIncomingOrder(order: ErliOrder): IncomingOrder {
     totals: mapTotals(order),
     shippingAddress: mapAddress(order.user.deliveryAddress),
     billingAddress: mapAddress(order.user.invoiceAddress),
+    pickupPoint: mapPickupPoint(order.delivery.pickupPlace),
     paymentStatus: derivePaymentStatus(order.status, order.delivery.cod),
     placedAt: order.purchasedAt,
     createdAt: order.created ?? nowIso,
@@ -214,4 +218,57 @@ function mapAddress(address?: ErliOrderAddress): IncomingOrderAddress | undefine
     country: address.country ?? '',
     phone: address.phone,
   };
+}
+
+/**
+ * Projects Erli's `delivery.pickupPlace` onto the neutral `OrderPickupPoint`,
+ * mirroring the shape produced by Allegro's `resolvePickupPoint`. The neutral
+ * `id` is the buyer-selected locker code — Erli's `externalId` (the carrier-side
+ * point code, e.g. `POZ08A`) when present, else the numeric internal `id`
+ * stringified. Returns `undefined` for courier / home-delivery orders (no
+ * `pickupPlace`) or when no locker id is resolvable, so the optional
+ * `pickupPoint` field stays absent.
+ *
+ * `pointType` is classified from Erli's free-form `type`/`provider` when a
+ * signal is present; absent a signal it is left unset (best-effort, mirroring
+ * Allegro — the authoritative InPost classification happens downstream when the
+ * point is resolved against `/v1/points`).
+ */
+function mapPickupPoint(pickupPlace?: ErliOrderPickupPlace): OrderPickupPoint | undefined {
+  if (!pickupPlace) {
+    return undefined;
+  }
+
+  const id = pickupPlace.externalId ?? (pickupPlace.id !== undefined ? String(pickupPlace.id) : undefined);
+  if (!id) {
+    return undefined;
+  }
+
+  return {
+    id,
+    name: pickupPlace.name,
+    description: pickupPlace.address,
+    pointType: classifyPickupPointType(id, pickupPlace.type, pickupPlace.name),
+  };
+}
+
+/**
+ * Best-effort InPost point-kind classification from Erli's free-form
+ * `type`/`name`/id signals: a `pop`/`paczkopunkt` marker ⇒ `pop`, an
+ * `apm`/`paczkomat`/`locker` marker ⇒ `apm`. Returns `undefined` when nothing
+ * is classifiable — the neutral field then stays unset rather than guessing.
+ */
+function classifyPickupPointType(
+  id: string,
+  type?: string,
+  name?: string,
+): OrderPickupPointType | undefined {
+  const haystack = `${id} ${type ?? ''} ${name ?? ''}`.toLowerCase();
+  if (haystack.includes('pop') || haystack.includes('paczkopunkt')) {
+    return 'pop';
+  }
+  if (haystack.includes('apm') || haystack.includes('paczkomat') || haystack.includes('locker')) {
+    return 'apm';
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Problem

An Erli order placed with an InPost Paczkomat was mapped to an `IncomingOrder` with no `pickupPoint`, so OL's order snapshot never recorded the buyer-selected locker and label generation could not auto-resolve it (the `paczkomatId` had to be supplied manually).

The neutral contract already carries the field (`IncomingOrder.pickupPoint?: OrderPickupPoint`) and Allegro's source adapter already populates it (`resolvePickupPoint`). Only the Erli mapper dropped it: `mapErliOrderToIncomingOrder` never projected `delivery.pickupPlace` (which the raw `ErliOrderDelivery` type carries).

## Fix

`mapErliOrderToIncomingOrder` now projects `order.delivery.pickupPlace` onto the neutral `IncomingOrder.pickupPoint`, mirroring the shape Allegro's `resolvePickupPoint` produces:

- Neutral `id` = Erli's carrier-side `externalId` locker code (e.g. `POZ08A`) when present, else the numeric internal `id` stringified.
- `name` from `pickupPlace.name`, `description` from `pickupPlace.address`.
- `pointType` best-effort classified (`apm`/`pop`) from Erli's free-form `type`/`name`/id signals; left unset when nothing is classifiable (mirrors Allegro — authoritative InPost classification happens downstream against `/v1/points`).
- Courier / home-delivery orders (no `pickupPlace`) and pickup places with no resolvable id leave `pickupPoint` undefined.

The mapper stays pure + total (raw passthrough, no identifier mapping, #995).

## Tests

Extended `erli-order.mapper.spec.ts` with 5 cases: full pickupPlace -> populated `pickupPoint` (apm), `externalId`-absent fallback to numeric id, PaczkoPunkt -> `pop`, courier order -> undefined, id-less pickupPlace -> undefined.

## Quality gate

`pnpm --filter @openlinker/integrations-erli type-check` and `... test` (394 passed) both green.

Closes #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)