### PR TITLE
feat(products): polish product detail page — full-width variant table, rich listing drawer, mobile layout

### DIFF
--- a/apps/web/src/features/products/components/product-source-section.tsx
+++ b/apps/web/src/features/products/components/product-source-section.tsx
@@ -1,0 +1,81 @@
+/**
+ * Product Source Section (#1752)
+ *
+ * Renames the product-detail "External IDs" block to "Source" and leads with
+ * the product's master origin — `externalIds[0]`, the mapping the cockpit's
+ * Source column already treats as provenance — shown as a channel pill +
+ * connection name + `platformType · externalId` with a `Master` tag. Any
+ * further per-connection identifier mappings list beneath as secondary chips.
+ *
+ * @module apps/web/src/features/products/components
+ */
+import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import { StatusBadge } from '../../../shared/ui/status-badge';
+import { usePlatforms } from '../../../shared/plugins';
+import type { Connection } from '../../connections';
+import type { ExternalIdMapping } from '../api/products.types';
+
+interface ProductSourceSectionProps {
+  mappings: ExternalIdMapping[];
+  connections: readonly Connection[];
+}
+
+export function ProductSourceSection({
+  mappings,
+  connections,
+}: ProductSourceSectionProps): ReactElement {
+  const platforms = usePlatforms();
+
+  if (mappings.length === 0) {
+    return <span className="text-muted">No source mapping</span>;
+  }
+
+  const [primary, ...rest] = mappings;
+  const platformLabel =
+    platforms.find((p) => p.platformType === primary.platformType)?.displayName ??
+    primary.platformType;
+  const connectionName = connections.find((c) => c.id === primary.connectionId)?.name;
+
+  return (
+    <div className="product-source">
+      <Link
+        className="product-source__primary"
+        to={`/connections/${primary.connectionId}`}
+        title={`Open the master connection for ${platformLabel}`}
+      >
+        <span className="channel-pill" data-channel={primary.platformType}>
+          {platformLabel}
+        </span>
+        <span className="product-source__body">
+          <span className="product-source__conn">{connectionName ?? platformLabel}</span>
+          <span className="product-source__ref">
+            {primary.platformType} · {primary.externalId}
+          </span>
+        </span>
+        <StatusBadge className="product-source__tag" tone="neutral" compact>
+          Master
+        </StatusBadge>
+      </Link>
+
+      {rest.length > 0 ? (
+        <div className="product-source__more">
+          <span className="product-source__more-label">Also mapped on</span>
+          <div className="id-chip-row">
+            {rest.map((mapping) => (
+              <Link
+                key={`${mapping.platformType}-${mapping.connectionId}-${mapping.externalId}`}
+                className="id-chip id-chip--link"
+                to={`/connections/${mapping.connectionId}`}
+                title={`Open connection for ${mapping.platformType} ${mapping.externalId}`}
+              >
+                <span className="id-chip__platform">{mapping.platformType}</span>
+                <span>{mapping.externalId}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -12181,12 +12181,10 @@ input.bulk-dispatch__num--wide {
   font-weight: 600;
 }
 
-/* Forces horizontal scroll (via the shared .data-table__container overflow-x)
-   instead of crushing cells into vertical per-character wraps when this table
-   is embedded in a narrow context - the products cockpit's mobile card
-   disclosure and expandable drawer (#1720). */
+/* Full-width variant table (#1752). Below 640px it folds into stacked
+   accordion cards (see the v2 section), so no min-width scroll is needed. */
 .variant-stock-table {
-  min-width: 640px;
+  width: 100%;
 }
 
 .variant-stock-table th,
@@ -12344,6 +12342,411 @@ input.bulk-dispatch__num--wide {
 
 .listings-subtable__link:hover {
   text-decoration: underline;
+}
+
+/* ── Product detail v2 (#1752) ─────────────────────────────────────────────
+   Full-width variants table in the products-cockpit row language, a rich
+   per-listing accordion drawer, a renamed "Source" section, a unified 4-tile
+   KPI strip, and a genuine mobile layout (stacking hero + table→cards). Reuses
+   the global `.coverage-pill`, `.channel-pill`, `.products-row-cta`,
+   `.status-badge`, and `.products-cell-stack` primitives — this block only adds
+   the detail-page-specific chrome. */
+
+/* Unified 4-tile KPI strip (replaces the split cols-1 + cols-3). */
+.product-detail__kpi-row--cols-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+@media (max-width: 899.98px) {
+  .product-detail__kpi-row--cols-4 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Hero stacks under 768px so the facts get full width — kills the
+   one-character-per-line wrap the fixed 8rem gallery used to force. */
+@media (max-width: 767.98px) {
+  .product-detail-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .product-gallery {
+    width: 100%;
+  }
+
+  .product-gallery__main {
+    aspect-ratio: 16 / 10;
+  }
+
+  .product-detail-hero__fact {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.125rem;
+  }
+
+  .product-detail-hero__fact-label {
+    min-width: 0;
+  }
+}
+
+/* Description section header — read-only source vs editable Content. */
+.detail-section__edit-link {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-primary-soft-strong);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.detail-section__edit-link:hover {
+  text-decoration: underline;
+}
+
+/* Source section (renamed from "External IDs"): the master origin gets a
+   Master tag; any further per-connection mappings list beneath. */
+.product-source {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.product-source__primary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+}
+
+.product-source__primary:hover .product-source__conn {
+  color: var(--accent-primary-soft-strong);
+}
+
+.product-source__primary:focus-visible {
+  box-shadow: var(--shadow-focus);
+}
+
+.product-source__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.product-source__conn {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.product-source__ref {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.product-source__tag {
+  margin-left: auto;
+}
+
+.product-source__more {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.product-source__more-label {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* Variant table cells in cockpit language. */
+.variant-stock-table__name {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.variant-stock-table__sku {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.variant-stock-table__meta {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.variant-stock-table__stock {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+}
+
+.variant-stock-table__stock-value {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.variant-stock-table__stock-reserved {
+  margin-left: 4px;
+  font-size: 0.6875rem;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.variant-stock-table__listings-cell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  align-items: center;
+  white-space: normal;
+}
+
+.variant-stock-table__price {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Expanded drawer — the products-row-detail inset look, filled with listings. */
+.variant-drawer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: 0 var(--space-4) var(--space-4) calc(2.25rem + var(--space-4));
+  padding: var(--space-4);
+  background: var(--bg-surface-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.variant-drawer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.variant-drawer__label {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.variant-listing-cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.variant-listing-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  padding: var(--space-3) var(--space-4);
+}
+
+.variant-listing-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.variant-listing-card__left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.variant-listing-card__price {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+.variant-listing-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-1) var(--space-3);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.variant-listing-meta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.variant-listing-meta b {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.variant-listing-meta a {
+  color: var(--text-link);
+  text-decoration: none;
+}
+
+.variant-listing-meta a:hover {
+  text-decoration: underline;
+}
+
+.variant-listing-card__note {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+/* Mobile: the table folds into stacked accordion cards (<640px). The
+   component swaps markup via useMediaQuery; these style the card variant. */
+.variant-cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.variant-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  overflow: hidden;
+}
+
+.variant-card__header {
+  /* Full reset — the global `button, .button {}` base (accent background,
+     fixed 2rem height, border, box-shadow) otherwise survives and both
+     collapses the header height (content overflows) and paints it orange on
+     hover/active. Mirrors the .products-card-disclosure reset (#1720). */
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  height: auto;
+  padding: var(--space-3) var(--space-4);
+  border: 0;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+.variant-card__header:hover,
+.variant-card__header:active {
+  background: none;
+  border: 0;
+  box-shadow: none;
+  color: inherit;
+}
+
+.variant-card__header:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.variant-card__aside {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+}
+
+.variant-card__disclosure {
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+}
+
+.variant-card__disclosure svg {
+  width: 11px;
+  height: 11px;
+  transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.variant-card__header[aria-expanded='true'] .variant-card__disclosure svg {
+  transform: rotate(90deg);
+}
+
+.variant-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: 0 var(--space-4) var(--space-4);
+}
+
+.variant-card__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+
+.variant-card__cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.variant-card__cell--full {
+  grid-column: 1 / -1;
+}
+
+.variant-card__cell-label {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.variant-card__cell-value {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+}
+
+/* Inside a mobile card the drawer needs no inset margin. */
+.variant-card__body .variant-drawer {
+  margin: 0;
+  padding: var(--space-3);
 }
 
 .guest-form__demo-callout-icon {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -12611,13 +12611,26 @@ input.bulk-dispatch__num--wide {
   font-weight: 500;
 }
 
+/* Identifier / external links in the drawer read as quiet primary text with
+   a faint underline; the brand accent appears only on hover (no off-palette
+   blue in this dense, status-coloured region). */
 .variant-listing-meta a {
-  color: var(--text-link);
-  text-decoration: none;
+  color: var(--text-primary);
+  text-decoration: underline;
+  text-decoration-color: var(--border-strong);
+  text-underline-offset: 2px;
+  transition: color var(--duration-fast) var(--ease-out);
 }
 
 .variant-listing-meta a:hover {
-  text-decoration: underline;
+  color: var(--accent-primary-soft-strong);
+  text-decoration-color: currentColor;
+}
+
+.variant-listing-meta a:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  border-radius: var(--radius-xs);
 }
 
 .variant-listing-card__note {

--- a/apps/web/src/pages/products/product-detail-page.test.tsx
+++ b/apps/web/src/pages/products/product-detail-page.test.tsx
@@ -2,7 +2,11 @@ import { cleanup, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Route, Routes } from 'react-router-dom';
 import { afterEach, describe, it, expect, vi } from 'vitest';
-import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import {
+  renderWithProviders,
+  createMockApiClient,
+  createAuthenticatedSessionAdapter,
+} from '../../test/test-utils';
 import { ProductDetailPage } from './product-detail-page';
 import type { Product } from '../../features/products/api/products.types';
 import type { InventoryItem, PaginatedInventory } from '../../features/inventory/api/inventory.types';
@@ -128,14 +132,15 @@ describe('ProductDetailPage', () => {
     expect(screen.getByText('29.99')).toBeInTheDocument();
     expect(screen.getByText('A test product')).toBeInTheDocument();
 
-    // Variant & stock table
+    // Variant & stock table — SKU headline + combined EAN/attributes meta line
     expect(screen.getByText('SKU-001-M')).toBeInTheDocument();
-    expect(screen.getByText('1234567890123')).toBeInTheDocument();
-    expect(screen.getByText('size: M, color: blue')).toBeInTheDocument();
+    expect(screen.getByText(/EAN 1234567890123/)).toBeInTheDocument();
+    expect(screen.getByText(/size: M, color: blue/)).toBeInTheDocument();
 
-    // External IDs (rendered as chips)
-    expect(screen.getByText('prestashop')).toBeInTheDocument();
-    expect(screen.getByText('10')).toBeInTheDocument();
+    // Source section (renamed from External IDs) — master origin with ref
+    expect(screen.getByRole('heading', { name: 'Source' })).toBeInTheDocument();
+    expect(screen.getByText('prestashop · 10')).toBeInTheDocument();
+    expect(screen.getByText('Master')).toBeInTheDocument();
   });
 
   it('should show error state when fetch fails', async () => {
@@ -250,7 +255,7 @@ describe('ProductDetailPage', () => {
     expect(within(kpiCard).getByText('1 oversold')).toBeInTheDocument();
   });
 
-  it('should toggle the "Listings using this stock" panel and render the matching listings subtable', async () => {
+  it('should toggle the variant drawer and render the matching per-listing detail', async () => {
     const user = userEvent.setup();
     const listingsList = vi.fn().mockResolvedValue(
       paginatedListings([
@@ -272,8 +277,48 @@ describe('ProductDetailPage', () => {
     await user.click(toggle);
 
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
-    expect(await screen.findByText('allegro')).toBeInTheDocument();
-    expect(screen.getByText('ALG-1')).toBeInTheDocument();
+    // Drawer label + per-listing detail card (offer-id link).
+    expect(await screen.findByText('Listings (1)')).toBeInTheDocument();
+    expect(screen.getByText(/ALG-1/)).toBeInTheDocument();
+  });
+
+  it('should render a "+ Create offer" CTA when an OfferCreator connection has no listing for the variant', async () => {
+    const mockApi = createMockApiClient({
+      products: {
+        getById: vi.fn().mockResolvedValue(sampleProduct),
+      },
+      connections: {
+        list: vi.fn().mockResolvedValue([
+          {
+            id: 'conn_allegro',
+            name: 'Allegro sandbox',
+            platformType: 'allegro',
+            status: 'active',
+            adapterKey: 'allegro.publicapi.v1',
+            supportedCapabilities: ['OfferManager', 'OfferCreator'],
+            enabledCapabilities: ['OfferManager', 'OfferCreator'],
+            config: {},
+            createdAt: '2026-01-15T10:00:00.000Z',
+            updatedAt: '2026-01-15T10:00:00.000Z',
+          },
+        ]),
+      },
+      listings: { list: vi.fn().mockResolvedValue(paginatedListings([])) },
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/products/:id" element={<ProductDetailPage />} />
+      </Routes>,
+      {
+        apiClient: mockApi,
+        route: '/products/ol_product_abc123',
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      },
+    );
+
+    await screen.findByText('SKU-001-M');
+    expect(await screen.findByRole('button', { name: '+ Create offer' })).toBeInTheDocument();
   });
 
   it('should show the empty listings message when a variant has no matching listings', async () => {

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState, type ReactElement, type ReactNode } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useCallback, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
@@ -11,9 +11,13 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { ContentEditor } from '../../features/content/components/content-editor';
 import { useProductQuery } from '../../features/products/hooks/use-product-query';
 import { ProductGallery } from '../../features/products/components/product-gallery';
-import { ExternalIdChips } from '../../features/products/components/external-id-chips';
+import { ProductSourceSection } from '../../features/products/components/product-source-section';
 import { useInventoryQuery } from '../../features/inventory/hooks/use-inventory-query';
+import { useConnectionsQuery, type Connection } from '../../features/connections';
+import { useWriteAccess } from '../../shared/auth/use-permission';
+import { useDemoMode } from '../../features/system';
 import { VariantStockTable } from './variant-stock-table';
+import { MarketplacePickerModal } from './marketplace-picker-modal';
 import {
   DEFAULT_LOW_STOCK_THRESHOLD,
   deriveStockStatus,
@@ -70,6 +74,38 @@ export function ProductDetailPage(): ReactElement {
   const handleListingsCount = useCallback((variantId: string, count: number) => {
     setListingsCounts((prev) => (prev[variantId] === count ? prev : { ...prev, [variantId]: count }));
   }, []);
+
+  // Create-offer launch (mirrors products-list-page #1096): target connections
+  // by the OfferCreator capability — never a literal platformType. The CTA is
+  // gated on `listings:write` (demo viewers see it and hit the gated confirm).
+  const navigate = useNavigate();
+  const connectionsQuery = useConnectionsQuery();
+  const demoMode = useDemoMode();
+  const write = useWriteAccess('listings:write', demoMode);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const offerCreatorConnections = useMemo<Connection[]>(
+    () =>
+      (connectionsQuery.data ?? [])
+        .filter((c) => c.status === 'active' && c.supportedCapabilities?.includes('OfferCreator'))
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [connectionsQuery.data],
+  );
+  const goToWizard = useCallback(
+    (connectionId?: string): void => {
+      const params = new URLSearchParams({ productIds: id });
+      if (connectionId) params.set('connectionId', connectionId);
+      void navigate(`/listings/bulk-create/wizard?${params.toString()}`);
+    },
+    [id, navigate],
+  );
+  const handleCreateOffers = useCallback((): void => {
+    if (offerCreatorConnections.length === 1) {
+      goToWizard(offerCreatorConnections[0]!.id);
+    } else if (offerCreatorConnections.length > 1) {
+      setPickerOpen(true);
+    }
+  }, [offerCreatorConnections, goToWizard]);
 
   if (query.isLoading) {
     return (
@@ -170,39 +206,53 @@ export function ProductDetailPage(): ReactElement {
             </div>
           </section>
 
+          <section className="detail-section" aria-label="At a glance">
+            <h3 className="detail-section__title">At a glance</h3>
+            <div className="product-detail__kpi-row product-detail__kpi-row--cols-4">
+              <KpiCard label="Price" value={formatPrice(product.price, product.currency)} />
+              <KpiCard
+                label="Available"
+                tone={availableTone}
+                value={totalAvailable}
+                description={oversoldCount > 0 ? `${oversoldCount} oversold` : undefined}
+              />
+              <KpiCard label="Variants" value={variants.length} />
+              <KpiCard label="Listings" value={totalListings} />
+            </div>
+          </section>
+
           <div className="product-detail__primary-grid--split">
             <div className="product-detail__stack">
               <section className="detail-section">
-                <h3 className="detail-section__title">Description</h3>
+                <div className="detail-section__title-row">
+                  <h3 className="detail-section__title">
+                    Description{' '}
+                    <StatusBadge tone="neutral" compact>
+                      Source · read-only
+                    </StatusBadge>
+                  </h3>
+                  <Link className="detail-section__edit-link" to="?view=content">
+                    Edit in Content →
+                  </Link>
+                </div>
                 {product.description ? (
                   <p className="description-block">{product.description}</p>
                 ) : (
-                  <p className="text-muted">No description available.</p>
+                  <p className="text-muted">
+                    No description synced from the source. Draft and publish one per channel in the
+                    Content tab.
+                  </p>
                 )}
               </section>
             </div>
 
             <div className="product-detail__stack">
-              <section className="detail-section" aria-label="At a glance">
-                <h3 className="detail-section__title">At a glance</h3>
-                <div className="product-detail__kpi-row product-detail__kpi-row--cols-1">
-                  <KpiCard label="Price" value={formatPrice(product.price, product.currency)} />
-                </div>
-                <div className="product-detail__kpi-row product-detail__kpi-row--cols-3">
-                  <KpiCard
-                    label="Available"
-                    tone={availableTone}
-                    value={totalAvailable}
-                    description={oversoldCount > 0 ? `${oversoldCount} oversold` : undefined}
-                  />
-                  <KpiCard label="Variants" value={variants.length} />
-                  <KpiCard label="Listings" value={totalListings} />
-                </div>
-              </section>
-
               <section className="detail-section">
-                <h3 className="detail-section__title">External IDs</h3>
-                <ExternalIdChips mappings={product.externalIds ?? []} />
+                <h3 className="detail-section__title">Source</h3>
+                <ProductSourceSection
+                  mappings={product.externalIds ?? []}
+                  connections={connectionsQuery.data ?? []}
+                />
               </section>
             </div>
           </div>
@@ -239,6 +289,10 @@ export function ProductDetailPage(): ReactElement {
               <VariantStockTable
                 variants={variants}
                 stockByVariant={stockByVariant}
+                currency={product.currency}
+                connections={offerCreatorConnections}
+                canCreateOffers={write.visible}
+                onCreateOffers={handleCreateOffers}
                 onListingsCount={handleListingsCount}
               />
             )}
@@ -249,6 +303,17 @@ export function ProductDetailPage(): ReactElement {
           <ContentEditor productId={product.id} />
         </TabsContent>
       </Tabs>
+
+      <MarketplacePickerModal
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        productCount={1}
+        connections={offerCreatorConnections}
+        onContinue={(connectionId) => {
+          setPickerOpen(false);
+          goToWizard(connectionId);
+        }}
+      />
     </PageLayout>
   );
 }

--- a/apps/web/src/pages/products/variant-stock-table.tsx
+++ b/apps/web/src/pages/products/variant-stock-table.tsx
@@ -1,25 +1,73 @@
-import { useEffect, useState, type ReactElement } from 'react';
+/**
+ * Variant Stock Table (#1752)
+ *
+ * Full-width variants table for the product-detail Overview tab, rebuilt in the
+ * products-cockpit row language: per-variant stock (available / reserved) with
+ * an IN STOCK badge, per-channel coverage pills, a "+ Create offer" CTA on
+ * listing gaps, master variant price, and an expandable per-variant drawer that
+ * shows rich per-listing detail (status, price, quantity, offer-id link,
+ * category, marketplace URL) fetched lazily on expand. Below 640px the table
+ * folds into stacked accordion cards.
+ *
+ * @module apps/web/src/pages/products
+ */
+import { useEffect, useState, type ReactElement, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
+import type { Connection } from '../../features/connections';
 import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
+import { useListingMarketplaceOfferQuery } from '../../features/listings/hooks/use-listing-marketplace-offer-query';
 import type { OfferMapping } from '../../features/listings/api/listings.types';
 import type { ProductVariant } from '../../features/products/api/products.types';
 import type { InventoryItem } from '../../features/inventory/api/inventory.types';
 import { TimeDisplay } from '../../shared/ui/time-display';
-import { StatusBadge } from '../../shared/ui/status-badge';
-import { deriveStockStatus } from './product-stock-status';
+import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { useMediaQuery } from '../../shared/ui/use-media-query';
+import { usePlatforms } from '../../shared/plugins';
+import {
+  deriveStockStatus,
+  STOCK_STATUS_BADGE_TONE,
+  STOCK_STATUS_LABEL,
+} from './product-stock-status';
 
 interface VariantStockTableProps {
   variants: ProductVariant[];
   stockByVariant: Map<string, InventoryItem>;
+  /** Product currency, used to format the master variant price. */
+  currency: string | null;
+  /** Active OfferCreator connections — the coverage pill set is derived from these. */
+  connections: readonly Connection[];
+  /** Whether the "+ Create offer" CTA renders (write access, incl. demo). */
+  canCreateOffers: boolean;
+  /** Opens the create-offer flow for this product (picker or wizard). */
+  onCreateOffers: () => void;
   onListingsCount: (variantId: string, count: number) => void;
 }
 
-export function VariantStockTable({
-  variants,
-  stockByVariant,
-  onListingsCount,
-}: VariantStockTableProps): ReactElement {
+const MOBILE_QUERY = '(max-width: 639.98px)';
+
+export function VariantStockTable(props: VariantStockTableProps): ReactElement {
+  const isMobile = useMediaQuery(MOBILE_QUERY);
+
+  if (isMobile) {
+    return (
+      <div className="variant-cards">
+        {props.variants.map((variant) => (
+          <VariantStockCard
+            key={variant.id}
+            variant={variant}
+            stock={props.stockByVariant.get(variant.id)}
+            currency={props.currency}
+            connections={props.connections}
+            canCreateOffers={props.canCreateOffers}
+            onCreateOffers={props.onCreateOffers}
+            onListingsCount={props.onListingsCount}
+          />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="data-table__container variant-stock-table__container">
       <table className="data-table variant-stock-table">
@@ -28,20 +76,23 @@ export function VariantStockTable({
           <tr>
             <th aria-hidden="true"></th>
             <th>Variant</th>
-            <th>EAN</th>
-            <th>Attributes</th>
-            <th>Available</th>
-            <th>Reserved</th>
+            <th>Stock</th>
             <th>Listings</th>
+            <th className="data-table__cell--right">Price</th>
+            <th className="data-table__cell--right">Updated</th>
           </tr>
         </thead>
         <tbody>
-          {variants.map((variant) => (
+          {props.variants.map((variant) => (
             <VariantStockRow
               key={variant.id}
               variant={variant}
-              stock={stockByVariant.get(variant.id)}
-              onListingsCount={onListingsCount}
+              stock={props.stockByVariant.get(variant.id)}
+              currency={props.currency}
+              connections={props.connections}
+              canCreateOffers={props.canCreateOffers}
+              onCreateOffers={props.onCreateOffers}
+              onListingsCount={props.onListingsCount}
             />
           ))}
         </tbody>
@@ -50,26 +101,72 @@ export function VariantStockTable({
   );
 }
 
-function stockCellClass(availableQuantity: number): string {
-  const status = deriveStockStatus(availableQuantity);
-  if (status === 'out-of-stock') return 'tabular stock-cell--error';
-  if (status === 'low-stock') return 'tabular stock-cell--warning';
-  return 'tabular';
+// ── Shared helpers ─────────────────────────────────────────────────────────
+
+function formatPrice(price: number | null, currency: string | null): ReactNode {
+  if (price === null) {
+    return <span className="text-muted">—</span>;
+  }
+  if (currency) {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(price);
+  }
+  return (
+    <span className="text-muted" title="Currency unknown">
+      {price.toFixed(2)}
+    </span>
+  );
 }
 
-function VariantStockRow({
-  variant,
-  stock,
-  onListingsCount,
-}: {
-  variant: ProductVariant;
-  stock: InventoryItem | undefined;
-  onListingsCount: (variantId: string, count: number) => void;
-}): ReactElement {
-  const [isOpen, setOpen] = useState(false);
+/**
+ * Map marketplace-native offer status to our badge palette (mirrors the
+ * listing-detail section). Unknown statuses fall back to neutral — the wire
+ * value is an intentional string passthrough.
+ */
+function statusTone(status: string): StatusBadgeTone {
+  const normalised = status.trim().toUpperCase();
+  if (normalised === 'ACTIVE' || normalised === 'BIDDING') return 'success';
+  if (normalised === 'ENDED' || normalised === 'INACTIVE') return 'warning';
+  return 'neutral';
+}
+
+function variantMetaLine(variant: ProductVariant): string | null {
+  const attrs =
+    variant.attributes && Object.keys(variant.attributes).length > 0
+      ? Object.entries(variant.attributes)
+          .map(([key, value]: [string, string]) => `${key}: ${value}`)
+          .join(', ')
+      : null;
+  const parts = [
+    variant.ean ? `EAN ${variant.ean}` : null,
+    // Show the SKU on the meta line only when it isn't already the headline.
+    variant.sku ? `SKU ${variant.sku}` : null,
+    attrs,
+  ].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+function stockValueClass(availableQuantity: number): string {
+  const status = deriveStockStatus(availableQuantity);
+  if (status === 'out-of-stock' || status === 'oversold') {
+    return 'variant-stock-table__stock-value stock-cell--error';
+  }
+  if (status === 'low-stock') return 'variant-stock-table__stock-value stock-cell--warning';
+  return 'variant-stock-table__stock-value';
+}
+
+/** One TanStack Query per variant for its listings, plus the count callback. */
+function useVariantListings(
+  variant: ProductVariant,
+  onListingsCount: (variantId: string, count: number) => void,
+): {
+  listings: OfferMapping[];
+  total: number;
+  isLoading: boolean;
+  isError: boolean;
+} {
   const listingsQuery = useListingsQuery({ internalId: variant.id }, { limit: 50, offset: 0 });
   const listings = listingsQuery.data?.items ?? [];
-  const listingsCount = listingsQuery.data?.total ?? 0;
+  const total = listingsQuery.data?.total ?? 0;
 
   useEffect(() => {
     if (listingsQuery.data) {
@@ -77,12 +174,208 @@ function VariantStockRow({
     }
   }, [variant.id, listingsQuery.data, onListingsCount]);
 
+  return { listings, total, isLoading: listingsQuery.isLoading, isError: Boolean(listingsQuery.error) };
+}
+
+// ── Coverage pills (cockpit language) ────────────────────────────────────────
+
+function VariantCoverage({
+  listings,
+  connections,
+  canCreateOffers,
+  onCreateOffers,
+}: {
+  listings: OfferMapping[];
+  connections: readonly Connection[];
+  canCreateOffers: boolean;
+  onCreateOffers: () => void;
+}): ReactElement {
+  const platforms = usePlatforms();
+  const listedConnectionIds = new Set(listings.map((l) => l.connectionId));
+  const platformLabel = (platformType: string): string =>
+    platforms.find((p) => p.platformType === platformType)?.displayName ?? platformType;
+
+  const listedConnections = connections.filter((c) => listedConnectionIds.has(c.id));
+
+  // Prefer one full pill per listed OfferCreator connection (matches the
+  // cockpit). When no OfferCreator connections resolve (edge/demo), fall back
+  // to one pill per listing so the column is never mysteriously empty.
+  const pills =
+    listedConnections.length > 0
+      ? listedConnections.map((connection) => {
+          const soleOfPlatform =
+            connections.filter((c) => c.platformType === connection.platformType).length === 1;
+          const label = soleOfPlatform ? platformLabel(connection.platformType) : connection.name;
+          return { key: connection.id, label, channel: connection.platformType };
+        })
+      : listings.map((listing) => ({
+          key: listing.id,
+          label: platformLabel(listing.platformType),
+          channel: listing.platformType,
+        }));
+
+  const hasGap = connections.some((c) => !listedConnectionIds.has(c.id));
+
+  if (pills.length === 0 && !(canCreateOffers && hasGap)) {
+    return <span className="text-muted">—</span>;
+  }
+
+  return (
+    <div className="variant-stock-table__listings-cell">
+      {pills.map((pill) => (
+        <span key={pill.key} className="coverage-pill coverage-pill--full" data-channel={pill.channel}>
+          {pill.label}
+        </span>
+      ))}
+      {canCreateOffers && hasGap ? (
+        <button type="button" className="products-row-cta" onClick={onCreateOffers}>
+          + Create offer
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Rich per-listing drawer ──────────────────────────────────────────────────
+
+function VariantDrawer({
+  listings,
+  total,
+  isLoading,
+  isError,
+  open,
+}: {
+  listings: OfferMapping[];
+  total: number;
+  isLoading: boolean;
+  isError: boolean;
+  open: boolean;
+}): ReactElement {
+  return (
+    <div className="variant-drawer">
+      <div className="variant-drawer__label">Listings{total > 0 ? ` (${total})` : ''}</div>
+      {isLoading ? (
+        <p className="variant-listing-card__note">Loading listings…</p>
+      ) : isError ? (
+        <p className="variant-listing-card__note">Couldn&rsquo;t load listings.</p>
+      ) : listings.length === 0 ? (
+        <p className="variant-listing-card__note">
+          No marketplace listings reference this variant yet.
+        </p>
+      ) : (
+        <div className="variant-listing-cards">
+          {listings.map((listing) => (
+            <ListingDetailCard key={listing.id} listing={listing} enabled={open} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ListingDetailCard({
+  listing,
+  enabled,
+}: {
+  listing: OfferMapping;
+  enabled: boolean;
+}): ReactElement {
+  const platforms = usePlatforms();
+  const isOffer = listing.entityType === 'Offer';
+  // Rich marketplace state is fetched lazily — only when the row is open and
+  // the mapping is an Offer (the endpoint 404s / 422s otherwise). One query
+  // per listing, retry-off, 30s stale (see the hook).
+  const offerQuery = useListingMarketplaceOfferQuery(listing.id, { enabled: enabled && isOffer });
+  const offer = offerQuery.data;
+  const label =
+    platforms.find((p) => p.platformType === listing.platformType)?.displayName ??
+    listing.platformType;
+
+  return (
+    <div className="variant-listing-card">
+      <div className="variant-listing-card__top">
+        <span className="variant-listing-card__left">
+          <span className="channel-pill" data-channel={listing.platformType}>
+            {label}
+          </span>
+          <ConnectionEntityLabel connectionId={listing.connectionId} showId={false} />
+          {offer ? (
+            <StatusBadge tone={statusTone(offer.status)} compact>
+              {offer.status}
+            </StatusBadge>
+          ) : null}
+        </span>
+        {offer ? (
+          <span className="variant-listing-card__price">
+            {offer.price.amount} {offer.price.currency}
+          </span>
+        ) : null}
+      </div>
+      <div className="variant-listing-card__meta">
+        <span className="variant-listing-meta">
+          Offer{' '}
+          <Link to={`/listings/${listing.id}`}>
+            {listing.externalId} ↗
+          </Link>
+        </span>
+        {offer ? (
+          <span className="variant-listing-meta">
+            <b>Qty</b> {offer.availableQuantity}
+          </span>
+        ) : null}
+        {offer?.category ? (
+          <span className="variant-listing-meta">
+            <b>Category</b> {offer.category.name ?? offer.category.id}
+          </span>
+        ) : null}
+        {offer?.marketplaceUrl ? (
+          <span className="variant-listing-meta">
+            <a href={offer.marketplaceUrl} target="_blank" rel="noreferrer">
+              Open on marketplace ↗
+            </a>
+          </span>
+        ) : null}
+        <span className="variant-listing-meta">
+          <b>Updated</b> <TimeDisplay iso={listing.updatedAt} />
+        </span>
+      </div>
+      {enabled && offerQuery.isLoading ? (
+        <p className="variant-listing-card__note">Loading live marketplace data…</p>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Desktop row ──────────────────────────────────────────────────────────────
+
+function VariantStockRow({
+  variant,
+  stock,
+  currency,
+  connections,
+  canCreateOffers,
+  onCreateOffers,
+  onListingsCount,
+}: {
+  variant: ProductVariant;
+  stock: InventoryItem | undefined;
+  currency: string | null;
+  connections: readonly Connection[];
+  canCreateOffers: boolean;
+  onCreateOffers: () => void;
+  onListingsCount: (variantId: string, count: number) => void;
+}): ReactElement {
+  const [isOpen, setOpen] = useState(false);
+  const { listings, total, isLoading, isError } = useVariantListings(variant, onListingsCount);
+
   const available = stock?.availableQuantity ?? 0;
   const reserved = stock?.reservedQuantity ?? 0;
+  const status = deriveStockStatus(available);
+  const meta = variantMetaLine(variant);
 
   return (
     <>
-      <tr>
+      <tr className={isOpen ? 'is-open' : undefined}>
         <td className="variant-stock-table__expand-cell">
           <button
             type="button"
@@ -97,52 +390,48 @@ function VariantStockRow({
           </button>
         </td>
         <td>
-          <div className="variant-stock-table__variant-cell">
-            {variant.sku ? (
-              <span className="mono-text">{variant.sku}</span>
-            ) : (
-              <span className="text-muted">—</span>
-            )}
+          <div className="variant-stock-table__name">
+            <span className="variant-stock-table__sku mono-text">{variant.sku ?? variant.id}</span>
+            {meta ? <span className="variant-stock-table__meta">{meta}</span> : null}
           </div>
         </td>
-        <td className="mono-text">{variant.ean ?? <span className="text-muted">—</span>}</td>
-        <td className="mono-text">
-          {variant.attributes && Object.keys(variant.attributes).length > 0 ? (
-            Object.entries(variant.attributes)
-              .map(([key, value]: [string, string]) => `${key}: ${value}`)
-              .join(', ')
-          ) : (
-            <span className="text-muted">—</span>
-          )}
-        </td>
-        <td className={stockCellClass(available)}>{available}</td>
-        <td className="tabular">{reserved > 0 ? reserved : <span className="text-muted">0</span>}</td>
         <td>
-          <StatusBadge tone="info" compact>
-            {listingsCount}
-          </StatusBadge>
+          <span className="variant-stock-table__stock">
+            <span>
+              <span className={stockValueClass(available)}>{available}</span>
+              <span className="variant-stock-table__stock-reserved">/ res {reserved}</span>
+            </span>
+            <StatusBadge tone={STOCK_STATUS_BADGE_TONE[status]} withDot compact>
+              {STOCK_STATUS_LABEL[status]}
+            </StatusBadge>
+          </span>
+        </td>
+        <td>
+          <VariantCoverage
+            listings={listings}
+            connections={connections}
+            canCreateOffers={canCreateOffers}
+            onCreateOffers={onCreateOffers}
+          />
+        </td>
+        <td className="data-table__cell--right variant-stock-table__price">
+          {formatPrice(variant.price, currency)}
+        </td>
+        <td className="data-table__cell--right">
+          <TimeDisplay className="mono-text tabular" iso={variant.updatedAt} />
         </td>
       </tr>
       <tr className={`variant-stock-table__expand-row${isOpen ? ' is-open' : ''}`}>
-        <td colSpan={7}>
+        <td colSpan={6}>
           <div className="variant-stock-table__expand-content">
             <div className="variant-stock-table__expand-content-inner">
-              <div className="listings-panel">
-                <p className="listings-panel__title">
-                  Listings using this stock{listingsCount > 0 ? ` (${listingsCount})` : ''}
-                </p>
-                {listingsQuery.isLoading ? (
-                  <p className="text-muted">Loading listings…</p>
-                ) : listingsQuery.error ? (
-                  <p className="text-muted">Couldn&rsquo;t load listings.</p>
-                ) : listings.length === 0 ? (
-                  <p className="listings-subtable__empty">
-                    No marketplace listings reference this variant yet.
-                  </p>
-                ) : (
-                  <ListingsSubtable listings={listings} />
-                )}
-              </div>
+              <VariantDrawer
+                listings={listings}
+                total={total}
+                isLoading={isLoading}
+                isError={isError}
+                open={isOpen}
+              />
             </div>
           </div>
         </td>
@@ -151,39 +440,89 @@ function VariantStockRow({
   );
 }
 
-function ListingsSubtable({ listings }: { listings: OfferMapping[] }): ReactElement {
+// ── Mobile accordion card ────────────────────────────────────────────────────
+
+function VariantStockCard({
+  variant,
+  stock,
+  currency,
+  connections,
+  canCreateOffers,
+  onCreateOffers,
+  onListingsCount,
+}: {
+  variant: ProductVariant;
+  stock: InventoryItem | undefined;
+  currency: string | null;
+  connections: readonly Connection[];
+  canCreateOffers: boolean;
+  onCreateOffers: () => void;
+  onListingsCount: (variantId: string, count: number) => void;
+}): ReactElement {
+  const [isOpen, setOpen] = useState(false);
+  const { listings, total, isLoading, isError } = useVariantListings(variant, onListingsCount);
+
+  const available = stock?.availableQuantity ?? 0;
+  const reserved = stock?.reservedQuantity ?? 0;
+  const status = deriveStockStatus(available);
+  const meta = variantMetaLine(variant);
+
   return (
-    <table className="listings-subtable">
-      <thead>
-        <tr>
-          <th>Platform</th>
-          <th>Connection</th>
-          <th>External ID</th>
-          <th>Updated</th>
-        </tr>
-      </thead>
-      <tbody>
-        {listings.map((listing) => (
-          <tr key={listing.id}>
-            <td>
-              <Link className="listings-subtable__link" to={`/listings/${listing.id}`}>
-                {listing.platformType}
-              </Link>
-            </td>
-            <td>
-              <ConnectionEntityLabel connectionId={listing.connectionId} showId={false} />
-            </td>
-            <td className="mono-text">
-              <Link className="listings-subtable__link" to={`/listings/${listing.id}`}>
-                {listing.externalId}
-              </Link>
-            </td>
-            <td className="mono-text tabular">
-              <TimeDisplay iso={listing.updatedAt} />
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <div className="variant-card">
+      <button
+        type="button"
+        className="variant-card__header"
+        aria-expanded={isOpen}
+        aria-label={`Toggle details for ${variant.sku ?? variant.id}`}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <span className="variant-stock-table__name">
+          <span className="variant-stock-table__sku mono-text">{variant.sku ?? variant.id}</span>
+          {meta ? <span className="variant-stock-table__meta">{meta}</span> : null}
+        </span>
+        <span className="variant-card__aside">
+          <StatusBadge tone={STOCK_STATUS_BADGE_TONE[status]} withDot compact>
+            {STOCK_STATUS_LABEL[status]}
+          </StatusBadge>
+          <span className="variant-card__disclosure" aria-hidden="true">
+            <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M4 2l4 4-4 4" />
+            </svg>
+          </span>
+        </span>
+      </button>
+      {isOpen ? (
+        <div className="variant-card__body">
+          <div className="variant-card__grid">
+            <span className="variant-card__cell">
+              <span className="variant-card__cell-label">Available</span>
+              <span className="variant-card__cell-value">
+                {available} / res {reserved}
+              </span>
+            </span>
+            <span className="variant-card__cell">
+              <span className="variant-card__cell-label">Price</span>
+              <span className="variant-card__cell-value">{formatPrice(variant.price, currency)}</span>
+            </span>
+            <span className="variant-card__cell variant-card__cell--full">
+              <span className="variant-card__cell-label">Listings</span>
+              <VariantCoverage
+                listings={listings}
+                connections={connections}
+                canCreateOffers={canCreateOffers}
+                onCreateOffers={onCreateOffers}
+              />
+            </span>
+          </div>
+          <VariantDrawer
+            listings={listings}
+            total={total}
+            isLoading={isLoading}
+            isError={isError}
+            open={isOpen}
+          />
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/docs/plans/implementation-plan-product-detail-polish.md
+++ b/docs/plans/implementation-plan-product-detail-polish.md
@@ -1,0 +1,88 @@
+# Implementation Plan — Product detail polish (#1752)
+
+## 1. Goal & layer
+
+Frontend-only polish of `/products/:id` (Overview tab). Match the approved design mockup
+(https://claude.ai/code/artifact/e27cee32-0cf6-4c53-b0b6-8ee9a27a4780). Dark + light preserved,
+existing OKLCH tokens only, existing shared components reused.
+
+**Layer:** Frontend / Interface — `apps/web/src/pages/products/**`, `apps/web/src/features/products/**`,
+`apps/web/src/index.css`.
+
+**Non-goals:** no backend changes; no new design tokens (unless forced, then `index.css` → `tokens.ts`);
+no change to the Content tab; no new per-variant "listing gap" API (derive from existing data).
+
+## 2. Reuse (verified in repo)
+
+- `VariantStockTable` is used **only** by `product-detail-page.tsx`; `product-detail-hero`,
+  `product-detail__kpi-row`, `description-block`, `id-chip*` CSS are page-local — safe to restyle.
+- Cockpit row language already exists as global CSS: `.coverage-pill(--full/--partial/--none)`,
+  `.channel-pill`, `.products-row-cta`, `.products-variant-row*`, `.products-detail-*`,
+  `.products-cell-stack`, `.status-badge*`. Reuse verbatim; add only the table-specific chrome.
+- Per-listing rich detail: `useListingMarketplaceOfferQuery(mappingId, { enabled })` (retry:false,
+  30s stale) returns `{ status, title, price{amount,currency}, availableQuantity, category, marketplaceUrl, endsAt }`.
+- Active OfferCreator connections + create-offer launch: mirror `products-list-page.tsx`
+  (`useConnectionsQuery` → filter `status==='active' && supportedCapabilities.includes('OfferCreator')`,
+  `MarketplacePickerModal`, navigate `/listings/bulk-create/wizard?productIds=&connectionId=`).
+- Stock tones: `deriveStockStatus` / `STOCK_STATUS_BADGE_TONE` / `STOCK_STATUS_LABEL` (page-local helper).
+- Marketplace status → tone: replicate the tiny `statusTone` helper (ACTIVE/BIDDING→success,
+  ENDED/INACTIVE→warning, else neutral).
+
+## 3. Design
+
+### 3.1 `product-detail-page.tsx`
+- **KPI strip:** merge the `--cols-1` Price card + `--cols-3` stat row into one 4-tile strip
+  (`--cols-4`): Price / Available / Variants / Listings. Keep Available's tone + Price accent rule.
+- **Description → read-only Source clarity:** keep the block, add a `Source · read-only` `StatusBadge`
+  tag in the section header + an "Edit in Content →" link; empty state points to the Content tab.
+- **"External IDs" → "Source":** new `ProductSourceSection` (feature component) — renders the master
+  origin (`externalIds[0]`) as `channel-pill` + connection name + `platformType · externalId` with a
+  `Master` badge; remaining mappings render below via existing `ExternalIdChips`. Needs connections
+  (name) + `usePlatforms` (label).
+- **Create-offer plumbing:** add `useConnectionsQuery`, derive `offerCreatorConnections`, `MarketplacePickerModal`,
+  `goToWizard`; pass `connections` / `canCreateOffers` (`useWriteAccess('listings:write', demoMode)`) /
+  `onCreateOffers` into `VariantStockTable`.
+
+### 3.2 `variant-stock-table.tsx` (rewrite)
+- Full-width `.data-table` (drop `min-width: 640px`; add mobile card transform).
+- Columns: expand · **Variant** (SKU/attrs + `EAN … · SKU` meta) · **Stock** (`avail / res n` + IN STOCK
+  badge, `products-cell-stack`) · **Listings** (coverage pills full-per-listed-connection + `+ Create offer`
+  CTA on gap) · **Price** (master variant price, right) · **Updated** (right).
+- **Rich drawer:** inset panel (`products-row-detail` look) — per listing a `ListingDetailCard`
+  (own `useListingMarketplaceOfferQuery`, enabled only when row open + `entityType==='Offer'`):
+  channel-pill + connection (`ConnectionEntityLabel`) + status badge + price + qty + offer-id link
+  (`/listings/:id`) + category + marketplace URL + updated. Falls back to mapping-only fields on
+  loading/unavailable (non-offer, 404/422).
+- **Mobile (<640px):** table → stacked accordion cards (tappable header: SKU + stock badge + chevron;
+  expanded: labelled grid + listing cards).
+
+### 3.3 `index.css`
+New bounded section `/* ── Product detail v2 (#1752) ── */`:
+- `.product-detail__kpi-row--cols-4` (4 → 2 → 2 responsive).
+- `.product-source*` (source item + Master tag + secondary chips).
+- `.variant-stock-table` full-width table chrome + listing-detail cards (`.variant-listing-card*`).
+- Hero responsive: `.product-detail-hero` single-column + full-width gallery under 768px;
+  facts as auto-fit grid with `overflow-wrap:anywhere` (kills char-wrap).
+- Mobile card transform for the variant table under 640px.
+
+## 4. Steps
+
+1. `index.css` — add the v2 section (KPI cols-4, source, hero responsive, table chrome, listing cards, mobile cards).
+2. `variant-stock-table.tsx` — rewrite (props, columns, coverage pills, rich drawer, mobile cards).
+3. `product-source-section.tsx` — new feature component (`features/products/components`).
+4. `product-detail-page.tsx` — KPI strip merge, Description tag+link, Source section, create-offer plumbing, table props.
+5. Tests — update `variant-stock-table` test (if present) + add coverage-pill / drawer / source-section cases.
+6. Quality gate: `pnpm lint`, `pnpm type-check`, scoped `pnpm test`.
+7. Visual verify: run web (worktree) against demo API :3000, screenshot desktop 1280 + mobile 375, compare to mockup.
+
+## 5. Validation
+
+- FE dependency direction respected (pages → features → shared; barrel imports; no raw fetch).
+- No `any`; explicit return types on components; tokens only (drift check green).
+- All four async states handled in the drawer (loading/error/empty/data).
+- a11y: expand buttons keep `aria-expanded`/`aria-label`; focus rings via `shadow-focus`; color paired with text/badge.
+
+## Risks
+
+- Create-offer wiring pulls the picker modal + write-access gate onto the detail page — mirrors the list page 1:1 to stay low-risk.
+- Per-listing detail fan-out: one query per listing on expand — bounded (a variant has a handful of listings), lazy, retry-off.


### PR DESCRIPTION
## What & why

Polishes the product detail page (`/products/:id`, Overview tab) and gives it a real mobile layout. The page looked thin and had no mobile support (the hero pinned the gallery at 8rem so dates wrapped one character per line; the variant table forced a 640px horizontal scroll).

Follows the approved design proposal: https://claude.ai/code/artifact/e27cee32-0cf6-4c53-b0b6-8ee9a27a4780

## Changes

- **Full-width Variants & stock table** in the products-cockpit row language: per-variant stock as `available / reserved` + `IN STOCK` badge, per-channel `coverage-pill`s, master price, and a `+ Create offer` CTA on listing gaps (reuses the OfferCreator connection set + bulk-wizard launch, mirroring `products-list-page`).
- **Rich per-listing variant drawer**: expanding a variant lazily fetches each listing's live marketplace state (status, price, quantity, category, marketplace URL) via the existing `useListingMarketplaceOfferQuery` — one query per listing, gated on expand.
- **"External IDs" -> "Source"**: leads with the master origin (`externalIds[0]`) + a `Master` tag; any further per-connection mappings list beneath.
- **Description vs Content clarified**: Description is tagged read-only source with an "Edit in Content ->" link (the Content tab remains the editable draft/publish surface).
- **Unified 4-tile KPI strip** (Price / Available / Variants / Listings; 2x2 on mobile).
- **Responsive**: hero stacks under 768px with a full-width gallery (fixes the char-by-char wrap); the variant table folds into tappable accordion cards under 640px showing the same listing detail.

Reuses existing OKLCH tokens and shared primitives — no new tokens, no backend changes. New `product-source-section.tsx`; the rest is `variant-stock-table.tsx`, `product-detail-page.tsx`, and a bounded `index.css` section.

## How to test

1. Open `/products/:id` for a product with listings (e.g. the E2E Golden Path product on the demo stack).
2. Confirm the 4-tile KPI strip, the Source section with a `Master` tag, and the read-only Description tag + "Edit in Content" link.
3. Expand a variant row — the drawer shows one card per listing with live status/price/qty/category/URL.
4. Resize to <640px: the hero stacks (no char-wrap) and the table becomes tappable accordion cards.

Verified against the running app (demo API) at desktop 1360px and mobile 390px; both match the mockup.

## Quality gate

- `pnpm --filter @openlinker/web type-check` — clean
- `pnpm --filter @openlinker/web test` — 2378 passing (updated `product-detail-page.test.tsx`, added coverage/CTA + drawer cases)
- eslint on changed files — clean; design-token drift check — clean (no new tokens)

Closes #1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013C86Sx5EyrNAwd3a2K7GVg
