### PR TITLE
fix(web/orders): match products table header alignment and density

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7750,8 +7750,10 @@ a.kpi-card:focus-visible {
    Merged Shipment + money columns, per-label sort controls, the row items
    summary, the folded channel line, and the mobile card summary/facts. */
 
-/* Right-aligned two-line stack (the money column). */
-.orders-cell-stack--end { align-items: flex-end; text-align: right; }
+/* Right-aligned two-line stack (the money column). `min-width: 8rem`
+   co-anchors the body column width with the header sort buttons so the
+   column doesn't resize between sorts, matching the products table (#1747). */
+.orders-cell-stack--end { align-items: flex-end; text-align: right; min-width: 8rem; }
 .orders-money-total { font-weight: 640; }
 
 /* Row items summary: a truncating first-item name + a never-truncated "+N"
@@ -7838,11 +7840,22 @@ a.kpi-card:focus-visible {
 /* Per-label sort controls in the merged-column headers. */
 .orders-sortstack { display: inline-flex; flex-direction: column; gap: 4px; }
 .orders-sortstack--left { align-items: flex-start; }
-.orders-sortstack--right { align-items: flex-end; }
+/* `display: flex` + `width: 100%` makes the right-hand money stack fill the
+   entire <th> so `align-items: flex-end` reliably pins the buttons to the
+   right edge; the th's text-align alone left it content-width and off-edge.
+   Scoped to --right so the left/plain header stacks stay content-width (#1747). */
+.orders-sortstack--right { display: flex; width: 100%; align-items: flex-end; }
+/* Stable per-button width so the three labels line up flush-right with even
+   gaps, matching the products header (#1747, mirrors .sortbtn from #1720). */
+.orders-sortstack--right .orders-sortbtn { justify-content: flex-end; min-width: 8rem; }
 .orders-sortbtn {
   display: inline-flex;
   align-items: center;
   gap: 3px;
+  /* Opt out of the global `button { height: 2rem }` so the stacked sort
+     labels are content-height (~15px), not 32px each - otherwise the header
+     renders ~2x taller than the products table (#1747, mirrors .sortbtn). */
+  height: auto;
   padding: 0;
   border: none;
   background: none;


### PR DESCRIPTION
## What changed and why

The orders list table header did not match the products list table header. The rightmost money-column header group (`TOTAL` / `PAYMENT` / `CREATED`) was not right-aligned and had uneven per-label gaps, and the whole orders header stack rendered roughly 2x taller than the products header.

Two fixes, both mirroring the products table's `#1720` header treatment, applied in `apps/web/src/index.css`:

1. **Alignment** - scope the fill-and-right-pin to the `--right` sort stack: `display: flex` + `width: 100%` so `align-items: flex-end` reliably pins buttons to the right edge of the `<th>`, plus a stable `8rem` `min-width` with flush-right justification per button. The money body cell (`.orders-cell-stack--end`) is co-anchored to the same `8rem` width so the column doesn't resize between sorts.
2. **Density** - the orders sort buttons inherited the global `button { height: 2rem }` (32px). The products `.sortbtn` opts out with `height: auto`; the orders `.orders-sortbtn` did not, so each label was 32px tall instead of content-height. Adding `height: auto` tightens the whole orders header to the products density.

No JSX change - both columns already declared `align: 'right'`. Change is confined to the `apps/web` presentation layer.

## Verified (in-browser, same viewport)

| | Orders (before) | Orders (after) | Products |
|---|---|---|---|
| Stack height | 104px | 54.2px | 54.2px |
| Per-button height | 32px | 15.4px | 15.4px |
| Inter-label gap | 4px | 4px | 4px |
| Right-aligned | no | yes | yes |

The orders header now matches the products header on alignment, height, and gaps.

## How to test

1. Open `/orders` and `/products` side by side.
2. Confirm the rightmost header group on orders (`TOTAL` / `PAYMENT` / `CREATED`) is right-aligned, flush to the column edge, with even spacing - matching the products header (`PRICE` / `UPDATED` / `CREATED`).
3. Confirm the orders header is no longer visibly taller than the products header.
4. Confirm the left-aligned orders header stacks (Customer, Status, Shipment/Ship-by) still render correctly.

## Screenshots

_Before / after attached below._
### Before 
<img width="1454" height="215" alt="image" src="https://github.com/user-attachments/assets/5b1c8ff2-4211-4c8d-a04c-e4e5f51eb894" />

### After
<img width="1558" height="189" alt="image" src="https://github.com/user-attachments/assets/0da4df36-de48-43af-ae08-6a960c0959b2" />

Closes #1747
