### PR TITLE
feat(web/shipping): scope COD currency to the routed carrier (#1569)

### DIFF
--- a/apps/web/src/features/connections/components/cod-currency-support.test.tsx
+++ b/apps/web/src/features/connections/components/cod-currency-support.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * CodCurrencySupport — component tests (#1569)
+ *
+ * Renders the read-only per-carrier COD currency chip list. DPD carries the
+ * full set (PLN/EUR/RON/CZK); InPost is PLN-only.
+ */
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { CodCurrencySupport } from './cod-currency-support';
+
+afterEach(cleanup);
+
+describe('CodCurrencySupport', () => {
+  it('should render the full DPD currency set as list items', () => {
+    render(<CodCurrencySupport platformType="dpd" />);
+
+    const list = screen.getByRole('list', { name: 'Supported COD currencies' });
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(4);
+    expect(items.map((el) => el.textContent)).toEqual(['PLN', 'EUR', 'RON', 'CZK']);
+  });
+
+  it('should render only PLN for InPost', () => {
+    render(<CodCurrencySupport platformType="inpost" />);
+
+    const list = screen.getByRole('list', { name: 'Supported COD currencies' });
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toBe('PLN');
+  });
+});

--- a/apps/web/src/features/connections/components/cod-currency-support.tsx
+++ b/apps/web/src/features/connections/components/cod-currency-support.tsx
@@ -1,0 +1,36 @@
+/**
+ * Supported COD currencies (read-only carrier info, #1569)
+ *
+ * Renders the set of cash-on-delivery currencies a carrier accepts as a
+ * read-only chip list on its connection setup form. Informational only — the
+ * carrier API decides the set, not the operator. Shared by the DPD and InPost
+ * setup wizards so the block stays identical across carriers.
+ *
+ * @module features/connections/components
+ */
+import type { ReactElement } from 'react';
+
+import { codCurrenciesForPlatform } from '../../../shared/shipping/cod-currencies';
+
+interface CodCurrencySupportProps {
+  /** Connection `platformType` whose supported COD currencies to list. */
+  platformType: string;
+}
+
+export function CodCurrencySupport({ platformType }: CodCurrencySupportProps): ReactElement {
+  return (
+    <div className="form-field">
+      <span className="form-field__label">Supported COD currencies</span>
+      <p className="form-field__description">
+        The carrier collects cash on delivery in these currencies.
+      </p>
+      <div className="cod-currency-support" role="list" aria-label="Supported COD currencies">
+        {codCurrenciesForPlatform(platformType).map((currency) => (
+          <span key={currency} className="cod-currency-support__chip" role="listitem">
+            {currency}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/connections/components/dpd-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/dpd-setup-form.test.tsx
@@ -50,6 +50,18 @@ describe('DpdSetupForm', () => {
     expect(screen.queryByLabelText('Address')).toBeNull();
   });
 
+  it('shows the DPD COD currencies as read-only info on the account step (#1569)', () => {
+    const { container } = renderWithProviders(<DpdSetupForm />);
+
+    expect(screen.getByText('Supported COD currencies')).toBeInTheDocument();
+    const support = container.querySelector('.cod-currency-support') as HTMLElement;
+    expect(support).not.toBeNull();
+    expect(within(support).getByText('PLN')).toBeInTheDocument();
+    expect(within(support).getByText('EUR')).toBeInTheDocument();
+    expect(within(support).getByText('RON')).toBeInTheDocument();
+    expect(within(support).getByText('CZK')).toBeInTheDocument();
+  });
+
   it('advances to the sender-address step once the account step is valid', async () => {
     const { container } = renderWithProviders(<DpdSetupForm />);
     fillAccountStep(container, { name: 'DPD — main', login: 'ol_12345', password: 'secret', payerFid: '1495' });

--- a/apps/web/src/features/connections/components/dpd-setup-form.tsx
+++ b/apps/web/src/features/connections/components/dpd-setup-form.tsx
@@ -32,7 +32,7 @@ import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
-import { codCurrenciesForPlatform } from '../../../shared/shipping/cod-currencies';
+import { CodCurrencySupport } from './cod-currency-support';
 import { SetupStepper } from '../../../shared/ui/setup-stepper';
 import { WizardLayout } from '../../../shared/ui/wizard-layout';
 import { useToast } from '../../../shared/ui/toast-provider';
@@ -224,19 +224,7 @@ export function DpdSetupForm(): ReactElement {
               />
             </FormField>
 
-            <div className="form-field">
-              <span className="form-field__label">Supported COD currencies</span>
-              <p className="form-field__description">
-                Cash on delivery is collected in these currencies — set by the carrier.
-              </p>
-              <div className="cod-currency-support">
-                {codCurrenciesForPlatform('dpd').map((currency) => (
-                  <span key={currency} className="cod-currency-support__chip">
-                    {currency}
-                  </span>
-                ))}
-              </div>
-            </div>
+            <CodCurrencySupport platformType="dpd" />
           </>
         ) : null}
 

--- a/apps/web/src/features/connections/components/dpd-setup-form.tsx
+++ b/apps/web/src/features/connections/components/dpd-setup-form.tsx
@@ -32,6 +32,7 @@ import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
+import { codCurrenciesForPlatform } from '../../../shared/shipping/cod-currencies';
 import { SetupStepper } from '../../../shared/ui/setup-stepper';
 import { WizardLayout } from '../../../shared/ui/wizard-layout';
 import { useToast } from '../../../shared/ui/toast-provider';
@@ -222,6 +223,20 @@ export function DpdSetupForm(): ReactElement {
                 invalid={Boolean(form.formState.errors.masterFid)}
               />
             </FormField>
+
+            <div className="form-field">
+              <span className="form-field__label">Supported COD currencies</span>
+              <p className="form-field__description">
+                Cash on delivery is collected in these currencies — set by the carrier.
+              </p>
+              <div className="cod-currency-support">
+                {codCurrenciesForPlatform('dpd').map((currency) => (
+                  <span key={currency} className="cod-currency-support__chip">
+                    {currency}
+                  </span>
+                ))}
+              </div>
+            </div>
           </>
         ) : null}
 

--- a/apps/web/src/features/connections/components/inpost-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/inpost-setup-form.test.tsx
@@ -52,6 +52,17 @@ describe('InpostSetupForm', () => {
     expect(screen.queryByLabelText('Street')).toBeNull();
   });
 
+  it('shows PLN as the only read-only COD currency on the account step (#1569)', () => {
+    const { container } = renderWithProviders(<InpostSetupForm />);
+
+    expect(screen.getByText('Supported COD currencies')).toBeInTheDocument();
+    const support = container.querySelector('.cod-currency-support') as HTMLElement;
+    expect(support).not.toBeNull();
+    expect(within(support).getByText('PLN')).toBeInTheDocument();
+    expect(within(support).queryByText('EUR')).toBeNull();
+    expect(within(support).getAllByText(/^(?:PLN|EUR|RON|CZK)$/)).toHaveLength(1);
+  });
+
   it('advances to the sender-address step once the account step is valid', async () => {
     const { container } = renderWithProviders(<InpostSetupForm />);
     fillAccountStep(container, { name: 'InPost — main', apiToken: 'shipx-token', organizationId: '123456' });

--- a/apps/web/src/features/connections/components/inpost-setup-form.tsx
+++ b/apps/web/src/features/connections/components/inpost-setup-form.tsx
@@ -32,6 +32,7 @@ import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
+import { codCurrenciesForPlatform } from '../../../shared/shipping/cod-currencies';
 import { SetupStepper } from '../../../shared/ui/setup-stepper';
 import { WizardLayout } from '../../../shared/ui/wizard-layout';
 import { useToast } from '../../../shared/ui/toast-provider';
@@ -200,6 +201,20 @@ export function InpostSetupForm(): ReactElement {
                 invalid={Boolean(form.formState.errors.organizationId)}
               />
             </FormField>
+
+            <div className="form-field">
+              <span className="form-field__label">Supported COD currencies</span>
+              <p className="form-field__description">
+                Cash on delivery is collected in these currencies — set by the carrier.
+              </p>
+              <div className="cod-currency-support">
+                {codCurrenciesForPlatform('inpost').map((currency) => (
+                  <span key={currency} className="cod-currency-support__chip">
+                    {currency}
+                  </span>
+                ))}
+              </div>
+            </div>
           </>
         ) : null}
 

--- a/apps/web/src/features/connections/components/inpost-setup-form.tsx
+++ b/apps/web/src/features/connections/components/inpost-setup-form.tsx
@@ -32,7 +32,7 @@ import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
-import { codCurrenciesForPlatform } from '../../../shared/shipping/cod-currencies';
+import { CodCurrencySupport } from './cod-currency-support';
 import { SetupStepper } from '../../../shared/ui/setup-stepper';
 import { WizardLayout } from '../../../shared/ui/wizard-layout';
 import { useToast } from '../../../shared/ui/toast-provider';
@@ -202,19 +202,7 @@ export function InpostSetupForm(): ReactElement {
               />
             </FormField>
 
-            <div className="form-field">
-              <span className="form-field__label">Supported COD currencies</span>
-              <p className="form-field__description">
-                Cash on delivery is collected in these currencies — set by the carrier.
-              </p>
-              <div className="cod-currency-support">
-                {codCurrenciesForPlatform('inpost').map((currency) => (
-                  <span key={currency} className="cod-currency-support__chip">
-                    {currency}
-                  </span>
-                ))}
-              </div>
-            </div>
+            <CodCurrencySupport platformType="inpost" />
           </>
         ) : null}
 

--- a/apps/web/src/features/mappings/index.ts
+++ b/apps/web/src/features/mappings/index.ts
@@ -6,5 +6,9 @@
  * for the fallback carrier picker) import from here.
  */
 export type { MappingOption, AllegroCategory } from './api/mappings.types';
+export type { RoutingRule, FulfillmentProcessorKind } from './api/mappings.types';
 export { useAllegroCategoriesQuery } from './hooks/use-allegro-categories';
 export { useMappingOptions } from './hooks/use-mapping-options';
+// Consumed by the orders generate-label flow to predict the routed carrier
+// (#1569 — scope the COD currency to the carrier a delivery method routes to).
+export { useRoutingRulesQuery } from './hooks/use-routing-rules';

--- a/apps/web/src/features/orders/components/generate-label-form.schema.ts
+++ b/apps/web/src/features/orders/components/generate-label-form.schema.ts
@@ -9,16 +9,17 @@
  */
 import { z } from 'zod';
 
+import { COD_CURRENCY_VALUES, type CodCurrency } from '../../../shared/shipping/cod-currencies';
+
 /**
- * COD currencies the carrier accepts. **FE mirror** of the BE
- * `DpdCodCurrencyValues` (`libs/integrations/dpd-polska/.../dpd-rest.types.ts`).
- * DPD is the only COD-capable carrier today, so this carrier-neutral form
- * carries DPD's set; if a second COD carrier with a different set ships, source
- * this per-platform instead of widening here. Keep in sync with the BE — same
- * FE↔BE value-drift discipline as `SHIPPING_METHOD_VALUES` (#966).
+ * COD currency vocabulary — the source of truth now lives in
+ * `shared/shipping/cod-currencies` (#1569), which also carries the per-carrier
+ * scoping. Re-exported here so colocated importers keep resolving it from the
+ * form schema; `generateLabelSchema` validates against the full union (the
+ * per-carrier narrowing is a UI concern, and the adapter preflight is the
+ * server-side backstop).
  */
-export const COD_CURRENCY_VALUES = ['PLN', 'EUR', 'RON', 'CZK'] as const;
-export type CodCurrency = (typeof COD_CURRENCY_VALUES)[number];
+export { COD_CURRENCY_VALUES, type CodCurrency };
 
 /**
  * Currencies accepted for declared-value insurance (#1542). InPost ShipX

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -6,7 +6,7 @@
  * Plus the happy-path render: with a complete snapshot, the form mounts
  * focused on the first input and the submit is enabled.
  */
-import { cleanup, screen, fireEvent, waitFor } from '@testing-library/react';
+import { cleanup, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 
 import {
@@ -798,5 +798,163 @@ describe('GenerateLabelForm — #953 dispatch-outcome toast', () => {
 
     expect(await findToastTitle(/Fulfilled by destination store/i)).toBeInTheDocument();
     expect(screen.queryByText(/Label generated/i)).not.toBeInTheDocument();
+  });
+});
+
+// ── #1569 — COD currency scoped to the routed carrier ─────────────────────
+
+describe('GenerateLabelForm — #1569 COD currency per routed carrier', () => {
+  function carrierConnection(id: string, platformType: string) {
+    return {
+      id,
+      platformType,
+      name: platformType,
+      status: 'active',
+      config: {},
+      credentialsBacked: true,
+      enabledCapabilities: [],
+      supportedCapabilities: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+  }
+
+  function routedApi(
+    processorPlatform: string,
+    overrides: Parameters<typeof createMockApiClient>[0] = {},
+  ) {
+    return createMockApiClient({
+      mappings: {
+        getRoutingRules: vi.fn().mockResolvedValue([
+          {
+            id: 'rule-1',
+            sourceConnectionId: 'b3f1c2d4-0000-4000-8000-000000000099',
+            sourceDeliveryMethodId: 'allegro-courier',
+            processorKind: 'ol_managed_carrier',
+            processorConnectionId: `conn-${processorPlatform}`,
+          },
+        ]),
+      },
+      connections: {
+        list: vi.fn().mockResolvedValue([carrierConnection(`conn-${processorPlatform}`, processorPlatform)]),
+      },
+      ...overrides,
+    });
+  }
+
+  function fillParcel(): void {
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+  }
+
+  function codOrder(currency?: string): OrderRecord {
+    const base = makeOrder();
+    return makeOrder({
+      orderSnapshot: {
+        ...(base.orderSnapshot as Record<string, unknown>),
+        paymentStatus: 'cod',
+        ...(currency
+          ? { totals: { subtotal: 100, tax: 0, shipping: 0, total: 100, currency } }
+          : {}),
+      },
+    });
+  }
+
+  it('should lock COD to PLN and hide the currency picker for an InPost-routed order', async () => {
+    const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
+    const apiClient = routedApi('inpost', { shipments: { generateLabel } });
+
+    renderWithProviders(
+      <GenerateLabelForm order={codOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+
+    // Once the routing resolves the carrier, the picker collapses to a locked
+    // value + reason line and the select is gone.
+    expect(
+      await screen.findByText(/collects cash on delivery in PLN only/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'COD currency' })).toBeNull();
+
+    fillParcel();
+    fireEvent.change(screen.getByLabelText(/COD amount to collect/i), { target: { value: '129.90' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() =>
+      expect(generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ cod: { amount: '129.90', currency: 'PLN' } }),
+      ),
+    );
+  });
+
+  it('should offer the full set and default from the order currency for a DPD-routed order', async () => {
+    const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
+    const apiClient = routedApi('dpd', { shipments: { generateLabel } });
+
+    renderWithProviders(
+      <GenerateLabelForm order={codOrder('EUR')} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+
+    const select = await screen.findByRole('combobox', { name: 'COD currency' });
+    expect(within(select).getAllByRole('option')).toHaveLength(4);
+    expect(select).toHaveValue('EUR');
+    expect(screen.getByText(/Defaulted from the order \(EUR\)/i)).toBeInTheDocument();
+
+    fillParcel();
+    fireEvent.change(screen.getByLabelText(/COD amount to collect/i), { target: { value: '50.00' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() =>
+      expect(generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ cod: { amount: '50.00', currency: 'EUR' } }),
+      ),
+    );
+  });
+
+  it('should coerce an order currency the carrier rejects (CZK order → InPost) down to PLN', async () => {
+    const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
+    const apiClient = routedApi('inpost', { shipments: { generateLabel } });
+
+    renderWithProviders(
+      <GenerateLabelForm order={codOrder('CZK')} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+
+    expect(
+      await screen.findByText(/collects cash on delivery in PLN only/i),
+    ).toBeInTheDocument();
+
+    fillParcel();
+    fireEvent.change(screen.getByLabelText(/COD amount to collect/i), { target: { value: '80.00' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    await waitFor(() =>
+      expect(generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ cod: { amount: '80.00', currency: 'PLN' } }),
+      ),
+    );
+  });
+
+  it('should keep the full currency union when no routing rule matches (carrier unknown)', async () => {
+    // Default mock returns [] routing rules → carrier unpredictable → union.
+    const apiClient = createMockApiClient({
+      shipments: { generateLabel: vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null }) },
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={codOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+
+    const select = await screen.findByRole('combobox', { name: 'COD currency' });
+    expect(within(select).getAllByRole('option').map((o) => o.textContent)).toEqual([
+      'PLN',
+      'EUR',
+      'RON',
+      'CZK',
+    ]);
   });
 });

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -901,7 +901,7 @@ describe('GenerateLabelForm — #1569 COD currency per routed carrier', () => {
     const select = await screen.findByRole('combobox', { name: 'COD currency' });
     expect(within(select).getAllByRole('option')).toHaveLength(4);
     expect(select).toHaveValue('EUR');
-    expect(screen.getByText(/Defaulted from the order \(EUR\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/Set from the order currency \(EUR\)/i)).toBeInTheDocument();
 
     fillParcel();
     fireEvent.change(screen.getByLabelText(/COD amount to collect/i), { target: { value: '50.00' } });
@@ -924,7 +924,7 @@ describe('GenerateLabelForm — #1569 COD currency per routed carrier', () => {
     );
 
     expect(
-      await screen.findByText(/collects cash on delivery in PLN only/i),
+      await screen.findByText(/Order is in CZK, but this carrier collects cash on delivery in PLN/i),
     ).toBeInTheDocument();
 
     fillParcel();

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -52,7 +52,6 @@ import {
   type GenerateLabelInput,
 } from '../../shipments';
 import {
-  COD_CURRENCY_VALUES,
   INSURED_CURRENCY_VALUES,
   LOCKER_TEMPLATE_VALUES,
   generateLabelSchema,
@@ -60,6 +59,12 @@ import {
   type GenerateLabelFormValues,
   type LockerTemplate,
 } from './generate-label-form.schema';
+import {
+  COD_CURRENCY_VALUES,
+  clampCodCurrency,
+  codCurrenciesForPlatform,
+} from '../../../shared/shipping/cod-currencies';
+import { useRoutedCarrierPlatform } from '../hooks/use-routed-carrier-platform';
 import {
   buildDispatchItem,
   classifyDeliveryMethod,
@@ -198,7 +203,10 @@ export function GenerateLabelForm({
       // order (Allegro) for a COD order; these fields back only the fallback
       // manual input shown for a COD order with no sourced amount.
       codAmount: '',
-      codCurrency: 'PLN',
+      // Default the currency from the order (#1569), clamped to a currency any
+      // carrier accepts; the routed-carrier effect below narrows it further once
+      // the routing rules resolve.
+      codCurrency: clampCodCurrency(snapshot.totals?.currency, COD_CURRENCY_VALUES),
       // Declared-value / insurance (#1542) — operator-supplied, blank ⇒ none.
       insuredAmount: '',
       insuredCurrency: 'PLN',
@@ -246,6 +254,37 @@ export function GenerateLabelForm({
   // The read-only "from Allegro" panel only applies to a marketplace COD order
   // that carried a sourced amount; every other allowed state uses the input.
   const showSourcedCod = isCodOrder && sourcedCod !== undefined;
+
+  // COD currency scoping (#1569). Predict the carrier this order's delivery
+  // method routes to, then scope the editable currency set to what that carrier
+  // accepts. Unknown carrier ⇒ the full union (adapter preflight is the
+  // backstop). Only relevant for the editable fallback field, not the read-only
+  // sourced panel.
+  const orderCurrency = snapshot.totals?.currency;
+  const routedCarrierPlatform = useRoutedCarrierPlatform(
+    order.sourceConnectionId,
+    snapshot.shipping?.methodId,
+    { enabled: codAllowed && !showSourcedCod },
+  );
+  const allowedCodCurrencies = useMemo(
+    () => codCurrenciesForPlatform(routedCarrierPlatform),
+    [routedCarrierPlatform],
+  );
+  const codCurrencyValue = form.watch('codCurrency');
+  // Coerce the selection when the routed carrier doesn't accept it (e.g. a CZK
+  // order routed to InPost, PLN-only): prefer the order currency, else the
+  // carrier's default. Keeps the FE from submitting a currency the carrier will
+  // reject at preflight.
+  useEffect(() => {
+    if (!codAllowed || showSourcedCod) return;
+    const allowed = allowedCodCurrencies as readonly string[];
+    if (codCurrencyValue !== undefined && allowed.includes(codCurrencyValue)) return;
+    form.setValue(
+      'codCurrency',
+      clampCodCurrency(orderCurrency ?? codCurrencyValue, allowedCodCurrencies),
+      { shouldValidate: false },
+    );
+  }, [allowedCodCurrencies, codCurrencyValue, codAllowed, showSourcedCod, orderCurrency, form]);
 
   // Focus first input on mount (a11y — focus enters the inline expansion).
   const firstInputRef = useRef<HTMLInputElement | null>(null);
@@ -578,23 +617,51 @@ export function GenerateLabelForm({
                     ? "This order is cash-on-delivery, but the collect amount didn't come from the source (non-Allegro or missing). Enter the amount to collect."
                     : 'Amount to collect on delivery. Leave blank for a prepaid shipment.'}
                 </p>
-                <div className="generate-label-form__cod">
+                {/* Amount + currency as one control (#1569). The currency
+                    defaults from the order and is scoped to the routed carrier:
+                    a borderless select when the carrier takes several
+                    currencies, a static suffix when it takes just one. */}
+                <div className="generate-label-form__money">
                   <Input
                     {...codAmountRegister}
+                    className="generate-label-form__money-amount"
                     inputMode="decimal"
                     placeholder="129.90"
                     aria-label="COD amount to collect"
                     invalid={Boolean(form.formState.errors.codAmount)}
                   />
-                  <Select {...codCurrencyRegister} aria-label="COD currency">
-                    {COD_CURRENCY_VALUES.map((c) => (
-                      <option key={c} value={c}>
-                        {c}
-                      </option>
-                    ))}
-                  </Select>
+                  {allowedCodCurrencies.length > 1 ? (
+                    <Select
+                      {...codCurrencyRegister}
+                      className="generate-label-form__money-ccy"
+                      aria-label="COD currency"
+                    >
+                      {allowedCodCurrencies.map((c) => (
+                        <option key={c} value={c}>
+                          {c}
+                        </option>
+                      ))}
+                    </Select>
+                  ) : (
+                    <span
+                      className="generate-label-form__money-ccy--static"
+                      aria-label={`COD currency: ${allowedCodCurrencies[0]}`}
+                    >
+                      {allowedCodCurrencies[0]}
+                    </span>
+                  )}
                 </div>
                 <FieldError id="cod-error" message={form.formState.errors.codAmount?.message} />
+                {allowedCodCurrencies.length <= 1 ? (
+                  <p className="generate-label-form__cod-caption">
+                    This carrier collects cash on delivery in {allowedCodCurrencies[0]} only.
+                  </p>
+                ) : orderCurrency && codCurrencyValue === orderCurrency ? (
+                  <p className="generate-label-form__cod-caption">
+                    Defaulted from the order ({orderCurrency}). Change it if the carrier needs a
+                    different currency.
+                  </p>
+                ) : null}
               </>
             )}
           </div>

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -52,6 +52,11 @@ import {
   type GenerateLabelInput,
 } from '../../shipments';
 import {
+  COD_CURRENCY_VALUES,
+  clampCodCurrency,
+  codCurrenciesForPlatform,
+} from '../../../shared/shipping/cod-currencies';
+import {
   INSURED_CURRENCY_VALUES,
   LOCKER_TEMPLATE_VALUES,
   generateLabelSchema,
@@ -59,11 +64,6 @@ import {
   type GenerateLabelFormValues,
   type LockerTemplate,
 } from './generate-label-form.schema';
-import {
-  COD_CURRENCY_VALUES,
-  clampCodCurrency,
-  codCurrenciesForPlatform,
-} from '../../../shared/shipping/cod-currencies';
 import { useRoutedCarrierPlatform } from '../hooks/use-routed-carrier-platform';
 import {
   buildDispatchItem,
@@ -285,6 +285,39 @@ export function GenerateLabelForm({
       { shouldValidate: false },
     );
   }, [allowedCodCurrencies, codCurrencyValue, codAllowed, showSourcedCod, orderCurrency, form]);
+
+  // COD currency caption (#1569). Frames the currency as what the courier
+  // collects at delivery, warns when the routed carrier can't collect in the
+  // order currency (coercion), and only shows the "set from the order" hint
+  // until the operator manually re-picks a currency.
+  function renderCodCaption(): ReactElement | null {
+    const effectiveCurrency = codCurrencyValue ?? allowedCodCurrencies[0];
+    const currencyDirty = form.formState.dirtyFields.codCurrency;
+    if (orderCurrency && effectiveCurrency && effectiveCurrency !== orderCurrency) {
+      return (
+        <p className="generate-label-form__cod-caption">
+          Order is in {orderCurrency}, but this carrier collects cash on delivery in{' '}
+          {effectiveCurrency} — the amount will be collected in {effectiveCurrency}.
+        </p>
+      );
+    }
+    if (allowedCodCurrencies.length <= 1) {
+      return (
+        <p className="generate-label-form__cod-caption">
+          This carrier collects cash on delivery in {effectiveCurrency} only.
+        </p>
+      );
+    }
+    if (orderCurrency && !currencyDirty) {
+      return (
+        <p className="generate-label-form__cod-caption">
+          Set from the order currency ({orderCurrency}). Change it if the carrier requires a
+          different one.
+        </p>
+      );
+    }
+    return null;
+  }
 
   // Focus first input on mount (a11y — focus enters the inline expansion).
   const firstInputRef = useRef<HTMLInputElement | null>(null);
@@ -627,7 +660,11 @@ export function GenerateLabelForm({
                     className="generate-label-form__money-amount"
                     inputMode="decimal"
                     placeholder="129.90"
-                    aria-label="COD amount to collect"
+                    aria-label={
+                      allowedCodCurrencies.length > 1
+                        ? 'COD amount to collect'
+                        : `COD amount to collect in ${allowedCodCurrencies[0]}`
+                    }
                     invalid={Boolean(form.formState.errors.codAmount)}
                   />
                   {allowedCodCurrencies.length > 1 ? (
@@ -643,25 +680,13 @@ export function GenerateLabelForm({
                       ))}
                     </Select>
                   ) : (
-                    <span
-                      className="generate-label-form__money-ccy--static"
-                      aria-label={`COD currency: ${allowedCodCurrencies[0]}`}
-                    >
+                    <span className="generate-label-form__money-ccy--static" aria-hidden="true">
                       {allowedCodCurrencies[0]}
                     </span>
                   )}
                 </div>
                 <FieldError id="cod-error" message={form.formState.errors.codAmount?.message} />
-                {allowedCodCurrencies.length <= 1 ? (
-                  <p className="generate-label-form__cod-caption">
-                    This carrier collects cash on delivery in {allowedCodCurrencies[0]} only.
-                  </p>
-                ) : orderCurrency && codCurrencyValue === orderCurrency ? (
-                  <p className="generate-label-form__cod-caption">
-                    Defaulted from the order ({orderCurrency}). Change it if the carrier needs a
-                    different currency.
-                  </p>
-                ) : null}
+                {renderCodCaption()}
               </>
             )}
           </div>

--- a/apps/web/src/features/orders/hooks/use-routed-carrier-platform.ts
+++ b/apps/web/src/features/orders/hooks/use-routed-carrier-platform.ts
@@ -10,8 +10,9 @@
  *
  * Returns `undefined` when the carrier can't be predicted — no matching rule,
  * an OMP-fulfilled route (the destination store ships it, no OL carrier), or a
- * null / unresolvable processor connection — so callers fall back to the full
- * currency union and let the adapter preflight stay the backstop.
+ * processor connection that can't be resolved to a live connection — so callers
+ * fall back to the full currency union and let the adapter preflight stay the
+ * backstop.
  *
  * @module features/orders/hooks
  */
@@ -27,6 +28,8 @@ export function useRoutedCarrierPlatform(
 ): string | undefined {
   const enabled = (options?.enabled ?? true) && Boolean(deliveryMethodId);
   const routingRulesQuery = useRoutingRulesQuery(sourceConnectionId, { enabled });
+  // Not `enabled`-gated: connections are cache-warm across the app, so this
+  // resolves from cache rather than triggering a fetch on this hook's behalf.
   const connectionsQuery = useConnectionsQuery();
 
   return useMemo(() => {

--- a/apps/web/src/features/orders/hooks/use-routed-carrier-platform.ts
+++ b/apps/web/src/features/orders/hooks/use-routed-carrier-platform.ts
@@ -1,0 +1,45 @@
+/**
+ * Routed-carrier platform prediction (#1569)
+ *
+ * The generate-label form never names a carrier — fulfillment routing resolves
+ * DPD vs InPost server-side at dispatch time. This hook reconstructs that
+ * decision on the frontend so the COD currency field can scope to the routed
+ * carrier's supported set: it matches the order's source delivery method against
+ * the source connection's routing rules, resolves the processor connection, and
+ * returns its `platformType`.
+ *
+ * Returns `undefined` when the carrier can't be predicted — no matching rule,
+ * an OMP-fulfilled route (the destination store ships it, no OL carrier), or a
+ * null / unresolvable processor connection — so callers fall back to the full
+ * currency union and let the adapter preflight stay the backstop.
+ *
+ * @module features/orders/hooks
+ */
+import { useMemo } from 'react';
+
+import { useConnectionsQuery } from '../../connections';
+import { useRoutingRulesQuery } from '../../mappings';
+
+export function useRoutedCarrierPlatform(
+  sourceConnectionId: string,
+  deliveryMethodId: string | undefined,
+  options?: { enabled?: boolean },
+): string | undefined {
+  const enabled = (options?.enabled ?? true) && Boolean(deliveryMethodId);
+  const routingRulesQuery = useRoutingRulesQuery(sourceConnectionId, { enabled });
+  const connectionsQuery = useConnectionsQuery();
+
+  return useMemo(() => {
+    if (!deliveryMethodId) return undefined;
+    const rule = (routingRulesQuery.data ?? []).find(
+      (r) => r.sourceDeliveryMethodId === deliveryMethodId,
+    );
+    if (!rule || rule.processorKind === 'omp_fulfilled' || !rule.processorConnectionId) {
+      return undefined;
+    }
+    const processor = (connectionsQuery.data ?? []).find(
+      (c) => c.id === rule.processorConnectionId,
+    );
+    return processor?.platformType;
+  }, [deliveryMethodId, routingRulesQuery.data, connectionsQuery.data]);
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9385,14 +9385,6 @@ input.bulk-dispatch__num--wide {
   }
 }
 
-/* COD composite (#966) — amount input + currency select; amount takes the
- * remaining width, currency is sized to its content. */
-.generate-label-form__cod {
-  display: grid;
-  grid-template-columns: 1fr 7rem;
-  gap: var(--space-2);
-}
-
 /* ── COD payment panel (#1435) ──────────────────────────────────────────────
  * Payment-status-driven COD surface. Neutral recap container shared by the
  * read-only "from Allegro" amount and the fallback manual input, so both read
@@ -9429,10 +9421,6 @@ input.bulk-dispatch__num--wide {
   color: var(--text-muted);
 }
 
-.generate-label-form__cod-panel .generate-label-form__cod {
-  margin-top: var(--space-2);
-}
-
 /* ── Generate-label COD money field (#1569) ──────────────────────────────────
  * Amount + currency as a single control: a bordered row wrapping a borderless
  * amount input and a currency segment. The segment is a borderless select for a
@@ -9449,7 +9437,6 @@ input.bulk-dispatch__num--wide {
   overflow: hidden;
 }
 .generate-label-form__money:focus-within {
-  border-color: var(--border-strong);
   box-shadow: var(--shadow-focus);
 }
 .generate-label-form__money-amount.control {
@@ -9485,13 +9472,13 @@ input.bulk-dispatch__num--wide {
   padding: 0 var(--space-3);
   border-left: 1px solid var(--border-subtle);
   background: var(--bg-muted);
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 0.8125rem;
 }
 .generate-label-form__cod-caption {
   margin: var(--space-2) 0 0;
-  font-size: 0.72rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
 }
 
@@ -9505,7 +9492,7 @@ input.bulk-dispatch__num--wide {
 }
 .cod-currency-support__chip {
   font-family: var(--font-mono);
-  font-size: 0.72rem;
+  font-size: 0.75rem;
   padding: 2px var(--space-2);
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-default);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9433,6 +9433,86 @@ input.bulk-dispatch__num--wide {
   margin-top: var(--space-2);
 }
 
+/* ── Generate-label COD money field (#1569) ──────────────────────────────────
+ * Amount + currency as a single control: a bordered row wrapping a borderless
+ * amount input and a currency segment. The segment is a borderless select for a
+ * multi-currency carrier, or a static suffix for a single-currency carrier. */
+.generate-label-form__money {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  margin-top: var(--space-2);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-xs);
+  overflow: hidden;
+}
+.generate-label-form__money:focus-within {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-focus);
+}
+.generate-label-form__money-amount.control {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+.generate-label-form__money-amount.control:focus-visible {
+  box-shadow: none;
+}
+.generate-label-form__money-ccy.control {
+  width: auto;
+  flex: 0 0 auto;
+  border: 0;
+  border-left: 1px solid var(--border-subtle);
+  border-radius: 0;
+  box-shadow: none;
+  background-color: var(--bg-muted);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+.generate-label-form__money-ccy.control:focus-visible {
+  box-shadow: none;
+}
+.generate-label-form__money-ccy--static {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  height: 2rem;
+  padding: 0 var(--space-3);
+  border-left: 1px solid var(--border-subtle);
+  background: var(--bg-muted);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+.generate-label-form__cod-caption {
+  margin: var(--space-2) 0 0;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+/* ── COD currency support (read-only carrier info, #1569) ────────────────────
+ * Chips listing a carrier's supported COD currencies on its connection setup —
+ * informational, not a control (the carrier API decides, not the operator). */
+.cod-currency-support {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.cod-currency-support__chip {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-default);
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+}
+
 /* ── Declared-value / insurance panel (#1542) ───────────────────────────────
  * Operator-supplied insured value. Mirrors the COD manual-input panel visually
  * (same neutral recap container + StatusBadge pill) but is always shown and not

--- a/apps/web/src/shared/shipping/cod-currencies.test.ts
+++ b/apps/web/src/shared/shipping/cod-currencies.test.ts
@@ -1,0 +1,56 @@
+/**
+ * COD currency capability map — unit tests (#1569)
+ *
+ * Pins the per-carrier sets to the backend sources of truth and covers the
+ * fallback + clamp helpers that drive the generate-label COD field.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  COD_CURRENCY_VALUES,
+  COD_CURRENCIES_BY_PLATFORM,
+  codCurrenciesForPlatform,
+  clampCodCurrency,
+} from './cod-currencies';
+
+describe('cod-currencies — per-carrier sets (drift guard)', () => {
+  it('should carry DPD full set PLN/EUR/RON/CZK (mirrors DpdCodCurrencyValues)', () => {
+    expect(COD_CURRENCIES_BY_PLATFORM.dpd).toEqual(['PLN', 'EUR', 'RON', 'CZK']);
+  });
+
+  it('should carry InPost PLN-only (mirrors SHIPX_COD_CURRENCIES)', () => {
+    expect(COD_CURRENCIES_BY_PLATFORM.inpost).toEqual(['PLN']);
+  });
+
+  it('should expose the union as the fallback vocabulary', () => {
+    expect(COD_CURRENCY_VALUES).toEqual(['PLN', 'EUR', 'RON', 'CZK']);
+  });
+});
+
+describe('codCurrenciesForPlatform', () => {
+  it('should scope to the carrier set for a known platformType', () => {
+    expect(codCurrenciesForPlatform('dpd')).toEqual(['PLN', 'EUR', 'RON', 'CZK']);
+    expect(codCurrenciesForPlatform('inpost')).toEqual(['PLN']);
+  });
+
+  it('should fall back to the union when the carrier is unknown or absent', () => {
+    expect(codCurrenciesForPlatform(undefined)).toEqual(COD_CURRENCY_VALUES);
+    expect(codCurrenciesForPlatform('allegro')).toEqual(COD_CURRENCY_VALUES);
+    expect(codCurrenciesForPlatform('')).toEqual(COD_CURRENCY_VALUES);
+  });
+});
+
+describe('clampCodCurrency', () => {
+  it('should keep the desired currency when the carrier allows it', () => {
+    expect(clampCodCurrency('EUR', ['PLN', 'EUR', 'RON', 'CZK'])).toBe('EUR');
+  });
+
+  it('should fall back to the first allowed currency when the desired one is not accepted', () => {
+    expect(clampCodCurrency('EUR', ['PLN'])).toBe('PLN');
+    expect(clampCodCurrency('CZK', ['PLN'])).toBe('PLN');
+  });
+
+  it('should fall back to the first allowed currency when no currency is desired', () => {
+    expect(clampCodCurrency(undefined, ['PLN', 'EUR'])).toBe('PLN');
+  });
+});

--- a/apps/web/src/shared/shipping/cod-currencies.test.ts
+++ b/apps/web/src/shared/shipping/cod-currencies.test.ts
@@ -25,6 +25,13 @@ describe('cod-currencies — per-carrier sets (drift guard)', () => {
   it('should expose the union as the fallback vocabulary', () => {
     expect(COD_CURRENCY_VALUES).toEqual(['PLN', 'EUR', 'RON', 'CZK']);
   });
+
+  it('should keep the union equal to the de-duplicated union of every per-platform set', () => {
+    const perPlatformUnion = [
+      ...new Set(Object.values(COD_CURRENCIES_BY_PLATFORM).flat()),
+    ].sort();
+    expect([...COD_CURRENCY_VALUES].sort()).toEqual(perPlatformUnion);
+  });
 });
 
 describe('codCurrenciesForPlatform', () => {

--- a/apps/web/src/shared/shipping/cod-currencies.ts
+++ b/apps/web/src/shared/shipping/cod-currencies.ts
@@ -58,8 +58,9 @@ export function clampCodCurrency(
   desired: string | undefined,
   allowed: readonly CodCurrency[],
 ): CodCurrency {
-  if (desired !== undefined && (allowed as readonly string[]).includes(desired)) {
-    return desired as CodCurrency;
+  const normalized = desired?.toUpperCase();
+  if (normalized !== undefined && (allowed as readonly string[]).includes(normalized)) {
+    return normalized as CodCurrency;
   }
   return allowed[0] ?? 'PLN';
 }

--- a/apps/web/src/shared/shipping/cod-currencies.ts
+++ b/apps/web/src/shared/shipping/cod-currencies.ts
@@ -1,0 +1,65 @@
+/**
+ * COD currency capability, per shipping carrier (#1569)
+ *
+ * FE mirror of the backend per-carrier cash-on-delivery currency support. Two
+ * backend sources of truth this must stay in sync with (a test pins the sets):
+ *   - DPD:    `DpdCodCurrencyValues`
+ *             (libs/integrations/dpd-polska/src/domain/types/dpd-rest.types.ts)
+ *   - InPost: `SHIPX_COD_CURRENCIES`
+ *             (libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts)
+ *
+ * Lives in `shared/` (not a feature) because both the orders feature
+ * (generate-label COD field) and the connections feature (carrier setup) read
+ * it, and neither should depend on the other. Same FE<->BE value-drift
+ * discipline as `SHIPPING_METHOD_VALUES` (#966).
+ *
+ * @module shared/shipping
+ */
+
+/**
+ * Every COD currency any supported carrier accepts — the union, used as the
+ * fallback set when the routed carrier can't be predicted (see
+ * {@link codCurrenciesForPlatform}) and as the Zod validation vocabulary.
+ */
+export const COD_CURRENCY_VALUES = ['PLN', 'EUR', 'RON', 'CZK'] as const;
+export type CodCurrency = (typeof COD_CURRENCY_VALUES)[number];
+
+/**
+ * Supported COD currencies keyed by connection `platformType`. A carrier absent
+ * here (or an unknown platformType) falls back to the union via
+ * {@link codCurrenciesForPlatform} — the backstop is the adapter preflight,
+ * which rejects an unsupported currency server-side.
+ */
+export const COD_CURRENCIES_BY_PLATFORM: Record<string, readonly CodCurrency[]> = {
+  dpd: ['PLN', 'EUR', 'RON', 'CZK'],
+  inpost: ['PLN'],
+};
+
+/**
+ * Allowed COD currencies for a routed carrier's `platformType`. Returns the
+ * full union when the carrier is unknown / unpredictable (no routing rule,
+ * OMP-fulfilled, null processor, or a platformType with no declared set), so
+ * the picker never falsely restricts a currency the carrier might accept.
+ */
+export function codCurrenciesForPlatform(platformType?: string): readonly CodCurrency[] {
+  if (platformType !== undefined && platformType in COD_CURRENCIES_BY_PLATFORM) {
+    return COD_CURRENCIES_BY_PLATFORM[platformType];
+  }
+  return COD_CURRENCY_VALUES;
+}
+
+/**
+ * Clamp a desired currency to a carrier's allowed set: keep it if allowed,
+ * otherwise fall back to the set's first entry (PLN for every carrier today).
+ * Used to default the field from the order currency and to coerce a stale
+ * selection when the routed carrier narrows the set.
+ */
+export function clampCodCurrency(
+  desired: string | undefined,
+  allowed: readonly CodCurrency[],
+): CodCurrency {
+  if (desired !== undefined && (allowed as readonly string[]).includes(desired)) {
+    return desired as CodCurrency;
+  }
+  return allowed[0] ?? 'PLN';
+}


### PR DESCRIPTION
## What & why

The generate-label COD field offered PLN/EUR/RON/CZK for every order, but InPost courier COD is PLN-only server-side, so an InPost order set to a non-PLN currency passed FE validation then failed at the adapter preflight (a graceful 502 the operator only saw after submitting). The form never names a carrier - fulfillment routing resolves DPD vs InPost server-side - so this predicts the routed carrier on the frontend and scopes the currency to what it accepts.

Scope was widened slightly during design review (agreed with the issue owner) from "scope the options" to a small rework of the fallback COD field. The marketplace-sourced ("from Allegro") read-only path is untouched.

**Design mockup (before/after + connection settings):** https://claude.ai/code/artifact/f3116e49-d8a5-4336-ae1c-4ec42d012d41

## Changes (frontend-only)

- **Shared `cod-currencies` map** (`shared/shipping/`) - `platformType -> supported COD currencies`, mirroring the two backend sources of truth (`DpdCodCurrencyValues`, `SHIPX_COD_CURRENCIES`) with a drift-guard test. Lives in `shared/` so both the orders and connections features read it without depending on each other.
- **Routed-carrier prediction** (`useRoutedCarrierPlatform`) - order delivery method -> routing rule -> processor connection -> `platformType`. Unknown / OMP-fulfilled / null processor keeps the full currency union; the adapter preflight stays the backstop (no false restriction).
- **Default from the order** - the COD currency defaults to the order's `totals.currency` (was hardcoded PLN), clamped to the routed carrier's set. An order currency the carrier can't take (e.g. CZK -> InPost) coerces to PLN before submit.
- **Money field** - amount + currency render as one control: a borderless in-field select for a multi-currency carrier, a static suffix for a single-currency one (InPost -> PLN), with a muted caption.
- **Connection settings** - a read-only "Supported COD currencies" line on the DPD and InPost setup forms (informational; the carrier API decides, not the operator).

## Per-carrier map

| Routed carrier | platformType | Allowed COD currencies |
|---|---|---|
| DPD | `dpd` | PLN, EUR, RON, CZK |
| InPost | `inpost` | PLN |
| Unknown / OMP-fulfilled | `null` | PLN, EUR, RON, CZK (union) |

## Testing

- `pnpm --filter @openlinker/web type-check` - clean
- `pnpm --filter @openlinker/web lint` - clean (changed files)
- New/updated unit tests (48 passing across the 4 affected suites): shared map drift-guard + helpers; per-carrier scoping, order-currency default, CZK->InPost coercion, and union fallback on the generate-label form; read-only currency chips on both setup forms.

## Out of scope

New backend endpoint, `KnownProviderRejectionCodeValues` additions, the Allegro sourced-COD read-only panel, and any operator-configurable currency setting.

Closes #1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
