### PR TITLE
fix(erli): reconcile frozen-field protection to the verified frozen{} object shape

### DIFF
--- a/apps/api/test/integration/erli/erli-offers-vertical-slice.int-spec.ts
+++ b/apps/api/test/integration/erli/erli-offers-vertical-slice.int-spec.ts
@@ -170,7 +170,7 @@ describe('Erli Offers Vertical Slice Integration (#991)', () => {
   it('S2: updateOfferFields issues a sparse PATCH of only the changed field', async () => {
     const adapter = await getAdapter();
     // Live product with no frozen fields.
-    erli.fake.setProduct(VARIANT_A, { frozenFields: [], status: 'active' });
+    erli.fake.setProduct(VARIANT_A, { frozen: {}, status: 'active' });
 
     const cmd: UpdateOfferFieldsCommand = {
       externalOfferId: VARIANT_A,
@@ -201,7 +201,7 @@ describe('Erli Offers Vertical Slice Integration (#991)', () => {
   it('S3b: updateOfferQuantity is a no-op once a status read cached frozen stock', async () => {
     const adapter = await getAdapter();
     // A status read that sees frozen stock populates the per-offer cache flag.
-    erli.fake.setProduct(VARIANT_A, { frozenFields: ['stock'], status: 'active' });
+    erli.fake.setProduct(VARIANT_A, { frozen: { stock: true }, status: 'active' });
     await adapter.getOfferStatus(VARIANT_A);
 
     const patchesBefore = erli.fake.callsOf('PATCH').length;
@@ -250,7 +250,7 @@ describe('Erli Offers Vertical Slice Integration (#991)', () => {
   // ── S5: frozen-field suppression + 0-stock listed as 0 ─────────────────────
   it('S5a: updateOfferFields drops a frozen field but keeps a non-frozen one', async () => {
     const adapter = await getAdapter();
-    erli.fake.setProduct(VARIANT_A, { frozenFields: ['price'], status: 'active' });
+    erli.fake.setProduct(VARIANT_A, { frozen: { price: true }, status: 'active' });
 
     await adapter.updateOfferFields({
       externalOfferId: VARIANT_A,
@@ -288,8 +288,8 @@ describe('Erli Offers Vertical Slice Integration (#991)', () => {
 
     // Model Erli's async settle: accepted (→ activating) then active (→ active).
     erli.fake.enqueueGet(VARIANT_A, [
-      { status: 'accepted', frozenFields: [] },
-      { status: 'active', frozenFields: [] },
+      { status: 'accepted', frozen: {} },
+      { status: 'active', frozen: {} },
     ]);
 
     await syncService.sync(connectionId, { limit: 50, offset: 0 });

--- a/apps/api/test/integration/helpers/erli-fake-http-client.ts
+++ b/apps/api/test/integration/helpers/erli-fake-http-client.ts
@@ -27,6 +27,7 @@
  * @module apps/api/test/integration/helpers
  */
 import { ErliApiException } from '@openlinker/integrations-erli';
+import type { ErliProductResource } from '@openlinker/integrations-erli/infrastructure/adapters/erli-product.types';
 import type { IErliHttpClient } from '@openlinker/integrations-erli/infrastructure/http/erli-http-client.interface';
 import type {
   ErliHttpResponse,
@@ -64,7 +65,7 @@ export class ErliFakeHttpClient implements IErliHttpClient {
    * it (unless a sequenced response is queued, which wins). Pass `undefined` to
    * model a bodyless 2xx.
    */
-  setProduct(externalId: string, resource: unknown): void {
+  setProduct(externalId: string, resource: Partial<ErliProductResource> | undefined): void {
     this.stickyByPath.set(this.pathFor(externalId), resource);
   }
 
@@ -73,7 +74,7 @@ export class ErliFakeHttpClient implements IErliHttpClient {
    * modelling). Each `get` shifts the next entry; once drained, falls back to a
    * sticky product (if any). Replaces any previously-queued sequence for the id.
    */
-  enqueueGet(externalId: string, responses: unknown[]): void {
+  enqueueGet(externalId: string, responses: Array<Partial<ErliProductResource> | undefined>): void {
     this.queuedByPath.set(this.pathFor(externalId), [...responses]);
   }
 

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-offer-manager.adapter.spec.ts
@@ -70,7 +70,7 @@ describe('ErliOfferManagerAdapter', () => {
   beforeEach(() => {
     httpClient = {
       // Default read: no frozen fields, so field-updates PATCH everything supplied.
-      get: jest.fn().mockResolvedValue({ status: 200, data: { frozenFields: [] } }),
+      get: jest.fn().mockResolvedValue({ status: 200, data: { frozen: {} } }),
       post: jest.fn().mockResolvedValue({ status: 202, data: undefined }),
       patch: jest.fn().mockResolvedValue({ status: 202, data: undefined }),
       put: jest.fn().mockResolvedValue({ status: 202, data: undefined }),
@@ -872,7 +872,7 @@ describe('ErliOfferManagerAdapter', () => {
       });
 
       it('should drop a supplied field that is frozen and patch the rest', async () => {
-        httpClient.get.mockResolvedValue({ status: 200, data: { frozenFields: ['price'] } });
+        httpClient.get.mockResolvedValue({ status: 200, data: { frozen: { price: true } } });
 
         await adapter.updateOfferFields({
           externalOfferId: VALID_ID,
@@ -885,7 +885,7 @@ describe('ErliOfferManagerAdapter', () => {
 
       it('should patch the full body when the GET returns an empty body (no frozen info)', async () => {
         // The client yields `data: undefined` for a 204 / empty-body 2xx; the read
-        // must degrade to "nothing frozen" rather than throwing on current.frozenFields (#1061).
+        // must degrade to "nothing frozen" rather than throwing on current.frozen (#1061).
         httpClient.get.mockResolvedValue({ status: 200, data: undefined });
 
         await adapter.updateOfferFields({
@@ -900,7 +900,10 @@ describe('ErliOfferManagerAdapter', () => {
       });
 
       it('should patch every supplied field when none are frozen', async () => {
-        httpClient.get.mockResolvedValue({ status: 200, data: { frozenFields: [] } });
+        httpClient.get.mockResolvedValue({
+          status: 200,
+          data: { frozen: { name: false, price: false } },
+        });
 
         await adapter.updateOfferFields({
           externalOfferId: VALID_ID,
@@ -913,10 +916,28 @@ describe('ErliOfferManagerAdapter', () => {
         });
       });
 
+      it('should drop only the true-valued keys of a full frozen object (#1737 live shape)', async () => {
+        // The live GET returns a full object with explicit false for un-frozen
+        // fields; only `frozen[key] === true` must drop the key (#1737).
+        httpClient.get.mockResolvedValue({
+          status: 200,
+          data: {
+            frozen: { name: false, price: true, description: false, stock: false },
+          },
+        });
+
+        await adapter.updateOfferFields({
+          externalOfferId: VALID_ID,
+          fields: { title: 'Keep me', price: { amount: '79.00', currency: 'PLN' } },
+        });
+
+        expect(httpClient.patch).toHaveBeenCalledWith(`products/${VALID_ID}`, { name: 'Keep me' });
+      });
+
       it('should issue NO patch when every supplied field is frozen', async () => {
         httpClient.get.mockResolvedValue({
           status: 200,
-          data: { frozenFields: ['name', 'price'] },
+          data: { frozen: { name: true, price: true } },
         });
 
         await adapter.updateOfferFields({
@@ -1150,7 +1171,7 @@ describe('ErliOfferManagerAdapter', () => {
       cache.get.mockImplementation((key) => Promise.resolve((store.get(key) ?? null) as never));
       httpClient.get.mockResolvedValueOnce({
         status: 200,
-        data: { status: 'active', frozenFields: ['stock'] },
+        data: { status: 'active', frozen: { stock: true } },
       });
 
       await cachedAdapter.getOfferStatus(VALID_ID);
@@ -1209,7 +1230,7 @@ describe('ErliOfferManagerAdapter', () => {
     it('should set the flag with the TTL when reconciliation sees a frozen stock', async () => {
       httpClient.get.mockResolvedValueOnce({
         status: 200,
-        data: { status: 'active', frozenFields: ['stock'] },
+        data: { status: 'active', frozen: { stock: true } },
       });
 
       await cachedAdapter.getOfferStatus(VALID_ID);
@@ -1221,7 +1242,7 @@ describe('ErliOfferManagerAdapter', () => {
     it('should delete the flag (not store false) when reconciliation sees stock not frozen', async () => {
       httpClient.get.mockResolvedValueOnce({
         status: 200,
-        data: { status: 'active', frozenFields: [] },
+        data: { status: 'active', frozen: { stock: false } },
       });
 
       await cachedAdapter.getOfferStatus(VALID_ID);
@@ -1230,7 +1251,7 @@ describe('ErliOfferManagerAdapter', () => {
       expect(cache.set).not.toHaveBeenCalled();
     });
 
-    it('should leave the cache untouched on a bodyless 2xx (frozenFields undefined)', async () => {
+    it('should leave the cache untouched on a bodyless 2xx (frozen undefined)', async () => {
       httpClient.get.mockResolvedValueOnce({ status: 200, data: undefined });
 
       await cachedAdapter.getOfferStatus(VALID_ID);
@@ -1250,7 +1271,7 @@ describe('ErliOfferManagerAdapter', () => {
     });
 
     it('should opportunistically set the flag from updateOfferFields (secondary writer)', async () => {
-      httpClient.get.mockResolvedValue({ status: 200, data: { frozenFields: ['stock'] } });
+      httpClient.get.mockResolvedValue({ status: 200, data: { frozen: { stock: true } } });
 
       await cachedAdapter.updateOfferFields({ externalOfferId: VALID_ID, fields: { title: 'T' } });
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -26,15 +26,15 @@
  * Frozen-field ownership (#988, ADR-025 §4b): Erli marks seller-panel manual
  * edits `frozen`; OL must not overwrite them. `updateOfferFields` reads the
  * current product (`fetchErliProduct`) and DROPS any supplied field whose Erli
- * frozen-name is in `frozenFields` before issuing the PATCH (per-nested-field
- * granularity); an all-frozen update issues no PATCH.
+ * frozen-name reads `frozen[<erliName>] === true` before issuing the PATCH
+ * (per-nested-field granularity); an all-frozen update issues no PATCH.
  *
  * Frozen-`stock` on the hot path (#1066, ADR-025 §4b): `updateOfferQuantity`
  * runs on every inventory tick and deliberately does NOT pre-fetch — a per-tick
  * GET would double the tick's API calls. Frozen-`stock` is instead honored via a
  * per-offer cache flag populated by the steady-state `erli-offer-status-sync`
  * reconciliation (#989), which already GETs each mapped offer and sees
- * `frozenFields`. `getOfferStatus` (and opportunistically `updateOfferFields`)
+ * `frozen`. `getOfferStatus` (and opportunistically `updateOfferFields`)
  * writes that flag; `updateOfferQuantity` reads it and skips the stock PATCH when
  * set. A cache miss fails OPEN (push), preserving the pre-#1066 behaviour when the
  * flag is unknown. The honoring holds from the first reconciliation pass onward;
@@ -151,19 +151,19 @@ import type {
 const ERLI_CURRENCY = 'PLN';
 
 /**
- * Maps OL patch-body keys to the Erli field name carried in
- * {@link ErliProductResource.frozenFields} (#988, ADR-025 §4b). Only the keys a
+ * Maps OL patch-body keys to the Erli field name keyed in
+ * {@link ErliProductResource.frozen} (#988, ADR-025 §4b). Only the keys a
  * field-update can supply are listed; an unmapped key is never treated as frozen.
- * PROVISIONAL alongside the wire shape in `erli-product.types.ts` (#992): if the
- * confirmed frozen-name set differs, this is the single change point.
+ * The verified wire shape (#1737) is a `frozen` object — a field is frozen iff
+ * `frozen[<erliName>] === true`. This map is the single change point for the
+ * OL-key → Erli-name mapping.
  */
-// OL patch-key → Erli frozen-marker wire name. Provisional #992 wire vocabulary,
-// coupled to `ErliProductResource.frozenFields` (erli-product.types.ts) — reconcile
-// both against the sandbox together. `stock` is intentionally absent from THIS map:
-// it drives `dropFrozenFields` on the field-update path, which reads live
-// `frozenFields` per call — the quantity path doesn't read live frozen state. Frozen
-// `stock` IS now honored (#1066, ADR-025 §4b), but via the separate cache-flag check
-// in `updateOfferQuantity` (see {@link ERLI_FROZEN_STOCK_FIELD}), not this map.
+// OL patch-key → Erli frozen-object key name (#1737 verified shape). `stock` is
+// intentionally absent from THIS map: it drives `dropFrozenFields` on the
+// field-update path, which reads live `frozen` per call — the quantity path
+// doesn't read live frozen state. Frozen `stock` IS honored (#1066, ADR-025 §4b),
+// but via the separate cache-flag check in `updateOfferQuantity` (see
+// {@link ERLI_FROZEN_STOCK_FIELD}), not this map.
 const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, string>> = {
   price: 'price',
   name: 'name',
@@ -171,11 +171,11 @@ const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, 
 };
 
 /**
- * Erli `frozenFields` wire-name for stock (#1066, ADR-025 §4b). Looked for during
- * reconciliation to populate the per-offer frozen-stock cache flag the hot
- * `updateOfferQuantity` path reads. Colocated with {@link PATCH_KEY_TO_ERLI_FROZEN_NAME}
- * (the same provisional #992 wire vocabulary): if the sandbox spike confirms a
- * different name, this is the single change point alongside that map.
+ * Erli `frozen`-object key name for stock (#1066, ADR-025 §4b). Read during
+ * reconciliation (`frozen.stock === true`) to populate the per-offer frozen-stock
+ * cache flag the hot `updateOfferQuantity` path reads. Colocated with
+ * {@link PATCH_KEY_TO_ERLI_FROZEN_NAME} (the same #1737-verified wire vocabulary):
+ * if the wire name changes, this is the single change point alongside that map.
  */
 const ERLI_FROZEN_STOCK_FIELD = 'stock';
 
@@ -352,11 +352,11 @@ export class ErliOfferManagerAdapter
         throw error;
       }
     }
-    // #1066: opportunistically refresh the frozen-stock cache flag — `frozenFields`
+    // #1066: opportunistically refresh the frozen-stock cache flag — `frozen`
     // is already in hand from the read above. On the 404 fail-open branch `current`
-    // is `{}` so `frozenFields` is undefined and the helper no-ops.
-    await this.writeFrozenStockFlag(cmd.externalOfferId, current.frozenFields);
-    const filtered = this.dropFrozenFields(body, current.frozenFields);
+    // is `{}` so `frozen` is undefined and the helper no-ops.
+    await this.writeFrozenStockFlag(cmd.externalOfferId, current.frozen);
+    const filtered = this.dropFrozenFields(body, current.frozen);
     if (Object.keys(filtered).length === 0) {
       this.logger.debug(
         `Erli field-update is a no-op — all supplied fields are frozen [connectionId=${this.connectionId}]`,
@@ -387,7 +387,7 @@ export class ErliOfferManagerAdapter
     // reconciliation sweep GETs every mapped offer here, so the hot quantity path
     // gets the flag without its own GET. Written before mapping/returning; a 404
     // (handled above → OfferNotFoundOnMarketplaceException) never reaches here.
-    await this.writeFrozenStockFlag(externalOfferId, product.frozenFields);
+    await this.writeFrozenStockFlag(externalOfferId, product.frozen);
     return mapErliStatusToReadResult(product);
   }
 
@@ -544,7 +544,7 @@ export class ErliOfferManagerAdapter
     const res = await this.httpClient.get<ErliProductResource>(this.productPath(externalId));
     // The client returns `data: undefined` for a 204 / empty-body 2xx. Treat a
     // bodyless read as "no frozen info known" (empty resource) so the PATCH still
-    // proceeds rather than throwing on `current.frozenFields` (review #1061).
+    // proceeds rather than throwing on `current.frozen` (review #1061).
     return res.data ?? {};
   }
 
@@ -556,18 +556,17 @@ export class ErliOfferManagerAdapter
    */
   private dropFrozenFields(
     body: ErliProductPatchBody,
-    frozenFields: string[] | undefined,
+    frozen: Record<string, boolean> | undefined,
   ): ErliProductPatchBody {
-    if (!frozenFields || frozenFields.length === 0) {
+    if (!frozen) {
       return body;
     }
-    const frozen = new Set(frozenFields);
     // Shallow-copy then delete frozen keys — avoids a per-key index-write cast
     // while preserving each value's own type.
     const result: ErliProductPatchBody = { ...body };
     for (const key of Object.keys(result) as (keyof ErliProductPatchBody)[]) {
       const erliName = PATCH_KEY_TO_ERLI_FROZEN_NAME[key];
-      if (erliName !== undefined && frozen.has(erliName)) {
+      if (erliName !== undefined && frozen[erliName] === true) {
         this.logger.debug(
           `Skipping frozen Erli field "${erliName}" on field-update [connectionId=${this.connectionId}]`,
         );
@@ -655,16 +654,16 @@ export class ErliOfferManagerAdapter
    * Write-on-frozen-only: stock frozen → `set(true)`; stock NOT frozen →
    * `delete` (unfreeze transition) — "known not-frozen" and "unknown" both read
    * as fail-open, so storing `false` buys nothing but write amplification. A
-   * bodyless 2xx leaves `frozenFields` `undefined` (GET carried no frozen info):
+   * bodyless 2xx leaves `frozen` `undefined` (GET carried no frozen info):
    * leave the cache untouched so a previously-cached `true` is not clobbered.
    * Cache errors are swallowed at debug — a cache write must never break
    * reconciliation.
    */
   private async writeFrozenStockFlag(
     externalOfferId: string,
-    frozenFields: string[] | undefined,
+    frozen: Record<string, boolean> | undefined,
   ): Promise<void> {
-    if (!this.cache || frozenFields === undefined) {
+    if (!this.cache || frozen === undefined) {
       return;
     }
     const key = this.frozenStockCacheKey(externalOfferId);
@@ -672,7 +671,7 @@ export class ErliOfferManagerAdapter
       return;
     }
     try {
-      if (frozenFields.includes(ERLI_FROZEN_STOCK_FIELD)) {
+      if (frozen[ERLI_FROZEN_STOCK_FIELD] === true) {
         await this.cache.set(key, true, ERLI_FROZEN_STOCK_CACHE_TTL_SEC);
       } else {
         await this.cache.delete(key);

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -168,18 +168,19 @@ export type ErliProductPatchBody = Pick<
 >;
 
 /**
- * Provisional read-side product resource — `GET /products/{externalId}` (#988 /
- * #992). The single field #988 needs is {@link ErliProductResource.frozenFields}:
- * Erli marks seller-panel manual edits `frozen` (ADR-025 §4b, per-nested-field
- * granularity), and OL must NOT overwrite a frozen field on a subsequent PATCH.
+ * Read-side product resource — `GET /products/{externalId}` (#988 / #992). The
+ * field #988 needs is {@link ErliProductResource.frozen}: Erli marks seller-panel
+ * manual edits `frozen` (ADR-025 §4b, per-nested-field granularity), and OL must
+ * NOT overwrite a frozen field on a subsequent PATCH.
  *
- * PROVISIONAL: the exact wire shape of the frozen marker is unconfirmed until
- * the #992 sandbox spike. Modelled here as a flat list of frozen Erli field
- * names (e.g. `["price","name","description","stock"]`) — the most plausible
- * shape and the simplest to evaluate per-field. If #992 reveals a different
- * shape (e.g. a per-field `{ value, frozen }` object), this type and
- * {@link ErliOfferManagerAdapter.fetchErliProduct}'s consumers are the single
- * change point. #989 reuses this same read path for offer-status reconciliation.
+ * The live shape (verified against the sandbox and
+ * `docs/architecture/adrs/erli-sandbox-swagger.json`, #1737) is a `frozen` OBJECT
+ * keyed by Erli field name with boolean values, e.g.
+ * `{ "name": false, "price": true, "stock": false, ... }`. A field is frozen iff
+ * `frozen[<erliName>] === true`. {@link ErliOfferManagerAdapter.fetchErliProduct}'s
+ * consumers ({@link PATCH_KEY_TO_ERLI_FROZEN_NAME}, `ERLI_FROZEN_STOCK_FIELD`)
+ * are the single change point for the OL-key → Erli-name mapping. #989 reuses this
+ * same read path for offer-status reconciliation.
  */
 /**
  * Erli-side publication status of a product/offer (read side, #989).
@@ -225,12 +226,16 @@ export interface ErliProductCategoryNode {
 
 export interface ErliProductResource {
   /**
-   * Erli field names the seller has frozen via manual panel edits (#988). May
-   * include `"stock"` (#1066): reconciliation reads it to populate the per-offer
-   * frozen-stock cache flag the hot quantity path honors. No shape change — the
-   * flat `string[]` already covers it (#992-provisional, same as the other names).
+   * Per-field frozen markers the seller has set via manual panel edits (#988):
+   * a `Record<erliFieldName, boolean>` where `true` means frozen. Verified live
+   * shape (#1737) — the API returns an object, e.g.
+   * `{ name: false, price: true, stock: false, ... }`, not a flat name list.
+   * Includes `stock` (#1066): reconciliation reads `frozen.stock === true` to
+   * populate the per-offer frozen-stock cache flag the hot quantity path honors.
+   * Absent (`undefined`) means the read carried no frozen info (bodyless 2xx or
+   * the 404 fail-open branch) — treated as "unknown", never "nothing frozen".
    */
-  frozenFields?: string[];
+  frozen?: Record<string, boolean>;
   /** Current Erli-side publication status (#989). */
   status?: ErliProductStatus;
   /** Rejection / inactivation detail Erli supplies, when present (#989). */


### PR DESCRIPTION
## Problem

`ErliOfferManagerAdapter`'s frozen-field protection (#988) and frozen-stock cache flag (#1066) read `product.frozenFields` typed as `string[]`, but the live Erli Shop API `GET /products/{externalId}` returns a `frozen` **object** keyed by field name with boolean values:

```json
"frozen": { "name": false, "price": false, "stock": false, "externalAttributes": true }
```

Verified against the sandbox and `docs/architecture/adrs/erli-sandbox-swagger.json` (`ProductResponse.frozen` is an object; `stock` is one of its keys). The `frozenFields` key the adapter read was therefore always `undefined`, so the protection was **inert**:

- `updateOfferFields` never dropped a frozen field - a seller's manual panel edit to name/price/description could be silently overwritten (the regression #988 was meant to prevent).
- `writeFrozenStockFlag` never saw a frozen `stock`, so `updateOfferQuantity` always pushed stock even when the seller froze it (#1066).

## Change

- `ErliProductResource.frozen` modelled as `Record<string, boolean>` (replaces `frozenFields: string[]`).
- `dropFrozenFields` and `writeFrozenStockFlag` derive "is field X frozen" from `frozen[<erliName>] === true`.
- The `undefined` (bodyless 2xx / 404 fail-open) case is preserved as "unknown" - fail open, never clobber a cached `true`.
- OL-key -> Erli-name mapping (`PATCH_KEY_TO_ERLI_FROZEN_NAME` + `ERLI_FROZEN_STOCK_FIELD`) stays the single change point.
- Tests migrated from the array shape to the object shape; added an AC test that a full panel `frozen` object with explicit `false` values drops only the `true`-valued key.

## Verification

- `pnpm --filter @openlinker/integrations-erli test` - 410 passed
- `type-check` clean, `lint` clean

## Acceptance Criteria

- [x] `ErliProductResource` models `frozen` as the verified object shape (no `frozenFields: string[]`).
- [x] `updateOfferFields` drops a supplied field when `frozen[<erliName>] === true`, verified by a test where `frozen.price === true` keeps the PATCH from touching price.
- [x] `updateOfferQuantity` skips the stock push when `frozen.stock === true` (#1066), verified by a test.
- [x] Existing frozen-field / frozen-stock unit tests updated to the object shape.
- [x] No architecture boundary violations.

Closes #1737

🤖 Generated with [Claude Code](https://claude.com/claude-code)