### PR TITLE
feat(orders): responsive orders-table redesign + deep links, invoicing status & empty-state actions

### DIFF
--- a/apps/api/src/orders/http/dto/order-invoice-projection.dto.ts
+++ b/apps/api/src/orders/http/dto/order-invoice-projection.dto.ts
@@ -11,6 +11,7 @@
  */
 import { ApiProperty } from '@nestjs/swagger';
 import {
+  DocumentTypeValues,
   InvoiceStatus,
   InvoiceStatusValues,
   RegulatoryStatus,
@@ -23,6 +24,13 @@ export class OrderInvoiceProjectionDto {
       'Internal invoice record id the UPO download endpoint (GET /invoices/:invoiceId/upo) keys on.',
   })
   invoiceId!: string;
+
+  @ApiProperty({
+    enum: DocumentTypeValues,
+    description:
+      'Neutral document type (open-world). Correction documents (`corrected` / `credit-note`) are distinguished from a plain `invoice` so the FE can label them.',
+  })
+  documentType!: string;
 
   @ApiProperty({
     enum: InvoiceStatusValues,

--- a/apps/api/src/orders/http/dto/order-invoice-projection.dto.ts
+++ b/apps/api/src/orders/http/dto/order-invoice-projection.dto.ts
@@ -10,7 +10,12 @@
  * @module apps/api/src/orders/http/dto
  */
 import { ApiProperty } from '@nestjs/swagger';
-import { RegulatoryStatus, RegulatoryStatusValues } from '@openlinker/core/invoicing';
+import {
+  InvoiceStatus,
+  InvoiceStatusValues,
+  RegulatoryStatus,
+  RegulatoryStatusValues,
+} from '@openlinker/core/invoicing';
 
 export class OrderInvoiceProjectionDto {
   @ApiProperty({
@@ -18,6 +23,13 @@ export class OrderInvoiceProjectionDto {
       'Internal invoice record id the UPO download endpoint (GET /invoices/:invoiceId/upo) keys on.',
   })
   invoiceId!: string;
+
+  @ApiProperty({
+    enum: InvoiceStatusValues,
+    description:
+      'Issue lifecycle status of the invoice document (pending → issuing → issued | failed).',
+  })
+  status!: InvoiceStatus;
 
   @ApiProperty({
     enum: RegulatoryStatusValues,

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -68,6 +68,7 @@ describe('OrdersController', () => {
     const mockInvoiceService: jest.Mocked<IInvoiceService> = {
       getInvoiceById: jest.fn(),
       getLatestInvoiceForOrder: jest.fn(),
+      getLatestInvoicesForOrders: jest.fn().mockResolvedValue([]),
       issueInvoice: jest.fn(),
       getInvoice: jest.fn(),
       issueCorrection: jest.fn(),
@@ -380,6 +381,7 @@ describe('OrdersController', () => {
 
       expect(result.orderSnapshot.invoice).toEqual({
         invoiceId: 'rec-inv-1',
+        status: 'issued',
         regulatoryStatus: 'accepted',
         clearanceReference: '5265877635-20250826-0100001AF629-AF',
         confirmationDocumentAvailable: true,

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -381,6 +381,7 @@ describe('OrdersController', () => {
 
       expect(result.orderSnapshot.invoice).toEqual({
         invoiceId: 'rec-inv-1',
+        documentType: 'invoice',
         status: 'issued',
         regulatoryStatus: 'accepted',
         clearanceReference: '5265877635-20250826-0100001AF629-AF',

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -200,9 +200,10 @@ export class OrdersController {
       throw new NotFoundException(`Order not found: ${internalOrderId}`);
     }
     const dto = this.toDto(order);
-    // Order-detail-only invoice projection (#1224): the FE invoice panel reads a
-    // neutral `invoice` sub-tree off the snapshot. Joined on the detail read only
-    // (the list endpoint stays a single query — no N+1).
+    // Invoice projection (#1224): the FE invoice panel reads a neutral `invoice`
+    // sub-tree off the snapshot. The list endpoint now shares the same projection
+    // via a batch read (`getLatestInvoicesForOrders`, one query per page — #1713);
+    // this detail read joins the single record for one order.
     const invoiceRecord = await this.invoiceService.getLatestInvoiceForOrder(
       order.internalOrderId
     );
@@ -292,6 +293,7 @@ export class OrdersController {
     const confirmationDocumentAvailable = record.status === 'issued' && record.regulatoryStatus === 'accepted';
     return {
       invoiceId: record.id,
+      documentType: record.documentType,
       status: record.status,
       regulatoryStatus: record.regulatoryStatus,
       clearanceReference: record.clearanceReference,

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -112,8 +112,24 @@ export class OrdersController {
       { limit, offset }
     );
 
+    // Batch the invoice projection for the whole page (#1713): one query, not an
+    // N+1 of per-row `getLatestInvoiceForOrder`. Orders with no invoice are
+    // absent from the map and simply carry no `invoice` sub-tree — the FE then
+    // shows the "Issue invoice" action instead of a status pill.
+    const invoices = await this.invoiceService.getLatestInvoicesForOrders(
+      items.map((order) => order.internalOrderId)
+    );
+    const invoiceByOrderId = new Map(invoices.map((invoice) => [invoice.orderId, invoice]));
+
     return {
-      items: items.map((order) => this.toDto(order)),
+      items: items.map((order) => {
+        const dto = this.toDto(order);
+        const invoice = invoiceByOrderId.get(order.internalOrderId);
+        if (invoice) {
+          dto.orderSnapshot = { ...dto.orderSnapshot, invoice: this.toInvoiceProjection(invoice) };
+        }
+        return dto;
+      }),
       total,
       limit,
       offset,
@@ -276,6 +292,7 @@ export class OrdersController {
     const confirmationDocumentAvailable = record.status === 'issued' && record.regulatoryStatus === 'accepted';
     return {
       invoiceId: record.id,
+      status: record.status,
       regulatoryStatus: record.regulatoryStatus,
       clearanceReference: record.clearanceReference,
       confirmationDocumentAvailable,

--- a/apps/api/test/integration/invoicing/invoice-record-repository.int-spec.ts
+++ b/apps/api/test/integration/invoicing/invoice-record-repository.int-spec.ts
@@ -379,9 +379,22 @@ describe('invoice_records persistence (integration)', () => {
       const repository = new InvoiceRecordRepository(repo);
       await repo.save(claimRow({ orderId: 'ol_o1', status: 'issued' }));
       await repo.save(claimRow({ orderId: 'ol_o2', status: 'failed' }));
-      // Two records for the same order → DISTINCT ON collapses to one.
-      await repo.save(claimRow({ orderId: 'ol_o3', status: 'pending' }));
-      await repo.save(claimRow({ orderId: 'ol_o3', status: 'issued' }));
+      // Two records for the same order with EXPLICIT distinct createdAt (older
+      // then newer) → DISTINCT ON must keep the NEWEST, proving latest-per-order.
+      await repo.save(
+        claimRow({
+          orderId: 'ol_o3',
+          status: 'pending',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      );
+      await repo.save(
+        claimRow({
+          orderId: 'ol_o3',
+          status: 'issued',
+          createdAt: new Date('2026-01-02T00:00:00.000Z'),
+        }),
+      );
 
       const results = await repository.findLatestByOrderIds([
         'ol_o1',
@@ -395,8 +408,8 @@ describe('invoice_records persistence (integration)', () => {
       expect(byOrder.has('ol_missing')).toBe(false);
       expect(byOrder.get('ol_o1')?.status).toBe('issued');
       expect(byOrder.get('ol_o2')?.status).toBe('failed');
-      // Exactly one ol_o3 row survives the dedup; its status is one of the two saved.
-      expect(['pending', 'issued']).toContain(byOrder.get('ol_o3')?.status);
+      // The newer ol_o3 row wins — latest-per-order.
+      expect(byOrder.get('ol_o3')?.status).toBe('issued');
     });
 
     it('returns [] for an empty input', async () => {

--- a/apps/api/test/integration/invoicing/invoice-record-repository.int-spec.ts
+++ b/apps/api/test/integration/invoicing/invoice-record-repository.int-spec.ts
@@ -373,4 +373,35 @@ describe('invoice_records persistence (integration)', () => {
       });
     });
   });
+
+  describe('findLatestByOrderIds — batch latest-per-order (#1713)', () => {
+    it('returns at most one (latest) record per order and omits orders with none', async () => {
+      const repository = new InvoiceRecordRepository(repo);
+      await repo.save(claimRow({ orderId: 'ol_o1', status: 'issued' }));
+      await repo.save(claimRow({ orderId: 'ol_o2', status: 'failed' }));
+      // Two records for the same order → DISTINCT ON collapses to one.
+      await repo.save(claimRow({ orderId: 'ol_o3', status: 'pending' }));
+      await repo.save(claimRow({ orderId: 'ol_o3', status: 'issued' }));
+
+      const results = await repository.findLatestByOrderIds([
+        'ol_o1',
+        'ol_o2',
+        'ol_o3',
+        'ol_missing',
+      ]);
+
+      const byOrder = new Map(results.map((r) => [r.orderId, r]));
+      expect(byOrder.size).toBe(3);
+      expect(byOrder.has('ol_missing')).toBe(false);
+      expect(byOrder.get('ol_o1')?.status).toBe('issued');
+      expect(byOrder.get('ol_o2')?.status).toBe('failed');
+      // Exactly one ol_o3 row survives the dedup; its status is one of the two saved.
+      expect(['pending', 'issued']).toContain(byOrder.get('ol_o3')?.status);
+    });
+
+    it('returns [] for an empty input', async () => {
+      const repository = new InvoiceRecordRepository(repo);
+      expect(await repository.findLatestByOrderIds([])).toEqual([]);
+    });
+  });
 });

--- a/apps/api/test/integration/order-column-sort.int-spec.ts
+++ b/apps/api/test/integration/order-column-sort.int-spec.ts
@@ -186,4 +186,29 @@ describe('Order column sort (integration)', () => {
       synced.internalOrderId, // 3
     ]);
   });
+
+  it('sorts by payment status ascending (alphabetical), NULLs last (#1713)', async () => {
+    const ds = harness.getDataSource();
+    const paid = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [], paymentStatus: 'paid' },
+    });
+    const awaiting = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [], paymentStatus: 'awaiting' },
+    });
+    const noPayment = await createTestOrderRecord(ds, {
+      sourceConnectionId: SOURCE,
+      orderSnapshot: { items: [] },
+    });
+
+    const { items } = await repository.findMany({ sort: 'payment', dir: 'asc' }, PAGE);
+
+    // Alphabetical: awaiting < paid; the order with no paymentStatus sorts last.
+    expect(items.map((o) => o.internalOrderId)).toEqual([
+      awaiting.internalOrderId,
+      paid.internalOrderId,
+      noPayment.internalOrderId, // NULLs last
+    ]);
+  });
 });

--- a/apps/web/src/features/invoicing/components/invoice-pdf-link.tsx
+++ b/apps/web/src/features/invoicing/components/invoice-pdf-link.tsx
@@ -15,17 +15,7 @@
  */
 import type { ReactElement } from 'react';
 import { useTranslation } from '../../../shared/i18n';
-
-/** True only for `http:` / `https:` absolute URLs. Rejects `javascript:`,
- *  `data:`, `vbscript:`, relative / garbage strings, and whitespace-prefixed
- *  payloads (`new URL().protocol` is the stricter form). */
-export function isSafeHttpUrl(value: string): boolean {
-  try {
-    return ['http:', 'https:'].includes(new URL(value).protocol);
-  } catch {
-    return false;
-  }
-}
+import { isSafeHttpUrl } from '../../../shared/lib/is-safe-http-url';
 
 interface InvoicePdfLinkProps {
   invoiceNumber: string | null;

--- a/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
@@ -228,6 +228,32 @@ describe('parseOrderSnapshot', () => {
     expect(parsed.parseWarnings).toHaveLength(0);
   });
 
+  it('parses the invoice projection when present, warns on a malformed one (#1713)', () => {
+    const parsed = parseOrderSnapshot({
+      invoice: {
+        invoiceId: 'rec-1',
+        status: 'issued',
+        regulatoryStatus: 'accepted',
+        clearanceReference: 'KSEF-123',
+        confirmationDocumentAvailable: true,
+      },
+    });
+    expect(parsed.invoice).toEqual({
+      invoiceId: 'rec-1',
+      status: 'issued',
+      regulatoryStatus: 'accepted',
+      clearanceReference: 'KSEF-123',
+      confirmationDocumentAvailable: true,
+    });
+
+    expect(parseOrderSnapshot({}).invoice).toBeUndefined();
+
+    // A malformed invoice sub-tree is dropped with a warning, never crashes.
+    const bad = parseOrderSnapshot({ invoice: { invoiceId: 'x', status: 'bogus' } });
+    expect(bad.invoice).toBeUndefined();
+    expect(bad.parseWarnings.some((w) => w.field === 'invoice')).toBe(true);
+  });
+
   it('reads the source deep link when present and omits it otherwise (#1713)', () => {
     const withUrl = parseOrderSnapshot({
       sourceExternalUrl: 'https://salescenter.allegro.pl/orders/abc',

--- a/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
@@ -227,4 +227,16 @@ describe('parseOrderSnapshot', () => {
     expect(parsed.items[0]?.id).toBe('i1');
     expect(parsed.parseWarnings).toHaveLength(0);
   });
+
+  it('reads the source deep link when present and omits it otherwise (#1713)', () => {
+    const withUrl = parseOrderSnapshot({
+      sourceExternalUrl: 'https://salescenter.allegro.pl/orders/abc',
+    });
+    expect(withUrl.sourceExternalUrl).toBe('https://salescenter.allegro.pl/orders/abc');
+
+    expect(parseOrderSnapshot({}).sourceExternalUrl).toBeUndefined();
+    // A non-string / empty value is treated as absent, never crashes.
+    expect(parseOrderSnapshot({ sourceExternalUrl: '' }).sourceExternalUrl).toBeUndefined();
+    expect(parseOrderSnapshot({ sourceExternalUrl: 42 }).sourceExternalUrl).toBeUndefined();
+  });
 });

--- a/apps/web/src/features/orders/api/order-snapshot.schema.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.ts
@@ -101,6 +101,38 @@ const codToCollectSchema = z.object({
   currency: z.string(),
 });
 
+/**
+ * Invoice lifecycle values — hand-mirrored from `InvoiceStatusValues` /
+ * `RegulatoryStatusValues` in `@openlinker/core/invoicing` per the FE-001
+ * contract strategy. `status` is the issue lifecycle, `regulatoryStatus` the
+ * neutral CTC clearance lifecycle. Keep in sync with the core unions.
+ */
+export const InvoiceStatusValues = ['pending', 'issuing', 'issued', 'failed'] as const;
+export type InvoiceStatus = (typeof InvoiceStatusValues)[number];
+export const RegulatoryStatusValues = [
+  'not-applicable',
+  'submitted',
+  'cleared',
+  'accepted',
+  'rejected',
+] as const;
+export type RegulatoryStatus = (typeof RegulatoryStatusValues)[number];
+
+/**
+ * Order invoice projection (#1224/#1713) — merged onto `orderSnapshot.invoice`
+ * by the API (order-detail read AND, since #1713, the orders-list read). Drives
+ * the invoice-status pill / "Issue invoice" action and the accordion clearance
+ * reference. Absent ⇒ no invoice record yet.
+ */
+const orderInvoiceSchema = z.object({
+  invoiceId: z.string(),
+  status: z.enum(InvoiceStatusValues),
+  regulatoryStatus: z.enum(RegulatoryStatusValues),
+  clearanceReference: z.string().nullish(),
+  confirmationDocumentAvailable: z.boolean().optional(),
+});
+export type ParsedOrderInvoice = z.infer<typeof orderInvoiceSchema>;
+
 export type ParsedOrderItem = z.infer<typeof orderItemSchema>;
 export type ParsedAddress = z.infer<typeof addressSchema>;
 export type ParsedOrderTotals = z.infer<typeof orderTotalsSchema>;
@@ -165,6 +197,8 @@ export interface ParsedOrderSnapshot {
   pickupPoint?: ParsedOrderPickupPoint;
   /** Source-reported payment status (#928); absent when the source didn't report it. */
   paymentStatus?: PaymentStatus;
+  /** Invoice projection (#1713); absent when the order has no invoice record. */
+  invoice?: ParsedOrderInvoice;
   /**
    * Marketplace-sourced COD collect amount (#1435). Present only for a COD order
    * whose source exposed the amount; drives the read-only "from Allegro" COD
@@ -338,6 +372,22 @@ export function parseOrderSnapshot(snapshot: Record<string, unknown>): ParsedOrd
     }
   }
 
+  // Invoice projection — optional; only warn when present-but-malformed.
+  let invoice: ParsedOrderInvoice | undefined;
+  if (snapshot.invoice !== undefined && snapshot.invoice !== null) {
+    const candidate = asRecord(snapshot.invoice);
+    if (candidate === null) {
+      warnings.push({ field: 'invoice', message: 'expected an object' });
+    } else {
+      const result = orderInvoiceSchema.safeParse(candidate);
+      if (result.success) {
+        invoice = result.data;
+      } else {
+        warnings.push({ field: 'invoice', message: firstZodMessage(result.error) });
+      }
+    }
+  }
+
   return {
     id,
     orderNumber,
@@ -352,6 +402,7 @@ export function parseOrderSnapshot(snapshot: Record<string, unknown>): ParsedOrd
     shipping,
     pickupPoint,
     paymentStatus: readPaymentStatus(snapshot.paymentStatus, warnings),
+    invoice,
     codToCollect,
     parseWarnings: warnings,
   };

--- a/apps/web/src/features/orders/api/order-snapshot.schema.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.ts
@@ -127,6 +127,12 @@ export interface ParsedOrderSnapshot {
   orderNumber?: string;
   status?: string;
   /**
+   * Deep link to this order in the source platform's own UI (#1713), built by
+   * the source adapter (Allegro Sales Center today; other sources hide the link
+   * until a stable URL scheme is confirmed). Absent ⇒ no source link rendered.
+   */
+  sourceExternalUrl?: string;
+  /**
    * Buyer email from the source platform — adapters typically populate from
    * `IncomingOrder.customerEmail`. Consumed by the Generate Label form
    * (#769) to pre-fill the recipient.email field; absent for sources that
@@ -211,6 +217,10 @@ export function parseOrderSnapshot(snapshot: Record<string, unknown>): ParsedOrd
   const orderNumber =
     typeof snapshot.orderNumber === 'string' ? snapshot.orderNumber : undefined;
   const status = typeof snapshot.status === 'string' ? snapshot.status : undefined;
+  const sourceExternalUrl =
+    typeof snapshot.sourceExternalUrl === 'string' && snapshot.sourceExternalUrl.length > 0
+      ? snapshot.sourceExternalUrl
+      : undefined;
   const customerEmail =
     typeof snapshot.customerEmail === 'string' && snapshot.customerEmail.length > 0
       ? snapshot.customerEmail
@@ -332,6 +342,7 @@ export function parseOrderSnapshot(snapshot: Record<string, unknown>): ParsedOrd
     id,
     orderNumber,
     status,
+    sourceExternalUrl,
     customerEmail,
     placedAt,
     items,

--- a/apps/web/src/features/orders/api/order-snapshot.schema.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.ts
@@ -126,6 +126,10 @@ export type RegulatoryStatus = (typeof RegulatoryStatusValues)[number];
  */
 const orderInvoiceSchema = z.object({
   invoiceId: z.string(),
+  /** Neutral document type (open-world) — correction documents (`corrected` /
+   *  `credit-note`) are distinguished from a plain invoice so the badge can
+   *  prefix them. Optional for backward-compat with pre-#1713 snapshots. */
+  documentType: z.string().nullish(),
   status: z.enum(InvoiceStatusValues),
   regulatoryStatus: z.enum(RegulatoryStatusValues),
   clearanceReference: z.string().nullish(),

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -110,6 +110,7 @@ export const OrderSortValues = [
   'status',
   'total',
   'fulfillment',
+  'payment',
 ] as const;
 export type OrderSortValue = (typeof OrderSortValues)[number];
 

--- a/apps/web/src/features/orders/components/order-row-detail.test.tsx
+++ b/apps/web/src/features/orders/components/order-row-detail.test.tsx
@@ -1,13 +1,15 @@
 /**
  * OrderRowDetail tests
  *
- * Covers the expandable-row / mobile-card detail panel (#1620): every field
- * slot renders even when the underlying data is missing (showing "-"), and
- * populated fields surface the parsed snapshot values.
+ * Covers the expandable-row / mobile-card detail panel (#1620, regrouped #1713):
+ * the long-form field slots fall back to "-" when data is missing, populated
+ * fields surface the parsed snapshot values, the "Open order" links render, and
+ * the itemised line list shows one row per item.
  */
 import { cleanup, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it } from 'vitest';
+import { LocaleProvider } from '../../../shared/i18n';
 import { OrderRowDetail } from './order-row-detail';
 import type { OrderRecord } from '../api/orders.types';
 
@@ -26,37 +28,58 @@ const baseOrder: OrderRecord = {
 
 function renderDetail(order: OrderRecord): ReturnType<typeof render> {
   return render(
-    <MemoryRouter>
-      <OrderRowDetail order={order} channelLabel={() => undefined} platformByConnection={new Map()} />
-    </MemoryRouter>,
+    <LocaleProvider>
+      <MemoryRouter>
+        <OrderRowDetail
+          order={order}
+          channelLabel={() => undefined}
+          platformByConnection={new Map()}
+        />
+      </MemoryRouter>
+    </LocaleProvider>,
   );
 }
 
 describe('OrderRowDetail', () => {
   afterEach(cleanup);
 
-  it('renders "-" for every field when the snapshot has no data', () => {
+  it('renders "-" for every empty long-form field when the snapshot has no data', () => {
     renderDetail(baseOrder);
 
     const placeholders = screen.getAllByText('-');
-    // Order reference, items, ship-by, carrier, destination, placed, payment,
-    // shipping address, billing address — every optional slot falls back.
-    expect(placeholders.length).toBeGreaterThanOrEqual(9);
+    // Order reference, placed, destination, ship-by, items, shipping address,
+    // billing address — every optional slot falls back (internal id always shows).
+    expect(placeholders.length).toBeGreaterThanOrEqual(6);
   });
 
-  it('always renders the internal id and created timestamp', () => {
+  it('always renders the internal id and the OpenLinker order-details link', () => {
     renderDetail(baseOrder);
 
     expect(screen.getByText('ol_order_bare')).toBeInTheDocument();
+    const detailsLink = screen.getByRole('link', { name: /order details/i });
+    expect(detailsLink).toHaveAttribute('href', '/orders/ol_order_bare');
   });
 
-  it('renders parsed snapshot values when present', () => {
+  it('renders the source deep link when the snapshot carries a sourceExternalUrl', () => {
+    const order: OrderRecord = {
+      ...baseOrder,
+      orderSnapshot: { sourceExternalUrl: 'https://salescenter.allegro.pl/orders/abc' },
+    };
+
+    renderDetail(order);
+
+    const sourceLink = screen.getByRole('link', { name: /view on/i });
+    expect(sourceLink).toHaveAttribute('href', 'https://salescenter.allegro.pl/orders/abc');
+    expect(sourceLink).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('renders parsed snapshot values and an itemised line list when present', () => {
     const order: OrderRecord = {
       ...baseOrder,
       orderSnapshot: {
         orderNumber: 'ALG-1',
-        items: [{ id: 'i1', quantity: 1, price: 10, name: 'Widget' }],
-        paymentStatus: 'paid',
+        totals: { subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' },
+        items: [{ id: 'i1', quantity: 2, price: 10, name: 'Widget', sku: 'SKU-1' }],
         shippingAddress: {
           firstName: 'Anna',
           lastName: 'Kowalska',
@@ -71,9 +94,10 @@ describe('OrderRowDetail', () => {
     renderDetail(order);
 
     expect(screen.getByText('ALG-1')).toBeInTheDocument();
-    expect(screen.getByText('1 item')).toBeInTheDocument();
+    expect(screen.getByText('Items (1)')).toBeInTheDocument();
     expect(screen.getByText('Widget')).toBeInTheDocument();
-    expect(screen.getByText('Paid')).toBeInTheDocument();
+    expect(screen.getByText('SKU-1')).toBeInTheDocument();
+    expect(screen.getByText('2×')).toBeInTheDocument();
     const shippingField = screen.getByText('Shipping address').closest('div') as HTMLElement;
     expect(within(shippingField).getByText('Anna Kowalska')).toBeInTheDocument();
   });

--- a/apps/web/src/features/orders/components/order-row-detail.tsx
+++ b/apps/web/src/features/orders/components/order-row-detail.tsx
@@ -18,6 +18,7 @@ import type { ReactElement, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { TimeDisplay } from '../../../shared/ui/time-display';
 import { getBcp47Locale, useTranslation } from '../../../shared/i18n';
+import { isSafeHttpUrl } from '../../../shared/lib/is-safe-http-url';
 import {
   parseOrderSnapshot,
   type ParsedAddress,
@@ -113,7 +114,7 @@ export function OrderRowDetail({
         <Link className="orders-ext-link orders-ext-link--internal" to={`/orders/${order.internalOrderId}`}>
           Order details <span aria-hidden="true" className="orders-ext-link__arrow">→</span>
         </Link>
-        {parsed.sourceExternalUrl ? (
+        {parsed.sourceExternalUrl && isSafeHttpUrl(parsed.sourceExternalUrl) ? (
           <a
             className="orders-ext-link"
             data-channel={sourcePlatform}

--- a/apps/web/src/features/orders/components/order-row-detail.tsx
+++ b/apps/web/src/features/orders/components/order-row-detail.tsx
@@ -1,20 +1,28 @@
 /**
  * OrderRowDetail
  *
- * The non-essential order fields moved out of the dense orders-list row into a
- * shared detail view (#1620). On desktop it fills the expandable-row accordion
- * panel; on mobile it fills the card body so a collapsed card still shows every
- * field. Every field is always rendered — missing values show "-" — so the
- * detail reads the same across both layouts and no data is hidden.
+ * The long-form order fields that stay out of the dense orders-list row (#1620,
+ * regrouped #1713). On desktop it fills the expandable-row accordion panel; on
+ * mobile it fills the card's "View full details" disclosure. Leads with an
+ * "Open order" strip (OpenLinker detail + source-marketplace deep link), then
+ * the identity/timing fields, the itemised line list, and the addresses.
  *
- * Pure presentation: all inputs are already-resolved view-model values; no
- * transport logic at this layer.
+ * Fields now surfaced directly in the row (carrier, payment, created) are no
+ * longer repeated here — the panel keeps only what's worth expanding for.
+ *
+ * Pure presentation: all inputs are already-resolved view-model values.
  *
  * @module features/orders/components
  */
 import type { ReactElement, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import { TimeDisplay } from '../../../shared/ui/time-display';
-import { parseOrderSnapshot, type ParsedAddress } from '../api/order-snapshot.schema';
+import { getBcp47Locale, useTranslation } from '../../../shared/i18n';
+import {
+  parseOrderSnapshot,
+  type ParsedAddress,
+  type ParsedOrderItem,
+} from '../api/order-snapshot.schema';
 import type { OrderRecord } from '../api/orders.types';
 
 interface OrderRowDetailProps {
@@ -23,13 +31,6 @@ interface OrderRowDetailProps {
   channelLabel: (platform: string | undefined) => string | undefined;
   platformByConnection: Map<string, string>;
 }
-
-const PAYMENT_LABELS: Record<string, string> = {
-  paid: 'Paid',
-  cod: 'Cash on delivery',
-  awaiting: 'Awaiting payment',
-  refunded: 'Refunded',
-};
 
 /** Placeholder for an absent value — keeps every field slot visible. */
 const EMPTY = '-';
@@ -64,61 +65,100 @@ function Field({ label, children }: { label: string; children: ReactNode }): Rea
   );
 }
 
+function LineItem({
+  item,
+  formatPrice,
+}: {
+  item: ParsedOrderItem;
+  formatPrice: (price: number) => string;
+}): ReactElement {
+  return (
+    <div className="orders-line-item">
+      <span className="orders-line-item__qty mono tabular">{item.quantity}×</span>
+      <span className="orders-line-item__name">
+        {item.name ?? item.sku ?? item.id}
+        {item.sku ? <span className="orders-line-item__sku mono">{item.sku}</span> : null}
+      </span>
+      <span className="orders-line-item__price mono tabular">{formatPrice(item.price)}</span>
+    </div>
+  );
+}
+
 export function OrderRowDetail({
   order,
   channelLabel,
   platformByConnection,
 }: OrderRowDetailProps): ReactElement {
   const parsed = parseOrderSnapshot(order.orderSnapshot);
-  const itemNames = parsed.items.map((i) => i.name).filter((n): n is string => Boolean(n));
-  // Carrier precedence (#1617): the list doesn't load per-order shipment data
-  // (that's a per-order fetch, too expensive for a paged table), so it can't
-  // read the shipment's actual `carrier` the way `OrderDetailPage` does —
-  // `shipping.methodName` (the source's stated delivery-method preference) is
-  // the best signal available at the row level, falling back to the pickup
-  // point's name for pickup-point orders that carry no separate method name.
-  // "-" (via `EMPTY` below) when neither is present.
-  const carrier = parsed.shipping?.methodName ?? parsed.pickupPoint?.name ?? null;
+  const { locale } = useTranslation();
+  const currency = parsed.totals?.currency;
+  const formatPrice = (price: number): string =>
+    currency
+      ? new Intl.NumberFormat(getBcp47Locale(locale), { style: 'currency', currency }).format(price)
+      : price.toFixed(2);
+
+  const sourcePlatform = platformByConnection.get(order.sourceConnectionId);
+  const sourceLabel = channelLabel(sourcePlatform);
   const destPlatform = order.syncStatus[0]
     ? platformByConnection.get(order.syncStatus[0].destinationConnectionId)
     : undefined;
   const destLabel = channelLabel(destPlatform);
-  const paymentLabel = parsed.paymentStatus ? PAYMENT_LABELS[parsed.paymentStatus] : null;
 
   return (
     <dl className="orders-detail">
+      {/* "Open order" strip (#1713): OpenLinker detail (internal) + the
+          source-marketplace deep link when the adapter supplied one. */}
+      <div className="orders-detail__links">
+        <Link className="orders-ext-link orders-ext-link--internal" to={`/orders/${order.internalOrderId}`}>
+          Order details <span aria-hidden="true" className="orders-ext-link__arrow">→</span>
+        </Link>
+        {parsed.sourceExternalUrl ? (
+          <a
+            className="orders-ext-link"
+            data-channel={sourcePlatform}
+            href={parsed.sourceExternalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View on {sourceLabel ?? 'marketplace'}{' '}
+            <span aria-hidden="true" className="orders-ext-link__arrow">
+              ↗
+            </span>
+          </a>
+        ) : null}
+      </div>
+
       <Field label="Order reference">
         {parsed.orderNumber ? <span className="mono">{parsed.orderNumber}</span> : EMPTY}
       </Field>
       <Field label="Internal ID">
         <span className="mono">{order.internalOrderId}</span>
       </Field>
-      <Field label="Items">
-        {parsed.items.length === 0 ? (
-          EMPTY
-        ) : (
-          <span className="orders-detail__items">
-            <span>
-              {parsed.items.length} {parsed.items.length === 1 ? 'item' : 'items'}
-            </span>
-            {itemNames.length > 0 ? (
-              <span className="text-muted">{itemNames.join(', ')}</span>
-            ) : null}
-          </span>
-        )}
-      </Field>
-      <Field label="Ship-by">
-        {order.dispatchByAt ? <TimeDisplay iso={order.dispatchByAt} format="datetime" /> : EMPTY}
-      </Field>
-      <Field label="Carrier">{carrier ?? EMPTY}</Field>
-      <Field label="Destination">{destLabel ?? EMPTY}</Field>
-      <Field label="Created">
-        <TimeDisplay iso={order.createdAt} format="datetime" />
-      </Field>
       <Field label="Placed">
         {parsed.placedAt ? <TimeDisplay iso={parsed.placedAt} format="datetime" /> : EMPTY}
       </Field>
-      <Field label="Payment">{paymentLabel ?? EMPTY}</Field>
+      <Field label="Destination">{destLabel ?? EMPTY}</Field>
+      <Field label="Ship-by">
+        {order.dispatchByAt ? <TimeDisplay iso={order.dispatchByAt} format="datetime" /> : EMPTY}
+      </Field>
+
+      <div className="orders-detail__field orders-detail__field--wide">
+        <dt className="orders-detail__label">
+          Items{parsed.items.length > 0 ? ` (${parsed.items.length})` : ''}
+        </dt>
+        <dd className="orders-detail__value">
+          {parsed.items.length === 0 ? (
+            EMPTY
+          ) : (
+            <div className="orders-detail__items-list">
+              {parsed.items.map((item) => (
+                <LineItem key={item.id} item={item} formatPrice={formatPrice} />
+              ))}
+            </div>
+          )}
+        </dd>
+      </div>
+
       <Field label="Shipping address">{formatAddress(parsed.shippingAddress)}</Field>
       <Field label="Billing address">{formatAddress(parsed.billingAddress)}</Field>
     </dl>

--- a/apps/web/src/features/orders/components/order-row-detail.tsx
+++ b/apps/web/src/features/orders/components/order-row-detail.tsx
@@ -23,6 +23,7 @@ import {
   type ParsedAddress,
   type ParsedOrderItem,
 } from '../api/order-snapshot.schema';
+import { invoiceBadge } from '../lib/order-row';
 import type { OrderRecord } from '../api/orders.types';
 
 interface OrderRowDetailProps {
@@ -140,6 +141,18 @@ export function OrderRowDetail({
       <Field label="Destination">{destLabel ?? EMPTY}</Field>
       <Field label="Ship-by">
         {order.dispatchByAt ? <TimeDisplay iso={order.dispatchByAt} format="datetime" /> : EMPTY}
+      </Field>
+      <Field label="Invoice">
+        {parsed.invoice ? (
+          <span className="orders-detail__invoice">
+            <span>{invoiceBadge(parsed.invoice).label}</span>
+            {parsed.invoice.clearanceReference ? (
+              <span className="mono text-muted">{parsed.invoice.clearanceReference}</span>
+            ) : null}
+          </span>
+        ) : (
+          EMPTY
+        )}
       </Field>
 
       <div className="orders-detail__field orders-detail__field--wide">

--- a/apps/web/src/features/orders/lib/order-row.test.ts
+++ b/apps/web/src/features/orders/lib/order-row.test.ts
@@ -65,4 +65,23 @@ describe('invoiceBadge', () => {
     expect(invoiceBadge(inv('issued', 'accepted'))).toEqual({ label: 'Cleared', tone: 'success' });
     expect(invoiceBadge(inv('issued', 'rejected'))).toEqual({ label: 'Rejected', tone: 'error' });
   });
+
+  it('prefixes correction documents (corrected / credit-note) with "Correction · "', () => {
+    expect(invoiceBadge({ ...inv('issued', 'accepted'), documentType: 'corrected' })).toEqual({
+      label: 'Correction · Cleared',
+      tone: 'success',
+    });
+    expect(invoiceBadge({ ...inv('issued', 'not-applicable'), documentType: 'credit-note' })).toEqual({
+      label: 'Correction · Issued',
+      tone: 'success',
+    });
+  });
+
+  it('keeps the base label for a plain invoice or an unset document type', () => {
+    expect(invoiceBadge({ ...inv('issued', 'accepted'), documentType: 'invoice' })).toEqual({
+      label: 'Cleared',
+      tone: 'success',
+    });
+    expect(invoiceBadge(inv('issued', 'accepted'))).toEqual({ label: 'Cleared', tone: 'success' });
+  });
 });

--- a/apps/web/src/features/orders/lib/order-row.test.ts
+++ b/apps/web/src/features/orders/lib/order-row.test.ts
@@ -2,8 +2,8 @@
  * order-row view-model helper tests (#1713).
  */
 import { describe, expect, it } from 'vitest';
-import type { ParsedOrderItem } from '../api/order-snapshot.schema';
-import { itemsSummary, paymentBadge } from './order-row';
+import type { ParsedOrderInvoice, ParsedOrderItem } from '../api/order-snapshot.schema';
+import { itemsSummary, paymentBadge, invoiceBadge } from './order-row';
 
 function item(id: string, name?: string): ParsedOrderItem {
   return { id, quantity: 1, price: 10, name };
@@ -40,5 +40,29 @@ describe('paymentBadge', () => {
     expect(paymentBadge('cod')).toEqual({ label: 'COD', tone: 'review' });
     expect(paymentBadge('awaiting')).toEqual({ label: 'Awaiting', tone: 'warning' });
     expect(paymentBadge('refunded')).toEqual({ label: 'Refunded', tone: 'neutral' });
+  });
+});
+
+describe('invoiceBadge', () => {
+  const inv = (
+    status: ParsedOrderInvoice['status'],
+    regulatoryStatus: ParsedOrderInvoice['regulatoryStatus'],
+  ): ParsedOrderInvoice => ({ invoiceId: 'inv-1', status, regulatoryStatus });
+
+  it('reports a failed issue as an error', () => {
+    expect(invoiceBadge(inv('failed', 'not-applicable'))).toEqual({ label: 'Failed', tone: 'error' });
+  });
+
+  it('reports pending/issuing as in-progress', () => {
+    expect(invoiceBadge(inv('pending', 'not-applicable'))).toEqual({ label: 'Issuing', tone: 'warning' });
+    expect(invoiceBadge(inv('issuing', 'not-applicable'))).toEqual({ label: 'Issuing', tone: 'warning' });
+  });
+
+  it('refines an issued invoice by its clearance lifecycle', () => {
+    expect(invoiceBadge(inv('issued', 'not-applicable'))).toEqual({ label: 'Issued', tone: 'success' });
+    expect(invoiceBadge(inv('issued', 'submitted'))).toEqual({ label: 'Submitted', tone: 'info' });
+    expect(invoiceBadge(inv('issued', 'cleared'))).toEqual({ label: 'Cleared', tone: 'success' });
+    expect(invoiceBadge(inv('issued', 'accepted'))).toEqual({ label: 'Cleared', tone: 'success' });
+    expect(invoiceBadge(inv('issued', 'rejected'))).toEqual({ label: 'Rejected', tone: 'error' });
   });
 });

--- a/apps/web/src/features/orders/lib/order-row.test.ts
+++ b/apps/web/src/features/orders/lib/order-row.test.ts
@@ -1,0 +1,44 @@
+/**
+ * order-row view-model helper tests (#1713).
+ */
+import { describe, expect, it } from 'vitest';
+import type { ParsedOrderItem } from '../api/order-snapshot.schema';
+import { itemsSummary, paymentBadge } from './order-row';
+
+function item(id: string, name?: string): ParsedOrderItem {
+  return { id, quantity: 1, price: 10, name };
+}
+
+describe('itemsSummary', () => {
+  it('returns null when there are no named items', () => {
+    expect(itemsSummary([])).toBeNull();
+    expect(itemsSummary([item('i1', undefined)])).toBeNull();
+  });
+
+  it('returns the single name with moreCount 0 for a one-item order', () => {
+    expect(itemsSummary([item('i1', 'Widget')])).toEqual({ firstName: 'Widget', moreCount: 0 });
+  });
+
+  it('returns the first name and the count of the rest for a multi-item order', () => {
+    const summary = itemsSummary([item('i1', 'Widget'), item('i2', 'Gadget'), item('i3', 'Gizmo')]);
+    expect(summary).toEqual({ firstName: 'Widget', moreCount: 2 });
+  });
+
+  it('ignores unnamed items when counting the remainder', () => {
+    const summary = itemsSummary([item('i1', 'Widget'), item('i2', undefined)]);
+    expect(summary).toEqual({ firstName: 'Widget', moreCount: 0 });
+  });
+});
+
+describe('paymentBadge', () => {
+  it('returns null when the status is absent', () => {
+    expect(paymentBadge(undefined)).toBeNull();
+  });
+
+  it('maps each payment status to a distinct label + tone', () => {
+    expect(paymentBadge('paid')).toEqual({ label: 'Paid', tone: 'success' });
+    expect(paymentBadge('cod')).toEqual({ label: 'COD', tone: 'review' });
+    expect(paymentBadge('awaiting')).toEqual({ label: 'Awaiting', tone: 'warning' });
+    expect(paymentBadge('refunded')).toEqual({ label: 'Refunded', tone: 'neutral' });
+  });
+});

--- a/apps/web/src/features/orders/lib/order-row.ts
+++ b/apps/web/src/features/orders/lib/order-row.ts
@@ -1,0 +1,54 @@
+/**
+ * Order Row View-Model Helpers
+ *
+ * Pure, framework-free derivations for the redesigned orders-list row (#1713):
+ * the multi-item summary (first name + "+N" count) and the payment-status badge
+ * (label + tone). Kept out of the page so the rules are unit-testable in
+ * isolation and shared between the desktop table and the mobile card.
+ *
+ * @module apps/web/src/features/orders/lib
+ */
+import type { ParsedOrderItem, PaymentStatus } from '../api/order-snapshot.schema';
+import type { StatusBadgeTone } from '../../../shared/ui/status-badge';
+
+/** First named item + how many further lines the order carries. */
+export interface ItemsSummary {
+  firstName: string;
+  /** Count of items beyond the first (0 for a single-item order). */
+  moreCount: number;
+}
+
+/**
+ * Summarise an order's line items for the collapsed row (#1713): the first
+ * named item plus a count of the rest, so a multi-item order never masquerades
+ * as a single-item one. `null` when the snapshot carries no named items (parse
+ * failure or genuinely empty) — the row then shows nothing rather than a blank.
+ * The name is returned verbatim; the row truncates it in CSS while the count
+ * chip stays fully visible.
+ */
+export function itemsSummary(items: readonly ParsedOrderItem[]): ItemsSummary | null {
+  const names = items.map((i) => i.name).filter((n): n is string => Boolean(n));
+  if (names.length === 0) return null;
+  const [first, ...rest] = names;
+  return { firstName: first, moreCount: rest.length };
+}
+
+/** Label + tone per payment status. Colour never carries meaning alone — the
+ *  label always ships alongside (StatusBadge enforces the dot + text). */
+export const PAYMENT_BADGE_META: Record<PaymentStatus, { label: string; tone: StatusBadgeTone }> = {
+  paid: { label: 'Paid', tone: 'success' },
+  cod: { label: 'COD', tone: 'review' },
+  awaiting: { label: 'Awaiting', tone: 'warning' },
+  refunded: { label: 'Refunded', tone: 'neutral' },
+};
+
+/**
+ * Resolve the payment badge for an order row, or `null` when the source didn't
+ * report a status (the cell then shows an em dash rather than a misleading pill).
+ */
+export function paymentBadge(
+  status: PaymentStatus | undefined,
+): { label: string; tone: StatusBadgeTone } | null {
+  if (!status) return null;
+  return PAYMENT_BADGE_META[status];
+}

--- a/apps/web/src/features/orders/lib/order-row.ts
+++ b/apps/web/src/features/orders/lib/order-row.ts
@@ -8,7 +8,11 @@
  *
  * @module apps/web/src/features/orders/lib
  */
-import type { ParsedOrderItem, PaymentStatus } from '../api/order-snapshot.schema';
+import type {
+  ParsedOrderInvoice,
+  ParsedOrderItem,
+  PaymentStatus,
+} from '../api/order-snapshot.schema';
 import type { StatusBadgeTone } from '../../../shared/ui/status-badge';
 
 /** First named item + how many further lines the order carries. */
@@ -51,4 +55,34 @@ export function paymentBadge(
 ): { label: string; tone: StatusBadgeTone } | null {
   if (!status) return null;
   return PAYMENT_BADGE_META[status];
+}
+
+/**
+ * Collapse an order's invoice projection (#1713) into one operator-facing badge:
+ * the issue lifecycle (`status`) crossed with the neutral CTC clearance
+ * lifecycle (`regulatoryStatus`). Only called when an invoice record exists — a
+ * missing invoice is rendered as the "Issue invoice" action by the caller, not
+ * here. Colour is never the only signal; the label always ships alongside.
+ */
+export function invoiceBadge(invoice: ParsedOrderInvoice): {
+  label: string;
+  tone: StatusBadgeTone;
+} {
+  if (invoice.status === 'failed') return { label: 'Failed', tone: 'error' };
+  if (invoice.status === 'pending' || invoice.status === 'issuing') {
+    return { label: 'Issuing', tone: 'warning' };
+  }
+  // status === 'issued' — refine by clearance lifecycle.
+  switch (invoice.regulatoryStatus) {
+    case 'accepted':
+    case 'cleared':
+      return { label: 'Cleared', tone: 'success' };
+    case 'submitted':
+      return { label: 'Submitted', tone: 'info' };
+    case 'rejected':
+      return { label: 'Rejected', tone: 'error' };
+    case 'not-applicable':
+    default:
+      return { label: 'Issued', tone: 'success' };
+  }
 }

--- a/apps/web/src/features/orders/lib/order-row.ts
+++ b/apps/web/src/features/orders/lib/order-row.ts
@@ -58,13 +58,34 @@ export function paymentBadge(
 }
 
 /**
+ * Neutral document types (mirrors `DocumentTypeValues` in
+ * `@openlinker/core/invoicing`) that represent a correction rather than an
+ * original invoice — the badge prefixes these with `Correction · `.
+ */
+const CORRECTION_DOCUMENT_TYPES: ReadonlySet<string> = new Set(['corrected', 'credit-note']);
+
+/**
  * Collapse an order's invoice projection (#1713) into one operator-facing badge:
  * the issue lifecycle (`status`) crossed with the neutral CTC clearance
- * lifecycle (`regulatoryStatus`). Only called when an invoice record exists — a
- * missing invoice is rendered as the "Issue invoice" action by the caller, not
- * here. Colour is never the only signal; the label always ships alongside.
+ * lifecycle (`regulatoryStatus`). Correction documents (`documentType` of
+ * `corrected` / `credit-note`, #1713) are prefixed `Correction · …` so a KOR
+ * reads distinctly from an original invoice. Only called when an invoice record
+ * exists — a missing invoice is rendered as the "Issue invoice" action by the
+ * caller, not here. Colour is never the only signal; the label always ships
+ * alongside.
  */
 export function invoiceBadge(invoice: ParsedOrderInvoice): {
+  label: string;
+  tone: StatusBadgeTone;
+} {
+  const base = invoiceBadgeBase(invoice);
+  const isCorrection = invoice.documentType
+    ? CORRECTION_DOCUMENT_TYPES.has(invoice.documentType)
+    : false;
+  return isCorrection ? { ...base, label: `Correction · ${base.label}` } : base;
+}
+
+function invoiceBadgeBase(invoice: ParsedOrderInvoice): {
   label: string;
   tone: StatusBadgeTone;
 } {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7741,6 +7741,30 @@ a.kpi-card:focus-visible {
   padding: 0 5px;
 }
 
+/* Inline row action shown in place of a status pill when the next step is
+   unstarted — "Generate label" (no shipment) / "Issue invoice" (no invoice).
+   Accent-outlined; deep-links to the matching section of the order-detail page. */
+.orders-row-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 8px;
+  border: 1px solid var(--accent-primary-border);
+  border-radius: var(--radius-sm);
+  background: var(--accent-primary-soft);
+  color: var(--accent-primary-soft-strong);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.orders-row-cta:hover { border-color: var(--accent-primary); }
+.orders-row-cta:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+.orders-row-cta__plus { color: var(--accent-primary); font-weight: 700; }
+
 /* Ship-by badge + live countdown share one line inside the Shipment cell. */
 .orders-shipby-row { display: inline-flex; align-items: center; gap: 6px; }
 .orders-carrier { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -7817,6 +7841,7 @@ a.kpi-card:focus-visible {
 .orders-ext-link--internal { border-color: var(--accent-primary-border); color: var(--accent-primary-soft-strong); font-weight: 600; }
 .orders-ext-link--internal::before { background: var(--accent-primary); }
 
+.orders-detail__invoice { display: inline-flex; flex-direction: column; gap: 2px; align-items: flex-start; }
 .orders-detail__items-list { display: flex; flex-direction: column; gap: 6px; }
 .orders-line-item {
   display: grid;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2814,12 +2814,24 @@ textarea,
   padding: var(--space-4) var(--space-4) var(--space-4) 2.75rem;
 }
 
-/* Detail field grid — shared by the desktop accordion and the mobile card. */
+/* Detail field grid — shared by the desktop accordion and the mobile card.
+   Inset "drawer" (#1713): a recessed panel (color-mix darkens the current
+   theme's surface, so it reads recessed in both light and dark) with side
+   padding, set apart from the row above. */
 .orders-detail {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: var(--space-3) var(--space-5);
+  gap: var(--space-4) var(--space-5);
   margin: 0;
+  padding: var(--space-4) var(--space-5);
+  background: color-mix(in oklch, var(--bg-surface), black 7%);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+/* Full-width detail row (the itemised line list) spanning the auto-fill grid. */
+.orders-detail__field--wide {
+  grid-column: 1 / -1;
 }
 
 .orders-detail__field {
@@ -7705,6 +7717,166 @@ a.kpi-card:focus-visible {
   border-radius: var(--radius-sm);
   padding: 1px 7px;
 }
+
+/* ── Orders list redesign (#1713) ────────────────────────────────────
+   Merged Shipment + money columns, per-label sort controls, the row items
+   summary, the folded channel line, and the mobile card summary/facts. */
+
+/* Right-aligned two-line stack (the money column). */
+.orders-cell-stack--end { align-items: flex-end; text-align: right; }
+.orders-money-total { font-weight: 640; }
+
+/* Row items summary: a truncating first-item name + a never-truncated "+N"
+   count chip, so a multi-item order never reads as a single-item one. */
+.orders-items-line { display: inline-flex; align-items: center; gap: 6px; max-width: 250px; min-width: 0; }
+.orders-items-line .orders-items-preview { flex: 0 1 auto; min-width: 0; }
+.orders-more-count {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  color: var(--text-muted);
+  background: var(--bg-surface-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0 5px;
+}
+
+/* Ship-by badge + live countdown share one line inside the Shipment cell. */
+.orders-shipby-row { display: inline-flex; align-items: center; gap: 6px; }
+.orders-carrier { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Channel folds under the order name below the Channel column's 1024px hide
+   breakpoint — hidden on wide screens where the standalone column shows. */
+.orders-order-channel { display: none; align-items: center; gap: 6px; }
+@media (max-width: 1023px) {
+  .orders-order-channel { display: inline-flex; }
+}
+
+/* Per-label sort controls in the merged-column headers. */
+.orders-sortstack { display: inline-flex; flex-direction: column; gap: 4px; }
+.orders-sortstack--left { align-items: flex-start; }
+.orders-sortstack--right { align-items: flex-end; }
+.orders-sortbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.orders-sortbtn:hover { color: var(--text-secondary); }
+.orders-sortbtn:focus-visible { outline: none; box-shadow: var(--shadow-focus); border-radius: var(--radius-xs); }
+.orders-sortbtn--active { color: var(--text-secondary); }
+.orders-sortbtn__ind { color: var(--text-disabled); font-size: 0.625rem; }
+.orders-sortbtn--active .orders-sortbtn__ind { color: var(--accent-primary); }
+
+/* Accordion "Open order" links strip + itemised line list. */
+.orders-detail__links {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px dashed var(--border-default);
+}
+.orders-ext-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: border-color var(--duration-fast), color var(--duration-fast);
+}
+.orders-ext-link:hover { border-color: var(--accent-primary-border); color: var(--accent-primary-soft-strong); }
+.orders-ext-link:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+.orders-ext-link::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex-shrink: 0;
+}
+.orders-ext-link[data-channel='allegro']::before { background: oklch(70% 0.18 35); }
+.orders-ext-link[data-channel='prestashop']::before { background: oklch(60% 0.18 250); }
+.orders-ext-link[data-channel='erli']::before { background: oklch(66% 0.17 320); }
+.orders-ext-link__arrow { color: var(--accent-primary); }
+.orders-ext-link--internal { border-color: var(--accent-primary-border); color: var(--accent-primary-soft-strong); font-weight: 600; }
+.orders-ext-link--internal::before { background: var(--accent-primary); }
+
+.orders-detail__items-list { display: flex; flex-direction: column; gap: 6px; }
+.orders-line-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: baseline;
+  column-gap: var(--space-3);
+  padding: 7px 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+.orders-line-item__qty { color: var(--text-muted); font-size: 0.75rem; }
+.orders-line-item__name { min-width: 0; font-size: 0.8125rem; color: var(--text-secondary); }
+.orders-line-item__sku { display: block; font-size: 0.6875rem; color: var(--text-muted); }
+.orders-line-item__price { font-size: 0.78rem; color: var(--text-secondary); white-space: nowrap; }
+
+/* Mobile card: subtitle (channel + relative time), always-visible summary +
+   facts grid, and the collapsible-detail disclosure. */
+.orders-card-sub { display: inline-flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.orders-card-summary { display: flex; flex-direction: column; gap: var(--space-3); }
+.orders-card-items { font-size: 0.8125rem; color: var(--text-secondary); }
+.orders-card-facts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3) var(--space-4);
+  margin: 0;
+  padding: var(--space-3);
+  background: var(--bg-surface-muted);
+  border-radius: var(--radius-md);
+}
+.orders-card-facts > div { min-width: 0; }
+.orders-card-facts__wide { grid-column: 1 / -1; }
+.orders-card-facts dt {
+  font-family: var(--font-mono);
+  font-size: 0.5938rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 3px;
+}
+.orders-card-facts dd { margin: 0; font-size: 0.8125rem; color: var(--text-secondary); }
+
+.data-table__card-summary { margin-top: var(--space-3); }
+.data-table__card-disclosure {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: var(--space-3);
+  padding: 4px 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: var(--tracking-wide);
+  color: var(--text-muted);
+}
+.data-table__card-disclosure:hover { color: var(--text-secondary); }
+.data-table__card-disclosure:focus-visible { outline: none; box-shadow: var(--shadow-focus); border-radius: var(--radius-xs); }
+.data-table__card-disclosure-chev { color: var(--accent-primary); }
 
 /* ── Orders list filter/sort bar (#939) ─────────────────────────────── */
 .orders-toolbar {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7771,6 +7771,31 @@ a.kpi-card:focus-visible {
 .orders-row-cta:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
 .orders-row-cta__plus { color: var(--text-muted); font-weight: 700; }
 
+/* Inline Retry under the order name (#1713). Sits in the Order cell rather than
+   a trailing column so a rare failed row can't widen the whole table. Carries an
+   error tint because it only ever appears on a failed sync — a ghost button read
+   as decoration next to the row's error badge. */
+.orders-row-retry {
+  min-height: 24px;
+  margin-top: 2px;
+  padding: 1px 8px;
+  border: 1px solid var(--status-error-border);
+  border-radius: var(--radius-sm);
+  background: var(--status-error-soft);
+  color: var(--status-error-strong);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.orders-row-retry:hover:not(:disabled) {
+  border-color: var(--status-error-strong);
+  background: var(--status-error-soft);
+  color: var(--status-error-strong);
+}
+
 /* Ship-by badge + live countdown share one line inside the Shipment cell. */
 .orders-shipby-row { display: inline-flex; align-items: center; gap: 6px; }
 .orders-carrier { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2815,8 +2815,8 @@ textarea,
 }
 
 /* Detail field grid — shared by the desktop accordion and the mobile card.
-   Inset "drawer" (#1713): a recessed panel (color-mix darkens the current
-   theme's surface, so it reads recessed in both light and dark) with side
+   Inset "drawer" (#1713): a recessed panel (the muted surface token reads
+   recessed in both light and dark, matching the mobile facts grid) with side
    padding, set apart from the row above. */
 .orders-detail {
   display: grid;
@@ -2824,7 +2824,7 @@ textarea,
   gap: var(--space-4) var(--space-5);
   margin: 0;
   padding: var(--space-4) var(--space-5);
-  background: color-mix(in oklch, var(--bg-surface), black 7%);
+  background: var(--bg-surface-muted);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
 }
@@ -7733,7 +7733,7 @@ a.kpi-card:focus-visible {
 .orders-more-count {
   flex-shrink: 0;
   font-family: var(--font-mono);
-  font-size: 0.625rem;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   background: var(--bg-surface-muted);
   border: 1px solid var(--border-subtle);
@@ -7743,27 +7743,33 @@ a.kpi-card:focus-visible {
 
 /* Inline row action shown in place of a status pill when the next step is
    unstarted — "Generate label" (no shipment) / "Issue invoice" (no invoice).
-   Accent-outlined; deep-links to the matching section of the order-detail page. */
+   Neutral/ghost at rest so the accent stays reserved (#1713 review): a plain
+   outline that lifts to the accent on hover/focus. `min-height: 24px` meets the
+   WCAG 2.5.8 target size without enlarging the visible text. */
 .orders-row-cta {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  min-height: 24px;
   padding: 1px 8px;
-  border: 1px solid var(--accent-primary-border);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
-  background: var(--accent-primary-soft);
-  color: var(--accent-primary-soft-strong);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 0.625rem;
+  font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: 0.03em;
   text-transform: uppercase;
   text-decoration: none;
   white-space: nowrap;
 }
-.orders-row-cta:hover { border-color: var(--accent-primary); }
+.orders-row-cta:hover,
+.orders-row-cta:focus-visible {
+  border-color: var(--accent-primary-border);
+  color: var(--accent-primary-soft-strong);
+}
 .orders-row-cta:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
-.orders-row-cta__plus { color: var(--accent-primary); font-weight: 700; }
+.orders-row-cta__plus { color: var(--text-muted); font-weight: 700; }
 
 /* Ship-by badge + live countdown share one line inside the Shipment cell. */
 .orders-shipby-row { display: inline-flex; align-items: center; gap: 6px; }
@@ -7772,7 +7778,7 @@ a.kpi-card:focus-visible {
 /* Channel folds under the order name below the Channel column's 1024px hide
    breakpoint — hidden on wide screens where the standalone column shows. */
 .orders-order-channel { display: none; align-items: center; gap: 6px; }
-@media (max-width: 1023px) {
+@media (max-width: 1023.98px) {
   .orders-order-channel { display: inline-flex; }
 }
 
@@ -7798,7 +7804,7 @@ a.kpi-card:focus-visible {
 .orders-sortbtn:hover { color: var(--text-secondary); }
 .orders-sortbtn:focus-visible { outline: none; box-shadow: var(--shadow-focus); border-radius: var(--radius-xs); }
 .orders-sortbtn--active { color: var(--text-secondary); }
-.orders-sortbtn__ind { color: var(--text-disabled); font-size: 0.625rem; }
+.orders-sortbtn__ind { color: var(--text-muted); font-size: 0.625rem; }
 .orders-sortbtn--active .orders-sortbtn__ind { color: var(--accent-primary); }
 
 /* Accordion "Open order" links strip + itemised line list. */
@@ -7856,13 +7862,12 @@ a.kpi-card:focus-visible {
 .orders-line-item__qty { color: var(--text-muted); font-size: 0.75rem; }
 .orders-line-item__name { min-width: 0; font-size: 0.8125rem; color: var(--text-secondary); }
 .orders-line-item__sku { display: block; font-size: 0.6875rem; color: var(--text-muted); }
-.orders-line-item__price { font-size: 0.78rem; color: var(--text-secondary); white-space: nowrap; }
+.orders-line-item__price { font-size: 0.75rem; color: var(--text-secondary); white-space: nowrap; }
 
 /* Mobile card: subtitle (channel + relative time), always-visible summary +
    facts grid, and the collapsible-detail disclosure. */
 .orders-card-sub { display: inline-flex; align-items: center; gap: 6px; flex-wrap: wrap; }
 .orders-card-summary { display: flex; flex-direction: column; gap: var(--space-3); }
-.orders-card-items { font-size: 0.8125rem; color: var(--text-secondary); }
 .orders-card-facts {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -7876,7 +7881,7 @@ a.kpi-card:focus-visible {
 .orders-card-facts__wide { grid-column: 1 / -1; }
 .orders-card-facts dt {
   font-family: var(--font-mono);
-  font-size: 0.5938rem;
+  font-size: 0.6875rem;
   letter-spacing: var(--tracking-caps);
   text-transform: uppercase;
   color: var(--text-muted);

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -76,10 +76,15 @@ export function OrderDetailPage(): ReactElement {
     const targetId = location.hash.replace(/^#/, '');
     if (!targetId) return;
     const raf = requestAnimationFrame(() => {
+      const target = document.getElementById(targetId);
+      if (!target) return;
       const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches
         ? 'auto'
         : 'smooth';
-      document.getElementById(targetId)?.scrollIntoView({ behavior, block: 'start' });
+      // Move focus to the section so keyboard/AT users follow the visual jump;
+      // `preventScroll` lets scrollIntoView own the (possibly smooth) scroll.
+      target.focus({ preventScroll: true });
+      target.scrollIntoView({ behavior, block: 'start' });
     });
     return () => { cancelAnimationFrame(raf); };
   }, [hasOrder, location.hash]);
@@ -314,10 +319,10 @@ export function OrderDetailPage(): ReactElement {
               (`/orders/{id}#shipment`, `/orders/{id}#invoicing`). Page-level
               divs so the target exists even while a panel is capability-gated
               (renders null) or still loading. */}
-          <div id="shipment">
+          <div id="shipment" tabIndex={-1}>
             <OrderShipmentPanel order={order} />
           </div>
-          <div id="invoicing">
+          <div id="invoicing" tabIndex={-1}>
             <OrderInvoicePanel order={order} />
           </div>
           <OrderCustomerCard customerId={order.customerId} sourceConnectionId={order.sourceConnectionId} />

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -10,8 +10,8 @@
  *
  * @module apps/web/src/pages/orders
  */
-import { useCallback, type ReactElement } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useCallback, useEffect, type ReactElement } from 'react';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { Alert } from '../../shared/ui/alert';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
@@ -63,6 +63,26 @@ export function OrderDetailPage(): ReactElement {
   const shipmentsQuery = useOrderShipmentsQuery(internalOrderId);
   const retry = useRetryOrderDestinationMutation();
   const { showToast } = useToast();
+  const location = useLocation();
+
+  // Scroll to the section a deep-link CTA targets (#1713): the orders-list
+  // "Generate label" / "Issue invoice" actions land here on `#shipment` /
+  // `#invoicing`. Runs once the order data is present (the anchor wrapper divs
+  // render with it) — the app has no other hash-scroll, and the panels mount
+  // asynchronously, so a native browser jump on first paint would miss.
+  const hasOrder = query.data !== undefined;
+  useEffect(() => {
+    if (!hasOrder) return;
+    const targetId = location.hash.replace(/^#/, '');
+    if (!targetId) return;
+    const raf = requestAnimationFrame(() => {
+      const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        ? 'auto'
+        : 'smooth';
+      document.getElementById(targetId)?.scrollIntoView({ behavior, block: 'start' });
+    });
+    return () => { cancelAnimationFrame(raf); };
+  }, [hasOrder, location.hash]);
 
   const pendingDestinationId =
     retry.isPending && retry.variables ? retry.variables.destinationConnectionId : null;
@@ -290,8 +310,16 @@ export function OrderDetailPage(): ReactElement {
             sourcePlatformType={sourcePlatformType}
             carrier={carrier}
           />
-          <OrderShipmentPanel order={order} />
-          <OrderInvoicePanel order={order} />
+          {/* Anchor wrappers (#1713) for the orders-list deep-link CTAs
+              (`/orders/{id}#shipment`, `/orders/{id}#invoicing`). Page-level
+              divs so the target exists even while a panel is capability-gated
+              (renders null) or still loading. */}
+          <div id="shipment">
+            <OrderShipmentPanel order={order} />
+          </div>
+          <div id="invoicing">
+            <OrderInvoicePanel order={order} />
+          </div>
           <OrderCustomerCard customerId={order.customerId} sourceConnectionId={order.sourceConnectionId} />
         </div>
       </div>

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -739,4 +739,54 @@ describe('OrdersListPage', () => {
     const row = container.querySelector('.data-table__row') as HTMLElement;
     expect(within(row).queryByText(/more$/)).not.toBeInTheDocument();
   });
+
+  it('should offer "Issue invoice" and "Generate label" actions for an order with neither yet (#1713)', async () => {
+    // syncedOrder carries no invoice and no fulfillmentState (⇒ not-shipped).
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+
+    const invoiceCta = within(row).getByRole('link', { name: /issue invoice/i });
+    expect(invoiceCta).toHaveAttribute('href', '/orders/ol_order_synced#invoicing');
+    const labelCta = within(row).getByRole('link', { name: /generate label/i });
+    expect(labelCta).toHaveAttribute('href', '/orders/ol_order_synced#shipment');
+  });
+
+  it('should show status pills (not actions) once an invoice exists and the order is dispatched (#1713)', async () => {
+    const richOrder: OrderRecord = {
+      ...syncedOrder,
+      internalOrderId: 'ol_order_rich',
+      fulfillmentState: 'dispatched',
+      orderSnapshot: {
+        ...syncedOrder.orderSnapshot,
+        invoice: {
+          invoiceId: 'rec-1',
+          status: 'issued',
+          regulatoryStatus: 'accepted',
+          clearanceReference: 'KSEF-1',
+          confirmationDocumentAvailable: true,
+        },
+      },
+    };
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([richOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+
+    expect(within(row).queryByRole('link', { name: /issue invoice/i })).not.toBeInTheDocument();
+    expect(within(row).queryByRole('link', { name: /generate label/i })).not.toBeInTheDocument();
+    expect(within(row).getByText('Cleared')).toBeInTheDocument();
+    expect(within(row).getByText('Dispatched')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -506,12 +506,37 @@ describe('OrdersListPage', () => {
 
     await screen.findByText('ALG-882414');
     // Total's first-click default direction is descending (biggest first).
-    await user.click(screen.getByRole('button', { name: 'Total' }));
+    // The sort button's accessible name now carries its sorted state (#1713).
+    await user.click(screen.getByRole('button', { name: /^Total,/ }));
 
     await vi.waitFor(() => {
       const called = list.mock.calls.some(([filters]) => {
         const f = filters as { sort?: string; dir?: string } | undefined;
         return f?.sort === 'total' && f?.dir === 'desc';
+      });
+      expect(called).toBe(true);
+    });
+  });
+
+  it('should server-sort by payment and drop the offset when the Payment header is clicked (#1713)', async () => {
+    const user = userEvent.setup();
+    const list = vi.fn().mockResolvedValue(paginated([syncedOrder]));
+    const mockApi = createMockApiClient({
+      orders: { list },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    // Start on page 2 so the re-sort's offset-drop is observable.
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi, route: '/orders?offset=20' });
+
+    await screen.findByText('ALG-882414');
+    await user.click(screen.getByRole('button', { name: /^Payment/ }));
+
+    await vi.waitFor(() => {
+      const called = list.mock.calls.some(([filters, pagination]) => {
+        const f = filters as { sort?: string; dir?: string } | undefined;
+        const p = pagination as { offset?: number } | undefined;
+        return f?.sort === 'payment' && f?.dir === 'asc' && p?.offset === 0;
       });
       expect(called).toBe(true);
     });
@@ -532,7 +557,9 @@ describe('OrdersListPage', () => {
     });
 
     await screen.findByText('ALG-882414');
-    await user.click(screen.getByRole('button', { name: 'Ship-by' }));
+    // `/^Ship-by,/` targets the sort button (aria-label "Ship-by, sorted …"),
+    // not the "Ship-by ≤ 24h / overdue" chip (#1713).
+    await user.click(screen.getByRole('button', { name: /^Ship-by,/ }));
 
     await vi.waitFor(() => {
       const called = list.mock.calls.some(([filters]) => {
@@ -741,10 +768,19 @@ describe('OrdersListPage', () => {
   });
 
   it('should offer "Issue invoice" and "Generate label" actions for an order with neither yet (#1713)', async () => {
-    // syncedOrder carries no invoice and no fulfillmentState (⇒ not-shipped).
+    // Explicit not-shipped order (the Generate-label gate needs it explicit,
+    // never undefined — #1713) with no invoice, plus an invoicing-capable
+    // connection so the "Issue invoice" CTA is offered rather than an em dash.
+    const notShippedOrder: OrderRecord = { ...syncedOrder, fulfillmentState: 'not-shipped' };
+    const invoicingConnection: Connection = {
+      ...sampleConnection,
+      id: 'conn_invoicing_1',
+      name: 'KSeF',
+      enabledCapabilities: ['Invoicing'],
+    };
     const mockApi = createMockApiClient({
-      orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
-      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+      orders: { list: vi.fn().mockResolvedValue(paginated([notShippedOrder])) },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
     });
 
     const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
@@ -756,6 +792,24 @@ describe('OrdersListPage', () => {
     expect(invoiceCta).toHaveAttribute('href', '/orders/ol_order_synced#invoicing');
     const labelCta = within(row).getByRole('link', { name: /generate label/i });
     expect(labelCta).toHaveAttribute('href', '/orders/ol_order_synced#shipment');
+  });
+
+  it('should show an em dash for "Issue invoice" when no connection can issue invoices (#1713)', async () => {
+    const notShippedOrder: OrderRecord = { ...syncedOrder, fulfillmentState: 'not-shipped' };
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([notShippedOrder])) },
+      // sampleConnection has no Invoicing capability.
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-882414');
+    const row = container.querySelector('.data-table__row') as HTMLElement;
+
+    expect(within(row).queryByRole('link', { name: /issue invoice/i })).not.toBeInTheDocument();
+    // Generate label is still offered — it isn't invoicing-gated.
+    expect(within(row).getByRole('link', { name: /generate label/i })).toBeInTheDocument();
   });
 
   it('should show status pills (not actions) once an invoice exists and the order is dispatched (#1713)', async () => {

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -282,7 +282,8 @@ describe('OrdersListPage', () => {
 
     const detailRow = container.querySelector('.data-table__detail-row') as HTMLElement;
     expect(detailRow).not.toBeNull();
-    expect(within(detailRow).getByText('1 item')).toBeInTheDocument();
+    // The accordion now leads with an itemised list headed "Items (N)" (#1713).
+    expect(within(detailRow).getByText('Items (1)')).toBeInTheDocument();
     expect(row).toHaveAttribute('class', expect.stringContaining('data-table__row--expanded'));
 
     await user.click(row);
@@ -322,7 +323,11 @@ describe('OrdersListPage', () => {
 
       const card = container.querySelector('.data-table__card') as HTMLElement;
       expect(card).not.toBeNull();
-      expect(within(card).getByText('1 item')).toBeInTheDocument();
+      // The full field set is collapsed behind a "View full details" disclosure
+      // now (#1713); the summary shows up front. Expand it, then assert a field.
+      const disclosure = within(card).getByRole('button', { name: /view full details/i });
+      await user.click(disclosure);
+      expect(within(card).getByText('Items (1)')).toBeInTheDocument();
 
       const checkbox = within(card).getByRole('checkbox', { name: 'Select ol_order_synced' });
       await user.click(checkbox);
@@ -711,7 +716,10 @@ describe('OrdersListPage', () => {
 
     await screen.findByText('ALG-882414');
     const row = container.querySelector('.data-table__row') as HTMLElement;
-    expect(within(row).getByText('Filtr kubełkowy AquaPro +2 more')).toBeInTheDocument();
+    // The first item name truncates in its own span; the "+N" count is a separate
+    // never-truncated chip now (#1713), so assert the two pieces independently.
+    expect(within(row).getByText('Filtr kubełkowy AquaPro')).toBeInTheDocument();
+    expect(within(row).getByText('+2')).toBeInTheDocument();
   });
 
   it('should not render an items preview line when the snapshot has no named items (#1646)', async () => {

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -24,7 +24,7 @@
  *
  * @module pages/orders
  */
-import { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
@@ -53,6 +53,7 @@ import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../shared/config/demo-mode';
 import { useDemoMode } from '../../features/system';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
 import { deriveOrderHealth, slaBadge, fulfillmentBadge } from '../../features/orders/lib/order-health';
+import { itemsSummary, paymentBadge } from '../../features/orders/lib/order-row';
 import { capSelectionPerSource, sourcesAtCap } from '../../features/orders/lib/dispatch-input';
 import { BulkDispatchDialog } from '../../features/orders/components/bulk-dispatch-dialog';
 import { OrderRowDetail } from '../../features/orders/components/order-row-detail';
@@ -126,28 +127,14 @@ function isOrderDir(value: string | null): value is OrderSortDirection {
 }
 
 /**
- * Sortable-column wiring (#944). The table column `id` and the server sort key
- * diverge only for ship-by (`shipBy` column ↔ `dispatchBy` key); the rest match.
- * Columns not in these maps (Order / Channel / Payment / actions) aren't sortable.
+ * Native react-table-sortable columns (#1713): only these two carry the built-in
+ * header-button + arrow. Their column `id` equals the server sort key. Every
+ * other sortable field (ship-by, fulfillment, total, payment, created) lives in
+ * a merged column whose header renders its own per-label sort controls that call
+ * `applySort` directly — so those keys are driven by custom buttons, not by
+ * react-table's single-column sorting model.
  */
-const SORT_KEY_TO_COLUMN: Record<OrderSortValue, string> = {
-  dispatchBy: 'shipBy',
-  createdAt: 'createdAt',
-  customer: 'customer',
-  items: 'items',
-  status: 'status',
-  total: 'total',
-  fulfillment: 'fulfillment',
-};
-const COLUMN_TO_SORT_KEY: Record<string, OrderSortValue> = {
-  shipBy: 'dispatchBy',
-  createdAt: 'createdAt',
-  customer: 'customer',
-  items: 'items',
-  status: 'status',
-  total: 'total',
-  fulfillment: 'fulfillment',
-};
+const NATIVE_SORTABLE_COLUMNS: readonly OrderSortValue[] = ['customer', 'status'];
 
 /**
  * First-click direction per sort key (#944): the operator-intuitive default
@@ -162,6 +149,7 @@ const DEFAULT_DIR: Record<OrderSortValue, OrderSortDirection> = {
   status: 'asc',
   total: 'desc',
   fulfillment: 'asc',
+  payment: 'asc',
 };
 
 /** Type-guard for the `slaState` URL filter (#1108). */
@@ -234,21 +222,6 @@ function customerName(parsed: ReturnType<typeof parseOrderSnapshot>): string | n
   const name = [a?.firstName, a?.lastName].filter(Boolean).join(' ').trim();
   if (name.length > 0) return name;
   return parsed.customerEmail ?? null;
-}
-
-/**
- * Compact items preview for the collapsed row (#1646). Live feedback: the
- * order's contents were only visible after expanding the accordion — this
- * gives an at-a-glance signal in the Order cell without duplicating the full
- * per-line quantities/prices, which stay in `OrderRowDetail`. First item name
- * plus a "+N more" suffix when the order has more than one line; `null` when
- * the snapshot carries no named items (parse failure or genuinely empty).
- */
-function itemsPreview(parsed: ReturnType<typeof parseOrderSnapshot>): string | null {
-  const names = parsed.items.map((i) => i.name).filter((n): n is string => Boolean(n));
-  if (names.length === 0) return null;
-  const [first, ...rest] = names;
-  return rest.length > 0 ? `${first} +${rest.length} more` : first;
 }
 
 /**
@@ -476,6 +449,53 @@ export function OrdersListPage(): ReactElement {
     );
   }
 
+  /**
+   * Apply a server-side sort (#1713): clicking a sort key flips its direction
+   * when it's already active, else starts at the key's default direction. The
+   * single entry point for both the native react-table columns (customer /
+   * status) and the merged-column per-label sort buttons. Drops `offset` so a
+   * re-sort lands on page 1. Stable across renders except when the active
+   * sort/dir change, so the columns memo (which renders the sort buttons in its
+   * headers) rebuilds exactly when the active-state arrows need to.
+   */
+  const applySort = useCallback(
+    (key: OrderSortValue): void => {
+      const nextDir: OrderSortDirection =
+        key === sort ? (dir === 'asc' ? 'desc' : 'asc') : DEFAULT_DIR[key];
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev);
+        p.set('sort', key);
+        p.set('dir', nextDir);
+        p.delete('offset');
+        return p;
+      });
+    },
+    [sort, dir, setSearchParams],
+  );
+
+  /** Render one per-label sort control for a merged-column header (#1713). */
+  const sortLabel = useCallback(
+    (label: string, key: OrderSortValue): ReactElement => {
+      const active = sort === key;
+      return (
+        <button
+          type="button"
+          className={['orders-sortbtn', active ? 'orders-sortbtn--active' : '']
+            .filter(Boolean)
+            .join(' ')}
+          onClick={() => { applySort(key); }}
+          aria-pressed={active}
+        >
+          {label}
+          <span className="orders-sortbtn__ind" aria-hidden="true">
+            {active ? (dir === 'asc' ? '▲' : '▼') : '↕'}
+          </span>
+        </button>
+      );
+    },
+    [sort, dir, applySort],
+  );
+
   const columns: DataTableColumn<OrderRecord>[] = useMemo(
     () => [
       {
@@ -498,7 +518,13 @@ export function OrdersListPage(): ReactElement {
         header: 'Order',
         cell: (order) => {
           const parsed = parseOrderSnapshot(order.orderSnapshot);
-          const preview = itemsPreview(parsed);
+          const items = itemsSummary(parsed.items);
+          const sourcePlatform = platformByConnection.get(order.sourceConnectionId);
+          const source = channelLabel(sourcePlatform);
+          const destPlatform = order.syncStatus[0]
+            ? platformByConnection.get(order.syncStatus[0].destinationConnectionId)
+            : undefined;
+          const dest = channelLabel(destPlatform);
           return (
             <span className="orders-cell-stack">
               <EntityLabel
@@ -506,9 +532,28 @@ export function OrdersListPage(): ReactElement {
                 name={formatOrderRef(parsed.orderNumber) || order.internalOrderId}
                 to={order.internalOrderId}
               />
-              {preview ? (
-                <span className="text-muted orders-cell-sub orders-items-preview" title={preview}>
-                  {preview}
+              {items ? (
+                <span className="orders-items-line">
+                  <span
+                    className="text-muted orders-cell-sub orders-items-preview"
+                    title={items.firstName}
+                  >
+                    {items.firstName}
+                  </span>
+                  {items.moreCount > 0 ? (
+                    <span className="orders-more-count">+{items.moreCount}</span>
+                  ) : null}
+                </span>
+              ) : null}
+              {/* Channel folds under the order name below the Channel column's
+                  hide breakpoint (#1713) — hidden on wide screens where the
+                  standalone Channel column is visible. */}
+              {source ? (
+                <span className="orders-order-channel">
+                  <span className="channel-pill" data-channel={sourcePlatform}>
+                    {source}
+                  </span>
+                  {dest ? <span className="text-muted orders-cell-sub">→ {dest}</span> : null}
                 </span>
               ) : null}
             </span>
@@ -535,6 +580,9 @@ export function OrdersListPage(): ReactElement {
       {
         id: 'channel',
         header: 'Channel',
+        // Folds under the order name below 1024px (#1713) — the order cell then
+        // renders the channel pill inline instead.
+        hideBelow: 1024,
         cell: (order) => {
           const source = channelLabel(platformByConnection.get(order.sourceConnectionId));
           const destPlatform = order.syncStatus[0]
@@ -573,56 +621,90 @@ export function OrdersListPage(): ReactElement {
         },
       },
       {
-        id: 'shipBy',
-        header: 'Ship-by',
-        sortable: true,
+        id: 'shipment',
+        // Merged dispatch column (#1713): fulfillment status + ship-by SLA (with
+        // the live countdown) + carrier, one per-label sort control each in the
+        // header. Not `sortable` — the header renders its own sort buttons.
+        header: (
+          <span className="orders-sortstack orders-sortstack--left">
+            {sortLabel('Shipment', 'fulfillment')}
+            {sortLabel('Ship-by', 'dispatchBy')}
+          </span>
+        ),
         cell: (order) => {
+          const parsed = parseOrderSnapshot(order.orderSnapshot);
+          const f = fulfillmentBadge(order.fulfillmentState);
+          // BE-owned SLA bucket drives the badge (#1108); the live countdown
+          // stays client-side, falling back to the client-derived urgency for
+          // older payloads without slaState.
+          const sla = slaBadge(order.slaState);
           const due = order.dispatchByAt ?? null;
           const view = formatShipBy(due);
-          if (!due || !view) return <span className="text-muted">—</span>;
-          // BE-owned SLA bucket drives the badge (#1108) — single source of truth
-          // the filter agrees with; the live countdown stays client-side. Falls
-          // back to the client-derived urgency for older payloads without slaState.
-          // The exact ship-by date moved to the expandable detail panel (#1620).
-          const sla = slaBadge(order.slaState);
-          const tone = sla ? sla.tone : SHIP_BY_TONE[view.level];
-          const label = sla ? sla.label : view.remaining;
+          // Carrier at row level (#1617): the list can't fetch per-order
+          // shipments, so `shipping.methodName` (the source's stated delivery
+          // method) is the best signal, falling back to the pickup-point name.
+          const carrier = parsed.shipping?.methodName ?? parsed.pickupPoint?.name ?? null;
           return (
             <span className="orders-cell-stack">
-              <StatusBadge tone={tone} withDot compact>
-                {label}
+              <StatusBadge tone={f.tone} withDot compact>
+                {f.label}
               </StatusBadge>
               {sla ? (
-                <span className="text-muted orders-cell-sub mono tabular">{view.remaining}</span>
+                <span className="orders-shipby-row">
+                  <StatusBadge tone={sla.tone} withDot compact>
+                    {sla.label}
+                  </StatusBadge>
+                  {view ? (
+                    <span className="text-muted orders-cell-sub mono tabular">{view.remaining}</span>
+                  ) : null}
+                </span>
+              ) : due && view ? (
+                <StatusBadge tone={SHIP_BY_TONE[view.level]} withDot compact>
+                  {view.remaining}
+                </StatusBadge>
+              ) : null}
+              {carrier ? (
+                <span className="text-muted orders-cell-sub orders-carrier" title={carrier}>
+                  {carrier}
+                </span>
               ) : null}
             </span>
           );
         },
       },
       {
-        id: 'fulfillment',
-        header: 'Fulfillment',
-        sortable: true,
-        cell: (order) => {
-          const f = fulfillmentBadge(order.fulfillmentState);
-          return (
-            <StatusBadge tone={f.tone} withDot compact>
-              {f.label}
-            </StatusBadge>
-          );
-        },
-      },
-      {
-        id: 'total',
-        header: 'Total',
+        id: 'money',
         align: 'right',
-        sortable: true,
+        // Merged money column (#1713): total + payment pill + created, each an
+        // independent per-label sort control in the header. Not `sortable` — the
+        // header renders its own sort buttons.
+        header: (
+          <span className="orders-sortstack orders-sortstack--right">
+            {sortLabel('Total', 'total')}
+            {sortLabel('Payment', 'payment')}
+            {sortLabel('Created', 'createdAt')}
+          </span>
+        ),
         cell: (order) => {
           const parsed = parseOrderSnapshot(order.orderSnapshot);
-          if (!parsed.totals) return <span className="text-muted">—</span>;
+          const pay = paymentBadge(parsed.paymentStatus);
           return (
-            <span className="mono tabular">
-              {formatCurrency(parsed.totals.total, parsed.totals.currency, locale)}
+            <span className="orders-cell-stack orders-cell-stack--end">
+              {parsed.totals ? (
+                <span className="mono tabular orders-money-total">
+                  {formatCurrency(parsed.totals.total, parsed.totals.currency, locale)}
+                </span>
+              ) : (
+                <span className="text-muted">—</span>
+              )}
+              {pay ? (
+                <StatusBadge tone={pay.tone} withDot compact>
+                  {pay.label}
+                </StatusBadge>
+              ) : null}
+              <span className="text-muted orders-cell-sub mono tabular">
+                <TimeDisplay iso={order.createdAt} format="datetime" />
+              </span>
             </span>
           );
         },
@@ -667,6 +749,10 @@ export function OrdersListPage(): ReactElement {
       selectedIds,
       atCapSources,
       headerCheckboxState,
+      // Sort controls in the merged-column headers (#1713) — rebuild so the
+      // active-state arrows track the current sort/dir. `sortLabel` is a
+      // useCallback keyed on sort/dir, so this rebuilds exactly on a sort change.
+      sortLabel,
     ],
   );
 
@@ -745,10 +831,14 @@ export function OrdersListPage(): ReactElement {
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
 
-  // Controlled (server-side) sort state for the DataTable (#944): the active
-  // sort key → its table column id, plus direction. Structurally a
+  // Controlled (server-side) sort state for the DataTable (#944/#1713): only the
+  // two native-sortable columns (customer / status) drive react-table's arrow;
+  // merged-column keys render their own arrows via the per-label sort buttons, so
+  // the SortingState is empty when one of those is active. Structurally a
   // `SortingState` ({ id, desc }[]) without importing the react-table type.
-  const sortingState = [{ id: SORT_KEY_TO_COLUMN[sort], desc: dir === 'desc' }];
+  const sortingState = NATIVE_SORTABLE_COLUMNS.includes(sort)
+    ? [{ id: sort, desc: dir === 'desc' }]
+    : [];
 
   const freshness = useMemo(
     () => formatFreshness(query.data?.items ?? [], locale),
@@ -975,25 +1065,16 @@ export function OrdersListPage(): ReactElement {
             manualSorting
             sort={sortingState}
             onSortChange={(updater) => {
-              // Server-side sort (#944): take the column the user interacted
-              // with (the new state's column, or the active one when react-table
-              // cleared on a third click), then apply our own asc⇄desc toggle —
-              // same column flips, a new column starts at its default direction.
+              // Server-side sort (#944/#1713): react-table only fires this for the
+              // native-sortable columns (customer / status), whose column id equals
+              // the sort key. Resolve the interacted column and delegate to the
+              // shared `applySort` toggle. Merged-column keys go through their own
+              // header buttons, not this path.
               const next =
                 typeof updater === 'function' ? updater(sortingState) : updater;
-              const clickedColumnId =
-                next.length > 0 ? next[0].id : SORT_KEY_TO_COLUMN[sort];
-              const key = COLUMN_TO_SORT_KEY[clickedColumnId];
-              if (!key) return;
-              const nextDir: OrderSortDirection =
-                key === sort ? (dir === 'asc' ? 'desc' : 'asc') : DEFAULT_DIR[key];
-              setSearchParams((prev) => {
-                const p = new URLSearchParams(prev);
-                p.set('sort', key);
-                p.set('dir', nextDir);
-                p.delete('offset');
-                return p;
-              });
+              const clickedColumnId = next.length > 0 ? next[0].id : sort;
+              if (!isOrderSort(clickedColumnId)) return;
+              applySort(clickedColumnId);
             }}
             cardView={{
               // Per-row select stays usable in the mobile card layout (#1109/#1620).
@@ -1008,9 +1089,26 @@ export function OrdersListPage(): ReactElement {
                   />
                 );
               },
-              subtitle: (order) => <TimeDisplay iso={order.createdAt} format="relative" />,
-              // Full field set below the badges — the mobile counterpart of the
-              // desktop accordion; a collapsed card still shows every field (#1620).
+              subtitle: (order) => {
+                const source = channelLabel(platformByConnection.get(order.sourceConnectionId));
+                return (
+                  <span className="orders-card-sub">
+                    {source ? (
+                      <span
+                        className="channel-pill"
+                        data-channel={platformByConnection.get(order.sourceConnectionId)}
+                      >
+                        {source}
+                      </span>
+                    ) : null}
+                    <TimeDisplay iso={order.createdAt} format="relative" />
+                  </span>
+                );
+              },
+              // Full field set behind a "View full details" disclosure (#1713) —
+              // the mobile counterpart of the desktop accordion. Collapsed by
+              // default so the card leads with the summary, not a wall of fields.
+              collapsibleDetail: true,
               detail: (order) => (
                 <OrderRowDetail
                   order={order}
@@ -1018,9 +1116,68 @@ export function OrdersListPage(): ReactElement {
                   platformByConnection={platformByConnection}
                 />
               ),
+              // Scannable essentials shown before expanding (#1713): the items
+              // summary plus a tight facts grid (total / payment / customer /
+              // created / shipment carrier).
+              summary: (order) => {
+                const parsed = parseOrderSnapshot(order.orderSnapshot);
+                const items = itemsSummary(parsed.items);
+                const pay = paymentBadge(parsed.paymentStatus);
+                const cust = customerName(parsed);
+                const carrier = parsed.shipping?.methodName ?? parsed.pickupPoint?.name ?? null;
+                return (
+                  <div className="orders-card-summary">
+                    {items ? (
+                      <div className="orders-items-line">
+                        <span className="orders-items-preview" title={items.firstName}>
+                          {items.firstName}
+                        </span>
+                        {items.moreCount > 0 ? (
+                          <span className="orders-more-count">+{items.moreCount}</span>
+                        ) : null}
+                      </div>
+                    ) : null}
+                    <dl className="orders-card-facts">
+                      <div>
+                        <dt>Total</dt>
+                        <dd className="mono tabular">
+                          {parsed.totals
+                            ? formatCurrency(parsed.totals.total, parsed.totals.currency, locale)
+                            : '—'}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>Payment</dt>
+                        <dd>
+                          {pay ? (
+                            <StatusBadge tone={pay.tone} withDot compact>
+                              {pay.label}
+                            </StatusBadge>
+                          ) : (
+                            '—'
+                          )}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>Customer</dt>
+                        <dd>{cust ?? '—'}</dd>
+                      </div>
+                      <div>
+                        <dt>Created</dt>
+                        <dd className="mono tabular">
+                          <TimeDisplay iso={order.createdAt} format="datetime" />
+                        </dd>
+                      </div>
+                      <div className="orders-card-facts__wide">
+                        <dt>Shipment</dt>
+                        <dd>{carrier ?? '—'}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                );
+              },
               meta: (order) => {
                 const h = deriveOrderHealth(order);
-                const source = channelLabel(platformByConnection.get(order.sourceConnectionId));
                 const shipBy = formatShipBy(order.dispatchByAt ?? null);
                 const sla = slaBadge(order.slaState);
                 const fulfillment = fulfillmentBadge(order.fulfillmentState);
@@ -1030,14 +1187,6 @@ export function OrdersListPage(): ReactElement {
                   retryMutation.variables?.internalOrderId === order.internalOrderId;
                 return (
                   <span className="data-table__badge-row">
-                    {source && (
-                      <span
-                        className="channel-pill"
-                        data-channel={platformByConnection.get(order.sourceConnectionId)}
-                      >
-                        {source}
-                      </span>
-                    )}
                     <StatusBadge tone={h.tone} withDot compact>
                       {h.label}
                     </StatusBadge>

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -53,7 +53,7 @@ import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../shared/config/demo-mode';
 import { useDemoMode } from '../../features/system';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
 import { deriveOrderHealth, slaBadge, fulfillmentBadge } from '../../features/orders/lib/order-health';
-import { itemsSummary, paymentBadge } from '../../features/orders/lib/order-row';
+import { itemsSummary, paymentBadge, invoiceBadge } from '../../features/orders/lib/order-row';
 import { capSelectionPerSource, sourcesAtCap } from '../../features/orders/lib/dispatch-input';
 import { BulkDispatchDialog } from '../../features/orders/components/bulk-dispatch-dialog';
 import { OrderRowDetail } from '../../features/orders/components/order-row-detail';
@@ -644,11 +644,27 @@ export function OrdersListPage(): ReactElement {
           // shipments, so `shipping.methodName` (the source's stated delivery
           // method) is the best signal, falling back to the pickup-point name.
           const carrier = parsed.shipping?.methodName ?? parsed.pickupPoint?.name ?? null;
+          // Nothing dispatched yet → offer the action instead of a passive
+          // "Not shipped" status (#1713): deep-link to the order's shipment
+          // section where the operator generates the label.
+          const notShipped = (order.fulfillmentState ?? 'not-shipped') === 'not-shipped';
           return (
             <span className="orders-cell-stack">
-              <StatusBadge tone={f.tone} withDot compact>
-                {f.label}
-              </StatusBadge>
+              {notShipped ? (
+                <Link
+                  className="orders-row-cta"
+                  to={`/orders/${order.internalOrderId}#shipment`}
+                >
+                  <span className="orders-row-cta__plus" aria-hidden="true">
+                    +
+                  </span>{' '}
+                  Generate label
+                </Link>
+              ) : (
+                <StatusBadge tone={f.tone} withDot compact>
+                  {f.label}
+                </StatusBadge>
+              )}
               {sla ? (
                 <span className="orders-shipby-row">
                   <StatusBadge tone={sla.tone} withDot compact>
@@ -688,6 +704,7 @@ export function OrdersListPage(): ReactElement {
         cell: (order) => {
           const parsed = parseOrderSnapshot(order.orderSnapshot);
           const pay = paymentBadge(parsed.paymentStatus);
+          const inv = parsed.invoice ? invoiceBadge(parsed.invoice) : null;
           return (
             <span className="orders-cell-stack orders-cell-stack--end">
               {parsed.totals ? (
@@ -702,6 +719,24 @@ export function OrdersListPage(): ReactElement {
                   {pay.label}
                 </StatusBadge>
               ) : null}
+              {/* Invoice: the clearance-status pill when an invoice exists, else
+                  the "Issue invoice" action deep-linking to the order's invoicing
+                  section (#1713). */}
+              {inv ? (
+                <StatusBadge tone={inv.tone} withDot compact>
+                  {inv.label}
+                </StatusBadge>
+              ) : (
+                <Link
+                  className="orders-row-cta"
+                  to={`/orders/${order.internalOrderId}#invoicing`}
+                >
+                  <span className="orders-row-cta__plus" aria-hidden="true">
+                    +
+                  </span>{' '}
+                  Issue invoice
+                </Link>
+              )}
               <span className="text-muted orders-cell-sub mono tabular">
                 <TimeDisplay iso={order.createdAt} format="datetime" />
               </span>
@@ -1125,6 +1160,8 @@ export function OrdersListPage(): ReactElement {
                 const pay = paymentBadge(parsed.paymentStatus);
                 const cust = customerName(parsed);
                 const carrier = parsed.shipping?.methodName ?? parsed.pickupPoint?.name ?? null;
+                const inv = parsed.invoice ? invoiceBadge(parsed.invoice) : null;
+                const notShipped = (order.fulfillmentState ?? 'not-shipped') === 'not-shipped';
                 return (
                   <div className="orders-card-summary">
                     {items ? (
@@ -1159,6 +1196,26 @@ export function OrdersListPage(): ReactElement {
                         </dd>
                       </div>
                       <div>
+                        <dt>Invoice</dt>
+                        <dd>
+                          {inv ? (
+                            <StatusBadge tone={inv.tone} withDot compact>
+                              {inv.label}
+                            </StatusBadge>
+                          ) : (
+                            <Link
+                              className="orders-row-cta"
+                              to={`/orders/${order.internalOrderId}#invoicing`}
+                            >
+                              <span className="orders-row-cta__plus" aria-hidden="true">
+                                +
+                              </span>{' '}
+                              Issue invoice
+                            </Link>
+                          )}
+                        </dd>
+                      </div>
+                      <div>
                         <dt>Customer</dt>
                         <dd>{cust ?? '—'}</dd>
                       </div>
@@ -1170,7 +1227,21 @@ export function OrdersListPage(): ReactElement {
                       </div>
                       <div className="orders-card-facts__wide">
                         <dt>Shipment</dt>
-                        <dd>{carrier ?? '—'}</dd>
+                        <dd>
+                          {notShipped ? (
+                            <Link
+                              className="orders-row-cta"
+                              to={`/orders/${order.internalOrderId}#shipment`}
+                            >
+                              <span className="orders-row-cta__plus" aria-hidden="true">
+                                +
+                              </span>{' '}
+                              Generate label
+                            </Link>
+                          ) : (
+                            (carrier ?? '—')
+                          )}
+                        </dd>
                       </div>
                     </dl>
                   </div>

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -127,16 +127,6 @@ function isOrderDir(value: string | null): value is OrderSortDirection {
 }
 
 /**
- * Native react-table-sortable columns (#1713): only these two carry the built-in
- * header-button + arrow. Their column `id` equals the server sort key. Every
- * other sortable field (ship-by, fulfillment, total, payment, created) lives in
- * a merged column whose header renders its own per-label sort controls that call
- * `applySort` directly — so those keys are driven by custom buttons, not by
- * react-table's single-column sorting model.
- */
-const NATIVE_SORTABLE_COLUMNS: readonly OrderSortValue[] = ['customer', 'status'];
-
-/**
  * First-click direction per sort key (#944): the operator-intuitive default
  * when a column is newly selected. Re-clicking the active column flips it.
  * Ship-by asc (soonest first) is the list's default sort state.
@@ -347,6 +337,32 @@ export function OrdersListPage(): ReactElement {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkOpen, setBulkOpen] = useState(false);
 
+  // Parse each row's snapshot once per page (#1713) — the order / customer /
+  // shipment / money cells and the mobile summary all read the same parse
+  // instead of re-parsing per cell. Keyed by internalOrderId over the current
+  // page's items.
+  const parsedByOrder = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof parseOrderSnapshot>>();
+    for (const order of query.data?.items ?? []) {
+      map.set(order.internalOrderId, parseOrderSnapshot(order.orderSnapshot));
+    }
+    return map;
+  }, [query.data?.items]);
+  const parsedFor = useCallback(
+    (order: OrderRecord): ReturnType<typeof parseOrderSnapshot> =>
+      parsedByOrder.get(order.internalOrderId) ?? parseOrderSnapshot(order.orderSnapshot),
+    [parsedByOrder],
+  );
+
+  // Whether ANY connection exposes the Invoicing capability (#1713). When none
+  // does, the "Issue invoice" CTA degrades to an em dash — the platform can't
+  // issue invoices, so offering the action would dead-end. An existing invoice
+  // pill still renders regardless (the record exists independent of this gate).
+  const hasInvoicingCapability = useMemo(
+    () => (connectionsQuery.data ?? []).some((c) => c.enabledCapabilities.includes('Invoicing')),
+    [connectionsQuery.data],
+  );
+
   // Already-shipped orders can't be dispatched — their checkbox is disabled.
   const isSelectable = (order: OrderRecord): boolean =>
     order.fulfillmentState !== 'dispatched' && order.fulfillmentState !== 'delivered';
@@ -485,6 +501,11 @@ export function OrdersListPage(): ReactElement {
             .join(' ')}
           onClick={() => { applySort(key); }}
           aria-pressed={active}
+          aria-label={
+            active
+              ? `${label}, sorted ${dir === 'asc' ? 'ascending' : 'descending'}`
+              : `${label}, sort`
+          }
         >
           {label}
           <span className="orders-sortbtn__ind" aria-hidden="true">
@@ -517,7 +538,7 @@ export function OrdersListPage(): ReactElement {
         id: 'order',
         header: 'Order',
         cell: (order) => {
-          const parsed = parseOrderSnapshot(order.orderSnapshot);
+          const parsed = parsedFor(order);
           const items = itemsSummary(parsed.items);
           const sourcePlatform = platformByConnection.get(order.sourceConnectionId);
           const source = channelLabel(sourcePlatform);
@@ -525,6 +546,9 @@ export function OrdersListPage(): ReactElement {
             ? platformByConnection.get(order.syncStatus[0].destinationConnectionId)
             : undefined;
           const dest = channelLabel(destPlatform);
+          // Multi-destination indicator (#1713): an order fanned out to more than
+          // one destination shows `→ Dest +N` where N is the extra destinations.
+          const extraDests = order.syncStatus.length > 1 ? order.syncStatus.length - 1 : 0;
           return (
             <span className="orders-cell-stack">
               <EntityLabel
@@ -553,7 +577,12 @@ export function OrdersListPage(): ReactElement {
                   <span className="channel-pill" data-channel={sourcePlatform}>
                     {source}
                   </span>
-                  {dest ? <span className="text-muted orders-cell-sub">→ {dest}</span> : null}
+                  {dest ? (
+                    <span className="text-muted orders-cell-sub">
+                      → {dest}
+                      {extraDests > 0 ? ` +${extraDests}` : ''}
+                    </span>
+                  ) : null}
                 </span>
               ) : null}
             </span>
@@ -562,10 +591,12 @@ export function OrdersListPage(): ReactElement {
       },
       {
         id: 'customer',
-        header: 'Customer',
-        sortable: true,
+        // Non-sortable in react-table's model (#1713) — the header renders the
+        // same per-label sort control as the merged columns, routed through
+        // `applySort`, so every sortable header shares one affordance.
+        header: <span className="orders-sortstack">{sortLabel('Customer', 'customer')}</span>,
         cell: (order) => {
-          const parsed = parseOrderSnapshot(order.orderSnapshot);
+          const parsed = parsedFor(order);
           const name = customerName(parsed);
           if (!name) return <span className="text-muted">—</span>;
           const city = parsed.shippingAddress?.city;
@@ -602,8 +633,9 @@ export function OrdersListPage(): ReactElement {
       },
       {
         id: 'status',
-        header: 'Status',
-        sortable: true,
+        // Non-sortable in react-table's model (#1713) — header uses the shared
+        // per-label sort control (see the customer column).
+        header: <span className="orders-sortstack">{sortLabel('Status', 'status')}</span>,
         cell: (order) => {
           const h = deriveOrderHealth(order);
           return (
@@ -632,7 +664,7 @@ export function OrdersListPage(): ReactElement {
           </span>
         ),
         cell: (order) => {
-          const parsed = parseOrderSnapshot(order.orderSnapshot);
+          const parsed = parsedFor(order);
           const f = fulfillmentBadge(order.fulfillmentState);
           // BE-owned SLA bucket drives the badge (#1108); the live countdown
           // stays client-side, falling back to the client-derived urgency for
@@ -644,13 +676,15 @@ export function OrdersListPage(): ReactElement {
           // shipments, so `shipping.methodName` (the source's stated delivery
           // method) is the best signal, falling back to the pickup-point name.
           const carrier = parsed.shipping?.methodName ?? parsed.pickupPoint?.name ?? null;
-          // Nothing dispatched yet → offer the action instead of a passive
-          // "Not shipped" status (#1713): deep-link to the order's shipment
-          // section where the operator generates the label.
-          const notShipped = (order.fulfillmentState ?? 'not-shipped') === 'not-shipped';
+          // Offer "Generate label" ONLY when fulfillment is EXPLICITLY not-shipped
+          // and the order isn't cancelled (#1713). An undefined fulfillmentState
+          // (genuinely unknown) or a cancelled order shows the passive fulfillment
+          // badge instead — never a dead-end action.
+          const canGenerateLabel =
+            order.fulfillmentState === 'not-shipped' && parsed.status !== 'cancelled';
           return (
             <span className="orders-cell-stack">
-              {notShipped ? (
+              {canGenerateLabel ? (
                 <Link
                   className="orders-row-cta"
                   to={`/orders/${order.internalOrderId}#shipment`}
@@ -702,7 +736,7 @@ export function OrdersListPage(): ReactElement {
           </span>
         ),
         cell: (order) => {
-          const parsed = parseOrderSnapshot(order.orderSnapshot);
+          const parsed = parsedFor(order);
           const pay = paymentBadge(parsed.paymentStatus);
           const inv = parsed.invoice ? invoiceBadge(parsed.invoice) : null;
           return (
@@ -719,14 +753,15 @@ export function OrdersListPage(): ReactElement {
                   {pay.label}
                 </StatusBadge>
               ) : null}
-              {/* Invoice: the clearance-status pill when an invoice exists, else
+              {/* Invoice: the clearance-status pill when an invoice exists; else
                   the "Issue invoice" action deep-linking to the order's invoicing
-                  section (#1713). */}
+                  section — but only when some connection can actually issue an
+                  invoice (#1713). No invoicing capability ⇒ em dash. */}
               {inv ? (
                 <StatusBadge tone={inv.tone} withDot compact>
                   {inv.label}
                 </StatusBadge>
-              ) : (
+              ) : hasInvoicingCapability ? (
                 <Link
                   className="orders-row-cta"
                   to={`/orders/${order.internalOrderId}#invoicing`}
@@ -736,6 +771,8 @@ export function OrdersListPage(): ReactElement {
                   </span>{' '}
                   Issue invoice
                 </Link>
+              ) : (
+                <span className="text-muted">—</span>
               )}
               <span className="text-muted orders-cell-sub mono tabular">
                 <TimeDisplay iso={order.createdAt} format="datetime" />
@@ -788,6 +825,9 @@ export function OrdersListPage(): ReactElement {
       // active-state arrows track the current sort/dir. `sortLabel` is a
       // useCallback keyed on sort/dir, so this rebuilds exactly on a sort change.
       sortLabel,
+      // Per-page snapshot cache + invoicing-capability gate (#1713).
+      parsedFor,
+      hasInvoicingCapability,
     ],
   );
 
@@ -865,15 +905,6 @@ export function OrdersListPage(): ReactElement {
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
-
-  // Controlled (server-side) sort state for the DataTable (#944/#1713): only the
-  // two native-sortable columns (customer / status) drive react-table's arrow;
-  // merged-column keys render their own arrows via the per-label sort buttons, so
-  // the SortingState is empty when one of those is active. Structurally a
-  // `SortingState` ({ id, desc }[]) without importing the react-table type.
-  const sortingState = NATIVE_SORTABLE_COLUMNS.includes(sort)
-    ? [{ id: sort, desc: dir === 'desc' }]
-    : [];
 
   const freshness = useMemo(
     () => formatFreshness(query.data?.items ?? [], locale),
@@ -1097,25 +1128,17 @@ export function OrdersListPage(): ReactElement {
               toggleLabel: (order, expanded) =>
                 `${expanded ? 'Collapse' : 'Expand'} details for order ${order.internalOrderId}`,
             }}
+            // Server-side ordering (#944/#1713): every sortable header (customer,
+            // status, and the merged shipment/money columns) renders its own
+            // per-label sort control that calls `applySort` directly, so no
+            // column is react-table-sortable and `onSortChange` never fires.
+            // `manualSorting` keeps react-table from client-sorting the page.
             manualSorting
-            sort={sortingState}
-            onSortChange={(updater) => {
-              // Server-side sort (#944/#1713): react-table only fires this for the
-              // native-sortable columns (customer / status), whose column id equals
-              // the sort key. Resolve the interacted column and delegate to the
-              // shared `applySort` toggle. Merged-column keys go through their own
-              // header buttons, not this path.
-              const next =
-                typeof updater === 'function' ? updater(sortingState) : updater;
-              const clickedColumnId = next.length > 0 ? next[0].id : sort;
-              if (!isOrderSort(clickedColumnId)) return;
-              applySort(clickedColumnId);
-            }}
             cardView={{
               // Per-row select stays usable in the mobile card layout (#1109/#1620).
               select: (order) => renderSelectCheckbox(order),
               title: (order) => {
-                const parsed = parseOrderSnapshot(order.orderSnapshot);
+                const parsed = parsedFor(order);
                 return (
                   <EntityLabel
                     id={order.internalOrderId}
@@ -1126,6 +1149,13 @@ export function OrdersListPage(): ReactElement {
               },
               subtitle: (order) => {
                 const source = channelLabel(platformByConnection.get(order.sourceConnectionId));
+                const destPlatform = order.syncStatus[0]
+                  ? platformByConnection.get(order.syncStatus[0].destinationConnectionId)
+                  : undefined;
+                const dest = channelLabel(destPlatform);
+                // Multi-destination indicator (#1713) — extra destinations beyond
+                // the first, mirroring the desktop order cell.
+                const extraDests = order.syncStatus.length > 1 ? order.syncStatus.length - 1 : 0;
                 return (
                   <span className="orders-card-sub">
                     {source ? (
@@ -1134,6 +1164,12 @@ export function OrdersListPage(): ReactElement {
                         data-channel={platformByConnection.get(order.sourceConnectionId)}
                       >
                         {source}
+                      </span>
+                    ) : null}
+                    {dest ? (
+                      <span className="text-muted orders-cell-sub">
+                        → {dest}
+                        {extraDests > 0 ? ` +${extraDests}` : ''}
                       </span>
                     ) : null}
                     <TimeDisplay iso={order.createdAt} format="relative" />
@@ -1155,13 +1191,17 @@ export function OrdersListPage(): ReactElement {
               // summary plus a tight facts grid (total / payment / customer /
               // created / shipment carrier).
               summary: (order) => {
-                const parsed = parseOrderSnapshot(order.orderSnapshot);
+                const parsed = parsedFor(order);
                 const items = itemsSummary(parsed.items);
                 const pay = paymentBadge(parsed.paymentStatus);
                 const cust = customerName(parsed);
                 const carrier = parsed.shipping?.methodName ?? parsed.pickupPoint?.name ?? null;
                 const inv = parsed.invoice ? invoiceBadge(parsed.invoice) : null;
-                const notShipped = (order.fulfillmentState ?? 'not-shipped') === 'not-shipped';
+                const fulfillment = fulfillmentBadge(order.fulfillmentState);
+                // Offer "Generate label" ONLY when explicitly not-shipped and not
+                // cancelled (#1713) — otherwise the passive fulfillment badge.
+                const canGenerateLabel =
+                  order.fulfillmentState === 'not-shipped' && parsed.status !== 'cancelled';
                 return (
                   <div className="orders-card-summary">
                     {items ? (
@@ -1202,7 +1242,7 @@ export function OrdersListPage(): ReactElement {
                             <StatusBadge tone={inv.tone} withDot compact>
                               {inv.label}
                             </StatusBadge>
-                          ) : (
+                          ) : hasInvoicingCapability ? (
                             <Link
                               className="orders-row-cta"
                               to={`/orders/${order.internalOrderId}#invoicing`}
@@ -1212,6 +1252,8 @@ export function OrdersListPage(): ReactElement {
                               </span>{' '}
                               Issue invoice
                             </Link>
+                          ) : (
+                            '—'
                           )}
                         </dd>
                       </div>
@@ -1219,16 +1261,10 @@ export function OrdersListPage(): ReactElement {
                         <dt>Customer</dt>
                         <dd>{cust ?? '—'}</dd>
                       </div>
-                      <div>
-                        <dt>Created</dt>
-                        <dd className="mono tabular">
-                          <TimeDisplay iso={order.createdAt} format="datetime" />
-                        </dd>
-                      </div>
                       <div className="orders-card-facts__wide">
                         <dt>Shipment</dt>
                         <dd>
-                          {notShipped ? (
+                          {canGenerateLabel ? (
                             <Link
                               className="orders-row-cta"
                               to={`/orders/${order.internalOrderId}#shipment`}
@@ -1239,7 +1275,14 @@ export function OrdersListPage(): ReactElement {
                               Generate label
                             </Link>
                           ) : (
-                            (carrier ?? '—')
+                            <span className="orders-cell-stack">
+                              <StatusBadge tone={fulfillment.tone} withDot compact>
+                                {fulfillment.label}
+                              </StatusBadge>
+                              {carrier ? (
+                                <span className="text-muted orders-cell-sub">{carrier}</span>
+                              ) : null}
+                            </span>
                           )}
                         </dd>
                       </div>

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -549,6 +549,15 @@ export function OrdersListPage(): ReactElement {
           // Multi-destination indicator (#1713): an order fanned out to more than
           // one destination shows `→ Dest +N` where N is the extra destinations.
           const extraDests = order.syncStatus.length > 1 ? order.syncStatus.length - 1 : 0;
+          // The inline Retry lives under the order name rather than in its own
+          // trailing column (#1713): a column that only ever renders for failed
+          // rows widened the table past the viewport for every other row.
+          const failed = order.syncStatus.find((s) => s.status === 'failed');
+          const canRetry =
+            failed !== undefined && order.recordStatus !== 'awaiting_mapping' && retryWrite.visible;
+          const isRetrying =
+            retryMutation.isPending &&
+            retryMutation.variables?.internalOrderId === order.internalOrderId;
           return (
             <span className="orders-cell-stack">
               <EntityLabel
@@ -584,6 +593,18 @@ export function OrdersListPage(): ReactElement {
                     </span>
                   ) : null}
                 </span>
+              ) : null}
+              {canRetry && failed ? (
+                <ReadOnlyLock active={retryWrite.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                  <Button
+                    tone="ghost"
+                    className="button--sm orders-row-retry"
+                    disabled={isRetrying || retryWrite.demoReadOnly}
+                    onClick={() => { handleRetry(order.internalOrderId, failed.destinationConnectionId); }}
+                  >
+                    {isRetrying ? 'Retrying…' : 'Retry'}
+                  </Button>
+                </ReadOnlyLock>
               ) : null}
             </span>
           );
@@ -778,30 +799,6 @@ export function OrdersListPage(): ReactElement {
                 <TimeDisplay iso={order.createdAt} format="datetime" />
               </span>
             </span>
-          );
-        },
-      },
-      {
-        id: 'actions',
-        header: '',
-        align: 'right',
-        cell: (order) => {
-          const failed = order.syncStatus.find((s) => s.status === 'failed');
-          if (order.recordStatus === 'awaiting_mapping' || !failed || !retryWrite.visible) return null;
-          const isRetrying =
-            retryMutation.isPending &&
-            retryMutation.variables?.internalOrderId === order.internalOrderId;
-          return (
-            <ReadOnlyLock active={retryWrite.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
-              <Button
-                tone="ghost"
-                className="button--sm"
-                disabled={isRetrying || retryWrite.demoReadOnly}
-                onClick={() => { handleRetry(order.internalOrderId, failed.destinationConnectionId); }}
-              >
-                {isRetrying ? 'Retrying…' : 'Retry'}
-              </Button>
-            </ReadOnlyLock>
           );
         },
       },

--- a/apps/web/src/shared/lib/is-safe-http-url.test.ts
+++ b/apps/web/src/shared/lib/is-safe-http-url.test.ts
@@ -1,0 +1,26 @@
+/**
+ * is-safe-http-url tests
+ */
+import { describe, expect, it } from 'vitest';
+import { isSafeHttpUrl } from './is-safe-http-url';
+
+describe('isSafeHttpUrl', () => {
+  it('accepts absolute http/https URLs', () => {
+    expect(isSafeHttpUrl('http://example.com')).toBe(true);
+    expect(isSafeHttpUrl('https://salescenter.allegro.pl/orders/abc')).toBe(true);
+  });
+
+  it('rejects non-http schemes', () => {
+    expect(isSafeHttpUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeHttpUrl('data:text/html,<script>')).toBe(false);
+    expect(isSafeHttpUrl('vbscript:msgbox')).toBe(false);
+    expect(isSafeHttpUrl('ftp://example.com')).toBe(false);
+  });
+
+  it('rejects relative, empty, and malformed values', () => {
+    expect(isSafeHttpUrl('')).toBe(false);
+    expect(isSafeHttpUrl('/orders/abc')).toBe(false);
+    expect(isSafeHttpUrl('not a url')).toBe(false);
+    expect(isSafeHttpUrl('ht tp://example.com')).toBe(false);
+  });
+});

--- a/apps/web/src/shared/lib/is-safe-http-url.ts
+++ b/apps/web/src/shared/lib/is-safe-http-url.ts
@@ -1,0 +1,22 @@
+/**
+ * is-safe-http-url
+ *
+ * Shared guard for adapter-controlled URLs that reach the FE with no
+ * server-side scheme validation. React JSX does not sanitize `href`, so any
+ * value rendered into an anchor is treated as untrusted: the anchor is emitted
+ * only when the scheme is `http:` / `https:`. Any other scheme
+ * (`javascript:`, `data:`, `vbscript:`, …), relative / garbage strings, or a
+ * whitespace-prefixed payload degrades to no link.
+ *
+ * @module apps/web/src/shared/lib
+ */
+
+/** True only for `http:` / `https:` absolute URLs. `new URL().protocol` is the
+ *  stricter form — it rejects relative strings and leading whitespace. */
+export function isSafeHttpUrl(value: string): boolean {
+  try {
+    return ['http:', 'https:'].includes(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -12,6 +12,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   Fragment,
   useCallback,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -530,6 +531,7 @@ function DataTableCard<Row>({
   onClick,
 }: DataTableCardProps<Row>): ReactElement {
   const [detailOpen, setDetailOpen] = useState(false);
+  const detailId = useId();
   const detail = cardView.detail;
   const collapsible = cardView.collapsibleDetail ?? false;
   const showDetail = detail !== undefined && (!collapsible || detailOpen);
@@ -571,6 +573,7 @@ function DataTableCard<Row>({
           type="button"
           className="data-table__card-disclosure"
           aria-expanded={detailOpen}
+          aria-controls={detailId}
           onClick={(event) => {
             // Never bubble to the card-level navigation handler.
             event.stopPropagation();
@@ -584,7 +587,9 @@ function DataTableCard<Row>({
         </button>
       ) : null}
       {showDetail && detail ? (
-        <div className="data-table__card-detail">{detail(row)}</div>
+        <div id={detailId} className="data-table__card-detail">
+          {detail(row)}
+        </div>
       ) : null}
     </li>
   );

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -54,9 +54,22 @@ export interface DataTableCardView<Row> {
   /**
    * Full field set for the card body — the mobile counterpart of the desktop
    * expandable detail panel. Rendered below the meta row so a card shows every
-   * field without an expand step (#1620).
+   * field without an expand step (#1620), unless `collapsibleDetail` is set.
    */
   detail?: (row: Row) => ReactNode;
+  /**
+   * Always-visible summary block rendered between the meta row and the detail
+   * (#1713) — the handful of facts worth showing before expanding. Distinct
+   * from `detail`, which carries the full long-form field set.
+   */
+  summary?: (row: Row) => ReactNode;
+  /**
+   * When true, `detail` is collapsed behind a "View full details" disclosure
+   * (#1713) instead of always rendered — so the card leads with `title` /
+   * `subtitle` / `meta` / `summary` and the long field set is opt-in. Defaults
+   * to false: existing consumers keep the always-expanded card body.
+   */
+  collapsibleDetail?: boolean;
 }
 
 /**
@@ -479,49 +492,101 @@ export function DataTable<Row>({
             tableRows.map((tanstackRow) => {
               const row = tanstackRow.original;
               const href = rowHref?.(row);
-
-              const mainContent = (
-                <>
-                  <strong className="data-table__card-title">{cardView.title(row)}</strong>
-                  {cardView.subtitle ? (
-                    <span className="data-table__card-subtitle">{cardView.subtitle(row)}</span>
-                  ) : null}
-                </>
-              );
-
               return (
-                <li
+                <DataTableCard
                   key={rowKey(row)}
-                  className={
-                    href ? 'data-table__card data-table__card--linked' : 'data-table__card'
-                  }
+                  row={row}
+                  cardView={cardView}
+                  href={href}
                   onClick={href ? makeRowClickHandler(href) : undefined}
-                >
-                  <div className="data-table__card-head">
-                    {cardView.select ? (
-                      <div className="data-table__card-select">{cardView.select(row)}</div>
-                    ) : null}
-                    {href ? (
-                      <Link to={href} className="data-table__card-main data-table__card-main--link">
-                        {mainContent}
-                      </Link>
-                    ) : (
-                      <div className="data-table__card-main">{mainContent}</div>
-                    )}
-                    {cardView.meta ? (
-                      <div className="data-table__card-meta">{cardView.meta(row)}</div>
-                    ) : null}
-                  </div>
-                  {cardView.detail ? (
-                    <div className="data-table__card-detail">{cardView.detail(row)}</div>
-                  ) : null}
-                </li>
+                />
               );
             })
           )}
         </ul>
       ) : null}
     </div>
+  );
+}
+
+interface DataTableCardProps<Row> {
+  row: Row;
+  cardView: DataTableCardView<Row>;
+  href?: string;
+  onClick?: (event: MouseEvent<HTMLLIElement>) => void;
+}
+
+/**
+ * One mobile card (#1713). Holds its own `detailOpen` state so the full detail
+ * can collapse behind a "View full details" disclosure when
+ * `cardView.collapsibleDetail` is set; otherwise the detail renders inline as
+ * before. The always-visible `summary` sits between the meta row and the
+ * disclosure.
+ */
+function DataTableCard<Row>({
+  row,
+  cardView,
+  href,
+  onClick,
+}: DataTableCardProps<Row>): ReactElement {
+  const [detailOpen, setDetailOpen] = useState(false);
+  const detail = cardView.detail;
+  const collapsible = cardView.collapsibleDetail ?? false;
+  const showDetail = detail !== undefined && (!collapsible || detailOpen);
+
+  const mainContent = (
+    <>
+      <strong className="data-table__card-title">{cardView.title(row)}</strong>
+      {cardView.subtitle ? (
+        <span className="data-table__card-subtitle">{cardView.subtitle(row)}</span>
+      ) : null}
+    </>
+  );
+
+  return (
+    <li
+      className={href ? 'data-table__card data-table__card--linked' : 'data-table__card'}
+      onClick={onClick}
+    >
+      <div className="data-table__card-head">
+        {cardView.select ? (
+          <div className="data-table__card-select">{cardView.select(row)}</div>
+        ) : null}
+        {href ? (
+          <Link to={href} className="data-table__card-main data-table__card-main--link">
+            {mainContent}
+          </Link>
+        ) : (
+          <div className="data-table__card-main">{mainContent}</div>
+        )}
+        {cardView.meta ? (
+          <div className="data-table__card-meta">{cardView.meta(row)}</div>
+        ) : null}
+      </div>
+      {cardView.summary ? (
+        <div className="data-table__card-summary">{cardView.summary(row)}</div>
+      ) : null}
+      {detail !== undefined && collapsible ? (
+        <button
+          type="button"
+          className="data-table__card-disclosure"
+          aria-expanded={detailOpen}
+          onClick={(event) => {
+            // Never bubble to the card-level navigation handler.
+            event.stopPropagation();
+            setDetailOpen((open) => !open);
+          }}
+        >
+          <span className="data-table__card-disclosure-chev" aria-hidden="true">
+            {detailOpen ? '⌄' : '›'}
+          </span>
+          {detailOpen ? 'Hide details' : 'View full details'}
+        </button>
+      ) : null}
+      {showDetail && detail ? (
+        <div className="data-table__card-detail">{detail(row)}</div>
+      ) : null}
+    </li>
   );
 }
 

--- a/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
@@ -69,6 +69,7 @@ describe('InvoicingIssueHandler', () => {
       getInvoice: jest.fn(),
       getInvoiceById: jest.fn(),
       getLatestInvoiceForOrder: jest.fn(),
+      getLatestInvoicesForOrders: jest.fn(),
       listInvoices: jest.fn(),
       issueCorrection: jest.fn(),
       applyRegulatoryClearance: jest.fn(),

--- a/docs/plans/analysis/ANALYSIS-orders-table-redesign.md
+++ b/docs/plans/analysis/ANALYSIS-orders-table-redesign.md
@@ -1,0 +1,42 @@
+# Pre-implement gate — Orders table redesign (#1713)
+
+**Verdict: READY**
+
+Grounded against fresh `main` (4bc702cb) via two deep Explore passes (FE list surface + backend DTO/sort/adapter surface). No reuse collisions, no contract-surface breaks. All backend touches are additive.
+
+## Reuse findings
+
+| Plan artifact | Status | Evidence |
+|---|---|---|
+| Merged `shipment` / `money` columns, composite sort headers | NEW (FE-internal column config) | `orders-list-page.tsx` columns useMemo; no shared primitive needed — `DataTable` renders a non-sortable column's `header` node verbatim. |
+| `applySort(key)` FE helper | NEW (extracted from existing `onSortChange`) | logic already inline at `orders-list-page.tsx` onSortChange; extraction only. |
+| Items summary / payment-badge view-model helpers | NEW | add to `features/orders/lib/order-health.ts`; reuses existing `fulfillmentBadge`/`slaBadge`/`deriveOrderHealth`. |
+| `payment` sort key | PARTIAL (extend) | `OrderRecordSortValues` (`order-record.types.ts`) + `applySort` switch (`order-record.repository.ts`) already hold `total`/`customer`/`fulfillment` JSONB sorts; mirror `->>'paymentStatus'`. |
+| Source `externalUrl` | PARTIAL (extend) | `IncomingOrder` type gains optional field; adapters' `getOrder` populate; `order-record.service.ts` persist methods already write the snapshot — add one key. No new port/service. |
+| Allegro salescenter URL helper | NEW (sibling of existing) | `allegro-hosts.ts` already has `getAllegroWebBaseUrl(env)`; add `getAllegroSalesCenterOrderUrl`. |
+| PrestaShop base URL access | EXISTS (reuse) | `connection.config.baseUrl` already read in `prestashop-order-source.adapter.ts:173`. |
+
+No new ports, services, DI tokens, ORM entities, or capabilities. Nothing reinvented.
+
+## Backward-compat findings
+
+| Surface | Change | Severity | Note |
+|---|---|---|---|
+| `@openlinker/core/orders` barrel — `OrderRecordSortValues` | add `'payment'` | none (additive to `as const`) | No consumer breaks; FE `OrderSortValues` mirror is additive too. |
+| `IncomingOrder` type | add optional `externalUrl?` | none (additive, optional) | Adapters populate opportunistically; absent ⇒ link hidden. |
+| `OrderRecordResponseDto` / `OrderSyncStatusResponseDto` | **none** | none | Source URL rides in the `orderSnapshot` JSONB (already `Record<string, unknown>`), which `toDto` returns verbatim — **no API DTO change, no per-row lookup**. |
+| ORM schema | **none** | none | URL persisted as a snapshot JSONB key, not a column ⇒ **no migration**. |
+| `ParsedOrderSnapshot` (FE) | add optional `sourceExternalUrl?` | none (additive) | Zod schema extend. |
+| `check:invariants` | none expected | none | Backend edits stay within orders context + adapters that already import the orders barrel; no new cross-context/deny-pattern imports; no repo-URL-guard trip. FE not walked. |
+| FE column id rename `fulfillment`→`shipment`, `total`→`money` | internal | none | Not a published contract; `SORT_KEY_TO_COLUMN`/`COLUMN_TO_SORT_KEY` kept consistent; server sort keys unchanged. |
+
+## Open questions (non-blocking)
+
+1. **Master-shop (destination) link** — decided **deferred** to a follow-up issue (PrestaShop admin URL needs token + admin-dir, not in config). Out of scope for this PR.
+2. **Erli source URL scheme** — if no confirmable seller-panel order URL, Erli's source link is simply hidden (graceful degradation). Not a blocker.
+3. **Composite sort-header discoverability** — two headers each carrying multiple sort buttons is dense/non-standard; verify on the live UI (`/verify`) before finalizing; fallback is splitting back to separate columns.
+4. **Payment ordering** — alphabetical (`awaiting<cod<paid<refunded`) is fine for MVP; semantic ordinal optional. Expression index migration optional (low row counts).
+
+## Conclusion
+
+Proceed. The FE redesign is self-contained over data the list already loads; the two backend additions (`payment` sort, source `externalUrl` via snapshot) are additive and migration-free. Follow the sequenced commits in the plan §4 (steps 1-6; step 7 deferred).

--- a/docs/plans/implementation-plan-orders-table-redesign.md
+++ b/docs/plans/implementation-plan-orders-table-redesign.md
@@ -1,0 +1,85 @@
+# Implementation Plan — Responsive /orders table redesign + order deep links (#1713)
+
+## 1. Goal & classification
+
+Surface shipment (carrier + status), payment status, and a sortable created-at date directly in the `/orders` list rows; make the table responsive across three breakpoints (desktop full table, tablet condensed table, mobile cards); rework the accordion; render multi-item orders properly; and add "Open order" deep links (source marketplace + master shop) in the accordion.
+
+- **Layer**: Frontend (bulk) + Integration/Interface (deep links, payment sort key).
+- **Non-goals**: no change to the order ingestion pipeline, no new shared UI primitives, no order-detail-page changes, no change to which data the list endpoint returns beyond the additive `externalUrl` / `payment` sort.
+
+A faithful 3-breakpoint mockup is approved (design signed off).
+
+## 2. Frontend design (self-contained; reads data the list already loads)
+
+All in `apps/web`. Styling stays vanilla CSS + OKLCH tokens in `index.css` (bounded `/* ── Orders list redesign (#1713) ── */` section), `StatusBadge` for pills, `.mono`/`.tabular` for ids/numerics. Theme-aware.
+
+### 2.1 Unified column model (`orders-list-page.tsx` columns useMemo)
+Desktop columns: `select, order, customer, channel, status, shipment, money`. Tablet: same minus `channel` (folds under order name) via `hideBelow`.
+- **status** (id `status`): sync health only (`deriveOrderHealth`) — unchanged content, keeps single-arrow sort.
+- **shipment** (new merged id, replaces `fulfillment` + `shipBy`): stacked cell = fulfillment badge (`fulfillmentBadge`) + ship-by SLA badge (`slaBadge` + live countdown from `dispatchByAt`) + carrier sub-line (`parsed.shipping?.methodName ?? parsed.pickupPoint?.name`).
+- **money** (new merged id, replaces `total`): right-aligned stack = total (`formatCurrency`), payment pill (`parsed.paymentStatus`), created (`order.createdAt`).
+- **order** cell gains an items line: first item name (truncated) + `+N` chip when `parsed.items.length > 1`.
+
+### 2.2 Per-label sorting (composite headers)
+The `shipment` and `money` columns are declared **non-sortable** (`sortable` omitted) so `DataTable` renders their `header` ReactNode verbatim (confirmed: `data-table.tsx` renders the node as-is when `!canSort`). Each header is a small vertical stack of `<button class="sortbtn">` controls:
+- shipment header → `Shipment` (key `fulfillment`) + `Ship-by` (key `dispatchBy`).
+- money header → `Total` (`total`) + `Payment` (`payment`) + `Created` (`createdAt`).
+
+Extract the existing sort-toggle logic from `onSortChange` (lines ~977-996) into a page-level `applySort(key: OrderSortValue)` that toggles dir if `key === sort` else `DEFAULT_DIR[key]`, and writes `sort`/`dir` to the URL (dropping `offset`). Both the react-table `onSortChange` (for `customer`/`status`) and the custom header buttons call `applySort`. Each button shows its active state + ▲/▼/↕ derived from the page's `sort`/`dir`. Update `SORT_KEY_TO_COLUMN` / `COLUMN_TO_SORT_KEY` / `DEFAULT_DIR` for the new/renamed column ids and `payment`.
+
+### 2.3 Accordion rework (`order-row-detail.tsx` + CSS)
+- Inset "drawer": `tr.detail-row td` gets side padding; the inner panel background = `color-mix(in oklch, var(--bg-surface), black 7%)` (theme-safe recess), border, radius.
+- Field order regrouped: `Order reference · Internal ID · Placed · Destination` first, then a full-width **line-item list** (`qty × name`, SKU beneath, line price right — one row per `parsed.items[]`), then Shipping / Billing addresses.
+- New "Open order" links strip at the top (§3.3).
+
+### 2.4 Mobile cardView rewrite (`orders-list-page.tsx` cardView)
+Replace the always-expanded full `OrderRowDetail` dump with: header (order name + id chip, amount right, channel sub), badge row (status / ship-by / shipment), one-line items summary, a 2×2 facts grid (Customer, Payment, Shipment carrier, Created), and the full `OrderRowDetail` **collapsed behind a "View full details" disclosure** (local `useState` toggle inside the card detail renderer).
+
+### 2.5 View-model helpers
+Add small pure helpers to `features/orders/lib/order-health.ts` (or a new `order-row.ts`) for the items summary (`{firstName, moreCount}`) and payment badge tone/label; unit-test them (`.test.ts`).
+
+## 3. Backend design
+
+### 3.1 Payment sort key (small, self-contained)
+- `libs/core/src/orders/domain/types/order-record.types.ts`: add `'payment'` to `OrderRecordSortValues`.
+- `order-record.repository.ts`: add `PAYMENT_EXPR = rec."orderSnapshot"->>'paymentStatus'` and `case 'payment'` in `applySort` (`orderBy(PAYMENT_EXPR, d('ASC'), 'NULLS LAST').addOrderBy('rec.createdAt','DESC')`). Alphabetical ordering is acceptable; a semantic CASE ordinal is optional. (Companion expression index migration optional — low row counts; skip unless perf demands it.)
+- FE mirror: add `'payment'` to `OrderSortValues` in `features/orders/api/orders.types.ts` + the sort maps.
+
+### 3.2 Source-marketplace deep link (moderate)
+The source external id is not reliably on a `ready` `OrderRecord`, so build the URL where the adapter knows both the scheme and the id, and persist it onto the snapshot:
+- `libs/core/src/orders/domain/types/incoming-order.types.ts`: add optional `externalUrl?: string`.
+- Source adapters populate it in `getOrder`:
+  - Allegro: `getAllegroWebBaseUrl(env)` sibling → add a `getAllegroSalesCenterOrderUrl(env, checkoutFormId)` host helper in `allegro-hosts.ts`; adapter reads `connection.config.environment` (currently discards `_connection`).
+  - Erli: confirm seller-panel order URL scheme; if none is confirmable, leave `undefined` (link hidden).
+  - PrestaShop-as-source: `{connection.config.baseUrl}` + order id (front-office order URL, or admin per §3.3 decision).
+- Persist into the snapshot in `order-record.service.ts` (`persistOrder` + `persistIncomingSnapshot`) as `orderSnapshot.sourceExternalUrl`. API `toDto` already returns the snapshot verbatim, so the FE reads `parsed.sourceExternalUrl` — **no API-layer change, no per-row lookup**.
+- FE: extend `order-snapshot.schema.ts` `ParsedOrderSnapshot` with `sourceExternalUrl?`, render the source link in the accordion strip when present.
+
+### 3.3 Master-shop (destination) deep link — DEFERRED (decided)
+**Decision: option A — deferred to a separate follow-up issue.** The destination `externalOrderId` (PrestaShop `id_order`) is on the sync-status row, but a working PrestaShop admin URL needs the per-employee `token` and the randomized admin-dir, neither stored in connection config — a genuine data gap. This PR ships only the source-marketplace link (§3.2). A follow-up issue will cover the master link (likely by adding an optional `adminDir` to PrestaShop connection config + `OrderSyncStatusResponseDto.externalUrl` + an async per-request destination-config resolve in `orders.controller.ts`). The FE accordion links strip is built so a `destinationExternalUrl` simply lights up a second link when it later exists.
+
+## 4. Step-by-step plan (one PR, sequenced commits)
+
+1. **feat(web): unified column model + shipment/money merged cells + items `+N`** — `orders-list-page.tsx`, `order-health.ts` helpers, `index.css`; unit tests for helpers + column render.
+2. **feat(web): per-label sort controls** — `applySort` extraction, composite headers, sort maps.
+3. **feat(web): accordion rework + line-item list** — `order-row-detail.tsx`, CSS.
+4. **feat(web): mobile card rewrite + disclosure** — cardView config, CSS; card tests.
+5. **feat(orders): add `payment` sort key** — core enum + repo expr + FE mirror; repo/int test.
+6. **feat(orders): source-marketplace deep link** — `IncomingOrder.externalUrl`, adapters, snapshot persistence, FE schema + render; adapter unit tests.
+7. ~~master-shop deep link~~ — **deferred to a follow-up issue** (§3.3).
+
+Each step keeps `pnpm lint` / `type-check` / `test` green.
+
+## 5. Validation
+
+- **Architecture**: URL-scheme knowledge stays in adapters (source link built in `getOrder`); no platform strings in core/FE. Payment sort stays in core + repo. No CORE↔Integration boundary crossing.
+- **Naming/conventions**: FE per `.claude/rules/frontend.md` (tokens, StatusBadge, mono/tabular, kebab files). BE per engineering-standards.
+- **Testing**: unit tests for new FE view-model helpers + card/column render; repo integration test for the `payment` ORDER BY; adapter unit tests for URL builders.
+- **Security**: deep links are `rel="noopener"` external anchors; no secrets in URLs.
+
+## 6. Open questions / risks
+
+1. **§3.3 master-shop link** — defer (A), add config (B), or front-office (C)? (Recommend A.)
+2. **Erli source URL** — is there a public seller-panel order URL scheme? If not, Erli source link is hidden (graceful).
+3. **Composite sort headers** — two headers with multiple sort buttons is a dense, non-standard affordance; verify discoverability on the live UI (`/verify`) before finalizing. Fallback: split back into separate columns.
+4. **Payment sort ordering** — alphabetical vs semantic ordinal; alphabetical is fine for MVP.

--- a/libs/core/src/invoicing/application/services/invoice.service.interface.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.interface.ts
@@ -107,6 +107,15 @@ export interface IInvoiceService {
   getLatestInvoiceForOrder(orderId: string): Promise<InvoiceRecord | null>;
 
   /**
+   * Batch counterpart of {@link getLatestInvoiceForOrder} (#1713): the latest
+   * `InvoiceRecord` for each of the given order ids, at most one per order.
+   * Projection read — NEVER queries the provider/adapter. Backs the orders-list
+   * invoice projection (one query per page, not an N+1). Orders with no record
+   * are absent from the result; returns `[]` for an empty input.
+   */
+  getLatestInvoicesForOrders(orderIds: string[]): Promise<InvoiceRecord[]>;
+
+  /**
    * Read-only AC-6 list (#1119) of OL's OWN `InvoiceRecord` projection, filtered
    * + paginated. The cross-context list seam the HTTP layer calls — apps/** reach
    * the invoice projection through this service interface, NEVER the repository

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -185,6 +185,7 @@ describe('InvoiceService', () => {
       findByOrderId: jest.fn(),
       findBySeriesId: jest.fn(),
       findLatestByOrderId: jest.fn(),
+      findLatestByOrderIds: jest.fn(),
       findByProviderInvoiceId: jest.fn(),
       findByIdempotencyKey: jest.fn(),
       updateOutcome: jest.fn(),

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -794,6 +794,10 @@ export class InvoiceService implements IInvoiceService {
     return this.repo.findLatestByOrderId(orderId);
   }
 
+  async getLatestInvoicesForOrders(orderIds: string[]): Promise<InvoiceRecord[]> {
+    return this.repo.findLatestByOrderIds(orderIds);
+  }
+
   async listInvoices(
     filter: InvoiceRecordFilters,
     pagination: InvoiceRecordPagination,

--- a/libs/core/src/invoicing/domain/ports/invoice-record-repository.port.ts
+++ b/libs/core/src/invoicing/domain/ports/invoice-record-repository.port.ts
@@ -44,6 +44,15 @@ export interface InvoiceRecordRepositoryPort {
   findLatestByOrderId(orderId: string): Promise<InvoiceRecord | null>;
 
   /**
+   * Batch counterpart of {@link findLatestByOrderId} (#1713): the most-recently-
+   * created record for each of the given order ids, at most one per order. Backs
+   * the orders-list invoice projection, which needs one query for the whole page
+   * rather than an N+1 of per-row `findLatestByOrderId`. Orders with no record
+   * are simply absent from the result; returns `[]` for an empty input.
+   */
+  findLatestByOrderIds(orderIds: string[]): Promise<InvoiceRecord[]>;
+
+  /**
    * Find the most-recently-created record for a provider invoice id on the
    * connection (#1354). Backs the payment-status refresh triggered by a
    * provider payment webhook, which names the document by its provider id;

--- a/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
+++ b/libs/core/src/invoicing/infrastructure/persistence/repositories/invoice-record.repository.ts
@@ -94,6 +94,24 @@ export class InvoiceRecordRepository implements InvoiceRecordRepositoryPort {
     return entity ? this.toDomain(entity) : null;
   }
 
+  async findLatestByOrderIds(orderIds: string[]): Promise<InvoiceRecord[]> {
+    if (orderIds.length === 0) {
+      return [];
+    }
+    // DISTINCT ON keeps one row per order — the newest — mirroring
+    // `findLatestByOrderId`'s (createdAt DESC, id DESC) tiebreak. One query for
+    // the whole orders-list page instead of an N+1.
+    const entities = await this.repository
+      .createQueryBuilder('record')
+      .where('record.orderId IN (:...orderIds)', { orderIds })
+      .distinctOn(['record.orderId'])
+      .orderBy('record.orderId', 'ASC')
+      .addOrderBy('record.createdAt', 'DESC')
+      .addOrderBy('record.id', 'DESC')
+      .getMany();
+    return entities.map((entity) => this.toDomain(entity));
+  }
+
   async findByProviderInvoiceId(
     connectionId: string,
     providerInvoiceId: string,

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -28,12 +28,16 @@ export interface IOrderRecordService {
    * @param order - Unified order with internal IDs
    * @param sourceConnectionId - Source connection ID (where order originated)
    * @param sourceEventId - Optional source event ID
+   * @param sourceExternalUrl - Optional deep link to the order in the source
+   *   platform's UI (#1713), built by the source adapter; persisted onto the
+   *   snapshot as `sourceExternalUrl`.
    * @returns Persisted order record
    */
   persistOrder(
     order: Order,
     sourceConnectionId: string,
-    sourceEventId: string | null
+    sourceEventId: string | null,
+    sourceExternalUrl?: string | null
   ): Promise<OrderRecord>;
 
   /**

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -337,6 +337,8 @@ describe('OrderIngestionService', () => {
       expect(orderRecordService.persistOrder).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'ol_order_test' }),
         connectionId,
+        null,
+        // sourceExternalUrl (#1713) — the test fixture's incoming order carries none.
         null
       );
       expect(orderRecordService.persistIncomingSnapshot.mock.invocationCallOrder[0]).toBeLessThan(

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -336,7 +336,12 @@ export class OrderIngestionService implements IOrderIngestionService {
       internalCustomerId,
       resolvedItems
     );
-    await this.orderRecordService.persistOrder(order, connectionId, sourceEventId ?? null);
+    await this.orderRecordService.persistOrder(
+      order,
+      connectionId,
+      sourceEventId ?? null,
+      incoming.externalUrl ?? null
+    );
 
     // Cancellation-observe hook (#1146): on the `→ cancelled` transition, enqueue
     // a marketplace.offer.stockRestore job so the destination marketplace's

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -45,7 +45,8 @@ export class OrderRecordService implements IOrderRecordService {
   async persistOrder(
     order: Order,
     sourceConnectionId: string,
-    sourceEventId: string | null = null
+    sourceEventId: string | null = null,
+    sourceExternalUrl: string | null = null
   ): Promise<OrderRecord> {
     const piiConfig = getPiiConfig();
     const now = new Date();
@@ -110,6 +111,10 @@ export class OrderRecordService implements IOrderRecordService {
       // always resolves to the omp_fulfilled default).
       ...(order.shipping !== undefined && { shipping: order.shipping }),
       ...(order.pickupPoint !== undefined && { pickupPoint: order.pickupPoint }),
+      // Source-platform deep link (#1713) — present-only. Built by the source
+      // adapter (it owns the URL scheme + base URL); the FE renders the
+      // "Open order" link off this key. Absent when the source can't build one.
+      ...(sourceExternalUrl !== null && { sourceExternalUrl }),
       createdAt: order.createdAt.toISOString(),
       updatedAt: order.updatedAt.toISOString(),
     };
@@ -185,6 +190,10 @@ export class OrderRecordService implements IOrderRecordService {
       // the present-only + non-PII rationale. Same fields, same placement.
       ...(incoming.shipping !== undefined && { shipping: incoming.shipping }),
       ...(incoming.pickupPoint !== undefined && { pickupPoint: incoming.pickupPoint }),
+      // Source-platform deep link (#1713) — see persistOrder. Written here too so
+      // records still awaiting item mapping carry the link before the ready-path
+      // snapshot overwrites this one.
+      ...(incoming.externalUrl !== undefined && { sourceExternalUrl: incoming.externalUrl }),
     };
 
     const orderRecord = new OrderRecord(

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -31,6 +31,16 @@ export interface IncomingOrder {
   orderNumber?: string;
 
   /**
+   * Optional deep link to this order in the source platform's own UI
+   * (marketplace seller panel / shop admin) (#1713). Built by the source
+   * adapter — the only layer that knows the platform's URL scheme and its
+   * per-connection base URL / environment. Absent when the source can't build
+   * a stable URL; core persists it verbatim onto the snapshot and the FE
+   * renders a link only when present.
+   */
+  externalUrl?: string;
+
+  /**
    * Status as provided/mapped by adapter.
    */
   status: string;

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -160,8 +160,9 @@ export interface OrderRecordFilters {
  * Sort fields for order-record list queries (#927, extended #944).
  *
  * - `createdAt` / `dispatchBy` — top-level timestamp columns.
- * - `customer` / `items` / `status` / `total` — derived from `orderSnapshot`
- *   JSONB (and the health `CASE` for `status`); back the sortable table columns.
+ * - `customer` / `items` / `status` / `total` / `payment` — derived from
+ *   `orderSnapshot` JSONB (and the health `CASE` for `status`); back the
+ *   sortable table columns.
  */
 export const OrderRecordSortValues = [
   'createdAt',
@@ -171,6 +172,7 @@ export const OrderRecordSortValues = [
   'status',
   'total',
   'fulfillment',
+  'payment',
 ] as const;
 export type OrderRecordSort = (typeof OrderRecordSortValues)[number];
 

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -249,6 +249,10 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
   private static readonly ITEMS_EXPR =
     `CASE WHEN jsonb_typeof(rec."orderSnapshot"->'items') = 'array' ` +
     `THEN jsonb_array_length(rec."orderSnapshot"->'items') END`;
+  // Top-level `paymentStatus` string (#1713). Sorts alphabetically
+  // (awaiting < cod < paid < refunded), NULLs last — good enough to group by
+  // payment state; a semantic ordinal isn't warranted for the current vocabulary.
+  private static readonly PAYMENT_EXPR = `rec."orderSnapshot"->>'paymentStatus'`;
 
   /**
    * Apply result ordering (#927/#944). `dispatchBy` is the list's triage
@@ -294,6 +298,12 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
         return;
       case 'fulfillment':
         qb.orderBy(OrderRecordRepository.FULFILLMENT_ORDINAL, d('ASC')).addOrderBy(
+          'rec.createdAt',
+          'DESC'
+        );
+        return;
+      case 'payment':
+        qb.orderBy(OrderRecordRepository.PAYMENT_EXPR, d('ASC'), 'NULLS LAST').addOrderBy(
           'rec.createdAt',
           'DESC'
         );

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -32,6 +32,7 @@ import type {
   OrderDispatchWindow,
 } from '@openlinker/core/orders';
 import type { Connection } from '@openlinker/core/identifier-mapping';
+import { getAllegroSalesCenterOrderUrl } from '../http/allegro-hosts';
 import { Logger } from '@openlinker/shared/logging';
 import type { IAllegroHttpClient } from '../http/allegro-http-client.interface';
 import type {
@@ -70,12 +71,20 @@ export class AllegroOrderSourceAdapter
 {
   private readonly logger = new Logger(AllegroOrderSourceAdapter.name);
 
+  /**
+   * Allegro environment (`production` | `sandbox`), read from connection config
+   * to build the seller Sales Center order deep link (#1713). Defaults to '' so
+   * the host resolver falls back to sandbox on an absent/unknown value.
+   */
+  private readonly environment: string;
+
   constructor(
     private readonly connectionId: string,
     private readonly httpClient: IAllegroHttpClient,
-    _connection: Connection
+    connection: Connection
   ) {
-    void _connection;
+    const env = connection.config?.environment;
+    this.environment = typeof env === 'string' ? env : '';
   }
 
   /**
@@ -343,6 +352,9 @@ export class AllegroOrderSourceAdapter
       return {
         externalOrderId: checkoutFormId,
         orderNumber: checkoutFormId,
+        // Seller Sales Center deep link (#1713) — checkoutFormId is Allegro's
+        // native order id; the FE renders this as the source "Open order" link.
+        externalUrl: getAllegroSalesCenterOrderUrl(this.environment, checkoutFormId),
         status,
         customerExternalId: checkoutForm.buyer.id,
         customerEmail: checkoutForm.buyer.email,

--- a/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-hosts.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-hosts.spec.ts
@@ -5,7 +5,11 @@
  * here rather than silently shipping to one environment, and asserts the
  * unknown-environment defaults stay aligned between the two resolvers.
  */
-import { getAllegroWebBaseUrl, getAllegroRestApiBaseUrl } from '../allegro-hosts';
+import {
+  getAllegroWebBaseUrl,
+  getAllegroRestApiBaseUrl,
+  getAllegroSalesCenterOrderUrl,
+} from '../allegro-hosts';
 
 describe('allegro-hosts', () => {
   describe('getAllegroWebBaseUrl', () => {
@@ -41,5 +45,25 @@ describe('allegro-hosts', () => {
     // environment while resolving REST calls against another.
     expect(getAllegroWebBaseUrl('???')).toContain('allegrosandbox.pl');
     expect(getAllegroRestApiBaseUrl('???')).toContain('allegrosandbox.pl');
+  });
+
+  describe('getAllegroSalesCenterOrderUrl (#1713)', () => {
+    it('should build a production Sales Center order URL', () => {
+      expect(getAllegroSalesCenterOrderUrl('production', 'abc-123')).toBe(
+        'https://salescenter.allegro.pl/orders/abc-123',
+      );
+    });
+
+    it('should build a sandbox URL for the sandbox environment', () => {
+      expect(getAllegroSalesCenterOrderUrl('sandbox', 'abc-123')).toBe(
+        'https://salescenter.allegro.pl.allegrosandbox.pl/orders/abc-123',
+      );
+    });
+
+    it('should default to sandbox for an absent/unknown environment', () => {
+      expect(getAllegroSalesCenterOrderUrl('', 'abc-123')).toBe(
+        'https://salescenter.allegro.pl.allegrosandbox.pl/orders/abc-123',
+      );
+    });
   });
 });

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-hosts.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-hosts.ts
@@ -93,5 +93,5 @@ export function getAllegroSalesCenterOrderUrl(
     environment === 'production'
       ? PRODUCTION_SALESCENTER_BASE_URL
       : SANDBOX_SALESCENTER_BASE_URL;
-  return `${base}/orders/${checkoutFormId}`;
+  return `${base}/orders/${encodeURIComponent(checkoutFormId)}`;
 }

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-hosts.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-hosts.ts
@@ -34,6 +34,12 @@ const PRODUCTION_WEB_BASE_URL = 'https://allegro.pl';
 const SANDBOX_REST_API_BASE_URL = 'https://api.allegro.pl.allegrosandbox.pl';
 const PRODUCTION_REST_API_BASE_URL = 'https://api.allegro.pl';
 
+// Sales-center host — the seller-facing order-management UI. A seller order
+// deep link is `{salescenter}/orders/{checkoutFormId}` (#1713). Follows the same
+// sandbox suffix convention as the web/REST hosts.
+const SANDBOX_SALESCENTER_BASE_URL = 'https://salescenter.allegro.pl.allegrosandbox.pl';
+const PRODUCTION_SALESCENTER_BASE_URL = 'https://salescenter.allegro.pl';
+
 /**
  * Resolve the Allegro web/site base URL for an environment.
  *
@@ -70,4 +76,22 @@ export function getAllegroRestApiBaseUrl(environment: string): string {
       logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
       return SANDBOX_REST_API_BASE_URL;
   }
+}
+
+/**
+ * Build the seller Sales Center deep link for an Allegro order (#1713).
+ *
+ * `checkoutFormId` is Allegro's native order id (the value the adapter also
+ * emits as `externalOrderId`). Defaults to sandbox on anything other than
+ * `'production'`, matching the other resolvers.
+ */
+export function getAllegroSalesCenterOrderUrl(
+  environment: string,
+  checkoutFormId: string
+): string {
+  const base =
+    environment === 'production'
+      ? PRODUCTION_SALESCENTER_BASE_URL
+      : SANDBOX_SALESCENTER_BASE_URL;
+  return `${base}/orders/${checkoutFormId}`;
 }


### PR DESCRIPTION
## What & why

Redesigns the `/orders` table into a responsive, action-oriented operator cockpit and surfaces facts that were previously buried in the expanded row. Closes #1713.

### Frontend
- **Unified desktop + tablet column model.** `Shipment` groups fulfillment status + ship-by SLA + carrier; a merged **money** column stacks Total / Payment / Created — each with per-label sort controls in the header. `Status` keeps sync health only. Channel folds under the order name below 1024px.
- **Multi-item rows.** First item name (truncated) + a `+N` count chip; the accordion shows a full itemised line list (qty × name, SKU, line price).
- **Reworked accordion** — an inset recessed drawer, fields regrouped (reference / internal id / placed / destination → items → addresses), with an **Open order** links strip: OpenLinker detail + source-marketplace deep link.
- **Mobile card rewrite** — header + badges + a tight facts grid, full detail behind a **View full details** disclosure (new `DataTableCardView` `summary` + `collapsibleDetail`).
- **Invoice status** — a neutral clearance pill in the money column / mobile facts / accordion (with the clearance reference).
- **Empty-state actions** — when the next step is unstarted the status is replaced by a one-click deep link: **Issue invoice** → `#invoicing`, **Generate label** → `#shipment`. The order-detail page gains anchor wrappers + a reduced-motion-aware hash-scroll.

### Backend (additive, no migration)
- `payment` sort key (core enum + repository JSONB ordering; FE mirror).
- Source-marketplace `externalUrl` threaded through `IncomingOrder`, persisted on the snapshot; Allegro builds the Sales Center order URL.
- Orders **list** now merges each order's latest invoice projection (new batched `findLatestByOrderIds` — one query per page, no N+1); `status` added to `OrderInvoiceProjectionDto`.

## How to test
- `/orders`: resize across the three breakpoints; sort each money/shipment label; expand a row; check the Open-order links; click **Issue invoice** / **Generate label** and confirm the detail page scrolls to the right section.
- Multi-item order shows `+N`; single-item shows just the name.

## Notes
- Sorting by invoice status is intentionally **not** included (it needs a cross-table join); invoice is display + action only.
- Draft: commits are currently unsigned — they need GPG re-signing before merge.

## Design
Approved 3-breakpoint mock covers desktop table, tablet condensed table, and mobile cards, including the invoice pill and both empty-state CTAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
