### PR TITLE
feat(orders): expose delivery routing resolution on order response

### DIFF
--- a/apps/api/src/mappings/http/fulfillment-routing.controller.spec.ts
+++ b/apps/api/src/mappings/http/fulfillment-routing.controller.spec.ts
@@ -52,6 +52,7 @@ describe('FulfillmentRoutingController', () => {
       getCandidateProcessors: jest.fn(),
       replaceRules: jest.fn(),
       resolve: jest.fn(),
+      resolveBatch: jest.fn(),
     };
     controller = new FulfillmentRoutingController(routing);
   });

--- a/apps/api/src/orders/http/dto/order-delivery-resolution.dto.ts
+++ b/apps/api/src/orders/http/dto/order-delivery-resolution.dto.ts
@@ -1,0 +1,47 @@
+/**
+ * Order Delivery Resolution DTO
+ *
+ * Read-only projection (#1791, epic #1776) of how fulfillment routing
+ * resolved for an order's delivery method — the outcome
+ * `IFulfillmentRoutingService.resolve` already computes, surfaced on the
+ * order response so the FE can render a mapping-aware delivery cell without
+ * re-deriving routing rules it can't see. No new persistence; the resolution
+ * is derived at read time from the live routing rules.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  FulfillmentProcessorKind,
+  FulfillmentProcessorKindValues,
+  FulfillmentRoutingSource,
+  FulfillmentRoutingSourceValues,
+} from '@openlinker/core/mappings';
+
+export class OrderDeliveryResolutionDto {
+  @ApiProperty({
+    enum: FulfillmentRoutingSourceValues,
+    description:
+      '"rule" when a configured fulfillment-routing rule matched the order\'s ' +
+      '(source connection, delivery method); "default" when it fell back to the ' +
+      'omp_fulfilled default (today\'s PrestaShop-fulfilled behaviour).',
+  })
+  source!: FulfillmentRoutingSource;
+
+  @ApiProperty({
+    enum: FulfillmentProcessorKindValues,
+    description:
+      'Where the fulfilling connection sits: "omp_fulfilled" (destination OMP ships via its own ' +
+      'carrier setup), "ol_managed_carrier" (OL drives an own-contract carrier), or ' +
+      '"source_brokered" (OL drives the order source\'s own shipping brokerage).',
+  })
+  processorKind!: FulfillmentProcessorKind;
+
+  @ApiProperty({
+    nullable: true,
+    description:
+      'The fulfilling connection id. Null for the omp_fulfilled default (no rule matched) — under ' +
+      'fan-out there is no single fulfilling OMP; non-null for an explicit rule.',
+  })
+  processorConnectionId!: string | null;
+}

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -101,12 +101,11 @@ export class OrderRecordResponseDto {
 
   @ApiPropertyOptional({
     type: OrderDeliveryResolutionDto,
-    nullable: true,
     description:
       'Read-only projection (#1791) of how fulfillment routing resolved for this order\'s delivery ' +
       'method — the outcome IFulfillmentRoutingService.resolve computes. Present on both the list and ' +
       'detail reads when the order carries a source delivery method; absent otherwise. Never changes ' +
       'routing behaviour — a pure derived read.',
   })
-  deliveryResolution?: OrderDeliveryResolutionDto | null;
+  deliveryResolution?: OrderDeliveryResolutionDto;
 }

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -17,6 +17,7 @@ import { OrderRecordStatus, SlaState, FulfillmentRollupState } from '@openlinker
 import { OrderSyncStatusResponseDto } from './order-sync-status-response.dto';
 import { SyncAttemptResponseDto } from './sync-attempt-response.dto';
 import type { OrderInvoiceProjectionDto } from './order-invoice-projection.dto';
+import { OrderDeliveryResolutionDto } from './order-delivery-resolution.dto';
 
 export class OrderRecordResponseDto {
   @ApiProperty({ description: 'Internal order ID (e.g. ol_order_...)' })
@@ -97,4 +98,15 @@ export class OrderRecordResponseDto {
       'Ship-by SLA bucket (#1108), server-derived from dispatchByAt + fulfillmentState (cleared to "none" once shipped). The single source of truth the list badge + filter agree on; the FE renders only the live countdown from dispatchByAt.',
   })
   slaState!: SlaState;
+
+  @ApiPropertyOptional({
+    type: OrderDeliveryResolutionDto,
+    nullable: true,
+    description:
+      'Read-only projection (#1791) of how fulfillment routing resolved for this order\'s delivery ' +
+      'method — the outcome IFulfillmentRoutingService.resolve computes. Present on both the list and ' +
+      'detail reads when the order carries a source delivery method; absent otherwise. Never changes ' +
+      'routing behaviour — a pure derived read.',
+  })
+  deliveryResolution?: OrderDeliveryResolutionDto | null;
 }

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -23,12 +23,15 @@ import type {
 import { INVOICE_SERVICE_TOKEN } from '@openlinker/core/invoicing';
 import type { IInvoiceService } from '@openlinker/core/invoicing';
 import { InvoiceRecord } from '@openlinker/core/invoicing';
+import { FULFILLMENT_ROUTING_SERVICE_TOKEN } from '@openlinker/core/mappings';
+import type { IFulfillmentRoutingService } from '@openlinker/core/mappings';
 
 describe('OrdersController', () => {
   let controller: OrdersController;
   let repository: jest.Mocked<OrderRecordRepositoryPort>;
   let retryService: jest.Mocked<IOrderDestinationRetryService>;
   let invoiceService: jest.Mocked<IInvoiceService>;
+  let fulfillmentRouting: jest.Mocked<IFulfillmentRoutingService>;
 
   const mockOrder = new OrderRecord(
     'ol_order_001',
@@ -76,6 +79,14 @@ describe('OrdersController', () => {
       applyRegulatoryClearance: jest.fn(),
     };
 
+    const mockFulfillmentRouting: jest.Mocked<IFulfillmentRoutingService> = {
+      getRules: jest.fn(),
+      getCandidateProcessors: jest.fn(),
+      replaceRules: jest.fn(),
+      resolve: jest.fn(),
+      resolveBatch: jest.fn().mockResolvedValue([]),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [OrdersController],
       providers: [
@@ -91,6 +102,10 @@ describe('OrdersController', () => {
           provide: INVOICE_SERVICE_TOKEN,
           useValue: mockInvoiceService,
         },
+        {
+          provide: FULFILLMENT_ROUTING_SERVICE_TOKEN,
+          useValue: mockFulfillmentRouting,
+        },
       ],
     }).compile();
 
@@ -98,6 +113,7 @@ describe('OrdersController', () => {
     repository = module.get(ORDER_RECORD_REPOSITORY_TOKEN);
     retryService = module.get(ORDER_DESTINATION_RETRY_SERVICE_TOKEN);
     invoiceService = module.get(INVOICE_SERVICE_TOKEN);
+    fulfillmentRouting = module.get(FULFILLMENT_ROUTING_SERVICE_TOKEN);
   });
 
   describe('listOrders', () => {
@@ -317,6 +333,45 @@ describe('OrdersController', () => {
       expect(result.items[0].dispatchByEstimated).toBe(true);
       expect(result.items[1].dispatchByEstimated).toBe(false);
     });
+
+    it('should attach a batched deliveryResolution only to orders with a source delivery method (#1791)', async () => {
+      const orderWithMethod = new OrderRecord(
+        'ol_order_shipped',
+        null,
+        'conn-source-001',
+        null,
+        { shipping: { methodId: 'courier-standard' } },
+        [],
+        'ready',
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-04-01T00:00:00Z')
+      );
+      repository.findMany.mockResolvedValue({ items: [orderWithMethod, mockOrder], total: 2 });
+      fulfillmentRouting.resolveBatch.mockResolvedValue([
+        { processorKind: 'ol_managed_carrier', processorConnectionId: 'conn-inpost', source: 'rule' },
+      ]);
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(fulfillmentRouting.resolveBatch).toHaveBeenCalledWith([
+        { sourceConnectionId: 'conn-source-001', sourceDeliveryMethodId: 'courier-standard' },
+      ]);
+      expect(result.items[0].deliveryResolution).toEqual({
+        source: 'rule',
+        processorKind: 'ol_managed_carrier',
+        processorConnectionId: 'conn-inpost',
+      });
+      expect(result.items[1].deliveryResolution).toBeUndefined();
+    });
+
+    it('should skip resolveBatch entirely when no order in the page has a delivery method (#1791)', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockOrder], total: 1 });
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(fulfillmentRouting.resolveBatch).not.toHaveBeenCalled();
+      expect(result.items[0].deliveryResolution).toBeUndefined();
+    });
   });
 
   describe('statusSummary', () => {
@@ -451,6 +506,47 @@ describe('OrdersController', () => {
       const result = await controller.getOrder('ol_order_001');
 
       expect(result.orderSnapshot).toEqual({ externalOrderId: 'EXT-123', items: [] });
+    });
+
+    it('should attach deliveryResolution when the order carries a source delivery method (#1791)', async () => {
+      const orderWithMethod = new OrderRecord(
+        'ol_order_shipped',
+        null,
+        'conn-source-001',
+        null,
+        { shipping: { methodId: 'courier-standard' } },
+        [],
+        'ready',
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-04-01T00:00:00Z')
+      );
+      repository.findById.mockResolvedValue(orderWithMethod);
+      fulfillmentRouting.resolve.mockResolvedValue({
+        processorKind: 'omp_fulfilled',
+        processorConnectionId: null,
+        source: 'default',
+      });
+
+      const result = await controller.getOrder('ol_order_shipped');
+
+      expect(fulfillmentRouting.resolve).toHaveBeenCalledWith({
+        sourceConnectionId: 'conn-source-001',
+        sourceDeliveryMethodId: 'courier-standard',
+      });
+      expect(result.deliveryResolution).toEqual({
+        source: 'default',
+        processorKind: 'omp_fulfilled',
+        processorConnectionId: null,
+      });
+    });
+
+    it('should leave deliveryResolution absent when the order carries no delivery method (#1791)', async () => {
+      repository.findById.mockResolvedValue(mockOrder);
+
+      const result = await controller.getOrder('ol_order_001');
+
+      expect(fulfillmentRouting.resolve).not.toHaveBeenCalled();
+      expect(result.deliveryResolution).toBeUndefined();
     });
   });
 

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -44,6 +44,11 @@ import {
   IInvoiceService,
 } from '@openlinker/core/invoicing';
 import type { InvoiceRecord } from '@openlinker/core/invoicing';
+import {
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import type { FulfillmentRoutingResolution } from '@openlinker/core/mappings';
 import { ListOrdersQueryDto } from './dto/list-orders-query.dto';
 import { OrderHealthSummaryQueryDto } from './dto/order-health-summary-query.dto';
 import { OrderHealthSummaryResponseDto } from './dto/order-health-summary-response.dto';
@@ -54,6 +59,7 @@ import type { SyncAttemptResponseDto } from './dto/sync-attempt-response.dto';
 import { PaginatedOrdersResponseDto } from './dto/paginated-orders-response.dto';
 import { RetryOrderDestinationResponseDto } from './dto/retry-order-destination-response.dto';
 import type { OrderInvoiceProjectionDto } from './dto/order-invoice-projection.dto';
+import type { OrderDeliveryResolutionDto } from './dto/order-delivery-resolution.dto';
 
 @ApiBearerAuth()
 @ApiTags('orders')
@@ -65,7 +71,9 @@ export class OrdersController {
     @Inject(ORDER_DESTINATION_RETRY_SERVICE_TOKEN)
     private readonly destinationRetryService: IOrderDestinationRetryService,
     @Inject(INVOICE_SERVICE_TOKEN)
-    private readonly invoiceService: IInvoiceService
+    private readonly invoiceService: IInvoiceService,
+    @Inject(FULFILLMENT_ROUTING_SERVICE_TOKEN)
+    private readonly fulfillmentRouting: IFulfillmentRoutingService
   ) {}
 
   @Get()
@@ -126,12 +134,23 @@ export class OrdersController {
     );
     const invoiceByOrderId = new Map(invoices.map((invoice) => [invoice.orderId, invoice]));
 
+    // Batch the delivery-routing-resolution projection for the whole page
+    // (#1791): one `resolveBatch` call (one repository read per distinct
+    // sourceConnectionId — typically 1-3 per page), not an N+1 of per-row
+    // `resolve`. Only orders that carry a source delivery method are queried;
+    // the rest simply have no `deliveryResolution` on their DTO.
+    const resolutionByOrderId = await this.resolveDeliveryForOrders(items);
+
     return {
       items: items.map((order) => {
         const dto = this.toDto(order);
         const invoice = invoiceByOrderId.get(order.internalOrderId);
         if (invoice) {
           dto.orderSnapshot = { ...dto.orderSnapshot, invoice: this.toInvoiceProjection(invoice) };
+        }
+        const deliveryResolution = resolutionByOrderId.get(order.internalOrderId);
+        if (deliveryResolution) {
+          dto.deliveryResolution = deliveryResolution;
         }
         return dto;
       }),
@@ -214,6 +233,18 @@ export class OrdersController {
     );
     if (invoiceRecord) {
       dto.orderSnapshot = { ...dto.orderSnapshot, invoice: this.toInvoiceProjection(invoiceRecord) };
+    }
+    // Delivery-routing-resolution projection (#1791): a single-order counterpart
+    // to the list read's batched resolution below. Absent when the order carries
+    // no source delivery method — resolving would just echo the omp_fulfilled
+    // default with no delivery method to route.
+    if (order.sourceDeliveryMethodId) {
+      dto.deliveryResolution = this.toDeliveryResolutionDto(
+        await this.fulfillmentRouting.resolve({
+          sourceConnectionId: order.sourceConnectionId,
+          sourceDeliveryMethodId: order.sourceDeliveryMethodId,
+        })
+      );
     }
     return dto;
   }
@@ -309,6 +340,49 @@ export class OrdersController {
       regulatoryStatus: record.regulatoryStatus,
       clearanceReference: record.clearanceReference,
       confirmationDocumentAvailable,
+    };
+  }
+
+  /**
+   * Batched delivery-routing resolution for a page of orders (#1791). Queries
+   * `IFulfillmentRoutingService.resolveBatch` once for every order that
+   * carries a source delivery method (`OrderRecord.sourceDeliveryMethodId`,
+   * the same key the shipping dispatch seam resolves against) — the service
+   * itself further collapses that into one repository read per distinct
+   * `sourceConnectionId`, so this stays a small, fixed number of DB round
+   * trips regardless of page size, not an N+1 per order.
+   */
+  private async resolveDeliveryForOrders(
+    orders: OrderRecord[]
+  ): Promise<Map<string, OrderDeliveryResolutionDto>> {
+    const ordersWithMethod = orders.filter(
+      (order): order is OrderRecord & { sourceDeliveryMethodId: string } =>
+        order.sourceDeliveryMethodId !== null
+    );
+    if (ordersWithMethod.length === 0) {
+      return new Map();
+    }
+    const resolutions = await this.fulfillmentRouting.resolveBatch(
+      ordersWithMethod.map((order) => ({
+        sourceConnectionId: order.sourceConnectionId,
+        sourceDeliveryMethodId: order.sourceDeliveryMethodId,
+      }))
+    );
+    return new Map(
+      ordersWithMethod.map((order, i) => [
+        order.internalOrderId,
+        this.toDeliveryResolutionDto(resolutions[i]),
+      ])
+    );
+  }
+
+  private toDeliveryResolutionDto(
+    resolution: FulfillmentRoutingResolution
+  ): OrderDeliveryResolutionDto {
+    return {
+      source: resolution.source,
+      processorKind: resolution.processorKind,
+      processorConnectionId: resolution.processorConnectionId,
     };
   }
 

