### PR TITLE
fix(mappings): grant operator write access to mapping configuration

### DIFF
--- a/apps/api/src/auth/write-guard-coverage.spec.ts
+++ b/apps/api/src/auth/write-guard-coverage.spec.ts
@@ -47,6 +47,7 @@ import { WebhookDeliveryController } from '../webhooks/http/webhook-delivery.con
 import { AiProviderSettingsController } from '../ai/http/ai-provider-settings.controller';
 import { PromptTemplatesController } from '../ai/http/prompt-templates.controller';
 import { ContentController } from '../content/http/content.controller';
+import { MappingsController } from '../mappings/http/mappings.controller';
 import { MailerSettingsController } from '../mailer/http/mailer-settings.controller';
 
 const METHOD_METADATA = 'method';
@@ -80,6 +81,7 @@ const CONTROLLERS = [
   PromptTemplatesController,
   ContentController,
   MailerSettingsController,
+  MappingsController,
 ];
 
 describe('Write-guard coverage invariant (#1124 / #1126 / #1357)', () => {

--- a/apps/api/src/mappings/http/__tests__/mapping-roles-guard.spec.ts
+++ b/apps/api/src/mappings/http/__tests__/mapping-roles-guard.spec.ts
@@ -1,13 +1,14 @@
 /**
- * Mapping controllers role-guard coverage (#1652)
+ * Mapping controllers role-guard coverage (#1652 / #1653)
  *
- * Verifies the demo-viewer-read-access relaxation applied to
- * `MappingOptionsController` (class-level, every method is a read) and
- * `MappingsController` (per-method override on exactly the 5 GET handlers,
- * class-level `@Roles('admin')` default still gating all 6 PUT/DELETE
- * writes). Exercises the real `RolesGuard` + `Reflector` against the actual
- * controller prototypes so the test fails if a future edit drifts the role
- * set on any of these handlers.
+ * Verifies the role posture of the mapping controllers:
+ * `MappingOptionsController` (class-level read relaxation, every method is a
+ * read) and `MappingsController` (per-method overrides — the 5 GET handlers
+ * open to admin/operator/viewer via #1652, the 6 PUT/DELETE writes open to
+ * admin/operator via #1653; viewer stays denied on writes). Exercises the
+ * real `RolesGuard` + `Reflector` against the actual controller prototypes so
+ * the test fails if a future edit drifts the role set on any of these
+ * handlers.
  *
  * @module apps/api/src/mappings/http/__tests__
  */
@@ -104,15 +105,15 @@ describe('Mapping controllers role-guard coverage (#1652)', () => {
     });
   });
 
