### PR TITLE
test(e2e): fire a real signed inbound webhook end-to-end (#1512)

### DIFF
--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -34,6 +34,7 @@ apps/e2e/
     auth.setup.ts         # global-setup auth project → writes .auth/admin.json
     smoke/                # health + login + connections list (proves the substrate)
     golden-path/          # operator-setup.spec (S1-S4)
+    webhooks/             # real signed inbound-webhook receiver path (#1512)
   .auth/                  # storageState (gitignored)
 ```
 
@@ -68,6 +69,7 @@ so the suite is never swept into the root `pnpm -r test` unit gate.
 pnpm --filter @openlinker/e2e test:e2e                       # full suite
 pnpm --filter @openlinker/e2e test:e2e -- --project=smoke    # smoke only (read-only)
 pnpm --filter @openlinker/e2e test:e2e -- --project=golden-path
+pnpm --filter @openlinker/e2e test:e2e -- --project=webhooks # signed inbound-webhook receiver path (#1512)
 pnpm --filter @openlinker/e2e test:e2e:ui                    # Playwright UI mode
 pnpm --filter @openlinker/e2e test:e2e:headed                # headed browser
 pnpm --filter @openlinker/e2e test:e2e:report                # open last HTML report
@@ -181,3 +183,10 @@ all six systems with field- and amount-level parity
 covers the post-purchase half (order ingest, InPost label, KSeF invoice,
 reconciliation) and drives a manual buyer purchase + external-dashboard
 checkpoints. See [`docs/manual-testing/e2e-golden-path.md`](../../docs/manual-testing/e2e-golden-path.md).
+
+Also delivered: the `webhooks` project (`tests/webhooks/inbound-webhook.spec.ts`,
+#1512) — fires a real OL-HMAC-signed inbound webhook at
+`POST /webhooks/:provider/:connectionId` and asserts verify -> record -> enqueue
+-> dedup. The truly external platform-delivery round-trip stays a documented
+manual check: see
+[`docs/manual-testing/inbound-webhook-round-trip.md`](../../docs/manual-testing/inbound-webhook-round-trip.md).

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -13,6 +13,11 @@
  *                      Self-configuring (asserts correct-for-mode, skips otherwise);
  *                      independent of the golden-path projects. `retries: 1`
  *                      (idempotent: each run provisions a fresh unique viewer).
+ *   - `webhooks`     — fires a real signed inbound webhook at the receiver
+ *                      (`POST /webhooks/:provider/:connectionId`) and asserts
+ *                      verify -> record -> enqueue -> dedup. Self-configuring
+ *                      (skips when no PrestaShop connection is present).
+ *                      `retries: 0` (rotates the secret + enqueues a job).
  *
  * Reporters: html + list. Retries are per-project: read-only projects (setup,
  * smoke) retry once; the mutating golden-path project runs with `retries: 0` —
@@ -84,6 +89,18 @@ export default defineConfig({
       // bounded — pollers, job waits, and each manualCheckpoint's timeoutMs —
       // so a hung run still fails at the responsible checkpoint, not silently.
       timeout: 0,
+      dependencies: ['setup'],
+      use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+    },
+    {
+      // Real signed inbound-webhook receiver path (#1512) — independent of the
+      // golden-path/full-flow projects. Depends only on `setup` for the admin
+      // storageState (the spec rotates the connection's webhook secret and fires
+      // a signed delivery via the node API client). `retries: 0` — a retry would
+      // rotate the secret again and enqueue a second downstream job.
+      name: 'webhooks',
+      testMatch: /webhooks\/.*\.spec\.ts/,
+      retries: 0,
       dependencies: ['setup'],
       use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
     },

--- a/apps/e2e/src/api/api-client.ts
+++ b/apps/e2e/src/api/api-client.ts
@@ -26,6 +26,8 @@ import type {
   EnqueueSyncJobInput,
   EnqueueSyncJobResponse,
   GenerateLabelInput,
+  InboundWebhookResult,
+  ListWebhookDeliveriesQuery,
   InternalHealthResponse,
   InventoryAvailability,
   InventoryAvailabilityResponse,
@@ -48,6 +50,7 @@ import type {
   ProductVariant,
   RawResponse,
   RegisterInput,
+  RotateWebhookSecretResponse,
   RoutingRule,
   RoutingRuleInput,
   Shipment,
@@ -56,6 +59,7 @@ import type {
   SyncJobListResponse,
   SystemConfig,
   UserListResponse,
+  WebhookDeliverySummary,
 } from './api.types';
 
 const API_VERSION_PREFIX = '/v1';
@@ -248,6 +252,59 @@ export class ApiClient {
       this.request<SystemConfig>('/system/config', { skipAuth: true }),
   };
 
+  // ── Webhooks ──────────────────────────────────────────────────────────────
+  webhooks = {
+    /**
+     * Fire a raw inbound webhook at the version-NEUTRAL ingress
+     * `/webhooks/:provider/:connectionId` (no `/v1` prefix, no auth header) —
+     * exactly the URL an external platform posts to. The raw body string and
+     * signature headers are supplied by the caller (see `support/webhooks.ts`),
+     * so the request is byte-identical to a real platform delivery. Never throws
+     * on non-2xx — returns the status so the spec can assert 202 / 401 itself.
+     */
+    sendInbound: async (
+      provider: string,
+      connectionId: string,
+      rawBody: string,
+      headers: Record<string, string>,
+    ): Promise<InboundWebhookResult> => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+      let response: Response;
+      try {
+        response = await fetch(`${this.baseUrl}/webhooks/${provider}/${connectionId}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...headers },
+          body: rawBody,
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timeout);
+      }
+      const raw = await response.text();
+      return {
+        status: response.status,
+        ok: response.ok,
+        body: raw.length > 0 ? this.tryParseJson(raw) : undefined,
+      };
+    },
+
+    /** List recorded webhook deliveries (admin). Summary rows, no payload. */
+    listDeliveries: (query?: ListWebhookDeliveriesQuery): Promise<Paginated<WebhookDeliverySummary>> =>
+      this.request<Paginated<WebhookDeliverySummary>>(
+        `/webhook-deliveries${buildQuery({
+          provider: query?.provider,
+          connectionId: query?.connectionId,
+          eventType: query?.eventType,
+          status: query?.status,
+          since: query?.since,
+          until: query?.until,
+          limit: query?.limit,
+          offset: query?.offset,
+        })}`,
+      ),
+  };
+
   // ── Auth (registration) ───────────────────────────────────────────────────
   auth = {
     /**
@@ -290,6 +347,16 @@ export class ApiClient {
       ),
     getById: (connectionId: string): Promise<Connection> =>
       this.request<Connection>(`/connections/${connectionId}`),
+    /**
+     * Rotate the connection's webhook secret (admin). Returns the new plaintext
+     * secret ONCE — the E2E webhook spec uses it to compute the OL-HMAC
+     * signature an external platform would send.
+     */
+    rotateWebhookSecret: (connectionId: string): Promise<RotateWebhookSecretResponse> =>
+      this.request<RotateWebhookSecretResponse>(
+        `/connections/${connectionId}/webhooks/secret/rotate`,
+        { method: 'POST' },
+      ),
   };
 
   // ── Products ────────────────────────────────────────────────────────────