--- a/apps/api/src/orders/orders.module.ts
+++ b/apps/api/src/orders/orders.module.ts
@@ -9,10 +9,14 @@
 import { Module } from '@nestjs/common';
 import { OrdersModule as CoreOrdersModule } from '@openlinker/core/orders';
 import { InvoicingModule as CoreInvoicingModule } from '@openlinker/core/invoicing';
+import { MappingsModule as CoreMappingsModule } from '@openlinker/core/mappings';
 import { OrdersController } from './http/orders.controller';
 
 @Module({
-  imports: [CoreOrdersModule, CoreInvoicingModule],
+  // CoreMappingsModule (#1791) provides FULFILLMENT_ROUTING_SERVICE_TOKEN —
+  // the orders controller resolves the delivery-routing-resolution
+  // projection off the same service the shipping dispatch seam (#835) uses.
+  imports: [CoreOrdersModule, CoreInvoicingModule, CoreMappingsModule],
   controllers: [OrdersController],
 })
 export class OrdersModule {}

--- a/apps/api/test/integration/orders/order-delivery-resolution.int-spec.ts
+++ b/apps/api/test/integration/orders/order-delivery-resolution.int-spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Order Delivery Resolution Int-Spec (#1791)
+ *
+ * Vertical slice for the read-only delivery-routing-resolution projection on
+ * the orders HTTP endpoints: `GET /orders` (list, batched) and
+ * `GET /orders/:internalOrderId` (detail). Exercises the real
+ * `FulfillmentRoutingService.resolve` / `resolveBatch` against real Postgres
+ * (a persisted routing rule vs. the omp_fulfilled default vs. no delivery
+ * method at all) — the layers the controller unit spec mocks.
+ *
+ * @module apps/api/test/integration/orders
+ */
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from '../setup';
+import { loginAsAdmin } from '../helpers/test-auth.helper';
+import { createTestConnection } from '../helpers/test-connection.helper';
+import { createTestOrderRecord } from '../fixtures/order.fixtures';
+
+describe('Order delivery-resolution projection (#1791)', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function seedConnections(): Promise<{ sourceId: string; inpostId: string }> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.publicapi.v1',
+      enabledCapabilities: ['OrderSource'],
+    });
+    const inpost = await createTestConnection(dataSource, {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: 'inpost.shipx.v1',
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    return { sourceId: source.id, inpostId: inpost.id };
+  }
+
+  it('should surface the rule-matched resolution on both the detail and list reads', async () => {
+    const { sourceId, inpostId } = await seedConnections();
+    const routing = harness.getApp().get<IFulfillmentRoutingService>(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+    await routing.replaceRules(sourceId, [
+      {
+        sourceDeliveryMethodId: 'courier-standard',
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: inpostId,
+      },
+    ]);
+    const order = await createTestOrderRecord(harness.getDataSource(), {
+      sourceConnectionId: sourceId,
+      orderSnapshot: { items: [], shipping: { methodId: 'courier-standard' } },
+    });
+
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+
+    const detail = await http
+      .get(`/v1/orders/${order.internalOrderId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(detail.body.deliveryResolution).toEqual({
+      source: 'rule',
+      processorKind: 'ol_managed_carrier',
+      processorConnectionId: inpostId,
+    });
+
+    const list = await http
+      .get(`/v1/orders?sourceConnectionId=${sourceId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(list.body.items).toHaveLength(1);
+    expect(list.body.items[0].deliveryResolution).toEqual({
+      source: 'rule',
+      processorKind: 'ol_managed_carrier',
+      processorConnectionId: inpostId,
+    });
+  });
+
+  it('should fall back to the omp_fulfilled default when the delivery method has no configured rule', async () => {
+    const { sourceId } = await seedConnections();
+    const order = await createTestOrderRecord(harness.getDataSource(), {
+      sourceConnectionId: sourceId,
+      orderSnapshot: { items: [], shipping: { methodId: 'unmapped-method' } },
+    });
+
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+
+    const detail = await http
+      .get(`/v1/orders/${order.internalOrderId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(detail.body.deliveryResolution).toEqual({
+      source: 'default',
+      processorKind: 'omp_fulfilled',
+      processorConnectionId: null,
+    });
+
+    const list = await http
+      .get(`/v1/orders?sourceConnectionId=${sourceId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(list.body.items[0].deliveryResolution).toEqual({
+      source: 'default',
+      processorKind: 'omp_fulfilled',
+      processorConnectionId: null,
+    });
+  });
+
+  it('should omit deliveryResolution when the order carries no source delivery method', async () => {
+    const order = await createTestOrderRecord(harness.getDataSource(), {
+      orderSnapshot: { items: [] },
+    });
+
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+
+    const detail = await http
+      .get(`/v1/orders/${order.internalOrderId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(detail.body.deliveryResolution).toBeUndefined();
+
+    const list = await http
+      .get(`/v1/orders?sourceConnectionId=${order.sourceConnectionId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(list.body.items[0].deliveryResolution).toBeUndefined();
+  });
+});

--- a/libs/core/src/mappings/application/interfaces/fulfillment-routing.service.interface.ts
+++ b/libs/core/src/mappings/application/interfaces/fulfillment-routing.service.interface.ts
@@ -47,4 +47,13 @@ export interface IFulfillmentRoutingService {
    * when no rule matches or the order carries no delivery method.
    */
   resolve(query: FulfillmentRoutingQuery): Promise<FulfillmentRoutingResolution>;
+
+  /**
+   * Batched counterpart to {@link resolve} (#1791): resolves many orders'
+   * `(source, method)` pairs in one pass — one repository read per distinct
+   * `sourceConnectionId` rather than one per order — so a page of orders can
+   * carry a `deliveryResolution` projection without an N+1. Returns
+   * resolutions positionally aligned with `queries`.
+   */
+  resolveBatch(queries: FulfillmentRoutingQuery[]): Promise<FulfillmentRoutingResolution[]>;
 }

--- a/libs/core/src/mappings/application/services/fulfillment-routing.service.spec.ts
+++ b/libs/core/src/mappings/application/services/fulfillment-routing.service.spec.ts
@@ -134,6 +134,62 @@ describe('FulfillmentRoutingService', () => {
     });
   });
 
+  describe('resolveBatch (#1791)', () => {
+    it('should resolve rule hits, default fallbacks, and no-method orders positionally', async () => {
+      repository.findBySourceConnectionId.mockResolvedValue([
+        makeRule({
+          sourceConnectionId: SOURCE,
+          sourceDeliveryMethodId: 'method-x',
+          processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+          processorConnectionId: INPOST,
+        }),
+      ]);
+
+      const results = await service.resolveBatch([
+        { sourceConnectionId: SOURCE, sourceDeliveryMethodId: 'method-x' },
+        { sourceConnectionId: SOURCE, sourceDeliveryMethodId: 'method-unmapped' },
+        { sourceConnectionId: SOURCE, sourceDeliveryMethodId: null },
+      ]);
+
+      expect(results).toEqual([
+        { processorKind: 'ol_managed_carrier', processorConnectionId: INPOST, source: 'rule' },
+        { processorKind: 'omp_fulfilled', processorConnectionId: null, source: 'default' },
+        { processorKind: 'omp_fulfilled', processorConnectionId: null, source: 'default' },
+      ]);
+    });
+
+    it('should read each distinct source connection at most once (no N+1)', async () => {
+      repository.findBySourceConnectionId.mockResolvedValue([]);
+
+      await service.resolveBatch([
+        { sourceConnectionId: SOURCE, sourceDeliveryMethodId: 'method-a' },
+        { sourceConnectionId: SOURCE, sourceDeliveryMethodId: 'method-b' },
+        { sourceConnectionId: SOURCE, sourceDeliveryMethodId: 'method-c' },
+        { sourceConnectionId: PS, sourceDeliveryMethodId: 'method-d' },
+      ]);
+
+      expect(repository.findBySourceConnectionId).toHaveBeenCalledTimes(2);
+      expect(repository.findBySourceConnectionId).toHaveBeenCalledWith(SOURCE);
+      expect(repository.findBySourceConnectionId).toHaveBeenCalledWith(PS);
+    });
+
+    it('should skip the repository entirely for an empty batch', async () => {
+      const results = await service.resolveBatch([]);
+
+      expect(results).toEqual([]);
+      expect(repository.findBySourceConnectionId).not.toHaveBeenCalled();
+    });
+
+    it('should not query connections whose orders all carry no delivery method', async () => {
+      const results = await service.resolveBatch([
+        { sourceConnectionId: SOURCE, sourceDeliveryMethodId: null },
+      ]);
+
+      expect(results).toEqual([{ processorKind: 'omp_fulfilled', processorConnectionId: null, source: 'default' }]);
+      expect(repository.findBySourceConnectionId).not.toHaveBeenCalled();
+    });
+  });
+
   describe('replaceRules', () => {
     it('should persist an omp_fulfilled rule when the processor declares OrderProcessorManager', async () => {
       declareCapabilities(PS, ['OrderProcessorManager']);

--- a/libs/core/src/mappings/application/services/fulfillment-routing.service.ts
+++ b/libs/core/src/mappings/application/services/fulfillment-routing.service.ts
@@ -150,16 +150,64 @@ export class FulfillmentRoutingService implements IFulfillmentRoutingService {
     if (sourceDeliveryMethodId) {
       const rule = await this.repository.findRule(sourceConnectionId, sourceDeliveryMethodId);
       if (rule) {
-        return {
-          processorKind: rule.processorKind,
-          processorConnectionId: rule.processorConnectionId,
-          source: 'rule',
-        };
+        return this.toResolution(rule);
       }
     }
 
-    // No rule (or no method): today's PrestaShop-fulfilled default. Under
-    // fan-out there is no single fulfilling OMP, so processorConnectionId is null.
+    return this.defaultResolution();
+  }
+
+  /**
+   * Batched counterpart to {@link resolve} (#1791) — resolves many orders'
+   * `(source, method)` pairs in one pass, avoiding an N+1 repository round
+   * trip for a page of orders. Groups queries by distinct `sourceConnectionId`
+   * (typically 1-3 per page) and fetches each connection's full rule set once
+   * via `findBySourceConnectionId` — the same read `getRules` uses — instead
+   * of one `findRule` call per order. Returns resolutions in the same order
+   * as `queries`, one-to-one.
+   */
+  async resolveBatch(
+    queries: FulfillmentRoutingQuery[],
+  ): Promise<FulfillmentRoutingResolution[]> {
+    const connectionIds = Array.from(
+      new Set(
+        queries.filter((q) => q.sourceDeliveryMethodId !== null).map((q) => q.sourceConnectionId),
+      ),
+    );
+
+    const ruleSets = await Promise.all(
+      connectionIds.map((id) => this.repository.findBySourceConnectionId(id)),
+    );
+    const rulesByConnection = new Map(connectionIds.map((id, i) => [id, ruleSets[i]]));
+
+    return queries.map((query) => {
+      if (query.sourceDeliveryMethodId) {
+        const rule = (rulesByConnection.get(query.sourceConnectionId) ?? []).find(
+          (r) => r.sourceDeliveryMethodId === query.sourceDeliveryMethodId,
+        );
+        if (rule) {
+          return this.toResolution(rule);
+        }
+      }
+      return this.defaultResolution();
+    });
+  }
+
+  /** Shared rule → resolution mapping between {@link resolve} and {@link resolveBatch}. */
+  private toResolution(rule: FulfillmentRoutingRule): FulfillmentRoutingResolution {
+    return {
+      processorKind: rule.processorKind,
+      processorConnectionId: rule.processorConnectionId,
+      source: 'rule',
+    };
+  }
+
+  /**
+   * Shared default fallback between {@link resolve} and {@link resolveBatch}:
+   * today's PrestaShop-fulfilled default. Under fan-out there is no single
+   * fulfilling OMP, so `processorConnectionId` is null.
+   */
+  private defaultResolution(): FulfillmentRoutingResolution {
     return {
       processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
       processorConnectionId: null,

--- a/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
@@ -66,3 +66,26 @@ describe('OrderRecord.codToCollect (#1435)', () => {
     expect(makeRecord({ codToCollect: { amount: 510.94, currency: 'PLN' } }).codToCollect).toBeUndefined();
   });
 });
+
+describe('OrderRecord.sourceDeliveryMethodId (#1791)', () => {
+  it('returns the methodId from a well-formed shipping snapshot', () => {
+    expect(
+      makeRecord({ shipping: { methodId: 'courier-standard', methodName: 'Standard' } })
+        .sourceDeliveryMethodId,
+    ).toBe('courier-standard');
+  });
+
+  it('returns null when the snapshot has no shipping key', () => {
+    expect(makeRecord({}).sourceDeliveryMethodId).toBeNull();
+  });
+
+  it('returns null when shipping is not an object', () => {
+    expect(makeRecord({ shipping: 'courier-standard' }).sourceDeliveryMethodId).toBeNull();
+    expect(makeRecord({ shipping: null }).sourceDeliveryMethodId).toBeNull();
+  });
+
+  it('returns null when methodId is missing or non-string', () => {
+    expect(makeRecord({ shipping: {} }).sourceDeliveryMethodId).toBeNull();
+    expect(makeRecord({ shipping: { methodId: 42 } }).sourceDeliveryMethodId).toBeNull();
+  });
+});

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -95,4 +95,24 @@ export class OrderRecord {
       ? { amount, currency }
       : undefined;
   }
+
+  /**
+   * Typed, fail-safe read of the source-side delivery method id (#1791) from
+   * the snapshot. Pure derivation of an already-loaded field (ADR-011): no
+   * I/O, no mutation. Mirrors {@link paymentStatus} / {@link codToCollect} —
+   * centralises the `orderSnapshot.shipping.methodId` key so cross-context
+   * consumers (the delivery-routing-resolution projection) bind to a typed
+   * contract, not the JSON layout. Same key the shipping dispatch seam
+   * (`ShipmentDispatchInput.sourceDeliveryMethodId`) resolves against.
+   * Returns `null` when the order carries no shipping method (the source
+   * didn't expose one, or the snapshot predates the field).
+   */
+  get sourceDeliveryMethodId(): string | null {
+    const shipping = this.orderSnapshot.shipping;
+    if (typeof shipping !== 'object' || shipping === null) {
+      return null;
+    }
+    const { methodId } = shipping as Record<string, unknown>;
+    return typeof methodId === 'string' ? methodId : null;
+  }
 }

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -135,6 +135,7 @@ describe('ShipmentDispatchService', () => {
       getCandidateProcessors: jest.fn(),
       replaceRules: jest.fn(),
       resolve: jest.fn(),
+      resolveBatch: jest.fn(),
     };
     adapter = {
       generateLabel: jest.fn(),


### PR DESCRIPTION
## What & why

The frontend can't render a mapping-aware delivery cell (parent epic #1776) without knowing **how routing resolved** for each order. The order response carried the `orderSnapshot` but not the routing outcome, and the FE can't re-derive it because resolution depends on rules the FE doesn't see.

`FulfillmentRoutingService.resolve` already computes exactly what's needed (`{ processorKind, processorConnectionId, source: 'rule' | 'default' }`). This PR exposes that as a read-only `deliveryResolution` projection on the orders HTTP response. Part of epic #1776; addresses #1791.

## Changes

**Core (mappings context)**
- `IFulfillmentRoutingService.resolveBatch(queries)` — batched counterpart to `resolve()`. Groups queries by distinct `sourceConnectionId` and reads each connection's rule set once via `findBySourceConnectionId` (the same read `getRules` uses), so a page of orders resolves without an N+1. `resolve()` / `resolveBatch()` share the rule→resolution and default-fallback mapping.

**Core (orders context)**
- `OrderRecord.sourceDeliveryMethodId` getter — a pure, fail-safe derivation of `orderSnapshot.shipping.methodId` (ADR-011), mirroring the existing `paymentStatus` / `codToCollect` getters. This is the same key (`OrderShipping.methodId`) the shipping dispatch seam (`ShipmentDispatchInput.sourceDeliveryMethodId`) resolves against, so the projection and dispatch agree.

**API (orders interface layer)**
- New `OrderDeliveryResolutionDto` (`{ source, processorKind, processorConnectionId }`) and an optional/nullable `deliveryResolution` on `OrderRecordResponseDto`.
- `OrdersController` injects `IFulfillmentRoutingService`:
  - Detail read (`GET /orders/:internalOrderId`) → one `resolve()` call when the order has a delivery method.
  - List read (`GET /orders`) → one `resolveBatch()` call for the whole page (only orders that carry a delivery method), mirroring the existing invoice-projection batch pattern (#1713).
  - Field is **absent** when the order carries no source delivery method.
- `OrdersModule` imports the core `MappingsModule` for `FULFILLMENT_ROUTING_SERVICE_TOKEN`.

No new persistence, no migration, no routing-behaviour change — a pure derived read.

## Tests

- Unit: `OrderRecord.sourceDeliveryMethodId` (4 cases); `FulfillmentRoutingService.resolveBatch` (rule/default/no-method positional resolution, one-read-per-connection no-N+1 assertion, empty batch); `OrdersController` list-batching + detail single-resolve + absent cases.
- Integration: `order-delivery-resolution.int-spec.ts` asserts the field on both `GET /orders` and `GET /orders/:id` against real Postgres (rule-matched, omp_fulfilled default, no-method-absent).

## Quality gate

- `pnpm --filter @openlinker/core test`: 170 suites / 1756 tests pass.
- `pnpm --filter @openlinker/api test` (unit): 75 suites / 994 tests pass.
- `pnpm --filter @openlinker/core type-check` and `--filter @openlinker/api type-check`: clean.
- `eslint src/**` on both packages: 0 errors.
- `check-cross-context-imports` + `check-service-interfaces` invariants: pass (no CORE↔Integration boundary violations).

Note: the integration test was authored and type-checks with the rest of `apps/api`, but was not executed locally (Docker/Testcontainers unavailable in the dev environment) — CI runs the integration suite.