-  describe('MappingsController — 6 write handlers stay admin-only (class-level fallback)', () => {
+  describe('MappingsController — 6 write handlers open to admin/operator (#1653)', () => {
     it.each(MAPPINGS_WRITE_HANDLERS)('%s rejects viewer', (methodName) => {
       const context = createContext(MappingsController, methodName, 'viewer');
       expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
     });
 
-    it.each(MAPPINGS_WRITE_HANDLERS)('%s rejects operator (unchanged baseline — no operator write access)', (methodName) => {
+    it.each(MAPPINGS_WRITE_HANDLERS)('%s allows operator', (methodName) => {
       const context = createContext(MappingsController, methodName, 'operator');
-      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+      expect(guard.canActivate(context)).toBe(true);
     });
 
     it.each(MAPPINGS_WRITE_HANDLERS)('%s allows admin', (methodName) => {

--- a/apps/api/src/mappings/http/__tests__/mappings.controller.spec.ts
+++ b/apps/api/src/mappings/http/__tests__/mappings.controller.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * MappingsController role-metadata tests (#1653)
+ *
+ * Asserts the @Roles posture of every route handler after #1652 (reads opened
+ * to viewer) and #1653 (writes opened to operator):
+ *   - read (GET) handlers grant admin/operator/viewer
+ *   - write (PUT/DELETE) handlers grant admin/operator
+ *
+ * Reads decorator metadata off the prototype via Reflect.getMetadata — no DI or
+ * database required, mirroring write-guard-coverage.spec.ts. The class-level
+ * @Roles('admin') deny-by-default default is intentionally not asserted here;
+ * every handler carries its own override.
+ *
+ * @module apps/api/src/mappings/http/__tests__
+ */
+import 'reflect-metadata';
+import { RequestMethod } from '@nestjs/common';
+
+import { ROLES_KEY } from '../../../auth/decorators/roles.decorator';
+import { MappingsController } from '../mappings.controller';
+
+const METHOD_METADATA = 'method';
+
+const WRITE_METHODS = new Set<RequestMethod>([
+  RequestMethod.POST,
+  RequestMethod.PUT,
+  RequestMethod.PATCH,
+  RequestMethod.DELETE,
+]);
+
+type HandlerRoles = { method: RequestMethod; roles: string[] };
+
+function collectHandlers(): Record<string, HandlerRoles> {
+  const proto = MappingsController.prototype as unknown as Record<string, unknown>;
+  const handlers: Record<string, HandlerRoles> = {};
+
+  for (const methodName of Object.getOwnPropertyNames(proto)) {
+    if (methodName === 'constructor') continue;
+    if (typeof proto[methodName] !== 'function') continue;
+
+    const fn = proto[methodName] as object;
+    const httpMethod = Reflect.getMetadata(METHOD_METADATA, fn) as RequestMethod | undefined;
+    if (httpMethod === undefined) continue;
+
+    const roles = (Reflect.getMetadata(ROLES_KEY, fn) as string[] | undefined) ?? [];
+    handlers[methodName] = { method: httpMethod, roles };
+  }
+
+  return handlers;
+}
+
+describe('MappingsController role metadata (#1652 / #1653)', () => {
+  const handlers = collectHandlers();
+
+  it('exposes both read and write handlers', () => {
+    const methods = Object.values(handlers).map((h) => h.method);
+    expect(methods).toContain(RequestMethod.GET);
+    expect(methods.some((m) => WRITE_METHODS.has(m))).toBe(true);
+  });
+
+  it('read (GET) handlers grant admin/operator/viewer', () => {
+    const offenders = Object.entries(handlers)
+      .filter(([, h]) => h.method === RequestMethod.GET)
+      .filter(([, h]) => {
+        const set = new Set(h.roles);
+        return !(set.has('admin') && set.has('operator') && set.has('viewer'));
+      })
+      .map(([name, h]) => `${name}: [${h.roles.join(', ')}]`);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('write (PUT/DELETE) handlers grant admin and operator', () => {
+    const offenders = Object.entries(handlers)
+      .filter(([, h]) => WRITE_METHODS.has(h.method))
+      .filter(([, h]) => {
+        const set = new Set(h.roles);
+        return !(set.has('admin') && set.has('operator'));
+      })
+      .map(([name, h]) => `${name}: [${h.roles.join(', ')}]`);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('does not grant viewer write access', () => {
+    const viewerWrites = Object.entries(handlers)
+      .filter(([, h]) => WRITE_METHODS.has(h.method))
+      .filter(([, h]) => h.roles.includes('viewer'))
+      .map(([name]) => name);
+
+    expect(viewerWrites).toEqual([]);
+  });
+});

--- a/apps/api/src/mappings/http/mappings.controller.ts
+++ b/apps/api/src/mappings/http/mappings.controller.ts
@@ -3,10 +3,13 @@
  *
  * HTTP REST API endpoints for connection-scoped mapping configuration.
  * Supports CRUD for status, carrier, and payment mapping types.
- * Write endpoints (PUT/DELETE) require admin role (class-level default);
- * the 5 read (GET) endpoints are relaxed to admin/operator/viewer via a
- * per-method override (#1652) so demo viewers can inspect mapping
- * configuration without a 403.
+ * Read (GET) endpoints allow admin/operator/viewer (#1652) so demo viewers
+ * can inspect mapping configuration without a 403. Write endpoints
+ * (PUT/DELETE) allow admin/operator (#1653) — mapping configuration is
+ * routine operator work, matching operator's write access in sibling
+ * controllers (listings, orders). The class-level @Roles('admin') stays as a
+ * deny-by-default safety net for any future endpoint added without a
+ * per-method override.
  *
  * @module apps/api/src/mappings/http
  */
@@ -62,6 +65,7 @@ export class MappingsController {
   }
 
   @Put('status')
+  @Roles('admin', 'operator')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Replace all status mappings for a connection' })
   @ApiParam({ name: 'connectionId', type: String })
@@ -92,6 +96,7 @@ export class MappingsController {
   }
 
   @Put('carriers')
+  @Roles('admin', 'operator')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Replace all carrier mappings for a connection' })
   @ApiParam({ name: 'connectionId', type: String })
@@ -122,6 +127,7 @@ export class MappingsController {
   }
 
   @Put('order-states')
+  @Roles('admin', 'operator')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Replace all OL→destination order-state mappings for a connection' })
   @ApiParam({ name: 'connectionId', type: String })
@@ -155,6 +161,7 @@ export class MappingsController {
   }
 
   @Put('payments')
+  @Roles('admin', 'operator')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Replace all payment mappings for a connection' })
   @ApiParam({ name: 'connectionId', type: String })
@@ -185,6 +192,7 @@ export class MappingsController {
   }
 
   @Put('categories/:prestashopCategoryId')
+  @Roles('admin', 'operator')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Create or update a category mapping for a PrestaShop category' })
   @ApiParam({ name: 'connectionId', type: String })
@@ -210,6 +218,7 @@ export class MappingsController {
   }
 
   @Delete('categories/:prestashopCategoryId')
+  @Roles('admin', 'operator')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a category mapping for a PrestaShop category' })
   @ApiParam({ name: 'connectionId', type: String })


### PR DESCRIPTION
## What & why

`MappingsController` write endpoints (status / carrier / order-state / payment / category mappings) inherited the class-level `@Roles('admin')`, so the **operator** role — a routine, non-admin production role that configures carrier/status/category mappings as part of normal operation — had **zero** write access. Reads were already opened to `admin/operator/viewer` in #1652; this closes the write half.

Product decision (confirmed): operator gets full **read + write** access to mapping configuration, consistent with how operator is treated in sibling controllers (`listings`, `orders`), where it holds write access alongside `admin`.

## Changes

- **`mappings.controller.ts`** — add `@Roles('admin', 'operator')` to all six write handlers (`PUT status`, `PUT carriers`, `PUT order-states`, `PUT payments`, `PUT categories/:id`, `DELETE categories/:id`). The class-level `@Roles('admin')` stays as a deny-by-default safety net for any future endpoint added without a per-method override.
- **`write-guard-coverage.spec.ts`** — register `MappingsController` in the write-guard-coverage invariant (it had write endpoints but was not covered), so any future write handler added without `@Roles` fails CI.
- **`mappings.controller.spec.ts`** (new) — role-metadata spec asserting reads = `admin/operator/viewer`, writes = `admin/operator`, and that viewer has no write access.

## Notes

- **No `ROLE_PERMISSIONS` change.** There are no `mappings:*` entries in `PermissionValues`, and the FE gates neither the mapping routes nor their UI on a permission (or on role), so the `@Roles` guard is the sole enforcement point and the change is immediately usable by operators.
- No architecture boundary impact — pure Interface-layer decorator change.

## Verification

- `pnpm type-check` ✓
- `pnpm lint` + `check:invariants` ✓
- Unit tests: new metadata spec + write-guard-coverage invariant pass (26/26)

Closes #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)