### PR TITLE
fix(ci): resolve migration timestamp collision and flaky connection-form test (#1698)

### DIFF
--- a/apps/api/src/migrations/1825000000000-add-posthog-settings.ts
+++ b/apps/api/src/migrations/1825000000000-add-posthog-settings.ts
@@ -1,7 +1,7 @@
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddPosthogSettings1823000000000 implements MigrationInterface {
-  name = 'AddPosthogSettings1823000000000';
+export class AddPosthogSettings1825000000000 implements MigrationInterface {
+  name = 'AddPosthogSettings1825000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/apps/web/src/features/connections/components/create-connection-form.test.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.test.tsx
@@ -149,8 +149,8 @@ describe('CreateConnectionForm', () => {
       fireEvent.change(nameInput, { target: { value: 'Should not persist' } });
       expect(nameInput).toHaveValue('Should not persist');
 
-      const submit = within(view.container).getByRole('button', { name: 'Create connection' });
       await waitFor(() => {
+        const submit = within(view.container).getByRole('button', { name: 'Create connection' });
         expect(submit).toBeDisabled();
       });
     });


### PR DESCRIPTION
## What & why

Two independent CI blockers on `main`, surfaced by release PR #1345 (`chore(main): release 0.2.0`, which carries no source changes - so both failures were pre-existing on `main`).

### 1. Lint / `check:invariants` - migration timestamp collision

`1823000000000-add-posthog-settings.ts` (#1687) and `1823000000000-add-numbering-fiscal-year-start.ts` (#1686 / #1697) shared timestamp `1823000000000`. `scripts/check-migration-timestamps.mjs` rejects this because TypeORM's run order between same-timestamp migrations is undefined.

Renamed the PostHog migration to the next free synthetic timestamp `1825000000000` (file + class + `name`). The check enforces that a new/renamed migration sort after the newest on `main` (`1824000000000-numbering-routing-axes.ts`, #1013 rule), so `1825000000000` is the correct slot. The two migrations touch independent tables, so relative run order is immaterial.

### 2. Test - flaky FE unit test

`create-connection-form.test.tsx` > `demo read-only viewer (#1667)` > `opens with editable inputs but disables the final submit` intermittently failed. The test captured the submit button via `getByRole` before the async `demoMode` config resolved; once `ReadOnlyLock` wrapped the button React remounted the node, leaving the captured `submit` reference stale while the live DOM button was correctly rendered `disabled`.

Fix: re-query the button inside `waitFor` so the assertion always runs against the live node.

## How to test

- `node scripts/check-migration-timestamps.mjs` -> `OK`
- `apps/web` suite: `create-connection-form.test.tsx` (6 tests) passes; the previously-flaky case passed 3/3 on repeat.

Closes #1698

🤖 Generated with [Claude Code](https://claude.com/claude-code)
