### PR TITLE
feat(listings): redesign the Create-offers product picker (two-region modal + two-step wizard + discard guard) (#1779)

### DIFF
--- a/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
@@ -151,7 +151,7 @@ describe('OfferProductPickerModal', () => {
     const cb = await screen.findByLabelText<HTMLInputElement>('Select Product p1');
     fireEvent.click(cb);
     expect(cb.checked).toBe(true);
-    expect(screen.getByText(/1 item selected across/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 offer selected across/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /continue/i }));
     const qs = continueUrlParams();
@@ -203,12 +203,12 @@ describe('OfferProductPickerModal', () => {
       apiClient: mocks([conn('conn_a', 'Allegro', 'allegro')]),
     });
     fireEvent.click(await screen.findByLabelText('Select Product p1'));
-    expect(screen.getByText(/1 item selected across.*1 product/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 offer selected across.*1 product/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /next page of products/i }));
     // p1 is no longer rendered, but the selection total persists.
     expect(await screen.findByText('Product p21')).toBeInTheDocument();
-    expect(screen.getByText(/1 item selected across.*1 product/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 offer selected across.*1 product/i)).toBeInTheDocument();
   });
 
   it('auto-resolves the sole eligible connection (no picker shown)', async () => {
@@ -296,13 +296,13 @@ describe('OfferProductPickerModal', () => {
       { apiClient: mocks([conn('conn_a', 'Allegro', 'allegro')]) },
     );
     fireEvent.click(await screen.findByLabelText('Select Product p1'));
-    expect(screen.getByText(/1 item selected across.*1 product/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 offer selected across.*1 product/i)).toBeInTheDocument();
 
     rerender(<OfferProductPickerModal isOpen={false} onClose={vi.fn()} />);
     rerender(<OfferProductPickerModal isOpen onClose={vi.fn()} />);
 
     expect(await screen.findByText('Product p1')).toBeInTheDocument();
-    expect(screen.getByText(/0 items selected across 0 products/i)).toBeInTheDocument();
+    expect(screen.getByText(/0 offers selected across 0 products/i)).toBeInTheDocument();
   });
 
   it('materializes an ALL product into an explicit subset when a variant is unchecked', async () => {
@@ -337,6 +337,35 @@ describe('OfferProductPickerModal', () => {
     // Confirming discards and closes.
     fireEvent.click(screen.getByRole('button', { name: /discard changes/i }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the discard confirm on Escape and keeps the modal open on "Keep editing"', async () => {
+    const onClose = vi.fn();
+    renderWithProviders(<OfferProductPickerModal isOpen onClose={onClose} />, {
+      apiClient: mocks([conn('conn_a', 'Allegro', 'allegro')]),
+    });
+    fireEvent.click(await screen.findByLabelText('Select Product p1'));
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(await screen.findByText('Discard changes?')).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    // "Keep editing" dismisses the confirm without closing the modal.
+    fireEvent.click(screen.getByRole('button', { name: /keep editing/i }));
+    expect(screen.queryByText('Discard changes?')).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('shows a non-success EAN chip for a whole product whose loaded variants lack a barcode', async () => {
+    renderWithProviders(<OfferProductPickerModal isOpen onClose={vi.fn()} />, {
+      apiClient: mocks([conn('conn_a', 'Allegro', 'allegro')]),
+    });
+    // Whole product picked but not yet expanded -> barcode state unknown.
+    fireEvent.click(await screen.findByLabelText('Select Product p1'));
+    expect(screen.getByText('not checked')).toBeInTheDocument();
+
+    // Expanding loads the variants (P1's variants carry no EAN/GTIN), so the
+    // whole-product chip and the need-EAN tile agree on the missing count.
+    fireEvent.click(screen.getByRole('button', { name: /expand product p1/i }));
+    expect(await screen.findByText('2 need EAN')).toBeInTheDocument();
   });
 
   it('closes directly on Cancel when nothing is selected', async () => {

--- a/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
@@ -94,13 +94,13 @@ function makeProduct(id: string, variantIds: string[]): Product {
 
 const P1 = makeProduct('p1', ['v1a', 'v1b']);
 const P2 = makeProduct('p2', ['v2a']);
-// A full first page (10) plus 2 on page 2 so the pager shows.
+// A full first page (20) plus 2 on page 2 so the pager shows.
 const FIRST_PAGE: Product[] = [
   P1,
   P2,
-  ...Array.from({ length: 8 }, (_, i) => makeProduct(`f${i.toString()}`, [`fv${i.toString()}`])),
+  ...Array.from({ length: 18 }, (_, i) => makeProduct(`f${i.toString()}`, [`fv${i.toString()}`])),
 ];
-const SECOND_PAGE: Product[] = [makeProduct('p11', ['v11a']), makeProduct('p12', ['v12a'])];
+const SECOND_PAGE: Product[] = [makeProduct('p21', ['v21a']), makeProduct('p22', ['v22a'])];
 
 function mocks(connections: Connection[]): ApiClient {
   const byId = new Map<string, Product>();
@@ -113,7 +113,7 @@ function mocks(connections: Connection[]): ApiClient {
         .mockImplementation((_f, pagination): Promise<PaginatedProductsShape> => {
           const offset = (pagination?.offset as number | undefined) ?? 0;
           const items = offset === 0 ? FIRST_PAGE : SECOND_PAGE;
-          return Promise.resolve({ items, total: 12, limit: 10, offset });
+          return Promise.resolve({ items, total: 22, limit: 20, offset });
         }),
       getById: vi.fn().mockImplementation((id: string) => Promise.resolve(byId.get(id) ?? null)),
     },
@@ -141,7 +141,7 @@ describe('OfferProductPickerModal', () => {
       apiClient: mocks([conn('conn_a', 'Allegro', 'allegro')]),
     });
     expect(await screen.findByText('Product p1')).toBeInTheDocument();
-    expect(screen.getByText('1–10 of 12')).toBeInTheDocument();
+    expect(screen.getByText('1–20 of 22')).toBeInTheDocument();
   });
 
   it('selects a whole product (tri-state all) and Continue omits variantIds', async () => {
@@ -207,7 +207,7 @@ describe('OfferProductPickerModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /next page of products/i }));
     // p1 is no longer rendered, but the selection total persists.
-    expect(await screen.findByText('Product p11')).toBeInTheDocument();
+    expect(await screen.findByText('Product p21')).toBeInTheDocument();
     expect(screen.getByText(/1 item selected across.*1 product/i)).toBeInTheDocument();
   });
 
@@ -227,11 +227,13 @@ describe('OfferProductPickerModal', () => {
       apiClient: mocks([conn('conn_a', 'Allegro', 'allegro'), conn('conn_e', 'Erli', 'erli')]),
     });
     fireEvent.click(await screen.findByLabelText('Select Product p1'));
-    const continueBtn = screen.getByRole('button', { name: /continue/i });
-    expect(continueBtn).toBeDisabled();
+    // Disabled Continue is wrapped in a tooltip trigger; re-query after the
+    // connection pick since the enabled button is a fresh DOM node.
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
 
     const select = screen.getByLabelText<HTMLSelectElement>(/marketplace connection/i);
     fireEvent.change(select, { target: { value: 'conn_e' } });
+    const continueBtn = screen.getByRole('button', { name: /continue/i });
     expect(continueBtn).toBeEnabled();
 
     fireEvent.click(continueBtn);
@@ -320,5 +322,46 @@ describe('OfferProductPickerModal', () => {
     const qs = continueUrlParams();
     expect(qs.get('productIds')).toBe('p1');
     expect(qs.get('variantIds')).toBe('v1b');
+  });
+
+  it('guards close with a discard confirm when a selection exists', async () => {
+    const onClose = vi.fn();
+    renderWithProviders(<OfferProductPickerModal isOpen onClose={onClose} />, {
+      apiClient: mocks([conn('conn_a', 'Allegro', 'allegro')]),
+    });
+    fireEvent.click(await screen.findByLabelText('Select Product p1'));
+    // Cancel routes through the discard guard - the confirm appears, nothing closes.
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(await screen.findByText('Discard changes?')).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    // Confirming discards and closes.
+    fireEvent.click(screen.getByRole('button', { name: /discard changes/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes directly on Cancel when nothing is selected', async () => {
+    const onClose = vi.fn();
+    renderWithProviders(<OfferProductPickerModal isOpen onClose={onClose} />, {
+      apiClient: mocks([conn('conn_a', 'Allegro', 'allegro')]),
+    });
+    await screen.findByText('Product p1');
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(screen.queryByText('Discard changes?')).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates between the product list and review steps (two-step wizard)', async () => {
+    renderWithProviders(<OfferProductPickerModal isOpen onClose={vi.fn()} />, {
+      apiClient: mocks([conn('conn_a', 'Allegro', 'allegro')]),
+    });
+    await screen.findByText('Product p1');
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-mstep', '1');
+    // Review → advances to the rail (connection + Continue live here).
+    fireEvent.click(screen.getByRole('button', { name: /review/i }));
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-mstep', '2');
+    expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
+    // Back returns to the product list.
+    fireEvent.click(screen.getByRole('button', { name: /back to products/i }));
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-mstep', '1');
   });
 });

--- a/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
@@ -1,12 +1,21 @@
 /**
  * OfferProductPickerModal
  *
- * Single entry point for offer creation on `/listings` (#1754). A modal that
- * lets the operator multi-select across products at two granularities:
+ * Single entry point for offer creation on `/listings` (#1754). A wide,
+ * two-region modal that lets the operator multi-select across products at two
+ * granularities:
  *   - whole product (all variants), via a tri-state product checkbox, or
  *   - individual variants, via per-variant checkboxes revealed by expanding
  *     a product row (variants lazy-load on expand),
  * or any mix across many products - all resolved into one bulk batch.
+ *
+ * Layout (#1779 redesign): on desktop (>=1024px) a left list region (search +
+ * product list + sticky pager) sits beside a right rail (~340px) that reviews
+ * the running selection ("In this batch" counts + per-product groups with
+ * status chips + per-item / per-product remove + "Clear all") and pins the
+ * connection picker above Cancel / Continue. Below 1024px the same regions
+ * become a two-step wizard (step 1 = list, step 2 = review) driven by a
+ * `data-mstep` attribute; below 600px the modal is a full-screen sheet.
  *
  * Selection persists across pagination and search changes, keyed by product
  * id to `'ALL'` (whole product) or a `Set<variantId>` (explicit subset).
@@ -15,6 +24,9 @@
  * imports from `pages/`): active connections advertising the `OfferCreator`
  * sub-capability are eligible; exactly one auto-resolves, several render a
  * `<Select>`, none renders a warning.
+ *
+ * Closing via X / Cancel / esc / outside-click is routed through a discard
+ * guard: a pending selection opens a `ConfirmDialog` before the modal closes.
  *
  * Continue navigates into the bulk wizard route
  * (`/listings/bulk-create/wizard?productIds=...&variantIds=...&connectionId=...`).
@@ -31,15 +43,17 @@ import { useNavigate } from 'react-router-dom';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { CheckboxCell } from '../../../shared/ui/checkbox-cell';
+import { ConfirmDialog } from '../../../shared/ui/confirm-dialog';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '../../../shared/ui/dialog';
-import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
+import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
 import { Select } from '../../../shared/ui/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../../shared/ui/tooltip';
 import { useDebouncedValue } from '../../../shared/hooks/use-debounced-value';
 import { useConnectionsQuery } from '../../connections';
 import type { Connection } from '../../connections';
@@ -49,11 +63,14 @@ import type { Product, ProductVariant } from '../../products';
 /** Max distinct products per batch (mirrors the `/products` BULK_SELECTION_CAP,
  *  kept local per R1 to avoid a `features -> pages` import). */
 const OFFER_PICKER_PRODUCT_CAP = 100;
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 20;
 const SEARCH_DEBOUNCE_MS = 300;
 
 /** Per-product selection: whole product, or an explicit variant subset. */
 type SelectionEntry = 'ALL' | Set<string>;
+
+/** Two-step wizard step (meaningful only <=1023px; desktop shows both regions). */
+type PickerStep = 'products' | 'review';
 
 interface OfferProductPickerModalProps {
   isOpen: boolean;
@@ -79,11 +96,26 @@ function variantLabel(product: Product, variant: ProductVariant): string {
   return product.name;
 }
 
+/** Short, product-name-free label for the rail review (attrs, else SKU, else id). */
+function variantShortLabel(variant: ProductVariant): string {
+  const attrs = variant.attributes ? Object.values(variant.attributes).join(' · ') : '';
+  return attrs || variant.sku || variant.id;
+}
+
+/** Whether a variant carries a barcode (EAN or GTIN). */
+function variantHasBarcode(variant: ProductVariant): boolean {
+  return (variant.ean ?? variant.gtin ?? '').trim() !== '';
+}
+
+function firstImage(images: string[] | null | undefined): string | null {
+  return images && images.length > 0 ? images[0] : null;
+}
+
 /**
  * One product row. Lazily loads its variants when expanded (passing an empty
  * id keeps `useProductQuery` disabled until then). Computes its own tri-state
- * and reports its loaded variant count up so the selection bar can total items
- * across products.
+ * and reports its loaded variants up so the parent can total items across
+ * products and render the selection rail even after paging away.
  */
 interface PickerProductRowProps {
   product: Product;
@@ -94,7 +126,7 @@ interface PickerProductRowProps {
   onSelectAll: () => void;
   onClear: () => void;
   onToggleVariant: (variantId: string, loadedVariantIds: string[]) => void;
-  onVariantsLoaded: (count: number) => void;
+  onVariantsLoaded: (variants: ProductVariant[]) => void;
 }
 
 function PickerProductRow({
@@ -115,12 +147,12 @@ function PickerProductRow({
   );
   const loadedVariantIds = useMemo(() => loadedVariants.map((v) => v.id), [loadedVariants]);
 
-  // Report loaded variant count up for the item-count total.
+  // Report loaded variants up for the item-count total + rail review.
   useEffect(() => {
     if (isExpanded && detailQuery.data) {
-      onVariantsLoaded(loadedVariants.length);
+      onVariantsLoaded(loadedVariants);
     }
-  }, [isExpanded, detailQuery.data, loadedVariants.length, onVariantsLoaded]);
+  }, [isExpanded, detailQuery.data, loadedVariants, onVariantsLoaded]);
 
   const selectedVariantIds = entry instanceof Set ? entry : null;
   const allLoadedSelected =
@@ -140,9 +172,19 @@ function PickerProductRow({
     else onSelectAll();
   };
 
+  const variantCount = product.variantCount;
+  const isSimple = typeof variantCount === 'number' && variantCount <= 1;
+  const rowClasses = [
+    'offer-product-picker__prow',
+    isExpanded ? 'offer-product-picker__prow--open' : '',
+    isSimple ? 'offer-product-picker__prow--simple' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <li className="create-offer-variant-picker__product">
-      <div className="offer-product-picker__product-row">
+    <li className={rowClasses}>
+      <div className="offer-product-picker__prow-main">
         <CheckboxCell
           state={checkboxState}
           onToggle={handleToggleProduct}
@@ -156,26 +198,33 @@ function PickerProductRow({
         />
         <button
           type="button"
-          className="offer-product-picker__expand"
+          className="offer-product-picker__prow-toggle"
           onClick={onToggleExpand}
           aria-expanded={isExpanded}
           aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${product.name}`}
         >
-          <span className="offer-product-picker__caret" aria-hidden="true">
-            {isExpanded ? '▾' : '▸'}
+          <ProductThumbnail name={product.name} src={firstImage(product.images)} size="md" />
+          <span className="offer-product-picker__pname">
+            <b>{product.name}</b>
+            <small className="mono-text">{product.sku ?? '—'}</small>
           </span>
-          <span className="offer-product-picker__name">{product.name}</span>
-          <span className="mono-text muted-text">{product.sku ?? '—'}</span>
-          {typeof product.variantCount === 'number' ? (
-            <span className="muted-text offer-product-picker__variant-count">
-              {product.variantCount} {product.variantCount === 1 ? 'variant' : 'variants'}
+          {typeof variantCount === 'number' ? (
+            <span
+              className={`offer-product-picker__vcount${
+                isSimple ? ' offer-product-picker__vcount--simple' : ''
+              }`}
+            >
+              {variantCount} {variantCount === 1 ? 'variant' : 'variants'}
             </span>
           ) : null}
+          <span className="offer-product-picker__chev" aria-hidden="true">
+            ▸
+          </span>
         </button>
       </div>
 
       {isExpanded ? (
-        <ul className="create-offer-variant-picker__variants">
+        <ul className="offer-product-picker__vrows">
           {detailQuery.isLoading ? (
             <li className="muted-text">Loading variants…</li>
           ) : detailQuery.error ? (
@@ -201,10 +250,11 @@ function PickerProductRow({
           ) : (
             loadedVariants.map((variant) => {
               const picked = entry === 'ALL' || (selectedVariantIds?.has(variant.id) ?? false);
+              const hasBarcode = variantHasBarcode(variant);
               return (
                 <li key={variant.id}>
                   <label
-                    className={`create-offer-variant-picker__variant${picked ? ' create-offer-variant-picker__variant--picked' : ''}`}
+                    className={`offer-product-picker__vrow${picked ? ' offer-product-picker__vrow--picked' : ''}`}
                   >
                     <input
                       type="checkbox"
@@ -212,11 +262,16 @@ function PickerProductRow({
                       disabled={capBlocked}
                       onChange={() => onToggleVariant(variant.id, loadedVariantIds)}
                     />
-                    <span className="create-offer-variant-picker__variant-name">
-                      {variantLabel(detailQuery.data ?? product, variant)}
-                    </span>
-                    <span className="mono-text muted-text">
-                      SKU {variant.sku ?? '—'} · EAN {variant.ean ?? '—'}
+                    <ProductThumbnail
+                      name={variantShortLabel(variant)}
+                      src={null}
+                      size="sm"
+                    />
+                    <span className="offer-product-picker__vname">
+                      <b>{variantLabel(detailQuery.data ?? product, variant)}</b>
+                      <small className={`mono-text${hasBarcode ? '' : ' offer-product-picker__vname-bad'}`}>
+                        SKU {variant.sku ?? '—'} · {hasBarcode ? `EAN ${variant.ean ?? variant.gtin ?? '—'}` : 'no EAN'}
+                      </small>
                     </span>
                   </label>
                 </li>
@@ -227,6 +282,17 @@ function PickerProductRow({
       ) : null}
     </li>
   );
+}
+
+/** Derived per-product row for the selection rail. */
+interface RailGroup {
+  productId: string;
+  name: string;
+  imageSrc: string | null;
+  whole: boolean;
+  totalVariants: number;
+  /** Selected variants for a subset pick; `null` for a whole-product pick. */
+  selected: { id: string; label: string; hasBarcode: boolean }[] | null;
 }
 
 export function OfferProductPickerModal({
@@ -241,6 +307,12 @@ export function OfferProductPickerModal({
   const [selection, setSelection] = useState<Map<string, SelectionEntry>>(new Map());
   const [variantCounts, setVariantCounts] = useState<Map<string, number>>(new Map());
   const [pickedConnectionId, setPickedConnectionId] = useState<string>('');
+  const [step, setStep] = useState<PickerStep>('products');
+  const [discardOpen, setDiscardOpen] = useState(false);
+  // Accumulated product / variant metadata for the rail review, so a product
+  // selected then paged away still renders its name, image, and variant labels.
+  const [productMeta, setProductMeta] = useState<Map<string, Product>>(new Map());
+  const [variantMeta, setVariantMeta] = useState<Map<string, ProductVariant[]>>(new Map());
 
   const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
 
@@ -254,6 +326,10 @@ export function OfferProductPickerModal({
       setSelection(new Map());
       setVariantCounts(new Map());
       setPickedConnectionId('');
+      setStep('products');
+      setDiscardOpen(false);
+      setProductMeta(new Map());
+      setVariantMeta(new Map());
     }
   }, [isOpen]);
 
@@ -274,8 +350,25 @@ export function OfferProductPickerModal({
     { search: debouncedSearch || undefined },
     { limit: PAGE_SIZE, offset },
   );
-  const products = productsQuery.data?.items ?? [];
+  const productItems = productsQuery.data?.items;
+  const products = useMemo(() => productItems ?? [], [productItems]);
   const total = productsQuery.data?.total ?? 0;
+
+  // Accumulate metadata for every product the operator has seen.
+  useEffect(() => {
+    if (!productItems || productItems.length === 0) return;
+    setProductMeta((prev) => {
+      let changed = false;
+      const next = new Map(prev);
+      for (const p of productItems) {
+        if (!next.has(p.id)) {
+          next.set(p.id, p);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [productItems]);
 
   const capReached = selection.size >= OFFER_PICKER_PRODUCT_CAP;
 
@@ -338,11 +431,27 @@ export function OfferProductPickerModal({
     [],
   );
 
-  const reportVariantsLoaded = useCallback((productId: string, count: number) => {
+  const reportVariantsLoaded = useCallback((productId: string, variants: ProductVariant[]) => {
     setVariantCounts((prev) => {
-      if (prev.get(productId) === count) return prev;
+      if (prev.get(productId) === variants.length) return prev;
       const next = new Map(prev);
-      next.set(productId, count);
+      next.set(productId, variants.length);
+      return next;
+    });
+    setVariantMeta((prev) => {
+      // Guard against re-storing an unchanged list: the source `variants` ref
+      // is not stable across renders (react-query), so an unconditional write
+      // would loop the reporting effect. Compare by variant ids.
+      const existing = prev.get(productId);
+      if (
+        existing &&
+        existing.length === variants.length &&
+        existing.every((v, i) => v.id === variants[i]!.id)
+      ) {
+        return prev;
+      }
+      const next = new Map(prev);
+      next.set(productId, variants);
       return next;
     });
   }, []);
@@ -362,6 +471,60 @@ export function OfferProductPickerModal({
     return sum;
   }, [selection, variantCounts]);
 
+  // Per-product rail rows, derived from the selection + accumulated metadata.
+  const railGroups = useMemo<RailGroup[]>(() => {
+    const groups: RailGroup[] = [];
+    for (const [productId, entry] of selection) {
+      const meta = productMeta.get(productId);
+      const variants = variantMeta.get(productId) ?? meta?.variants ?? [];
+      const totalVariants =
+        variantCounts.get(productId) ?? meta?.variantCount ?? (variants.length || 1);
+      if (entry === 'ALL') {
+        groups.push({
+          productId,
+          name: meta?.name ?? productId,
+          imageSrc: firstImage(meta?.images),
+          whole: true,
+          totalVariants,
+          selected: null,
+        });
+        continue;
+      }
+      const selected = [...entry].map((variantId) => {
+        const variant = variants.find((v) => v.id === variantId);
+        return {
+          id: variantId,
+          label: variant ? variantShortLabel(variant) : variantId,
+          hasBarcode: variant ? variantHasBarcode(variant) : true,
+        };
+      });
+      groups.push({
+        productId,
+        name: meta?.name ?? productId,
+        imageSrc: firstImage(meta?.images),
+        whole: false,
+        totalVariants,
+        selected,
+      });
+    }
+    return groups;
+  }, [selection, productMeta, variantMeta, variantCounts]);
+
+  // Selected variants (across groups) whose barcode is missing, best-effort
+  // from loaded metadata. Whole-product picks contribute their known variants.
+  const needEanCount = useMemo(() => {
+    let sum = 0;
+    for (const group of railGroups) {
+      if (group.selected === null) {
+        const variants = variantMeta.get(group.productId) ?? [];
+        sum += variants.filter((v) => !variantHasBarcode(v)).length;
+      } else {
+        sum += group.selected.filter((s) => !s.hasBarcode).length;
+      }
+    }
+    return sum;
+  }, [railGroups, variantMeta]);
+
   const handleContinue = useCallback(() => {
     if (selection.size === 0 || resolvedConnectionId === null) return;
     const productIds: string[] = [];
@@ -378,188 +541,403 @@ export function OfferProductPickerModal({
     void navigate(`/listings/bulk-create/wizard?${params.toString()}`);
   }, [selection, resolvedConnectionId, navigate]);
 
+  // Discard guard: a pending selection intercepts every close path (X, Cancel,
+  // esc, outside-click) with a confirm; an empty selection closes directly.
+  const requestClose = useCallback(() => {
+    if (selection.size > 0) setDiscardOpen(true);
+    else onClose();
+  }, [selection.size, onClose]);
+
   if (!isOpen) return null;
 
   const pageEnd = Math.min(offset + PAGE_SIZE, total);
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
   const canContinue = selection.size > 0 && resolvedConnectionId !== null;
+  const selectionSummary = `${itemCount} ${itemCount === 1 ? 'item' : 'items'} selected across ${
+    selection.size
+  } ${selection.size === 1 ? 'product' : 'products'}`;
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent>
-        <DialogTitle>Create offers</DialogTitle>
-        <DialogDescription>
-          Select whole products or individual variants to publish - mix across products in one
-          batch.
-        </DialogDescription>
-
-        <FormField
-          label="Search products"
-          name="offerProductSearch"
-          description="Search by product name, SKU, or EAN."
+    <>
+      <Dialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (!open) requestClose();
+        }}
+      >
+        <DialogContent
+          className="offer-product-picker"
+          data-mstep={step === 'products' ? '1' : '2'}
+          onEscapeKeyDown={(event) => {
+            if (selection.size > 0) {
+              event.preventDefault();
+              setDiscardOpen(true);
+            }
+          }}
+          onInteractOutside={(event) => {
+            if (selection.size > 0) {
+              event.preventDefault();
+              setDiscardOpen(true);
+            }
+          }}
         >
-          <Input
-            value={searchInput}
-            onChange={(e) => {
-              setSearchInput(e.target.value);
-              // Reset offset synchronously so the next debounced query lands on
-              // page 1 rather than a now-empty page.
-              setOffset(0);
-            }}
-            placeholder="e.g. T-shirt, SKU-123, 5901234567890"
-          />
-        </FormField>
+          <button
+            type="button"
+            className="offer-product-picker__x"
+            aria-label="Close"
+            onClick={requestClose}
+          >
+            ×
+          </button>
 
-        <div className="create-offer-variant-picker">
-          {productsQuery.isLoading ? (
-            <p className="muted-text">Loading products…</p>
-          ) : productsQuery.error ? (
-            <Alert
-              tone="error"
-              title="Unable to load products"
-              action={
-                <Button
-                  tone="secondary"
-                  type="button"
-                  onClick={() => void productsQuery.refetch()}
-                >
-                  Retry
-                </Button>
-              }
-            >
-              {productsQuery.error.message}
-            </Alert>
-          ) : products.length === 0 ? (
-            <p className="muted-text">No products match.</p>
-          ) : (
-            <ul className="create-offer-variant-picker__list">
-              {products.map((product) => (
-                <PickerProductRow
-                  key={product.id}
-                  product={product}
-                  isExpanded={expanded.has(product.id)}
-                  entry={selection.get(product.id)}
-                  capBlocked={capReached && !selection.has(product.id)}
-                  onToggleExpand={() => toggleExpand(product.id)}
-                  onSelectAll={() => selectAllProduct(product.id, product.variantCount)}
-                  onClear={() => clearProduct(product.id)}
-                  onToggleVariant={(variantId, loadedVariantIds) =>
-                    toggleVariant(product.id, variantId, loadedVariantIds)
-                  }
-                  onVariantsLoaded={(count) => reportVariantsLoaded(product.id, count)}
+          <header className="offer-product-picker__head">
+            <DialogTitle className="offer-product-picker__title">Create offers</DialogTitle>
+            <DialogDescription className="offer-product-picker__sub">
+              Pick whole products or individual variants, mix across products - it all becomes one
+              batch.
+            </DialogDescription>
+          </header>
+
+          <div className="offer-product-picker__body">
+            <section className="offer-product-picker__list-region" aria-label="Product picker">
+              <div className="offer-product-picker__search">
+                <Input
+                  value={searchInput}
+                  onChange={(e) => {
+                    setSearchInput(e.target.value);
+                    // Reset offset synchronously so the next debounced query
+                    // lands on page 1 rather than a now-empty page.
+                    setOffset(0);
+                  }}
+                  placeholder="Search by name, SKU or EAN"
+                  aria-label="Search products"
                 />
-              ))}
-            </ul>
-          )}
+                <p className="offer-product-picker__hint">
+                  Tick a product to add every variant, or expand it to choose specific ones.
+                </p>
+              </div>
 
-          {total > PAGE_SIZE ? (
-            <div className="create-offer-variant-picker__pagination">
-              <span className="muted-text">
-                {offset + 1}–{pageEnd} of {total}
-              </span>
-              <div className="create-offer-variant-picker__pagination-actions">
-                <Button
-                  tone="secondary"
-                  type="button"
-                  aria-label="Previous page of products"
-                  disabled={offset === 0}
-                  onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
-                >
-                  Previous
-                </Button>
-                <Button
-                  tone="secondary"
-                  type="button"
-                  aria-label="Next page of products"
-                  disabled={offset + PAGE_SIZE >= total}
-                  onClick={() => setOffset((o) => o + PAGE_SIZE)}
-                >
-                  Next
+              <div className="offer-product-picker__list">
+                {productsQuery.isLoading ? (
+                  <p className="muted-text">Loading products…</p>
+                ) : productsQuery.error ? (
+                  <Alert
+                    tone="error"
+                    title="Unable to load products"
+                    action={
+                      <Button
+                        tone="secondary"
+                        type="button"
+                        onClick={() => void productsQuery.refetch()}
+                      >
+                        Retry
+                      </Button>
+                    }
+                  >
+                    {productsQuery.error.message}
+                  </Alert>
+                ) : products.length === 0 ? (
+                  <p className="muted-text">No products match.</p>
+                ) : (
+                  <ul className="offer-product-picker__prows">
+                    {products.map((product) => (
+                      <PickerProductRow
+                        key={product.id}
+                        product={product}
+                        isExpanded={expanded.has(product.id)}
+                        entry={selection.get(product.id)}
+                        capBlocked={capReached && !selection.has(product.id)}
+                        onToggleExpand={() => toggleExpand(product.id)}
+                        onSelectAll={() => selectAllProduct(product.id, product.variantCount)}
+                        onClear={() => clearProduct(product.id)}
+                        onToggleVariant={(variantId, loadedVariantIds) =>
+                          toggleVariant(product.id, variantId, loadedVariantIds)
+                        }
+                        onVariantsLoaded={(variants) => reportVariantsLoaded(product.id, variants)}
+                      />
+                    ))}
+                  </ul>
+                )}
+
+                {capReached ? (
+                  <p className="muted-text offer-product-picker__cap-hint" aria-live="polite">
+                    Maximum {OFFER_PICKER_PRODUCT_CAP} products per batch reached - clear a product
+                    to add another.
+                  </p>
+                ) : null}
+              </div>
+
+              <div className="offer-product-picker__pager">
+                <span className="offer-product-picker__pager-count tabular">
+                  {offset + 1}–{pageEnd} of {total}
+                </span>
+                <div className="offer-product-picker__pager-nav">
+                  <Button
+                    tone="secondary"
+                    type="button"
+                    className="button--sm"
+                    aria-label="Previous page of products"
+                    disabled={offset === 0}
+                    onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
+                  >
+                    Previous
+                  </Button>
+                  <span className="offer-product-picker__pager-page tabular">
+                    {currentPage} / {pageCount}
+                  </span>
+                  <Button
+                    tone="secondary"
+                    type="button"
+                    className="button--sm"
+                    aria-label="Next page of products"
+                    disabled={offset + PAGE_SIZE >= total}
+                    onClick={() => setOffset((o) => o + PAGE_SIZE)}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+
+              {/* Step-1 action bar - visible only on the <=1023px two-step layout. */}
+              <div className="offer-product-picker__mstep-next">
+                <span className="offer-product-picker__mstep-count">
+                  <b>{itemCount}</b> {itemCount === 1 ? 'item' : 'items'} · {selection.size}{' '}
+                  {selection.size === 1 ? 'product' : 'products'}
+                </span>
+                <Button type="button" onClick={() => setStep('review')}>
+                  Review →
                 </Button>
               </div>
-            </div>
-          ) : null}
-        </div>
+            </section>
 
-        <div className="offer-product-picker__selection-bar" aria-live="polite">
-          <span className="tabular">
-            {`${itemCount} ${itemCount === 1 ? 'item' : 'items'} selected across ${selection.size} ${
-              selection.size === 1 ? 'product' : 'products'
-            }`}
-          </span>
-          <Button
-            tone="ghost"
-            type="button"
-            disabled={selection.size === 0}
-            onClick={clearSelection}
-          >
-            Clear
-          </Button>
-        </div>
+            <aside className="offer-product-picker__rail" aria-label="Selection">
+              <div className="offer-product-picker__rail-head">
+                <button
+                  type="button"
+                  className="offer-product-picker__rail-back"
+                  aria-label="Back to products"
+                  onClick={() => setStep('products')}
+                >
+                  ‹
+                </button>
+                <div className="offer-product-picker__rail-titlebar">
+                  <span className="offer-product-picker__rail-title">In this batch</span>
+                  <Button
+                    tone="ghost"
+                    type="button"
+                    className="button--sm"
+                    disabled={selection.size === 0}
+                    onClick={clearSelection}
+                  >
+                    Clear all
+                  </Button>
+                </div>
+              </div>
 
-        {capReached ? (
-          <p className="muted-text offer-product-picker__cap-hint" aria-live="polite">
-            Maximum {OFFER_PICKER_PRODUCT_CAP} products per batch reached - clear a product to add
-            another.
-          </p>
-        ) : null}
+              <div className="offer-product-picker__rail-counts">
+                <div>
+                  <span className="offer-product-picker__rail-n tabular">{itemCount}</span>
+                  <span className="offer-product-picker__rail-lbl">offers</span>
+                </div>
+                <div>
+                  <span className="offer-product-picker__rail-n tabular">{selection.size}</span>
+                  <span className="offer-product-picker__rail-lbl">products</span>
+                </div>
+                <div>
+                  <span className="offer-product-picker__rail-n offer-product-picker__rail-n--warn tabular">
+                    {needEanCount}
+                  </span>
+                  <span className="offer-product-picker__rail-lbl">need EAN</span>
+                </div>
+              </div>
 
-        {connectionsQuery.isLoading ? (
-          <p className="muted-text">Loading marketplace connections…</p>
-        ) : connectionsQuery.error ? (
-          <Alert
-            tone="error"
-            title="Unable to load connections"
-            action={
-              <Button
-                tone="secondary"
-                type="button"
-                onClick={() => void connectionsQuery.refetch()}
-              >
-                Retry
-              </Button>
-            }
-          >
-            {connectionsQuery.error.message}
-          </Alert>
-        ) : eligibleConnections.length === 0 ? (
-          <Alert tone="warning" title="No marketplace connections available">
-            Add an active connection that supports offer creation before publishing offers.
-          </Alert>
-        ) : eligibleConnections.length > 1 ? (
-          <FormField label="Connection" name="offerConnection">
-            <Select
-              value={pickedConnectionId}
-              onChange={(e) => setPickedConnectionId(e.target.value)}
-              aria-label="Marketplace connection"
-            >
-              <option value="">Choose a connection…</option>
-              {eligibleConnections.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name} ({c.platformType})
-                </option>
-              ))}
-            </Select>
-          </FormField>
-        ) : (
-          <p className="muted-text offer-product-picker__resolved-connection">
-            Publishing to: <strong>{eligibleConnections[0]!.name}</strong> (
-            {eligibleConnections[0]!.platformType})
-          </p>
-        )}
+              <div className="offer-product-picker__rail-body">
+                {railGroups.length === 0 ? (
+                  <p className="offer-product-picker__rail-empty">
+                    Nothing selected yet. Tick products or variants on the left.
+                  </p>
+                ) : (
+                  railGroups.map((group) => {
+                    const isPartial =
+                      group.selected !== null && group.selected.length < group.totalVariants;
+                    return (
+                      <div className="offer-product-picker__selgrp" key={group.productId}>
+                        <div className="offer-product-picker__selgrp-head">
+                          <ProductThumbnail
+                            name={group.name}
+                            src={group.imageSrc}
+                            size="sm"
+                          />
+                          <b>{group.name}</b>
+                          {group.whole ? (
+                            <span className="bulk-chip bulk-chip--success">
+                              <span className="bulk-chip__dot" />
+                              ready
+                            </span>
+                          ) : isPartial ? (
+                            <span className="bulk-chip bulk-chip--warning">
+                              <span className="bulk-chip__dot" />
+                              {group.selected!.length} of {group.totalVariants}
+                            </span>
+                          ) : (
+                            <span className="bulk-chip bulk-chip--success">
+                              <span className="bulk-chip__dot" />
+                              ready
+                            </span>
+                          )}
+                          <button
+                            type="button"
+                            className="offer-product-picker__rm"
+                            aria-label={`Remove ${group.name}`}
+                            onClick={() => clearProduct(group.productId)}
+                          >
+                            ×
+                          </button>
+                        </div>
+                        {group.whole ? (
+                          <div className="offer-product-picker__seltag offer-product-picker__seltag--muted">
+                            <span className="offer-product-picker__seltag-dot" />
+                            Whole product · {group.totalVariants}{' '}
+                            {group.totalVariants === 1 ? 'variant' : 'variants'}
+                          </div>
+                        ) : (
+                          group.selected!.map((variant) => (
+                            <div className="offer-product-picker__seltag" key={variant.id}>
+                              <span className="offer-product-picker__seltag-dot" />
+                              {variant.label}
+                              {variant.hasBarcode ? null : (
+                                <span className="bulk-chip bulk-chip--warning">
+                                  <span className="bulk-chip__dot" />
+                                  no EAN
+                                </span>
+                              )}
+                              <button
+                                type="button"
+                                className="offer-product-picker__rm offer-product-picker__rm--tag"
+                                aria-label={`Remove ${variant.label}`}
+                                onClick={() =>
+                                  toggleVariant(
+                                    group.productId,
+                                    variant.id,
+                                    (variantMeta.get(group.productId) ?? []).map((v) => v.id),
+                                  )
+                                }
+                              >
+                                ×
+                              </button>
+                            </div>
+                          ))
+                        )}
+                      </div>
+                    );
+                  })
+                )}
+              </div>
 
-        <div className="wizard-actions">
-          <div className="wizard-actions__group">
-            <Button tone="ghost" type="button" onClick={onClose}>
-              Cancel
-            </Button>
+              <div className="offer-product-picker__rail-foot">
+                {connectionsQuery.isLoading ? (
+                  <p className="muted-text">Loading marketplace connections…</p>
+                ) : connectionsQuery.error ? (
+                  <Alert
+                    tone="error"
+                    title="Unable to load connections"
+                    action={
+                      <Button
+                        tone="secondary"
+                        type="button"
+                        onClick={() => void connectionsQuery.refetch()}
+                      >
+                        Retry
+                      </Button>
+                    }
+                  >
+                    {connectionsQuery.error.message}
+                  </Alert>
+                ) : eligibleConnections.length === 0 ? (
+                  <Alert tone="warning" title="No marketplace connections available">
+                    Add an active connection that supports offer creation before publishing offers.
+                  </Alert>
+                ) : (
+                  <div className="offer-product-picker__rail-conn">
+                    <label className="offer-product-picker__eyebrow" htmlFor="offerConnection">
+                      Publish to <span className="offer-product-picker__req">*</span>
+                    </label>
+                    {eligibleConnections.length > 1 ? (
+                      <Select
+                        id="offerConnection"
+                        value={pickedConnectionId}
+                        onChange={(e) => setPickedConnectionId(e.target.value)}
+                        aria-label="Marketplace connection"
+                      >
+                        <option value="">Choose a connection…</option>
+                        {eligibleConnections.map((c) => (
+                          <option key={c.id} value={c.id}>
+                            {c.name} ({c.platformType})
+                          </option>
+                        ))}
+                      </Select>
+                    ) : (
+                      <p className="muted-text offer-product-picker__resolved-connection">
+                        Publishing to: <strong>{eligibleConnections[0]!.name}</strong> (
+                        {eligibleConnections[0]!.platformType})
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                <p className="offer-product-picker__rail-summary" aria-live="polite">
+                  {selectionSummary}
+                </p>
+
+                <div className="offer-product-picker__rail-actions">
+                  <Button tone="ghost" type="button" onClick={requestClose}>
+                    Cancel
+                  </Button>
+                  {canContinue ? (
+                    <Button type="button" onClick={handleContinue}>
+                      Continue →
+                    </Button>
+                  ) : (
+                    // Disabled buttons swallow hover, so the span is the tooltip
+                    // trigger and the button inside opts out of pointer events.
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="offer-product-picker__continue-wrap">
+                          <Button type="button" disabled onClick={handleContinue}>
+                            Continue →
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {selection.size === 0
+                          ? 'Select at least one product, then choose a connection.'
+                          : 'Choose a connection to publish to first.'}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+              </div>
+            </aside>
           </div>
-          <div className="wizard-actions__group">
-            <Button type="button" disabled={!canContinue} onClick={handleContinue}>
-              Continue →
-            </Button>
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={discardOpen}
+        onOpenChange={setDiscardOpen}
+        className="dialog__content--elevated"
+        overlayClassName="dialog__overlay--elevated"
+        title="Discard changes?"
+        description="You have unsaved product selections. Closing now will discard them."
+        cancelLabel="Keep editing"
+        confirmLabel="Discard changes"
+        tone="danger"
+        onConfirm={() => {
+          setDiscardOpen(false);
+          onClose();
+        }}
+      />
+    </>
   );
 }

--- a/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
@@ -37,7 +37,14 @@
  *
  * @module apps/web/src/features/listings/components
  */
-import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Alert } from '../../../shared/ui/alert';
@@ -291,6 +298,13 @@ interface RailGroup {
   imageSrc: string | null;
   whole: boolean;
   totalVariants: number;
+  /**
+   * Barcode readiness for a whole-product pick, derived from loaded variant
+   * metadata; `null` for a subset pick (which shows per-variant chips instead).
+   * `loaded: false` means the product's variants have not been fetched yet, so
+   * the chip must read "not checked" rather than a confident "ready".
+   */
+  wholeEan: { loaded: boolean; needCount: number } | null;
   /** Selected variants for a subset pick; `null` for a whole-product pick. */
   selected: { id: string; label: string; hasBarcode: boolean }[] | null;
 }
@@ -313,6 +327,11 @@ export function OfferProductPickerModal({
   // selected then paged away still renders its name, image, and variant labels.
   const [productMeta, setProductMeta] = useState<Map<string, Product>>(new Map());
   const [variantMeta, setVariantMeta] = useState<Map<string, ProductVariant[]>>(new Map());
+
+  // Focus targets for the two-step wizard (<=1023px): moving focus on step
+  // change keeps keyboard / screen-reader users oriented.
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const railBackRef = useRef<HTMLButtonElement>(null);
 
   const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
 
@@ -480,12 +499,20 @@ export function OfferProductPickerModal({
       const totalVariants =
         variantCounts.get(productId) ?? meta?.variantCount ?? (variants.length || 1);
       if (entry === 'ALL') {
+        const loadedVariants = variantMeta.get(productId);
+        const wholeEan = loadedVariants
+          ? {
+              loaded: true,
+              needCount: loadedVariants.filter((v) => !variantHasBarcode(v)).length,
+            }
+          : { loaded: false, needCount: 0 };
         groups.push({
           productId,
           name: meta?.name ?? productId,
           imageSrc: firstImage(meta?.images),
           whole: true,
           totalVariants,
+          wholeEan,
           selected: null,
         });
         continue;
@@ -504,6 +531,7 @@ export function OfferProductPickerModal({
         imageSrc: firstImage(meta?.images),
         whole: false,
         totalVariants,
+        wholeEan: null,
         selected,
       });
     }
@@ -548,13 +576,22 @@ export function OfferProductPickerModal({
     else onClose();
   }, [selection.size, onClose]);
 
+  // Move focus to the region that just became active on a wizard step change
+  // (only meaningful <=1023px; on desktop `step` stays 'products'). Runs after
+  // the DOM updates so the focus target is present.
+  useEffect(() => {
+    if (!isOpen) return;
+    if (step === 'review') railBackRef.current?.focus();
+    else searchInputRef.current?.focus();
+  }, [step, isOpen]);
+
   if (!isOpen) return null;
 
   const pageEnd = Math.min(offset + PAGE_SIZE, total);
   const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
   const canContinue = selection.size > 0 && resolvedConnectionId !== null;
-  const selectionSummary = `${itemCount} ${itemCount === 1 ? 'item' : 'items'} selected across ${
+  const selectionSummary = `${itemCount} ${itemCount === 1 ? 'offer' : 'offers'} selected across ${
     selection.size
   } ${selection.size === 1 ? 'product' : 'products'}`;
 
@@ -570,16 +607,12 @@ export function OfferProductPickerModal({
           className="offer-product-picker"
           data-mstep={step === 'products' ? '1' : '2'}
           onEscapeKeyDown={(event) => {
-            if (selection.size > 0) {
-              event.preventDefault();
-              setDiscardOpen(true);
-            }
+            event.preventDefault();
+            requestClose();
           }}
           onInteractOutside={(event) => {
-            if (selection.size > 0) {
-              event.preventDefault();
-              setDiscardOpen(true);
-            }
+            event.preventDefault();
+            requestClose();
           }}
         >
           <button
@@ -590,6 +623,12 @@ export function OfferProductPickerModal({
           >
             ×
           </button>
+
+          <span className="sr-only" aria-live="polite">
+            {step === 'review'
+              ? 'Step 2 of 2: review your selection'
+              : 'Step 1 of 2: choose products'}
+          </span>
 
           <header className="offer-product-picker__head">
             <DialogTitle className="offer-product-picker__title">Create offers</DialogTitle>
@@ -603,6 +642,7 @@ export function OfferProductPickerModal({
             <section className="offer-product-picker__list-region" aria-label="Product picker">
               <div className="offer-product-picker__search">
                 <Input
+                  ref={searchInputRef}
                   value={searchInput}
                   onChange={(e) => {
                     setSearchInput(e.target.value);
@@ -638,7 +678,11 @@ export function OfferProductPickerModal({
                     {productsQuery.error.message}
                   </Alert>
                 ) : products.length === 0 ? (
-                  <p className="muted-text">No products match.</p>
+                  <p className="muted-text">
+                    {debouncedSearch.trim()
+                      ? `No products match "${debouncedSearch.trim()}".`
+                      : 'No products yet.'}
+                  </p>
                 ) : (
                   <ul className="offer-product-picker__prows">
                     {products.map((product) => (
@@ -668,41 +712,43 @@ export function OfferProductPickerModal({
                 ) : null}
               </div>
 
-              <div className="offer-product-picker__pager">
-                <span className="offer-product-picker__pager-count tabular">
-                  {offset + 1}–{pageEnd} of {total}
-                </span>
-                <div className="offer-product-picker__pager-nav">
-                  <Button
-                    tone="secondary"
-                    type="button"
-                    className="button--sm"
-                    aria-label="Previous page of products"
-                    disabled={offset === 0}
-                    onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
-                  >
-                    Previous
-                  </Button>
-                  <span className="offer-product-picker__pager-page tabular">
-                    {currentPage} / {pageCount}
+              {total > 0 ? (
+                <div className="offer-product-picker__pager">
+                  <span className="offer-product-picker__pager-count tabular">
+                    {offset + 1}–{pageEnd} of {total}
                   </span>
-                  <Button
-                    tone="secondary"
-                    type="button"
-                    className="button--sm"
-                    aria-label="Next page of products"
-                    disabled={offset + PAGE_SIZE >= total}
-                    onClick={() => setOffset((o) => o + PAGE_SIZE)}
-                  >
-                    Next
-                  </Button>
+                  <div className="offer-product-picker__pager-nav">
+                    <Button
+                      tone="secondary"
+                      type="button"
+                      className="button--sm"
+                      aria-label="Previous page of products"
+                      disabled={offset === 0}
+                      onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
+                    >
+                      Previous
+                    </Button>
+                    <span className="offer-product-picker__pager-page tabular">
+                      {currentPage} / {pageCount}
+                    </span>
+                    <Button
+                      tone="secondary"
+                      type="button"
+                      className="button--sm"
+                      aria-label="Next page of products"
+                      disabled={offset + PAGE_SIZE >= total}
+                      onClick={() => setOffset((o) => o + PAGE_SIZE)}
+                    >
+                      Next
+                    </Button>
+                  </div>
                 </div>
-              </div>
+              ) : null}
 
               {/* Step-1 action bar - visible only on the <=1023px two-step layout. */}
               <div className="offer-product-picker__mstep-next">
                 <span className="offer-product-picker__mstep-count">
-                  <b>{itemCount}</b> {itemCount === 1 ? 'item' : 'items'} · {selection.size}{' '}
+                  <b>{itemCount}</b> {itemCount === 1 ? 'offer' : 'offers'} · {selection.size}{' '}
                   {selection.size === 1 ? 'product' : 'products'}
                 </span>
                 <Button type="button" onClick={() => setStep('review')}>
@@ -714,6 +760,7 @@ export function OfferProductPickerModal({
             <aside className="offer-product-picker__rail" aria-label="Selection">
               <div className="offer-product-picker__rail-head">
                 <button
+                  ref={railBackRef}
                   type="button"
                   className="offer-product-picker__rail-back"
                   aria-label="Back to products"
@@ -771,10 +818,22 @@ export function OfferProductPickerModal({
                           />
                           <b>{group.name}</b>
                           {group.whole ? (
-                            <span className="bulk-chip bulk-chip--success">
-                              <span className="bulk-chip__dot" />
-                              ready
-                            </span>
+                            group.wholeEan && !group.wholeEan.loaded ? (
+                              <span className="bulk-chip bulk-chip--neutral">
+                                <span className="bulk-chip__dot" />
+                                not checked
+                              </span>
+                            ) : group.wholeEan && group.wholeEan.needCount > 0 ? (
+                              <span className="bulk-chip bulk-chip--warning">
+                                <span className="bulk-chip__dot" />
+                                {group.wholeEan.needCount} need EAN
+                              </span>
+                            ) : (
+                              <span className="bulk-chip bulk-chip--success">
+                                <span className="bulk-chip__dot" />
+                                ready
+                              </span>
+                            )
                           ) : isPartial ? (
                             <span className="bulk-chip bulk-chip--warning">
                               <span className="bulk-chip__dot" />
@@ -903,8 +962,8 @@ export function OfferProductPickerModal({
                     // trigger and the button inside opts out of pointer events.
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span className="offer-product-picker__continue-wrap">
-                          <Button type="button" disabled onClick={handleContinue}>
+                        <span className="offer-product-picker__continue-wrap" tabIndex={0}>
+                          <Button type="button" disabled>
                             Continue →
                           </Button>
                         </span>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6214,72 +6214,547 @@ a.kpi-card:focus-visible {
   color: var(--text-primary);
 }
 
-/* ── Offer product picker (#1754) ── */
-.offer-product-picker__product-row {
+/* ── Offer product picker (#1754, redesigned #1779) ──────────────────
+   Wide two-region modal: left list (search + products + sticky pager),
+   right rail (live selection review + connection + Continue). Below
+   1024px the regions become a two-step wizard (data-mstep on the root);
+   below 600px the modal is a full-screen sheet. */
+.offer-product-picker.dialog__content {
+  width: min(1080px, 96vw);
+  max-width: none;
+  /* Fixed height so the modal stays stable as selections/variants are added -
+     the product list and the rail scroll internally instead of growing the
+     modal (phone overrides to a 100dvh full-screen sheet below). */
+  height: min(760px, 88vh);
+  max-height: 88vh;
+  padding: 0;
+  overflow: hidden;
   display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-1) var(--space-2);
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  min-width: 0;
+  flex-direction: column;
+  background: var(--bg-surface);
 }
 
-.offer-product-picker__product-row:hover {
-  background: var(--bg-surface-muted);
+.offer-product-picker__x {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  z-index: 1;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 1.35rem;
+  line-height: 1;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.offer-product-picker__x:hover {
+  color: var(--text-primary);
+}
+
+.offer-product-picker__head {
+  padding: var(--space-4) var(--space-6) var(--space-3) var(--space-5);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.offer-product-picker__title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+  margin: 0;
+}
+.offer-product-picker__sub {
+  margin: var(--space-1) 0 0;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  max-width: 52ch;
+}
+
+.offer-product-picker__body {
+  display: grid;
+  grid-template-columns: 1fr 340px;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+/* Left: search + list + sticky pager */
+.offer-product-picker__list-region {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--border-subtle);
+}
+.offer-product-picker__search {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.offer-product-picker__hint {
+  margin: var(--space-1) 0 0;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.offer-product-picker__list {
+  overflow-y: auto;
+  flex: 1 1 auto;
+  padding: var(--space-2);
+}
+.offer-product-picker__prows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  /* Product list scrolls inside the list region; search stays pinned at the
+     top and the pager at the bottom, so the modal keeps a fixed height. */
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+.offer-product-picker__prow {
+  border-radius: var(--radius-md);
+  min-width: 0;
+}
+.offer-product-picker__prow-main {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+}
+.offer-product-picker__prow-main:hover {
+  background: var(--bg-surface-hover);
+}
+.offer-product-picker__prow--open .offer-product-picker__prow-main {
+  background: var(--bg-surface-elevated);
   border-color: var(--border-subtle);
 }
-
-.offer-product-picker__expand {
-  display: flex;
+.offer-product-picker__prow-toggle {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
   align-items: center;
-  gap: var(--space-2);
-  flex: 1 1 auto;
+  gap: var(--space-3);
   min-width: 0;
-  padding: var(--space-1) 0;
   background: transparent;
-  border: none;
+  border: 0;
+  padding: 0;
   cursor: pointer;
-  font-size: 0.875rem;
-  color: var(--text-primary);
+  color: inherit;
   text-align: left;
 }
-
-.offer-product-picker__caret {
-  color: var(--text-muted);
-  flex: 0 0 auto;
-}
-
-.offer-product-picker__name {
-  flex: 1 1 auto;
+.offer-product-picker__pname {
   min-width: 0;
+}
+.offer-product-picker__pname b {
+  font-weight: 600;
+  font-size: 0.86rem;
+  display: block;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.offer-product-picker__pname small {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+}
+.offer-product-picker__vcount {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  background: var(--bg-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  padding: 0.12rem 0.5rem;
   white-space: nowrap;
 }
+.offer-product-picker__vcount--simple {
+  color: var(--text-muted);
+}
+.offer-product-picker__chev {
+  color: var(--text-muted);
+  transition: transform var(--duration-fast) var(--ease-out);
+  justify-self: center;
+}
+.offer-product-picker__prow--open .offer-product-picker__chev {
+  transform: rotate(90deg);
+}
+.offer-product-picker__prow--simple .offer-product-picker__chev {
+  visibility: hidden;
+}
 
-.offer-product-picker__variant-count {
-  flex: 0 0 auto;
+.offer-product-picker__vrows {
+  list-style: none;
+  margin: 0;
+  padding: 2px var(--space-2) var(--space-2) 2.1rem;
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.offer-product-picker__vrow {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 0.42rem var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.offer-product-picker__vrow:hover {
+  background: var(--bg-surface-hover);
+}
+.offer-product-picker__vrow--picked {
+  background: var(--accent-primary-soft);
+  border-color: var(--accent-primary-border);
+}
+.offer-product-picker__vname {
+  min-width: 0;
+}
+.offer-product-picker__vname b {
+  font-weight: 600;
+  font-size: 0.8rem;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.offer-product-picker__vname small {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.66rem;
+}
+.offer-product-picker__vname-bad {
+  color: var(--status-error-fg);
+}
+
+.offer-product-picker__cap-hint {
+  margin-top: var(--space-2);
   font-size: 0.75rem;
 }
 
-.offer-product-picker__selection-bar {
+/* Sticky pager */
+.offer-product-picker__pager {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  padding: var(--space-2) var(--space-3);
-  margin-top: var(--space-2);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  background: var(--bg-surface-muted);
-  font-size: 0.875rem;
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-shell);
+}
+.offer-product-picker__pager-count {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+.offer-product-picker__pager-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.offer-product-picker__pager-page {
+  font-size: 0.72rem;
   color: var(--text-secondary);
+  padding: 0 var(--space-1);
 }
 
-.offer-product-picker__cap-hint {
-  margin-top: var(--space-1);
-  font-size: 0.75rem;
+/* Step-1 "Review" bar - desktop hidden, shown only on the two-step layout. */
+.offer-product-picker__mstep-next {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+}
+.offer-product-picker__mstep-count {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+.offer-product-picker__mstep-count b {
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Right rail: live selection review + CTA */
+.offer-product-picker__rail {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-shell);
+}
+.offer-product-picker__rail-head {
+  padding: var(--space-3) var(--space-4) var(--space-2);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-2);
+}
+.offer-product-picker__rail-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.offer-product-picker__rail-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+/* Back sits on its own row ABOVE the "In this batch" titlebar (two-step
+   wizard, <=1023px); hidden on desktop where both regions show at once. */
+.offer-product-picker__rail-back {
+  display: none;
+  align-self: flex-start;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface-elevated);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+/* Structural (non-CTA) buttons must not inherit the global primary-button
+   hover (signal-orange). Keep hover feedback subtle/neutral. */
+.offer-product-picker__prow-toggle:hover,
+.offer-product-picker__prow-toggle:active {
+  background: transparent;
+  border-color: transparent;
+  color: inherit;
+}
+.offer-product-picker__rail-back:hover {
+  background: var(--bg-surface-hover);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+.offer-product-picker__x:hover,
+.offer-product-picker__rm:hover {
+  background: transparent;
+  border-color: transparent;
+  color: var(--status-error-fg);
+}
+.offer-product-picker__rail-counts {
+  display: flex;
+  gap: var(--space-5);
+  padding: 0 var(--space-4) var(--space-2);
+}
+.offer-product-picker__rail-n {
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+  font-variant-numeric: tabular-nums;
+}
+.offer-product-picker__rail-n--warn {
+  color: var(--status-warning-fg);
+}
+.offer-product-picker__rail-lbl {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-top: 0.1rem;
+}
+.offer-product-picker__rail-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: var(--space-1) var(--space-3) var(--space-3);
+}
+.offer-product-picker__rail-empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  padding: var(--space-6) var(--space-4);
+}
+.offer-product-picker__selgrp {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  margin-bottom: var(--space-2);
+  overflow: hidden;
+}
+.offer-product-picker__selgrp-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0.45rem var(--space-2);
+}
+.offer-product-picker__selgrp-head b {
+  font-size: 0.76rem;
+  font-weight: 600;
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.offer-product-picker__rm {
+  color: var(--text-muted);
+  background: transparent;
+  border: 0;
+  font-size: 0.95rem;
+  line-height: 1;
+  padding: 0.1rem 0.25rem;
+  cursor: pointer;
+  flex: none;
+}
+.offer-product-picker__rm:hover {
+  color: var(--status-error-fg);
+}
+.offer-product-picker__rm--tag {
+  margin-left: auto;
+  font-size: 0.85rem;
+}
+.offer-product-picker__seltag {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.32rem var(--space-2) 0.32rem var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+  font-size: 0.74rem;
+  color: var(--text-secondary);
+}
+.offer-product-picker__seltag--muted {
+  color: var(--text-muted);
+}
+.offer-product-picker__seltag-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  flex: none;
+}
+.offer-product-picker__seltag--muted .offer-product-picker__seltag-dot {
+  background: var(--text-disabled);
+}
+
+.offer-product-picker__rail-foot {
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.offer-product-picker__rail-conn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.offer-product-picker__eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.offer-product-picker__req {
+  color: var(--accent-primary);
+}
+.offer-product-picker__resolved-connection {
+  font-size: 0.8rem;
+  margin: 0;
+}
+.offer-product-picker__rail-summary {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+.offer-product-picker__rail-summary b,
+.offer-product-picker__rail-summary strong {
+  color: var(--text-primary);
+}
+.offer-product-picker__rail-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+.offer-product-picker__rail-actions > .button,
+.offer-product-picker__rail-actions > .offer-product-picker__continue-wrap {
+  flex: 1 1 auto;
+}
+.offer-product-picker__continue-wrap {
+  display: inline-flex;
+}
+.offer-product-picker__continue-wrap > .button {
+  width: 100%;
+}
+/* Let hover fall through the disabled button to the span so its tooltip fires. */
+.offer-product-picker__continue-wrap > .button:disabled {
+  pointer-events: none;
+}
+
+/* ── Tablet + mobile (<=1023px): two-step wizard ──────────────────
+   Side-by-side list + rail is a desktop-only affordance. Below that,
+   one focused screen at a time: step 1 = list, step 2 = review. */
+@media (max-width: 1023px) {
+  .offer-product-picker.dialog__content {
+    width: min(720px, 96vw);
+  }
+  .offer-product-picker__body {
+    display: block;
+    overflow: hidden;
+  }
+  .offer-product-picker__list-region,
+  .offer-product-picker__rail {
+    height: 100%;
+    border-right: 0;
+  }
+  .offer-product-picker[data-mstep='1'] .offer-product-picker__rail {
+    display: none;
+  }
+  .offer-product-picker[data-mstep='1'] .offer-product-picker__list-region {
+    display: flex;
+  }
+  .offer-product-picker[data-mstep='1'] .offer-product-picker__mstep-next {
+    display: flex;
+    position: sticky;
+    bottom: 0;
+  }
+  .offer-product-picker[data-mstep='2'] .offer-product-picker__list-region {
+    display: none;
+  }
+  .offer-product-picker[data-mstep='2'] .offer-product-picker__rail {
+    display: flex;
+  }
+  .offer-product-picker__rail {
+    background: var(--bg-surface);
+  }
+  .offer-product-picker__rail-back {
+    display: inline-flex;
+  }
+  .offer-product-picker__rail-foot {
+    position: sticky;
+    bottom: 0;
+    background: var(--bg-surface);
+  }
+}
+
+/* ── Phone (<=600px): full-screen sheet ─────────────────────────── */
+@media (max-width: 600px) {
+  .offer-product-picker.dialog__content {
+    width: 100vw;
+    max-width: 100vw;
+    height: 100dvh;
+    max-height: 100dvh;
+    top: 0;
+    left: 0;
+    transform: none;
+    border: 0;
+    border-radius: 0;
+  }
+  .offer-product-picker__hint {
+    display: none;
+  }
 }
 
 /*

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6305,11 +6305,6 @@ a.kpi-card:focus-visible {
   display: grid;
   gap: 2px;
   min-width: 0;
-  /* Product list scrolls inside the list region; search stays pinned at the
-     top and the pager at the bottom, so the modal keeps a fixed height. */
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
 }
 .offer-product-picker__prow {
   border-radius: var(--radius-md);
@@ -6385,7 +6380,7 @@ a.kpi-card:focus-visible {
   transform: rotate(90deg);
 }
 .offer-product-picker__prow--simple .offer-product-picker__chev {
-  visibility: hidden;
+  opacity: 0.4;
 }
 
 .offer-product-picker__vrows {

--- a/docs/plans/implementation-plan-picker-redesign.md
+++ b/docs/plans/implementation-plan-picker-redesign.md
@@ -1,0 +1,44 @@
+# Implementation Plan — Create-offers picker redesign (#1779)
+
+**Issue:** #1779 · **Stacks on:** #1754 (PR #1774), branch `1754-unify-offer-creation-wizard`.
+**Layer:** Frontend (Interface). Visual/UX only — no route/selection/bulk-wizard/backend change.
+
+## 1. Goal
+Rework `OfferProductPickerModal` to the approved mockup: wide two-region desktop modal (list + live rail), product/variant thumbnails, always-visible sticky pager, connection `<select>` in the rail above Continue (required), two-step wizard on tablet + mobile (≤1023), and a discard-changes guard on X / Cancel / outside-click.
+
+**Visual source of truth:** the approved mockup — mirror its markup/CSS class family `offer-product-picker__*`. Non-goals: no change to the URL contract (`productIds`/`variantIds`/`connectionId`), the selection model, the bulk wizard, or any backend.
+
+## 2. Reuse (confirmed present — do not reinvent)
+- `ProductThumbnail` (`shared/ui`, props `{ name, src, size }`) — image-or-letter-tile, exactly the product-details treatment. Use for product rows (`size="md"`) and variant sub-rows (`size="sm"`/xs). Demo products have no image URL ⇒ letter tile; wire `src` from `product.images?.[0]`/variant image when present.
+- `ConfirmDialog` (`shared/ui`, props `{ open, onOpenChange, onConfirm, title, description, cancelLabel, confirmLabel, tone }`) — the exact discard pattern from `bulk-edit-modal`. Reuse verbatim: title "Discard changes?", description "You have unsaved product selections. Closing now will discard them.", cancel "Keep editing", confirm "Discard changes", `tone="danger"`.
+- `Select`, `CheckboxCell` (tri-state), `Dialog`/`DialogContent` — already imported by the current component.
+
+## 3. Design (keep existing state; restructure JSX + CSS)
+The current component already owns: `selection: Map<productId, 'ALL'|Set<variantId>>`, `expanded`, `offset`, `pickedConnectionId`, `variantCounts`, `useProductsQuery`/`useProductQuery`, connection filtering, and the Continue navigate. **All of that stays.** Changes:
+
+1. **Layout:** `DialogContent` becomes a two-region flex/grid — left `.offer-product-picker__list-region` (search + list + sticky pager), right `.offer-product-picker__rail` (~340px: "In this batch" counts + grouped selection + pinned footer with connection select + Cancel/Continue). Desktop ≥1024 only.
+2. **Thumbnails:** product rows + variant sub-rows render `ProductThumbnail`.
+3. **Sticky pager:** move pager into a sticky footer of the list region.
+4. **Connection select → rail footer**, above Continue, labelled "Publish to *"; Continue stays gated on `pickedConnectionId !== ''` (already the logic).
+5. **Rail selection review:** derive per-product groups from `selection` + `variantCounts`; status chips (ready / N of M / no-EAN) reuse the `bulk-review` chip vocabulary; per-variant + per-product remove; Clear all.
+6. **Two-step wizard (≤1023):** add `step: 'products' | 'review'` local state (mobile/tablet only; desktop shows both regions). Step 1 = list + sticky "Review →" bar (running count); step 2 = back-chevron + rail. CSS drives which region shows via a `data-mstep` attribute + the ≤1023 / ≤600 media queries from the mockup. Mobile ≤600 = full-screen sheet; tablet 768–1023 = centered card.
+7. **Discard guard:** replace the raw `onClose` on X / Cancel / Dialog `onOpenChange`(outside/esc) with a guarded `requestClose()` — if `selection.size > 0` open `ConfirmDialog`, else close. "Discard changes" → actually close.
+8. **CSS:** add the `.offer-product-picker__*` block to `apps/web/src/index.css` (tokens only, no raw hex; new tokens: none). Include the responsive rules (≤1023 two-step, ≤600 full-screen sheet) from the mockup.
+
+## 4. Steps
+1. Rewrite `offer-product-picker-modal.tsx` JSX to the two-region + rail + two-step structure, wiring existing state; add `ConfirmDialog` discard guard; render `ProductThumbnail`; move connection `Select` to the rail footer; add the mobile step state + "Review →"/back controls.
+2. Replace/extend the `.offer-product-picker__*` CSS in `index.css` with the mockup's styles (desktop grid, rail, sticky pager, chips, two-step media queries, full-screen mobile sheet).
+3. Update `offer-product-picker-modal.test.tsx`: keep the existing selection/URL/connection-gate/reset tests; add discard-guard tests (X/Cancel/outside with selection → confirm; empty → closes) and two-step navigation (Review → shows rail; back → list). Assert `ProductThumbnail` present.
+4. Quality gate (lint/type-check/test/invariants).
+5. Playwright: build the worktree web, screenshot desktop / tablet / mobile-step1 / mobile-step2 / discard, compare to the mockup; redeploy to `:8090`.
+
+## 5. Risks
+- Radix `Dialog` `onOpenChange` fires for esc/outside — route it through `requestClose()` so the discard guard covers all paths (don't let Dialog close itself directly).
+- Keep a11y: the `ConfirmDialog` is a nested dialog over the picker — use its `contentClassName` elevated variant (as bulk-edit-modal does) so focus/stacking is correct.
+- Two-step must not regress desktop: `data-mstep` rules apply only ≤1023.
+
+## 6. Docs impact (hypothesis)
+- `docs/frontend-ui-style-guide.md` — note the two-region-modal→responsive-two-step + discard-on-all-close-paths pattern if worth codifying; else none. No central/ADR/migration impact.
+
+## Pre-implement gate
+Skipped deliberately: frontend-only, touches no port / DTO / Symbol token / ORM / barrel contract; all reused primitives (`ProductThumbnail`, `ConfirmDialog`, `Select`, `CheckboxCell`, `Dialog`) confirmed to exist. The gate's backend-contract checks have nothing to bite on here.


### PR DESCRIPTION
## What & why

Visual/UX redesign of the `/listings` "Create offers" product picker (`OfferProductPickerModal`) shipped in #1754. The old modal was a narrow single column with the connection select buried below the list, hidden pagination, and no thumbnails. This reworks it to the approved mockup. **Design-only** - the selection model, route contract (`productIds` / `variantIds` / `connectionId`), the bulk wizard, and the backend are unchanged.

> Stacked on **#1774** (`1754-unify-offer-creation-wizard`) - base this PR on that branch; rebase onto `main` after #1774 merges.


## Design mockup

Approved interactive mockup (desktop two-region, tablet/mobile two-step, discard guard, both themes): https://claude.ai/code/artifact/515d6fc3-779e-4945-88ef-76f9a96d0f5f

## Changes

- **Desktop (>=1024px): two-region modal** - left search + paginated product list; right ~340px rail with a live "In this batch" review (counts offers / products / need-EAN, per-product groups with status chips, per-variant + per-product remove, Clear all) and a pinned footer holding the connection select above Continue. The modal now has a **fixed height** (`min(760px, 88vh)`) - the list and rail scroll internally instead of the modal growing as items are added.
- **Thumbnails** on product + variant rows via `ProductThumbnail` (image, else letter-tile).
- **Pagination** is an always-visible sticky footer; **20 products / page**.
- **Connection = required `<select>`** ("Publish to *") in the rail footer; Continue stays disabled until a connection is chosen, with a **tooltip** ("Choose a connection to publish to first.") on the disabled button.
- **Tablet + mobile (<=1023px): two-step wizard** - step 1 product list + sticky "Review ->" bar; step 2 back-chevron (its own row above "In this batch") + review + connection + Continue. Mobile (<=600) is a full-screen sheet; tablet is a centered card. No stacked panels.
- **Discard-changes guard** (reuses the shared `ConfirmDialog`, as `bulk-edit-modal` does): closing via X / Cancel / outside-click with a non-empty selection opens "Discard changes?"; empty selection closes without a prompt.
- Structural row/icon buttons no longer inherit the global primary (signal-orange) hover - product-row hover is a subtle neutral.

Also folds in a one-line fix on the base file `bulk-wizard.tsx` (removed an unnecessary non-null assertion flagged by `no-unnecessary-type-assertion`) - already pushed to the #1774 base, so it does not appear in this diff.

## Verification

- `type-check` clean, `lint` 0 errors, **2342 web unit tests** pass, `check:invariants` OK.
- Driven end-to-end on the live demo stack across desktop / tablet / mobile: two-region layout, thumbnails, sticky 20/page pager, required connection + disabled-Continue tooltip, two-step wizard, and the discard guard on all three close paths. Screenshots attached separately.

## Docs

None - visual redesign of a single component; no new shared primitive, state-ownership, route, capability, or contract. The discard-changes guard reuses the existing `ConfirmDialog` convention (already used by `bulk-edit-modal`); the picker's existence is already recorded in `docs/architecture-overview.md` §6 (#1754).

Closes #1779

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRpVJ5Ei4gt2zgCjCUspEy

