### PR TITLE
fix(web/connections): generalize escape-hatch banner copy on advanced setup page

### DIFF
--- a/apps/web/src/pages/connections/advanced-new-connection-page.tsx
+++ b/apps/web/src/pages/connections/advanced-new-connection-page.tsx
@@ -34,7 +34,7 @@ export function AdvancedNewConnectionPage(): ReactElement {
           <p className="advanced-banner__title">Escape hatch — prefer the guided flow</p>
           <p>
             This form exposes raw adapter keys, credential references, and config JSON. Use the{' '}
-            <Link to="/connections/new">guided PrestaShop or Allegro wizard</Link> unless you need
+            <Link to="/connections/new">guided setup flow</Link> unless you need
             direct control to debug an integration or bootstrap a platform without a dedicated
             flow.
           </p>


### PR DESCRIPTION
## What changed and why

The escape-hatch banner on /connections/new/advanced hardcoded "guided PrestaShop or Allegro wizard" - copy written when those were the only two integrations. With 9 integrations now shipping guided setup cards, the copy was misleading (implied guided flows exist only for those two) and would need editing on every new integration.

Changed only the link text to the generic "guided setup flow"; the link target (/connections/new) and the rest of the sentence are unchanged. No dynamic platform list on purpose - see the issue for rationale.

## How to test

1. Open http://localhost:5173/connections/new/advanced (or /connections/new/advanced on any running stack)
2. The banner now reads: "Use the guided setup flow unless you need direct control..."
3. The "guided setup flow" link still navigates to /connections/new
4. `grep -rn "PrestaShop or Allegro" apps/web/src` returns nothing

Quality gate: `pnpm --filter @openlinker/web lint` (0 errors) and `pnpm --filter @openlinker/web type-check` pass. Copy-only change; no test asserts this banner text.

Closes #1745

🤖 Generated with [Claude Code](https://claude.com/claude-code)