### PR TITLE
feat(api/auth): theme-aware transactional email layout derived from app design tokens

### DIFF
--- a/apps/api/src/auth/adapters/mailer-password-reset-notifier.adapter.ts
+++ b/apps/api/src/auth/adapters/mailer-password-reset-notifier.adapter.ts
@@ -18,6 +18,12 @@ import {
   type User,
 } from '@openlinker/core/users';
 
+import { renderPasswordResetEmailHtml } from '../templates/password-reset-email.template';
+
+// Mirrors DEFAULT_TTL_MINUTES in password-reset.service.ts - the notifier only
+// renders the value; the service owns token expiry.
+const DEFAULT_TTL_MINUTES = 60;
+
 @Injectable()
 export class MailerPasswordResetNotifierAdapter implements PasswordResetNotifierPort {
   constructor(
@@ -31,12 +37,17 @@ export class MailerPasswordResetNotifierAdapter implements PasswordResetNotifier
     }
     const base = this.configService.get<string>('WEB_URL', 'http://localhost:4173');
     const link = `${base.replace(/\/$/, '')}/reset-password/${rawToken}`;
+    const ttlMinutes = Number(
+      this.configService.get<string | number>('PASSWORD_RESET_TTL_MINUTES', DEFAULT_TTL_MINUTES),
+    );
     const text = `Hello ${user.username},\n\nA password reset was requested for your account. Use the link below to set a new password:\n\n${link}\n\nIf you did not request this, you can ignore this email.`;
+    const html = renderPasswordResetEmailHtml({ username: user.username, link, ttlMinutes });
 
     await this.mailer.sendEmail({
       to: user.email,
       subject: 'Reset your OpenLinker password',
       text,
+      html,
     });
   }
 }

--- a/apps/api/src/auth/templates/confirmation-email.template.spec.ts
+++ b/apps/api/src/auth/templates/confirmation-email.template.spec.ts
@@ -4,14 +4,17 @@
  * @module apps/api/src/auth/templates
  */
 import { renderConfirmationEmailHtml } from './confirmation-email.template';
