### PR TITLE
feat(dpd): ConnectionTester so 'Test connection' runs a real auth probe

### DIFF
--- a/docs/plans/implementation-plan-dpd-connection-tester.md
+++ b/docs/plans/implementation-plan-dpd-connection-tester.md
@@ -1,0 +1,68 @@
+# Implementation Plan — DPD Polska ConnectionTester (#1732)
+
+## 1. Goal & Classification
+
+Give the DPD Polska adapter (`dpd.polska.rest.v1`) a real "Test connection" probe.
+Today the button fails with *"Connection testing is not supported for adapter
+dpd.polska.rest.v1"* because the plugin registers no `ConnectionTesterPort`.
+
+- **Layer**: Integration → Infrastructure (adapter) + plugin registration.
+- **Non-goals**: no FE change (the connection-detail action already calls the
+  registry), no new core port, no validation that a full shipment payload would
+  succeed — auth-only probe.
+
+## 2. Research findings (live sandbox, verified via curl)
+
+- DPDServices has no cheap `GET /me`. Every endpoint is `POST`.
+- `findPoints` returns `403` for both valid + invalid creds on demo → useless as a probe.
+- `POST /public/shipment/v1/generatePackagesNumbers` with empty body `{}`:
+  - valid creds → **HTTP 400** validation error (`generationPolicy must not be null`) — auth passed, **no waybill created** (validation precedes creation).
+  - invalid creds → **HTTP 401**.
+  - valid creds but no `X-DPD-FID` header → **HTTP 401** (FID header required for auth).
+- Precedent: `AllegroConnectionTesterAdapter` + `register(host)` in the plugin.
+
+## 3. Design
+
+`DpdConnectionTesterAdapter implements ConnectionTesterPort`. It issues one raw
+`fetch` (no retry, short timeout) — **not** `DpdHttpClient`, because the client
+throws `ShippingProviderRejectionException` on 400 (our success signal) and would
+invert the semantics.
+
+Probe result mapping:
+| HTTP status | Result |
+|---|---|
+| 400 | `success: true`, `message: 'OK'` (auth accepted, body validation rejected) |
+| 401 / 403 | `success: false`, message `401 Unauthorized` / `403 Forbidden` |
+| other / network error | `success: false`, message echoes status or error |
+
+The base URL is shared with the factory via a new `dpd-hosts.ts` so they can't drift.
+
+## 4. Steps
+
+1. **`infrastructure/http/dpd-hosts.ts`** (new) — move `BASE_URLS` out of the
+   factory into `getDpdServicesBaseUrl(environment: DpdEnvironment): string`.
+   Refactor `dpd-adapter.factory.ts` to import + use it. (Leave `INFO_BASE_URLS`
+   in the factory — the tester doesn't touch SOAP tracking.)
+2. **`infrastructure/adapters/dpd-connection-tester.adapter.ts`** (new) —
+   `implements ConnectionTesterPort`:
+   - read `environment` + `masterFid` from `connection.config`; resolve
+     `{ login, password }` via `credentialsResolver`;
+   - `POST {}` to `${getDpdServicesBaseUrl(environment)}/public/shipment/v1/generatePackagesNumbers`
+     with `Authorization: Basic …` and, when `masterFid` present, `X-DPD-FID`;
+   - `AbortController` timeout ~10 s;
+   - map status per table above; never throw.
+3. **`dpd-plugin.ts`** — in `register(host)` add
+   `host.connectionTesterRegistry.register(dpdAdapterManifest.adapterKey, new DpdConnectionTesterAdapter())`.
+4. **`__tests__/dpd-connection-tester.adapter.spec.ts`** (new) — mock global
+   `fetch`: 400 → success; 401 → failure; assert `X-DPD-FID` sent iff `masterFid`
+   set; network error → `success: false` (no throw).
+
+## 5. Validation
+
+- Architecture: adapter lives in the plugin's infrastructure layer, depends only
+  on core contracts (`ConnectionTesterPort`, `ConnectionTestResult`,
+  `CredentialsResolverPort`) via the `@openlinker/core/integrations` barrel. No
+  CORE↔Integration violation.
+- Naming: `*.adapter.ts`, `*.spec.ts`, file header comment present.
+- Security: credentials never logged; message strings are UI-safe (status text
+  only), no credential echo.

--- a/libs/integrations/dpd-polska/src/application/dpd-adapter.factory.ts
+++ b/libs/integrations/dpd-polska/src/application/dpd-adapter.factory.ts
@@ -19,17 +19,8 @@ import { DpdEnvironmentValues } from '../domain/types/dpd-config.types';
 import type { DpdCredentials } from '../domain/types/dpd-credentials.types';
 import { DpdShippingAdapter } from '../infrastructure/adapters/dpd-shipping.adapter';
 import { DpdHttpClient } from '../infrastructure/http/dpd-http-client';
+import { getDpdServicesBaseUrl } from '../infrastructure/http/dpd-hosts';
 import { DpdInfoSoapClient } from '../infrastructure/http/dpd-info-soap-client';
-
-// OQ-3 (#962) RESOLVED: the DPDServices test environment is host-gated, not
-// credentials-gated. The demo account (login `test`, FID 1495) authenticates
-// only against the `…demo…` host — confirmed from the DPD-supplied DEMO Postman
-// environment (`DPD_SERVICES_REST_WSDL = https://dpdservicesdemo.dpd.com.pl/public`)
-// and a live auth probe. Sending demo creds to the production host returns 401.
-const BASE_URLS: Readonly<Record<DpdEnvironment, string>> = {
-  sandbox: 'https://dpdservicesdemo.dpd.com.pl',
-  production: 'https://dpdservices.dpd.com.pl',
-};
 
 // DPD InfoServices SOAP tracking endpoint (#965 / ADR-022). A SEPARATE host
 // from the REST shipment API above — `dpdinfoservices.dpd.com.pl` (PROD,
@@ -46,7 +37,7 @@ export async function createDpdShippingAdapter(
 ): Promise<DpdShippingAdapter> {
   const config = extractConfig(connection);
   const credentials = await resolveCredentials(connection, credentialsResolver);
-  const client = new DpdHttpClient(BASE_URLS[config.environment], {
+  const client = new DpdHttpClient(getDpdServicesBaseUrl(config.environment), {
     login: credentials.login,
     password: credentials.password,
     masterFid: config.masterFid,

--- a/libs/integrations/dpd-polska/src/dpd-plugin.ts
+++ b/libs/integrations/dpd-polska/src/dpd-plugin.ts
@@ -19,6 +19,7 @@ import type { Connection } from '@openlinker/core/identifier-mapping';
 import { createDpdShippingAdapter } from './application/dpd-adapter.factory';
 import { DpdAuthFailureClassifierAdapter } from './infrastructure/adapters/dpd-auth-failure-classifier.adapter';
 import { DpdConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/dpd-connection-config-shape-validator.adapter';
+import { DpdConnectionTesterAdapter } from './infrastructure/adapters/dpd-connection-tester.adapter';
 import { buildDpdSchedulerTasks } from './infrastructure/scheduler/dpd-scheduler-tasks';
 
 /**
@@ -50,6 +51,14 @@ export function createDpdPlugin(): AdapterPlugin {
       );
       // No credentials-shape validator: the `{ login, password }` shape is
       // enforced at adapter construction time by the factory.
+
+      // Connection tester (#1732): a cheap auth-only probe so the connection
+      // detail "Test connection" action verifies stored credentials instead of
+      // reporting "not supported".
+      host.connectionTesterRegistry.register(
+        dpdAdapterManifest.adapterKey,
+        new DpdConnectionTesterAdapter(),
+      );
 
       // Auth-failure classifier (#819 / #1103): a non-retryable 401/403 from
       // either DPD client flips the connection to `needs_reauth` on the

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-connection-tester.adapter.spec.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__/dpd-connection-tester.adapter.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * DPD Connection Tester Adapter Unit Tests
+ *
+ * Verifies the empty-body auth probe interprets DPDServices statuses correctly
+ * (400 ⇒ auth OK, 401/403 ⇒ failure), gates the `X-DPD-FID` header on
+ * `masterFid`, and never throws — failures become structured
+ * `ConnectionTestResult` values.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/adapters/__tests__
+ */
+import { DpdConnectionTesterAdapter } from '../dpd-connection-tester.adapter';
+import { Connection } from '@openlinker/core/identifier-mapping';
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+
+function buildConnection(config: Record<string, unknown>): Connection {
+  return new Connection(
+    'c1',
+    'dpd',
+    'DPD Sandbox',
+    'active',
+    config,
+    'db:ref',
+    new Date(),
+    new Date(),
+    'dpd.polska.rest.v1',
+    ['ShippingProviderManager'],
+  );
+}
+
+describe('DpdConnectionTesterAdapter', () => {
+  const tester = new DpdConnectionTesterAdapter();
+  const resolver: CredentialsResolverPort = {
+    get: jest.fn().mockResolvedValue({ login: 'test', password: 'secret' }),
+  } as unknown as CredentialsResolverPort;
+
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it('returns success when the probe is rejected at validation (HTTP 400)', async () => {
+    fetchMock.mockResolvedValue({ status: 400 } as Response);
+
+    const result = await tester.test(buildConnection({ environment: 'sandbox', masterFid: '1495' }), resolver);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe(400);
+    expect(result.message).toBe('OK');
+  });
+
+  it('returns failure with status 401 when credentials are rejected', async () => {
+    fetchMock.mockResolvedValue({ status: 401 } as Response);
+
+    const result = await tester.test(buildConnection({ environment: 'sandbox', masterFid: '1495' }), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(401);
+    expect(result.message).toContain('401');
+  });
+
+  it('returns failure for an unexpected status', async () => {
+    fetchMock.mockResolvedValue({ status: 500 } as Response);
+
+    const result = await tester.test(buildConnection({ environment: 'sandbox', masterFid: '1495' }), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(500);
+  });
+
+  function firstCall(): [string, RequestInit] {
+    return fetchMock.mock.calls[0] as [string, RequestInit];
+  }
+
+  it('sends the X-DPD-FID header when masterFid is set', async () => {
+    fetchMock.mockResolvedValue({ status: 400 } as Response);
+
+    await tester.test(buildConnection({ environment: 'sandbox', masterFid: '1495' }), resolver);
+
+    const headers = firstCall()[1].headers as Record<string, string>;
+    expect(headers['X-DPD-FID']).toBe('1495');
+    expect(headers.Authorization).toMatch(/^Basic /);
+  });
+
+  it('omits the X-DPD-FID header when masterFid is absent', async () => {
+    fetchMock.mockResolvedValue({ status: 400 } as Response);
+
+    await tester.test(buildConnection({ environment: 'sandbox' }), resolver);
+
+    const headers = firstCall()[1].headers as Record<string, string>;
+    expect(headers['X-DPD-FID']).toBeUndefined();
+  });
+
+  it('targets the sandbox host for a sandbox connection', async () => {
+    fetchMock.mockResolvedValue({ status: 400 } as Response);
+
+    await tester.test(buildConnection({ environment: 'sandbox', masterFid: '1495' }), resolver);
+
+    expect(firstCall()[0]).toBe(
+      'https://dpdservicesdemo.dpd.com.pl/public/shipment/v1/generatePackagesNumbers',
+    );
+  });
+
+  it('fails without throwing on a network error', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    const result = await tester.test(buildConnection({ environment: 'sandbox', masterFid: '1495' }), resolver);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('network down');
+  });
+
+  it('fails when the environment is missing', async () => {
+    const result = await tester.test(buildConnection({ masterFid: '1495' }), resolver);
+
+    expect(result.success).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-connection-tester.adapter.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/adapters/dpd-connection-tester.adapter.ts
@@ -1,0 +1,121 @@
+/**
+ * DPD Polska Connection Tester Adapter
+ *
+ * Implements ConnectionTesterPort for DPD connections. DPDServices exposes no
+ * cheap `GET /me`-style endpoint — every route is a `POST`. The probe therefore
+ * sends an intentionally-empty body to `generatePackagesNumbers`: DPD validates
+ * the request BEFORE creating anything, so a valid-credentials call is rejected
+ * at validation (HTTP 400, `generationPolicy must not be null`) without minting
+ * a waybill or a COD charge, while invalid credentials fail earlier with 401.
+ * The 400-vs-401 split is the auth signal.
+ *
+ * A raw `fetch` is used rather than `DpdHttpClient` on purpose: the client maps
+ * a 400 to `ShippingProviderRejectionException` (which here means "auth OK"), so
+ * reusing it would invert the success semantics.
+ *
+ * Never throws — all failures are translated into a structured, UI-safe
+ * `ConnectionTestResult` with `success: false`.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/adapters
+ * @implements {ConnectionTesterPort}
+ */
+import type {
+  ConnectionTesterPort,
+  ConnectionTestResult,
+  CredentialsResolverPort,
+} from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { DpdConnectionConfig } from '../../domain/types/dpd-config.types';
+import { DpdEnvironmentValues } from '../../domain/types/dpd-config.types';
+import type { DpdCredentials } from '../../domain/types/dpd-credentials.types';
+import { getDpdServicesBaseUrl } from '../http/dpd-hosts';
+
+const PROBE_PATH = '/public/shipment/v1/generatePackagesNumbers';
+const PROBE_TIMEOUT_MS = 10_000;
+
+export class DpdConnectionTesterAdapter implements ConnectionTesterPort {
+  async test(
+    connection: Connection,
+    credentialsResolver: CredentialsResolverPort,
+  ): Promise<ConnectionTestResult> {
+    const startedAt = Date.now();
+    try {
+      const config = (connection.config ?? {}) as Partial<DpdConnectionConfig>;
+      const environment = config.environment;
+      if (
+        typeof environment !== 'string' ||
+        !DpdEnvironmentValues.includes(environment)
+      ) {
+        return this.fail('Connection is missing a valid DPD environment', startedAt);
+      }
+
+      if (!connection.credentialsRef) {
+        return this.fail('Connection has no stored credentials', startedAt);
+      }
+      const credentials = await credentialsResolver.get<DpdCredentials>(connection.credentialsRef);
+      if (!credentials?.login || !credentials?.password) {
+        return this.fail('Stored credentials are missing login/password', startedAt);
+      }
+
+      const status = await this.probe(environment, credentials, config.masterFid);
+      return this.interpret(status, startedAt);
+    } catch (error) {
+      return this.fail((error as Error).message ?? 'DPD probe failed', startedAt);
+    }
+  }
+
+  /** Issue the empty-body probe and return the HTTP status code. */
+  private async probe(
+    environment: DpdConnectionConfig['environment'],
+    credentials: DpdCredentials,
+    masterFid: string | undefined,
+  ): Promise<number> {
+    const url = new URL(PROBE_PATH, getDpdServicesBaseUrl(environment)).toString();
+    const token = Buffer.from(`${credentials.login}:${credentials.password}`, 'utf8').toString(
+      'base64',
+    );
+    const headers: Record<string, string> = {
+      Authorization: `Basic ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+    if (masterFid) {
+      headers['X-DPD-FID'] = masterFid;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: '{}',
+        signal: controller.signal,
+      });
+      return response.status;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /**
+   * A 400 means auth was accepted and only the (deliberately empty) body was
+   * rejected — the connection is live. 401/403 are credential failures.
+   */
+  private interpret(status: number, startedAt: number): ConnectionTestResult {
+    if (status === 400) {
+      return { success: true, status, message: 'OK', latencyMs: Date.now() - startedAt };
+    }
+    if (status === 401) {
+      return this.fail('401 Unauthorized — check DPD login/password and payer FID', startedAt, status);
+    }
+    if (status === 403) {
+      return this.fail('403 Forbidden — credentials lack access', startedAt, status);
+    }
+    return this.fail(`Unexpected DPD probe status ${status}`, startedAt, status);
+  }
+
+  private fail(message: string, startedAt: number, status?: number): ConnectionTestResult {
+    return { success: false, status, message, latencyMs: Date.now() - startedAt };
+  }
+}

--- a/libs/integrations/dpd-polska/src/infrastructure/http/dpd-hosts.ts
+++ b/libs/integrations/dpd-polska/src/infrastructure/http/dpd-hosts.ts
@@ -1,0 +1,26 @@
+/**
+ * DPD Polska DPDServices Host Resolver
+ *
+ * Single source of truth for the DPDServices REST base URL per environment.
+ * Shared by the adapter factory (which wires the shipment client) and the
+ * connection tester (which issues a cheap auth probe) so the two can't drift.
+ *
+ * OQ-3 (#962) RESOLVED: the DPDServices test environment is host-gated, not
+ * credentials-gated. The demo account (login `test`, FID 1495) authenticates
+ * only against the `…demo…` host — confirmed from the DPD-supplied DEMO Postman
+ * environment (`DPD_SERVICES_REST_WSDL = https://dpdservicesdemo.dpd.com.pl/public`)
+ * and a live auth probe. Sending demo creds to the production host returns 401.
+ *
+ * @module libs/integrations/dpd-polska/src/infrastructure/http
+ */
+import type { DpdEnvironment } from '../../domain/types/dpd-config.types';
+
+const BASE_URLS: Readonly<Record<DpdEnvironment, string>> = {
+  sandbox: 'https://dpdservicesdemo.dpd.com.pl',
+  production: 'https://dpdservices.dpd.com.pl',
+};
+
+/** DPDServices REST base URL for the given environment. */
+export function getDpdServicesBaseUrl(environment: DpdEnvironment): string {
+  return BASE_URLS[environment];
+}


### PR DESCRIPTION
## What changed and why

The DPD Polska adapter (`dpd.polska.rest.v1`) registered no `ConnectionTesterPort`, so the connection-detail **"Test connection"** action failed with *"Connection testing is not supported for adapter dpd.polska.rest.v1"*. Operators had no way to verify DPD credentials short of attempting a real label generation (which mints a waybill + COD charge).

This adds a real, side-effect-free authentication probe.

**How the probe works.** DPDServices has no cheap `GET /me` — every route is `POST`. The probe sends an intentionally-empty body `{}` to `generatePackagesNumbers`. DPD validates the request **before** creating anything, so:

- valid credentials → **HTTP 400** validation error (`generationPolicy must not be null`) — auth accepted, **no waybill / COD created**;
- invalid credentials → **HTTP 401**;
- valid credentials without the required `X-DPD-FID` header → **HTTP 401**.

The 400-vs-401 split is the auth signal. All three behaviours were verified live against the sandbox host (`https://dpdservicesdemo.dpd.com.pl`).

A raw `fetch` is used rather than `DpdHttpClient` on purpose: the client maps a 400 to `ShippingProviderRejectionException` (which here means "auth OK"), so reusing it would invert the success semantics.

## Changes

- `infrastructure/http/dpd-hosts.ts` (new) — `getDpdServicesBaseUrl(environment)`, extracted from the factory so the tester and the factory share one source of truth for the base URL.
- `infrastructure/adapters/dpd-connection-tester.adapter.ts` (new) — `implements ConnectionTesterPort`; empty-body probe; maps 400→success, 401/403→failure; never throws.
- `dpd-plugin.ts` — registers the tester in `register(host)`.
- `application/dpd-adapter.factory.ts` — refactored to use `getDpdServicesBaseUrl`.
- unit spec covering the status matrix, `X-DPD-FID` gating on `masterFid`, sandbox host, and network-error resilience.

## How to test

1. Open a DPD connection → **Actions → Test connection**.
2. With valid credentials (sandbox demo: login `test`, payer/master FID `1495`) it returns success.
3. With a wrong password it returns a `401` failure instead of "not supported".
4. No waybill is created by the probe.

## Notes / assumptions

- The probe validates **authentication only** ("are the stored login/password/FID accepted"), matching the button's contract ("Verifies the base URL and stored credentials"). It does not validate that a full shipment payload would succeed.
- Production behaviour is assumed identical to the verified sandbox (same engine, different host); only sandbox was verified live.
- A connection without `masterFid` set will get `401` → failure, which is correct — real shipment calls omit `X-DPD-FID` too and would fail identically.

Closes #1732

🤖 Generated with [Claude Code](https://claude.com/claude-code)
