### PR TITLE
test(e2e): harden access-control demo-mode cold-start login flake (#1513)

### DIFF
--- a/apps/e2e/src/support/navigation.ts
+++ b/apps/e2e/src/support/navigation.ts
@@ -1,0 +1,45 @@
+/**
+ * SPA navigation helpers
+ *
+ * Cold-start-robust navigation for the React SPA. The web container's very first
+ * request after a (re)build must fetch, parse and execute the Vite bundle before
+ * React commits its first render into `#root` — on a freshly built stack this can
+ * comfortably exceed the default `expect` timeout, which manifested as a
+ * first-navigation flake that only passed on retry (issue #1513).
+ *
+ * `gotoWhenAppMounted` fixes this at the root: it navigates, then waits for an
+ * *interactive* signal (React has mounted content into `#root`) rather than a
+ * fixed sleep or a blanket global-timeout bump. The wait is bounded by a
+ * generous cold-start budget that only gates this readiness condition, so a
+ * genuinely broken app still fails — it just tolerates a slow first paint.
+ *
+ * @module support
+ */
+import type { Page } from '@playwright/test';
+
+/**
+ * Cold-start budget for the SPA to fetch/parse/execute its bundle and commit the
+ * first render. Generous on purpose: it gates only the "React has mounted"
+ * readiness condition on the FIRST navigation against a freshly built container,
+ * not per-action or per-assertion latency (those keep the project defaults).
+ */
+export const APP_MOUNT_TIMEOUT_MS = 60_000;
+
+/**
+ * Navigate to `path` and resolve once the SPA is interactive.
+ *
+ * Waits for the document to be parsed (`domcontentloaded`) and for React to have
+ * committed content into the `#root` mount point — a real readiness condition,
+ * not a fixed delay. Use for the FIRST navigation of a browser context against a
+ * possibly-cold web container; subsequent in-app navigations can use plain
+ * `page.goto`.
+ */
+export async function gotoWhenAppMounted(
+  page: Page,
+  path: string,
+  timeout: number = APP_MOUNT_TIMEOUT_MS
+): Promise<void> {
+  await page.goto(path, { waitUntil: 'domcontentloaded', timeout });
+  // React mounts into `#root`; a populated root is the interactive signal.
+  await page.locator('#root > *').first().waitFor({ state: 'attached', timeout });
+}

--- a/apps/e2e/tests/access-control/demo-mode.spec.ts
+++ b/apps/e2e/tests/access-control/demo-mode.spec.ts
@@ -19,6 +19,7 @@
  */
 import { test, expect } from '../../src/fixtures/test';
 import { provisionViewer, seedBrowserSession } from '../../src/support/access-control';
+import { gotoWhenAppMounted } from '../../src/support/navigation';
 
 test.describe('access-control: demo mode', () => {
   test('GET /system/config exposes a boolean demoMode flag', async ({ api }) => {
@@ -35,12 +36,16 @@ test.describe('access-control: demo mode', () => {
     const context = await browser.newContext({ baseURL: env.webUrl });
     try {
       const page = await context.newPage();
-      await page.goto('/login');
-      await expect(
-        page.getByRole('heading', { name: 'Sign in to your account' }),
-      ).toBeVisible();
+      // First navigation of this context against a possibly-cold web container:
+      // wait for the SPA to be interactive before asserting (issue #1513).
+      await gotoWhenAppMounted(page, '/login');
+      await expect(page.getByRole('heading', { name: 'Sign in to your account' })).toBeVisible();
 
-      const registerLink = page.getByRole('link', { name: /create a free demo account/i });
+      // Resilient to copy tweaks (the trailing arrow, casing, whitespace) by
+      // OR-ing the accessible name against the stable /register anchor.
+      const registerLink = page
+        .getByRole('link', { name: /create a free demo account/i })
+        .or(page.locator('a[href="/register"].guest-form__demo-register'));
       if (config.demoMode) {
         await expect(registerLink).toBeVisible();
         await expect(registerLink).toHaveAttribute('href', '/register');
@@ -52,7 +57,11 @@ test.describe('access-control: demo mode', () => {
     }
   });
 
-  test('viewer sees the demo banner when demo mode is on', async ({ api, env, browser }, testInfo) => {
+  test('viewer sees the demo banner when demo mode is on', async ({
+    api,
+    env,
+    browser,
+  }, testInfo) => {
     const config = await api.system.config();
     test.skip(!config.demoMode, 'demo mode is off — the demo banner is not rendered');
 
@@ -67,7 +76,8 @@ test.describe('access-control: demo mode', () => {
     try {
       await seedBrowserSession(context, env, viewer!.creds);
       const page = await context.newPage();
-      await page.goto('/');
+      // First navigation of this context against a possibly-cold web container.
+      await gotoWhenAppMounted(page, '/');
       const banner = page.getByRole('note', { name: 'Demo mode notice' });
       await expect(banner).toBeVisible();
       await expect(banner).toContainText(/write actions are\s+disabled/i);


### PR DESCRIPTION
## Problem

The access-control demo-mode spec (`login page shows the register link only in demo mode`) is flaky on a cold-started web container. The first navigation of a fresh browser context waited for the `Sign in to your account` heading immediately after `page.goto('/login')`. On a freshly (re)built stack the Vite bundle must still be fetched, parsed and executed before React commits its first render, so the heading assertion could exceed the default expect timeout on attempt 1 and only pass on retry (observed 2026-07-13: failed attempt 1 in 15.2s, passed retry #1 in 605ms).

Not a product bug - a first-navigation cold-start timing issue in the test.

## Fix

Root-cause the wait rather than adding a blanket retry or a global timeout bump:

- New `apps/e2e/src/support/navigation.ts` exposes `gotoWhenAppMounted(page, path)`. It navigates with `waitUntil: 'domcontentloaded'` and then waits for React to have mounted content into `#root` - a real interactive readiness condition, not a fixed sleep - bounded by a generous cold-start budget (`APP_MOUNT_TIMEOUT_MS = 60s`) that gates only this first-render condition. Per-action / per-assertion latency keeps the project defaults.
- The demo-mode spec uses `gotoWhenAppMounted` for the first navigation of both fresh-context tests (the login-page test and the demo-banner test).
- The register-link locator is made resilient by OR-ing the accessible name (`/create a free demo account/i`, already tolerant of the trailing arrow / casing / whitespace) against the stable `a[href="/register"].guest-form__demo-register` anchor. The negative (non-demo) `toHaveCount(0)` assertion still holds since neither selector matches.

`retries: 1` on the `access-control` project is kept as a backstop.

## Testing

- `pnpm --filter @openlinker/e2e type-check` - clean.
- Prettier-formatted.
- The live `playwright test` run is not exercised here (needs the demo stack).

## Acceptance criteria

- [x] Targeted first-navigation wait/readiness condition, not a blanket global timeout bump.
- [x] Register-link locator hardened against copy tweaks.

Closes #1513

🤖 Generated with [Claude Code](https://claude.com/claude-code)