+import { EMAIL_COLORS } from './email-layout.template';
+
+const input = {
+  username: 'demo_user',
+  link: 'https://app.example.com/confirm-email/raw-token',
+  ttlHours: 24,
+};
 
 describe('renderConfirmationEmailHtml', () => {
   it('renders the confirmation link as the CTA href and as a plain fallback link', () => {
-    const html = renderConfirmationEmailHtml({
-      username: 'demo_user',
-      link: 'https://app.example.com/confirm-email/raw-token',
-      ttlHours: 24,
-    });
+    const html = renderConfirmationEmailHtml(input);
 
     expect(html).toContain('href="https://app.example.com/confirm-email/raw-token"');
     expect(html).toContain('Confirm your email');
@@ -20,23 +23,35 @@ describe('renderConfirmationEmailHtml', () => {
   });
 
   it('greets the user by username', () => {
-    const html = renderConfirmationEmailHtml({
-      username: 'demo_user',
-      link: 'https://app.example.com/confirm-email/raw-token',
-      ttlHours: 24,
-    });
+    const html = renderConfirmationEmailHtml(input);
 
-    expect(html).toContain('Hello demo_user');
+    expect(html).toContain('demo_user');
   });
 
   it('escapes HTML-significant characters in the username', () => {
     const html = renderConfirmationEmailHtml({
+      ...input,
       username: '<script>alert(1)</script>',
-      link: 'https://app.example.com/confirm-email/raw-token',
-      ttlHours: 24,
     });
 
     expect(html).not.toContain('<script>alert(1)</script>');
     expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('uses the light palette inline and ships the dark-mode override block', () => {
+    const html = renderConfirmationEmailHtml(input);
+
+    expect(html).toContain('@media (prefers-color-scheme: dark)');
+    expect(html).toContain('<meta name="color-scheme" content="light dark" />');
+    expect(html).toContain(EMAIL_COLORS.light.accent);
+    expect(html).toContain(EMAIL_COLORS.dark.accent);
+    expect(html).toContain(EMAIL_COLORS.light.onAccent);
+    expect(html).toContain(EMAIL_COLORS.dark.onAccent);
+  });
+
+  it('does not carry the legacy indigo brand color', () => {
+    const html = renderConfirmationEmailHtml(input);
+
+    expect(html.toLowerCase()).not.toContain('#4f46e5');
   });
 });

--- a/apps/api/src/auth/templates/confirmation-email.template.ts
+++ b/apps/api/src/auth/templates/confirmation-email.template.ts
@@ -2,15 +2,20 @@
  * Confirmation Email HTML Template
  *
  * Renders the branded HTML body for the email-confirmation message
- * (#1650). Deliberately separate from the app's design-tokens-based web
- * CSS system: email clients don't load external stylesheets or support
- * most modern CSS, so every rule here is inlined on the element it
- * affects, and the layout uses table-friendly, widely-supported
- * properties only. Kept in `apps/api` (not `libs/core`) — this is a
- * rendering detail of one mailer call, not a domain concern.
+ * (#1650), composed on the shared theme-aware layout (#1748). Kept in
+ * `apps/api` (not `libs/core`) - this is a rendering detail of one mailer
+ * call, not a domain concern.
  *
  * @module apps/api/src/auth/templates
+ * @see {@link renderEmailLayout} for the shared shell and palette
  */
+import {
+  EMAIL_COLORS,
+  escapeHtml,
+  renderCtaButton,
+  renderEmailLayout,
+  renderFallbackLinkWell,
+} from './email-layout.template';
 
 export interface ConfirmationEmailTemplateInput {
   username: string;
@@ -18,24 +23,7 @@ export interface ConfirmationEmailTemplateInput {
   ttlHours: number;
 }
 
-const BRAND_COLOR = '#4f46e5';
-const TEXT_COLOR = '#1f2430';
-const MUTED_COLOR = '#6b7280';
-const BORDER_COLOR = '#e5e7eb';
-const SURFACE_COLOR = '#f4f5f7';
-
-/**
- * Escapes the handful of characters that matter when interpolating
- * user-controlled text (the username) into an HTML body.
- */
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
+const L = EMAIL_COLORS.light;
 
 export function renderConfirmationEmailHtml({
   username,
@@ -45,63 +33,19 @@ export function renderConfirmationEmailHtml({
   const safeUsername = escapeHtml(username);
   const safeLink = escapeHtml(link);
 
-  return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Confirm your OpenLinker account</title>
-  </head>
-  <body style="margin:0; padding:0; background-color:${SURFACE_COLOR}; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${SURFACE_COLOR}; padding:32px 16px;">
-      <tr>
-        <td align="center">
-          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px; background-color:#ffffff; border:1px solid ${BORDER_COLOR}; border-radius:8px; overflow:hidden;">
-            <tr>
-              <td style="padding:32px 32px 0 32px;">
-                <span style="font-size:18px; font-weight:700; color:${TEXT_COLOR}; letter-spacing:-0.01em;">OpenLinker</span>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding:24px 32px 0 32px;">
-                <h1 style="margin:0 0 12px 0; font-size:20px; line-height:1.3; font-weight:600; color:${TEXT_COLOR};">Confirm your email address</h1>
-                <p style="margin:0 0 20px 0; font-size:14px; line-height:1.6; color:${TEXT_COLOR};">
-                  Hello ${safeUsername}, thanks for signing up for OpenLinker. Confirm your email address to activate your account.
+  const contentHtml = `<p class="em-slate" style="margin:0 0 14px 0; font-size:14px; line-height:1.6; color:${L.slate};">
+                  Hello <strong class="em-ink" style="color:${L.ink}; font-weight:600;">${safeUsername}</strong>, thanks for signing up for OpenLinker. Confirm your email address to activate your account.
                 </p>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding:0 32px;">
-                <table role="presentation" cellpadding="0" cellspacing="0">
-                  <tr>
-                    <td style="border-radius:6px; background-color:${BRAND_COLOR};">
-                      <a href="${safeLink}" style="display:inline-block; padding:12px 24px; font-size:14px; font-weight:600; color:#ffffff; text-decoration:none; border-radius:6px;">
-                        Confirm your email
-                      </a>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding:24px 32px 8px 32px;">
-                <p style="margin:0; font-size:12px; line-height:1.6; color:${MUTED_COLOR};">
-                  Or paste this link into your browser:<br />
-                  <a href="${safeLink}" style="color:${BRAND_COLOR}; word-break:break-all;">${safeLink}</a>
-                </p>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding:16px 32px 32px 32px; border-top:1px solid ${BORDER_COLOR};">
-                <p style="margin:16px 0 0 0; font-size:12px; line-height:1.6; color:${MUTED_COLOR};">
-                  This link expires in ${ttlHours} hours. If you did not create this account, you can safely ignore this email.
-                </p>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>`;
+                ${renderCtaButton('Confirm your email', safeLink)}
+                ${renderFallbackLinkWell(safeLink)}`;
+
+  const metaHtml = `<p class="em-mist" style="margin:0 0 6px 0; font-size:12px; line-height:1.6; color:${L.mist};">This link expires in ${ttlHours} hours.</p>
+                      <p class="em-mist" style="margin:0; font-size:12px; line-height:1.6; color:${L.mist};">If you did not create this account, you can safely ignore this email.</p>`;
+
+  return renderEmailLayout({
+    title: 'Confirm your email address',
+    eyebrow: 'Account',
+    contentHtml,
+    metaHtml,
+  });
 }

--- a/apps/api/src/auth/templates/email-layout.template.ts
+++ b/apps/api/src/auth/templates/email-layout.template.ts
@@ -1,0 +1,192 @@
+/**
+ * Shared Transactional Email Layout
+ *
+ * Theme-aware shell composed by every HTML email OpenLinker sends (#1748).
+ * Colors are compile-time hex constants derived from the app design tokens
+ * in `apps/web/src/index.css` (email clients cannot parse OKLCH or CSS
+ * custom properties) - the derivation record is the design artifact linked
+ * from #1748. Light values are inlined per element as the always-works
+ * baseline; the dark palette is applied by the `<style>` block in `<head>`
+ * under `@media (prefers-color-scheme: dark)`, so the email follows the
+ * reader's system theme where the client supports it (Apple Mail,
+ * Thunderbird; Gmail strips the media query and keeps the branded light
+ * version). Kept in `apps/api` (not `libs/core`) - rendering detail of
+ * mailer calls, not a domain concern.
+ *
+ * @module apps/api/src/auth/templates
+ */
+
+export interface EmailLayoutInput {
+  /** Document title and the card's h1. Must be pre-escaped by the caller if dynamic. */
+  title: string;
+  /** Mono uppercase label naming the system area speaking (e.g. "Account", "Security"). */
+  eyebrow: string;
+  /** Pre-escaped HTML placed between the connector mark and the meta footer. */
+  contentHtml: string;
+  /** Pre-escaped HTML paragraphs for the bordered meta footer. */
+  metaHtml: string;
+}
+
+/**
+ * Email palette derived from the app design tokens (see module header).
+ * Light: `--bg-muted`/`--bg-surface`/`--text-*`/`--border-*`/`--accent-primary`
+ * at hue 80/50; dark: the same tokens under `html[data-theme='dark']`.
+ */
+export const EMAIL_COLORS = {
+  light: {
+    canvas: '#f3f1ee',
+    card: '#ffffff',
+    well: '#f3f1ee',
+    ink: '#191610',
+    slate: '#45423c',
+    mist: '#6b6864',
+    rule: '#ece9e5',
+    ruleStrong: '#dad7d2',
+    accent: '#ec6f00',
+    onAccent: '#16100d',
+    link: '#0465af',
+  },
+  dark: {
+    canvas: '#08090b',
+    card: '#121417',
+    well: '#1d1f24',
+    ink: '#f0f2f6',
+    slate: '#b5b7be',
+    mist: '#7d8088',
+    rule: '#1d1f24',
+    ruleStrong: '#2b2e34',
+    accent: '#fa7c20',
+    onAccent: '#120c09',
+    link: '#5bb9ff',
+  },
+} as const;
+
+export const EMAIL_SANS_STACK =
+  "'IBM Plex Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
+export const EMAIL_MONO_STACK =
+  "'IBM Plex Mono',ui-monospace,Menlo,Consolas,'Liberation Mono',monospace";
+
+/**
+ * Escapes the handful of characters that matter when interpolating
+ * user-controlled text (usernames, links) into an HTML body.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const L = EMAIL_COLORS.light;
+const D = EMAIL_COLORS.dark;
+
+/**
+ * The app's button pattern carried into email: dark ink on the accent,
+ * not white-on-color. `safeHref` must already be HTML-escaped.
+ */
+export function renderCtaButton(label: string, safeHref: string): string {
+  return `<table role="presentation" cellpadding="0" cellspacing="0" style="margin:26px 0;">
+                  <tr>
+                    <td class="em-btn" style="border-radius:8px; background-color:${L.accent};">
+                      <a href="${safeHref}" class="em-btn-a" style="display:inline-block; padding:12px 26px; font-size:14px; font-weight:600; color:${L.onAccent}; text-decoration:none; border-radius:8px;">${label}</a>
+                    </td>
+                  </tr>
+                </table>`;
+}
+
+/**
+ * Muted well carrying the raw fallback URL in the mono stack - machine
+ * strings always render as machine strings. `safeHref` must already be
+ * HTML-escaped.
+ */
+export function renderFallbackLinkWell(safeHref: string): string {
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td class="em-well" style="background-color:${L.well}; border:1px solid ${L.rule}; border-radius:8px; padding:12px 16px;">
+                      <p class="em-mist" style="margin:0 0 6px 0; font-size:12px; line-height:1.5; color:${L.mist};">Or paste this link into your browser:</p>
+                      <p style="margin:0; font-family:${EMAIL_MONO_STACK}; font-size:12px; line-height:1.55; word-break:break-all;"><a href="${safeHref}" class="em-link" style="color:${L.link};">${safeHref}</a></p>
+                    </td>
+                  </tr>
+                </table>`;
+}
+
+export function renderEmailLayout({ title, eyebrow, contentHtml, metaHtml }: EmailLayoutInput): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="supported-color-schemes" content="light dark" />
+    <title>${title}</title>
+    <style>
+      :root { color-scheme: light dark; supported-color-schemes: light dark; }
+      @media (prefers-color-scheme: dark) {
+        body, .em-canvas { background-color: ${D.canvas} !important; }
+        .em-card { background-color: ${D.card} !important; border-color: ${D.rule} !important; }
+        .em-ink { color: ${D.ink} !important; }
+        .em-slate { color: ${D.slate} !important; }
+        .em-mist { color: ${D.mist} !important; }
+        .em-rule { border-color: ${D.rule} !important; }
+        .em-accent-bg { background-color: ${D.accent} !important; }
+        .em-accent { color: ${D.accent} !important; }
+        .em-btn { background-color: ${D.accent} !important; }
+        .em-btn-a { color: ${D.onAccent} !important; }
+        .em-well { background-color: ${D.well} !important; border-color: ${D.ruleStrong} !important; }
+        .em-link { color: ${D.link} !important; }
+      }
+    </style>
+  </head>
+  <body class="em-canvas" style="margin:0; padding:0; background-color:${L.canvas}; font-family:${EMAIL_SANS_STACK};">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="em-canvas" style="background-color:${L.canvas}; padding:36px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="em-card" style="max-width:560px; background-color:${L.card}; border:1px solid ${L.rule}; border-radius:12px;">
+            <tr>
+              <td style="padding:32px 36px 0 36px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td><span class="em-ink" style="font-size:17px; font-weight:600; letter-spacing:-0.015em; color:${L.ink};">Open<span class="em-accent" style="color:${L.accent};">Linker</span></span></td>
+                    <td align="right"><span class="em-mist" style="font-family:${EMAIL_MONO_STACK}; font-size:10px; letter-spacing:0.16em; text-transform:uppercase; color:${L.mist};">${eyebrow}</span></td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:18px 36px 26px 36px; font-size:0; line-height:0;">
+                <span class="em-accent-bg" style="display:inline-block; width:6px; height:6px; border-radius:50%; background-color:${L.accent}; vertical-align:middle;"></span><span class="em-accent-bg" style="display:inline-block; width:34px; height:2px; border-radius:2px; background-color:${L.accent}; vertical-align:middle; margin:0 3px;"></span><span class="em-accent-bg" style="display:inline-block; width:6px; height:6px; border-radius:50%; background-color:${L.accent}; vertical-align:middle;"></span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 36px;">
+                <h1 class="em-ink" style="margin:0 0 14px 0; font-size:21px; line-height:1.3; font-weight:600; letter-spacing:-0.015em; color:${L.ink};">${title}</h1>
+                ${contentHtml}
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 36px 32px 36px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td class="em-rule" style="border-top:1px solid ${L.rule}; padding-top:18px;">
+                      ${metaHtml}
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;">
+            <tr>
+              <td style="padding:14px 4px 0 4px;">
+                <p class="em-mist" style="margin:0; font-size:11px; line-height:1.6; color:${L.mist};">OpenLinker &middot; open-source e-commerce orchestration</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}

--- a/apps/api/src/auth/templates/password-reset-email.template.spec.ts
+++ b/apps/api/src/auth/templates/password-reset-email.template.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * PasswordResetEmailTemplate Unit Tests
+ *
+ * @module apps/api/src/auth/templates
+ */
+import { EMAIL_COLORS } from './email-layout.template';
+import { renderPasswordResetEmailHtml } from './password-reset-email.template';
+
+const input = {
+  username: 'demo_user',
+  link: 'https://app.example.com/reset-password/raw-token',
+  ttlMinutes: 60,
+};
+
+describe('renderPasswordResetEmailHtml', () => {
+  it('renders the reset link as the CTA href and as a plain fallback link', () => {
+    const html = renderPasswordResetEmailHtml(input);
+
+    expect(html).toContain('href="https://app.example.com/reset-password/raw-token"');
+    expect(html).toContain('Choose a new password');
+    expect(html).toContain('Reset your password');
+    expect(html).toContain('expires in 60 minutes');
+  });
+
+  it('greets the user by username and escapes HTML-significant characters', () => {
+    const html = renderPasswordResetEmailHtml({
+      ...input,
+      username: '<b>evil</b>',
+    });
+
+    expect(html).not.toContain('<b>evil</b>');
+    expect(html).toContain('&lt;b&gt;evil&lt;/b&gt;');
+  });
+
+  it('escapes HTML-significant characters in the link', () => {
+    const html = renderPasswordResetEmailHtml({
+      ...input,
+      link: 'https://app.example.com/reset-password/tok"><img src=x>',
+    });
+
+    expect(html).not.toContain('"><img src=x>');
+    expect(html).toContain('&quot;&gt;&lt;img src=x&gt;');
+  });
+
+  it('uses the light palette inline and ships the dark-mode override block', () => {
+    const html = renderPasswordResetEmailHtml(input);
+
+    expect(html).toContain('@media (prefers-color-scheme: dark)');
+    expect(html).toContain(EMAIL_COLORS.light.accent);
+    expect(html).toContain(EMAIL_COLORS.dark.accent);
+    expect(html.toLowerCase()).not.toContain('#4f46e5');
+  });
+});

--- a/apps/api/src/auth/templates/password-reset-email.template.ts
+++ b/apps/api/src/auth/templates/password-reset-email.template.ts
@@ -1,0 +1,52 @@
+/**
+ * Password Reset Email HTML Template
+ *
+ * Renders the branded HTML body for the password-reset message on the
+ * shared theme-aware layout (#1748). The plaintext part stays with the
+ * notifier adapter as the multipart alternative. Kept in `apps/api`
+ * (not `libs/core`) - rendering detail of one mailer call, not a
+ * domain concern.
+ *
+ * @module apps/api/src/auth/templates
+ * @see {@link renderEmailLayout} for the shared shell and palette
+ */
+import {
+  EMAIL_COLORS,
+  escapeHtml,
+  renderCtaButton,
+  renderEmailLayout,
+  renderFallbackLinkWell,
+} from './email-layout.template';
+
+export interface PasswordResetEmailTemplateInput {
+  username: string;
+  link: string;
+  ttlMinutes: number;
+}
+
+const L = EMAIL_COLORS.light;
+
+export function renderPasswordResetEmailHtml({
+  username,
+  link,
+  ttlMinutes,
+}: PasswordResetEmailTemplateInput): string {
+  const safeUsername = escapeHtml(username);
+  const safeLink = escapeHtml(link);
+
+  const contentHtml = `<p class="em-slate" style="margin:0 0 14px 0; font-size:14px; line-height:1.6; color:${L.slate};">
+                  Hello <strong class="em-ink" style="color:${L.ink}; font-weight:600;">${safeUsername}</strong>, we received a request to reset the password for your OpenLinker account.
+                </p>
+                ${renderCtaButton('Choose a new password', safeLink)}
+                ${renderFallbackLinkWell(safeLink)}`;
+
+  const metaHtml = `<p class="em-mist" style="margin:0 0 6px 0; font-size:12px; line-height:1.6; color:${L.mist};">This link expires in ${ttlMinutes} minutes and can be used once.</p>
+                      <p class="em-mist" style="margin:0; font-size:12px; line-height:1.6; color:${L.mist};">If you did not request a reset, ignore this email - your password stays unchanged.</p>`;
+
+  return renderEmailLayout({
+    title: 'Reset your password',
+    eyebrow: 'Security',
+    contentHtml,
+    metaHtml,
+  });
+}

--- a/docs/plans/implementation-plan-theme-aware-email-layout.md
+++ b/docs/plans/implementation-plan-theme-aware-email-layout.md
@@ -1,0 +1,58 @@
+# Implementation Plan: Theme-aware transactional email layout (#1748)
+
+Design artifact (approved): https://claude.ai/code/artifact/12a735c2-d348-4423-bbaf-a713b7704c75
+
+## 1. Understand
+
+Replace the hardcoded indigo email styling with a shared, theme-aware layout whose
+colors are derived (at design time, as hex constants) from the app design tokens in
+`apps/web/src/index.css`, and give the password-reset email an HTML body.
+
+- **Layer**: Interface (API outbound email rendering, `apps/api/src/auth`).
+- **Non-goals**: the two future templates from the artifact (password-changed notice,
+  connection re-auth alert); any runtime coupling to `apps/web`; changing mailer
+  transports or `MailerPort`.
+
+## 2. Research
+
+- `apps/api/src/auth/templates/confirmation-email.template.ts` - only HTML email today;
+  local indigo constants; `escapeHtml` helper; table-based inline-styled markup; input
+  interface colocated in the template file (folder precedent).
+- `apps/api/src/auth/adapters/mailer-password-reset-notifier.adapter.ts` - text-only;
+  has `ConfigService`; reset TTL key `PASSWORD_RESET_TTL_MINUTES` (default 60, mirrors
+  `password-reset.service.ts`).
+- `MailerPort.sendEmail` already accepts optional `html`.
+- Collision check (pre-implement essence; full gate skipped as trivial/self-contained):
+  no existing `email-layout.template.ts`, no `renderPasswordResetEmailHtml`, the only
+  `#4f46e5` in the repo is the file being rewritten.
+
+## 3. Design
+
+One pure-function layout module; templates compose it. Light palette inlined per
+element (always-works baseline); dark palette applied by a `<style>` block in `<head>`
+under `@media (prefers-color-scheme: dark)` using `!important` class overrides
+(standard email dark-mode mechanism; Gmail falls back to light).
+
+## 4. Steps
+
+1. `apps/api/src/auth/templates/email-layout.template.ts` (new)
+   - `EMAIL_COLORS` (light/dark hex sets from the artifact's token mapping), font
+     stacks, `escapeHtml`, `renderCtaButton`, `renderFallbackLinkWell`,
+     `renderEmailLayout({ title, eyebrow, contentHtml, metaHtml })`.
+   - Shell: color-scheme metas + dark-mode style block, wordmark ("Linker" in accent)
+     + mono eyebrow, connector mark (dot-line-dot in accent), content slot, meta
+     footer with top rule, outside-card tagline.
+2. Rewrite `confirmation-email.template.ts` on the layout; delete indigo constants;
+   keep `ConfirmationEmailTemplateInput` and escaping semantics.
+3. `apps/api/src/auth/templates/password-reset-email.template.ts` (new) -
+   `renderPasswordResetEmailHtml({ username, link, ttlMinutes })`.
+4. `mailer-password-reset-notifier.adapter.ts` - read `PASSWORD_RESET_TTL_MINUTES`
+   (default 60), pass `html` alongside the existing `text`.
+5. Tests: extend `confirmation-email.template.spec.ts` (dark-mode block, both
+   palettes, no indigo, escaping); new `password-reset-email.template.spec.ts`.
+
+## 5. Validate
+
+- Boundaries: no `apps/web` imports; pure functions, no Nest/DI changes; templates
+  stay in the API interface layer. No migration. Quality gate scoped to
+  `@openlinker/api` + full lint/type-check.


### PR DESCRIPTION
## What changed and why

Transactional emails carried a hardcoded indigo palette (`#4f46e5`) disconnected from the app's design system, and the password-reset email had no HTML body at all. This PR implements the approved design:

**Design artifact (light/dark previews of every email type, token-to-hex mapping, mechanism notes):** https://claude.ai/code/artifact/12a735c2-d348-4423-bbaf-a713b7704c75

- **New shared layout** - `apps/api/src/auth/templates/email-layout.template.ts`: wordmark header + mono eyebrow, connector mark, content slot, mono fallback-URL well, bordered meta footer. `EMAIL_COLORS` holds light/dark hex sets derived at design time from the OKLCH tokens in `apps/web/src/index.css` (email clients cannot parse OKLCH; the artifact's table is the derivation record). No runtime coupling to `apps/web`.
- **Automatic theming** - light palette inlined per element as the always-works baseline; dark palette applied via `@media (prefers-color-scheme: dark)` class overrides in `<head>` plus `color-scheme`/`supported-color-schemes` metas, so the email follows the reader's system theme (Apple Mail/Thunderbird full support; Gmail falls back to the branded light version).
- **Confirmation email** rewritten on the shared layout; local indigo constants deleted. Escaping semantics preserved.
- **Password reset** now sends multipart text + HTML on the same layout; TTL read from `PASSWORD_RESET_TTL_MINUTES` (default 60, mirroring `password-reset.service.ts`).
- CTA buttons keep the app's dark-ink-on-accent button pattern; raw URLs render in the mono stack.
- Implementation plan included at `docs/plans/implementation-plan-theme-aware-email-layout.md`.

Out of scope (per issue): the two proposed future templates from the artifact (password-changed notice, connection re-auth alert) - they ship with their notification flows.

## How to test

- `pnpm --filter @openlinker/api exec jest src/auth/templates src/auth/adapters src/auth/password-reset-round-trip.spec.ts src/auth/email-confirmation.service.spec.ts` - 50 tests pass.
- New/updated specs assert: dark-mode block + both palettes present, no `#4f46e5`, username/link escaping, CTA + fallback links, TTL copy.
- Manual: trigger sign-up / password-reset against a dev SMTP sink and view in a client with dark mode toggled.

Closes #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)
