### PR TITLE
fix(allegro): allow operator/viewer to read responsible producers (#1707)

### DIFF
--- a/apps/api/src/integrations/http/allegro.controller.spec.ts
+++ b/apps/api/src/integrations/http/allegro.controller.spec.ts
@@ -10,6 +10,7 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { AllegroController } from './allegro.controller';
+import { ROLES_KEY } from '../../auth/decorators/roles.decorator';
 import type {
   IOAuthConnectionService,
   OAuthStateData,
@@ -474,6 +475,24 @@ describe('AllegroController', () => {
       await expect(controller.getCommand(connectionId, commandId)).rejects.toThrow(
         'Command not found'
       );
+    });
+  });
+
+  // ─── @Roles metadata (#1707) ──────────────────────────────────────────────
+  //
+  // Listing responsible producers is a read of the same data the listings
+  // controller already exposes to admin/operator/viewer (#1608). Its role gate
+  // must match so a non-admin editing an Allegro connection doesn't get a
+  // spurious 403 "Insufficient permissions". Reads decorator metadata directly
+  // to stay in the fast unit tier.
+  describe('@Roles metadata (#1707 — responsible-producers read parity)', () => {
+    function rolesOf(methodName: string): string[] | undefined {
+      const proto = AllegroController.prototype as unknown as Record<string, unknown>;
+      return Reflect.getMetadata(ROLES_KEY, proto[methodName] as object) as string[] | undefined;
+    }
+
+    it('listResponsibleProducers includes admin, operator, and viewer', () => {
+      expect(rolesOf('listResponsibleProducers')).toEqual(['admin', 'operator', 'viewer']);
     });
   });
 });

--- a/apps/api/src/integrations/http/allegro.controller.ts
+++ b/apps/api/src/integrations/http/allegro.controller.ts
@@ -389,7 +389,7 @@ export class AllegroController {
    * created in Allegro's seller panel, not from inside OL), so freshness
    * matters more than latency for a settings page.
    */
-  @Roles('admin')
+  @Roles('admin', 'operator', 'viewer')
   @ApiBearerAuth()
   @Get('connections/:id/responsible-producers')
   @ApiOperation({

--- a/apps/api/test/integration/viewer-role-authz.int-spec.ts
+++ b/apps/api/test/integration/viewer-role-authz.int-spec.ts
@@ -242,6 +242,17 @@ describe('Viewer Role Authorization', () => {
         .set('Authorization', `Bearer ${viewerToken}`);
       expect(res.status).not.toBe(403);
     });
+
+    // #1707 — the connection-edit seller-defaults section reads producers from
+    // this Allegro-controller endpoint; it must match the listings sibling so a
+    // non-admin editing a connection isn't 403'd with "Insufficient permissions".
+    it('GET /integrations/allegro/connections/:id/responsible-producers', async () => {
+      const { http, viewerToken } = await seeds();
+      const res = await http
+        .get(`/v1/integrations/allegro/connections/${FAKE_CONNECTION_ID}/responsible-producers`)
+        .set('Authorization', `Bearer ${viewerToken}`);
+      expect(res.status).not.toBe(403);
+    });
   });
 
   // ─── writes: viewer gets 403 ────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

On the Allegro connection-edit page, the "Responsible producer" (EU GPSR) section showed a red `Could not load responsible producers / Insufficient permissions` for any non-admin session (operator or viewer).

Root cause: an authorization inconsistency between two functionally-identical read endpoints that both fetch the same live Allegro `/sale/responsible-producers` list:

- `GET /integrations/allegro/connections/:id/responsible-producers` - was `@Roles('admin')` (the one the connection-edit UI calls).
- `GET /listings/connections/:connectionId/responsible-producers` - already `@Roles('admin', 'operator', 'viewer')` (#1608).

Connection read endpoints carry no role restriction, so operator/viewer can open the connection-edit page and render the seller-defaults section - but the admin-only producer GET then 403s via `RolesGuard`, surfaced verbatim as the alarming alert. This is OpenLinker's own role gate, not an Allegro OAuth-scope problem and not a raw Allegro 403.

## Changes

- `apps/api/src/integrations/http/allegro.controller.ts`: `listResponsibleProducers` role gate `@Roles('admin')` → `@Roles('admin', 'operator', 'viewer')`, matching its listings sibling and the connection-read audience.
- Writing the seller default (connection `PATCH`) stays `@Roles('admin')` - unchanged.

## Tests

- Unit: `@Roles` metadata assertion on `listResponsibleProducers` (mirrors the listings-controller #1608 test).
- Integration: a `viewer-role-authz` case asserting a viewer gets past the guard (not 403) on the endpoint.

## How to test

Open an Allegro connection-edit page as an operator or viewer: the "Responsible producer" section loads instead of showing "Insufficient permissions".

Closes #1707

🤖 Generated with [Claude Code](https://claude.com/claude-code)
