### PR TITLE
fix(ksef): gate numbering demo mode via useWriteAccess, keep nav open (#1705)

### DIFF
--- a/apps/web/src/plugins/ksef/components/ksef-connection-actions.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-connection-actions.tsx
@@ -16,12 +16,10 @@ import { KsefNumberingActions } from './ksef-numbering-actions';
 
 interface KsefConnectionActionsProps {
   connection: Connection;
-  readOnly?: boolean;
 }
 
 export function KsefConnectionActions({
   connection,
-  readOnly = false,
 }: KsefConnectionActionsProps): ReactElement {
-  return <KsefNumberingActions connection={connection} readOnly={readOnly} />;
+  return <KsefNumberingActions connection={connection} />;
 }

--- a/apps/web/src/plugins/ksef/components/ksef-numbering-actions.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-numbering-actions.test.tsx
@@ -3,8 +3,10 @@
  *
  * The row is KSeF-only by construction (it rides the KSeF plugin's
  * `ConnectionActions` slot). These tests cover its inline status derived from
- * the connection's numbering routes: "not set up yet" when unrouted, the routed
- * count when configured, and the read-only disabled CTA.
+ * the connection's numbering routes: "not set up yet" when unrouted and the
+ * routed count when configured. The CTA is pure navigation into the numbering
+ * page, so it stays a live link in every mode (the read-only gate lives on the
+ * save inside the editor, not here).
  *
  * @module plugins/ksef/components
  */
@@ -54,16 +56,19 @@ describe('KsefNumberingActions', () => {
     );
   });
 
-  it('disables the CTA in read-only mode', async () => {
+  it('keeps the CTA a live link (navigation is never gated)', async () => {
     const apiClient = createMockApiClient({
       invoiceNumbering: {
         listRoutes: vi.fn().mockResolvedValue([route]),
       },
     });
-    renderWithProviders(<KsefNumberingActions connection={ksefConnection} readOnly />, { apiClient });
+    renderWithProviders(<KsefNumberingActions connection={ksefConnection} />, { apiClient });
 
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Configure…' })).toBeDisabled(),
+      expect(screen.getByRole('link', { name: 'Configure…' })).toHaveAttribute(
+        'href',
+        `/connections/${ksefConnection.id}/numbering`,
+      ),
     );
   });
 });

--- a/apps/web/src/plugins/ksef/components/ksef-numbering-actions.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-numbering-actions.tsx
@@ -10,24 +10,23 @@
  * status query is in flight it shows a skeleton rather than flashing an empty
  * tail. The primary button opens the dedicated numbering page.
  *
+ * This is pure navigation, never a write, so it stays a live link even for a
+ * demo viewer — the read-only gate lives on the final save inside the numbering
+ * editor, not on the door into it.
+ *
  * @module plugins/ksef/components
  */
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { useNumberingRoutesQuery } from '../../../features/invoicing';
 import type { Connection } from '../../../features/connections';
