### PR TITLE
feat(woocommerce): inbound webhook decoder (InboundWebhookDecoderPort, ADR-021)

### DIFF
--- a/docs/plans/implementation-plan-woocommerce-inbound-webhook-decoder.md
+++ b/docs/plans/implementation-plan-woocommerce-inbound-webhook-decoder.md
@@ -1,0 +1,83 @@
+# Implementation Plan — WooCommerce Inbound Webhook Decoder (#1563)
+
+## 1. Task
+
+Implement a WooCommerce-specific `InboundWebhookDecoderPort` (ADR-021 seam) so real
+WooCommerce webhook deliveries authenticate end-to-end at the host ingress, instead of
+being dropped by the host default decoder (`DefaultWebhookDecoder`, which expects
+OpenLinker's own HMAC scheme).
+
+This is the deferred second half of #1548 (acceptance criterion 4). The provisioning
+adapter (`WooCommerceWebhookProvisioningAdapter`) and the event translator
+(`WooCommerceWebhookEventTranslatorAdapter`) already shipped via epic PR #1568.
+
+**Layer:** Integration (WooCommerce adapter package). No CORE changes — the port,
+types, and `InboundWebhookDecoderRegistryService` already exist.
+
+**Non-goals:** no new core ports/tokens/entities; no migration; no changes to
+provisioning or translator; no change to the poll backstop.
+
+## 2. WooCommerce signature facts (from provisioning adapter + WC types)
+
+- Header: `X-WC-Webhook-Signature: <base64(HMAC-SHA256(rawBody, secret))>`.
+- Secret: the per-connection rotated webhook secret (`IWebhookSecretService`,
+  provider key `woocommerce`) — the host supplies it to `verify` via
+  `authService.getSecret('woocommerce', connectionId)`.
+- **No signed timestamp header** → `verify` omits `timestampMs` → host skips the
+  replay-window check (same posture as Erli).
+- Delivery headers also carry `X-WC-Webhook-Topic` (`order.created` / `order.updated`),
+  `X-WC-Webhook-Resource` (`order`), `X-WC-Webhook-Event` (`created` / `updated`).
+- Order body is the full WC order resource (`{ id, status, date_modified_gmt, ... }`).
+  The creation "ping" body is `{ "webhook_id": N }` — signed, but has no order id.
+
+## 3. Design
+
+New file: `libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-inbound-webhook-decoder.adapter.ts`
+implementing `InboundWebhookDecoderPort` — mirrors `ErliInboundWebhookDecoderAdapter`.
+
+- `verify`: read `X-WC-Webhook-Signature`, compute `base64(HMAC-SHA256(rawBody))`
+  keyed by `secret`, `timingSafeEqual`. Missing header / length mismatch → `{ ok:false }`.
+  No `timestampMs` (WC sends none).
+- `extractEnvelope`:
+  - Parse JSON. Non-JSON / non-object → `reject`.
+  - No numeric/string `id` (e.g. the `{webhook_id}` ping) → `ignore` (well-formed,
+    not an order — 202, no publish, no source-side retry storm).
+  - Otherwise `route` with envelope:
+    - `objectType: 'order'`
+    - `externalId: String(body.id)`
+    - `eventType`: the `X-WC-Webhook-Topic` header (fallback: `order.` + `X-WC-Webhook-Event`,
+      fallback `order.updated`). Translator already accepts full topic or bare action.
+    - `occurredAt`: `date_modified_gmt` / `date_modified` / `date_created` → ISO, else now.
+    - `eventId`: deterministic hash `wc-sha256(orderId:status:topic:modified)` so retries
+      of the identical state dedupe while a real status/topic change stays distinct.
+      Uses the body timestamp only (never decode-time `now`) so retried deliveries hash
+      identically (same rationale as Erli's `deriveEventId`).
+- No `detectHandshake` — WC has no echo handshake; the ping is handled by `ignore`.
+
+Constants (topic/resource/event/signature header names) live in the existing
+`woocommerce-webhook.types.ts` (extend it; keep WC vocabulary in one place).
+
+Registration: one line in `woocommerce-plugin.ts` `register(host)`, keyed by
+`woocommerceAdapterManifest.platformType` (`'woocommerce'`), next to the existing
+translator registration. The `inboundWebhookDecoderRegistry` is already threaded into
+the plugin's `HostServices` bag by `woocommerce-integration.module.ts`.
+
+## 4. Steps
+
+1. Extend `woocommerce-webhook.types.ts` with the delivery header-name constants
+   (`X-WC-Webhook-Signature`, `-Topic`, `-Resource`, `-Event`) and the resource value.
+2. Add `woocommerce-inbound-webhook-decoder.adapter.ts` (the port impl above).
+3. Register it in `woocommerce-plugin.ts` `register(host)`.
+4. Unit spec `__tests__/woocommerce-inbound-webhook-decoder.adapter.spec.ts`:
+   valid signature passes; tampered/short/missing → fail; order body → `route` with
+   correct envelope; ping body → `ignore`; non-JSON → `reject`; deterministic eventId
+   across retries; distinct eventId across a status change.
+5. Optional: assert the plugin registers the decoder (extend the plugin spec).
+6. Quality gate: scoped `type-check` + `lint` + `test` on `@openlinker/integrations-woocommerce`.
+
+## 5. Validation
+
+- Architecture: adapter implements a CORE port; no CORE edit; no cross-context violation.
+- Naming: `*.adapter.ts`, `Woo...Adapter`, `*.spec.ts` — matches conventions.
+- Security: secret only compared via `timingSafeEqual`, never logged.
+- `detectHandshake` intentionally omitted (optional on the port).

--- a/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
+++ b/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
@@ -25,6 +25,7 @@ interface HostStub {
   authFailureRegistry: { register: jest.Mock };
   schedulerRegistry: { register: jest.Mock };
   translatorRegistry: { register: jest.Mock };
+  decoderRegistry: { register: jest.Mock };
 }
 
 function makeHostStub(): HostStub {
@@ -34,6 +35,7 @@ function makeHostStub(): HostStub {
   const authFailureRegistry = { register: jest.fn() };
   const schedulerRegistry = { register: jest.fn() };
   const translatorRegistry = { register: jest.fn() };
+  const decoderRegistry = { register: jest.fn() };
 
   const host = {
     connectionTesterRegistry: testerRegistry,
@@ -45,6 +47,7 @@ function makeHostStub(): HostStub {
     schedulerTaskRegistry: schedulerRegistry,
     webhookProvisioningRegistry: { register: jest.fn() },
     webhookEventTranslatorRegistry: translatorRegistry,
+    inboundWebhookDecoderRegistry: decoderRegistry,
     oauthCompletionRegistry: { register: jest.fn() },
     adapterRegistry: { register: jest.fn() },
     factoryResolver: { registerFactory: jest.fn() },
@@ -66,6 +69,7 @@ function makeHostStub(): HostStub {
     authFailureRegistry,
     schedulerRegistry,
     translatorRegistry,
+    decoderRegistry,
   };
 }
 
@@ -222,6 +226,18 @@ describe('createWooCommercePlugin → register(host) — #1548 inbound webhooks'
     expect(translatorRegistry.register).toHaveBeenCalledWith(
       'woocommerce.restapi.v3',
       expect.objectContaining({ translate: expect.any(Function) }),
+    );
+  });
+
+  it('should register the inbound webhook decoder keyed by platformType (#1563)', () => {
+    const { host, decoderRegistry } = makeHostStub();
+    createWooCommercePlugin().register!(host);
+    expect(decoderRegistry.register).toHaveBeenCalledWith(
+      'woocommerce',
+      expect.objectContaining({
+        verify: expect.any(Function),
+        extractEnvelope: expect.any(Function),
+      }),
     );
   });
 });

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/__tests__/woocommerce-inbound-webhook-decoder.adapter.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for WooCommerceInboundWebhookDecoderAdapter (#1563, ADR-021).
+ *
+ * WooCommerce signs each delivery with a base64 HMAC-SHA256 of the raw body in
+ * the `X-WC-Webhook-Signature` header (no signed timestamp), and delivers the
+ * full order resource as the body. Tests exercise the real HMAC so a wire
+ * change surfaces here rather than in production.
+ */
+import { createHmac } from 'node:crypto';
+import { WooCommerceInboundWebhookDecoderAdapter } from '../woocommerce-inbound-webhook-decoder.adapter';
+import {
+  WOOCOMMERCE_WEBHOOK_EVENT_HEADER,
+  WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER,
+  WOOCOMMERCE_WEBHOOK_TOPIC_HEADER,
+} from '../woocommerce-webhook.types';
+
+const SECRET = 'wc-connection-webhook-secret-ol-side';
+const ORDER_ID = 4321;
+
+function makeBody(overrides: Record<string, unknown> = {}): Buffer {
+  return Buffer.from(
+    JSON.stringify({
+      id: ORDER_ID,
+      status: 'processing',
+      date_modified_gmt: '2026-07-16T10:00:00',
+      ...overrides,
+    }),
+  );
+}
+
+function sign(rawBody: Buffer, secret: string = SECRET): string {
+  return createHmac('sha256', secret).update(rawBody).digest('base64');
+}
+
+function deliveryHeaders(rawBody: Buffer, extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    [WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER]: sign(rawBody),
+    [WOOCOMMERCE_WEBHOOK_TOPIC_HEADER]: 'order.updated',
+    ...extra,
+  };
+}
+
+describe('WooCommerceInboundWebhookDecoderAdapter', () => {
+  let decoder: WooCommerceInboundWebhookDecoderAdapter;
+
+  beforeEach(() => {
+    decoder = new WooCommerceInboundWebhookDecoderAdapter();
+  });
+
+  // ---------------------------------------------------------------------------
+  // verify()
+  // ---------------------------------------------------------------------------
+
+  describe('verify', () => {
+    it('should accept a correctly-signed delivery', () => {
+      const rawBody = makeBody();
+      const result = decoder.verify({
+        rawBody,
+        headers: { [WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER]: sign(rawBody) },
+        secret: SECRET,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('should accept the signature header in any casing', () => {
+      const rawBody = makeBody();
+      const result = decoder.verify({
+        rawBody,
+        headers: { 'X-WC-Webhook-Signature': sign(rawBody) },
+        secret: SECRET,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('should reject a signature computed with the wrong secret', () => {
+      const rawBody = makeBody();
+      const result = decoder.verify({
+        rawBody,
+        headers: { [WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER]: sign(rawBody, 'wrong-secret') },
+        secret: SECRET,
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('should reject when the body was tampered with after signing', () => {
+      const signed = makeBody();
+      const tampered = makeBody({ status: 'completed' });
+      const result = decoder.verify({
+        rawBody: tampered,
+        headers: { [WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER]: sign(signed) },
+        secret: SECRET,
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('should reject when the signature header is missing', () => {
+      const result = decoder.verify({ rawBody: makeBody(), headers: {}, secret: SECRET });
+      expect(result.ok).toBe(false);
+    });
+
+    it('should never surface a normalized timestamp (WooCommerce sends none)', () => {
+      const rawBody = makeBody();
+      const result = decoder.verify({
+        rawBody,
+        headers: { [WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER]: sign(rawBody) },
+        secret: SECRET,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.timestampMs).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // extractEnvelope()
+  // ---------------------------------------------------------------------------
+
+  describe('extractEnvelope', () => {
+    it('should route an order delivery with a neutral envelope', () => {
+      const rawBody = makeBody();
+      const result = decoder.extractEnvelope(rawBody, deliveryHeaders(rawBody));
+      expect(result.action).toBe('route');
+      if (result.action !== 'route') return;
+      expect(result.envelope.objectType).toBe('order');
+      expect(result.envelope.externalId).toBe(String(ORDER_ID));
+      expect(result.envelope.eventType).toBe('order.updated');
+      expect(result.envelope.occurredAt).toBe('2026-07-16T10:00:00');
+      expect(result.envelope.payload).toEqual({ id: String(ORDER_ID) });
+      expect(result.envelope.eventId).toMatch(/^woocommerce-[0-9a-f]{32}$/);
+    });
+
+    it('should carry the full topic header verbatim as eventType', () => {
+      const rawBody = makeBody();
+      const result = decoder.extractEnvelope(
+        rawBody,
+        deliveryHeaders(rawBody, { [WOOCOMMERCE_WEBHOOK_TOPIC_HEADER]: 'order.created' }),
+      );
+      expect(result.action).toBe('route');
+      if (result.action !== 'route') return;
+      expect(result.envelope.eventType).toBe('order.created');
+    });
+
+    it('should rebuild eventType from the bare action header when topic is absent', () => {
+      const rawBody = makeBody();
+      const result = decoder.extractEnvelope(rawBody, {
+        [WOOCOMMERCE_WEBHOOK_EVENT_HEADER]: 'created',
+      });
+      expect(result.action).toBe('route');
+      if (result.action !== 'route') return;
+      expect(result.envelope.eventType).toBe('order.created');
+    });
+
+    it('should fall back to order.updated when no topic/event header is present', () => {
+      const rawBody = makeBody();
+      const result = decoder.extractEnvelope(rawBody, {});
+      expect(result.action).toBe('route');
+      if (result.action !== 'route') return;
+      expect(result.envelope.eventType).toBe('order.updated');
+    });
+
+    it('should ignore the creation ping (body has no order id)', () => {
+      const rawBody = Buffer.from(JSON.stringify({ webhook_id: 99 }));
+      const result = decoder.extractEnvelope(rawBody, {});
+      expect(result.action).toBe('ignore');
+    });
+
+    it('should reject a non-JSON body', () => {
+      const result = decoder.extractEnvelope(Buffer.from('not-json'), {});
+      expect(result.action).toBe('reject');
+    });
+
+    it('should reject a JSON body that is not an object', () => {
+      const result = decoder.extractEnvelope(Buffer.from(JSON.stringify(['array'])), {});
+      expect(result.action).toBe('reject');
+    });
+
+    it('should derive an identical eventId for a retried identical delivery', () => {
+      const rawBody = makeBody();
+      const headers = deliveryHeaders(rawBody);
+      const first = decoder.extractEnvelope(rawBody, headers);
+      const second = decoder.extractEnvelope(rawBody, headers);
+      expect(first.action).toBe('route');
+      expect(second.action).toBe('route');
+      if (first.action !== 'route' || second.action !== 'route') return;
+      expect(first.envelope.eventId).toBe(second.envelope.eventId);
+    });
+
+    it('should derive a distinct eventId across a real status change', () => {
+      const created = makeBody({ status: 'processing', date_modified_gmt: '2026-07-16T10:00:00' });
+      const completed = makeBody({ status: 'completed', date_modified_gmt: '2026-07-16T11:00:00' });
+      const a = decoder.extractEnvelope(created, deliveryHeaders(created));
+      const b = decoder.extractEnvelope(completed, deliveryHeaders(completed));
+      if (a.action !== 'route' || b.action !== 'route') throw new Error('expected route');
+      expect(a.envelope.eventId).not.toBe(b.envelope.eventId);
+    });
+  });
+});

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-inbound-webhook-decoder.adapter.ts
@@ -1,0 +1,176 @@
+/**
+ * WooCommerce Inbound Webhook Decoder Adapter (#1563, ADR-021)
+ *
+ * Authenticates + decodes WooCommerce inbound order webhooks at the host
+ * ingress, keyed by `provider = 'woocommerce'`. The deferred second half of
+ * #1548 (acceptance criterion 4): the provisioning adapter (#1548) already
+ * registers the store-side `order.created` / `order.updated` webhooks and
+ * rotates the shared secret; this decoder lets the host authenticate the
+ * resulting deliveries instead of dropping them on the host default decoder
+ * (`DefaultWebhookDecoder`, which expects OpenLinker's own HMAC scheme).
+ *
+ * SIGNATURE: WooCommerce signs each delivery with
+ * `X-WC-Webhook-Signature: <base64(HMAC-SHA256(rawBody))>`, keyed by the
+ * per-connection webhook secret (`IWebhookSecretService`, provider key
+ * `woocommerce`) the host supplies to `verify`. WooCommerce sends NO signed
+ * timestamp header, so `verify` omits `timestampMs` and the host's shared
+ * replay-window check never fires (same posture as `ErliInboundWebhookDecoderAdapter`).
+ *
+ * TRIGGER MODEL: the webhook is a low-latency nudge, never the source of truth
+ * (`WooCommerceOrderSourceAdapter` remains the reconciliation backstop). The
+ * decoder reads only the order id + a coarse event type from the body/headers;
+ * the authoritative order is re-pulled downstream by the `marketplace.order.sync`
+ * job. The event vocabulary lives in `WooCommerceWebhookEventTranslatorAdapter`,
+ * which accepts either the full WC topic (`order.created`) or its bare action.
+ *
+ * @module libs/integrations/woocommerce/src/infrastructure/adapters
+ * @see {@link InboundWebhookDecoderPort} for the port interface
+ * @see {@link WooCommerceWebhookProvisioningAdapter} for the provisioner that sets the secret
+ * @see {@link WooCommerceWebhookEventTranslatorAdapter} for the downstream translator
+ */
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import type {
+  DecodeResult,
+  InboundWebhookDecoderPort,
+  WebhookVerifyResult,
+} from '@openlinker/core/integrations';
+import {
+  WOOCOMMERCE_WEBHOOK_EVENT_HEADER,
+  WOOCOMMERCE_WEBHOOK_ORDER_RESOURCE,
+  WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER,
+  WOOCOMMERCE_WEBHOOK_TOPIC_HEADER,
+} from './woocommerce-webhook.types';
+
+export class WooCommerceInboundWebhookDecoderAdapter implements InboundWebhookDecoderPort {
+  verify(input: {
+    rawBody: Buffer;
+    headers: Record<string, string>;
+    secret: string;
+  }): WebhookVerifyResult {
+    const provided = this.header(input.headers, WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER);
+    if (!provided) {
+      return { ok: false };
+    }
+
+    const expected = createHmac('sha256', input.secret).update(input.rawBody).digest('base64');
+    const providedBuf = Buffer.from(provided);
+    const expectedBuf = Buffer.from(expected);
+    if (providedBuf.length !== expectedBuf.length) {
+      return { ok: false };
+    }
+    if (!timingSafeEqual(providedBuf, expectedBuf)) {
+      return { ok: false };
+    }
+
+    // WooCommerce does not send a signed timestamp header, so `timestampMs` is
+    // omitted intentionally — the host's replay-window check only fires when
+    // the field is present.
+    return { ok: true };
+  }
+
+  extractEnvelope(rawBody: Buffer, headers: Record<string, string>): DecodeResult {
+    let body: unknown;
+    try {
+      body = JSON.parse(rawBody.toString('utf8'));
+    } catch {
+      return { action: 'reject', reason: 'body is not valid JSON' };
+    }
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      return { action: 'reject', reason: 'body is not a JSON object' };
+    }
+    const record = body as Record<string, unknown>;
+
+    const orderId = this.asId(record['id']);
+    if (!orderId) {
+      // No order id — e.g. WooCommerce's creation "ping" (`{ webhook_id: N }`),
+      // which is signed but is not an order event. Well-formed but not ours:
+      // 202 without publish, so it does not trigger a source-side retry storm.
+      return { action: 'ignore', reason: 'body has no order id (ping or non-order delivery)' };
+    }
+
+    const eventType = this.resolveEventType(headers);
+    const bodyTimestamp = this.resolveBodyTimestamp(record);
+    const occurredAt = bodyTimestamp ?? new Date().toISOString();
+
+    return {
+      action: 'route',
+      envelope: {
+        eventId: this.deriveEventId(record, orderId, eventType, bodyTimestamp),
+        eventType,
+        occurredAt,
+        objectType: WOOCOMMERCE_WEBHOOK_ORDER_RESOURCE,
+        externalId: orderId,
+        payload: { id: orderId },
+      },
+    };
+  }
+
+  /**
+   * The full WC topic (`order.created` / `order.updated`) from the delivery
+   * header, or `order.<event>` rebuilt from the bare action header, or a safe
+   * `order.updated` fallback. The translator accepts all three forms and coerces
+   * anything that is not a create to a re-pull.
+   */
+  private resolveEventType(headers: Record<string, string>): string {
+    const topic = this.header(headers, WOOCOMMERCE_WEBHOOK_TOPIC_HEADER);
+    if (topic) {
+      return topic;
+    }
+    const event = this.header(headers, WOOCOMMERCE_WEBHOOK_EVENT_HEADER);
+    if (event) {
+      return `${WOOCOMMERCE_WEBHOOK_ORDER_RESOURCE}.${event}`;
+    }
+    return `${WOOCOMMERCE_WEBHOOK_ORDER_RESOURCE}.updated`;
+  }
+
+  /**
+   * Deterministic dedup key. The hash basis folds in `status`, the event type,
+   * and the body's own modified timestamp so successive real changes of one
+   * order (created -> processing -> completed) hash distinctly, while a retried
+   * delivery of the identical body re-hashes to the same eventId and is caught
+   * by the Postgres eventId-dedup gate. The decode-time `now` fallback used for
+   * the advisory `occurredAt` is intentionally NOT part of the basis — hashing
+   * it would mint a fresh eventId on every retry and defeat dedup.
+   */
+  private deriveEventId(
+    record: Record<string, unknown>,
+    orderId: string,
+    eventType: string,
+    bodyTimestamp: string | null,
+  ): string {
+    const status = this.asNonEmptyString(record['status']) ?? 'no-status';
+    const timestamp = bodyTimestamp ?? 'no-timestamp';
+    const basis = `${orderId}:${status}:${eventType}:${timestamp}`;
+    return `woocommerce-${createHash('sha256').update(basis).digest('hex').slice(0, 32)}`;
+  }
+
+  private resolveBodyTimestamp(record: Record<string, unknown>): string | null {
+    return (
+      this.asNonEmptyString(record['date_modified_gmt']) ??
+      this.asNonEmptyString(record['date_modified']) ??
+      this.asNonEmptyString(record['date_created_gmt']) ??
+      this.asNonEmptyString(record['date_created'])
+    );
+  }
+
+  private header(headers: Record<string, string>, name: string): string | null {
+    const lower = name.toLowerCase();
+    const entry = Object.entries(headers).find(([k]) => k.toLowerCase() === lower);
+    const value = entry?.[1];
+    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+  }
+
+  /** Accept WooCommerce's numeric order id (or a stringified one); reject 0 / empty. */
+  private asId(value: unknown): string | null {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return String(value);
+    }
+    return this.asNonEmptyString(value);
+  }
+
+  private asNonEmptyString(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+}

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-provisioning.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook-provisioning.adapter.ts
@@ -28,13 +28,12 @@
  * `timestamp.body`). The two are incompatible, so end-to-end inbound
  * authentication requires a WooCommerce-specific `InboundWebhookDecoderPort`
  * (the ADR-021 seam, exactly like `ErliInboundWebhookDecoderAdapter`) that
- * verifies the base64 signature and omits the replay-timestamp. That decoder is
- * a scoped follow-up (tracked in #1563); this adapter provisions the store side
- * so the decoder can verify against the same rotated secret when it lands. Until
- * then the `WooCommerceOrderSourceAdapter` poll remains the reconciliation
- * backstop, and inbound deliveries fail host signature verification (WooCommerce
- * may auto-disable the store-side webhook after repeated failures — re-run
- * install once #1563 ships).
+ * verifies the base64 signature and omits the replay-timestamp. That decoder
+ * ships as `WooCommerceInboundWebhookDecoderAdapter` (#1563), registered by the
+ * plugin against the `woocommerce` provider key; it verifies against the same
+ * rotated secret this adapter hands to WooCommerce, so store-side deliveries
+ * authenticate end-to-end. The `WooCommerceOrderSourceAdapter` poll remains the
+ * reconciliation backstop.
  *
  * TEST PING: WooCommerce has no synchronous, verifiable test-ping round-trip
  * (its own "ping" on webhook creation is delivered asynchronously and cannot be

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-webhook.types.ts
@@ -23,6 +23,25 @@ export const WOOCOMMERCE_WEBHOOK_PROVIDER = 'woocommerce';
 export const WOOCOMMERCE_WEBHOOKS_PATH = '/wp-json/wc/v3/webhooks';
 
 /**
+ * Delivery header carrying the base64 HMAC-SHA256 of the raw body, keyed by the
+ * connection's rotated webhook secret. Verified by
+ * `WooCommerceInboundWebhookDecoderAdapter.verify`.
+ */
+export const WOOCOMMERCE_WEBHOOK_SIGNATURE_HEADER = 'x-wc-webhook-signature';
+
+/** Delivery header carrying the full topic, e.g. `order.created` / `order.updated`. */
+export const WOOCOMMERCE_WEBHOOK_TOPIC_HEADER = 'x-wc-webhook-topic';
+
+/** Delivery header carrying the resource, e.g. `order`. */
+export const WOOCOMMERCE_WEBHOOK_RESOURCE_HEADER = 'x-wc-webhook-resource';
+
+/** Delivery header carrying the bare action, e.g. `created` / `updated`. */
+export const WOOCOMMERCE_WEBHOOK_EVENT_HEADER = 'x-wc-webhook-event';
+
+/** `objectType` the decoder stamps for an order delivery (consumed by the translator). */
+export const WOOCOMMERCE_WEBHOOK_ORDER_RESOURCE = 'order';
+
+/**
  * Order-relevant WooCommerce webhook topics OL provisions. WooCommerce is used
  * here as an order SOURCE over webhooks (low-latency nudge; the poll reconciles),
  * so only the order lifecycle topics are registered. `order.created` and

--- a/libs/integrations/woocommerce/src/woocommerce-plugin.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-plugin.ts
@@ -35,6 +35,7 @@ import { WooCommerceProductPublisherAdapter } from './infrastructure/adapters/pr
 import { WooCommerceOfferManagerAdapter } from './infrastructure/adapters/offer-manager/woocommerce-offer-manager.adapter';
 import { WooCommerceAuthFailureClassifierAdapter } from './infrastructure/adapters/woocommerce-auth-failure-classifier.adapter';
 import { WooCommerceWebhookEventTranslatorAdapter } from './infrastructure/adapters/woocommerce-webhook-event-translator.adapter';
+import { WooCommerceInboundWebhookDecoderAdapter } from './infrastructure/adapters/woocommerce-inbound-webhook-decoder.adapter';
 import { buildWooCommerceSchedulerTasks } from './infrastructure/scheduler/woocommerce-scheduler-tasks';
 
 /**
@@ -111,6 +112,16 @@ export function createWooCommercePlugin(deps?: CreateWooCommercePluginDeps): Ada
       host.authFailureClassifierRegistry.register(
         woocommerceAdapterManifest.adapterKey,
         new WooCommerceAuthFailureClassifierAdapter(),
+      );
+      // Inbound webhook decoder (ADR-021 / #1563), provider-keyed by
+      // platformType: authenticates the base64 HMAC-SHA256 `X-WC-Webhook-Signature`
+      // against the connection's rotated secret and decodes the order body, so
+      // real WooCommerce deliveries are no longer dropped by the host's
+      // fail-closed OL-HMAC default decoder. WC sends no signed timestamp, so
+      // the decoder omits it and the host skips the replay-window check.
+      host.inboundWebhookDecoderRegistry.register(
+        woocommerceAdapterManifest.platformType,
+        new WooCommerceInboundWebhookDecoderAdapter(),
       );
       // Inbound webhook-event translator (ADR-015 / #1548) — decodes WC order
       // webhook events into neutral CanonicalInboundEvents. The webhook


### PR DESCRIPTION
## Summary

Implements a WooCommerce-specific `InboundWebhookDecoderPort` (the ADR-021 seam) so real WooCommerce webhook deliveries authenticate end-to-end at the host ingress, instead of being dropped by the host default decoder (`DefaultWebhookDecoder`, which expects OpenLinker's own `X-OpenLinker-Timestamp` + `X-OpenLinker-Signature` HMAC scheme).

This is the deferred second half of #1548 (acceptance criterion 4). The webhook **provisioner** and **event translator** already shipped via epic PR #1568; until this decoder landed, the inbound webhook path was dark (deliveries failed host signature verification; the `WooCommerceOrderSourceAdapter` poll was the only working path).

## What it does

`WooCommerceInboundWebhookDecoderAdapter` mirrors `ErliInboundWebhookDecoderAdapter`:

- **verify**: computes `base64(HMAC-SHA256(rawBody))` keyed by the connection's rotated webhook secret and compares it against `X-WC-Webhook-Signature` with `timingSafeEqual`. WooCommerce sends **no signed timestamp**, so `timestampMs` is omitted and the host skips its replay-window check.
- **extractEnvelope**:
  - order body -> `route` (`objectType: order`, `externalId` from the body `id`, `eventType` from `X-WC-Webhook-Topic`, deterministic `eventId` hash `orderId:status:eventType:modified` so retries dedupe while real status changes stay distinct);
  - the WooCommerce creation ping (`{ webhook_id: N }`, signed but no order id) -> `ignore` (202, no publish, no source-side retry storm);
  - non-JSON / non-object / array -> `reject`.
- No `detectHandshake` (WooCommerce has no echo handshake).
- Registered in `woocommerce-plugin.ts` `register(host)` against the `woocommerce` provider key, verifying against the same rotated secret the provisioner hands to WooCommerce.

## Scope

Confined to `libs/integrations/woocommerce/`. No CORE changes - the port, neutral types, and `InboundWebhookDecoderRegistryService` already exist and the registry is already threaded into the plugin's `HostServices` bag. No migration.

## Testing

Scoped checks on `@openlinker/integrations-woocommerce` pass: type-check, lint, and **437 unit tests across 24 suites** (new decoder suite + plugin-registration assertion). `pnpm check:invariants` (cross-context imports + service interfaces) passes.

Closes #1563

🤖 Generated with [Claude Code](https://claude.com/claude-code)