### PR TITLE
fix(inpost): authenticate both documented webhook HMAC variants (#1556)

### DIFF
--- a/docs/plans/implementation-plan-inpost-webhook-hmac-scheme.md
+++ b/docs/plans/implementation-plan-inpost-webhook-hmac-scheme.md
@@ -1,0 +1,155 @@
+# Implementation Plan — InPost ShipX webhook HMAC signature scheme (#1556)
+
+## 1. Understand the task
+
+**Goal.** Confirm the InPost webhook HMAC signature scheme and align
+`InpostInboundWebhookDecoderAdapter.verify()` so genuine deliveries authenticate.
+
+**Layer.** Integration (`libs/integrations/inpost`) — plus a docs note. No CORE
+port change, no ORM entity, no migration, no FE change.
+
+**Why it matters.** `verify()` runs *before* `extractEnvelope()`, so a wrong
+scheme rejects **100%** of real webhooks. The 30-minute reconciliation poll masks
+it: status still converges, so the dead low-latency path is invisible in prod.
+
+### What the research actually found (this inverts the issue's premise)
+
+The issue hypothesised the scheme is **hex over the raw body**, citing the
+openoms Go SDK, and proposed aligning `verify()` to that. That hypothesis is
+**refuted** by InPost's authoritative documentation:
+
+| Aspect | Issue's hypothesis | InPost official docs | OL today |
+|---|---|---|---|
+| Digest encoding | hex | **Base64** | Base64 ✅ |
+| Algorithm | HMAC-SHA256 | HMAC-SHA256 | HMAC-SHA256 ✅ |
+| Signature header | `x-inpost-signature` | `x-inpost-signature` | ✅ |
+| Signed content | raw body only | **two variants, "configurable per client"** | only `{ts}.{body}` ❌ |
+
+Verbatim, from [Webhook Signature Verification](https://developers.inpost-group.com/webhook-signature-verification):
+
+> "The calculated signature will be transformed from byte[] to **Base64** and then placed in the `x-inpost-signature` header."
+
+> "Payload to sign can be created in two ways **which also can be configurable per client**: concatenated request timestamp header (`x-inpost-timestamp`) and event payload ("." - dot sign will be a separator)."
+
+> Example 1: "the raw content if only the body of the webhook message is signed" — `{"customerReference":...}`
+> Example 2: "the raw content if the timestamp header is also included into the content" — `2025-01-08T14:03:55.387Z.{"customerReference":...}`
+
+The Java sample confirms Base64: `return Base64.getEncoder().encodeToString((mac.doFinal(contentToSign)));`
+
+**Conclusion:** the openoms Go SDK is a third-party OMS project, not an InPost
+artifact — its hex read is not authoritative. **Switching to hex would have
+broken a currently-correct half.** The encoding is right; the *defect* is that
+OL hard-codes exactly one of two documented, per-client-configurable variants.
+
+### The real defects
+
+1. **Variant lock-in (root cause).** OL only accepts variant 2 (`{ts}.{body}`).
+   If InPost's integration team configured the account for variant 1 (body-only)
+   — a documented, equally-valid choice OL does not control — every delivery is
+   rejected. This is precisely the silent-death mode the issue describes, just
+   with a different root cause than hypothesised.
+2. **Hard timestamp requirement.** `verify()` returns `ok:false` when
+   `x-inpost-timestamp` is absent. Under variant-1 signing the header is not part
+   of the signed content, so a delivery without it is still authentic — OL rejects
+   it anyway. Second silent-death mode.
+3. **Documented dedup id ignored.** InPost sends `x-inpost-event-id` ("Unique id
+   of the event"). `deriveEventId` reads only *body* fields and otherwise hashes
+   a synthetic id, so the Postgres dedup gate keys on a weaker basis than the
+   provider's own event id.
+4. **Non-ISO `occurredAt` (issue item 4, confirmed real).** ShipX documents
+   `event_ts` as `"2020-03-20 15:08:42 +0100"` — not ISO-8601. The envelope
+   contract and `webhook-event-publisher.service.ts` declare an ISO-8601 string;
+   the plugin path has no validator to catch the divergence (the strict
+   `@IsISO8601` on `WebhookRequestDto` gates only the *default* decoder).
+
+### Non-goals
+
+- **Switching to hex** — refuted above; would break verification.
+- **A live sandbox capture** — externally blocked, see §5.
+- **RSA digital-signature support** — the other per-client signing method. OL's
+  runbook generates a shared secret (HMAC); adding asymmetric verification is a
+  separate capability, not this fix.
+- **Payload-shape changes** — `payload.shipment_id` extraction landed in #1544.
+
+## 2. Research — established patterns reused
+
+- `InboundWebhookDecoderPort` (`verify` / `extractEnvelope`), CORE-owned; the
+  adapter is the only thing that changes. `WebhookVerifyResult.timestampMs` is
+  already `| undefined`, and the host **already** skips the replay window when it
+  is absent (`webhook.service.ts:95`) — no host change needed for defect 2.
+- ADR-021 trigger semantics: the webhook is a low-latency nudge, never the source
+  of truth; the routed refresh re-reads authoritative status.
+- Durable dedup gate on `(provider, connectionId, eventId)` (#711).
+- `timingSafeEqual` comparison already in place — preserved.
+
+## 3. Design
+
+`verify()` becomes **variant-tolerant over the two documented forms**, still
+Base64/HMAC-SHA256, still timing-safe:
+
+```
+timestamp present → candidates = [ `{ts}.{body}`, `{body}` ]   ; return timestampMs (replay window enforced)
+timestamp absent  → candidates = [ `{body}` ]                  ; return ok without timestampMs (dedup gate is the backstop)
+accept iff ANY candidate's Base64 HMAC timing-safe-equals the header
+```
+
+**Why trying both is not a downgrade.** An attacker cannot forge a body-only
+signature without the secret, so the fallback only succeeds when InPost genuinely
+signed body-only. Replaying a captured variant-2 delivery under a *different*
+timestamp fails both candidates. The one real consequence is inherent to variant 1
+itself, not introduced here: when InPost signs body-only the timestamp is
+unauthenticated, so a replay could slip the window — the durable `eventId` dedup
+gate collapses it, and under ADR-021 the worst case is a redundant idempotent
+re-read, never wrong state.
+
+Both comparisons run unconditionally (no early exit between candidates) to keep
+the check constant-work with respect to which variant matched.
+
+**Dedup id.** Prefer the documented `x-inpost-event-id` header, then existing
+body fields, then the current deterministic hash. Strictly additive.
+
+**`occurredAt` normalisation.** Normalise the documented ShipX `event_ts` form
+(`"2020-03-20 15:08:42 +0100"`) to ISO-8601 via a parse-and-reformat that emits
+the original instant; pass through anything already ISO; reject (as today) when
+absent. The header value stays preferred and is already ISO.
+
+## 4. Steps
+
+| # | File | Change | Acceptance |
+|---|---|---|---|
+| 1 | `.../inpost-inbound-webhook-decoder.adapter.ts` | `verify()` accepts both documented signed-content variants; timestamp header optional (body-only path) | Variant-1 and variant-2 deliveries both verify; tampered signature still rejected |
+| 2 | same | `deriveEventId` prefers `x-inpost-event-id` header | Header id wins over body id and over the hash |
+| 3 | same | Normalise non-ISO `event_ts` → ISO-8601 | `"2020-03-20 15:08:42 +0100"` → valid ISO of the same instant |
+| 4 | same | Rewrite the file header to state the *verified* scheme + doc citations | No stale "base64 over `{ts}.{body}`" claim |
+| 5 | `.../__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts` | `sign()` helper per variant; tests for both variants, missing-timestamp accept, tampered reject, wrong-secret reject, header event-id precedence, `event_ts` normalisation | All green; existing 17 still pass |
+| 6 | `libs/integrations/inpost/docs/setup-guide.md` | Document the scheme, both variants, and what to request from InPost's integration team | Operator can state the requirement when registering |
+
+## 5. Validation
+
+- **Architecture**: adapter-local; no CORE/port/DTO/ORM change; no `platformType`
+  leakage; no new dependency. Domain purity untouched.
+- **Standards**: no `any`, no `console.log`, explicit return types, file header
+  updated, types stay in the existing `*.types.ts`.
+- **Security**: timing-safe comparison retained on every candidate; secret never
+  logged; no weakening (see §3 rationale).
+- **Testing**: unit-only — pure function of `(rawBody, headers, secret)`; no
+  Testcontainers needed.
+- **Migration**: none (no ORM entity in scope).
+
+### Open risk — the live capture the issue asks for is externally blocked
+
+InPost does **not** offer self-service webhook registration:
+
+> "Please contact InPost Account Manager and/or Integration Team. Self-service portal is under development." — [InPost Webhooks](https://developers.inpost-group.com/webhooks)
+
+OL's own runbook already encodes this (email `integration@inpost.pl`). So a live
+sandbox capture cannot be produced unilaterally in this session — it needs InPost
+to configure a webhook against our endpoint and tell us (or pick) the variant.
+
+This plan's response is to **remove the capture from the critical path**: by
+accepting both documented variants, OL is correct under either configuration, so
+the empirical question stops being load-bearing. The capture is therefore not
+tracked as a follow-up — it would only re-confirm a payload shape #1544 already
+aligned and a scheme this change makes configuration-independent. If a real
+delivery ever does fail to verify, the decoder's own rejection log is the signal
+to revisit, and §3's rationale is the map.

--- a/libs/integrations/inpost/docs/setup-guide.md
+++ b/libs/integrations/inpost/docs/setup-guide.md
@@ -44,13 +44,51 @@ ingests shipment-status webhooks.
 ## 4. Webhooks (optional but recommended)
 
 InPost ShipX can push shipment-status events to OpenLinker so terminal states
-(`delivered`, etc.) propagate without polling. Configure the webhook target in
-the ShipX portal to point at your OL webhook endpoint for this connection.
-Without webhooks, OL falls back to polling tracking at a conservative cadence.
+(`delivered`, etc.) propagate without polling. Without webhooks, OL falls back to
+polling tracking at a conservative cadence — status still converges, just slower.
+
+### Registering the endpoint
+
+InPost has **no self-service webhook registration** ("Please contact InPost
+Account Manager and/or Integration Team. Self-service portal is under
+development."), so OL cannot auto-provision it. Ask InPost's integration team to
+deliver `Shipment.Tracking` events to your connection's endpoint:
+
+```
+{OL public API base}/webhooks/inpost/{connectionId}
+```
+
+The **InPost Webhook Runbook** on the connection page surfaces the exact URL, a
+copy-paste email template for `integration@inpost.pl`, and one-click secret
+rotation.
+
+### Signature scheme
+
+OL authenticates every delivery by **HMAC-SHA256, base64-encoded**, read from the
+`x-inpost-signature` header, using the shared secret you rotate in the runbook and
+hand to InPost. Give them that secret over a trusted channel or every delivery is
+rejected with `401 Invalid webhook signature`.
+
+InPost makes the **signed content configurable per client**, in two documented
+forms:
+
+| Variant | Signed content |
+|---|---|
+| 1 | the raw request body alone |
+| 2 | `{x-inpost-timestamp}.{body}` (dot separator) |
+
+**You do not need to know or request which one InPost configured** — OL
+authenticates both (#1556). Under variant 2 the signed timestamp additionally
+feeds OL's replay-window check; under variant 1 the durable event-id dedup gate
+is the replay backstop.
+
+InPost's other signing method — an RSA digital signature over the same content —
+is **not** supported: OL's runbook issues a shared secret, so request HMAC.
 
 ## 5. Troubleshooting
 
 - **Test Connection fails with 401** — the `apiToken` is wrong, expired, or from the other environment (sandbox token against production URL or vice-versa).
+- **Webhooks 401 with `Invalid webhook signature`** — the secret InPost holds differs from OL's. Rotate it in the runbook and re-send it to the integration team. Note the shipment status still converges via the 30-minute tracking poll, so a dead webhook path is easy to miss — check the logs, not just the status.
 - **`postCode must match the PL format NN-NNN`** — the sender postcode must be `NN-NNN` (e.g. `01-234`).
 - **Labels missing the sender** — re-check the sender address block on the connection config.
 

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-inbound-webhook-decoder.adapter.spec.ts
@@ -7,9 +7,22 @@ import { InpostInboundWebhookDecoderAdapter } from '../inpost-inbound-webhook-de
 const SECRET = 'fdXbfU27DBNG6LuoHu@ThKl3';
 const TIMESTAMP = '2025-01-08T14:03:55.387Z';
 
-function sign(rawBody: Buffer, timestamp: string, secret: string): string {
+/**
+ * InPost's Example 2 — the signed content is `{x-inpost-timestamp}.{body}`.
+ * Base64 per the docs' Java sample (`Base64.getEncoder().encodeToString(...)`).
+ */
+function signTimestampAndBody(rawBody: Buffer, timestamp: string, secret: string): string {
   const signed = Buffer.concat([Buffer.from(timestamp), Buffer.from('.'), rawBody]);
   return createHmac('sha256', secret).update(signed).digest('base64');
+}
+
+/**
+ * InPost's Example 1 — the signed content is the raw body alone. Which of the
+ * two variants a client receives is "configurable per client" (#1556), so the
+ * decoder must authenticate both.
+ */
+function signBodyOnly(rawBody: Buffer, secret: string): string {
+  return createHmac('sha256', secret).update(rawBody).digest('base64');
 }
 
 describe('InpostInboundWebhookDecoderAdapter', () => {
@@ -26,7 +39,7 @@ describe('InpostInboundWebhookDecoderAdapter', () => {
         rawBody,
         secret: SECRET,
         headers: {
-          'x-inpost-signature': sign(rawBody, TIMESTAMP, SECRET),
+          'x-inpost-signature': signTimestampAndBody(rawBody, TIMESTAMP, SECRET),
           'x-inpost-timestamp': TIMESTAMP,
         },
       });
@@ -40,16 +53,80 @@ describe('InpostInboundWebhookDecoderAdapter', () => {
         rawBody,
         secret: SECRET,
         headers: {
-          'x-inpost-signature': sign(Buffer.from('different'), TIMESTAMP, SECRET),
+          'x-inpost-signature': signTimestampAndBody(Buffer.from('different'), TIMESTAMP, SECRET),
           'x-inpost-timestamp': TIMESTAMP,
         },
       });
       expect(result.ok).toBe(false);
     });
 
-    it('should reject when signature or timestamp header is missing', () => {
+    it('should reject when the signature header is missing', () => {
       const rawBody = Buffer.from('{}');
       expect(decoder.verify({ rawBody, secret: SECRET, headers: {} }).ok).toBe(false);
+    });
+
+    // #1556: the signed content is "configurable per client" — InPost's Example 1
+    // (body only) is as valid as Example 2, and OL is not told which is in use.
+    it('should accept a body-only signature when the timestamp header is present', () => {
+      const rawBody = Buffer.from(JSON.stringify({ tracking_number: '6200000000001' }));
+      const result = decoder.verify({
+        rawBody,
+        secret: SECRET,
+        headers: {
+          'x-inpost-signature': signBodyOnly(rawBody, SECRET),
+          'x-inpost-timestamp': TIMESTAMP,
+        },
+      });
+      expect(result.ok).toBe(true);
+      expect(result.timestampMs).toBe(Date.parse(TIMESTAMP));
+    });
+
+    it('should accept a body-only signature when no timestamp header is sent', () => {
+      const rawBody = Buffer.from(JSON.stringify({ tracking_number: '6200000000001' }));
+      const result = decoder.verify({
+        rawBody,
+        secret: SECRET,
+        headers: { 'x-inpost-signature': signBodyOnly(rawBody, SECRET) },
+      });
+      expect(result.ok).toBe(true);
+      // No signed timestamp to replay-check — the host skips its replay window
+      // when the field is absent, leaving the durable dedup gate as backstop.
+      expect(result.timestampMs).toBeUndefined();
+    });
+
+    it('should reject a signature made with the wrong secret under either variant', () => {
+      const rawBody = Buffer.from(JSON.stringify({ tracking_number: '6200000000001' }));
+      const headers = { 'x-inpost-timestamp': TIMESTAMP };
+      expect(
+        decoder.verify({
+          rawBody,
+          secret: SECRET,
+          headers: { ...headers, 'x-inpost-signature': signBodyOnly(rawBody, 'wrong-secret') },
+        }).ok,
+      ).toBe(false);
+      expect(
+        decoder.verify({
+          rawBody,
+          secret: SECRET,
+          headers: {
+            ...headers,
+            'x-inpost-signature': signTimestampAndBody(rawBody, TIMESTAMP, 'wrong-secret'),
+          },
+        }).ok,
+      ).toBe(false);
+    });
+
+    it('should reject a timestamp-and-body signature replayed under a different timestamp', () => {
+      const rawBody = Buffer.from(JSON.stringify({ tracking_number: '6200000000001' }));
+      const result = decoder.verify({
+        rawBody,
+        secret: SECRET,
+        headers: {
+          'x-inpost-signature': signTimestampAndBody(rawBody, TIMESTAMP, SECRET),
+          'x-inpost-timestamp': '2025-01-08T15:03:55.387Z',
+        },
+      });
+      expect(result.ok).toBe(false);
     });
   });
 
@@ -154,8 +231,45 @@ describe('InpostInboundWebhookDecoderAdapter', () => {
         expect(result.envelope.externalId).toBe('49');
         expect(result.envelope.objectType).toBe('shipment');
         expect(result.envelope.eventType).toBe('tracking');
-        // Falls back to the body `event_ts` when no header timestamp is present.
-        expect(result.envelope.occurredAt).toBe('2020-03-20 15:08:42 +0100');
+        // Falls back to the body `event_ts` when no header timestamp is present,
+        // normalized from ShipX's non-ISO form to the envelope's ISO-8601
+        // contract, preserving the instant and offset (#1556).
+        expect(result.envelope.occurredAt).toBe('2020-03-20T15:08:42+01:00');
+        expect(Date.parse(result.envelope.occurredAt)).toBe(
+          Date.parse('2020-03-20 15:08:42 +0100'),
+        );
+      }
+    });
+
+    it('should normalize a fractional-second event_ts and pass an ISO value through untouched', () => {
+      const fractional = decoder.extractEnvelope(
+        realStatusWebhook({ event_ts: '2020-03-20 15:08:42.123 +0100' }),
+        {},
+      );
+      expect(fractional.action).toBe('route');
+      if (fractional.action === 'route') {
+        expect(fractional.envelope.occurredAt).toBe('2020-03-20T15:08:42.123+01:00');
+      }
+
+      // Already-ISO payloads (InPost's newer shape) must not be rewritten.
+      const iso = decoder.extractEnvelope(
+        realStatusWebhook({ event_ts: '2025-01-08T14:02:55.374675Z' }),
+        {},
+      );
+      expect(iso.action).toBe('route');
+      if (iso.action === 'route') {
+        expect(iso.envelope.occurredAt).toBe('2025-01-08T14:02:55.374675Z');
+      }
+    });
+
+    it('should prefer the x-inpost-event-id header as the dedup key', () => {
+      const result = decoder.extractEnvelope(realStatusWebhook({ event_id: 'body-event-id' }), {
+        'x-inpost-event-id': 'header-event-id',
+      });
+      expect(result.action).toBe('route');
+      if (result.action === 'route') {
+        // InPost's own "Unique id of the event" outranks body fields and the hash.
+        expect(result.envelope.eventId).toBe('header-event-id');
       }
     });
 

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-inbound-webhook-decoder.adapter.ts
@@ -2,11 +2,35 @@
  * InPost Inbound Webhook Decoder Adapter (#768, ADR-021)
  *
  * Authenticates + decodes InPost ShipX `Shipment.Tracking` webhooks at the host
- * ingress, keyed by `provider = 'inpost'`. The verify half uses InPost's HMAC
- * scheme (base64 HMAC-SHA256 over `{x-inpost-timestamp}.{rawBody}`, header
- * `x-inpost-signature`) — the shared secret OL generates and hands InPost,
- * resolved by the host via `WebhookSecretProviderPort`. The extract half is a
- * pure transform into the host's neutral envelope.
+ * ingress, keyed by `provider = 'inpost'`. The verify half implements InPost's
+ * HMAC scheme (base64 HMAC-SHA256, header `x-inpost-signature`) using the shared
+ * secret OL generates and hands InPost, resolved by the host via
+ * `WebhookSecretProviderPort`. The extract half is a pure transform into the
+ * host's neutral envelope.
+ *
+ * Signature scheme (#1556) — per InPost's "Webhook Signature Verification" docs
+ * (https://developers.inpost-group.com/webhook-signature-verification):
+ *
+ *   "The calculated signature will be transformed from byte[] to Base64 and then
+ *    placed in the x-inpost-signature header."
+ *   "Payload to sign can be created in two ways which also can be configurable
+ *    per client: concatenated request timestamp header (x-inpost-timestamp) and
+ *    event payload ("." - dot sign will be a separator)."
+ *
+ * The signed content is therefore NOT one fixed form: InPost's integration team
+ * configures it per client (their Example 1 = body only, Example 2 =
+ * `{x-inpost-timestamp}.{body}`), and OL neither controls nor is told the
+ * choice. So we accept EITHER, and are correct under both configurations rather
+ * than betting on one and rejecting 100% of deliveries if the bet is wrong.
+ *
+ * Trying both is not a downgrade: forging a body-only signature still requires
+ * the secret, so the fallback only succeeds when InPost genuinely signed
+ * body-only. Replaying a captured `{ts}.{body}` delivery under a different
+ * timestamp matches neither candidate. The one asymmetry is inherent to InPost's
+ * body-only variant, not introduced here — it leaves the timestamp unsigned, so
+ * a replay could slip the host's window; the durable `(provider, connectionId,
+ * eventId)` dedup gate (#711) collapses it, and under ADR-021 the worst case is
+ * a redundant idempotent re-read, never wrong state.
  *
  * Trigger model (ADR-021): the webhook is a low-latency nudge, never the source
  * of truth. We read ONLY the shipment identifier from the body — never InPost's
@@ -36,7 +60,17 @@ import type {
 const SIGNATURE_HEADER = 'x-inpost-signature';
 const TIMESTAMP_HEADER = 'x-inpost-timestamp';
 const TOPIC_HEADER = 'x-inpost-topic';
+const EVENT_ID_HEADER = 'x-inpost-event-id';
 const TRACKING_TOPIC = 'Shipment.Tracking';
+
+/**
+ * ShipX renders `event_ts` as `"2020-03-20 15:08:42 +0100"` — a space-separated,
+ * non-ISO-8601 form (docs: "[1.23.0] Webhooks"). The neutral envelope's
+ * `occurredAt` is contractually an ISO-8601 string, so that form is normalized
+ * rather than passed through verbatim (#1556). Anything already ISO-8601 (the
+ * `x-inpost-timestamp` header, and InPost's newer payloads) skips this path.
+ */
+const SHIPX_EVENT_TS_PATTERN = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?) ([+-]\d{2}):?(\d{2})$/;
 
 /**
  * ShipX `event` values that signify a shipment status change worth refreshing.
@@ -69,22 +103,34 @@ export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoder
     secret: string;
   }): WebhookVerifyResult {
     const signature = this.header(input.headers, SIGNATURE_HEADER);
+    if (!signature) {
+      return { ok: false };
+    }
     const timestamp = this.header(input.headers, TIMESTAMP_HEADER);
-    if (!signature || !timestamp) {
+
+    // Candidate signed contents, in InPost's documented order. Without the
+    // timestamp header only the body-only form is expressible — that delivery is
+    // still authentic under body-only signing, so it must not be rejected out of
+    // hand (rejecting it was the second silent-death mode behind #1556).
+    const candidates: Buffer[] = timestamp
+      ? [Buffer.concat([Buffer.from(timestamp), Buffer.from('.'), input.rawBody]), input.rawBody]
+      : [input.rawBody];
+
+    // reduce(), not some()/early-return: every candidate is compared so the work
+    // done does not vary with which variant matched.
+    const matched = candidates.reduce(
+      (acc, candidate) => this.signatureMatches(candidate, input.secret, signature) || acc,
+      false,
+    );
+    if (!matched) {
       return { ok: false };
     }
 
-    const signedPayload = Buffer.concat([
-      Buffer.from(timestamp),
-      Buffer.from('.'),
-      input.rawBody,
-    ]);
-    const expected = createHmac('sha256', input.secret).update(signedPayload).digest('base64');
-
-    const provided = Buffer.from(signature);
-    const expectedBuf = Buffer.from(expected);
-    if (provided.length !== expectedBuf.length || !timingSafeEqual(provided, expectedBuf)) {
-      return { ok: false };
+    if (!timestamp) {
+      // No signed timestamp to replay-check against. The host skips its
+      // replay window when `timestampMs` is absent; the durable eventId dedup
+      // gate stays the backstop (same posture as the WooCommerce decoder).
+      return { ok: true };
     }
 
     // InPost stamps an ISO-8601 timestamp (e.g. "2025-01-08T14:03:55.387Z"); the
@@ -127,14 +173,15 @@ export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoder
       return { action: 'reject', reason: 'no shipment identifier in payload' };
     }
 
-    // Prefer the signed `x-inpost-timestamp` header; fall back to the body's
-    // `event_ts` (present in the ShipX payload). Reject rather than fabricate a
-    // timestamp, keeping this a pure transform.
-    const occurredAt =
+    // Prefer the signed `x-inpost-timestamp` header (already ISO-8601); fall
+    // back to the body's `event_ts`, normalized from ShipX's non-ISO form.
+    // Reject rather than fabricate a timestamp, keeping this a pure transform.
+    const rawOccurredAt =
       this.header(headers, TIMESTAMP_HEADER) ?? this.firstString(record, [['event_ts']]);
-    if (!occurredAt) {
+    if (!rawOccurredAt) {
       return { action: 'reject', reason: 'missing event timestamp' };
     }
+    const occurredAt = this.toIsoTimestamp(rawOccurredAt);
     return {
       action: 'route',
       envelope: {
@@ -142,7 +189,7 @@ export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoder
         // hash of the shipment id + event timestamp so retries collapse and
         // distinct events don't. Best-effort (the idempotent re-read is the
         // correctness guarantee), so the eventId need only suppress obvious dupes.
-        eventId: this.deriveEventId(record, shipmentId, occurredAt),
+        eventId: this.deriveEventId(record, headers, shipmentId, occurredAt),
         eventType: 'tracking',
         occurredAt,
         objectType: 'shipment',
@@ -151,11 +198,46 @@ export class InpostInboundWebhookDecoderAdapter implements InboundWebhookDecoder
     };
   }
 
+  /**
+   * Timing-safe base64 HMAC-SHA256 comparison of one candidate signed content
+   * against the provided `x-inpost-signature` value.
+   */
+  private signatureMatches(signedContent: Buffer, secret: string, signature: string): boolean {
+    const expected = createHmac('sha256', secret).update(signedContent).digest('base64');
+    const provided = Buffer.from(signature);
+    const expectedBuf = Buffer.from(expected);
+    // Length must match before timingSafeEqual, which throws on unequal lengths.
+    return provided.length === expectedBuf.length && timingSafeEqual(provided, expectedBuf);
+  }
+
+  /**
+   * Normalize a ShipX `event_ts` (`"2020-03-20 15:08:42 +0100"`) into ISO-8601,
+   * preserving the instant and its UTC offset. Values that don't match that
+   * exact documented form — including anything already ISO-8601 — pass through
+   * untouched, so this never mangles a shape we haven't seen.
+   */
+  private toIsoTimestamp(value: string): string {
+    const match = SHIPX_EVENT_TS_PATTERN.exec(value);
+    if (!match) {
+      return value;
+    }
+    const [, date, time, offsetHours, offsetMinutes] = match;
+    const candidate = `${date}T${time}${offsetHours}:${offsetMinutes}`;
+    return Number.isNaN(Date.parse(candidate)) ? value : candidate;
+  }
+
   private deriveEventId(
     record: Record<string, unknown>,
+    headers: Record<string, string>,
     shipmentId: string,
     occurredAt: string | undefined,
   ): string {
+    // InPost's own event id, documented as the "Unique id of the event" — the
+    // authoritative dedup basis, so it outranks body fields and the hash (#1556).
+    const headerEventId = this.header(headers, EVENT_ID_HEADER);
+    if (headerEventId) {
+      return headerEventId;
+    }
     const explicit = this.firstString(record, [['event_id'], ['eventId'], ['id']]);
     if (explicit) {
       return explicit;


### PR DESCRIPTION
## What changed and why

`InpostInboundWebhookDecoderAdapter.verify()` hard-coded **one** of InPost's **two** documented signed-content forms. A connection InPost configured for the other form has **100% of its deliveries rejected** at the verify gate — before `extractEnvelope` ever runs. The 30-minute tracking poll masks it: status still converges, so the dead low-latency path is invisible in production.

### The research inverts this issue's premise

#1556 hypothesised the scheme is **hex over the raw body** (citing the openoms Go SDK) and proposed aligning `verify()` to that. InPost's authoritative [Webhook Signature Verification](https://developers.inpost-group.com/webhook-signature-verification) docs refute it, verbatim:

> "The calculated signature will be transformed from byte[] to **Base64** and then placed in the `x-inpost-signature` header."

> "Payload to sign can be created in two ways **which also can be configurable per client**: concatenated request timestamp header (`x-inpost-timestamp`) and event payload ("." - dot sign will be a separator)."

| Aspect | Issue's hypothesis | InPost docs | OL before |
|---|---|---|---|
| Digest encoding | hex | **Base64** | Base64 ✅ |
| Signed content | raw body only | **two variants, configurable per client** | only `{ts}.{body}` ❌ |

So **base64 was already correct** — implementing this issue literally would have broken a working half. openoms is a third-party OMS project, not an InPost artifact. The real defect is the **variant lock-in**: InPost's integration team picks the form per client (Example 1 = body only, Example 2 = `{timestamp}.{body}`), and OL neither controls nor is told the choice.

## Changes

- **`verify()` accepts either documented variant** — still base64 HMAC-SHA256, still timing-safe, both candidates always compared so the work doesn't vary with which matched.
- **The timestamp header no longer gates authentication.** Under body-only signing it isn't part of the signed content, so demanding it was a second silent-death mode. When absent, `timestampMs` is omitted and the host skips its replay window (`webhook.service.ts:95`) — the durable `(provider, connectionId, eventId)` dedup gate (#711) is the backstop. Same posture as the WooCommerce decoder (#1696).
- **Dedup key**: prefer InPost's documented `x-inpost-event-id` ("Unique id of the event") over body fields and the synthetic hash.
- **`occurredAt` (issue item 4, confirmed real)**: ShipX documents `event_ts` as `"2020-03-20 15:08:42 +0100"` — not ISO-8601, while the envelope contract declares ISO. Now normalized, preserving instant and offset; already-ISO values pass through untouched.
- **Setup guide**: documents the scheme, both variants, and that registration goes through InPost's integration team.

### Why trying both variants is not a downgrade

Forging a body-only signature still requires the secret, so the fallback only succeeds when InPost genuinely signed body-only. A captured `{ts}.{body}` delivery replayed under a different timestamp matches **neither** candidate (test covers this). The one asymmetry — an unsigned timestamp — is inherent to InPost's body-only variant, not introduced here: the dedup gate collapses replays, and under ADR-021 the worst case is a redundant idempotent re-read, never wrong state.

## On the live sandbox capture

The issue's original AC was a live capture. That is **not obtainable unilaterally** — InPost ships no self-service webhook registration:

> "Please contact InPost Account Manager and/or Integration Team. Self-service portal is under development." — [InPost Webhooks](https://developers.inpost-group.com/webhooks)

OL's own runbook already encodes this (email `integration@inpost.pl`). This PR removes the capture from the critical path instead: accepting both documented variants makes OL correct under either configuration, so the empirical question stops being load-bearing. No follow-up is filed — a capture would only re-confirm a payload shape #1544 already aligned. If a real delivery ever fails to verify, the decoder's rejection log is the signal and the adapter's file header is the map.

## How to test

```bash
pnpm --filter @openlinker/integrations-inpost test
```

Decoder spec: 17 → 23 tests. New coverage: body-only signature (with and without the timestamp header), wrong-secret rejection under both variants, cross-timestamp replay rejection, `x-inpost-event-id` precedence, `event_ts` normalization (incl. fractional seconds and ISO passthrough).

Quality gate: `pnpm lint` ✅ · `pnpm type-check` ✅ · InPost package 136/136 ✅. No CORE/port/DTO/ORM change — no migration.

Plan: `docs/plans/implementation-plan-inpost-webhook-hmac-scheme.md`

Closes #1556

🤖 Generated with [Claude Code](https://claude.com/claude-code)