--- a/apps/e2e/src/api/api.types.ts
+++ b/apps/e2e/src/api/api.types.ts
@@ -491,6 +491,65 @@ export interface EnqueueSyncJobResponse {
   isExisting?: boolean;
 }
 
+/**
+ * Response of `POST /connections/:id/webhooks/secret/rotate` — the plaintext
+ * webhook secret, revealed exactly once. The E2E webhook spec captures it to
+ * sign an inbound request the way the external platform would.
+ */
+export interface RotateWebhookSecretResponse {
+  secret: string;
+  revealedOnce: boolean;
+  warning: string;
+}
+
+/**
+ * Result of firing a raw inbound webhook at `/webhooks/:provider/:connectionId`
+ * (version-neutral ingress — no `/v1` prefix). Status + parsed body only.
+ */
+export interface InboundWebhookResult {
+  status: number;
+  ok: boolean;
+  body: unknown;
+}
+
+/** Filters for `GET /webhook-deliveries`. */
+export interface ListWebhookDeliveriesQuery {
+  provider?: string;
+  connectionId?: string;
+  eventType?: string;
+  status?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * A row from `GET /webhook-deliveries` (summary view — no payload). The webhook
+ * spec asserts on `signatureValid`, `status`, and the `downstream*` fields that
+ * capture the enqueue outcome.
+ */
+export interface WebhookDeliverySummary {
+  id: string;
+  eventId: string;
+  provider: string;
+  connectionId: string;
+  eventType: string | null;
+  objectType: string | null;
+  externalId: string | null;
+  receivedAt: string;
+  signatureValid: boolean | null;
+  dedupResult: string | null;
+  status: string;
+  rejectionReason: string | null;
+  publishedMessageId: string | null;
+  downstreamJobId: string | null;
+  downstreamJobType: string | null;
+  dlqReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface RoutingRule {
   id: string;
   sourceConnectionId: string;

--- a/apps/e2e/src/support/webhooks.ts
+++ b/apps/e2e/src/support/webhooks.ts
@@ -1,0 +1,102 @@
+/**
+ * Inbound-webhook signing helpers
+ *
+ * Reproduces, byte-for-byte, the OL-HMAC signature scheme an OpenLinker-module
+ * provider (PrestaShop) uses when it POSTs to `/webhooks/:provider/:connectionId`
+ * — the same scheme the host's `DefaultWebhookDecoder` verifies:
+ *
+ *   signature = "sha256=" + HMAC_SHA256(secret, `${timestampMs}.${rawBody}`)
+ *   headers   = X-OpenLinker-Timestamp: <epoch ms>, X-OpenLinker-Signature: <sig>
+ *
+ * The body is the OL webhook envelope (`WebhookRequestDto` shape). Keeping the
+ * signing here — off the API client — means the spec signs a request exactly as
+ * the platform would, rather than trusting server-side code to sign for it.
+ *
+ * @module support
+ */
+import { createHmac, randomUUID } from 'node:crypto';
+
+const SIGNATURE_HEADER = 'X-OpenLinker-Signature';
+const TIMESTAMP_HEADER = 'X-OpenLinker-Timestamp';
+
+/** The OL webhook envelope (mirrors the API's `WebhookRequestDto`). */
+export interface WebhookEnvelope {
+  schemaVersion: number;
+  eventId: string;
+  /** `category.action`, lowercase dot-separated (e.g. `order.created`). */
+  eventType: string;
+  /** ISO 8601 occurred-at. */
+  occurredAt: string;
+  object: { type: string; externalId: string };
+  payload?: Record<string, unknown>;
+}
+
+/** A fully-signed request ready to hand to `api.webhooks.sendInbound`. */
+export interface SignedWebhook {
+  envelope: WebhookEnvelope;
+  rawBody: string;
+  headers: Record<string, string>;
+  timestampMs: number;
+}
+
+export interface BuildWebhookOptions {
+  /** Unique event id (`[A-Za-z0-9_-]+`). Defaults to a fresh UUID. */
+  eventId?: string;
+  eventType?: string;
+  objectType?: string;
+  externalId?: string;
+  payload?: Record<string, unknown>;
+  /** Override the epoch-ms timestamp (defaults to now). */
+  timestampMs?: number;
+}
+
+/** Build a PrestaShop `order.created` envelope with unique, well-formed ids. */
+export function buildOrderWebhookEnvelope(options: BuildWebhookOptions = {}): WebhookEnvelope {
+  const eventId = options.eventId ?? `e2e-${randomUUID()}`;
+  return {
+    schemaVersion: 1,
+    eventId,
+    eventType: options.eventType ?? 'order.created',
+    occurredAt: new Date().toISOString(),
+    object: {
+      type: options.objectType ?? 'order',
+      // Synthetic id — the spec asserts the enqueue, not that the downstream
+      // order-sync job resolves a real PrestaShop order.
+      externalId: options.externalId ?? `e2e-order-${Date.now()}`,
+    },
+    payload: options.payload ?? { source: 'e2e-inbound-webhook-spec' },
+  };
+}
+
+/**
+ * Compute the OL-HMAC signature over `${timestampMs}.${rawBody}` and return the
+ * `sha256=<hex>` header value.
+ */
+export function computeOlHmacSignature(
+  secret: string,
+  timestampMs: number,
+  rawBody: string,
+): string {
+  const signedPayload = `${timestampMs}.${rawBody}`;
+  const hex = createHmac('sha256', secret).update(signedPayload).digest('hex');
+  return `sha256=${hex}`;
+}
+
+/**
+ * Serialize + sign an envelope with the connection's webhook secret. The
+ * returned `rawBody` is the exact string that was signed — send it verbatim
+ * (re-serializing would change the bytes and break the signature).
+ */
+export function signWebhook(secret: string, envelope: WebhookEnvelope, timestampMs = Date.now()): SignedWebhook {
+  const rawBody = JSON.stringify(envelope);
+  const signature = computeOlHmacSignature(secret, timestampMs, rawBody);
+  return {
+    envelope,
+    rawBody,
+    timestampMs,
+    headers: {
+      [TIMESTAMP_HEADER]: String(timestampMs),
+      [SIGNATURE_HEADER]: signature,
+    },
+  };
+}

--- a/apps/e2e/tests/webhooks/inbound-webhook.spec.ts
+++ b/apps/e2e/tests/webhooks/inbound-webhook.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * Inbound webhook: real signed delivery (end-to-end)
+ *
+ * The golden path ingests orders via manual job-trigger / poll — it never fires
+ * a real `POST /webhooks/:provider/:connectionId`. This spec closes that gap for
+ * the low-latency PRIMARY path (#1512): it signs an inbound PrestaShop webhook
+ * with the connection's own webhook secret (OL-HMAC, exactly as the PS module
+ * does) and asserts the full receiver chain against a running stack:
+ *
+ *   verify (signature + timestamp) -> record (webhook_deliveries) -> enqueue
+ *   (a downstream sync job) -> replay is deduped (one row, idempotent 202).
+ *
+ * A tampered-signature request is asserted to be rejected (401) and to leave no
+ * delivery row — proving the signature actually gates ingestion.
+ *
+ * The truly external round-trip (a real PrestaShop / Erli / InPost / inFakt
+ * platform delivering through a public tunnel) stays a documented MANUAL check —
+ * see docs/manual-testing/inbound-webhook-round-trip.md.
+ *
+ * Self-configuring: skips-with-annotation when no PrestaShop connection is on
+ * the stack or its webhook secret cannot be rotated (mirrors the access-control
+ * specs' skip-off-config pattern), so it is a no-op on a stack that isn't wired
+ * for webhooks rather than a failure.
+ *
+ * @module tests/webhooks
+ */
+import { test, expect } from '../../src/fixtures/test';
+import { PlatformType } from '../../src/world/world';
+import type { Connection } from '../../src/api/api.types';
+import { buildOrderWebhookEnvelope, signWebhook } from '../../src/support/webhooks';
+
+const PROVIDER = PlatformType.prestashop;
+
+test.describe('inbound webhook: signed PrestaShop delivery', () => {
+  let connection: Connection | undefined;
+  let secret: string | null = null;
+  let setupError: string | null = null;
+
+  test.beforeAll(async ({ api, world }) => {
+    connection = world.connectionFor(PROVIDER);
+    if (!connection) return;
+    try {
+      const rotated = await api.connections.rotateWebhookSecret(connection.id);
+      secret = rotated.secret;
+    } catch (error) {
+      setupError = error instanceof Error ? error.message : String(error);
+    }
+  });
+
+  test('verifies, records, enqueues, and dedupes a signed inbound webhook', async ({
+    api,
+    poll,
+  }, testInfo) => {
+    test.skip(!connection, `no ${PROVIDER} connection on the stack — cannot fire a webhook`);
+    test.skip(
+      secret === null,
+      `could not rotate ${PROVIDER} webhook secret${setupError ? `: ${setupError}` : ''}`,
+    );
+    const connectionId = connection!.id;
+    testInfo.annotations.push({
+      type: 'inbound-webhook',
+      description: `signed ${PROVIDER} webhook against connection ${connectionId}`,
+    });
+
+    // Narrow the delivery query to this run only — `order.created` rows from
+    // prior runs share the connection + eventType, so filter by receivedAt too.
+    const since = new Date(Date.now() - 5_000).toISOString();
+    const signed = signWebhook(secret!, buildOrderWebhookEnvelope());
+    const { eventId, eventType } = signed.envelope;
+
+    // 1. Fire the signed webhook -> 202 Accepted (verify + record + publish).
+    const first = await api.webhooks.sendInbound(
+      PROVIDER,
+      connectionId,
+      signed.rawBody,
+      signed.headers,
+    );
+    expect(
+      first.status,
+      `expected 202 for a correctly-signed webhook, got ${first.status}: ${JSON.stringify(first.body)}`,
+    ).toBe(202);
+
+    // 2. The delivery is recorded against webhook_deliveries with a valid sig.
+    const recorded = await poll.until(
+      () =>
+        api.webhooks.listDeliveries({
+          provider: PROVIDER,
+          connectionId,
+          eventType,
+          since,
+          limit: 100,
+        }),
+      (page) => page.items.some((d) => d.eventId === eventId),
+      { message: `webhook delivery for eventId=${eventId} to be recorded`, timeoutMs: 30_000 },
+    );
+    const delivery = recorded.items.find((d) => d.eventId === eventId)!;
+    expect(delivery.signatureValid).toBe(true);
+    expect(delivery.provider).toBe(PROVIDER);
+
+    // 3. The delivery is routed to a downstream sync job (record -> enqueue).
+    //    The WebhookToJobHandler consumes the published event asynchronously and
+    //    stamps the row with the enqueued job id/type.
+    const enqueued = await poll.until(
+      () =>
+        api.webhooks.listDeliveries({
+          provider: PROVIDER,
+          connectionId,
+          eventType,
+          since,
+          limit: 100,
+        }),
+      (page) => {
+        const row = page.items.find((d) => d.eventId === eventId);
+        return !!row && row.status === 'job_enqueued' && !!row.downstreamJobId;
+      },
+      {
+        message: `webhook delivery ${eventId} to reach status=job_enqueued`,
+        timeoutMs: 60_000,
+      },
+    );
+    const enqueuedRow = enqueued.items.find((d) => d.eventId === eventId)!;
+    expect(enqueuedRow.downstreamJobId).toBeTruthy();
+    expect(enqueuedRow.downstreamJobType).toBe('marketplace.order.sync');
+
+    // The enqueued job is visible on the sync-jobs API by its id.
+    const job = await api.syncJobs.getById(enqueuedRow.downstreamJobId!);
+    expect(job.jobType).toBe('marketplace.order.sync');
+
+    // 4. Replaying the byte-identical request is deduped (Postgres gate #711):
+    //    still 202 (idempotent ack), and NO second delivery row is created.
+    const replay = await api.webhooks.sendInbound(
+      PROVIDER,
+      connectionId,
+      signed.rawBody,
+      signed.headers,
+    );
+    expect(replay.status).toBe(202);
+
+    const afterReplay = await api.webhooks.listDeliveries({
+      provider: PROVIDER,
+      connectionId,
+      eventType,
+      since,
+      limit: 100,
+    });
+    const matches = afterReplay.items.filter((d) => d.eventId === eventId);
+    expect(matches).toHaveLength(1);
+  });
+
+  test('rejects a webhook whose signature does not match the connection secret', async ({
+    api,
+  }, testInfo) => {
+    test.skip(!connection, `no ${PROVIDER} connection on the stack — cannot fire a webhook`);
+    test.skip(
+      secret === null,
+      `could not rotate ${PROVIDER} webhook secret${setupError ? `: ${setupError}` : ''}`,
+    );
+    const connectionId = connection!.id;
+    testInfo.annotations.push({
+      type: 'inbound-webhook',
+      description: `tampered-signature rejection against connection ${connectionId}`,
+    });
+
+    const since = new Date(Date.now() - 5_000).toISOString();
+    // Sign with the WRONG secret — the body/headers are well-formed, only the
+    // HMAC is wrong, so this exercises signature verification specifically.
+    const forged = signWebhook('not-the-real-secret', buildOrderWebhookEnvelope());
+    const { eventId, eventType } = forged.envelope;
+
+    const result = await api.webhooks.sendInbound(
+      PROVIDER,
+      connectionId,
+      forged.rawBody,
+      forged.headers,
+    );
+    expect(
+      result.status,
+      `expected 401 for a bad signature, got ${result.status}: ${JSON.stringify(result.body)}`,
+    ).toBe(401);
+
+    // A rejected (unverified) webhook must NOT be recorded — a status='rejected'
+    // row would block a legitimate retry via the unique constraint (#711).
+    const deliveries = await api.webhooks.listDeliveries({
+      provider: PROVIDER,
+      connectionId,
+      eventType,
+      since,
+      limit: 100,
+    });
+    expect(deliveries.items.some((d) => d.eventId === eventId)).toBe(false);
+  });
+});

--- a/docs/manual-testing/inbound-webhook-round-trip.md
+++ b/docs/manual-testing/inbound-webhook-round-trip.md
@@ -1,0 +1,116 @@
+# Inbound webhook round-trip (manual + automated)
+
+Verifies OpenLinker's **low-latency primary ingestion path** — a real inbound
+webhook `POST /webhooks/:provider/:connectionId` — end to end. This complements
+the golden path, which ingests orders via job-trigger / poll and never fires a
+real webhook.
+
+There are two layers:
+
+1. **Automated** (CI-runnable): an `apps/e2e` spec fires a *self-signed* inbound
+   webhook and asserts the receiver chain. It signs the request with the
+   connection's own webhook secret, so the bytes are identical to a platform
+   delivery — but OL is both sender and receiver.
+2. **Manual / attended**: a real external platform (PrestaShop module, Erli,
+   InPost, inFakt) delivers a webhook through a public tunnel to the running
+   stack. CI cannot make a third-party platform fire, so this stays an attended
+   check.
+
+---
+
+## 1. Automated spec
+
+- **Spec**: `apps/e2e/tests/webhooks/inbound-webhook.spec.ts`
+- **Project**: `webhooks` (depends on `setup`, `retries: 0`)
+- **Provider covered**: PrestaShop (OL-HMAC). The same signing helper
+  (`apps/e2e/src/support/webhooks.ts`) works for any OL-enveloped provider.
+
+### What it asserts
+
+| Step | Assertion |
+|---|---|
+| verify | A correctly-signed `order.created` webhook returns `202`. |
+| record | A `webhook_deliveries` row appears (`GET /webhook-deliveries`) with `signatureValid: true`. |
+| enqueue | The row reaches `status: job_enqueued` with a `downstreamJobId` of type `marketplace.order.sync`, and the job is visible on `GET /sync/jobs/:id`. |
+| dedup | Re-POSTing the byte-identical request returns `202` again and creates **no** second row (Postgres dedup gate, #711). |
+| reject | A request signed with the wrong secret returns `401` and records **no** delivery row. |
+
+### How it signs
+
+The OL-HMAC scheme the PrestaShop module uses, reproduced exactly by
+`signWebhook()`:
+
+```
+timestamp = <epoch ms>                     ->  header X-OpenLinker-Timestamp
+signature = "sha256=" + HMAC_SHA256(secret, `${timestamp}.${rawBody}`)
+                                           ->  header X-OpenLinker-Signature
+```
+
+`rawBody` is the OL webhook envelope (`WebhookRequestDto` shape) and is sent
+verbatim — re-serializing would change the bytes and break the signature.
+
+The per-connection webhook **secret** is obtained via
+`POST /connections/:id/webhooks/secret/rotate` (revealed once). The spec rotates
+it in `beforeAll`, so the plaintext is known to the signer.
+
+### Run it
+
+```bash
+# against a running stack (defaults: web :8090, api :3000)
+pnpm --filter @openlinker/e2e exec playwright test --project=webhooks
+```
+
+The spec **self-skips with an annotation** when there is no PrestaShop
+connection on the stack or its secret cannot be rotated — it is a no-op on a
+stack that isn't wired for webhooks, not a failure.
+
+> Note: running the spec **rotates** the connection's webhook secret. If a real
+> external PrestaShop module was provisioned against the old secret, re-install
+> it (`POST /connections/:id/webhooks/install`, or the FE "Install webhooks"
+> action) so live deliveries keep verifying.
+
+---
+
+## 2. Manual attended round-trip
+
+Confirms a genuine third-party platform can reach the receiver through a public
+URL and that OL verifies + records the delivery. Do this once per webhook-capable
+integration after wiring changes.
+
+Webhook-capable integrations and their auth scheme:
+
+| Provider | Auth | Header(s) |
+|---|---|---|
+| PrestaShop | OL-HMAC | `X-OpenLinker-Timestamp`, `X-OpenLinker-Signature` |
+| Erli | Bearer echo | `Authorization: Bearer <accessToken>` |
+| InPost | InPost HMAC | `x-inpost-signature`, `x-inpost-timestamp` |
+| inFakt | HMAC + handshake | provider-specific |
+
+(The rest poll by design: Allegro, WooCommerce, DPD, KSeF, Subiekt.)
+
+### Steps
+
+1. **Expose the stack.** Start a public tunnel to the API origin (e.g.
+   `cloudflared tunnel --url http://localhost:3000`). Note the public base URL.
+2. **Provision the webhook on the platform.** For PrestaShop, use the
+   auto-installer: `POST /connections/:id/webhooks/install` (or the FE "Install
+   webhooks" button). It pushes the callback URL + secret to the module and
+   fires a `test.ping`. For third-party platforms, register
+   `<public-url>/webhooks/<provider>/<connectionId>` in the platform's webhook
+   settings using that platform's secret/scheme.
+3. **Trigger a real event** on the platform (e.g. create/update an order in the
+   PrestaShop back office; change an order status on Erli).
+4. **Confirm receipt** in OL:
+   - `GET /webhook-deliveries?provider=<provider>&connectionId=<id>` — a fresh
+     row with `signatureValid: true` and `status` of `published` /
+     `job_enqueued` (or `received` for a `test.ping`).
+   - For an order/stock/product event, confirm a `marketplace.*` /
+     `master.*` sync job on `GET /sync/jobs`.
+5. **Confirm downstream mutation** (optional, strongest signal): the synced
+   order/inventory/product appears/updates in OL.
+
+### Pass criteria
+
+- The delivery is recorded with a valid signature.
+- A non-`test.` event enqueues the expected downstream job.
+- A replayed delivery is deduped (no duplicate row, no duplicate job).


### PR DESCRIPTION
## What & why

No E2E/CI test fires a REAL inbound webhook today — the golden path ingests orders via manual job-trigger / poll, never via a real `POST /webhooks/:provider/:connectionId`. So OL's low-latency primary ingestion path is unexercised end-to-end against a running stack.

This adds a `webhooks` Playwright project that fires a correctly-signed inbound webhook at the version-neutral receiver and asserts the full receiver chain, plus a manual round-trip doc for the truly-external platform delivery (which CI cannot make a third-party platform perform).

## What the automated test asserts

For PrestaShop (OL-HMAC), one signed `order.created` delivery:

| Step | Assertion |
|---|---|
| verify | correctly-signed webhook -> `202` |
| record | a `webhook_deliveries` row appears (`GET /webhook-deliveries`) with `signatureValid: true` |
| enqueue | the row reaches `status: job_enqueued` with a `downstreamJobId` of type `marketplace.order.sync`, visible on `GET /sync/jobs/:id` |
| dedup | byte-identical replay -> `202` again, **no** second row (Postgres dedup gate, #711) |
| reject | wrong-secret signature -> `401`, records **no** delivery row |

## How it signs

Reproduces the PrestaShop OL module's scheme exactly, in `apps/e2e/src/support/webhooks.ts`:

```
timestamp = <epoch ms>                     -> X-OpenLinker-Timestamp
signature = "sha256=" + HMAC_SHA256(secret, `${timestamp}.${rawBody}`)  -> X-OpenLinker-Signature
```

`rawBody` (the OL `WebhookRequestDto` envelope) is sent verbatim. The per-connection secret is obtained via `POST /connections/:id/webhooks/secret/rotate` (revealed once), rotated in `beforeAll`.

## Self-skip

Mirrors the access-control specs: the spec **skips-with-annotation** when no PrestaShop connection is on the stack or its secret cannot be rotated — a no-op on a stack not wired for webhooks, not a failure.

## Notes

- New PW project `webhooks` (`retries: 0` — rotates the secret + enqueues a job).
- Base is the epic branch `1479-apps-e2e-playwright-framework` (apps/e2e is not on main).
- Manual attended round-trip documented in `docs/manual-testing/inbound-webhook-round-trip.md`.
- `pnpm --filter @openlinker/e2e type-check` is clean. The live `playwright test` (needs demo stack + tunnels) was not run.

Closes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)