### PR TITLE
fix(ci): use SSH_HOSTNAME for ssh-keyscan in deploy workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,7 @@ jobs:
           known_hosts: 'just-a-placeholder-so-we-dont-get-errors'
 
       - name: Adding Known Hosts
-        run: ssh-keyscan -p ${{ secrets.SSH_PORT }} -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+        run: ssh-keyscan -p ${{ secrets.SSH_PORT }} -H ${{ secrets.SSH_HOSTNAME }} >> ~/.ssh/known_hosts
 
       - name: Copy images to server
         run: rsync -avz -e "ssh -p ${{ secrets.SSH_PORT }}" ./openlinker-{migrate,api,web,worker}.tar ${{ secrets.SSH_HOST }}:${{ secrets.DESTINATION_PATH_IMAGES }}/


### PR DESCRIPTION
## Summary

- The "Adding Known Hosts" step in `.github/workflows/cd.yml` passed `secrets.SSH_HOST` to `ssh-keyscan`, but that secret holds the full `user@host` target (as consumed by the rsync/ssh steps below). `ssh-keyscan` needs a bare hostname, so `~/.ssh/known_hosts` was never populated correctly and the deploy steps failed host-key verification.
- Switch the keyscan input to `secrets.SSH_HOSTNAME` (bare hostname); all other steps keep using `SSH_HOST` unchanged.

## Related issues

Closes #1718

## Test plan

- Requires the `SSH_HOSTNAME` secret to be present in the `demo` environment.
- Push a `v*` tag (or re-run the CD workflow on one) and verify:
  - "Adding Known Hosts" writes a real host-key entry to `~/.ssh/known_hosts`,
  - "Copy images to server" and "Deploy" complete without host-key verification failure.

## Quality gate

- [x] `pnpm lint` passes (zero errors) - n/a, workflow-only change (no TS touched)
- [x] `pnpm type-check` passes (zero errors) - n/a, workflow-only change
- [x] `pnpm test` passes (all unit tests green) - n/a, workflow-only change
- [ ] *Optional, Docker required:* `pnpm test:integration` passes — needed
      only if you touched `apps/api/test/integration/**` or any plugin's
      `infrastructure/adapters/`.

## Migrations

- [x] If this PR changes an ORM entity, a migration is included under
      `apps/api/src/migrations/` (or the plugin package), `pnpm --filter
      @openlinker/api migration:show` confirms it's listed, and both
      `up()` and `down()` were tested locally. See
      [`docs/migrations.md`](../docs/migrations.md). Tick this box for
      PRs that don't touch schemas too — it's trivially satisfied.

## ADR

- [x] If this PR makes a non-trivial architectural decision (affects
      multiple contexts, the plugin contract, or has alternatives worth
      documenting), an ADR should be included under
      `docs/architecture/adrs/` or referenced in the PR description.
      ADRs are a recommendation, not a hard gate — see
      [`docs/architecture/adrs/README.md`](../docs/architecture/adrs/README.md)
      § "When to write an ADR" for the decision criteria. Tick this box
      for PRs that don't make architectural decisions too — it's
      trivially satisfied.

## DCO sign-off

Commit is signed off (`Signed-off-by`) and GPG-signed.

> Note: branch is named `fix/ci-cd` rather than the `{issue-number}-{description}` convention; GitHub does not allow renaming a PR's head ref, so it stays as-is.

---

<sub>By submitting this pull request, I confirm that my contributions are made under the terms of the project's open-source license, and I certify the Developer Certificate of Origin (DCO) for every commit in this PR.</sub>