### PR TITLE
fix(listings): auto-retry bulk-wizard resolve step on transient failure

### DIFF
--- a/apps/web/src/features/inventory/hooks/use-inventory-availability-batch-query.test.tsx
+++ b/apps/web/src/features/inventory/hooks/use-inventory-availability-batch-query.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * useInventoryAvailabilityBatchQuery tests (#1709)
+ *
+ * Covers the optional retry passthrough added for the bulk-wizard resolve step:
+ * the shared hook keeps its no-retry default for every existing caller, and
+ * honours a caller-supplied retry policy when one is provided.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren, ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { createMockApiClient } from '../../../test/test-utils';
+import { ApiError } from '../../../shared/api/api-error';
+import { useInventoryAvailabilityBatchQuery } from './use-inventory-availability-batch-query';
+
+function createWrapper(
+  apiClient: ReturnType<typeof createMockApiClient>,
+): ({ children }: PropsWithChildren) => ReactElement {
+  // App-wide default is `retry: false`; a per-query retry option must win over it.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: PropsWithChildren): ReactElement {
+    return (
+      <ApiClientProvider client={apiClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </ApiClientProvider>
+    );
+  };
+}
+
+describe('useInventoryAvailabilityBatchQuery', () => {
+  it('keeps the no-retry default when no retry option is supplied', async () => {
+    const availability = vi.fn().mockRejectedValue(new ApiError('boom', 503, null));
+    const apiClient = createMockApiClient({ inventory: { availability } });
+
+    const { result } = renderHook(() => useInventoryAvailabilityBatchQuery(['var_1']), {
+      wrapper: createWrapper(apiClient),
+    });
+
+    await waitFor(() => { expect(result.current.isError).toBe(true); });
+    // No retry override -> a single call, matching the app-wide default.
+    expect(availability).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries per the supplied policy when a retry option is provided', async () => {
+    const availability = vi
+      .fn()
+      .mockRejectedValueOnce(new ApiError('boom', 503, null))
+      .mockResolvedValue({ items: [{ productVariantId: 'var_1', totalAvailable: 3, locationCount: 1 }] });
+    const apiClient = createMockApiClient({ inventory: { availability } });
+
+    const { result } = renderHook(
+      () => useInventoryAvailabilityBatchQuery(['var_1'], { retry: 1, retryDelay: 0 }),
+      { wrapper: createWrapper(apiClient) },
+    );
+
+    await waitFor(() => { expect(result.current.isSuccess).toBe(true); }, { timeout: 4000 });
+    expect(availability).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fire a request when the deduped id list is empty', () => {
+    const availability = vi.fn().mockResolvedValue({ items: [] });
+    const apiClient = createMockApiClient({ inventory: { availability } });
+
+    renderHook(() => useInventoryAvailabilityBatchQuery([], { retry: 3 }), {
+      wrapper: createWrapper(apiClient),
+    });
+
+    expect(availability).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/inventory/hooks/use-inventory-availability-batch-query.ts
+++ b/apps/web/src/features/inventory/hooks/use-inventory-availability-batch-query.ts
@@ -12,14 +12,27 @@
  *
  * @module apps/web/src/features/inventory/hooks
  */
-import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import {
+  useQuery,
+  type UseQueryResult,
+  type UseQueryOptions,
+} from '@tanstack/react-query';
 import { useApiClient } from '../../../app/api/api-client-provider';
 import { inventoryQueryKeys } from '../api/inventory.query-keys';
 import type { InventoryAvailabilityResponse } from '../api/inventory.types';
 
+interface UseInventoryAvailabilityBatchQueryOptions {
+  enabled?: boolean;
+  // Optional retry policy passthrough so callers (e.g. the bulk wizard resolve
+  // step) can self-heal a transient cold-start failure instead of dead-ending
+  // the whole step on the app-wide `retry: false` default.
+  retry?: UseQueryOptions<InventoryAvailabilityResponse>['retry'];
+  retryDelay?: UseQueryOptions<InventoryAvailabilityResponse>['retryDelay'];
+}
+
 export function useInventoryAvailabilityBatchQuery(
   productVariantIds: readonly string[],
-  options?: { enabled?: boolean }
+  options?: UseInventoryAvailabilityBatchQueryOptions
 ): UseQueryResult<InventoryAvailabilityResponse> {
   const apiClient = useApiClient();
   const deduped = [...new Set(productVariantIds)];
@@ -29,5 +42,7 @@ export function useInventoryAvailabilityBatchQuery(
     queryKey: inventoryQueryKeys.availability(deduped),
     queryFn: () => apiClient.inventory.availability(deduped),
     enabled,
+    ...(options?.retry !== undefined ? { retry: options.retry } : {}),
+    ...(options?.retryDelay !== undefined ? { retryDelay: options.retryDelay } : {}),
   });
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
@@ -8,10 +8,24 @@
 import { describe, expect, it, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { renderWithProviders, createMockApiClient } from '../../../../test/test-utils';
-import { BulkResolveStep, type BulkResolveOutcome } from './bulk-resolve-step';
+import { ApiError } from '../../../../shared/api/api-error';
+import {
+  BulkResolveStep,
+  shouldRetryTransient,
+  type BulkResolveOutcome,
+} from './bulk-resolve-step';
 import type { BulkWizardRow } from './bulk-wizard.types';
 import type { Product, ProductVariant } from '../../../products';
-import type { EanMatchResult } from '../../api/listings.types';
+import type {
+  EanMatchResult,
+  ResolveCategoriesBatchRequest,
+  ResolveCategoriesBatchResponse,
+} from '../../api/listings.types';
+
+type ResolveCategoriesBatchFn = (
+  connectionId: string,
+  body: ResolveCategoriesBatchRequest,
+) => Promise<ResolveCategoriesBatchResponse>;
 
 function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
   return {
@@ -63,14 +77,26 @@ function makeRow(productId: string, variant: Partial<ProductVariant>, product: P
 function mockClient(opts: {
   results?: Record<string, EanMatchResult>;
   availability?: Array<{ productVariantId: string; totalAvailable: number; locationCount: number }>;
-  categoryRejects?: boolean;
-}) {
+  /** Reject every category call with this error (persistent failure). */
+  categoryError?: Error;
+  /** Reject the first N category calls with this error, then resolve `results`. */
+  categoryTransientError?: { error: Error; failures: number };
+}): ReturnType<typeof createMockApiClient> {
+  const resolveCategoriesBatch = vi.fn<ResolveCategoriesBatchFn>();
+  if (opts.categoryError) {
+    resolveCategoriesBatch.mockRejectedValue(opts.categoryError);
+  } else if (opts.categoryTransientError) {
+    const { error, failures } = opts.categoryTransientError;
+    for (let i = 0; i < failures; i += 1) {
+      resolveCategoriesBatch.mockRejectedValueOnce(error);
+    }
+    resolveCategoriesBatch.mockResolvedValue({ results: opts.results ?? {} });
+  } else {
+    resolveCategoriesBatch.mockResolvedValue({ results: opts.results ?? {} });
+  }
+
   return createMockApiClient({
-    listings: {
-      resolveCategoriesBatch: opts.categoryRejects
-        ? vi.fn().mockRejectedValue(new Error('Allegro 503'))
-        : vi.fn().mockResolvedValue({ results: opts.results ?? {} }),
-    },
+    listings: { resolveCategoriesBatch },
     inventory: {
       availability: vi.fn().mockResolvedValue({ items: opts.availability ?? [] }),
     },
@@ -250,9 +276,9 @@ describe('BulkResolveStep', () => {
     });
   });
 
-  it('shows a Retry affordance and does not advance when the batch call fails', async () => {
+  it('fails fast on a hard 4xx: shows the Retry affordance, does not retry, does not advance', async () => {
     const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
-    const apiClient = mockClient({ categoryRejects: true });
+    const apiClient = mockClient({ categoryError: new ApiError('Bad request', 400, null) });
 
     renderWithProviders(
       <BulkResolveStep
@@ -267,6 +293,56 @@ describe('BulkResolveStep', () => {
     );
 
     expect(await screen.findByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    // A 4xx is not transient - the single call is never retried.
+    expect(apiClient.listings.resolveCategoriesBatch).toHaveBeenCalledTimes(1);
     expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('auto-retries a transient 5xx and advances on the eventual success (no manual refresh)', async () => {
+    const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
+    const apiClient = mockClient({
+      categoryTransientError: { error: new ApiError('Allegro 503', 503, null), failures: 1 },
+      results: { var_prod_a: { kind: 'matched', allegroCategoryId: 'cat-A', productCardId: 'card-A' } },
+      availability: [{ productVariantId: 'var_prod_a', totalAvailable: 5, locationCount: 1 }],
+    });
+
+    renderWithProviders(
+      <BulkResolveStep
+        rows={[makeRow('prod_a', { ean: '590' })]}
+        connectionId="conn_1"
+        pricingPolicy={{ mode: 'use-master' }}
+        stockPolicy={{ mode: 'use-master' }}
+        currency="PLN"
+        onComplete={onComplete}
+      />,
+      { apiClient },
+    );
+
+    // First call rejects (503, transient), the query retries after its backoff
+    // and the second call resolves - the step advances without operator action.
+    await waitFor(() => { expect(onComplete).toHaveBeenCalledTimes(1); }, { timeout: 6000 });
+    expect(apiClient.listings.resolveCategoriesBatch).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+    expect(onComplete.mock.calls[0][0][0].blockers.length).toBe(0);
+  }, 10000);
+});
+
+describe('shouldRetryTransient', () => {
+  it('retries transient conditions (timeout/network, 429, 5xx) up to the cap', () => {
+    expect(shouldRetryTransient(0, new ApiError('timeout', 0, null))).toBe(true);
+    expect(shouldRetryTransient(0, new ApiError('rate limited', 429, null))).toBe(true);
+    expect(shouldRetryTransient(0, new ApiError('boom', 503, null))).toBe(true);
+    // A non-ApiError (unexpected throw) is treated as transient.
+    expect(shouldRetryTransient(0, new Error('unknown'))).toBe(true);
+  });
+
+  it('does not retry hard client errors (4xx other than 429)', () => {
+    expect(shouldRetryTransient(0, new ApiError('bad request', 400, null))).toBe(false);
+    expect(shouldRetryTransient(0, new ApiError('not found', 404, null))).toBe(false);
+    expect(shouldRetryTransient(0, new ApiError('conflict', 409, null))).toBe(false);
+  });
+
+  it('stops retrying once the failure count reaches the cap', () => {
+    expect(shouldRetryTransient(3, new ApiError('boom', 503, null))).toBe(false);
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useRef, type ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Alert, Button } from '../../../../shared/ui';
 import { useApiClient } from '../../../../app/api/api-client-provider';
+import { ApiError } from '../../../../shared/api/api-error';
 import { useInventoryAvailabilityBatchQuery } from '../../../inventory';
 import type { OfferRowValidationInput } from '../../../../shared/plugins';
 import { listingsQueryKeys } from '../../api/listings.query-keys';
@@ -58,6 +59,29 @@ interface BulkResolveStepProps {
   destinationResolvesCategoryAtSubmit?: boolean;
   /** Called once with the resolved outcomes for every row, on settle. */
   onComplete: (outcomes: BulkResolveOutcome[]) => void;
+}
+
+const RESOLVE_MAX_RETRIES = 3;
+
+/**
+ * Retry only transient conditions - request timeout / network drop (status 0),
+ * rate-limit (429), or a 5xx. The first Allegro `resolve-categories-batch` call
+ * on a cold connection (OAuth-token exchange + `/sale/products`) can time out or
+ * 5xx once; the app-wide `retry: false` default would otherwise dead-end the
+ * whole resolve step, forcing a manual page reload to warm the token and retry.
+ * A genuine 4xx (bad request, not-found) won't heal by retrying, so it fails fast.
+ */
+export function shouldRetryTransient(failureCount: number, error: Error): boolean {
+  if (failureCount >= RESOLVE_MAX_RETRIES) return false;
+  if (error instanceof ApiError) {
+    return error.isNetworkError() || error.status === 429 || error.isServerError();
+  }
+  return true;
+}
+
+/** Exponential backoff capped at 8s. */
+function resolveRetryDelay(attemptIndex: number): number {
+  return Math.min(1000 * 2 ** attemptIndex, 8000);
 }
 
 function barcodeOf(row: BulkWizardRow): string | null {
@@ -103,9 +127,14 @@ export function BulkResolveStep({
     queryKey: listingsQueryKeys.resolveCategoryBatch(connectionId, resolveVariantIds),
     queryFn: () => apiClient.listings.resolveCategoriesBatch(connectionId, { items: resolveItems }),
     enabled: resolveItems.length > 0,
+    retry: shouldRetryTransient,
+    retryDelay: resolveRetryDelay,
   });
 
-  const availabilityQuery = useInventoryAvailabilityBatchQuery(variantIds);
+  const availabilityQuery = useInventoryAvailabilityBatchQuery(variantIds, {
+    retry: shouldRetryTransient,
+    retryDelay: resolveRetryDelay,
+  });
 
   const categoryReady = resolveItems.length === 0 || categoryQuery.isSuccess;
   const availabilityReady = variantIds.length === 0 || availabilityQuery.isSuccess;


### PR DESCRIPTION
## What & why

In the bulk offer creation wizard, advancing from Config to the "Resolving" step often fails to load products on the **first** attempt, forcing the operator to manually refresh the page (which resets the wizard to Config) and redo the step before it works.

The "Resolving" step (`bulk-resolve-step.tsx`) is a transient spinner that only auto-advances to the product table once **both** batch queries succeed exactly once:
1. `categoryQuery` - Allegro `resolve-categories-batch` (`/sale/products` GTIN + category-mapping lookup)
2. `availabilityQuery` - `GET /inventory/availability`

Both inherited the app-wide `retry: false` default (`app-providers.tsx`). The first Allegro call on a cold connection (OAuth-token exchange + `/sale/products`) can time out or return a transient 5xx/429 once; with `retry: false` that single failure dead-ends the whole step. A full page reload warms the token/cache, which is exactly why "refresh fixes it".

## Change

- Add a narrow, transient-only auto-retry to both resolve-step queries: retries only request timeout / network drop (`ApiError` status 0), `429`, or `5xx`, up to 3 times with exponential backoff capped at 8s. Genuine 4xx (400/404/409) still fail fast and surface the existing Retry affordance.
- Extend `useInventoryAvailabilityBatchQuery` with backward-compatible optional `retry` / `retryDelay` passthrough - every other caller (e.g. `WoocommercePublishWizard`) keeps the no-retry default.
- `docs/frontend-architecture.md` § Async UX Conventions allows retries where "a feature explicitly justifies retries"; a single blocking gate on a cold third-party OAuth call is that justification. The app-wide `retry: false` default is unchanged.

The one-shot `completedRef` advance gate is left as-is: it stays `false` until the first success, so the auto-retry (or the manual Retry button) that eventually succeeds still advances correctly.

## Testing

- `pnpm --filter @openlinker/web type-check` and `eslint` (changed files) pass with zero errors/warnings.
- New/updated unit tests (13 in the two changed suites, 89 across `bulk` + `inventory`):
  - transient 5xx -> auto-retry -> success advances (no manual refresh)
  - hard 4xx -> no retry -> error screen + Retry affordance
  - `shouldRetryTransient` decision matrix (transient/429/5xx/non-ApiError -> retry; 4xx -> no; cap at 3)
  - hook keeps no-retry default when options omitted; honours a supplied retry policy; skips request on empty id list
- Verified live on the demo stack: the resolve step now self-advances to the product table without a manual reload.

Closes #1709