-import { Button } from '../../../shared/ui/button';
-import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
-import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
 
 interface KsefNumberingActionsProps {
   connection: Connection;
-  readOnly?: boolean;
 }
 
 export function KsefNumberingActions({
   connection,
-  readOnly = false,
 }: KsefNumberingActionsProps): ReactElement {
   const routesQuery = useNumberingRoutesQuery(connection.id);
   const routeCount = routesQuery.data?.length ?? 0;
@@ -52,17 +51,9 @@ export function KsefNumberingActions({
           )}
         </p>
       </div>
-      {readOnly ? (
-        <ReadOnlyLock active message={DEMO_READ_ONLY_ACTION_MESSAGE}>
-          <Button tone={configured ? 'secondary' : 'primary'} disabled>
-            {configured ? 'Configure…' : 'Set up…'}
-          </Button>
-        </ReadOnlyLock>
-      ) : (
-        <Link className={`button button--${configured ? 'secondary' : 'primary'}`} to={to}>
-          {configured ? 'Configure…' : 'Set up…'}
-        </Link>
-      )}
+      <Link className={`button button--${configured ? 'secondary' : 'primary'}`} to={to}>
+        {configured ? 'Configure…' : 'Set up…'}
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/plugins/ksef/components/ksef-numbering-editor.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-numbering-editor.tsx
@@ -24,11 +24,13 @@ import {
   type ResetPolicy,
 } from '../../../features/invoicing';
 import { ApiError } from '../../../shared/api/api-error';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
 import { Select } from '../../../shared/ui/select';
 import { useToast } from '../../../shared/ui/toast-provider';
 import { useMediaQuery } from '../../../shared/ui/use-media-query';
@@ -55,6 +57,8 @@ interface KsefNumberingEditorProps {
   series?: NumberingSeries;
   /** Create-mode prefill from a routing row ("Add a series first"). */
   createPrefill?: { documentType?: DocumentType; register?: string | null };
+  /** Demo viewer — the form is explorable but the final save is blocked. */
+  readOnly?: boolean;
   onDone: () => void;
   onCancel: () => void;
 }
@@ -74,6 +78,7 @@ export function KsefNumberingEditor({
   connectionId: _connectionId,
   series,
   createPrefill,
+  readOnly = false,
   onDone,
   onCancel,
 }: KsefNumberingEditorProps): ReactElement {
@@ -345,9 +350,11 @@ export function KsefNumberingEditor({
           <Button type="button" tone="secondary" onClick={onCancel} disabled={isPending}>
             Cancel
           </Button>
-          <Button type="submit" tone="primary" disabled={isPending}>
-            {isPending ? 'Saving…' : 'Save series'}
-          </Button>
+          <ReadOnlyLock active={readOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+            <Button type="submit" tone="primary" disabled={isPending || readOnly}>
+              {isPending ? 'Saving…' : 'Save series'}
+            </Button>
+          </ReadOnlyLock>
         </div>
       </form>
 

--- a/apps/web/src/plugins/ksef/components/ksef-numbering-page.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-numbering-page.tsx
@@ -6,7 +6,9 @@
  * gap audit). Reached only for a KSeF connection (the route is contributed by
  * the KSeF plugin), so the capability gate is the plugin boundary itself — no
  * platformType literal here. The active tab is URL state (`?tab=`), and the
- * write affordances degrade to read-only in demo mode.
+ * write affordances degrade to read-only only for a demo viewer — a session
+ * holding `invoices:write` (admin) keeps full access even in demo mode, per
+ * the app-wide `useWriteAccess` convention (#1615).
  *
  * @module plugins/ksef/components
  */
@@ -16,6 +18,7 @@ import { useConnectionQuery } from '../../../features/connections';
 import { PageLayout } from '../../../shared/ui/page-layout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../../shared/ui/tabs';
 import { useDemoMode } from '../../../features/system';
+import { useWriteAccess } from '../../../shared/auth/use-permission';
 import { KsefNumberingAuditTab } from './ksef-numbering-audit-tab';
 import { KsefNumberingSeriesTab } from './ksef-numbering-series-tab';
 
@@ -29,7 +32,8 @@ function isTabValue(value: string | null): value is TabValue {
 export function KsefNumberingPage(): ReactElement {
   const { connectionId = '' } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
-  const isDemoMode = useDemoMode();
+  const demoMode = useDemoMode();
+  const readOnly = useWriteAccess('invoices:write', demoMode).demoReadOnly;
 
   const connectionQuery = useConnectionQuery(connectionId);
   const connectionName = connectionQuery.data?.name;
@@ -64,10 +68,10 @@ export function KsefNumberingPage(): ReactElement {
           <TabsTrigger value="audit">Number audit</TabsTrigger>
         </TabsList>
         <TabsContent value="series">
-          <KsefNumberingSeriesTab connectionId={connectionId} readOnly={isDemoMode} />
+          <KsefNumberingSeriesTab connectionId={connectionId} readOnly={readOnly} />
         </TabsContent>
         <TabsContent value="audit">
-          <KsefNumberingAuditTab connectionId={connectionId} readOnly={isDemoMode} />
+          <KsefNumberingAuditTab connectionId={connectionId} readOnly={readOnly} />
         </TabsContent>
       </Tabs>
     </PageLayout>

--- a/apps/web/src/plugins/ksef/components/ksef-numbering-routing-card.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-numbering-routing-card.tsx
@@ -252,7 +252,6 @@ export function KsefNumberingRoutingCard({
                             register: row.register,
                           })
                         }
-                        disabled={readOnly}
                       >
                         Add a series first
                       </button>

--- a/apps/web/src/plugins/ksef/components/ksef-numbering-series-tab.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-numbering-series-tab.tsx
@@ -77,6 +77,7 @@ export function KsefNumberingSeriesTab({
         connectionId={connectionId}
         series={mode.kind === 'edit' ? mode.series : undefined}
         createPrefill={mode.kind === 'create' ? mode.prefill : undefined}
+        readOnly={readOnly}
         onDone={backToList}
         onCancel={backToList}
       />
@@ -123,7 +124,7 @@ export function KsefNumberingSeriesTab({
           title="No numbering series yet"
           message="Create a series before issuing invoices — KSeF needs a unique, sequential number for every document."
           action={
-            <Button tone="primary" onClick={() => setMode({ kind: 'create' })} disabled={readOnly}>
+            <Button tone="primary" onClick={() => setMode({ kind: 'create' })}>
               Add series
             </Button>
           }
@@ -164,7 +165,7 @@ export function KsefNumberingSeriesTab({
               </Select>
             </>
           ) : null}
-          <Button tone="primary" onClick={() => setMode({ kind: 'create' })} disabled={readOnly}>
+          <Button tone="primary" onClick={() => setMode({ kind: 'create' })}>
             Add series
           </Button>
         </div>
@@ -201,7 +202,7 @@ export function KsefNumberingSeriesTab({
                 <td className="mono-text tabular">{nextNumber(s)}</td>
                 <td>{RESET_POLICY_LABELS[s.resetPolicy]}</td>
                 <td className="numbering-table__actions">
-                  <Button tone="secondary" onClick={() => setMode({ kind: 'edit', series: s })} disabled={readOnly}>
+                  <Button tone="secondary" onClick={() => setMode({ kind: 'edit', series: s })}>
                     Edit
                   </Button>
                 </td>


### PR DESCRIPTION
## What & why

In demo mode the KSeF **Invoice numbering** UI was locked down far beyond intent. Demo mode should block only the **final write** for a demo **viewer** (a session without `invoices:write`); a demo **admin** (who holds `invoices:write`) must keep full access, and navigation must never be gated.

This brings the surface in line with the app-wide `useWriteAccess` convention: gate only the final write for demo viewers, exempt admins, never gate navigation.

## Changes

- **`ksef-numbering-page.tsx`** — compute `readOnly` via `useWriteAccess('invoices:write', demoMode).demoReadOnly` instead of raw `useDemoMode()`, so a demo admin keeps access. Thread it into both tabs.
- **`ksef-numbering-actions.tsx` / `ksef-connection-actions.tsx`** — "Set up…"/"Configure…" is pure navigation; always render the live `<Link>`. Dropped the `readOnly` prop from this row.
- **`ksef-numbering-series-tab.tsx`** — "Add series", "Edit" stay enabled; `readOnly` threaded only into the editor + routing card.
- **`ksef-numbering-editor.tsx`** — gate the "Save series" submit with `disabled={isPending || readOnly}` wrapped in `ReadOnlyLock` + `DEMO_READ_ONLY_ACTION_MESSAGE`. `readOnly` is **optional** (default `false`) so the existing editor test compiles under `vite build`.
- **`ksef-numbering-routing-card.tsx`** — routing `<Select>` stays gated (the final write); "Add a series first" entry un-gated.
- **`ksef-numbering-actions.test.tsx`** — the "disables the CTA in read-only mode" case replaced with one asserting the CTA is always a live link.

## Verification

- `pnpm --filter @openlinker/web build` succeeds (full `tsc -b` incl. test files), not only `type-check`.
- `ksef-numbering-actions.test.tsx` passes (3/3), asserting the CTA stays a live link.
- ESLint clean on all changed files.

Closes #1705

🤖 Generated with [Claude Code](https://claude.com/claude-code)