### PR TITLE
feat(erli): fulfillment routing for Erli sources + Fulfillment-tab routing-split bar

### DIFF
--- a/apps/api/src/mappings/http/__tests__/mapping-options.controller.spec.ts
+++ b/apps/api/src/mappings/http/__tests__/mapping-options.controller.spec.ts
@@ -7,8 +7,9 @@
  *   - 501: adapter resolved but doesn't implement the sub-capability
  *   - error propagation when getCapabilityAdapter throws
  *   - categories paths delegate to categoriesCacheService
- *   - #479 partner resolution: URL-is-Allegro / URL-is-PS / no pairing /
- *     ambiguous pairing / unsupported platform branches
+ *   - #479/#1738 partner resolution: pairing-first + capability-checked (no
+ *     platform literals) — source-URL / master-URL / no pairing / ambiguous
+ *     multi-source / capability-missing branches, including Erli as a source
  *
  * @module apps/api/src/mappings/http/__tests__
  */
@@ -43,6 +44,14 @@ describe('MappingOptionsController', () => {
 
   const ALLEGRO_CONNECTION_ID = 'conn-allegro-1';
   const PRESTASHOP_CONNECTION_ID = 'conn-ps-1';
+  const ERLI_CONNECTION_ID = 'conn-erli-1';
+
+  /**
+   * Advertised capabilities per connection id, served through the
+   * metadata-only `getAdapter` the #1738 resolution probes. Tests may extend
+   * or override entries per case.
+   */
+  let capabilitiesById: Record<string, string[]>;
 
   const fullDestinationAdapter: OrderProcessorManagerPort & DestinationOptionsReader = {
     createOrder: jest.fn(),
@@ -99,10 +108,38 @@ describe('MappingOptionsController', () => {
     id: PRESTASHOP_CONNECTION_ID,
     platformType: 'prestashop',
   });
+  const erliConnection = makeConnection({
+    id: ERLI_CONNECTION_ID,
+    platformType: 'erli',
+    config: { masterCatalogConnectionId: PRESTASHOP_CONNECTION_ID },
+  });
 
   beforeEach(async () => {
+    capabilitiesById = {
+      [ALLEGRO_CONNECTION_ID]: ['OrderSource', 'OfferManager'],
+      [ERLI_CONNECTION_ID]: ['OrderSource', 'OfferManager'],
+      [PRESTASHOP_CONNECTION_ID]: ['ProductMaster', 'OrderProcessorManager', 'OrderSource'],
+    };
     integrationsService = {
       getCapabilityAdapter: jest.fn(),
+      // Metadata-only capability probe (#1738): unknown ids reject, mirroring
+      // ConnectionNotFoundException from the real service.
+      getAdapter: jest.fn((id: string) => {
+        const capabilities = capabilitiesById[id];
+        if (!capabilities) {
+          return Promise.reject(new Error(`Connection not found: ${id}`));
+        }
+        return Promise.resolve({
+          connection: makeConnection({ id, platformType: 'test' }),
+          metadata: {
+            adapterKey: 'test.v1',
+            platformType: 'test',
+            supportedCapabilities: capabilities,
+            displayName: 'Test',
+            version: '1.0.0',
+          },
+        });
+      }),
     } as unknown as jest.Mocked<IIntegrationsService>;
     categoriesCache = {
       getPrestashopCategories: jest.fn(),
@@ -207,8 +244,8 @@ describe('MappingOptionsController', () => {
     });
   });
 
-  describe('partner resolution (#479)', () => {
-    it('URL is PrestaShop, side=destination → resolves to URL connection', async () => {
+  describe('partner resolution (#479 / #1738)', () => {
+    it('URL is PrestaShop (unpaired master), side=destination → resolves to URL connection', async () => {
       connectionPort.get.mockResolvedValueOnce(prestashopConnection);
       integrationsService.getCapabilityAdapter.mockResolvedValueOnce(fullDestinationAdapter);
 
@@ -220,41 +257,73 @@ describe('MappingOptionsController', () => {
       );
     });
 
-    it('URL is PrestaShop, side=source → reverse-resolves the paired Allegro', async () => {
+    it('URL is PrestaShop, side=source → reverse-resolves the single paired OrderSource connection', async () => {
       connectionPort.get.mockResolvedValueOnce(prestashopConnection);
       connectionPort.list.mockResolvedValueOnce([allegroConnection]);
       integrationsService.getCapabilityAdapter.mockResolvedValueOnce(fullSourceAdapter);
 
       await controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID);
 
-      // Reverse lookup filters Allegro connections to active ones.
-      expect(connectionPort.list).toHaveBeenCalledWith({
-        platformType: 'allegro',
-        status: 'active',
-      });
+      // Reverse lookup is capability-driven, not platform-filtered (#1738).
+      expect(connectionPort.list).toHaveBeenCalledWith({ status: 'active' });
       expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
         ALLEGRO_CONNECTION_ID,
         'OrderSource'
       );
     });
 
-    it('URL is Allegro with no masterCatalogConnectionId → 400 with operator message', async () => {
+    it('URL is Erli (paired source), side=source → resolves to the URL connection itself', async () => {
+      connectionPort.get.mockResolvedValueOnce(erliConnection);
+      integrationsService.getCapabilityAdapter.mockResolvedValueOnce(fullSourceAdapter);
+
+      await controller.getSourceDeliveryMethods(ERLI_CONNECTION_ID);
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
+        ERLI_CONNECTION_ID,
+        'OrderSource'
+      );
+    });
+
+    it('URL is Erli (paired source), side=destination → resolves to the paired master', async () => {
+      connectionPort.get.mockResolvedValueOnce(erliConnection);
+      integrationsService.getCapabilityAdapter.mockResolvedValueOnce(fullDestinationAdapter);
+
+      await controller.getDestinationCarriers(ERLI_CONNECTION_ID);
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
+        PRESTASHOP_CONNECTION_ID,
+        'OrderProcessorManager'
+      );
+    });
+
+    it('URL is a paired connection without OrderSource, side=source → 400 capability message', async () => {
+      capabilitiesById[ERLI_CONNECTION_ID] = ['OfferManager'];
+      connectionPort.get.mockResolvedValueOnce(erliConnection);
+
+      const promise = controller.getSourceDeliveryMethods(ERLI_CONNECTION_ID);
+      await expect(promise).rejects.toBeInstanceOf(BadRequestException);
+      await expect(promise).rejects.toThrow(/does not support OrderSource/);
+      expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('URL is an unpaired connection without OrderProcessorManager, side=destination → 400 capability message', async () => {
       const orphanedAllegro = makeConnection({
         id: 'orphan-allegro',
         platformType: 'allegro',
         config: {},
       });
+      capabilitiesById['orphan-allegro'] = ['OrderSource', 'OfferManager'];
       connectionPort.get.mockResolvedValueOnce(orphanedAllegro);
 
       const promise = controller.getDestinationCarriers('orphan-allegro');
       await expect(promise).rejects.toBeInstanceOf(BadRequestException);
-      await expect(promise).rejects.toThrow(/no destination paired/);
+      await expect(promise).rejects.toThrow(/does not support OrderProcessorManager/);
       expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
     });
 
-    it('URL is PrestaShop with zero paired Allegro connections → 400 with operator message', async () => {
+    it('URL is PrestaShop with zero paired source connections → 400 with operator message', async () => {
       connectionPort.get.mockResolvedValueOnce(prestashopConnection);
-      // No Allegro connection points at this PS.
+      // Nothing points at this PS.
       connectionPort.list.mockResolvedValueOnce([]);
 
       const promise = controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID);
@@ -263,46 +332,49 @@ describe('MappingOptionsController', () => {
       expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
     });
 
-    it('URL is PrestaShop with multiple paired Allegro connections → 400 listing the conflicting ids', async () => {
-      const allegroA = makeConnection({
-        id: 'allegro-a',
-        platformType: 'allegro',
-        config: { masterCatalogConnectionId: PRESTASHOP_CONNECTION_ID },
-      });
-      const allegroB = makeConnection({
-        id: 'allegro-b',
-        platformType: 'allegro',
-        config: { masterCatalogConnectionId: PRESTASHOP_CONNECTION_ID },
-      });
+    it('URL is PrestaShop with multiple paired OrderSource connections → 400 listing the conflicting ids', async () => {
       connectionPort.get.mockResolvedValueOnce(prestashopConnection);
-      connectionPort.list.mockResolvedValueOnce([allegroA, allegroB]);
+      connectionPort.list.mockResolvedValueOnce([allegroConnection, erliConnection]);
 
       const promise = controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID);
       await expect(promise).rejects.toBeInstanceOf(BadRequestException);
       await expect(promise).rejects.toThrow(
-        /multiple paired Allegro connections \(allegro-a, allegro-b\)/
+        new RegExp(
+          `multiple paired source connections \\(${ALLEGRO_CONNECTION_ID}, ${ERLI_CONNECTION_ID}\\)`
+        )
       );
     });
 
-    it('URL connection has unsupported platform → 400', async () => {
-      const shopify = makeConnection({ id: 'shopify-1', platformType: 'shopify' });
-      connectionPort.get.mockResolvedValueOnce(shopify);
+    it('URL is PrestaShop, side=source: a paired non-OrderSource connection is not counted', async () => {
+      const pairedCarrier = makeConnection({
+        id: 'conn-inpost-1',
+        platformType: 'inpost',
+        config: { masterCatalogConnectionId: PRESTASHOP_CONNECTION_ID },
+      });
+      capabilitiesById['conn-inpost-1'] = ['ShippingProviderManager'];
+      connectionPort.get.mockResolvedValueOnce(prestashopConnection);
+      connectionPort.list.mockResolvedValueOnce([pairedCarrier, allegroConnection]);
+      integrationsService.getCapabilityAdapter.mockResolvedValueOnce(fullSourceAdapter);
 
-      const promise = controller.getDestinationCarriers('shopify-1');
-      await expect(promise).rejects.toBeInstanceOf(BadRequestException);
-      await expect(promise).rejects.toThrow(/unsupported platform/);
+      await controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID);
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
+        ALLEGRO_CONNECTION_ID,
+        'OrderSource'
+      );
     });
 
-    it('URL is PrestaShop, side=source: ignores Allegro connections paired to other PS instances', async () => {
+    it('URL is PrestaShop, side=source: ignores connections paired to other masters', async () => {
       const otherPaired = makeConnection({
         id: 'allegro-other',
         platformType: 'allegro',
         config: { masterCatalogConnectionId: 'some-other-ps' },
       });
+      capabilitiesById['allegro-other'] = ['OrderSource'];
       connectionPort.get.mockResolvedValueOnce(prestashopConnection);
       connectionPort.list.mockResolvedValueOnce([otherPaired]);
 
-      // Same as zero-paired branch: 400 because no Allegro points at *this* PS.
+      // Same as zero-paired branch: 400 because nothing points at *this* PS.
       await expect(
         controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID)
       ).rejects.toBeInstanceOf(BadRequestException);

--- a/apps/api/src/mappings/http/mapping-options.controller.ts
+++ b/apps/api/src/mappings/http/mapping-options.controller.ts
@@ -72,16 +72,14 @@ import { ICategoriesCacheService } from '../../categories/categories-cache.servi
 import { CATEGORIES_CACHE_SERVICE_TOKEN } from '../../categories/categories.tokens';
 
 /**
- * Mapping-page partner platforms. The mappings UI is Allegro→PrestaShop only
- * today (FE labels say "Allegro status" → "PrestaShop status"). When a third
- * platform pair (Shopify→PS, etc.) gets added, this branching grows; for now
- * the literals match the de-facto convention used elsewhere in the codebase
- * (`Connection.platformType` is `string` per connection.types.ts:15 — once a
- * `PlatformTypeValues as const` lands per engineering-standards.md, swap
- * these literals for the constant references).
+ * Capabilities the resolved partner must advertise per side (#1738). Checked
+ * against adapter metadata (a metadata-only `getAdapter` lookup) so the
+ * resolution is capability-driven — no `platformType` literals — and a
+ * connection that can never serve the requested side fails with a clean 400
+ * instead of a downstream capability-gate error.
  */
-const PLATFORM_ALLEGRO = 'allegro';
-const PLATFORM_PRESTASHOP = 'prestashop';
+const SOURCE_CAPABILITY = 'OrderSource';
+const DESTINATION_CAPABILITY = 'OrderProcessorManager';
 
 type ResolvedSide = 'source' | 'destination';
 
@@ -258,24 +256,23 @@ export class MappingOptionsController {
 
   /**
    * Map the URL connection to the connection that actually carries the
-   * requested side's capability. The mappings page is hard-coded
-   * Allegro→PrestaShop today; the pairing is stored on the Allegro
-   * connection's `config.masterCatalogConnectionId` (set during OAuth).
+   * requested side's capability. Pairing-first + capability-checked (#1738 —
+   * previously a hard-coded Allegro→PrestaShop platform switch): the pairing
+   * key is `config.masterCatalogConnectionId`, stamped on every marketplace /
+   * shop connection that points at a master (Allegro, Erli, WooCommerce).
    *
    * Resolution table:
    *
-   * | URL platform | side          | Returns                                                |
-   * |--------------|---------------|--------------------------------------------------------|
-   * | allegro      | source        | URL connection                                         |
-   * | allegro      | destination   | `config.masterCatalogConnectionId` on URL connection   |
-   * | prestashop   | source        | the active Allegro whose `masterCatalogConnectionId` matches the URL id |
-   * | prestashop   | destination   | URL connection                                         |
-   * | other        | either        | 400 (unsupported platform)                             |
+   * | URL connection            | side        | Returns                                            |
+   * |---------------------------|-------------|-----------------------------------------------------|
+   * | has pairing key (source)  | source      | URL connection (must advertise OrderSource)         |
+   * | has pairing key (source)  | destination | the paired master from the pairing key              |
+   * | no pairing key (master)   | source      | the single active OrderSource paired at the URL id  |
+   * | no pairing key (master)   | destination | URL connection (must advertise OrderProcessorManager) |
    *
-   * Throws `BadRequestException` (NOT 501/404) for "no partner configured"
-   * and "ambiguous partner" — these are operator-input issues, not server
-   * faults, and the FE alert should point the operator at the connection-
-   * edit page rather than leaking internal capability terminology.
+   * Throws `BadRequestException` (NOT 501/404) for "no partner configured",
+   * "ambiguous partner", and "capability missing" — operator-input issues, not
+   * server faults; the FE alert should point at the connection-edit page.
    */
   private async resolvePartnerConnectionId(
     urlConnectionId: string,
@@ -284,59 +281,88 @@ export class MappingOptionsController {
     // ConnectionPort.get throws ConnectionNotFoundException for unknown ids;
     // that propagates through Nest as a 404 — existing behaviour.
     const url = await this.connectionPort.get(urlConnectionId);
+    const pairedMasterId = readMasterCatalogConnectionId(url);
 
-    if (url.platformType === PLATFORM_ALLEGRO) {
-      if (side === 'source') {
+    if (side === 'source') {
+      if (pairedMasterId) {
+        // The URL connection points at a master, so it IS the order source.
+        await this.assertAdvertisesCapability(url, SOURCE_CAPABILITY);
         return url.id;
       }
-      const partnerId = readMasterCatalogConnectionId(url);
-      if (!partnerId) {
-        throw new BadRequestException(
-          `Connection "${url.name}" (${shortId(url.id)}) has no destination paired. ` +
-            `Set the catalog connection on the connection-edit page and try again.`
-        );
-      }
-      return partnerId;
-    }
-
-    if (url.platformType === PLATFORM_PRESTASHOP) {
-      if (side === 'destination') {
-        return url.id;
-      }
-      // Reverse lookup: find the Allegro connection that points at this PS
-      // via `config.masterCatalogConnectionId`. Filter by `status: 'active'`
-      // because a disabled or errored Allegro pairing isn't a real partner —
-      // the mappings page would then call `getCapabilityAdapter` against it
-      // and fail downstream anyway.
+      // The URL connection is a master/destination: reverse-lookup the single
+      // active source paired to it. Filter by `status: 'active'` because a
+      // disabled pairing isn't a real partner, and by advertised capability so
+      // a paired non-source (another shop syncing the same catalog) is never
+      // offered as the source.
       // TODO(#479): when `ConnectionFilters` grows a `configKeyEquals` shape,
-      // push the filter into the repository instead of fetching all active
-      // Allegro connections and filtering in code.
-      const candidates = await this.connectionPort.list({
-        platformType: PLATFORM_ALLEGRO,
-        status: 'active',
-      });
-      const paired = candidates.filter((c) => readMasterCatalogConnectionId(c) === url.id);
+      // push the pairing filter into the repository.
+      const candidates = await this.connectionPort.list({ status: 'active' });
+      const pairedHere = candidates.filter((c) => readMasterCatalogConnectionId(c) === url.id);
+      const paired: Connection[] = [];
+      for (const candidate of pairedHere) {
+        if (await this.advertisesCapability(candidate.id, SOURCE_CAPABILITY)) {
+          paired.push(candidate);
+        }
+      }
       if (paired.length === 0) {
         throw new BadRequestException(
           `Connection "${url.name}" (${shortId(url.id)}) has no source paired. ` +
-            `Open the Allegro connection's edit page and set its catalog to this PrestaShop connection.`
+            `Open the marketplace connection's edit page and set its catalog to this connection.`
         );
       }
       if (paired.length > 1) {
         const ids = paired.map((c) => c.id).join(', ');
         throw new BadRequestException(
-          `Connection "${url.name}" (${shortId(url.id)}) has multiple paired Allegro connections (${ids}). ` +
-            `Multi-source mapping is not yet supported — disable the duplicates on the connection-edit page.`
+          `Connection "${url.name}" (${shortId(url.id)}) has multiple paired source connections (${ids}). ` +
+            `Open the mappings page from the source connection you want to configure.`
         );
       }
       const [only] = paired;
       return only.id;
     }
 
-    throw new BadRequestException(
-      `Connection "${url.name}" (${shortId(url.id)}) has unsupported platform "${url.platformType}" for the mappings page. ` +
-        `Today the mappings page is Allegro→PrestaShop only.`
-    );
+    // side === 'destination'
+    if (pairedMasterId) {
+      return pairedMasterId;
+    }
+    // No pairing key — the URL connection must itself be the destination.
+    await this.assertAdvertisesCapability(url, DESTINATION_CAPABILITY);
+    return url.id;
+  }
+
+  /**
+   * Metadata-only capability probe (`getAdapter` constructs no adapter
+   * instance — same lookup `FulfillmentRoutingService` uses for candidate
+   * enumeration). Returns `false` when the metadata can't be resolved (stale
+   * adapterKey / removed plugin) rather than failing the whole resolution.
+   */
+  private async advertisesCapability(connectionId: string, capability: string): Promise<boolean> {
+    try {
+      const { metadata } = await this.integrationsService.getAdapter(connectionId);
+      return metadata.supportedCapabilities.includes(capability);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * 400 with an operator-facing message when the connection can't serve the
+   * side. Unlike `advertisesCapability`, lifecycle exceptions from `getAdapter`
+   * (ConnectionNotFound → 404, ConnectionDisabled → 409 via the global
+   * `ConnectionExceptionFilter`) propagate unchanged — only a genuinely
+   * missing capability maps to 400.
+   */
+  private async assertAdvertisesCapability(
+    connection: Connection,
+    capability: string
+  ): Promise<void> {
+    const { metadata } = await this.integrationsService.getAdapter(connection.id);
+    if (!metadata.supportedCapabilities.includes(capability)) {
+      throw new BadRequestException(
+        `Connection "${connection.name}" (${shortId(connection.id)}) does not support ${capability}, ` +
+          `so it cannot serve this side of the mappings page.`
+      );
+    }
   }
 }
 

--- a/apps/web/src/features/mappings/components/routing-rules-panel.test.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.test.tsx
@@ -162,4 +162,97 @@ describe('RoutingRulesPanel', () => {
     });
     expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument();
   });
+
+  describe('routing-split bar (#1739)', () => {
+    function legendEntry(container: HTMLElement, label: string): HTMLElement {
+      const entry = Array.from(
+        container.querySelectorAll<HTMLElement>('.routing-split__key'),
+      ).find((el) => (el.textContent ?? '').includes(label));
+      if (!entry) throw new Error(`No legend entry for ${label}`);
+      return entry;
+    }
+
+    it('counts saved rules per processor with the rest in the default bucket', async () => {
+      const rules: RoutingRule[] = [
+        {
+          id: 'r1',
+          sourceConnectionId: 'conn_1',
+          sourceDeliveryMethodId: 'm1',
+          processorKind: 'ol_managed_carrier',
+          processorConnectionId: 'conn_inpost',
+        },
+      ];
+      const { container } = renderWithProviders(
+        <RoutingRulesPanel
+          connectionId="conn_1"
+          deliveryMethods={DELIVERY_METHODS}
+          deliveryMethodsLoading={false}
+          deliveryMethodsError={null}
+        />,
+        { apiClient: buildApiClient({ rules }) },
+      );
+
+      await screen.findByRole('combobox', {
+        name: /Fulfillment processor for InPost Paczkomat/i,
+      });
+      await waitFor(() => {
+        expect(legendEntry(container, 'InPost')).toHaveTextContent('1');
+      });
+      // m2 has no rule → default bucket, labeled from the omp candidate.
+      expect(legendEntry(container, 'My Shop')).toHaveTextContent('1');
+    });
+
+    it('recomputes the split live when a selection changes, before saving', async () => {
+      const { container } = renderWithProviders(
+        <RoutingRulesPanel
+          connectionId="conn_1"
+          deliveryMethods={DELIVERY_METHODS}
+          deliveryMethodsLoading={false}
+          deliveryMethodsError={null}
+        />,
+        { apiClient: buildApiClient() },
+      );
+
+      const select = await screen.findByRole('combobox', {
+        name: /Fulfillment processor for InPost Paczkomat/i,
+      });
+      await waitFor(() => {
+        expect(legendEntry(container, 'My Shop')).toHaveTextContent('2');
+      });
+
+      fireEvent.change(select, { target: { value: 'ol_managed_carrier::conn_inpost' } });
+
+      expect(legendEntry(container, 'InPost')).toHaveTextContent('1');
+      expect(legendEntry(container, 'My Shop')).toHaveTextContent('1');
+      // Live preview only — nothing saved yet.
+      expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+    });
+
+    it('renders Erli-shaped string method ids and saves their rules through the same flow', async () => {
+      const erliMethods: MappingOption[] = [
+        { value: 'erliPaczkomat', label: 'ERLI InPost Paczkomaty 24/7' },
+        { value: 'dpdCod', label: 'Kurier DPD Pobranie' },
+      ];
+      const replace = vi.fn().mockResolvedValue([]);
+      renderPanel(buildApiClient({ replace }), { deliveryMethods: erliMethods });
+
+      const select = await screen.findByRole('combobox', {
+        name: /Fulfillment processor for ERLI InPost Paczkomaty/i,
+      });
+      fireEvent.change(select, { target: { value: 'ol_managed_carrier::conn_inpost' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save routing' }));
+
+      await waitFor(() => {
+        expect(replace).toHaveBeenCalledWith('conn_1', {
+          items: [
+            {
+              sourceDeliveryMethodId: 'erliPaczkomat',
+              processorKind: 'ol_managed_carrier',
+              processorConnectionId: 'conn_inpost',
+            },
+          ],
+        });
+      });
+    });
+  });
 });

--- a/apps/web/src/features/mappings/components/routing-rules-panel.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.tsx
@@ -15,6 +15,7 @@ import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 
 import { Button } from '../../../shared/ui/button';
 import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import { ConnectionEntityLabel, useConnectionsQuery } from '../../connections';
+import { RoutingSplitBar, type RoutingSplitBucket } from './routing-split-bar';
 import {
   useRoutingRulesQuery,
   useRoutingCandidatesQuery,
@@ -142,6 +143,45 @@ export function RoutingRulesPanel({
     (m) => (selections[m.value] ?? DEFAULT_KEY) !== (savedKeyByMethod.get(m.value) ?? DEFAULT_KEY),
   );
 
+  // Routing-split buckets (#1739): methods-per-processor derived from the
+  // CURRENT selections (not the saved rules), so the bar moves live while the
+  // operator edits and before "Save routing". One bucket per live divert
+  // candidate (kept even at 0 so its colour slot stays stable), one bucket per
+  // saved-but-unavailable selection, and the default bucket last.
+  const splitBuckets = useMemo<RoutingSplitBucket[]>(() => {
+    const nameFor = (id: string): string => connectionNameById.get(id) ?? shortValue(id);
+    const counts = new Map<string, number>();
+    for (const method of rowMethods) {
+      const key = selections[method.value] ?? DEFAULT_KEY;
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    const buckets: RoutingSplitBucket[] = candidates
+      .filter((c) => c.processorKind !== 'omp_fulfilled')
+      .map((c) => {
+        const key = `${c.processorKind}::${c.processorConnectionId}`;
+        return { key, label: nameFor(c.processorConnectionId), count: counts.get(key) ?? 0 };
+      });
+
+    for (const [key, count] of counts) {
+      if (key === DEFAULT_KEY || buckets.some((b) => b.key === key)) continue;
+      const parsed = parseSelectionKey(key);
+      buckets.push({
+        key,
+        label: parsed ? `${nameFor(parsed.connectionId)} (unavailable)` : key,
+        count,
+      });
+    }
+
+    buckets.push({
+      key: DEFAULT_KEY,
+      label: defaultLabel,
+      count: counts.get(DEFAULT_KEY) ?? 0,
+      isDefault: true,
+    });
+    return buckets;
+  }, [rowMethods, selections, candidates, defaultLabel, connectionNameById]);
+
   function optionsForRow(currentKey: string): DivertOption[] {
     const base: DivertOption[] = [{ key: DEFAULT_KEY, label: defaultLabel }, ...divertOptions];
     // Keep a saved selection visible even when it is no longer a live candidate
@@ -253,6 +293,8 @@ export function RoutingRulesPanel({
           default until you add a carrier-managed or marketplace-delivery connection.
         </p>
       )}
+
+      {rowMethods.length > 0 && <RoutingSplitBar buckets={splitBuckets} />}
 
       {rowMethods.length === 0 ? (
         <p className="muted-text" role="status" aria-live="polite">

--- a/apps/web/src/features/mappings/components/routing-split-bar.test.tsx
+++ b/apps/web/src/features/mappings/components/routing-split-bar.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * RoutingSplitBar tests (#1739)
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RoutingSplitBar, type RoutingSplitBucket } from './routing-split-bar';
+
+function buckets(overrides: Partial<RoutingSplitBucket>[] = []): RoutingSplitBucket[] {
+  const base: RoutingSplitBucket[] = [
+    { key: 'ol_managed_carrier::conn_inpost', label: 'InPost Sandbox', count: 5 },
+    { key: 'ol_managed_carrier::conn_dpd', label: 'DPD Sandbox', count: 2 },
+    { key: '__default__', label: 'My Shop - default', count: 4, isDefault: true },
+  ];
+  return base.map((bucket, i) => ({ ...bucket, ...overrides[i] }));
+}
+
+describe('RoutingSplitBar', () => {
+  afterEach(cleanup);
+
+  it('renders one legend entry per bucket with its label and count', () => {
+    render(<RoutingSplitBar buckets={buckets()} />);
+
+    expect(screen.getByText('InPost Sandbox')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('DPD Sandbox')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('My Shop - default')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('renders bar segments only for buckets with a non-zero count, sized by count', () => {
+    const { container } = render(
+      <RoutingSplitBar buckets={buckets([{}, { count: 0 }, {}])} />,
+    );
+
+    const segments = container.querySelectorAll('.routing-split__seg');
+    expect(segments).toHaveLength(2);
+    expect((segments[0] as HTMLElement).style.flexGrow).toBe('5');
+    expect((segments[1] as HTMLElement).style.flexGrow).toBe('4');
+    // The zero-count bucket keeps its legend entry (colour slot stays stable).
+    expect(screen.getByText('DPD Sandbox')).toBeInTheDocument();
+  });
+
+  it('renders nothing when every bucket is empty', () => {
+    const { container } = render(
+      <RoutingSplitBar buckets={buckets([{ count: 0 }, { count: 0 }, { count: 0 }])} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('keeps the proportion bar decorative and the counts readable as text', () => {
+    const { container } = render(<RoutingSplitBar buckets={buckets()} />);
+
+    expect(container.querySelector('.routing-split__bar')).toHaveAttribute('aria-hidden', 'true');
+    const legend = container.querySelector('.routing-split__legend');
+    expect(legend).toHaveTextContent('InPost Sandbox 5');
+  });
+});

--- a/apps/web/src/features/mappings/components/routing-split-bar.tsx
+++ b/apps/web/src/features/mappings/components/routing-split-bar.tsx
@@ -1,0 +1,87 @@
+/**
+ * RoutingSplitBar (#1739)
+ *
+ * Segmented proportion bar for the Fulfillment tab: shows how many delivery
+ * methods route to each fulfillment processor, including the default bucket
+ * (methods with no rule). A pure derived view — the panel recomputes buckets
+ * from its unsaved selections, so the bar moves before "Save routing".
+ *
+ * Accessibility: the bar itself is decorative (`aria-hidden`); the legend
+ * carries every label + count as text.
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+
+import type { ReactElement } from 'react';
+import { tokens } from '../../../shared/theme/tokens';
+
+export interface RoutingSplitBucket {
+  /** Stable bucket key (processor selection key or the default sentinel). */
+  key: string;
+  /** Legend label (connection name; the default bucket uses the panel's default label). */
+  label: string;
+  /** How many delivery methods currently route to this bucket. */
+  count: number;
+  /** True for the "no rule → default OMP" bucket — rendered in the muted series colour. */
+  isDefault?: boolean;
+}
+
+const SERIES_TOKENS = [
+  tokens['viz-cat-1'],
+  tokens['viz-cat-2'],
+  tokens['viz-cat-3'],
+  tokens['viz-cat-4'],
+] as const;
+
+/** Series colour per bucket: muted for the default bucket, cycling palette otherwise. */
+function bucketColor(bucket: RoutingSplitBucket, seriesIndex: number): string {
+  if (bucket.isDefault) {
+    return tokens['viz-cat-muted'];
+  }
+  return SERIES_TOKENS[seriesIndex % SERIES_TOKENS.length];
+}
+
+interface RoutingSplitBarProps {
+  buckets: RoutingSplitBucket[];
+}
+
+export function RoutingSplitBar({ buckets }: RoutingSplitBarProps): ReactElement | null {
+  const total = buckets.reduce((sum, bucket) => sum + bucket.count, 0);
+  if (total === 0) {
+    return null;
+  }
+
+  // Colour is assigned by position among non-default buckets so it stays
+  // stable when counts change (a bucket dropping to 0 keeps its slot).
+  let seriesIndex = -1;
+  const coloured = buckets.map((bucket) => {
+    if (!bucket.isDefault) {
+      seriesIndex += 1;
+    }
+    return { bucket, color: bucketColor(bucket, Math.max(seriesIndex, 0)) };
+  });
+
+  return (
+    <div className="routing-split">
+      <div className="routing-split__bar" aria-hidden="true">
+        {coloured
+          .filter(({ bucket }) => bucket.count > 0)
+          .map(({ bucket, color }) => (
+            <div
+              key={bucket.key}
+              className="routing-split__seg"
+              style={{ flexGrow: bucket.count, background: color }}
+            />
+          ))}
+      </div>
+      <div className="routing-split__legend" aria-label="Delivery methods per fulfillment processor">
+        {coloured.map(({ bucket, color }) => (
+          <span key={bucket.key} className="routing-split__key">
+            <span className="routing-split__swatch" style={{ background: color }} aria-hidden="true" />
+            {bucket.label} <span className="routing-split__count">{bucket.count}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -268,6 +268,17 @@
   --status-info-fg: oklch(40% 0.12 245);
   --status-info-strong: oklch(40% 0.12 245);
 
+  /* ── Viz: categorical series (#1739) ──────────────────────────────────
+   * Small categorical palette for proportion visuals (routing-split bar).
+   * NOT status hues — a series colour distinguishes entities (carriers,
+   * connections), never encodes health. `--viz-cat-muted` is the neutral
+   * "default / unassigned" bucket. */
+  --viz-cat-1: oklch(75% 0.13 85);
+  --viz-cat-2: oklch(60% 0.15 20);
+  --viz-cat-3: oklch(58% 0.12 245);
+  --viz-cat-4: oklch(60% 0.13 150);
+  --viz-cat-muted: oklch(82% 0.008 80);
+
   /* ── Status: review / manual ──────────────────────────────────────── */
   --status-review: oklch(58% 0.16 290);
   --status-review-soft: oklch(96% 0.04 290);
@@ -430,6 +441,13 @@ html[data-theme='dark'] {
   --status-info-border: oklch(36% 0.10 245);
   --status-info-fg: oklch(86% 0.12 245);
   --status-info-strong: oklch(86% 0.12 245);
+
+  /* Viz — categorical series (#1739) */
+  --viz-cat-1: oklch(70% 0.12 85);
+  --viz-cat-2: oklch(62% 0.14 20);
+  --viz-cat-3: oklch(62% 0.11 245);
+  --viz-cat-4: oklch(62% 0.12 150);
+  --viz-cat-muted: oklch(42% 0.008 80);
 
   /* Status — review */
   --status-review: oklch(74% 0.14 290);
@@ -13522,4 +13540,58 @@ input.bulk-dispatch__num--wide {
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-muted);
+}
+
+/* ── RoutingSplitBar (#1739) ──────────────────────────────────────────
+ * Segmented proportion bar on the Fulfillment tab: how many delivery
+ * methods route to each processor, recomputed live from unsaved edits.
+ * The bar is decorative (aria-hidden); the legend carries the counts. */
+.routing-split {
+  margin-bottom: var(--space-4);
+}
+
+.routing-split__bar {
+  display: flex;
+  height: 10px;
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  border: 1px solid var(--border-default);
+}
+
+.routing-split__seg {
+  transition: flex-grow var(--duration-normal) ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .routing-split__seg {
+    transition: none;
+  }
+}
+
+.routing-split__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-4);
+  margin-top: var(--space-2);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.routing-split__key {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.routing-split__swatch {
+  width: 9px;
+  height: 9px;
+  border-radius: 3px;
+  flex: none;
+}
+
+.routing-split__count {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
 }

--- a/apps/web/src/shared/theme/tokens.ts
+++ b/apps/web/src/shared/theme/tokens.ts
@@ -141,6 +141,13 @@ export const tokens = {
   'status-info-border': 'var(--status-info-border)',
   'status-info-fg': 'var(--status-info-fg)',
 
+  // ── Viz — categorical series (#1739) ─────────────────────────────
+  'viz-cat-1': 'var(--viz-cat-1)',
+  'viz-cat-2': 'var(--viz-cat-2)',
+  'viz-cat-3': 'var(--viz-cat-3)',
+  'viz-cat-4': 'var(--viz-cat-4)',
+  'viz-cat-muted': 'var(--viz-cat-muted)',
+
   // ── Status — review (manual review / pending operator action) ───
   'status-review': 'var(--status-review)',
   'status-review-strong': 'var(--status-review-strong)',

--- a/docs/plans/implementation-plan-erli-fulfillment-routing.md
+++ b/docs/plans/implementation-plan-erli-fulfillment-routing.md
@@ -1,0 +1,56 @@
+# Implementation Plan - Erli Fulfillment Routing (#1738 + #1739)
+
+## 1. Goal
+
+Make fulfillment routing work end-to-end for Erli order sources (not only Allegro -> PrestaShop), and give the Fulfillment tab a live routing-split bar.
+
+- Backend (#1738): Erli order mapper emits `shipping.methodId`; `ErliOrderSourceAdapter` implements `SourceOptionsReader`; `MappingOptionsController.resolvePartnerConnectionId` becomes pairing/capability-driven (no platform literals).
+- Frontend (#1739): new `RoutingSplitBar` in the Fulfillment tab, recomputed live from unsaved selections; Erli renders through the existing capability-gated panel.
+
+Non-goals: weight-tier grouping of Erli methods, "Refresh from Erli" button, backfill of historical Erli order snapshots, Erli manifest capability advert (Allegro does not advertise `SourceOptionsReader` either - the `isSourceOptionsReader` guard is the functional gate; keeping manifests consistent).
+
+## 2. Research (verified live, 2026-07-20)
+
+- `IncomingOrder.shipping?: OrderShipping { methodId, methodName? }` exists (`libs/core/src/orders/domain/types/order.types.ts:161`); Allegro sets it, Erli drops `delivery.typeId/name` on the floor (`erli-order.mapper.ts`).
+- `SourceOptionsReader` = `listOrderStatuses/listDeliveryMethods/listPaymentMethods` (`source-options-reader.capability.ts`).
+- Erli sandbox confirmed: `GET /dictionaries/deliveryMethods` (114 `{id,name,cod,vendor}`), `GET /delivery/priceListsDetails` (`prices[].deliveryMethod.id` = shop-active method ids). `ErliOfferManagerAdapter.listDeliveryPriceLists` already consumes `delivery/priceLists` via the shared `IErliHttpClient` (paths WITHOUT leading slash).
+- `resolvePartnerConnectionId` (`apps/api/src/mappings/http/mapping-options.controller.ts:280+`) hardcodes allegro/prestashop; pairing key `config.masterCatalogConnectionId` is set on Allegro, Erli, and WooCommerce connections alike.
+- FE panel `routing-rules-panel.tsx` is capability-gated on `OrderSource` already; the only Erli blocker is the options endpoint.
+
+## 3. Design
+
+### BE
+
+1. **Mapper**: `mapErliOrderToIncomingOrder` emits `shipping` (present-only) from `delivery.typeId` + `delivery.name`.
+2. **Adapter**: `ErliOrderSourceAdapter implements ..., SourceOptionsReader`:
+   - `listDeliveryMethods()`: fetch price-list details (active ids) + dictionary (labels); return intersection as `MappingOption[]` (label falls back to the raw id when the dictionary misses it). Non-array bodies raise `ErliApiException` (no PII).
+   - `listOrderStatuses()`: static 4-value list from the Erli status enum.
+   - `listPaymentMethods()`: static `online` / `cod` (Erli exposes no payment-method vocabulary; COD is a boolean on delivery).
+   - New wire types + paths in `erli-delivery.types.ts`.
+3. **Controller**: `resolvePartnerConnectionId` rewritten pairing-first, capability-checked:
+   - source side: URL has `masterCatalogConnectionId` -> the URL is the source (verify metadata advertises `OrderSource`, else 400). Otherwise reverse-lookup active connections whose pairing key points at the URL and whose metadata advertises `OrderSource`; 0 -> 400, >1 -> 400 (open the page from the source connection), 1 -> id.
+   - destination side: URL has pairing key -> return it; else the URL must itself advertise `OrderProcessorManager` (400 otherwise).
+   - No `platformType` literals; metadata via `integrationsService.getAdapter` (metadata-only lookup, same as `FulfillmentRoutingService`).
+   - Behavior change (accepted): a destination URL paired to BOTH Allegro and Erli now 400s as ambiguous instead of silently picking Allegro - genuinely ambiguous under multi-source.
+
+### FE
+
+4. **`routing-split-bar.tsx`** (`features/mappings/components/`): pure view of `{ label, count, colorIndex }` buckets; segmented flex bar (aria-hidden) + text legend with counts (`tabular-nums`); segment colors from new `--viz-cat-*` tokens (index.css + tokens.ts, drift check); `prefers-reduced-motion` respected.
+5. **Panel wiring**: `RoutingRulesPanel` derives buckets from `selections` + `rowMethods` (default bucket = methods without a rule, labeled with the existing `defaultLabel`), renders the bar between description and table.
+
+## 4. Steps
+
+1. `erli-order.mapper.ts` + `erli-order.mapper.spec.ts` - shipping emission (with/without typeId).
+2. `erli-delivery.types.ts` (new) - wire types + path consts.
+3. `erli-order-source.adapter.ts` + spec - SourceOptionsReader.
+4. `mapping-options.controller.ts` - pairing/capability resolution; new `mapping-options.controller.spec.ts` covering allegro-source, erli-source, prestashop-reverse (single + ambiguous), unsupported (no capability).
+5. `routing-split-bar.tsx` + `routing-split-bar.test.tsx`; CSS section + tokens.
+6. `routing-rules-panel.tsx` + test extension (live recompute, Erli-shaped string ids).
+7. Quality gate: lint, type-check, scoped tests (erli, api, web) then full `pnpm test`.
+
+## 5. Validation
+
+- Hexagonal: adapter change stays in the Erli plugin; controller stays interface-layer; no CORE edits needed.
+- Naming: `*.types.ts` for wire shapes; component kebab-case; tests colocated.
+- Security: no PII in logs (adapter follows existing no-payload-logging rule); read-only endpoints unchanged in auth posture.
+- Pre-implement gate: run as in-session self-gate (greps above + live-code facts gathered this session); full /pre-implement skipped deliberately - all touched surfaces were read in this session at HEAD.

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts
@@ -297,6 +297,86 @@ describe('ErliOrderSourceAdapter', () => {
     });
   });
 
+  describe('SourceOptionsReader (#1738)', () => {
+    const DICT_PATH = 'dictionaries/deliveryMethods';
+    const DETAILS_PATH = 'delivery/priceListsDetails';
+
+    function mockDeliveryEndpoints(details: unknown, dictionary: unknown): void {
+      client.get.mockImplementation((path: string) => {
+        if (path === DETAILS_PATH) return Promise.resolve(ok(details));
+        if (path === DICT_PATH) return Promise.resolve(ok(dictionary));
+        return Promise.reject(new Error(`unexpected path: ${path}`));
+      });
+    }
+
+    it('should list the four documented Erli order statuses', async () => {
+      const statuses = await adapter.listOrderStatuses();
+      expect(statuses.map((s) => s.value)).toEqual([
+        'pending',
+        'purchased',
+        'cancelled',
+        'returned',
+      ]);
+    });
+
+    it('should list the two derivable payment methods (online + cod)', async () => {
+      const methods = await adapter.listPaymentMethods();
+      expect(methods.map((m) => m.value)).toEqual(['online', 'cod']);
+    });
+
+    it('should return active price-list methods labelled from the dictionary when both endpoints respond', async () => {
+      mockDeliveryEndpoints(
+        [
+          {
+            id: 298891,
+            name: 'Demo cennik',
+            prices: [
+              { deliveryMethod: { id: 'erliPaczkomat' } },
+              { deliveryMethod: { id: 'dpd' } },
+              // Duplicate across price rows — must dedupe by value.
+              { deliveryMethod: { id: 'erliPaczkomat' } },
+            ],
+          },
+        ],
+        [
+          { id: 'erliPaczkomat', name: 'ERLI InPost Paczkomaty 24/7', cod: false, vendor: 'inpost' },
+          { id: 'dpd', name: 'Kurier DPD', cod: false, vendor: 'dpd' },
+          { id: 'ups', name: 'Kurier UPS', cod: false, vendor: 'ups' },
+        ],
+      );
+
+      await expect(adapter.listDeliveryMethods()).resolves.toEqual([
+        { value: 'erliPaczkomat', label: 'ERLI InPost Paczkomaty 24/7' },
+        { value: 'dpd', label: 'Kurier DPD' },
+      ]);
+    });
+
+    it('should fall back to the raw method id when the dictionary misses it', async () => {
+      mockDeliveryEndpoints(
+        [{ id: 1, prices: [{ deliveryMethod: { id: 'someNewMethod' } }] }],
+        [],
+      );
+
+      await expect(adapter.listDeliveryMethods()).resolves.toEqual([
+        { value: 'someNewMethod', label: 'someNewMethod' },
+      ]);
+    });
+
+    it('should return empty when the shop has no price lists', async () => {
+      mockDeliveryEndpoints([], [{ id: 'dpd', name: 'Kurier DPD' }]);
+
+      await expect(adapter.listDeliveryMethods()).resolves.toEqual([]);
+    });
+
+    it('should throw ErliApiException when either delivery endpoint returns a non-array body', async () => {
+      mockDeliveryEndpoints({ message: 'No route' }, []);
+      await expect(adapter.listDeliveryMethods()).rejects.toThrow(ErliApiException);
+
+      mockDeliveryEndpoints([], { message: 'No route' });
+      await expect(adapter.listDeliveryMethods()).rejects.toThrow(ErliApiException);
+    });
+  });
+
   describe('getOrder', () => {
     it('should fetch the order and return mapErliOrderToIncomingOrder output (#994 composition)', async () => {
       client.get.mockResolvedValue(ok(buildErliOrder()));

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order.mapper.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order.mapper.spec.ts
@@ -55,6 +55,33 @@ function buildErliOrder(overrides: Partial<ErliOrder> = {}): ErliOrder {
 }
 
 describe('mapErliOrderToIncomingOrder', () => {
+  it('should map delivery.typeId and name onto the neutral shipping reference when present', () => {
+    const result = mapErliOrderToIncomingOrder(
+      buildErliOrder({
+        delivery: { name: 'ERLI InPost Paczkomaty 24/7', typeId: 'erliPaczkomat', cod: false },
+      }),
+    );
+
+    expect(result.shipping).toEqual({
+      methodId: 'erliPaczkomat',
+      methodName: 'ERLI InPost Paczkomaty 24/7',
+    });
+  });
+
+  it('should keep shipping absent when delivery carries no typeId', () => {
+    const result = mapErliOrderToIncomingOrder(buildErliOrder({ delivery: { cod: false } }));
+
+    expect(result.shipping).toBeUndefined();
+  });
+
+  it('should omit methodName when delivery has a typeId but no name', () => {
+    const result = mapErliOrderToIncomingOrder(
+      buildErliOrder({ delivery: { typeId: 'dpd', cod: false } }),
+    );
+
+    expect(result.shipping).toEqual({ methodId: 'dpd' });
+  });
+
   it('should map a COD purchased order to processing + paymentStatus cod', () => {
     const result = mapErliOrderToIncomingOrder(
       buildErliOrder({ status: 'purchased', delivery: { cod: true } }),

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-delivery.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-delivery.types.ts
@@ -1,0 +1,54 @@
+/**
+ * Erli Delivery Dictionary Wire Shapes (#1738)
+ *
+ * Wire types + path constants for the two read-only delivery endpoints backing
+ * `ErliOrderSourceAdapter`'s `SourceOptionsReader.listDeliveryMethods`:
+ *
+ *  - `GET /dictionaries/deliveryMethods` — the FULL platform dictionary
+ *    (~114 entries `{ id, name, cod, vendor }`); ids are the same tokens Erli
+ *    stamps on orders as `delivery.typeId` (e.g. `erliPaczkomat`, `dpdCod`).
+ *  - `GET /delivery/priceListsDetails` — the seller's active price lists; each
+ *    `prices[].deliveryMethod.id` names a method the shop actually offers, so
+ *    the intersection with the dictionary is the set of methods an order can
+ *    arrive with.
+ *
+ * Both shapes verified against the live sandbox (`sandbox.erli.dev`) on
+ * 2026-07-20. Note: the sibling `GET /delivery/priceLists` (id+name only) is
+ * consumed by `ErliOfferManagerAdapter.listDeliveryPriceLists` (#1530) via
+ * `ErliDeliveryPriceListItem` in `erli-product.types.ts` — a different, offer-
+ * creation-scoped concern; this file owns only the routing-options shapes.
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters
+ */
+
+/** `GET /dictionaries/deliveryMethods` — full platform delivery-method dictionary. */
+export const ERLI_DELIVERY_METHODS_DICT_PATH = 'dictionaries/deliveryMethods';
+
+/** `GET /delivery/priceListsDetails` — the seller's active price lists with per-method prices. */
+export const ERLI_PRICE_LISTS_DETAILS_PATH = 'delivery/priceListsDetails';
+
+/** One entry of the platform delivery-method dictionary. */
+export interface ErliDeliveryMethodDictEntry {
+  /** Stable method token — identical to `ErliOrderDelivery.typeId` on orders. */
+  id: string;
+  /** Operator-facing display name (repeats across weight tiers of one method family). */
+  name: string;
+  /** Whether the method is a cash-on-delivery variant. */
+  cod?: boolean;
+  /** Carrier vendor token (`inpost`, `dpd`, `dhl`, …). */
+  vendor?: string;
+}
+
+/** One per-method price row inside a price list. Only the method id is consumed. */
+export interface ErliPriceListPriceEntry {
+  deliveryMethod?: {
+    id?: string;
+  };
+}
+
+/** One seller price list with its per-method price rows. */
+export interface ErliPriceListDetails {
+  id: number;
+  name?: string;
+  prices?: ErliPriceListPriceEntry[];
+}

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-order-source.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-order-source.adapter.ts
@@ -73,10 +73,12 @@
  * @module libs/integrations/erli/src/infrastructure/adapters
  * @implements {OrderSourcePort}
  * @implements {OrderStatusWriteback}
+ * @implements {SourceOptionsReader}
  */
 import type {
   DispatchCarrierHint,
   IncomingOrder,
+  MappingOption,
   OrderFeedEventType,
   OrderFeedInput,
   OrderFeedItem,
@@ -85,6 +87,7 @@ import type {
   OrderSourcePort,
   OrderStatusWriteback,
   OrderWritebackResult,
+  SourceOptionsReader,
 } from '@openlinker/core/orders';
 import type { IInventoryQueryService } from '@openlinker/core/inventory';
 import type {
@@ -116,6 +119,12 @@ import {
   type ErliInboxMarkReadRequest,
   type ErliInboxMessage,
 } from './erli-inbox.types';
+import {
+  ERLI_DELIVERY_METHODS_DICT_PATH,
+  ERLI_PRICE_LISTS_DETAILS_PATH,
+  type ErliDeliveryMethodDictEntry,
+  type ErliPriceListDetails,
+} from './erli-delivery.types';
 
 /** The two order-relevant inbox event literals (#992 / Q-INBOX-3). */
 const ERLI_ORDER_EVENT_TYPES: ReadonlySet<string> = new Set([
@@ -130,7 +139,17 @@ const ERLI_ORDER_STATUSES: ReadonlySet<ErliOrderStatus> = new Set<ErliOrderStatu
   'returned',
 ]);
 
-export class ErliOrderSourceAdapter implements OrderSourcePort, OrderStatusWriteback {
+/** Operator-facing labels for the Erli order-status enum (SourceOptionsReader). */
+const ERLI_ORDER_STATUS_LABELS: ReadonlyArray<{ value: ErliOrderStatus; label: string }> = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'purchased', label: 'Purchased' },
+  { value: 'cancelled', label: 'Cancelled' },
+  { value: 'returned', label: 'Returned' },
+];
+
+export class ErliOrderSourceAdapter
+  implements OrderSourcePort, OrderStatusWriteback, SourceOptionsReader
+{
   private readonly logger = new Logger(ErliOrderSourceAdapter.name);
 
   /**
@@ -275,6 +294,95 @@ export class ErliOrderSourceAdapter implements OrderSourcePort, OrderStatusWrite
 
     const order = assertErliOrder(response.data);
     return mapErliOrderToIncomingOrder(order);
+  }
+
+  // ── SourceOptionsReader (#1738) ──────────────────────────────────────────
+  // Populates the source-side dropdowns of the connection-mappings page
+  // (`MappingOptionsController` narrows via `isSourceOptionsReader`). Mirrors
+  // the Allegro shape: statuses + payment methods are static documented
+  // vocabularies; delivery methods are the only live lookup.
+
+  /** Static list from the documented Erli order-status enum (`erli-order.types.ts`). */
+  listOrderStatuses(): Promise<MappingOption[]> {
+    return Promise.resolve(ERLI_ORDER_STATUS_LABELS.map(({ value, label }) => ({ value, label })));
+  }
+
+  /**
+   * Erli exposes no payment-method vocabulary — payment is derivable only from
+   * the `delivery.cod` boolean on orders (see `derivePaymentStatus` in the
+   * mapper). The two derivable values are surfaced so operators can still map
+   * COD vs online if a destination needs it.
+   */
+  listPaymentMethods(): Promise<MappingOption[]> {
+    return Promise.resolve([
+      { value: 'online', label: 'Online payment' },
+      { value: 'cod', label: 'Cash on delivery' },
+    ]);
+  }
+
+  /**
+   * Live lookup: the shop's ACTIVE delivery methods — the intersection of the
+   * seller's price lists (`GET /delivery/priceListsDetails`, the methods orders
+   * can actually arrive with) and the platform dictionary
+   * (`GET /dictionaries/deliveryMethods`, the labels). Returned `value`s are the
+   * same tokens Erli stamps on orders as `delivery.typeId`, i.e. the routing-rule
+   * lookup keys. A method missing from the dictionary keeps its raw id as the
+   * label (best-effort). Deduped by value; price-list order preserved.
+   */
+  async listDeliveryMethods(): Promise<MappingOption[]> {
+    const [priceLists, dictionary] = await Promise.all([
+      this.fetchPriceListDetails(),
+      this.fetchDeliveryMethodDictionary(),
+    ]);
+
+    const labelById = new Map(dictionary.map((entry) => [entry.id, entry.name]));
+
+    const options: MappingOption[] = [];
+    const seen = new Set<string>();
+    for (const priceList of priceLists) {
+      for (const price of priceList.prices ?? []) {
+        const methodId = price.deliveryMethod?.id;
+        if (!methodId || seen.has(methodId)) {
+          continue;
+        }
+        seen.add(methodId);
+        options.push({ value: methodId, label: labelById.get(methodId) ?? methodId });
+      }
+    }
+
+    if (options.length === 0) {
+      this.logger.warn(
+        `Erli returned no active delivery methods for connection ${this.connectionId} — ` +
+          `listDeliveryMethods is empty. Operator likely needs to configure a price list first.`,
+      );
+    }
+    return options;
+  }
+
+  /** `GET /delivery/priceListsDetails` with an array-shape guard (no PII bodies logged). */
+  private async fetchPriceListDetails(): Promise<ErliPriceListDetails[]> {
+    const response = await this.httpClient.get<unknown>(ERLI_PRICE_LISTS_DETAILS_PATH);
+    if (!Array.isArray(response.data)) {
+      throw new ErliApiException(
+        'Erli price-lists-details response is not an array',
+        response.status,
+      );
+    }
+    return response.data as ErliPriceListDetails[];
+  }
+
+  /** `GET /dictionaries/deliveryMethods` with an array-shape guard; drops malformed entries. */
+  private async fetchDeliveryMethodDictionary(): Promise<ErliDeliveryMethodDictEntry[]> {
+    const response = await this.httpClient.get<unknown>(ERLI_DELIVERY_METHODS_DICT_PATH);
+    if (!Array.isArray(response.data)) {
+      throw new ErliApiException(
+        'Erli delivery-methods dictionary response is not an array',
+        response.status,
+      );
+    }
+    return (response.data as ErliDeliveryMethodDictEntry[]).filter(
+      (entry) => typeof entry?.id === 'string' && typeof entry?.name === 'string',
+    );
   }
 
   /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-order.mapper.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-order.mapper.ts
@@ -36,6 +36,7 @@ import type {
   IncomingOrderTotals,
   OrderPickupPoint,
   OrderPickupPointType,
+  OrderShipping,
   OrderStatus,
   PaymentStatus,
 } from '@openlinker/core/orders';
@@ -43,6 +44,7 @@ import type {
 import type {
   ErliOrder,
   ErliOrderAddress,
+  ErliOrderDelivery,
   ErliOrderItem,
   ErliOrderPickupPlace,
   ErliOrderStatus,
@@ -72,6 +74,7 @@ export function mapErliOrderToIncomingOrder(order: ErliOrder): IncomingOrder {
     totals: mapTotals(order),
     shippingAddress: mapAddress(order.user.deliveryAddress),
     billingAddress: mapAddress(order.user.invoiceAddress),
+    shipping: mapShipping(order.delivery),
     pickupPoint: mapPickupPoint(order.delivery.pickupPlace),
     paymentStatus: derivePaymentStatus(order.status, order.delivery.cod),
     placedAt: order.purchasedAt,
@@ -184,6 +187,25 @@ function mapTotals(order: ErliOrder): IncomingOrderTotals {
 /** Round a monetary amount to 2 decimals (guards IEEE-754 residue). */
 function round2(value: number): number {
   return Math.round(value * 100) / 100;
+}
+
+/**
+ * Maps Erli's `delivery.typeId`/`name` onto the neutral `OrderShipping`
+ * reference (#1738). `methodId` is the routing-rule lookup key consumed by
+ * `FulfillmentRoutingService.resolve` (via the order snapshot), so an Erli
+ * order can divert to an OL-managed carrier per delivery method exactly like
+ * an Allegro order. Returns `undefined` when Erli reports no `typeId` (older
+ * orders / edge payloads) so the optional `shipping` key stays absent and
+ * routing falls back to the omp_fulfilled default.
+ */
+function mapShipping(delivery: ErliOrderDelivery): OrderShipping | undefined {
+  if (!delivery.typeId) {
+    return undefined;
+  }
+  return {
+    methodId: delivery.typeId,
+    ...(delivery.name !== undefined && { methodName: delivery.name }),
+  };
 }
 
 /**


### PR DESCRIPTION
## What & why

Fulfillment routing was effectively Allegro-only: Erli orders carried no delivery-method key, the source-options endpoints hardcoded `allegro`/`prestashop`, and routing rules written for an Erli connection could never fire. This PR makes the whole path work for Erli (and any future `OrderSource`) and adds the approved routing-split bar to the Fulfillment tab.

### Backend (#1738)
- `erli-order.mapper.ts` emits the neutral `shipping { methodId, methodName }` from `delivery.typeId`/`name`, so Erli order snapshots carry the routing-rule lookup key (`FulfillmentRoutingService.resolve` consumes it at dispatch).
- `ErliOrderSourceAdapter` implements `SourceOptionsReader`:
  - `listDeliveryMethods()` - live: `GET /delivery/priceListsDetails` (shop-active method ids) intersected with `GET /dictionaries/deliveryMethods` (labels); dedupe by value, raw-id label fallback, array-shape guards, no PII in logs. Endpoints verified against the live sandbox on 2026-07-20.
  - `listOrderStatuses()` - the documented 4-value enum; `listPaymentMethods()` - the two derivable values (`online`/`cod`; Erli has no payment-method vocabulary, COD is a boolean on delivery).
- `MappingOptionsController.resolvePartnerConnectionId` is now pairing-first + capability-checked (no `platformType` literals): a connection with `config.masterCatalogConnectionId` is the source side and its pairing key is the destination; an unpaired master resolves destination=self (must advertise `OrderProcessorManager`) and source via reverse lookup filtered to `OrderSource`-advertising candidates.

### Frontend (#1739)
- New `RoutingSplitBar` (`features/mappings/components/routing-split-bar.tsx`): segmented methods-per-processor proportion bar + text legend with counts, recomputed live from unsaved selections. Bar is `aria-hidden` decoration; counts live in the legend. New `--viz-cat-1..4` / `--viz-cat-muted` categorical tokens (light + dark, catalogued in `tokens.ts`).
- `RoutingRulesPanel` derives buckets from current selections (default bucket = rule absence, labeled from the omp_fulfilled candidate) - no platform branching; Erli renders through the existing capability-gated panel once the options endpoint serves it.

### Deliberate deviations / behavior notes
- The Erli manifest does NOT advertise `SourceOptionsReader` (issue text suggested it): Allegro's manifest doesn't either - the `isSourceOptionsReader` guard is the functional gate, and nothing FE-side keys on the manifest entry. Kept consistent.
- A master paired to BOTH Allegro and Erli now gets 400 "multiple paired source connections" when the mappings page is opened from the master's side (previously the platform filter silently picked Allegro). Genuinely ambiguous under multi-source; the message tells the operator to open the page from the source connection.
- Historical Erli orders keep `shipping` absent until the reconciliation poll re-pulls them (poll is authoritative); no backfill.

## How to test
1. `pnpm --filter @openlinker/integrations-erli test` (403), `pnpm --filter @openlinker/api test -- src/mappings` (91), `pnpm --filter @openlinker/web test routing-` (13).
2. Manual: on a stack with an Erli connection paired to PrestaShop, open `/connections/{erli}/mappings` -> Fulfillment: the delivery-method dropdowns populate from the Erli price list and the split bar recounts live while editing; ingest an Erli order and confirm its snapshot carries `shipping.methodId` (routing rule then resolves at Generate label).

Closes #1738
Closes #1739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
