### PR TITLE
feat(erli): implement OfferReader so listing details render for Erli (#1735)

### DIFF
--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -22,6 +22,7 @@ import {
   AdapterCapabilityNotSupportedException,
   CatalogProductNotFoundException,
   CategoryNotFoundException,
+  OfferNotFoundOnMarketplaceException,
 } from '@openlinker/core/listings';
 import {
   ConnectionNotFoundException,
@@ -430,6 +431,16 @@ describe('ListingsController', () => {
       integrationsService.getCapabilityAdapter.mockResolvedValue(makeOfferReaderAdapter(getOffer));
 
       await expect(controller.getMarketplaceOffer('uuid-1')).rejects.toThrow('Allegro 502');
+    });
+
+    it('should map OfferNotFoundOnMarketplaceException to a soft 404 (live data unavailable)', async () => {
+      repository.findById.mockResolvedValue(mockMapping);
+      const getOffer = jest
+        .fn()
+        .mockRejectedValue(new OfferNotFoundOnMarketplaceException('allegro-offer-456', 'conn-1'));
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeOfferReaderAdapter(getOffer));
+
+      await expect(controller.getMarketplaceOffer('uuid-1')).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -37,6 +37,7 @@ import {
   isCatalogProductReader,
   isCategoryParametersReader,
   isOfferReader,
+  OfferNotFoundOnMarketplaceException,
   OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
@@ -245,8 +246,19 @@ export class ListingsController {
       );
     }
 
-    const offer = await adapter.getOffer({ externalId: mapping.externalId });
-    return MarketplaceOfferResponseDto.fromDomain(offer);
+    try {
+      const offer = await adapter.getOffer({ externalId: mapping.externalId });
+      return MarketplaceOfferResponseDto.fromDomain(offer);
+    } catch (error) {
+      // The offer isn't (yet) retrievable on the marketplace — e.g. Erli's
+      // read-after-write cache lag or a deleted offer. Map to 404 so the FE
+      // renders the soft "live data unavailable" fallback rather than a hard
+      // error, keeping the rest of the detail page rendering.
+      if (error instanceof OfferNotFoundOnMarketplaceException) {
+        throw new NotFoundException(error.message);
+      }
+      throw error;
+    }
   }
 
   @Roles('admin', 'operator')

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -14,6 +14,7 @@
 import {
   isCategoryBrowser,
   isCategoryParametersReader,
+  isOfferReader,
   isOfferStatusReader,
   OfferCreateRejectedException,
   OfferNotFoundOnMarketplaceException,
@@ -1038,6 +1039,86 @@ describe('ErliOfferManagerAdapter', () => {
 
     it('should reject a hostile externalOfferId before any GET', async () => {
       await expect(adapter.getOfferStatus('evil/../x')).rejects.toBeInstanceOf(ErliConfigException);
+      expect(httpClient.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getOffer (#464 — OfferReader)', () => {
+    // A representative live read-side product resource (shape verified against
+    // the sandbox GET /products/{externalId}): grosze price, public image url,
+    // breadcrumb-path categories, flat HTML externalDescription.
+    const productResource = {
+      externalId: VALID_ID,
+      name: 'Swieca sojowa zapachowa 200g Aura',
+      externalDescription: '<p>Naturalna swieca sojowa.</p>',
+      ean: '5900000000114',
+      price: 3490,
+      stock: 16,
+      status: 'active',
+      slug: 'swieca-sojowa-200g-aura',
+      marketplaceId: 843284,
+      images: [
+        { url: 'https://presta.demo.openlinker.io/img/p/1/6/16.jpg', internalUrl: 'https://cdn/1.webp' },
+        { url: 'https://presta.demo.openlinker.io/img/p/1/7/17.jpg' },
+      ],
+      categories: [[{ id: 1, name: 'Dom i Ogród' }, { id: 1013, name: 'Pozostałe' }]],
+    };
+
+    it('should be detectable as an OfferReader', () => {
+      expect(isOfferReader(adapter)).toBe(true);
+    });
+
+    it('should map the Erli product resource onto a neutral MarketplaceOffer', async () => {
+      httpClient.get.mockResolvedValueOnce({ status: 200, data: productResource });
+
+      const offer = await adapter.getOffer({ externalId: VALID_ID });
+
+      expect(httpClient.get).toHaveBeenCalledWith(`products/${VALID_ID}`);
+      expect(offer).toEqual({
+        externalId: VALID_ID,
+        title: 'Swieca sojowa zapachowa 200g Aura',
+        description: '<p>Naturalna swieca sojowa.</p>',
+        imageUrl: 'https://presta.demo.openlinker.io/img/p/1/6/16.jpg',
+        price: { amount: '34.90', currency: 'PLN' },
+        availableQuantity: 16,
+        status: 'active',
+        category: { id: '1013', name: 'Pozostałe' },
+      });
+    });
+
+    it('should default missing fields defensively (empty title, 0 price/qty)', async () => {
+      httpClient.get.mockResolvedValueOnce({ status: 200, data: {} });
+
+      const offer = await adapter.getOffer({ externalId: VALID_ID });
+
+      expect(offer.title).toBe('');
+      expect(offer.price).toEqual({ amount: '0.00', currency: 'PLN' });
+      expect(offer.availableQuantity).toBe(0);
+      expect(offer.status).toBe('unknown');
+      expect(offer.category).toBeUndefined();
+      expect(offer.imageUrl).toBeUndefined();
+    });
+
+    it('should throw OfferNotFoundOnMarketplaceException on a 404 (read-after-write lag / deleted)', async () => {
+      httpClient.get.mockRejectedValueOnce(new ErliApiException('not found', 404));
+
+      await expect(adapter.getOffer({ externalId: VALID_ID })).rejects.toBeInstanceOf(
+        OfferNotFoundOnMarketplaceException,
+      );
+    });
+
+    it('should propagate non-404 transport errors', async () => {
+      httpClient.get.mockRejectedValueOnce(new ErliApiException('server error', 500));
+
+      await expect(adapter.getOffer({ externalId: VALID_ID })).rejects.toBeInstanceOf(
+        ErliApiException,
+      );
+    });
+
+    it('should reject a hostile externalId before any GET', async () => {
+      await expect(adapter.getOffer({ externalId: 'evil/../x' })).rejects.toBeInstanceOf(
+        ErliConfigException,
+      );
       expect(httpClient.get).not.toHaveBeenCalled();
     });
   });

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -108,6 +108,7 @@ import {
   type CreateOfferValidationError,
   type DeliveryPriceList,
   type DeliveryPriceListReader,
+  type MarketplaceOffer,
   type OfferCategory,
   type OfferCondition,
   type OfferCreator,
@@ -115,6 +116,7 @@ import {
   type OfferFieldUpdate,
   type OfferFieldUpdater,
   type OfferManagerPort,
+  type OfferReader,
   type OfferStatusReadResult,
   type OfferStatusReader,
   type OfferStockRestorer,
@@ -144,6 +146,9 @@ import type {
   ErliProductResource,
   ErliResponsibleProducerItem,
 } from './erli-product.types';
+
+/** Erli prices are PLN-only integers in minor units (grosze) — no currency field on the wire. */
+const ERLI_CURRENCY = 'PLN';
 
 /**
  * Maps OL patch-body keys to the Erli field name carried in
@@ -219,6 +224,7 @@ export class ErliOfferManagerAdapter
     OfferManagerPort,
     OfferCreator,
     OfferFieldUpdater,
+    OfferReader,
     OfferStatusReader,
     OfferStockRestorer,
     TaxonomyBorrower,
@@ -383,6 +389,59 @@ export class ErliOfferManagerAdapter
     // (handled above → OfferNotFoundOnMarketplaceException) never reaches here.
     await this.writeFrozenStockFlag(externalOfferId, product.frozenFields);
     return mapErliStatusToReadResult(product);
+  }
+
+  /**
+   * OfferReader (#464). Fetches the live Erli-side offer detail (title, image,
+   * price, qty, status, category, description) the listing-detail page surfaces
+   * above the raw mapping fields. Reuses {@link fetchErliProduct} — Erli
+   * represents an offer AS a product, so the same seller-keyed
+   * `GET /products/{externalId}` read backs it.
+   *
+   * A 404 (offer not yet visible on Erli — the ADR-025 §1 ~20-min read-after-write
+   * cache lag, or a deleted offer) becomes `OfferNotFoundOnMarketplaceException`,
+   * which the HTTP layer maps to the soft "live data unavailable" fallback rather
+   * than a hard error. Other transport errors propagate so the FE surfaces the
+   * retryable error state.
+   */
+  async getOffer(input: { externalId: string }): Promise<MarketplaceOffer> {
+    let product: ErliProductResource;
+    try {
+      product = await this.fetchErliProduct(input.externalId);
+    } catch (error) {
+      if (error instanceof ErliApiException && error.statusCode === 404) {
+        throw new OfferNotFoundOnMarketplaceException(input.externalId, this.connectionId);
+      }
+      throw error;
+    }
+    return this.toMarketplaceOffer(input.externalId, product);
+  }
+
+  /**
+   * Map a read-side Erli product resource onto the neutral {@link MarketplaceOffer}.
+   * Price is Erli's grosze integer → decimal string in PLN (Erli is PLN-only).
+   * Description prefers the flat `externalDescription` HTML over the structured
+   * `description.sections` tree. Category is the leaf of the first breadcrumb path.
+   * `marketplaceUrl` / `endsAt` are intentionally omitted — Erli exposes no stable
+   * buyer-facing offer URL on this read and has no fixed offer end date.
+   */
+  private toMarketplaceOffer(externalId: string, product: ErliProductResource): MarketplaceOffer {
+    const leafCategory = product.categories?.[0]?.at(-1);
+    return {
+      externalId: product.externalId ?? externalId,
+      title: product.name ?? '',
+      description: product.externalDescription,
+      imageUrl: product.images?.[0]?.url,
+      price: {
+        amount: ((product.price ?? 0) / 100).toFixed(2),
+        currency: ERLI_CURRENCY,
+      },
+      availableQuantity: product.stock ?? 0,
+      status: product.status ?? 'unknown',
+      category: leafCategory
+        ? { id: String(leafCategory.id), name: leafCategory.name }
+        : undefined,
+    };
   }
 
   /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -212,6 +212,17 @@ export interface ErliDeliveryPriceListItem {
   name: string;
 }
 
+/**
+ * One category-breadcrumb node on the read-side product resource. Erli returns
+ * `categories` as an array of breadcrumb paths (`[[{ id, name }, ...]]`); the
+ * leaf of the first path is the most-specific category the offer sits under.
+ * `id` is a numeric marketplace category id; `name` is the human-readable label.
+ */
+export interface ErliProductCategoryNode {
+  id: number;
+  name?: string;
+}
+
 export interface ErliProductResource {
   /**
    * Erli field names the seller has frozen via manual panel edits (#988). May
@@ -224,4 +235,31 @@ export interface ErliProductResource {
   status?: ErliProductStatus;
   /** Rejection / inactivation detail Erli supplies, when present (#989). */
   statusReason?: string;
+
+  // ── Read-side offer-detail fields (OfferReader.getOffer) ──
+  // Verified live against the sandbox GET /products/{externalId}: money is an
+  // INTEGER in minor units (grosze, PLN-only), `images[].url` is a public URL,
+  // and `categories` is an array of breadcrumb paths.
+  /** Seller-keyed product id echoed back (the OL variant id used as the offer id). */
+  externalId?: string;
+  /** Offer title. */
+  name?: string;
+  /**
+   * Rendered HTML description Erli returns alongside the structured
+   * `description.sections` object. Preferred for the detail-page preview
+   * because it is a flat string rather than a section tree.
+   */
+  externalDescription?: string;
+  ean?: string;
+  sku?: string;
+  /** Price in INTEGER minor units (grosze). PLN-only — no currency field. */
+  price?: number;
+  stock?: number;
+  images?: ErliProductImage[];
+  /** Category breadcrumb paths; the first path's leaf is the offer's category. */
+  categories?: ErliProductCategoryNode[][];
+  /** Buyer-facing offer slug (e.g. `swieca-sojowa-200g`). */
+  slug?: string;
+  /** Numeric Erli marketplace offer id (distinct from the seller-keyed `externalId`). */
+  marketplaceId?: number;
 }


### PR DESCRIPTION
## What changed and why

Erli offers showed only `Live data unavailable for this adapter.` on the listing-detail page, while Allegro offers render the full live card. Cause: `ErliOfferManagerAdapter` did not implement the `OfferReader` sub-capability (`getOffer`), so `GET /listings/.../marketplace-offer` returned `422` and the FE fell back to the soft message.

This implements `OfferReader` for Erli. Erli represents an offer **as a product**, so `getOffer` reuses the existing seller-keyed `GET /products/{externalId}` read (already backing `getOfferStatus` / `updateOfferFields`) - no new API call - and maps the read-side resource onto the neutral `MarketplaceOffer`:

- grosze integer -> `"34.90"` PLN decimal (Erli is PLN-only)
- first `images[].url` -> `imageUrl`
- leaf of the first `categories` breadcrumb path -> `category`
- flat `externalDescription` HTML -> `description`
- `marketplaceUrl` / `endsAt` omitted (Erli exposes no stable buyer URL on this read, no fixed end date)

A `404` (ADR-025 read-after-write cache lag, or a deleted offer) throws `OfferNotFoundOnMarketplaceException`, which the controller maps to a soft `404` so the FE keeps its "live data unavailable" fallback rather than a hard error, and the rest of the page keeps rendering.

No FE change: the existing `ListingMarketplaceOfferSection` renders the data path once the endpoint returns `200`. `OfferReader` stays resolved via the `isOfferReader` guard (Allegro precedent) - no manifest / `CoreCapabilityValues` change.

The read-side product shape was verified live against the Erli sandbox `GET /products/{externalId}`.

## Files

- `libs/integrations/erli/.../erli-product.types.ts` - read-side fields on `ErliProductResource`
- `libs/integrations/erli/.../erli-offer-manager.adapter.ts` - `OfferReader` + `getOffer` + mapper
- `apps/api/.../listings.controller.ts` - `OfferNotFoundOnMarketplaceException` -> 404 mapping
- `+` unit tests (adapter, controller)

## How to test

1. Open a listing-detail page for an Erli offer mapping (`entityType=Offer`).
2. The "Listing details" section renders the live card (title, image, ACTIVE badge, price, qty, category, description preview) instead of "Live data unavailable for this adapter."

Automated: `pnpm --filter @openlinker/integrations-erli test -- erli-offer-manager.adapter.spec` (109/109) and `pnpm --filter @openlinker/api test -- listings.controller.spec` (60/60).

## Notes / follow-up

Out of scope, found while verifying against the sandbox: the live API returns `frozen` as an object (`{ name: false, price: false, ... }`), but the adapter's frozen-field protection (#988 / #1066) reads `frozenFields: string[]`, which never exists in the response - so that protection is effectively inert. Filed as #1737.

Closes #1735

🤖 Generated with [Claude Code](https://claude.com/claude-code)