### PR TITLE
feat(products): product-detail round-2 — rich variant drawer, single/multi states, master currency & attributes

### DIFF
--- a/apps/api/src/listings/http/dto/category-path-response.dto.ts
+++ b/apps/api/src/listings/http/dto/category-path-response.dto.ts
@@ -1,0 +1,28 @@
+/**
+ * Category Path Response DTO
+ *
+ * Wire shape returned by
+ * `GET /listings/connections/:connectionId/categories/:categoryId/path`
+ * (#1752). Carries the resolved category breadcrumb ordered root -> leaf, so
+ * the listing-detail drawer can render "Root > ... > Leaf" instead of the raw
+ * category id Allegro's offer payload carries.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CategoryPathSegmentResponseDto {
+  @ApiProperty({ description: 'Marketplace-issued category id.' })
+  id!: string;
+
+  @ApiProperty({ description: 'Human-readable category name (operator-language).' })
+  name!: string;
+}
+
+export class CategoryPathResponseDto {
+  @ApiProperty({
+    type: [CategoryPathSegmentResponseDto],
+    description: 'Breadcrumb segments ordered root -> leaf.',
+  })
+  path!: CategoryPathSegmentResponseDto[];
+}

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -743,6 +743,59 @@ describe('ListingsController', () => {
     });
   });
 
+  describe('getCategoryPath (#1752)', () => {
+    const samplePath = [
+      { id: '1', name: 'Electronics' },
+      { id: '10', name: 'Smartphones' },
+    ];
+
+    function makeAdapter(
+      withCategoryPathReader: boolean,
+      fetch: jest.Mock = jest.fn().mockResolvedValue(samplePath)
+    ): OfferManagerPort {
+      const base = { updateOfferQuantity: jest.fn() } as unknown as OfferManagerPort;
+      if (withCategoryPathReader) {
+        return Object.assign(base, { fetchCategoryPath: fetch });
+      }
+      return base;
+    }
+
+    it('returns the breadcrumb wrapped under `path`, root -> leaf', async () => {
+      const fetch = jest.fn().mockResolvedValue(samplePath);
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeAdapter(true, fetch));
+
+      const result = await controller.getCategoryPath('conn-1', '10');
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith('conn-1', 'OfferManager');
+      expect(fetch).toHaveBeenCalledWith('10');
+      expect(result.path).toEqual(samplePath);
+    });
+
+    it('throws 422 when the adapter does not implement CategoryPathReader', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeAdapter(false));
+
+      await expect(controller.getCategoryPath('conn-1', '10')).rejects.toBeInstanceOf(
+        UnprocessableEntityException
+      );
+    });
+
+    it('translates CategoryNotFoundException to a 404 NotFoundException', async () => {
+      const fetch = jest.fn().mockRejectedValue(new CategoryNotFoundException('999999', 'allegro'));
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeAdapter(true, fetch));
+
+      await expect(controller.getCategoryPath('conn-1', '999999')).rejects.toBeInstanceOf(
+        NotFoundException
+      );
+    });
+
+    it('propagates upstream errors that are not CategoryNotFoundException', async () => {
+      const fetch = jest.fn().mockRejectedValue(new Error('upstream-503'));
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeAdapter(true, fetch));
+
+      await expect(controller.getCategoryPath('conn-1', '10')).rejects.toThrow('upstream-503');
+    });
+  });
+
   describe('resolveCategory (#631)', () => {
     // Opaque adapter — the integration-service mock returns it just to satisfy
     // the pre-flight connection-validity check; the resolveCategory service

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -36,6 +36,7 @@ import {
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
   isCatalogProductReader,
   isCategoryParametersReader,
+  isCategoryPathReader,
   isOfferReader,
   OfferNotFoundOnMarketplaceException,
   OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
@@ -82,6 +83,7 @@ import { ResponsibleProducersResponseDto } from './dto/responsible-producers-res
 import { DeliveryPriceListsResponseDto } from './dto/delivery-price-lists-response.dto';
 import type { CategoryParameterResponseDto } from './dto/category-parameter-response.dto';
 import { CategoryParametersListResponseDto } from './dto/category-parameter-response.dto';
+import { CategoryPathResponseDto } from './dto/category-path-response.dto';
 import { ResolveCategoryRequestDto, ResolveCategoryResponseDto } from './dto/resolve-category.dto';
 import {
   ResolveCategoryBatchRequestDto,
@@ -534,6 +536,63 @@ export class ListingsController {
     }
 
     return { parameters: parameters.map((p) => this.toCategoryParameterResponseDto(p)) };
+  }
+
+  @Roles('admin', 'operator', 'viewer')
+  @Get('connections/:connectionId/categories/:categoryId/path')
+  @HttpCode(HttpStatus.OK)
+  // Category breadcrumbs are effectively immutable public taxonomy — let the
+  // browser cache them for a day so re-opening the listing drawer never re-hits
+  // the marketplace.
+  @Header('Cache-Control', 'public, max-age=86400')
+  @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+  @ApiParam({ name: 'categoryId', description: 'Marketplace category ID (Allegro-issued).' })
+  @ApiOperation({
+    summary: 'Resolve a category id to its breadcrumb path (#1752)',
+    description:
+      "Returns the category's full ancestor breadcrumb ordered root -> leaf. The listing-detail drawer renders this instead of the raw category id Allegro's offer payload carries.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Breadcrumb segments wrapped under `path`.',
+    type: CategoryPathResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Connection or category not found.' })
+  @ApiResponse({ status: 409, description: 'Connection disabled.' })
+  @ApiResponse({
+    status: 422,
+    description: 'Adapter does not support category-path reading.',
+  })
+  async getCategoryPath(
+    @Param('connectionId') connectionId: string,
+    @Param('categoryId') categoryId: string
+  ): Promise<CategoryPathResponseDto> {
+    // Throws ConnectionNotFoundException (404) / ConnectionDisabledException (409) /
+    // CapabilityNotSupportedException (422) for upstream connection-level issues.
+    const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+      connectionId,
+      'OfferManager'
+    );
+
+    if (!isCategoryPathReader(adapter)) {
+      throw new UnprocessableEntityException(
+        `Adapter for connection ${connectionId} does not support category-path reading`
+      );
+    }
+
+    let path: { id: string; name: string }[];
+    try {
+      path = await adapter.fetchCategoryPath(categoryId);
+    } catch (err) {
+      if (err instanceof CategoryNotFoundException) {
+        throw new NotFoundException(
+          `Category ${categoryId} not found on connection ${connectionId}`
+        );
+      }
+      throw err;
+    }
+
+    return { path: path.map((segment) => ({ id: segment.id, name: segment.name })) };
   }
 
   @Roles('admin', 'operator', 'viewer')

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -55,6 +55,7 @@ import {
 } from '@openlinker/core/listings';
 import type {
   CategoryParameter,
+  CategoryPathSegment,
   OfferCreationRecord,
   OfferManagerPort,
 } from '@openlinker/core/listings';
@@ -580,7 +581,7 @@ export class ListingsController {
       );
     }
 
-    let path: { id: string; name: string }[];
+    let path: CategoryPathSegment[];
     try {
       path = await adapter.fetchCategoryPath(categoryId);
     } catch (err) {

--- a/apps/api/src/migrations/1827000000000-add-product-features.ts
+++ b/apps/api/src/migrations/1827000000000-add-product-features.ts
@@ -1,0 +1,26 @@
+/**
+ * Add Product Features (#1752)
+ *
+ * Adds a nullable `features` JSONB column to `products` — the source-platform
+ * product-level attributes carried on `Product.features` (`{ name, value }[]`,
+ * e.g. Brand / Material). Until now the master product sync fetched and mapped
+ * these features but dropped them on persist (no column). Existing rows get
+ * `NULL`; the column repopulates on the next product sync, so no backfill is
+ * needed.
+ *
+ * Mirrors the existing nullable `categories` / `images` JSONB columns.
+ * `IF NOT EXISTS` / `IF EXISTS` guards keep up/down idempotent.
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductFeatures1827000000000 implements MigrationInterface {
+  name = 'AddProductFeatures1827000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "products" ADD COLUMN IF NOT EXISTS "features" jsonb`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "products" DROP COLUMN IF EXISTS "features"`);
+  }
+}

--- a/apps/api/src/migrations/1828000000000-add-product-features.ts
+++ b/apps/api/src/migrations/1828000000000-add-product-features.ts
@@ -13,8 +13,8 @@
  */
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddProductFeatures1827000000000 implements MigrationInterface {
-  name = 'AddProductFeatures1827000000000';
+export class AddProductFeatures1828000000000 implements MigrationInterface {
+  name = 'AddProductFeatures1828000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "products" ADD COLUMN IF NOT EXISTS "features" jsonb`);

--- a/apps/api/src/products/http/dto/product-response.dto.ts
+++ b/apps/api/src/products/http/dto/product-response.dto.ts
@@ -47,6 +47,18 @@ export class ProductResponseDto {
   })
   categories!: string[] | null;
 
+  @ApiPropertyOptional({
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: { name: { type: 'string' }, value: { type: 'string' } },
+    },
+    description:
+      'Source-platform product-level attributes (#1752), e.g. Brand / Material. ' +
+      'Distinct from variant-distinguishing attributes. Absent until a sync populates it.',
+  })
+  features?: { name: string; value: string }[];
+
   @ApiProperty({ description: 'Creation timestamp (ISO 8601)' })
   createdAt!: string;
 

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -315,6 +315,7 @@ export class ProductsController {
       description: product.description,
       images: product.images,
       categories: product.categories ?? null,
+      ...(product.features ? { features: product.features } : {}),
       createdAt: product.createdAt!.toISOString(),
       updatedAt: product.updatedAt!.toISOString(),
     };

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -10,6 +10,7 @@ import type {
   CatalogProduct,
   CatalogProductMatchResult,
   CategoryParametersListResponse,
+  CategoryPathResponse,
   CreateOfferRequest,
   CreateOfferResponse,
   FindProductsByBarcodeRequest,
@@ -104,6 +105,16 @@ export interface ListingsApi {
     connectionId: string,
     categoryId: string,
   ) => Promise<CategoryParametersListResponse>;
+  /**
+   * Resolves a marketplace category id to its breadcrumb path (#1752), root ->
+   * leaf. Returns 404 if the category is unknown; 422 if the connection's
+   * adapter does not implement `CategoryPathReader`. Callers fall back to the
+   * raw id on either.
+   */
+  getCategoryPath: (
+    connectionId: string,
+    categoryId: string,
+  ) => Promise<CategoryPathResponse>;
   findProductsByBarcode: (
     connectionId: string,
     request: FindProductsByBarcodeRequest,
@@ -245,6 +256,11 @@ export function createListingsApi(request: ApiRequest): ListingsApi {
     getCategoryParameters(connectionId, categoryId): Promise<CategoryParametersListResponse> {
       return request<CategoryParametersListResponse>(
         `/listings/connections/${connectionId}/categories/${categoryId}/parameters`,
+      );
+    },
+    getCategoryPath(connectionId, categoryId): Promise<CategoryPathResponse> {
+      return request<CategoryPathResponse>(
+        `/listings/connections/${connectionId}/categories/${categoryId}/path`,
       );
     },
     findProductsByBarcode(connectionId, body): Promise<CatalogProductMatchResult> {

--- a/apps/web/src/features/listings/api/listings.query-keys.ts
+++ b/apps/web/src/features/listings/api/listings.query-keys.ts
@@ -28,6 +28,9 @@ export const listingsQueryKeys = {
       connectionId,
       categoryId,
     ] as const,
+  // #1752 — category breadcrumb resolution for the listing-detail drawer.
+  categoryPath: (connectionId: string, categoryId: string) =>
+    ['listings', 'categoryPath', connectionId, categoryId] as const,
   catalogProductMatch: (connectionId: string, barcode: string, categoryId: string) =>
     ['listings', 'catalogProductMatch', connectionId, barcode, categoryId] as const,
   catalogProduct: (connectionId: string, productId: string) =>

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -492,6 +492,19 @@ export interface CategoryParametersListResponse {
 }
 
 /**
+ * One node of a category breadcrumb, ordered root -> leaf (#1752). Mirrors the
+ * BE `CategoryPathResponseDto` 1:1.
+ */
+export interface CategoryPathSegment {
+  id: string;
+  name: string;
+}
+
+export interface CategoryPathResponse {
+  path: CategoryPathSegment[];
+}
+
+/**
  * Catalog product types — mirror the neutral BE shapes from
  * `@openlinker/core/listings` (#633). Preserve backend `camelCase`.
  */

--- a/apps/web/src/features/listings/hooks/use-category-path-query.ts
+++ b/apps/web/src/features/listings/hooks/use-category-path-query.ts
@@ -1,0 +1,46 @@
+/**
+ * use-category-path-query
+ *
+ * Resolves a marketplace category id to its breadcrumb path (#1752), root ->
+ * leaf, so the listing-detail drawer can render "Root > ... > Leaf" instead of
+ * the raw id Allegro's offer payload carries. Backend sets a 24h Cache-Control;
+ * the FE keeps a matching staleTime since category taxonomy is effectively
+ * immutable.
+ *
+ * `retry: false` — a 404/422 (unknown category / adapter without
+ * `CategoryPathReader`) is a soft fallback to the raw id, not worth retrying.
+ *
+ * Returns the unwrapped `CategoryPathSegment[]` — the response envelope's
+ * `path` wrapper is unpacked here.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { CategoryPathSegment } from '../api/listings.types';
+
+export const CATEGORY_PATH_STALE_TIME_MS = 24 * 60 * 60 * 1000;
+
+export function useCategoryPathQuery(
+  connectionId: string | undefined,
+  categoryId: string | undefined,
+  options?: { enabled?: boolean },
+): UseQueryResult<CategoryPathSegment[]> {
+  const apiClient = useApiClient();
+  const enabled = (options?.enabled ?? true) && Boolean(connectionId && categoryId);
+
+  return useQuery<CategoryPathSegment[]>({
+    queryKey: listingsQueryKeys.categoryPath(connectionId ?? '', categoryId ?? ''),
+    queryFn: async () => {
+      const response = await apiClient.listings.getCategoryPath(
+        connectionId as string,
+        categoryId as string,
+      );
+      return response.path;
+    },
+    enabled,
+    retry: false,
+    staleTime: CATEGORY_PATH_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/features/products/api/products.types.ts
+++ b/apps/web/src/features/products/api/products.types.ts
@@ -47,6 +47,12 @@ export interface Product {
    * per-source-category mapping (#1522). Null/absent until a sync populates it.
    */
   categories?: string[] | null;
+  /**
+   * Source-platform product-level attributes (#1752), e.g. Brand / Material.
+   * Distinct from variant-distinguishing attributes (which show per-variant in
+   * the stock drawer). Absent/empty until a sync populates them.
+   */
+  features?: { name: string; value: string }[];
   createdAt: string;
   updatedAt: string;
   variants?: ProductVariant[];

--- a/apps/web/src/features/products/components/product-gallery.tsx
+++ b/apps/web/src/features/products/components/product-gallery.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useState, type KeyboardEvent, type ReactElement } from 'react';
-import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
 import {
   Dialog,
   DialogContent,
@@ -16,6 +15,7 @@ interface ProductGalleryProps {
 export function ProductGallery({ images, name }: ProductGalleryProps): ReactElement {
   const [activeIndex, setActiveIndex] = useState(0);
   const [isLightboxOpen, setLightboxOpen] = useState(false);
+  const [brokenImages, setBrokenImages] = useState<Record<string, boolean>>({});
 
   const navigate = useCallback(
     (delta: number) => {
@@ -24,11 +24,22 @@ export function ProductGallery({ images, name }: ProductGalleryProps): ReactElem
     [images.length],
   );
 
+  const initial = name.trim().charAt(0).toUpperCase() || '?';
+
+  // No photos: render the same bordered square the gallery uses, with a
+  // neutral initial placeholder — never a clipped/broken-image box.
   if (images.length === 0) {
-    return <ProductThumbnail src={null} name={name} size="md" />;
+    return (
+      <div className="product-gallery" role="group" aria-label="Product photos">
+        <div className="product-gallery__main product-gallery__main--static" aria-hidden="true">
+          <span className="product-gallery__placeholder">{initial}</span>
+        </div>
+      </div>
+    );
   }
 
   const activeImage = images[activeIndex];
+  const isActiveBroken = Boolean(brokenImages[activeImage]);
 
   return (
     <div className="product-gallery" role="group" aria-label="Product photos">
@@ -41,7 +52,15 @@ export function ProductGallery({ images, name }: ProductGalleryProps): ReactElem
       <Dialog open={isLightboxOpen} onOpenChange={setLightboxOpen}>
         <DialogTrigger asChild>
           <button type="button" className="product-gallery__main" aria-label="Open photo viewer">
-            <img src={activeImage} alt="" />
+            <span className="product-gallery__placeholder" aria-hidden="true">
+              {initial}
+            </span>
+            <img
+              src={activeImage}
+              alt=""
+              className={isActiveBroken ? 'is-broken' : undefined}
+              onError={() => setBrokenImages((prev) => ({ ...prev, [activeImage]: true }))}
+            />
             <span className="product-gallery__expand-hint" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2}>
                 <path d="M9 4H4v5M15 4h5v5M9 20H4v-5M15 20h5v-5" />

--- a/apps/web/src/features/products/components/product-gallery.tsx
+++ b/apps/web/src/features/products/components/product-gallery.tsx
@@ -27,10 +27,12 @@ export function ProductGallery({ images, name }: ProductGalleryProps): ReactElem
   const initial = name.trim().charAt(0).toUpperCase() || '?';
 
   // No photos: render the same bordered square the gallery uses, with a
-  // neutral initial placeholder — never a clipped/broken-image box.
+  // neutral initial placeholder — never a clipped/broken-image box. No
+  // `role="group"` here: its only child is decorative (`aria-hidden`), so a
+  // labelled group would announce as empty to screen readers.
   if (images.length === 0) {
     return (
-      <div className="product-gallery" role="group" aria-label="Product photos">
+      <div className="product-gallery">
         <div className="product-gallery__main product-gallery__main--static" aria-hidden="true">
           <span className="product-gallery__placeholder">{initial}</span>
         </div>
@@ -57,7 +59,7 @@ export function ProductGallery({ images, name }: ProductGalleryProps): ReactElem
             </span>
             <img
               src={activeImage}
-              alt=""
+              alt={name}
               className={isActiveBroken ? 'is-broken' : undefined}
               onError={() => setBrokenImages((prev) => ({ ...prev, [activeImage]: true }))}
             />
@@ -78,7 +80,13 @@ export function ProductGallery({ images, name }: ProductGalleryProps): ReactElem
                 onClick={() => setActiveIndex(index)}
                 aria-label={`Photo ${index + 1} of ${images.length}`}
               >
-                <img src={image} alt="" loading="lazy" />
+                <img
+                  src={image}
+                  alt=""
+                  loading="lazy"
+                  className={brokenImages[image] ? 'is-broken' : undefined}
+                  onError={() => setBrokenImages((prev) => ({ ...prev, [image]: true }))}
+                />
               </button>
             ))}
           </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11831,13 +11831,6 @@ input.bulk-dispatch__num--wide {
   min-width: 0;
 }
 
-.product-detail-hero__title-row {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
 .product-detail-hero__title {
   margin: 0;
   font-size: 1.125rem;
@@ -11862,18 +11855,18 @@ input.bulk-dispatch__num--wide {
 }
 
 .product-detail-hero__facts {
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 0.5rem;
+  row-gap: 0.125rem;
+  align-items: baseline;
   margin-top: 0.125rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
 }
 
 .product-detail-hero__fact {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.3rem;
-  font-size: 0.75rem;
-  color: var(--text-secondary);
+  display: contents;
 }
 
 .product-detail-hero__fact-label {
@@ -11883,7 +11876,6 @@ input.bulk-dispatch__num--wide {
   letter-spacing: var(--tracking-caps);
   text-transform: uppercase;
   color: var(--text-muted);
-  min-width: 6.5rem;
 }
 
 .product-gallery {
@@ -11908,15 +11900,39 @@ input.bulk-dispatch__num--wide {
   box-shadow: var(--shadow-xs);
 }
 
+.product-gallery__main--static {
+  cursor: default;
+}
+
 .product-gallery__main:focus-visible {
   outline: 2px solid var(--accent-focus);
   outline-offset: 2px;
 }
 
 .product-gallery__main img {
+  position: absolute;
+  inset: 0;
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.product-gallery__main img.is-broken {
+  display: none;
+}
+
+.product-gallery__placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--bg-surface-muted);
 }
 
 .product-gallery__expand-hint {
@@ -12408,16 +12424,6 @@ input.bulk-dispatch__num--wide {
   .product-gallery__main {
     aspect-ratio: 16 / 10;
   }
-
-  .product-detail-hero__fact {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.125rem;
-  }
-
-  .product-detail-hero__fact-label {
-    min-width: 0;
-  }
 }
 
 /* Description section header — read-only source vs editable Content. */
@@ -12559,17 +12565,187 @@ input.bulk-dispatch__num--wide {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  margin: 0 var(--space-4) var(--space-4) calc(2.25rem + var(--space-4));
+  margin: var(--space-3) var(--space-4) var(--space-4) calc(2.25rem + var(--space-4));
   padding: var(--space-4);
   background: var(--bg-surface-muted);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
 }
 
+/* Single-product "Listed on" panel: same drawer chrome, no row-aligned inset. */
+.variant-drawer--flush {
+  margin: 0;
+}
+
 .variant-drawer__links {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
+}
+
+/* Top-of-drawer channel deep-link pills (mirrors .products-detail-links__link):
+   1px accent-bordered pill, channel-hued leading dot, accent arrow. */
+.variant-drawer__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px var(--space-3);
+  border: 1px solid var(--accent-primary-border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--accent-primary-soft-strong);
+  font-size: 0.75rem;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+
+.variant-drawer__link:hover {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+.variant-drawer__link:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.variant-drawer__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.variant-drawer__link[data-channel='allegro'] .variant-drawer__dot {
+  background: oklch(70% 0.18 35);
+}
+.variant-drawer__link[data-channel='erli'] .variant-drawer__dot {
+  background: oklch(66% 0.2 15);
+}
+.variant-drawer__link[data-channel='prestashop'] .variant-drawer__dot {
+  background: oklch(60% 0.18 250);
+}
+.variant-drawer__link[data-channel='woocommerce'] .variant-drawer__dot {
+  background: oklch(64% 0.16 150);
+}
+
+.variant-drawer__arrow {
+  color: var(--accent-primary);
+  font-size: 0.75rem;
+}
+
+/* Variant metadata grid — 4 mono-caps-labelled cells above the listings. */
+.variant-drawer__meta {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-3) var(--space-5);
+}
+
+@media (max-width: 1023.98px) {
+  .variant-drawer__meta {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.variant-drawer__meta-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.variant-drawer__meta-label {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.variant-drawer__meta-value {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.variant-drawer__meta-value--wrap {
+  overflow-wrap: anywhere;
+}
+
+.variant-drawer__meta-muted {
+  color: var(--text-muted);
+}
+
+/* Attribute chips — small mono pills in the Attributes cell. */
+.attr-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.attr-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 2px var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--bg-muted);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+}
+
+.attr-chip b {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* Listings block sits below the metadata grid with its own top gap. */
+.variant-drawer__listings {
+  margin-top: var(--space-4);
+}
+
+.listings-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1) var(--space-2);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  margin-bottom: var(--space-2);
+}
+
+/* Muted separator between meta / summary items. */
+.lmeta__sep {
+  color: var(--border-strong);
+}
+
+/* Two-line date stack for the table Updated column (no truncation). */
+.dt2 {
+  display: inline-flex;
+  flex-direction: column;
+  line-height: 1.25;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.dt2__date {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.dt2__time {
+  font-size: 0.66rem;
+  color: var(--text-muted);
+}
+
+.variant-stock-table__updated-cell {
+  white-space: normal;
 }
 
 .variant-drawer__label {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -279,6 +279,19 @@
   --viz-cat-4: oklch(60% 0.13 150);
   --viz-cat-muted: oklch(82% 0.008 80);
 
+  /* ── Channel brand hues (#1752) ──────────────────────────────────────
+   * Per-marketplace dot/pill identity colours, previously copy-pasted as raw
+   * oklch literals across the orders, coverage, channel-pill, product-detail,
+   * and variant-drawer rulesets. Brand identity, NOT status — a channel hue
+   * distinguishes the platform, never encodes health. Single definition
+   * (identical in light/dark), mirroring the viz categorical set. */
+  --channel-allegro: oklch(70% 0.18 35);
+  --channel-prestashop: oklch(60% 0.18 250);
+  --channel-erli: oklch(66% 0.17 320);
+  --channel-woocommerce: oklch(64% 0.16 150);
+  --channel-amazon: oklch(72% 0.16 75);
+  --channel-shopify: oklch(64% 0.16 150);
+
   /* ── Status: review / manual ──────────────────────────────────────── */
   --status-review: oklch(58% 0.16 290);
   --status-review-soft: oklch(96% 0.04 290);
@@ -7924,9 +7937,9 @@ a.kpi-card:focus-visible {
   background: var(--text-muted);
   flex-shrink: 0;
 }
-.orders-ext-link[data-channel='allegro']::before { background: oklch(70% 0.18 35); }
-.orders-ext-link[data-channel='prestashop']::before { background: oklch(60% 0.18 250); }
-.orders-ext-link[data-channel='erli']::before { background: oklch(66% 0.17 320); }
+.orders-ext-link[data-channel='allegro']::before { background: var(--channel-allegro); }
+.orders-ext-link[data-channel='prestashop']::before { background: var(--channel-prestashop); }
+.orders-ext-link[data-channel='erli']::before { background: var(--channel-erli); }
 .orders-ext-link__arrow { color: var(--accent-primary); }
 .orders-ext-link--internal { border-color: var(--accent-primary-border); color: var(--accent-primary-soft-strong); font-weight: 600; }
 .orders-ext-link--internal::before { background: var(--accent-primary); }
@@ -8187,10 +8200,10 @@ a.kpi-card:focus-visible {
   border-radius: 50%;
   background: var(--text-muted);
 }
-.channel-pill[data-channel='allegro']::before    { background: oklch(70% 0.18 35); }
-.channel-pill[data-channel='prestashop']::before { background: oklch(60% 0.18 250); }
-.channel-pill[data-channel='amazon']::before     { background: oklch(72% 0.16 75); }
-.channel-pill[data-channel='shopify']::before    { background: oklch(64% 0.16 150); }
+.channel-pill[data-channel='allegro']::before    { background: var(--channel-allegro); }
+.channel-pill[data-channel='prestashop']::before { background: var(--channel-prestashop); }
+.channel-pill[data-channel='amazon']::before     { background: var(--channel-amazon); }
+.channel-pill[data-channel='shopify']::before    { background: var(--channel-shopify); }
 
 /* ── Patterns: entity label (thumb + name + sub-id) ──────────────── */
 .entity-label { display: inline-flex; align-items: center; gap: var(--space-2); }
@@ -12620,16 +12633,16 @@ input.bulk-dispatch__num--wide {
 }
 
 .variant-drawer__link[data-channel='allegro'] .variant-drawer__dot {
-  background: oklch(70% 0.18 35);
+  background: var(--channel-allegro);
 }
 .variant-drawer__link[data-channel='erli'] .variant-drawer__dot {
-  background: oklch(66% 0.2 15);
+  background: var(--channel-erli);
 }
 .variant-drawer__link[data-channel='prestashop'] .variant-drawer__dot {
-  background: oklch(60% 0.18 250);
+  background: var(--channel-prestashop);
 }
 .variant-drawer__link[data-channel='woocommerce'] .variant-drawer__dot {
-  background: oklch(64% 0.16 150);
+  background: var(--channel-woocommerce);
 }
 
 .variant-drawer__arrow {
@@ -12715,37 +12728,14 @@ input.bulk-dispatch__num--wide {
   align-items: center;
   gap: var(--space-1) var(--space-2);
   font-family: var(--font-mono);
-  font-size: 0.68rem;
-  color: var(--text-muted);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
   margin-bottom: var(--space-2);
 }
 
 /* Muted separator between meta / summary items. */
 .lmeta__sep {
-  color: var(--border-strong);
-}
-
-/* Two-line date stack for the table Updated column (no truncation). */
-.dt2 {
-  display: inline-flex;
-  flex-direction: column;
-  line-height: 1.25;
-  font-family: var(--font-mono);
-  font-variant-numeric: tabular-nums;
-}
-
-.dt2__date {
-  font-size: 0.72rem;
-  color: var(--text-secondary);
-}
-
-.dt2__time {
-  font-size: 0.66rem;
   color: var(--text-muted);
-}
-
-.variant-stock-table__updated-cell {
-  white-space: normal;
 }
 
 .variant-drawer__label {
@@ -13920,10 +13910,10 @@ input.bulk-dispatch__num--wide {
   border-radius: 50%;
   background: var(--text-muted);
 }
-.coverage-pill[data-channel='allegro']::before    { background: oklch(70% 0.18 35); }
-.coverage-pill[data-channel='prestashop']::before { background: oklch(60% 0.18 250); }
-.coverage-pill[data-channel='amazon']::before     { background: oklch(72% 0.16 75); }
-.coverage-pill[data-channel='shopify']::before    { background: oklch(64% 0.16 150); }
+.coverage-pill[data-channel='allegro']::before    { background: var(--channel-allegro); }
+.coverage-pill[data-channel='prestashop']::before { background: var(--channel-prestashop); }
+.coverage-pill[data-channel='amazon']::before     { background: var(--channel-amazon); }
+.coverage-pill[data-channel='shopify']::before    { background: var(--channel-shopify); }
 .coverage-pill--full {
   border-color: var(--status-success-border);
   background: var(--status-success-soft);
@@ -14055,9 +14045,9 @@ input.bulk-dispatch__num--wide {
   font-weight: 600;
 }
 .products-detail-links__link--internal::before { background: var(--accent-primary); }
-.products-detail-links__link[data-channel='prestashop']::before { background: oklch(60% 0.18 250); }
-.products-detail-links__link[data-channel='allegro']::before { background: oklch(70% 0.18 35); }
-.products-detail-links__link[data-channel='woocommerce']::before { background: oklch(64% 0.16 150); }
+.products-detail-links__link[data-channel='prestashop']::before { background: var(--channel-prestashop); }
+.products-detail-links__link[data-channel='allegro']::before { background: var(--channel-allegro); }
+.products-detail-links__link[data-channel='woocommerce']::before { background: var(--channel-woocommerce); }
 .products-detail-links__link .products-detail-links__arrow { color: var(--accent-primary); font-size: 0.75rem; }
 
 /* Mobile card disclosure toggle (#1720) - the heavy per-variant detail (its

--- a/apps/web/src/pages/products/product-detail-page.test.tsx
+++ b/apps/web/src/pages/products/product-detail-page.test.tsx
@@ -43,6 +43,27 @@ const sampleProduct: Product = {
   ],
 };
 
+// A 2-variant product exercises the variants table (single-variant products
+// render the "Listed on" panel instead).
+const multiVariantProduct: Product = {
+  ...sampleProduct,
+  variants: [
+    sampleProduct.variants![0],
+    {
+      id: 'ol_product_var2',
+      productId: 'ol_product_abc123',
+      sku: 'SKU-001-L',
+      attributes: { size: 'L' },
+      ean: null,
+      gtin: null,
+      price: null,
+      createdAt: '2026-01-15T10:00:00.000Z',
+      updatedAt: '2026-01-15T10:00:00.000Z',
+      externalIds: [],
+    },
+  ],
+};
+
 function inventoryItem(overrides: Partial<InventoryItem>): InventoryItem {
   return {
     id: 'ol_inv_1',
@@ -132,10 +153,12 @@ describe('ProductDetailPage', () => {
     expect(screen.getByText('29.99')).toBeInTheDocument();
     expect(screen.getByText('A test product')).toBeInTheDocument();
 
-    // Variant & stock table — SKU headline + combined EAN/attributes meta line
-    expect(screen.getByText('SKU-001-M')).toBeInTheDocument();
-    expect(screen.getByText(/EAN 1234567890123/)).toBeInTheDocument();
-    expect(screen.getByText(/size: M, color: blue/)).toBeInTheDocument();
+    // Single variant → "Listed on" panel (no variants table). The metadata
+    // grid surfaces attribute chips, the variant id, and the EAN/GTIN.
+    expect(screen.getByRole('heading', { name: 'Listed on' })).toBeInTheDocument();
+    expect(screen.getByText('Attributes')).toBeInTheDocument();
+    expect(screen.getByText('ol_product_var1')).toBeInTheDocument();
+    expect(screen.getByText('1234567890123')).toBeInTheDocument();
 
     // Source section (renamed from External IDs) — master origin with ref
     expect(screen.getByRole('heading', { name: 'Source' })).toBeInTheDocument();
@@ -189,7 +212,7 @@ describe('ProductDetailPage', () => {
   it('should render the variant stock cell as out-of-stock (not low-stock) when available is exactly zero', async () => {
     const mockApi = createMockApiClient({
       products: {
-        getById: vi.fn().mockResolvedValue(sampleProduct),
+        getById: vi.fn().mockResolvedValue(multiVariantProduct),
       },
       inventory: {
         list: vi.fn().mockResolvedValue(
@@ -205,7 +228,7 @@ describe('ProductDetailPage', () => {
       { apiClient: mockApi, route: '/products/ol_product_abc123' },
     );
 
-    await screen.findByText('SKU-001-M');
+    await screen.findByText(/SKU-001-M/);
     const stockCell = container.querySelector('.stock-cell--error, .stock-cell--warning');
     expect(stockCell).not.toBeNull();
     expect(stockCell).toHaveClass('stock-cell--error');
@@ -257,14 +280,22 @@ describe('ProductDetailPage', () => {
 
   it('should toggle the variant drawer and render the matching per-listing detail', async () => {
     const user = userEvent.setup();
-    const listingsList = vi.fn().mockResolvedValue(
-      paginatedListings([
-        offerMapping({ id: 'ol_offer_1', platformType: 'allegro', externalId: 'ALG-1' }),
-      ]),
-    );
+    // Key listings to the first variant only so the second table row (var2)
+    // resolves an empty set — keeps "Listings (1)" and the ALG-1 link unique.
+    const listingsList = vi
+      .fn()
+      .mockImplementation((filters?: { internalId?: string }) =>
+        Promise.resolve(
+          paginatedListings(
+            filters?.internalId === 'ol_product_var1'
+              ? [offerMapping({ id: 'ol_offer_1', platformType: 'allegro', externalId: 'ALG-1' })]
+              : [],
+          ),
+        ),
+      );
     const mockApi = createMockApiClient({
       products: {
-        getById: vi.fn().mockResolvedValue(sampleProduct),
+        getById: vi.fn().mockResolvedValue(multiVariantProduct),
       },
       listings: { list: listingsList },
     });
@@ -285,7 +316,7 @@ describe('ProductDetailPage', () => {
   it('should render a "+ Create offer" CTA when an OfferCreator connection has no listing for the variant', async () => {
     const mockApi = createMockApiClient({
       products: {
-        getById: vi.fn().mockResolvedValue(sampleProduct),
+        getById: vi.fn().mockResolvedValue(multiVariantProduct),
       },
       connections: {
         list: vi.fn().mockResolvedValue([
@@ -317,12 +348,12 @@ describe('ProductDetailPage', () => {
       },
     );
 
-    await screen.findByText('SKU-001-M');
-    expect(await screen.findByRole('button', { name: '+ Create offer' })).toBeInTheDocument();
+    await screen.findByText(/SKU-001-M/);
+    // One CTA per gap row (both variants lack the Allegro listing).
+    expect((await screen.findAllByRole('button', { name: '+ Create offer' })).length).toBeGreaterThan(0);
   });
 
   it('should show the empty listings message when a variant has no matching listings', async () => {
-    const user = userEvent.setup();
     const mockApi = createMockApiClient({
       products: {
         getById: vi.fn().mockResolvedValue(sampleProduct),
@@ -332,12 +363,49 @@ describe('ProductDetailPage', () => {
 
     renderDetailPage(mockApi);
 
-    const toggle = await screen.findByRole('button', { name: 'Toggle listings for SKU-001-M' });
-    await user.click(toggle);
-
+    // Single-variant products render the always-expanded "Listed on" panel, so
+    // the empty message shows without a toggle.
     expect(
       await screen.findByText('No marketplace listings reference this variant yet.'),
     ).toBeInTheDocument();
+  });
+
+  it('should render the "Listed on" panel (no variants table) for a single-variant product', async () => {
+    const mockApi = createMockApiClient({
+      products: {
+        getById: vi.fn().mockResolvedValue(sampleProduct),
+      },
+    });
+
+    const { container } = renderWithProviders(
+      <Routes>
+        <Route path="/products/:id" element={<ProductDetailPage />} />
+      </Routes>,
+      { apiClient: mockApi, route: '/products/ol_product_abc123' },
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Listed on' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Variants & stock/ })).not.toBeInTheDocument();
+    expect(container.querySelector('.variant-stock-table')).toBeNull();
+  });
+
+  it('should render the variants table for a multi-variant product', async () => {
+    const mockApi = createMockApiClient({
+      products: {
+        getById: vi.fn().mockResolvedValue(multiVariantProduct),
+      },
+    });
+
+    const { container } = renderWithProviders(
+      <Routes>
+        <Route path="/products/:id" element={<ProductDetailPage />} />
+      </Routes>,
+      { apiClient: mockApi, route: '/products/ol_product_abc123' },
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Variants & stock (2)' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Listed on' })).not.toBeInTheDocument();
+    expect(container.querySelector('.variant-stock-table')).not.toBeNull();
   });
 
   it('should open the gallery lightbox, navigate with the keyboard, and close it', async () => {

--- a/apps/web/src/pages/products/product-detail-page.test.tsx
+++ b/apps/web/src/pages/products/product-detail-page.test.tsx
@@ -166,6 +166,45 @@ describe('ProductDetailPage', () => {
     expect(screen.getByText('Master')).toBeInTheDocument();
   });
 
+  it('should render the product-level Attributes block when the product has features', async () => {
+    const mockApi = createMockApiClient({
+      products: {
+        getById: vi.fn().mockResolvedValue({
+          ...sampleProduct,
+          features: [
+            { name: 'Brand', value: 'Acme' },
+            { name: 'Material', value: 'Ceramic' },
+          ],
+        }),
+      },
+    });
+
+    renderDetailPage(mockApi);
+
+    const attributesSection = (await screen.findByRole('heading', { name: 'Attributes' })).closest(
+      '.detail-section',
+    ) as HTMLElement;
+    expect(within(attributesSection).getByText('Brand')).toBeInTheDocument();
+    expect(within(attributesSection).getByText('Acme')).toBeInTheDocument();
+    expect(within(attributesSection).getByText('Material')).toBeInTheDocument();
+    expect(within(attributesSection).getByText('Ceramic')).toBeInTheDocument();
+  });
+
+  it('should not render the product-level Attributes block when the product has no features', async () => {
+    const mockApi = createMockApiClient({
+      products: {
+        getById: vi.fn().mockResolvedValue(sampleProduct),
+      },
+    });
+
+    renderDetailPage(mockApi);
+
+    await screen.findByRole('heading', { name: 'Source' });
+    // No product-level Attributes *section* heading (the variant panel still
+    // renders its own "Attributes" metadata label, which is not a heading).
+    expect(screen.queryByRole('heading', { name: 'Attributes' })).not.toBeInTheDocument();
+  });
+
   it('should show error state when fetch fails', async () => {
     const mockApi = createMockApiClient({
       products: {

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -250,6 +250,19 @@ export function ProductDetailPage(): ReactElement {
             </div>
 
             <div className="product-detail__stack">
+              {product.features && product.features.length > 0 ? (
+                <section className="detail-section" aria-label="Attributes">
+                  <h3 className="detail-section__title">Attributes</h3>
+                  <div className="attr-chips">
+                    {product.features.map((feature) => (
+                      <span className="attr-chip" key={`${feature.name}:${feature.value}`}>
+                        <b>{feature.name}</b>
+                        {feature.value}
+                      </span>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
               <section className="detail-section">
                 <h3 className="detail-section__title">Source</h3>
                 <ProductSourceSection

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -16,7 +16,7 @@ import { useInventoryQuery } from '../../features/inventory/hooks/use-inventory-
 import { useConnectionsQuery, type Connection } from '../../features/connections';
 import { useWriteAccess } from '../../shared/auth/use-permission';
 import { useDemoMode } from '../../features/system';
-import { VariantStockTable } from './variant-stock-table';
+import { VariantStockTable, VariantDetailPanel } from './variant-stock-table';
 import { MarketplacePickerModal } from './marketplace-picker-modal';
 import {
   DEFAULT_LOW_STOCK_THRESHOLD,
@@ -142,6 +142,21 @@ export function ProductDetailPage(): ReactElement {
   const availableTone = deriveAvailableTone(totalAvailable, oversoldCount);
   const stockStatus = deriveStockStatus(totalAvailable);
 
+  // Distinct stock locations across the product's inventory rows (fallback 1
+  // when the master reports no location). Feeds the Available KPI sub-line.
+  const distinctLocationCount =
+    new Set(
+      inventoryItems
+        .map((item) => item.locationId)
+        .filter((locationId): locationId is string => locationId !== null),
+    ).size || 1;
+  const availableDescription =
+    oversoldCount > 0
+      ? `${oversoldCount} oversold`
+      : `across ${distinctLocationCount} location${distinctLocationCount === 1 ? '' : 's'}`;
+
+  const isSingleVariant = variants.length === 1;
+
   const totalListings = variants.reduce(
     (sum, variant) => sum + (listingsCounts[variant.id] ?? 0),
     0,
@@ -168,20 +183,18 @@ export function ProductDetailPage(): ReactElement {
           <section className="product-detail-hero" aria-label="Product summary">
             <ProductGallery images={product.images ?? []} name={product.name} />
             <div className="product-detail-hero__body">
-              <div className="product-detail-hero__title-row">
-                <h3 className="product-detail-hero__title">{product.name}</h3>
-                <div className="product-detail-hero__badges">
-                  <StatusBadge compact withDot tone={STOCK_STATUS_BADGE_TONE[stockStatus]}>
-                    {STOCK_STATUS_LABEL[stockStatus]}
-                  </StatusBadge>
-                  <StatusBadge compact tone="neutral">
-                    {variants.length} variant{variants.length === 1 ? '' : 's'}
-                  </StatusBadge>
-                  <StatusBadge compact tone="info">
-                    {totalListings} listing{totalListings === 1 ? '' : 's'}
-                  </StatusBadge>
-                </div>
+              <div className="product-detail-hero__badges">
+                <StatusBadge compact withDot tone={STOCK_STATUS_BADGE_TONE[stockStatus]}>
+                  {STOCK_STATUS_LABEL[stockStatus]}
+                </StatusBadge>
+                <StatusBadge compact tone="neutral">
+                  {variants.length} variant{variants.length === 1 ? '' : 's'}
+                </StatusBadge>
+                <StatusBadge compact tone="info">
+                  {totalListings} listing{totalListings === 1 ? '' : 's'}
+                </StatusBadge>
               </div>
+              <h3 className="product-detail-hero__title">{product.name}</h3>
               <code className="product-detail-hero__id mono-text" title={product.id}>
                 {product.id}
               </code>
@@ -209,12 +222,16 @@ export function ProductDetailPage(): ReactElement {
           <section className="detail-section" aria-label="At a glance">
             <h3 className="detail-section__title">At a glance</h3>
             <div className="product-detail__kpi-row product-detail__kpi-row--cols-4">
-              <KpiCard label="Price" value={formatPrice(product.price, product.currency)} />
+              <KpiCard
+                label="Price"
+                value={formatPrice(product.price, product.currency)}
+                description={product.currency ?? undefined}
+              />
               <KpiCard
                 label="Available"
                 tone={availableTone}
                 value={totalAvailable}
-                description={oversoldCount > 0 ? `${oversoldCount} oversold` : undefined}
+                description={availableDescription}
               />
               <KpiCard label="Variants" value={variants.length} />
               <KpiCard label="Listings" value={totalListings} />
@@ -260,7 +277,9 @@ export function ProductDetailPage(): ReactElement {
           <section className="detail-section">
             <div className="detail-section__title-row">
               <h3 className="detail-section__title">
-                Variants &amp; stock{variants.length > 0 ? ` (${variants.length})` : ''}
+                {isSingleVariant
+                  ? 'Listed on'
+                  : `Variants & stock${variants.length > 0 ? ` (${variants.length})` : ''}`}
               </h3>
               {latestStockSync ? (
                 <span className="sync-freshness">
@@ -285,6 +304,13 @@ export function ProductDetailPage(): ReactElement {
               />
             ) : variants.length === 0 ? (
               <p className="text-muted">No variants found for this product.</p>
+            ) : isSingleVariant ? (
+              <VariantDetailPanel
+                variant={variants[0]!}
+                stock={stockByVariant.get(variants[0]!.id)}
+                connections={offerCreatorConnections}
+                onListingsCount={handleListingsCount}
+              />
             ) : (
               <VariantStockTable
                 variants={variants}

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { useCallback, useMemo, useState, type ReactElement } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
@@ -28,20 +28,6 @@ import {
 const VIEW_PARAM = 'view';
 const VIEW_OVERVIEW = 'overview';
 const VIEW_CONTENT = 'content';
-
-function formatPrice(price: number | null, currency: string | null): ReactNode {
-  if (price === null) {
-    return <span className="text-muted">—</span>;
-  }
-  if (currency) {
-    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(price);
-  }
-  return (
-    <span className="text-muted" title="Currency unknown">
-      {price.toFixed(2)}
-    </span>
-  );
-}
 
 function deriveAvailableTone(totalAvailable: number, oversoldCount: number): KpiCardTone {
   if (totalAvailable <= 0) return 'error';
@@ -224,7 +210,7 @@ export function ProductDetailPage(): ReactElement {
             <div className="product-detail__kpi-row product-detail__kpi-row--cols-4">
               <KpiCard
                 label="Price"
-                value={formatPrice(product.price, product.currency)}
+                value={product.price !== null ? product.price.toFixed(2) : '—'}
                 description={product.currency ?? undefined}
               />
               <KpiCard
@@ -255,7 +241,7 @@ export function ProductDetailPage(): ReactElement {
                 {product.description ? (
                   <p className="description-block">{product.description}</p>
                 ) : (
-                  <p className="text-muted">
+                  <p className="description-block text-muted">
                     No description synced from the source. Draft and publish one per channel in the
                     Content tab.
                   </p>

--- a/apps/web/src/pages/products/variant-stock-table.tsx
+++ b/apps/web/src/pages/products/variant-stock-table.tsx
@@ -11,7 +11,7 @@
  *
  * @module apps/web/src/pages/products
  */
-import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { useEffect, useState, type ReactElement, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import type { Connection } from '../../features/connections';
@@ -25,7 +25,6 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { useMediaQuery } from '../../shared/ui/use-media-query';
 import { usePlatforms } from '../../shared/plugins';
-import { useTranslation, getBcp47Locale } from '../../shared/i18n';
 import {
   deriveStockStatus,
   STOCK_STATUS_BADGE_TONE,
@@ -81,7 +80,6 @@ export function VariantStockTable(props: VariantStockTableProps): ReactElement {
             <th>Stock</th>
             <th>Listings</th>
             <th className="data-table__cell--right">Price</th>
-            <th className="data-table__cell--right">Updated</th>
           </tr>
         </thead>
         <tbody>
@@ -155,30 +153,6 @@ function variantMetaLine(variant: ProductVariant): string | null {
     variant.ean ? `EAN ${variant.ean}` : null,
   ].filter((part): part is string => Boolean(part));
   return parts.length > 0 ? parts.join(' · ') : null;
-}
-
-/** Two-line date stack for the table Updated column (no truncation). */
-function TwoLineDate({ iso }: { iso: string }): ReactElement {
-  const { locale } = useTranslation();
-  const { date, time } = useMemo(() => {
-    const bcp47 = getBcp47Locale(locale);
-    const parsed = new Date(iso);
-    return {
-      date: new Intl.DateTimeFormat(bcp47, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-      }).format(parsed),
-      time: new Intl.DateTimeFormat(bcp47, { hour: 'numeric', minute: '2-digit' }).format(parsed),
-    };
-  }, [iso, locale]);
-
-  return (
-    <span className="dt2">
-      <span className="dt2__date">{date}</span>
-      <span className="dt2__time">{time}</span>
-    </span>
-  );
 }
 
 function stockValueClass(availableQuantity: number): string {
@@ -540,7 +514,7 @@ function ListingDetailCard({
   }
   metaItems.push(
     <span key="updated" className="variant-listing-meta">
-      <b>Updated</b> <TimeDisplay iso={listing.updatedAt} />
+      <b>Offer updated</b> <TimeDisplay iso={listing.updatedAt} />
     </span>,
   );
 
@@ -655,12 +629,9 @@ function VariantStockRow({
         <td className="data-table__cell--right variant-stock-table__price">
           {formatPrice(variant.price, currency)}
         </td>
-        <td className="data-table__cell--right variant-stock-table__updated-cell">
-          <TwoLineDate iso={variant.updatedAt} />
-        </td>
       </tr>
       <tr className={`variant-stock-table__expand-row${isOpen ? ' is-open' : ''}`}>
-        <td colSpan={6}>
+        <td colSpan={5}>
           <div className="variant-stock-table__expand-content">
             <div className="variant-stock-table__expand-content-inner">
               <div className="variant-drawer">

--- a/apps/web/src/pages/products/variant-stock-table.tsx
+++ b/apps/web/src/pages/products/variant-stock-table.tsx
@@ -302,7 +302,8 @@ function VariantMetaGrid({
           <span className="attr-chips">
             {Object.entries(variant.attributes as Record<string, string>).map(([key, value]) => (
               <span key={key} className="attr-chip">
-                <b>{key}</b> {value}
+                <b>{key}</b>
+                {value}
               </span>
             ))}
           </span>

--- a/apps/web/src/pages/products/variant-stock-table.tsx
+++ b/apps/web/src/pages/products/variant-stock-table.tsx
@@ -11,12 +11,13 @@
  *
  * @module apps/web/src/pages/products
  */
-import { useEffect, useState, type ReactElement, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import type { Connection } from '../../features/connections';
 import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
 import { useListingMarketplaceOfferQuery } from '../../features/listings/hooks/use-listing-marketplace-offer-query';
+import { useCategoryPathQuery } from '../../features/listings/hooks/use-category-path-query';
 import type { OfferMapping } from '../../features/listings/api/listings.types';
 import type { ProductVariant } from '../../features/products/api/products.types';
 import type { InventoryItem } from '../../features/inventory/api/inventory.types';
@@ -24,6 +25,7 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { useMediaQuery } from '../../shared/ui/use-media-query';
 import { usePlatforms } from '../../shared/plugins';
+import { useTranslation, getBcp47Locale } from '../../shared/i18n';
 import {
   deriveStockStatus,
   STOCK_STATUS_BADGE_TONE,
@@ -129,20 +131,54 @@ function statusTone(status: string): StatusBadgeTone {
   return 'neutral';
 }
 
+function variantHasAttributes(variant: ProductVariant): boolean {
+  return Boolean(variant.attributes && Object.keys(variant.attributes).length > 0);
+}
+
+/**
+ * Row/card headline. When the variant carries distinguishing attributes we lead
+ * with their joined values ("Black · M") — the human-meaningful identity — and
+ * demote the SKU to the meta line. Otherwise the SKU (or id) stays the headline.
+ */
+function variantHeadline(variant: ProductVariant): string {
+  if (variantHasAttributes(variant)) {
+    return Object.values(variant.attributes as Record<string, string>).join(' · ');
+  }
+  return variant.sku ?? variant.id;
+}
+
 function variantMetaLine(variant: ProductVariant): string | null {
-  const attrs =
-    variant.attributes && Object.keys(variant.attributes).length > 0
-      ? Object.entries(variant.attributes)
-          .map(([key, value]: [string, string]) => `${key}: ${value}`)
-          .join(', ')
-      : null;
+  const hasAttrs = variantHasAttributes(variant);
   const parts = [
+    // SKU appears on the meta line only when attributes took the headline.
+    hasAttrs && variant.sku ? `SKU ${variant.sku}` : null,
     variant.ean ? `EAN ${variant.ean}` : null,
-    // Show the SKU on the meta line only when it isn't already the headline.
-    variant.sku ? `SKU ${variant.sku}` : null,
-    attrs,
   ].filter((part): part is string => Boolean(part));
   return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+/** Two-line date stack for the table Updated column (no truncation). */
+function TwoLineDate({ iso }: { iso: string }): ReactElement {
+  const { locale } = useTranslation();
+  const { date, time } = useMemo(() => {
+    const bcp47 = getBcp47Locale(locale);
+    const parsed = new Date(iso);
+    return {
+      date: new Intl.DateTimeFormat(bcp47, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }).format(parsed),
+      time: new Intl.DateTimeFormat(bcp47, { hour: 'numeric', minute: '2-digit' }).format(parsed),
+    };
+  }, [iso, locale]);
+
+  return (
+    <span className="dt2">
+      <span className="dt2__date">{date}</span>
+      <span className="dt2__time">{time}</span>
+    </span>
+  );
 }
 
 function stockValueClass(availableQuantity: number): string {
@@ -238,13 +274,141 @@ function VariantCoverage({
 
 // ── Rich per-listing drawer ──────────────────────────────────────────────────
 
-function VariantDrawer({
+/**
+ * Top-of-drawer deep-link pill for one listing that resolves a marketplace URL.
+ * Runs the same `useListingMarketplaceOfferQuery` as its `ListingDetailCard`
+ * sibling — TanStack Query dedupes by queryKey, so the two share ONE network
+ * request. Renders nothing until (and unless) the offer exposes a URL.
+ */
+function DrawerChannelLink({
+  listing,
+  enabled,
+}: {
+  listing: OfferMapping;
+  enabled: boolean;
+}): ReactElement | null {
+  const platforms = usePlatforms();
+  const isOffer = listing.entityType === 'Offer';
+  const offerQuery = useListingMarketplaceOfferQuery(listing.id, { enabled: enabled && isOffer });
+  const url = offerQuery.data?.marketplaceUrl;
+  if (!url) return null;
+  const label =
+    platforms.find((p) => p.platformType === listing.platformType)?.displayName ??
+    listing.platformType;
+  return (
+    <a
+      className="variant-drawer__link"
+      data-channel={listing.platformType}
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+    >
+      <span className="variant-drawer__dot" aria-hidden="true"></span>
+      Open on {label} <span className="variant-drawer__arrow" aria-hidden="true">↗</span>
+    </a>
+  );
+}
+
+/** Attribute chips + variant identity metadata grid, above the listings block. */
+function VariantMetaGrid({
+  variant,
+  available,
+  reserved,
+}: {
+  variant: ProductVariant;
+  available: number;
+  reserved: number;
+}): ReactElement {
+  const hasAttrs = variantHasAttributes(variant);
+  return (
+    <div className="variant-drawer__meta">
+      {hasAttrs ? (
+        <div className="variant-drawer__meta-cell">
+          <span className="variant-drawer__meta-label">Attributes</span>
+          <span className="attr-chips">
+            {Object.entries(variant.attributes as Record<string, string>).map(([key, value]) => (
+              <span key={key} className="attr-chip">
+                <b>{key}</b> {value}
+              </span>
+            ))}
+          </span>
+        </div>
+      ) : null}
+      <div className="variant-drawer__meta-cell">
+        <span className="variant-drawer__meta-label">Variant ID</span>
+        <span className="variant-drawer__meta-value variant-drawer__meta-value--wrap mono-text">
+          {variant.id}
+        </span>
+      </div>
+      <div className="variant-drawer__meta-cell">
+        <span className="variant-drawer__meta-label">EAN / GTIN</span>
+        <span className="variant-drawer__meta-value mono-text">
+          {variant.ean ?? variant.gtin ?? '—'}
+        </span>
+      </div>
+      <div className="variant-drawer__meta-cell">
+        <span className="variant-drawer__meta-label">Stock</span>
+        <span className="variant-drawer__meta-value mono-text tabular">
+          {available}
+          <span className="variant-drawer__meta-muted"> / res {reserved}</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** Honest "n listed · m gap · Channels" summary under the Listings label. */
+function ListingsSummary({
+  listings,
+  connections,
+}: {
+  listings: OfferMapping[];
+  connections: readonly Connection[];
+}): ReactElement {
+  const platforms = usePlatforms();
+  const platformLabel = (platformType: string): string =>
+    platforms.find((p) => p.platformType === platformType)?.displayName ?? platformType;
+  const listedConnectionIds = new Set(listings.map((l) => l.connectionId));
+  const gapConnections = connections.filter((c) => !listedConnectionIds.has(c.id));
+  const gapChannels = Array.from(
+    new Set(gapConnections.map((c) => platformLabel(c.platformType))),
+  );
+
+  return (
+    <div className="listings-summary">
+      <span>{listings.length} listed</span>
+      {gapConnections.length > 0 ? (
+        <>
+          <span className="lmeta__sep" aria-hidden="true">·</span>
+          <span>{gapConnections.length} gap</span>
+          <span className="lmeta__sep" aria-hidden="true">·</span>
+          <span>{gapChannels.join(', ')}</span>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Shared drawer body used by the expanded table row, the mobile card, and the
+ * single-product "Listed on" section. Order: (1) channel-link strip, (2)
+ * variant metadata grid, (3) listings block (label + summary + detail cards).
+ */
+function VariantDetailBody({
+  variant,
+  available,
+  reserved,
+  connections,
   listings,
   total,
   isLoading,
   isError,
   open,
 }: {
+  variant: ProductVariant;
+  available: number;
+  reserved: number;
+  connections: readonly Connection[];
   listings: OfferMapping[];
   total: number;
   isLoading: boolean;
@@ -252,23 +416,74 @@ function VariantDrawer({
   open: boolean;
 }): ReactElement {
   return (
-    <div className="variant-drawer">
-      <div className="variant-drawer__label">Listings{total > 0 ? ` (${total})` : ''}</div>
-      {isLoading ? (
-        <p className="variant-listing-card__note">Loading listings…</p>
-      ) : isError ? (
-        <p className="variant-listing-card__note">Couldn&rsquo;t load listings.</p>
-      ) : listings.length === 0 ? (
-        <p className="variant-listing-card__note">
-          No marketplace listings reference this variant yet.
-        </p>
-      ) : (
-        <div className="variant-listing-cards">
+    <>
+      {listings.length > 0 ? (
+        <div className="variant-drawer__links">
           {listings.map((listing) => (
-            <ListingDetailCard key={listing.id} listing={listing} enabled={open} />
+            <DrawerChannelLink key={listing.id} listing={listing} enabled={open} />
           ))}
         </div>
-      )}
+      ) : null}
+
+      <VariantMetaGrid variant={variant} available={available} reserved={reserved} />
+
+      <div className="variant-drawer__listings">
+        <div className="variant-drawer__label">Listings{total > 0 ? ` (${total})` : ''}</div>
+        {isLoading ? (
+          <p className="variant-listing-card__note">Loading listings…</p>
+        ) : isError ? (
+          <p className="variant-listing-card__note">Couldn&rsquo;t load listings.</p>
+        ) : (
+          <>
+            <ListingsSummary listings={listings} connections={connections} />
+            {listings.length === 0 ? (
+              <p className="variant-listing-card__note">
+                No marketplace listings reference this variant yet.
+              </p>
+            ) : (
+              <div className="variant-listing-cards">
+                {listings.map((listing) => (
+                  <ListingDetailCard key={listing.id} listing={listing} enabled={open} />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+/**
+ * Single-product panel — the same drawer body, always expanded, for the
+ * `variants.length === 1` "Listed on" section. Owns the per-variant listings
+ * query so `onListingsCount` still feeds the Listings KPI.
+ */
+export function VariantDetailPanel({
+  variant,
+  stock,
+  connections,
+  onListingsCount,
+}: {
+  variant: ProductVariant;
+  stock: InventoryItem | undefined;
+  connections: readonly Connection[];
+  onListingsCount: (variantId: string, count: number) => void;
+}): ReactElement {
+  const { listings, total, isLoading, isError } = useVariantListings(variant, onListingsCount);
+  return (
+    <div className="variant-drawer variant-drawer--flush">
+      <VariantDetailBody
+        variant={variant}
+        available={stock?.availableQuantity ?? 0}
+        reserved={stock?.reservedQuantity ?? 0}
+        connections={connections}
+        listings={listings}
+        total={total}
+        isLoading={isLoading}
+        isError={isError}
+        open
+      />
     </div>
   );
 }
@@ -287,9 +502,59 @@ function ListingDetailCard({
   // per listing, retry-off, 30s stale (see the hook).
   const offerQuery = useListingMarketplaceOfferQuery(listing.id, { enabled: enabled && isOffer });
   const offer = offerQuery.data;
+  // Resolve the offer's raw category id to a human breadcrumb (#1752). The
+  // offer payload carries only `category.id`; fall back to the raw id / name
+  // while loading or on 404/422.
+  const categoryPathQuery = useCategoryPathQuery(listing.connectionId, offer?.category?.id, {
+    enabled: enabled && Boolean(offer?.category?.id),
+  });
+  const categoryBreadcrumb =
+    categoryPathQuery.data && categoryPathQuery.data.length > 0
+      ? categoryPathQuery.data.map((segment) => segment.name).join(' › ')
+      : null;
   const label =
     platforms.find((p) => p.platformType === listing.platformType)?.displayName ??
     listing.platformType;
+
+  // Meta items are conditional (Qty / Category only when the live offer
+  // resolves). Build the rendered nodes first, then interleave a muted `·`
+  // separator so we never emit a leading / trailing / double separator.
+  const metaItems: ReactNode[] = [
+    <span key="offer" className="variant-listing-meta">
+      Offer <Link to={`/listings/${listing.id}`}>{listing.externalId} ↗</Link>
+    </span>,
+  ];
+  if (offer) {
+    metaItems.push(
+      <span key="qty" className="variant-listing-meta">
+        <b>Qty</b> {offer.availableQuantity}
+      </span>,
+    );
+  }
+  if (offer?.category) {
+    metaItems.push(
+      <span key="category" className="variant-listing-meta">
+        <b>Category</b> {categoryBreadcrumb ?? offer.category.name ?? offer.category.id}
+      </span>,
+    );
+  }
+  metaItems.push(
+    <span key="updated" className="variant-listing-meta">
+      <b>Updated</b> <TimeDisplay iso={listing.updatedAt} />
+    </span>,
+  );
+
+  const metaWithSeparators: ReactNode[] = [];
+  metaItems.forEach((node, index) => {
+    if (index > 0) {
+      metaWithSeparators.push(
+        <span key={`sep-${index}`} className="lmeta__sep" aria-hidden="true">
+          ·
+        </span>,
+      );
+    }
+    metaWithSeparators.push(node);
+  });
 
   return (
     <div className="variant-listing-card">
@@ -311,34 +576,7 @@ function ListingDetailCard({
           </span>
         ) : null}
       </div>
-      <div className="variant-listing-card__meta">
-        <span className="variant-listing-meta">
-          Offer{' '}
-          <Link to={`/listings/${listing.id}`}>
-            {listing.externalId} ↗
-          </Link>
-        </span>
-        {offer ? (
-          <span className="variant-listing-meta">
-            <b>Qty</b> {offer.availableQuantity}
-          </span>
-        ) : null}
-        {offer?.category ? (
-          <span className="variant-listing-meta">
-            <b>Category</b> {offer.category.name ?? offer.category.id}
-          </span>
-        ) : null}
-        {offer?.marketplaceUrl ? (
-          <span className="variant-listing-meta">
-            <a href={offer.marketplaceUrl} target="_blank" rel="noreferrer">
-              Open on marketplace ↗
-            </a>
-          </span>
-        ) : null}
-        <span className="variant-listing-meta">
-          <b>Updated</b> <TimeDisplay iso={listing.updatedAt} />
-        </span>
-      </div>
+      <div className="variant-listing-card__meta">{metaWithSeparators}</div>
       {enabled && offerQuery.isLoading ? (
         <p className="variant-listing-card__note">Loading live marketplace data…</p>
       ) : null}
@@ -391,7 +629,7 @@ function VariantStockRow({
         </td>
         <td>
           <div className="variant-stock-table__name">
-            <span className="variant-stock-table__sku mono-text">{variant.sku ?? variant.id}</span>
+            <span className="variant-stock-table__sku mono-text">{variantHeadline(variant)}</span>
             {meta ? <span className="variant-stock-table__meta">{meta}</span> : null}
           </div>
         </td>
@@ -417,21 +655,27 @@ function VariantStockRow({
         <td className="data-table__cell--right variant-stock-table__price">
           {formatPrice(variant.price, currency)}
         </td>
-        <td className="data-table__cell--right">
-          <TimeDisplay className="mono-text tabular" iso={variant.updatedAt} />
+        <td className="data-table__cell--right variant-stock-table__updated-cell">
+          <TwoLineDate iso={variant.updatedAt} />
         </td>
       </tr>
       <tr className={`variant-stock-table__expand-row${isOpen ? ' is-open' : ''}`}>
         <td colSpan={6}>
           <div className="variant-stock-table__expand-content">
             <div className="variant-stock-table__expand-content-inner">
-              <VariantDrawer
-                listings={listings}
-                total={total}
-                isLoading={isLoading}
-                isError={isError}
-                open={isOpen}
-              />
+              <div className="variant-drawer">
+                <VariantDetailBody
+                  variant={variant}
+                  available={available}
+                  reserved={reserved}
+                  connections={connections}
+                  listings={listings}
+                  total={total}
+                  isLoading={isLoading}
+                  isError={isError}
+                  open={isOpen}
+                />
+              </div>
             </div>
           </div>
         </td>
@@ -477,7 +721,7 @@ function VariantStockCard({
         onClick={() => setOpen((prev) => !prev)}
       >
         <span className="variant-stock-table__name">
-          <span className="variant-stock-table__sku mono-text">{variant.sku ?? variant.id}</span>
+          <span className="variant-stock-table__sku mono-text">{variantHeadline(variant)}</span>
           {meta ? <span className="variant-stock-table__meta">{meta}</span> : null}
         </span>
         <span className="variant-card__aside">
@@ -514,13 +758,19 @@ function VariantStockCard({
               />
             </span>
           </div>
-          <VariantDrawer
-            listings={listings}
-            total={total}
-            isLoading={isLoading}
-            isError={isError}
-            open={isOpen}
-          />
+          <div className="variant-drawer">
+            <VariantDetailBody
+              variant={variant}
+              available={available}
+              reserved={reserved}
+              connections={connections}
+              listings={listings}
+              total={total}
+              isLoading={isLoading}
+              isError={isError}
+              open={isOpen}
+            />
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/web/src/shared/theme/tokens.ts
+++ b/apps/web/src/shared/theme/tokens.ts
@@ -148,6 +148,14 @@ export const tokens = {
   'viz-cat-4': 'var(--viz-cat-4)',
   'viz-cat-muted': 'var(--viz-cat-muted)',
 
+  // ── Channel brand hues (#1752) ───────────────────────────────────
+  'channel-allegro': 'var(--channel-allegro)',
+  'channel-prestashop': 'var(--channel-prestashop)',
+  'channel-erli': 'var(--channel-erli)',
+  'channel-woocommerce': 'var(--channel-woocommerce)',
+  'channel-amazon': 'var(--channel-amazon)',
+  'channel-shopify': 'var(--channel-shopify)',
+
   // ── Status — review (manual review / pending operator action) ───
   'status-review': 'var(--status-review)',
   'status-review-strong': 'var(--status-review-strong)',

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -331,6 +331,9 @@ export function createMockApiClient(
       // #410 — default to "no parameters" so the wizard's category step
       // renders the friendly empty state in tests that don't override.
       getCategoryParameters: vi.fn().mockResolvedValue({ parameters: [] }),
+      // #1752 — default to an empty breadcrumb so the listing drawer falls back
+      // to the raw category id in tests that don't exercise category resolution.
+      getCategoryPath: vi.fn().mockResolvedValue({ path: [] }),
       // #635 — default the Allegro catalog match to "no_match" so tests
       // that don't exercise the catalog-prefill flow render the wizard
       // without a panel and without a real network call. `getCatalogProduct`

--- a/libs/core/src/listings/domain/ports/capabilities/category-path-reader.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/category-path-reader.capability.ts
@@ -1,0 +1,29 @@
+/**
+ * Category Path Reader Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that can resolve a
+ * single category id to its full ancestor breadcrumb declare
+ * `implements CategoryPathReader`. Used by the listing-detail drawer to render
+ * a human "Root > ... > Leaf" trail for an offer whose payload carries only
+ * `category.id` (Allegro).
+ *
+ * See `category-browser.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { CategoryPathSegment } from '../../types/category.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface CategoryPathReader {
+  /**
+   * Resolve `categoryId` to its full breadcrumb, ordered root -> leaf
+   * (the leaf being `categoryId` itself).
+   */
+  fetchCategoryPath(categoryId: string): Promise<CategoryPathSegment[]>;
+}
+
+export function isCategoryPathReader(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & CategoryPathReader {
+  return typeof (adapter as Partial<CategoryPathReader>).fetchCategoryPath === 'function';
+}

--- a/libs/core/src/listings/domain/types/category.types.ts
+++ b/libs/core/src/listings/domain/types/category.types.ts
@@ -13,3 +13,13 @@ export interface OfferCategory {
   parentId: string | null;
   leaf: boolean;
 }
+
+/**
+ * One node of a category breadcrumb path, ordered root -> leaf.
+ * Returned by `CategoryPathReader.fetchCategoryPath` so the FE can render a
+ * human-readable "Root > ... > Leaf" trail instead of the raw category id.
+ */
+export interface CategoryPathSegment {
+  id: string;
+  name: string;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -159,7 +159,7 @@ export type {
   UpdateOfferQuantitiesBatchFailure,
 } from './domain/types/offer-quantity-update.types';
 export type { UpdateOfferFieldsCommand } from './domain/types/offer-fields-update.types';
-export type { OfferCategory } from './domain/types/category.types';
+export type { OfferCategory, CategoryPathSegment } from './domain/types/category.types';
 export { CreateOfferResultStatusValues, OfferConditionValues } from './domain/types/offer-create.types';
 export type {
   CreateOfferCommand,
@@ -195,6 +195,8 @@ export { isOfferStockRestorer } from './domain/ports/capabilities/offer-stock-re
 export type { OfferStockRestoreTarget } from './domain/types/offer-stock-restore.types';
 export type { CategoryBrowser } from './domain/ports/capabilities/category-browser.capability';
 export { isCategoryBrowser } from './domain/ports/capabilities/category-browser.capability';
+export type { CategoryPathReader } from './domain/ports/capabilities/category-path-reader.capability';
+export { isCategoryPathReader } from './domain/ports/capabilities/category-path-reader.capability';
 export type { CategoryBarcodeMatcher } from './domain/ports/capabilities/category-barcode-matcher.capability';
 export { isCategoryBarcodeMatcher } from './domain/ports/capabilities/category-barcode-matcher.capability';
 export type { EanCategoryMatcher } from './domain/ports/capabilities/ean-category-matcher.capability';

--- a/libs/core/src/products/domain/entities/product.entity.ts
+++ b/libs/core/src/products/domain/entities/product.entity.ts
@@ -49,7 +49,8 @@ export interface Product {
    * Master-derived product features (e.g. `{ name: 'Material', value: 'Ceramic' }`),
    * distinct from variant-distinguishing attributes (#1096, F2). A destination
    * that accepts shop-native attributes (Erli `source:"shop"` `externalAttributes`)
-   * emits these. Absent/empty ⇒ no features. Not persisted on the products table.
+   * emits these. Absent/empty ⇒ no features. Persisted on the `products.features`
+   * jsonb column (#1752).
    */
   features?: { name: string; value: string }[];
 }

--- a/libs/core/src/products/infrastructure/persistence/entities/product.orm-entity.ts
+++ b/libs/core/src/products/infrastructure/persistence/entities/product.orm-entity.ts
@@ -39,6 +39,14 @@ export class ProductOrmEntity {
   @Column({ type: 'jsonb', nullable: true })
   categories!: string[] | null;
 
+  /**
+   * Source-platform product-level attributes (#1752) — `{ name, value }[]`
+   * (e.g. Brand / Material), distinct from variant-distinguishing attributes.
+   * Null until a product sync populates it.
+   */
+  @Column({ type: 'jsonb', nullable: true })
+  features!: { name: string; value: string }[] | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/products/infrastructure/persistence/repositories/product.repository.spec.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product.repository.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Product Repository — mapping unit tests
+ *
+ * Verifies the ORM ↔ domain mapping round-trips the fields that are easy to
+ * silently drop — here the #1752 `features` column (product-level attributes).
+ */
+import type { Repository } from 'typeorm';
+import { ProductRepository } from './product.repository';
+import { ProductOrmEntity } from '../entities/product.orm-entity';
+import type { Product } from '../../../domain/entities/product.entity';
+
+function baseProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 'ol_product_1',
+    name: 'Test',
+    sku: 'SKU-1',
+    price: 10,
+    currency: 'PLN',
+    description: null,
+    images: null,
+    ...overrides,
+  };
+}
+
+describe('ProductRepository mapping', () => {
+  let ormRepo: jest.Mocked<Repository<ProductOrmEntity>>;
+  let repository: ProductRepository;
+
+  beforeEach(() => {
+    ormRepo = {
+      // save persists the ORM entity produced by toOrmEntity and echoes it back,
+      // so upsert exercises toOrmEntity → save → toDomain (a full round-trip).
+      save: jest.fn((entity: ProductOrmEntity) => Promise.resolve(entity)),
+      findOne: jest.fn(),
+    } as unknown as jest.Mocked<Repository<ProductOrmEntity>>;
+    repository = new ProductRepository(ormRepo);
+  });
+
+  it('should round-trip features through upsert', async () => {
+    const features = [
+      { name: 'Brand', value: 'Acme' },
+      { name: 'Material', value: 'Ceramic' },
+    ];
+
+    const saved = await repository.upsert(baseProduct({ features }));
+
+    // Persisted onto the ORM entity...
+    const persisted = ormRepo.save.mock.calls[0][0];
+    expect(persisted.features).toEqual(features);
+    // ...and surfaced back on the domain entity.
+    expect(saved.features).toEqual(features);
+  });
+
+  it('should persist null features when absent', async () => {
+    await repository.upsert(baseProduct());
+
+    const persisted = ormRepo.save.mock.calls[0][0];
+    expect(persisted.features).toBeNull();
+  });
+
+  it('should omit features on load when the column is null', async () => {
+    const entity = new ProductOrmEntity();
+    Object.assign(entity, {
+      id: 'ol_product_1',
+      name: 'Test',
+      sku: null,
+      price: null,
+      currency: null,
+      description: null,
+      images: null,
+      categories: null,
+      features: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    ormRepo.findOne.mockResolvedValue(entity);
+
+    const product = await repository.findById('ol_product_1');
+
+    expect(product?.features).toBeUndefined();
+  });
+});

--- a/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
@@ -223,6 +223,9 @@ export class ProductRepository implements ProductRepositoryPort {
       // Source-platform category ids (#1034). DB `null` → omit (the field is
       // optional + non-null on the domain interface); `[]` is preserved.
       categories: entity.categories ?? undefined,
+      // Source-platform product-level attributes (#1752). DB `null` → omit
+      // (optional + non-null on the domain interface).
+      features: entity.features ?? undefined,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
     };
@@ -244,6 +247,7 @@ export class ProductRepository implements ProductRepositoryPort {
     entity.description = product.description;
     entity.images = product.images;
     entity.categories = product.categories ?? null;
+    entity.features = product.features ?? null;
     if (product.createdAt) entity.createdAt = product.createdAt;
     if (product.updatedAt) entity.updatedAt = product.updatedAt;
     return entity;

--- a/libs/integrations/allegro/src/allegro-plugin.ts
+++ b/libs/integrations/allegro/src/allegro-plugin.ts
@@ -95,6 +95,7 @@ export const allegroAdapterManifest: AdapterMetadata = {
     'OfferManager',
     'ShippingProviderManager',
     'CategoryBrowser',
+    'CategoryPathReader',
     'EanCategoryMatcher',
     'OfferCreator',
     'OfferEventReader',

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -425,6 +425,21 @@ export interface AllegroCategoriesResponse {
 }
 
 /**
+ * Single Allegro category node (from GET /sale/categories/{id}).
+ * Same fields as an item in the list response, but returned as the node
+ * itself (not its children). `parent.id` links to the ancestor used to walk
+ * the breadcrumb up to the root.
+ */
+export interface AllegroCategoryResponse {
+  id: string;
+  name: string;
+  parent?: {
+    id: string;
+  } | null;
+  leaf: boolean;
+}
+
+/**
  * Allegro category parameter — raw shape from
  * GET /sale/categories/{categoryId}/parameters
  *

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -24,6 +24,7 @@ import {
   OfferNotFoundOnMarketplaceException,
   isCatalogProductReader,
   isCategoryBrowser,
+  isCategoryPathReader,
   isEanCategoryMatcher,
   isOfferSmartClassificationReader,
   isOfferStatusReader,
@@ -718,6 +719,56 @@ describe('AllegroOfferManagerAdapter', () => {
     });
   });
 
+  describe('fetchCategoryPath (#1752)', () => {
+    it('declares the CategoryPathReader capability via the runtime guard', () => {
+      expect(isCategoryPathReader(adapter)).toBe(true);
+    });
+
+    it('walks up parent.id and returns the breadcrumb root -> leaf', async () => {
+      httpClient.get
+        .mockResolvedValueOnce({
+          data: { id: '10', name: 'Smartphones', parent: { id: '1' }, leaf: true },
+          status: 200,
+          headers: {},
+        })
+        .mockResolvedValueOnce({
+          data: { id: '1', name: 'Electronics', parent: null, leaf: false },
+          status: 200,
+          headers: {},
+        });
+
+      const result = await adapter.fetchCategoryPath('10');
+
+      expect(result).toEqual([
+        { id: '1', name: 'Electronics' },
+        { id: '10', name: 'Smartphones' },
+      ]);
+      expect(httpClient.get).toHaveBeenNthCalledWith(1, '/sale/categories/10');
+      expect(httpClient.get).toHaveBeenNthCalledWith(2, '/sale/categories/1');
+    });
+
+    it('returns a single segment for a root-level category', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: { id: '1', name: 'Electronics', parent: null, leaf: false },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.fetchCategoryPath('1');
+
+      expect(result).toEqual([{ id: '1', name: 'Electronics' }]);
+      expect(httpClient.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('translates Allegro 404 to CategoryNotFoundException', async () => {
+      httpClient.get.mockRejectedValueOnce(new AllegroApiException('not found', 404));
+
+      await expect(adapter.fetchCategoryPath('unknown')).rejects.toBeInstanceOf(
+        CategoryNotFoundException
+      );
+    });
+  });
+
   describe('matchCategoryByBarcode', () => {
     // Delegates to `resolveCategoriesForBatchByEan` (#735, #794) — these
     // tests assert the public boundary contract (categoryId | null) plus the
@@ -895,7 +946,8 @@ describe('AllegroOfferManagerAdapter', () => {
         availableQuantity: 3,
         status: 'ACTIVE',
         category: { id: '12345' },
-        marketplaceUrl: 'https://allegro.pl.allegrosandbox.pl/oferta/7781562863',
+        marketplaceUrl:
+          'https://allegro.pl.allegrosandbox.pl/oferta/vintage-camera-lens-50mm-f-1-4-7781562863',
         endsAt: '2026-05-15T12:00:00Z',
       });
     });
@@ -924,9 +976,26 @@ describe('AllegroOfferManagerAdapter', () => {
         availableQuantity: 0,
         status: 'UNKNOWN',
         category: undefined,
-        marketplaceUrl: 'https://allegro.pl/oferta/7781562864',
+        marketplaceUrl: 'https://allegro.pl/oferta/sparse-offer-7781562864',
         endsAt: undefined,
       });
+    });
+
+    it('should fall back to an id-only offer URL when the offer has no name', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: '7781562867',
+          sellingMode: { price: { amount: '10.00', currency: 'PLN' } },
+          stock: { available: 0 },
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const subject = buildAdapterWithStorefront('https://allegro.pl');
+      const result = await subject.getOffer({ externalId: '7781562867' });
+
+      expect(result.marketplaceUrl).toBe('https://allegro.pl/oferta/7781562867');
     });
 
     it('should map offer-section and product-section parameters with productSet linkage (#1482)', async () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -767,6 +767,62 @@ describe('AllegroOfferManagerAdapter', () => {
         CategoryNotFoundException
       );
     });
+
+    it('returns the partial breadcrumb when an ANCESTOR 404s mid-walk', async () => {
+      // Leaf resolves and points at a parent that no longer exists.
+      httpClient.get
+        .mockResolvedValueOnce({
+          data: { id: '10', name: 'Smartphones', parent: { id: '99' }, leaf: true },
+          status: 200,
+          headers: {},
+        })
+        .mockRejectedValueOnce(new AllegroApiException('gone', 404));
+
+      const result = await adapter.fetchCategoryPath('10');
+
+      // The leaf survives; the missing ancestor just truncates the breadcrumb.
+      expect(result).toEqual([{ id: '10', name: 'Smartphones' }]);
+    });
+
+    it('stops at the depth cap / cyclic parent chain instead of looping forever', async () => {
+      // A node whose parent points back at itself would loop without the guard.
+      httpClient.get.mockResolvedValue({
+        data: { id: '10', name: 'Loop', parent: { id: '10' }, leaf: true },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.fetchCategoryPath('10');
+
+      expect(result).toEqual([{ id: '10', name: 'Loop' }]);
+      // `seen` short-circuits the self-reference after the first fetch.
+      expect(httpClient.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves a category node from cache without re-hitting Allegro', async () => {
+      const cache: jest.Mocked<CachePort> = {
+        get: jest.fn(),
+        set: jest.fn(),
+        delete: jest.fn(),
+      };
+      const adapterWithCache = new AllegroOfferManagerAdapter(
+        connectionId,
+        httpClient,
+        uploadHttpClient,
+        identifierMapping,
+        connection,
+        undefined,
+        undefined,
+        cache
+      );
+      cache.get.mockResolvedValueOnce({ id: '1', name: 'Electronics', parent: null, leaf: false });
+
+      const result = await adapterWithCache.fetchCategoryPath('1');
+
+      expect(result).toEqual([{ id: '1', name: 'Electronics' }]);
+      expect(cache.get).toHaveBeenCalledWith('allegro:category-node:1');
+      expect(httpClient.get).not.toHaveBeenCalled();
+    });
   });
 
   describe('matchCategoryByBarcode', () => {
@@ -996,6 +1052,26 @@ describe('AllegroOfferManagerAdapter', () => {
       const result = await subject.getOffer({ externalId: '7781562867' });
 
       expect(result.marketplaceUrl).toBe('https://allegro.pl/oferta/7781562867');
+    });
+
+    it('should slug Polish stroke letters (ł/Ł) rather than dropping them', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: '7781562868',
+          name: 'Słuchawki Łódź',
+          sellingMode: { price: { amount: '10.00', currency: 'PLN' } },
+          stock: { available: 1 },
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const subject = buildAdapterWithStorefront('https://allegro.pl');
+      const result = await subject.getOffer({ externalId: '7781562868' });
+
+      // ł/Ł are single codepoints NFD does not decompose; they must map to `l`
+      // (not vanish, which would yield `s-uchawki`).
+      expect(result.marketplaceUrl).toBe('https://allegro.pl/oferta/sluchawki-lodz-7781562868');
     });
 
     it('should map offer-section and product-section parameters with productSet linkage (#1482)', async () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -15,6 +15,8 @@ import type {
   OfferEventReader,
   OfferFieldUpdater,
   CategoryBrowser,
+  CategoryPathReader,
+  CategoryPathSegment,
   CategoryBarcodeMatcher,
   EanCategoryMatcher,
   BatchCategoryByEanInput,
@@ -78,6 +80,7 @@ import type {
   AllegroQuantityChangeCommandStatusResponse,
   AllegroCategoryParametersResponse,
   AllegroCategoriesResponse,
+  AllegroCategoryResponse,
   AllegroOfferParameter,
   AllegroOfferPublicationStatus,
   AllegroProductOffer,
@@ -129,11 +132,33 @@ const DEFAULT_CAT_PARAMS_TTL_SEC = 24 * 60 * 60;
 const CAT_PARAMS_CACHE_PREFIX = 'allegro:cat-params:';
 
 /**
+ * Upper bound on category-breadcrumb ancestor hops (#1752). Allegro's tree is
+ * far shallower; the cap only guards against a malformed/cyclic parent chain.
+ */
+const MAX_CATEGORY_PATH_DEPTH = 12;
+
+/**
  * Variant key used when `matchCategoryByBarcode` delegates to the batch util
  * with a single-item input. Any stable string works — the result map is
  * consumed by one read in the same call.
  */
 const SINGLE_ITEM_KEY = 'single';
+
+/**
+ * Build a URL-safe slug from a human offer name for the cosmetic path segment
+ * of a public offer URL. Lowercases, strips diacritics (NFD + drop combining
+ * marks), collapses every non-alphanumeric run to a single `-`, and trims
+ * leading/trailing separators. Returns an empty string for blank/symbol-only
+ * input so the caller can fall back to an id-only URL.
+ */
+function slugify(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
 
 /**
  * Defensive runtime check for the persisted `Connection.config.allegro
@@ -210,6 +235,7 @@ export class AllegroOfferManagerAdapter
     OfferEventReader,
     OfferFieldUpdater,
     CategoryBrowser,
+    CategoryPathReader,
     CategoryBarcodeMatcher,
     EanCategoryMatcher,
     CategoryParametersReader,
@@ -701,7 +727,7 @@ export class AllegroOfferManagerAdapter
       availableQuantity: offer.stock?.available ?? 0,
       status: offer.publication?.status ?? 'UNKNOWN',
       category: offer.category ? { id: offer.category.id } : undefined,
-      marketplaceUrl: this.buildMarketplaceUrl(offer.id),
+      marketplaceUrl: this.buildMarketplaceUrl(offer),
       endsAt: offer.publication?.endingAt,
       parameters: this.mapOfferParameters(offer),
       productSet: this.mapOfferProductSet(offer),
@@ -795,12 +821,19 @@ export class AllegroOfferManagerAdapter
    * hosts differ between sandbox and production; the factory passes the
    * right storefront base via the constructor. When unset (legacy callers,
    * tests), omit the URL — the FE renders no link rather than a wrong one.
+   *
+   * Canonical shape is `/oferta/{slug}-{offerId}`; the numeric id suffix is
+   * what resolves, the slug is cosmetic (Allegro 301s to the canonical slug),
+   * so a stale/mismatched slug is safe. When the offer carries no name we fall
+   * back to the id-only `/oferta/{offerId}` form.
    */
-  private buildMarketplaceUrl(offerId: string): string | undefined {
+  private buildMarketplaceUrl(offer: AllegroProductOffer): string | undefined {
     if (!this.storefrontBaseUrl) {
       return undefined;
     }
-    return `${this.storefrontBaseUrl.replace(/\/+$/, '')}/oferta/${offerId}`;
+    const base = `${this.storefrontBaseUrl.replace(/\/+$/, '')}/oferta`;
+    const slug = slugify(offer.name ?? '');
+    return slug ? `${base}/${slug}-${offer.id}` : `${base}/${offer.id}`;
   }
 
   /**
@@ -882,6 +915,64 @@ export class AllegroOfferManagerAdapter
       parentId: cat.parent?.id ?? null,
       leaf: cat.leaf,
     }));
+  }
+
+  /**
+   * Raw, uncached fetch of `GET /sale/categories/{id}` — the single category
+   * node (not its children). Returns Allegro's native shape verbatim. 404
+   * surfaces as an `AllegroApiException` the caller maps to a neutral not-found.
+   */
+  async fetchCategoryByIdRaw(categoryId: string): Promise<AllegroCategoryResponse> {
+    const response = await this.httpClient.get<AllegroCategoryResponse>(
+      `/sale/categories/${categoryId}`
+    );
+    return response.data;
+  }
+
+  /**
+   * `CategoryPathReader.fetchCategoryPath` — resolve `categoryId` to its full
+   * breadcrumb ordered root -> leaf. Walks up the tree via each node's
+   * `parent.id`, one `GET /sale/categories/{id}` per ancestor. A per-walk
+   * memo avoids re-fetching a node reached twice; a depth cap guards against a
+   * malformed/cyclic parent chain. 404 on the requested leaf maps to the
+   * neutral `CategoryNotFoundException`.
+   */
+  async fetchCategoryPath(categoryId: string): Promise<CategoryPathSegment[]> {
+    this.logger.debug(
+      `Fetching Allegro category path (connection: ${this.connectionId}, categoryId: ${categoryId})`
+    );
+    const memo = new Map<string, AllegroCategoryResponse>();
+    const segments: CategoryPathSegment[] = [];
+    const seen = new Set<string>();
+
+    let currentId: string | null = categoryId;
+    for (let depth = 0; currentId && depth < MAX_CATEGORY_PATH_DEPTH; depth += 1) {
+      if (seen.has(currentId)) {
+        // Defensive: a cyclic parent chain should never happen, but stop
+        // rather than loop.
+        break;
+      }
+      seen.add(currentId);
+
+      let node = memo.get(currentId);
+      if (!node) {
+        try {
+          node = await this.fetchCategoryByIdRaw(currentId);
+        } catch (err) {
+          if (err instanceof AllegroApiException && err.statusCode === 404) {
+            throw new CategoryNotFoundException(currentId, 'allegro');
+          }
+          throw err;
+        }
+        memo.set(currentId, node);
+      }
+
+      // Prepend so the result stays root -> leaf.
+      segments.unshift({ id: node.id, name: node.name });
+      currentId = node.parent?.id ?? null;
+    }
+
+    return segments;
   }
 
   async matchCategoryByBarcode(barcode: string): Promise<string | null> {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -130,6 +130,12 @@ const ALLEGRO_CONDITION_VALUE_IDS: Record<OfferCondition, string> = {
 const DEFAULT_CAT_PARAMS_TTL_SEC = 24 * 60 * 60;
 /** Cache key prefix — global namespace; Allegro category schemas are public taxonomy. */
 const CAT_PARAMS_CACHE_PREFIX = 'allegro:cat-params:';
+/**
+ * Cache key prefix for a single category node (`GET /sale/categories/{id}`).
+ * Global namespace — a category node is immutable public taxonomy, so it is
+ * shared across connections and reused by every breadcrumb walk that touches it.
+ */
+const CATEGORY_NODE_CACHE_PREFIX = 'allegro:category-node:';
 
 /**
  * Upper bound on category-breadcrumb ancestor hops (#1752). Allegro's tree is
@@ -150,14 +156,25 @@ const SINGLE_ITEM_KEY = 'single';
  * marks), collapses every non-alphanumeric run to a single `-`, and trims
  * leading/trailing separators. Returns an empty string for blank/symbol-only
  * input so the caller can fall back to an id-only URL.
+ *
+ * The slug is cosmetic only \u2014 Allegro resolves the offer by the trailing id and
+ * 301s to the canonical URL \u2014 so it must never be treated as canonical.
  */
 function slugify(name: string): string {
-  return name
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  return (
+    name
+      // Latin letters with a stroke (Polish \u0142/\u0141, and the same family for other
+      // languages) are single codepoints NFD does not decompose, so map them
+      // explicitly before the combining-mark strip \u2014 otherwise `s\u0142uchawki`
+      // would slug to `s-uchawki`.
+      .replace(/[\u0142\u0141]/g, 'l')
+      .replace(/[\u0111\u0110]/g, 'd')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+  );
 }
 
 /**
@@ -918,30 +935,43 @@ export class AllegroOfferManagerAdapter
   }
 
   /**
-   * Raw, uncached fetch of `GET /sale/categories/{id}` — the single category
-   * node (not its children). Returns Allegro's native shape verbatim. 404
-   * surfaces as an `AllegroApiException` the caller maps to a neutral not-found.
+   * Fetch a single category node (`GET /sale/categories/{id}`, not its
+   * children), returning Allegro's native shape verbatim. Cached under a global
+   * namespace when a cache is wired — a category node is immutable public
+   * taxonomy — so repeat breadcrumb walks that share an ancestor hit the cache.
+   * 404 surfaces as an `AllegroApiException` the caller maps to a neutral
+   * not-found.
    */
-  async fetchCategoryByIdRaw(categoryId: string): Promise<AllegroCategoryResponse> {
+  private async fetchCategoryByIdRaw(categoryId: string): Promise<AllegroCategoryResponse> {
+    const cacheKey = `${CATEGORY_NODE_CACHE_PREFIX}${categoryId}`;
+    if (this.cache) {
+      const cached = await this.cache.get<AllegroCategoryResponse>(cacheKey);
+      if (cached) {
+        return cached;
+      }
+    }
     const response = await this.httpClient.get<AllegroCategoryResponse>(
       `/sale/categories/${categoryId}`
     );
+    if (this.cache) {
+      await this.cache.set(cacheKey, response.data, this.catParamsTtlSec);
+    }
     return response.data;
   }
 
   /**
    * `CategoryPathReader.fetchCategoryPath` — resolve `categoryId` to its full
    * breadcrumb ordered root -> leaf. Walks up the tree via each node's
-   * `parent.id`, one `GET /sale/categories/{id}` per ancestor. A per-walk
-   * memo avoids re-fetching a node reached twice; a depth cap guards against a
-   * malformed/cyclic parent chain. 404 on the requested leaf maps to the
-   * neutral `CategoryNotFoundException`.
+   * `parent.id`, one `GET /sale/categories/{id}` per ancestor (nodes are cached
+   * in `fetchCategoryByIdRaw`); a depth cap + a `seen` set guard against a
+   * malformed/cyclic parent chain. 404 on the requested leaf (the first hop)
+   * maps to the neutral `CategoryNotFoundException`; a 404 on an *ancestor*
+   * returns the partial breadcrumb resolved so far rather than discarding it.
    */
   async fetchCategoryPath(categoryId: string): Promise<CategoryPathSegment[]> {
     this.logger.debug(
       `Fetching Allegro category path (connection: ${this.connectionId}, categoryId: ${categoryId})`
     );
-    const memo = new Map<string, AllegroCategoryResponse>();
     const segments: CategoryPathSegment[] = [];
     const seen = new Set<string>();
 
@@ -954,17 +984,19 @@ export class AllegroOfferManagerAdapter
       }
       seen.add(currentId);
 
-      let node = memo.get(currentId);
-      if (!node) {
-        try {
-          node = await this.fetchCategoryByIdRaw(currentId);
-        } catch (err) {
-          if (err instanceof AllegroApiException && err.statusCode === 404) {
+      let node: AllegroCategoryResponse;
+      try {
+        node = await this.fetchCategoryByIdRaw(currentId);
+      } catch (err) {
+        if (err instanceof AllegroApiException && err.statusCode === 404) {
+          // The requested leaf not existing is a genuine not-found; an ancestor
+          // vanishing mid-walk just truncates the breadcrumb — keep what we have.
+          if (depth === 0) {
             throw new CategoryNotFoundException(currentId, 'allegro');
           }
-          throw err;
+          break;
         }
-        memo.set(currentId, node);
+        throw err;
       }
 
       // Prepend so the result stays root -> leaf.

--- a/libs/integrations/erli/src/application/erli-adapter.factory.ts
+++ b/libs/integrations/erli/src/application/erli-adapter.factory.ts
@@ -31,6 +31,8 @@ import { isAllowedErliBaseUrl } from '../domain/policies/erli-base-url.policy';
 import {
   ERLI_DEFAULT_BASE_URL,
   ERLI_SANDBOX_BASE_URL,
+  ERLI_DEFAULT_WEB_BASE_URL,
+  ERLI_SANDBOX_WEB_BASE_URL,
   type ErliConnectionConfig,
   type ErliCredentials,
 } from '../domain/types/erli-connection.types';
@@ -85,6 +87,8 @@ export class ErliAdapterFactory implements IErliAdapterFactory {
     const allegroCategoryCatalog = this.buildAllegroCategoryCatalog(credentials, config, cache);
     // Construct the offer manager first so its reference can be shared with the
     // order-source adapter (which needs it for the `cancelled` stock-restore path).
+    const webBaseUrl =
+      config.environment === 'sandbox' ? ERLI_SANDBOX_WEB_BASE_URL : ERLI_DEFAULT_WEB_BASE_URL;
     const offerManager = new ErliOfferManagerAdapter(
       connection.id,
       ERLI_ADAPTER_KEY,
@@ -92,6 +96,7 @@ export class ErliAdapterFactory implements IErliAdapterFactory {
       config.defaultDispatchTime,
       cache,
       allegroCategoryCatalog,
+      webBaseUrl,
     );
     return {
       offerManager,

--- a/libs/integrations/erli/src/domain/types/erli-connection.types.ts
+++ b/libs/integrations/erli/src/domain/types/erli-connection.types.ts
@@ -135,3 +135,17 @@ export const ERLI_DEFAULT_BASE_URL = 'https://erli.pl/svc/shop-api';
  * — the single source of truth for the sandbox host, no longer duplicated on the FE.
  */
 export const ERLI_SANDBOX_BASE_URL = 'https://sandbox.erli.dev/svc/shop-api';
+
+/**
+ * Production buyer-facing web host (origin only, NO `/svc/shop-api` prefix).
+ * Used to build public offer URLs (`{host}/produkt/{slug},{marketplaceId}`),
+ * which live on the storefront origin, not the API base.
+ */
+export const ERLI_DEFAULT_WEB_BASE_URL = 'https://erli.pl';
+
+/**
+ * Sandbox buyer-facing web host (origin only). Counterpart to
+ * {@link ERLI_DEFAULT_WEB_BASE_URL}; resolved by the adapter factory when
+ * `connection.config.environment === 'sandbox'`.
+ */
+export const ERLI_SANDBOX_WEB_BASE_URL = 'https://sandbox.erli.dev';

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -1086,6 +1086,51 @@ describe('ErliOfferManagerAdapter', () => {
       });
     });
 
+    it('should build the public marketplaceUrl when a web host, slug and marketplaceId are present', async () => {
+      const webAdapter = new ErliOfferManagerAdapter(
+        'conn-1',
+        ERLI_ADAPTER_KEY,
+        httpClient,
+        { period: 2, unit: 'day' },
+        undefined,
+        undefined,
+        'https://sandbox.erli.dev',
+      );
+      httpClient.get.mockResolvedValueOnce({ status: 200, data: productResource });
+
+      const offer = await webAdapter.getOffer({ externalId: VALID_ID });
+
+      expect(offer.marketplaceUrl).toBe('https://sandbox.erli.dev/produkt/swieca-sojowa-200g-aura,843284');
+    });
+
+    it('should omit marketplaceUrl when the slug or marketplaceId is missing (even with a web host)', async () => {
+      const webAdapter = new ErliOfferManagerAdapter(
+        'conn-1',
+        ERLI_ADAPTER_KEY,
+        httpClient,
+        { period: 2, unit: 'day' },
+        undefined,
+        undefined,
+        'https://sandbox.erli.dev',
+      );
+      httpClient.get.mockResolvedValueOnce({
+        status: 200,
+        data: { ...productResource, slug: undefined },
+      });
+
+      const offer = await webAdapter.getOffer({ externalId: VALID_ID });
+
+      expect(offer.marketplaceUrl).toBeUndefined();
+    });
+
+    it('should omit marketplaceUrl when no web host is wired', async () => {
+      httpClient.get.mockResolvedValueOnce({ status: 200, data: productResource });
+
+      const offer = await adapter.getOffer({ externalId: VALID_ID });
+
+      expect(offer.marketplaceUrl).toBeUndefined();
+    });
+
     it('should default missing fields defensively (empty title, 0 price/qty)', async () => {
       httpClient.get.mockResolvedValueOnce({ status: 200, data: {} });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -288,6 +288,14 @@ export class ErliOfferManagerAdapter
      * capability" case callers already handle.
      */
     allegroCategoryCatalog?: AllegroCategoryCatalogClient,
+    /**
+     * Buyer-facing web host (origin, e.g. `https://sandbox.erli.dev` /
+     * `https://erli.pl` — NOT the `/svc/shop-api` API base). Used to build the
+     * public offer URL in {@link toMarketplaceOffer}. Optional: when absent (unit
+     * tests, legacy callers) the offer URL is simply omitted, preserving the
+     * pre-fix behaviour.
+     */
+    private readonly webBaseUrl?: string,
   ) {
     if (allegroCategoryCatalog) {
       this.fetchCategories = (parentId?: string): Promise<OfferCategory[]> =>
@@ -422,11 +430,17 @@ export class ErliOfferManagerAdapter
    * Price is Erli's grosze integer → decimal string in PLN (Erli is PLN-only).
    * Description prefers the flat `externalDescription` HTML over the structured
    * `description.sections` tree. Category is the leaf of the first breadcrumb path.
-   * `marketplaceUrl` / `endsAt` are intentionally omitted — Erli exposes no stable
-   * buyer-facing offer URL on this read and has no fixed offer end date.
+   * `marketplaceUrl` is the public `{webBaseUrl}/produkt/{slug},{marketplaceId}`
+   * when the read carries both a `slug` and a numeric `marketplaceId` (and a web
+   * host is wired); otherwise it is omitted — Erli exposes no stable buyer-facing
+   * URL for such reads. `endsAt` is always omitted (Erli has no fixed offer end date).
    */
   private toMarketplaceOffer(externalId: string, product: ErliProductResource): MarketplaceOffer {
     const leafCategory = product.categories?.[0]?.at(-1);
+    const marketplaceUrl =
+      this.webBaseUrl && product.slug && product.marketplaceId !== undefined
+        ? `${this.webBaseUrl}/produkt/${product.slug},${product.marketplaceId}`
+        : undefined;
     return {
       externalId: product.externalId ?? externalId,
       title: product.name ?? '',
@@ -441,6 +455,7 @@ export class ErliOfferManagerAdapter
       category: leafCategory
         ? { id: String(leafCategory.id), name: leafCategory.name }
         : undefined,
+      marketplaceUrl,
     };
   }
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -258,6 +258,13 @@ export interface ErliProductResource {
   images?: ErliProductImage[];
   /** Category breadcrumb paths; the first path's leaf is the offer's category. */
   categories?: ErliProductCategoryNode[][];
+  // ── Buyer-facing URL fields (#1752) ──
+  // PROVISIONAL: unlike the read-side fields above, these two are NOT yet
+  // confirmed against a live sandbox `GET /products/{externalId}` response.
+  // The public offer URL (`{host}/produkt/{slug},{marketplaceId}`) is built
+  // only when BOTH are present, so an absent field just omits the URL (safe
+  // fallback, no broken link) rather than mislabelling anything. Confirm the
+  // live read returns them before treating the URL as a guaranteed feature.
   /** Buyer-facing offer slug (e.g. `swieca-sojowa-200g`). */
   slug?: string;
   /** Numeric Erli marketplace offer id (distinct from the seller-keyed `externalId`). */

--- a/libs/integrations/prestashop/src/application/__tests__/prestashop-adapter.factory.spec.ts
+++ b/libs/integrations/prestashop/src/application/__tests__/prestashop-adapter.factory.spec.ts
@@ -7,6 +7,7 @@
  * @module libs/integrations/prestashop/src/application/__tests__
  */
 import { PrestashopAdapterFactory } from '../prestashop-adapter.factory';
+import { PrestashopShopCurrencyResolver } from '../../infrastructure/provisioners/prestashop-shop-currency.resolver';
 import type { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import type { CredentialsResolverPort } from '@openlinker/core/integrations';
 import type { PrestashopCredentials } from '@openlinker/integrations-prestashop';
@@ -98,6 +99,33 @@ describe('PrestashopAdapterFactory', () => {
 
       // Adapters should be created with defaults
       expect(adapters.productMaster).toBeDefined();
+    });
+
+    it('should resolve the shop-default currency when config.currency is unset', async () => {
+      const resolveSpy = jest
+        .spyOn(PrestashopShopCurrencyResolver.prototype, 'resolveDefaultCurrencyIso')
+        .mockResolvedValue('PLN');
+      const connection = createTestConnection();
+      mockCredentialsResolver.get.mockResolvedValue({ webserviceApiKey: 'test-key' });
+
+      await factory.createAdapters(connection, mockIdentifierMapping, mockCredentialsResolver);
+
+      expect(resolveSpy).toHaveBeenCalledWith('test-connection-id', expect.anything());
+      resolveSpy.mockRestore();
+    });
+
+    it('should not resolve the shop-default currency when config.currency is set (explicit wins)', async () => {
+      const resolveSpy = jest.spyOn(
+        PrestashopShopCurrencyResolver.prototype,
+        'resolveDefaultCurrencyIso'
+      );
+      const connection = createTestConnection({ currency: 'EUR' });
+      mockCredentialsResolver.get.mockResolvedValue({ webserviceApiKey: 'test-key' });
+
+      await factory.createAdapters(connection, mockIdentifierMapping, mockCredentialsResolver);
+
+      expect(resolveSpy).not.toHaveBeenCalled();
+      resolveSpy.mockRestore();
     });
   });
 

--- a/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
+++ b/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
@@ -38,6 +38,7 @@ import type { PrestashopCustomerProvisioner } from '../infrastructure/provisione
 import { PrestashopAddressProvisioner } from '../infrastructure/provisioners/prestashop-address-provisioner';
 import { PrestashopCountryResolver } from '../infrastructure/provisioners/prestashop-country-resolver';
 import { PrestashopCurrencyResolver } from '../infrastructure/provisioners/prestashop-currency-resolver';
+import { PrestashopShopCurrencyResolver } from '../infrastructure/provisioners/prestashop-shop-currency.resolver';
 import { PrestashopTaxRateResolver } from '../infrastructure/provisioners/prestashop-tax-rate.resolver';
 import { PrestashopAttributeResolver } from '../infrastructure/provisioners/prestashop-attribute.resolver';
 import { PrestashopFeatureResolver } from '../infrastructure/provisioners/prestashop-feature.resolver';
@@ -63,6 +64,12 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
   // mirroring `attributeResolver`.
   private readonly featureResolver = new PrestashopFeatureResolver();
   private readonly categoryPathResolver = new PrestashopCategoryPathResolver();
+
+  // Process-singleton (mirrors the resolvers above) so its per-connection cache
+  // of the shop-default-currency ISO survives across per-product adapter
+  // instances the master sync creates. Resolves the fallback currency when the
+  // connection config leaves `currency` unset.
+  private readonly shopCurrencyResolver = new PrestashopShopCurrencyResolver();
 
   constructor(
     private readonly customerProvisioner?: PrestashopCustomerProvisioner,
@@ -101,12 +108,21 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
     // Create HTTP client
     const httpClient = new PrestashopWebserviceClient(config.baseUrl, credentials, config);
 
+    // Resolve the product currency: an explicit connection-config `currency`
+    // always wins; otherwise fall back to the PrestaShop shop default (cached
+    // per connection). Resolution is best-effort — on any failure the currency
+    // stays unset and the mapper emits `currency: null` (today's behaviour).
+    const resolvedCurrency =
+      config.currency ??
+      (await this.shopCurrencyResolver.resolveDefaultCurrencyIso(connection.id, httpClient)) ??
+      undefined;
+
     // Create mappers. `storefrontBaseUrl` falls back to the webservice `baseUrl`
     // when unset — works for the common case where webservice and storefront
     // share a host. Operators override it via connection config when they differ.
     const productMapper = new PrestashopProductMapper({
       storefrontBaseUrl: config.storefrontBaseUrl ?? config.baseUrl,
-      currency: config.currency,
+      currency: resolvedCurrency,
     });
     const inventoryMapper = new PrestashopInventoryMapper();
     const orderMapper = new PrestashopOrderMapper();

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-shop-currency.resolver.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-shop-currency.resolver.spec.ts
@@ -100,4 +100,42 @@ describe('PrestashopShopCurrencyResolver', () => {
 
     await expect(resolver.resolveDefaultCurrencyIso('conn-1', client)).resolves.toBeNull();
   });
+
+  it('should NOT poison the cache for 24h on a transient failure — the next call retries', async () => {
+    // First call: a transient WS blip resolves to null.
+    client.listResources.mockRejectedValueOnce(new Error('timeout'));
+    const first = await resolver.resolveDefaultCurrencyIso('conn-1', client);
+    expect(first).toBeNull();
+
+    // A short-TTL failure entry must not survive; jump past FAILURE_CACHE_TTL_MS.
+    const realNow = Date.now;
+    const past = realNow();
+    jest.spyOn(Date, 'now').mockReturnValue(past + 61 * 1000);
+    try {
+      // Second call: the client is healthy again → resolves the real ISO,
+      // proving the transient null was not cached under the full 24h TTL.
+      const second = await resolver.resolveDefaultCurrencyIso('conn-1', client);
+      expect(second).toBe('PLN');
+    } finally {
+      (Date.now as jest.Mock).mockRestore();
+    }
+    expect(client.listResources).toHaveBeenCalledTimes(2);
+  });
+
+  it('should cache a definitive absence for the full TTL (no short-TTL retry)', async () => {
+    client.listResources.mockResolvedValueOnce([]);
+    const first = await resolver.resolveDefaultCurrencyIso('conn-1', client);
+    expect(first).toBeNull();
+
+    // Past the failure TTL but well within the 24h definitive TTL: no refetch.
+    const past = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(past + 61 * 1000);
+    try {
+      const second = await resolver.resolveDefaultCurrencyIso('conn-1', client);
+      expect(second).toBeNull();
+    } finally {
+      (Date.now as jest.Mock).mockRestore();
+    }
+    expect(client.listResources).toHaveBeenCalledTimes(1);
+  });
 });

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-shop-currency.resolver.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-shop-currency.resolver.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for PrestashopShopCurrencyResolver (#1752)
+ *
+ * Verifies the shop-default-currency ISO is resolved from `PS_CURRENCY_DEFAULT`
+ * → `/currencies/{id}`, cached per connection, and that any failure yields
+ * `null` (never throws into product sync).
+ */
+import { PrestashopShopCurrencyResolver } from '../prestashop-shop-currency.resolver';
+import type { IPrestashopWebserviceClient } from '../../http/prestashop-webservice.client.interface';
+
+describe('PrestashopShopCurrencyResolver', () => {
+  let resolver: PrestashopShopCurrencyResolver;
+  let client: jest.Mocked<IPrestashopWebserviceClient>;
+
+  beforeEach(() => {
+    resolver = new PrestashopShopCurrencyResolver();
+    client = {
+      getResource: jest.fn((resource: string, id: string | number) => {
+        if (resource === 'currencies' && String(id) === '2') {
+          return Promise.resolve({ id: '2', iso_code: 'PLN' });
+        }
+        return Promise.resolve({});
+      }),
+      listResources: jest.fn((resource: string) => {
+        if (resource === 'configurations') {
+          return Promise.resolve([{ id: '1', name: 'PS_CURRENCY_DEFAULT', value: '2' }]);
+        }
+        return Promise.resolve([]);
+      }),
+      createResource: jest.fn(),
+      updateResource: jest.fn(),
+      deleteResource: jest.fn(),
+      uploadImage: jest.fn(),
+    } as unknown as jest.Mocked<IPrestashopWebserviceClient>;
+  });
+
+  it('should resolve the shop default currency ISO from PS_CURRENCY_DEFAULT', async () => {
+    const iso = await resolver.resolveDefaultCurrencyIso('conn-1', client);
+
+    expect(iso).toBe('PLN');
+    expect(client.listResources).toHaveBeenCalledWith(
+      'configurations',
+      { custom: { name: 'PS_CURRENCY_DEFAULT' } },
+      1,
+      0
+    );
+    expect(client.getResource).toHaveBeenCalledWith('currencies', '2');
+  });
+
+  it('should uppercase the returned iso_code', async () => {
+    client.getResource.mockResolvedValueOnce({ id: '2', iso_code: 'eur' });
+
+    const iso = await resolver.resolveDefaultCurrencyIso('conn-1', client);
+
+    expect(iso).toBe('EUR');
+  });
+
+  it('should cache per connection — a second call makes no WS request', async () => {
+    await resolver.resolveDefaultCurrencyIso('conn-1', client);
+    await resolver.resolveDefaultCurrencyIso('conn-1', client);
+
+    expect(client.listResources).toHaveBeenCalledTimes(1);
+    expect(client.getResource).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fetch independently for different connections', async () => {
+    await resolver.resolveDefaultCurrencyIso('conn-1', client);
+    await resolver.resolveDefaultCurrencyIso('conn-2', client);
+
+    expect(client.listResources).toHaveBeenCalledTimes(2);
+  });
+
+  it('should refetch after the cache is cleared', async () => {
+    await resolver.resolveDefaultCurrencyIso('conn-1', client);
+    resolver.clearCache('conn-1');
+    await resolver.resolveDefaultCurrencyIso('conn-1', client);
+
+    expect(client.listResources).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return null when PS_CURRENCY_DEFAULT is absent', async () => {
+    client.listResources.mockResolvedValueOnce([]);
+
+    const iso = await resolver.resolveDefaultCurrencyIso('conn-1', client);
+
+    expect(iso).toBeNull();
+    expect(client.getResource).not.toHaveBeenCalled();
+  });
+
+  it('should return null when the currency has no iso_code', async () => {
+    client.getResource.mockResolvedValueOnce({ id: '2' });
+
+    const iso = await resolver.resolveDefaultCurrencyIso('conn-1', client);
+
+    expect(iso).toBeNull();
+  });
+
+  it('should return null (never throw) when the WS request fails', async () => {
+    client.listResources.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(resolver.resolveDefaultCurrencyIso('conn-1', client)).resolves.toBeNull();
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-provisioner.types.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-provisioner.types.ts
@@ -110,3 +110,16 @@ export interface PrestashopCurrency {
   id: string;
   iso_code?: string;
 }
+
+/**
+ * PrestaShop Configuration Data
+ *
+ * Represents a single `/configurations` row (a global key/value setting, e.g.
+ * `PS_CURRENCY_DEFAULT`). `value` carries the setting payload — for
+ * `PS_CURRENCY_DEFAULT` it is the numeric id of the shop's default currency.
+ */
+export interface PrestashopConfiguration {
+  id: string;
+  name?: string;
+  value?: string;
+}

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-shop-currency.resolver.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-shop-currency.resolver.ts
@@ -34,10 +34,28 @@ const DEFAULT_CURRENCY_CONFIG_KEY = 'PS_CURRENCY_DEFAULT';
  */
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Short TTL (60s) for a transient-failure `null`. A network blip / 5xx during
+ * the first product sync must NOT pin `currency: null` for the whole 24h TTL —
+ * the next sync re-attempts within a minute. A *definitive* resolution (a real
+ * ISO, or a genuinely absent `PS_CURRENCY_DEFAULT`) still caches for the full
+ * `CACHE_TTL_MS`.
+ */
+const FAILURE_CACHE_TTL_MS = 60 * 1000;
+
 interface CacheEntry {
   /** Resolved default ISO, or `null` when resolution failed / was absent. */
   iso: string | null;
+  /** Per-entry TTL; short for transient failures, full for definitive results. */
+  ttlMs: number;
   timestamp: number;
+}
+
+/** Distinguishes a definitive resolution from a transient-failure `null`. */
+interface ResolutionResult {
+  iso: string | null;
+  /** `true` when `iso === null` came from a transient error (short TTL). */
+  transient: boolean;
 }
 
 export class PrestashopShopCurrencyResolver {
@@ -57,14 +75,18 @@ export class PrestashopShopCurrencyResolver {
   ): Promise<string | null> {
     const cached = this.cache.get(connectionId);
     if (cached !== undefined) {
-      if (Date.now() - cached.timestamp < CACHE_TTL_MS) {
+      if (Date.now() - cached.timestamp < cached.ttlMs) {
         return cached.iso;
       }
       this.cache.delete(connectionId);
     }
 
-    const iso = await this.fetchDefaultCurrencyIso(connectionId, client);
-    this.cache.set(connectionId, { iso, timestamp: Date.now() });
+    const { iso, transient } = await this.fetchDefaultCurrencyIso(connectionId, client);
+    this.cache.set(connectionId, {
+      iso,
+      ttlMs: transient ? FAILURE_CACHE_TTL_MS : CACHE_TTL_MS,
+      timestamp: Date.now(),
+    });
     return iso;
   }
 
@@ -80,8 +102,13 @@ export class PrestashopShopCurrencyResolver {
   private async fetchDefaultCurrencyIso(
     connectionId: string,
     client: IPrestashopWebserviceClient
-  ): Promise<string | null> {
+  ): Promise<ResolutionResult> {
     try {
+      // NOTE (multistore): on a multistore PrestaShop, `PS_CURRENCY_DEFAULT`
+      // can carry per-shop / per-shop-group rows. `limit=1` here takes an
+      // arbitrary one, which can mislabel the currency for the shop the
+      // connection's products actually come from. Correct for the common
+      // single-store case; shop-scoping this read is a documented follow-up.
       const configs = await client.listResources<PrestashopConfiguration>(
         'configurations',
         { custom: { name: DEFAULT_CURRENCY_CONFIG_KEY } },
@@ -94,7 +121,8 @@ export class PrestashopShopCurrencyResolver {
           `No ${DEFAULT_CURRENCY_CONFIG_KEY} configured in PrestaShop (connection: ${connectionId}); ` +
             `product currency stays null`
         );
-        return null;
+        // Definitive absence — cache for the full TTL.
+        return { iso: null, transient: false };
       }
 
       const currency = await client.getResource<PrestashopCurrency>('currencies', currencyId);
@@ -104,19 +132,21 @@ export class PrestashopShopCurrencyResolver {
           `Default currency ${currencyId} has no iso_code in PrestaShop (connection: ${connectionId}); ` +
             `product currency stays null`
         );
-        return null;
+        // Definitive (malformed data, not a transient blip) — full TTL.
+        return { iso: null, transient: false };
       }
 
       this.logger.debug(
         `Resolved PrestaShop default currency for connection ${connectionId}: ${iso}`
       );
-      return iso;
+      return { iso, transient: false };
     } catch (error) {
       this.logger.warn(
         `Failed to resolve PrestaShop default currency (connection: ${connectionId}); ` +
           `product currency stays null: ${(error as Error).message}`
       );
-      return null;
+      // Transient failure (WS timeout / 5xx) — short TTL so the next sync retries.
+      return { iso: null, transient: true };
     }
   }
 }

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-shop-currency.resolver.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-shop-currency.resolver.ts
@@ -1,0 +1,122 @@
+/**
+ * PrestaShop Shop-Default-Currency Resolver
+ *
+ * Resolves the ISO 4217 code of a PrestaShop shop's **default** currency for a
+ * connection. PrestaShop stores the default as the `PS_CURRENCY_DEFAULT`
+ * configuration value (a currency id); this resolver reads that id, then reads
+ * `/currencies/{id}` for its `iso_code`.
+ *
+ * The result is a per-connection constant (a shop rarely changes its default
+ * currency), so it is cached once per connection with a 24h TTL — mirroring the
+ * companion `PrestashopFeatureResolver` / `PrestashopCurrencyResolver`. The
+ * master sync resolves the adapter per product, so this resolver must be held on
+ * the process-singleton factory for its cache to survive across product jobs.
+ *
+ * Robust by design: any failure (missing/malformed config, ambiguous result,
+ * WS error) returns `null` and never throws into product sync — the mapper then
+ * emits `currency: null`, today's behaviour before a currency is configured.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/provisioners
+ */
+import { Logger } from '@openlinker/shared/logging';
+import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
+import type {
+  PrestashopConfiguration,
+  PrestashopCurrency,
+} from './prestashop-provisioner.types';
+
+/** The PrestaShop configuration key holding the shop's default currency id. */
+const DEFAULT_CURRENCY_CONFIG_KEY = 'PS_CURRENCY_DEFAULT';
+
+/**
+ * Cache TTL (24h). The shop default currency changes rarely, but the cache
+ * expires so a back-office change eventually surfaces without a restart.
+ */
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface CacheEntry {
+  /** Resolved default ISO, or `null` when resolution failed / was absent. */
+  iso: string | null;
+  timestamp: number;
+}
+
+export class PrestashopShopCurrencyResolver {
+  private readonly logger = new Logger(PrestashopShopCurrencyResolver.name);
+  private readonly cache = new Map<string, CacheEntry>();
+
+  /**
+   * Resolve the shop's default-currency ISO code for a connection.
+   *
+   * @param connectionId - Cache key
+   * @param client - PrestaShop WebService client for this connection
+   * @returns The default ISO 4217 code (e.g. `'PLN'`), or `null` on any failure.
+   */
+  async resolveDefaultCurrencyIso(
+    connectionId: string,
+    client: IPrestashopWebserviceClient
+  ): Promise<string | null> {
+    const cached = this.cache.get(connectionId);
+    if (cached !== undefined) {
+      if (Date.now() - cached.timestamp < CACHE_TTL_MS) {
+        return cached.iso;
+      }
+      this.cache.delete(connectionId);
+    }
+
+    const iso = await this.fetchDefaultCurrencyIso(connectionId, client);
+    this.cache.set(connectionId, { iso, timestamp: Date.now() });
+    return iso;
+  }
+
+  /** Clear the cache for one connection, or all connections when omitted. */
+  clearCache(connectionId?: string): void {
+    if (connectionId) {
+      this.cache.delete(connectionId);
+    } else {
+      this.cache.clear();
+    }
+  }
+
+  private async fetchDefaultCurrencyIso(
+    connectionId: string,
+    client: IPrestashopWebserviceClient
+  ): Promise<string | null> {
+    try {
+      const configs = await client.listResources<PrestashopConfiguration>(
+        'configurations',
+        { custom: { name: DEFAULT_CURRENCY_CONFIG_KEY } },
+        1,
+        0
+      );
+      const currencyId = configs?.[0]?.value?.trim();
+      if (!currencyId) {
+        this.logger.warn(
+          `No ${DEFAULT_CURRENCY_CONFIG_KEY} configured in PrestaShop (connection: ${connectionId}); ` +
+            `product currency stays null`
+        );
+        return null;
+      }
+
+      const currency = await client.getResource<PrestashopCurrency>('currencies', currencyId);
+      const iso = currency?.iso_code?.trim().toUpperCase();
+      if (!iso) {
+        this.logger.warn(
+          `Default currency ${currencyId} has no iso_code in PrestaShop (connection: ${connectionId}); ` +
+            `product currency stays null`
+        );
+        return null;
+      }
+
+      this.logger.debug(
+        `Resolved PrestaShop default currency for connection ${connectionId}: ${iso}`
+      );
+      return iso;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to resolve PrestaShop default currency (connection: ${connectionId}); ` +
+          `product currency stays null: ${(error as Error).message}`
+      );
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## What & why

Continues the product-detail polish for #1752. PR #1753 merged the first slice (full-width variant table, KPI strip, Source section, mobile layout, link-colour fix). This PR carries the remaining, reviewed work — rebased onto current `main`.

## Changes

- **Category breadcrumb + correct marketplace URLs** — `CategoryPathReader` capability resolves an Allegro category id to a "Root › … › Leaf" breadcrumb (id fallback); Allegro `/oferta/{slug}-{id}` and Erli `/produkt/{slug},{id}` URLs, sandbox/prod-host aware.
- **Round-2 drawer + hero + states** — hero fact alignment, badges above title, gallery placeholder; drawer with top channel deep-links, metadata grid (Attributes / Variant ID / EAN / combined Stock) above the listings, a "n listed · m gap · Channels" summary, `·` meta separators; single-variant products render a "Listed on" panel, multi-variant keep the table; KPI subs (currency, "across N locations").
- **De-duplicated dates** — dropped the confusing per-variant "Updated" column (kept the "Stock synced" pill + per-offer "Offer updated"); boxed the empty description; price KPI shows amount + currency sub (no double-format).
- **Master currency** — `PrestashopShopCurrencyResolver` derives the shop default currency (PS_CURRENCY_DEFAULT → iso, cached) as the fallback so `Product.currency` is populated on sync.
- **Master product attributes** — persist the already-fetched PrestaShop product features (`features jsonb` migration + repo mapping), expose on `ProductResponseDto`, and render a product-level "Attributes" block (the natural home for simple products whose per-variant attributes are empty).

## How to test

Open `/products/:id` (multi-variant e.g. the adidas 3-variant fixture, and a single-variant product). Verify the refined drawer, single-vs-multi layout, KPI subs, the "Attributes" block when the product has features, and category breadcrumbs / marketplace links (need an API carrying this branch + a fresh product sync to populate currency/features live).

## Quality gate

- `pnpm build` (all packages) — clean on current `main`.
- `pnpm --filter @openlinker/web exec vitest run src/pages/products/` — 56 passing; core / prestashop / api suites green on the source branch.
- design-token drift check — OK.
- Migration `1827000000000-add-product-features.ts` — idempotent `ADD COLUMN IF NOT EXISTS features jsonb` (mirrors the categories migration); run `migration:show` against a DB in CI.

Closes #1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013C86Sx5EyrNAwd3a2K7GVg
