### PR TITLE
feat(web/data-table): frozen columns, pinned bulk-action bar, viewport-pinned accordion drawer

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2514,10 +2514,22 @@ textarea,
 .data-table__footer-rail {
   position: fixed;
   z-index: 30;
+  /* The rail box spans the full table width and stays in the layout even when
+     the bar self-hides (count 0), so it must NOT catch pointer events itself —
+     otherwise an invisible fixed strip near the viewport bottom would swallow
+     clicks on the rows/pagination beneath it. Only the visible inner bar is a
+     click target. */
+  pointer-events: none;
 }
 .data-table__footer-rail .bulk-action-bar {
   position: static;
   margin: 0;
+  pointer-events: auto;
+}
+/* Re-assert inert when the bar has faded out at count 0 (equal specificity to
+   the rule above, so source order wins — keep this last). */
+.data-table__footer-rail .bulk-action-bar--hidden {
+  pointer-events: none;
 }
 
 /* Virtualized mode: the inner scroller owns both axes. */
@@ -2910,7 +2922,11 @@ textarea,
      horizontally-scrolled) table: it sticks to the left edge of the scroll
      container and takes the container's visible width (--dt-visible-width,
      published from JS). So the detail stays fully readable and never slides
-     under the frozen columns, however far the row columns are scrolled. */
+     under the frozen columns, however far the row columns are scrolled.
+     Applies to every expandable table, not just frozen-column ones: when a
+     table has no horizontal overflow (no `stickyLeftColumns`), `sticky; left:0`
+     resolves to the same position as static and `--dt-visible-width` equals the
+     table width, so the drawer renders identically to before — a safe no-op. */
   position: sticky;
   left: 0;
   width: var(--dt-visible-width, 100%);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2504,6 +2504,22 @@ textarea,
   box-shadow: var(--shadow-focus);
 }
 
