### PR TITLE
fix(api/auth): add OL_COOKIE_DOMAIN for split-subdomain deploys (#1725)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -55,6 +55,26 @@ OL_DEMO_MODE=false
 # Set explicitly for any non-local environment.
 # OL_CORS_ORIGIN=http://localhost:4173
 
+# --- Auth cookies -------------------------------------------------------------
+# ol_refresh (HttpOnly) + ol_csrf (readable by the SPA) back the silent
+# /auth/refresh flow. Both default to host-only, same-origin-friendly cookies.
+#
+# SameSite: 'strict' in prod / 'lax' in dev by default. Set explicitly when the
+# SPA and API are on different origins.
+# OL_COOKIE_SAMESITE=lax
+#
+# Domain: unset ⇒ host-only. For a SPLIT-SUBDOMAIN deploy (SPA on
+# app.example.com, API on api.example.com) set the shared parent domain so the
+# SPA subdomain can read ol_csrf set by the API subdomain — otherwise every
+# full-page navigation (e.g. the Allegro OAuth redirect) logs the user out.
+# OL_COOKIE_DOMAIN=.example.com
+#
+# Split-subdomain recipe (all four together):
+#   OL_COOKIE_DOMAIN=.example.com
+#   OL_COOKIE_SAMESITE=none        # cross-origin XHR; requires Secure
+#   NODE_ENV=production            # turns on the Secure flag (needs real TLS)
+#   OL_CORS_ORIGIN=https://app.example.com
+
 # --- JWT auth -----------------------------------------------------------------
 # REQUIRED. Change for any non-local environment.
 JWT_SECRET=dev-secret-change-in-production

--- a/apps/api/src/auth/auth.cookies.spec.ts
+++ b/apps/api/src/auth/auth.cookies.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Auth Cookie Helpers — unit tests
+ *
+ * Covers the OL_COOKIE_DOMAIN knob added for split-subdomain deploys (#1725):
+ * when set, the Domain attribute is applied to both auth cookies on set + clear;
+ * when unset, cookies stay host-only (unchanged behaviour).
+ *
+ * @module apps/api/src/auth
+ */
+import type { CookieOptions, Response } from 'express';
+import {
+  CSRF_COOKIE_NAME,
+  REFRESH_COOKIE_NAME,
+  clearAuthCookies,
+  setCsrfCookie,
+  setRefreshCookie,
+} from './auth.cookies';
+
+interface CookieCall {
+  name: string;
+  value: string;
+  options: CookieOptions;
+}
+
+interface ClearCall {
+  name: string;
+  options: CookieOptions;
+}
+
+function createResponseSpy(): {
+  res: Response;
+  cookies: CookieCall[];
+  clears: ClearCall[];
+} {
+  const cookies: CookieCall[] = [];
+  const clears: ClearCall[] = [];
+  const res = {
+    cookie: (name: string, value: string, options: CookieOptions): Response => {
+      cookies.push({ name, value, options });
+      return res;
+    },
+    clearCookie: (name: string, options: CookieOptions): Response => {
+      clears.push({ name, options });
+      return res;
+    },
+  } as unknown as Response;
+  return { res, cookies, clears };
+}
+
+describe('auth.cookies', () => {
+  const originalDomain = process.env.OL_COOKIE_DOMAIN;
+
+  afterEach(() => {
+    if (originalDomain === undefined) {
+      delete process.env.OL_COOKIE_DOMAIN;
+    } else {
+      process.env.OL_COOKIE_DOMAIN = originalDomain;
+    }
+  });
+
+  describe('when OL_COOKIE_DOMAIN is set', () => {
+    beforeEach(() => {
+      process.env.OL_COOKIE_DOMAIN = '.example.com';
+    });
+
+    it('should apply the Domain attribute to the refresh cookie', () => {
+      const { res, cookies } = createResponseSpy();
+
+      setRefreshCookie(res, 'raw-refresh-token');
+
+      const set = cookies.find((c) => c.name === REFRESH_COOKIE_NAME);
+      expect(set?.options.domain).toBe('.example.com');
+    });
+
+    it('should apply the Domain attribute to the CSRF cookie', () => {
+      const { res, cookies } = createResponseSpy();
+
+      setCsrfCookie(res);
+
+      const set = cookies.find((c) => c.name === CSRF_COOKIE_NAME);
+      expect(set?.options.domain).toBe('.example.com');
+    });
+
+    it('should apply the Domain attribute when clearing the current auth cookies', () => {
+      const { res, clears } = createResponseSpy();
+
+      clearAuthCookies(res);
+
+      // Current-path clears carry the Domain; legacy /auth clears stay host-only.
+      const refreshCurrent = clears.find(
+        (c) => c.name === REFRESH_COOKIE_NAME && c.options.path?.startsWith('/v'),
+      );
+      const csrfCurrent = clears.find(
+        (c) => c.name === CSRF_COOKIE_NAME && c.options.path === '/',
+      );
+      expect(refreshCurrent?.options.domain).toBe('.example.com');
+      expect(csrfCurrent?.options.domain).toBe('.example.com');
+
+      const legacyClears = clears.filter((c) => c.options.path === '/auth');
+      expect(legacyClears.length).toBeGreaterThan(0);
+      for (const legacy of legacyClears) {
+        expect(legacy.options.domain).toBeUndefined();
+      }
+    });
+  });
+
+  describe('when OL_COOKIE_DOMAIN is unset', () => {
+    beforeEach(() => {
+      delete process.env.OL_COOKIE_DOMAIN;
+    });
+
+    it('should leave the refresh cookie host-only', () => {
+      const { res, cookies } = createResponseSpy();
+
+      setRefreshCookie(res, 'raw-refresh-token');
+
+      const set = cookies.find((c) => c.name === REFRESH_COOKIE_NAME);
+      expect(set?.options.domain).toBeUndefined();
+    });
+
+    it('should leave the CSRF cookie host-only', () => {
+      const { res, cookies } = createResponseSpy();
+
+      setCsrfCookie(res);
+
+      const set = cookies.find((c) => c.name === CSRF_COOKIE_NAME);
+      expect(set?.options.domain).toBeUndefined();
+    });
+
+    it('should leave every clear host-only', () => {
+      const { res, clears } = createResponseSpy();
+
+      clearAuthCookies(res);
+
+      for (const clear of clears) {
+        expect(clear.options.domain).toBeUndefined();
+      }
+    });
+  });
+
+  describe('OL_COOKIE_DOMAIN with surrounding whitespace', () => {
+    it('should trim the value before applying it', () => {
+      process.env.OL_COOKIE_DOMAIN = '  .example.com  ';
+      const { res, cookies } = createResponseSpy();
+
+      setCsrfCookie(res);
+
+      const set = cookies.find((c) => c.name === CSRF_COOKIE_NAME);
+      expect(set?.options.domain).toBe('.example.com');
+    });
+
+    it('should treat a whitespace-only value as unset', () => {
+      process.env.OL_COOKIE_DOMAIN = '   ';
+      const { res, cookies } = createResponseSpy();
+
+      setCsrfCookie(res);
+
+      const set = cookies.find((c) => c.name === CSRF_COOKIE_NAME);
+      expect(set?.options.domain).toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/auth/auth.cookies.ts
+++ b/apps/api/src/auth/auth.cookies.ts
@@ -56,6 +56,26 @@ function resolveSameSite(): 'strict' | 'lax' | 'none' {
   return isProd() ? 'strict' : 'lax';
 }
 
+// Read an explicit cookie Domain from env for split-subdomain deploys (SPA on
+// app.example.com, API on api.example.com). Without a Domain the cookies are
+// host-only, so the SPA host can't read the non-HttpOnly ol_csrf cookie set by
+// the API host via document.cookie — the X-CSRF-Token mirror comes up empty and
+// every silent /auth/refresh after a full-page navigation (e.g. the OAuth
+// bounce back from allegro.pl) is rejected, logging the user out. Setting
+// OL_COOKIE_DOMAIN=.example.com scopes both cookies to the shared parent domain
+// so the SPA subdomain can read ol_csrf. Unset ⇒ host-only (unchanged). See
+// #1725. A Domain-scoped cookie can only be cleared with the same Domain, so
+// this value MUST also be threaded through every clearCookie() below.
+function resolveCookieDomain(): string | undefined {
+  const raw = process.env.OL_COOKIE_DOMAIN?.trim();
+  return raw && raw.length > 0 ? raw : undefined;
+}
+
+function domainOption(): Pick<CookieOptions, 'domain'> | undefined {
+  const domain = resolveCookieDomain();
+  return domain ? { domain } : undefined;
+}
+
 function refreshCookieOptions(): CookieOptions {
   return {
     httpOnly: true,
@@ -63,6 +83,7 @@ function refreshCookieOptions(): CookieOptions {
     sameSite: resolveSameSite(),
     path: REFRESH_COOKIE_PATH,
     maxAge: REFRESH_TOKEN_TTL_SECONDS * 1000,
+    ...domainOption(),
   };
 }
 
@@ -74,6 +95,7 @@ function csrfCookieOptions(): CookieOptions {
     sameSite: resolveSameSite(),
     path: CSRF_COOKIE_PATH,
     maxAge: REFRESH_TOKEN_TTL_SECONDS * 1000,
+    ...domainOption(),
   };
 }
 
@@ -104,8 +126,12 @@ export function setCsrfCookie(res: Response): string {
 }
 
 export function clearAuthCookies(res: Response): void {
-  res.clearCookie(REFRESH_COOKIE_NAME, { path: REFRESH_COOKIE_PATH });
-  res.clearCookie(CSRF_COOKIE_NAME, { path: CSRF_COOKIE_PATH });
+  // Current cookies may carry a Domain (OL_COOKIE_DOMAIN); a Domain-scoped
+  // cookie only clears when the clear carries the same Domain. The legacy
+  // /auth clears below stay host-only — those copies predate #1725 and were
+  // never Domain-scoped.
+  res.clearCookie(REFRESH_COOKIE_NAME, { path: REFRESH_COOKIE_PATH, ...domainOption() });
+  res.clearCookie(CSRF_COOKIE_NAME, { path: CSRF_COOKIE_PATH, ...domainOption() });
   // Migration cleanup: ol_csrf was previously set at /auth (#748), ol_refresh
   // until #1327. Clear those copies too so stale cookies from the buggy
   // windows don't linger (csrf could even shadow the new /-scoped value).


### PR DESCRIPTION
## What & why

Fixes a logout bug on **split-subdomain deploys** (SPA on `app.example.com`, API on `api.example.com`). Any full-page navigation — most visibly the guided "Connect with Allegro" OAuth redirect — bounced the user to `/login`.

Root cause chain:
1. The access token is in-memory only (#710), so a full-page navigation destroys it and re-auth depends entirely on the silent `POST /v1/auth/refresh`.
2. `/v1/auth/refresh` is CSRF-protected: the SPA reads the non-HttpOnly `ol_csrf` cookie via `document.cookie` and mirrors it into `x-csrf-token`.
3. In `apps/api/src/auth/auth.cookies.ts` both `ol_refresh` and `ol_csrf` were set **host-only** (no `Domain`). So `ol_csrf` written by `api.*` is unreadable from `app.*`, the CSRF header is empty, `CsrfGuard` rejects the refresh, and the session goes anonymous.

`OL_COOKIE_SAMESITE` already existed; the missing piece was a `Domain` knob.

## Change

- **`auth.cookies.ts`** — new `resolveCookieDomain()` + `domainOption()` (mirrors `resolveSameSite()`). When `OL_COOKIE_DOMAIN` is set, its value is applied as the `Domain` attribute on both cookies on set **and** on the current-path clears in `clearAuthCookies` (a Domain-scoped cookie only clears with the same Domain). Legacy `/auth` clears stay host-only — those copies predate this change and were never Domain-scoped.
- **`auth.cookies.spec.ts`** — new unit spec: domain applied when set, absent when unset (host-only, unchanged), applied to both cookies + current clears but not legacy clears, value trimmed, whitespace-only treated as unset.
- **`apps/api/.env.example`** — documents `OL_COOKIE_DOMAIN` + `OL_COOKIE_SAMESITE` and the split-subdomain recipe.

**Backward-compatible:** with `OL_COOKIE_DOMAIN` unset, cookie shaping is byte-identical to before.

## Split-subdomain recipe

```
OL_COOKIE_DOMAIN=.example.com
OL_COOKIE_SAMESITE=none        # cross-origin XHR; requires Secure
NODE_ENV=production            # turns on Secure (needs real TLS)
OL_CORS_ORIGIN=https://app.example.com
```

## Out of scope

The FE callback route sitting under `AuthenticatedAppLayout` with a hard `/login` bounce and no return-to preservation is a separate follow-up. Fixing the cookie `Domain` restores silent refresh, which resolves the reported logout.

## Testing

- `apps/api` unit spec: 8/8 pass
- `pnpm --filter @openlinker/api type-check` — pass
- lint on changed files — pass

Closes #1725

🤖 Generated with [Claude Code](https://claude.com/claude-code)
