### PR TITLE
fix(web/connections): WooCommerce setup wizard with capability selection

### DIFF
--- a/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.test.tsx
@@ -117,6 +117,47 @@ describe('ConnectionCapabilitiesPanel', () => {
     expect(screen.queryByText(/no capabilities available to toggle/)).not.toBeInTheDocument();
   });
 
+  it('disables OfferManager with an explanation while InventoryMaster is enabled', () => {
+    const connection: Connection = {
+      ...sampleConnection,
+      supportedCapabilities: ['ProductMaster', 'InventoryMaster', 'OfferManager'],
+      enabledCapabilities: ['ProductMaster', 'InventoryMaster'],
+    };
+    renderWithProviders(<ConnectionCapabilitiesPanel connection={connection} />);
+
+    expect(screen.getByRole('checkbox', { name: /OfferManager/ })).toBeDisabled();
+    expect(
+      screen.getByText(/Unavailable while InventoryMaster is selected/),
+    ).toBeInTheDocument();
+    // The non-conflicting checkboxes stay operable.
+    expect(screen.getByRole('checkbox', { name: /ProductMaster/ })).toBeEnabled();
+  });
+
+  it('disables InventoryMaster with an explanation while OfferManager is enabled', () => {
+    const connection: Connection = {
+      ...sampleConnection,
+      supportedCapabilities: ['InventoryMaster', 'OfferManager'],
+      enabledCapabilities: ['OfferManager'],
+    };
+    renderWithProviders(<ConnectionCapabilitiesPanel connection={connection} />);
+
+    expect(screen.getByRole('checkbox', { name: /InventoryMaster/ })).toBeDisabled();
+    expect(screen.getByText(/Unavailable while OfferManager is selected/)).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /OfferManager/ })).toBeEnabled();
+  });
+
+  it('keeps both pair members enabled for unchecking when neither is enabled', () => {
+    const connection: Connection = {
+      ...sampleConnection,
+      supportedCapabilities: ['InventoryMaster', 'OfferManager'],
+      enabledCapabilities: [],
+    };
+    renderWithProviders(<ConnectionCapabilitiesPanel connection={connection} />);
+
+    expect(screen.getByRole('checkbox', { name: /InventoryMaster/ })).toBeEnabled();
+    expect(screen.getByRole('checkbox', { name: /OfferManager/ })).toBeEnabled();
+  });
+
   it('renders togglable checkboxes for ProductPublisher and CategoryProvisioner (shop-listing caps)', () => {
     const connection: Connection = {
       ...sampleConnection,

--- a/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.tsx
@@ -11,6 +11,11 @@ import { useState, type ReactElement } from 'react';
 import type { Connection, CoreCapability } from '../api/connections.types';
 import { CORE_CAPABILITY_VALUES } from '../api/connections.types';
 import { useUpdateConnectionMutation } from '../hooks/use-update-connection-mutation';
+import {
+  CAPABILITY_HELP,
+  capabilityConflictMessage,
+  getCapabilityConflict,
+} from '../lib/capability-metadata';
 import { Alert } from '../../../shared/ui/alert';
 import { StatusBadge } from '../../../shared/ui/status-badge';
 import { useToast } from '../../../shared/ui/toast-provider';
@@ -18,17 +23,6 @@ import { useToast } from '../../../shared/ui/toast-provider';
 interface ConnectionCapabilitiesPanelProps {
   connection: Connection;
 }
-
-const CAPABILITY_HELP: Record<CoreCapability, string> = {
-  ProductMaster: 'Read the product catalog (variants, attributes, categories) from this connection.',
-  InventoryMaster: 'Read stock levels from this connection as the inventory source of truth.',
-  OrderProcessorManager: 'Create and manage orders in this connection (typically the destination shop).',
-  OrderSource: 'Fetch new orders from this connection (e.g. a marketplace).',
-  OfferManager: 'Manage offers and listings on this marketplace connection.',
-  ProductPublisher: 'Publish and manage shop listings owned by this connection (cross-platform listing).',
-  CategoryProvisioner: 'Create or resolve destination categories when publishing listings to this connection.',
-  Invoicing: 'Issue and manage fiscal documents (invoices) through this connection.',
-};
 
 const CORE_CAPABILITY_SET = new Set<string>(CORE_CAPABILITY_VALUES);
 
@@ -128,6 +122,10 @@ export function ConnectionCapabilitiesPanel({
           {supported.map((capability) => {
             const id = `cap-${connection.id}-${capability}`;
             const isChecked = enabled.has(capability);
+            // Mutual-exclusion guard: the backend rejects the conflicting
+            // pair with a 400, so keep the invalid state unreachable here.
+            const conflict = getCapabilityConflict(enabled, capability);
+            const isBlocked = conflict !== null && !isChecked;
             return (
               <li key={capability} className="capability-list__item">
                 <label htmlFor={id} className="capability-list__label">
@@ -135,13 +133,15 @@ export function ConnectionCapabilitiesPanel({
                     id={id}
                     type="checkbox"
                     checked={isChecked}
-                    disabled={pending === capability || updateMutation.isPending}
+                    disabled={isBlocked || pending === capability || updateMutation.isPending}
                     onChange={(e) => void handleToggle(capability, e.target.checked)}
                   />
                   <span className="capability-list__name mono-text">{capability}</span>
                 </label>
                 <p className="capability-list__help muted-text">
-                  {CAPABILITY_HELP[capability]}
+                  {isBlocked && conflict
+                    ? capabilityConflictMessage(conflict)
+                    : CAPABILITY_HELP[capability]}
                 </p>
               </li>
             );

--- a/apps/web/src/features/connections/components/prestashop-setup-form.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.tsx
@@ -29,6 +29,7 @@ import {
 } from './prestashop-setup.schema';
 import { PrestashopSetupSummary } from './prestashop-setup-summary';
 import { CORE_CAPABILITY_VALUES, type CoreCapability } from '../api/connections.types';
+import { CAPABILITY_HELP } from '../lib/capability-metadata';
 import { useAdaptersQuery } from '../../adapters';
 import { Alert } from '../../../shared/ui/alert';
 import { BackLink } from '../../../shared/ui/back-link';
@@ -40,18 +41,6 @@ import { Select } from '../../../shared/ui/select';
 import { SetupStepper } from '../../../shared/ui/setup-stepper';
 import { WizardLayout } from '../../../shared/ui/wizard-layout';
 import { useToast } from '../../../shared/ui/toast-provider';
-
-const CAPABILITY_HELP: Record<CoreCapability, string> = {
-  ProductMaster: 'Read the product catalog (variants, attributes, categories) from this shop.',
-  InventoryMaster: 'Read stock levels from this shop as the inventory source of truth.',
-  OrderProcessorManager: 'Create and manage orders in this shop (typically the order destination).',
-  OrderSource:
-    'Fetch new orders from this shop (disable if orders come from a marketplace instead).',
-  OfferManager: 'Manage offers and listings on this marketplace.',
-  ProductPublisher: 'Publish and manage shop listings owned by this connection (cross-platform listing).',
-  CategoryProvisioner: 'Create or resolve destination categories when publishing listings to this connection.',
-  Invoicing: 'Issue and manage fiscal documents (invoices) through this connection.',
-};
 
 // "Verify credentials" rather than "Test connection": the PrestaShop `/test`
 // endpoint is only reachable after the connection is saved, so this step is a

--- a/apps/web/src/features/connections/components/prestashop-setup.schema.ts
+++ b/apps/web/src/features/connections/components/prestashop-setup.schema.ts
@@ -22,9 +22,8 @@ export const PRESTASHOP_ADAPTER_KEY = 'prestashop.webservice.v1';
  * an intentionally minimal default. The ADR-024 shop-listing capabilities
  * (`ProductPublisher`, `CategoryProvisioner`) still render as checkboxes once
  * real adapter metadata loads, but start unchecked here; the operator opts in
- * explicitly rather than the wizard reseeding from the manifest (contrast with
- * `WoocommerceSetupForm`, which reseeds `enabledCapabilities` from the
- * adapter's `supportedCapabilities` on load).
+ * explicitly rather than the wizard reseeding from the manifest. The
+ * WooCommerce wizard follows the same opt-in model since #1727.
  */
 export const PRESTASHOP_FALLBACK_CAPABILITIES: CoreCapability[] = [
   'ProductMaster',

--- a/apps/web/src/features/connections/components/woocommerce-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/woocommerce-setup-form.test.tsx
@@ -1,11 +1,14 @@
 /**
  * WoocommerceSetupForm Tests
  *
- * Coverage for the single-step WooCommerce setup wizard. Tests form validation,
- * capability seeding from adapter registry, and submission flow.
+ * Coverage for the 4-step WooCommerce setup wizard: per-step validation,
+ * capability selection with the InventoryMaster/OfferManager mutual-exclusion
+ * guard, review content, and submission payload shape.
  */
-import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useLocation } from 'react-router-dom';
 import {
   createMockApiClient,
   findToastTitle,
@@ -13,226 +16,298 @@ import {
 } from '../../../test/test-utils';
 import { WoocommerceSetupForm } from './woocommerce-setup-form';
 
+function LocationProbe(): ReactElement {
+  const location = useLocation();
+  return <div data-testid="location-pathname">{location.pathname}</div>;
+}
+
+function fillStoreDetailsStep(
+  container: HTMLElement,
+  values: { name: string; url: string },
+): void {
+  fireEvent.change(within(container).getByLabelText('Connection name'), {
+    target: { value: values.name },
+  });
+  fireEvent.change(within(container).getByLabelText('Site URL'), {
+    target: { value: values.url },
+  });
+}
+
+function fillCredentialsStep(
+  container: HTMLElement,
+  values: { key: string; secret: string },
+): void {
+  fireEvent.change(within(container).getByLabelText('Consumer key'), {
+    target: { value: values.key },
+  });
+  fireEvent.change(within(container).getByLabelText('Consumer secret'), {
+    target: { value: values.secret },
+  });
+}
+
+async function advanceOneStep(container: HTMLElement): Promise<void> {
+  const before = container.querySelector('[aria-current="step"]')?.textContent ?? '';
+  fireEvent.click(within(container).getByRole('button', { name: 'Next' }));
+  await waitFor(() => {
+    const after = container.querySelector('[aria-current="step"]')?.textContent ?? '';
+    if (after === before) throw new Error('Step did not advance');
+  });
+}
+
+async function advanceToReview(
+  container: HTMLElement,
+  values = {
+    name: 'My Store',
+    url: 'https://shop.example.com',
+    key: 'ck_test1234567890',
+    secret: 'cs_test1234567890',
+  },
+): Promise<void> {
+  fillStoreDetailsStep(container, { name: values.name, url: values.url });
+  await advanceOneStep(container);
+  fillCredentialsStep(container, { key: values.key, secret: values.secret });
+  await advanceOneStep(container);
+  await advanceOneStep(container); // capabilities → review
+}
+
 describe('WoocommerceSetupForm', () => {
   afterEach(cleanup);
 
-  it('renders all required form fields', () => {
-    renderWithProviders(<WoocommerceSetupForm />);
-    expect(screen.getByLabelText('Connection name')).toBeInTheDocument();
-    expect(screen.getByLabelText('Site URL')).toBeInTheDocument();
-    expect(screen.getByLabelText('Consumer key')).toBeInTheDocument();
-    expect(screen.getByLabelText('Consumer secret')).toBeInTheDocument();
+  it('renders the store-details step first with only its fields', () => {
+    const view = renderWithProviders(<WoocommerceSetupForm />);
+    expect(within(view.container).getByLabelText('Connection name')).toBeInTheDocument();
+    expect(within(view.container).getByLabelText('Site URL')).toBeInTheDocument();
+    expect(within(view.container).queryByLabelText('Consumer key')).toBeNull();
+    expect(within(view.container).queryByLabelText('Consumer secret')).toBeNull();
   });
 
-  it('requires connection name to be non-empty', async () => {
-    renderWithProviders(<WoocommerceSetupForm />);
-    const submitButton = screen.getByRole('button', { name: 'Connect WooCommerce' });
+  it('blocks advancing when the connection name is empty', async () => {
+    const view = renderWithProviders(<WoocommerceSetupForm />);
+    fillStoreDetailsStep(view.container, { name: '', url: 'https://shop.example.com' });
 
-    fireEvent.click(submitButton);
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Next' }));
 
-    await waitFor(() => {
-      expect(screen.getAllByText('Connection name is required')[0]).toBeInTheDocument();
-    });
+    expect((await screen.findAllByText('Connection name is required')).length).toBeGreaterThan(0);
+    expect(within(view.container).queryByLabelText('Consumer key')).toBeNull();
   });
 
-  it('requires site URL to be HTTPS', async () => {
-    renderWithProviders(<WoocommerceSetupForm />);
+  it('blocks advancing when the site URL is not HTTPS', async () => {
+    const view = renderWithProviders(<WoocommerceSetupForm />);
+    fillStoreDetailsStep(view.container, { name: 'My Store', url: 'http://example.com' });
 
-    fireEvent.change(screen.getByLabelText('Connection name'), {
-      target: { value: 'My Store' },
-    });
-    fireEvent.change(screen.getByLabelText('Site URL'), {
-      target: { value: 'http://example.com' }, // HTTP, not HTTPS
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Connect WooCommerce' }));
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Next' }));
 
-    await waitFor(() => {
-      expect(screen.getAllByText('Site URL must use HTTPS')[0]).toBeInTheDocument();
-    });
+    expect((await screen.findAllByText('Site URL must use HTTPS')).length).toBeGreaterThan(0);
+    expect(within(view.container).queryByLabelText('Consumer key')).toBeNull();
   });
 
-  it('rejects plain-http localhost URLs (BE enforces https-only)', async () => {
-    renderWithProviders(<WoocommerceSetupForm />);
+  it('blocks advancing when the consumer key does not start with ck_', async () => {
+    const view = renderWithProviders(<WoocommerceSetupForm />);
+    fillStoreDetailsStep(view.container, { name: 'My Store', url: 'https://shop.example.com' });
+    await advanceOneStep(view.container);
 
-    fireEvent.change(screen.getByLabelText('Connection name'), {
-      target: { value: 'Local Store' },
-    });
-    fireEvent.change(screen.getByLabelText('Site URL'), {
-      target: { value: 'http://localhost:8080' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Connect WooCommerce' }));
+    fillCredentialsStep(view.container, { key: 'invalid_key', secret: 'cs_test1234567890' });
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Next' }));
 
-    await waitFor(() => {
-      expect(screen.getAllByText('Site URL must use HTTPS')[0]).toBeInTheDocument();
-    });
+    expect((await screen.findAllByText('Consumer key must start with ck_')).length).toBeGreaterThan(
+      0,
+    );
   });
 
-  it('accepts https localhost URLs for local development', async () => {
-    const createConnection = vi.fn().mockResolvedValue({
-      id: 'conn-1',
-      name: 'Local Store',
-    });
-    const apiClient = createMockApiClient({
-      connections: { create: createConnection },
-    });
+  it('blocks advancing when the consumer secret does not start with cs_', async () => {
+    const view = renderWithProviders(<WoocommerceSetupForm />);
+    fillStoreDetailsStep(view.container, { name: 'My Store', url: 'https://shop.example.com' });
+    await advanceOneStep(view.container);
 
-    renderWithProviders(<WoocommerceSetupForm />, { apiClient });
+    fillCredentialsStep(view.container, { key: 'ck_test1234567890', secret: 'invalid_secret' });
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Next' }));
 
-    fireEvent.change(screen.getByLabelText('Connection name'), {
-      target: { value: 'Local Store' },
-    });
-    fireEvent.change(screen.getByLabelText('Site URL'), {
-      target: { value: 'https://localhost:8443' },
-    });
-    fireEvent.change(screen.getByLabelText('Consumer key'), {
-      target: { value: 'ck_test1234567890' },
-    });
-    fireEvent.change(screen.getByLabelText('Consumer secret'), {
-      target: { value: 'cs_test1234567890' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Connect WooCommerce' }));
-
-    await waitFor(() => {
-      expect(createConnection).toHaveBeenCalled();
-    });
+    expect(
+      (await screen.findAllByText('Consumer secret must start with cs_')).length,
+    ).toBeGreaterThan(0);
   });
 
-  it('requires consumer key to start with ck_', async () => {
-    renderWithProviders(<WoocommerceSetupForm />);
+  it('pre-selects the shop-master capability defaults on the capabilities step', async () => {
+    const view = renderWithProviders(<WoocommerceSetupForm />);
+    fillStoreDetailsStep(view.container, { name: 'My Store', url: 'https://shop.example.com' });
+    await advanceOneStep(view.container);
+    fillCredentialsStep(view.container, { key: 'ck_test1234567890', secret: 'cs_test1234567890' });
+    await advanceOneStep(view.container);
 
-    fireEvent.change(screen.getByLabelText('Connection name'), {
-      target: { value: 'My Store' },
-    });
-    fireEvent.change(screen.getByLabelText('Site URL'), {
-      target: { value: 'https://shop.example.com' },
-    });
-    fireEvent.change(screen.getByLabelText('Consumer key'), {
-      target: { value: 'invalid_key' }, // Should start with ck_
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Connect WooCommerce' }));
-
-    await waitFor(() => {
-      expect(
-        screen.getAllByText('Consumer key must start with ck_')[0]
-      ).toBeInTheDocument();
-    });
+    expect(within(view.container).getByRole('checkbox', { name: /ProductMaster/ })).toBeChecked();
+    expect(within(view.container).getByRole('checkbox', { name: /InventoryMaster/ })).toBeChecked();
+    expect(
+      within(view.container).getByRole('checkbox', { name: /OrderProcessorManager/ }),
+    ).toBeChecked();
+    expect(within(view.container).getByRole('checkbox', { name: /OrderSource/ })).toBeChecked();
   });
 
-  it('requires consumer secret to start with cs_', async () => {
-    renderWithProviders(<WoocommerceSetupForm />);
+  it('disables OfferManager while InventoryMaster is selected and re-enables it after deselection', async () => {
+    const adapters = vi.fn().mockResolvedValue([
+      {
+        adapterKey: 'woocommerce.restapi.v3',
+        platformType: 'woocommerce',
+        supportedCapabilities: [
+          'ProductMaster',
+          'InventoryMaster',
+          'OrderProcessorManager',
+          'OrderSource',
+          'ProductPublisher',
+          'CategoryProvisioner',
+          'OfferManager',
+        ],
+      },
+    ]);
+    const apiClient = createMockApiClient({ adapters: { list: adapters } });
+    const view = renderWithProviders(<WoocommerceSetupForm />, { apiClient });
 
-    fireEvent.change(screen.getByLabelText('Connection name'), {
-      target: { value: 'My Store' },
-    });
-    fireEvent.change(screen.getByLabelText('Site URL'), {
-      target: { value: 'https://shop.example.com' },
-    });
-    fireEvent.change(screen.getByLabelText('Consumer key'), {
-      target: { value: 'ck_test1234567890' },
-    });
-    fireEvent.change(screen.getByLabelText('Consumer secret'), {
-      target: { value: 'invalid_secret' }, // Should start with cs_
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Connect WooCommerce' }));
+    fillStoreDetailsStep(view.container, { name: 'My Store', url: 'https://shop.example.com' });
+    await advanceOneStep(view.container);
+    fillCredentialsStep(view.container, { key: 'ck_test1234567890', secret: 'cs_test1234567890' });
+    await advanceOneStep(view.container);
 
+    const offerManager = await within(view.container).findByRole('checkbox', {
+      name: /OfferManager/,
+    });
+    expect(offerManager).toBeDisabled();
+    expect(
+      within(view.container).getByText(/Unavailable while InventoryMaster is selected/),
+    ).toBeInTheDocument();
+
+    // Deselect InventoryMaster → OfferManager unlocks.
+    fireEvent.click(within(view.container).getByRole('checkbox', { name: /InventoryMaster/ }));
     await waitFor(() => {
       expect(
-        screen.getAllByText('Consumer secret must start with cs_')[0]
-      ).toBeInTheDocument();
-    });
-  });
-
-  it('submits valid form and shows success toast', async () => {
-    const createConnection = vi.fn().mockResolvedValue({
-      id: 'conn-1',
-      name: 'My Store',
-    });
-    const apiClient = createMockApiClient({
-      connections: { create: createConnection },
+        within(view.container).getByRole('checkbox', { name: /OfferManager/ }),
+      ).toBeEnabled();
     });
 
-    renderWithProviders(<WoocommerceSetupForm />, { apiClient });
-
-    fireEvent.change(screen.getByLabelText('Connection name'), {
-      target: { value: 'My Store' },
-    });
-    fireEvent.change(screen.getByLabelText('Site URL'), {
-      target: { value: 'https://shop.example.com' },
-    });
-    fireEvent.change(screen.getByLabelText('Consumer key'), {
-      target: { value: 'ck_test1234567890' },
-    });
-    fireEvent.change(screen.getByLabelText('Consumer secret'), {
-      target: { value: 'cs_test1234567890' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Connect WooCommerce' }));
-
+    // Select OfferManager → InventoryMaster locks in the other direction.
+    fireEvent.click(within(view.container).getByRole('checkbox', { name: /OfferManager/ }));
     await waitFor(() => {
-      expect(createConnection).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'My Store',
-          platformType: 'woocommerce',
-          adapterKey: expect.any(String),
-          config: expect.objectContaining({
-            siteUrl: 'https://shop.example.com',
-          }),
-          credentials: expect.objectContaining({
-            consumerKey: 'ck_test1234567890',
-            consumerSecret: 'cs_test1234567890',
-          }),
-          enabledCapabilities: expect.any(Array),
-        })
-      );
+      expect(
+        within(view.container).getByRole('checkbox', { name: /InventoryMaster/ }),
+      ).toBeDisabled();
     });
     expect(
-      await findToastTitle('Connection created')
+      within(view.container).getByText(/Unavailable while OfferManager is selected/),
     ).toBeInTheDocument();
   });
 
-  it('disables submit button during mutation', async () => {
-    const createConnection = vi.fn().mockImplementation(
-      () => new Promise(resolve => setTimeout(() => resolve({
-        id: 'conn-1',
-        name: 'My Store',
-      }), 100))
+  it('shows the review summary with a masked consumer key and selected capabilities', async () => {
+    const view = renderWithProviders(<WoocommerceSetupForm />);
+    await advanceToReview(view.container);
+
+    expect(within(view.container).getByText('My Store')).toBeInTheDocument();
+    expect(within(view.container).getByText('https://shop.example.com')).toBeInTheDocument();
+    // Masked: only the last 4 chars visible.
+    expect(within(view.container).getByText(/•+7890$/)).toBeInTheDocument();
+    expect(within(view.container).queryByText('ck_test1234567890')).toBeNull();
+    expect(
+      within(view.container).getByText(
+        'ProductMaster, InventoryMaster, OrderProcessorManager, OrderSource',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('submits exactly the user-selected capabilities and shows a success toast', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Store' });
+    const apiClient = createMockApiClient({ connections: { create } });
+    const view = renderWithProviders(
+      <>
+        <WoocommerceSetupForm />
+        <LocationProbe />
+      </>,
+      { apiClient },
     );
-    const apiClient = createMockApiClient({
-      connections: { create: createConnection },
-    });
 
-    renderWithProviders(<WoocommerceSetupForm />, { apiClient });
+    fillStoreDetailsStep(view.container, { name: 'My Store', url: 'https://shop.example.com' });
+    await advanceOneStep(view.container);
+    fillCredentialsStep(view.container, { key: 'ck_test1234567890', secret: 'cs_test1234567890' });
+    await advanceOneStep(view.container);
 
-    fireEvent.change(screen.getByLabelText('Connection name'), {
-      target: { value: 'My Store' },
-    });
-    fireEvent.change(screen.getByLabelText('Site URL'), {
-      target: { value: 'https://shop.example.com' },
-    });
-    fireEvent.change(screen.getByLabelText('Consumer key'), {
-      target: { value: 'ck_test1234567890' },
-    });
-    fireEvent.change(screen.getByLabelText('Consumer secret'), {
-      target: { value: 'cs_test1234567890' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Connect WooCommerce' }));
+    fireEvent.click(within(view.container).getByRole('checkbox', { name: /OrderSource/ }));
+    await advanceOneStep(view.container);
+
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
 
     await waitFor(() => {
-      const button = screen.getByRole('button', { name: /Connecting|Connect WooCommerce/ });
+      expect(create).toHaveBeenCalledWith({
+        name: 'My Store',
+        platformType: 'woocommerce',
+        adapterKey: 'woocommerce.restapi.v3',
+        credentials: {
+          consumerKey: 'ck_test1234567890',
+          consumerSecret: 'cs_test1234567890',
+        },
+        config: { siteUrl: 'https://shop.example.com' },
+        enabledCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderProcessorManager'],
+      });
+    });
+    expect(await findToastTitle('Connection created')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('location-pathname')).toHaveTextContent('/connections');
+    });
+  });
+
+  it('never submits both InventoryMaster and OfferManager together', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'conn-1', name: 'My Store' });
+    const apiClient = createMockApiClient({ connections: { create } });
+    const view = renderWithProviders(<WoocommerceSetupForm />, { apiClient });
+    await advanceToReview(view.container);
+
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalled();
+    });
+    const payload = create.mock.calls[0]?.[0] as { enabledCapabilities: string[] };
+    const hasBoth =
+      payload.enabledCapabilities.includes('InventoryMaster') &&
+      payload.enabledCapabilities.includes('OfferManager');
+    expect(hasBoth).toBe(false);
+  });
+
+  it('surfaces API errors in a form-level alert on the review step', async () => {
+    const apiClient = createMockApiClient({
+      connections: { create: vi.fn().mockRejectedValue(new Error('API create failed')) },
+    });
+    const view = renderWithProviders(<WoocommerceSetupForm />, { apiClient });
+    await advanceToReview(view.container);
+
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
+
+    expect(await screen.findByText('Unable to create connection')).toBeInTheDocument();
+    expect(screen.getByText('API create failed')).toBeInTheDocument();
+  });
+
+  it('disables the submit button during the mutation', async () => {
+    const create = vi
+      .fn()
+      .mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ id: 'conn-1', name: 'My Store' }), 100),
+          ),
+      );
+    const apiClient = createMockApiClient({ connections: { create } });
+    const view = renderWithProviders(<WoocommerceSetupForm />, { apiClient });
+    await advanceToReview(view.container);
+
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
+
+    await waitFor(() => {
+      const button = within(view.container).getByRole('button', {
+        name: /Creating|Create connection/,
+      });
       expect(button).toBeDisabled();
     });
   });
 
-  it('shows validation errors only after first submit attempt', async () => {
-    renderWithProviders(<WoocommerceSetupForm />);
-
-    // Initially no error summary
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-
-    // After submit attempt
-    fireEvent.click(screen.getByRole('button', { name: 'Connect WooCommerce' }));
-
-    await waitFor(() => {
-      expect(screen.getAllByText('Connection name is required')[0]).toBeInTheDocument();
-    });
+  it('renders the back-to-connections link inside the wizard card', () => {
+    const view = renderWithProviders(<WoocommerceSetupForm />);
+    const backLink = within(view.container).getByRole('link', { name: 'Connections' });
+    expect(backLink).toHaveAttribute('href', '/connections/new');
+    expect(backLink).toHaveClass('back-link', 'wizard-card__back');
   });
 });

--- a/apps/web/src/features/connections/components/woocommerce-setup-form.tsx
+++ b/apps/web/src/features/connections/components/woocommerce-setup-form.tsx
@@ -1,24 +1,30 @@
 /**
  * WooCommerce Setup Form
  *
- * Single-step wizard for creating a WooCommerce connection. Collects:
- *   - Connection name
- *   - Site URL (HTTPS)
- *   - Consumer key (ck_...)
- *   - Consumer secret (cs_...)
+ * Multi-step wizard for creating a WooCommerce connection. Steps:
+ *   1. Store details — connection name, site URL (HTTPS)
+ *   2. API credentials — consumer key (ck_...), consumer secret (cs_...)
+ *   3. Capabilities — which roles this connection will fulfil, with the
+ *      InventoryMaster/OfferManager mutual exclusivity enforced via a
+ *      disable-guard (the backend rejects the pair with a 400)
+ *   4. Review & create — final summary before submit
  *
- * Simpler than the PrestaShop 4-step wizard — no stepper, no capabilities
- * step (capabilities are seeded silently from the adapter registry, falling
- * back to the manifest's full set). Abandon-prevention triggers a native
- * confirm dialog when the form is dirty and the tab is closed.
+ * Per-step validation runs on Next so the operator cannot advance with
+ * invalid fields. Abandon-prevention triggers a native confirm dialog
+ * when the form is dirty and the tab is closed.
  */
-import { useEffect, type ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm } from 'react-hook-form';
+import { useForm, type Path } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { useAdaptersQuery } from '../../adapters';
 import { useCreateConnectionMutation } from '../hooks/use-create-connection-mutation';
 import { CORE_CAPABILITY_VALUES, type CoreCapability } from '../api/connections.types';
+import {
+  CAPABILITY_HELP,
+  capabilityConflictMessage,
+  getCapabilityConflict,
+} from '../lib/capability-metadata';
 import {
   WOOCOMMERCE_ADAPTER_KEY,
   WOOCOMMERCE_FALLBACK_CAPABILITIES,
@@ -34,7 +40,28 @@ import { Button } from '../../../shared/ui/button';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
+import { SetupStepper } from '../../../shared/ui/setup-stepper';
+import { WizardLayout } from '../../../shared/ui/wizard-layout';
 import { useToast } from '../../../shared/ui/toast-provider';
+
+const STEP_LABELS = [
+  'Store details',
+  'API credentials',
+  'Capabilities',
+  'Review & create',
+] as const;
+
+const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<WoocommerceSetupFormValues>>> = [
+  ['name', 'siteUrl'],
+  ['consumerKey', 'consumerSecret'],
+  ['enabledCapabilities'],
+  [],
+];
+
+function maskKey(key: string): string {
+  if (key.length <= 4) return '•'.repeat(key.length);
+  return `${'•'.repeat(Math.max(0, key.length - 4))}${key.slice(-4)}`;
+}
 
 export function WoocommerceSetupForm(): ReactElement {
   const createConnection = useCreateConnectionMutation();
@@ -48,16 +75,8 @@ export function WoocommerceSetupForm(): ReactElement {
     mode: 'onBlur',
   });
 
-  // Seed enabledCapabilities from the adapter registry once loaded.
-  useEffect(() => {
-    const adapter = adaptersQuery.data?.find((a) => a.adapterKey === WOOCOMMERCE_ADAPTER_KEY);
-    const capabilities: CoreCapability[] = (
-      adapter?.supportedCapabilities ?? WOOCOMMERCE_FALLBACK_CAPABILITIES
-    ).filter((cap): cap is CoreCapability =>
-      (CORE_CAPABILITY_VALUES as readonly string[]).includes(cap),
-    );
-    form.setValue('enabledCapabilities', capabilities);
-  }, [adaptersQuery.data, form]);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [completedSteps, setCompletedSteps] = useState<ReadonlySet<number>>(new Set());
 
   // Abandon-prevention.
   useEffect(() => {
@@ -70,9 +89,33 @@ export function WoocommerceSetupForm(): ReactElement {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [form.formState.isDirty]);
 
+  const adapterMetadata = adaptersQuery.data?.find((a) => a.adapterKey === WOOCOMMERCE_ADAPTER_KEY);
+  // The checkbox list is gated on the well-known core capabilities: the
+  // create-connection request DTO is still strict on `CoreCapabilityValues`
+  // (#576), so the wizard only exposes core caps today.
+  const supportedCapabilities: CoreCapability[] = (
+    adapterMetadata?.supportedCapabilities ?? WOOCOMMERCE_FALLBACK_CAPABILITIES
+  ).filter((capability): capability is CoreCapability =>
+    (CORE_CAPABILITY_VALUES as readonly string[]).includes(capability),
+  );
+
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
     error?.message ? [String(error.message)] : [],
   );
+
+  async function goNext(): Promise<void> {
+    const fields = STEP_FIELDS[stepIndex];
+    if (fields.length > 0) {
+      const valid = await form.trigger([...fields]);
+      if (!valid) return;
+    }
+    setCompletedSteps((prev) => new Set(prev).add(stepIndex));
+    setStepIndex((i) => Math.min(i + 1, STEP_LABELS.length - 1));
+  }
+
+  function goBack(): void {
+    setStepIndex((i) => Math.max(i - 1, 0));
+  }
 
   const onSubmit = form.handleSubmit(async (values) => {
     try {
@@ -89,88 +132,175 @@ export function WoocommerceSetupForm(): ReactElement {
     }
   });
 
+  const values = form.watch();
+  const selectedCapabilities = values.enabledCapabilities ?? [];
+
   return (
-    <form className="wizard-card" onSubmit={(event) => void onSubmit(event)} noValidate>
-      <BackLink to="/connections/new" label="Connections" className="wizard-card__back" />
+    <WizardLayout
+      stepper={
+        <SetupStepper steps={STEP_LABELS} currentStep={stepIndex} completedSteps={completedSteps} />
+      }
+    >
+      <form className="wizard-card" onSubmit={(event) => void onSubmit(event)} noValidate>
+        <BackLink to="/connections/new" label="Connections" className="wizard-card__back" />
 
-      {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
-        <FormErrorSummary errors={validationMessages} />
-      ) : null}
-      {createConnection.error ? (
-        <Alert tone="error" title="Unable to create connection">
-          {createConnection.error.message}
-        </Alert>
-      ) : null}
+        {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
+          <FormErrorSummary errors={validationMessages} />
+        ) : null}
+        {createConnection.error ? (
+          <Alert tone="error" title="Unable to create connection">
+            {createConnection.error.message}
+          </Alert>
+        ) : null}
 
-      <Alert tone="info" title="Before you start">
-        In your WooCommerce admin, go to <strong>WooCommerce → Settings → Advanced → REST API</strong>{' '}
-        and generate a key with <strong>Read/Write</strong> permissions. Copy the consumer key and
-        consumer secret below — they are only shown once.
-      </Alert>
+        {stepIndex === 0 ? (
+          <>
+            <FormField
+              label="Connection name"
+              name="name"
+              error={form.formState.errors.name?.message}
+              description="A label to identify this store in OpenLinker."
+            >
+              <Input
+                {...form.register('name')}
+                placeholder="My WooCommerce Store"
+                autoComplete="off"
+                invalid={Boolean(form.formState.errors.name)}
+              />
+            </FormField>
 
-      <FormField
-        label="Connection name"
-        name="name"
-        error={form.formState.errors.name?.message}
-        description="A label to identify this store in OpenLinker."
-      >
-        <Input
-          {...form.register('name')}
-          placeholder="My WooCommerce Store"
-          autoComplete="off"
-          invalid={Boolean(form.formState.errors.name)}
-        />
-      </FormField>
+            <FormField
+              label="Site URL"
+              name="siteUrl"
+              error={form.formState.errors.siteUrl?.message}
+              description="The root URL of your WooCommerce store. Must use HTTPS."
+            >
+              <Input
+                {...form.register('siteUrl')}
+                className="mono-text"
+                placeholder="https://shop.example.com"
+                autoComplete="off"
+                invalid={Boolean(form.formState.errors.siteUrl)}
+              />
+            </FormField>
+          </>
+        ) : null}
 
-      <FormField
-        label="Site URL"
-        name="siteUrl"
-        error={form.formState.errors.siteUrl?.message}
-        description="The root URL of your WooCommerce store. Must use HTTPS."
-      >
-        <Input
-          {...form.register('siteUrl')}
-          placeholder="https://shop.example.com"
-          autoComplete="off"
-          invalid={Boolean(form.formState.errors.siteUrl)}
-        />
-      </FormField>
+        {stepIndex === 1 ? (
+          <>
+            <Alert tone="info" title="Before you start">
+              In your WooCommerce admin, go to{' '}
+              <strong>WooCommerce → Settings → Advanced → REST API</strong> and generate a key with{' '}
+              <strong>Read/Write</strong> permissions. Copy the consumer key and consumer secret
+              below — they are only shown once.
+            </Alert>
 
-      <FormField
-        label="Consumer key"
-        name="consumerKey"
-        error={form.formState.errors.consumerKey?.message}
-        description="Starts with ck_ — generated in WooCommerce REST API settings."
-      >
-        <Input
-          {...form.register('consumerKey')}
-          type="password"
-          placeholder="ck_••••••••••••••••••••••••••••••••••••••••"
-          autoComplete="off"
-          invalid={Boolean(form.formState.errors.consumerKey)}
-        />
-      </FormField>
+            <FormField
+              label="Consumer key"
+              name="consumerKey"
+              error={form.formState.errors.consumerKey?.message}
+              description="Starts with ck_ — generated in WooCommerce REST API settings."
+            >
+              <Input
+                {...form.register('consumerKey')}
+                className="mono-text"
+                type="password"
+                placeholder="ck_••••••••••••••••••••••••••••••••••••••••"
+                autoComplete="off"
+                invalid={Boolean(form.formState.errors.consumerKey)}
+              />
+            </FormField>
 
-      <FormField
-        label="Consumer secret"
-        name="consumerSecret"
-        error={form.formState.errors.consumerSecret?.message}
-        description="Starts with cs_ — generated alongside the consumer key."
-      >
-        <Input
-          {...form.register('consumerSecret')}
-          type="password"
-          placeholder="cs_••••••••••••••••••••••••••••••••••••••••"
-          autoComplete="off"
-          invalid={Boolean(form.formState.errors.consumerSecret)}
-        />
-      </FormField>
+            <FormField
+              label="Consumer secret"
+              name="consumerSecret"
+              error={form.formState.errors.consumerSecret?.message}
+              description="Starts with cs_ — generated alongside the consumer key."
+            >
+              <Input
+                {...form.register('consumerSecret')}
+                className="mono-text"
+                type="password"
+                placeholder="cs_••••••••••••••••••••••••••••••••••••••••"
+                autoComplete="off"
+                invalid={Boolean(form.formState.errors.consumerSecret)}
+              />
+            </FormField>
+          </>
+        ) : null}
 
-      <div className="form-actions">
-        <Button type="submit" disabled={createConnection.isPending}>
-          {createConnection.isPending ? 'Connecting…' : 'Connect WooCommerce'}
-        </Button>
-      </div>
-    </form>
+        {stepIndex === 2 ? (
+          <fieldset className="capability-fieldset">
+            <legend className="capability-fieldset__legend">Capabilities</legend>
+            <p className="muted-text capability-fieldset__help">
+              Pick which roles this connection should fulfil. You can change this later on the
+              connection&rsquo;s detail page.
+            </p>
+            <ul className="capability-list">
+              {supportedCapabilities.map((capability) => {
+                const id = `new-cap-${capability}`;
+                const conflict = getCapabilityConflict(selectedCapabilities, capability);
+                const isBlocked = conflict !== null && !selectedCapabilities.includes(capability);
+                return (
+                  <li key={capability} className="capability-list__item">
+                    <label htmlFor={id} className="capability-list__label">
+                      <input
+                        id={id}
+                        type="checkbox"
+                        value={capability}
+                        disabled={isBlocked}
+                        {...form.register('enabledCapabilities')}
+                      />
+                      <span className="capability-list__name mono-text">{capability}</span>
+                    </label>
+                    <p className="capability-list__help muted-text">
+                      {isBlocked && conflict
+                        ? capabilityConflictMessage(conflict)
+                        : CAPABILITY_HELP[capability]}
+                    </p>
+                  </li>
+                );
+              })}
+            </ul>
+          </fieldset>
+        ) : null}
+
+        {stepIndex === 3 ? (
+          <dl className="wizard-review-list">
+            <dt>Name</dt>
+            <dd>{values.name || '—'}</dd>
+            <dt>Site URL</dt>
+            <dd className="mono-text">{values.siteUrl || '—'}</dd>
+            <dt>Consumer key</dt>
+            <dd className="mono-text">{values.consumerKey ? maskKey(values.consumerKey) : '—'}</dd>
+            <dt>Capabilities</dt>
+            <dd>
+              {selectedCapabilities.length > 0 ? selectedCapabilities.join(', ') : 'None selected'}
+            </dd>
+          </dl>
+        ) : null}
+
+        <div className="wizard-actions">
+          <div className="wizard-actions__group">
+            {stepIndex > 0 ? (
+              <Button tone="secondary" type="button" onClick={goBack}>
+                Back
+              </Button>
+            ) : null}
+          </div>
+          <div className="wizard-actions__group">
+            {stepIndex < STEP_LABELS.length - 1 ? (
+              <Button type="button" onClick={() => void goNext()}>
+                Next
+              </Button>
+            ) : (
+              <Button type="submit" disabled={createConnection.isPending}>
+                {createConnection.isPending ? 'Creating...' : 'Create connection'}
+              </Button>
+            )}
+          </div>
+        </div>
+      </form>
+    </WizardLayout>
   );
 }

--- a/apps/web/src/features/connections/components/woocommerce-setup.schema.ts
+++ b/apps/web/src/features/connections/components/woocommerce-setup.schema.ts
@@ -11,6 +11,7 @@
  */
 import { z } from 'zod';
 import { CORE_CAPABILITY_VALUES, type CoreCapability, type CreateConnectionInput } from '../api/connections.types';
+import { hasCapabilityConflict } from '../lib/capability-metadata';
 
 export const WOOCOMMERCE_ADAPTER_KEY = 'woocommerce.restapi.v3';
 
@@ -53,7 +54,13 @@ export const woocommerceSetupSchema = z.object({
     .refine((v) => v.startsWith('cs_'), 'Consumer secret must start with cs_'),
   enabledCapabilities: z
     .array(z.enum(CORE_CAPABILITY_VALUES))
-    .default(WOOCOMMERCE_FALLBACK_CAPABILITIES),
+    .default(WOOCOMMERCE_FALLBACK_CAPABILITIES)
+    // Backstop for the UI disable-guard: the backend rejects this pair with a
+    // 400, so the payload must never carry both.
+    .refine(
+      (capabilities) => !hasCapabilityConflict(capabilities),
+      'InventoryMaster and OfferManager cannot both be enabled on the same connection.',
+    ),
 });
 
 export type WoocommerceSetupFormValues = z.input<typeof woocommerceSetupSchema>;

--- a/apps/web/src/features/connections/lib/capability-metadata.test.ts
+++ b/apps/web/src/features/connections/lib/capability-metadata.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Capability Metadata Tests
+ *
+ * Unit coverage for the shared capability exclusivity helpers consumed by the
+ * setup wizards and the ConnectionCapabilitiesPanel.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  capabilityConflictMessage,
+  getCapabilityConflict,
+  hasCapabilityConflict,
+} from './capability-metadata';
+
+describe('getCapabilityConflict', () => {
+  it('should report InventoryMaster as the blocker for OfferManager when selected', () => {
+    expect(getCapabilityConflict(['InventoryMaster'], 'OfferManager')).toBe('InventoryMaster');
+  });
+
+  it('should report OfferManager as the blocker for InventoryMaster when selected', () => {
+    expect(getCapabilityConflict(new Set(['OfferManager']), 'InventoryMaster')).toBe(
+      'OfferManager',
+    );
+  });
+
+  it('should return null when the counterpart is not selected', () => {
+    expect(getCapabilityConflict(['ProductMaster', 'OrderSource'], 'OfferManager')).toBeNull();
+  });
+
+  it('should return null for capabilities outside any exclusivity pair', () => {
+    expect(getCapabilityConflict(['InventoryMaster', 'OfferManager'], 'ProductMaster')).toBeNull();
+  });
+});
+
+describe('hasCapabilityConflict', () => {
+  it('should detect the InventoryMaster/OfferManager pair', () => {
+    expect(hasCapabilityConflict(['ProductMaster', 'InventoryMaster', 'OfferManager'])).toBe(true);
+  });
+
+  it('should pass a set containing only one side of the pair', () => {
+    expect(hasCapabilityConflict(['InventoryMaster', 'OrderSource'])).toBe(false);
+    expect(hasCapabilityConflict(['OfferManager', 'ProductPublisher'])).toBe(false);
+  });
+
+  it('should pass an empty set', () => {
+    expect(hasCapabilityConflict([])).toBe(false);
+  });
+});
+
+describe('capabilityConflictMessage', () => {
+  it('should name the conflicting capability', () => {
+    expect(capabilityConflictMessage('InventoryMaster')).toContain(
+      'Unavailable while InventoryMaster is selected',
+    );
+  });
+});

--- a/apps/web/src/features/connections/lib/capability-metadata.ts
+++ b/apps/web/src/features/connections/lib/capability-metadata.ts
@@ -1,0 +1,69 @@
+/**
+ * Capability Metadata
+ *
+ * Single source of the operator-facing capability help copy and the
+ * capability mutual-exclusivity rules shared by the connection setup wizards
+ * (PrestaShop, WooCommerce) and the edit-time ConnectionCapabilitiesPanel.
+ *
+ * The exclusivity rule is expressed in capability terms only - a stock source
+ * of truth (InventoryMaster) must never also be a stock write-back target
+ * (OfferManager) on the same connection - so no platformType dispatch is
+ * needed; the backend enforces the same rule authoritatively on create/update.
+ *
+ * @module features/connections/lib
+ */
+import type { CoreCapability } from '../api/connections.types';
+
+export const CAPABILITY_HELP: Record<CoreCapability, string> = {
+  ProductMaster:
+    'Read the product catalog (variants, attributes, categories) from this connection.',
+  InventoryMaster: 'Read stock levels from this connection as the inventory source of truth.',
+  OrderProcessorManager:
+    'Create and manage orders in this connection (typically the destination shop).',
+  OrderSource:
+    'Fetch new orders from this connection (disable if orders come from a marketplace instead).',
+  OfferManager: 'Manage offers and listings on this marketplace connection.',
+  ProductPublisher:
+    'Publish and manage shop listings owned by this connection (cross-platform listing).',
+  CategoryProvisioner:
+    'Create or resolve destination categories when publishing listings to this connection.',
+  Invoicing: 'Issue and manage fiscal documents (invoices) through this connection.',
+};
+
+/**
+ * Pairs of capabilities that must never be enabled together on one connection.
+ * Mirrors the backend guard so the UI can prevent the invalid state up front.
+ */
+export const CAPABILITY_EXCLUSIVITY_PAIRS: ReadonlyArray<
+  readonly [CoreCapability, CoreCapability]
+> = [['InventoryMaster', 'OfferManager']];
+
+/**
+ * Returns the currently-selected capability that blocks `capability` from
+ * being enabled, or null when there is no conflict.
+ */
+export function getCapabilityConflict(
+  selected: ReadonlySet<string> | readonly string[],
+  capability: string,
+): CoreCapability | null {
+  const selectedSet = selected instanceof Set ? selected : new Set(selected);
+  for (const [a, b] of CAPABILITY_EXCLUSIVITY_PAIRS) {
+    if (capability === a && selectedSet.has(b)) return b;
+    if (capability === b && selectedSet.has(a)) return a;
+  }
+  return null;
+}
+
+/** True when the set contains at least one mutually-exclusive pair. */
+export function hasCapabilityConflict(capabilities: readonly string[]): boolean {
+  const set = new Set(capabilities);
+  return CAPABILITY_EXCLUSIVITY_PAIRS.some(([a, b]) => set.has(a) && set.has(b));
+}
+
+/**
+ * Operator-facing explanation rendered next to a checkbox disabled by an
+ * exclusivity conflict.
+ */
+export function capabilityConflictMessage(conflictingCapability: string): string {
+  return `Unavailable while ${conflictingCapability} is selected - the inventory source of truth cannot also be a stock write-back target.`;
+}

--- a/docs/plans/implementation-plan-woocommerce-setup-wizard.md
+++ b/docs/plans/implementation-plan-woocommerce-setup-wizard.md
@@ -1,0 +1,81 @@
+# Implementation Plan - WooCommerce setup wizard with capability selection (#1727)
+
+## 1. Goal
+
+Convert the single-step WooCommerce connection creation form into a 4-step setup wizard
+(mirroring the PrestaShop wizard) with a Capabilities step, and enforce the
+`InventoryMaster` x `OfferManager` mutual exclusivity in both the wizard and the
+edit-time `ConnectionCapabilitiesPanel`. Today the form silently submits the adapter's
+full `supportedCapabilities` set, which contains the mutually exclusive pair, so every
+create attempt 400s.
+
+**Layer**: Frontend only (`apps/web`, `features/connections`). No backend changes -
+the BE 400 remains the authoritative guard.
+
+**Non-goals**: no changes to the PrestaShop wizard flow (only extracting shared
+metadata), no plugin-registered (non-core) capability editing (#576 follow-up), no
+platform-generic exclusivity registry beyond the single known pair.
+
+## 2. Existing patterns reused
+
+- `prestashop-setup-form.tsx` - 4-step `WizardLayout` + `SetupStepper`, per-step
+  `form.trigger(STEP_FIELDS[i])`, `.capability-list` checkbox fieldset, `wizard-review-list`.
+- `woocommerce-setup.schema.ts` - existing Zod schema + `toCreateConnectionInput`.
+- `ConnectionCapabilitiesPanel.tsx` - edit-time checkbox list (gets the same guard).
+- `CAPABILITY_HELP` exists twice (PrestaShop form + panel, slightly divergent copy) -
+  unify into one shared module.
+
+## 3. Steps
+
+1. **`features/connections/lib/capability-metadata.ts`** (new; `lib/` is a canonical
+   feature subdirectory):
+   - `CAPABILITY_HELP: Record<CoreCapability, string>` - single source of the help copy
+     (merge the two existing maps; connection-neutral wording).
+   - `CAPABILITY_EXCLUSIVITY_PAIRS: ReadonlyArray<readonly [CoreCapability, CoreCapability]>`
+     = `[['InventoryMaster', 'OfferManager']]` - platform-agnostic rule (a stock source
+     of truth is never a stock write-back target); no `platformType` dispatch.
+   - `getCapabilityConflict(selected: ReadonlySet<string> | readonly string[], capability: string): CoreCapability | null`
+     - returns the selected capability that blocks `capability`, else null.
+   - `hasCapabilityConflict(capabilities: readonly string[]): boolean` - Zod backstop helper.
+
+2. **`woocommerce-setup.schema.ts`**:
+   - `.refine(...)` on `enabledCapabilities` rejecting any exclusivity pair
+     (message mirrors the BE copy).
+   - Defaults unchanged (`WOOCOMMERCE_FALLBACK_CAPABILITIES` = ProductMaster,
+     InventoryMaster, OrderProcessorManager, OrderSource).
+
+3. **`woocommerce-setup-form.tsx`** - rewrite as 4-step wizard:
+   - Steps: `Store details` (name, siteUrl) / `API credentials` (info Alert, consumerKey,
+     consumerSecret) / `Capabilities` / `Review & create`.
+   - Capabilities step: `.capability-list` checkboxes over the adapter registry's
+     `supportedCapabilities` (fallback preserved), default-checked set from schema
+     defaults; conflicting checkbox rendered `disabled` with an inline
+     `.capability-list__help` explanation while its counterpart is selected.
+   - Remove the silent `useEffect` seeding of all capabilities (root cause of the bug);
+     `enabledCapabilities` becomes user-controlled with sane defaults. Registry
+     capabilities not in defaults render unchecked.
+   - Review step: name, site URL, masked consumer key (reuse `maskKey` shape), selected
+     capabilities. Keep abandon-prevention, `FormErrorSummary`, API-error Alert.
+   - No summary rail (WizardLayout's `summary` is optional) - Woo has few fields;
+     review step covers it.
+
+4. **`prestashop-setup-form.tsx`**: drop the local `CAPABILITY_HELP`, import from
+   `../lib/capability-metadata`. No behavior change.
+
+5. **`ConnectionCapabilitiesPanel.tsx`**: import shared `CAPABILITY_HELP` +
+   `getCapabilityConflict`; when a capability's counterpart is enabled, render its
+   checkbox `disabled` with the inline explanation (prevents the post-create 400).
+
+6. **Tests**:
+   - `woocommerce-setup-form.test.tsx` - update/extend: step navigation + per-step
+     validation, exclusivity disable both directions, submit payload contains exactly
+     the selected capabilities, review content.
+   - `capability-metadata.test.ts` - conflict helper unit tests.
+   - `ConnectionCapabilitiesPanel.test.tsx` - extend with the disable-guard case.
+   - Schema refine test (in the form test file or a schema test).
+
+## 4. Validation
+
+- Quality gate: `pnpm lint`, `pnpm type-check`, scoped `pnpm --filter @openlinker/web test`.
+- No architecture violations: pure feature-slice change; shared module lives inside the
+  feature (`lib/`), no `shared/` -> `features/` import, no `platformType` literals.


### PR DESCRIPTION
## What changed and why

Creating a WooCommerce connection from the UI always failed with a 400: the single-step form silently submitted the adapter's full `supportedCapabilities` set, which since #1498 contains the mutually exclusive `InventoryMaster` + `OfferManager` pair (the inventory source of truth must not be a stock write-back target).

This PR converts the form into a 4-step setup wizard mirroring the PrestaShop flow, with an explicit Capabilities step:

1. **Store details** - name, site URL (HTTPS)
2. **API credentials** - REST API key instructions, consumer key/secret
3. **Capabilities** - checkbox list over the adapter registry's `supportedCapabilities`; defaults: `ProductMaster`, `InventoryMaster`, `OrderProcessorManager`, `OrderSource`
4. **Review & create** - summary with masked consumer key and selected capabilities

The `InventoryMaster`/`OfferManager` exclusivity is enforced three ways:
- **Wizard disable-guard**: the conflicting checkbox is disabled with an inline explanation while its counterpart is selected (both directions).
- **Zod backstop**: `.refine(...)` on `enabledCapabilities` so the invalid pair can never reach the API even if the UI guard regresses.
- **Edit-time guard**: the same disable + explanation in `ConnectionCapabilitiesPanel` on the connection detail page, so the pair cannot be re-enabled post-create.

The rule and the capability help copy now live in one shared module, `features/connections/lib/capability-metadata.ts`, consumed by the WooCommerce wizard, the PrestaShop wizard, and the panel (previously two divergent `CAPABILITY_HELP` copies). No backend changes - the BE 400 stays authoritative. No `platformType` literal dispatch: the exclusivity pair is expressed in capability terms only.

Approved design mockup: 4-step wizard with checkbox disable-guard, shop-master defaults.

## How to test

1. `pnpm start:dev:web` + API, go to `/connections/new/woocommerce`.
2. Walk the wizard; on step 3 note `OfferManager` is disabled while `InventoryMaster` is checked (and vice versa after unchecking).
3. Create the connection - succeeds (previously 400).
4. On the connection detail page, verify the capabilities panel blocks enabling the conflicting pair.

`pnpm --filter @openlinker/web lint` (0 errors), `type-check` clean, web vitest suite: 2376 passed; the one failing test (`settings-page.test.tsx > shows environment info`) is a pre-existing local-env artifact (`apps/web/.env.local` overriding `VITE_API_BASE_URL`), unrelated to this change.

## Related issues

Closes #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)
