### PR TITLE
fix(worker): cap master.product.syncAll default page size at 100

### DIFF
--- a/apps/worker/src/sync/handlers/__tests__/master-product-sync-all.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/master-product-sync-all.handler.spec.ts
@@ -78,7 +78,7 @@ describe('MasterProductSyncAllHandler', () => {
   });
 
   it('should paginate through multiple pages until a short page is returned', async () => {
-    const fullPage = Array.from({ length: 200 }, (_, i) => String(i));
+    const fullPage = Array.from({ length: 100 }, (_, i) => String(i));
     productMaster.listExternalIds
       .mockResolvedValueOnce(fullPage)
       .mockResolvedValueOnce(['x1', 'x2']);
@@ -87,22 +87,22 @@ describe('MasterProductSyncAllHandler', () => {
     await handler.execute(createJob('conn-1'));
 
     expect(productMaster.listExternalIds).toHaveBeenCalledTimes(2);
-    expect(productMaster.listExternalIds).toHaveBeenNthCalledWith(1, { limit: 200, offset: 0 });
-    expect(productMaster.listExternalIds).toHaveBeenNthCalledWith(2, { limit: 200, offset: 200 });
-    expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(202);
+    expect(productMaster.listExternalIds).toHaveBeenNthCalledWith(1, { limit: 100, offset: 0 });
+    expect(productMaster.listExternalIds).toHaveBeenNthCalledWith(2, { limit: 100, offset: 100 });
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(102);
   });
 
   it('should deduplicate external ids repeated across pages', async () => {
-    const fullPage = Array.from({ length: 200 }, (_, i) => String(i));
+    const fullPage = Array.from({ length: 100 }, (_, i) => String(i));
     // Second page overlaps with first — defensive dedupe should keep the count honest.
     productMaster.listExternalIds
       .mockResolvedValueOnce(fullPage)
-      .mockResolvedValueOnce(['199', '200']);
+      .mockResolvedValueOnce(['99', '100']);
     jobEnqueue.enqueueJob.mockResolvedValue({ jobId: 'j', isExisting: false });
 
     await handler.execute(createJob('conn-1'));
 
-    expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(201);
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(101);
   });
 
   it('should handle empty catalog gracefully', async () => {

--- a/apps/worker/src/sync/handlers/master-product-sync-all.handler.ts
+++ b/apps/worker/src/sync/handlers/master-product-sync-all.handler.ts
@@ -34,7 +34,12 @@ import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 
 type SyncJob = SyncJobEntity;
 
-const DEFAULT_PAGE_SIZE = 200;
+// 100 is the lowest common denominator across ProductMasterPort adapters —
+// WooCommerce's REST API hard-caps `per_page` at 100 and rejects anything
+// higher with a 400, so a larger default permanently fails WC master syncs
+// (#1723). PrestaShop has no such cap; MAX_PAGES still bounds a full sweep
+// at 100,000 products.
+const DEFAULT_PAGE_SIZE = 100;
 const MAX_PAGES = 1000; // Safety guard against infinite loops.
 
 @Injectable()


### PR DESCRIPTION
## Summary
- WooCommerce's REST API hard-caps `per_page` at 100 and returns a 400 (`rest_invalid_param`) for anything higher; the previous `DEFAULT_PAGE_SIZE = 200` in `MasterProductSyncAllHandler` made `master.product.syncAll` retry forever with exponential backoff for any WooCommerce `ProductMaster` connection.
- Lowered the default to 100. `MAX_PAGES = 1000` still bounds a full sweep at 100,000 products, so PrestaShop just makes twice as many (cheap) requests — no behavior change there.
- Updated `master-product-sync-all.handler.spec.ts`'s hardcoded 200-item fixtures/expectations to 100.

## Verification
- Live: reproduced the 400 against a demo stack's WooCommerce connection (`GET /wp-json/wc/v3/products?per_page=200` → `per_page must be between 1 and 100`).
- After the fix, rebuilt the worker image on the live stack and re-triggered `master.product.syncAll` for the same WooCommerce connection — job now completes `succeeded | ok` (previously stuck in `queued`/retry with the 400 in `lastError`).
- `pnpm --filter @openlinker/worker exec jest sync/handlers/__tests__/master-product-sync-all.handler.spec.ts` — 7/7 passing.
- `pnpm --filter @openlinker/worker... build` (full dependency graph) — clean.
- `pnpm --filter @openlinker/worker exec eslint` on both changed files — zero errors.

Found while implementing the e2e WooCommerce-parity suite for #1571.

Closes #1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)