+/* Footer rail (bulk actions): a popover-style bar fixed to the viewport and
+   positioned by JS (see data-table.tsx) — anchored to the viewport bottom,
+   clamped to the table's top/bottom edges, and matched to the table's width, so
+   it stays on screen while the table is visible and never leaves the table's
+   box. Fixed (not sticky) because an ancestor's overflow would capture sticky.
+   top/left/width are set imperatively; the inner bar keeps its floating-card
+   look and drops its own positioning. */
+.data-table__footer-rail {
+  position: fixed;
+  z-index: 30;
+}
+.data-table__footer-rail .bulk-action-bar {
+  position: static;
+  margin: 0;
+}
+
 /* Virtualized mode: the inner scroller owns both axes. */
 .data-table__container--virtual {
   overflow: visible;
@@ -2588,6 +2604,49 @@ textarea,
 
 .data-table tbody tr:last-child td {
   border-bottom: 0;
+}
+
+/* ── DataTable frozen leading columns (horizontal sticky) ────────────────
+   `stickyLeftColumns` pins the identity cluster (expander / checkbox / name)
+   to the left while the rest of the row scrolls under it. Frozen cells need
+   opaque backgrounds so scrolled content can't bleed through, and they mirror
+   the row hover/expanded tints (which are transparent bg-shell mixes over the
+   surface) with their opaque equivalents. The boundary itself stays inert
+   until content is actually hidden beneath it — see --sticky-scrolled. */
+.data-table__sticky-col {
+  position: sticky;
+  z-index: 2;
+  background: var(--bg-surface);
+}
+.data-table thead th.data-table__sticky-col {
+  /* Corner cells are sticky on both axes; keep them above the frozen body
+     column (2) and the plain sticky header (1). */
+  z-index: 3;
+  background: var(--bg-shell);
+}
+.data-table__row--linked:hover .data-table__sticky-col,
+.data-table__row--expandable:hover .data-table__sticky-col {
+  background: color-mix(in oklab, var(--bg-shell) 60%, var(--bg-surface));
+}
+.data-table__row--expanded .data-table__sticky-col {
+  background: color-mix(in oklab, var(--bg-shell) 45%, var(--bg-surface));
+}
+
+/* Boundary divider: no edge at rest (the frozen columns read as ordinary
+   columns), escalating to a soft signal-orange edge + a shadow cast rightward
+   only once the row is scrolled and content is actually hidden beneath it. */
+.data-table__sticky-col--last {
+  box-shadow: none;
+}
+.data-table--sticky-scrolled .data-table__sticky-col--last {
+  box-shadow:
+    inset -1px 0 0 color-mix(in oklab, var(--accent-primary) 42%, transparent),
+    6px 0 12px -6px color-mix(in oklab, var(--accent-primary) 22%, transparent);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .data-table__sticky-col--last {
+    transition: box-shadow var(--duration-normal) var(--ease-out);
+  }
 }
 
 .data-table__row--linked {
@@ -2847,6 +2906,15 @@ textarea,
 }
 
 .data-table__detail {
+  /* Pin the expanded drawer to the viewport, not the (often wider,
+     horizontally-scrolled) table: it sticks to the left edge of the scroll
+     container and takes the container's visible width (--dt-visible-width,
+     published from JS). So the detail stays fully readable and never slides
+     under the frozen columns, however far the row columns are scrolled. */
+  position: sticky;
+  left: 0;
+  width: var(--dt-visible-width, 100%);
+  box-sizing: border-box;
   padding: var(--space-4) var(--space-4) var(--space-4) 2.75rem;
 }
 

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -1111,6 +1111,28 @@ export function OrdersListPage(): ReactElement {
             columns={columns}
             rows={query.data?.items ?? []}
             rowKey={(order) => order.internalOrderId}
+            stickyLeftColumns={2}
+            footer={
+              <BulkActionBar
+                count={selectedOrders.length}
+                itemNoun="order"
+                hint={
+                  distinctSelectedSources > 1
+                    ? `${distinctSelectedSources} sources · max ${BULK_DISPATCH_MAX_ITEMS} per source`
+                    : `Max ${BULK_DISPATCH_MAX_ITEMS} per source`
+                }
+                actions={
+                  <>
+                    <Button tone="ghost" onClick={clearSelection}>
+                      Clear
+                    </Button>
+                    <Button tone="primary" onClick={() => { setBulkOpen(true); }}>
+                      Dispatch {selectedOrders.length}
+                    </Button>
+                  </>
+                }
+              />
+            }
             expandable={{
               // Non-essential fields (order ref, items, exact ship-by, carrier,
               // created, payment, addresses) live in the accordion (#1620); the
@@ -1347,29 +1369,6 @@ export function OrdersListPage(): ReactElement {
               </Button>
             </div>
           </div>
-
-          {/* Bulk dispatch (#1109) — multi-select → batch generate-labels. The
-              cap is per source; a selection may span sources (dispatched in
-              per-source groups). */}
-          <BulkActionBar
-            count={selectedOrders.length}
-            itemNoun="order"
-            hint={
-              distinctSelectedSources > 1
-                ? `${distinctSelectedSources} sources · max ${BULK_DISPATCH_MAX_ITEMS} per source`
-                : `Max ${BULK_DISPATCH_MAX_ITEMS} per source`
-            }
-            actions={
-              <>
-                <Button tone="ghost" onClick={clearSelection}>
-                  Clear
-                </Button>
-                <Button tone="primary" onClick={() => { setBulkOpen(true); }}>
-                  Dispatch {selectedOrders.length}
-                </Button>
-              </>
-            }
-          />
         </>
       )}
 

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -1055,6 +1055,33 @@ export function ProductsListPage(): ReactElement {
             columns={columns}
             rows={items}
             rowKey={(product) => product.id}
+            stickyLeftColumns={2}
+            footer={
+              <BulkActionBar
+                count={selectedIds.size}
+                itemNoun="product"
+                hint={
+                  atCap
+                    ? `Max ${BULK_SELECTION_CAP} per batch`
+                    : `Max ${BULK_SELECTION_CAP} per batch · ${BULK_SELECTION_CAP - selectedIds.size} more available`
+                }
+                actions={
+                  <>
+                    <Button tone="ghost" className="button--sm" onClick={clearSelection}>
+                      Clear
+                    </Button>
+                    {/* Capability-gated (#1096): hidden with 0 OfferManager connections. */}
+                    {offerManagerConnections.length > 0 && write.visible ? (
+                      <Button tone="primary" onClick={handleCreateOffers}>
+                        {soleConnectionName
+                          ? `Create ${soleConnectionName} offers (${selectedIds.size.toLocaleString()})`
+                          : `Create offers (${selectedIds.size.toLocaleString()})`}
+                      </Button>
+                    ) : null}
+                  </>
+                }
+              />
+            }
             manualSorting
             sort={sortingState}
             onSortChange={(updater) => {
@@ -1169,31 +1196,6 @@ export function ProductsListPage(): ReactElement {
               </Button>
             </div>
           </div>
-
-          <BulkActionBar
-            count={selectedIds.size}
-            itemNoun="product"
-            hint={
-              atCap
-                ? `Max ${BULK_SELECTION_CAP} per batch`
-                : `Max ${BULK_SELECTION_CAP} per batch · ${BULK_SELECTION_CAP - selectedIds.size} more available`
-            }
-            actions={
-              <>
-                <Button tone="ghost" className="button--sm" onClick={clearSelection}>
-                  Clear
-                </Button>
-                {/* Capability-gated (#1096): hidden with 0 OfferManager connections. */}
-                {offerManagerConnections.length > 0 && write.visible ? (
-                  <Button tone="primary" onClick={handleCreateOffers}>
-                    {soleConnectionName
-                      ? `Create ${soleConnectionName} offers (${selectedIds.size.toLocaleString()})`
-                      : `Create offers (${selectedIds.size.toLocaleString()})`}
-                  </Button>
-                ) : null}
-              </>
-            }
-          />
 
           <MarketplacePickerModal
             open={pickerOpen}

--- a/apps/web/src/shared/ui/data-table.test.tsx
+++ b/apps/web/src/shared/ui/data-table.test.tsx
@@ -582,4 +582,120 @@ describe('DataTable', () => {
       restore();
     }
   });
+
+  // ── Frozen leading columns (#1755) ──────────────────────────────────────
+  const FREEZE_COLUMNS = [
+    { id: 'name', header: 'Name', cell: (row: TestRow): string => row.name },
+    { id: 'created', header: 'Created', cell: (row: TestRow): string => row.createdAt },
+    { id: 'id', header: 'Ident', cell: (row: TestRow): string => row.id },
+  ];
+
+  it('applies the sticky-col class to the first N columns and marks the last frozen one (#1755)', () => {
+    const { container } = renderWithRouter(
+      <DataTable<TestRow>
+        columns={FREEZE_COLUMNS}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        stickyLeftColumns={2}
+      />,
+    );
+
+    const headerCells = Array.from(container.querySelectorAll('thead th'));
+    // First two columns are frozen; the third is not.
+    expect(headerCells[0]).toHaveClass('data-table__sticky-col');
+    expect(headerCells[1]).toHaveClass('data-table__sticky-col', 'data-table__sticky-col--last');
+    expect(headerCells[2]).not.toHaveClass('data-table__sticky-col');
+
+    // Same freeze pattern on the body cells of the first row.
+    const firstBodyRow = container.querySelector('tbody tr');
+    const bodyCells = Array.from(firstBodyRow?.querySelectorAll('td') ?? []);
+    expect(bodyCells[0]).toHaveClass('data-table__sticky-col');
+    expect(bodyCells[1]).toHaveClass('data-table__sticky-col', 'data-table__sticky-col--last');
+    expect(bodyCells[2]).not.toHaveClass('data-table__sticky-col');
+  });
+
+  it('freezes the expander cell alongside the data columns when expandable (#1755)', () => {
+    const { container } = renderWithRouter(
+      <DataTable<TestRow>
+        columns={FREEZE_COLUMNS}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        stickyLeftColumns={1}
+        expandable={{ renderDetail: (row): string => `detail ${row.id}` }}
+      />,
+    );
+
+    const headerCells = Array.from(container.querySelectorAll('thead th'));
+    // The leading expander cell freezes as part of the identity cluster, and the
+    // single frozen data column after it is the boundary.
+    expect(headerCells[0]).toHaveClass('data-table__expand-cell', 'data-table__sticky-col');
+    expect(headerCells[1]).toHaveClass('data-table__sticky-col', 'data-table__sticky-col--last');
+    expect(headerCells[2]).not.toHaveClass('data-table__sticky-col');
+  });
+
+  it('does not apply any sticky-col class when stickyLeftColumns is 0 (default) (#1755)', () => {
+    const { container } = renderWithRouter(
+      <DataTable<TestRow>
+        columns={FREEZE_COLUMNS}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+      />,
+    );
+
+    expect(container.querySelector('.data-table__sticky-col')).toBeNull();
+  });
+
+  it('marks the table as sticky-scrolled once the container is scrolled horizontally (#1755)', () => {
+    const { container } = renderWithRouter(
+      <DataTable<TestRow>
+        columns={FREEZE_COLUMNS}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        stickyLeftColumns={2}
+      />,
+    );
+
+    const scrollContainer = container.querySelector('.data-table__container') as HTMLElement;
+    const table = container.querySelector('.data-table') as HTMLElement;
+    expect(table).not.toHaveClass('data-table--sticky-scrolled');
+
+    Object.defineProperty(scrollContainer, 'scrollLeft', { configurable: true, value: 120 });
+    fireEvent.scroll(scrollContainer);
+    expect(table).toHaveClass('data-table--sticky-scrolled');
+  });
+
+  // ── Pinned footer rail (#1755) ──────────────────────────────────────────
+  it('wraps the table and renders the footer rail when a footer is provided (#1755)', () => {
+    const { container } = renderWithRouter(
+      <DataTable<TestRow>
+        columns={FREEZE_COLUMNS}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        footer={<div data-testid="bulk-bar">Bulk actions</div>}
+      />,
+    );
+
+    const wrap = container.querySelector('.data-table__wrap');
+    expect(wrap).not.toBeNull();
+    const rail = wrap?.querySelector('.data-table__footer-rail');
+    expect(rail).not.toBeNull();
+    // The footer content renders inside the rail, and the scroll region is a
+    // sibling of the rail inside the wrap (so page content after DataTable is
+    // never covered).
+    expect(within(rail as HTMLElement).getByTestId('bulk-bar')).toBeInTheDocument();
+    expect(wrap?.querySelector('.data-table__container')).not.toBeNull();
+  });
+
+  it('does not wrap the table when no footer is provided (#1755)', () => {
+    const { container } = renderWithRouter(
+      <DataTable<TestRow>
+        columns={FREEZE_COLUMNS}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+      />,
+    );
+
+    expect(container.querySelector('.data-table__wrap')).toBeNull();
+    expect(container.querySelector('.data-table__footer-rail')).toBeNull();
+  });
 });

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -111,12 +111,14 @@ interface DataTableProps<Row> {
   expandable?: DataTableExpandable<Row>;
   /**
    * Slot rendered as a bottom rail on the table — a bulk action bar is the
-   * canonical use. The rail is `position: sticky`, clamped to the table's box:
-   * it pins to the bottom of the viewport whenever any part of the table is on
-   * screen, and rests at the table's end (above whatever follows, e.g.
-   * pagination) once you scroll there — never below the table, never above its
-   * top. Typically a self-hiding bar (e.g. `BulkActionBar`, which goes
-   * `aria-hidden` + fades out at count 0) so the rail is inert when idle.
+   * canonical use. The rail is `position: fixed`, positioned imperatively and
+   * clamped to the table's box: it pins to the bottom of the viewport whenever
+   * any part of the table is on screen, and rests at the table's end (above
+   * whatever follows, e.g. pagination) once you scroll there — never below the
+   * table, never above its top. `fixed` (not `sticky`) because an ancestor's
+   * `overflow` would otherwise capture the sticky context. Typically a
+   * self-hiding bar (e.g. `BulkActionBar`, which goes `aria-hidden` + fades out
+   * at count 0) so the rail is inert when idle.
    */
   footer?: ReactNode;
   /** Per-row height estimate used by the virtualizer. Default 36. */
@@ -146,6 +148,12 @@ interface DataTableProps<Row> {
    * once the container is scrolled right, the last frozen column gains an
    * accent hairline + a shadow cast rightward, so the affordance appears
    * exactly when it carries meaning.
+   *
+   * **Works with `virtualize`.** The scroll handler that toggles the boundary
+   * is wired to the virtual scroller as well as the plain container, and the
+   * frozen cells use CSS `position: sticky` inside whichever scroll box is
+   * active — so freezing behaves identically in virtualized and non-virtualized
+   * tables. (It does not combine with the mobile card view, which ignores it.)
    */
   stickyLeftColumns?: number;
   /**
@@ -702,11 +710,13 @@ export function DataTable<Row>({
     </div>
   );
 
-  // The footer rail is wrapped together with the table so its `position: sticky`
-  // is clamped to the table's box: it pins to the viewport bottom whenever any
-  // part of the table is on screen, and rests at the table's end once scrolled
-  // there — never below the table, never above its top. Whatever the page puts
-  // after DataTable (pagination) sits outside the wrap, so it's never covered.
+  // The footer rail is wrapped together with the table so the imperatively
+  // positioned `position: fixed` bar is clamped to the table's box: it pins to
+  // the viewport bottom whenever any part of the table is on screen, and rests
+  // at the table's end once scrolled there — never below the table, never above
+  // its top. `fixed` (not `sticky`) because .shell-content's overflow would
+  // capture the sticky context. Whatever the page puts after DataTable
+  // (pagination) sits outside the wrap, so it's never covered.
   if (footer) {
     return (
       <div className="data-table__wrap" ref={wrapRef}>

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -13,6 +13,7 @@ import {
   Fragment,
   useCallback,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -21,6 +22,7 @@ import {
   type MouseEvent,
   type ReactElement,
   type ReactNode,
+  type UIEvent,
 } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useMediaQuery } from './use-media-query';
@@ -107,6 +109,16 @@ interface DataTableProps<Row> {
   emptyState?: ReactNode;
   /** Per-row expandable detail panel (desktop accordion). See {@link DataTableExpandable}. */
   expandable?: DataTableExpandable<Row>;
+  /**
+   * Slot rendered as a bottom rail on the table — a bulk action bar is the
+   * canonical use. The rail is `position: sticky`, clamped to the table's box:
+   * it pins to the bottom of the viewport whenever any part of the table is on
+   * screen, and rests at the table's end (above whatever follows, e.g.
+   * pagination) once you scroll there — never below the table, never above its
+   * top. Typically a self-hiding bar (e.g. `BulkActionBar`, which goes
+   * `aria-hidden` + fades out at count 0) so the rail is inert when idle.
+   */
+  footer?: ReactNode;
   /** Per-row height estimate used by the virtualizer. Default 36. */
   estimateRowHeight?: number;
   /**
@@ -123,6 +135,19 @@ interface DataTableProps<Row> {
   rowKey: (row: Row) => Key;
   rows: Row[];
   sort?: SortingState;
+  /**
+   * Freeze the leading N data columns to the left edge while the rest of the
+   * row scrolls horizontally underneath them (desktop table layout only — the
+   * mobile card view ignores it). Counts entries in `columns`; the auto
+   * expander column, when `expandable` is set, is frozen alongside them as part
+   * of the identity cluster. `0` (default) keeps every column scrolling.
+   *
+   * The freeze boundary is inert until content is actually hidden beneath it:
+   * once the container is scrolled right, the last frozen column gains an
+   * accent hairline + a shadow cast rightward, so the affordance appears
+   * exactly when it carries meaning.
+   */
+  stickyLeftColumns?: number;
   /**
    * When true, the table body renders only rows visible inside a fixed-height
    * scroll container. Use for lists that commonly exceed ~200 rows.
@@ -152,6 +177,7 @@ export function DataTable<Row>({
   containerHeight = 560,
   emptyState,
   expandable,
+  footer,
   estimateRowHeight = 36,
   manualSorting = false,
   onSortChange,
@@ -159,10 +185,15 @@ export function DataTable<Row>({
   rowKey,
   rows,
   sort,
+  stickyLeftColumns = 0,
   virtualize = false,
 }: DataTableProps<Row>): ReactElement {
   const navigate = useNavigate();
   const scrollRef = useRef<HTMLDivElement>(null);
+  const tableRef = useRef<HTMLTableElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const railRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const defs = useMemo(() => buildColumnDefs(columns), [columns]);
   const columnById = useMemo(() => {
     const map = new Map<string, DataTableColumn<Row>>();
@@ -189,6 +220,71 @@ export function DataTable<Row>({
   }, []);
   // Leading toggle column widens the desktop body/header/padding colSpans.
   const columnCount = columns.length + (expandable ? 1 : 0);
+
+  // ── Horizontal sticky (frozen) leading columns ──────────────────────────
+  // The expander cell (when present) leads the identity cluster, so it freezes
+  // together with the first `stickyLeftColumns` data columns. Left offsets are
+  // measured from the header row because column widths are content-driven.
+  const leadCellCount = expandable ? 1 : 0;
+  const stickyCount = Math.min(Math.max(stickyLeftColumns, 0), columns.length);
+  const stickyActive = stickyCount > 0 && !renderCards;
+  const frozenCellCount = stickyActive ? leadCellCount + stickyCount : 0;
+  const [stickyOffsets, setStickyOffsets] = useState<number[]>([]);
+  const [stickyScrolled, setStickyScrolled] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!stickyActive) {
+      setStickyOffsets((prev) => (prev.length === 0 ? prev : []));
+      return;
+    }
+    const tableEl = tableRef.current;
+    if (!tableEl) return;
+    const measure = (): void => {
+      const headRow = tableEl.querySelector('thead tr');
+      if (!headRow) return;
+      const cells = Array.from(headRow.children) as HTMLElement[];
+      const offsets: number[] = [];
+      let acc = 0;
+      for (let i = 0; i < frozenCellCount && i < cells.length; i += 1) {
+        offsets.push(acc);
+        acc += cells[i].getBoundingClientRect().width;
+      }
+      setStickyOffsets((prev) =>
+        prev.length === offsets.length && prev.every((v, i) => v === offsets[i]) ? prev : offsets,
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(tableEl);
+    return () => {
+      observer.disconnect();
+    };
+  }, [stickyActive, frozenCellCount, columns, rows]);
+
+  const handleStickyScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>): void => {
+      if (!stickyActive) return;
+      const next = event.currentTarget.scrollLeft > 0;
+      setStickyScrolled((prev) => (prev === next ? prev : next));
+    },
+    [stickyActive],
+  );
+
+  // `cellIndex` is the cell's position in the rendered row, counting the
+  // leading expander cell (when present) as index 0.
+  const stickyCellProps = useCallback(
+    (cellIndex: number): { className: string; style?: CSSProperties } => {
+      if (!stickyActive || cellIndex >= frozenCellCount) return { className: '' };
+      const isLast = cellIndex === frozenCellCount - 1;
+      return {
+        className: isLast
+          ? 'data-table__sticky-col data-table__sticky-col--last'
+          : 'data-table__sticky-col',
+        style: { left: stickyOffsets[cellIndex] ?? 0 },
+      };
+    },
+    [stickyActive, frozenCellCount, stickyOffsets],
+  );
 
   const table = useReactTable<Row>({
     data: rows,
@@ -224,6 +320,76 @@ export function DataTable<Row>({
   ]
     .filter(Boolean)
     .join(' ');
+
+  // Footer rail = a popover-style bar fixed to the viewport, clamped to the
+  // table's box. `position: sticky` can't be used because an ancestor
+  // (.shell-content, overflow-x: hidden) captures the sticky context and never
+  // scrolls. Instead the bar is `position: fixed` and positioned imperatively:
+  // anchored to the bottom of the viewport, then clamped so it never leaves the
+  // table's top/bottom edges, and matched to the table's left/width. Updated on
+  // scroll/resize by mutating style directly (no React re-render → smooth).
+  const hasFooter = footer != null;
+  useLayoutEffect(() => {
+    if (!hasFooter) return;
+    const wrap = wrapRef.current;
+    const rail = railRef.current;
+    if (!wrap || !rail) return;
+
+    const GAP = 12; // rest distance from the viewport bottom edge
+    const update = (): void => {
+      const box = wrap.getBoundingClientRect();
+      // No layout yet (or a non-rendering environment like jsdom, where every
+      // rect is 0) — leave the rail as-is (visible, unpositioned) so it stays in
+      // the accessibility tree; don't mistake "not measured" for "off-screen".
+      if (box.width === 0 && box.height === 0) return;
+      // Hide while the table is genuinely scrolled entirely off-screen.
+      if (box.bottom <= 0 || box.top >= window.innerHeight) {
+        rail.style.visibility = 'hidden';
+        return;
+      }
+      rail.style.visibility = 'visible';
+      const barHeight = rail.offsetHeight;
+      const bottomAnchored = window.innerHeight - barHeight - GAP;
+      // Clamp between the table's top edge and bottom edge.
+      const top = Math.min(Math.max(bottomAnchored, box.top), box.bottom - barHeight);
+      rail.style.top = `${Math.round(top)}px`;
+      rail.style.left = `${Math.round(box.left)}px`;
+      rail.style.width = `${Math.round(box.width)}px`;
+    };
+
+    update();
+    // Capture phase so scrolls in any scroll container (incl. .shell-content) fire.
+    window.addEventListener('scroll', update, true);
+    window.addEventListener('resize', update);
+    const observer = new ResizeObserver(update);
+    observer.observe(wrap);
+    observer.observe(rail);
+    return () => {
+      window.removeEventListener('scroll', update, true);
+      window.removeEventListener('resize', update);
+      observer.disconnect();
+    };
+  }, [hasFooter, rows.length]);
+
+  // Publish the scroll container's visible width so an expanded accordion detail
+  // can pin itself to the viewport (sticky-left, that width) instead of stretching
+  // to the full — often horizontally-scrolled — table width. Keeps the drawer
+  // fully readable and out from under the frozen columns.
+  const hasExpandable = expandable != null;
+  useLayoutEffect(() => {
+    if (!hasExpandable || renderCards) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const publish = (): void => {
+      container.style.setProperty('--dt-visible-width', `${container.clientWidth}px`);
+    };
+    publish();
+    const observer = new ResizeObserver(publish);
+    observer.observe(container);
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasExpandable, renderCards, rows.length]);
 
   const emptyNode = emptyState ?? (
     <div className="empty-state">
@@ -285,7 +451,12 @@ export function DataTable<Row>({
     const bodyRow = (
       <tr key={key} className={rowClasses} onClick={onClick} style={style}>
         {expandable ? (
-          <td className="data-table__expand-cell">
+          <td
+            className={['data-table__expand-cell', stickyCellProps(0).className]
+              .filter(Boolean)
+              .join(' ')}
+            style={stickyCellProps(0).style}
+          >
             <button
               type="button"
               className="data-table__expand-toggle"
@@ -306,9 +477,11 @@ export function DataTable<Row>({
           </td>
         ) : null}
         {columns.map((column, index) => {
+          const sticky = stickyCellProps(leadCellCount + index);
           const cellClasses = [
             column.align ? `data-table__cell--${column.align}` : '',
             column.hideBelow ? `data-table__cell--hide-below-${column.hideBelow}` : '',
+            sticky.className,
           ]
             .filter(Boolean)
             .join(' ');
@@ -323,7 +496,7 @@ export function DataTable<Row>({
             );
 
           return (
-            <td key={column.id} className={cellClasses || undefined}>
+            <td key={column.id} className={cellClasses || undefined} style={sticky.style}>
               {content}
             </td>
           );
@@ -347,25 +520,40 @@ export function DataTable<Row>({
     );
   };
 
-  const renderTable = (): ReactElement => (
-    <table className="data-table">
+  const renderTable = (): ReactElement => {
+    const expanderSticky = stickyCellProps(0);
+    return (
+    <table
+      ref={tableRef}
+      className={['data-table', stickyScrolled ? 'data-table--sticky-scrolled' : '']
+        .filter(Boolean)
+        .join(' ')}
+    >
       {caption ? <caption className="sr-only">{caption}</caption> : null}
       <thead>
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
             {expandable ? (
-              <th scope="col" className="data-table__expand-cell">
+              <th
+                scope="col"
+                className={['data-table__expand-cell', expanderSticky.className]
+                  .filter(Boolean)
+                  .join(' ')}
+                style={expanderSticky.style}
+              >
                 <span className="sr-only">Expand row</span>
               </th>
             ) : null}
-            {headerGroup.headers.map((header) => {
+            {headerGroup.headers.map((header, headerIndex) => {
               const column = columnById.get(header.column.id);
               const canSort = column?.sortable ?? false;
               const sortDir = header.column.getIsSorted();
+              const sticky = stickyCellProps(leadCellCount + headerIndex);
               const classes = [
                 column?.align ? `data-table__cell--${column.align}` : '',
                 column?.hideBelow ? `data-table__cell--hide-below-${column.hideBelow}` : '',
                 canSort ? 'data-table__header--sortable' : '',
+                sticky.className,
               ]
                 .filter(Boolean)
                 .join(' ');
@@ -375,6 +563,7 @@ export function DataTable<Row>({
                   key={header.id}
                   scope="col"
                   className={classes || undefined}
+                  style={sticky.style}
                   aria-sort={
                     canSort
                       ? sortDir === 'asc'
@@ -419,7 +608,8 @@ export function DataTable<Row>({
         )}
       </tbody>
     </table>
-  );
+    );
+  };
 
   function renderVirtualRows(): ReactElement[] {
     const virtualItems = virtualizer.getVirtualItems();
@@ -455,9 +645,11 @@ export function DataTable<Row>({
 
   const plainScrollable = !renderCards && !virtualizeActive;
 
-  return (
+  const scrollRegion = (
     <div
+      ref={containerRef}
       className={containerClasses}
+      onScroll={stickyActive ? handleStickyScroll : undefined}
       tabIndex={plainScrollable ? 0 : undefined}
       role={plainScrollable ? 'region' : undefined}
       aria-label={
@@ -473,6 +665,7 @@ export function DataTable<Row>({
           <div
             ref={scrollRef}
             className="data-table__virtual-scroller"
+            onScroll={stickyActive ? handleStickyScroll : undefined}
             style={{ height: containerHeight }}
             tabIndex={0}
             role="region"
@@ -508,6 +701,24 @@ export function DataTable<Row>({
       ) : null}
     </div>
   );
+
+  // The footer rail is wrapped together with the table so its `position: sticky`
+  // is clamped to the table's box: it pins to the viewport bottom whenever any
+  // part of the table is on screen, and rests at the table's end once scrolled
+  // there — never below the table, never above its top. Whatever the page puts
+  // after DataTable (pagination) sits outside the wrap, so it's never covered.
+  if (footer) {
+    return (
+      <div className="data-table__wrap" ref={wrapRef}>
+        {scrollRegion}
+        <div className="data-table__footer-rail" ref={railRef}>
+          {footer}
+        </div>
+      </div>
+    );
+  }
+
+  return scrollRegion;
 }
 
 interface DataTableCardProps<Row> {


### PR DESCRIPTION
## What changed and why

Three composable cockpit capabilities on the shared `DataTable` (`apps/web/src/shared/ui/data-table.tsx`), wired into the Orders and Products list pages. Pure vanilla CSS against existing tokens; no new dependencies. Closes #1755.

1. **Frozen leading columns** (`stickyLeftColumns` prop) - pin the identity cluster (expander / checkbox / Order or Product) to the left while the row scrolls horizontally. Offsets are measured from the header row (`ResizeObserver`). The freeze boundary is inert at rest and only reveals a soft, semi-transparent signal-orange hairline + a rightward shadow once content is scrolled beneath it. Orders and Products pass `stickyLeftColumns={2}`.

2. **Pinned bulk-action bar** (`footer` slot) - the `BulkActionBar` now renders inside `DataTable`, wrapped with the table, before whatever the page renders after it, so it can never cover pagination. It's a popover-style `position: fixed` bar positioned imperatively: anchored to the viewport bottom, clamped between the table's top and bottom edges, matched to the table width. It stays on screen while any part of the table is visible and rests at the table's bottom edge (above pagination) when scrolled to the end - never below the table, never above its top, never sliding sideways with the frozen columns. `position: sticky` cannot be used because `.shell-content { overflow-x: hidden }` captures the sticky context and never scrolls. Style writes are direct (no React re-render) so scrolling stays smooth. The bar self-hides at count 0.

3. **Viewport-pinned accordion drawer** - the expanded detail (`.data-table__detail`) is `position: sticky; left: 0` sized to the container's visible width (`--dt-visible-width`, published via `ResizeObserver`), so it stays fully readable and never slides under the frozen columns during horizontal scroll. Fills 100% of the visible width.

### Known tradeoff

The column header is not vertically sticky. A vertically-sticky header needs an internal-scroll frame, which is incompatible with a screen-pinned bulk bar while horizontal scroll (frozen columns) is in play. A JS synced-header approach is deferred to a separate issue.

## How to test

1. On `/orders` and `/products`, scroll a row horizontally - the leading columns stay pinned and the freeze boundary lights up (soft orange) only while scrolled.
2. Select rows - the bulk bar pins to the bottom of the screen while the table is visible, and rests above pagination when you scroll to the end. It never covers pagination (desktop or mobile) and only shows with a selection.
3. Expand a row, then scroll the columns sideways - the detail drawer stays put, fully readable, and doesn't slide under the frozen columns.

## Quality gate

- `pnpm --filter @openlinker/web type-check` - clean
- affected tests (`data-table`, `orders-list-page`, `products-list-page`) - 91 passing
- `eslint` on changed files - 0 errors (pre-existing inline return-type warnings only)
- design-token drift check - OK

## Screenshots

_Before / after attached below._

Closes #1755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lue55oisHGW3U1gn1KYz5
